### PR TITLE
fix: add /leo start command and fix Supabase RPC .catch() error

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -1,6 +1,6 @@
 ---
 description: LEO stack management and session control
-argument-hint: [assist|inbox|<SD-ID>|create|next|continue|complete|restart|settings]
+argument-hint: [start <SD-ID>|assist|inbox|create|next|continue|complete|restart|settings]
 ---
 
 # LEO Stack Control
@@ -763,6 +763,59 @@ Restore session state after a crash, compaction, or interruption using the Unifi
    - Simplified compliance rubric (100-point scale)
    - Auto-escalates to full SD if complexity exceeds threshold
 
+### If argument is "start" followed by SD-ID (e.g., `/leo start SD-XXX-001`)
+
+**Unified SD initialization with automatic protocol file loading.**
+
+This is the RECOMMENDED way to begin work on an SD. It combines claiming + context loading.
+
+1. **Parse the SD-ID** from the argument (e.g., `start SD-LEO-SELF-IMPROVE-002C` → `SD-LEO-SELF-IMPROVE-002C`)
+
+2. **Claim the SD:**
+   ```bash
+   npm run sd:start <SD-ID>
+   ```
+
+3. **Get the current phase from output** (look for `Phase: LEAD` or similar)
+
+4. **MANDATORY: Read protocol files based on phase:**
+
+   | Phase | Files to Read (use Read tool) |
+   |-------|-------------------------------|
+   | LEAD | `CLAUDE_LEAD.md` |
+   | PLAN | `CLAUDE_PLAN.md` |
+   | EXEC | `CLAUDE_EXEC.md` |
+
+   **Execute the file read immediately** - do not just mention it, actually use the Read tool:
+   ```
+   Read tool: CLAUDE_LEAD.md   (if phase is LEAD)
+   Read tool: CLAUDE_PLAN.md   (if phase is PLAN)
+   Read tool: CLAUDE_EXEC.md   (if phase is EXEC)
+   ```
+
+5. **Check for orchestrator/child status:**
+   - If SD has children (orchestrator) → run `node scripts/orchestrator-preflight.js <SD-ID>`
+   - If SD has parent (child) → run `node scripts/child-sd-preflight.js <SD-ID>`
+
+6. **Display unified output:**
+   ```
+   ✅ SD Started: <SD-ID>
+      Title: <title>
+      Phase: <phase>
+      Type: <sd_type>
+      Progress: <progress>%
+
+   📚 Protocol Context Loaded: CLAUDE_<PHASE>.md
+      (File has been read and context is active)
+
+   📋 Next Action: <recommended handoff command>
+   ```
+
+**Why use `/leo start` instead of just `/leo SD-XXX`:**
+- Explicit about protocol file loading (not buried in requirements)
+- Shows confirmation that context was loaded
+- Reduces "forgot to read CLAUDE_LEAD.md" failures
+
 ### If argument looks like an SD ID (SD-* pattern)
 
 When the argument matches `SD-*` pattern (e.g., `SD-FEATURE-001`):
@@ -771,6 +824,8 @@ When the argument matches `SD-*` pattern (e.g., `SD-FEATURE-001`):
 3. Check if child SD (has parent) → run child preflight
 4. Load appropriate CLAUDE_*.md context based on phase
 5. Proceed with LEAD→PLAN→EXEC workflow
+
+**NOTE**: Consider using `/leo start <SD-ID>` instead for explicit protocol file loading with confirmation.
 
 ### If argument is "run":
 Run the LEO protocol workflow:
@@ -784,6 +839,7 @@ Display the available commands:
 ```
 LEO Commands:
   /leo                   - Show this help menu
+  /leo start <SD-ID>     - Start SD with auto protocol file loading (RECOMMENDED)
   /leo assist    (a)     - Autonomous inbox processing (issues + enhancements)
   /leo settings  (s)     - View/modify AUTO-PROCEED and Chaining settings
   /leo restart   (r)     - Restart all LEO servers

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -292,27 +292,31 @@ export async function getOrCreateSession() {
     // Log auto-release event for observability (FR-5)
     console.log(`[Session] Auto-released previous session ${dbResult.previous_session_id} for terminal ${dbResult.terminal_identity}`);
 
-    // Log to session lifecycle events
+    // Log to session lifecycle events (silent fail for telemetry)
+    try {
+      await supabase.rpc('log_session_event', {
+        p_event_type: 'SESSION_AUTO_RELEASED',
+        p_session_id: dbResult.previous_session_id,
+        p_machine_id: machineId,
+        p_terminal_id: terminalId,
+        p_pid: pid,
+        p_reason: 'AUTO_REPLACED',
+        p_metadata: { new_session_id: sessionId }
+      });
+    } catch { /* telemetry - silent fail */ }
+  }
+
+  // Log session creation event (silent fail for telemetry)
+  try {
     await supabase.rpc('log_session_event', {
-      p_event_type: 'SESSION_AUTO_RELEASED',
-      p_session_id: dbResult.previous_session_id,
+      p_event_type: 'SESSION_CREATED',
+      p_session_id: sessionId,
       p_machine_id: machineId,
       p_terminal_id: terminalId,
       p_pid: pid,
-      p_reason: 'AUTO_REPLACED',
-      p_metadata: { new_session_id: sessionId }
-    }).catch(() => {}); // Silent fail for telemetry
-  }
-
-  // Log session creation event
-  await supabase.rpc('log_session_event', {
-    p_event_type: 'SESSION_CREATED',
-    p_session_id: sessionId,
-    p_machine_id: machineId,
-    p_terminal_id: terminalId,
-    p_pid: pid,
-    p_metadata: { codebase, hostname }
-  }).catch(() => {}); // Silent fail for telemetry
+      p_metadata: { codebase, hostname }
+    });
+  } catch { /* telemetry - silent fail */ }
 
   return sessionData;
 }
@@ -416,11 +420,13 @@ export async function cleanupStaleSessions() {
       // FR-2/US-003: PID validation for local sessions
       if (!pidAlive && data.machine_id === localMachineId) {
         results.pidValidationFailed++;
-        // Report PID validation failure to database
-        await supabase.rpc('report_pid_validation_failure', {
-          p_session_id: data.session_id,
-          p_machine_id: localMachineId
-        }).catch(() => {});
+        // Report PID validation failure to database (silent fail for telemetry)
+        try {
+          await supabase.rpc('report_pid_validation_failure', {
+            p_session_id: data.session_id,
+            p_machine_id: localMachineId
+          });
+        } catch { /* telemetry - silent fail */ }
       }
 
       // Stale if heartbeat too old OR process not running
@@ -618,18 +624,20 @@ export async function endSession(reason = 'graceful_exit') {
     // Silent fail for status line cleanup
   }
 
-  // FR-5: Log release event with latency
+  // FR-5: Log release event with latency (silent fail for telemetry)
   const latencyMs = Date.now() - startTime;
-  await supabase.rpc('log_session_event', {
-    p_event_type: 'SESSION_RELEASED',
-    p_session_id: session.session_id,
-    p_machine_id: session.machine_id,
-    p_terminal_id: session.terminal_id,
-    p_pid: session.pid,
-    p_reason: reason,
-    p_latency_ms: latencyMs,
-    p_metadata: { had_sd_claim: !!session.sd_id }
-  }).catch(() => {}); // Silent fail for telemetry
+  try {
+    await supabase.rpc('log_session_event', {
+      p_event_type: 'SESSION_RELEASED',
+      p_session_id: session.session_id,
+      p_machine_id: session.machine_id,
+      p_terminal_id: session.terminal_id,
+      p_pid: session.pid,
+      p_reason: reason,
+      p_latency_ms: latencyMs,
+      p_metadata: { had_sd_claim: !!session.sd_id }
+    });
+  } catch { /* telemetry - silent fail */ }
 
   return { success: true, session_id: session.session_id, latency_ms: latencyMs };
 }


### PR DESCRIPTION
## Summary
- Add `/leo start <SD-ID>` command for unified SD initialization with automatic protocol file loading
- Fix Supabase RPC `.catch()` error that was blocking `sd:start` command

## Changes

### 1. `/leo start` Command (`.claude/commands/leo.md`)
New subcommand that combines SD claiming with protocol file loading:
- Claims SD via `sd:start`
- Detects current phase (LEAD/PLAN/EXEC)
- **Automatically reads** the appropriate `CLAUDE_*.md` file
- Displays confirmation that protocol context is loaded

**Why**: Prevents "forgot to read CLAUDE_LEAD.md" gate failures by making file loading explicit and automatic.

### 2. Supabase RPC Fix (`lib/session-manager.mjs`)
- **Root Cause**: Supabase-js v2 builder pattern returns thenable without `.catch()` method
- **Fix**: Replaced `.catch(() => {})` with `try/catch` pattern
- **Lines affected**: 304, 315, 421, 632

## Test plan
- [x] Smoke tests pass
- [x] `npm run sd:start SD-LEO-SELF-IMPROVE-002C` succeeds (previously failed with RPC error)
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)