### PR TITLE
feat(pre-commit): exempt docs/reports/test branches from LOC threshold

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -340,8 +340,14 @@ if [ "$LOC_TOTAL" -gt "$LOC_THRESHOLD" ]; then
   echo "⚠️  LARGE CHANGE DETECTED: $LOC_TOTAL lines (threshold: $LOC_THRESHOLD)"
   echo ""
 
+  # SD-LEO-INFRA-PRE-COMMIT-HOOK-001: Exempt docs/, reports/, test/ branches from LOC threshold
+  # These branches typically contain documentation regeneration, reports, or test additions
+  # that don't need SD tracking (database-generated CLAUDE.md files often exceed 500 LOC)
+  if echo "$BRANCH" | grep -qE '^(docs|reports|test)/'; then
+    echo "   ✅ Large change permitted - documentation/reports/test branch"
+    echo "   ℹ️  Branch type '$(echo "$BRANCH" | cut -d'/' -f1)/' exempt from SD requirement"
   # If we have an SD, verify it's in EXEC phase
-  if [ ! -z "$SD_ID" ]; then
+  elif [ ! -z "$SD_ID" ]; then
     echo "   SD detected: $SD_ID"
     echo "   ✅ Large change permitted - SD reference found"
   else
@@ -361,6 +367,7 @@ if [ "$LOC_TOTAL" -gt "$LOC_THRESHOLD" ]; then
     echo ""
     echo "   Or split changes into smaller commits (<$LOC_THRESHOLD lines)"
     echo ""
+    echo "   For documentation regeneration: Use docs/ branch prefix"
     echo "   Emergency bypass (logged): git commit --no-verify"
     echo ""
     exit 1


### PR DESCRIPTION
## Summary
- Add intelligent branch prefix detection to the LOC threshold check
- Branches with `docs/`, `reports/`, or `test/` prefixes are now exempt from the 500 LOC threshold
- These branches typically contain documentation regeneration, reports, or test additions that don't require SD tracking (e.g., database-generated CLAUDE.md files often exceed 500 LOC)
- Add clear messaging for exempt branches and hint in error message

## SD Reference
SD-LEO-INFRA-PRE-COMMIT-HOOK-001

## Test plan
- [x] Smoke tests pass
- [x] Pre-commit hook runs successfully
- [x] Small changes (under threshold) pass without changes
- [ ] Large docs/ branch commits will be permitted (verified by previous session issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)