### PR TITLE
feat(sd): LLM-Assisted SD Type Classification

### DIFF
--- a/lib/sd/index.js
+++ b/lib/sd/index.js
@@ -1,0 +1,14 @@
+/**
+ * SD Module Index
+ *
+ * Purpose: Export all SD-related functions
+ * SD: SD-LEO-FEAT-LLM-ASSISTED-TYPE-001
+ *
+ * @module lib/sd
+ */
+
+export {
+  SDTypeClassifier,
+  sdTypeClassifier,
+  SD_TYPE_PROFILES
+} from './type-classifier.js';

--- a/lib/sd/type-classifier.js
+++ b/lib/sd/type-classifier.js
@@ -1,0 +1,364 @@
+/**
+ * SD Type Classifier - LLM-Assisted Classification
+ *
+ * Uses GPT to intelligently classify SD type at creation time
+ * based on title and description analysis.
+ *
+ * Part of: SD-LEO-FEAT-LLM-ASSISTED-TYPE-001
+ *
+ * @module lib/sd/type-classifier
+ * @version 1.0.0
+ */
+
+import OpenAI from 'openai';
+import { getOpenAIModel } from '../config/model-config.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/**
+ * SD Type Profiles - Validation rules per type
+ */
+export const SD_TYPE_PROFILES = {
+  feature: {
+    name: 'Feature',
+    description: 'User-facing functionality with UI',
+    prdRequired: true,
+    e2eRequired: true,
+    designRequired: true,
+    minHandoffs: 4,
+    gateThreshold: 85,
+    subAgents: ['DESIGN', 'DATABASE', 'STORIES', 'TESTING', 'RISK']
+  },
+  infrastructure: {
+    name: 'Infrastructure',
+    description: 'Backend systems, tooling, scripts, CI/CD',
+    prdRequired: true,
+    e2eRequired: false,
+    designRequired: false,
+    minHandoffs: 3,
+    gateThreshold: 80,
+    subAgents: ['DATABASE', 'STORIES', 'RISK']
+  },
+  library: {
+    name: 'Library',
+    description: 'Reusable modules, utilities, backend code',
+    prdRequired: false,
+    e2eRequired: false,
+    designRequired: false,
+    minHandoffs: 2,
+    gateThreshold: 75,
+    subAgents: ['DATABASE', 'RISK']
+  },
+  fix: {
+    name: 'Fix',
+    description: 'Bug fixes, error corrections',
+    prdRequired: false,
+    e2eRequired: false,
+    designRequired: false,
+    minHandoffs: 1,
+    gateThreshold: 70,
+    subAgents: ['RCA']
+  },
+  enhancement: {
+    name: 'Enhancement',
+    description: 'Improvements to existing features',
+    prdRequired: false,
+    e2eRequired: false,
+    designRequired: false,
+    minHandoffs: 2,
+    gateThreshold: 75,
+    subAgents: ['VALIDATION', 'STORIES']
+  },
+  documentation: {
+    name: 'Documentation',
+    description: 'Documentation-only changes',
+    prdRequired: false,
+    e2eRequired: false,
+    designRequired: false,
+    minHandoffs: 1,
+    gateThreshold: 60,
+    subAgents: ['DOCMON']
+  },
+  refactor: {
+    name: 'Refactor',
+    description: 'Code restructuring without behavior change',
+    prdRequired: false,
+    e2eRequired: true,
+    designRequired: false,
+    minHandoffs: 2,
+    gateThreshold: 80,
+    subAgents: ['REGRESSION', 'VALIDATION']
+  },
+  security: {
+    name: 'Security',
+    description: 'Security-related changes',
+    prdRequired: true,
+    e2eRequired: true,
+    designRequired: false,
+    minHandoffs: 3,
+    gateThreshold: 90,
+    subAgents: ['SECURITY', 'RISK', 'TESTING']
+  }
+};
+
+/**
+ * Type classification keywords for fallback
+ */
+const TYPE_KEYWORDS = {
+  feature: ['user', 'dashboard', 'page', 'button', 'form', 'ui', 'interface', 'component', 'screen', 'display'],
+  infrastructure: ['script', 'ci', 'cd', 'deploy', 'pipeline', 'tooling', 'automation', 'hook', 'workflow'],
+  library: ['module', 'util', 'helper', 'lib', 'service', 'class', 'function', 'api client', 'sdk'],
+  fix: ['bug', 'fix', 'error', 'broken', 'crash', 'issue', 'wrong', 'incorrect', 'fail'],
+  enhancement: ['improve', 'enhance', 'better', 'optimize', 'upgrade', 'update'],
+  documentation: ['doc', 'readme', 'guide', 'tutorial', 'comment', 'jsdoc'],
+  refactor: ['refactor', 'restructure', 'reorganize', 'clean', 'simplify', 'rename'],
+  security: ['auth', 'permission', 'rls', 'token', 'encrypt', 'password', 'credential', 'vulnerability']
+};
+
+/**
+ * SD Type Classifier using GPT
+ */
+export class SDTypeClassifier {
+  constructor() {
+    this.openai = null;
+
+    if (process.env.OPENAI_API_KEY) {
+      this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    }
+
+    this.model = getOpenAIModel('validation');
+  }
+
+  /**
+   * Classify SD type based on title and description
+   * @param {string} title - SD title
+   * @param {string} description - SD description
+   * @param {Object} options - Classification options
+   * @returns {Promise<Object>} Classification result
+   */
+  async classify(title, description, options = {}) {
+    const { useKeywordFallback = true } = options;
+
+    // Try GPT classification first
+    if (this.openai) {
+      try {
+        const gptResult = await this.classifyWithGPT(title, description);
+        return {
+          ...gptResult,
+          source: 'gpt',
+          profile: SD_TYPE_PROFILES[gptResult.recommendedType]
+        };
+      } catch (error) {
+        console.error('GPT classification failed:', error.message);
+        if (!useKeywordFallback) {
+          throw error;
+        }
+      }
+    }
+
+    // Fallback to keyword-based classification
+    const keywordResult = this.classifyByKeywords(title, description);
+    return {
+      ...keywordResult,
+      source: 'keyword_fallback',
+      profile: SD_TYPE_PROFILES[keywordResult.recommendedType]
+    };
+  }
+
+  /**
+   * Classify using GPT
+   */
+  async classifyWithGPT(title, description) {
+    const prompt = this.buildClassificationPrompt(title, description);
+
+    const response = await this.openai.chat.completions.create({
+      model: this.model,
+      messages: [
+        { role: 'system', content: prompt.system },
+        { role: 'user', content: prompt.user }
+      ],
+      temperature: 0.2,
+      response_format: { type: 'json_object' }
+    });
+
+    const result = JSON.parse(response.choices[0].message.content);
+
+    // Normalize the type to our known types
+    const normalizedType = this.normalizeType(result.sdType || result.recommendedType);
+
+    return {
+      recommendedType: normalizedType,
+      confidence: result.confidence || 0.8,
+      reasoning: result.reasoning,
+      analysis: {
+        hasUI: result.hasUI,
+        hasAPIEndpoints: result.hasAPIEndpoints,
+        isLibrary: result.isLibrary,
+        complexity: result.complexity,
+        riskAreas: result.riskAreas || []
+      }
+    };
+  }
+
+  /**
+   * Build classification prompt for GPT
+   */
+  buildClassificationPrompt(title, description) {
+    const typeDescriptions = Object.entries(SD_TYPE_PROFILES)
+      .map(([type, profile]) => `- ${type}: ${profile.description}`)
+      .join('\n');
+
+    return {
+      system: `You are an expert software architect helping classify Strategic Directives (SDs) for a LEO Protocol workflow system.
+
+Your job is to analyze the SD title and description, then determine the most appropriate SD type.
+
+Available SD types:
+${typeDescriptions}
+
+Classification rules:
+1. If it has user-facing UI components (pages, buttons, forms, dashboards) → feature
+2. If it's backend processing with no UI but not a reusable module → infrastructure
+3. If it's a reusable module/utility/library/class → library
+4. If it fixes a bug or error → fix
+5. If it improves existing functionality without adding new features → enhancement
+6. If it's documentation-only → documentation
+7. If it restructures code without changing behavior → refactor
+8. If it involves authentication, permissions, or security → security
+
+Return JSON with your analysis.`,
+
+      user: `Analyze this Strategic Directive and classify it:
+
+Title: "${title}"
+Description: "${description || 'No description provided'}"
+
+Return JSON:
+{
+  "sdType": "feature|infrastructure|library|fix|enhancement|documentation|refactor|security",
+  "confidence": 0.0-1.0,
+  "reasoning": "Brief explanation of why this type was chosen",
+  "hasUI": true/false,
+  "hasAPIEndpoints": true/false,
+  "isLibrary": true/false,
+  "complexity": "low|medium|high",
+  "riskAreas": ["auth", "data", "performance", etc. or empty array]
+}`
+    };
+  }
+
+  /**
+   * Normalize type string to valid SD type
+   */
+  normalizeType(type) {
+    const normalized = type?.toLowerCase()?.trim();
+    if (SD_TYPE_PROFILES[normalized]) {
+      return normalized;
+    }
+
+    // Handle common variations
+    const typeMap = {
+      'bugfix': 'fix',
+      'bug_fix': 'fix',
+      'bug-fix': 'fix',
+      'hotfix': 'fix',
+      'feat': 'feature',
+      'infra': 'infrastructure',
+      'lib': 'library',
+      'module': 'library',
+      'util': 'library',
+      'doc': 'documentation',
+      'docs': 'documentation',
+      'sec': 'security',
+      'auth': 'security'
+    };
+
+    return typeMap[normalized] || 'infrastructure'; // Default to infrastructure if unknown
+  }
+
+  /**
+   * Classify using keyword matching (fallback)
+   */
+  classifyByKeywords(title, description) {
+    const text = `${title} ${description}`.toLowerCase();
+    const scores = {};
+
+    for (const [type, keywords] of Object.entries(TYPE_KEYWORDS)) {
+      scores[type] = keywords.filter(kw => text.includes(kw)).length;
+    }
+
+    const maxScore = Math.max(...Object.values(scores));
+    const recommendedType = maxScore > 0
+      ? Object.keys(scores).find(type => scores[type] === maxScore)
+      : 'infrastructure'; // Default
+
+    return {
+      recommendedType,
+      confidence: maxScore > 0 ? Math.min(0.6 + (maxScore * 0.1), 0.85) : 0.5,
+      reasoning: maxScore > 0
+        ? `Matched ${maxScore} keyword(s) for ${recommendedType} type`
+        : 'No keywords matched, defaulting to infrastructure',
+      analysis: {
+        hasUI: TYPE_KEYWORDS.feature.some(kw => text.includes(kw)),
+        hasAPIEndpoints: text.includes('api') || text.includes('endpoint'),
+        isLibrary: TYPE_KEYWORDS.library.some(kw => text.includes(kw)),
+        complexity: 'medium',
+        riskAreas: []
+      }
+    };
+  }
+
+  /**
+   * Format classification result for display
+   */
+  formatForDisplay(result) {
+    const profile = result.profile;
+    const implications = [];
+
+    if (profile.prdRequired) implications.push('PRD required');
+    if (profile.e2eRequired) implications.push('E2E tests required');
+    if (profile.designRequired) implications.push('DESIGN sub-agent required');
+    implications.push(`${profile.gateThreshold}% gate threshold`);
+    implications.push(`Min ${profile.minHandoffs} handoffs`);
+
+    return {
+      type: result.recommendedType,
+      typeName: profile.name,
+      confidence: Math.round(result.confidence * 100) + '%',
+      reasoning: result.reasoning,
+      implications,
+      subAgents: profile.subAgents
+    };
+  }
+
+  /**
+   * Get validation profile for an SD type
+   */
+  getProfile(sdType) {
+    return SD_TYPE_PROFILES[sdType] || SD_TYPE_PROFILES.infrastructure;
+  }
+
+  /**
+   * Check if a validation is required for an SD type
+   */
+  isValidationRequired(sdType, validationType) {
+    const profile = this.getProfile(sdType);
+
+    switch (validationType) {
+      case 'prd':
+        return profile.prdRequired;
+      case 'e2e':
+        return profile.e2eRequired;
+      case 'design':
+        return profile.designRequired;
+      default:
+        return true;
+    }
+  }
+}
+
+// Export singleton instance
+export const sdTypeClassifier = new SDTypeClassifier();
+
+export default SDTypeClassifier;

--- a/tests/unit/sd/type-classifier.test.js
+++ b/tests/unit/sd/type-classifier.test.js
@@ -1,0 +1,335 @@
+/**
+ * Unit Tests: SD Type Classifier
+ *
+ * Tests for SD-LEO-FEAT-LLM-ASSISTED-TYPE-001
+ *
+ * @module tests/unit/sd/type-classifier.test.js
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SDTypeClassifier, SD_TYPE_PROFILES } from '../../../lib/sd/type-classifier.js';
+
+describe('SDTypeClassifier', () => {
+  let classifier;
+
+  beforeEach(() => {
+    classifier = new SDTypeClassifier();
+  });
+
+  describe('SD_TYPE_PROFILES', () => {
+    it('should have all expected SD types defined', () => {
+      expect(SD_TYPE_PROFILES.feature).toBeDefined();
+      expect(SD_TYPE_PROFILES.infrastructure).toBeDefined();
+      expect(SD_TYPE_PROFILES.library).toBeDefined();
+      expect(SD_TYPE_PROFILES.fix).toBeDefined();
+      expect(SD_TYPE_PROFILES.enhancement).toBeDefined();
+      expect(SD_TYPE_PROFILES.documentation).toBeDefined();
+      expect(SD_TYPE_PROFILES.refactor).toBeDefined();
+      expect(SD_TYPE_PROFILES.security).toBeDefined();
+    });
+
+    it('should have correct gate thresholds', () => {
+      expect(SD_TYPE_PROFILES.feature.gateThreshold).toBe(85);
+      expect(SD_TYPE_PROFILES.infrastructure.gateThreshold).toBe(80);
+      expect(SD_TYPE_PROFILES.library.gateThreshold).toBe(75);
+      expect(SD_TYPE_PROFILES.fix.gateThreshold).toBe(70);
+      expect(SD_TYPE_PROFILES.security.gateThreshold).toBe(90);
+    });
+
+    it('should have correct validation requirements', () => {
+      // Feature requires everything
+      expect(SD_TYPE_PROFILES.feature.prdRequired).toBe(true);
+      expect(SD_TYPE_PROFILES.feature.e2eRequired).toBe(true);
+      expect(SD_TYPE_PROFILES.feature.designRequired).toBe(true);
+
+      // Infrastructure has relaxed requirements
+      expect(SD_TYPE_PROFILES.infrastructure.prdRequired).toBe(true);
+      expect(SD_TYPE_PROFILES.infrastructure.e2eRequired).toBe(false);
+      expect(SD_TYPE_PROFILES.infrastructure.designRequired).toBe(false);
+
+      // Library is minimal
+      expect(SD_TYPE_PROFILES.library.prdRequired).toBe(false);
+      expect(SD_TYPE_PROFILES.library.e2eRequired).toBe(false);
+      expect(SD_TYPE_PROFILES.library.designRequired).toBe(false);
+
+      // Fix is minimal
+      expect(SD_TYPE_PROFILES.fix.prdRequired).toBe(false);
+      expect(SD_TYPE_PROFILES.fix.e2eRequired).toBe(false);
+
+      // Security is strict
+      expect(SD_TYPE_PROFILES.security.prdRequired).toBe(true);
+      expect(SD_TYPE_PROFILES.security.e2eRequired).toBe(true);
+    });
+  });
+
+  describe('classifyByKeywords()', () => {
+    it('should classify UI-related SDs as feature', () => {
+      const result = classifier.classifyByKeywords(
+        'Add user dashboard page',
+        'Create a new dashboard page with charts and user metrics'
+      );
+
+      expect(result.recommendedType).toBe('feature');
+      expect(result.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('should classify script-related SDs as infrastructure', () => {
+      const result = classifier.classifyByKeywords(
+        'Add deployment pipeline script',
+        'Create CI/CD pipeline for automated deployments'
+      );
+
+      expect(result.recommendedType).toBe('infrastructure');
+      expect(result.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('should classify utility modules as library', () => {
+      const result = classifier.classifyByKeywords(
+        'Create validation helper module',
+        'Reusable validation utility functions for form inputs'
+      );
+
+      expect(result.recommendedType).toBe('library');
+      expect(result.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('should classify bug fixes as fix', () => {
+      const result = classifier.classifyByKeywords(
+        'Fix login error',
+        'Users are getting an error when trying to log in'
+      );
+
+      expect(result.recommendedType).toBe('fix');
+      expect(result.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('should classify auth-related SDs as security', () => {
+      const result = classifier.classifyByKeywords(
+        'Implement RLS policies for user data',
+        'Add row-level security to protect user credentials and permissions'
+      );
+
+      expect(result.recommendedType).toBe('security');
+      expect(result.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('should default to infrastructure when no keywords match', () => {
+      const result = classifier.classifyByKeywords(
+        'Arbitrary work item',
+        'Something without any recognizable patterns'
+      );
+
+      expect(result.recommendedType).toBe('infrastructure');
+      expect(result.confidence).toBeLessThanOrEqual(0.7);
+    });
+
+    it('should detect UI presence in analysis', () => {
+      const result = classifier.classifyByKeywords(
+        'Add button to form',
+        'User interface improvement'
+      );
+
+      expect(result.analysis.hasUI).toBe(true);
+    });
+
+    it('should detect API presence in analysis', () => {
+      const result = classifier.classifyByKeywords(
+        'Add new API endpoint',
+        'REST API for data retrieval'
+      );
+
+      expect(result.analysis.hasAPIEndpoints).toBe(true);
+    });
+  });
+
+  describe('normalizeType()', () => {
+    it('should return valid types unchanged', () => {
+      expect(classifier.normalizeType('feature')).toBe('feature');
+      expect(classifier.normalizeType('infrastructure')).toBe('infrastructure');
+      expect(classifier.normalizeType('library')).toBe('library');
+    });
+
+    it('should normalize common variations', () => {
+      expect(classifier.normalizeType('bugfix')).toBe('fix');
+      expect(classifier.normalizeType('bug_fix')).toBe('fix');
+      expect(classifier.normalizeType('bug-fix')).toBe('fix');
+      expect(classifier.normalizeType('hotfix')).toBe('fix');
+    });
+
+    it('should normalize abbreviations', () => {
+      expect(classifier.normalizeType('feat')).toBe('feature');
+      expect(classifier.normalizeType('infra')).toBe('infrastructure');
+      expect(classifier.normalizeType('lib')).toBe('library');
+      expect(classifier.normalizeType('doc')).toBe('documentation');
+      expect(classifier.normalizeType('docs')).toBe('documentation');
+    });
+
+    it('should handle case insensitivity', () => {
+      expect(classifier.normalizeType('FEATURE')).toBe('feature');
+      expect(classifier.normalizeType('Infrastructure')).toBe('infrastructure');
+      expect(classifier.normalizeType('FIX')).toBe('fix');
+    });
+
+    it('should default to infrastructure for unknown types', () => {
+      expect(classifier.normalizeType('unknown')).toBe('infrastructure');
+      expect(classifier.normalizeType('random')).toBe('infrastructure');
+    });
+  });
+
+  describe('getProfile()', () => {
+    it('should return correct profile for known types', () => {
+      const featureProfile = classifier.getProfile('feature');
+      expect(featureProfile.name).toBe('Feature');
+      expect(featureProfile.gateThreshold).toBe(85);
+
+      const infraProfile = classifier.getProfile('infrastructure');
+      expect(infraProfile.name).toBe('Infrastructure');
+      expect(infraProfile.gateThreshold).toBe(80);
+    });
+
+    it('should return infrastructure profile for unknown types', () => {
+      const unknownProfile = classifier.getProfile('unknown_type');
+      expect(unknownProfile.name).toBe('Infrastructure');
+    });
+  });
+
+  describe('isValidationRequired()', () => {
+    it('should correctly identify PRD requirements', () => {
+      expect(classifier.isValidationRequired('feature', 'prd')).toBe(true);
+      expect(classifier.isValidationRequired('infrastructure', 'prd')).toBe(true);
+      expect(classifier.isValidationRequired('library', 'prd')).toBe(false);
+      expect(classifier.isValidationRequired('fix', 'prd')).toBe(false);
+    });
+
+    it('should correctly identify E2E requirements', () => {
+      expect(classifier.isValidationRequired('feature', 'e2e')).toBe(true);
+      expect(classifier.isValidationRequired('infrastructure', 'e2e')).toBe(false);
+      expect(classifier.isValidationRequired('refactor', 'e2e')).toBe(true);
+      expect(classifier.isValidationRequired('security', 'e2e')).toBe(true);
+    });
+
+    it('should correctly identify DESIGN requirements', () => {
+      expect(classifier.isValidationRequired('feature', 'design')).toBe(true);
+      expect(classifier.isValidationRequired('infrastructure', 'design')).toBe(false);
+      expect(classifier.isValidationRequired('library', 'design')).toBe(false);
+    });
+
+    it('should return true for unknown validation types', () => {
+      expect(classifier.isValidationRequired('feature', 'unknown')).toBe(true);
+    });
+  });
+
+  describe('formatForDisplay()', () => {
+    it('should format classification result correctly', () => {
+      const result = {
+        recommendedType: 'feature',
+        confidence: 0.92,
+        reasoning: 'Has UI components',
+        profile: SD_TYPE_PROFILES.feature
+      };
+
+      const formatted = classifier.formatForDisplay(result);
+
+      expect(formatted.type).toBe('feature');
+      expect(formatted.typeName).toBe('Feature');
+      expect(formatted.confidence).toBe('92%');
+      expect(formatted.reasoning).toBe('Has UI components');
+      expect(formatted.implications).toContain('PRD required');
+      expect(formatted.implications).toContain('E2E tests required');
+      expect(formatted.implications).toContain('DESIGN sub-agent required');
+      expect(formatted.implications).toContain('85% gate threshold');
+      expect(formatted.subAgents).toContain('DESIGN');
+      expect(formatted.subAgents).toContain('TESTING');
+    });
+
+    it('should format infrastructure type correctly', () => {
+      const result = {
+        recommendedType: 'infrastructure',
+        confidence: 0.85,
+        reasoning: 'Backend processing',
+        profile: SD_TYPE_PROFILES.infrastructure
+      };
+
+      const formatted = classifier.formatForDisplay(result);
+
+      expect(formatted.implications).not.toContain('E2E tests required');
+      expect(formatted.implications).not.toContain('DESIGN sub-agent required');
+      expect(formatted.implications).toContain('80% gate threshold');
+    });
+  });
+
+  describe('buildClassificationPrompt()', () => {
+    it('should include all SD types in prompt', () => {
+      const prompt = classifier.buildClassificationPrompt('Test', 'Description');
+
+      expect(prompt.system).toContain('feature');
+      expect(prompt.system).toContain('infrastructure');
+      expect(prompt.system).toContain('library');
+      expect(prompt.system).toContain('fix');
+      expect(prompt.system).toContain('security');
+    });
+
+    it('should include title and description in user prompt', () => {
+      const prompt = classifier.buildClassificationPrompt(
+        'My Test SD',
+        'This is a test description'
+      );
+
+      expect(prompt.user).toContain('My Test SD');
+      expect(prompt.user).toContain('This is a test description');
+    });
+
+    it('should handle missing description', () => {
+      const prompt = classifier.buildClassificationPrompt('Test', '');
+
+      expect(prompt.user).toContain('No description provided');
+    });
+  });
+});
+
+describe('Integration: Full Classification Flow', () => {
+  let classifier;
+
+  beforeEach(() => {
+    classifier = new SDTypeClassifier();
+  });
+
+  it('should classify backend classification module as infrastructure/library', async () => {
+    const result = classifier.classifyByKeywords(
+      'Multi-Model Classification Module',
+      'Backend library for classifying data using GPT and Gemini APIs'
+    );
+
+    // Should be infrastructure or library since it's a backend module
+    expect(['infrastructure', 'library']).toContain(result.recommendedType);
+    expect(result.analysis.hasUI).toBe(false);
+  });
+
+  it('should classify user dashboard as feature', async () => {
+    const result = classifier.classifyByKeywords(
+      'Add User Profile Dashboard',
+      'Create a new page with user profile information, settings form, and activity display'
+    );
+
+    expect(result.recommendedType).toBe('feature');
+    expect(result.analysis.hasUI).toBe(true);
+  });
+
+  it('should classify RLS policy work as security', async () => {
+    const result = classifier.classifyByKeywords(
+      'Implement Row-Level Security for Ventures',
+      'Add RLS policies to protect venture data with user authentication checks'
+    );
+
+    expect(result.recommendedType).toBe('security');
+  });
+
+  it('should classify code cleanup as refactor', async () => {
+    const result = classifier.classifyByKeywords(
+      'Refactor Authentication Module',
+      'Clean up and reorganize the auth code for better maintainability'
+    );
+
+    expect(result.recommendedType).toBe('refactor');
+  });
+});


### PR DESCRIPTION
## Summary
- Add GPT-powered SD type classification module (`lib/sd/type-classifier.js`)
- Intelligent type detection based on title/description analysis
- Keyword-based fallback when GPT unavailable
- SD type profiles with validation rules per type (thresholds, required sub-agents, handoffs)

## Changes
- `lib/sd/type-classifier.js` - Main classification module with GPT integration
- `lib/sd/index.js` - Module exports
- `tests/unit/sd/type-classifier.test.js` - 31 unit tests (all passing)

## Test plan
- [x] All 31 unit tests pass
- [x] Keyword classification works for all SD types
- [x] Type normalization handles variations (bugfix→fix, feat→feature, etc.)
- [x] Profile lookup returns correct validation requirements

## SD Reference
SD-LEO-FEAT-LLM-ASSISTED-TYPE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)