### PR TITLE
fix(sd-creation): prevent success_metrics/success_criteria validation failures

### DIFF
--- a/scripts/templates/sd-creation-template.js
+++ b/scripts/templates/sd-creation-template.js
@@ -134,6 +134,10 @@ async function createStrategicDirective() {
     /**
      * success_criteria: Array of criteria that define success
      * Should be testable/verifiable criteria
+     *
+     * ⚠️  IMPORTANT: Do NOT use JSON.stringify() on this field!
+     * Supabase handles JSONB natively. Using JSON.stringify() stores
+     * a string instead of an array, causing validation failures.
      */
     success_criteria: [
       '[Criterion 1 - How will we know this SD succeeded?]',
@@ -227,10 +231,16 @@ async function createStrategicDirective() {
 
     /**
      * success_metrics: Array of measurable metrics
+     * REQUIRED: At least 3 items with {metric, target} for handoff validation
+     *
+     * ⚠️  IMPORTANT: Do NOT use JSON.stringify() on this field!
+     * Supabase handles JSONB natively. Using JSON.stringify() stores
+     * a string instead of an array, causing validation failures.
      */
     success_metrics: [
-      '[Metric 1 - How will success be measured quantitatively?]',
-      '[Metric 2 - Another metric]'
+      { metric: '[Metric 1]', target: '[Target value]' },
+      { metric: '[Metric 2]', target: '[Target value]' },
+      { metric: '[Metric 3]', target: '[Target value]' }
     ],
 
     /**


### PR DESCRIPTION
## Summary

Fixes the recurring issue where SD creation fails validation because:
- `success_criteria` is stored as a JSON string instead of an array
- `success_metrics` is empty but validator requires 3+ items

**Root Cause Analysis:**
1. Many SD creation scripts incorrectly use `JSON.stringify()` on JSONB fields, storing strings instead of native arrays
2. `leo-create-sd.js` initialized `success_criteria: []` and `success_metrics: []` as empty arrays

**Changes:**
- `leo-create-sd.js`: Add `buildDefaultSuccessMetrics()` and `buildDefaultSuccessCriteria()` functions that auto-populate required fields based on SD type
- `sd-creation-validator.js`: Add `isStringifiedJson()` check that catches JSON strings at creation time with clear error message
- `sd-creation-template.js`: Add warning comments about not using `JSON.stringify()` on JSONB fields

## Test plan

- [ ] Create SD via `/leo create` - verify success_metrics has 3+ items with `{metric, target}`
- [ ] Verify validator catches JSON strings: `validateSDCreation({success_metrics: JSON.stringify([...])})`
- [ ] Run smoke tests: `npm run test:smoke`

🤖 Generated with [Claude Code](https://claude.com/claude-code)