### PR TITLE
fix(handoff): Add sd_key lookup support to all SD queries

### DIFF
--- a/scripts/handoff.js
+++ b/scripts/handoff.js
@@ -95,11 +95,11 @@ async function getSDWorkflow(sdId) {
     process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
 
-  // Support both UUID and legacy_id lookups
+  // Support UUID, legacy_id, and sd_key lookups
   const { data: sd, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, legacy_id, title, sd_type, category, current_phase, status')
-    .or(`id.eq.${sdId},legacy_id.eq.${sdId}`)
+    .select('id, legacy_id, sd_key, title, sd_type, intensity_level, category, current_phase, status')
+    .or(`id.eq.${sdId},legacy_id.eq.${sdId},sd_key.eq.${sdId}`)
     .single();
 
   if (error || !sd) {
@@ -188,11 +188,11 @@ async function verifySDCompletion(sdId) {
     process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
 
-  // Get SD details
+  // Get SD details (supports UUID, legacy_id, and sd_key)
   const { data: sd, error: sdError } = await supabase
     .from('strategic_directives_v2')
-    .select('id, legacy_id, title, status, current_phase, sd_type, category')
-    .or(`id.eq.${sdId},legacy_id.eq.${sdId}`)
+    .select('id, legacy_id, sd_key, title, status, current_phase, sd_type, intensity_level, category')
+    .or(`id.eq.${sdId},legacy_id.eq.${sdId},sd_key.eq.${sdId}`)
     .single();
 
   if (sdError || !sd) {
@@ -200,7 +200,7 @@ async function verifySDCompletion(sdId) {
   }
 
   // Get workflow requirements for this SD type
-  const workflowInfo = await getSDWorkflow(sd.legacy_id || sd.id);
+  const workflowInfo = await getSDWorkflow(sd.sd_key || sd.legacy_id || sd.id);
   const requiredHandoffs = workflowInfo.workflow?.required || [];
 
   // Get existing handoffs for this SD

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -68,7 +68,7 @@ export class HandoffRecorder {
     const { data: sd, error } = await this.supabase
       .from('strategic_directives_v2')
       .select('id')
-      .or(`id.eq.${sdId},legacy_id.eq.${sdId}`)
+      .or(`id.eq.${sdId},legacy_id.eq.${sdId},sd_key.eq.${sdId}`)
       .single();
 
     if (error || !sd) {

--- a/scripts/verify-handoff-lead-to-plan.js
+++ b/scripts/verify-handoff-lead-to-plan.js
@@ -59,11 +59,11 @@ class LeadToPlanVerifier {
     console.log(`Strategic Directive: ${sdId}`);
     
     try {
-      // 1. Load Strategic Directive (support both UUID and legacy_id)
+      // 1. Load Strategic Directive (support UUID, legacy_id, and sd_key)
       const { data: sd, error: sdError } = await this.supabase
         .from('strategic_directives_v2')
         .select('*')
-        .or(`id.eq.${sdId},legacy_id.eq.${sdId}`)
+        .or(`id.eq.${sdId},legacy_id.eq.${sdId},sd_key.eq.${sdId}`)
         .single();
 
       if (sdError || !sd) {
@@ -1016,11 +1016,11 @@ class LeadToPlanVerifier {
     }
 
     try {
-      // Query all referenced dependencies
+      // Query all referenced dependencies (support id, legacy_id, and sd_key)
       const { data: existingDeps, error } = await this.supabase
         .from('strategic_directives_v2')
-        .select('id, legacy_id, status, title')
-        .or(deps.map(d => `id.eq.${d},legacy_id.eq.${d}`).join(','));
+        .select('id, legacy_id, sd_key, status, title')
+        .or(deps.map(d => `id.eq.${d},legacy_id.eq.${d},sd_key.eq.${d}`).join(','));
 
       if (error) {
         result.warnings.push(


### PR DESCRIPTION
## Summary
- Adds `sd_key` as a valid lookup field alongside `id` and `legacy_id`
- Fixes handoff system to work with SDs identified by their `sd_key`
- Enables test refactoring SD (`SD-REFACTOR-TEST-001`) to complete handoffs

## Files Changed
- `scripts/handoff.js` - getSDWorkflow, verifySdComplete
- `scripts/modules/handoff/db/SDRepository.js` - getById, verifyExists
- `scripts/modules/handoff/recording/HandoffRecorder.js` - _resolveToUUID
- `scripts/verify-handoff-lead-to-plan.js` - main SD query

## Test Plan
- [x] Test SD lookup by sd_key works
- [x] LEAD-TO-PLAN handoff completes with 96% score
- [x] Handoff execution stored successfully in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)