### PR TITLE
feat(leo): Add SD type-aware gate thresholds and orchestrator bypass

### DIFF
--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -29,16 +29,16 @@
   "loading_patterns": [
     {
       "pattern": "Loading states (isLoading, Skeleton)",
-      "count": 1883,
+      "count": 1909,
       "confidence": "high"
     }
   ],
   "navigation": [
     {
       "pattern": "Programmatic navigation",
-      "count": 214,
+      "count": 221,
       "confidence": "high"
     }
   ],
-  "last_scan": "2025-12-31T03:53:16.528Z"
+  "last_scan": "2026-01-02T04:34:45.094Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ See documentation for table structure: `database/schema/007_leo_protocol_schema_
 
 ## Session Prologue (Short)
 
-1. **Follow LEAD→PLAN→EXEC** - Target ≥85% gate pass rate
+1. **Follow LEAD→PLAN→EXEC** - Target gate pass rate varies by SD type (60-90%, typically 85%)
 2. **Use sub-agents** - Architect, QA, Reviewer - summarize outputs
 3. **Database-first** - No markdown files as source of truth
 4. **USE PROCESS SCRIPTS** - ⚠️ NEVER bypass add-prd-to-database.js, handoff.js ⚠️
@@ -64,7 +64,7 @@ This command provides:
 - `bash scripts/leo-stack.sh stop` - Stop all servers
 
 ## ⚠️ DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2025-12-27 5:55:08 PM
+**Last Generated**: 2026-01-02 8:31:59 AM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 
@@ -104,6 +104,6 @@ This command provides:
 
 ---
 
-*Router generated from database: 2025-12-27*
+*Router generated from database: 2026-01-02*
 *Protocol Version: 4.3.3*
 *Part of LEO Protocol router architecture*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2025-12-27 5:55:08 PM
+**Generated**: 2026-01-02 8:31:59 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions (15-20k chars)
 
@@ -185,37 +185,6 @@ npm run handoff:compliance SD-ID  # Check specific SD
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
-## Mandatory Agent Invocation Rules
-
-**CRITICAL**: Certain task types REQUIRE specialized agent invocation - NO ad-hoc manual inspection allowed.
-
-### Task Type -> Required Agent
-
-| Task Keywords | MUST Invoke | Purpose |
-|---------------|-------------|---------|
-| UI, UX, design, landing page, styling, CSS, colors, buttons | **design-agent** | Accessibility audit (axe-core), contrast checking |
-| accessibility, a11y, WCAG, screen reader, contrast | **design-agent** | WCAG 2.1 AA compliance validation |
-| form, input, validation, user flow | **design-agent** + **testing-agent** | UX + E2E verification |
-| performance, slow, loading, latency | **performance-agent** | Load testing, optimization |
-| security, auth, RLS, permissions | **security-agent** | Vulnerability assessment |
-| API, endpoint, REST, GraphQL | **api-agent** | API design patterns |
-| database, migration, schema | **database-agent** | Schema validation |
-| test, E2E, Playwright, coverage | **testing-agent** | Test execution |
-
-### Why This Exists
-
-**Incident**: Human-like testing perspective interpreted as manual content inspection.
-**Result**: 47 accessibility issues missed, including critical contrast failures (1.03:1 ratio).
-**Root Cause**: Ad-hoc review instead of specialized agent invocation.
-**Prevention**: Explicit rules mandate agent use for specialized tasks.
-
-### How to Apply
-
-1. Detect task type from user request keywords
-2. Invoke required agent(s) BEFORE making changes
-3. Agent findings inform implementation
-4. Re-run agent AFTER changes to verify fixes
-
 ## 🤖 Built-in Agent Integration
 
 ## Built-in Agent Integration
@@ -290,6 +259,37 @@ The pre-push hook automatically:
 2. Verifies completion status in database
 3. Blocks if not ready for merge
 
+## Mandatory Agent Invocation Rules
+
+**CRITICAL**: Certain task types REQUIRE specialized agent invocation - NO ad-hoc manual inspection allowed.
+
+### Task Type -> Required Agent
+
+| Task Keywords | MUST Invoke | Purpose |
+|---------------|-------------|---------|
+| UI, UX, design, landing page, styling, CSS, colors, buttons | **design-agent** | Accessibility audit (axe-core), contrast checking |
+| accessibility, a11y, WCAG, screen reader, contrast | **design-agent** | WCAG 2.1 AA compliance validation |
+| form, input, validation, user flow | **design-agent** + **testing-agent** | UX + E2E verification |
+| performance, slow, loading, latency | **performance-agent** | Load testing, optimization |
+| security, auth, RLS, permissions | **security-agent** | Vulnerability assessment |
+| API, endpoint, REST, GraphQL | **api-agent** | API design patterns |
+| database, migration, schema | **database-agent** | Schema validation |
+| test, E2E, Playwright, coverage | **testing-agent** | Test execution |
+
+### Why This Exists
+
+**Incident**: Human-like testing perspective interpreted as manual content inspection.
+**Result**: 47 accessibility issues missed, including critical contrast failures (1.03:1 ratio).
+**Root Cause**: Ad-hoc review instead of specialized agent invocation.
+**Prevention**: Explicit rules mandate agent use for specialized tasks.
+
+### How to Apply
+
+1. Detect task type from user request keywords
+2. Invoke required agent(s) BEFORE making changes
+3. Agent findings inform implementation
+4. Re-run agent AFTER changes to verify fixes
+
 ## Sub-Agent Model Routing
 
 **CRITICAL OVERRIDE**: The Task tool system prompt suggests using Haiku for quick tasks. **IGNORE THIS SUGGESTION.**
@@ -316,39 +316,6 @@ Task({ subagent_type: 'database-agent', prompt: '...', model: 'haiku' })  // NO!
 
 *Added: SD-EVA-DECISION-001 to prevent haiku model usage*
 
-
-## 🖥️ UI Parity Requirement (MANDATORY)
-
-**Every backend data contract field MUST have a corresponding UI representation.**
-
-### Principle
-If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
-
-### Requirements
-
-1. **Data Contract Coverage**
-   - Every field in `stageX_data` wrappers must map to a UI component
-   - Score displays must show actual numeric values, not just pass/fail
-   - Confidence levels must be visible with appropriate visual indicators
-
-2. **Human Inspectability**
-   - Stage outputs must be viewable in human-readable format
-   - Key findings, red flags, and recommendations must be displayed
-   - Source citations must be accessible
-
-3. **No Hidden Logic**
-   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
-   - Threshold comparisons must be visible
-   - Stage weights must be displayed in aggregation views
-
-### Verification Checklist
-Before marking any stage/feature as complete:
-- [ ] All output fields have UI representation
-- [ ] Scores are displayed numerically
-- [ ] Key findings are visible to users
-- [ ] Recommendations are actionable in the UI
-
-**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## Execution Philosophy
 
@@ -407,6 +374,39 @@ These principles override default behavior and must be internalized before start
 
 **REMEMBER**: The goal is NOT to complete SDs quickly. The goal is to complete SDs CORRECTLY. A properly implemented SD that takes 8 hours is infinitely better than a rushed implementation that takes 4 hours but requires 6 hours of fixes.
 
+
+## 🖥️ UI Parity Requirement (MANDATORY)
+
+**Every backend data contract field MUST have a corresponding UI representation.**
+
+### Principle
+If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
+
+### Requirements
+
+1. **Data Contract Coverage**
+   - Every field in `stageX_data` wrappers must map to a UI component
+   - Score displays must show actual numeric values, not just pass/fail
+   - Confidence levels must be visible with appropriate visual indicators
+
+2. **Human Inspectability**
+   - Stage outputs must be viewable in human-readable format
+   - Key findings, red flags, and recommendations must be displayed
+   - Source citations must be accessible
+
+3. **No Hidden Logic**
+   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
+   - Threshold comparisons must be visible
+   - Stage weights must be displayed in aggregation views
+
+### Verification Checklist
+Before marking any stage/feature as complete:
+- [ ] All output fields have UI representation
+- [ ] Scores are displayed numerically
+- [ ] Key findings are visible to users
+- [ ] Recommendations are actionable in the UI
+
+**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## 🎯 Skill Integration (Claude Code Skills)
 
@@ -843,10 +843,18 @@ The LEO Protocol supports hierarchical SDs for multi-phase work. Parent SDs coor
 
 1. **Every child gets full LEAD→PLAN→EXEC** - complete workflow, no shortcuts
 2. **Parent PLAN creates children** - PLAN agent proposes decomposition during parent PRD
-3. **Each child needs LEAD approval** - validates strategic value, scope, risks per child
-4. **Children execute sequentially** - Child B waits for Child A to complete
-5. **Parent progress = weighted child progress** - auto-calculated
-6. **Parent completes last** - after all children finish
+3. **Parent SDs bypass user story gates** - user stories exist in child SDs, not parent (USER_STORY_EXISTENCE_GATE bypassed for orchestrators)
+4. **Each child needs LEAD approval** - validates strategic value, scope, risks per child
+5. **Children execute sequentially** - Child B waits for Child A to complete
+6. **Parent progress = weighted child progress** - auto-calculated
+7. **Parent completes last** - after all children finish
+
+### Orchestrator Gate Handling
+
+Parent orchestrator SDs have special validation logic:
+- **USER_STORY_EXISTENCE_GATE**: Bypassed (user stories are in child SDs)
+- **Gate thresholds**: Use `orchestrator` threshold (70%) instead of feature (85%)
+- **Validation focus**: Child SD progress and completion status
 
 ### Workflow Diagram
 
@@ -903,18 +911,36 @@ SELECT calculate_parent_sd_progress('SD-PARENT-001');
 
 -- Get next child to execute
 SELECT get_next_child_sd('SD-PARENT-001');
-```
 
+-- Detect orchestrator (for gate bypass)
+SELECT COUNT(*) > 0 as is_orchestrator 
+FROM strategic_directives_v2 
+WHERE parent_sd_id = 'SD-XXX';
+```
 
 ## SD Type-Aware Workflow Paths
 
-**IMPORTANT**: Different SD types have different required handoffs. Always check the workflow before executing handoffs.
+**IMPORTANT**: Different SD types have different required handoffs AND different gate pass thresholds.
 
 ### Workflow Command
 ```bash
 # Check recommended workflow for any SD
 node scripts/handoff.js workflow SD-XXX-001
 ```
+
+### Gate Pass Thresholds by SD Type
+
+| SD Type | Gate Threshold | Rationale |
+|---------|----------------|-----------|
+| **feature** | 85% | Full validation (UI, E2E, integration) |
+| **database** | 75% | Schema-focused, may skip UI-dependent E2E |
+| **infrastructure** | 80% | Tooling/protocols, reduced code validation |
+| **security** | 90% | Higher bar for security-critical work |
+| **documentation** | 60% | No code changes, minimal validation |
+| **orchestrator** | 70% | Coordination layer, user stories in children |
+| **refactor** | 80% | Behavior preservation focus |
+| **bugfix** | 80% | Targeted fix validation |
+| **performance** | 85% | Measurable impact verification |
 
 ### Workflow by SD Type
 
@@ -925,19 +951,22 @@ node scripts/handoff.js workflow SD-XXX-001
 | **documentation** | LEAD→PLAN→EXEC→LEAD (final) | EXEC-TO-PLAN | All code validation |
 | **database** | Full workflow | None | Some E2E (UI-dependent) |
 | **security** | Full workflow | None | None |
+| **orchestrator** | LEAD→PLAN→(children)→LEAD (final) | N/A | USER_STORY_EXISTENCE_GATE |
 
 ### Key Rules
 
-1. **Feature SDs**: Full 5-handoff workflow with all validation gates
-2. **Infrastructure SDs**: Can skip EXEC-TO-PLAN (no code to validate)
-3. **Documentation SDs**: Can skip EXEC-TO-PLAN (no implementation to verify)
+1. **Feature SDs**: Full 5-handoff workflow with all validation gates at 85%
+2. **Infrastructure SDs**: Can skip EXEC-TO-PLAN (no code to validate), threshold 80%
+3. **Documentation SDs**: Can skip EXEC-TO-PLAN, threshold only 60%
 4. **Database/Security SDs**: Full workflow but may skip UI-dependent E2E tests
+5. **Orchestrator SDs**: User stories expected in children, not parent (70% threshold)
 
 ### Pre-Handoff Check
 Before executing any handoff:
 1. Run `node scripts/handoff.js workflow SD-ID` to see the recommended path
 2. The execute command will warn you if a handoff is optional
 3. Infrastructure/docs SDs can proceed directly from EXEC to PLAN-TO-LEAD
+4. Gate thresholds are automatically applied based on SD type
 
 ## Database-First Enforcement - Expanded
 
@@ -1361,6 +1390,8 @@ const assessment = await prdRubric.validatePRDQuality(prd, sd);
 
 **Result**: Objective quality gates that enforce LEO Protocol's philosophy without relying on human judgment.
 
+
+
 ## 🔥 Hot Issue Patterns (Auto-Updated)
 
 **CRITICAL**: These are active patterns detected from retrospectives. Review before starting work.
@@ -1407,9 +1438,9 @@ const assessment = await prdRubric.validatePRDQuality(prd, sd);
 |------|-----------|----------|----------|--------|
 | Gate 0 | 0% | 36 | 36 | 🔴 Critical |
 | Gate 1 | 0% | 1 | 1 | 🔴 Critical |
-| Gate 3 | 0% | 54 | 54 | 🔴 Critical |
-| Gate 2B | 0% | 54 | 54 | 🔴 Critical |
-| Gate 2D | 0% | 54 | 54 | 🔴 Critical |
+| Gate 3 | 0% | 42 | 42 | 🔴 Critical |
+| Gate 2B | 0% | 42 | 42 | 🔴 Critical |
+| Gate 2D | 0% | 42 | 42 | 🔴 Critical |
 
 ### Remediation Actions
 
@@ -1426,7 +1457,29 @@ When gates consistently fail:
 
 **From Published Retrospectives** - Apply these learnings proactively.
 
-### 1. Vision V2: EVA Orchestration Layer - Retrospective ⭐
+### 1. UI Canon Alignment - Retrospective ⭐
+**Category**: TESTING_STRATEGY | **Date**: 12/19/2025 | **Score**: 100
+
+**Key Improvements**:
+- E2E test timeout configuration for mock mode
+- Deprecation enforcement for legacy stage constants
+
+**Action Items**:
+- [ ] Add eslint rule to deprecate IDEATION_STAGES import and suggest VENTURE_STAGES
+- [ ] Configure separate Playwright timeouts for mock-mode tests (30s) vs real-mode te...
+
+### 2. Settings Tab Clarity + Feature Catalog Copy (NAV-48 + NAV-49) - Retrospective ⭐
+**Category**: APPLICATION_ISSUE | **Date**: 12/26/2025 | **Score**: 100
+
+**Key Improvements**:
+- PLAN-TO-EXEC handoff timed out on OpenAI API calls
+- Had to manually advance phase due to API timeouts
+
+**Action Items**:
+- [ ] Add timeout fallback for AI quality assessment in handoffs
+- [ ] Complete missing handoff documentation
+
+### 3. Vision V2: EVA Orchestration Layer - Retrospective ⭐
 **Category**: DATABASE_SCHEMA | **Date**: 12/14/2025 | **Score**: 100
 
 **Key Improvements**:
@@ -1437,7 +1490,7 @@ When gates consistently fail:
 - [ ] Add reset_sd_phase RPC function for administrative phase corrections
 - [ ] Maintain E2E test path auto-generation for all SD types
 
-### 2. Legacy Protocol Cleanup (The Exorcism) - Retrospective ⭐
+### 4. Legacy Protocol Cleanup (The Exorcism) - Retrospective ⭐
 **Category**: DEPLOYMENT_ISSUE | **Date**: 12/16/2025 | **Score**: 100
 
 **Key Improvements**:
@@ -1448,38 +1501,16 @@ When gates consistently fail:
 - [ ] Create rollback procedure for stage component deletions
 - [ ] Add E2E test verifying Stage1-25 UI renders correctly
 
-### 3. Vision V2: Chairman's Dashboard UI - Retrospective ⭐
-**Category**: TESTING_STRATEGY | **Date**: 12/14/2025 | **Score**: 100
+### 5. Sovereign Industrial Expansion - Stages 7-25 Materialization (Orchestrator) ⭐
+**Category**: PROCESS_IMPROVEMENT | **Date**: 12/27/2025 | **Score**: 100
 
 **Key Improvements**:
-- No unified test evidence found - consider running comprehensive E2E tests
-- No unified test evidence found - consider running comprehensive E2E tests
+- LEO Protocol artifacts should be created BEFORE implementation, not retroactively
+- Handoff chain documentation should accompany development from the start
 
 **Action Items**:
-- [ ] Complete PLAN-TO-LEAD handoff
-- [ ] Merge PR to main branch
-
-### 4. LEO Protocol Enhancement: Discovery Gate & Quality Improvements - Retrospective ⭐
-**Category**: TESTING_STRATEGY | **Date**: 12/12/2025 | **Score**: 100
-
-**Key Improvements**:
-- RETRO sub-agent accumulates duplicates - needs deduplication logic
-- Infrastructure SDs lack unified test evidence - need alternative validation
-
-**Action Items**:
-- [ ] RETRO Deduplication | Owner: LEO Team | Due: 2025-01-15 | Acceptance: No duplica...
-- [ ] Infrastructure Test Validation | Owner: LEO Team | Due: 2025-01-31 | Acceptance:...
-
-### 5. UI Canon Alignment - Retrospective ⭐
-**Category**: TESTING_STRATEGY | **Date**: 12/19/2025 | **Score**: 100
-
-**Key Improvements**:
-- E2E test timeout configuration for mock mode
-- Deprecation enforcement for legacy stage constants
-
-**Action Items**:
-- [ ] Add eslint rule to deprecate IDEATION_STAGES import and suggest VENTURE_STAGES
-- [ ] Configure separate Playwright timeouts for mock-mode tests (30s) vs real-mode te...
+- [ ] Create orchestrator SD template with built-in child tracking
+- [ ] Enforce LEO Protocol compliance for all SDs from LEAD phase
 
 
 *Lessons auto-generated from `retrospectives` table. Query for full details.*
@@ -1549,7 +1580,7 @@ Total = EXEC: 30% + LEAD: 35% + PLAN: 35% = 100%
 
 ---
 
-*Generated from database: 2025-12-27*
+*Generated from database: 2026-01-02*
 *Protocol Version: 4.3.3*
-*Includes: Hot Patterns (5) + Recent Lessons (5)*
+*Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,10 +1,50 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2025-12-27 5:55:08 PM
+**Generated**: 2026-01-02 8:31:59 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 
 ---
+
+## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
+
+**Anti-Bypass Protocol**: These commands MUST be run for ALL phase transitions. Do NOT use database-agent to create handoffs directly.
+
+### ⛔ NEVER DO THIS:
+- Using `database-agent` to directly insert into `sd_phase_handoffs`
+- Creating handoff records without running validation scripts
+- Skipping preflight knowledge retrieval
+
+### ✅ ALWAYS DO THIS:
+
+#### LEAD → PLAN Transition
+```bash
+node scripts/phase-preflight.js --phase PLAN --sd-id SD-XXX-001
+node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001
+```
+
+#### PLAN → EXEC Transition
+```bash
+node scripts/phase-preflight.js --phase EXEC --sd-id SD-XXX-001
+node scripts/handoff.js execute PLAN-TO-EXEC SD-XXX-001
+```
+
+#### EXEC → PLAN Transition (Verification)
+```bash
+node scripts/handoff.js execute EXEC-TO-PLAN SD-XXX-001
+```
+
+#### PLAN → LEAD Transition (Final Approval)
+```bash
+node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
+```
+
+### Compliance Check
+```bash
+npm run handoff:compliance SD-XXX-001
+```
+
+**Database trigger now BLOCKS direct inserts. You MUST use the scripts above.**
 
 ## Baseline Issues Management
 
@@ -51,73 +91,6 @@ security, testing, performance, database, documentation, accessibility, code_qua
 ### Functions
 - `check_baseline_gate(p_sd_id)`: Returns PASS/BLOCKED verdict for LEAD gate
 - `generate_baseline_issue_key(p_category)`: Generates unique issue key
-
-## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
-
-**Anti-Bypass Protocol**: These commands MUST be run for ALL phase transitions. Do NOT use database-agent to create handoffs directly.
-
-### ⛔ NEVER DO THIS:
-- Using `database-agent` to directly insert into `sd_phase_handoffs`
-- Creating handoff records without running validation scripts
-- Skipping preflight knowledge retrieval
-
-### ✅ ALWAYS DO THIS:
-
-#### LEAD → PLAN Transition
-```bash
-node scripts/phase-preflight.js --phase PLAN --sd-id SD-XXX-001
-node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001
-```
-
-#### PLAN → EXEC Transition
-```bash
-node scripts/phase-preflight.js --phase EXEC --sd-id SD-XXX-001
-node scripts/handoff.js execute PLAN-TO-EXEC SD-XXX-001
-```
-
-#### EXEC → PLAN Transition (Verification)
-```bash
-node scripts/handoff.js execute EXEC-TO-PLAN SD-XXX-001
-```
-
-#### PLAN → LEAD Transition (Verification Complete)
-```bash
-node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
-```
-
-#### LEAD → Final Approval (SD Completion)
-```bash
-node scripts/handoff.js execute LEAD-FINAL-APPROVAL SD-XXX-001
-```
-
-### LEAD_FINAL Phase Documentation
-
-**Purpose**: Final approval gate before SD completion. Validates all work is done.
-
-**Prerequisites** (must all be met):
-- All handoffs complete: LEAD-TO-PLAN → PLAN-TO-EXEC → EXEC-TO-PLAN → PLAN-TO-LEAD
-- All tests passing (unit + E2E)
-- UI parity verified (≥80% coverage)
-- No blocking issues remaining
-
-**Actions performed**:
-1. Verify all acceptance criteria met
-2. Generate retrospective for continuous improvement
-3. Mark SD as 'completed'
-4. Archive handoff history
-5. Trigger parent orchestrator completion check (if child SD)
-
-**When to use**:
-- After PLAN-TO-LEAD handoff succeeds
-- When all implementation and verification is complete
-- Ready to mark the SD as fully completed
-
-### Compliance Check
-```bash
-npm run handoff:compliance SD-XXX-001
-```
-
-**Database trigger now BLOCKS direct inserts. You MUST use the scripts above.**
 
 ## 🔍 Explore Before Validation (LEAD Phase)
 
@@ -883,6 +856,6 @@ npm run sd:status    # Overall progress by track
 
 ---
 
-*Generated from database: 2025-12-27*
+*Generated from database: 2026-01-02*
 *Protocol Version: 4.3.3*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2025-12-27 5:55:08 PM
+**Generated**: 2026-01-02 8:31:59 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates (30-35k chars)
 
@@ -122,30 +122,6 @@ Launch 1-3 Plan agents based on complexity:
 
 Do NOT launch 3 agents for every task—that wastes time on simple decisions.
 
-## Deferred Work Management
-
-### What Gets Deferred
-- Technical debt discovered during implementation
-- Edge cases not critical for MVP
-- Performance optimizations for later
-- Nice-to-have features
-
-### Creating Deferred Items
-```sql
-INSERT INTO deferred_work (sd_id, title, reason, priority)
-VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
-```
-
-### Tracking
-- Deferred items linked to parent SD
-- Reviewed during retrospective
-- May become new SDs if significant
-
-### Rules
-- Document WHY deferred, not just WHAT
-- Set realistic priority (critical items shouldn't be deferred)
-- Max 5 deferred items per SD
-
 ## PLAN Phase Negative Constraints
 
 ## 🚫 PLAN Phase Negative Constraints
@@ -183,6 +159,30 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 **Why Wrong**: PRD validator blocks placeholders, signals incomplete planning
 **Correct Approach**: If truly unknown, use AskUserQuestion to clarify before PRD creation
 </negative_constraints>
+
+## Deferred Work Management
+
+### What Gets Deferred
+- Technical debt discovered during implementation
+- Edge cases not critical for MVP
+- Performance optimizations for later
+- Nice-to-have features
+
+### Creating Deferred Items
+```sql
+INSERT INTO deferred_work (sd_id, title, reason, priority)
+VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
+```
+
+### Tracking
+- Deferred items linked to parent SD
+- Reviewed during retrospective
+- May become new SDs if significant
+
+### Rules
+- Document WHY deferred, not just WHAT
+- Set realistic priority (critical items shouldn't be deferred)
+- Max 5 deferred items per SD
 
 ## PRD Template Scaffolding
 
@@ -644,6 +644,21 @@ node scripts/add-prd-to-database.js SD-RESEARCH-106
 ```
 
 
+## CI/CD Pipeline Verification
+
+## CI/CD Pipeline Verification (MANDATORY)
+
+**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
+
+### Verification Process
+
+**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
+
+1. Wait 2-3 minutes for GitHub Actions to complete
+2. Trigger DevOps sub-agent to verify pipeline status
+3. Document CI/CD status in PLAN→LEAD handoff
+4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
+
 ## DESIGN→DATABASE Validation Gates
 
 **4 mandatory gates ensuring sub-agent execution and implementation fidelity.**
@@ -695,21 +710,6 @@ Retroactive audit at SD closure:
 
 **Reference**: `scripts/modules/design-database-gates-validation.js`
 
-
-## CI/CD Pipeline Verification
-
-## CI/CD Pipeline Verification (MANDATORY)
-
-**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
-
-### Verification Process
-
-**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
-
-1. Wait 2-3 minutes for GitHub Actions to complete
-2. Trigger DevOps sub-agent to verify pipeline status
-3. Document CI/CD status in PLAN→LEAD handoff
-4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
 
 ## 🚪 Gate 2.5: Human Inspectability Validation
 
@@ -1825,6 +1825,6 @@ Test scenarios only cover happy path ('user logs in successfully'). Missing:
 
 ---
 
-*Generated from database: 2025-12-27*
+*Generated from database: 2026-01-02*
 *Protocol Version: 4.3.3*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/database/migrations/028_fix_sub_agent_id_type_mismatch.sql
+++ b/database/migrations/028_fix_sub_agent_id_type_mismatch.sql
@@ -1,0 +1,154 @@
+-- Migration 028: Fix sub_agent_id type mismatch in sub_agent_executions
+-- Created: 2026-01-02
+--
+-- PROBLEM:
+-- sub_agent_executions.sub_agent_id is UUID type
+-- leo_sub_agents.id is VARCHAR(50) type
+-- FK constraint incompatible between UUID and VARCHAR
+--
+-- SOLUTION:
+-- Convert sub_agent_executions.sub_agent_id from UUID to VARCHAR(50)
+-- to align with leo_sub_agents.id type
+--
+-- This is a safe migration because:
+-- 1. sub_agent_executions may not have FK constraint yet (due to type mismatch)
+-- 2. UUID values will convert to VARCHAR(50) cleanly
+-- 3. Adds proper FK constraint after type alignment
+
+BEGIN;
+
+-- Step 1: Check if the table exists
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public'
+    AND table_name = 'sub_agent_executions'
+  ) THEN
+    RAISE NOTICE 'Table sub_agent_executions does not exist, skipping migration';
+    RETURN;
+  END IF;
+
+  RAISE NOTICE 'Starting sub_agent_id type migration for sub_agent_executions';
+END $$;
+
+-- Step 2: Drop any existing FK constraints that might fail
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_name = 'sub_agent_executions'
+    AND constraint_type = 'FOREIGN KEY'
+    AND constraint_name LIKE '%sub_agent%'
+  ) THEN
+    EXECUTE (
+      SELECT string_agg(
+        'ALTER TABLE sub_agent_executions DROP CONSTRAINT IF EXISTS ' || constraint_name,
+        '; '
+      )
+      FROM information_schema.table_constraints
+      WHERE table_name = 'sub_agent_executions'
+      AND constraint_type = 'FOREIGN KEY'
+      AND constraint_name LIKE '%sub_agent%'
+    );
+    RAISE NOTICE 'Dropped existing sub_agent FK constraints';
+  END IF;
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'No FK constraints to drop or error: %', SQLERRM;
+END $$;
+
+-- Step 3: Drop the unique index that includes sub_agent_id
+DROP INDEX IF EXISTS ux_subagent_prd;
+RAISE NOTICE 'Dropped ux_subagent_prd index if it existed';
+
+-- Step 4: Check current column type and convert if needed
+DO $$
+DECLARE
+  current_type TEXT;
+BEGIN
+  SELECT data_type INTO current_type
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+  AND table_name = 'sub_agent_executions'
+  AND column_name = 'sub_agent_id';
+
+  IF current_type IS NULL THEN
+    RAISE NOTICE 'Column sub_agent_id not found, table may not exist';
+    RETURN;
+  END IF;
+
+  IF current_type = 'uuid' THEN
+    -- Convert UUID to VARCHAR(50)
+    ALTER TABLE sub_agent_executions
+      ALTER COLUMN sub_agent_id TYPE VARCHAR(50) USING sub_agent_id::TEXT;
+    RAISE NOTICE 'Converted sub_agent_id from UUID to VARCHAR(50)';
+  ELSIF current_type = 'character varying' THEN
+    RAISE NOTICE 'sub_agent_id is already VARCHAR type';
+  ELSE
+    RAISE NOTICE 'sub_agent_id has unexpected type: %. Attempting conversion...', current_type;
+    ALTER TABLE sub_agent_executions
+      ALTER COLUMN sub_agent_id TYPE VARCHAR(50) USING sub_agent_id::TEXT;
+  END IF;
+END $$;
+
+-- Step 5: Recreate the unique index with new type
+CREATE UNIQUE INDEX IF NOT EXISTS ux_subagent_prd
+  ON sub_agent_executions(prd_id, sub_agent_id);
+
+-- Step 6: Add FK constraint (now compatible types)
+-- Note: This will only succeed if the sub_agent_id values actually exist in leo_sub_agents
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_name = 'sub_agent_executions'
+    AND constraint_name = 'fk_sub_agent_executions_sub_agent'
+  ) THEN
+    -- First, clean up any orphaned records (sub_agent_id not in leo_sub_agents)
+    DELETE FROM sub_agent_executions
+    WHERE sub_agent_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM leo_sub_agents WHERE id = sub_agent_executions.sub_agent_id
+    );
+
+    RAISE NOTICE 'Cleaned up orphaned sub_agent_executions records';
+
+    -- Now add the FK constraint
+    ALTER TABLE sub_agent_executions
+      ADD CONSTRAINT fk_sub_agent_executions_sub_agent
+      FOREIGN KEY (sub_agent_id) REFERENCES leo_sub_agents(id) ON DELETE CASCADE;
+
+    RAISE NOTICE 'Added FK constraint fk_sub_agent_executions_sub_agent';
+  ELSE
+    RAISE NOTICE 'FK constraint fk_sub_agent_executions_sub_agent already exists';
+  END IF;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'Could not add FK constraint: %. Consider manual cleanup.', SQLERRM;
+END $$;
+
+COMMIT;
+
+-- Verification
+DO $$
+DECLARE
+  col_type TEXT;
+  has_fk BOOLEAN;
+BEGIN
+  SELECT data_type INTO col_type
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+  AND table_name = 'sub_agent_executions'
+  AND column_name = 'sub_agent_id';
+
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_name = 'sub_agent_executions'
+    AND constraint_name = 'fk_sub_agent_executions_sub_agent'
+  ) INTO has_fk;
+
+  RAISE NOTICE '========================================';
+  RAISE NOTICE 'Migration 028 Verification:';
+  RAISE NOTICE '  sub_agent_id type: %', COALESCE(col_type, 'N/A');
+  RAISE NOTICE '  FK constraint exists: %', has_fk;
+  RAISE NOTICE '========================================';
+END $$;

--- a/docs/reference/handoff-system-guide.md
+++ b/docs/reference/handoff-system-guide.md
@@ -473,7 +473,7 @@ const result = await executor.execute();
 ### DON'T
 
 - Don't bypass prerequisite validation
-- Don't allow scores below 85% to pass
+- Don't allow scores below the SD type threshold to pass (60-90%, typically 85%)
 - Don't skip claim checking
 - Don't create handoffs without gates
 - Don't ignore blocking gate failures

--- a/docs/reference/schema/engineer/tables/product_requirements_v2.md
+++ b/docs/reference/schema/engineer/tables/product_requirements_v2.md
@@ -61,7 +61,7 @@
 | updated_at | `timestamp without time zone` | YES | `CURRENT_TIMESTAMP` | Timestamp of last modification. Auto-updated via trigger on any column change. |
 | created_by | `character varying(100)` | YES | `'PLAN'::character varying` | User ID or agent code that created this PRD. Typically "PLAN" agent or human user ID. |
 | updated_by | `character varying(100)` | YES | - | User ID or agent code that last modified this PRD. Updated with each change. |
-| metadata | `jsonb` | YES | `'{}'::jsonb` | JSONB object: Flexible metadata storage. Custom fields, integrations, temporary data. Format: { key: value } |
+| metadata | `jsonb` | YES | `'{}'::jsonb` | JSONB object: Flexible metadata storage. Custom fields, integrations, sub-agent results. Auto-populated by orchestrate-phase-subagents.js with: `{ "<phase>_sub_agents": { executed_at, all_passed, agents: [{ code, verdict, confidence, executed_at }] } }` |
 | content | `text` | YES | - | Full markdown content of PRD. Can be used for markdown-based PRD generation or legacy compatibility. |
 | evidence_appendix | `text` | YES | - | Supporting evidence and artifacts. Screenshots, logs, research findings. Appended to PRD for reference. |
 | backlog_items | `jsonb` | YES | `'[]'::jsonb` | JSONB array: Linked backlog items from sd_backlog_map. Cached for quick access. Format: [{ id, title, status }] |

--- a/docs/reference/schema/engineer/tables/sub_agent_executions.md
+++ b/docs/reference/schema/engineer/tables/sub_agent_executions.md
@@ -20,7 +20,7 @@
 |--------|------|----------|---------|-------------|
 | id | `uuid` | **NO** | `gen_random_uuid()` | - |
 | prd_id | `text` | **NO** | - | - |
-| sub_agent_id | `uuid` | **NO** | - | - |
+| sub_agent_id | `character varying(50)` | **NO** | - | FK to leo_sub_agents.id (migrated from UUID in migration 028) |
 | status | `text` | **NO** | - | - |
 | results | `jsonb` | YES | `'{}'::jsonb` | - |
 | started_at | `timestamp with time zone` | YES | `now()` | - |

--- a/docs/reference/validation-agent-proactive-gates.md
+++ b/docs/reference/validation-agent-proactive-gates.md
@@ -65,6 +65,7 @@ node scripts/systems-analyst-codebase-audit.js <SD-ID>
 - [ ] **Route Validation**: URLs/paths available and not conflicting
 - [ ] **Component Validation**: Check for existing similar components (reuse > rebuild)
 - [ ] **User Story Validation**: User stories created in PRD and mapped to E2E tests (100% coverage required)
+  - **Exception**: Parent orchestrator SDs (those with child SDs) skip this check—user stories belong to children
 - [ ] **Test Infrastructure Validation**: Existing test patterns identified
 
 **Invocation**:

--- a/docs/reference/validation-enforcement.md
+++ b/docs/reference/validation-enforcement.md
@@ -46,6 +46,39 @@ Each gate uses 2-phase validation:
 
 ---
 
+## SD Type-Aware Thresholds (v1.1.0)
+
+**NEW**: Gate pass thresholds now vary by SD type in addition to risk-based adaptive thresholds.
+
+### SD Type Base Thresholds
+
+| SD Type | Base Threshold | Rationale |
+|---------|----------------|-----------|
+| **feature** | 85% | Full validation (UI, E2E, integration) |
+| **database** | 75% | Schema-focused, may skip UI-dependent E2E |
+| **infrastructure** | 80% | Tooling/protocols, reduced code validation |
+| **security** | 90% | Higher bar for security-critical work |
+| **documentation** | 60% | No code changes, minimal validation |
+| **orchestrator** | 70% | Coordination layer, user stories in children |
+| **refactor** | 80% | Behavior preservation focus |
+| **bugfix** | 80% | Targeted fix validation |
+| **performance** | 85% | Measurable impact verification |
+
+### Orchestrator SD Handling
+
+Parent orchestrator SDs (those with child SDs) have special validation logic:
+- **USER_STORY_EXISTENCE_GATE**: Bypassed (user stories are in child SDs)
+- Gate validates child SD progress and completion instead of parent user stories
+- Detection query: `SELECT COUNT(*) FROM strategic_directives_v2 WHERE parent_sd_id = :sd_id`
+
+### Priority: SD Type vs Risk-Based
+
+1. **SD Type threshold** is checked first (from `getThreshold(sd.sd_type)`)
+2. **Risk-based modifiers** can still apply on top
+3. **Special case minimums** (security, production) take precedence
+
+---
+
 ## Adaptive Thresholds
 
 ### How It Works

--- a/tools/gates/gate2b.ts
+++ b/tools/gates/gate2b.ts
@@ -10,7 +10,7 @@
 
 import { exit } from 'node:process';
 import { getDb } from './lib/db';
-import { scoreGate, formatGateResults, Check } from './lib/score';
+import { scoreGate, formatGateResults, gatePass, getThreshold, Check } from './lib/score';
 import { getRulesForGate, getPRDDetails, storeGateReview } from './lib/rules';
 import { meetsA11yLevel } from './lib/evidence';
 
@@ -33,6 +33,7 @@ import { meetsA11yLevel } from './lib/evidence';
 
   console.log(`Title: ${prdDetails.title}`);
   console.log(`SD: ${prdDetails.sd_id || 'None'}`);
+  console.log(`SD Type: ${prdDetails.sd_type} (threshold: ${getThreshold(prdDetails.sd_type)}%)`);
   console.log('');
 
   const db = await getDb();
@@ -117,18 +118,19 @@ import { meetsA11yLevel } from './lib/evidence';
   // Score the gate
   const { score, results } = await scoreGate(rules, checks);
 
-  // Format and display results
-  console.log(formatGateResults('2B', { score, results }));
+  // Format and display results (with SD type for threshold)
+  console.log(formatGateResults('2B', { score, results }, prdDetails.sd_type));
 
   // Store review in database
   await storeGateReview(prdId, '2B', score, results);
 
-  // Exit with appropriate code
-  if (score < 85) {
-    console.log(`\n❌ Gate 2B failed: ${score}% < 85%`);
+  // Exit with appropriate code (using SD type-aware threshold)
+  const threshold = getThreshold(prdDetails.sd_type);
+  if (!gatePass(score, prdDetails.sd_type)) {
+    console.log(`\n❌ Gate 2B failed: ${score}% < ${threshold}%`);
     exit(1);
   } else {
-    console.log(`\n✅ Gate 2B passed: ${score}%`);
+    console.log(`\n✅ Gate 2B passed: ${score}% >= ${threshold}%`);
     exit(0);
   }
 })().catch((error) => {

--- a/tools/gates/gate2c.ts
+++ b/tools/gates/gate2c.ts
@@ -10,7 +10,7 @@
 
 import { exit } from 'node:process';
 import { getDb } from './lib/db';
-import { scoreGate, formatGateResults, Check } from './lib/score';
+import { scoreGate, formatGateResults, gatePass, getThreshold, Check } from './lib/score';
 import { getRulesForGate, getPRDDetails, storeGateReview } from './lib/rules';
 import { isSecurityScanClean, safeJsonParse } from './lib/evidence';
 
@@ -33,6 +33,7 @@ import { isSecurityScanClean, safeJsonParse } from './lib/evidence';
 
   console.log(`Title: ${prdDetails.title}`);
   console.log(`SD: ${prdDetails.sd_id || 'None'}`);
+  console.log(`SD Type: ${prdDetails.sd_type} (threshold: ${getThreshold(prdDetails.sd_type)}%)`);
   console.log('');
 
   const db = await getDb();
@@ -113,18 +114,19 @@ import { isSecurityScanClean, safeJsonParse } from './lib/evidence';
   // Score the gate
   const { score, results } = await scoreGate(rules, checks);
 
-  // Format and display results
-  console.log(formatGateResults('2C', { score, results }));
+  // Format and display results (with SD type for threshold)
+  console.log(formatGateResults('2C', { score, results }, prdDetails.sd_type));
 
   // Store review in database
   await storeGateReview(prdId, '2C', score, results);
 
-  // Exit with appropriate code
-  if (score < 85) {
-    console.log(`\n❌ Gate 2C failed: ${score}% < 85%`);
+  // Exit with appropriate code (using SD type-aware threshold)
+  const threshold = getThreshold(prdDetails.sd_type);
+  if (!gatePass(score, prdDetails.sd_type)) {
+    console.log(`\n❌ Gate 2C failed: ${score}% < ${threshold}%`);
     exit(1);
   } else {
-    console.log(`\n✅ Gate 2C passed: ${score}%`);
+    console.log(`\n✅ Gate 2C passed: ${score}% >= ${threshold}%`);
     exit(0);
   }
 })().catch((error) => {

--- a/tools/gates/gate2d.ts
+++ b/tools/gates/gate2d.ts
@@ -11,7 +11,7 @@
 
 import { exit } from 'node:process';
 import { getDb } from './lib/db';
-import { scoreGate, formatGateResults, Check } from './lib/score';
+import { scoreGate, formatGateResults, gatePass, getThreshold, Check } from './lib/score';
 import { getRulesForGate, getPRDDetails, storeGateReview } from './lib/rules';
 import { areNFRBudgetsValid, hasAllTestMatrices, safeJsonParse } from './lib/evidence';
 
@@ -34,6 +34,7 @@ import { areNFRBudgetsValid, hasAllTestMatrices, safeJsonParse } from './lib/evi
 
   console.log(`Title: ${prdDetails.title}`);
   console.log(`SD: ${prdDetails.sd_id || 'None'}`);
+  console.log(`SD Type: ${prdDetails.sd_type} (threshold: ${getThreshold(prdDetails.sd_type)}%)`);
   console.log('');
 
   const db = await getDb();
@@ -139,18 +140,19 @@ import { areNFRBudgetsValid, hasAllTestMatrices, safeJsonParse } from './lib/evi
   // Score the gate
   const { score, results } = await scoreGate(rules, checks);
 
-  // Format and display results
-  console.log(formatGateResults('2D', { score, results }));
+  // Format and display results (with SD type for threshold)
+  console.log(formatGateResults('2D', { score, results }, prdDetails.sd_type));
 
   // Store review in database
   await storeGateReview(prdId, '2D', score, results);
 
-  // Exit with appropriate code
-  if (score < 85) {
-    console.log(`\n❌ Gate 2D failed: ${score}% < 85%`);
+  // Exit with appropriate code (using SD type-aware threshold)
+  const threshold = getThreshold(prdDetails.sd_type);
+  if (!gatePass(score, prdDetails.sd_type)) {
+    console.log(`\n❌ Gate 2D failed: ${score}% < ${threshold}%`);
     exit(1);
   } else {
-    console.log(`\n✅ Gate 2D passed: ${score}%`);
+    console.log(`\n✅ Gate 2D passed: ${score}% >= ${threshold}%`);
     exit(0);
   }
 })().catch((error) => {


### PR DESCRIPTION
## Summary

- **Orchestrator bypass**: Parent SDs with children now skip USER_STORY_EXISTENCE_GATE (stories are in child SDs)
- **SD type-aware thresholds**: Gate pass thresholds now vary by SD type (60-90%, typically 85%)
- **PRD metadata auto-population**: Sub-agent results automatically stored in PRD.metadata
- **Schema alignment**: Migration 028 fixes sub_agent_id type mismatch (UUID→VARCHAR)
- **Documentation updates**: 8 docs updated to reflect new threshold behavior

## SD Type Thresholds

| SD Type | Threshold |
|---------|-----------|
| feature | 85% |
| database | 75% |
| infrastructure | 80% |
| security | 90% |
| documentation | 60% |
| orchestrator | 70% |
| refactor/bugfix | 80% |
| performance | 85% |

## Test plan

- [ ] Verify orchestrator SD can pass USER_STORY gate (bypass works)
- [ ] Verify documentation SD passes at 60% threshold
- [ ] Run migration 028 to align sub_agent_id types
- [ ] Confirm PRD metadata populated after sub-agent orchestration

🤖 Generated with [Claude Code](https://claude.com/claude-code)