### PR TITLE
fix(gates): enhance SD_START gate with handoff-specific phase validation

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -92,11 +92,11 @@ export class ExecToPlanExecutor extends BaseExecutor {
     const gates = [];
 
     // SD Start Gate - FIRST (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
-    // Ensures CLAUDE_CORE.md is read before any SD work
-    gates.push(createSdStartGate(sd?.sd_key || sd?.id || 'unknown'));
+    // Ensures CLAUDE_CORE.md AND CLAUDE_PLAN.md (destination phase) are read before handoff
+    gates.push(createSdStartGate(sd?.sd_key || sd?.id || 'unknown', 'EXEC-TO-PLAN'));
 
     // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
-    // Ensures agent has read CLAUDE_EXEC.md before proceeding
+    // Validates CLAUDE_PLAN.md was read (destination phase file)
     gates.push(createProtocolFileReadGate('EXEC-TO-PLAN'));
 
     // Prerequisite handoff check

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -60,11 +60,11 @@ export class LeadToPlanExecutor extends BaseExecutor {
     const gates = [];
 
     // SD Start Gate - FIRST (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
-    // Ensures CLAUDE_CORE.md is read before any SD work
-    gates.push(createSdStartGate(sd?.sd_key || sd?.id || 'unknown'));
+    // Ensures CLAUDE_CORE.md AND CLAUDE_PLAN.md (destination phase) are read before handoff
+    gates.push(createSdStartGate(sd?.sd_key || sd?.id || 'unknown', 'LEAD-TO-PLAN'));
 
     // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
-    // Ensures agent has read CLAUDE_LEAD.md before proceeding
+    // Validates CLAUDE_PLAN.md was read (destination phase file)
     gates.push(createProtocolFileReadGate('LEAD-TO-PLAN'));
 
     // SD Transition Readiness Gate

--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -94,11 +94,11 @@ export class PlanToExecExecutor extends BaseExecutor {
     const parentOrchestrator = options._isParentOrchestrator;
 
     // SD Start Gate - FIRST (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
-    // Ensures CLAUDE_CORE.md is read before any SD work
-    gates.push(createSdStartGate(sd?.sd_key || sd?.id || 'unknown'));
+    // Ensures CLAUDE_CORE.md AND CLAUDE_EXEC.md (destination phase) are read before handoff
+    gates.push(createSdStartGate(sd?.sd_key || sd?.id || 'unknown', 'PLAN-TO-EXEC'));
 
     // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
-    // Ensures agent has read CLAUDE_PLAN.md before proceeding
+    // Validates CLAUDE_EXEC.md was read (destination phase file)
     gates.push(createProtocolFileReadGate('PLAN-TO-EXEC'));
 
     // Prerequisite handoff check (always first after protocol read)

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -13,6 +13,9 @@ import { isInfrastructureSDSync } from '../../../sd-type-checker.js';
 // Core Protocol Gate - SD Start Gate (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
 import { createSdStartGate } from '../../gates/core-protocol-gate.js';
 
+// Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
+import { createProtocolFileReadGate } from '../../gates/protocol-file-read-gate.js';
+
 // Gate creators
 import {
   createPrerequisiteCheckGate,
@@ -62,8 +65,12 @@ export class PlanToLeadExecutor extends BaseExecutor {
     const appPath = options._appPath;
 
     // SD Start Gate - FIRST (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
-    // Ensures CLAUDE_CORE.md is read before any SD work
-    gates.push(createSdStartGate(sd?.sd_key || sd?.id || 'unknown'));
+    // Ensures CLAUDE_CORE.md AND CLAUDE_LEAD.md (destination phase) are read before handoff
+    gates.push(createSdStartGate(sd?.sd_key || sd?.id || 'unknown', 'PLAN-TO-LEAD'));
+
+    // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
+    // Validates CLAUDE_LEAD.md was read (destination phase file)
+    gates.push(createProtocolFileReadGate('PLAN-TO-LEAD'));
 
     // Prerequisite handoff check
     gates.push(createPrerequisiteCheckGate(this.supabase));

--- a/scripts/modules/handoff/gates/protocol-file-read-gate.js
+++ b/scripts/modules/handoff/gates/protocol-file-read-gate.js
@@ -21,11 +21,13 @@ const SESSION_STATE_FILE = path.join(PROJECT_DIR, '.claude', 'unified-session-st
 
 /**
  * Handoff type to required protocol file mapping
+ * Maps to the DESTINATION phase's protocol file (the phase you're going TO)
  */
 const HANDOFF_FILE_REQUIREMENTS = {
-  'LEAD-TO-PLAN': 'CLAUDE_LEAD.md',
-  'PLAN-TO-EXEC': 'CLAUDE_PLAN.md',
-  'EXEC-TO-PLAN': 'CLAUDE_EXEC.md'
+  'LEAD-TO-PLAN': 'CLAUDE_PLAN.md',   // Going TO Plan phase
+  'PLAN-TO-EXEC': 'CLAUDE_EXEC.md',   // Going TO Exec phase
+  'EXEC-TO-PLAN': 'CLAUDE_PLAN.md',   // Going back TO Plan phase
+  'PLAN-TO-LEAD': 'CLAUDE_LEAD.md'    // Going TO Lead phase (final approval)
 };
 
 /**


### PR DESCRIPTION
## Summary

Enhanced the protocol file validation system to enforce **destination phase file** reading at each handoff boundary. This ensures agents load the correct phase-specific instructions before transitioning between LEO phases.

**Key Changes:**
- Added `HANDOFF_PHASE_FILES` constant mapping handoff types to destination phase protocol files
- Enhanced `validateSdStartGate()` to accept optional `handoffType` parameter
- Updated `createSdStartGate()` to include phase-specific files in validation
- Fixed all handoff executors to pass handoff type during gate creation
- Corrected `protocol-file-read-gate.js` mappings to use **destination** files (not source)
- Updated documentation (session-start-gate-implementation.md) with v1.2.0 changes

**Handoff Validation Matrix:**

| Handoff | Required Files |
|---------|----------------|
| LEAD→PLAN | CLAUDE.md, CLAUDE_CORE.md, **CLAUDE_PLAN.md** |
| PLAN→EXEC | CLAUDE.md, CLAUDE_CORE.md, **CLAUDE_EXEC.md** |
| EXEC→PLAN | CLAUDE.md, CLAUDE_CORE.md, **CLAUDE_PLAN.md** |
| PLAN→LEAD | CLAUDE.md, CLAUDE_CORE.md, **CLAUDE_LEAD.md** |

## Test Plan

- [x] Code compiles without errors
- [x] Enhanced gate logic validates destination phase files
- [x] All handoff executors updated (lead-to-plan, plan-to-exec, exec-to-plan, plan-to-lead)
- [x] Documentation updated with v1.2.0 changelog
- [ ] Manual verification: Run handoff and confirm destination file validation in gate output

## Related

- **SD**: SD-LEO-FIX-PHASE0-INTEGRATION-001
- **Files Modified**: 7 files (6 code + 1 doc)
- **Documentation**: docs/reference/session-start-gate-implementation.md (v1.2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)