### PR TITLE
fix(migrations): Fix RAISE parameter counts and constraint for legacy data

### DIFF
--- a/database/migrations/20260101_fix5_governance_automation_bypass.sql
+++ b/database/migrations/20260101_fix5_governance_automation_bypass.sql
@@ -297,7 +297,7 @@ BEGIN
 
     -- Block type changes after PLAN phase has handoffs
     IF has_handoffs AND sd_phase NOT IN ('LEAD', 'DRAFT') THEN
-      RAISE EXCEPTION E'SD_TYPE_CHANGE_TIMING_BLOCKED: Cannot change type from "%" to "%" after handoffs created.\n\nCurrent Phase: %\nProgress: %%\n\nType changes should happen in LEAD phase before work begins.\nUse automation bypass if this is intentional.',
+      RAISE EXCEPTION E'SD_TYPE_CHANGE_TIMING_BLOCKED: Cannot change type from "%" to "%" after handoffs created.\n\nCurrent Phase: %\nProgress: %\n\nType changes should happen in LEAD phase before work begins.\nUse automation bypass if this is intentional.',
         OLD.sd_type, NEW.sd_type, sd_phase, sd_progress;
     END IF;
   END IF;


### PR DESCRIPTION
## Summary

Fixes syntax errors in migrations that prevented clean execution.

### Changes
- **Fix 1**: Allow NULL validation_score (22 legacy rows have NULL with status=accepted)
- **Fix 1**: RAISE WARNING had 5 params but only 4 placeholders - simplified format
- **Fix 1**: Multi-line COMMENT statements caused parser issues - converted to single-line
- **Fix 5**: RAISE EXCEPTION had `%%` (literal %) but 4 params expected

### Verification
All migrations now execute cleanly:
- Fix 1: 19/19 statements ✅
- Fix 4: 15/15 statements ✅  
- Fix 5: 21/21 statements ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)