### PR TITLE
fix: resolve SD lookup pattern for non-UUID IDs in RETRO and orchestrator

### DIFF
--- a/lib/sub-agents/retro.js
+++ b/lib/sub-agents/retro.js
@@ -570,15 +570,55 @@ async function checkExistingRetrospective(sdId) {
  * Gather SD metadata
  */
 async function gatherSDMetadata(sdId) {
-  // SD-VENTURE-STAGE0-UI-001: Support both UUID and legacy_id lookups
+  // SD-EHG-001-FIX: Support UUID, id, legacy_id, and sd_key lookups with proper fallback
   const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sdId);
-  const queryField = isUUID ? 'id' : 'legacy_id';
 
-  const { data: sd, error } = await supabase
-    .from('strategic_directives_v2')
-    .select('*')
-    .eq(queryField, sdId)
-    .single();
+  let sd = null;
+  let error = null;
+
+  if (isUUID) {
+    // UUID format - use id column directly
+    const result = await supabase
+      .from('strategic_directives_v2')
+      .select('*')
+      .eq('id', sdId)
+      .maybeSingle();
+    sd = result.data;
+    error = result.error;
+  } else {
+    // Non-UUID: Try id column first (some SDs use string IDs like SD-EHG-001)
+    const idResult = await supabase
+      .from('strategic_directives_v2')
+      .select('*')
+      .eq('id', sdId)
+      .maybeSingle();
+
+    if (idResult.data) {
+      sd = idResult.data;
+      error = idResult.error;
+    } else {
+      // Try legacy_id
+      const legacyResult = await supabase
+        .from('strategic_directives_v2')
+        .select('*')
+        .eq('legacy_id', sdId)
+        .maybeSingle();
+
+      if (legacyResult.data) {
+        sd = legacyResult.data;
+        error = legacyResult.error;
+      } else {
+        // Try sd_key as last resort
+        const sdKeyResult = await supabase
+          .from('strategic_directives_v2')
+          .select('*')
+          .eq('sd_key', sdId)
+          .maybeSingle();
+        sd = sdKeyResult.data;
+        error = sdKeyResult.error;
+      }
+    }
+  }
 
   if (error || !sd) {
     return {


### PR DESCRIPTION
## Summary
- Fixed SD ID lookup in `retro.js` to support string IDs like `SD-EHG-001`
- Fixed SD ID lookup in `orchestrate-phase-subagents.js` with same pattern
- Both files now try `id` column first for non-UUID lookups before falling back to `legacy_id` and `sd_key`

## Problem Solved
RETRO sub-agent was failing when processing SDs with string IDs (e.g., `SD-EHG-001`) because the lookup function only checked `legacy_id` for non-UUID IDs. The SD had `id='SD-EHG-001'` and `legacy_id='EHG-001'`, causing "SD not found" errors.

## Changes
1. Updated `gatherSDMetadata()` in `lib/sub-agents/retro.js`
2. Updated `getSDDetails()` in `scripts/orchestrate-phase-subagents.js`
3. Lookup order: `id` (if non-UUID) → `legacy_id` → `sd_key`

## Testing
- ✅ Pre-commit smoke tests passed
- ✅ DOCMON database-first compliance check passed
- ✅ Successfully completed LEAD-FINAL-APPROVAL for SD-EHG-001

## Related
- Resolves blocker in SD-EHG-001 LEAD-FINAL-APPROVAL handoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)