### PR TITLE
feat(validation): UAT requirement checking (SD-UAT-VALID-001)

### DIFF
--- a/lib/utils/sd-type-validation.js
+++ b/lib/utils/sd-type-validation.js
@@ -183,12 +183,12 @@ export function getValidationRequirements(sd, validationProfile = null) {
       requiresLLMUXValidation: false,
       requiresUATExecution: true
     },
-    // LEO Protocol v4.4.1: Enhancement - improvements to existing features (UAT optional)
+    // LEO Protocol v4.4.1: Enhancement - improvements to existing features (UAT required per triangulation)
     enhancement: {
-      requiresHumanVerifiableOutcome: false,  // Existing feature, not new capability
+      requiresHumanVerifiableOutcome: true,  // User-facing improvements need verification
       humanVerificationType: 'ui_smoke_test',
       requiresLLMUXValidation: false,
-      requiresUATExecution: false  // Key difference from 'feature' - UAT is optional
+      requiresUATExecution: true  // LEO v4.4.1: Enhancement requires UAT (triangulation review)
     },
     performance: {
       requiresHumanVerifiableOutcome: true,
@@ -212,7 +212,7 @@ export function getValidationRequirements(sd, validationProfile = null) {
       requiresHumanVerifiableOutcome: false,
       humanVerificationType: 'none',
       requiresLLMUXValidation: false,
-      requiresUATExecution: false
+      requiresUATExecution: true  // LEO v4.4.1: Refactoring requires UAT for regression testing
     },
     orchestrator: {
       requiresHumanVerifiableOutcome: false,
@@ -276,6 +276,47 @@ export function getValidationRequirements(sd, validationProfile = null) {
       ? `SD type '${sdType}' requires ${hvConfig.humanVerificationType} verification`
       : `SD type '${sdType}' does not require human verification`
   };
+}
+
+/**
+ * Get UAT requirement for an SD type
+ * Used by /uat command to determine if UAT should proceed, prompt, or skip
+ *
+ * Returns:
+ * - 'REQUIRED': UAT must be executed (feature, bugfix, security, refactor, enhancement)
+ * - 'PROMPT': Ask user if UAT is needed (performance - only if visible UX changes)
+ * - 'EXEMPT': No UAT needed (infrastructure, database, docs, orchestrator)
+ *
+ * @param {string} sdType - The SD type (e.g., 'feature', 'bugfix', 'infrastructure')
+ * @returns {string} UAT requirement: 'REQUIRED', 'PROMPT', or 'EXEMPT'
+ */
+export function getUATRequirement(sdType) {
+  // SD types that require UAT execution
+  const REQUIRED_TYPES = ['feature', 'bugfix', 'security', 'refactor', 'enhancement'];
+
+  // SD types where UAT is optional (prompt user)
+  const PROMPT_TYPES = ['performance'];
+
+  // SD types exempt from UAT (no user-facing UI)
+  const EXEMPT_TYPES = ['infrastructure', 'database', 'documentation', 'docs', 'orchestrator'];
+
+  const normalizedType = (sdType || 'feature').toLowerCase();
+
+  if (REQUIRED_TYPES.includes(normalizedType)) {
+    return 'REQUIRED';
+  }
+
+  if (PROMPT_TYPES.includes(normalizedType)) {
+    return 'PROMPT';
+  }
+
+  if (EXEMPT_TYPES.includes(normalizedType)) {
+    return 'EXEMPT';
+  }
+
+  // Default to PROMPT for unknown types (safe fallback)
+  console.log(`   ⚠️  Unknown SD type '${sdType}' - defaulting to PROMPT for UAT`);
+  return 'PROMPT';
 }
 
 /**
@@ -479,6 +520,7 @@ export default {
   shouldSkipCodeValidation,
   requiresCodeValidation,
   getValidationRequirements,
+  getUATRequirement,
   getPlanVerifySubAgents,
   autoDetectSdType,
   validateSdType,


### PR DESCRIPTION
## Summary
- Add `getUATRequirement(sdType)` function to SD type validation
- Returns REQUIRED, PROMPT, or EXEMPT based on SD type
- Update refactor and enhancement to require UAT (per triangulation review)
- Part of SD-UAT-PLATFORM-001 (UAT Platform Integration)

## UAT Requirement Matrix
| SD Type | UAT Requirement |
|---------|-----------------|
| feature | REQUIRED |
| bugfix | REQUIRED |
| security | REQUIRED |
| refactor | REQUIRED |
| enhancement | REQUIRED |
| performance | PROMPT |
| infrastructure | EXEMPT |
| database | EXEMPT |
| docs | EXEMPT |
| orchestrator | EXEMPT |

## Test plan
- [ ] Import and call `getUATRequirement('feature')` - expect 'REQUIRED'
- [ ] Import and call `getUATRequirement('infrastructure')` - expect 'EXEMPT'
- [ ] Import and call `getUATRequirement('performance')` - expect 'PROMPT'

🤖 Generated with [Claude Code](https://claude.com/claude-code)