### PR TITLE
fix: update /leo argument-hint to match cleaner menu

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -1,6 +1,6 @@
 ---
 description: LEO stack management and session control
-argument-hint: [init|restart|next|create|continue|complete|resume|<SD-ID>|<QF-ID>]
+argument-hint: [settings|restart|next|create|continue|complete|<SD-ID>]
 ---
 
 # LEO Stack Control


### PR DESCRIPTION
## Summary

Update the autocomplete hint shown when typing `/leo ` to match the decluttered help menu.

**Before:** `[init|restart|next|create|continue|complete|resume|<SD-ID>|<QF-ID>]`

**After:** `[settings|restart|next|create|continue|complete|<SD-ID>]`

Changes:
- Added `settings` (was missing)
- Removed `init`, `resume`, `QF-ID` (rarely used)

🤖 Generated with [Claude Code](https://claude.com/claude-code)