### PR TITLE
docs(index): add session-start-gate-implementation.md to reference index

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -30,12 +30,12 @@ See **[/docs/leo/README.md](/docs/leo/README.md)** for:
 | [Database & Schema](#database--schema) | 12 | Database patterns, schemas, migrations |
 | [Sub-Agents](#sub-agents) | 14 | Sub-agent patterns and guides |
 | [Validation & Testing](#validation--testing) | 9 | Validation patterns, testing reference |
-| [LEO Protocol](#leo-protocol) | 12 | Protocol reference, context management, hooks |
+| [LEO Protocol](#leo-protocol) | 13 | Protocol reference, context management, hooks |
 | [Patterns & Best Practices](#patterns--best-practices) | 12 | Development patterns |
 | [Quick References](#quick-references) | 12 | Cheat sheets and quick guides |
 | [Other](#other-references) | 7 | Miscellaneous references |
 
-**Total References**: 78
+**Total References**: 79
 
 ---
 
@@ -110,6 +110,7 @@ See **[/docs/leo/README.md](/docs/leo/README.md)** for:
 | [handoff-system-guide.md](handoff-system-guide.md) | Handoff system reference |
 | [leo-hook-feedback-system.md](leo-hook-feedback-system.md) | Hook feedback system |
 | [protocol-self-improvement.md](protocol-self-improvement.md) | Protocol self-improvement |
+| [session-start-gate-implementation.md](session-start-gate-implementation.md) | SESSION_START gate implementation + state structure mismatch fix |
 | [skip-and-continue-pattern.md](skip-and-continue-pattern.md) | **⭐ NEW** Skip-and-continue for validation gate failures (AUTO-PROCEED D16) |
 
 ---


### PR DESCRIPTION
## Summary
- Add new SESSION_START gate implementation document to reference index
- Update LEO Protocol section count (12→13)
- Update total reference count (78→79)

Part of SD-LEO-INFRA-SESSION-START-GATE-001 documentation follow-up.

## Test plan
- [x] Index file renders correctly in markdown
- [x] Link to new document is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)