### PR TITLE
fix(branch): ignore archive repos in cleanup discovery

### DIFF
--- a/scripts/branch-cleanup-v2.js
+++ b/scripts/branch-cleanup-v2.js
@@ -31,6 +31,9 @@ const execAsync = promisify(exec);
 // Base directory for repo discovery
 const EHG_BASE_DIR = '/mnt/c/_EHG';
 
+// Repositories to permanently ignore (archive/inactive repos with messy state)
+const IGNORED_REPOS = ['ehg-replit-archive', 'solara2'];
+
 // Static repo paths (fallback if discovery fails)
 const STATIC_REPO_PATHS = {
   EHG: '/mnt/c/_EHG/EHG',
@@ -48,6 +51,11 @@ function discoverRepos() {
     const entries = readdirSync(EHG_BASE_DIR);
 
     for (const entry of entries) {
+      // Skip ignored repos
+      if (IGNORED_REPOS.includes(entry)) {
+        continue;
+      }
+
       const fullPath = join(EHG_BASE_DIR, entry);
       const gitPath = join(fullPath, '.git');
 


### PR DESCRIPTION
## Summary
- Add `ehg-replit-archive` and `solara2` to IGNORED_REPOS list
- These repos are permanently excluded from branch cleanup discovery

## Reason
These archive repos have messy state that blocks cleanup:
- `solara2`: Has git worktree blocking branch deletion
- `ehg-replit-archive`: Has extensive uncommitted changes blocking checkout

Both are inactive archives that don't need branch management.

## Test plan
- [x] Verified `--discover` only shows EHG_Engineer and ehg
- [x] Verified `--all` processes only active repos
- [x] Verified both active repos show 0 branches (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)