### PR TITLE
feat(db-agent): add SQL execution intent semantic triggering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,7 +222,7 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 ```
 
 ## DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2026-01-23 10:31:12 AM
+**Last Generated**: 2026-01-23 3:50:39 PM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 
@@ -269,7 +269,7 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 | `ANALYTICS` | analytics, metrics, aarrr, funnel, conversion rate, user behavior, tracking, kpi, retention rate, churn rate |
 | `API` | rest, restful, graphql, endpoint, route, controller, middleware, request, response, payload (+6 more) |
 | `CRM` | crm, customer relationship, contact management, lead tracking, customer success, salesforce, hubspot, customer data |
-| `DATABASE` | schema, database, query, select from, insert into, supabase, table, rls, postgres, sql (+2 more) |
+| `DATABASE` | schema, database, query, select from, insert into, supabase, table, rls, postgres, sql (+39 more) |
 | `DEPENDENCY` | dependency, dependencies, npm, yarn, pnpm, package, package.json, vulnerability, cve, security advisory (+12 more) |
 | `DESIGN` | visual, design system, styling, css, tailwind, button, form, modal, theme, dark mode (+25 more) |
 | `DOCMON` | lead_sd_creation, lead_handoff_creation, lead_approval, plan_prd_generation, plan_verification, exec_implementation, exec_completion, handoff_created, handoff_accepted, phase_transition (+4 more) |
@@ -294,43 +294,6 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 
 *Full trigger list in CLAUDE_CORE.md. Use Task tool with `subagent_type="<agent-code>"`*
 
-## Task Hydration (LEO 5.0)
-
-**CRITICAL**: When handoff output contains `CLAUDE_TASK_HYDRATION`, you MUST create the tasks using TaskCreate.
-
-### Detection Pattern
-Look for this block in handoff output:
-```
-🎯 CLAUDE_TASK_HYDRATION: Tasks for next phase
-```
-
-### Required Action
-For each task listed in the hydration block:
-1. Call **TaskCreate** with the task's subject, description, and activeForm
-2. After all tasks are created, use **TaskUpdate** to set up blockedBy dependencies
-3. The task IDs in the hydration output (e.g., `SD-XXX-001-EXEC-IMPL`) are reference IDs - map them to actual Claude Code task IDs after creation
-
-### Example Processing
-When you see:
-```
-📋 TASK: SD-FEATURE-001-EXEC-IMPL
-   Subject: Implement Feature X
-   ActiveForm: Implementing Feature X
-   Description: Execute implementation according to PRD.
-   BlockedBy: SD-FEATURE-001-EXEC-READY
-```
-
-You should:
-```
-TaskCreate(subject="Implement Feature X", description="Execute implementation according to PRD.", activeForm="Implementing Feature X")
-```
-
-Then after all tasks are created, set up the blockedBy chain using TaskUpdate.
-
-### Why This Matters
-- Tasks provide visibility into SD progress
-- BlockedBy chains enforce phase boundaries (walls)
-- The TaskList shows what can be worked on next
 
 ---
 

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-01-23 8:29:37 AM
+**Generated**: 2026-01-23 3:50:39 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing (20-25k chars)
 
@@ -248,6 +248,70 @@ See: `docs/03_protocols_and_standards/gate0-workflow-entry-enforcement.md` for c
 **If SD is in draft**: STOP. Do not implement. Run LEAD-TO-PLAN handoff first.
 
 
+## Branch Creation (Automated at LEAD-TO-PLAN)
+
+## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
+
+### Automatic Branch Creation
+
+As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
+
+1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
+2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
+3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
+4. Database is updated with branch name for tracking
+
+### Manual Branch Creation (If Needed)
+
+If branch creation fails or you need to create one manually:
+
+```bash
+# Create branch for an SD (looks up title from database)
+npm run sd:branch SD-XXX-001
+
+# Create with auto-stash (non-interactive)
+npm run sd:branch:auto SD-XXX-001
+
+# Check if branch exists
+npm run sd:branch:check SD-XXX-001
+
+# Full command with options
+node scripts/create-sd-branch.js SD-XXX-001 --app EHG --auto-stash
+```
+
+### Branch Naming Convention
+
+| SD Type | Branch Prefix | Example |
+|---------|---------------|---------|
+| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
+| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
+| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
+| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
+| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
+
+### Branch Hygiene Rules
+
+From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
+- **≤7 days stale** at PLAN-TO-EXEC handoff
+- **One SD per branch** (no mixing work)
+- **Merge main at phase transitions**
+
+### When Branch is Created
+
+```
+LEAD Phase                    PLAN Phase                   EXEC Phase
+    |                              |                            |
+    |   LEAD-TO-PLAN handoff       |                            |
+    |---[Branch Created Here]----->|                            |
+    |                              |   PRD Creation             |
+    |                              |   Sub-agent validation     |
+    |                              |                            |
+    |                              |   PLAN-TO-EXEC handoff     |
+    |                              |---[Branch Validated]------>|
+    |                              |                            |
+```
+
+
 ## ❌ Anti-Patterns from Retrospectives (EXEC Phase)
 
 **Source**: Analysis of 175 high-quality retrospectives (score ≥60)
@@ -335,70 +399,6 @@ If `research_confidence_score = 0.00`, you skipped this step.
 | Simulate sub-agents | 15% quality loss | Execute actual tools |
 
 **Pattern References**: PAT-RECURSION-001 through PAT-RECURSION-005
-
-## Branch Creation (Automated at LEAD-TO-PLAN)
-
-## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
-
-### Automatic Branch Creation
-
-As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
-
-1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
-2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
-3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
-4. Database is updated with branch name for tracking
-
-### Manual Branch Creation (If Needed)
-
-If branch creation fails or you need to create one manually:
-
-```bash
-# Create branch for an SD (looks up title from database)
-npm run sd:branch SD-XXX-001
-
-# Create with auto-stash (non-interactive)
-npm run sd:branch:auto SD-XXX-001
-
-# Check if branch exists
-npm run sd:branch:check SD-XXX-001
-
-# Full command with options
-node scripts/create-sd-branch.js SD-XXX-001 --app EHG --auto-stash
-```
-
-### Branch Naming Convention
-
-| SD Type | Branch Prefix | Example |
-|---------|---------------|---------|
-| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
-| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
-| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
-| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
-| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
-
-### Branch Hygiene Rules
-
-From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
-- **≤7 days stale** at PLAN-TO-EXEC handoff
-- **One SD per branch** (no mixing work)
-- **Merge main at phase transitions**
-
-### When Branch is Created
-
-```
-LEAD Phase                    PLAN Phase                   EXEC Phase
-    |                              |                            |
-    |   LEAD-TO-PLAN handoff       |                            |
-    |---[Branch Created Here]----->|                            |
-    |                              |   PRD Creation             |
-    |                              |   Sub-agent validation     |
-    |                              |                            |
-    |                              |   PLAN-TO-EXEC handoff     |
-    |                              |---[Branch Validated]------>|
-    |                              |                            |
-```
-
 
 ## EXEC Phase Negative Constraints
 
@@ -883,86 +883,6 @@ UI Parity Status:
 - Gate 2.5 Status: PASS/FAIL
 ```
 
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
-
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
-
-**Every completed Strategic Directive and Quick-Fix MUST end with:**
-
-1. **Commit** - All changes committed with proper message format
-2. **Push** - Branch pushed to remote
-3. **Merge to Main** - Feature branch merged into main
-
-### For Quick-Fixes
-
-The `complete-quick-fix.js` script handles this automatically:
-
-```bash
-node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
-```
-
-The script will:
-1. Verify tests pass and UAT completed
-2. Commit and push changes
-3. **Prompt to merge PR to main** (or local merge if no PR)
-4. Delete the feature branch
-
-### For Strategic Directives
-
-After LEAD approval, execute the following:
-
-```bash
-# 1. Ensure all changes committed
-git add .
-git commit -m "feat(SD-YYYY-XXX): [description]
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
-
-# 2. Push to remote
-git push origin feature/SD-YYYY-XXX
-
-# 3. Create PR if not exists
-gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
-
-# 4. Merge PR (preferred method)
-gh pr merge --merge --delete-branch
-
-# OR local merge fallback
-git checkout main
-git pull origin main
-git merge --no-ff feature/SD-YYYY-XXX
-git push origin main
-git branch -d feature/SD-YYYY-XXX
-git push origin --delete feature/SD-YYYY-XXX
-```
-
-### Merge Checklist
-
-Before merging, verify:
-- [ ] All tests passing (unit + E2E)
-- [ ] CI/CD pipeline green
-- [ ] Code review completed (if required)
-- [ ] No merge conflicts
-- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
-
-### Anti-Patterns
-
-❌ **NEVER** leave feature branches unmerged after completion
-❌ **NEVER** skip the push step
-❌ **NEVER** merge without verifying tests pass
-❌ **NEVER** force push to main
-
-### Verification
-
-After merge, confirm:
-```bash
-git checkout main
-git pull origin main
-git log --oneline -5  # Should show your merge commit
-```
-
 ## 🌿 Branch Hygiene Gate (MANDATORY)
 
 ## Branch Hygiene Gate (MANDATORY)
@@ -1052,6 +972,86 @@ When starting implementation:
 3. If multiple SDs detected → split branches
 4. If >100 files changed → assess scope creep
 5. Document branch health in handoff notes
+
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
+
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
+
+**Every completed Strategic Directive and Quick-Fix MUST end with:**
+
+1. **Commit** - All changes committed with proper message format
+2. **Push** - Branch pushed to remote
+3. **Merge to Main** - Feature branch merged into main
+
+### For Quick-Fixes
+
+The `complete-quick-fix.js` script handles this automatically:
+
+```bash
+node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
+```
+
+The script will:
+1. Verify tests pass and UAT completed
+2. Commit and push changes
+3. **Prompt to merge PR to main** (or local merge if no PR)
+4. Delete the feature branch
+
+### For Strategic Directives
+
+After LEAD approval, execute the following:
+
+```bash
+# 1. Ensure all changes committed
+git add .
+git commit -m "feat(SD-YYYY-XXX): [description]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# 2. Push to remote
+git push origin feature/SD-YYYY-XXX
+
+# 3. Create PR if not exists
+gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
+
+# 4. Merge PR (preferred method)
+gh pr merge --merge --delete-branch
+
+# OR local merge fallback
+git checkout main
+git pull origin main
+git merge --no-ff feature/SD-YYYY-XXX
+git push origin main
+git branch -d feature/SD-YYYY-XXX
+git push origin --delete feature/SD-YYYY-XXX
+```
+
+### Merge Checklist
+
+Before merging, verify:
+- [ ] All tests passing (unit + E2E)
+- [ ] CI/CD pipeline green
+- [ ] Code review completed (if required)
+- [ ] No merge conflicts
+- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
+
+### Anti-Patterns
+
+❌ **NEVER** leave feature branches unmerged after completion
+❌ **NEVER** skip the push step
+❌ **NEVER** merge without verifying tests pass
+❌ **NEVER** force push to main
+
+### Verification
+
+After merge, confirm:
+```bash
+git checkout main
+git pull origin main
+git log --oneline -5  # Should show your merge commit
+```
 
 ## Auto-Merge Workflow for SD Completion
 

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-01-23 8:29:37 AM
+**Generated**: 2026-01-23 3:50:39 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 
@@ -27,6 +27,52 @@ At each handoff point, familiarize yourself with and read the LEO protocol docum
 
 *Directives from `leo_autonomous_directives` table (SD-LEO-CONTINUITY-001)*
 
+
+## Baseline Issues Management
+
+## Baseline Issues System
+
+Pre-existing codebase issues are tracked in `sd_baseline_issues` table to prevent blocking unrelated SDs.
+
+### LEAD Gate: BASELINE_DEBT_CHECK
+- **BLOCKS** if: Stale critical issues (>30 days) exist without owner
+- **WARNS** if: Total open issues > 10 or stale non-critical > 5
+
+### Lifecycle
+| Status | Meaning |
+|--------|---------|
+| open | Issue identified, no owner assigned |
+| acknowledged | Issue reviewed, owner assigned |
+| in_progress | Remediation SD actively working |
+| resolved | Fixed and verified |
+| wont_fix | Accepted risk (requires LEAD approval + justification) |
+
+### Commands
+```bash
+npm run baseline:list          # Show all open issues
+npm run baseline:assign <key> <SD-ID>  # Assign ownership
+npm run baseline:resolve <key> # Mark resolved
+npm run baseline:summary       # Category summary
+```
+
+### Categories
+security, testing, performance, database, documentation, accessibility, code_quality, dependency, infrastructure
+
+### Issue Key Format
+`BL-{CATEGORY}-{NNN}` where:
+- BL-SEC-001: Security baseline issue #1
+- BL-TST-001: Testing baseline issue #1
+- BL-PRF-001: Performance baseline issue #1
+- BL-DB-001: Database baseline issue #1
+- BL-DOC-001: Documentation baseline issue #1
+- BL-A11Y-001: Accessibility baseline issue #1
+- BL-CQ-001: Code quality baseline issue #1
+- BL-DEP-001: Dependency baseline issue #1
+- BL-INF-001: Infrastructure baseline issue #1
+
+### Functions
+- `check_baseline_gate(p_sd_id)`: Returns PASS/BLOCKED verdict for LEAD gate
+- `generate_baseline_issue_key(p_category)`: Generates unique issue key
 
 ## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
 
@@ -115,52 +161,6 @@ npm run handoff:compliance SD-ID  # Check specific SD
 ```
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
-
-## Baseline Issues Management
-
-## Baseline Issues System
-
-Pre-existing codebase issues are tracked in `sd_baseline_issues` table to prevent blocking unrelated SDs.
-
-### LEAD Gate: BASELINE_DEBT_CHECK
-- **BLOCKS** if: Stale critical issues (>30 days) exist without owner
-- **WARNS** if: Total open issues > 10 or stale non-critical > 5
-
-### Lifecycle
-| Status | Meaning |
-|--------|---------|
-| open | Issue identified, no owner assigned |
-| acknowledged | Issue reviewed, owner assigned |
-| in_progress | Remediation SD actively working |
-| resolved | Fixed and verified |
-| wont_fix | Accepted risk (requires LEAD approval + justification) |
-
-### Commands
-```bash
-npm run baseline:list          # Show all open issues
-npm run baseline:assign <key> <SD-ID>  # Assign ownership
-npm run baseline:resolve <key> # Mark resolved
-npm run baseline:summary       # Category summary
-```
-
-### Categories
-security, testing, performance, database, documentation, accessibility, code_quality, dependency, infrastructure
-
-### Issue Key Format
-`BL-{CATEGORY}-{NNN}` where:
-- BL-SEC-001: Security baseline issue #1
-- BL-TST-001: Testing baseline issue #1
-- BL-PRF-001: Performance baseline issue #1
-- BL-DB-001: Database baseline issue #1
-- BL-DOC-001: Documentation baseline issue #1
-- BL-A11Y-001: Accessibility baseline issue #1
-- BL-CQ-001: Code quality baseline issue #1
-- BL-DEP-001: Dependency baseline issue #1
-- BL-INF-001: Infrastructure baseline issue #1
-
-### Functions
-- `check_baseline_gate(p_sd_id)`: Returns PASS/BLOCKED verdict for LEAD gate
-- `generate_baseline_issue_key(p_category)`: Generates unique issue key
 
 ## 🔍 Explore Before Validation (LEAD Phase)
 

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-01-23 8:29:37 AM
+**Generated**: 2026-01-23 3:50:39 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates (30-35k chars)
 
@@ -788,21 +788,6 @@ node scripts/add-prd-to-database.js {SD-ID}
 - ⚠️ Never create PRDs as markdown files
 - ⚠️ Never skip validation gates
 
-## CI/CD Pipeline Verification
-
-## CI/CD Pipeline Verification (MANDATORY)
-
-**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
-
-### Verification Process
-
-**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
-
-1. Wait 2-3 minutes for GitHub Actions to complete
-2. Trigger DevOps sub-agent to verify pipeline status
-3. Document CI/CD status in PLAN→LEAD handoff
-4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
-
 ## DESIGN→DATABASE Validation Gates
 
 **4 mandatory gates ensuring sub-agent execution and implementation fidelity.**
@@ -854,6 +839,21 @@ Retroactive audit at SD closure:
 
 **Reference**: `scripts/modules/design-database-gates-validation.js`
 
+
+## CI/CD Pipeline Verification
+
+## CI/CD Pipeline Verification (MANDATORY)
+
+**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
+
+### Verification Process
+
+**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
+
+1. Wait 2-3 minutes for GitHub Actions to complete
+2. Trigger DevOps sub-agent to verify pipeline status
+3. Document CI/CD status in PLAN→LEAD handoff
+4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
 
 ## 🚪 Gate 2.5: Human Inspectability Validation
 
@@ -1723,34 +1723,6 @@ for (const childId of childIds) {
 > **NOTE**: A database trigger (trg_inherit_parent_metadata) also enforces this automatically as a safety net.
 
 
-## PRD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off PRD creation scripts like:**
-- `create-prd-sd-*.js`
-- `insert-prd-*.js`
-- `enhance-prd-*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/add-prd-to-database.js
-```
-
-### Why This Matters
-- One-off scripts bypass PRD quality validation
-- They create massive maintenance burden (100+ orphaned scripts)
-- They fragment PRD creation patterns
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-prd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/add-prd-to-database.js`
-2. Follow the modular PRD creation system in `scripts/prd/`
-3. PRD is properly validated against quality rubrics
-
 ## Vision V2 PRD Requirements (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Integration in PRDs
@@ -1791,6 +1763,34 @@ Key spec requirements addressed:
 ### Implementation Guidance (from SD metadata)
 
 All Vision V2 SDs have `creation_mode: CREATE_FROM_NEW` - implement fresh per specs, learn from existing code but do not modify it.
+
+## PRD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off PRD creation scripts like:**
+- `create-prd-sd-*.js`
+- `insert-prd-*.js`
+- `enhance-prd-*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/add-prd-to-database.js
+```
+
+### Why This Matters
+- One-off scripts bypass PRD quality validation
+- They create massive maintenance burden (100+ orphaned scripts)
+- They fragment PRD creation patterns
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-prd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/add-prd-to-database.js`
+2. Follow the modular PRD creation system in `scripts/prd/`
+3. PRD is properly validated against quality rubrics
 
 ## Visual Documentation Best Practices
 

--- a/database/migrations/20260123_add_database_agent_auto_invoke_docs.sql
+++ b/database/migrations/20260123_add_database_agent_auto_invoke_docs.sql
@@ -1,0 +1,94 @@
+-- Migration: Add Database Sub-Agent Auto-Invocation Documentation
+-- Purpose: Document SQL execution intent triggers for database sub-agent
+-- Created: 2026-01-23
+-- SD: SD-LEO-INFRA-PRD-CREATION-CONSOLIDATION-001
+
+INSERT INTO leo_protocol_sections (
+  protocol_id,
+  section_type,
+  title,
+  content,
+  order_index,
+  metadata,
+  priority,
+  context_tier,
+  target_file
+) VALUES (
+  'leo-v4-3-3-ui-parity',
+  'sub_agent_config',
+  'Database Sub-Agent Auto-Invocation',
+  E'## Database Sub-Agent Semantic Triggering
+
+When SQL execution intent is detected, the database sub-agent should be auto-invoked instead of outputting manual execution instructions.
+
+### Intent Detection Triggers
+
+The following phrases trigger automatic database sub-agent invocation:
+
+| Category | Example Phrases | Priority |
+|----------|-----------------|----------|
+| **Direct Command** | "run this sql", "execute the query" | 9 |
+| **Delegation** | "use database sub-agent", "have the database agent" | 8 |
+| **Imperative** | "please run", "can you execute" | 8 |
+| **Operational** | "update the table", "create the table" | 7 |
+| **Result-Oriented** | "make this change in the database" | 6 |
+| **Contextual** | "run it", "execute it" (requires SQL context) | 5 |
+
+### Denylist Phrases (Block Execution Intent)
+
+These phrases force NO_EXECUTION intent:
+- "do not execute"
+- "for reference only"
+- "example query"
+- "sample sql"
+- "here is an example"
+
+### Integration
+
+When Claude generates SQL with execution instructions:
+1. Check for SQL execution intent using `shouldAutoInvokeAndExecute()`
+2. If intent detected with confidence >= 80%, use Task tool with database-agent
+3. Never output "run this manually" when auto-invocation is permitted
+
+```javascript
+// Import
+import { shouldAutoInvokeAndExecute } from ''lib/utils/db-agent-auto-invoker.js'';
+
+// Check before outputting SQL
+const result = await shouldAutoInvokeAndExecute(sqlMessage);
+if (result.shouldInvoke) {
+  // Use Task tool instead of manual instructions
+  Task({ subagent_type: ''database-agent'', prompt: result.taskParams.prompt });
+}
+```
+
+### Configuration
+
+Runtime configuration in `db_agent_config` table:
+- `MIN_CONFIDENCE_TO_INVOKE`: 0.80 (default)
+- `DB_AGENT_ENABLED`: true (default)
+- `DENYLIST_PHRASES`: Array of blocking phrases
+
+### Audit Trail
+
+All invocation decisions logged to `db_agent_invocations` table with:
+- correlation_id for tracing
+- intent and confidence scores
+- matched trigger IDs
+- decision outcome
+',
+  318,
+  '{"added_date": "2026-01-23", "author": "LEO_PROTOCOL", "version": "v4.3.3", "purpose": "SQL execution intent auto-invocation"}'::jsonb,
+  'SITUATIONAL',
+  'CORE',
+  'CLAUDE.md'
+)
+ON CONFLICT (protocol_id, section_type, order_index)
+DO UPDATE SET
+  content = EXCLUDED.content,
+  priority = EXCLUDED.priority,
+  metadata = EXCLUDED.metadata;
+
+-- Add comment
+COMMENT ON COLUMN leo_protocol_sections.priority IS
+  'Section priority: CORE (always loaded, never removed), STANDARD (normal rules), SITUATIONAL (context-dependent)';

--- a/database/migrations/20260124_add_sql_execution_intent_triggers.sql
+++ b/database/migrations/20260124_add_sql_execution_intent_triggers.sql
@@ -1,0 +1,207 @@
+-- Migration: Add SQL Execution Intent Triggers
+-- SD: SD-LEO-INFRA-DATABASE-SUB-AGENT-001
+-- Purpose: Add intent-based trigger patterns for SQL execution detection
+-- This migration adds 30+ triggers that detect when users want SQL executed (not just discussed)
+
+-- ============================================================================
+-- UP MIGRATION
+-- ============================================================================
+
+-- Get the DATABASE sub-agent ID
+DO $$
+DECLARE
+    db_agent_id UUID;
+BEGIN
+    -- Get DATABASE sub-agent ID
+    SELECT id INTO db_agent_id FROM leo_sub_agents WHERE code = 'DATABASE';
+
+    IF db_agent_id IS NULL THEN
+        RAISE EXCEPTION 'DATABASE sub-agent not found in leo_sub_agents';
+    END IF;
+
+    -- ========================================================================
+    -- CATEGORY 1: Direct SQL Execution Commands (Priority 9 - highest)
+    -- ========================================================================
+
+    INSERT INTO leo_sub_agent_triggers (sub_agent_id, trigger_phrase, trigger_type, priority, active, trigger_context, metadata)
+    VALUES
+        (db_agent_id, 'run this sql', 'pattern', 9, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "direct_command", "confidence_boost": 0.2, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'execute this sql', 'pattern', 9, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "direct_command", "confidence_boost": 0.2, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'run the query', 'pattern', 9, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "direct_command", "confidence_boost": 0.2, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'execute the query', 'pattern', 9, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "direct_command", "confidence_boost": 0.2, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'run this migration', 'pattern', 9, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "direct_command", "confidence_boost": 0.2, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'execute the migration', 'pattern', 9, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "direct_command", "confidence_boost": 0.2, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'run that migration', 'pattern', 9, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "direct_command", "confidence_boost": 0.2, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb)
+    ON CONFLICT DO NOTHING;
+
+    -- ========================================================================
+    -- CATEGORY 2: Imperative Phrasing (Priority 8)
+    -- ========================================================================
+
+    INSERT INTO leo_sub_agent_triggers (sub_agent_id, trigger_phrase, trigger_type, priority, active, trigger_context, metadata)
+    VALUES
+        (db_agent_id, 'execute the following', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "imperative", "confidence_boost": 0.15, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'run the following', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "imperative", "confidence_boost": 0.15, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'please run', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "imperative", "confidence_boost": 0.15, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'please execute', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "imperative", "confidence_boost": 0.15, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'can you run', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "imperative", "confidence_boost": 0.15, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'can you execute', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "imperative", "confidence_boost": 0.15, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'apply this migration', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "imperative", "confidence_boost": 0.15, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'apply the migration', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "imperative", "confidence_boost": 0.15, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb)
+    ON CONFLICT DO NOTHING;
+
+    -- ========================================================================
+    -- CATEGORY 3: Operational Phrasing (Priority 7)
+    -- ========================================================================
+
+    INSERT INTO leo_sub_agent_triggers (sub_agent_id, trigger_phrase, trigger_type, priority, active, trigger_context, metadata)
+    VALUES
+        (db_agent_id, 'insert this into', 'pattern', 7, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "operational", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'update the database', 'pattern', 7, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "operational", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'update the table', 'pattern', 7, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "operational", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'delete from the table', 'pattern', 7, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "operational", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'create the table', 'pattern', 7, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "operational", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'alter the table', 'pattern', 7, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "operational", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'drop the table', 'pattern', 7, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "operational", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'add this column', 'pattern', 7, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "operational", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb)
+    ON CONFLICT DO NOTHING;
+
+    -- ========================================================================
+    -- CATEGORY 4: Result-Oriented Requests (Priority 6)
+    -- ========================================================================
+
+    INSERT INTO leo_sub_agent_triggers (sub_agent_id, trigger_phrase, trigger_type, priority, active, trigger_context, metadata)
+    VALUES
+        (db_agent_id, 'make this change in the database', 'pattern', 6, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "result_oriented", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'update this in supabase', 'pattern', 6, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "result_oriented", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'fix this in the database', 'pattern', 6, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "result_oriented", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'modify the schema', 'pattern', 6, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "result_oriented", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'add this to the database', 'pattern', 6, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "result_oriented", "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb)
+    ON CONFLICT DO NOTHING;
+
+    -- ========================================================================
+    -- CATEGORY 5: Sub-Agent Delegation Phrases (Priority 8)
+    -- ========================================================================
+
+    INSERT INTO leo_sub_agent_triggers (sub_agent_id, trigger_phrase, trigger_type, priority, active, trigger_context, metadata)
+    VALUES
+        (db_agent_id, 'use the database sub-agent', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "delegation", "confidence_boost": 0.25, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'use database sub-agent', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "delegation", "confidence_boost": 0.25, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'database agent should run', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "delegation", "confidence_boost": 0.25, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'have the database agent', 'pattern', 8, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "delegation", "confidence_boost": 0.25, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb)
+    ON CONFLICT DO NOTHING;
+
+    -- ========================================================================
+    -- CATEGORY 6: Contextual SQL Execution (Priority 5)
+    -- These require SQL to be present in context to trigger
+    -- ========================================================================
+
+    INSERT INTO leo_sub_agent_triggers (sub_agent_id, trigger_phrase, trigger_type, priority, active, trigger_context, metadata)
+    VALUES
+        (db_agent_id, 'run it', 'pattern', 5, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "contextual", "requires_sql_context": true, "confidence_boost": 0.05, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'execute it', 'pattern', 5, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "contextual", "requires_sql_context": true, "confidence_boost": 0.05, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'go ahead and run', 'pattern', 5, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "contextual", "requires_sql_context": true, "confidence_boost": 0.05, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'yes, run it', 'pattern', 5, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "contextual", "requires_sql_context": true, "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb),
+        (db_agent_id, 'yes, execute', 'pattern', 5, true, 'SQL_EXECUTION_INTENT',
+         '{"intent": "SQL_EXECUTION", "category": "contextual", "requires_sql_context": true, "confidence_boost": 0.1, "created_by": "migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001"}'::jsonb)
+    ON CONFLICT DO NOTHING;
+
+    RAISE NOTICE 'Successfully inserted SQL execution intent triggers for DATABASE sub-agent';
+END $$;
+
+-- ============================================================================
+-- Create config table for runtime tuning (FR-4)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS db_agent_config (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key VARCHAR(100) UNIQUE NOT NULL,
+    value JSONB NOT NULL,
+    description TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Insert default configuration values
+INSERT INTO db_agent_config (key, value, description)
+VALUES
+    ('MIN_CONFIDENCE_TO_INVOKE', '0.80'::jsonb, 'Minimum confidence score (0-1) required to auto-invoke database sub-agent'),
+    ('MAX_TRIGGERS_EVALUATED', '200'::jsonb, 'Maximum number of triggers to evaluate per request'),
+    ('DB_AGENT_ENABLED', 'true'::jsonb, 'Master switch to enable/disable database sub-agent auto-invocation'),
+    ('DENYLIST_PHRASES', '["do not execute", "for reference only", "example query", "sample sql", "here is an example", "you could run", "would look like"]'::jsonb, 'Phrases that force NO_EXECUTION intent regardless of trigger matches')
+ON CONFLICT (key) DO NOTHING;
+
+-- ============================================================================
+-- Create audit table for invocation tracking (FR-3, FR-5)
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS db_agent_invocations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    correlation_id UUID NOT NULL,
+    conversation_id TEXT,
+    message_id TEXT,
+    intent VARCHAR(50) NOT NULL,
+    confidence DECIMAL(4,3) NOT NULL,
+    matched_trigger_ids UUID[],
+    decision VARCHAR(50) NOT NULL, -- 'invoke_db_agent', 'blocked_policy', 'blocked_confidence', 'no_execution'
+    block_reason TEXT,
+    environment VARCHAR(50),
+    db_agent_enabled BOOLEAN,
+    execution_result JSONB,
+    latency_ms INTEGER,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index for querying by correlation_id and time-based analytics
+CREATE INDEX IF NOT EXISTS idx_db_agent_invocations_correlation ON db_agent_invocations(correlation_id);
+CREATE INDEX IF NOT EXISTS idx_db_agent_invocations_created_at ON db_agent_invocations(created_at);
+CREATE INDEX IF NOT EXISTS idx_db_agent_invocations_intent ON db_agent_invocations(intent);
+CREATE INDEX IF NOT EXISTS idx_db_agent_invocations_decision ON db_agent_invocations(decision);
+
+-- ============================================================================
+-- DOWN MIGRATION (Rollback)
+-- ============================================================================
+
+-- To rollback, run:
+-- DELETE FROM leo_sub_agent_triggers WHERE metadata->>'created_by' = 'migration:SD-LEO-INFRA-DATABASE-SUB-AGENT-001';
+-- DROP TABLE IF EXISTS db_agent_invocations;
+-- DROP TABLE IF EXISTS db_agent_config;
+
+COMMENT ON TABLE db_agent_config IS 'Runtime configuration for database sub-agent auto-invocation (SD-LEO-INFRA-DATABASE-SUB-AGENT-001)';
+COMMENT ON TABLE db_agent_invocations IS 'Audit trail for database sub-agent invocation decisions (SD-LEO-INFRA-DATABASE-SUB-AGENT-001)';

--- a/lib/utils/db-agent-auto-invoker.js
+++ b/lib/utils/db-agent-auto-invoker.js
@@ -1,0 +1,267 @@
+/**
+ * Database Sub-Agent Auto-Invoker
+ *
+ * Provides orchestration-level integration for auto-invoking the database sub-agent
+ * when SQL execution intent is detected. Used by Claude/orchestrator to determine
+ * if a response should trigger database sub-agent instead of manual execution.
+ *
+ * Created: 2026-01-24
+ * SD: SD-LEO-INFRA-DATABASE-SUB-AGENT-001
+ * Part of: Database Sub-Agent Semantic Triggering Enhancement
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  classifySQLExecutionIntent,
+  shouldAutoInvokeDBAgent,
+  getConfig
+} from './sql-execution-intent-classifier.js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+/**
+ * Auto-invocation result structure
+ * @typedef {Object} AutoInvocationResult
+ * @property {boolean} shouldInvoke - Whether to invoke database sub-agent
+ * @property {string} intent - Detected intent
+ * @property {number} confidence - Confidence score
+ * @property {string} decision - Decision made
+ * @property {string|null} blockReason - Reason if blocked
+ * @property {string} correlationId - Correlation ID for tracing
+ * @property {Object} suggestedAction - Recommended action for orchestrator
+ */
+
+/**
+ * Response templates for different outcomes
+ */
+const RESPONSE_TEMPLATES = {
+  invoking: {
+    user: 'Executing via database sub-agent...',
+    log: '[db-auto-invoker] SQL execution intent detected (confidence: {confidence}). Invoking database sub-agent.'
+  },
+  blocked_policy: {
+    user: 'Database sub-agent auto-invocation is disabled. {blockReason}',
+    log: '[db-auto-invoker] Blocked by policy: {blockReason}'
+  },
+  blocked_confidence: {
+    user: 'SQL execution detected but confidence too low. Please clarify your intent.',
+    log: '[db-auto-invoker] Confidence ({confidence}) below threshold. Not invoking.'
+  },
+  blocked_environment: {
+    user: 'Database execution not permitted in this environment. {blockReason}',
+    log: '[db-auto-invoker] Environment restriction: {blockReason}'
+  },
+  no_execution: {
+    user: null, // No user message needed
+    log: '[db-auto-invoker] No SQL execution intent detected.'
+  }
+};
+
+/**
+ * Check environment permissions for database execution
+ */
+function checkEnvironmentPermissions() {
+  const env = process.env.NODE_ENV || 'development';
+  const prodApproval = process.env.DB_PROD_EXECUTION_APPROVED === 'true';
+
+  if (env === 'production' && !prodApproval) {
+    return {
+      permitted: false,
+      reason: 'Production database execution requires DB_PROD_EXECUTION_APPROVED=true'
+    };
+  }
+
+  return { permitted: true, reason: null };
+}
+
+/**
+ * Check if a message should trigger auto-invocation of database sub-agent
+ * and return formatted result for orchestrator consumption.
+ *
+ * @param {string} message - Message to analyze (usually Claude's response)
+ * @param {Object} options - Options
+ * @param {string} options.conversationId - Conversation ID for logging
+ * @param {string} options.messageId - Message ID for logging
+ * @param {string} options.sdKey - Current SD key for context
+ * @returns {Promise<AutoInvocationResult>}
+ */
+export async function checkAndPrepareAutoInvocation(message, options = {}) {
+  const correlationId = uuidv4();
+
+  // First check environment permissions
+  const envCheck = checkEnvironmentPermissions();
+
+  // Classify the message
+  const classification = await classifySQLExecutionIntent(message, {
+    conversationId: options.conversationId,
+    messageId: options.messageId,
+    skipLogging: false
+  });
+
+  // Build result
+  const result = {
+    correlationId,
+    shouldInvoke: false,
+    intent: classification.intent,
+    confidence: classification.confidence,
+    decision: classification.decision,
+    blockReason: classification.blockReason,
+    matchedTriggers: classification.matchedTriggerIds.length,
+    suggestedAction: null,
+    messages: {
+      user: null,
+      log: null
+    }
+  };
+
+  // Determine action based on classification and environment
+  if (classification.decision === 'invoke_db_agent') {
+    if (!envCheck.permitted) {
+      result.decision = 'blocked_environment';
+      result.blockReason = envCheck.reason;
+      result.messages = formatMessages(RESPONSE_TEMPLATES.blocked_environment, result);
+    } else {
+      result.shouldInvoke = true;
+      result.messages = formatMessages(RESPONSE_TEMPLATES.invoking, result);
+      result.suggestedAction = {
+        type: 'invoke_task_tool',
+        subagent_type: 'database-agent',
+        prompt_prefix: 'Execute the following SQL operation:\n\n',
+        model: 'sonnet'
+      };
+    }
+  } else if (classification.decision === 'blocked_policy') {
+    result.messages = formatMessages(RESPONSE_TEMPLATES.blocked_policy, result);
+  } else if (classification.decision === 'blocked_confidence') {
+    result.messages = formatMessages(RESPONSE_TEMPLATES.blocked_confidence, result);
+  } else {
+    result.messages = formatMessages(RESPONSE_TEMPLATES.no_execution, result);
+  }
+
+  // Log the decision
+  console.log(result.messages.log);
+
+  return result;
+}
+
+/**
+ * Format message templates with actual values
+ */
+function formatMessages(template, data) {
+  const format = (str) => {
+    if (!str) return null;
+    return str
+      .replace('{confidence}', (data.confidence * 100).toFixed(0) + '%')
+      .replace('{blockReason}', data.blockReason || 'Unknown reason')
+      .replace('{correlationId}', data.correlationId);
+  };
+
+  return {
+    user: format(template.user),
+    log: format(template.log)
+  };
+}
+
+/**
+ * Get the Task tool invocation parameters for database sub-agent.
+ * Returns null if auto-invocation not applicable.
+ *
+ * @param {string} message - Message containing SQL to execute
+ * @param {Object} options - Options
+ * @returns {Promise<Object|null>} Task tool parameters or null
+ */
+export async function getDBAgentTaskParams(message, options = {}) {
+  const result = await checkAndPrepareAutoInvocation(message, options);
+
+  if (!result.shouldInvoke) {
+    return null;
+  }
+
+  return {
+    description: 'Execute SQL via database sub-agent',
+    prompt: `${result.suggestedAction.prompt_prefix}${message}`,
+    subagent_type: result.suggestedAction.subagent_type,
+    model: result.suggestedAction.model
+  };
+}
+
+/**
+ * Structured logging for metrics/observability
+ */
+export function logMetric(metricName, value, tags = {}) {
+  const metric = {
+    name: metricName,
+    value,
+    timestamp: new Date().toISOString(),
+    tags: {
+      ...tags,
+      service: 'db-agent-auto-invoker',
+      environment: process.env.NODE_ENV || 'development'
+    }
+  };
+
+  // In production, this would emit to your metrics system
+  // For now, structured log output
+  console.log(JSON.stringify({ type: 'metric', ...metric }));
+}
+
+/**
+ * Record invocation metrics
+ */
+export async function recordInvocationMetrics(result) {
+  logMetric('db_trigger.intent_detected_total', 1, { intent: result.intent });
+
+  if (result.shouldInvoke) {
+    logMetric('db_trigger.invoked_total', 1);
+  } else if (result.decision.startsWith('blocked_')) {
+    logMetric('db_trigger.blocked_total', 1, { reason: result.decision });
+  }
+
+  logMetric('db_trigger.classification_latency_ms', result.latencyMs || 0);
+}
+
+/**
+ * Integration helper for CLAUDE.md proactive invocation.
+ * Call this when Claude is about to output SQL with execution instructions.
+ *
+ * Example usage in orchestrator context:
+ * ```
+ * if (responseContainsSQL && suggestsManualExecution) {
+ *   const autoInvoke = await shouldAutoInvokeAndExecute(response);
+ *   if (autoInvoke.shouldInvoke) {
+ *     // Use Task tool instead of outputting manual instructions
+ *     return { useTaskTool: true, params: autoInvoke.taskParams };
+ *   }
+ * }
+ * ```
+ *
+ * @param {string} message - Message to check
+ * @param {Object} options - Options
+ * @returns {Promise<{shouldInvoke: boolean, taskParams: Object|null, userMessage: string|null}>}
+ */
+export async function shouldAutoInvokeAndExecute(message, options = {}) {
+  const result = await checkAndPrepareAutoInvocation(message, options);
+
+  return {
+    shouldInvoke: result.shouldInvoke,
+    taskParams: result.shouldInvoke ? await getDBAgentTaskParams(message, options) : null,
+    userMessage: result.messages.user,
+    correlationId: result.correlationId,
+    confidence: result.confidence
+  };
+}
+
+export default {
+  checkAndPrepareAutoInvocation,
+  getDBAgentTaskParams,
+  shouldAutoInvokeAndExecute,
+  logMetric,
+  recordInvocationMetrics
+};

--- a/lib/utils/sql-execution-intent-classifier.js
+++ b/lib/utils/sql-execution-intent-classifier.js
@@ -1,0 +1,397 @@
+/**
+ * SQL Execution Intent Classifier
+ *
+ * Deterministic classifier that evaluates messages for SQL execution intent.
+ * Uses trigger patterns from leo_sub_agent_triggers and applies denylist filtering.
+ *
+ * Created: 2026-01-24
+ * SD: SD-LEO-INFRA-DATABASE-SUB-AGENT-001
+ * Part of: Database Sub-Agent Semantic Triggering Enhancement
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { v4 as uuidv4 } from 'uuid';
+
+dotenv.config();
+
+// Initialize Supabase client
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+/**
+ * Classification result structure
+ * @typedef {Object} ClassificationResult
+ * @property {string} intent - 'SQL_EXECUTION' or 'NO_EXECUTION'
+ * @property {number} confidence - Confidence score (0-1)
+ * @property {string[]} matchedTriggerIds - UUIDs of matched triggers
+ * @property {string} decision - 'invoke_db_agent', 'blocked_policy', 'blocked_confidence', 'no_execution'
+ * @property {string|null} blockReason - Reason if blocked
+ * @property {Object} metadata - Additional classification metadata
+ */
+
+/**
+ * Default configuration values (can be overridden by database config)
+ */
+const DEFAULT_CONFIG = {
+  MIN_CONFIDENCE_TO_INVOKE: 0.80,
+  MAX_TRIGGERS_EVALUATED: 200,
+  DB_AGENT_ENABLED: true,
+  DENYLIST_PHRASES: [
+    'do not execute',
+    'for reference only',
+    'example query',
+    'sample sql',
+    'here is an example',
+    'you could run',
+    'would look like'
+  ]
+};
+
+/**
+ * SQL patterns that indicate SQL is present in context
+ */
+const SQL_CONTEXT_PATTERNS = [
+  /\bSELECT\s+.+\s+FROM\b/i,
+  /\bINSERT\s+INTO\b/i,
+  /\bUPDATE\s+.+\s+SET\b/i,
+  /\bDELETE\s+FROM\b/i,
+  /\bCREATE\s+(TABLE|INDEX|FUNCTION|VIEW)\b/i,
+  /\bALTER\s+TABLE\b/i,
+  /\bDROP\s+(TABLE|INDEX|FUNCTION|VIEW)\b/i,
+  /\bTRUNCATE\s+TABLE\b/i,
+  /\bGRANT\b.*\bON\b/i,
+  /\bREVOKE\b.*\bON\b/i
+];
+
+/**
+ * Load runtime configuration from database
+ * Falls back to defaults if database unavailable
+ */
+async function loadConfig() {
+  try {
+    const { data, error } = await supabase
+      .from('db_agent_config')
+      .select('key, value');
+
+    if (error || !data) {
+      console.log('[sql-intent-classifier] Using default config (db unavailable)');
+      return DEFAULT_CONFIG;
+    }
+
+    const config = { ...DEFAULT_CONFIG };
+    for (const row of data) {
+      if (row.key === 'MIN_CONFIDENCE_TO_INVOKE') {
+        config.MIN_CONFIDENCE_TO_INVOKE = parseFloat(row.value) || DEFAULT_CONFIG.MIN_CONFIDENCE_TO_INVOKE;
+      } else if (row.key === 'MAX_TRIGGERS_EVALUATED') {
+        config.MAX_TRIGGERS_EVALUATED = parseInt(row.value) || DEFAULT_CONFIG.MAX_TRIGGERS_EVALUATED;
+      } else if (row.key === 'DB_AGENT_ENABLED') {
+        config.DB_AGENT_ENABLED = row.value === true || row.value === 'true';
+      } else if (row.key === 'DENYLIST_PHRASES') {
+        config.DENYLIST_PHRASES = Array.isArray(row.value) ? row.value : DEFAULT_CONFIG.DENYLIST_PHRASES;
+      }
+    }
+    return config;
+  } catch (err) {
+    console.log('[sql-intent-classifier] Config load error, using defaults:', err.message);
+    return DEFAULT_CONFIG;
+  }
+}
+
+/**
+ * Load SQL execution intent triggers from database
+ */
+async function loadTriggers(maxTriggers = 200) {
+  try {
+    const { data, error } = await supabase
+      .from('leo_sub_agent_triggers')
+      .select('id, trigger_phrase, trigger_type, priority, metadata, trigger_context')
+      .eq('trigger_context', 'SQL_EXECUTION_INTENT')
+      .eq('active', true)
+      .order('priority', { ascending: false })
+      .limit(maxTriggers);
+
+    if (error) {
+      console.error('[sql-intent-classifier] Trigger load error:', error.message);
+      return [];
+    }
+
+    return data || [];
+  } catch (err) {
+    console.error('[sql-intent-classifier] Trigger load exception:', err.message);
+    return [];
+  }
+}
+
+/**
+ * Check if message contains SQL context (for contextual triggers)
+ */
+function hasSQLContext(message) {
+  return SQL_CONTEXT_PATTERNS.some(pattern => pattern.test(message));
+}
+
+/**
+ * Check if message contains any denylist phrases
+ */
+function containsDenylistPhrase(message, denylist) {
+  const lowerMessage = message.toLowerCase();
+  return denylist.some(phrase => lowerMessage.includes(phrase.toLowerCase()));
+}
+
+/**
+ * Match message against triggers and calculate confidence
+ */
+function matchTriggers(message, triggers) {
+  const lowerMessage = message.toLowerCase();
+  const matches = [];
+  let totalConfidenceBoost = 0;
+  const hasSql = hasSQLContext(message);
+
+  for (const trigger of triggers) {
+    const phrase = trigger.trigger_phrase.toLowerCase();
+    const metadata = trigger.metadata || {};
+
+    // Check if trigger requires SQL context
+    if (metadata.requires_sql_context && !hasSql) {
+      continue;
+    }
+
+    // Match based on trigger type
+    let isMatch = false;
+    if (trigger.trigger_type === 'pattern' || trigger.trigger_type === 'phrase') {
+      isMatch = lowerMessage.includes(phrase);
+    } else if (trigger.trigger_type === 'regex') {
+      try {
+        const regex = new RegExp(phrase, 'i');
+        isMatch = regex.test(message);
+      } catch (e) {
+        // Invalid regex, skip
+        continue;
+      }
+    } else if (trigger.trigger_type === 'keyword') {
+      // Word boundary match for keywords
+      const wordRegex = new RegExp(`\\b${escapeRegExp(phrase)}\\b`, 'i');
+      isMatch = wordRegex.test(message);
+    }
+
+    if (isMatch) {
+      matches.push({
+        triggerId: trigger.id,
+        phrase: trigger.trigger_phrase,
+        priority: trigger.priority,
+        category: metadata.category || 'unknown',
+        confidenceBoost: metadata.confidence_boost || 0
+      });
+      totalConfidenceBoost += metadata.confidence_boost || 0;
+    }
+  }
+
+  return { matches, totalConfidenceBoost };
+}
+
+/**
+ * Escape special regex characters
+ */
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Calculate final confidence score
+ */
+function calculateConfidence(matches, totalBoost, hasSql, hasDenylist) {
+  // Base confidence from number of matches and their priorities
+  let baseConfidence = 0;
+
+  if (matches.length === 0) {
+    return 0;
+  }
+
+  // Higher priority matches contribute more
+  const maxPriority = Math.max(...matches.map(m => m.priority));
+  baseConfidence = 0.5 + (maxPriority / 20); // Max priority 9 = 0.95 base
+
+  // Add confidence boosts from matched triggers
+  const confidence = Math.min(1.0, baseConfidence + totalBoost);
+
+  // SQL context present adds confidence
+  const sqlBonus = hasSql ? 0.1 : 0;
+
+  // Denylist forces low confidence
+  if (hasDenylist) {
+    return Math.min(0.3, confidence * 0.3);
+  }
+
+  return Math.min(1.0, confidence + sqlBonus);
+}
+
+/**
+ * Log classification decision to database
+ */
+async function logInvocation(correlationId, result, context = {}) {
+  try {
+    await supabase.from('db_agent_invocations').insert({
+      correlation_id: correlationId,
+      conversation_id: context.conversationId || null,
+      message_id: context.messageId || null,
+      intent: result.intent,
+      confidence: result.confidence,
+      matched_trigger_ids: result.matchedTriggerIds,
+      decision: result.decision,
+      block_reason: result.blockReason,
+      environment: context.environment || process.env.NODE_ENV || 'development',
+      db_agent_enabled: result.metadata?.dbAgentEnabled ?? true,
+      latency_ms: result.metadata?.latencyMs || 0
+    });
+  } catch (err) {
+    console.error('[sql-intent-classifier] Failed to log invocation:', err.message);
+  }
+}
+
+/**
+ * Classify a message for SQL execution intent
+ *
+ * @param {string} message - The message to classify
+ * @param {Object} options - Classification options
+ * @param {string} options.conversationId - Optional conversation ID for logging
+ * @param {string} options.messageId - Optional message ID for logging
+ * @param {string} options.environment - Optional environment (defaults to NODE_ENV)
+ * @param {boolean} options.skipLogging - Skip database logging (for testing)
+ * @returns {Promise<ClassificationResult>} Classification result
+ */
+export async function classifySQLExecutionIntent(message, options = {}) {
+  const startTime = Date.now();
+  const correlationId = uuidv4();
+
+  // Load configuration
+  const config = await loadConfig();
+
+  // Initialize result
+  const result = {
+    correlationId,
+    intent: 'NO_EXECUTION',
+    confidence: 0,
+    matchedTriggerIds: [],
+    decision: 'no_execution',
+    blockReason: null,
+    metadata: {
+      dbAgentEnabled: config.DB_AGENT_ENABLED,
+      minConfidenceThreshold: config.MIN_CONFIDENCE_TO_INVOKE,
+      latencyMs: 0,
+      matchCount: 0,
+      hasSQLContext: false,
+      hasDenylistPhrase: false
+    }
+  };
+
+  // Check for denylist phrases first
+  const hasDenylist = containsDenylistPhrase(message, config.DENYLIST_PHRASES);
+  result.metadata.hasDenylistPhrase = hasDenylist;
+
+  if (hasDenylist) {
+    result.intent = 'NO_EXECUTION';
+    result.confidence = 0.95; // High confidence it's NOT an execution request
+    result.decision = 'no_execution';
+    result.metadata.latencyMs = Date.now() - startTime;
+
+    if (!options.skipLogging) {
+      await logInvocation(correlationId, result, options);
+    }
+    return result;
+  }
+
+  // Load triggers
+  const triggers = await loadTriggers(config.MAX_TRIGGERS_EVALUATED);
+
+  // Match triggers
+  const { matches, totalConfidenceBoost } = matchTriggers(message, triggers);
+  const hasSql = hasSQLContext(message);
+
+  result.metadata.hasSQLContext = hasSql;
+  result.metadata.matchCount = matches.length;
+  result.matchedTriggerIds = matches.map(m => m.triggerId);
+
+  // Calculate confidence
+  const confidence = calculateConfidence(matches, totalConfidenceBoost, hasSql, false);
+  result.confidence = confidence;
+
+  // Determine intent and decision
+  if (matches.length > 0 && confidence >= config.MIN_CONFIDENCE_TO_INVOKE) {
+    result.intent = 'SQL_EXECUTION';
+
+    // Check if DB agent is enabled
+    if (!config.DB_AGENT_ENABLED) {
+      result.decision = 'blocked_policy';
+      result.blockReason = 'DB_AGENT_DISABLED: Database sub-agent auto-invocation is disabled globally';
+    } else {
+      result.decision = 'invoke_db_agent';
+    }
+  } else if (matches.length > 0) {
+    result.intent = 'SQL_EXECUTION';
+    result.decision = 'blocked_confidence';
+    result.blockReason = `Confidence ${confidence.toFixed(2)} below threshold ${config.MIN_CONFIDENCE_TO_INVOKE}`;
+  } else {
+    result.intent = 'NO_EXECUTION';
+    result.decision = 'no_execution';
+  }
+
+  result.metadata.latencyMs = Date.now() - startTime;
+
+  // Log to database
+  if (!options.skipLogging) {
+    await logInvocation(correlationId, result, options);
+  }
+
+  return result;
+}
+
+/**
+ * Check if a message should auto-invoke the database sub-agent
+ *
+ * @param {string} message - The message to check
+ * @param {Object} options - Options passed to classifier
+ * @returns {Promise<{shouldInvoke: boolean, result: ClassificationResult}>}
+ */
+export async function shouldAutoInvokeDBAgent(message, options = {}) {
+  const result = await classifySQLExecutionIntent(message, options);
+
+  return {
+    shouldInvoke: result.decision === 'invoke_db_agent',
+    result
+  };
+}
+
+/**
+ * Get current configuration
+ */
+export async function getConfig() {
+  return loadConfig();
+}
+
+/**
+ * Get active SQL execution intent triggers
+ */
+export async function getActiveTriggers() {
+  return loadTriggers();
+}
+
+// Export for testing
+export const _internal = {
+  loadConfig,
+  loadTriggers,
+  matchTriggers,
+  hasSQLContext,
+  containsDenylistPhrase,
+  calculateConfidence,
+  SQL_CONTEXT_PATTERNS,
+  DEFAULT_CONFIG
+};
+
+export default {
+  classifySQLExecutionIntent,
+  shouldAutoInvokeDBAgent,
+  getConfig,
+  getActiveTriggers
+};

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -14,6 +14,7 @@
     "description": "Essential context for ALL sessions (~15-20k chars)",
     "sections": [
       "infrastructure",
+      "sub_agent_config",
       "script_anti_patterns",
       "mandatory_agent_invocation",
       "application_architecture",

--- a/test/unit/sql-execution-intent-classifier.test.js
+++ b/test/unit/sql-execution-intent-classifier.test.js
@@ -1,0 +1,368 @@
+/**
+ * Unit Tests: SQL Execution Intent Classifier
+ *
+ * Tests the deterministic SQL execution intent classifier.
+ *
+ * SD: SD-LEO-INFRA-DATABASE-SUB-AGENT-001
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock Supabase before importing the module
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            order: vi.fn(() => ({
+              limit: vi.fn(() => Promise.resolve({ data: [], error: null }))
+            }))
+          })),
+          single: vi.fn(() => Promise.resolve({ data: null, error: null }))
+        }))
+      })),
+      insert: vi.fn(() => Promise.resolve({ data: null, error: null }))
+    }))
+  }))
+}));
+
+// Mock uuid
+vi.mock('uuid', () => ({
+  v4: vi.fn(() => 'test-correlation-id')
+}));
+
+// Import after mocking
+import { createClient } from '@supabase/supabase-js';
+import {
+  classifySQLExecutionIntent,
+  shouldAutoInvokeDBAgent,
+  _internal
+} from '../../lib/utils/sql-execution-intent-classifier.js';
+
+describe('SQL Execution Intent Classifier', () => {
+  let mockSupabase;
+  let mockFrom;
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    // Setup mock Supabase responses
+    mockFrom = vi.fn();
+    mockSupabase = {
+      from: mockFrom
+    };
+
+    // Default mock for config loading
+    mockFrom.mockImplementation((table) => {
+      if (table === 'db_agent_config') {
+        return {
+          select: vi.fn(() => Promise.resolve({
+            data: [
+              { key: 'MIN_CONFIDENCE_TO_INVOKE', value: 0.80 },
+              { key: 'MAX_TRIGGERS_EVALUATED', value: 200 },
+              { key: 'DB_AGENT_ENABLED', value: true },
+              { key: 'DENYLIST_PHRASES', value: ['do not execute', 'for reference only', 'example query'] }
+            ],
+            error: null
+          }))
+        };
+      }
+      if (table === 'leo_sub_agent_triggers') {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn(() => Promise.resolve({
+                    data: [
+                      {
+                        id: 'trigger-1',
+                        trigger_phrase: 'run this sql',
+                        trigger_type: 'pattern',
+                        priority: 9,
+                        metadata: { intent: 'SQL_EXECUTION', category: 'direct_command', confidence_boost: 0.2 },
+                        trigger_context: 'SQL_EXECUTION_INTENT'
+                      },
+                      {
+                        id: 'trigger-2',
+                        trigger_phrase: 'please execute',
+                        trigger_type: 'pattern',
+                        priority: 8,
+                        metadata: { intent: 'SQL_EXECUTION', category: 'imperative', confidence_boost: 0.15 },
+                        trigger_context: 'SQL_EXECUTION_INTENT'
+                      },
+                      {
+                        id: 'trigger-3',
+                        trigger_phrase: 'run it',
+                        trigger_type: 'pattern',
+                        priority: 5,
+                        metadata: { intent: 'SQL_EXECUTION', category: 'contextual', confidence_boost: 0.05, requires_sql_context: true },
+                        trigger_context: 'SQL_EXECUTION_INTENT'
+                      }
+                    ],
+                    error: null
+                  }))
+                }))
+              }))
+            }))
+          }))
+        };
+      }
+      if (table === 'db_agent_invocations') {
+        return {
+          insert: vi.fn(() => Promise.resolve({ data: null, error: null }))
+        };
+      }
+      return {
+        select: vi.fn(() => Promise.resolve({ data: [], error: null }))
+      };
+    });
+
+    createClient.mockReturnValue(mockSupabase);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('hasSQLContext', () => {
+    it('should detect SELECT statements', () => {
+      expect(_internal.hasSQLContext('SELECT * FROM users')).toBe(true);
+      expect(_internal.hasSQLContext('SELECT id, name FROM products WHERE active = true')).toBe(true);
+    });
+
+    it('should detect INSERT statements', () => {
+      expect(_internal.hasSQLContext('INSERT INTO users VALUES (1, "test")')).toBe(true);
+    });
+
+    it('should detect UPDATE statements', () => {
+      expect(_internal.hasSQLContext('UPDATE users SET name = "new" WHERE id = 1')).toBe(true);
+    });
+
+    it('should detect DELETE statements', () => {
+      expect(_internal.hasSQLContext('DELETE FROM users WHERE id = 1')).toBe(true);
+    });
+
+    it('should detect CREATE statements', () => {
+      expect(_internal.hasSQLContext('CREATE TABLE users (id INT)')).toBe(true);
+      expect(_internal.hasSQLContext('CREATE INDEX idx_name ON users(name)')).toBe(true);
+    });
+
+    it('should detect ALTER statements', () => {
+      expect(_internal.hasSQLContext('ALTER TABLE users ADD COLUMN email VARCHAR')).toBe(true);
+    });
+
+    it('should return false for non-SQL content', () => {
+      expect(_internal.hasSQLContext('Hello, how are you?')).toBe(false);
+      expect(_internal.hasSQLContext('The select function is used to choose items')).toBe(false);
+    });
+  });
+
+  describe('containsDenylistPhrase', () => {
+    const denylist = ['do not execute', 'for reference only', 'example query'];
+
+    it('should detect denylist phrases', () => {
+      expect(_internal.containsDenylistPhrase('Here is an example query for reference only', denylist)).toBe(true);
+      expect(_internal.containsDenylistPhrase('Do not execute this SQL', denylist)).toBe(true);
+    });
+
+    it('should be case insensitive', () => {
+      expect(_internal.containsDenylistPhrase('FOR REFERENCE ONLY: SELECT * FROM users', denylist)).toBe(true);
+    });
+
+    it('should return false when no denylist phrases present', () => {
+      expect(_internal.containsDenylistPhrase('Please run this SQL: SELECT * FROM users', denylist)).toBe(false);
+    });
+  });
+
+  describe('matchTriggers', () => {
+    const triggers = [
+      {
+        id: 'trigger-1',
+        trigger_phrase: 'run this sql',
+        trigger_type: 'pattern',
+        priority: 9,
+        metadata: { category: 'direct_command', confidence_boost: 0.2 }
+      },
+      {
+        id: 'trigger-2',
+        trigger_phrase: 'please execute',
+        trigger_type: 'pattern',
+        priority: 8,
+        metadata: { category: 'imperative', confidence_boost: 0.15 }
+      },
+      {
+        id: 'trigger-3',
+        trigger_phrase: 'run it',
+        trigger_type: 'pattern',
+        priority: 5,
+        metadata: { category: 'contextual', confidence_boost: 0.05, requires_sql_context: true }
+      }
+    ];
+
+    it('should match direct command phrases', () => {
+      const result = _internal.matchTriggers('Can you run this sql for me?', triggers);
+      expect(result.matches.length).toBe(1);
+      expect(result.matches[0].triggerId).toBe('trigger-1');
+      expect(result.totalConfidenceBoost).toBe(0.2);
+    });
+
+    it('should match multiple triggers', () => {
+      const result = _internal.matchTriggers('Please execute and run this sql', triggers);
+      expect(result.matches.length).toBe(2);
+      expect(result.totalConfidenceBoost).toBe(0.35);
+    });
+
+    it('should skip contextual triggers without SQL context', () => {
+      const result = _internal.matchTriggers('Just run it please', triggers);
+      expect(result.matches.length).toBe(0);
+    });
+
+    it('should match contextual triggers when SQL is present', () => {
+      const result = _internal.matchTriggers('SELECT * FROM users; just run it', triggers);
+      expect(result.matches.some(m => m.triggerId === 'trigger-3')).toBe(true);
+    });
+
+    it('should handle case insensitivity', () => {
+      const result = _internal.matchTriggers('RUN THIS SQL please', triggers);
+      expect(result.matches.length).toBe(1);
+    });
+  });
+
+  describe('calculateConfidence', () => {
+    it('should return 0 for no matches', () => {
+      expect(_internal.calculateConfidence([], 0, false, false)).toBe(0);
+    });
+
+    it('should return high confidence for high priority matches', () => {
+      const matches = [{ priority: 9, category: 'direct_command' }];
+      const confidence = _internal.calculateConfidence(matches, 0.2, false, false);
+      expect(confidence).toBeGreaterThan(0.8);
+    });
+
+    it('should add SQL context bonus', () => {
+      const matches = [{ priority: 5, category: 'contextual' }];
+      const withoutSql = _internal.calculateConfidence(matches, 0.05, false, false);
+      const withSql = _internal.calculateConfidence(matches, 0.05, true, false);
+      expect(withSql).toBeGreaterThan(withoutSql);
+    });
+
+    it('should heavily penalize denylist matches', () => {
+      const matches = [{ priority: 9, category: 'direct_command' }];
+      const confidence = _internal.calculateConfidence(matches, 0.2, false, true);
+      expect(confidence).toBeLessThanOrEqual(0.3);
+    });
+  });
+
+  describe('classifySQLExecutionIntent', () => {
+    it('should return NO_EXECUTION for denylist phrases', async () => {
+      const result = await classifySQLExecutionIntent(
+        'Here is an example query for reference only: SELECT * FROM users',
+        { skipLogging: true }
+      );
+
+      expect(result.intent).toBe('NO_EXECUTION');
+      expect(result.decision).toBe('no_execution');
+      expect(result.metadata.hasDenylistPhrase).toBe(true);
+    });
+
+    it('should have correlation_id in result', async () => {
+      const result = await classifySQLExecutionIntent(
+        'Hello world',
+        { skipLogging: true }
+      );
+
+      expect(result.correlationId).toBe('test-correlation-id');
+    });
+
+    it('should include latency in metadata', async () => {
+      const result = await classifySQLExecutionIntent(
+        'test message',
+        { skipLogging: true }
+      );
+
+      expect(typeof result.metadata.latencyMs).toBe('number');
+    });
+  });
+
+  describe('shouldAutoInvokeDBAgent', () => {
+    it('should return shouldInvoke: false for non-execution content', async () => {
+      const { shouldInvoke, result } = await shouldAutoInvokeDBAgent(
+        'What is the weather today?',
+        { skipLogging: true }
+      );
+
+      expect(shouldInvoke).toBe(false);
+      expect(result.intent).toBe('NO_EXECUTION');
+    });
+
+    it('should include full classification result', async () => {
+      const { result } = await shouldAutoInvokeDBAgent(
+        'test message',
+        { skipLogging: true }
+      );
+
+      expect(result).toHaveProperty('intent');
+      expect(result).toHaveProperty('confidence');
+      expect(result).toHaveProperty('decision');
+      expect(result).toHaveProperty('matchedTriggerIds');
+    });
+  });
+
+  describe('SQL_CONTEXT_PATTERNS', () => {
+    it('should export SQL patterns for testing', () => {
+      expect(Array.isArray(_internal.SQL_CONTEXT_PATTERNS)).toBe(true);
+      expect(_internal.SQL_CONTEXT_PATTERNS.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('DEFAULT_CONFIG', () => {
+    it('should have reasonable defaults', () => {
+      expect(_internal.DEFAULT_CONFIG.MIN_CONFIDENCE_TO_INVOKE).toBe(0.80);
+      expect(_internal.DEFAULT_CONFIG.MAX_TRIGGERS_EVALUATED).toBe(200);
+      expect(_internal.DEFAULT_CONFIG.DB_AGENT_ENABLED).toBe(true);
+      expect(Array.isArray(_internal.DEFAULT_CONFIG.DENYLIST_PHRASES)).toBe(true);
+    });
+  });
+});
+
+describe('Integration Scenarios', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  describe('Real-world execution phrases', () => {
+    const executionPhrases = [
+      'Please run this SQL: SELECT * FROM users',
+      'Can you execute this query for me?',
+      'Run the following migration',
+      'Execute the migration script',
+      'Use the database sub-agent to run this',
+      'Apply this migration to the database'
+    ];
+
+    it.each(executionPhrases)('should detect execution intent in: "%s"', async (phrase) => {
+      // Note: In real tests with actual DB, these would return SQL_EXECUTION
+      // With mocked empty triggers, we just verify the function runs
+      const result = await classifySQLExecutionIntent(phrase, { skipLogging: true });
+      expect(result).toHaveProperty('intent');
+      expect(result).toHaveProperty('confidence');
+    });
+  });
+
+  describe('Real-world non-execution phrases', () => {
+    const nonExecutionPhrases = [
+      'Here is an example query you could use',
+      'For reference only, the SQL would look like this',
+      'Do not execute this, but here is a sample',
+      'This is just a sample SQL for documentation'
+    ];
+
+    it.each(nonExecutionPhrases)('should NOT detect execution intent in: "%s"', async (phrase) => {
+      const result = await classifySQLExecutionIntent(phrase, { skipLogging: true });
+      expect(result.intent).toBe('NO_EXECUTION');
+      expect(result.metadata.hasDenylistPhrase).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **SD-LEO-INFRA-DATABASE-SUB-AGENT-001** - Database Sub-Agent Semantic Triggering Enhancement.

This PR enables automatic database sub-agent invocation when SQL execution intent is detected, rather than outputting manual execution instructions to the user.

### Changes
- Add 37 SQL execution intent triggers to `leo_sub_agent_triggers` table with 6 categories:
  - Direct commands ("run this sql", "execute the query") - Priority 9
  - Delegation ("use database sub-agent") - Priority 8
  - Imperative ("please run", "can you execute") - Priority 8
  - Operational ("update the table", "create the table") - Priority 7
  - Result-oriented ("make this change in the database") - Priority 6
  - Contextual ("run it", "execute it" - requires SQL context) - Priority 5

- Create `sql-execution-intent-classifier.js` for deterministic intent classification:
  - Loads triggers from database
  - Matches messages against trigger patterns
  - Calculates confidence scores
  - Applies denylist filtering for false positive protection

- Create `db-agent-auto-invoker.js` for orchestrator integration:
  - `shouldAutoInvokeAndExecute()` - Check if message should trigger auto-invocation
  - `getDBAgentTaskParams()` - Get Task tool parameters for invocation
  - Structured logging and metrics emission

- Add `db_agent_config` table for runtime configuration:
  - `MIN_CONFIDENCE_TO_INVOKE`: 0.80 (default)
  - `MAX_TRIGGERS_EVALUATED`: 200
  - `DB_AGENT_ENABLED`: true
  - `DENYLIST_PHRASES`: ["do not execute", "for reference only", "example query", etc.]

- Add `db_agent_invocations` audit table for invocation tracking with:
  - correlation_id for tracing
  - intent and confidence scores
  - matched trigger IDs
  - decision outcome

- Add 36 unit tests (all passing)

- Add documentation to `CLAUDE_CORE.md` via `leo_protocol_sections` table

## Test plan
- [x] Unit tests pass (36 tests)
- [x] Smoke tests pass
- [x] Migration executed successfully in database
- [x] Triggers verified in database (37 rows)
- [x] Documentation regenerated from database

🤖 Generated with [Claude Code](https://claude.com/claude-code)