### PR TITLE
refactor(sd-next): extract modules from sd-next.js

### DIFF
--- a/scripts/modules/sd-next/colors.js
+++ b/scripts/modules/sd-next/colors.js
@@ -1,0 +1,33 @@
+/**
+ * ANSI Terminal Colors for SD-Next Display
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+export const colors = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m',
+  red: '\x1b[31m',
+  white: '\x1b[37m',
+  bgGreen: '\x1b[42m',
+  bgYellow: '\x1b[43m',
+  bgBlue: '\x1b[44m',
+  bgMagenta: '\x1b[45m',
+  bgCyan: '\x1b[46m',
+};
+
+/**
+ * Track-specific color mapping
+ */
+export const trackColors = {
+  A: colors.magenta,
+  B: colors.blue,
+  C: colors.cyan,
+  STANDALONE: colors.yellow,
+  UNASSIGNED: colors.dim
+};

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -1,0 +1,264 @@
+/**
+ * Data Loaders for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+import { execSync } from 'child_process';
+
+/**
+ * Load active baseline and its items
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<{baseline: Object|null, items: Array, actuals: Object}>}
+ */
+export async function loadActiveBaseline(supabase) {
+  const { data: baseline, error } = await supabase
+    .from('sd_execution_baselines')
+    .select('*')
+    .eq('is_active', true)
+    .single();
+
+  if (error || !baseline) {
+    return { baseline: null, items: [], actuals: {} };
+  }
+
+  // Load baseline items
+  const { data: items } = await supabase
+    .from('sd_baseline_items')
+    .select('*')
+    .eq('baseline_id', baseline.id)
+    .order('sequence_rank');
+
+  // Load actuals
+  const { data: actuals } = await supabase
+    .from('sd_execution_actuals')
+    .select('*')
+    .eq('baseline_id', baseline.id);
+
+  const actualsMap = {};
+  if (actuals) {
+    actuals.forEach(a => actualsMap[a.sd_id] = a);
+  }
+
+  return {
+    baseline,
+    items: items || [],
+    actuals: actualsMap
+  };
+}
+
+/**
+ * Load recent git activity for SD references
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} cwd - Current working directory
+ * @returns {Promise<Array>} Array of {sd_id, commits, updated_at}
+ */
+export async function loadRecentActivity(supabase, cwd) {
+  const recentActivity = [];
+
+  // Method 1: Check git commits for SD references (last 7 days)
+  try {
+    const gitLog = execSync(
+      'git log --oneline --since="7 days ago" --format="%s"',
+      { encoding: 'utf8', cwd, stdio: ['pipe', 'pipe', 'ignore'] }
+    );
+
+    const sdPattern = /SD-[A-Z0-9-]+/g;
+    const matches = gitLog.match(sdPattern) || [];
+    const sdCounts = {};
+
+    matches.forEach(sd => {
+      sdCounts[sd] = (sdCounts[sd] || 0) + 1;
+    });
+
+    // Sort by frequency
+    Object.entries(sdCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .forEach(([sd, count]) => {
+        recentActivity.push({ sd_id: sd, commits: count });
+      });
+
+  } catch {
+    // Git not available or error - continue with database fallback
+  }
+
+  // Method 2: Check updated_at on SDs (fallback/supplement)
+  const { data: recentSDs } = await supabase
+    .from('strategic_directives_v2')
+    .select('legacy_id, title, updated_at')
+    .eq('is_active', true)
+    .in('status', ['draft', 'active', 'in_progress'])
+    .order('updated_at', { ascending: false })
+    .limit(5);
+
+  if (recentSDs) {
+    recentSDs.forEach(sd => {
+      if (!recentActivity.find(a => a.sd_id === sd.legacy_id)) {
+        recentActivity.push({
+          sd_id: sd.legacy_id,
+          commits: 0,
+          updated_at: sd.updated_at
+        });
+      }
+    });
+  }
+
+  return recentActivity;
+}
+
+/**
+ * Load blocking conflicts
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<Array>} Array of conflict objects
+ */
+export async function loadConflicts(supabase) {
+  const { data: conflicts } = await supabase
+    .from('sd_conflict_matrix')
+    .select('*')
+    .is('resolved_at', null)
+    .eq('conflict_severity', 'blocking');
+
+  return conflicts || [];
+}
+
+/**
+ * Load pending SD proposals (LEO Protocol v4.4)
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<Array>} Array of proposal objects
+ */
+export async function loadPendingProposals(supabase) {
+  try {
+    const { data: proposals, error } = await supabase
+      .from('sd_proposals')
+      .select('*')
+      .eq('status', 'pending')
+      .order('urgency_level', { ascending: true }) // critical first
+      .order('confidence_score', { ascending: false })
+      .limit(5);
+
+    if (error) {
+      // Table may not exist yet - non-fatal
+      return [];
+    }
+
+    return proposals || [];
+  } catch {
+    // Non-fatal - proposals are optional
+    return [];
+  }
+}
+
+/**
+ * Load SD hierarchy for parent-child tree display
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<{allSDs: Map, sdHierarchy: Map}>}
+ */
+export async function loadSDHierarchy(supabase) {
+  const allSDs = new Map();
+  const sdHierarchy = new Map();
+
+  try {
+    const { data: sds } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, legacy_id, title, parent_sd_id, status, current_phase, progress_percentage, dependencies, is_working_on, metadata, priority')
+      .eq('is_active', true)
+      .order('created_at');
+
+    if (!sds) return { allSDs, sdHierarchy };
+
+    // Build lookup map and hierarchy
+    for (const sd of sds) {
+      const sdId = sd.legacy_id || sd.id;
+      allSDs.set(sdId, sd);
+      allSDs.set(sd.id, sd); // Also map by UUID
+
+      if (sd.parent_sd_id) {
+        if (!sdHierarchy.has(sd.parent_sd_id)) {
+          sdHierarchy.set(sd.parent_sd_id, []);
+        }
+        sdHierarchy.get(sd.parent_sd_id).push(sd);
+      }
+    }
+  } catch {
+    // Non-fatal - continue without hierarchy
+  }
+
+  return { allSDs, sdHierarchy };
+}
+
+/**
+ * Load OKR scorecard and vision
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<{vision: Object|null, scorecard: Array}>}
+ */
+export async function loadOKRScorecard(supabase) {
+  try {
+    // Load active vision
+    const { data: vision } = await supabase
+      .from('strategic_vision')
+      .select('*')
+      .eq('is_active', true)
+      .single();
+
+    // Load OKR scorecard
+    const { data: scorecard, error } = await supabase
+      .from('v_okr_scorecard')
+      .select('*')
+      .order('sequence');
+
+    if (error) {
+      // View may not exist yet - non-fatal
+      return { vision, scorecard: [] };
+    }
+
+    const okrScorecard = scorecard || [];
+
+    // Load key results with details for each objective
+    for (const obj of okrScorecard) {
+      const { data: krs } = await supabase
+        .from('key_results')
+        .select('code, title, current_value, target_value, unit, status, baseline_value, direction')
+        .eq('objective_id', obj.objective_id)
+        .eq('is_active', true)
+        .order('sequence');
+
+      obj.key_results = krs || [];
+    }
+
+    return { vision, scorecard: okrScorecard };
+  } catch {
+    // Non-fatal - OKRs are optional
+    return { vision: null, scorecard: [] };
+  }
+}
+
+/**
+ * Count how many baseline items have non-completed SDs
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Array} baselineItems - Baseline items to check
+ * @returns {Promise<number>} Count of actionable items
+ */
+export async function countActionableBaselineItems(supabase, baselineItems) {
+  if (!baselineItems || !baselineItems.length) return 0;
+
+  let actionableCount = 0;
+  for (const item of baselineItems) {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('status, is_active')
+      .eq('legacy_id', item.sd_id)
+      .single();
+
+    if (sd && sd.is_active && sd.status !== 'completed' && sd.status !== 'cancelled') {
+      actionableCount++;
+    }
+  }
+  return actionableCount;
+}

--- a/scripts/modules/sd-next/dependency-resolver.js
+++ b/scripts/modules/sd-next/dependency-resolver.js
@@ -1,0 +1,107 @@
+/**
+ * Dependency Resolution for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+/**
+ * Parse dependencies from various formats
+ *
+ * @param {string|Array} dependencies - Dependencies in string or array format
+ * @returns {Array} Array of {sd_id, resolved} objects
+ */
+export function parseDependencies(dependencies) {
+  if (!dependencies) return [];
+
+  let deps = [];
+  if (typeof dependencies === 'string') {
+    try {
+      deps = JSON.parse(dependencies);
+    } catch {
+      return [];
+    }
+  } else if (Array.isArray(dependencies)) {
+    deps = dependencies;
+  }
+
+  // Only return entries that are actual SD references (SD-XXX format)
+  // Ignore text descriptions of prerequisites
+  return deps
+    .map(dep => {
+      if (typeof dep === 'string') {
+        // Parse "SD-XXX (description)" format
+        const match = dep.match(/^(SD-[A-Z0-9-]+)/);
+        if (match) {
+          return { sd_id: match[1], resolved: false };
+        }
+        // Not an SD reference - skip it
+        return null;
+      }
+      // Object format with sd_id field
+      if (dep.sd_id && dep.sd_id.match(/^SD-[A-Z0-9-]+/)) {
+        return { sd_id: dep.sd_id, resolved: false };
+      }
+      return null;
+    })
+    .filter(Boolean); // Remove nulls
+}
+
+/**
+ * Check if all dependencies are resolved
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string|Array} dependencies - Dependencies to check
+ * @returns {Promise<boolean>} True if all dependencies are resolved
+ */
+export async function checkDependenciesResolved(supabase, dependencies) {
+  if (!dependencies) return true;
+
+  const deps = parseDependencies(dependencies);
+  if (deps.length === 0) return true;
+
+  for (const dep of deps) {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('status')
+      .eq('legacy_id', dep.sd_id)
+      .single();
+
+    if (!sd || sd.status !== 'completed') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Get unresolved dependencies for an SD
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string|Array} dependencies - Dependencies to check
+ * @returns {Promise<Array>} Array of unresolved dependency objects
+ */
+export async function getUnresolvedDependencies(supabase, dependencies) {
+  if (!dependencies) return [];
+
+  const deps = parseDependencies(dependencies);
+  if (deps.length === 0) return [];
+
+  const unresolvedDeps = [];
+  for (const dep of deps) {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('status, title')
+      .eq('legacy_id', dep.sd_id)
+      .single();
+
+    if (!sd || sd.status !== 'completed') {
+      unresolvedDeps.push({
+        sd_id: dep.sd_id,
+        status: sd?.status || 'not_found',
+        title: sd?.title || 'Unknown'
+      });
+    }
+  }
+
+  return unresolvedDeps;
+}

--- a/scripts/modules/sd-next/display/fallback-queue.js
+++ b/scripts/modules/sd-next/display/fallback-queue.js
@@ -1,0 +1,139 @@
+/**
+ * Fallback Queue Display for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+import { colors } from '../colors.js';
+import { checkDependenciesResolved } from '../dependency-resolver.js';
+import { displayTrackSection } from './tracks.js';
+
+/**
+ * Show fallback queue when no baseline is active
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Object} options - Display options
+ */
+export async function showFallbackQueue(supabase, options = {}) {
+  const { skipBaselineWarning = false, sessionContext = {} } = options;
+
+  // No baseline - fall back to sequence_rank on SDs directly
+  const { data: sds, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, legacy_id, title, priority, status, sequence_rank, progress_percentage, dependencies, metadata, is_working_on, parent_sd_id')
+    .eq('is_active', true)
+    .in('status', ['draft', 'lead_review', 'plan_active', 'exec_active', 'active', 'in_progress'])
+    .in('priority', ['critical', 'high', 'medium'])
+    .order('sequence_rank', { nullsFirst: false })
+    .limit(15);
+
+  if (error || !sds || sds.length === 0) {
+    console.log(`${colors.red}No prioritized SDs found. Run: npm run sd:baseline to create one.${colors.reset}`);
+    return;
+  }
+
+  // Group by track from metadata
+  const tracks = { A: [], B: [], C: [], STANDALONE: [], UNASSIGNED: [] };
+
+  for (const sd of sds) {
+    const track = sd.metadata?.execution_track || 'UNASSIGNED';
+    const trackKey = track === 'Infrastructure' || track === 'Safety' ? 'A' :
+                     track === 'Feature' ? 'B' :
+                     track === 'Quality' ? 'C' :
+                     track === 'STANDALONE' ? 'STANDALONE' : 'UNASSIGNED';
+
+    const depsResolved = await checkDependenciesResolved(supabase, sd.dependencies);
+
+    tracks[trackKey].push({
+      ...sd,
+      deps_resolved: depsResolved,
+      track: trackKey
+    });
+  }
+
+  // Display tracks
+  displayTrackSection('A', 'Infrastructure/Safety', tracks.A, sessionContext);
+  displayTrackSection('B', 'Feature/Stages', tracks.B, sessionContext);
+  displayTrackSection('C', 'Quality', tracks.C, sessionContext);
+  if (tracks.STANDALONE.length > 0) {
+    displayTrackSection('STANDALONE', 'Standalone (No Dependencies)', tracks.STANDALONE, sessionContext);
+  }
+  if (tracks.UNASSIGNED.length > 0) {
+    displayTrackSection('UNASSIGNED', 'Unassigned (Needs Track)', tracks.UNASSIGNED, sessionContext);
+  }
+
+  // Find ready SDs (include unassigned)
+  const readySDs = [];
+  for (const sd of sds) {
+    const depsResolved = await checkDependenciesResolved(supabase, sd.dependencies);
+    if (depsResolved) {
+      readySDs.push(sd);
+    }
+  }
+
+  console.log(`\n${colors.bold}${colors.green}RECOMMENDED STARTING POINTS:${colors.reset}`);
+
+  if (sds.find(s => s.is_working_on)) {
+    const workingOn = sds.find(s => s.is_working_on);
+    console.log(`${colors.bgYellow}${colors.bold} CONTINUE ${colors.reset} ${workingOn.legacy_id} - ${workingOn.title}`);
+    console.log(`${colors.dim}   (Marked as "Working On" in UI)${colors.reset}`);
+  }
+
+  // Show top ready SD per track (including unassigned)
+  for (const [trackKey, trackSDs] of Object.entries(tracks)) {
+    const ready = trackSDs.find(s => s.deps_resolved && !s.is_working_on);
+    if (ready) {
+      const trackLabel = trackKey === 'UNASSIGNED' ? 'Unassigned' : `Track ${trackKey}`;
+      console.log(`${colors.green}  ${trackLabel}:${colors.reset} ${ready.legacy_id} - ${ready.title.substring(0, 50)}...`);
+    }
+  }
+
+  console.log(`\n${colors.dim}To begin: "I'm working on <SD-ID>"${colors.reset}`);
+
+  // Baseline creation prompt (skip if we already showed exhausted baseline message)
+  if (!skipBaselineWarning) {
+    displayNoBaselineWarning();
+  }
+}
+
+/**
+ * Show message when baseline exists but all items are completed
+ *
+ * @param {Object} baseline - The baseline object
+ * @param {Array} baselineItems - The baseline items
+ */
+export function showExhaustedBaselineMessage(baseline, baselineItems) {
+  const completedCount = baselineItems.length;
+
+  console.log(`${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.green}${colors.bold}✓ BASELINE COMPLETE${colors.reset}\n`);
+  console.log(`  All ${completedCount} SDs in the current baseline are completed!`);
+  console.log(`  ${colors.dim}Baseline ID: ${baseline.id.substring(0, 8)}...${colors.reset}\n`);
+
+  console.log(`${colors.cyan}OPTIONS:${colors.reset}`);
+  console.log(`  1. ${colors.bold}Continue with available SDs${colors.reset} (shown below)`);
+  console.log(`  2. ${colors.bold}Create new baseline:${colors.reset} npm run sd:baseline`);
+  console.log(`  3. ${colors.bold}Deactivate old baseline:${colors.reset} npm run sd:baseline:deactivate\n`);
+
+  // Show completed baseline items summary
+  console.log(`${colors.dim}Completed baseline items:${colors.reset}`);
+  for (const item of baselineItems.slice(0, 5)) {
+    console.log(`${colors.dim}  ✓ ${item.sd_id}${colors.reset}`);
+  }
+  if (baselineItems.length > 5) {
+    console.log(`${colors.dim}  ... and ${baselineItems.length - 5} more${colors.reset}`);
+  }
+  console.log();
+}
+
+/**
+ * Display warning when no baseline is active
+ */
+function displayNoBaselineWarning() {
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.yellow}${colors.bold}⚠️  NO ACTIVE BASELINE${colors.reset}`);
+  console.log(`${colors.dim}A baseline captures your execution plan with sequence and track assignments.${colors.reset}`);
+  console.log(`${colors.dim}Without one, SDs are ordered by sequence_rank only.${colors.reset}\n`);
+  console.log(`${colors.cyan}To create a baseline:${colors.reset}`);
+  console.log(`  ${colors.bold}npm run sd:baseline${colors.reset}        ${colors.dim}Create execution baseline${colors.reset}`);
+  console.log(`  ${colors.bold}npm run sd:baseline view${colors.reset}   ${colors.dim}View current baseline${colors.reset}`);
+}

--- a/scripts/modules/sd-next/display/index.js
+++ b/scripts/modules/sd-next/display/index.js
@@ -1,0 +1,21 @@
+/**
+ * Display Module Index for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+export { displayOKRScorecard } from './okr-scorecard.js';
+export { displayProposals } from './proposals.js';
+export {
+  displayTrackSection,
+  displayMultiRepoWarning
+} from './tracks.js';
+export {
+  displayRecommendations,
+  displayActiveSessions,
+  displaySessionContext
+} from './recommendations.js';
+export { displayParallelOpportunities } from './parallel.js';
+export {
+  showFallbackQueue,
+  showExhaustedBaselineMessage
+} from './fallback-queue.js';

--- a/scripts/modules/sd-next/display/okr-scorecard.js
+++ b/scripts/modules/sd-next/display/okr-scorecard.js
@@ -1,0 +1,80 @@
+/**
+ * OKR Scorecard Display for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+import { colors } from '../colors.js';
+
+/**
+ * Display OKR scorecard - strategic visibility header
+ *
+ * @param {Object|null} vision - Strategic vision object
+ * @param {Array} okrScorecard - OKR scorecard data
+ */
+export function displayOKRScorecard(vision, okrScorecard) {
+  if (!okrScorecard || okrScorecard.length === 0) return;
+
+  // Vision header (if available)
+  if (vision) {
+    console.log(`${colors.dim}┌─ VISION: ${vision.code} ${'─'.repeat(Math.max(0, 52 - vision.code.length))}┐${colors.reset}`);
+    const stmt = vision.statement.substring(0, 63);
+    console.log(`${colors.dim}│${colors.reset} ${colors.white}"${stmt}"${colors.reset}`);
+    console.log(`${colors.dim}└${'─'.repeat(67)}┘${colors.reset}\n`);
+  }
+
+  console.log(`${colors.bold}┌─ OKR SCORECARD ${'─'.repeat(52)}┐${colors.reset}`);
+  console.log(`${colors.bold}│${colors.reset}`);
+
+  for (const obj of okrScorecard) {
+    // Objective line with progress dots
+    const dots = obj.progress_dots || '[○○○○○]';
+    const pct = obj.avg_progress_pct ? `${Math.round(obj.avg_progress_pct)}%` : '0%';
+    const statusColor = obj.at_risk_krs > 0 ? colors.yellow : colors.green;
+
+    console.log(`${colors.bold}│${colors.reset} ${colors.bold}${obj.objective_code}${colors.reset}: ${obj.objective_title.substring(0, 35)}`);
+    console.log(`${colors.bold}│${colors.reset}   ${statusColor}${dots}${colors.reset} ${pct} avg | ${obj.total_krs} KRs`);
+
+    // Key results detail (if loaded)
+    if (obj.key_results && obj.key_results.length > 0) {
+      for (const kr of obj.key_results) {
+        displayKeyResult(kr);
+      }
+    }
+    console.log(`${colors.bold}│${colors.reset}`);
+  }
+
+  console.log(`${colors.bold}└${'─'.repeat(67)}┘${colors.reset}\n`);
+}
+
+/**
+ * Display a single key result with progress bar
+ *
+ * @param {Object} kr - Key result object
+ */
+function displayKeyResult(kr) {
+  const krStatus = kr.status === 'achieved' ? `${colors.green}✓` :
+                  kr.status === 'on_track' ? `${colors.green}●` :
+                  kr.status === 'at_risk' ? `${colors.yellow}●` :
+                  kr.status === 'off_track' ? `${colors.red}●` : `${colors.dim}○`;
+
+  // Calculate progress bar
+  let progress = 0;
+  if (kr.target_value && kr.target_value !== 0) {
+    if (kr.direction === 'decrease') {
+      progress = ((kr.baseline_value - kr.current_value) / (kr.baseline_value - kr.target_value)) * 100;
+    } else {
+      progress = ((kr.current_value - (kr.baseline_value || 0)) / (kr.target_value - (kr.baseline_value || 0))) * 100;
+    }
+  }
+  progress = Math.min(100, Math.max(0, progress));
+
+  const barFilled = Math.round(progress / 10);
+  const barEmpty = 10 - barFilled;
+  const progressBar = '█'.repeat(barFilled) + '░'.repeat(barEmpty);
+
+  const current = kr.current_value ?? 0;
+  const target = kr.target_value ?? 0;
+  const unit = kr.unit || '';
+
+  console.log(`${colors.bold}│${colors.reset}     ${krStatus}${colors.reset} ${kr.code.substring(0, 20).padEnd(20)} ${progressBar} ${current}${unit}→${target}${unit}`);
+}

--- a/scripts/modules/sd-next/display/parallel.js
+++ b/scripts/modules/sd-next/display/parallel.js
@@ -1,0 +1,92 @@
+/**
+ * Parallel Opportunities Display for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+import { colors } from '../colors.js';
+
+/**
+ * Display parallel opportunities for multi-session work
+ *
+ * @param {Object|null} sessionManager - Session manager instance
+ * @param {Object|null} currentSession - Current session
+ */
+export async function displayParallelOpportunities(sessionManager, currentSession) {
+  if (!sessionManager) return;
+
+  try {
+    const trackStatus = await sessionManager.getParallelTrackStatus();
+
+    // Find tracks without active sessions that have available work
+    const openTracks = trackStatus.filter(t =>
+      t.track_status === 'open' && t.available_sds > 0
+    );
+
+    // If current session has no SD claimed, suggest claiming one
+    if (currentSession && !currentSession.sd_id) {
+      const readyTracks = trackStatus.filter(t => t.available_sds > 0);
+      if (readyTracks.length > 0) {
+        displayClaimSuggestion();
+      }
+    }
+
+    // If there are open tracks and current session already has a claim, suggest parallel
+    if (openTracks.length > 0 && currentSession?.sd_id) {
+      displayOpenTracksForParallel(openTracks);
+    }
+
+    // If all tracks are occupied, show status
+    const occupiedTracks = trackStatus.filter(t => t.track_status === 'occupied');
+    if (occupiedTracks.length === trackStatus.length && trackStatus.length > 0) {
+      displayAllTracksOccupied();
+    }
+
+  } catch {
+    // Non-fatal - just skip parallel suggestions
+  }
+}
+
+/**
+ * Display suggestion to claim an SD
+ */
+function displayClaimSuggestion() {
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}${colors.cyan}CLAIM AN SD:${colors.reset}\n`);
+  console.log(`${colors.dim}This session has no SD claimed. To claim:${colors.reset}`);
+  console.log(`  ${colors.cyan}npm run sd:claim <SD-ID>${colors.reset}  - Claim a specific SD`);
+  console.log(`  ${colors.dim}Or tell me: "I want to work on <SD-ID>"${colors.reset}\n`);
+}
+
+/**
+ * Display open tracks available for parallel work
+ *
+ * @param {Array} openTracks - Open tracks with available SDs
+ */
+function displayOpenTracksForParallel(openTracks) {
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}${colors.green}PARALLEL OPPORTUNITY:${colors.reset}\n`);
+  console.log(`  ${colors.dim}Open another terminal for parallel work:${colors.reset}\n`);
+
+  for (const track of openTracks) {
+    const trackColor = track.track === 'A' ? colors.magenta :
+                      track.track === 'B' ? colors.blue :
+                      track.track === 'C' ? colors.cyan : colors.yellow;
+
+    console.log(`  ${trackColor}${colors.bold}Track ${track.track}${colors.reset} (${track.track_name})`);
+    console.log(`    Next: ${colors.bold}${track.next_available_sd}${colors.reset}`);
+    console.log(`    Available: ${track.available_sds} SDs`);
+  }
+
+  console.log(`\n  ${colors.dim}Run ${colors.cyan}npm run sd:next${colors.dim} in new terminal, then:${colors.reset}`);
+  console.log(`  ${colors.cyan}npm run sd:claim <SD-ID>${colors.reset}`);
+}
+
+/**
+ * Display message when all tracks are occupied
+ */
+function displayAllTracksOccupied() {
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}${colors.yellow}ALL TRACKS ACTIVE:${colors.reset}\n`);
+  console.log(`  ${colors.dim}All parallel tracks have active sessions.${colors.reset}`);
+  console.log(`  ${colors.dim}Wait for a session to complete or release its SD.${colors.reset}`);
+}

--- a/scripts/modules/sd-next/display/proposals.js
+++ b/scripts/modules/sd-next/display/proposals.js
@@ -1,0 +1,63 @@
+/**
+ * Proposals Display for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+import { colors } from '../colors.js';
+
+/**
+ * Display pending proposals (LEO Protocol v4.4)
+ *
+ * @param {Array} proposals - Pending proposals to display
+ */
+export function displayProposals(proposals) {
+  if (!proposals || proposals.length === 0) return;
+
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}${colors.magenta}SUGGESTED (Proactive Proposals):${colors.reset}\n`);
+
+  for (const p of proposals) {
+    const urgencyIcon = getUrgencyIcon(p.urgency_level);
+    const triggerLabel = getTriggerLabel(p.trigger_type);
+    const confidence = (p.confidence_score * 100).toFixed(0);
+    const shortId = p.id.substring(0, 8);
+
+    console.log(`  ${urgencyIcon} [${triggerLabel}]${colors.reset} ${p.title.substring(0, 50)}...`);
+    console.log(`${colors.dim}    Confidence: ${confidence}% | ID: ${shortId} | approve: npm run proposal:approve ${shortId}${colors.reset}`);
+  }
+
+  console.log(`\n${colors.dim}  Dismiss: npm run proposal:dismiss <id> <reason>${colors.reset}`);
+  console.log(`${colors.dim}  Reasons: not_relevant, wrong_timing, duplicate, too_small, too_large, already_fixed${colors.reset}`);
+}
+
+/**
+ * Get urgency icon based on level
+ *
+ * @param {string} urgencyLevel - Urgency level
+ * @returns {string} Colored icon string
+ */
+function getUrgencyIcon(urgencyLevel) {
+  switch (urgencyLevel) {
+    case 'critical':
+      return `${colors.red}🔴`;
+    case 'medium':
+      return `${colors.yellow}🟡`;
+    default:
+      return `${colors.green}🟢`;
+  }
+}
+
+/**
+ * Get trigger label for display
+ *
+ * @param {string} triggerType - Trigger type
+ * @returns {string} Short label for display
+ */
+function getTriggerLabel(triggerType) {
+  const labels = {
+    'dependency_update': 'DEP',
+    'retrospective_pattern': 'RETRO',
+    'code_health': 'HEALTH'
+  };
+  return labels[triggerType] || triggerType.substring(0, 5).toUpperCase();
+}

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -1,0 +1,243 @@
+/**
+ * Recommendations Display for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+import { colors } from '../colors.js';
+import { isActionableForLead } from '../status-helpers.js';
+import { checkDependenciesResolved } from '../dependency-resolver.js';
+import { getEstimatedDuration, formatEstimateShort } from '../../../lib/duration-estimator.js';
+
+/**
+ * Display recommendations section
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Array} baselineItems - Baseline items
+ * @param {Array} conflicts - Active conflicts
+ */
+export async function displayRecommendations(supabase, baselineItems, conflicts = []) {
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}${colors.green}RECOMMENDED ACTIONS:${colors.reset}\n`);
+
+  // Check for "working on" SD first
+  const workingOn = await getWorkingOnSD(supabase);
+
+  if (workingOn) {
+    await displayWorkingOnSD(supabase, workingOn);
+  }
+
+  // Find ready SDs from baseline
+  const { readySDs, needsVerificationSDs } = await categorizeBaselineSDs(supabase, baselineItems);
+
+  // Show SDs needing verification/close-out FIRST (Control Gap Fix)
+  if (needsVerificationSDs.length > 0) {
+    displayVerificationNeeded(needsVerificationSDs);
+  }
+
+  if (readySDs.length > 0 && !workingOn) {
+    await displayStartRecommendation(supabase, readySDs[0]);
+  }
+
+  // Show parallel opportunities
+  const parallelReady = readySDs.filter(sd => sd.track !== readySDs[0]?.track).slice(0, 2);
+  if (parallelReady.length > 0) {
+    displayParallelOpportunities(parallelReady);
+  }
+
+  // Show conflicts if any
+  if (conflicts.length > 0) {
+    displayConflictWarnings(conflicts);
+  }
+
+  // Show how to begin work
+  displayBeginWorkInstructions();
+}
+
+/**
+ * Get SD marked as "working on"
+ */
+async function getWorkingOnSD(supabase) {
+  const { data: workingOn } = await supabase
+    .from('strategic_directives_v2')
+    .select('legacy_id, title, progress_percentage')
+    .eq('is_active', true)
+    .eq('is_working_on', true)
+    .lt('progress_percentage', 100)
+    .single();
+
+  return workingOn;
+}
+
+/**
+ * Display "working on" SD with duration estimate
+ */
+async function displayWorkingOnSD(supabase, workingOn) {
+  console.log(`${colors.bgYellow}${colors.bold} CONTINUE ${colors.reset} ${workingOn.legacy_id}`);
+  console.log(`  ${workingOn.title}`);
+  console.log(`  ${colors.dim}Progress: ${workingOn.progress_percentage || 0}% | Marked as "Working On"${colors.reset}`);
+
+  // Add duration estimate
+  try {
+    const { data: sdFull } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_type, category, priority')
+      .eq('legacy_id', workingOn.legacy_id)
+      .single();
+
+    if (sdFull) {
+      const estimate = await getEstimatedDuration(supabase, sdFull);
+      console.log(`  ${colors.dim}Est: ${formatEstimateShort(estimate)}${colors.reset}\n`);
+    } else {
+      console.log();
+    }
+  } catch {
+    console.log();
+  }
+}
+
+/**
+ * Categorize baseline SDs into ready and needs verification
+ */
+async function categorizeBaselineSDs(supabase, baselineItems) {
+  const readySDs = [];
+  const needsVerificationSDs = [];
+
+  for (const item of baselineItems) {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('legacy_id, title, status, current_phase, progress_percentage, dependencies, is_active')
+      .eq('legacy_id', item.sd_id)
+      .single();
+
+    if (sd && sd.is_active && sd.status !== 'completed' && sd.status !== 'cancelled') {
+      const depsResolved = await checkDependenciesResolved(supabase, sd.dependencies);
+      const enrichedSD = { ...item, ...sd, deps_resolved: depsResolved };
+
+      // Separate SDs needing verification from truly ready SDs
+      if (sd.current_phase === 'EXEC_COMPLETE' || sd.status === 'review') {
+        needsVerificationSDs.push(enrichedSD);
+      } else if (depsResolved && isActionableForLead(enrichedSD)) {
+        readySDs.push(enrichedSD);
+      }
+    }
+  }
+
+  return { readySDs, needsVerificationSDs };
+}
+
+/**
+ * Display SDs that need verification
+ */
+function displayVerificationNeeded(needsVerificationSDs) {
+  console.log(`${colors.bgMagenta}${colors.bold} NEEDS VERIFICATION ${colors.reset}`);
+  needsVerificationSDs.forEach(sd => {
+    console.log(`  ${sd.legacy_id} - ${sd.title.substring(0, 45)}...`);
+    console.log(`  ${colors.dim}Phase: ${sd.current_phase} | Status: ${sd.status} | Run: npm run sd:verify ${sd.legacy_id}${colors.reset}\n`);
+  });
+}
+
+/**
+ * Display start recommendation with duration estimate
+ */
+async function displayStartRecommendation(supabase, topSD) {
+  console.log(`${colors.bgGreen}${colors.bold} START ${colors.reset} ${topSD.legacy_id}`);
+  console.log(`  ${topSD.title}`);
+  console.log(`  ${colors.dim}Track: ${topSD.track || 'N/A'} | Rank: ${topSD.sequence_rank} | All dependencies satisfied${colors.reset}`);
+
+  // Add duration estimate
+  try {
+    const { data: sdFull } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_type, category, priority')
+      .eq('legacy_id', topSD.legacy_id)
+      .single();
+
+    if (sdFull) {
+      const estimate = await getEstimatedDuration(supabase, sdFull);
+      console.log(`  ${colors.dim}Est: ${formatEstimateShort(estimate)}${colors.reset}\n`);
+    } else {
+      console.log();
+    }
+  } catch {
+    console.log();
+  }
+}
+
+/**
+ * Display parallel opportunities
+ */
+function displayParallelOpportunities(parallelReady) {
+  console.log(`${colors.cyan}PARALLEL OPPORTUNITIES:${colors.reset}`);
+  parallelReady.forEach(sd => {
+    console.log(`  Track ${sd.track}: ${sd.legacy_id} - ${sd.title.substring(0, 40)}...`);
+  });
+}
+
+/**
+ * Display conflict warnings
+ */
+function displayConflictWarnings(conflicts) {
+  console.log(`\n${colors.red}${colors.bold}CONFLICT WARNINGS:${colors.reset}`);
+  conflicts.forEach(c => {
+    console.log(`  ${colors.red}!${colors.reset} ${c.sd_id_a} + ${c.sd_id_b}: ${c.conflict_type}`);
+  });
+}
+
+/**
+ * Display instructions for beginning work
+ */
+function displayBeginWorkInstructions() {
+  console.log(`\n${colors.bold}TO BEGIN WORK:${colors.reset}`);
+  console.log(`  ${colors.cyan}npm run sd:start <SD-ID>${colors.reset}  ${colors.dim}(recommended - claims SD and shows info)${colors.reset}`);
+  console.log(`  ${colors.dim}OR: node scripts/handoff.js execute LEAD-TO-PLAN <SD-ID>${colors.reset}`);
+}
+
+/**
+ * Display active sessions
+ *
+ * @param {Array} activeSessions - Active sessions
+ * @param {Object|null} currentSession - Current session
+ */
+export function displayActiveSessions(activeSessions, currentSession) {
+  if (activeSessions.length === 0) return;
+
+  const sessionsWithClaims = activeSessions.filter(s => s.sd_id);
+  const idleSessions = activeSessions.filter(s => !s.sd_id);
+
+  if (sessionsWithClaims.length > 0) {
+    console.log(`${colors.bold}ACTIVE SESSIONS (${sessionsWithClaims.length}):${colors.reset}\n`);
+
+    for (const s of sessionsWithClaims) {
+      const isCurrent = currentSession && s.session_id === currentSession.session_id;
+      const marker = isCurrent ? `${colors.green}→${colors.reset}` : ' ';
+      const shortId = s.session_id.substring(0, 16) + '...';
+      const ageMin = Math.round(s.claim_duration_minutes || 0);
+
+      console.log(`${marker} ${shortId} │ ${colors.bold}${s.sd_id}${colors.reset} (Track ${s.track}) │ ${ageMin}m active`);
+    }
+    console.log();
+  }
+
+  if (idleSessions.length > 0 && sessionsWithClaims.length === 0) {
+    console.log(`${colors.dim}(${idleSessions.length} idle session(s) detected)${colors.reset}\n`);
+  }
+}
+
+/**
+ * Display session context (recent activity)
+ *
+ * @param {Array} recentActivity - Recent activity data
+ */
+export function displaySessionContext(recentActivity) {
+  if (recentActivity.length === 0) return;
+
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}RECENT SESSION ACTIVITY:${colors.reset}\n`);
+
+  recentActivity.slice(0, 3).forEach(activity => {
+    const commitInfo = activity.commits > 0 ? `${activity.commits} commits` : 'recently updated';
+    console.log(`  ${activity.sd_id} - ${commitInfo}`);
+  });
+
+  console.log(`\n${colors.dim}Consider continuing recent work for context preservation.${colors.reset}`);
+}

--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -1,0 +1,196 @@
+/**
+ * Tracks Display for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ */
+
+import { colors, trackColors } from '../colors.js';
+import { getPhaseAwareStatus } from '../status-helpers.js';
+import { parseDependencies } from '../dependency-resolver.js';
+
+/**
+ * Display a track section with hierarchical SD items
+ *
+ * @param {string} trackKey - Track key (A, B, C, STANDALONE, UNASSIGNED)
+ * @param {string} trackName - Track display name
+ * @param {Array} items - SD items in this track
+ * @param {Object} sessionContext - Session context {claimedSDs, currentSession, activeSessions}
+ */
+export function displayTrackSection(trackKey, trackName, items, sessionContext = {}) {
+  if (items.length === 0) return;
+
+  console.log(`\n${trackColors[trackKey]}${colors.bold}TRACK ${trackKey}: ${trackName}${colors.reset}`);
+
+  // Group items by parent for hierarchical display
+  const rootItems = [];
+  const childItems = new Map(); // parent_sd_id -> children
+
+  for (const item of items) {
+    if (item.parent_sd_id) {
+      if (!childItems.has(item.parent_sd_id)) {
+        childItems.set(item.parent_sd_id, []);
+      }
+      childItems.get(item.parent_sd_id).push(item);
+    } else {
+      rootItems.push(item);
+    }
+  }
+
+  // Also add items whose parent is not in this track as roots
+  for (const item of items) {
+    if (item.parent_sd_id) {
+      const parentInTrack = items.find(i =>
+        (i.legacy_id || i.sd_id) === item.parent_sd_id || i.id === item.parent_sd_id
+      );
+      if (!parentInTrack && !rootItems.includes(item)) {
+        rootItems.push(item);
+      }
+    }
+  }
+
+  // Display hierarchically
+  for (const item of rootItems) {
+    displaySDItem(item, '', childItems, items, sessionContext);
+  }
+}
+
+/**
+ * Display a single SD item with its children (recursive)
+ *
+ * @param {Object} item - SD item to display
+ * @param {string} indent - Current indentation
+ * @param {Map} childItems - Map of parent_sd_id -> children
+ * @param {Array} allItems - All items in the track
+ * @param {Object} sessionContext - Session context
+ */
+function displaySDItem(item, indent, childItems, allItems, sessionContext) {
+  const { claimedSDs = new Map(), currentSession = null, activeSessions = [] } = sessionContext;
+
+  const sdId = item.legacy_id || item.sd_id;
+  const rankStr = item.sequence_rank ? `[${item.sequence_rank}]`.padEnd(5) : '     ';
+
+  // Check if claimed by another session
+  const claimedBySession = claimedSDs.get(sdId);
+  const isClaimedByOther = claimedBySession &&
+    currentSession &&
+    claimedBySession !== currentSession.session_id;
+  const isClaimedByMe = claimedBySession &&
+    currentSession &&
+    claimedBySession === currentSession.session_id;
+
+  // Status icon logic - now phase-aware (Control Gap Fix)
+  let statusIcon;
+  if (isClaimedByOther) {
+    statusIcon = `${colors.yellow}CLAIMED${colors.reset}`;
+  } else if (isClaimedByMe) {
+    statusIcon = `${colors.green}YOURS${colors.reset}`;
+  } else {
+    // Use phase-aware status to prevent showing READY for SDs needing verification
+    statusIcon = getPhaseAwareStatus(item);
+  }
+
+  const workingIcon = item.is_working_on ? `${colors.bgYellow} ACTIVE ${colors.reset} ` : '';
+  const claimedIcon = isClaimedByOther ? `${colors.bgBlue} CLAIMED ${colors.reset} ` : '';
+  const title = (item.title || '').substring(0, 40 - indent.length);
+
+  console.log(`${indent}${claimedIcon}${workingIcon}${rankStr} ${sdId} - ${title}... ${statusIcon}`);
+
+  // Show who claimed it
+  if (isClaimedByOther) {
+    const claimingSession = activeSessions.find(s => s.session_id === claimedBySession);
+    const shortId = claimedBySession.substring(0, 12) + '...';
+    const ageMin = claimingSession ? Math.round(claimingSession.claim_duration_minutes || 0) : '?';
+    console.log(`${colors.dim}${indent}        └─ Claimed by session ${shortId} (${ageMin}m)${colors.reset}`);
+  }
+
+  // Show blockers if not resolved and not claimed
+  if (!item.deps_resolved && item.dependencies && !isClaimedByOther) {
+    const deps = parseDependencies(item.dependencies);
+    const unresolvedDeps = deps.filter(d => !d.resolved);
+    if (unresolvedDeps.length > 0) {
+      console.log(`${colors.dim}${indent}        └─ Blocked by: ${unresolvedDeps.map(d => d.sd_id).join(', ')}${colors.reset}`);
+    }
+  }
+
+  // Show sibling dependency status for child SDs (pre-computed)
+  if (item.childDepStatus && !item.childDepStatus.allComplete) {
+    console.log(`${colors.dim}${indent}        └─ Child deps: ${item.childDepStatus.summary}${colors.reset}`);
+  }
+
+  // Display children recursively
+  const children = childItems.get(sdId) || childItems.get(item.id) || [];
+  const childrenInTrack = children.filter(c => allItems.includes(c));
+
+  for (let i = 0; i < childrenInTrack.length; i++) {
+    const child = childrenInTrack[i];
+    const isLast = i === childrenInTrack.length - 1;
+    const childIndent = indent + (isLast ? '  └─ ' : '  ├─ ');
+    const nextIndent = indent + (isLast ? '     ' : '  │  ');
+
+    // For children, use simpler display
+    displaySDItemSimple(child, childIndent, nextIndent, childItems, allItems);
+  }
+}
+
+/**
+ * Display child SD item (simpler format for nested items)
+ *
+ * @param {Object} item - SD item to display
+ * @param {string} prefix - Prefix for this line
+ * @param {string} nextIndent - Indentation for next level
+ * @param {Map} childItems - Map of parent_sd_id -> children
+ * @param {Array} allItems - All items in the track
+ */
+function displaySDItemSimple(item, prefix, nextIndent, childItems, allItems) {
+  const sdId = item.legacy_id || item.sd_id;
+
+  // Status icon - now phase-aware (Control Gap Fix)
+  const statusIcon = getPhaseAwareStatus(item);
+
+  const workingIcon = item.is_working_on ? `${colors.bgYellow}◆${colors.reset}` : '';
+  const title = (item.title || '').substring(0, 30);
+
+  console.log(`${prefix}${workingIcon}${sdId} - ${title}... ${statusIcon}`);
+
+  // Recursively show grandchildren
+  const children = childItems.get(sdId) || childItems.get(item.id) || [];
+  const childrenInTrack = children.filter(c => allItems.includes(c));
+
+  for (let i = 0; i < childrenInTrack.length; i++) {
+    const child = childrenInTrack[i];
+    const isLast = i === childrenInTrack.length - 1;
+    const childPrefix = nextIndent + (isLast ? '└─ ' : '├─ ');
+    const childNextIndent = nextIndent + (isLast ? '   ' : '│  ');
+
+    displaySDItemSimple(child, childPrefix, childNextIndent, childItems, allItems);
+  }
+}
+
+/**
+ * Display multi-repo status warning if uncommitted changes exist
+ *
+ * @param {Object} multiRepoStatus - Multi-repo status object
+ */
+export function displayMultiRepoWarning(multiRepoStatus) {
+  if (!multiRepoStatus || !multiRepoStatus.hasChanges) return;
+
+  const minAgeDays = multiRepoStatus.minAgeDays || 5;
+
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bgYellow}${colors.bold} MULTI-REPO WARNING ${colors.reset}`);
+  console.log(`${colors.dim}(Showing files ≥${minAgeDays} days old)${colors.reset}\n`);
+
+  for (const repo of multiRepoStatus.summary) {
+    const icon = repo.uncommittedCount > 0 ? '📝' : '📤';
+    console.log(`  ${icon} ${colors.bold}${repo.displayName}${colors.reset} (${repo.branch})`);
+
+    if (repo.uncommittedCount > 0) {
+      console.log(`     ${repo.uncommittedCount} uncommitted change(s)`);
+    }
+    if (repo.unpushedCount > 0) {
+      console.log(`     ${repo.unpushedCount} unpushed commit(s)`);
+    }
+  }
+
+  console.log(`\n  ${colors.yellow}⚠️  Commit changes before starting new SD work${colors.reset}`);
+  console.log(`  ${colors.dim}Run: node scripts/multi-repo-status.js for details${colors.reset}`);
+}

--- a/scripts/modules/sd-next/index.js
+++ b/scripts/modules/sd-next/index.js
@@ -1,0 +1,45 @@
+/**
+ * SD-Next Module Index
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ *
+ * This module provides the SD-Next intelligent strategic directive selection system,
+ * broken down into focused modules for maintainability.
+ */
+
+// Colors and display utilities
+export { colors, trackColors } from './colors.js';
+
+// Status helpers
+export { getPhaseAwareStatus, isActionableForLead } from './status-helpers.js';
+
+// Dependency resolution
+export {
+  parseDependencies,
+  checkDependenciesResolved,
+  getUnresolvedDependencies
+} from './dependency-resolver.js';
+
+// Data loaders
+export {
+  loadActiveBaseline,
+  loadRecentActivity,
+  loadConflicts,
+  loadPendingProposals,
+  loadSDHierarchy,
+  loadOKRScorecard,
+  countActionableBaselineItems
+} from './data-loaders.js';
+
+// Display modules
+export {
+  displayOKRScorecard,
+  displayProposals,
+  displayTrackSection,
+  displayMultiRepoWarning,
+  displayRecommendations,
+  displayActiveSessions,
+  displaySessionContext,
+  displayParallelOpportunities,
+  showFallbackQueue,
+  showExhaustedBaselineMessage
+} from './display/index.js';

--- a/scripts/modules/sd-next/status-helpers.js
+++ b/scripts/modules/sd-next/status-helpers.js
@@ -1,0 +1,91 @@
+/**
+ * Phase-Aware Status Helpers for SD-Next
+ * Part of SD-LEO-REFACTOR-SD-NEXT-001
+ *
+ * Control Gap Fix: SD status must reflect actual phase, not just dependency resolution
+ */
+
+import { colors } from './colors.js';
+
+/**
+ * Get phase-aware status icon for an SD
+ * Control Gap Fix: SD status must reflect actual phase, not just dependency resolution
+ *
+ * @param {Object} item - SD item with current_phase, status, deps_resolved, progress_percentage
+ * @returns {string} Colored status string for display
+ */
+export function getPhaseAwareStatus(item) {
+  const phase = item.current_phase || '';
+  const status = item.status || '';
+  const depsResolved = item.deps_resolved;
+  const progress = item.progress_percentage || 0;
+
+  // Phase-based status takes priority over dependency resolution
+  // This prevents showing "READY" for SDs that need verification/review
+
+  // EXEC_COMPLETE with review status = needs verification
+  if (phase === 'EXEC_COMPLETE' && status === 'review') {
+    return `${colors.magenta}VERIFY${colors.reset}`;
+  }
+
+  // Any COMPLETE phase that isn't fully completed = needs close-out
+  if (phase.includes('COMPLETE') && status !== 'completed') {
+    return `${colors.magenta}CLOSE-OUT${colors.reset}`;
+  }
+
+  // PLAN phases = in planning, not ready for LEAD work
+  if (phase === 'PLAN_PRD' || phase === 'PLAN') {
+    return `${colors.cyan}PLANNING${colors.reset}`;
+  }
+
+  // Draft status = needs LEAD review first
+  if (status === 'draft') {
+    return `${colors.yellow}DRAFT${colors.reset}`;
+  }
+
+  // In active EXEC phase
+  if (phase === 'EXEC' || phase === 'EXEC_ACTIVE') {
+    if (progress > 0 && progress < 100) {
+      return `${colors.blue}EXEC ${progress}%${colors.reset}`;
+    }
+    return `${colors.blue}IN_EXEC${colors.reset}`;
+  }
+
+  // Standard dependency-based logic for LEAD phase or new SDs
+  if (depsResolved) {
+    return `${colors.green}READY${colors.reset}`;
+  } else if (progress > 0) {
+    return `${colors.yellow}${progress}%${colors.reset}`;
+  } else {
+    return `${colors.red}BLOCKED${colors.reset}`;
+  }
+}
+
+/**
+ * Check if an SD is actionable for LEAD work (starting new work)
+ * Returns false for SDs in verification, planning, or other non-LEAD phases
+ *
+ * @param {Object} item - SD item with current_phase and status
+ * @returns {boolean} True if SD is actionable for LEAD work
+ */
+export function isActionableForLead(item) {
+  const phase = item.current_phase || '';
+  const status = item.status || '';
+
+  // Not actionable if needs verification
+  if (phase === 'EXEC_COMPLETE' || phase.includes('COMPLETE')) {
+    return false;
+  }
+
+  // Not actionable if in active planning or execution
+  if (phase === 'PLAN_PRD' || phase === 'PLAN' || phase === 'EXEC' || phase === 'EXEC_ACTIVE') {
+    return false;
+  }
+
+  // Not actionable if in review status
+  if (status === 'review') {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

Part of orchestrator SD-LEO-REFACTOR-LARGE-FILES-002 (child: SD-LEO-REFACTOR-SD-NEXT-001)

Extracts 12 focused modules from `sd-next.js` (1,239 LOC) for improved maintainability:

### Modules Created (all <500 LOC)

| Module | LOC | Purpose |
|--------|-----|---------|
| `colors.js` | 33 | ANSI terminal color codes |
| `status-helpers.js` | 91 | Phase-aware status helpers |
| `dependency-resolver.js` | 107 | Dependency parsing and resolution |
| `data-loaders.js` | 264 | Baseline, activity, OKR data loading |
| `display/okr-scorecard.js` | 80 | OKR scorecard display |
| `display/proposals.js` | 63 | Proposals display |
| `display/tracks.js` | 198 | Track section display |
| `display/recommendations.js` | 243 | Recommendations display |
| `display/parallel.js` | 92 | Parallel opportunities display |
| `display/fallback-queue.js` | 139 | Fallback queue display |
| `display/index.js` | 21 | Display module index |
| `index.js` | 45 | Main module index (24 exports) |

**Total: 1,376 LOC in 12 modules**

## Test plan
- [x] Dynamic import test: All 24 exports verified
- [x] Original sd-next.js still runs correctly
- [x] ESLint passes with no errors
- [x] Smoke tests: 15/15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)