### PR TITLE
docs(commands): add AskUserQuestion pattern for interactive suggestions

### DIFF
--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -394,27 +394,36 @@ The `/document` command connects to other commands in the workflow:
 
 ### After Documentation Updates
 
-**If documentation changes created uncommitted files:**
+**If documentation changes created uncommitted files - Use AskUserQuestion:**
+
+```javascript
+{
+  "question": "Documentation updated. Uncommitted changes detected. What's next?",
+  "header": "Next Step",
+  "multiSelect": false,
+  "options": [
+    {"label": "/ship", "description": "Commit and create PR for doc changes"},
+    {"label": "Done for now", "description": "Leave uncommitted, address later"}
+  ]
+}
 ```
-✅ Documentation Updated
 
-Files modified:
-- CLAUDE.md (regenerated)
-- docs/reference/xxx.md
+**If documentation is complete and committed - Use AskUserQuestion:**
 
-💡 Uncommitted changes detected. Run /ship to commit and create PR.
+```javascript
+{
+  "question": "Documentation updated and committed. What's next?",
+  "header": "Next Step",
+  "multiSelect": false,
+  "options": [
+    {"label": "/learn", "description": "Capture documentation patterns"},
+    {"label": "/leo next", "description": "Continue with next SD"},
+    {"label": "Done for now", "description": "End session"}
+  ]
+}
 ```
 
-**If documentation is complete and committed:**
-```
-✅ Documentation Updated
-
-All changes committed.
-
-💡 Next commands:
-   • /learn - Capture documentation patterns (if systemic improvement)
-   • /leo next - Continue with next SD
-```
+**Auto-invoke behavior:** When user selects a command option, immediately invoke that skill using the Skill tool.
 
 ### Related Commands
 

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -113,12 +113,21 @@ The created SD will appear in the SD queue. Follow normal LEO workflow:
 - EXEC phase (implementation)
 - LEAD-FINAL-APPROVAL (auto-resolves patterns)
 
-**After SD creation, suggest:**
-```
-✅ SD created: SD-LEARN-XXX
+**After SD creation - Use AskUserQuestion:**
 
-💡 Next: Run /leo next to start the LEO Protocol workflow for this SD
+```javascript
+{
+  "question": "SD created: SD-LEARN-XXX. What's next?",
+  "header": "Next Step",
+  "multiSelect": false,
+  "options": [
+    {"label": "/leo next", "description": "Start LEO Protocol workflow for this SD"},
+    {"label": "Done for now", "description": "End session, work on SD later"}
+  ]
+}
 ```
+
+**Auto-invoke behavior:** When user selects "/leo next", immediately invoke that skill using the Skill tool.
 
 This connects `/learn` → `/leo` in the command ecosystem.
 

--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -107,26 +107,37 @@ When an SD reaches LEAD-FINAL-APPROVAL and is marked complete, suggest this sequ
 | 4 | `/document` | Feature/API SD | Update documentation |
 | 5 | `/learn` | Always | Capture learnings while fresh |
 
-**For UI/Feature SDs:**
-```
-🎯 UI Feature Completed
+**For UI/Feature SDs - Use AskUserQuestion:**
 
-Recommended sequence:
-1. /restart - Fresh servers for visual review
-2. Manual visual check - Verify UI renders
-3. /ship - Create PR and merge
-4. /document - Update feature documentation
-5. /learn - Capture session learnings
+```javascript
+{
+  "question": "UI Feature completed! What's next?",
+  "header": "Post-Completion",
+  "multiSelect": false,
+  "options": [
+    {"label": "/restart", "description": "Fresh servers for visual review (recommended first)"},
+    {"label": "/ship", "description": "Skip restart, go straight to shipping"},
+    {"label": "Done for now", "description": "End session"}
+  ]
+}
 ```
 
-**For Infrastructure/Database SDs:**
-```
-🔧 Infrastructure Work Completed
+**For Infrastructure/Database SDs - Use AskUserQuestion:**
 
-Recommended sequence:
-1. /ship - Create PR and merge
-2. /learn - Capture learnings
+```javascript
+{
+  "question": "Infrastructure work completed! What's next?",
+  "header": "Post-Completion",
+  "multiSelect": false,
+  "options": [
+    {"label": "/ship", "description": "Create PR and merge"},
+    {"label": "/learn", "description": "Capture learnings first"},
+    {"label": "Done for now", "description": "End session"}
+  ]
+}
 ```
+
+**Auto-invoke behavior:** When user selects a command option, immediately invoke that skill using the Skill tool.
 
 ### Starting New Work
 

--- a/.claude/commands/quick-fix.md
+++ b/.claude/commands/quick-fix.md
@@ -186,24 +186,37 @@ The `/quick-fix` command connects to other commands:
 
 ### After Quick-Fix Completion
 
-**When PR is created with auto-merge:**
-```
-✅ Quick-Fix Complete: QF-YYYYMMDD-NNN
+**When PR is created with auto-merge - Use AskUserQuestion:**
 
-PR #XX created with auto-merge enabled.
-
-💡 Next commands:
-   • /learn - Capture any patterns from this fix (optional)
-   • /leo next - Continue with next SD if queue has work
+```javascript
+{
+  "question": "Quick-Fix complete! PR #XX created with auto-merge. What's next?",
+  "header": "Next Step",
+  "multiSelect": false,
+  "options": [
+    {"label": "/learn", "description": "Capture patterns from this fix"},
+    {"label": "/leo next", "description": "Continue with next SD"},
+    {"label": "Done for now", "description": "End session"}
+  ]
+}
 ```
 
-**If quick-fix was triggered by `/triangulation-protocol`:**
-```
-✅ Quick-Fix Complete
+**If quick-fix was triggered by `/triangulation-protocol` - Use AskUserQuestion:**
 
-This fix addressed the issue identified during triangulation.
-Consider running /learn if this revealed a systemic pattern.
+```javascript
+{
+  "question": "Quick-Fix complete! Issue from triangulation resolved. What's next?",
+  "header": "Next Step",
+  "multiSelect": false,
+  "options": [
+    {"label": "/learn", "description": "This revealed a systemic pattern"},
+    {"label": "/leo next", "description": "Continue with SD work"},
+    {"label": "Done for now", "description": "End session"}
+  ]
+}
 ```
+
+**Auto-invoke behavior:** When user selects a command option, immediately invoke that skill using the Skill tool.
 
 ### Related Commands
 

--- a/.claude/commands/restart.md
+++ b/.claude/commands/restart.md
@@ -30,32 +30,37 @@ The `/restart` command connects to other commands in the workflow:
 
 ### Post-Restart Suggestions
 
-**If SD just completed (LEAD-FINAL-APPROVAL passed):**
-```
-✅ Servers restarted
+**If SD just completed (LEAD-FINAL-APPROVAL passed) - Use AskUserQuestion:**
 
-📋 Post-Restart Checklist:
-1. Visual review - Open http://localhost:8080 and verify UI
-2. Then run /ship - Create PR and merge your work
-```
-
-**If starting fresh work:**
-```
-✅ Servers restarted
-
-💡 Ready to work:
-   • /leo next - See SD queue and pick next work
-   • /leo status - Check current SD progress
+```javascript
+{
+  "question": "Servers restarted. Ready for visual review?",
+  "header": "Post-Restart",
+  "multiSelect": false,
+  "options": [
+    {"label": "Visual review done, /ship", "description": "Proceed to shipping workflow"},
+    {"label": "/leo next", "description": "Check SD queue first"},
+    {"label": "Done for now", "description": "End session"}
+  ]
+}
 ```
 
-**If context is high (>70%):**
-```
-✅ Servers restarted
+**If starting fresh work - Use AskUserQuestion:**
 
-💡 Context is at XX%. Consider:
-   • /context-compact - Summarize and reduce context
-   • Start fresh session if >85%
+```javascript
+{
+  "question": "Servers restarted. What would you like to do?",
+  "header": "Next Step",
+  "multiSelect": false,
+  "options": [
+    {"label": "/leo next", "description": "See SD queue and pick next work"},
+    {"label": "/leo status", "description": "Check current SD progress"},
+    {"label": "Done for now", "description": "End session"}
+  ]
+}
 ```
+
+**Auto-invoke behavior:** When user selects a command option, immediately invoke that skill using the Skill tool.
 
 ### When to Use /restart
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -202,28 +202,38 @@ Options:
 
 ### Step 7: Post-Merge Command Ecosystem (NEW)
 
-**After a successful merge, display contextual suggestions based on the work just shipped:**
+**After a successful merge, present contextual suggestions using AskUserQuestion:**
 
 ```
 ✅ PR #X merged and branch deleted.
-
-📋 Next Steps (choose based on your context):
 ```
 
-| Condition | Suggest | Why |
-|-----------|---------|-----|
-| Always | `/learn` | Capture learnings while context is fresh |
-| Feature/API SD just completed | `/document` | Update documentation for new functionality |
-| More SDs in queue | `/leo next` | Continue with next SD |
-| Long session (>2 hours) | `/restart` | Fresh environment before next work |
+**Use AskUserQuestion with these options (adapt based on context):**
 
-**Present as non-blocking suggestion:**
+```javascript
+// Standard post-merge options
+{
+  "question": "What would you like to do next?",
+  "header": "Next Step",
+  "multiSelect": false,
+  "options": [
+    {"label": "/learn", "description": "Capture learnings from this session"},
+    {"label": "/document", "description": "Update documentation (feature/API work)"},
+    {"label": "/leo next", "description": "Continue with next SD in queue"},
+    {"label": "Done for now", "description": "End session, no further action"}
+  ]
+}
 ```
-💡 Suggested next commands:
-   • /learn - Capture learnings from this session
-   • /document - Update docs if feature/API work (detects SD type)
-   • /leo next - Continue with next SD in queue
-```
+
+**Auto-invoke behavior:** When user selects a command option (e.g., "/learn"), immediately invoke that skill using the Skill tool. Do NOT just acknowledge - execute the command.
+
+**Context-aware option filtering:**
+| Condition | Include Option |
+|-----------|----------------|
+| Always | `/learn`, "Done for now" |
+| Feature/API SD just completed | `/document` |
+| More SDs in queue | `/leo next` |
+| Long session (>2 hours) | `/restart` |
 
 **Why:** The command ecosystem connects related workflows. `/ship` is often the end of one work unit but the beginning of another.
 

--- a/.claude/commands/triangulation-protocol.md
+++ b/.claude/commands/triangulation-protocol.md
@@ -242,28 +242,37 @@ The `/triangulation-protocol` command connects to other commands:
 
 ### After Bug/Issue Confirmed
 
-**If issue is small (<50 LOC fix):**
+**If issue is small (<50 LOC fix) - Use AskUserQuestion:**
+
+```javascript
+{
+  "question": "Issue confirmed (~XX LOC fix). How would you like to proceed?",
+  "header": "Fix Approach",
+  "multiSelect": false,
+  "options": [
+    {"label": "/quick-fix [issue]", "description": "Small fix workflow with auto-merge"},
+    {"label": "Create full SD", "description": "Full LEO Protocol for this issue"},
+    {"label": "Done for now", "description": "Document and address later"}
+  ]
+}
 ```
-🔍 Ground-Truth Analysis Complete
 
-Issue confirmed: [description]
-Estimated fix: ~XX lines of code
+**If issue is larger (requires full SD) - Use AskUserQuestion:**
 
-💡 Suggested: Run /quick-fix [issue description]
-   Quick-fix workflow handles small fixes efficiently.
+```javascript
+{
+  "question": "Issue confirmed (>50 LOC). Requires full SD. What's next?",
+  "header": "SD Creation",
+  "multiSelect": false,
+  "options": [
+    {"label": "/learn", "description": "Create SD via learning patterns"},
+    {"label": "/leo next", "description": "Create SD manually via LEO Protocol"},
+    {"label": "Done for now", "description": "Document and address later"}
+  ]
+}
 ```
 
-**If issue is larger (requires full SD):**
-```
-🔍 Ground-Truth Analysis Complete
-
-Issue confirmed: [description]
-Scope: Too large for quick-fix (>50 LOC or multiple files)
-
-💡 Suggested:
-   1. Create SD via /learn (if pattern-based) or manual SD creation
-   2. Follow LEO Protocol: /leo next → LEAD → PLAN → EXEC
-```
+**Auto-invoke behavior:** When user selects a command option, immediately invoke that skill using the Skill tool.
 
 ### Related Commands
 

--- a/docs/reference/command-ecosystem.md
+++ b/docs/reference/command-ecosystem.md
@@ -181,18 +181,55 @@ Issue Reported
 Each command file (`.claude/commands/*.md`) includes a "Command Ecosystem Integration" section that:
 
 1. **Documents connections** - What commands it suggests and when
-2. **Provides templates** - Example output showing suggestions
+2. **Provides templates** - AskUserQuestion JSON for interactive suggestions
 3. **Lists conditions** - When each suggestion applies
+4. **Specifies auto-invoke** - Selected commands execute immediately
+
+## Suggestion UX Pattern
+
+All command suggestions use `AskUserQuestion` with auto-invoke behavior:
+
+### Standard Pattern
+
+```javascript
+// After completing a command action
+{
+  "question": "Action complete. What would you like to do next?",
+  "header": "Next Step",
+  "multiSelect": false,
+  "options": [
+    {"label": "/command-name", "description": "Brief description of what it does"},
+    {"label": "Done for now", "description": "End session, no further action"}
+  ]
+}
+```
+
+### Auto-Invoke Behavior
+
+When user selects a command option (e.g., "/learn"), the system immediately invokes that skill using the Skill tool. This provides:
+- **One-click workflow** - No need to type commands
+- **Contextual continuity** - Session state preserved
+- **Reduced friction** - Faster task completion
+
+### "Done for now" Option
+
+Every suggestion set includes a "Done for now" option allowing users to:
+- End the current workflow
+- Address remaining work later
+- Exit without further action
 
 ## Best Practices
 
-1. **Suggestions are non-blocking** - User can always ignore and proceed differently
-2. **Context-aware** - Suggestions change based on SD type, session length, etc.
-3. **Not circular** - Commands don't suggest themselves
-4. **Progressive** - Flow moves forward (completion → shipping → learning → new work)
+1. **Interactive suggestions** - Use AskUserQuestion, not plain text
+2. **Auto-invoke on selection** - Don't just acknowledge, execute the command
+3. **Context-aware options** - Filter options based on SD type, session state
+4. **Always include exit** - "Done for now" option in every suggestion
+5. **Not circular** - Commands don't suggest themselves
+6. **Progressive** - Flow moves forward (completion → shipping → learning → new work)
 
 ## Version History
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.1.0 | 2026-01-11 | Added AskUserQuestion pattern with auto-invoke behavior |
 | 1.0.0 | 2026-01-11 | Initial command ecosystem implementation |


### PR DESCRIPTION
## Summary
- Updated all 7 command files to use `AskUserQuestion` for suggestions
- Added auto-invoke behavior: selecting a command executes it immediately
- Added "Done for now" exit option to all suggestion sets
- Updated `command-ecosystem.md` with Suggestion UX Pattern section

## Key Changes

### Before (text-only suggestions)
```
💡 Suggested next commands:
   • /learn - Capture learnings
   • /leo next - Continue with next SD
```

### After (interactive AskUserQuestion)
```javascript
{
  "question": "What would you like to do next?",
  "header": "Next Step",
  "options": [
    {"label": "/learn", "description": "Capture learnings from this session"},
    {"label": "/leo next", "description": "Continue with next SD in queue"},
    {"label": "Done for now", "description": "End session"}
  ]
}
```

### Auto-Invoke Behavior
When user selects a command option, the system immediately invokes that skill - no need to type the command manually.

## Files Changed
- 7 command files (`.claude/commands/*.md`)
- 1 reference doc (`docs/reference/command-ecosystem.md` → v1.1.0)

## Test plan
- [x] All command files have AskUserQuestion patterns
- [x] Each suggestion set includes "Done for now" option
- [x] command-ecosystem.md documents the new pattern
- [x] Smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)