### PR TITLE
docs: update route references from /chairman-analytics to /chairman/analytics

### DIFF
--- a/docs/reference/qa-director-guide.md
+++ b/docs/reference/qa-director-guide.md
@@ -46,7 +46,7 @@ claude mcp list  # Verify "playwright" is connected
 **1. Basic Navigation & Screenshot**
 ```
 Use Playwright MCP to:
-- Navigate to http://localhost:3000/chairman-analytics
+- Navigate to http://localhost:3000/chairman/analytics
 - Wait for the page to load completely
 - Take a screenshot and save as "chairman-analytics-before.png"
 ```
@@ -123,7 +123,7 @@ Use Puppeteer MCP to:
 **2. Performance Measurement**
 ```
 Use Puppeteer MCP to:
-- Navigate to http://localhost:3000/chairman-analytics
+- Navigate to http://localhost:3000/chairman/analytics
 - Measure page load time
 - Report metrics
 ```

--- a/docs/vision/ROUTE_AUDIT_SD_STRUCTURE.md
+++ b/docs/vision/ROUTE_AUDIT_SD_STRUCTURE.md
@@ -251,7 +251,7 @@ Escalation views, and legacy dashboard fallback. Evaluate each route for design 
 accessibility compliance, performance metrics, security posture, and UX quality.`,
 
   scope: `Routes: /chairman, /chairman/decisions, /chairman/portfolio, /chairman/settings,
-/chairman/escalations/:id, /chairman-legacy, /chairman-analytics. Components: BriefingDashboard,
+/chairman/escalations/:id, /chairman/analytics. Components: BriefingDashboard,
 DecisionsInbox, VenturesPage, ChairmanSettingsPage, ChairmanEscalationPage, DecisionAnalyticsDashboard.`,
 
   rationale: `The Command Center is the strategic executive dashboard. Any issues here directly
@@ -266,7 +266,7 @@ high quality.`,
   sequence_rank: 1,
 
   strategic_objectives: [
-    "Audit all 7 Command Center routes for completeness",
+    "Audit all 6 Command Center routes for completeness",
     "Verify Glass Cockpit design consistency",
     "Check executive-level accessibility compliance",
     "Measure performance metrics (LCP, FID, CLS)",
@@ -274,7 +274,7 @@ high quality.`,
   ],
 
   success_criteria: [
-    "All 7 routes accessed and evaluated",
+    "All 6 routes accessed and evaluated",
     "Design inconsistencies documented",
     "Accessibility issues cataloged with WCAG references",
     "Performance baselines recorded",
@@ -296,8 +296,7 @@ high quality.`,
       { path: "/chairman/portfolio", component: "VenturesPage", purpose: "Portfolio overview" },
       { path: "/chairman/settings", component: "ChairmanSettingsPage", purpose: "Settings" },
       { path: "/chairman/escalations/:id", component: "ChairmanEscalationPage", purpose: "Escalation detail" },
-      { path: "/chairman-legacy", component: "ChairmanDashboard", purpose: "Legacy fallback" },
-      { path: "/chairman-analytics", component: "DecisionAnalyticsDashboard", purpose: "Analytics" }
+      { path: "/chairman/analytics", component: "DecisionAnalyticsDashboard", purpose: "Analytics" }
     ]
   },
 


### PR DESCRIPTION
## Summary
- Update qa-director-guide.md with new route path `/chairman/analytics`
- Update ROUTE_AUDIT_SD_STRUCTURE.md to remove deprecated `/chairman-legacy` and update analytics path

## SD Reference
- SD-FIX-NAV-001-C: Documentation Update for Navigation Routes
- Parent: SD-FIX-NAV-001 (Chairman Sidebar Navigation Architecture Fix)

## Test plan
- [x] Verify no references to `/chairman-analytics` remain (grep confirms 0 matches after changes)
- [x] Verify no references to `/chairman-legacy` in route lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)