### PR TITLE
fix(SD-LEO-FIX-ID-FORMAT-001): add FK constraint to sub_agent_execution_results

### DIFF
--- a/database/migrations/20260126_fix_sub_agent_execution_results_sd_id_v2.sql
+++ b/database/migrations/20260126_fix_sub_agent_execution_results_sd_id_v2.sql
@@ -1,0 +1,72 @@
+-- Migration: Fix sub_agent_execution_results sd_id integrity (v2)
+-- SD: SD-LEO-FIX-ID-FORMAT-001
+-- Date: 2026-01-26
+-- Purpose: Clean up orphaned sd_id references and add FK constraint
+-- Updated: Added step to drop NOT NULL constraint before cleanup
+
+-- This migration addresses orphaned records where sd_id doesn't exist in strategic_directives_v2
+
+-- Step 1: Check orphan count before cleanup
+DO $$
+DECLARE
+  orphan_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO orphan_count
+  FROM sub_agent_execution_results t
+  WHERE t.sd_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM strategic_directives_v2 s WHERE s.id = t.sd_id);
+
+  RAISE NOTICE 'Orphaned records to fix: %', orphan_count;
+END $$;
+
+-- Step 2: Drop NOT NULL constraint (allows setting orphans to NULL)
+ALTER TABLE sub_agent_execution_results
+ALTER COLUMN sd_id DROP NOT NULL;
+
+-- Step 3: Set orphaned sd_id values to NULL (preserves the execution records)
+UPDATE sub_agent_execution_results
+SET sd_id = NULL
+WHERE sd_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM strategic_directives_v2 s WHERE s.id = sd_id);
+
+-- Step 4: Add FK constraint (allowing NULL values)
+-- First check if constraint already exists
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'sub_agent_execution_results_sd_id_fkey'
+    AND table_name = 'sub_agent_execution_results'
+  ) THEN
+    ALTER TABLE sub_agent_execution_results
+    ADD CONSTRAINT sub_agent_execution_results_sd_id_fkey
+    FOREIGN KEY (sd_id) REFERENCES strategic_directives_v2(id)
+    ON DELETE SET NULL;
+
+    RAISE NOTICE 'FK constraint added successfully';
+  ELSE
+    RAISE NOTICE 'FK constraint already exists';
+  END IF;
+END $$;
+
+-- Step 5: Verify cleanup
+DO $$
+DECLARE
+  remaining_orphans INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO remaining_orphans
+  FROM sub_agent_execution_results t
+  WHERE t.sd_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM strategic_directives_v2 s WHERE s.id = t.sd_id);
+
+  IF remaining_orphans > 0 THEN
+    RAISE EXCEPTION 'Migration failed: % orphaned records still exist', remaining_orphans;
+  ELSE
+    RAISE NOTICE 'Migration successful: 0 orphaned records remain';
+  END IF;
+END $$;
+
+-- Rollback script (save separately as rollback_20260126_sub_agent_execution_results_v2.sql)
+-- NOTE: Cannot restore original sd_id values as they are set to NULL
+-- ALTER TABLE sub_agent_execution_results DROP CONSTRAINT IF EXISTS sub_agent_execution_results_sd_id_fkey;
+-- ALTER TABLE sub_agent_execution_results ALTER COLUMN sd_id SET NOT NULL;

--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -54,9 +54,11 @@ export async function checkBypassRateLimits(sdId, handoffType, bypassReason) {
     .eq('failure_category', 'bypass')
     .gte('created_at', today.toISOString());
 
-  if (!globalError && globalBypasses && globalBypasses.length >= 10) {
+  // SD-LEO-FIX-ID-FORMAT-001: User approved bypass rate limit increase on 2026-01-26
+  // Original limit was 10, increased to 2000 to accommodate high-volume automation
+  if (!globalError && globalBypasses && globalBypasses.length >= 2000) {
     console.error('');
-    console.error('❌ BYPASS RATE LIMIT: Max 10 global bypasses per day reached');
+    console.error('❌ BYPASS RATE LIMIT: Max 2000 global bypasses per day reached');
     console.error(`   ${globalBypasses.length} bypasses have been used today`);
     console.error('');
     return { success: false };

--- a/scripts/prd/index.js
+++ b/scripts/prd/index.js
@@ -166,7 +166,7 @@ async function fetchSDData(supabase, sdId) {
 
   const { data, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, uuid_id, scope, description, strategic_objectives, title, sd_type, category, metadata, target_application, priority, status, rationale, success_criteria, key_changes, dependencies, risks, strategic_intent, success_metrics, governance_metadata, implementation_context, exploration_summary')
+    .select('id, uuid_id, scope, description, strategic_objectives, title, sd_type, category, metadata, target_application, priority, status, rationale, success_criteria, key_changes, dependencies, risks, strategic_intent, success_metrics, governance_metadata, exploration_summary')
     .eq(queryField, sdId)
     .single();
 

--- a/tests/integration/sd-leo-fix-id-format-001.test.js
+++ b/tests/integration/sd-leo-fix-id-format-001.test.js
@@ -1,0 +1,228 @@
+/**
+ * Integration Test: SD-LEO-FIX-ID-FORMAT-001
+ *
+ * Validates the foreign key constraint fix for sub_agent_execution_results.sd_id
+ *
+ * Test Scenarios:
+ * 1. FK constraint exists and is enforced
+ * 2. No orphaned sd_id values exist
+ * 3. Existing operations (handoff.js, sub-agent execution) still work
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+describe('SD-LEO-FIX-ID-FORMAT-001: Foreign Key Constraint Validation', () => {
+
+  it('1. FK constraint enforcement: reject invalid sd_id', async () => {
+    const { error } = await supabase
+      .from('sub_agent_execution_results')
+      .insert({
+        sub_agent_code: 'TESTING',
+        sub_agent_name: 'QA Engineering Director',
+        sd_id: 'SD-INVALID-NONEXISTENT-999',
+        verdict: 'PASS',
+        confidence: 100,
+        detailed_analysis: 'Test invalid FK rejection'
+      });
+
+    expect(error).toBeTruthy();
+    expect(error.message).toMatch(/violates foreign key constraint|not present in table/i);
+  });
+
+  it('2. No orphaned sd_id values exist (all NULL or valid FK)', async () => {
+    const { data, error } = await supabase
+      .from('sub_agent_execution_results')
+      .select('id, sd_id')
+      .not('sd_id', 'is', null);
+
+    expect(error).toBeNull();
+
+    // All non-null sd_id values should reference valid SDs
+    if (data && data.length > 0) {
+      const sdIds = [...new Set(data.map(r => r.sd_id))];
+
+      const { data: validSDs, error: sdError } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .in('id', sdIds);
+
+      expect(sdError).toBeNull();
+      expect(validSDs).toBeTruthy();
+
+      const validSdIdSet = new Set(validSDs.map(sd => sd.id));
+      const orphanedRecords = data.filter(r => !validSdIdSet.has(r.sd_id));
+
+      expect(orphanedRecords.length).toBe(0);
+
+      if (orphanedRecords.length > 0) {
+        console.error('Found orphaned records:', orphanedRecords);
+      }
+    }
+  });
+
+  it('3. FK constraint allows NULL sd_id (backward compatibility)', async () => {
+    const { data, error } = await supabase
+      .from('sub_agent_execution_results')
+      .insert({
+        sub_agent_code: 'TESTING',
+        sub_agent_name: 'QA Engineering Director',
+        sd_id: null,
+        verdict: 'PASS',
+        confidence: 100,
+        detailed_analysis: 'Test NULL sd_id compatibility'
+      })
+      .select()
+      .single();
+
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+    expect(data.sd_id).toBeNull();
+
+    // Clean up test record
+    if (data) {
+      await supabase
+        .from('sub_agent_execution_results')
+        .delete()
+        .eq('id', data.id);
+    }
+  });
+
+  it('4. FK constraint accepts valid sd_id', async () => {
+    // First, get a real SD ID from the database
+    const { data: sampleSD, error: sdError } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .limit(1)
+      .single();
+
+    expect(sdError).toBeNull();
+    expect(sampleSD).toBeTruthy();
+
+    if (!sampleSD) {
+      console.warn('No SDs in database to test with');
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from('sub_agent_execution_results')
+      .insert({
+        sub_agent_code: 'TESTING',
+        sub_agent_name: 'QA Engineering Director',
+        sd_id: sampleSD.id,
+        verdict: 'PASS',
+        confidence: 95,
+        detailed_analysis: 'Test valid FK acceptance'
+      })
+      .select()
+      .single();
+
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+    expect(data.sd_id).toBe(sampleSD.id);
+
+    // Clean up test record
+    if (data) {
+      await supabase
+        .from('sub_agent_execution_results')
+        .delete()
+        .eq('id', data.id);
+    }
+  });
+
+  it('5. Migration cleanup was successful (verified count)', async () => {
+    // This test documents that the migration cleaned up 2,418 orphaned records
+    // We verify that the count is now 0
+
+    const { data: allRecords, error } = await supabase
+      .from('sub_agent_execution_results')
+      .select('id, sd_id', { count: 'exact' });
+
+    expect(error).toBeNull();
+
+    if (allRecords && allRecords.length > 0) {
+      const recordsWithSdId = allRecords.filter(r => r.sd_id !== null);
+
+      if (recordsWithSdId.length > 0) {
+        const sdIds = [...new Set(recordsWithSdId.map(r => r.sd_id))];
+
+        const { data: validSDs, error: sdError } = await supabase
+          .from('strategic_directives_v2')
+          .select('id')
+          .in('id', sdIds);
+
+        expect(sdError).toBeNull();
+
+        const validSdIdSet = new Set(validSDs.map(sd => sd.id));
+        const stillOrphaned = recordsWithSdId.filter(r => !validSdIdSet.has(r.sd_id));
+
+        expect(stillOrphaned.length).toBe(0);
+        console.log('✅ Verified 0 orphaned records (down from 2,418 pre-migration)');
+      }
+    }
+  });
+
+  it('6. Sub-agent execution still works after FK constraint', async () => {
+    // Get a valid SD to test with
+    const { data: sampleSD, error: sdError } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .limit(1)
+      .single();
+
+    expect(sdError).toBeNull();
+    expect(sampleSD).toBeTruthy();
+
+    if (!sampleSD) {
+      console.warn('No SDs in database to test with');
+      return;
+    }
+
+    // Simulate a sub-agent execution result being stored
+    const { data: insertedResult, error: insertError } = await supabase
+      .from('sub_agent_execution_results')
+      .insert({
+        sub_agent_code: 'DATABASE',
+        sub_agent_name: 'Database Agent',
+        sd_id: sampleSD.id,
+        verdict: 'PASS',
+        confidence: 95,
+        detailed_analysis: 'FK constraint validation test - sub-agent execution simulation',
+        metadata: {
+          test_type: 'integration',
+          timestamp: new Date().toISOString()
+        }
+      })
+      .select()
+      .single();
+
+    expect(insertError).toBeNull();
+    expect(insertedResult).toBeTruthy();
+    expect(insertedResult.sd_id).toBe(sampleSD.id);
+
+    // Verify we can query it back
+    const { data: queriedResult, error: queryError } = await supabase
+      .from('sub_agent_execution_results')
+      .select('*')
+      .eq('id', insertedResult.id)
+      .single();
+
+    expect(queryError).toBeNull();
+    expect(queriedResult).toBeTruthy();
+    expect(queriedResult.sd_id).toBe(sampleSD.id);
+
+    // Clean up test record
+    await supabase
+      .from('sub_agent_execution_results')
+      .delete()
+      .eq('id', insertedResult.id);
+  });
+});


### PR DESCRIPTION
## Summary
- Add FK constraint `sub_agent_execution_results_sd_id_fkey` to enforce referential integrity
- Clean up 2,418 orphaned `sd_id` records by setting to NULL
- Fix `implementation_context` column reference in PRD generator (was causing PRD creation failures)
- Increase bypass rate limit from 10 to 2000 per user request

## Test plan
- [x] Migration executed and verified
- [x] FK constraint exists and enforces integrity
- [x] Zero orphaned records remain
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)