### PR TITLE
feat(notifications): Add email notifications for Claude Code completion

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,57 @@
+# Ship Command
+
+Commit your changes and create a pull request.
+
+## Instructions
+
+1. **Check current state**:
+   - Run `git status` to see uncommitted changes
+   - Run `git log origin/main..HEAD` to see unpushed commits
+
+2. **If there are uncommitted changes**:
+   - Stage all changes: `git add .`
+   - Create a commit with a descriptive message summarizing the changes
+   - Follow the commit message format with the 🤖 Generated footer
+
+3. **Push to remote**:
+   - If on main branch, create a new feature branch first
+   - Push the branch to origin with `-u` flag
+
+4. **Create Pull Request**:
+   - Use `gh pr create` with:
+     - A clear, concise title
+     - A body with `## Summary` (bullet points of changes) and `## Test plan`
+     - The 🤖 Generated footer
+
+5. **Return the PR URL** to the user
+
+## Example Flow
+
+```bash
+# Check state
+git status
+git log origin/main..HEAD --oneline
+
+# Commit if needed
+git add .
+git commit -m "feat: add notification system
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+
+# Push
+git push -u origin HEAD
+
+# Create PR
+gh pr create --title "feat: add notification system" --body "## Summary
+- Added email notifications via Resend
+- Added SMS notifications via Twilio
+- Updated Claude Code hooks
+
+## Test plan
+- [ ] Verify email notifications arrive
+- [ ] Verify hooks trigger on Stop event
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```

--- a/.claude/notify-email.sh
+++ b/.claude/notify-email.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Claude Code Email Notification via Resend
+# Sends an email when Claude needs user input
+
+# Resend credentials (set these in your environment or .env file)
+RESEND_API_KEY="${RESEND_API_KEY:-}"
+TO_EMAIL="${CLAUDE_NOTIFY_EMAIL:-}"
+
+if [ -z "$RESEND_API_KEY" ] || [ -z "$TO_EMAIL" ]; then
+    echo "Email notification not configured. Set RESEND_API_KEY and CLAUDE_NOTIFY_EMAIL."
+    exit 0
+fi
+
+# Message based on notification type
+MESSAGE_TYPE="${1:-complete}"
+case "$MESSAGE_TYPE" in
+    "complete"|"done"|"success")
+        SUBJECT="Claude Code is waiting for your input"
+        BODY="Claude Code has completed and is waiting for your input."
+        ;;
+    "attention"|"urgent")
+        SUBJECT="URGENT: Claude Code needs your attention!"
+        BODY="Claude Code requires your immediate attention."
+        ;;
+    "question"|"input")
+        SUBJECT="Claude Code has a question"
+        BODY="Claude Code has a question for you."
+        ;;
+    "error"|"fail")
+        SUBJECT="Claude Code encountered an error"
+        BODY="Claude Code encountered an error and needs your help."
+        ;;
+    *)
+        SUBJECT="Claude Code notification"
+        BODY="$MESSAGE_TYPE"
+        ;;
+esac
+
+# Send email via Resend API
+curl -s -X POST 'https://api.resend.com/emails' \
+    -H "Authorization: Bearer $RESEND_API_KEY" \
+    -H 'Content-Type: application/json' \
+    -d "{
+        \"from\": \"Claude Code <onboarding@resend.dev>\",
+        \"to\": [\"$TO_EMAIL\"],
+        \"subject\": \"$SUBJECT\",
+        \"text\": \"$BODY\"
+    }" > /dev/null 2>&1
+
+exit 0

--- a/.claude/notify-sms.sh
+++ b/.claude/notify-sms.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Claude Code SMS Notification via Twilio
+# Sends a text message when Claude needs user input
+
+# Twilio credentials (set these in your environment or .env file)
+# TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_MESSAGING_SERVICE, TWILIO_TO_PHONE
+TWILIO_ACCOUNT_SID="${TWILIO_ACCOUNT_SID:-}"
+TWILIO_AUTH_TOKEN="${TWILIO_AUTH_TOKEN:-}"
+TWILIO_MESSAGING_SERVICE="${TWILIO_MESSAGING_SERVICE:-}"
+TO_PHONE="${TWILIO_TO_PHONE:-}"
+
+if [ -z "$TWILIO_ACCOUNT_SID" ] || [ -z "$TWILIO_AUTH_TOKEN" ]; then
+    echo "Twilio credentials not configured. Skipping SMS notification."
+    exit 0
+fi
+
+# Message based on notification type
+MESSAGE_TYPE="${1:-complete}"
+case "$MESSAGE_TYPE" in
+    "complete"|"done"|"success")
+        MESSAGE="Claude Code has completed and is waiting for your input."
+        ;;
+    "attention"|"urgent")
+        MESSAGE="URGENT: Claude Code needs your attention!"
+        ;;
+    "question"|"input")
+        MESSAGE="Claude Code has a question for you."
+        ;;
+    "error"|"fail")
+        MESSAGE="Claude Code encountered an error and needs help."
+        ;;
+    *)
+        MESSAGE="Claude Code notification: $MESSAGE_TYPE"
+        ;;
+esac
+
+# Send SMS via Twilio
+curl -s 'https://api.twilio.com/2010-04-01/Accounts/'"$TWILIO_ACCOUNT_SID"'/Messages.json' \
+    -X POST \
+    --data-urlencode "To=$TO_PHONE" \
+    --data-urlencode "MessagingServiceSid=$TWILIO_MESSAGING_SERVICE" \
+    --data-urlencode "Body=$MESSAGE" \
+    -u "$TWILIO_ACCOUNT_SID:$TWILIO_AUTH_TOKEN" \
+    > /dev/null 2>&1
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,11 @@
             "type": "command",
             "command": "/mnt/c/_EHG/EHG_Engineer/.claude/notify-user.sh complete",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/notify-email.sh complete",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/test-sms-gateway.sh
+++ b/.claude/test-sms-gateway.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Test SMS via Verizon email-to-SMS gateway using Resend
+#
+# Usage: ./test-sms-gateway.sh 1234567890
+# (Replace with your 10-digit phone number)
+
+PHONE_NUMBER="$1"
+
+if [ -z "$PHONE_NUMBER" ]; then
+    echo "Usage: $0 <10-digit-phone-number>"
+    echo "Example: $0 5551234567"
+    exit 1
+fi
+
+# Check for Resend API key
+if [ -z "$RESEND_API_KEY" ]; then
+    echo "Error: RESEND_API_KEY environment variable not set"
+    echo "Set it with: export RESEND_API_KEY=re_xxxx"
+    exit 1
+fi
+
+# Verizon email-to-SMS gateway
+SMS_EMAIL="${PHONE_NUMBER}@vtext.com"
+
+echo "Sending test SMS to: $SMS_EMAIL"
+
+# Send via Resend API
+RESPONSE=$(curl -s -X POST 'https://api.resend.com/emails' \
+    -H "Authorization: Bearer $RESEND_API_KEY" \
+    -H 'Content-Type: application/json' \
+    -d "{
+        \"from\": \"Claude Code <onboarding@resend.dev>\",
+        \"to\": [\"$SMS_EMAIL\"],
+        \"subject\": \"Claude Code Ready\",
+        \"text\": \"Claude Code is waiting for your input.\"
+    }")
+
+# Check response
+if echo "$RESPONSE" | grep -q '"id"'; then
+    echo "Success! SMS sent via Verizon gateway."
+    echo "Check your phone in the next 1-2 minutes."
+else
+    echo "Failed to send. Response:"
+    echo "$RESPONSE"
+fi


### PR DESCRIPTION
## Summary
- Add email notification via Resend when Claude Code stops and waits for input
- Add `/ship` command for quick commit + PR workflow
- Include SMS notification scripts (Twilio) for future use
- Update `.claude/settings.json` to trigger notifications on Stop hook

## Configuration Required
Set these environment variables to enable notifications:
```bash
# For email notifications
export RESEND_API_KEY=re_xxxx
export CLAUDE_NOTIFY_EMAIL=your@email.com

# For SMS notifications (optional, requires Twilio verification)
export TWILIO_ACCOUNT_SID=ACxxxx
export TWILIO_AUTH_TOKEN=xxxx
export TWILIO_MESSAGING_SERVICE=MGxxxx
export TWILIO_TO_PHONE=+1234567890
```

## Test plan
- [x] Verified email notification arrives via Resend
- [x] Verified hooks trigger on Stop event
- [ ] SMS notifications pending Twilio toll-free verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)