### PR TITLE
fix(learn): add success_criteria to SD creation payload

### DIFF
--- a/scripts/modules/learning/sd-builders.js
+++ b/scripts/modules/learning/sd-builders.js
@@ -142,6 +142,40 @@ export function buildStrategicObjectives(items) {
 }
 
 /**
+ * Build success_criteria from selected items
+ * @param {Array} items - Selected patterns and improvements
+ * @returns {Array} success_criteria array
+ */
+export function buildSuccessCriteria(items) {
+  const criteria = [];
+
+  for (const item of items) {
+    if (item.pattern_id) {
+      criteria.push({
+        criterion: `${item.pattern_id} eliminated from codebase`,
+        measure: 'Zero occurrences after implementation'
+      });
+    } else {
+      const desc = (item.description || 'improvement').slice(0, 60);
+      criteria.push({
+        criterion: `${desc}... implemented`,
+        measure: 'Feature fully functional and tested'
+      });
+    }
+  }
+
+  // Ensure at least one criterion (constraint requires non-empty array)
+  if (criteria.length === 0) {
+    criteria.push({
+      criterion: 'All learning items addressed',
+      measure: '100% completion with validation'
+    });
+  }
+
+  return criteria;
+}
+
+/**
  * Build key_principles from selected items
  * @param {Array} items - Selected patterns and improvements
  * @returns {Array} key_principles array

--- a/scripts/modules/learning/sd-creation.js
+++ b/scripts/modules/learning/sd-creation.js
@@ -12,6 +12,7 @@ import {
   buildSDDescription,
   buildSDTitle,
   buildSuccessMetrics,
+  buildSuccessCriteria,
   buildSmokeTestSteps,
   buildStrategicObjectives,
   buildKeyPrinciples
@@ -41,6 +42,7 @@ export async function createSDFromLearning(items, type) {
   const sdKey = await generateSDId(type, title);
   const description = buildSDDescription(items);
   const successMetrics = buildSuccessMetrics(items);
+  const successCriteria = buildSuccessCriteria(items);
   const smokeTestSteps = buildSmokeTestSteps(items);
   const strategicObjectives = buildStrategicObjectives(items);
   const keyPrinciples = buildKeyPrinciples(items);
@@ -61,6 +63,7 @@ export async function createSDFromLearning(items, type) {
     created_by: 'LEARN-Agent',
     created_at: new Date().toISOString(),
     success_metrics: successMetrics,
+    success_criteria: successCriteria,
     smoke_test_steps: smokeTestSteps,
     strategic_objectives: strategicObjectives,
     key_principles: keyPrinciples,


### PR DESCRIPTION
## Summary
- Add `buildSuccessCriteria()` function to `sd-builders.js`
- Import and use in `sd-creation.js` 
- Ensures non-empty array for database constraint compliance

## Root Cause
Schema constraint `success_criteria_not_empty` requires at least one element in the `success_criteria` JSONB array, but `/learn apply` was missing this field entirely, causing SD creation to fail.

## Issue Pattern
Documented as `PAT-SCHEMA-SYNC-01` - schema-application synchronization gap

## Test plan
- [ ] Run `/learn apply` with test patterns
- [ ] Verify SD created successfully without constraint violation
- [ ] Verify `success_criteria` field populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)