### PR TITLE
feat(sd-key-generator): enforce CLAUDE_LEAD.md complete read before SD creation

### DIFF
--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -676,6 +676,31 @@ node scripts/handoff.js precheck PLAN-TO-EXEC SD-XXX-001
 
 ### SDKeyGenerator Errors (SD-LEO-SDKEY-001)
 
+#### Error: `CLAUDE_LEAD.md has not been read in this session` (SD-LEO-SDKEY-ENFORCE-LEAD-READ-001)
+
+**Cause**: Attempting to generate an SD key without first reading CLAUDE_LEAD.md completely
+**Solution**: Read CLAUDE_LEAD.md in full (without limit parameter) before generating SD keys
+
+```bash
+# Check if CLAUDE_LEAD.md has been read
+node scripts/modules/sd-key-generator.js --check-lead
+
+# The Read tool must be used WITHOUT limit parameter:
+# CORRECT: Read tool with file_path="CLAUDE_LEAD.md"
+# WRONG: Read tool with file_path="CLAUDE_LEAD.md" and limit=200
+```
+
+**Why This Enforcement Exists**:
+- CLAUDE_LEAD.md contains critical SD field requirements (lines 370-476)
+- Success criteria/metrics structure is documented (lines 399-415)
+- SD type-specific requirements are explained (lines 417-430)
+- Partial reads miss late-document content like error handling (lines 552-823)
+
+**Emergency Bypass** (not recommended):
+```bash
+node scripts/modules/sd-key-generator.js --skip-validation LEO feature "Title"
+```
+
 #### Error: `Invalid SD type` or `new value for domain sd_type violates check constraint`
 
 **Cause**: Using user-friendly type names that don't match database constraint


### PR DESCRIPTION
## Summary

- Add validation to SDKeyGenerator that blocks SD key generation if CLAUDE_LEAD.md has not been fully read
- Detect partial reads (when `limit`/`offset` parameters were used on the Read tool)
- Block with clear remediation instructions showing which sections may be missing
- Add `--check-lead` CLI option to verify read status
- Add `--skip-validation` CLI option for emergencies
- Document new error in CLAUDE_LEAD.md SDKeyGenerator Errors section

## Why This Change

When creating Strategic Directives, Claude needs to be familiar with:
- Required SD fields (sd_key, title, description, rationale, etc.)
- Success criteria/metrics structure
- SD type-specific requirements
- Handoff validation gates

Without reading CLAUDE_LEAD.md completely, critical requirements in later sections (lines 370-823) may be missed, causing SD creation errors.

## Test Plan

- [ ] Run `node scripts/modules/sd-key-generator.js --check-lead` to verify validation works
- [ ] Test that key generation blocks when CLAUDE_LEAD.md hasn't been read
- [ ] Test that partial reads are detected and blocked
- [ ] Verify `--skip-validation` bypass works for emergencies

Part of SD-LEO-SDKEY-ENFORCE-LEAD-READ-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)