### PR TITLE
feat(hooks): smart email notifications with 15-minute threshold

### DIFF
--- a/.claude/notify-email.sh
+++ b/.claude/notify-email.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Claude Code Email Notification via Resend
 # Sends an email when Claude needs user input
+#
+# SMART EMAIL: Only sends if task ran longer than threshold (15 min default)
+# This prevents email spam during quick back-and-forth interactions.
 
 # Load environment variables from .env if available
 if [ -f "/mnt/c/_EHG/EHG_Engineer/.env" ]; then
@@ -14,6 +17,32 @@ TO_EMAIL="${CLAUDE_NOTIFY_EMAIL:-}"
 if [ -z "$RESEND_API_KEY" ] || [ -z "$TO_EMAIL" ]; then
     echo "Email notification not configured. Set RESEND_API_KEY and CLAUDE_NOTIFY_EMAIL."
     exit 0
+fi
+
+# ============================================================
+# SMART EMAIL THRESHOLD CHECK
+# Only send email if elapsed time since last user input > threshold
+# ============================================================
+STATE_FILE="/tmp/claude-last-user-input.timestamp"
+THRESHOLD_SECONDS="${CLAUDE_EMAIL_THRESHOLD:-900}"  # Default 15 minutes (900 seconds)
+
+# Check if state file exists
+if [ -f "$STATE_FILE" ]; then
+    LAST_INPUT=$(cat "$STATE_FILE")
+    NOW=$(date +%s)
+    ELAPSED=$((NOW - LAST_INPUT))
+    ELAPSED_MINUTES=$((ELAPSED / 60))
+
+    if [ "$ELAPSED" -lt "$THRESHOLD_SECONDS" ]; then
+        # Short interaction - skip email, bell sound is enough
+        echo "Skipping email: only ${ELAPSED_MINUTES}m elapsed (threshold: $((THRESHOLD_SECONDS / 60))m)"
+        exit 0
+    fi
+
+    echo "Sending email: ${ELAPSED_MINUTES}m elapsed (threshold: $((THRESHOLD_SECONDS / 60))m)"
+else
+    # No state file = first run or state lost, send email to be safe
+    echo "No timestamp found, sending email"
 fi
 
 # Message based on notification type

--- a/.claude/record-user-input.sh
+++ b/.claude/record-user-input.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Record timestamp when user submits input to Claude Code
+# Used by notify-email.sh to determine if email should be sent
+
+STATE_FILE="/tmp/claude-last-user-input.timestamp"
+
+# Record current timestamp
+date +%s > "$STATE_FILE"
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,17 @@
     "command": "/mnt/c/_EHG/EHG_Engineer/.claude/statusline-context-tracker.sh"
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/record-user-input.sh",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
- Only send email notification if task ran longer than 15 minutes
- Add `UserPromptSubmit` hook to track when user last provided input
- Add `record-user-input.sh` to save timestamp on each user input
- Bell sound still fires immediately for all completions
- Configurable via `CLAUDE_EMAIL_THRESHOLD` env var (default 900 seconds)

## How it works
1. When user submits input → timestamp saved to `/tmp/claude-last-user-input.timestamp`
2. When Claude completes → check elapsed time since last input
3. If < 15 minutes → bell only (no email spam)
4. If ≥ 15 minutes → bell + email

## Test plan
- [x] Verified notify-email.sh logic
- [x] Verified record-user-input.sh writes timestamp
- [x] Verified settings.json has UserPromptSubmit hook
- [ ] Manual test: quick interaction should skip email
- [ ] Manual test: 15+ min task should send email

🤖 Generated with [Claude Code](https://claude.com/claude-code)