### PR TITLE
feat(hooks): add quality-over-speed reminder hooks

### DIFF
--- a/.claude/quality-reminder.ps1
+++ b/.claude/quality-reminder.ps1
@@ -1,0 +1,16 @@
+# Quality Reminder Hook Script
+# Outputs reminder when handoff commands are detected
+
+param(
+    [string]$ToolInput = ""
+)
+
+# Check if this is a handoff-related command
+if ($ToolInput -match "handoff" -or $env:TOOL_INPUT -match "handoff") {
+    Write-Output ""
+    Write-Output "============================================"
+    Write-Output "[REMINDER] Quality over speed."
+    Write-Output "Follow the LEO protocol diligently."
+    Write-Output "============================================"
+    Write-Output ""
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,18 @@
     "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\statusline-context-tracker.ps1"
   },
   "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell.exe -NoProfile -Command \"if ($env:CLAUDE_TOOL_INPUT -match 'handoff') { Write-Output '[REMINDER] Quality over speed. Follow the LEO protocol diligently.' }\"",
+            "timeout": 2
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
@@ -33,6 +45,16 @@
             "type": "command",
             "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\set-activity-state.ps1 -State running",
             "timeout": 2
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo [REMINDER] Quality over speed. Follow the LEO protocol diligently.",
+            "timeout": 1
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add PreToolUse hook on Write|Edit tools to display quality reminder before code changes
- Add PostToolUse hook on Bash to display reminder after handoff commands
- Create `quality-reminder.ps1` helper script for handoff detection

**Reminder text:** "Quality over speed. Follow the LEO protocol diligently."

## Why
Reinforces quality-first mindset during Claude Code sessions. Prevents corner-cutting behavior by displaying contextual reminders at key moments.

## Test plan
- [x] Smoke tests pass
- [ ] Verify reminder appears before Write/Edit operations
- [ ] Verify reminder appears after handoff commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)