### PR TITLE
fix(security): type-safe data validation and bounds checking

### DIFF
--- a/lib/validation/leo-schemas.ts
+++ b/lib/validation/leo-schemas.ts
@@ -44,13 +44,27 @@ export const GateScoresQuery = z.object({
 });
 
 /**
+ * Evidence value schema - allows structured data but requires type narrowing
+ * SD-SEC-DATA-VALIDATION-001: Replaced z.any() with z.unknown() for type safety
+ */
+const EvidenceValue = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.unknown()),
+  z.record(z.string(), z.unknown())
+]);
+
+/**
  * POST /api/leo/sub-agent-reports request body
  */
 export const SubAgentReportBody = z.object({
   prd_id: z.string().min(1, 'PRD ID is required'),
   agent: AgentEnum,
   status: StatusEnum,
-  evidence: z.record(z.any()).default({}),
+  // SD-SEC-DATA-VALIDATION-001: Replaced z.any() with structured evidence schema
+  evidence: z.record(z.string(), EvidenceValue).default({}),
   message: z.string().optional(),
   error_details: z.string().optional()
 });
@@ -88,7 +102,8 @@ export const GateScoresResponse = z.object({
   history: z.array(z.object({
     gate: GateEnum,
     score: z.number(),
-    evidence: z.record(z.any()),
+    // SD-SEC-DATA-VALIDATION-001: Replaced z.any() with structured evidence schema
+    evidence: z.record(z.string(), EvidenceValue),
     created_at: z.string().datetime()
   })),
   last_updated: z.string().datetime().nullable(),

--- a/pages/api/aegis/stats.ts
+++ b/pages/api/aegis/stats.ts
@@ -32,7 +32,8 @@ async function handler(
   const { period = '7d' } = req.query;
 
   // Parse period (e.g., "7d", "30d")
-  const days = parseInt((period as string).replace('d', '')) || 7;
+  // SD-SEC-DATA-VALIDATION-001: Safe parsing with radix and bounds (1-365 days)
+  const days = Math.min(Math.max(parseInt((period as string).replace('d', ''), 10) || 7, 1), 365);
   const sinceDate = new Date();
   sinceDate.setDate(sinceDate.getDate() - days);
 


### PR DESCRIPTION
## Summary
- Replace `z.any()` in leo-schemas.ts with structured `EvidenceValue` union type for type safety
- Add radix parameter (10) to all `parseInt()` calls to prevent base confusion
- Add bounds checking for query parameters:
  - `limit`: clamped to 1-100
  - `offset`: minimum 0
  - `days/period`: clamped to 1-365

## Security Fixes
- **SD-SEC-DATA-VALIDATION-001**: Type-safe API validation
- Prevents potential type confusion attacks via z.any()
- Prevents integer overflow/underflow via unbounded parseInt()

## Files Changed
- `lib/validation/leo-schemas.ts` - Structured evidence schema
- `pages/api/aegis/violations.ts` - Bounds checking
- `pages/api/aegis/stats.ts` - Bounds checking

## Test plan
- [x] TypeScript compiles without errors
- [x] Smoke tests pass
- [ ] API endpoints accept valid parameters
- [ ] API endpoints reject out-of-bounds values

🤖 Generated with [Claude Code](https://claude.com/claude-code)