### PR TITLE
docs(commands): /uat ecosystem integration (SD-UAT-INT-001)

### DIFF
--- a/.claude/commands/restart.md
+++ b/.claude/commands/restart.md
@@ -30,7 +30,23 @@ The `/restart` command connects to other commands in the workflow:
 
 ### Post-Restart Suggestions
 
-**If SD just completed (LEAD-FINAL-APPROVAL passed) - Use AskUserQuestion:**
+**If SD requires UAT (feature, bugfix, security, refactor, enhancement) - Use AskUserQuestion:**
+
+```javascript
+{
+  "question": "Servers restarted. Ready for User Acceptance Testing?",
+  "header": "Post-Restart",
+  "multiSelect": false,
+  "options": [
+    {"label": "/uat (Recommended)", "description": "Run human acceptance testing before shipping"},
+    {"label": "Skip UAT, /ship", "description": "Ship without formal UAT (not recommended for features)"},
+    {"label": "/leo next", "description": "Check SD queue first"},
+    {"label": "Done for now", "description": "End session"}
+  ]
+}
+```
+
+**If SD is infrastructure/database/docs (UAT exempt) - Use AskUserQuestion:**
 
 ```javascript
 {
@@ -66,8 +82,17 @@ The `/restart` command connects to other commands in the workflow:
 
 | Scenario | Suggest /restart | Why |
 |----------|------------------|-----|
+| Before `/uat` for feature SDs | Yes | Clean environment for UAT testing |
 | Before `/ship` with UI changes | Yes | Verify renders in clean environment |
 | After LEAD-FINAL-APPROVAL | Yes (if UI) | Fresh state for visual verification |
 | Long session (>2 hours) | Yes | Prevents stale server state |
 | After major implementation | Yes | Ensure changes are reflected |
 | Quick-fix or small changes | Optional | Usually not needed |
+
+### Typical Flow After /restart
+
+```
+/restart → /uat → /ship → /document → /learn
+```
+
+For UAT-requiring SDs (feature, bugfix, security, refactor, enhancement), always suggest /uat before /ship.


### PR DESCRIPTION
## Summary
Integrate /uat command into the command ecosystem workflow.

## Changes

### restart.md
- Add /uat as recommended next step for UAT-requiring SDs
- Distinguish between UAT-required (feature, bugfix, security, refactor, enhancement) and UAT-exempt (infrastructure, database, docs) types
- Add typical flow diagram: /restart → /uat → /ship

### command-ecosystem.md  
- Update command flow diagram to include /uat
- Add /uat position description with defect routing
- Update primary flow table with UAT steps (2, 2a, 3, 3a, 3b)
- Add /uat command responsibility section

## Workflow
```
LEAD-FINAL-APPROVAL → /restart → /uat → /ship → /document → /learn → /leo next
                                   │
                                   └── defect found → /quick-fix or Create SD
```

## Test plan
- [ ] Run /restart on feature SD - verify /uat suggested
- [ ] Run /restart on infrastructure SD - verify /ship suggested (not /uat)
- [ ] Verify command-ecosystem.md diagram renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)