### PR TITLE
fix(handoff): add task vs handoff terminology disambiguation

### DIFF
--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -145,6 +145,14 @@ async function hydrateAndOutputTasks(sdId, currentHandoff, supabase) {
     console.log('   INSTRUCTION: Claude MUST call TaskCreate for each task below.');
     console.log('   Use TaskUpdate to set blockedBy dependencies after creation.');
     console.log('');
+    console.log('   ⚠️  IMPORTANT: These are TASKS, not handoffs!');
+    console.log('      • DO NOT execute these with handoff.js');
+    console.log('      • Use TaskCreate tool to create these tasks');
+    console.log('');
+    console.log('   Valid HANDOFF types (for handoff.js execute):');
+    console.log('      LEAD-TO-PLAN, PLAN-TO-EXEC, EXEC-TO-PLAN,');
+    console.log('      PLAN-TO-LEAD, LEAD-FINAL-APPROVAL');
+    console.log('');
     console.log('───────────────────────────────────────────────────────────');
 
     for (const task of result.tasks) {


### PR DESCRIPTION
## Summary

- Add warning in task hydration output clarifying that tasks are NOT handoffs
- Add validation in `handoff.js` to reject task-like arguments with helpful error message
- Pattern detection catches `VERIFY-*`, `EXEC-*`, `SD-*` prefixes and `-GATE-`/`-WALL` markers

## Root Cause

Task names (`VERIFY-FIDELITY`) and handoff types (`EXEC-TO-PLAN`) both use ALL-CAPS-WITH-HYPHENS pattern, causing AI confusion when determining what to execute after handoff completion.

## Test Plan

- [x] Tested `VERIFY-FIDELITY` is rejected with helpful error
- [x] Tested `EXEC-IMPL` is rejected with helpful error  
- [x] Tested valid handoff types (`LEAD-TO-PLAN`) still work
- [x] Smoke tests pass

## Pattern ID

PAT-TERM-001 - Task vs Handoff Naming Confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)