### PR TITLE
feat(infrastructure): SD-UAT-WORKFLOW-001 - UAT-to-SD Workflow Improvements

### DIFF
--- a/docs/reference/sd-validation-profiles.md
+++ b/docs/reference/sd-validation-profiles.md
@@ -1,0 +1,240 @@
+# SD Validation Profiles Reference
+
+This document defines the validation requirements for Strategic Directives (SDs) based on their `sd_type`. It was created as part of SD-UAT-WORKFLOW-001 to eliminate trial-and-error during SD creation.
+
+---
+
+## Table of Contents
+
+1. [Valid SD Status Values](#valid-sd-status-values)
+2. [Valid SD Type Values](#valid-sd-type-values)
+3. [Type-Specific Required Fields](#type-specific-required-fields)
+4. [Feedback Table Schema](#feedback-table-schema)
+5. [Handoff Requirements by Type](#handoff-requirements-by-type)
+6. [Quick Reference Matrix](#quick-reference-matrix)
+
+---
+
+## Valid SD Status Values
+
+The `strategic_directives_v2.status` column accepts these values:
+
+| Status | Description | When to Use |
+|--------|-------------|-------------|
+| `draft` | Initial state, not yet started | New SDs |
+| `in_progress` | Work has begun | After LEAD-TO-PLAN approval |
+| `active` | Currently being executed | During EXEC phase |
+| `pending_approval` | Awaiting review | Before final approval |
+| `completed` | Work finished | After LEAD-FINAL-APPROVAL |
+| `deferred` | Postponed to future | Deprioritized SDs |
+| `cancelled` | Abandoned | SDs that won't be completed |
+
+**Constraint**: `strategic_directives_v2_status_check`
+
+---
+
+## Valid SD Type Values
+
+The `strategic_directives_v2.sd_type` column accepts these values:
+
+| SD Type | Purpose | Sub-agents Involved |
+|---------|---------|---------------------|
+| `bugfix` | Fix defects/errors | TESTING, GITHUB |
+| `database` | Schema changes, migrations | DATABASE |
+| `docs` | Documentation only | DOCMON |
+| `documentation` | Documentation (alias) | DOCMON |
+| `feature` | New functionality | DESIGN, DATABASE, TESTING, GITHUB |
+| `infrastructure` | Build tools, CI/CD, scripts | None (reduced workflow) |
+| `orchestrator` | Parent SD coordinating children | None (manages children) |
+| `qa` | Testing/quality work | TESTING |
+| `refactor` | Code restructuring | REGRESSION |
+| `security` | Security improvements | SECURITY |
+| `implementation` | General implementation | TESTING, GITHUB |
+| `discovery_spike` | Research/exploration | None |
+| `ux_debt` | UX improvements | DESIGN |
+| `product_decision` | Product direction | None |
+
+**Constraint**: `strategic_directives_v2_sd_type_check`
+
+---
+
+## Type-Specific Required Fields
+
+Different SD types have different required fields for handoff validation:
+
+### All Types (Required)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Auto-generated or explicit UUID |
+| `sd_key` | string | Human-readable key (e.g., SD-FIX-001) |
+| `title` | string | Descriptive title |
+| `description` | text | What the SD accomplishes |
+| `rationale` | text | **Why** this work matters |
+| `status` | enum | See valid statuses above |
+| `sd_type` | enum | See valid types above |
+| `success_criteria` | JSON array | Measurable success criteria |
+
+### bugfix / feature Types
+
+These types require **smoke_test_steps** for LEAD-TO-PLAN:
+
+```json
+{
+  "smoke_test_steps": [
+    {
+      "step_number": 1,
+      "instruction": "Navigate to [feature]",
+      "expected_outcome": "Feature loads without errors"
+    },
+    {
+      "step_number": 2,
+      "instruction": "Perform [action]",
+      "expected_outcome": "[Expected result]"
+    }
+  ]
+}
+```
+
+**Why**: Human-verifiable outcome (Q9 in LEAD checklist)
+
+### refactor Type
+
+Requires **intensity_level** field:
+
+| Level | Description | Risk |
+|-------|-------------|------|
+| `cosmetic` | Naming, formatting only | Very Low |
+| `minor` | Small structural changes | Low |
+| `moderate` | Significant restructuring | Medium |
+| `major` | Architecture-level changes | High |
+| `critical` | Core system changes | Very High |
+
+### orchestrator Type
+
+Requires:
+- `parent_sd_id` should be NULL (it's the parent)
+- Children must have `parent_sd_id` set to orchestrator's `id`
+
+### infrastructure / documentation Types
+
+**Reduced workflow**:
+- E2E tests not required
+- TESTING/GITHUB sub-agents skipped
+- EXEC-TO-PLAN optional
+
+---
+
+## Feedback Table Schema
+
+The `feedback` table stores UAT findings and manual feedback:
+
+### Valid source_type Values
+
+| Value | Description | When to Use |
+|-------|-------------|-------------|
+| `uat_failure` | Defect found during UAT | Automated by /uat command |
+| `manual_feedback` | User-reported issue | Manual entry |
+
+### Valid type Values
+
+| Value | Description | Maps to SD Type |
+|-------|-------------|-----------------|
+| `issue` | Bug, error, problem | `bugfix` |
+| `enhancement` | New feature request | `feature` |
+
+### Valid status Values
+
+| Value | Description |
+|-------|-------------|
+| `open` | New, unprocessed |
+| `triaged` | Reviewed, prioritized |
+| `in_progress` | Being worked on |
+| `resolved` | Fixed |
+| `closed` | Completed |
+| `rejected` | Won't fix |
+| `snoozed` | Deferred |
+
+### Valid priority Values
+
+| Value | Description |
+|-------|-------------|
+| `P0` | Critical - blocking |
+| `P1` | High - urgent |
+| `P2` | Medium - normal |
+| `P3` | Low - nice to have |
+
+---
+
+## Handoff Requirements by Type
+
+### LEAD-TO-PLAN Handoff
+
+| SD Type | Minimum Score | Required Fields | Notes |
+|---------|--------------|-----------------|-------|
+| `bugfix` | 90% | smoke_test_steps | Human-verifiable outcome |
+| `feature` | 90% | smoke_test_steps | Human-verifiable outcome |
+| `refactor` | 90% | intensity_level | Risk assessment |
+| `infrastructure` | 80% | None extra | Reduced validation |
+| `documentation` | 80% | None extra | Reduced validation |
+| `orchestrator` | 90% | Children defined | Coordination SD |
+
+### PLAN-TO-EXEC Handoff
+
+| SD Type | PRD Required | User Stories | E2E Tests |
+|---------|--------------|--------------|-----------|
+| `bugfix` | Yes | Yes | Yes |
+| `feature` | Yes | Yes | Yes |
+| `refactor` | Yes | Optional | Optional |
+| `infrastructure` | Yes | Yes | No |
+| `documentation` | Optional | No | No |
+| `orchestrator` | No | No | No (children have own) |
+
+### EXEC-TO-PLAN Handoff
+
+| SD Type | Required | Tests Must Pass |
+|---------|----------|-----------------|
+| `bugfix` | Yes | Yes |
+| `feature` | Yes | Yes |
+| `refactor` | Yes | Yes |
+| `infrastructure` | Optional | N/A |
+| `documentation` | No | N/A |
+| `orchestrator` | No | N/A |
+
+---
+
+## Quick Reference Matrix
+
+| SD Type | smoke_test_steps | intensity_level | E2E Required | Sub-agents |
+|---------|-----------------|-----------------|--------------|------------|
+| `bugfix` | REQUIRED | - | Yes | TESTING, GITHUB |
+| `feature` | REQUIRED | - | Yes | DESIGN, DATABASE, TESTING, GITHUB |
+| `refactor` | - | REQUIRED | Optional | REGRESSION |
+| `infrastructure` | - | - | No | None |
+| `documentation` | - | - | No | DOCMON |
+| `orchestrator` | - | - | No | None |
+| `security` | - | - | Yes | SECURITY |
+| `qa` | - | - | Yes | TESTING |
+| `ux_debt` | - | - | Yes | DESIGN |
+
+---
+
+## Related Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/create-sd.js` | Create SDs with type-aware validation |
+| `scripts/sd-from-feedback.js` | Convert feedback items to SDs |
+| `scripts/handoff.js` | Execute phase transitions |
+
+---
+
+## Version History
+
+| Date | Change |
+|------|--------|
+| 2026-01-19 | Initial creation (SD-UAT-WORKFLOW-001) |
+
+---
+
+*This document is maintained as part of the LEO Protocol infrastructure.*

--- a/lib/uat/feedback-saver.js
+++ b/lib/uat/feedback-saver.js
@@ -1,0 +1,210 @@
+/**
+ * UAT Feedback Saver
+ *
+ * Auto-saves raw user feedback to markdown files during UAT sessions.
+ * This ensures no feedback is lost even if the session ends unexpectedly.
+ *
+ * Created as part of SD-UAT-WORKFLOW-001 - UAT-to-SD Workflow Process Improvements
+ *
+ * @module lib/uat/feedback-saver
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * Directory where UAT session files are stored
+ */
+const UAT_SESSIONS_DIR = 'uat-sessions';
+
+/**
+ * Ensures the UAT sessions directory exists
+ * @returns {Promise<string>} The absolute path to the sessions directory
+ */
+async function ensureSessionsDir() {
+  const sessionsPath = path.resolve(process.cwd(), UAT_SESSIONS_DIR);
+  try {
+    await fs.mkdir(sessionsPath, { recursive: true });
+  } catch (error) {
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  }
+  return sessionsPath;
+}
+
+/**
+ * Generates the filename for a raw feedback file
+ * @param {string} sdKey - The SD key (e.g., 'SD-UAT-NAV-001')
+ * @param {Date} [date] - The date for the filename (defaults to now)
+ * @returns {string} The filename (e.g., 'SD-UAT-NAV-001_2026-01-19_raw-feedback.md')
+ */
+function generateFilename(sdKey, date = new Date()) {
+  const dateStr = date.toISOString().split('T')[0]; // YYYY-MM-DD
+  return `${sdKey}_${dateStr}_raw-feedback.md`;
+}
+
+/**
+ * Saves raw feedback to a markdown file
+ *
+ * @param {string} sdKey - The SD key being tested
+ * @param {string} rawText - The raw user feedback (verbatim)
+ * @param {Object} [options] - Optional parameters
+ * @param {string} [options.testNumber] - The test number (e.g., '1', '2')
+ * @param {string} [options.testTitle] - The test title (e.g., 'Verify Sidebar Menu Navigation')
+ * @param {Date} [options.timestamp] - The timestamp for the feedback
+ * @param {boolean} [options.append] - Whether to append to existing file (default: true)
+ * @returns {Promise<{success: boolean, filePath: string, error?: string}>}
+ */
+export async function saveRawFeedback(sdKey, rawText, options = {}) {
+  const {
+    testNumber,
+    testTitle,
+    timestamp = new Date(),
+    append = true
+  } = options;
+
+  try {
+    const sessionsPath = await ensureSessionsDir();
+    const filename = generateFilename(sdKey, timestamp);
+    const filePath = path.join(sessionsPath, filename);
+
+    // Build the content block
+    let content = '';
+
+    // Check if file exists and we're not appending
+    let fileExists = false;
+    try {
+      await fs.access(filePath);
+      fileExists = true;
+    } catch {
+      fileExists = false;
+    }
+
+    // Add header if new file
+    if (!fileExists) {
+      content += '# UAT Session Raw Feedback\n';
+      content += `**SD**: ${sdKey}\n`;
+      content += `**Date**: ${timestamp.toISOString().split('T')[0]}\n`;
+      content += '**Tester**: User (Manual)\n\n';
+      content += '---\n\n';
+    }
+
+    // Add test header if test info provided
+    if (testNumber || testTitle) {
+      const testHeader = testNumber ? `## Test ${testNumber}` : '## Test';
+      content += testHeader;
+      if (testTitle) {
+        content += `: ${testTitle}`;
+      }
+      content += '\n\n';
+    }
+
+    // Add timestamp and raw feedback
+    content += '### Raw User Feedback (verbatim)\n';
+    content += `*Captured: ${timestamp.toISOString()}*\n\n`;
+    content += `> ${rawText.replace(/\n/g, '\n> ')}\n\n`;
+    content += '---\n\n';
+
+    // Write or append to file
+    if (append && fileExists) {
+      await fs.appendFile(filePath, content, 'utf8');
+    } else {
+      await fs.writeFile(filePath, content, 'utf8');
+    }
+
+    return {
+      success: true,
+      filePath: filePath
+    };
+  } catch (error) {
+    return {
+      success: false,
+      filePath: '',
+      error: error.message
+    };
+  }
+}
+
+/**
+ * Appends processed observations/defects to the raw feedback file
+ *
+ * @param {string} sdKey - The SD key being tested
+ * @param {Object} processed - The processed data
+ * @param {Array<Object>} [processed.observations] - Extracted observations
+ * @param {Array<Object>} [processed.defects] - Extracted defects
+ * @param {string} [processed.result] - Test result (PASS/FAIL/WARN)
+ * @param {Date} [timestamp] - The date for the file
+ * @returns {Promise<{success: boolean, filePath: string, error?: string}>}
+ */
+export async function appendProcessedData(sdKey, processed, timestamp = new Date()) {
+  try {
+    const sessionsPath = await ensureSessionsDir();
+    const filename = generateFilename(sdKey, timestamp);
+    const filePath = path.join(sessionsPath, filename);
+
+    let content = '';
+
+    // Add result if provided
+    if (processed.result) {
+      content += `### Result: ${processed.result}\n\n`;
+    }
+
+    // Add observations table if provided
+    if (processed.observations && processed.observations.length > 0) {
+      content += '### Extracted Observations\n\n';
+      content += '| Item | Result | Notes |\n';
+      content += '|------|--------|-------|\n';
+      for (const obs of processed.observations) {
+        content += `| ${obs.item || '-'} | ${obs.result || '-'} | ${obs.notes || '-'} |\n`;
+      }
+      content += '\n';
+    }
+
+    // Add defects table if provided
+    if (processed.defects && processed.defects.length > 0) {
+      content += '### Defects Extracted\n\n';
+      content += '| ID | Title | Severity | Type | Description |\n';
+      content += '|----|-------|----------|------|-------------|\n';
+      for (const def of processed.defects) {
+        content += `| ${def.id || '-'} | ${def.title || '-'} | ${def.severity || '-'} | ${def.type || '-'} | ${def.description || '-'} |\n`;
+      }
+      content += '\n';
+    }
+
+    content += '---\n\n';
+
+    // Append to file
+    await fs.appendFile(filePath, content, 'utf8');
+
+    return {
+      success: true,
+      filePath: filePath
+    };
+  } catch (error) {
+    return {
+      success: false,
+      filePath: '',
+      error: error.message
+    };
+  }
+}
+
+/**
+ * Gets the path to the raw feedback file for an SD on a given date
+ *
+ * @param {string} sdKey - The SD key
+ * @param {Date} [date] - The date (defaults to today)
+ * @returns {string} The file path
+ */
+export function getRawFeedbackPath(sdKey, date = new Date()) {
+  const sessionsPath = path.resolve(process.cwd(), UAT_SESSIONS_DIR);
+  const filename = generateFilename(sdKey, date);
+  return path.join(sessionsPath, filename);
+}
+
+export default {
+  saveRawFeedback,
+  appendProcessedData,
+  getRawFeedbackPath
+};

--- a/package.json
+++ b/package.json
@@ -196,6 +196,8 @@
     "sd:verify:list": "node scripts/sd-verify.js --list",
     "sd:complete": "node scripts/sd-verify.js --complete",
     "sd:hierarchy": "node scripts/lib/sd-hierarchy-mapper.js",
+    "sd:new": "node scripts/create-sd.js",
+    "sd:from-feedback": "node scripts/sd-from-feedback.js",
     "leo:continuous": "node scripts/leo-continuous.js",
     "leo:checkpoint": "node scripts/lib/leo-checkpoint.js",
     "baseline:list": "node scripts/baseline.js list",

--- a/scripts/create-sd.js
+++ b/scripts/create-sd.js
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+
+/**
+ * SD Creation Helper Script
+ *
+ * Creates Strategic Directives with type-aware validation profiles.
+ * Ensures all required fields are present based on sd_type.
+ *
+ * Created as part of SD-UAT-WORKFLOW-001 - UAT-to-SD Workflow Process Improvements
+ *
+ * Usage:
+ *   node scripts/create-sd.js --type bugfix --title "Fix login error"
+ *   node scripts/create-sd.js --type feature --title "Add dark mode" --parent SD-PARENT-001
+ *   node scripts/create-sd.js --interactive
+ *
+ * @module scripts/create-sd
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { randomUUID } from 'crypto';
+import readline from 'readline';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// Valid SD types and their requirements
+const SD_TYPES = {
+  bugfix: {
+    requiredFields: ['smoke_test_steps'],
+    defaultPriority: 'high',
+    description: 'Fix defects/errors',
+    subAgents: ['TESTING', 'GITHUB']
+  },
+  feature: {
+    requiredFields: ['smoke_test_steps'],
+    defaultPriority: 'medium',
+    description: 'New functionality',
+    subAgents: ['DESIGN', 'DATABASE', 'TESTING', 'GITHUB']
+  },
+  refactor: {
+    requiredFields: ['intensity_level'],
+    defaultPriority: 'medium',
+    description: 'Code restructuring',
+    subAgents: ['REGRESSION']
+  },
+  infrastructure: {
+    requiredFields: [],
+    defaultPriority: 'medium',
+    description: 'Build tools, CI/CD, scripts',
+    subAgents: []
+  },
+  documentation: {
+    requiredFields: [],
+    defaultPriority: 'low',
+    description: 'Documentation only',
+    subAgents: ['DOCMON']
+  },
+  orchestrator: {
+    requiredFields: [],
+    defaultPriority: 'high',
+    description: 'Parent SD coordinating children',
+    subAgents: []
+  },
+  security: {
+    requiredFields: [],
+    defaultPriority: 'high',
+    description: 'Security improvements',
+    subAgents: ['SECURITY']
+  },
+  qa: {
+    requiredFields: [],
+    defaultPriority: 'medium',
+    description: 'Testing/quality work',
+    subAgents: ['TESTING']
+  },
+  ux_debt: {
+    requiredFields: [],
+    defaultPriority: 'low',
+    description: 'UX improvements',
+    subAgents: ['DESIGN']
+  },
+  database: {
+    requiredFields: [],
+    defaultPriority: 'medium',
+    description: 'Schema changes, migrations',
+    subAgents: ['DATABASE']
+  }
+};
+
+// Valid status values (for reference - used in help text)
+const _VALID_STATUSES = ['draft', 'in_progress', 'active', 'pending_approval', 'completed', 'deferred', 'cancelled'];
+
+// Valid intensity levels for refactor type
+const INTENSITY_LEVELS = ['cosmetic', 'minor', 'moderate', 'major', 'critical'];
+
+// Valid priorities (for reference - used in help text)
+const _VALID_PRIORITIES = ['critical', 'high', 'medium', 'low'];
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {
+    type: null,
+    title: null,
+    description: null,
+    parent: null,
+    priority: null,
+    interactive: false,
+    help: false
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--type':
+      case '-t':
+        parsed.type = args[++i];
+        break;
+      case '--title':
+        parsed.title = args[++i];
+        break;
+      case '--description':
+      case '-d':
+        parsed.description = args[++i];
+        break;
+      case '--parent':
+      case '-p':
+        parsed.parent = args[++i];
+        break;
+      case '--priority':
+        parsed.priority = args[++i];
+        break;
+      case '--interactive':
+      case '-i':
+        parsed.interactive = true;
+        break;
+      case '--help':
+      case '-h':
+        parsed.help = true;
+        break;
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Display help message
+ */
+function showHelp() {
+  console.log(`
+SD Creation Helper Script
+=========================
+
+Creates Strategic Directives with type-aware validation profiles.
+
+Usage:
+  node scripts/create-sd.js [options]
+
+Options:
+  --type, -t <type>       SD type (required unless interactive)
+  --title <title>         SD title (required unless interactive)
+  --description, -d       SD description
+  --parent, -p <sd_key>   Parent SD key for child SDs
+  --priority              Priority: critical, high, medium, low
+  --interactive, -i       Interactive mode (prompts for all fields)
+  --help, -h              Show this help
+
+Valid SD Types:
+${Object.entries(SD_TYPES).map(([type, info]) => `  ${type.padEnd(15)} - ${info.description}`).join('\n')}
+
+Examples:
+  node scripts/create-sd.js --type bugfix --title "Fix login error"
+  node scripts/create-sd.js --type feature --title "Add dark mode" --parent SD-PARENT-001
+  node scripts/create-sd.js --interactive
+
+Required Fields by Type:
+  bugfix/feature  → smoke_test_steps (will prompt)
+  refactor        → intensity_level (will prompt)
+  other types     → no extra fields required
+`);
+}
+
+/**
+ * Create readline interface for interactive prompts
+ */
+function createReadline() {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+}
+
+/**
+ * Prompt user for input
+ */
+function prompt(rl, question) {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * Prompt for smoke test steps
+ */
+async function promptSmokeTestSteps(rl) {
+  console.log('\n📋 Smoke Test Steps Required');
+  console.log('   (Enter 2-5 steps that verify the fix/feature works)\n');
+
+  const steps = [];
+  let stepNumber = 1;
+  let addMore = true;
+
+  while (addMore && steps.length < 5) {
+    const instruction = await prompt(rl, `Step ${stepNumber} instruction (or empty to finish): `);
+    if (!instruction) {
+      if (steps.length < 2) {
+        console.log('   ⚠️  Minimum 2 steps required');
+        continue;
+      }
+      break;
+    }
+
+    const expectedOutcome = await prompt(rl, `Step ${stepNumber} expected outcome: `);
+    if (!expectedOutcome) {
+      console.log('   ⚠️  Expected outcome is required');
+      continue;
+    }
+
+    steps.push({
+      step_number: stepNumber,
+      instruction,
+      expected_outcome: expectedOutcome
+    });
+    stepNumber++;
+  }
+
+  return steps;
+}
+
+/**
+ * Prompt for intensity level
+ */
+async function promptIntensityLevel(rl) {
+  console.log('\n📊 Intensity Level Required');
+  console.log('   Options: cosmetic, minor, moderate, major, critical\n');
+
+  while (true) {
+    const level = await prompt(rl, 'Intensity level: ');
+    if (INTENSITY_LEVELS.includes(level.toLowerCase())) {
+      return level.toLowerCase();
+    }
+    console.log(`   ⚠️  Invalid level. Choose from: ${INTENSITY_LEVELS.join(', ')}`);
+  }
+}
+
+/**
+ * Generate SD key from title
+ */
+function generateSdKey(title, type) {
+  const prefix = type === 'bugfix' ? 'FIX' :
+    type === 'feature' ? 'FEAT' :
+      type === 'refactor' ? 'REF' :
+        type === 'infrastructure' ? 'INFRA' :
+          type === 'documentation' ? 'DOC' :
+            type === 'orchestrator' ? 'ORCH' :
+              type === 'security' ? 'SEC' :
+                type.toUpperCase().slice(0, 4);
+
+  // Extract meaningful words from title
+  const words = title
+    .replace(/[^a-zA-Z0-9\s]/g, '')
+    .split(/\s+/)
+    .filter(w => w.length > 2)
+    .slice(0, 3)
+    .map(w => w.toUpperCase())
+    .join('-');
+
+  // Add random suffix to ensure uniqueness
+  const suffix = Math.floor(Math.random() * 1000).toString().padStart(3, '0');
+
+  return `SD-${prefix}-${words || 'GEN'}-${suffix}`;
+}
+
+/**
+ * Validate and resolve parent SD
+ */
+async function resolveParentSd(parentKey) {
+  if (!parentKey) return null;
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, status')
+    .eq('sd_key', parentKey)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Parent SD not found: ${parentKey}`);
+  }
+
+  // Check parent is in PLAN phase (required for children)
+  if (!['in_progress', 'active', 'planning'].includes(data.status)) {
+    throw new Error(`Parent SD ${parentKey} must be in PLAN phase (current: ${data.status})`);
+  }
+
+  return data.id;
+}
+
+/**
+ * Create the Strategic Directive
+ */
+async function createSD(sdData) {
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .insert(sdData)
+    .select('id, sd_key, title, sd_type, status')
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create SD: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  const args = parseArgs();
+
+  if (args.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  console.log('\n🚀 SD Creation Helper');
+  console.log('=' .repeat(50));
+
+  let rl;
+  let sdType = args.type;
+  let title = args.title;
+  let description = args.description;
+  let parentKey = args.parent;
+  let priority = args.priority;
+
+  // Interactive mode or missing required fields
+  if (args.interactive || !sdType || !title) {
+    rl = createReadline();
+
+    if (!sdType) {
+      console.log('\nValid SD Types:');
+      Object.entries(SD_TYPES).forEach(([type, info]) => {
+        console.log(`  ${type.padEnd(15)} - ${info.description}`);
+      });
+      while (!sdType || !SD_TYPES[sdType]) {
+        sdType = await prompt(rl, '\nSD Type: ');
+        if (!SD_TYPES[sdType]) {
+          console.log(`   ⚠️  Invalid type. Choose from: ${Object.keys(SD_TYPES).join(', ')}`);
+        }
+      }
+    }
+
+    if (!title) {
+      title = await prompt(rl, 'Title: ');
+      if (!title) {
+        console.error('❌ Title is required');
+        process.exit(1);
+      }
+    }
+
+    if (!description) {
+      description = await prompt(rl, 'Description (optional): ');
+    }
+
+    if (!parentKey) {
+      parentKey = await prompt(rl, 'Parent SD key (optional, e.g., SD-PARENT-001): ');
+    }
+
+    if (!priority) {
+      console.log(`\nPriority (default: ${SD_TYPES[sdType].defaultPriority})`);
+      priority = await prompt(rl, 'Priority [critical/high/medium/low]: ') || SD_TYPES[sdType].defaultPriority;
+    }
+  }
+
+  // Validate SD type
+  if (!SD_TYPES[sdType]) {
+    console.error(`❌ Invalid SD type: ${sdType}`);
+    console.error(`   Valid types: ${Object.keys(SD_TYPES).join(', ')}`);
+    process.exit(1);
+  }
+
+  const typeConfig = SD_TYPES[sdType];
+
+  // Initialize SD data
+  const sdKey = generateSdKey(title, sdType);
+  const sdData = {
+    id: randomUUID(),
+    sd_key: sdKey,
+    title: title,
+    description: description || title,
+    rationale: `Created via create-sd.js helper script. Type: ${sdType}.`,
+    sd_type: sdType,
+    status: 'draft',
+    priority: priority || typeConfig.defaultPriority,
+    category: sdType.charAt(0).toUpperCase() + sdType.slice(1),
+    success_criteria: JSON.stringify([`${title} - verified complete`]),
+    target_application: 'EHG_Engineer'
+  };
+
+  // Handle type-specific required fields
+  if (!rl) {
+    rl = createReadline();
+  }
+
+  if (typeConfig.requiredFields.includes('smoke_test_steps')) {
+    console.log('\n📋 This SD type requires smoke_test_steps');
+    const steps = await promptSmokeTestSteps(rl);
+    sdData.smoke_test_steps = JSON.stringify(steps);
+  }
+
+  if (typeConfig.requiredFields.includes('intensity_level')) {
+    console.log('\n📊 This SD type requires intensity_level');
+    sdData.intensity_level = await promptIntensityLevel(rl);
+  }
+
+  // Resolve parent SD if provided
+  if (parentKey) {
+    try {
+      const parentId = await resolveParentSd(parentKey);
+      sdData.parent_sd_id = parentId;
+      sdData.metadata = JSON.stringify({
+        contract_governed: true,
+        contract_parent_chain: [parentId]
+      });
+      console.log(`\n✅ Linked to parent: ${parentKey}`);
+    } catch (error) {
+      console.error(`\n❌ ${error.message}`);
+      rl.close();
+      process.exit(1);
+    }
+  }
+
+  // Close readline
+  rl.close();
+
+  // Create the SD
+  console.log('\n📝 Creating Strategic Directive...');
+  try {
+    const created = await createSD(sdData);
+    console.log('\n✅ SD Created Successfully!');
+    console.log('=' .repeat(50));
+    console.log(`   SD Key:  ${created.sd_key}`);
+    console.log(`   Title:   ${created.title}`);
+    console.log(`   Type:    ${created.sd_type}`);
+    console.log(`   Status:  ${created.status}`);
+    console.log(`   UUID:    ${created.id}`);
+
+    if (typeConfig.subAgents.length > 0) {
+      console.log(`\n📋 Sub-agents for this type: ${typeConfig.subAgents.join(', ')}`);
+    }
+
+    console.log('\n📝 Next Steps:');
+    console.log('   1. Run LEAD-TO-PLAN handoff:');
+    console.log(`      node scripts/handoff.js execute LEAD-TO-PLAN ${created.sd_key}`);
+    console.log('');
+  } catch (error) {
+    console.error(`\n❌ ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main().catch(error => {
+  console.error('\n❌ Unexpected error:', error.message);
+  process.exit(1);
+});

--- a/scripts/sd-from-feedback.js
+++ b/scripts/sd-from-feedback.js
@@ -1,0 +1,419 @@
+#!/usr/bin/env node
+
+/**
+ * Feedback-to-SD Automation Script
+ *
+ * Converts triaged feedback items into Strategic Directives.
+ * Maps feedback types to appropriate SD types and ensures
+ * all required fields are populated.
+ *
+ * Created as part of SD-UAT-WORKFLOW-001 - UAT-to-SD Workflow Process Improvements
+ *
+ * Usage:
+ *   npm run sd:from-feedback
+ *   node scripts/sd-from-feedback.js
+ *   node scripts/sd-from-feedback.js --parent SD-PARENT-001
+ *
+ * @module scripts/sd-from-feedback
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { randomUUID } from 'crypto';
+import readline from 'readline';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// Feedback type to SD type mapping
+const FEEDBACK_TYPE_MAP = {
+  issue: 'bugfix',
+  enhancement: 'feature'
+};
+
+// Priority mapping (feedback P0-P3 to SD priority)
+const PRIORITY_MAP = {
+  P0: 'critical',
+  P1: 'high',
+  P2: 'medium',
+  P3: 'low'
+};
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {
+    parent: null,
+    all: false,
+    help: false
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    switch (arg) {
+      case '--parent':
+      case '-p':
+        parsed.parent = args[++i];
+        break;
+      case '--all':
+      case '-a':
+        parsed.all = true;
+        break;
+      case '--help':
+      case '-h':
+        parsed.help = true;
+        break;
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Display help message
+ */
+function showHelp() {
+  console.log(`
+Feedback-to-SD Automation Script
+================================
+
+Converts triaged feedback items into Strategic Directives.
+
+Usage:
+  npm run sd:from-feedback [options]
+  node scripts/sd-from-feedback.js [options]
+
+Options:
+  --parent, -p <sd_key>   Parent SD key for child SDs
+  --all, -a               Include all open feedback (not just triaged)
+  --help, -h              Show this help
+
+Workflow:
+  1. Shows list of triaged/open feedback items
+  2. You select items to convert (or 'all')
+  3. Script creates SDs with appropriate types:
+     - issue → bugfix SD (requires smoke_test_steps)
+     - enhancement → feature SD (requires smoke_test_steps)
+  4. Links SDs to feedback items in feedback_sd_map
+
+Examples:
+  npm run sd:from-feedback
+  npm run sd:from-feedback -- --parent SD-ORCH-001
+`);
+}
+
+/**
+ * Create readline interface
+ */
+function createReadline() {
+  return readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+}
+
+/**
+ * Prompt user for input
+ */
+function prompt(rl, question) {
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      resolve(answer.trim());
+    });
+  });
+}
+
+/**
+ * Fetch open feedback items
+ */
+async function fetchFeedbackItems(includeAll = false) {
+  let query = supabase
+    .from('feedback')
+    .select('id, type, title, description, priority, status, source_type, created_at')
+    .order('priority', { ascending: true })
+    .order('created_at', { ascending: true });
+
+  if (includeAll) {
+    query = query.not('status', 'in', '(closed,resolved,rejected)');
+  } else {
+    query = query.in('status', ['open', 'triaged']);
+  }
+
+  const { data, error } = await query.limit(50);
+
+  if (error) {
+    throw new Error(`Failed to fetch feedback: ${error.message}`);
+  }
+
+  return data || [];
+}
+
+/**
+ * Display feedback items in table format
+ */
+function displayFeedbackTable(items) {
+  console.log('\n' + '─'.repeat(100));
+  console.log(`│ ${'#'.padEnd(3)} │ ${'ID'.padEnd(10)} │ ${'Type'.padEnd(12)} │ ${'Priority'.padEnd(8)} │ ${'Status'.padEnd(10)} │ Title`);
+  console.log('─'.repeat(100));
+
+  items.forEach((item, index) => {
+    const num = (index + 1).toString().padEnd(3);
+    const id = (item.id || '-').substring(0, 10).padEnd(10);
+    const type = (item.type || '-').padEnd(12);
+    const priority = (item.priority || '-').padEnd(8);
+    const status = (item.status || '-').padEnd(10);
+    const title = (item.title || '-').substring(0, 40);
+    console.log(`│ ${num} │ ${id} │ ${type} │ ${priority} │ ${status} │ ${title}`);
+  });
+
+  console.log('─'.repeat(100));
+  console.log(`Total: ${items.length} item(s)\n`);
+}
+
+/**
+ * Generate SD key from feedback
+ */
+function generateSdKey(feedback) {
+  const prefix = feedback.type === 'issue' ? 'FIX' : 'FEAT';
+
+  // Extract meaningful words from title
+  const words = (feedback.title || 'untitled')
+    .replace(/[^a-zA-Z0-9\s]/g, '')
+    .split(/\s+/)
+    .filter(w => w.length > 2)
+    .slice(0, 3)
+    .map(w => w.toUpperCase())
+    .join('-');
+
+  // Add random suffix
+  const suffix = Math.floor(Math.random() * 1000).toString().padStart(3, '0');
+
+  return `SD-${prefix}-${words || 'GEN'}-${suffix}`;
+}
+
+/**
+ * Generate default smoke test steps from feedback
+ */
+function generateDefaultSmokeTestSteps(feedback) {
+  const steps = [
+    {
+      step_number: 1,
+      instruction: `Navigate to the affected area: ${feedback.title}`,
+      expected_outcome: 'Page loads without errors'
+    },
+    {
+      step_number: 2,
+      instruction: `Verify the ${feedback.type === 'issue' ? 'fix' : 'feature'} works as expected`,
+      expected_outcome: `${feedback.type === 'issue' ? 'Error no longer occurs' : 'Feature functions correctly'}`
+    }
+  ];
+
+  return steps;
+}
+
+/**
+ * Resolve parent SD
+ */
+async function resolveParentSd(parentKey) {
+  if (!parentKey) return null;
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, status')
+    .eq('sd_key', parentKey)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Parent SD not found: ${parentKey}`);
+  }
+
+  return data;
+}
+
+/**
+ * Create SD from feedback item
+ */
+async function createSdFromFeedback(feedback, parentId = null) {
+  const sdType = FEEDBACK_TYPE_MAP[feedback.type] || 'bugfix';
+  const priority = PRIORITY_MAP[feedback.priority] || 'medium';
+  const sdKey = generateSdKey(feedback);
+
+  const sdData = {
+    id: randomUUID(),
+    sd_key: sdKey,
+    title: feedback.title,
+    description: feedback.description || feedback.title,
+    rationale: `Created from feedback item. Source: ${feedback.source_type || 'manual'}. Original ID: ${feedback.id}`,
+    sd_type: sdType,
+    status: 'draft',
+    priority: priority,
+    category: sdType.charAt(0).toUpperCase() + sdType.slice(1),
+    success_criteria: JSON.stringify([`${feedback.title} - verified complete`]),
+    target_application: 'EHG_Engineer',
+    smoke_test_steps: JSON.stringify(generateDefaultSmokeTestSteps(feedback))
+  };
+
+  if (parentId) {
+    sdData.parent_sd_id = parentId;
+    sdData.metadata = JSON.stringify({
+      contract_governed: true,
+      contract_parent_chain: [parentId],
+      source_feedback_id: feedback.id
+    });
+  } else {
+    sdData.metadata = JSON.stringify({
+      source_feedback_id: feedback.id
+    });
+  }
+
+  // Insert SD
+  const { data: created, error: createError } = await supabase
+    .from('strategic_directives_v2')
+    .insert(sdData)
+    .select('id, sd_key, title, sd_type')
+    .single();
+
+  if (createError) {
+    throw new Error(`Failed to create SD: ${createError.message}`);
+  }
+
+  // Link feedback to SD via feedback_sd_map (if table exists)
+  try {
+    await supabase
+      .from('feedback_sd_map')
+      .insert({
+        feedback_id: feedback.id,
+        sd_id: created.id
+      });
+  } catch (_mapError) {
+    // Table might not exist, ignore
+  }
+
+  // Update feedback status to 'in_progress'
+  await supabase
+    .from('feedback')
+    .update({ status: 'in_progress' })
+    .eq('id', feedback.id);
+
+  return created;
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  const args = parseArgs();
+
+  if (args.help) {
+    showHelp();
+    process.exit(0);
+  }
+
+  console.log('\n📋 Feedback-to-SD Automation');
+  console.log('=' .repeat(50));
+
+  // Resolve parent SD if provided
+  let parentSd = null;
+  if (args.parent) {
+    try {
+      parentSd = await resolveParentSd(args.parent);
+      console.log(`\n📎 Parent SD: ${parentSd.sd_key} - ${parentSd.title}`);
+    } catch (error) {
+      console.error(`\n❌ ${error.message}`);
+      process.exit(1);
+    }
+  }
+
+  // Fetch feedback items
+  console.log('\n🔍 Fetching feedback items...');
+  const items = await fetchFeedbackItems(args.all);
+
+  if (items.length === 0) {
+    console.log('\n✅ No feedback items to process.');
+    console.log('   Use --all flag to include all open items (not just triaged).');
+    process.exit(0);
+  }
+
+  // Display items
+  displayFeedbackTable(items);
+
+  // Get user selection
+  const rl = createReadline();
+
+  console.log('Enter numbers to select (comma-separated), "all" for all, or "q" to quit:');
+  const selection = await prompt(rl, '> ');
+
+  if (selection.toLowerCase() === 'q') {
+    console.log('\n👋 Cancelled.');
+    rl.close();
+    process.exit(0);
+  }
+
+  // Parse selection
+  let selectedIndices = [];
+  if (selection.toLowerCase() === 'all') {
+    selectedIndices = items.map((_, i) => i);
+  } else {
+    selectedIndices = selection
+      .split(',')
+      .map(s => parseInt(s.trim()) - 1)
+      .filter(i => i >= 0 && i < items.length);
+  }
+
+  if (selectedIndices.length === 0) {
+    console.log('\n⚠️  No valid items selected.');
+    rl.close();
+    process.exit(0);
+  }
+
+  const selectedItems = selectedIndices.map(i => items[i]);
+  console.log(`\n📝 Creating ${selectedItems.length} SD(s)...`);
+
+  rl.close();
+
+  // Create SDs
+  const results = {
+    success: [],
+    failed: []
+  };
+
+  for (const item of selectedItems) {
+    try {
+      const created = await createSdFromFeedback(item, parentSd?.id);
+      results.success.push(created);
+      console.log(`   ✅ ${created.sd_key} - ${created.title.substring(0, 40)}`);
+    } catch (error) {
+      results.failed.push({ item, error: error.message });
+      console.log(`   ❌ ${item.title.substring(0, 40)} - ${error.message}`);
+    }
+  }
+
+  // Summary
+  console.log('\n' + '=' .repeat(50));
+  console.log(`✅ Created: ${results.success.length}`);
+  if (results.failed.length > 0) {
+    console.log(`❌ Failed: ${results.failed.length}`);
+  }
+
+  if (results.success.length > 0) {
+    console.log('\n📝 Next Steps:');
+    console.log('   For each created SD, run LEAD-TO-PLAN handoff:');
+    results.success.slice(0, 3).forEach(sd => {
+      console.log(`   node scripts/handoff.js execute LEAD-TO-PLAN ${sd.sd_key}`);
+    });
+    if (results.success.length > 3) {
+      console.log(`   ... and ${results.success.length - 3} more`);
+    }
+  }
+}
+
+main().catch(error => {
+  console.error('\n❌ Unexpected error:', error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Implements SD-UAT-WORKFLOW-001: UAT-to-SD Workflow Process Improvements
- Adds raw feedback auto-save functionality to prevent data loss during UAT sessions
- Documents all schema constraints for feedback and SD tables
- Creates type-aware SD creation helper script
- Automates feedback-to-SD conversion workflow

## Changes

- `lib/uat/feedback-saver.js`: New module for auto-saving raw UAT feedback to markdown
- `docs/reference/sd-validation-profiles.md`: Comprehensive documentation of valid enum values and type-specific requirements
- `scripts/create-sd.js`: Interactive SD creation with type-aware validation
- `scripts/sd-from-feedback.js`: Bulk conversion of triaged feedback to SDs
- `package.json`: Added `sd:new` and `sd:from-feedback` npm scripts

## Test plan

- [x] Smoke test 1: feedback-saver creates markdown file with verbatim content
- [x] Smoke test 2: create-sd.js prompts for smoke_test_steps for bugfix type
- [x] Smoke test 3: sd:from-feedback shows feedback items in table format

Generated with [Claude Code](https://claude.com/claude-code)