### PR TITLE
fix(notify): add retries, PreToolUse hook, and timing fix

### DIFF
--- a/.claude/notify-user.sh
+++ b/.claude/notify-user.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 # Claude Code Notification Script for WSL
 # Plays a Windows sound when Claude needs user input
+# Made resilient with retries and fallbacks
 
 # Default sound - pleasant notification chime
 SOUND_FILE="${1:-notify.wav}"
 WINDOWS_MEDIA_PATH="C:\\Windows\\Media"
+LOG_FILE="/mnt/c/_EHG/EHG_Engineer/.claude/logs/notify.log"
+MAX_RETRIES=2
 
 # Convert common names to full paths
 case "$SOUND_FILE" in
@@ -22,7 +25,25 @@ case "$SOUND_FILE" in
         ;;
 esac
 
-# Play the sound via PowerShell (works in WSL)
-powershell.exe -c "(New-Object Media.SoundPlayer '$WINDOWS_MEDIA_PATH\\$SOUND_FILE').PlaySync()" 2>/dev/null
+# Function to play sound with timeout
+play_sound() {
+    timeout 3 powershell.exe -c "(New-Object Media.SoundPlayer '$WINDOWS_MEDIA_PATH\\$SOUND_FILE').PlaySync()" 2>/dev/null
+    return $?
+}
+
+# Try to play with retries
+for ((i=1; i<=MAX_RETRIES; i++)); do
+    if play_sound; then
+        exit 0
+    fi
+    echo "$(date -Iseconds) Retry $i/$MAX_RETRIES failed for $SOUND_FILE" >> "$LOG_FILE" 2>/dev/null
+    sleep 0.2
+done
+
+# Fallback: try system beep
+echo -e '\a' 2>/dev/null
+
+# Log final failure
+echo "$(date -Iseconds) FAILED: Could not play $SOUND_FILE after $MAX_RETRIES retries" >> "$LOG_FILE" 2>/dev/null
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,8 +9,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/set-activity-state.sh idle && /mnt/c/_EHG/EHG_Engineer/.claude/notify-user.sh complete",
-            "timeout": 5
+            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/set-activity-state.sh idle && sleep 0.5 && /mnt/c/_EHG/EHG_Engineer/.claude/notify-user.sh complete",
+            "timeout": 6
           }
         ]
       }
@@ -27,6 +27,15 @@
       }
     ],
     "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/set-activity-state.sh running",
+            "timeout": 2
+          }
+        ]
+      },
       {
         "matcher": "Bash",
         "hooks": [


### PR DESCRIPTION
## Summary
Makes the notification and traffic signal more reliable:

**Notification improvements:**
- Add 3-second timeout to prevent hangs
- Retry up to 2 times on failure
- Fallback to terminal beep if PowerShell fails

**Activity state improvements:**
- Add PreToolUse hook to refresh "running" state during tool execution
- Prevents false "YOUR TURN" during long Bash commands
- Add 0.5s delay before sound so traffic signal flips first

🤖 Generated with [Claude Code](https://claude.com/claude-code)