### PR TITLE
feat(handoff): dynamic type-aware TESTING validation with git diff code detection

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/mandatory-testing-validation.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/mandatory-testing-validation.js
@@ -8,7 +8,58 @@
  * SD-LEO-HARDEN-VALIDATION-001: Narrowed exemptions to documentation-only
  * - Infrastructure, orchestrator, database now use ADVISORY mode
  * - Only documentation types skip TESTING entirely
+ *
+ * SD-LEO-TESTING-ENFORCEMENT-001: Type-aware dynamic validation
+ * - Uses getValidationRequirements() instead of hardcoded type lists
+ * - Git diff detection to detect actual code changes
+ * - Infrastructure SDs that produce code now require TESTING (ADVISORY mode)
  */
+
+import { getValidationRequirements } from '../../../../../../lib/utils/sd-type-validation.js';
+import { execSync } from 'child_process';
+
+/**
+ * Detect code file changes in the current branch/working directory
+ * Checks git diff for common code file extensions
+ *
+ * @returns {Object} { hasCodeFiles: boolean, codeFileCount: number, codeFiles: string[] }
+ */
+function detectCodeChanges() {
+  const CODE_EXTENSIONS = /\.(js|ts|tsx|jsx|mjs|cjs|py|rb|go|rs|java|cs|php|sql)$/i;
+
+  try {
+    // Get list of modified files (staged + unstaged + recent commits)
+    // Use git diff HEAD~10 to catch recent changes, fallback to just working tree
+    let diffOutput = '';
+    try {
+      diffOutput = execSync('git diff --name-only HEAD~10 2>nul || git diff --name-only', {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe']
+      }).trim();
+    } catch {
+      // Fallback: just check working tree changes
+      diffOutput = execSync('git diff --name-only', {
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe']
+      }).trim();
+    }
+
+    const files = diffOutput.split('\n').filter(f => f.trim());
+    const codeFiles = files.filter(f => CODE_EXTENSIONS.test(f));
+
+    return {
+      hasCodeFiles: codeFiles.length > 0,
+      codeFileCount: codeFiles.length,
+      codeFiles: codeFiles.slice(0, 10) // Limit for logging
+    };
+  } catch (error) {
+    // If git fails, assume there might be code changes (safer default)
+    console.log(`   ⚠️  Git diff detection failed: ${error.message}`);
+    return { hasCodeFiles: true, codeFileCount: 0, codeFiles: [] };
+  }
+}
 
 /**
  * Create the MANDATORY_TESTING_VALIDATION gate validator
@@ -20,31 +71,53 @@ export function createMandatoryTestingValidationGate(supabase) {
   return {
     name: 'MANDATORY_TESTING_VALIDATION',
     validator: async (ctx) => {
-      console.log('\n🧪 MANDATORY TESTING VALIDATION (LEO v4.4.2)');
+      console.log('\n🧪 MANDATORY TESTING VALIDATION (LEO v4.4.3)');
       console.log('-'.repeat(50));
 
-      // 1. Check SD type exemptions
-      // SD-LEO-HARDEN-VALIDATION-001: Narrowed exemptions to documentation-only
-      const sdType = (ctx.sd?.sd_type || 'feature').toLowerCase();
-      const EXEMPT_TYPES = ['documentation', 'docs'];
-      const ADVISORY_TYPES = ['infrastructure', 'orchestrator', 'database'];
+      // 1. Get type-aware validation requirements (replaces hardcoded lists)
+      // SD-LEO-TESTING-ENFORCEMENT-001: Dynamic validation based on sd_type
+      const validationReqs = getValidationRequirements(ctx.sd);
+      const sdType = validationReqs.sd_type;
 
-      if (EXEMPT_TYPES.includes(sdType)) {
-        console.log(`   ℹ️  ${sdType} type SD - TESTING validation SKIPPED`);
-        console.log('   → Documentation-only SDs have no code paths');
+      console.log(`   📋 SD Type: ${sdType}`);
+      console.log(`   📋 requiresTesting (type-based): ${validationReqs.requiresTesting}`);
+      console.log(`   📋 skipCodeValidation: ${validationReqs.skipCodeValidation}`);
+
+      // 2. Detect actual code changes via git diff
+      const codeEvidence = detectCodeChanges();
+      console.log(`   📋 Code files detected: ${codeEvidence.hasCodeFiles} (${codeEvidence.codeFileCount} files)`);
+
+      if (codeEvidence.codeFiles.length > 0) {
+        console.log(`      Files: ${codeEvidence.codeFiles.slice(0, 5).join(', ')}${codeEvidence.codeFiles.length > 5 ? '...' : ''}`);
+      }
+
+      // 3. TIER: SKIP - truly non-code SD with no code changes
+      // Only skip if type says skip AND no actual code files changed
+      if (validationReqs.skipCodeValidation && !codeEvidence.hasCodeFiles) {
+        console.log(`   ℹ️  ${sdType} type SD with no code changes - TESTING validation SKIPPED`);
+        console.log('   → No code paths to test');
         return {
           passed: true,
           score: 100,
           max_score: 100,
           issues: [],
-          warnings: [`TESTING skipped for ${sdType} type SD (documentation exemption)`],
-          details: { skipped: true, reason: sdType }
+          warnings: [`TESTING skipped for ${sdType} type SD (no code changes detected)`],
+          details: { skipped: true, reason: sdType, tier: 'SKIP' }
         };
       }
 
-      const isAdvisoryMode = ADVISORY_TYPES.includes(sdType);
+      // 4. Determine enforcement tier based on type + code evidence
+      // REQUIRED: Type requires testing (feature, bugfix, security, etc.)
+      // ADVISORY: Type doesn't require testing BUT code changes detected
+      const requiresTesting = validationReqs.requiresTesting || codeEvidence.hasCodeFiles;
+      const isAdvisoryMode = !validationReqs.requiresTesting && codeEvidence.hasCodeFiles;
 
-      // 2. Query for TESTING sub-agent execution
+      if (isAdvisoryMode) {
+        console.log(`   ⚠️  ${sdType} SD type doesn't require TESTING but code changes detected`);
+        console.log('   → ADVISORY mode: TESTING recommended but not blocking');
+      }
+
+      // 5. Query for TESTING sub-agent execution
       const sdUuid = ctx.sd?.id || ctx.sdId;
       const { data: testingResults, error } = await supabase
         .from('sub_agent_execution_results')
@@ -61,28 +134,41 @@ export function createMandatoryTestingValidationGate(supabase) {
           score: 0,
           max_score: 100,
           issues: [`Failed to verify TESTING execution: ${error.message}`],
-          warnings: []
+          warnings: [],
+          details: { tier: requiresTesting ? 'REQUIRED' : 'ADVISORY' }
         };
       }
 
-      // 3. Validate execution exists
+      // 6. Validate execution exists
       if (!testingResults?.length) {
-        // SD-LEO-HARDEN-VALIDATION-001: Advisory mode for infrastructure types
+        // TIER: ADVISORY - non-blocking for infrastructure/orchestrator/database with code changes
+        // SD-LEO-TESTING-ENFORCEMENT-001: Improved warning with code evidence
         if (isAdvisoryMode) {
-          console.log(`   ⚠️  TESTING not executed for ${sdType} SD (ADVISORY MODE)`);
-          console.log('   → Infrastructure SDs should run TESTING for unit test coverage');
+          console.log(`   ⚠️  TESTING not executed for ${sdType} SD with code changes (ADVISORY MODE)`);
+          console.log(`   → ${codeEvidence.codeFileCount} code file(s) detected but type doesn't require TESTING`);
+          console.log('   → Consider running TESTING for test coverage validation');
           console.log('   → This is a warning, not a blocker');
           return {
             passed: true,
             score: 70,
             max_score: 100,
             issues: [],
-            warnings: [`TESTING not executed for ${sdType} SD - consider running for unit test coverage`],
-            details: { advisory: true, reason: `${sdType} SD missing TESTING` }
+            warnings: [
+              `TESTING not executed for ${sdType} SD with ${codeEvidence.codeFileCount} code file(s)`,
+              'Consider running TESTING sub-agent for test coverage validation'
+            ],
+            details: {
+              advisory: true,
+              reason: `${sdType} SD with code changes missing TESTING`,
+              tier: 'ADVISORY',
+              codeFileCount: codeEvidence.codeFileCount,
+              codeFiles: codeEvidence.codeFiles
+            }
           };
         }
 
-        console.log('   ❌ ERR_TESTING_REQUIRED: TESTING sub-agent must complete before EXEC-TO-PLAN');
+        // TIER: REQUIRED - blocking for feature/bugfix/security types
+        console.log(`   ❌ ERR_TESTING_REQUIRED: TESTING sub-agent must complete before EXEC-TO-PLAN for ${sdType} SDs`);
         console.log('\n   REMEDIATION:');
         console.log('   1. Run TESTING sub-agent before completing EXEC phase');
         console.log('   2. Command: node scripts/orchestrate-phase-subagents.js PLAN_VERIFY ' + (ctx.sdId || sdUuid));
@@ -92,12 +178,13 @@ export function createMandatoryTestingValidationGate(supabase) {
           passed: false,
           score: 0,
           max_score: 100,
-          issues: ['ERR_TESTING_REQUIRED: TESTING sub-agent must complete before EXEC-TO-PLAN for feature/qa SDs'],
-          warnings: []
+          issues: [`ERR_TESTING_REQUIRED: TESTING sub-agent must complete before EXEC-TO-PLAN for ${sdType} SDs`],
+          warnings: [],
+          details: { tier: 'REQUIRED' }
         };
       }
 
-      // 4. Validate verdict is acceptable
+      // 8. Validate verdict is acceptable
       const result = testingResults[0];
       console.log(`   📊 TESTING result found: ${result.verdict} (${result.confidence}% confidence)`);
 
@@ -112,7 +199,7 @@ export function createMandatoryTestingValidationGate(supabase) {
         };
       }
 
-      // 5. Validate freshness (default 24h)
+      // 9. Validate freshness (default 24h)
       const maxAgeHours = parseInt(process.env.LEO_TESTING_MAX_AGE_HOURS || '24');
       const ageHours = (Date.now() - new Date(result.created_at)) / 3600000;
 
@@ -123,13 +210,16 @@ export function createMandatoryTestingValidationGate(supabase) {
           score: 50,
           max_score: 100,
           issues: [`TESTING results stale (${ageHours.toFixed(1)}h old, max ${maxAgeHours}h)`],
-          warnings: []
+          warnings: [],
+          details: { tier: requiresTesting ? 'REQUIRED' : 'ADVISORY' }
         };
       }
 
+      // 10. TESTING validation passed
       console.log('   ✅ TESTING validation passed');
       console.log(`      Verdict: ${result.verdict}`);
       console.log(`      Age: ${ageHours.toFixed(1)}h (max ${maxAgeHours}h)`);
+      console.log(`      Tier: ${requiresTesting ? 'REQUIRED' : 'ADVISORY'}`);
 
       return {
         passed: true,
@@ -141,7 +231,8 @@ export function createMandatoryTestingValidationGate(supabase) {
           verdict: result.verdict,
           confidence: result.confidence,
           age_hours: ageHours.toFixed(1),
-          max_age_hours: maxAgeHours
+          max_age_hours: maxAgeHours,
+          tier: requiresTesting ? 'REQUIRED' : 'ADVISORY'
         }
       };
     },


### PR DESCRIPTION
## Summary

- Replace hardcoded SD type exemption lists with dynamic validation using `getValidationRequirements()` from `lib/utils/sd-type-validation.js`
- Add `detectCodeChanges()` function that scans git diff for code file extensions (`.js`, `.ts`, `.tsx`, `.py`, `.sql`, etc.)
- Implement 3-tier enforcement system:
  - **SKIP**: `skipCodeValidation=true` AND no code files detected → 100/100 score
  - **ADVISORY**: `requiresTesting=false` BUT code files detected → 70/100 score with warnings
  - **REQUIRED**: `requiresTesting=true` (feature, bugfix, security) → blocks if TESTING missing
- Update documentation with v4.4.3 changes, new tier mapping table, and enhanced example outputs

**Closes enforcement gap**: All 6 AUTO-PROCEED orchestrator children retrospectives identified "Mandate TESTING sub-agent execution before EXEC→PLAN handoff" as missing enforcement. Infrastructure/orchestrator SDs that produce code now trigger ADVISORY mode instead of full exemption.

## Files Changed

- `scripts/modules/handoff/executors/exec-to-plan/gates/mandatory-testing-validation.js` - Core implementation (~145 lines modified)
- `docs/03_protocols_and_standards/LEO_v4.4.2_testing_governance.md` - Documentation (~192 lines added/modified)

## Test plan

- [x] Syntax check passes (`node --check mandatory-testing-validation.js`)
- [x] Import resolves correctly (verified `getValidationRequirements` is exported)
- [x] Pre-commit smoke tests pass (15/15 tests)
- [ ] Integration test: Run EXEC→PLAN handoff on a documentation SD (should SKIP)
- [ ] Integration test: Run EXEC→PLAN handoff on infrastructure SD with code changes (should ADVISORY)
- [ ] Integration test: Run EXEC→PLAN handoff on feature SD (should REQUIRED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)