### PR TITLE
feat(auto-proceed): add type-aware AI bias detection

### DIFF
--- a/scripts/hooks/stop-subagent-enforcement.js
+++ b/scripts/hooks/stop-subagent-enforcement.js
@@ -461,6 +461,190 @@ async function validateCompletionForType(supabase, sd, sdKey) {
 }
 
 // ============================================================================
+// TYPE-AWARE BIAS DETECTION (SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-J)
+// ============================================================================
+
+/**
+ * Detect common AI workflow biases based on SD type and current state.
+ *
+ * Detects three types of biases:
+ * 1. COMPLETION_BIAS: Code shipped to main but SD not marked complete in database
+ * 2. EFFICIENCY_BIAS: Jumped to EXEC phase without proper handoffs
+ * 3. AUTONOMY_BIAS: Code exists without PRD for code-requiring SD types
+ *
+ * Uses type-specific requirements to determine if a bias is applicable.
+ * For example, infrastructure SDs don't require PRD so AUTONOMY_BIAS doesn't apply.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Object} sd - The Strategic Directive
+ * @param {string} sdKey - The SD key
+ * @param {Object} requirements - Validation requirements from getValidationRequirements()
+ */
+async function detectBiasesForType(supabase, sd, sdKey, requirements) {
+  const biases = [];
+  const sdType = sd.sd_type || 'feature';
+
+  // 1. COMPLETION_BIAS: Code on main but SD not complete
+  // Check if commits from this SD's branch have been merged to main
+  try {
+    // Check if there are merged PRs for this SD
+    const { data: prRecords } = await supabase
+      .from('sd_scope_deliverables')
+      .select('deliverable_name, completion_status, metadata')
+      .eq('sd_id', sd.id)
+      .ilike('deliverable_name', '%PR%');
+
+    const hasMergedPR = prRecords?.some(pr =>
+      pr.completion_status === 'completed' ||
+      pr.metadata?.merged === true
+    );
+
+    // SD has code on main but isn't marked complete
+    if (hasMergedPR && sd.status !== 'completed' && sd.current_phase !== 'COMPLETED') {
+      biases.push({
+        type: 'COMPLETION_BIAS',
+        severity: 'high',
+        message: 'Code merged to main but SD not marked complete in database',
+        details: {
+          sd_status: sd.status,
+          current_phase: sd.current_phase,
+          has_merged_pr: true
+        },
+        root_cause: 'Claude may confuse "code shipped" with "SD complete"',
+        remediation: 'Execute LEAD-FINAL-APPROVAL handoff or mark SD complete',
+        command: `node scripts/handoff.js execute LEAD-FINAL-APPROVAL ${sdKey}`
+      });
+    }
+  } catch {
+    // Ignore errors in PR check
+  }
+
+  // 2. EFFICIENCY_BIAS: In EXEC phase without proper handoffs
+  // Check if jumped to implementation without LEAD-TO-PLAN and PLAN-TO-EXEC
+  if (sd.current_phase === 'EXEC' || sd.current_phase === 'EXEC_IMPLEMENTATION') {
+    const { data: handoffs } = await supabase
+      .from('sd_phase_handoffs')
+      .select('handoff_type, status')
+      .eq('sd_id', sd.id)
+      .eq('status', 'accepted');
+
+    const acceptedHandoffs = (handoffs || []).map(h => h.handoff_type);
+    const hasLeadToPlan = acceptedHandoffs.includes('LEAD-TO-PLAN');
+    const hasPlanToExec = acceptedHandoffs.includes('PLAN-TO-EXEC');
+
+    if (!hasLeadToPlan || !hasPlanToExec) {
+      const missingHandoffs = [];
+      if (!hasLeadToPlan) missingHandoffs.push('LEAD-TO-PLAN');
+      if (!hasPlanToExec) missingHandoffs.push('PLAN-TO-EXEC');
+
+      biases.push({
+        type: 'EFFICIENCY_BIAS',
+        severity: 'medium',
+        message: `In EXEC phase without required handoffs: ${missingHandoffs.join(', ')}`,
+        details: {
+          current_phase: sd.current_phase,
+          accepted_handoffs: acceptedHandoffs,
+          missing_handoffs: missingHandoffs
+        },
+        root_cause: 'Claude may skip planning to start coding faster',
+        remediation: 'Execute missing handoffs before continuing',
+        command: `node scripts/handoff.js execute ${missingHandoffs[0]} ${sdKey}`
+      });
+    }
+  }
+
+  // 3. AUTONOMY_BIAS: Code exists without PRD for code-requiring SD types
+  // Only check for SD types that require PRD (feature, bugfix, security, etc.)
+  if (!requirements.skipCodeValidation) {
+    // Check if there's a PRD
+    const { data: prd } = await supabase
+      .from('product_requirements_v2')
+      .select('id')
+      .eq('sd_id', sd.id)
+      .single();
+
+    const hasPRD = prd !== null;
+
+    // Check if there are code changes on the branch
+    let hasCodeChanges = false;
+    try {
+      const diffOutput = execSync('git diff main...HEAD --name-only', { encoding: 'utf-8' }).trim();
+      // Filter for actual code files (not test files, not markdown, not config)
+      const codeFiles = diffOutput.split('\n').filter(f =>
+        f && !f.includes('.test.') && !f.includes('.spec.') &&
+        !f.endsWith('.md') && !f.endsWith('.json') &&
+        (f.endsWith('.js') || f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.jsx'))
+      );
+      hasCodeChanges = codeFiles.length > 0;
+    } catch {
+      // Ignore diff errors
+    }
+
+    if (hasCodeChanges && !hasPRD) {
+      biases.push({
+        type: 'AUTONOMY_BIAS',
+        severity: 'high',
+        message: `Code changes exist without PRD for ${sdType} SD (requires PRD)`,
+        details: {
+          sd_type: sdType,
+          has_prd: false,
+          has_code_changes: true,
+          requires_prd: !requirements.skipCodeValidation
+        },
+        root_cause: 'Claude may start coding without defining requirements first',
+        remediation: 'Create PRD before continuing with implementation',
+        command: `node scripts/add-prd-to-database.js ${sdKey}`
+      });
+    }
+  }
+
+  // Output detected biases
+  if (biases.length > 0) {
+    console.error(`\n🧠 AI Bias Detection for ${sdKey} (${sdType})`);
+    console.error(`   Current Phase: ${sd.current_phase}`);
+    console.error(`   Status: ${sd.status}`);
+    console.error('');
+
+    biases.forEach((bias, idx) => {
+      const severityIcon = bias.severity === 'high' ? '🔴' : bias.severity === 'medium' ? '🟡' : '🟢';
+      console.error(`   ${idx + 1}. ${severityIcon} ${bias.type}`);
+      console.error(`      Message: ${bias.message}`);
+      console.error(`      Root Cause: ${bias.root_cause}`);
+      console.error(`      Action: ${bias.remediation}`);
+      if (bias.command) {
+        console.error(`      Command: ${bias.command}`);
+      }
+      console.error('');
+    });
+
+    // High severity biases should block
+    const highSeverityBiases = biases.filter(b => b.severity === 'high');
+    if (highSeverityBiases.length > 0) {
+      const output = {
+        decision: 'block',
+        reason: `Detected ${highSeverityBiases.length} high-severity AI biases for ${sdKey}`,
+        details: {
+          sd_key: sdKey,
+          sd_type: sdType,
+          current_phase: sd.current_phase,
+          biases: biases
+        },
+        remediation: {
+          priority_actions: highSeverityBiases.map(b => b.remediation),
+          commands: highSeverityBiases.map(b => b.command).filter(Boolean)
+        }
+      };
+
+      console.log(JSON.stringify(output));
+      process.exit(2);
+    }
+
+    // Medium severity biases warn but don't block
+    console.error('   (Medium severity biases are warnings - not blocking)');
+  }
+}
+
+// ============================================================================
 // MAIN LOGIC
 // ============================================================================
 
@@ -539,6 +723,11 @@ async function main() {
   } catch {
     // If diff fails (e.g., main doesn't exist), continue with normal validation
   }
+
+  // 5c. Type-aware bias detection (SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-J)
+  // Detect common AI workflow biases based on SD type and state
+  const validationRequirements = getValidationRequirements(sd);
+  await detectBiasesForType(supabase, sd, sdKey, validationRequirements);
 
   // 6. Determine required + recommended sub-agents
   const sdType = sd.sd_type || 'feature';

--- a/test/unit/bias-detection.test.js
+++ b/test/unit/bias-detection.test.js
@@ -1,0 +1,266 @@
+/**
+ * Unit Tests: Type-Aware Bias Detection
+ *
+ * Tests the AI bias detection logic that identifies workflow violations.
+ *
+ * SD: SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-J
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Test the bias detection patterns
+// The actual detectBiasesForType() function requires database and git,
+// so we test the logic patterns independently
+
+describe('Type-Aware Bias Detection Patterns', () => {
+  describe('COMPLETION_BIAS detection logic', () => {
+    it('should detect when SD has merged PR but is not complete', () => {
+      const sd = {
+        status: 'in_progress',
+        current_phase: 'EXEC',
+        sd_type: 'feature'
+      };
+      const hasMergedPR = true;
+      const isComplete = sd.status === 'completed' || sd.current_phase === 'COMPLETED';
+
+      const hasCompletionBias = hasMergedPR && !isComplete;
+      expect(hasCompletionBias).toBe(true);
+    });
+
+    it('should NOT detect bias when SD is properly complete', () => {
+      const sd = {
+        status: 'completed',
+        current_phase: 'COMPLETED',
+        sd_type: 'feature'
+      };
+      const hasMergedPR = true;
+      const isComplete = sd.status === 'completed' || sd.current_phase === 'COMPLETED';
+
+      const hasCompletionBias = hasMergedPR && !isComplete;
+      expect(hasCompletionBias).toBe(false);
+    });
+
+    it('should NOT detect bias when no PR has been merged', () => {
+      const sd = {
+        status: 'in_progress',
+        current_phase: 'EXEC',
+        sd_type: 'feature'
+      };
+      const hasMergedPR = false;
+      const isComplete = sd.status === 'completed' || sd.current_phase === 'COMPLETED';
+
+      const hasCompletionBias = hasMergedPR && !isComplete;
+      expect(hasCompletionBias).toBe(false);
+    });
+  });
+
+  describe('EFFICIENCY_BIAS detection logic', () => {
+    it('should detect when in EXEC without LEAD-TO-PLAN handoff', () => {
+      const sd = { current_phase: 'EXEC' };
+      const acceptedHandoffs = ['PLAN-TO-EXEC'];
+
+      const hasLeadToPlan = acceptedHandoffs.includes('LEAD-TO-PLAN');
+      const hasPlanToExec = acceptedHandoffs.includes('PLAN-TO-EXEC');
+      const inExecPhase = sd.current_phase === 'EXEC' || sd.current_phase === 'EXEC_IMPLEMENTATION';
+
+      const hasEfficiencyBias = inExecPhase && (!hasLeadToPlan || !hasPlanToExec);
+      expect(hasEfficiencyBias).toBe(true);
+    });
+
+    it('should detect when in EXEC without PLAN-TO-EXEC handoff', () => {
+      const sd = { current_phase: 'EXEC' };
+      const acceptedHandoffs = ['LEAD-TO-PLAN'];
+
+      const hasLeadToPlan = acceptedHandoffs.includes('LEAD-TO-PLAN');
+      const hasPlanToExec = acceptedHandoffs.includes('PLAN-TO-EXEC');
+      const inExecPhase = sd.current_phase === 'EXEC' || sd.current_phase === 'EXEC_IMPLEMENTATION';
+
+      const hasEfficiencyBias = inExecPhase && (!hasLeadToPlan || !hasPlanToExec);
+      expect(hasEfficiencyBias).toBe(true);
+    });
+
+    it('should NOT detect bias when all required handoffs exist', () => {
+      const sd = { current_phase: 'EXEC' };
+      const acceptedHandoffs = ['LEAD-TO-PLAN', 'PLAN-TO-EXEC'];
+
+      const hasLeadToPlan = acceptedHandoffs.includes('LEAD-TO-PLAN');
+      const hasPlanToExec = acceptedHandoffs.includes('PLAN-TO-EXEC');
+      const inExecPhase = sd.current_phase === 'EXEC' || sd.current_phase === 'EXEC_IMPLEMENTATION';
+
+      const hasEfficiencyBias = inExecPhase && (!hasLeadToPlan || !hasPlanToExec);
+      expect(hasEfficiencyBias).toBe(false);
+    });
+
+    it('should NOT detect bias when not in EXEC phase', () => {
+      const sd = { current_phase: 'PLAN' };
+      const acceptedHandoffs = [];
+
+      const hasLeadToPlan = acceptedHandoffs.includes('LEAD-TO-PLAN');
+      const hasPlanToExec = acceptedHandoffs.includes('PLAN-TO-EXEC');
+      const inExecPhase = sd.current_phase === 'EXEC' || sd.current_phase === 'EXEC_IMPLEMENTATION';
+
+      const hasEfficiencyBias = inExecPhase && (!hasLeadToPlan || !hasPlanToExec);
+      expect(hasEfficiencyBias).toBe(false);
+    });
+  });
+
+  describe('AUTONOMY_BIAS detection logic', () => {
+    it('should detect when code changes exist without PRD for code-requiring SD', () => {
+      const requirements = { skipCodeValidation: false };
+      const hasPRD = false;
+      const hasCodeChanges = true;
+
+      const hasAutonomyBias = !requirements.skipCodeValidation && hasCodeChanges && !hasPRD;
+      expect(hasAutonomyBias).toBe(true);
+    });
+
+    it('should NOT detect bias when PRD exists', () => {
+      const requirements = { skipCodeValidation: false };
+      const hasPRD = true;
+      const hasCodeChanges = true;
+
+      const hasAutonomyBias = !requirements.skipCodeValidation && hasCodeChanges && !hasPRD;
+      expect(hasAutonomyBias).toBe(false);
+    });
+
+    it('should NOT detect bias when no code changes exist', () => {
+      const requirements = { skipCodeValidation: false };
+      const hasPRD = false;
+      const hasCodeChanges = false;
+
+      const hasAutonomyBias = !requirements.skipCodeValidation && hasCodeChanges && !hasPRD;
+      expect(hasAutonomyBias).toBe(false);
+    });
+
+    it('should NOT detect bias for infrastructure SDs (skipCodeValidation = true)', () => {
+      const requirements = { skipCodeValidation: true }; // Infrastructure SD
+      const hasPRD = false;
+      const hasCodeChanges = true;
+
+      const hasAutonomyBias = !requirements.skipCodeValidation && hasCodeChanges && !hasPRD;
+      expect(hasAutonomyBias).toBe(false);
+    });
+  });
+
+  describe('Bias severity classification', () => {
+    it('should classify COMPLETION_BIAS as high severity', () => {
+      const bias = {
+        type: 'COMPLETION_BIAS',
+        severity: 'high'
+      };
+      expect(bias.severity).toBe('high');
+    });
+
+    it('should classify EFFICIENCY_BIAS as medium severity', () => {
+      const bias = {
+        type: 'EFFICIENCY_BIAS',
+        severity: 'medium'
+      };
+      expect(bias.severity).toBe('medium');
+    });
+
+    it('should classify AUTONOMY_BIAS as high severity', () => {
+      const bias = {
+        type: 'AUTONOMY_BIAS',
+        severity: 'high'
+      };
+      expect(bias.severity).toBe('high');
+    });
+
+    it('should block on high severity biases', () => {
+      const biases = [
+        { type: 'COMPLETION_BIAS', severity: 'high' },
+        { type: 'EFFICIENCY_BIAS', severity: 'medium' }
+      ];
+
+      const highSeverityBiases = biases.filter(b => b.severity === 'high');
+      const shouldBlock = highSeverityBiases.length > 0;
+
+      expect(shouldBlock).toBe(true);
+    });
+
+    it('should NOT block on only medium severity biases', () => {
+      const biases = [
+        { type: 'EFFICIENCY_BIAS', severity: 'medium' }
+      ];
+
+      const highSeverityBiases = biases.filter(b => b.severity === 'high');
+      const shouldBlock = highSeverityBiases.length > 0;
+
+      expect(shouldBlock).toBe(false);
+    });
+  });
+
+  describe('Phase-specific bias applicability', () => {
+    const execPhases = ['EXEC', 'EXEC_IMPLEMENTATION'];
+    const nonExecPhases = ['LEAD', 'PLAN', 'PLAN_VERIFY', 'LEAD_FINAL', 'COMPLETED'];
+
+    execPhases.forEach(phase => {
+      it(`should check EFFICIENCY_BIAS for ${phase} phase`, () => {
+        const sd = { current_phase: phase };
+        const isExecPhase = ['EXEC', 'EXEC_IMPLEMENTATION'].includes(sd.current_phase);
+        expect(isExecPhase).toBe(true);
+      });
+    });
+
+    nonExecPhases.forEach(phase => {
+      it(`should NOT check EFFICIENCY_BIAS for ${phase} phase`, () => {
+        const sd = { current_phase: phase };
+        const isExecPhase = ['EXEC', 'EXEC_IMPLEMENTATION'].includes(sd.current_phase);
+        expect(isExecPhase).toBe(false);
+      });
+    });
+  });
+
+  describe('Code file detection patterns', () => {
+    it('should identify JavaScript files as code files', () => {
+      const files = ['src/utils/helper.js', 'lib/index.js'];
+      const codeFiles = files.filter(f =>
+        f && !f.includes('.test.') && !f.includes('.spec.') &&
+        !f.endsWith('.md') && !f.endsWith('.json') &&
+        (f.endsWith('.js') || f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.jsx'))
+      );
+      expect(codeFiles.length).toBe(2);
+    });
+
+    it('should identify TypeScript files as code files', () => {
+      const files = ['src/components/Button.tsx', 'lib/types.ts'];
+      const codeFiles = files.filter(f =>
+        f && !f.includes('.test.') && !f.includes('.spec.') &&
+        !f.endsWith('.md') && !f.endsWith('.json') &&
+        (f.endsWith('.js') || f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.jsx'))
+      );
+      expect(codeFiles.length).toBe(2);
+    });
+
+    it('should exclude test files from code detection', () => {
+      const files = ['src/utils/helper.test.js', 'lib/index.spec.ts'];
+      const codeFiles = files.filter(f =>
+        f && !f.includes('.test.') && !f.includes('.spec.') &&
+        !f.endsWith('.md') && !f.endsWith('.json') &&
+        (f.endsWith('.js') || f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.jsx'))
+      );
+      expect(codeFiles.length).toBe(0);
+    });
+
+    it('should exclude markdown files from code detection', () => {
+      const files = ['README.md', 'docs/guide.md'];
+      const codeFiles = files.filter(f =>
+        f && !f.includes('.test.') && !f.includes('.spec.') &&
+        !f.endsWith('.md') && !f.endsWith('.json') &&
+        (f.endsWith('.js') || f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.jsx'))
+      );
+      expect(codeFiles.length).toBe(0);
+    });
+
+    it('should exclude JSON config files from code detection', () => {
+      const files = ['package.json', 'tsconfig.json'];
+      const codeFiles = files.filter(f =>
+        f && !f.includes('.test.') && !f.includes('.spec.') &&
+        !f.endsWith('.md') && !f.endsWith('.json') &&
+        (f.endsWith('.js') || f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.jsx'))
+      );
+      expect(codeFiles.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add detectBiasesForType() function to stop-subagent-enforcement.js
- COMPLETION_BIAS: Detects when code is merged but SD not marked complete
- EFFICIENCY_BIAS: Detects when in EXEC without required handoffs
- AUTONOMY_BIAS: Detects when code exists without PRD for code-requiring SDs

## Severity Handling
- High-severity biases (COMPLETION_BIAS, AUTONOMY_BIAS) block session end
- Medium-severity biases (EFFICIENCY_BIAS) warn only

## Files Changed
- `scripts/hooks/stop-subagent-enforcement.js` - Added detectBiasesForType()
- `test/unit/bias-detection.test.js` - New unit tests (28 tests)

## Testing
- All 28 unit tests pass
- Smoke tests pass

## SD Reference
Part of SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-J

🤖 Generated with [Claude Code](https://claude.com/claude-code)