### PR TITLE
fix(progress): recognize all PRD active statuses in calculate_sd_progress

### DIFF
--- a/database/migrations/20260105_fix_progress_prd_status_check.sql
+++ b/database/migrations/20260105_fix_progress_prd_status_check.sql
@@ -1,0 +1,498 @@
+-- Migration: Fix calculate_sd_progress PRD Status Recognition
+-- Date: 2026-01-05
+-- Root Cause: PRD status 'verification' not recognized by progress function
+--
+-- SINGLE SOURCE OF TRUTH: lib/constants/status-definitions.ts
+-- This migration syncs the SQL function with the TypeScript definitions.
+--
+-- PRD_ACTIVE_STATUSES (from status-definitions.ts):
+--   'planning', 'in_progress', 'testing', 'verification', 'approved', 'completed'
+--
+-- Previous (broken): 'approved', 'in_progress', 'completed'
+-- New (fixed): All active PRD statuses from single source of truth
+
+-- ============================================================================
+-- STEP 1: Update product_requirements_v2 CHECK constraint
+-- ============================================================================
+
+-- First, drop the existing constraint (if exists)
+ALTER TABLE product_requirements_v2
+DROP CONSTRAINT IF EXISTS product_requirements_v2_status_check;
+
+-- Add the updated constraint with all valid statuses
+ALTER TABLE product_requirements_v2
+ADD CONSTRAINT product_requirements_v2_status_check
+CHECK (status IN (
+  'draft',
+  'planning',
+  'in_progress',
+  'testing',
+  'verification',
+  'approved',
+  'completed',
+  'archived',
+  'rejected',
+  'on_hold',
+  'cancelled'
+));
+
+-- ============================================================================
+-- STEP 2: Fix calculate_sd_progress function
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION calculate_sd_progress(sd_id_param TEXT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  sd RECORD;
+  sd_type_val VARCHAR;
+  profile RECORD;
+  progress INTEGER := 0;
+
+  -- Component states
+  prd_exists BOOLEAN := false;
+  deliverables_complete BOOLEAN := false;
+  user_stories_validated BOOLEAN := false;
+  retrospective_exists BOOLEAN := false;
+  handoffs_count INT := 0;
+  subagent_check JSONB;
+  subagent_ok BOOLEAN := false;
+
+  -- Orchestrator variables
+  is_orchestrator_flag BOOLEAN := false;
+  total_children INT := 0;
+  completed_children INT := 0;
+  child_progress INT := 0;
+BEGIN
+  -- Get SD
+  SELECT * INTO sd FROM strategic_directives_v2 WHERE id = sd_id_param;
+
+  IF NOT FOUND THEN
+    RETURN 0;
+  END IF;
+
+  -- Check if this is an orchestrator SD (has children)
+  is_orchestrator_flag := is_orchestrator_sd(sd_id_param);
+
+  IF is_orchestrator_flag THEN
+    -- Orchestrator SD: Progress = weighted average of children
+    SELECT
+      COUNT(*),
+      COUNT(*) FILTER (WHERE status = 'completed')
+    INTO total_children, completed_children
+    FROM strategic_directives_v2
+    WHERE parent_sd_id = sd_id_param;
+
+    IF total_children > 0 THEN
+      -- Calculate based on child progress
+      SELECT COALESCE(AVG(calculate_sd_progress(id)), 0)::INT
+      INTO child_progress
+      FROM strategic_directives_v2
+      WHERE parent_sd_id = sd_id_param;
+
+      -- Add 10% bonus if LEAD approval received
+      IF sd.status IN ('active', 'in_progress', 'pending_approval', 'completed') THEN
+        progress := LEAST(child_progress + 10, 100);
+      ELSE
+        progress := child_progress;
+      END IF;
+    END IF;
+
+    RETURN progress;
+  END IF;
+
+  -- Standard SD: Calculate phase-by-phase progress
+  sd_type_val := COALESCE(sd.sd_type, 'feature');
+
+  -- Get validation profile
+  SELECT * INTO profile FROM sd_type_validation_profiles WHERE sd_type = sd_type_val;
+
+  IF NOT FOUND THEN
+    -- Fallback to 'feature' profile
+    SELECT * INTO profile FROM sd_type_validation_profiles WHERE sd_type = 'feature';
+  END IF;
+
+  -- Phase 1: LEAD Approval (lead_weight)
+  IF sd.status IN ('active', 'in_progress', 'pending_approval', 'completed') THEN
+    progress := progress + profile.lead_weight;
+  END IF;
+
+  -- Phase 2: PLAN / PRD (plan_weight)
+  -- FIX: Use all PRD_ACTIVE_STATUSES from status-definitions.ts
+  -- Previous (broken): ('approved', 'in_progress', 'completed')
+  -- New (fixed): All statuses that indicate PRD work is happening
+  IF NOT profile.requires_prd THEN
+    progress := progress + profile.plan_weight;
+  ELSE
+    SELECT EXISTS (
+      SELECT 1 FROM product_requirements_v2
+      WHERE directive_id = sd_id_param
+      AND status IN (
+        'planning',
+        'in_progress',
+        'testing',
+        'verification',
+        'approved',
+        'completed'
+      )
+    ) INTO prd_exists;
+
+    IF prd_exists THEN
+      progress := progress + profile.plan_weight;
+    END IF;
+  END IF;
+
+  -- Phase 3: EXEC / Implementation (exec_weight)
+  IF profile.requires_deliverables THEN
+    IF EXISTS (SELECT 1 FROM sd_scope_deliverables WHERE sd_id = sd_id_param) THEN
+      SELECT
+        CASE
+          WHEN COUNT(*) = 0 THEN true
+          WHEN COUNT(*) FILTER (WHERE completion_status = 'completed') = COUNT(*) THEN true
+          ELSE false
+        END INTO deliverables_complete
+      FROM sd_scope_deliverables
+      WHERE sd_id = sd_id_param
+      AND priority IN ('required', 'high');
+    ELSE
+      deliverables_complete := true;
+    END IF;
+
+    IF deliverables_complete THEN
+      progress := progress + profile.exec_weight;
+    END IF;
+  ELSE
+    progress := progress + profile.exec_weight;
+  END IF;
+
+  -- Phase 4: Verification (verify_weight)
+  IF profile.requires_e2e_tests THEN
+    IF EXISTS (SELECT 1 FROM user_stories WHERE sd_id = sd_id_param) THEN
+      SELECT
+        CASE
+          WHEN COUNT(*) = 0 THEN true
+          WHEN COUNT(*) FILTER (WHERE validation_status = 'validated' AND e2e_test_status = 'passing') = COUNT(*) THEN true
+          ELSE false
+        END INTO user_stories_validated
+      FROM user_stories
+      WHERE sd_id = sd_id_param;
+    ELSE
+      user_stories_validated := true;
+    END IF;
+
+    IF profile.requires_sub_agents THEN
+      BEGIN
+        subagent_check := check_required_sub_agents(sd_id_param);
+        subagent_ok := COALESCE((subagent_check->>'all_verified')::boolean, false);
+      EXCEPTION WHEN OTHERS THEN
+        subagent_ok := true;
+      END;
+
+      IF user_stories_validated AND subagent_ok THEN
+        progress := progress + profile.verify_weight;
+      END IF;
+    ELSE
+      IF user_stories_validated THEN
+        progress := progress + profile.verify_weight;
+      END IF;
+    END IF;
+  ELSE
+    progress := progress + profile.verify_weight;
+  END IF;
+
+  -- Phase 5: Final Approval (final_weight)
+  SELECT EXISTS (SELECT 1 FROM retrospectives WHERE sd_id = sd_id_param) INTO retrospective_exists;
+  SELECT COUNT(DISTINCT handoff_type) INTO handoffs_count
+  FROM sd_phase_handoffs
+  WHERE sd_id = sd_id_param AND status = 'accepted';
+
+  IF (NOT profile.requires_retrospective OR retrospective_exists) AND handoffs_count >= profile.min_handoffs THEN
+    progress := progress + profile.final_weight;
+  END IF;
+
+  RETURN LEAST(progress, 100);
+END;
+$$;
+
+-- ============================================================================
+-- STEP 3: Also fix get_progress_breakdown for consistency
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_progress_breakdown(sd_id_param TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  sd RECORD;
+  sd_type_val VARCHAR;
+  profile RECORD;
+  breakdown JSONB;
+  total_progress INTEGER;
+  is_orchestrator_flag BOOLEAN;
+  total_children INT;
+  completed_children INT;
+
+  prd_exists BOOLEAN;
+  deliverables_complete BOOLEAN := false;
+  user_stories_validated BOOLEAN := false;
+  subagent_verified BOOLEAN := false;
+  retrospective_exists BOOLEAN;
+  handoffs_count INT;
+BEGIN
+  SELECT * INTO sd FROM strategic_directives_v2 WHERE id = sd_id_param;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error', 'SD not found');
+  END IF;
+
+  is_orchestrator_flag := is_orchestrator_sd(sd_id_param);
+
+  IF is_orchestrator_flag THEN
+    SELECT
+      COUNT(*),
+      COUNT(*) FILTER (WHERE status = 'completed')
+    INTO total_children, completed_children
+    FROM strategic_directives_v2
+    WHERE parent_sd_id = sd_id_param;
+
+    SELECT EXISTS (
+      SELECT 1 FROM retrospectives WHERE sd_id = sd_id_param
+    ) INTO retrospective_exists;
+
+    SELECT COUNT(*) INTO handoffs_count
+    FROM sd_phase_handoffs
+    WHERE sd_id = sd_id_param
+    AND handoff_type = 'PLAN-TO-LEAD'
+    AND status = 'accepted';
+
+    total_progress := calculate_sd_progress(sd_id_param);
+
+    RETURN jsonb_build_object(
+      'sd_id', sd_id_param,
+      'sd_type', COALESCE(sd.sd_type, 'feature'),
+      'is_orchestrator', true,
+      'status', sd.status,
+      'total_progress', total_progress,
+      'can_complete', total_progress = 100
+    );
+  END IF;
+
+  sd_type_val := COALESCE(sd.sd_type, 'feature');
+  SELECT * INTO profile FROM sd_type_validation_profiles WHERE sd_type = sd_type_val;
+
+  IF NOT FOUND THEN
+    SELECT * INTO profile FROM sd_type_validation_profiles WHERE sd_type = 'feature';
+  END IF;
+
+  -- FIX: Check PRD with all active statuses (matches calculate_sd_progress)
+  SELECT EXISTS (
+    SELECT 1 FROM product_requirements_v2
+    WHERE directive_id = sd_id_param
+    AND status IN (
+      'planning',
+      'in_progress',
+      'testing',
+      'verification',
+      'approved',
+      'completed'
+    )
+  ) INTO prd_exists;
+
+  SELECT EXISTS (
+    SELECT 1 FROM retrospectives WHERE sd_id = sd_id_param
+  ) INTO retrospective_exists;
+
+  SELECT COUNT(DISTINCT handoff_type) INTO handoffs_count
+  FROM sd_phase_handoffs
+  WHERE sd_id = sd_id_param AND status = 'accepted';
+
+  -- Deliverables check
+  IF profile.requires_deliverables THEN
+    IF EXISTS (SELECT 1 FROM sd_scope_deliverables WHERE sd_id = sd_id_param) THEN
+      SELECT
+        CASE
+          WHEN COUNT(*) = 0 THEN true
+          WHEN COUNT(*) FILTER (WHERE completion_status = 'completed') = COUNT(*) THEN true
+          ELSE false
+        END INTO deliverables_complete
+      FROM sd_scope_deliverables
+      WHERE sd_id = sd_id_param
+      AND priority IN ('required', 'high');
+    ELSE
+      deliverables_complete := true;
+    END IF;
+  ELSE
+    deliverables_complete := true;
+  END IF;
+
+  -- User stories check
+  IF profile.requires_e2e_tests THEN
+    IF EXISTS (SELECT 1 FROM user_stories WHERE sd_id = sd_id_param) THEN
+      SELECT
+        CASE
+          WHEN COUNT(*) = 0 THEN true
+          WHEN COUNT(*) FILTER (WHERE validation_status = 'validated' AND e2e_test_status = 'passing') = COUNT(*) THEN true
+          ELSE false
+        END INTO user_stories_validated
+      FROM user_stories
+      WHERE sd_id = sd_id_param;
+    ELSE
+      user_stories_validated := true;
+    END IF;
+
+    IF profile.requires_sub_agents THEN
+      BEGIN
+        DECLARE
+          subagent_check JSONB;
+        BEGIN
+          subagent_check := check_required_sub_agents(sd_id_param);
+          subagent_verified := (subagent_check->>'all_verified')::boolean;
+        EXCEPTION WHEN OTHERS THEN
+          subagent_verified := true;
+        END;
+      END;
+    ELSE
+      subagent_verified := true;
+    END IF;
+  ELSE
+    user_stories_validated := true;
+    subagent_verified := true;
+  END IF;
+
+  total_progress := calculate_sd_progress(sd_id_param);
+
+  breakdown := jsonb_build_object(
+    'sd_id', sd_id_param,
+    'sd_type', sd_type_val,
+    'is_orchestrator', false,
+    'current_phase', sd.current_phase,
+    'status', sd.status,
+    'profile', jsonb_build_object(
+      'name', profile.sd_type,
+      'description', profile.description,
+      'requires_prd', profile.requires_prd,
+      'requires_deliverables', profile.requires_deliverables,
+      'requires_e2e_tests', profile.requires_e2e_tests,
+      'requires_sub_agents', profile.requires_sub_agents,
+      'requires_retrospective', profile.requires_retrospective,
+      'min_handoffs', profile.min_handoffs
+    ),
+    'phases', jsonb_build_object(
+      'LEAD_approval', jsonb_build_object(
+        'weight', profile.lead_weight,
+        'complete', sd.status IN ('active', 'in_progress', 'pending_approval', 'completed'),
+        'progress', CASE WHEN sd.status IN ('active', 'in_progress', 'pending_approval', 'completed')
+                        THEN profile.lead_weight ELSE 0 END,
+        'required', true
+      ),
+      'PLAN_prd', jsonb_build_object(
+        'weight', profile.plan_weight,
+        'complete', NOT profile.requires_prd OR prd_exists,
+        'progress', CASE WHEN NOT profile.requires_prd OR prd_exists
+                        THEN profile.plan_weight ELSE 0 END,
+        'required', profile.requires_prd,
+        'prd_exists', prd_exists
+      ),
+      'EXEC_implementation', jsonb_build_object(
+        'weight', profile.exec_weight,
+        'complete', deliverables_complete,
+        'progress', CASE WHEN deliverables_complete
+                        THEN profile.exec_weight ELSE 0 END,
+        'required', profile.requires_deliverables,
+        'deliverables_complete', deliverables_complete
+      ),
+      'PLAN_verification', jsonb_build_object(
+        'weight', profile.verify_weight,
+        'complete', user_stories_validated AND subagent_verified,
+        'progress', CASE WHEN user_stories_validated AND subagent_verified
+                        THEN profile.verify_weight ELSE 0 END,
+        'required', profile.requires_e2e_tests,
+        'user_stories_validated', user_stories_validated,
+        'subagent_verified', subagent_verified
+      ),
+      'LEAD_final_approval', jsonb_build_object(
+        'weight', profile.final_weight,
+        'complete', retrospective_exists AND handoffs_count >= profile.min_handoffs,
+        'progress', CASE WHEN retrospective_exists AND handoffs_count >= profile.min_handoffs
+                        THEN profile.final_weight ELSE 0 END,
+        'retrospective_required', profile.requires_retrospective,
+        'retrospective_exists', retrospective_exists,
+        'min_handoffs', profile.min_handoffs,
+        'handoffs_count', handoffs_count
+      )
+    ),
+    'total_progress', total_progress,
+    'can_complete', total_progress = 100
+  );
+
+  RETURN breakdown;
+END;
+$$;
+
+-- VARCHAR overload for backwards compatibility
+CREATE OR REPLACE FUNCTION get_progress_breakdown(sd_id_param VARCHAR)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN get_progress_breakdown(sd_id_param::TEXT);
+END;
+$$;
+
+-- ============================================================================
+-- STEP 4: Grant permissions
+-- ============================================================================
+
+GRANT EXECUTE ON FUNCTION calculate_sd_progress(TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION calculate_sd_progress(TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION get_progress_breakdown(TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_progress_breakdown(TEXT) TO service_role;
+GRANT EXECUTE ON FUNCTION get_progress_breakdown(VARCHAR) TO authenticated;
+GRANT EXECUTE ON FUNCTION get_progress_breakdown(VARCHAR) TO service_role;
+
+-- ============================================================================
+-- STEP 5: Validation
+-- ============================================================================
+
+DO $$
+DECLARE
+  test_progress INT;
+  test_breakdown JSONB;
+BEGIN
+  RAISE NOTICE '============================================================';
+  RAISE NOTICE 'PRD Status Recognition Fix - Applied';
+  RAISE NOTICE '============================================================';
+  RAISE NOTICE '';
+  RAISE NOTICE 'Changes made:';
+  RAISE NOTICE '  1. Updated CHECK constraint to include all valid PRD statuses';
+  RAISE NOTICE '  2. Fixed calculate_sd_progress to recognize:';
+  RAISE NOTICE '     planning, in_progress, testing, verification, approved, completed';
+  RAISE NOTICE '  3. Fixed get_progress_breakdown to match';
+  RAISE NOTICE '';
+  RAISE NOTICE 'Single Source of Truth: lib/constants/status-definitions.ts';
+  RAISE NOTICE '';
+
+  -- Test the fix
+  SELECT calculate_sd_progress('SD-FINANCIAL-ENGINE-001') INTO test_progress;
+  RAISE NOTICE 'Test Result for SD-FINANCIAL-ENGINE-001:';
+  RAISE NOTICE '  Progress: %', test_progress;
+
+  SELECT get_progress_breakdown('SD-FINANCIAL-ENGINE-001') INTO test_breakdown;
+  RAISE NOTICE '  PLAN_prd.prd_exists: %', test_breakdown->'phases'->'PLAN_prd'->>'prd_exists';
+  RAISE NOTICE '  PLAN_prd.progress: %', test_breakdown->'phases'->'PLAN_prd'->>'progress';
+
+  IF test_progress = 100 THEN
+    RAISE NOTICE '';
+    RAISE NOTICE '✅ FIX SUCCESSFUL: Progress now 100%%';
+  ELSE
+    RAISE NOTICE '';
+    RAISE NOTICE '⚠️  Progress is % - check other phase requirements', test_progress;
+  END IF;
+END $$;

--- a/lib/constants/status-definitions.ts
+++ b/lib/constants/status-definitions.ts
@@ -1,0 +1,218 @@
+/**
+ * SINGLE SOURCE OF TRUTH for all LEO Protocol Status Definitions
+ *
+ * This file is the authoritative source for status values across:
+ * - Database CHECK constraints (generate via npm run db:sync-statuses)
+ * - TypeScript/JavaScript validation
+ * - SQL functions (referenced via comments, synced via migration)
+ *
+ * @module status-definitions
+ * @see database/migrations/*_sync_status_constraints.sql
+ */
+
+// ============================================================================
+// PRD (Product Requirements Document) Statuses
+// ============================================================================
+
+/**
+ * All valid PRD status values.
+ * Database constraint: product_requirements_v2.status
+ */
+export const PRD_STATUSES = [
+  'draft',
+  'planning',
+  'in_progress',
+  'testing',
+  'verification',
+  'approved',
+  'completed',
+  'archived',
+  'rejected',
+  'on_hold',
+  'cancelled'
+] as const;
+
+export type PRDStatus = typeof PRD_STATUSES[number];
+
+/**
+ * PRD statuses that indicate work is actively happening.
+ * Used by calculate_sd_progress to credit PLAN phase.
+ */
+export const PRD_ACTIVE_STATUSES: readonly PRDStatus[] = [
+  'planning',
+  'in_progress',
+  'testing',
+  'verification',
+  'approved',
+  'completed'
+] as const;
+
+/**
+ * PRD statuses that indicate the PRD exists and is valid (not abandoned).
+ * Broadest set for "PRD exists" checks.
+ */
+export const PRD_EXISTS_STATUSES: readonly PRDStatus[] = [
+  'draft',
+  'planning',
+  'in_progress',
+  'testing',
+  'verification',
+  'approved',
+  'completed',
+  'on_hold'
+] as const;
+
+/**
+ * Terminal PRD statuses (no further transitions allowed)
+ */
+export const PRD_TERMINAL_STATUSES: readonly PRDStatus[] = [
+  'archived',
+  'cancelled'
+] as const;
+
+// ============================================================================
+// SD (Strategic Directive) Statuses
+// ============================================================================
+
+/**
+ * All valid SD status values.
+ * Database constraint: strategic_directives_v2.status
+ */
+export const SD_STATUSES = [
+  'draft',
+  'active',
+  'in_progress',
+  'on_hold',
+  'completed',
+  'cancelled',
+  'deferred',
+  'pending_approval'
+] as const;
+
+export type SDStatus = typeof SD_STATUSES[number];
+
+/**
+ * SD statuses that indicate active work.
+ * Used by calculate_sd_progress for LEAD phase credit.
+ */
+export const SD_ACTIVE_STATUSES: readonly SDStatus[] = [
+  'active',
+  'in_progress',
+  'pending_approval',
+  'completed'
+] as const;
+
+// ============================================================================
+// Handoff Statuses
+// ============================================================================
+
+export const HANDOFF_STATUSES = [
+  'pending',
+  'accepted',
+  'rejected',
+  'expired'
+] as const;
+
+export type HandoffStatus = typeof HANDOFF_STATUSES[number];
+
+// ============================================================================
+// User Story Statuses
+// ============================================================================
+
+export const USER_STORY_VALIDATION_STATUSES = [
+  'pending',
+  'in_progress',
+  'validated',
+  'failed'
+] as const;
+
+export const USER_STORY_E2E_STATUSES = [
+  'pending',
+  'running',
+  'passing',
+  'failing',
+  'error'
+] as const;
+
+// ============================================================================
+// Deliverable Statuses
+// ============================================================================
+
+export const DELIVERABLE_STATUSES = [
+  'pending',
+  'in_progress',
+  'completed',
+  'blocked',
+  'cancelled'
+] as const;
+
+export type DeliverableStatus = typeof DELIVERABLE_STATUSES[number];
+
+// ============================================================================
+// SQL Generation Helpers
+// ============================================================================
+
+/**
+ * Generate SQL CHECK constraint for a status list
+ */
+export function generateSQLCheckConstraint(
+  columnName: string,
+  statuses: readonly string[]
+): string {
+  const statusList = statuses.map(s => `'${s}'`).join(', ');
+  return `CHECK (${columnName} IN (${statusList}))`;
+}
+
+/**
+ * Generate SQL IN clause for status checks
+ */
+export function generateSQLInClause(statuses: readonly string[]): string {
+  return statuses.map(s => `'${s}'`).join(', ');
+}
+
+// ============================================================================
+// Validation Helpers
+// ============================================================================
+
+export function isValidPRDStatus(status: string): status is PRDStatus {
+  return PRD_STATUSES.includes(status as PRDStatus);
+}
+
+export function isActivePRDStatus(status: string): boolean {
+  return PRD_ACTIVE_STATUSES.includes(status as PRDStatus);
+}
+
+export function isValidSDStatus(status: string): status is SDStatus {
+  return SD_STATUSES.includes(status as SDStatus);
+}
+
+export function isActiveSDStatus(status: string): boolean {
+  return SD_ACTIVE_STATUSES.includes(status as SDStatus);
+}
+
+// ============================================================================
+// Export for SQL sync script
+// ============================================================================
+
+export const STATUS_DEFINITIONS = {
+  PRD: {
+    all: PRD_STATUSES,
+    active: PRD_ACTIVE_STATUSES,
+    exists: PRD_EXISTS_STATUSES,
+    terminal: PRD_TERMINAL_STATUSES
+  },
+  SD: {
+    all: SD_STATUSES,
+    active: SD_ACTIVE_STATUSES
+  },
+  HANDOFF: {
+    all: HANDOFF_STATUSES
+  },
+  USER_STORY: {
+    validation: USER_STORY_VALIDATION_STATUSES,
+    e2e: USER_STORY_E2E_STATUSES
+  },
+  DELIVERABLE: {
+    all: DELIVERABLE_STATUSES
+  }
+} as const;

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "validate:story-mapping": "node scripts/validate-story-test-mapping.js",
     "validate:story-mapping:verbose": "node scripts/validate-story-test-mapping.js --verbose",
     "validate:story-mapping:fix": "node scripts/validate-story-test-mapping.js --fix",
+    "validate:status-sync": "node scripts/verify-status-sync.cjs",
     "rca:list": "node scripts/root-cause-agent.js list",
     "rca:view": "node scripts/root-cause-agent.js view",
     "rca:trigger": "node scripts/root-cause-agent.js trigger",

--- a/scripts/verify-status-sync.cjs
+++ b/scripts/verify-status-sync.cjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+/**
+ * Status Synchronization Verifier
+ *
+ * Compares the single source of truth (lib/constants/status-definitions.ts)
+ * against:
+ *   1. Database CHECK constraints
+ *   2. Hardcoded status lists in SQL functions
+ *   3. JavaScript/TypeScript status checks
+ *
+ * Usage: node scripts/verify-status-sync.cjs [--fix]
+ *
+ * Exit codes:
+ *   0 - All synchronized
+ *   1 - Mismatches found
+ *   2 - Error during verification
+ */
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const fs = require('fs');
+const path = require('path');
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// Single Source of Truth (must match status-definitions.ts)
+const STATUS_DEFINITIONS = {
+  PRD: {
+    all: [
+      'draft', 'planning', 'in_progress', 'testing', 'verification',
+      'approved', 'completed', 'archived', 'rejected', 'on_hold', 'cancelled'
+    ],
+    active: [
+      'planning', 'in_progress', 'testing', 'verification', 'approved', 'completed'
+    ]
+  },
+  SD: {
+    all: [
+      'draft', 'active', 'in_progress', 'on_hold', 'completed',
+      'cancelled', 'deferred', 'pending_approval'
+    ],
+    active: ['active', 'in_progress', 'pending_approval', 'completed']
+  }
+};
+
+const issues = [];
+const warnings = [];
+
+async function checkDatabaseConstraints() {
+  console.log('\n📋 Checking database CHECK constraints...\n');
+
+  try {
+    // Get CHECK constraint definitions from information_schema
+    const { data, error } = await supabase.rpc('exec_sql', {
+      sql: `
+        SELECT
+          tc.table_name,
+          tc.constraint_name,
+          cc.check_clause
+        FROM information_schema.table_constraints tc
+        JOIN information_schema.check_constraints cc
+          ON tc.constraint_name = cc.constraint_name
+        WHERE tc.table_name IN ('product_requirements_v2', 'strategic_directives_v2')
+          AND tc.constraint_type = 'CHECK'
+          AND cc.check_clause LIKE '%status%'
+      `
+    });
+
+    if (error) {
+      // Fallback: check pg_constraint directly
+      console.log('  Using pg_constraint fallback...');
+      const { data: pgData, error: pgError } = await supabase.rpc('exec_sql', {
+        sql: `
+          SELECT
+            c.relname as table_name,
+            con.conname as constraint_name,
+            pg_get_constraintdef(con.oid) as check_clause
+          FROM pg_constraint con
+          JOIN pg_class c ON con.conrelid = c.oid
+          WHERE c.relname IN ('product_requirements_v2', 'strategic_directives_v2')
+            AND con.contype = 'c'
+            AND pg_get_constraintdef(con.oid) LIKE '%status%'
+        `
+      });
+
+      if (pgError) {
+        warnings.push(`Could not verify CHECK constraints: ${pgError.message}`);
+        return;
+      }
+
+      processConstraints(pgData);
+    } else {
+      processConstraints(data);
+    }
+  } catch (err) {
+    warnings.push(`Error checking constraints: ${err.message}`);
+  }
+}
+
+function processConstraints(constraints) {
+  if (!constraints || constraints.length === 0) {
+    warnings.push('No status CHECK constraints found in database');
+    return;
+  }
+
+  for (const constraint of constraints) {
+    const table = constraint.table_name;
+    const clause = constraint.check_clause;
+
+    // Extract status values from CHECK clause
+    const matches = clause.match(/'([^']+)'/g);
+    if (!matches) continue;
+
+    const dbStatuses = matches.map(m => m.replace(/'/g, '')).sort();
+    const sourceOfTruth = table === 'product_requirements_v2'
+      ? STATUS_DEFINITIONS.PRD.all.sort()
+      : STATUS_DEFINITIONS.SD.all.sort();
+
+    console.log(`  ${table}:`);
+    console.log(`    Constraint: ${constraint.constraint_name}`);
+    console.log(`    DB statuses: [${dbStatuses.join(', ')}]`);
+    console.log(`    Source of truth: [${sourceOfTruth.join(', ')}]`);
+
+    // Find differences
+    const missingInDb = sourceOfTruth.filter(s => !dbStatuses.includes(s));
+    const extraInDb = dbStatuses.filter(s => !sourceOfTruth.includes(s));
+
+    if (missingInDb.length > 0) {
+      issues.push({
+        type: 'CONSTRAINT_MISMATCH',
+        table,
+        message: `Missing in DB constraint: ${missingInDb.join(', ')}`
+      });
+      console.log(`    ❌ MISSING: ${missingInDb.join(', ')}`);
+    }
+
+    if (extraInDb.length > 0) {
+      warnings.push(`Extra in DB constraint (${table}): ${extraInDb.join(', ')}`);
+      console.log(`    ⚠️  EXTRA: ${extraInDb.join(', ')}`);
+    }
+
+    if (missingInDb.length === 0 && extraInDb.length === 0) {
+      console.log(`    ✅ Synchronized`);
+    }
+    console.log('');
+  }
+}
+
+async function checkDatabaseValues() {
+  console.log('📊 Checking actual status values in database...\n');
+
+  // Check PRD statuses in use
+  const { data: prdStatuses } = await supabase
+    .from('product_requirements_v2')
+    .select('status');
+
+  const uniquePrdStatuses = [...new Set(prdStatuses?.map(p => p.status))].sort();
+  console.log(`  PRD statuses in use: [${uniquePrdStatuses.join(', ')}]`);
+
+  const unknownPrdStatuses = uniquePrdStatuses.filter(
+    s => !STATUS_DEFINITIONS.PRD.all.includes(s)
+  );
+  if (unknownPrdStatuses.length > 0) {
+    issues.push({
+      type: 'UNKNOWN_STATUS',
+      table: 'product_requirements_v2',
+      message: `Unknown PRD statuses in database: ${unknownPrdStatuses.join(', ')}`
+    });
+    console.log(`  ❌ Unknown: ${unknownPrdStatuses.join(', ')}`);
+  } else {
+    console.log('  ✅ All PRD statuses recognized');
+  }
+
+  // Check SD statuses in use
+  const { data: sdStatuses } = await supabase
+    .from('strategic_directives_v2')
+    .select('status');
+
+  const uniqueSdStatuses = [...new Set(sdStatuses?.map(s => s.status))].sort();
+  console.log(`\n  SD statuses in use: [${uniqueSdStatuses.join(', ')}]`);
+
+  const unknownSdStatuses = uniqueSdStatuses.filter(
+    s => !STATUS_DEFINITIONS.SD.all.includes(s)
+  );
+  if (unknownSdStatuses.length > 0) {
+    issues.push({
+      type: 'UNKNOWN_STATUS',
+      table: 'strategic_directives_v2',
+      message: `Unknown SD statuses in database: ${unknownSdStatuses.join(', ')}`
+    });
+    console.log(`  ❌ Unknown: ${unknownSdStatuses.join(', ')}`);
+  } else {
+    console.log('  ✅ All SD statuses recognized');
+  }
+  console.log('');
+}
+
+async function checkSqlFunctions() {
+  console.log('🔍 Checking SQL function status lists...\n');
+
+  // Get function source code
+  const { data, error } = await supabase.rpc('exec_sql', {
+    sql: `
+      SELECT
+        proname as function_name,
+        pg_get_functiondef(oid) as definition
+      FROM pg_proc
+      WHERE proname IN ('calculate_sd_progress', 'get_progress_breakdown')
+      AND pronamespace = 'public'::regnamespace
+    `
+  });
+
+  if (error || !data) {
+    warnings.push(`Could not retrieve function definitions: ${error?.message || 'No data'}`);
+    return;
+  }
+
+  for (const func of data) {
+    console.log(`  ${func.function_name}:`);
+
+    // Extract status IN clauses
+    const inClauses = func.definition.match(/status\s+IN\s*\([^)]+\)/gi) || [];
+
+    for (const clause of inClauses) {
+      const matches = clause.match(/'([^']+)'/g);
+      if (!matches) continue;
+
+      const funcStatuses = matches.map(m => m.replace(/'/g, '')).sort();
+      console.log(`    Found IN clause: [${funcStatuses.join(', ')}]`);
+
+      // Check if this matches PRD active statuses or SD active statuses
+      const isPrdCheck = clause.toLowerCase().includes('product_requirements') ||
+                         func.definition.includes('prd_exists');
+      const sourceList = isPrdCheck
+        ? STATUS_DEFINITIONS.PRD.active
+        : STATUS_DEFINITIONS.SD.active;
+
+      const missing = sourceList.filter(s => !funcStatuses.includes(s));
+      if (missing.length > 0 && isPrdCheck) {
+        // Only flag as issue for PRD checks (the original bug)
+        if (missing.some(s => ['verification', 'testing', 'planning'].includes(s))) {
+          console.log(`    ⚠️  May be missing: ${missing.join(', ')}`);
+        }
+      }
+    }
+    console.log('');
+  }
+}
+
+function checkCodebaseHardcoding() {
+  console.log('📁 Checking codebase for hardcoded status lists...\n');
+
+  const filesToCheck = [
+    'src/services/status-validator.js',
+    'lib/validation/leo-schemas.ts'
+  ];
+
+  for (const file of filesToCheck) {
+    const fullPath = path.join(process.cwd(), file);
+    if (!fs.existsSync(fullPath)) {
+      console.log(`  ${file}: Not found (skipped)`);
+      continue;
+    }
+
+    const content = fs.readFileSync(fullPath, 'utf-8');
+    const prdMatches = content.match(/PRD[^}]+all:\s*\[[^\]]+\]/s);
+
+    if (prdMatches) {
+      console.log(`  ${file}: Contains PRD status definitions`);
+      // Could add detailed comparison here
+    }
+  }
+  console.log('');
+}
+
+async function testProgressCalculation() {
+  console.log('🧪 Testing progress calculation for known PRDs...\n');
+
+  // Get all PRDs with their statuses
+  const { data: prds } = await supabase
+    .from('product_requirements_v2')
+    .select('id, directive_id, status, title')
+    .limit(10);
+
+  if (!prds || prds.length === 0) {
+    console.log('  No PRDs found\n');
+    return;
+  }
+
+  for (const prd of prds) {
+    const { data: progress } = await supabase.rpc('calculate_sd_progress', {
+      sd_id_param: prd.directive_id
+    });
+
+    const isActiveStatus = STATUS_DEFINITIONS.PRD.active.includes(prd.status);
+    console.log(`  ${prd.directive_id}:`);
+    console.log(`    PRD Status: ${prd.status} (active: ${isActiveStatus})`);
+    console.log(`    Progress: ${progress}%`);
+
+    // If PRD is active but progress seems low, flag potential issue
+    if (isActiveStatus && progress < 20) {
+      warnings.push(`${prd.directive_id}: Active PRD status '${prd.status}' but low progress (${progress}%)`);
+    }
+  }
+  console.log('');
+}
+
+async function main() {
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('  STATUS SYNCHRONIZATION VERIFIER');
+  console.log('  Single Source of Truth: lib/constants/status-definitions.ts');
+  console.log('═══════════════════════════════════════════════════════════════');
+
+  try {
+    await checkDatabaseConstraints();
+    await checkDatabaseValues();
+    await checkSqlFunctions();
+    checkCodebaseHardcoding();
+    await testProgressCalculation();
+
+    // Summary
+    console.log('═══════════════════════════════════════════════════════════════');
+    console.log('  SUMMARY');
+    console.log('═══════════════════════════════════════════════════════════════\n');
+
+    if (issues.length === 0 && warnings.length === 0) {
+      console.log('✅ All status definitions are synchronized!\n');
+      process.exit(0);
+    }
+
+    if (issues.length > 0) {
+      console.log('❌ ISSUES FOUND:\n');
+      issues.forEach((issue, i) => {
+        console.log(`  ${i + 1}. [${issue.type}] ${issue.table || ''}`);
+        console.log(`     ${issue.message}\n`);
+      });
+    }
+
+    if (warnings.length > 0) {
+      console.log('⚠️  WARNINGS:\n');
+      warnings.forEach((warning, i) => {
+        console.log(`  ${i + 1}. ${warning}`);
+      });
+      console.log('');
+    }
+
+    process.exit(issues.length > 0 ? 1 : 0);
+  } catch (err) {
+    console.error('Error during verification:', err);
+    process.exit(2);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `lib/constants/status-definitions.ts` as single source of truth for all status definitions
- Fix `calculate_sd_progress` SQL function to recognize 'verification', 'testing', 'planning' PRD statuses
- Update CHECK constraint on `product_requirements_v2` table
- Add `verify-status-sync` script to prevent future drift between DB and code

## Root Cause
PRD status 'verification' was not recognized by the progress function, causing SDs to show incorrect progress percentages.

## Test plan
- [ ] Run `npm run validate:status-sync` to verify synchronization
- [ ] Apply migration to database
- [ ] Verify affected SDs now show correct progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)