### PR TITLE
fix(validation): add SD-type-aware validation policy for handoffs

### DIFF
--- a/database/migrations/20260124_sd_type_aware_progress_calculation.sql
+++ b/database/migrations/20260124_sd_type_aware_progress_calculation.sql
@@ -1,0 +1,212 @@
+-- ============================================================================
+-- SD-Type-Aware Progress Calculation
+-- ============================================================================
+-- Purpose: Fix 75% handoff rejection rate for refactor/infrastructure SDs
+-- SD: SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001
+-- Created: 2026-01-24
+-- ============================================================================
+-- PROBLEM:
+--   Refactor SDs were blocked because progress calculation required 3 handoff types,
+--   but refactor SDs only need REGRESSION validation (not TESTING/DESIGN).
+--
+-- SOLUTION:
+--   Make handoff count requirement SD-type-aware. Different SD types have
+--   different minimum handoff requirements based on their validation profile.
+-- ============================================================================
+
+-- Create a helper function to get minimum required handoff count by SD type
+CREATE OR REPLACE FUNCTION get_min_required_handoffs(sd_type_param VARCHAR)
+RETURNS INTEGER AS $$
+BEGIN
+  -- SD-Type to minimum handoff count mapping
+  -- Based on SD_TYPE_APPLICABILITY_POLICY from sd-type-applicability-policy.js
+  RETURN CASE
+    -- Infrastructure/Documentation SDs - minimal handoffs (LEAD->PLAN, PLAN->LEAD)
+    WHEN sd_type_param IN ('infrastructure', 'documentation', 'docs', 'process', 'qa', 'orchestrator')
+    THEN 2
+
+    -- Refactor SDs - need REGRESSION but skip TESTING/DESIGN
+    -- LEAD->PLAN, PLAN->EXEC, EXEC->PLAN (optional), PLAN->LEAD
+    WHEN sd_type_param = 'refactor'
+    THEN 2  -- Only LEAD-TO-PLAN and one completion handoff required
+
+    -- Bugfix/Performance - need validation but lighter than feature
+    WHEN sd_type_param IN ('bugfix', 'performance', 'enhancement')
+    THEN 3
+
+    -- Feature/Database/Security - full validation
+    WHEN sd_type_param IN ('feature', 'database', 'security')
+    THEN 3
+
+    -- Default (unknown type) - require full validation (safe default)
+    ELSE 3
+  END;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Update the main progress calculation function
+CREATE OR REPLACE FUNCTION calculate_sd_progress(sd_id_param VARCHAR)
+RETURNS INTEGER AS $$
+DECLARE
+  sd RECORD;
+  progress INTEGER := 0;
+  user_stories_validated BOOLEAN := false;
+  sd_uuid_val UUID;
+  sd_type_val VARCHAR(50);
+  user_story_count INTEGER;
+  min_handoffs INTEGER;
+  actual_handoffs INTEGER;
+BEGIN
+  -- Get SD with type information
+  SELECT * INTO sd FROM strategic_directives_v2 WHERE id = sd_id_param;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SD not found: %', sd_id_param;
+  END IF;
+
+  sd_uuid_val := sd.uuid_id;
+  sd_type_val := COALESCE(sd.sd_type, 'feature');  -- Default to 'feature' for backward compatibility
+
+  -- Get SD-type-aware minimum handoff requirement
+  min_handoffs := get_min_required_handoffs(sd_type_val);
+
+  -- =========================================================================
+  -- PHASE 1: LEAD Initial Approval (20%)
+  -- =========================================================================
+  IF sd.status IN ('active', 'in_progress', 'pending_approval', 'completed') THEN
+    progress := progress + 20;
+  END IF;
+
+  -- =========================================================================
+  -- PHASE 2: PLAN PRD Creation (20%)
+  -- =========================================================================
+  IF EXISTS (SELECT 1 FROM product_requirements_v2 WHERE sd_uuid = sd_uuid_val) THEN
+    progress := progress + 20;
+  END IF;
+
+  -- =========================================================================
+  -- PHASE 3: EXEC Implementation (30%)
+  -- =========================================================================
+  IF NOT EXISTS (SELECT 1 FROM sd_scope_deliverables WHERE sd_id = sd_id_param) THEN
+    -- No deliverables = legacy SD or infrastructure SD, assume complete
+    progress := progress + 30;
+  ELSE
+    -- Check if all required/high priority deliverables are complete
+    IF (SELECT COUNT(*) FILTER (WHERE completion_status = 'completed') = COUNT(*)
+        FROM sd_scope_deliverables
+        WHERE sd_id = sd_id_param AND priority IN ('required', 'high')) THEN
+      progress := progress + 30;
+    END IF;
+  END IF;
+
+  -- =========================================================================
+  -- PHASE 4: PLAN Verification (15%) - SD-TYPE-AWARE
+  -- =========================================================================
+  SELECT COUNT(*) INTO user_story_count
+  FROM user_stories
+  WHERE sd_id = sd_id_param;
+
+  IF user_story_count = 0 THEN
+    -- No user stories = infrastructure/documentation SD = validation not required
+    user_stories_validated := true;
+  ELSE
+    -- SD-TYPE-AWARE validation:
+    -- Infrastructure/Documentation SDs: Check status='completed' (skip E2E)
+    -- Feature SDs: Check validation_status='validated' (E2E required)
+    IF sd_type_val IN ('infrastructure', 'documentation', 'docs', 'process', 'qa', 'refactor', 'orchestrator') THEN
+      SELECT COUNT(*) FILTER (WHERE status = 'completed') = COUNT(*)
+      INTO user_stories_validated
+      FROM user_stories
+      WHERE sd_id = sd_id_param;
+    ELSE
+      SELECT COUNT(*) FILTER (WHERE validation_status = 'validated') = COUNT(*)
+      INTO user_stories_validated
+      FROM user_stories
+      WHERE sd_id = sd_id_param;
+    END IF;
+  END IF;
+
+  IF user_stories_validated THEN
+    progress := progress + 15;
+  END IF;
+
+  -- =========================================================================
+  -- PHASE 5: LEAD Final Approval (15%) - SD-TYPE-AWARE HANDOFF COUNT
+  -- =========================================================================
+  -- SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001: Use SD-type-aware minimum handoff count
+  SELECT COUNT(DISTINCT handoff_type) INTO actual_handoffs
+  FROM sd_phase_handoffs
+  WHERE sd_id = sd_id_param
+  AND status = 'accepted';
+
+  IF EXISTS (
+    SELECT 1 FROM retrospectives
+    WHERE sd_id = sd_id_param
+    AND status = 'PUBLISHED'
+    AND quality_score IS NOT NULL
+  ) AND actual_handoffs >= min_handoffs THEN
+    progress := progress + 15;
+  END IF;
+
+  RETURN progress;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- VERIFICATION TESTS
+-- ============================================================================
+
+-- Test 1: Verify get_min_required_handoffs returns correct values
+DO $$
+BEGIN
+  RAISE NOTICE '════════════════════════════════════════════════════════════';
+  RAISE NOTICE 'TEST: SD-Type-Aware Minimum Handoff Requirements';
+  RAISE NOTICE '════════════════════════════════════════════════════════════';
+
+  RAISE NOTICE 'infrastructure: % (expected: 2)', get_min_required_handoffs('infrastructure');
+  RAISE NOTICE 'documentation: % (expected: 2)', get_min_required_handoffs('documentation');
+  RAISE NOTICE 'refactor: % (expected: 2)', get_min_required_handoffs('refactor');
+  RAISE NOTICE 'bugfix: % (expected: 3)', get_min_required_handoffs('bugfix');
+  RAISE NOTICE 'feature: % (expected: 3)', get_min_required_handoffs('feature');
+  RAISE NOTICE 'unknown: % (expected: 3)', get_min_required_handoffs('unknown');
+
+  -- Assertions
+  IF get_min_required_handoffs('infrastructure') = 2 THEN
+    RAISE NOTICE '✅ Infrastructure SD handoff requirement correct';
+  ELSE
+    RAISE WARNING '❌ Infrastructure SD handoff requirement incorrect';
+  END IF;
+
+  IF get_min_required_handoffs('refactor') = 2 THEN
+    RAISE NOTICE '✅ Refactor SD handoff requirement correct';
+  ELSE
+    RAISE WARNING '❌ Refactor SD handoff requirement incorrect';
+  END IF;
+
+  IF get_min_required_handoffs('feature') = 3 THEN
+    RAISE NOTICE '✅ Feature SD handoff requirement correct (backward compat)';
+  ELSE
+    RAISE WARNING '❌ Feature SD handoff requirement incorrect';
+  END IF;
+END $$;
+
+-- Test 2: Show current SDs with their type-aware progress
+SELECT
+  sd.id,
+  LEFT(sd.title, 40) as title,
+  COALESCE(sd.sd_type, 'feature') as sd_type,
+  get_min_required_handoffs(COALESCE(sd.sd_type, 'feature')) as min_handoffs,
+  (SELECT COUNT(DISTINCT handoff_type) FROM sd_phase_handoffs WHERE sd_id = sd.id AND status = 'accepted') as actual_handoffs,
+  calculate_sd_progress(sd.id) as progress,
+  sd.status
+FROM strategic_directives_v2 sd
+WHERE sd.status IN ('active', 'in_progress')
+  AND sd.sd_type IN ('infrastructure', 'refactor', 'documentation')
+ORDER BY sd.created_at DESC
+LIMIT 10;
+
+RAISE NOTICE '════════════════════════════════════════════════════════════';
+RAISE NOTICE 'SD-Type-Aware Progress Calculation Migration Complete';
+RAISE NOTICE '✅ Refactor SDs: Need only 2 handoffs (was 3)';
+RAISE NOTICE '✅ Infrastructure SDs: Need only 2 handoffs (was 3)';
+RAISE NOTICE '✅ Feature SDs: Still require 3 handoffs (backward compat)';
+RAISE NOTICE '════════════════════════════════════════════════════════════';

--- a/scripts/modules/handoff/validation/sd-type-applicability-policy.js
+++ b/scripts/modules/handoff/validation/sd-type-applicability-policy.js
@@ -1,0 +1,427 @@
+/**
+ * SD-Type Applicability Policy Module
+ * Part of SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001
+ *
+ * Centralized policy defining which validators are REQUIRED vs NON_APPLICABLE
+ * per SD type. Used by:
+ * - Validator runner (early-exit gating)
+ * - Progress calculator (treat SKIPPED as satisfied for non-applicable)
+ * - Handoff decision aggregator
+ *
+ * Design Principle: ALLOWLIST approach (safe default = all REQUIRED)
+ * Unknown SD types require ALL validators. Only explicitly listed types can skip.
+ *
+ * @version 1.0.0
+ * @since 2026-01-24
+ */
+
+// Policy version for traceability and debugging
+export const POLICY_VERSION = '1.0.0';
+
+/**
+ * Validator requirement levels
+ */
+export const RequirementLevel = {
+  REQUIRED: 'REQUIRED',         // Must PASS for handoff to succeed
+  NON_APPLICABLE: 'NON_APPLICABLE', // Should SKIP for this SD type
+  OPTIONAL: 'OPTIONAL'          // Can SKIP or run - doesn't affect outcome
+};
+
+/**
+ * Validator result statuses
+ */
+export const ValidatorStatus = {
+  PASS: 'PASS',
+  FAIL: 'FAIL',
+  SKIPPED: 'SKIPPED',
+  NOT_RUN: 'NOT_RUN'
+};
+
+/**
+ * Reason codes for SKIPPED status
+ */
+export const SkipReasonCode = {
+  NON_APPLICABLE_SD_TYPE: 'NON_APPLICABLE_SD_TYPE',  // Validator not needed for this SD type
+  PREREQUISITE_NOT_MET: 'PREREQUISITE_NOT_MET',      // Required prerequisite missing
+  DISABLED_BY_CONFIG: 'DISABLED_BY_CONFIG',          // Explicitly disabled in config
+  ALREADY_COMPLETED: 'ALREADY_COMPLETED'             // Already ran and passed
+};
+
+/**
+ * SD-Type to Validator Applicability Policy
+ *
+ * For each SD type, defines which validators are REQUIRED vs NON_APPLICABLE.
+ * Validators not listed default to REQUIRED (safe default).
+ *
+ * Key:
+ * - TESTING: Code quality, unit tests, coverage
+ * - GITHUB: Git/PR validation, branch enforcement
+ * - DESIGN: UI/UX design validation
+ * - DATABASE: Schema/migration validation
+ * - REGRESSION: Behavior preservation validation (critical for refactors)
+ * - DOCMON: Documentation validation
+ * - STORIES: User story quality validation
+ */
+const SD_TYPE_POLICY = {
+  // ============================================================================
+  // NON-CODE SD TYPES (skip most code validation)
+  // ============================================================================
+
+  infrastructure: {
+    TESTING: RequirementLevel.NON_APPLICABLE,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.NON_APPLICABLE,
+    DATABASE: RequirementLevel.OPTIONAL,
+    REGRESSION: RequirementLevel.OPTIONAL,
+    DOCMON: RequirementLevel.REQUIRED,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  documentation: {
+    TESTING: RequirementLevel.NON_APPLICABLE,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.NON_APPLICABLE,
+    DATABASE: RequirementLevel.NON_APPLICABLE,
+    REGRESSION: RequirementLevel.NON_APPLICABLE,
+    DOCMON: RequirementLevel.REQUIRED,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  docs: {  // Alias for documentation
+    TESTING: RequirementLevel.NON_APPLICABLE,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.NON_APPLICABLE,
+    DATABASE: RequirementLevel.NON_APPLICABLE,
+    REGRESSION: RequirementLevel.NON_APPLICABLE,
+    DOCMON: RequirementLevel.REQUIRED,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  process: {
+    TESTING: RequirementLevel.NON_APPLICABLE,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.NON_APPLICABLE,
+    DATABASE: RequirementLevel.NON_APPLICABLE,
+    REGRESSION: RequirementLevel.NON_APPLICABLE,
+    DOCMON: RequirementLevel.REQUIRED,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  qa: {
+    TESTING: RequirementLevel.NON_APPLICABLE,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.NON_APPLICABLE,
+    DATABASE: RequirementLevel.NON_APPLICABLE,
+    REGRESSION: RequirementLevel.NON_APPLICABLE,
+    DOCMON: RequirementLevel.OPTIONAL,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  orchestrator: {
+    // Orchestrators coordinate children - no direct validation needed
+    TESTING: RequirementLevel.NON_APPLICABLE,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.NON_APPLICABLE,
+    DATABASE: RequirementLevel.NON_APPLICABLE,
+    REGRESSION: RequirementLevel.NON_APPLICABLE,
+    DOCMON: RequirementLevel.OPTIONAL,
+    STORIES: RequirementLevel.NON_APPLICABLE
+  },
+
+  // ============================================================================
+  // CODE-PRODUCING SD TYPES (require validation, but some are non-applicable)
+  // ============================================================================
+
+  refactor: {
+    // CRITICAL: Refactors ONLY need REGRESSION (behavior preservation)
+    // This is the primary fix for SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001
+    TESTING: RequirementLevel.NON_APPLICABLE,  // No new tests for refactors
+    DESIGN: RequirementLevel.NON_APPLICABLE,   // No design changes
+    GITHUB: RequirementLevel.REQUIRED,         // Still need PR validation
+    DATABASE: RequirementLevel.NON_APPLICABLE, // No schema changes
+    REGRESSION: RequirementLevel.REQUIRED,     // CRITICAL: Must verify no behavior change
+    DOCMON: RequirementLevel.OPTIONAL,
+    STORIES: RequirementLevel.NON_APPLICABLE   // No new user stories
+  },
+
+  bugfix: {
+    TESTING: RequirementLevel.REQUIRED,        // Must verify fix
+    DESIGN: RequirementLevel.NON_APPLICABLE,   // Usually no design changes
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.OPTIONAL,
+    REGRESSION: RequirementLevel.OPTIONAL,
+    DOCMON: RequirementLevel.OPTIONAL,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  feature: {
+    // Full validation for features
+    TESTING: RequirementLevel.REQUIRED,
+    DESIGN: RequirementLevel.REQUIRED,
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.OPTIONAL,  // Only if DB changes
+    REGRESSION: RequirementLevel.OPTIONAL,
+    DOCMON: RequirementLevel.REQUIRED,
+    STORIES: RequirementLevel.REQUIRED
+  },
+
+  enhancement: {
+    // Similar to feature but lighter
+    TESTING: RequirementLevel.REQUIRED,
+    DESIGN: RequirementLevel.OPTIONAL,
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.OPTIONAL,
+    REGRESSION: RequirementLevel.OPTIONAL,
+    DOCMON: RequirementLevel.OPTIONAL,
+    STORIES: RequirementLevel.REQUIRED
+  },
+
+  database: {
+    TESTING: RequirementLevel.OPTIONAL,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.REQUIRED,    // CRITICAL
+    REGRESSION: RequirementLevel.REQUIRED,  // Must verify no breakage
+    DOCMON: RequirementLevel.OPTIONAL,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  security: {
+    // Full validation for security
+    TESTING: RequirementLevel.REQUIRED,
+    DESIGN: RequirementLevel.OPTIONAL,
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.OPTIONAL,
+    REGRESSION: RequirementLevel.REQUIRED,
+    DOCMON: RequirementLevel.REQUIRED,
+    STORIES: RequirementLevel.REQUIRED
+  },
+
+  performance: {
+    TESTING: RequirementLevel.REQUIRED,     // Must measure improvement
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.OPTIONAL,
+    REGRESSION: RequirementLevel.REQUIRED,  // Must not break existing behavior
+    DOCMON: RequirementLevel.OPTIONAL,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  // API/backend - no E2E but needs unit/integration tests
+  api: {
+    TESTING: RequirementLevel.REQUIRED,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.OPTIONAL,
+    REGRESSION: RequirementLevel.OPTIONAL,
+    DOCMON: RequirementLevel.REQUIRED,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  backend: {
+    TESTING: RequirementLevel.REQUIRED,
+    DESIGN: RequirementLevel.NON_APPLICABLE,
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.OPTIONAL,
+    REGRESSION: RequirementLevel.OPTIONAL,
+    DOCMON: RequirementLevel.REQUIRED,
+    STORIES: RequirementLevel.OPTIONAL
+  }
+};
+
+/**
+ * Get the requirement level for a specific validator and SD type
+ *
+ * @param {string} sdType - SD type (e.g., 'refactor', 'feature')
+ * @param {string} validatorName - Validator name (e.g., 'TESTING', 'REGRESSION')
+ * @returns {string} RequirementLevel (REQUIRED, NON_APPLICABLE, or OPTIONAL)
+ */
+export function getValidatorRequirement(sdType, validatorName) {
+  const normalizedType = (sdType || '').toLowerCase();
+  const normalizedValidator = (validatorName || '').toUpperCase();
+
+  // Check if SD type is defined in policy
+  const typePolicy = SD_TYPE_POLICY[normalizedType];
+
+  if (!typePolicy) {
+    // SAFE DEFAULT: Unknown SD types require all validators
+    console.log(`   ⚠️  Unknown SD type '${sdType}' - defaulting to REQUIRED for ${validatorName}`);
+    return RequirementLevel.REQUIRED;
+  }
+
+  // Check if validator is defined for this type
+  const requirement = typePolicy[normalizedValidator];
+
+  if (requirement === undefined) {
+    // Validators not in policy default to REQUIRED
+    return RequirementLevel.REQUIRED;
+  }
+
+  return requirement;
+}
+
+/**
+ * Check if a validator is required for a given SD type
+ *
+ * @param {string} sdType - SD type
+ * @param {string} validatorName - Validator name
+ * @returns {boolean} True if REQUIRED
+ */
+export function isValidatorRequired(sdType, validatorName) {
+  return getValidatorRequirement(sdType, validatorName) === RequirementLevel.REQUIRED;
+}
+
+/**
+ * Check if a validator is non-applicable for a given SD type
+ *
+ * @param {string} sdType - SD type
+ * @param {string} validatorName - Validator name
+ * @returns {boolean} True if NON_APPLICABLE
+ */
+export function isValidatorNonApplicable(sdType, validatorName) {
+  return getValidatorRequirement(sdType, validatorName) === RequirementLevel.NON_APPLICABLE;
+}
+
+/**
+ * Get all validators and their requirements for an SD type
+ *
+ * @param {string} sdType - SD type
+ * @returns {Object} Map of validator name to requirement level
+ */
+export function getValidatorRequirements(sdType) {
+  const normalizedType = (sdType || '').toLowerCase();
+  const typePolicy = SD_TYPE_POLICY[normalizedType];
+
+  if (!typePolicy) {
+    // Return empty - all validators will default to REQUIRED
+    return {};
+  }
+
+  return { ...typePolicy };
+}
+
+/**
+ * Get list of required validators for an SD type
+ *
+ * @param {string} sdType - SD type
+ * @returns {string[]} Array of required validator names
+ */
+export function getRequiredValidators(sdType) {
+  const requirements = getValidatorRequirements(sdType);
+
+  return Object.entries(requirements)
+    .filter(([_, level]) => level === RequirementLevel.REQUIRED)
+    .map(([name]) => name);
+}
+
+/**
+ * Get list of non-applicable validators for an SD type
+ *
+ * @param {string} sdType - SD type
+ * @returns {string[]} Array of non-applicable validator names
+ */
+export function getNonApplicableValidators(sdType) {
+  const requirements = getValidatorRequirements(sdType);
+
+  return Object.entries(requirements)
+    .filter(([_, level]) => level === RequirementLevel.NON_APPLICABLE)
+    .map(([name]) => name);
+}
+
+/**
+ * Create a SKIPPED validator result
+ *
+ * @param {string} validatorName - Validator name
+ * @param {string} sdType - SD type
+ * @param {string} reasonCode - SkipReasonCode value
+ * @returns {Object} Validator result with SKIPPED status
+ */
+export function createSkippedResult(validatorName, sdType, reasonCode = SkipReasonCode.NON_APPLICABLE_SD_TYPE) {
+  return {
+    passed: true,           // Backward compatible - SKIPPED counts as not blocking
+    status: ValidatorStatus.SKIPPED,
+    score: 100,             // Full score (not a deduction)
+    max_score: 100,
+    issues: [],
+    warnings: [],
+    skipped: true,
+    skipReason: reasonCode,
+    skipDetails: {
+      validator_name: validatorName,
+      sd_type: sdType,
+      reason_code: reasonCode,
+      policy_version: POLICY_VERSION,
+      timestamp: new Date().toISOString()
+    }
+  };
+}
+
+/**
+ * Check if a validator result represents a SKIPPED validation
+ *
+ * @param {Object} result - Validator result
+ * @returns {boolean} True if result is SKIPPED
+ */
+export function isSkippedResult(result) {
+  if (!result) return false;
+
+  return result.status === ValidatorStatus.SKIPPED ||
+         result.skipped === true ||
+         result.skipReason !== undefined;
+}
+
+/**
+ * Get policy summary for an SD type (for logging/debugging)
+ *
+ * @param {string} sdType - SD type
+ * @returns {Object} Policy summary
+ */
+export function getPolicySummary(sdType) {
+  const requirements = getValidatorRequirements(sdType);
+  const required = getRequiredValidators(sdType);
+  const nonApplicable = getNonApplicableValidators(sdType);
+  const optional = Object.entries(requirements)
+    .filter(([_, level]) => level === RequirementLevel.OPTIONAL)
+    .map(([name]) => name);
+
+  return {
+    sd_type: sdType,
+    policy_version: POLICY_VERSION,
+    required,
+    non_applicable: nonApplicable,
+    optional,
+    total_validators: Object.keys(requirements).length
+  };
+}
+
+/**
+ * Log policy summary for an SD
+ *
+ * @param {string} sdType - SD type
+ */
+export function logPolicySummary(sdType) {
+  const summary = getPolicySummary(sdType);
+
+  console.log(`\n📋 SD-Type Applicability Policy (v${POLICY_VERSION})`);
+  console.log(`   SD Type: ${sdType}`);
+  console.log(`   Required validators: ${summary.required.join(', ') || 'none'}`);
+  console.log(`   Non-applicable validators: ${summary.non_applicable.join(', ') || 'none'}`);
+  console.log(`   Optional validators: ${summary.optional.join(', ') || 'none'}`);
+}
+
+export default {
+  POLICY_VERSION,
+  RequirementLevel,
+  ValidatorStatus,
+  SkipReasonCode,
+  getValidatorRequirement,
+  isValidatorRequired,
+  isValidatorNonApplicable,
+  getValidatorRequirements,
+  getRequiredValidators,
+  getNonApplicableValidators,
+  createSkippedResult,
+  isSkippedResult,
+  getPolicySummary,
+  logPolicySummary
+};

--- a/tests/unit/sd-type-applicability-policy.test.js
+++ b/tests/unit/sd-type-applicability-policy.test.js
@@ -1,0 +1,316 @@
+/**
+ * Unit Tests for SD-Type Applicability Policy
+ * Part of SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001
+ *
+ * Tests the centralized policy module that determines which validators
+ * are REQUIRED vs NON_APPLICABLE for each SD type.
+ */
+
+// Jest test file - uses global describe/it/expect
+import {
+  POLICY_VERSION,
+  RequirementLevel,
+  ValidatorStatus,
+  SkipReasonCode,
+  getValidatorRequirement,
+  isValidatorRequired,
+  isValidatorNonApplicable,
+  getValidatorRequirements,
+  getRequiredValidators,
+  getNonApplicableValidators,
+  createSkippedResult,
+  isSkippedResult,
+  getPolicySummary
+} from '../../scripts/modules/handoff/validation/sd-type-applicability-policy.js';
+
+describe('SD-Type Applicability Policy', () => {
+  describe('Policy Version', () => {
+    it('should have a policy version defined', () => {
+      expect(POLICY_VERSION).toBeDefined();
+      expect(typeof POLICY_VERSION).toBe('string');
+      expect(POLICY_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+  });
+
+  describe('Enums', () => {
+    it('should define RequirementLevel correctly', () => {
+      expect(RequirementLevel.REQUIRED).toBe('REQUIRED');
+      expect(RequirementLevel.NON_APPLICABLE).toBe('NON_APPLICABLE');
+      expect(RequirementLevel.OPTIONAL).toBe('OPTIONAL');
+    });
+
+    it('should define ValidatorStatus correctly', () => {
+      expect(ValidatorStatus.PASS).toBe('PASS');
+      expect(ValidatorStatus.FAIL).toBe('FAIL');
+      expect(ValidatorStatus.SKIPPED).toBe('SKIPPED');
+      expect(ValidatorStatus.NOT_RUN).toBe('NOT_RUN');
+    });
+
+    it('should define SkipReasonCode correctly', () => {
+      expect(SkipReasonCode.NON_APPLICABLE_SD_TYPE).toBe('NON_APPLICABLE_SD_TYPE');
+    });
+  });
+
+  describe('getValidatorRequirement()', () => {
+    it('should return REQUIRED for unknown SD types (safe default)', () => {
+      const result = getValidatorRequirement('unknown_type', 'TESTING');
+      expect(result).toBe(RequirementLevel.REQUIRED);
+    });
+
+    it('should handle null/undefined SD type', () => {
+      expect(getValidatorRequirement(null, 'TESTING')).toBe(RequirementLevel.REQUIRED);
+      expect(getValidatorRequirement(undefined, 'TESTING')).toBe(RequirementLevel.REQUIRED);
+    });
+
+    // Refactor SD type - PRIMARY FIX
+    describe('refactor SD type', () => {
+      it('should mark TESTING as NON_APPLICABLE for refactor', () => {
+        expect(getValidatorRequirement('refactor', 'TESTING')).toBe(RequirementLevel.NON_APPLICABLE);
+      });
+
+      it('should mark DESIGN as NON_APPLICABLE for refactor', () => {
+        expect(getValidatorRequirement('refactor', 'DESIGN')).toBe(RequirementLevel.NON_APPLICABLE);
+      });
+
+      it('should mark REGRESSION as REQUIRED for refactor', () => {
+        expect(getValidatorRequirement('refactor', 'REGRESSION')).toBe(RequirementLevel.REQUIRED);
+      });
+
+      it('should mark GITHUB as REQUIRED for refactor', () => {
+        expect(getValidatorRequirement('refactor', 'GITHUB')).toBe(RequirementLevel.REQUIRED);
+      });
+    });
+
+    // Infrastructure SD type
+    describe('infrastructure SD type', () => {
+      it('should mark TESTING as NON_APPLICABLE for infrastructure', () => {
+        expect(getValidatorRequirement('infrastructure', 'TESTING')).toBe(RequirementLevel.NON_APPLICABLE);
+      });
+
+      it('should mark DESIGN as NON_APPLICABLE for infrastructure', () => {
+        expect(getValidatorRequirement('infrastructure', 'DESIGN')).toBe(RequirementLevel.NON_APPLICABLE);
+      });
+
+      it('should mark GITHUB as NON_APPLICABLE for infrastructure', () => {
+        expect(getValidatorRequirement('infrastructure', 'GITHUB')).toBe(RequirementLevel.NON_APPLICABLE);
+      });
+
+      it('should mark DOCMON as REQUIRED for infrastructure', () => {
+        expect(getValidatorRequirement('infrastructure', 'DOCMON')).toBe(RequirementLevel.REQUIRED);
+      });
+    });
+
+    // Feature SD type (full validation)
+    describe('feature SD type', () => {
+      it('should mark TESTING as REQUIRED for feature', () => {
+        expect(getValidatorRequirement('feature', 'TESTING')).toBe(RequirementLevel.REQUIRED);
+      });
+
+      it('should mark DESIGN as REQUIRED for feature', () => {
+        expect(getValidatorRequirement('feature', 'DESIGN')).toBe(RequirementLevel.REQUIRED);
+      });
+
+      it('should mark STORIES as REQUIRED for feature', () => {
+        expect(getValidatorRequirement('feature', 'STORIES')).toBe(RequirementLevel.REQUIRED);
+      });
+    });
+  });
+
+  describe('isValidatorRequired()', () => {
+    it('should return true for REQUIRED validators', () => {
+      expect(isValidatorRequired('refactor', 'REGRESSION')).toBe(true);
+      expect(isValidatorRequired('feature', 'TESTING')).toBe(true);
+    });
+
+    it('should return false for NON_APPLICABLE validators', () => {
+      expect(isValidatorRequired('refactor', 'TESTING')).toBe(false);
+      expect(isValidatorRequired('infrastructure', 'DESIGN')).toBe(false);
+    });
+
+    it('should return false for OPTIONAL validators', () => {
+      expect(isValidatorRequired('refactor', 'DOCMON')).toBe(false);
+    });
+  });
+
+  describe('isValidatorNonApplicable()', () => {
+    it('should return true for NON_APPLICABLE validators', () => {
+      expect(isValidatorNonApplicable('refactor', 'TESTING')).toBe(true);
+      expect(isValidatorNonApplicable('documentation', 'GITHUB')).toBe(true);
+    });
+
+    it('should return false for REQUIRED validators', () => {
+      expect(isValidatorNonApplicable('refactor', 'REGRESSION')).toBe(false);
+      expect(isValidatorNonApplicable('feature', 'TESTING')).toBe(false);
+    });
+  });
+
+  describe('getRequiredValidators()', () => {
+    it('should return only REQUIRED validators for refactor', () => {
+      const required = getRequiredValidators('refactor');
+      expect(required).toContain('REGRESSION');
+      expect(required).toContain('GITHUB');
+      expect(required).not.toContain('TESTING');
+      expect(required).not.toContain('DESIGN');
+    });
+
+    it('should return multiple REQUIRED validators for feature', () => {
+      const required = getRequiredValidators('feature');
+      expect(required).toContain('TESTING');
+      expect(required).toContain('DESIGN');
+      expect(required).toContain('DOCMON');
+      expect(required).toContain('STORIES');
+    });
+
+    it('should return empty array for unknown SD type', () => {
+      const required = getRequiredValidators('unknown_type');
+      expect(required).toEqual([]);
+    });
+  });
+
+  describe('getNonApplicableValidators()', () => {
+    it('should return NON_APPLICABLE validators for refactor', () => {
+      const nonApplicable = getNonApplicableValidators('refactor');
+      expect(nonApplicable).toContain('TESTING');
+      expect(nonApplicable).toContain('DESIGN');
+      expect(nonApplicable).toContain('DATABASE');
+      expect(nonApplicable).toContain('STORIES');
+      expect(nonApplicable).not.toContain('REGRESSION');
+    });
+
+    it('should return many NON_APPLICABLE validators for documentation', () => {
+      const nonApplicable = getNonApplicableValidators('documentation');
+      expect(nonApplicable).toContain('TESTING');
+      expect(nonApplicable).toContain('DESIGN');
+      expect(nonApplicable).toContain('GITHUB');
+      expect(nonApplicable).toContain('DATABASE');
+      expect(nonApplicable).toContain('REGRESSION');
+    });
+  });
+
+  describe('createSkippedResult()', () => {
+    it('should create a properly structured SKIPPED result', () => {
+      const result = createSkippedResult('TESTING', 'refactor');
+
+      expect(result.passed).toBe(true);
+      expect(result.status).toBe(ValidatorStatus.SKIPPED);
+      expect(result.score).toBe(100);
+      expect(result.max_score).toBe(100);
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe(SkipReasonCode.NON_APPLICABLE_SD_TYPE);
+      expect(result.issues).toEqual([]);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('should include skip details for traceability', () => {
+      const result = createSkippedResult('DESIGN', 'infrastructure', SkipReasonCode.NON_APPLICABLE_SD_TYPE);
+
+      expect(result.skipDetails).toBeDefined();
+      expect(result.skipDetails.validator_name).toBe('DESIGN');
+      expect(result.skipDetails.sd_type).toBe('infrastructure');
+      expect(result.skipDetails.reason_code).toBe(SkipReasonCode.NON_APPLICABLE_SD_TYPE);
+      expect(result.skipDetails.policy_version).toBe(POLICY_VERSION);
+      expect(result.skipDetails.timestamp).toBeDefined();
+    });
+
+    it('should accept custom reason codes', () => {
+      const result = createSkippedResult('TESTING', 'refactor', SkipReasonCode.DISABLED_BY_CONFIG);
+      expect(result.skipReason).toBe(SkipReasonCode.DISABLED_BY_CONFIG);
+    });
+  });
+
+  describe('isSkippedResult()', () => {
+    it('should return true for SKIPPED status', () => {
+      const result = { status: ValidatorStatus.SKIPPED };
+      expect(isSkippedResult(result)).toBe(true);
+    });
+
+    it('should return true for skipped=true flag', () => {
+      const result = { skipped: true };
+      expect(isSkippedResult(result)).toBe(true);
+    });
+
+    it('should return true for skipReason present', () => {
+      const result = { skipReason: SkipReasonCode.NON_APPLICABLE_SD_TYPE };
+      expect(isSkippedResult(result)).toBe(true);
+    });
+
+    it('should return true for createSkippedResult() output', () => {
+      const result = createSkippedResult('TESTING', 'refactor');
+      expect(isSkippedResult(result)).toBe(true);
+    });
+
+    it('should return false for PASS result', () => {
+      const result = { passed: true, status: ValidatorStatus.PASS };
+      expect(isSkippedResult(result)).toBe(false);
+    });
+
+    it('should return false for FAIL result', () => {
+      const result = { passed: false, status: ValidatorStatus.FAIL };
+      expect(isSkippedResult(result)).toBe(false);
+    });
+
+    it('should return false for null/undefined', () => {
+      expect(isSkippedResult(null)).toBe(false);
+      expect(isSkippedResult(undefined)).toBe(false);
+    });
+  });
+
+  describe('getPolicySummary()', () => {
+    it('should return a complete summary for refactor', () => {
+      const summary = getPolicySummary('refactor');
+
+      expect(summary.sd_type).toBe('refactor');
+      expect(summary.policy_version).toBe(POLICY_VERSION);
+      expect(Array.isArray(summary.required)).toBe(true);
+      expect(Array.isArray(summary.non_applicable)).toBe(true);
+      expect(Array.isArray(summary.optional)).toBe(true);
+      expect(typeof summary.total_validators).toBe('number');
+    });
+
+    it('should correctly categorize validators for refactor', () => {
+      const summary = getPolicySummary('refactor');
+
+      expect(summary.required).toContain('REGRESSION');
+      expect(summary.required).toContain('GITHUB');
+      expect(summary.non_applicable).toContain('TESTING');
+      expect(summary.non_applicable).toContain('DESIGN');
+    });
+  });
+
+  describe('Integration: Refactor SD Workflow', () => {
+    it('should allow refactor SD to complete with REGRESSION only', () => {
+      const sdType = 'refactor';
+      const required = getRequiredValidators(sdType);
+      const nonApplicable = getNonApplicableValidators(sdType);
+
+      // Verify REGRESSION is the primary required validator
+      expect(required).toContain('REGRESSION');
+
+      // Verify TESTING and DESIGN are skippable
+      expect(nonApplicable).toContain('TESTING');
+      expect(nonApplicable).toContain('DESIGN');
+
+      // Simulate validation results
+      const validationResults = {
+        REGRESSION: { passed: true, status: ValidatorStatus.PASS },
+        GITHUB: { passed: true, status: ValidatorStatus.PASS },
+        TESTING: createSkippedResult('TESTING', sdType),
+        DESIGN: createSkippedResult('DESIGN', sdType)
+      };
+
+      // All results should be acceptable
+      for (const [validator, result] of Object.entries(validationResults)) {
+        const isNonApplicable = isValidatorNonApplicable(sdType, validator);
+
+        if (isNonApplicable) {
+          // Non-applicable validators should be SKIPPED
+          expect(isSkippedResult(result)).toBe(true);
+          expect(result.passed).toBe(true); // SKIPPED counts as passing
+        } else {
+          // Required validators should PASS
+          expect(result.passed).toBe(true);
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the 75% handoff rejection rate for refactor/infrastructure SDs by making validators SD-type-aware.

**Problem**: Validators were enforcing TESTING/DESIGN sub-agents for ALL SD types, even when those validators aren't applicable (e.g., refactor SDs don't need new tests, just regression validation).

**Solution**:
- Created centralized `SD_TYPE_POLICY` defining REQUIRED vs NON_APPLICABLE validators per SD type
- Updated `ValidationOrchestrator` to track SKIPPED status properly with full traceability
- Added database migration for SD-type-aware progress calculation

## Key Changes

| File | Change |
|------|--------|
| `sd-type-applicability-policy.js` | New policy module with 12 SD types, REQUIRED/NON_APPLICABLE/OPTIONAL levels |
| `ValidationOrchestrator.js` | Integration of policy, SKIPPED gate tracking |
| `20260124_sd_type_aware_progress_calculation.sql` | `get_min_required_handoffs()` - refactor/infra need 2, feature needs 3 |
| `sd-type-applicability-policy.test.js` | 40 unit tests covering all policy functions |

## Test Plan

- [x] 40 unit tests pass (`npm run test:unit -- --testPathPattern="sd-type-applicability"`)
- [x] Refactor SD type correctly marks TESTING/DESIGN as NON_APPLICABLE
- [x] Infrastructure SD type correctly marks GITHUB as NON_APPLICABLE
- [x] Unknown SD types default to REQUIRED (safe fallback)
- [x] SKIPPED results include full traceability (validator_name, sd_type, policy_version, timestamp)

## SD Reference

SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements SD-type-aware validation and progress to prevent unnecessary handoff rejections and align checks with each SD’s profile.
> 
> - New `sd-type-applicability-policy.js`: defines REQUIRED/NON_APPLICABLE/OPTIONAL per SD type, enums, helpers, and `createSkippedResult()`/`isSkippedResult()`
> - `ValidationOrchestrator.js`: integrates policy; tracks per-gate status; counts SKIPPED gates; treats SKIPPED as satisfied; emits `skippedGates`/`gateStatuses`; DB-rule validators now return proper SKIPPED results for non-applicable SD types
> - SQL migration: adds `get_min_required_handoffs(sd_type)` and updates `calculate_sd_progress()` to use SD-type-aware handoff minimums and user-story validation rules; includes verification queries
> - Tests: adds unit suite for policy module covering requirement resolution, skip behavior, and summaries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53e7a182200b97405a058941c572902ee19900d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->