### PR TITLE
fix(hooks): read tool info from stdin instead of env vars

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -662,6 +662,40 @@ When starting work on an SD that has a `parent_sd_id`:
 node scripts/child-sd-preflight.js SD-XXX-001
 ```
 
+### Context Loading Requirements (MANDATORY)
+
+**CRITICAL**: Before starting work on ANY SD (new, existing, or child), you MUST load the required context files in this order:
+
+#### Step 1: ALWAYS Read CLAUDE_CORE.md First
+```
+Read tool: CLAUDE_CORE.md
+```
+This provides:
+- SD type definitions and workflow requirements
+- PRD requirements, handoff counts, gate thresholds
+- Sub-agent invocation requirements
+- Validation gate definitions
+
+**This applies to ALL SDs including children of orchestrators.**
+
+#### Step 2: Load Phase-Specific Context
+Based on the SD's `current_phase`, load the appropriate file:
+
+| Phase | File to Load |
+|-------|--------------|
+| LEAD_APPROVAL, LEAD_FINAL_APPROVAL | CLAUDE_LEAD.md |
+| PLAN_*, PRD_* | CLAUDE_PLAN.md |
+| EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
+
+#### Why This Matters
+Without loading CLAUDE_CORE.md:
+- SD type requirements are unknown
+- Gate thresholds may be violated
+- Required sub-agents may be skipped
+- Handoff chain may be incomplete
+
+**Skipping context loading is a protocol violation.**
+
 #### What It Validates
 1. **Dependency Chain**: Each SD in `dependency_chain` must be:
    - Status: `completed`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 ```
 
 ## DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2026-01-25 1:41:46 PM
+**Last Generated**: 2026-01-25 5:23:18 PM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 
@@ -326,6 +326,13 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 1. **ALWAYS**: Read CLAUDE_CORE.md first (15k)
 2. **Phase Detection**: Load phase-specific file based on keywords
 3. **On-Demand**: Load reference docs only when issues arise
+
+**CRITICAL**: This loading strategy applies to ALL SD work:
+- New SDs being created
+- Existing SDs being resumed
+- **Child SDs of orchestrators** (each child requires fresh context loading)
+
+Skipping CLAUDE_CORE.md causes: unknown SD type requirements, missed gate thresholds, skipped sub-agents.
 
 ### Phase Keywords → File
 | Keywords | Load |

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-01-25 1:41:46 PM
+**Generated**: 2026-01-25 5:23:18 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions (15-20k chars)
 
@@ -140,6 +140,37 @@ npm run handoff:compliance SD-ID
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
+## Mandatory Agent Invocation Rules
+
+**CRITICAL**: Certain task types REQUIRE specialized agent invocation - NO ad-hoc manual inspection allowed.
+
+### Task Type -> Required Agent
+
+| Task Keywords | MUST Invoke | Purpose |
+|---------------|-------------|---------|
+| UI, UX, design, landing page, styling, CSS, colors, buttons | **design-agent** | Accessibility audit (axe-core), contrast checking |
+| accessibility, a11y, WCAG, screen reader, contrast | **design-agent** | WCAG 2.1 AA compliance validation |
+| form, input, validation, user flow | **design-agent** + **testing-agent** | UX + E2E verification |
+| performance, slow, loading, latency | **performance-agent** | Load testing, optimization |
+| security, auth, RLS, permissions | **security-agent** | Vulnerability assessment |
+| API, endpoint, REST, GraphQL | **api-agent** | API design patterns |
+| database, migration, schema | **database-agent** | Schema validation |
+| test, E2E, Playwright, coverage | **testing-agent** | Test execution |
+
+### Why This Exists
+
+**Incident**: Human-like testing perspective interpreted as manual content inspection.
+**Result**: 47 accessibility issues missed, including critical contrast failures (1.03:1 ratio).
+**Root Cause**: Ad-hoc review instead of specialized agent invocation.
+**Prevention**: Explicit rules mandate agent use for specialized tasks.
+
+### How to Apply
+
+1. Detect task type from user request keywords
+2. Invoke required agent(s) BEFORE making changes
+3. Agent findings inform implementation
+4. Re-run agent AFTER changes to verify fixes
+
 ## 🤖 Built-in Agent Integration
 
 ## Built-in Agent Integration
@@ -181,37 +212,6 @@ Task(subagent_type="Explore", prompt="Identify affected areas")
 ```
 
 This is faster than sequential exploration and provides comprehensive coverage.
-
-## Mandatory Agent Invocation Rules
-
-**CRITICAL**: Certain task types REQUIRE specialized agent invocation - NO ad-hoc manual inspection allowed.
-
-### Task Type -> Required Agent
-
-| Task Keywords | MUST Invoke | Purpose |
-|---------------|-------------|---------|
-| UI, UX, design, landing page, styling, CSS, colors, buttons | **design-agent** | Accessibility audit (axe-core), contrast checking |
-| accessibility, a11y, WCAG, screen reader, contrast | **design-agent** | WCAG 2.1 AA compliance validation |
-| form, input, validation, user flow | **design-agent** + **testing-agent** | UX + E2E verification |
-| performance, slow, loading, latency | **performance-agent** | Load testing, optimization |
-| security, auth, RLS, permissions | **security-agent** | Vulnerability assessment |
-| API, endpoint, REST, GraphQL | **api-agent** | API design patterns |
-| database, migration, schema | **database-agent** | Schema validation |
-| test, E2E, Playwright, coverage | **testing-agent** | Test execution |
-
-### Why This Exists
-
-**Incident**: Human-like testing perspective interpreted as manual content inspection.
-**Result**: 47 accessibility issues missed, including critical contrast failures (1.03:1 ratio).
-**Root Cause**: Ad-hoc review instead of specialized agent invocation.
-**Prevention**: Explicit rules mandate agent use for specialized tasks.
-
-### How to Apply
-
-1. Detect task type from user request keywords
-2. Invoke required agent(s) BEFORE making changes
-3. Agent findings inform implementation
-4. Re-run agent AFTER changes to verify fixes
 
 ## Claude Code Plan Mode Integration
 
@@ -385,6 +385,47 @@ Before marking any stage/feature as complete:
 
 **BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
+## Sustainable Issue Resolution Philosophy
+
+**CHAIRMAN PREFERENCE**: When encountering issues, bugs, or blockers during implementation:
+
+### Core Principles
+
+1. **Handle Issues Immediately**
+   - Do NOT defer problems to "fix later" or create tech debt
+   - Address issues as they arise, before moving forward
+   - Blocking issues must be resolved before continuing
+
+2. **Resolve Systemically**
+   - Fix the root cause, not just the symptom
+   - Consider why the issue occurred and prevent recurrence
+   - Update patterns, validation rules, or documentation as needed
+
+3. **Prefer Sustainable Solutions**
+   - Choose fixes that will last, not quick patches
+   - Avoid workarounds that need to be revisited
+   - Ensure the solution integrates properly with existing architecture
+
+### Implementation Guidelines
+
+| Scenario | Wrong Approach | Right Approach |
+|----------|----------------|----------------|
+| Test failing | Skip test, add TODO | Fix underlying issue, ensure test passes |
+| Type error | Cast to `any` | Fix types properly, update interfaces |
+| Migration issue | Comment out problematic code | Fix schema, add proper handling |
+| Build warning | Suppress warning | Address root cause of warning |
+| Performance issue | Defer to "optimization SD" | Fix if simple; create SD only if complex |
+
+### Exception Handling
+
+If immediate resolution is truly impossible:
+1. Document the issue thoroughly
+2. Create a high-priority SD for resolution
+3. Add a failing test that captures the issue
+4. Note the workaround as TEMPORARY with removal timeline
+
+**Default behavior**: Resolve now, resolve properly, resolve sustainably.
+
 ## 🎯 Skill Integration (Claude Code Skills)
 
 ## Skill Integration (Claude Code Skills)
@@ -427,47 +468,6 @@ Before marking any stage/feature as complete:
 - **Project**: .claude/skills/ (project-specific)
 - **Index**: ~/.claude/skills/SKILL-INDEX.md
 - **Total**: 54 skills covering all 14 sub-agents
-
-## Sustainable Issue Resolution Philosophy
-
-**CHAIRMAN PREFERENCE**: When encountering issues, bugs, or blockers during implementation:
-
-### Core Principles
-
-1. **Handle Issues Immediately**
-   - Do NOT defer problems to "fix later" or create tech debt
-   - Address issues as they arise, before moving forward
-   - Blocking issues must be resolved before continuing
-
-2. **Resolve Systemically**
-   - Fix the root cause, not just the symptom
-   - Consider why the issue occurred and prevent recurrence
-   - Update patterns, validation rules, or documentation as needed
-
-3. **Prefer Sustainable Solutions**
-   - Choose fixes that will last, not quick patches
-   - Avoid workarounds that need to be revisited
-   - Ensure the solution integrates properly with existing architecture
-
-### Implementation Guidelines
-
-| Scenario | Wrong Approach | Right Approach |
-|----------|----------------|----------------|
-| Test failing | Skip test, add TODO | Fix underlying issue, ensure test passes |
-| Type error | Cast to `any` | Fix types properly, update interfaces |
-| Migration issue | Comment out problematic code | Fix schema, add proper handling |
-| Build warning | Suppress warning | Address root cause of warning |
-| Performance issue | Defer to "optimization SD" | Fix if simple; create SD only if complex |
-
-### Exception Handling
-
-If immediate resolution is truly impossible:
-1. Document the issue thoroughly
-2. Create a high-priority SD for resolution
-3. Add a failing test that captures the issue
-4. Note the workaround as TEMPORARY with removal timeline
-
-**Default behavior**: Resolve now, resolve properly, resolve sustainably.
 
 ## 🚫 Stage 7 Hard Block: UI Coverage Prerequisite
 
@@ -514,38 +514,6 @@ To request an exception to this block:
 
 **No exceptions without explicit LEAD approval.**
 
-## Child SD Pre-Work Validation (MANDATORY)
-
-**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
-
-### Validation Command
-```bash
-node scripts/child-sd-preflight.js SD-XXX-001
-```
-
-### What It Checks
-1. **Is Child SD**: Verifies the SD has a parent_sd_id
-2. **Dependency Chain**: For each dependency SD:
-   - Status must be `completed`
-   - Progress must be `100%`
-   - Required handoffs must be present
-3. **Parent Context**: Loads parent orchestrator for reference
-
-### Results
-**PASS** - Ready to work if:
-- SD is standalone (not a child), OR
-- No dependencies, OR
-- All dependencies complete with required handoffs
-
-**BLOCKED** - Cannot proceed if:
-- One or more dependency SDs incomplete
-- Missing required handoffs on dependencies
-- Action: Complete blocking dependency first
-
-### Integration
-- `npm run sd:next` shows dependency status in queue
-- Child SDs with incomplete dependencies show as BLOCKED
-
 ## Global Negative Constraints
 
 These anti-patterns apply across ALL phases. Violating them leads to failed handoffs and rework.
@@ -578,6 +546,38 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 - `node scripts/handoff.js execute ...`
 - `node scripts/add-prd-to-database.js ...`
 - `node scripts/phase-preflight.js ...`
+
+## Child SD Pre-Work Validation (MANDATORY)
+
+**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
+
+### Validation Command
+```bash
+node scripts/child-sd-preflight.js SD-XXX-001
+```
+
+### What It Checks
+1. **Is Child SD**: Verifies the SD has a parent_sd_id
+2. **Dependency Chain**: For each dependency SD:
+   - Status must be `completed`
+   - Progress must be `100%`
+   - Required handoffs must be present
+3. **Parent Context**: Loads parent orchestrator for reference
+
+### Results
+**PASS** - Ready to work if:
+- SD is standalone (not a child), OR
+- No dependencies, OR
+- All dependencies complete with required handoffs
+
+**BLOCKED** - Cannot proceed if:
+- One or more dependency SDs incomplete
+- Missing required handoffs on dependencies
+- Action: Complete blocking dependency first
+
+### Integration
+- `npm run sd:next` shows dependency status in queue
+- Child SDs with incomplete dependencies show as BLOCKED
 
 ## 🔄 Git Commit Guidelines
 

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-01-25 1:41:46 PM
+**Generated**: 2026-01-25 5:23:18 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing (20-25k chars)
 
@@ -248,6 +248,70 @@ See: `docs/03_protocols_and_standards/gate0-workflow-entry-enforcement.md` for c
 **If SD is in draft**: STOP. Do not implement. Run LEAD-TO-PLAN handoff first.
 
 
+## Branch Creation (Automated at LEAD-TO-PLAN)
+
+## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
+
+### Automatic Branch Creation
+
+As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
+
+1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
+2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
+3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
+4. Database is updated with branch name for tracking
+
+### Manual Branch Creation (If Needed)
+
+If branch creation fails or you need to create one manually:
+
+```bash
+# Create branch for an SD (looks up title from database)
+npm run sd:branch SD-XXX-001
+
+# Create with auto-stash (non-interactive)
+npm run sd:branch:auto SD-XXX-001
+
+# Check if branch exists
+npm run sd:branch:check SD-XXX-001
+
+# Full command with options
+node scripts/create-sd-branch.js SD-XXX-001 --app EHG --auto-stash
+```
+
+### Branch Naming Convention
+
+| SD Type | Branch Prefix | Example |
+|---------|---------------|---------|
+| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
+| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
+| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
+| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
+| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
+
+### Branch Hygiene Rules
+
+From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
+- **≤7 days stale** at PLAN-TO-EXEC handoff
+- **One SD per branch** (no mixing work)
+- **Merge main at phase transitions**
+
+### When Branch is Created
+
+```
+LEAD Phase                    PLAN Phase                   EXEC Phase
+    |                              |                            |
+    |   LEAD-TO-PLAN handoff       |                            |
+    |---[Branch Created Here]----->|                            |
+    |                              |   PRD Creation             |
+    |                              |   Sub-agent validation     |
+    |                              |                            |
+    |                              |   PLAN-TO-EXEC handoff     |
+    |                              |---[Branch Validated]------>|
+    |                              |                            |
+```
+
+
 ## ❌ Anti-Patterns from Retrospectives (EXEC Phase)
 
 **Source**: Analysis of 175 high-quality retrospectives (score ≥60)
@@ -335,70 +399,6 @@ If `research_confidence_score = 0.00`, you skipped this step.
 | Simulate sub-agents | 15% quality loss | Execute actual tools |
 
 **Pattern References**: PAT-RECURSION-001 through PAT-RECURSION-005
-
-## Branch Creation (Automated at LEAD-TO-PLAN)
-
-## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
-
-### Automatic Branch Creation
-
-As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
-
-1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
-2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
-3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
-4. Database is updated with branch name for tracking
-
-### Manual Branch Creation (If Needed)
-
-If branch creation fails or you need to create one manually:
-
-```bash
-# Create branch for an SD (looks up title from database)
-npm run sd:branch SD-XXX-001
-
-# Create with auto-stash (non-interactive)
-npm run sd:branch:auto SD-XXX-001
-
-# Check if branch exists
-npm run sd:branch:check SD-XXX-001
-
-# Full command with options
-node scripts/create-sd-branch.js SD-XXX-001 --app EHG --auto-stash
-```
-
-### Branch Naming Convention
-
-| SD Type | Branch Prefix | Example |
-|---------|---------------|---------|
-| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
-| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
-| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
-| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
-| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
-
-### Branch Hygiene Rules
-
-From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
-- **≤7 days stale** at PLAN-TO-EXEC handoff
-- **One SD per branch** (no mixing work)
-- **Merge main at phase transitions**
-
-### When Branch is Created
-
-```
-LEAD Phase                    PLAN Phase                   EXEC Phase
-    |                              |                            |
-    |   LEAD-TO-PLAN handoff       |                            |
-    |---[Branch Created Here]----->|                            |
-    |                              |   PRD Creation             |
-    |                              |   Sub-agent validation     |
-    |                              |                            |
-    |                              |   PLAN-TO-EXEC handoff     |
-    |                              |---[Branch Validated]------>|
-    |                              |                            |
-```
-
 
 ## EXEC Phase Negative Constraints
 
@@ -665,24 +665,6 @@ EXEC→PLAN handoffs now have **intelligent verification**:
 | **300-600** | ✅ **OPTIMAL** | Sweet spot |
 | **>800** | **MUST split** | Too complex |
 
-## TODO Comment Standard
-
-## TODO Comment Standard (When Deferring Work)
-
-**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
-
-### Standard TODO Format
-
-```typescript
-// TODO (SD-ID): Action required
-// Requires: Dependencies, prerequisites
-// Estimated effort: X-Y hours
-// Current state: Mock/temporary/placeholder
-```
-
-**Success Pattern** (SD-UAT-003):
-> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
-
 ## Human-Like E2E Testing Fixtures
 
 ### Human-Like E2E Testing Enhancements (LEO v4.4)
@@ -766,6 +748,24 @@ All human-like test results are automatically included in the LEO evidence pack:
 - `test_results.attachments.accessibility` - axe-core violations
 - `test_results.attachments.chaos` - resilience test results
 - `test_results.attachments.llm_ux` - LLM evaluation scores
+
+## TODO Comment Standard
+
+## TODO Comment Standard (When Deferring Work)
+
+**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
+
+### Standard TODO Format
+
+```typescript
+// TODO (SD-ID): Action required
+// Requires: Dependencies, prerequisites
+// Estimated effort: X-Y hours
+// Current state: Mock/temporary/placeholder
+```
+
+**Success Pattern** (SD-UAT-003):
+> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
 
 ## EXEC Dual Test Requirement
 
@@ -1174,6 +1174,77 @@ npm run sd:branch SD-XXX-001    # Creates and switches to branch
 ```
 
 
+## Playwright MCP Integration
+
+## 🎭 Playwright MCP Integration
+
+**Status**: ✅ READY (Installed 2025-10-12)
+
+### Overview
+Playwright MCP (Model Context Protocol) provides browser automation capabilities for testing, scraping, and UI verification.
+
+### Installed Components
+- **Chrome**: Google Chrome browser for MCP operations
+- **Chromium**: Chromium 141.0.7390.37 (build 1194) for standard Playwright tests
+- **Chromium Headless Shell**: Headless browser for CI/CD pipelines
+- **System Dependencies**: All required Linux libraries installed
+
+### Available MCP Tools
+
+#### Navigation
+- `mcp__playwright__browser_navigate` - Navigate to URL
+- `mcp__playwright__browser_navigate_back` - Go back to previous page
+
+#### Interaction
+- `mcp__playwright__browser_click` - Click elements
+- `mcp__playwright__browser_fill` - Fill form fields
+- `mcp__playwright__browser_select` - Select dropdown options
+- `mcp__playwright__browser_hover` - Hover over elements
+- `mcp__playwright__browser_type` - Type text into elements
+
+#### Verification
+- `mcp__playwright__browser_snapshot` - Capture accessibility snapshot
+- `mcp__playwright__browser_take_screenshot` - Take screenshots
+- `mcp__playwright__browser_evaluate` - Execute JavaScript
+
+#### Management
+- `mcp__playwright__browser_close` - Close browser
+- `mcp__playwright__browser_tabs` - Manage tabs
+
+### Testing Integration
+
+**When to Use Playwright MCP**:
+1. ✅ Visual regression testing
+2. ✅ UI component verification
+3. ✅ Screenshot capture for evidence
+4. ✅ Accessibility tree validation
+5. ✅ Cross-browser testing
+
+**When to Use Standard Playwright**:
+1. ✅ E2E test suites (`npm run test:e2e`)
+2. ✅ CI/CD pipeline tests
+3. ✅ Automated test runs
+4. ✅ User story validation
+
+### Usage Example
+
+```javascript
+// Using Playwright MCP for visual verification
+await mcp__playwright__browser_navigate({ url: 'http://localhost:3000/dashboard' });
+await mcp__playwright__browser_snapshot(); // Get accessibility tree
+await mcp__playwright__browser_take_screenshot({ name: 'dashboard-state' });
+await mcp__playwright__browser_click({ element: 'Submit button', ref: 'e5' });
+```
+
+### QA Director Integration
+
+The QA Engineering Director sub-agent now has access to:
+- Playwright MCP for visual testing
+- Standard Playwright for E2E automation
+- Both Chrome (MCP) and Chromium (tests) browsers
+
+**Complete Guide**: See `docs/reference/playwright-mcp-guide.md`
+
 ## Triangulated Runtime Audit Protocol
 
 ### Purpose
@@ -1391,77 +1462,6 @@ See: `/runtime-audit` skill for full template
 - `codebase-search` - Finding code references
 - `schema-design` - Database schema issues
 
-
-## Playwright MCP Integration
-
-## 🎭 Playwright MCP Integration
-
-**Status**: ✅ READY (Installed 2025-10-12)
-
-### Overview
-Playwright MCP (Model Context Protocol) provides browser automation capabilities for testing, scraping, and UI verification.
-
-### Installed Components
-- **Chrome**: Google Chrome browser for MCP operations
-- **Chromium**: Chromium 141.0.7390.37 (build 1194) for standard Playwright tests
-- **Chromium Headless Shell**: Headless browser for CI/CD pipelines
-- **System Dependencies**: All required Linux libraries installed
-
-### Available MCP Tools
-
-#### Navigation
-- `mcp__playwright__browser_navigate` - Navigate to URL
-- `mcp__playwright__browser_navigate_back` - Go back to previous page
-
-#### Interaction
-- `mcp__playwright__browser_click` - Click elements
-- `mcp__playwright__browser_fill` - Fill form fields
-- `mcp__playwright__browser_select` - Select dropdown options
-- `mcp__playwright__browser_hover` - Hover over elements
-- `mcp__playwright__browser_type` - Type text into elements
-
-#### Verification
-- `mcp__playwright__browser_snapshot` - Capture accessibility snapshot
-- `mcp__playwright__browser_take_screenshot` - Take screenshots
-- `mcp__playwright__browser_evaluate` - Execute JavaScript
-
-#### Management
-- `mcp__playwright__browser_close` - Close browser
-- `mcp__playwright__browser_tabs` - Manage tabs
-
-### Testing Integration
-
-**When to Use Playwright MCP**:
-1. ✅ Visual regression testing
-2. ✅ UI component verification
-3. ✅ Screenshot capture for evidence
-4. ✅ Accessibility tree validation
-5. ✅ Cross-browser testing
-
-**When to Use Standard Playwright**:
-1. ✅ E2E test suites (`npm run test:e2e`)
-2. ✅ CI/CD pipeline tests
-3. ✅ Automated test runs
-4. ✅ User story validation
-
-### Usage Example
-
-```javascript
-// Using Playwright MCP for visual verification
-await mcp__playwright__browser_navigate({ url: 'http://localhost:3000/dashboard' });
-await mcp__playwright__browser_snapshot(); // Get accessibility tree
-await mcp__playwright__browser_take_screenshot({ name: 'dashboard-state' });
-await mcp__playwright__browser_click({ element: 'Submit button', ref: 'e5' });
-```
-
-### QA Director Integration
-
-The QA Engineering Director sub-agent now has access to:
-- Playwright MCP for visual testing
-- Standard Playwright for E2E automation
-- Both Chrome (MCP) and Chromium (tests) browsers
-
-**Complete Guide**: See `docs/reference/playwright-mcp-guide.md`
 
 ## Edge Case Testing Checklist
 

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-01-25 1:41:46 PM
+**Generated**: 2026-01-25 5:23:18 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 
@@ -732,6 +732,81 @@ const sdKey = await generateSDKey({ source, type, title });
 4. `scripts/create-sd.js`
 5. `scripts/modules/learning/executor.js`
 
+
+## Child SD Context Loading (MANDATORY)
+
+**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
+
+### Why This Applies to Children
+
+Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
+- Has its own PRD
+- Has its own handoffs
+- Has its own retrospective
+- Must meet its own gate thresholds
+
+**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
+
+### Required Context Loading Sequence
+
+Before starting ANY work on a child SD:
+
+1. **Run child preflight validation**:
+   ```bash
+   node scripts/child-sd-preflight.js SD-XXX-001
+   ```
+
+2. **Read CLAUDE_CORE.md** (provides SD type requirements):
+   ```
+   Read tool: CLAUDE_CORE.md
+   ```
+
+3. **Read phase-specific file** based on current_phase:
+   | Phase | File |
+   |-------|------|
+   | LEAD_APPROVAL | CLAUDE_LEAD.md |
+   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
+   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
+
+### What CLAUDE_CORE.md Provides
+
+- SD type definitions (feature, bugfix, infrastructure, etc.)
+- Gate pass thresholds per SD type
+- Required handoff counts
+- Required sub-agents per SD type
+- Global negative constraints
+
+### Consequences of Skipping Context Loading
+
+Without loading CLAUDE_CORE.md before child SD work:
+- **Unknown requirements**: May not know PRD is required
+- **Wrong thresholds**: May target 70% when 85% is required
+- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
+- **Incomplete handoffs**: May not execute full chain
+
+### Enforcement
+
+The `child-sd-preflight.js` script now displays a reminder:
+```
+⚠️  CONTEXT LOADING REMINDER:
+   Before starting work, you MUST read:
+   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
+   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
+```
+
+**This reminder is advisory.** The actual context loading must be performed by reading the files.
+
+### Quick Reference
+
+| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
+|---------------|----------------|--------------|--------------|
+| feature | 85% | 5 | YES |
+| bugfix | 85% | 5 | YES |
+| infrastructure | 80% | 4 | YES |
+| documentation | 60% | 4 | NO |
+| refactor | 75-90% | 5 | Brief |
+
+*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
 
 ## 📋 Directive Submission Review Process
 

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-01-25 1:41:46 PM
+**Generated**: 2026-01-25 5:23:18 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates (30-35k chars)
 
@@ -266,30 +266,6 @@ LEAD Phase                    PLAN Phase                   EXEC Phase
 ```
 
 
-## Deferred Work Management
-
-### What Gets Deferred
-- Technical debt discovered during implementation
-- Edge cases not critical for MVP
-- Performance optimizations for later
-- Nice-to-have features
-
-### Creating Deferred Items
-```sql
-INSERT INTO deferred_work (sd_id, title, reason, priority)
-VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
-```
-
-### Tracking
-- Deferred items linked to parent SD
-- Reviewed during retrospective
-- May become new SDs if significant
-
-### Rules
-- Document WHY deferred, not just WHAT
-- Set realistic priority (critical items shouldn't be deferred)
-- Max 5 deferred items per SD
-
 ## PLAN Phase Negative Constraints
 
 ## 🚫 PLAN Phase Negative Constraints
@@ -327,6 +303,30 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 **Why Wrong**: PRD validator blocks placeholders, signals incomplete planning
 **Correct Approach**: If truly unknown, use AskUserQuestion to clarify before PRD creation
 </negative_constraints>
+
+## Deferred Work Management
+
+### What Gets Deferred
+- Technical debt discovered during implementation
+- Edge cases not critical for MVP
+- Performance optimizations for later
+- Nice-to-have features
+
+### Creating Deferred Items
+```sql
+INSERT INTO deferred_work (sd_id, title, reason, priority)
+VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
+```
+
+### Tracking
+- Deferred items linked to parent SD
+- Reviewed during retrospective
+- May become new SDs if significant
+
+### Rules
+- Document WHY deferred, not just WHAT
+- Set realistic priority (critical items shouldn't be deferred)
+- Max 5 deferred items per SD
 
 ## PRD Template Scaffolding
 
@@ -436,23 +436,6 @@ node scripts/detect-stubbed-code.js <SD-ID>
 **Exit Requirement**: Zero stubbed code in production files, OR documented in "Known Issues" with follow-up SD created.
 
 
-## Enhanced QA Engineering Director v2.0 - Testing-First Edition
-
-**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
-
-**Core Capabilities:**
-1. Professional test case generation from user stories
-2. Pre-test build validation (saves 2-3 hours)
-3. Database migration verification (prevents 1-2 hours debugging)
-4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
-5. Test infrastructure discovery and reuse
-
-**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
-
-**Activation**: Auto-triggers on `EXEC_IMPLEMENTATION_COMPLETE`, coverage keywords, testing evidence requests
-
-**Full Guide**: See `docs/reference/qa-director-guide.md`
-
 ## ✅ Scope Verification with Explore (PLAN_VERIFY)
 
 ## Scope Verification with Explore
@@ -523,6 +506,23 @@ This change [describe]. Options:
 
 Which do you prefer?"
 ```
+
+## Enhanced QA Engineering Director v2.0 - Testing-First Edition
+
+**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
+
+**Core Capabilities:**
+1. Professional test case generation from user stories
+2. Pre-test build validation (saves 2-3 hours)
+3. Database migration verification (prevents 1-2 hours debugging)
+4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
+5. Test infrastructure discovery and reuse
+
+**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
+
+**Activation**: Auto-triggers on `EXEC_IMPLEMENTATION_COMPLETE`, coverage keywords, testing evidence requests
+
+**Full Guide**: See `docs/reference/qa-director-guide.md`
 
 ## Database Schema Documentation
 

--- a/database/manual-updates/20260125_fix_all_legacy_id_functions.sql
+++ b/database/manual-updates/20260125_fix_all_legacy_id_functions.sql
@@ -1,0 +1,715 @@
+-- ============================================================================
+-- FIX: Update all database functions to use sd_key instead of legacy_id
+-- Date: 2026-01-25
+-- Issue: PAT-LEGACYID-001 - legacy_id column was removed from strategic_directives_v2
+-- Replacement: Use sd_key column instead
+-- ============================================================================
+
+-- ============================================================================
+-- STEP 0: Drop functions/views with changed return types (required before recreation)
+-- ============================================================================
+DROP FUNCTION IF EXISTS get_sd_children_depth_first(text) CASCADE;
+DROP FUNCTION IF EXISTS get_unaligned_sds() CASCADE;
+DROP FUNCTION IF EXISTS lead_preflight_kr_check(varchar) CASCADE;
+
+-- Drop views that will be recreated
+DROP VIEW IF EXISTS v_sd_execution_status CASCADE;
+DROP VIEW IF EXISTS v_sd_next_candidates CASCADE;
+DROP VIEW IF EXISTS v_sd_okr_context CASCADE;
+DROP VIEW IF EXISTS v_sd_hierarchy CASCADE;
+DROP VIEW IF EXISTS v_sd_alignment_warnings CASCADE;
+
+-- ============================================================================
+-- 1. assess_sd_type_change_risk - Fix return value
+-- ============================================================================
+CREATE OR REPLACE FUNCTION assess_sd_type_change_risk(
+  p_sd_id VARCHAR(100),
+  p_from_type VARCHAR(50),
+  p_to_type VARCHAR(50)
+)
+RETURNS JSONB AS $$
+DECLARE
+  risk_score INTEGER := 0;
+  risk_factors JSONB := '[]'::jsonb;
+  risk_level VARCHAR(20);
+  sd RECORD;
+  from_profile RECORD;
+  to_profile RECORD;
+  user_story_count INTEGER;
+  deliverable_count INTEGER;
+  completed_deliverables INTEGER;
+  handoff_count INTEGER;
+  requirement_reduction INTEGER := 0;
+BEGIN
+  -- Get SD details
+  SELECT * INTO sd FROM strategic_directives_v2 WHERE id = p_sd_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'error', 'SD not found',
+      'sd_id', p_sd_id
+    );
+  END IF;
+
+  -- Get validation profiles
+  SELECT * INTO from_profile FROM sd_type_validation_profiles WHERE sd_type = p_from_type;
+  SELECT * INTO to_profile FROM sd_type_validation_profiles WHERE sd_type = p_to_type;
+
+  -- Count existing work
+  SELECT COUNT(*) INTO user_story_count FROM user_stories WHERE sd_id = sd.id;
+  SELECT COUNT(*) INTO deliverable_count FROM sd_scope_deliverables WHERE sd_id = sd.id;
+  SELECT COUNT(*) INTO completed_deliverables FROM sd_scope_deliverables
+    WHERE sd_id = sd.id AND completion_status = 'completed';
+  SELECT COUNT(DISTINCT handoff_type) INTO handoff_count FROM sd_phase_handoffs
+    WHERE sd_id = p_sd_id AND status = 'accepted';
+
+  -- ============================================================================
+  -- RISK FACTOR 1: Requirement Reduction (0-40 points)
+  -- ============================================================================
+  IF COALESCE(from_profile.requires_e2e_tests, false) AND NOT COALESCE(to_profile.requires_e2e_tests, false) THEN
+    risk_score := risk_score + 20;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'E2E Test Requirement Dropped',
+      'points', 20,
+      'description', 'Changing from type requiring E2E tests to type without E2E requirement'
+    );
+  END IF;
+
+  IF COALESCE(from_profile.requires_user_stories, from_profile.requires_e2e_tests, false)
+     AND NOT COALESCE(to_profile.requires_user_stories, to_profile.requires_e2e_tests, false) THEN
+    risk_score := risk_score + 15;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'User Story Requirement Dropped',
+      'points', 15,
+      'description', 'Changing from type requiring user stories to type without story requirement'
+    );
+  END IF;
+
+  IF COALESCE(from_profile.requires_deliverables, false) AND NOT COALESCE(to_profile.requires_deliverables, false) THEN
+    risk_score := risk_score + 10;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'Deliverables Requirement Dropped',
+      'points', 10,
+      'description', 'Changing from type requiring deliverables to type without deliverable tracking'
+    );
+  END IF;
+
+  IF COALESCE(from_profile.requires_retrospective, false) AND NOT COALESCE(to_profile.requires_retrospective, false) THEN
+    risk_score := risk_score + 5;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'Retrospective Requirement Dropped',
+      'points', 5,
+      'description', 'Changing from type requiring retrospective to type without retrospective'
+    );
+  END IF;
+
+  -- ============================================================================
+  -- RISK FACTOR 2: Phase Timing (0-25 points)
+  -- ============================================================================
+  IF sd.current_phase = 'EXEC' THEN
+    risk_score := risk_score + 15;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'Change During EXEC Phase',
+      'points', 15,
+      'description', 'SD is currently in EXEC phase - type change may invalidate in-progress work'
+    );
+  END IF;
+
+  IF sd.current_phase = 'LEAD_FINAL' THEN
+    risk_score := risk_score + 25;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'Change During Final Approval',
+      'points', 25,
+      'description', 'SD is in LEAD_FINAL phase - type change at this stage is highly suspicious'
+    );
+  END IF;
+
+  IF sd.status = 'pending_approval' THEN
+    risk_score := risk_score + 10;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'Change While Pending Approval',
+      'points', 10,
+      'description', 'SD is pending approval - type change may be attempt to bypass review'
+    );
+  END IF;
+
+  -- ============================================================================
+  -- RISK FACTOR 3: Existing Work Impact (0-25 points)
+  -- ============================================================================
+  IF user_story_count > 0 AND NOT COALESCE(to_profile.requires_user_stories, to_profile.requires_e2e_tests, true) THEN
+    risk_score := risk_score + (LEAST(user_story_count, 5) * 5);
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'User Stories May Be Orphaned',
+      'points', LEAST(user_story_count, 5) * 5,
+      'description', format('%s user stories exist but new type does not require stories', user_story_count)
+    );
+  END IF;
+
+  IF completed_deliverables > 0 AND NOT COALESCE(to_profile.requires_deliverables, true) THEN
+    risk_score := risk_score + 15;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'Completed Deliverables May Be Orphaned',
+      'points', 15,
+      'description', format('%s completed deliverables exist but new type does not track deliverables', completed_deliverables)
+    );
+  END IF;
+
+  -- ============================================================================
+  -- RISK FACTOR 4: Pattern Detection (0-20 points)
+  -- ============================================================================
+  IF p_from_type = 'feature' AND p_to_type = 'infrastructure' THEN
+    risk_score := risk_score + 10;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'Feature-to-Infrastructure Pattern',
+      'points', 10,
+      'description', 'Changing from feature to infrastructure - common validation bypass pattern'
+    );
+  END IF;
+
+  IF p_from_type = 'feature' AND p_to_type = 'docs' AND (user_story_count > 0 OR deliverable_count > 0) THEN
+    risk_score := risk_score + 15;
+    risk_factors := risk_factors || jsonb_build_object(
+      'factor', 'Feature-to-Docs With Existing Work',
+      'points', 15,
+      'description', 'Changing from feature to docs when user stories or deliverables exist'
+    );
+  END IF;
+
+  -- Multiple type changes check
+  DECLARE
+    recent_changes INTEGER;
+  BEGIN
+    SELECT COUNT(*) INTO recent_changes
+    FROM sd_type_change_audit
+    WHERE sd_id = p_sd_id
+    AND created_at > NOW() - INTERVAL '7 days';
+
+    IF recent_changes >= 2 THEN
+      risk_score := risk_score + 20;
+      risk_factors := risk_factors || jsonb_build_object(
+        'factor', 'Multiple Recent Type Changes',
+        'points', 20,
+        'description', format('%s type changes in last 7 days - pattern suggests gaming the system', recent_changes + 1)
+      );
+    END IF;
+  END;
+
+  -- Cap score at 100
+  risk_score := LEAST(risk_score, 100);
+
+  IF risk_score <= 30 THEN
+    risk_level := 'LOW';
+  ELSIF risk_score <= 60 THEN
+    risk_level := 'MEDIUM';
+  ELSIF risk_score <= 80 THEN
+    risk_level := 'HIGH';
+  ELSE
+    risk_level := 'CRITICAL';
+  END IF;
+
+  -- RETURN ASSESSMENT (FIXED: Use sd_key instead of legacy_id)
+  RETURN jsonb_build_object(
+    'sd_id', p_sd_id,
+    'sd_key', sd.sd_key,  -- Changed from 'sd_legacy_id', sd.id
+    'from_type', p_from_type,
+    'to_type', p_to_type,
+    'risk_score', risk_score,
+    'risk_level', risk_level,
+    'risk_factors', risk_factors,
+    'blocked', risk_level = 'CRITICAL',
+    'approval_required', risk_level = 'HIGH',
+    'context', jsonb_build_object(
+      'current_phase', sd.current_phase,
+      'current_status', sd.status,
+      'user_story_count', user_story_count,
+      'deliverable_count', deliverable_count,
+      'completed_deliverables', completed_deliverables,
+      'handoff_count', handoff_count
+    ),
+    'recommendation', CASE risk_level
+      WHEN 'LOW' THEN 'Proceed with type change'
+      WHEN 'MEDIUM' THEN 'Review risk factors before proceeding'
+      WHEN 'HIGH' THEN 'Requires Chairman approval before proceeding'
+      WHEN 'CRITICAL' THEN 'Type change BLOCKED - too risky'
+    END
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================================
+-- 2. calculate_dependency_health_score - Fix WHERE clauses
+-- ============================================================================
+CREATE OR REPLACE FUNCTION calculate_dependency_health_score(p_sd_id TEXT)
+RETURNS NUMERIC AS $$
+DECLARE
+  v_deps JSONB;
+  v_total_deps INTEGER;
+  v_completed_deps INTEGER;
+  v_score NUMERIC;
+BEGIN
+  -- Get dependencies for this SD (FIXED: Use sd_key instead of legacy_id)
+  SELECT dependencies INTO v_deps
+  FROM strategic_directives_v2
+  WHERE sd_key = p_sd_id;  -- Changed from legacy_id
+
+  IF v_deps IS NULL OR jsonb_array_length(v_deps) = 0 THEN
+    RETURN 1.00;
+  END IF;
+
+  v_total_deps := jsonb_array_length(v_deps);
+
+  -- Count completed dependencies (FIXED: Use sd_key instead of legacy_id)
+  SELECT COUNT(*) INTO v_completed_deps
+  FROM jsonb_array_elements_text(v_deps) dep
+  WHERE EXISTS (
+    SELECT 1 FROM strategic_directives_v2 sd2
+    WHERE sd2.sd_key = split_part(dep, ' ', 1)  -- Changed from legacy_id
+    AND sd2.status = 'completed'
+  );
+
+  v_score := ROUND(v_completed_deps::NUMERIC / v_total_deps::NUMERIC, 2);
+
+  RETURN v_score;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- 3. check_lead_approval_kr_alignment - Fix dual id/legacy_id support
+-- ============================================================================
+CREATE OR REPLACE FUNCTION check_lead_approval_kr_alignment(p_sd_id VARCHAR)
+RETURNS JSONB AS $$
+DECLARE
+  v_sd_id VARCHAR;
+  v_alignment_count INT;
+  v_kr_codes TEXT[];
+  v_result JSONB;
+BEGIN
+  -- Get SD id (FIXED: Support both id and sd_key)
+  SELECT id INTO v_sd_id
+  FROM strategic_directives_v2
+  WHERE id = p_sd_id OR sd_key = p_sd_id  -- Changed from legacy_id
+  LIMIT 1;
+
+  IF v_sd_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'passed', FALSE,
+      'gate', 'KR_ALIGNMENT',
+      'message', 'SD not found: ' || p_sd_id
+    );
+  END IF;
+
+  -- Check alignment
+  SELECT COUNT(*), ARRAY_AGG(kr.code)
+  INTO v_alignment_count, v_kr_codes
+  FROM sd_key_result_alignment ska
+  JOIN key_results kr ON ska.key_result_id = kr.id
+  WHERE ska.sd_id = v_sd_id;
+
+  IF v_alignment_count = 0 THEN
+    RETURN jsonb_build_object(
+      'passed', FALSE,
+      'gate', 'KR_ALIGNMENT',
+      'severity', 'warning',
+      'message', 'SD has no Key Result alignment. Recommend running alignment before approval.',
+      'action', 'Run: node scripts/align-sds-to-krs.js or manually align via sd_key_result_alignment table'
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'passed', TRUE,
+    'gate', 'KR_ALIGNMENT',
+    'message', 'SD aligned to ' || v_alignment_count || ' Key Result(s): ' || array_to_string(v_kr_codes, ', '),
+    'kr_count', v_alignment_count,
+    'kr_codes', v_kr_codes
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- 4. get_sd_children_depth_first - Fix RETURNS TABLE and SELECT
+-- ============================================================================
+CREATE OR REPLACE FUNCTION get_sd_children_depth_first(p_sd_id TEXT)
+RETURNS TABLE (
+  id TEXT,
+  sd_key TEXT,  -- Changed from legacy_id
+  title TEXT,
+  status TEXT,
+  depth INT,
+  execution_order INT
+) AS $$
+WITH RECURSIVE children AS (
+  -- Start with immediate children
+  SELECT
+    sd.id,
+    sd.sd_key,  -- Changed from legacy_id
+    sd.title,
+    sd.status,
+    1 as depth,
+    ROW_NUMBER() OVER (ORDER BY sd.sequence_rank, sd.created_at) as sibling_order,
+    ARRAY[ROW_NUMBER() OVER (ORDER BY sd.sequence_rank, sd.created_at)] as order_path
+  FROM strategic_directives_v2 sd
+  WHERE sd.parent_sd_id = p_sd_id
+    AND sd.is_active = TRUE
+
+  UNION ALL
+
+  -- Recurse to grandchildren
+  SELECT
+    sd.id,
+    sd.sd_key,  -- Changed from legacy_id
+    sd.title,
+    sd.status,
+    c.depth + 1,
+    ROW_NUMBER() OVER (PARTITION BY sd.parent_sd_id ORDER BY sd.sequence_rank, sd.created_at),
+    c.order_path || ROW_NUMBER() OVER (PARTITION BY sd.parent_sd_id ORDER BY sd.sequence_rank, sd.created_at)
+  FROM strategic_directives_v2 sd
+  INNER JOIN children c ON sd.parent_sd_id = c.id
+  WHERE sd.is_active = TRUE
+)
+SELECT
+  id,
+  sd_key,  -- Changed from legacy_id
+  title,
+  status,
+  depth,
+  ROW_NUMBER() OVER (ORDER BY order_path) as execution_order
+FROM children
+ORDER BY order_path;
+$$ LANGUAGE SQL;
+
+-- ============================================================================
+-- 5. get_unaligned_sds - Fix RETURNS TABLE and SELECT
+-- ============================================================================
+CREATE OR REPLACE FUNCTION get_unaligned_sds()
+RETURNS TABLE (
+  sd_id VARCHAR(50),
+  sd_key VARCHAR(50),  -- Changed from legacy_id
+  title VARCHAR(500),
+  status VARCHAR(50),
+  created_at TIMESTAMP
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    sd.id,
+    sd.sd_key,  -- Changed from legacy_id
+    sd.title,
+    sd.status,
+    sd.created_at
+  FROM strategic_directives_v2 sd
+  LEFT JOIN sd_key_result_alignment ska ON sd.id = ska.sd_id
+  WHERE sd.is_active = TRUE
+    AND sd.status NOT IN ('completed', 'cancelled', 'deferred')
+    AND ska.id IS NULL
+  ORDER BY sd.created_at DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- 6. lead_preflight_kr_check - Update parameter name for clarity
+-- ============================================================================
+CREATE OR REPLACE FUNCTION lead_preflight_kr_check(p_sd_key VARCHAR)  -- Renamed from p_legacy_id
+RETURNS TABLE (
+  check_name TEXT,
+  passed BOOLEAN,
+  severity TEXT,
+  message TEXT
+) AS $$
+DECLARE
+  v_result JSONB;
+BEGIN
+  v_result := check_lead_approval_kr_alignment(p_sd_key);  -- Pass sd_key
+
+  RETURN QUERY SELECT
+    'Key Result Alignment'::TEXT as check_name,
+    (v_result->>'passed')::BOOLEAN as passed,
+    COALESCE(v_result->>'severity', 'info')::TEXT as severity,
+    (v_result->>'message')::TEXT as message;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================================
+-- 7. Fix v_sd_execution_status view
+-- ============================================================================
+CREATE OR REPLACE VIEW v_sd_execution_status AS
+SELECT
+  bi.sd_id,
+  sd.title,
+  sd.priority,
+  sd.status as sd_status,
+  sd.progress_percentage,
+  b.baseline_name,
+  b.is_active as is_active_baseline,
+  bi.sequence_rank,
+  bi.track,
+  bi.track_name,
+  bi.estimated_effort_hours,
+  bi.planned_start_date,
+  bi.planned_end_date,
+  bi.is_ready,
+  bi.dependency_health_score,
+  ea.actual_start_date,
+  ea.actual_end_date,
+  ea.actual_effort_hours,
+  ea.status as execution_status,
+  ea.blockers,
+  ea.blocked_by_sd_ids,
+  -- Variance calculations
+  CASE
+    WHEN bi.estimated_effort_hours > 0 AND ea.actual_effort_hours IS NOT NULL
+    THEN ROUND((ea.actual_effort_hours / bi.estimated_effort_hours) * 100, 1)
+    ELSE NULL
+  END as effort_variance_pct,
+  CASE
+    WHEN bi.planned_end_date IS NOT NULL AND ea.actual_end_date IS NOT NULL
+    THEN ea.actual_end_date::date - bi.planned_end_date
+    ELSE NULL
+  END as schedule_variance_days
+FROM sd_baseline_items bi
+JOIN sd_execution_baselines b ON bi.baseline_id = b.id
+LEFT JOIN strategic_directives_v2 sd ON bi.sd_id = sd.sd_key  -- Changed from legacy_id
+LEFT JOIN sd_execution_actuals ea ON bi.sd_id = ea.sd_id AND bi.baseline_id = ea.baseline_id
+ORDER BY bi.sequence_rank;
+
+-- ============================================================================
+-- 8. Fix v_sd_next_candidates view
+-- ============================================================================
+CREATE OR REPLACE VIEW v_sd_next_candidates AS
+WITH active_baseline AS (
+  SELECT id FROM sd_execution_baselines WHERE is_active = TRUE LIMIT 1
+),
+dependency_status AS (
+  SELECT
+    bi.sd_id,
+    bi.sequence_rank,
+    bi.track,
+    bi.dependencies_snapshot,
+    COALESCE(
+      (
+        SELECT COUNT(*) = 0
+        FROM jsonb_array_elements_text(bi.dependencies_snapshot) dep
+        WHERE NOT EXISTS (
+          SELECT 1 FROM strategic_directives_v2 sd2
+          WHERE sd2.sd_key = split_part(dep, ' ', 1)  -- Changed from legacy_id
+          AND sd2.status = 'completed'
+        )
+      ),
+      TRUE
+    ) as deps_satisfied
+  FROM sd_baseline_items bi
+  WHERE bi.baseline_id = (SELECT id FROM active_baseline)
+)
+SELECT
+  bi.sd_id,
+  sd.title,
+  sd.priority,
+  sd.status,
+  sd.progress_percentage,
+  bi.sequence_rank,
+  bi.track,
+  bi.track_name,
+  bi.estimated_effort_hours,
+  bi.dependency_health_score,
+  ds.deps_satisfied,
+  ea.status as execution_status,
+  sd.is_working_on,
+  CASE
+    WHEN sd.is_working_on = TRUE THEN 1
+    WHEN ea.status = 'in_progress' THEN 2
+    WHEN ds.deps_satisfied AND sd.status IN ('draft', 'active') THEN 3
+    WHEN sd.progress_percentage > 0 AND sd.progress_percentage < 100 THEN 4
+    ELSE 5
+  END as readiness_priority
+FROM sd_baseline_items bi
+JOIN strategic_directives_v2 sd ON bi.sd_id = sd.sd_key  -- Changed from legacy_id
+JOIN dependency_status ds ON bi.sd_id = ds.sd_id
+LEFT JOIN sd_execution_actuals ea ON bi.sd_id = ea.sd_id
+  AND ea.baseline_id = (SELECT id FROM active_baseline)
+WHERE bi.baseline_id = (SELECT id FROM active_baseline)
+  AND sd.status NOT IN ('completed', 'cancelled')
+ORDER BY readiness_priority, bi.sequence_rank;
+
+-- ============================================================================
+-- 9. Fix v_sd_okr_context view
+-- ============================================================================
+CREATE OR REPLACE VIEW v_sd_okr_context AS
+SELECT
+  sd.id as sd_uuid,
+  sd.sd_key,  -- Changed from legacy_id
+  sd.title as sd_title,
+  sd.status,
+  sd.progress_percentage,
+  sd.is_working_on,
+  COALESCE(
+    jsonb_agg(DISTINCT jsonb_build_object(
+      'kr_code', kr.code,
+      'kr_title', kr.title,
+      'kr_status', kr.status,
+      'objective_code', o.code,
+      'objective_title', o.title,
+      'contribution_type', ska.contribution_type,
+      'contribution_note', ska.contribution_note,
+      'kr_progress_pct', CASE
+        WHEN kr.direction = 'decrease' THEN
+          ROUND(((kr.baseline_value - kr.current_value) / NULLIF(kr.baseline_value - kr.target_value, 0)) * 100, 1)
+        ELSE
+          ROUND(((kr.current_value - COALESCE(kr.baseline_value, 0)) / NULLIF(kr.target_value - COALESCE(kr.baseline_value, 0), 0)) * 100, 1)
+      END
+    )) FILTER (WHERE kr.id IS NOT NULL),
+    '[]'::jsonb
+  ) as aligned_krs,
+  COUNT(DISTINCT kr.id) as aligned_kr_count
+FROM strategic_directives_v2 sd
+LEFT JOIN sd_key_result_alignment ska ON sd.id = ska.sd_id
+LEFT JOIN key_results kr ON ska.key_result_id = kr.id AND kr.is_active = TRUE
+LEFT JOIN objectives o ON kr.objective_id = o.id AND o.is_active = TRUE
+WHERE sd.is_active = TRUE
+GROUP BY sd.id, sd.sd_key, sd.title, sd.status, sd.progress_percentage, sd.is_working_on;
+
+-- ============================================================================
+-- Add migration comments
+-- ============================================================================
+COMMENT ON FUNCTION assess_sd_type_change_risk IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+COMMENT ON FUNCTION calculate_dependency_health_score IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+COMMENT ON FUNCTION check_lead_approval_kr_alignment IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+COMMENT ON FUNCTION get_sd_children_depth_first IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+COMMENT ON FUNCTION get_unaligned_sds IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+COMMENT ON FUNCTION lead_preflight_kr_check IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+COMMENT ON VIEW v_sd_execution_status IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+COMMENT ON VIEW v_sd_next_candidates IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+COMMENT ON VIEW v_sd_okr_context IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+-- Verification query
+SELECT 'Migration complete. All functions and views updated to use sd_key instead of legacy_id.' as status;
+
+-- ============================================================================
+-- 10. Fix v_sd_hierarchy view
+-- ============================================================================
+CREATE OR REPLACE VIEW v_sd_hierarchy AS
+WITH RECURSIVE hierarchy AS (
+  -- Base case: SDs with no parent (root level)
+  SELECT
+    id,
+    sd_key,  -- Changed from legacy_id
+    title,
+    status,
+    current_phase,
+    parent_sd_id,
+    0 as depth,
+    ARRAY[sd_key::TEXT] as path,  -- Changed from legacy_id
+    sd_key::TEXT as root_sd  -- Changed from legacy_id
+  FROM strategic_directives_v2
+  WHERE is_active = TRUE
+
+  UNION ALL
+
+  -- Recursive case: children
+  SELECT
+    sd.id,
+    sd.sd_key,  -- Changed from legacy_id
+    sd.title,
+    sd.status,
+    sd.current_phase,
+    sd.parent_sd_id,
+    h.depth + 1,
+    h.path || sd.sd_key::TEXT,  -- Changed from legacy_id
+    h.root_sd
+  FROM strategic_directives_v2 sd
+  INNER JOIN hierarchy h ON sd.parent_sd_id = h.id
+  WHERE sd.is_active = TRUE
+)
+SELECT
+  *,
+  CASE
+    WHEN status IN ('completed', 'cancelled') THEN TRUE
+    ELSE FALSE
+  END as is_complete
+FROM hierarchy;
+
+COMMENT ON VIEW v_sd_hierarchy IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+-- ============================================================================
+-- 11. Fix v_sd_alignment_warnings view
+-- ============================================================================
+CREATE OR REPLACE VIEW v_sd_alignment_warnings AS
+SELECT
+  sd.id,
+  sd.sd_key,  -- Changed from legacy_id
+  sd.title,
+  sd.status,
+  sd.created_at,
+  sd.priority,
+  CASE
+    WHEN sd.status IN ('draft', 'lead_review') THEN 'warning'
+    WHEN sd.status IN ('plan_active', 'exec_active', 'active', 'in_progress') THEN 'critical'
+    ELSE 'info'
+  END as severity,
+  'SD has no Key Result alignment' as message
+FROM strategic_directives_v2 sd
+LEFT JOIN sd_key_result_alignment ska ON sd.id = ska.sd_id
+WHERE sd.is_active = TRUE
+  AND sd.status NOT IN ('completed', 'cancelled', 'deferred')
+  AND ska.id IS NULL
+ORDER BY
+  CASE
+    WHEN sd.status IN ('plan_active', 'exec_active', 'active', 'in_progress') THEN 1
+    WHEN sd.status IN ('draft', 'lead_review') THEN 2
+    ELSE 3
+  END,
+  sd.created_at DESC;
+
+COMMENT ON VIEW v_sd_alignment_warnings IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';
+
+-- ============================================================================
+-- 12. Fix warn_on_sd_transition_without_kr function
+-- ============================================================================
+CREATE OR REPLACE FUNCTION warn_on_sd_transition_without_kr()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_alignment_count INT;
+  v_transition_to_active BOOLEAN;
+BEGIN
+  -- Check if transitioning to an active phase
+  v_transition_to_active := (
+    OLD.status NOT IN ('plan_active', 'exec_active', 'active', 'in_progress')
+    AND NEW.status IN ('plan_active', 'exec_active', 'active', 'in_progress')
+  );
+
+  IF v_transition_to_active THEN
+    -- Check alignment count
+    SELECT COUNT(*) INTO v_alignment_count
+    FROM sd_key_result_alignment
+    WHERE sd_id = NEW.id;
+
+    IF v_alignment_count = 0 THEN
+      -- Log warning (change to RAISE EXCEPTION to block)
+      RAISE NOTICE 'SD % is transitioning to % without Key Result alignment. Consider running: node scripts/align-sds-to-krs.js',
+        NEW.sd_key, NEW.status;  -- Changed from legacy_id to sd_key
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION warn_on_sd_transition_without_kr IS
+'PAT-LEGACYID-001: Updated to use sd_key instead of legacy_id (2026-01-25)';

--- a/database/manual-updates/20260125_fix_claim_sd_legacy_id.sql
+++ b/database/manual-updates/20260125_fix_claim_sd_legacy_id.sql
@@ -1,0 +1,188 @@
+-- ============================================================================
+-- FIX: Update claim_sd, release_sd functions and views to use sd_key instead of legacy_id
+-- Date: 2026-01-25
+-- Issue: PAT-LEGACYID-001 - legacy_id column was removed but functions still reference it
+-- ============================================================================
+
+-- Step 1: Update v_active_sessions view to use sd_key
+DROP VIEW IF EXISTS v_active_sessions CASCADE;
+
+CREATE OR REPLACE VIEW v_active_sessions AS
+SELECT
+  cs.session_id,
+  cs.status,
+  cs.heartbeat_at,
+  cs.sd_id,
+  sd.title as sd_title,
+  sd.status as sd_status,
+  cs.track,
+  cs.metadata,
+  cs.created_at,
+  EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 60 as heartbeat_age_minutes,
+  CASE
+    WHEN cs.status = 'active' AND cs.heartbeat_at > NOW() - INTERVAL '5 minutes' THEN 'active'
+    WHEN cs.status = 'active' AND cs.heartbeat_at > NOW() - INTERVAL '15 minutes' THEN 'idle'
+    ELSE 'stale'
+  END as computed_status
+FROM claude_sessions cs
+LEFT JOIN strategic_directives_v2 sd ON cs.sd_id = sd.sd_key;  -- Changed from legacy_id to sd_key
+
+-- Step 2: Update v_sd_session_allocation view to use sd_key
+DROP VIEW IF EXISTS v_sd_session_allocation CASCADE;
+
+CREATE OR REPLACE VIEW v_sd_session_allocation AS
+SELECT
+  bi.sd_id,
+  bi.track,
+  bi.sequence_rank,
+  sd.title,
+  sd.status as sd_status,
+  sd.is_working_on,
+  vas.session_id,
+  vas.computed_status as session_status,
+  vas.heartbeat_age_minutes
+FROM sd_baseline_items bi
+JOIN strategic_directives_v2 sd ON bi.sd_id = sd.sd_key  -- Changed from legacy_id to sd_key
+LEFT JOIN v_active_sessions vas ON bi.sd_id = vas.sd_id
+WHERE bi.baseline_id = (
+  SELECT id FROM sd_baselines WHERE is_active = true LIMIT 1
+);
+
+-- Step 3: Update claim_sd function to use sd_key
+CREATE OR REPLACE FUNCTION claim_sd(
+  p_sd_id TEXT,
+  p_session_id TEXT,
+  p_track TEXT
+) RETURNS JSONB AS $$
+DECLARE
+  v_existing_claim RECORD;
+  v_conflict RECORD;
+  v_result JSONB;
+BEGIN
+  -- Check if SD is already claimed by another active session
+  SELECT cs.session_id, cs.sd_id, vas.computed_status
+  INTO v_existing_claim
+  FROM claude_sessions cs
+  JOIN v_active_sessions vas ON cs.session_id = vas.session_id
+  WHERE cs.sd_id = p_sd_id
+    AND vas.computed_status = 'active'
+    AND cs.session_id != p_session_id
+  LIMIT 1;
+
+  IF v_existing_claim IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'already_claimed',
+      'message', format('SD %s is already claimed by session %s', p_sd_id, v_existing_claim.session_id),
+      'claimed_by', v_existing_claim.session_id
+    );
+  END IF;
+
+  -- Check for blocking conflicts with active SDs
+  SELECT cm.*, vas.sd_id as active_sd, vas.session_id as active_session
+  INTO v_conflict
+  FROM sd_conflict_matrix cm
+  JOIN v_active_sessions vas ON (
+    (cm.sd_id_a = p_sd_id AND cm.sd_id_b = vas.sd_id) OR
+    (cm.sd_id_b = p_sd_id AND cm.sd_id_a = vas.sd_id)
+  )
+  WHERE cm.conflict_severity = 'blocking'
+    AND cm.resolved_at IS NULL
+    AND vas.computed_status = 'active'
+    AND vas.session_id != p_session_id
+  LIMIT 1;
+
+  IF v_conflict IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'blocking_conflict',
+      'message', format('SD %s has blocking conflict with active SD %s', p_sd_id, v_conflict.active_sd),
+      'conflict_type', v_conflict.conflict_type,
+      'conflicting_sd', v_conflict.active_sd,
+      'conflicting_session', v_conflict.active_session
+    );
+  END IF;
+
+  -- Record the claim in sd_claims table
+  INSERT INTO sd_claims (sd_id, session_id, track, claimed_at)
+  VALUES (p_sd_id, p_session_id, p_track, NOW())
+  ON CONFLICT (sd_id, session_id)
+  DO UPDATE SET claimed_at = NOW(), track = p_track;
+
+  -- Update session with SD
+  UPDATE claude_sessions
+  SET sd_id = p_sd_id,
+      track = p_track,
+      heartbeat_at = NOW()
+  WHERE session_id = p_session_id;
+
+  -- Set is_working_on on the SD (using sd_key instead of legacy_id)
+  UPDATE strategic_directives_v2
+  SET active_session_id = p_session_id,
+      is_working_on = true
+  WHERE sd_key = p_sd_id;  -- Changed from legacy_id to sd_key
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'message', format('SD %s claimed successfully', p_sd_id),
+    'sd_id', p_sd_id,
+    'session_id', p_session_id,
+    'track', p_track
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Step 4: Update release_sd function to use sd_key
+CREATE OR REPLACE FUNCTION release_sd(
+  p_session_id TEXT
+) RETURNS JSONB AS $$
+DECLARE
+  v_sd_id TEXT;
+BEGIN
+  -- Get the SD being released
+  SELECT sd_id INTO v_sd_id
+  FROM claude_sessions
+  WHERE session_id = p_session_id;
+
+  IF v_sd_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'message', 'No SD was claimed by this session'
+    );
+  END IF;
+
+  -- Clear session's SD claim
+  UPDATE claude_sessions
+  SET sd_id = NULL,
+      track = NULL
+  WHERE session_id = p_session_id;
+
+  -- Clear is_working_on on the SD (using sd_key instead of legacy_id)
+  UPDATE strategic_directives_v2
+  SET active_session_id = NULL,
+      is_working_on = false
+  WHERE sd_key = v_sd_id;  -- Changed from legacy_id to sd_key
+
+  -- Mark claim as released
+  UPDATE sd_claims
+  SET released_at = NOW()
+  WHERE sd_id = v_sd_id
+    AND session_id = p_session_id
+    AND released_at IS NULL;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'message', format('SD %s released', v_sd_id),
+    'sd_id', v_sd_id
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Step 5: Add comments
+COMMENT ON VIEW v_active_sessions IS 'Active Claude sessions with computed status and SD info. Updated 2026-01-25 to use sd_key instead of legacy_id.';
+COMMENT ON VIEW v_sd_session_allocation IS 'SD session allocation with track info. Updated 2026-01-25 to use sd_key instead of legacy_id.';
+COMMENT ON FUNCTION claim_sd IS 'Atomically claim an SD for a session. Updated 2026-01-25 to use sd_key instead of legacy_id.';
+COMMENT ON FUNCTION release_sd IS 'Release an SD claim for a session. Updated 2026-01-25 to use sd_key instead of legacy_id.';
+
+-- Verification query
+SELECT 'Migration complete. Functions and views updated to use sd_key instead of legacy_id.' as status;

--- a/scripts/child-sd-preflight.js
+++ b/scripts/child-sd-preflight.js
@@ -260,6 +260,10 @@ class ChildSDPreflightValidator {
       console.log(`${colors.dim}   No dependencies defined for this child SD.${colors.reset}\n`);
       console.log(`${colors.green}✅ RESULT: PASS${colors.reset}`);
       console.log(`${colors.dim}   Ready to work on ${displayId}.${colors.reset}`);
+      console.log(`\n${colors.yellow}${colors.bold}⚠️  CONTEXT LOADING REMINDER:${colors.reset}`);
+      console.log(`${colors.yellow}   Before starting work, you MUST read:${colors.reset}`);
+      console.log(`${colors.yellow}   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)${colors.reset}`);
+      console.log(`${colors.yellow}   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)${colors.reset}`);
       console.log(`\n${colors.cyan}${'═'.repeat(59)}${colors.reset}\n`);
       return { status: 'PASS', reason: 'No dependencies', parent: this.parent, sd: this.sd };
     }
@@ -355,6 +359,10 @@ class ChildSDPreflightValidator {
 
     console.log(`${colors.bgGreen}${colors.bold} ✅ RESULT: PROCEED ${colors.reset}`);
     console.log(`${colors.green}   All dependencies satisfied. Ready to work on ${displayId}.${colors.reset}`);
+    console.log(`\n${colors.yellow}${colors.bold}⚠️  CONTEXT LOADING REMINDER:${colors.reset}`);
+    console.log(`${colors.yellow}   Before starting work, you MUST read:${colors.reset}`);
+    console.log(`${colors.yellow}   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)${colors.reset}`);
+    console.log(`${colors.yellow}   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)${colors.reset}`);
     console.log(`\n${colors.cyan}${'═'.repeat(59)}${colors.reset}\n`);
 
     return {

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -57,6 +57,7 @@
       "sd_creation_process",
       "sd_creation_anti_pattern",
       "sd_creation_errors",
+      "child_sd_context_loading",
       "lead_operations",
       "lead_explore_integration",
       "directive_submission_review",


### PR DESCRIPTION
## Summary

- **Fixed protocol-file-tracker.cjs hook** to read tool info from stdin (JSON) instead of environment variables
- Claude Code passes tool info via stdin, not CLAUDE_TOOL_NAME/CLAUDE_TOOL_INPUT env vars
- This was causing GATE_SD_START_PROTOCOL validation failures (CLAUDE_CORE.md not tracked)
- Added PAT-LEGACYID-001 database migrations (legacy_id → sd_key in 10+ functions/views)
- Enhanced child SD context loading requirements in CLAUDE_LEAD.md
- Updated leo.md skill with mandatory context loading section
- Regenerated CLAUDE.md family files from database

## Root Cause Analysis

The PostToolUse hook was using:
```javascript
// WRONG - these are NOT set by Claude Code
const toolInput = process.env.CLAUDE_TOOL_INPUT || '';
const toolName = process.env.CLAUDE_TOOL_NAME || '';
```

Claude Code actually passes tool info via stdin as JSON:
```json
{
  "tool_name": "Read",
  "tool_input": { "file_path": "/path/to/file" },
  "tool_response": { ... }
}
```

## Test Plan

- [x] Verified hook tracks CLAUDE_CORE.md reads after fix
- [x] Verified hook tracks CLAUDE_PLAN.md reads after fix
- [x] Verified GATE_SD_START_PROTOCOL now passes
- [x] Smoke tests pass (15/15)
- [x] No secrets detected, ESLint auto-fix complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)