### PR TITLE
fix(ci): Fix heredoc syntax and add RLS policies

### DIFF
--- a/.github/workflows/leo-drift-check.yml
+++ b/.github/workflows/leo-drift-check.yml
@@ -106,24 +106,24 @@ jobs:
 
       - name: Create pre-commit config
         run: |
-          cat > .pre-commit-config.yaml <<'EOF'
-          repos:
-            - repo: local
-              hooks:
-                - id: drift-check
-                  name: LEO Drift Check
-                  entry: node dist/tools/gates/drift-check.js
-                  language: system
-                  pass_filenames: false
-                  always_run: true
-
-                - id: boundary-check
-                  name: Module Boundary Check
-                  entry: npx eslint
-                  language: system
-                  types: [javascript, typescript]
-                  args: ['--max-warnings', '0']
-          EOF
+          printf '%s\n' \
+            "repos:" \
+            "  - repo: local" \
+            "    hooks:" \
+            "      - id: drift-check" \
+            "        name: LEO Drift Check" \
+            "        entry: node dist/tools/gates/drift-check.js" \
+            "        language: system" \
+            "        pass_filenames: false" \
+            "        always_run: true" \
+            "" \
+            "      - id: boundary-check" \
+            "        name: Module Boundary Check" \
+            "        entry: npx eslint" \
+            "        language: system" \
+            "        types: [javascript, typescript]" \
+            "        args: ['--max-warnings', '0']" \
+            > .pre-commit-config.yaml
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
@@ -250,24 +250,8 @@ jobs:
             echo "Attempt $attempt of $MAX_RETRIES..."
 
             # Test that anonymous users cannot write with connection timeout
-            if PGCONNECT_TIMEOUT=10 psql "$DATABASE_URL" <<'EOF' 2>&1
-            -- Set role to anonymous
-            SET ROLE anon;
-
-            -- This should fail with insufficient privilege
-            DO $$
-            BEGIN
-              INSERT INTO leo_gate_reviews (prd_id, gate, score, evidence)
-              VALUES ('test-prd', '2A', 50, '{}');
-              RAISE EXCEPTION 'ERROR: Anonymous insert was allowed!';
-            EXCEPTION
-              WHEN insufficient_privilege THEN
-                RAISE NOTICE 'Anonymous insert correctly blocked';
-            END $$;
-
-            -- Reset role
-            RESET ROLE;
-EOF
+            RLS_TEST_SQL="SET ROLE anon; DO \$\$ BEGIN INSERT INTO leo_gate_reviews (prd_id, gate, score, evidence) VALUES ('test-prd', '2A', 50, '{}'); RAISE EXCEPTION 'ERROR: Anonymous insert was allowed!'; EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'Anonymous insert correctly blocked'; END \$\$; RESET ROLE;"
+            if PGCONNECT_TIMEOUT=10 psql "$DATABASE_URL" -c "$RLS_TEST_SQL" 2>&1
             then
               echo "RLS permissions are properly restrictive"
               exit 0

--- a/database/migrations/20251227_missing_rls_policies.sql
+++ b/database/migrations/20251227_missing_rls_policies.sql
@@ -1,0 +1,104 @@
+-- ============================================================================
+-- LEO Protocol - Missing RLS Policies Hotfix
+-- Migration: 20251227_missing_rls_policies.sql
+-- ============================================================================
+-- Purpose: Enable RLS and add policies for tables identified as missing them
+--
+-- Tables:
+--   - sd_type_gate_exemptions
+--   - story_manual_tests
+--   - system_components
+--   - task_triggers
+--   - type_gate_exemptions
+--   - ui_components
+--   - user_story_tests
+--   - ux_research_library
+-- ============================================================================
+
+-- Helper function to safely add RLS and policies
+DO $$
+DECLARE
+  tables_to_fix TEXT[] := ARRAY[
+    'sd_type_gate_exemptions',
+    'story_manual_tests',
+    'system_components',
+    'task_triggers',
+    'type_gate_exemptions',
+    'ui_components',
+    'user_story_tests',
+    'ux_research_library'
+  ];
+  tbl TEXT;
+BEGIN
+  FOREACH tbl IN ARRAY tables_to_fix
+  LOOP
+    -- Check if table exists
+    IF EXISTS (
+      SELECT 1 FROM pg_tables
+      WHERE schemaname = 'public' AND tablename = tbl
+    ) THEN
+      -- Enable RLS
+      EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', tbl);
+      RAISE NOTICE 'Enabled RLS on %', tbl;
+
+      -- Create authenticated policy if not exists
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+        AND tablename = tbl
+        AND policyname = 'Allow all for authenticated'
+      ) THEN
+        EXECUTE format(
+          'CREATE POLICY "Allow all for authenticated" ON %I FOR ALL TO authenticated USING (true) WITH CHECK (true)',
+          tbl
+        );
+        RAISE NOTICE 'Created authenticated policy on %', tbl;
+      END IF;
+
+      -- Create anon select policy if not exists
+      IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+        AND tablename = tbl
+        AND policyname = 'Allow select for anon'
+      ) THEN
+        EXECUTE format(
+          'CREATE POLICY "Allow select for anon" ON %I FOR SELECT TO anon USING (true)',
+          tbl
+        );
+        RAISE NOTICE 'Created anon policy on %', tbl;
+      END IF;
+    ELSE
+      RAISE NOTICE 'Table % does not exist, skipping', tbl;
+    END IF;
+  END LOOP;
+END $$;
+
+-- Verify all tables have RLS enabled
+DO $$
+DECLARE
+  missing_rls TEXT[];
+BEGIN
+  SELECT array_agg(tablename) INTO missing_rls
+  FROM pg_tables t
+  JOIN pg_class c ON c.relname = t.tablename
+  JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = t.schemaname
+  WHERE t.schemaname = 'public'
+  AND t.tablename IN (
+    'sd_type_gate_exemptions',
+    'story_manual_tests',
+    'system_components',
+    'task_triggers',
+    'type_gate_exemptions',
+    'ui_components',
+    'user_story_tests',
+    'ux_research_library'
+  )
+  AND NOT c.relrowsecurity;
+
+  IF missing_rls IS NOT NULL AND array_length(missing_rls, 1) > 0 THEN
+    RAISE EXCEPTION 'RLS not enabled on tables: %', array_to_string(missing_rls, ', ');
+  ELSE
+    RAISE NOTICE 'SUCCESS: All specified tables have RLS enabled';
+  END IF;
+END $$;

--- a/database/migrations/20251227_rls_sd_type_gate_exemptions.sql
+++ b/database/migrations/20251227_rls_sd_type_gate_exemptions.sql
@@ -1,0 +1,38 @@
+-- Migration: Apply RLS to sd_type_gate_exemptions
+-- Date: 2025-12-27
+-- Purpose: Enable Row Level Security on sd_type_gate_exemptions table
+--
+-- Context: Part of broader RLS governance initiative to ensure all tables
+-- have appropriate security policies. This table currently has RLS disabled.
+--
+-- Tables affected:
+--   - sd_type_gate_exemptions (RLS enabled + 2 policies)
+--
+-- Policy Design:
+--   1. authenticated: Full access (SELECT, INSERT, UPDATE, DELETE)
+--   2. anon: Read-only access (SELECT)
+--
+-- Rollback: If needed, run:
+--   ALTER TABLE sd_type_gate_exemptions DISABLE ROW LEVEL SECURITY;
+--   DROP POLICY IF EXISTS "Allow all for authenticated" ON sd_type_gate_exemptions;
+--   DROP POLICY IF EXISTS "Allow select for anon" ON sd_type_gate_exemptions;
+
+-- Enable RLS on sd_type_gate_exemptions
+ALTER TABLE sd_type_gate_exemptions ENABLE ROW LEVEL SECURITY;
+
+-- Policy 1: Allow all operations for authenticated users
+DROP POLICY IF EXISTS "Allow all for authenticated" ON sd_type_gate_exemptions;
+CREATE POLICY "Allow all for authenticated"
+  ON sd_type_gate_exemptions
+  FOR ALL
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+-- Policy 2: Allow SELECT for anonymous users
+DROP POLICY IF EXISTS "Allow select for anon" ON sd_type_gate_exemptions;
+CREATE POLICY "Allow select for anon"
+  ON sd_type_gate_exemptions
+  FOR SELECT
+  TO anon
+  USING (true);

--- a/scripts/apply-rls-sd-type-gate-exemptions.js
+++ b/scripts/apply-rls-sd-type-gate-exemptions.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Apply RLS to sd_type_gate_exemptions
+ * Purpose: Enable RLS on sd_type_gate_exemptions table
+ * Migration: database/migrations/20251227_rls_sd_type_gate_exemptions.sql
+ */
+
+import { readFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+async function applyMigration() {
+  console.log('\n🔧 Applying RLS Migration for sd_type_gate_exemptions...\n');
+
+  let client;
+  try {
+    // Read migration file
+    const migrationPath = join(__dirname, '..', 'database', 'migrations', '20251227_rls_sd_type_gate_exemptions.sql');
+    console.log(`📄 Reading migration: ${migrationPath}`);
+    const sql = await readFile(migrationPath, 'utf-8');
+
+    // Connect to database
+    console.log('🔌 Connecting to database...');
+    client = await createDatabaseClient('engineer', {
+      verify: true,
+      verbose: false
+    });
+    console.log('✅ Connected to database\n');
+
+    // Split SQL into statements
+    const statements = splitPostgreSQLStatements(sql);
+    console.log(`📝 Found ${statements.length} SQL statements\n`);
+
+    // Execute each statement
+    for (let i = 0; i < statements.length; i++) {
+      const stmt = statements[i];
+      const preview = stmt.substring(0, 60).replace(/\n/g, ' ');
+      console.log(`[${i + 1}/${statements.length}] Executing: ${preview}...`);
+
+      try {
+        const result = await client.query(stmt);
+
+        // Check for NOTICE messages
+        if (result.rows && result.rows.length > 0) {
+          console.log(`    Result: ${JSON.stringify(result.rows)}`);
+        }
+        console.log(`    ✅ Success`);
+      } catch (error) {
+        console.error(`    ❌ Error: ${error.message}`);
+        throw error;
+      }
+    }
+
+    console.log('\n🎉 Migration applied successfully!\n');
+
+    // Verify RLS is enabled
+    console.log('🔍 Verifying RLS status...\n');
+    const verifyQuery = `
+      SELECT
+        c.relname AS table_name,
+        c.relrowsecurity AS rls_enabled,
+        (
+          SELECT COUNT(*)
+          FROM pg_policies p
+          WHERE p.tablename = c.relname
+            AND p.schemaname = 'public'
+        ) AS policy_count
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relname = 'sd_type_gate_exemptions'
+      ORDER BY c.relname;
+    `;
+
+    const { rows } = await client.query(verifyQuery);
+
+    let allGood = true;
+    rows.forEach(row => {
+      const status = row.rls_enabled ? '✅' : '❌';
+      console.log(`${status} ${row.table_name}:`);
+      console.log(`    RLS Enabled: ${row.rls_enabled}`);
+      console.log(`    Policies: ${row.policy_count}`);
+
+      if (!row.rls_enabled || row.policy_count === 0) {
+        allGood = false;
+      }
+    });
+
+    // List actual policies
+    console.log('\n📋 Policy Details:\n');
+    const policyQuery = `
+      SELECT
+        policyname,
+        permissive,
+        roles,
+        cmd,
+        qual,
+        with_check
+      FROM pg_policies
+      WHERE schemaname = 'public'
+        AND tablename = 'sd_type_gate_exemptions'
+      ORDER BY policyname;
+    `;
+
+    const policyResult = await client.query(policyQuery);
+    policyResult.rows.forEach(policy => {
+      console.log(`  Policy: ${policy.policyname}`);
+      console.log(`    Roles: ${Array.isArray(policy.roles) ? policy.roles.join(', ') : policy.roles}`);
+      console.log(`    Command: ${policy.cmd}`);
+      console.log(`    Permissive: ${policy.permissive}`);
+    });
+
+    console.log('');
+    if (allGood) {
+      console.log('✅ VERIFICATION PASSED: RLS enabled on sd_type_gate_exemptions\n');
+      return true;
+    } else {
+      console.error('❌ VERIFICATION FAILED: Table missing RLS or policies\n');
+      return false;
+    }
+
+  } catch (error) {
+    console.error('\n❌ Migration failed:', error.message);
+    console.error('\nStack trace:', error.stack);
+    return false;
+  } finally {
+    if (client) {
+      await client.end();
+      console.log('🔌 Database connection closed\n');
+    }
+  }
+}
+
+// Run migration
+applyMigration()
+  .then(success => {
+    process.exit(success ? 0 : 1);
+  })
+  .catch(error => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Replace heredocs with printf/inline SQL to fix YAML parsing issues
- Add RLS to `sd_type_gate_exemptions` table (only existing table of the 8 reported)

## Root Cause

Heredoc `EOF` at column 1 in YAML multiline blocks is interpreted as a YAML key, breaking parsing.

## Changes

- `.github/workflows/leo-drift-check.yml` - Use printf and inline SQL instead of heredocs
- `database/migrations/20251227_rls_sd_type_gate_exemptions.sql` - RLS migration
- `scripts/apply-rls-sd-type-gate-exemptions.js` - Application script

## Test plan

- [ ] LEO Drift Check workflow passes
- [ ] RLS Policy Verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)