### PR TITLE
feat(leo): add Gate 0 pre-commit SD status validation

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -275,8 +275,51 @@ fi
 echo "✅ Work accumulation check complete"
 
 # ============================================================================
-# STAGE 6: Root Temp File Warning (NON-BLOCKING)
+# STAGE 7: SD Status Validation - Gate 0 (BLOCKING)
 # ============================================================================
+# SD-LEO-GATE0-PRECOMMIT-001: Prevents commits when referenced SD is in draft
+# status or LEAD_APPROVAL phase. Ensures LEO Protocol workflow is followed.
+# ============================================================================
+echo ""
+echo "🔍 Running Gate 0: SD Status Validation..."
+
+# Get commit message (try reading from staged commit or file)
+# During commit, the message is passed via stdin or COMMIT_EDITMSG
+COMMIT_MSG=""
+if [ -f ".git/COMMIT_EDITMSG" ]; then
+  COMMIT_MSG=$(cat .git/COMMIT_EDITMSG 2>/dev/null || true)
+fi
+
+# Also check branch name for SD reference
+if [ -z "$COMMIT_MSG" ]; then
+  COMMIT_MSG="$BRANCH"
+fi
+
+# Extract SD identifier pattern from commit message or branch name
+# Matches: SD-LEO-GATE0-001, SD-FEATURE-001, SD-LEO-REFACTOR-LARGE-FILES-002
+SD_ID=$(echo "$COMMIT_MSG $BRANCH" | grep -oE 'SD-[A-Z]+-[A-Z0-9]+-[0-9]+|SD-[A-Z]+-[0-9]+' | head -1)
+
+if [ ! -z "$SD_ID" ]; then
+  echo "   Found SD reference: $SD_ID"
+
+  # Run validation script
+  node scripts/validate-sd-commit.js "$SD_ID"
+  VALIDATION_EXIT=$?
+
+  if [ $VALIDATION_EXIT -ne 0 ]; then
+    exit 1
+  fi
+else
+  echo "   No SD reference found in branch/commit - skipping validation"
+  echo "   ℹ️  Non-SD branches (reports/, docs/) are allowed"
+fi
+
+echo "✅ Gate 0 validation complete"
+
+# ============================================================================
+# STAGE 8: Root Temp File Warning (NON-BLOCKING)
+# ============================================================================
+# (Renumbered from Stage 6 after Gate 0 addition in SD-LEO-GATE0-PRECOMMIT-001)
 echo ""
 echo "🧹 Checking for root temp files..."
 

--- a/scripts/validate-sd-commit.js
+++ b/scripts/validate-sd-commit.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * SD Commit Validation - Gate 0 Enforcement
+ *
+ * Validates that commits referencing Strategic Directives are only allowed
+ * when the SD is in an active state (not draft, past LEAD_APPROVAL phase).
+ *
+ * Part of SD-LEO-GATE0-PRECOMMIT-001: Pre-commit Hook: SD Phase Validation
+ *
+ * Usage: node scripts/validate-sd-commit.js <SD-ID>
+ * Exit codes:
+ *   0 - Validation passed (commit allowed)
+ *   1 - Validation failed (commit blocked)
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const BLOCKING_STATUSES = ['draft'];
+const BLOCKING_PHASES = ['LEAD_APPROVAL'];
+
+async function validateSDCommit(sdId) {
+  // Check environment variables
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    console.warn('⚠️  Warning: Supabase credentials not configured. Skipping Gate 0 validation.');
+    process.exit(0); // Fail-open
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  try {
+    // Query SD by various ID formats
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, title, status, current_phase')
+      .or(`id.eq.${sdId},legacy_id.eq.${sdId},sd_key.eq.${sdId}`)
+      .maybeSingle();
+
+    if (error) {
+      console.warn(`⚠️  Warning: Database query failed: ${error.message}`);
+      console.warn('   Skipping Gate 0 validation (fail-open).');
+      process.exit(0); // Fail-open on DB errors
+    }
+
+    if (!data) {
+      console.error('');
+      console.error('❌ BLOCKED: Strategic Directive not found in database');
+      console.error('═══════════════════════════════════════════════════════════');
+      console.error(`   Commit message references: ${sdId}`);
+      console.error('   Status: Not found in strategic_directives_v2');
+      console.error('');
+      console.error('   REMEDIATION:');
+      console.error('   1. Create SD first: npm run sd:create');
+      console.error('   2. OR use correct SD identifier');
+      console.error(`   3. Check database: npm run sd:status ${sdId}`);
+      console.error('');
+      console.error('   Emergency bypass (logged): git commit --no-verify');
+      console.error('');
+      process.exit(1);
+    }
+
+    const { sd_key, title, status, current_phase } = data;
+    const displayId = sd_key || sdId;
+
+    // Check for blocking status
+    if (BLOCKING_STATUSES.includes(status)) {
+      console.error('');
+      console.error('❌ BLOCKED: SD is in DRAFT status');
+      console.error('═══════════════════════════════════════════════════════════');
+      console.error(`   SD: ${displayId}`);
+      console.error(`   Title: ${title}`);
+      console.error(`   Current Status: ${status}`);
+      console.error(`   Current Phase: ${current_phase}`);
+      console.error('');
+      console.error('   REASON: Commits are not allowed until SD passes LEAD approval.');
+      console.error('   This ensures work is validated BEFORE code changes begin.');
+      console.error('');
+      console.error('   REMEDIATION:');
+      console.error('   1. Complete LEAD-TO-PLAN handoff:');
+      console.error(`      node scripts/handoff.js execute LEAD-TO-PLAN ${displayId}`);
+      console.error('   2. Retry commit after handoff');
+      console.error('');
+      console.error(`   To check SD status: npm run sd:status ${displayId}`);
+      console.error('');
+      console.error('   Emergency bypass (not recommended): git commit --no-verify');
+      console.error('');
+      process.exit(1);
+    }
+
+    // Check for blocking phase
+    if (BLOCKING_PHASES.includes(current_phase)) {
+      console.error('');
+      console.error('⚠️  BLOCKED: SD still in LEAD_APPROVAL phase');
+      console.error('═══════════════════════════════════════════════════════════');
+      console.error(`   SD: ${displayId}`);
+      console.error(`   Title: ${title}`);
+      console.error(`   Current Phase: ${current_phase}`);
+      console.error('   Expected Phase: PLAN, EXEC, or beyond');
+      console.error('');
+      console.error('   LEO Protocol requires LEAD approval before implementation.');
+      console.error('');
+      console.error('   REMEDIATION:');
+      console.error('   1. Complete LEAD-TO-PLAN handoff:');
+      console.error(`      node scripts/handoff.js execute LEAD-TO-PLAN ${displayId}`);
+      console.error('   2. Retry commit after handoff');
+      console.error('');
+      console.error('   Emergency bypass (logged): git commit --no-verify');
+      console.error('');
+      process.exit(1);
+    }
+
+    // Validation passed
+    console.log(`✅ Gate 0 validation passed (${displayId}: ${status}, ${current_phase})`);
+    process.exit(0);
+
+  } catch (err) {
+    console.warn(`⚠️  Warning: Unexpected error: ${err.message}`);
+    console.warn('   Skipping Gate 0 validation (fail-open).');
+    process.exit(0); // Fail-open
+  }
+}
+
+// Main execution
+const sdId = process.argv[2];
+
+if (!sdId) {
+  console.error('Usage: node scripts/validate-sd-commit.js <SD-ID>');
+  process.exit(1);
+}
+
+validateSDCommit(sdId);


### PR DESCRIPTION
## Summary
- Added `scripts/validate-sd-commit.js` for SD status validation
- Added Stage 7 to `.husky/pre-commit` for Gate 0 enforcement
- Blocks commits when SD is in draft status or LEAD_APPROVAL phase
- Fail-open on database errors (development not blocked)
- Clear error messages with remediation steps

## SD Reference
- **SD-LEO-GATE0-PRECOMMIT-001**: Pre-commit Hook: SD Phase Validation
- **Parent**: SD-LEO-GATE0-001 (Gate 0: Workflow Entry Enforcement)

## Test plan
- [x] Smoke tests pass
- [x] ESLint passes
- [x] Gate 0 validation stage runs in pre-commit hook
- [x] Non-SD branches allowed (skip validation)
- [x] --no-verify bypass available for emergencies

## Success Criteria Verification
- [x] Commit blocked when SD in message is in draft status
- [x] Commit allowed when SD is in EXEC phase
- [x] Clear error message explains what to do
- [x] Emergency bypass available with --no-verify flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)