### PR TITLE
fix: reorder /leo argument-hint by usage frequency

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -1,6 +1,6 @@
 ---
 description: LEO stack management and session control
-argument-hint: [settings|restart|next|create|continue|complete|<SD-ID>]
+argument-hint: [<SD-ID>|create|next|continue|complete|restart|settings]
 ---
 
 # LEO Stack Control


### PR DESCRIPTION
## Summary

Reorder autocomplete hints for `/leo` command by usage frequency:

**Before:** `settings|restart|next|create|continue|complete|<SD-ID>`

**After:** `<SD-ID>|create|next|continue|complete|restart|settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)