### PR TITLE
feat(ai-validation): Add scoring bands + confidence for stable decisions

### DIFF
--- a/scripts/modules/rubrics/prd-quality-rubric.js
+++ b/scripts/modules/rubrics/prd-quality-rubric.js
@@ -41,7 +41,7 @@
  * 4. Risk Analysis (25%) - HIGHEST weight (threat modeling)
  *
  * @module rubrics/prd-quality-rubric
- * @version 1.1.0-sd-type-aware
+ * @version 1.2.0-scoring-bands
  */
 
 import { AIQualityEvaluator } from '../ai-quality-evaluator.js';
@@ -554,6 +554,10 @@ SD UUID: ${prd.sd_uuid || 'Not linked'}`;
           criterion_scores: assessment.scores,
           weighted_score: assessment.weightedScore,
           threshold: assessment.threshold, // Dynamic threshold based on sd_type
+          // v1.2.0: Scoring bands for stable decisions
+          band: assessment.band,
+          confidence: assessment.confidence,
+          confidence_reasoning: assessment.confidence_reasoning,
           sd_type: assessment.sd_type,
           cost_usd: assessment.cost,
           duration_ms: assessment.duration,

--- a/scripts/modules/rubrics/retrospective-quality-rubric.js
+++ b/scripts/modules/rubrics/retrospective-quality-rubric.js
@@ -22,7 +22,7 @@
  * 4. Lesson Applicability (10%) - Reusable patterns for future SDs
  *
  * @module rubrics/retrospective-quality-rubric
- * @version 1.1.0-sd-type-aware
+ * @version 1.2.0-scoring-bands
  */
 
 import { AIQualityEvaluator } from '../ai-quality-evaluator.js';
@@ -377,6 +377,10 @@ Duration: ${retrospective.duration_days || 'Unknown'} days`;
           criterion_scores: assessment.scores,
           weighted_score: assessment.weightedScore,
           threshold: assessment.threshold, // Dynamic threshold based on sd_type
+          // v1.2.0: Scoring bands for stable decisions
+          band: assessment.band,
+          confidence: assessment.confidence,
+          confidence_reasoning: assessment.confidence_reasoning,
           sd_type: assessment.sd_type,
           is_orchestrator: assessment.is_orchestrator, // Orchestrator awareness
           child_count: assessment.child_count, // Number of child SDs

--- a/scripts/modules/rubrics/sd-quality-rubric.js
+++ b/scripts/modules/rubrics/sd-quality-rubric.js
@@ -195,7 +195,11 @@ Current Phase: ${sd.current_phase || 'Not set'}`;
         details: {
           criterion_scores: assessment.scores,
           weighted_score: assessment.weightedScore,
-          threshold: 70,
+          threshold: assessment.threshold || 70,
+          // v1.2.0: Scoring bands for stable decisions
+          band: assessment.band,
+          confidence: assessment.confidence,
+          confidence_reasoning: assessment.confidence_reasoning,
           cost_usd: assessment.cost,
           duration_ms: assessment.duration
         }

--- a/scripts/modules/rubrics/user-story-quality-rubric.js
+++ b/scripts/modules/rubrics/user-story-quality-rubric.js
@@ -450,6 +450,10 @@ SD Link: ${userStory.sd_id || 'Not linked'}`;
           criterion_scores: assessment.scores,
           weighted_score: assessment.weightedScore,
           threshold: assessment.threshold, // Dynamic threshold based on sd_type
+          // v1.2.0: Scoring bands for stable decisions
+          band: assessment.band,
+          confidence: assessment.confidence,
+          confidence_reasoning: assessment.confidence_reasoning,
           sd_type: assessment.sd_type,
           cost_usd: assessment.cost,
           duration_ms: assessment.duration,


### PR DESCRIPTION
## Summary
- Add scoring bands: PASS (80+), NEEDS_REVIEW (50-79), FAIL (<50) to stabilize AI validation decisions
- Add confidence field to AI response schema (HIGH/MEDIUM/LOW) - LOW confidence always triggers NEEDS_REVIEW
- Band-based decisions ensure same content gets consistent pass/fail (68% and 72% both get NEEDS_REVIEW band)
- Backward compatible with existing SD-type-aware thresholds during transition
- Update all rubric files (PRD, SD, User Story, Retrospective) to include band and confidence in response

## Why This Matters
The Russian Judge AI validation was producing varying scores on identical content (68% then 72%) causing unpredictable pass/fail decisions. This change preserves AI intelligence while making decisions stable:
- AI still provides nuanced, semantic scoring
- Decision (pass/fail) is now deterministic based on which band the score falls into
- Same SD evaluated twice → same BAND (even if exact score varies)

## Test Plan
- [ ] Verify AI validation returns band and confidence fields
- [ ] Test that same PRD evaluated multiple times gets same band
- [ ] Verify LOW confidence results in NEEDS_REVIEW regardless of score
- [ ] Confirm backward compatibility with existing threshold logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)