### PR TITLE
feat(capabilities): Automated Capability Ledger with Plane 1 Integration (SD-CAP-LEDGER-001)

### DIFF
--- a/database/migrations/20260108_capability_ledger_v2.sql
+++ b/database/migrations/20260108_capability_ledger_v2.sql
@@ -1,0 +1,369 @@
+-- Migration: Capability Ledger V2 - Enhanced Taxonomy and Plane 1 Integration
+-- SD: SD-CAP-LEDGER-001 | US-002
+-- Date: 2026-01-08
+-- Purpose: Extend sd_capabilities with comprehensive taxonomy and Plane 1 scoring
+-- Based on: Ground-Truth Triangulation Synthesis recommendations
+
+-- ============================================================================
+-- PHASE 1: Expand capability_type constraint with full taxonomy
+-- ============================================================================
+
+-- Drop existing constraint to replace with expanded version
+ALTER TABLE sd_capabilities
+  DROP CONSTRAINT IF EXISTS sd_capabilities_capability_type_check;
+
+-- Add expanded capability_type constraint with full taxonomy
+-- Categories: ai_automation, infrastructure, application, integration, governance
+ALTER TABLE sd_capabilities
+  ADD CONSTRAINT sd_capabilities_capability_type_check
+  CHECK (capability_type IN (
+    -- AI & Automation
+    'agent', 'crew', 'tool', 'skill',
+    -- Infrastructure
+    'database_schema', 'database_function', 'rls_policy', 'migration',
+    -- Application
+    'api_endpoint', 'component', 'hook', 'service', 'utility',
+    -- Integration
+    'workflow', 'webhook', 'external_integration',
+    -- Governance
+    'validation_rule', 'quality_gate', 'protocol'
+  ));
+
+COMMENT ON COLUMN sd_capabilities.capability_type IS
+'Capability type from formal taxonomy. Categories: ai_automation (agent, crew, tool, skill), infrastructure (database_schema, database_function, rls_policy, migration), application (api_endpoint, component, hook, service, utility), integration (workflow, webhook, external_integration), governance (validation_rule, quality_gate, protocol)';
+
+-- ============================================================================
+-- PHASE 2: Add capability metadata columns
+-- ============================================================================
+
+-- 2.1: Category column for grouping
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS category VARCHAR(50);
+
+-- Update category based on capability_type
+UPDATE sd_capabilities
+SET category = CASE
+  WHEN capability_type IN ('agent', 'crew', 'tool', 'skill') THEN 'ai_automation'
+  WHEN capability_type IN ('database_schema', 'database_function', 'rls_policy', 'migration') THEN 'infrastructure'
+  WHEN capability_type IN ('api_endpoint', 'component', 'hook', 'service', 'utility') THEN 'application'
+  WHEN capability_type IN ('workflow', 'webhook', 'external_integration') THEN 'integration'
+  WHEN capability_type IN ('validation_rule', 'quality_gate', 'protocol') THEN 'governance'
+  ELSE 'application' -- Default fallback
+END
+WHERE category IS NULL;
+
+-- Add constraint for category
+ALTER TABLE sd_capabilities
+  ADD CONSTRAINT sd_capabilities_category_check
+  CHECK (category IN ('ai_automation', 'infrastructure', 'application', 'integration', 'governance'));
+
+-- 2.2: Human-readable name and description
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS name VARCHAR(200);
+
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS description TEXT;
+
+-- ============================================================================
+-- PHASE 3: Add Plane 1 scoring fields
+-- ============================================================================
+-- Plane 1 (Capability Graph) scoring components:
+-- - Graph Centrality Gain (0-5): How central to capability graph
+-- - Maturity Lift (0-5): What maturity level does this add
+-- - Extraction Clarity (0-5): How reusable/extractable
+
+-- 3.1: Maturity score (0-5)
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS maturity_score INTEGER DEFAULT 0
+  CHECK (maturity_score >= 0 AND maturity_score <= 5);
+
+COMMENT ON COLUMN sd_capabilities.maturity_score IS
+'Maturity level 0-5. Per taxonomy criteria: 0=concept, 1=basic, 2=functional, 3=reliable, 4=production-grade, 5=fully autonomous/published';
+
+-- 3.2: Extraction score (0-5) - How reusable
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS extraction_score INTEGER DEFAULT 0
+  CHECK (extraction_score >= 0 AND extraction_score <= 5);
+
+COMMENT ON COLUMN sd_capabilities.extraction_score IS
+'Extraction/reusability level 0-5. Per taxonomy: 0=hardcoded, 1=configurable, 2=adaptable, 3=generic, 4=published, 5=marketplace-ready';
+
+-- 3.3: Graph centrality (computed from reuse patterns)
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS graph_centrality_score INTEGER DEFAULT 0
+  CHECK (graph_centrality_score >= 0 AND graph_centrality_score <= 5);
+
+COMMENT ON COLUMN sd_capabilities.graph_centrality_score IS
+'Graph centrality 0-5. Computed from dependency analysis and reuse count. Higher = more central to capability ecosystem';
+
+-- 3.4: Category weight for Plane 1 calculation
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS category_weight DECIMAL(3,2) DEFAULT 1.0;
+
+COMMENT ON COLUMN sd_capabilities.category_weight IS
+'Weight multiplier for Plane 1 scoring. ai_automation=1.5, governance=1.3, infrastructure=1.2, integration=1.1, application=1.0';
+
+-- 3.5: Computed Plane 1 total (sum of subscores * weight)
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS plane1_score DECIMAL(5,2) DEFAULT 0;
+
+COMMENT ON COLUMN sd_capabilities.plane1_score IS
+'Computed Plane 1 score = (maturity + extraction + centrality) * category_weight. Max ~22.5 for AI capabilities';
+
+-- ============================================================================
+-- PHASE 4: Add reuse tracking fields
+-- ============================================================================
+
+-- 4.1: Count of times this capability was reused
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS reuse_count INTEGER DEFAULT 0;
+
+COMMENT ON COLUMN sd_capabilities.reuse_count IS
+'Number of times this capability was reused in other SDs or ventures';
+
+-- 4.2: Array of SD IDs that reuse this capability
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS reused_by_sds JSONB DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN sd_capabilities.reused_by_sds IS
+'Array of SD IDs that reuse this capability: [{sd_id, date, context}]';
+
+-- 4.3: First registration date (for age calculation)
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS first_registered_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+-- 4.4: Last reuse date
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS last_reused_at TIMESTAMP;
+
+-- 4.5: Source file paths where capability is implemented
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS source_files JSONB DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN sd_capabilities.source_files IS
+'Array of file paths where this capability is implemented: ["lib/foo.js", "src/components/Bar.tsx"]';
+
+-- ============================================================================
+-- PHASE 5: Add dependency tracking
+-- ============================================================================
+
+-- 5.1: Capabilities this depends on
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS depends_on JSONB DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN sd_capabilities.depends_on IS
+'Array of capability_keys this capability depends on';
+
+-- 5.2: Capabilities that depend on this
+ALTER TABLE sd_capabilities
+  ADD COLUMN IF NOT EXISTS depended_by JSONB DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN sd_capabilities.depended_by IS
+'Array of capability_keys that depend on this capability';
+
+-- ============================================================================
+-- PHASE 6: Create indexes for new columns
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_sd_capabilities_category ON sd_capabilities(category);
+CREATE INDEX IF NOT EXISTS idx_sd_capabilities_maturity ON sd_capabilities(maturity_score);
+CREATE INDEX IF NOT EXISTS idx_sd_capabilities_plane1 ON sd_capabilities(plane1_score DESC);
+CREATE INDEX IF NOT EXISTS idx_sd_capabilities_reuse_count ON sd_capabilities(reuse_count DESC);
+
+-- ============================================================================
+-- PHASE 7: Create trigger to auto-compute Plane 1 score
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION fn_compute_plane1_score()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Set category weight based on capability type
+  NEW.category_weight := CASE
+    WHEN NEW.capability_type IN ('agent', 'crew', 'tool', 'skill') THEN 1.5
+    WHEN NEW.capability_type IN ('validation_rule', 'quality_gate', 'protocol') THEN 1.3
+    WHEN NEW.capability_type IN ('database_schema', 'database_function', 'rls_policy', 'migration') THEN 1.2
+    WHEN NEW.capability_type IN ('workflow', 'webhook', 'external_integration') THEN 1.1
+    ELSE 1.0
+  END;
+
+  -- Set category based on type
+  NEW.category := CASE
+    WHEN NEW.capability_type IN ('agent', 'crew', 'tool', 'skill') THEN 'ai_automation'
+    WHEN NEW.capability_type IN ('database_schema', 'database_function', 'rls_policy', 'migration') THEN 'infrastructure'
+    WHEN NEW.capability_type IN ('api_endpoint', 'component', 'hook', 'service', 'utility') THEN 'application'
+    WHEN NEW.capability_type IN ('workflow', 'webhook', 'external_integration') THEN 'integration'
+    WHEN NEW.capability_type IN ('validation_rule', 'quality_gate', 'protocol') THEN 'governance'
+    ELSE 'application'
+  END;
+
+  -- Compute graph centrality from reuse count (0-5, +1 per 2 reuses)
+  NEW.graph_centrality_score := LEAST(5, FLOOR(COALESCE(NEW.reuse_count, 0) / 2));
+
+  -- Compute Plane 1 total
+  NEW.plane1_score := (
+    COALESCE(NEW.maturity_score, 0) +
+    COALESCE(NEW.extraction_score, 0) +
+    NEW.graph_centrality_score
+  ) * NEW.category_weight;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_compute_plane1_score ON sd_capabilities;
+
+CREATE TRIGGER trg_compute_plane1_score
+  BEFORE INSERT OR UPDATE ON sd_capabilities
+  FOR EACH ROW
+  EXECUTE FUNCTION fn_compute_plane1_score();
+
+-- ============================================================================
+-- PHASE 8: Create capability_reuse junction table for detailed tracking
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS capability_reuse_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  capability_id UUID NOT NULL REFERENCES sd_capabilities(id) ON DELETE CASCADE,
+  capability_key VARCHAR(200) NOT NULL,
+  reusing_sd_id VARCHAR(100) NOT NULL,
+  reusing_sd_uuid UUID REFERENCES strategic_directives_v2(uuid_id) ON DELETE SET NULL,
+  reuse_context TEXT, -- Description of how it was reused
+  reuse_type VARCHAR(50) CHECK (reuse_type IN ('direct', 'extended', 'forked', 'referenced')),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_capability_reuse_capability ON capability_reuse_log(capability_id);
+CREATE INDEX IF NOT EXISTS idx_capability_reuse_sd ON capability_reuse_log(reusing_sd_id);
+
+COMMENT ON TABLE capability_reuse_log IS
+'Detailed log of capability reuse events. Tracks when, where, and how capabilities are reused across SDs.';
+
+-- Enable RLS
+ALTER TABLE capability_reuse_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on capability_reuse_log"
+ON capability_reuse_log
+FOR ALL
+TO service_role
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY "Authenticated users can read capability_reuse_log"
+ON capability_reuse_log
+FOR SELECT
+TO authenticated
+USING (true);
+
+-- ============================================================================
+-- PHASE 9: Create function to record capability reuse
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION fn_record_capability_reuse(
+  p_capability_key VARCHAR(200),
+  p_reusing_sd_id VARCHAR(100),
+  p_reuse_context TEXT DEFAULT NULL,
+  p_reuse_type VARCHAR(50) DEFAULT 'direct'
+)
+RETURNS VOID AS $$
+DECLARE
+  v_capability_id UUID;
+  v_sd_uuid UUID;
+BEGIN
+  -- Find the capability
+  SELECT id INTO v_capability_id
+  FROM sd_capabilities
+  WHERE capability_key = p_capability_key
+  LIMIT 1;
+
+  IF v_capability_id IS NULL THEN
+    RAISE NOTICE 'Capability not found: %', p_capability_key;
+    RETURN;
+  END IF;
+
+  -- Find the SD UUID
+  SELECT uuid_id INTO v_sd_uuid
+  FROM strategic_directives_v2
+  WHERE id = p_reusing_sd_id;
+
+  -- Insert reuse log entry
+  INSERT INTO capability_reuse_log (
+    capability_id,
+    capability_key,
+    reusing_sd_id,
+    reusing_sd_uuid,
+    reuse_context,
+    reuse_type
+  ) VALUES (
+    v_capability_id,
+    p_capability_key,
+    p_reusing_sd_id,
+    v_sd_uuid,
+    p_reuse_context,
+    p_reuse_type
+  );
+
+  -- Update capability reuse metrics
+  UPDATE sd_capabilities
+  SET
+    reuse_count = reuse_count + 1,
+    last_reused_at = CURRENT_TIMESTAMP,
+    reused_by_sds = reused_by_sds || jsonb_build_array(jsonb_build_object(
+      'sd_id', p_reusing_sd_id,
+      'date', CURRENT_TIMESTAMP::text,
+      'context', p_reuse_context
+    ))
+  WHERE id = v_capability_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION fn_record_capability_reuse IS
+'Records when a capability is reused by another SD. Updates reuse metrics and logs the event.';
+
+-- ============================================================================
+-- PHASE 10: Create view for capability ledger dashboard
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_capability_ledger AS
+SELECT
+  sc.id,
+  sc.capability_key,
+  sc.name,
+  sc.description,
+  sc.capability_type,
+  sc.category,
+  sc.maturity_score,
+  sc.extraction_score,
+  sc.graph_centrality_score,
+  sc.plane1_score,
+  sc.reuse_count,
+  sc.first_registered_at,
+  sc.last_reused_at,
+  sc.sd_id AS registered_by_sd,
+  sd.title AS sd_title,
+  sc.action,
+  sc.source_files,
+  -- Age in days
+  EXTRACT(DAY FROM (CURRENT_TIMESTAMP - sc.first_registered_at))::INTEGER AS age_days,
+  -- Reuse rate (reuses per 30 days of existence)
+  CASE
+    WHEN EXTRACT(DAY FROM (CURRENT_TIMESTAMP - sc.first_registered_at)) > 0
+    THEN ROUND((sc.reuse_count::DECIMAL / EXTRACT(DAY FROM (CURRENT_TIMESTAMP - sc.first_registered_at)) * 30)::NUMERIC, 2)
+    ELSE 0
+  END AS reuse_rate_per_month
+FROM sd_capabilities sc
+LEFT JOIN strategic_directives_v2 sd ON sc.sd_uuid = sd.uuid_id
+WHERE sc.action = 'registered'
+ORDER BY sc.plane1_score DESC, sc.reuse_count DESC;
+
+COMMENT ON VIEW v_capability_ledger IS
+'Dashboard view of the capability ledger showing all registered capabilities with Plane 1 scores and reuse metrics.';
+
+-- ============================================================================
+-- Verification queries (uncomment to run after migration)
+-- ============================================================================
+-- SELECT column_name, data_type, is_nullable
+-- FROM information_schema.columns
+-- WHERE table_name = 'sd_capabilities'
+-- ORDER BY ordinal_position;
+
+-- SELECT * FROM v_capability_ledger LIMIT 10;

--- a/lib/capabilities/capability-reuse-tracker.js
+++ b/lib/capabilities/capability-reuse-tracker.js
@@ -1,0 +1,409 @@
+/**
+ * Capability Reuse Tracker
+ * SD: SD-CAP-LEDGER-001 | US-005
+ *
+ * Tracks and reports on capability reuse across SDs and ventures.
+ * Measures "ecosystem lift" - the value generated through capability reuse.
+ *
+ * Key Metrics:
+ * - Reuse Count: How many times a capability is reused
+ * - Reuse Rate: Reuses per month of existence
+ * - Ecosystem Lift: Value multiplier from reuse
+ * - Compounding Factor: Rate of capability growth
+ */
+
+import { CAPABILITY_TYPES, CAPABILITY_CATEGORIES } from './capability-taxonomy.js';
+
+/**
+ * Reuse tracking configuration
+ */
+export const REUSE_CONFIG = {
+  // Reuse types with their multipliers
+  REUSE_TYPES: {
+    direct: { multiplier: 1.0, description: 'Direct reuse without modification' },
+    extended: { multiplier: 0.8, description: 'Extended with additional features' },
+    forked: { multiplier: 0.5, description: 'Forked and modified significantly' },
+    referenced: { multiplier: 0.3, description: 'Referenced for patterns/inspiration' },
+  },
+
+  // Ecosystem lift thresholds
+  LIFT_THRESHOLDS: {
+    LOW: { maxReuses: 2, multiplier: 1.0 },
+    MEDIUM: { maxReuses: 5, multiplier: 1.5 },
+    HIGH: { maxReuses: 10, multiplier: 2.0 },
+    EXCEPTIONAL: { maxReuses: Infinity, multiplier: 3.0 },
+  },
+
+  // Compounding calculation window (days)
+  COMPOUNDING_WINDOW: 90,
+};
+
+/**
+ * Calculate ecosystem lift for a capability
+ *
+ * Ecosystem Lift = Base Value * (1 + Weighted Reuse Factor)
+ *
+ * @param {Object} capability - Capability with reuse metrics
+ * @returns {Object} Ecosystem lift calculation
+ */
+export function calculateEcosystemLift(capability) {
+  const reuseCount = capability.reuse_count || 0;
+  const reusedBy = capability.reused_by_sds || [];
+
+  if (reuseCount === 0) {
+    return {
+      lift_multiplier: 1.0,
+      total_value_generated: capability.plane1_score || 0,
+      reuse_breakdown: [],
+      lift_category: 'NONE',
+    };
+  }
+
+  // Calculate weighted reuse factor based on reuse types
+  let weightedReuses = 0;
+  const reuseBreakdown = [];
+
+  for (const reuse of reusedBy) {
+    const reuseType = reuse.type || 'direct';
+    const typeConfig = REUSE_CONFIG.REUSE_TYPES[reuseType] || REUSE_CONFIG.REUSE_TYPES.direct;
+    const weightedValue = typeConfig.multiplier;
+    weightedReuses += weightedValue;
+
+    reuseBreakdown.push({
+      sd_id: reuse.sd_id,
+      date: reuse.date,
+      type: reuseType,
+      weighted_value: weightedValue,
+    });
+  }
+
+  // Determine lift category
+  let liftCategory = 'LOW';
+  let categoryMultiplier = 1.0;
+
+  for (const [category, config] of Object.entries(REUSE_CONFIG.LIFT_THRESHOLDS)) {
+    if (reuseCount <= config.maxReuses) {
+      liftCategory = category;
+      categoryMultiplier = config.multiplier;
+      break;
+    }
+  }
+
+  // Calculate final lift multiplier
+  const baseLift = 1 + (weightedReuses * 0.2); // 20% lift per weighted reuse
+  const liftMultiplier = baseLift * categoryMultiplier;
+
+  // Calculate total value generated
+  const baseValue = capability.plane1_score || 1;
+  const totalValueGenerated = baseValue * liftMultiplier;
+
+  return {
+    lift_multiplier: Math.round(liftMultiplier * 100) / 100,
+    total_value_generated: Math.round(totalValueGenerated * 100) / 100,
+    base_value: baseValue,
+    weighted_reuses: Math.round(weightedReuses * 100) / 100,
+    reuse_count: reuseCount,
+    reuse_breakdown: reuseBreakdown,
+    lift_category: liftCategory,
+  };
+}
+
+/**
+ * Calculate compounding factor for capability growth
+ *
+ * Measures how fast the capability ecosystem is growing
+ *
+ * @param {Array} capabilities - All capabilities with timestamps
+ * @param {number} windowDays - Time window for calculation
+ * @returns {Object} Compounding metrics
+ */
+export function calculateCompoundingFactor(capabilities, windowDays = REUSE_CONFIG.COMPOUNDING_WINDOW) {
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+
+  // Count capabilities created in window
+  const recentCapabilities = capabilities.filter((c) => {
+    const createdAt = new Date(c.first_registered_at || c.created_at);
+    return createdAt >= windowStart;
+  });
+
+  // Count capabilities before window
+  const previousCapabilities = capabilities.filter((c) => {
+    const createdAt = new Date(c.first_registered_at || c.created_at);
+    return createdAt < windowStart;
+  });
+
+  const previousCount = previousCapabilities.length;
+  const recentCount = recentCapabilities.length;
+  const totalCount = capabilities.length;
+
+  // Calculate growth rate
+  let growthRate = 0;
+  if (previousCount > 0) {
+    growthRate = (recentCount / previousCount) * 100;
+  } else if (recentCount > 0) {
+    growthRate = 100; // All capabilities are new
+  }
+
+  // Count total reuses in window
+  let recentReuses = 0;
+  for (const cap of capabilities) {
+    const reusedBy = cap.reused_by_sds || [];
+    for (const reuse of reusedBy) {
+      const reuseDate = new Date(reuse.date);
+      if (reuseDate >= windowStart) {
+        recentReuses++;
+      }
+    }
+  }
+
+  // Calculate reuse velocity
+  const reuseVelocity = recentReuses / (windowDays / 30); // Reuses per month
+
+  // Calculate compounding factor
+  // Higher when both growth rate and reuse velocity are high
+  const compoundingFactor = (growthRate * 0.3 + reuseVelocity * 10 * 0.7) / 100;
+
+  return {
+    window_days: windowDays,
+    total_capabilities: totalCount,
+    new_capabilities: recentCount,
+    previous_capabilities: previousCount,
+    growth_rate_percent: Math.round(growthRate * 10) / 10,
+    recent_reuses: recentReuses,
+    reuse_velocity_per_month: Math.round(reuseVelocity * 10) / 10,
+    compounding_factor: Math.round(compoundingFactor * 100) / 100,
+    health_status: getHealthStatus(compoundingFactor),
+  };
+}
+
+/**
+ * Determine ecosystem health status
+ */
+function getHealthStatus(compoundingFactor) {
+  if (compoundingFactor >= 0.8) {
+    return { status: 'THRIVING', emoji: '🚀', message: 'Excellent capability growth and reuse' };
+  }
+  if (compoundingFactor >= 0.5) {
+    return { status: 'HEALTHY', emoji: '✅', message: 'Good capability ecosystem' };
+  }
+  if (compoundingFactor >= 0.2) {
+    return { status: 'DEVELOPING', emoji: '📈', message: 'Growing capability base' };
+  }
+  return { status: 'NASCENT', emoji: '🌱', message: 'Early stage capability development' };
+}
+
+/**
+ * Generate reuse report for capabilities
+ *
+ * @param {Array} capabilities - Array of capabilities from ledger
+ * @returns {Object} Comprehensive reuse report
+ */
+export function generateReuseReport(capabilities) {
+  if (!capabilities || capabilities.length === 0) {
+    return {
+      summary: { total: 0, with_reuse: 0, total_reuses: 0 },
+      ecosystem_lift: { total: 0 },
+      top_reused: [],
+      by_category: {},
+      compounding: null,
+    };
+  }
+
+  // Calculate lift for each capability
+  const withLift = capabilities.map((cap) => ({
+    ...cap,
+    ecosystem_lift: calculateEcosystemLift(cap),
+  }));
+
+  // Summary stats
+  const withReuse = withLift.filter((c) => (c.reuse_count || 0) > 0);
+  const totalReuses = withLift.reduce((sum, c) => sum + (c.reuse_count || 0), 0);
+  const totalLift = withLift.reduce(
+    (sum, c) => sum + (c.ecosystem_lift?.total_value_generated || c.plane1_score || 0),
+    0
+  );
+
+  // Top 10 most reused
+  const topReused = [...withLift]
+    .sort((a, b) => (b.reuse_count || 0) - (a.reuse_count || 0))
+    .slice(0, 10)
+    .map((c) => ({
+      capability_key: c.capability_key,
+      capability_type: c.capability_type,
+      reuse_count: c.reuse_count || 0,
+      lift_multiplier: c.ecosystem_lift?.lift_multiplier || 1,
+      total_value: c.ecosystem_lift?.total_value_generated || 0,
+    }));
+
+  // By category
+  const byCategory = {};
+  for (const cap of withLift) {
+    const type = CAPABILITY_TYPES[cap.capability_type];
+    const category = type?.category || 'unknown';
+
+    if (!byCategory[category]) {
+      byCategory[category] = {
+        count: 0,
+        total_reuses: 0,
+        total_lift: 0,
+        capabilities: [],
+      };
+    }
+
+    byCategory[category].count++;
+    byCategory[category].total_reuses += cap.reuse_count || 0;
+    byCategory[category].total_lift += cap.ecosystem_lift?.total_value_generated || 0;
+    byCategory[category].capabilities.push(cap.capability_key);
+  }
+
+  // Calculate compounding
+  const compounding = calculateCompoundingFactor(capabilities);
+
+  return {
+    summary: {
+      total: capabilities.length,
+      with_reuse: withReuse.length,
+      reuse_rate: Math.round((withReuse.length / capabilities.length) * 100),
+      total_reuses: totalReuses,
+      avg_reuses_per_capability: Math.round((totalReuses / capabilities.length) * 10) / 10,
+    },
+    ecosystem_lift: {
+      total: Math.round(totalLift * 100) / 100,
+      average: Math.round((totalLift / capabilities.length) * 100) / 100,
+      lift_ratio: Math.round((totalLift / capabilities.reduce((s, c) => s + (c.plane1_score || 1), 0)) * 100) / 100,
+    },
+    top_reused: topReused,
+    by_category: byCategory,
+    compounding,
+  };
+}
+
+/**
+ * Record a capability reuse event
+ *
+ * @param {Object} supabaseClient - Supabase client
+ * @param {string} capabilityKey - Key of capability being reused
+ * @param {string} reusingSDId - ID of SD that's reusing it
+ * @param {string} context - Description of how it's being reused
+ * @param {string} reuseType - Type of reuse (direct, extended, forked, referenced)
+ */
+export async function recordReuseEvent(
+  supabaseClient,
+  capabilityKey,
+  reusingSDId,
+  context = null,
+  reuseType = 'direct'
+) {
+  // Use the database function
+  const { error } = await supabaseClient.rpc('fn_record_capability_reuse', {
+    p_capability_key: capabilityKey,
+    p_reusing_sd_id: reusingSDId,
+    p_reuse_context: context,
+    p_reuse_type: reuseType,
+  });
+
+  if (error) {
+    console.error('Error recording reuse event:', error);
+    return { success: false, error: error.message };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Get reuse suggestions for an SD
+ *
+ * Analyzes the SD and suggests capabilities from the ledger that could be reused
+ *
+ * @param {Object} supabaseClient - Supabase client
+ * @param {Object} sd - Strategic Directive to analyze
+ * @returns {Array} Suggested capabilities for reuse
+ */
+export async function getReusesuggestions(supabaseClient, sd) {
+  // Get all capabilities from ledger
+  const { data: capabilities, error } = await supabaseClient
+    .from('v_capability_ledger')
+    .select('*')
+    .order('plane1_score', { ascending: false })
+    .limit(100);
+
+  if (error || !capabilities) {
+    return [];
+  }
+
+  const suggestions = [];
+
+  // Analyze SD title and description for keyword matches
+  const sdText = `${sd.title || ''} ${sd.description || ''} ${sd.scope || ''}`.toLowerCase();
+
+  for (const cap of capabilities) {
+    const capText = `${cap.capability_key} ${cap.name || ''} ${cap.description || ''}`.toLowerCase();
+
+    // Simple keyword matching (could be enhanced with embeddings)
+    const keywords = capText.split(/\W+/).filter((w) => w.length > 3);
+    const matches = keywords.filter((kw) => sdText.includes(kw));
+
+    if (matches.length >= 2) {
+      suggestions.push({
+        capability_key: cap.capability_key,
+        capability_type: cap.capability_type,
+        name: cap.name,
+        plane1_score: cap.plane1_score,
+        reuse_count: cap.reuse_count,
+        relevance_score: matches.length,
+        matching_keywords: matches.slice(0, 5),
+      });
+    }
+  }
+
+  // Sort by relevance * plane1_score
+  return suggestions
+    .sort((a, b) => (b.relevance_score * b.plane1_score) - (a.relevance_score * a.plane1_score))
+    .slice(0, 10);
+}
+
+/**
+ * Format reuse report for display
+ */
+export function formatReuseReport(report) {
+  const health = report.compounding?.health_status || { emoji: '❓', status: 'UNKNOWN' };
+
+  return `
+╔══════════════════════════════════════════════════════════════════╗
+║              CAPABILITY REUSE REPORT                              ║
+║              ${health.emoji} ${health.status.padEnd(20)}                            ║
+╠══════════════════════════════════════════════════════════════════╣
+║  SUMMARY                                                          ║
+║    Total Capabilities:     ${String(report.summary.total).padStart(5)}                              ║
+║    With Reuse:             ${String(report.summary.with_reuse).padStart(5)} (${report.summary.reuse_rate}%)                        ║
+║    Total Reuse Events:     ${String(report.summary.total_reuses).padStart(5)}                              ║
+║    Avg Reuses/Capability:  ${String(report.summary.avg_reuses_per_capability).padStart(5)}                              ║
+╠══════════════════════════════════════════════════════════════════╣
+║  ECOSYSTEM LIFT                                                   ║
+║    Total Value Generated:  ${String(report.ecosystem_lift.total).padStart(8)}                          ║
+║    Average per Capability: ${String(report.ecosystem_lift.average).padStart(8)}                          ║
+║    Lift Ratio:             ${String(report.ecosystem_lift.lift_ratio).padStart(8)}x                         ║
+╠══════════════════════════════════════════════════════════════════╣
+║  COMPOUNDING FACTOR: ${String(report.compounding?.compounding_factor || 0).padStart(5)}                                ║
+║    Growth Rate:            ${String(report.compounding?.growth_rate_percent || 0).padStart(5)}%                             ║
+║    Reuse Velocity:         ${String(report.compounding?.reuse_velocity_per_month || 0).padStart(5)}/month                        ║
+╠══════════════════════════════════════════════════════════════════╣
+║  TOP REUSED CAPABILITIES                                          ║
+${report.top_reused
+    .slice(0, 5)
+    .map((c) => `║    ${String(c.reuse_count).padStart(3)}x | ${c.capability_type.padEnd(15)} | ${c.capability_key.substring(0, 30).padEnd(30)}║`)
+    .join('\n') || '║    (No reuse data yet)                                            ║'}
+╚══════════════════════════════════════════════════════════════════╝
+`.trim();
+}
+
+export default {
+  REUSE_CONFIG,
+  calculateEcosystemLift,
+  calculateCompoundingFactor,
+  generateReuseReport,
+  recordReuseEvent,
+  getReusesuggestions,
+  formatReuseReport,
+};

--- a/lib/capabilities/capability-taxonomy.js
+++ b/lib/capabilities/capability-taxonomy.js
@@ -1,0 +1,593 @@
+/**
+ * Capability Taxonomy Module
+ * SD: SD-CAP-LEDGER-001 | US-001
+ *
+ * Defines formal capability types, hierarchy, and scoring criteria
+ * for the Automated Capability Ledger with Plane 1 integration.
+ *
+ * Based on Ground-Truth Triangulation Synthesis (2026-01-08)
+ */
+
+/**
+ * Capability Categories - Top-level classification
+ */
+export const CAPABILITY_CATEGORIES = {
+  AI_AUTOMATION: {
+    code: 'ai_automation',
+    name: 'AI & Automation',
+    description: 'AI agents, crews, and automated workflows',
+    plane1_weight: 1.5, // Higher weight for AI capabilities (core EHG value)
+  },
+  INFRASTRUCTURE: {
+    code: 'infrastructure',
+    name: 'Infrastructure',
+    description: 'Database schemas, functions, policies, and system foundations',
+    plane1_weight: 1.2,
+  },
+  APPLICATION: {
+    code: 'application',
+    name: 'Application',
+    description: 'APIs, components, services, and user-facing features',
+    plane1_weight: 1.0,
+  },
+  INTEGRATION: {
+    code: 'integration',
+    name: 'Integration',
+    description: 'External integrations, webhooks, and cross-system workflows',
+    plane1_weight: 1.1,
+  },
+  GOVERNANCE: {
+    code: 'governance',
+    name: 'Governance',
+    description: 'Validation rules, quality gates, and protocol enforcement',
+    plane1_weight: 1.3,
+  },
+};
+
+/**
+ * Capability Types - Specific capability classifications
+ *
+ * Each type includes:
+ * - category: Parent category code
+ * - description: What this type represents
+ * - maturity_criteria: How to assess maturity (0-5)
+ * - extraction_criteria: How easy to reuse in other ventures
+ * - examples: Real examples from EHG codebase
+ */
+export const CAPABILITY_TYPES = {
+  // ═══════════════════════════════════════════════════════════════
+  // AI & AUTOMATION CAPABILITIES
+  // ═══════════════════════════════════════════════════════════════
+  agent: {
+    category: 'ai_automation',
+    description: 'Autonomous AI agent with defined role, goal, and backstory',
+    maturity_criteria: {
+      0: 'Concept only, no implementation',
+      1: 'Basic prompt, unreliable output',
+      2: 'Functional with supervision required',
+      3: 'Reliable in happy path scenarios',
+      4: 'Handles edge cases, self-correcting',
+      5: 'Production-grade, fully autonomous',
+    },
+    extraction_criteria: {
+      0: 'Hardcoded to specific domain, not reusable',
+      1: 'Some configurable parameters',
+      2: 'Domain-specific but adaptable',
+      3: 'Generic with clear extension points',
+      4: 'Fully parameterized, documented API',
+      5: 'Published module, versioned, tested',
+    },
+    examples: ['RISK-AGENT', 'REGRESSION-AGENT', 'DESIGN-AGENT'],
+  },
+
+  crew: {
+    category: 'ai_automation',
+    description: 'Orchestrated multi-agent workflow with defined collaboration patterns',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Agents defined but no orchestration',
+      2: 'Basic sequential execution',
+      3: 'Parallel execution with handoffs',
+      4: 'Dynamic routing based on context',
+      5: 'Self-optimizing crew composition',
+    },
+    extraction_criteria: {
+      0: 'Hardcoded agent composition',
+      1: 'Configurable agent list',
+      2: 'Pluggable agents, fixed workflow',
+      3: 'Pluggable agents and workflow',
+      4: 'Full configuration via schema',
+      5: 'Published as reusable crew template',
+    },
+    examples: ['PRD-GENERATION-CREW', 'UAT-EXECUTION-CREW'],
+  },
+
+  tool: {
+    category: 'ai_automation',
+    description: 'Discrete capability exposed to AI agents for task execution',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Basic function, no error handling',
+      2: 'Error handling, limited validation',
+      3: 'Full validation, typed inputs/outputs',
+      4: 'Comprehensive logging, metrics',
+      5: 'Self-describing, auto-documented',
+    },
+    extraction_criteria: {
+      0: 'Embedded in agent code',
+      1: 'Separate function, agent-specific',
+      2: 'Standalone module, some dependencies',
+      3: 'Zero external dependencies',
+      4: 'Published with schema',
+      5: 'MCP-compatible, versioned',
+    },
+    examples: ['database-query-tool', 'file-search-tool', 'web-fetch-tool'],
+  },
+
+  skill: {
+    category: 'ai_automation',
+    description: 'User-invokable capability (slash command) with defined workflow',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Basic implementation, fragile',
+      2: 'Works for primary use case',
+      3: 'Handles variations, good UX',
+      4: 'Comprehensive with help/docs',
+      5: 'Self-improving based on usage',
+    },
+    extraction_criteria: {
+      0: 'Embedded in codebase',
+      1: 'Configurable via prompts',
+      2: 'Standalone skill file',
+      3: 'Parameterized, documented',
+      4: 'Published skill template',
+      5: 'Skill marketplace ready',
+    },
+    examples: ['/commit', '/review-pr', '/leo', '/quick-fix'],
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // INFRASTRUCTURE CAPABILITIES
+  // ═══════════════════════════════════════════════════════════════
+  database_schema: {
+    category: 'infrastructure',
+    description: 'Database table definition with indexes and constraints',
+    maturity_criteria: {
+      0: 'Conceptual ERD only',
+      1: 'Basic CREATE TABLE, no constraints',
+      2: 'Constraints, basic indexes',
+      3: 'Optimized indexes, referential integrity',
+      4: 'Full normalization, audit columns',
+      5: 'Partitioned, performance-tuned',
+    },
+    extraction_criteria: {
+      0: 'Domain-specific columns',
+      1: 'Some generic columns',
+      2: 'Pattern-based (follows conventions)',
+      3: 'Template-able structure',
+      4: 'Parameterized migration generator',
+      5: 'Schema-as-code module',
+    },
+    examples: ['strategic_directives_v2', 'sd_capabilities', 'retrospectives'],
+  },
+
+  database_function: {
+    category: 'infrastructure',
+    description: 'Stored procedure or database function for business logic',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Basic SQL, no error handling',
+      2: 'Error handling, typed parameters',
+      3: 'Transaction support, idempotent',
+      4: 'Comprehensive logging, metrics',
+      5: 'Self-documenting, versioned',
+    },
+    extraction_criteria: {
+      0: 'Hardcoded business logic',
+      1: 'Parameterized queries',
+      2: 'Generic utility functions',
+      3: 'Reusable across tables',
+      4: 'Published function library',
+      5: 'Cross-database compatible',
+    },
+    examples: ['fn_handle_capability_lifecycle', 'fn_calculate_sd_progress'],
+  },
+
+  rls_policy: {
+    category: 'infrastructure',
+    description: 'Row Level Security policy for data access control',
+    maturity_criteria: {
+      0: 'No RLS defined',
+      1: 'Basic allow/deny',
+      2: 'Role-based access',
+      3: 'Multi-tenant aware',
+      4: 'Comprehensive audit trail',
+      5: 'Dynamic policy generation',
+    },
+    extraction_criteria: {
+      0: 'Table-specific policy',
+      1: 'Pattern-based policy',
+      2: 'Reusable policy template',
+      3: 'Policy generator function',
+      4: 'Published RLS framework',
+      5: 'Universal access control module',
+    },
+    examples: ['Service role full access', 'Authenticated users can read'],
+  },
+
+  migration: {
+    category: 'infrastructure',
+    description: 'Database schema migration for evolving data structures',
+    maturity_criteria: {
+      0: 'Raw SQL changes',
+      1: 'Versioned migration file',
+      2: 'Reversible (up/down)',
+      3: 'Safe for production (no locks)',
+      4: 'Zero-downtime capable',
+      5: 'Auto-generated from diff',
+    },
+    extraction_criteria: {
+      0: 'Project-specific',
+      1: 'Pattern documented',
+      2: 'Template available',
+      3: 'Generator script',
+      4: 'Migration framework',
+      5: 'Universal migration tool',
+    },
+    examples: ['20251202_capability_lifecycle_automation.sql'],
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // APPLICATION CAPABILITIES
+  // ═══════════════════════════════════════════════════════════════
+  api_endpoint: {
+    category: 'application',
+    description: 'REST or GraphQL endpoint for data access or actions',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Basic CRUD, no validation',
+      2: 'Input validation, error handling',
+      3: 'Auth, rate limiting, logging',
+      4: 'Versioned, documented, tested',
+      5: 'OpenAPI spec, client SDKs',
+    },
+    extraction_criteria: {
+      0: 'Hardcoded to domain',
+      1: 'Parameterized routes',
+      2: 'Generic CRUD generator',
+      3: 'API framework patterns',
+      4: 'Published API template',
+      5: 'API-as-module package',
+    },
+    examples: ['/api/sd/next', '/api/handoff/execute'],
+  },
+
+  component: {
+    category: 'application',
+    description: 'React/UI component for user interface rendering',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Basic render, no props',
+      2: 'Props, basic styling',
+      3: 'Accessible, responsive',
+      4: 'Storybook, visual tests',
+      5: 'Design system component',
+    },
+    extraction_criteria: {
+      0: 'Page-specific component',
+      1: 'Some configurable props',
+      2: 'Reusable within project',
+      3: 'Generic, well-documented',
+      4: 'Published component',
+      5: 'Component library entry',
+    },
+    examples: ['ErrorBoundary', 'SDQueueDisplay', 'HandoffStatusBadge'],
+  },
+
+  hook: {
+    category: 'application',
+    description: 'React hook for shared stateful logic',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Basic hook, side effects',
+      2: 'Cleanup, error handling',
+      3: 'TypeScript, tested',
+      4: 'Comprehensive documentation',
+      5: 'Published hook library',
+    },
+    extraction_criteria: {
+      0: 'Component-specific',
+      1: 'Extracted to shared',
+      2: 'Parameterized',
+      3: 'Generic utility hook',
+      4: 'Published package',
+      5: 'Hook ecosystem entry',
+    },
+    examples: ['useSDProgress', 'useHandoffStatus', 'useCapabilityLedger'],
+  },
+
+  service: {
+    category: 'application',
+    description: 'Backend service module for business logic orchestration',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Basic implementation',
+      2: 'Error handling, logging',
+      3: 'Testable, dependency injection',
+      4: 'Metrics, health checks',
+      5: 'Self-healing, auto-scaling',
+    },
+    extraction_criteria: {
+      0: 'Embedded in route',
+      1: 'Separate module',
+      2: 'Interface-driven',
+      3: 'Pluggable dependencies',
+      4: 'Published service',
+      5: 'Microservice-ready',
+    },
+    examples: ['HandoffExecutor', 'CapabilityAnalyzer', 'PRDGenerator'],
+  },
+
+  utility: {
+    category: 'application',
+    description: 'Standalone utility function for common operations',
+    maturity_criteria: {
+      0: 'Inline code',
+      1: 'Extracted function',
+      2: 'Typed, documented',
+      3: 'Unit tested',
+      4: 'Comprehensive edge cases',
+      5: 'Published utility',
+    },
+    extraction_criteria: {
+      0: 'Project-specific',
+      1: 'Parameterized',
+      2: 'Generic',
+      3: 'Zero dependencies',
+      4: 'npm-publishable',
+      5: 'Published package',
+    },
+    examples: ['formatSDKey', 'calculateProgress', 'parseHandoffScore'],
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // INTEGRATION CAPABILITIES
+  // ═══════════════════════════════════════════════════════════════
+  workflow: {
+    category: 'integration',
+    description: 'Multi-step automated process with defined triggers and actions',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Manual multi-step process',
+      2: 'Partially automated',
+      3: 'Fully automated, happy path',
+      4: 'Error recovery, retry logic',
+      5: 'Self-optimizing workflow',
+    },
+    extraction_criteria: {
+      0: 'Hardcoded steps',
+      1: 'Configurable steps',
+      2: 'Template-based',
+      3: 'Workflow DSL',
+      4: 'Published workflow',
+      5: 'Workflow marketplace',
+    },
+    examples: ['LEO-HANDOFF-WORKFLOW', 'SD-COMPLETION-WORKFLOW'],
+  },
+
+  webhook: {
+    category: 'integration',
+    description: 'HTTP callback endpoint for external system integration',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Basic receiver',
+      2: 'Signature validation',
+      3: 'Idempotent, queued processing',
+      4: 'Comprehensive logging, replay',
+      5: 'Self-documenting, versioned',
+    },
+    extraction_criteria: {
+      0: 'Provider-specific',
+      1: 'Adapter pattern',
+      2: 'Generic webhook handler',
+      3: 'Webhook framework',
+      4: 'Published handler',
+      5: 'Universal webhook gateway',
+    },
+    examples: ['github-webhook', 'vercel-webhook', 'stripe-webhook'],
+  },
+
+  external_integration: {
+    category: 'integration',
+    description: 'Client library or adapter for external service',
+    maturity_criteria: {
+      0: 'Direct API calls',
+      1: 'Wrapper functions',
+      2: 'Typed client',
+      3: 'Retry, circuit breaker',
+      4: 'Caching, rate limiting',
+      5: 'Self-healing client',
+    },
+    extraction_criteria: {
+      0: 'Hardcoded credentials',
+      1: 'Configurable endpoints',
+      2: 'Environment-based config',
+      3: 'Dependency injection',
+      4: 'Published client',
+      5: 'Official SDK contribution',
+    },
+    examples: ['supabase-client', 'openai-client', 'anthropic-client'],
+  },
+
+  // ═══════════════════════════════════════════════════════════════
+  // GOVERNANCE CAPABILITIES
+  // ═══════════════════════════════════════════════════════════════
+  validation_rule: {
+    category: 'governance',
+    description: 'Business rule enforced via validation logic',
+    maturity_criteria: {
+      0: 'Documented requirement',
+      1: 'Manual check',
+      2: 'Automated check',
+      3: 'Enforced at gate',
+      4: 'Self-correcting',
+      5: 'Predictive prevention',
+    },
+    extraction_criteria: {
+      0: 'Domain-specific',
+      1: 'Parameterized rule',
+      2: 'Rule template',
+      3: 'Rule engine compatible',
+      4: 'Published rule',
+      5: 'Rule marketplace',
+    },
+    examples: ['PRD-QUALITY-GATE', 'HANDOFF-SCORE-THRESHOLD'],
+  },
+
+  quality_gate: {
+    category: 'governance',
+    description: 'Checkpoint that blocks progression without meeting criteria',
+    maturity_criteria: {
+      0: 'Concept only',
+      1: 'Manual gate',
+      2: 'Automated check',
+      3: 'Automated block',
+      4: 'Override with audit',
+      5: 'Adaptive thresholds',
+    },
+    extraction_criteria: {
+      0: 'Project-specific gate',
+      1: 'Configurable threshold',
+      2: 'Generic gate pattern',
+      3: 'Gate framework',
+      4: 'Published gate',
+      5: 'Gate marketplace',
+    },
+    examples: ['PLAN-TO-EXEC-GATE', 'PR-MERGE-GATE', 'UAT-PASS-GATE'],
+  },
+
+  protocol: {
+    category: 'governance',
+    description: 'Defined process with phases, roles, and transitions',
+    maturity_criteria: {
+      0: 'Informal process',
+      1: 'Documented process',
+      2: 'Tooling support',
+      3: 'Automated transitions',
+      4: 'Metrics and optimization',
+      5: 'Self-evolving protocol',
+    },
+    extraction_criteria: {
+      0: 'Organization-specific',
+      1: 'Documented pattern',
+      2: 'Template-based',
+      3: 'Protocol framework',
+      4: 'Published protocol',
+      5: 'Protocol standard',
+    },
+    examples: ['LEO-PROTOCOL', 'FOUR-OATHS', 'GROUND-TRUTH-TRIANGULATION'],
+  },
+};
+
+/**
+ * Get all capability type codes for database constraint
+ */
+export function getCapabilityTypeCodes() {
+  return Object.keys(CAPABILITY_TYPES);
+}
+
+/**
+ * Get capability type details
+ */
+export function getCapabilityType(typeCode) {
+  return CAPABILITY_TYPES[typeCode] || null;
+}
+
+/**
+ * Get all types in a category
+ */
+export function getTypesByCategory(categoryCode) {
+  return Object.entries(CAPABILITY_TYPES)
+    .filter(([_, type]) => type.category === categoryCode)
+    .map(([code, type]) => ({ code, ...type }));
+}
+
+/**
+ * Calculate Plane 1 sub-scores for a capability
+ *
+ * Plane 1 (Capability Graph) components:
+ * - Graph Centrality Gain (0-5): How central is this to the capability graph?
+ * - Maturity Lift (0-5): What maturity level does this add?
+ * - Extraction Clarity (0-5): How reusable/extractable is this?
+ *
+ * @param {Object} capability - Capability with type, maturity, extraction scores
+ * @returns {Object} Plane 1 scoring breakdown
+ */
+export function calculatePlane1Score(capability) {
+  const type = CAPABILITY_TYPES[capability.capability_type];
+  if (!type) {
+    return {
+      graph_centrality_gain: 0,
+      maturity_lift: 0,
+      extraction_clarity: 0,
+      raw_total: 0,
+      weighted_total: 0,
+      category_weight: 1.0,
+    };
+  }
+
+  const category = CAPABILITY_CATEGORIES[type.category.toUpperCase()];
+  const categoryWeight = category?.plane1_weight || 1.0;
+
+  // Graph Centrality Gain: Based on how many other capabilities depend on this
+  // For now, use reuse_count as proxy (will be enhanced with dependency analysis)
+  const reuse = capability.reuse_count || 0;
+  const graphCentralityGain = Math.min(5, Math.floor(reuse / 2));
+
+  // Maturity Lift: Direct from maturity score
+  const maturityLift = capability.maturity_score || 0;
+
+  // Extraction Clarity: Direct from extraction score
+  const extractionClarity = capability.extraction_score || 0;
+
+  const rawTotal = graphCentralityGain + maturityLift + extractionClarity;
+  const weightedTotal = rawTotal * categoryWeight;
+
+  return {
+    graph_centrality_gain: graphCentralityGain,
+    maturity_lift: maturityLift,
+    extraction_clarity: extractionClarity,
+    raw_total: rawTotal,
+    weighted_total: Math.round(weightedTotal * 100) / 100,
+    category_weight: categoryWeight,
+    max_possible: 15 * categoryWeight,
+  };
+}
+
+/**
+ * Validate a capability type is valid
+ */
+export function isValidCapabilityType(typeCode) {
+  return typeCode in CAPABILITY_TYPES;
+}
+
+/**
+ * Get maturity description for a type and score
+ */
+export function getMaturityDescription(typeCode, score) {
+  const type = CAPABILITY_TYPES[typeCode];
+  if (!type || !type.maturity_criteria) return null;
+  return type.maturity_criteria[score] || null;
+}
+
+/**
+ * Get extraction description for a type and score
+ */
+export function getExtractionDescription(typeCode, score) {
+  const type = CAPABILITY_TYPES[typeCode];
+  if (!type || !type.extraction_criteria) return null;
+  return type.extraction_criteria[score] || null;
+}
+
+// Export for database migration
+export const CAPABILITY_TYPE_ENUM = getCapabilityTypeCodes().map((c) => `'${c}'`).join(', ');

--- a/lib/capabilities/index.js
+++ b/lib/capabilities/index.js
@@ -1,0 +1,41 @@
+/**
+ * Capability Ledger Module
+ * SD: SD-CAP-LEDGER-001
+ *
+ * Unified exports for the Automated Capability Ledger with Plane 1 integration.
+ */
+
+// Taxonomy definitions
+export {
+  CAPABILITY_CATEGORIES,
+  CAPABILITY_TYPES,
+  getCapabilityTypeCodes,
+  getCapabilityType,
+  getTypesByCategory,
+  calculatePlane1Score,
+  isValidCapabilityType,
+  getMaturityDescription,
+  getExtractionDescription,
+  CAPABILITY_TYPE_ENUM,
+} from './capability-taxonomy.js';
+
+// Plane 1 scoring
+export {
+  PLANE1_CONFIG,
+  calculateVenturePlane1Score,
+  calculateSDPlane1Score,
+  calculateVentureAggregatedPlane1,
+  calculatePlane1FromLedger,
+  formatPlane1Score,
+} from './plane1-scoring.js';
+
+// Reuse tracking
+export {
+  REUSE_CONFIG,
+  calculateEcosystemLift,
+  calculateCompoundingFactor,
+  generateReuseReport,
+  recordReuseEvent,
+  getReusesuggestions,
+  formatReuseReport,
+} from './capability-reuse-tracker.js';

--- a/lib/capabilities/plane1-scoring.js
+++ b/lib/capabilities/plane1-scoring.js
@@ -1,0 +1,337 @@
+/**
+ * Plane 1 Scoring Module - Capability Graph Assessment
+ * SD: SD-CAP-LEDGER-001 | US-004
+ *
+ * Integrates with the Capability Ledger to calculate Plane 1 scores
+ * for venture evaluation.
+ *
+ * Plane 1 (Capability Graph) Components:
+ * - Graph Centrality Gain (0-5): How central to capability graph
+ * - Maturity Lift (0-5): What maturity level does this add
+ * - Extraction Clarity (0-5): How reusable/extractable
+ *
+ * Total: 0-15 raw, weighted by category (max ~22.5)
+ * Threshold: 10 (ventures with Plane 1 < 10 should be questioned)
+ *
+ * Based on: Ground-Truth Triangulation Synthesis and Four-Plane Evaluation Matrix
+ */
+
+import { CAPABILITY_TYPES, CAPABILITY_CATEGORIES, calculatePlane1Score } from './capability-taxonomy.js';
+
+/**
+ * Plane 1 Scoring Configuration
+ */
+export const PLANE1_CONFIG = {
+  // Score ranges
+  MAX_RAW_SCORE: 15,
+  MAX_WEIGHTED_SCORE: 22.5, // 15 * 1.5 (max weight)
+
+  // Threshold for venture evaluation (from triangulation)
+  REJECTION_THRESHOLD: 10,
+  CAUTION_THRESHOLD: 12,
+
+  // Component weights for final calculation
+  WEIGHTS: {
+    GRAPH_CENTRALITY: 1.0,
+    MATURITY_LIFT: 1.0,
+    EXTRACTION_CLARITY: 1.0,
+  },
+
+  // Risk levels
+  RISK_LEVELS: {
+    HIGH: { max: 10, label: 'High Risk', action: 'Requires exception for approval' },
+    MEDIUM: { max: 15, label: 'Medium Risk', action: 'Review capability strategy' },
+    LOW: { max: 22.5, label: 'Low Risk', action: 'Proceed with monitoring' },
+  },
+};
+
+/**
+ * Calculate Plane 1 score for a venture based on its declared capabilities
+ *
+ * @param {Array} capabilities - Array of capability declarations
+ * @param {Object} options - Scoring options
+ * @returns {Object} Plane 1 scoring breakdown
+ */
+export function calculateVenturePlane1Score(capabilities, options = {}) {
+  if (!capabilities || capabilities.length === 0) {
+    return {
+      total_score: 0,
+      risk_level: 'HIGH',
+      risk_action: PLANE1_CONFIG.RISK_LEVELS.HIGH.action,
+      capabilities_assessed: 0,
+      breakdown: {
+        graph_centrality_gain: 0,
+        maturity_lift: 0,
+        extraction_clarity: 0,
+      },
+      recommendation: 'No capabilities declared. Define capability contributions.',
+      passes_threshold: false,
+    };
+  }
+
+  // Calculate individual scores
+  const scores = capabilities.map((cap) => calculatePlane1Score(cap));
+
+  // Aggregate scores (average weighted by capability count)
+  const totalGraphCentrality = scores.reduce((sum, s) => sum + s.graph_centrality_gain, 0);
+  const totalMaturity = scores.reduce((sum, s) => sum + s.maturity_lift, 0);
+  const totalExtraction = scores.reduce((sum, s) => sum + s.extraction_clarity, 0);
+  const totalWeighted = scores.reduce((sum, s) => sum + s.weighted_total, 0);
+
+  // Calculate averages
+  const count = capabilities.length;
+  const avgGraphCentrality = totalGraphCentrality / count;
+  const avgMaturity = totalMaturity / count;
+  const avgExtraction = totalExtraction / count;
+
+  // Total Plane 1 score is sum of weighted scores (not average)
+  // This rewards ventures that deliver more capabilities
+  const totalScore = Math.min(totalWeighted, PLANE1_CONFIG.MAX_WEIGHTED_SCORE);
+
+  // Determine risk level
+  let riskLevel = 'HIGH';
+  let riskAction = PLANE1_CONFIG.RISK_LEVELS.HIGH.action;
+
+  if (totalScore >= PLANE1_CONFIG.CAUTION_THRESHOLD) {
+    riskLevel = 'LOW';
+    riskAction = PLANE1_CONFIG.RISK_LEVELS.LOW.action;
+  } else if (totalScore >= PLANE1_CONFIG.REJECTION_THRESHOLD) {
+    riskLevel = 'MEDIUM';
+    riskAction = PLANE1_CONFIG.RISK_LEVELS.MEDIUM.action;
+  }
+
+  // Generate recommendation
+  const recommendation = generateRecommendation(
+    totalScore,
+    avgGraphCentrality,
+    avgMaturity,
+    avgExtraction,
+    capabilities
+  );
+
+  return {
+    total_score: Math.round(totalScore * 100) / 100,
+    risk_level: riskLevel,
+    risk_action: riskAction,
+    capabilities_assessed: count,
+    breakdown: {
+      graph_centrality_gain: Math.round(avgGraphCentrality * 100) / 100,
+      maturity_lift: Math.round(avgMaturity * 100) / 100,
+      extraction_clarity: Math.round(avgExtraction * 100) / 100,
+      raw_total: Math.round((avgGraphCentrality + avgMaturity + avgExtraction) * 100) / 100,
+    },
+    individual_scores: scores,
+    recommendation,
+    passes_threshold: totalScore >= PLANE1_CONFIG.REJECTION_THRESHOLD,
+    exceeds_caution: totalScore >= PLANE1_CONFIG.CAUTION_THRESHOLD,
+  };
+}
+
+/**
+ * Generate recommendation based on score analysis
+ */
+function generateRecommendation(totalScore, centrality, maturity, extraction, capabilities) {
+  const issues = [];
+
+  if (centrality < 2) {
+    issues.push('Low graph centrality - capabilities may be isolated');
+  }
+  if (maturity < 2) {
+    issues.push('Low maturity - capabilities need more development');
+  }
+  if (extraction < 2) {
+    issues.push('Low extraction clarity - capabilities may be hard to reuse');
+  }
+
+  // Check category diversity
+  const categories = new Set(
+    capabilities.map((c) => CAPABILITY_TYPES[c.capability_type]?.category)
+  );
+  if (categories.size < 2) {
+    issues.push('Low category diversity - consider adding different capability types');
+  }
+
+  // Check for AI capabilities (high value for EHG)
+  const hasAI = capabilities.some((c) =>
+    ['agent', 'crew', 'tool', 'skill'].includes(c.capability_type)
+  );
+  if (!hasAI) {
+    issues.push('No AI/automation capabilities - consider adding agents or tools');
+  }
+
+  if (totalScore >= PLANE1_CONFIG.CAUTION_THRESHOLD && issues.length === 0) {
+    return 'Strong capability contribution. Proceed with confidence.';
+  }
+
+  if (totalScore >= PLANE1_CONFIG.REJECTION_THRESHOLD) {
+    return `Acceptable capability contribution. ${issues.join('. ')}.`;
+  }
+
+  return `Capability contribution below threshold. ${issues.join('. ')}. Consider enhancing before approval.`;
+}
+
+/**
+ * Calculate Plane 1 score for an SD based on delivers_capabilities
+ *
+ * @param {Object} sd - Strategic Directive with delivers_capabilities
+ * @returns {Object} Plane 1 scoring for the SD
+ */
+export function calculateSDPlane1Score(sd) {
+  const capabilities = sd.delivers_capabilities || [];
+
+  if (capabilities.length === 0) {
+    return {
+      total_score: 0,
+      sd_id: sd.id,
+      message: 'SD does not declare any capabilities',
+      passes_threshold: false,
+    };
+  }
+
+  const score = calculateVenturePlane1Score(capabilities);
+
+  return {
+    ...score,
+    sd_id: sd.id,
+    sd_title: sd.title,
+  };
+}
+
+/**
+ * Aggregate Plane 1 scores for a venture across all its SDs
+ *
+ * @param {Array} sds - Array of Strategic Directives for a venture
+ * @returns {Object} Aggregated Plane 1 score
+ */
+export function calculateVentureAggregatedPlane1(sds) {
+  if (!sds || sds.length === 0) {
+    return {
+      total_score: 0,
+      sds_assessed: 0,
+      total_capabilities: 0,
+      passes_threshold: false,
+      message: 'No SDs found for venture',
+    };
+  }
+
+  // Collect all capabilities across SDs
+  const allCapabilities = sds.flatMap((sd) => sd.delivers_capabilities || []);
+
+  if (allCapabilities.length === 0) {
+    return {
+      total_score: 0,
+      sds_assessed: sds.length,
+      total_capabilities: 0,
+      passes_threshold: false,
+      message: 'No capabilities declared across SDs',
+    };
+  }
+
+  const score = calculateVenturePlane1Score(allCapabilities);
+
+  // Calculate SD-level breakdown
+  const sdBreakdown = sds.map((sd) => ({
+    sd_id: sd.id,
+    sd_title: sd.title,
+    capabilities_count: (sd.delivers_capabilities || []).length,
+    score: calculateSDPlane1Score(sd),
+  }));
+
+  return {
+    ...score,
+    sds_assessed: sds.length,
+    total_capabilities: allCapabilities.length,
+    sd_breakdown: sdBreakdown,
+  };
+}
+
+/**
+ * Query capability ledger and calculate Plane 1 for registered capabilities
+ *
+ * @param {Object} supabaseClient - Supabase client
+ * @param {string} sdId - SD ID to query
+ * @returns {Object} Plane 1 score from registered capabilities
+ */
+export async function calculatePlane1FromLedger(supabaseClient, sdId) {
+  const { data: capabilities, error } = await supabaseClient
+    .from('sd_capabilities')
+    .select('*')
+    .eq('sd_id', sdId)
+    .eq('action', 'registered');
+
+  if (error) {
+    console.error('Error querying capability ledger:', error);
+    return {
+      total_score: 0,
+      error: error.message,
+      passes_threshold: false,
+    };
+  }
+
+  if (!capabilities || capabilities.length === 0) {
+    return {
+      total_score: 0,
+      sd_id: sdId,
+      message: 'No registered capabilities found in ledger',
+      passes_threshold: false,
+    };
+  }
+
+  // Use stored Plane 1 scores from database
+  const totalScore = capabilities.reduce((sum, c) => sum + (c.plane1_score || 0), 0);
+  const avgScore = totalScore / capabilities.length;
+
+  return {
+    total_score: Math.round(totalScore * 100) / 100,
+    average_score: Math.round(avgScore * 100) / 100,
+    capabilities_count: capabilities.length,
+    passes_threshold: totalScore >= PLANE1_CONFIG.REJECTION_THRESHOLD,
+    capabilities: capabilities.map((c) => ({
+      key: c.capability_key,
+      type: c.capability_type,
+      plane1_score: c.plane1_score,
+      maturity: c.maturity_score,
+      extraction: c.extraction_score,
+      reuse_count: c.reuse_count,
+    })),
+  };
+}
+
+/**
+ * Format Plane 1 score for display
+ */
+export function formatPlane1Score(score) {
+  const indicator = score.passes_threshold
+    ? (score.exceeds_caution ? '✅' : '⚠️')
+    : '❌';
+
+  return `
+╔══════════════════════════════════════════════════════════════════╗
+║                    PLANE 1: CAPABILITY GRAPH                      ║
+╠══════════════════════════════════════════════════════════════════╣
+║  Total Score: ${String(score.total_score).padStart(5)} / ${PLANE1_CONFIG.MAX_WEIGHTED_SCORE}  ${indicator}                              ║
+║  Threshold:   ${PLANE1_CONFIG.REJECTION_THRESHOLD}  │  Caution: ${PLANE1_CONFIG.CAUTION_THRESHOLD}                                   ║
+╠══════════════════════════════════════════════════════════════════╣
+║  BREAKDOWN:                                                       ║
+║    Graph Centrality Gain: ${String(score.breakdown.graph_centrality_gain).padStart(4)} / 5                           ║
+║    Maturity Lift:         ${String(score.breakdown.maturity_lift).padStart(4)} / 5                           ║
+║    Extraction Clarity:    ${String(score.breakdown.extraction_clarity).padStart(4)} / 5                           ║
+╠══════════════════════════════════════════════════════════════════╣
+║  Risk Level: ${score.risk_level.padEnd(8)}                                             ║
+║  Action: ${score.risk_action.substring(0, 55).padEnd(55)}║
+╠══════════════════════════════════════════════════════════════════╣
+║  Capabilities Assessed: ${String(score.capabilities_assessed).padStart(3)}                                     ║
+║  Recommendation:                                                  ║
+║    ${score.recommendation.substring(0, 60).padEnd(60)}║
+╚══════════════════════════════════════════════════════════════════╝
+`.trim();
+}
+
+export default {
+  PLANE1_CONFIG,
+  calculateVenturePlane1Score,
+  calculateSDPlane1Score,
+  calculateVentureAggregatedPlane1,
+  calculatePlane1FromLedger,
+  formatPlane1Score,
+};

--- a/package.json
+++ b/package.json
@@ -244,7 +244,10 @@
     "hooks:setup": "node scripts/setup-global-hooks.cjs",
     "hooks:recover": "node scripts/hooks/recover-session-state.cjs",
     "hooks:baseline": "node scripts/hooks/compare-test-baseline.cjs",
-    "sd:baseline:deactivate": "node scripts/sd-baseline-deactivate.js"
+    "sd:baseline:deactivate": "node scripts/sd-baseline-deactivate.js",
+    "capability:analyze": "node scripts/capability-analyzer.js analyze",
+    "capability:scan": "node scripts/capability-analyzer.js scan",
+    "capability:report": "node scripts/capability-analyzer.js report"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.63.0",

--- a/scripts/capability-analyzer.js
+++ b/scripts/capability-analyzer.js
@@ -1,0 +1,530 @@
+#!/usr/bin/env node
+/**
+ * Capability Analyzer Pipeline
+ * SD: SD-CAP-LEDGER-001 | US-003
+ *
+ * Analyzes capabilities across the codebase and SD history.
+ * Identifies, scores, and tracks capability reuse.
+ *
+ * Usage:
+ *   npm run capability:analyze           # Full analysis
+ *   npm run capability:scan              # Scan codebase only
+ *   npm run capability:report            # Generate report
+ */
+
+import { createDatabaseClient } from './lib/supabase-connection.js';
+import { execSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import {
+  CAPABILITY_TYPES,
+  CAPABILITY_CATEGORIES,
+  calculatePlane1Score,
+  isValidCapabilityType,
+  getCapabilityType,
+} from '../lib/capabilities/capability-taxonomy.js';
+
+const EHG_ROOT = process.env.EHG_ROOT || '/mnt/c/_EHG/EHG';
+const ENGINEER_ROOT = process.env.ENGINEER_ROOT || process.cwd();
+
+/**
+ * Capability detection patterns for codebase scanning
+ */
+const DETECTION_PATTERNS = {
+  agent: {
+    patterns: [
+      /class\s+(\w+Agent)\s+extends/gi,
+      /export\s+const\s+(\w+_AGENT)\s*=/gi,
+      /agent_key:\s*['"]([^'"]+)['"]/gi,
+    ],
+    filePatterns: ['**/agents/**/*.{js,ts}', '**/sub-agents/**/*.{js,ts}'],
+  },
+  crew: {
+    patterns: [
+      /class\s+(\w+Crew)\s+extends/gi,
+      /crew:\s*\[/gi,
+      /createCrew\(['"]([^'"]+)['"]/gi,
+    ],
+    filePatterns: ['**/crews/**/*.{js,ts}'],
+  },
+  tool: {
+    patterns: [
+      /export\s+function\s+(\w+Tool)/gi,
+      /tools:\s*\[/gi,
+      /@tool\(['"]([^'"]+)['"]\)/gi,
+    ],
+    filePatterns: ['**/tools/**/*.{js,ts}'],
+  },
+  skill: {
+    patterns: [
+      /skill:\s*['"]([^'"]+)['"]/gi,
+      /\/(\w+)\.md$/gi,
+    ],
+    filePatterns: ['skills/**/*.md', '.claude/skills/**/*.md'],
+  },
+  database_schema: {
+    patterns: [
+      /CREATE TABLE\s+(?:IF NOT EXISTS\s+)?(\w+)/gi,
+    ],
+    filePatterns: ['database/**/*.sql', 'supabase/**/*.sql'],
+  },
+  database_function: {
+    patterns: [
+      /CREATE\s+(?:OR REPLACE\s+)?FUNCTION\s+(\w+)/gi,
+    ],
+    filePatterns: ['database/**/*.sql', 'supabase/**/*.sql'],
+  },
+  rls_policy: {
+    patterns: [
+      /CREATE POLICY\s+['"]([^'"]+)['"]/gi,
+    ],
+    filePatterns: ['database/**/*.sql', 'supabase/**/*.sql'],
+  },
+  api_endpoint: {
+    patterns: [
+      /router\.(get|post|put|delete|patch)\(['"]([^'"]+)['"]/gi,
+      /app\.(get|post|put|delete|patch)\(['"]([^'"]+)['"]/gi,
+    ],
+    filePatterns: ['**/routes/**/*.{js,ts}', '**/api/**/*.{js,ts}'],
+  },
+  component: {
+    patterns: [
+      /export\s+(?:default\s+)?function\s+(\w+)\s*\(/gi,
+      /export\s+const\s+(\w+):\s*(?:React\.)?FC/gi,
+    ],
+    filePatterns: ['src/components/**/*.{jsx,tsx}'],
+  },
+  hook: {
+    patterns: [
+      /export\s+function\s+(use\w+)/gi,
+      /export\s+const\s+(use\w+)\s*=/gi,
+    ],
+    filePatterns: ['**/hooks/**/*.{js,ts,jsx,tsx}'],
+  },
+  service: {
+    patterns: [
+      /class\s+(\w+Service)\s+/gi,
+      /export\s+const\s+(\w+Service)\s*=/gi,
+    ],
+    filePatterns: ['**/services/**/*.{js,ts}'],
+  },
+  workflow: {
+    patterns: [
+      /workflow:\s*['"]([^'"]+)['"]/gi,
+      /class\s+(\w+Workflow)/gi,
+    ],
+    filePatterns: ['**/workflows/**/*.{js,ts}'],
+  },
+  quality_gate: {
+    patterns: [
+      /GATE\d+/gi,
+      /validateGate\(['"]([^'"]+)['"]/gi,
+    ],
+    filePatterns: ['**/validators/**/*.{js,ts}', '**/gates/**/*.{js,ts}'],
+  },
+  protocol: {
+    patterns: [
+      /protocol:\s*['"]([^'"]+)['"]/gi,
+    ],
+    filePatterns: ['docs/**/*.md'],
+  },
+};
+
+/**
+ * Scan codebase for capabilities
+ */
+async function scanCodebase(rootPath = EHG_ROOT) {
+  console.log('🔍 Scanning codebase for capabilities...\n');
+  const capabilities = [];
+
+  for (const [type, config] of Object.entries(DETECTION_PATTERNS)) {
+    console.log(`   Scanning for ${type}...`);
+    let found = 0;
+
+    for (const filePattern of config.filePatterns) {
+      try {
+        // Use glob to find files
+        const files = execSync(
+          `find "${rootPath}" -path "*/${filePattern.replace('**/', '')}" -type f 2>/dev/null || true`,
+          { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
+        ).trim().split('\n').filter(Boolean);
+
+        for (const file of files) {
+          try {
+            const content = fs.readFileSync(file, 'utf-8');
+            for (const pattern of config.patterns) {
+              const matches = content.matchAll(pattern);
+              for (const match of matches) {
+                const capabilityKey = match[1] || match[2] || match[0];
+                if (capabilityKey && capabilityKey.length > 2) {
+                  capabilities.push({
+                    capability_type: type,
+                    capability_key: capabilityKey.replace(/['"]/g, ''),
+                    source_file: file.replace(rootPath, ''),
+                    detected_at: new Date().toISOString(),
+                  });
+                  found++;
+                }
+              }
+            }
+          } catch (e) {
+            // Skip unreadable files
+          }
+        }
+      } catch (e) {
+        // Pattern didn't match anything
+      }
+    }
+
+    console.log(`      Found ${found} ${type} capabilities`);
+  }
+
+  console.log(`\n   Total capabilities detected: ${capabilities.length}`);
+  return capabilities;
+}
+
+/**
+ * Load capabilities from database
+ */
+async function loadExistingCapabilities(client) {
+  console.log('\n📊 Loading existing capabilities from database...');
+
+  const result = await client.query(`
+    SELECT
+      capability_key,
+      capability_type,
+      sd_id,
+      action,
+      maturity_score,
+      extraction_score,
+      reuse_count,
+      plane1_score
+    FROM sd_capabilities
+    ORDER BY created_at DESC
+  `);
+
+  console.log(`   Found ${result.rows.length} capabilities in database`);
+  return result.rows;
+}
+
+/**
+ * Analyze capability dependencies
+ */
+async function analyzeDependencies(capabilities) {
+  console.log('\n🔗 Analyzing capability dependencies...');
+
+  const dependencyMap = new Map();
+
+  // Build import/dependency graph (simplified)
+  for (const cap of capabilities) {
+    if (cap.source_file) {
+      try {
+        const content = fs.readFileSync(
+          path.join(EHG_ROOT, cap.source_file),
+          'utf-8'
+        );
+
+        // Find imports
+        const imports = content.matchAll(/import\s+.*from\s+['"]([^'"]+)['"]/gi);
+        const deps = [];
+
+        for (const imp of imports) {
+          const importPath = imp[1];
+          // Find if any capability matches this import
+          const matchingCap = capabilities.find(
+            (c) => c.source_file && c.source_file.includes(importPath)
+          );
+          if (matchingCap) {
+            deps.push(matchingCap.capability_key);
+          }
+        }
+
+        if (deps.length > 0) {
+          dependencyMap.set(cap.capability_key, deps);
+        }
+      } catch (e) {
+        // Skip files that can't be read
+      }
+    }
+  }
+
+  console.log(`   Found ${dependencyMap.size} capabilities with dependencies`);
+  return dependencyMap;
+}
+
+/**
+ * Calculate Plane 1 scores for capabilities
+ */
+function calculateScores(capabilities, existingCaps, dependencyMap) {
+  console.log('\n📈 Calculating Plane 1 scores...');
+
+  const scored = capabilities.map((cap) => {
+    const existing = existingCaps.find((e) => e.capability_key === cap.capability_key);
+    const deps = dependencyMap.get(cap.capability_key) || [];
+    const dependedBy = Array.from(dependencyMap.entries())
+      .filter(([_, v]) => v.includes(cap.capability_key))
+      .map(([k, _]) => k);
+
+    // Use existing scores or estimate defaults
+    const maturity = existing?.maturity_score ?? estimateMaturity(cap);
+    const extraction = existing?.extraction_score ?? estimateExtraction(cap);
+    const reuseCount = existing?.reuse_count ?? dependedBy.length;
+
+    const scoreInput = {
+      capability_type: cap.capability_type,
+      maturity_score: maturity,
+      extraction_score: extraction,
+      reuse_count: reuseCount,
+    };
+
+    const plane1 = calculatePlane1Score(scoreInput);
+
+    return {
+      ...cap,
+      maturity_score: maturity,
+      extraction_score: extraction,
+      reuse_count: reuseCount,
+      depends_on: deps,
+      depended_by: dependedBy,
+      plane1_score: plane1.weighted_total,
+      plane1_breakdown: plane1,
+    };
+  });
+
+  return scored;
+}
+
+/**
+ * Estimate maturity score based on file analysis
+ */
+function estimateMaturity(cap) {
+  // Default estimates based on capability type patterns
+  const typeDefaults = {
+    agent: 2, // Most agents are functional
+    crew: 2,
+    tool: 3, // Tools tend to be more mature
+    skill: 2,
+    database_schema: 3, // Schemas are usually stable
+    database_function: 3,
+    rls_policy: 2,
+    api_endpoint: 2,
+    component: 2,
+    hook: 2,
+    service: 2,
+    workflow: 2,
+    quality_gate: 3,
+    protocol: 3,
+  };
+
+  return typeDefaults[cap.capability_type] || 2;
+}
+
+/**
+ * Estimate extraction score based on file location
+ */
+function estimateExtraction(cap) {
+  if (!cap.source_file) return 1;
+
+  // Higher extraction for lib/shared locations
+  if (cap.source_file.includes('/lib/') || cap.source_file.includes('/shared/')) {
+    return 3;
+  }
+  if (cap.source_file.includes('/utils/') || cap.source_file.includes('/helpers/')) {
+    return 3;
+  }
+  if (cap.source_file.includes('/components/') || cap.source_file.includes('/hooks/')) {
+    return 2;
+  }
+
+  return 1;
+}
+
+/**
+ * Generate capability report
+ */
+function generateReport(capabilities) {
+  console.log('\n📋 CAPABILITY LEDGER REPORT');
+  console.log('═'.repeat(70));
+
+  // Summary by category
+  const byCategory = {};
+  for (const cap of capabilities) {
+    const type = getCapabilityType(cap.capability_type);
+    const category = type?.category || 'unknown';
+    byCategory[category] = byCategory[category] || [];
+    byCategory[category].push(cap);
+  }
+
+  console.log('\n📊 SUMMARY BY CATEGORY:');
+  console.log('-'.repeat(50));
+  for (const [category, caps] of Object.entries(byCategory)) {
+    const catInfo = Object.values(CAPABILITY_CATEGORIES).find((c) => c.code === category);
+    const avgPlane1 = caps.reduce((sum, c) => sum + (c.plane1_score || 0), 0) / caps.length;
+    console.log(`   ${catInfo?.name || category}: ${caps.length} capabilities (avg Plane 1: ${avgPlane1.toFixed(2)})`);
+  }
+
+  // Top 10 by Plane 1 score
+  console.log('\n🏆 TOP 10 BY PLANE 1 SCORE:');
+  console.log('-'.repeat(50));
+  const top10 = [...capabilities]
+    .sort((a, b) => (b.plane1_score || 0) - (a.plane1_score || 0))
+    .slice(0, 10);
+
+  for (const cap of top10) {
+    console.log(
+      `   ${cap.plane1_score?.toFixed(2) || '0.00'} | ${cap.capability_type.padEnd(15)} | ${cap.capability_key.substring(0, 40)}`
+    );
+  }
+
+  // Most reused
+  console.log('\n🔄 MOST REUSED CAPABILITIES:');
+  console.log('-'.repeat(50));
+  const mostReused = [...capabilities]
+    .filter((c) => c.reuse_count > 0)
+    .sort((a, b) => (b.reuse_count || 0) - (a.reuse_count || 0))
+    .slice(0, 10);
+
+  if (mostReused.length === 0) {
+    console.log('   No reuse data yet. Run capability analysis after SD completions.');
+  } else {
+    for (const cap of mostReused) {
+      console.log(
+        `   ${cap.reuse_count} reuses | ${cap.capability_type.padEnd(15)} | ${cap.capability_key.substring(0, 40)}`
+      );
+    }
+  }
+
+  // Central capabilities (most depended upon)
+  console.log('\n🎯 MOST CENTRAL (DEPENDED UPON):');
+  console.log('-'.repeat(50));
+  const mostCentral = [...capabilities]
+    .filter((c) => c.depended_by && c.depended_by.length > 0)
+    .sort((a, b) => (b.depended_by?.length || 0) - (a.depended_by?.length || 0))
+    .slice(0, 10);
+
+  if (mostCentral.length === 0) {
+    console.log('   No dependency data yet. Run full codebase scan.');
+  } else {
+    for (const cap of mostCentral) {
+      console.log(
+        `   ${cap.depended_by.length} deps | ${cap.capability_type.padEnd(15)} | ${cap.capability_key.substring(0, 40)}`
+      );
+    }
+  }
+
+  console.log('\n' + '═'.repeat(70));
+
+  return {
+    total: capabilities.length,
+    byCategory,
+    top10,
+    mostReused,
+    mostCentral,
+  };
+}
+
+/**
+ * Sync capabilities to database
+ */
+async function syncToDatabase(client, capabilities) {
+  console.log('\n💾 Syncing capabilities to database...');
+
+  let inserted = 0;
+  let updated = 0;
+
+  for (const cap of capabilities) {
+    try {
+      // Check if exists
+      const existing = await client.query(
+        'SELECT id FROM sd_capabilities WHERE capability_key = $1 LIMIT 1',
+        [cap.capability_key]
+      );
+
+      if (existing.rows.length > 0) {
+        // Update existing
+        await client.query(
+          `UPDATE sd_capabilities SET
+            maturity_score = $1,
+            extraction_score = $2,
+            depends_on = $3,
+            depended_by = $4,
+            source_files = source_files || $5::jsonb
+          WHERE capability_key = $6`,
+          [
+            cap.maturity_score,
+            cap.extraction_score,
+            JSON.stringify(cap.depends_on || []),
+            JSON.stringify(cap.depended_by || []),
+            JSON.stringify([cap.source_file].filter(Boolean)),
+            cap.capability_key,
+          ]
+        );
+        updated++;
+      } else {
+        // Insert new (without sd_uuid for scanner-detected capabilities)
+        // These will be properly registered when an SD delivers them
+        console.log(`   Detected but not registered: ${cap.capability_key} (${cap.capability_type})`);
+      }
+    } catch (e) {
+      // Skip errors
+    }
+  }
+
+  console.log(`   Updated: ${updated} capabilities`);
+  console.log(`   New (unregistered): ${capabilities.length - updated} detected`);
+}
+
+/**
+ * Main analysis pipeline
+ */
+async function main() {
+  const command = process.argv[2] || 'analyze';
+
+  console.log('╔══════════════════════════════════════════════════════════════════╗');
+  console.log('║           CAPABILITY ANALYZER PIPELINE                            ║');
+  console.log('║           SD-CAP-LEDGER-001 | US-003                               ║');
+  console.log('╚══════════════════════════════════════════════════════════════════╝\n');
+
+  const client = await createDatabaseClient('engineer', { verify: false });
+
+  try {
+    if (command === 'scan' || command === 'analyze') {
+      // Scan codebase
+      const detected = await scanCodebase(EHG_ROOT);
+
+      // Also scan engineer repo
+      const engineerDetected = await scanCodebase(ENGINEER_ROOT);
+      detected.push(...engineerDetected);
+
+      // Load existing from database
+      const existing = await loadExistingCapabilities(client);
+
+      // Analyze dependencies
+      const deps = await analyzeDependencies(detected);
+
+      // Calculate scores
+      const scored = calculateScores(detected, existing, deps);
+
+      if (command === 'analyze') {
+        // Sync to database
+        await syncToDatabase(client, scored);
+      }
+
+      // Generate report
+      generateReport(scored);
+    } else if (command === 'report') {
+      // Load from database only
+      const existing = await loadExistingCapabilities(client);
+      generateReport(existing);
+    } else {
+      console.log('Usage:');
+      console.log('  node capability-analyzer.js analyze  - Full analysis with sync');
+      console.log('  node capability-analyzer.js scan     - Scan codebase only');
+      console.log('  node capability-analyzer.js report   - Report from database');
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Implement formal capability taxonomy with 18 types across 5 categories
- Extend sd_capabilities table with Plane 1 scoring fields
- Create capability analysis pipeline for codebase scanning
- Add ecosystem lift metrics and reuse tracking

## User Stories Completed
- US-001: Define capability taxonomy
- US-002: Audit and redesign sd_capabilities table
- US-003: Create capability analysis pipeline
- US-004: Integrate with Plane 1 scoring
- US-005: Track capability reuse metrics

## Test plan
- [x] Run `npm test:smoke` - passed
- [x] All user stories implemented
- [x] LEAD-FINAL-APPROVAL passed (93%)

## Files Changed
- lib/capabilities/ - New module with taxonomy, scoring, tracking
- database/migrations/20260108_capability_ledger_v2.sql - Schema updates
- scripts/capability-analyzer.js - Analysis pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)