### PR TITLE
fix: show /leo help menu when no argument provided

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -713,26 +713,27 @@ When the argument matches `SD-*` pattern (e.g., `SD-FEATURE-001`):
 4. Load appropriate CLAUDE_*.md context based on phase
 5. Proceed with LEAD→PLAN→EXEC workflow
 
-### If no argument provided:
+### If argument is "run":
 Run the LEO protocol workflow:
 ```bash
 npm run leo
 ```
 
-### If argument not recognized:
+### If no argument provided OR argument not recognized:
 Display the available commands:
 
 ```
 LEO Commands:
-  /leo           - Run LEO protocol workflow (npm run leo)
-  /leo init      (i)    - Initialize session (set auto-proceed preference)
-  /leo settings  (s)    - View/modify AUTO-PROCEED and Chaining settings
-  /leo restart   (r)    - Restart all LEO servers
-  /leo next      (n)    - Show SD queue (what to work on)
-  /leo create    (c)    - Create new SD (interactive wizard)
-  /leo continue  (cont) - Resume current working SD
-  /leo complete  (comp) - Run full sequence: document → ship → learn → next
-  /leo resume    (res)  - Restore session from saved state (crash recovery)
+  /leo                   - Show this help menu
+  /leo init      (i)     - Initialize session (set auto-proceed preference)
+  /leo settings  (s)     - View/modify AUTO-PROCEED and Chaining settings
+  /leo restart   (r)     - Restart all LEO servers
+  /leo next      (n)     - Show SD queue (what to work on)
+  /leo create    (c)     - Create new SD (interactive wizard)
+  /leo continue  (cont)  - Resume current working SD
+  /leo complete  (comp)  - Run full sequence: document → ship → learn → next
+  /leo resume    (res)   - Restore session from saved state (crash recovery)
+  /leo run               - Run LEO protocol workflow (npm run leo)
 
 Direct ID Access:
   /leo SD-XXX-001        - Start/continue work on a Strategic Directive


### PR DESCRIPTION
## Summary

- `/leo` with no arguments now shows the help menu instead of silently running `npm run leo`
- Added `/leo run` for users who want the old behavior (run LEO protocol workflow)
- Makes subcommands like `/leo settings` more discoverable

## Before
```
/leo → runs npm run leo (no visible output about available options)
```

## After
```
/leo → shows help menu with all available subcommands
/leo run → runs npm run leo
```

## Test plan

- [x] `/leo` shows help menu
- [x] `/leo settings` still works
- [x] `/leo run` runs the LEO protocol workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)