### PR TITLE
docs(sdkey): add SDKeyGenerator guide and update LEO protocol (SD-LEO-SDKEY-001)

### DIFF
--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-01-20 9:06:09 AM
+**Generated**: 2026-01-20 9:49:50 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 
@@ -583,6 +583,154 @@ node scripts/handoff.js list SD-XXX-001
 # Validate before handoff (find all issues)
 node scripts/handoff.js precheck PLAN-TO-EXEC SD-XXX-001
 ```
+
+
+### SDKeyGenerator Errors (SD-LEO-SDKEY-001)
+
+#### Error: `Invalid SD type` or `new value for domain sd_type violates check constraint`
+
+**Cause**: Using user-friendly type names that don't match database constraint
+**Solution**: SDKeyGenerator automatically maps user types to valid database types:
+```javascript
+// User-friendly types → Database types
+fix, bugfix → bugfix
+feature, feat → feature
+enhancement → feature
+refactor, refactoring → refactor
+infrastructure, infra → infrastructure
+documentation, docs → documentation
+testing, test → testing
+security → security
+```
+
+**Reference**: `scripts/modules/sd-key-generator.js` line 45-60
+
+#### Error: `SD key collision detected` or duplicate key in different format
+
+**Cause**: Proposed SD key matches existing SD in either `sd_key` OR `id` column
+**Solution**: SDKeyGenerator checks BOTH columns automatically:
+```javascript
+// Checks both columns
+const { data: existing } = await supabase
+  .from('strategic_directives_v2')
+  .select('id, sd_key')
+  .or(`sd_key.eq.${proposedKey},id.eq.${proposedKey}`);
+```
+If collision detected, sequential number auto-increments (001 → 002 → 003).
+
+**Reference**: `scripts/modules/sd-key-generator.js` keyExists() function
+
+#### Error: Semantic extraction produces unclear abbreviations
+
+**Cause**: Title contains many small words or acronyms
+**Solution**: SDKeyGenerator extracts 2-3 meaningful words, skipping common words:
+```javascript
+// "Fix navigation route not working" → "NAV-ROUTE"
+// "Add user authentication feature" → "USER-AUTH"
+// Skips: the, a, an, and, or, but, to, from, with, of, for, in, on, at
+```
+
+**Manual override available**:
+```javascript
+await generateSDKey({
+  source: 'UAT',
+  type: 'bugfix',
+  title: 'Fix navigation route not working',
+  semanticOverride: 'NAV-FIX'  // Force specific semantic
+});
+```
+
+**Reference**: `scripts/modules/sd-key-generator.js` extractSemanticWords() function
+
+#### Error: Child SD key format incorrect (e.g., `SD-UAT-FIX-NAV-001-A` vs `SD-UAT-FIX-NAV-001A`)
+
+**Cause**: Manual child key creation without using SDKeyGenerator hierarchy functions
+**Solution**: Use SDKeyGenerator hierarchy functions for consistent encoding:
+```javascript
+// Root SD
+const rootKey = await generateSDKey({...}); // SD-UAT-FIX-NAV-001
+
+// Child (no hyphen before suffix)
+const childKey = generateChildKey(rootKey, 'A'); // SD-UAT-FIX-NAV-001A
+
+// Grandchild (hyphen before numeric suffix)
+const grandchildKey = generateGrandchildKey(childKey, '1'); // SD-UAT-FIX-NAV-001A-1
+
+// Great-grandchild (dot separator)
+const greatGrandchildKey = generateGreatGrandchildKey(grandchildKey, '1'); // SD-UAT-FIX-NAV-001A-1.1
+```
+
+**Hierarchy encoding rules**:
+- Root: `SD-SOURCE-TYPE-SEMANTIC-NUM`
+- Child: Append letter (no hyphen): `-NUMA`
+- Grandchild: Add hyphen + number: `-NUMA-1`
+- Great-grandchild: Add dot + number: `-NUMA-1.1`
+
+**Reference**: `docs/reference/sd-key-generator-guide.md` Hierarchy Support section
+
+#### Error: Sequential numbering gaps (e.g., 001, 002, 005)
+
+**Cause**: Deleted SDs or manual key creation creating gaps
+**Solution**: SDKeyGenerator automatically finds next available number:
+```javascript
+// If SD-UAT-FIX-NAV-001 and SD-UAT-FIX-NAV-003 exist
+// Next key will be SD-UAT-FIX-NAV-002 (fills gap)
+// Then SD-UAT-FIX-NAV-004 (next sequential)
+```
+
+**Reference**: `scripts/modules/sd-key-generator.js` getNextSequentialNumber() function
+
+### Using /leo create Command
+
+#### Recommended: Unified SD creation interface (SD-LEO-SDKEY-001)
+
+Instead of manually calling SDKeyGenerator or legacy scripts, use `/leo create`:
+
+```bash
+# Interactive mode - Prompts for all fields
+/leo create
+
+# From UAT finding
+/leo create --from-uat <test-id>
+
+# From /learn pattern
+/leo create --from-learn <pattern-id>
+
+# From /inbox feedback
+/leo create --from-feedback <feedback-id>
+
+# Create child SD
+/leo create --child SD-UAT-FIX-NAV-001 A
+```
+
+**Features**:
+- Automatic source detection (UAT, LEARN, FEEDBACK, etc.)
+- Type mapping to valid database constraints
+- Collision detection across both `sd_key` and `id` columns
+- Sequential numbering with gap detection
+- Hierarchy support (4 levels)
+
+**Reference**: `docs/reference/npm-scripts-guide.md` line 121-148, `docs/reference/sd-key-generator-guide.md`
+
+#### Migration from legacy scripts
+
+If you have code using old SD creation patterns, migrate to SDKeyGenerator:
+
+```javascript
+// OLD (manual key generation)
+const sdKey = `SD-${source}-${type.toUpperCase()}-${semantic}-001`;
+
+// NEW (SDKeyGenerator)
+import { generateSDKey } from './modules/sd-key-generator.js';
+const sdKey = await generateSDKey({ source, type, title });
+```
+
+**Migrated scripts**:
+1. `scripts/uat-to-strategic-directive-ai.js`
+2. `scripts/sd-from-feedback.js`
+3. `scripts/pattern-alert-sd-creator.js`
+4. `scripts/create-sd.js`
+5. `scripts/modules/learning/executor.js`
 
 
 ## 📋 Directive Submission Review Process

--- a/docs/reference/npm-scripts-guide.md
+++ b/docs/reference/npm-scripts-guide.md
@@ -11,6 +11,7 @@ This guide documents all 140+ npm scripts available in EHG_Engineer.
 | [PRD Management](#prd-management) | 15+ | `prd:validate`, `prd:health`, `prd:new` |
 | [Database](#database-operations) | 10+ | `db:create`, `schema:docs`, `check-db` |
 | [Testing](#testing) | 15+ | `test`, `test:e2e`, `test:uat` |
+| [Validation](#validation) | 6+ | `validate:bypass`, `validate:sd-type-sync` |
 | [Context Management](#context-management) | 8+ | `context:usage`, `context:compact` |
 | [Pattern Management](#pattern-management) | 12+ | `pattern:resolve`, `pattern:sync` |
 | [Handoffs](#handoffs) | 5+ | `handoff`, `handoff:list`, `handoff:compliance` |
@@ -117,10 +118,41 @@ npm run sd:release       # Release SD claim
 
 ### Creating SDs
 
+#### Recommended: /leo create Command
+
+The `/leo create` command provides a unified interface for SD creation (SD-LEO-SDKEY-001):
+
 ```bash
-npm run new-sd           # Interactive new SD wizard
-npm run add-sd           # Add SD to database
-npm run create-app-sd    # Create app-specific SD
+# Interactive mode - Prompts for type, title, etc.
+/leo create
+
+# From UAT finding
+/leo create --from-uat <test-id>
+
+# From /learn pattern
+/leo create --from-learn <pattern-id>
+
+# From /inbox feedback
+/leo create --from-feedback <feedback-id>
+
+# Create child SD
+/leo create --child <parent-key> [index]
+```
+
+**Features**:
+- Unified SDKeyGenerator with source traceability (UAT, LEARN, FEEDBACK, PATTERN, LEO)
+- Consistent key format: `SD-{SOURCE}-{TYPE}-{SEMANTIC}-{NUM}`
+- Automatic collision detection across `sd_key` and `id` columns
+- Hierarchy support (parent/child/grandchild/great-grandchild)
+
+See: `docs/reference/sd-key-generator-guide.md` for API documentation.
+
+#### Legacy Commands
+
+```bash
+npm run new-sd           # Interactive new SD wizard (legacy)
+npm run add-sd           # Add SD to database (legacy)
+npm run create-app-sd    # Create app-specific SD (legacy)
 ```
 
 ---
@@ -232,10 +264,20 @@ npm run rca:test:integration # Run RCA integration tests
 
 ### Validation
 
+### Story Mapping
+
 ```bash
 npm run validate:story-mapping          # Validate story-test mapping
 npm run validate:story-mapping:verbose  # Verbose output
 npm run validate:story-mapping:fix      # Auto-fix mapping
+```
+
+### LEO Protocol Validation
+
+```bash
+npm run validate:bypass                 # Run bypass detection on recent SDs (last 7 days)
+npm run validate:bypass:all             # Run bypass detection on all SDs
+npm run validate:sd-type-sync           # Verify SD type synchronization across constraint/profiles/code
 ```
 
 ---
@@ -572,6 +614,14 @@ npm run prd:health           # Check PRD health
 npm run gate:health          # Check gates
 ```
 
+### Validating Protocol Integrity
+
+```bash
+npm run validate:bypass      # Check for artifact chronology violations
+npm run validate:sd-type-sync # Verify SD type consistency
+npm run handoff:compliance   # Check handoff compliance
+```
+
 ---
 
 ## Environment Variables
@@ -596,4 +646,4 @@ Many scripts respect these environment variables:
 
 ---
 
-*Last Updated: 2026-01-03*
+*Last Updated: 2026-01-19*

--- a/docs/reference/sd-key-generator-guide.md
+++ b/docs/reference/sd-key-generator-guide.md
@@ -1,0 +1,461 @@
+# SDKeyGenerator Module - Reference Guide
+
+**Module**: `scripts/modules/sd-key-generator.js`
+**SD**: SD-LEO-SDKEY-001
+**Purpose**: Centralized Strategic Directive key generation with source traceability
+**Status**: Active (implemented 2026-01-20)
+
+---
+
+## Overview
+
+The SDKeyGenerator module provides unified SD key generation across all SD creation paths, replacing 6+ different implementations with a single, consistent system.
+
+### Key Format
+
+```
+SD-{SOURCE}-{TYPE}-{SEMANTIC}-{NUM}
+```
+
+**Example**: `SD-UAT-FIX-NAV-ROUTE-001`
+
+Where:
+- **SOURCE**: Origin of the SD (UAT, LEARN, FEEDBACK, PATTERN, MANUAL, LEO)
+- **TYPE**: SD type abbreviation (FIX, FEAT, INFRA, DOC, etc.)
+- **SEMANTIC**: 1-3 meaningful words from title (e.g., NAV-ROUTE)
+- **NUM**: Sequential 3-digit number with collision detection (001, 002, etc.)
+
+### Hierarchy Support
+
+The module supports 4-level hierarchies:
+
+| Level | Format | Example | Description |
+|-------|--------|---------|-------------|
+| Root | `SD-{SOURCE}-{TYPE}-{SEMANTIC}-{NUM}` | `SD-UAT-FIX-NAV-001` | Parent SD |
+| Child | `{PARENT}-{LETTER}` | `SD-UAT-FIX-NAV-001-A` | Direct child |
+| Grandchild | `{CHILD}{NUMBER}` | `SD-UAT-FIX-NAV-001-A1` | Child of child |
+| Great-grandchild | `{GRANDCHILD}.{NUMBER}` | `SD-UAT-FIX-NAV-001-A1.1` | 3rd level |
+
+---
+
+## API Reference
+
+### Core Functions
+
+#### `generateSDKey(options)`
+
+Generates a new SD key with collision detection.
+
+**Parameters**:
+```javascript
+{
+  source: string,        // 'UAT', 'LEARN', 'FEEDBACK', 'PATTERN', 'MANUAL', 'LEO'
+  type: string,          // 'fix', 'feature', 'refactor', 'infrastructure', etc.
+  title: string,         // SD title for semantic extraction
+  parentKey?: string,    // Parent SD key (for hierarchies)
+  hierarchyDepth?: number, // 0=root, 1=child, 2=grandchild, 3+=great-grandchild
+  siblingIndex?: number  // Index among siblings (for suffix)
+}
+```
+
+**Returns**: `Promise<string>` - Generated SD key
+
+**Example**:
+```javascript
+import { generateSDKey } from './modules/sd-key-generator.js';
+
+const sdKey = await generateSDKey({
+  source: 'UAT',
+  type: 'bugfix',
+  title: 'Navigation route not working'
+});
+// Returns: SD-UAT-FIX-NAVIGATION-ROUTE-001
+```
+
+#### `generateChildKey(parentKey, childIndex)`
+
+Generates a child SD key.
+
+**Parameters**:
+- `parentKey` (string): Parent SD key
+- `childIndex` (number): Zero-based index (0=A, 1=B, etc.)
+
+**Returns**: `string` - Child SD key
+
+**Example**:
+```javascript
+import { generateChildKey } from './modules/sd-key-generator.js';
+
+const childKey = generateChildKey('SD-UAT-FIX-NAV-001', 0);
+// Returns: SD-UAT-FIX-NAV-001-A
+```
+
+#### `generateGrandchildKey(parentKey, grandchildIndex)`
+
+Generates a grandchild SD key.
+
+**Parameters**:
+- `parentKey` (string): Parent (child) SD key (e.g., "SD-FIX-NAV-001-A")
+- `grandchildIndex` (number): Zero-based index
+
+**Returns**: `string` - Grandchild SD key
+
+**Example**:
+```javascript
+import { generateGrandchildKey } from './modules/sd-key-generator.js';
+
+const grandchildKey = generateGrandchildKey('SD-UAT-FIX-NAV-001-A', 0);
+// Returns: SD-UAT-FIX-NAV-001-A1
+```
+
+#### `parseSDKey(sdKey)`
+
+Parses an SD key into its components.
+
+**Parameters**:
+- `sdKey` (string): SD key to parse
+
+**Returns**: `Object | null` - Parsed components or null if invalid
+
+**Example**:
+```javascript
+import { parseSDKey } from './modules/sd-key-generator.js';
+
+const parsed = parseSDKey('SD-UAT-FIX-NAV-ROUTE-001');
+// Returns:
+// {
+//   isRoot: true,
+//   source: 'UAT',
+//   type: 'FIX',
+//   semantic: 'NAV-ROUTE',
+//   number: 1,
+//   hierarchyDepth: 0,
+//   parentKey: null
+// }
+```
+
+### Utility Functions
+
+#### `extractSemanticWords(title, maxWords)`
+
+Extracts meaningful words from a title for key generation.
+
+**Parameters**:
+- `title` (string): SD title
+- `maxWords` (number, optional): Maximum words to extract (default: 3)
+
+**Returns**: `string` - Semantic portion (e.g., "NAV-ROUTE-FIX")
+
+**Example**:
+```javascript
+import { extractSemanticWords } from './modules/sd-key-generator.js';
+
+const semantic = extractSemanticWords('Fix the navigation route error', 3);
+// Returns: "FIX-NAVIGATION-ROUTE"
+```
+
+#### `keyExists(proposedKey)`
+
+Checks if an SD key already exists in the database.
+
+**Parameters**:
+- `proposedKey` (string): Key to check
+
+**Returns**: `Promise<boolean>` - True if key exists
+
+**Example**:
+```javascript
+import { keyExists } from './modules/sd-key-generator.js';
+
+const exists = await keyExists('SD-UAT-FIX-NAV-001');
+// Returns: true or false
+```
+
+#### `getNextSequentialNumber(prefix)`
+
+Finds the next available sequential number for a key namespace.
+
+**Parameters**:
+- `prefix` (string): Key prefix (e.g., "SD-UAT-FIX-NAV")
+
+**Returns**: `Promise<number>` - Next available number
+
+---
+
+## Constants
+
+### `SD_SOURCES`
+
+Valid SD sources:
+
+```javascript
+{
+  UAT: 'UAT',           // From UAT process
+  LEARN: 'LEARN',       // From /learn command
+  FEEDBACK: 'FDBK',     // From /inbox or sd-from-feedback
+  PATTERN: 'PAT',       // From pattern-alert-sd-creator
+  MANUAL: 'MAN',        // From create-sd.js or manual creation
+  LEO: 'LEO'            // From /leo create
+}
+```
+
+### `SD_TYPES`
+
+Valid SD types (maps user-friendly names to abbreviations):
+
+```javascript
+{
+  fix: 'FIX',
+  bugfix: 'FIX',
+  feature: 'FEAT',
+  feat: 'FEAT',
+  refactor: 'REFAC',
+  infrastructure: 'INFRA',
+  infra: 'INFRA',
+  documentation: 'DOC',
+  doc: 'DOC',
+  enhancement: 'ENH',
+  testing: 'TEST',
+  orchestrator: 'ORCH'
+}
+```
+
+---
+
+## Integration Points
+
+### Scripts Using SDKeyGenerator
+
+All SD creation scripts have been refactored to use the centralized generator:
+
+| Script | Source | Usage |
+|--------|--------|-------|
+| `leo-create-sd.js` | LEO | Direct import for /leo create command |
+| `uat-to-strategic-directive-ai.js` | UAT | Replaced local generateUATSDKey() |
+| `sd-from-feedback.js` | FEEDBACK | Replaced local generateSdKey() |
+| `pattern-alert-sd-creator.js` | PATTERN | Replaced local generateSDKey() |
+| `create-sd.js` | MANUAL | Replaced local generateSdKey() |
+| `modules/learning/executor.js` | LEARN | Replaced local generateSDId() |
+
+### Command Integration
+
+The `/leo create` command uses SDKeyGenerator through `leo-create-sd.js`:
+
+```bash
+# Interactive mode
+/leo create
+
+# Flag-based creation
+/leo create --from-uat <test-id>
+/leo create --from-learn <pattern-id>
+/leo create --from-feedback <feedback-id>
+/leo create --child <parent-key> [index]
+```
+
+See `.claude/commands/leo.md` for full command documentation.
+
+---
+
+## Database Integration
+
+### Collision Detection
+
+The module checks both `sd_key` and `id` columns to prevent collisions:
+
+```javascript
+const { data, error } = await supabase
+  .from('strategic_directives_v2')
+  .select('id, sd_key')
+  .or(`sd_key.eq.${proposedKey},id.eq.${proposedKey}`)
+  .limit(1);
+```
+
+This handles cases where legacy SDs used the key format directly in the `id` column.
+
+### Sequential Numbering
+
+Sequential numbers are determined by querying existing keys with the same prefix:
+
+```sql
+SELECT sd_key, id
+FROM strategic_directives_v2
+WHERE sd_key ILIKE 'SD-UAT-FIX-NAV-%' OR id ILIKE 'SD-UAT-FIX-NAV-%'
+ORDER BY created_at DESC;
+```
+
+The module extracts used numbers and finds the first gap in the sequence.
+
+---
+
+## Usage Examples
+
+### Create Root SD from UAT
+
+```javascript
+import { generateSDKey } from './modules/sd-key-generator.js';
+
+const sdKey = await generateSDKey({
+  source: 'UAT',
+  type: 'bugfix',
+  title: 'Login button not responding'
+});
+
+// Returns: SD-UAT-FIX-LOGIN-BUTTON-001
+```
+
+### Create Child SD
+
+```javascript
+import { generateSDKey } from './modules/sd-key-generator.js';
+
+const childKey = await generateSDKey({
+  source: 'LEO',
+  type: 'bugfix',
+  title: 'Fix database schema',
+  parentKey: 'SD-UAT-FIX-LOGIN-001',
+  hierarchyDepth: 1,
+  siblingIndex: 0  // First child (A)
+});
+
+// Returns: SD-UAT-FIX-LOGIN-001-A
+```
+
+### Create SD from Feedback
+
+```javascript
+import { generateSDKey } from './modules/sd-key-generator.js';
+
+const sdKey = await generateSDKey({
+  source: 'FEEDBACK',
+  type: 'feature',
+  title: 'Add dark mode toggle'
+});
+
+// Returns: SD-FDBK-FEAT-ADD-DARK-MODE-001
+```
+
+### Parse Existing Key
+
+```javascript
+import { parseSDKey } from './modules/sd-key-generator.js';
+
+const components = parseSDKey('SD-UAT-FIX-NAV-001-A1');
+
+// Returns:
+// {
+//   isRoot: false,
+//   parentKey: 'SD-UAT-FIX-NAV-001-A',
+//   hierarchyDepth: 2,
+//   siblingIndex: 0
+// }
+```
+
+---
+
+## CLI Usage
+
+The module supports direct CLI invocation for testing:
+
+```bash
+# Generate root SD key
+node scripts/modules/sd-key-generator.js UAT fix "Navigation route not working"
+
+# Generate child key
+node scripts/modules/sd-key-generator.js --child SD-UAT-FIX-NAV-001 0
+
+# Parse SD key
+node scripts/modules/sd-key-generator.js --parse SD-UAT-FIX-NAV-001-A
+```
+
+---
+
+## Migration Notes
+
+### Before (Legacy Approach)
+
+Each creation script had its own key generation:
+
+- **UAT**: `SD-UAT-###`
+- **/learn**: `SD-LEARN-###` or `QF-YYYYMMDD-###`
+- **Feedback**: `SD-FIX-{WORDS}-{RANDOM}` or `SD-FEAT-{WORDS}-{RANDOM}`
+- **Pattern**: `SD-PAT-FIX-{CATEGORY}-###`
+- **Manual**: `SD-{TYPE}-{WORDS}-{RANDOM}`
+
+### After (Unified Approach)
+
+All scripts use SDKeyGenerator with consistent format:
+
+```
+SD-{SOURCE}-{TYPE}-{SEMANTIC}-{NUM}
+```
+
+**Backward Compatibility**: Existing SDs are not migrated. New convention applies only to newly created SDs.
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+#### Issue: "sd_type constraint violation"
+
+**Error**: `new row for relation "strategic_directives_v2" violates check constraint "sd_type_check"`
+
+**Cause**: The `type` parameter doesn't map to a valid database `sd_type`.
+
+**Solution**: Use the type mapping in `leo-create-sd.js`:
+
+```javascript
+// Valid database sd_types:
+// bugfix, database, docs, documentation, feature, infrastructure,
+// orchestrator, qa, refactor, security, implementation
+
+// User-friendly mappings:
+fix → bugfix
+feature → feature
+enhancement → feature
+infra → infrastructure
+doc → documentation
+```
+
+#### Issue: Collision detected
+
+**Error**: `Collision detected for SD-UAT-FIX-NAV-001, incrementing...`
+
+**Cause**: The proposed key already exists in `sd_key` or `id` column.
+
+**Solution**: The module automatically increments and retries. If this persists, check for corrupted data:
+
+```sql
+SELECT id, sd_key FROM strategic_directives_v2
+WHERE sd_key ILIKE 'SD-UAT-FIX-NAV%' OR id ILIKE 'SD-UAT-FIX-NAV%';
+```
+
+#### Issue: Semantic extraction returns "GEN"
+
+**Cause**: Title contains only stop words or very short words.
+
+**Solution**: Use a more descriptive title with technical terms:
+
+```javascript
+// Bad: "Fix the thing"
+// Returns: SD-UAT-FIX-GEN-001
+
+// Good: "Fix navigation route error"
+// Returns: SD-UAT-FIX-NAVIGATION-ROUTE-001
+```
+
+---
+
+## Related Documentation
+
+- **Command Documentation**: `.claude/commands/leo.md` - /leo create command
+- **Hierarchy Guide**: `docs/reference/sd-hierarchy-schema-guide.md` - Parent-child relationships
+- **Schema Reference**: `docs/database/strategic_directives_v2_field_reference.md` - Database fields
+- **npm Scripts**: `docs/reference/npm-scripts-guide.md` - CLI commands
+
+---
+
+**Last Updated**: 2026-01-20
+**Maintainer**: Claude (LEO Protocol)
+**SD**: SD-LEO-SDKEY-001

--- a/scripts/query-leo-section.js
+++ b/scripts/query-leo-section.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+/**
+ * Query LEO Protocol Section
+ * Usage: node scripts/query-leo-section.js <section-id>
+ */
+
+import { createDatabaseClient } from './lib/supabase-connection.js';
+
+async function main() {
+  const sectionId = process.argv[2] || '390';
+  const client = await createDatabaseClient('engineer', { verify: false });
+
+  try {
+    const result = await client.query(
+      'SELECT id, title, content, target_file FROM leo_protocol_sections WHERE id = $1;',
+      [sectionId]
+    );
+
+    if (result.rows.length === 0) {
+      console.log(`\n❌ No section found with ID: ${sectionId}\n`);
+      return;
+    }
+
+    const section = result.rows[0];
+    console.log(`\n📄 LEO Protocol Section ${section.id}`);
+    console.log(`Title: ${section.title}`);
+    console.log(`Target File: ${section.target_file || 'N/A'}`);
+    console.log(`Content Length: ${section.content ? section.content.length : 0} chars`);
+    console.log('\n--- Content Preview (first 1000 chars) ---');
+    console.log(section.content ? section.content.substring(0, 1000) : 'No content');
+    console.log('\n--- End Preview ---\n');
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+main();

--- a/scripts/update-section-390.js
+++ b/scripts/update-section-390.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Update Section 390 with SDKeyGenerator patterns
+ * Adds SDKeyGenerator-specific troubleshooting to existing content
+ */
+
+import { createDatabaseClient } from './lib/supabase-connection.js';
+
+const ADDITIONAL_CONTENT = `
+
+### SDKeyGenerator Errors (SD-LEO-SDKEY-001)
+
+#### Error: \`Invalid SD type\` or \`new value for domain sd_type violates check constraint\`
+
+**Cause**: Using user-friendly type names that don't match database constraint
+**Solution**: SDKeyGenerator automatically maps user types to valid database types:
+\`\`\`javascript
+// User-friendly types → Database types
+fix, bugfix → bugfix
+feature, feat → feature
+enhancement → feature
+refactor, refactoring → refactor
+infrastructure, infra → infrastructure
+documentation, docs → documentation
+testing, test → testing
+security → security
+\`\`\`
+
+**Reference**: \`scripts/modules/sd-key-generator.js\` line 45-60
+
+#### Error: \`SD key collision detected\` or duplicate key in different format
+
+**Cause**: Proposed SD key matches existing SD in either \`sd_key\` OR \`id\` column
+**Solution**: SDKeyGenerator checks BOTH columns automatically:
+\`\`\`javascript
+// Checks both columns
+const { data: existing } = await supabase
+  .from('strategic_directives_v2')
+  .select('id, sd_key')
+  .or(\`sd_key.eq.\${proposedKey},id.eq.\${proposedKey}\`);
+\`\`\`
+If collision detected, sequential number auto-increments (001 → 002 → 003).
+
+**Reference**: \`scripts/modules/sd-key-generator.js\` keyExists() function
+
+#### Error: Semantic extraction produces unclear abbreviations
+
+**Cause**: Title contains many small words or acronyms
+**Solution**: SDKeyGenerator extracts 2-3 meaningful words, skipping common words:
+\`\`\`javascript
+// "Fix navigation route not working" → "NAV-ROUTE"
+// "Add user authentication feature" → "USER-AUTH"
+// Skips: the, a, an, and, or, but, to, from, with, of, for, in, on, at
+\`\`\`
+
+**Manual override available**:
+\`\`\`javascript
+await generateSDKey({
+  source: 'UAT',
+  type: 'bugfix',
+  title: 'Fix navigation route not working',
+  semanticOverride: 'NAV-FIX'  // Force specific semantic
+});
+\`\`\`
+
+**Reference**: \`scripts/modules/sd-key-generator.js\` extractSemanticWords() function
+
+#### Error: Child SD key format incorrect (e.g., \`SD-UAT-FIX-NAV-001-A\` vs \`SD-UAT-FIX-NAV-001A\`)
+
+**Cause**: Manual child key creation without using SDKeyGenerator hierarchy functions
+**Solution**: Use SDKeyGenerator hierarchy functions for consistent encoding:
+\`\`\`javascript
+// Root SD
+const rootKey = await generateSDKey({...}); // SD-UAT-FIX-NAV-001
+
+// Child (no hyphen before suffix)
+const childKey = generateChildKey(rootKey, 'A'); // SD-UAT-FIX-NAV-001A
+
+// Grandchild (hyphen before numeric suffix)
+const grandchildKey = generateGrandchildKey(childKey, '1'); // SD-UAT-FIX-NAV-001A-1
+
+// Great-grandchild (dot separator)
+const greatGrandchildKey = generateGreatGrandchildKey(grandchildKey, '1'); // SD-UAT-FIX-NAV-001A-1.1
+\`\`\`
+
+**Hierarchy encoding rules**:
+- Root: \`SD-SOURCE-TYPE-SEMANTIC-NUM\`
+- Child: Append letter (no hyphen): \`-NUMA\`
+- Grandchild: Add hyphen + number: \`-NUMA-1\`
+- Great-grandchild: Add dot + number: \`-NUMA-1.1\`
+
+**Reference**: \`docs/reference/sd-key-generator-guide.md\` Hierarchy Support section
+
+#### Error: Sequential numbering gaps (e.g., 001, 002, 005)
+
+**Cause**: Deleted SDs or manual key creation creating gaps
+**Solution**: SDKeyGenerator automatically finds next available number:
+\`\`\`javascript
+// If SD-UAT-FIX-NAV-001 and SD-UAT-FIX-NAV-003 exist
+// Next key will be SD-UAT-FIX-NAV-002 (fills gap)
+// Then SD-UAT-FIX-NAV-004 (next sequential)
+\`\`\`
+
+**Reference**: \`scripts/modules/sd-key-generator.js\` getNextSequentialNumber() function
+
+### Using /leo create Command
+
+#### Recommended: Unified SD creation interface (SD-LEO-SDKEY-001)
+
+Instead of manually calling SDKeyGenerator or legacy scripts, use \`/leo create\`:
+
+\`\`\`bash
+# Interactive mode - Prompts for all fields
+/leo create
+
+# From UAT finding
+/leo create --from-uat <test-id>
+
+# From /learn pattern
+/leo create --from-learn <pattern-id>
+
+# From /inbox feedback
+/leo create --from-feedback <feedback-id>
+
+# Create child SD
+/leo create --child SD-UAT-FIX-NAV-001 A
+\`\`\`
+
+**Features**:
+- Automatic source detection (UAT, LEARN, FEEDBACK, etc.)
+- Type mapping to valid database constraints
+- Collision detection across both \`sd_key\` and \`id\` columns
+- Sequential numbering with gap detection
+- Hierarchy support (4 levels)
+
+**Reference**: \`docs/reference/npm-scripts-guide.md\` line 121-148, \`docs/reference/sd-key-generator-guide.md\`
+
+#### Migration from legacy scripts
+
+If you have code using old SD creation patterns, migrate to SDKeyGenerator:
+
+\`\`\`javascript
+// OLD (manual key generation)
+const sdKey = \`SD-\${source}-\${type.toUpperCase()}-\${semantic}-001\`;
+
+// NEW (SDKeyGenerator)
+import { generateSDKey } from './modules/sd-key-generator.js';
+const sdKey = await generateSDKey({ source, type, title });
+\`\`\`
+
+**Migrated scripts**:
+1. \`scripts/uat-to-strategic-directive-ai.js\`
+2. \`scripts/sd-from-feedback.js\`
+3. \`scripts/pattern-alert-sd-creator.js\`
+4. \`scripts/create-sd.js\`
+5. \`scripts/modules/learning/executor.js\`
+`;
+
+async function main() {
+  const client = await createDatabaseClient('engineer', { verify: false });
+
+  try {
+    // Get current content
+    const result = await client.query(
+      'SELECT id, title, content FROM leo_protocol_sections WHERE id = 390;'
+    );
+
+    if (result.rows.length === 0) {
+      console.error('❌ Section 390 not found');
+      process.exit(1);
+    }
+
+    const section = result.rows[0];
+    const currentContent = section.content || '';
+    const updatedContent = currentContent + ADDITIONAL_CONTENT;
+
+    console.log(`\n📝 Updating Section 390: ${section.title}`);
+    console.log(`Current length: ${currentContent.length} chars`);
+    console.log(`Additional content: ${ADDITIONAL_CONTENT.length} chars`);
+    console.log(`New length: ${updatedContent.length} chars\n`);
+
+    // Update the section
+    const updateResult = await client.query(
+      'UPDATE leo_protocol_sections SET content = $1 WHERE id = 390 RETURNING id, title;',
+      [updatedContent]
+    );
+
+    if (updateResult.rowCount > 0) {
+      console.log('✅ Section 390 updated successfully');
+      console.log(`\n📋 Updated: ${updateResult.rows[0].title}`);
+      console.log('\n💡 Next step: Run `node scripts/generate-claude-md-from-db.js` to regenerate CLAUDE.md files\n');
+    } else {
+      console.error('❌ Update failed - no rows affected');
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- **Created** `docs/reference/sd-key-generator-guide.md` - Comprehensive API reference for the centralized SDKeyGenerator module
- **Updated** `docs/reference/npm-scripts-guide.md` - Added `/leo create` command documentation with examples
- **Updated** `CLAUDE_LEAD.md` - Added SDKeyGenerator error patterns to section 390 (Common SD Creation Errors)
- **Added** utility scripts `scripts/query-leo-section.js` and `scripts/update-section-390.js` for LEO section management

This PR completes the documentation phase for SD-LEO-SDKEY-001, which centralized SD creation through the `/leo` command with a unified key generation module.

## Test plan

- [x] Smoke tests pass
- [x] DOCMON database-first compliance check passes
- [ ] Verify `sd-key-generator-guide.md` is accessible and renders correctly
- [ ] Verify `/leo create` command documented in npm-scripts-guide.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)