### PR TITLE
feat(SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-A): add PLAN agent style tagger and venture_personality migration

### DIFF
--- a/database/migrations/20260130_add_venture_personality.sql
+++ b/database/migrations/20260130_add_venture_personality.sql
@@ -1,0 +1,38 @@
+-- Migration: Add venture_personality to strategic_directives_v2
+-- SD: SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-A
+-- Purpose: Support aesthetic-driven design system by storing venture personality
+-- values that map to style vocabulary aesthetics.
+
+-- Add venture_personality column
+-- Valid values: 12 aesthetics + 2 special values (neutral, mixed)
+ALTER TABLE strategic_directives_v2
+ADD COLUMN IF NOT EXISTS venture_personality VARCHAR(50) DEFAULT 'neutral'
+CHECK (venture_personality IN (
+  'spartan',
+  'enterprise',
+  'startup',
+  'dashboard',
+  'consumer',
+  'executive',
+  'technical',
+  'marketing',
+  'minimal',
+  'glass',
+  'dark-mode-first',
+  'accessible',
+  'neutral',
+  'mixed'
+));
+
+-- Create index for efficient filtering by personality
+CREATE INDEX IF NOT EXISTS idx_strategic_directives_v2_venture_personality
+ON strategic_directives_v2(venture_personality);
+
+-- Add comment explaining the column
+COMMENT ON COLUMN strategic_directives_v2.venture_personality IS
+'Maps to EHG style vocabulary aesthetics. Determines design constraints, token preferences, and typography for SD-related UI. See lib/design/venture-personality-mapping.js';
+
+-- Update existing SDs to have default value (idempotent)
+UPDATE strategic_directives_v2
+SET venture_personality = 'neutral'
+WHERE venture_personality IS NULL;

--- a/lib/agents/plan/index.js
+++ b/lib/agents/plan/index.js
@@ -1,0 +1,9 @@
+/**
+ * PLAN Agent Module Index
+ * Exports all PLAN phase agent capabilities.
+ *
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-A
+ */
+
+export * from './styleTagger.js';
+export { default as styleTagger } from './styleTagger.js';

--- a/lib/agents/plan/styleTagger.js
+++ b/lib/agents/plan/styleTagger.js
@@ -1,0 +1,287 @@
+/**
+ * PLAN Agent Style Tagger
+ * Suggests venture_personality based on SD characteristics during PRD elaboration.
+ *
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-A
+ */
+
+/**
+ * Valid personality values (must match venture-personality-mapping.js)
+ */
+export const VALID_PERSONALITIES = [
+  'spartan',
+  'enterprise',
+  'startup',
+  'dashboard',
+  'consumer',
+  'executive',
+  'technical',
+  'marketing',
+  'minimal',
+  'glass',
+  'dark-mode-first',
+  'accessible',
+  'neutral',
+  'mixed'
+];
+
+/**
+ * Personality descriptions for reasoning
+ */
+export const PERSONALITY_DESCRIPTIONS = {
+  spartan: 'Minimal, functional, maximum information density',
+  enterprise: 'Professional, trustworthy, B2B suitable',
+  startup: 'Modern, bold, energetic tech aesthetic',
+  dashboard: 'Data-rich, analytical, decision-focused',
+  consumer: 'Friendly, approachable, B2C suitable',
+  executive: 'Premium, sophisticated, C-suite appropriate',
+  technical: 'Developer-focused, precise, documentation-ready',
+  marketing: 'Attention-grabbing, conversion-optimized',
+  minimal: 'Clean, focused, intentional simplicity',
+  glass: 'Modern glassmorphism with translucency',
+  'dark-mode-first': 'Dark mode primary, light mode secondary',
+  accessible: 'WCAG AAA compliant, inclusive design',
+  neutral: 'Default, no specific personality applied',
+  mixed: 'Combines multiple personalities contextually'
+};
+
+/**
+ * Keyword mappings for style inference
+ */
+const STYLE_KEYWORDS = {
+  spartan: ['minimal', 'simple', 'clean', 'no-frills', 'functional', 'utilitarian', 'bare-bones'],
+  enterprise: ['enterprise', 'corporate', 'b2b', 'business', 'professional', 'formal', 'compliant'],
+  startup: ['startup', 'modern', 'innovative', 'dynamic', 'agile', 'disruptive', 'cutting-edge'],
+  dashboard: ['dashboard', 'analytics', 'metrics', 'kpi', 'monitoring', 'data', 'reporting', 'charts'],
+  consumer: ['consumer', 'b2c', 'retail', 'user-friendly', 'casual', 'lifestyle', 'social'],
+  executive: ['executive', 'c-suite', 'premium', 'luxury', 'high-end', 'vip', 'board'],
+  technical: ['technical', 'developer', 'api', 'documentation', 'code', 'engineering', 'devops'],
+  marketing: ['marketing', 'landing', 'conversion', 'campaign', 'promotion', 'sales', 'cta'],
+  minimal: ['minimal', 'zen', 'focused', 'distraction-free', 'calm', 'simple'],
+  glass: ['glass', 'glassmorphism', 'blur', 'translucent', 'modern', 'frosted'],
+  'dark-mode-first': ['dark', 'night', 'low-light', 'dark-mode', 'developer', 'coding'],
+  accessible: ['accessible', 'a11y', 'wcag', 'inclusive', 'disability', 'screen-reader', 'contrast']
+};
+
+/**
+ * SD type to personality mapping defaults
+ */
+const SD_TYPE_DEFAULTS = {
+  feature: 'neutral',
+  bugfix: 'neutral',
+  refactor: 'technical',
+  infrastructure: 'technical',
+  documentation: 'technical',
+  security: 'enterprise',
+  performance: 'dashboard',
+  research: 'minimal',
+  orchestrator: 'neutral',
+  integration: 'enterprise'
+};
+
+/**
+ * Category to personality mapping defaults
+ */
+const CATEGORY_DEFAULTS = {
+  'quality': 'dashboard',
+  'venture-management': 'executive',
+  'infrastructure': 'technical',
+  'feature': 'consumer',
+  'security': 'enterprise',
+  'compliance': 'enterprise',
+  'analytics': 'dashboard',
+  'developer-experience': 'technical'
+};
+
+/**
+ * Analyze text for personality keywords
+ * @param {string} text - Text to analyze
+ * @returns {Object} Keyword matches per personality
+ */
+function analyzeKeywords(text) {
+  const lowerText = (text || '').toLowerCase();
+  const matches = {};
+
+  for (const [personality, keywords] of Object.entries(STYLE_KEYWORDS)) {
+    matches[personality] = keywords.filter(kw => lowerText.includes(kw)).length;
+  }
+
+  return matches;
+}
+
+/**
+ * Suggest venture personality based on SD characteristics
+ * @param {Object} sd - Strategic directive object
+ * @param {string} sd.title - SD title
+ * @param {string} sd.description - SD description
+ * @param {string} sd.sd_type - SD type (feature, bugfix, etc.)
+ * @param {string} sd.category - SD category
+ * @param {string} [sd.scope] - SD scope text
+ * @param {Object} [sd.prd] - PRD content if available
+ * @returns {Object} Suggestion with personality, confidence, and reasoning
+ */
+export function suggestPersonality(sd) {
+  const suggestions = [];
+  let totalWeight = 0;
+
+  // Analyze title and description
+  const textToAnalyze = [
+    sd.title || '',
+    sd.description || '',
+    sd.scope || '',
+    sd.prd?.overview || ''
+  ].join(' ');
+
+  const keywordMatches = analyzeKeywords(textToAnalyze);
+
+  // Score based on keyword matches
+  for (const [personality, matchCount] of Object.entries(keywordMatches)) {
+    if (matchCount > 0) {
+      suggestions.push({
+        personality,
+        weight: matchCount * 3,
+        source: 'keyword_match',
+        detail: `${matchCount} keyword match(es)`
+      });
+      totalWeight += matchCount * 3;
+    }
+  }
+
+  // Factor in SD type default
+  if (sd.sd_type && SD_TYPE_DEFAULTS[sd.sd_type]) {
+    const typeDefault = SD_TYPE_DEFAULTS[sd.sd_type];
+    suggestions.push({
+      personality: typeDefault,
+      weight: 2,
+      source: 'sd_type',
+      detail: `SD type "${sd.sd_type}" defaults to ${typeDefault}`
+    });
+    totalWeight += 2;
+  }
+
+  // Factor in category default
+  if (sd.category && CATEGORY_DEFAULTS[sd.category]) {
+    const catDefault = CATEGORY_DEFAULTS[sd.category];
+    suggestions.push({
+      personality: catDefault,
+      weight: 2,
+      source: 'category',
+      detail: `Category "${sd.category}" defaults to ${catDefault}`
+    });
+    totalWeight += 2;
+  }
+
+  // Aggregate scores
+  const scores = {};
+  for (const suggestion of suggestions) {
+    if (!scores[suggestion.personality]) {
+      scores[suggestion.personality] = { weight: 0, sources: [] };
+    }
+    scores[suggestion.personality].weight += suggestion.weight;
+    scores[suggestion.personality].sources.push(suggestion);
+  }
+
+  // Find winner
+  let topPersonality = 'neutral';
+  let topWeight = 0;
+  let topSources = [];
+
+  for (const [personality, data] of Object.entries(scores)) {
+    if (data.weight > topWeight) {
+      topWeight = data.weight;
+      topPersonality = personality;
+      topSources = data.sources;
+    }
+  }
+
+  // Calculate confidence (0-1 scale)
+  const confidence = totalWeight > 0 ? Math.min(topWeight / (totalWeight * 0.6), 1) : 0.1;
+
+  // Build reasoning
+  const reasoning = topSources.map(s => `• ${s.source}: ${s.detail}`).join('\n');
+
+  return {
+    personality: topPersonality,
+    confidence: Math.round(confidence * 100) / 100,
+    description: PERSONALITY_DESCRIPTIONS[topPersonality],
+    reasoning: reasoning || '• No strong signals found, defaulting to neutral',
+    alternatives: Object.entries(scores)
+      .filter(([p]) => p !== topPersonality)
+      .sort((a, b) => b[1].weight - a[1].weight)
+      .slice(0, 2)
+      .map(([p, data]) => ({
+        personality: p,
+        weight: data.weight,
+        description: PERSONALITY_DESCRIPTIONS[p]
+      }))
+  };
+}
+
+/**
+ * Validate a personality value
+ * @param {string} personality - Personality to validate
+ * @returns {boolean} True if valid
+ */
+export function isValidPersonality(personality) {
+  return VALID_PERSONALITIES.includes(personality);
+}
+
+/**
+ * Get all valid personality options with descriptions
+ * @returns {Array} Array of {value, label, description}
+ */
+export function getPersonalityOptions() {
+  return VALID_PERSONALITIES.map(p => ({
+    value: p,
+    label: p.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+    description: PERSONALITY_DESCRIPTIONS[p]
+  }));
+}
+
+/**
+ * Apply style tag to SD (database update helper)
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdId - SD ID
+ * @param {string} personality - Personality value
+ * @returns {Object} Update result
+ */
+export async function applyStyleTag(supabase, sdId, personality) {
+  if (!isValidPersonality(personality)) {
+    return {
+      success: false,
+      error: `Invalid personality value: ${personality}. Valid values: ${VALID_PERSONALITIES.join(', ')}`
+    };
+  }
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .update({
+      venture_personality: personality,
+      updated_at: new Date().toISOString()
+    })
+    .eq('id', sdId)
+    .select('id, title, venture_personality')
+    .single();
+
+  if (error) {
+    return {
+      success: false,
+      error: error.message
+    };
+  }
+
+  return {
+    success: true,
+    data,
+    message: `Applied style tag "${personality}" to SD ${sdId}`
+  };
+}
+
+export default {
+  suggestPersonality,
+  isValidPersonality,
+  getPersonalityOptions,
+  applyStyleTag,
+  VALID_PERSONALITIES,
+  PERSONALITY_DESCRIPTIONS
+};

--- a/lib/templates/prd-template.js
+++ b/lib/templates/prd-template.js
@@ -2,8 +2,11 @@
  * PRD Template Engine
  * Generates PRD data from SD metadata with configurable overrides.
  * Part of SD-REFACTOR-SCRIPTS-001: Script Framework Consolidation
+ * Extended with Design Vocabulary support: SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-A
  * @module lib/templates/prd-template
  */
+
+import { suggestPersonality, getPersonalityOptions } from '../agents/plan/styleTagger.js';
 
 export const PRD_TEMPLATE = {
   version: '1.0',
@@ -138,6 +141,126 @@ function generateImplementationApproach(sd) {
   return '## Implementation Approach\n\n### Development Strategy\n\n1. Set up development environment and branch\n2. Implement core functionality per user stories\n3. Add unit and integration tests\n4. Code review and documentation\n';
 }
 
+/**
+ * Generate Design Vocabulary section for PRD
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-A
+ */
+function generateDesignVocabulary(sd) {
+  // Get suggested personality
+  const suggestion = suggestPersonality(sd);
+
+  // Use existing venture_personality if set, otherwise use suggestion
+  const personality = sd.venture_personality || suggestion.personality;
+
+  return {
+    venture_personality: personality,
+    suggestion: {
+      recommended: suggestion.personality,
+      confidence: suggestion.confidence,
+      description: suggestion.description,
+      reasoning: suggestion.reasoning,
+      alternatives: suggestion.alternatives
+    },
+    style_constraints: generateStyleConstraints(personality),
+    available_options: getPersonalityOptions()
+  };
+}
+
+/**
+ * Generate style constraints based on personality
+ */
+function generateStyleConstraints(personality) {
+  // Map personality to general constraint categories
+  const constraintsByPersonality = {
+    spartan: {
+      layout: 'Maximum information density, minimal whitespace',
+      colors: 'Monochrome palette with single accent',
+      typography: 'Monospace preferred, minimal weight variation',
+      components: 'Sharp corners, minimal padding, no shadows'
+    },
+    enterprise: {
+      layout: 'Professional hierarchy, 60% whitespace ratio',
+      colors: 'Conservative palette, muted accents',
+      typography: 'Sans-serif, professional weights',
+      components: 'Medium rounded corners, subtle shadows'
+    },
+    startup: {
+      layout: 'Bold sections, gradient heroes',
+      colors: 'Vibrant, saturated palette',
+      typography: 'Bold headlines (700+), energetic',
+      components: 'Rounded corners, animated interactions'
+    },
+    dashboard: {
+      layout: 'Data-dense grids, tabular alignment',
+      colors: 'Chart color palette (chart-1 to chart-8)',
+      typography: 'Monospace for data, clear labels',
+      components: 'Compact padding, minimal decoration'
+    },
+    consumer: {
+      layout: 'Friendly, conversational spacing',
+      colors: 'Warm, inviting palette',
+      typography: 'Friendly sans-serif, readable',
+      components: 'Extra-rounded corners, playful hovers'
+    },
+    executive: {
+      layout: 'Premium, 70%+ whitespace, balanced',
+      colors: 'Restrained (2-3 colors max)',
+      typography: 'Elegant, proper kerning',
+      components: 'Subtle depth, refined shadows'
+    },
+    technical: {
+      layout: 'Documentation-ready, code-centric',
+      colors: 'Syntax highlighting compatible',
+      typography: 'Monospace for code, clear hierarchy',
+      components: 'Copy buttons, code blocks, precise'
+    },
+    marketing: {
+      layout: 'Conversion-focused, clear CTAs',
+      colors: 'High-contrast hero sections',
+      typography: 'Large bold headlines, persuasive',
+      components: 'Gradient CTAs, social proof visible'
+    },
+    minimal: {
+      layout: 'Single-column focus, generous spacing',
+      colors: '2 colors + neutrals maximum',
+      typography: 'Clean, high line-height (1.8+)',
+      components: 'No borders, no shadows, intentional'
+    },
+    glass: {
+      layout: 'Layered depth with blur effects',
+      colors: 'Semi-transparent surfaces',
+      typography: 'Contrast-aware for readability',
+      components: 'Backdrop-blur, soft rounded corners'
+    },
+    'dark-mode-first': {
+      layout: 'Dark surfaces as primary',
+      colors: 'Elevated dark surfaces, bright accents',
+      typography: 'Optimized for dark background contrast',
+      components: 'Visible focus indicators, WCAG AA dark'
+    },
+    accessible: {
+      layout: '44px minimum touch targets throughout',
+      colors: '7:1 contrast ratio for text',
+      typography: 'Large, readable, skip-link support',
+      components: 'Visible focus, keyboard navigable'
+    },
+    neutral: {
+      layout: 'Default system layout patterns',
+      colors: 'Default color scheme',
+      typography: 'Standard typography',
+      components: 'Default component styling'
+    },
+    mixed: {
+      layout: 'Context-dependent layout choices',
+      colors: 'Varies by component context',
+      typography: 'Adaptive typography',
+      components: 'Mixed styling based on needs'
+    }
+  };
+
+  return constraintsByPersonality[personality] || constraintsByPersonality.neutral;
+}
+
 export function generatePRD(sd, config = {}) {
   if (!sd || !sd.id) throw new Error('Valid SD with id required');
   return {
@@ -161,12 +284,14 @@ export function generatePRD(sd, config = {}) {
     implementation_approach: config.implementation_approach || generateImplementationApproach(sd),
     risks: config.risks || generateRisks(sd),
     exploration_summary: config.exploration_summary || [],
+    design_vocabulary: config.design_vocabulary || generateDesignVocabulary(sd),
     metadata: {
       generated_at: new Date().toISOString(),
-      generator_version: '1.0.0',
+      generator_version: '1.1.0',
       // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
       sd_key: sd.sd_key,
       sd_type: sd.sd_type,
+      venture_personality: sd.venture_personality || generateDesignVocabulary(sd).venture_personality,
       config_applied: Object.keys(config).length > 0
     }
   };

--- a/tests/unit/agents/plan/styleTagger.test.js
+++ b/tests/unit/agents/plan/styleTagger.test.js
@@ -1,0 +1,199 @@
+/**
+ * Style Tagger Unit Tests
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-A
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  suggestPersonality,
+  isValidPersonality,
+  getPersonalityOptions,
+  VALID_PERSONALITIES,
+  PERSONALITY_DESCRIPTIONS
+} from '../../../../lib/agents/plan/styleTagger.js';
+
+describe('Style Tagger', () => {
+  describe('suggestPersonality', () => {
+    it('should return a valid suggestion object', () => {
+      const sd = {
+        title: 'Test SD',
+        description: 'A test strategic directive'
+      };
+
+      const result = suggestPersonality(sd);
+
+      expect(result).toHaveProperty('personality');
+      expect(result).toHaveProperty('confidence');
+      expect(result).toHaveProperty('description');
+      expect(result).toHaveProperty('reasoning');
+      expect(result).toHaveProperty('alternatives');
+    });
+
+    it('should suggest dashboard for analytics-related SDs', () => {
+      const sd = {
+        title: 'Analytics Dashboard',
+        description: 'Build a KPI dashboard with metrics and reporting',
+        sd_type: 'feature',
+        category: 'analytics'
+      };
+
+      const result = suggestPersonality(sd);
+      expect(result.personality).toBe('dashboard');
+      expect(result.confidence).toBeGreaterThan(0.5);
+    });
+
+    it('should suggest technical for developer-focused SDs', () => {
+      const sd = {
+        title: 'API Documentation Generator',
+        description: 'Create developer documentation for the REST API',
+        sd_type: 'documentation'
+      };
+
+      const result = suggestPersonality(sd);
+      expect(result.personality).toBe('technical');
+    });
+
+    it('should suggest enterprise for B2B SDs', () => {
+      const sd = {
+        title: 'Enterprise Client Portal',
+        description: 'Professional B2B portal for corporate clients',
+        sd_type: 'feature',
+        category: 'feature'
+      };
+
+      const result = suggestPersonality(sd);
+      expect(result.personality).toBe('enterprise');
+    });
+
+    it('should suggest consumer for B2C SDs', () => {
+      const sd = {
+        title: 'User Profile Page',
+        description: 'Friendly consumer-facing profile management',
+        sd_type: 'feature'
+      };
+
+      const result = suggestPersonality(sd);
+      expect(result.personality).toBe('consumer');
+    });
+
+    it('should suggest accessible for a11y-focused SDs', () => {
+      const sd = {
+        title: 'WCAG Compliance Updates',
+        description: 'Implement accessible screen-reader support with proper contrast',
+        sd_type: 'feature'
+      };
+
+      const result = suggestPersonality(sd);
+      expect(result.personality).toBe('accessible');
+    });
+
+    it('should default to neutral when no clear signals', () => {
+      const sd = {
+        title: 'Generic Update',
+        description: 'Some updates',
+        sd_type: 'feature'
+      };
+
+      const result = suggestPersonality(sd);
+      expect(VALID_PERSONALITIES).toContain(result.personality);
+    });
+
+    it('should use sd_type defaults', () => {
+      const sd = {
+        title: 'Code Refactor',
+        description: 'Refactoring work',
+        sd_type: 'refactor'
+      };
+
+      const result = suggestPersonality(sd);
+      expect(result.personality).toBe('technical');
+    });
+
+    it('should provide alternatives in results', () => {
+      const sd = {
+        title: 'Executive Dashboard',
+        description: 'Premium analytics for C-suite with KPI monitoring',
+        sd_type: 'feature'
+      };
+
+      const result = suggestPersonality(sd);
+      expect(Array.isArray(result.alternatives)).toBe(true);
+    });
+  });
+
+  describe('isValidPersonality', () => {
+    it('should return true for all valid personalities', () => {
+      VALID_PERSONALITIES.forEach(p => {
+        expect(isValidPersonality(p)).toBe(true);
+      });
+    });
+
+    it('should return false for invalid personalities', () => {
+      expect(isValidPersonality('invalid')).toBe(false);
+      expect(isValidPersonality('')).toBe(false);
+      expect(isValidPersonality('SPARTAN')).toBe(false); // Case sensitive
+    });
+  });
+
+  describe('getPersonalityOptions', () => {
+    it('should return array of options', () => {
+      const options = getPersonalityOptions();
+
+      expect(Array.isArray(options)).toBe(true);
+      expect(options.length).toBe(VALID_PERSONALITIES.length);
+    });
+
+    it('should have value, label, and description for each option', () => {
+      const options = getPersonalityOptions();
+
+      options.forEach(opt => {
+        expect(opt).toHaveProperty('value');
+        expect(opt).toHaveProperty('label');
+        expect(opt).toHaveProperty('description');
+        expect(typeof opt.value).toBe('string');
+        expect(typeof opt.label).toBe('string');
+        expect(typeof opt.description).toBe('string');
+      });
+    });
+
+    it('should format labels with proper capitalization', () => {
+      const options = getPersonalityOptions();
+      const darkModeOption = options.find(o => o.value === 'dark-mode-first');
+
+      expect(darkModeOption.label).toBe('Dark Mode First');
+    });
+  });
+
+  describe('VALID_PERSONALITIES', () => {
+    it('should contain exactly 14 personalities', () => {
+      expect(VALID_PERSONALITIES.length).toBe(14);
+    });
+
+    it('should include all aesthetic-mapped personalities', () => {
+      const aesthetics = [
+        'spartan', 'enterprise', 'startup', 'dashboard', 'consumer',
+        'executive', 'technical', 'marketing', 'minimal', 'glass',
+        'dark-mode-first', 'accessible'
+      ];
+
+      aesthetics.forEach(a => {
+        expect(VALID_PERSONALITIES).toContain(a);
+      });
+    });
+
+    it('should include special values neutral and mixed', () => {
+      expect(VALID_PERSONALITIES).toContain('neutral');
+      expect(VALID_PERSONALITIES).toContain('mixed');
+    });
+  });
+
+  describe('PERSONALITY_DESCRIPTIONS', () => {
+    it('should have descriptions for all valid personalities', () => {
+      VALID_PERSONALITIES.forEach(p => {
+        expect(PERSONALITY_DESCRIPTIONS[p]).toBeDefined();
+        expect(typeof PERSONALITY_DESCRIPTIONS[p]).toBe('string');
+        expect(PERSONALITY_DESCRIPTIONS[p].length).toBeGreaterThan(10);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add database migration for `venture_personality` column on `strategic_directives_v2` table
- Create PLAN agent style tagger (`lib/agents/plan/styleTagger.js`) for suggesting aesthetics during PRD elaboration
- Extend PRD template with `design_vocabulary` section containing style constraints
- Add comprehensive unit tests (18 tests passing)

## Test plan
- [x] Run styleTagger unit tests - 18 tests passing
- [ ] Execute database migration to add venture_personality column
- [x] Verify PRD template generates design_vocabulary section

🤖 Generated with [Claude Code](https://claude.com/claude-code)