### PR TITLE
fix(SD-LEO-FIX-NORMALIZE-UUID-SUB-001): normalize SD ID to UUID in sub-agent storage

### DIFF
--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -13,6 +13,8 @@
 import { getSupabaseClient } from './supabase-client.js';
 import { USE_TASK_CONTRACTS, RESULT_COMPRESSION_THRESHOLD, PRD_LINKABLE_SUBAGENTS } from './constants.js';
 import { createArtifact } from '../artifact-tools.js';
+// SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Import normalizeSDId to fix FK constraint violation (PAT-FK-SDKEY-001)
+import { normalizeSDId } from '../../scripts/modules/sd-id-normalizer.js';
 
 /**
  * Normalize confidence value from sub-agent results
@@ -138,6 +140,23 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
 
   const supabase = await getSupabaseClient();
 
+  // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Normalize sd_id to UUID before insert
+  // PAT-FK-SDKEY-001: sub_agent_execution_results.sd_id FK expects UUID, not sd_key
+  let normalizedSdId = sdId;
+  if (sdId) {
+    const resolvedId = await normalizeSDId(supabase, sdId);
+    if (resolvedId) {
+      if (resolvedId !== sdId) {
+        console.log(`   [SD-ID] Normalized: "${sdId}" -> "${resolvedId}"`);
+      }
+      normalizedSdId = resolvedId;
+    } else {
+      // If normalization fails, log warning but continue with original
+      // This allows storage even if SD doesn't exist (edge case)
+      console.warn(`   [SD-ID] Warning: Could not normalize "${sdId}" - using as-is`);
+    }
+  }
+
   // Convert milliseconds to seconds for execution_time column
   const executionTimeSec = results.execution_time_ms
     ? Math.round(results.execution_time_ms / 1000)
@@ -233,7 +252,7 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   }
 
   const record = {
-    sd_id: sdId,
+    sd_id: normalizedSdId,  // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Use normalized UUID
     sub_agent_code: code,
     sub_agent_name: subAgent?.name || code,
     verdict: mappedVerdict,

--- a/lib/sub-agents/regression.js
+++ b/lib/sub-agents/regression.js
@@ -18,6 +18,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import { createSupabaseServiceClient } from '../../scripts/lib/supabase-connection.js';
+// SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Import normalizeSDId to fix FK constraint violation (PAT-FK-SDKEY-001)
+import { normalizeSDId } from '../../scripts/modules/sd-id-normalizer.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -729,9 +731,25 @@ async function storeResults(sdId, results) {
   if (!supabase) return;
 
   try {
+    // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Normalize sd_id to UUID before insert
+    // PAT-FK-SDKEY-001: sub_agent_execution_results.sd_id FK expects UUID, not sd_key
+    let normalizedSdId = sdId;
+    if (sdId) {
+      const resolvedId = await normalizeSDId(supabase, sdId);
+      if (resolvedId) {
+        if (resolvedId !== sdId) {
+          console.log(`   [SD-ID] Normalized: "${sdId}" -> "${resolvedId}"`);
+        }
+        normalizedSdId = resolvedId;
+      } else {
+        console.warn(`   [SD-ID] Warning: Could not normalize "${sdId}" - using null`);
+        normalizedSdId = null;
+      }
+    }
+
     // Store in sub_agent_execution_results
     await supabase.from('sub_agent_execution_results').insert({
-      sd_id: sdId,
+      sd_id: normalizedSdId,
       sub_agent_code: 'REGRESSION',
       verdict: results.verdict,
       confidence_score: results.confidence,


### PR DESCRIPTION
## Summary
- Fixes PAT-FK-SDKEY-001: FK constraint violation when storing sub-agent execution results
- Adds `normalizeSDId()` call before database inserts to resolve sd_key to uuid_id
- Applied to: results-storage.js, regression.js, task-subagent-recorder.cjs

## Problem
The `sub_agent_execution_results.sd_id` column has a foreign key to `strategic_directives_v2.uuid_id` (UUID type), but code was passing `sd_key` strings (e.g., "SD-LEO-001"), causing:
```
violates foreign key constraint "sub_agent_execution_results_sd_id_fkey"
```

## Solution
Import and use `normalizeSDId(supabase, sdId)` which:
1. Checks if input is already a valid UUID → returns as-is
2. Otherwise queries `strategic_directives_v2` to resolve sd_key → uuid_id
3. Returns normalized UUID for database insert

## Test plan
- [x] Smoke tests pass
- [x] Gate 0 validation passed
- [ ] Manual: Run sub-agent, verify no FK constraint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)