### PR TITLE
fix(prd): correct SD lookup column (QF-20260131-116)

### DIFF
--- a/scripts/prd/index.js
+++ b/scripts/prd/index.js
@@ -161,8 +161,8 @@ export async function addPRDToDatabase(sdId, prdTitle) {
  */
 async function fetchSDData(supabase, sdId) {
   const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sdId);
-  // Query by uuid_id for UUIDs, otherwise by sd_key or id (text SD keys)
-  const queryField = isUUID ? 'uuid_id' : 'id';
+  // Quick-fix QF-20260131-116: Query by 'id' for UUIDs (primary key), 'sd_key' for text keys
+  const queryField = isUUID ? 'id' : 'sd_key';
 
   const { data, error } = await supabase
     .from('strategic_directives_v2')


### PR DESCRIPTION
## Summary
- Fixed `fetchSDData()` in `scripts/prd/index.js` to query correct columns
- Changed: `isUUID ? 'uuid_id' : 'id'` → `isUUID ? 'id' : 'sd_key'`
- Root cause: `uuid_id` is a different column from `id` (the primary UUID)

## Test plan
- [x] Verified lookup works with UUID input
- [x] Verified lookup works with sd_key input (e.g., SD-XXX-001)
- [x] Smoke tests pass

## Related
- Quick-Fix: QF-20260131-116
- Note: 8 other files have similar issues - will create separate SD

🤖 Generated with [Claude Code](https://claude.ai/code)