### PR TITLE
fix(statusline): increase delay before notification bell

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/set-activity-state.sh idle && sleep 0.5 && /mnt/c/_EHG/EHG_Engineer/.claude/notify-user.sh complete",
+            "command": "/mnt/c/_EHG/EHG_Engineer/.claude/set-activity-state.sh idle && sleep 1.5 && /mnt/c/_EHG/EHG_Engineer/.claude/notify-user.sh complete",
             "timeout": 6
           }
         ]


### PR DESCRIPTION
## Summary
- Increases Stop hook delay from 0.5s to 1.5s
- Ensures traffic signal visually updates to "YOUR TURN" before the notification bell plays
- Improves user experience by making the state transition visible before audio feedback

## Test plan
- [x] Verified traffic signal changes to "YOUR TURN" before bell sounds
- [x] Tested multiple times to confirm consistent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)