### PR TITLE
fix(learning): correct feedback table column references in clusterer

### DIFF
--- a/lib/learning/feedback-clusterer.js
+++ b/lib/learning/feedback-clusterer.js
@@ -46,7 +46,7 @@ async function findPromotableClusters() {
   // Query feedback grouped by error_hash
   const { data: clusters, error } = await supabase
     .from('feedback')
-    .select('error_hash, category, feedback_text, severity, sd_id, id, created_at')
+    .select('error_hash, category, description, title, severity, sd_id, id, created_at')
     .in('status', ['new', 'triaged'])
     .is('cluster_processed_at', null)
     .gte('created_at', windowStart.toISOString())
@@ -137,8 +137,9 @@ function evaluateForPromotion(cluster) {
  * Create a draft pattern from a feedback cluster
  */
 async function createDraftPattern(cluster) {
-  // Get representative feedback text
-  const representativeText = cluster.items[0].feedback_text;
+  // Get representative feedback text (title + description)
+  const firstItem = cluster.items[0];
+  const representativeText = firstItem.title + (firstItem.description ? ': ' + firstItem.description : '');
   const category = cluster.categories[0] || 'general';
   const severity = cluster.severities.has('critical') ? 'critical' :
                    cluster.severities.has('high') ? 'high' : 'medium';


### PR DESCRIPTION
## Summary
- Fixed feedback-clusterer.js querying non-existent 'feedback_text' column
- Updated to use actual 'title' and 'description' columns from feedback table
- Verified all migrations are applied and success criteria met

## Test plan
- [x] Smoke tests pass
- [x] feedback-clusterer.js runs with --dry-run flag
- [x] Migrations verified: source, source_feedback_ids, cluster_processed_at, learning_extracted_at columns exist

## Related
SD-LEO-FIX-LEO-PROTOCOL-LEARNING-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)