### PR TITLE
fix(handoff): Use correct SD ID format for user story query

### DIFF
--- a/scripts/modules/handoff/executors/PlanToLeadExecutor.js
+++ b/scripts/modules/handoff/executors/PlanToLeadExecutor.js
@@ -695,10 +695,13 @@ export class PlanToLeadExecutor extends BaseExecutor {
         }
 
         // Count user stories for this SD
+        // Note: user_stories.sd_id uses the uppercase ID format (e.g., SD-XXX-001)
+        // not the lowercase sd_key format
+        const sdIdForStories = sdUuid || sdLegacyId.toUpperCase().replace(/^(?!SD-)/, 'SD-');
         const { data: userStories, error: storyError } = await this.supabase
           .from('user_stories')
           .select('id, title, status, validation_status')
-          .eq('sd_id', sdLegacyId);
+          .eq('sd_id', sdIdForStories);
 
         if (storyError) {
           console.log(`   ⚠️  User story query error: ${storyError.message}`);


### PR DESCRIPTION
## Summary

Fixes a bug in the USER_STORY_EXISTENCE_GATE where the query was using the 
lowercase `sd_key` format but `user_stories.sd_id` uses the uppercase ID 
format (e.g., `SD-XXX-001`).

### Bug

The handoff script was querying:
```sql
SELECT * FROM user_stories WHERE sd_id = 'genesis-v31-mason-branch'
```

But the actual data has:
```sql
sd_id = 'SD-GENESIS-V31-MASON-BRANCH'
```

This caused valid user stories to not be found, blocking handoffs.

### Fix

Updated the query to use the correct ID format by using `sdUuid` (which 
contains the uppercase ID from `ctx.sd?.id`).

## Test plan
- [x] Verified genesis-v31-mason-branch now passes USER_STORY_EXISTENCE_GATE
- [x] PLAN-TO-LEAD handoff succeeded with score 93%

🤖 Generated with [Claude Code](https://claude.com/claude-code)