### PR TITLE
feat(SD-LEO-SELF-IMPROVE-001M): implement control-plane observability

### DIFF
--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,71 @@
+# /status - Pipeline Status Command
+
+**Purpose**: Display real-time health metrics for the self-improvement pipeline.
+
+## What This Shows
+
+The /status command provides visibility into:
+- **MTTI (Mean Time To Intervention)**: How quickly issues are detected and proposals created
+- **MTTR (Mean Time To Remediate)**: How quickly proposals lead to completed SDs
+- **Pipeline Activity**: Recent proposals, completions, and feedback
+- **Queue Depths**: Pending work and active SDs
+
+## Usage
+
+```
+/status
+```
+
+## Execution
+
+When invoked, run:
+```bash
+node scripts/pipeline-status.js
+```
+
+## Output Format
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║              SELF-IMPROVEMENT PIPELINE STATUS                  ║
+╠═══════════════════════════════════════════════════════════════╣
+║                                                                ║
+║  ⏱️  MTTI (Mean Time To Intervention)                         ║
+║  ├─ 7-day average:  X.X hours                                 ║
+║  └─ 30-day average: X.X hours                                 ║
+║                                                                ║
+║  🔧 MTTR (Mean Time To Remediate)                             ║
+║  ├─ 7-day average:  X.X hours                                 ║
+║  └─ 30-day average: X.X hours                                 ║
+║                                                                ║
+║  📊 LAST 24 HOURS                                             ║
+║  ├─ Proposals created:   X                                    ║
+║  ├─ SDs completed:       X                                    ║
+║  └─ Feedback received:   X                                    ║
+║                                                                ║
+║  📋 QUEUE STATUS                                              ║
+║  ├─ Pending proposals:   X                                    ║
+║  └─ Active SDs:          X                                    ║
+║                                                                ║
+║  ⏰ Last metric: YYYY-MM-DD HH:mm:ss                          ║
+╚═══════════════════════════════════════════════════════════════╝
+```
+
+## Targets
+
+| Metric | Target | Status |
+|--------|--------|--------|
+| MTTI | < 24 hours | 🟢 On track / 🟡 Warning / 🔴 Critical |
+| MTTR | < 72 hours | 🟢 On track / 🟡 Warning / 🔴 Critical |
+
+## Health Indicators
+
+- 🟢 **Healthy**: Metrics within target, pipeline flowing
+- 🟡 **Warning**: Metrics approaching threshold, review needed
+- 🔴 **Critical**: Metrics exceeded, intervention required
+
+## Related Commands
+
+- `/leo next` - View SD queue
+- `/inbox` - View pending feedback
+- `/learn` - Capture patterns from completed work

--- a/database/migrations/20260201_pipeline_metrics.sql
+++ b/database/migrations/20260201_pipeline_metrics.sql
@@ -1,0 +1,255 @@
+-- Migration: Pipeline Metrics for Self-Improvement Observability
+-- SD: SD-LEO-SELF-IMPROVE-001M (Phase 7b: Control-Plane + Observability)
+-- Purpose: Track MTTI (Mean Time To Intervention) and MTTR (Mean Time To Remediate)
+
+-- ============================================================================
+-- 1. PIPELINE_METRICS TABLE
+-- Time-series metrics for self-improvement pipeline health
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS pipeline_metrics (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  metric_name TEXT NOT NULL,
+  metric_value NUMERIC NOT NULL,
+  labels JSONB DEFAULT '{}',
+  recorded_at TIMESTAMPTZ DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Index for efficient time-range queries
+CREATE INDEX IF NOT EXISTS idx_pipeline_metrics_name_time
+  ON pipeline_metrics(metric_name, recorded_at DESC);
+
+-- Index for label-based filtering
+CREATE INDEX IF NOT EXISTS idx_pipeline_metrics_labels
+  ON pipeline_metrics USING GIN(labels);
+
+-- Retention policy: Keep metrics for 30 days
+COMMENT ON TABLE pipeline_metrics IS
+  'Time-series metrics for self-improvement pipeline. Retention: 30 days.';
+
+-- ============================================================================
+-- 2. RLS POLICIES
+-- ============================================================================
+
+ALTER TABLE pipeline_metrics ENABLE ROW LEVEL SECURITY;
+
+-- Service role can do everything
+CREATE POLICY "Service role full access to pipeline_metrics"
+  ON pipeline_metrics
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Authenticated users can read metrics
+CREATE POLICY "Authenticated users can read pipeline_metrics"
+  ON pipeline_metrics
+  FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+-- ============================================================================
+-- 3. MTTI/MTTR TRACKING FUNCTIONS
+-- ============================================================================
+
+-- Function to record MTTI when proposal is created from feedback
+CREATE OR REPLACE FUNCTION record_mtti_on_proposal_creation()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_feedback_created_at TIMESTAMPTZ;
+  v_mtti_hours NUMERIC;
+BEGIN
+  -- Only track if proposal has feedback origin
+  IF NEW.feedback_id IS NOT NULL THEN
+    -- Get feedback creation time
+    SELECT created_at INTO v_feedback_created_at
+    FROM feedback
+    WHERE id = NEW.feedback_id;
+
+    IF v_feedback_created_at IS NOT NULL THEN
+      -- Calculate MTTI in hours
+      v_mtti_hours := EXTRACT(EPOCH FROM (NEW.created_at - v_feedback_created_at)) / 3600;
+
+      -- Record metric
+      INSERT INTO pipeline_metrics (metric_name, metric_value, labels)
+      VALUES (
+        'mtti_hours',
+        v_mtti_hours,
+        jsonb_build_object(
+          'proposal_id', NEW.id,
+          'feedback_id', NEW.feedback_id,
+          'source', 'proposal_creation'
+        )
+      );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Function to record MTTR when SD completes (with proposal origin)
+CREATE OR REPLACE FUNCTION record_mttr_on_sd_completion()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_proposal_created_at TIMESTAMPTZ;
+  v_proposal_id UUID;
+  v_mttr_hours NUMERIC;
+BEGIN
+  -- Only track when status changes to 'completed'
+  IF NEW.status = 'completed' AND (OLD.status IS NULL OR OLD.status != 'completed') THEN
+    -- Check if SD has proposal origin
+    IF NEW.metadata->>'proposal_id' IS NOT NULL THEN
+      v_proposal_id := (NEW.metadata->>'proposal_id')::UUID;
+
+      -- Get proposal creation time
+      SELECT created_at INTO v_proposal_created_at
+      FROM leo_proposals
+      WHERE id = v_proposal_id;
+
+      IF v_proposal_created_at IS NOT NULL THEN
+        -- Calculate MTTR in hours
+        v_mttr_hours := EXTRACT(EPOCH FROM (NOW() - v_proposal_created_at)) / 3600;
+
+        -- Record metric
+        INSERT INTO pipeline_metrics (metric_name, metric_value, labels)
+        VALUES (
+          'mttr_hours',
+          v_mttr_hours,
+          jsonb_build_object(
+            'sd_id', NEW.id,
+            'proposal_id', v_proposal_id,
+            'source', 'sd_completion'
+          )
+        );
+      END IF;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================================
+-- 4. TRIGGERS
+-- ============================================================================
+
+-- Trigger for MTTI tracking on proposal creation
+DROP TRIGGER IF EXISTS trg_record_mtti_on_proposal ON leo_proposals;
+CREATE TRIGGER trg_record_mtti_on_proposal
+  AFTER INSERT ON leo_proposals
+  FOR EACH ROW
+  EXECUTE FUNCTION record_mtti_on_proposal_creation();
+
+-- Trigger for MTTR tracking on SD completion
+DROP TRIGGER IF EXISTS trg_record_mttr_on_sd_completion ON strategic_directives_v2;
+CREATE TRIGGER trg_record_mttr_on_sd_completion
+  AFTER UPDATE ON strategic_directives_v2
+  FOR EACH ROW
+  EXECUTE FUNCTION record_mttr_on_sd_completion();
+
+-- ============================================================================
+-- 5. PIPELINE HEALTH VIEW
+-- Aggregated metrics for /status command
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_pipeline_health AS
+SELECT
+  -- MTTI metrics
+  (SELECT COALESCE(AVG(metric_value), 0)
+   FROM pipeline_metrics
+   WHERE metric_name = 'mtti_hours'
+   AND recorded_at > NOW() - INTERVAL '7 days') AS avg_mtti_hours_7d,
+
+  (SELECT COALESCE(AVG(metric_value), 0)
+   FROM pipeline_metrics
+   WHERE metric_name = 'mtti_hours'
+   AND recorded_at > NOW() - INTERVAL '30 days') AS avg_mtti_hours_30d,
+
+  -- MTTR metrics
+  (SELECT COALESCE(AVG(metric_value), 0)
+   FROM pipeline_metrics
+   WHERE metric_name = 'mttr_hours'
+   AND recorded_at > NOW() - INTERVAL '7 days') AS avg_mttr_hours_7d,
+
+  (SELECT COALESCE(AVG(metric_value), 0)
+   FROM pipeline_metrics
+   WHERE metric_name = 'mttr_hours'
+   AND recorded_at > NOW() - INTERVAL '30 days') AS avg_mttr_hours_30d,
+
+  -- Pipeline activity
+  (SELECT COUNT(*)
+   FROM leo_proposals
+   WHERE created_at > NOW() - INTERVAL '24 hours') AS proposals_24h,
+
+  (SELECT COUNT(*)
+   FROM strategic_directives_v2
+   WHERE completion_date > NOW() - INTERVAL '24 hours') AS sds_completed_24h,
+
+  (SELECT COUNT(*)
+   FROM feedback
+   WHERE created_at > NOW() - INTERVAL '24 hours') AS feedback_24h,
+
+  -- Queue depths
+  (SELECT COUNT(*)
+   FROM leo_proposals
+   WHERE status IN ('draft', 'submitted', 'pending_vetting')) AS pending_proposals,
+
+  (SELECT COUNT(*)
+   FROM strategic_directives_v2
+   WHERE status = 'in_progress') AS active_sds,
+
+  -- Last activity
+  (SELECT MAX(recorded_at)
+   FROM pipeline_metrics) AS last_metric_recorded,
+
+  NOW() AS snapshot_at;
+
+-- ============================================================================
+-- 6. RETENTION CLEANUP FUNCTION
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION cleanup_old_pipeline_metrics()
+RETURNS INTEGER AS $$
+DECLARE
+  v_deleted INTEGER;
+BEGIN
+  DELETE FROM pipeline_metrics
+  WHERE recorded_at < NOW() - INTERVAL '30 days';
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  -- Log cleanup
+  INSERT INTO pipeline_metrics (metric_name, metric_value, labels)
+  VALUES (
+    'metrics_cleanup',
+    v_deleted,
+    jsonb_build_object('retention_days', 30)
+  );
+
+  RETURN v_deleted;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================================
+-- 7. VERIFICATION QUERIES
+-- ============================================================================
+
+-- Verify table exists
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'pipeline_metrics') THEN
+    RAISE NOTICE '✅ pipeline_metrics table created successfully';
+  ELSE
+    RAISE EXCEPTION '❌ pipeline_metrics table creation failed';
+  END IF;
+END $$;
+
+-- Verify view exists
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.views WHERE table_name = 'v_pipeline_health') THEN
+    RAISE NOTICE '✅ v_pipeline_health view created successfully';
+  ELSE
+    RAISE EXCEPTION '❌ v_pipeline_health view creation failed';
+  END IF;
+END $$;

--- a/package.json
+++ b/package.json
@@ -281,7 +281,8 @@
     "docmon:all": "node scripts/docmon.js --all",
     "exec:commit-gate": "node scripts/exec-commit-gate.js",
     "exec:commit-gate:pr": "node scripts/exec-commit-gate.js --pr-range origin/main",
-    "test:pipeline:smoke": "node scripts/test-pipeline-smoke.js"
+    "test:pipeline:smoke": "node scripts/test-pipeline-smoke.js",
+    "pipeline:status": "node scripts/pipeline-status.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.63.0",

--- a/scripts/pipeline-status.js
+++ b/scripts/pipeline-status.js
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+
+/**
+ * Pipeline Status - Self-Improvement Observability
+ * SD-LEO-SELF-IMPROVE-001M (Phase 7b: Control-Plane + Observability)
+ *
+ * Displays real-time health metrics for the self-improvement pipeline:
+ * - MTTI (Mean Time To Intervention)
+ * - MTTR (Mean Time To Remediate)
+ * - Pipeline activity and queue depths
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// ANSI colors for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  bright: '\x1b[1m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  white: '\x1b[37m',
+  bgBlue: '\x1b[44m',
+};
+
+/**
+ * Get health indicator based on value and thresholds
+ */
+function getHealthIndicator(value, warningThreshold, criticalThreshold) {
+  if (value <= warningThreshold) {
+    return { icon: '🟢', status: 'Healthy', color: colors.green };
+  } else if (value <= criticalThreshold) {
+    return { icon: '🟡', status: 'Warning', color: colors.yellow };
+  } else {
+    return { icon: '🔴', status: 'Critical', color: colors.red };
+  }
+}
+
+/**
+ * Format hours to human-readable string
+ */
+function formatHours(hours) {
+  if (hours === 0 || hours === null) return 'N/A';
+  if (hours < 1) return `${(hours * 60).toFixed(0)} min`;
+  if (hours < 24) return `${hours.toFixed(1)} hrs`;
+  return `${(hours / 24).toFixed(1)} days`;
+}
+
+/**
+ * Fetch pipeline health data
+ */
+async function fetchPipelineHealth() {
+  // Try the view first
+  const { data: viewData, error: viewError } = await supabase
+    .from('v_pipeline_health')
+    .select('*')
+    .single();
+
+  if (!viewError && viewData) {
+    return viewData;
+  }
+
+  // Fallback: query metrics directly
+  const now = new Date().toISOString();
+
+  // Get MTTI averages
+  const { data: mttiData } = await supabase
+    .from('pipeline_metrics')
+    .select('metric_value, recorded_at')
+    .eq('metric_name', 'mtti_hours')
+    .gte('recorded_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString());
+
+  // Get MTTR averages
+  const { data: mttrData } = await supabase
+    .from('pipeline_metrics')
+    .select('metric_value, recorded_at')
+    .eq('metric_name', 'mttr_hours')
+    .gte('recorded_at', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString());
+
+  // Get pipeline activity
+  const { count: proposals24h } = await supabase
+    .from('leo_proposals')
+    .select('*', { count: 'exact', head: true })
+    .gte('created_at', new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+
+  const { count: sdsCompleted24h } = await supabase
+    .from('strategic_directives_v2')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', 'completed')
+    .gte('completion_date', new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+
+  const { count: feedback24h } = await supabase
+    .from('feedback')
+    .select('*', { count: 'exact', head: true })
+    .gte('created_at', new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+
+  // Get queue depths
+  const { count: pendingProposals } = await supabase
+    .from('leo_proposals')
+    .select('*', { count: 'exact', head: true })
+    .in('status', ['draft', 'submitted', 'pending_vetting']);
+
+  const { count: activeSds } = await supabase
+    .from('strategic_directives_v2')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', 'in_progress');
+
+  // Calculate averages
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const mtti7d = mttiData?.filter(d => new Date(d.recorded_at).getTime() > sevenDaysAgo) || [];
+  const mttr7d = mttrData?.filter(d => new Date(d.recorded_at).getTime() > sevenDaysAgo) || [];
+
+  const avgMtti7d = mtti7d.length > 0
+    ? mtti7d.reduce((sum, d) => sum + parseFloat(d.metric_value), 0) / mtti7d.length
+    : 0;
+  const avgMtti30d = mttiData?.length > 0
+    ? mttiData.reduce((sum, d) => sum + parseFloat(d.metric_value), 0) / mttiData.length
+    : 0;
+  const avgMttr7d = mttr7d.length > 0
+    ? mttr7d.reduce((sum, d) => sum + parseFloat(d.metric_value), 0) / mttr7d.length
+    : 0;
+  const avgMttr30d = mttrData?.length > 0
+    ? mttrData.reduce((sum, d) => sum + parseFloat(d.metric_value), 0) / mttrData.length
+    : 0;
+
+  return {
+    avg_mtti_hours_7d: avgMtti7d,
+    avg_mtti_hours_30d: avgMtti30d,
+    avg_mttr_hours_7d: avgMttr7d,
+    avg_mttr_hours_30d: avgMttr30d,
+    proposals_24h: proposals24h || 0,
+    sds_completed_24h: sdsCompleted24h || 0,
+    feedback_24h: feedback24h || 0,
+    pending_proposals: pendingProposals || 0,
+    active_sds: activeSds || 0,
+    snapshot_at: now,
+  };
+}
+
+/**
+ * Display the pipeline status
+ */
+async function displayStatus() {
+  console.log('\n');
+
+  try {
+    const health = await fetchPipelineHealth();
+
+    // MTTI health (target: <24 hours)
+    const mttiHealth = getHealthIndicator(health.avg_mtti_hours_7d, 24, 48);
+
+    // MTTR health (target: <72 hours)
+    const mttrHealth = getHealthIndicator(health.avg_mttr_hours_7d, 72, 168);
+
+    // Overall health
+    const overallHealth = mttiHealth.icon === '🟢' && mttrHealth.icon === '🟢'
+      ? '🟢 Healthy'
+      : (mttiHealth.icon === '🔴' || mttrHealth.icon === '🔴')
+      ? '🔴 Needs Attention'
+      : '🟡 Warning';
+
+    console.log('╔═══════════════════════════════════════════════════════════════╗');
+    console.log('║         SELF-IMPROVEMENT PIPELINE STATUS                      ║');
+    console.log('║                                               ' + overallHealth.padEnd(16) + '  ║');
+    console.log('╠═══════════════════════════════════════════════════════════════╣');
+    console.log('║                                                               ║');
+    console.log('║  ⏱️  MTTI (Mean Time To Intervention)  ' + mttiHealth.icon + '                     ║');
+    console.log('║  ├─ 7-day average:  ' + formatHours(health.avg_mtti_hours_7d).padEnd(15) + ' (target: <24h)     ║');
+    console.log('║  └─ 30-day average: ' + formatHours(health.avg_mtti_hours_30d).padEnd(15) + '                    ║');
+    console.log('║                                                               ║');
+    console.log('║  🔧 MTTR (Mean Time To Remediate)  ' + mttrHealth.icon + '                         ║');
+    console.log('║  ├─ 7-day average:  ' + formatHours(health.avg_mttr_hours_7d).padEnd(15) + ' (target: <72h)     ║');
+    console.log('║  └─ 30-day average: ' + formatHours(health.avg_mttr_hours_30d).padEnd(15) + '                    ║');
+    console.log('║                                                               ║');
+    console.log('║  📊 LAST 24 HOURS                                             ║');
+    console.log('║  ├─ Proposals created:   ' + String(health.proposals_24h).padStart(4) + '                          ║');
+    console.log('║  ├─ SDs completed:       ' + String(health.sds_completed_24h).padStart(4) + '                          ║');
+    console.log('║  └─ Feedback received:   ' + String(health.feedback_24h).padStart(4) + '                          ║');
+    console.log('║                                                               ║');
+    console.log('║  📋 QUEUE STATUS                                              ║');
+    console.log('║  ├─ Pending proposals:   ' + String(health.pending_proposals).padStart(4) + '                          ║');
+    console.log('║  └─ Active SDs:          ' + String(health.active_sds).padStart(4) + '                          ║');
+    console.log('║                                                               ║');
+    console.log('║  ⏰ Snapshot: ' + new Date(health.snapshot_at).toISOString().slice(0, 19).replace('T', ' ') + '                       ║');
+    console.log('╚═══════════════════════════════════════════════════════════════╝');
+    console.log('\n');
+
+    // Return exit code based on health
+    if (overallHealth.includes('Needs Attention')) {
+      process.exit(2);
+    } else if (overallHealth.includes('Warning')) {
+      process.exit(1);
+    } else {
+      process.exit(0);
+    }
+  } catch (error) {
+    console.error('Error fetching pipeline status:', error.message);
+
+    // Show fallback view when table doesn't exist yet
+    console.log('╔═══════════════════════════════════════════════════════════════╗');
+    console.log('║         SELF-IMPROVEMENT PIPELINE STATUS                      ║');
+    console.log('║                                               ⚪ Initializing  ║');
+    console.log('╠═══════════════════════════════════════════════════════════════╣');
+    console.log('║                                                               ║');
+    console.log('║  ℹ️  Pipeline metrics not yet initialized                     ║');
+    console.log('║                                                               ║');
+    console.log('║  Run the migration to enable metrics tracking:                ║');
+    console.log('║  database/migrations/20260201_pipeline_metrics.sql            ║');
+    console.log('║                                                               ║');
+    console.log('╚═══════════════════════════════════════════════════════════════╝');
+    console.log('\n');
+    process.exit(0);
+  }
+}
+
+// Run if called directly
+displayStatus();


### PR DESCRIPTION
## Summary
- Add `pipeline_metrics` table for time-series health data with automatic MTTI/MTTR tracking
- Create `/status` command skill for pipeline observability via `npm run pipeline:status`
- Implement `v_pipeline_health` view for aggregated health metrics
- Add automatic triggers for MTTI (proposal creation) and MTTR (SD completion) recording

## Test plan
- [x] Migration applied successfully to database
- [x] `/status` command displays health metrics with proper formatting
- [x] Pipeline shows real queue data (1 pending proposal, 12 active SDs)
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)