### PR TITLE
feat(phase-0): implement Intent Discovery Engine with Obra patterns

### DIFF
--- a/scripts/modules/phase-0/engine.js
+++ b/scripts/modules/phase-0/engine.js
@@ -1,0 +1,582 @@
+/**
+ * Phase 0 Intent Discovery Engine
+ *
+ * Part of SD-LEO-INFRA-PHASE-INTENT-DISCOVERY-001
+ *
+ * Implements Obra brainstorming patterns for strategic directive creation:
+ * - One-question-at-a-time flow (maxQuestionsPerMessage=1)
+ * - Minimum 3 discovery questions before completion
+ * - STAGED_CHECKPOINT pattern (produces intent_summary ≤500 chars)
+ * - UN_DONE_PROPOSAL pattern (produces out_of_scope array ≥3 items)
+ * - intent_crystallization_score calculation (0.0-1.0, threshold 0.7)
+ * - EHG stage-aware signal identification
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// State file for persisting discovery session
+const STATE_FILE = path.join(__dirname, '../../../.claude/phase-0-state.json');
+
+/**
+ * Phase 0 Engine States
+ */
+export const Phase0State = {
+  NOT_STARTED: 'not_started',
+  DISCOVERY_QUESTIONS: 'discovery_questions',
+  STAGED_CHECKPOINT: 'staged_checkpoint',
+  UN_DONE_PROPOSAL: 'un_done_proposal',
+  COMPLETED: 'completed',
+  BYPASSED: 'bypassed' // For non-feature/enhancement SDs
+};
+
+/**
+ * EHG Venture Lifecycle Stages
+ */
+export const EHGStage = {
+  IDEATION: 'ideation',
+  VALIDATION: 'validation',
+  MVP: 'mvp',
+  GROWTH: 'growth',
+  SCALE: 'scale'
+};
+
+/**
+ * SD Types that require Phase 0
+ */
+export const PHASE_0_REQUIRED_TYPES = ['feature', 'enhancement'];
+
+/**
+ * Minimum questions required before Phase 0 can complete
+ */
+export const MIN_QUESTIONS = 3;
+
+/**
+ * Minimum out-of-scope items required
+ */
+export const MIN_OUT_OF_SCOPE_ITEMS = 3;
+
+/**
+ * Intent summary maximum character length
+ */
+export const MAX_INTENT_SUMMARY_LENGTH = 500;
+
+/**
+ * Score threshold for Phase 0 completion
+ */
+export const CRYSTALLIZATION_THRESHOLD = 0.7;
+
+/**
+ * Maximum questions per message (one-question-at-a-time mandate)
+ */
+export const MAX_QUESTIONS_PER_MESSAGE = 1;
+
+/**
+ * Discovery question templates based on EHG stage
+ */
+export const DISCOVERY_QUESTIONS = {
+  [EHGStage.IDEATION]: [
+    { id: 'problem', question: 'What specific problem are you trying to solve?', required: true },
+    { id: 'user', question: 'Who is the primary user affected by this problem?', required: true },
+    { id: 'outcome', question: 'What outcome would success look like for this feature?', required: true },
+    { id: 'validation', question: 'How would you validate that this solves the problem?', required: false },
+    { id: 'risk', question: 'What is the biggest risk or unknown for this work?', required: false }
+  ],
+  [EHGStage.VALIDATION]: [
+    { id: 'hypothesis', question: 'What hypothesis are you testing with this feature?', required: true },
+    { id: 'metric', question: 'What metric will prove/disprove the hypothesis?', required: true },
+    { id: 'mvp', question: 'What is the minimum implementation to test this?', required: true },
+    { id: 'pivot', question: 'What would trigger a pivot or change in direction?', required: false }
+  ],
+  [EHGStage.MVP]: [
+    { id: 'user_value', question: 'What user value does this feature provide?', required: true },
+    { id: 'integration', question: 'How does this integrate with existing features?', required: true },
+    { id: 'success_metric', question: 'What metric defines success for this feature?', required: true },
+    { id: 'dependencies', question: 'What dependencies or blockers exist?', required: false }
+  ],
+  [EHGStage.GROWTH]: [
+    { id: 'retention', question: 'How does this improve user retention or engagement?', required: true },
+    { id: 'scalability', question: 'What scalability considerations are there?', required: true },
+    { id: 'measurement', question: 'How will you measure impact?', required: true },
+    { id: 'iteration', question: 'What iteration plan exists after launch?', required: false }
+  ],
+  [EHGStage.SCALE]: [
+    { id: 'efficiency', question: 'How does this improve operational efficiency?', required: true },
+    { id: 'automation', question: 'What can be automated in this feature?', required: true },
+    { id: 'enterprise', question: 'How does this support enterprise requirements?', required: true },
+    { id: 'maintenance', question: 'What is the long-term maintenance burden?', required: false }
+  ]
+};
+
+/**
+ * Create initial Phase 0 session state
+ * @param {string} sdType - The SD type being created
+ * @param {string} initialContext - Initial context from conversation
+ * @returns {object} Initial session state
+ */
+export function createSession(sdType, initialContext = '') {
+  const requiresPhase0 = PHASE_0_REQUIRED_TYPES.includes(sdType);
+
+  return {
+    version: '1.0.0',
+    sdType,
+    requiresPhase0,
+    state: requiresPhase0 ? Phase0State.DISCOVERY_QUESTIONS : Phase0State.BYPASSED,
+    ehgStage: null, // Will be detected or asked
+    questionsAsked: 0,
+    questionsAnswered: 0,
+    answers: {},
+    intentSummary: null,
+    outOfScope: [],
+    explicitSuccessMetric: null,
+    stageSignal: null,
+    crystallizationScore: 0.0,
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+    initialContext,
+    questionHistory: []
+  };
+}
+
+/**
+ * Get the next question to ask based on current state
+ * @param {object} session - Current session state
+ * @returns {object|null} Next question or null if no more questions needed
+ */
+export function getNextQuestion(session) {
+  // First, check if we need to determine EHG stage
+  if (!session.ehgStage) {
+    return {
+      id: '_ehg_stage',
+      question: 'What stage is this venture at?',
+      type: 'stage_selection',
+      options: [
+        { value: EHGStage.IDEATION, label: 'Ideation', description: 'Exploring problem space and solutions' },
+        { value: EHGStage.VALIDATION, label: 'Validation', description: 'Testing hypotheses with real users' },
+        { value: EHGStage.MVP, label: 'MVP', description: 'Building minimum viable product' },
+        { value: EHGStage.GROWTH, label: 'Growth', description: 'Scaling user acquisition and engagement' },
+        { value: EHGStage.SCALE, label: 'Scale', description: 'Enterprise and operational efficiency' }
+      ]
+    };
+  }
+
+  // Get stage-specific questions
+  const stageQuestions = DISCOVERY_QUESTIONS[session.ehgStage] || DISCOVERY_QUESTIONS[EHGStage.MVP];
+
+  // Find next unanswered required question
+  for (const q of stageQuestions) {
+    if (q.required && !session.answers[q.id]) {
+      session.questionsAsked++;
+      session.questionHistory.push({
+        questionId: q.id,
+        askedAt: new Date().toISOString()
+      });
+      return {
+        id: q.id,
+        question: q.question,
+        type: 'open_ended',
+        required: q.required
+      };
+    }
+  }
+
+  // If minimum questions not met, ask optional questions
+  if (session.questionsAnswered < MIN_QUESTIONS) {
+    for (const q of stageQuestions) {
+      if (!q.required && !session.answers[q.id]) {
+        session.questionsAsked++;
+        session.questionHistory.push({
+          questionId: q.id,
+          askedAt: new Date().toISOString()
+        });
+        return {
+          id: q.id,
+          question: q.question,
+          type: 'open_ended',
+          required: false
+        };
+      }
+    }
+  }
+
+  // Check if we need explicit success metric
+  if (!session.explicitSuccessMetric && session.questionsAnswered >= MIN_QUESTIONS) {
+    return {
+      id: '_success_metric',
+      question: 'What is the single most important metric that will tell you this was successful?',
+      type: 'open_ended',
+      required: true
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Process an answer from the user
+ * @param {object} session - Current session state
+ * @param {string} questionId - ID of the question being answered
+ * @param {string} answer - User's answer
+ * @returns {object} Updated session state
+ */
+export function processAnswer(session, questionId, answer) {
+  // Handle EHG stage selection
+  if (questionId === '_ehg_stage') {
+    session.ehgStage = answer;
+    session.stageSignal = {
+      stage: answer,
+      detectedAt: new Date().toISOString(),
+      method: 'user_selection'
+    };
+    return session;
+  }
+
+  // Handle success metric
+  if (questionId === '_success_metric') {
+    session.explicitSuccessMetric = answer;
+    session.questionsAnswered++;
+    return session;
+  }
+
+  // Handle regular answers
+  session.answers[questionId] = {
+    answer,
+    answeredAt: new Date().toISOString()
+  };
+  session.questionsAnswered++;
+
+  // Update question history
+  const historyEntry = session.questionHistory.find(h => h.questionId === questionId);
+  if (historyEntry) {
+    historyEntry.answeredAt = new Date().toISOString();
+  }
+
+  return session;
+}
+
+/**
+ * Check if STAGED_CHECKPOINT should be triggered
+ * @param {object} session - Current session state
+ * @returns {boolean} True if checkpoint should be triggered
+ */
+export function shouldTriggerCheckpoint(session) {
+  return session.questionsAnswered >= MIN_QUESTIONS &&
+         !session.intentSummary &&
+         session.state === Phase0State.DISCOVERY_QUESTIONS;
+}
+
+/**
+ * Generate intent summary (STAGED_CHECKPOINT)
+ * @param {object} session - Current session state
+ * @returns {string} Generated intent summary (≤500 chars)
+ */
+export function generateIntentSummary(session) {
+  const answers = Object.entries(session.answers)
+    .map(([id, data]) => `${id}: ${data.answer}`)
+    .join('; ');
+
+  const context = session.initialContext ? `Context: ${session.initialContext}. ` : '';
+  const stage = session.ehgStage ? `Stage: ${session.ehgStage}. ` : '';
+  const metric = session.explicitSuccessMetric ? `Success metric: ${session.explicitSuccessMetric}. ` : '';
+
+  let summary = `${context}${stage}${answers}. ${metric}`;
+
+  // Truncate to MAX_INTENT_SUMMARY_LENGTH
+  if (summary.length > MAX_INTENT_SUMMARY_LENGTH) {
+    summary = summary.substring(0, MAX_INTENT_SUMMARY_LENGTH - 3) + '...';
+  }
+
+  return summary;
+}
+
+/**
+ * Set intent summary (STAGED_CHECKPOINT complete)
+ * @param {object} session - Current session state
+ * @param {string} summary - Intent summary (≤500 chars)
+ * @returns {object} Updated session state
+ */
+export function setIntentSummary(session, summary) {
+  // Enforce max length
+  if (summary.length > MAX_INTENT_SUMMARY_LENGTH) {
+    summary = summary.substring(0, MAX_INTENT_SUMMARY_LENGTH - 3) + '...';
+  }
+
+  session.intentSummary = summary;
+  session.state = Phase0State.UN_DONE_PROPOSAL;
+  return session;
+}
+
+/**
+ * Check if UN_DONE_PROPOSAL should be triggered
+ * @param {object} session - Current session state
+ * @returns {boolean} True if UN_DONE_PROPOSAL should be triggered
+ */
+export function shouldTriggerUnDoneProposal(session) {
+  return Boolean(
+    session.intentSummary &&
+    session.outOfScope.length === 0 &&
+    session.state === Phase0State.UN_DONE_PROPOSAL
+  );
+}
+
+/**
+ * Generate out-of-scope suggestions (UN_DONE_PROPOSAL)
+ * @param {object} _session - Current session state (unused but kept for API consistency)
+ * @returns {string[]} Suggested out-of-scope items
+ */
+export function generateOutOfScopeSuggestions(_session) {
+  // These are template suggestions based on common scope creep patterns
+  const commonOutOfScope = [
+    'Full redesign of existing UI components',
+    'Performance optimization beyond functional requirements',
+    'Support for legacy browser versions',
+    'Internationalization and localization',
+    'Advanced analytics and reporting',
+    'Integration with third-party services not specified',
+    'Automated testing infrastructure changes',
+    'Documentation beyond inline code comments',
+    'Mobile-responsive design (unless specified)',
+    'Accessibility compliance beyond current baseline'
+  ];
+
+  // Return at least MIN_OUT_OF_SCOPE_ITEMS suggestions
+  return commonOutOfScope.slice(0, Math.max(MIN_OUT_OF_SCOPE_ITEMS, 5));
+}
+
+/**
+ * Set out-of-scope items (UN_DONE_PROPOSAL complete)
+ * @param {object} session - Current session state
+ * @param {string[]} items - Out-of-scope items
+ * @returns {object} Updated session state
+ */
+export function setOutOfScope(session, items) {
+  session.outOfScope = items;
+
+  // Calculate crystallization score after UN_DONE_PROPOSAL
+  session.crystallizationScore = calculateCrystallizationScore(session);
+
+  // Check if threshold met
+  if (session.crystallizationScore >= CRYSTALLIZATION_THRESHOLD) {
+    session.state = Phase0State.COMPLETED;
+    session.completedAt = new Date().toISOString();
+  }
+
+  return session;
+}
+
+/**
+ * Calculate intent crystallization score
+ *
+ * Scoring heuristics:
+ * - +0.2 if minQuestions >= 3 satisfied
+ * - +0.2 if STAGED_CHECKPOINT completed with non-empty intent_summary
+ * - +0.2 if UN_DONE_PROPOSAL completed with >= 3 out_of_scope items
+ * - +0.2 if EHG stage-aware signal captured
+ * - +0.2 if user provides explicit success metric
+ *
+ * @param {object} session - Current session state
+ * @returns {number} Score between 0.0 and 1.0
+ */
+export function calculateCrystallizationScore(session) {
+  let score = 0.0;
+
+  // +0.2 if minQuestions >= 3 satisfied
+  if (session.questionsAnswered >= MIN_QUESTIONS) {
+    score += 0.2;
+  }
+
+  // +0.2 if STAGED_CHECKPOINT completed with non-empty intent_summary
+  if (session.intentSummary && session.intentSummary.length > 0) {
+    score += 0.2;
+  }
+
+  // +0.2 if UN_DONE_PROPOSAL completed with >= 3 out_of_scope items
+  if (session.outOfScope.length >= MIN_OUT_OF_SCOPE_ITEMS) {
+    score += 0.2;
+  }
+
+  // +0.2 if EHG stage-aware signal captured
+  if (session.stageSignal && session.ehgStage) {
+    score += 0.2;
+  }
+
+  // +0.2 if user provides explicit success metric
+  if (session.explicitSuccessMetric && session.explicitSuccessMetric.length > 0) {
+    score += 0.2;
+  }
+
+  return Math.min(1.0, score);
+}
+
+/**
+ * Check if Phase 0 is complete
+ * @param {object} session - Current session state
+ * @returns {boolean} True if Phase 0 is complete
+ */
+export function isComplete(session) {
+  return session.state === Phase0State.COMPLETED ||
+         session.state === Phase0State.BYPASSED;
+}
+
+/**
+ * Check if Phase 0 requirements are met
+ * @param {object} session - Current session state
+ * @returns {object} Validation result with details
+ */
+export function validateCompletion(session) {
+  const issues = [];
+
+  if (session.state === Phase0State.BYPASSED) {
+    return { valid: true, issues: [], message: 'Phase 0 bypassed (not required for this SD type)' };
+  }
+
+  if (session.questionsAnswered < MIN_QUESTIONS) {
+    issues.push(`Minimum questions not met: ${session.questionsAnswered}/${MIN_QUESTIONS}`);
+  }
+
+  if (!session.intentSummary) {
+    issues.push('STAGED_CHECKPOINT not completed: no intent_summary');
+  }
+
+  if (session.outOfScope.length < MIN_OUT_OF_SCOPE_ITEMS) {
+    issues.push(`UN_DONE_PROPOSAL not satisfied: ${session.outOfScope.length}/${MIN_OUT_OF_SCOPE_ITEMS} out-of-scope items`);
+  }
+
+  if (session.crystallizationScore < CRYSTALLIZATION_THRESHOLD) {
+    issues.push(`Crystallization score below threshold: ${session.crystallizationScore.toFixed(2)}/${CRYSTALLIZATION_THRESHOLD}`);
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    score: session.crystallizationScore,
+    threshold: CRYSTALLIZATION_THRESHOLD,
+    message: issues.length === 0
+      ? `Phase 0 complete (score: ${session.crystallizationScore.toFixed(2)})`
+      : `Phase 0 incomplete: ${issues.join('; ')}`
+  };
+}
+
+/**
+ * Get Phase 0 artifacts for SD metadata enrichment
+ * @param {object} session - Current session state
+ * @returns {object} Artifacts to store in SD metadata
+ */
+export function getArtifacts(session) {
+  return {
+    phase_0_completed: isComplete(session),
+    phase_0_bypassed: session.state === Phase0State.BYPASSED,
+    intent_summary: session.intentSummary,
+    out_of_scope: session.outOfScope,
+    ehg_stage: session.ehgStage,
+    crystallization_score: session.crystallizationScore,
+    explicit_success_metric: session.explicitSuccessMetric,
+    questions_asked: session.questionsAsked,
+    questions_answered: session.questionsAnswered,
+    discovery_answers: session.answers,
+    started_at: session.startedAt,
+    completed_at: session.completedAt
+  };
+}
+
+// === State Persistence ===
+
+/**
+ * Save session state to file
+ * @param {object} session - Session state to save
+ */
+export function saveSession(session) {
+  const dir = path.dirname(STATE_FILE);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.writeFileSync(STATE_FILE, JSON.stringify(session, null, 2), 'utf8');
+}
+
+/**
+ * Load session state from file
+ * @returns {object|null} Session state or null if not found
+ */
+export function loadSession() {
+  try {
+    if (fs.existsSync(STATE_FILE)) {
+      let content = fs.readFileSync(STATE_FILE, 'utf8');
+      // Remove BOM if present
+      if (content.charCodeAt(0) === 0xFEFF) {
+        content = content.slice(1);
+      }
+      return JSON.parse(content);
+    }
+  } catch (err) {
+    console.warn(`[phase-0] Error loading session: ${err.message}`);
+  }
+  return null;
+}
+
+/**
+ * Clear session state file
+ */
+export function clearSession() {
+  try {
+    if (fs.existsSync(STATE_FILE)) {
+      fs.unlinkSync(STATE_FILE);
+    }
+  } catch (err) {
+    console.warn(`[phase-0] Error clearing session: ${err.message}`);
+  }
+}
+
+/**
+ * Check if SD type requires Phase 0
+ * @param {string} sdType - The SD type
+ * @returns {boolean} True if Phase 0 is required
+ */
+export function requiresPhase0(sdType) {
+  return PHASE_0_REQUIRED_TYPES.includes(sdType);
+}
+
+export default {
+  // State constants
+  Phase0State,
+  EHGStage,
+  PHASE_0_REQUIRED_TYPES,
+  MIN_QUESTIONS,
+  MIN_OUT_OF_SCOPE_ITEMS,
+  MAX_INTENT_SUMMARY_LENGTH,
+  CRYSTALLIZATION_THRESHOLD,
+  MAX_QUESTIONS_PER_MESSAGE,
+  DISCOVERY_QUESTIONS,
+
+  // Session management
+  createSession,
+  saveSession,
+  loadSession,
+  clearSession,
+
+  // Discovery flow
+  getNextQuestion,
+  processAnswer,
+
+  // STAGED_CHECKPOINT
+  shouldTriggerCheckpoint,
+  generateIntentSummary,
+  setIntentSummary,
+
+  // UN_DONE_PROPOSAL
+  shouldTriggerUnDoneProposal,
+  generateOutOfScopeSuggestions,
+  setOutOfScope,
+
+  // Scoring and validation
+  calculateCrystallizationScore,
+  isComplete,
+  validateCompletion,
+  requiresPhase0,
+
+  // Artifacts
+  getArtifacts
+};

--- a/scripts/modules/phase-0/index.js
+++ b/scripts/modules/phase-0/index.js
@@ -1,0 +1,22 @@
+/**
+ * Phase 0 Intent Discovery Module
+ *
+ * Part of SD-LEO-INFRA-PHASE-INTENT-DISCOVERY-001
+ *
+ * Exports:
+ * - engine: Core Phase 0 state machine and scoring logic
+ * - integration: LEO /leo create integration functions
+ */
+
+export * from './engine.js';
+export * as engine from './engine.js';
+export * as integration from './leo-integration.js';
+
+// Default export for convenience
+import engine from './engine.js';
+import integration from './leo-integration.js';
+
+export default {
+  engine,
+  integration
+};

--- a/scripts/modules/phase-0/leo-integration.js
+++ b/scripts/modules/phase-0/leo-integration.js
@@ -1,0 +1,460 @@
+/**
+ * Phase 0 LEO Integration Module
+ *
+ * Part of SD-LEO-INFRA-PHASE-INTENT-DISCOVERY-001
+ *
+ * Provides integration points for the `/leo create` command workflow:
+ * - Gates feature/enhancement SDs with mandatory Phase 0
+ * - Generates one-question-at-a-time prompts for Claude
+ * - Validates Phase 0 completion before SD creation
+ * - Enriches SD metadata with Phase 0 artifacts
+ */
+
+import {
+  createSession,
+  loadSession,
+  saveSession,
+  clearSession,
+  getNextQuestion,
+  processAnswer,
+  shouldTriggerCheckpoint,
+  generateIntentSummary,
+  setIntentSummary,
+  shouldTriggerUnDoneProposal,
+  generateOutOfScopeSuggestions,
+  setOutOfScope,
+  isComplete,
+  validateCompletion,
+  requiresPhase0,
+  getArtifacts,
+  CRYSTALLIZATION_THRESHOLD,
+  MIN_QUESTIONS,
+  MIN_OUT_OF_SCOPE_ITEMS,
+  MAX_QUESTIONS_PER_MESSAGE
+} from './engine.js';
+
+/**
+ * Start Phase 0 for SD creation
+ * Returns the first question to ask (one-question-at-a-time)
+ *
+ * @param {string} sdType - The SD type being created
+ * @param {string} initialContext - Initial context from conversation
+ * @returns {object} Result with session and first question (or bypass info)
+ */
+export function startPhase0(sdType, initialContext = '') {
+  // Check if Phase 0 is required
+  if (!requiresPhase0(sdType)) {
+    const session = createSession(sdType, initialContext);
+    saveSession(session);
+    return {
+      required: false,
+      bypassed: true,
+      session,
+      message: `Phase 0 not required for SD type: ${sdType}. Proceeding to SD creation.`
+    };
+  }
+
+  // Create new session
+  const session = createSession(sdType, initialContext);
+  saveSession(session);
+
+  // Get first question
+  const question = getNextQuestion(session);
+
+  return {
+    required: true,
+    bypassed: false,
+    session,
+    question,
+    message: `Phase 0 Intent Discovery started for ${sdType} SD.`
+  };
+}
+
+/**
+ * Continue Phase 0 with user's answer
+ * Returns the next question or completion status
+ *
+ * @param {string} questionId - ID of the question being answered
+ * @param {string|string[]} answer - User's answer
+ * @returns {object} Result with next question or completion info
+ */
+export function continuePhase0(questionId, answer) {
+  // Load existing session
+  let session = loadSession();
+
+  if (!session) {
+    return {
+      error: true,
+      message: 'No Phase 0 session found. Run startPhase0 first.'
+    };
+  }
+
+  if (isComplete(session)) {
+    return {
+      complete: true,
+      session,
+      artifacts: getArtifacts(session),
+      message: 'Phase 0 already complete.'
+    };
+  }
+
+  // Process the answer
+  session = processAnswer(session, questionId, answer);
+  saveSession(session);
+
+  // Check for STAGED_CHECKPOINT trigger
+  if (shouldTriggerCheckpoint(session)) {
+    const summary = generateIntentSummary(session);
+    return {
+      checkpoint: true,
+      pattern: 'STAGED_CHECKPOINT',
+      suggestedSummary: summary,
+      session,
+      instruction: `STAGED_CHECKPOINT: Review and confirm the intent summary below (max 500 chars):\n\n"${summary}"\n\nConfirm this summary or provide a revised version.`
+    };
+  }
+
+  // Check for UN_DONE_PROPOSAL trigger
+  if (shouldTriggerUnDoneProposal(session)) {
+    const suggestions = generateOutOfScopeSuggestions(session);
+    return {
+      proposal: true,
+      pattern: 'UN_DONE_PROPOSAL',
+      suggestedItems: suggestions,
+      session,
+      instruction: `UN_DONE_PROPOSAL: Define what is explicitly OUT OF SCOPE for this SD.\n\nSuggested items (select at least ${MIN_OUT_OF_SCOPE_ITEMS}):\n${suggestions.map((s, i) => `${i + 1}. ${s}`).join('\n')}\n\nConfirm these items or provide your own list.`
+    };
+  }
+
+  // Get next question
+  const nextQuestion = getNextQuestion(session);
+
+  if (!nextQuestion && !session.intentSummary) {
+    // Ready for STAGED_CHECKPOINT
+    const summary = generateIntentSummary(session);
+    return {
+      checkpoint: true,
+      pattern: 'STAGED_CHECKPOINT',
+      suggestedSummary: summary,
+      session,
+      instruction: `STAGED_CHECKPOINT: Review and confirm the intent summary below (max 500 chars):\n\n"${summary}"\n\nConfirm this summary or provide a revised version.`
+    };
+  }
+
+  if (!nextQuestion && session.intentSummary && session.outOfScope.length === 0) {
+    // Ready for UN_DONE_PROPOSAL
+    const suggestions = generateOutOfScopeSuggestions(session);
+    return {
+      proposal: true,
+      pattern: 'UN_DONE_PROPOSAL',
+      suggestedItems: suggestions,
+      session,
+      instruction: `UN_DONE_PROPOSAL: Define what is explicitly OUT OF SCOPE for this SD.\n\nSuggested items (select at least ${MIN_OUT_OF_SCOPE_ITEMS}):\n${suggestions.map((s, i) => `${i + 1}. ${s}`).join('\n')}\n\nConfirm these items or provide your own list.`
+    };
+  }
+
+  if (nextQuestion) {
+    return {
+      question: nextQuestion,
+      session,
+      progress: {
+        questionsAnswered: session.questionsAnswered,
+        minQuestions: MIN_QUESTIONS,
+        state: session.state
+      }
+    };
+  }
+
+  // Check completion
+  const validation = validateCompletion(session);
+
+  if (validation.valid) {
+    return {
+      complete: true,
+      session,
+      artifacts: getArtifacts(session),
+      message: validation.message
+    };
+  }
+
+  return {
+    incomplete: true,
+    session,
+    validation,
+    message: validation.message
+  };
+}
+
+/**
+ * Confirm STAGED_CHECKPOINT with intent summary
+ *
+ * @param {string} summary - Confirmed or revised intent summary
+ * @returns {object} Result with next step (UN_DONE_PROPOSAL)
+ */
+export function confirmCheckpoint(summary) {
+  let session = loadSession();
+
+  if (!session) {
+    return {
+      error: true,
+      message: 'No Phase 0 session found.'
+    };
+  }
+
+  session = setIntentSummary(session, summary);
+  saveSession(session);
+
+  // Trigger UN_DONE_PROPOSAL
+  const suggestions = generateOutOfScopeSuggestions(session);
+  return {
+    checkpointComplete: true,
+    proposal: true,
+    pattern: 'UN_DONE_PROPOSAL',
+    suggestedItems: suggestions,
+    session,
+    instruction: `UN_DONE_PROPOSAL: Define what is explicitly OUT OF SCOPE for this SD.\n\nSuggested items (select at least ${MIN_OUT_OF_SCOPE_ITEMS}):\n${suggestions.map((s, i) => `${i + 1}. ${s}`).join('\n')}\n\nConfirm these items or provide your own list.`
+  };
+}
+
+/**
+ * Confirm UN_DONE_PROPOSAL with out-of-scope items
+ *
+ * @param {string[]} items - Confirmed or revised out-of-scope items
+ * @returns {object} Result with completion status
+ */
+export function confirmUnDoneProposal(items) {
+  let session = loadSession();
+
+  if (!session) {
+    return {
+      error: true,
+      message: 'No Phase 0 session found.'
+    };
+  }
+
+  session = setOutOfScope(session, items);
+  saveSession(session);
+
+  const validation = validateCompletion(session);
+
+  if (validation.valid) {
+    return {
+      complete: true,
+      session,
+      artifacts: getArtifacts(session),
+      validation,
+      message: `Phase 0 complete! Crystallization score: ${session.crystallizationScore.toFixed(2)}`
+    };
+  }
+
+  return {
+    incomplete: true,
+    session,
+    validation,
+    message: validation.message
+  };
+}
+
+/**
+ * Gate check for /leo create command
+ * Determines if Phase 0 is required and returns appropriate action
+ *
+ * @param {string} sdType - The SD type being created
+ * @returns {object} Gate result
+ */
+export function checkGate(sdType) {
+  // Check for existing session
+  const existingSession = loadSession();
+
+  if (existingSession && !isComplete(existingSession)) {
+    // Resume existing session
+    return {
+      action: 'resume',
+      session: existingSession,
+      message: 'Resuming existing Phase 0 session.'
+    };
+  }
+
+  // Check if Phase 0 required
+  if (!requiresPhase0(sdType)) {
+    return {
+      action: 'proceed',
+      required: false,
+      message: `Phase 0 not required for SD type: ${sdType}.`
+    };
+  }
+
+  // Phase 0 required but not started
+  return {
+    action: 'start',
+    required: true,
+    message: `Phase 0 required for ${sdType} SD. Starting Intent Discovery.`
+  };
+}
+
+/**
+ * Get current Phase 0 status
+ *
+ * @returns {object} Current status
+ */
+export function getStatus() {
+  const session = loadSession();
+
+  if (!session) {
+    return {
+      active: false,
+      message: 'No Phase 0 session active.'
+    };
+  }
+
+  const validation = validateCompletion(session);
+
+  return {
+    active: true,
+    state: session.state,
+    sdType: session.sdType,
+    ehgStage: session.ehgStage,
+    questionsAnswered: session.questionsAnswered,
+    minQuestions: MIN_QUESTIONS,
+    hasIntentSummary: !!session.intentSummary,
+    outOfScopeCount: session.outOfScope.length,
+    minOutOfScope: MIN_OUT_OF_SCOPE_ITEMS,
+    crystallizationScore: session.crystallizationScore,
+    threshold: CRYSTALLIZATION_THRESHOLD,
+    complete: isComplete(session),
+    validation
+  };
+}
+
+/**
+ * Reset/cancel Phase 0 session
+ *
+ * @returns {object} Result
+ */
+export function reset() {
+  clearSession();
+  return {
+    reset: true,
+    message: 'Phase 0 session cleared.'
+  };
+}
+
+/**
+ * Generate AskUserQuestion format for Claude
+ * Enforces one-question-at-a-time (maxQuestionsPerMessage=1)
+ *
+ * @param {object} question - Question from getNextQuestion
+ * @returns {object} AskUserQuestion format
+ */
+export function formatForAskUserQuestion(question) {
+  if (!question) {
+    return null;
+  }
+
+  // Stage selection question
+  if (question.type === 'stage_selection') {
+    return {
+      questions: [{
+        question: question.question,
+        header: 'EHG Stage',
+        multiSelect: false,
+        options: question.options.map(opt => ({
+          label: opt.label,
+          description: opt.description
+        }))
+      }]
+    };
+  }
+
+  // Open-ended question - use options for common patterns or free-form
+  return {
+    questions: [{
+      question: question.question,
+      header: 'Discovery',
+      multiSelect: false,
+      options: [
+        { label: 'Provide answer', description: 'Type your response' }
+      ]
+    }]
+  };
+}
+
+/**
+ * Get integration instructions for Claude
+ * Returns markdown instructions for how to use Phase 0 in /leo create
+ *
+ * @returns {string} Instructions
+ */
+export function getIntegrationInstructions() {
+  return `
+## Phase 0 Intent Discovery Integration
+
+When processing \`/leo create\` for **feature** or **enhancement** SD types:
+
+### 1. Check Gate
+\`\`\`javascript
+const result = checkGate(sdType);
+// result.action: 'start' | 'resume' | 'proceed'
+\`\`\`
+
+### 2. If action is 'start' or 'resume'
+Run the discovery flow one question at a time:
+
+\`\`\`javascript
+// Start new session
+const start = startPhase0(sdType, conversationContext);
+// Ask start.question using AskUserQuestion (one question only!)
+
+// On each answer
+const next = continuePhase0(questionId, userAnswer);
+// If next.question → ask it
+// If next.checkpoint → confirm STAGED_CHECKPOINT
+// If next.proposal → confirm UN_DONE_PROPOSAL
+// If next.complete → proceed to SD creation
+\`\`\`
+
+### 3. On STAGED_CHECKPOINT
+Present the suggested intent summary and get confirmation:
+\`\`\`javascript
+const result = confirmCheckpoint(confirmedOrRevisedSummary);
+\`\`\`
+
+### 4. On UN_DONE_PROPOSAL
+Present out-of-scope suggestions and get confirmation:
+\`\`\`javascript
+const result = confirmUnDoneProposal(confirmedItems);
+\`\`\`
+
+### 5. When Complete
+Get artifacts for SD metadata:
+\`\`\`javascript
+const artifacts = getArtifacts(session);
+// Include in SD's metadata.phase_0 field
+\`\`\`
+
+### Key Rules
+- **ONE question per message** (maxQuestionsPerMessage=1)
+- **Minimum 3 questions** before checkpoint
+- **Minimum 3 out-of-scope items** required
+- **Score threshold: 0.7** for completion
+- **BLOCKED** if Phase 0 incomplete for feature/enhancement
+`;
+}
+
+export default {
+  startPhase0,
+  continuePhase0,
+  confirmCheckpoint,
+  confirmUnDoneProposal,
+  checkGate,
+  getStatus,
+  reset,
+  formatForAskUserQuestion,
+  getIntegrationInstructions,
+
+  // Re-export key constants
+  CRYSTALLIZATION_THRESHOLD,
+  MIN_QUESTIONS,
+  MIN_OUT_OF_SCOPE_ITEMS,
+  MAX_QUESTIONS_PER_MESSAGE
+};

--- a/tests/unit/phase-0/engine.test.js
+++ b/tests/unit/phase-0/engine.test.js
@@ -1,0 +1,569 @@
+/**
+ * Unit tests for Phase 0 Intent Discovery Engine
+ *
+ * Tests:
+ * - Session creation and state management
+ * - One-question-at-a-time flow
+ * - STAGED_CHECKPOINT pattern
+ * - UN_DONE_PROPOSAL pattern
+ * - Crystallization score calculation
+ * - EHG stage-aware signals
+ * - Phase 0 gating for feature/enhancement SDs
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  createSession,
+  getNextQuestion,
+  processAnswer,
+  shouldTriggerCheckpoint,
+  generateIntentSummary,
+  setIntentSummary,
+  shouldTriggerUnDoneProposal,
+  generateOutOfScopeSuggestions,
+  setOutOfScope,
+  calculateCrystallizationScore,
+  isComplete,
+  validateCompletion,
+  requiresPhase0,
+  getArtifacts,
+  saveSession,
+  loadSession,
+  clearSession,
+  Phase0State,
+  EHGStage,
+  PHASE_0_REQUIRED_TYPES,
+  MIN_QUESTIONS,
+  MIN_OUT_OF_SCOPE_ITEMS,
+  MAX_INTENT_SUMMARY_LENGTH,
+  CRYSTALLIZATION_THRESHOLD
+} from '../../../scripts/modules/phase-0/engine.js';
+
+describe('Phase 0 Intent Discovery Engine', () => {
+  beforeEach(() => {
+    // Clear any existing session state
+    clearSession();
+  });
+
+  afterEach(() => {
+    clearSession();
+  });
+
+  describe('Constants', () => {
+    it('should have correct threshold values', () => {
+      expect(CRYSTALLIZATION_THRESHOLD).toBe(0.7);
+      expect(MIN_QUESTIONS).toBe(3);
+      expect(MIN_OUT_OF_SCOPE_ITEMS).toBe(3);
+      expect(MAX_INTENT_SUMMARY_LENGTH).toBe(500);
+    });
+
+    it('should require Phase 0 for feature and enhancement types', () => {
+      expect(PHASE_0_REQUIRED_TYPES).toContain('feature');
+      expect(PHASE_0_REQUIRED_TYPES).toContain('enhancement');
+      expect(PHASE_0_REQUIRED_TYPES).not.toContain('fix');
+      expect(PHASE_0_REQUIRED_TYPES).not.toContain('infrastructure');
+    });
+  });
+
+  describe('requiresPhase0()', () => {
+    it('should return true for feature type', () => {
+      expect(requiresPhase0('feature')).toBe(true);
+    });
+
+    it('should return true for enhancement type', () => {
+      expect(requiresPhase0('enhancement')).toBe(true);
+    });
+
+    it('should return false for fix type', () => {
+      expect(requiresPhase0('fix')).toBe(false);
+    });
+
+    it('should return false for infrastructure type', () => {
+      expect(requiresPhase0('infrastructure')).toBe(false);
+    });
+
+    it('should return false for documentation type', () => {
+      expect(requiresPhase0('documentation')).toBe(false);
+    });
+  });
+
+  describe('createSession()', () => {
+    it('should create session for feature SD requiring Phase 0', () => {
+      const session = createSession('feature', 'Initial context');
+
+      expect(session.version).toBe('1.0.0');
+      expect(session.sdType).toBe('feature');
+      expect(session.requiresPhase0).toBe(true);
+      expect(session.state).toBe(Phase0State.DISCOVERY_QUESTIONS);
+      expect(session.questionsAsked).toBe(0);
+      expect(session.questionsAnswered).toBe(0);
+      expect(session.initialContext).toBe('Initial context');
+    });
+
+    it('should create bypassed session for fix SD', () => {
+      const session = createSession('fix');
+
+      expect(session.requiresPhase0).toBe(false);
+      expect(session.state).toBe(Phase0State.BYPASSED);
+    });
+
+    it('should initialize empty answers object', () => {
+      const session = createSession('feature');
+
+      expect(session.answers).toEqual({});
+      expect(session.outOfScope).toEqual([]);
+      expect(session.intentSummary).toBeNull();
+    });
+  });
+
+  describe('getNextQuestion()', () => {
+    it('should ask EHG stage first if not set', () => {
+      const session = createSession('feature');
+      const question = getNextQuestion(session);
+
+      expect(question.id).toBe('_ehg_stage');
+      expect(question.type).toBe('stage_selection');
+      expect(question.options).toHaveLength(5); // 5 EHG stages
+    });
+
+    it('should ask stage-specific questions after stage is set', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+
+      const question = getNextQuestion(session);
+
+      expect(question.id).not.toBe('_ehg_stage');
+      expect(question.type).toBe('open_ended');
+      expect(question.required).toBe(true);
+    });
+
+    it('should increment questionsAsked counter', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+
+      expect(session.questionsAsked).toBe(0);
+      getNextQuestion(session);
+      expect(session.questionsAsked).toBe(1);
+    });
+  });
+
+  describe('processAnswer()', () => {
+    it('should set EHG stage when answering stage question', () => {
+      const session = createSession('feature');
+      processAnswer(session, '_ehg_stage', EHGStage.GROWTH);
+
+      expect(session.ehgStage).toBe(EHGStage.GROWTH);
+      expect(session.stageSignal).toBeDefined();
+      expect(session.stageSignal.stage).toBe(EHGStage.GROWTH);
+      expect(session.stageSignal.method).toBe('user_selection');
+    });
+
+    it('should store regular answers in answers object', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+
+      processAnswer(session, 'user_value', 'Better user experience');
+
+      expect(session.answers['user_value']).toBeDefined();
+      expect(session.answers['user_value'].answer).toBe('Better user experience');
+      expect(session.questionsAnswered).toBe(1);
+    });
+
+    it('should store success metric separately', () => {
+      const session = createSession('feature');
+      processAnswer(session, '_success_metric', '50% reduction in support tickets');
+
+      expect(session.explicitSuccessMetric).toBe('50% reduction in support tickets');
+    });
+  });
+
+  describe('STAGED_CHECKPOINT Pattern', () => {
+    it('should trigger checkpoint after minimum questions', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.questionsAnswered = MIN_QUESTIONS;
+
+      expect(shouldTriggerCheckpoint(session)).toBe(true);
+    });
+
+    it('should not trigger checkpoint before minimum questions', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.questionsAnswered = MIN_QUESTIONS - 1;
+
+      expect(shouldTriggerCheckpoint(session)).toBe(false);
+    });
+
+    it('should not trigger checkpoint if already completed', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.questionsAnswered = MIN_QUESTIONS;
+      session.intentSummary = 'Already set';
+
+      expect(shouldTriggerCheckpoint(session)).toBe(false);
+    });
+
+    it('should generate intent summary within max length', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.answers = {
+        question1: { answer: 'Answer 1' },
+        question2: { answer: 'Answer 2' },
+        question3: { answer: 'Answer 3' }
+      };
+
+      const summary = generateIntentSummary(session);
+
+      expect(summary.length).toBeLessThanOrEqual(MAX_INTENT_SUMMARY_LENGTH);
+      expect(summary.toLowerCase()).toContain('mvp');
+    });
+
+    it('should truncate long summaries', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.initialContext = 'A'.repeat(600); // Very long context
+
+      const summary = generateIntentSummary(session);
+
+      expect(summary.length).toBeLessThanOrEqual(MAX_INTENT_SUMMARY_LENGTH);
+      expect(summary.endsWith('...')).toBe(true);
+    });
+
+    it('should transition to UN_DONE_PROPOSAL state after checkpoint', () => {
+      const session = createSession('feature');
+      session.state = Phase0State.DISCOVERY_QUESTIONS;
+
+      setIntentSummary(session, 'Test intent summary');
+
+      expect(session.state).toBe(Phase0State.UN_DONE_PROPOSAL);
+      expect(session.intentSummary).toBe('Test intent summary');
+    });
+  });
+
+  describe('UN_DONE_PROPOSAL Pattern', () => {
+    it('should trigger after checkpoint with no out-of-scope items', () => {
+      const session = createSession('feature');
+      session.state = Phase0State.UN_DONE_PROPOSAL;
+      session.intentSummary = 'Test summary';
+      session.outOfScope = [];
+
+      expect(shouldTriggerUnDoneProposal(session)).toBe(true);
+    });
+
+    it('should not trigger before checkpoint', () => {
+      const session = createSession('feature');
+      session.state = Phase0State.DISCOVERY_QUESTIONS;
+
+      expect(shouldTriggerUnDoneProposal(session)).toBe(false);
+    });
+
+    it('should generate at least MIN_OUT_OF_SCOPE_ITEMS suggestions', () => {
+      const session = createSession('feature');
+      const suggestions = generateOutOfScopeSuggestions(session);
+
+      expect(suggestions.length).toBeGreaterThanOrEqual(MIN_OUT_OF_SCOPE_ITEMS);
+    });
+
+    it('should calculate score after setting out-of-scope', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.questionsAnswered = MIN_QUESTIONS;
+      session.intentSummary = 'Test summary';
+      session.stageSignal = { stage: EHGStage.MVP };
+      session.explicitSuccessMetric = 'Test metric';
+
+      setOutOfScope(session, ['Item 1', 'Item 2', 'Item 3']);
+
+      expect(session.crystallizationScore).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Crystallization Score', () => {
+    it('should score 0 for empty session', () => {
+      const session = createSession('feature');
+      const score = calculateCrystallizationScore(session);
+
+      expect(score).toBe(0);
+    });
+
+    it('should add 0.2 for meeting minimum questions', () => {
+      const session = createSession('feature');
+      session.questionsAnswered = MIN_QUESTIONS;
+
+      const score = calculateCrystallizationScore(session);
+
+      expect(score).toBeGreaterThanOrEqual(0.2);
+    });
+
+    it('should add 0.2 for intent summary', () => {
+      const session = createSession('feature');
+      session.intentSummary = 'Test summary';
+
+      const score = calculateCrystallizationScore(session);
+
+      expect(score).toBeGreaterThanOrEqual(0.2);
+    });
+
+    it('should add 0.2 for sufficient out-of-scope items', () => {
+      const session = createSession('feature');
+      session.outOfScope = ['Item 1', 'Item 2', 'Item 3'];
+
+      const score = calculateCrystallizationScore(session);
+
+      expect(score).toBeGreaterThanOrEqual(0.2);
+    });
+
+    it('should add 0.2 for EHG stage signal', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.stageSignal = { stage: EHGStage.MVP };
+
+      const score = calculateCrystallizationScore(session);
+
+      expect(score).toBeGreaterThanOrEqual(0.2);
+    });
+
+    it('should add 0.2 for explicit success metric', () => {
+      const session = createSession('feature');
+      session.explicitSuccessMetric = 'Reduce errors by 50%';
+
+      const score = calculateCrystallizationScore(session);
+
+      expect(score).toBeGreaterThanOrEqual(0.2);
+    });
+
+    it('should reach 1.0 with all criteria met', () => {
+      const session = createSession('feature');
+      session.questionsAnswered = MIN_QUESTIONS;
+      session.intentSummary = 'Test summary';
+      session.outOfScope = ['Item 1', 'Item 2', 'Item 3'];
+      session.ehgStage = EHGStage.MVP;
+      session.stageSignal = { stage: EHGStage.MVP };
+      session.explicitSuccessMetric = 'Test metric';
+
+      const score = calculateCrystallizationScore(session);
+
+      expect(score).toBe(1.0);
+    });
+
+    it('should not exceed 1.0', () => {
+      const session = createSession('feature');
+      session.questionsAnswered = 10; // More than minimum
+      session.intentSummary = 'Test summary';
+      session.outOfScope = ['Item 1', 'Item 2', 'Item 3', 'Item 4', 'Item 5']; // More than minimum
+      session.ehgStage = EHGStage.MVP;
+      session.stageSignal = { stage: EHGStage.MVP };
+      session.explicitSuccessMetric = 'Test metric';
+
+      const score = calculateCrystallizationScore(session);
+
+      expect(score).toBeLessThanOrEqual(1.0);
+    });
+  });
+
+  describe('Completion Validation', () => {
+    it('should pass for bypassed sessions', () => {
+      const session = createSession('fix');
+      const validation = validateCompletion(session);
+
+      expect(validation.valid).toBe(true);
+      expect(validation.message).toContain('bypassed');
+    });
+
+    it('should fail for incomplete sessions', () => {
+      const session = createSession('feature');
+      const validation = validateCompletion(session);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.issues.length).toBeGreaterThan(0);
+    });
+
+    it('should pass for fully completed sessions', () => {
+      const session = createSession('feature');
+      session.questionsAnswered = MIN_QUESTIONS;
+      session.intentSummary = 'Test summary';
+      session.outOfScope = ['Item 1', 'Item 2', 'Item 3'];
+      session.ehgStage = EHGStage.MVP;
+      session.stageSignal = { stage: EHGStage.MVP };
+      session.explicitSuccessMetric = 'Test metric';
+      session.crystallizationScore = calculateCrystallizationScore(session);
+
+      const validation = validateCompletion(session);
+
+      expect(validation.valid).toBe(true);
+      expect(validation.score).toBeGreaterThanOrEqual(CRYSTALLIZATION_THRESHOLD);
+    });
+
+    it('should list specific issues for incomplete sessions', () => {
+      const session = createSession('feature');
+      session.questionsAnswered = 1; // Below minimum
+      session.intentSummary = null; // No summary
+      session.outOfScope = []; // No out-of-scope
+
+      const validation = validateCompletion(session);
+
+      expect(validation.issues).toContain(`Minimum questions not met: 1/${MIN_QUESTIONS}`);
+      expect(validation.issues).toContain('STAGED_CHECKPOINT not completed: no intent_summary');
+      expect(validation.issues).toContain(`UN_DONE_PROPOSAL not satisfied: 0/${MIN_OUT_OF_SCOPE_ITEMS} out-of-scope items`);
+    });
+  });
+
+  describe('Session Completion States', () => {
+    it('should be complete when state is COMPLETED', () => {
+      const session = createSession('feature');
+      session.state = Phase0State.COMPLETED;
+
+      expect(isComplete(session)).toBe(true);
+    });
+
+    it('should be complete when state is BYPASSED', () => {
+      const session = createSession('fix');
+
+      expect(isComplete(session)).toBe(true);
+    });
+
+    it('should not be complete during discovery', () => {
+      const session = createSession('feature');
+
+      expect(isComplete(session)).toBe(false);
+    });
+  });
+
+  describe('Artifacts Export', () => {
+    it('should export all required artifacts', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.questionsAsked = 4;
+      session.questionsAnswered = 3;
+      session.intentSummary = 'Test summary';
+      session.outOfScope = ['Item 1', 'Item 2', 'Item 3'];
+      session.explicitSuccessMetric = 'Test metric';
+      session.crystallizationScore = 0.8;
+      session.state = Phase0State.COMPLETED;
+      session.completedAt = new Date().toISOString();
+
+      const artifacts = getArtifacts(session);
+
+      expect(artifacts.phase_0_completed).toBe(true);
+      expect(artifacts.phase_0_bypassed).toBe(false);
+      expect(artifacts.intent_summary).toBe('Test summary');
+      expect(artifacts.out_of_scope).toHaveLength(3);
+      expect(artifacts.ehg_stage).toBe(EHGStage.MVP);
+      expect(artifacts.crystallization_score).toBe(0.8);
+      expect(artifacts.explicit_success_metric).toBe('Test metric');
+      expect(artifacts.questions_asked).toBe(4);
+      expect(artifacts.questions_answered).toBe(3);
+    });
+
+    it('should indicate bypassed status for non-required types', () => {
+      const session = createSession('fix');
+      const artifacts = getArtifacts(session);
+
+      expect(artifacts.phase_0_completed).toBe(true);
+      expect(artifacts.phase_0_bypassed).toBe(true);
+    });
+  });
+
+  describe('State Persistence', () => {
+    it('should save and load session', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+      session.questionsAnswered = 2;
+
+      saveSession(session);
+      const loaded = loadSession();
+
+      expect(loaded).toBeDefined();
+      expect(loaded.sdType).toBe('feature');
+      expect(loaded.ehgStage).toBe(EHGStage.MVP);
+      expect(loaded.questionsAnswered).toBe(2);
+    });
+
+    it('should return null for non-existent session', () => {
+      clearSession();
+      const loaded = loadSession();
+
+      expect(loaded).toBeNull();
+    });
+
+    it('should clear session', () => {
+      const session = createSession('feature');
+      saveSession(session);
+
+      clearSession();
+      const loaded = loadSession();
+
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe('EHG Stage-Aware Signals', () => {
+    it('should have questions for all EHG stages', () => {
+      const stages = Object.values(EHGStage);
+
+      for (const stage of stages) {
+        const session = createSession('feature');
+        session.ehgStage = stage;
+
+        const question = getNextQuestion(session);
+
+        expect(question).toBeDefined();
+        expect(question.type).toBe('open_ended');
+      }
+    });
+
+    it('should capture stage signal on selection', () => {
+      const session = createSession('feature');
+      processAnswer(session, '_ehg_stage', EHGStage.VALIDATION);
+
+      expect(session.stageSignal).toBeDefined();
+      expect(session.stageSignal.stage).toBe(EHGStage.VALIDATION);
+      expect(session.stageSignal.detectedAt).toBeDefined();
+    });
+
+    it('should have different questions for different stages', () => {
+      const mvpSession = createSession('feature');
+      mvpSession.ehgStage = EHGStage.MVP;
+      const mvpQuestion = getNextQuestion(mvpSession);
+
+      const growthSession = createSession('feature');
+      growthSession.ehgStage = EHGStage.GROWTH;
+      const growthQuestion = getNextQuestion(growthSession);
+
+      // Different stages should have different first questions
+      expect(mvpQuestion.id).not.toBe(growthQuestion.id);
+    });
+  });
+
+  describe('One-Question-At-A-Time Compliance', () => {
+    it('should return only one question at a time', () => {
+      const session = createSession('feature');
+
+      // First question should be stage selection
+      const q1 = getNextQuestion(session);
+      expect(q1).toBeDefined();
+
+      // Process stage answer
+      processAnswer(session, '_ehg_stage', EHGStage.MVP);
+
+      // Next question should be a single question
+      const q2 = getNextQuestion(session);
+      expect(q2).toBeDefined();
+
+      // Both should be single objects, not arrays
+      expect(Array.isArray(q1)).toBe(false);
+      expect(Array.isArray(q2)).toBe(false);
+    });
+
+    it('should track question history', () => {
+      const session = createSession('feature');
+      session.ehgStage = EHGStage.MVP;
+
+      getNextQuestion(session);
+
+      expect(session.questionHistory.length).toBe(1);
+      expect(session.questionHistory[0].questionId).toBeDefined();
+      expect(session.questionHistory[0].askedAt).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements SD-LEO-INFRA-PHASE-INTENT-DISCOVERY-001 - Phase 0 Intent Discovery Engine with Obra Brainstorming Patterns.

### Changes
- **Core engine** (`scripts/modules/phase-0/engine.js`): State machine, scoring logic, session management
- **LEO integration** (`scripts/modules/phase-0/leo-integration.js`): Hooks for `/leo create` workflow
- **Module exports** (`scripts/modules/phase-0/index.js`): Clean API surface

### Features
- One-question-at-a-time mandate (maxQuestionsPerMessage=1)
- STAGED_CHECKPOINT pattern for intent summary (≤500 chars)
- UN_DONE_PROPOSAL pattern for out-of-scope items (≥3 items)
- Crystallization score calculation (threshold: 0.7)
- EHG stage-aware discovery signals (Ideation → Scale)
- SD type gating (feature/enhancement types only)

### Tests
- 51 unit tests covering all requirements
- All tests passing

## Test plan
- [x] All 51 unit tests pass
- [x] Smoke tests pass
- [x] Gate 0 validation passed
- [x] DOCMON compliance check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)