### PR TITLE
fix(SD-LEO-FIX-METADATA-001): implement SD metadata inheritance for child SDs

### DIFF
--- a/scripts/modules/traceability-validation/sections/traceability-mapping.js
+++ b/scripts/modules/traceability-validation/sections/traceability-mapping.js
@@ -73,15 +73,16 @@ export async function validateTraceabilityMapping(sd_id, sdUuid, designAnalysis,
     return;
   }
 
-  // Docs/Infrastructure SDs get full credit
-  if (isDocsSD) {
-    console.log('   OK Docs/Infrastructure SD - Section C simplified (25/25)');
-    console.log('   INFO Traceability via PRD requirements -> documentation/implementation');
+  // Docs/Infrastructure/Lightweight SDs get full credit
+  // SD-LEO-FIX-METADATA-001: Fixed undefined isDocsSD - use isLightweightSD instead
+  if (isLightweightSD) {
+    console.log('   OK Lightweight SD - Section C simplified (25/25)');
+    console.log('   INFO Traceability via PRD requirements -> implementation');
     validation.score += 25;
     validation.gate_scores.traceability_mapping = 25;
     validation.details.traceability_mapping = {
       skipped: true,
-      reason: 'Docs/Infrastructure SD - no design/database requirements to trace'
+      reason: 'Lightweight SD - simplified traceability requirements'
     };
     return;
   }


### PR DESCRIPTION
## Summary
- Add `inheritStrategicFields()` function to inherit parent strategic fields (strategic_objectives, success_metrics, key_principles)
- Update `createChild()` to call `inheritStrategicFields()` when parent exists  
- Update `createSD()` to accept and use inherited fields
- Fix undefined `isDocsSD` bug in traceability-mapping.js (use `isLightweightSD` instead)

## Test plan
- [x] Syntax check passed
- [x] Implementation verified with code inspection
- [x] Smoke tests passed

## Related
Part of SD-LEO-FIX-WORKFLOW-001 orchestrator (fixing LEO Protocol workflow issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)