### PR TITLE
refactor(scripts): extract queue/generation modules (SD-LEO-REFACTOR-QUEUE-001)

### DIFF
--- a/scripts/claude-gen/data-fetchers.js
+++ b/scripts/claude-gen/data-fetchers.js
@@ -1,0 +1,253 @@
+/**
+ * Data fetchers for CLAUDE.md generation
+ * Handles all database queries for LEO Protocol data
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+export { supabase };
+
+/**
+ * Get active protocol version
+ */
+export async function getActiveProtocol() {
+  const { data, error } = await supabase
+    .from('leo_protocols')
+    .select('*')
+    .eq('status', 'ACTIVE')
+    .single();
+
+  if (error) {
+    console.warn(`⚠️ No active protocol found: ${error.message}`);
+    return {
+      id: 'leo-v4-3-3-ui-parity',
+      version: '4.3.3',
+      title: 'LEO Protocol v4.3.3 - UI Parity Governance',
+      status: 'ACTIVE'
+    };
+  }
+  return data;
+}
+
+/**
+ * Get agents configuration
+ */
+export async function getAgents() {
+  const { data, error } = await supabase.from('leo_agents').select('*').eq('is_active', true);
+  if (error) console.warn(`⚠️ Agents: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get sub-agents with trigger keywords
+ */
+export async function getSubAgents() {
+  const { data, error } = await supabase
+    .from('leo_sub_agents')
+    .select('*')
+    .eq('is_active', true)
+    .order('code');
+
+  if (error) console.warn(`⚠️ Sub-agents: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get handoff templates
+ */
+export async function getHandoffTemplates() {
+  const { data, error } = await supabase.from('sd_phase_handoff_templates').select('*').order('created_at');
+  if (error) console.warn(`⚠️ Handoff templates: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get validation rules
+ */
+export async function getValidationRules() {
+  const { data, error } = await supabase.from('leo_validation_rules').select('*').eq('active', true).order('gate');
+  if (error) console.warn(`⚠️ Validation rules: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get schema constraints
+ */
+export async function getSchemaConstraints() {
+  const { data: constraints, error } = await supabase
+    .from('schema_validation_rules')
+    .select('*')
+    .eq('is_active', true)
+    .order('table_name, column_name');
+
+  if (error) {
+    console.warn(`⚠️ Schema constraints: ${error.message}`);
+    return [];
+  }
+
+  const grouped = {};
+  for (const c of constraints || []) {
+    const key = c.table_name;
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push(c);
+  }
+
+  return Object.entries(grouped).map(([table, rules]) => ({
+    table_name: table,
+    constraints: rules
+  }));
+}
+
+/**
+ * Get process scripts
+ */
+export async function getProcessScripts() {
+  const { data: scripts, error } = await supabase
+    .from('leo_process_scripts')
+    .select('*')
+    .eq('is_active', true)
+    .order('category, script_name');
+
+  if (error) {
+    console.warn(`⚠️ Process scripts: ${error.message}`);
+    return [];
+  }
+
+  const grouped = {};
+  for (const s of scripts || []) {
+    const key = s.category || 'uncategorized';
+    if (!grouped[key]) grouped[key] = [];
+    grouped[key].push(s);
+  }
+
+  return Object.entries(grouped).map(([category, items]) => ({
+    category,
+    scripts: items
+  }));
+}
+
+/**
+ * Get hot patterns (recent recurring issues)
+ */
+export async function getHotPatterns(limit = 5) {
+  try {
+    const { data, error } = await supabase
+      .from('issue_patterns')
+      .select('*')
+      .in('status', ['active', 'monitoring'])
+      .order('occurrence_count', { ascending: false })
+      .order('last_seen_at', { ascending: false })
+      .limit(limit);
+
+    if (error) return [];
+    return data || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get recent retrospectives
+ */
+export async function getRecentRetrospectives(days = 30, limit = 5) {
+  try {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - days);
+
+    const { data, error } = await supabase
+      .from('retrospectives')
+      .select('*')
+      .gte('created_at', cutoff.toISOString())
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error) return [];
+    return data || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get gate health metrics
+ */
+export async function getGateHealth() {
+  try {
+    const { data: handoffs, error } = await supabase
+      .from('sd_phase_handoffs')
+      .select('handoff_type, status, quality_score, created_at')
+      .gte('created_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString());
+
+    if (error) return null;
+
+    const gateMetrics = {};
+    for (const h of handoffs || []) {
+      const gate = h.handoff_type;
+      if (!gateMetrics[gate]) {
+        gateMetrics[gate] = { total: 0, passed: 0, totalScore: 0, scores: [] };
+      }
+      gateMetrics[gate].total++;
+      if (h.status === 'accepted') gateMetrics[gate].passed++;
+      if (h.quality_score) {
+        gateMetrics[gate].totalScore += h.quality_score;
+        gateMetrics[gate].scores.push(h.quality_score);
+      }
+    }
+
+    return Object.entries(gateMetrics).map(([gate, m]) => ({
+      gate,
+      pass_rate: m.total > 0 ? ((m.passed / m.total) * 100).toFixed(1) : 'N/A',
+      avg_score: m.scores.length > 0 ? (m.totalScore / m.scores.length).toFixed(1) : 'N/A',
+      total_handoffs: m.total
+    }));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get pending proposals
+ */
+export async function getPendingProposals(limit = 5) {
+  try {
+    const { data, error } = await supabase
+      .from('sd_proposals')
+      .select('*')
+      .eq('status', 'pending')
+      .order('urgency_level', { ascending: true })
+      .order('confidence_score', { ascending: false })
+      .limit(limit);
+
+    if (error) return [];
+    return data || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get autonomous directives
+ */
+export async function getAutonomousDirectives() {
+  try {
+    const { data, error } = await supabase
+      .from('leo_autonomous_directives')
+      .select('*')
+      .eq('is_active', true)
+      .order('priority', { ascending: false })
+      .order('phase');
+
+    if (error) return [];
+    return data || [];
+  } catch {
+    return [];
+  }
+}

--- a/scripts/claude-gen/index.js
+++ b/scripts/claude-gen/index.js
@@ -1,0 +1,39 @@
+/**
+ * CLAUDE.md Generation Modules - Entry Point
+ *
+ * Re-exports all modules for convenient importing.
+ * Part of SD-LEO-REFACTOR-QUEUE-001 refactoring.
+ */
+
+// Data fetching functions
+export {
+  supabase,
+  getActiveProtocol,
+  getAgents,
+  getSubAgents,
+  getHandoffTemplates,
+  getValidationRules,
+  getSchemaConstraints,
+  getProcessScripts,
+  getHotPatterns,
+  getRecentRetrospectives,
+  getGateHealth,
+  getPendingProposals,
+  getAutonomousDirectives
+} from './data-fetchers.js';
+
+// Section generation functions
+export {
+  generateSchemaConstraintsSection,
+  generateProcessScriptsSection,
+  generateHotPatternsSection,
+  generateRecentLessonsSection,
+  generateGateHealthSection,
+  generateProposalsSection,
+  generateAutonomousDirectivesSection,
+  generateAgentSection,
+  generateSubAgentSection,
+  generateTriggerQuickReference,
+  generateHandoffTemplates,
+  generateValidationRules
+} from './section-generators.js';

--- a/scripts/claude-gen/section-generators.js
+++ b/scripts/claude-gen/section-generators.js
@@ -1,0 +1,624 @@
+/**
+ * Section generators for CLAUDE.md files
+ * Generates markdown sections from database data
+ *
+ * Extracted from CLAUDEMDGeneratorV3 class in generate-claude-md-from-db.js
+ * Part of SD-LEO-REFACTOR-QUEUE-001
+ */
+
+/**
+ * Helper to safely stringify JSONB values
+ */
+function safeJson(val, fallback = 'N/A') {
+  if (val === null || val === undefined) return fallback;
+  if (typeof val === 'string') return val;
+  try {
+    return JSON.stringify(val, null, 2);
+  } catch {
+    return String(val);
+  }
+}
+
+/**
+ * Generate schema constraints section for EXEC phase
+ */
+export function generateSchemaConstraintsSection(constraints) {
+  if (!constraints || constraints.length === 0) {
+    return '';
+  }
+
+  let section = `## Database Schema Constraints Reference
+
+**CRITICAL**: These constraints are enforced by the database. Agents MUST use valid values to avoid insert failures.
+
+`;
+
+  // Group by table
+  const byTable = {};
+  constraints.forEach(c => {
+    if (!byTable[c.table_name]) byTable[c.table_name] = [];
+    byTable[c.table_name].push(c);
+  });
+
+  for (const [table, cols] of Object.entries(byTable)) {
+    section += `### ${table}\n\n`;
+    section += '| Column | Valid Values | Hint |\n';
+    section += '|--------|--------------|------|\n';
+
+    cols.forEach(c => {
+      const values = c.valid_values ? JSON.parse(JSON.stringify(c.valid_values)).join(', ') : 'N/A';
+      section += `| \`${c.column_name}\` | ${values} | ${c.remediation_hint || ''} |\n`;
+    });
+
+    section += '\n';
+  }
+
+  return section;
+}
+
+/**
+ * Generate process scripts section for EXEC phase
+ */
+export function generateProcessScriptsSection(scripts) {
+  if (!scripts || scripts.length === 0) {
+    return '';
+  }
+
+  let section = `## LEO Process Scripts Reference
+
+**Usage**: All scripts use positional arguments unless noted otherwise.
+
+`;
+
+  // Group by category
+  const byCategory = {};
+  scripts.forEach(s => {
+    const cat = s.category || 'other';
+    if (!byCategory[cat]) byCategory[cat] = [];
+    byCategory[cat].push(s);
+  });
+
+  for (const [category, categoryScripts] of Object.entries(byCategory)) {
+    section += `### ${category.charAt(0).toUpperCase() + category.slice(1)} Scripts\n\n`;
+
+    categoryScripts.forEach(s => {
+      section += `#### ${s.script_name}\n`;
+      section += `${s.description}\n\n`;
+      section += `**Usage**: \`${s.usage_pattern}\`\n\n`;
+
+      if (s.examples && s.examples.length > 0) {
+        section += '**Examples**:\n';
+        s.examples.forEach(ex => {
+          section += `- \`${ex.command}\`\n`;
+        });
+        section += '\n';
+      }
+
+      if (s.common_errors && s.common_errors.length > 0) {
+        section += '**Common Errors**:\n';
+        s.common_errors.forEach(err => {
+          section += `- Pattern: \`${err.error_pattern}\` → Fix: ${err.fix}\n`;
+        });
+        section += '\n';
+      }
+    });
+  }
+
+  return section;
+}
+
+/**
+ * Generate Hot Issue Patterns section for CLAUDE_CORE.md
+ */
+export function generateHotPatternsSection(patterns) {
+  if (!patterns || patterns.length === 0) {
+    return '';
+  }
+
+  let section = `## 🔥 Hot Issue Patterns (Auto-Updated)
+
+**CRITICAL**: These are active patterns detected from retrospectives. Review before starting work.
+
+| Pattern ID | Category | Severity | Count | Trend | Top Solution |
+|------------|----------|----------|-------|-------|--------------|
+`;
+
+  patterns.forEach(p => {
+    const topSolution = p.proven_solutions && p.proven_solutions.length > 0
+      ? (p.proven_solutions[0].solution || p.proven_solutions[0].method || 'See details').substring(0, 40)
+      : 'N/A';
+    const trendIcon = p.trend === 'increasing' ? '📈' : p.trend === 'decreasing' ? '📉' : '➡️';
+    const severityIcon = p.severity === 'critical' ? '🔴' : p.severity === 'high' ? '🟠' : p.severity === 'medium' ? '🟡' : '🟢';
+
+    section += `| ${p.pattern_id} | ${p.category} | ${severityIcon} ${p.severity} | ${p.occurrence_count} | ${trendIcon} | ${topSolution} |\n`;
+  });
+
+  section += `
+### Prevention Checklists
+
+`;
+
+  // Group patterns by category and show prevention checklists
+  const byCategory = {};
+  patterns.forEach(p => {
+    if (p.prevention_checklist && p.prevention_checklist.length > 0) {
+      const cat = p.category || 'general';
+      if (!byCategory[cat]) byCategory[cat] = [];
+      byCategory[cat].push(...p.prevention_checklist.slice(0, 3));
+    }
+  });
+
+  for (const [category, items] of Object.entries(byCategory)) {
+    section += `**${category}**:\n`;
+    const uniqueItems = [...new Set(items)].slice(0, 3);
+    uniqueItems.forEach(item => {
+      section += `- [ ] ${item}\n`;
+    });
+    section += '\n';
+  }
+
+  section += `
+*Patterns auto-updated from \`issue_patterns\` table. Use \`npm run pattern:resolve PAT-XXX\` to mark resolved.*
+`;
+
+  return section;
+}
+
+/**
+ * Generate Recent Lessons section for CLAUDE_CORE.md
+ */
+export function generateRecentLessonsSection(retrospectives) {
+  if (!retrospectives || retrospectives.length === 0) {
+    return '';
+  }
+
+  let section = `## 📝 Recent Lessons (Last 30 Days)
+
+**From Published Retrospectives** - Apply these learnings proactively.
+
+`;
+
+  retrospectives.forEach((r, idx) => {
+    const date = r.conducted_date ? new Date(r.conducted_date).toLocaleDateString() : 'N/A';
+    const category = r.learning_category || 'GENERAL';
+    const qualityBadge = r.quality_score >= 80 ? '⭐' : '';
+
+    section += `### ${idx + 1}. ${r.title || r.sd_id || 'Untitled'} ${qualityBadge}\n`;
+    section += `**Category**: ${category} | **Date**: ${date} | **Score**: ${r.quality_score || 'N/A'}\n\n`;
+
+    // Show improvements if available (filter out boilerplate)
+    if (r.what_needs_improvement && Array.isArray(r.what_needs_improvement)) {
+      const improvements = r.what_needs_improvement
+        .filter(item => {
+          if (typeof item === 'object' && item.is_boilerplate === true) return false;
+          return true;
+        })
+        .slice(0, 2);
+      if (improvements.length > 0) {
+        section += '**Key Improvements**:\n';
+        improvements.forEach(item => {
+          let text;
+          if (typeof item === 'string') {
+            text = item;
+          } else if (item.improvement) {
+            text = item.improvement;
+          } else if (item.description) {
+            text = item.description;
+          } else if (item.item) {
+            text = item.item;
+          } else {
+            text = JSON.stringify(item);
+          }
+          section += `- ${text.substring(0, 100)}${text.length > 100 ? '...' : ''}\n`;
+        });
+        section += '\n';
+      }
+    }
+
+    // Show action items if available (filter out boilerplate)
+    if (r.action_items && Array.isArray(r.action_items)) {
+      const actions = r.action_items
+        .filter(item => {
+          if (typeof item === 'object' && item.is_boilerplate === true) return false;
+          return true;
+        })
+        .slice(0, 2);
+      if (actions.length > 0) {
+        section += '**Action Items**:\n';
+        actions.forEach(item => {
+          let text;
+          if (typeof item === 'string') {
+            text = item;
+          } else if (item.text) {
+            text = item.text;
+          } else if (item.action) {
+            text = item.action;
+          } else if (item.description) {
+            text = item.description;
+          } else {
+            text = Object.values(item).find(v => typeof v === 'string') || 'See details';
+          }
+          section += `- [ ] ${text.substring(0, 80)}${text.length > 80 ? '...' : ''}\n`;
+        });
+        section += '\n';
+      }
+    }
+  });
+
+  section += `
+*Lessons auto-generated from \`retrospectives\` table. Query for full details.*
+`;
+
+  return section;
+}
+
+/**
+ * Generate Gate Health section for CLAUDE_CORE.md
+ */
+export function generateGateHealthSection(gateHealth) {
+  if (!gateHealth || gateHealth.length === 0) {
+    return '';
+  }
+
+  let section = `## 🏥 Gate Health Monitor (Auto-Updated)
+
+**ATTENTION**: These gates are below the 80% pass rate threshold and may need remediation.
+
+| Gate | Pass Rate | Attempts | Failures | Status |
+|------|-----------|----------|----------|--------|
+`;
+
+  gateHealth.forEach(g => {
+    const statusIcon = g.pass_rate < 50 ? '🔴' : g.pass_rate < 70 ? '🟠' : '🟡';
+    const status = g.pass_rate < 50 ? 'Critical' : g.pass_rate < 70 ? 'Warning' : 'Monitor';
+
+    section += `| Gate ${g.gate} | ${g.pass_rate}% | ${g.total_attempts} | ${g.failures} | ${statusIcon} ${status} |\n`;
+  });
+
+  section += `
+### Remediation Actions
+
+When gates consistently fail:
+1. Run \`npm run gate:health\` for detailed analysis
+2. Review validation rules in \`leo_validation_rules\` table
+3. Check if rules are too strict or outdated
+4. Create remediation SD if pass rate < 70% for 2+ weeks
+
+*Gate health auto-updated from \`v_gate_health_metrics\`. Run \`npm run gate:health\` for details.*
+`;
+
+  return section;
+}
+
+/**
+ * Generate Proactive SD Proposals section for CLAUDE_CORE.md
+ */
+export function generateProposalsSection(proposals) {
+  if (!proposals || proposals.length === 0) {
+    return '';
+  }
+
+  let section = `## 📋 Proactive SD Proposals (LEO v4.4)
+
+**ACTION REQUIRED**: These are AI-generated proposals awaiting chairman approval.
+
+`;
+
+  proposals.forEach((p, idx) => {
+    const urgencyIcon = p.urgency_level === 'critical' ? '🔴' :
+                        p.urgency_level === 'medium' ? '🟡' : '🟢';
+    const triggerLabel = {
+      'dependency_update': 'Dependency',
+      'retrospective_pattern': 'Pattern',
+      'code_health': 'Code Health'
+    }[p.trigger_type] || p.trigger_type;
+    const confidence = (p.confidence_score * 100).toFixed(0);
+
+    section += `### ${idx + 1}. ${urgencyIcon} ${p.title}
+**Trigger**: ${triggerLabel} | **Confidence**: ${confidence}% | **ID**: \`${p.id.substring(0, 8)}\`
+
+${p.description.substring(0, 200)}${p.description.length > 200 ? '...' : ''}
+
+`;
+  });
+
+  section += `### Quick Actions
+
+\`\`\`bash
+# Approve proposal (creates draft SD):
+npm run proposal:approve <proposal-id>
+
+# Dismiss proposal:
+npm run proposal:dismiss <proposal-id> <reason>
+# Reasons: not_relevant, wrong_timing, duplicate, too_small, too_large, already_fixed, other
+
+# View all pending:
+npm run proposal:list
+\`\`\`
+
+*Proposals auto-generated by observer agents. Run \`npm run proposal:list\` for full details.*
+`;
+
+  return section;
+}
+
+/**
+ * Generate Autonomous Continuation Directives section for phase files
+ */
+export function generateAutonomousDirectivesSection(directives, phase) {
+  if (!directives || directives.length === 0) {
+    return '';
+  }
+
+  // Filter directives for this phase
+  const phaseDirectives = directives.filter(d =>
+    d.applies_to_phases && d.applies_to_phases.includes(phase)
+  );
+
+  if (phaseDirectives.length === 0) {
+    return '';
+  }
+
+  // Separate by enforcement point
+  const alwaysDirectives = phaseDirectives.filter(d => d.enforcement_point === 'ALWAYS');
+  const onFailureDirectives = phaseDirectives.filter(d => d.enforcement_point === 'ON_FAILURE');
+  const handoffDirectives = phaseDirectives.filter(d => d.enforcement_point === 'HANDOFF_START');
+
+  let section = `## Autonomous Continuation Directives
+
+**CRITICAL**: These directives guide autonomous agent behavior during ${phase} phase execution.
+
+`;
+
+  // ALWAYS directives - shown prominently
+  if (alwaysDirectives.length > 0) {
+    section += `### Core Directives (Always Apply)
+
+`;
+    alwaysDirectives.forEach((d, idx) => {
+      const blockingBadge = d.is_blocking ? ' **[BLOCKING]**' : '';
+      section += `**${idx + 1}. ${d.title}**${blockingBadge}
+${d.content}
+
+`;
+    });
+  }
+
+  // HANDOFF_START directives - shown at phase transitions
+  if (handoffDirectives.length > 0) {
+    section += `### Handoff Directives (Apply at Phase Start)
+
+`;
+    handoffDirectives.forEach((d, idx) => {
+      const blockingBadge = d.is_blocking ? ' **[BLOCKING]**' : '';
+      section += `**${idx + 1}. ${d.title}**${blockingBadge}
+${d.content}
+
+`;
+    });
+  }
+
+  // ON_FAILURE directives - conditional reminders
+  if (onFailureDirectives.length > 0) {
+    section += `### Conditional Directives (Apply When Issues Occur)
+
+**Trigger**: When encountering errors, blockers, or failures during execution.
+
+`;
+    onFailureDirectives.forEach((d, idx) => {
+      const blockingBadge = d.is_blocking ? ' **[BLOCKING]**' : '';
+      section += `**${idx + 1}. ${d.title}**${blockingBadge}
+${d.content}
+
+`;
+    });
+  }
+
+  section += `---
+
+*Directives from \`leo_autonomous_directives\` table (SD-LEO-CONTINUITY-001)*
+`;
+
+  return section;
+}
+
+/**
+ * Generate agent section for CLAUDE_CORE.md
+ */
+export function generateAgentSection(agents) {
+  let table = '| Agent | Code | Responsibilities | % Split |\n';
+  table += '|-------|------|------------------|----------|\n';
+
+  agents.forEach(agent => {
+    const responsibilities = agent.responsibilities.substring(0, 80) + (agent.responsibilities.length > 80 ? '...' : '');
+    const percentages = [];
+    if (agent.planning_percentage) percentages.push(`P:${agent.planning_percentage}`);
+    if (agent.implementation_percentage) percentages.push(`I:${agent.implementation_percentage}`);
+    if (agent.verification_percentage) percentages.push(`V:${agent.verification_percentage}`);
+    if (agent.approval_percentage) percentages.push(`A:${agent.approval_percentage}`);
+    const split = percentages.join(' ') + ` = ${agent.total_percentage}%`;
+
+    table += `| ${agent.name} | ${agent.agent_code} | ${responsibilities} | ${split} |\n`;
+  });
+
+  table += '\n**Legend**: P=Planning, I=Implementation, V=Verification, A=Approval\n';
+  table += '**Total**: EXEC (30%) + LEAD (35%) + PLAN (35%) = 100%';
+
+  return table;
+}
+
+/**
+ * Generate sub-agent section for CLAUDE_CORE.md
+ */
+export function generateSubAgentSection(subAgents) {
+  if (!subAgents || subAgents.length === 0) {
+    return '';
+  }
+
+  let section = `## Available Sub-Agents
+
+**Usage**: Invoke sub-agents using the Task tool with matching subagent_type.
+**IMPORTANT**: When user query contains trigger keywords, PROACTIVELY invoke the corresponding sub-agent.
+
+`;
+
+  // Group sub-agents by whether they have triggers or not
+  const withTriggers = subAgents.filter(sa => sa.triggers && sa.triggers.length > 0);
+  const withoutTriggers = subAgents.filter(sa => !sa.triggers || sa.triggers.length === 0);
+
+  if (withoutTriggers.length > 0) {
+    section += '### Sub-Agents Without Keyword Triggers\n\n';
+    withoutTriggers.forEach(sa => {
+      section += `- **${sa.name}** (\`${sa.code || 'N/A'}\`): ${sa.description?.substring(0, 80) || 'N/A'}\n`;
+    });
+    section += '\n';
+  }
+
+  section += '### Keyword-Triggered Sub-Agents\n\n';
+
+  withTriggers.forEach(sa => {
+    // Extract all trigger_phrases from triggers array
+    const triggers = sa.triggers?.map(t => t.trigger_phrase).filter(Boolean) || [];
+    const desc = sa.description?.substring(0, 100) || 'N/A';
+
+    section += `#### ${sa.name} (\`${sa.code || 'N/A'}\`)\n`;
+    section += `${desc}\n\n`;
+
+    if (triggers.length > 0) {
+      section += `**Trigger Keywords**: \`${triggers.join('\`, \`')}\`\n\n`;
+    }
+  });
+
+  section += `
+**Note**: Sub-agent results MUST be persisted to \`sub_agent_execution_results\` table.
+`;
+
+  return section;
+}
+
+/**
+ * Generate a compact trigger keyword reference for the router file
+ */
+export function generateTriggerQuickReference(subAgents) {
+  if (!subAgents || subAgents.length === 0) {
+    return '';
+  }
+
+  // Build keyword -> sub-agent mapping
+  const keywordMap = {};
+  subAgents.forEach(sa => {
+    if (!sa.triggers || sa.triggers.length === 0) return;
+    sa.triggers.forEach(t => {
+      if (t.trigger_phrase) {
+        const keyword = t.trigger_phrase.toLowerCase();
+        if (!keywordMap[keyword]) {
+          keywordMap[keyword] = { agent: sa.code, priority: t.priority || sa.priority || 50 };
+        }
+      }
+    });
+  });
+
+  // Group by sub-agent for compact display
+  const agentKeywords = {};
+  Object.entries(keywordMap).forEach(([keyword, info]) => {
+    if (!agentKeywords[info.agent]) {
+      agentKeywords[info.agent] = [];
+    }
+    agentKeywords[info.agent].push(keyword);
+  });
+
+  let section = `## Sub-Agent Trigger Keywords (Quick Reference)
+
+**CRITICAL**: When user query contains these keywords, PROACTIVELY invoke the corresponding sub-agent via Task tool.
+
+| Sub-Agent | Trigger Keywords |
+|-----------|------------------|
+`;
+
+  // Sort by agent code for consistency
+  Object.keys(agentKeywords).sort().forEach(agent => {
+    const keywords = agentKeywords[agent].slice(0, 10); // Limit to top 10 keywords per agent
+    const moreCount = agentKeywords[agent].length - 10;
+    let keywordStr = keywords.join(', ');
+    if (moreCount > 0) {
+      keywordStr += ` (+${moreCount} more)`;
+    }
+    section += `| \`${agent}\` | ${keywordStr} |\n`;
+  });
+
+  section += `
+*Full trigger list in CLAUDE_CORE.md. Use Task tool with \`subagent_type="<agent-code>"\`*
+`;
+
+  return section;
+}
+
+/**
+ * Generate handoff templates section
+ */
+export function generateHandoffTemplates(templates) {
+  if (!templates || templates.length === 0) return 'No templates in database';
+
+  // Helper to extract section names from template_structure JSONB
+  const extractSections = (templateStructure) => {
+    if (!templateStructure) return 'Not defined';
+    const sections = templateStructure.sections;
+    if (!sections) return 'Not defined';
+    if (Array.isArray(sections)) {
+      return sections.map(s => {
+        if (typeof s === 'string') return s;
+        if (s?.title) return s.title;
+        if (s?.name) return s.name;
+        return safeJson(s);
+      }).join(', ');
+    }
+    return safeJson(sections);
+  };
+
+  // Helper to format required_elements JSONB
+  const formatRequired = (requiredElements) => {
+    if (!requiredElements) return 'None specified';
+    if (Array.isArray(requiredElements)) {
+      return requiredElements.map(el => typeof el === 'string' ? el : safeJson(el)).join(', ');
+    }
+    return safeJson(requiredElements);
+  };
+
+  return templates.map(t => `
+#### ${t.from_agent || 'Unknown'} → ${t.to_agent || 'Unknown'} (${t.handoff_type || 'N/A'})
+- **Elements**: ${extractSections(t.template_structure)}
+- **Required**: ${formatRequired(t.required_elements)}
+`).join('\n');
+}
+
+/**
+ * Generate validation rules section
+ */
+export function generateValidationRules(rules) {
+  if (!rules || rules.length === 0) return 'No validation rules in database';
+
+  // Helper to safely stringify JSONB criteria
+  const formatCriteria = (criteria) => {
+    if (!criteria) return 'Not specified';
+    if (typeof criteria === 'string') return criteria;
+    try {
+      if (typeof criteria === 'object') {
+        const keys = Object.keys(criteria);
+        if (keys.length <= 3) {
+          return keys.map(k => `${k}: ${JSON.stringify(criteria[k])}`).join('; ');
+        }
+        return `${keys.length} criteria defined (${keys.slice(0, 3).join(', ')}...)`;
+      }
+      return JSON.stringify(criteria);
+    } catch {
+      return String(criteria);
+    }
+  };
+
+  return rules.map(r => `
+- **${r.rule_name || 'Unnamed Rule'}** (Gate ${r.gate || 'N/A'})
+  - Weight: ${r.weight ?? 'N/A'}
+  - Required: ${r.required ? 'Yes' : 'No'}
+  - Criteria: ${formatCriteria(r.criteria)}
+`).join('\n');
+}

--- a/scripts/sd-next/colors.js
+++ b/scripts/sd-next/colors.js
@@ -1,0 +1,22 @@
+/**
+ * ANSI color codes for terminal output
+ * Extracted from sd-next.js for reusability
+ */
+
+export const colors = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m',
+  red: '\x1b[31m',
+  white: '\x1b[37m',
+  bgGreen: '\x1b[42m',
+  bgYellow: '\x1b[43m',
+  bgBlue: '\x1b[44m',
+  bgMagenta: '\x1b[45m',
+  bgCyan: '\x1b[46m',
+};

--- a/scripts/sd-next/data-loaders.js
+++ b/scripts/sd-next/data-loaders.js
@@ -1,0 +1,261 @@
+/**
+ * Data loading functions for SD-next
+ * Handles all database queries and external data loading
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { execSync } from 'child_process';
+import dotenv from 'dotenv';
+import { checkUncommittedChanges, getAffectedRepos } from '../../lib/multi-repo/index.js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+export { supabase };
+
+/**
+ * Load active baseline and items
+ */
+export async function loadActiveBaseline() {
+  const { data: baseline, error } = await supabase
+    .from('sd_execution_baselines')
+    .select('*')
+    .eq('is_active', true)
+    .single();
+
+  if (error || !baseline) {
+    return { baseline: null, items: [], actuals: {} };
+  }
+
+  const { data: items } = await supabase
+    .from('sd_baseline_items')
+    .select('*')
+    .eq('baseline_id', baseline.id)
+    .order('sequence_rank');
+
+  const { data: actuals } = await supabase
+    .from('sd_execution_actuals')
+    .select('*')
+    .eq('baseline_id', baseline.id);
+
+  const actualsMap = {};
+  if (actuals) {
+    actuals.forEach(a => actualsMap[a.sd_id] = a);
+  }
+
+  return { baseline, items: items || [], actuals: actualsMap };
+}
+
+/**
+ * Count actionable baseline items
+ */
+export async function countActionableBaselineItems(baselineItems) {
+  if (!baselineItems || baselineItems.length === 0) return 0;
+
+  let actionableCount = 0;
+  for (const item of baselineItems) {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('status, is_active')
+      .eq('legacy_id', item.sd_id)
+      .single();
+
+    if (sd && sd.is_active && sd.status !== 'completed' && sd.status !== 'cancelled') {
+      actionableCount++;
+    }
+  }
+  return actionableCount;
+}
+
+/**
+ * Load recent git activity
+ */
+export async function loadRecentActivity() {
+  const recentActivity = [];
+
+  try {
+    const gitLog = execSync(
+      'git log --oneline --since="7 days ago" --format="%s"',
+      { encoding: 'utf8', cwd: process.cwd(), stdio: ['pipe', 'pipe', 'ignore'] }
+    );
+
+    const sdPattern = /SD-[A-Z0-9-]+/g;
+    const matches = gitLog.match(sdPattern) || [];
+    const sdCounts = {};
+
+    matches.forEach(sd => {
+      sdCounts[sd] = (sdCounts[sd] || 0) + 1;
+    });
+
+    Object.entries(sdCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .forEach(([sd, count]) => {
+        recentActivity.push({ sd_id: sd, commits: count });
+      });
+  } catch {
+    // Git not available
+  }
+
+  const { data: recentSDs } = await supabase
+    .from('strategic_directives_v2')
+    .select('legacy_id, title, updated_at')
+    .eq('is_active', true)
+    .in('status', ['draft', 'active', 'in_progress'])
+    .order('updated_at', { ascending: false })
+    .limit(5);
+
+  if (recentSDs) {
+    recentSDs.forEach(sd => {
+      if (!recentActivity.find(a => a.sd_id === sd.legacy_id)) {
+        recentActivity.push({
+          sd_id: sd.legacy_id,
+          commits: 0,
+          updated_at: sd.updated_at
+        });
+      }
+    });
+  }
+
+  return recentActivity;
+}
+
+/**
+ * Load blocking conflicts
+ */
+export async function loadConflicts() {
+  const { data: conflicts } = await supabase
+    .from('sd_conflict_matrix')
+    .select('*')
+    .is('resolved_at', null)
+    .eq('conflict_severity', 'blocking');
+
+  return conflicts || [];
+}
+
+/**
+ * Load multi-repo status (files older than minAgeDays)
+ */
+export function loadMultiRepoStatus(minAgeDays = 5) {
+  try {
+    return checkUncommittedChanges(true, { minAgeDays });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get affected repos for an SD
+ */
+export function getSDRepos(sd) {
+  try {
+    return getAffectedRepos({
+      title: sd.title || '',
+      description: sd.description || '',
+      sd_type: sd.sd_type || sd.metadata?.sd_type || 'feature'
+    });
+  } catch {
+    return ['ehg', 'EHG_Engineer'];
+  }
+}
+
+/**
+ * Load pending SD proposals
+ */
+export async function loadPendingProposals(limit = 5) {
+  try {
+    const { data: proposals, error } = await supabase
+      .from('sd_proposals')
+      .select('*')
+      .eq('status', 'pending')
+      .order('urgency_level', { ascending: true })
+      .order('confidence_score', { ascending: false })
+      .limit(limit);
+
+    if (error) return [];
+    return proposals || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Load SD hierarchy for parent-child tree display
+ */
+export async function loadSDHierarchy() {
+  const hierarchy = new Map();
+  const allSDs = new Map();
+
+  try {
+    const { data: sds } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, legacy_id, title, parent_sd_id, status, current_phase, progress_percentage, dependencies, is_working_on, metadata, priority')
+      .eq('is_active', true)
+      .order('created_at');
+
+    if (!sds) return { hierarchy, allSDs };
+
+    for (const sd of sds) {
+      const sdId = sd.legacy_id || sd.id;
+      allSDs.set(sdId, sd);
+      allSDs.set(sd.id, sd);
+
+      if (sd.parent_sd_id) {
+        if (!hierarchy.has(sd.parent_sd_id)) {
+          hierarchy.set(sd.parent_sd_id, []);
+        }
+        hierarchy.get(sd.parent_sd_id).push(sd);
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  return { hierarchy, allSDs };
+}
+
+/**
+ * Load OKR scorecard
+ */
+export async function loadOKRScorecard() {
+  let vision = null;
+  let scorecard = [];
+
+  try {
+    const { data: visionData } = await supabase
+      .from('strategic_vision')
+      .select('*')
+      .eq('is_active', true)
+      .single();
+
+    vision = visionData;
+
+    const { data: scorecardData, error } = await supabase
+      .from('v_okr_scorecard')
+      .select('*')
+      .order('sequence');
+
+    if (error) return { vision, scorecard: [] };
+    scorecard = scorecardData || [];
+
+    // Load key results for each objective
+    for (const obj of scorecard) {
+      const { data: krs } = await supabase
+        .from('key_results')
+        .select('code, title, current_value, target_value, unit, status, baseline_value, direction')
+        .eq('objective_id', obj.objective_id)
+        .eq('is_active', true)
+        .order('sequence');
+
+      obj.key_results = krs || [];
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  return { vision, scorecard };
+}

--- a/scripts/sd-next/dependency-utils.js
+++ b/scripts/sd-next/dependency-utils.js
@@ -1,0 +1,84 @@
+/**
+ * Dependency utilities for SD-next
+ * Handles parsing and checking of SD dependencies
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+/**
+ * Parse dependencies from various formats
+ * @param {string|Array|Object} dependencies - Raw dependencies
+ * @returns {Array<{sd_id: string, resolved: boolean}>}
+ */
+export function parseDependencies(dependencies) {
+  if (!dependencies) return [];
+
+  let deps = [];
+  if (typeof dependencies === 'string') {
+    try {
+      deps = JSON.parse(dependencies);
+    } catch {
+      return [];
+    }
+  } else if (Array.isArray(dependencies)) {
+    deps = dependencies;
+  }
+
+  // Only return entries that are actual SD references (SD-XXX format)
+  return deps
+    .map(dep => {
+      if (typeof dep === 'string') {
+        const match = dep.match(/^(SD-[A-Z0-9-]+)/);
+        if (match) {
+          return { sd_id: match[1], resolved: false };
+        }
+        return null;
+      }
+      if (dep.sd_id && dep.sd_id.match(/^SD-[A-Z0-9-]+/)) {
+        return { sd_id: dep.sd_id, resolved: false };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Check if all dependencies are resolved (async)
+ * @param {string|Array|Object} dependencies - Raw dependencies
+ * @returns {Promise<boolean>}
+ */
+export async function checkDependenciesResolved(dependencies) {
+  if (!dependencies) return true;
+
+  const deps = parseDependencies(dependencies);
+  if (deps.length === 0) return true;
+
+  for (const dep of deps) {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('status')
+      .eq('legacy_id', dep.sd_id)
+      .single();
+
+    if (!sd || sd.status !== 'completed') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Sync version for display (placeholder - actual check happens async)
+ */
+export function checkDependenciesResolvedSync(_dependencies) {
+  return true;
+}

--- a/scripts/sd-next/display.js
+++ b/scripts/sd-next/display.js
@@ -1,0 +1,422 @@
+/**
+ * Display functions for SD-next
+ * Handles all terminal output and formatting
+ */
+
+import { colors } from './colors.js';
+import { getPhaseAwareStatus, isActionableForLead } from './status-helpers.js';
+import { parseDependencies, checkDependenciesResolved } from './dependency-utils.js';
+import { supabase } from './data-loaders.js';
+import { getEstimatedDuration, formatEstimateShort } from '../lib/duration-estimator.js';
+import { checkDependencyStatus } from '../child-sd-preflight.js';
+
+/**
+ * Display active sessions
+ */
+export function displayActiveSessions(activeSessions, currentSession) {
+  if (activeSessions.length === 0) return;
+
+  const sessionsWithClaims = activeSessions.filter(s => s.sd_id);
+  const idleSessions = activeSessions.filter(s => !s.sd_id);
+
+  if (sessionsWithClaims.length > 0) {
+    console.log(`${colors.bold}ACTIVE SESSIONS (${sessionsWithClaims.length}):${colors.reset}\n`);
+
+    for (const s of sessionsWithClaims) {
+      const isCurrent = currentSession && s.session_id === currentSession.session_id;
+      const marker = isCurrent ? `${colors.green}→${colors.reset}` : ' ';
+      const shortId = s.session_id.substring(0, 16) + '...';
+      const ageMin = Math.round(s.claim_duration_minutes || 0);
+
+      console.log(`${marker} ${shortId} │ ${colors.bold}${s.sd_id}${colors.reset} (Track ${s.track}) │ ${ageMin}m active`);
+    }
+    console.log();
+  }
+
+  if (idleSessions.length > 0 && sessionsWithClaims.length === 0) {
+    console.log(`${colors.dim}(${idleSessions.length} idle session(s) detected)${colors.reset}\n`);
+  }
+}
+
+/**
+ * Display multi-repo warning
+ */
+export function displayMultiRepoWarning(multiRepoStatus) {
+  if (!multiRepoStatus || !multiRepoStatus.hasChanges) return;
+
+  const minAgeDays = multiRepoStatus.minAgeDays || 5;
+
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bgYellow}${colors.bold} MULTI-REPO WARNING ${colors.reset}`);
+  console.log(`${colors.dim}(Showing files ≥${minAgeDays} days old)${colors.reset}\n`);
+
+  for (const repo of multiRepoStatus.summary) {
+    const icon = repo.uncommittedCount > 0 ? '📝' : '📤';
+    console.log(`  ${icon} ${colors.bold}${repo.displayName}${colors.reset} (${repo.branch})`);
+
+    if (repo.uncommittedCount > 0) {
+      console.log(`     ${repo.uncommittedCount} uncommitted change(s)`);
+    }
+    if (repo.unpushedCount > 0) {
+      console.log(`     ${repo.unpushedCount} unpushed commit(s)`);
+    }
+  }
+
+  console.log(`\n  ${colors.yellow}⚠️  Commit changes before starting new SD work${colors.reset}`);
+  console.log(`  ${colors.dim}Run: node scripts/multi-repo-status.js for details${colors.reset}`);
+}
+
+/**
+ * Display OKR scorecard
+ */
+export function displayOKRScorecard(vision, scorecard) {
+  if (!scorecard || scorecard.length === 0) return;
+
+  if (vision) {
+    console.log(`${colors.dim}┌─ VISION: ${vision.code} ${'─'.repeat(Math.max(0, 52 - vision.code.length))}┐${colors.reset}`);
+    const stmt = vision.statement.substring(0, 63);
+    console.log(`${colors.dim}│${colors.reset} ${colors.white}"${stmt}"${colors.reset}`);
+    console.log(`${colors.dim}└${'─'.repeat(67)}┘${colors.reset}\n`);
+  }
+
+  console.log(`${colors.bold}┌─ OKR SCORECARD ${'─'.repeat(52)}┐${colors.reset}`);
+  console.log(`${colors.bold}│${colors.reset}`);
+
+  for (const obj of scorecard) {
+    const dots = obj.progress_dots || '[○○○○○]';
+    const pct = obj.avg_progress_pct ? `${Math.round(obj.avg_progress_pct)}%` : '0%';
+    const statusColor = obj.at_risk_krs > 0 ? colors.yellow : colors.green;
+
+    console.log(`${colors.bold}│${colors.reset} ${colors.bold}${obj.objective_code}${colors.reset}: ${obj.objective_title.substring(0, 35)}`);
+    console.log(`${colors.bold}│${colors.reset}   ${statusColor}${dots}${colors.reset} ${pct} avg | ${obj.total_krs} KRs`);
+
+    if (obj.key_results && obj.key_results.length > 0) {
+      for (const kr of obj.key_results) {
+        const krStatus = kr.status === 'achieved' ? `${colors.green}✓` :
+                        kr.status === 'on_track' ? `${colors.green}●` :
+                        kr.status === 'at_risk' ? `${colors.yellow}●` :
+                        kr.status === 'off_track' ? `${colors.red}●` : `${colors.dim}○`;
+
+        let progress = 0;
+        if (kr.target_value && kr.target_value !== 0) {
+          if (kr.direction === 'decrease') {
+            progress = ((kr.baseline_value - kr.current_value) / (kr.baseline_value - kr.target_value)) * 100;
+          } else {
+            progress = ((kr.current_value - (kr.baseline_value || 0)) / (kr.target_value - (kr.baseline_value || 0))) * 100;
+          }
+        }
+        progress = Math.min(100, Math.max(0, progress));
+
+        const barFilled = Math.round(progress / 10);
+        const barEmpty = 10 - barFilled;
+        const progressBar = '█'.repeat(barFilled) + '░'.repeat(barEmpty);
+
+        const current = kr.current_value ?? 0;
+        const target = kr.target_value ?? 0;
+        const unit = kr.unit || '';
+
+        console.log(`${colors.bold}│${colors.reset}     ${krStatus}${colors.reset} ${kr.code.substring(0, 20).padEnd(20)} ${progressBar} ${current}${unit}→${target}${unit}`);
+      }
+    }
+    console.log(`${colors.bold}│${colors.reset}`);
+  }
+
+  console.log(`${colors.bold}└${'─'.repeat(67)}┘${colors.reset}\n`);
+}
+
+/**
+ * Display pending proposals
+ */
+export function displayProposals(pendingProposals) {
+  if (pendingProposals.length === 0) return;
+
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}${colors.magenta}SUGGESTED (Proactive Proposals):${colors.reset}\n`);
+
+  for (const p of pendingProposals) {
+    const urgencyIcon = p.urgency_level === 'critical' ? `${colors.red}🔴` :
+                        p.urgency_level === 'medium' ? `${colors.yellow}🟡` : `${colors.green}🟢`;
+    const triggerLabel = {
+      'dependency_update': 'DEP',
+      'retrospective_pattern': 'RETRO',
+      'code_health': 'HEALTH'
+    }[p.trigger_type] || p.trigger_type.substring(0, 5).toUpperCase();
+    const confidence = (p.confidence_score * 100).toFixed(0);
+    const shortId = p.id.substring(0, 8);
+
+    console.log(`  ${urgencyIcon} [${triggerLabel}]${colors.reset} ${p.title.substring(0, 50)}...`);
+    console.log(`${colors.dim}    Confidence: ${confidence}% | ID: ${shortId} | approve: npm run proposal:approve ${shortId}${colors.reset}`);
+  }
+
+  console.log(`\n${colors.dim}  Dismiss: npm run proposal:dismiss <id> <reason>${colors.reset}`);
+  console.log(`${colors.dim}  Reasons: not_relevant, wrong_timing, duplicate, too_small, too_large, already_fixed${colors.reset}`);
+}
+
+/**
+ * Display track section
+ */
+export function displayTrackSection(trackKey, trackName, items, context = {}) {
+  if (items.length === 0) return;
+
+  const trackColors = {
+    A: colors.magenta,
+    B: colors.blue,
+    C: colors.cyan,
+    STANDALONE: colors.yellow,
+    UNASSIGNED: colors.dim
+  };
+
+  console.log(`\n${trackColors[trackKey]}${colors.bold}TRACK ${trackKey}: ${trackName}${colors.reset}`);
+
+  // Group items by parent for hierarchical display
+  const rootItems = [];
+  const childItems = new Map();
+
+  for (const item of items) {
+    if (item.parent_sd_id) {
+      if (!childItems.has(item.parent_sd_id)) {
+        childItems.set(item.parent_sd_id, []);
+      }
+      childItems.get(item.parent_sd_id).push(item);
+    } else {
+      rootItems.push(item);
+    }
+  }
+
+  // Add items whose parent is not in this track as roots
+  for (const item of items) {
+    if (item.parent_sd_id) {
+      const parentInTrack = items.find(i =>
+        (i.legacy_id || i.sd_id) === item.parent_sd_id || i.id === item.parent_sd_id
+      );
+      if (!parentInTrack && !rootItems.includes(item)) {
+        rootItems.push(item);
+      }
+    }
+  }
+
+  // Display hierarchically
+  for (const item of rootItems) {
+    displaySDItem(item, '', childItems, items, context);
+  }
+}
+
+/**
+ * Display a single SD item with its children
+ */
+export function displaySDItem(item, indent, childItems, allItems, context = {}) {
+  const { claimedSDs = new Map(), currentSession, activeSessions = [] } = context;
+  const sdId = item.legacy_id || item.sd_id;
+  const rankStr = item.sequence_rank ? `[${item.sequence_rank}]`.padEnd(5) : '     ';
+
+  const claimedBySession = claimedSDs.get(sdId);
+  const isClaimedByOther = claimedBySession &&
+    currentSession &&
+    claimedBySession !== currentSession.session_id;
+  const isClaimedByMe = claimedBySession &&
+    currentSession &&
+    claimedBySession === currentSession.session_id;
+
+  let statusIcon;
+  if (isClaimedByOther) {
+    statusIcon = `${colors.yellow}CLAIMED${colors.reset}`;
+  } else if (isClaimedByMe) {
+    statusIcon = `${colors.green}YOURS${colors.reset}`;
+  } else {
+    statusIcon = getPhaseAwareStatus(item);
+  }
+
+  const workingIcon = item.is_working_on ? `${colors.bgYellow} ACTIVE ${colors.reset} ` : '';
+  const claimedIcon = isClaimedByOther ? `${colors.bgBlue} CLAIMED ${colors.reset} ` : '';
+  const title = (item.title || '').substring(0, 40 - indent.length);
+
+  console.log(`${indent}${claimedIcon}${workingIcon}${rankStr} ${sdId} - ${title}... ${statusIcon}`);
+
+  if (isClaimedByOther) {
+    const claimingSession = activeSessions.find(s => s.session_id === claimedBySession);
+    const shortId = claimedBySession.substring(0, 12) + '...';
+    const ageMin = claimingSession ? Math.round(claimingSession.claim_duration_minutes || 0) : '?';
+    console.log(`${colors.dim}${indent}        └─ Claimed by session ${shortId} (${ageMin}m)${colors.reset}`);
+  }
+
+  if (!item.deps_resolved && item.dependencies && !isClaimedByOther) {
+    const deps = parseDependencies(item.dependencies);
+    const unresolvedDeps = deps.filter(d => !d.resolved);
+    if (unresolvedDeps.length > 0) {
+      console.log(`${colors.dim}${indent}        └─ Blocked by: ${unresolvedDeps.map(d => d.sd_id).join(', ')}${colors.reset}`);
+    }
+  }
+
+  if (item.childDepStatus && !item.childDepStatus.allComplete) {
+    console.log(`${colors.dim}${indent}        └─ Child deps: ${item.childDepStatus.summary}${colors.reset}`);
+  }
+
+  // Display children recursively
+  const children = childItems.get(sdId) || childItems.get(item.id) || [];
+  const childrenInTrack = children.filter(c => allItems.includes(c));
+
+  for (let i = 0; i < childrenInTrack.length; i++) {
+    const child = childrenInTrack[i];
+    const isLast = i === childrenInTrack.length - 1;
+    const childIndent = indent + (isLast ? '  └─ ' : '  ├─ ');
+    const nextIndent = indent + (isLast ? '     ' : '  │  ');
+
+    displaySDItemSimple(child, childIndent, nextIndent, childItems, allItems);
+  }
+}
+
+/**
+ * Display child SD item (simpler format)
+ */
+export function displaySDItemSimple(item, prefix, nextIndent, childItems, allItems) {
+  const sdId = item.legacy_id || item.sd_id;
+  const statusIcon = getPhaseAwareStatus(item);
+  const workingIcon = item.is_working_on ? `${colors.bgYellow}◆${colors.reset}` : '';
+  const title = (item.title || '').substring(0, 30);
+
+  console.log(`${prefix}${workingIcon}${sdId} - ${title}... ${statusIcon}`);
+
+  const children = childItems.get(sdId) || childItems.get(item.id) || [];
+  const childrenInTrack = children.filter(c => allItems.includes(c));
+
+  for (let i = 0; i < childrenInTrack.length; i++) {
+    const child = childrenInTrack[i];
+    const isLast = i === childrenInTrack.length - 1;
+    const childPrefix = nextIndent + (isLast ? '└─ ' : '├─ ');
+    const childNextIndent = nextIndent + (isLast ? '   ' : '│  ');
+
+    displaySDItemSimple(child, childPrefix, childNextIndent, childItems, allItems);
+  }
+}
+
+/**
+ * Display recommendations section
+ */
+export async function displayRecommendations(baselineItems, actuals, conflicts = [], context = {}) {
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}${colors.green}RECOMMENDED ACTIONS:${colors.reset}\n`);
+
+  // Check for "working on" SD first
+  const { data: workingOn } = await supabase
+    .from('strategic_directives_v2')
+    .select('legacy_id, title, progress_percentage')
+    .eq('is_active', true)
+    .eq('is_working_on', true)
+    .lt('progress_percentage', 100)
+    .single();
+
+  if (workingOn) {
+    console.log(`${colors.bgYellow}${colors.bold} CONTINUE ${colors.reset} ${workingOn.legacy_id}`);
+    console.log(`  ${workingOn.title}`);
+    console.log(`  ${colors.dim}Progress: ${workingOn.progress_percentage || 0}% | Marked as "Working On"${colors.reset}`);
+
+    try {
+      const { data: sdFull } = await supabase
+        .from('strategic_directives_v2')
+        .select('id, sd_type, category, priority')
+        .eq('legacy_id', workingOn.legacy_id)
+        .single();
+      if (sdFull) {
+        const estimate = await getEstimatedDuration(supabase, sdFull);
+        console.log(`  ${colors.dim}Est: ${formatEstimateShort(estimate)}${colors.reset}\n`);
+      } else {
+        console.log();
+      }
+    } catch {
+      console.log();
+    }
+  }
+
+  // Find ready and verification-needed SDs
+  const readySDs = [];
+  const needsVerificationSDs = [];
+
+  for (const item of baselineItems) {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('legacy_id, title, status, current_phase, progress_percentage, dependencies, is_active')
+      .eq('legacy_id', item.sd_id)
+      .single();
+
+    if (sd && sd.is_active && sd.status !== 'completed' && sd.status !== 'cancelled') {
+      const depsResolved = await checkDependenciesResolved(sd.dependencies);
+      const enrichedSD = { ...item, ...sd, deps_resolved: depsResolved };
+
+      if (sd.current_phase === 'EXEC_COMPLETE' || sd.status === 'review') {
+        needsVerificationSDs.push(enrichedSD);
+      } else if (depsResolved && isActionableForLead(enrichedSD)) {
+        readySDs.push(enrichedSD);
+      }
+    }
+  }
+
+  // Show verification needed first
+  if (needsVerificationSDs.length > 0) {
+    console.log(`${colors.bgMagenta}${colors.bold} NEEDS VERIFICATION ${colors.reset}`);
+    needsVerificationSDs.forEach(sd => {
+      console.log(`  ${sd.legacy_id} - ${sd.title.substring(0, 45)}...`);
+      console.log(`  ${colors.dim}Phase: ${sd.current_phase} | Status: ${sd.status} | Run: npm run sd:verify ${sd.legacy_id}${colors.reset}\n`);
+    });
+  }
+
+  if (readySDs.length > 0 && !workingOn) {
+    const top = readySDs[0];
+    console.log(`${colors.bgGreen}${colors.bold} START ${colors.reset} ${top.legacy_id}`);
+    console.log(`  ${top.title}`);
+    console.log(`  ${colors.dim}Track: ${top.track || 'N/A'} | Rank: ${top.sequence_rank} | All dependencies satisfied${colors.reset}`);
+
+    try {
+      const { data: sdFull } = await supabase
+        .from('strategic_directives_v2')
+        .select('id, sd_type, category, priority')
+        .eq('legacy_id', top.legacy_id)
+        .single();
+      if (sdFull) {
+        const estimate = await getEstimatedDuration(supabase, sdFull);
+        console.log(`  ${colors.dim}Est: ${formatEstimateShort(estimate)}${colors.reset}\n`);
+      } else {
+        console.log();
+      }
+    } catch {
+      console.log();
+    }
+  }
+
+  // Show parallel opportunities
+  const parallelReady = readySDs.filter(sd => sd.track !== readySDs[0]?.track).slice(0, 2);
+  if (parallelReady.length > 0) {
+    console.log(`${colors.cyan}PARALLEL OPPORTUNITIES:${colors.reset}`);
+    parallelReady.forEach(sd => {
+      console.log(`  Track ${sd.track}: ${sd.legacy_id} - ${sd.title.substring(0, 40)}...`);
+    });
+  }
+
+  // Show conflicts
+  if (conflicts.length > 0) {
+    console.log(`\n${colors.red}${colors.bold}CONFLICT WARNINGS:${colors.reset}`);
+    conflicts.forEach(c => {
+      console.log(`  ${colors.red}!${colors.reset} ${c.sd_id_a} + ${c.sd_id_b}: ${c.conflict_type}`);
+    });
+  }
+
+  console.log(`\n${colors.bold}TO BEGIN WORK:${colors.reset}`);
+  console.log(`  ${colors.cyan}npm run sd:start <SD-ID>${colors.reset}  ${colors.dim}(recommended - claims SD and shows info)${colors.reset}`);
+  console.log(`  ${colors.dim}OR: node scripts/handoff.js execute LEAD-TO-PLAN <SD-ID>${colors.reset}`);
+}
+
+/**
+ * Display session context
+ */
+export function displaySessionContext(recentActivity) {
+  if (recentActivity.length === 0) return;
+
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}RECENT SESSION ACTIVITY:${colors.reset}\n`);
+
+  recentActivity.slice(0, 3).forEach(activity => {
+    const commitInfo = activity.commits > 0 ? `${activity.commits} commits` : 'recently updated';
+    console.log(`  ${activity.sd_id} - ${commitInfo}`);
+  });
+
+  console.log(`\n${colors.dim}Consider continuing recent work for context preservation.${colors.reset}`);
+}

--- a/scripts/sd-next/index.js
+++ b/scripts/sd-next/index.js
@@ -1,0 +1,33 @@
+/**
+ * SD-Next Module Index
+ * Re-exports all SD-Next functionality for easy importing
+ */
+
+export { colors } from './colors.js';
+export { getPhaseAwareStatus, isActionableForLead } from './status-helpers.js';
+export { parseDependencies, checkDependenciesResolved, checkDependenciesResolvedSync } from './dependency-utils.js';
+
+export {
+  supabase,
+  loadActiveBaseline,
+  countActionableBaselineItems,
+  loadRecentActivity,
+  loadConflicts,
+  loadMultiRepoStatus,
+  getSDRepos,
+  loadPendingProposals,
+  loadSDHierarchy,
+  loadOKRScorecard
+} from './data-loaders.js';
+
+export {
+  displayActiveSessions,
+  displayMultiRepoWarning,
+  displayOKRScorecard,
+  displayProposals,
+  displayTrackSection,
+  displaySDItem,
+  displaySDItemSimple,
+  displayRecommendations,
+  displaySessionContext
+} from './display.js';

--- a/scripts/sd-next/status-helpers.js
+++ b/scripts/sd-next/status-helpers.js
@@ -1,0 +1,83 @@
+/**
+ * Status helper functions for SD-next
+ * Handles phase-aware status display and actionability checks
+ */
+
+import { colors } from './colors.js';
+
+/**
+ * Get phase-aware status icon for an SD
+ * Control Gap Fix: SD status must reflect actual phase, not just dependency resolution
+ *
+ * @param {Object} item - SD item with current_phase, status, deps_resolved, progress_percentage
+ * @returns {string} Colored status string for display
+ */
+export function getPhaseAwareStatus(item) {
+  const phase = item.current_phase || '';
+  const status = item.status || '';
+  const depsResolved = item.deps_resolved;
+  const progress = item.progress_percentage || 0;
+
+  // EXEC_COMPLETE with review status = needs verification
+  if (phase === 'EXEC_COMPLETE' && status === 'review') {
+    return `${colors.magenta}VERIFY${colors.reset}`;
+  }
+
+  // Any COMPLETE phase that isn't fully completed = needs close-out
+  if (phase.includes('COMPLETE') && status !== 'completed') {
+    return `${colors.magenta}CLOSE-OUT${colors.reset}`;
+  }
+
+  // PLAN phases = in planning, not ready for LEAD work
+  if (phase === 'PLAN_PRD' || phase === 'PLAN') {
+    return `${colors.cyan}PLANNING${colors.reset}`;
+  }
+
+  // Draft status = needs LEAD review first
+  if (status === 'draft') {
+    return `${colors.yellow}DRAFT${colors.reset}`;
+  }
+
+  // In active EXEC phase
+  if (phase === 'EXEC' || phase === 'EXEC_ACTIVE') {
+    if (progress > 0 && progress < 100) {
+      return `${colors.blue}EXEC ${progress}%${colors.reset}`;
+    }
+    return `${colors.blue}IN_EXEC${colors.reset}`;
+  }
+
+  // Standard dependency-based logic for LEAD phase or new SDs
+  if (depsResolved) {
+    return `${colors.green}READY${colors.reset}`;
+  } else if (progress > 0) {
+    return `${colors.yellow}${progress}%${colors.reset}`;
+  } else {
+    return `${colors.red}BLOCKED${colors.reset}`;
+  }
+}
+
+/**
+ * Check if an SD is actionable for LEAD work (starting new work)
+ * Returns false for SDs in verification, planning, or other non-LEAD phases
+ */
+export function isActionableForLead(item) {
+  const phase = item.current_phase || '';
+  const status = item.status || '';
+
+  // Not actionable if needs verification
+  if (phase === 'EXEC_COMPLETE' || phase.includes('COMPLETE')) {
+    return false;
+  }
+
+  // Not actionable if in active planning or execution
+  if (phase === 'PLAN_PRD' || phase === 'PLAN' || phase === 'EXEC' || phase === 'EXEC_ACTIVE') {
+    return false;
+  }
+
+  // Not actionable if in review status
+  if (status === 'review') {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- Extract reusable modules from `sd-next.js` (1,239 LOC) into `scripts/sd-next/` directory
- Extract reusable modules from `generate-claude-md-from-db.js` (1,236 LOC) into `scripts/claude-gen/` directory
- All modules under 500 LOC target (except section-generators.js at 624 LOC)
- Both module sets verified to load successfully

## Modules Created

### sd-next/ (905 LOC total)
| Module | LOC | Purpose |
|--------|-----|---------|
| colors.js | 22 | ANSI color codes |
| status-helpers.js | 83 | Phase-aware status display |
| dependency-utils.js | 84 | SD dependency parsing |
| data-loaders.js | 261 | Database queries |
| display.js | 422 | Terminal display functions |
| index.js | 33 | Re-exports |

### claude-gen/ (916 LOC total)
| Module | LOC | Purpose |
|--------|-----|---------|
| data-fetchers.js | 253 | Database queries |
| section-generators.js | 624 | Markdown generators |
| index.js | 39 | Re-exports |

## Test plan
- [x] Verify sd-next modules load: `node -e "import('./scripts/sd-next/index.js')"`
- [x] Verify claude-gen modules load: `node -e "import('./scripts/claude-gen/index.js')"`
- [x] Smoke tests pass
- [x] ESLint checks pass

## Related
- Parent SD: SD-LEO-REFACTOR-LARGE-FILES-001 (orchestrator)
- Child SD: SD-LEO-REFACTOR-QUEUE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)