### PR TITLE
feat(security): add RBAC authorization to all 17 API endpoints

### DIFF
--- a/lib/middleware/rbac.ts
+++ b/lib/middleware/rbac.ts
@@ -32,6 +32,8 @@ export type Permission =
   | 'ventures:read'
   | 'compliance:read'
   | 'compliance:write'
+  | 'leo:read'
+  | 'leo:write'
   | 'admin:*';
 
 // Role-to-permission mapping
@@ -48,14 +50,17 @@ const rolePermissions: Record<Role, Permission[]> = {
     'ventures:update',
     'ventures:read',
     'compliance:read',
-    'compliance:write'
+    'compliance:write',
+    'leo:read',
+    'leo:write'
   ],
   viewer: [
     'violations:read',
     'rules:read',
     'constitutions:read',
     'ventures:read',
-    'compliance:read'
+    'compliance:read',
+    'leo:read'
   ],
   owner: [] // Owner permissions are checked dynamically based on resource ownership
 };

--- a/pages/api/aegis/constitutions.ts
+++ b/pages/api/aegis/constitutions.ts
@@ -2,15 +2,19 @@
  * GET /api/aegis/constitutions
  * SD-AEGIS-GOVERNANCE-001: AEGIS Constitutions API
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Retrieve governance constitutions
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'constitutions:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -121,5 +125,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires constitutions:read permission
+export default withAuth(withPermission('constitutions:read')(handler));

--- a/pages/api/aegis/rules.ts
+++ b/pages/api/aegis/rules.ts
@@ -2,15 +2,19 @@
  * GET /api/aegis/rules
  * SD-AEGIS-GOVERNANCE-001: AEGIS Rules API
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Retrieve governance rules with filters
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'rules:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -123,5 +127,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires rules:read permission
+export default withAuth(withPermission('rules:read')(handler));

--- a/pages/api/aegis/stats.ts
+++ b/pages/api/aegis/stats.ts
@@ -2,15 +2,19 @@
  * GET /api/aegis/stats
  * SD-AEGIS-GOVERNANCE-001: AEGIS Statistics API
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Retrieve compliance statistics
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'violations:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -171,5 +175,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires violations:read permission
+export default withAuth(withPermission('violations:read')(handler));

--- a/pages/api/aegis/validate.ts
+++ b/pages/api/aegis/validate.ts
@@ -2,15 +2,19 @@
  * POST /api/aegis/validate
  * SD-AEGIS-GOVERNANCE-001: AEGIS Validation API
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Validate an operation context against governance rules
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'compliance:write' permission (editor+) since can record violations
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -235,5 +239,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires compliance:write permission
+export default withAuth(withPermission('compliance:write')(handler));

--- a/pages/api/blueprints.ts
+++ b/pages/api/blueprints.ts
@@ -2,16 +2,20 @@
  * GET /api/blueprints
  * SD-STAGE1-ENTRY-UX-001: Retrieve blueprint catalog
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Returns blueprint catalog with optional category/market filters.
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'ventures:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { z } from 'zod';
 import { withAuth, AuthenticatedRequest } from '../../lib/middleware/api-auth';
+import { withPermission } from '../../lib/middleware/rbac';
 
 // Query params validation schema
 const BlueprintQuerySchema = z.object({
@@ -81,5 +85,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires ventures:read permission
+export default withAuth(withPermission('ventures:read')(handler));

--- a/pages/api/competitor-analysis.ts
+++ b/pages/api/competitor-analysis.ts
@@ -3,16 +3,21 @@
  * SD-STAGE1-ENTRY-UX-001: Analyze competitor URL
  * SD-IDEATION-GENESIS-AUDIT: Real market intelligence (not hallucinated)
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Analyzes a competitor URL using REAL web fetching and AI analysis.
  * Classifies all outputs using Four Buckets (Facts/Assumptions/Simulations/Unknowns).
  *
- * SECURITY: Requires authenticated user.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'ventures:create' permission (editor+) since used in venture creation
+ * - Uses user-scoped Supabase client
  */
 
 import { NextApiResponse } from 'next';
 import { z } from 'zod';
 import { withAuth, AuthenticatedRequest } from '../../lib/middleware/api-auth';
+import { withPermission } from '../../lib/middleware/rbac';
 
 // Request body validation schema
 const AnalyzeCompetitorSchema = z.object({
@@ -146,5 +151,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires ventures:create permission
+export default withAuth(withPermission('ventures:create')(handler));

--- a/pages/api/compliance/checks.ts
+++ b/pages/api/compliance/checks.ts
@@ -2,11 +2,14 @@
  * GET /api/compliance/checks
  * SD-AUTO-COMPLIANCE-ENGINE-001: CCE Compliance Checks API
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Retrieve compliance check history with filtering
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'compliance:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
@@ -15,6 +18,7 @@ import {
   validateWithDetails
 } from '../../../lib/validation/leo-schemas';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -85,5 +89,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires compliance:read permission
+export default withAuth(withPermission('compliance:read')(handler));

--- a/pages/api/compliance/policies.ts
+++ b/pages/api/compliance/policies.ts
@@ -2,11 +2,14 @@
  * GET /api/compliance/policies
  * SD-AUTO-COMPLIANCE-ENGINE-001: CCE Policy Registry API
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Retrieve compliance policies from the registry
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'compliance:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
@@ -15,6 +18,7 @@ import {
   validateWithDetails
 } from '../../../lib/validation/leo-schemas';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -94,5 +98,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires compliance:read permission
+export default withAuth(withPermission('compliance:read')(handler));

--- a/pages/api/compliance/summary.ts
+++ b/pages/api/compliance/summary.ts
@@ -2,15 +2,19 @@
  * GET /api/compliance/summary
  * SD-AUTO-COMPLIANCE-ENGINE-001: CCE Compliance Summary API
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Get overall compliance summary for dashboard
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'compliance:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -127,5 +131,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires compliance:read permission
+export default withAuth(withPermission('compliance:read')(handler));

--- a/pages/api/compliance/violations.ts
+++ b/pages/api/compliance/violations.ts
@@ -2,11 +2,14 @@
  * GET /api/compliance/violations
  * SD-AUTO-COMPLIANCE-ENGINE-001: CCE Compliance Violations API
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Retrieve compliance violations with filtering
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'compliance:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
@@ -15,6 +18,7 @@ import {
   validateWithDetails
 } from '../../../lib/validation/leo-schemas';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -103,5 +107,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires compliance:read permission
+export default withAuth(withPermission('compliance:read')(handler));

--- a/pages/api/leo/gate-scores.ts
+++ b/pages/api/leo/gate-scores.ts
@@ -1,16 +1,20 @@
 /**
  * GET /api/leo/gate-scores
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Retrieve gate scores for a PRD
  * Includes historical data and current status
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'leo:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 import {
   GateScoresQuery,
   GateScoresResponse,
@@ -173,5 +177,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires leo:read permission
+export default withAuth(withPermission('leo:read')(handler));

--- a/pages/api/leo/metrics.ts
+++ b/pages/api/leo/metrics.ts
@@ -1,17 +1,21 @@
 /**
  * GET /api/leo/metrics
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Dashboard metrics for LEO Protocol monitoring
  * Provides aggregated statistics for portfolio-level view
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'leo:read' permission (viewer+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 
 interface DashboardMetrics {
   overview: {
@@ -89,8 +93,9 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires leo:read permission
+export default withAuth(withPermission('leo:read')(handler));
 
 /**
  * Get overview metrics

--- a/pages/api/leo/sub-agent-reports.ts
+++ b/pages/api/leo/sub-agent-reports.ts
@@ -1,17 +1,21 @@
 /**
  * POST /api/leo/sub-agent-reports
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Submit sub-agent execution results
  * Validates status transitions and recomputes affected gates
  *
- * SECURITY: Requires authenticated user. Uses user-scoped Supabase client
- * that respects RLS policies.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'leo:write' permission (editor+)
+ * - Uses user-scoped Supabase client that respects RLS policies
  */
 
 import { NextApiResponse } from 'next';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
+import { withPermission } from '../../../lib/middleware/rbac';
 import {
   SubAgentReportBody,
   SubAgentReportResponse,
@@ -291,5 +295,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires leo:write permission
+export default withAuth(withPermission('leo:write')(handler));

--- a/pages/api/ventures/[id]/calibration.ts
+++ b/pages/api/ventures/[id]/calibration.ts
@@ -2,18 +2,23 @@
  * GET /api/ventures/[id]/calibration
  * Operation 'Final Weld' v6.0.0: Truth Aggregator - Live δ scores
  * SD-LEO-GEN-REMEDIATE-CRITICAL-SECURITY-001: Added authentication
+ * SD-SEC-AUTHORIZATION-RBAC-001: Added RBAC authorization
  *
  * Returns calibration data for a specific venture including:
  * - normalized_delta: Calibration delta normalized by vertical complexity
  * - health_status: 'green' | 'yellow' | 'red'
  * - thresholds: Vertical-specific health thresholds
  *
- * SECURITY: Requires authenticated user.
+ * SECURITY:
+ * - Authentication: Requires valid JWT token
+ * - Authorization: Requires 'ventures:read' permission (viewer+)
+ * - Uses user-scoped Supabase client
  */
 
 import { NextApiResponse } from 'next';
 import { CalibrationService } from '../../../../src/services/CalibrationService.js';
 import { withAuth, AuthenticatedRequest } from '../../../../lib/middleware/api-auth';
+import { withPermission } from '../../../../lib/middleware/rbac';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -68,5 +73,6 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
-export default withAuth(handler);
+// SECURITY: Wrap handler with authentication and authorization middleware
+// SD-SEC-AUTHORIZATION-RBAC-001: Requires ventures:read permission
+export default withAuth(withPermission('ventures:read')(handler));


### PR DESCRIPTION
## Summary
- Added `leo:read` and `leo:write` permissions to RBAC middleware
- Updated viewer and editor role permission mappings
- Protected all 17 API endpoints with appropriate RBAC permission checks

### Endpoint Permission Matrix

| Endpoint | Method | Permission |
|----------|--------|------------|
| aegis/rules | GET | rules:read |
| aegis/constitutions | GET | constitutions:read |
| aegis/stats | GET | violations:read |
| aegis/validate | POST | compliance:write |
| aegis/violations | GET | violations:read |
| aegis/violations | PUT | violations:override |
| compliance/checks | GET | compliance:read |
| compliance/events | GET/PATCH | compliance:read/write |
| compliance/policies | GET | compliance:read |
| compliance/summary | GET | compliance:read |
| compliance/violations | GET | compliance:read |
| leo/gate-scores | GET | leo:read |
| leo/metrics | GET | leo:read |
| leo/sub-agent-reports | POST | leo:write |
| ventures | GET | ventures:read |
| ventures | POST | ventures:create |
| blueprints | GET | ventures:read |
| competitor-analysis | POST | ventures:create |
| ventures/[id]/calibration | GET | ventures:read |

### Role Permissions
- **viewer**: read-only access (all :read permissions)
- **editor**: read + write access (all permissions except admin:*)
- **admin**: full access via admin:*

## Test plan
- [ ] Verify TypeScript compiles without errors
- [ ] Verify smoke tests pass
- [ ] Test API endpoint access with different role levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)