### PR TITLE
refactor(api-sub-agent): extract domains into modular structure

### DIFF
--- a/lib/agents/api-sub-agent.js
+++ b/lib/agents/api-sub-agent.js
@@ -2,18 +2,53 @@
  * API Sub-Agent - Intelligent API Analysis
  * Extends IntelligentBaseSubAgent for full integration with improvements
  * Analyzes REST/GraphQL APIs for compliance, performance, and security
+ *
+ * REFACTORED: This file is a thin wrapper that delegates to domain modules.
+ * Domain modules located in ./api-sub-agent/domains/:
+ * - endpoint-analysis.js - Endpoint detection and analysis
+ * - documentation-analysis.js - OpenAPI/Swagger validation
+ * - structure-analysis.js - RESTful patterns
+ * - security-analysis.js - Security checks
+ * - quality-analysis.js - Error handling, schemas, rate limiting
+ *
+ * @module api-sub-agent
  */
 
 import IntelligentBaseSubAgent from './intelligent-base-sub-agent.js';
 import fsModule from 'fs';
 const fs = fsModule.promises;
 import path from 'path';
-// execSync not currently used but may be needed for future CLI integrations
+
+// Import domain modules
+import {
+  analyzeEndpoints,
+  findAPIFiles
+} from './api-sub-agent/domains/endpoint-analysis.js';
+
+import {
+  analyzeAPIDocumentation
+} from './api-sub-agent/domains/documentation-analysis.js';
+
+import {
+  analyzeAPIStructure,
+  analyzeVersioning
+} from './api-sub-agent/domains/structure-analysis.js';
+
+import {
+  analyzeAPISecurity,
+  analyzeCORS
+} from './api-sub-agent/domains/security-analysis.js';
+
+import {
+  analyzeErrorHandling,
+  validateSchemas,
+  checkRateLimiting
+} from './api-sub-agent/domains/quality-analysis.js';
 
 class APISubAgent extends IntelligentBaseSubAgent {
   constructor() {
     super('API', '🚀');
-    
+
     // API quality thresholds
     this.thresholds = {
       responseTime: 200,      // ms
@@ -22,7 +57,7 @@ class APISubAgent extends IntelligentBaseSubAgent {
       versioning: true,       // API should be versioned
       errorHandling: 0.9      // 90% of endpoints should have error handling
     };
-    
+
     // API health tracking
     this.apiHealth = {
       endpoints: [],
@@ -39,13 +74,13 @@ class APISubAgent extends IntelligentBaseSubAgent {
    */
   async intelligentAnalyze(basePath, _context) {
     console.log('🚀 Intelligent API Analysis Starting...');
-    
+
     // Use inherited codebase knowledge for better API detection
-    const apiFramework = this.codebaseProfile.backend || 
+    const apiFramework = this.codebaseProfile.backend ||
                         (this.codebaseProfile.framework === 'Next.js' ? 'Next.js API' : null);
-    
+
     console.log(`   API Framework: ${apiFramework || 'None detected'}`);
-    
+
     if (!apiFramework) {
       // Check if there are API-like patterns in code
       const hasAPIPatterns = await this.detectAPIPatterns(basePath);
@@ -54,36 +89,39 @@ class APISubAgent extends IntelligentBaseSubAgent {
         return;
       }
     }
-    
+
     const apiInfo = { framework: apiFramework };
-    
-    // Find and analyze API endpoints
-    await this.analyzeEndpoints(basePath, apiInfo);
-    
-    // Check API documentation
-    await this.analyzeAPIDocumentation(basePath);
-    
-    // Analyze API structure and patterns
-    await this.analyzeAPIStructure(basePath);
-    
-    // Check authentication and security
-    await this.analyzeAPISecurity(basePath);
-    
-    // Check error handling
-    await this.analyzeErrorHandling(basePath);
-    
-    // Validate request/response schemas
-    await this.validateSchemas(basePath);
-    
-    // Check rate limiting
-    await this.checkRateLimiting(basePath);
-    
-    // Analyze API versioning
-    await this.analyzeVersioning(basePath);
-    
-    // Check CORS configuration
-    await this.analyzeCORS(basePath);
-    
+
+    // Bind addFinding to this instance
+    const addFinding = this.addFinding.bind(this);
+
+    // Find and analyze API endpoints (delegated to domain)
+    await analyzeEndpoints(basePath, apiInfo, this.apiHealth, addFinding);
+
+    // Check API documentation (delegated to domain)
+    await analyzeAPIDocumentation(basePath, this.apiHealth, this.thresholds, addFinding);
+
+    // Analyze API structure and patterns (delegated to domain)
+    analyzeAPIStructure(this.apiHealth, addFinding);
+
+    // Check authentication and security (delegated to domain)
+    await analyzeAPISecurity(basePath, addFinding);
+
+    // Check error handling (delegated to domain)
+    await analyzeErrorHandling(basePath, addFinding);
+
+    // Validate request/response schemas (delegated to domain)
+    await validateSchemas(basePath, this.apiHealth, addFinding);
+
+    // Check rate limiting (delegated to domain)
+    await checkRateLimiting(basePath, this.apiHealth, addFinding);
+
+    // Analyze API versioning (delegated to domain)
+    analyzeVersioning(this.apiHealth, addFinding);
+
+    // Check CORS configuration (delegated to domain)
+    await analyzeCORS(basePath, this.apiHealth, addFinding);
+
     console.log(`✓ Analyzed ${this.apiHealth.totalEndpoints} API endpoints`);
   }
 
@@ -94,27 +132,27 @@ class APISubAgent extends IntelligentBaseSubAgent {
     try {
       const pkg = JSON.parse(await fs.readFile(path.join(basePath, 'package.json'), 'utf8'));
       const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-      
+
       // REST frameworks
       if ('express' in deps) return { framework: 'Express', type: 'REST' };
       if ('koa' in deps) return { framework: 'Koa', type: 'REST' };
       if ('fastify' in deps) return { framework: 'Fastify', type: 'REST' };
       if ('@hapi/hapi' in deps || 'hapi' in deps) return { framework: 'Hapi', type: 'REST' };
       if ('@nestjs/core' in deps) return { framework: 'NestJS', type: 'REST' };
-      
+
       // GraphQL
       if ('graphql' in deps) {
         if ('apollo-server' in deps) return { framework: 'Apollo Server', type: 'GraphQL' };
         if ('graphql-yoga' in deps) return { framework: 'GraphQL Yoga', type: 'GraphQL' };
         return { framework: 'GraphQL', type: 'GraphQL' };
       }
-      
+
       // Next.js API routes
       if ('next' in deps) return { framework: 'Next.js', type: 'REST' };
-      
+
       // Serverless
       if ('serverless' in deps) return { framework: 'Serverless', type: 'REST' };
-      
+
       return { framework: null, type: null };
     } catch {
       return { framework: null, type: null };
@@ -126,16 +164,16 @@ class APISubAgent extends IntelligentBaseSubAgent {
    */
   async detectAPIPatterns(basePath) {
     const apiDirs = ['api', 'routes', 'controllers', 'endpoints', 'src/api', 'src/routes'];
-    
+
     for (const dir of apiDirs) {
       try {
         const fullPath = path.join(basePath, dir);
         const files = await fs.readdir(fullPath);
-        
+
         for (const file of files) {
           if (file.endsWith('.js') || file.endsWith('.ts')) {
             const content = await fs.readFile(path.join(fullPath, file), 'utf8');
-            
+
             // Look for HTTP method patterns
             if (/\.(get|post|put|delete|patch)\s*\(/i.test(content) ||
                 /app\.use\s*\(/i.test(content) ||
@@ -149,728 +187,23 @@ class APISubAgent extends IntelligentBaseSubAgent {
         // Directory doesn't exist
       }
     }
-    
+
     return false;
-  }
-
-  /**
-   * Analyze API endpoints
-   */
-  async analyzeEndpoints(basePath, apiInfo) {
-    const apiFiles = await this.findAPIFiles(basePath);
-    
-    for (const file of apiFiles) {
-      await this.analyzeAPIFile(file, basePath);
-    }
-    
-    // Check for common endpoint issues
-    if (this.apiHealth.totalEndpoints === 0) {
-      this.addFinding({
-        type: 'NO_API_ENDPOINTS',
-        severity: 'high',
-        confidence: 0.9,
-        file: 'api',
-        description: 'API framework detected but no endpoints found',
-        recommendation: 'Define API endpoints or remove unused framework dependencies',
-        metadata: {
-          framework: apiInfo.framework
-        }
-      });
-    }
-  }
-
-  /**
-   * Find API files
-   */
-  async findAPIFiles(basePath) {
-    const apiFiles = [];
-    const searchDirs = [
-      'api', 'routes', 'controllers', 'endpoints',
-      'src/api', 'src/routes', 'src/controllers',
-      'pages/api', // Next.js
-      'functions', // Serverless
-      'lambda' // AWS Lambda
-    ];
-    
-    for (const dir of searchDirs) {
-      const fullPath = path.join(basePath, dir);
-      
-      async function scan(scanDir) {
-        try {
-          const entries = await fs.readdir(scanDir, { withFileTypes: true });
-          
-          for (const entry of entries) {
-            const entryPath = path.join(scanDir, entry.name);
-            
-            if (entry.isDirectory() && !entry.name.startsWith('.')) {
-              await scan(entryPath);
-            } else if (entry.isFile() && 
-                      (entry.name.endsWith('.js') || entry.name.endsWith('.ts'))) {
-              apiFiles.push(entryPath);
-            }
-          }
-        } catch {
-          // Directory doesn't exist
-        }
-      }
-      
-      await scan(fullPath);
-    }
-    
-    return apiFiles;
-  }
-
-  /**
-   * Analyze individual API file
-   */
-  async analyzeAPIFile(file, basePath) {
-    try {
-      const content = await fs.readFile(file, 'utf8');
-      const relativePath = path.relative(basePath, file);
-      
-      // Find HTTP method definitions
-      const methodRegex = /\.(get|post|put|delete|patch|head|options)\s*\(\s*['"`]([^'"`]+)['"`]\s*,?\s*(?:async\s+)?\(?([^)]*)\)?\s*=>\s*{|app\.(get|post|put|delete|patch|head|options)\s*\(\s*['"`]([^'"`]+)['"`]/gi;
-      
-      let match;
-      while ((match = methodRegex.exec(content)) !== null) {
-        const method = (match[1] || match[4]).toUpperCase();
-        const route = match[2] || match[5];
-        const params = match[3] || '';
-        
-        this.apiHealth.totalEndpoints++;
-        
-        const endpoint = {
-          method,
-          route,
-          file: relativePath,
-          params,
-          documented: false,
-          authenticated: false,
-          validated: false,
-          errorHandled: false
-        };
-        
-        this.apiHealth.endpoints.push(endpoint);
-        
-        // Analyze endpoint quality
-        await this.analyzeEndpoint(endpoint, content, relativePath);
-      }
-      
-      // Check for GraphQL schemas
-      if (content.includes('GraphQL') || content.includes('gql`') || content.includes('buildSchema')) {
-        await this.analyzeGraphQL(content, relativePath);
-      }
-      
-    } catch {
-      // File read error - silently ignore
-    }
-  }
-
-  /**
-   * Analyze individual endpoint
-   */
-  async analyzeEndpoint(endpoint, fileContent, file) {
-    const { method, route } = endpoint;
-    
-    // Check for parameter validation
-    const hasValidation = /req\.body\s*&&|joi\.|yup\.|validate|schema/i.test(fileContent);
-    if (!hasValidation && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
-      this.addFinding({
-        type: 'MISSING_INPUT_VALIDATION',
-        severity: 'high',
-        confidence: 0.9,
-        file,
-        description: `${method} ${route} lacks input validation`,
-        recommendation: 'Add request body validation using Joi, Yup, or similar',
-        metadata: {
-          endpoint: `${method} ${route}`,
-          method,
-          route
-        }
-      });
-    }
-    
-    // Check for authentication
-    const hasAuth = /auth|jwt|token|passport|session/i.test(fileContent);
-    if (!hasAuth && !route.includes('public') && !route.includes('health')) {
-      this.addFinding({
-        type: 'MISSING_AUTHENTICATION',
-        severity: 'high',
-        confidence: 0.8,
-        file,
-        description: `${method} ${route} appears to lack authentication`,
-        recommendation: 'Add authentication middleware for protected endpoints',
-        metadata: {
-          endpoint: `${method} ${route}`
-        }
-      });
-    }
-    
-    // Check for error handling
-    const hasErrorHandling = /try\s*{|catch\s*\(|\.catch\s*\(/i.test(fileContent);
-    if (!hasErrorHandling) {
-      this.addFinding({
-        type: 'MISSING_ERROR_HANDLING',
-        severity: 'medium',
-        confidence: 0.85,
-        file,
-        description: `${method} ${route} lacks error handling`,
-        recommendation: 'Add try-catch blocks or error handling middleware',
-        metadata: {
-          endpoint: `${method} ${route}`
-        }
-      });
-    }
-    
-    // Check for SQL injection vulnerabilities
-    if (fileContent.includes('query(') && fileContent.includes('req.body')) {
-      const hasSQLInjection = /query\s*\(\s*['"`].*\$\{.*req\./i.test(fileContent);
-      if (hasSQLInjection) {
-        this.addFinding({
-          type: 'SQL_INJECTION_RISK',
-          severity: 'critical',
-          confidence: 0.95,
-          file,
-          description: `${method} ${route} vulnerable to SQL injection`,
-          recommendation: 'Use parameterized queries or ORM methods',
-          metadata: {
-            endpoint: `${method} ${route}`
-          }
-        });
-      }
-    }
-    
-    // Check for proper HTTP status codes
-    const statusCodeRegex = /res\.status\s*\(\s*(\d+)\s*\)|res\.sendStatus\s*\(\s*(\d+)\s*\)/g;
-    const statusCodes = [];
-    let statusMatch;
-    
-    while ((statusMatch = statusCodeRegex.exec(fileContent)) !== null) {
-      statusCodes.push(parseInt(statusMatch[1] || statusMatch[2]));
-    }
-    
-    // Check if using appropriate status codes
-    if (method === 'POST' && !statusCodes.includes(201) && statusCodes.length > 0) {
-      this.addFinding({
-        type: 'INCORRECT_STATUS_CODE',
-        severity: 'low',
-        confidence: 0.7,
-        file,
-        description: `POST ${route} should return 201 for successful creation`,
-        recommendation: 'Use res.status(201) for successful resource creation',
-        metadata: {
-          endpoint: `${method} ${route}`,
-          currentCodes: statusCodes
-        }
-      });
-    }
-    
-    // Check for rate limiting
-    const hasRateLimit = /rate.*limit|express-rate-limit|slowdown/i.test(fileContent);
-    if (!hasRateLimit && (method === 'POST' || method === 'PUT')) {
-      this.addFinding({
-        type: 'MISSING_RATE_LIMITING',
-        severity: 'medium',
-        confidence: 0.8,
-        file,
-        description: `${method} ${route} lacks rate limiting`,
-        recommendation: 'Add rate limiting middleware for write operations',
-        metadata: {
-          endpoint: `${method} ${route}`
-        }
-      });
-    }
-  }
-
-  /**
-   * Analyze GraphQL
-   */
-  async analyzeGraphQL(content, file) {
-    // Check for GraphQL best practices
-    if (!content.includes('Query') || !content.includes('Mutation')) {
-      this.addFinding({
-        type: 'INCOMPLETE_GRAPHQL_SCHEMA',
-        severity: 'medium',
-        confidence: 0.8,
-        file,
-        description: 'GraphQL schema missing Query or Mutation types',
-        recommendation: 'Define proper GraphQL schema with Query and Mutation types',
-        metadata: {
-          type: 'GraphQL'
-        }
-      });
-    }
-    
-    // Check for N+1 query problems
-    if (content.includes('for') && content.includes('await')) {
-      this.addFinding({
-        type: 'GRAPHQL_N_PLUS_ONE',
-        severity: 'high',
-        confidence: 0.7,
-        file,
-        description: 'Potential N+1 query problem in GraphQL resolver',
-        recommendation: 'Use DataLoader or batch queries to avoid N+1 problems',
-        metadata: {
-          type: 'GraphQL'
-        }
-      });
-    }
-  }
-
-  /**
-   * Analyze API documentation
-   */
-  async analyzeAPIDocumentation(basePath) {
-    // Check for OpenAPI/Swagger
-    const swaggerFiles = [
-      'swagger.json', 'swagger.yaml', 'swagger.yml',
-      'openapi.json', 'openapi.yaml', 'openapi.yml',
-      'api-docs.json', 'api-docs.yaml'
-    ];
-    
-    let hasAPIDoc = false;
-    
-    for (const swaggerFile of swaggerFiles) {
-      try {
-        const content = await fs.readFile(path.join(basePath, swaggerFile), 'utf8');
-        hasAPIDoc = true;
-        
-        // Validate swagger/openapi
-        if (swaggerFile.endsWith('.json')) {
-          try {
-            const spec = JSON.parse(content);
-            await this.validateOpenAPISpec(spec, swaggerFile);
-          } catch (error) {
-            this.addFinding({
-              type: 'INVALID_API_SPECIFICATION',
-              severity: 'high',
-              confidence: 1.0,
-              file: swaggerFile,
-              description: 'API specification has invalid JSON syntax',
-              recommendation: 'Fix JSON syntax errors in API specification',
-              metadata: {
-                error: error.message
-              }
-            });
-          }
-        }
-        break;
-      } catch {
-        // File doesn't exist
-      }
-    }
-    
-    if (!hasAPIDoc && this.apiHealth.totalEndpoints > 0) {
-      this.addFinding({
-        type: 'MISSING_API_DOCUMENTATION',
-        severity: 'high',
-        confidence: 0.9,
-        file: 'api-docs',
-        description: `${this.apiHealth.totalEndpoints} API endpoints lack documentation`,
-        recommendation: 'Create OpenAPI/Swagger specification for API',
-        metadata: {
-          endpoints: this.apiHealth.totalEndpoints,
-          suggestion: 'Use swagger-jsdoc to generate docs from code comments'
-        }
-      });
-    }
-    
-    // Check for README API documentation
-    try {
-      const readme = await fs.readFile(path.join(basePath, 'README.md'), 'utf8');
-      
-      if (this.apiHealth.totalEndpoints > 0 && !readme.toLowerCase().includes('api')) {
-        this.addFinding({
-          type: 'API_NOT_DOCUMENTED_IN_README',
-          severity: 'medium',
-          confidence: 0.8,
-          file: 'README.md',
-          description: 'API endpoints not mentioned in README',
-          recommendation: 'Add API usage examples to README',
-          metadata: {
-            endpoints: this.apiHealth.totalEndpoints
-          }
-        });
-      }
-    } catch {
-      // No README
-    }
-  }
-
-  /**
-   * Validate OpenAPI specification
-   */
-  async validateOpenAPISpec(spec, file) {
-    // Check required fields
-    if (!spec.openapi && !spec.swagger) {
-      this.addFinding({
-        type: 'MISSING_API_VERSION',
-        severity: 'high',
-        confidence: 1.0,
-        file,
-        description: 'API specification missing version field',
-        recommendation: 'Add openapi or swagger version field',
-        metadata: {
-          required: 'openapi: "3.0.0" or swagger: "2.0"'
-        }
-      });
-    }
-    
-    if (!spec.info) {
-      this.addFinding({
-        type: 'MISSING_API_INFO',
-        severity: 'medium',
-        confidence: 1.0,
-        file,
-        description: 'API specification missing info section',
-        recommendation: 'Add API title, description, and version in info section',
-        metadata: {
-          required: 'info: { title, description, version }'
-        }
-      });
-    }
-    
-    if (!spec.paths || Object.keys(spec.paths).length === 0) {
-      this.addFinding({
-        type: 'EMPTY_API_SPECIFICATION',
-        severity: 'high',
-        confidence: 1.0,
-        file,
-        description: 'API specification has no endpoints defined',
-        recommendation: 'Add endpoint definitions to paths section',
-        metadata: {
-          actualEndpoints: this.apiHealth.totalEndpoints
-        }
-      });
-    } else {
-      // Check coverage
-      const specEndpoints = Object.keys(spec.paths).length;
-      const coverage = specEndpoints / this.apiHealth.totalEndpoints;
-      
-      if (coverage < this.thresholds.documentation) {
-        this.addFinding({
-          type: 'INCOMPLETE_API_DOCUMENTATION',
-          severity: 'medium',
-          confidence: 0.9,
-          file,
-          description: `Only ${Math.round(coverage * 100)}% of endpoints are documented`,
-          recommendation: 'Document all API endpoints in specification',
-          metadata: {
-            documented: specEndpoints,
-            total: this.apiHealth.totalEndpoints,
-            coverage: Math.round(coverage * 100)
-          }
-        });
-      }
-    }
-  }
-
-  /**
-   * Analyze API structure
-   */
-  async analyzeAPIStructure(_basePath) {
-    // Check for RESTful patterns
-    const endpoints = this.apiHealth.endpoints;
-    const routes = endpoints.map(e => e.route);
-    
-    // Check for inconsistent naming
-    const hasInconsistentNaming = routes.some(route => 
-      route.includes('_') && routes.some(r => r.includes('-'))
-    );
-    
-    if (hasInconsistentNaming) {
-      this.addFinding({
-        type: 'INCONSISTENT_ROUTE_NAMING',
-        severity: 'low',
-        confidence: 0.8,
-        file: 'api-structure',
-        description: 'API routes use inconsistent naming conventions',
-        recommendation: 'Use consistent naming (either kebab-case or snake_case)',
-        metadata: {
-          examples: routes.filter(r => r.includes('_') || r.includes('-')).slice(0, 3)
-        }
-      });
-    }
-    
-    // Check for proper resource naming (plural vs singular)
-    const singularRoutes = routes.filter(route => 
-      /\/\w+\/\d+$/.test(route) && !route.includes('/') // e.g., /user/123
-    );
-    
-    if (singularRoutes.length > 0) {
-      this.addFinding({
-        type: 'NON_RESTFUL_RESOURCE_NAMING',
-        severity: 'low',
-        confidence: 0.7,
-        file: 'api-structure',
-        description: 'Some routes use singular resource names',
-        recommendation: 'Use plural resource names for RESTful APIs (e.g., /users/123)',
-        metadata: {
-          examples: singularRoutes.slice(0, 3)
-        }
-      });
-    }
-    
-    // Check for deep nesting
-    const deepRoutes = routes.filter(route => 
-      (route.match(/\//g) || []).length > 4
-    );
-    
-    if (deepRoutes.length > 0) {
-      this.addFinding({
-        type: 'DEEPLY_NESTED_ROUTES',
-        severity: 'medium',
-        confidence: 0.8,
-        file: 'api-structure',
-        description: 'Some routes are deeply nested (>4 levels)',
-        recommendation: 'Consider flattening route structure for better usability',
-        metadata: {
-          examples: deepRoutes.slice(0, 3)
-        }
-      });
-    }
-  }
-
-  /**
-   * Analyze API security
-   */
-  async analyzeAPISecurity(basePath) {
-    const apiFiles = await this.findAPIFiles(basePath);
-    
-    for (const file of apiFiles.slice(0, 10)) { // Sample for performance
-      try {
-        const content = await fs.readFile(file, 'utf8');
-        const relativePath = path.relative(basePath, file);
-        
-        // Check for hardcoded secrets
-        if (/api[_-]?key\s*[:=]\s*["'][^"']+["']/i.test(content)) {
-          this.addFinding({
-            type: 'HARDCODED_API_KEY',
-            severity: 'critical',
-            confidence: 0.9,
-            file: relativePath,
-            description: 'Hardcoded API key found in source code',
-            recommendation: 'Move API keys to environment variables',
-            metadata: {
-              type: 'security'
-            }
-          });
-        }
-        
-        // Check for CORS misconfiguration
-        if (content.includes('cors') && content.includes('origin: "*"')) {
-          this.addFinding({
-            type: 'INSECURE_CORS',
-            severity: 'high',
-            confidence: 0.95,
-            file: relativePath,
-            description: 'CORS configured to allow all origins',
-            recommendation: 'Restrict CORS to specific trusted domains',
-            metadata: {
-              current: 'origin: "*"',
-              suggestion: 'origin: ["https://yourdomain.com"]'
-            }
-          });
-        }
-        
-        // Check for missing HTTPS enforcement
-        if (content.includes('http://') && !content.includes('localhost')) {
-          this.addFinding({
-            type: 'INSECURE_HTTP',
-            severity: 'high',
-            confidence: 0.8,
-            file: relativePath,
-            description: 'Using HTTP instead of HTTPS',
-            recommendation: 'Enforce HTTPS for all API communications',
-            metadata: {
-              protocol: 'HTTP'
-            }
-          });
-        }
-      } catch {
-        // File read error
-      }
-    }
-  }
-
-  /**
-   * Analyze error handling
-   */
-  async analyzeErrorHandling(basePath) {
-    const apiFiles = await this.findAPIFiles(basePath);
-    let filesWithoutErrorHandling = 0;
-    
-    for (const file of apiFiles) {
-      try {
-        const content = await fs.readFile(file, 'utf8');
-        
-        // Check for error handling patterns
-        const hasErrorHandling = 
-          content.includes('try') && content.includes('catch') ||
-          content.includes('.catch(') ||
-          content.includes('error') && content.includes('status');
-        
-        if (!hasErrorHandling) {
-          filesWithoutErrorHandling++;
-        }
-      } catch {
-        // File read error
-      }
-    }
-    
-    if (filesWithoutErrorHandling > 0) {
-      const ratio = filesWithoutErrorHandling / apiFiles.length;
-      
-      if (ratio > 0.5) {
-        this.addFinding({
-          type: 'INADEQUATE_ERROR_HANDLING',
-          severity: 'high',
-          confidence: 0.9,
-          file: 'api',
-          description: `${Math.round(ratio * 100)}% of API files lack error handling`,
-          recommendation: 'Implement comprehensive error handling for all endpoints',
-          metadata: {
-            filesWithoutHandling: filesWithoutErrorHandling,
-            totalFiles: apiFiles.length
-          }
-        });
-      }
-    }
-  }
-
-  /**
-   * Validate schemas
-   */
-  async validateSchemas(basePath) {
-    // Look for schema validation libraries
-    try {
-      const pkg = JSON.parse(await fs.readFile(path.join(basePath, 'package.json'), 'utf8'));
-      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-      
-      const validationLibs = ['joi', 'yup', 'ajv', 'express-validator', 'class-validator'];
-      const hasValidation = validationLibs.some(lib => lib in deps);
-      
-      if (!hasValidation && this.apiHealth.totalEndpoints > 0) {
-        this.addFinding({
-          type: 'MISSING_SCHEMA_VALIDATION',
-          severity: 'high',
-          confidence: 0.8,
-          file: 'package.json',
-          description: 'No schema validation library found',
-          recommendation: 'Add Joi, Yup, or similar for request/response validation',
-          metadata: {
-            suggestions: validationLibs.slice(0, 3)
-          }
-        });
-      }
-    } catch {
-      // Package.json error
-    }
-  }
-
-  /**
-   * Check rate limiting
-   */
-  async checkRateLimiting(basePath) {
-    try {
-      const pkg = JSON.parse(await fs.readFile(path.join(basePath, 'package.json'), 'utf8'));
-      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-      
-      const rateLimitLibs = ['express-rate-limit', 'rate-limiter-flexible', 'express-slow-down'];
-      const hasRateLimit = rateLimitLibs.some(lib => lib in deps);
-      
-      if (!hasRateLimit && this.apiHealth.totalEndpoints > 5) {
-        this.addFinding({
-          type: 'MISSING_RATE_LIMITING',
-          severity: 'medium',
-          confidence: 0.8,
-          file: 'package.json',
-          description: 'No rate limiting configured for API',
-          recommendation: 'Add rate limiting to prevent abuse',
-          metadata: {
-            endpoints: this.apiHealth.totalEndpoints,
-            suggestions: rateLimitLibs
-          }
-        });
-      }
-    } catch {
-      // Package.json error
-    }
-  }
-
-  /**
-   * Analyze versioning
-   */
-  async analyzeVersioning(_basePath) {
-    const endpoints = this.apiHealth.endpoints;
-    const versionedRoutes = endpoints.filter(e => 
-      /\/v\d+\/|\/api\/v\d+\/|version.*=/.test(e.route)
-    );
-    
-    this.apiHealth.versionedEndpoints = versionedRoutes.length;
-    
-    if (endpoints.length > 5 && versionedRoutes.length === 0) {
-      this.addFinding({
-        type: 'MISSING_API_VERSIONING',
-        severity: 'high',
-        confidence: 0.9,
-        file: 'api-versioning',
-        description: 'API lacks versioning strategy',
-        recommendation: 'Implement API versioning (URL path or header-based)',
-        metadata: {
-          totalEndpoints: endpoints.length,
-          suggestion: 'Use /api/v1/ prefix or Accept-Version header'
-        }
-      });
-    }
-  }
-
-  /**
-   * Analyze CORS
-   */
-  async analyzeCORS(basePath) {
-    const apiFiles = await this.findAPIFiles(basePath);
-    let hasCORS = false;
-    
-    for (const file of apiFiles.slice(0, 5)) { // Check sample
-      try {
-        const content = await fs.readFile(file, 'utf8');
-        
-        if (content.includes('cors') || content.includes('Access-Control-Allow')) {
-          hasCORS = true;
-          break;
-        }
-      } catch {
-        // File read error
-      }
-    }
-    
-    if (!hasCORS && this.apiHealth.totalEndpoints > 0) {
-      // Check if it's likely a web API that needs CORS
-      try {
-        const pkg = JSON.parse(await fs.readFile(path.join(basePath, 'package.json'), 'utf8'));
-        const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-        
-        const needsCORS = 'express' in deps || 'koa' in deps || 'fastify' in deps;
-        
-        if (needsCORS) {
-          this.addFinding({
-            type: 'MISSING_CORS_CONFIGURATION',
-            severity: 'medium',
-            confidence: 0.7,
-            file: 'api',
-            description: 'No CORS configuration found',
-            recommendation: 'Configure CORS for web API access',
-            metadata: {
-              suggestion: 'Install and configure cors middleware'
-            }
-          });
-        }
-      } catch {
-        // Package.json error
-      }
-    }
   }
 }
 
 export default APISubAgent;
+
+// Re-export domain functions for direct access if needed
+export {
+  analyzeEndpoints,
+  findAPIFiles,
+  analyzeAPIDocumentation,
+  analyzeAPIStructure,
+  analyzeVersioning,
+  analyzeAPISecurity,
+  analyzeCORS,
+  analyzeErrorHandling,
+  validateSchemas,
+  checkRateLimiting
+};

--- a/lib/agents/api-sub-agent.test.js
+++ b/lib/agents/api-sub-agent.test.js
@@ -1,0 +1,202 @@
+/**
+ * API Sub-Agent Tests
+ * Verifies modular structure and backward compatibility
+ *
+ * @module api-sub-agent.test
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import APISubAgent from './api-sub-agent.js';
+
+// Test backward-compatible imports
+import {
+  analyzeEndpoints,
+  findAPIFiles,
+  analyzeAPIDocumentation,
+  analyzeAPIStructure,
+  analyzeVersioning,
+  analyzeAPISecurity,
+  analyzeCORS,
+  analyzeErrorHandling,
+  validateSchemas,
+  checkRateLimiting
+} from './api-sub-agent.js';
+
+// Test direct domain imports
+import {
+  analyzeEndpoints as endpointAnalysis,
+  findAPIFiles as findFiles
+} from './api-sub-agent/domains/endpoint-analysis.js';
+
+import {
+  analyzeAPIDocumentation as docAnalysis
+} from './api-sub-agent/domains/documentation-analysis.js';
+
+describe('API Sub-Agent - Backward Compatibility', () => {
+  it('should export APISubAgent class as default', () => {
+    expect(APISubAgent).toBeDefined();
+    expect(typeof APISubAgent).toBe('function');
+  });
+
+  it('should have prototype methods defined', () => {
+    // Check prototype instead of instantiating (due to budget enforcement)
+    expect(typeof APISubAgent.prototype.intelligentAnalyze).toBe('function');
+    expect(typeof APISubAgent.prototype.detectAPIFramework).toBe('function');
+    expect(typeof APISubAgent.prototype.detectAPIPatterns).toBe('function');
+  });
+
+  it('should extend IntelligentBaseSubAgent', () => {
+    // Verify class hierarchy by checking prototype chain
+    const proto = Object.getPrototypeOf(APISubAgent.prototype);
+    expect(proto.constructor.name).toBe('IntelligentBaseSubAgent');
+  });
+});
+
+describe('API Sub-Agent - Domain Function Exports', () => {
+  it('should export analyzeEndpoints function', () => {
+    expect(analyzeEndpoints).toBeDefined();
+    expect(typeof analyzeEndpoints).toBe('function');
+  });
+
+  it('should export findAPIFiles function', () => {
+    expect(findAPIFiles).toBeDefined();
+    expect(typeof findAPIFiles).toBe('function');
+  });
+
+  it('should export analyzeAPIDocumentation function', () => {
+    expect(analyzeAPIDocumentation).toBeDefined();
+    expect(typeof analyzeAPIDocumentation).toBe('function');
+  });
+
+  it('should export analyzeAPIStructure function', () => {
+    expect(analyzeAPIStructure).toBeDefined();
+    expect(typeof analyzeAPIStructure).toBe('function');
+  });
+
+  it('should export analyzeVersioning function', () => {
+    expect(analyzeVersioning).toBeDefined();
+    expect(typeof analyzeVersioning).toBe('function');
+  });
+
+  it('should export analyzeAPISecurity function', () => {
+    expect(analyzeAPISecurity).toBeDefined();
+    expect(typeof analyzeAPISecurity).toBe('function');
+  });
+
+  it('should export analyzeCORS function', () => {
+    expect(analyzeCORS).toBeDefined();
+    expect(typeof analyzeCORS).toBe('function');
+  });
+
+  it('should export analyzeErrorHandling function', () => {
+    expect(analyzeErrorHandling).toBeDefined();
+    expect(typeof analyzeErrorHandling).toBe('function');
+  });
+
+  it('should export validateSchemas function', () => {
+    expect(validateSchemas).toBeDefined();
+    expect(typeof validateSchemas).toBe('function');
+  });
+
+  it('should export checkRateLimiting function', () => {
+    expect(checkRateLimiting).toBeDefined();
+    expect(typeof checkRateLimiting).toBe('function');
+  });
+});
+
+describe('API Sub-Agent - Direct Domain Imports', () => {
+  it('should export same functions from domain modules', () => {
+    expect(endpointAnalysis).toBeDefined();
+    expect(typeof endpointAnalysis).toBe('function');
+
+    expect(findFiles).toBeDefined();
+    expect(typeof findFiles).toBe('function');
+
+    expect(docAnalysis).toBeDefined();
+    expect(typeof docAnalysis).toBe('function');
+  });
+
+  it('should reference same function instances', () => {
+    // Functions from main export should be same as domain exports
+    expect(analyzeEndpoints).toBe(endpointAnalysis);
+    expect(findAPIFiles).toBe(findFiles);
+    expect(analyzeAPIDocumentation).toBe(docAnalysis);
+  });
+});
+
+describe('API Sub-Agent - Structure Analysis', () => {
+  it('should detect inconsistent naming', () => {
+    const mockApiHealth = {
+      endpoints: [
+        { route: '/api/user_profile' },
+        { route: '/api/user-settings' }
+      ]
+    };
+    const findings = [];
+    const addFinding = (f) => findings.push(f);
+
+    analyzeAPIStructure(mockApiHealth, addFinding);
+
+    const namingFinding = findings.find(f => f.type === 'INCONSISTENT_ROUTE_NAMING');
+    expect(namingFinding).toBeDefined();
+    expect(namingFinding.severity).toBe('low');
+  });
+
+  it('should detect deeply nested routes', () => {
+    const mockApiHealth = {
+      endpoints: [
+        { route: '/api/v1/org/team/project/resource/action' }
+      ]
+    };
+    const findings = [];
+    const addFinding = (f) => findings.push(f);
+
+    analyzeAPIStructure(mockApiHealth, addFinding);
+
+    const nestingFinding = findings.find(f => f.type === 'DEEPLY_NESTED_ROUTES');
+    expect(nestingFinding).toBeDefined();
+    expect(nestingFinding.severity).toBe('medium');
+  });
+});
+
+describe('API Sub-Agent - Versioning Analysis', () => {
+  it('should detect missing API versioning', () => {
+    const mockApiHealth = {
+      endpoints: [
+        { route: '/api/users' },
+        { route: '/api/products' },
+        { route: '/api/orders' },
+        { route: '/api/invoices' },
+        { route: '/api/reports' },
+        { route: '/api/settings' }
+      ],
+      versionedEndpoints: 0
+    };
+    const findings = [];
+    const addFinding = (f) => findings.push(f);
+
+    analyzeVersioning(mockApiHealth, addFinding);
+
+    const versionFinding = findings.find(f => f.type === 'MISSING_API_VERSIONING');
+    expect(versionFinding).toBeDefined();
+    expect(versionFinding.severity).toBe('high');
+  });
+
+  it('should not flag versioned APIs', () => {
+    const mockApiHealth = {
+      endpoints: [
+        { route: '/api/v1/users' },
+        { route: '/api/v1/products' }
+      ],
+      versionedEndpoints: 0
+    };
+    const findings = [];
+    const addFinding = (f) => findings.push(f);
+
+    analyzeVersioning(mockApiHealth, addFinding);
+
+    expect(mockApiHealth.versionedEndpoints).toBe(2);
+    const versionFinding = findings.find(f => f.type === 'MISSING_API_VERSIONING');
+    expect(versionFinding).toBeUndefined();
+  });
+});

--- a/lib/agents/api-sub-agent/domains/documentation-analysis.js
+++ b/lib/agents/api-sub-agent/domains/documentation-analysis.js
@@ -1,0 +1,172 @@
+/**
+ * Documentation Analysis Domain
+ * Handles API documentation validation (OpenAPI/Swagger, README)
+ *
+ * @module api-sub-agent/domains/documentation-analysis
+ */
+
+import fsModule from 'fs';
+const fs = fsModule.promises;
+import path from 'path';
+
+/**
+ * Analyze API documentation quality
+ * @param {string} basePath - Base path to analyze
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Object} thresholds - Quality thresholds
+ * @param {Function} addFinding - Function to add findings
+ */
+export async function analyzeAPIDocumentation(basePath, apiHealth, thresholds, addFinding) {
+  // Check for OpenAPI/Swagger
+  const swaggerFiles = [
+    'swagger.json', 'swagger.yaml', 'swagger.yml',
+    'openapi.json', 'openapi.yaml', 'openapi.yml',
+    'api-docs.json', 'api-docs.yaml'
+  ];
+
+  let hasAPIDoc = false;
+
+  for (const swaggerFile of swaggerFiles) {
+    try {
+      const content = await fs.readFile(path.join(basePath, swaggerFile), 'utf8');
+      hasAPIDoc = true;
+
+      // Validate swagger/openapi
+      if (swaggerFile.endsWith('.json')) {
+        try {
+          const spec = JSON.parse(content);
+          validateOpenAPISpec(spec, swaggerFile, apiHealth, thresholds, addFinding);
+        } catch (error) {
+          addFinding({
+            type: 'INVALID_API_SPECIFICATION',
+            severity: 'high',
+            confidence: 1.0,
+            file: swaggerFile,
+            description: 'API specification has invalid JSON syntax',
+            recommendation: 'Fix JSON syntax errors in API specification',
+            metadata: {
+              error: error.message
+            }
+          });
+        }
+      }
+      break;
+    } catch {
+      // File doesn't exist
+    }
+  }
+
+  if (!hasAPIDoc && apiHealth.totalEndpoints > 0) {
+    addFinding({
+      type: 'MISSING_API_DOCUMENTATION',
+      severity: 'high',
+      confidence: 0.9,
+      file: 'api-docs',
+      description: `${apiHealth.totalEndpoints} API endpoints lack documentation`,
+      recommendation: 'Create OpenAPI/Swagger specification for API',
+      metadata: {
+        endpoints: apiHealth.totalEndpoints,
+        suggestion: 'Use swagger-jsdoc to generate docs from code comments'
+      }
+    });
+  }
+
+  // Check for README API documentation
+  try {
+    const readme = await fs.readFile(path.join(basePath, 'README.md'), 'utf8');
+
+    if (apiHealth.totalEndpoints > 0 && !readme.toLowerCase().includes('api')) {
+      addFinding({
+        type: 'API_NOT_DOCUMENTED_IN_README',
+        severity: 'medium',
+        confidence: 0.8,
+        file: 'README.md',
+        description: 'API endpoints not mentioned in README',
+        recommendation: 'Add API usage examples to README',
+        metadata: {
+          endpoints: apiHealth.totalEndpoints
+        }
+      });
+    }
+  } catch {
+    // No README
+  }
+}
+
+/**
+ * Validate OpenAPI specification
+ * @param {Object} spec - OpenAPI specification object
+ * @param {string} file - File path
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Object} thresholds - Quality thresholds
+ * @param {Function} addFinding - Function to add findings
+ */
+export function validateOpenAPISpec(spec, file, apiHealth, thresholds, addFinding) {
+  // Check required fields
+  if (!spec.openapi && !spec.swagger) {
+    addFinding({
+      type: 'MISSING_API_VERSION',
+      severity: 'high',
+      confidence: 1.0,
+      file,
+      description: 'API specification missing version field',
+      recommendation: 'Add openapi or swagger version field',
+      metadata: {
+        required: 'openapi: "3.0.0" or swagger: "2.0"'
+      }
+    });
+  }
+
+  if (!spec.info) {
+    addFinding({
+      type: 'MISSING_API_INFO',
+      severity: 'medium',
+      confidence: 1.0,
+      file,
+      description: 'API specification missing info section',
+      recommendation: 'Add API title, description, and version in info section',
+      metadata: {
+        required: 'info: { title, description, version }'
+      }
+    });
+  }
+
+  if (!spec.paths || Object.keys(spec.paths).length === 0) {
+    addFinding({
+      type: 'EMPTY_API_SPECIFICATION',
+      severity: 'high',
+      confidence: 1.0,
+      file,
+      description: 'API specification has no endpoints defined',
+      recommendation: 'Add endpoint definitions to paths section',
+      metadata: {
+        actualEndpoints: apiHealth.totalEndpoints
+      }
+    });
+  } else {
+    // Check coverage
+    const specEndpoints = Object.keys(spec.paths).length;
+    const coverage = specEndpoints / apiHealth.totalEndpoints;
+
+    if (coverage < thresholds.documentation) {
+      addFinding({
+        type: 'INCOMPLETE_API_DOCUMENTATION',
+        severity: 'medium',
+        confidence: 0.9,
+        file,
+        description: `Only ${Math.round(coverage * 100)}% of endpoints are documented`,
+        recommendation: 'Document all API endpoints in specification',
+        metadata: {
+          documented: specEndpoints,
+          total: apiHealth.totalEndpoints,
+          coverage: Math.round(coverage * 100)
+        }
+      });
+    }
+  }
+}
+
+export default {
+  analyzeAPIDocumentation,
+  validateOpenAPISpec
+};

--- a/lib/agents/api-sub-agent/domains/endpoint-analysis.js
+++ b/lib/agents/api-sub-agent/domains/endpoint-analysis.js
@@ -1,0 +1,299 @@
+/**
+ * Endpoint Analysis Domain
+ * Handles detection and analysis of API endpoints (REST and GraphQL)
+ *
+ * @module api-sub-agent/domains/endpoint-analysis
+ */
+
+import fsModule from 'fs';
+const fs = fsModule.promises;
+import path from 'path';
+
+/**
+ * Find API files in standard directories
+ * @param {string} basePath - Base path to search
+ * @returns {Promise<string[]>} Array of API file paths
+ */
+export async function findAPIFiles(basePath) {
+  const apiFiles = [];
+  const searchDirs = [
+    'api', 'routes', 'controllers', 'endpoints',
+    'src/api', 'src/routes', 'src/controllers',
+    'pages/api', // Next.js
+    'functions', // Serverless
+    'lambda' // AWS Lambda
+  ];
+
+  for (const dir of searchDirs) {
+    const fullPath = path.join(basePath, dir);
+
+    async function scan(scanDir) {
+      try {
+        const entries = await fs.readdir(scanDir, { withFileTypes: true });
+
+        for (const entry of entries) {
+          const entryPath = path.join(scanDir, entry.name);
+
+          if (entry.isDirectory() && !entry.name.startsWith('.')) {
+            await scan(entryPath);
+          } else if (entry.isFile() &&
+                    (entry.name.endsWith('.js') || entry.name.endsWith('.ts'))) {
+            apiFiles.push(entryPath);
+          }
+        }
+      } catch {
+        // Directory doesn't exist
+      }
+    }
+
+    await scan(fullPath);
+  }
+
+  return apiFiles;
+}
+
+/**
+ * Analyze API endpoints in a base path
+ * @param {string} basePath - Base path to analyze
+ * @param {Object} apiInfo - API framework information
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Function} addFinding - Function to add findings
+ */
+export async function analyzeEndpoints(basePath, apiInfo, apiHealth, addFinding) {
+  const apiFiles = await findAPIFiles(basePath);
+
+  for (const file of apiFiles) {
+    await analyzeAPIFile(file, basePath, apiHealth, addFinding);
+  }
+
+  // Check for common endpoint issues
+  if (apiHealth.totalEndpoints === 0) {
+    addFinding({
+      type: 'NO_API_ENDPOINTS',
+      severity: 'high',
+      confidence: 0.9,
+      file: 'api',
+      description: 'API framework detected but no endpoints found',
+      recommendation: 'Define API endpoints or remove unused framework dependencies',
+      metadata: {
+        framework: apiInfo.framework
+      }
+    });
+  }
+}
+
+/**
+ * Analyze individual API file
+ * @param {string} file - File path
+ * @param {string} basePath - Base path
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Function} addFinding - Function to add findings
+ */
+export async function analyzeAPIFile(file, basePath, apiHealth, addFinding) {
+  try {
+    const content = await fs.readFile(file, 'utf8');
+    const relativePath = path.relative(basePath, file);
+
+    // Find HTTP method definitions
+    const methodRegex = /\.(get|post|put|delete|patch|head|options)\s*\(\s*['"`]([^'"`]+)['"`]\s*,?\s*(?:async\s+)?\(?([^)]*)\)?\s*=>\s*{|app\.(get|post|put|delete|patch|head|options)\s*\(\s*['"`]([^'"`]+)['"`]/gi;
+
+    let match;
+    while ((match = methodRegex.exec(content)) !== null) {
+      const method = (match[1] || match[4]).toUpperCase();
+      const route = match[2] || match[5];
+      const params = match[3] || '';
+
+      apiHealth.totalEndpoints++;
+
+      const endpoint = {
+        method,
+        route,
+        file: relativePath,
+        params,
+        documented: false,
+        authenticated: false,
+        validated: false,
+        errorHandled: false
+      };
+
+      apiHealth.endpoints.push(endpoint);
+
+      // Analyze endpoint quality
+      analyzeEndpoint(endpoint, content, relativePath, addFinding);
+    }
+
+    // Check for GraphQL schemas
+    if (content.includes('GraphQL') || content.includes('gql`') || content.includes('buildSchema')) {
+      analyzeGraphQL(content, relativePath, addFinding);
+    }
+
+  } catch {
+    // File read error - silently ignore
+  }
+}
+
+/**
+ * Analyze individual endpoint for quality issues
+ * @param {Object} endpoint - Endpoint object
+ * @param {string} fileContent - File content
+ * @param {string} file - File path
+ * @param {Function} addFinding - Function to add findings
+ */
+export function analyzeEndpoint(endpoint, fileContent, file, addFinding) {
+  const { method, route } = endpoint;
+
+  // Check for parameter validation
+  const hasValidation = /req\.body\s*&&|joi\.|yup\.|validate|schema/i.test(fileContent);
+  if (!hasValidation && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
+    addFinding({
+      type: 'MISSING_INPUT_VALIDATION',
+      severity: 'high',
+      confidence: 0.9,
+      file,
+      description: `${method} ${route} lacks input validation`,
+      recommendation: 'Add request body validation using Joi, Yup, or similar',
+      metadata: {
+        endpoint: `${method} ${route}`,
+        method,
+        route
+      }
+    });
+  }
+
+  // Check for authentication
+  const hasAuth = /auth|jwt|token|passport|session/i.test(fileContent);
+  if (!hasAuth && !route.includes('public') && !route.includes('health')) {
+    addFinding({
+      type: 'MISSING_AUTHENTICATION',
+      severity: 'high',
+      confidence: 0.8,
+      file,
+      description: `${method} ${route} appears to lack authentication`,
+      recommendation: 'Add authentication middleware for protected endpoints',
+      metadata: {
+        endpoint: `${method} ${route}`
+      }
+    });
+  }
+
+  // Check for error handling
+  const hasErrorHandling = /try\s*{|catch\s*\(|\.catch\s*\(/i.test(fileContent);
+  if (!hasErrorHandling) {
+    addFinding({
+      type: 'MISSING_ERROR_HANDLING',
+      severity: 'medium',
+      confidence: 0.85,
+      file,
+      description: `${method} ${route} lacks error handling`,
+      recommendation: 'Add try-catch blocks or error handling middleware',
+      metadata: {
+        endpoint: `${method} ${route}`
+      }
+    });
+  }
+
+  // Check for SQL injection vulnerabilities
+  if (fileContent.includes('query(') && fileContent.includes('req.body')) {
+    const hasSQLInjection = /query\s*\(\s*['"`].*\$\{.*req\./i.test(fileContent);
+    if (hasSQLInjection) {
+      addFinding({
+        type: 'SQL_INJECTION_RISK',
+        severity: 'critical',
+        confidence: 0.95,
+        file,
+        description: `${method} ${route} vulnerable to SQL injection`,
+        recommendation: 'Use parameterized queries or ORM methods',
+        metadata: {
+          endpoint: `${method} ${route}`
+        }
+      });
+    }
+  }
+
+  // Check for proper HTTP status codes
+  const statusCodeRegex = /res\.status\s*\(\s*(\d+)\s*\)|res\.sendStatus\s*\(\s*(\d+)\s*\)/g;
+  const statusCodes = [];
+  let statusMatch;
+
+  while ((statusMatch = statusCodeRegex.exec(fileContent)) !== null) {
+    statusCodes.push(parseInt(statusMatch[1] || statusMatch[2]));
+  }
+
+  // Check if using appropriate status codes
+  if (method === 'POST' && !statusCodes.includes(201) && statusCodes.length > 0) {
+    addFinding({
+      type: 'INCORRECT_STATUS_CODE',
+      severity: 'low',
+      confidence: 0.7,
+      file,
+      description: `POST ${route} should return 201 for successful creation`,
+      recommendation: 'Use res.status(201) for successful resource creation',
+      metadata: {
+        endpoint: `${method} ${route}`,
+        currentCodes: statusCodes
+      }
+    });
+  }
+
+  // Check for rate limiting
+  const hasRateLimit = /rate.*limit|express-rate-limit|slowdown/i.test(fileContent);
+  if (!hasRateLimit && (method === 'POST' || method === 'PUT')) {
+    addFinding({
+      type: 'MISSING_RATE_LIMITING',
+      severity: 'medium',
+      confidence: 0.8,
+      file,
+      description: `${method} ${route} lacks rate limiting`,
+      recommendation: 'Add rate limiting middleware for write operations',
+      metadata: {
+        endpoint: `${method} ${route}`
+      }
+    });
+  }
+}
+
+/**
+ * Analyze GraphQL schemas and resolvers
+ * @param {string} content - File content
+ * @param {string} file - File path
+ * @param {Function} addFinding - Function to add findings
+ */
+export function analyzeGraphQL(content, file, addFinding) {
+  // Check for GraphQL best practices
+  if (!content.includes('Query') || !content.includes('Mutation')) {
+    addFinding({
+      type: 'INCOMPLETE_GRAPHQL_SCHEMA',
+      severity: 'medium',
+      confidence: 0.8,
+      file,
+      description: 'GraphQL schema missing Query or Mutation types',
+      recommendation: 'Define proper GraphQL schema with Query and Mutation types',
+      metadata: {
+        type: 'GraphQL'
+      }
+    });
+  }
+
+  // Check for N+1 query problems
+  if (content.includes('for') && content.includes('await')) {
+    addFinding({
+      type: 'GRAPHQL_N_PLUS_ONE',
+      severity: 'high',
+      confidence: 0.7,
+      file,
+      description: 'Potential N+1 query problem in GraphQL resolver',
+      recommendation: 'Use DataLoader or batch queries to avoid N+1 problems',
+      metadata: {
+        type: 'GraphQL'
+      }
+    });
+  }
+}
+
+export default {
+  findAPIFiles,
+  analyzeEndpoints,
+  analyzeAPIFile,
+  analyzeEndpoint,
+  analyzeGraphQL
+};

--- a/lib/agents/api-sub-agent/domains/index.js
+++ b/lib/agents/api-sub-agent/domains/index.js
@@ -1,0 +1,40 @@
+/**
+ * API Sub-Agent Domain Exports
+ * Re-exports all domain modules for easy import
+ *
+ * @module api-sub-agent/domains
+ */
+
+// Endpoint Analysis
+export {
+  findAPIFiles,
+  analyzeEndpoints,
+  analyzeAPIFile,
+  analyzeEndpoint,
+  analyzeGraphQL
+} from './endpoint-analysis.js';
+
+// Documentation Analysis
+export {
+  analyzeAPIDocumentation,
+  validateOpenAPISpec
+} from './documentation-analysis.js';
+
+// Structure Analysis
+export {
+  analyzeAPIStructure,
+  analyzeVersioning
+} from './structure-analysis.js';
+
+// Security Analysis
+export {
+  analyzeAPISecurity,
+  analyzeCORS
+} from './security-analysis.js';
+
+// Quality Analysis
+export {
+  analyzeErrorHandling,
+  validateSchemas,
+  checkRateLimiting
+} from './quality-analysis.js';

--- a/lib/agents/api-sub-agent/domains/quality-analysis.js
+++ b/lib/agents/api-sub-agent/domains/quality-analysis.js
@@ -1,0 +1,130 @@
+/**
+ * Quality Analysis Domain
+ * Handles API quality validation (error handling, schemas, rate limiting)
+ *
+ * @module api-sub-agent/domains/quality-analysis
+ */
+
+import fsModule from 'fs';
+const fs = fsModule.promises;
+import path from 'path';
+import { findAPIFiles } from './endpoint-analysis.js';
+
+/**
+ * Analyze error handling across API files
+ * @param {string} basePath - Base path to analyze
+ * @param {Function} addFinding - Function to add findings
+ */
+export async function analyzeErrorHandling(basePath, addFinding) {
+  const apiFiles = await findAPIFiles(basePath);
+  let filesWithoutErrorHandling = 0;
+
+  for (const file of apiFiles) {
+    try {
+      const content = await fs.readFile(file, 'utf8');
+
+      // Check for error handling patterns
+      const hasErrorHandling =
+        content.includes('try') && content.includes('catch') ||
+        content.includes('.catch(') ||
+        content.includes('error') && content.includes('status');
+
+      if (!hasErrorHandling) {
+        filesWithoutErrorHandling++;
+      }
+    } catch {
+      // File read error
+    }
+  }
+
+  if (filesWithoutErrorHandling > 0) {
+    const ratio = filesWithoutErrorHandling / apiFiles.length;
+
+    if (ratio > 0.5) {
+      addFinding({
+        type: 'INADEQUATE_ERROR_HANDLING',
+        severity: 'high',
+        confidence: 0.9,
+        file: 'api',
+        description: `${Math.round(ratio * 100)}% of API files lack error handling`,
+        recommendation: 'Implement comprehensive error handling for all endpoints',
+        metadata: {
+          filesWithoutHandling: filesWithoutErrorHandling,
+          totalFiles: apiFiles.length
+        }
+      });
+    }
+  }
+}
+
+/**
+ * Validate schema validation library usage
+ * @param {string} basePath - Base path to analyze
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Function} addFinding - Function to add findings
+ */
+export async function validateSchemas(basePath, apiHealth, addFinding) {
+  // Look for schema validation libraries
+  try {
+    const pkg = JSON.parse(await fs.readFile(path.join(basePath, 'package.json'), 'utf8'));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+    const validationLibs = ['joi', 'yup', 'ajv', 'express-validator', 'class-validator'];
+    const hasValidation = validationLibs.some(lib => lib in deps);
+
+    if (!hasValidation && apiHealth.totalEndpoints > 0) {
+      addFinding({
+        type: 'MISSING_SCHEMA_VALIDATION',
+        severity: 'high',
+        confidence: 0.8,
+        file: 'package.json',
+        description: 'No schema validation library found',
+        recommendation: 'Add Joi, Yup, or similar for request/response validation',
+        metadata: {
+          suggestions: validationLibs.slice(0, 3)
+        }
+      });
+    }
+  } catch {
+    // Package.json error
+  }
+}
+
+/**
+ * Check rate limiting configuration
+ * @param {string} basePath - Base path to analyze
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Function} addFinding - Function to add findings
+ */
+export async function checkRateLimiting(basePath, apiHealth, addFinding) {
+  try {
+    const pkg = JSON.parse(await fs.readFile(path.join(basePath, 'package.json'), 'utf8'));
+    const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+    const rateLimitLibs = ['express-rate-limit', 'rate-limiter-flexible', 'express-slow-down'];
+    const hasRateLimit = rateLimitLibs.some(lib => lib in deps);
+
+    if (!hasRateLimit && apiHealth.totalEndpoints > 5) {
+      addFinding({
+        type: 'MISSING_RATE_LIMITING',
+        severity: 'medium',
+        confidence: 0.8,
+        file: 'package.json',
+        description: 'No rate limiting configured for API',
+        recommendation: 'Add rate limiting to prevent abuse',
+        metadata: {
+          endpoints: apiHealth.totalEndpoints,
+          suggestions: rateLimitLibs
+        }
+      });
+    }
+  } catch {
+    // Package.json error
+  }
+}
+
+export default {
+  analyzeErrorHandling,
+  validateSchemas,
+  checkRateLimiting
+};

--- a/lib/agents/api-sub-agent/domains/security-analysis.js
+++ b/lib/agents/api-sub-agent/domains/security-analysis.js
@@ -1,0 +1,130 @@
+/**
+ * Security Analysis Domain
+ * Handles API security validation (secrets, CORS, HTTPS)
+ *
+ * @module api-sub-agent/domains/security-analysis
+ */
+
+import fsModule from 'fs';
+const fs = fsModule.promises;
+import path from 'path';
+import { findAPIFiles } from './endpoint-analysis.js';
+
+/**
+ * Analyze API security issues
+ * @param {string} basePath - Base path to analyze
+ * @param {Function} addFinding - Function to add findings
+ */
+export async function analyzeAPISecurity(basePath, addFinding) {
+  const apiFiles = await findAPIFiles(basePath);
+
+  for (const file of apiFiles.slice(0, 10)) { // Sample for performance
+    try {
+      const content = await fs.readFile(file, 'utf8');
+      const relativePath = path.relative(basePath, file);
+
+      // Check for hardcoded secrets
+      if (/api[_-]?key\s*[:=]\s*["'][^"']+["']/i.test(content)) {
+        addFinding({
+          type: 'HARDCODED_API_KEY',
+          severity: 'critical',
+          confidence: 0.9,
+          file: relativePath,
+          description: 'Hardcoded API key found in source code',
+          recommendation: 'Move API keys to environment variables',
+          metadata: {
+            type: 'security'
+          }
+        });
+      }
+
+      // Check for CORS misconfiguration
+      if (content.includes('cors') && content.includes('origin: "*"')) {
+        addFinding({
+          type: 'INSECURE_CORS',
+          severity: 'high',
+          confidence: 0.95,
+          file: relativePath,
+          description: 'CORS configured to allow all origins',
+          recommendation: 'Restrict CORS to specific trusted domains',
+          metadata: {
+            current: 'origin: "*"',
+            suggestion: 'origin: ["https://yourdomain.com"]'
+          }
+        });
+      }
+
+      // Check for missing HTTPS enforcement
+      if (content.includes('http://') && !content.includes('localhost')) {
+        addFinding({
+          type: 'INSECURE_HTTP',
+          severity: 'high',
+          confidence: 0.8,
+          file: relativePath,
+          description: 'Using HTTP instead of HTTPS',
+          recommendation: 'Enforce HTTPS for all API communications',
+          metadata: {
+            protocol: 'HTTP'
+          }
+        });
+      }
+    } catch {
+      // File read error
+    }
+  }
+}
+
+/**
+ * Analyze CORS configuration
+ * @param {string} basePath - Base path to analyze
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Function} addFinding - Function to add findings
+ */
+export async function analyzeCORS(basePath, apiHealth, addFinding) {
+  const apiFiles = await findAPIFiles(basePath);
+  let hasCORS = false;
+
+  for (const file of apiFiles.slice(0, 5)) { // Check sample
+    try {
+      const content = await fs.readFile(file, 'utf8');
+
+      if (content.includes('cors') || content.includes('Access-Control-Allow')) {
+        hasCORS = true;
+        break;
+      }
+    } catch {
+      // File read error
+    }
+  }
+
+  if (!hasCORS && apiHealth.totalEndpoints > 0) {
+    // Check if it's likely a web API that needs CORS
+    try {
+      const pkg = JSON.parse(await fs.readFile(path.join(basePath, 'package.json'), 'utf8'));
+      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+      const needsCORS = 'express' in deps || 'koa' in deps || 'fastify' in deps;
+
+      if (needsCORS) {
+        addFinding({
+          type: 'MISSING_CORS_CONFIGURATION',
+          severity: 'medium',
+          confidence: 0.7,
+          file: 'api',
+          description: 'No CORS configuration found',
+          recommendation: 'Configure CORS for web API access',
+          metadata: {
+            suggestion: 'Install and configure cors middleware'
+          }
+        });
+      }
+    } catch {
+      // Package.json error
+    }
+  }
+}
+
+export default {
+  analyzeAPISecurity,
+  analyzeCORS
+};

--- a/lib/agents/api-sub-agent/domains/structure-analysis.js
+++ b/lib/agents/api-sub-agent/domains/structure-analysis.js
@@ -1,0 +1,108 @@
+/**
+ * Structure Analysis Domain
+ * Handles API structure and RESTful patterns validation
+ *
+ * @module api-sub-agent/domains/structure-analysis
+ */
+
+/**
+ * Analyze API structure for RESTful patterns
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Function} addFinding - Function to add findings
+ */
+export function analyzeAPIStructure(apiHealth, addFinding) {
+  // Check for RESTful patterns
+  const endpoints = apiHealth.endpoints;
+  const routes = endpoints.map(e => e.route);
+
+  // Check for inconsistent naming
+  const hasInconsistentNaming = routes.some(route =>
+    route.includes('_') && routes.some(r => r.includes('-'))
+  );
+
+  if (hasInconsistentNaming) {
+    addFinding({
+      type: 'INCONSISTENT_ROUTE_NAMING',
+      severity: 'low',
+      confidence: 0.8,
+      file: 'api-structure',
+      description: 'API routes use inconsistent naming conventions',
+      recommendation: 'Use consistent naming (either kebab-case or snake_case)',
+      metadata: {
+        examples: routes.filter(r => r.includes('_') || r.includes('-')).slice(0, 3)
+      }
+    });
+  }
+
+  // Check for proper resource naming (plural vs singular)
+  const singularRoutes = routes.filter(route =>
+    /\/\w+\/\d+$/.test(route) && !route.includes('/') // e.g., /user/123
+  );
+
+  if (singularRoutes.length > 0) {
+    addFinding({
+      type: 'NON_RESTFUL_RESOURCE_NAMING',
+      severity: 'low',
+      confidence: 0.7,
+      file: 'api-structure',
+      description: 'Some routes use singular resource names',
+      recommendation: 'Use plural resource names for RESTful APIs (e.g., /users/123)',
+      metadata: {
+        examples: singularRoutes.slice(0, 3)
+      }
+    });
+  }
+
+  // Check for deep nesting
+  const deepRoutes = routes.filter(route =>
+    (route.match(/\//g) || []).length > 4
+  );
+
+  if (deepRoutes.length > 0) {
+    addFinding({
+      type: 'DEEPLY_NESTED_ROUTES',
+      severity: 'medium',
+      confidence: 0.8,
+      file: 'api-structure',
+      description: 'Some routes are deeply nested (>4 levels)',
+      recommendation: 'Consider flattening route structure for better usability',
+      metadata: {
+        examples: deepRoutes.slice(0, 3)
+      }
+    });
+  }
+}
+
+/**
+ * Analyze API versioning strategy
+ * @param {Object} apiHealth - API health tracking object
+ * @param {Function} addFinding - Function to add findings
+ */
+export function analyzeVersioning(apiHealth, addFinding) {
+  const endpoints = apiHealth.endpoints;
+  const versionedRoutes = endpoints.filter(e =>
+    /\/v\d+\/|\/api\/v\d+\/|version.*=/.test(e.route)
+  );
+
+  apiHealth.versionedEndpoints = versionedRoutes.length;
+
+  if (endpoints.length > 5 && versionedRoutes.length === 0) {
+    addFinding({
+      type: 'MISSING_API_VERSIONING',
+      severity: 'high',
+      confidence: 0.9,
+      file: 'api-versioning',
+      description: 'API lacks versioning strategy',
+      recommendation: 'Implement API versioning (URL path or header-based)',
+      metadata: {
+        totalEndpoints: endpoints.length,
+        suggestion: 'Use /api/v1/ prefix or Accept-Version header'
+      }
+    });
+  }
+}
+
+export default {
+  analyzeAPIStructure,
+  analyzeVersioning
+};


### PR DESCRIPTION
## Summary
- Extract 5 domain modules from api-sub-agent.js (875 LOC -> 210 LOC wrapper)
- Create lib/agents/api-sub-agent/domains/ directory structure
- Refactor main file to thin wrapper delegating to domain modules
- Maintain backward compatibility via re-exports
- Add 19 unit tests verifying modular structure

## Domain Modules
- `endpoint-analysis.js` - Endpoint detection and analysis
- `documentation-analysis.js` - OpenAPI/Swagger validation
- `structure-analysis.js` - RESTful patterns and versioning
- `security-analysis.js` - Security checks and CORS
- `quality-analysis.js` - Error handling, schemas, rate limiting

## Test plan
- [x] All 19 new unit tests pass
- [x] Smoke tests pass
- [x] ESLint passes
- [x] Backward compatibility verified (same exports)

Part of SD-LEO-REFAC-API-AGENT-003 (Child of SD-LEO-REFACTOR-LARGE-FILES-003)

🤖 Generated with [Claude Code](https://claude.com/claude-code)