### PR TITLE
feat(skills): Claude Code skills architecture overhaul v3.0.0

### DIFF
--- a/.claude/agents/design-agent.md
+++ b/.claude/agents/design-agent.md
@@ -32,7 +32,10 @@ This agent works with companion **Claude Code Skills** for creative guidance. Sk
 
 | Skill | Purpose | Invoke When |
 |-------|---------|-------------|
-| `frontend-design` | Visual design patterns, colors, typography | Creating UI from scratch |
+| `frontend-design` | Reference-driven UI, Glass Cockpit patterns | Creating UI from references |
+| `design-token-map` | Authoritative colors, typography, spacing | Binding to design tokens |
+| `design-validation-gates` | Component sizing gates, accessibility blocking | Enforcing design standards |
+| `ui-reference-workflow` | Reference image → component pipeline | Building from mockups |
 | `component-architecture` | 300-600 LOC sizing, Shadcn patterns | Building components |
 | `accessibility-guide` | WCAG 2.1 AA implementation patterns | Making things accessible |
 | `design-system` | Tailwind conventions, responsive design | Applying CSS/responsive styles |

--- a/docs/assets/ui_reference/README.md
+++ b/docs/assets/ui_reference/README.md
@@ -1,0 +1,81 @@
+# UI Reference Images
+
+This directory contains reference images for UI components and layouts used in the EHG Glass Cockpit interface.
+
+## Purpose
+
+Reference images serve as the source of truth for UI implementation. When creating new components:
+
+1. Check this directory for existing references
+2. Use the `ui-reference-workflow` skill for the image-to-component workflow
+3. Map visual elements to design tokens (see `design-token-map` skill)
+
+## Directory Structure
+
+```
+ui_reference/
+├── dashboards/          # Full dashboard layouts
+│   ├── glass-cockpit-main.png
+│   └── briefing-panel.png
+├── components/          # Individual component references
+│   ├── decision-card.png
+│   ├── metric-tile.png
+│   └── action-button.png
+└── patterns/            # UI patterns and compositions
+    ├── data-table.png
+    └── form-layout.png
+```
+
+## Adding New References
+
+1. **Name convention**: `kebab-case.png` (e.g., `decision-card.png`)
+2. **Resolution**: 2x for retina (e.g., 800x600 for a 400x300 component)
+3. **Format**: PNG preferred for UI, JPG acceptable for photos
+4. **Document**: Reference the image in your SD/PRD
+
+## Using References in Implementation
+
+### In SD/PRD
+
+```markdown
+## UI Reference
+- Image: `docs/assets/ui_reference/components/decision-card.png`
+- Target component: DecisionCard
+- Key elements: Header, body, action buttons
+```
+
+### In Code Comments
+
+```tsx
+/**
+ * DecisionCard component
+ * Reference: docs/assets/ui_reference/components/decision-card.png
+ */
+```
+
+## Design Token Mapping
+
+When analyzing a reference image, map visual elements to design tokens:
+
+| Visual Element | Design Token |
+|----------------|--------------|
+| Blue button | `bg-primary` |
+| Card shadow | `shadow-card` |
+| Heading | `text-lg font-semibold` |
+| Body text | `text-sm text-muted-foreground` |
+
+See `~/.claude/skills/design-token-map/SKILL.md` for the complete token reference.
+
+## Workflow
+
+1. **LEAD Phase**: Select reference image, define acceptance criteria
+2. **PLAN Phase**: Document component mapping, bind to API types
+3. **EXEC Phase**: Implement using `frontend-design` skill guidance
+4. **Validation**: Run DESIGN sub-agent for compliance check
+
+## Related Skills
+
+- `frontend-design` - Overall design guidance
+- `ui-reference-workflow` - Step-by-step implementation workflow
+- `design-token-map` - Authoritative design tokens
+- `design-validation-gates` - Validation requirements


### PR DESCRIPTION
## Summary

- Updated `design-agent.md` with 4 new design skills for reference-driven UI workflow
- Added `docs/assets/ui_reference/` placeholder structure for reference images

### Skills Created (27 total in ~/.claude/skills/)

**Design Ecosystem (4):**
- `design-token-map` - Authoritative colors, typography, spacing from CSS
- `design-validation-gates` - Component sizing gates (300-600 LOC), WCAG AA
- `ui-reference-workflow` - Reference image → component pipeline
- `frontend-design` - Enhanced with LEO integration

**LEO Process (7):**
- `validation-enforcement`, `handoff-workflow`, `context-management`
- `leo-process-scripts`, `git-workflow`, `sub-agent-engagement`, `retrospective-patterns`

**Database (4):**
- `database-agent-patterns`, `rls-policy-patterns`, `schema-validation`, `error-handling-database`

**Business Sub-Agents (9):**
- `pricing-strategy`, `financial-modeling`, `marketing-gtm`, `sales-operations`
- `crm-integration`, `analytics-metrics`, `launch-checklist`, `valuation-exit`, `monitoring-alerting`

**Orchestration (4):**
- `sub-agent-orchestration-guide`, `test-strategy-planning`
- `api-validation-gates`, `sub-agent-result-validation`

### SKILL-INDEX.md Updated
- Version: 2.0.0 → 3.0.0
- Total skills: 56 → 83 (+27)

## Test plan

- [x] All smoke tests pass
- [x] Skills created and verified in ~/.claude/skills/
- [x] SKILL-INDEX.md updated with new entries
- [x] design-agent.md references new skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)