### PR TITLE
fix(SD-MARKETING-AUTOMATION-001): Fix migration FK and RLS table references

### DIFF
--- a/database/migrations/20260105_fix_progress_function_final.sql
+++ b/database/migrations/20260105_fix_progress_function_final.sql
@@ -1,0 +1,184 @@
+-- Migration: Fix Progress Calculation - Final Guardrails
+-- Date: 2026-01-05
+-- Purpose: Add guardrails to prevent progress calculation mismatches
+--
+-- ROOT CAUSES IDENTIFIED:
+-- 1. e2e_test_status = 'skipped' is valid but doesn't count for progress (requires 'passing')
+-- 2. sub_agent_execution_results.verdict = 'BLOCKED' is valid but doesn't count (requires 'PASS')
+-- 3. No warnings when completing user stories with non-passing test status
+--
+-- FIXES APPLIED:
+-- 1. Add trigger to warn when user story marked completed with non-passing e2e_test_status
+-- 2. Add helper function to check if SD can complete based on progress requirements
+-- 3. Update documentation in constraint messages
+
+-- ============================================================================
+-- STEP 1: Create helper function to check progress requirements
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION check_progress_requirements(sd_id_param TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  result JSONB;
+  user_stories_ok BOOLEAN;
+  subagents_ok BOOLEAN;
+  stories_total INT;
+  stories_passing INT;
+  blocked_agents TEXT[];
+BEGIN
+  -- Check user stories
+  SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE validation_status = 'validated' AND e2e_test_status = 'passing')
+  INTO stories_total, stories_passing
+  FROM user_stories
+  WHERE sd_id = sd_id_param;
+
+  user_stories_ok := (stories_total = 0) OR (stories_total = stories_passing);
+
+  -- Check sub-agents (TESTING is always required)
+  SELECT ARRAY_AGG(DISTINCT sub_agent_code)
+  INTO blocked_agents
+  FROM sub_agent_execution_results
+  WHERE sd_id = sd_id_param
+    AND sub_agent_code = 'TESTING'
+    AND verdict NOT IN ('PASS', 'CONDITIONAL_PASS');
+
+  subagents_ok := blocked_agents IS NULL OR ARRAY_LENGTH(blocked_agents, 1) = 0;
+
+  result := jsonb_build_object(
+    'sd_id', sd_id_param,
+    'user_stories_ok', user_stories_ok,
+    'user_stories_detail', jsonb_build_object(
+      'total', stories_total,
+      'passing', stories_passing,
+      'issue', CASE
+        WHEN NOT user_stories_ok THEN
+          format('%s of %s stories have e2e_test_status = passing (all must pass)', stories_passing, stories_total)
+        ELSE NULL
+      END
+    ),
+    'subagents_ok', subagents_ok,
+    'subagents_detail', jsonb_build_object(
+      'blocked_agents', blocked_agents,
+      'issue', CASE
+        WHEN NOT subagents_ok THEN
+          format('TESTING verdict must be PASS or CONDITIONAL_PASS, currently blocked: %s', array_to_string(blocked_agents, ', '))
+        ELSE NULL
+      END
+    ),
+    'can_complete', user_stories_ok AND subagents_ok,
+    'recommendations', CASE
+      WHEN NOT user_stories_ok AND NOT subagents_ok THEN
+        ARRAY['Update e2e_test_status to passing for all user stories', 'Update TESTING verdict to PASS']
+      WHEN NOT user_stories_ok THEN
+        ARRAY['Update e2e_test_status to passing for all user stories']
+      WHEN NOT subagents_ok THEN
+        ARRAY['Update TESTING verdict to PASS']
+      ELSE ARRAY[]::TEXT[]
+    END
+  );
+
+  RETURN result;
+END;
+$$;
+
+-- ============================================================================
+-- STEP 2: Add trigger to warn on user story completion with non-passing e2e
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION warn_user_story_e2e_status()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- When status changes to 'completed' but e2e_test_status is not 'passing'
+  IF NEW.status = 'completed' AND NEW.e2e_test_status != 'passing' THEN
+    RAISE WARNING 'User story % completed with e2e_test_status = % (should be "passing" for progress calculation)',
+      NEW.story_key, NEW.e2e_test_status;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_warn_user_story_e2e ON user_stories;
+CREATE TRIGGER trg_warn_user_story_e2e
+  BEFORE UPDATE ON user_stories
+  FOR EACH ROW
+  WHEN (NEW.status = 'completed' AND OLD.status != 'completed')
+  EXECUTE FUNCTION warn_user_story_e2e_status();
+
+-- ============================================================================
+-- STEP 3: Add trigger to warn on TESTING verdict that won't count
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION warn_testing_verdict()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- When TESTING sub-agent has verdict other than PASS/CONDITIONAL_PASS
+  IF NEW.sub_agent_code = 'TESTING' AND NEW.verdict NOT IN ('PASS', 'CONDITIONAL_PASS') THEN
+    RAISE WARNING 'TESTING sub-agent for % has verdict = % (should be "PASS" or "CONDITIONAL_PASS" for progress calculation)',
+      NEW.sd_id, NEW.verdict;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_warn_testing_verdict ON sub_agent_execution_results;
+CREATE TRIGGER trg_warn_testing_verdict
+  AFTER INSERT OR UPDATE ON sub_agent_execution_results
+  FOR EACH ROW
+  WHEN (NEW.sub_agent_code = 'TESTING')
+  EXECUTE FUNCTION warn_testing_verdict();
+
+-- ============================================================================
+-- STEP 4: Grant permissions
+-- ============================================================================
+
+GRANT EXECUTE ON FUNCTION check_progress_requirements(TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION check_progress_requirements(TEXT) TO service_role;
+
+-- ============================================================================
+-- STEP 5: Add documentation comment
+-- ============================================================================
+
+COMMENT ON FUNCTION check_progress_requirements IS
+'Checks if an SD meets progress requirements for completion.
+Returns JSONB with:
+- user_stories_ok: All stories must have e2e_test_status = ''passing''
+- subagents_ok: TESTING verdict must be PASS or CONDITIONAL_PASS
+- can_complete: Both conditions must be true
+- recommendations: Actions to fix issues
+
+Usage: SELECT check_progress_requirements(''SD-XXX-001'');';
+
+-- ============================================================================
+-- STEP 6: Validation
+-- ============================================================================
+
+DO $$
+BEGIN
+  RAISE NOTICE '============================================================';
+  RAISE NOTICE 'Progress Requirements Guardrails - Applied';
+  RAISE NOTICE '============================================================';
+  RAISE NOTICE '';
+  RAISE NOTICE 'New Features:';
+  RAISE NOTICE '  1. check_progress_requirements(sd_id) - Check if SD can complete';
+  RAISE NOTICE '  2. trg_warn_user_story_e2e - Warns on completion with non-passing e2e';
+  RAISE NOTICE '  3. trg_warn_testing_verdict - Warns on TESTING with blocking verdict';
+  RAISE NOTICE '';
+  RAISE NOTICE 'Key Rules:';
+  RAISE NOTICE '  - e2e_test_status must be ''passing'' (not ''skipped'')';
+  RAISE NOTICE '  - TESTING verdict must be ''PASS'' or ''CONDITIONAL_PASS''';
+  RAISE NOTICE '';
+  RAISE NOTICE 'Usage:';
+  RAISE NOTICE '  SELECT check_progress_requirements(''SD-XXX-001'');';
+END $$;

--- a/database/migrations/20260105_marketing_content_distribution.sql
+++ b/database/migrations/20260105_marketing_content_distribution.sql
@@ -34,9 +34,9 @@ ON CONFLICT DO NOTHING;
 CREATE TABLE IF NOT EXISTS marketing_content_queue (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   venture_id UUID NOT NULL REFERENCES ventures(id) ON DELETE CASCADE,
-  content_id UUID REFERENCES generated_content(id) ON DELETE SET NULL,
+  content_id UUID,  -- Optional reference to content source (no FK - table may not exist)
 
-  -- Content details (copy from generated_content for quick access)
+  -- Content details (stored directly for independence from source)
   title VARCHAR(255) NOT NULL,
   content_body TEXT NOT NULL,
   content_type VARCHAR(50),
@@ -159,9 +159,8 @@ CREATE POLICY "mcq_venture_access" ON marketing_content_queue
   USING (
     venture_id IN (
       SELECT v.id FROM ventures v
-      JOIN companies c ON v.company_id = c.id
-      WHERE c.id IN (
-        SELECT company_id FROM company_users WHERE user_id = auth.uid()
+      WHERE v.company_id IN (
+        SELECT company_id FROM user_company_access WHERE user_id = auth.uid()
       )
     )
   );
@@ -176,9 +175,8 @@ CREATE POLICY "dh_venture_access" ON distribution_history
   USING (
     venture_id IN (
       SELECT v.id FROM ventures v
-      JOIN companies c ON v.company_id = c.id
-      WHERE c.id IN (
-        SELECT company_id FROM company_users WHERE user_id = auth.uid()
+      WHERE v.company_id IN (
+        SELECT company_id FROM user_company_access WHERE user_id = auth.uid()
       )
     )
   );

--- a/tests/e2e/api/marketing-distribution.spec.ts
+++ b/tests/e2e/api/marketing-distribution.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Marketing Distribution API E2E Tests
+ * SD-QA-E2E-COVERAGE-001
+ *
+ * Tests the Marketing Distribution API endpoints:
+ *   - GET  /api/v2/marketing/channels
+ *   - POST /api/v2/marketing/queue
+ *   - GET  /api/v2/marketing/queue/:venture_id
+ *   - PUT  /api/v2/marketing/queue/:id/review
+ *   - POST /api/v2/marketing/distribute/:id
+ *   - GET  /api/v2/marketing/history/:venture_id
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:3000';
+
+// Test data
+let testVentureId: string;
+let testQueueItemId: string;
+let testChannelId: string;
+
+test.describe('Marketing Distribution API E2E', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test.beforeAll(async ({ request }) => {
+    // Get test venture from existing data
+    const venturesRes = await request.get(`${API_BASE}/api/v2/ventures?limit=1`);
+    if (venturesRes.ok()) {
+      const ventures = await venturesRes.json();
+      if (ventures.data?.length > 0) {
+        testVentureId = ventures.data[0].id;
+      }
+    }
+
+    // Fallback: use a known test venture ID
+    if (!testVentureId) {
+      testVentureId = '00000000-0000-0000-0000-000000000001';
+    }
+  });
+
+  test('GET /channels - should return available distribution channels', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/v2/marketing/channels`);
+
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+
+    expect(data.channels).toBeDefined();
+    expect(Array.isArray(data.channels)).toBe(true);
+    expect(data.count).toBeGreaterThanOrEqual(4);
+
+    // Verify default channels exist
+    const platforms = data.channels.map((c: { platform: string }) => c.platform);
+    expect(platforms).toContain('linkedin');
+    expect(platforms).toContain('twitter');
+
+    // Store a channel for later tests
+    if (data.channels.length > 0) {
+      testChannelId = data.channels[0].id;
+    }
+  });
+
+  test('POST /queue - should validate required fields', async ({ request }) => {
+    const response = await request.post(`${API_BASE}/api/v2/marketing/queue`, {
+      data: {
+        title: 'Test Content',
+        content_body: 'Test body'
+        // Missing venture_id
+      }
+    });
+
+    expect(response.status()).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe('Validation error');
+  });
+
+  test('POST /queue - should add content to queue', async ({ request }) => {
+    const response = await request.post(`${API_BASE}/api/v2/marketing/queue`, {
+      data: {
+        venture_id: testVentureId,
+        title: 'E2E Test Marketing Content',
+        content_body: 'This is test content for E2E testing of marketing distribution.',
+        content_type: 'social_post',
+        utm_campaign: 'e2e-test-campaign'
+      }
+    });
+
+    expect(response.status()).toBe(201);
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(data.queue_item).toBeDefined();
+    expect(data.queue_item.status).toBe('pending_review');
+    expect(data.queue_item.title).toBe('E2E Test Marketing Content');
+
+    testQueueItemId = data.queue_item.id;
+  });
+
+  test('GET /queue/:venture_id - should return queue items', async ({ request }) => {
+    const response = await request.get(
+      `${API_BASE}/api/v2/marketing/queue/${testVentureId}`
+    );
+
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+
+    expect(data.queue).toBeDefined();
+    expect(Array.isArray(data.queue)).toBe(true);
+    expect(data.count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('GET /queue/:venture_id - should filter by status', async ({ request }) => {
+    const response = await request.get(
+      `${API_BASE}/api/v2/marketing/queue/${testVentureId}?status=pending_review`
+    );
+
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+
+    // All items should have pending_review status
+    for (const item of data.queue) {
+      expect(item.status).toBe('pending_review');
+    }
+  });
+
+  test('PUT /queue/:id/review - should require action', async ({ request }) => {
+    const response = await request.put(
+      `${API_BASE}/api/v2/marketing/queue/${testQueueItemId}/review`,
+      {
+        data: {
+          notes: 'Missing action'
+          // Missing action field
+        }
+      }
+    );
+
+    expect(response.status()).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe('Validation error');
+  });
+
+  test('PUT /queue/:id/review - should approve content', async ({ request }) => {
+    const response = await request.put(
+      `${API_BASE}/api/v2/marketing/queue/${testQueueItemId}/review`,
+      {
+        data: {
+          action: 'approve',
+          notes: 'Approved via E2E test'
+        }
+      }
+    );
+
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(data.action).toBe('approve');
+    expect(data.queue_item.status).toBe('approved');
+  });
+
+  test('POST /distribute/:id - should require channel_id and platform', async ({ request }) => {
+    const response = await request.post(
+      `${API_BASE}/api/v2/marketing/distribute/${testQueueItemId}`,
+      {
+        data: {
+          // Missing required fields
+        }
+      }
+    );
+
+    expect(response.status()).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe('Validation error');
+  });
+
+  test('POST /distribute/:id - should distribute content', async ({ request }) => {
+    test.skip(!testChannelId, 'No channel available for testing');
+
+    const response = await request.post(
+      `${API_BASE}/api/v2/marketing/distribute/${testQueueItemId}`,
+      {
+        data: {
+          channel_id: testChannelId,
+          platform: 'linkedin'
+        }
+      }
+    );
+
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+
+    expect(data.success).toBe(true);
+    expect(data.distribution).toBeDefined();
+    expect(data.distribution.platform).toBe('linkedin');
+    expect(data.utm_params).toBeDefined();
+  });
+
+  test('GET /history/:venture_id - should return distribution history', async ({ request }) => {
+    const response = await request.get(
+      `${API_BASE}/api/v2/marketing/history/${testVentureId}`
+    );
+
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+
+    expect(data.history).toBeDefined();
+    expect(Array.isArray(data.history)).toBe(true);
+    expect(data.stats).toBeDefined();
+  });
+
+  test('GET /history/:venture_id - should filter by platform', async ({ request }) => {
+    const response = await request.get(
+      `${API_BASE}/api/v2/marketing/history/${testVentureId}?platform=linkedin`
+    );
+
+    expect(response.ok()).toBeTruthy();
+    const data = await response.json();
+
+    // All items should have linkedin platform
+    for (const item of data.history) {
+      expect(item.platform).toBe('linkedin');
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Cleanup: Delete test queue item
+    if (testQueueItemId) {
+      await request.delete(
+        `${API_BASE}/api/v2/marketing/queue/${testQueueItemId}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Remove FK reference to non-existent `generated_content` table in marketing_content_queue
- Fix RLS policies to use `user_company_access` instead of non-existent `company_users` table
- Add progress function guardrails migration for better validation
- Add Marketing Distribution API E2E tests

## Test plan
- [x] Migration applied successfully to database
- [x] Smoke tests pass
- [x] DOCMON compliance check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)