### PR TITLE
feat(LEO-v4.4.0): Add human-verifiable outcome validation for SDs

### DIFF
--- a/database/migrations/20260104_human_verifiable_outcome_validation.sql
+++ b/database/migrations/20260104_human_verifiable_outcome_validation.sql
@@ -1,0 +1,407 @@
+-- ============================================================================
+-- Migration: Human-Verifiable Outcome Validation
+-- Version: LEO Protocol v4.4.0
+-- Date: 2026-01-04
+-- Purpose: Add intelligent SD-type-aware human verification requirements
+--
+-- Problem Solved:
+--   "The current plan optimizes for completing SDs rather than delivering
+--    working software. Every SD should have a smoke test that a non-technical
+--    person could run to verify it works."
+--
+-- Solution:
+--   1. Add columns to sd_type_validation_profiles for human verification config
+--   2. Only require human verification for SD types that produce user-visible output
+--   3. Integrate with existing UAT Agent + LLM UX Oracle infrastructure
+-- ============================================================================
+
+BEGIN;
+
+-- ============================================================================
+-- PART 1: Extend sd_type_validation_profiles with human verification columns
+-- ============================================================================
+
+-- Add human verification requirement column
+ALTER TABLE sd_type_validation_profiles
+ADD COLUMN IF NOT EXISTS requires_human_verifiable_outcome BOOLEAN DEFAULT false;
+
+COMMENT ON COLUMN sd_type_validation_profiles.requires_human_verifiable_outcome IS
+  'If true, SD completion requires evidence that a human (or LLM acting as human) verified the outcome works. For feature SDs with UI, this triggers UAT Agent + LLM UX Oracle validation.';
+
+-- Add human verification type enum
+ALTER TABLE sd_type_validation_profiles
+ADD COLUMN IF NOT EXISTS human_verification_type TEXT DEFAULT 'none';
+
+COMMENT ON COLUMN sd_type_validation_profiles.human_verification_type IS
+  'Type of human verification required: ui_smoke_test (Playwright + LLM UX), api_test (endpoint verification), cli_verification (script output check), documentation_review (manual doc check), none (no human verification)';
+
+-- Add constraint for valid verification types
+ALTER TABLE sd_type_validation_profiles
+ADD CONSTRAINT valid_human_verification_type
+CHECK (human_verification_type IN ('ui_smoke_test', 'api_test', 'cli_verification', 'documentation_review', 'none'));
+
+-- Add smoke test template (JSONB for structured steps)
+ALTER TABLE sd_type_validation_profiles
+ADD COLUMN IF NOT EXISTS smoke_test_template JSONB DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN sd_type_validation_profiles.smoke_test_template IS
+  'Template for smoke test steps. Array of {step_number, instruction_template, expected_outcome_template}. Merged with SD-specific context at runtime.';
+
+-- Add LLM UX Oracle requirements
+ALTER TABLE sd_type_validation_profiles
+ADD COLUMN IF NOT EXISTS requires_llm_ux_validation BOOLEAN DEFAULT false;
+
+COMMENT ON COLUMN sd_type_validation_profiles.requires_llm_ux_validation IS
+  'If true, LLM UX Oracle (GPT-5.2) must evaluate affected pages with minimum score threshold.';
+
+ALTER TABLE sd_type_validation_profiles
+ADD COLUMN IF NOT EXISTS llm_ux_min_score INTEGER DEFAULT 50;
+
+COMMENT ON COLUMN sd_type_validation_profiles.llm_ux_min_score IS
+  'Minimum LLM UX Oracle score (0-100) required for SD completion. Default 50 (standard stringency).';
+
+ALTER TABLE sd_type_validation_profiles
+ADD COLUMN IF NOT EXISTS llm_ux_required_lenses TEXT[] DEFAULT ARRAY['first-time-user'];
+
+COMMENT ON COLUMN sd_type_validation_profiles.llm_ux_required_lenses IS
+  'Which LLM UX Oracle lenses must pass: first-time-user, accessibility, mobile-user, error-recovery, cognitive-load';
+
+-- Add UAT Agent requirements
+ALTER TABLE sd_type_validation_profiles
+ADD COLUMN IF NOT EXISTS requires_uat_execution BOOLEAN DEFAULT false;
+
+COMMENT ON COLUMN sd_type_validation_profiles.requires_uat_execution IS
+  'If true, UAT Agent must execute smoke test steps via Playwright MCP and capture evidence.';
+
+-- ============================================================================
+-- PART 2: Update existing SD type profiles with intelligent defaults
+-- ============================================================================
+
+-- Feature SDs: Full human verification (UI smoke test + LLM UX Oracle)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = true,
+  human_verification_type = 'ui_smoke_test',
+  requires_llm_ux_validation = true,
+  llm_ux_min_score = 50,
+  llm_ux_required_lenses = ARRAY['first-time-user', 'error-recovery'],
+  requires_uat_execution = true,
+  smoke_test_template = '[
+    {"step_number": 1, "instruction_template": "Navigate to the feature URL: {feature_url}", "expected_outcome_template": "Page loads without errors"},
+    {"step_number": 2, "instruction_template": "Verify the main UI elements are visible", "expected_outcome_template": "All primary components render correctly"},
+    {"step_number": 3, "instruction_template": "Perform the primary user action: {primary_action}", "expected_outcome_template": "Action completes successfully with visible feedback"},
+    {"step_number": 4, "instruction_template": "Check for any console errors", "expected_outcome_template": "No JavaScript errors in console"}
+  ]'::jsonb
+WHERE sd_type = 'feature';
+
+-- Security SDs: API-level verification (auth flows, permission checks)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = true,
+  human_verification_type = 'api_test',
+  requires_llm_ux_validation = false,  -- Security is about correctness, not UX
+  requires_uat_execution = true,
+  smoke_test_template = '[
+    {"step_number": 1, "instruction_template": "Attempt unauthorized access to protected resource", "expected_outcome_template": "Request is rejected with 401/403"},
+    {"step_number": 2, "instruction_template": "Authenticate with valid credentials", "expected_outcome_template": "Authentication succeeds, token/session created"},
+    {"step_number": 3, "instruction_template": "Access protected resource with auth", "expected_outcome_template": "Resource is accessible"},
+    {"step_number": 4, "instruction_template": "Verify RLS policies via direct query", "expected_outcome_template": "Only authorized rows returned"}
+  ]'::jsonb
+WHERE sd_type = 'security';
+
+-- Database SDs: API-level verification (schema changes, data integrity)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = true,
+  human_verification_type = 'api_test',
+  requires_llm_ux_validation = false,
+  requires_uat_execution = false,  -- No UI to test
+  smoke_test_template = '[
+    {"step_number": 1, "instruction_template": "Verify migration applied successfully", "expected_outcome_template": "No migration errors, schema matches expected"},
+    {"step_number": 2, "instruction_template": "Insert test data via API", "expected_outcome_template": "Data inserted correctly with constraints enforced"},
+    {"step_number": 3, "instruction_template": "Query data via application", "expected_outcome_template": "Data retrieved correctly, RLS applied"}
+  ]'::jsonb
+WHERE sd_type = 'database';
+
+-- Infrastructure SDs: CLI verification (scripts, pipelines)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = false,  -- Internal tooling, not user-facing
+  human_verification_type = 'cli_verification',
+  requires_llm_ux_validation = false,
+  requires_uat_execution = false,
+  smoke_test_template = '[
+    {"step_number": 1, "instruction_template": "Run the script/pipeline", "expected_outcome_template": "Exits with code 0, no errors"},
+    {"step_number": 2, "instruction_template": "Verify expected output/artifacts", "expected_outcome_template": "Output matches expected format"}
+  ]'::jsonb
+WHERE sd_type = 'infrastructure';
+
+-- Documentation SDs: No human verification (docs review is manual)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = false,
+  human_verification_type = 'none',
+  requires_llm_ux_validation = false,
+  requires_uat_execution = false,
+  smoke_test_template = '[]'::jsonb
+WHERE sd_type = 'documentation';
+
+-- Bugfix SDs: Same as feature (user-visible fix)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = true,
+  human_verification_type = 'ui_smoke_test',
+  requires_llm_ux_validation = false,  -- Focus on fix correctness, not UX redesign
+  requires_uat_execution = true,
+  smoke_test_template = '[
+    {"step_number": 1, "instruction_template": "Reproduce the original bug scenario", "expected_outcome_template": "Bug no longer occurs"},
+    {"step_number": 2, "instruction_template": "Verify fix does not introduce regression", "expected_outcome_template": "Related functionality still works"},
+    {"step_number": 3, "instruction_template": "Check console for errors", "expected_outcome_template": "No new errors introduced"}
+  ]'::jsonb
+WHERE sd_type = 'bugfix';
+
+-- Refactor SDs: No human verification (behavior unchanged by definition)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = false,
+  human_verification_type = 'none',
+  requires_llm_ux_validation = false,
+  requires_uat_execution = false,
+  smoke_test_template = '[]'::jsonb
+WHERE sd_type = 'refactor';
+
+-- Performance SDs: API-level verification (latency, throughput)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = true,
+  human_verification_type = 'api_test',
+  requires_llm_ux_validation = false,
+  requires_uat_execution = false,
+  smoke_test_template = '[
+    {"step_number": 1, "instruction_template": "Run performance benchmark", "expected_outcome_template": "Latency/throughput meets target metrics"},
+    {"step_number": 2, "instruction_template": "Compare before/after metrics", "expected_outcome_template": "Measurable improvement over baseline"}
+  ]'::jsonb
+WHERE sd_type = 'performance';
+
+-- Orchestrator SDs: No direct verification (children handle it)
+UPDATE sd_type_validation_profiles
+SET
+  requires_human_verifiable_outcome = false,
+  human_verification_type = 'none',
+  requires_llm_ux_validation = false,
+  requires_uat_execution = false,
+  smoke_test_template = '[]'::jsonb
+WHERE sd_type = 'orchestrator';
+
+-- ============================================================================
+-- PART 3: Add smoke_test_steps column to strategic_directives_v2
+-- ============================================================================
+
+ALTER TABLE strategic_directives_v2
+ADD COLUMN IF NOT EXISTS smoke_test_steps JSONB DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN strategic_directives_v2.smoke_test_steps IS
+  'SD-specific smoke test steps. Array of {step_number, instruction, expected_outcome, evidence_url}. Populated from template + SD context. Required for feature SDs.';
+
+ALTER TABLE strategic_directives_v2
+ADD COLUMN IF NOT EXISTS human_verification_status TEXT DEFAULT 'not_required';
+
+COMMENT ON COLUMN strategic_directives_v2.human_verification_status IS
+  'Status of human-verifiable outcome validation: not_required, pending, in_progress, passed, failed';
+
+ALTER TABLE strategic_directives_v2
+ADD CONSTRAINT valid_human_verification_status
+CHECK (human_verification_status IN ('not_required', 'pending', 'in_progress', 'passed', 'failed'));
+
+ALTER TABLE strategic_directives_v2
+ADD COLUMN IF NOT EXISTS llm_ux_score INTEGER;
+
+COMMENT ON COLUMN strategic_directives_v2.llm_ux_score IS
+  'LLM UX Oracle average score for this SD (0-100). NULL if not evaluated.';
+
+-- ============================================================================
+-- PART 4: Create view for human verification requirements
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_sd_human_verification_requirements AS
+SELECT
+  sd.id as sd_id,
+  sd.sd_key,
+  sd.title,
+  sd.sd_type,
+  sd.status,
+  sd.human_verification_status,
+  sd.smoke_test_steps,
+  sd.llm_ux_score,
+
+  -- From validation profile
+  vp.requires_human_verifiable_outcome,
+  vp.human_verification_type,
+  vp.requires_llm_ux_validation,
+  vp.llm_ux_min_score,
+  vp.llm_ux_required_lenses,
+  vp.requires_uat_execution,
+  vp.smoke_test_template,
+
+  -- Computed: Is verification required and pending?
+  CASE
+    WHEN vp.requires_human_verifiable_outcome = true
+      AND sd.human_verification_status IN ('pending', 'in_progress', 'failed')
+    THEN true
+    ELSE false
+  END as verification_blocking,
+
+  -- Computed: Did LLM UX pass threshold?
+  CASE
+    WHEN vp.requires_llm_ux_validation = true
+      AND (sd.llm_ux_score IS NULL OR sd.llm_ux_score < vp.llm_ux_min_score)
+    THEN false
+    WHEN vp.requires_llm_ux_validation = true
+      AND sd.llm_ux_score >= vp.llm_ux_min_score
+    THEN true
+    ELSE NULL  -- Not applicable
+  END as llm_ux_passed
+
+FROM strategic_directives_v2 sd
+LEFT JOIN sd_type_validation_profiles vp ON vp.sd_type = COALESCE(sd.sd_type, 'feature');
+
+COMMENT ON VIEW v_sd_human_verification_requirements IS
+  'View combining SD data with human verification requirements from sd_type_validation_profiles. Used by handoff validators to determine if human verification is needed.';
+
+-- ============================================================================
+-- PART 5: Create function to check human verification gate
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION check_human_verification_gate(p_sd_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_result JSONB;
+  v_sd RECORD;
+  v_profile RECORD;
+BEGIN
+  -- Get SD and its validation profile
+  SELECT
+    sd.*,
+    vp.requires_human_verifiable_outcome,
+    vp.human_verification_type,
+    vp.requires_llm_ux_validation,
+    vp.llm_ux_min_score,
+    vp.requires_uat_execution
+  INTO v_sd
+  FROM strategic_directives_v2 sd
+  LEFT JOIN sd_type_validation_profiles vp ON vp.sd_type = COALESCE(sd.sd_type, 'feature')
+  WHERE sd.id = p_sd_id;
+
+  IF v_sd IS NULL THEN
+    RETURN jsonb_build_object(
+      'passed', false,
+      'error', 'SD not found',
+      'sd_id', p_sd_id
+    );
+  END IF;
+
+  -- If no human verification required, auto-pass
+  IF v_sd.requires_human_verifiable_outcome = false THEN
+    RETURN jsonb_build_object(
+      'passed', true,
+      'reason', 'Human verification not required for sd_type: ' || COALESCE(v_sd.sd_type, 'unknown'),
+      'sd_id', p_sd_id,
+      'sd_type', v_sd.sd_type
+    );
+  END IF;
+
+  -- Check human verification status
+  IF v_sd.human_verification_status = 'passed' THEN
+    v_result := jsonb_build_object(
+      'passed', true,
+      'reason', 'Human verification completed successfully',
+      'verification_type', v_sd.human_verification_type
+    );
+  ELSIF v_sd.human_verification_status = 'failed' THEN
+    v_result := jsonb_build_object(
+      'passed', false,
+      'reason', 'Human verification failed - smoke test did not pass',
+      'verification_type', v_sd.human_verification_type,
+      'action_required', 'Fix issues and re-run UAT Agent'
+    );
+  ELSIF v_sd.human_verification_status IN ('pending', 'in_progress') THEN
+    v_result := jsonb_build_object(
+      'passed', false,
+      'reason', 'Human verification not yet completed',
+      'verification_type', v_sd.human_verification_type,
+      'status', v_sd.human_verification_status,
+      'action_required', 'Run UAT Agent to execute smoke tests'
+    );
+  ELSE
+    -- Status is 'not_required' but profile says it IS required - inconsistency
+    v_result := jsonb_build_object(
+      'passed', false,
+      'reason', 'Human verification required but status is not_required - need to initialize',
+      'action_required', 'Initialize smoke test steps and run UAT Agent'
+    );
+  END IF;
+
+  -- Add LLM UX check if required
+  IF v_sd.requires_llm_ux_validation = true THEN
+    IF v_sd.llm_ux_score IS NULL THEN
+      v_result := v_result || jsonb_build_object(
+        'llm_ux_passed', false,
+        'llm_ux_reason', 'LLM UX Oracle evaluation not yet performed'
+      );
+      v_result := jsonb_set(v_result, '{passed}', 'false'::jsonb);
+    ELSIF v_sd.llm_ux_score < v_sd.llm_ux_min_score THEN
+      v_result := v_result || jsonb_build_object(
+        'llm_ux_passed', false,
+        'llm_ux_score', v_sd.llm_ux_score,
+        'llm_ux_min_score', v_sd.llm_ux_min_score,
+        'llm_ux_reason', 'LLM UX score below threshold'
+      );
+      v_result := jsonb_set(v_result, '{passed}', 'false'::jsonb);
+    ELSE
+      v_result := v_result || jsonb_build_object(
+        'llm_ux_passed', true,
+        'llm_ux_score', v_sd.llm_ux_score
+      );
+    END IF;
+  END IF;
+
+  -- Add metadata
+  v_result := v_result || jsonb_build_object(
+    'sd_id', p_sd_id,
+    'sd_type', v_sd.sd_type,
+    'requires_uat_execution', v_sd.requires_uat_execution,
+    'smoke_test_steps_count', jsonb_array_length(COALESCE(v_sd.smoke_test_steps, '[]'::jsonb))
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION check_human_verification_gate(UUID) IS
+  'Checks if an SD passes the human verification gate. Returns {passed: boolean, reason: string, ...}. Called by handoff validators.';
+
+-- Grant execute to authenticated users
+GRANT EXECUTE ON FUNCTION check_human_verification_gate(UUID) TO authenticated;
+
+COMMIT;
+
+-- ============================================================================
+-- ROLLBACK (if needed)
+-- ============================================================================
+-- BEGIN;
+-- ALTER TABLE sd_type_validation_profiles DROP COLUMN IF EXISTS requires_human_verifiable_outcome;
+-- ALTER TABLE sd_type_validation_profiles DROP COLUMN IF EXISTS human_verification_type;
+-- ALTER TABLE sd_type_validation_profiles DROP COLUMN IF EXISTS smoke_test_template;
+-- ALTER TABLE sd_type_validation_profiles DROP COLUMN IF EXISTS requires_llm_ux_validation;
+-- ALTER TABLE sd_type_validation_profiles DROP COLUMN IF EXISTS llm_ux_min_score;
+-- ALTER TABLE sd_type_validation_profiles DROP COLUMN IF EXISTS llm_ux_required_lenses;
+-- ALTER TABLE sd_type_validation_profiles DROP COLUMN IF EXISTS requires_uat_execution;
+-- ALTER TABLE strategic_directives_v2 DROP COLUMN IF EXISTS smoke_test_steps;
+-- ALTER TABLE strategic_directives_v2 DROP COLUMN IF EXISTS human_verification_status;
+-- ALTER TABLE strategic_directives_v2 DROP COLUMN IF EXISTS llm_ux_score;
+-- DROP VIEW IF EXISTS v_sd_human_verification_requirements;
+-- DROP FUNCTION IF EXISTS check_human_verification_gate(UUID);
+-- COMMIT;

--- a/lib/utils/sd-type-validation.js
+++ b/lib/utils/sd-type-validation.js
@@ -147,10 +147,85 @@ export function requiresCodeValidation(sd) {
  * Get the validation requirements for an SD based on its type
  *
  * @param {Object} sd - Strategic Directive object
+ * @param {Object} validationProfile - Optional pre-loaded validation profile from database
  * @returns {Object} Validation requirements
  */
-export function getValidationRequirements(sd) {
+export function getValidationRequirements(sd, validationProfile = null) {
   const skipCode = shouldSkipCodeValidation(sd);
+  const sdType = sd.sd_type || 'feature';
+
+  // Human verification requirements by SD type
+  // These align with sd_type_validation_profiles table
+  const humanVerificationConfig = {
+    feature: {
+      requiresHumanVerifiableOutcome: true,
+      humanVerificationType: 'ui_smoke_test',
+      requiresLLMUXValidation: true,
+      llmUxMinScore: 50,
+      llmUxRequiredLenses: ['first-time-user', 'error-recovery'],
+      requiresUATExecution: true
+    },
+    security: {
+      requiresHumanVerifiableOutcome: true,
+      humanVerificationType: 'api_test',
+      requiresLLMUXValidation: false,
+      requiresUATExecution: true
+    },
+    database: {
+      requiresHumanVerifiableOutcome: true,
+      humanVerificationType: 'api_test',
+      requiresLLMUXValidation: false,
+      requiresUATExecution: false
+    },
+    bugfix: {
+      requiresHumanVerifiableOutcome: true,
+      humanVerificationType: 'ui_smoke_test',
+      requiresLLMUXValidation: false,
+      requiresUATExecution: true
+    },
+    performance: {
+      requiresHumanVerifiableOutcome: true,
+      humanVerificationType: 'api_test',
+      requiresLLMUXValidation: false,
+      requiresUATExecution: false
+    },
+    infrastructure: {
+      requiresHumanVerifiableOutcome: false,
+      humanVerificationType: 'cli_verification',
+      requiresLLMUXValidation: false,
+      requiresUATExecution: false
+    },
+    documentation: {
+      requiresHumanVerifiableOutcome: false,
+      humanVerificationType: 'none',
+      requiresLLMUXValidation: false,
+      requiresUATExecution: false
+    },
+    refactor: {
+      requiresHumanVerifiableOutcome: false,
+      humanVerificationType: 'none',
+      requiresLLMUXValidation: false,
+      requiresUATExecution: false
+    },
+    orchestrator: {
+      requiresHumanVerifiableOutcome: false,
+      humanVerificationType: 'none',
+      requiresLLMUXValidation: false,
+      requiresUATExecution: false
+    }
+  };
+
+  // Use validation profile from database if provided, otherwise use defaults
+  const hvConfig = validationProfile || humanVerificationConfig[sdType] || humanVerificationConfig.feature;
+
+  // Check if SD has UI components (for feature SDs)
+  const hasUIComponents = sdType === 'feature' && (
+    (sd.scope || '').toLowerCase().includes('ui') ||
+    (sd.scope || '').toLowerCase().includes('component') ||
+    (sd.scope || '').toLowerCase().includes('page') ||
+    (sd.scope || '').toLowerCase().includes('dashboard') ||
+    (sd.scope || '').toLowerCase().includes('form')
+  );
 
   return {
     // Always required
@@ -171,12 +246,28 @@ export function getValidationRequirements(sd) {
     requiresDesign: sd.sd_type === 'feature' && ((sd.scope || '').toLowerCase().includes('ui') ||
                                                   (sd.scope || '').toLowerCase().includes('component')),
 
+    // NEW: Human-verifiable outcome requirements (LEO v4.4.0)
+    requiresHumanVerifiableOutcome: hvConfig.requiresHumanVerifiableOutcome ?? false,
+    humanVerificationType: hvConfig.humanVerificationType ?? 'none',
+    requiresLLMUXValidation: hvConfig.requiresLLMUXValidation ?? false,
+    llmUxMinScore: hvConfig.llmUxMinScore ?? 50,
+    llmUxRequiredLenses: hvConfig.llmUxRequiredLenses ?? ['first-time-user'],
+    requiresUATExecution: hvConfig.requiresUATExecution ?? false,
+
+    // Computed: Does this SD have visible UI to verify?
+    hasUIComponents,
+
     // Metadata
-    sd_type: sd.sd_type || 'feature',
+    sd_type: sdType,
     skipCodeValidation: skipCode,
     reason: skipCode
       ? `SD type '${sd.sd_type || 'detected as documentation'}' does not require code validation`
-      : `SD type '${sd.sd_type || 'feature'}' requires full code validation`
+      : `SD type '${sd.sd_type || 'feature'}' requires full code validation`,
+
+    // Human verification reason
+    humanVerificationReason: hvConfig.requiresHumanVerifiableOutcome
+      ? `SD type '${sdType}' requires ${hvConfig.humanVerificationType} verification`
+      : `SD type '${sdType}' does not require human verification`
   };
 }
 

--- a/scripts/modules/ai-quality-evaluator.js
+++ b/scripts/modules/ai-quality-evaluator.js
@@ -512,7 +512,15 @@ NO additional text, explanations, or markdown - ONLY the JSON object.`;
 - Balance user value with technical quality
 - Require clear end-user benefit (not generic "improve system")
 - Strict on UI/UX requirements and acceptance criteria
-- Apply standard LEO Protocol quality standards`,
+- Apply standard LEO Protocol quality standards
+
+**LEO v4.4.0 - Human-Verifiable Outcome Requirement:**
+- Feature SDs MUST include criteria that a non-technical person could verify
+- Look for "smoke test" style outcomes: Navigate to X, click Y, see Z
+- Penalize if ALL criteria are technical-only (API returns 200, data in database)
+- Good: "User sees success toast within 2 seconds of clicking Save"
+- Bad: "Data is correctly persisted to venture_artifacts table"
+- If SD lacks human-verifiable outcomes, cap score at 70% for this criterion`,
 
       database: `- Prioritize schema design quality and data integrity
 - Emphasize migration safety, rollback plans, and RLS policies

--- a/scripts/modules/handoff/executors/ExecToPlanExecutor.js
+++ b/scripts/modules/handoff/executors/ExecToPlanExecutor.js
@@ -292,6 +292,74 @@ export class ExecToPlanExecutor extends BaseExecutor {
       required: true
     });
 
+    // LEO v4.4.0: Human Verification Gate
+    // Validates that feature SDs have human-verifiable outcomes (smoke tests, LLM UX)
+    gates.push({
+      name: 'HUMAN_VERIFICATION_GATE',
+      validator: async (ctx) => {
+        console.log('\n👤 Human Verification Gate (LEO v4.4.0)');
+        console.log('-'.repeat(50));
+
+        // Load the human verification validator dynamically
+        const { validateHumanVerification } = await import('../../human-verification-validator.js');
+
+        const result = await validateHumanVerification(ctx.sd?.id || ctx.sdId);
+
+        if (result.skipped) {
+          console.log(`   ℹ️  Human verification skipped: ${result.reason}`);
+          return {
+            passed: true,
+            score: 100,
+            max_score: 100,
+            issues: [],
+            warnings: [`Human verification skipped for sd_type: ${result.sdType || 'unknown'}`],
+            details: result
+          };
+        }
+
+        if (result.passed) {
+          console.log('   ✅ Human verification passed');
+          if (result.llmUxScore) {
+            console.log(`      LLM UX Score: ${result.llmUxScore}/100`);
+          }
+          if (result.smokeTestStepsCount) {
+            console.log(`      Smoke test steps: ${result.smokeTestStepsCount}`);
+          }
+          return {
+            passed: true,
+            score: 100,
+            max_score: 100,
+            issues: [],
+            warnings: [],
+            details: result
+          };
+        }
+
+        // Failed - provide detailed issues
+        console.log(`   ❌ Human verification failed: ${result.reason}`);
+        const issues = result.issues?.map(i => i.message || i) || [result.reason];
+        const actionRequired = result.issues?.find(i => i.actionRequired)?.actionRequired;
+
+        if (actionRequired) {
+          console.log(`\n   ACTION REQUIRED: ${actionRequired}`);
+        }
+
+        return {
+          passed: false,
+          score: 0,
+          max_score: 100,
+          issues,
+          warnings: [],
+          details: result,
+          remediation: actionRequired
+        };
+      },
+      // Required for feature SDs only - determined dynamically
+      required: false,
+      // Soft gate: logs warning but doesn't block (Phase 1 - Advisory Mode)
+      advisory: true
+    });
+
     return gates;
   }
 

--- a/scripts/modules/handoff/executors/LeadToPlanExecutor.js
+++ b/scripts/modules/handoff/executors/LeadToPlanExecutor.js
@@ -78,6 +78,20 @@ export class LeadToPlanExecutor extends BaseExecutor {
       remediation: 'Address stale critical baseline issues or assign ownership via: npm run baseline:assign <issue-key> <SD-ID>'
     });
 
+    // LEO v4.4.0: Smoke Test Specification Gate
+    // "Describe the 30-second demo that proves this SD delivered value."
+    // If you can't answer this at LEAD, the SD is too vague.
+    gates.push({
+      name: 'SMOKE_TEST_SPECIFICATION',
+      validator: async (ctx) => {
+        console.log('\n👤 GATE: Smoke Test Specification (LEO v4.4.0)');
+        console.log('-'.repeat(50));
+        return this._validateSmokeTestSpecification(ctx.sd);
+      },
+      required: true,
+      remediation: 'Add smoke_test_steps array with 3-5 user-observable verification steps. Example: [{step_number: 1, instruction: "Navigate to /dashboard", expected_outcome: "Dashboard loads with venture list visible"}]'
+    });
+
     return gates;
   }
 
@@ -901,6 +915,127 @@ export class LeadToPlanExecutor extends BaseExecutor {
       console.log('   PRD script can be generated manually:');
       console.log(`   npm run prd:new ${sdId}`);
     }
+  }
+
+  /**
+   * LEO v4.4.0: Validate smoke test specification
+   * "Describe the 30-second demo that proves this SD delivered value."
+   *
+   * BLOCKS feature SDs without smoke_test_steps
+   * SKIPS for infrastructure/documentation/orchestrator SDs
+   *
+   * @param {Object} sd - Strategic Directive
+   * @returns {Object} Validation result
+   */
+  async _validateSmokeTestSpecification(sd) {
+    const sdType = (sd.sd_type || 'feature').toLowerCase();
+
+    // SD types that don't require smoke test specification
+    const EXEMPT_SD_TYPES = ['documentation', 'infrastructure', 'refactor', 'orchestrator'];
+
+    if (EXEMPT_SD_TYPES.includes(sdType)) {
+      console.log(`   ℹ️  SD Type: ${sdType} - smoke test specification not required`);
+      return {
+        pass: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings: [`Smoke test skipped for ${sdType} SD type`],
+        details: { skipped: true, reason: `${sdType} SD type exempt` }
+      };
+    }
+
+    console.log(`   SD Type: ${sdType} - smoke test specification REQUIRED`);
+
+    // Check if smoke_test_steps exists and is valid
+    const smokeTestSteps = sd.smoke_test_steps || [];
+    const isArray = Array.isArray(smokeTestSteps);
+    const stepCount = isArray ? smokeTestSteps.length : 0;
+
+    console.log(`   Smoke test steps: ${stepCount} defined`);
+
+    if (stepCount === 0) {
+      console.log('   ❌ BLOCKING: No smoke test steps defined');
+      console.log('\n   LEAD Question 9: "Describe the 30-second demo that proves this SD delivered value."');
+      console.log('   If you cannot answer this question, the SD is too vague.\n');
+      console.log('   Required: Add smoke_test_steps array with 3-5 user-observable steps');
+      console.log('   Example:');
+      console.log('   [');
+      console.log('     { "step_number": 1, "instruction": "Navigate to /dashboard", "expected_outcome": "Dashboard loads with venture list" },');
+      console.log('     { "step_number": 2, "instruction": "Click Create Venture button", "expected_outcome": "New venture form appears" },');
+      console.log('     { "step_number": 3, "instruction": "Fill form and click Save", "expected_outcome": "Success toast + venture in list" }');
+      console.log('   ]');
+
+      return {
+        pass: false,
+        score: 0,
+        max_score: 100,
+        issues: [
+          'BLOCKING: Feature SD requires smoke_test_steps for LEAD approval',
+          'Answer LEAD Q9: "Describe the 30-second demo that proves this SD delivered value"'
+        ],
+        warnings: [],
+        remediation: 'Add smoke_test_steps JSONB array with 3-5 user-observable verification steps'
+      };
+    }
+
+    // Validate step quality
+    const issues = [];
+    const warnings = [];
+
+    if (stepCount < 3) {
+      warnings.push(`Only ${stepCount} smoke test steps - recommend 3-5 for comprehensive verification`);
+    }
+
+    // Check each step has required fields
+    let validSteps = 0;
+    for (const step of smokeTestSteps) {
+      const hasInstruction = step.instruction || step.instruction_template;
+      const hasOutcome = step.expected_outcome || step.expected_outcome_template;
+
+      if (hasInstruction && hasOutcome) {
+        validSteps++;
+        console.log(`   ✅ Step ${step.step_number || validSteps}: ${(hasInstruction).substring(0, 50)}...`);
+      } else {
+        warnings.push(`Step ${step.step_number || '?'} missing instruction or expected_outcome`);
+      }
+    }
+
+    if (validSteps === 0) {
+      issues.push('No valid smoke test steps (each must have instruction and expected_outcome)');
+    }
+
+    // Use GPT-5 Mini to validate smoke test is concrete (if available)
+    let aiValidation = null;
+    try {
+      const { validateSmokeTestQuality } = await import('../../human-verification-validator.js').catch(() => ({}));
+      if (validateSmokeTestQuality) {
+        aiValidation = await validateSmokeTestQuality(smokeTestSteps, sd);
+        if (aiValidation && !aiValidation.isConcreteEnough) {
+          warnings.push(`AI review: ${aiValidation.feedback || 'Smoke test steps may be too vague'}`);
+        }
+      }
+    } catch {
+      // AI validation optional - continue without it
+    }
+
+    const passed = issues.length === 0;
+    const score = passed ? (warnings.length > 0 ? 85 : 100) : 0;
+
+    console.log(`   Result: ${passed ? '✅ PASS' : '❌ FAIL'} (${validSteps}/${stepCount} valid steps)`);
+
+    return {
+      pass: passed,
+      score,
+      max_score: 100,
+      issues,
+      warnings,
+      details: {
+        stepCount,
+        validSteps,
+        aiValidation: aiValidation?.isConcreteEnough ?? null
+      }
+    };
   }
 
   getRemediation(_gateName) {

--- a/scripts/modules/human-verification-validator.js
+++ b/scripts/modules/human-verification-validator.js
@@ -1,0 +1,530 @@
+/**
+ * Human Verification Validator
+ * LEO Protocol v4.4.0 - Human-Verifiable Outcome Validation
+ *
+ * Purpose: Validates that SDs produce human-verifiable outcomes based on SD type.
+ * Integrates with:
+ *   - UAT Agent (Playwright MCP execution)
+ *   - LLM UX Oracle (GPT-5.2 evaluation)
+ *   - sd_type_validation_profiles (database configuration)
+ *
+ * Philosophy:
+ *   "Every SD should have a smoke test that a non-technical person could run
+ *    to verify it works. The current plan optimizes for completing SDs rather
+ *    than delivering working software."
+ *
+ * @module human-verification-validator
+ * @version 1.0.0
+ * @created 2026-01-04
+ */
+
+import { createSupabaseServiceClient } from '../lib/supabase-connection.js';
+import { getValidationRequirements } from '../../lib/utils/sd-type-validation.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// Supabase client - initialized lazily
+let supabase = null;
+
+/**
+ * Human Verification Validator
+ */
+export class HumanVerificationValidator {
+  constructor() {
+    this.DEBUG = process.env.HUMAN_VERIFICATION_DEBUG === 'true';
+  }
+
+  /**
+   * Initialize Supabase client
+   */
+  async initSupabase() {
+    if (!supabase) {
+      supabase = await createSupabaseServiceClient('engineer', { verbose: false });
+    }
+    return supabase;
+  }
+
+  /**
+   * Main validation entry point
+   * Called by handoff validators to check if SD passes human verification gate
+   *
+   * @param {string} sdId - Strategic Directive ID
+   * @returns {Promise<Object>} Validation result
+   */
+  async validate(sdId) {
+    await this.initSupabase();
+
+    const logPrefix = `[HumanVerify:${sdId.substring(0, 8)}]`;
+    if (this.DEBUG) console.log(`${logPrefix} Starting human verification validation...`);
+
+    try {
+      // Step 1: Load SD and validation profile
+      const { sd, validationProfile, error } = await this.loadSDWithProfile(sdId);
+      if (error) {
+        return this.createResult(false, `Failed to load SD: ${error}`, { sdId });
+      }
+
+      // Step 2: Get validation requirements
+      const requirements = getValidationRequirements(sd, validationProfile);
+
+      if (this.DEBUG) {
+        console.log(`${logPrefix} SD Type: ${sd.sd_type}`);
+        console.log(`${logPrefix} Requires Human Verification: ${requirements.requiresHumanVerifiableOutcome}`);
+        console.log(`${logPrefix} Verification Type: ${requirements.humanVerificationType}`);
+      }
+
+      // Step 3: If no human verification required, auto-pass
+      if (!requirements.requiresHumanVerifiableOutcome) {
+        return this.createResult(true, requirements.humanVerificationReason, {
+          sdId,
+          sdType: sd.sd_type,
+          skipped: true
+        });
+      }
+
+      // Step 4: Check current verification status
+      const statusCheck = await this.checkVerificationStatus(sd, requirements);
+      if (!statusCheck.shouldContinue) {
+        return statusCheck.result;
+      }
+
+      // Step 5: Run type-specific verification
+      let verificationResult;
+      switch (requirements.humanVerificationType) {
+        case 'ui_smoke_test':
+          verificationResult = await this.validateUISmokeTest(sd, requirements);
+          break;
+        case 'api_test':
+          verificationResult = await this.validateAPITest(sd, requirements);
+          break;
+        case 'cli_verification':
+          verificationResult = await this.validateCLI(sd, requirements);
+          break;
+        default:
+          verificationResult = this.createResult(true, 'No specific verification required', { skipped: true });
+      }
+
+      // Step 6: Update SD status based on result
+      await this.updateVerificationStatus(sdId, verificationResult.passed ? 'passed' : 'failed');
+
+      return verificationResult;
+
+    } catch (error) {
+      console.error(`${logPrefix} Validation error:`, error.message);
+      return this.createResult(false, `Validation error: ${error.message}`, { sdId, error: error.message });
+    }
+  }
+
+  /**
+   * Load SD with its validation profile from database
+   */
+  async loadSDWithProfile(sdId) {
+    const { data: sd, error: sdError } = await supabase
+      .from('strategic_directives_v2')
+      .select(`
+        id, sd_key, title, sd_type, status, scope, description,
+        smoke_test_steps, human_verification_status, llm_ux_score
+      `)
+      .eq('id', sdId)
+      .single();
+
+    if (sdError || !sd) {
+      return { error: sdError?.message || 'SD not found' };
+    }
+
+    // Load validation profile for this SD type
+    const { data: profile, error: profileError } = await supabase
+      .from('sd_type_validation_profiles')
+      .select(`
+        requires_human_verifiable_outcome,
+        human_verification_type,
+        requires_llm_ux_validation,
+        llm_ux_min_score,
+        llm_ux_required_lenses,
+        requires_uat_execution,
+        smoke_test_template
+      `)
+      .eq('sd_type', sd.sd_type || 'feature')
+      .single();
+
+    // Profile is optional - use defaults if not found
+    const validationProfile = profile || null;
+
+    return { sd, validationProfile };
+  }
+
+  /**
+   * Check if verification has already been completed
+   */
+  async checkVerificationStatus(sd, requirements) {
+    // Already passed - no need to re-verify
+    if (sd.human_verification_status === 'passed') {
+      // But still check LLM UX if required
+      if (requirements.requiresLLMUXValidation) {
+        if (sd.llm_ux_score === null) {
+          return {
+            shouldContinue: false,
+            result: this.createResult(false, 'Human verification passed but LLM UX evaluation missing', {
+              sdId: sd.id,
+              humanVerificationPassed: true,
+              llmUxMissing: true,
+              actionRequired: 'Run LLM UX Oracle evaluation'
+            })
+          };
+        }
+        if (sd.llm_ux_score < requirements.llmUxMinScore) {
+          return {
+            shouldContinue: false,
+            result: this.createResult(false, `LLM UX score (${sd.llm_ux_score}) below threshold (${requirements.llmUxMinScore})`, {
+              sdId: sd.id,
+              llmUxScore: sd.llm_ux_score,
+              llmUxMinScore: requirements.llmUxMinScore,
+              actionRequired: 'Improve UX and re-run LLM UX Oracle'
+            })
+          };
+        }
+      }
+
+      return {
+        shouldContinue: false,
+        result: this.createResult(true, 'Human verification already completed', {
+          sdId: sd.id,
+          status: 'passed',
+          llmUxScore: sd.llm_ux_score
+        })
+      };
+    }
+
+    // Failed previously - block until fixed
+    if (sd.human_verification_status === 'failed') {
+      return {
+        shouldContinue: false,
+        result: this.createResult(false, 'Human verification previously failed - fix required', {
+          sdId: sd.id,
+          status: 'failed',
+          actionRequired: 'Fix issues and re-run UAT Agent'
+        })
+      };
+    }
+
+    // Pending or not started - continue with verification
+    return { shouldContinue: true };
+  }
+
+  /**
+   * Validate UI smoke test (for feature SDs)
+   * Checks:
+   *   1. Smoke test steps defined
+   *   2. UAT Agent execution completed
+   *   3. LLM UX Oracle score meets threshold (if required)
+   */
+  async validateUISmokeTest(sd, requirements) {
+    const issues = [];
+    const warnings = [];
+
+    // Check 1: Smoke test steps defined
+    const smokeTestSteps = sd.smoke_test_steps || [];
+    if (smokeTestSteps.length === 0) {
+      issues.push({
+        type: 'missing_smoke_test_steps',
+        message: 'No smoke test steps defined for this feature SD',
+        actionRequired: 'Add smoke_test_steps to SD using template from sd_type_validation_profiles'
+      });
+    }
+
+    // Check 2: UAT execution evidence (if required)
+    if (requirements.requiresUATExecution) {
+      const uatEvidence = await this.checkUATEvidence(sd.id);
+      if (!uatEvidence.found) {
+        issues.push({
+          type: 'missing_uat_evidence',
+          message: 'UAT Agent execution not found',
+          actionRequired: 'Run UAT Agent to execute smoke tests via Playwright MCP'
+        });
+      } else if (!uatEvidence.passed) {
+        issues.push({
+          type: 'uat_failed',
+          message: `UAT execution failed: ${uatEvidence.failureReason}`,
+          evidence: uatEvidence
+        });
+      }
+    }
+
+    // Check 3: LLM UX Oracle score (if required)
+    if (requirements.requiresLLMUXValidation) {
+      if (sd.llm_ux_score === null) {
+        issues.push({
+          type: 'missing_llm_ux_evaluation',
+          message: 'LLM UX Oracle evaluation not performed',
+          requiredLenses: requirements.llmUxRequiredLenses,
+          actionRequired: 'Run LLM UX Oracle with required lenses'
+        });
+      } else if (sd.llm_ux_score < requirements.llmUxMinScore) {
+        issues.push({
+          type: 'llm_ux_below_threshold',
+          message: `LLM UX score (${sd.llm_ux_score}) below minimum (${requirements.llmUxMinScore})`,
+          score: sd.llm_ux_score,
+          minScore: requirements.llmUxMinScore,
+          actionRequired: 'Improve UX based on LLM UX Oracle feedback'
+        });
+      }
+    }
+
+    // Determine pass/fail
+    const passed = issues.length === 0;
+    const reason = passed
+      ? 'UI smoke test validation passed'
+      : `UI smoke test failed with ${issues.length} issue(s)`;
+
+    return this.createResult(passed, reason, {
+      sdId: sd.id,
+      sdType: sd.sd_type,
+      verificationType: 'ui_smoke_test',
+      smokeTestStepsCount: smokeTestSteps.length,
+      llmUxScore: sd.llm_ux_score,
+      llmUxMinScore: requirements.llmUxMinScore,
+      issues,
+      warnings
+    });
+  }
+
+  /**
+   * Validate API test (for database/security/performance SDs)
+   */
+  async validateAPITest(sd, requirements) {
+    const issues = [];
+
+    // Check smoke test steps for API verification
+    const smokeTestSteps = sd.smoke_test_steps || [];
+    if (smokeTestSteps.length === 0) {
+      issues.push({
+        type: 'missing_smoke_test_steps',
+        message: 'No API test steps defined',
+        actionRequired: 'Add API verification steps to smoke_test_steps'
+      });
+    }
+
+    // For database SDs, check migration evidence
+    if (sd.sd_type === 'database') {
+      // TODO: Check for migration success evidence
+      // This could query leo_test_plans or migration logs
+    }
+
+    // For security SDs, check auth test evidence
+    if (sd.sd_type === 'security') {
+      // TODO: Check for security test evidence
+      // This could verify RLS policy tests ran
+    }
+
+    const passed = issues.length === 0;
+    return this.createResult(passed,
+      passed ? 'API test validation passed' : `API test failed: ${issues.length} issue(s)`,
+      { sdId: sd.id, verificationType: 'api_test', issues }
+    );
+  }
+
+  /**
+   * Validate CLI verification (for infrastructure SDs)
+   */
+  async validateCLI(sd, requirements) {
+    // Infrastructure SDs don't require human verification by default
+    // But if explicitly required, check for script execution evidence
+    return this.createResult(true, 'CLI verification not enforced for infrastructure SDs', {
+      sdId: sd.id,
+      verificationType: 'cli_verification',
+      skipped: true
+    });
+  }
+
+  /**
+   * Check for UAT Agent execution evidence
+   */
+  async checkUATEvidence(sdId) {
+    // Check leo_test_plans for UAT evidence
+    const { data: testPlans, error } = await supabase
+      .from('leo_test_plans')
+      .select('smoke_tests, updated_at')
+      .eq('sd_id', sdId)
+      .order('updated_at', { ascending: false })
+      .limit(1);
+
+    if (error || !testPlans || testPlans.length === 0) {
+      return { found: false };
+    }
+
+    const smokTests = testPlans[0].smoke_tests || [];
+    if (smokTests.length === 0) {
+      return { found: false };
+    }
+
+    // Check if all smoke tests passed
+    const allPassed = smokTests.every(test => test.status === 'passed');
+    const failedTests = smokTests.filter(test => test.status === 'failed');
+
+    return {
+      found: true,
+      passed: allPassed,
+      failureReason: failedTests.length > 0
+        ? `${failedTests.length} smoke test(s) failed`
+        : null,
+      testsRun: smokTests.length,
+      lastUpdated: testPlans[0].updated_at
+    };
+  }
+
+  /**
+   * Update SD's human verification status
+   */
+  async updateVerificationStatus(sdId, status) {
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      .update({ human_verification_status: status })
+      .eq('id', sdId);
+
+    if (error) {
+      console.error(`Failed to update verification status for ${sdId}:`, error.message);
+    }
+  }
+
+  /**
+   * Create standardized result object
+   */
+  createResult(passed, reason, details = {}) {
+    return {
+      passed,
+      reason,
+      timestamp: new Date().toISOString(),
+      validator: 'HumanVerificationValidator',
+      version: '1.0.0',
+      ...details
+    };
+  }
+
+  /**
+   * Generate smoke test steps from template and SD context
+   * Called during SD creation/update to populate smoke_test_steps
+   */
+  async generateSmokeTestSteps(sdId) {
+    await this.initSupabase();
+
+    // Load SD and its validation profile
+    const { sd, validationProfile, error } = await this.loadSDWithProfile(sdId);
+    if (error) {
+      return { error };
+    }
+
+    // Get template from profile
+    const template = validationProfile?.smoke_test_template || [];
+    if (template.length === 0) {
+      return { steps: [], message: 'No smoke test template for this SD type' };
+    }
+
+    // Extract context from SD for template substitution
+    const context = this.extractSDContext(sd);
+
+    // Generate steps by substituting context into template
+    const steps = template.map(templateStep => ({
+      step_number: templateStep.step_number,
+      instruction: this.substituteTemplate(templateStep.instruction_template, context),
+      expected_outcome: this.substituteTemplate(templateStep.expected_outcome_template, context),
+      evidence_url: null,  // To be filled during UAT execution
+      status: 'pending'
+    }));
+
+    // Update SD with generated steps
+    const { error: updateError } = await supabase
+      .from('strategic_directives_v2')
+      .update({
+        smoke_test_steps: steps,
+        human_verification_status: 'pending'
+      })
+      .eq('id', sdId);
+
+    if (updateError) {
+      return { error: updateError.message };
+    }
+
+    return { steps, generated: true };
+  }
+
+  /**
+   * Extract context variables from SD for template substitution
+   */
+  extractSDContext(sd) {
+    // Extract feature URL from scope/description
+    const urlMatch = (sd.scope || sd.description || '').match(/\/[\w-/]+/);
+    const featureUrl = urlMatch ? urlMatch[0] : '/dashboard';
+
+    // Extract primary action from scope
+    const actionMatch = (sd.scope || '').match(/(create|update|delete|view|submit|navigate|configure)\s+(\w+)/i);
+    const primaryAction = actionMatch
+      ? `${actionMatch[1]} ${actionMatch[2]}`
+      : 'interact with the feature';
+
+    return {
+      feature_url: featureUrl,
+      primary_action: primaryAction,
+      sd_title: sd.title,
+      sd_type: sd.sd_type
+    };
+  }
+
+  /**
+   * Substitute template variables with context values
+   */
+  substituteTemplate(template, context) {
+    if (!template) return '';
+    return template.replace(/\{(\w+)\}/g, (match, key) => context[key] || match);
+  }
+}
+
+/**
+ * Convenience function for handoff validators
+ */
+export async function validateHumanVerification(sdId) {
+  const validator = new HumanVerificationValidator();
+  return validator.validate(sdId);
+}
+
+/**
+ * Convenience function for generating smoke test steps
+ */
+export async function generateSmokeTestSteps(sdId) {
+  const validator = new HumanVerificationValidator();
+  return validator.generateSmokeTestSteps(sdId);
+}
+
+// CLI interface for testing
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length === 0) {
+    console.log('Usage: node human-verification-validator.js <SD-ID>');
+    console.log('       node human-verification-validator.js --generate <SD-ID>');
+    process.exit(1);
+  }
+
+  if (args[0] === '--generate' && args[1]) {
+    console.log(`\nGenerating smoke test steps for ${args[1]}...`);
+    const result = await generateSmokeTestSteps(args[1]);
+    console.log('\nResult:', JSON.stringify(result, null, 2));
+    process.exit(result.error ? 1 : 0);
+  }
+
+  console.log(`\nValidating human verification for ${args[0]}...`);
+  const result = await validateHumanVerification(args[0]);
+  console.log('\nResult:', JSON.stringify(result, null, 2));
+  process.exit(result.passed ? 0 : 1);
+}
+
+// Execute if run directly
+const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+if (isMainModule) {
+  main().catch(error => {
+    console.error('Fatal error:', error);
+    process.exit(1);
+  });
+}
+
+export default HumanVerificationValidator;

--- a/scripts/modules/rubrics/user-story-quality-rubric.js
+++ b/scripts/modules/rubrics/user-story-quality-rubric.js
@@ -76,7 +76,14 @@ export class UserStoryQualityRubric extends AIQualityEvaluator {
 - Strict on testability: all acceptance criteria must be independently testable
 - Apply full INVEST principles (Independent, Negotiable, Valuable, Estimable, Small, Testable)
 - No boilerplate like "works correctly", "good performance", "user-friendly"
-- Given-When-Then should cover happy path + edge cases`,
+- Given-When-Then should cover happy path + edge cases
+
+**LEO v4.4.0 - HUMAN-VERIFIABLE OUTCOME REQUIREMENT:**
+- Feature SDs MUST include at least one acceptance criterion that a non-technical person could verify
+- This should be a "smoke test" style criterion: Navigate to X, click Y, see Z
+- Example GOOD: "When user clicks Save, a success toast appears within 2 seconds"
+- Example BAD: "Data is persisted to database correctly" (requires technical verification)
+- Penalize stories that only have technical criteria without user-observable outcomes`,
 
       database: `**MODERATE MODE for Database SDs:**
 - Focus on data integrity and migration safety in acceptance criteria
@@ -110,7 +117,15 @@ export class UserStoryQualityRubric extends AIQualityEvaluator {
 - 7-8: Most criteria are specific, testable, and verifiable
 - 9-10: All acceptance criteria are specific, testable, verifiable, with clear pass/fail conditions
 
-Penalize heavily for generic boilerplate like "system works", "good performance", "user-friendly". Reserve 9-10 for truly testable criteria.`
+Penalize heavily for generic boilerplate like "system works", "good performance", "user-friendly". Reserve 9-10 for truly testable criteria.
+
+**LEO v4.4.0 - Human-Verifiable Outcome Check (for FEATURE SDs only):**
+For feature SDs, also check that at least one criterion describes a user-observable outcome that a non-technical person could verify:
+- GOOD: "User sees success message after clicking Submit"
+- GOOD: "Form validation shows inline error when email format is invalid"
+- BAD: "Data is correctly saved to database" (only a developer can verify)
+- BAD: "API returns 200 status" (only a developer can verify)
+If ALL criteria are technical-only with no user-observable outcomes, score maximum 6/10.`
         },
         {
           name: 'story_independence_implementability',


### PR DESCRIPTION
## Summary

Addresses the core issue: **"The current plan optimizes for completing SDs rather than delivering working software."**

This PR implements two-phase human-verifiable outcome validation:

- **LEAD Phase**: `smoke_test_steps` REQUIRED for feature SDs (blocks approval if empty)
- **EXEC Phase**: UAT Agent + LLM UX Oracle validation (advisory mode initially)

## Key Changes

- Add `SMOKE_TEST_SPECIFICATION` gate to LeadToPlanExecutor
- Add `HUMAN_VERIFICATION_GATE` to ExecToPlanExecutor  
- Create `human-verification-validator.js` module
- Extend `sd-type-validation.js` with human verification requirements
- Update AI Quality Evaluator to cap scores at 70% for feature SDs lacking human-verifiable outcomes
- Update User Story rubric to cap scores at 6/10 for technical-only acceptance criteria
- Add database migration for new columns and SD-type-aware configuration

## SD Type Configuration

| SD Type | Requires Verification | Type |
|---------|----------------------|------|
| feature | ✅ YES | ui_smoke_test |
| bugfix | ✅ YES | ui_smoke_test |
| security | ✅ YES | api_test |
| database | ✅ YES | api_test |
| performance | ✅ YES | api_test |
| infrastructure | ❌ NO | - |
| documentation | ❌ NO | - |
| refactor | ❌ NO | - |

## Key Principle

> **LEAD Question 9**: "Describe the 30-second demo that proves this SD delivered value."
> If you can't answer this at LEAD, the SD is too vague.

## Test plan

- [ ] Verify LEAD-TO-PLAN handoff blocks feature SDs without `smoke_test_steps`
- [ ] Verify infrastructure/documentation SDs skip the smoke test gate
- [ ] Verify EXEC-TO-PLAN handoff logs human verification status (advisory mode)
- [ ] Confirm database migration applied (new columns visible in `sd_type_validation_profiles`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)