### PR TITLE
fix(sub-agents): Add refactor SD type support to TESTING and GITHUB

### DIFF
--- a/lib/sub-agents/github.js
+++ b/lib/sub-agents/github.js
@@ -51,7 +51,8 @@ export async function execute(sdId, subAgent, options = {}) {
   const sdCategory = sdData?.category?.toLowerCase() || '';
   // Security SDs focus on code hardening, not deployment pipelines
   // Pre-existing workflow failures should not block security-focused work
-  const relaxedCiSdTypes = ['database', 'infrastructure', 'documentation', 'protocol', 'security'];
+  // 'refactor' added per SD-REFACTOR-SCRIPTS-001: refactors use REGRESSION, not full CI/CD
+  const relaxedCiSdTypes = ['database', 'infrastructure', 'documentation', 'protocol', 'security', 'refactor'];
 
   // Determine repo path based on target application or options
   // SD-VISION-V2-009 FIX: GITHUB sub-agent must run gh commands from correct repo directory

--- a/lib/sub-agents/testing.js
+++ b/lib/sub-agents/testing.js
@@ -98,12 +98,19 @@ export async function execute(sdId, subAgent, options = {}) {
     .single();
 
   const sdCategory = sdData?.category?.toLowerCase() || '';
-  const skipE2ESdTypes = ['database', 'infrastructure', 'documentation', 'protocol'];
+  // PAT-DB-SD-E2E-001: Skip UI E2E for non-UI SDs
+  // 'refactor' added per SD-REFACTOR-SCRIPTS-001: structural refactors use REGRESSION, not E2E
+  const skipE2ESdTypes = ['database', 'infrastructure', 'documentation', 'protocol', 'refactor'];
 
   if (skipE2ESdTypes.includes(sdCategory)) {
+    const isRefactor = sdCategory === 'refactor';
     console.log(`\n🗄️  SD Type Detection: ${sdCategory.toUpperCase()}`);
-    console.log('   💡 Database/Infrastructure SDs do not require UI E2E tests');
-    console.log('   ✅ Validation via DATABASE/SECURITY sub-agents + table existence');
+    console.log(isRefactor
+      ? '   💡 Refactor SDs use REGRESSION sub-agent for validation'
+      : '   💡 Database/Infrastructure SDs do not require UI E2E tests');
+    console.log(isRefactor
+      ? '   ✅ Validation via REGRESSION sub-agent (before/after behavior comparison)'
+      : '   ✅ Validation via DATABASE/SECURITY sub-agents + table existence');
 
     return {
       verdict: 'PASS',
@@ -114,12 +121,18 @@ export async function execute(sdId, subAgent, options = {}) {
       recommendations: [{
         severity: 'INFO',
         issue: `${sdCategory} SD - UI E2E tests not applicable`,
-        recommendation: 'Schema validated via DATABASE sub-agent and table existence checks'
+        recommendation: isRefactor
+          ? 'Behavior validated via REGRESSION sub-agent (before/after comparison)'
+          : 'Schema validated via DATABASE sub-agent and table existence checks'
       }],
       detailed_analysis: {
         sd_type: sdCategory,
-        skip_reason: 'Non-UI SD type - E2E validation deferred to DATABASE/SECURITY sub-agents',
-        validation_approach: 'SQL schema validation, RLS policy verification'
+        skip_reason: isRefactor
+          ? 'Refactor SD - validation via REGRESSION sub-agent behavior comparison'
+          : 'Non-UI SD type - E2E validation deferred to DATABASE/SECURITY sub-agents',
+        validation_approach: isRefactor
+          ? 'REGRESSION sub-agent: before/after behavior comparison, no functional changes'
+          : 'SQL schema validation, RLS policy verification'
       },
       findings: {
         phase0_intelligence: { skipped: true, reason: `${sdCategory} SD - no UI components` },


### PR DESCRIPTION
## Summary
- Adds 'refactor' SD type support to TESTING and GITHUB sub-agents
- Refactor SDs now correctly skip E2E tests (use REGRESSION sub-agent instead)
- Refactor SDs now have relaxed CI/CD requirements (PR existence check only)

## Changes
- **TESTING sub-agent**: Added 'refactor' to `skipE2ESdTypes` array with context-aware messaging
- **GITHUB sub-agent**: Added 'refactor' to `relaxedCiSdTypes` array

## Test plan
- [x] Smoke tests passing
- [x] ESLint auto-fix applied (pre-existing warnings unrelated to changes)
- [x] Verified refactor SD (SD-REFACTOR-SCRIPTS-001) successfully completed full LEO workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)