### PR TITLE
feat(leo): Add shift-left SD creation validation modules

### DIFF
--- a/scripts/fix-stage-arch-child-sd-fields.js
+++ b/scripts/fix-stage-arch-child-sd-fields.js
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+/**
+ * Fix Stage Architecture Child SD Strategic Fields
+ *
+ * Populates missing strategic fields for P5-P10 child SDs
+ * to enable LEAD-TO-PLAN handoff validation.
+ *
+ * P4 already has fields populated from earlier work.
+ *
+ * Usage: node scripts/fix-stage-arch-child-sd-fields.js
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+// Strategic fields for each phase SD
+const PHASE_UPDATES = [
+  // P5: Governance & Polish
+  {
+    id: 'SD-STAGE-ARCH-001-P5',
+    success_metrics: [
+      { metric: 'CI governance rules active', target: 100, unit: 'percent' },
+      { metric: 'Stage audit test coverage', target: 25, unit: 'stages' },
+      { metric: 'No-hardcoded-counts lint violations', target: 0, unit: 'errors' },
+      { metric: 'E2E golden path test pass rate', target: 100, unit: 'percent' }
+    ],
+    key_principles: [
+      { principle: 'Permanent Governance', description: 'CI rules prevent regression of hardcoded values' },
+      { principle: 'Documentation First', description: 'All changes documented before merge' },
+      { principle: 'Full Lifecycle Coverage', description: 'E2E test covers stages 1-25' }
+    ],
+    strategic_objectives: [
+      { objective: 'Implement stage audit test', metric: 'All 25 stages validated' },
+      { objective: 'Add lint rule for hardcoded counts', metric: 'ESLint rule active in CI' },
+      { objective: 'Create Vision V2 compliance check', metric: 'Check runs on every PR' },
+      { objective: 'Document V2 architecture', metric: 'README complete' }
+    ],
+    success_criteria: [
+      { criterion: 'CI pipeline includes stage audit', measure: 'GitHub Action runs on PR' },
+      { criterion: 'Hardcoded counts blocked by lint', measure: 'ESLint rule prevents "40" values' },
+      { criterion: 'E2E test passes for full venture lifecycle', measure: 'Stages 1-25 navigable' }
+    ],
+    risks: [
+      { risk: 'ESLint rule too strict blocks valid code', severity: 'LOW', mitigation: 'Use specific pattern matching for count violations' },
+      { risk: 'E2E test flaky due to async operations', severity: 'MEDIUM', mitigation: 'Add proper waits and retry logic' }
+    ]
+  },
+
+  // P6: EVA Service Timeout & Resilience
+  {
+    id: 'SD-STAGE-ARCH-001-P6',
+    success_metrics: [
+      { metric: 'EVA API timeout implemented', target: 10, unit: 'seconds' },
+      { metric: 'Error recovery coverage', target: 100, unit: 'percent' },
+      { metric: 'Hanging request incidents', target: 0, unit: 'count' },
+      { metric: 'Graceful degradation paths', target: 3, unit: 'scenarios' }
+    ],
+    key_principles: [
+      { principle: 'Fail Fast', description: 'Timeout after 10 seconds rather than hanging indefinitely' },
+      { principle: 'Graceful Degradation', description: 'Show helpful error state when AI unavailable' },
+      { principle: 'User Feedback', description: 'Always inform user of AI request status' }
+    ],
+    strategic_objectives: [
+      { objective: 'Add AbortController to ai-service-manager', metric: 'All fetch calls have timeout' },
+      { objective: 'Implement error boundary for AI failures', metric: 'Errors caught and displayed' },
+      { objective: 'Add retry logic with exponential backoff', metric: '3 retries before failure' }
+    ],
+    success_criteria: [
+      { criterion: 'No requests hang > 15 seconds', measure: 'Timeout triggers at 10s' },
+      { criterion: 'Error states show helpful messages', measure: 'User sees "AI unavailable" not crash' },
+      { criterion: 'Unit tests cover timeout scenarios', measure: 'Mock timeouts pass' }
+    ],
+    risks: [
+      { risk: 'Timeout too aggressive for slow models', severity: 'MEDIUM', mitigation: 'Make timeout configurable, start with 10s' },
+      { risk: 'Retry logic causes rate limiting', severity: 'LOW', mitigation: 'Exponential backoff with jitter' }
+    ]
+  },
+
+  // P7: God Component Refactoring
+  {
+    id: 'SD-STAGE-ARCH-001-P7',
+    success_metrics: [
+      { metric: 'Components refactored', target: 4, unit: 'components' },
+      { metric: 'Max component LOC', target: 600, unit: 'lines' },
+      { metric: 'Behavior regressions', target: 0, unit: 'count' },
+      { metric: 'Test coverage maintained', target: 100, unit: 'percent' }
+    ],
+    key_principles: [
+      { principle: 'Extract, Dont Rewrite', description: 'Move code to sub-components, preserve logic' },
+      { principle: 'One Concern Per Component', description: 'Each sub-component has single responsibility' },
+      { principle: 'Regression Safety', description: 'Capture baseline before refactoring' }
+    ],
+    strategic_objectives: [
+      { objective: 'Refactor Stage04CompetitiveIntelligence (1290 LOC)', metric: 'Under 600 LOC' },
+      { objective: 'Refactor Stage06RiskEvaluation (37KB)', metric: 'Under 600 LOC' },
+      { objective: 'Refactor Stage07ComprehensivePlanning (36KB)', metric: 'Under 600 LOC' },
+      { objective: 'Refactor Stage09GapAnalysis (1116 LOC)', metric: 'Under 600 LOC' }
+    ],
+    success_criteria: [
+      { criterion: 'All 4 components under 600 LOC', measure: 'LOC check passes in CI' },
+      { criterion: 'No behavior changes detected', measure: 'Regression tests pass' },
+      { criterion: 'Sub-components properly extracted', measure: 'Each has single concern' }
+    ],
+    risks: [
+      { risk: 'Refactoring introduces subtle bugs', severity: 'HIGH', mitigation: 'Capture baseline screenshots, run regression tests' },
+      { risk: 'Shared state breaks when extracted', severity: 'MEDIUM', mitigation: 'Use context or prop drilling carefully' }
+    ]
+  },
+
+  // P8: Stage Component Test Suite
+  {
+    id: 'SD-STAGE-ARCH-001-P8',
+    success_metrics: [
+      { metric: 'Stage components with tests', target: 25, unit: 'stages' },
+      { metric: 'Test file coverage', target: 100, unit: 'percent' },
+      { metric: 'Render tests passing', target: 25, unit: 'tests' },
+      { metric: 'Data loading tests', target: 25, unit: 'tests' }
+    ],
+    key_principles: [
+      { principle: 'Test Every Stage', description: 'No stage component without a test file' },
+      { principle: 'Render First', description: 'Basic render test before complex scenarios' },
+      { principle: 'Mock Supabase', description: 'Tests should not require database connection' }
+    ],
+    strategic_objectives: [
+      { objective: 'Create __tests__ directory structure', metric: 'Directory exists' },
+      { objective: 'Add render test for each stage', metric: '25 render tests' },
+      { objective: 'Add data loading test for each stage', metric: '25 data tests' },
+      { objective: 'Add validation test for form stages', metric: 'Form stages covered' }
+    ],
+    success_criteria: [
+      { criterion: 'Every stage has test file', measure: '25 test files in __tests__/' },
+      { criterion: 'All tests pass in CI', measure: 'Jest exit code 0' },
+      { criterion: 'Coverage meets threshold', measure: '>80% line coverage for stages' }
+    ],
+    risks: [
+      { risk: 'Test setup complex due to providers', severity: 'MEDIUM', mitigation: 'Create test-utils with common wrapper' },
+      { risk: 'Mocking Supabase difficult', severity: 'LOW', mitigation: 'Use msw or manual mock' }
+    ]
+  },
+
+  // P9: API Error Handling & Observability
+  {
+    id: 'SD-STAGE-ARCH-001-P9',
+    success_metrics: [
+      { metric: 'Error codes with graceful UX', target: 100, unit: 'percent' },
+      { metric: 'Correlation ID coverage', target: 100, unit: 'percent' },
+      { metric: 'Idempotency headers on mutations', target: 100, unit: 'percent' },
+      { metric: 'Unhandled errors in production', target: 0, unit: 'count' }
+    ],
+    key_principles: [
+      { principle: 'User-Friendly Errors', description: 'Technical errors translated to helpful messages' },
+      { principle: 'Debug Traceability', description: 'Every request has correlation ID' },
+      { principle: 'Safe Retries', description: 'Mutations use idempotency keys' }
+    ],
+    strategic_objectives: [
+      { objective: 'Add graceful UX for 400/403 errors', metric: 'Error toasts with helpful messages' },
+      { objective: 'Implement client-side correlation IDs', metric: 'X-Correlation-ID on all requests' },
+      { objective: 'Add Idempotency-Key to mutations', metric: 'All POST/PUT/DELETE have key' },
+      { objective: 'Improve error logging', metric: 'Structured logs with context' }
+    ],
+    success_criteria: [
+      { criterion: 'All API errors show user message', measure: 'No raw error codes in UI' },
+      { criterion: 'Correlation IDs in headers', measure: 'Every request has ID' },
+      { criterion: 'Mutations are idempotent', measure: 'Retry doesnt create duplicates' }
+    ],
+    risks: [
+      { risk: 'Correlation ID overhead in high-traffic', severity: 'LOW', mitigation: 'UUID generation is cheap' },
+      { risk: 'Idempotency key storage fills up', severity: 'LOW', mitigation: 'TTL-based cleanup' }
+    ]
+  },
+
+  // P10: Vision Alignment Review & Next SD Generation
+  {
+    id: 'SD-STAGE-ARCH-001-P10',
+    success_metrics: [
+      { metric: 'Vision spec alignment', target: 100, unit: 'percent' },
+      { metric: 'Stage-spec mapping complete', target: 25, unit: 'stages' },
+      { metric: 'Next SDs generated', target: 3, unit: 'SDs' },
+      { metric: 'Documentation gaps', target: 0, unit: 'count' }
+    ],
+    key_principles: [
+      { principle: 'Spec Compliance', description: 'Every stage matches Vision V2 specification' },
+      { principle: 'Forward Planning', description: 'Generate SDs for remaining work' },
+      { principle: 'Close the Loop', description: 'Document lessons learned' }
+    ],
+    strategic_objectives: [
+      { objective: 'Review against SIMULATION_CHAMBER_ARCHITECTURE.md', metric: 'All stages validated' },
+      { objective: 'Review against GENESIS_RITUAL_SPECIFICATION.md', metric: 'All gates validated' },
+      { objective: 'Generate next SD batch', metric: '3 SDs for remaining work' },
+      { objective: 'Create retrospective', metric: 'Lessons documented' }
+    ],
+    success_criteria: [
+      { criterion: 'All 25 stages match Vision V2', measure: 'Compliance check passes' },
+      { criterion: 'Kill gates match spec', measure: 'Stages 3,5,13,23 validated' },
+      { criterion: 'Promotion gates match spec', measure: 'Stages 16,17,22 validated' },
+      { criterion: 'Next work identified', measure: 'SDs created for gaps' }
+    ],
+    risks: [
+      { risk: 'Vision specs changed during implementation', severity: 'MEDIUM', mitigation: 'Re-read specs before validation' },
+      { risk: 'Gaps larger than expected', severity: 'LOW', mitigation: 'Generate additional SDs as needed' }
+    ]
+  }
+];
+
+async function fixChildSDs() {
+  console.log('Fixing Stage Architecture Child SD Strategic Fields...\n');
+  console.log('=' .repeat(60));
+
+  for (const update of PHASE_UPDATES) {
+    const { id, ...fields } = update;
+
+    // Add updated_at
+    fields.updated_at = new Date().toISOString();
+
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      .update(fields)
+      .eq('id', id);
+
+    if (error) {
+      console.error(`FAILED ${id}: ${error.message}`);
+    } else {
+      console.log(`✅ ${id}`);
+      console.log(`   metrics: ${update.success_metrics.length}, principles: ${update.key_principles.length}, objectives: ${update.strategic_objectives.length}`);
+    }
+  }
+
+  console.log('\n' + '=' .repeat(60));
+  console.log('Done! Verify with: node scripts/handoff.js execute LEAD-TO-PLAN SD-STAGE-ARCH-001-P5');
+}
+
+fixChildSDs().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/modules/child-sd-template.js
+++ b/scripts/modules/child-sd-template.js
@@ -1,0 +1,394 @@
+/**
+ * Child SD Template Generator
+ * LEO Protocol v4.4 - Shift-Left Validation
+ *
+ * PURPOSE: Auto-populates child SDs from parent SD template
+ * Inherits strategic fields while allowing child-specific customization
+ *
+ * ROOT CAUSE FIX: SD-STAGE-ARCH-001-P4 discovered child SDs were created
+ * without strategic fields. This module ensures children inherit from parent
+ * and have their own context-specific values.
+ *
+ * Usage:
+ *   import { generateChildSD, inheritStrategicFields } from './modules/child-sd-template.js';
+ *   const childData = generateChildSD(parentSD, childConfig);
+ *
+ * @module child-sd-template
+ * @version 1.0.0
+ */
+
+import { validateSDCreation } from './sd-creation-validator.js';
+
+/**
+ * Default child SD template structure
+ * All children must have these fields populated
+ */
+export const CHILD_SD_TEMPLATE = {
+  // Required strategic fields (inherited or generated)
+  success_metrics: [],
+  key_principles: [],
+  strategic_objectives: [],
+  success_criteria: [],
+  risks: [],
+
+  // Required core fields
+  title: '',
+  description: '',
+  scope: '',
+  rationale: '',
+  category: 'feature',
+  priority: 'high',
+
+  // Child-specific fields
+  parent_sd_id: null,
+  phase_number: null,
+  dependency_requirements: []
+};
+
+/**
+ * Inherit strategic fields from parent SD
+ * Transforms parent fields to be child-appropriate
+ *
+ * @param {Object} parentSD - Parent Strategic Directive
+ * @param {Object} childContext - Child-specific context
+ * @returns {Object} Inherited strategic fields
+ */
+export function inheritStrategicFields(parentSD, childContext = {}) {
+  const { phaseNumber, phaseTitle, phaseObjective } = childContext;
+
+  // Start with parent's strategic fields
+  const inherited = {};
+
+  // Inherit success_metrics - add phase-specific context
+  if (parentSD.success_metrics?.length > 0) {
+    inherited.success_metrics = parentSD.success_metrics.map(metric => ({
+      metric: metric.metric,
+      target: metric.target,
+      unit: metric.unit || 'percent',
+      phase_relevance: `P${phaseNumber}: ${phaseTitle}`
+    }));
+  } else {
+    // Generate minimal metrics if parent has none
+    inherited.success_metrics = [
+      { metric: `P${phaseNumber} completion`, target: 100, unit: 'percent' },
+      { metric: 'Quality gate pass rate', target: 85, unit: 'percent' },
+      { metric: 'Regressions introduced', target: 0, unit: 'count' }
+    ];
+  }
+
+  // Inherit key_principles - contextualize for phase
+  if (parentSD.key_principles?.length > 0) {
+    inherited.key_principles = parentSD.key_principles.map(p => {
+      if (typeof p === 'string') {
+        return { principle: p, description: `Applied in ${phaseTitle}` };
+      }
+      return {
+        principle: p.principle,
+        description: p.description || 'Inherited from parent SD'
+      };
+    });
+  } else {
+    inherited.key_principles = [
+      { principle: 'Phase Isolation', description: 'Changes confined to phase scope' },
+      { principle: 'Backward Compatibility', description: 'No breaking changes to existing functionality' }
+    ];
+  }
+
+  // Inherit strategic_objectives - scope to phase
+  if (parentSD.strategic_objectives?.length > 0) {
+    inherited.strategic_objectives = parentSD.strategic_objectives
+      .slice(0, 3) // Take top 3 from parent
+      .map(obj => {
+        if (typeof obj === 'string') {
+          return { objective: obj, metric: 'Completion verified' };
+        }
+        return {
+          objective: `${obj.objective} (P${phaseNumber} contribution)`,
+          metric: obj.metric || 'Phase deliverables complete'
+        };
+      });
+
+    // Add phase-specific objective
+    if (phaseObjective) {
+      inherited.strategic_objectives.push({
+        objective: phaseObjective,
+        metric: `P${phaseNumber} deliverables complete`
+      });
+    }
+  } else {
+    inherited.strategic_objectives = [
+      { objective: phaseObjective || `Complete P${phaseNumber}`, metric: 'Phase gate passed' },
+      { objective: 'Maintain code quality', metric: 'No linting errors' }
+    ];
+  }
+
+  // Inherit success_criteria - make phase-specific
+  if (parentSD.success_criteria?.length > 0) {
+    inherited.success_criteria = parentSD.success_criteria.map(c => {
+      if (typeof c === 'string') {
+        return { criterion: c, measure: 'Verified complete' };
+      }
+      return {
+        criterion: c.criterion,
+        measure: c.measure || 'Verified complete'
+      };
+    });
+  } else {
+    inherited.success_criteria = [
+      { criterion: 'All phase tasks completed', measure: 'Checklist 100%' },
+      { criterion: 'Tests passing', measure: 'CI green' },
+      { criterion: 'Code reviewed', measure: 'PR approved' }
+    ];
+  }
+
+  // Inherit risks - filter/adjust for phase scope
+  if (parentSD.risks?.length > 0) {
+    inherited.risks = parentSD.risks
+      .filter(r => r.severity !== 'LOW') // Skip low risks for children
+      .map(r => ({
+        risk: r.risk,
+        severity: r.severity || 'MEDIUM',
+        mitigation: r.mitigation,
+        phase_impact: `Relevant to P${phaseNumber}`
+      }));
+
+    // Ensure at least empty array if no relevant risks
+    if (inherited.risks.length === 0) {
+      inherited.risks = [];
+    }
+  } else {
+    inherited.risks = []; // Empty is valid for low-risk phases
+  }
+
+  return inherited;
+}
+
+/**
+ * Generate a complete child SD from parent template
+ *
+ * @param {Object} parentSD - Parent Strategic Directive from database
+ * @param {Object} config - Child configuration
+ * @param {number} config.phaseNumber - Phase number (0-10)
+ * @param {string} config.phaseTitle - Short title for this phase
+ * @param {string} config.phaseDescription - Full description (50+ chars)
+ * @param {string} config.phaseScope - Scope definition (30+ chars)
+ * @param {string} config.phaseObjective - Main objective for this phase
+ * @param {string} config.category - Category override (optional)
+ * @param {string} config.priority - Priority override (optional)
+ * @param {Object} config.customMetrics - Additional success_metrics (optional)
+ * @param {Object} config.customRisks - Additional risks (optional)
+ * @returns {Object} Complete child SD data ready for database insert
+ */
+export function generateChildSD(parentSD, config) {
+  const {
+    phaseNumber,
+    phaseTitle,
+    phaseDescription,
+    phaseScope,
+    phaseObjective,
+    category = parentSD.category || 'feature',
+    priority = parentSD.priority || 'high',
+    customMetrics = [],
+    customRisks = []
+  } = config;
+
+  // Generate SD key pattern: PARENT-ID-P{N}
+  const parentKey = parentSD.sd_key || parentSD.legacy_id || parentSD.id;
+  const childKey = `${parentKey}-P${phaseNumber}`;
+
+  // Inherit strategic fields from parent
+  const inherited = inheritStrategicFields(parentSD, {
+    phaseNumber,
+    phaseTitle,
+    phaseObjective
+  });
+
+  // Merge custom metrics/risks with inherited
+  const mergedMetrics = [...inherited.success_metrics, ...customMetrics];
+  const mergedRisks = [...inherited.risks, ...customRisks];
+
+  // Build complete child SD
+  const childSD = {
+    // Identity
+    id: childKey,
+    sd_key: childKey,
+    legacy_id: childKey,
+    parent_sd_id: parentSD.id,
+
+    // Core fields (required)
+    title: `Phase ${phaseNumber}: ${phaseTitle}`,
+    description: phaseDescription,
+    scope: phaseScope,
+    rationale: `Part of ${parentSD.title} - ${phaseObjective || phaseTitle}`,
+    category,
+    priority,
+
+    // Strategic fields (inherited + merged)
+    success_metrics: mergedMetrics,
+    key_principles: inherited.key_principles,
+    strategic_objectives: inherited.strategic_objectives,
+    success_criteria: inherited.success_criteria,
+    risks: mergedRisks,
+
+    // Workflow fields
+    status: 'draft',
+    progress: 0,
+    phase: 'LEAD',
+
+    // Metadata
+    metadata: {
+      phase_number: phaseNumber,
+      parent_sd_key: parentKey,
+      inherited_from: parentSD.id,
+      generation_date: new Date().toISOString()
+    },
+
+    // Timestamps
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+
+  return childSD;
+}
+
+/**
+ * Generate multiple child SDs for an orchestrator parent
+ *
+ * @param {Object} parentSD - Parent Strategic Directive
+ * @param {Array} phases - Array of phase configurations
+ * @returns {Array} Array of validated child SD data
+ */
+export function generatePhaseChildren(parentSD, phases) {
+  const children = [];
+  const errors = [];
+
+  for (const phase of phases) {
+    const childSD = generateChildSD(parentSD, phase);
+
+    // Validate the generated child
+    const validation = validateSDCreation(childSD, { isChildSD: true });
+
+    if (validation.valid) {
+      children.push({
+        sd: childSD,
+        validation
+      });
+    } else {
+      errors.push({
+        phaseNumber: phase.phaseNumber,
+        errors: validation.errors,
+        warnings: validation.warnings
+      });
+    }
+  }
+
+  return {
+    children,
+    errors,
+    allValid: errors.length === 0,
+    summary: `Generated ${children.length}/${phases.length} valid child SDs`
+  };
+}
+
+/**
+ * Create a minimal phase configuration
+ * Use this when you don't have detailed phase info
+ *
+ * @param {number} phaseNumber - Phase number
+ * @param {string} phaseTitle - Short title
+ * @returns {Object} Minimal phase config
+ */
+export function createMinimalPhaseConfig(phaseNumber, phaseTitle) {
+  return {
+    phaseNumber,
+    phaseTitle,
+    phaseDescription: `Phase ${phaseNumber} implementation: ${phaseTitle}. This phase contributes to the overall strategic directive objectives.`,
+    phaseScope: `Implementation of ${phaseTitle} as defined in parent SD scope.`,
+    phaseObjective: `Complete ${phaseTitle} deliverables`
+  };
+}
+
+/**
+ * Validate a child SD meets requirements before creation
+ *
+ * @param {Object} childData - Child SD data to validate
+ * @returns {Object} Validation result with details
+ */
+export function validateChildBeforeCreation(childData) {
+  // Use strict child validation (isChildSD: true)
+  const result = validateSDCreation(childData, {
+    isChildSD: true,
+    allowWarnings: false
+  });
+
+  // Add additional child-specific checks
+  const additionalChecks = [];
+
+  // Check parent_sd_id is set
+  if (!childData.parent_sd_id) {
+    additionalChecks.push('parent_sd_id is required for child SDs');
+  }
+
+  // Check sd_key follows pattern
+  const keyPattern = /-P\d+$/;
+  if (!keyPattern.test(childData.sd_key || childData.id)) {
+    additionalChecks.push('sd_key should end with -P{N} pattern for child SDs');
+  }
+
+  // Check title includes phase number
+  if (!/Phase \d+/.test(childData.title)) {
+    additionalChecks.push('title should include "Phase N:" for clarity');
+  }
+
+  return {
+    ...result,
+    additionalChecks,
+    canCreate: result.valid && additionalChecks.length === 0
+  };
+}
+
+/**
+ * Get example phase configurations for common SD types
+ *
+ * @param {string} sdType - Type of SD (feature, infrastructure, refactor)
+ * @param {number} phaseCount - Number of phases to generate
+ * @returns {Array} Example phase configurations
+ */
+export function getExamplePhaseConfigs(sdType, phaseCount = 3) {
+  const examples = {
+    feature: [
+      { phaseTitle: 'Foundation Setup', phaseObjective: 'Create base infrastructure' },
+      { phaseTitle: 'Core Implementation', phaseObjective: 'Implement main functionality' },
+      { phaseTitle: 'Testing & Polish', phaseObjective: 'Complete testing and refinements' }
+    ],
+    infrastructure: [
+      { phaseTitle: 'Audit & Analysis', phaseObjective: 'Analyze current state' },
+      { phaseTitle: 'Migration', phaseObjective: 'Execute migration plan' },
+      { phaseTitle: 'Verification', phaseObjective: 'Verify and document changes' }
+    ],
+    refactor: [
+      { phaseTitle: 'Baseline Capture', phaseObjective: 'Capture current behavior' },
+      { phaseTitle: 'Restructure', phaseObjective: 'Refactor code structure' },
+      { phaseTitle: 'Regression Testing', phaseObjective: 'Verify no behavior changes' }
+    ]
+  };
+
+  const baseConfigs = examples[sdType] || examples.feature;
+
+  return baseConfigs.slice(0, phaseCount).map((config, index) => ({
+    phaseNumber: index,
+    ...config,
+    phaseDescription: `Phase ${index} implementation: ${config.phaseTitle}. ${config.phaseObjective} as part of the strategic directive.`,
+    phaseScope: `${config.phaseTitle} - focused on ${config.phaseObjective.toLowerCase()}.`
+  }));
+}
+
+export default {
+  generateChildSD,
+  generatePhaseChildren,
+  inheritStrategicFields,
+  createMinimalPhaseConfig,
+  validateChildBeforeCreation,
+  getExamplePhaseConfigs,
+  CHILD_SD_TEMPLATE
+};

--- a/scripts/modules/sd-creation-validator.js
+++ b/scripts/modules/sd-creation-validator.js
@@ -1,0 +1,340 @@
+/**
+ * SD Creation Validator
+ * LEO Protocol v4.4 - Shift-Left Validation
+ *
+ * Prevents "hollow" SDs from being created by enforcing
+ * strategic field requirements at creation time.
+ *
+ * ROOT CAUSE FIX: SD-STAGE-ARCH-001-P4 discovered that child SDs
+ * were created without strategic fields, causing repeated handoff failures.
+ * This module validates fields at creation time rather than handoff time.
+ *
+ * Usage:
+ *   import { validateSDCreation, SD_FIELD_REQUIREMENTS } from './modules/sd-creation-validator.js';
+ *   const result = validateSDCreation(sdData);
+ *   if (!result.valid) { console.error(result.errors); process.exit(1); }
+ *
+ * @module sd-creation-validator
+ * @version 1.0.0
+ */
+
+/**
+ * Field requirements for SD creation validation
+ * These match LEAD-TO-PLAN handoff requirements from LeadToPlanExecutor.js
+ */
+export const SD_FIELD_REQUIREMENTS = {
+  // Strategic fields (LEAD-owned) - must exist at creation for child SDs
+  strategic: {
+    success_metrics: {
+      required: true,
+      minItems: 3,
+      itemSchema: ['metric', 'target'],
+      optionalFields: ['unit', 'baseline'],
+      errorMessage: 'success_metrics must have 3+ items with {metric, target}'
+    },
+    key_principles: {
+      required: true,
+      minItems: 2,
+      itemSchema: ['principle'],
+      optionalFields: ['description'],
+      // Also accepts string arrays for backward compatibility
+      acceptsStringArray: true,
+      errorMessage: 'key_principles must have 2+ items with {principle} or as strings'
+    },
+    strategic_objectives: {
+      required: true,
+      minItems: 2,
+      itemSchema: ['objective'],
+      optionalFields: ['metric'],
+      acceptsStringArray: true,
+      errorMessage: 'strategic_objectives must have 2+ items'
+    },
+    success_criteria: {
+      required: true,
+      minItems: 3,
+      itemSchema: ['criterion'],
+      optionalFields: ['measure'],
+      acceptsStringArray: true,
+      errorMessage: 'success_criteria must have 3+ items'
+    },
+    risks: {
+      required: true,
+      minItems: 0, // Can be empty array for low-risk SDs
+      itemSchema: ['risk', 'severity', 'mitigation'],
+      optionalFields: ['probability', 'impact', 'category'],
+      errorMessage: 'risks must be defined (can be empty array [])'
+    }
+  },
+
+  // Core fields (always required)
+  core: {
+    title: {
+      required: true,
+      minLength: 10,
+      errorMessage: 'title must be at least 10 characters'
+    },
+    description: {
+      required: true,
+      minLength: 50,
+      errorMessage: 'description must be at least 50 characters'
+    },
+    scope: {
+      required: true,
+      minLength: 30,
+      errorMessage: 'scope must be at least 30 characters'
+    },
+    rationale: {
+      required: true,
+      minLength: 20,
+      errorMessage: 'rationale must be at least 20 characters'
+    },
+    category: {
+      required: true,
+      validValues: ['feature', 'infrastructure', 'database', 'security', 'documentation', 'refactor', 'bug_fix', 'tech_debt'],
+      errorMessage: 'category must be one of: feature, infrastructure, database, security, documentation, refactor, bug_fix, tech_debt'
+    },
+    priority: {
+      required: true,
+      validValues: ['critical', 'high', 'medium', 'low'],
+      errorMessage: 'priority must be one of: critical, high, medium, low'
+    }
+  }
+};
+
+/**
+ * Validate an array field against schema requirements
+ * @param {Array} value - The array to validate
+ * @param {Object} rules - Validation rules
+ * @returns {Object} { valid: boolean, message: string }
+ */
+function validateArrayField(value, rules) {
+  if (!Array.isArray(value)) {
+    return { valid: false, message: 'must be an array' };
+  }
+
+  if (value.length < rules.minItems) {
+    return { valid: false, message: `needs ${rules.minItems}+ items (got ${value.length})` };
+  }
+
+  // If array is empty and that's allowed, pass validation
+  if (value.length === 0 && rules.minItems === 0) {
+    return { valid: true };
+  }
+
+  // Check first item for schema compliance
+  if (rules.itemSchema && value.length > 0) {
+    const firstItem = value[0];
+
+    // Accept string arrays if allowed
+    if (rules.acceptsStringArray && typeof firstItem === 'string') {
+      return { valid: true };
+    }
+
+    // Check for required schema fields
+    if (typeof firstItem === 'object') {
+      const missingKeys = rules.itemSchema.filter(k => !Object.prototype.hasOwnProperty.call(firstItem, k));
+      if (missingKeys.length > 0) {
+        return {
+          valid: false,
+          message: `items should have ${rules.itemSchema.join(', ')} (missing: ${missingKeys.join(', ')})`
+        };
+      }
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Validate a string field against requirements
+ * @param {string} value - The string to validate
+ * @param {Object} rules - Validation rules
+ * @returns {Object} { valid: boolean, message: string }
+ */
+function validateStringField(value, rules) {
+  if (!value || typeof value !== 'string') {
+    return { valid: false, message: 'is required' };
+  }
+
+  if (rules.minLength && value.length < rules.minLength) {
+    return { valid: false, message: `must be at least ${rules.minLength} characters (got ${value.length})` };
+  }
+
+  if (rules.validValues && !rules.validValues.includes(value)) {
+    return { valid: false, message: `must be one of: ${rules.validValues.join(', ')}` };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Calculate completion score for an SD
+ * @param {Object} sdData - Strategic Directive data
+ * @returns {number} Score 0-100
+ */
+function calculateCompletionScore(sdData) {
+  let score = 0;
+  const maxScore = 100;
+
+  // Strategic fields: 60 points
+  if (sdData.success_metrics?.length >= 3) score += 15;
+  else if (sdData.success_metrics?.length >= 1) score += 5;
+
+  if (sdData.key_principles?.length >= 2) score += 10;
+  else if (sdData.key_principles?.length >= 1) score += 5;
+
+  if (sdData.strategic_objectives?.length >= 2) score += 15;
+  else if (sdData.strategic_objectives?.length >= 1) score += 5;
+
+  if (sdData.success_criteria?.length >= 3) score += 10;
+  else if (sdData.success_criteria?.length >= 1) score += 5;
+
+  if (sdData.risks !== undefined) score += 10;
+
+  // Core fields: 40 points
+  if (sdData.title?.length >= 10) score += 10;
+  if (sdData.description?.length >= 100) score += 10;
+  else if (sdData.description?.length >= 50) score += 5;
+  if (sdData.scope?.length >= 50) score += 10;
+  else if (sdData.scope?.length >= 30) score += 5;
+  if (sdData.rationale?.length >= 30) score += 5;
+  if (sdData.category) score += 5;
+
+  return Math.round((score / maxScore) * 100);
+}
+
+/**
+ * Main validation function for SD creation
+ *
+ * @param {Object} sdData - Strategic Directive data to validate
+ * @param {Object} options - Validation options
+ * @param {boolean} options.isChildSD - Whether this is a child SD (stricter validation)
+ * @param {boolean} options.allowWarnings - Allow warnings but continue (default: true)
+ * @returns {Object} { valid: boolean, canCreate: boolean, errors: [], warnings: [], score: number }
+ */
+export function validateSDCreation(sdData, options = {}) {
+  const { isChildSD = !!sdData?.parent_sd_id, allowWarnings = true } = options;
+
+  const errors = [];
+  const warnings = [];
+
+  // Validate core fields (always required)
+  for (const [field, rules] of Object.entries(SD_FIELD_REQUIREMENTS.core)) {
+    const value = sdData[field];
+    const result = validateStringField(value, rules);
+    if (!result.valid) {
+      errors.push(`${field}: ${rules.errorMessage}`);
+    }
+  }
+
+  // Validate strategic fields
+  // For child SDs, these are required; for standalone SDs, they're warnings
+  for (const [field, rules] of Object.entries(SD_FIELD_REQUIREMENTS.strategic)) {
+    const value = sdData[field];
+
+    // Check presence
+    if (value === undefined || value === null) {
+      if (field === 'risks') {
+        // risks must be defined but can be empty
+        if (isChildSD) {
+          errors.push(`${field}: Must be defined (use [] for low-risk SDs)`);
+        } else {
+          warnings.push(`${field}: Should be defined (use [] for low-risk SDs)`);
+        }
+      } else {
+        if (isChildSD) {
+          errors.push(`${field}: ${rules.errorMessage}`);
+        } else {
+          warnings.push(`${field}: ${rules.errorMessage} (recommended for handoff success)`);
+        }
+      }
+      continue;
+    }
+
+    // Validate array structure
+    const result = validateArrayField(value, rules);
+    if (!result.valid) {
+      if (isChildSD) {
+        errors.push(`${field}: ${result.message}`);
+      } else {
+        warnings.push(`${field}: ${result.message}`);
+      }
+    }
+  }
+
+  const score = calculateCompletionScore(sdData);
+  const valid = errors.length === 0;
+  const canCreate = valid || (allowWarnings && errors.length === 0);
+
+  return {
+    valid,
+    canCreate,
+    errors,
+    warnings,
+    score,
+    isChildSD,
+    summary: generateValidationSummary(sdData, errors, warnings, score)
+  };
+}
+
+/**
+ * Generate a human-readable validation summary
+ */
+function generateValidationSummary(sdData, errors, warnings, score) {
+  const lines = [];
+  lines.push(`SD Creation Validation: ${errors.length === 0 ? '✅ PASSED' : '❌ FAILED'}`);
+  lines.push(`Score: ${score}%`);
+
+  if (errors.length > 0) {
+    lines.push(`\nBlocking Errors (${errors.length}):`);
+    errors.forEach(e => lines.push(`  ❌ ${e}`));
+  }
+
+  if (warnings.length > 0) {
+    lines.push(`\nWarnings (${warnings.length}):`);
+    warnings.forEach(w => lines.push(`  ⚠️  ${w}`));
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Quick validation check (returns boolean only)
+ * @param {Object} sdData - Strategic Directive data
+ * @returns {boolean} True if SD can be created
+ */
+export function canCreateSD(sdData) {
+  const result = validateSDCreation(sdData);
+  return result.canCreate;
+}
+
+/**
+ * Get the list of missing required fields for a child SD
+ * @param {Object} sdData - Strategic Directive data
+ * @returns {string[]} List of missing field names
+ */
+export function getMissingChildFields(sdData) {
+  const missing = [];
+
+  for (const [field, rules] of Object.entries(SD_FIELD_REQUIREMENTS.strategic)) {
+    const value = sdData[field];
+
+    if (value === undefined || value === null) {
+      missing.push(field);
+      continue;
+    }
+
+    if (Array.isArray(value) && value.length < rules.minItems) {
+      missing.push(`${field} (needs ${rules.minItems}+ items)`);
+    }
+  }
+
+  return missing;
+}
+
+export default {
+  validateSDCreation,
+  canCreateSD,
+  getMissingChildFields,
+  SD_FIELD_REQUIREMENTS
+};


### PR DESCRIPTION
## Summary
- Implements shift-left validation infrastructure for SD-LEO-CREATION-VALIDATION-001
- Prevents "hollow" SDs by enforcing strategic fields at creation time
- Auto-populates child SDs from parent template with proper inheritance

## Changes
- **sd-creation-validator.js**: Validates strategic fields (success_metrics 3+, key_principles 2+, etc.) at SD creation
- **child-sd-template.js**: Generates child SDs with inherited strategic fields from parent
- **fix-stage-arch-child-sd-fields.js**: Populates P5-P10 with strategic fields for SD-STAGE-ARCH-001

## Root Cause Fix
Addresses temporal validation mismatch where SDs were created with 5 fields but handoffs required 50+ fields. This shift-left approach validates at creation time rather than handoff time.

## Test plan
- [x] Verified modules import correctly
- [x] Integration test: child generation + validation passes at 95%
- [x] Smoke tests pass
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)