### PR TITLE
fix(workflow): Auto-invoke sub-agents and fix state transitions

### DIFF
--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -80,10 +80,37 @@ node scripts/handoff.js execute PLAN-TO-EXEC SD-XXX-001
 node scripts/handoff.js execute EXEC-TO-PLAN SD-XXX-001
 ```
 
-#### PLAN → LEAD Transition (Final Approval)
+#### PLAN → LEAD Transition (Verification Complete)
 ```bash
 node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
 ```
+
+#### LEAD → Final Approval (SD Completion)
+```bash
+node scripts/handoff.js execute LEAD-FINAL-APPROVAL SD-XXX-001
+```
+
+### LEAD_FINAL Phase Documentation
+
+**Purpose**: Final approval gate before SD completion. Validates all work is done.
+
+**Prerequisites** (must all be met):
+- All handoffs complete: LEAD-TO-PLAN → PLAN-TO-EXEC → EXEC-TO-PLAN → PLAN-TO-LEAD
+- All tests passing (unit + E2E)
+- UI parity verified (≥80% coverage)
+- No blocking issues remaining
+
+**Actions performed**:
+1. Verify all acceptance criteria met
+2. Generate retrospective for continuous improvement
+3. Mark SD as 'completed'
+4. Archive handoff history
+5. Trigger parent orchestrator completion check (if child SD)
+
+**When to use**:
+- After PLAN-TO-LEAD handoff succeeds
+- When all implementation and verification is complete
+- Ready to mark the SD as fully completed
 
 ### Compliance Check
 ```bash

--- a/scripts/modules/design-database-gates-validation.js
+++ b/scripts/modules/design-database-gates-validation.js
@@ -275,7 +275,13 @@ export async function validateGate1PlanToExec(sd_id, supabase) {
     console.log('\n[5/9] Checking if schema documentation was consulted (MINOR)...');
 
     if (prdData?.metadata?.database_analysis?.raw_analysis) {
-      const dbAnalysis = prdData.metadata.database_analysis.raw_analysis;
+      const rawDbAnalysis = prdData.metadata.database_analysis.raw_analysis;
+
+      // ROOT CAUSE FIX: Ensure dbAnalysis is a string before calling .includes()
+      // raw_analysis can be: string, object, or compressed artifact reference
+      const dbAnalysis = typeof rawDbAnalysis === 'string'
+        ? rawDbAnalysis
+        : JSON.stringify(rawDbAnalysis);
 
       // Check if analysis mentions schema docs
       const mentionsSchemaDocs = dbAnalysis.includes('docs/reference/schema/') ||

--- a/scripts/modules/handoff/executors/PlanToExecExecutor.js
+++ b/scripts/modules/handoff/executors/PlanToExecExecutor.js
@@ -352,6 +352,7 @@ export class PlanToExecExecutor extends BaseExecutor {
     // Gate 1: DESIGN→DATABASE Workflow (conditional)
     // ROOT CAUSE FIX: Use sync version - async version was causing Promise-always-truthy bug (SD-NAV-CMD-001A)
     // bugfix type SDs do NOT require DESIGN/DATABASE sub-agents (quick fixes don't need full architecture review)
+    // Gap #2 Fix (2026-01-01): Auto-invoke missing sub-agents instead of just failing
     if (shouldValidateDesignDatabaseSync(sd)) {
       gates.push({
         name: 'GATE1_DESIGN_DATABASE',
@@ -360,7 +361,43 @@ export class PlanToExecExecutor extends BaseExecutor {
           console.log('-'.repeat(50));
           // Use UUID (ctx.sd.id) not legacy_id (ctx.sdId) for database queries
           const sdUuidForQuery = ctx.sd?.id || ctx.sdId;
-          return validateGate1PlanToExec(sdUuidForQuery, this.supabase);
+
+          // First check: Validate existing sub-agents
+          const initialResult = await validateGate1PlanToExec(sdUuidForQuery, this.supabase);
+
+          // Gap #2 Fix: If validation fails, auto-invoke missing sub-agents
+          if (!initialResult.passed && !ctx._autoInvokeAttempted) {
+            console.log('\n   🔄 Auto-invoking missing PLAN phase sub-agents...');
+            ctx._autoInvokeAttempted = true;
+
+            try {
+              const { orchestrate } = await import('../../../orchestrate-phase-subagents.js');
+              const orchestrationResult = await orchestrate('PLAN_PRD', sdUuidForQuery, {
+                autoRemediate: true,
+                skipIfExists: true
+              });
+
+              if (orchestrationResult.status === 'PASS' || orchestrationResult.status === 'COMPLETE') {
+                console.log('   ✅ Sub-agents invoked successfully');
+                if (orchestrationResult.executed?.length > 0) {
+                  console.log(`      Executed: ${orchestrationResult.executed.join(', ')}`);
+                }
+
+                // Re-check after invocation
+                console.log('\n   🔁 Re-validating after sub-agent invocation...');
+                const reCheckResult = await validateGate1PlanToExec(sdUuidForQuery, this.supabase);
+                return reCheckResult;
+              } else {
+                console.log(`   ⚠️  Sub-agent orchestration status: ${orchestrationResult.status}`);
+                console.log('      Proceeding with original validation result');
+              }
+            } catch (orchestrationError) {
+              console.error('   ⚠️  Auto-invocation failed:', orchestrationError.message);
+              console.log('      Proceeding with original validation result');
+            }
+          }
+
+          return initialResult;
         },
         required: true
       });

--- a/scripts/modules/prd-quality-validation.js
+++ b/scripts/modules/prd-quality-validation.js
@@ -235,7 +235,10 @@ export async function validatePRDQuality(prd, options = {}) {
   // similar to infrastructure - they don't need the full AI semantic analysis
   // Added 'theming', 'ux', 'design', 'ui' (2025-12-28): UI/UX SDs focus on visual/style changes
   // Check both sdType and sdCategory since SDs can have type='implementation' but category='theming'
-  const heuristicTypes = ['bugfix', 'bug_fix', 'infrastructure', 'quality assurance', 'quality_assurance', 'orchestrator', 'documentation', 'refactor', 'theming', 'ux', 'design', 'ui', 'layout', 'state-management'];
+  // ROOT CAUSE FIX (2026-01-01): Added 'database', 'database_schema' - same rationale as
+  // user-story-quality-validation.js line 157: database SDs focus on schema/migrations,
+  // not user narratives. This was an incomplete refactoring that caused false PRD failures.
+  const heuristicTypes = ['bugfix', 'bug_fix', 'infrastructure', 'database', 'database_schema', 'quality assurance', 'quality_assurance', 'orchestrator', 'documentation', 'refactor', 'theming', 'ux', 'design', 'ui', 'layout', 'state-management'];
   const usesHeuristic = process.env.PRD_VALIDATION_MODE === 'heuristic' ||
                         heuristicTypes.includes(sdType) ||
                         heuristicTypes.includes(sdCategory);

--- a/scripts/orchestrate-phase-subagents.js
+++ b/scripts/orchestrate-phase-subagents.js
@@ -110,7 +110,12 @@ const MANDATORY_SUBAGENTS_BY_PHASE = {
   PLAN_VERIFY: {
     // SD-type specific mandatory agents
     feature: ['TESTING', 'SECURITY', 'PERFORMANCE'],
-    database: ['TESTING', 'DATABASE', 'SECURITY', 'PERFORMANCE'],
+    // ROOT CAUSE FIX (2026-01-01): Removed TESTING from database mandatory list
+    // Database SDs focus on schema/migrations, not user-facing code. TESTING exemption
+    // is configured in sd_type_validation_profiles table. Step 3D was overriding this
+    // exemption by hardcoding TESTING as mandatory here. Now database SDs correctly
+    // use DATABASE agent for schema validation instead of TESTING agent.
+    database: ['DATABASE', 'SECURITY', 'PERFORMANCE'],
     security: ['TESTING', 'SECURITY'],
     api: ['TESTING', 'SECURITY', 'PERFORMANCE', 'API'],
     documentation: ['DOCMON'],


### PR DESCRIPTION
## Summary

This PR fixes 5 systemic workflow gaps discovered during SD-VENTURE-SELECTION-001 child SD execution. These issues caused manual intervention requirements that should be automated.

### P0 Fixes (Critical)
- **Gap #1**: PRD creation now auto-invokes ALL PLAN phase sub-agents via `orchestrate('PLAN_PRD')`
- **Gap #2**: PLAN-TO-EXEC gate auto-invokes missing sub-agents and re-validates instead of just failing

### P1 Fixes (High)
- **Gap #3**: LEAD-TO-PLAN now auto-executes the generated PRD script (not just creates the file)
- **Gap #7**: Added `_transitionSdToPlan()` method to update SD phase from LEAD → PLAN_PRD

### P2 Fixes (Medium)
- **Gap #6**: Documented LEAD_FINAL phase in CLAUDE_LEAD.md with prerequisites and actions

### Also Includes Previous ROOT CAUSE Fixes
- Fix #1: Added `database`/`database_schema` to heuristicTypes in prd-quality-validation.js
- Fix #2: Check ACCEPTED handoffs first in ExecToPlanExecutor (before checking blocked)
- Fix #3: Removed TESTING from database mandatory sub-agents list

## Files Changed (9)
| File | Change |
|------|--------|
| `templates/prd-script-template.js` | Added Step 6: Auto-invoke orchestrate() |
| `scripts/add-prd-to-database.js` | Replaced autoTriggerStories with full orchestrator |
| `PlanToExecExecutor.js` | Gate auto-invokes missing sub-agents |
| `LeadToPlanExecutor.js` | Auto-execute PRD script + state transition |
| `ExecToPlanExecutor.js` | Check ACCEPTED before BLOCKED |
| `prd-quality-validation.js` | Added database heuristic types |
| `orchestrate-phase-subagents.js` | Removed TESTING from database mandatory |
| `design-database-gates-validation.js` | Minor adjustment |
| `CLAUDE_LEAD.md` | LEAD_FINAL documentation |

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint auto-fix applied
- [x] PRD script validation passed
- [x] DOCMON compliance check passed
- [ ] Manual: Run LEAD-TO-PLAN handoff and verify auto-execution
- [ ] Manual: Run PLAN-TO-EXEC with missing sub-agents and verify auto-invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)