### PR TITLE
feat(leo5): integrate TaskHydrator with handoff success events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,6 +294,43 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 
 *Full trigger list in CLAUDE_CORE.md. Use Task tool with `subagent_type="<agent-code>"`*
 
+## Task Hydration (LEO 5.0)
+
+**CRITICAL**: When handoff output contains `CLAUDE_TASK_HYDRATION`, you MUST create the tasks using TaskCreate.
+
+### Detection Pattern
+Look for this block in handoff output:
+```
+🎯 CLAUDE_TASK_HYDRATION: Tasks for next phase
+```
+
+### Required Action
+For each task listed in the hydration block:
+1. Call **TaskCreate** with the task's subject, description, and activeForm
+2. After all tasks are created, use **TaskUpdate** to set up blockedBy dependencies
+3. The task IDs in the hydration output (e.g., `SD-XXX-001-EXEC-IMPL`) are reference IDs - map them to actual Claude Code task IDs after creation
+
+### Example Processing
+When you see:
+```
+📋 TASK: SD-FEATURE-001-EXEC-IMPL
+   Subject: Implement Feature X
+   ActiveForm: Implementing Feature X
+   Description: Execute implementation according to PRD.
+   BlockedBy: SD-FEATURE-001-EXEC-READY
+```
+
+You should:
+```
+TaskCreate(subject="Implement Feature X", description="Execute implementation according to PRD.", activeForm="Implementing Feature X")
+```
+
+Then after all tasks are created, set up the blockedBy chain using TaskUpdate.
+
+### Why This Matters
+- Tasks provide visibility into SD progress
+- BlockedBy chains enforce phase boundaries (walls)
+- The TaskList shows what can be worked on next
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `hydrateAndOutputTasks()` function to execution-helpers.js that integrates TaskHydrator with successful handoff events
- Output `CLAUDE_TASK_HYDRATION` block after successful handoffs containing tasks for the next phase
- Add task hydration instruction to CLAUDE.md explaining how Claude should process hydrated tasks via TaskCreate
- Tasks include subject, activeForm, description, and blockedBy dependencies for proper task sequencing

## Context
Part of LEO 5.0 Task System Architecture (SD-LEO-INFRA-LEO-TASK-SYSTEM-001). This enables automatic task creation in Claude Code when phase transitions occur during handoff execution.

## Test plan
- [x] End-to-end test verified all 4 tracks and phases produce correct task output
- [x] PLAN-TO-EXEC handoff shows CLAUDE_TASK_HYDRATION block with 8 EXEC tasks
- [x] PLAN-TO-LEAD handoff shows CLAUDE_TASK_HYDRATION block with 7 FINAL tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)