### PR TITLE
feat(status-line): add child progress tracking for orchestrator SDs

### DIFF
--- a/.claude/statusline-context-tracker.ps1
+++ b/.claude/statusline-context-tracker.ps1
@@ -206,7 +206,7 @@ if ($gitBranch) {
     $projectInfo = $projectName
 }
 
-# Read AUTO-PROCEED status from leo-status-line cache (SD-LEO-ENH-AUTO-PROCEED-001-13)
+# Read AUTO-PROCEED status from leo-status-line cache (SD-LEO-ENH-AUTO-PROCEED-001-13/14)
 $autoProceedInfo = ""
 $leoStatusFile = Join-Path $cwd ".leo-status.json"
 if (Test-Path $leoStatusFile) {
@@ -216,7 +216,22 @@ if (Test-Path $leoStatusFile) {
             $apStatus = if ($leoStatus.autoProceed.isActive) { "ON" } else { "OFF" }
             $apPhase = if ($leoStatus.autoProceed.phase) { $leoStatus.autoProceed.phase } else { "?" }
             $apProgress = if ($null -ne $leoStatus.autoProceed.progress) { $leoStatus.autoProceed.progress } else { "?" }
-            $autoProceedInfo = " | AP:${apStatus}/${apPhase}/${apProgress}%"
+
+            # SD-LEO-ENH-AUTO-PROCEED-001-14: Add child progress if available
+            $childInfo = ""
+            if ($leoStatus.autoProceed.childProgress) {
+                $childCurrent = $leoStatus.autoProceed.childProgress.current
+                $childTotal = $leoStatus.autoProceed.childProgress.total
+                if ($null -ne $childCurrent) {
+                    if ($null -ne $childTotal) {
+                        $childInfo = " C${childCurrent}/${childTotal}"
+                    } else {
+                        $childInfo = " C${childCurrent}/?"
+                    }
+                }
+            }
+
+            $autoProceedInfo = " | AP:${apStatus}/${apPhase}/${apProgress}%${childInfo}"
         }
     } catch { }
 }


### PR DESCRIPTION
## Summary
- Add auto-detection of orchestrator child SDs from database
- Display child progress in status line as `C{current}/{total}` format
- Clear stale AUTO-PROCEED data on new sessions to prevent showing outdated info

## Changes
- `scripts/leo-status-line.js`: Added `fetchChildProgressFromDatabase()`, `buildChildProgressSegment()`, `clearAutoProceed()` methods
- `.claude/statusline-context-tracker.ps1`: Added child progress display in PowerShell status line
- `scripts/hooks/session-start-loader.ps1`: Clear stale autoProceed on fresh sessions

## Test plan
- [x] Status line JavaScript imports without errors
- [x] Smoke tests pass
- [x] Child progress shows correctly when on orchestrator child SD
- [x] Stale data cleared on new session start

SD-LEO-ENH-AUTO-PROCEED-001-14

🤖 Generated with [Claude Code](https://claude.ai/code)