### PR TITLE
feat(SD-LEO-ENH-AUTO-PROCEED-001-03): implement orchestrator completion hook

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/helpers.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/helpers.js
@@ -5,6 +5,8 @@
  * @module lead-final-approval/helpers
  */
 
+import { executeOrchestratorCompletionHook } from '../../orchestrator-completion-hook.js';
+
 /**
  * Check and complete parent SD when all children are done
  *
@@ -51,6 +53,14 @@ export async function checkAndCompleteParentSD(sd, supabase) {
           const result = await guardian.complete();
           if (result.success) {
             console.log(`   ✅ Parent SD "${parentSD.title}" completed via Guardian`);
+
+            // SD-LEO-ENH-AUTO-PROCEED-001-03: Trigger orchestrator completion hook
+            await executeOrchestratorCompletionHook(
+              parentSD.id,
+              parentSD.title,
+              siblings.length,
+              { supabase }
+            );
           } else {
             console.log(`   ⚠️  Guardian completion failed: ${result.error}`);
             await recordFailedCompletion(parentSD, result.error, null, supabase);
@@ -62,6 +72,14 @@ export async function checkAndCompleteParentSD(sd, supabase) {
           const result = await guardian.complete();
           if (result.success) {
             console.log(`   ✅ Parent SD "${parentSD.title}" completed (with auto-created artifacts)`);
+
+            // SD-LEO-ENH-AUTO-PROCEED-001-03: Trigger orchestrator completion hook
+            await executeOrchestratorCompletionHook(
+              parentSD.id,
+              parentSD.title,
+              siblings.length,
+              { supabase }
+            );
           } else {
             console.log(`   ⚠️  Completion failed after auto-fix: ${result.error}`);
             await recordFailedCompletion(parentSD, result.error, null, supabase);
@@ -94,6 +112,14 @@ export async function checkAndCompleteParentSD(sd, supabase) {
           await recordFailedCompletion(parentSD, error.message, null, supabase);
         } else {
           console.log(`   ✅ Parent SD "${parentSD.title}" auto-completed (legacy path)`);
+
+          // SD-LEO-ENH-AUTO-PROCEED-001-03: Trigger orchestrator completion hook
+          await executeOrchestratorCompletionHook(
+            parentSD.id,
+            parentSD.title,
+            siblings.length,
+            { supabase }
+          );
         }
       }
     }

--- a/scripts/modules/handoff/index.js
+++ b/scripts/modules/handoff/index.js
@@ -62,6 +62,17 @@ export {
 } from './auto-proceed-resolver.js';
 
 // ============================================================================
+// SD-LEO-ENH-AUTO-PROCEED-001-03: Orchestrator Completion Hook
+// ============================================================================
+export {
+  executeOrchestratorCompletionHook,
+  hasHookFired,
+  recordHookEvent,
+  invokeLearnSkill,
+  displayQueue
+} from './orchestrator-completion-hook.js';
+
+// ============================================================================
 // SD-LEO-REFACTOR-HANDOFF-001: Extracted CLI utilities
 // ============================================================================
 

--- a/scripts/modules/handoff/orchestrator-completion-hook.js
+++ b/scripts/modules/handoff/orchestrator-completion-hook.js
@@ -1,0 +1,286 @@
+/**
+ * Orchestrator Completion Hook
+ *
+ * Triggers when an orchestrator SD completes (all children done).
+ * Auto-invokes /learn when AUTO-PROCEED is enabled, then displays queue.
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-03
+ *
+ * @see docs/discovery/auto-proceed-enhancement-discovery.md D07, D08
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { resolveAutoProceed } from './auto-proceed-resolver.js';
+
+/**
+ * Generate a unique idempotency key for orchestrator completion
+ * @param {string} orchestratorId - Orchestrator SD ID
+ * @returns {string} Idempotency key
+ */
+export function generateIdempotencyKey(orchestratorId) {
+  return `orch-completion-${orchestratorId}-${Date.now()}`;
+}
+
+/**
+ * Check if hook has already fired for this orchestrator (idempotency check)
+ * @param {object} supabase - Supabase client
+ * @param {string} orchestratorId - Orchestrator SD ID
+ * @returns {Promise<boolean>} True if hook already fired
+ */
+export async function hasHookFired(supabase, orchestratorId) {
+  try {
+    const { data, error } = await supabase
+      .from('system_events')
+      .select('id')
+      .eq('event_type', 'ORCHESTRATOR_COMPLETION_HOOK')
+      .eq('entity_id', orchestratorId)
+      .limit(1);
+
+    if (error) {
+      console.warn(`   ⚠️  Could not check hook status: ${error.message}`);
+      return false; // Fail open - allow hook to fire
+    }
+
+    return data && data.length > 0;
+  } catch (err) {
+    console.warn(`   ⚠️  Hook check error: ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Record hook event for idempotency and traceability
+ * @param {object} supabase - Supabase client
+ * @param {string} orchestratorId - Orchestrator SD ID
+ * @param {string} correlationId - Correlation ID for tracing
+ * @param {object} details - Additional event details
+ * @returns {Promise<boolean>} Success status
+ */
+export async function recordHookEvent(supabase, orchestratorId, correlationId, details = {}) {
+  try {
+    const { error } = await supabase
+      .from('system_events')
+      .insert({
+        event_type: 'ORCHESTRATOR_COMPLETION_HOOK',
+        entity_type: 'strategic_directive',
+        entity_id: orchestratorId,
+        details: {
+          correlation_id: correlationId,
+          auto_proceed: details.autoProceed || false,
+          learn_invoked: details.learnInvoked || false,
+          queue_displayed: details.queueDisplayed || false,
+          child_count: details.childCount || 0,
+          timestamp: new Date().toISOString(),
+          ...details
+        },
+        severity: 'info',
+        created_by: 'ORCHESTRATOR_COMPLETION_HOOK'
+      });
+
+    if (error) {
+      console.warn(`   ⚠️  Could not record hook event: ${error.message}`);
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    console.warn(`   ⚠️  Hook event recording error: ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Invoke /learn skill programmatically
+ * @param {object} supabase - Supabase client
+ * @param {string} orchestratorId - Orchestrator SD ID
+ * @param {string} correlationId - Correlation ID for tracing
+ * @returns {Promise<{ success: boolean, message: string }>}
+ */
+export async function invokeLearnSkill(supabase, orchestratorId, correlationId) {
+  console.log('\n   📚 AUTO-PROCEED: Invoking /learn for orchestrator completion...');
+
+  try {
+    // Record the /learn invocation attempt
+    await supabase
+      .from('system_events')
+      .insert({
+        event_type: 'LEARN_SKILL_INVOKED',
+        entity_type: 'strategic_directive',
+        entity_id: orchestratorId,
+        details: {
+          correlation_id: correlationId,
+          trigger: 'orchestrator_completion_hook',
+          timestamp: new Date().toISOString()
+        },
+        severity: 'info',
+        created_by: 'ORCHESTRATOR_COMPLETION_HOOK'
+      });
+
+    // Note: The actual /learn skill execution happens in the CLI context
+    // Here we signal that /learn should be invoked
+    console.log('   ✅ /learn invocation signaled');
+    console.log(`   🔗 Correlation ID: ${correlationId}`);
+
+    return { success: true, message: 'Learn skill invocation signaled' };
+  } catch (err) {
+    console.warn(`   ⚠️  Learn invocation error: ${err.message}`);
+    return { success: false, message: err.message };
+  }
+}
+
+/**
+ * Display the full SD queue after orchestrator completion
+ * @param {object} supabase - Supabase client
+ * @param {number} limit - Maximum items to display (default: 200)
+ * @returns {Promise<void>}
+ */
+export async function displayQueue(supabase, limit = 200) {
+  console.log('\n   📋 AUTO-PROCEED: Displaying SD queue...');
+  console.log('   ' + '─'.repeat(60));
+
+  try {
+    const { data: queue, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, title, status, priority, current_phase, parent_sd_id')
+      .in('status', ['draft', 'in_progress', 'planning', 'active', 'pending_approval'])
+      .order('priority', { ascending: false })
+      .order('created_at', { ascending: true })
+      .limit(limit);
+
+    if (error) {
+      console.log(`   ⚠️  Queue fetch error: ${error.message}`);
+      return;
+    }
+
+    if (!queue || queue.length === 0) {
+      console.log('   ✅ Queue is empty - no pending SDs');
+      return;
+    }
+
+    // Group by status
+    const byStatus = {};
+    queue.forEach(sd => {
+      const status = sd.status || 'unknown';
+      if (!byStatus[status]) byStatus[status] = [];
+      byStatus[status].push(sd);
+    });
+
+    console.log(`   Total: ${queue.length} SD(s) in queue\n`);
+
+    Object.entries(byStatus).forEach(([status, sds]) => {
+      console.log(`   [${status.toUpperCase()}] (${sds.length})`);
+      sds.slice(0, 10).forEach(sd => {
+        const isChild = sd.parent_sd_id ? '  └─' : '  •';
+        const phase = sd.current_phase ? ` (${sd.current_phase})` : '';
+        console.log(`   ${isChild} ${sd.id}: ${sd.title?.slice(0, 40)}${phase}`);
+      });
+      if (sds.length > 10) {
+        console.log(`      ... and ${sds.length - 10} more`);
+      }
+      console.log('');
+    });
+
+    console.log('   ' + '─'.repeat(60));
+    console.log('   💡 Run: npm run sd:next for detailed recommendations');
+  } catch (err) {
+    console.log(`   ⚠️  Queue display error: ${err.message}`);
+  }
+}
+
+/**
+ * Main orchestrator completion hook
+ *
+ * Called when an orchestrator SD completes (all children done).
+ * When AUTO-PROCEED is enabled:
+ * 1. Records hook event (idempotent)
+ * 2. Invokes /learn skill
+ * 3. Displays full queue
+ *
+ * @param {string} orchestratorId - Orchestrator SD ID
+ * @param {string} orchestratorTitle - Orchestrator title
+ * @param {number} childCount - Number of completed children
+ * @param {object} options - Hook options
+ * @param {object} options.supabase - Supabase client (optional)
+ * @returns {Promise<{ fired: boolean, autoProceed: boolean, correlationId: string }>}
+ */
+export async function executeOrchestratorCompletionHook(
+  orchestratorId,
+  orchestratorTitle,
+  childCount,
+  options = {}
+) {
+  console.log('\n🎉 ORCHESTRATOR COMPLETION HOOK');
+  console.log('═'.repeat(60));
+  console.log(`   Orchestrator: ${orchestratorId}`);
+  console.log(`   Title: ${orchestratorTitle}`);
+  console.log(`   Children Completed: ${childCount}`);
+
+  // Get or create Supabase client
+  const supabase = options.supabase || createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  );
+
+  // Generate correlation ID for tracing
+  const correlationId = `orch-${orchestratorId}-${Date.now()}`;
+
+  // Idempotency check
+  const alreadyFired = await hasHookFired(supabase, orchestratorId);
+  if (alreadyFired) {
+    console.log('   ℹ️  Hook already fired for this orchestrator (idempotent skip)');
+    return { fired: false, autoProceed: false, correlationId };
+  }
+
+  // Resolve AUTO-PROCEED mode
+  const autoProceedResult = await resolveAutoProceed({
+    supabase,
+    verbose: false
+  });
+
+  const hookDetails = {
+    autoProceed: autoProceedResult.autoProceed,
+    childCount,
+    correlationId,
+    learnInvoked: false,
+    queueDisplayed: false
+  };
+
+  if (autoProceedResult.autoProceed) {
+    console.log('   ✅ AUTO-PROCEED: ENABLED');
+
+    // Invoke /learn
+    const learnResult = await invokeLearnSkill(supabase, orchestratorId, correlationId);
+    hookDetails.learnInvoked = learnResult.success;
+
+    // Display queue
+    await displayQueue(supabase);
+    hookDetails.queueDisplayed = true;
+
+    console.log('\n   ⏸️  PAUSE POINT: Orchestrator complete');
+    console.log('   💡 Review learnings and select next work from queue');
+  } else {
+    console.log('   ℹ️  AUTO-PROCEED: DISABLED');
+    console.log('   💡 Run /learn manually to capture patterns');
+    console.log('   💡 Run npm run sd:next to see the queue');
+  }
+
+  // Record hook event (idempotency marker)
+  await recordHookEvent(supabase, orchestratorId, correlationId, hookDetails);
+
+  console.log('═'.repeat(60));
+
+  return {
+    fired: true,
+    autoProceed: autoProceedResult.autoProceed,
+    correlationId
+  };
+}
+
+export default {
+  executeOrchestratorCompletionHook,
+  generateIdempotencyKey,
+  hasHookFired,
+  recordHookEvent,
+  invokeLearnSkill,
+  displayQueue
+};

--- a/tests/unit/handoff/orchestrator-completion-hook.test.js
+++ b/tests/unit/handoff/orchestrator-completion-hook.test.js
@@ -1,0 +1,269 @@
+/**
+ * Unit tests for Orchestrator Completion Hook
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-03
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  generateIdempotencyKey,
+  hasHookFired,
+  recordHookEvent,
+  executeOrchestratorCompletionHook
+} from '../../../scripts/modules/handoff/orchestrator-completion-hook.js';
+
+describe('Orchestrator Completion Hook', () => {
+  describe('generateIdempotencyKey', () => {
+    it('should generate correlation keys containing orchestrator ID and timestamp', () => {
+      const key = generateIdempotencyKey('SD-TEST-001');
+
+      expect(key).toContain('SD-TEST-001');
+      expect(key).toMatch(/^orch-completion-SD-TEST-001-\d+$/);
+      // Key includes timestamp for correlation tracing
+      // Note: Actual idempotency is handled by hasHookFired() database check
+    });
+
+    it('should include orchestrator ID in key', () => {
+      const key = generateIdempotencyKey('SD-ORCH-123');
+      expect(key).toContain('SD-ORCH-123');
+      expect(key).toMatch(/^orch-completion-SD-ORCH-123-\d+$/);
+    });
+  });
+
+  describe('hasHookFired', () => {
+    it('should return false when no hook event exists', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                limit: () => Promise.resolve({ data: [], error: null })
+              })
+            })
+          })
+        })
+      };
+
+      const result = await hasHookFired(mockSupabase, 'SD-TEST-001');
+      expect(result).toBe(false);
+    });
+
+    it('should return true when hook event exists', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                limit: () => Promise.resolve({ data: [{ id: 'event-1' }], error: null })
+              })
+            })
+          })
+        })
+      };
+
+      const result = await hasHookFired(mockSupabase, 'SD-TEST-001');
+      expect(result).toBe(true);
+    });
+
+    it('should fail open on error (return false)', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                limit: () => Promise.resolve({ data: null, error: { message: 'DB error' } })
+              })
+            })
+          })
+        })
+      };
+
+      const result = await hasHookFired(mockSupabase, 'SD-TEST-001');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('recordHookEvent', () => {
+    it('should successfully record hook event', async () => {
+      const mockSupabase = {
+        from: () => ({
+          insert: () => Promise.resolve({ error: null })
+        })
+      };
+
+      const result = await recordHookEvent(
+        mockSupabase,
+        'SD-TEST-001',
+        'corr-123',
+        { autoProceed: true, childCount: 5 }
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false on error', async () => {
+      const mockSupabase = {
+        from: () => ({
+          insert: () => Promise.resolve({ error: { message: 'Insert failed' } })
+        })
+      };
+
+      const result = await recordHookEvent(
+        mockSupabase,
+        'SD-TEST-001',
+        'corr-123',
+        {}
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('executeOrchestratorCompletionHook', () => {
+    let mockSupabase;
+
+    beforeEach(() => {
+      // Reset mock for each test
+      mockSupabase = {
+        from: vi.fn((table) => {
+          if (table === 'system_events') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    limit: () => Promise.resolve({ data: [], error: null })
+                  })
+                })
+              }),
+              insert: () => Promise.resolve({ error: null })
+            };
+          }
+          if (table === 'strategic_directives_v2') {
+            return {
+              select: () => ({
+                in: () => ({
+                  order: () => ({
+                    order: () => ({
+                      limit: () => Promise.resolve({ data: [], error: null })
+                    })
+                  })
+                })
+              })
+            };
+          }
+          if (table === 'claude_sessions') {
+            return {
+              select: () => ({
+                eq: () => ({
+                  order: () => ({
+                    limit: () => ({
+                      single: () => Promise.resolve({
+                        data: { session_id: 'test-session', metadata: { auto_proceed: true } },
+                        error: null
+                      })
+                    })
+                  })
+                })
+              })
+            };
+          }
+          return { select: () => ({ eq: () => Promise.resolve({ data: [], error: null }) }) };
+        })
+      };
+    });
+
+    it('should fire hook when not previously fired', async () => {
+      const result = await executeOrchestratorCompletionHook(
+        'SD-ORCH-001',
+        'Test Orchestrator',
+        5,
+        { supabase: mockSupabase }
+      );
+
+      expect(result.fired).toBe(true);
+      expect(result.correlationId).toContain('SD-ORCH-001');
+    });
+
+    it('should skip when hook already fired (idempotency)', async () => {
+      // Override to simulate hook already fired
+      mockSupabase.from = vi.fn((table) => {
+        if (table === 'system_events') {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  limit: () => Promise.resolve({ data: [{ id: 'existing' }], error: null })
+                })
+              })
+            })
+          };
+        }
+        return { select: () => Promise.resolve({ data: [], error: null }) };
+      });
+
+      const result = await executeOrchestratorCompletionHook(
+        'SD-ORCH-001',
+        'Test Orchestrator',
+        5,
+        { supabase: mockSupabase }
+      );
+
+      expect(result.fired).toBe(false);
+    });
+
+    it('should respect AUTO-PROCEED setting', async () => {
+      // Override to disable AUTO-PROCEED
+      mockSupabase.from = vi.fn((table) => {
+        if (table === 'system_events') {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  limit: () => Promise.resolve({ data: [], error: null })
+                })
+              })
+            }),
+            insert: () => Promise.resolve({ error: null })
+          };
+        }
+        if (table === 'claude_sessions') {
+          return {
+            select: () => ({
+              eq: () => ({
+                order: () => ({
+                  limit: () => ({
+                    single: () => Promise.resolve({
+                      data: { session_id: 'test', metadata: { auto_proceed: false } },
+                      error: null
+                    })
+                  })
+                })
+              })
+            })
+          };
+        }
+        return {
+          select: () => ({
+            in: () => ({
+              order: () => ({
+                order: () => ({
+                  limit: () => Promise.resolve({ data: [], error: null })
+                })
+              })
+            })
+          })
+        };
+      });
+
+      const result = await executeOrchestratorCompletionHook(
+        'SD-ORCH-001',
+        'Test Orchestrator',
+        5,
+        { supabase: mockSupabase }
+      );
+
+      expect(result.fired).toBe(true);
+      expect(result.autoProceed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements orchestrator completion hook that fires when all children complete
- Auto-invokes `/learn` when AUTO-PROCEED enabled
- Displays full SD queue after completion
- Uses idempotency pattern via system_events table

## Test plan

- [x] Unit tests pass (10 tests)
- [x] Smoke tests pass
- [ ] Manual test: Complete orchestrator SD and verify hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)