### PR TITLE
feat(status-line): add child progress tracking for orchestrator SDs

### DIFF
--- a/scripts/modules/handoff/auto-approve-prd.js
+++ b/scripts/modules/handoff/auto-approve-prd.js
@@ -231,8 +231,9 @@ export async function autoApproveChildPRDs(parentSdId) {
   return { results, summary };
 }
 
-// CLI execution
-if (process.argv[1].includes('auto-approve-prd.js')) {
+// CLI execution (only runs when called directly from command line)
+const isDirectExecution = process.argv[1] && process.argv[1].includes('auto-approve-prd.js');
+if (isDirectExecution) {
   const sdId = process.argv[2];
 
   if (!sdId) {


### PR DESCRIPTION
## Summary
- Add auto-detection of orchestrator child SDs from database
- Display child progress in status line as `C{current}/{total}` format
- Clear stale AUTO-PROCEED data on new sessions to prevent showing outdated info

## Changes
- `scripts/leo-status-line.js`: Added `fetchChildProgressFromDatabase()`, `buildChildProgressSegment()`, `clearAutoProceed()` methods
- `.claude/statusline-context-tracker.ps1`: Added child progress display in PowerShell status line
- `scripts/hooks/session-start-loader.ps1`: Clear stale autoProceed on fresh sessions

## Test plan
- [x] Status line JavaScript imports without errors
- [x] Smoke tests pass
- [x] Child progress shows correctly when on orchestrator child SD
- [x] Stale data cleared on new session start

SD-LEO-ENH-AUTO-PROCEED-001-14

🤖 Generated with [Claude Code](https://claude.ai/code)