### PR TITLE
fix(QF-20260201-371): Insert future enhancements into feedback inbox

### DIFF
--- a/lib/sub-agents/retro/db-operations.js
+++ b/lib/sub-agents/retro/db-operations.js
@@ -362,3 +362,36 @@ export async function storeRetrospectiveContributions(supabase, retroId, chairma
     }
   }
 }
+
+/**
+ * Quick-fix QF-20260201-371: Insert future enhancements into feedback table
+ * Makes them visible in /inbox for triage and actionable follow-up.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Array} enhancements - Future enhancement opportunities
+ * @param {string} sdId - Source SD ID
+ * @param {string} retroId - Retrospective ID that captured them
+ */
+export async function insertFeedbackForFutureEnhancements(supabase, enhancements, sdId, retroId) {
+  if (!enhancements || enhancements.length === 0) return { inserted: 0 };
+
+  const records = enhancements.map(e => ({
+    type: 'enhancement',
+    source_application: 'engineer',
+    source_type: 'retrospective',
+    source_id: retroId,
+    title: e.enhancement?.substring(0, 200) || 'Future enhancement opportunity',
+    description: JSON.stringify({ ...e, captured_from_retro: retroId }),
+    status: 'new',
+    priority: e.effort === 'low' ? 'high' : 'medium',
+    sd_id: sdId
+  }));
+
+  const { error } = await supabase.from('feedback').insert(records);
+  if (error) {
+    console.log(`   ⚠️ Failed to insert feedback: ${error.message}`);
+    return { inserted: 0, error: error.message };
+  }
+  console.log(`   ✅ Inserted ${records.length} future enhancement(s) into feedback inbox`);
+  return { inserted: records.length };
+}

--- a/lib/sub-agents/retro/index.js
+++ b/lib/sub-agents/retro/index.js
@@ -29,7 +29,8 @@ import {
   checkExistingRetrospective,
   gatherSDMetadata,
   storeRetrospective,
-  enhanceRetrospective
+  enhanceRetrospective,
+  insertFeedbackForFutureEnhancements
 } from './db-operations.js';
 import { generateRetrospective } from './generators.js';
 import { captureLessonLearned } from './lesson-capture.js';
@@ -286,6 +287,11 @@ export async function execute(sdId, subAgent, options = {}) {
           'Review retrospective for insights',
           'Apply learnings to future SDs'
         );
+
+        // Quick-fix QF-20260201-371: Insert future enhancements into feedback inbox
+        if (retrospective.future_enhancements?.length > 0) {
+          await insertFeedbackForFutureEnhancements(supabase, retrospective.future_enhancements, sdId, stored.id);
+        }
       } else {
         console.log(`   ❌ Failed to store retrospective: ${stored.error}`);
         results.warnings.push({


### PR DESCRIPTION
## Summary

- Add `insertFeedbackForFutureEnhancements()` function to RETRO sub-agent's db-operations.js
- Call the function from index.js after storing retrospective
- Future enhancements captured during SD completion now appear in `/inbox` for triage

## Context

QF-20260201-963 added `future_enhancements` capture to retrospectives table. However, retrospectives are historical records - not actionable items. This quick-fix ensures future enhancements ALSO get inserted into the `feedback` table where they:
- Appear in `/inbox` command output
- Can be triaged to `backlog` status
- Can be converted to future SDs

## Test plan

- [x] Syntax validation passed
- [x] RETRO module imports successfully
- [x] Smoke tests passed
- [x] LOC count: 40 insertions (under 50 LOC limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)