### PR TITLE
feat(statusline): add hooks for real-time activity detection

### DIFF
--- a/.claude/set-activity-state.sh
+++ b/.claude/set-activity-state.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Sets the activity state for the status line traffic signal
+# Usage: set-activity-state.sh <running|idle>
+
+STATE_FILE="/mnt/c/_EHG/EHG_Engineer/.claude/logs/.context-state.json"
+ACTIVITY_STATE="${1:-idle}"
+
+# Ensure state file exists
+if [ ! -f "$STATE_FILE" ]; then
+    echo '{}' > "$STATE_FILE"
+fi
+
+# Update the activity state and timestamp
+CURRENT_EPOCH=$(date +%s)
+
+# Use jq to update just the activity fields
+if command -v jq &> /dev/null; then
+    jq --arg state "$ACTIVITY_STATE" --arg epoch "$CURRENT_EPOCH" '
+        .activity_state = $state |
+        .last_active_epoch = ($epoch | tonumber) |
+        .hook_triggered = true
+    ' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,28 @@
     "command": "/mnt/c/_EHG/EHG_Engineer/.claude/statusline-context-tracker.sh"
   },
   "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/set-activity-state.sh idle",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/set-activity-state.sh running",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary
Adds real-time activity detection using Claude Code hooks, tied to the notification bell:

- **Stop hook** → Instantly shows "YOUR TURN" when Claude finishes (bell rings)
- **UserPromptSubmit hook** → Instantly shows "WORKING" when you submit a prompt

Falls back to token change detection if hooks haven't fired.

## Files changed
- `.claude/settings.json` - Added Stop and UserPromptSubmit hooks
- `.claude/set-activity-state.sh` - New script to update state file
- `.claude/statusline-context-tracker.sh` - Prioritizes hook state over token detection

## Test plan
- [ ] Restart Claude Code to load new hooks
- [ ] Submit a prompt → should immediately show WORKING
- [ ] Wait for Claude to finish → should immediately show YOUR TURN (on bell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)