### PR TITLE
docs(leo): bring LEO hub documentation into standards compliance (SD-DOC-LEO-STANDARDS-001)

### DIFF
--- a/docs/DOCUMENTATION_STANDARDS.md
+++ b/docs/DOCUMENTATION_STANDARDS.md
@@ -141,6 +141,7 @@ Every markdown file MUST start with:
 | Feature Docs | `/docs/04_features/` | `mvp_engine.md`, `01b_idea_generation.md` |
 | Test Docs | `/docs/05_testing/` | `testing_qa.md` |
 | Deploy Docs | `/docs/06_deployment/` | `deployment_ops.md` |
+| **LEO Protocol Hub** | `/docs/leo/` | `handoffs/`, `sub-agents/`, `commands/` |
 | How-to Guides | `/docs/guides/` | `[guide-name].md` |
 | Quick Reference | `/docs/reference/` | `database-agent-patterns.md` |
 | Database Docs | `/docs/database/` | `schema/`, `migrations/` |

--- a/docs/leo/README.md
+++ b/docs/leo/README.md
@@ -1,8 +1,16 @@
 # LEO Protocol Documentation Hub
 
-Central documentation for the LEO (LEAD-EXEC-OPS) Protocol system.
+## Metadata
+- **Category**: Protocol
+- **Status**: Approved
+- **Version**: 1.0.0
+- **Author**: LEO Protocol Team
+- **Last Updated**: 2026-01-20
+- **Tags**: leo, protocol, documentation, hub
 
 ## Overview
+
+Central documentation for the LEO (LEAD-EXEC-OPS) Protocol system.
 
 The LEO Protocol is a structured software development governance framework that enforces quality through:
 - **LEAD Phase**: Strategic directive approval and scoping
@@ -130,3 +138,9 @@ node scripts/generate-claude-md-from-db.js  # Regenerate CLAUDE.md
 
 *LEO Protocol Version: 4.3.3*
 *Last Updated: 2026-01-20*
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-01-20 | Initial documentation hub creation |

--- a/docs/leo/commands/command-ecosystem.md
+++ b/docs/leo/commands/command-ecosystem.md
@@ -8,7 +8,18 @@
 - **Last Updated**: 2026-01-11
 - **Tags**: commands, workflow, ecosystem, slash-commands
 
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Overview](#overview)
+- [Command Flow Diagram](#command-flow-diagram)
+- [Command Reference](#command-reference)
+- [Workflow Integration](#workflow-integration)
+- [Related Documentation](#related-documentation)
+- [Version History](#version-history)
+
 ## Purpose
+
 Defines how slash commands intelligently reference each other based on workflow context.
 
 ## Overview

--- a/docs/leo/handoffs/handoff-system-guide.md
+++ b/docs/leo/handoffs/handoff-system-guide.md
@@ -1,8 +1,31 @@
 # Handoff System Guide
 
+## Metadata
+- **Category**: Protocol
+- **Status**: Approved
+- **Version**: 1.0.0
+- **Author**: LEO Protocol Team
+- **Last Updated**: 2026-01-20
+- **Tags**: leo, handoff, gates, validation, executor
+
+## Overview
+
 **SD-REFACTOR-HANDOFF-001: Handoff System Modularization**
 
 This guide documents the LEO Protocol handoff system architecture, gate validation patterns, and executor framework.
+
+## Table of Contents
+
+- [Quick Reference](#quick-reference)
+- [1. Prerequisite Validator Behavior](#1-prerequisite-validator-behavior)
+- [2. Executor Framework Architecture](#2-executor-framework-architecture)
+- [3. Gate Validation System](#3-gate-validation-system)
+- [4. Template Engine](#4-template-engine)
+- [5. Error Handling Patterns](#5-error-handling-patterns)
+- [6. Executor Reference](#6-executor-reference)
+- [7. Best Practices](#7-best-practices)
+- [Related Documentation](#related-documentation)
+- [Version History](#version-history)
 
 ## Quick Reference
 
@@ -482,10 +505,16 @@ const result = await executor.execute();
 
 ## Related Documentation
 
-- [Sub-Agent Patterns Guide](./sub-agent-patterns-guide.md) - Sub-agent integration
-- [Governance Library Guide](./governance-library-guide.md) - Exception handling
-- [Agent Patterns Guide](./agent-patterns-guide.md) - Agent architecture
+- [Sub-Agent Patterns Guide](../sub-agents/patterns-guide.md) - Sub-agent integration patterns
+- [Sub-Agent System](../sub-agents/sub-agent-system.md) - Complete sub-agent reference
+- [Command Ecosystem](../commands/command-ecosystem.md) - Command workflow integration
 
 ---
 
 *Generated for SD-REFACTOR-HANDOFF-001 | LEO Protocol v4.3.3*
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-01-20 | Initial documentation, moved to LEO hub |

--- a/docs/leo/operational/self-improvement.md
+++ b/docs/leo/operational/self-improvement.md
@@ -1,10 +1,25 @@
 # LEO Protocol Self-Improvement System
 
-**Updated**: 2026-01-10
-**Status**: Active
-**Context Tier**: REFERENCE
+## Metadata
+- **Category**: Protocol
+- **Status**: Approved
+- **Version**: 2.0.0
+- **Author**: LEO Protocol Team
+- **Last Updated**: 2026-01-20
+- **Tags**: leo, self-improvement, retrospectives, learning, continuous-improvement
 
 ---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Architecture Flow (v2)](#architecture-flow-v2)
+- [Database Schema](#database-schema)
+- [Commands Reference](#commands-reference)
+- [Retrospective Patterns](#retrospective-patterns)
+- [Effectiveness Tracking](#effectiveness-tracking)
+- [Related Documentation](#related-documentation)
+- [Version History](#version-history)
 
 ## Overview
 
@@ -958,7 +973,20 @@ A: Prioritize by impact and evidence count. Test in isolation before combining. 
 
 ---
 
-**Last Updated**: 2026-01-10
+**Last Updated**: 2026-01-20
 **Related SD**: SD-LEO-LEARN-001 (Proactive Learning Integration)
 **Evidence Base**: 74+ retrospectives analyzed
 **System Status**: Active - v2 SD Creation Workflow (January 2026)
+
+## Related Documentation
+
+- [Retrospective Patterns Skill](../../reference/retrospective-patterns-skill-content.md) - Retrospective creation patterns
+- [Handoff System Guide](../handoffs/handoff-system-guide.md) - Handoff integration
+- [Command Ecosystem](../commands/command-ecosystem.md) - /learn command integration
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 2.0.0 | 2026-01-20 | Added metadata, TOC, version history; moved to LEO hub |
+| 1.0.0 | 2026-01-10 | v2 SD creation workflow |

--- a/docs/leo/sub-agents/sub-agent-system.md
+++ b/docs/leo/sub-agents/sub-agent-system.md
@@ -1,10 +1,39 @@
 # Sub-Agent System Reference
 
+## Metadata
+- **Category**: Protocol
+- **Status**: Approved
+- **Version**: 1.0.0
+- **Author**: LEO Protocol Team
+- **Last Updated**: 2026-01-20
+- **Tags**: leo, sub-agents, triggers, automation, validation
+
+## Overview
+
 **Database-Driven Sub-Agent Architecture**
 
 This document provides comprehensive details about all active sub-agents, their triggers, and activation patterns.
 
 > **Note**: This is extracted from the database. For the latest information, query the `leo_sub_agents` and `leo_sub_agent_triggers` tables directly.
+
+## Table of Contents
+
+- [Active Sub-Agents](#active-sub-agents)
+- [Sub-Agent Details](#sub-agent-details)
+  - [Information Architecture Lead (DOCMON)](#information-architecture-lead-docmon)
+  - [DevOps Platform Architect (GITHUB)](#devops-platform-architect-github)
+  - [UAT Test Executor (UAT)](#uat-test-executor-uat)
+  - [Continuous Improvement Coach (RETRO)](#continuous-improvement-coach-retro)
+  - [Senior Design Sub-Agent (DESIGN)](#senior-design-sub-agent-design)
+  - [Chief Security Architect (SECURITY)](#chief-security-architect-security)
+  - [Principal Database Architect (DATABASE)](#principal-database-architect-database)
+  - [QA Engineering Director (TESTING)](#qa-engineering-director-testing)
+  - [Performance Engineering Lead (PERFORMANCE)](#performance-engineering-lead-performance)
+  - [Principal Systems Analyst (VALIDATION)](#principal-systems-analyst-validation)
+- [Trigger Types](#trigger-types)
+- [Execution Patterns](#execution-patterns)
+- [Related Documentation](#related-documentation)
+- [Version History](#version-history)
 
 ## Active Sub-Agents
 
@@ -745,3 +774,15 @@ INSERT INTO leo_sub_agent_triggers (
   true
 );
 ```
+
+## Related Documentation
+
+- [Patterns Guide](./patterns-guide.md) - Sub-agent integration patterns
+- [Handoff System Guide](../handoffs/handoff-system-guide.md) - Handoff integration
+- [Command Ecosystem](../commands/command-ecosystem.md) - Command workflow
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2026-01-20 | Initial documentation, moved to LEO hub |


### PR DESCRIPTION
## Summary

Brings the docs/leo/ hub files into compliance with DOCUMENTATION_STANDARDS.md:

- Add standard metadata headers to 4 files (README.md, handoff-system-guide.md, sub-agent-system.md, self-improvement.md)
- Add Table of Contents to 4 long files (>200 lines: handoff-system-guide.md at 492 lines, sub-agent-system.md at 776 lines, command-ecosystem.md at 260 lines, self-improvement.md at 965 lines)
- Update DOCUMENTATION_STANDARDS.md Location Rules to include docs/leo/
- Fix stale cross-references in handoff-system-guide.md (lines 485-487 pointed to non-existent files)
- Add version history sections to 3 files

## Files Changed

| File | Changes |
|------|---------|
| docs/leo/README.md | +metadata header, +version history |
| docs/leo/handoffs/handoff-system-guide.md | +metadata, +TOC, +version history, fixed cross-refs |
| docs/leo/sub-agents/sub-agent-system.md | +metadata, +TOC, +related docs, +version history |
| docs/leo/commands/command-ecosystem.md | +TOC |
| docs/leo/operational/self-improvement.md | +metadata, +TOC, +related docs, +version history |
| docs/DOCUMENTATION_STANDARDS.md | +docs/leo/ in Location Rules |

## Test plan

- [x] All metadata headers follow DOCUMENTATION_STANDARDS.md template
- [x] TOC links functional (verified anchor links work)
- [x] Cross-references point to existing files in docs/leo/ structure
- [x] Version history tables present at end of files

🤖 Generated with [Claude Code](https://claude.com/claude-code)