### PR TITLE
feat(cli): add interactive LEO command center and hooks setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sync-app": "node scripts/sync-manager.js",
     "create-app-sd": "node scripts/create-app-sd.js",
     "deploy-sd": "node scripts/deploy-sd-to-app.js",
-    "leo": "node scripts/leo.js",
+    "leo": "node scripts/run-leo.cjs",
     "leo-status": "node scripts/leo-status-line.js show",
     "build:loader": "tsc -p tsconfig.json",
     "test:loader:dry": "node dist/services/database-loader/index.js --dry-run",
@@ -202,8 +202,6 @@
     "leo:continuous": "node scripts/leo-continuous.js",
     "leo:continuous:start": "node scripts/leo-continuous.js --start",
     "leo:continuous:status": "node scripts/leo-continuous.js --status",
-    "leo:prompt": "node scripts/leo-continuous-prompt.js",
-    "leo:prompt:short": "node scripts/leo-continuous-prompt.js --short",
     "leo:checkpoint": "node scripts/lib/leo-checkpoint.js",
     "leo:checkpoint:validate": "node scripts/lib/leo-checkpoint.js validate",
     "leo:checkpoint:history": "node scripts/lib/leo-checkpoint.js history",
@@ -241,7 +239,10 @@
     "leo:cleanup:root:force": "node scripts/cleanup-root-temp-files.js --force",
     "untrack:manifest": "node scripts/generate-untrack-manifest.js",
     "untrack:execute": "node scripts/execute-untrack-manifest.js",
-    "untrack:execute:force": "node scripts/execute-untrack-manifest.js --force"
+    "untrack:execute:force": "node scripts/execute-untrack-manifest.js --force",
+    "hooks:setup": "node scripts/setup-global-hooks.cjs",
+    "hooks:recover": "node scripts/hooks/recover-session-state.cjs",
+    "hooks:baseline": "node scripts/hooks/compare-test-baseline.cjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.63.0",

--- a/scripts/run-leo.cjs
+++ b/scripts/run-leo.cjs
@@ -1,0 +1,574 @@
+#!/usr/bin/env node
+
+/**
+ * Run LEO - Interactive LEO Protocol Entry Point
+ *
+ * Unified command center for all LEO Protocol operations
+ * with intuitive multiple choice interface.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const { execSync, spawn } = require('child_process');
+
+const ENGINEER_DIR = '/mnt/c/_EHG/EHG_Engineer';
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+function question(prompt) {
+  return new Promise(resolve => rl.question(prompt, resolve));
+}
+
+function clearScreen() {
+  console.clear();
+}
+
+function printHeader() {
+  console.log('\n' + '═'.repeat(60));
+  console.log('  🦁 LEO PROTOCOL - Command Center');
+  console.log('  LEAD → PLAN → EXEC');
+  console.log('═'.repeat(60) + '\n');
+}
+
+function printMenu(title, options) {
+  console.log(`📋 ${title}\n`);
+  options.forEach((opt, i) => {
+    const rec = opt.recommended ? ' ⭐' : '';
+    console.log(`  ${i + 1}. ${opt.label}${rec}`);
+    if (opt.description) {
+      console.log(`     ${opt.description}\n`);
+    }
+  });
+  console.log('-'.repeat(60));
+}
+
+async function selectOption(title, options) {
+  clearScreen();
+  printHeader();
+  printMenu(title, options);
+
+  while (true) {
+    const answer = await question(`Select [1-${options.length}]: `);
+    const num = parseInt(answer);
+    if (num >= 1 && num <= options.length) {
+      return options[num - 1];
+    }
+    console.log('Invalid selection. Try again.');
+  }
+}
+
+function runCommand(cmd, options = {}) {
+  console.log(`\n▶ Running: ${cmd}\n`);
+  try {
+    execSync(cmd, {
+      stdio: 'inherit',
+      cwd: options.cwd || ENGINEER_DIR,
+      ...options
+    });
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function getActiveSD() {
+  try {
+    const result = execSync(`node -e "
+      const { createClient } = require('@supabase/supabase-js');
+      require('dotenv').config();
+      const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+      async function get() {
+        const { data } = await supabase.from('strategic_directives_v2').select('id, title, current_phase, status').eq('is_working_on', true).single();
+        if (data) console.log(JSON.stringify(data));
+      }
+      get();
+    "`, { encoding: 'utf8', cwd: ENGINEER_DIR }).trim();
+    return result ? JSON.parse(result) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function getRecentSDs() {
+  try {
+    const result = execSync(`node -e "
+      const { createClient } = require('@supabase/supabase-js');
+      require('dotenv').config();
+      const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+      async function get() {
+        const { data } = await supabase.from('strategic_directives_v2')
+          .select('id, title, current_phase, status')
+          .in('status', ['draft', 'in_progress', 'active', 'planning'])
+          .order('updated_at', { ascending: false })
+          .limit(5);
+        console.log(JSON.stringify(data || []));
+      }
+      get();
+    "`, { encoding: 'utf8', cwd: ENGINEER_DIR }).trim();
+    return JSON.parse(result);
+  } catch {
+    return [];
+  }
+}
+
+// ============================================================
+// MAIN MENU
+// ============================================================
+
+async function mainMenu() {
+  const activeSD = await getActiveSD();
+
+  const options = [];
+
+  if (activeSD) {
+    options.push({
+      id: 'continue',
+      label: `Continue: ${activeSD.id}`,
+      description: `Phase: ${activeSD.current_phase} | ${activeSD.title.substring(0, 40)}...`,
+      recommended: true,
+      action: () => continueSD(activeSD)
+    });
+  }
+
+  options.push({
+    id: 'queue',
+    label: 'View SD Queue',
+    description: 'See all READY Strategic Directives and pick one',
+    recommended: !activeSD,
+    action: viewQueue
+  });
+
+  options.push({
+    id: 'start',
+    label: 'Start Specific SD',
+    description: 'Enter an SD ID to begin work',
+    action: startSpecificSD
+  });
+
+  options.push({
+    id: 'status',
+    label: 'Check Status',
+    description: 'View baseline progress and recent activity',
+    action: checkStatus
+  });
+
+  options.push({
+    id: 'setup',
+    label: 'Setup & Configuration',
+    description: 'Configure hooks, settings, and tools',
+    action: setupMenu
+  });
+
+  options.push({
+    id: 'recovery',
+    label: 'Session Recovery',
+    description: 'Recover from crash or view session state',
+    action: recoveryMenu
+  });
+
+  options.push({
+    id: 'exit',
+    label: 'Exit',
+    description: 'Close LEO Command Center',
+    action: () => process.exit(0)
+  });
+
+  const selected = await selectOption('What would you like to do?', options);
+  await selected.action();
+}
+
+// ============================================================
+// CONTINUE SD
+// ============================================================
+
+async function continueSD(sd) {
+  const options = [
+    {
+      id: 'prompt',
+      label: 'Get Continuous Execution Prompt',
+      description: 'Copy-paste prompt for continuous LEO mode',
+      recommended: true,
+      action: () => {
+        runCommand(`npm run leo:prompt ${sd.id}`);
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'handoff',
+      label: 'Execute Next Handoff',
+      description: `Current phase: ${sd.current_phase}`,
+      action: () => executeHandoffMenu(sd)
+    },
+    {
+      id: 'status',
+      label: 'View SD Details',
+      description: 'See full status, user stories, and handoffs',
+      action: () => {
+        runCommand(`node -e "
+          const { createClient } = require('@supabase/supabase-js');
+          require('dotenv').config();
+          const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+          async function get() {
+            const { data: sd } = await supabase.from('strategic_directives_v2').select('*').eq('id', '${sd.id}').single();
+            const { data: stories } = await supabase.from('user_stories').select('story_key, status, title').eq('sd_id', '${sd.id}');
+            console.log('\\n' + '═'.repeat(60));
+            console.log('SD:', sd.id);
+            console.log('Title:', sd.title);
+            console.log('Status:', sd.status, '| Phase:', sd.current_phase);
+            console.log('Progress:', sd.progress_percentage + '%');
+            console.log('-'.repeat(60));
+            console.log('User Stories:', stories?.length || 0);
+            stories?.forEach(s => console.log('  ', s.status === 'completed' ? '✓' : '○', s.story_key, '-', s.title?.substring(0,40)));
+            console.log('═'.repeat(60));
+          }
+          get();
+        "`);
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'back',
+      label: '← Back to Main Menu',
+      action: mainMenu
+    }
+  ];
+
+  const selected = await selectOption(`Continue: ${sd.id}`, options);
+  await selected.action();
+}
+
+// ============================================================
+// HANDOFF MENU
+// ============================================================
+
+async function executeHandoffMenu(sd) {
+  const phase = sd.current_phase;
+  const handoffs = [];
+
+  if (phase === 'LEAD' || phase === 'draft') {
+    handoffs.push({ type: 'LEAD-TO-PLAN', desc: 'Move to PLAN phase for PRD creation' });
+  }
+  if (phase === 'PLAN' || phase === 'PLAN_PRD' || phase === 'planning') {
+    handoffs.push({ type: 'PLAN-TO-EXEC', desc: 'Move to EXEC phase for implementation' });
+  }
+  if (phase === 'EXEC' || phase === 'in_progress' || phase === 'active') {
+    handoffs.push({ type: 'PLAN-TO-LEAD', desc: 'Move to LEAD for final approval' });
+  }
+  if (phase === 'pending_approval') {
+    handoffs.push({ type: 'LEAD-FINAL-APPROVAL', desc: 'Complete the SD' });
+  }
+
+  const options = handoffs.map(h => ({
+    id: h.type,
+    label: h.type,
+    description: h.desc,
+    recommended: true,
+    action: () => {
+      runCommand(`node scripts/handoff.js execute ${h.type} ${sd.id}`);
+      return promptAfterAction();
+    }
+  }));
+
+  options.push({
+    id: 'back',
+    label: '← Back',
+    action: () => continueSD(sd)
+  });
+
+  const selected = await selectOption('Select Handoff to Execute', options);
+  await selected.action();
+}
+
+// ============================================================
+// VIEW QUEUE
+// ============================================================
+
+async function viewQueue() {
+  runCommand('npm run sd:next');
+  await promptAfterAction();
+}
+
+// ============================================================
+// START SPECIFIC SD
+// ============================================================
+
+async function startSpecificSD() {
+  clearScreen();
+  printHeader();
+
+  const recentSDs = await getRecentSDs();
+
+  if (recentSDs.length > 0) {
+    console.log('📋 Recent SDs:\n');
+    recentSDs.forEach((sd, i) => {
+      console.log(`  ${i + 1}. ${sd.id}`);
+      console.log(`     ${sd.title?.substring(0, 50)}...`);
+      console.log(`     Phase: ${sd.current_phase} | Status: ${sd.status}\n`);
+    });
+    console.log('-'.repeat(60));
+    console.log('Enter a number to select, or type an SD ID directly.\n');
+  }
+
+  const answer = await question('SD ID or number: ');
+
+  let sdId = answer.trim();
+  const num = parseInt(answer);
+  if (num >= 1 && num <= recentSDs.length) {
+    sdId = recentSDs[num - 1].id;
+  }
+
+  if (!sdId || sdId.toLowerCase() === 'back') {
+    return mainMenu();
+  }
+
+  const options = [
+    {
+      id: 'prompt',
+      label: 'Get Continuous Execution Prompt',
+      description: 'Copy-paste prompt for continuous LEO mode',
+      recommended: true,
+      action: () => {
+        runCommand(`npm run leo:prompt ${sdId}`);
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'start',
+      label: 'Start with LEAD-TO-PLAN Handoff',
+      description: 'Begin the LEO workflow',
+      action: () => {
+        runCommand(`node scripts/handoff.js execute LEAD-TO-PLAN ${sdId}`);
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'back',
+      label: '← Back to Main Menu',
+      action: mainMenu
+    }
+  ];
+
+  const selected = await selectOption(`Start: ${sdId}`, options);
+  await selected.action();
+}
+
+// ============================================================
+// CHECK STATUS
+// ============================================================
+
+async function checkStatus() {
+  const options = [
+    {
+      id: 'baseline',
+      label: 'Baseline Progress',
+      description: 'Overall SD completion vs baseline',
+      recommended: true,
+      action: () => {
+        runCommand('npm run sd:status');
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'burnrate',
+      label: 'Velocity & Burnrate',
+      description: 'SD completion velocity and forecasting',
+      action: () => {
+        runCommand('npm run sd:burnrate');
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'test-baseline',
+      label: 'Test Baseline Comparison',
+      description: 'Compare current test state to session baseline',
+      action: () => {
+        runCommand('npm run hooks:baseline');
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'back',
+      label: '← Back to Main Menu',
+      action: mainMenu
+    }
+  ];
+
+  const selected = await selectOption('Status & Metrics', options);
+  await selected.action();
+}
+
+// ============================================================
+// SETUP MENU
+// ============================================================
+
+async function setupMenu() {
+  const options = [
+    {
+      id: 'hooks',
+      label: 'Configure Global Hooks',
+      description: 'Set up automatic session init, baseline capture, etc.',
+      recommended: true,
+      action: () => {
+        runCommand('npm run hooks:setup');
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'stack',
+      label: 'LEO Stack Management',
+      description: 'Start/stop/restart LEO servers',
+      action: stackMenu
+    },
+    {
+      id: 'back',
+      label: '← Back to Main Menu',
+      action: mainMenu
+    }
+  ];
+
+  const selected = await selectOption('Setup & Configuration', options);
+  await selected.action();
+}
+
+async function stackMenu() {
+  const options = [
+    {
+      id: 'status',
+      label: 'Check Stack Status',
+      action: () => {
+        runCommand('bash scripts/leo-stack.sh status');
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'restart',
+      label: 'Restart All Servers',
+      action: () => {
+        runCommand('bash scripts/leo-stack.sh restart');
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'stop',
+      label: 'Stop All Servers',
+      action: () => {
+        runCommand('bash scripts/leo-stack.sh stop');
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'back',
+      label: '← Back',
+      action: setupMenu
+    }
+  ];
+
+  const selected = await selectOption('LEO Stack Management', options);
+  await selected.action();
+}
+
+// ============================================================
+// RECOVERY MENU
+// ============================================================
+
+async function recoveryMenu() {
+  const options = [
+    {
+      id: 'recover',
+      label: 'Recover Session State',
+      description: 'Restore from last checkpoint after crash',
+      recommended: true,
+      action: () => {
+        runCommand('npm run hooks:recover');
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'view',
+      label: 'View Current Session State',
+      description: 'See what\'s stored in session state',
+      action: () => {
+        const statePath = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
+        if (fs.existsSync(statePath)) {
+          const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+          console.log('\n' + '═'.repeat(60));
+          console.log('SESSION STATE');
+          console.log('═'.repeat(60));
+          console.log('Session ID:', state.session_id);
+          console.log('Current SD:', state.current_sd || 'none');
+          console.log('Current Phase:', state.current_phase || 'unknown');
+          console.log('Tool Executions:', state.tool_executions);
+          console.log('Last Activity:', state.last_activity);
+          console.log('Test Baseline:', state.test_baseline ? 'captured' : 'not captured');
+          console.log('Checkpoints:', state.checkpoints?.length || 0);
+          console.log('═'.repeat(60));
+        } else {
+          console.log('\nNo session state found. Start a new session first.');
+        }
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'clear',
+      label: 'Clear Session State',
+      description: 'Start fresh (deletes checkpoints)',
+      action: async () => {
+        const confirm = await question('\nAre you sure? This deletes all checkpoints. [y/N]: ');
+        if (confirm.toLowerCase() === 'y') {
+          const statePath = path.join(process.env.HOME || '/tmp', '.claude-session-state.json');
+          const checkpointDir = path.join(process.env.HOME || '/tmp', '.claude-checkpoints');
+          if (fs.existsSync(statePath)) fs.unlinkSync(statePath);
+          if (fs.existsSync(checkpointDir)) {
+            fs.readdirSync(checkpointDir).forEach(f => fs.unlinkSync(path.join(checkpointDir, f)));
+          }
+          console.log('✅ Session state cleared.');
+        }
+        return promptAfterAction();
+      }
+    },
+    {
+      id: 'back',
+      label: '← Back to Main Menu',
+      action: mainMenu
+    }
+  ];
+
+  const selected = await selectOption('Session Recovery', options);
+  await selected.action();
+}
+
+// ============================================================
+// HELPERS
+// ============================================================
+
+async function promptAfterAction() {
+  console.log();
+  const answer = await question('Press Enter to continue (or type "exit" to quit): ');
+  if (answer.toLowerCase() === 'exit' || answer.toLowerCase() === 'q') {
+    rl.close();
+    process.exit(0);
+  }
+  return mainMenu();
+}
+
+// ============================================================
+// ENTRY POINT
+// ============================================================
+
+async function main() {
+  try {
+    await mainMenu();
+  } catch (error) {
+    if (error.message !== 'readline was closed') {
+      console.error('Error:', error.message);
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+main();

--- a/scripts/setup-global-hooks.cjs
+++ b/scripts/setup-global-hooks.cjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+
+/**
+ * Interactive Global Hooks Setup
+ * SD-CLAUDE-CODE-2.1.0-LEO-001
+ *
+ * Configures Claude Code global hooks via an intuitive CLI interface.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const SETTINGS_PATH = '/mnt/c/_EHG/EHG_Engineer/.claude/settings.json';
+const HOOKS_DIR = '/mnt/c/_EHG/EHG_Engineer/scripts/hooks';
+
+// Available hooks with descriptions
+const AVAILABLE_HOOKS = {
+  PreToolUse: [
+    {
+      id: 'session-init',
+      name: 'Session Initialization',
+      description: 'Detects current SD from git branch, initializes session state',
+      script: 'session-init.cjs',
+      once: true,
+      recommended: true
+    },
+    {
+      id: 'baseline-capture',
+      name: 'Test Baseline Capture',
+      description: 'Captures test state at session start to distinguish new vs pre-existing failures',
+      script: 'capture-baseline-test-state.cjs',
+      once: true,
+      recommended: true
+    }
+  ],
+  PostToolUse: [
+    {
+      id: 'model-tracking',
+      name: 'Model Tracking',
+      description: 'Logs which Claude model is used for auditing',
+      script: 'model-tracking.cjs',
+      once: false,
+      recommended: false
+    },
+    {
+      id: 'session-persist',
+      name: 'Session Persistence',
+      description: 'Creates checkpoints for crash recovery (every 5 tools or 2 min)',
+      script: 'persist-session-state.cjs',
+      once: false,
+      recommended: true
+    }
+  ],
+  Stop: [
+    {
+      id: 'final-persist',
+      name: 'Final State Persistence',
+      description: 'Saves final session state when Claude Code exits',
+      script: 'persist-session-state.cjs',
+      once: false,
+      recommended: false
+    }
+  ]
+};
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+function question(prompt) {
+  return new Promise(resolve => rl.question(prompt, resolve));
+}
+
+function clearScreen() {
+  console.clear();
+}
+
+function printHeader() {
+  console.log('\n' + '═'.repeat(60));
+  console.log('  🔧 CLAUDE CODE GLOBAL HOOKS SETUP');
+  console.log('  Configure automatic hooks for all sessions');
+  console.log('═'.repeat(60) + '\n');
+}
+
+function printHookInfo(hook, index, selected) {
+  const checkbox = selected ? '[✓]' : '[ ]';
+  const rec = hook.recommended ? ' (Recommended)' : '';
+  const once = hook.once ? ' [runs once]' : ' [runs every tool]';
+
+  console.log(`  ${checkbox} ${index}. ${hook.name}${rec}`);
+  console.log(`      ${hook.description}`);
+  console.log(`      Script: ${hook.script}${once}`);
+  console.log();
+}
+
+async function selectHooks(hookType, hooks) {
+  const selected = new Set(hooks.filter(h => h.recommended).map(h => h.id));
+
+  while (true) {
+    clearScreen();
+    printHeader();
+    console.log(`📋 ${hookType} Hooks\n`);
+    console.log('These hooks run ' + (hookType === 'PreToolUse' ? 'BEFORE' : hookType === 'PostToolUse' ? 'AFTER' : 'WHEN') + ' each tool execution.\n');
+
+    hooks.forEach((hook, i) => {
+      printHookInfo(hook, i + 1, selected.has(hook.id));
+    });
+
+    console.log('-'.repeat(60));
+    console.log('Commands: [number] toggle, [a] select all, [n] select none, [d] done\n');
+
+    const answer = await question('> ');
+
+    if (answer.toLowerCase() === 'd' || answer.toLowerCase() === 'done') {
+      break;
+    } else if (answer.toLowerCase() === 'a' || answer.toLowerCase() === 'all') {
+      hooks.forEach(h => selected.add(h.id));
+    } else if (answer.toLowerCase() === 'n' || answer.toLowerCase() === 'none') {
+      selected.clear();
+    } else {
+      const num = parseInt(answer);
+      if (num >= 1 && num <= hooks.length) {
+        const hook = hooks[num - 1];
+        if (selected.has(hook.id)) {
+          selected.delete(hook.id);
+        } else {
+          selected.add(hook.id);
+        }
+      }
+    }
+  }
+
+  return hooks.filter(h => selected.has(h.id));
+}
+
+async function runQuickSetup() {
+  clearScreen();
+  printHeader();
+
+  console.log('📦 QUICK SETUP OPTIONS\n');
+  console.log('  1. Minimal (Recommended)');
+  console.log('     Session init + Baseline capture + Crash recovery');
+  console.log('     Best for most users\n');
+  console.log('  2. Full');
+  console.log('     All hooks enabled including model tracking');
+  console.log('     Best for detailed auditing\n');
+  console.log('  3. Custom');
+  console.log('     Choose individual hooks\n');
+  console.log('  4. None');
+  console.log('     Disable all global hooks\n');
+  console.log('  5. Exit');
+  console.log('     Cancel without changes\n');
+
+  const answer = await question('Select option [1-5]: ');
+
+  switch (answer) {
+    case '1':
+      return {
+        PreToolUse: AVAILABLE_HOOKS.PreToolUse.filter(h => h.recommended),
+        PostToolUse: AVAILABLE_HOOKS.PostToolUse.filter(h => h.recommended),
+        Stop: []
+      };
+    case '2':
+      return {
+        PreToolUse: AVAILABLE_HOOKS.PreToolUse,
+        PostToolUse: AVAILABLE_HOOKS.PostToolUse,
+        Stop: AVAILABLE_HOOKS.Stop
+      };
+    case '3':
+      return null; // Signal to run custom setup
+    case '4':
+      return { PreToolUse: [], PostToolUse: [], Stop: [] };
+    case '5':
+    default:
+      return 'exit';
+  }
+}
+
+async function runCustomSetup() {
+  const selectedHooks = {
+    PreToolUse: await selectHooks('PreToolUse', AVAILABLE_HOOKS.PreToolUse),
+    PostToolUse: await selectHooks('PostToolUse', AVAILABLE_HOOKS.PostToolUse),
+    Stop: await selectHooks('Stop', AVAILABLE_HOOKS.Stop)
+  };
+  return selectedHooks;
+}
+
+function buildHooksConfig(selectedHooks) {
+  const config = {};
+
+  for (const [hookType, hooks] of Object.entries(selectedHooks)) {
+    if (hooks.length > 0) {
+      config[hookType] = hooks.map(hook => {
+        const entry = {
+          command: `node ${HOOKS_DIR}/${hook.script}`
+        };
+        if (hook.once) {
+          entry.once = true;
+        }
+        return entry;
+      });
+    }
+  }
+
+  return config;
+}
+
+function loadSettings() {
+  try {
+    if (fs.existsSync(SETTINGS_PATH)) {
+      return JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+    }
+  } catch (error) {
+    console.error('Warning: Could not load existing settings:', error.message);
+  }
+  return {};
+}
+
+function saveSettings(settings) {
+  const dir = path.dirname(SETTINGS_PATH);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
+}
+
+async function confirmAndSave(hooksConfig) {
+  clearScreen();
+  printHeader();
+
+  console.log('📋 CONFIGURATION SUMMARY\n');
+
+  let totalHooks = 0;
+  for (const [hookType, hooks] of Object.entries(hooksConfig)) {
+    if (hooks && hooks.length > 0) {
+      console.log(`${hookType}:`);
+      hooks.forEach(h => {
+        const once = h.once ? ' (once)' : '';
+        console.log(`  • ${h.command}${once}`);
+        totalHooks++;
+      });
+      console.log();
+    }
+  }
+
+  if (totalHooks === 0) {
+    console.log('  No hooks will be enabled.\n');
+  }
+
+  console.log('-'.repeat(60));
+  const answer = await question('\nSave this configuration? [Y/n]: ');
+
+  if (answer.toLowerCase() !== 'n' && answer.toLowerCase() !== 'no') {
+    const settings = loadSettings();
+    settings.hooks = hooksConfig;
+    saveSettings(settings);
+
+    console.log('\n✅ Configuration saved to .claude/settings.json');
+    console.log('\n📍 Hooks will be active on your next Claude Code session.');
+
+    if (totalHooks > 0) {
+      console.log('\n💡 Quick commands:');
+      console.log('   • Recover from crash: node scripts/hooks/recover-session-state.cjs');
+      console.log('   • Compare baseline:   node scripts/hooks/compare-test-baseline.cjs');
+    }
+
+    return true;
+  }
+
+  console.log('\n❌ Configuration not saved.');
+  return false;
+}
+
+async function main() {
+  try {
+    let selectedHooks = await runQuickSetup();
+
+    if (selectedHooks === 'exit') {
+      console.log('\nSetup cancelled.\n');
+      rl.close();
+      return;
+    }
+
+    if (selectedHooks === null) {
+      selectedHooks = await runCustomSetup();
+    }
+
+    const hooksConfig = buildHooksConfig(selectedHooks);
+    await confirmAndSave(hooksConfig);
+
+  } catch (error) {
+    console.error('Error:', error.message);
+  } finally {
+    rl.close();
+  }
+}
+
+// Run if executed directly
+if (require.main === module) {
+  main();
+}
+
+module.exports = { AVAILABLE_HOOKS, buildHooksConfig };


### PR DESCRIPTION
## Summary
- Add `npm run leo` - Interactive LEO command center with multiple choice menus
- Add `npm run hooks:setup` - Configure global hooks with intuitive interface
- Main menu options: Continue SD, View Queue, Start Specific SD, Check Status, Setup, Recovery
- Hooks setup options: Minimal (recommended), Full, Custom, None

## Test plan
- [ ] Run `npm run leo` and verify menu displays correctly
- [ ] Run `npm run hooks:setup` and verify configuration saves to .claude/settings.json
- [ ] Test each menu option navigates to correct sub-menu
- [ ] Verify exit options work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)