### PR TITLE
refactor(prd): extract add-prd-to-database.js into 7 focused modules

### DIFF
--- a/scripts/modules/prd-generator/config.js
+++ b/scripts/modules/prd-generator/config.js
@@ -1,0 +1,154 @@
+/**
+ * PRD Generator Configuration
+ * Part of SD-LEO-REFACTOR-PRD-DB-001
+ *
+ * LLM-based PRD content generation configuration
+ */
+
+import { getOpenAIModel } from '../../../lib/config/model-config.js';
+
+/**
+ * LLM PRD Generation Configuration
+ */
+export const LLM_PRD_CONFIG = {
+  model: getOpenAIModel('generation'),
+  temperature: 0.6,   // Slightly lower for more structured PRD content
+  maxTokens: 32000,   // Extended for comprehensive PRD generation
+  enabled: process.env.LLM_PRD_GENERATION !== 'false'  // Enabled by default
+};
+
+/**
+ * PRD Quality Rubric Criteria for LLM context injection
+ *
+ * This is embedded in the LLM prompt so it generates content that will pass
+ * the Russian Judge quality validation.
+ */
+export const PRD_QUALITY_RUBRIC_CRITERIA = `
+## QUALITY CRITERIA (You will be judged on these dimensions)
+
+### 1. Requirements Depth & Specificity (40% weight)
+- 0-3: Mostly placeholders ("To be defined", "TBD", generic statements) - WILL FAIL
+- 4-6: Some specific requirements but many vague or incomplete
+- 7-8: Most requirements are specific, actionable, and complete
+- 9-10: All requirements are detailed, specific, testable, with clear acceptance criteria
+
+**Target**: Score 7-8 minimum. Each requirement must be implementation-ready.
+
+### 2. Architecture Explanation Quality (30% weight)
+- 0-3: No architecture details or vague high-level statements
+- 4-6: Basic architecture mentioned but missing key details
+- 7-8: Clear architecture with components, data flow, and integration points
+- 9-10: Comprehensive: components + data flow + integration + trade-offs + scalability
+
+**Target**: Score 7-8 minimum. Must enable implementation without guessing.
+
+### 3. Test Scenario Sophistication (20% weight)
+- 0-3: No test scenarios or only trivial happy path - WILL FAIL
+- 4-6: Happy path covered but missing edge cases and error conditions
+- 7-8: Happy path + common edge cases + error handling scenarios
+- 9-10: Comprehensive: happy path + edge cases + errors + performance + security
+
+**Target**: Score 7-8 minimum. Must demonstrate failure mode understanding.
+
+### 4. Risk Analysis Completeness (10% weight)
+- 0-3: No technical risks or listed without mitigation
+- 4-6: Basic risks with generic mitigation ("test thoroughly")
+- 7-8: Specific technical risks with concrete mitigation strategies
+- 9-10: Comprehensive: risks + mitigation + rollback plan + monitoring
+
+**Target**: Score 7-8 minimum. Must be proactive and specific to this SD.
+`;
+
+/**
+ * LLM System Prompt for PRD Generation
+ */
+export function buildSystemPrompt(sdType) {
+  return `You are a Technical Product Manager creating a Product Requirements Document (PRD) for a software engineering team.
+
+Your PRD must be IMPLEMENTATION-READY. The development team will use this document to build the feature.
+
+${PRD_QUALITY_RUBRIC_CRITERIA}
+
+## OUTPUT REQUIREMENTS
+
+Return a JSON object with exactly these fields:
+{
+  "executive_summary": "string - 200-500 chars describing WHAT, WHY, and IMPACT",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "requirement": "Specific, actionable requirement statement",
+      "description": "Detailed description of what this achieves",
+      "priority": "CRITICAL|HIGH|MEDIUM|LOW",
+      "acceptance_criteria": ["AC-1", "AC-2", "AC-3"]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "requirement": "Technical constraint or requirement",
+      "rationale": "Why this is needed"
+    }
+  ],
+  "system_architecture": {
+    "overview": "High-level architecture description",
+    "components": [
+      {
+        "name": "Component Name",
+        "responsibility": "What this component does",
+        "technology": "Tech stack used"
+      }
+    ],
+    "data_flow": "Description of how data moves through the system",
+    "integration_points": ["Integration point 1", "Integration point 2"]
+  },
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Test scenario description",
+      "test_type": "unit|integration|e2e|performance|security",
+      "given": "Preconditions",
+      "when": "Action taken",
+      "then": "Expected outcome"
+    }
+  ],
+  "acceptance_criteria": [
+    "Specific, measurable criterion 1",
+    "Specific, measurable criterion 2"
+  ],
+  "risks": [
+    {
+      "risk": "Specific risk description",
+      "probability": "HIGH|MEDIUM|LOW",
+      "impact": "HIGH|MEDIUM|LOW",
+      "mitigation": "Concrete mitigation strategy",
+      "rollback_plan": "How to rollback if this fails"
+    }
+  ],
+  "implementation_approach": {
+    "phases": [
+      {
+        "phase": "Phase 1",
+        "description": "What happens in this phase",
+        "deliverables": ["Deliverable 1", "Deliverable 2"]
+      }
+    ],
+    "technical_decisions": ["Key decision 1 with rationale", "Key decision 2"]
+  }
+}
+
+## CRITICAL RULES
+
+1. **NO PLACEHOLDERS**: Never use "To be defined", "TBD", "Will be determined", or similar
+2. **SPECIFIC**: Every requirement must be specific enough to implement immediately
+3. **TESTABLE**: Every acceptance criterion must be verifiable
+4. **SD-ALIGNED**: All content must directly relate to the SD objectives
+5. **TYPE-AWARE**: Tailor depth based on SD type (${sdType})
+
+SD Type-Specific Guidance:
+${sdType === 'database' ? '- Focus heavily on schema design, migration safety, RLS policies, data integrity' : ''}
+${sdType === 'infrastructure' ? '- Focus on deployment, CI/CD, monitoring, rollback procedures' : ''}
+${sdType === 'security' ? '- Focus on threat modeling, auth flows, permission boundaries, audit logging' : ''}
+${sdType === 'documentation' ? '- Focus on content completeness, accuracy verification, maintenance plan' : ''}
+${sdType === 'feature' || !sdType ? '- Balance functional requirements, UX, and technical implementation' : ''}`;
+}

--- a/scripts/modules/prd-generator/content-formatter.js
+++ b/scripts/modules/prd-generator/content-formatter.js
@@ -1,0 +1,195 @@
+/**
+ * PRD Content Formatter
+ * Part of SD-LEO-REFACTOR-PRD-DB-001
+ *
+ * Formats LLM-generated PRD content into markdown
+ */
+
+/**
+ * Format LLM-generated PRD content into markdown
+ *
+ * @param {string} sdId - Strategic Directive ID
+ * @param {Object} sdData - Strategic Directive data
+ * @param {Object} llmContent - LLM-generated content
+ * @returns {string} Formatted markdown PRD
+ */
+export function formatPRDContent(sdId, sdData, llmContent) {
+  const sections = [];
+
+  sections.push(`# Product Requirements Document
+
+## Strategic Directive
+${sdId}
+
+## Title
+${sdData.title || 'Untitled'}
+
+## Status
+Planning
+
+## Executive Summary
+${llmContent.executive_summary || 'See functional requirements below.'}`);
+
+  // Functional Requirements
+  if (llmContent.functional_requirements && llmContent.functional_requirements.length > 0) {
+    sections.push(`## Functional Requirements
+
+${llmContent.functional_requirements.map(req => {
+  const lines = [`### ${req.id}: ${req.requirement}`];
+  if (req.description) lines.push(`\n${req.description}`);
+  if (req.priority) lines.push(`\n**Priority**: ${req.priority}`);
+  if (req.acceptance_criteria && req.acceptance_criteria.length > 0) {
+    lines.push('\n**Acceptance Criteria**:');
+    req.acceptance_criteria.forEach(ac => lines.push(`- ${ac}`));
+  }
+  return lines.join('');
+}).join('\n\n')}`);
+  }
+
+  // Technical Requirements
+  if (llmContent.technical_requirements && llmContent.technical_requirements.length > 0) {
+    sections.push(`## Technical Requirements
+
+${llmContent.technical_requirements.map(req => {
+  const lines = [`### ${req.id}: ${req.requirement}`];
+  if (req.rationale) lines.push(`\n**Rationale**: ${req.rationale}`);
+  return lines.join('');
+}).join('\n\n')}`);
+  }
+
+  // System Architecture
+  if (llmContent.system_architecture) {
+    const arch = llmContent.system_architecture;
+    const archLines = ['## System Architecture'];
+    if (arch.overview) archLines.push(`\n### Overview\n${arch.overview}`);
+    if (arch.components && arch.components.length > 0) {
+      archLines.push('\n### Components');
+      arch.components.forEach(comp => {
+        archLines.push(`\n#### ${comp.name}`);
+        if (comp.responsibility) archLines.push(`- **Responsibility**: ${comp.responsibility}`);
+        if (comp.technology) archLines.push(`- **Technology**: ${comp.technology}`);
+      });
+    }
+    if (arch.data_flow) archLines.push(`\n### Data Flow\n${arch.data_flow}`);
+    if (arch.integration_points && arch.integration_points.length > 0) {
+      archLines.push('\n### Integration Points');
+      arch.integration_points.forEach(point => archLines.push(`- ${point}`));
+    }
+    sections.push(archLines.join(''));
+  }
+
+  // Implementation Approach
+  if (llmContent.implementation_approach) {
+    const impl = llmContent.implementation_approach;
+    const implLines = ['## Implementation Approach'];
+    if (impl.phases && impl.phases.length > 0) {
+      implLines.push('\n### Phases');
+      impl.phases.forEach(phase => {
+        implLines.push(`\n#### ${phase.phase}`);
+        if (phase.description) implLines.push(phase.description);
+        if (phase.deliverables && phase.deliverables.length > 0) {
+          implLines.push('\n**Deliverables**:');
+          phase.deliverables.forEach(d => implLines.push(`- ${d}`));
+        }
+      });
+    }
+    if (impl.technical_decisions && impl.technical_decisions.length > 0) {
+      implLines.push('\n### Key Technical Decisions');
+      impl.technical_decisions.forEach(dec => implLines.push(`- ${dec}`));
+    }
+    sections.push(implLines.join(''));
+  }
+
+  // Test Scenarios
+  if (llmContent.test_scenarios && llmContent.test_scenarios.length > 0) {
+    sections.push(`## Test Scenarios
+
+${llmContent.test_scenarios.map(ts => {
+  const lines = [`### ${ts.id}: ${ts.scenario}`];
+  if (ts.test_type) lines.push(`\n**Type**: ${ts.test_type}`);
+  if (ts.given) lines.push(`\n**Given**: ${ts.given}`);
+  if (ts.when) lines.push(`\n**When**: ${ts.when}`);
+  if (ts.then) lines.push(`\n**Then**: ${ts.then}`);
+  return lines.join('');
+}).join('\n\n')}`);
+  }
+
+  // Acceptance Criteria
+  if (llmContent.acceptance_criteria && llmContent.acceptance_criteria.length > 0) {
+    sections.push(`## Acceptance Criteria
+
+${llmContent.acceptance_criteria.map((ac, i) => `${i + 1}. ${ac}`).join('\n')}`);
+  }
+
+  // Risks
+  if (llmContent.risks && llmContent.risks.length > 0) {
+    sections.push(`## Risks & Mitigations
+
+${llmContent.risks.map(risk => {
+  const lines = [`### ${risk.risk}`];
+  if (risk.probability) lines.push(`\n**Probability**: ${risk.probability}`);
+  if (risk.impact) lines.push(`\n**Impact**: ${risk.impact}`);
+  if (risk.mitigation) lines.push(`\n**Mitigation**: ${risk.mitigation}`);
+  if (risk.rollback_plan) lines.push(`\n**Rollback Plan**: ${risk.rollback_plan}`);
+  return lines.join('');
+}).join('\n\n')}`);
+  }
+
+  sections.push(`
+---
+*Generated by LLM PRD Content Generation (GPT 5.2)*
+*Date: ${new Date().toISOString()}*`);
+
+  return sections.join('\n\n');
+}
+
+/**
+ * Create default PRD checklists
+ *
+ * @param {Object|null} llmContent - LLM-generated content (optional)
+ * @returns {Object} Object with plan, exec, and validation checklists
+ */
+export function createDefaultChecklists(llmContent = null) {
+  const planChecklist = [
+    { text: 'PRD created and saved', checked: true },
+    { text: 'SD requirements mapped to technical specs', checked: !!llmContent },
+    { text: 'Technical architecture defined', checked: !!llmContent?.system_architecture },
+    { text: 'Implementation approach documented', checked: !!llmContent?.implementation_approach },
+    { text: 'Test scenarios defined', checked: llmContent?.test_scenarios?.length > 0 },
+    { text: 'Acceptance criteria established', checked: llmContent?.acceptance_criteria?.length > 0 },
+    { text: 'Resource requirements estimated', checked: false },
+    { text: 'Timeline and milestones set', checked: false },
+    { text: 'Risk assessment completed', checked: llmContent?.risks?.length > 0 }
+  ];
+
+  const execChecklist = [
+    { text: 'Development environment setup', checked: false },
+    { text: 'Core functionality implemented', checked: false },
+    { text: 'Unit tests written', checked: false },
+    { text: 'Integration tests completed', checked: false },
+    { text: 'Code review completed', checked: false },
+    { text: 'Documentation updated', checked: false }
+  ];
+
+  const validationChecklist = [
+    { text: 'All acceptance criteria met', checked: false },
+    { text: 'Performance requirements validated', checked: false },
+    { text: 'Security review completed', checked: false },
+    { text: 'User acceptance testing passed', checked: false },
+    { text: 'Deployment readiness confirmed', checked: false }
+  ];
+
+  return { planChecklist, execChecklist, validationChecklist };
+}
+
+/**
+ * Calculate PRD progress from checklist
+ *
+ * @param {Array} checklist - Checklist items
+ * @returns {number} Progress percentage (0-100)
+ */
+export function calculateProgress(checklist) {
+  if (!checklist || checklist.length === 0) return 0;
+  const checkedCount = checklist.filter(item => item.checked).length;
+  return Math.round((checkedCount / checklist.length) * 100);
+}

--- a/scripts/modules/prd-generator/context-builder.js
+++ b/scripts/modules/prd-generator/context-builder.js
@@ -1,0 +1,474 @@
+/**
+ * Context Builder for PRD Generator
+ * Part of SD-LEO-REFACTOR-PRD-DB-001
+ *
+ * Builds comprehensive context strings for LLM PRD generation
+ */
+
+import {
+  formatArrayField,
+  formatRisks,
+  formatObjectives,
+  formatMetadata,
+  formatVisionSpecs,
+  formatGovernance
+} from './format-helpers.js';
+
+/**
+ * Build comprehensive context string for PRD generation
+ * Includes ALL available SD metadata for thorough PRD generation
+ * Also includes existing user stories for consistency
+ *
+ * @param {Object} sd - Strategic Directive data
+ * @param {Object} context - Additional context (design analysis, database analysis, personas)
+ * @returns {string} Complete context string for LLM
+ */
+export function buildPRDGenerationContext(sd, context = {}) {
+  const sections = [];
+
+  // 1. Strategic Directive Context - COMPREHENSIVE
+  sections.push(`## STRATEGIC DIRECTIVE - COMPLETE CONTEXT
+
+**ID**: ${sd.id || sd.legacy_id}
+**Legacy ID**: ${sd.legacy_id || 'N/A'}
+**Title**: ${sd.title || 'Untitled'}
+**Type**: ${sd.sd_type || sd.category || 'feature'}
+**Category**: ${sd.category || 'Not specified'}
+**Priority**: ${sd.priority || 'Not specified'}
+**Status**: ${sd.status || 'draft'}
+
+### Description
+${sd.description || 'No description provided'}
+
+### Scope
+${sd.scope || 'No scope defined'}
+
+### Rationale
+${sd.rationale || 'No rationale provided'}
+
+### Strategic Objectives
+${formatObjectives(sd.strategic_objectives)}
+
+### Success Criteria
+${formatArrayField(sd.success_criteria, 'success criterion')}
+
+### Key Changes
+${formatArrayField(sd.key_changes, 'key change')}
+
+### Success Metrics
+${formatArrayField(sd.success_metrics, 'success metric')}
+
+### Dependencies
+${formatArrayField(sd.dependencies, 'dependency')}
+
+### Risks
+${formatRisks(sd.risks)}
+
+### Target Application
+${sd.target_application || 'EHG_Engineer'}`);
+
+  // 2. SD Metadata (contains vision specs, governance, etc.)
+  if (sd.metadata && Object.keys(sd.metadata).length > 0) {
+    sections.push(`## SD METADATA (Extended Context)
+
+${formatMetadata(sd.metadata)}`);
+  }
+
+  // 3. Design Analysis (if available) - Extended
+  if (context.designAnalysis) {
+    sections.push(`## DESIGN ANALYSIS (from DESIGN sub-agent)
+
+This analysis defines the UI/UX requirements and user workflows:
+
+${typeof context.designAnalysis === 'string'
+  ? context.designAnalysis.substring(0, 5000)
+  : JSON.stringify(context.designAnalysis, null, 2).substring(0, 5000)}`);
+  }
+
+  // 4. Database Analysis (if available) - Extended
+  if (context.databaseAnalysis) {
+    sections.push(`## DATABASE ANALYSIS (from DATABASE sub-agent)
+
+This analysis defines schema requirements and data architecture:
+
+${typeof context.databaseAnalysis === 'string'
+  ? context.databaseAnalysis.substring(0, 5000)
+  : JSON.stringify(context.databaseAnalysis, null, 2).substring(0, 5000)}`);
+  }
+
+  // 4.1 Security Analysis (if available)
+  if (context.securityAnalysis) {
+    sections.push(`## SECURITY ANALYSIS (from SECURITY sub-agent)
+
+This analysis defines authentication, authorization, and security requirements:
+
+${typeof context.securityAnalysis === 'string'
+  ? context.securityAnalysis.substring(0, 4000)
+  : JSON.stringify(context.securityAnalysis, null, 2).substring(0, 4000)}`);
+  }
+
+  // 4.2 Risk Analysis (if available)
+  if (context.riskAnalysis) {
+    sections.push(`## RISK ANALYSIS (from RISK sub-agent)
+
+This analysis identifies implementation risks and mitigation strategies:
+
+${typeof context.riskAnalysis === 'string'
+  ? context.riskAnalysis.substring(0, 4000)
+  : JSON.stringify(context.riskAnalysis, null, 2).substring(0, 4000)}`);
+  }
+
+  // 5. Persona Context (if available) - Extended
+  if (context.personas && context.personas.length > 0) {
+    sections.push(`## STAKEHOLDER PERSONAS
+
+These personas represent the users who will interact with this feature:
+
+${context.personas.map(p => {
+  const details = [];
+  details.push(`### ${p.name}`);
+  if (p.role) details.push(`**Role**: ${p.role}`);
+  if (p.description) details.push(`**Description**: ${p.description}`);
+  if (p.goals) details.push(`**Goals**: ${Array.isArray(p.goals) ? p.goals.join(', ') : p.goals}`);
+  if (p.pain_points) details.push(`**Pain Points**: ${Array.isArray(p.pain_points) ? p.pain_points.join(', ') : p.pain_points}`);
+  return details.join('\n');
+}).join('\n\n')}`);
+  }
+
+  // 6. Vision Spec References (if in metadata)
+  if (sd.metadata?.vision_spec_references) {
+    sections.push(`## VISION SPECIFICATION REFERENCES
+
+${formatVisionSpecs(sd.metadata.vision_spec_references)}`);
+  }
+
+  // 7. Governance Requirements (if in metadata)
+  if (sd.metadata?.governance) {
+    sections.push(`## GOVERNANCE REQUIREMENTS
+
+${formatGovernance(sd.metadata.governance)}`);
+  }
+
+  // 8. Existing User Stories (for consistency if PRD being regenerated)
+  if (context.existingStories && context.existingStories.length > 0) {
+    sections.push(`## EXISTING USER STORIES (Ensure PRD Consistency)
+
+The following user stories already exist for this SD. The PRD MUST be consistent with these stories:
+
+${context.existingStories.map(story => {
+  const lines = [`### ${story.story_key}: ${story.title}`];
+  if (story.user_role) lines.push(`**As a** ${story.user_role}`);
+  if (story.user_want) lines.push(`**I want** ${story.user_want}`);
+  if (story.user_benefit) lines.push(`**So that** ${story.user_benefit}`);
+  if (story.acceptance_criteria && story.acceptance_criteria.length > 0) {
+    lines.push('\n**Acceptance Criteria**:');
+    story.acceptance_criteria.forEach(ac => {
+      if (typeof ac === 'string') {
+        lines.push(`- ${ac}`);
+      } else if (ac.criterion) {
+        lines.push(`- ${ac.criterion}`);
+      }
+    });
+  }
+  return lines.join('\n');
+}).join('\n\n')}`);
+  }
+
+  // 9. Generation Instructions - Comprehensive
+  sections.push(`## TASK - GENERATE COMPREHENSIVE PRD
+
+Using ALL the context above, generate a complete PRD that:
+
+1. **Is Implementation-Ready**: Every requirement must be specific enough for a developer to implement immediately without asking clarifying questions
+2. **Aligns with SD Objectives**: Each requirement must trace back to a strategic objective or success criterion
+3. **Incorporates Sub-Agent Analysis**: Use the design and database analysis to inform technical requirements and architecture
+4. **Addresses All Personas**: Ensure requirements cover the needs of identified stakeholders
+5. **Follows Vision Specs**: If vision spec references exist, ensure PRD aligns with those specifications
+6. **Identifies Real Risks**: Document genuine technical and business risks specific to THIS implementation
+7. **Defines Testable Criteria**: Every acceptance criterion must be verifiable through automated or manual testing
+8. **Consistent with User Stories**: If existing user stories are provided, the PRD functional requirements MUST support and align with those stories. Do not contradict user story acceptance criteria.
+
+### Minimum Content Requirements:
+- At least 5 functional requirements with acceptance criteria
+- At least 3 technical requirements
+- At least 5 test scenarios covering happy path, edge cases, and error conditions
+- At least 3 identified risks with mitigation strategies
+- Complete system architecture with components and data flow
+
+Return the PRD as a valid JSON object following the schema in the system prompt.`);
+
+  return sections.join('\n\n');
+}
+
+/**
+ * Build design agent prompt
+ *
+ * @param {string} sdId - SD ID
+ * @param {Object} sdData - SD data
+ * @param {string} personaContextBlock - Persona context string
+ * @returns {string} Design agent prompt
+ */
+export function buildDesignAgentPrompt(sdId, sdData, personaContextBlock = '') {
+  return `Analyze UI/UX design and user workflows for Strategic Directive: ${sdId}
+
+## STRATEGIC DIRECTIVE - COMPLETE CONTEXT
+
+**ID**: ${sdData.id || sdId}
+**Legacy ID**: ${sdData.legacy_id || 'N/A'}
+**Title**: ${sdData.title || 'N/A'}
+**Type**: ${sdData.sd_type || sdData.category || 'feature'}
+**Category**: ${sdData.category || 'Not specified'}
+**Priority**: ${sdData.priority || 'Not specified'}
+
+**Scope**: ${sdData.scope || 'N/A'}
+**Description**: ${sdData.description || 'N/A'}
+**Rationale**: ${sdData.rationale || 'N/A'}
+
+**Strategic Objectives**:
+${formatObjectives(sdData.strategic_objectives)}
+
+**Success Criteria**:
+${formatArrayField(sdData.success_criteria, 'criterion')}
+
+**Key Changes**:
+${formatArrayField(sdData.key_changes, 'change')}
+
+**Success Metrics**:
+${formatArrayField(sdData.success_metrics, 'metric')}
+
+**Dependencies**:
+${formatArrayField(sdData.dependencies, 'dependency')}
+
+**Known Risks**:
+${formatRisks(sdData.risks)}
+
+**Target Application**: ${sdData.target_application || 'EHG_Engineer'}
+
+${sdData.metadata ? `## SD METADATA (Extended Context)\n${formatMetadata(sdData.metadata)}` : ''}
+${personaContextBlock ? `\n${personaContextBlock}` : ''}
+**Task**:
+1. Identify user workflows and interaction patterns
+2. Determine UI components and layouts needed
+3. Analyze user journey and navigation flows
+4. Identify data that users will view/create/edit
+5. Determine what user actions trigger database changes
+
+**Output Format**:
+{
+  "user_workflows": [
+    {
+      "workflow_name": "Workflow 1",
+      "steps": ["step1", "step2"],
+      "user_actions": ["create", "edit", "delete"],
+      "data_displayed": ["field1", "field2"],
+      "data_modified": ["field1", "field2"]
+    }
+  ],
+  "ui_components_needed": ["component1", "component2"],
+  "user_journey": "Description of user flow",
+  "data_requirements": {
+    "fields_to_display": ["field1", "field2"],
+    "fields_to_edit": ["field1"],
+    "relationships": ["parent_entity -> child_entity"]
+  }
+}
+
+Please analyze user workflows and design requirements.`;
+}
+
+/**
+ * Build database agent prompt
+ *
+ * @param {string} sdId - SD ID
+ * @param {Object} sdData - SD data
+ * @param {string} designAnalysis - Design analysis output (optional)
+ * @param {string} personaContextBlock - Persona context string
+ * @returns {string} Database agent prompt
+ */
+export function buildDatabaseAgentPrompt(sdId, sdData, designAnalysis = null, personaContextBlock = '') {
+  return `Analyze database schema for Strategic Directive: ${sdId}
+
+## STRATEGIC DIRECTIVE - COMPLETE CONTEXT
+
+**ID**: ${sdData.id || sdId}
+**Legacy ID**: ${sdData.legacy_id || 'N/A'}
+**Title**: ${sdData.title || 'N/A'}
+**Type**: ${sdData.sd_type || sdData.category || 'feature'}
+**Category**: ${sdData.category || 'Not specified'}
+**Priority**: ${sdData.priority || 'Not specified'}
+
+**Scope**: ${sdData.scope || 'N/A'}
+**Description**: ${sdData.description || 'N/A'}
+**Rationale**: ${sdData.rationale || 'N/A'}
+
+**Strategic Objectives**:
+${formatObjectives(sdData.strategic_objectives)}
+
+**Success Criteria**:
+${formatArrayField(sdData.success_criteria, 'criterion')}
+
+**Key Changes**:
+${formatArrayField(sdData.key_changes, 'change')}
+
+**Success Metrics**:
+${formatArrayField(sdData.success_metrics, 'metric')}
+
+**Dependencies**:
+${formatArrayField(sdData.dependencies, 'dependency')}
+
+**Known Risks**:
+${formatRisks(sdData.risks)}
+
+**Target Application**: ${sdData.target_application || 'EHG_Engineer'}
+
+${sdData.metadata ? `## SD METADATA (Extended Context)\n${formatMetadata(sdData.metadata)}` : ''}
+${personaContextBlock ? `\n${personaContextBlock}` : ''}
+${designAnalysis ? `
+**DESIGN ANALYSIS CONTEXT** (from DESIGN sub-agent):
+${designAnalysis}
+
+Use this design analysis to understand:
+- What data users will view/create/edit (drives table structure)
+- User workflows and actions (drives CRUD requirements)
+- UI component data needs (drives column selection)
+- Data relationships (drives foreign keys and joins)
+` : ''}
+
+**Task**:
+1. Review the EHG_Engineer database schema documentation at docs/reference/schema/engineer/database-schema-overview.md
+2. ${designAnalysis ? 'Based on design analysis, ' : ''}Identify which tables will be affected by this SD
+3. Recommend specific database changes (new tables, new columns, modified columns, new RLS policies)
+4. ${designAnalysis ? 'Ensure schema supports all user workflows identified in design analysis' : 'Provide technical_approach recommendations for database integration'}
+5. List any schema dependencies or constraints to be aware of
+
+**Output Format**:
+{
+  "affected_tables": ["table1", "table2"],
+  "new_tables": [
+    {
+      "name": "table_name",
+      "purpose": "description",
+      "key_columns": ["col1", "col2"]
+    }
+  ],
+  "table_modifications": [
+    {
+      "table": "existing_table",
+      "changes": ["add column x", "modify column y"]
+    }
+  ],
+  "rls_policies_needed": ["policy description 1", "policy description 2"],
+  "technical_approach": "Detailed technical approach for database integration",
+  "dependencies": ["dependency 1", "dependency 2"],
+  "migration_complexity": "LOW|MEDIUM|HIGH",
+  "estimated_migration_lines": 50
+}
+
+Please analyze and provide structured recommendations.`;
+}
+
+/**
+ * Build security agent prompt
+ *
+ * @param {string} sdId - SD ID
+ * @param {Object} sdData - SD data
+ * @param {string} sdType - SD type
+ * @returns {string} Security agent prompt
+ */
+export function buildSecurityAgentPrompt(sdId, sdData, sdType) {
+  return `Analyze security requirements for Strategic Directive: ${sdId}
+
+## STRATEGIC DIRECTIVE - SECURITY ANALYSIS CONTEXT
+
+**ID**: ${sdData.id || sdId}
+**Title**: ${sdData.title || 'N/A'}
+**Type**: ${sdType}
+**Scope**: ${sdData.scope || 'N/A'}
+**Description**: ${sdData.description || 'N/A'}
+
+${sdData.metadata ? `## SD METADATA\n${formatMetadata(sdData.metadata)}` : ''}
+
+**Task**:
+1. Identify authentication requirements (login flows, session management)
+2. Analyze authorization needs (roles, permissions, RLS policies)
+3. Identify data access boundaries and sensitivity levels
+4. Recommend security test scenarios
+5. Identify potential security risks and mitigations
+
+**Output Format**:
+{
+  "auth_requirements": ["requirement1", "requirement2"],
+  "authorization_model": {
+    "roles": ["role1", "role2"],
+    "permissions": ["permission1", "permission2"],
+    "rls_policies_needed": ["policy1", "policy2"]
+  },
+  "data_sensitivity": {
+    "sensitive_fields": ["field1", "field2"],
+    "protection_mechanisms": ["encryption", "masking"]
+  },
+  "security_test_scenarios": ["scenario1", "scenario2"],
+  "security_risks": [
+    {
+      "risk": "risk description",
+      "mitigation": "mitigation strategy"
+    }
+  ]
+}`;
+}
+
+/**
+ * Build risk agent prompt
+ *
+ * @param {string} sdId - SD ID
+ * @param {Object} sdData - SD data
+ * @param {string} sdType - SD type
+ * @returns {string} Risk agent prompt
+ */
+export function buildRiskAgentPrompt(sdId, sdData, sdType) {
+  return `Analyze implementation risks for Strategic Directive: ${sdId}
+
+## STRATEGIC DIRECTIVE - RISK ANALYSIS CONTEXT
+
+**ID**: ${sdData.id || sdId}
+**Title**: ${sdData.title || 'N/A'}
+**Type**: ${sdType}
+**Scope**: ${sdData.scope || 'N/A'}
+**Description**: ${sdData.description || 'N/A'}
+**Rationale**: ${sdData.rationale || 'N/A'}
+
+**Strategic Objectives**:
+${formatObjectives(sdData.strategic_objectives)}
+
+**Dependencies**:
+${formatArrayField(sdData.dependencies, 'dependency')}
+
+**Known Risks from SD**:
+${formatRisks(sdData.risks)}
+
+${sdData.metadata ? `## SD METADATA\n${formatMetadata(sdData.metadata)}` : ''}
+
+**Task**:
+1. Identify technical implementation risks specific to this SD
+2. Assess probability and impact of each risk
+3. Propose concrete mitigation strategies
+4. Define rollback plans for critical changes
+5. Suggest monitoring strategies to detect issues early
+
+**Output Format**:
+{
+  "technical_risks": [
+    {
+      "risk": "specific risk description",
+      "probability": "HIGH|MEDIUM|LOW",
+      "impact": "HIGH|MEDIUM|LOW",
+      "mitigation": "concrete mitigation strategy",
+      "rollback_plan": "rollback approach if this fails",
+      "monitoring": "how to detect early warning signs"
+    }
+  ],
+  "dependency_risks": ["risk from dependency 1"],
+  "timeline_risks": ["potential delays"],
+  "overall_risk_level": "HIGH|MEDIUM|LOW"
+}`;
+}

--- a/scripts/modules/prd-generator/format-helpers.js
+++ b/scripts/modules/prd-generator/format-helpers.js
@@ -1,0 +1,137 @@
+/**
+ * Format Helpers for PRD Generator
+ * Part of SD-LEO-REFACTOR-PRD-DB-001
+ *
+ * Utility functions for formatting SD data into context strings
+ */
+
+/**
+ * Format array fields for context
+ *
+ * @param {Array} arr - Array to format
+ * @param {string} itemName - Name of items for "no items" message
+ * @returns {string} Formatted string
+ */
+export function formatArrayField(arr, itemName) {
+  if (!arr || !Array.isArray(arr) || arr.length === 0) {
+    return `- No ${itemName}s defined`;
+  }
+  return arr.map((item, i) => {
+    if (typeof item === 'string') return `${i + 1}. ${item}`;
+    return `${i + 1}. ${item.text || item.description || item.name || JSON.stringify(item)}`;
+  }).join('\n');
+}
+
+/**
+ * Format risks for context
+ *
+ * @param {Array} risks - Risks array
+ * @returns {string} Formatted risks string
+ */
+export function formatRisks(risks) {
+  if (!risks || !Array.isArray(risks) || risks.length === 0) {
+    return '- No risks identified';
+  }
+  return risks.map((risk, i) => {
+    if (typeof risk === 'string') return `${i + 1}. ${risk}`;
+    const parts = [`${i + 1}. ${risk.risk || risk.description || risk.name || 'Unknown risk'}`];
+    if (risk.mitigation) parts.push(`   Mitigation: ${risk.mitigation}`);
+    if (risk.probability) parts.push(`   Probability: ${risk.probability}`);
+    if (risk.impact) parts.push(`   Impact: ${risk.impact}`);
+    return parts.join('\n');
+  }).join('\n');
+}
+
+/**
+ * Format strategic objectives for context
+ *
+ * @param {Array|Object|string} objectives - Objectives to format
+ * @returns {string} Formatted objectives string
+ */
+export function formatObjectives(objectives) {
+  if (!objectives) return '- No objectives defined';
+  if (Array.isArray(objectives)) {
+    return objectives.map((obj, i) => {
+      if (typeof obj === 'string') return `${i + 1}. ${obj}`;
+      return `${i + 1}. ${obj.objective || obj.description || JSON.stringify(obj)}`;
+    }).join('\n');
+  }
+  return JSON.stringify(objectives);
+}
+
+/**
+ * Format metadata for context - extracts important fields
+ *
+ * @param {Object} metadata - SD metadata object
+ * @returns {string} Formatted metadata string
+ */
+export function formatMetadata(metadata) {
+  const sections = [];
+
+  // Skip deeply nested or very long fields
+  const skipKeys = ['vision_spec_references', 'governance', 'vision_discovery'];
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (skipKeys.includes(key)) continue;
+    if (value === null || value === undefined) continue;
+
+    if (typeof value === 'string') {
+      sections.push(`**${key}**: ${value}`);
+    } else if (Array.isArray(value)) {
+      sections.push(`**${key}**: ${value.slice(0, 5).map(v => typeof v === 'string' ? v : JSON.stringify(v)).join(', ')}${value.length > 5 ? '...' : ''}`);
+    } else if (typeof value === 'object') {
+      // Shallow representation for objects
+      const objStr = JSON.stringify(value, null, 2).substring(0, 500);
+      sections.push(`**${key}**:\n\`\`\`json\n${objStr}\n\`\`\``);
+    }
+  }
+
+  return sections.join('\n\n') || 'No additional metadata';
+}
+
+/**
+ * Format vision spec references
+ *
+ * @param {Array|Object|string} specs - Vision spec references
+ * @returns {string} Formatted vision specs string
+ */
+export function formatVisionSpecs(specs) {
+  if (!specs) return 'No vision specs referenced';
+
+  if (Array.isArray(specs)) {
+    return specs.map((spec, i) => {
+      if (typeof spec === 'string') return `${i + 1}. ${spec}`;
+      return `${i + 1}. ${spec.name || spec.path || JSON.stringify(spec)}`;
+    }).join('\n');
+  }
+
+  if (typeof specs === 'object') {
+    return Object.entries(specs).map(([key, value]) => `- **${key}**: ${value}`).join('\n');
+  }
+
+  return String(specs);
+}
+
+/**
+ * Format governance requirements
+ *
+ * @param {Object} governance - Governance object
+ * @returns {string} Formatted governance string
+ */
+export function formatGovernance(governance) {
+  if (!governance) return 'No governance requirements';
+
+  const parts = [];
+
+  if (governance.strangler_pattern !== undefined) {
+    parts.push(`**Strangler Pattern**: ${governance.strangler_pattern ? 'Enabled' : 'Disabled'}`);
+  }
+  if (governance.workflow_policies) {
+    parts.push(`**Workflow Policies**: ${JSON.stringify(governance.workflow_policies)}`);
+  }
+  if (governance.creation_mode) {
+    parts.push(`**Creation Mode**: ${governance.creation_mode}`);
+  }
+
+  return parts.join('\n') || JSON.stringify(governance, null, 2);
+}

--- a/scripts/modules/prd-generator/index.js
+++ b/scripts/modules/prd-generator/index.js
@@ -1,0 +1,48 @@
+/**
+ * PRD Generator Module Index
+ * Part of SD-LEO-REFACTOR-PRD-DB-001
+ *
+ * This module provides PRD generation functionality,
+ * broken down into focused modules for maintainability.
+ */
+
+// Configuration
+export { LLM_PRD_CONFIG, PRD_QUALITY_RUBRIC_CRITERIA, buildSystemPrompt } from './config.js';
+
+// Format Helpers
+export {
+  formatArrayField,
+  formatRisks,
+  formatObjectives,
+  formatMetadata,
+  formatVisionSpecs,
+  formatGovernance
+} from './format-helpers.js';
+
+// Context Builder
+export {
+  buildPRDGenerationContext,
+  buildDesignAgentPrompt,
+  buildDatabaseAgentPrompt,
+  buildSecurityAgentPrompt,
+  buildRiskAgentPrompt
+} from './context-builder.js';
+
+// LLM Generator
+export { generatePRDContentWithLLM } from './llm-generator.js';
+
+// Content Formatter
+export {
+  formatPRDContent,
+  createDefaultChecklists,
+  calculateProgress
+} from './content-formatter.js';
+
+// Sub-Agent Runners
+export {
+  runDesignAgent,
+  runDatabaseAgent,
+  runSecurityAgent,
+  runRiskAgent,
+  updatePRDWithAnalyses
+} from './sub-agent-runners.js';

--- a/scripts/modules/prd-generator/llm-generator.js
+++ b/scripts/modules/prd-generator/llm-generator.js
@@ -1,0 +1,87 @@
+/**
+ * LLM-Based PRD Content Generator
+ * Part of SD-LEO-REFACTOR-PRD-DB-001
+ *
+ * Uses GPT 5.2 to generate actual PRD content instead of placeholder text
+ */
+
+import OpenAI from 'openai';
+import { LLM_PRD_CONFIG, buildSystemPrompt } from './config.js';
+import { buildPRDGenerationContext } from './context-builder.js';
+
+/**
+ * Generate PRD content using LLM (GPT 5.2)
+ *
+ * @param {Object} sd - Strategic Directive data
+ * @param {Object} context - Additional context (design analysis, database analysis, personas)
+ * @returns {Promise<Object|null>} Generated PRD content or null if failed
+ */
+export async function generatePRDContentWithLLM(sd, context = {}) {
+  if (!LLM_PRD_CONFIG.enabled) {
+    console.log('   \u2139\ufe0f  LLM PRD generation disabled via LLM_PRD_GENERATION=false');
+    return null;
+  }
+
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (!openaiKey) {
+    console.warn('   \u26a0\ufe0f  OPENAI_API_KEY not set, falling back to template PRD');
+    return null;
+  }
+
+  const openai = new OpenAI({ apiKey: openaiKey });
+  const sdType = sd.sd_type || sd.category || 'feature';
+
+  console.log('   \ud83e\udd16 Generating PRD content with GPT 5.2...');
+  console.log(`   \ud83d\udccb SD Type: ${sdType}`);
+
+  try {
+    const systemPrompt = buildSystemPrompt(sdType);
+    const userPrompt = buildPRDGenerationContext(sd, context);
+
+    const response = await openai.chat.completions.create({
+      model: LLM_PRD_CONFIG.model,
+      temperature: LLM_PRD_CONFIG.temperature,
+      max_completion_tokens: LLM_PRD_CONFIG.maxTokens,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt }
+      ]
+    });
+
+    const content = response.choices[0]?.message?.content;
+    const finishReason = response.choices[0]?.finish_reason;
+
+    if (!content) {
+      console.warn('   \u26a0\ufe0f  LLM returned empty content');
+      return null;
+    }
+
+    if (finishReason === 'length') {
+      console.warn('   \u26a0\ufe0f  LLM response truncated (token limit), attempting parse anyway');
+    }
+
+    // Parse JSON response
+    const jsonMatch = content.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      console.warn('   \u26a0\ufe0f  Could not extract JSON from LLM response');
+      console.log('   Response preview:', content.substring(0, 500));
+      return null;
+    }
+
+    const prdContent = JSON.parse(jsonMatch[0]);
+
+    console.log('   \u2705 PRD content generated successfully');
+    console.log(`   \ud83d\udcca Generated: ${prdContent.functional_requirements?.length || 0} functional requirements`);
+    console.log(`   \ud83d\udcca Generated: ${prdContent.test_scenarios?.length || 0} test scenarios`);
+    console.log(`   \ud83d\udcca Generated: ${prdContent.risks?.length || 0} risks identified`);
+
+    return prdContent;
+
+  } catch (error) {
+    console.error('   \u274c LLM PRD generation failed:', error.message);
+    if (error.response?.data) {
+      console.error('   API Error:', JSON.stringify(error.response.data, null, 2));
+    }
+    return null;
+  }
+}

--- a/scripts/modules/prd-generator/sub-agent-runners.js
+++ b/scripts/modules/prd-generator/sub-agent-runners.js
@@ -1,0 +1,191 @@
+/**
+ * Sub-Agent Runners for PRD Generator
+ * Part of SD-LEO-REFACTOR-PRD-DB-001
+ *
+ * Functions to run DESIGN, DATABASE, SECURITY, and RISK sub-agents
+ */
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * Run a sub-agent with a prompt file
+ *
+ * @param {string} agentType - Sub-agent type (DESIGN, DATABASE, SECURITY, RISK)
+ * @param {string} prompt - Prompt content
+ * @param {Object} options - Options
+ * @returns {Promise<string|null>} Agent output or null on failure
+ */
+async function runSubAgent(agentType, prompt, options = {}) {
+  const { timeout = 120000, maxBuffer = 10 * 1024 * 1024 } = options;
+
+  // Write prompt to temp file
+  const promptFile = path.join('/tmp', `${agentType.toLowerCase()}-agent-prompt-${Date.now()}.txt`);
+
+  try {
+    fs.writeFileSync(promptFile, prompt);
+    console.log('\ud83d\udcdd Prompt written to:', promptFile);
+    console.log(`\n\ud83e\udd16 Executing ${agentType} sub-agent...\n`);
+
+    const output = execSync(
+      `node lib/sub-agent-executor.js ${agentType} --context-file "${promptFile}"`,
+      {
+        encoding: 'utf-8',
+        maxBuffer,
+        timeout
+      }
+    );
+
+    console.log(`\u2705 ${agentType} analysis complete!\n`);
+    console.log('\u2500'.repeat(53));
+    console.log(output);
+    console.log('\u2500'.repeat(53) + '\n');
+
+    // Clean up temp file
+    fs.unlinkSync(promptFile);
+
+    return output;
+  } catch (error) {
+    console.warn(`\u26a0\ufe0f  ${agentType} analysis failed:`, error.message);
+    console.log(`   Continuing without ${agentType} analysis...\n`);
+
+    // Clean up temp file if it exists
+    try {
+      fs.unlinkSync(promptFile);
+    } catch {
+      // Ignore cleanup errors
+    }
+
+    return null;
+  }
+}
+
+/**
+ * Run DESIGN sub-agent
+ *
+ * @param {string} prompt - Design agent prompt
+ * @returns {Promise<string|null>} Design analysis output
+ */
+export async function runDesignAgent(prompt) {
+  console.log('\n\u2550'.repeat(55));
+  console.log('\ud83c\udfa8 PHASE 1: DESIGN ANALYSIS');
+  console.log('\u2550'.repeat(55));
+  console.log('\ud83d\udd0d Invoking DESIGN sub-agent to analyze UI/UX workflows...\n');
+
+  return runSubAgent('DESIGN', prompt);
+}
+
+/**
+ * Run DATABASE sub-agent
+ *
+ * @param {string} prompt - Database agent prompt
+ * @returns {Promise<string|null>} Database analysis output
+ */
+export async function runDatabaseAgent(prompt) {
+  console.log('\n\u2550'.repeat(55));
+  console.log('\ud83d\udcca PHASE 2: DATABASE SCHEMA ANALYSIS');
+  console.log('\u2550'.repeat(55));
+  console.log('\ud83d\udd0d Invoking DATABASE sub-agent to analyze schema and recommend changes...\n');
+
+  return runSubAgent('DATABASE', prompt);
+}
+
+/**
+ * Run SECURITY sub-agent (conditional - only for security-related SDs)
+ *
+ * @param {Object} sdData - SD data
+ * @param {string} prompt - Security agent prompt
+ * @returns {Promise<string|null>} Security analysis output
+ */
+export async function runSecurityAgent(sdData, prompt) {
+  const sdType = sdData.sd_type || sdData.category || 'feature';
+  const needsSecurity = sdType === 'security' ||
+                       sdData.scope?.toLowerCase().includes('auth') ||
+                       sdData.scope?.toLowerCase().includes('security') ||
+                       sdData.description?.toLowerCase().includes('permission') ||
+                       sdData.description?.toLowerCase().includes('rls');
+
+  if (!needsSecurity) {
+    return null;
+  }
+
+  console.log('\n\u2550'.repeat(55));
+  console.log('\ud83d\udd12 PHASE 2.1: SECURITY ANALYSIS');
+  console.log('\u2550'.repeat(55));
+  console.log('\ud83d\udd0d Invoking SECURITY sub-agent to analyze security requirements...\n');
+
+  return runSubAgent('SECURITY', prompt);
+}
+
+/**
+ * Run RISK sub-agent
+ *
+ * @param {string} prompt - Risk agent prompt
+ * @returns {Promise<string|null>} Risk analysis output
+ */
+export async function runRiskAgent(prompt) {
+  console.log('\n\u2550'.repeat(55));
+  console.log('\u26a0\ufe0f  PHASE 2.2: RISK ANALYSIS');
+  console.log('\u2550'.repeat(55));
+  console.log('\ud83d\udd0d Invoking RISK sub-agent to assess implementation risks...\n');
+
+  return runSubAgent('RISK', prompt);
+}
+
+/**
+ * Update PRD with analysis metadata
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} prdId - PRD ID
+ * @param {string} sdId - SD ID
+ * @param {Object} sdData - SD data
+ * @param {Object} analyses - Object with designAnalysis, databaseAnalysis
+ */
+export async function updatePRDWithAnalyses(supabase, prdId, sdId, sdData, analyses) {
+  const { designAnalysis, databaseAnalysis } = analyses;
+
+  if (!designAnalysis && !databaseAnalysis) return;
+
+  const metadata = {};
+
+  if (designAnalysis) {
+    metadata.design_analysis = {
+      generated_at: new Date().toISOString(),
+      sd_context: {
+        id: sdId,
+        title: sdData.title,
+        scope: sdData.scope
+      },
+      raw_analysis: designAnalysis.substring(0, 5000)
+    };
+  }
+
+  if (databaseAnalysis) {
+    metadata.database_analysis = {
+      generated_at: new Date().toISOString(),
+      sd_context: {
+        id: sdId,
+        title: sdData.title,
+        scope: sdData.scope
+      },
+      raw_analysis: databaseAnalysis.substring(0, 5000),
+      design_informed: !!designAnalysis
+    };
+  }
+
+  const { error: updateError } = await supabase
+    .from('product_requirements_v2')
+    .update({ metadata })
+    .eq('id', prdId);
+
+  if (updateError) {
+    console.warn('\u26a0\ufe0f  Failed to update PRD with analyses:', updateError.message);
+  } else {
+    console.log('\u2705 PRD updated with design + database schema analyses\n');
+  }
+}


### PR DESCRIPTION
## Summary

Part of SD-LEO-REFACTOR-PRD-DB-001 (Child 3 of SD-LEO-REFACTOR-LARGE-FILES-002)

- Extracts add-prd-to-database.js (1,770 LOC) into 7 focused modules
- All modules under 500 LOC target (largest: context-builder.js at 474 LOC)
- 23 exports tested with dynamic import
- ESLint clean, smoke tests pass

### Modules Created (1,286 LOC total)

| Module | LOC | Purpose |
|--------|-----|---------|
| config.js | 154 | LLM config and quality rubric |
| format-helpers.js | 137 | Array/object formatting utilities |
| context-builder.js | 474 | PRD context and agent prompts |
| llm-generator.js | 87 | GPT 5.2 PRD generation |
| content-formatter.js | 195 | Markdown PRD formatting |
| sub-agent-runners.js | 191 | DESIGN/DATABASE/SECURITY/RISK runners |
| index.js | 48 | Module exports |

## Test plan

- [x] Dynamic import test passes (23 exports load correctly)
- [x] ESLint passes with no errors
- [x] Smoke tests pass (15 tests)
- [x] DOCMON database-first compliance check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)