### PR TITLE
feat(SD-NAMING-ENGINE-001): Venture Naming Generation Engine

### DIFF
--- a/database/migrations/20260104_naming_suggestions.sql
+++ b/database/migrations/20260104_naming_suggestions.sql
@@ -1,0 +1,114 @@
+-- ============================================================================
+-- LEO Protocol - Venture Naming Engine
+-- Migration: 20260104_naming_suggestions.sql
+-- SD: SD-NAMING-ENGINE-001
+-- ============================================================================
+-- Purpose: Create tables for venture name generation and favorites
+--
+-- Tables:
+--   - naming_suggestions: Generated name suggestions with scores
+--   - naming_favorites: User's saved favorite names
+-- ============================================================================
+
+-- Create naming_suggestions table
+CREATE TABLE IF NOT EXISTS naming_suggestions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID REFERENCES ventures(id) ON DELETE CASCADE,
+  brand_genome_id UUID REFERENCES brand_genome_submissions(id) ON DELETE SET NULL,
+
+  -- Generation metadata
+  generation_session_id UUID NOT NULL,
+  generation_style TEXT CHECK (generation_style IN ('descriptive', 'coined', 'abstract', 'combined', 'metaphorical')),
+
+  -- Name data
+  name TEXT NOT NULL,
+  phonetic_guide TEXT,
+  rationale TEXT,
+
+  -- Scoring
+  brand_fit_score INTEGER CHECK (brand_fit_score >= 0 AND brand_fit_score <= 100),
+  length_score INTEGER CHECK (length_score >= 0 AND length_score <= 100),
+  pronounceability_score INTEGER CHECK (pronounceability_score >= 0 AND pronounceability_score <= 100),
+  uniqueness_score INTEGER CHECK (uniqueness_score >= 0 AND uniqueness_score <= 100),
+
+  -- Domain availability (cached)
+  domain_com_status TEXT CHECK (domain_com_status IN ('available', 'taken', 'error', 'unknown')),
+  domain_io_status TEXT CHECK (domain_io_status IN ('available', 'taken', 'error', 'unknown')),
+  domain_ai_status TEXT CHECK (domain_ai_status IN ('available', 'taken', 'error', 'unknown')),
+  domain_checked_at TIMESTAMPTZ,
+
+  -- LLM metadata
+  llm_model TEXT,
+  llm_provider TEXT,
+  generation_cost DECIMAL(10, 6),
+
+  -- Timestamps
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Create naming_favorites table
+CREATE TABLE IF NOT EXISTS naming_favorites (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  naming_suggestion_id UUID REFERENCES naming_suggestions(id) ON DELETE CASCADE,
+  venture_id UUID REFERENCES ventures(id) ON DELETE CASCADE,
+
+  -- User can also save custom names not from suggestions
+  custom_name TEXT,
+  notes TEXT,
+
+  -- Timestamps
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- Constraints
+  CONSTRAINT unique_favorite UNIQUE (user_id, naming_suggestion_id),
+  CONSTRAINT name_source CHECK (naming_suggestion_id IS NOT NULL OR custom_name IS NOT NULL)
+);
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_naming_suggestions_venture ON naming_suggestions(venture_id);
+CREATE INDEX IF NOT EXISTS idx_naming_suggestions_session ON naming_suggestions(generation_session_id);
+CREATE INDEX IF NOT EXISTS idx_naming_suggestions_score ON naming_suggestions(brand_fit_score DESC);
+CREATE INDEX IF NOT EXISTS idx_naming_favorites_user ON naming_favorites(user_id);
+CREATE INDEX IF NOT EXISTS idx_naming_favorites_venture ON naming_favorites(venture_id);
+
+-- Enable RLS
+ALTER TABLE naming_suggestions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE naming_favorites ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies for naming_suggestions
+CREATE POLICY "Allow all for authenticated" ON naming_suggestions
+  FOR ALL TO authenticated USING (true) WITH CHECK (true);
+
+CREATE POLICY "Allow select for anon" ON naming_suggestions
+  FOR SELECT TO anon USING (true);
+
+-- RLS policies for naming_favorites
+CREATE POLICY "Users can manage their own favorites" ON naming_favorites
+  FOR ALL TO authenticated USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Add updated_at trigger
+CREATE OR REPLACE FUNCTION update_naming_suggestions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER naming_suggestions_updated_at
+  BEFORE UPDATE ON naming_suggestions
+  FOR EACH ROW
+  EXECUTE FUNCTION update_naming_suggestions_updated_at();
+
+-- Verification
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'naming_suggestions') THEN
+    RAISE NOTICE 'naming_suggestions table created successfully';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'naming_favorites') THEN
+    RAISE NOTICE 'naming_favorites table created successfully';
+  END IF;
+END $$;

--- a/server.js
+++ b/server.js
@@ -32,6 +32,7 @@ import RealtimeDashboard from './src/services/realtime-dashboard.js';
 
 // Import Story API
 import * as storiesAPI from './src/api/stories.js';
+import * as namingEngineAPI from './src/api/naming-engine/index.js';
 import StoryAgentBootstrap from './src/agents/story-bootstrap.js';
 
 // Import Directive Enhancement Service
@@ -2399,6 +2400,22 @@ app.get('/api/v2/ventures/:venture_id/backlog', requireVentureScope, asyncHandle
     backlog_items: backlogItems || []
   });
 }));
+
+// =============================================================================
+// SD-NAMING-ENGINE-001: Naming Engine API Routes
+// =============================================================================
+
+/**
+ * Generate venture name suggestions
+ * POST /api/v2/naming-engine/generate
+ */
+app.post('/api/v2/naming-engine/generate', asyncHandler(namingEngineAPI.generateNames));
+
+/**
+ * Get saved name suggestions for a brand genome
+ * GET /api/v2/naming-engine/suggestions/:brand_genome_id
+ */
+app.get('/api/v2/naming-engine/suggestions/:brand_genome_id', asyncHandler(namingEngineAPI.getSuggestions));
 
 // =============================================================================
 // SOVEREIGN PIPE v3.7.0: EVA ERROR HANDLER

--- a/src/api/naming-engine/index.js
+++ b/src/api/naming-engine/index.js
@@ -1,0 +1,346 @@
+/**
+ * Naming Engine API
+ * SD-NAMING-ENGINE-001
+ *
+ * Endpoints:
+ *   POST /api/v2/naming-engine/generate - Generate name suggestions
+ *   GET /api/v2/naming-engine/suggestions/:brand_genome_id - Get saved suggestions
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { z } from 'zod';
+import { v4 as uuidv4 } from 'uuid';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// Request validation schemas
+const generateSchema = z.object({
+  brand_genome_id: z.string().uuid(),
+  count: z.number().min(1).max(20).default(10),
+  styles: z.array(z.enum(['descriptive', 'coined', 'abstract', 'combined', 'metaphorical'])).optional()
+});
+
+/**
+ * Generate venture name suggestions using LLM
+ * POST /api/v2/naming-engine/generate
+ */
+export async function generateNames(req, res) {
+  const startTime = Date.now();
+
+  try {
+    // Validate request
+    const data = generateSchema.parse(req.body);
+    const { brand_genome_id, count, styles } = data;
+
+    // Fetch brand genome data
+    const { data: brandGenome, error: bgError } = await supabase
+      .from('brand_genome_submissions')
+      .select('*')
+      .eq('id', brand_genome_id)
+      .single();
+
+    if (bgError || !brandGenome) {
+      return res.status(404).json({
+        error: 'Brand genome not found',
+        brand_genome_id
+      });
+    }
+
+    // Generate session ID for this batch
+    const sessionId = uuidv4();
+
+    // Build LLM prompt
+    const prompt = buildNamingPrompt(brandGenome, count, styles);
+
+    // Call LLM to generate names
+    const llmResponse = await callLLM(prompt);
+
+    // Parse and score the generated names
+    const suggestions = parseAndScoreNames(llmResponse, brandGenome, sessionId);
+
+    // Save to database
+    const { data: savedSuggestions, error: saveError } = await supabase
+      .from('naming_suggestions')
+      .insert(suggestions.map(s => ({
+        ...s,
+        venture_id: brandGenome.venture_id,
+        brand_genome_id: brand_genome_id,
+        generation_session_id: sessionId,
+        llm_model: process.env.AI_MODEL || 'gpt-5-mini',
+        llm_provider: 'openai'
+      })))
+      .select();
+
+    if (saveError) {
+      console.error('Error saving suggestions:', saveError);
+      // Return suggestions anyway, just not persisted
+    }
+
+    const generationTime = Date.now() - startTime;
+
+    return res.status(200).json({
+      success: true,
+      generation_session_id: sessionId,
+      generation_time_ms: generationTime,
+      suggestions: savedSuggestions || suggestions,
+      count: suggestions.length
+    });
+
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({
+        error: 'Validation error',
+        details: error.errors
+      });
+    }
+
+    console.error('Name generation error:', error);
+    return res.status(500).json({
+      error: 'Failed to generate names',
+      message: error.message
+    });
+  }
+}
+
+/**
+ * Get saved suggestions for a brand genome
+ * GET /api/v2/naming-engine/suggestions/:brand_genome_id
+ */
+export async function getSuggestions(req, res) {
+  try {
+    const { brand_genome_id } = req.params;
+
+    if (!brand_genome_id) {
+      return res.status(400).json({ error: 'brand_genome_id required' });
+    }
+
+    const { data: suggestions, error } = await supabase
+      .from('naming_suggestions')
+      .select('*')
+      .eq('brand_genome_id', brand_genome_id)
+      .order('brand_fit_score', { ascending: false });
+
+    if (error) {
+      return res.status(500).json({ error: error.message });
+    }
+
+    return res.status(200).json({
+      suggestions: suggestions || [],
+      count: suggestions?.length || 0
+    });
+
+  } catch (error) {
+    console.error('Get suggestions error:', error);
+    return res.status(500).json({
+      error: 'Failed to fetch suggestions',
+      message: error.message
+    });
+  }
+}
+
+/**
+ * Build LLM prompt for name generation
+ */
+function buildNamingPrompt(brandGenome, count, styles) {
+  const styleList = styles?.length
+    ? styles.join(', ')
+    : 'descriptive, coined, abstract, combined, metaphorical';
+
+  return `You are a brand naming expert. Generate ${count} unique venture/brand names based on the following brand genome:
+
+## Brand Context
+- Industry: ${brandGenome.industry || 'Technology'}
+- Target Market: ${brandGenome.target_audience || 'General'}
+- Brand Values: ${JSON.stringify(brandGenome.brand_values || [])}
+- Brand Personality: ${brandGenome.brand_personality || 'Professional, innovative'}
+- Positioning: ${brandGenome.positioning_statement || ''}
+- Key Differentiators: ${JSON.stringify(brandGenome.differentiators || [])}
+
+## Generation Styles to Include
+${styleList}
+
+## Requirements
+1. Each name should be:
+   - Memorable and easy to pronounce
+   - 1-3 words maximum
+   - Available as a potential domain (.com preferred)
+   - Culturally appropriate globally
+
+2. For each name, provide:
+   - The name itself
+   - Phonetic pronunciation guide
+   - Brief rationale (1-2 sentences) explaining brand fit
+   - Generation style used (descriptive/coined/abstract/combined/metaphorical)
+
+## Output Format
+Return a JSON array with exactly ${count} objects:
+[
+  {
+    "name": "BrandName",
+    "phonetic_guide": "BRAND-naym",
+    "rationale": "Why this name fits the brand...",
+    "generation_style": "coined"
+  }
+]
+
+Generate creative, unique names that capture the brand essence.`;
+}
+
+/**
+ * Call LLM API to generate names
+ */
+async function callLLM(prompt) {
+  const apiKey = process.env.OPENAI_API_KEY;
+
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY not configured');
+  }
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: process.env.AI_MODEL || 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'system',
+          content: 'You are a creative brand naming expert. Always return valid JSON arrays.'
+        },
+        {
+          role: 'user',
+          content: prompt
+        }
+      ],
+      temperature: 0.8,
+      max_tokens: 2000,
+      response_format: { type: 'json_object' }
+    })
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`LLM API error: ${error}`);
+  }
+
+  const result = await response.json();
+  return result.choices[0].message.content;
+}
+
+/**
+ * Parse LLM response and calculate scores
+ */
+function parseAndScoreNames(llmResponse, brandGenome, _sessionId) {
+  let names;
+
+  try {
+    const parsed = JSON.parse(llmResponse);
+    names = parsed.names || parsed.suggestions || parsed;
+    if (!Array.isArray(names)) {
+      names = [names];
+    }
+  } catch (e) {
+    console.error('Failed to parse LLM response:', e);
+    throw new Error('Invalid LLM response format');
+  }
+
+  return names.map(item => ({
+    name: item.name,
+    phonetic_guide: item.phonetic_guide || item.phonetic,
+    rationale: item.rationale,
+    generation_style: item.generation_style || item.style || 'combined',
+
+    // Calculate scores
+    brand_fit_score: calculateBrandFitScore(item, brandGenome),
+    length_score: calculateLengthScore(item.name),
+    pronounceability_score: calculatePronounceabilityScore(item.name),
+    uniqueness_score: calculateUniquenessScore(item.name),
+
+    // Domain status (default to unknown, can be checked separately)
+    domain_com_status: 'unknown',
+    domain_io_status: 'unknown',
+    domain_ai_status: 'unknown'
+  }));
+}
+
+/**
+ * Calculate brand fit score (0-100)
+ */
+function calculateBrandFitScore(nameData, brandGenome) {
+  let score = 70; // Base score
+
+  // Bonus for having rationale
+  if (nameData.rationale?.length > 20) score += 10;
+
+  // Bonus for matching brand values in rationale
+  const brandValues = brandGenome.brand_values || [];
+  for (const value of brandValues) {
+    if (nameData.rationale?.toLowerCase().includes(value.toLowerCase())) {
+      score += 5;
+    }
+  }
+
+  return Math.min(100, Math.max(0, score));
+}
+
+/**
+ * Calculate length score (0-100) - shorter names score higher
+ */
+function calculateLengthScore(name) {
+  const len = name.replace(/\s/g, '').length;
+  if (len <= 5) return 100;
+  if (len <= 8) return 90;
+  if (len <= 12) return 75;
+  if (len <= 15) return 60;
+  return 40;
+}
+
+/**
+ * Calculate pronounceability score (0-100)
+ */
+function calculatePronounceabilityScore(name) {
+  let score = 80;
+
+  // Penalize consecutive consonants
+  const consonantClusters = name.match(/[bcdfghjklmnpqrstvwxyz]{3,}/gi) || [];
+  score -= consonantClusters.length * 10;
+
+  // Bonus for alternating vowels and consonants
+  const vowelPattern = name.match(/[aeiou]/gi) || [];
+  if (vowelPattern.length >= name.length * 0.3) score += 10;
+
+  // Penalize unusual character combinations
+  if (/[xzq]{2}/i.test(name)) score -= 15;
+
+  return Math.min(100, Math.max(0, score));
+}
+
+/**
+ * Calculate uniqueness score (0-100)
+ */
+function calculateUniquenessScore(name) {
+  let score = 75;
+
+  // Bonus for coined words (no common word patterns)
+  const commonPatterns = ['tech', 'app', 'hub', 'lab', 'pro', 'plus', 'cloud', 'smart'];
+  for (const pattern of commonPatterns) {
+    if (name.toLowerCase().includes(pattern)) {
+      score -= 10;
+    }
+  }
+
+  // Bonus for unusual letter combinations
+  if (/[qxz]/i.test(name)) score += 5;
+
+  return Math.min(100, Math.max(0, score));
+}
+
+export default {
+  generateNames,
+  getSuggestions
+};


### PR DESCRIPTION
## Summary

Implements the Venture Naming Generation Engine - AI-powered name suggestions for ventures based on brand genome data.

## Changes

### Database
- `naming_suggestions` table with scoring columns (brand_fit, length, pronounceability, uniqueness)
- `naming_favorites` table for user-saved names
- RLS policies and performance indexes

### API Endpoints
- `POST /api/v2/naming-engine/generate`
  - Accepts brand_genome_id and count
  - Calls LLM to generate names with 5 styles (descriptive, coined, abstract, combined, metaphorical)
  - Scores and saves suggestions to database

- `GET /api/v2/naming-engine/suggestions/:brand_genome_id`
  - Retrieves saved suggestions ordered by brand_fit_score

### LLM Integration
- OpenAI GPT integration for name generation
- Structured JSON response parsing
- Scoring algorithms for name quality assessment

## Test plan
- [x] Migration applied to Supabase
- [x] Module loads without errors
- [x] Smoke tests pass
- [ ] E2E test with brand genome data (requires test fixtures)

## Dependencies
- Requires `brand_genome_submissions` data to generate names
- Uses OpenAI API key from environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)