### PR TITLE
fix(hooks): correct protocol-file-tracker path from .js to .cjs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/protocol-file-tracker.js",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/protocol-file-tracker.cjs",
             "timeout": 3
           }
         ]


### PR DESCRIPTION
## Summary
- Fix protocol-file-tracker hook path in settings.json
- Root cause: File was renamed to .cjs but settings.json still referenced .js
- This caused silent hook failures, preventing protocol file reads from being recorded

## Root Cause Analysis
| Item | Finding |
|------|---------|
| **Symptom** | GATE_SD_START_PROTOCOL always failed with "NEVER_READ" |
| **Root Cause** | settings.json pointed to non-existent `.js` file |
| **Actual File** | `protocol-file-tracker.cjs` |
| **Fix** | Update path in settings.json to use `.cjs` extension |

## Test plan
- [x] Hook executes successfully when Read tool is used
- [x] Protocol files are recorded in session state
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)