### PR TITLE
feat(subagent): database-driven sub-agent requirements per SD type

### DIFF
--- a/database/migrations/20260131_add_required_sub_agents_column.sql
+++ b/database/migrations/20260131_add_required_sub_agents_column.sql
@@ -1,0 +1,80 @@
+-- Migration: Add required_sub_agents column to sd_type_validation_profiles
+-- SD: SD-LEO-INFRA-SUBAGENT-ORCHESTRATION-001
+-- US-001: Extend sd_type_validation_profiles table with sub-agent requirement metadata
+
+-- Add the new column for phase-keyed sub-agent requirements
+ALTER TABLE sd_type_validation_profiles
+ADD COLUMN IF NOT EXISTS required_sub_agents JSONB DEFAULT '{}'::jsonb;
+
+-- Add column comment
+COMMENT ON COLUMN sd_type_validation_profiles.required_sub_agents IS
+'Phase-keyed sub-agent requirements. Format: {"PLAN": ["STORIES", "DESIGN"], "EXEC": ["TESTING"]}';
+
+-- Populate required_sub_agents for each SD type based on CLAUDE_CORE.md definitions
+-- Feature: Full sub-agent support
+UPDATE sd_type_validation_profiles
+SET required_sub_agents = '{
+  "LEAD": ["RISK", "VALIDATION"],
+  "PLAN": ["STORIES", "DESIGN", "DATABASE"],
+  "EXEC": ["TESTING", "GITHUB"]
+}'::jsonb
+WHERE sd_type = 'feature';
+
+-- Infrastructure: Reduced sub-agent set (no DESIGN, TESTING, GITHUB)
+UPDATE sd_type_validation_profiles
+SET required_sub_agents = '{
+  "LEAD": ["RISK"],
+  "PLAN": [],
+  "EXEC": ["DOCMON"]
+}'::jsonb
+WHERE sd_type = 'infrastructure';
+
+-- Enhancement: Moderate sub-agent set
+UPDATE sd_type_validation_profiles
+SET required_sub_agents = '{
+  "LEAD": ["VALIDATION"],
+  "PLAN": ["STORIES"],
+  "EXEC": ["TESTING"]
+}'::jsonb
+WHERE sd_type = 'enhancement';
+
+-- Fix: Minimal sub-agent set
+UPDATE sd_type_validation_profiles
+SET required_sub_agents = '{
+  "LEAD": [],
+  "PLAN": [],
+  "EXEC": ["TESTING", "REGRESSION"]
+}'::jsonb
+WHERE sd_type = 'fix';
+
+-- Documentation: Doc-focused sub-agents
+UPDATE sd_type_validation_profiles
+SET required_sub_agents = '{
+  "LEAD": [],
+  "PLAN": [],
+  "EXEC": ["DOCMON"]
+}'::jsonb
+WHERE sd_type = 'documentation';
+
+-- Security: Security-focused sub-agents
+UPDATE sd_type_validation_profiles
+SET required_sub_agents = '{
+  "LEAD": ["RISK", "SECURITY"],
+  "PLAN": ["SECURITY"],
+  "EXEC": ["SECURITY", "TESTING"]
+}'::jsonb
+WHERE sd_type = 'security';
+
+-- Refactor: Regression-focused sub-agents
+UPDATE sd_type_validation_profiles
+SET required_sub_agents = '{
+  "LEAD": ["RISK"],
+  "PLAN": ["REGRESSION"],
+  "EXEC": ["REGRESSION", "TESTING"]
+}'::jsonb
+WHERE sd_type = 'refactor';
+
+-- Verify the updates
+SELECT sd_type, required_sub_agents
+FROM sd_type_validation_profiles
+ORDER BY sd_type;

--- a/scripts/modules/phase-subagent-orchestrator/phase-config.js
+++ b/scripts/modules/phase-subagent-orchestrator/phase-config.js
@@ -1,9 +1,18 @@
 /**
  * Phase Configuration for Sub-Agent Orchestrator
  * Contains phase-to-sub-agent mappings and mandatory agent definitions
+ *
+ * SD-LEO-INFRA-SUBAGENT-ORCHESTRATION-001: These are FALLBACK configurations.
+ * The primary source of truth is now sd_type_validation_profiles.required_sub_agents
+ * in the database. See sd-queries.js:getRequiredSubAgentsFromProfile()
+ *
+ * Fallback is used when:
+ * - SD type has no validation profile in database
+ * - required_sub_agents column is empty for the SD type
+ * - Database query fails (graceful degradation)
  */
 
-// Phase to sub-agent mapping (loaded from database, this is fallback)
+// Phase to sub-agent mapping (FALLBACK - database takes precedence)
 const PHASE_SUBAGENT_MAP = {
   LEAD_PRE_APPROVAL: ['VALIDATION', 'DATABASE', 'SECURITY', 'DESIGN', 'RISK'],
   PLAN_PRD: ['DATABASE', 'STORIES', 'RISK', 'TESTING'],

--- a/scripts/validate-subagent-profile-sync.js
+++ b/scripts/validate-subagent-profile-sync.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+/**
+ * Validate Sub-Agent Profile Sync
+ * SD-LEO-INFRA-SUBAGENT-ORCHESTRATION-001: US-004
+ *
+ * Ensures all sub-agents referenced in sd_type_validation_profiles.required_sub_agents
+ * exist in the leo_sub_agents table and are active.
+ *
+ * Usage:
+ *   node scripts/validate-subagent-profile-sync.js
+ *   node scripts/validate-subagent-profile-sync.js --fix  # Auto-fix by removing invalid references
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const PHASE_KEYS = ['LEAD', 'PLAN', 'EXEC'];
+
+async function validateSync() {
+  console.log('\n╔════════════════════════════════════════════════════════════╗');
+  console.log('║       SUB-AGENT / VALIDATION PROFILE SYNC CHECK           ║');
+  console.log('╚════════════════════════════════════════════════════════════╝\n');
+
+  const issues = [];
+  const warnings = [];
+
+  // Step 1: Get all active sub-agents from database
+  console.log('Step 1: Querying active sub-agents...');
+  const { data: subAgents, error: saError } = await supabase
+    .from('leo_sub_agents')
+    .select('code, name, active')
+    .order('code');
+
+  if (saError) {
+    console.error('   ERROR: Failed to query sub-agents:', saError.message);
+    process.exit(1);
+  }
+
+  const activeAgents = new Set(subAgents.filter(a => a.active).map(a => a.code));
+  const inactiveAgents = new Set(subAgents.filter(a => !a.active).map(a => a.code));
+  console.log(`   Found ${activeAgents.size} active sub-agents`);
+  console.log(`   Found ${inactiveAgents.size} inactive sub-agents`);
+
+  // Step 2: Get all validation profiles with required_sub_agents
+  console.log('\nStep 2: Querying validation profiles...');
+  const { data: profiles, error: vpError } = await supabase
+    .from('sd_type_validation_profiles')
+    .select('sd_type, required_sub_agents')
+    .order('sd_type');
+
+  if (vpError) {
+    console.error('   ERROR: Failed to query validation profiles:', vpError.message);
+    process.exit(1);
+  }
+
+  const profilesWithRequirements = profiles.filter(p =>
+    p.required_sub_agents && Object.keys(p.required_sub_agents).length > 0
+  );
+  console.log(`   Found ${profiles.length} total profiles`);
+  console.log(`   Found ${profilesWithRequirements.length} profiles with required_sub_agents`);
+
+  // Step 3: Validate each profile's sub-agent references
+  console.log('\nStep 3: Validating sub-agent references...\n');
+
+  for (const profile of profilesWithRequirements) {
+    const sdType = profile.sd_type;
+    const requirements = profile.required_sub_agents;
+
+    console.log(`   SD Type: ${sdType}`);
+
+    for (const phase of PHASE_KEYS) {
+      const phaseAgents = requirements[phase];
+      if (!phaseAgents || !Array.isArray(phaseAgents)) continue;
+
+      for (const agentCode of phaseAgents) {
+        if (!activeAgents.has(agentCode)) {
+          if (inactiveAgents.has(agentCode)) {
+            issues.push({
+              type: 'INACTIVE_REFERENCE',
+              sdType,
+              phase,
+              agentCode,
+              message: `${sdType}.${phase} references INACTIVE sub-agent: ${agentCode}`
+            });
+            console.log(`      ❌ ${phase}: ${agentCode} (INACTIVE)`);
+          } else {
+            issues.push({
+              type: 'MISSING_REFERENCE',
+              sdType,
+              phase,
+              agentCode,
+              message: `${sdType}.${phase} references NON-EXISTENT sub-agent: ${agentCode}`
+            });
+            console.log(`      ❌ ${phase}: ${agentCode} (NOT FOUND)`);
+          }
+        } else {
+          console.log(`      ✓ ${phase}: ${agentCode}`);
+        }
+      }
+    }
+    console.log('');
+  }
+
+  // Step 4: Check for profiles without required_sub_agents
+  console.log('Step 4: Checking profiles without requirements...');
+  const emptyProfiles = profiles.filter(p =>
+    !p.required_sub_agents || Object.keys(p.required_sub_agents).length === 0
+  );
+
+  if (emptyProfiles.length > 0) {
+    console.log(`   Found ${emptyProfiles.length} profiles without required_sub_agents:`);
+    for (const profile of emptyProfiles) {
+      console.log(`      ⚠ ${profile.sd_type} (will use fallback config)`);
+      warnings.push({
+        type: 'EMPTY_PROFILE',
+        sdType: profile.sd_type,
+        message: `${profile.sd_type} has no required_sub_agents - will use phase-config.js fallback`
+      });
+    }
+  } else {
+    console.log('   All profiles have required_sub_agents configured');
+  }
+
+  // Step 5: Summary
+  console.log('\n' + '═'.repeat(60));
+  console.log('VALIDATION SUMMARY');
+  console.log('═'.repeat(60));
+
+  if (issues.length === 0 && warnings.length === 0) {
+    console.log('\n✅ All validations passed!');
+    console.log('   - All referenced sub-agents exist and are active');
+    console.log('   - All SD types have required_sub_agents configured');
+    process.exit(0);
+  }
+
+  if (issues.length > 0) {
+    console.log(`\n❌ Found ${issues.length} ISSUE(S):`);
+    for (const issue of issues) {
+      console.log(`   - ${issue.message}`);
+    }
+  }
+
+  if (warnings.length > 0) {
+    console.log(`\n⚠ Found ${warnings.length} WARNING(S):`);
+    for (const warning of warnings) {
+      console.log(`   - ${warning.message}`);
+    }
+  }
+
+  // Handle --fix flag
+  if (process.argv.includes('--fix') && issues.length > 0) {
+    console.log('\n' + '─'.repeat(60));
+    console.log('AUTO-FIX MODE');
+    console.log('─'.repeat(60));
+    await autoFix(issues);
+  } else if (issues.length > 0) {
+    console.log('\n💡 Run with --fix to automatically remove invalid references');
+  }
+
+  process.exit(issues.length > 0 ? 1 : 0);
+}
+
+async function autoFix(issues) {
+  const profileUpdates = {};
+
+  // Group issues by SD type
+  for (const issue of issues) {
+    if (!profileUpdates[issue.sdType]) {
+      profileUpdates[issue.sdType] = { phases: {} };
+    }
+    if (!profileUpdates[issue.sdType].phases[issue.phase]) {
+      profileUpdates[issue.sdType].phases[issue.phase] = [];
+    }
+    profileUpdates[issue.sdType].phases[issue.phase].push(issue.agentCode);
+  }
+
+  // Apply fixes
+  for (const [sdType, update] of Object.entries(profileUpdates)) {
+    console.log(`\nFixing ${sdType}...`);
+
+    // Get current profile
+    const { data: profile } = await supabase
+      .from('sd_type_validation_profiles')
+      .select('required_sub_agents')
+      .eq('sd_type', sdType)
+      .single();
+
+    if (!profile) {
+      console.log('   ⚠ Profile not found, skipping');
+      continue;
+    }
+
+    const updatedRequirements = { ...profile.required_sub_agents };
+
+    // Remove invalid agents from each phase
+    for (const [phase, invalidAgents] of Object.entries(update.phases)) {
+      if (updatedRequirements[phase]) {
+        updatedRequirements[phase] = updatedRequirements[phase].filter(
+          a => !invalidAgents.includes(a)
+        );
+        console.log(`   Removed from ${phase}: ${invalidAgents.join(', ')}`);
+      }
+    }
+
+    // Update database
+    const { error } = await supabase
+      .from('sd_type_validation_profiles')
+      .update({ required_sub_agents: updatedRequirements })
+      .eq('sd_type', sdType);
+
+    if (error) {
+      console.log(`   ❌ Failed to update: ${error.message}`);
+    } else {
+      console.log('   ✅ Updated successfully');
+    }
+  }
+
+  console.log('\n✅ Auto-fix complete. Run validation again to verify.');
+}
+
+// Run validation
+validateSync().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Implements SD-LEO-INFRA-SUBAGENT-ORCHESTRATION-001: Intelligent sub-agent orchestration
- Sub-agent requirements now queried from `sd_type_validation_profiles.required_sub_agents`
- Fallback to hardcoded `phase-config.js` when database doesn't have requirements

## User Stories Completed
- **US-001**: Add `required_sub_agents` JSONB column with phase-keyed requirements
- **US-002**: Update `orchestrate-phase-subagents.js` to query validation profiles first
- **US-003**: Document `phase-config.js` as fallback configuration
- **US-004**: Create `validate-subagent-profile-sync.js` for sync verification

## Database Changes
New column on `sd_type_validation_profiles`:
```sql
ALTER TABLE sd_type_validation_profiles
ADD COLUMN required_sub_agents JSONB DEFAULT '{}'::jsonb;
```

Configured SD types:
| SD Type | LEAD | PLAN | EXEC |
|---------|------|------|------|
| feature | RISK, VALIDATION | STORIES, DESIGN, DATABASE | TESTING, GITHUB |
| infrastructure | RISK | - | DOCMON |
| security | RISK, SECURITY | SECURITY | SECURITY, TESTING |
| refactor | RISK | REGRESSION | REGRESSION, TESTING |
| documentation | - | - | DOCMON |

## Test plan
- [x] Unit tests pass
- [x] Smoke tests pass
- [x] Validation script confirms all referenced sub-agents exist
- [x] Functional test confirms database queries return correct requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)