### PR TITLE
fix(ci): Remove heredoc dash operator for space-indented YAML

### DIFF
--- a/.github/workflows/leo-drift-check.yml
+++ b/.github/workflows/leo-drift-check.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Create pre-commit config
         run: |
-          cat > .pre-commit-config.yaml <<-'EOF'
+          cat > .pre-commit-config.yaml <<'EOF'
           repos:
             - repo: local
               hooks:
@@ -250,7 +250,7 @@ jobs:
             echo "Attempt $attempt of $MAX_RETRIES..."
 
             # Test that anonymous users cannot write with connection timeout
-            if PGCONNECT_TIMEOUT=10 psql "$DATABASE_URL" <<-'EOF' 2>&1
+            if PGCONNECT_TIMEOUT=10 psql "$DATABASE_URL" <<'EOF' 2>&1
             -- Set role to anonymous
             SET ROLE anon;
 
@@ -267,7 +267,7 @@ jobs:
 
             -- Reset role
             RESET ROLE;
-            EOF
+EOF
             then
               echo "RLS permissions are properly restrictive"
               exit 0


### PR DESCRIPTION
## Summary
Fixed syntax error in LEO Protocol Drift Check workflow where heredoc used `<<-'EOF'` (tab-stripping) but content was space-indented.

## Root Cause
The `<<-` operator in bash strips leading **tabs** from the heredoc closing delimiter, but YAML `run:` blocks use **space** indentation. This caused bash to never find the closing `EOF` delimiter, resulting in "here-document delimited by end-of-file" error.

## Changes
- Line 109: Changed `<<-'EOF'` to `<<'EOF'` (pre-commit config)
- Line 253: Changed `<<-'EOF'` to `<<'EOF'` (RLS test SQL)

## Testing
- Verified heredoc syntax is now correct for space-indented YAML
- Waiting for GitHub Actions to confirm workflow passes

## Impact
- Fixes LEO Protocol Drift Check workflow
- Fixes RLS Policy Verification workflow
- Both were failing with syntax error on main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)