### PR TITLE
feat(status-line): add AUTO-PROCEED mode display when starting SD work

### DIFF
--- a/lib/intelligent-impact-analyzer.js
+++ b/lib/intelligent-impact-analyzer.js
@@ -80,7 +80,10 @@ function getAnthropicClient() {
   if (!anthropicClient) {
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) {
-      throw new Error('ANTHROPIC_API_KEY not set - LLM impact analysis disabled');
+      // Graceful degradation - return null instead of throwing
+      // This allows the calling code to handle missing API key appropriately
+      console.warn('   ⚠️  ANTHROPIC_API_KEY not set - LLM impact analysis disabled');
+      return null;
     }
     anthropicClient = new Anthropic({ apiKey });
   }
@@ -115,6 +118,21 @@ export async function analyzeSDImpact(sd) {
 
   try {
     const client = getAnthropicClient();
+
+    // Handle graceful degradation when API key not set
+    if (!client) {
+      return {
+        success: false,
+        error: 'ANTHROPIC_API_KEY not configured',
+        impacts: {},
+        requiredSubAgents: [],
+        fallbackUsed: true,
+        metadata: {
+          analysisTimeMs: Date.now() - startTime,
+          timestamp: new Date().toISOString()
+        }
+      };
+    }
 
     // Build the analysis prompt
     const prompt = buildAnalysisPrompt(sd);

--- a/scripts/phase-preflight.js
+++ b/scripts/phase-preflight.js
@@ -596,15 +596,26 @@ function displayResults(sd, phase, strategy, patterns, retrospectives) {
       console.log(`   Date: ${new Date(retro.conducted_date).toLocaleDateString()}`);
 
       // Show key learnings (first 2)
+      // key_learnings can be array of strings OR array of objects {learning: "...", evidence: "...", category: "..."}
       if (retro.key_learnings && retro.key_learnings.length > 0) {
-        console.log(`   Key Learning: ${retro.key_learnings[0].substring(0, 70)}${retro.key_learnings[0].length > 70 ? '...' : ''}`);
+        const firstLearning = typeof retro.key_learnings[0] === 'string'
+          ? retro.key_learnings[0]
+          : retro.key_learnings[0]?.learning || JSON.stringify(retro.key_learnings[0]);
+        console.log(`   Key Learning: ${firstLearning.substring(0, 70)}${firstLearning.length > 70 ? '...' : ''}`);
       }
 
       // Show success or failure pattern (context-dependent)
+      // Patterns can be array of strings OR array of objects {pattern: "...", ...}
+      const extractPatternText = (pattern) => {
+        if (typeof pattern === 'string') return pattern;
+        return pattern?.pattern || pattern?.description || JSON.stringify(pattern);
+      };
       if (phase === 'PLAN' && retro.success_patterns && retro.success_patterns.length > 0) {
-        console.log(`   Success Pattern: ${retro.success_patterns[0].substring(0, 70)}${retro.success_patterns[0].length > 70 ? '...' : ''}`);
+        const patternText = extractPatternText(retro.success_patterns[0]);
+        console.log(`   Success Pattern: ${patternText.substring(0, 70)}${patternText.length > 70 ? '...' : ''}`);
       } else if (retro.failure_patterns && retro.failure_patterns.length > 0) {
-        console.log(`   Failure Pattern: ${retro.failure_patterns[0].substring(0, 70)}${retro.failure_patterns[0].length > 70 ? '...' : ''}`);
+        const patternText = extractPatternText(retro.failure_patterns[0]);
+        console.log(`   Failure Pattern: ${patternText.substring(0, 70)}${patternText.length > 70 ? '...' : ''}`);
       }
 
       console.log('');


### PR DESCRIPTION
## Summary
- Add AUTO-PROCEED status line display to Claude Code CLI when starting SD work
- Status line format: `🤖 AUTO-PROCEED: ON | EXEC | 30% | SD-XXX-001`
- Integrated with handoff execution to update status automatically
- Bug fixes for graceful degradation when ANTHROPIC_API_KEY not set
- Bug fixes for handling object types in retrospective arrays

## Changes
- `lib/intelligent-impact-analyzer.js` - Return null instead of throwing when API key missing
- `scripts/leo-status-line.js` - New `updateForAutoProceed()` method and CLI command
- `scripts/modules/handoff/cli/cli-main.js` - Status line integration in handoff execution
- `scripts/phase-preflight.js` - Handle both string and object types for key_learnings

## Test plan
- [x] Status line updates correctly when running `node scripts/leo-status-line.js autoproceed on EXEC 30 SD-XXX`
- [x] Handoff execution updates status line automatically
- [x] Smoke tests pass
- [x] Module compiles without errors

## Related
- SD-LEO-ENH-AUTO-PROCEED-001-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)