### PR TITLE
fix(env): convert WSL paths to cross-platform relative paths

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,8 +3,8 @@ BASE_URL=http://localhost:8080
 TEST_USER_EMAIL=test@example.com
 TEST_USER_PASSWORD=Test123!
 
-# EHG App Settings
-EHG_APP_PATH=/mnt/c/_EHG/ehg
+# EHG App Settings (cross-platform relative path)
+EHG_APP_PATH=../ehg
 EHG_APP_PORT=8080
 
 # Supabase Test Connection (Consolidated Database)

--- a/.env.test.local
+++ b/.env.test.local
@@ -8,8 +8,8 @@ BASE_URL=http://localhost:8080
 TEST_USER_EMAIL=rickfelix2000@gmail.com
 TEST_USER_PASSWORD=RQu4BX*cq*6*QKLZu
 
-# EHG App Settings
-EHG_APP_PATH=/mnt/c/_EHG/ehg
+# EHG App Settings (cross-platform relative path)
+EHG_APP_PATH=../ehg
 EHG_APP_PORT=8080
 
 # Supabase Test Connection (Consolidated Database)

--- a/.env.uat
+++ b/.env.uat
@@ -5,7 +5,7 @@
 # TARGET APPLICATION (EHG - What we're testing)
 # ============================================
 BASE_URL=http://localhost:8080
-EHG_APP_PATH=/mnt/c/_EHG/ehg
+EHG_APP_PATH=../ehg
 EHG_APP_PORT=8080
 
 # ============================================
@@ -25,7 +25,7 @@ ADMIN_PASSWORD=Admin123!
 # Dashboard for viewing UAT results (not being tested)
 DASHBOARD_URL=http://localhost:3000
 DASHBOARD_PORT=3000
-DASHBOARD_PATH=/mnt/c/_EHG/EHG_Engineer
+DASHBOARD_PATH=.
 
 # ============================================
 # DATABASE CONFIGURATION

--- a/scripts/map-e2e-tests-to-user-stories.mjs
+++ b/scripts/map-e2e-tests-to-user-stories.mjs
@@ -22,6 +22,10 @@ import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 dotenv.config();
 
@@ -31,8 +35,9 @@ const supabase = createClient(
   process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
 
-const EHG_APP_PATH = '/mnt/c/_EHG/EHG';
-const E2E_TEST_DIR = `${EHG_APP_PATH}/tests/e2e`;
+// Cross-platform path (relative from scripts/ to ehg/)
+const EHG_APP_PATH = process.env.EHG_APP_PATH || path.join(__dirname, '../../ehg');
+const E2E_TEST_DIR = path.join(EHG_APP_PATH, 'tests/e2e');
 
 /**
  * Recursively find all .spec.ts files in directory
@@ -70,7 +75,7 @@ async function scanE2ETestFiles() {
 
   for (const file of testFiles) {
     const content = await fs.readFile(file, 'utf-8');
-    const relativePath = file.replace(`${EHG_APP_PATH}/`, '');
+    const relativePath = path.relative(EHG_APP_PATH, file).replace(/\\/g, '/');
 
     // Extract all test() declarations with US-XXX references
     // Matches: test('US-001: Description', async ({ page }) => {

--- a/scripts/modules/handoff/map-e2e-tests-to-stories.js
+++ b/scripts/modules/handoff/map-e2e-tests-to-stories.js
@@ -10,9 +10,14 @@
 
 import fs from 'fs/promises';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
-const EHG_APP_PATH = '/mnt/c/_EHG/EHG';
-const E2E_TEST_DIR = `${EHG_APP_PATH}/tests/e2e`;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Cross-platform path (relative from scripts/modules/handoff/ to ehg/)
+const EHG_APP_PATH = process.env.EHG_APP_PATH || path.join(__dirname, '../../../../ehg');
+const E2E_TEST_DIR = path.join(EHG_APP_PATH, 'tests/e2e');
 
 /**
  * Recursively find all .spec.ts files in directory
@@ -51,7 +56,7 @@ async function scanE2ETestFiles() {
   for (const file of testFiles) {
     try {
       const content = await fs.readFile(file, 'utf-8');
-      const relativePath = file.replace(`${EHG_APP_PATH}/`, '');
+      const relativePath = path.relative(EHG_APP_PATH, file).replace(/\\/g, '/');
 
       // Extract all test() declarations with US-XXX references
       // Matches: test('US-001: Description', async ({ page }) => {

--- a/scripts/run-uat-tests.js
+++ b/scripts/run-uat-tests.js
@@ -30,7 +30,7 @@ const supabase = createClient(
 
 // Configuration
 const CONFIG = {
-  ehgPath: process.env.EHG_APP_PATH || '/mnt/c/_EHG/EHG',
+  ehgPath: process.env.EHG_APP_PATH || join(__dirname, '../../ehg'),
   ehgPort: process.env.EHG_APP_PORT || 5173,
   dashboardPort: process.env.DASHBOARD_PORT || 3000,
   headless: process.env.HEADLESS === 'true',


### PR DESCRIPTION
## Summary

SD-WIN-MIG-001: Environment Files Migration - Part of the WSL-to-Windows migration parent SD (SD-WIN-MIG-PARENT).

- Convert hardcoded `/mnt/c/_EHG/` WSL paths to cross-platform relative paths (`../ehg`)
- Update `.env.test`, `.env.test.local`, `.env.uat` environment files
- Fix script fallbacks in `run-uat-tests.js`, `map-e2e-tests-to-user-stories.mjs`, and `map-e2e-tests-to-stories.js`
- Use `path.join()` and `path.relative()` for cross-platform path handling

## Files Changed

| File | Change |
|------|--------|
| `.env.test` | `EHG_APP_PATH=/mnt/c/_EHG/ehg` → `../ehg` |
| `.env.test.local` | `EHG_APP_PATH=/mnt/c/_EHG/ehg` → `../ehg` |
| `.env.uat` | Both `EHG_APP_PATH` and `DASHBOARD_PATH` updated |
| `scripts/run-uat-tests.js` | Fallback path now uses `path.join()` |
| `scripts/map-e2e-tests-to-user-stories.mjs` | Added `__dirname` for ESM + cross-platform paths |
| `scripts/modules/handoff/map-e2e-tests-to-stories.js` | Added `__dirname` for ESM + cross-platform paths |

## Test plan

- [x] Verified path resolution with Node.js test
- [x] Confirmed `../ehg` resolves to `C:\Users\rickf\Projects\_EHG\ehg`
- [x] All modified scripts pass syntax validation
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)