### PR TITLE
docs(SD-TRUTH-LABELING-001): Platform truth labeling and GDPR gap documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,47 @@ npx eslint --fix .
 psql $DATABASE_URL -c "UPDATE leo_validation_rules SET weight = 0.333 WHERE gate = '2A' AND rule_name = 'has_adrs';"
 ```
 
+## Truth Labels Convention
+
+Documentation and specification files must include truth status labels to clearly communicate implementation status. This prevents stakeholder confusion about what is built vs. what is planned.
+
+### Truth Status Labels
+
+Add one of these labels at the top of relevant documentation files:
+
+| Label | Meaning | When to Use |
+|-------|---------|-------------|
+| `TRUTH_STATUS: VISION_ONLY` | Specification only, no code exists | Feature designs, architecture specs, future plans |
+| `TRUTH_STATUS: SCAFFOLD_ONLY` | Database schema or tests exist, no functional implementation | Tables without API endpoints, E2E tests without UI |
+| `TRUTH_STATUS: IMPLEMENTED` | Feature is complete and functional | Working features with tests passing |
+
+### Label Format
+
+Add the label at the top of the file after the title:
+
+```markdown
+# Feature Name PRD
+
+> **TRUTH_STATUS: VISION_ONLY**
+> This document describes planned functionality. No implementation exists.
+
+## Executive Summary
+...
+```
+
+### When Labels Are Required
+
+- **Exit Pipeline specs** (`docs/vision/specs/`): VISION_ONLY (Stages 11-25)
+- **GDPR documentation**: Label based on current implementation status
+- **PRD documents**: Label if implementation is incomplete
+- **Architecture docs**: VISION_ONLY if describing future state
+
+### Database-First Principle
+
+Remember: Truth labels document the *code* status, not the *documentation* status. The presence of a PRD in the database does not mean the feature is implemented.
+
+---
+
 ## Running Tests
 
 ### Unit Tests

--- a/docs/02_api/13a_exit_oriented_design.md
+++ b/docs/02_api/13a_exit_oriented_design.md
@@ -2,6 +2,9 @@
 
 > **⚠️ LARGE FILE NOTICE**: This file is 66KB (approximately 2,300+ lines). Use the table of contents below for navigation. Consider splitting into smaller focused documents if editing frequently.
 
+> **TRUTH_STATUS: VISION_ONLY**
+> This document describes planned functionality for Stage 13 Exit-Oriented Design. No implementation exists. All TypeScript interfaces and specifications are architectural designs, not working code.
+
 **Status:** Enhanced for Lovable.dev • **Owner:** EVA Core • **Scope:** Exit Strategy Planning & Readiness Engine  
 **Stack:** React + Vite + Tailwind • TypeScript/Zod • Supabase • Financial Modeling Libraries
 **Enhancement Level:** Technical Architecture Specification (Not Implementation)

--- a/docs/04_features/governance_compliance.md
+++ b/docs/04_features/governance_compliance.md
@@ -1,5 +1,28 @@
 # Stage 59 – Governance & Compliance Enhanced PRD (v4)
 
+> **TRUTH_STATUS: SCAFFOLD_ONLY**
+> Database schema exists for GDPR compliance (consent, deletion, export tables). User-facing UI and API endpoints are NOT implemented.
+
+## GDPR Implementation Gap Analysis
+
+**Last Audited:** 2026-01-04 (SD-TRUTH-LABELING-001)
+
+| Component | Status | Implementation Gap |
+|-----------|--------|-------------------|
+| Consent Tables | IMPLEMENTED | `user_consent_records` table exists with full schema |
+| Consent Banner UI | NOT IMPLEMENTED | No cookie banner or consent popup |
+| Preference Center | NOT IMPLEMENTED | No user settings page for consent management |
+| Deletion Request Table | IMPLEMENTED | `data_deletion_requests` table with workflow schema |
+| Deletion Request API | NOT IMPLEMENTED | No `/api/gdpr/delete` endpoint |
+| Deletion Admin UI | NOT IMPLEMENTED | No admin dashboard for processing requests |
+| Export Request Table | IMPLEMENTED | `data_export_requests` table with status workflow |
+| Export Request API | NOT IMPLEMENTED | No `/api/gdpr/export` endpoint |
+| User GDPR Guide | NOT IMPLEMENTED | No documentation for users on data rights |
+
+**Remediation Priority:** Create separate SD for GDPR user-facing implementation after foundation work complete.
+
+---
+
 ## EHG Management Model Integration
 
 ### Corporate Governance Framework Implementation


### PR DESCRIPTION
## Summary
- Add **Truth Labels Convention** to CONTRIBUTING.md (VISION_ONLY, SCAFFOLD_ONLY, IMPLEMENTED)
- Label Exit Pipeline spec (`docs/02_api/13a_exit_oriented_design.md`) as VISION_ONLY
- Document GDPR implementation gaps in `docs/04_features/governance_compliance.md`

## Strategic Directive
**SD-TRUTH-LABELING-001**: Platform Truth Labeling & Documentation

## Changes
| File | Change |
|------|--------|
| `CONTRIBUTING.md` | Added Truth Labels Convention section with usage guidelines |
| `docs/02_api/13a_exit_oriented_design.md` | Added VISION_ONLY truth status label |
| `docs/04_features/governance_compliance.md` | Added SCAFFOLD_ONLY label + GDPR gap analysis table |

## Human-Verifiable Outcome
1. Open `docs/02_api/13a_exit_oriented_design.md` → VISION_ONLY label in header
2. Open `docs/04_features/governance_compliance.md` → GDPR gap list visible
3. Search for `TRUTH_STATUS:` in codebase → Convention documented in CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>