### PR TITLE
docs(hooks): add Stop Hook Sub-Agent Enforcement documentation

### DIFF
--- a/docs/06_deployment/stop-hook-operations.md
+++ b/docs/06_deployment/stop-hook-operations.md
@@ -1,0 +1,489 @@
+# Stop Hook Sub-Agent Enforcement - Operational Runbook
+
+**Document Type**: Operational Runbook
+**System**: Claude Code Stop Hook
+**Component**: `scripts/hooks/stop-subagent-enforcement.js`
+**Owner**: LEO Infrastructure Team
+**Last Updated**: 2026-01-21
+**SD**: SD-LEO-INFRA-STOP-HOOK-SUB-001
+
+## Overview
+
+The Stop Hook Sub-Agent Enforcement system validates that required sub-agents have been executed for a Strategic Directive before allowing a Claude session to end. This ensures quality gates are enforced across all SD types.
+
+## System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Claude Code Stop Hook                                       │
+│  (Triggered when session ends)                              │
+└────────────────┬────────────────────────────────────────────┘
+                 │
+                 ├─> 1. Extract SD from git branch
+                 │
+                 ├─> 2. Query Supabase for SD details
+                 │       ├─ SD type (feature, infrastructure, etc.)
+                 │       ├─ Category
+                 │       └─ Current phase
+                 │
+                 ├─> 3. Determine required sub-agents
+                 │       ├─ By SD type (REQUIREMENTS.byType)
+                 │       ├─ By category (REQUIREMENTS.byCategory)
+                 │       └─ Universal (RETRO for near-completion)
+                 │
+                 ├─> 4. Query sub-agent execution results
+                 │       ├─ Check for PASS/CONDITIONAL_PASS verdicts
+                 │       ├─ Apply 1-hour cache for recent PASSes
+                 │       └─ Validate phase window timing
+                 │
+                 ├─> 5. Validation outcome
+                 │       ├─ All validations passed → Exit 0
+                 │       ├─ Missing sub-agents → Exit 2 (block)
+                 │       └─ Wrong timing → Exit 2 (block)
+                 │
+                 └─> 6. Auto-remediation
+                         └─ Return JSON with commands to run
+```
+
+## Configuration
+
+### Hook Registration
+
+**File**: `.claude/settings.json`
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/stop-subagent-enforcement.js",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Timeout**: 120 seconds (includes database queries and validation)
+
+### Environment Variables
+
+Required in `.env`:
+- `SUPABASE_URL`: Supabase project URL
+- `SUPABASE_SERVICE_ROLE_KEY`: Service role key for database access
+- `CLAUDE_PROJECT_DIR`: Project root directory (optional, defaults to `process.cwd()`)
+
+## Sub-Agent Requirements Matrix
+
+### By SD Type
+
+| SD Type | Required Sub-Agents | Recommended Sub-Agents |
+|---------|---------------------|------------------------|
+| `feature` | TESTING, DESIGN, STORIES | UAT, API |
+| `implementation` | TESTING, API | DATABASE |
+| `infrastructure` | GITHUB, DOCMON | VALIDATION |
+| `database` | DATABASE, SECURITY | REGRESSION |
+| `security` | SECURITY, DATABASE | TESTING, RCA |
+| `documentation` | DOCMON | VALIDATION |
+| `bugfix` | RCA, REGRESSION, TESTING | UAT |
+| `refactor` | REGRESSION, VALIDATION | TESTING |
+| `performance` | PERFORMANCE, TESTING | REGRESSION |
+| `orchestrator` | (none) | RETRO |
+
+### By Category
+
+| Category | Additional Sub-Agents |
+|----------|----------------------|
+| `Quality Assurance` | TESTING, UAT, VALIDATION |
+| `quality` | TESTING, UAT, VALIDATION |
+| `testing` | TESTING, UAT |
+| `audit` | VALIDATION, RCA |
+| `security` | SECURITY, RISK |
+| `bug_fix` | RCA, REGRESSION |
+| `ux_improvement` | DESIGN, UAT |
+| `product_feature` | DESIGN, STORIES, API |
+| `database` | DATABASE |
+| `database_schema` | DATABASE, SECURITY |
+
+### Universal Requirements
+
+**RETRO** sub-agent is universally required when SD is in one of these phases:
+- `PLAN`
+- `LEAD`
+- `PLAN_VERIFY`
+- `LEAD_FINAL`
+
+## Phase Window Timing Rules
+
+Sub-agents must run within designated phase windows:
+
+| Sub-Agent | After Handoff | Before Handoff | Phase Window |
+|-----------|---------------|----------------|--------------|
+| DESIGN | LEAD-TO-PLAN | PLAN-TO-EXEC | PLAN |
+| STORIES | LEAD-TO-PLAN | PLAN-TO-EXEC | PLAN |
+| API | LEAD-TO-PLAN | PLAN-TO-EXEC | PLAN |
+| DATABASE | LEAD-TO-PLAN | EXEC-TO-PLAN | PLAN/EXEC |
+| TESTING | PLAN-TO-EXEC | LEAD-FINAL-APPROVAL | EXEC |
+| REGRESSION | PLAN-TO-EXEC | EXEC-TO-PLAN | EXEC |
+| PERFORMANCE | PLAN-TO-EXEC | EXEC-TO-PLAN | EXEC |
+| SECURITY | (any) | LEAD-FINAL-APPROVAL | ANY |
+| UAT | EXEC-TO-PLAN | LEAD-FINAL-APPROVAL | VERIFICATION |
+| VALIDATION | (any) | LEAD-FINAL-APPROVAL | ANY |
+| RCA | (any) | (any) | EARLY |
+| RETRO | PLAN-TO-LEAD | (any) | COMPLETION |
+| GITHUB | PLAN-TO-EXEC | LEAD-FINAL-APPROVAL | EXEC |
+| DOCMON | (any) | LEAD-FINAL-APPROVAL | ANY |
+| RISK | (any) | PLAN-TO-EXEC | EARLY |
+
+**Timing Validation**: The hook checks that at least one PASS verdict exists within the designated phase window based on handoff timestamps.
+
+## Caching Strategy
+
+**Duration**: 1 hour (3600000 ms)
+
+**Logic**:
+```javascript
+const recentPass = passingExecs.find(e =>
+  (Date.now() - new Date(e.created_at).getTime()) < CACHE_DURATION_MS
+);
+
+if (recentPass) {
+  // Skip validation, use cached result
+}
+```
+
+**Purpose**: Avoid redundant sub-agent executions when stopping and resuming work on the same SD within an hour.
+
+## Exit Codes
+
+| Exit Code | Meaning | Action |
+|-----------|---------|--------|
+| `0` | All validations passed | Session ends normally |
+| `2` | Blocking: Missing sub-agents | Claude continues session with remediation instructions |
+
+**Note**: Exit code `2` signals to Claude Code that the session should NOT end yet. Claude receives the blocking JSON output and can auto-remediate.
+
+## Bypass Mechanism
+
+### When to Bypass
+
+Use bypass for:
+- Emergency hotfixes
+- Temporary workarounds
+- Situations where sub-agent execution is impossible (e.g., external dependency failure)
+
+### Bypass Process
+
+**Step 1**: Create `.stop-hook-bypass.json` in project root:
+
+```json
+{
+  "sd_key": "SD-LEO-XXX-001",
+  "explanation": "Emergency hotfix for production outage - sub-agent validation deferred to post-incident review",
+  "skipped_agents": ["TESTING", "UAT"],
+  "retrospective_committed": false,
+  "retrospective_id": null
+}
+```
+
+**Requirements**:
+- `explanation`: Minimum 50 characters, must justify bypass
+- `skipped_agents`: List of sub-agents being skipped
+- `retrospective_committed`: Must be `true` to proceed
+
+**Step 2**: Generate retrospective entry:
+
+```bash
+node scripts/generate-retrospective.js --bypass-entry
+```
+
+This creates a retrospective entry documenting the bypass decision.
+
+**Step 3**: Update bypass file:
+
+```json
+{
+  "sd_key": "SD-LEO-XXX-001",
+  "explanation": "Emergency hotfix for production outage - sub-agent validation deferred to post-incident review",
+  "skipped_agents": ["TESTING", "UAT"],
+  "retrospective_committed": true,
+  "retrospective_id": "5ef55068..."
+}
+```
+
+**Step 4**: Retry session end
+
+The hook will:
+1. Validate bypass file structure
+2. Check `retrospective_committed === true`
+3. Log bypass to audit table (`audit_log` with severity `warning`)
+4. Delete bypass file
+5. Allow session to end (exit 0)
+
+### Bypass Validation Failures
+
+| Error | Resolution |
+|-------|------------|
+| `explanation` < 50 chars | Provide detailed justification |
+| `retrospective_committed !== true` | Run `generate-retrospective.js --bypass-entry` |
+| Invalid JSON | Fix JSON syntax |
+| Missing required fields | Add `sd_key`, `explanation`, `skipped_agents`, `retrospective_committed` |
+
+## Auto-Remediation
+
+When validation fails, the hook returns JSON with remediation instructions:
+
+```json
+{
+  "decision": "block",
+  "reason": "SD SD-LEO-INFRA-STOP-HOOK-SUB-001 (infrastructure) requires sub-agent validation",
+  "details": {
+    "sd_key": "SD-LEO-INFRA-STOP-HOOK-SUB-001",
+    "sd_type": "infrastructure",
+    "category": "infrastructure",
+    "current_phase": "EXEC",
+    "missing": ["GITHUB", "DOCMON"],
+    "wrong_timing": [],
+    "cached": 0
+  },
+  "remediation": {
+    "auto_run": true,
+    "agents_to_run": ["GITHUB", "DOCMON"],
+    "command": "node scripts/orchestrate-phase-subagents.js SD-LEO-INFRA-STOP-HOOK-SUB-001 --agents GITHUB,DOCMON"
+  },
+  "bypass_instructions": {
+    "step1": "Create .stop-hook-bypass.json with explanation (min 50 chars)",
+    "step2": "Run: node scripts/generate-retrospective.js --bypass-entry",
+    "step3": "Set retrospective_committed: true in bypass file"
+  }
+}
+```
+
+**Remediation Order**: Sub-agents are sorted by execution order (defined in `REMEDIATION_ORDER` constant).
+
+## Monitoring and Observability
+
+### Logs
+
+**Success**:
+```
+✅ Sub-Agent Enforcement: SD-LEO-XXX-001 passed (2 cached, 3 validated)
+```
+
+**Failure**:
+```
+🔍 Sub-Agent Enforcement for SD-LEO-XXX-001 (feature)
+   Phase: EXEC
+   Cached: 1 sub-agents
+   Missing: TESTING, UAT
+```
+
+**Bypass**:
+```
+⚠️ Bypass allowed for SD-LEO-XXX-001: Emergency hotfix for production outage - sub-agent...
+```
+
+### Audit Trail
+
+All bypass events are logged to `audit_log` table:
+
+```sql
+SELECT
+  event_type,
+  severity,
+  details->>'sd_key' as sd_key,
+  details->>'explanation' as explanation,
+  details->>'skipped_agents' as skipped_agents,
+  created_at
+FROM audit_log
+WHERE event_type = 'STOP_HOOK_BYPASS'
+ORDER BY created_at DESC;
+```
+
+### Metrics
+
+Track these metrics for effectiveness:
+
+1. **Block Rate**: How often does enforcement fire?
+   ```sql
+   SELECT COUNT(*) FROM sub_agent_execution_results
+   WHERE created_at > NOW() - INTERVAL '7 days';
+   ```
+
+2. **Bypass Rate**: How often is bypass used?
+   ```sql
+   SELECT COUNT(*) FROM audit_log
+   WHERE event_type = 'STOP_HOOK_BYPASS'
+   AND created_at > NOW() - INTERVAL '7 days';
+   ```
+
+3. **Cache Hit Rate**: How often does caching avoid redundant execution?
+   - Monitor log output for "X cached" counts
+
+## Troubleshooting
+
+### Hook Not Triggering
+
+**Symptom**: Session ends without validation
+
+**Diagnosis**:
+1. Check `.claude/settings.json` has Stop hook configured
+2. Verify hook script exists at correct path
+3. Check file permissions (must be executable on Unix systems)
+4. Look for hook errors in Claude Code output
+
+**Resolution**:
+```bash
+# Verify hook configuration
+cat .claude/settings.json | jq '.hooks.Stop'
+
+# Test hook manually
+node scripts/hooks/stop-subagent-enforcement.js
+```
+
+### Hook Times Out
+
+**Symptom**: Hook exceeds 120s timeout
+
+**Diagnosis**:
+1. Check Supabase connectivity
+2. Review database query performance
+3. Check for large result sets
+
+**Resolution**:
+- Increase timeout in `.claude/settings.json`
+- Optimize database queries
+- Add indexes if needed
+
+### False Positives
+
+**Symptom**: Hook blocks when sub-agents were actually run
+
+**Diagnosis**:
+1. Check `sub_agent_execution_results` table for missing entries
+2. Verify sub-agent code matches exactly (case-sensitive)
+3. Check verdict is `PASS` or `CONDITIONAL_PASS`
+
+**Resolution**:
+```bash
+# Query sub-agent executions
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+supabase.from('sub_agent_execution_results')
+  .select('sub_agent_code, verdict, created_at')
+  .eq('sd_id', 'SD-XXX-001')
+  .then(({data}) => console.log(JSON.stringify(data, null, 2)));
+"
+```
+
+### SD Not Detected
+
+**Symptom**: Hook exits 0 immediately (no validation)
+
+**Diagnosis**:
+1. Check git branch name matches pattern: `SD-[A-Z]+-(?:[A-Z]+-)*[0-9]+`
+2. Verify SD exists in `strategic_directives_v2` table
+3. Check SD status is not `completed`
+
+**Resolution**:
+```bash
+# Test regex pattern
+node -e "
+const branch = require('child_process').execSync('git rev-parse --abbrev-ref HEAD', {encoding: 'utf-8'}).trim();
+const sdMatch = branch.match(/SD-[A-Z]+-(?:[A-Z]+-)*[0-9]+/i);
+console.log('Branch:', branch);
+console.log('SD Match:', sdMatch ? sdMatch[0] : 'NO MATCH');
+"
+```
+
+### Wrong Timing Detection
+
+**Symptom**: Hook reports "wrong timing" for sub-agents that ran in correct phase
+
+**Diagnosis**:
+1. Check handoff timestamps in `sd_phase_handoffs` table
+2. Verify sub-agent execution timestamp falls within phase window
+3. Check for clock drift or timezone issues
+
+**Resolution**:
+```bash
+# Query handoff timestamps
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+supabase.from('sd_phase_handoffs')
+  .select('handoff_type, status, created_at')
+  .eq('sd_id', 'SD-XXX-001')
+  .eq('status', 'accepted')
+  .order('created_at', { ascending: true })
+  .then(({data}) => console.log(JSON.stringify(data, null, 2)));
+"
+```
+
+## Maintenance
+
+### Updating Requirements Matrix
+
+To change which sub-agents are required for an SD type:
+
+1. Edit `scripts/hooks/stop-subagent-enforcement.js`
+2. Update `REQUIREMENTS.byType` or `REQUIREMENTS.byCategory`
+3. Commit changes
+4. Update this documentation
+
+### Adding New Sub-Agents
+
+When adding a new sub-agent to the system:
+
+1. Add to appropriate sections in `REQUIREMENTS`
+2. Add timing rules to `TIMING_RULES` if phase-specific
+3. Add to `REMEDIATION_ORDER` for proper sequencing
+4. Update this documentation
+
+### Disabling Hook (Emergency)
+
+If the hook is causing widespread issues:
+
+```bash
+# Temporary disable (remove from settings.json)
+node -e "
+const fs = require('fs');
+const settings = JSON.parse(fs.readFileSync('.claude/settings.json', 'utf-8'));
+settings.hooks.Stop = settings.hooks.Stop.filter(h =>
+  !h.hooks.some(hook => hook.command.includes('stop-subagent-enforcement'))
+);
+fs.writeFileSync('.claude/settings.json', JSON.stringify(settings, null, 2));
+console.log('Hook disabled');
+"
+
+# Or use environment variable bypass
+LEO_SKIP_HOOKS=1 claude-code
+```
+
+## Related Documentation
+
+- **Design Document**: `docs/drafts/STOP-HOOK-SUBAGENT-ENFORCEMENT-DRAFT.md`
+- **Triangulation Synthesis**: `docs/research/triangulation-stop-hook-synthesis.md`
+- **Protocol Amendment**: `docs/03_protocols_and_standards/LEO_v4.3_subagent_enforcement.md`
+- **Hook Reference**: `docs/reference/claude-code-hooks.md` (general hook documentation)
+- **Sub-Agent Guide**: `docs/reference/sub-agent-execution.md`
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-21 | Initial operational runbook for SD-LEO-INFRA-STOP-HOOK-SUB-001 |
+
+---
+
+**Document Status**: ✅ Active
+**Review Cycle**: Quarterly
+**Next Review**: 2026-04-21

--- a/docs/reference/claude-code-hooks.md
+++ b/docs/reference/claude-code-hooks.md
@@ -1,0 +1,583 @@
+# Claude Code Hooks Reference
+
+**Document Type**: Technical Reference
+**System**: Claude Code Hook System
+**Last Updated**: 2026-01-21
+
+## Overview
+
+Claude Code supports lifecycle hooks that execute shell commands in response to events during a Claude session. Hooks enable custom automation, validation, and enforcement workflows.
+
+## Hook Types
+
+| Hook Type | Trigger | Purpose | Exit Code Handling |
+|-----------|---------|---------|-------------------|
+| `Stop` | Session ends | Validation before session termination | Exit 2 blocks termination |
+| `PreToolUse` | Before any tool use | Pre-validation, rate limiting | Exit 2 blocks tool |
+| `PostToolUse` | After tool use completes | Logging, notifications | Non-blocking |
+| `UserPromptSubmit` | User submits prompt | Input validation, pre-processing | Exit 2 blocks prompt |
+
+## Configuration
+
+Hooks are configured in `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/my-hook.js",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo [REMINDER] Quality over speed",
+            "timeout": 1
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Hook Structure
+
+### Basic Hook
+
+```json
+{
+  "type": "command",
+  "command": "node path/to/script.js",
+  "timeout": 30
+}
+```
+
+**Fields**:
+- `type`: Always `"command"` for shell command hooks
+- `command`: Shell command to execute (supports full shell syntax)
+- `timeout`: Maximum execution time in seconds (default: 30)
+
+### Matcher-Based Hook (PreToolUse, PostToolUse)
+
+```json
+{
+  "matcher": "Bash|Edit|Write",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "node scripts/validate-tool.js",
+      "timeout": 5
+    }
+  ]
+}
+```
+
+**matcher**: Regex pattern to match tool names (e.g., `"Bash"`, `"Write|Edit"`, `".*"` for all tools)
+
+## Exit Code Behavior
+
+| Exit Code | Behavior | Use Case |
+|-----------|----------|----------|
+| `0` | Success - Continue normal operation | Validation passed |
+| `1` | Error - Log warning but continue | Non-critical failure |
+| `2` | **Block** - Prevent operation from completing | Validation failed, enforcement required |
+| `Other` | Treated as error (like exit 1) | Unexpected failure |
+
+### Blocking with Exit Code 2
+
+**Stop Hook**: Prevents session from ending. Claude continues and can read hook output.
+
+**PreToolUse Hook**: Blocks tool execution. User must resolve issue before retrying.
+
+**UserPromptSubmit Hook**: Blocks prompt submission. User must fix input.
+
+## Environment Variables Available to Hooks
+
+Claude Code provides these environment variables to hook scripts:
+
+| Variable | Content | Available In |
+|----------|---------|--------------|
+| `CLAUDE_TOOL_NAME` | Name of tool being used | PreToolUse, PostToolUse |
+| `CLAUDE_TOOL_INPUT` | Tool input (JSON string) | PreToolUse, PostToolUse |
+| `CLAUDE_PROJECT_DIR` | Project root directory | All hooks |
+| `CLAUDE_SESSION_ID` | Current session ID | All hooks |
+
+## Hook Output
+
+### Standard Output (stdout)
+
+Content written to stdout is:
+- **Stop Hook**: Displayed to Claude (blocking JSON output)
+- **PreToolUse**: Shown to user as reminder/warning
+- **PostToolUse**: Logged (not shown to Claude)
+- **UserPromptSubmit**: Shown to user as validation message
+
+### Standard Error (stderr)
+
+Content written to stderr is logged but not displayed to Claude.
+
+### JSON Output (Stop Hook)
+
+Stop hooks can return structured JSON for enforcement:
+
+```json
+{
+  "decision": "block",
+  "reason": "Validation failed: Missing required checks",
+  "details": {
+    "missing_items": ["test", "documentation"]
+  },
+  "remediation": {
+    "auto_run": true,
+    "command": "npm run fix-validation"
+  },
+  "bypass_instructions": {
+    "step1": "Create bypass file with explanation",
+    "step2": "Run bypass script",
+    "step3": "Retry session end"
+  }
+}
+```
+
+## Implementation Patterns
+
+### Pattern 1: Simple Validation
+
+```javascript
+#!/usr/bin/env node
+
+// Validate something
+const isValid = checkSomething();
+
+if (!isValid) {
+  console.error('Validation failed');
+  process.exit(2); // Block
+}
+
+console.log('Validation passed');
+process.exit(0); // Continue
+```
+
+### Pattern 2: Blocking with Remediation
+
+```javascript
+#!/usr/bin/env node
+
+const issues = detectIssues();
+
+if (issues.length > 0) {
+  const output = {
+    decision: 'block',
+    reason: `Found ${issues.length} issue(s)`,
+    details: { issues },
+    remediation: {
+      auto_run: true,
+      command: 'npm run fix-issues'
+    }
+  };
+
+  console.log(JSON.stringify(output));
+  process.exit(2);
+}
+
+process.exit(0);
+```
+
+### Pattern 3: Bypass Mechanism
+
+```javascript
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+
+const bypassFile = path.join(process.cwd(), '.hook-bypass.json');
+
+// Check for bypass
+if (fs.existsSync(bypassFile)) {
+  const bypass = JSON.parse(fs.readFileSync(bypassFile, 'utf-8'));
+
+  // Validate bypass
+  if (!bypass.explanation || bypass.explanation.length < 50) {
+    console.log(JSON.stringify({
+      decision: 'block',
+      reason: 'Bypass explanation must be at least 50 characters'
+    }));
+    process.exit(2);
+  }
+
+  // Log bypass and allow
+  console.log(`⚠️ Bypass: ${bypass.explanation}`);
+  fs.unlinkSync(bypassFile); // Clean up
+  process.exit(0);
+}
+
+// Normal validation
+const valid = performValidation();
+process.exit(valid ? 0 : 2);
+```
+
+### Pattern 4: Async Operations
+
+```javascript
+#!/usr/bin/env node
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  // Query database
+  const { data, error } = await supabase
+    .from('validations')
+    .select('status')
+    .eq('session_id', process.env.CLAUDE_SESSION_ID)
+    .single();
+
+  if (error || !data || data.status !== 'passed') {
+    console.log(JSON.stringify({
+      decision: 'block',
+      reason: 'Validation not completed in database'
+    }));
+    process.exit(2);
+  }
+
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  process.exit(0); // Don't block on internal errors
+});
+```
+
+### Pattern 5: Caching
+
+```javascript
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+
+const CACHE_FILE = path.join(process.cwd(), '.hook-cache.json');
+const CACHE_DURATION_MS = 60 * 60 * 1000; // 1 hour
+
+// Check cache
+if (fs.existsSync(CACHE_FILE)) {
+  const cache = JSON.parse(fs.readFileSync(CACHE_FILE, 'utf-8'));
+  const age = Date.now() - cache.timestamp;
+
+  if (age < CACHE_DURATION_MS && cache.result === 'passed') {
+    console.log('✅ Using cached validation result');
+    process.exit(0);
+  }
+}
+
+// Perform validation
+const result = performExpensiveValidation();
+
+// Update cache
+fs.writeFileSync(CACHE_FILE, JSON.stringify({
+  timestamp: Date.now(),
+  result: result ? 'passed' : 'failed'
+}));
+
+process.exit(result ? 0 : 2);
+```
+
+## Implemented Hooks in EHG_Engineer
+
+### Stop Hook: Sub-Agent Enforcement
+
+**Location**: `scripts/hooks/stop-subagent-enforcement.js`
+**Purpose**: Validates that required sub-agents have been executed before session end
+**Exit Behavior**: Exit 2 blocks session end, returns remediation JSON
+**Timeout**: 120 seconds
+
+**Key Features**:
+- Detects SD from git branch
+- Validates sub-agents based on SD type/category matrix
+- Checks phase window timing
+- 1-hour caching for PASS verdicts
+- Bypass mechanism with audit logging
+
+**Documentation**: `docs/06_deployment/stop-hook-operations.md`
+
+### PreToolUse Hook: Activity State Tracking
+
+**Location**: `.claude/set-activity-state.ps1`
+**Purpose**: Sets activity state to "running" when tools are used
+**Matcher**: All tools (`.*`)
+**Timeout**: 2 seconds
+
+### PreToolUse Hook: Quality Reminders
+
+**Matcher**: `Write|Edit`
+**Purpose**: Displays quality reminder before file modifications
+**Timeout**: 1 second
+
+### PostToolUse Hook: Handoff Reminders
+
+**Matcher**: `Bash` (when command contains "handoff")
+**Purpose**: Reminds Claude to follow LEO protocol diligently
+**Timeout**: 2 seconds
+
+### UserPromptSubmit Hook: Activity State Tracking
+
+**Location**: `.claude/set-activity-state.ps1`
+**Purpose**: Sets activity state to "running" when user submits prompt
+**Timeout**: 2 seconds
+
+## Best Practices
+
+### 1. Fail Open on Internal Errors
+
+Don't block Claude sessions due to hook script bugs:
+
+```javascript
+main().catch(err => {
+  console.error('Hook error:', err.message);
+  process.exit(0); // Allow session to continue
+});
+```
+
+### 2. Set Appropriate Timeouts
+
+- Simple checks: 1-5 seconds
+- Database queries: 10-30 seconds
+- Complex validation: 60-120 seconds
+
+### 3. Provide Clear Output
+
+Users should understand why validation failed:
+
+```javascript
+console.error(`❌ Validation failed: ${reason}`);
+console.error(`   Details: ${details}`);
+console.error(`   Fix: ${remedy}`);
+```
+
+### 4. Use Bypass Mechanisms
+
+Always provide an escape hatch for emergencies:
+
+```javascript
+if (fs.existsSync('.hook-bypass')) {
+  // Log bypass and allow
+  process.exit(0);
+}
+```
+
+### 5. Cache Expensive Operations
+
+Don't re-validate on every hook trigger:
+
+```javascript
+const cachedResult = checkCache();
+if (cachedResult && cachedResult.age < CACHE_DURATION) {
+  return cachedResult.value;
+}
+```
+
+### 6. Use Structured Output for Automation
+
+JSON output enables auto-remediation:
+
+```json
+{
+  "decision": "block",
+  "remediation": {
+    "auto_run": true,
+    "command": "npm run fix"
+  }
+}
+```
+
+### 7. Test Hooks in Isolation
+
+```bash
+# Test hook script directly
+node scripts/hooks/my-hook.js
+
+# Test with environment variables
+CLAUDE_PROJECT_DIR=$(pwd) node scripts/hooks/my-hook.js
+
+# Test blocking behavior
+node scripts/hooks/my-hook.js && echo "Allowed" || echo "Blocked (exit $?)"
+```
+
+## Troubleshooting
+
+### Hook Not Executing
+
+**Check**:
+1. `.claude/settings.json` syntax is valid JSON
+2. Hook command path is correct (use absolute paths on Windows)
+3. Hook script has execute permissions (Unix)
+4. Timeout is sufficient for hook to complete
+
+**Debug**:
+```bash
+# Validate settings.json
+cat .claude/settings.json | jq .
+
+# Test hook manually
+node path/to/hook.js
+```
+
+### Hook Times Out
+
+**Symptoms**: Hook execution exceeds timeout, session hangs
+
+**Solutions**:
+1. Increase timeout in settings.json
+2. Optimize hook script (use caching, parallel queries)
+3. Remove expensive operations
+
+### Exit Code 2 Not Blocking
+
+**Check**:
+1. Hook is configured for correct lifecycle event
+2. Script explicitly calls `process.exit(2)`
+3. Hook output is being read by Claude Code
+4. No error in hook execution (check stderr)
+
+### Hook Output Not Visible
+
+**Check**:
+1. Writing to stdout, not stderr (for Claude visibility)
+2. Output is well-formed JSON (for Stop hooks)
+3. Timeout is sufficient for script to complete
+
+## Security Considerations
+
+### 1. Validate Bypass Inputs
+
+Always validate bypass file contents:
+
+```javascript
+if (!bypass.explanation || bypass.explanation.length < 50) {
+  // Reject insufficient explanation
+  process.exit(2);
+}
+```
+
+### 2. Log All Bypass Events
+
+Audit all bypass usage:
+
+```javascript
+await supabase.from('audit_log').insert({
+  event_type: 'HOOK_BYPASS',
+  severity: 'warning',
+  details: { reason: bypass.explanation }
+});
+```
+
+### 3. Rate Limit Hook Execution
+
+Prevent DoS from rapid hook triggers:
+
+```javascript
+const RATE_LIMIT_MS = 1000; // 1 second
+const lastRun = getLastRunTime();
+if (Date.now() - lastRun < RATE_LIMIT_MS) {
+  process.exit(0); // Skip this execution
+}
+```
+
+### 4. Sanitize Environment Variables
+
+Don't trust environment variables for security decisions:
+
+```javascript
+// BAD: Using env var for auth
+if (process.env.CLAUDE_BYPASS_HOOK === '1') {
+  process.exit(0);
+}
+
+// GOOD: Using file-based bypass with validation
+const bypass = validateBypassFile();
+```
+
+### 5. Limit Hook Permissions
+
+Run hooks with minimal permissions:
+- Read-only access to most files
+- Write access only to specific cache/log directories
+- No sudo/admin privileges
+
+## Performance Optimization
+
+### 1. Parallel Operations
+
+```javascript
+const [validation1, validation2] = await Promise.all([
+  performValidation1(),
+  performValidation2()
+]);
+```
+
+### 2. Early Exit
+
+```javascript
+// Check cheapest validations first
+if (!quickCheck()) {
+  process.exit(2);
+}
+
+// Then expensive validations
+if (!expensiveCheck()) {
+  process.exit(2);
+}
+```
+
+### 3. Connection Pooling
+
+```javascript
+// Reuse database connections
+const supabase = createClient(url, key, {
+  db: { pool: { max: 1 } }
+});
+```
+
+### 4. Incremental Validation
+
+```javascript
+// Only validate changes, not entire state
+const changedFiles = getGitDiff();
+const validationNeeded = changedFiles.some(needsValidation);
+```
+
+## Related Documentation
+
+- **Stop Hook Operations**: `docs/06_deployment/stop-hook-operations.md`
+- **Hook Troubleshooting**: `docs/troubleshooting/FIX_HOOK_ERRORS.md`
+- **Claude Code Settings**: `docs/reference/claude-code-settings.md`
+- **LEO Protocol Enforcement**: `docs/03_protocols_and_standards/LEO_v4.3_subagent_enforcement.md`
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-01-21 | Initial hook reference documentation |
+
+---
+
+**Document Status**: ✅ Active
+**Review Cycle**: Quarterly
+**Next Review**: 2026-04-21


### PR DESCRIPTION
## Summary
- Updated `docs/03_protocols_and_standards/LEO_v4.3_subagent_enforcement.md` with implementation status (Proposed → IMPLEMENTED)
- Created operational runbook for stop hook at `docs/06_deployment/stop-hook-operations.md`
- Created Claude Code hooks reference at `docs/reference/claude-code-hooks.md`
- Updated `leo_protocol_sections` database section 234 with enforcement details

## Documentation Contents

### Operational Runbook
- System architecture diagram
- Complete sub-agent requirements matrix (by SD type and category)
- Phase window timing rules
- Caching strategy (1-hour duration)
- Bypass mechanism with 3-step process
- Monitoring and observability
- Troubleshooting guide (5 common issues)

### Hook Reference
- Overview of Claude Code hook system
- Hook types (Stop, PreToolUse, PostToolUse, UserPromptSubmit)
- Exit code behavior (0=continue, 1=error, 2=block)
- Implementation patterns (5 patterns with code)
- Best practices (7 guidelines)
- Security considerations

## Test plan
- [x] DOCMON validation passed (CONDITIONAL_PASS, 80%)
- [x] Existing doc search completed before changes
- [x] No duplicate documentation created
- [x] Cross-references verified

## Related
- SD: SD-LEO-INFRA-STOP-HOOK-SUB-001 (completed)
- PR #458: Implementation of stop hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)