### PR TITLE
feat(SD-LEO-ENH-AUTO-PROCEED-001-05): implement configurable orchestrator chaining

### DIFF
--- a/tests/unit/handoff/orchestrator-completion-hook.test.js
+++ b/tests/unit/handoff/orchestrator-completion-hook.test.js
@@ -9,7 +9,9 @@ import {
   generateIdempotencyKey,
   hasHookFired,
   recordHookEvent,
-  executeOrchestratorCompletionHook
+  executeOrchestratorCompletionHook,
+  findNextAvailableOrchestrator,
+  emitChainingTelemetry
 } from '../../../scripts/modules/handoff/orchestrator-completion-hook.js';
 
 describe('Orchestrator Completion Hook', () => {
@@ -264,6 +266,345 @@ describe('Orchestrator Completion Hook', () => {
 
       expect(result.fired).toBe(true);
       expect(result.autoProceed).toBe(false);
+    });
+
+    // SD-LEO-ENH-AUTO-PROCEED-001-05: Orchestrator Chaining Tests
+    it('should return chainContinue when chaining enabled and orchestrator available', async () => {
+      // Override to enable chaining and provide next orchestrator
+      mockSupabase.from = (table) => {
+        if (table === 'system_events') {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  limit: () => Promise.resolve({ data: [], error: null })
+                })
+              })
+            }),
+            insert: () => Promise.resolve({ error: null })
+          };
+        }
+        if (table === 'claude_sessions') {
+          return {
+            select: () => ({
+              eq: () => ({
+                order: () => ({
+                  limit: () => ({
+                    single: () => Promise.resolve({
+                      data: {
+                        session_id: 'test',
+                        metadata: { auto_proceed: true, chain_orchestrators: true }
+                      },
+                      error: null
+                    })
+                  })
+                })
+              })
+            })
+          };
+        }
+        if (table === 'strategic_directives_v2') {
+          return {
+            select: () => ({
+              in: () => ({
+                is: () => ({
+                  order: () => ({
+                    order: () => ({
+                      limit: () => ({
+                        neq: () => Promise.resolve({
+                          data: [{ id: 'SD-NEXT-001', sd_key: 'SD-NEXT-001', title: 'Next Orchestrator' }],
+                          error: null
+                        })
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          };
+        }
+        return { select: () => Promise.resolve({ data: [], error: null }) };
+      };
+
+      const result = await executeOrchestratorCompletionHook(
+        'SD-ORCH-001',
+        'Completed Orchestrator',
+        5,
+        { supabase: mockSupabase }
+      );
+
+      expect(result.fired).toBe(true);
+      expect(result.autoProceed).toBe(true);
+      expect(result.chainContinue).toBe(true);
+      expect(result.nextOrchestrator).toBe('SD-NEXT-001');
+    });
+
+    it('should not chain when chaining disabled', async () => {
+      // Override to disable chaining
+      mockSupabase.from = (table) => {
+        if (table === 'system_events') {
+          return {
+            select: () => ({
+              eq: () => ({
+                eq: () => ({
+                  limit: () => Promise.resolve({ data: [], error: null })
+                })
+              })
+            }),
+            insert: () => Promise.resolve({ error: null })
+          };
+        }
+        if (table === 'claude_sessions') {
+          return {
+            select: () => ({
+              eq: () => ({
+                order: () => ({
+                  limit: () => ({
+                    single: () => Promise.resolve({
+                      data: {
+                        session_id: 'test',
+                        metadata: { auto_proceed: true, chain_orchestrators: false }
+                      },
+                      error: null
+                    })
+                  })
+                })
+              })
+            })
+          };
+        }
+        if (table === 'strategic_directives_v2') {
+          return {
+            select: () => ({
+              in: () => ({
+                is: () => ({
+                  order: () => ({
+                    order: () => ({
+                      limit: () => ({
+                        neq: () => Promise.resolve({
+                          data: [{ id: 'SD-NEXT-001', sd_key: 'SD-NEXT-001', title: 'Next Orchestrator' }],
+                          error: null
+                        })
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          };
+        }
+        return { select: () => Promise.resolve({ data: [], error: null }) };
+      };
+
+      const result = await executeOrchestratorCompletionHook(
+        'SD-ORCH-001',
+        'Completed Orchestrator',
+        5,
+        { supabase: mockSupabase }
+      );
+
+      expect(result.fired).toBe(true);
+      expect(result.autoProceed).toBe(true);
+      expect(result.chainContinue).toBeUndefined();
+    });
+  });
+
+  // SD-LEO-ENH-AUTO-PROCEED-001-05: findNextAvailableOrchestrator Tests
+  describe('findNextAvailableOrchestrator', () => {
+    it('should find next orchestrator when one is available', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            in: () => ({
+              is: () => ({
+                order: () => ({
+                  order: () => ({
+                    limit: () => Promise.resolve({
+                      data: [
+                        { id: 'SD-NEXT-001', sd_key: 'SD-NEXT-001', title: 'Next Orch', status: 'draft', priority: 5 }
+                      ],
+                      error: null
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      };
+
+      const result = await findNextAvailableOrchestrator(mockSupabase);
+      expect(result.orchestrator).toBeDefined();
+      expect(result.orchestrator.id).toBe('SD-NEXT-001');
+      expect(result.reason).toBe('Next orchestrator found');
+    });
+
+    it('should return null when no orchestrators in queue', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            in: () => ({
+              is: () => ({
+                order: () => ({
+                  order: () => ({
+                    limit: () => Promise.resolve({ data: [], error: null })
+                  })
+                })
+              })
+            })
+          })
+        })
+      };
+
+      const result = await findNextAvailableOrchestrator(mockSupabase);
+      expect(result.orchestrator).toBe(null);
+      expect(result.reason).toBe('No orchestrators in queue');
+    });
+
+    it('should exclude current orchestrator when specified', async () => {
+      let capturedQuery = null;
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            in: () => ({
+              is: () => ({
+                order: () => ({
+                  order: () => ({
+                    limit: () => ({
+                      neq: (field, value) => {
+                        capturedQuery = { field, value };
+                        return Promise.resolve({
+                          data: [{ id: 'SD-OTHER-001' }],
+                          error: null
+                        });
+                      }
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      };
+
+      await findNextAvailableOrchestrator(mockSupabase, 'SD-CURRENT-001');
+      expect(capturedQuery.value).toBe('SD-CURRENT-001');
+    });
+
+    it('should handle database error gracefully', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            in: () => ({
+              is: () => ({
+                order: () => ({
+                  order: () => ({
+                    limit: () => Promise.resolve({ data: null, error: { message: 'DB error' } })
+                  })
+                })
+              })
+            })
+          })
+        })
+      };
+
+      const result = await findNextAvailableOrchestrator(mockSupabase);
+      expect(result.orchestrator).toBe(null);
+      expect(result.reason).toContain('Query error');
+    });
+  });
+
+  // SD-LEO-ENH-AUTO-PROCEED-001-05: emitChainingTelemetry Tests
+  describe('emitChainingTelemetry', () => {
+    it('should successfully emit chain decision telemetry', async () => {
+      let insertedData = null;
+      const mockSupabase = {
+        from: () => ({
+          insert: (data) => {
+            insertedData = data;
+            return Promise.resolve({ error: null });
+          }
+        })
+      };
+
+      const result = await emitChainingTelemetry(
+        mockSupabase,
+        'SD-ORCH-001',
+        'SD-NEXT-001',
+        'chain',
+        'corr-123'
+      );
+
+      expect(result).toBe(true);
+      expect(insertedData.event_type).toBe('ORCHESTRATOR_CHAINING_DECISION');
+      expect(insertedData.details.decision).toBe('chain');
+      expect(insertedData.details.next_orchestrator_id).toBe('SD-NEXT-001');
+      expect(insertedData.severity).toBe('info');
+    });
+
+    it('should emit pause_disabled decision with info severity', async () => {
+      let insertedData = null;
+      const mockSupabase = {
+        from: () => ({
+          insert: (data) => {
+            insertedData = data;
+            return Promise.resolve({ error: null });
+          }
+        })
+      };
+
+      await emitChainingTelemetry(
+        mockSupabase,
+        'SD-ORCH-001',
+        null,
+        'pause_disabled',
+        'corr-456'
+      );
+
+      expect(insertedData.details.decision).toBe('pause_disabled');
+      expect(insertedData.details.next_orchestrator_id).toBe(null);
+      expect(insertedData.severity).toBe('info');
+    });
+
+    it('should emit stop_on_error decision with warning severity', async () => {
+      let insertedData = null;
+      const mockSupabase = {
+        from: () => ({
+          insert: (data) => {
+            insertedData = data;
+            return Promise.resolve({ error: null });
+          }
+        })
+      };
+
+      await emitChainingTelemetry(
+        mockSupabase,
+        'SD-ORCH-001',
+        null,
+        'stop_on_error',
+        'corr-789'
+      );
+
+      expect(insertedData.details.decision).toBe('stop_on_error');
+      expect(insertedData.severity).toBe('warning');
+    });
+
+    it('should return false on database error', async () => {
+      const mockSupabase = {
+        from: () => ({
+          insert: () => Promise.resolve({ error: { message: 'Insert failed' } })
+        })
+      };
+
+      const result = await emitChainingTelemetry(
+        mockSupabase,
+        'SD-ORCH-001',
+        null,
+        'chain',
+        'corr-123'
+      );
+
+      expect(result).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Implements configurable orchestrator chaining for AUTO-PROCEED mode, allowing power users to automatically continue to the next orchestrator after one completes.

**Key Changes:**
- Add `chain_orchestrators` preference in session metadata (default: false)
- Add `getChainOrchestrators()` and `setChainOrchestrators()` functions
- Add `findNextAvailableOrchestrator()` to find next orchestrator in queue
- Add `emitChainingTelemetry()` for structured telemetry events
- Update `checkAndCompleteParentSD()` to return chaining information
- Handle `chainContinue` signal in `handleExecuteWithContinuation()`
- Update `/leo init` skill to expose chaining preference
- Add 19 new unit tests (49 total tests pass)

**User Stories:**
- US-001: chain_orchestrators boolean in session metadata
- US-002: With chain_orchestrators=false, pause at orchestrator boundary (default)
- US-003: With chain_orchestrators=true, auto-continue to next orchestrator
- US-004: On failure, don't chain
- US-005: Emit telemetry events for chaining decisions

## Test plan
- [x] Unit tests for `getChainOrchestrators` (4 tests)
- [x] Unit tests for `setChainOrchestrators` (4 tests)
- [x] Unit tests for `findNextAvailableOrchestrator` (4 tests)
- [x] Unit tests for `emitChainingTelemetry` (4 tests)
- [x] Unit tests for chaining behavior in `executeOrchestratorCompletionHook` (3 tests)
- [x] All 49 tests pass
- [x] Smoke tests pass

**Part of SD-LEO-ENH-AUTO-PROCEED-001 (Enhance AUTO-PROCEED for Long Sustainable Runs)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)