### PR TITLE
fix(SD-LEO-FIX-NORMALIZE-UUID-SUB-001): normalize SD ID in orchestrator paths

### DIFF
--- a/scripts/modules/orchestrator/subagent-execution.js
+++ b/scripts/modules/orchestrator/subagent-execution.js
@@ -10,6 +10,8 @@
 
 import { executeSubAgent as realExecuteSubAgent } from '../../../lib/sub-agent-executor.js';
 import { safeInsert, generateUUID } from '../safe-insert.js';
+// SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Import normalizeSDId to fix FK constraint violation (PAT-FK-SDKEY-001)
+import { normalizeSDId } from '../sd-id-normalizer.js';
 
 /**
  * Ensure detailed_analysis is always a string (TEXT column requirement)
@@ -151,10 +153,27 @@ export async function verifyExecutionRecorded(recordId, supabase) {
 export async function storeSubAgentResult(sdId, result, supabase) {
   console.log(`      Recording ${result.sub_agent_code} execution...`);
 
+  // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Normalize sd_id to UUID before insert
+  // PAT-FK-SDKEY-001: sub_agent_execution_results.sd_id FK expects UUID, not sd_key
+  let normalizedSdId = sdId;
+  if (sdId) {
+    const resolvedId = await normalizeSDId(supabase, sdId);
+    if (resolvedId) {
+      if (resolvedId !== sdId) {
+        console.log(`      [SD-ID] Normalized: "${sdId}" -> "${resolvedId}"`);
+      }
+      normalizedSdId = resolvedId;
+    } else {
+      // If normalization fails, set to null to avoid FK violation
+      console.warn(`      [SD-ID] Warning: Could not normalize "${sdId}" - setting to null`);
+      normalizedSdId = null;
+    }
+  }
+
   // Prepare data for insert
   const insertData = {
     id: generateUUID(),
-    sd_id: sdId,
+    sd_id: normalizedSdId,  // SD-LEO-FIX-NORMALIZE-UUID-SUB-001: Use normalized UUID
     sub_agent_code: result.sub_agent_code,
     sub_agent_name: result.sub_agent_name,
     verdict: result.verdict,


### PR DESCRIPTION
## Summary
- Additional fix for PAT-FK-SDKEY-001 - found two more code paths that insert into `sub_agent_execution_results` without normalizing the SD ID
- Both orchestrator files now import `normalizeSDId` and convert sd_key to UUID before insert

## Files Changed
- `scripts/modules/orchestrator/subagent-execution.js`
- `scripts/modules/phase-subagent-orchestrator/execution.js`

## Test plan
- [x] Verified normalization logs appear during handoff execution
- [x] Sub-agent orchestration passed (FK constraint no longer violated)
- [ ] Full handoff workflow validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)