### PR TITLE
fix(lib): convert WSL paths to Windows-compatible relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,7 @@ src/client/dist/
 
 # Archived bootstrap scripts (local reference only)
 /docs/archive/
+
+# Claude Code temp files (Windows migration artifacts)
+tmpclaude-*-cwd
+nul

--- a/lib/session-conflict-checker.mjs
+++ b/lib/session-conflict-checker.mjs
@@ -12,16 +12,15 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
-import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 
-// Load environment from EHG_Engineer regardless of cwd
-const envPath = '/mnt/c/_EHG/EHG_Engineer/.env';
-if (fs.existsSync(envPath)) {
-  dotenv.config({ path: envPath });
-} else {
-  dotenv.config();
-}
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load environment from EHG_Engineer (Windows-compatible)
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -19,30 +19,32 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
 
-// Load environment from EHG_Engineer regardless of cwd
-const envPath = '/mnt/c/_EHG/EHG_Engineer/.env';
-if (fs.existsSync(envPath)) {
-  dotenv.config({ path: envPath });
-} else {
-  dotenv.config();
-}
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load environment from EHG_Engineer (Windows-compatible)
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
   process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
-// Session file directory (shared across codebases)
-const SESSION_DIR = '/mnt/c/_EHG/.claude-sessions';
+// Session file directory - use user's home directory for cross-platform compatibility
+const SESSION_DIR = path.join(os.homedir(), '.claude-sessions');
 const STALE_THRESHOLD_SECONDS = 300; // 5 minutes
 
 /**
- * Get the current TTY identifier
+ * Get the current TTY identifier (Windows: use PID as pseudo-TTY)
  */
 function getTTY() {
   try {
-    return execSync('tty 2>/dev/null || echo "unknown"', { encoding: 'utf8' }).trim();
+    if (process.platform === 'win32') {
+      return `win-${process.pid}`;
+    }
+    return execSync('tty', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
   } catch {
     return 'unknown';
   }
@@ -53,7 +55,7 @@ function getTTY() {
  */
 function getBranch() {
   try {
-    return execSync('git rev-parse --abbrev-ref HEAD 2>/dev/null', { encoding: 'utf8' }).trim();
+    return execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
   } catch {
     return 'unknown';
   }

--- a/scripts/sd-next.js
+++ b/scripts/sd-next.js
@@ -19,18 +19,17 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { execSync } from 'child_process';
-import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import { warnIfTempFilesExceedThreshold } from '../lib/root-temp-checker.mjs';
 import { getEstimatedDuration, formatEstimateShort } from './lib/duration-estimator.js';
 
-// Load environment from EHG_Engineer regardless of cwd
-const envPath = '/mnt/c/_EHG/EHG_Engineer/.env';
-if (fs.existsSync(envPath)) {
-  dotenv.config({ path: envPath });
-} else {
-  dotenv.config();
-}
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load environment from EHG_Engineer (Windows-compatible)
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
 
 // Import session manager (dynamic import for ESM compatibility)
 let sessionManager;
@@ -371,8 +370,8 @@ class SDNextSelector {
     // Method 1: Check git commits for SD references (last 7 days)
     try {
       const gitLog = execSync(
-        'git log --oneline --since="7 days ago" --format="%s" 2>/dev/null || echo ""',
-        { encoding: 'utf8', cwd: process.cwd() }
+        'git log --oneline --since="7 days ago" --format="%s"',
+        { encoding: 'utf8', cwd: process.cwd(), stdio: ['pipe', 'pipe', 'ignore'] }
       );
 
       const sdPattern = /SD-[A-Z0-9-]+/g;


### PR DESCRIPTION
## Summary
- Replace hardcoded WSL paths (`/mnt/c/_EHG/`) with portable relative paths using `path.resolve(__dirname, ...)`
- Add Windows platform detection for TTY handling in session-manager
- Fix `execSync` calls to use `stdio: ['pipe', 'pipe', 'ignore']` instead of `2>/dev/null`
- Add `tmpclaude-*` temp file patterns to .gitignore

## Test plan
- [x] Verify `npm run sd:next` runs without "system cannot find path" errors
- [x] Verify database connection works (OKR scorecard displays)
- [x] Verify git operations work in session-manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)