### PR TITLE
feat(auto-proceed): AskUserQuestion AUTO-PROCEED Awareness (Child B)

### DIFF
--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -1119,6 +1119,31 @@ The `/document` command connects to other commands in the workflow:
 
 ### After Documentation Updates
 
+**AUTO-PROCEED Detection**: Before asking, check if AUTO-PROCEED mode is active:
+
+```bash
+# Check for AUTO-PROCEED context
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+supabase.from('auto_proceed_sessions')
+  .select('id, active_sd_key')
+  .eq('is_active', true)
+  .single()
+  .then(({data}) => {
+    if (data) console.log('AUTO-PROCEED ACTIVE: ' + data.active_sd_key);
+    else console.log('AUTO-PROCEED: INACTIVE');
+  });
+"
+```
+
+**If AUTO-PROCEED is ACTIVE:**
+- Skip AskUserQuestion
+- Output status: `🤖 AUTO-PROCEED: Documentation complete, continuing to next command...`
+- Auto-invoke the next command in post-completion sequence (typically `/learn` or `/leo next`)
+
+**If AUTO-PROCEED is INACTIVE:**
 **If documentation changes created uncommitted files - Use AskUserQuestion:**
 
 ```javascript

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -113,6 +113,31 @@ The created SD will appear in the SD queue. Follow normal LEO workflow:
 - EXEC phase (implementation)
 - LEAD-FINAL-APPROVAL (auto-resolves patterns)
 
+**AUTO-PROCEED Detection**: Before asking, check if AUTO-PROCEED mode is active:
+
+```bash
+# Check for AUTO-PROCEED context
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+supabase.from('auto_proceed_sessions')
+  .select('id, active_sd_key')
+  .eq('is_active', true)
+  .single()
+  .then(({data}) => {
+    if (data) console.log('AUTO-PROCEED ACTIVE: ' + data.active_sd_key);
+    else console.log('AUTO-PROCEED: INACTIVE');
+  });
+"
+```
+
+**If AUTO-PROCEED is ACTIVE:**
+- Skip AskUserQuestion
+- Output status: `🤖 AUTO-PROCEED: Learning captured, continuing to next SD...`
+- Auto-invoke `/leo next` to continue with next SD in queue
+
+**If AUTO-PROCEED is INACTIVE:**
 **After SD creation - Use AskUserQuestion:**
 
 ```javascript


### PR DESCRIPTION
## Summary
- Add AUTO-PROCEED detection to /ship, /document, /learn commands
- Auto-continue to next command in sequence when AUTO-PROCEED is active
- Skip user confirmation prompts and output status messages instead

## Changes
- `.claude/commands/ship.md` - AUTO-PROCEED awareness at merge and post-merge steps
- `.claude/commands/document.md` - AUTO-PROCEED awareness after documentation updates
- `.claude/commands/learn.md` - AUTO-PROCEED awareness after SD creation

## SD Reference
SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-B

## Test plan
- [x] Post-completion requirements tests pass (31/31)
- [x] Smoke tests pass (15/15)
- [x] No ESLint errors

---
Generated with [Claude Code](https://claude.com/claude-code)