### PR TITLE
fix: replace shell-unsafe ! operators in inline node -e commands

### DIFF
--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -589,7 +589,7 @@ supabase.from('documentation_inventory')
   .select('id, file_path, title, category, last_updated')
   .or('title.ilike.%KEYWORD%,file_path.ilike.%KEYWORD%')
   .then(({data, error}) => {
-    if (error && error.code !== 'PGRST116') console.error(error);
+    if (error && error.code === 'PGRST116') { /* no rows - ok */ } else if (error) { console.error(error); }
     else if (data) console.log('Doc inventory:', JSON.stringify(data, null, 2));
   });
 "

--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -26,7 +26,9 @@ argument-hint: [init|restart|next|create|continue|complete|resume|<SD-ID>|<QF-ID
      .limit(1)
      .single()
      .then(({data, error}) => {
-       if (data?.metadata?.auto_proceed !== undefined) {
+       if (data && data.metadata && data.metadata.auto_proceed === undefined) {
+         console.log('SESSION_NEW=true');
+       } else if (data && data.metadata) {
          console.log('SESSION_AUTO_PROCEED=' + data.metadata.auto_proceed);
        } else {
          console.log('SESSION_NEW=true');
@@ -157,8 +159,8 @@ Display and modify AUTO-PROCEED and Orchestrator Chaining settings.
      console.log('GLOBAL_AUTO_PROCEED=' + globals.auto_proceed);
      console.log('GLOBAL_CHAIN=' + globals.chain_orchestrators);
      console.log('SESSION_ID=' + (sessionData?.session_id || 'none'));
-     console.log('SESSION_AUTO_PROCEED=' + (sessionAP !== undefined ? sessionAP : 'inherited'));
-     console.log('SESSION_CHAIN=' + (sessionChain !== undefined ? sessionChain : 'inherited'));
+     console.log('SESSION_AUTO_PROCEED=' + (sessionAP === undefined ? 'inherited' : sessionAP));
+     console.log('SESSION_CHAIN=' + (sessionChain === undefined ? 'inherited' : sessionChain));
    }
 
    getSettings();
@@ -476,7 +478,7 @@ Restore session state after a crash, compaction, or interruption using the Unifi
    const path = require('path');
    const stateFile = path.join(process.cwd(), '.claude', 'unified-session-state.json');
 
-   if (!fs.existsSync(stateFile)) {
+   if (fs.existsSync(stateFile) === false) {
      console.log('STATE_EXISTS=false');
      process.exit(0);
    }
@@ -530,11 +532,11 @@ Restore session state after a crash, compaction, or interruption using the Unifi
      if (state.sd && state.sd.id) {
        console.log('[SD] Working on: ' + state.sd.id);
        if (state.sd.phase) console.log('[SD] Phase: ' + state.sd.phase);
-       if (state.sd.progress !== null) console.log('[SD] Progress: ' + state.sd.progress + '%');
+       if (state.sd.progress === null) { /* skip */ } else { console.log('[SD] Progress: ' + state.sd.progress + '%'); }
      }
 
      // Workflow
-     if (state.workflow && state.workflow.currentPhase !== 'unknown') {
+     if (state.workflow && state.workflow.currentPhase && state.workflow.currentPhase === 'unknown' ? false : true) {
        console.log('[WORKFLOW] Phase: ' + state.workflow.currentPhase);
      }
 
@@ -553,7 +555,7 @@ Restore session state after a crash, compaction, or interruption using the Unifi
 
      // Open Questions
      if (state.openQuestions) {
-       const unresolved = state.openQuestions.filter(q => !q.resolved);
+       const unresolved = state.openQuestions.filter(q => q.resolved === false || q.resolved === undefined);
        if (unresolved.length > 0) {
          console.log('[QUESTIONS] ' + unresolved.length + ' open');
        }

--- a/docs/guides/supabase-connectivity.md
+++ b/docs/guides/supabase-connectivity.md
@@ -144,8 +144,9 @@ Check data integrity using JavaScript client (always works)
 echo $SUPABASE_DB_PASSWORD
 
 # URL-encode the password
-node -e "console.log(encodeURIComponent('YourPassword!'))"
-# Output: YourPassword%21
+node -e "console.log(encodeURIComponent('YourP@ssword#123'))"
+# Output: YourP%40ssword%23123
+# Note: Avoid ! in examples as it triggers bash history expansion
 
 # Use single quotes to prevent shell interpretation
 psql 'postgresql://...'  # Good

--- a/docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md
+++ b/docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md
@@ -787,7 +787,7 @@ async function executePostCompletionCommand(command, supabase, sd, sdKey) {
 grep "exitCode3\|gracefulExit(3)" scripts/hooks/stop-subagent-enforcement/index.js
 
 # Verify continuation state module
-node -e "const cs = require('./scripts/modules/handoff/continuation-state.js'); console.log('Module loaded:', !!cs.readState)"
+node -e "const cs = require('./scripts/modules/handoff/continuation-state.js'); console.log('Module loaded:', Boolean(cs.readState))"
 
 # Test prompt generation
 node scripts/generate-continuation-prompt.js --check


### PR DESCRIPTION
## Summary

- Replace `!==` with `===` and swap logic branches in inline JavaScript commands
- Replace `!variable` with `variable === false` 
- Replace `!!` double negation with `Boolean()`
- Remove `!` from example string literals in documentation

## Root Cause

Bash history expansion interprets `!` inside double-quoted strings, escaping it to `\!` which breaks JavaScript syntax when commands are executed via shell. This caused `/leo settings` to fail with `SyntaxError: Invalid or unexpected token`.

## Files Changed

| File | Changes |
|------|---------|
| `.claude/commands/leo.md` | 7 pattern replacements |
| `.claude/commands/document.md` | 1 pattern replacement |
| `docs/leo/protocol/v4.3.3-auto-proceed-enhancement.md` | 1 pattern replacement |
| `docs/guides/supabase-connectivity.md` | 1 pattern replacement + note |

## Test plan

- [x] Verified `/leo settings` executes without syntax errors
- [x] Searched codebase for remaining shell-unsafe patterns in `node -e` commands
- [x] All markdown files with inline JavaScript now use shell-safe patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)