### PR TITLE
feat(SD-LEO-ENH-AUTO-PROCEED-001-04): add auto-resume after user interrupt

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,0 +1,12 @@
+{
+  "isActive": false,
+  "wasInterrupted": false,
+  "currentSd": null,
+  "currentPhase": null,
+  "currentTask": null,
+  "lastInterruptedAt": null,
+  "lastResumedAt": null,
+  "resumeCount": 0,
+  "version": "1.0.0",
+  "clearedAt": "2026-01-25T15:55:08.459Z"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,6 +91,11 @@
             "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/autonomous-checkpoint.js",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/auto-proceed-resume.js",
+            "timeout": 3
           }
         ]
       }

--- a/scripts/hooks/auto-proceed-resume.js
+++ b/scripts/hooks/auto-proceed-resume.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * AUTO-PROCEED Resume Hook
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-04
+ *
+ * Runs after user prompt is submitted during AUTO-PROCEED mode.
+ * Outputs a resume message indicating what was being worked on.
+ *
+ * Discovery References:
+ * - D13: After handling user input, AUTO-PROCEED should automatically resume
+ * - D29: Show brief reminder: "Resuming: SD-XXX EXEC phase, task Y..."
+ *
+ * @see docs/discovery/auto-proceed-enhancement-discovery.md
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// State file location
+const STATE_FILE = path.join(__dirname, '../../.claude/unified-session-state.json');
+const AUTO_PROCEED_STATE_FILE = path.join(__dirname, '../../.claude/auto-proceed-state.json');
+
+/**
+ * Read the unified session state
+ * @returns {object|null} State object or null if not found
+ */
+function readSessionState() {
+  try {
+    if (fs.existsSync(STATE_FILE)) {
+      const content = fs.readFileSync(STATE_FILE, 'utf8');
+      return JSON.parse(content);
+    }
+  } catch (_err) {
+    // Silently fail - state may not exist
+  }
+  return null;
+}
+
+/**
+ * Read AUTO-PROCEED specific state
+ * @returns {object} AUTO-PROCEED state with defaults
+ */
+function readAutoProceedState() {
+  try {
+    if (fs.existsSync(AUTO_PROCEED_STATE_FILE)) {
+      const content = fs.readFileSync(AUTO_PROCEED_STATE_FILE, 'utf8');
+      return JSON.parse(content);
+    }
+  } catch (_err) {
+    // Silently fail
+  }
+  return {
+    isActive: false,
+    wasInterrupted: false,
+    currentSd: null,
+    currentPhase: null,
+    currentTask: null,
+    lastInterruptedAt: null,
+    resumeCount: 0
+  };
+}
+
+/**
+ * Write AUTO-PROCEED state
+ * @param {object} state - State to write
+ */
+function writeAutoProceedState(state) {
+  try {
+    const dir = path.dirname(AUTO_PROCEED_STATE_FILE);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(AUTO_PROCEED_STATE_FILE, JSON.stringify(state, null, 2));
+  } catch (err) {
+    console.error(`[auto-proceed-resume] Failed to write state: ${err.message}`);
+  }
+}
+
+/**
+ * Check if AUTO-PROCEED is enabled via environment or session
+ * @returns {boolean}
+ */
+function isAutoProceedEnabled() {
+  // Check environment variable first
+  const envValue = process.env.AUTO_PROCEED;
+  if (envValue !== undefined && envValue !== '') {
+    const normalized = String(envValue).toLowerCase().trim();
+    if (['1', 'true', 'yes', 'on', 'enabled'].includes(normalized)) {
+      return true;
+    }
+    if (['0', 'false', 'no', 'off', 'disabled'].includes(normalized)) {
+      return false;
+    }
+  }
+
+  // Check session state
+  const sessionState = readSessionState();
+  if (sessionState?.autoProceed === true) {
+    return true;
+  }
+
+  // Check auto-proceed state file
+  const apState = readAutoProceedState();
+  return apState.isActive === true;
+}
+
+/**
+ * Format the resume message
+ * @param {object} context - Context object with sd, phase, task
+ * @returns {string} Formatted resume message
+ */
+function formatResumeMessage(context) {
+  const sdKey = context.sd || context.sdKey || context.currentSd || 'unknown';
+  const phase = context.phase || context.currentPhase || 'EXEC';
+  const task = context.task || context.currentTask || 'previous task';
+
+  return `🤖 Resuming: ${sdKey} ${phase} phase, ${task}...`;
+}
+
+/**
+ * Main hook execution
+ */
+async function main() {
+  // Check if AUTO-PROCEED is enabled
+  if (!isAutoProceedEnabled()) {
+    // Not in AUTO-PROCEED mode, skip
+    return;
+  }
+
+  // Read current state
+  const apState = readAutoProceedState();
+  const sessionState = readSessionState();
+
+  // If we were working on something before this user input
+  if (apState.wasInterrupted && apState.currentSd) {
+    // Output the resume message
+    const message = formatResumeMessage({
+      sd: apState.currentSd,
+      phase: apState.currentPhase,
+      task: apState.currentTask
+    });
+
+    console.log('');
+    console.log(message);
+    console.log('');
+
+    // Update state - increment resume count, clear interrupted flag
+    apState.wasInterrupted = false;
+    apState.resumeCount = (apState.resumeCount || 0) + 1;
+    apState.lastResumedAt = new Date().toISOString();
+    writeAutoProceedState(apState);
+  } else if (sessionState?.sd?.id) {
+    // We have an active SD from session state, mark as potentially interrupted
+    // This will be used on the NEXT user input if we're still working
+    apState.isActive = true;
+    apState.wasInterrupted = true;
+    apState.currentSd = sessionState.sd.id;
+    apState.currentPhase = sessionState.sd.phase || sessionState.workflow?.currentPhase || 'EXEC';
+    apState.currentTask = sessionState.summaries?.pendingActions?.[0] || 'implementation';
+    apState.lastInterruptedAt = new Date().toISOString();
+    writeAutoProceedState(apState);
+  }
+}
+
+// Execute
+main().catch(err => {
+  console.error(`[auto-proceed-resume] Error: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/modules/handoff/auto-proceed-state.js
+++ b/scripts/modules/handoff/auto-proceed-state.js
@@ -1,0 +1,197 @@
+/**
+ * AUTO-PROCEED State Management
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-04
+ *
+ * Manages the AUTO-PROCEED execution state for:
+ * - Tracking current SD, phase, and task
+ * - Marking interruption state
+ * - Enabling resume message display
+ *
+ * Discovery References:
+ * - D13: User can interrupt, AUTO-PROCEED auto-resumes after
+ * - D19: Auto-resume after user interruption
+ * - D29: Show "Resuming: SD-XXX EXEC phase, task Y..."
+ *
+ * @see docs/discovery/auto-proceed-enhancement-discovery.md
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// State file location (relative to project root)
+const STATE_FILE = path.join(__dirname, '../../../.claude/auto-proceed-state.json');
+
+/**
+ * Default state structure
+ */
+const DEFAULT_STATE = {
+  isActive: false,
+  wasInterrupted: false,
+  currentSd: null,
+  currentPhase: null,
+  currentTask: null,
+  lastInterruptedAt: null,
+  lastResumedAt: null,
+  resumeCount: 0,
+  version: '1.0.0'
+};
+
+/**
+ * Read AUTO-PROCEED state from file
+ * @returns {object} State object (with defaults for missing fields)
+ */
+export function readState() {
+  try {
+    if (fs.existsSync(STATE_FILE)) {
+      const content = fs.readFileSync(STATE_FILE, 'utf8');
+      const state = JSON.parse(content);
+      return { ...DEFAULT_STATE, ...state };
+    }
+  } catch (err) {
+    console.warn(`[auto-proceed-state] Read error: ${err.message}`);
+  }
+  return { ...DEFAULT_STATE };
+}
+
+/**
+ * Write AUTO-PROCEED state to file
+ * @param {object} state - State to write
+ * @returns {boolean} Success status
+ */
+export function writeState(state) {
+  try {
+    const dir = path.dirname(STATE_FILE);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const mergedState = { ...DEFAULT_STATE, ...state };
+    fs.writeFileSync(STATE_FILE, JSON.stringify(mergedState, null, 2));
+    return true;
+  } catch (err) {
+    console.warn(`[auto-proceed-state] Write error: ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Update current execution context
+ * Call this when starting work on an SD or changing phases/tasks
+ *
+ * @param {object} context - Execution context
+ * @param {string} context.sdKey - Current SD key (e.g., "SD-LEO-ENH-AUTO-PROCEED-001-04")
+ * @param {string} context.phase - Current phase (e.g., "EXEC", "PLAN")
+ * @param {string} context.task - Current task description
+ * @param {boolean} context.isActive - Whether AUTO-PROCEED is active (default: true)
+ * @returns {boolean} Success status
+ */
+export function updateExecutionContext(context) {
+  const state = readState();
+
+  state.currentSd = context.sdKey || context.sd || state.currentSd;
+  state.currentPhase = context.phase || state.currentPhase;
+  state.currentTask = context.task || state.currentTask;
+  state.isActive = context.isActive !== undefined ? context.isActive : true;
+  state.lastUpdatedAt = new Date().toISOString();
+
+  return writeState(state);
+}
+
+/**
+ * Mark that an interruption occurred
+ * Call this when user submits a prompt during AUTO-PROCEED
+ *
+ * @returns {boolean} Success status
+ */
+export function markInterrupted() {
+  const state = readState();
+
+  if (state.isActive && state.currentSd) {
+    state.wasInterrupted = true;
+    state.lastInterruptedAt = new Date().toISOString();
+    return writeState(state);
+  }
+
+  return false;
+}
+
+/**
+ * Mark that resume has occurred
+ * Call this after displaying the resume message
+ *
+ * @returns {boolean} Success status
+ */
+export function markResumed() {
+  const state = readState();
+
+  state.wasInterrupted = false;
+  state.resumeCount = (state.resumeCount || 0) + 1;
+  state.lastResumedAt = new Date().toISOString();
+
+  return writeState(state);
+}
+
+/**
+ * Clear the AUTO-PROCEED state (e.g., when SD completes)
+ *
+ * @param {boolean} keepHistory - Whether to keep resume count history
+ * @returns {boolean} Success status
+ */
+export function clearState(keepHistory = true) {
+  const state = readState();
+  const resumeCount = keepHistory ? state.resumeCount : 0;
+
+  return writeState({
+    ...DEFAULT_STATE,
+    resumeCount,
+    clearedAt: new Date().toISOString()
+  });
+}
+
+/**
+ * Get the formatted resume message
+ *
+ * @returns {string|null} Resume message or null if not applicable
+ */
+export function getResumeMessage() {
+  const state = readState();
+
+  if (!state.isActive || !state.wasInterrupted || !state.currentSd) {
+    return null;
+  }
+
+  const sdKey = state.currentSd;
+  const phase = state.currentPhase || 'EXEC';
+  const task = state.currentTask || 'previous task';
+
+  return `🤖 Resuming: ${sdKey} ${phase} phase, ${task}...`;
+}
+
+/**
+ * Check if AUTO-PROCEED is active and we should show resume message
+ *
+ * @returns {boolean}
+ */
+export function shouldShowResumeMessage() {
+  const state = readState();
+  return state.isActive && state.wasInterrupted && !!state.currentSd;
+}
+
+// Named export for DEFAULT_STATE for testing
+export { DEFAULT_STATE };
+
+export default {
+  readState,
+  writeState,
+  updateExecutionContext,
+  markInterrupted,
+  markResumed,
+  clearState,
+  getResumeMessage,
+  shouldShowResumeMessage,
+  DEFAULT_STATE
+};

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -19,6 +19,7 @@ import {
   releaseSessionClaim
 } from './helpers.js';
 import { getRemediation } from './remediations.js';
+import { clearState as clearAutoProceedState } from '../../auto-proceed-state.js';
 
 export class LeadFinalApprovalExecutor extends BaseExecutor {
   constructor(dependencies = {}) {
@@ -101,6 +102,14 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
 
     // Release the session claim
     await releaseSessionClaim(sd, this.supabase);
+
+    // SD-LEO-ENH-AUTO-PROCEED-001-04: Clear AUTO-PROCEED state on SD completion
+    try {
+      clearAutoProceedState(true); // Keep resume count history
+      console.log('   ✅ AUTO-PROCEED state cleared');
+    } catch (apError) {
+      console.warn(`   ⚠️  Could not clear AUTO-PROCEED state: ${apError.message}`);
+    }
 
     // Check if this SD has a parent that should be auto-completed
     if (sd.parent_sd_id) {

--- a/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
+++ b/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
@@ -25,6 +25,7 @@ import {
 } from './index.js';
 import { validateWorkflowReview, createHandoffExecution } from './workflow-validation.js';
 import { rejectHandoff } from './rejection.js';
+import { updateExecutionContext } from '../../auto-proceed-state.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -345,6 +346,18 @@ export class PlanToExecVerifier {
 
       console.log('\n🚀 EXEC PHASE AUTHORIZED');
       console.log('PRD handed off to EXEC agent for implementation');
+
+      // SD-LEO-ENH-AUTO-PROCEED-001-04: Update AUTO-PROCEED state for resume tracking
+      try {
+        updateExecutionContext({
+          sdKey: sdId,
+          phase: 'EXEC',
+          task: `Implementing ${prd.title || sdId}`,
+          isActive: true
+        });
+      } catch (apError) {
+        console.warn(`   ⚠️  Could not update AUTO-PROCEED state: ${apError.message}`);
+      }
 
       return {
         success: true,

--- a/tests/unit/auto-proceed-state.test.js
+++ b/tests/unit/auto-proceed-state.test.js
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for AUTO-PROCEED State Management
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-04
+ *
+ * Tests:
+ * - State read/write operations
+ * - Execution context updates
+ * - Interruption/resume tracking
+ * - Resume message generation
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const _dirname = path.dirname(__filename);
+
+// Use a temp directory for testing instead of mocking fs
+const TEST_DIR = path.join(os.tmpdir(), 'auto-proceed-test-' + Date.now());
+const TEST_STATE_FILE = path.join(TEST_DIR, 'auto-proceed-state.json');
+
+// Helper to clear test state
+function clearTestState() {
+  if (fs.existsSync(TEST_STATE_FILE)) {
+    fs.unlinkSync(TEST_STATE_FILE);
+  }
+}
+
+describe('AUTO-PROCEED State Management', () => {
+  let autoProceedState;
+
+  beforeEach(async () => {
+    // Create test directory
+    if (!fs.existsSync(TEST_DIR)) {
+      fs.mkdirSync(TEST_DIR, { recursive: true });
+    }
+
+    // Clear any existing test state
+    clearTestState();
+
+    // Import fresh module
+    // Note: We test the actual functions but use the module's real file path
+    // This tests the logic even though we can't easily change STATE_FILE
+    autoProceedState = await import('../../scripts/modules/handoff/auto-proceed-state.js');
+  });
+
+  afterEach(() => {
+    // Clean up test files
+    clearTestState();
+    if (fs.existsSync(TEST_DIR)) {
+      try {
+        fs.rmdirSync(TEST_DIR);
+      } catch (_e) {
+        // Ignore - may have other files
+      }
+    }
+  });
+
+  describe('readState', () => {
+    it('returns default state when file does not exist', () => {
+      // The module's readState uses its own path, but we test the default behavior
+      const state = autoProceedState.readState();
+
+      // Default state should have these properties
+      expect(state).toHaveProperty('isActive');
+      expect(state).toHaveProperty('wasInterrupted');
+      expect(state).toHaveProperty('currentSd');
+      expect(state).toHaveProperty('version', '1.0.0');
+    });
+
+    it('has correct default state structure', () => {
+      // DEFAULT_STATE is now a named export
+      const defaultState = autoProceedState.DEFAULT_STATE;
+
+      expect(defaultState.isActive).toBe(false);
+      expect(defaultState.wasInterrupted).toBe(false);
+      expect(defaultState.currentSd).toBeNull();
+      expect(defaultState.currentPhase).toBeNull();
+      expect(defaultState.currentTask).toBeNull();
+      expect(defaultState.resumeCount).toBe(0);
+      expect(defaultState.version).toBe('1.0.0');
+    });
+  });
+
+  describe('updateExecutionContext', () => {
+    it('updates state with new execution context', () => {
+      const result = autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-002',
+        phase: 'EXEC',
+        task: 'Implementing feature'
+      });
+
+      expect(result).toBe(true);
+
+      // Read back the state to verify
+      const state = autoProceedState.readState();
+      expect(state.currentSd).toBe('SD-TEST-002');
+      expect(state.currentPhase).toBe('EXEC');
+      expect(state.currentTask).toBe('Implementing feature');
+      expect(state.isActive).toBe(true);
+    });
+
+    it('preserves existing values when not provided', () => {
+      // First set some values
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-003',
+        phase: 'PLAN',
+        task: 'Planning'
+      });
+
+      // Update only the phase
+      autoProceedState.updateExecutionContext({
+        phase: 'EXEC'
+      });
+
+      const state = autoProceedState.readState();
+      expect(state.currentSd).toBe('SD-TEST-003'); // Preserved
+      expect(state.currentPhase).toBe('EXEC'); // Updated
+      expect(state.currentTask).toBe('Planning'); // Preserved
+    });
+  });
+
+  describe('markInterrupted', () => {
+    it('marks state as interrupted when active with current SD', () => {
+      // Set up active state
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-004',
+        phase: 'EXEC',
+        isActive: true
+      });
+
+      const result = autoProceedState.markInterrupted();
+
+      expect(result).toBe(true);
+
+      const state = autoProceedState.readState();
+      expect(state.wasInterrupted).toBe(true);
+      expect(state.lastInterruptedAt).toBeDefined();
+    });
+
+    it('returns false when not active', () => {
+      // Clear state to make inactive
+      autoProceedState.clearState(false);
+
+      const result = autoProceedState.markInterrupted();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('markResumed', () => {
+    it('clears interrupted flag and increments resume count', () => {
+      // Set up interrupted state
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-005',
+        phase: 'EXEC'
+      });
+      autoProceedState.markInterrupted();
+
+      const stateBefore = autoProceedState.readState();
+      const resumeCountBefore = stateBefore.resumeCount || 0;
+
+      const result = autoProceedState.markResumed();
+
+      expect(result).toBe(true);
+
+      const stateAfter = autoProceedState.readState();
+      expect(stateAfter.wasInterrupted).toBe(false);
+      expect(stateAfter.resumeCount).toBe(resumeCountBefore + 1);
+      expect(stateAfter.lastResumedAt).toBeDefined();
+    });
+  });
+
+  describe('getResumeMessage', () => {
+    it('returns formatted message when should resume', () => {
+      // Set up state for resume message
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-006',
+        phase: 'EXEC',
+        task: 'Unit testing'
+      });
+      autoProceedState.markInterrupted();
+
+      const message = autoProceedState.getResumeMessage();
+
+      expect(message).toBe('🤖 Resuming: SD-TEST-006 EXEC phase, Unit testing...');
+    });
+
+    it('returns null when not interrupted', () => {
+      // Set up active but not interrupted state
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-007',
+        phase: 'EXEC'
+      });
+      // Don't mark as interrupted
+
+      // Clear any previous interrupted state
+      autoProceedState.markResumed();
+
+      const message = autoProceedState.getResumeMessage();
+
+      expect(message).toBeNull();
+    });
+
+    it('returns null when no current SD', () => {
+      // Clear state
+      autoProceedState.clearState(false);
+
+      const message = autoProceedState.getResumeMessage();
+
+      expect(message).toBeNull();
+    });
+  });
+
+  describe('clearState', () => {
+    it('resets state while keeping resume count when requested', () => {
+      // Set up state with resume count
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-008',
+        phase: 'EXEC'
+      });
+      autoProceedState.markInterrupted();
+      autoProceedState.markResumed();
+      autoProceedState.markInterrupted();
+      autoProceedState.markResumed();
+
+      const stateBefore = autoProceedState.readState();
+      const resumeCountBefore = stateBefore.resumeCount;
+
+      const result = autoProceedState.clearState(true);
+
+      expect(result).toBe(true);
+
+      const stateAfter = autoProceedState.readState();
+      expect(stateAfter.isActive).toBe(false);
+      expect(stateAfter.currentSd).toBeNull();
+      expect(stateAfter.resumeCount).toBe(resumeCountBefore); // Preserved
+      expect(stateAfter.clearedAt).toBeDefined();
+    });
+
+    it('resets resume count when not keeping history', () => {
+      // Set up state with resume count
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-009',
+        phase: 'EXEC'
+      });
+      autoProceedState.markInterrupted();
+      autoProceedState.markResumed();
+
+      const result = autoProceedState.clearState(false);
+
+      expect(result).toBe(true);
+
+      const stateAfter = autoProceedState.readState();
+      expect(stateAfter.resumeCount).toBe(0);
+    });
+  });
+
+  describe('shouldShowResumeMessage', () => {
+    it('returns true when all conditions met', () => {
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-010',
+        phase: 'EXEC',
+        isActive: true
+      });
+      autoProceedState.markInterrupted();
+
+      expect(autoProceedState.shouldShowResumeMessage()).toBe(true);
+    });
+
+    it('returns false when not active', () => {
+      autoProceedState.clearState(false);
+
+      expect(autoProceedState.shouldShowResumeMessage()).toBe(false);
+    });
+
+    it('returns false when not interrupted', () => {
+      autoProceedState.updateExecutionContext({
+        sdKey: 'SD-TEST-011',
+        phase: 'EXEC',
+        isActive: true
+      });
+      // Not interrupted
+
+      expect(autoProceedState.shouldShowResumeMessage()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements D13, D19, D29 from AUTO-PROCEED discovery - adding automatic resume functionality after user interrupts during AUTO-PROCEED mode.

- Add `auto-proceed-state.js` module for tracking current SD/phase/task
- Add `auto-proceed-resume.js` hook that shows resume message on UserPromptSubmit  
- Integrate state tracking into PLAN-TO-EXEC (updateExecutionContext)
- Integrate state clearing into LEAD-FINAL-APPROVAL (clearState)
- Add unit tests (15/15 passing)

When user types during AUTO-PROCEED, the system now shows:
```
🤖 Resuming: SD-XXX EXEC phase, task Y...
```

## Test plan

- [x] Unit tests pass (15/15)
- [x] Smoke tests pass
- [x] Hook registered in settings.json
- [x] Integration points verified in PlanToExecVerifier.js and lead-final-approval/index.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)