### PR TITLE
feat(genesis): Add simulation firewall for mock mode isolation

### DIFF
--- a/.github/workflows/simulation-firewall-check.yml
+++ b/.github/workflows/simulation-firewall-check.yml
@@ -1,0 +1,121 @@
+# Genesis Virtual Bunker - Simulation Firewall Check
+#
+# Verifies that simulation code cannot access production resources:
+# 1. No production environment variables present
+# 2. Network isolation enforced
+# 3. Mock mode working correctly
+#
+# Part of SD-GENESIS-V31-MASON-FIREWALL
+
+name: Simulation Firewall Check
+
+on:
+  push:
+    paths:
+      - 'lib/mock/**'
+      - 'lib/genesis/**'
+      - '.github/workflows/simulation-firewall-check.yml'
+  pull_request:
+    paths:
+      - 'lib/mock/**'
+      - 'lib/genesis/**'
+      - '.github/workflows/simulation-firewall-check.yml'
+
+jobs:
+  firewall-check:
+    name: Verify Simulation Isolation
+    runs-on: ubuntu-latest
+
+    # Simulation environment - NO production secrets
+    env:
+      EHG_MOCK_MODE: 'true'
+      NODE_ENV: 'test'
+      # Explicitly do NOT include:
+      # - SUPABASE_SERVICE_ROLE_KEY
+      # - STRIPE_SECRET_KEY
+      # - Any other production secrets
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify no production env vars
+        run: |
+          echo "Checking for production secrets in environment..."
+
+          DENIED_VARS="SUPABASE_SERVICE_ROLE_KEY STRIPE_SECRET_KEY SENDGRID_API_KEY OPENAI_API_KEY"
+
+          for VAR in $DENIED_VARS; do
+            if [ -n "${!VAR}" ]; then
+              echo "::error::Production secret detected: $VAR"
+              exit 1
+            fi
+          done
+
+          echo "✅ No production secrets detected"
+
+      - name: Verify EHG_MOCK_MODE is set
+        run: |
+          if [ "$EHG_MOCK_MODE" != "true" ]; then
+            echo "::error::EHG_MOCK_MODE must be 'true' for simulation tests"
+            exit 1
+          fi
+          echo "✅ Mock mode is enabled"
+
+      - name: Run firewall unit tests
+        run: npm run test:unit -- --testPathPattern="mock/firewall" --passWithNoTests
+
+      - name: Test firewall initialization
+        run: |
+          node -e "
+            import('./lib/mock/firewall.js').then(firewall => {
+              console.log('Testing firewall initialization...');
+
+              // Test isMockMode
+              const mockEnabled = firewall.isMockMode();
+              if (!mockEnabled) {
+                console.error('ERROR: isMockMode() should return true');
+                process.exit(1);
+              }
+              console.log('✅ isMockMode() returns true');
+
+              // Test validateSimulationEnv (should pass since no prod vars)
+              const result = firewall.validateSimulationEnv({ throwOnViolation: false });
+              if (!result.valid) {
+                console.error('ERROR: Found violations:', result.violations);
+                process.exit(1);
+              }
+              console.log('✅ validateSimulationEnv() passes');
+
+              // Test assertMockMode (should not throw)
+              try {
+                firewall.assertMockMode();
+                console.log('✅ assertMockMode() passes');
+              } catch (e) {
+                console.error('ERROR: assertMockMode() threw:', e.message);
+                process.exit(1);
+              }
+
+              console.log('');
+              console.log('All firewall checks passed!');
+            });
+          "
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Simulation Firewall Check Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- Environment: \`EHG_MOCK_MODE=$EHG_MOCK_MODE\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Production secrets: **Not present** (verified)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Simulation isolation is enforced." >> $GITHUB_STEP_SUMMARY

--- a/lib/mock/firewall.js
+++ b/lib/mock/firewall.js
@@ -1,0 +1,321 @@
+/**
+ * Genesis Virtual Bunker - Mock Firewall Enforcement
+ *
+ * Ensures simulations cannot access production resources:
+ * - No real database connections
+ * - No external API calls with real credentials
+ * - No production secrets
+ * - No side effects outside the simulation
+ *
+ * @module lib/mock/firewall
+ * Part of SD-GENESIS-V31-MASON-FIREWALL
+ */
+
+/**
+ * Canonical environment variable for mock mode detection.
+ * Matches playwright.config.ts for consistency.
+ */
+export const MOCK_MODE_ENV_VAR = 'EHG_MOCK_MODE';
+
+/**
+ * Environment variables that are DENIED in simulation mode.
+ * If any of these are present, the simulation should not start.
+ */
+export const DENIED_ENV_VARS = [
+  'SUPABASE_SERVICE_ROLE_KEY',  // Production DB access with elevated privileges
+  'STRIPE_SECRET_KEY',          // Payment processing
+  'STRIPE_WEBHOOK_SECRET',      // Payment webhooks
+  'SENDGRID_API_KEY',           // Email sending
+  'TWILIO_AUTH_TOKEN',          // SMS sending
+  'AWS_SECRET_ACCESS_KEY',      // Cloud resources
+  'OPENAI_API_KEY',             // AI API (use mock in simulation)
+  'ANTHROPIC_API_KEY',          // Claude API
+  'GOOGLE_CLOUD_KEY',           // Google Cloud
+  'DATABASE_URL',               // Direct database URL (if using real connection string)
+];
+
+/**
+ * Hosts allowed in simulation mode.
+ * All other hosts will have requests blocked or mocked.
+ */
+export const ALLOWED_HOSTS = [
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  /.*\.vercel\.app$/,    // Vercel preview URLs
+  /.*\.localhost$/,      // Local subdomains
+];
+
+/**
+ * Check if mock mode is enabled.
+ *
+ * Mock mode can be enabled via:
+ * 1. Environment variable: EHG_MOCK_MODE=true
+ * 2. URL parameter: ?mock=true
+ * 3. LocalStorage: mockMode=true
+ *
+ * @returns {boolean} True if mock mode is enabled
+ */
+export function isMockMode() {
+  // Browser environment checks
+  if (typeof window !== 'undefined') {
+    // Check URL parameter
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('mock') === 'true') return true;
+
+    // Check localStorage
+    try {
+      if (localStorage.getItem('mockMode') === 'true') return true;
+    } catch {
+      // localStorage may not be available
+    }
+  }
+
+  // Environment variable check (Node.js or bundled)
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env[MOCK_MODE_ENV_VAR] === 'true';
+  }
+
+  return false;
+}
+
+/**
+ * Assert that mock mode is enabled.
+ * Throws an error if mock mode is not enabled.
+ *
+ * Use this at the start of simulation-only code paths.
+ *
+ * @throws {Error} If mock mode is not enabled
+ */
+export function assertMockMode() {
+  if (!isMockMode()) {
+    throw new Error(
+      'SIMULATION FIREWALL: This code requires mock mode. ' +
+      'Set EHG_MOCK_MODE=true or add ?mock=true to URL. ' +
+      'Production resources are not available in simulation context.'
+    );
+  }
+}
+
+/**
+ * Validate that no denied environment variables are present.
+ * This should be called at simulation startup to ensure no production
+ * secrets can leak into the simulation.
+ *
+ * @param {Object} options - Validation options
+ * @param {boolean} [options.throwOnViolation=true] - Whether to throw on violation
+ * @param {string[]} [options.additionalDenied=[]] - Additional env vars to deny
+ * @returns {{ valid: boolean, violations: string[] }} Validation result
+ * @throws {Error} If throwOnViolation is true and violations found
+ */
+export function validateSimulationEnv(options = {}) {
+  const { throwOnViolation = true, additionalDenied = [] } = options;
+
+  const allDenied = [...DENIED_ENV_VARS, ...additionalDenied];
+  const violations = [];
+
+  for (const envVar of allDenied) {
+    if (typeof process !== 'undefined' && process.env && process.env[envVar]) {
+      violations.push(envVar);
+    }
+  }
+
+  const result = {
+    valid: violations.length === 0,
+    violations,
+  };
+
+  if (!result.valid && throwOnViolation) {
+    throw new Error(
+      'SIMULATION FIREWALL: Production secrets detected! ' +
+      'The following environment variables are not allowed in simulation mode: ' +
+      `${violations.join(', ')}. ` +
+      'Please unset these variables or use a separate simulation environment.'
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Check if a hostname is allowed in simulation mode.
+ *
+ * @param {string} hostname - The hostname to check
+ * @returns {boolean} True if the hostname is allowed
+ */
+export function isAllowedHost(hostname) {
+  for (const allowed of ALLOWED_HOSTS) {
+    if (typeof allowed === 'string') {
+      if (hostname === allowed) return true;
+    } else if (allowed instanceof RegExp) {
+      if (allowed.test(hostname)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Generate a mock response for a blocked network request.
+ *
+ * @param {string|URL} url - The blocked URL
+ * @param {string} [reason='blocked'] - The reason for blocking
+ * @returns {Response} A mock Response object
+ */
+export function mockBlockedResponse(url, reason = 'blocked') {
+  const body = JSON.stringify({
+    error: 'SIMULATION_FIREWALL_BLOCKED',
+    message: `Request to ${url} was blocked by the simulation firewall`,
+    reason,
+    mock: true,
+  });
+
+  return new Response(body, {
+    status: 403,
+    statusText: 'Forbidden - Simulation Firewall',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Simulation-Firewall': 'blocked',
+    },
+  });
+}
+
+// Store original fetch for restoration
+let originalFetch = null;
+let isInterceptorInstalled = false;
+
+/**
+ * Install network interceptor for simulation mode.
+ * Intercepts fetch calls and blocks requests to non-allowed hosts.
+ *
+ * @param {Object} options - Interceptor options
+ * @param {boolean} [options.logBlocked=true] - Whether to log blocked requests
+ * @param {Function} [options.mockProvider] - Custom mock response provider
+ */
+export function installNetworkInterceptor(options = {}) {
+  const { logBlocked = true, mockProvider } = options;
+
+  if (!isMockMode()) {
+    console.warn('[Firewall] Network interceptor not installed - mock mode is off');
+    return;
+  }
+
+  if (isInterceptorInstalled) {
+    console.warn('[Firewall] Network interceptor already installed');
+    return;
+  }
+
+  if (typeof globalThis.fetch !== 'function') {
+    console.warn('[Firewall] fetch not available in this environment');
+    return;
+  }
+
+  originalFetch = globalThis.fetch;
+  isInterceptorInstalled = true;
+
+  globalThis.fetch = async (input, init) => {
+    let url;
+    try {
+      url = typeof input === 'string' ? new URL(input) : new URL(input.url);
+    } catch {
+      // If URL parsing fails, it's likely a relative URL - allow it
+      return originalFetch(input, init);
+    }
+
+    const hostname = url.hostname;
+
+    if (!isAllowedHost(hostname)) {
+      if (logBlocked) {
+        console.warn(`[Firewall] Blocked request to: ${hostname}${url.pathname}`);
+      }
+
+      // Use custom mock provider if available
+      if (mockProvider) {
+        return mockProvider(url, init);
+      }
+
+      return mockBlockedResponse(url.toString());
+    }
+
+    return originalFetch(input, init);
+  };
+
+  console.log('[Firewall] Network interceptor installed for simulation mode');
+}
+
+/**
+ * Uninstall network interceptor and restore original fetch.
+ */
+export function uninstallNetworkInterceptor() {
+  if (!isInterceptorInstalled || !originalFetch) {
+    return;
+  }
+
+  globalThis.fetch = originalFetch;
+  originalFetch = null;
+  isInterceptorInstalled = false;
+
+  console.log('[Firewall] Network interceptor uninstalled');
+}
+
+/**
+ * Initialize simulation firewall.
+ * Runs all validation checks and installs interceptors.
+ *
+ * @param {Object} options - Initialization options
+ * @param {boolean} [options.validateEnv=true] - Validate environment variables
+ * @param {boolean} [options.installInterceptor=true] - Install network interceptor
+ * @param {boolean} [options.strict=true] - Throw on any violation
+ * @returns {{ initialized: boolean, warnings: string[] }}
+ */
+export function initSimulationFirewall(options = {}) {
+  const {
+    validateEnv = true,
+    installInterceptor = true,
+    strict = true,
+  } = options;
+
+  const warnings = [];
+
+  // Verify mock mode is enabled
+  if (!isMockMode()) {
+    if (strict) {
+      throw new Error('SIMULATION FIREWALL: Mock mode must be enabled');
+    }
+    warnings.push('Mock mode is not enabled');
+    return { initialized: false, warnings };
+  }
+
+  // Validate environment
+  if (validateEnv) {
+    try {
+      validateSimulationEnv({ throwOnViolation: strict });
+    } catch (err) {
+      if (strict) throw err;
+      warnings.push(err.message);
+    }
+  }
+
+  // Install network interceptor
+  if (installInterceptor) {
+    installNetworkInterceptor();
+  }
+
+  console.log('[Firewall] Simulation firewall initialized');
+
+  return { initialized: true, warnings };
+}
+
+// Export all functions as default object for convenience
+export default {
+  MOCK_MODE_ENV_VAR,
+  DENIED_ENV_VARS,
+  ALLOWED_HOSTS,
+  isMockMode,
+  assertMockMode,
+  validateSimulationEnv,
+  isAllowedHost,
+  mockBlockedResponse,
+  installNetworkInterceptor,
+  uninstallNetworkInterceptor,
+  initSimulationFirewall,
+};

--- a/lib/mock/simulation-supabase-client.js
+++ b/lib/mock/simulation-supabase-client.js
@@ -1,0 +1,329 @@
+/**
+ * Genesis Virtual Bunker - Simulation Supabase Client
+ *
+ * Returns a mock Supabase client that doesn't connect to real database.
+ * All operations return mock data.
+ *
+ * @module lib/mock/simulation-supabase-client
+ * Part of SD-GENESIS-V31-MASON-FIREWALL
+ */
+
+import { assertMockMode } from './firewall.js';
+
+/**
+ * Mock data storage for simulation.
+ * Tables can be seeded with test data.
+ */
+const mockTables = new Map();
+
+/**
+ * Create a mock table client that simulates Supabase table operations.
+ *
+ * @param {string} tableName - The table name
+ * @returns {Object} Mock table client with Supabase-like API
+ */
+function mockTableClient(tableName) {
+  // Initialize table if not exists
+  if (!mockTables.has(tableName)) {
+    mockTables.set(tableName, []);
+  }
+
+  let filters = [];
+  let selectColumns = '*';
+  let orderConfig = null;
+  let limitCount = null;
+  let singleMode = false;
+
+  const builder = {
+    select(columns = '*') {
+      selectColumns = columns;
+      return builder;
+    },
+
+    insert(data) {
+      const rows = Array.isArray(data) ? data : [data];
+      const table = mockTables.get(tableName);
+      const inserted = rows.map(row => ({
+        id: row.id || crypto.randomUUID(),
+        ...row,
+        created_at: row.created_at || new Date().toISOString(),
+      }));
+      table.push(...inserted);
+      return {
+        select() {
+          return {
+            single() {
+              return Promise.resolve({ data: inserted[0], error: null });
+            },
+            then(resolve) {
+              resolve({ data: inserted, error: null });
+            }
+          };
+        },
+        then(resolve) {
+          resolve({ data: inserted, error: null });
+        }
+      };
+    },
+
+    update(data) {
+      return {
+        eq(column, value) {
+          const table = mockTables.get(tableName);
+          const index = table.findIndex(row => row[column] === value);
+          if (index >= 0) {
+            table[index] = { ...table[index], ...data };
+            return Promise.resolve({ data: table[index], error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        match(criteria) {
+          const table = mockTables.get(tableName);
+          const updated = [];
+          table.forEach((row, index) => {
+            if (Object.entries(criteria).every(([k, v]) => row[k] === v)) {
+              table[index] = { ...row, ...data };
+              updated.push(table[index]);
+            }
+          });
+          return Promise.resolve({ data: updated, error: null });
+        }
+      };
+    },
+
+    delete() {
+      return {
+        eq(column, value) {
+          const table = mockTables.get(tableName);
+          const index = table.findIndex(row => row[column] === value);
+          if (index >= 0) {
+            const deleted = table.splice(index, 1);
+            return Promise.resolve({ data: deleted[0], error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        match(criteria) {
+          const table = mockTables.get(tableName);
+          const deleted = [];
+          for (let i = table.length - 1; i >= 0; i--) {
+            if (Object.entries(criteria).every(([k, v]) => table[i][k] === v)) {
+              deleted.push(...table.splice(i, 1));
+            }
+          }
+          return Promise.resolve({ data: deleted, error: null });
+        }
+      };
+    },
+
+    eq(column, value) {
+      filters.push({ type: 'eq', column, value });
+      return builder;
+    },
+
+    neq(column, value) {
+      filters.push({ type: 'neq', column, value });
+      return builder;
+    },
+
+    ilike(column, value) {
+      filters.push({ type: 'ilike', column, value });
+      return builder;
+    },
+
+    in(column, values) {
+      filters.push({ type: 'in', column, values });
+      return builder;
+    },
+
+    order(column, options = {}) {
+      orderConfig = { column, ascending: options.ascending !== false };
+      return builder;
+    },
+
+    limit(count) {
+      limitCount = count;
+      return builder;
+    },
+
+    single() {
+      singleMode = true;
+      return builder;
+    },
+
+    then(resolve) {
+      let results = [...mockTables.get(tableName)];
+
+      // Apply filters
+      for (const filter of filters) {
+        switch (filter.type) {
+          case 'eq':
+            results = results.filter(r => r[filter.column] === filter.value);
+            break;
+          case 'neq':
+            results = results.filter(r => r[filter.column] !== filter.value);
+            break;
+          case 'ilike': {
+            const pattern = filter.value.replace(/%/g, '.*').toLowerCase();
+            const regex = new RegExp(pattern);
+            results = results.filter(r => regex.test(String(r[filter.column]).toLowerCase()));
+            break;
+          }
+          case 'in':
+            results = results.filter(r => filter.values.includes(r[filter.column]));
+            break;
+        }
+      }
+
+      // Apply order
+      if (orderConfig) {
+        results.sort((a, b) => {
+          const aVal = a[orderConfig.column];
+          const bVal = b[orderConfig.column];
+          const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+          return orderConfig.ascending ? cmp : -cmp;
+        });
+      }
+
+      // Apply limit
+      if (limitCount !== null) {
+        results = results.slice(0, limitCount);
+      }
+
+      // Return single or array
+      if (singleMode) {
+        resolve({ data: results[0] || null, error: null });
+      } else {
+        resolve({ data: results, error: null });
+      }
+    }
+  };
+
+  return builder;
+}
+
+/**
+ * Create a mock auth client that simulates Supabase auth.
+ *
+ * @returns {Object} Mock auth client
+ */
+function mockAuthClient() {
+  let currentUser = null;
+
+  return {
+    getUser() {
+      return Promise.resolve({
+        data: { user: currentUser },
+        error: null
+      });
+    },
+
+    getSession() {
+      return Promise.resolve({
+        data: {
+          session: currentUser ? {
+            user: currentUser,
+            access_token: 'mock-access-token',
+            refresh_token: 'mock-refresh-token',
+            expires_at: Date.now() + 3600000,
+          } : null
+        },
+        error: null
+      });
+    },
+
+    signInWithPassword({ email, password }) {
+      // Accept any credentials in mock mode
+      currentUser = {
+        id: crypto.randomUUID(),
+        email,
+        created_at: new Date().toISOString(),
+        app_metadata: {},
+        user_metadata: {},
+        aud: 'authenticated',
+        role: 'authenticated',
+      };
+      return Promise.resolve({
+        data: { user: currentUser, session: { user: currentUser } },
+        error: null
+      });
+    },
+
+    signOut() {
+      currentUser = null;
+      return Promise.resolve({ error: null });
+    },
+
+    onAuthStateChange(callback) {
+      // Return mock unsubscribe
+      return {
+        data: {
+          subscription: {
+            unsubscribe: () => {}
+          }
+        }
+      };
+    },
+
+    // Mock user for testing
+    _setMockUser(user) {
+      currentUser = user;
+    }
+  };
+}
+
+/**
+ * Get a simulation Supabase client.
+ * This client operates entirely in memory and doesn't connect to any database.
+ *
+ * @returns {Object} Mock Supabase client
+ * @throws {Error} If mock mode is not enabled
+ */
+export function getSimulationClient() {
+  assertMockMode();
+
+  return {
+    from: (tableName) => mockTableClient(tableName),
+    auth: mockAuthClient(),
+
+    // Utility methods for testing
+    _seedTable(tableName, data) {
+      mockTables.set(tableName, Array.isArray(data) ? [...data] : [data]);
+    },
+
+    _clearTable(tableName) {
+      mockTables.set(tableName, []);
+    },
+
+    _clearAll() {
+      mockTables.clear();
+    },
+
+    _getTableData(tableName) {
+      return mockTables.get(tableName) || [];
+    }
+  };
+}
+
+/**
+ * Seed mock tables with test data.
+ *
+ * @param {Object} seedData - Object mapping table names to arrays of rows
+ */
+export function seedMockData(seedData) {
+  for (const [tableName, rows] of Object.entries(seedData)) {
+    mockTables.set(tableName, Array.isArray(rows) ? [...rows] : [rows]);
+  }
+}
+
+/**
+ * Clear all mock data.
+ */
+export function clearMockData() {
+  mockTables.clear();
+}
+
+export default {
+  getSimulationClient,
+  seedMockData,
+  clearMockData,
+};

--- a/tests/unit/mock/firewall.test.js
+++ b/tests/unit/mock/firewall.test.js
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for Genesis Mock Firewall
+ * Part of SD-GENESIS-V31-MASON-FIREWALL
+ */
+
+import { jest } from '@jest/globals';
+
+// Store original env and fetch
+const originalEnv = { ...process.env };
+let originalFetch;
+
+beforeEach(() => {
+  // Reset modules to get fresh state
+  jest.resetModules();
+  // Restore original env
+  process.env = { ...originalEnv };
+  // Store original fetch
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  // Restore env
+  process.env = originalEnv;
+  // Restore fetch if it was modified
+  if (originalFetch) {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+describe('Mock Firewall', () => {
+  describe('isMockMode', () => {
+    it('should return true when EHG_MOCK_MODE is true', async () => {
+      process.env.EHG_MOCK_MODE = 'true';
+      const { isMockMode } = await import('../../../lib/mock/firewall.js');
+      expect(isMockMode()).toBe(true);
+    });
+
+    it('should return false when EHG_MOCK_MODE is not set', async () => {
+      delete process.env.EHG_MOCK_MODE;
+      const { isMockMode } = await import('../../../lib/mock/firewall.js');
+      expect(isMockMode()).toBe(false);
+    });
+
+    it('should return false when EHG_MOCK_MODE is false', async () => {
+      process.env.EHG_MOCK_MODE = 'false';
+      const { isMockMode } = await import('../../../lib/mock/firewall.js');
+      expect(isMockMode()).toBe(false);
+    });
+  });
+
+  describe('assertMockMode', () => {
+    it('should not throw when mock mode is enabled', async () => {
+      process.env.EHG_MOCK_MODE = 'true';
+      const { assertMockMode } = await import('../../../lib/mock/firewall.js');
+      expect(() => assertMockMode()).not.toThrow();
+    });
+
+    it('should throw when mock mode is disabled', async () => {
+      delete process.env.EHG_MOCK_MODE;
+      const { assertMockMode } = await import('../../../lib/mock/firewall.js');
+      expect(() => assertMockMode()).toThrow('SIMULATION FIREWALL');
+    });
+
+    it('should include helpful message in error', async () => {
+      delete process.env.EHG_MOCK_MODE;
+      const { assertMockMode } = await import('../../../lib/mock/firewall.js');
+      expect(() => assertMockMode()).toThrow('EHG_MOCK_MODE=true');
+    });
+  });
+
+  describe('validateSimulationEnv', () => {
+    it('should pass when no denied vars are present', async () => {
+      process.env.EHG_MOCK_MODE = 'true';
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+      delete process.env.STRIPE_SECRET_KEY;
+
+      const { validateSimulationEnv } = await import('../../../lib/mock/firewall.js');
+      const result = validateSimulationEnv({ throwOnViolation: false });
+
+      expect(result.valid).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('should fail when SUPABASE_SERVICE_ROLE_KEY is present', async () => {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = 'secret-key';
+
+      const { validateSimulationEnv } = await import('../../../lib/mock/firewall.js');
+      const result = validateSimulationEnv({ throwOnViolation: false });
+
+      expect(result.valid).toBe(false);
+      expect(result.violations).toContain('SUPABASE_SERVICE_ROLE_KEY');
+    });
+
+    it('should throw when throwOnViolation is true', async () => {
+      process.env.STRIPE_SECRET_KEY = 'secret';
+
+      const { validateSimulationEnv } = await import('../../../lib/mock/firewall.js');
+      expect(() => validateSimulationEnv({ throwOnViolation: true }))
+        .toThrow('SIMULATION FIREWALL');
+    });
+
+    it('should check additional denied vars', async () => {
+      process.env.CUSTOM_SECRET = 'secret';
+
+      const { validateSimulationEnv } = await import('../../../lib/mock/firewall.js');
+      const result = validateSimulationEnv({
+        throwOnViolation: false,
+        additionalDenied: ['CUSTOM_SECRET']
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.violations).toContain('CUSTOM_SECRET');
+    });
+  });
+
+  describe('isAllowedHost', () => {
+    it('should allow localhost', async () => {
+      const { isAllowedHost } = await import('../../../lib/mock/firewall.js');
+      expect(isAllowedHost('localhost')).toBe(true);
+    });
+
+    it('should allow 127.0.0.1', async () => {
+      const { isAllowedHost } = await import('../../../lib/mock/firewall.js');
+      expect(isAllowedHost('127.0.0.1')).toBe(true);
+    });
+
+    it('should allow vercel.app subdomains', async () => {
+      const { isAllowedHost } = await import('../../../lib/mock/firewall.js');
+      expect(isAllowedHost('my-app-123.vercel.app')).toBe(true);
+    });
+
+    it('should block external hosts', async () => {
+      const { isAllowedHost } = await import('../../../lib/mock/firewall.js');
+      expect(isAllowedHost('api.stripe.com')).toBe(false);
+      expect(isAllowedHost('supabase.co')).toBe(false);
+      expect(isAllowedHost('google.com')).toBe(false);
+    });
+  });
+
+  describe('mockBlockedResponse', () => {
+    it('should return 403 status', async () => {
+      const { mockBlockedResponse } = await import('../../../lib/mock/firewall.js');
+      const response = mockBlockedResponse('https://api.stripe.com/v1/charges');
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should include firewall header', async () => {
+      const { mockBlockedResponse } = await import('../../../lib/mock/firewall.js');
+      const response = mockBlockedResponse('https://api.stripe.com/v1/charges');
+
+      expect(response.headers.get('X-Simulation-Firewall')).toBe('blocked');
+    });
+
+    it('should include JSON error body', async () => {
+      const { mockBlockedResponse } = await import('../../../lib/mock/firewall.js');
+      const response = mockBlockedResponse('https://api.stripe.com/v1/charges');
+      const body = await response.json();
+
+      expect(body.error).toBe('SIMULATION_FIREWALL_BLOCKED');
+      expect(body.mock).toBe(true);
+    });
+  });
+
+  describe('initSimulationFirewall', () => {
+    it('should fail when mock mode is not enabled', async () => {
+      delete process.env.EHG_MOCK_MODE;
+
+      const { initSimulationFirewall } = await import('../../../lib/mock/firewall.js');
+      const result = initSimulationFirewall({ strict: false });
+
+      expect(result.initialized).toBe(false);
+      expect(result.warnings).toContain('Mock mode is not enabled');
+    });
+
+    it('should initialize when mock mode is enabled', async () => {
+      process.env.EHG_MOCK_MODE = 'true';
+
+      const { initSimulationFirewall } = await import('../../../lib/mock/firewall.js');
+      const result = initSimulationFirewall({
+        validateEnv: true,
+        installInterceptor: false  // Don't modify fetch in tests
+      });
+
+      expect(result.initialized).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds simulation firewall to isolate mock mode from production
- Creates mock Supabase client for safe testing
- Adds GitHub workflow for firewall validation
- Includes comprehensive unit tests

## Files Added
- `lib/mock/firewall.js` - Core firewall logic
- `lib/mock/simulation-supabase-client.js` - Mock Supabase client
- `.github/workflows/simulation-firewall-check.yml` - CI validation
- `tests/unit/mock/firewall.test.js` - Unit tests

## Test Plan
- [x] Unit tests included
- [x] GitHub workflow for CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)