### PR TITLE
feat(leo): add session-based auto-proceed preference

### DIFF
--- a/docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md
+++ b/docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md
@@ -24,15 +24,49 @@ This created workflow friction and reduced autonomous execution efficiency.
 
 **Enabled by default** for all Strategic Directive workflows:
 
-| Action | Previous Behavior | New Behavior |
-|--------|------------------|--------------|
+| Action | Previous Behavior | New Behavior (v4.3.3+) |
+|--------|------------------|----------------------|
 | Phase transitions | Implicit stops | **Automatic progression** |
 | Post-completion | Ask "what's next?" | **Auto-execute sequence** |
 | Next SD | Manual selection | **Auto-show queue** |
 
+### Session Preferences (v4.3.3.1+)
+
+**NEW**: Auto-proceed can now be configured per-session:
+
+| Component | Behavior |
+|-----------|----------|
+| **Default Setting** | Auto-proceed ON (recommended) |
+| **Session Initialization** | At session start, Claude asks if user wants to disable |
+| **Storage** | Preference stored in `claude_sessions.metadata.auto_proceed` |
+| **Runtime Check** | Commands check session preference before auto-proceeding |
+| **Override** | Run `/leo init` anytime to change preference |
+
+#### Session Preference Architecture
+
+```javascript
+// Session metadata structure
+{
+  session_id: 'session_1769205775472_9sou6djf',
+  status: 'active',
+  metadata: {
+    auto_proceed: true  // Default: ON
+  }
+}
+```
+
+#### Commands Respecting Session Preference
+
+| Command | When auto_proceed=true | When auto_proceed=false |
+|---------|----------------------|------------------------|
+| `/leo complete` | Auto-runs document→ship→learn→next | Asks before each step |
+| `/document` | Auto-proceeds to next command | Asks user what's next |
+| `/ship` | Auto-proceeds to /learn | Asks if user wants /learn |
+| Phase transitions | Automatic handoff execution | Asks before executing |
+
 ### Stop Conditions (Explicit)
 
-Auto-proceed **only stops** for:
+Auto-proceed **only stops** for (regardless of preference):
 1. **Blocking errors** - Merge conflicts, critical failures
 2. **Test failures** - After 2 retry attempts
 3. **Security/Data-loss** - Critical scenarios requiring human judgment
@@ -153,6 +187,22 @@ Updated "Continue autonomously" definition with type-aware behavior.
 #### Database Section 317 (`parent_child_overview`)
 Updated orchestrator STOP conditions with dependency awareness.
 
+#### Database Table: `claude_sessions` (v4.3.3.1+)
+Enhanced `metadata` JSONB column to store session preferences:
+- **Field**: `metadata.auto_proceed` (boolean)
+- **Default**: `true` (auto-proceed ON)
+- **Usage**: Runtime check before workflow auto-progression
+- **Access**: Query active session's metadata to determine behavior
+
+```sql
+-- Example query
+SELECT metadata->>'auto_proceed' as auto_proceed_enabled
+FROM claude_sessions
+WHERE status = 'active'
+ORDER BY heartbeat_at DESC
+LIMIT 1;
+```
+
 ### Test Coverage
 
 **95+ new unit tests**:
@@ -260,12 +310,45 @@ If issues arise, rollback by:
 
 | Version | Date | Change |
 |---------|------|--------|
+| v4.3.3.1 | 2026-01-23 | Added session-based preference control for auto-proceed |
 | v4.3.3 | 2026-01-22 | Auto-proceed mode added as default |
 | v4.3.2 | 2026-01-20 | Gate refinements |
 | v4.3.1 | 2026-01-18 | Sub-agent integration |
 
+## Changes in v4.3.3.1 (2026-01-23)
+
+### Feature: Session-Based Auto-Proceed Preferences
+
+**Problem**: Auto-proceed was always ON with no user control except manual interruption.
+
+**Solution**:
+1. **Session initialization prompt** - At session start, Claude asks if user wants to disable auto-proceed
+2. **Database persistence** - Preference stored in `claude_sessions.metadata.auto_proceed`
+3. **Runtime checks** - Commands query session preference before auto-proceeding
+4. **Explicit override** - `/leo init` command to change preference anytime
+
+**Files Changed**:
+- `.claude/commands/leo.md` - Added session initialization logic and `/leo init` command
+- `database/migrations/20251204_multi_session_coordination.sql` - Already supports `metadata` JSONB field
+- This documentation file - Updated with new preference system
+
+**User Experience**:
+```
+# Session start
+User: /leo next
+Claude: Auto-proceed mode is ON by default. Would you like to disable it?
+  [Keep ON (Recommended)] | [Turn OFF]
+User: Keep ON
+Claude: ✅ Session Initialized - Auto-Proceed: ON
+```
+
+**Backward Compatibility**:
+- Default remains ON (no breaking changes)
+- Existing sessions without preference default to ON
+- All existing auto-proceed behavior preserved
+
 ---
 
-**Last Updated**: 2026-01-22
+**Last Updated**: 2026-01-23
 **Maintained By**: LEO Protocol Team
 **Status**: Active and In Production


### PR DESCRIPTION
## Summary

- Add `/leo init` command for explicit session initialization
- Default auto-proceed to ON with user prompt at session start asking if they want to disable
- Store preference in `claude_sessions.metadata.auto_proceed`
- Commands check session preference before auto-proceeding
- Update protocol documentation with v4.3.3.1 session preference feature

### Behavior Changes

**When auto_proceed=true (default):**
- Phase transitions execute automatically
- Post-completion sequence runs without prompts
- Next SD shown automatically

**When auto_proceed=false:**
- Pause at phase transitions and ask for confirmation
- Confirm before running post-completion sequence
- Wait for explicit "proceed" before continuing

### Files Changed

| File | Changes |
|------|---------|
| `.claude/commands/leo.md` | Added session init, `/leo init`, preference checks |
| `docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md` | Documented v4.3.3.1 session preference feature |

## Test plan

- [x] Smoke tests pass
- [x] DOCMON compliance check pass
- [x] `/leo init` tested manually - prompts user for preference
- [x] Session preference saved to database successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)