### PR TITLE
feat: enforce CLAUDE_CORE.md and CLAUDE_LEAD.md read before SD creation

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -410,6 +410,14 @@ node scripts/modules/sd-key-generator.js LEO <type> "<title>"
   ```
 
 - `create --from-plan [path]`: Create from Claude Code plan file
+
+  **MANDATORY**: Before running `--from-plan`, you MUST read protocol files:
+  ```
+  Read tool: CLAUDE_CORE.md    (SD types, validation requirements, sub-agent triggers)
+  Read tool: CLAUDE_LEAD.md    (SD creation process, field requirements, handoff gates)
+  ```
+
+  Then run the creation script:
   ```bash
   # Auto-detect most recent plan in ~/.claude/plans/
   node scripts/leo-create-sd.js --from-plan

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -333,11 +333,11 @@ async function createFromPlan(planPath = null, skipConfirmation = false) {
   }
 
   // Step 5: Generate SD key
+  // Protocol files (CLAUDE_CORE.md, CLAUDE_LEAD.md) must be read before SD creation
   const sdKey = await generateSDKey({
     source: 'LEO',
     type: parsed.type,
-    title: parsed.title,
-    skipLeadValidation: true  // Plans are pre-validated by plan mode
+    title: parsed.title
   });
 
   console.log(`   Generated SD Key: ${sdKey}`);
@@ -511,7 +511,7 @@ function mapToDbType(userType) {
  * Build default success_metrics based on SD type and title
  * Ensures validator requirements (3+ items with {metric, target}) are met
  */
-function buildDefaultSuccessMetrics(type, title) {
+function buildDefaultSuccessMetrics(type, _title) {
   const baseMetrics = [
     {
       metric: 'Implementation completeness',
@@ -547,7 +547,7 @@ function buildDefaultSuccessMetrics(type, title) {
  * Build default success_criteria based on SD type
  * Returns array of strings (qualitative acceptance criteria)
  */
-function buildDefaultSuccessCriteria(type, title) {
+function buildDefaultSuccessCriteria(type, _title) {
   const baseCriteria = [
     'All implementation items from scope are complete',
     'Code passes lint and type checks',


### PR DESCRIPTION
## Summary

- Added protocol file validation to SDKeyGenerator requiring both CLAUDE_CORE.md and CLAUDE_LEAD.md to be read before SD creation
- Added `validateCoreFileRead()`, `validateLeadFileRead()`, `validateProtocolFilesRead()` functions
- Updated `generateSDKey()` to use combined protocol file validation
- Removed `skipLeadValidation` bypass from `--from-plan` SD creation
- Added CLI validation commands: `--check-protocol`, `--check-core`, `--check-lead`
- Updated `/leo create --from-plan` command with mandatory protocol file read instructions
- Documented validation system in sd-key-generator-guide.md
- Added sub-agent learning capture enhancements for future /learn improvements

## Why

This ensures Claude is familiar with:
- Sub-agent trigger keywords and invocation patterns (CLAUDE_CORE.md)
- SD type definitions and validation requirements (CLAUDE_CORE.md)
- Required SD fields and success criteria formats (CLAUDE_LEAD.md)
- Strategic validation questions and handoff requirements (CLAUDE_LEAD.md)

## Test plan

- [ ] Run `node scripts/modules/sd-key-generator.js --check-protocol` without reading files (should fail)
- [ ] Read CLAUDE_CORE.md and CLAUDE_LEAD.md, then retry (should pass)
- [ ] Try `/leo create --from-plan` without reading protocol files (should show error)
- [ ] Verify documentation accurately reflects new validation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)