### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002): remove legacy_id references from active code

### DIFF
--- a/lib/sub-agents/github.js
+++ b/lib/sub-agents/github.js
@@ -47,10 +47,11 @@ export async function execute(sdId, subAgent, options = {}) {
 
   // PAT-DB-SD-E2E-001: Database/Infrastructure SDs have reduced CI/CD requirements
   // Check SD type and apply relaxed validation for non-deployment SDs
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
   const { data: sdData } = await supabase
     .from('strategic_directives_v2')
     .select('category, target_application')
-    .or(`legacy_id.eq.${sdId},id.eq.${sdId}`)
+    .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
     .single();
 
   const sdCategory = sdData?.category?.toLowerCase() || '';

--- a/lib/sub-agents/retro/action-items.js
+++ b/lib/sub-agents/retro/action-items.js
@@ -9,7 +9,8 @@
  */
 export function generateSmartActionItems(sdData, prdData, handoffs, subAgentResults, whatNeedsImprovement, protocolImprovements) {
   const actionItems = [];
-  const sdKey = sdData.sd_key || sdData.legacy_id || sdData.id?.substring(0, 8);
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Removed legacy_id fallback (column dropped 2026-01-24)
+  const sdKey = sdData.sd_key || sdData.id?.substring(0, 8);
   const sdType = (sdData.category || sdData.sd_type || 'feature').toLowerCase();
 
   for (const improvement of whatNeedsImprovement) {
@@ -166,7 +167,8 @@ export function convertToSmartAction(improvement, sdKey, sdType) {
  */
 export function generateImprovementAreas(sdData, prdData, handoffs, subAgentResults, whatNeedsImprovement, testEvidence) {
   const areas = [];
-  const sdKey = sdData.sd_key || sdData.legacy_id || sdData.id?.substring(0, 8);
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Removed legacy_id fallback (column dropped 2026-01-24)
+  const sdKey = sdData.sd_key || sdData.id?.substring(0, 8);
   const sdType = (sdData.category || sdData.sd_type || 'feature').toLowerCase();
 
   for (const improvement of whatNeedsImprovement) {
@@ -381,7 +383,8 @@ export function buildImprovementArea(improvement, sdKey, sdType, prdData, handof
  */
 export function getTypeSpecificImprovementAreas(sdType, sdData, subAgentResults) {
   const areas = [];
-  const sdKey = sdData.sd_key || sdData.legacy_id || sdData.id?.substring(0, 8);
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Removed legacy_id fallback (column dropped 2026-01-24)
+  const sdKey = sdData.sd_key || sdData.id?.substring(0, 8);
 
   const databaseRun = subAgentResults.results?.some(r => r.sub_agent_code === 'DATABASE');
   const securityRun = subAgentResults.results?.some(r => r.sub_agent_code === 'SECURITY');

--- a/lib/sub-agents/retro/db-operations.js
+++ b/lib/sub-agents/retro/db-operations.js
@@ -20,10 +20,11 @@ export async function checkExistingRetrospective(supabase, sdId) {
 
   let sdUuid = sdId;
   if (!isUUID) {
+    // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
     const { data: sd } = await supabase
       .from('strategic_directives_v2')
       .select('id')
-      .eq('legacy_id', sdId)
+      .eq('sd_key', sdId)
       .single();
     if (sd) {
       sdUuid = sd.id;
@@ -123,24 +124,14 @@ export async function gatherSDMetadata(supabase, sdId) {
       sd = idResult.data;
       error = idResult.error;
     } else {
-      const legacyResult = await supabase
+      // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
+      const sdKeyResult = await supabase
         .from('strategic_directives_v2')
         .select('*')
-        .eq('legacy_id', sdId)
+        .eq('sd_key', sdId)
         .maybeSingle();
-
-      if (legacyResult.data) {
-        sd = legacyResult.data;
-        error = legacyResult.error;
-      } else {
-        const sdKeyResult = await supabase
-          .from('strategic_directives_v2')
-          .select('*')
-          .eq('sd_key', sdId)
-          .maybeSingle();
-        sd = sdKeyResult.data;
-        error = sdKeyResult.error;
-      }
+      sd = sdKeyResult.data;
+      error = sdKeyResult.error;
     }
   }
 

--- a/lib/sub-agents/retro/generators.js
+++ b/lib/sub-agents/retro/generators.js
@@ -31,7 +31,8 @@ export function generateRetrospective(sdData, prdData, handoffs, subAgentResults
   const objectivesMet = sdData.status === 'completed';
   const onSchedule = calculateOnSchedule(prdData, handoffs, sdData);
   const withinScope = calculateWithinScope(deliverables);
-  const sdKey = sdData.sd_key || sdData.legacy_id || sdData.id?.substring(0, 8);
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Removed legacy_id fallback (column dropped 2026-01-24)
+  const sdKey = sdData.sd_key || sdData.id?.substring(0, 8);
   const sdTitle = sdData.title || 'Unknown SD';
 
   // SD-LEO-REFAC-TESTING-INFRA-001: Generate SD-specific "what went well" items
@@ -225,7 +226,8 @@ export function generateProtocolImprovements(sdData, prdData, handoffs, subAgent
 export function generateSdTypeSpecificLearnings(sdData, prdData, handoffs, subAgentResults, testEvidence) {
   const learnings = [];
   const sdTitle = sdData.title || 'Unknown SD';
-  const sdKey = sdData.sd_key || sdData.legacy_id || sdData.id?.substring(0, 8);
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Removed legacy_id fallback (column dropped 2026-01-24)
+  const sdKey = sdData.sd_key || sdData.id?.substring(0, 8);
 
   // SD-LEO-INFRA-ENHANCE-RETRO-SUB-001: Extract insights from success_metrics
   const successMetricsInsights = extractSuccessMetricsInsights(sdData, sdKey);

--- a/lib/sub-agents/testing/index.js
+++ b/lib/sub-agents/testing/index.js
@@ -274,10 +274,11 @@ async function fetchSemanticPatterns(sdId) {
 }
 
 async function checkForNonUISdType(sdId, validationMode, options) {
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
   const { data: sdData } = await supabase
     .from('strategic_directives_v2')
     .select('category')
-    .or(`legacy_id.eq.${sdId},id.eq.${sdId}`)
+    .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
     .single();
 
   const sdCategory = sdData?.category?.toLowerCase() || '';

--- a/lib/templates/prd-template.js
+++ b/lib/templates/prd-template.js
@@ -11,7 +11,8 @@ export const PRD_TEMPLATE = {
   phase: 'planning',
   created_by: 'LEO_TEMPLATE_ENGINE',
   computed: {
-    id: (sd) => `PRD-${sd.legacy_id}`,
+    // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
+    id: (sd) => `PRD-${sd.sd_key || sd.id}`,
     directive_id: (sd) => sd.id,
     sd_id: (sd) => sd.id,
     title: (sd) => `${sd.title} PRD`,
@@ -163,7 +164,8 @@ export function generatePRD(sd, config = {}) {
     metadata: {
       generated_at: new Date().toISOString(),
       generator_version: '1.0.0',
-      sd_legacy_id: sd.legacy_id,
+      // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
+      sd_key: sd.sd_key,
       sd_type: sd.sd_type,
       config_applied: Object.keys(config).length > 0
     }

--- a/lib/utils/sd-type-guard.js
+++ b/lib/utils/sd-type-guard.js
@@ -135,7 +135,7 @@ export async function validateSDType(sd, declaredType, options = {}) {
 /**
  * Update SD with validated type and store classification metadata
  *
- * @param {string} sdId - SD legacy_id (e.g., 'SD-REFACTOR-SCRIPTS-001')
+ * @param {string} sdId - SD sd_key (e.g., 'SD-REFACTOR-SCRIPTS-001')
  * @param {string} newType - The sd_type to set
  * @param {Object} options - Options
  * @returns {Promise<Object>} Update result
@@ -143,11 +143,12 @@ export async function validateSDType(sd, declaredType, options = {}) {
 export async function updateSDTypeWithValidation(sdId, newType, options = {}) {
   const supabase = await getSupabaseClient();
 
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
   // Fetch current SD data
   const { data: sd, error: fetchError } = await supabase
     .from('strategic_directives_v2')
     .select('title, description, scope, sd_type, intensity_level')
-    .eq('legacy_id', sdId)
+    .eq('sd_key', sdId)
     .single();
 
   if (fetchError || !sd) {
@@ -171,12 +172,13 @@ export async function updateSDTypeWithValidation(sdId, newType, options = {}) {
     updateData.intensity_level = validation.intensity.level;
   }
 
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
   // Update SD
   const { data: updated, error: updateError } = await supabase
     .from('strategic_directives_v2')
     .update(updateData)
-    .eq('legacy_id', sdId)
-    .select('legacy_id, sd_type, intensity_level');
+    .eq('sd_key', sdId)
+    .select('sd_key, sd_type, intensity_level');
 
   if (updateError) {
     throw new Error(`Failed to update SD ${sdId}: ${updateError.message}`);
@@ -209,10 +211,11 @@ export async function auditSDTypes(options = {}) {
   console.log(`\n📋 SD TYPE AUDIT ${dryRun ? '(DRY RUN)' : ''}`);
   console.log('='.repeat(60));
 
+  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
   // Fetch all active SDs with types that could be misclassified
   const { data: sds, error } = await supabase
     .from('strategic_directives_v2')
-    .select('legacy_id, title, description, scope, sd_type, intensity_level')
+    .select('sd_key, title, description, scope, sd_type, intensity_level')
     .in('status', ['draft', 'active', 'in_progress'])
     .not('sd_type', 'is', null);
 
@@ -231,8 +234,9 @@ export async function auditSDTypes(options = {}) {
     if (classification.detectedType !== sd.sd_type &&
         classification.confidence >= MISMATCH_CONFIDENCE_THRESHOLD) {
 
+      // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
       mismatches.push({
-        sdId: sd.legacy_id,
+        sdId: sd.sd_key,
         title: sd.title,
         declaredType: sd.sd_type,
         detectedType: classification.detectedType,
@@ -240,11 +244,11 @@ export async function auditSDTypes(options = {}) {
         reasoning: classification.reasoning
       });
 
-      console.log(`⚠️  ${sd.legacy_id}`);
+      console.log(`⚠️  ${sd.sd_key}`);
       console.log(`   Declared: ${sd.sd_type} → Detected: ${classification.detectedType} (${classification.confidence}%)`);
 
       if (!dryRun) {
-        await updateSDTypeWithValidation(sd.legacy_id, classification.detectedType);
+        await updateSDTypeWithValidation(sd.sd_key, classification.detectedType);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Removes `legacy_id` column references from 7 active code files
- Addresses PAT-EXECSQL-001 and PAT-LEGACYID-001 patterns identified by `/learn`
- Updates queries to use `sd_key` instead of the dropped `legacy_id` column

## Changes
| File | Change |
|------|--------|
| `lib/sub-agents/github.js` | SD lookup query |
| `lib/sub-agents/testing/index.js` | SD type check query |
| `lib/sub-agents/retro/db-operations.js` | Retrospective SD lookup |
| `lib/sub-agents/retro/action-items.js` | sdKey fallback chain |
| `lib/sub-agents/retro/generators.js` | sdKey fallback chain |
| `lib/templates/prd-template.js` | PRD ID generation and metadata |
| `lib/utils/sd-type-guard.js` | SD audit and update functions |

## Test plan
- [x] Smoke tests pass
- [x] SD lookup by sd_key verified working
- [x] Both patterns marked resolved in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)