### PR TITLE
feat(SD-LEO-FIX-DESIGN-TOKENS-001): add three-tier design tokens configuration

### DIFF
--- a/config/ehg-design-tokens.json
+++ b/config/ehg-design-tokens.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": "1.0.0",
+  "description": "EHG Design Tokens - Three-tier token hierarchy for consistent design language",
+  "sd": "SD-LEO-FIX-DESIGN-TOKENS-001",
+
+  "brand": {
+    "--ehg-brand-primary": "#2563eb",
+    "--ehg-brand-primary-dark": "#1d4ed8",
+    "--ehg-brand-primary-light": "#3b82f6",
+    "--ehg-brand-secondary": "#64748b",
+    "--ehg-brand-secondary-dark": "#475569",
+    "--ehg-brand-secondary-light": "#94a3b8",
+    "--ehg-brand-accent": "#8b5cf6",
+    "--ehg-brand-accent-dark": "#7c3aed",
+    "--ehg-brand-accent-light": "#a78bfa"
+  },
+
+  "semantic": {
+    "--color-primary": "var(--ehg-brand-primary)",
+    "--color-primary-hover": "var(--ehg-brand-primary-dark)",
+    "--color-secondary": "var(--ehg-brand-secondary)",
+    "--color-accent": "var(--ehg-brand-accent)",
+
+    "--color-success": "#22c55e",
+    "--color-success-light": "#86efac",
+    "--color-warning": "#f59e0b",
+    "--color-warning-light": "#fcd34d",
+    "--color-error": "#ef4444",
+    "--color-error-light": "#fca5a5",
+    "--color-info": "#3b82f6",
+    "--color-info-light": "#93c5fd",
+
+    "--color-text-primary": "#1e293b",
+    "--color-text-secondary": "#64748b",
+    "--color-text-muted": "#94a3b8",
+    "--color-text-inverse": "#ffffff",
+
+    "--color-background": "#ffffff",
+    "--color-background-secondary": "#f8fafc",
+    "--color-background-tertiary": "#f1f5f9",
+
+    "--color-border": "#e2e8f0",
+    "--color-border-light": "#f1f5f9",
+    "--color-border-dark": "#cbd5e1",
+
+    "--spacing-xs": "0.25rem",
+    "--spacing-sm": "0.5rem",
+    "--spacing-md": "1rem",
+    "--spacing-lg": "1.5rem",
+    "--spacing-xl": "2rem",
+    "--spacing-2xl": "3rem",
+
+    "--radius-sm": "0.25rem",
+    "--radius-md": "0.375rem",
+    "--radius-lg": "0.5rem",
+    "--radius-xl": "0.75rem",
+    "--radius-full": "9999px",
+
+    "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+    "--shadow-md": "0 4px 6px -1px rgb(0 0 0 / 0.1)",
+    "--shadow-lg": "0 10px 15px -3px rgb(0 0 0 / 0.1)"
+  },
+
+  "component": {
+    "--button-bg": "var(--color-primary)",
+    "--button-bg-hover": "var(--color-primary-hover)",
+    "--button-text": "var(--color-text-inverse)",
+    "--button-border-radius": "var(--radius-md)",
+    "--button-padding": "var(--spacing-sm) var(--spacing-md)",
+
+    "--button-secondary-bg": "var(--color-background)",
+    "--button-secondary-border": "var(--color-border)",
+    "--button-secondary-text": "var(--color-text-primary)",
+
+    "--card-bg": "var(--color-background)",
+    "--card-border": "1px solid var(--color-border)",
+    "--card-border-radius": "var(--radius-lg)",
+    "--card-padding": "var(--spacing-lg)",
+    "--card-shadow": "var(--shadow-sm)",
+
+    "--input-bg": "var(--color-background)",
+    "--input-border": "var(--color-border)",
+    "--input-border-focus": "var(--color-primary)",
+    "--input-border-radius": "var(--radius-md)",
+    "--input-padding": "var(--spacing-sm) var(--spacing-md)",
+
+    "--nav-bg": "var(--color-background)",
+    "--nav-border": "var(--color-border)",
+    "--nav-link-color": "var(--color-text-secondary)",
+    "--nav-link-hover": "var(--color-primary)",
+    "--nav-link-active": "var(--color-primary)",
+
+    "--badge-success-bg": "var(--color-success-light)",
+    "--badge-success-text": "#166534",
+    "--badge-warning-bg": "var(--color-warning-light)",
+    "--badge-warning-text": "#92400e",
+    "--badge-error-bg": "var(--color-error-light)",
+    "--badge-error-text": "#991b1b",
+    "--badge-info-bg": "var(--color-info-light)",
+    "--badge-info-text": "#1e40af"
+  }
+}


### PR DESCRIPTION
## Summary
- Create `config/ehg-design-tokens.json` with three-tier token hierarchy
- **Brand tier**: 9 core brand colors (primary, secondary, accent with dark/light variants)
- **Semantic tier**: 36 tokens (colors, spacing, radius, shadows)
- **Component tier**: 31 tokens (button, card, input, nav, badge)

## Implementation Details
Tokens follow CSS custom property naming convention (`--ehg-brand-*`, `--color-*`, `--button-*`, etc.) and support variable references for consistent theming:
- Brand → Semantic references: `"--color-primary": "var(--ehg-brand-primary)"`
- Semantic → Component references: `"--button-bg": "var(--color-primary)"`

## Test plan
- [x] Validate JSON structure
- [x] Verify three-tier hierarchy exists (brand, semantic, component)
- [x] Confirm token count: 9 brand + 36 semantic + 31 component = 76 total

Part of SD-LEO-ORCH-SYNERGY-REMEDIATION-001 (Child C: Design Tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)