### PR TITLE
feat(design): add dual-mode auditing to Visual Polish Gate

### DIFF
--- a/lib/agents/design-sub-agent/visual-polish-gate.js
+++ b/lib/agents/design-sub-agent/visual-polish-gate.js
@@ -1,6 +1,7 @@
 /**
- * Visual Polish Gate with AI Slop Detection
+ * Visual Polish Gate with AI Slop Detection and Dual-Mode Auditing
  * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-C
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D
  *
  * Detects AI-generated design anti-patterns ("AI Slop") and enforces
  * visual polish standards with stage-based enforcement:
@@ -12,9 +13,34 @@
  * - Hierarchy: Visual weight distribution
  * - Clarity: Information architecture
  * - Emotional Resonance: Brand alignment
+ *
+ * Child D Enhancement: Dual-Mode (Light/Dark) Auditing
+ * - Sequential Light and Dark mode audits
+ * - Class-based and media-query theme detection
+ * - Multi-viewport screenshot capture
+ * - WCAG AA contrast validation per mode
  */
 
 import { SEVERITY } from './constants.js';
+
+/**
+ * Viewport configurations for multi-device screenshot capture
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D
+ */
+export const VIEWPORTS = {
+  desktop: { width: 1920, height: 1080, name: 'desktop' },
+  tablet: { width: 768, height: 1024, name: 'tablet' },
+  mobile: { width: 375, height: 667, name: 'mobile' }
+};
+
+/**
+ * Theme detection methods
+ */
+export const THEME_METHODS = {
+  CLASS_BASED: 'class-based',
+  MEDIA_QUERY: 'media-query',
+  UNKNOWN: 'unknown'
+};
 
 /**
  * AI Slop Anti-Patterns (Hard-Coded)
@@ -612,15 +638,528 @@ export function formatGateResult(result) {
   return lines.join('\n');
 }
 
+/**
+ * Detect which theme toggle method the page supports
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D (US-002)
+ * @param {Object} page - Playwright page object
+ * @returns {Promise<string>} Theme method: 'class-based', 'media-query', or 'unknown'
+ */
+export async function detectThemeMethod(page) {
+  try {
+    // Check for class-based theming (.dark class support)
+    const hasClassBasedSupport = await page.evaluate(() => {
+      const html = document.documentElement;
+      const body = document.body;
+      // Check if dark class exists or if toggling it changes styles
+      const hasDarkClass = html.classList.contains('dark') || body.classList.contains('dark');
+      // Check for Tailwind/shadcn dark mode CSS variables
+      const style = getComputedStyle(document.documentElement);
+      const hasDarkVars = style.getPropertyValue('--background') !== '';
+      return hasDarkClass || hasDarkVars;
+    });
+
+    if (hasClassBasedSupport) {
+      return THEME_METHODS.CLASS_BASED;
+    }
+
+    // Check for media query support by testing if styles change with color-scheme
+    const hasMediaQuerySupport = await page.evaluate(() => {
+      // Check if any stylesheets use prefers-color-scheme
+      const sheets = Array.from(document.styleSheets);
+      for (const sheet of sheets) {
+        try {
+          const rules = Array.from(sheet.cssRules || []);
+          for (const rule of rules) {
+            if (rule.media && rule.media.mediaText.includes('prefers-color-scheme')) {
+              return true;
+            }
+          }
+        } catch (e) {
+          // Cross-origin stylesheets may throw
+        }
+      }
+      return false;
+    });
+
+    if (hasMediaQuerySupport) {
+      return THEME_METHODS.MEDIA_QUERY;
+    }
+
+    return THEME_METHODS.UNKNOWN;
+  } catch (error) {
+    console.warn('Theme detection failed:', error.message);
+    return THEME_METHODS.UNKNOWN;
+  }
+}
+
+/**
+ * Toggle page theme to specified mode
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D (US-002)
+ * @param {Object} page - Playwright page object
+ * @param {string} mode - 'light' or 'dark'
+ * @param {string} method - Theme method to use (auto-detected if not provided)
+ * @returns {Promise<Object>} Toggle result with method used
+ */
+export async function toggleTheme(page, mode, method = null) {
+  const detectedMethod = method || await detectThemeMethod(page);
+  const result = {
+    mode,
+    themeMethod: detectedMethod,
+    success: false,
+    error: null
+  };
+
+  try {
+    if (detectedMethod === THEME_METHODS.CLASS_BASED) {
+      // Class-based theming: toggle .dark class on html element
+      await page.evaluate((targetMode) => {
+        const html = document.documentElement;
+        if (targetMode === 'dark') {
+          html.classList.add('dark');
+          html.classList.remove('light');
+        } else {
+          html.classList.remove('dark');
+          html.classList.add('light');
+        }
+      }, mode);
+      result.success = true;
+    } else if (detectedMethod === THEME_METHODS.MEDIA_QUERY) {
+      // Media query theming: use Playwright emulateMedia
+      await page.emulateMedia({ colorScheme: mode });
+      result.success = true;
+    } else {
+      // Unknown method: try both approaches
+      await page.evaluate((targetMode) => {
+        const html = document.documentElement;
+        if (targetMode === 'dark') {
+          html.classList.add('dark');
+        } else {
+          html.classList.remove('dark');
+        }
+      }, mode);
+      await page.emulateMedia({ colorScheme: mode });
+      result.success = true;
+      result.themeMethod = 'hybrid';
+    }
+
+    // Wait for theme transition to complete
+    await page.waitForTimeout(300);
+  } catch (error) {
+    result.error = error.message;
+  }
+
+  return result;
+}
+
+/**
+ * Capture dual-mode screenshots for all configured viewports
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D (US-003)
+ * @param {Object} page - Playwright page object
+ * @param {string} outputDir - Output directory for screenshots
+ * @param {Object} viewports - Viewport configurations (defaults to VIEWPORTS)
+ * @returns {Promise<Object>} Screenshot paths per viewport and mode
+ */
+export async function captureDualModeScreenshots(page, outputDir = './visual-polish-reports/screenshots', viewports = VIEWPORTS) {
+  const screenshots = {};
+
+  for (const [viewportKey, viewport] of Object.entries(viewports)) {
+    screenshots[viewportKey] = { light: null, dark: null };
+
+    // Set viewport size
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+
+    // Capture Light mode
+    await toggleTheme(page, 'light');
+    const lightPath = `${outputDir}/${viewport.name}-light.png`;
+    try {
+      await page.screenshot({ path: lightPath, fullPage: false });
+      screenshots[viewportKey].light = `screenshots/${viewport.name}-light.png`;
+    } catch (error) {
+      console.warn(`Failed to capture ${viewport.name}-light:`, error.message);
+    }
+
+    // Capture Dark mode
+    await toggleTheme(page, 'dark');
+    const darkPath = `${outputDir}/${viewport.name}-dark.png`;
+    try {
+      await page.screenshot({ path: darkPath, fullPage: false });
+      screenshots[viewportKey].dark = `screenshots/${viewport.name}-dark.png`;
+    } catch (error) {
+      console.warn(`Failed to capture ${viewport.name}-dark:`, error.message);
+    }
+  }
+
+  return screenshots;
+}
+
+/**
+ * Validate WCAG AA contrast in specified theme mode
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D (US-004)
+ * @param {Object} page - Playwright page object
+ * @param {string} mode - 'light' or 'dark'
+ * @returns {Promise<Object>} Contrast validation results
+ */
+export async function validateContrastInMode(page, mode) {
+  const result = {
+    mode,
+    violations: [],
+    passed: 0,
+    total: 0
+  };
+
+  try {
+    // Toggle to specified mode first
+    await toggleTheme(page, mode);
+
+    // Get all text elements and their computed colors
+    const elements = await page.evaluate(() => {
+      const textElements = [];
+      const walker = document.createTreeWalker(
+        document.body,
+        NodeFilter.SHOW_TEXT,
+        null
+      );
+
+      let node;
+      while ((node = walker.nextNode())) {
+        const parent = node.parentElement;
+        if (!parent || !node.textContent.trim()) continue;
+
+        const style = getComputedStyle(parent);
+        const fontSize = parseFloat(style.fontSize);
+        const fontWeight = parseInt(style.fontWeight) || 400;
+        const isLargeText = fontSize >= 24 || (fontSize >= 18.66 && fontWeight >= 700);
+
+        // Get foreground color
+        const fgColor = style.color;
+
+        // Get background color (traverse up to find non-transparent)
+        let bgColor = 'rgb(255, 255, 255)';
+        let el = parent;
+        while (el) {
+          const bg = getComputedStyle(el).backgroundColor;
+          if (bg && bg !== 'rgba(0, 0, 0, 0)' && bg !== 'transparent') {
+            bgColor = bg;
+            break;
+          }
+          el = el.parentElement;
+        }
+
+        textElements.push({
+          selector: parent.tagName.toLowerCase() +
+            (parent.id ? '#' + parent.id : '') +
+            (parent.className ? '.' + parent.className.split(' ')[0] : ''),
+          foreground: fgColor,
+          background: bgColor,
+          isLargeText,
+          fontSize
+        });
+      }
+
+      // Sample up to 200 elements to avoid performance issues
+      return textElements.slice(0, 200);
+    });
+
+    result.total = elements.length;
+
+    // Calculate contrast ratios
+    for (const el of elements) {
+      const fgRgb = parseRgb(el.foreground);
+      const bgRgb = parseRgb(el.background);
+
+      if (!fgRgb || !bgRgb) continue;
+
+      const ratio = calculateContrastRatio(fgRgb, bgRgb);
+      const requiredRatio = el.isLargeText ? 3.0 : 4.5;
+
+      if (ratio < requiredRatio) {
+        result.violations.push({
+          selector: el.selector,
+          actualRatio: Math.round(ratio * 100) / 100,
+          requiredRatio,
+          foreground: el.foreground,
+          background: el.background,
+          mode,
+          isLargeText: el.isLargeText
+        });
+      } else {
+        result.passed++;
+      }
+    }
+  } catch (error) {
+    result.error = error.message;
+  }
+
+  return result;
+}
+
+/**
+ * Parse RGB color string to {r, g, b} object
+ * @param {string} color - CSS color string (rgb or rgba format)
+ * @returns {Object|null} RGB values or null if parse fails
+ */
+function parseRgb(color) {
+  const match = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+  if (!match) return null;
+  return {
+    r: parseInt(match[1]),
+    g: parseInt(match[2]),
+    b: parseInt(match[3])
+  };
+}
+
+/**
+ * Calculate relative luminance per WCAG 2.1
+ * @param {Object} rgb - RGB color object
+ * @returns {number} Relative luminance
+ */
+function calculateLuminance(rgb) {
+  const [r, g, b] = [rgb.r, rgb.g, rgb.b].map(c => {
+    const sRGB = c / 255;
+    return sRGB <= 0.03928 ? sRGB / 12.92 : Math.pow((sRGB + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/**
+ * Calculate contrast ratio between two colors
+ * @param {Object} fg - Foreground RGB
+ * @param {Object} bg - Background RGB
+ * @returns {number} Contrast ratio (1-21)
+ */
+function calculateContrastRatio(fg, bg) {
+  const l1 = calculateLuminance(fg);
+  const l2 = calculateLuminance(bg);
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Execute dual-mode Visual Polish Gate audit
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D (US-001)
+ * @param {Object} options - Audit options
+ * @param {Object} options.page - Playwright page object (required for full audit)
+ * @param {string} options.previewUrl - URL to audit
+ * @param {string} options.outputDir - Output directory for screenshots
+ * @param {string} options.ventureStage - Venture stage for enforcement
+ * @param {string} options.venturePersonality - Optional personality tag
+ * @returns {Promise<Object>} Combined dual-mode audit results
+ */
+export async function executeDualModeAudit(options = {}) {
+  const {
+    page = null,
+    previewUrl = null,
+    outputDir = './visual-polish-reports',
+    ventureStage = 'build',
+    venturePersonality = null,
+    viewports = VIEWPORTS
+  } = options;
+
+  const result = {
+    timestamp: new Date().toISOString(),
+    gate: 'VISUAL_POLISH_GATE_DUAL_MODE',
+    previewUrl,
+    status: 'UNKNOWN',
+    exitCode: 0,
+    themeMethod: null,
+    modes: {
+      light: null,
+      dark: null
+    },
+    screenshots: {},
+    contrastViolations: {
+      light: [],
+      dark: []
+    },
+    summary: {
+      lightPassed: false,
+      darkPassed: false,
+      totalViolations: 0
+    }
+  };
+
+  // If no page provided, return with content-only analysis
+  if (!page) {
+    result.status = 'SKIPPED';
+    result.error = 'Playwright page object required for dual-mode audit';
+    return result;
+  }
+
+  try {
+    // Navigate to URL if provided
+    if (previewUrl) {
+      await page.goto(previewUrl, { waitUntil: 'networkidle' });
+    }
+
+    // Detect theme method
+    result.themeMethod = await detectThemeMethod(page);
+
+    // Run Light mode audit
+    await toggleTheme(page, 'light', result.themeMethod);
+    const pageContent = await page.content();
+    result.modes.light = await executeVisualPolishGate({
+      content: pageContent,
+      fileType: 'jsx',
+      ventureStage,
+      venturePersonality
+    });
+    result.modes.light.mode = 'light';
+
+    // Run contrast validation in Light mode
+    const lightContrast = await validateContrastInMode(page, 'light');
+    result.contrastViolations.light = lightContrast.violations;
+
+    // Run Dark mode audit
+    await toggleTheme(page, 'dark', result.themeMethod);
+    const darkPageContent = await page.content();
+    result.modes.dark = await executeVisualPolishGate({
+      content: darkPageContent,
+      fileType: 'jsx',
+      ventureStage,
+      venturePersonality
+    });
+    result.modes.dark.mode = 'dark';
+
+    // Run contrast validation in Dark mode
+    const darkContrast = await validateContrastInMode(page, 'dark');
+    result.contrastViolations.dark = darkContrast.violations;
+
+    // Capture dual-mode screenshots
+    result.screenshots = await captureDualModeScreenshots(page, `${outputDir}/screenshots`, viewports);
+
+    // Calculate summary
+    result.summary.lightPassed = result.modes.light.status !== 'HARD_BLOCK';
+    result.summary.darkPassed = result.modes.dark.status !== 'HARD_BLOCK';
+    result.summary.totalViolations =
+      (result.modes.light.aiSlop?.violations?.length || 0) +
+      (result.modes.dark.aiSlop?.violations?.length || 0) +
+      result.contrastViolations.light.length +
+      result.contrastViolations.dark.length;
+
+    // Determine overall status
+    if (!result.summary.lightPassed || !result.summary.darkPassed) {
+      result.status = 'HARD_BLOCK';
+      result.exitCode = 1;
+    } else if (result.summary.totalViolations > 0) {
+      result.status = 'WARNING';
+    } else {
+      result.status = 'PASS';
+    }
+
+  } catch (error) {
+    result.status = 'ERROR';
+    result.error = error.message;
+    result.exitCode = 1;
+  }
+
+  return result;
+}
+
+/**
+ * Format dual-mode audit result for console output
+ * @sd SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D
+ * @param {Object} result - Dual-mode audit result
+ * @returns {string} Formatted output
+ */
+export function formatDualModeResult(result) {
+  const lines = [];
+
+  lines.push('');
+  lines.push('='.repeat(70));
+  lines.push('VISUAL POLISH GATE - DUAL MODE AUDIT');
+  lines.push('='.repeat(70));
+  lines.push('');
+
+  const statusIcon = {
+    'PASS': '✅',
+    'WARNING': '⚠️',
+    'HARD_BLOCK': '❌',
+    'ERROR': '💥',
+    'SKIPPED': '⏭️'
+  }[result.status] || '❓';
+
+  lines.push(`${statusIcon} Overall Status: ${result.status}`);
+  lines.push(`🔧 Theme Method: ${result.themeMethod || 'unknown'}`);
+  lines.push(`📍 URL: ${result.previewUrl || 'N/A'}`);
+  lines.push('');
+
+  // Light mode section
+  lines.push('☀️  LIGHT MODE AUDIT');
+  lines.push('-'.repeat(50));
+  if (result.modes.light) {
+    const lightIcon = result.summary.lightPassed ? '✅' : '❌';
+    lines.push(`   ${lightIcon} Status: ${result.modes.light.status}`);
+    lines.push(`   📊 Score: ${result.modes.light.score}/100`);
+    lines.push(`   🤖 AI Slop: ${result.modes.light.aiSlop?.violations?.length || 0} violations`);
+    lines.push(`   🎨 Contrast: ${result.contrastViolations.light.length} violations`);
+  }
+  lines.push('');
+
+  // Dark mode section
+  lines.push('🌙 DARK MODE AUDIT');
+  lines.push('-'.repeat(50));
+  if (result.modes.dark) {
+    const darkIcon = result.summary.darkPassed ? '✅' : '❌';
+    lines.push(`   ${darkIcon} Status: ${result.modes.dark.status}`);
+    lines.push(`   📊 Score: ${result.modes.dark.score}/100`);
+    lines.push(`   🤖 AI Slop: ${result.modes.dark.aiSlop?.violations?.length || 0} violations`);
+    lines.push(`   🎨 Contrast: ${result.contrastViolations.dark.length} violations`);
+  }
+  lines.push('');
+
+  // Screenshots section
+  lines.push('📸 SCREENSHOTS CAPTURED');
+  lines.push('-'.repeat(50));
+  for (const [viewport, paths] of Object.entries(result.screenshots || {})) {
+    lines.push(`   ${viewport}:`);
+    lines.push(`      Light: ${paths.light || 'failed'}`);
+    lines.push(`      Dark: ${paths.dark || 'failed'}`);
+  }
+  lines.push('');
+
+  // Contrast violations detail
+  if (result.summary.totalViolations > 0) {
+    lines.push('⚠️  CONTRAST VIOLATIONS');
+    lines.push('-'.repeat(50));
+    if (result.contrastViolations.light.length > 0) {
+      lines.push('   Light Mode:');
+      for (const v of result.contrastViolations.light.slice(0, 5)) {
+        lines.push(`      • ${v.selector}: ${v.actualRatio}:1 (need ${v.requiredRatio}:1)`);
+      }
+    }
+    if (result.contrastViolations.dark.length > 0) {
+      lines.push('   Dark Mode:');
+      for (const v of result.contrastViolations.dark.slice(0, 5)) {
+        lines.push(`      • ${v.selector}: ${v.actualRatio}:1 (need ${v.requiredRatio}:1)`);
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push(`🏁 Exit Code: ${result.exitCode}`);
+  lines.push('='.repeat(70));
+
+  return lines.join('\n');
+}
+
 export default {
   AI_SLOP_PATTERNS,
   STAGE_ENFORCEMENT,
   CRITIQUE_DIMENSIONS,
   PERSONALITY_CONSTRAINTS,
+  VIEWPORTS,
+  THEME_METHODS,
   detectAISlop,
   auditPersonalityCompliance,
   getEnforcementDecision,
   generateImpeccableCritique,
   executeVisualPolishGate,
-  formatGateResult
+  formatGateResult,
+  detectThemeMethod,
+  toggleTheme,
+  captureDualModeScreenshots,
+  validateContrastInMode,
+  executeDualModeAudit,
+  formatDualModeResult
 };


### PR DESCRIPTION
## Summary

Implements **SD-LEO-ORCH-AESTHETIC-DESIGN-SYSTEM-001-D** - Dark Mode Default Mandate with Dual-State Auditing.

- Adds dual-mode (Light/Dark) CI gate for Visual Polish audits
- Implements theme detection (class-based and media-query methods)
- Multi-viewport screenshot capture with standard naming
- WCAG AA contrast validation per theme mode
- 41 new unit tests (69 total) - all passing

### User Stories Delivered
- **US-001**: Dual-State CI Gate for Light/Dark Mode Audits
- **US-002**: Theme Toggle Detection and Method Recording
- **US-003**: Dual-Mode Screenshot Capture with Standard Naming
- **US-004**: WCAG AA Contrast Validation in Both Modes

## Test plan
- [x] 69 unit tests pass (`npx vitest run tests/unit/agents/design/visual-polish-gate.test.js`)
- [x] Smoke tests pass
- [x] EXEC-TO-PLAN handoff: 80%
- [x] PLAN-TO-LEAD handoff: 67%
- [x] LEAD-FINAL-APPROVAL: 97%

🤖 Generated with [Claude Code](https://claude.com/claude-code)