### PR TITLE
feat(database): add migrations for children C, D, E

### DIFF
--- a/database/migrations/20260124_remove_legacy_id.sql
+++ b/database/migrations/20260124_remove_legacy_id.sql
@@ -1,0 +1,40 @@
+-- Migration: Remove legacy_id column
+-- Date: 2026-01-24
+-- SD: SD-LEO-GEN-RENAME-COLUMNS-SELF-001-D
+--
+-- PURPOSE:
+-- legacy_id was a numeric ID from before UUID migration.
+-- It's no longer used and should be removed.
+--
+-- PRE-REQUISITE: Verify no codebase references exist before running!
+
+BEGIN;
+
+-- Backup legacy_id values before removal (for rollback if needed)
+CREATE TABLE IF NOT EXISTS strategic_directives_v2_legacy_id_backup AS
+SELECT uuid_id, legacy_id FROM strategic_directives_v2 WHERE legacy_id IS NOT NULL;
+
+-- Drop the column
+ALTER TABLE strategic_directives_v2
+DROP COLUMN IF EXISTS legacy_id;
+
+-- Verify removal
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'strategic_directives_v2'
+        AND column_name = 'legacy_id'
+    ) THEN
+        RAISE NOTICE 'SUCCESS: legacy_id column removed';
+    ELSE
+        RAISE WARNING 'FAILED: legacy_id column still exists';
+    END IF;
+END $$;
+
+COMMIT;
+
+-- ROLLBACK (if needed):
+-- ALTER TABLE strategic_directives_v2 ADD COLUMN legacy_id INT;
+-- UPDATE strategic_directives_v2 sd SET legacy_id = b.legacy_id
+-- FROM strategic_directives_v2_legacy_id_backup b WHERE sd.uuid_id = b.uuid_id;

--- a/database/migrations/20260124_rename_uuid_id_to_uuid_internal_pk.sql
+++ b/database/migrations/20260124_rename_uuid_id_to_uuid_internal_pk.sql
@@ -1,0 +1,80 @@
+-- Migration: Rename uuid_id column to uuid_internal_pk
+-- Date: 2026-01-24
+-- SD: SD-LEO-GEN-RENAME-COLUMNS-SELF-001-C
+--
+-- PURPOSE:
+-- The uuid_id column is the actual primary key but the name doesn't indicate this.
+-- Renaming to uuid_internal_pk makes the purpose clear.
+--
+-- APPROACH: Same as Child B - backward compatible with sync trigger
+
+BEGIN;
+
+-- Add new column (if not exists)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'strategic_directives_v2'
+        AND column_name = 'uuid_internal_pk'
+    ) THEN
+        ALTER TABLE strategic_directives_v2
+        ADD COLUMN uuid_internal_pk UUID;
+        RAISE NOTICE 'Added uuid_internal_pk column';
+    ELSE
+        RAISE NOTICE 'uuid_internal_pk column already exists';
+    END IF;
+END $$;
+
+-- Copy data
+UPDATE strategic_directives_v2
+SET uuid_internal_pk = uuid_id
+WHERE uuid_internal_pk IS NULL;
+
+-- Add NOT NULL constraint
+ALTER TABLE strategic_directives_v2
+ALTER COLUMN uuid_internal_pk SET NOT NULL;
+
+-- Create sync trigger
+CREATE OR REPLACE FUNCTION sync_uuid_internal_pk()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' AND NEW.uuid_id IS DISTINCT FROM OLD.uuid_id THEN
+        NEW.uuid_internal_pk := NEW.uuid_id;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NEW.uuid_internal_pk IS DISTINCT FROM OLD.uuid_internal_pk THEN
+        NEW.uuid_id := NEW.uuid_internal_pk;
+    END IF;
+    IF TG_OP = 'INSERT' THEN
+        IF NEW.uuid_internal_pk IS NULL THEN
+            NEW.uuid_internal_pk := NEW.uuid_id;
+        ELSIF NEW.uuid_id IS NULL THEN
+            NEW.uuid_id := NEW.uuid_internal_pk;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_sync_uuid_internal_pk ON strategic_directives_v2;
+CREATE TRIGGER trg_sync_uuid_internal_pk
+    BEFORE INSERT OR UPDATE ON strategic_directives_v2
+    FOR EACH ROW
+    EXECUTE FUNCTION sync_uuid_internal_pk();
+
+-- Verify
+DO $$
+DECLARE
+    total_rows INT;
+    synced_rows INT;
+BEGIN
+    SELECT COUNT(*) INTO total_rows FROM strategic_directives_v2;
+    SELECT COUNT(*) INTO synced_rows FROM strategic_directives_v2 WHERE uuid_id = uuid_internal_pk;
+    IF total_rows = synced_rows THEN
+        RAISE NOTICE 'SUCCESS: All % rows synced', total_rows;
+    ELSE
+        RAISE WARNING 'MISMATCH: % of % rows synced', synced_rows, total_rows;
+    END IF;
+END $$;
+
+COMMIT;

--- a/docs/database/strategic_directives_v2_field_reference.md
+++ b/docs/database/strategic_directives_v2_field_reference.md
@@ -361,3 +361,14 @@ ORDER BY
 - Use Supabase Studio or pgAdmin to view descriptions in database explorer
 - Descriptions will appear in IDEs with database plugins (DataGrip, DBeaver, etc.)
 - This reference document is generated from the actual database schema
+
+## Deprecated Fields
+
+### `category` (DEPRECATED)
+- **Status**: DEPRECATED - Use `sd_type` instead
+- **Reason**: `sd_type` is now the authoritative field for SD classification
+- **Migration**: All new code should use `sd_type`. The `category` field will be removed in a future migration.
+
+### `metadata.sd_type` (REMOVED)  
+- **Status**: REMOVED
+- **Reason**: Was a temporary workaround. Now use root `sd_type` field.


### PR DESCRIPTION
## Summary
- Child C: Add uuid_internal_pk column migration (rename from uuid_id)
- Child D: Add legacy_id removal migration
- Child E: Document category deprecation in field reference

## SD Reference
Part of orchestrator SD-LEO-GEN-RENAME-COLUMNS-SELF-001 (children C, D, E)

## Test plan
- [x] Smoke tests pass
- [ ] Apply migrations via Supabase Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)