### PR TITLE
feat(self-improvement): Phase 2 - Risk Classification Module

### DIFF
--- a/scripts/modules/risk-classifier/index.js
+++ b/scripts/modules/risk-classifier/index.js
@@ -1,0 +1,390 @@
+/**
+ * Risk Classifier Module
+ * Phase 2: SD-LEO-SELF-IMPROVE-RISK-001
+ *
+ * Auto-classifies protocol improvements into IMMUTABLE/GOVERNED/AUTO tiers
+ * based on target table and change type. Defaults to GOVERNED when uncertain.
+ *
+ * Risk Tiers:
+ * - IMMUTABLE: Cannot be modified by any automated process
+ * - GOVERNED: Requires human approval (Phase 1 default)
+ * - AUTO: Can be applied automatically if score threshold met
+ */
+
+import { RISK_TIERS } from '../ai-quality-judge/config.js';
+
+/**
+ * Classification rules per Section 10.2 of Self-Improvement Plan
+ *
+ * Rule 1: IMMUTABLE - Constitution table changes
+ * Rule 2: IMMUTABLE - Changes to CONST-* rules
+ * Rule 3: IMMUTABLE - CORE priority sections
+ * Rule 4: GOVERNED - Validation rules
+ * Rule 5: GOVERNED - Sub-agent configuration
+ * Rule 6: GOVERNED - DELETE/UPDATE operations
+ * Rule 7: AUTO - Checklist items (INSERT only)
+ * Rule 8: AUTO - SITUATIONAL priority sections (INSERT only)
+ * Rule 9: DEFAULT - Unknown → GOVERNED (safe fallback)
+ */
+const CLASSIFICATION_RULES = [
+  {
+    id: 'RULE-001',
+    name: 'Constitution table is IMMUTABLE',
+    tier: 'IMMUTABLE',
+    check: (improvement) => {
+      return improvement.target_table === 'protocol_constitution';
+    }
+  },
+  {
+    id: 'RULE-002',
+    name: 'CONST rule changes are IMMUTABLE',
+    tier: 'IMMUTABLE',
+    check: (improvement) => {
+      const payload = improvement.payload || {};
+      const ruleCode = payload.rule_code || payload.rule_id || '';
+      return ruleCode.startsWith('CONST-');
+    }
+  },
+  {
+    id: 'RULE-003',
+    name: 'CORE priority sections are IMMUTABLE',
+    tier: 'IMMUTABLE',
+    check: (improvement) => {
+      if (improvement.target_table !== 'leo_protocol_sections') return false;
+      const payload = improvement.payload || {};
+      return payload.priority === 'CORE' ||
+             (payload.section_key && payload.section_key.includes('CORE'));
+    }
+  },
+  {
+    id: 'RULE-004',
+    name: 'Validation rules require GOVERNED',
+    tier: 'GOVERNED',
+    check: (improvement) => {
+      return improvement.target_table === 'leo_validation_rules' ||
+             improvement.improvement_type === 'VALIDATION_RULE';
+    }
+  },
+  {
+    id: 'RULE-005',
+    name: 'Sub-agent configuration requires GOVERNED',
+    tier: 'GOVERNED',
+    check: (improvement) => {
+      return improvement.target_table === 'leo_sub_agents' ||
+             improvement.target_table === 'leo_sub_agent_triggers' ||
+             improvement.improvement_type === 'SUB_AGENT_CONFIG';
+    }
+  },
+  {
+    id: 'RULE-006',
+    name: 'DELETE/UPDATE operations require GOVERNED',
+    tier: 'GOVERNED',
+    check: (improvement) => {
+      const op = (improvement.target_operation || '').toUpperCase();
+      return op === 'DELETE' || op === 'UPDATE';
+    }
+  },
+  {
+    id: 'RULE-007',
+    name: 'Checklist items can be AUTO (INSERT only)',
+    tier: 'AUTO',
+    check: (improvement) => {
+      const op = (improvement.target_operation || '').toUpperCase();
+      return improvement.improvement_type === 'CHECKLIST_ITEM' &&
+             (op === 'INSERT' || op === 'UPSERT');
+    }
+  },
+  {
+    id: 'RULE-008',
+    name: 'SITUATIONAL sections can be AUTO (INSERT only)',
+    tier: 'AUTO',
+    check: (improvement) => {
+      if (improvement.target_table !== 'leo_protocol_sections') return false;
+      const op = (improvement.target_operation || '').toUpperCase();
+      const payload = improvement.payload || {};
+      return payload.priority === 'SITUATIONAL' &&
+             (op === 'INSERT' || op === 'UPSERT');
+    }
+  },
+  {
+    id: 'RULE-009',
+    name: 'Unknown defaults to GOVERNED',
+    tier: 'GOVERNED',
+    check: () => true // Default fallback - always matches
+  }
+];
+
+/**
+ * Tables that are IMMUTABLE by nature
+ */
+const IMMUTABLE_TABLES = [
+  'protocol_constitution',
+  'audit_log',
+  'system_flags'
+];
+
+/**
+ * Tables that typically require GOVERNED tier
+ */
+const GOVERNED_TABLES = [
+  'leo_validation_rules',
+  'leo_sub_agents',
+  'leo_sub_agent_triggers',
+  'strategic_directives_v2',
+  'product_requirements_v2',
+  'sd_phase_handoffs'
+];
+
+/**
+ * Tables that can potentially be AUTO
+ */
+const AUTO_ELIGIBLE_TABLES = [
+  'leo_protocol_sections',
+  'issue_patterns',
+  'retrospectives'
+];
+
+/**
+ * RiskClassifier class
+ * Main entry point for improvement classification
+ */
+export class RiskClassifier {
+  constructor(options = {}) {
+    this.rules = options.rules || CLASSIFICATION_RULES;
+    this.verbose = options.verbose || false;
+  }
+
+  /**
+   * Classify a single improvement
+   *
+   * @param {Object} improvement - Improvement to classify
+   * @returns {Object} Classification result with tier, rule, and confidence
+   */
+  classify(improvement) {
+    if (!improvement) {
+      return {
+        tier: 'GOVERNED',
+        rule: 'RULE-009',
+        ruleName: 'Unknown defaults to GOVERNED',
+        confidence: 100,
+        reason: 'Null improvement - defaulting to GOVERNED'
+      };
+    }
+
+    // Check rules in order (first match wins, except default)
+    for (const rule of this.rules) {
+      // Skip the default rule initially
+      if (rule.id === 'RULE-009') continue;
+
+      try {
+        if (rule.check(improvement)) {
+          const result = {
+            tier: rule.tier,
+            rule: rule.id,
+            ruleName: rule.name,
+            confidence: this._calculateConfidence(improvement, rule),
+            reason: `Matched ${rule.id}: ${rule.name}`
+          };
+
+          if (this.verbose) {
+            console.log(`[RiskClassifier] ${improvement.id || 'unknown'}: ${result.tier} (${rule.id})`);
+          }
+
+          return result;
+        }
+      } catch (error) {
+        console.warn(`[RiskClassifier] Rule ${rule.id} check failed: ${error.message}`);
+      }
+    }
+
+    // Default fallback (RULE-009)
+    return {
+      tier: 'GOVERNED',
+      rule: 'RULE-009',
+      ruleName: 'Unknown defaults to GOVERNED',
+      confidence: 100,
+      reason: 'No specific rule matched - defaulting to GOVERNED (safe fallback)'
+    };
+  }
+
+  /**
+   * Classify multiple improvements
+   *
+   * @param {Array} improvements - Array of improvements to classify
+   * @returns {Array} Array of classification results
+   */
+  classifyBatch(improvements) {
+    return (improvements || []).map(imp => ({
+      improvement_id: imp.id,
+      ...this.classify(imp)
+    }));
+  }
+
+  /**
+   * Get the tier for a specific target table
+   *
+   * @param {string} tableName - Table name to check
+   * @returns {string} Risk tier
+   */
+  getTierForTable(tableName) {
+    if (IMMUTABLE_TABLES.includes(tableName)) {
+      return 'IMMUTABLE';
+    }
+    if (GOVERNED_TABLES.includes(tableName)) {
+      return 'GOVERNED';
+    }
+    if (AUTO_ELIGIBLE_TABLES.includes(tableName)) {
+      return 'AUTO'; // Note: Actual tier depends on operation type
+    }
+    return 'GOVERNED'; // Unknown tables default to GOVERNED
+  }
+
+  /**
+   * Check if an improvement can be auto-applied
+   *
+   * @param {Object} improvement - Improvement to check
+   * @param {number} score - Quality score (0-100)
+   * @param {number} safetyScore - Safety score (0-10)
+   * @returns {Object} Auto-apply eligibility
+   */
+  canAutoApply(improvement, score = 0, safetyScore = 0) {
+    const classification = this.classify(improvement);
+
+    if (classification.tier !== 'AUTO') {
+      return {
+        eligible: false,
+        reason: `Tier is ${classification.tier}, not AUTO`,
+        classification
+      };
+    }
+
+    const autoConfig = RISK_TIERS.AUTO;
+
+    if (score < autoConfig.min_score) {
+      return {
+        eligible: false,
+        reason: `Score ${score} below threshold ${autoConfig.min_score}`,
+        classification
+      };
+    }
+
+    if (safetyScore < autoConfig.min_safety) {
+      return {
+        eligible: false,
+        reason: `Safety score ${safetyScore} below threshold ${autoConfig.min_safety}`,
+        classification
+      };
+    }
+
+    const op = (improvement.target_operation || '').toUpperCase();
+    if (!autoConfig.allowed_operations.includes(op)) {
+      return {
+        eligible: false,
+        reason: `Operation ${op} not in allowed list: ${autoConfig.allowed_operations.join(', ')}`,
+        classification
+      };
+    }
+
+    return {
+      eligible: true,
+      reason: 'All AUTO criteria met',
+      classification
+    };
+  }
+
+  /**
+   * Calculate confidence level for a classification
+   *
+   * @param {Object} improvement - The improvement
+   * @param {Object} rule - The matched rule
+   * @returns {number} Confidence 0-100
+   */
+  _calculateConfidence(improvement, rule) {
+    // Higher confidence for explicit rules
+    if (rule.id === 'RULE-001' || rule.id === 'RULE-002' || rule.id === 'RULE-003') {
+      return 100; // IMMUTABLE rules are definitive
+    }
+
+    // Medium-high confidence for GOVERNED rules
+    if (rule.tier === 'GOVERNED') {
+      return 95;
+    }
+
+    // AUTO rules have slightly lower confidence
+    if (rule.tier === 'AUTO') {
+      // Check if we have all the expected fields
+      const hasAllFields = improvement.target_table &&
+                          improvement.target_operation &&
+                          improvement.improvement_type;
+      return hasAllFields ? 90 : 75;
+    }
+
+    return 80; // Default confidence
+  }
+
+  /**
+   * Get all classification rules
+   *
+   * @returns {Array} Array of rule definitions
+   */
+  getRules() {
+    return this.rules.map(r => ({
+      id: r.id,
+      name: r.name,
+      tier: r.tier
+    }));
+  }
+
+  /**
+   * Get statistics about classified improvements
+   *
+   * @param {Array} classifications - Array of classification results
+   * @returns {Object} Statistics
+   */
+  getStatistics(classifications) {
+    const stats = {
+      total: classifications.length,
+      byTier: {
+        IMMUTABLE: 0,
+        GOVERNED: 0,
+        AUTO: 0
+      },
+      byRule: {},
+      avgConfidence: 0
+    };
+
+    let totalConfidence = 0;
+
+    for (const c of classifications) {
+      stats.byTier[c.tier] = (stats.byTier[c.tier] || 0) + 1;
+      stats.byRule[c.rule] = (stats.byRule[c.rule] || 0) + 1;
+      totalConfidence += c.confidence || 0;
+    }
+
+    stats.avgConfidence = classifications.length > 0
+      ? Math.round(totalConfidence / classifications.length)
+      : 0;
+
+    return stats;
+  }
+}
+
+/**
+ * Create a RiskClassifier instance
+ *
+ * @param {Object} options - Configuration options
+ * @returns {RiskClassifier} Classifier instance
+ */
+export function createRiskClassifier(options = {}) {
+  return new RiskClassifier(options);
+}
+
+// Export rule definitions for testing
+export {
+  CLASSIFICATION_RULES,
+  IMMUTABLE_TABLES,
+  GOVERNED_TABLES,
+  AUTO_ELIGIBLE_TABLES
+};
+
+export default RiskClassifier;

--- a/tests/unit/risk-classifier/risk-classifier.test.js
+++ b/tests/unit/risk-classifier/risk-classifier.test.js
@@ -1,0 +1,516 @@
+/**
+ * Risk Classifier Unit Tests
+ * Phase 2: SD-LEO-SELF-IMPROVE-RISK-001
+ *
+ * Tests all 9 classification rules plus edge cases
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  RiskClassifier,
+  createRiskClassifier,
+  CLASSIFICATION_RULES,
+  IMMUTABLE_TABLES,
+  GOVERNED_TABLES,
+  AUTO_ELIGIBLE_TABLES
+} from '../../../scripts/modules/risk-classifier/index.js';
+
+// Mock the config import
+vi.mock('../../../scripts/modules/ai-quality-judge/config.js', () => ({
+  RISK_TIERS: {
+    AUTO: {
+      min_score: 85,
+      min_safety: 8,
+      allowed_operations: ['INSERT', 'UPSERT']
+    },
+    GOVERNED: {
+      min_score: 70
+    },
+    IMMUTABLE: {
+      min_score: 0
+    }
+  }
+}));
+
+describe('RiskClassifier', () => {
+  let classifier;
+
+  beforeEach(() => {
+    classifier = createRiskClassifier();
+  });
+
+  describe('RULE-001: Constitution table is IMMUTABLE', () => {
+    it('should classify protocol_constitution changes as IMMUTABLE', () => {
+      const improvement = {
+        id: 'test-001',
+        target_table: 'protocol_constitution',
+        target_operation: 'INSERT',
+        payload: { rule_code: 'CONST-010' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('IMMUTABLE');
+      expect(result.rule).toBe('RULE-001');
+      expect(result.confidence).toBe(100);
+    });
+
+    it('should classify UPDATE to protocol_constitution as IMMUTABLE', () => {
+      const improvement = {
+        target_table: 'protocol_constitution',
+        target_operation: 'UPDATE'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('IMMUTABLE');
+      expect(result.rule).toBe('RULE-001');
+    });
+  });
+
+  describe('RULE-002: CONST rule changes are IMMUTABLE', () => {
+    it('should classify CONST-* rule changes as IMMUTABLE', () => {
+      const improvement = {
+        target_table: 'leo_validation_rules',
+        payload: { rule_code: 'CONST-001' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('IMMUTABLE');
+      expect(result.rule).toBe('RULE-002');
+    });
+
+    it('should recognize rule_id as well as rule_code', () => {
+      const improvement = {
+        target_table: 'some_table',
+        payload: { rule_id: 'CONST-005' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('IMMUTABLE');
+      expect(result.rule).toBe('RULE-002');
+    });
+
+    it('should not match non-CONST rule codes', () => {
+      const improvement = {
+        target_table: 'leo_validation_rules',
+        payload: { rule_code: 'VAL-001' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-004'); // Matches validation rules
+    });
+  });
+
+  describe('RULE-003: CORE priority sections are IMMUTABLE', () => {
+    it('should classify CORE priority sections as IMMUTABLE', () => {
+      const improvement = {
+        target_table: 'leo_protocol_sections',
+        payload: { priority: 'CORE', content: 'test' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('IMMUTABLE');
+      expect(result.rule).toBe('RULE-003');
+    });
+
+    it('should recognize CORE in section_key', () => {
+      const improvement = {
+        target_table: 'leo_protocol_sections',
+        payload: { section_key: 'CORE_WORKFLOW_001' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('IMMUTABLE');
+      expect(result.rule).toBe('RULE-003');
+    });
+
+    it('should not match non-CORE sections', () => {
+      const improvement = {
+        target_table: 'leo_protocol_sections',
+        target_operation: 'INSERT',
+        payload: { priority: 'STANDARD' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).not.toBe('IMMUTABLE');
+    });
+  });
+
+  describe('RULE-004: Validation rules require GOVERNED', () => {
+    it('should classify leo_validation_rules changes as GOVERNED', () => {
+      const improvement = {
+        target_table: 'leo_validation_rules',
+        target_operation: 'INSERT',
+        payload: { rule_name: 'test_rule' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-004');
+    });
+
+    it('should classify VALIDATION_RULE type as GOVERNED', () => {
+      const improvement = {
+        improvement_type: 'VALIDATION_RULE',
+        target_table: 'other_table'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-004');
+    });
+  });
+
+  describe('RULE-005: Sub-agent configuration requires GOVERNED', () => {
+    it('should classify leo_sub_agents changes as GOVERNED', () => {
+      const improvement = {
+        target_table: 'leo_sub_agents',
+        target_operation: 'UPDATE'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-005');
+    });
+
+    it('should classify leo_sub_agent_triggers as GOVERNED', () => {
+      const improvement = {
+        target_table: 'leo_sub_agent_triggers',
+        target_operation: 'INSERT'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-005');
+    });
+
+    it('should classify SUB_AGENT_CONFIG type as GOVERNED', () => {
+      const improvement = {
+        improvement_type: 'SUB_AGENT_CONFIG',
+        target_table: 'custom_table'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-005');
+    });
+  });
+
+  describe('RULE-006: DELETE/UPDATE operations require GOVERNED', () => {
+    it('should classify DELETE operations as GOVERNED', () => {
+      const improvement = {
+        target_table: 'issue_patterns',
+        target_operation: 'DELETE'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-006');
+    });
+
+    it('should classify UPDATE operations as GOVERNED', () => {
+      const improvement = {
+        target_table: 'issue_patterns',
+        target_operation: 'UPDATE'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-006');
+    });
+
+    it('should handle case-insensitive operations', () => {
+      const improvement = {
+        target_table: 'issue_patterns',
+        target_operation: 'delete'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-006');
+    });
+  });
+
+  describe('RULE-007: Checklist items can be AUTO (INSERT only)', () => {
+    it('should classify CHECKLIST_ITEM INSERT as AUTO', () => {
+      const improvement = {
+        improvement_type: 'CHECKLIST_ITEM',
+        target_table: 'leo_protocol_sections',
+        target_operation: 'INSERT'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('AUTO');
+      expect(result.rule).toBe('RULE-007');
+    });
+
+    it('should classify CHECKLIST_ITEM UPSERT as AUTO', () => {
+      const improvement = {
+        improvement_type: 'CHECKLIST_ITEM',
+        target_table: 'leo_protocol_sections',
+        target_operation: 'UPSERT'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('AUTO');
+      expect(result.rule).toBe('RULE-007');
+    });
+
+    it('should NOT classify CHECKLIST_ITEM DELETE as AUTO', () => {
+      const improvement = {
+        improvement_type: 'CHECKLIST_ITEM',
+        target_operation: 'DELETE'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-006');
+    });
+  });
+
+  describe('RULE-008: SITUATIONAL sections can be AUTO (INSERT only)', () => {
+    it('should classify SITUATIONAL section INSERT as AUTO', () => {
+      const improvement = {
+        target_table: 'leo_protocol_sections',
+        target_operation: 'INSERT',
+        payload: { priority: 'SITUATIONAL' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('AUTO');
+      expect(result.rule).toBe('RULE-008');
+    });
+
+    it('should NOT classify SITUATIONAL UPDATE as AUTO', () => {
+      const improvement = {
+        target_table: 'leo_protocol_sections',
+        target_operation: 'UPDATE',
+        payload: { priority: 'SITUATIONAL' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-006');
+    });
+  });
+
+  describe('RULE-009: Unknown defaults to GOVERNED', () => {
+    it('should default unknown improvements to GOVERNED', () => {
+      const improvement = {
+        target_table: 'unknown_table',
+        target_operation: 'INSERT'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-009');
+    });
+
+    it('should handle null improvement as GOVERNED', () => {
+      const result = classifier.classify(null);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-009');
+    });
+
+    it('should handle empty improvement as GOVERNED', () => {
+      const result = classifier.classify({});
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-009');
+    });
+  });
+
+  describe('classifyBatch', () => {
+    it('should classify multiple improvements', () => {
+      const improvements = [
+        { id: '1', target_table: 'protocol_constitution' },
+        { id: '2', target_table: 'leo_validation_rules' },
+        { id: '3', improvement_type: 'CHECKLIST_ITEM', target_operation: 'INSERT' }
+      ];
+
+      const results = classifier.classifyBatch(improvements);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].tier).toBe('IMMUTABLE');
+      expect(results[1].tier).toBe('GOVERNED');
+      expect(results[2].tier).toBe('AUTO');
+    });
+
+    it('should include improvement_id in results', () => {
+      const improvements = [{ id: 'test-id', target_table: 'unknown' }];
+
+      const results = classifier.classifyBatch(improvements);
+
+      expect(results[0].improvement_id).toBe('test-id');
+    });
+  });
+
+  describe('getTierForTable', () => {
+    it('should return IMMUTABLE for constitution tables', () => {
+      expect(classifier.getTierForTable('protocol_constitution')).toBe('IMMUTABLE');
+      expect(classifier.getTierForTable('audit_log')).toBe('IMMUTABLE');
+      expect(classifier.getTierForTable('system_flags')).toBe('IMMUTABLE');
+    });
+
+    it('should return GOVERNED for governance tables', () => {
+      expect(classifier.getTierForTable('leo_validation_rules')).toBe('GOVERNED');
+      expect(classifier.getTierForTable('leo_sub_agents')).toBe('GOVERNED');
+      expect(classifier.getTierForTable('strategic_directives_v2')).toBe('GOVERNED');
+    });
+
+    it('should return AUTO for auto-eligible tables', () => {
+      expect(classifier.getTierForTable('leo_protocol_sections')).toBe('AUTO');
+      expect(classifier.getTierForTable('issue_patterns')).toBe('AUTO');
+    });
+
+    it('should return GOVERNED for unknown tables', () => {
+      expect(classifier.getTierForTable('unknown_table')).toBe('GOVERNED');
+    });
+  });
+
+  describe('canAutoApply', () => {
+    it('should allow AUTO tier with high score and safety', () => {
+      const improvement = {
+        improvement_type: 'CHECKLIST_ITEM',
+        target_operation: 'INSERT'
+      };
+
+      const result = classifier.canAutoApply(improvement, 90, 10);
+
+      expect(result.eligible).toBe(true);
+    });
+
+    it('should reject non-AUTO tier', () => {
+      const improvement = {
+        target_table: 'protocol_constitution'
+      };
+
+      const result = classifier.canAutoApply(improvement, 100, 10);
+
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('IMMUTABLE');
+    });
+
+    it('should reject low score', () => {
+      const improvement = {
+        improvement_type: 'CHECKLIST_ITEM',
+        target_operation: 'INSERT'
+      };
+
+      const result = classifier.canAutoApply(improvement, 70, 10);
+
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('Score');
+    });
+
+    it('should reject low safety score', () => {
+      const improvement = {
+        improvement_type: 'CHECKLIST_ITEM',
+        target_operation: 'INSERT'
+      };
+
+      const result = classifier.canAutoApply(improvement, 90, 5);
+
+      expect(result.eligible).toBe(false);
+      expect(result.reason).toContain('Safety');
+    });
+  });
+
+  describe('getStatistics', () => {
+    it('should calculate tier distribution', () => {
+      const classifications = [
+        { tier: 'IMMUTABLE', rule: 'RULE-001', confidence: 100 },
+        { tier: 'GOVERNED', rule: 'RULE-004', confidence: 95 },
+        { tier: 'GOVERNED', rule: 'RULE-005', confidence: 95 },
+        { tier: 'AUTO', rule: 'RULE-007', confidence: 90 }
+      ];
+
+      const stats = classifier.getStatistics(classifications);
+
+      expect(stats.total).toBe(4);
+      expect(stats.byTier.IMMUTABLE).toBe(1);
+      expect(stats.byTier.GOVERNED).toBe(2);
+      expect(stats.byTier.AUTO).toBe(1);
+      expect(stats.avgConfidence).toBe(95);
+    });
+  });
+
+  describe('Rule ordering', () => {
+    it('should match IMMUTABLE before GOVERNED', () => {
+      // A CONST rule in validation_rules should be IMMUTABLE, not GOVERNED
+      const improvement = {
+        target_table: 'leo_validation_rules',
+        payload: { rule_code: 'CONST-001' }
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('IMMUTABLE');
+      expect(result.rule).toBe('RULE-002');
+    });
+
+    it('should match DELETE before AUTO-eligible', () => {
+      // A CHECKLIST_ITEM DELETE should be GOVERNED
+      const improvement = {
+        improvement_type: 'CHECKLIST_ITEM',
+        target_operation: 'DELETE'
+      };
+
+      const result = classifier.classify(improvement);
+
+      expect(result.tier).toBe('GOVERNED');
+      expect(result.rule).toBe('RULE-006');
+    });
+  });
+
+  describe('getRules', () => {
+    it('should return all 9 rules', () => {
+      const rules = classifier.getRules();
+
+      expect(rules).toHaveLength(9);
+      expect(rules.map(r => r.id)).toContain('RULE-001');
+      expect(rules.map(r => r.id)).toContain('RULE-009');
+    });
+  });
+});
+
+describe('Module exports', () => {
+  it('should export CLASSIFICATION_RULES', () => {
+    expect(CLASSIFICATION_RULES).toBeDefined();
+    expect(CLASSIFICATION_RULES.length).toBe(9);
+  });
+
+  it('should export table lists', () => {
+    expect(IMMUTABLE_TABLES).toContain('protocol_constitution');
+    expect(GOVERNED_TABLES).toContain('leo_validation_rules');
+    expect(AUTO_ELIGIBLE_TABLES).toContain('leo_protocol_sections');
+  });
+
+  it('should export createRiskClassifier factory', () => {
+    const classifier = createRiskClassifier();
+    expect(classifier).toBeInstanceOf(RiskClassifier);
+  });
+});


### PR DESCRIPTION
## Summary

SD-LEO-SELF-IMPROVE-RISK-001: Phase 2 of the LEO Self-Improvement Loop

- Add RiskClassifier module that auto-classifies improvements into IMMUTABLE/GOVERNED/AUTO tiers
- Implements 9 deterministic classification rules based on target table and change type
- Safe defaults: unknown improvements default to GOVERNED tier
- Comprehensive unit test suite (41 tests covering all rules and edge cases)

## Classification Rules

| Tier | Rules | Examples |
|------|-------|----------|
| IMMUTABLE | RULE-001 to 003 | protocol_constitution, CONST-* rules, CORE sections |
| GOVERNED | RULE-004 to 006 | validation rules, sub-agent config, DELETE/UPDATE ops |
| AUTO | RULE-007 to 008 | checklist items (INSERT), SITUATIONAL sections (INSERT) |
| DEFAULT | RULE-009 | unknown → GOVERNED |

## Test plan

- [x] Unit tests pass (41 tests)
- [x] All 9 classification rules tested
- [x] Edge cases covered (null, empty, unknown tables)
- [x] Batch classification works
- [x] canAutoApply() threshold checks work

## Files Changed

- `scripts/modules/risk-classifier/index.js` - Main module
- `tests/unit/risk-classifier/risk-classifier.test.js` - Unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)