### PR TITLE
fix(e2e): fix VLP-060 data persistence test assertion

### DIFF
--- a/tests/e2e/venture-launch/protocol-validation.spec.ts
+++ b/tests/e2e/venture-launch/protocol-validation.spec.ts
@@ -429,10 +429,10 @@ test.describe('Data Persistence', () => {
     await page.locator('nav, [role="navigation"], main, .sidebar').first().waitFor({ timeout: 10000 });
 
     // Verify page loads consistently
-    const finalTitle = page.locator('h1, h2').first();
+    const finalTitle = await page.locator('h1, h2').first().textContent();
 
     // Both navigations should result in the same page structure
-    await expect(finalTitle).toHaveText();
+    expect(finalTitle).toBeTruthy();
     // Either same title or both are truthy (page loaded)
     if (initialTitle && finalTitle) {
       expect(typeof initialTitle).toBe('string');


### PR DESCRIPTION
## Summary
- Fix VLP-060 test by properly awaiting textContent() call
- Replace toHaveText() with toBeTruthy() for proper assertion
- All 15 Venture Launch Protocol validation tests pass

## Test Results
```
15 passed (18.5s)
```

## SD Reference
SD-E2E-VENTURE-LAUNCH-001A: Domain A - Venture Launch Protocol Validation Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)