### PR TITLE
feat(session-lifecycle): implement intelligent session lifecycle management

### DIFF
--- a/database/migrations/20260201_fix_cleanup_release_reason.sql
+++ b/database/migrations/20260201_fix_cleanup_release_reason.sql
@@ -1,0 +1,90 @@
+-- Fix cleanup_stale_sessions to use valid release_reason
+-- SD-LEO-INFRA-INTELLIGENT-SESSION-LIFECYCLE-001
+-- Issue: sd_claims table has a check constraint on release_reason that doesn't include 'STALE_CLEANUP'
+-- Fix: Use 'timeout' for sd_claims which is an allowed value
+
+CREATE OR REPLACE FUNCTION cleanup_stale_sessions(
+  p_stale_threshold_seconds INTEGER DEFAULT 120,
+  p_batch_size INTEGER DEFAULT 100
+) RETURNS JSONB AS $$
+DECLARE
+  v_stale_count INTEGER := 0;
+  v_released_count INTEGER := 0;
+BEGIN
+  -- Step 1: Mark active sessions as stale if heartbeat too old
+  WITH stale_sessions AS (
+    SELECT session_id
+    FROM claude_sessions
+    WHERE status IN ('active', 'idle')
+      AND heartbeat_at < NOW() - (p_stale_threshold_seconds || ' seconds')::INTERVAL
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE claude_sessions cs
+    SET status = 'stale',
+        stale_at = NOW(),
+        stale_reason = 'HEARTBEAT_TIMEOUT',
+        updated_at = NOW()
+    FROM stale_sessions ss
+    WHERE cs.session_id = ss.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_stale_count FROM updated;
+
+  -- Step 2: Release stale sessions that have been stale for >30 seconds
+  WITH release_sessions AS (
+    SELECT session_id, sd_id
+    FROM claude_sessions
+    WHERE status = 'stale'
+      AND stale_at < NOW() - INTERVAL '30 seconds'
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  released AS (
+    UPDATE claude_sessions cs
+    SET status = 'released',
+        released_at = NOW(),
+        released_reason = 'STALE_CLEANUP',
+        sd_id = NULL,
+        track = NULL,
+        claimed_at = NULL,
+        updated_at = NOW()
+    FROM release_sessions rs
+    WHERE cs.session_id = rs.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_released_count FROM released;
+
+  -- Release SD claims for any recently released sessions
+  -- Use 'timeout' which is a valid value for sd_claims.release_reason
+  UPDATE sd_claims
+  SET released_at = NOW(), release_reason = 'timeout'
+  WHERE session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  ) AND released_at IS NULL;
+
+  -- Clear is_working_on for released sessions
+  UPDATE strategic_directives_v2
+  SET active_session_id = NULL, is_working_on = false
+  WHERE active_session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sessions_marked_stale', v_stale_count,
+    'sessions_released', v_released_count,
+    'stale_threshold_seconds', p_stale_threshold_seconds,
+    'batch_size', p_batch_size,
+    'executed_at', NOW()
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cleanup_stale_sessions IS
+  'Batch cleanup of stale sessions: marks stale after threshold, releases after 30s stale. Uses timeout for sd_claims release_reason. Part of FR-4.';

--- a/database/migrations/20260201_fix_cleanup_stale_sessions.sql
+++ b/database/migrations/20260201_fix_cleanup_stale_sessions.sql
@@ -1,0 +1,89 @@
+-- Fix cleanup_stale_sessions function
+-- SD-LEO-INFRA-INTELLIGENT-SESSION-LIFECYCLE-001
+-- Issue: Previous version used RETURNING ... INTO with multiple rows, causing P0003 error
+-- Fix: Use COUNT(*) with CTE to get row count
+
+CREATE OR REPLACE FUNCTION cleanup_stale_sessions(
+  p_stale_threshold_seconds INTEGER DEFAULT 120,
+  p_batch_size INTEGER DEFAULT 100
+) RETURNS JSONB AS $$
+DECLARE
+  v_stale_count INTEGER := 0;
+  v_released_count INTEGER := 0;
+BEGIN
+  -- Step 1: Mark active sessions as stale if heartbeat too old
+  WITH stale_sessions AS (
+    SELECT session_id
+    FROM claude_sessions
+    WHERE status IN ('active', 'idle')
+      AND heartbeat_at < NOW() - (p_stale_threshold_seconds || ' seconds')::INTERVAL
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE claude_sessions cs
+    SET status = 'stale',
+        stale_at = NOW(),
+        stale_reason = 'HEARTBEAT_TIMEOUT',
+        updated_at = NOW()
+    FROM stale_sessions ss
+    WHERE cs.session_id = ss.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_stale_count FROM updated;
+
+  -- Step 2: Release stale sessions that have been stale for >30 seconds
+  WITH release_sessions AS (
+    SELECT session_id, sd_id
+    FROM claude_sessions
+    WHERE status = 'stale'
+      AND stale_at < NOW() - INTERVAL '30 seconds'
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  released AS (
+    UPDATE claude_sessions cs
+    SET status = 'released',
+        released_at = NOW(),
+        released_reason = 'STALE_CLEANUP',
+        sd_id = NULL,
+        track = NULL,
+        claimed_at = NULL,
+        updated_at = NOW()
+    FROM release_sessions rs
+    WHERE cs.session_id = rs.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_released_count FROM released;
+
+  -- Release SD claims for any released sessions
+  UPDATE sd_claims
+  SET released_at = NOW(), release_reason = 'STALE_CLEANUP'
+  WHERE session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  ) AND released_at IS NULL;
+
+  -- Clear is_working_on for released sessions
+  UPDATE strategic_directives_v2
+  SET active_session_id = NULL, is_working_on = false
+  WHERE active_session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sessions_marked_stale', v_stale_count,
+    'sessions_released', v_released_count,
+    'stale_threshold_seconds', p_stale_threshold_seconds,
+    'batch_size', p_batch_size,
+    'executed_at', NOW()
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cleanup_stale_sessions IS
+  'Batch cleanup of stale sessions: marks stale after threshold, releases after 30s stale. Fixed to handle multiple rows. Part of FR-4.';

--- a/database/migrations/20260201_intelligent_session_lifecycle.sql
+++ b/database/migrations/20260201_intelligent_session_lifecycle.sql
@@ -1,0 +1,608 @@
+-- Intelligent Session Lifecycle Management
+-- SD-LEO-INFRA-INTELLIGENT-SESSION-LIFECYCLE-001
+-- Purpose: Add terminal identity tracking, auto-release, and lifecycle event logging
+-- Created: 2026-02-01
+
+-- ============================================================================
+-- FR-1: Terminal Identity Tracking for Auto-Release
+-- Purpose: Track machine_id and terminal_id to auto-release previous sessions
+-- ============================================================================
+
+-- Add machine_id and terminal_id columns if they don't exist
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'claude_sessions' AND column_name = 'machine_id'
+  ) THEN
+    ALTER TABLE claude_sessions ADD COLUMN machine_id TEXT;
+    RAISE NOTICE 'Added machine_id column to claude_sessions';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'claude_sessions' AND column_name = 'terminal_id'
+  ) THEN
+    ALTER TABLE claude_sessions ADD COLUMN terminal_id TEXT;
+    RAISE NOTICE 'Added terminal_id column to claude_sessions';
+  END IF;
+
+  -- Add released_reason column for tracking why sessions were released
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'claude_sessions' AND column_name = 'released_reason'
+  ) THEN
+    ALTER TABLE claude_sessions ADD COLUMN released_reason TEXT;
+    RAISE NOTICE 'Added released_reason column to claude_sessions';
+  END IF;
+
+  -- Add released_at column for tracking when sessions were released
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'claude_sessions' AND column_name = 'released_at'
+  ) THEN
+    ALTER TABLE claude_sessions ADD COLUMN released_at TIMESTAMPTZ;
+    RAISE NOTICE 'Added released_at column to claude_sessions';
+  END IF;
+
+  -- Add stale_at column for tracking when sessions became stale
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'claude_sessions' AND column_name = 'stale_at'
+  ) THEN
+    ALTER TABLE claude_sessions ADD COLUMN stale_at TIMESTAMPTZ;
+    RAISE NOTICE 'Added stale_at column to claude_sessions';
+  END IF;
+
+  -- Add stale_reason column
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'claude_sessions' AND column_name = 'stale_reason'
+  ) THEN
+    ALTER TABLE claude_sessions ADD COLUMN stale_reason TEXT;
+    RAISE NOTICE 'Added stale_reason column to claude_sessions';
+  END IF;
+
+  -- Add pid_validated_at column for PID validation caching
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'claude_sessions' AND column_name = 'pid_validated_at'
+  ) THEN
+    ALTER TABLE claude_sessions ADD COLUMN pid_validated_at TIMESTAMPTZ;
+    RAISE NOTICE 'Added pid_validated_at column to claude_sessions';
+  END IF;
+END $$;
+
+-- Create computed terminal_identity column
+ALTER TABLE claude_sessions DROP COLUMN IF EXISTS terminal_identity;
+ALTER TABLE claude_sessions ADD COLUMN terminal_identity TEXT
+  GENERATED ALWAYS AS (COALESCE(machine_id, '') || ':' || COALESCE(terminal_id, tty, '')) STORED;
+
+COMMENT ON COLUMN claude_sessions.terminal_identity IS
+  'Computed identity from machine_id:terminal_id for uniqueness. Part of FR-1.';
+
+-- ============================================================================
+-- FR-1: Partial Unique Index for Single Active Session per Terminal
+-- ============================================================================
+
+-- Create partial unique index on terminal_identity for active sessions
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE indexname = 'idx_claude_sessions_unique_terminal_active'
+  ) THEN
+    CREATE UNIQUE INDEX idx_claude_sessions_unique_terminal_active
+    ON claude_sessions (terminal_identity)
+    WHERE terminal_identity IS NOT NULL
+      AND terminal_identity != ':'
+      AND status IN ('active', 'idle');
+
+    RAISE NOTICE 'Created unique index idx_claude_sessions_unique_terminal_active';
+  ELSE
+    RAISE NOTICE 'Index idx_claude_sessions_unique_terminal_active already exists';
+  END IF;
+END $$;
+
+COMMENT ON INDEX idx_claude_sessions_unique_terminal_active IS
+  'Enforces single active/idle session per terminal identity. Prevents same-terminal duplicates. Part of FR-1.';
+
+-- ============================================================================
+-- FR-1: Auto-Release Function for Same Terminal
+-- Purpose: Atomically release previous session and create new one
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION create_or_replace_session(
+  p_session_id TEXT,
+  p_machine_id TEXT,
+  p_terminal_id TEXT,
+  p_tty TEXT,
+  p_pid INTEGER,
+  p_hostname TEXT,
+  p_codebase TEXT,
+  p_metadata JSONB DEFAULT '{}'::JSONB
+) RETURNS JSONB AS $$
+DECLARE
+  v_terminal_identity TEXT;
+  v_previous_session RECORD;
+  v_auto_released BOOLEAN := false;
+  v_previous_session_id TEXT := NULL;
+BEGIN
+  -- Compute terminal identity
+  v_terminal_identity := COALESCE(p_machine_id, '') || ':' || COALESCE(p_terminal_id, p_tty, '');
+
+  -- Find and release any existing active session for this terminal identity
+  SELECT session_id, sd_id, status INTO v_previous_session
+  FROM claude_sessions
+  WHERE terminal_identity = v_terminal_identity
+    AND status IN ('active', 'idle')
+    AND session_id != p_session_id
+  FOR UPDATE SKIP LOCKED
+  LIMIT 1;
+
+  IF v_previous_session IS NOT NULL THEN
+    -- Auto-release the previous session
+    UPDATE claude_sessions
+    SET status = 'released',
+        released_at = NOW(),
+        released_reason = 'AUTO_REPLACED',
+        updated_at = NOW()
+    WHERE session_id = v_previous_session.session_id;
+
+    -- If it had an SD claim, release that too
+    IF v_previous_session.sd_id IS NOT NULL THEN
+      UPDATE sd_claims
+      SET released_at = NOW(), release_reason = 'AUTO_REPLACED'
+      WHERE session_id = v_previous_session.session_id AND released_at IS NULL;
+
+      UPDATE strategic_directives_v2
+      SET active_session_id = NULL, is_working_on = false
+      WHERE active_session_id = v_previous_session.session_id;
+    END IF;
+
+    v_auto_released := true;
+    v_previous_session_id := v_previous_session.session_id;
+
+    RAISE NOTICE 'Auto-released previous session % for terminal %',
+      v_previous_session.session_id, v_terminal_identity;
+  END IF;
+
+  -- Upsert the new session
+  INSERT INTO claude_sessions (
+    session_id, machine_id, terminal_id, tty, pid, hostname, codebase,
+    status, heartbeat_at, metadata, created_at, updated_at
+  ) VALUES (
+    p_session_id, p_machine_id, p_terminal_id, p_tty, p_pid, p_hostname, p_codebase,
+    'idle', NOW(), p_metadata, NOW(), NOW()
+  )
+  ON CONFLICT (session_id) DO UPDATE SET
+    machine_id = EXCLUDED.machine_id,
+    terminal_id = EXCLUDED.terminal_id,
+    tty = EXCLUDED.tty,
+    pid = EXCLUDED.pid,
+    hostname = EXCLUDED.hostname,
+    heartbeat_at = NOW(),
+    metadata = EXCLUDED.metadata,
+    status = CASE
+      WHEN claude_sessions.status = 'released' THEN 'idle'
+      ELSE claude_sessions.status
+    END,
+    updated_at = NOW();
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'terminal_identity', v_terminal_identity,
+    'auto_released', v_auto_released,
+    'previous_session_id', v_previous_session_id,
+    'created_at', NOW()
+  );
+
+EXCEPTION
+  WHEN unique_violation THEN
+    -- Race condition: another session claimed the terminal identity
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'terminal_conflict',
+      'message', format('Terminal identity %s already claimed by another session', v_terminal_identity)
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION create_or_replace_session IS
+  'Atomically creates a session, auto-releasing any previous session for the same terminal identity. Part of FR-1.';
+
+-- ============================================================================
+-- FR-3: Enhanced Session Release Function
+-- Purpose: Release session with reason tracking and idempotency
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION release_session(
+  p_session_id TEXT,
+  p_reason TEXT DEFAULT 'graceful_exit'
+) RETURNS JSONB AS $$
+DECLARE
+  v_session RECORD;
+BEGIN
+  -- Get current session state
+  SELECT session_id, status, sd_id, released_at INTO v_session
+  FROM claude_sessions
+  WHERE session_id = p_session_id;
+
+  IF v_session IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'session_not_found',
+      'message', format('Session %s not found', p_session_id)
+    );
+  END IF;
+
+  -- Idempotent: if already released, return success with original timestamp
+  IF v_session.status = 'released' THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'already_released', true,
+      'session_id', p_session_id,
+      'released_at', v_session.released_at
+    );
+  END IF;
+
+  -- Release any SD claim first
+  IF v_session.sd_id IS NOT NULL THEN
+    UPDATE sd_claims
+    SET released_at = NOW(), release_reason = p_reason
+    WHERE session_id = p_session_id AND released_at IS NULL;
+
+    UPDATE strategic_directives_v2
+    SET active_session_id = NULL, is_working_on = false
+    WHERE active_session_id = p_session_id;
+  END IF;
+
+  -- Update session to released
+  UPDATE claude_sessions
+  SET status = 'released',
+      released_at = NOW(),
+      released_reason = p_reason,
+      sd_id = NULL,
+      track = NULL,
+      claimed_at = NULL,
+      updated_at = NOW()
+  WHERE session_id = p_session_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'released_at', NOW(),
+    'reason', p_reason,
+    'had_sd_claim', v_session.sd_id IS NOT NULL
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION release_session IS
+  'Releases a session with reason tracking. Idempotent - safe to call multiple times. Part of FR-3.';
+
+-- ============================================================================
+-- FR-4: Cleanup Stale Sessions Function (Enhanced)
+-- Purpose: Mark stale sessions and release them with batch processing
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION cleanup_stale_sessions(
+  p_stale_threshold_seconds INTEGER DEFAULT 120,
+  p_batch_size INTEGER DEFAULT 100
+) RETURNS JSONB AS $$
+DECLARE
+  v_stale_count INTEGER := 0;
+  v_released_count INTEGER := 0;
+  v_stale_ids TEXT[];
+  v_release_ids TEXT[];
+BEGIN
+  -- Step 1: Mark active sessions as stale if heartbeat too old
+  WITH stale_sessions AS (
+    SELECT session_id
+    FROM claude_sessions
+    WHERE status IN ('active', 'idle')
+      AND heartbeat_at < NOW() - (p_stale_threshold_seconds || ' seconds')::INTERVAL
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE claude_sessions cs
+  SET status = 'stale',
+      stale_at = NOW(),
+      stale_reason = 'HEARTBEAT_TIMEOUT',
+      updated_at = NOW()
+  FROM stale_sessions ss
+  WHERE cs.session_id = ss.session_id
+  RETURNING cs.session_id INTO v_stale_ids;
+
+  v_stale_count := COALESCE(array_length(v_stale_ids, 1), 0);
+
+  -- Step 2: Release stale sessions that have been stale for >30 seconds
+  WITH release_sessions AS (
+    SELECT session_id, sd_id
+    FROM claude_sessions
+    WHERE status = 'stale'
+      AND stale_at < NOW() - INTERVAL '30 seconds'
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE claude_sessions cs
+  SET status = 'released',
+      released_at = NOW(),
+      released_reason = 'STALE_CLEANUP',
+      sd_id = NULL,
+      track = NULL,
+      claimed_at = NULL,
+      updated_at = NOW()
+  FROM release_sessions rs
+  WHERE cs.session_id = rs.session_id
+  RETURNING cs.session_id INTO v_release_ids;
+
+  v_released_count := COALESCE(array_length(v_release_ids, 1), 0);
+
+  -- Release SD claims for released sessions
+  UPDATE sd_claims
+  SET released_at = NOW(), release_reason = 'STALE_CLEANUP'
+  WHERE session_id = ANY(v_release_ids) AND released_at IS NULL;
+
+  -- Clear is_working_on for released sessions
+  UPDATE strategic_directives_v2
+  SET active_session_id = NULL, is_working_on = false
+  WHERE active_session_id = ANY(v_release_ids);
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sessions_marked_stale', v_stale_count,
+    'sessions_released', v_released_count,
+    'stale_threshold_seconds', p_stale_threshold_seconds,
+    'batch_size', p_batch_size,
+    'executed_at', NOW()
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cleanup_stale_sessions IS
+  'Batch cleanup of stale sessions: marks stale after threshold, releases after 30s stale. Part of FR-4.';
+
+-- ============================================================================
+-- FR-2: PID Validation Reporting Function
+-- Purpose: Mark session stale when PID validation fails
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION report_pid_validation_failure(
+  p_session_id TEXT,
+  p_machine_id TEXT
+) RETURNS JSONB AS $$
+DECLARE
+  v_session RECORD;
+BEGIN
+  -- Get session info
+  SELECT session_id, machine_id, status INTO v_session
+  FROM claude_sessions
+  WHERE session_id = p_session_id;
+
+  IF v_session IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'session_not_found'
+    );
+  END IF;
+
+  -- Verify machine_id matches (security: prevent cross-machine false positives)
+  IF v_session.machine_id IS NOT NULL AND v_session.machine_id != p_machine_id THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'machine_mismatch',
+      'message', 'PID validation must be reported from same machine'
+    );
+  END IF;
+
+  -- Only mark stale if currently active/idle
+  IF v_session.status NOT IN ('active', 'idle') THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'already_processed', true,
+      'current_status', v_session.status
+    );
+  END IF;
+
+  -- Mark session as stale due to PID not found
+  UPDATE claude_sessions
+  SET status = 'stale',
+      stale_at = NOW(),
+      stale_reason = 'PID_NOT_FOUND',
+      pid_validated_at = NOW(),
+      updated_at = NOW()
+  WHERE session_id = p_session_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'new_status', 'stale',
+    'stale_reason', 'PID_NOT_FOUND',
+    'stale_at', NOW()
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION report_pid_validation_failure IS
+  'Marks a session as stale when PID validation fails. Includes machine_id check for safety. Part of FR-2.';
+
+-- ============================================================================
+-- FR-5: Session Lifecycle Events Table for Observability
+-- Purpose: Log all session lifecycle events for metrics and debugging
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS session_lifecycle_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  machine_id TEXT,
+  terminal_id TEXT,
+  pid INTEGER,
+  reason TEXT,
+  latency_ms INTEGER,
+  metadata JSONB DEFAULT '{}'::JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Add index for querying by session and time
+CREATE INDEX IF NOT EXISTS idx_session_lifecycle_events_session
+ON session_lifecycle_events (session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_session_lifecycle_events_type_time
+ON session_lifecycle_events (event_type, created_at DESC);
+
+COMMENT ON TABLE session_lifecycle_events IS
+  'Audit log for session lifecycle events: create, heartbeat, stale, release. Part of FR-5.';
+
+-- ============================================================================
+-- FR-5: Function to Log Lifecycle Events
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION log_session_event(
+  p_event_type TEXT,
+  p_session_id TEXT,
+  p_machine_id TEXT DEFAULT NULL,
+  p_terminal_id TEXT DEFAULT NULL,
+  p_pid INTEGER DEFAULT NULL,
+  p_reason TEXT DEFAULT NULL,
+  p_latency_ms INTEGER DEFAULT NULL,
+  p_metadata JSONB DEFAULT '{}'::JSONB
+) RETURNS UUID AS $$
+DECLARE
+  v_event_id UUID;
+BEGIN
+  INSERT INTO session_lifecycle_events (
+    event_type, session_id, machine_id, terminal_id, pid, reason, latency_ms, metadata
+  ) VALUES (
+    p_event_type, p_session_id, p_machine_id, p_terminal_id, p_pid, p_reason, p_latency_ms, p_metadata
+  )
+  RETURNING id INTO v_event_id;
+
+  RETURN v_event_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION log_session_event IS
+  'Logs a session lifecycle event for observability. Part of FR-5.';
+
+-- ============================================================================
+-- FR-5: View for Session Metrics
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_session_metrics AS
+SELECT
+  (SELECT COUNT(*) FROM claude_sessions WHERE status IN ('active', 'idle')) as active_sessions_count,
+  (SELECT COUNT(*) FROM claude_sessions WHERE status = 'stale') as stale_sessions_count,
+  (SELECT COUNT(*) FROM session_lifecycle_events
+   WHERE event_type = 'SESSION_RELEASED'
+   AND created_at > NOW() - INTERVAL '1 hour') as releases_last_hour,
+  (SELECT AVG(latency_ms) FROM session_lifecycle_events
+   WHERE event_type = 'SESSION_RELEASED'
+   AND latency_ms IS NOT NULL
+   AND created_at > NOW() - INTERVAL '1 hour') as avg_release_latency_ms,
+  (SELECT COUNT(*) FROM session_lifecycle_events
+   WHERE event_type = 'PID_VALIDATION_FAILED'
+   AND created_at > NOW() - INTERVAL '24 hours') as pid_validation_failures_24h,
+  (SELECT COUNT(*) FROM session_lifecycle_events
+   WHERE reason = 'AUTO_REPLACED'
+   AND created_at > NOW() - INTERVAL '24 hours') as auto_replacements_24h;
+
+COMMENT ON VIEW v_session_metrics IS
+  'Aggregated session metrics for observability dashboards. Part of FR-5.';
+
+-- ============================================================================
+-- Update v_active_sessions view with new columns
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_active_sessions AS
+SELECT
+  cs.id,
+  cs.session_id,
+  cs.sd_id,
+  sd.title as sd_title,
+  cs.track,
+  cs.tty,
+  cs.pid,
+  cs.hostname,
+  cs.codebase,
+  cs.machine_id,
+  cs.terminal_id,
+  cs.terminal_identity,
+  cs.claimed_at,
+  cs.heartbeat_at,
+  cs.status,
+  cs.released_reason,
+  cs.released_at,
+  cs.stale_reason,
+  cs.stale_at,
+  cs.metadata,
+  cs.created_at,
+  EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) as heartbeat_age_seconds,
+  EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 60 as heartbeat_age_minutes,
+  GREATEST(0, 300 - EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at))) as seconds_until_stale,
+  CASE
+    WHEN cs.status = 'released' THEN 'released'
+    WHEN cs.status = 'stale' THEN 'stale'
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) > 300 THEN 'stale'
+    WHEN cs.sd_id IS NULL THEN 'idle'
+    ELSE 'active'
+  END as computed_status,
+  CASE
+    WHEN cs.claimed_at IS NOT NULL
+    THEN EXTRACT(EPOCH FROM (NOW() - cs.claimed_at)) / 60
+    ELSE NULL
+  END as claim_duration_minutes,
+  CASE
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 60 THEN
+      EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at))::int || 's ago'
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 3600 THEN
+      (EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 60)::int || 'm ago'
+    ELSE
+      (EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 3600)::int || 'h ago'
+  END as heartbeat_age_human
+FROM claude_sessions cs
+LEFT JOIN strategic_directives_v2 sd ON cs.sd_id = sd.sd_key
+WHERE cs.status NOT IN ('released')
+ORDER BY cs.track NULLS LAST, cs.claimed_at DESC;
+
+COMMENT ON VIEW v_active_sessions IS
+  'Active sessions with terminal identity, staleness info, and lifecycle timestamps. Enhanced for SD-LEO-INFRA-ISL-001.';
+
+-- ============================================================================
+-- Verification
+-- ============================================================================
+
+DO $$
+BEGIN
+  -- Verify terminal_identity index
+  IF EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE indexname = 'idx_claude_sessions_unique_terminal_active'
+  ) THEN
+    RAISE NOTICE 'SUCCESS: Terminal identity unique index exists';
+  ELSE
+    RAISE WARNING 'FAILED: Terminal identity unique index not created';
+  END IF;
+
+  -- Verify lifecycle events table
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_name = 'session_lifecycle_events'
+  ) THEN
+    RAISE NOTICE 'SUCCESS: session_lifecycle_events table exists';
+  ELSE
+    RAISE WARNING 'FAILED: session_lifecycle_events table not created';
+  END IF;
+
+  -- Verify new columns
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'claude_sessions' AND column_name = 'terminal_identity'
+  ) THEN
+    RAISE NOTICE 'SUCCESS: terminal_identity column exists';
+  ELSE
+    RAISE WARNING 'FAILED: terminal_identity column not created';
+  END IF;
+END $$;

--- a/lib/heartbeat-manager.mjs
+++ b/lib/heartbeat-manager.mjs
@@ -15,20 +15,85 @@
  * (well within the 60s requirement, providing safety margin).
  */
 
-import { updateHeartbeat as dbUpdateHeartbeat } from './session-manager.mjs';
+import { updateHeartbeat as dbUpdateHeartbeat, endSession } from './session-manager.mjs';
 
 // Configuration
 const HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds (safety margin under 60s requirement)
 const MAX_CONSECUTIVE_FAILURES = 3;
+const GRACEFUL_EXIT_TIMEOUT_MS = 5000; // 5 second timeout for graceful release (FR-3/US-002)
+const GRACEFUL_EXIT_RETRIES = 3; // Number of retry attempts
 
 // Module state
 let heartbeatInterval = null;
 let currentSessionId = null;
 let consecutiveFailures = 0;
 let lastSuccessfulHeartbeat = null;
+let isReleasing = false; // Prevent duplicate release attempts
+let exitHandlersRegistered = false;
+
+/**
+ * SD-LEO-INFRA-ISL-001 (US-002): Release session with retry and timeout
+ * Attempts graceful release within 5 seconds, with exponential backoff retries
+ *
+ * @param {string} reason - Release reason
+ * @returns {Promise<{success: boolean, latency_ms?: number}>}
+ */
+async function releaseSessionWithRetry(reason = 'graceful_exit') {
+  if (isReleasing) {
+    console.log('[Heartbeat] Release already in progress, skipping duplicate');
+    return { success: true, skipped: true };
+  }
+
+  if (!currentSessionId) {
+    return { success: false, error: 'no_session' };
+  }
+
+  isReleasing = true;
+  const startTime = Date.now();
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= GRACEFUL_EXIT_RETRIES; attempt++) {
+    try {
+      // Create a timeout promise
+      const timeoutPromise = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('Release timeout')), GRACEFUL_EXIT_TIMEOUT_MS);
+      });
+
+      // Race between release and timeout
+      const result = await Promise.race([
+        endSession(reason),
+        timeoutPromise
+      ]);
+
+      if (result?.success) {
+        const latencyMs = Date.now() - startTime;
+        console.log(`[Heartbeat] Session released successfully (${latencyMs}ms)`);
+        isReleasing = false;
+        return { success: true, latency_ms: latencyMs };
+      }
+
+      lastError = new Error(result?.error || 'Unknown error');
+    } catch (err) {
+      lastError = err;
+      const backoffMs = Math.pow(2, attempt - 1) * 100; // 100ms, 200ms, 400ms
+      console.warn(`[Heartbeat] Release attempt ${attempt}/${GRACEFUL_EXIT_RETRIES} failed: ${err.message}`);
+
+      if (attempt < GRACEFUL_EXIT_RETRIES) {
+        await new Promise(resolve => setTimeout(resolve, backoffMs));
+      }
+    }
+  }
+
+  // All retries failed - log warning, heartbeat cleanup will handle it
+  console.warn(`[Heartbeat] Graceful release failed after ${GRACEFUL_EXIT_RETRIES} attempts, relying on heartbeat cleanup`);
+  isReleasing = false;
+  return { success: false, error: lastError?.message };
+}
 
 /**
  * Start automatic heartbeat updates for a session
+ * SD-LEO-INFRA-ISL-001 (US-002): Enhanced with graceful exit handlers
+ *
  * @param {string} sessionId - Session ID to send heartbeats for
  * @returns {object} - Result with success status
  */
@@ -54,16 +119,39 @@ export function startHeartbeat(sessionId) {
     sendHeartbeat();
   }, HEARTBEAT_INTERVAL_MS);
 
-  // Ensure cleanup on process exit
-  process.on('beforeExit', stopHeartbeat);
-  process.on('SIGINT', () => {
-    stopHeartbeat();
-    process.exit(0);
-  });
-  process.on('SIGTERM', () => {
-    stopHeartbeat();
-    process.exit(0);
-  });
+  // SD-LEO-INFRA-ISL-001 (US-002): Enhanced exit handlers with graceful release
+  // Only register once to prevent duplicate handlers
+  if (!exitHandlersRegistered) {
+    exitHandlersRegistered = true;
+
+    // Handle graceful exit (Ctrl+C, normal exit)
+    const gracefulExitHandler = async (signal) => {
+      console.log(`[Heartbeat] Received ${signal}, releasing session...`);
+      stopHeartbeat();
+      await releaseSessionWithRetry(`${signal.toLowerCase()}_exit`);
+      process.exit(0);
+    };
+
+    process.on('SIGINT', () => gracefulExitHandler('SIGINT'));
+    process.on('SIGTERM', () => gracefulExitHandler('SIGTERM'));
+
+    // beforeExit is async-safe, use for final cleanup
+    process.on('beforeExit', async (code) => {
+      if (currentSessionId) {
+        console.log(`[Heartbeat] beforeExit (code ${code}), releasing session...`);
+        await releaseSessionWithRetry('process_exit');
+      }
+    });
+
+    // exit is sync-only, just log
+    process.on('exit', (code) => {
+      if (heartbeatInterval) {
+        clearInterval(heartbeatInterval);
+        heartbeatInterval = null;
+      }
+      console.log(`[Heartbeat] Process exiting (code ${code})`);
+    });
+  }
 
   console.log(`[Heartbeat] Started automatic heartbeat (every ${HEARTBEAT_INTERVAL_MS / 1000}s)`);
 
@@ -168,11 +256,79 @@ export async function forceHeartbeat() {
   };
 }
 
+/**
+ * SD-LEO-INFRA-ISL-001 (US-003): Validate if a process ID is still running
+ * Uses OS-level check (process.kill with signal 0)
+ *
+ * @param {number} pid - Process ID to validate
+ * @returns {boolean} - true if process exists, false otherwise
+ */
+export function isProcessRunning(pid) {
+  if (!pid || typeof pid !== 'number') {
+    return false;
+  }
+
+  try {
+    // Signal 0 checks process existence without sending a signal
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH means process doesn't exist
+    if (err.code === 'ESRCH') {
+      return false;
+    }
+    // EPERM means process exists but we don't have permission
+    if (err.code === 'EPERM') {
+      return true;
+    }
+    // Other errors - assume process doesn't exist
+    return false;
+  }
+}
+
+/**
+ * SD-LEO-INFRA-ISL-001 (US-003): Validate PID and report failure if not running
+ * Used by cleanup workers to detect orphaned sessions
+ *
+ * @param {string} sessionId - Session ID to validate
+ * @param {number} pid - Process ID to check
+ * @param {string} machineId - Machine ID for cross-machine safety
+ * @param {object} supabase - Supabase client
+ * @returns {Promise<{valid: boolean, reported?: boolean}>}
+ */
+export async function validateAndReportPid(sessionId, pid, machineId, supabase) {
+  const isRunning = isProcessRunning(pid);
+
+  if (isRunning) {
+    return { valid: true };
+  }
+
+  // Report PID validation failure to database
+  try {
+    const { data, error } = await supabase.rpc('report_pid_validation_failure', {
+      p_session_id: sessionId,
+      p_machine_id: machineId
+    });
+
+    if (error) {
+      console.warn(`[Heartbeat] Failed to report PID validation failure: ${error.message}`);
+      return { valid: false, reported: false, error: error.message };
+    }
+
+    console.log(`[Heartbeat] Reported PID validation failure for session ${sessionId}`);
+    return { valid: false, reported: true, result: data };
+  } catch (err) {
+    return { valid: false, reported: false, error: err.message };
+  }
+}
+
 // Export default object
 export default {
   startHeartbeat,
   stopHeartbeat,
   isHeartbeatActive,
   getHeartbeatStats,
-  forceHeartbeat
+  forceHeartbeat,
+  isProcessRunning,
+  validateAndReportPid
 };

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -51,6 +51,43 @@ function getTTY() {
 }
 
 /**
+ * SD-LEO-INFRA-ISL-001: Get machine identifier for terminal identity
+ * Uses hostname + OS info to create a unique machine ID
+ */
+function getMachineId() {
+  try {
+    const hostname = os.hostname();
+    const platform = os.platform();
+    const arch = os.arch();
+    // Create a hash of machine characteristics
+    const machineString = `${hostname}-${platform}-${arch}`;
+    return crypto.createHash('sha256').update(machineString).digest('hex').substring(0, 16);
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * SD-LEO-INFRA-ISL-001: Get terminal identifier
+ * Uses TTY path or window ID on Windows
+ */
+function getTerminalId() {
+  try {
+    if (process.platform === 'win32') {
+      // Use parent PID as terminal identifier on Windows
+      return `win-ppid-${process.ppid || process.pid}`;
+    }
+    // On Unix, use the TTY device path
+    const tty = execSync('tty', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    // Hash the TTY path for cleaner ID
+    return crypto.createHash('sha256').update(tty).digest('hex').substring(0, 12);
+  } catch {
+    // Fallback to PID-based
+    return `pid-${process.ppid || process.pid}`;
+  }
+}
+
+/**
  * Get the current git branch
  */
 function getBranch() {
@@ -166,6 +203,7 @@ async function getGlobalDefaults() {
 
 /**
  * Get or create a session for the current terminal
+ * SD-LEO-INFRA-ISL-001: Uses create_or_replace_session for atomic auto-release
  */
 export async function getOrCreateSession() {
   // Check for existing session
@@ -185,11 +223,23 @@ export async function getOrCreateSession() {
   const codebase = getCodebase();
   const branch = getBranch();
 
+  // SD-LEO-INFRA-ISL-001: Get terminal identity components
+  const machineId = getMachineId();
+  const terminalId = getTerminalId();
+
   // Get global defaults for new sessions
   const defaults = await getGlobalDefaults();
 
+  const metadata = {
+    branch,
+    auto_proceed: defaults.auto_proceed,
+    chain_orchestrators: defaults.chain_orchestrators
+  };
+
   const sessionData = {
     session_id: sessionId,
+    machine_id: machineId,
+    terminal_id: terminalId,
     tty,
     pid,
     hostname,
@@ -199,37 +249,70 @@ export async function getOrCreateSession() {
     claimed_at: null,
     heartbeat_at: new Date().toISOString(),
     created_at: new Date().toISOString(),
-    metadata: {
-      branch,
-      auto_proceed: defaults.auto_proceed,
-      chain_orchestrators: defaults.chain_orchestrators
-    }
+    metadata
   };
 
   // Save to local file
   ensureSessionDir();
   fs.writeFileSync(getSessionFilePath(sessionId), JSON.stringify(sessionData, null, 2));
 
-  // Save to database
-  const { error } = await supabase
-    .from('claude_sessions')
-    .upsert({
-      session_id: sessionId,
-      tty,
-      pid,
-      hostname,
-      codebase,
-      status: 'idle',
-      metadata: {
-        branch,
-        auto_proceed: defaults.auto_proceed,
-        chain_orchestrators: defaults.chain_orchestrators
-      }
-    }, { onConflict: 'session_id' });
+  // SD-LEO-INFRA-ISL-001: Use create_or_replace_session for atomic auto-release
+  const { data: dbResult, error } = await supabase.rpc('create_or_replace_session', {
+    p_session_id: sessionId,
+    p_machine_id: machineId,
+    p_terminal_id: terminalId,
+    p_tty: tty,
+    p_pid: pid,
+    p_hostname: hostname,
+    p_codebase: codebase,
+    p_metadata: metadata
+  });
 
   if (error) {
-    console.error('Warning: Could not register session in database:', error.message);
+    // Fallback to direct upsert if RPC not available
+    console.warn('Warning: create_or_replace_session RPC failed, using fallback:', error.message);
+    const { error: upsertError } = await supabase
+      .from('claude_sessions')
+      .upsert({
+        session_id: sessionId,
+        machine_id: machineId,
+        terminal_id: terminalId,
+        tty,
+        pid,
+        hostname,
+        codebase,
+        status: 'idle',
+        metadata
+      }, { onConflict: 'session_id' });
+
+    if (upsertError) {
+      console.error('Warning: Could not register session in database:', upsertError.message);
+    }
+  } else if (dbResult?.auto_released) {
+    // Log auto-release event for observability (FR-5)
+    console.log(`[Session] Auto-released previous session ${dbResult.previous_session_id} for terminal ${dbResult.terminal_identity}`);
+
+    // Log to session lifecycle events
+    await supabase.rpc('log_session_event', {
+      p_event_type: 'SESSION_AUTO_RELEASED',
+      p_session_id: dbResult.previous_session_id,
+      p_machine_id: machineId,
+      p_terminal_id: terminalId,
+      p_pid: pid,
+      p_reason: 'AUTO_REPLACED',
+      p_metadata: { new_session_id: sessionId }
+    }).catch(() => {}); // Silent fail for telemetry
   }
+
+  // Log session creation event
+  await supabase.rpc('log_session_event', {
+    p_event_type: 'SESSION_CREATED',
+    p_session_id: sessionId,
+    p_machine_id: machineId,
+    p_terminal_id: terminalId,
+    p_pid: pid,
+    p_metadata: { codebase, hostname }
+  }).catch(() => {}); // Silent fail for telemetry
 
   return sessionData;
 }
@@ -305,17 +388,22 @@ export async function getClaimedSessions() {
 
 /**
  * Cleanup stale sessions (>5 min no heartbeat)
+ * SD-LEO-INFRA-ISL-001: Enhanced with PID validation (FR-2/US-003) and status file cleanup (US-006)
  */
 export async function cleanupStaleSessions() {
   const results = {
     localCleaned: 0,
     dbCleaned: 0,
+    dbStaleMarked: 0,
+    pidValidationFailed: 0,
+    statusFilesCleaned: 0,
     errors: []
   };
 
-  // Cleanup local files
+  // Cleanup local session files
   ensureSessionDir();
   const files = fs.readdirSync(SESSION_DIR).filter(f => f.endsWith('.json'));
+  const localMachineId = getMachineId();
 
   for (const file of files) {
     try {
@@ -324,6 +412,16 @@ export async function cleanupStaleSessions() {
 
       const heartbeatAge = (Date.now() - new Date(data.heartbeat_at).getTime()) / 1000;
       const pidAlive = data.pid ? isProcessRunning(data.pid) : false;
+
+      // FR-2/US-003: PID validation for local sessions
+      if (!pidAlive && data.machine_id === localMachineId) {
+        results.pidValidationFailed++;
+        // Report PID validation failure to database
+        await supabase.rpc('report_pid_validation_failure', {
+          p_session_id: data.session_id,
+          p_machine_id: localMachineId
+        }).catch(() => {});
+      }
 
       // Stale if heartbeat too old OR process not running
       if (heartbeatAge > STALE_THRESHOLD_SECONDS || !pidAlive) {
@@ -335,13 +433,47 @@ export async function cleanupStaleSessions() {
     }
   }
 
-  // Cleanup database
-  const { data: dbResult, error } = await supabase.rpc('cleanup_stale_sessions');
+  // Cleanup database using enhanced RPC
+  const { data: dbResult, error } = await supabase.rpc('cleanup_stale_sessions', {
+    p_stale_threshold_seconds: STALE_THRESHOLD_SECONDS,
+    p_batch_size: 100
+  });
 
   if (error) {
     results.errors.push(`Database: ${error.message}`);
   } else if (dbResult) {
-    results.dbCleaned = dbResult.stale_sessions_cleaned || 0;
+    results.dbStaleMarked = dbResult.sessions_marked_stale || 0;
+    results.dbCleaned = dbResult.sessions_released || 0;
+  }
+
+  // US-006: Clean up stale status line files
+  try {
+    const { data: activeSessions } = await supabase
+      .from('v_active_sessions')
+      .select('session_id')
+      .in('computed_status', ['active', 'idle']);
+
+    const activeIds = new Set(activeSessions?.map(s => s.session_id) || []);
+    const statusDir = path.join(process.cwd(), '.claude', 'status-line');
+
+    if (fs.existsSync(statusDir)) {
+      const statusFiles = fs.readdirSync(statusDir);
+      for (const file of statusFiles) {
+        const sessionMatch = file.match(/^(session|telemetry)_(.+)\.(json|txt)$/);
+        if (sessionMatch) {
+          const fileSessionId = sessionMatch[2];
+          // Skip PID-based fallback sessions
+          if (fileSessionId.startsWith('pid_')) continue;
+          // Remove if session is no longer active
+          if (!activeIds.has(fileSessionId)) {
+            fs.unlinkSync(path.join(statusDir, file));
+            results.statusFilesCleaned++;
+          }
+        }
+      }
+    }
+  } catch (err) {
+    results.errors.push(`Status file cleanup: ${err.message}`);
   }
 
   return results;
@@ -428,24 +560,42 @@ export async function releaseCurrentClaim(reason = 'manual') {
 
 /**
  * Mark session as released (on graceful exit)
+ * SD-LEO-INFRA-ISL-001: Uses release_session RPC with idempotency
+ * US-006: Cleans up session-specific status line files
  */
-export async function endSession() {
+export async function endSession(reason = 'graceful_exit') {
+  const startTime = Date.now();
   const session = findExistingSession();
 
   if (!session) {
     return { success: false, error: 'no_session' };
   }
 
-  // Release any claim first
-  if (session.sd_id) {
-    await releaseCurrentClaim('session_ended');
-  }
+  // SD-LEO-INFRA-ISL-001: Use release_session RPC (handles SD claims internally)
+  const { data: dbResult, error } = await supabase.rpc('release_session', {
+    p_session_id: session.session_id,
+    p_reason: reason
+  });
 
-  // Mark as released in database
-  await supabase
-    .from('claude_sessions')
-    .update({ status: 'released' })
-    .eq('session_id', session.session_id);
+  if (error) {
+    // Fallback to manual release if RPC not available
+    console.warn('Warning: release_session RPC failed, using fallback:', error.message);
+
+    // Release any claim first
+    if (session.sd_id) {
+      await releaseCurrentClaim(reason);
+    }
+
+    // Mark as released in database
+    await supabase
+      .from('claude_sessions')
+      .update({
+        status: 'released',
+        released_at: new Date().toISOString(),
+        released_reason: reason
+      })
+      .eq('session_id', session.session_id);
+  }
 
   // Delete local file
   const filePath = getSessionFilePath(session.session_id);
@@ -453,7 +603,35 @@ export async function endSession() {
     fs.unlinkSync(filePath);
   }
 
-  return { success: true, session_id: session.session_id };
+  // US-006: Clean up session-specific status line files
+  try {
+    const statusDir = path.join(process.cwd(), '.claude', 'status-line');
+    const sessionFiles = [
+      path.join(statusDir, `session_${session.session_id}.json`),
+      path.join(statusDir, `session_${session.session_id}.txt`),
+      path.join(statusDir, `telemetry_${session.session_id}.json`)
+    ];
+    for (const file of sessionFiles) {
+      if (fs.existsSync(file)) fs.unlinkSync(file);
+    }
+  } catch (_e) {
+    // Silent fail for status line cleanup
+  }
+
+  // FR-5: Log release event with latency
+  const latencyMs = Date.now() - startTime;
+  await supabase.rpc('log_session_event', {
+    p_event_type: 'SESSION_RELEASED',
+    p_session_id: session.session_id,
+    p_machine_id: session.machine_id,
+    p_terminal_id: session.terminal_id,
+    p_pid: session.pid,
+    p_reason: reason,
+    p_latency_ms: latencyMs,
+    p_metadata: { had_sd_claim: !!session.sd_id }
+  }).catch(() => {}); // Silent fail for telemetry
+
+  return { success: true, session_id: session.session_id, latency_ms: latencyMs };
 }
 
 // Export for use as module


### PR DESCRIPTION
## Summary

Implements SD-LEO-INFRA-INTELLIGENT-SESSION-LIFECYCLE-001 - Intelligent Session Lifecycle Management with all 6 user stories:

- **US-001**: Terminal identity auto-release - Same-terminal sessions automatically replace previous ones
- **US-002**: Graceful exit release within 5 seconds with retry/timeout
- **US-003**: PID validation to detect orphaned sessions (dead processes)
- **US-004**: Batch cleanup for stale sessions (heartbeat timeout + release)
- **US-005**: Observability - lifecycle event logging and metrics view
- **US-006**: Session-specific status line files (prevents multi-session collisions)

### Database Changes
- New columns: `machine_id`, `terminal_id`, `terminal_identity`, `released_at`, `released_reason`, `stale_at`, `stale_reason`
- New table: `session_lifecycle_events` for audit logging
- New view: `v_session_metrics` for dashboards
- New functions: `create_or_replace_session`, `release_session`, `cleanup_stale_sessions`, `report_pid_validation_failure`, `log_session_event`
- Unique index: `idx_claude_sessions_unique_terminal_active` (one active session per terminal)

### Code Changes
- `lib/session-manager.mjs` - Terminal identity tracking, atomic auto-release
- `lib/heartbeat-manager.mjs` - Graceful exit handlers with retry, PID validation
- `scripts/leo-status-line.js` - Session-specific file paths

## Test plan
- [x] Integration tests: 6/6 passing
- [x] Terminal auto-release verified (previous session released on new start)
- [x] Graceful release idempotency verified
- [x] PID validation marks sessions stale
- [x] Cleanup function handles batch processing
- [x] Lifecycle events logged successfully
- [x] Session metrics view returns data

🤖 Generated with [Claude Code](https://claude.com/claude-code)