### PR TITLE
fix(stop-hook): resolve post-completion validator false positive blocking AUTO-PROCEED

### DIFF
--- a/scripts/hooks/stop-subagent-enforcement/index.js
+++ b/scripts/hooks/stop-subagent-enforcement/index.js
@@ -175,7 +175,7 @@ export async function main() {
   const sdResult = await safeAsync(async () => {
     return supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, sd_key, title, sd_type, category, current_phase, status')
+      .select('id, sd_key, sd_key, title, sd_type, category, current_phase, status, completion_date')
       .or(`sd_key.eq.${sdKey},sd_key.eq.${sdKey},id.eq.${sdKey}`)
       .single();
   }, 'getSDDetails');

--- a/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
+++ b/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
@@ -59,8 +59,10 @@ export async function validatePostCompletion(supabase, sd, sdKey) {
         missingRequired.push('SHIP');
       }
     } catch {
-      // If diff fails, assume ship is needed
-      missingRequired.push('SHIP');
+      // If diff fails (branch deleted after merge, or on main), don't assume ship is needed
+      // The completion_date check above should handle completed/shipped SDs
+      // Only log for debugging - don't block
+      console.error(`   ℹ️  Git diff failed for ${sdKey} - branch may already be merged`);
     }
   }
 


### PR DESCRIPTION
## Summary

- Fixes false positive in post-completion validator that was blocking AUTO-PROCEED mode
- Root cause identified via RCA sub-agent analysis

## Root Cause Analysis (5-Whys)

1. **Why was AUTO-PROCEED stopping?** → Post-completion validator was blocking with "Missing SHIP"
2. **Why did validator think SHIP was missing?** → `sd.completion_date` was undefined
3. **Why was completion_date undefined?** → SD query in index.js did not include it in select
4. **Why did the catch block also fail?** → `git diff main...HEAD` fails after branch merge
5. **Why did catch assume SHIP needed?** → Incorrect assumption that diff failure means uncommitted work

## Changes

1. **index.js:178** - Added `completion_date` to SD select query
2. **post-completion-validator.js:61-64** - Changed catch block to log info instead of blocking

## Test plan

- [x] Smoke tests pass
- [x] DOCMON compliance check passes
- [ ] Verify AUTO-PROCEED continues after SD completion (manual test)
- [ ] Verify completed SDs with `completion_date` set are not blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)