### PR TITLE
feat(auto-proceed): integrate post-completion sequence in leo-continuous.js

### DIFF
--- a/test/unit/leo-continuous-post-completion.test.js
+++ b/test/unit/leo-continuous-post-completion.test.js
@@ -1,0 +1,126 @@
+/**
+ * Unit Tests: leo-continuous.js Post-Completion Integration
+ *
+ * Tests the post-completion sequence integration in leo-continuous.js.
+ *
+ * SD: SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-N
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Test the post-completion requirements module integration
+import {
+  getPostCompletionRequirements,
+  getPostCompletionSequence,
+  shouldSkipLearn
+} from '../../lib/utils/post-completion-requirements.js';
+
+describe('leo-continuous Post-Completion Integration', () => {
+  describe('Post-completion requirements integration', () => {
+    it('should return full sequence for feature SDs', () => {
+      const requirements = getPostCompletionRequirements('feature');
+      const sequence = getPostCompletionSequence('feature');
+
+      expect(requirements.sequenceType).toBe('full');
+      expect(sequence).toContain('ship');
+      expect(requirements.ship).toBe(true);
+    });
+
+    it('should return minimal sequence for infrastructure SDs', () => {
+      const requirements = getPostCompletionRequirements('infrastructure');
+      const sequence = getPostCompletionSequence('infrastructure');
+
+      expect(requirements.sequenceType).toBe('minimal');
+      expect(sequence).toContain('ship');
+      expect(sequence).not.toContain('learn');
+      expect(requirements.learn).toBe(false);
+    });
+
+    it('should return minimal sequence for orchestrator SDs', () => {
+      const requirements = getPostCompletionRequirements('orchestrator');
+      const sequence = getPostCompletionSequence('orchestrator');
+
+      expect(requirements.sequenceType).toBe('minimal');
+      expect(sequence.length).toBe(1);
+      expect(sequence[0]).toBe('ship');
+    });
+
+    it('should skip learn for SDs created by learn command', () => {
+      const requirements = getPostCompletionRequirements('feature', { source: 'learn' });
+
+      expect(requirements.learn).toBe(false);
+      expect(requirements.skipLearnReason).toContain('learn');
+    });
+
+    it('should skip learn for quick-fix SDs', () => {
+      const sd = { sd_type: 'bugfix', source: 'quick-fix' };
+      const result = shouldSkipLearn(sd);
+
+      expect(result.skip).toBe(true);
+      expect(result.reason).toContain('quick-fix');
+    });
+  });
+
+  describe('Sequence ordering', () => {
+    it('should have restart before ship for feature SDs', () => {
+      const sequence = getPostCompletionSequence('feature', { hasUIChanges: true });
+
+      if (sequence.includes('restart')) {
+        const restartIdx = sequence.indexOf('restart');
+        const shipIdx = sequence.indexOf('ship');
+        expect(restartIdx).toBeLessThan(shipIdx);
+      }
+    });
+
+    it('should have document after ship', () => {
+      const sequence = getPostCompletionSequence('feature');
+
+      if (sequence.includes('document')) {
+        const documentIdx = sequence.indexOf('document');
+        const shipIdx = sequence.indexOf('ship');
+        expect(documentIdx).toBeGreaterThan(shipIdx);
+      }
+    });
+
+    it('should have learn at the end', () => {
+      const sequence = getPostCompletionSequence('feature');
+
+      if (sequence.includes('learn')) {
+        const learnIdx = sequence.indexOf('learn');
+        expect(learnIdx).toBe(sequence.length - 1);
+      }
+    });
+  });
+
+  describe('SD type coverage', () => {
+    const sdTypes = [
+      'feature',
+      'bugfix',
+      'security',
+      'enhancement',
+      'refactor',
+      'performance',
+      'infrastructure',
+      'documentation',
+      'orchestrator',
+      'database'
+    ];
+
+    sdTypes.forEach(sdType => {
+      it(`should handle ${sdType} SD type`, () => {
+        const requirements = getPostCompletionRequirements(sdType);
+        const sequence = getPostCompletionSequence(sdType);
+
+        // All SD types should have sdType property
+        expect(requirements.sdType).toBe(sdType.toLowerCase());
+
+        // All SD types should have sequenceType
+        expect(['full', 'minimal']).toContain(requirements.sequenceType);
+
+        // All SD types should have at least ship command
+        expect(sequence).toContain('ship');
+        expect(sequence.length).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Integrates post-completion sequence into leo-continuous.js for autonomous execution
- After SD completion, calls getPostCompletionRequirements(sdType) from Child A
- Executes command sequence based on SD type (restart, ship, document, learn)
- Logs to continuous_execution_log for audit trail

## Test plan
- [x] Unit tests pass (18/18)
- [x] Smoke tests pass

## SD Reference
SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-N

🤖 Generated with [Claude Code](https://claude.com/claude-code)