### PR TITLE
feat(leo): filter uncommitted file warnings by age (5+ days)

### DIFF
--- a/lib/multi-repo/index.js
+++ b/lib/multi-repo/index.js
@@ -166,9 +166,13 @@ export function getPrimaryRepos() {
 /**
  * Get git status for a repository
  * @param {string} repoPath - Path to repository
+ * @param {Object} options - Options
+ * @param {boolean} options.includeFileAge - Include file modification age in results
  * @returns {Object} Status information
  */
-export function getRepoGitStatus(repoPath) {
+export function getRepoGitStatus(repoPath, options = {}) {
+  const { includeFileAge = true } = options;
+
   try {
     // Get current branch
     const branch = execSync('git rev-parse --abbrev-ref HEAD', {
@@ -190,8 +194,11 @@ export function getRepoGitStatus(repoPath) {
       for (const line of statusOutput.split('\n')) {
         if (!line.trim()) continue;
 
+        // Git porcelain format: XY PATH (2 status chars + space + path)
+        // But the space between XY and PATH can merge with Y when Y is space
+        // So we take first 2 chars as status, then trim the rest to get the path
         const status = line.substring(0, 2);
-        const file = line.substring(3);
+        const file = line.substring(2).trim();
 
         let changeType = 'modified';
         if (status.includes('?')) changeType = 'untracked';
@@ -200,7 +207,22 @@ export function getRepoGitStatus(repoPath) {
         else if (status.includes('R')) changeType = 'renamed';
         else if (status.includes('M')) changeType = 'modified';
 
-        changes.push({ status: status.trim(), file, changeType });
+        // Get file age if requested
+        let fileAgeDays = null;
+        if (includeFileAge && changeType !== 'deleted') {
+          try {
+            const filePath = join(repoPath, file);
+            const fileStat = statSync(filePath);
+            const now = new Date();
+            const mtime = new Date(fileStat.mtime);
+            fileAgeDays = Math.floor((now - mtime) / (1000 * 60 * 60 * 24));
+          } catch {
+            // File might not exist or be inaccessible
+            fileAgeDays = null;
+          }
+        }
+
+        changes.push({ status: status.trim(), file, changeType, fileAgeDays });
       }
     }
 
@@ -261,19 +283,56 @@ export function getAllReposStatus(primaryOnly = true) {
 /**
  * Check if any repository has uncommitted changes
  * @param {boolean} primaryOnly - Only check primary repos
+ * @param {Object} options - Filtering options
+ * @param {number} options.minAgeDays - Only include files older than this many days (default: 0 = all files)
  * @returns {Object} Summary of uncommitted changes
  */
-export function checkUncommittedChanges(primaryOnly = true) {
+export function checkUncommittedChanges(primaryOnly = true, options = {}) {
+  const { minAgeDays = 0 } = options;
   const statuses = getAllReposStatus(primaryOnly);
 
-  const withChanges = statuses.filter(r => r.status.hasUncommitted || r.status.hasUnpushed);
-  const clean = statuses.filter(r => r.status.isClean);
+  // Filter changes by age if minAgeDays is specified
+  const filteredStatuses = statuses.map(r => {
+    if (minAgeDays > 0 && r.status.changes) {
+      const filteredChanges = r.status.changes.filter(change => {
+        // Only include if we can confirm the file is old enough
+        // Files with unknown age (null) are excluded - be conservative with warnings
+        return change.fileAgeDays !== null && change.fileAgeDays >= minAgeDays;
+      });
+
+      return {
+        ...r,
+        status: {
+          ...r.status,
+          changes: filteredChanges,
+          hasUncommitted: filteredChanges.length > 0,
+          isClean: filteredChanges.length === 0 && r.status.unpushedCount === 0
+        },
+        // Track original counts for display
+        originalChangesCount: r.status.changes.length,
+        filteredOutCount: r.status.changes.length - filteredChanges.length
+      };
+    }
+    return {
+      ...r,
+      originalChangesCount: r.status.changes?.length || 0,
+      filteredOutCount: 0
+    };
+  });
+
+  const withChanges = filteredStatuses.filter(r => r.status.hasUncommitted || r.status.hasUnpushed);
+  const clean = filteredStatuses.filter(r => r.status.isClean);
+
+  // Calculate total filtered out across all repos
+  const totalFilteredOut = filteredStatuses.reduce((sum, r) => sum + (r.filteredOutCount || 0), 0);
 
   return {
     hasChanges: withChanges.length > 0,
-    totalRepos: statuses.length,
+    totalRepos: filteredStatuses.length,
     reposWithChanges: withChanges,
     cleanRepos: clean,
+    minAgeDays,
+    totalFilteredOut,
     summary: withChanges.map(r => ({
       name: r.name,
       displayName: r.displayName,
@@ -281,7 +340,8 @@ export function checkUncommittedChanges(primaryOnly = true) {
       branch: r.status.branch,
       uncommittedCount: r.status.changes.length,
       unpushedCount: r.status.unpushedCount,
-      changes: r.status.changes
+      changes: r.status.changes,
+      filteredOutCount: r.filteredOutCount || 0
     }))
   };
 }

--- a/scripts/sd-next.js
+++ b/scripts/sd-next.js
@@ -438,10 +438,12 @@ class SDNextSelector {
   /**
    * Load multi-repo status (Phase 2 multi-repo intelligence)
    * Checks for uncommitted changes across all EHG repositories
+   * Only warns about files older than 5 days (WIP files are ignored)
    */
   loadMultiRepoStatus() {
     try {
-      this.multiRepoStatus = checkUncommittedChanges(true); // primary repos only
+      // Only warn about files older than 5 days - recent WIP is expected
+      this.multiRepoStatus = checkUncommittedChanges(true, { minAgeDays: 5 });
     } catch {
       // Non-fatal - continue without multi-repo status
       this.multiRepoStatus = null;
@@ -467,12 +469,16 @@ class SDNextSelector {
 
   /**
    * Display multi-repo status warning if uncommitted changes exist
+   * Only shows files older than the configured threshold (default 5 days)
    */
   displayMultiRepoWarning() {
     if (!this.multiRepoStatus || !this.multiRepoStatus.hasChanges) return;
 
+    const minAgeDays = this.multiRepoStatus.minAgeDays || 5;
+
     console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
-    console.log(`${colors.bgYellow}${colors.bold} MULTI-REPO WARNING ${colors.reset}\n`);
+    console.log(`${colors.bgYellow}${colors.bold} MULTI-REPO WARNING ${colors.reset}`);
+    console.log(`${colors.dim}(Showing files ≥${minAgeDays} days old)${colors.reset}\n`);
 
     for (const repo of this.multiRepoStatus.summary) {
       const icon = repo.uncommittedCount > 0 ? '📝' : '📤';


### PR DESCRIPTION
## Summary

- Add age-based filtering to multi-repo uncommitted changes warning in `sd:next`
- Files modified less than 5 days ago are now ignored (assumed work-in-progress)
- Files 5+ days old still trigger the warning (stale uncommitted work)
- Fix git status parsing bug where file paths were truncated

## Changes

- `lib/multi-repo/index.js`: Add `fileAgeDays` to change detection, add `minAgeDays` option
- `scripts/sd-next.js`: Use 5-day threshold, show threshold in warning message

## Test plan

- [x] Run `npm run sd:next` with recent uncommitted files → no warning shown
- [x] Verify file age detection works correctly for all file types
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)