### PR TITLE
refactor(scripts): extract PRD modules (SD-LEO-REFACTOR-PRD-001)

### DIFF
--- a/scripts/modules/prd/context-builder.js
+++ b/scripts/modules/prd/context-builder.js
@@ -1,0 +1,301 @@
+/**
+ * PRD Context Builder
+ *
+ * Functions for building comprehensive context for PRD generation.
+ * Extracted from add-prd-to-database.js for maintainability.
+ *
+ * Part of SD-LEO-REFACTOR-PRD-001
+ */
+
+/**
+ * Format array fields for context
+ */
+export function formatArrayField(arr, itemName) {
+  if (!arr || !Array.isArray(arr) || arr.length === 0) {
+    return `- No ${itemName}s defined`;
+  }
+  return arr.map((item, i) => {
+    if (typeof item === 'string') return `${i + 1}. ${item}`;
+    return `${i + 1}. ${item.text || item.description || item.name || JSON.stringify(item)}`;
+  }).join('\n');
+}
+
+/**
+ * Format risks for context
+ */
+export function formatRisks(risks) {
+  if (!risks || !Array.isArray(risks) || risks.length === 0) {
+    return '- No risks identified';
+  }
+  return risks.map((risk, i) => {
+    if (typeof risk === 'string') return `${i + 1}. ${risk}`;
+    const parts = [`${i + 1}. ${risk.risk || risk.description || risk.name || 'Unknown risk'}`];
+    if (risk.mitigation) parts.push(`   Mitigation: ${risk.mitigation}`);
+    if (risk.probability) parts.push(`   Probability: ${risk.probability}`);
+    if (risk.impact) parts.push(`   Impact: ${risk.impact}`);
+    return parts.join('\n');
+  }).join('\n');
+}
+
+/**
+ * Format metadata for context - extracts important fields
+ */
+export function formatMetadata(metadata) {
+  const sections = [];
+
+  // Skip deeply nested or very long fields
+  const skipKeys = ['vision_spec_references', 'governance', 'vision_discovery'];
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (skipKeys.includes(key)) continue;
+    if (value === null || value === undefined) continue;
+
+    if (typeof value === 'string') {
+      sections.push(`**${key}**: ${value}`);
+    } else if (Array.isArray(value)) {
+      sections.push(`**${key}**: ${value.slice(0, 5).map(v => typeof v === 'string' ? v : JSON.stringify(v)).join(', ')}${value.length > 5 ? '...' : ''}`);
+    } else if (typeof value === 'object') {
+      // Shallow representation for objects
+      const objStr = JSON.stringify(value, null, 2).substring(0, 500);
+      sections.push(`**${key}**:\n\`\`\`json\n${objStr}\n\`\`\``);
+    }
+  }
+
+  return sections.join('\n\n') || 'No additional metadata';
+}
+
+/**
+ * Format vision spec references
+ */
+export function formatVisionSpecs(specs) {
+  if (!specs) return 'No vision specs referenced';
+
+  if (Array.isArray(specs)) {
+    return specs.map((spec, i) => {
+      if (typeof spec === 'string') return `${i + 1}. ${spec}`;
+      return `${i + 1}. ${spec.name || spec.path || JSON.stringify(spec)}`;
+    }).join('\n');
+  }
+
+  if (typeof specs === 'object') {
+    return Object.entries(specs).map(([key, value]) => `- **${key}**: ${value}`).join('\n');
+  }
+
+  return String(specs);
+}
+
+/**
+ * Format governance requirements
+ */
+export function formatGovernance(governance) {
+  if (!governance) return 'No governance requirements';
+
+  const parts = [];
+
+  if (governance.strangler_pattern !== undefined) {
+    parts.push(`**Strangler Pattern**: ${governance.strangler_pattern ? 'Enabled' : 'Disabled'}`);
+  }
+  if (governance.workflow_policies) {
+    parts.push(`**Workflow Policies**: ${JSON.stringify(governance.workflow_policies)}`);
+  }
+  if (governance.creation_mode) {
+    parts.push(`**Creation Mode**: ${governance.creation_mode}`);
+  }
+
+  return parts.join('\n') || JSON.stringify(governance, null, 2);
+}
+
+/**
+ * Format strategic objectives for context
+ */
+export function formatObjectives(objectives) {
+  if (!objectives) return '- No objectives defined';
+  if (Array.isArray(objectives)) {
+    return objectives.map((obj, i) => {
+      if (typeof obj === 'string') return `${i + 1}. ${obj}`;
+      return `${i + 1}. ${obj.objective || obj.description || JSON.stringify(obj)}`;
+    }).join('\n');
+  }
+  return JSON.stringify(objectives);
+}
+
+/**
+ * Build comprehensive context string for PRD generation
+ * Includes ALL available SD metadata for thorough PRD generation
+ */
+export function buildPRDGenerationContext(sd, context = {}) {
+  const sections = [];
+
+  // 1. Strategic Directive Context - COMPREHENSIVE
+  sections.push(`## STRATEGIC DIRECTIVE - COMPLETE CONTEXT
+
+**ID**: ${sd.id || sd.legacy_id}
+**Legacy ID**: ${sd.legacy_id || 'N/A'}
+**Title**: ${sd.title || 'Untitled'}
+**Type**: ${sd.sd_type || sd.category || 'feature'}
+**Category**: ${sd.category || 'Not specified'}
+**Priority**: ${sd.priority || 'Not specified'}
+**Status**: ${sd.status || 'draft'}
+
+### Description
+${sd.description || 'No description provided'}
+
+### Scope
+${sd.scope || 'No scope defined'}
+
+### Rationale
+${sd.rationale || 'No rationale provided'}
+
+### Strategic Objectives
+${formatObjectives(sd.strategic_objectives)}
+
+### Success Criteria
+${formatArrayField(sd.success_criteria, 'success criterion')}
+
+### Key Changes
+${formatArrayField(sd.key_changes, 'key change')}
+
+### Success Metrics
+${formatArrayField(sd.success_metrics, 'success metric')}
+
+### Dependencies
+${formatArrayField(sd.dependencies, 'dependency')}
+
+### Risks
+${formatRisks(sd.risks)}
+
+### Target Application
+${sd.target_application || 'EHG_Engineer'}`);
+
+  // 2. SD Metadata (contains vision specs, governance, etc.)
+  if (sd.metadata && Object.keys(sd.metadata).length > 0) {
+    sections.push(`## SD METADATA (Extended Context)
+
+${formatMetadata(sd.metadata)}`);
+  }
+
+  // 3. Design Analysis (if available) - Extended
+  if (context.designAnalysis) {
+    sections.push(`## DESIGN ANALYSIS (from DESIGN sub-agent)
+
+This analysis defines the UI/UX requirements and user workflows:
+
+${typeof context.designAnalysis === 'string'
+  ? context.designAnalysis.substring(0, 5000)
+  : JSON.stringify(context.designAnalysis, null, 2).substring(0, 5000)}`);
+  }
+
+  // 4. Database Analysis (if available) - Extended
+  if (context.databaseAnalysis) {
+    sections.push(`## DATABASE ANALYSIS (from DATABASE sub-agent)
+
+This analysis defines schema requirements and data architecture:
+
+${typeof context.databaseAnalysis === 'string'
+  ? context.databaseAnalysis.substring(0, 5000)
+  : JSON.stringify(context.databaseAnalysis, null, 2).substring(0, 5000)}`);
+  }
+
+  // 4.1 Security Analysis (if available)
+  if (context.securityAnalysis) {
+    sections.push(`## SECURITY ANALYSIS (from SECURITY sub-agent)
+
+This analysis defines authentication, authorization, and security requirements:
+
+${typeof context.securityAnalysis === 'string'
+  ? context.securityAnalysis.substring(0, 4000)
+  : JSON.stringify(context.securityAnalysis, null, 2).substring(0, 4000)}`);
+  }
+
+  // 4.2 Risk Analysis (if available)
+  if (context.riskAnalysis) {
+    sections.push(`## RISK ANALYSIS (from RISK sub-agent)
+
+This analysis identifies implementation risks and mitigation strategies:
+
+${typeof context.riskAnalysis === 'string'
+  ? context.riskAnalysis.substring(0, 4000)
+  : JSON.stringify(context.riskAnalysis, null, 2).substring(0, 4000)}`);
+  }
+
+  // 5. Persona Context (if available) - Extended
+  if (context.personas && context.personas.length > 0) {
+    sections.push(`## STAKEHOLDER PERSONAS
+
+These personas represent the users who will interact with this feature:
+
+${context.personas.map(p => {
+  const details = [];
+  details.push(`### ${p.name}`);
+  if (p.role) details.push(`**Role**: ${p.role}`);
+  if (p.description) details.push(`**Description**: ${p.description}`);
+  if (p.goals) details.push(`**Goals**: ${Array.isArray(p.goals) ? p.goals.join(', ') : p.goals}`);
+  if (p.pain_points) details.push(`**Pain Points**: ${Array.isArray(p.pain_points) ? p.pain_points.join(', ') : p.pain_points}`);
+  return details.join('\n');
+}).join('\n\n')}`);
+  }
+
+  // 6. Vision Spec References (if in metadata)
+  if (sd.metadata?.vision_spec_references) {
+    sections.push(`## VISION SPECIFICATION REFERENCES
+
+${formatVisionSpecs(sd.metadata.vision_spec_references)}`);
+  }
+
+  // 7. Governance Requirements (if in metadata)
+  if (sd.metadata?.governance) {
+    sections.push(`## GOVERNANCE REQUIREMENTS
+
+${formatGovernance(sd.metadata.governance)}`);
+  }
+
+  // 8. Existing User Stories (for consistency if PRD being regenerated)
+  if (context.existingStories && context.existingStories.length > 0) {
+    sections.push(`## EXISTING USER STORIES (Ensure PRD Consistency)
+
+The following user stories already exist for this SD. The PRD MUST be consistent with these stories:
+
+${context.existingStories.map(story => {
+  const lines = [`### ${story.story_key}: ${story.title}`];
+  if (story.user_role) lines.push(`**As a** ${story.user_role}`);
+  if (story.user_want) lines.push(`**I want** ${story.user_want}`);
+  if (story.user_benefit) lines.push(`**So that** ${story.user_benefit}`);
+  if (story.acceptance_criteria && story.acceptance_criteria.length > 0) {
+    lines.push('\n**Acceptance Criteria**:');
+    story.acceptance_criteria.forEach(ac => {
+      if (typeof ac === 'string') {
+        lines.push(`- ${ac}`);
+      } else if (ac.criterion) {
+        lines.push(`- ${ac.criterion}`);
+      }
+    });
+  }
+  return lines.join('\n');
+}).join('\n\n')}`);
+  }
+
+  // 9. Generation Instructions - Comprehensive
+  sections.push(`## TASK - GENERATE COMPREHENSIVE PRD
+
+Using ALL the context above, generate a complete PRD that:
+
+1. **Is Implementation-Ready**: Every requirement must be specific enough for a developer to implement immediately without asking clarifying questions
+2. **Aligns with SD Objectives**: Each requirement must trace back to a strategic objective or success criterion
+3. **Incorporates Sub-Agent Analysis**: Use the design and database analysis to inform technical requirements and architecture
+4. **Addresses All Personas**: Ensure requirements cover the needs of identified stakeholders
+5. **Follows Vision Specs**: If vision spec references exist, ensure PRD aligns with those specifications
+6. **Identifies Real Risks**: Document genuine technical and business risks specific to THIS implementation
+7. **Defines Testable Criteria**: Every acceptance criterion must be verifiable through automated or manual testing
+8. **Consistent with User Stories**: If existing user stories are provided, the PRD functional requirements MUST support and align with those stories. Do not contradict user story acceptance criteria.
+
+### Minimum Content Requirements:
+- At least 5 functional requirements with acceptance criteria
+- At least 3 technical requirements
+- At least 5 test scenarios covering happy path, edge cases, and error conditions
+- At least 3 identified risks with mitigation strategies
+- Complete system architecture with components and data flow
+
+Return the PRD as a valid JSON object following the schema in the system prompt.`);
+
+  return sections.join('\n\n');
+}

--- a/scripts/modules/prd/index.js
+++ b/scripts/modules/prd/index.js
@@ -1,0 +1,34 @@
+/**
+ * PRD Module - Entry Point
+ *
+ * Re-exports all PRD-related modules for convenient importing.
+ * Part of SD-LEO-REFACTOR-PRD-001 refactoring.
+ */
+
+// Context building functions
+export {
+  formatArrayField,
+  formatRisks,
+  formatMetadata,
+  formatVisionSpecs,
+  formatGovernance,
+  formatObjectives,
+  buildPRDGenerationContext
+} from './context-builder.js';
+
+// LLM generation functions
+export {
+  LLM_PRD_CONFIG,
+  PRD_QUALITY_RUBRIC_CRITERIA,
+  generatePRDContentWithLLM,
+  formatPRDContent
+} from './llm-generator.js';
+
+// Sub-agent analysis phases
+export {
+  runDesignAnalysis,
+  runDatabaseAnalysis,
+  runSecurityAnalysis,
+  runRiskAnalysis,
+  needsSecurityAnalysis
+} from './subagent-phases.js';

--- a/scripts/modules/prd/llm-generator.js
+++ b/scripts/modules/prd/llm-generator.js
@@ -1,0 +1,365 @@
+/**
+ * PRD LLM Generator
+ *
+ * LLM-based PRD content generation using GPT.
+ * Extracted from add-prd-to-database.js for maintainability.
+ *
+ * Part of SD-LEO-REFACTOR-PRD-001
+ */
+
+import OpenAI from 'openai';
+import { getOpenAIModel } from '../../../lib/config/model-config.js';
+import { buildPRDGenerationContext } from './context-builder.js';
+
+/**
+ * LLM Configuration for PRD Generation
+ */
+export const LLM_PRD_CONFIG = {
+  model: getOpenAIModel('generation'),
+  temperature: 0.6,   // Slightly lower for more structured PRD content
+  maxTokens: 32000,   // Extended for comprehensive PRD generation
+  enabled: process.env.LLM_PRD_GENERATION !== 'false'  // Enabled by default
+};
+
+/**
+ * PRD Quality Rubric Criteria for LLM context injection
+ */
+export const PRD_QUALITY_RUBRIC_CRITERIA = `
+## QUALITY CRITERIA (You will be judged on these dimensions)
+
+### 1. Requirements Depth & Specificity (40% weight)
+- 0-3: Mostly placeholders ("To be defined", "TBD", generic statements) - WILL FAIL
+- 4-6: Some specific requirements but many vague or incomplete
+- 7-8: Most requirements are specific, actionable, and complete
+- 9-10: All requirements are detailed, specific, testable, with clear acceptance criteria
+
+**Target**: Score 7-8 minimum. Each requirement must be implementation-ready.
+
+### 2. Architecture Explanation Quality (30% weight)
+- 0-3: No architecture details or vague high-level statements
+- 4-6: Basic architecture mentioned but missing key details
+- 7-8: Clear architecture with components, data flow, and integration points
+- 9-10: Comprehensive: components + data flow + integration + trade-offs + scalability
+
+**Target**: Score 7-8 minimum. Must enable implementation without guessing.
+
+### 3. Test Scenario Sophistication (20% weight)
+- 0-3: No test scenarios or only trivial happy path - WILL FAIL
+- 4-6: Happy path covered but missing edge cases and error conditions
+- 7-8: Happy path + common edge cases + error handling scenarios
+- 9-10: Comprehensive: happy path + edge cases + errors + performance + security
+
+**Target**: Score 7-8 minimum. Must demonstrate failure mode understanding.
+
+### 4. Risk Analysis Completeness (10% weight)
+- 0-3: No technical risks or listed without mitigation
+- 4-6: Basic risks with generic mitigation ("test thoroughly")
+- 7-8: Specific technical risks with concrete mitigation strategies
+- 9-10: Comprehensive: risks + mitigation + rollback plan + monitoring
+
+**Target**: Score 7-8 minimum. Must be proactive and specific to this SD.
+`;
+
+/**
+ * Build the system prompt for PRD generation
+ */
+function buildSystemPrompt(sdType) {
+  return `You are a Technical Product Manager creating a Product Requirements Document (PRD) for a software engineering team.
+
+Your PRD must be IMPLEMENTATION-READY. The development team will use this document to build the feature.
+
+${PRD_QUALITY_RUBRIC_CRITERIA}
+
+## OUTPUT REQUIREMENTS
+
+Return a JSON object with exactly these fields:
+{
+  "executive_summary": "string - 200-500 chars describing WHAT, WHY, and IMPACT",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "requirement": "Specific, actionable requirement statement",
+      "description": "Detailed description of what this achieves",
+      "priority": "CRITICAL|HIGH|MEDIUM|LOW",
+      "acceptance_criteria": ["AC-1", "AC-2", "AC-3"]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "requirement": "Technical constraint or requirement",
+      "rationale": "Why this is needed"
+    }
+  ],
+  "system_architecture": {
+    "overview": "High-level architecture description",
+    "components": [
+      {
+        "name": "Component Name",
+        "responsibility": "What this component does",
+        "technology": "Tech stack used"
+      }
+    ],
+    "data_flow": "Description of how data moves through the system",
+    "integration_points": ["Integration point 1", "Integration point 2"]
+  },
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Test scenario description",
+      "test_type": "unit|integration|e2e|performance|security",
+      "given": "Preconditions",
+      "when": "Action taken",
+      "then": "Expected outcome"
+    }
+  ],
+  "acceptance_criteria": [
+    "Specific, measurable criterion 1",
+    "Specific, measurable criterion 2"
+  ],
+  "risks": [
+    {
+      "risk": "Specific risk description",
+      "probability": "HIGH|MEDIUM|LOW",
+      "impact": "HIGH|MEDIUM|LOW",
+      "mitigation": "Concrete mitigation strategy",
+      "rollback_plan": "How to rollback if this fails"
+    }
+  ],
+  "implementation_approach": {
+    "phases": [
+      {
+        "phase": "Phase 1",
+        "description": "What happens in this phase",
+        "deliverables": ["Deliverable 1", "Deliverable 2"]
+      }
+    ],
+    "technical_decisions": ["Key decision 1 with rationale", "Key decision 2"]
+  }
+}
+
+## CRITICAL RULES
+
+1. **NO PLACEHOLDERS**: Never use "To be defined", "TBD", "Will be determined", or similar
+2. **SPECIFIC**: Every requirement must be specific enough to implement immediately
+3. **TESTABLE**: Every acceptance criterion must be verifiable
+4. **SD-ALIGNED**: All content must directly relate to the SD objectives
+5. **TYPE-AWARE**: Tailor depth based on SD type (${sdType})
+
+SD Type-Specific Guidance:
+${sdType === 'database' ? '- Focus heavily on schema design, migration safety, RLS policies, data integrity' : ''}
+${sdType === 'infrastructure' ? '- Focus on deployment, CI/CD, monitoring, rollback procedures' : ''}
+${sdType === 'security' ? '- Focus on threat modeling, auth flows, permission boundaries, audit logging' : ''}
+${sdType === 'documentation' ? '- Focus on content completeness, accuracy verification, maintenance plan' : ''}
+${sdType === 'feature' || !sdType ? '- Balance functional requirements, UX, and technical implementation' : ''}`;
+}
+
+/**
+ * Generate PRD content using LLM
+ *
+ * @param {Object} sd - Strategic Directive data
+ * @param {Object} context - Additional context (design analysis, database analysis, personas)
+ * @returns {Promise<Object|null>} Generated PRD content or null if failed
+ */
+export async function generatePRDContentWithLLM(sd, context = {}) {
+  if (!LLM_PRD_CONFIG.enabled) {
+    console.log('   ℹ️  LLM PRD generation disabled via LLM_PRD_GENERATION=false');
+    return null;
+  }
+
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (!openaiKey) {
+    console.warn('   ⚠️  OPENAI_API_KEY not set, falling back to template PRD');
+    return null;
+  }
+
+  const openai = new OpenAI({ apiKey: openaiKey });
+  const sdType = sd.sd_type || sd.category || 'feature';
+
+  console.log('   🤖 Generating PRD content with GPT...');
+  console.log(`   📋 SD Type: ${sdType}`);
+
+  try {
+    const systemPrompt = buildSystemPrompt(sdType);
+    const userPrompt = buildPRDGenerationContext(sd, context);
+
+    const response = await openai.chat.completions.create({
+      model: LLM_PRD_CONFIG.model,
+      temperature: LLM_PRD_CONFIG.temperature,
+      max_completion_tokens: LLM_PRD_CONFIG.maxTokens,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt }
+      ]
+    });
+
+    const content = response.choices[0]?.message?.content;
+    const finishReason = response.choices[0]?.finish_reason;
+
+    if (!content) {
+      console.warn('   ⚠️  LLM returned empty content');
+      return null;
+    }
+
+    if (finishReason === 'length') {
+      console.warn('   ⚠️  LLM response truncated (token limit), attempting parse anyway');
+    }
+
+    // Parse JSON response
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      console.warn('   ⚠️  Could not extract JSON from LLM response');
+      console.log('   Response preview:', content.substring(0, 500));
+      return null;
+    }
+
+    const prdContent = JSON.parse(jsonMatch[0]);
+
+    console.log('   ✅ PRD content generated successfully');
+    console.log(`   📊 Generated: ${prdContent.functional_requirements?.length || 0} functional requirements`);
+    console.log(`   📊 Generated: ${prdContent.test_scenarios?.length || 0} test scenarios`);
+    console.log(`   📊 Generated: ${prdContent.risks?.length || 0} risks identified`);
+
+    return prdContent;
+
+  } catch (error) {
+    console.error('   ❌ LLM PRD generation failed:', error.message);
+    if (error.response?.data) {
+      console.error('   API Error:', JSON.stringify(error.response.data, null, 2));
+    }
+    return null;
+  }
+}
+
+/**
+ * Format LLM-generated PRD content into markdown
+ */
+export function formatPRDContent(sdId, sdData, llmContent) {
+  const sections = [];
+
+  sections.push(`# Product Requirements Document
+
+## Strategic Directive
+${sdId}
+
+## Title
+${sdData.title || 'Untitled'}
+
+## Status
+Planning
+
+## Executive Summary
+${llmContent.executive_summary || 'See functional requirements below.'}`);
+
+  // Functional Requirements
+  if (llmContent.functional_requirements && llmContent.functional_requirements.length > 0) {
+    sections.push(`## Functional Requirements
+
+${llmContent.functional_requirements.map(req => {
+  const lines = [`### ${req.id}: ${req.requirement}`];
+  if (req.description) lines.push(`\n${req.description}`);
+  if (req.priority) lines.push(`\n**Priority**: ${req.priority}`);
+  if (req.acceptance_criteria && req.acceptance_criteria.length > 0) {
+    lines.push('\n**Acceptance Criteria**:');
+    req.acceptance_criteria.forEach(ac => lines.push(`- ${ac}`));
+  }
+  return lines.join('');
+}).join('\n\n')}`);
+  }
+
+  // Technical Requirements
+  if (llmContent.technical_requirements && llmContent.technical_requirements.length > 0) {
+    sections.push(`## Technical Requirements
+
+${llmContent.technical_requirements.map(req => {
+  const lines = [`### ${req.id}: ${req.requirement}`];
+  if (req.rationale) lines.push(`\n**Rationale**: ${req.rationale}`);
+  return lines.join('');
+}).join('\n\n')}`);
+  }
+
+  // System Architecture
+  if (llmContent.system_architecture) {
+    const arch = llmContent.system_architecture;
+    const archLines = ['## System Architecture'];
+    if (arch.overview) archLines.push(`\n### Overview\n${arch.overview}`);
+    if (arch.components && arch.components.length > 0) {
+      archLines.push('\n### Components');
+      arch.components.forEach(comp => {
+        archLines.push(`\n#### ${comp.name}`);
+        if (comp.responsibility) archLines.push(`- **Responsibility**: ${comp.responsibility}`);
+        if (comp.technology) archLines.push(`- **Technology**: ${comp.technology}`);
+      });
+    }
+    if (arch.data_flow) archLines.push(`\n### Data Flow\n${arch.data_flow}`);
+    if (arch.integration_points && arch.integration_points.length > 0) {
+      archLines.push('\n### Integration Points');
+      arch.integration_points.forEach(point => archLines.push(`- ${point}`));
+    }
+    sections.push(archLines.join(''));
+  }
+
+  // Implementation Approach
+  if (llmContent.implementation_approach) {
+    const impl = llmContent.implementation_approach;
+    const implLines = ['## Implementation Approach'];
+    if (impl.phases && impl.phases.length > 0) {
+      implLines.push('\n### Phases');
+      impl.phases.forEach(phase => {
+        implLines.push(`\n#### ${phase.phase}`);
+        if (phase.description) implLines.push(phase.description);
+        if (phase.deliverables && phase.deliverables.length > 0) {
+          implLines.push('\n**Deliverables**:');
+          phase.deliverables.forEach(d => implLines.push(`- ${d}`));
+        }
+      });
+    }
+    if (impl.technical_decisions && impl.technical_decisions.length > 0) {
+      implLines.push('\n### Key Technical Decisions');
+      impl.technical_decisions.forEach(dec => implLines.push(`- ${dec}`));
+    }
+    sections.push(implLines.join(''));
+  }
+
+  // Test Scenarios
+  if (llmContent.test_scenarios && llmContent.test_scenarios.length > 0) {
+    sections.push(`## Test Scenarios
+
+${llmContent.test_scenarios.map(ts => {
+  const lines = [`### ${ts.id}: ${ts.scenario}`];
+  if (ts.test_type) lines.push(`\n**Type**: ${ts.test_type}`);
+  if (ts.given) lines.push(`\n**Given**: ${ts.given}`);
+  if (ts.when) lines.push(`\n**When**: ${ts.when}`);
+  if (ts.then) lines.push(`\n**Then**: ${ts.then}`);
+  return lines.join('');
+}).join('\n\n')}`);
+  }
+
+  // Acceptance Criteria
+  if (llmContent.acceptance_criteria && llmContent.acceptance_criteria.length > 0) {
+    sections.push(`## Acceptance Criteria
+
+${llmContent.acceptance_criteria.map((ac, i) => `${i + 1}. ${ac}`).join('\n')}`);
+  }
+
+  // Risks
+  if (llmContent.risks && llmContent.risks.length > 0) {
+    sections.push(`## Risks & Mitigations
+
+${llmContent.risks.map(risk => {
+  const lines = [`### ${risk.risk}`];
+  if (risk.probability) lines.push(`\n**Probability**: ${risk.probability}`);
+  if (risk.impact) lines.push(`\n**Impact**: ${risk.impact}`);
+  if (risk.mitigation) lines.push(`\n**Mitigation**: ${risk.mitigation}`);
+  if (risk.rollback_plan) lines.push(`\n**Rollback Plan**: ${risk.rollback_plan}`);
+  return lines.join('');
+}).join('\n\n')}`);
+  }
+
+  sections.push(`
+---
+*Generated by LLM PRD Content Generation*
+*Date: ${new Date().toISOString()}*`);
+
+  return sections.join('\n\n');
+}

--- a/scripts/modules/prd/subagent-phases.js
+++ b/scripts/modules/prd/subagent-phases.js
@@ -1,0 +1,447 @@
+/**
+ * PRD Sub-Agent Analysis Phases
+ *
+ * Functions for invoking sub-agents during PRD creation.
+ * Extracted from add-prd-to-database.js for maintainability.
+ *
+ * Part of SD-LEO-REFACTOR-PRD-001
+ */
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  formatObjectives,
+  formatArrayField,
+  formatRisks,
+  formatMetadata
+} from './context-builder.js';
+
+/**
+ * Get temp directory (cross-platform)
+ */
+function getTempDir() {
+  return os.tmpdir();
+}
+
+/**
+ * Run DESIGN sub-agent analysis
+ *
+ * @param {string} sdId - Strategic Directive ID
+ * @param {Object} sdData - SD data from database
+ * @param {string} personaContextBlock - Persona context string
+ * @returns {Promise<string|null>} Analysis output or null
+ */
+export async function runDesignAnalysis(sdId, sdData, personaContextBlock = '') {
+  console.log('🔍 Invoking DESIGN sub-agent to analyze UI/UX workflows...\n');
+
+  const designPrompt = `Analyze UI/UX design and user workflows for Strategic Directive: ${sdId}
+
+## STRATEGIC DIRECTIVE - COMPLETE CONTEXT
+
+**ID**: ${sdData.id || sdId}
+**Legacy ID**: ${sdData.legacy_id || 'N/A'}
+**Title**: ${sdData.title || 'N/A'}
+**Type**: ${sdData.sd_type || sdData.category || 'feature'}
+**Category**: ${sdData.category || 'Not specified'}
+**Priority**: ${sdData.priority || 'Not specified'}
+
+**Scope**: ${sdData.scope || 'N/A'}
+**Description**: ${sdData.description || 'N/A'}
+**Rationale**: ${sdData.rationale || 'N/A'}
+
+**Strategic Objectives**:
+${formatObjectives(sdData.strategic_objectives)}
+
+**Success Criteria**:
+${formatArrayField(sdData.success_criteria, 'criterion')}
+
+**Key Changes**:
+${formatArrayField(sdData.key_changes, 'change')}
+
+**Success Metrics**:
+${formatArrayField(sdData.success_metrics, 'metric')}
+
+**Dependencies**:
+${formatArrayField(sdData.dependencies, 'dependency')}
+
+**Known Risks**:
+${formatRisks(sdData.risks)}
+
+**Target Application**: ${sdData.target_application || 'EHG_Engineer'}
+
+${sdData.metadata ? `## SD METADATA (Extended Context)\n${formatMetadata(sdData.metadata)}` : ''}
+${personaContextBlock ? `\n${personaContextBlock}` : ''}
+**Task**:
+1. Identify user workflows and interaction patterns
+2. Determine UI components and layouts needed
+3. Analyze user journey and navigation flows
+4. Identify data that users will view/create/edit
+5. Determine what user actions trigger database changes
+
+**Output Format**:
+{
+  "user_workflows": [
+    {
+      "workflow_name": "Workflow 1",
+      "steps": ["step1", "step2"],
+      "user_actions": ["create", "edit", "delete"],
+      "data_displayed": ["field1", "field2"],
+      "data_modified": ["field1", "field2"]
+    }
+  ],
+  "ui_components_needed": ["component1", "component2"],
+  "user_journey": "Description of user flow",
+  "data_requirements": {
+    "fields_to_display": ["field1", "field2"],
+    "fields_to_edit": ["field1"],
+    "relationships": ["parent_entity -> child_entity"]
+  }
+}
+
+Please analyze user workflows and design requirements.`;
+
+  try {
+    const designPromptFile = path.join(getTempDir(), `design-agent-prompt-${Date.now()}.txt`);
+    fs.writeFileSync(designPromptFile, designPrompt);
+
+    console.log('📝 Prompt written to:', designPromptFile);
+    console.log('\n🤖 Executing DESIGN sub-agent...\n');
+
+    const designOutput = execSync(
+      `node lib/sub-agent-executor.js DESIGN --context-file "${designPromptFile}"`,
+      {
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 120000,
+        cwd: process.cwd()
+      }
+    );
+
+    console.log('✅ Design analysis complete!\n');
+    console.log('─────────────────────────────────────────────────');
+    console.log(designOutput);
+    console.log('─────────────────────────────────────────────────\n');
+
+    fs.unlinkSync(designPromptFile);
+    return designOutput;
+
+  } catch (error) {
+    console.warn('⚠️  Design analysis failed:', error.message);
+    console.log('   Continuing with manual design review...\n');
+    return null;
+  }
+}
+
+/**
+ * Run DATABASE sub-agent analysis
+ *
+ * @param {string} sdId - Strategic Directive ID
+ * @param {Object} sdData - SD data from database
+ * @param {string} designAnalysis - Design analysis output (optional)
+ * @param {string} personaContextBlock - Persona context string
+ * @returns {Promise<string|null>} Analysis output or null
+ */
+export async function runDatabaseAnalysis(sdId, sdData, designAnalysis = null, personaContextBlock = '') {
+  console.log('🔍 Invoking DATABASE sub-agent to analyze schema and recommend changes...\n');
+
+  const dbAgentPrompt = `Analyze database schema for Strategic Directive: ${sdId}
+
+## STRATEGIC DIRECTIVE - COMPLETE CONTEXT
+
+**ID**: ${sdData.id || sdId}
+**Legacy ID**: ${sdData.legacy_id || 'N/A'}
+**Title**: ${sdData.title || 'N/A'}
+**Type**: ${sdData.sd_type || sdData.category || 'feature'}
+**Category**: ${sdData.category || 'Not specified'}
+**Priority**: ${sdData.priority || 'Not specified'}
+
+**Scope**: ${sdData.scope || 'N/A'}
+**Description**: ${sdData.description || 'N/A'}
+**Rationale**: ${sdData.rationale || 'N/A'}
+
+**Strategic Objectives**:
+${formatObjectives(sdData.strategic_objectives)}
+
+**Success Criteria**:
+${formatArrayField(sdData.success_criteria, 'criterion')}
+
+**Key Changes**:
+${formatArrayField(sdData.key_changes, 'change')}
+
+**Success Metrics**:
+${formatArrayField(sdData.success_metrics, 'metric')}
+
+**Dependencies**:
+${formatArrayField(sdData.dependencies, 'dependency')}
+
+**Known Risks**:
+${formatRisks(sdData.risks)}
+
+**Target Application**: ${sdData.target_application || 'EHG_Engineer'}
+
+${sdData.metadata ? `## SD METADATA (Extended Context)\n${formatMetadata(sdData.metadata)}` : ''}
+${personaContextBlock ? `\n${personaContextBlock}` : ''}
+${designAnalysis ? `
+**DESIGN ANALYSIS CONTEXT** (from DESIGN sub-agent):
+${designAnalysis}
+
+Use this design analysis to understand:
+- What data users will view/create/edit (drives table structure)
+- User workflows and actions (drives CRUD requirements)
+- UI component data needs (drives column selection)
+- Data relationships (drives foreign keys and joins)
+` : ''}
+
+**Task**:
+1. Review the EHG_Engineer database schema documentation at docs/reference/schema/engineer/database-schema-overview.md
+2. ${designAnalysis ? 'Based on design analysis, ' : ''}Identify which tables will be affected by this SD
+3. Recommend specific database changes (new tables, new columns, modified columns, new RLS policies)
+4. ${designAnalysis ? 'Ensure schema supports all user workflows identified in design analysis' : 'Provide technical_approach recommendations for database integration'}
+5. List any schema dependencies or constraints to be aware of
+
+**Output Format**:
+{
+  "affected_tables": ["table1", "table2"],
+  "new_tables": [
+    {
+      "name": "table_name",
+      "purpose": "description",
+      "key_columns": ["col1", "col2"]
+    }
+  ],
+  "table_modifications": [
+    {
+      "table": "existing_table",
+      "changes": ["add column x", "modify column y"]
+    }
+  ],
+  "rls_policies_needed": ["policy description 1", "policy description 2"],
+  "technical_approach": "Detailed technical approach for database integration",
+  "dependencies": ["dependency 1", "dependency 2"],
+  "migration_complexity": "LOW|MEDIUM|HIGH",
+  "estimated_migration_lines": 50
+}
+
+Please analyze and provide structured recommendations.`;
+
+  try {
+    const promptFile = path.join(getTempDir(), `db-agent-prompt-${Date.now()}.txt`);
+    fs.writeFileSync(promptFile, dbAgentPrompt);
+
+    console.log('📝 Prompt written to:', promptFile);
+    console.log('\n🤖 Executing DATABASE sub-agent...\n');
+
+    const dbAgentOutput = execSync(
+      `node lib/sub-agent-executor.js DATABASE --context-file "${promptFile}"`,
+      {
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 120000,
+        cwd: process.cwd()
+      }
+    );
+
+    console.log('✅ Database sub-agent analysis complete!\n');
+    console.log('─────────────────────────────────────────────────');
+    console.log(dbAgentOutput);
+    console.log('─────────────────────────────────────────────────\n');
+
+    fs.unlinkSync(promptFile);
+    return dbAgentOutput;
+
+  } catch (error) {
+    console.warn('⚠️  Database schema analysis failed:', error.message);
+    console.log('   Continuing with manual schema review...\n');
+    return null;
+  }
+}
+
+/**
+ * Run SECURITY sub-agent analysis
+ *
+ * @param {string} sdId - Strategic Directive ID
+ * @param {Object} sdData - SD data from database
+ * @returns {Promise<string|null>} Analysis output or null
+ */
+export async function runSecurityAnalysis(sdId, sdData) {
+  const sdType = sdData.sd_type || sdData.category || 'feature';
+
+  console.log('🔍 Invoking SECURITY sub-agent to analyze security requirements...\n');
+
+  const securityPrompt = `Analyze security requirements for Strategic Directive: ${sdId}
+
+## STRATEGIC DIRECTIVE - SECURITY ANALYSIS CONTEXT
+
+**ID**: ${sdData.id || sdId}
+**Title**: ${sdData.title || 'N/A'}
+**Type**: ${sdType}
+**Scope**: ${sdData.scope || 'N/A'}
+**Description**: ${sdData.description || 'N/A'}
+
+${sdData.metadata ? `## SD METADATA\n${formatMetadata(sdData.metadata)}` : ''}
+
+**Task**:
+1. Identify authentication requirements (login flows, session management)
+2. Analyze authorization needs (roles, permissions, RLS policies)
+3. Identify data access boundaries and sensitivity levels
+4. Recommend security test scenarios
+5. Identify potential security risks and mitigations
+
+**Output Format**:
+{
+  "auth_requirements": ["requirement1", "requirement2"],
+  "authorization_model": {
+    "roles": ["role1", "role2"],
+    "permissions": ["permission1", "permission2"],
+    "rls_policies_needed": ["policy1", "policy2"]
+  },
+  "data_sensitivity": {
+    "sensitive_fields": ["field1", "field2"],
+    "protection_mechanisms": ["encryption", "masking"]
+  },
+  "security_test_scenarios": ["scenario1", "scenario2"],
+  "security_risks": [
+    {
+      "risk": "risk description",
+      "mitigation": "mitigation strategy"
+    }
+  ]
+}`;
+
+  try {
+    const securityPromptFile = path.join(getTempDir(), `security-agent-prompt-${Date.now()}.txt`);
+    fs.writeFileSync(securityPromptFile, securityPrompt);
+
+    console.log('📝 Prompt written to:', securityPromptFile);
+    console.log('\n🤖 Executing SECURITY sub-agent...\n');
+
+    const securityOutput = execSync(
+      `node lib/sub-agent-executor.js SECURITY --context-file "${securityPromptFile}"`,
+      {
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 120000,
+        cwd: process.cwd()
+      }
+    );
+
+    console.log('✅ Security analysis complete!\n');
+    console.log('─────────────────────────────────────────────────');
+    console.log(securityOutput);
+    console.log('─────────────────────────────────────────────────\n');
+
+    fs.unlinkSync(securityPromptFile);
+    return securityOutput;
+
+  } catch (error) {
+    console.warn('⚠️  Security analysis failed:', error.message);
+    console.log('   Continuing without security analysis...\n');
+    return null;
+  }
+}
+
+/**
+ * Run RISK sub-agent analysis
+ *
+ * @param {string} sdId - Strategic Directive ID
+ * @param {Object} sdData - SD data from database
+ * @returns {Promise<string|null>} Analysis output or null
+ */
+export async function runRiskAnalysis(sdId, sdData) {
+  const sdType = sdData.sd_type || sdData.category || 'feature';
+
+  console.log('🔍 Invoking RISK sub-agent to assess implementation risks...\n');
+
+  const riskPrompt = `Analyze implementation risks for Strategic Directive: ${sdId}
+
+## STRATEGIC DIRECTIVE - RISK ANALYSIS CONTEXT
+
+**ID**: ${sdData.id || sdId}
+**Title**: ${sdData.title || 'N/A'}
+**Type**: ${sdType}
+**Scope**: ${sdData.scope || 'N/A'}
+**Description**: ${sdData.description || 'N/A'}
+**Rationale**: ${sdData.rationale || 'N/A'}
+
+**Strategic Objectives**:
+${formatObjectives(sdData.strategic_objectives)}
+
+**Dependencies**:
+${formatArrayField(sdData.dependencies, 'dependency')}
+
+**Known Risks from SD**:
+${formatRisks(sdData.risks)}
+
+${sdData.metadata ? `## SD METADATA\n${formatMetadata(sdData.metadata)}` : ''}
+
+**Task**:
+1. Identify technical implementation risks specific to this SD
+2. Assess probability and impact of each risk
+3. Propose concrete mitigation strategies
+4. Define rollback plans for critical changes
+5. Suggest monitoring strategies to detect issues early
+
+**Output Format**:
+{
+  "technical_risks": [
+    {
+      "risk": "specific risk description",
+      "probability": "HIGH|MEDIUM|LOW",
+      "impact": "HIGH|MEDIUM|LOW",
+      "mitigation": "concrete mitigation strategy",
+      "rollback_plan": "rollback approach if this fails",
+      "monitoring": "how to detect early warning signs"
+    }
+  ],
+  "dependency_risks": ["risk from dependency 1"],
+  "timeline_risks": ["potential delays"],
+  "overall_risk_level": "HIGH|MEDIUM|LOW"
+}`;
+
+  try {
+    const riskPromptFile = path.join(getTempDir(), `risk-agent-prompt-${Date.now()}.txt`);
+    fs.writeFileSync(riskPromptFile, riskPrompt);
+
+    console.log('📝 Prompt written to:', riskPromptFile);
+    console.log('\n🤖 Executing RISK sub-agent...\n');
+
+    const riskOutput = execSync(
+      `node lib/sub-agent-executor.js RISK --context-file "${riskPromptFile}"`,
+      {
+        encoding: 'utf-8',
+        maxBuffer: 10 * 1024 * 1024,
+        timeout: 120000,
+        cwd: process.cwd()
+      }
+    );
+
+    console.log('✅ Risk analysis complete!\n');
+    console.log('─────────────────────────────────────────────────');
+    console.log(riskOutput);
+    console.log('─────────────────────────────────────────────────\n');
+
+    fs.unlinkSync(riskPromptFile);
+    return riskOutput;
+
+  } catch (error) {
+    console.warn('⚠️  Risk analysis failed:', error.message);
+    console.log('   Continuing without risk analysis...\n');
+    return null;
+  }
+}
+
+/**
+ * Check if SD needs security analysis
+ */
+export function needsSecurityAnalysis(sdData) {
+  const sdType = sdData.sd_type || sdData.category || 'feature';
+  return (
+    sdType === 'security' ||
+    sdData.scope?.toLowerCase().includes('auth') ||
+    sdData.scope?.toLowerCase().includes('security') ||
+    sdData.description?.toLowerCase().includes('permission') ||
+    sdData.description?.toLowerCase().includes('rls')
+  );
+}


### PR DESCRIPTION
## Summary
- Extract reusable modules from `add-prd-to-database.js` (1,770 LOC) into `scripts/modules/prd/` directory
- All modules under 500 LOC target

## Modules Created

### scripts/modules/prd/ (1,147 LOC total)
| Module | LOC | Purpose |
|--------|-----|---------|
| context-builder.js | 301 | Context building functions (format*, build*) |
| llm-generator.js | 365 | LLM PRD content generation |
| subagent-phases.js | 447 | Sub-agent analysis phases (design, db, security, risk) |
| index.js | 34 | Re-exports |

## Test plan
- [x] Verify modules load: `node -e "import('./scripts/modules/prd/index.js')"`
- [x] Smoke tests pass
- [x] ESLint checks pass

## Related
- Parent SD: SD-LEO-REFACTOR-LARGE-FILES-001 (orchestrator)
- Child SD: SD-LEO-REFACTOR-PRD-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)