### PR TITLE
fix(workflow): place /document before /ship in post-completion sequence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ This command provides:
 
 ```
 Issue Found → /triangulation-protocol → /quick-fix (if <50 LOC) OR Create SD (if larger)
-SD Complete → /restart (if UI) → /uat → /ship → /document → /learn → /leo next
+SD Complete → /restart (if UI) → /uat → /document → /ship → /learn → /leo next
 ```
 
 ### Auto-Invoke Behavior
@@ -218,11 +218,11 @@ LEO Protocol includes intelligent slash commands that interconnect based on work
 
 **Example Flow (UI Feature Completion)**:
 ```
-LEAD-FINAL-APPROVAL → /restart → Visual Review → /ship → /document → /learn → /leo next
+LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /learn → /leo next
 ```
 
 ## DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2026-01-23 8:29:37 AM
+**Last Generated**: 2026-01-23 10:31:12 AM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 

--- a/database/migrations/20260123_fix_command_flow_order.sql
+++ b/database/migrations/20260123_fix_command_flow_order.sql
@@ -1,0 +1,24 @@
+-- Migration: Fix command flow order - document before ship
+-- Date: 2026-01-23
+-- Purpose: Update the command ecosystem flow to place /document before /ship
+-- Rationale: Documentation should be included in the PR, not created after shipping
+
+-- Update the skill_intent_detection section to fix the command flow
+UPDATE leo_protocol_sections
+SET content = REPLACE(
+  content,
+  'SD Complete → /restart (if UI) → /uat → /ship → /document → /learn → /leo next',
+  'SD Complete → /restart (if UI) → /uat → /document → /ship → /learn → /leo next'
+)
+WHERE section_type = 'skill_intent_detection'
+  AND content LIKE '%/ship → /document%';
+
+-- Verify the update
+SELECT section_type,
+       CASE
+         WHEN content LIKE '%/document → /ship%' THEN 'CORRECT'
+         WHEN content LIKE '%/ship → /document%' THEN 'INCORRECT - needs fix'
+         ELSE 'N/A'
+       END as command_order_status
+FROM leo_protocol_sections
+WHERE section_type = 'skill_intent_detection';

--- a/database/migrations/20260123_fix_command_flow_order_part2.sql
+++ b/database/migrations/20260123_fix_command_flow_order_part2.sql
@@ -1,0 +1,24 @@
+-- Migration: Fix command flow order - document before ship (Part 2)
+-- Date: 2026-01-23
+-- Purpose: Update the common_commands section example flow
+-- Rationale: Consistency with main command flow
+
+-- Update the common_commands section to fix the example flow
+UPDATE leo_protocol_sections
+SET content = REPLACE(
+  content,
+  'LEAD-FINAL-APPROVAL → /restart → Visual Review → /ship → /document → /learn → /leo next',
+  'LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /learn → /leo next'
+)
+WHERE section_type = 'common_commands'
+  AND content LIKE '%/ship → /document%';
+
+-- Verify the update
+SELECT section_type,
+       CASE
+         WHEN content LIKE '%Visual Review → /document → /ship%' THEN 'CORRECT'
+         WHEN content LIKE '%Visual Review → /ship → /document%' THEN 'INCORRECT - needs fix'
+         ELSE 'N/A'
+       END as command_order_status
+FROM leo_protocol_sections
+WHERE section_type = 'common_commands';

--- a/docs/leo/commands/README.md
+++ b/docs/leo/commands/README.md
@@ -30,9 +30,9 @@ LEAD-FINAL-APPROVAL
         ↓
    Visual Review
         ↓
-      /ship
-        ↓
     /document
+        ↓
+      /ship
         ↓
       /learn
         ↓

--- a/docs/leo/commands/command-ecosystem.md
+++ b/docs/leo/commands/command-ecosystem.md
@@ -68,7 +68,7 @@ The LEO Protocol commands form an interconnected ecosystem where each command su
 
 ### /uat Position in Workflow
 ```
-LEAD-FINAL-APPROVAL → /restart → /uat → /ship → /document → /learn → /leo next
+LEAD-FINAL-APPROVAL → /restart → /uat → /document → /ship → /learn → /leo next
                                    │
                                    └── defect found → /quick-fix (auto-merge)
                                                   or → Create SD (full workflow)
@@ -83,11 +83,11 @@ LEAD-FINAL-APPROVAL → /restart → /uat → /ship → /document → /learn →
 | 1 | LEAD-FINAL-APPROVAL | UI/feature SD | `/restart` | Clean environment for UAT |
 | 2 | `/restart` | Feature/bugfix/security/refactor/enhancement | `/uat` | Human acceptance testing |
 | 2a | `/restart` | Infrastructure/database/docs | `/ship` | UAT not required |
-| 3 | `/uat` | GREEN or YELLOW gate | `/ship` | Proceed to shipping |
+| 3 | `/uat` | GREEN or YELLOW gate | `/document` | Update documentation first |
 | 3a | `/uat` | Defect found, <=50 LOC | `/quick-fix` | Auto-merge fix |
 | 3b | `/uat` | Defect found, >50 LOC | Create SD | Full workflow for fix |
-| 4 | `/ship` (merge) | Always | `/learn` | Capture learnings while fresh |
-| 5 | `/ship` (merge) | Feature/API SD | `/document` | Update documentation |
+| 4 | `/document` | Feature/API SD | `/ship` | Docs included in PR |
+| 5 | `/ship` (merge) | Always | `/learn` | Capture learnings while fresh |
 | 6 | `/ship` (merge) | More SDs queued | `/leo next` | Continue work |
 
 ### Secondary Flows
@@ -193,10 +193,10 @@ LEAD-FINAL-APPROVAL
 Visual Review ─── "Verify UI renders correctly"
        │
        ▼
-    /ship ─── "Commit and create PR"
+  /document ─── "Update feature documentation"
        │
        ▼
-  /document ─── "Update feature documentation"
+    /ship ─── "Commit and create PR (includes docs)"
        │
        ▼
    /learn ─── "Capture session learnings"

--- a/docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md
+++ b/docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md
@@ -178,7 +178,7 @@ SD Complete → [WAIT] → User: "what's next?" → [WAIT] →
 
 ### After (v4.3.3+)
 ```
-SD Complete → /restart (auto) → /ship (auto) → /document (auto) →
+SD Complete → /restart (auto) → /document (auto) → /ship (auto) →
   /learn (auto) → sd:next (auto)
 ```
 

--- a/lib/utils/post-completion-requirements.js
+++ b/lib/utils/post-completion-requirements.js
@@ -4,7 +4,7 @@
  * Purpose: Return different post-completion command sequences based on SD type.
  *
  * Code SDs (feature, bugfix, security, refactor, enhancement):
- *   Full sequence: restart -> ship -> document -> learn
+ *   Full sequence: restart -> document -> ship -> learn
  *
  * Non-code SDs (documentation, orchestrator, infrastructure):
  *   Minimal sequence: ship only
@@ -16,7 +16,7 @@
 
 /**
  * SD types that require full post-completion sequence
- * (restart -> ship -> document -> learn)
+ * (restart -> document -> ship -> learn)
  *
  * These are CODE_PRODUCING types from sd-type-checker.js
  */
@@ -126,12 +126,13 @@ export function getPostCompletionSequence(sdType, options = {}) {
     sequence.push('restart');
   }
 
-  // Ship is always included
-  sequence.push('ship');
-
+  // Document before ship - docs should be part of the PR
   if (requirements.document) {
     sequence.push('document');
   }
+
+  // Ship is always included
+  sequence.push('ship');
 
   if (requirements.learn) {
     sequence.push('learn');

--- a/test/unit/post-completion-requirements.test.js
+++ b/test/unit/post-completion-requirements.test.js
@@ -172,7 +172,7 @@ describe('Post-Completion Requirements', () => {
     it('should return correct sequence for feature SD', () => {
       const sequence = getPostCompletionSequence('feature');
 
-      expect(sequence).toEqual(['restart', 'ship', 'document', 'learn']);
+      expect(sequence).toEqual(['restart', 'document', 'ship', 'learn']);
     });
 
     it('should return minimal sequence for infrastructure SD', () => {
@@ -188,17 +188,17 @@ describe('Post-Completion Requirements', () => {
       expect(sequence).not.toContain('learn');
     });
 
-    it('should return correct order: restart -> ship -> document -> learn', () => {
+    it('should return correct order: restart -> document -> ship -> learn', () => {
       const sequence = getPostCompletionSequence('feature');
 
       const restartIndex = sequence.indexOf('restart');
-      const shipIndex = sequence.indexOf('ship');
       const documentIndex = sequence.indexOf('document');
+      const shipIndex = sequence.indexOf('ship');
       const learnIndex = sequence.indexOf('learn');
 
-      expect(restartIndex).toBeLessThan(shipIndex);
-      expect(shipIndex).toBeLessThan(documentIndex);
-      expect(documentIndex).toBeLessThan(learnIndex);
+      expect(restartIndex).toBeLessThan(documentIndex);
+      expect(documentIndex).toBeLessThan(shipIndex);
+      expect(shipIndex).toBeLessThan(learnIndex);
     });
   });
 


### PR DESCRIPTION
## Summary

- Reorders the LEO post-completion command sequence to place `/document` before `/ship`
- Documentation is now created before shipping, ensuring docs are included in the same PR
- Updates code, tests, and all related documentation for consistency

## Rationale

The previous order (`/ship → /document`) meant documentation was created as a separate follow-up task after the PR was merged. This led to:
- Documentation potentially being forgotten
- Reviewers unable to verify docs alongside code
- Non-atomic changes (feature in one PR, docs in another)

The new order (`/document → /ship`) ensures:
- Docs are part of the same PR
- Reviewers can verify both code and documentation together
- Changes ship atomically

## Changes

| File | Change |
|------|--------|
| `lib/utils/post-completion-requirements.js` | Reorder sequence builder to put document before ship |
| `test/unit/post-completion-requirements.test.js` | Update test expectations for new order |
| `docs/leo/commands/command-ecosystem.md` | Update workflow diagrams and tables |
| `docs/leo/commands/README.md` | Update command flow diagram |
| `docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md` | Update workflow example |
| `database/migrations/*.sql` | Update database sections for CLAUDE.md regeneration |
| `CLAUDE.md` | Regenerated with correct order |

## Test plan

- [x] Unit tests pass (`npx vitest run test/unit/post-completion-requirements.test.js`)
- [x] Smoke tests pass
- [x] CLAUDE.md regenerated with correct flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)