### PR TITLE
fix(hooks): resolve race condition in state file writes

### DIFF
--- a/.claude/set-activity-state.sh
+++ b/.claude/set-activity-state.sh
@@ -13,11 +13,17 @@ fi
 # Update the activity state and timestamp
 CURRENT_EPOCH=$(date +%s)
 
-# Use jq to update just the activity fields
+# Use jq to update just the activity fields (with error handling for race conditions)
 if command -v jq &> /dev/null; then
-    jq --arg state "$ACTIVITY_STATE" --arg epoch "$CURRENT_EPOCH" '
-        .activity_state = $state |
-        .last_active_epoch = ($epoch | tonumber) |
-        .hook_triggered = true
-    ' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    # Validate JSON before attempting update (handles race condition with statusline script)
+    if jq empty "$STATE_FILE" 2>/dev/null; then
+        jq --arg state "$ACTIVITY_STATE" --arg epoch "$CURRENT_EPOCH" '
+            .activity_state = $state |
+            .last_active_epoch = ($epoch | tonumber) |
+            .hook_triggered = true
+        ' "$STATE_FILE" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    else
+        # File is corrupted or being written - create fresh state
+        echo "{\"activity_state\": \"$ACTIVITY_STATE\", \"last_active_epoch\": $CURRENT_EPOCH, \"hook_triggered\": true}" > "${STATE_FILE}.tmp" && mv "${STATE_FILE}.tmp" "$STATE_FILE"
+    fi
 fi

--- a/.claude/statusline-context-tracker.sh
+++ b/.claude/statusline-context-tracker.sh
@@ -268,8 +268,8 @@ ACTIVITY_BAR+="$LABEL"
 for ((i=0; i<PADDING_RIGHT; i++)); do ACTIVITY_BAR+=" "; done
 ACTIVITY_SIGNAL="${ACTIVITY_COLOR}[${ACTIVITY_BAR}]${RESET}"
 
-# Update state file
-cat > "$STATE_FILE" << EOF
+# Update state file (atomic write to prevent race condition with set-activity-state.sh)
+cat > "${STATE_FILE}.tmp" << EOF
 {
   "last_context_used": $CONTEXT_USED,
   "last_percent": $PERCENT_USED,
@@ -286,6 +286,7 @@ cat > "$STATE_FILE" << EOF
   "activity_state": "$ACTIVITY_STATE"
 }
 EOF
+mv "${STATE_FILE}.tmp" "$STATE_FILE"
 
 # Batch logging (log every 10 seconds or on significant change)
 SHOULD_LOG="false"


### PR DESCRIPTION
## Summary
- Fixed race condition causing `jq: parse error: Expected value before ','` in Stop hook
- `statusline-context-tracker.sh` now uses atomic write (tmp file + mv)
- `set-activity-state.sh` now validates JSON before update with fallback to fresh state

## Root Cause (5 Whys)
1. jq failed parsing JSON with incomplete value on line 11
2. File was being written by another process during read
3. Two scripts (`statusline-context-tracker.sh` and `set-activity-state.sh`) access same state file
4. Heredoc write (`cat > file << EOF`) is non-atomic - truncates first, writes line-by-line
5. No file locking or atomic write pattern was implemented

## Test plan
- [x] Syntax validation passed for both scripts
- [x] Functional test: `set-activity-state.sh running` updates state correctly
- [x] Smoke tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)