### PR TITLE
fix(status-line): integrate AUTO-PROCEED into Claude Code status line

### DIFF
--- a/.claude/statusline-context-tracker.ps1
+++ b/.claude/statusline-context-tracker.ps1
@@ -206,8 +206,23 @@ if ($gitBranch) {
     $projectInfo = $projectName
 }
 
+# Read AUTO-PROCEED status from leo-status-line cache (SD-LEO-ENH-AUTO-PROCEED-001-13)
+$autoProceedInfo = ""
+$leoStatusFile = Join-Path $cwd ".leo-status.json"
+if (Test-Path $leoStatusFile) {
+    try {
+        $leoStatus = Get-Content $leoStatusFile -Raw | ConvertFrom-Json
+        if ($leoStatus.autoProceed -and $leoStatus.autoProceed.isActive) {
+            $apStatus = if ($leoStatus.autoProceed.isActive) { "ON" } else { "OFF" }
+            $apPhase = if ($leoStatus.autoProceed.phase) { $leoStatus.autoProceed.phase } else { "?" }
+            $apProgress = if ($null -ne $leoStatus.autoProceed.progress) { $leoStatus.autoProceed.progress } else { "?" }
+            $autoProceedInfo = " | AP:${apStatus}/${apPhase}/${apProgress}%"
+        }
+    } catch { }
+}
+
 # Build output
-$output = "${activitySignal} ${projectInfo} ${barColor}[${bar}]${reset} ${percentUsed}% (${modelShort})${icon}"
+$output = "${activitySignal} ${projectInfo}${autoProceedInfo} ${barColor}[${bar}]${reset} ${percentUsed}% (${modelShort})${icon}"
 
 # Update state file
 $totalInput = if ($data.context_window.total_input_tokens) { [int]$data.context_window.total_input_tokens } else { 0 }


### PR DESCRIPTION
## Summary
- Integrate AUTO-PROCEED info into the actual Claude Code status line
- Read from `.leo-status.json` in the PowerShell status line script
- Display format: `AP:ON/EXEC/30%` when AUTO-PROCEED is active

## Problem
The original implementation (PR #656) wrote AUTO-PROCEED status to files, but didn't integrate with the actual Claude Code status line PowerShell script (`statusline-context-tracker.ps1`). Users couldn't see the AUTO-PROCEED info in their session.

## Solution
Updated the PowerShell script to read the `autoProceed` object from `.leo-status.json` and append it to the status line output.

## Test plan
- [x] Status line shows `AP:ON/PLAN/0%` when AUTO-PROCEED is active
- [x] Falls back gracefully if no AUTO-PROCEED state exists
- [x] Smoke tests pass

## Related
- SD-LEO-ENH-AUTO-PROCEED-001-13
- Completes PR #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)