### PR TITLE
fix(validation): correct Gate 4 lookup for Gate 3 results location

### DIFF
--- a/scripts/modules/workflow-roi-validation.js
+++ b/scripts/modules/workflow-roi-validation.js
@@ -95,8 +95,14 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
           if (handoff.handoff_type === 'EXEC-TO-PLAN' && handoff.metadata?.gate2_validation) {
             gateResults.gate2 = handoff.metadata.gate2_validation;
           }
-          if (handoff.handoff_type === 'PLAN-TO-LEAD' && handoff.metadata?.gate3_validation) {
-            gateResults.gate3 = handoff.metadata.gate3_validation;
+          // SD-LIFECYCLE-GAP-002 FIX: Check both gate3_validation and gate_results.GATE3_TRACEABILITY
+          // The unified handoff system stores Gate 3 results in gate_results object
+          if (handoff.handoff_type === 'PLAN-TO-LEAD') {
+            if (handoff.metadata?.gate3_validation) {
+              gateResults.gate3 = handoff.metadata.gate3_validation;
+            } else if (handoff.metadata?.gate_results?.GATE3_TRACEABILITY) {
+              gateResults.gate3 = handoff.metadata.gate_results.GATE3_TRACEABILITY;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- Fixed Gate 4 validation lookup for Gate 3 results
- PLAN-TO-LEAD handoff stores Gate 3 results at `metadata.gate_results.GATE3_TRACEABILITY` not `metadata.gate3_validation`
- Added fallback check to find Gate 3 results in both locations

## Context
Discovered during SD-LIFECYCLE-GAP-002 completion when Gate 4 was failing to find Gate 3 results even though Gate 3 passed.

## Test plan
- [x] Manual verification: Gate 4 now correctly finds Gate 3 results
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)