### PR TITLE
docs(protocol): add metadata headers for documentation standards compliance

### DIFF
--- a/docs/cli/protocol-improvements-cli-guide.md
+++ b/docs/cli/protocol-improvements-cli-guide.md
@@ -1,5 +1,15 @@
 # Protocol Improvements CLI Guide
 
+## Metadata
+- **Category**: Guide
+- **Status**: Approved
+- **Version**: 2.1.0
+- **Author**: LEO Protocol / DOCMON
+- **Last Updated**: 2026-01-23
+- **Tags**: protocol-improvements, cli, self-improvement, retrospectives, automation
+
+## Overview
+
 This guide covers the CLI tools for managing the protocol improvement system that automatically extracts, reviews, and applies improvements from retrospectives.
 
 ## Overview

--- a/docs/guides/self-improvement-system-guide.md
+++ b/docs/guides/self-improvement-system-guide.md
@@ -1,8 +1,16 @@
 # LEO Protocol Self-Improvement System
 
+## Metadata
+- **Category**: Guide
+- **Status**: Approved
+- **Version**: 3.1.0
+- **Author**: LEO Protocol / RETRO Sub-Agent
+- **Last Updated**: 2026-01-23
+- **Tags**: self-improvement, retrospectives, protocol-evolution, ai-quality-judge, learning
+
+---
+
 **Migration**: `20251210_retrospective_self_improvement_system.sql`
-**Updated**: 2026-01-22
-**Status**: Active (v3 - AI Quality Judge)
 **Purpose**: Database-first protocol evolution through retrospective analysis
 
 ---


### PR DESCRIPTION
## Summary
- Added required metadata headers to protocol improvement documentation files
- protocol-improvements-cli-guide.md now includes proper metadata (v2.1.0)
- self-improvement-system-guide.md now includes proper metadata (v3.1.0)

## Documentation Protocol Compliance

Per `docs/03_protocols_and_standards/DOCUMENTATION_STANDARDS.md` (lines 108-128), all markdown files require:
- Category (e.g., Guide, Protocol, API)
- Status (Draft, Review, Approved, Deprecated)
- Version (semver format)
- Author
- Last Updated (YYYY-MM-DD)
- Tags

Both files were missing these required metadata headers after PR #504.

## Files Updated
- `docs/cli/protocol-improvements-cli-guide.md` - Added metadata header
- `docs/guides/self-improvement-system-guide.md` - Added metadata header

## Test plan
- [x] Metadata headers follow standard format
- [x] Version numbers are appropriate (2.1.0 for CLI guide, 3.1.0 for system guide)
- [x] All required fields present
- [x] Smoke tests passed
- [x] DOCMON compliance verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)