### PR TITLE
feat(auto-proceed): add type-aware SD completion validation

### DIFF
--- a/scripts/hooks/stop-subagent-enforcement.js
+++ b/scripts/hooks/stop-subagent-enforcement.js
@@ -24,6 +24,12 @@ import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
 
+// SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-H: Type-aware completion validation
+import {
+  getValidationRequirements,
+  getUATRequirement
+} from '../../lib/utils/sd-type-validation.js';
+
 dotenv.config();
 
 // ============================================================================
@@ -277,6 +283,184 @@ async function validatePostCompletion(supabase, sd, sdKey) {
 }
 
 // ============================================================================
+// TYPE-AWARE COMPLETION VALIDATION (SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-H)
+// ============================================================================
+
+/**
+ * Validate that an SD is properly completed based on its type-specific requirements.
+ *
+ * Uses getValidationRequirements() and getUATRequirement() to determine:
+ * - Whether UAT was executed (for types that require it)
+ * - Whether human verification was performed (for types that require it)
+ * - Whether E2E tests exist (for code-producing types)
+ *
+ * Blocks session end if SD has commits on main but is not properly completed
+ * per its type-specific requirements.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Object} sd - The Strategic Directive
+ * @param {string} sdKey - The SD key
+ */
+async function validateCompletionForType(supabase, sd, sdKey) {
+  const requirements = getValidationRequirements(sd);
+  const uatRequirement = getUATRequirement(sd.sd_type);
+
+  const violations = [];
+  const warnings = [];
+
+  // 1. Check UAT execution for types that require it
+  if (uatRequirement === 'REQUIRED' || requirements.requiresUATExecution) {
+    // Check for UAT execution records
+    const { data: uatRecords } = await supabase
+      .from('uat_test_runs')
+      .select('id, status, overall_result')
+      .eq('sd_id', sd.id)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    const hasPassingUAT = uatRecords?.some(r =>
+      r.status === 'completed' && ['pass', 'partial_pass'].includes(r.overall_result)
+    );
+
+    if (!hasPassingUAT) {
+      violations.push({
+        type: 'UAT_MISSING',
+        message: `SD type '${sd.sd_type}' requires UAT execution before completion`,
+        requirement: uatRequirement,
+        remediation: 'Run /uat to execute user acceptance testing'
+      });
+    }
+  }
+
+  // 2. Check human-verifiable outcome for types that require it
+  if (requirements.requiresHumanVerifiableOutcome) {
+    // Check for human verification records
+    const { data: verificationRecords } = await supabase
+      .from('sub_agent_execution_results')
+      .select('verdict, metadata')
+      .eq('sd_id', sd.id)
+      .eq('sub_agent_code', 'UAT')
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    const hasHumanVerification = verificationRecords?.some(r =>
+      ['PASS', 'CONDITIONAL_PASS'].includes(r.verdict)
+    );
+
+    if (!hasHumanVerification) {
+      // This is a warning, not a blocking violation
+      // UAT execution already covers the blocking requirement
+      warnings.push({
+        type: 'HUMAN_VERIFICATION_MISSING',
+        message: `SD type '${sd.sd_type}' recommends ${requirements.humanVerificationType} verification`,
+        reason: requirements.humanVerificationReason
+      });
+    }
+  }
+
+  // 3. Check E2E tests for code-producing types
+  if (requirements.requiresE2ETests) {
+    // Check for E2E test runs
+    const { data: e2eRecords } = await supabase
+      .from('sub_agent_execution_results')
+      .select('verdict')
+      .eq('sd_id', sd.id)
+      .eq('sub_agent_code', 'TESTING')
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    const hasPassingE2E = e2eRecords?.some(r =>
+      ['PASS', 'CONDITIONAL_PASS'].includes(r.verdict)
+    );
+
+    if (!hasPassingE2E) {
+      violations.push({
+        type: 'E2E_TESTS_MISSING',
+        message: `SD type '${sd.sd_type}' requires E2E tests before completion`,
+        remediation: 'Run TESTING sub-agent to execute E2E tests'
+      });
+    }
+  }
+
+  // 4. Check LLM UX validation for types that require it
+  if (requirements.requiresLLMUXValidation) {
+    const { data: uxRecords } = await supabase
+      .from('sub_agent_execution_results')
+      .select('verdict, metadata')
+      .eq('sd_id', sd.id)
+      .eq('sub_agent_code', 'DESIGN')
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    const hasPassingUX = uxRecords?.some(r => {
+      if (!['PASS', 'CONDITIONAL_PASS'].includes(r.verdict)) return false;
+      // Check for minimum score if metadata available
+      const score = r.metadata?.ux_score || r.metadata?.score || 100;
+      return score >= requirements.llmUxMinScore;
+    });
+
+    if (!hasPassingUX) {
+      warnings.push({
+        type: 'LLM_UX_VALIDATION_MISSING',
+        message: `SD type '${sd.sd_type}' recommends LLM UX validation (min score: ${requirements.llmUxMinScore})`,
+        lenses: requirements.llmUxRequiredLenses
+      });
+    }
+  }
+
+  // Output violations (BLOCK)
+  if (violations.length > 0) {
+    console.error(`\n⚠️  Type-Aware Completion Validation for ${sdKey}`);
+    console.error(`   SD Type: ${sd.sd_type}`);
+    console.error(`   UAT Requirement: ${uatRequirement}`);
+    console.error('   ❌ BLOCKING VIOLATIONS:');
+    violations.forEach(v => {
+      console.error(`      - ${v.type}: ${v.message}`);
+      if (v.remediation) console.error(`        Action: ${v.remediation}`);
+    });
+
+    if (warnings.length > 0) {
+      console.error('   ⚠️  Additional warnings:');
+      warnings.forEach(w => console.error(`      - ${w.type}: ${w.message}`));
+    }
+
+    const output = {
+      decision: 'block',
+      reason: `SD ${sdKey} (${sd.sd_type}) has type-specific completion violations`,
+      details: {
+        sd_key: sdKey,
+        sd_type: sd.sd_type,
+        uat_requirement: uatRequirement,
+        violations: violations,
+        warnings: warnings,
+        requirements_summary: {
+          requiresUAT: requirements.requiresUATExecution,
+          requiresE2E: requirements.requiresE2ETests,
+          requiresHumanVerification: requirements.requiresHumanVerifiableOutcome,
+          requiresLLMUX: requirements.requiresLLMUXValidation
+        }
+      },
+      remediation: {
+        priority_actions: violations.map(v => v.remediation).filter(Boolean)
+      }
+    };
+
+    console.log(JSON.stringify(output));
+    process.exit(2);
+  }
+
+  // Output warnings (non-blocking)
+  if (warnings.length > 0) {
+    console.error(`\n💡 Type-Aware Completion Advisory for ${sdKey}`);
+    console.error(`   SD Type: ${sd.sd_type}`);
+    warnings.forEach(w => console.error(`   - ${w.type}: ${w.message}`));
+    console.error('   (Not blocking - these improve quality assurance)');
+  } else {
+    console.error(`✅ Type-Aware Completion: ${sdKey} (${sd.sd_type}) passed all type-specific checks`);
+  }
+}
+
+// ============================================================================
 // MAIN LOGIC
 // ============================================================================
 
@@ -327,6 +511,22 @@ async function main() {
   if (sd.status === 'completed' || sd.current_phase === 'COMPLETED') {
     await validatePostCompletion(supabase, sd, sdKey);
     process.exit(0);
+  }
+
+  // 5a. Type-aware completion validation (SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-H)
+  // Check if SD has commits and is near completion (EXEC phase or later)
+  const nearCompletionPhases = ['EXEC', 'PLAN_VERIFY', 'LEAD_FINAL', 'PLAN', 'PLAN-TO-LEAD'];
+  if (nearCompletionPhases.includes(sd.current_phase)) {
+    // Only validate if there are actual commits
+    try {
+      const diffOutput = execSync('git diff main...HEAD --name-only', { encoding: 'utf-8' }).trim();
+      if (diffOutput) {
+        // Has commits - validate type-specific completion requirements
+        await validateCompletionForType(supabase, sd, sdKey);
+      }
+    } catch {
+      // If diff fails, skip type-aware validation
+    }
   }
 
   // 5b. Skip if no work has been committed on the branch (nothing to validate)

--- a/test/unit/type-aware-completion.test.js
+++ b/test/unit/type-aware-completion.test.js
@@ -1,0 +1,228 @@
+/**
+ * Unit Tests: Type-Aware SD Completion Validation
+ *
+ * Tests the type-specific completion validation logic.
+ *
+ * SD: SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-H
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Test the sd-type-validation module functions
+import {
+  getValidationRequirements,
+  getUATRequirement
+} from '../../lib/utils/sd-type-validation.js';
+
+describe('Type-Aware SD Completion Validation', () => {
+  describe('getUATRequirement', () => {
+    it('should return REQUIRED for feature SDs', () => {
+      expect(getUATRequirement('feature')).toBe('REQUIRED');
+    });
+
+    it('should return REQUIRED for bugfix SDs', () => {
+      expect(getUATRequirement('bugfix')).toBe('REQUIRED');
+    });
+
+    it('should return REQUIRED for security SDs', () => {
+      expect(getUATRequirement('security')).toBe('REQUIRED');
+    });
+
+    it('should return REQUIRED for refactor SDs', () => {
+      expect(getUATRequirement('refactor')).toBe('REQUIRED');
+    });
+
+    it('should return REQUIRED for enhancement SDs', () => {
+      expect(getUATRequirement('enhancement')).toBe('REQUIRED');
+    });
+
+    it('should return PROMPT for performance SDs', () => {
+      expect(getUATRequirement('performance')).toBe('PROMPT');
+    });
+
+    it('should return EXEMPT for infrastructure SDs', () => {
+      expect(getUATRequirement('infrastructure')).toBe('EXEMPT');
+    });
+
+    it('should return EXEMPT for database SDs', () => {
+      expect(getUATRequirement('database')).toBe('EXEMPT');
+    });
+
+    it('should return EXEMPT for documentation SDs', () => {
+      expect(getUATRequirement('documentation')).toBe('EXEMPT');
+    });
+
+    it('should return EXEMPT for orchestrator SDs', () => {
+      expect(getUATRequirement('orchestrator')).toBe('EXEMPT');
+    });
+
+    it('should return PROMPT for unknown types', () => {
+      expect(getUATRequirement('unknown-type')).toBe('PROMPT');
+    });
+
+    it('should handle case insensitivity', () => {
+      expect(getUATRequirement('FEATURE')).toBe('REQUIRED');
+      expect(getUATRequirement('Feature')).toBe('REQUIRED');
+    });
+
+    it('should handle null/undefined', () => {
+      expect(getUATRequirement(null)).toBe('REQUIRED'); // defaults to feature
+      expect(getUATRequirement(undefined)).toBe('REQUIRED');
+    });
+  });
+
+  describe('getValidationRequirements', () => {
+    describe('Feature SDs', () => {
+      it('should require UAT execution', () => {
+        const sd = { sd_type: 'feature', title: 'Test Feature' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresUATExecution).toBe(true);
+      });
+
+      it('should require human verifiable outcome', () => {
+        const sd = { sd_type: 'feature', title: 'Test Feature' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresHumanVerifiableOutcome).toBe(true);
+        expect(reqs.humanVerificationType).toBe('ui_smoke_test');
+      });
+
+      it('should require E2E tests', () => {
+        const sd = { sd_type: 'feature', title: 'Test Feature' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresE2ETests).toBe(true);
+      });
+
+      it('should require LLM UX validation', () => {
+        const sd = { sd_type: 'feature', title: 'Test Feature' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresLLMUXValidation).toBe(true);
+        expect(reqs.llmUxMinScore).toBe(50);
+      });
+    });
+
+    describe('Bugfix SDs', () => {
+      it('should require UAT execution', () => {
+        const sd = { sd_type: 'bugfix', title: 'Fix Bug' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresUATExecution).toBe(true);
+      });
+
+      it('should require human verifiable outcome', () => {
+        const sd = { sd_type: 'bugfix', title: 'Fix Bug' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresHumanVerifiableOutcome).toBe(true);
+        expect(reqs.humanVerificationType).toBe('ui_smoke_test');
+      });
+
+      it('should NOT require LLM UX validation', () => {
+        const sd = { sd_type: 'bugfix', title: 'Fix Bug' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresLLMUXValidation).toBe(false);
+      });
+    });
+
+    describe('Infrastructure SDs', () => {
+      it('should NOT require UAT execution', () => {
+        const sd = { sd_type: 'infrastructure', title: 'Infra Work' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresUATExecution).toBe(false);
+      });
+
+      it('should NOT require human verifiable outcome', () => {
+        const sd = { sd_type: 'infrastructure', title: 'Infra Work' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresHumanVerifiableOutcome).toBe(false);
+      });
+
+      it('should skip code validation', () => {
+        const sd = { sd_type: 'infrastructure', title: 'Infra Work' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.skipCodeValidation).toBe(true);
+      });
+    });
+
+    describe('Documentation SDs', () => {
+      it('should NOT require any human verification', () => {
+        const sd = { sd_type: 'documentation', title: 'Docs Update' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresUATExecution).toBe(false);
+        expect(reqs.requiresHumanVerifiableOutcome).toBe(false);
+        expect(reqs.humanVerificationType).toBe('none');
+      });
+
+      it('should skip code validation', () => {
+        const sd = { sd_type: 'documentation', title: 'Docs Update' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.skipCodeValidation).toBe(true);
+        expect(reqs.requiresTesting).toBe(false);
+        expect(reqs.requiresE2ETests).toBe(false);
+      });
+    });
+
+    describe('Orchestrator SDs', () => {
+      it('should have minimal requirements', () => {
+        const sd = { sd_type: 'orchestrator', title: 'Orchestrator' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresUATExecution).toBe(false);
+        expect(reqs.requiresHumanVerifiableOutcome).toBe(false);
+        expect(reqs.requiresLLMUXValidation).toBe(false);
+      });
+    });
+
+    describe('Security SDs', () => {
+      it('should require UAT and human verification', () => {
+        const sd = { sd_type: 'security', title: 'Security Fix' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresUATExecution).toBe(true);
+        expect(reqs.requiresHumanVerifiableOutcome).toBe(true);
+        expect(reqs.humanVerificationType).toBe('api_test');
+      });
+    });
+
+    describe('Enhancement SDs', () => {
+      it('should require UAT (LEO v4.4.1)', () => {
+        const sd = { sd_type: 'enhancement', title: 'Enhancement' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresUATExecution).toBe(true);
+      });
+    });
+
+    describe('Refactor SDs', () => {
+      it('should require UAT for regression testing (LEO v4.4.1)', () => {
+        const sd = { sd_type: 'refactor', title: 'Refactor' };
+        const reqs = getValidationRequirements(sd);
+        expect(reqs.requiresUATExecution).toBe(true);
+      });
+    });
+  });
+
+  describe('Integration scenarios', () => {
+    it('UAT requirement should align with validation requirements for feature SDs', () => {
+      const sd = { sd_type: 'feature', title: 'Feature' };
+      const uatReq = getUATRequirement('feature');
+      const validationReqs = getValidationRequirements(sd);
+
+      // Both should indicate UAT is required
+      expect(uatReq).toBe('REQUIRED');
+      expect(validationReqs.requiresUATExecution).toBe(true);
+    });
+
+    it('UAT requirement should align with validation requirements for infrastructure SDs', () => {
+      const sd = { sd_type: 'infrastructure', title: 'Infra' };
+      const uatReq = getUATRequirement('infrastructure');
+      const validationReqs = getValidationRequirements(sd);
+
+      // Both should indicate UAT is NOT required
+      expect(uatReq).toBe('EXEMPT');
+      expect(validationReqs.requiresUATExecution).toBe(false);
+    });
+
+    it('should handle SD with scope containing UI keywords', () => {
+      const sd = { sd_type: 'feature', title: 'Feature', scope: 'Add new dashboard component' };
+      const reqs = getValidationRequirements(sd);
+
+      expect(reqs.hasUIComponents).toBe(true);
+      expect(reqs.requiresDesign).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add validateCompletionForType() function to stop-subagent-enforcement.js
- Uses getValidationRequirements() and getUATRequirement() for type-specific checks
- Validates UAT execution for types that require it (feature, bugfix, security, etc.)
- Validates E2E tests for code-producing types
- Warns about missing human verification and LLM UX validation
- Blocks session end if SD has commits but is not properly completed

## Files Changed
- `scripts/hooks/stop-subagent-enforcement.js` - Added validateCompletionForType()
- `test/unit/type-aware-completion.test.js` - New unit tests (32 tests)

## Testing
- All 32 unit tests pass
- Smoke tests pass

## SD Reference
Part of SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-H

🤖 Generated with [Claude Code](https://claude.com/claude-code)