### PR TITLE
feat(uat): add DOM capture with selector drift recovery

### DIFF
--- a/lib/uat/dom-capture.js
+++ b/lib/uat/dom-capture.js
@@ -1,0 +1,332 @@
+/**
+ * DOM Capture Module for UAT Visual Failures
+ *
+ * Captures DOM element information when visual failures occur during UAT,
+ * enabling EXEC agents to target exact elements via selectors.
+ *
+ * Uses Playwright MCP browser_snapshot for element capture.
+ */
+
+/**
+ * Capture visual defect details from the current page
+ * @param {import('playwright').Page} page - Playwright page instance
+ * @param {Object} element - Element context (can be locator or selector)
+ * @param {Object} options - Capture options
+ * @returns {Promise<Object>} DOM capture metadata
+ */
+export async function captureVisualDefect(page, element, options = {}) {
+  const {
+    includeScreenshot = true,
+    outputDir = './visual-polish-reports/screenshots',
+    defectId = `defect-${Date.now()}`
+  } = options;
+
+  try {
+    // Get element locator from various input types
+    const locator = await resolveLocator(page, element);
+
+    if (!locator) {
+      return {
+        success: false,
+        error: 'Could not resolve element to locator',
+        element_ref: null
+      };
+    }
+
+    // Capture element information
+    const elementInfo = await captureElementInfo(page, locator);
+
+    // Generate selectors with fallbacks
+    const selectors = await generateSelectors(page, locator);
+
+    // Get bounding box
+    const boundingBox = await locator.boundingBox();
+
+    // Capture annotated screenshot if requested
+    let annotatedScreenshot = null;
+    if (includeScreenshot && boundingBox) {
+      const { addBoundingBoxOverlay } = await import('./screenshot-annotator.js');
+      const screenshotPath = `${outputDir}/${defectId}.png`;
+      await page.screenshot({ path: screenshotPath, fullPage: false });
+      annotatedScreenshot = await addBoundingBoxOverlay(
+        screenshotPath,
+        boundingBox,
+        `${outputDir}/${defectId}-annotated.png`
+      );
+    }
+
+    // Try to resolve component path from source maps
+    const componentPath = await resolveComponentPath(page, locator);
+
+    return {
+      success: true,
+      element_ref: elementInfo.elementRef,
+      primary_selector: selectors.primary,
+      alternative_selectors: selectors.alternatives,
+      component_path: componentPath,
+      bounding_box: boundingBox ? {
+        x: Math.round(boundingBox.x),
+        y: Math.round(boundingBox.y),
+        width: Math.round(boundingBox.width),
+        height: Math.round(boundingBox.height)
+      } : null,
+      annotated_screenshot: annotatedScreenshot,
+      captured_at: new Date().toISOString(),
+      tag_name: elementInfo.tagName,
+      text_content: elementInfo.textContent?.substring(0, 100),
+      attributes: elementInfo.attributes
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error.message,
+      element_ref: null
+    };
+  }
+}
+
+/**
+ * Resolve various element inputs to a Playwright locator
+ */
+async function resolveLocator(page, element) {
+  if (!element) return null;
+
+  // Already a locator
+  if (element.locator || element._selector) {
+    return element;
+  }
+
+  // String selector
+  if (typeof element === 'string') {
+    return page.locator(element).first();
+  }
+
+  // Object with selector property
+  if (element.selector) {
+    return page.locator(element.selector).first();
+  }
+
+  // ElementHandle
+  if (element.asElement) {
+    return element;
+  }
+
+  return null;
+}
+
+/**
+ * Capture detailed element information
+ */
+async function captureElementInfo(page, locator) {
+  return await locator.evaluate((el) => {
+    // Generate a unique reference for this element
+    const elementRef = `e${Math.random().toString(36).substring(2, 8)}`;
+
+    // Get computed attributes
+    const attributes = {};
+    for (const attr of el.attributes) {
+      if (['id', 'class', 'data-testid', 'name', 'type', 'role', 'aria-label'].includes(attr.name)) {
+        attributes[attr.name] = attr.value;
+      }
+    }
+
+    return {
+      elementRef,
+      tagName: el.tagName.toLowerCase(),
+      textContent: el.textContent?.trim(),
+      attributes
+    };
+  });
+}
+
+/**
+ * Generate multiple selector strategies for element targeting
+ */
+async function generateSelectors(page, locator) {
+  const selectors = await locator.evaluate((el) => {
+    const results = [];
+
+    // Strategy 1: data-testid (most stable)
+    if (el.dataset.testid) {
+      results.push({
+        selector: `[data-testid="${el.dataset.testid}"]`,
+        strategy: 'data-testid',
+        confidence: 0.95
+      });
+    }
+
+    // Strategy 2: ID (stable if not dynamically generated)
+    if (el.id && !el.id.match(/^\d|^:r|^__/)) {
+      results.push({
+        selector: `#${el.id}`,
+        strategy: 'id',
+        confidence: 0.9
+      });
+    }
+
+    // Strategy 3: Unique class combination
+    if (el.className) {
+      const classes = el.className.split(' ').filter(c =>
+        c && !c.match(/^(hover|active|focus|disabled|hidden|visible)/)
+      ).slice(0, 3);
+      if (classes.length > 0) {
+        results.push({
+          selector: `${el.tagName.toLowerCase()}.${classes.join('.')}`,
+          strategy: 'class',
+          confidence: 0.7
+        });
+      }
+    }
+
+    // Strategy 4: Role + accessible name
+    const role = el.getAttribute('role') || el.tagName.toLowerCase();
+    const name = el.getAttribute('aria-label') || el.textContent?.trim().substring(0, 30);
+    if (name) {
+      results.push({
+        selector: `[role="${role}"]`,
+        strategy: 'role',
+        confidence: 0.6,
+        textHint: name
+      });
+    }
+
+    // Strategy 5: CSS path (least stable, last resort)
+    const path = [];
+    let current = el;
+    while (current && current.tagName) {
+      let selector = current.tagName.toLowerCase();
+      if (current.id) {
+        selector = `#${current.id}`;
+        path.unshift(selector);
+        break;
+      }
+      const siblings = current.parentElement?.children || [];
+      const sameTag = Array.from(siblings).filter(s => s.tagName === current.tagName);
+      if (sameTag.length > 1) {
+        const index = sameTag.indexOf(current) + 1;
+        selector += `:nth-of-type(${index})`;
+      }
+      path.unshift(selector);
+      current = current.parentElement;
+      if (path.length > 4) break;
+    }
+    results.push({
+      selector: path.join(' > '),
+      strategy: 'css-path',
+      confidence: 0.4
+    });
+
+    return results;
+  });
+
+  // Sort by confidence and select primary + alternatives
+  selectors.sort((a, b) => b.confidence - a.confidence);
+
+  return {
+    primary: selectors[0]?.selector || null,
+    alternatives: selectors.slice(1).map(s => s.selector),
+    all: selectors
+  };
+}
+
+/**
+ * Try to resolve the React/Vue component file path from source maps
+ */
+async function resolveComponentPath(page, locator) {
+  try {
+    const componentInfo = await locator.evaluate((el) => {
+      // React DevTools integration
+      if (el._reactRootContainer || el.__reactFiber$) {
+        const fiber = el.__reactFiber$ || Object.keys(el).find(k => k.startsWith('__reactFiber'))
+          ? el[Object.keys(el).find(k => k.startsWith('__reactFiber'))]
+          : null;
+        if (fiber && fiber._debugSource) {
+          return {
+            fileName: fiber._debugSource.fileName,
+            lineNumber: fiber._debugSource.lineNumber
+          };
+        }
+      }
+
+      // Vue DevTools integration
+      if (el.__vue__) {
+        const vm = el.__vue__;
+        if (vm.$options && vm.$options.__file) {
+          return { fileName: vm.$options.__file };
+        }
+      }
+
+      return null;
+    });
+
+    if (componentInfo) {
+      return componentInfo.lineNumber
+        ? `${componentInfo.fileName}:${componentInfo.lineNumber}`
+        : componentInfo.fileName;
+    }
+  } catch {
+    // Source maps not available
+  }
+
+  return null;
+}
+
+/**
+ * Verify that a captured selector still matches an element
+ * @param {import('playwright').Page} page - Playwright page instance
+ * @param {Object} domCapture - Previously captured DOM metadata
+ * @returns {Promise<Object>} Verification result with matched selector
+ */
+export async function verifySelector(page, domCapture) {
+  const { primary_selector, alternative_selectors = [] } = domCapture;
+
+  // Try primary selector first
+  if (primary_selector) {
+    const count = await page.locator(primary_selector).count();
+    if (count > 0) {
+      return {
+        verified: true,
+        matchedSelector: primary_selector,
+        strategy: 'primary',
+        message: `Selector verified: ${primary_selector} found`
+      };
+    }
+  }
+
+  // Try alternatives
+  for (const selector of alternative_selectors) {
+    const count = await page.locator(selector).count();
+    if (count > 0) {
+      return {
+        verified: true,
+        matchedSelector: selector,
+        strategy: 'fallback',
+        message: `Fallback selector matched: ${selector}`
+      };
+    }
+  }
+
+  // No match - trigger drift recovery
+  return {
+    verified: false,
+    matchedSelector: null,
+    strategy: 'none',
+    message: 'Selector not found: attempting drift recovery'
+  };
+}
+
+/**
+ * Prompt user for DOM capture during UAT (terminal interaction)
+ * @param {string} failureType - Type of failure detected
+ * @returns {Promise<boolean>} User's response
+ */
+export function shouldCaptureDom(failureType) {
+  // Visual failures should prompt for DOM capture
+  return failureType === 'visual' || failureType === 'Visual bug';
+}
+
+export default {
+  captureVisualDefect,
+  verifySelector,
+  shouldCaptureDom
+};

--- a/lib/uat/index.js
+++ b/lib/uat/index.js
@@ -22,8 +22,31 @@ export {
   completeSession,
   getSessionStatus,
   getLatestSession,
+  captureVisualDefect,
+  verifySelector,
+  shouldCaptureDom,
   default as resultRecorder
 } from './result-recorder.js';
+
+// DOM Capture (SD-LEO-ENH-UAT-DOM-CAPTURE-001)
+export {
+  captureVisualDefect as domCapture,
+  verifySelector as verifySelectorCapture,
+  shouldCaptureDom as shouldOfferDomCapture
+} from './dom-capture.js';
+
+// Screenshot Annotator (SD-LEO-ENH-UAT-DOM-CAPTURE-001)
+export {
+  addBoundingBoxOverlay,
+  createComparisonView
+} from './screenshot-annotator.js';
+
+// Selector Drift Recovery (SD-LEO-ENH-UAT-DOM-CAPTURE-001)
+export {
+  recoverFromDrift,
+  calculateDriftScore,
+  logDriftRecovery
+} from './selector-drift-recovery.js';
 
 // Risk Router
 export {

--- a/lib/uat/result-recorder.js
+++ b/lib/uat/result-recorder.js
@@ -2,17 +2,19 @@
  * UAT Result Recorder
  *
  * Purpose: Record UAT test results to database for /uat command
- * SD: SD-UAT-REC-001
+ * SD: SD-UAT-REC-001, SD-LEO-ENH-UAT-DOM-CAPTURE-001
  *
  * Features:
  * - Start/complete UAT sessions (test runs)
  * - Record individual scenario results (PASS/FAIL/BLOCKED/SKIP)
  * - Calculate quality gate (GREEN/YELLOW/RED)
  * - Store scenario snapshots for traceability
+ * - DOM capture support for visual failures (SD-LEO-ENH-UAT-DOM-CAPTURE-001)
  */
 
 import { createSupabaseServiceClient } from '../../scripts/lib/supabase-connection.js';
 import { calculatePriority } from '../quality/priority-calculator.js';
+import { captureVisualDefect, verifySelector, shouldCaptureDom } from './dom-capture.js';
 
 let supabase = null;
 
@@ -107,7 +109,10 @@ export async function recordResult(testRunId, scenario, result, details = {}) {
     notes = null,
     errorMessage = null,
     failureType = null,
-    estimatedLOC = null
+    estimatedLOC = null,
+    domCapture = null,
+    domCaptureOffered = false,
+    domCaptureAccepted = false
   } = details;
 
   // Create test result record
@@ -146,7 +151,10 @@ export async function recordResult(testRunId, scenario, result, details = {}) {
     await recordDefect(testRunId, scenario, {
       errorMessage,
       failureType,
-      estimatedLOC
+      estimatedLOC,
+      domCapture,
+      domCaptureOffered,
+      domCaptureAccepted
     });
   }
 
@@ -200,15 +208,19 @@ async function updateRunCounts(testRunId, result) {
 /**
  * Record a defect from a failed test
  * SD-QUALITY-INT-001: Also writes to unified feedback table
+ * SD-LEO-ENH-UAT-DOM-CAPTURE-001: Includes DOM capture metadata for visual failures
  *
  * @param {string} testRunId - Test run ID
  * @param {Object} scenario - The failed scenario
  * @param {Object} details - Defect details
+ * @param {Object} details.domCapture - DOM capture metadata (selectors, bounding box, etc.)
+ * @param {boolean} details.domCaptureOffered - Whether DOM capture was offered to user
+ * @param {boolean} details.domCaptureAccepted - Whether user accepted DOM capture
  */
 async function recordDefect(testRunId, scenario, details) {
   const db = await getSupabase();
 
-  const { errorMessage, failureType, estimatedLOC } = details;
+  const { errorMessage, failureType, estimatedLOC, domCapture, domCaptureOffered, domCaptureAccepted } = details;
   const severityLevel = estimatedLOC && estimatedLOC <= 50 ? 'minor' : 'major';
 
   // SD-QUALITY-TRIAGE-001: Use priority-calculator instead of hardcoded mapping
@@ -239,7 +251,11 @@ async function recordDefect(testRunId, scenario, details) {
         failure_type: failureType,
         estimated_loc: estimatedLOC,
         source_id: scenario.sourceId,
-        source: scenario.source
+        source: scenario.source,
+        // SD-LEO-ENH-UAT-DOM-CAPTURE-001: DOM capture metadata
+        dom_capture_offered: domCaptureOffered,
+        dom_capture_accepted: domCaptureAccepted,
+        dom_capture: domCapture || null
       },
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString()
@@ -420,10 +436,17 @@ export async function getLatestSession(sdId) {
   return runs[0];
 }
 
+// Re-export DOM capture functions for convenience
+export { captureVisualDefect, verifySelector, shouldCaptureDom };
+
 export default {
   startSession,
   recordResult,
   completeSession,
   getSessionStatus,
-  getLatestSession
+  getLatestSession,
+  // DOM capture exports
+  captureVisualDefect,
+  verifySelector,
+  shouldCaptureDom
 };

--- a/lib/uat/screenshot-annotator.js
+++ b/lib/uat/screenshot-annotator.js
@@ -1,0 +1,245 @@
+/**
+ * Screenshot Annotator for UAT Visual Defects
+ *
+ * Adds bounding box overlays to screenshots to highlight
+ * captured elements for visual defect reports.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+/**
+ * Add a bounding box overlay to a screenshot
+ * @param {string} screenshotPath - Path to the original screenshot
+ * @param {Object} bbox - Bounding box { x, y, width, height }
+ * @param {string} outputPath - Path for the annotated screenshot
+ * @param {Object} options - Annotation options
+ * @returns {Promise<string>} Path to the annotated screenshot
+ */
+export async function addBoundingBoxOverlay(screenshotPath, bbox, outputPath, options = {}) {
+  const {
+    borderColor = '#FF0000',
+    borderWidth = 2,
+    labelText = null,
+    labelBackground = '#FF0000',
+    labelColor = '#FFFFFF'
+  } = options;
+
+  // Ensure output directory exists
+  const outputDir = path.dirname(outputPath);
+  await fs.mkdir(outputDir, { recursive: true });
+
+  try {
+    // Try to use sharp if available (best quality)
+    const sharp = await import('sharp').catch(() => null);
+
+    if (sharp) {
+      return await annotateWithSharp(
+        sharp.default,
+        screenshotPath,
+        bbox,
+        outputPath,
+        { borderColor, borderWidth, labelText, labelBackground, labelColor }
+      );
+    }
+
+    // Fallback: Create SVG overlay metadata file
+    return await createSvgOverlayMetadata(
+      screenshotPath,
+      bbox,
+      outputPath,
+      { borderColor, borderWidth, labelText }
+    );
+  } catch (error) {
+    console.error('Screenshot annotation failed:', error.message);
+    // Return original screenshot path on failure
+    return screenshotPath;
+  }
+}
+
+/**
+ * Annotate screenshot using sharp library
+ */
+async function annotateWithSharp(sharp, screenshotPath, bbox, outputPath, options) {
+  const { borderColor, borderWidth, labelText, labelBackground, labelColor } = options;
+
+  // Read the original image
+  const image = sharp(screenshotPath);
+  const metadata = await image.metadata();
+
+  // Create SVG overlay with bounding box
+  const svgOverlay = createSvgOverlay(
+    metadata.width,
+    metadata.height,
+    bbox,
+    { borderColor, borderWidth, labelText, labelBackground, labelColor }
+  );
+
+  // Composite the overlay onto the image
+  await image
+    .composite([{
+      input: Buffer.from(svgOverlay),
+      top: 0,
+      left: 0
+    }])
+    .toFile(outputPath);
+
+  return outputPath;
+}
+
+/**
+ * Create SVG overlay string for bounding box annotation
+ */
+function createSvgOverlay(width, height, bbox, options) {
+  const { borderColor, borderWidth, labelText, labelBackground, labelColor } = options;
+
+  let labelSvg = '';
+  if (labelText) {
+    const labelX = bbox.x;
+    const labelY = bbox.y - 20;
+    const labelPadding = 4;
+    const fontSize = 12;
+    const labelWidth = labelText.length * 7 + labelPadding * 2;
+
+    labelSvg = `
+      <rect x="${labelX}" y="${Math.max(0, labelY)}" width="${labelWidth}" height="${fontSize + labelPadding * 2}" fill="${labelBackground}" rx="2"/>
+      <text x="${labelX + labelPadding}" y="${Math.max(fontSize, labelY + fontSize + labelPadding - 2)}" font-family="Arial, sans-serif" font-size="${fontSize}" fill="${labelColor}">${escapeXml(labelText)}</text>
+    `;
+  }
+
+  return `
+    <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+      <rect
+        x="${bbox.x}"
+        y="${bbox.y}"
+        width="${bbox.width}"
+        height="${bbox.height}"
+        fill="none"
+        stroke="${borderColor}"
+        stroke-width="${borderWidth}"
+        stroke-dasharray="none"
+      />
+      ${labelSvg}
+    </svg>
+  `.trim();
+}
+
+/**
+ * Fallback: Create metadata file with SVG overlay instructions
+ * Used when sharp is not available
+ */
+async function createSvgOverlayMetadata(screenshotPath, bbox, outputPath, options) {
+  const { borderColor, borderWidth, labelText } = options;
+
+  const metadata = {
+    original_screenshot: screenshotPath,
+    annotation: {
+      type: 'bounding_box',
+      bbox: {
+        x: bbox.x,
+        y: bbox.y,
+        width: bbox.width,
+        height: bbox.height
+      },
+      style: {
+        borderColor,
+        borderWidth,
+        labelText
+      }
+    },
+    note: 'Install sharp (npm i sharp) for automatic image annotation',
+    created_at: new Date().toISOString()
+  };
+
+  // Write metadata file
+  const metadataPath = outputPath.replace(/\.(png|jpg|jpeg)$/i, '-annotation.json');
+  await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2));
+
+  // Copy original to output path
+  await fs.copyFile(screenshotPath, outputPath);
+
+  console.log(`Screenshot annotation metadata saved to: ${metadataPath}`);
+  return outputPath;
+}
+
+/**
+ * Escape XML special characters
+ */
+function escapeXml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Create a comparison view of two screenshots side by side
+ * @param {string} leftPath - Path to left screenshot
+ * @param {string} rightPath - Path to right screenshot
+ * @param {string} outputPath - Path for combined output
+ * @returns {Promise<string>} Path to comparison image
+ */
+export async function createComparisonView(leftPath, rightPath, outputPath, options = {}) {
+  const { labels = ['Expected', 'Actual'] } = options;
+
+  try {
+    const sharp = await import('sharp').catch(() => null);
+
+    if (!sharp) {
+      console.log('Sharp not available, creating comparison metadata only');
+      const metadata = {
+        type: 'comparison',
+        left: { path: leftPath, label: labels[0] },
+        right: { path: rightPath, label: labels[1] },
+        created_at: new Date().toISOString()
+      };
+      const metadataPath = outputPath.replace(/\.(png|jpg|jpeg)$/i, '-comparison.json');
+      await fs.writeFile(metadataPath, JSON.stringify(metadata, null, 2));
+      return metadataPath;
+    }
+
+    // Load both images
+    const leftImage = sharp.default(leftPath);
+    const rightImage = sharp.default(rightPath);
+
+    const [leftMeta, rightMeta] = await Promise.all([
+      leftImage.metadata(),
+      rightImage.metadata()
+    ]);
+
+    // Resize to same height
+    const targetHeight = Math.max(leftMeta.height, rightMeta.height);
+    const gap = 10;
+    const totalWidth = leftMeta.width + rightMeta.width + gap;
+
+    // Create composite
+    const leftBuffer = await leftImage.resize({ height: targetHeight }).toBuffer();
+    const rightBuffer = await rightImage.resize({ height: targetHeight }).toBuffer();
+
+    await sharp.default({
+      create: {
+        width: totalWidth,
+        height: targetHeight,
+        channels: 4,
+        background: { r: 255, g: 255, b: 255, alpha: 1 }
+      }
+    })
+      .composite([
+        { input: leftBuffer, left: 0, top: 0 },
+        { input: rightBuffer, left: leftMeta.width + gap, top: 0 }
+      ])
+      .toFile(outputPath);
+
+    return outputPath;
+  } catch (error) {
+    console.error('Comparison view creation failed:', error.message);
+    return leftPath;
+  }
+}
+
+export default {
+  addBoundingBoxOverlay,
+  createComparisonView
+};

--- a/lib/uat/selector-drift-recovery.js
+++ b/lib/uat/selector-drift-recovery.js
@@ -1,0 +1,353 @@
+/**
+ * Selector Drift Recovery Module
+ *
+ * Detects when previously captured selectors no longer match DOM elements
+ * and attempts to recover by finding similar elements using heuristics.
+ */
+
+/**
+ * Attempt to recover from selector drift
+ * @param {import('playwright').Page} page - Playwright page instance
+ * @param {Object} domCapture - Original DOM capture metadata
+ * @returns {Promise<Object>} Recovery result with new selector or null
+ */
+export async function recoverFromDrift(page, domCapture) {
+  const {
+    primary_selector,
+    alternative_selectors = [],
+    tag_name,
+    text_content,
+    attributes = {},
+    bounding_box
+  } = domCapture;
+
+  const strategies = [];
+
+  // Strategy 1: Try all alternative selectors
+  for (const selector of alternative_selectors) {
+    try {
+      const count = await page.locator(selector).count();
+      if (count > 0) {
+        strategies.push({
+          strategy: 'alternative_selector',
+          selector,
+          confidence: 0.8,
+          message: `Alternative selector matched: ${selector}`
+        });
+      }
+    } catch {
+      // Invalid selector, skip
+    }
+  }
+
+  // Strategy 2: Search by data-testid pattern
+  if (attributes['data-testid']) {
+    const testId = attributes['data-testid'];
+    // Try partial match
+    const partialSelector = `[data-testid*="${testId.split('-')[0]}"]`;
+    try {
+      const elements = await page.locator(partialSelector).all();
+      for (const el of elements) {
+        const currentTestId = await el.getAttribute('data-testid');
+        if (currentTestId && currentTestId.includes(testId.split('-')[0])) {
+          strategies.push({
+            strategy: 'testid_pattern',
+            selector: `[data-testid="${currentTestId}"]`,
+            confidence: 0.7,
+            message: `Similar testid found: ${currentTestId}`
+          });
+        }
+      }
+    } catch {
+      // Pattern search failed
+    }
+  }
+
+  // Strategy 3: Search by text content
+  if (text_content && text_content.length > 2) {
+    const searchText = text_content.substring(0, 30);
+    try {
+      const textSelector = `${tag_name || '*'}:has-text("${escapeText(searchText)}")`;
+      const count = await page.locator(textSelector).count();
+      if (count > 0 && count < 5) {
+        strategies.push({
+          strategy: 'text_content',
+          selector: textSelector,
+          confidence: 0.6,
+          message: `Text match found: "${searchText}..."`
+        });
+      }
+    } catch {
+      // Text search failed
+    }
+  }
+
+  // Strategy 4: Search by role and accessible name
+  if (attributes.role || attributes['aria-label']) {
+    const role = attributes.role || tag_name;
+    const name = attributes['aria-label'] || text_content?.substring(0, 20);
+    if (role && name) {
+      try {
+        const roleSelector = `[role="${role}"]`;
+        const elements = await page.locator(roleSelector).all();
+        for (const el of elements.slice(0, 10)) {
+          const elName = await el.getAttribute('aria-label') || await el.textContent();
+          if (elName && elName.includes(name.split(' ')[0])) {
+            strategies.push({
+              strategy: 'role_name',
+              selector: roleSelector,
+              confidence: 0.5,
+              message: `Role/name match: ${role} with "${name}"`
+            });
+            break;
+          }
+        }
+      } catch {
+        // Role search failed
+      }
+    }
+  }
+
+  // Strategy 5: Search by class pattern
+  if (attributes.class) {
+    const classes = attributes.class.split(' ').filter(c =>
+      c && !c.match(/^(hover|active|focus|disabled|hidden|visible|--|__)/)
+    );
+    for (const cls of classes.slice(0, 2)) {
+      try {
+        const classSelector = `.${cls}`;
+        const count = await page.locator(classSelector).count();
+        if (count > 0 && count < 10) {
+          strategies.push({
+            strategy: 'class_pattern',
+            selector: `${tag_name || '*'}${classSelector}`,
+            confidence: 0.4,
+            message: `Class pattern matched: .${cls}`
+          });
+        }
+      } catch {
+        // Class search failed
+      }
+    }
+  }
+
+  // Strategy 6: Search by position (last resort)
+  if (bounding_box) {
+    try {
+      const nearbyElement = await findElementNearPosition(page, bounding_box, tag_name);
+      if (nearbyElement) {
+        strategies.push({
+          strategy: 'position',
+          selector: nearbyElement.selector,
+          confidence: 0.3,
+          message: `Position-based match at (${bounding_box.x}, ${bounding_box.y})`
+        });
+      }
+    } catch {
+      // Position search failed
+    }
+  }
+
+  // Sort by confidence and return best match
+  strategies.sort((a, b) => b.confidence - a.confidence);
+
+  if (strategies.length > 0) {
+    return {
+      recovered: true,
+      original_selector: primary_selector,
+      new_selector: strategies[0].selector,
+      confidence: strategies[0].confidence,
+      strategy: strategies[0].strategy,
+      message: strategies[0].message,
+      alternatives_tried: strategies.length
+    };
+  }
+
+  return {
+    recovered: false,
+    original_selector: primary_selector,
+    new_selector: null,
+    confidence: 0,
+    strategy: 'none',
+    message: 'No matching element found. Manual intervention required.',
+    alternatives_tried: 0
+  };
+}
+
+/**
+ * Find element near a given position
+ */
+async function findElementNearPosition(page, bbox, preferredTag) {
+  const { x, y, width, height } = bbox;
+  const centerX = x + width / 2;
+  const centerY = y + height / 2;
+  const tolerance = 50; // pixels
+
+  return await page.evaluate(({ centerX, centerY, tolerance, preferredTag }) => {
+    const elements = document.elementsFromPoint(centerX, centerY);
+
+    for (const el of elements) {
+      if (el.tagName === 'HTML' || el.tagName === 'BODY') continue;
+
+      // Prefer matching tag
+      if (preferredTag && el.tagName.toLowerCase() !== preferredTag) continue;
+
+      const rect = el.getBoundingClientRect();
+      const elCenterX = rect.x + rect.width / 2;
+      const elCenterY = rect.y + rect.height / 2;
+
+      // Check if within tolerance
+      if (Math.abs(elCenterX - centerX) <= tolerance &&
+          Math.abs(elCenterY - centerY) <= tolerance) {
+        // Generate a selector for this element
+        let selector = el.tagName.toLowerCase();
+        if (el.id) {
+          selector = `#${el.id}`;
+        } else if (el.dataset.testid) {
+          selector = `[data-testid="${el.dataset.testid}"]`;
+        } else if (el.className) {
+          const cls = el.className.split(' ')[0];
+          selector = `${el.tagName.toLowerCase()}.${cls}`;
+        }
+
+        return { selector };
+      }
+    }
+
+    return null;
+  }, { centerX, centerY, tolerance, preferredTag });
+}
+
+/**
+ * Calculate drift score between original and current element
+ * @param {Object} original - Original DOM capture
+ * @param {Object} current - Current element info
+ * @returns {number} Drift score (0-1, lower is better)
+ */
+export function calculateDriftScore(original, current) {
+  let score = 0;
+  let weights = 0;
+
+  // Compare tag name (weight: 0.1)
+  if (original.tag_name && current.tag_name) {
+    weights += 0.1;
+    if (original.tag_name !== current.tag_name) {
+      score += 0.1;
+    }
+  }
+
+  // Compare text content (weight: 0.2)
+  if (original.text_content && current.text_content) {
+    weights += 0.2;
+    const similarity = calculateTextSimilarity(original.text_content, current.text_content);
+    score += 0.2 * (1 - similarity);
+  }
+
+  // Compare position (weight: 0.3)
+  if (original.bounding_box && current.bounding_box) {
+    weights += 0.3;
+    const positionDrift = calculatePositionDrift(original.bounding_box, current.bounding_box);
+    score += 0.3 * Math.min(1, positionDrift / 100); // Cap at 100px difference
+  }
+
+  // Compare attributes (weight: 0.4)
+  if (original.attributes && current.attributes) {
+    weights += 0.4;
+    const attrSimilarity = calculateAttributeSimilarity(original.attributes, current.attributes);
+    score += 0.4 * (1 - attrSimilarity);
+  }
+
+  return weights > 0 ? score / weights : 1;
+}
+
+/**
+ * Calculate text similarity using Levenshtein distance
+ */
+function calculateTextSimilarity(str1, str2) {
+  const s1 = str1.toLowerCase().substring(0, 50);
+  const s2 = str2.toLowerCase().substring(0, 50);
+
+  if (s1 === s2) return 1;
+  if (s1.length === 0 || s2.length === 0) return 0;
+
+  const matrix = [];
+  for (let i = 0; i <= s1.length; i++) {
+    matrix[i] = [i];
+  }
+  for (let j = 0; j <= s2.length; j++) {
+    matrix[0][j] = j;
+  }
+
+  for (let i = 1; i <= s1.length; i++) {
+    for (let j = 1; j <= s2.length; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost
+      );
+    }
+  }
+
+  const distance = matrix[s1.length][s2.length];
+  return 1 - distance / Math.max(s1.length, s2.length);
+}
+
+/**
+ * Calculate position drift in pixels
+ */
+function calculatePositionDrift(box1, box2) {
+  const dx = Math.abs(box1.x - box2.x);
+  const dy = Math.abs(box1.y - box2.y);
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+/**
+ * Calculate attribute similarity score
+ */
+function calculateAttributeSimilarity(attrs1, attrs2) {
+  const keys = new Set([...Object.keys(attrs1), ...Object.keys(attrs2)]);
+  if (keys.size === 0) return 1;
+
+  let matches = 0;
+  for (const key of keys) {
+    if (attrs1[key] === attrs2[key]) {
+      matches++;
+    }
+  }
+
+  return matches / keys.size;
+}
+
+/**
+ * Escape text for use in CSS selectors
+ */
+function escapeText(text) {
+  return text
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, ' ')
+    .trim();
+}
+
+/**
+ * Log drift recovery attempt to console
+ */
+export function logDriftRecovery(result) {
+  if (result.recovered) {
+    console.log(`Selector drift recovery: ${result.strategy}`);
+    console.log(`  Original: ${result.original_selector}`);
+    console.log(`  New: ${result.new_selector}`);
+    console.log(`  Confidence: ${(result.confidence * 100).toFixed(0)}%`);
+  } else {
+    console.log(`Selector drift recovery failed for: ${result.original_selector}`);
+    console.log(`  Tried ${result.alternatives_tried} strategies`);
+    console.log('  Manual intervention required');
+  }
+}
+
+export default {
+  recoverFromDrift,
+  calculateDriftScore,
+  logDriftRecovery
+};

--- a/tests/unit/uat/dom-capture.test.js
+++ b/tests/unit/uat/dom-capture.test.js
@@ -1,0 +1,218 @@
+/**
+ * Unit Tests: DOM Capture for UAT Visual Failures
+ *
+ * Tests for SD-LEO-ENH-UAT-DOM-CAPTURE-001
+ *
+ * @module tests/unit/uat/dom-capture.test.js
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { captureVisualDefect, verifySelector, shouldCaptureDom } from '../../../lib/uat/dom-capture.js';
+
+// ============================================================================
+// shouldCaptureDom TESTS
+// ============================================================================
+describe('shouldCaptureDom', () => {
+  it('should return true for visual failure type', () => {
+    expect(shouldCaptureDom('visual')).toBe(true);
+    expect(shouldCaptureDom('Visual bug')).toBe(true);
+  });
+
+  it('should return false for non-visual failure types', () => {
+    expect(shouldCaptureDom('functional')).toBe(false);
+    expect(shouldCaptureDom('performance')).toBe(false);
+    expect(shouldCaptureDom('console')).toBe(false);
+    expect(shouldCaptureDom('Functional bug')).toBe(false);
+  });
+});
+
+// ============================================================================
+// captureVisualDefect TESTS
+// ============================================================================
+describe('captureVisualDefect', () => {
+  let mockPage;
+  let mockLocator;
+
+  beforeEach(() => {
+    // Mock locator
+    mockLocator = {
+      evaluate: vi.fn(),
+      boundingBox: vi.fn()
+    };
+
+    // Mock page
+    mockPage = {
+      locator: vi.fn().mockReturnValue({
+        first: vi.fn().mockReturnValue(mockLocator),
+        count: vi.fn().mockResolvedValue(1)
+      }),
+      screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png'))
+    };
+  });
+
+  it('should capture element info successfully', async () => {
+    mockLocator.evaluate
+      .mockResolvedValueOnce({
+        elementRef: 'e12abc',
+        tagName: 'button',
+        textContent: 'Submit',
+        attributes: {
+          'data-testid': 'submit-btn',
+          class: 'btn-primary'
+        }
+      })
+      .mockResolvedValueOnce([
+        { selector: '[data-testid="submit-btn"]', strategy: 'data-testid', confidence: 0.95 },
+        { selector: '.btn-primary', strategy: 'class', confidence: 0.7 }
+      ])
+      .mockResolvedValueOnce(null); // componentPath
+
+    mockLocator.boundingBox.mockResolvedValue({
+      x: 100,
+      y: 200,
+      width: 80,
+      height: 32
+    });
+
+    const result = await captureVisualDefect(mockPage, '[data-testid="submit-btn"]', {
+      includeScreenshot: false
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.element_ref).toBe('e12abc');
+    expect(result.primary_selector).toBe('[data-testid="submit-btn"]');
+    expect(result.alternative_selectors).toContain('.btn-primary');
+    expect(result.bounding_box).toEqual({
+      x: 100,
+      y: 200,
+      width: 80,
+      height: 32
+    });
+    expect(result.tag_name).toBe('button');
+    expect(result.text_content).toBe('Submit');
+  });
+
+  it('should return failure when element cannot be resolved', async () => {
+    const result = await captureVisualDefect(mockPage, null);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Could not resolve');
+    expect(result.element_ref).toBeNull();
+  });
+
+  it('should handle string selector input', async () => {
+    mockLocator.evaluate
+      .mockResolvedValueOnce({
+        elementRef: 'e99xyz',
+        tagName: 'div',
+        textContent: 'Content',
+        attributes: { id: 'main' }
+      })
+      .mockResolvedValueOnce([
+        { selector: '#main', strategy: 'id', confidence: 0.9 }
+      ])
+      .mockResolvedValueOnce(null);
+
+    mockLocator.boundingBox.mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 });
+
+    const result = await captureVisualDefect(mockPage, '#main', {
+      includeScreenshot: false
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPage.locator).toHaveBeenCalledWith('#main');
+  });
+
+  it('should handle object with selector property', async () => {
+    mockLocator.evaluate
+      .mockResolvedValueOnce({
+        elementRef: 'eabc123',
+        tagName: 'input',
+        textContent: '',
+        attributes: { type: 'text', name: 'email' }
+      })
+      .mockResolvedValueOnce([
+        { selector: 'input[name="email"]', strategy: 'name', confidence: 0.8 }
+      ])
+      .mockResolvedValueOnce(null);
+
+    mockLocator.boundingBox.mockResolvedValue({ x: 50, y: 150, width: 200, height: 40 });
+
+    const result = await captureVisualDefect(mockPage, { selector: 'input[name="email"]' }, {
+      includeScreenshot: false
+    });
+
+    expect(result.success).toBe(true);
+    expect(mockPage.locator).toHaveBeenCalledWith('input[name="email"]');
+  });
+});
+
+// ============================================================================
+// verifySelector TESTS
+// ============================================================================
+describe('verifySelector', () => {
+  let mockPage;
+
+  beforeEach(() => {
+    mockPage = {
+      locator: vi.fn()
+    };
+  });
+
+  it('should verify primary selector when found', async () => {
+    mockPage.locator.mockReturnValue({
+      count: vi.fn().mockResolvedValue(1)
+    });
+
+    const domCapture = {
+      primary_selector: '[data-testid="submit-btn"]',
+      alternative_selectors: ['#submit', '.btn-primary']
+    };
+
+    const result = await verifySelector(mockPage, domCapture);
+
+    expect(result.verified).toBe(true);
+    expect(result.matchedSelector).toBe('[data-testid="submit-btn"]');
+    expect(result.strategy).toBe('primary');
+    expect(result.message).toContain('Selector verified');
+  });
+
+  it('should try alternative selectors when primary fails', async () => {
+    const countMock = vi.fn()
+      .mockResolvedValueOnce(0)  // primary fails
+      .mockResolvedValueOnce(0)  // first alternative fails
+      .mockResolvedValueOnce(1); // second alternative succeeds
+
+    mockPage.locator.mockReturnValue({ count: countMock });
+
+    const domCapture = {
+      primary_selector: '[data-testid="old-id"]',
+      alternative_selectors: ['#removed', '.btn-primary']
+    };
+
+    const result = await verifySelector(mockPage, domCapture);
+
+    expect(result.verified).toBe(true);
+    expect(result.matchedSelector).toBe('.btn-primary');
+    expect(result.strategy).toBe('fallback');
+    expect(result.message).toContain('Fallback selector matched');
+  });
+
+  it('should return not verified when no selectors match', async () => {
+    mockPage.locator.mockReturnValue({
+      count: vi.fn().mockResolvedValue(0)
+    });
+
+    const domCapture = {
+      primary_selector: '[data-testid="removed"]',
+      alternative_selectors: ['#gone', '.deleted']
+    };
+
+    const result = await verifySelector(mockPage, domCapture);
+
+    expect(result.verified).toBe(false);
+    expect(result.matchedSelector).toBeNull();
+    expect(result.strategy).toBe('none');
+    expect(result.message).toContain('drift recovery');
+  });
+});

--- a/tests/unit/uat/screenshot-annotator.test.js
+++ b/tests/unit/uat/screenshot-annotator.test.js
@@ -1,0 +1,112 @@
+/**
+ * Unit Tests: Screenshot Annotator
+ *
+ * Tests for SD-LEO-ENH-UAT-DOM-CAPTURE-001
+ *
+ * @module tests/unit/uat/screenshot-annotator.test.js
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { addBoundingBoxOverlay, createComparisonView } from '../../../lib/uat/screenshot-annotator.js';
+
+// Mock fs module
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      copyFile: vi.fn().mockResolvedValue(undefined)
+    }
+  };
+});
+
+describe('addBoundingBoxOverlay', () => {
+  const testScreenshotPath = '/tmp/test-screenshot.png';
+  const testOutputPath = '/tmp/test-annotated.png';
+  const testBbox = { x: 100, y: 200, width: 80, height: 32 };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create output directory if it does not exist', async () => {
+    await addBoundingBoxOverlay(testScreenshotPath, testBbox, testOutputPath);
+
+    expect(fs.mkdir).toHaveBeenCalledWith(
+      path.dirname(testOutputPath),
+      { recursive: true }
+    );
+  });
+
+  it('should fall back to metadata file when sharp is not available', async () => {
+    const result = await addBoundingBoxOverlay(testScreenshotPath, testBbox, testOutputPath);
+
+    // Without sharp, it should create metadata file and copy original
+    expect(fs.copyFile).toHaveBeenCalled();
+    expect(result).toBe(testOutputPath);
+  });
+
+  it('should use custom border color and width', async () => {
+    await addBoundingBoxOverlay(testScreenshotPath, testBbox, testOutputPath, {
+      borderColor: '#00FF00',
+      borderWidth: 4,
+      labelText: 'Test Element'
+    });
+
+    // Should still work with custom options
+    expect(fs.mkdir).toHaveBeenCalled();
+  });
+
+  it('should handle zero-sized bounding box', async () => {
+    const zeroBbox = { x: 0, y: 0, width: 0, height: 0 };
+
+    const result = await addBoundingBoxOverlay(testScreenshotPath, zeroBbox, testOutputPath);
+
+    // Should still produce output even with zero bbox
+    expect(result).toBeTruthy();
+  });
+
+  it('should handle negative coordinates', async () => {
+    const negativeBbox = { x: -10, y: -20, width: 100, height: 50 };
+
+    const result = await addBoundingBoxOverlay(testScreenshotPath, negativeBbox, testOutputPath);
+
+    // Should handle edge case without crashing
+    expect(result).toBeTruthy();
+  });
+});
+
+describe('createComparisonView', () => {
+  const leftPath = '/tmp/expected.png';
+  const rightPath = '/tmp/actual.png';
+  const outputPath = '/tmp/comparison.png';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create metadata file when sharp is not available', async () => {
+    const result = await createComparisonView(leftPath, rightPath, outputPath);
+
+    // Without sharp, should return metadata path
+    expect(result).toContain('-comparison.json');
+    expect(fs.writeFile).toHaveBeenCalled();
+  });
+
+  it('should use custom labels', async () => {
+    await createComparisonView(leftPath, rightPath, outputPath, {
+      labels: ['Before', 'After']
+    });
+
+    // Should handle custom labels
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Before')
+    );
+  });
+});

--- a/tests/unit/uat/selector-drift-recovery.test.js
+++ b/tests/unit/uat/selector-drift-recovery.test.js
@@ -1,0 +1,231 @@
+/**
+ * Unit Tests: Selector Drift Recovery
+ *
+ * Tests for SD-LEO-ENH-UAT-DOM-CAPTURE-001
+ *
+ * @module tests/unit/uat/selector-drift-recovery.test.js
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  recoverFromDrift,
+  calculateDriftScore,
+  logDriftRecovery
+} from '../../../lib/uat/selector-drift-recovery.js';
+
+// ============================================================================
+// calculateDriftScore TESTS
+// ============================================================================
+describe('calculateDriftScore', () => {
+  it('should return 0 for identical elements', () => {
+    const original = {
+      tag_name: 'button',
+      text_content: 'Submit',
+      bounding_box: { x: 100, y: 200, width: 80, height: 32 },
+      attributes: { 'data-testid': 'submit-btn', class: 'btn-primary' }
+    };
+
+    const current = { ...original };
+
+    const score = calculateDriftScore(original, current);
+    expect(score).toBe(0);
+  });
+
+  it('should return high score for completely different elements', () => {
+    const original = {
+      tag_name: 'button',
+      text_content: 'Submit',
+      bounding_box: { x: 100, y: 200, width: 80, height: 32 },
+      attributes: { 'data-testid': 'submit-btn' }
+    };
+
+    const current = {
+      tag_name: 'div',
+      text_content: 'Header',
+      bounding_box: { x: 0, y: 0, width: 1920, height: 60 },
+      attributes: { class: 'header' }
+    };
+
+    const score = calculateDriftScore(original, current);
+    expect(score).toBeGreaterThan(0.5);
+  });
+
+  it('should penalize position drift', () => {
+    const original = {
+      tag_name: 'button',
+      text_content: 'Submit',
+      bounding_box: { x: 100, y: 200, width: 80, height: 32 },
+      attributes: {}
+    };
+
+    const movedSlightly = {
+      tag_name: 'button',
+      text_content: 'Submit',
+      bounding_box: { x: 110, y: 205, width: 80, height: 32 },
+      attributes: {}
+    };
+
+    const movedFar = {
+      tag_name: 'button',
+      text_content: 'Submit',
+      bounding_box: { x: 500, y: 800, width: 80, height: 32 },
+      attributes: {}
+    };
+
+    const slightScore = calculateDriftScore(original, movedSlightly);
+    const farScore = calculateDriftScore(original, movedFar);
+
+    expect(slightScore).toBeLessThan(farScore);
+    expect(slightScore).toBeLessThan(0.2);
+  });
+
+  it('should penalize text content changes', () => {
+    const original = {
+      tag_name: 'button',
+      text_content: 'Submit Form',
+      attributes: {}
+    };
+
+    const similarText = {
+      tag_name: 'button',
+      text_content: 'Submit',
+      attributes: {}
+    };
+
+    const differentText = {
+      tag_name: 'button',
+      text_content: 'Cancel',
+      attributes: {}
+    };
+
+    const similarScore = calculateDriftScore(original, similarText);
+    const differentScore = calculateDriftScore(original, differentText);
+
+    expect(similarScore).toBeLessThan(differentScore);
+  });
+});
+
+// ============================================================================
+// recoverFromDrift TESTS
+// ============================================================================
+describe('recoverFromDrift', () => {
+  let mockPage;
+
+  beforeEach(() => {
+    mockPage = {
+      locator: vi.fn(),
+      evaluate: vi.fn()
+    };
+  });
+
+  it('should recover using alternative selector', async () => {
+    const countMock = vi.fn()
+      .mockResolvedValueOnce(1); // First alternative works
+
+    mockPage.locator.mockReturnValue({
+      count: countMock,
+      all: vi.fn().mockResolvedValue([])
+    });
+
+    const domCapture = {
+      primary_selector: '[data-testid="old-id"]',
+      alternative_selectors: ['#fallback-id', '.btn-class'],
+      tag_name: 'button',
+      text_content: 'Submit'
+    };
+
+    const result = await recoverFromDrift(mockPage, domCapture);
+
+    expect(result.recovered).toBe(true);
+    expect(result.strategy).toBe('alternative_selector');
+    expect(result.confidence).toBe(0.8);
+    expect(result.new_selector).toBe('#fallback-id');
+  });
+
+  it('should try testid pattern matching', async () => {
+    const allMock = vi.fn().mockResolvedValue([
+      { getAttribute: vi.fn().mockResolvedValue('submit-button-new') }
+    ]);
+
+    mockPage.locator.mockReturnValue({
+      count: vi.fn().mockResolvedValue(0),
+      all: allMock
+    });
+
+    const domCapture = {
+      primary_selector: '[data-testid="submit-button-v1"]',
+      alternative_selectors: [],
+      tag_name: 'button',
+      attributes: { 'data-testid': 'submit-button-v1' }
+    };
+
+    const result = await recoverFromDrift(mockPage, domCapture);
+
+    // Should find partial match
+    expect(result.alternatives_tried).toBeGreaterThan(0);
+  });
+
+  it('should return not recovered when all strategies fail', async () => {
+    mockPage.locator.mockReturnValue({
+      count: vi.fn().mockResolvedValue(0),
+      all: vi.fn().mockResolvedValue([])
+    });
+    mockPage.evaluate.mockResolvedValue(null);
+
+    const domCapture = {
+      primary_selector: '[data-testid="completely-removed"]',
+      alternative_selectors: [],
+      tag_name: 'button',
+      text_content: 'Nonexistent',
+      attributes: {}
+    };
+
+    const result = await recoverFromDrift(mockPage, domCapture);
+
+    expect(result.recovered).toBe(false);
+    expect(result.new_selector).toBeNull();
+    expect(result.confidence).toBe(0);
+    expect(result.message).toContain('Manual intervention required');
+  });
+});
+
+// ============================================================================
+// logDriftRecovery TESTS
+// ============================================================================
+describe('logDriftRecovery', () => {
+  it('should log successful recovery', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = {
+      recovered: true,
+      original_selector: '[data-testid="old"]',
+      new_selector: '#fallback',
+      confidence: 0.8,
+      strategy: 'alternative_selector'
+    };
+
+    logDriftRecovery(result);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('alternative_selector'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('80%'));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should log failed recovery', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const result = {
+      recovered: false,
+      original_selector: '[data-testid="removed"]',
+      alternatives_tried: 5
+    };
+
+    logDriftRecovery(result);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('failed'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('5 strategies'));
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

SD-LEO-ENH-UAT-DOM-CAPTURE-001: Agentation DOM Capture with Selector Drift Recovery

- **dom-capture.js**: Captures DOM state for UAT scenarios with element metadata (IDs, classes, attributes, positions)
- **screenshot-annotator.js**: Annotates screenshots with element bounding boxes and labels
- **selector-drift-recovery.js**: Handles selector changes between test runs using fuzzy matching and attribute similarity

## Changes

- Added 3 new modules to `lib/uat/`
- Updated `index.js` to export new modules
- Enhanced `result-recorder.js` with DOM capture integration
- Added comprehensive unit tests (all passing)

## Test Plan

- [x] Unit tests for dom-capture.js (218 lines)
- [x] Unit tests for screenshot-annotator.js (112 lines)
- [x] Unit tests for selector-drift-recovery.js (231 lines)
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)