### PR TITLE
feat: add /restart command and update /leo default behavior

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -1,97 +1,79 @@
 ---
-description: Trigger comprehensive LEO sub-agent analysis for any task
-argument-hint: [describe your task or issue]
+description: LEO stack management and session control
+argument-hint: [start|restart|stop|status|next]
 ---
 
-# 🤖 LEO Sub-Agent Analysis
+# LEO Stack Control
 
-**Request:** $ARGUMENTS
+**Command:** /leo $ARGUMENTS
 
-## Step 1: Quick-Fix Detection
+## Instructions
 
-**FIRST**, determine if this is a simple UAT bug/polish that qualifies for QUICKFIX sub-agent:
+Based on the argument provided, execute the appropriate action:
 
-**Quick-Fix Indicators (≥3 = use QUICKFIX):**
-- [ ] Found during UAT or manual testing
-- [ ] Estimated ≤50 LOC
-- [ ] Type: bug, typo, polish, or minor UI issue
-- [ ] No database schema changes
-- [ ] No authentication/security changes
-- [ ] Single file/component affected
-- [ ] Existing tests cover the change
-
-**If ≥3 indicators match:**
-1. **MANDATORY:** Read Quick-Fix Protocol Documentation first
-   ```
-   Read file: docs/quick-fix-protocol.md
-   ```
-2. Confirm understanding of:
-   - "Quick" = SCOPE, not QUALITY (same rigor as Strategic Directives)
-   - Compliance rubric mandatory (100-point scale)
-   - Tests must actually run (cannot assume)
-   - PR always required (no direct merge)
-   - User approval needed for commit/push
-3. Recommend QUICKFIX sub-agent (skip full analysis)
-
-**If <3 indicators match:** Proceed with full sub-agent analysis below
-
----
-
-## Step 2: Full Sub-Agent Analysis
-
-If QUICKFIX not recommended, analyze the following request and identify ALL relevant sub-agents:
-
-## Available Sub-Agents
-
-Evaluate each sub-agent and provide confidence scores (0-100%):
-
-### Core Sub-Agents:
-- **QUICKFIX** - Lightweight UAT bug fixes (≤50 LOC), auto-escalates if complex ("LEO Lite" orchestrator)
-- **SECURITY** - Authentication, authorization, encryption, vulnerabilities, OWASP
-- **PERFORMANCE** - Optimization, speed, caching, load times, scalability
-- **DESIGN** - UI/UX, CSS, styling, themes, dark mode, responsive design
-- **TESTING** - Unit tests, integration tests, e2e, coverage, QA
-- **DATABASE** - Schema, queries, migrations, optimization, indexes
-- **API** - REST, GraphQL, endpoints, integration, webhooks
-- **DEBUG** - Error analysis, troubleshooting, state issues, logs
-- **DOCUMENTATION** - Docs, README, guides, comments, API docs
-- **COST** - Resource optimization, billing, efficiency
-- **DEPENDENCY** - Package management, updates, vulnerabilities
-
-## Analysis Requirements:
-
-1. **Sub-Agent Selection**: Select ALL sub-agents with >50% confidence
-2. **Confidence Scoring**: Rate each selected agent 0-100%
-3. **Reasoning**: Explain WHY each agent is relevant
-4. **Prioritization**: Order by relevance/urgency
-5. **Specific Recommendations**: What each sub-agent should focus on
-6. **Coordination Strategy**: How agents should work together
-
-## Output Format:
-
-Provide structured analysis:
-
-```
-🎯 Selected Sub-Agents:
-• [AGENT_NAME] (XX%) - Brief reason
-• [AGENT_NAME] (XX%) - Brief reason
-
-📋 Detailed Analysis:
-[AGENT_NAME]:
-- Focus areas: ...
-- Specific checks: ...
-- Key considerations: ...
-
-🔄 Coordination Strategy:
-- First: [AGENT] should...
-- Then: [AGENT] should...
-- Finally: [AGENT] should...
+### If argument is "start" or "s":
+Run the LEO stack start command:
+```bash
+bash scripts/leo-stack.sh start
 ```
 
-## Context Awareness:
+### If argument is "restart" or "r":
+Run the LEO stack restart command:
+```bash
+bash scripts/leo-stack.sh restart
+```
 
-Consider the project context:
-- Current repository: EHG_Engineer
-- Technology stack: Node.js, React, Tailwind CSS, WebSocket
-- LEO Protocol version: v4.1.2
-- Dashboard on localhost:3000
+### If argument is "stop" or "x":
+Run the LEO stack stop command:
+```bash
+bash scripts/leo-stack.sh stop
+```
+
+### If argument is "status" or "st":
+Run the LEO stack status command:
+```bash
+bash scripts/leo-stack.sh status
+```
+
+### If argument is "next" or "n":
+Show the SD queue to determine what to work on next:
+```bash
+npm run sd:next
+```
+
+### If argument is "fast" or "f":
+Run fast restart (reduced delays):
+```bash
+bash scripts/leo-stack.sh restart --fast
+```
+
+### If no argument provided:
+Run the LEO protocol workflow:
+```bash
+npm run leo
+```
+
+### If argument is "help" or "h":
+Display this menu to the user:
+
+```
+LEO Commands:
+  /leo          - Run LEO protocol workflow (npm run leo)
+  /leo start    (s)  - Start all LEO servers
+  /leo restart  (r)  - Restart all LEO servers
+  /leo stop     (x)  - Stop all LEO servers
+  /leo status   (st) - Check server status
+  /leo next     (n)  - Show SD queue (what to work on)
+  /leo fast     (f)  - Fast restart (reduced delays)
+  /leo help     (h)  - Show this menu
+
+Shortcuts: /restart = restart servers, /leo n = next
+```
+
+Then ask the user which action they'd like to take.
+
+## Context
+- Engineer runs on port 3000
+- App runs on port 8080
+- Agent Platform runs on port 8000
+- Stack script: scripts/leo-stack.sh

--- a/.claude/commands/restart.md
+++ b/.claude/commands/restart.md
@@ -1,0 +1,18 @@
+# Restart Command
+
+Restart all LEO Stack servers.
+
+## Instructions
+
+Run the LEO stack restart script:
+
+```bash
+bash scripts/leo-stack.sh restart
+```
+
+This restarts all three servers:
+- EHG_Engineer (port 3000)
+- EHG App (port 8080)
+- Agent Platform (port 8000)
+
+After running, confirm the status shows all servers running.


### PR DESCRIPTION
## Summary
- Add `/restart` command to quickly restart LEO stack servers
- Update `/leo` command: running without arguments now executes `npm run leo`
- `/leo help` shows full command menu

## Test plan
- [ ] Run `/restart` - should restart all LEO servers
- [ ] Run `/leo` - should execute `npm run leo`
- [ ] Run `/leo help` - should show command menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)