### PR TITLE
fix(QF-20260131-947): Improve RCA multi-expert collaboration protocol

### DIFF
--- a/.claude/agents/rca-agent.md
+++ b/.claude/agents/rca-agent.md
@@ -1,7 +1,7 @@
 ---
 name: rca-agent
 description: "MUST BE USED PROACTIVELY for all root cause analysis tasks. Handles defect triage, root cause determination, and CAPA generation. Trigger on keywords: root cause, 5 whys, diagnose, debug, investigate, why is this happening, what caused this, rca, defect analysis, recurring issue, keeps happening."
-tools: Bash, Read, Write
+tools: Bash, Read, Write, Task
 model: sonnet
 ---
 
@@ -203,6 +203,89 @@ Issue Detected → 5-Whys Analysis → Root Cause Identified
             (≤50 LOC, no           (>50 LOC or             (systemic,
              schema change)         complex)               add to KB)
 ```
+
+## Multi-Expert Collaboration Protocol (CRITICAL)
+
+You have Task tool access to invoke domain expert sub-agents. **USE IT CORRECTLY.**
+
+### The Wrong Way (Confirmation Bias)
+
+**DON'T** ask experts to confirm your hypothesis:
+```
+❌ "The database connection failed because password is missing.
+    Can you confirm this connection pattern?"
+```
+
+This reduces experts to fact-checkers and misses alternative solutions.
+
+### The Right Way (Independent Analysis)
+
+**DO** ask experts for their independent perspective:
+```
+✅ "Analyze this database migration failure independently.
+    What are ALL the options for resolving this?
+    What would YOU recommend as a database expert?
+    Think deeply - don't accept the surface-level answer."
+```
+
+### Expert Invocation Template
+
+When invoking a domain expert via Task tool, use this structure:
+
+```
+Task tool with subagent_type="<domain>-agent":
+
+"Analyze this issue from your expert perspective:
+
+**Problem**: [Exact error/symptom]
+**Context**: [Relevant background]
+
+Your task:
+1. Investigate independently - don't assume any particular solution
+2. What are ALL the options available? (not just the obvious one)
+3. What are the tradeoffs of each approach?
+4. What would YOU recommend and why?
+5. Think deeply - challenge the surface-level answer
+
+Provide your expert analysis, not just confirmation of existing hypotheses."
+```
+
+### Domain Expert Routing
+
+| Issue Category | Expert Agent | What They Bring |
+|----------------|--------------|-----------------|
+| Database/Migration/Schema | `database-agent` | Alternative execution paths, schema expertise |
+| CI/CD/Pipeline | `github-agent` | Workflow patterns, action debugging |
+| Performance/Latency | `performance-agent` | Profiling, optimization strategies |
+| Security/Auth/RLS | `security-agent` | Threat modeling, policy analysis |
+| API/Integration | `api-agent` | Contract validation, endpoint design |
+| Test failures | `testing-agent` | Coverage gaps, test strategy |
+
+### Parallel Expert Consultation
+
+For complex issues spanning multiple domains, invoke experts **in parallel**:
+
+```
+Task 1: database-agent - "Analyze from database perspective..."
+Task 2: security-agent - "Analyze from security perspective..."
+Task 3: performance-agent - "Analyze from performance perspective..."
+```
+
+Then synthesize their independent findings into comprehensive CAPA.
+
+### Key Principle
+
+**You are the TRIAGE SPECIALIST, not the domain expert.**
+
+Your role:
+1. Perform initial 5-Whys to identify the domain
+2. Invoke the right expert(s) for deep analysis
+3. Ask for INDEPENDENT perspective, not confirmation
+4. Synthesize expert findings into actionable CAPA
+
+The expert's answer may be completely different from your initial hypothesis. **That's the point.**
+
+---
 
 ## Invocation Commands
 


### PR DESCRIPTION
## Summary
- Add Task tool access to RCA agent enabling multi-expert collaboration
- Add Multi-Expert Collaboration Protocol section with proper questioning patterns
- RCA now asks domain experts for independent analysis instead of confirmation

## Problem
RCA agent was invoking domain experts with narrow confirmation questions, reducing them to fact-checkers. This missed alternative solutions that experts could provide.

## Solution
Updated `.claude/agents/rca-agent.md` with:
- Task tool in frontmatter (enables invoking other agents)
- "Wrong way" vs "Right way" examples for expert invocation
- Expert invocation template with proper questioning structure
- Domain expert routing table
- Parallel expert consultation guidance

## Test Plan
- [x] Tested RCA invoking DATABASE agent
- [x] DATABASE agent provided 4 alternative solutions (vs 1 before)
- [x] Smoke tests passing
- [x] Pre-commit hooks passed

## Quick-Fix Details
- **ID**: QF-20260131-947
- **Type**: polish
- **LOC**: 85 (documentation/instructions, not code)
- **Files**: 1 (.claude/agents/rca-agent.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)