### PR TITLE
fix(docmon): add pending_approval to retrospective validation statuses

### DIFF
--- a/lib/utils/adaptive-validation.js
+++ b/lib/utils/adaptive-validation.js
@@ -55,7 +55,9 @@ export async function detectValidationMode(sdId, options = {}) {
     }
 
     // Determine mode based on status
-    const retrospectiveStatuses = ['completed', 'done'];
+    // SD-LIFECYCLE-GAP-003: Add 'pending_approval' - at this stage, implementation is DONE
+    // and we should validate retrospectively (did THIS SD create violations?) not prospectively
+    const retrospectiveStatuses = ['completed', 'done', 'pending_approval'];
     const _prospectiveStatuses = ['active', 'in_progress', 'pending', 'blocked'];
 
     const mode = retrospectiveStatuses.includes(sd.status?.toLowerCase()) ? 'retrospective' : 'prospective';


### PR DESCRIPTION
## Summary

Fixes DOCMON sub-agent incorrectly blocking SDs during LEAD-FINAL-APPROVAL due to pre-existing legacy markdown files.

### Root Cause Analysis (5 Whys)

| Why | Finding |
|-----|---------|
| 1. Why was SD blocked at 85%? | `subagent_verified=false` in PLAN_verification phase |
| 2. Why was subagent_verified=false? | `check_required_sub_agents()` found DOCMON with BLOCKED verdict |
| 3. Why was DOCMON BLOCKED? | It flagged 98+ legacy markdown files as violations |
| 4. Why flag legacy files? | DOCMON ran in `prospective` mode which doesn't filter by creation date |
| 5. Why prospective mode? | `detectValidationMode()` only treated 'completed'/'done' as retrospective |

### The Fix

Added `pending_approval` to `retrospectiveStatuses` in `lib/utils/adaptive-validation.js` because:
- At `pending_approval` stage, implementation work is **DONE**
- SD is in LEAD-FINAL-APPROVAL phase
- Validation should check "did THIS SD create violations?" not "are there ANY violations?"

### Changes

- `lib/utils/adaptive-validation.js`: Added `pending_approval` to retrospective statuses array

## Test plan

- [x] DOCMON now returns CONDITIONAL_PASS for SDs with pre-existing legacy files
- [x] SD-LIFECYCLE-GAP-003 successfully completed after fix
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)