### PR TITLE
feat(learning): add quick_fix to pattern integration bridge

### DIFF
--- a/database/migrations/20260201_add_quick_fix_cluster_source.sql
+++ b/database/migrations/20260201_add_quick_fix_cluster_source.sql
@@ -1,0 +1,10 @@
+-- SD-LEO-ENH-QUICK-FIX-PATTERN-001: Add quick_fix_cluster as valid source
+-- This allows the feedback-clusterer to track patterns from quick_fixes
+
+-- Drop existing constraint
+ALTER TABLE issue_patterns DROP CONSTRAINT IF EXISTS issue_patterns_source_check;
+
+-- Add updated constraint with quick_fix_cluster
+ALTER TABLE issue_patterns 
+ADD CONSTRAINT issue_patterns_source_check 
+CHECK (source IN ('retrospective', 'feedback_cluster', 'manual', 'quick_fix_cluster'));

--- a/lib/learning/feedback-clusterer.js
+++ b/lib/learning/feedback-clusterer.js
@@ -2,13 +2,15 @@
 /**
  * Feedback Clusterer
  *
- * Promotes recurring feedback items to issue patterns.
+ * Promotes recurring feedback items and quick_fixes to issue patterns.
  * Bridges the gap between raw feedback intake and curated pattern knowledge.
  *
  * SD: SD-LEO-INFRA-LEARNING-ARCHITECTURE-001
+ * SD: SD-LEO-ENH-QUICK-FIX-PATTERN-001 (quick_fix integration)
  *
  * Key Features:
  * - Groups feedback by error_hash
+ * - Groups quick_fixes by title similarity
  * - Promotes clusters meeting threshold to draft patterns
  * - Prevents duplicate pattern creation via similarity check
  * - Supports dry-run mode for testing
@@ -33,7 +35,8 @@ const THRESHOLDS = {
   TIME_WINDOW_DAYS: 14,         // Within 14 days
   CRITICAL_MIN_OCCURRENCES: 3,  // Critical severity: ≥3 occurrences (immediate)
   SIMILARITY_THRESHOLD: 0.5,    // Prevent duplicates if >50% similar
-  MIN_SOURCE_DIVERSITY: 2       // ≥2 different SDs/sources (optional)
+  MIN_SOURCE_DIVERSITY: 2,      // ≥2 different SDs/sources (optional)
+  QUICK_FIX_MIN_OCCURRENCES: 3  // Quick fixes: lower threshold (3+)
 };
 
 /**
@@ -97,6 +100,110 @@ async function findPromotableClusters() {
   }
 
   return promotable;
+}
+
+/**
+ * Find quick_fix clusters that are promotable to patterns
+ * SD-LEO-ENH-QUICK-FIX-PATTERN-001: Quick fix to pattern bridge
+ */
+async function findPromotableQuickFixClusters() {
+  const windowStart = new Date();
+  windowStart.setDate(windowStart.getDate() - THRESHOLDS.TIME_WINDOW_DAYS);
+
+  // Query quick_fixes - group by title similarity
+  const { data: quickFixes, error } = await supabase
+    .from('quick_fixes')
+    .select('id, title, type, severity, description, escalated_to_sd_id, created_at')
+    .in('status', ['open', 'completed'])
+    .gte('created_at', windowStart.toISOString());
+
+  if (error) {
+    console.error('Error querying quick_fixes:', error);
+    throw error;
+  }
+
+  if (!quickFixes || quickFixes.length === 0) {
+    console.log('  ℹ️  No quick_fixes found in time window');
+    return [];
+  }
+
+  // Group by normalized title (lowercase, trimmed)
+  const grouped = {};
+  for (const qf of quickFixes) {
+    const normalizedTitle = qf.title.toLowerCase().trim();
+    if (!grouped[normalizedTitle]) {
+      grouped[normalizedTitle] = {
+        title: qf.title,
+        items: [],
+        types: new Set(),
+        severities: new Set()
+      };
+    }
+    grouped[normalizedTitle].items.push(qf);
+    grouped[normalizedTitle].types.add(qf.type);
+    if (qf.severity) grouped[normalizedTitle].severities.add(qf.severity);
+  }
+
+  // Evaluate each cluster for promotion
+  const promotable = [];
+  for (const [key, cluster] of Object.entries(grouped)) {
+    const count = cluster.items.length;
+
+    // Quick fixes have lower threshold (3+)
+    if (count >= THRESHOLDS.QUICK_FIX_MIN_OCCURRENCES) {
+      promotable.push({
+        title_key: key,
+        ...cluster,
+        types: Array.from(cluster.types),
+        severities: Array.from(cluster.severities),
+        shouldPromote: true,
+        reason: `${count} quick_fixes with similar title (threshold: ${THRESHOLDS.QUICK_FIX_MIN_OCCURRENCES})`,
+        promotionType: 'quick_fix',
+        source: 'quick_fix_cluster'
+      });
+    }
+  }
+
+  return promotable;
+}
+
+/**
+ * Create a draft pattern from a quick_fix cluster
+ * SD-LEO-ENH-QUICK-FIX-PATTERN-001
+ */
+async function createQuickFixDraftPattern(cluster) {
+  const firstItem = cluster.items[0];
+  const representativeText = firstItem.title + (firstItem.description ? ': ' + firstItem.description : '');
+  const category = cluster.types[0] || 'general';
+  const severity = cluster.severities.has('critical') ? 'critical' :
+                   cluster.severities.has('high') ? 'high' : 'medium';
+
+  // Check for similar existing patterns
+  const similar = await kb.search(representativeText, { limit: 1 });
+  if (similar.length > 0 && similar[0].similarity > THRESHOLDS.SIMILARITY_THRESHOLD) {
+    console.log(`  ⚠️  Similar pattern exists: ${similar[0].pattern_id} (${Math.round(similar[0].similarity * 100)}% match)`);
+    return {
+      exists: true,
+      pattern_id: similar[0].pattern_id,
+      similarity: similar[0].similarity
+    };
+  }
+
+  // Create pattern with quick_fix_cluster source
+  const pattern = await kb.createDraftPattern({
+    issue_summary: representativeText,
+    category,
+    severity,
+    source: 'quick_fix_cluster',
+    source_feedback_ids: cluster.items.map(i => i.id),
+    occurrence_count: cluster.items.length
+  });
+
+  return {
+    created: true,
+    pattern_id: pattern.pattern_id,
+    occurrence_count: cluster.items.length
+  };
 }
 
 /**
@@ -196,69 +303,123 @@ async function markProcessed(feedbackIds) {
 async function runClusteringJob(options = {}) {
   const { dryRun = false, _verbose = true } = options;
 
-  console.log('\n📊 FEEDBACK CLUSTERING JOB');
+  console.log('\n📊 FEEDBACK & QUICK-FIX CLUSTERING JOB');
   console.log('═'.repeat(60));
   console.log(`Mode: ${dryRun ? 'DRY RUN (no changes)' : 'LIVE'}`);
-  console.log(`Thresholds: ${THRESHOLDS.MIN_OCCURRENCES} occurrences in ${THRESHOLDS.TIME_WINDOW_DAYS} days`);
+  console.log(`Feedback threshold: ${THRESHOLDS.MIN_OCCURRENCES} occurrences in ${THRESHOLDS.TIME_WINDOW_DAYS} days`);
+  console.log(`Quick-fix threshold: ${THRESHOLDS.QUICK_FIX_MIN_OCCURRENCES} occurrences`);
   console.log(`Critical threshold: ${THRESHOLDS.CRITICAL_MIN_OCCURRENCES} occurrences\n`);
-
-  // Find promotable clusters
-  const clusters = await findPromotableClusters();
-
-  if (clusters.length === 0) {
-    console.log('✅ No clusters ready for promotion');
-    return { promoted: 0, skipped: 0, processed: 0 };
-  }
-
-  console.log(`Found ${clusters.length} cluster(s) ready for promotion:\n`);
 
   const results = {
     promoted: 0,
     skipped: 0,
     processed: 0,
-    patterns: []
+    patterns: [],
+    quickFixPromoted: 0,
+    quickFixSkipped: 0
   };
 
-  for (const cluster of clusters) {
-    console.log(`\n📦 Cluster: ${cluster.error_hash.substring(0, 20)}...`);
-    console.log(`   Items: ${cluster.items.length}`);
-    console.log(`   Categories: ${cluster.categories.join(', ')}`);
-    console.log(`   SDs: ${cluster.sds.length}`);
-    console.log(`   Reason: ${cluster.reason}`);
+  // Part 1: Find promotable feedback clusters
+  console.log('─'.repeat(60));
+  console.log('PART 1: FEEDBACK CLUSTERS');
+  console.log('─'.repeat(60));
+  const feedbackClusters = await findPromotableClusters();
 
-    if (dryRun) {
-      console.log('   [DRY RUN] Would create draft pattern');
-      results.promoted++;
-      continue;
-    }
+  if (feedbackClusters.length === 0) {
+    console.log('✅ No feedback clusters ready for promotion');
+  } else {
+    console.log(`Found ${feedbackClusters.length} feedback cluster(s) ready for promotion:\n`);
 
-    try {
-      const patternResult = await createDraftPattern(cluster);
+    for (const cluster of feedbackClusters) {
+      console.log(`\n📦 Cluster: ${cluster.error_hash.substring(0, 20)}...`);
+      console.log(`   Items: ${cluster.items.length}`);
+      console.log(`   Categories: ${cluster.categories.join(', ')}`);
+      console.log(`   SDs: ${cluster.sds.length}`);
+      console.log(`   Reason: ${cluster.reason}`);
 
-      if (patternResult.exists) {
-        console.log(`   ⏭️  Skipped (similar pattern ${patternResult.pattern_id} exists)`);
-        results.skipped++;
-      } else if (patternResult.created) {
-        console.log(`   ✅ Created draft pattern: ${patternResult.pattern_id}`);
+      if (dryRun) {
+        console.log('   [DRY RUN] Would create draft pattern');
         results.promoted++;
-        results.patterns.push(patternResult.pattern_id);
+        continue;
       }
 
-      // Mark feedback items as processed
-      const feedbackIds = cluster.items.map(i => i.id);
-      await markProcessed(feedbackIds);
-      results.processed += feedbackIds.length;
+      try {
+        const patternResult = await createDraftPattern(cluster);
 
-    } catch (error) {
-      console.error(`   ❌ Error processing cluster: ${error.message}`);
+        if (patternResult.exists) {
+          console.log(`   ⏭️  Skipped (similar pattern ${patternResult.pattern_id} exists)`);
+          results.skipped++;
+        } else if (patternResult.created) {
+          console.log(`   ✅ Created draft pattern: ${patternResult.pattern_id}`);
+          results.promoted++;
+          results.patterns.push(patternResult.pattern_id);
+        }
+
+        // Mark feedback items as processed
+        const feedbackIds = cluster.items.map(i => i.id);
+        await markProcessed(feedbackIds);
+        results.processed += feedbackIds.length;
+
+      } catch (error) {
+        console.error(`   ❌ Error processing cluster: ${error.message}`);
+      }
     }
+  }
+
+  // Part 2: Find promotable quick_fix clusters (SD-LEO-ENH-QUICK-FIX-PATTERN-001)
+  console.log('\n' + '─'.repeat(60));
+  console.log('PART 2: QUICK-FIX CLUSTERS');
+  console.log('─'.repeat(60));
+
+  try {
+    const quickFixClusters = await findPromotableQuickFixClusters();
+
+    if (quickFixClusters.length === 0) {
+      console.log('✅ No quick-fix clusters ready for promotion');
+    } else {
+      console.log(`Found ${quickFixClusters.length} quick-fix cluster(s) ready for promotion:\n`);
+
+      for (const cluster of quickFixClusters) {
+        console.log(`\n🔧 Quick-Fix Cluster: "${cluster.title.substring(0, 40)}..."`);
+        console.log(`   Items: ${cluster.items.length}`);
+        console.log(`   Types: ${cluster.types.join(', ')}`);
+        console.log(`   Severities: ${cluster.severities.join(', ')}`);
+        console.log(`   Reason: ${cluster.reason}`);
+
+        if (dryRun) {
+          console.log('   [DRY RUN] Would create draft pattern');
+          results.quickFixPromoted++;
+          continue;
+        }
+
+        try {
+          const patternResult = await createQuickFixDraftPattern(cluster);
+
+          if (patternResult.exists) {
+            console.log(`   ⏭️  Skipped (similar pattern ${patternResult.pattern_id} exists)`);
+            results.quickFixSkipped++;
+          } else if (patternResult.created) {
+            console.log(`   ✅ Created draft pattern: ${patternResult.pattern_id}`);
+            results.quickFixPromoted++;
+            results.patterns.push(patternResult.pattern_id);
+          }
+        } catch (error) {
+          console.error(`   ❌ Error processing quick-fix cluster: ${error.message}`);
+        }
+      }
+    }
+  } catch (qfError) {
+    console.warn(`   ⚠️ Quick-fix clustering skipped: ${qfError.message}`);
   }
 
   console.log('\n' + '═'.repeat(60));
   console.log('📊 CLUSTERING JOB COMPLETE');
-  console.log(`   Patterns created: ${results.promoted}`);
-  console.log(`   Clusters skipped: ${results.skipped}`);
-  console.log(`   Feedback processed: ${results.processed}`);
+  console.log(`   Feedback patterns created: ${results.promoted}`);
+  console.log(`   Feedback clusters skipped: ${results.skipped}`);
+  console.log(`   Feedback items processed: ${results.processed}`);
+  console.log(`   Quick-fix patterns created: ${results.quickFixPromoted}`);
+  console.log(`   Quick-fix clusters skipped: ${results.quickFixSkipped}`);
+  console.log(`   Total patterns: ${results.patterns.length}`);
 
   return results;
 }
@@ -286,8 +447,10 @@ async function main() {
 export {
   runClusteringJob,
   findPromotableClusters,
+  findPromotableQuickFixClusters,
   evaluateForPromotion,
   createDraftPattern,
+  createQuickFixDraftPattern,
   markProcessed,
   THRESHOLDS
 };


### PR DESCRIPTION
## Summary
- Extends feedback-clusterer.js to query and promote recurring quick_fixes
- Adds quick_fix_cluster as valid source in issue_patterns table
- Uses lower threshold (3+) for quick_fix patterns vs feedback (5+)

## Test plan
- [x] Smoke tests pass
- [x] feedback-clusterer.js runs with --dry-run
- [x] Migration executed successfully
- [x] Code review: AC-001, AC-002, AC-003 met

## Related
SD-LEO-ENH-QUICK-FIX-PATTERN-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)