### PR TITLE
fix(QF-20260121-001): Fix [object Object] bug in action-items.js

### DIFF
--- a/lib/sub-agents/retro/action-items.js
+++ b/lib/sub-agents/retro/action-items.js
@@ -58,7 +58,11 @@ export function generateSmartActionItems(sdData, prdData, handoffs, subAgentResu
     }
   }
 
-  return actionItems;
+  // Quick-fix QF-20260121-001: Extract .action string from SmartAction objects
+  // to prevent [object Object] serialization in database storage
+  return actionItems.map(item =>
+    typeof item === 'string' ? item : (item.action || String(item))
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix serialization bug where SmartAction objects became `[object Object]` in database
- Extract `.action` string property before returning from `generateSmartActionItems()`
- 5 lines changed (well under 50 LOC quick-fix limit)

## Root Cause
`generateSmartActionItems()` returned full SmartAction objects which became `[object Object]` when serialized to JSONB `action_items` column in retrospectives table.

## Fix
Map array at return to extract just the action string:
```javascript
return actionItems.map(item =>
  typeof item === 'string' ? item : (item.action || String(item))
);
```

## Test plan
- [x] Smoke tests passing (15/15)
- [x] ESLint passing
- [x] LOC under limit (5 lines)

## Quick-Fix Compliance
- **QF ID:** QF-20260121-001
- **Type:** bug
- **Severity:** high
- **LOC:** 5 (limit: 50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)