### PR TITLE
fix: remove legacy_id references from dependency handling scripts

### DIFF
--- a/scripts/lib/dependency-graph.js
+++ b/scripts/lib/dependency-graph.js
@@ -49,8 +49,8 @@ export function parseDependencies(dependencies) {
         return match ? match[1] : null;
       }
       if (dep && typeof dep === 'object') {
-        // Object format: { sd_id: "SD-XXX" } or { id: "SD-XXX" }
-        const id = dep.sd_id || dep.id || dep.legacy_id;
+        // Object format: { sd_id: "SD-XXX" } or { sd_key: "SD-XXX" } or { id: "SD-XXX" }
+        const id = dep.sd_id || dep.sd_key || dep.id;
         if (id && id.match(/^SD-[A-Z0-9-]+/)) {
           return id;
         }
@@ -62,19 +62,19 @@ export function parseDependencies(dependencies) {
 
 /**
  * Build a directed graph from Strategic Directives
- * @param {Array} sds - Array of SD objects with legacy_id and dependencies
+ * @param {Array} sds - Array of SD objects with sd_key and dependencies
  * @returns {Object} Graph with adjacency list and metadata
  */
 export function buildGraph(sds) {
   const graph = {
     nodes: new Map(),      // SD ID -> { sd, inDegree, outEdges }
     edges: [],             // Array of { from, to }
-    sdMap: new Map(),      // Quick lookup by legacy_id
+    sdMap: new Map(),      // Quick lookup by sd_key
   };
 
   // Initialize nodes
   for (const sd of sds) {
-    const id = sd.legacy_id;
+    const id = sd.sd_key || sd.id;
     graph.nodes.set(id, {
       sd,
       inDegree: 0,
@@ -86,7 +86,7 @@ export function buildGraph(sds) {
 
   // Build edges from dependencies
   for (const sd of sds) {
-    const toId = sd.legacy_id;
+    const toId = sd.sd_key || sd.id;
     const deps = parseDependencies(sd.dependencies);
 
     for (const fromId of deps) {

--- a/scripts/modules/sd-next/dependency-resolver.js
+++ b/scripts/modules/sd-next/dependency-resolver.js
@@ -15,13 +15,18 @@ export function parseDependencies(dependencies) {
   let deps = [];
   if (typeof dependencies === 'string') {
     try {
-      deps = JSON.parse(dependencies);
+      const parsed = JSON.parse(dependencies);
+      // Handle both array and object formats from JSON parsing
+      deps = Array.isArray(parsed) ? parsed : [];
     } catch {
       return [];
     }
   } else if (Array.isArray(dependencies)) {
     deps = dependencies;
   }
+
+  // Ensure deps is an array before mapping
+  if (!Array.isArray(deps)) return [];
 
   // Only return entries that are actual SD references (SD-XXX format)
   // Ignore text descriptions of prerequisites

--- a/scripts/sd-next/dependency-utils.js
+++ b/scripts/sd-next/dependency-utils.js
@@ -62,10 +62,11 @@ export async function checkDependenciesResolved(dependencies) {
   if (deps.length === 0) return true;
 
   for (const dep of deps) {
+    // Use sd_key with fallback to id (for UUID lookups)
     const { data: sd } = await supabase
       .from('strategic_directives_v2')
       .select('status')
-      .eq('legacy_id', dep.sd_id)
+      .or(`sd_key.eq.${dep.sd_id},id.eq.${dep.sd_id}`)
       .single();
 
     if (!sd || sd.status !== 'completed') {


### PR DESCRIPTION
## Summary

- Fix `parseDependencies` to handle JSON objects that parse to non-arrays (fixing "deps.map is not a function" error)
- Update `dependency-graph.js` to use `sd_key` instead of deprecated `legacy_id`
- Update `dependency-utils.js` to use `.or()` query pattern for `sd_key`/`id` lookups

## Context

The `legacy_id` column was removed from the `strategic_directives_v2` table. These scripts now properly use `sd_key` with `id` fallback.

This fixes the error that was occurring when running `npm run sd:next`:
```
Error: deps.map is not a function
    at parseDependencies (dependency-resolver.js:29:6)
```

## Test plan

- [x] `npm run sd:next` displays SD queue without errors
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)