### PR TITLE
fix(ci): Fix remaining CI/CD workflow failures

### DIFF
--- a/.github/workflows/leo-drift-check.yml
+++ b/.github/workflows/leo-drift-check.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Compile drift checker
         run: |
-          npx tsc tools/gates/drift-check.ts --outDir dist/tools/gates --module es2020 --target es2020 --moduleResolution node --esModuleInterop
+          npx tsc tools/gates/drift-check.ts --outDir dist/tools/gates --module es2020 --target es2020 --moduleResolution node --esModuleInterop --skipLibCheck
 
       - name: Run drift detection
         env:

--- a/scripts/generate-schema-docs-from-db.js
+++ b/scripts/generate-schema-docs-from-db.js
@@ -202,9 +202,9 @@ class SchemaDocumentationGenerator {
       this.log('✅ Schema documentation generated successfully!');
       this.log(`📁 Output: ${CONFIG.outputDir}`);
 
-    } catch {
-      console.error('❌ Error generating schema documentation:', _error);
-      throw _error;
+    } catch (error) {
+      console.error('❌ Error generating schema documentation:', error);
+      throw error;
     } finally {
       if (this.pgClient) {
         await this.pgClient.end();


### PR DESCRIPTION
## Summary

- Add `--skipLibCheck` to TypeScript compilation in `leo-drift-check.yml` to resolve Supabase type definition conflicts
- Fix undefined `_error` variable in `generate-schema-docs-from-db.js`

## Note

The RLS migration (`20251227_context_usage_rls_hotfix.sql`) still needs to be applied manually via Supabase dashboard or CLI to fix the RLS Policy Verification workflow.

## Test plan

- [ ] Verify LEO Drift Check workflow compiles successfully
- [ ] Verify Schema Documentation workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)