### PR TITLE
refactor(SD-LEO-INFRA-DEPRECATE-UAT-DEFECTS-001): deprecate uat_defects in favor of unified feedback

### DIFF
--- a/docs/reference/schema/engineer/tables/uat_defects.md
+++ b/docs/reference/schema/engineer/tables/uat_defects.md
@@ -1,5 +1,9 @@
 # uat_defects Table
 
+> ⚠️ **DEPRECATED**: This table is deprecated as of SD-LEO-INFRA-DEPRECATE-UAT-DEFECTS-001.
+> All UAT defects now write to the unified `feedback` table with `source_type='uat_failure'`.
+> See [Quality Lifecycle Workflow](../../workflow/quality-lifecycle-workflow.md) for the unified feedback approach.
+
 **Application**: EHG_Engineer - LEO Protocol Management Dashboard - CONSOLIDATED DB
 **Database**: dedlbzhpgkmetvhbkyzq
 **Repository**: EHG_Engineer (this repository)
@@ -11,6 +15,17 @@
 ⚠️ **This is a REFERENCE document** - Query database directly for validation
 
 ⚠️ **CRITICAL**: This schema is for **EHG_Engineer** database. Implementations go in EHG_Engineer (this repository)
+
+⚠️ **MIGRATION NOTE**: Use `feedback` table with the following field mappings:
+| uat_defects field | feedback field |
+|-------------------|----------------|
+| run_id | metadata.test_run_id |
+| case_id | metadata.case_id |
+| severity (critical/major/minor) | severity (high/medium/low) |
+| summary | title |
+| description | description |
+| status (open) | status (new) |
+| source | source_type='uat_failure' |
 
 ---
 

--- a/lib/agents/uat-sub-agent.js
+++ b/lib/agents/uat-sub-agent.js
@@ -330,21 +330,33 @@ class UATSubAgent extends IntelligentBaseSubAgent {
 
   /**
    * Create defect for failed test
+   * SD-LEO-INFRA-DEPRECATE-UAT-DEFECTS-001: Write to unified feedback table
    */
   async createDefect(notes) {
+    const severity = this.context.testCase.priority === 'critical' ? 'high' : 'medium';
     const { error } = await supabase
-      .from('uat_defects')
+      .from('feedback')
       .insert({
-        run_id: this.context.runId,
-        case_id: this.context.caseId,
-        severity: this.context.testCase.priority === 'critical' ? 'critical' : 'major',
-        summary: `${this.context.testCase.title} failed`,
+        type: 'issue',
+        title: `UAT Failure: ${this.context.testCase.title}`,
         description: notes,
-        created_at: new Date().toISOString()
+        severity: severity,
+        priority: severity === 'high' ? 'P1' : 'P2',
+        status: 'new',
+        source_type: 'uat_failure',
+        source_application: 'EHG_Engineer',
+        metadata: {
+          run_id: this.context.runId,
+          case_id: this.context.caseId,
+          test_section: this.context.testCase.section,
+          test_priority: this.context.testCase.priority
+        },
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
       });
 
     if (!error) {
-      console.log(chalk.yellow('🐛 Defect logged for tracking'));
+      console.log(chalk.yellow('🐛 Defect logged to feedback table for tracking'));
     }
   }
 

--- a/lib/uat/result-recorder.js
+++ b/lib/uat/result-recorder.js
@@ -261,24 +261,6 @@ async function recordDefect(testRunId, scenario, details) {
       updated_at: new Date().toISOString()
     });
     console.log('   Recorded UAT failure to feedback table');
-  } catch (feedbackError) {
-    // Non-blocking - log but continue
-    console.log('   Note: Could not record to feedback table:', feedbackError.message);
-  }
-
-  // Legacy: Also try uat_defects table for backward compatibility
-  try {
-    await db.from('uat_defects').insert({
-      test_run_id: testRunId,
-      title: `${scenario.title} - ${failureType || 'Failure'}`,
-      description: errorMessage,
-      severity: severityLevel,
-      status: 'open',
-      scenario_id: scenario.id,
-      failure_type: failureType,
-      estimated_loc: estimatedLOC,
-      created_at: new Date().toISOString()
-    });
 
     // Update defect count on test run
     const { data: run } = await db
@@ -293,10 +275,12 @@ async function recordDefect(testRunId, scenario, details) {
         .update({ defects_found: (run.defects_found || 0) + 1 })
         .eq('id', testRunId);
     }
-  } catch {
-    // Table may not exist - non-blocking
-    console.log('   Note: Could not record to uat_defects table');
+  } catch (feedbackError) {
+    // Non-blocking - log but continue
+    console.log('   Note: Could not record to feedback table:', feedbackError.message);
   }
+  // SD-LEO-INFRA-DEPRECATE-UAT-DEFECTS-001: Removed legacy uat_defects fallback
+  // All UAT defects now write exclusively to the unified feedback table
 }
 
 /**


### PR DESCRIPTION
## Summary

- Update uat-sub-agent.js to write defects to feedback table instead of uat_defects
- Remove legacy uat_defects fallback from result-recorder.js
- Update getOpenDefects() in handlers.ts to query feedback table with field mapping
- Add deprecation notice and field mapping table to uat_defects schema documentation
- Add TypeScript interfaces for proper typing

All UAT failures now write exclusively to feedback table with `source_type='uat_failure'` per Quality Lifecycle System design.

## Test plan

- [x] Verify uat-sub-agent.js writes to feedback table
- [x] Verify result-recorder.js no longer has uat_defects fallback
- [x] Verify getOpenDefects() queries feedback table correctly
- [x] Verify schema documentation includes deprecation notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)