### PR TITLE
docs: Database Agent PostToolUse Hook Documentation

### DIFF
--- a/docs/reference/database-agent-first-responder.md
+++ b/docs/reference/database-agent-first-responder.md
@@ -1,8 +1,9 @@
 # Database Agent First-Responder Quick Reference
 
 **Status**: ACTIVE
-**Last Updated**: 2025-10-12
+**Last Updated**: 2026-01-23
 **Purpose**: Quick reference for proactive database agent invocation
+**Recent Changes**: Added PostToolUse hook for automatic migration detection (SD-LEO-HARDEN-VALIDATION-001)
 
 ---
 
@@ -88,6 +89,23 @@ Database Agent: [Provides expert guidance]
 ```
 
 **Note**: For ANY actual implementation work, use script invocation with SD context
+
+### Automatic Migration Detection (NEW - 2026-01-23)
+
+**PostToolUse Hook**: When Claude creates a migration file, a hook automatically outputs execution reminders.
+
+**How It Works**:
+1. Write tool creates file matching pattern: `database/migrations/*.sql`
+2. Hook `migration-execution-reminder.cjs` detects migration file
+3. Outputs 4 execution options (Supabase SQL Editor, DATABASE sub-agent, Supabase CLI, psql)
+4. Claude sees reminder and chooses execution method
+
+**Why This Matters**:
+- Prevents forgot-to-execute-migration errors
+- Bridges gap between file creation and execution
+- No more "I created the migration but didn't run it" issues
+
+**See**: `docs/reference/database-agent-patterns.md` → "PostToolUse Hook" section for full details
 
 ---
 

--- a/docs/reference/database-migration-application-pattern.md
+++ b/docs/reference/database-migration-application-pattern.md
@@ -1,8 +1,67 @@
 # Database Migration Application Pattern
 
-**Last Updated**: 2025-10-23
-**Lesson Source**: SD-VWC-PHASE4-001 Checkpoint 1
+**Last Updated**: 2026-01-23
+**Lesson Source**: SD-VWC-PHASE4-001 Checkpoint 1, SD-LEO-HARDEN-VALIDATION-001
 **Root Cause**: Database sub-agent incorrectly stated manual application required
+**Recent Update**: Added automatic migration detection via PostToolUse hook
+
+---
+
+## 🔔 Automatic Migration Detection (NEW - SD-LEO-HARDEN-VALIDATION-001)
+
+**Problem Solved**: Migrations were created but not executed because DATABASE sub-agent wasn't triggered.
+
+**Solution**: PostToolUse hook `migration-execution-reminder.cjs` automatically detects when migration files are created.
+
+### How It Works
+
+1. **Claude creates migration file** (e.g., `database/migrations/20260123_*.sql`)
+2. **Write tool completes**
+3. **PostToolUse hook fires** (`migration-execution-reminder.cjs`)
+4. **Hook detects migration file pattern**:
+   - `database/migrations/*.sql`
+   - `supabase/migrations/*.sql`
+   - `supabase/ehg_engineer/migrations/*.sql`
+5. **Hook outputs execution reminder** with 4 options:
+   - Supabase SQL Editor (manual)
+   - DATABASE sub-agent (programmatic)
+   - Supabase CLI (`supabase db push`)
+   - Direct psql
+6. **Claude sees reminder** and chooses execution method
+
+### Benefits
+
+- ✅ No more forgotten migrations
+- ✅ Immediate awareness after file creation
+- ✅ Multiple execution options provided
+- ✅ Non-blocking advisory (doesn't interrupt workflow)
+- ✅ Automatic SD ID extraction from migration content
+
+### Configuration
+
+- **Hook file**: `scripts/hooks/migration-execution-reminder.cjs`
+- **Settings**: `.claude/settings.json` → PostToolUse → Write matcher
+- **Timeout**: 5000ms
+- **Exit code**: 0 (advisory, non-blocking)
+
+### Example Output
+
+```
+════════════════════════════════════════════════════════════
+  MIGRATION FILE CREATED - ACTION REQUIRED
+════════════════════════════════════════════════════════════
+   File: 20260123_retrospective_auto_archive_trigger.sql
+   Path: database/migrations/20260123_retrospective_auto_archive_trigger.sql
+   SD: SD-LEO-HARDEN-VALIDATION-001
+
+   This migration needs to be EXECUTED against the database.
+
+   OPTIONS TO EXECUTE:
+   [Lists 4 execution methods]
+════════════════════════════════════════════════════════════
+```
+
+**See Also**: `docs/reference/database-agent-patterns.md` → "PostToolUse Hook" section
 
 ---
 


### PR DESCRIPTION
## Summary
Documents the new PostToolUse hook mechanism for automatic migration detection added in SD-LEO-HARDEN-VALIDATION-001.

### Files Updated
- **database-agent-patterns.md**: Added comprehensive "PostToolUse Hook" section
  - How migration-execution-reminder.cjs works
  - File patterns detected
  - Execution options provided
  - Example output and configuration

- **database-agent-first-responder.md**: Added quick reference section
  - Brief explanation of automatic detection
  - Cross-reference to full patterns doc

- **database-migration-application-pattern.md**: Added "Automatic Migration Detection" section
  - Problem solved (migrations created but not executed)
  - Step-by-step workflow
  - Benefits and configuration

## Why This Documentation Was Needed
**Root Cause**: DATABASE sub-agent has ACTION_TRIGGERS for "apply migration" keywords, but only runs when explicitly invoked. Creating migration files did NOT automatically trigger execution reminders.

**Fix**: PostToolUse hook `migration-execution-reminder.cjs` bridges the gap between file creation and execution awareness.

## Test Plan
- [x] Read all three updated documentation files
- [x] Verify PostToolUse hook section is comprehensive
- [x] Confirm cross-references between docs are correct
- [x] Check that hook configuration details match actual implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)