### PR TITLE
feat(vetting): Multi-Model Debate System for Self-Improvement Governance

### DIFF
--- a/database/migrations/20260202_create_proposal_debates.sql
+++ b/database/migrations/20260202_create_proposal_debates.sql
@@ -1,0 +1,197 @@
+-- Multi-Model Debate System Database Schema
+-- SD-LEO-ORCH-SELF-IMPROVING-LEO-001-B (FR-4)
+--
+-- Creates tables for storing debate transcripts, rounds, and outcomes
+-- with proper indexing for queryability
+
+BEGIN;
+
+-- ============================================================================
+-- PART 1: Create proposal_debates table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS proposal_debates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  proposal_id UUID NOT NULL,
+
+  -- Status tracking
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'running', 'completed', 'failed', 'cancelled')),
+  started_at TIMESTAMP WITH TIME ZONE,
+  completed_at TIMESTAMP WITH TIME ZONE,
+
+  -- Debate configuration
+  max_rounds INTEGER NOT NULL DEFAULT 3,
+  actual_rounds INTEGER DEFAULT 0,
+  consensus_threshold INTEGER DEFAULT 15, -- Score delta for consensus
+
+  -- Consensus outcome
+  consensus_reached BOOLEAN DEFAULT FALSE,
+  consensus_reason TEXT,
+  final_verdict TEXT CHECK (final_verdict IN ('approve', 'revise', 'reject')),
+  final_score NUMERIC(5,2),
+
+  -- Aggregated results
+  top_issues JSONB DEFAULT '[]'::JSONB, -- Array of top 5 issues
+  recommended_next_steps JSONB DEFAULT '[]'::JSONB,
+
+  -- CONST-002 validation
+  const_002_passed BOOLEAN,
+  const_002_result JSONB,
+
+  -- Error handling
+  error_code TEXT,
+  error_message TEXT,
+
+  -- Correlation for logging
+  correlation_id UUID DEFAULT gen_random_uuid(),
+
+  -- Metadata
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  created_by TEXT DEFAULT 'debate_orchestrator'
+);
+
+-- Indexes for proposal_debates
+CREATE INDEX IF NOT EXISTS idx_proposal_debates_proposal_id ON proposal_debates(proposal_id);
+CREATE INDEX IF NOT EXISTS idx_proposal_debates_status ON proposal_debates(status);
+CREATE INDEX IF NOT EXISTS idx_proposal_debates_created_at ON proposal_debates(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_proposal_debates_correlation_id ON proposal_debates(correlation_id);
+
+-- Idempotency index: prevent duplicate debates for same proposal in running/completed state
+CREATE UNIQUE INDEX IF NOT EXISTS idx_proposal_debates_idempotent
+  ON proposal_debates(proposal_id)
+  WHERE status IN ('running', 'completed');
+
+-- ============================================================================
+-- PART 2: Create proposal_debate_rounds table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS proposal_debate_rounds (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  debate_id UUID NOT NULL REFERENCES proposal_debates(id) ON DELETE CASCADE,
+  round_index INTEGER NOT NULL CHECK (round_index >= 0),
+
+  -- Round metadata
+  started_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  completed_at TIMESTAMP WITH TIME ZONE,
+
+  -- Persona outputs (one per persona per round)
+  persona_outputs JSONB NOT NULL DEFAULT '{}'::JSONB,
+  -- Structure: {
+  --   "safety": { "verdict": "approve", "score": 85, "rationale": "...", "change_requests": [...], "provider": "anthropic", "model": "claude-3" },
+  --   "value": { "verdict": "revise", "score": 70, "rationale": "...", "change_requests": [...], "provider": "openai", "model": "gpt-4" },
+  --   "risk": { "verdict": "approve", "score": 80, "rationale": "...", "change_requests": [...], "provider": "google", "model": "gemini-pro" }
+  -- }
+
+  -- Orchestrator summary for this round (fed to next round)
+  orchestrator_summary TEXT,
+
+  -- Consensus check for this round
+  consensus_check JSONB,
+  -- Structure: { "checked": true, "reached": false, "reason": "score delta > 15" }
+
+  -- Provider/model tracking for audit
+  provider_calls JSONB DEFAULT '[]'::JSONB,
+  -- Array of { "persona": "safety", "provider": "anthropic", "model": "claude-3", "duration_ms": 1234, "tokens_used": {...} }
+
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Indexes for proposal_debate_rounds
+CREATE INDEX IF NOT EXISTS idx_debate_rounds_debate_id ON proposal_debate_rounds(debate_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_debate_rounds_debate_round ON proposal_debate_rounds(debate_id, round_index);
+
+-- ============================================================================
+-- PART 3: Update trigger for proposal_debates
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION update_proposal_debates_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_proposal_debates_updated ON proposal_debates;
+CREATE TRIGGER trg_proposal_debates_updated
+  BEFORE UPDATE ON proposal_debates
+  FOR EACH ROW
+  EXECUTE FUNCTION update_proposal_debates_timestamp();
+
+-- ============================================================================
+-- PART 4: RLS Policies
+-- ============================================================================
+
+ALTER TABLE proposal_debates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE proposal_debate_rounds ENABLE ROW LEVEL SECURITY;
+
+-- Service role has full access
+CREATE POLICY proposal_debates_service_all ON proposal_debates
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY proposal_debate_rounds_service_all ON proposal_debate_rounds
+  FOR ALL USING (auth.role() = 'service_role');
+
+-- Authenticated users can read
+CREATE POLICY proposal_debates_read ON proposal_debates
+  FOR SELECT USING (auth.role() = 'authenticated');
+
+CREATE POLICY proposal_debate_rounds_read ON proposal_debate_rounds
+  FOR SELECT USING (auth.role() = 'authenticated');
+
+-- ============================================================================
+-- PART 5: Helper functions
+-- ============================================================================
+
+-- Function to get latest debate for a proposal
+CREATE OR REPLACE FUNCTION get_latest_debate(p_proposal_id UUID)
+RETURNS SETOF proposal_debates AS $$
+  SELECT * FROM proposal_debates
+  WHERE proposal_id = p_proposal_id
+  ORDER BY created_at DESC
+  LIMIT 1;
+$$ LANGUAGE SQL STABLE;
+
+-- Function to check if debate can be created (idempotency)
+CREATE OR REPLACE FUNCTION can_create_debate(p_proposal_id UUID)
+RETURNS JSONB AS $$
+DECLARE
+  v_existing proposal_debates%ROWTYPE;
+BEGIN
+  SELECT * INTO v_existing
+  FROM proposal_debates
+  WHERE proposal_id = p_proposal_id
+    AND status IN ('running', 'completed')
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'can_create', false,
+      'reason', 'existing_debate',
+      'existing_debate_id', v_existing.id,
+      'existing_status', v_existing.status
+    );
+  ELSE
+    RETURN jsonb_build_object(
+      'can_create', true,
+      'reason', null
+    );
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;
+
+-- ============================================================================
+-- SUCCESS MESSAGE
+-- ============================================================================
+
+DO $$
+BEGIN
+  RAISE NOTICE 'Migration complete: proposal_debates tables created';
+  RAISE NOTICE '  - proposal_debates: Main debate records';
+  RAISE NOTICE '  - proposal_debate_rounds: Per-round persona outputs';
+  RAISE NOTICE '  - Idempotency index: Prevents duplicate debates';
+  RAISE NOTICE '  - RLS: Enabled with service/authenticated policies';
+END $$;

--- a/database/migrations/20260202_fix_progress_sd_id_column.sql
+++ b/database/migrations/20260202_fix_progress_sd_id_column.sql
@@ -1,0 +1,355 @@
+-- Migration: Fix get_progress_breakdown PRD column name and handoff checks
+-- Date: 2026-02-02
+-- Root Cause: Function uses 'directive_id' but actual column is 'sd_id'
+--             EXEC/PLAN phases don't check accepted handoffs
+-- Fix: Use correct column name and check handoffs for phase completion
+
+CREATE OR REPLACE FUNCTION get_progress_breakdown(sd_id_param text)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  sd RECORD;
+  sd_type_val text;
+  profile RECORD;
+  breakdown JSONB;
+  total_progress INTEGER;
+  is_orchestrator_flag BOOLEAN;
+  total_children INT;
+  completed_children INT;
+
+  -- Component states
+  prd_exists BOOLEAN;
+  deliverables_complete BOOLEAN;
+  user_stories_validated BOOLEAN;
+  retrospective_exists BOOLEAN;
+  handoffs_count INT;
+  lead_to_plan_handoff_exists BOOLEAN;
+  final_handoff_exists BOOLEAN;
+
+  -- NEW: Handoff-based phase completion
+  plan_to_exec_accepted BOOLEAN;
+  exec_to_plan_accepted BOOLEAN;
+BEGIN
+  -- Get SD
+  SELECT * INTO sd FROM strategic_directives_v2 WHERE id = sd_id_param;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error', 'SD not found');
+  END IF;
+
+  -- ============================================================================
+  -- ORCHESTRATOR PATH (CRITICAL: Check this FIRST)
+  -- ============================================================================
+  -- Check if orchestrator (has children OR sd_type='orchestrator')
+  is_orchestrator_flag := is_orchestrator_sd(sd_id_param) OR sd.sd_type = 'orchestrator';
+
+  IF is_orchestrator_flag THEN
+    -- Get child completion stats
+    SELECT
+      COUNT(*),
+      COUNT(*) FILTER (WHERE status = 'completed')
+    INTO total_children, completed_children
+    FROM strategic_directives_v2
+    WHERE parent_sd_id = sd_id_param;
+
+    -- Check retrospective
+    SELECT EXISTS (
+      SELECT 1 FROM retrospectives WHERE sd_id = sd_id_param
+    ) INTO retrospective_exists;
+
+    -- Check LEAD-TO-PLAN handoff (initial orchestrator approval)
+    SELECT EXISTS (
+      SELECT 1 FROM sd_phase_handoffs
+      WHERE sd_id = sd_id_param
+      AND handoff_type = 'LEAD-TO-PLAN'
+      AND status = 'accepted'
+    ) INTO lead_to_plan_handoff_exists;
+
+    -- Check final handoff (PLAN-TO-LEAD or PLAN-TO-EXEC both valid)
+    SELECT EXISTS (
+      SELECT 1 FROM sd_phase_handoffs
+      WHERE sd_id = sd_id_param
+      AND handoff_type IN ('PLAN-TO-LEAD', 'PLAN-TO-EXEC')
+      AND status = 'accepted'
+    ) INTO final_handoff_exists;
+
+    -- Calculate orchestrator progress
+    total_progress := calculate_orchestrator_progress(sd_id_param);
+
+    -- Return orchestrator-specific breakdown
+    RETURN jsonb_build_object(
+      'sd_id', sd_id_param,
+      'sd_type', COALESCE(sd.sd_type, 'feature'),
+      'is_orchestrator', true,
+      'status', sd.status,
+      'profile', jsonb_build_object(
+        'name', 'orchestrator',
+        'description', 'Parent SD that coordinates child SDs. Progress based on child completion.',
+        'requires_prd', false,
+        'requires_deliverables', false,
+        'requires_e2e_tests', false,
+        'requires_retrospective', true,
+        'min_handoffs', 1
+      ),
+      'phases', jsonb_build_object(
+        'LEAD_initial', jsonb_build_object(
+          'weight', 20,
+          'complete', lead_to_plan_handoff_exists,
+          'progress', CASE WHEN lead_to_plan_handoff_exists THEN 20 ELSE 0 END,
+          'note', 'LEAD-TO-PLAN handoff indicates orchestrator approved and active'
+        ),
+        'CHILDREN_completion', jsonb_build_object(
+          'weight', 60,
+          'complete', completed_children = total_children AND total_children > 0,
+          'progress', CASE WHEN total_children > 0 THEN (60 * completed_children / total_children) ELSE 0 END,
+          'total_children', total_children,
+          'completed_children', completed_children,
+          'note', format('%s of %s children completed', completed_children, total_children)
+        ),
+        'RETROSPECTIVE', jsonb_build_object(
+          'weight', 15,
+          'complete', retrospective_exists,
+          'progress', CASE WHEN retrospective_exists THEN 15 ELSE 0 END,
+          'required', true
+        ),
+        'FINAL_handoff', jsonb_build_object(
+          'weight', 5,
+          'complete', final_handoff_exists,
+          'progress', CASE WHEN final_handoff_exists THEN 5 ELSE 0 END,
+          'required', true,
+          'note', 'PLAN-TO-LEAD or PLAN-TO-EXEC indicating orchestrator work complete'
+        )
+      ),
+      'total_progress', total_progress,
+      'can_complete', total_progress = 100
+    );
+  END IF;
+
+  -- ============================================================================
+  -- STANDARD SD BREAKDOWN (FIXED logic)
+  -- ============================================================================
+  sd_type_val := COALESCE(sd.sd_type, 'feature');
+  SELECT * INTO profile FROM sd_type_validation_profiles WHERE sd_type = sd_type_val;
+
+  IF NOT FOUND THEN
+    SELECT * INTO profile FROM sd_type_validation_profiles WHERE sd_type = 'feature';
+  END IF;
+
+  -- Check each component
+  -- FIX: Use 'sd_id' column instead of 'directive_id'
+  SELECT EXISTS (
+    SELECT 1 FROM product_requirements_v2 WHERE sd_id = sd_id_param
+  ) INTO prd_exists;
+
+  SELECT EXISTS (
+    SELECT 1 FROM retrospectives WHERE sd_id = sd_id_param
+  ) INTO retrospective_exists;
+
+  SELECT COUNT(DISTINCT handoff_type) INTO handoffs_count
+  FROM sd_phase_handoffs
+  WHERE sd_id = sd_id_param AND status = 'accepted';
+
+  -- NEW: Check for accepted handoffs that indicate phase completion
+  SELECT EXISTS (
+    SELECT 1 FROM sd_phase_handoffs
+    WHERE sd_id = sd_id_param
+    AND handoff_type = 'PLAN-TO-EXEC'
+    AND status = 'accepted'
+  ) INTO plan_to_exec_accepted;
+
+  SELECT EXISTS (
+    SELECT 1 FROM sd_phase_handoffs
+    WHERE sd_id = sd_id_param
+    AND handoff_type = 'EXEC-TO-PLAN'
+    AND status = 'accepted'
+  ) INTO exec_to_plan_accepted;
+
+  -- Calculate total
+  total_progress := calculate_sd_progress(sd_id_param);
+
+  -- Build standard breakdown
+  -- FIX: Phase completion now based on accepted handoffs
+  breakdown := jsonb_build_object(
+    'sd_id', sd_id_param,
+    'sd_type', sd_type_val,
+    'is_orchestrator', false,
+    'current_phase', sd.current_phase,
+    'status', sd.status,
+    'profile', jsonb_build_object(
+      'name', profile.sd_type,
+      'description', profile.description,
+      'requires_prd', profile.requires_prd,
+      'requires_deliverables', profile.requires_deliverables,
+      'requires_e2e_tests', profile.requires_e2e_tests,
+      'requires_sub_agents', profile.requires_sub_agents,
+      'requires_retrospective', profile.requires_retrospective,
+      'min_handoffs', profile.min_handoffs
+    ),
+    'phases', jsonb_build_object(
+      'LEAD_approval', jsonb_build_object(
+        'weight', profile.lead_weight,
+        'complete', sd.status IN ('active', 'in_progress', 'pending_approval', 'completed'),
+        'progress', CASE WHEN sd.status IN ('active', 'in_progress', 'pending_approval', 'completed')
+                        THEN profile.lead_weight ELSE 0 END,
+        'required', true
+      ),
+      'PLAN_prd', jsonb_build_object(
+        'weight', profile.plan_weight,
+        'complete', NOT profile.requires_prd OR prd_exists,
+        'progress', CASE WHEN NOT profile.requires_prd OR prd_exists
+                        THEN profile.plan_weight ELSE 0 END,
+        'required', profile.requires_prd,
+        'prd_exists', prd_exists
+      ),
+      'PLAN_verification', jsonb_build_object(
+        'weight', profile.verify_weight,
+        -- FIX: Complete if e2e not required OR PLAN-TO-EXEC handoff accepted
+        'complete', NOT profile.requires_e2e_tests OR plan_to_exec_accepted,
+        'progress', CASE WHEN NOT profile.requires_e2e_tests OR plan_to_exec_accepted
+                        THEN profile.verify_weight ELSE 0 END,
+        'required', profile.requires_e2e_tests,
+        'plan_to_exec_accepted', plan_to_exec_accepted,
+        'note', CASE
+          WHEN NOT profile.requires_e2e_tests THEN 'Auto-complete: E2E tests not required for ' || sd_type_val
+          WHEN plan_to_exec_accepted THEN 'Complete: PLAN-TO-EXEC handoff accepted'
+          ELSE NULL
+        END
+      ),
+      'EXEC_implementation', jsonb_build_object(
+        'weight', profile.exec_weight,
+        -- FIX: Complete if deliverables not required OR EXEC-TO-PLAN handoff accepted
+        'complete', NOT profile.requires_deliverables OR exec_to_plan_accepted,
+        'progress', CASE WHEN NOT profile.requires_deliverables OR exec_to_plan_accepted
+                        THEN profile.exec_weight ELSE 0 END,
+        'required', profile.requires_deliverables,
+        'exec_to_plan_accepted', exec_to_plan_accepted,
+        'note', CASE
+          WHEN NOT profile.requires_deliverables THEN 'Auto-complete: deliverables not required for ' || sd_type_val
+          WHEN exec_to_plan_accepted THEN 'Complete: EXEC-TO-PLAN handoff accepted'
+          ELSE NULL
+        END
+      ),
+      'LEAD_final_approval', jsonb_build_object(
+        'weight', profile.final_weight,
+        'complete', retrospective_exists AND handoffs_count >= profile.min_handoffs,
+        'progress', CASE WHEN retrospective_exists AND handoffs_count >= profile.min_handoffs
+                        THEN profile.final_weight ELSE 0 END,
+        'retrospective_required', profile.requires_retrospective,
+        'retrospective_exists', retrospective_exists,
+        'min_handoffs', profile.min_handoffs,
+        'handoffs_count', handoffs_count
+      )
+    ),
+    'total_progress', total_progress,
+    'can_complete', total_progress = 100
+  );
+
+  RETURN breakdown;
+END;
+$$;
+
+-- Also fix calculate_sd_progress to use correct column and handoff checks
+CREATE OR REPLACE FUNCTION calculate_sd_progress(sd_id_param text)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  sd RECORD;
+  profile RECORD;
+  sd_type_val text;
+  progress INTEGER := 0;
+
+  -- Component states
+  prd_exists BOOLEAN;
+  retrospective_exists BOOLEAN;
+  handoffs_count INT;
+  plan_to_exec_accepted BOOLEAN;
+  exec_to_plan_accepted BOOLEAN;
+BEGIN
+  -- Get SD
+  SELECT * INTO sd FROM strategic_directives_v2 WHERE id = sd_id_param;
+  IF NOT FOUND THEN
+    RETURN 0;
+  END IF;
+
+  -- Check if orchestrator - use different calculation
+  IF is_orchestrator_sd(sd_id_param) OR sd.sd_type = 'orchestrator' THEN
+    RETURN calculate_orchestrator_progress(sd_id_param);
+  END IF;
+
+  -- Get profile
+  sd_type_val := COALESCE(sd.sd_type, 'feature');
+  SELECT * INTO profile FROM sd_type_validation_profiles WHERE sd_type = sd_type_val;
+  IF NOT FOUND THEN
+    SELECT * INTO profile FROM sd_type_validation_profiles WHERE sd_type = 'feature';
+  END IF;
+
+  -- Check components
+  -- FIX: Use 'sd_id' column instead of 'directive_id'
+  SELECT EXISTS (
+    SELECT 1 FROM product_requirements_v2 WHERE sd_id = sd_id_param
+  ) INTO prd_exists;
+
+  SELECT EXISTS (
+    SELECT 1 FROM retrospectives WHERE sd_id = sd_id_param
+  ) INTO retrospective_exists;
+
+  SELECT COUNT(DISTINCT handoff_type) INTO handoffs_count
+  FROM sd_phase_handoffs
+  WHERE sd_id = sd_id_param AND status = 'accepted';
+
+  -- NEW: Check handoffs
+  SELECT EXISTS (
+    SELECT 1 FROM sd_phase_handoffs
+    WHERE sd_id = sd_id_param
+    AND handoff_type = 'PLAN-TO-EXEC'
+    AND status = 'accepted'
+  ) INTO plan_to_exec_accepted;
+
+  SELECT EXISTS (
+    SELECT 1 FROM sd_phase_handoffs
+    WHERE sd_id = sd_id_param
+    AND handoff_type = 'EXEC-TO-PLAN'
+    AND status = 'accepted'
+  ) INTO exec_to_plan_accepted;
+
+  -- Calculate progress
+  -- LEAD approval
+  IF sd.status IN ('active', 'in_progress', 'pending_approval', 'completed') THEN
+    progress := progress + profile.lead_weight;
+  END IF;
+
+  -- PLAN PRD (FIX: Now correctly detects PRD)
+  IF NOT profile.requires_prd OR prd_exists THEN
+    progress := progress + profile.plan_weight;
+  END IF;
+
+  -- PLAN verification (FIX: Now checks PLAN-TO-EXEC handoff)
+  IF NOT profile.requires_e2e_tests OR plan_to_exec_accepted THEN
+    progress := progress + profile.verify_weight;
+  END IF;
+
+  -- EXEC implementation (FIX: Now checks EXEC-TO-PLAN handoff)
+  IF NOT profile.requires_deliverables OR exec_to_plan_accepted THEN
+    progress := progress + profile.exec_weight;
+  END IF;
+
+  -- LEAD final approval
+  IF retrospective_exists AND handoffs_count >= profile.min_handoffs THEN
+    progress := progress + profile.final_weight;
+  END IF;
+
+  RETURN progress;
+END;
+$$;
+
+COMMENT ON FUNCTION get_progress_breakdown IS
+'Returns detailed progress breakdown. Fixed 2026-02-02: Uses sd_id column (not directive_id), checks PLAN-TO-EXEC/EXEC-TO-PLAN handoffs for phase completion.';
+
+COMMENT ON FUNCTION calculate_sd_progress IS
+'Calculates SD progress percentage. Fixed 2026-02-02: Uses sd_id column, checks handoff acceptance for PLAN/EXEC phases.';

--- a/lib/sub-agents/vetting/const-002-validator.js
+++ b/lib/sub-agents/vetting/const-002-validator.js
@@ -1,0 +1,299 @@
+/**
+ * CONST-002 Family Separation Validator
+ * SD-LEO-ORCH-SELF-IMPROVING-LEO-001-B (FR-3, TR-3)
+ *
+ * Enforces constitutional requirement for AI model family separation:
+ * - Evaluator models must be from different families than the proposer
+ * - At least 2 distinct evaluator families required
+ * - No cross-contamination of persona contexts
+ */
+
+// Model family detection patterns
+const FAMILY_PATTERNS = {
+  anthropic: [
+    /^claude[-:/_]/i,
+    /^anthropic[-:/_]/i,
+    /^claude\b/i
+  ],
+  openai: [
+    /^gpt[-:/_]/i,
+    /^o\d[-:/_]/i,
+    /^openai[-:/_]/i,
+    /^text-embedding-/i,
+    /^gpt\b/i
+  ],
+  google: [
+    /^gemini[-:/_]/i,
+    /^palm[-:/_]/i,
+    /^google[-:/_]/i,
+    /^gemini\b/i
+  ],
+  meta: [
+    /^llama[-:/_]/i,
+    /^meta[-:/_]/i,
+    /^llama\b/i
+  ],
+  mistral: [
+    /^mistral[-:/_]/i,
+    /^mixtral[-:/_]/i,
+    /^mixtral\b/i,
+    /^mistral\b/i
+  ]
+};
+
+// Forbidden context markers that indicate cross-contamination
+const FORBIDDEN_CONTEXT_MARKERS = [
+  // Other persona's raw outputs
+  /__PERSONA_OUTPUT_START__/,
+  /__PERSONA_OUTPUT_END__/,
+  // Direct persona transcript references
+  /\[SAFETY_TRANSCRIPT\]/,
+  /\[VALUE_TRANSCRIPT\]/,
+  /\[RISK_TRANSCRIPT\]/,
+  // Internal state markers
+  /__INTERNAL_STATE__/,
+  /__RAW_SCORE__/
+];
+
+/**
+ * Detect model family from model identifier
+ * @param {string} modelId - Model identifier (e.g., "claude-3-sonnet", "gpt-4")
+ * @returns {string} Family name or 'unknown'
+ */
+export function detectModelFamily(modelId) {
+  if (!modelId) return 'unknown';
+
+  const normalizedId = modelId.toLowerCase();
+
+  for (const [family, patterns] of Object.entries(FAMILY_PATTERNS)) {
+    if (patterns.some(pattern => pattern.test(normalizedId))) {
+      return family;
+    }
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Validate CONST-002 family separation for a debate configuration
+ * @param {Object} config - Debate configuration
+ * @param {string} config.proposerModel - Model used for proposal generation
+ * @param {Array<{persona: string, model: string}>} config.evaluators - Evaluator models
+ * @returns {Object} Validation result
+ */
+export function validateFamilySeparation(config) {
+  const { proposerModel, evaluators } = config;
+
+  const result = {
+    passed: false,
+    violations: [],
+    warnings: [],
+    families: {},
+    reason_code: null
+  };
+
+  // Get proposer family
+  const proposerFamily = detectModelFamily(proposerModel);
+  result.families.proposer = {
+    model: proposerModel,
+    family: proposerFamily
+  };
+
+  // Check proposer family is known
+  if (proposerFamily === 'unknown') {
+    result.violations.push({
+      code: 'CONST_002_UNKNOWN_PROPOSER',
+      message: `Proposer model '${proposerModel}' has unknown family`
+    });
+  }
+
+  // Analyze evaluators
+  const evaluatorFamilies = new Set();
+  result.families.evaluators = [];
+
+  for (const evaluator of evaluators) {
+    const family = detectModelFamily(evaluator.model);
+
+    result.families.evaluators.push({
+      persona: evaluator.persona,
+      model: evaluator.model,
+      family
+    });
+
+    if (family === 'unknown') {
+      result.warnings.push({
+        code: 'CONST_002_UNKNOWN_EVALUATOR',
+        message: `Evaluator '${evaluator.persona}' uses unknown family model '${evaluator.model}'`
+      });
+    } else {
+      evaluatorFamilies.add(family);
+    }
+
+    // Check evaluator doesn't share family with proposer
+    if (family === proposerFamily && proposerFamily !== 'unknown') {
+      result.violations.push({
+        code: 'CONST_002_FAMILY_COLLISION',
+        message: `Evaluator '${evaluator.persona}' (${evaluator.model}) shares family '${family}' with proposer`
+      });
+    }
+  }
+
+  // Check at least 2 distinct evaluator families
+  if (evaluatorFamilies.size < 2) {
+    result.violations.push({
+      code: 'CONST_002_INSUFFICIENT_DIVERSITY',
+      message: `Need at least 2 distinct evaluator families, found ${evaluatorFamilies.size}: ${Array.from(evaluatorFamilies).join(', ')}`
+    });
+  }
+
+  // Check all 3 evaluators use different families from each other
+  const evaluatorFamilyList = result.families.evaluators.map(e => e.family);
+  const uniqueEvaluatorFamilies = new Set(evaluatorFamilyList.filter(f => f !== 'unknown'));
+
+  if (uniqueEvaluatorFamilies.size < evaluatorFamilyList.filter(f => f !== 'unknown').length) {
+    const duplicates = evaluatorFamilyList.filter((f, i) =>
+      f !== 'unknown' && evaluatorFamilyList.indexOf(f) !== i
+    );
+    result.warnings.push({
+      code: 'CONST_002_EVALUATOR_DUPLICATION',
+      message: `Multiple evaluators share the same family: ${duplicates.join(', ')}`
+    });
+  }
+
+  // Determine final result
+  result.passed = result.violations.length === 0;
+  result.reason_code = result.passed
+    ? 'CONST_002_PASS'
+    : result.violations[0]?.code || 'CONST_002_FAIL';
+
+  return result;
+}
+
+/**
+ * Validate prompt context for cross-contamination
+ * @param {string} promptContext - The constructed prompt to validate
+ * @param {string} currentPersona - The persona this prompt is for
+ * @returns {Object} Validation result
+ */
+export function validatePromptContext(promptContext, currentPersona) {
+  const result = {
+    passed: true,
+    violations: [],
+    scanned_length: promptContext.length
+  };
+
+  // Check for forbidden markers
+  for (const marker of FORBIDDEN_CONTEXT_MARKERS) {
+    if (marker.test(promptContext)) {
+      result.passed = false;
+      result.violations.push({
+        code: 'CONST_002_CONTEXT_CONTAMINATION',
+        message: `Forbidden marker found in ${currentPersona} context`,
+        marker: marker.toString()
+      });
+    }
+  }
+
+  // Check for other personas' raw transcripts
+  const otherPersonas = ['safety', 'value', 'risk'].filter(p => p !== currentPersona);
+  for (const persona of otherPersonas) {
+    // Look for patterns that suggest raw persona output
+    const rawOutputPattern = new RegExp(`"persona"\\s*:\\s*"${persona}".*?"rationale"\\s*:`, 's');
+    if (rawOutputPattern.test(promptContext)) {
+      result.passed = false;
+      result.violations.push({
+        code: 'CONST_002_RAW_TRANSCRIPT_LEAK',
+        message: `Raw '${persona}' persona output detected in ${currentPersona} context`,
+        persona: persona
+      });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Create a validated debate configuration
+ * Ensures CONST-002 compliance at configuration time
+ * @param {string} proposerModel - Model used for proposal
+ * @param {Object} options - Configuration options
+ * @returns {Object} Validated configuration or throws on violation
+ */
+export function createValidatedDebateConfig(proposerModel, options = {}) {
+  // Default evaluator configuration (3 distinct families)
+  const defaultEvaluators = [
+    { persona: 'safety', model: 'claude-sonnet-4-20250514' },
+    { persona: 'value', model: 'gpt-4o' },
+    { persona: 'risk', model: 'gemini-1.5-pro' }
+  ];
+
+  const evaluators = options.evaluators || defaultEvaluators;
+
+  // Validate configuration
+  const validation = validateFamilySeparation({
+    proposerModel: proposerModel || 'unknown',
+    evaluators
+  });
+
+  if (!validation.passed) {
+    const error = new Error(`CONST-002 validation failed: ${validation.violations.map(v => v.message).join('; ')}`);
+    error.code = validation.reason_code;
+    error.violations = validation.violations;
+    throw error;
+  }
+
+  return {
+    proposerModel,
+    evaluators,
+    validation,
+    const_002_passed: true,
+    validated_at: new Date().toISOString()
+  };
+}
+
+/**
+ * Get a summary of CONST-002 compliance for logging
+ * @param {Object} validation - Validation result from validateFamilySeparation
+ * @returns {string} Human-readable summary
+ */
+export function getComplianceSummary(validation) {
+  const lines = [];
+
+  lines.push(`CONST-002 Compliance: ${validation.passed ? '✅ PASS' : '❌ FAIL'}`);
+  lines.push(`Reason: ${validation.reason_code}`);
+
+  if (validation.families.proposer) {
+    lines.push(`Proposer: ${validation.families.proposer.model} (${validation.families.proposer.family})`);
+  }
+
+  if (validation.families.evaluators) {
+    lines.push('Evaluators:');
+    for (const e of validation.families.evaluators) {
+      lines.push(`  - ${e.persona}: ${e.model} (${e.family})`);
+    }
+  }
+
+  if (validation.violations.length > 0) {
+    lines.push('Violations:');
+    for (const v of validation.violations) {
+      lines.push(`  - [${v.code}] ${v.message}`);
+    }
+  }
+
+  if (validation.warnings.length > 0) {
+    lines.push('Warnings:');
+    for (const w of validation.warnings) {
+      lines.push(`  - [${w.code}] ${w.message}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export default {
+  detectModelFamily,
+  validateFamilySeparation,
+  validatePromptContext,
+  createValidatedDebateConfig,
+  getComplianceSummary
+};

--- a/lib/sub-agents/vetting/critic-personas.js
+++ b/lib/sub-agents/vetting/critic-personas.js
@@ -1,0 +1,306 @@
+/**
+ * Critic Personas for Multi-Model Debate System
+ * SD-LEO-ORCH-SELF-IMPROVING-LEO-001-B (FR-2, FR-3)
+ *
+ * Defines 3 distinct critic personas with:
+ * - System prompts
+ * - Scoring rubrics
+ * - Assigned provider families
+ */
+
+/**
+ * Persona definitions with system prompts and rubrics
+ */
+export const CRITIC_PERSONAS = {
+  safety: {
+    id: 'safety',
+    name: 'Safety Guardian',
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-20250514',
+
+    systemPrompt: `You are the Safety Guardian critic in a governance debate about self-improvement proposals.
+
+Your role is to evaluate proposals from a SAFETY perspective, focusing on:
+- Risk of unintended consequences
+- Potential for cascading failures
+- Reversibility of changes
+- Impact on system stability
+- Data integrity and security implications
+
+SCORING RUBRIC (0-100):
+- 90-100: Exceptionally safe, minimal risk, easily reversible
+- 70-89: Generally safe with minor concerns, manageable risks
+- 50-69: Moderate risks requiring mitigation strategies
+- 30-49: Significant safety concerns, needs substantial revision
+- 0-29: Unacceptable safety risks, should be rejected
+
+You MUST respond in JSON format:
+{
+  "verdict": "approve" | "revise" | "reject",
+  "score": <number 0-100>,
+  "rationale": "<detailed explanation of your safety assessment>",
+  "change_requests": ["<specific change 1>", "<specific change 2>", ...]
+}
+
+Be thorough but fair. Consider both immediate and long-term safety implications.`,
+
+    rubric: {
+      criteria: [
+        { name: 'reversibility', weight: 0.25, description: 'Can changes be rolled back?' },
+        { name: 'stability_impact', weight: 0.25, description: 'Impact on system stability' },
+        { name: 'cascading_risk', weight: 0.20, description: 'Risk of cascading failures' },
+        { name: 'data_integrity', weight: 0.15, description: 'Data integrity preservation' },
+        { name: 'security', weight: 0.15, description: 'Security implications' }
+      ]
+    }
+  },
+
+  value: {
+    id: 'value',
+    name: 'Value Assessor',
+    provider: 'openai',
+    model: 'gpt-4o',
+
+    systemPrompt: `You are the Value Assessor critic in a governance debate about self-improvement proposals.
+
+Your role is to evaluate proposals from a VALUE perspective, focusing on:
+- Business value and ROI
+- User impact and benefit
+- Alignment with strategic objectives
+- Opportunity cost of implementation
+- Long-term value sustainability
+
+SCORING RUBRIC (0-100):
+- 90-100: Exceptional value, clear ROI, strong strategic alignment
+- 70-89: Good value proposition with clear benefits
+- 50-69: Moderate value, benefits present but not compelling
+- 30-49: Limited value, questionable ROI
+- 0-29: Negative value or misaligned with objectives
+
+You MUST respond in JSON format:
+{
+  "verdict": "approve" | "revise" | "reject",
+  "score": <number 0-100>,
+  "rationale": "<detailed explanation of your value assessment>",
+  "change_requests": ["<specific change 1>", "<specific change 2>", ...]
+}
+
+Be objective and quantitative where possible. Consider both immediate and long-term value.`,
+
+    rubric: {
+      criteria: [
+        { name: 'business_value', weight: 0.30, description: 'Direct business benefit' },
+        { name: 'user_impact', weight: 0.25, description: 'User experience improvement' },
+        { name: 'strategic_alignment', weight: 0.20, description: 'Alignment with strategy' },
+        { name: 'opportunity_cost', weight: 0.15, description: 'Cost vs alternatives' },
+        { name: 'sustainability', weight: 0.10, description: 'Long-term maintainability' }
+      ]
+    }
+  },
+
+  risk: {
+    id: 'risk',
+    name: 'Risk Analyst',
+    provider: 'google',
+    model: 'gemini-1.5-pro',
+
+    systemPrompt: `You are the Risk Analyst critic in a governance debate about self-improvement proposals.
+
+Your role is to evaluate proposals from a RISK perspective, focusing on:
+- Implementation complexity
+- Technical debt implications
+- Dependency risks
+- Timeline and resource risks
+- Compliance and governance risks
+
+SCORING RUBRIC (0-100):
+- 90-100: Very low risk, straightforward implementation
+- 70-89: Manageable risks with clear mitigation paths
+- 50-69: Moderate risks requiring careful management
+- 30-49: High risks, needs significant risk mitigation
+- 0-29: Unacceptable risk levels, should be rejected
+
+You MUST respond in JSON format:
+{
+  "verdict": "approve" | "revise" | "reject",
+  "score": <number 0-100>,
+  "rationale": "<detailed explanation of your risk assessment>",
+  "change_requests": ["<specific change 1>", "<specific change 2>", ...]
+}
+
+Be analytical and thorough. Identify both obvious and hidden risks.`,
+
+    rubric: {
+      criteria: [
+        { name: 'implementation_complexity', weight: 0.25, description: 'How complex is the implementation?' },
+        { name: 'technical_debt', weight: 0.20, description: 'Technical debt implications' },
+        { name: 'dependencies', weight: 0.20, description: 'External dependency risks' },
+        { name: 'resource_risk', weight: 0.20, description: 'Timeline and resource risks' },
+        { name: 'compliance', weight: 0.15, description: 'Governance and compliance risks' }
+      ]
+    }
+  }
+};
+
+/**
+ * Get persona by ID
+ * @param {string} personaId - Persona identifier (safety, value, risk)
+ * @returns {Object} Persona definition
+ */
+export function getPersona(personaId) {
+  const persona = CRITIC_PERSONAS[personaId];
+  if (!persona) {
+    throw new Error(`Unknown persona: ${personaId}. Valid personas: ${Object.keys(CRITIC_PERSONAS).join(', ')}`);
+  }
+  return persona;
+}
+
+/**
+ * Get all personas
+ * @returns {Object[]} Array of persona definitions
+ */
+export function getAllPersonas() {
+  return Object.values(CRITIC_PERSONAS);
+}
+
+/**
+ * Build user prompt for a persona evaluation
+ * @param {Object} proposal - The proposal to evaluate
+ * @param {string} orchestratorSummary - Summary from previous round (null for round 0)
+ * @returns {string} Formatted user prompt
+ */
+export function buildEvaluationPrompt(proposal, orchestratorSummary = null) {
+  let prompt = `## Proposal for Evaluation
+
+**Title:** ${proposal.title || 'Untitled Proposal'}
+
+**Summary:**
+${proposal.summary || proposal.description || 'No summary provided'}
+
+**Motivation:**
+${proposal.motivation || 'Not specified'}
+
+**Scope:**
+${formatScope(proposal.scope)}
+
+**Affected Components:**
+${formatComponents(proposal.affected_components)}
+
+**Risk Level (Initial Assessment):** ${proposal.risk_level || 'Unknown'}
+`;
+
+  if (orchestratorSummary) {
+    prompt += `
+---
+
+## Previous Round Summary (from Orchestrator)
+
+${orchestratorSummary}
+
+---
+
+Based on the orchestrator's summary of the previous round, provide your updated assessment.
+`;
+  }
+
+  prompt += `
+Please provide your assessment in the required JSON format.`;
+
+  return prompt;
+}
+
+/**
+ * Format scope items for prompt
+ */
+function formatScope(scope) {
+  if (!scope || scope.length === 0) {
+    return 'Not specified';
+  }
+  return scope.map(s => `- ${s.area}: ${s.description}`).join('\n');
+}
+
+/**
+ * Format affected components for prompt
+ */
+function formatComponents(components) {
+  if (!components || components.length === 0) {
+    return 'Not specified';
+  }
+  return components.map(c => `- ${c.name} (${c.type}, impact: ${c.impact})`).join('\n');
+}
+
+/**
+ * Parse persona response to extract structured data
+ * @param {string} responseText - Raw response from LLM
+ * @returns {Object} Parsed response with verdict, score, rationale, change_requests
+ */
+export function parsePersonaResponse(responseText) {
+  try {
+    // Try to extract JSON from response
+    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+
+      // Validate required fields
+      if (!parsed.verdict || typeof parsed.score !== 'number' || !parsed.rationale) {
+        throw new Error('Missing required fields in response');
+      }
+
+      // Normalize verdict
+      const normalizedVerdict = parsed.verdict.toLowerCase();
+      if (!['approve', 'revise', 'reject'].includes(normalizedVerdict)) {
+        throw new Error(`Invalid verdict: ${parsed.verdict}`);
+      }
+
+      return {
+        verdict: normalizedVerdict,
+        score: Math.max(0, Math.min(100, parsed.score)),
+        rationale: parsed.rationale,
+        change_requests: Array.isArray(parsed.change_requests) ? parsed.change_requests : []
+      };
+    }
+
+    throw new Error('No JSON found in response');
+  } catch (error) {
+    // Return a structured error response
+    return {
+      verdict: 'revise',
+      score: 50,
+      rationale: `Failed to parse response: ${error.message}. Raw response: ${responseText.substring(0, 200)}...`,
+      change_requests: ['Response parsing failed - manual review required'],
+      parse_error: true
+    };
+  }
+}
+
+/**
+ * Validate that persona assignments follow CONST-002 family separation
+ * @returns {{ valid: boolean, violations: string[] }}
+ */
+export function validatePersonaFamilySeparation() {
+  const families = getAllPersonas().map(p => p.provider);
+  const uniqueFamilies = new Set(families);
+
+  const violations = [];
+
+  // Check all 3 personas use different providers
+  if (uniqueFamilies.size !== 3) {
+    const duplicates = families.filter((f, i) => families.indexOf(f) !== i);
+    violations.push(`CONST-002: Duplicate provider families detected: ${duplicates.join(', ')}`);
+  }
+
+  return {
+    valid: violations.length === 0,
+    violations,
+    families: Array.from(uniqueFamilies)
+  };
+}
+
+export default {
+  CRITIC_PERSONAS,
+  getPersona,
+  getAllPersonas,
+  buildEvaluationPrompt,
+  parsePersonaResponse,
+  validatePersonaFamilySeparation
+};

--- a/lib/sub-agents/vetting/debate-orchestrator.js
+++ b/lib/sub-agents/vetting/debate-orchestrator.js
@@ -1,0 +1,634 @@
+/**
+ * Debate Orchestrator for Multi-Model Debate System
+ * SD-LEO-ORCH-SELF-IMPROVING-LEO-001-B (FR-1, FR-2, FR-5, FR-6)
+ *
+ * Orchestrates multi-round debates using 3 distinct LLM provider families.
+ * Implements:
+ * - Multi-round debate with configurable max rounds
+ * - Early stopping on consensus detection
+ * - CONST-002 family separation validation
+ * - Full transcript persistence
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { v4 as uuidv4 } from 'uuid';
+import { getProviderAdapter } from './provider-adapters.js';
+import {
+  getAllPersonas,
+  getPersona,
+  buildEvaluationPrompt,
+  parsePersonaResponse,
+  validatePersonaFamilySeparation
+} from './critic-personas.js';
+
+// Initialize Supabase
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+// Configuration
+const DEFAULT_MAX_ROUNDS = 3;
+const CONSENSUS_SCORE_DELTA = 15; // Max score difference for consensus
+const DEBUG_TRANSCRIPTS = process.env.DEBATE_DEBUG_TRANSCRIPTS === 'true';
+const TRANSCRIPT_SNIPPET_LENGTH = 500;
+
+/**
+ * Debate Orchestrator Class
+ */
+export class DebateOrchestrator {
+  constructor(options = {}) {
+    this.supabase = options.supabase || supabase;
+    this.maxRounds = options.maxRounds || DEFAULT_MAX_ROUNDS;
+    this.consensusThreshold = options.consensusThreshold || CONSENSUS_SCORE_DELTA;
+    this.correlationId = options.correlationId || uuidv4();
+  }
+
+  /**
+   * Run a full debate for a proposal
+   * @param {Object} proposal - The proposal to debate
+   * @returns {Object} Debate result with transcript
+   */
+  async runDebate(proposal) {
+    const startTime = Date.now();
+
+    this.log('debate_start', { proposalId: proposal.id, maxRounds: this.maxRounds });
+
+    // Step 1: Check idempotency - don't create duplicate debates
+    const canCreate = await this.checkIdempotency(proposal.id);
+    if (!canCreate.can_create) {
+      this.log('idempotency_skip', {
+        proposalId: proposal.id,
+        reason: canCreate.reason,
+        existingDebateId: canCreate.existing_debate_id
+      });
+      return {
+        success: false,
+        skipped: true,
+        reason: canCreate.reason,
+        existingDebateId: canCreate.existing_debate_id
+      };
+    }
+
+    // Step 2: Validate CONST-002 family separation
+    const const002Result = this.validateConst002();
+    if (!const002Result.valid) {
+      this.log('const_002_fail', { violations: const002Result.violations });
+      return {
+        success: false,
+        const002Passed: false,
+        violations: const002Result.violations
+      };
+    }
+
+    // Step 3: Create debate record
+    const debate = await this.createDebateRecord(proposal.id);
+    this.log('debate_created', { debateId: debate.id });
+
+    try {
+      // Step 4: Run debate rounds
+      let orchestratorSummary = null;
+      let consensusReached = false;
+      let consensusReason = null;
+
+      for (let roundIndex = 0; roundIndex < this.maxRounds && !consensusReached; roundIndex++) {
+        this.log('round_start', { debateId: debate.id, roundIndex });
+
+        // Run all personas for this round
+        const roundResult = await this.runRound(
+          debate.id,
+          roundIndex,
+          proposal,
+          orchestratorSummary
+        );
+
+        // Check for consensus
+        const consensusCheck = this.checkConsensus(roundResult.personaOutputs);
+        consensusReached = consensusCheck.reached;
+        consensusReason = consensusCheck.reason;
+
+        // Store round result
+        await this.storeRoundResult(debate.id, roundIndex, roundResult, consensusCheck);
+
+        // Generate orchestrator summary for next round
+        if (!consensusReached && roundIndex < this.maxRounds - 1) {
+          orchestratorSummary = this.generateOrchestratorSummary(roundResult.personaOutputs, roundIndex);
+        }
+
+        this.log('round_complete', {
+          debateId: debate.id,
+          roundIndex,
+          consensusReached,
+          consensusReason
+        });
+      }
+
+      // Step 5: Calculate final verdict
+      const finalResult = await this.calculateFinalVerdict(debate.id, consensusReached, consensusReason);
+
+      // Step 6: Update debate record with results
+      await this.completeDebate(debate.id, finalResult, Date.now() - startTime);
+
+      this.log('debate_complete', {
+        debateId: debate.id,
+        finalVerdict: finalResult.verdict,
+        finalScore: finalResult.score,
+        consensusReached,
+        durationMs: Date.now() - startTime
+      });
+
+      return {
+        success: true,
+        debateId: debate.id,
+        proposalId: proposal.id,
+        const002Passed: true,
+        consensusReached,
+        consensusReason,
+        finalVerdict: finalResult.verdict,
+        finalScore: finalResult.score,
+        topIssues: finalResult.topIssues,
+        recommendedNextSteps: finalResult.recommendedNextSteps,
+        roundsCompleted: finalResult.roundsCompleted,
+        durationMs: Date.now() - startTime
+      };
+
+    } catch (error) {
+      // Step 6 (error): Mark debate as failed
+      await this.failDebate(debate.id, error);
+
+      this.log('debate_fail', {
+        debateId: debate.id,
+        error: error.message
+      });
+
+      return {
+        success: false,
+        debateId: debate.id,
+        error: error.message
+      };
+    }
+  }
+
+  /**
+   * Check if a debate can be created (idempotency)
+   */
+  async checkIdempotency(proposalId) {
+    const { data, error } = await this.supabase.rpc('can_create_debate', {
+      p_proposal_id: proposalId
+    });
+
+    if (error) {
+      // If function doesn't exist, do manual check
+      const { data: existing } = await this.supabase
+        .from('proposal_debates')
+        .select('id, status')
+        .eq('proposal_id', proposalId)
+        .in('status', ['running', 'completed'])
+        .limit(1);
+
+      if (existing && existing.length > 0) {
+        return {
+          can_create: false,
+          reason: 'existing_debate',
+          existing_debate_id: existing[0].id
+        };
+      }
+      return { can_create: true };
+    }
+
+    return data;
+  }
+
+  /**
+   * Validate CONST-002 family separation
+   */
+  validateConst002() {
+    return validatePersonaFamilySeparation();
+  }
+
+  /**
+   * Create initial debate record
+   */
+  async createDebateRecord(proposalId) {
+    const { data, error } = await this.supabase
+      .from('proposal_debates')
+      .insert({
+        proposal_id: proposalId,
+        status: 'running',
+        started_at: new Date().toISOString(),
+        max_rounds: this.maxRounds,
+        consensus_threshold: this.consensusThreshold,
+        correlation_id: this.correlationId,
+        const_002_passed: true,
+        const_002_result: { validated_at: new Date().toISOString(), families: ['anthropic', 'openai', 'google'] }
+      })
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to create debate record: ${error.message}`);
+    }
+
+    return data;
+  }
+
+  /**
+   * Run a single debate round
+   */
+  async runRound(debateId, roundIndex, proposal, orchestratorSummary) {
+    const personas = getAllPersonas();
+    const personaOutputs = {};
+    const providerCalls = [];
+
+    // Run personas in parallel
+    const promises = personas.map(async (persona) => {
+      const startTime = Date.now();
+      this.log('persona_call_start', {
+        debateId,
+        roundIndex,
+        persona: persona.id,
+        provider: persona.provider
+      });
+
+      try {
+        const adapter = getProviderAdapter(persona.provider, { model: persona.model });
+        const userPrompt = buildEvaluationPrompt(proposal, orchestratorSummary);
+
+        const response = await adapter.complete(persona.systemPrompt, userPrompt);
+        const parsed = parsePersonaResponse(response.content);
+
+        const durationMs = Date.now() - startTime;
+
+        this.log('persona_call_end', {
+          debateId,
+          roundIndex,
+          persona: persona.id,
+          provider: persona.provider,
+          model: response.model,
+          durationMs,
+          verdict: parsed.verdict,
+          score: parsed.score
+        });
+
+        return {
+          personaId: persona.id,
+          output: {
+            ...parsed,
+            provider: response.provider,
+            family: response.family,
+            model: response.model,
+            durationMs,
+            tokensUsed: response.usage
+          },
+          providerCall: {
+            persona: persona.id,
+            provider: response.provider,
+            model: response.model,
+            duration_ms: durationMs,
+            tokens_used: response.usage
+          }
+        };
+      } catch (error) {
+        const durationMs = Date.now() - startTime;
+
+        this.log('persona_call_error', {
+          debateId,
+          roundIndex,
+          persona: persona.id,
+          error: error.message,
+          durationMs
+        });
+
+        return {
+          personaId: persona.id,
+          output: {
+            verdict: 'revise',
+            score: 50,
+            rationale: `Provider call failed: ${error.message}`,
+            change_requests: ['Provider call failed - retry required'],
+            provider: persona.provider,
+            model: persona.model,
+            durationMs,
+            error: error.message
+          },
+          providerCall: {
+            persona: persona.id,
+            provider: persona.provider,
+            model: persona.model,
+            duration_ms: durationMs,
+            error: error.message
+          }
+        };
+      }
+    });
+
+    const results = await Promise.all(promises);
+
+    for (const result of results) {
+      personaOutputs[result.personaId] = result.output;
+      providerCalls.push(result.providerCall);
+    }
+
+    return { personaOutputs, providerCalls };
+  }
+
+  /**
+   * Check if consensus is reached
+   */
+  checkConsensus(personaOutputs) {
+    const verdicts = Object.values(personaOutputs).map(o => o.verdict);
+    const scores = Object.values(personaOutputs).map(o => o.score);
+
+    // Count verdicts
+    const verdictCounts = {};
+    for (const v of verdicts) {
+      verdictCounts[v] = (verdictCounts[v] || 0) + 1;
+    }
+
+    // Find majority verdict (at least 2 of 3)
+    const majorityVerdict = Object.entries(verdictCounts)
+      .find(([_, count]) => count >= 2)?.[0];
+
+    if (!majorityVerdict) {
+      return { reached: false, reason: 'no_majority_verdict' };
+    }
+
+    // Check score delta
+    const minScore = Math.min(...scores);
+    const maxScore = Math.max(...scores);
+    const scoreDelta = maxScore - minScore;
+
+    if (scoreDelta > this.consensusThreshold) {
+      return {
+        reached: false,
+        reason: `score_delta_too_high: ${scoreDelta} > ${this.consensusThreshold}`
+      };
+    }
+
+    return {
+      reached: true,
+      reason: `consensus: ${majorityVerdict} (${verdictCounts[majorityVerdict]}/3), score_delta=${scoreDelta}`,
+      majorityVerdict,
+      scoreDelta
+    };
+  }
+
+  /**
+   * Generate orchestrator summary for next round
+   */
+  generateOrchestratorSummary(personaOutputs, roundIndex) {
+    const summaries = [];
+
+    for (const [personaId, output] of Object.entries(personaOutputs)) {
+      const persona = getPersona(personaId);
+      summaries.push(`**${persona.name} (${personaId}):**
+- Verdict: ${output.verdict.toUpperCase()}
+- Score: ${output.score}/100
+- Key points: ${output.rationale.substring(0, 200)}...
+- Change requests: ${output.change_requests.slice(0, 2).join('; ') || 'None'}`);
+    }
+
+    return `## Round ${roundIndex + 1} Summary
+
+${summaries.join('\n\n')}
+
+---
+Consider the feedback from your fellow critics and update your assessment if warranted.`;
+  }
+
+  /**
+   * Store round result in database
+   */
+  async storeRoundResult(debateId, roundIndex, roundResult, consensusCheck) {
+    const { error } = await this.supabase
+      .from('proposal_debate_rounds')
+      .insert({
+        debate_id: debateId,
+        round_index: roundIndex,
+        persona_outputs: roundResult.personaOutputs,
+        orchestrator_summary: this.generateOrchestratorSummary(roundResult.personaOutputs, roundIndex),
+        consensus_check: consensusCheck,
+        provider_calls: roundResult.providerCalls,
+        completed_at: new Date().toISOString()
+      });
+
+    if (error) {
+      console.error('[DebateOrchestrator] Failed to store round result:', error.message);
+    }
+  }
+
+  /**
+   * Calculate final verdict from all rounds
+   */
+  async calculateFinalVerdict(debateId, consensusReached, consensusReason) {
+    // Get all rounds
+    const { data: rounds, error } = await this.supabase
+      .from('proposal_debate_rounds')
+      .select('*')
+      .eq('debate_id', debateId)
+      .order('round_index', { ascending: true });
+
+    if (error || !rounds || rounds.length === 0) {
+      throw new Error('No rounds found for verdict calculation');
+    }
+
+    const lastRound = rounds[rounds.length - 1];
+    const personaOutputs = lastRound.persona_outputs;
+
+    // Calculate weighted average score (equal weights)
+    const scores = Object.values(personaOutputs).map(o => o.score);
+    const avgScore = scores.reduce((a, b) => a + b, 0) / scores.length;
+
+    // Determine final verdict
+    let finalVerdict;
+    if (consensusReached) {
+      // Use majority verdict from consensus
+      const verdicts = Object.values(personaOutputs).map(o => o.verdict);
+      const verdictCounts = {};
+      for (const v of verdicts) {
+        verdictCounts[v] = (verdictCounts[v] || 0) + 1;
+      }
+      finalVerdict = Object.entries(verdictCounts)
+        .sort((a, b) => b[1] - a[1])[0][0];
+    } else {
+      // Tie-break: use score-based verdict
+      if (avgScore >= 70) finalVerdict = 'approve';
+      else if (avgScore >= 50) finalVerdict = 'revise';
+      else finalVerdict = 'reject';
+    }
+
+    // Collect top issues (max 5)
+    const allChangeRequests = Object.values(personaOutputs)
+      .flatMap(o => o.change_requests || []);
+    const topIssues = [...new Set(allChangeRequests)].slice(0, 5);
+
+    // Generate recommended next steps
+    const recommendedNextSteps = this.generateNextSteps(finalVerdict, topIssues);
+
+    return {
+      verdict: finalVerdict,
+      score: Math.round(avgScore * 100) / 100,
+      topIssues,
+      recommendedNextSteps,
+      roundsCompleted: rounds.length,
+      consensusReached,
+      consensusReason
+    };
+  }
+
+  /**
+   * Generate recommended next steps based on verdict
+   */
+  generateNextSteps(verdict, topIssues) {
+    switch (verdict) {
+      case 'approve':
+        return ['Proceed with implementation', 'Monitor for issues during rollout'];
+      case 'revise':
+        return [
+          'Address the identified issues',
+          ...topIssues.slice(0, 3).map(issue => `Resolve: ${issue}`),
+          'Resubmit for another debate round'
+        ];
+      case 'reject':
+        return [
+          'Do not proceed with implementation',
+          'Consider fundamental redesign if the proposal is still valuable',
+          'Consult with stakeholders on alternative approaches'
+        ];
+      default:
+        return ['Review debate transcript for details'];
+    }
+  }
+
+  /**
+   * Mark debate as completed
+   */
+  async completeDebate(debateId, result, _durationMs) {
+    const { error } = await this.supabase
+      .from('proposal_debates')
+      .update({
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+        actual_rounds: result.roundsCompleted,
+        consensus_reached: result.consensusReached,
+        consensus_reason: result.consensusReason,
+        final_verdict: result.verdict,
+        final_score: result.score,
+        top_issues: result.topIssues,
+        recommended_next_steps: result.recommendedNextSteps
+      })
+      .eq('id', debateId);
+
+    if (error) {
+      console.error('[DebateOrchestrator] Failed to complete debate:', error.message);
+    }
+  }
+
+  /**
+   * Mark debate as failed
+   */
+  async failDebate(debateId, error) {
+    await this.supabase
+      .from('proposal_debates')
+      .update({
+        status: 'failed',
+        completed_at: new Date().toISOString(),
+        error_code: error.code || 'UNKNOWN_ERROR',
+        error_message: error.message
+      })
+      .eq('id', debateId);
+  }
+
+  /**
+   * Structured logging
+   */
+  log(eventType, data) {
+    const logEntry = {
+      correlation_id: this.correlationId,
+      event_type: eventType,
+      timestamp: new Date().toISOString(),
+      ...data
+    };
+
+    // Truncate transcript snippets if debug mode disabled
+    if (!DEBUG_TRANSCRIPTS && data.rationale) {
+      logEntry.rationale = data.rationale.substring(0, TRANSCRIPT_SNIPPET_LENGTH);
+    }
+
+    console.log(`[DebateOrchestrator] ${eventType}:`, JSON.stringify(logEntry));
+  }
+}
+
+/**
+ * Trigger a debate for a proposal (convenience function)
+ * @param {string} proposalId - UUID of the proposal
+ * @param {Object} options - Orchestrator options
+ * @returns {Object} Debate result
+ */
+export async function triggerDebate(proposalId, options = {}) {
+  // Fetch proposal
+  const { data: proposal, error } = await supabase
+    .from('leo_proposals')
+    .select('*')
+    .eq('id', proposalId)
+    .single();
+
+  if (error || !proposal) {
+    throw new Error(`Proposal not found: ${proposalId}`);
+  }
+
+  // Check proposal status
+  if (proposal.status !== 'submitted') {
+    return {
+      success: false,
+      skipped: true,
+      reason: `Proposal status is '${proposal.status}', expected 'submitted'`
+    };
+  }
+
+  const orchestrator = new DebateOrchestrator(options);
+  return orchestrator.runDebate(proposal);
+}
+
+/**
+ * Get debate by ID
+ */
+export async function getDebate(debateId) {
+  const { data, error } = await supabase
+    .from('proposal_debates')
+    .select(`
+      *,
+      rounds:proposal_debate_rounds(*)
+    `)
+    .eq('id', debateId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to get debate: ${error.message}`);
+  }
+
+  return data;
+}
+
+/**
+ * Get latest debate for a proposal
+ */
+export async function getLatestDebate(proposalId) {
+  const { data, error } = await supabase
+    .from('proposal_debates')
+    .select(`
+      *,
+      rounds:proposal_debate_rounds(*)
+    `)
+    .eq('proposal_id', proposalId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error && error.code !== 'PGRST116') {
+    throw new Error(`Failed to get debate: ${error.message}`);
+  }
+
+  return data || null;
+}
+
+export default DebateOrchestrator;

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -1,0 +1,289 @@
+/**
+ * Provider Adapters for Multi-Model Debate System
+ * SD-LEO-ORCH-SELF-IMPROVING-LEO-001-B (TR-1)
+ *
+ * Implements a shared interface for Anthropic, OpenAI, and Google providers
+ * with strict timeout/retry policy.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+
+// Timeout and retry configuration
+const PROVIDER_TIMEOUT_MS = 15000; // 15 seconds per call
+const MAX_RETRIES = 2;
+const RETRY_DELAY_MS = 1000;
+
+/**
+ * Base adapter interface
+ * @typedef {Object} ProviderResponse
+ * @property {string} content - The response content
+ * @property {string} provider - Provider name (anthropic, openai, google)
+ * @property {string} model - Model identifier
+ * @property {number} durationMs - Time taken for the call
+ * @property {Object} usage - Token usage info
+ */
+
+/**
+ * Sleep helper for retry delays
+ */
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Anthropic Provider Adapter
+ */
+export class AnthropicAdapter {
+  constructor(options = {}) {
+    this.client = new Anthropic({
+      apiKey: options.apiKey || process.env.ANTHROPIC_API_KEY
+    });
+    this.defaultModel = options.model || 'claude-sonnet-4-20250514';
+    this.provider = 'anthropic';
+    this.family = 'anthropic';
+  }
+
+  async complete(systemPrompt, userPrompt, options = {}) {
+    const startTime = Date.now();
+    const model = options.model || this.defaultModel;
+
+    let lastError = null;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const response = await Promise.race([
+          this.client.messages.create({
+            model,
+            max_tokens: options.maxTokens || 2000,
+            system: systemPrompt,
+            messages: [{ role: 'user', content: userPrompt }]
+          }),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('TIMEOUT')), PROVIDER_TIMEOUT_MS)
+          )
+        ]);
+
+        const durationMs = Date.now() - startTime;
+
+        return {
+          content: response.content[0].text,
+          provider: this.provider,
+          family: this.family,
+          model,
+          durationMs,
+          usage: {
+            inputTokens: response.usage?.input_tokens,
+            outputTokens: response.usage?.output_tokens
+          },
+          attempt: attempt + 1
+        };
+      } catch (error) {
+        lastError = error;
+        if (attempt < MAX_RETRIES) {
+          console.warn(`[AnthropicAdapter] Attempt ${attempt + 1} failed, retrying...`, error.message);
+          await sleep(RETRY_DELAY_MS * (attempt + 1));
+        }
+      }
+    }
+
+    throw new Error(`Anthropic call failed after ${MAX_RETRIES + 1} attempts: ${lastError?.message}`);
+  }
+}
+
+/**
+ * OpenAI Provider Adapter
+ */
+export class OpenAIAdapter {
+  constructor(options = {}) {
+    this.apiKey = options.apiKey || process.env.OPENAI_API_KEY;
+    this.baseUrl = options.baseUrl || 'https://api.openai.com/v1';
+    this.defaultModel = options.model || 'gpt-4o';
+    this.provider = 'openai';
+    this.family = 'openai';
+  }
+
+  async complete(systemPrompt, userPrompt, options = {}) {
+    const startTime = Date.now();
+    const model = options.model || this.defaultModel;
+
+    let lastError = null;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), PROVIDER_TIMEOUT_MS);
+
+        const response = await fetch(`${this.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${this.apiKey}`
+          },
+          body: JSON.stringify({
+            model,
+            max_tokens: options.maxTokens || 2000,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt }
+            ]
+          }),
+          signal: controller.signal
+        });
+
+        clearTimeout(timeoutId);
+
+        if (!response.ok) {
+          const errorBody = await response.text();
+          throw new Error(`OpenAI API error ${response.status}: ${errorBody}`);
+        }
+
+        const data = await response.json();
+        const durationMs = Date.now() - startTime;
+
+        return {
+          content: data.choices[0].message.content,
+          provider: this.provider,
+          family: this.family,
+          model,
+          durationMs,
+          usage: {
+            inputTokens: data.usage?.prompt_tokens,
+            outputTokens: data.usage?.completion_tokens
+          },
+          attempt: attempt + 1
+        };
+      } catch (error) {
+        lastError = error;
+        if (error.name === 'AbortError') {
+          lastError = new Error('TIMEOUT');
+        }
+        if (attempt < MAX_RETRIES) {
+          console.warn(`[OpenAIAdapter] Attempt ${attempt + 1} failed, retrying...`, lastError.message);
+          await sleep(RETRY_DELAY_MS * (attempt + 1));
+        }
+      }
+    }
+
+    throw new Error(`OpenAI call failed after ${MAX_RETRIES + 1} attempts: ${lastError?.message}`);
+  }
+}
+
+/**
+ * Google (Gemini) Provider Adapter
+ */
+export class GoogleAdapter {
+  constructor(options = {}) {
+    this.apiKey = options.apiKey || process.env.GOOGLE_AI_API_KEY || process.env.GEMINI_API_KEY;
+    this.baseUrl = options.baseUrl || 'https://generativelanguage.googleapis.com/v1beta';
+    this.defaultModel = options.model || 'gemini-1.5-pro';
+    this.provider = 'google';
+    this.family = 'google';
+  }
+
+  async complete(systemPrompt, userPrompt, options = {}) {
+    const startTime = Date.now();
+    const model = options.model || this.defaultModel;
+
+    let lastError = null;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), PROVIDER_TIMEOUT_MS);
+
+        const response = await fetch(
+          `${this.baseUrl}/models/${model}:generateContent?key=${this.apiKey}`,
+          {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              systemInstruction: { parts: [{ text: systemPrompt }] },
+              contents: [{ parts: [{ text: userPrompt }] }],
+              generationConfig: {
+                maxOutputTokens: options.maxTokens || 2000
+              }
+            }),
+            signal: controller.signal
+          }
+        );
+
+        clearTimeout(timeoutId);
+
+        if (!response.ok) {
+          const errorBody = await response.text();
+          throw new Error(`Google API error ${response.status}: ${errorBody}`);
+        }
+
+        const data = await response.json();
+        const durationMs = Date.now() - startTime;
+
+        const content = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+
+        return {
+          content,
+          provider: this.provider,
+          family: this.family,
+          model,
+          durationMs,
+          usage: {
+            inputTokens: data.usageMetadata?.promptTokenCount,
+            outputTokens: data.usageMetadata?.candidatesTokenCount
+          },
+          attempt: attempt + 1
+        };
+      } catch (error) {
+        lastError = error;
+        if (error.name === 'AbortError') {
+          lastError = new Error('TIMEOUT');
+        }
+        if (attempt < MAX_RETRIES) {
+          console.warn(`[GoogleAdapter] Attempt ${attempt + 1} failed, retrying...`, lastError.message);
+          await sleep(RETRY_DELAY_MS * (attempt + 1));
+        }
+      }
+    }
+
+    throw new Error(`Google call failed after ${MAX_RETRIES + 1} attempts: ${lastError?.message}`);
+  }
+}
+
+/**
+ * Get provider adapter by family name
+ * @param {string} family - Provider family (anthropic, openai, google)
+ * @param {Object} options - Adapter options
+ * @returns {AnthropicAdapter|OpenAIAdapter|GoogleAdapter}
+ */
+export function getProviderAdapter(family, options = {}) {
+  switch (family.toLowerCase()) {
+    case 'anthropic':
+    case 'claude':
+      return new AnthropicAdapter(options);
+    case 'openai':
+    case 'gpt':
+      return new OpenAIAdapter(options);
+    case 'google':
+    case 'gemini':
+      return new GoogleAdapter(options);
+    default:
+      throw new Error(`Unknown provider family: ${family}`);
+  }
+}
+
+/**
+ * Get all three adapters for multi-model debate
+ * @returns {{ anthropic: AnthropicAdapter, openai: OpenAIAdapter, google: GoogleAdapter }}
+ */
+export function getAllAdapters() {
+  return {
+    anthropic: new AnthropicAdapter(),
+    openai: new OpenAIAdapter(),
+    google: new GoogleAdapter()
+  };
+}
+
+export default {
+  AnthropicAdapter,
+  OpenAIAdapter,
+  GoogleAdapter,
+  getProviderAdapter,
+  getAllAdapters
+};

--- a/tests/unit/sub-agents/vetting/debate-system.test.js
+++ b/tests/unit/sub-agents/vetting/debate-system.test.js
@@ -1,0 +1,409 @@
+/**
+ * Unit Tests for Multi-Model Debate System
+ * SD-LEO-ORCH-SELF-IMPROVING-LEO-001-B
+ *
+ * Tests:
+ * - CONST-002 family separation validator
+ * - Critic persona configuration
+ * - Prompt context validation
+ * - Consensus detection
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  detectModelFamily,
+  validateFamilySeparation,
+  validatePromptContext,
+  createValidatedDebateConfig,
+  getComplianceSummary
+} from '../../../../lib/sub-agents/vetting/const-002-validator.js';
+import {
+  CRITIC_PERSONAS,
+  getPersona,
+  getAllPersonas,
+  buildEvaluationPrompt,
+  parsePersonaResponse,
+  validatePersonaFamilySeparation
+} from '../../../../lib/sub-agents/vetting/critic-personas.js';
+
+describe('CONST-002 Family Separation Validator', () => {
+  describe('detectModelFamily', () => {
+    it('should detect Anthropic models', () => {
+      expect(detectModelFamily('claude-3-sonnet')).toBe('anthropic');
+      expect(detectModelFamily('claude-sonnet-4-20250514')).toBe('anthropic');
+      expect(detectModelFamily('anthropic/claude-3')).toBe('anthropic');
+    });
+
+    it('should detect OpenAI models', () => {
+      expect(detectModelFamily('gpt-4')).toBe('openai');
+      expect(detectModelFamily('gpt-4o')).toBe('openai');
+      expect(detectModelFamily('o1-preview')).toBe('openai');
+      expect(detectModelFamily('text-embedding-ada-002')).toBe('openai');
+    });
+
+    it('should detect Google models', () => {
+      expect(detectModelFamily('gemini-1.5-pro')).toBe('google');
+      expect(detectModelFamily('gemini-pro')).toBe('google');
+      expect(detectModelFamily('palm-2')).toBe('google');
+    });
+
+    it('should detect Meta models', () => {
+      expect(detectModelFamily('llama-3-70b')).toBe('meta');
+      expect(detectModelFamily('meta/llama-2')).toBe('meta');
+    });
+
+    it('should detect Mistral models', () => {
+      expect(detectModelFamily('mistral-large')).toBe('mistral');
+      expect(detectModelFamily('mixtral-8x7b')).toBe('mistral');
+    });
+
+    it('should return unknown for unrecognized models', () => {
+      expect(detectModelFamily('custom-model-v1')).toBe('unknown');
+      expect(detectModelFamily(null)).toBe('unknown');
+      expect(detectModelFamily('')).toBe('unknown');
+    });
+  });
+
+  describe('validateFamilySeparation', () => {
+    it('should pass with 3 distinct evaluator families', () => {
+      const result = validateFamilySeparation({
+        proposerModel: 'llama-3-70b',
+        evaluators: [
+          { persona: 'safety', model: 'claude-3-sonnet' },
+          { persona: 'value', model: 'gpt-4' },
+          { persona: 'risk', model: 'gemini-pro' }
+        ]
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.violations).toHaveLength(0);
+      expect(result.reason_code).toBe('CONST_002_PASS');
+    });
+
+    it('should fail when evaluator shares family with proposer', () => {
+      const result = validateFamilySeparation({
+        proposerModel: 'claude-3-sonnet',
+        evaluators: [
+          { persona: 'safety', model: 'claude-3-opus' }, // Same family as proposer
+          { persona: 'value', model: 'gpt-4' },
+          { persona: 'risk', model: 'gemini-pro' }
+        ]
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.violations.some(v => v.code === 'CONST_002_FAMILY_COLLISION')).toBe(true);
+    });
+
+    it('should fail with insufficient evaluator family diversity', () => {
+      const result = validateFamilySeparation({
+        proposerModel: 'llama-3-70b',
+        evaluators: [
+          { persona: 'safety', model: 'claude-3-sonnet' },
+          { persona: 'value', model: 'claude-3-opus' }, // Same family
+          { persona: 'risk', model: 'claude-3-haiku' }  // Same family
+        ]
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.violations.some(v => v.code === 'CONST_002_INSUFFICIENT_DIVERSITY')).toBe(true);
+    });
+
+    it('should warn about unknown evaluator families', () => {
+      const result = validateFamilySeparation({
+        proposerModel: 'llama-3-70b',
+        evaluators: [
+          { persona: 'safety', model: 'claude-3-sonnet' },
+          { persona: 'value', model: 'gpt-4' },
+          { persona: 'risk', model: 'unknown-model-v1' }
+        ]
+      });
+
+      // Should pass but with warning
+      expect(result.passed).toBe(true);
+      expect(result.warnings.some(w => w.code === 'CONST_002_UNKNOWN_EVALUATOR')).toBe(true);
+    });
+  });
+
+  describe('validatePromptContext', () => {
+    it('should pass clean context', () => {
+      const cleanContext = `
+        ## Proposal for Evaluation
+        Title: Improve logging system
+        Summary: Add structured logging...
+      `;
+
+      const result = validatePromptContext(cleanContext, 'safety');
+      expect(result.passed).toBe(true);
+      expect(result.violations).toHaveLength(0);
+    });
+
+    it('should detect forbidden markers', () => {
+      const contaminatedContext = `
+        ## Proposal
+        __PERSONA_OUTPUT_START__
+        Some leaked content
+        __PERSONA_OUTPUT_END__
+      `;
+
+      const result = validatePromptContext(contaminatedContext, 'safety');
+      expect(result.passed).toBe(false);
+      expect(result.violations.some(v => v.code === 'CONST_002_CONTEXT_CONTAMINATION')).toBe(true);
+    });
+
+    it('should detect raw persona transcript leak', () => {
+      const leakedContext = `
+        ## Proposal
+        Previous round data:
+        {"persona": "value", "verdict": "approve", "rationale": "looks good"}
+      `;
+
+      const result = validatePromptContext(leakedContext, 'safety');
+      expect(result.passed).toBe(false);
+      expect(result.violations.some(v => v.code === 'CONST_002_RAW_TRANSCRIPT_LEAK')).toBe(true);
+    });
+  });
+
+  describe('createValidatedDebateConfig', () => {
+    it('should create valid config with defaults', () => {
+      const config = createValidatedDebateConfig('llama-3-70b');
+
+      expect(config.const_002_passed).toBe(true);
+      expect(config.evaluators).toHaveLength(3);
+      expect(config.validation.passed).toBe(true);
+    });
+
+    it('should throw on CONST-002 violation', () => {
+      expect(() => {
+        createValidatedDebateConfig('claude-3-sonnet', {
+          evaluators: [
+            { persona: 'safety', model: 'claude-3-opus' },
+            { persona: 'value', model: 'claude-3-sonnet' },
+            { persona: 'risk', model: 'claude-3-haiku' }
+          ]
+        });
+      }).toThrow(/CONST-002 validation failed/);
+    });
+  });
+
+  describe('getComplianceSummary', () => {
+    it('should generate readable summary', () => {
+      const result = validateFamilySeparation({
+        proposerModel: 'llama-3-70b',
+        evaluators: [
+          { persona: 'safety', model: 'claude-3-sonnet' },
+          { persona: 'value', model: 'gpt-4' },
+          { persona: 'risk', model: 'gemini-pro' }
+        ]
+      });
+
+      const summary = getComplianceSummary(result);
+      expect(summary).toContain('CONST-002 Compliance');
+      expect(summary).toContain('PASS');
+      expect(summary).toContain('Proposer:');
+      expect(summary).toContain('Evaluators:');
+    });
+  });
+});
+
+describe('Critic Personas', () => {
+  describe('CRITIC_PERSONAS configuration', () => {
+    it('should have 3 distinct personas', () => {
+      expect(Object.keys(CRITIC_PERSONAS)).toHaveLength(3);
+      expect(CRITIC_PERSONAS).toHaveProperty('safety');
+      expect(CRITIC_PERSONAS).toHaveProperty('value');
+      expect(CRITIC_PERSONAS).toHaveProperty('risk');
+    });
+
+    it('should have distinct provider families', () => {
+      const families = new Set(Object.values(CRITIC_PERSONAS).map(p => p.provider));
+      expect(families.size).toBe(3);
+      expect(families.has('anthropic')).toBe(true);
+      expect(families.has('openai')).toBe(true);
+      expect(families.has('google')).toBe(true);
+    });
+
+    it('should have valid rubrics for each persona', () => {
+      for (const persona of Object.values(CRITIC_PERSONAS)) {
+        expect(persona.rubric).toBeDefined();
+        expect(persona.rubric.criteria).toBeInstanceOf(Array);
+        expect(persona.rubric.criteria.length).toBeGreaterThan(0);
+
+        // Weights should sum to 1
+        const totalWeight = persona.rubric.criteria.reduce((sum, c) => sum + c.weight, 0);
+        expect(totalWeight).toBeCloseTo(1, 2);
+      }
+    });
+
+    it('should have system prompts requiring JSON response', () => {
+      for (const persona of Object.values(CRITIC_PERSONAS)) {
+        expect(persona.systemPrompt).toContain('JSON format');
+        expect(persona.systemPrompt).toContain('verdict');
+        expect(persona.systemPrompt).toContain('score');
+        expect(persona.systemPrompt).toContain('rationale');
+      }
+    });
+  });
+
+  describe('getPersona', () => {
+    it('should return persona by ID', () => {
+      const safety = getPersona('safety');
+      expect(safety.id).toBe('safety');
+      expect(safety.name).toBe('Safety Guardian');
+    });
+
+    it('should throw for unknown persona', () => {
+      expect(() => getPersona('unknown')).toThrow(/Unknown persona/);
+    });
+  });
+
+  describe('getAllPersonas', () => {
+    it('should return all 3 personas', () => {
+      const personas = getAllPersonas();
+      expect(personas).toHaveLength(3);
+    });
+  });
+
+  describe('validatePersonaFamilySeparation', () => {
+    it('should validate built-in personas pass CONST-002', () => {
+      const result = validatePersonaFamilySeparation();
+      expect(result.valid).toBe(true);
+      expect(result.violations).toHaveLength(0);
+      expect(result.families).toHaveLength(3);
+    });
+  });
+
+  describe('buildEvaluationPrompt', () => {
+    it('should build prompt with proposal details', () => {
+      const proposal = {
+        title: 'Test Proposal',
+        summary: 'A test proposal for unit testing',
+        motivation: 'To verify the system works',
+        scope: [{ area: 'testing', description: 'Unit tests' }],
+        affected_components: [{ name: 'test-component', type: 'testing', impact: 'low' }],
+        risk_level: 'low'
+      };
+
+      const prompt = buildEvaluationPrompt(proposal);
+
+      expect(prompt).toContain('Test Proposal');
+      expect(prompt).toContain('A test proposal for unit testing');
+      expect(prompt).toContain('testing: Unit tests');
+      expect(prompt).toContain('JSON format');
+    });
+
+    it('should include orchestrator summary if provided', () => {
+      const proposal = { title: 'Test', summary: 'Test' };
+      const summary = '## Round 1 Summary\n\nSome feedback...';
+
+      const prompt = buildEvaluationPrompt(proposal, summary);
+
+      expect(prompt).toContain('Previous Round Summary');
+      expect(prompt).toContain('Round 1 Summary');
+    });
+  });
+
+  describe('parsePersonaResponse', () => {
+    it('should parse valid JSON response', () => {
+      const response = `
+        Here is my assessment:
+        {
+          "verdict": "approve",
+          "score": 85,
+          "rationale": "The proposal looks solid",
+          "change_requests": ["Add more tests", "Document edge cases"]
+        }
+      `;
+
+      const parsed = parsePersonaResponse(response);
+
+      expect(parsed.verdict).toBe('approve');
+      expect(parsed.score).toBe(85);
+      expect(parsed.rationale).toContain('solid');
+      expect(parsed.change_requests).toHaveLength(2);
+    });
+
+    it('should normalize verdict to lowercase', () => {
+      const response = '{"verdict": "APPROVE", "score": 90, "rationale": "Good"}';
+      const parsed = parsePersonaResponse(response);
+      expect(parsed.verdict).toBe('approve');
+    });
+
+    it('should clamp score to 0-100', () => {
+      const response = '{"verdict": "approve", "score": 150, "rationale": "Amazing"}';
+      const parsed = parsePersonaResponse(response);
+      expect(parsed.score).toBe(100);
+    });
+
+    it('should handle missing JSON gracefully', () => {
+      const response = 'This response has no JSON';
+      const parsed = parsePersonaResponse(response);
+
+      expect(parsed.verdict).toBe('revise');
+      expect(parsed.score).toBe(50);
+      expect(parsed.parse_error).toBe(true);
+    });
+
+    it('should handle invalid verdict', () => {
+      const response = '{"verdict": "maybe", "score": 50, "rationale": "Unsure"}';
+      const parsed = parsePersonaResponse(response);
+      expect(parsed.parse_error).toBe(true);
+    });
+  });
+});
+
+describe('Consensus Detection', () => {
+  // Helper to create mock persona outputs
+  const createOutputs = (safetyVerdict, safetyScore, valueVerdict, valueScore, riskVerdict, riskScore) => ({
+    safety: { verdict: safetyVerdict, score: safetyScore },
+    value: { verdict: valueVerdict, score: valueScore },
+    risk: { verdict: riskVerdict, score: riskScore }
+  });
+
+  describe('consensus rules (FR-5)', () => {
+    it('should detect consensus when 2/3 agree and scores within 15 points', () => {
+      // This test verifies the consensus detection logic that would be in DebateOrchestrator
+      const outputs = createOutputs('approve', 85, 'approve', 80, 'revise', 75);
+
+      // Count verdicts
+      const verdicts = Object.values(outputs).map(o => o.verdict);
+      const scores = Object.values(outputs).map(o => o.score);
+      const verdictCounts = {};
+      for (const v of verdicts) {
+        verdictCounts[v] = (verdictCounts[v] || 0) + 1;
+      }
+
+      // Majority check (2/3)
+      const majorityVerdict = Object.entries(verdictCounts)
+        .find(([_, count]) => count >= 2)?.[0];
+      expect(majorityVerdict).toBe('approve');
+
+      // Score delta check (<=15)
+      const scoreDelta = Math.max(...scores) - Math.min(...scores);
+      expect(scoreDelta).toBe(10); // 85-75=10, within threshold
+    });
+
+    it('should not reach consensus if score delta > 15', () => {
+      const outputs = createOutputs('approve', 90, 'approve', 70, 'approve', 65);
+
+      const scores = Object.values(outputs).map(o => o.score);
+      const scoreDelta = Math.max(...scores) - Math.min(...scores);
+
+      expect(scoreDelta).toBe(25); // 90-65=25, exceeds threshold
+    });
+
+    it('should not reach consensus without majority verdict', () => {
+      const outputs = createOutputs('approve', 80, 'revise', 75, 'reject', 70);
+
+      const verdicts = Object.values(outputs).map(o => o.verdict);
+      const verdictCounts = {};
+      for (const v of verdicts) {
+        verdictCounts[v] = (verdictCounts[v] || 0) + 1;
+      }
+
+      const majorityVerdict = Object.entries(verdictCounts)
+        .find(([_, count]) => count >= 2)?.[0];
+
+      expect(majorityVerdict).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements a CONST-002 compliant multi-model debate system for vetting self-improvement proposals:

- **const-002-validator.js**: Family separation validation ensuring evaluator models (Anthropic, OpenAI, Google) differ from the proposer model
- **critic-personas.js**: Three distinct critic personas (Safety Guardian, Value Assessor, Risk Analyst) with weighted rubrics
- **debate-orchestrator.js**: Multi-round debate coordination with consensus detection (2/3 majority + ≤15 point score delta)
- **provider-adapters.js**: Unified interface for Claude, GPT-4, and Gemini APIs
- **board-vetting.js**: CLI `debate --proposal-id <id>` command for triggering debates
- **34 unit tests** covering CONST-002 validation, persona configuration, and consensus rules
- **Database schema**: `proposal_debates` and `proposal_debate_rounds` tables
- **Progress tracking fix**: `get_progress_breakdown()` now uses correct `sd_id` column

## Test plan

- [x] Run unit tests: `npx vitest run tests/unit/sub-agents/vetting/debate-system.test.js` - 34 tests passing
- [ ] Verify CLI command: `node scripts/board-vetting.js debate --proposal-id <id>`
- [ ] Verify database migration creates tables correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)