### PR TITLE
feat(SD-LEO-INFRA-PLAN-AWARE-SD-CREATION-001): add --from-plan flag to /leo create

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -356,6 +356,24 @@ node scripts/modules/sd-key-generator.js LEO <type> "<title>"
   node scripts/modules/sd-key-generator.js --child <parent-key> <index>
   ```
 
+- `create --from-plan [path]`: Create from Claude Code plan file
+  ```bash
+  # Auto-detect most recent plan in ~/.claude/plans/
+  node scripts/leo-create-sd.js --from-plan
+
+  # Use specific plan file
+  node scripts/leo-create-sd.js --from-plan ~/.claude/plans/my-plan.md
+  ```
+
+  This extracts from the plan:
+  - **Title** from `# Plan: Title` or first `# Heading`
+  - **Summary/Description** from `## Goal` or `## Summary` section
+  - **Success Criteria** from `- [ ]` checklist items (max 10)
+  - **Scope** from file modification tables
+  - **SD Type** inferred from content keywords (security, bug, refactor, infrastructure, documentation → appropriate type)
+
+  The original plan is archived to `docs/plans/archived/{sd-key}-plan.md` for reference.
+
 After generating the key, create the SD in database with initial fields:
 - status: 'draft'
 - current_phase: 'LEAD'
@@ -723,6 +741,7 @@ SD Creation Flags:
   /leo create --from-uat <id>    - Create from UAT finding
   /leo create --from-learn <id>  - Create from /learn pattern
   /leo create --from-feedback <id> - Create from /inbox item
+  /leo create --from-plan [path] - Create from Claude Code plan file
   /leo create --child <parent>   - Create child SD
 
 Quick-Fix vs SD:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,7 +435,7 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 ```
 
 ## DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2026-01-31 8:13:13 AM
+**Last Generated**: 2026-01-31 8:34:04 AM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-01-31 8:13:13 AM
+**Generated**: 2026-01-31 8:34:04 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions (15-20k chars)
 

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-01-31 8:13:13 AM
+**Generated**: 2026-01-31 8:34:04 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing (20-25k chars)
 

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-01-31 8:13:13 AM
+**Generated**: 2026-01-31 8:34:04 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 
@@ -377,10 +377,43 @@ Strategic Directives (SDs) are the primary unit of work in the LEO Protocol. Thi
 
 **MANDATORY**: Use process scripts - never create SDs manually in the database.
 
+#### Option A: Direct SD Creation
 ```bash
 # Create a new Strategic Directive
 node scripts/add-sd-to-database.js --sd-id SD-XXX-001 --title "Your SD Title"
 ```
+
+#### Option B: Create from Claude Code Plan (NEW)
+
+When working in Claude Code plan mode, create SDs directly from plan files:
+
+```bash
+# Auto-detect most recent plan (prompts for confirmation)
+node scripts/leo-create-sd.js --from-plan
+
+# Auto-detect without confirmation
+node scripts/leo-create-sd.js --from-plan --yes
+
+# Use specific plan file
+node scripts/leo-create-sd.js --from-plan ~/.claude/plans/my-plan.md
+```
+
+**What --from-plan does:**
+- Parses plan file to extract title, goal, steps, and file modifications
+- Infers SD type from plan content keywords (security, bug, refactor, etc.)
+- Archives original plan to `docs/plans/archived/{sd-key}-plan.md`
+- Populates SD fields: title, description, scope, success_criteria, key_changes, strategic_objectives, risks
+- Stores full plan content in `metadata.plan_content` for reference
+
+**Plan Parsing:**
+- **Title**: Extracted from `# Plan: Title` or first `# Heading`
+- **Summary**: From `## Goal` or `## Summary` section
+- **Success Criteria**: From `- [ ]` checklist items (max 10)
+- **Scope**: From file modification tables (`| path | ACTION |`)
+- **Key Changes**: From implementation sections and file tables
+- **Risks**: From `## Risks` or `## Concerns` sections
+
+**Related Modules**: `scripts/modules/plan-parser.js`, `scripts/modules/plan-archiver.js`
 
 ### Required Fields (ALL SDs)
 
@@ -472,7 +505,8 @@ node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
 - **Field Reference**: `docs/database/strategic_directives_v2_field_reference.md`
 - **Handoff System**: `docs/reference/handoff-system-guide.md`
 - **Schema Mapping**: `docs/reference/strategic-directives-v2-schema.md`
-- **Process Scripts**: `scripts/add-sd-to-database.js`, `scripts/handoff.js`
+- **Process Scripts**: `scripts/add-sd-to-database.js`, `scripts/handoff.js`, `scripts/leo-create-sd.js`
+- **Plan-Aware Creation**: `docs/reference/sd-key-generator-guide.md` (--from-plan section)
 
 ## Common SD Creation Errors and Solutions
 

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-01-31 8:13:13 AM
+**Generated**: 2026-01-31 8:34:04 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates (30-35k chars)
 

--- a/docs/plans/archived/.gitkeep
+++ b/docs/plans/archived/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the archived plans directory is tracked by git
+# Plan files are archived here when creating SDs from Claude Code plans

--- a/scripts/modules/plan-archiver.js
+++ b/scripts/modules/plan-archiver.js
@@ -1,0 +1,206 @@
+/**
+ * Plan Archiver Module
+ *
+ * Archives Claude Code plan files to permanent locations and finds recent plans.
+ * Part of SD-LEO-INFRA-PLAN-AWARE-SD-CREATION feature.
+ *
+ * @module scripts/modules/plan-archiver
+ */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * Default archive directory for plan files
+ */
+export const ARCHIVE_DIR = path.join(process.cwd(), 'docs', 'plans', 'archived');
+
+/**
+ * Default Claude Code plans directory
+ */
+export const CLAUDE_PLANS_DIR = path.join(os.homedir(), '.claude', 'plans');
+
+/**
+ * Find the most recently modified plan file in a directory
+ *
+ * @param {string} plansDir - Directory to search (defaults to ~/.claude/plans/)
+ * @returns {Promise<{path: string, mtime: Date}|null>} Most recent plan or null
+ */
+export async function findMostRecentPlan(plansDir = CLAUDE_PLANS_DIR) {
+  try {
+    // Check if directory exists
+    if (!fs.existsSync(plansDir)) {
+      console.log(`[PlanArchiver] Plans directory not found: ${plansDir}`);
+      return null;
+    }
+
+    // Read all files in directory
+    const files = fs.readdirSync(plansDir);
+
+    // Filter to .md files and get stats
+    const planFiles = [];
+    for (const file of files) {
+      if (file.endsWith('.md')) {
+        const filePath = path.join(plansDir, file);
+        try {
+          const stat = fs.statSync(filePath);
+          planFiles.push({
+            path: filePath,
+            mtime: stat.mtime,
+            name: file
+          });
+        } catch {
+          // Skip files we can't stat
+        }
+      }
+    }
+
+    if (planFiles.length === 0) {
+      console.log('[PlanArchiver] No .md plan files found');
+      return null;
+    }
+
+    // Sort by modification time descending
+    planFiles.sort((a, b) => b.mtime.getTime() - a.mtime.getTime());
+
+    const mostRecent = planFiles[0];
+    console.log(`[PlanArchiver] Most recent plan: ${mostRecent.name} (${mostRecent.mtime.toISOString()})`);
+
+    return {
+      path: mostRecent.path,
+      mtime: mostRecent.mtime,
+      name: mostRecent.name
+    };
+  } catch (error) {
+    console.error('[PlanArchiver] Error finding recent plan:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Ensure archive directory exists
+ *
+ * @param {string} archiveDir - Archive directory path
+ */
+export function ensureArchiveDir(archiveDir = ARCHIVE_DIR) {
+  if (!fs.existsSync(archiveDir)) {
+    fs.mkdirSync(archiveDir, { recursive: true });
+    console.log(`[PlanArchiver] Created archive directory: ${archiveDir}`);
+  }
+}
+
+/**
+ * Archive a plan file to permanent location
+ *
+ * @param {string} sourcePath - Path to source plan file
+ * @param {string} sdKey - SD key for naming the archived file
+ * @param {string} archiveDir - Archive directory (defaults to docs/plans/archived/)
+ * @returns {Promise<{success: boolean, archivedPath: string|null, error: string|null}>}
+ */
+export async function archivePlanFile(sourcePath, sdKey, archiveDir = ARCHIVE_DIR) {
+  try {
+    // Validate source exists
+    if (!fs.existsSync(sourcePath)) {
+      return {
+        success: false,
+        archivedPath: null,
+        error: `Source file not found: ${sourcePath}`
+      };
+    }
+
+    // Ensure archive directory exists
+    ensureArchiveDir(archiveDir);
+
+    // Generate archive filename
+    const sanitizedKey = sdKey.replace(/[^a-zA-Z0-9-]/g, '-').toLowerCase();
+    const archiveFileName = `${sanitizedKey}-plan.md`;
+    const archivedPath = path.join(archiveDir, archiveFileName);
+
+    // Read source content
+    const content = fs.readFileSync(sourcePath, 'utf8');
+
+    // Add archive header
+    const archiveHeader = `<!-- Archived from: ${sourcePath} -->
+<!-- SD Key: ${sdKey} -->
+<!-- Archived at: ${new Date().toISOString()} -->
+
+`;
+
+    // Write to archive
+    fs.writeFileSync(archivedPath, archiveHeader + content, 'utf8');
+
+    console.log(`[PlanArchiver] Archived plan to: ${archivedPath}`);
+
+    return {
+      success: true,
+      archivedPath,
+      error: null
+    };
+  } catch (error) {
+    console.error('[PlanArchiver] Error archiving plan:', error.message);
+    return {
+      success: false,
+      archivedPath: null,
+      error: error.message
+    };
+  }
+}
+
+/**
+ * Read plan file content
+ *
+ * @param {string} planPath - Path to plan file
+ * @returns {string|null} File content or null if error
+ */
+export function readPlanFile(planPath) {
+  try {
+    if (!fs.existsSync(planPath)) {
+      console.error(`[PlanArchiver] Plan file not found: ${planPath}`);
+      return null;
+    }
+
+    let content = fs.readFileSync(planPath, 'utf8');
+
+    // Remove BOM if present
+    if (content.charCodeAt(0) === 0xFEFF) {
+      content = content.slice(1);
+    }
+
+    return content;
+  } catch (error) {
+    console.error('[PlanArchiver] Error reading plan file:', error.message);
+    return null;
+  }
+}
+
+/**
+ * Get relative path for display purposes
+ *
+ * @param {string} absolutePath - Absolute file path
+ * @returns {string} Relative or shortened path
+ */
+export function getDisplayPath(absolutePath) {
+  const home = os.homedir();
+  if (absolutePath.startsWith(home)) {
+    return absolutePath.replace(home, '~');
+  }
+
+  const cwd = process.cwd();
+  if (absolutePath.startsWith(cwd)) {
+    return absolutePath.replace(cwd + path.sep, '');
+  }
+
+  return absolutePath;
+}
+
+// Default export
+export default {
+  ARCHIVE_DIR,
+  CLAUDE_PLANS_DIR,
+  findMostRecentPlan,
+  ensureArchiveDir,
+  archivePlanFile,
+  readPlanFile,
+  getDisplayPath
+};

--- a/scripts/modules/plan-parser.js
+++ b/scripts/modules/plan-parser.js
@@ -1,0 +1,377 @@
+/**
+ * Plan Parser Module
+ *
+ * Parses Claude Code plan files and extracts structured content.
+ * Part of SD-LEO-INFRA-PLAN-AWARE-SD-CREATION feature.
+ *
+ * @module scripts/modules/plan-parser
+ */
+
+/**
+ * Extract title from plan content
+ * Matches patterns like "# Plan: Title" or "# Title"
+ *
+ * @param {string} content - Plan file content
+ * @returns {string|null} Extracted title or null
+ */
+export function extractTitle(content) {
+  if (!content) return null;
+
+  // Try "# Plan: Title" pattern first
+  const planMatch = content.match(/^#\s+Plan:\s*(.+)$/m);
+  if (planMatch) {
+    return planMatch[1].trim();
+  }
+
+  // Fall back to first h1 heading
+  const h1Match = content.match(/^#\s+(.+)$/m);
+  if (h1Match) {
+    return h1Match[1].trim();
+  }
+
+  return null;
+}
+
+/**
+ * Extract summary/goal from plan content
+ * Matches "## Goal", "## Summary", or "## Executive Summary" sections
+ *
+ * @param {string} content - Plan file content
+ * @returns {string|null} Extracted summary or null
+ */
+export function extractSummary(content) {
+  if (!content) return null;
+
+  // Match ## Goal, ## Summary, or ## Executive Summary
+  const sectionPattern = /^##\s+(Goal|Summary|Executive Summary)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|$)/mi;
+  const match = content.match(sectionPattern);
+
+  if (match) {
+    // Clean up the extracted content
+    let summary = match[2].trim();
+    // Remove markdown formatting for cleaner description
+    summary = summary.replace(/\*\*/g, '').replace(/\*/g, '');
+    // Limit to first paragraph or 500 chars
+    const firstPara = summary.split('\n\n')[0];
+    return firstPara.length > 500 ? firstPara.substring(0, 497) + '...' : firstPara;
+  }
+
+  return null;
+}
+
+/**
+ * Extract checklist steps from plan content
+ * Matches "- [ ]" and "- [x]" task items
+ *
+ * @param {string} content - Plan file content
+ * @returns {Array<{text: string, completed: boolean}>} Array of steps
+ */
+export function extractSteps(content) {
+  if (!content) return [];
+
+  const steps = [];
+  // Match both unchecked "- [ ]" and checked "- [x]" items
+  const stepPattern = /^-\s+\[([ xX])\]\s+(.+)$/gm;
+
+  let match;
+  while ((match = stepPattern.exec(content)) !== null) {
+    steps.push({
+      text: match[2].trim(),
+      completed: match[1].toLowerCase() === 'x'
+    });
+  }
+
+  return steps;
+}
+
+/**
+ * Extract file modification table from plan content
+ * Matches markdown tables with file paths and actions
+ *
+ * @param {string} content - Plan file content
+ * @returns {Array<{path: string, action: string, purpose: string}>} Array of files
+ */
+export function extractFiles(content) {
+  if (!content) return [];
+
+  const files = [];
+
+  // Look for table rows with file paths
+  // Pattern: | path | action | purpose | (or variations)
+  const tableRowPattern = /^\|\s*`?([^|`]+)`?\s*\|\s*([^|]+)\s*\|\s*([^|]*)\s*\|$/gm;
+
+  let match;
+  while ((match = tableRowPattern.exec(content)) !== null) {
+    const path = match[1].trim();
+    const action = match[2].trim().toUpperCase();
+    const purpose = match[3]?.trim() || '';
+
+    // Skip header rows and separator rows
+    if (path === 'File' || path === 'path' || path.match(/^-+$/) || action === 'Action' || action.match(/^-+$/)) {
+      continue;
+    }
+
+    // Validate it looks like a file path
+    if (path.includes('/') || path.includes('\\') || path.includes('.')) {
+      files.push({ path, action, purpose });
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Infer SD type from plan content based on keywords
+ *
+ * @param {string} content - Plan file content
+ * @returns {string} Inferred SD type
+ */
+export function inferSDType(content) {
+  if (!content) return 'feature';
+
+  const lowerContent = content.toLowerCase();
+
+  // Check for security-related keywords
+  if (lowerContent.includes('security') ||
+      lowerContent.includes('vulnerability') ||
+      lowerContent.includes('cve') ||
+      lowerContent.includes('authentication') && lowerContent.includes('fix')) {
+    return 'fix'; // Security issues map to fix type
+  }
+
+  // Check for bug/error keywords
+  if (lowerContent.includes('bug') ||
+      lowerContent.includes('error') ||
+      lowerContent.includes('broken') ||
+      lowerContent.includes('failing') ||
+      lowerContent.match(/\bfix\b/)) {
+    return 'fix';
+  }
+
+  // Check for refactoring keywords
+  if (lowerContent.includes('refactor') ||
+      lowerContent.includes('cleanup') ||
+      lowerContent.includes('restructure') ||
+      lowerContent.includes('reorganize')) {
+    return 'refactor';
+  }
+
+  // Check for infrastructure keywords
+  if (lowerContent.includes('infrastructure') ||
+      lowerContent.includes('tooling') ||
+      lowerContent.includes('script') ||
+      lowerContent.includes('ci/cd') ||
+      lowerContent.includes('pipeline') ||
+      lowerContent.includes('automation')) {
+    return 'infrastructure';
+  }
+
+  // Check for documentation keywords
+  if (lowerContent.includes('documentation') ||
+      lowerContent.includes('readme') ||
+      lowerContent.includes('docs')) {
+    return 'documentation';
+  }
+
+  // Default to feature
+  return 'feature';
+}
+
+/**
+ * Extract key changes from plan content
+ * Looks for sections describing what will change
+ *
+ * @param {string} content - Plan file content
+ * @returns {Array<{change: string, impact: string}>} Array of key changes
+ */
+export function extractKeyChanges(content) {
+  if (!content) return [];
+
+  const changes = [];
+
+  // Look for "## Changes" or "## Key Changes" or "## What Changes" sections
+  const changesPattern = /^##\s+(Changes|Key Changes|What Changes|Implementation)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|$)/mi;
+  const match = content.match(changesPattern);
+
+  if (match) {
+    const sectionContent = match[2];
+    // Extract bullet points as changes
+    const bulletPattern = /^[-*]\s+(.+)$/gm;
+    let bulletMatch;
+    while ((bulletMatch = bulletPattern.exec(sectionContent)) !== null) {
+      const changeText = bulletMatch[1].trim();
+      changes.push({
+        change: changeText,
+        impact: 'See plan for details'
+      });
+    }
+  }
+
+  // Also extract from files table as key changes
+  const files = extractFiles(content);
+  files.forEach(f => {
+    changes.push({
+      change: `${f.action}: ${f.path}`,
+      impact: f.purpose || 'File modification'
+    });
+  });
+
+  return changes.slice(0, 10); // Limit to 10
+}
+
+/**
+ * Extract strategic objectives from plan content
+ *
+ * @param {string} content - Plan file content
+ * @returns {Array<{objective: string, metric: string}>} Array of objectives
+ */
+export function extractStrategicObjectives(content) {
+  if (!content) return [];
+
+  const objectives = [];
+
+  // Try to find "## Objectives" or similar sections
+  const objectivesPattern = /^##\s+(Objectives|Strategic Objectives|Goals)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|$)/mi;
+  const match = content.match(objectivesPattern);
+
+  if (match) {
+    const sectionContent = match[2];
+    const bulletPattern = /^[-*]\s+(.+)$/gm;
+    let bulletMatch;
+    while ((bulletMatch = bulletPattern.exec(sectionContent)) !== null) {
+      objectives.push({
+        objective: bulletMatch[1].trim(),
+        metric: 'Completion of objective'
+      });
+    }
+  }
+
+  // If no explicit objectives, derive from goal/summary
+  if (objectives.length === 0) {
+    const summary = extractSummary(content);
+    if (summary) {
+      objectives.push({
+        objective: summary,
+        metric: 'Plan implementation complete'
+      });
+    }
+  }
+
+  return objectives.slice(0, 5); // Limit to 5
+}
+
+/**
+ * Extract risks from plan content
+ *
+ * @param {string} content - Plan file content
+ * @returns {Array<{risk: string, severity: string, mitigation: string}>} Array of risks
+ */
+export function extractRisks(content) {
+  if (!content) return [];
+
+  const risks = [];
+
+  // Look for "## Risks" or "## Concerns" sections
+  const risksPattern = /^##\s+(Risks|Concerns|Considerations|Caveats)\s*\n\n?([\s\S]*?)(?=\n##|\n#\s|$)/mi;
+  const match = content.match(risksPattern);
+
+  if (match) {
+    const sectionContent = match[2];
+    const bulletPattern = /^[-*]\s+(.+)$/gm;
+    let bulletMatch;
+    while ((bulletMatch = bulletPattern.exec(sectionContent)) !== null) {
+      risks.push({
+        risk: bulletMatch[1].trim(),
+        severity: 'medium',
+        mitigation: 'Address during implementation'
+      });
+    }
+  }
+
+  return risks.slice(0, 5); // Limit to 5
+}
+
+/**
+ * Parse a complete plan file and extract all structured content
+ *
+ * @param {string} content - Plan file content
+ * @returns {Object} Parsed plan with title, summary, steps, files, type, and fullContent
+ */
+export function parsePlanFile(content) {
+  if (!content) {
+    return {
+      title: null,
+      summary: null,
+      steps: [],
+      files: [],
+      keyChanges: [],
+      strategicObjectives: [],
+      risks: [],
+      type: 'feature',
+      fullContent: ''
+    };
+  }
+
+  return {
+    title: extractTitle(content),
+    summary: extractSummary(content),
+    steps: extractSteps(content),
+    files: extractFiles(content),
+    keyChanges: extractKeyChanges(content),
+    strategicObjectives: extractStrategicObjectives(content),
+    risks: extractRisks(content),
+    type: inferSDType(content),
+    fullContent: content
+  };
+}
+
+/**
+ * Format files array into scope string for SD
+ *
+ * @param {Array<{path: string, action: string, purpose: string}>} files - Files to format
+ * @returns {string} Formatted scope string
+ */
+export function formatFilesAsScope(files) {
+  if (!files || files.length === 0) {
+    return '';
+  }
+
+  const lines = files.map(f => {
+    const actionIcon = f.action === 'CREATE' ? '+' : f.action === 'MODIFY' ? '~' : '-';
+    return `${actionIcon} ${f.path}${f.purpose ? ` - ${f.purpose}` : ''}`;
+  });
+
+  return lines.join('\n');
+}
+
+/**
+ * Format steps array into success criteria for SD
+ *
+ * @param {Array<{text: string, completed: boolean}>} steps - Steps to format
+ * @param {number} maxSteps - Maximum number of steps to include
+ * @returns {Array<string>} Formatted success criteria
+ */
+export function formatStepsAsCriteria(steps, maxSteps = 10) {
+  if (!steps || steps.length === 0) {
+    return [];
+  }
+
+  return steps
+    .slice(0, maxSteps)
+    .map(s => s.text);
+}
+
+// Default export
+export default {
+  extractTitle,
+  extractSummary,
+  extractSteps,
+  extractFiles,
+  extractKeyChanges,
+  extractStrategicObjectives,
+  extractRisks,
+  inferSDType,
+  parsePlanFile,
+  formatFilesAsScope,
+  formatStepsAsCriteria
+};


### PR DESCRIPTION
## Summary

- Add plan-parser.js module to extract structured content from Claude Code plan files
- Add plan-archiver.js module to find recent plans and archive to permanent location
- Extend leo-create-sd.js with `--from-plan` flag for plan-aware SD creation
- Update command and reference documentation
- Update database section 388 for CLAUDE_LEAD.md regeneration

## Key Features

- **Auto-detect**: Finds most recent plan in `~/.claude/plans/`
- **Confirmation**: Shows plan details before creating (use `--yes` to skip)
- **Type inference**: Determines SD type from plan content keywords
- **Archiving**: Preserves original plan to `docs/plans/archived/{sd-key}-plan.md`
- **Rich extraction**: Pulls title, summary, steps, files, key changes, objectives, risks

## Usage

```bash
# Auto-detect most recent plan (prompts for confirmation)
node scripts/leo-create-sd.js --from-plan

# Auto-detect without confirmation
node scripts/leo-create-sd.js --from-plan --yes

# Use specific plan file
node scripts/leo-create-sd.js --from-plan ~/.claude/plans/my-plan.md
```

## Test plan

- [x] Verify plan-parser.js extracts all expected fields
- [x] Verify plan-archiver.js finds most recent plan correctly
- [x] Verify --from-plan creates SD with populated metadata
- [x] Verify plan archived to permanent location
- [x] Verify documentation appears in regenerated CLAUDE_LEAD.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)