### PR TITLE
fix(ci): Fix heredoc syntax in LEO Drift Check workflow

### DIFF
--- a/.github/workflows/leo-drift-check.yml
+++ b/.github/workflows/leo-drift-check.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Create pre-commit config
         run: |
-          cat > .pre-commit-config.yaml << 'EOF'
+          cat > .pre-commit-config.yaml <<-'EOF'
           repos:
             - repo: local
               hooks:

--- a/scripts/apply-rls-hotfix.js
+++ b/scripts/apply-rls-hotfix.js
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * Apply RLS Hotfix Migration
+ * Purpose: Enable RLS on context_usage tables
+ * Migration: database/migrations/20251227_context_usage_rls_hotfix.sql
+ */
+
+import { readFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function applyMigration() {
+  console.log('\n🔧 Applying RLS Hotfix Migration...\n');
+
+  let client;
+  try {
+    // Read migration file
+    const migrationPath = join(__dirname, '..', 'database', 'migrations', '20251227_context_usage_rls_hotfix.sql');
+    console.log(`📄 Reading migration: ${migrationPath}`);
+    const sql = await readFile(migrationPath, 'utf-8');
+
+    // Connect to database
+    console.log('🔌 Connecting to database...');
+    client = await createDatabaseClient('engineer', {
+      verify: true,
+      verbose: false
+    });
+    console.log('✅ Connected to database\n');
+
+    // Split SQL into statements
+    const statements = splitPostgreSQLStatements(sql);
+    console.log(`📝 Found ${statements.length} SQL statements\n`);
+
+    // Execute each statement
+    for (let i = 0; i < statements.length; i++) {
+      const stmt = statements[i];
+      const preview = stmt.substring(0, 60).replace(/\n/g, ' ');
+      console.log(`[${i + 1}/${statements.length}] Executing: ${preview}...`);
+
+      try {
+        const result = await client.query(stmt);
+
+        // Check for NOTICE messages
+        if (result.rows && result.rows.length > 0) {
+          console.log(`    Result: ${JSON.stringify(result.rows)}`);
+        }
+        console.log(`    ✅ Success`);
+      } catch (error) {
+        console.error(`    ❌ Error: ${error.message}`);
+        throw error;
+      }
+    }
+
+    console.log('\n🎉 Migration applied successfully!\n');
+
+    // Verify RLS is enabled
+    console.log('🔍 Verifying RLS status...\n');
+    const verifyQuery = `
+      SELECT
+        c.relname AS table_name,
+        c.relrowsecurity AS rls_enabled,
+        (
+          SELECT COUNT(*)
+          FROM pg_policies p
+          WHERE p.tablename = c.relname
+            AND p.schemaname = 'public'
+        ) AS policy_count
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relname IN ('context_usage_log', 'context_usage_daily')
+      ORDER BY c.relname;
+    `;
+
+    const { rows } = await client.query(verifyQuery);
+
+    let allGood = true;
+    rows.forEach(row => {
+      const status = row.rls_enabled ? '✅' : '❌';
+      console.log(`${status} ${row.table_name}:`);
+      console.log(`    RLS Enabled: ${row.rls_enabled}`);
+      console.log(`    Policies: ${row.policy_count}`);
+
+      if (!row.rls_enabled || row.policy_count === 0) {
+        allGood = false;
+      }
+    });
+
+    console.log('');
+    if (allGood) {
+      console.log('✅ VERIFICATION PASSED: RLS enabled on all context_usage tables\n');
+      return true;
+    } else {
+      console.error('❌ VERIFICATION FAILED: Some tables missing RLS or policies\n');
+      return false;
+    }
+
+  } catch (error) {
+    console.error('\n❌ Migration failed:', error.message);
+    console.error('\nStack trace:', error.stack);
+    return false;
+  } finally {
+    if (client) {
+      await client.end();
+      console.log('🔌 Database connection closed\n');
+    }
+  }
+}
+
+// Run migration
+applyMigration()
+  .then(success => {
+    process.exit(success ? 0 : 1);
+  })
+  .catch(error => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });

--- a/scripts/verify-context-usage-rls.js
+++ b/scripts/verify-context-usage-rls.js
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Verify RLS on Context Usage Tables
+ * Purpose: Detailed verification of RLS policies on context_usage tables
+ */
+
+import { createDatabaseClient } from './lib/supabase-connection.js';
+
+async function verifyRLS() {
+  console.log('\n🔍 Verifying RLS on Context Usage Tables...\n');
+
+  let client;
+  try {
+    // Connect to database
+    client = await createDatabaseClient('engineer', {
+      verify: true,
+      verbose: false
+    });
+
+    // Query RLS status and policies
+    const query = `
+      SELECT
+        c.relname AS table_name,
+        c.relrowsecurity AS rls_enabled,
+        (
+          SELECT json_agg(json_build_object(
+            'policy_name', policyname,
+            'command', cmd,
+            'roles', roles,
+            'qual', qual,
+            'with_check', with_check
+          ))
+          FROM pg_policies p
+          WHERE p.tablename = c.relname
+            AND p.schemaname = 'public'
+        ) AS policies
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relname IN ('context_usage_log', 'context_usage_daily')
+      ORDER BY c.relname;
+    `;
+
+    const { rows } = await client.query(query);
+
+    if (rows.length === 0) {
+      console.error('❌ No context_usage tables found!\n');
+      return false;
+    }
+
+    let allPassed = true;
+
+    rows.forEach(row => {
+      console.log(`📋 Table: ${row.table_name}`);
+      console.log(`   RLS Enabled: ${row.rls_enabled ? '✅ Yes' : '❌ No'}`);
+
+      if (!row.rls_enabled) {
+        allPassed = false;
+      }
+
+      if (row.policies && row.policies.length > 0) {
+        console.log(`   Policies: ${row.policies.length}`);
+        row.policies.forEach(policy => {
+          console.log(`     - ${policy.policy_name}`);
+          console.log(`       Command: ${policy.command}`);
+          console.log(`       Roles: ${policy.roles}`);
+        });
+      } else {
+        console.log('   ❌ No policies defined!');
+        allPassed = false;
+      }
+      console.log('');
+    });
+
+    if (allPassed) {
+      console.log('✅ VERIFICATION PASSED: All context_usage tables have RLS enabled with policies\n');
+      return true;
+    } else {
+      console.error('❌ VERIFICATION FAILED: Some tables missing RLS or policies\n');
+      return false;
+    }
+
+  } catch (error) {
+    console.error('\n❌ Verification failed:', error.message);
+    console.error('Stack:', error.stack);
+    return false;
+  } finally {
+    if (client) {
+      await client.end();
+    }
+  }
+}
+
+// Run verification
+verifyRLS()
+  .then(success => {
+    process.exit(success ? 0 : 1);
+  })
+  .catch(error => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Fix heredoc syntax at line 109: `<< 'EOF'` → `<<- 'EOF'`
  - Bash requires closing delimiter at column 0 with `<<`
  - Using `<<-` allows tab-indented closing delimiter
- Add RLS hotfix scripts for context_usage tables

## Test plan

- [ ] Verify LEO Drift Check workflow passes without heredoc errors
- [ ] Verify RLS Policy Verification passes (RLS already applied to database)

🤖 Generated with [Claude Code](https://claude.com/claude-code)