### PR TITLE
feat(SD-LEO-INFRA-DOCMON-SUB-AGENT-001-D): implement Git integration with pre-commit hooks

### DIFF
--- a/.github/workflows/doc-validation.yml
+++ b/.github/workflows/doc-validation.yml
@@ -192,8 +192,24 @@ jobs:
       - name: Fail on critical issues (PRs only)
         if: github.event_name == 'pull_request' && (steps.results.outputs.location_failed == 'true' || steps.results.outputs.naming_failed == 'true')
         run: |
-          echo "Critical documentation validation issues found in PR"
-          echo "See docmon-report.json artifact for details"
+          echo ""
+          echo "════════════════════════════════════════════════════════════"
+          echo "  DOCMON VALIDATION FAILED"
+          echo "════════════════════════════════════════════════════════════"
+          echo "  Files: ${{ steps.results.outputs.files_checked }} | Violations: ${{ steps.results.outputs.violations }}"
+          echo ""
+          if [ "${{ steps.results.outputs.location_failed }}" == "true" ]; then
+            echo "  DOCMON_ERROR: LOCATION_VALIDATION_FAILED"
+          fi
+          if [ "${{ steps.results.outputs.naming_failed }}" == "true" ]; then
+            echo "  DOCMON_ERROR: NAMING_VALIDATION_FAILED"
+          fi
+          echo ""
+          echo "────────────────────────────────────────────────────────────"
+          echo "  See docmon-report.json artifact for details"
+          echo "  Run 'npm run docmon:validate' locally to reproduce"
+          echo "════════════════════════════════════════════════════════════"
+          echo ""
           exit 1
 
   notify-on-failure:

--- a/package.json
+++ b/package.json
@@ -255,6 +255,7 @@
     "docs:validate-metadata": "node scripts/validate-doc-metadata.js",
     "docs:validate-naming": "node scripts/validate-doc-naming.js",
     "docs:validate-links": "node scripts/validate-doc-links.js",
+    "docs:validate:staged": "node scripts/validate-doc-staged.js",
     "docs:detect-duplicates": "node scripts/detect-duplicate-docs.js",
     "docs:inject-metadata": "node scripts/inject-doc-metadata.js",
     "docs:health": "node scripts/doc-health-report.js",

--- a/scripts/install-doc-validation-hooks.js
+++ b/scripts/install-doc-validation-hooks.js
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * Install Documentation Validation Hooks
+ * Sets up pre-commit hooks for documentation validation
+ *
+ * Creates hooks to run validation scripts before commits
+ * that include .md file changes.
+ *
+ * Features:
+ *   - Validates only STAGED .md files (not all docs)
+ *   - Emergency bypass: DOCMON_BYPASS=1 git commit ...
+ *   - Idempotent installation (preserves existing hooks)
+ *   - Standardized DOCMON_ERROR output format
+ *
+ * Usage:
+ *   node scripts/install-doc-validation-hooks.js          # Install hooks
+ *   node scripts/install-doc-validation-hooks.js --check  # Check if installed
+ *   node scripts/install-doc-validation-hooks.js --remove # Remove hooks
+ *
+ * Bypass (emergencies only):
+ *   DOCMON_BYPASS=1 git commit -m "emergency: ..."
+ *
+ * Part of SD-LEO-INFRA-DOCMON-SUB-AGENT-001-D
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+const HUSKY_DIR = path.join(ROOT_DIR, '.husky');
+
+// Hook file configuration
+const DOC_HOOK_MARKER = '# DOC-VALIDATION-HOOK';
+const HOOK_VERSION = '2.0.0'; // Track hook version for updates
+const HOOK_CONTENT = `
+${DOC_HOOK_MARKER}
+# DOCMON Pre-Commit Validation Hook v${HOOK_VERSION}
+# Validates only STAGED .md files before commit
+# Bypass: DOCMON_BYPASS=1 git commit -m "emergency: ..."
+
+# Emergency bypass mechanism
+if [ "\${DOCMON_BYPASS:-0}" = "1" ]; then
+  echo "⚠️  DOCMON_BYPASS=1 detected - skipping documentation validation"
+  echo "   WARNING: This bypass should only be used for emergencies!"
+  echo "   Please run 'npm run docs:validate' before pushing."
+  # Log bypass for audit trail
+  echo "[$(date -Iseconds)] DOCMON bypass used for commit" >> .docmon-bypass.log 2>/dev/null || true
+else
+  # Check if any .md files are being committed (staged)
+  md_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\\.md$' || true)
+
+  if [ -n "$md_files" ]; then
+    start_time=$(date +%s%3N 2>/dev/null || date +%s)
+    file_count=$(echo "$md_files" | wc -l | tr -d ' ')
+    echo ""
+    echo "════════════════════════════════════════════════════════════"
+    echo "  DOCMON PRE-COMMIT VALIDATION"
+    echo "════════════════════════════════════════════════════════════"
+    echo "  Staged files: $file_count .md file(s)"
+    echo ""
+
+    validation_errors=0
+    validation_warnings=0
+
+    # Run location validation on staged files only
+    echo "  [1/3] Location validation..."
+    if ! npm run docs:validate:staged -- --validator=location 2>/dev/null; then
+      echo "  DOCMON_ERROR: LOCATION_VALIDATION_FAILED"
+      echo "    Run 'npm run docs:validate-location' for details"
+      validation_errors=$((validation_errors + 1))
+    else
+      echo "        ✓ Location check passed"
+    fi
+
+    # Run metadata validation (warning only, not blocking)
+    echo "  [2/3] Metadata validation..."
+    if ! npm run docs:validate:staged -- --validator=metadata 2>/dev/null; then
+      echo "        ⚠ Metadata warnings (non-blocking)"
+      validation_warnings=$((validation_warnings + 1))
+    else
+      echo "        ✓ Metadata check passed"
+    fi
+
+    # Run naming validation
+    echo "  [3/3] Naming validation..."
+    if ! npm run docs:validate:staged -- --validator=naming 2>/dev/null; then
+      echo "  DOCMON_ERROR: NAMING_VALIDATION_FAILED"
+      echo "    Run 'npm run docs:validate-naming' for details"
+      validation_errors=$((validation_errors + 1))
+    else
+      echo "        ✓ Naming check passed"
+    fi
+
+    end_time=$(date +%s%3N 2>/dev/null || date +%s)
+    elapsed=$((end_time - start_time))
+
+    echo ""
+    echo "────────────────────────────────────────────────────────────"
+    echo "  Summary: $file_count files | $validation_errors errors | $validation_warnings warnings | \${elapsed}ms"
+
+    if [ "$validation_errors" -gt 0 ]; then
+      echo ""
+      echo "  ❌ RESULT: BLOCKED"
+      echo "     Fix validation errors or use DOCMON_BYPASS=1 for emergencies"
+      echo "════════════════════════════════════════════════════════════"
+      echo ""
+      exit 1
+    else
+      echo ""
+      echo "  ✅ RESULT: PASS"
+      echo "════════════════════════════════════════════════════════════"
+      echo ""
+    fi
+  fi
+fi
+# END-DOC-VALIDATION-HOOK
+`;
+
+function checkHuskyExists() {
+  if (!fs.existsSync(HUSKY_DIR)) {
+    console.log('❌ Husky directory not found at .husky/');
+    console.log('   Run "npx husky install" first to set up husky.');
+    return false;
+  }
+  return true;
+}
+
+function getPreCommitPath() {
+  return path.join(HUSKY_DIR, 'pre-commit');
+}
+
+function isHookInstalled() {
+  const preCommitPath = getPreCommitPath();
+  if (!fs.existsSync(preCommitPath)) {
+    return false;
+  }
+  const content = fs.readFileSync(preCommitPath, 'utf8');
+  return content.includes(DOC_HOOK_MARKER);
+}
+
+function installHook() {
+  if (!checkHuskyExists()) {
+    process.exit(1);
+  }
+
+  const preCommitPath = getPreCommitPath();
+
+  // Check if pre-commit exists
+  if (fs.existsSync(preCommitPath)) {
+    // Check if already installed
+    if (isHookInstalled()) {
+      console.log('✅ Documentation validation hook is already installed.');
+      return;
+    }
+
+    // Append to existing pre-commit
+    console.log('📝 Appending documentation validation to existing pre-commit hook...');
+    const existingContent = fs.readFileSync(preCommitPath, 'utf8');
+    fs.writeFileSync(preCommitPath, existingContent + '\n' + HOOK_CONTENT, 'utf8');
+  } else {
+    // Create new pre-commit hook
+    console.log('📝 Creating pre-commit hook with documentation validation...');
+    const fullContent = `#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+${HOOK_CONTENT}`;
+    fs.writeFileSync(preCommitPath, fullContent, 'utf8');
+    // Make executable on Unix systems
+    try {
+      fs.chmodSync(preCommitPath, '755');
+    } catch (_e) {
+      // Ignore on Windows
+    }
+  }
+
+  console.log('✅ Documentation validation hook installed successfully!');
+  console.log(`   Version: ${HOOK_VERSION}`);
+  console.log('');
+  console.log('The hook validates STAGED .md files on commit:');
+  console.log('  • Location validation (blocking)');
+  console.log('  • Metadata validation (warning only)');
+  console.log('  • Naming validation (blocking)');
+  console.log('');
+  console.log('Emergency bypass (use sparingly):');
+  console.log('  DOCMON_BYPASS=1 git commit -m "emergency: message"');
+}
+
+function removeHook() {
+  const preCommitPath = getPreCommitPath();
+
+  if (!fs.existsSync(preCommitPath)) {
+    console.log('ℹ️  No pre-commit hook found. Nothing to remove.');
+    return;
+  }
+
+  if (!isHookInstalled()) {
+    console.log('ℹ️  Documentation validation hook is not installed. Nothing to remove.');
+    return;
+  }
+
+  const content = fs.readFileSync(preCommitPath, 'utf8');
+
+  // Remove the doc validation section
+  const startMarker = `\n${DOC_HOOK_MARKER}`;
+  const endMarker = '# END-DOC-VALIDATION-HOOK\n';
+  const startIndex = content.indexOf(startMarker);
+  const endIndex = content.indexOf(endMarker);
+
+  if (startIndex === -1 || endIndex === -1) {
+    console.log('⚠️  Could not locate hook boundaries. Manual removal may be needed.');
+    return;
+  }
+
+  const newContent = content.substring(0, startIndex) + content.substring(endIndex + endMarker.length);
+
+  // Check if anything meaningful is left
+  const remainingContent = newContent.replace(/#!.*\n/, '').replace(/\. .*husky\.sh.*\n/, '').trim();
+
+  if (!remainingContent) {
+    // Nothing else in the hook, remove the file
+    fs.unlinkSync(preCommitPath);
+    console.log('✅ Pre-commit hook removed (no other hooks were present).');
+  } else {
+    // Keep other hooks
+    fs.writeFileSync(preCommitPath, newContent, 'utf8');
+    console.log('✅ Documentation validation hook removed. Other hooks preserved.');
+  }
+}
+
+function checkStatus() {
+  if (!checkHuskyExists()) {
+    process.exit(1);
+  }
+
+  if (isHookInstalled()) {
+    console.log('✅ Documentation validation hook is INSTALLED');
+    console.log(`   Version: ${HOOK_VERSION}`);
+    console.log('');
+    console.log('Validations run on STAGED .md files:');
+    console.log('  • Location validation (blocking)');
+    console.log('  • Metadata validation (warning only)');
+    console.log('  • Naming validation (blocking)');
+    console.log('');
+    console.log('Emergency bypass:');
+    console.log('  DOCMON_BYPASS=1 git commit -m "emergency: message"');
+    process.exit(0);
+  } else {
+    console.log('❌ Documentation validation hook is NOT INSTALLED');
+    console.log('');
+    console.log('Run this script without arguments to install:');
+    console.log('  node scripts/install-doc-validation-hooks.js');
+    process.exit(1);
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+
+  console.log('📋 Documentation Validation Hook Manager');
+  console.log('='.repeat(50));
+  console.log('');
+
+  if (args.includes('--check')) {
+    checkStatus();
+  } else if (args.includes('--remove')) {
+    removeHook();
+  } else if (args.includes('--help') || args.includes('-h')) {
+    console.log('Usage:');
+    console.log('  node scripts/install-doc-validation-hooks.js          Install hooks');
+    console.log('  node scripts/install-doc-validation-hooks.js --check  Check status');
+    console.log('  node scripts/install-doc-validation-hooks.js --remove Remove hooks');
+  } else {
+    installHook();
+  }
+}
+
+main();

--- a/scripts/validate-doc-staged.js
+++ b/scripts/validate-doc-staged.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * DOCMON Staged Files Validator
+ * Validates only staged (git diff --cached) .md files
+ *
+ * Used by pre-commit hook to validate only files being committed,
+ * not the entire documentation tree.
+ *
+ * Exit codes:
+ *   0 - Validation passed (or no staged .md files)
+ *   1 - Runtime error
+ *   2 - Validation failed
+ *
+ * Usage:
+ *   node scripts/validate-doc-staged.js                    # Run all validators
+ *   node scripts/validate-doc-staged.js --validator=location  # Run specific validator
+ *   node scripts/validate-doc-staged.js --validator=naming
+ *   node scripts/validate-doc-staged.js --validator=metadata
+ *   node scripts/validate-doc-staged.js --format=json      # JSON output
+ *
+ * Part of SD-LEO-INFRA-DOCMON-SUB-AGENT-001-D
+ */
+import { execSync } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+// Exit codes matching DOCMON convention
+const EXIT_CODES = {
+  PASS: 0,
+  RUNTIME_ERROR: 1,
+  VALIDATION_FAILED: 2
+};
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return {
+    validator: args.find(a => a.startsWith('--validator='))?.split('=')[1],
+    format: args.find(a => a.startsWith('--format='))?.split('=')[1] || 'text',
+    help: args.includes('--help') || args.includes('-h')
+  };
+}
+
+function showHelp() {
+  console.log(`
+DOCMON Staged Files Validator
+
+Validates only staged .md files (git diff --cached)
+
+Usage:
+  node scripts/validate-doc-staged.js [options]
+
+Options:
+  --validator=<name>   Run specific validator: location, naming, metadata
+  --format=<format>    Output format: text, json (default: text)
+  --help, -h           Show this help message
+
+Exit codes:
+  0 - Validation passed (or no staged files)
+  1 - Runtime error
+  2 - Validation failed
+
+Examples:
+  node scripts/validate-doc-staged.js                     # All validators
+  node scripts/validate-doc-staged.js --validator=location
+  npm run docs:validate:staged -- --validator=naming
+`);
+}
+
+function getStagedMdFiles() {
+  try {
+    const output = execSync('git diff --cached --name-only --diff-filter=ACM', {
+      cwd: ROOT_DIR,
+      encoding: 'utf8'
+    });
+    return output
+      .split('\n')
+      .filter(f => f.endsWith('.md'))
+      .map(f => f.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function runValidator(validatorName, files, _format) {
+  if (files.length === 0) {
+    return { passed: true, message: 'No staged .md files' };
+  }
+
+  const startTime = Date.now();
+  const results = {
+    validator: validatorName,
+    files_checked: files.length,
+    passed: true,
+    violations: [],
+    warnings: []
+  };
+
+  // Dynamically import and run the appropriate validator logic
+  // For now, we'll call the existing validators with --path for each file
+  // or use --changed-only which already exists
+
+  try {
+    const scriptMap = {
+      location: 'validate-doc-location.js',
+      naming: 'validate-doc-naming.js',
+      metadata: 'validate-doc-metadata.js'
+    };
+
+    const script = scriptMap[validatorName];
+    if (!script) {
+      throw new Error(`Unknown validator: ${validatorName}`);
+    }
+
+    // Run validator in changed-only mode (uses git diff)
+    // But we need staged files, so we pass each file individually
+    for (const file of files) {
+      try {
+        execSync(`node scripts/${script} --path="${file}" --format=json`, {
+          cwd: ROOT_DIR,
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe']
+        });
+      } catch (err) {
+        // Non-zero exit means validation failed
+        if (err.status === 2) {
+          results.passed = false;
+          try {
+            const output = JSON.parse(err.stdout || '{}');
+            if (output.results?.invalid) {
+              results.violations.push(...output.results.invalid);
+            }
+          } catch {
+            results.violations.push({ path: file, reason: 'Validation failed' });
+          }
+        } else if (err.status === 1) {
+          // Runtime error
+          throw err;
+        }
+      }
+    }
+  } catch (err) {
+    if (err.status === 1) {
+      throw err;
+    }
+  }
+
+  results.execution_time_ms = Date.now() - startTime;
+  return results;
+}
+
+async function main() {
+  const args = parseArgs();
+
+  if (args.help) {
+    showHelp();
+    process.exit(EXIT_CODES.PASS);
+  }
+
+  const stagedFiles = getStagedMdFiles();
+
+  if (stagedFiles.length === 0) {
+    if (args.format === 'json') {
+      console.log(JSON.stringify({
+        staged_files: 0,
+        message: 'No staged .md files',
+        passed: true
+      }));
+    }
+    // No staged files = pass (nothing to validate)
+    process.exit(EXIT_CODES.PASS);
+  }
+
+  const startTime = Date.now();
+  let overallPassed = true;
+  const allResults = [];
+
+  // Determine which validators to run
+  const validators = args.validator
+    ? [args.validator]
+    : ['location', 'naming', 'metadata'];
+
+  for (const validator of validators) {
+    const result = runValidator(validator, stagedFiles, args.format);
+    allResults.push(result);
+
+    // Only location and naming are blocking
+    if (validator !== 'metadata' && !result.passed) {
+      overallPassed = false;
+    }
+  }
+
+  const combinedResults = {
+    staged_files: stagedFiles.length,
+    files: stagedFiles,
+    validators: allResults,
+    overall_passed: overallPassed,
+    execution_time_ms: Date.now() - startTime
+  };
+
+  if (args.format === 'json') {
+    console.log(JSON.stringify(combinedResults, null, 2));
+  } else {
+    // Text output with DOCMON_ERROR format
+    console.log('');
+    for (const result of allResults) {
+      if (!result.passed && result.validator !== 'metadata') {
+        console.log(`DOCMON_ERROR: ${result.validator.toUpperCase()}_VALIDATION_FAILED`);
+        console.log(`  Files: ${result.files_checked} | Violations: ${result.violations.length}`);
+        for (const v of result.violations.slice(0, 3)) {
+          console.log(`    - ${v.path}`);
+        }
+      }
+    }
+    console.log(`  Total elapsed: ${combinedResults.execution_time_ms}ms`);
+  }
+
+  process.exit(overallPassed ? EXIT_CODES.PASS : EXIT_CODES.VALIDATION_FAILED);
+}
+
+main().catch(err => {
+  console.error(`Runtime error: ${err.message}`);
+  process.exit(EXIT_CODES.RUNTIME_ERROR);
+});


### PR DESCRIPTION
## Summary

- Enhanced `install-doc-validation-hooks.js` with v2.0.0 pre-commit hook
- Added `DOCMON_BYPASS=1` emergency bypass mechanism with audit logging
- Created `validate-doc-staged.js` for staged-only .md file validation
- Added `docs:validate:staged` npm script
- Enhanced `reporter.js` with `formatDocmonError()` for standardized output
- Updated `doc-validation.yml` workflow with DOCMON_ERROR format on failures

## Child D (SD-LEO-INFRA-DOCMON-SUB-AGENT-001-D) Requirements Addressed

| Requirement | Implementation |
|-------------|----------------|
| FR-1: Pre-commit hook installation | `install-doc-validation-hooks.js` v2.0.0 |
| FR-2: `docs:validate` npm script | Existing + new `docs:validate:staged` |
| FR-3: Validate only staged .md files | Hook uses `git diff --cached` |
| FR-4: Bypass mechanism | `DOCMON_BYPASS=1` env var + audit logging |
| FR-5: GitHub Actions integration | `doc-validation.yml` already comprehensive |
| FR-6: Standardized output | `DOCMON_ERROR` format with counts + elapsed time |

## Pre-commit Hook Features

- Validates only STAGED .md files (not entire docs tree)
- Shows file count, elapsed time, and error/warning counts
- Emergency bypass: `DOCMON_BYPASS=1 git commit -m "emergency: ..."`
- Clear `DOCMON_ERROR` output for CI/automation parsing

## Test Plan

- [ ] Run `node scripts/install-doc-validation-hooks.js --check` to verify hook status
- [ ] Run `npm run docs:validate:staged` with no staged files (should pass)
- [ ] Stage a .md file and run validation to test hook flow
- [ ] Test bypass with `DOCMON_BYPASS=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)