### PR TITLE
fix(migration): use NOT VALID for success_metrics constraint

### DIFF
--- a/database/migrations/20260130_add_success_metrics_constraint.sql
+++ b/database/migrations/20260130_add_success_metrics_constraint.sql
@@ -3,9 +3,10 @@
 -- Pattern: PAT-AUTOPROCEED-EMPTY-ARRAY
 --
 -- This constraint ensures:
--- 1. success_metrics cannot be an empty array
+-- 1. success_metrics cannot be an empty array for NEW inserts/updates
 -- 2. success_metrics must have at least one valid entry
--- 3. Existing empty arrays will be caught on next UPDATE (not retroactively enforced)
+-- 3. NOT VALID: Existing rows are NOT validated (194 historical SDs have empty arrays)
+-- 4. Historical data can be backfilled gradually or left as-is for completed/cancelled SDs
 
 -- First, let's see how many SDs have empty success_metrics (for awareness)
 -- SELECT COUNT(*) as empty_metrics_count
@@ -22,7 +23,7 @@ CHECK (
   OR
   -- If array, must have at least 1 element
   jsonb_array_length(success_metrics) >= 1
-);
+) NOT VALID;  -- Skip validation of existing rows
 
 -- Add comment explaining the constraint
 COMMENT ON CONSTRAINT success_metrics_not_empty ON strategic_directives_v2 IS
@@ -35,7 +36,18 @@ CHECK (
   success_criteria IS NULL
   OR
   jsonb_array_length(success_criteria) >= 1
-);
+) NOT VALID;  -- Skip validation of existing rows
 
 COMMENT ON CONSTRAINT success_criteria_not_empty ON strategic_directives_v2 IS
 'Prevents empty success_criteria arrays. Each SD must have acceptance criteria defined.';
+
+-- ============================================================
+-- OPTIONAL: Validate existing data after backfill
+-- ============================================================
+-- After running data healing on historical SDs, you can validate the constraints:
+--
+-- ALTER TABLE strategic_directives_v2 VALIDATE CONSTRAINT success_metrics_not_empty;
+-- ALTER TABLE strategic_directives_v2 VALIDATE CONSTRAINT success_criteria_not_empty;
+--
+-- Note: VALIDATE will fail if any existing rows violate the constraint.
+-- First run the healing script for completed/cancelled SDs if validation is desired.


### PR DESCRIPTION
## Summary
The original constraint failed because 194 historical SDs (completed/cancelled) have empty success_metrics or success_criteria arrays.

## Fix
Using `NOT VALID` in PostgreSQL constraints:
- Constraint applies to NEW inserts/updates only
- Existing rows are not validated on constraint creation
- Can be validated later with `VALIDATE CONSTRAINT` after optional data backfill

## Updated SQL
```sql
ALTER TABLE strategic_directives_v2
ADD CONSTRAINT success_metrics_not_empty
CHECK (
  success_metrics IS NULL
  OR
  jsonb_array_length(success_metrics) >= 1
) NOT VALID;  -- Skip validation of existing rows
```

## Test plan
- [x] Constraint will now apply without error
- [x] New SDs with empty arrays will be blocked
- [x] Existing 194 historical SDs remain untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)