### PR TITLE
feat(auto-proceed): implement D17 session summary generation

### DIFF
--- a/scripts/modules/handoff/orchestrator-completion-hook.js
+++ b/scripts/modules/handoff/orchestrator-completion-hook.js
@@ -416,6 +416,14 @@ export async function executeOrchestratorCompletionHook(
     queueDisplayed: false
   };
 
+  // Generate session summary (D17 - detailed summary on completion)
+  const summaryResult = await generateSessionSummary(supabase, orchestratorId, correlationId);
+  hookDetails.summaryGenerated = !!summaryResult;
+  hookDetails.summaryStatus = summaryResult?.json?.overall_status || null;
+  hookDetails.summaryTotalSds = summaryResult?.json?.total_sds || 0;
+  hookDetails.summaryIssuesCount = summaryResult?.json?.issues?.length || 0;
+  hookDetails.summaryGenerationTimeMs = summaryResult?.generation_time_ms || null;
+
   if (autoProceedResult.autoProceed) {
     console.log('   ✅ AUTO-PROCEED: ENABLED');
 
@@ -549,5 +557,6 @@ export default {
   invokeLearnSkill,
   displayQueue,
   findNextAvailableOrchestrator,
-  emitChainingTelemetry
+  emitChainingTelemetry,
+  generateSessionSummary
 };

--- a/scripts/modules/session-summary/SessionEventCollector.js
+++ b/scripts/modules/session-summary/SessionEventCollector.js
@@ -12,10 +12,10 @@
 import { redactSecrets } from './secret-redactor.js';
 
 // Valid SD final statuses
-const VALID_STATUSES = ['NOT_STARTED', 'IN_PROGRESS', 'SUCCESS', 'FAILED', 'SKIPPED', 'CANCELLED'];
+export const VALID_STATUSES = ['NOT_STARTED', 'IN_PROGRESS', 'SUCCESS', 'FAILED', 'SKIPPED', 'CANCELLED'];
 
 // Issue severity levels
-const VALID_SEVERITIES = ['ERROR', 'WARN'];
+export const VALID_SEVERITIES = ['ERROR', 'WARN'];
 
 /**
  * Session Event Collector

--- a/scripts/modules/session-summary/SummaryGenerator.js
+++ b/scripts/modules/session-summary/SummaryGenerator.js
@@ -12,13 +12,13 @@
 import { redactObject, redactSecrets } from './secret-redactor.js';
 
 // Schema version for the session summary
-const SCHEMA_VERSION = '1.0';
+export const SCHEMA_VERSION = '1.0';
 
 // Compilation timeout (500ms per TR-3)
-const COMPILATION_TIMEOUT_MS = 500;
+export const COMPILATION_TIMEOUT_MS = 500;
 
 // Maximum lines for human-readable digest
-const MAX_DIGEST_LINES = 60;
+export const MAX_DIGEST_LINES = 60;
 
 // Maximum issues to show in digest
 const MAX_DIGEST_ISSUES = 10;

--- a/scripts/modules/session-summary/index.js
+++ b/scripts/modules/session-summary/index.js
@@ -7,8 +7,12 @@
  * @see docs/discovery/auto-proceed-enhancement-discovery.md
  */
 
-export { SessionEventCollector, createCollector, VALID_STATUSES, VALID_SEVERITIES } from './SessionEventCollector.js';
-export { SummaryGenerator, createGenerator, SCHEMA_VERSION, COMPILATION_TIMEOUT_MS, MAX_DIGEST_LINES } from './SummaryGenerator.js';
+// Import from default exports and re-export
+import SessionEventCollectorModule from './SessionEventCollector.js';
+import SummaryGeneratorModule from './SummaryGenerator.js';
+
+export const { SessionEventCollector, createCollector, VALID_STATUSES, VALID_SEVERITIES } = SessionEventCollectorModule;
+export const { SummaryGenerator, createGenerator, SCHEMA_VERSION, COMPILATION_TIMEOUT_MS, MAX_DIGEST_LINES } = SummaryGeneratorModule;
 export { redactSecrets, redactObject, containsSecrets } from './secret-redactor.js';
 
 /**

--- a/tests/e2e/session-summary.test.js
+++ b/tests/e2e/session-summary.test.js
@@ -1,0 +1,476 @@
+/**
+ * E2E Tests for Session Summary Feature
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-08
+ * Tests the 5 user stories for session summary generation.
+ *
+ * US-001: Structured event with report_type='session_summary' and schema_version
+ * US-002: SD list with final_status and timestamps matches orchestrator queue
+ * US-003: Issues array on failures
+ * US-004: Performance <200ms avg (500 SDs benchmark)
+ * US-005: No secrets in output
+ */
+
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from '@jest/globals';
+import { createClient } from '@supabase/supabase-js';
+import { SessionEventCollector, createCollector } from '../../scripts/modules/session-summary/SessionEventCollector.js';
+import { SummaryGenerator, createGenerator, SCHEMA_VERSION } from '../../scripts/modules/session-summary/SummaryGenerator.js';
+import { generateAndEmitSummary } from '../../scripts/modules/session-summary/index.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+describe('Session Summary E2E Tests', () => {
+  let supabase;
+  const testSessionId = `e2e-session-${Date.now()}`;
+
+  beforeAll(async () => {
+    if (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+      supabase = createClient(
+        process.env.SUPABASE_URL,
+        process.env.SUPABASE_SERVICE_ROLE_KEY
+      );
+    }
+  });
+
+  afterAll(async () => {
+    // Cleanup test data
+    if (supabase) {
+      await supabase
+        .from('system_events')
+        .delete()
+        .eq('entity_id', testSessionId);
+    }
+  });
+
+  describe('US-001: Structured Event Emission', () => {
+    it('should emit exactly one session_summary event with report_type and schema_version', async () => {
+      const collector = createCollector(testSessionId);
+      const generator = createGenerator();
+
+      // Simulate a session with 3 successful SDs
+      collector.recordSdQueued('SD-001', { title: 'First SD' });
+      collector.recordSdQueued('SD-002', { title: 'Second SD' });
+      collector.recordSdQueued('SD-003', { title: 'Third SD' });
+
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.recordSdStarted('SD-002');
+      collector.recordSdTerminal('SD-002', 'SUCCESS');
+      collector.recordSdStarted('SD-003');
+      collector.recordSdTerminal('SD-003', 'SUCCESS');
+
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      // Verify report_type
+      expect(result.json.report_type).toBe('session_summary');
+
+      // Verify schema_version
+      expect(result.json.schema_version).toBe(SCHEMA_VERSION);
+      expect(result.json.schema_version).toBe('1.0');
+
+      // Verify overall_status is SUCCESS for all successful SDs
+      expect(result.json.overall_status).toBe('SUCCESS');
+    });
+
+    it('should emit session_summary for FAILED outcome', async () => {
+      const collector = createCollector(`${testSessionId}-failed`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001', { title: 'Failing SD' });
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'FAILED', {
+        errorClass: 'TestError',
+        errorMessage: 'Test failure'
+      });
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.json.report_type).toBe('session_summary');
+      expect(result.json.schema_version).toBe(SCHEMA_VERSION);
+      expect(result.json.overall_status).toBe('FAILED');
+    });
+
+    it('should emit session_summary for CANCELLED outcome', async () => {
+      const collector = createCollector(`${testSessionId}-cancelled`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'CANCELLED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.json.report_type).toBe('session_summary');
+      expect(result.json.overall_status).toBe('CANCELLED');
+    });
+  });
+
+  describe('US-002: SD List Completeness', () => {
+    it('should include all SDs with final_status and timestamps', async () => {
+      const collector = createCollector(`${testSessionId}-list`);
+      const generator = createGenerator();
+      const numSds = 5;
+
+      // Queue all SDs
+      for (let i = 0; i < numSds; i++) {
+        collector.recordSdQueued(`SD-${i}`, {
+          title: `SD ${i}`,
+          category: 'test',
+          priority: 'medium'
+        });
+      }
+
+      // Process SDs with different outcomes
+      collector.recordSdStarted('SD-0');
+      collector.recordSdTerminal('SD-0', 'SUCCESS');
+
+      collector.recordSdStarted('SD-1');
+      collector.recordSdTerminal('SD-1', 'FAILED');
+
+      collector.recordSdStarted('SD-2');
+      collector.recordSdTerminal('SD-2', 'SUCCESS');
+
+      // SD-3 is skipped
+      collector.recordSdTerminal('SD-3', 'SKIPPED');
+
+      // SD-4 never started (NOT_STARTED)
+
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      // Verify SD count matches
+      expect(result.json.total_sds).toBe(numSds);
+      expect(result.json.sds.length).toBe(numSds);
+
+      // Verify each SD has required fields
+      for (const sd of result.json.sds) {
+        expect(sd.sd_id).toBeTruthy();
+        expect(sd.final_status).toBeTruthy();
+        expect(['SUCCESS', 'FAILED', 'SKIPPED', 'CANCELLED', 'NOT_STARTED', 'IN_PROGRESS']).toContain(sd.final_status);
+      }
+
+      // Verify status distribution
+      const statusCounts = result.json.sd_counts_by_status;
+      expect(statusCounts['SUCCESS']).toBe(2);
+      expect(statusCounts['FAILED']).toBe(1);
+      expect(statusCounts['SKIPPED']).toBe(1);
+      expect(statusCounts['NOT_STARTED']).toBe(1);
+
+      // Verify timestamps for processed SDs
+      const sd0 = result.json.sds.find(s => s.sd_id === 'SD-0');
+      expect(sd0.start_timestamp).toBeTruthy();
+      expect(sd0.end_timestamp).toBeTruthy();
+      expect(sd0.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should maintain SD order as queued', async () => {
+      const collector = createCollector(`${testSessionId}-order`);
+      const generator = createGenerator();
+
+      // Queue in specific order
+      collector.recordSdQueued('SD-A');
+      collector.recordSdQueued('SD-B');
+      collector.recordSdQueued('SD-C');
+
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      // Note: Order may not be preserved due to Map iteration, but all should be present
+      const sdIds = result.json.sds.map(s => s.sd_id);
+      expect(sdIds).toContain('SD-A');
+      expect(sdIds).toContain('SD-B');
+      expect(sdIds).toContain('SD-C');
+    });
+  });
+
+  describe('US-003: Issues Array on Failures', () => {
+    it('should include issues array with entry for each failed SD', async () => {
+      const collector = createCollector(`${testSessionId}-issues`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdQueued('SD-002');
+
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+
+      collector.recordSdStarted('SD-002');
+      collector.recordSdTerminal('SD-002', 'FAILED', {
+        errorClass: 'ValidationError',
+        errorMessage: 'Validation failed for SD-002'
+      });
+
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.json.overall_status).toBe('FAILED');
+      expect(result.json.issues.length).toBeGreaterThan(0);
+
+      // Find issue for SD-002
+      const sd002Issue = result.json.issues.find(i => i.sd_id === 'SD-002');
+      expect(sd002Issue).toBeTruthy();
+      expect(sd002Issue.severity).toBe('ERROR');
+      expect(sd002Issue.issue_code).toBe('SD_FAILED');
+    });
+
+    it('should include session-level issues for anomalies', async () => {
+      const collector = createCollector(`${testSessionId}-session-issues`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+
+      // Record a session-level issue (no sd_id)
+      collector.recordIssue('WARN', 'SESSION_TIMEOUT', 'Session timeout warning', {
+        correlation_ids: ['corr-123']
+      });
+
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      const sessionIssue = result.json.issues.find(i => i.sd_id === null);
+      expect(sessionIssue).toBeTruthy();
+      expect(sessionIssue.issue_code).toBe('SESSION_TIMEOUT');
+      expect(sessionIssue.correlation_ids).toContain('corr-123');
+    });
+
+    it('should include empty issues array when no issues', async () => {
+      const collector = createCollector(`${testSessionId}-no-issues`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(Array.isArray(result.json.issues)).toBe(true);
+      expect(result.json.issues.length).toBe(0);
+    });
+  });
+
+  describe('US-004: Performance Benchmark', () => {
+    it('should generate summary in <200ms avg for 500 SDs (p95 <500ms)', async () => {
+      const generator = createGenerator();
+      const runs = 100;
+      const sdCount = 500;
+      const issueCount = 200;
+      const times = [];
+
+      for (let run = 0; run < runs; run++) {
+        const collector = createCollector(`perf-session-${run}`);
+
+        // Populate with 500 SDs
+        for (let i = 0; i < sdCount; i++) {
+          collector.recordSdQueued(`SD-${i}`, {
+            title: `Performance Test SD ${i}`,
+            category: 'test',
+            priority: i % 3 === 0 ? 'high' : 'medium'
+          });
+          collector.recordSdStarted(`SD-${i}`);
+          collector.recordSdTerminal(`SD-${i}`, i % 5 === 0 ? 'FAILED' : 'SUCCESS');
+        }
+
+        // Add 200 issues
+        for (let j = 0; j < issueCount; j++) {
+          collector.recordIssue(
+            j % 2 === 0 ? 'ERROR' : 'WARN',
+            `ISSUE_${j}`,
+            `Issue message ${j}`,
+            { sd_id: `SD-${j % sdCount}` }
+          );
+        }
+
+        collector.complete();
+
+        const startTime = Date.now();
+        await generator.generate(collector.getSnapshot());
+        const elapsed = Date.now() - startTime;
+        times.push(elapsed);
+      }
+
+      // Calculate statistics
+      const avg = times.reduce((a, b) => a + b, 0) / times.length;
+      const sorted = [...times].sort((a, b) => a - b);
+      const p95Index = Math.floor(runs * 0.95);
+      const p95 = sorted[p95Index];
+
+      console.log(`Performance Test Results (${runs} runs, ${sdCount} SDs, ${issueCount} issues):`);
+      console.log(`  Average: ${avg.toFixed(1)}ms`);
+      console.log(`  P95: ${p95}ms`);
+      console.log(`  Min: ${sorted[0]}ms`);
+      console.log(`  Max: ${sorted[sorted.length - 1]}ms`);
+
+      // Assertions
+      expect(avg).toBeLessThanOrEqual(200);
+
+      // If p95 exceeds 500ms, degraded summary should be emitted
+      if (p95 > 500) {
+        console.warn('P95 exceeded 500ms - would emit degraded summary in production');
+      }
+    }, 60000); // 60 second timeout for performance test
+  });
+
+  describe('US-005: Secret Redaction', () => {
+    it('should redact API keys from issue messages', async () => {
+      const collector = createCollector(`${testSessionId}-secrets-api`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordIssue('ERROR', 'AUTH_ERROR', 'Failed with api_key=super_secret_key_value_12345');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      const authIssue = result.json.issues.find(i => i.issue_code === 'AUTH_ERROR');
+      expect(authIssue.message).not.toContain('super_secret');
+      expect(authIssue.message).toContain('[REDACTED]');
+    });
+
+    it('should redact Bearer tokens from issue messages', async () => {
+      const collector = createCollector(`${testSessionId}-secrets-bearer`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordIssue('ERROR', 'AUTH_ERROR', 'Request failed: Authorization: Bearer eyJhbGciOiJIUzI1Nisecret');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      const authIssue = result.json.issues.find(i => i.issue_code === 'AUTH_ERROR');
+      expect(authIssue.message).not.toContain('eyJhbGciOiJIUzI1Nisecret');
+      expect(authIssue.message).toContain('[REDACTED]');
+    });
+
+    it('should redact passwords from issue messages', async () => {
+      const collector = createCollector(`${testSessionId}-secrets-password`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordIssue('ERROR', 'DB_ERROR', 'Connection failed: password=supersecret123');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      const dbIssue = result.json.issues.find(i => i.issue_code === 'DB_ERROR');
+      expect(dbIssue.message).not.toContain('supersecret123');
+      expect(dbIssue.message).toContain('[REDACTED]');
+    });
+
+    it('should redact database connection strings', async () => {
+      const collector = createCollector(`${testSessionId}-secrets-db`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordIssue('ERROR', 'DB_ERROR', 'Cannot connect to postgres://admin:secretpass@db.host.com/mydb');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      const dbIssue = result.json.issues.find(i => i.issue_code === 'DB_ERROR');
+      expect(dbIssue.message).not.toContain('admin:secretpass');
+      expect(dbIssue.message).toContain('[REDACTED]');
+    });
+
+    it('should ensure no secrets in digest text', async () => {
+      const collector = createCollector(`${testSessionId}-secrets-digest`);
+      const generator = createGenerator();
+
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordIssue('ERROR', 'AUTH_ERROR', 'Token expired: token=secret_token_value_12345678');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.digest).not.toContain('secret_token');
+      expect(result.digest).toContain('[REDACTED]');
+    });
+  });
+
+  describe('Integration: Full Session Workflow', () => {
+    it('should generate complete summary for realistic orchestrator session', async () => {
+      const collector = createCollector(`${testSessionId}-full`);
+
+      // Simulate realistic orchestrator session
+      const sds = [
+        { id: 'SD-INFRA-001', title: 'Setup infrastructure', category: 'infrastructure' },
+        { id: 'SD-FEAT-001', title: 'Implement feature A', category: 'feature' },
+        { id: 'SD-FEAT-002', title: 'Implement feature B', category: 'feature' },
+        { id: 'SD-TEST-001', title: 'Integration tests', category: 'test' },
+        { id: 'SD-DOC-001', title: 'Update documentation', category: 'documentation' }
+      ];
+
+      // Queue all SDs
+      for (const sd of sds) {
+        collector.recordSdQueued(sd.id, {
+          title: sd.title,
+          category: sd.category,
+          priority: 'medium'
+        });
+      }
+
+      // Process SDs with mixed outcomes
+      collector.recordSdStarted('SD-INFRA-001');
+      collector.recordSdTerminal('SD-INFRA-001', 'SUCCESS');
+
+      collector.recordSdStarted('SD-FEAT-001');
+      collector.recordSdTerminal('SD-FEAT-001', 'SUCCESS');
+
+      collector.recordSdStarted('SD-FEAT-002');
+      collector.recordSdTerminal('SD-FEAT-002', 'FAILED', {
+        errorClass: 'BuildError',
+        errorMessage: 'Build failed: missing dependency'
+      });
+
+      collector.recordSdStarted('SD-TEST-001');
+      collector.recordSdTerminal('SD-TEST-001', 'SKIPPED'); // Skipped due to FEAT-002 failure
+
+      collector.recordSdStarted('SD-DOC-001');
+      collector.recordSdTerminal('SD-DOC-001', 'SUCCESS');
+
+      collector.complete();
+
+      const result = await generateAndEmitSummary(collector, {
+        emitLog: false,
+        emitDigest: false,
+        persistArtifact: false
+      });
+
+      // Verify complete structure
+      expect(result.json.report_type).toBe('session_summary');
+      expect(result.json.schema_version).toBe('1.0');
+      expect(result.json.total_sds).toBe(5);
+      expect(result.json.overall_status).toBe('FAILED');
+      expect(result.json.sd_counts_by_status['SUCCESS']).toBe(3);
+      expect(result.json.sd_counts_by_status['FAILED']).toBe(1);
+      expect(result.json.sd_counts_by_status['SKIPPED']).toBe(1);
+      expect(result.json.issues.length).toBeGreaterThan(0);
+      expect(result.generation_time_ms).toBeGreaterThanOrEqual(0);
+
+      // Verify digest
+      expect(result.digest).toContain('SESSION SUMMARY');
+      expect(result.digest).toContain('FAILED');
+    });
+  });
+});

--- a/tests/unit/session-summary/SessionEventCollector.test.js
+++ b/tests/unit/session-summary/SessionEventCollector.test.js
@@ -1,0 +1,317 @@
+/**
+ * Session Event Collector Unit Tests
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-08
+ * Tests collector invariants: no negative durations, terminal set once, attempt_count increments
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { SessionEventCollector, createCollector, VALID_STATUSES, VALID_SEVERITIES } from '../../../scripts/modules/session-summary/SessionEventCollector.js';
+
+describe('SessionEventCollector', () => {
+  let collector;
+
+  beforeEach(() => {
+    collector = createCollector('test-session-123', {
+      orchestratorVersion: '1.0.0'
+    });
+  });
+
+  describe('Initialization', () => {
+    it('should create collector with session ID', () => {
+      expect(collector.sessionId).toBe('test-session-123');
+      expect(collector.orchestratorVersion).toBe('1.0.0');
+      expect(collector.startTimestamp).toBeTruthy();
+      expect(collector.endTimestamp).toBeNull();
+    });
+
+    it('should initialize with empty SD and issues collections', () => {
+      expect(collector.sds.size).toBe(0);
+      expect(collector.issues.length).toBe(0);
+    });
+  });
+
+  describe('recordSdQueued', () => {
+    it('should record SD queued event with metadata', () => {
+      const result = collector.recordSdQueued('SD-001', {
+        title: 'Test SD',
+        category: 'feature',
+        priority: 'high'
+      });
+
+      expect(result).toBe(true);
+      expect(collector.sds.size).toBe(1);
+
+      const sd = collector.sds.get('SD-001');
+      expect(sd.sd_id).toBe('SD-001');
+      expect(sd.title).toBe('Test SD');
+      expect(sd.category).toBe('feature');
+      expect(sd.priority).toBe('high');
+      expect(sd.queued_at).toBeTruthy();
+      expect(sd.final_status).toBe('NOT_STARTED');
+      expect(sd.attempt_count).toBe(0);
+    });
+
+    it('should return false for missing sd_id', () => {
+      const result = collector.recordSdQueued(null);
+      expect(result).toBe(false);
+      expect(collector.storeWriteFailures).toBe(1);
+    });
+  });
+
+  describe('recordSdStarted', () => {
+    it('should record SD started and increment attempt count', () => {
+      collector.recordSdQueued('SD-001');
+      const result = collector.recordSdStarted('SD-001');
+
+      expect(result).toBe(true);
+
+      const sd = collector.sds.get('SD-001');
+      expect(sd.start_timestamp).toBeTruthy();
+      expect(sd.final_status).toBe('IN_PROGRESS');
+      expect(sd.attempt_count).toBe(1);
+    });
+
+    it('should increment attempt count on multiple starts (retries)', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdStarted('SD-001');
+
+      const sd = collector.sds.get('SD-001');
+      expect(sd.attempt_count).toBe(3);
+    });
+
+    it('should auto-queue SD if not already queued', () => {
+      const result = collector.recordSdStarted('SD-NEW');
+
+      expect(result).toBe(true);
+      expect(collector.sds.has('SD-NEW')).toBe(true);
+    });
+  });
+
+  describe('recordSdTerminal', () => {
+    it('should record terminal status and calculate duration', async () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+
+      // Small delay to ensure measurable duration
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const result = collector.recordSdTerminal('SD-001', 'SUCCESS');
+
+      expect(result).toBe(true);
+
+      const sd = collector.sds.get('SD-001');
+      expect(sd.final_status).toBe('SUCCESS');
+      expect(sd.end_timestamp).toBeTruthy();
+      expect(sd.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should prevent duplicate terminal state assignments', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+
+      const sd = collector.sds.get('SD-001');
+      expect(sd.final_status).toBe('SUCCESS'); // Should remain SUCCESS
+    });
+
+    it('should reject invalid status', () => {
+      collector.recordSdQueued('SD-001');
+      const result = collector.recordSdTerminal('SD-001', 'INVALID_STATUS');
+
+      expect(result).toBe(false);
+      expect(collector.storeWriteFailures).toBe(1);
+    });
+
+    it('should auto-record issue for FAILED status with error info', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'FAILED', {
+        errorClass: 'ValidationError',
+        errorMessage: 'Validation failed'
+      });
+
+      expect(collector.issues.length).toBe(1);
+      expect(collector.issues[0].issue_code).toBe('SD_FAILED');
+      expect(collector.issues[0].severity).toBe('ERROR');
+    });
+  });
+
+  describe('recordIssue', () => {
+    it('should record new issue', () => {
+      const result = collector.recordIssue('ERROR', 'TEST_ERROR', 'Something went wrong', {
+        sd_id: 'SD-001',
+        correlation_ids: ['corr-123']
+      });
+
+      expect(result).toBe(true);
+      expect(collector.issues.length).toBe(1);
+
+      const issue = collector.issues[0];
+      expect(issue.severity).toBe('ERROR');
+      expect(issue.issue_code).toBe('TEST_ERROR');
+      expect(issue.message).toBe('Something went wrong');
+      expect(issue.sd_id).toBe('SD-001');
+      expect(issue.correlation_ids).toContain('corr-123');
+      expect(issue.occurrences_count).toBe(1);
+    });
+
+    it('should aggregate duplicate issues', () => {
+      collector.recordIssue('WARN', 'RATE_LIMIT', 'Rate limit hit');
+      collector.recordIssue('WARN', 'RATE_LIMIT', 'Rate limit hit');
+      collector.recordIssue('WARN', 'RATE_LIMIT', 'Rate limit hit');
+
+      expect(collector.issues.length).toBe(1);
+      expect(collector.issues[0].occurrences_count).toBe(3);
+    });
+
+    it('should default invalid severity to ERROR', () => {
+      collector.recordIssue('INVALID', 'CODE', 'message');
+      expect(collector.issues[0].severity).toBe('ERROR');
+    });
+
+    it('should redact secrets from messages', () => {
+      collector.recordIssue('ERROR', 'AUTH_ERROR', 'api_key=super_secret_key_12345');
+      expect(collector.issues[0].message).not.toContain('super_secret_key');
+      expect(collector.issues[0].message).toContain('[REDACTED]');
+    });
+  });
+
+  describe('getSnapshot', () => {
+    it('should return complete snapshot with all collected data', () => {
+      collector.recordSdQueued('SD-001', { title: 'First SD' });
+      collector.recordSdQueued('SD-002', { title: 'Second SD' });
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.recordIssue('WARN', 'TEST_WARN', 'Test warning');
+
+      const snapshot = collector.getSnapshot();
+
+      expect(snapshot.session_id).toBe('test-session-123');
+      expect(snapshot.orchestrator_version).toBe('1.0.0');
+      expect(snapshot.start_timestamp).toBeTruthy();
+      expect(snapshot.sds.length).toBe(2);
+      expect(snapshot.issues.length).toBe(1);
+    });
+
+    it('should include store write failure issue if any', () => {
+      collector.recordSdQueued(null); // Force a write failure
+      const snapshot = collector.getSnapshot();
+
+      const storeFailureIssue = snapshot.issues.find(
+        i => i.issue_code === 'SESSION_STORE_WRITE_FAILED'
+      );
+      expect(storeFailureIssue).toBeTruthy();
+      expect(storeFailureIssue.severity).toBe('WARN');
+    });
+  });
+
+  describe('getSdCountsByStatus', () => {
+    it('should return correct counts by status', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdQueued('SD-002');
+      collector.recordSdQueued('SD-003');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.recordSdStarted('SD-002');
+      collector.recordSdTerminal('SD-002', 'FAILED');
+
+      const counts = collector.getSdCountsByStatus();
+
+      expect(counts['SUCCESS']).toBe(1);
+      expect(counts['FAILED']).toBe(1);
+      expect(counts['NOT_STARTED']).toBe(1);
+    });
+  });
+
+  describe('getOverallStatus', () => {
+    it('should return SUCCESS when all SDs succeed', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdQueued('SD-002');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdStarted('SD-002');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.recordSdTerminal('SD-002', 'SUCCESS');
+
+      expect(collector.getOverallStatus()).toBe('SUCCESS');
+    });
+
+    it('should return FAILED when any SD fails', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdQueued('SD-002');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdStarted('SD-002');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.recordSdTerminal('SD-002', 'FAILED');
+
+      expect(collector.getOverallStatus()).toBe('FAILED');
+    });
+
+    it('should return CANCELLED when any SD is cancelled', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'CANCELLED');
+
+      expect(collector.getOverallStatus()).toBe('CANCELLED');
+    });
+
+    it('should return SUCCESS for empty session', () => {
+      expect(collector.getOverallStatus()).toBe('SUCCESS');
+    });
+  });
+
+  describe('validate', () => {
+    it('should return valid for proper data', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+
+      const validation = collector.validate();
+      expect(validation.valid).toBe(true);
+      expect(validation.errors.length).toBe(0);
+    });
+
+    it('should detect invalid status', () => {
+      collector.recordSdQueued('SD-001');
+      // Manually set invalid status for testing
+      collector.sds.get('SD-001').final_status = 'INVALID';
+
+      const validation = collector.validate();
+      expect(validation.valid).toBe(false);
+      expect(validation.errors.some(e => e.includes('invalid status'))).toBe(true);
+    });
+  });
+
+  describe('Invariants', () => {
+    it('should never produce negative durations', () => {
+      for (let i = 0; i < 10; i++) {
+        collector.recordSdQueued(`SD-${i}`);
+        collector.recordSdStarted(`SD-${i}`);
+        collector.recordSdTerminal(`SD-${i}`, 'SUCCESS');
+      }
+
+      const snapshot = collector.getSnapshot();
+      for (const sd of snapshot.sds) {
+        expect(sd.duration_ms).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('should set terminal status exactly once', () => {
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+
+      // First terminal call sets status
+      collector.recordSdTerminal('SD-001', 'FAILED');
+      expect(collector.sds.get('SD-001').final_status).toBe('FAILED');
+
+      // Subsequent calls should not change status
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.recordSdTerminal('SD-001', 'CANCELLED');
+
+      expect(collector.sds.get('SD-001').final_status).toBe('FAILED');
+    });
+  });
+});

--- a/tests/unit/session-summary/SummaryGenerator.test.js
+++ b/tests/unit/session-summary/SummaryGenerator.test.js
@@ -1,0 +1,359 @@
+/**
+ * Summary Generator Unit Tests
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-08
+ * Tests schema validation, timeout behavior, and fallback behavior (TS-6)
+ */
+
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { SummaryGenerator, createGenerator, SCHEMA_VERSION, COMPILATION_TIMEOUT_MS } from '../../../scripts/modules/session-summary/SummaryGenerator.js';
+import { createCollector } from '../../../scripts/modules/session-summary/SessionEventCollector.js';
+
+describe('SummaryGenerator', () => {
+  let generator;
+
+  beforeEach(() => {
+    generator = createGenerator();
+  });
+
+  describe('Initialization', () => {
+    it('should create generator with default options', () => {
+      expect(generator.timeout).toBe(COMPILATION_TIMEOUT_MS);
+      expect(generator.maxDigestLines).toBe(60);
+    });
+
+    it('should accept custom options', () => {
+      const customGenerator = createGenerator({ timeout: 1000, maxDigestLines: 30 });
+      expect(customGenerator.timeout).toBe(1000);
+      expect(customGenerator.maxDigestLines).toBe(30);
+    });
+  });
+
+  describe('generate - Happy Path', () => {
+    it('should generate valid JSON summary with schema_version', async () => {
+      const collector = createCollector('session-123', { orchestratorVersion: '1.0.0' });
+      collector.recordSdQueued('SD-001', { title: 'Test SD' });
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.complete();
+
+      const snapshot = collector.getSnapshot();
+      const result = await generator.generate(snapshot);
+
+      expect(result.json).toBeTruthy();
+      expect(result.json.report_type).toBe('session_summary');
+      expect(result.json.schema_version).toBe(SCHEMA_VERSION);
+      expect(result.json.session_id).toBe('session-123');
+      expect(result.json.total_sds).toBe(1);
+    });
+
+    it('should include SD counts by status', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdQueued('SD-002');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdStarted('SD-002');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.recordSdTerminal('SD-002', 'FAILED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.json.sd_counts_by_status).toBeTruthy();
+      expect(result.json.sd_counts_by_status['SUCCESS']).toBe(1);
+      expect(result.json.sd_counts_by_status['FAILED']).toBe(1);
+    });
+
+    it('should calculate overall_status correctly', async () => {
+      // All success case
+      const successCollector = createCollector('success-session');
+      successCollector.recordSdQueued('SD-001');
+      successCollector.recordSdStarted('SD-001');
+      successCollector.recordSdTerminal('SD-001', 'SUCCESS');
+      successCollector.complete();
+
+      const successResult = await generator.generate(successCollector.getSnapshot());
+      expect(successResult.json.overall_status).toBe('SUCCESS');
+
+      // Failed case
+      const failedCollector = createCollector('failed-session');
+      failedCollector.recordSdQueued('SD-001');
+      failedCollector.recordSdStarted('SD-001');
+      failedCollector.recordSdTerminal('SD-001', 'FAILED');
+      failedCollector.complete();
+
+      const failedResult = await generator.generate(failedCollector.getSnapshot());
+      expect(failedResult.json.overall_status).toBe('FAILED');
+    });
+
+    it('should include sds array with all required fields', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001', {
+        title: 'Test SD',
+        category: 'feature',
+        priority: 'high'
+      });
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.json.sds.length).toBe(1);
+      const sd = result.json.sds[0];
+      expect(sd.sd_id).toBe('SD-001');
+      expect(sd.title).toBe('Test SD');
+      expect(sd.category).toBe('feature');
+      expect(sd.priority).toBe('high');
+      expect(sd.final_status).toBe('SUCCESS');
+      expect(sd.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should generate human-readable digest', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.digest).toBeTruthy();
+      expect(typeof result.digest).toBe('string');
+      expect(result.digest).toContain('SESSION SUMMARY');
+      expect(result.digest).toContain('session-123');
+      expect(result.digest).toContain('SUCCESS');
+    });
+
+    it('should record generation time', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.generation_time_ms).toBeGreaterThanOrEqual(0);
+      expect(result.json.report_generation_time_ms).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('generate - Issues Handling', () => {
+    it('should include issues array in output', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'FAILED', {
+        errorClass: 'ValidationError',
+        errorMessage: 'Test failed'
+      });
+      collector.recordIssue('WARN', 'TEST_WARN', 'A warning occurred');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.json.issues.length).toBeGreaterThan(0);
+      const errorIssue = result.json.issues.find(i => i.severity === 'ERROR');
+      const warnIssue = result.json.issues.find(i => i.severity === 'WARN');
+
+      expect(errorIssue).toBeTruthy();
+      expect(warnIssue).toBeTruthy();
+    });
+
+    it('should include empty issues array when no issues', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(Array.isArray(result.json.issues)).toBe(true);
+      expect(result.json.issues.length).toBe(0);
+    });
+
+    it('should include issues in digest (max 10)', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+
+      // Add multiple issues
+      for (let i = 0; i < 15; i++) {
+        collector.recordIssue('WARN', `WARN_${i}`, `Warning ${i}`, { sd_id: `SD-00${i}` });
+      }
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.digest).toContain('ISSUES');
+      // Should mention "and X more issues" since we have > 10
+      expect(result.digest).toContain('more issues');
+    });
+  });
+
+  describe('generate - Validation', () => {
+    it('should reject snapshot missing session_id (TS-6)', async () => {
+      const invalidSnapshot = {
+        session_id: null,
+        orchestrator_version: '1.0.0',
+        start_timestamp: new Date().toISOString(),
+        end_timestamp: new Date().toISOString(),
+        sds: [],
+        issues: []
+      };
+
+      const result = await generator.generate(invalidSnapshot);
+
+      expect(result.json.overall_status).toBe('FAILED');
+      expect(result.json.issues.some(
+        i => i.issue_code === 'SUMMARY_SCHEMA_VALIDATION_FAILED'
+      )).toBe(true);
+    });
+
+    it('should reject SD entry missing sd_id (TS-6)', async () => {
+      const invalidSnapshot = {
+        session_id: 'session-123',
+        orchestrator_version: '1.0.0',
+        start_timestamp: new Date().toISOString(),
+        end_timestamp: new Date().toISOString(),
+        sds: [
+          { sd_id: null, title: 'Invalid SD', final_status: 'SUCCESS' }
+        ],
+        issues: []
+      };
+
+      const result = await generator.generate(invalidSnapshot);
+
+      expect(result.json.overall_status).toBe('FAILED');
+      expect(result.json.issues.some(
+        i => i.issue_code === 'SUMMARY_SCHEMA_VALIDATION_FAILED'
+      )).toBe(true);
+    });
+
+    it('should generate minimal fallback summary on validation failure (TS-6)', async () => {
+      const invalidSnapshot = {
+        session_id: null,
+        sds: 'not an array',
+        issues: 'not an array'
+      };
+
+      const result = await generator.generate(invalidSnapshot);
+
+      // Should still have required fields
+      expect(result.json.report_type).toBe('session_summary');
+      expect(result.json.schema_version).toBe(SCHEMA_VERSION);
+      expect(result.json.overall_status).toBe('FAILED');
+      expect(Array.isArray(result.json.issues)).toBe(true);
+    });
+  });
+
+  describe('generate - Timeout Behavior', () => {
+    it('should emit degraded summary on timeout', async () => {
+      // Create generator with very short timeout
+      const fastGenerator = createGenerator({ timeout: 1 });
+
+      const collector = createCollector('session-123');
+      // Add many SDs to potentially slow down generation
+      for (let i = 0; i < 100; i++) {
+        collector.recordSdQueued(`SD-${i}`, { title: `SD ${i}` });
+        collector.recordSdStarted(`SD-${i}`);
+        collector.recordSdTerminal(`SD-${i}`, 'SUCCESS');
+      }
+      collector.complete();
+
+      const result = await fastGenerator.generate(collector.getSnapshot());
+
+      // Either succeeds normally or produces degraded summary
+      if (result.degraded) {
+        expect(result.json.issues.some(
+          i => i.issue_code === 'SUMMARY_TIMEOUT'
+        )).toBe(true);
+        expect(result.json.degraded).toBe(true);
+      }
+      // If it didn't time out, that's also acceptable
+    });
+
+    it('should include issue_code SUMMARY_TIMEOUT in degraded summary', async () => {
+      // Force timeout by using a mock that takes too long
+      const mockSnapshot = {
+        session_id: 'timeout-session',
+        orchestrator_version: '1.0.0',
+        start_timestamp: new Date().toISOString(),
+        end_timestamp: new Date().toISOString(),
+        sds: [],
+        issues: []
+      };
+
+      // Test the degraded summary directly
+      const degradedResult = generator._generateDegradedSummary(mockSnapshot, Date.now() - 600);
+
+      expect(degradedResult.json.issues[0].issue_code).toBe('SUMMARY_TIMEOUT');
+      expect(degradedResult.json.degraded).toBe(true);
+    });
+  });
+
+  describe('Secret Redaction', () => {
+    it('should redact secrets from issue messages', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordIssue('ERROR', 'AUTH_ERROR', 'Failed with api_key=super_secret_123 and password=hunter2');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      const errorIssue = result.json.issues.find(i => i.issue_code === 'AUTH_ERROR');
+      expect(errorIssue.message).not.toContain('super_secret');
+      expect(errorIssue.message).not.toContain('hunter2');
+      expect(errorIssue.message).toContain('[REDACTED]');
+    });
+
+    it('should redact secrets from digest', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordIssue('ERROR', 'AUTH_ERROR', 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.secret');
+      collector.recordSdTerminal('SD-001', 'FAILED');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.digest).not.toContain('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9');
+    });
+  });
+
+  describe('Duration Calculation', () => {
+    it('should calculate session duration correctly', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+
+      // Wait a bit
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      expect(result.json.duration_ms).toBeGreaterThanOrEqual(15);
+    });
+
+    it('should format duration in digest', async () => {
+      const collector = createCollector('session-123');
+      collector.recordSdQueued('SD-001');
+      collector.recordSdStarted('SD-001');
+      collector.recordSdTerminal('SD-001', 'SUCCESS');
+      collector.complete();
+
+      const result = await generator.generate(collector.getSnapshot());
+
+      // Duration should be formatted (ms, s, or m s)
+      expect(result.digest).toMatch(/Duration:/);
+    });
+  });
+});

--- a/tests/unit/session-summary/secret-redactor.test.js
+++ b/tests/unit/session-summary/secret-redactor.test.js
@@ -1,0 +1,248 @@
+/**
+ * Secret Redactor Unit Tests
+ *
+ * Part of SD-LEO-ENH-AUTO-PROCEED-001-08 (TR-4, TS-5)
+ * Tests pattern-based secret redaction
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { redactSecrets, redactObject, containsSecrets } from '../../../scripts/modules/session-summary/secret-redactor.js';
+
+describe('SecretRedactor', () => {
+  describe('redactSecrets', () => {
+    it('should redact api_key patterns', () => {
+      expect(redactSecrets('api_key=ABC123SECRET456789')).toBe('api_key=[REDACTED]');
+      expect(redactSecrets('api-key: super_secret_key_12345')).toContain('[REDACTED]');
+      expect(redactSecrets('APIKEY=mysecretapikey12345')).toContain('[REDACTED]');
+    });
+
+    it('should redact Authorization Bearer tokens', () => {
+      expect(redactSecrets('Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.token')).toBe('Authorization: Bearer [REDACTED]');
+    });
+
+    it('should redact Authorization Basic tokens', () => {
+      expect(redactSecrets('Authorization: Basic dXNlcjpwYXNzd29yZA==')).toBe('Authorization: Basic [REDACTED]');
+    });
+
+    it('should redact password patterns', () => {
+      expect(redactSecrets('password=hunter2')).toBe('password=[REDACTED]');
+      expect(redactSecrets('PASSWORD: supersecret123')).toContain('[REDACTED]');
+      expect(redactSecrets('passwd=mypass')).toContain('[REDACTED]');
+    });
+
+    it('should redact database connection strings', () => {
+      expect(redactSecrets('postgres://user:password@localhost/db')).toBe('postgres://[REDACTED]@localhost/db');
+      expect(redactSecrets('mysql://admin:secret123@mysql.server.com/mydb')).toBe('mysql://[REDACTED]@mysql.server.com/mydb');
+      expect(redactSecrets('mongodb://root:pass@mongo.host/admin')).toBe('mongodb://[REDACTED]@mongo.host/admin');
+    });
+
+    it('should redact AWS credentials', () => {
+      expect(redactSecrets('AKIAIOSFODNN7EXAMPLE')).toBe('[AWS_KEY_REDACTED]');
+      expect(redactSecrets('aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')).toContain('[REDACTED]');
+    });
+
+    it('should redact Supabase keys', () => {
+      expect(redactSecrets('SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.secret')).toContain('[REDACTED]');
+      expect(redactSecrets('SUPABASE_ANON_KEY=public_anon_key_value')).toContain('[REDACTED]');
+    });
+
+    it('should redact JWTs', () => {
+      // JWT pattern requires at least 50 chars in first segment
+      const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImV4dHJhIjoiZGF0YXRvbWFrZWl0bG9uZ2VyIn0.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature';
+      expect(redactSecrets(jwt)).toBe('[JWT_REDACTED]');
+    });
+
+    it('should redact private keys', () => {
+      const privateKey = '-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7etc\n-----END PRIVATE KEY-----';
+      expect(redactSecrets(privateKey)).toBe('[PRIVATE_KEY_REDACTED]');
+    });
+
+    it('should redact GitHub tokens', () => {
+      expect(redactSecrets('ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')).toBe('[GITHUB_TOKEN_REDACTED]');
+      expect(redactSecrets('gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')).toBe('[GITHUB_OAUTH_REDACTED]');
+    });
+
+    it('should redact OpenAI/Anthropic keys', () => {
+      expect(redactSecrets('sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx')).toBe('[OPENAI_KEY_REDACTED]');
+      const anthropicKey = 'sk-ant-' + 'x'.repeat(80);
+      expect(redactSecrets(anthropicKey)).toBe('[ANTHROPIC_KEY_REDACTED]');
+    });
+
+    it('should redact generic secret patterns', () => {
+      expect(redactSecrets('secret=very_secret_value_123')).toContain('[REDACTED]');
+      expect(redactSecrets('token: my_access_token_12345')).toContain('[REDACTED]');
+      expect(redactSecrets('credential=some_credential_value')).toContain('[REDACTED]');
+    });
+
+    it('should handle null and undefined input', () => {
+      expect(redactSecrets(null)).toBeNull();
+      expect(redactSecrets(undefined)).toBeUndefined();
+    });
+
+    it('should handle non-string input', () => {
+      expect(redactSecrets(12345)).toBe(12345);
+      expect(redactSecrets({})).toEqual({});
+    });
+
+    it('should preserve non-sensitive text', () => {
+      const text = 'This is a normal log message without any secrets';
+      expect(redactSecrets(text)).toBe(text);
+    });
+
+    it('should handle multiple secrets in one string', () => {
+      // api_key pattern requires at least 16 chars
+      const text = 'api_key=secret_key_value_1234567890 and password=hunter2';
+      const result = redactSecrets(text);
+      expect(result).toContain('api_key=[REDACTED]');
+      expect(result).toContain('password=[REDACTED]');
+      expect(result).not.toContain('secret_key_value');
+      expect(result).not.toContain('hunter2');
+    });
+  });
+
+  describe('redactObject', () => {
+    it('should redact secrets in object values', () => {
+      const obj = {
+        message: 'Error: api_key=secret_value_that_is_long_enough_123',
+        code: 'AUTH_ERROR'
+      };
+
+      const result = redactObject(obj);
+
+      expect(result.message).toContain('[REDACTED]');
+      expect(result.message).not.toContain('secret_value_that_is_long');
+      expect(result.code).toBe('AUTH_ERROR');
+    });
+
+    it('should redact nested objects', () => {
+      const obj = {
+        level1: {
+          level2: {
+            secret: 'password=hunter2'
+          }
+        }
+      };
+
+      const result = redactObject(obj);
+
+      expect(result.level1.level2.secret).toContain('[REDACTED]');
+    });
+
+    it('should redact arrays', () => {
+      const arr = [
+        'normal text',
+        'api_key=secret_value_12345',
+        { nested: 'password=test123' }
+      ];
+
+      const result = redactObject(arr);
+
+      expect(result[0]).toBe('normal text');
+      expect(result[1]).toContain('[REDACTED]');
+      expect(result[2].nested).toContain('[REDACTED]');
+    });
+
+    it('should redact values of sensitive keys', () => {
+      const obj = {
+        username: 'john',
+        password: 'super_secret',
+        api_key: 'my_api_key',
+        token: 'access_token_value',
+        normal_field: 'normal value'
+      };
+
+      const result = redactObject(obj);
+
+      expect(result.username).toBe('john');
+      expect(result.password).toBe('[REDACTED]');
+      expect(result.api_key).toBe('[REDACTED]');
+      expect(result.token).toBe('[REDACTED]');
+      expect(result.normal_field).toBe('normal value');
+    });
+
+    it('should handle circular references', () => {
+      const obj = { name: 'test' };
+      obj.self = obj;
+
+      const result = redactObject(obj);
+
+      expect(result.name).toBe('test');
+      expect(result.self).toBe('[CIRCULAR_REFERENCE]');
+    });
+
+    it('should handle null and undefined', () => {
+      expect(redactObject(null)).toBeNull();
+      expect(redactObject(undefined)).toBeUndefined();
+    });
+
+    it('should handle primitive values', () => {
+      expect(redactObject(42)).toBe(42);
+      expect(redactObject(true)).toBe(true);
+      expect(redactObject('simple string')).toBe('simple string');
+    });
+  });
+
+  describe('containsSecrets', () => {
+    it('should detect API keys', () => {
+      expect(containsSecrets('api_key=secret123456789012')).toBe(true);
+    });
+
+    it('should detect Bearer tokens', () => {
+      expect(containsSecrets('Authorization: Bearer sometoken')).toBe(true);
+    });
+
+    it('should detect passwords', () => {
+      expect(containsSecrets('password=mypassword')).toBe(true);
+    });
+
+    it('should detect database URLs', () => {
+      expect(containsSecrets('postgres://user:pass@host/db')).toBe(true);
+    });
+
+    it('should return false for clean text', () => {
+      expect(containsSecrets('This is normal text')).toBe(false);
+    });
+
+    it('should handle null/undefined', () => {
+      expect(containsSecrets(null)).toBe(false);
+      expect(containsSecrets(undefined)).toBe(false);
+    });
+
+    it('should handle non-strings', () => {
+      expect(containsSecrets(12345)).toBe(false);
+      expect(containsSecrets({})).toBe(false);
+    });
+  });
+
+  describe('Edge Cases (TS-5)', () => {
+    it('should redact secrets appearing at start of string', () => {
+      // api_key pattern requires at least 16 chars
+      expect(redactSecrets('api_key=start_secret_value_12345')).toContain('[REDACTED]');
+    });
+
+    it('should redact secrets appearing at end of string', () => {
+      // api_key pattern requires at least 16 chars
+      expect(redactSecrets('end with api_key=endsecretvalue_123456')).toContain('[REDACTED]');
+    });
+
+    it('should handle empty strings', () => {
+      expect(redactSecrets('')).toBe('');
+    });
+
+    it('should handle very long strings', () => {
+      const longString = 'x'.repeat(10000) + 'api_key=secret123' + 'x'.repeat(10000);
+      const result = redactSecrets(longString);
+      expect(result).toContain('[REDACTED]');
+      expect(result).not.toContain('secret123');
+    });
+
+    it('should not produce false positives for short values', () => {
+      // api_key pattern requires at least 16 chars after =
+      expect(redactSecrets('api_key=short')).toBe('api_key=short');
+    });
+
+    it('should handle special regex characters in surrounding text', () => {
+      expect(redactSecrets('[test] api_key=secret_value_12345 {info}')).toContain('[REDACTED]');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements detailed session summaries on orchestrator completion (D17 from AUTO-PROCEED discovery):

- **SessionEventCollector**: Captures SD events during session execution
- **SummaryGenerator**: Creates structured JSON summaries with metrics
- **Secret redaction**: Removes sensitive data (JWTs, API keys, connection strings) from summaries
- **Integration**: Hooks into orchestrator-completion-hook for automatic summary generation

## Changes

- `scripts/modules/session-summary/` - Core summary generation modules
- `scripts/modules/handoff/orchestrator-completion-hook.js` - Integration point
- `scripts/modules/handoff/gates/core-protocol-gate.js` - Enhanced validation
- `tests/unit/session-summary/` - Comprehensive unit tests
- `tests/e2e/session-summary.test.js` - End-to-end tests

## Test plan

- [x] Unit tests for SessionEventCollector
- [x] Unit tests for SummaryGenerator
- [x] Unit tests for secret-redactor
- [x] E2E tests for full workflow
- [ ] Manual verification with orchestrator completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)