### PR TITLE
feat(outcome-loop): implement outcome loop closure automation

### DIFF
--- a/database/migrations/20260202_outcome_loop_closure.sql
+++ b/database/migrations/20260202_outcome_loop_closure.sql
@@ -1,0 +1,108 @@
+-- Outcome Loop Closure Automation
+-- SD-LEO-ORCH-SELF-IMPROVING-LEO-001-C
+
+-- 1) Outcome signals
+CREATE TABLE IF NOT EXISTS outcome_signals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  signal_type text NOT NULL,
+  sd_id varchar(50) NOT NULL,
+  source_feedback_id uuid,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE outcome_signals
+  ADD CONSTRAINT outcome_signals_sd_id_fkey
+  FOREIGN KEY (sd_id) REFERENCES strategic_directives_v2(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_outcome_signals_sd_id_created_at
+  ON outcome_signals (sd_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_outcome_signals_signal_type
+  ON outcome_signals (signal_type);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_outcome_signals_completion
+  ON outcome_signals (signal_type, sd_id)
+  WHERE signal_type = 'sd_completion' AND source_feedback_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_outcome_signals_recurrence
+  ON outcome_signals (signal_type, sd_id, source_feedback_id)
+  WHERE source_feedback_id IS NOT NULL;
+
+-- 2) SD effectiveness metrics
+CREATE TABLE IF NOT EXISTS sd_effectiveness_metrics (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sd_id varchar(50) NOT NULL,
+  window_start timestamptz NOT NULL,
+  window_end timestamptz NOT NULL,
+  pre_feedback_count integer NOT NULL DEFAULT 0,
+  post_feedback_count integer NOT NULL DEFAULT 0,
+  delta_count integer NOT NULL DEFAULT 0,
+  pct_change numeric(10,4),
+  computed_at timestamptz NOT NULL DEFAULT now(),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb
+);
+
+ALTER TABLE sd_effectiveness_metrics
+  ADD CONSTRAINT sd_effectiveness_metrics_sd_id_fkey
+  FOREIGN KEY (sd_id) REFERENCES strategic_directives_v2(id) ON DELETE CASCADE;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_sd_effectiveness_window
+  ON sd_effectiveness_metrics (sd_id, window_start, window_end);
+
+CREATE INDEX IF NOT EXISTS idx_sd_effectiveness_metrics_sd_id
+  ON sd_effectiveness_metrics (sd_id);
+
+-- 3) Feedback linkage + resolution fields
+ALTER TABLE leo_feedback
+  ADD COLUMN IF NOT EXISTS sd_id varchar(50),
+  ADD COLUMN IF NOT EXISTS resolved_by_sd_id varchar(50),
+  ADD COLUMN IF NOT EXISTS resolved_at timestamptz;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'leo_feedback_status_check'
+  ) THEN
+    ALTER TABLE leo_feedback DROP CONSTRAINT leo_feedback_status_check;
+  END IF;
+END $$;
+
+ALTER TABLE leo_feedback
+  ADD CONSTRAINT leo_feedback_status_check
+  CHECK (
+    status = ANY (ARRAY[
+      'pending',
+      'vetted',
+      'rejected',
+      'implemented',
+      'duplicate',
+      'resolved'
+    ])
+  );
+
+CREATE INDEX IF NOT EXISTS idx_leo_feedback_sd_id
+  ON leo_feedback (sd_id);
+
+CREATE INDEX IF NOT EXISTS idx_leo_feedback_resolved_by_status_created
+  ON leo_feedback (resolved_by_sd_id, status, created_at);
+
+-- 4) Trigger: sd_completion outcome signal
+CREATE OR REPLACE FUNCTION fn_record_sd_completion_signal()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.status = 'completed' AND (OLD.status IS DISTINCT FROM 'completed') THEN
+    INSERT INTO outcome_signals (signal_type, sd_id, source_feedback_id, metadata)
+    VALUES ('sd_completion', NEW.id, NULL, jsonb_build_object('source', 'db_trigger'))
+    ON CONFLICT DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_record_sd_completion_signal ON strategic_directives_v2;
+
+CREATE TRIGGER trg_record_sd_completion_signal
+AFTER UPDATE OF status ON strategic_directives_v2
+FOR EACH ROW
+EXECUTE FUNCTION fn_record_sd_completion_signal();

--- a/lib/learning/outcome-tracker.js
+++ b/lib/learning/outcome-tracker.js
@@ -1,0 +1,463 @@
+#!/usr/bin/env node
+/**
+ * Outcome Tracker
+ *
+ * Centralizes outcome loop closure for SD completions:
+ * - Resolve linked feedback
+ * - Record sd_completion signals
+ * - Detect recurrence signals
+ * - Compute effectiveness metrics
+ */
+
+import { createSupabaseServiceClient } from '../../scripts/lib/supabase-connection.js';
+
+const DEFAULT_WINDOW_DAYS = 30;
+const DEFAULT_MATCH_THRESHOLD = 0.75;
+const MATCH_VERSION = 'v1';
+
+function normalizeText(text) {
+  if (!text) return '';
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenize(text) {
+  const normalized = normalizeText(text);
+  if (!normalized) return [];
+  return normalized.split(' ').filter(Boolean);
+}
+
+function jaccardSimilarity(tokensA, tokensB) {
+  if (!tokensA.length || !tokensB.length) return 0;
+  const setA = new Set(tokensA);
+  const setB = new Set(tokensB);
+  const intersection = new Set([...setA].filter(t => setB.has(t)));
+  const union = new Set([...setA, ...setB]);
+  return union.size === 0 ? 0 : intersection.size / union.size;
+}
+
+function computePercentChange(preCount, postCount) {
+  if (preCount === 0) return null;
+  return ((postCount - preCount) / preCount) * 100;
+}
+
+function buildWindowBounds(completionTime, windowDays = DEFAULT_WINDOW_DAYS) {
+  const completion = new Date(completionTime);
+  const preStart = new Date(completion);
+  preStart.setDate(preStart.getDate() - windowDays);
+  const postEnd = new Date(completion);
+  postEnd.setDate(postEnd.getDate() + windowDays);
+
+  return {
+    preStart,
+    preEnd: completion,
+    postStart: completion,
+    postEnd
+  };
+}
+
+async function getSupabaseClient(supabase) {
+  if (supabase) return supabase;
+  return createSupabaseServiceClient('engineer');
+}
+
+async function fetchSd(supabase, sdId) {
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, category, completion_date, status')
+    .eq('id', sdId)
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to load SD ${sdId}: ${error.message}`);
+  }
+
+  return data;
+}
+
+async function countFeedbackInWindow(supabase, { start, end, sdId, category }) {
+  let query = supabase
+    .from('leo_feedback')
+    .select('id', { count: 'exact', head: true })
+    .gte('created_at', start.toISOString())
+    .lt('created_at', end.toISOString());
+
+  if (sdId) {
+    query = query.eq('sd_id', sdId);
+  } else if (category) {
+    query = query.eq('category', category);
+  }
+
+  const { count, error } = await query;
+  if (error) {
+    throw new Error(`Failed to count feedback: ${error.message}`);
+  }
+
+  return count || 0;
+}
+
+async function ensureSdCompletionSignal(supabase, sdId, metadata = {}) {
+  const { data: existing, error: readError } = await supabase
+    .from('outcome_signals')
+    .select('id, metadata')
+    .eq('signal_type', 'sd_completion')
+    .eq('sd_id', sdId)
+    .is('source_feedback_id', null)
+    .limit(1);
+
+  if (readError) {
+    throw new Error(`Failed to read sd_completion signal: ${readError.message}`);
+  }
+
+  if (existing && existing.length > 0) {
+    const current = existing[0];
+    const merged = { ...(current.metadata || {}), ...metadata };
+    const { error } = await supabase
+      .from('outcome_signals')
+      .update({ metadata: merged })
+      .eq('id', current.id);
+
+    if (error) {
+      throw new Error(`Failed to update sd_completion metadata: ${error.message}`);
+    }
+
+    return { inserted: false, updated: true };
+  }
+
+  const { error: insertError } = await supabase
+    .from('outcome_signals')
+    .insert({
+      signal_type: 'sd_completion',
+      sd_id: sdId,
+      source_feedback_id: null,
+      metadata
+    });
+
+  if (insertError && insertError.code !== '23505') {
+    throw new Error(`Failed to insert sd_completion signal: ${insertError.message}`);
+  }
+
+  return { inserted: !insertError, updated: false };
+}
+
+export async function recordSdCompleted({ supabase, sdId, actor = 'LeadFinalApprovalExecutor', completionTime = new Date() }) {
+  const client = await getSupabaseClient(supabase);
+  const resolvedAt = new Date(completionTime).toISOString();
+
+  const { data: feedbackRows, error: feedbackError } = await client
+    .from('leo_feedback')
+    .select('id, status, resolved_by_sd_id')
+    .eq('sd_id', sdId);
+
+  if (feedbackError) {
+    throw new Error(`Failed to load linked feedback: ${feedbackError.message}`);
+  }
+
+  const linkedFeedback = feedbackRows || [];
+  const unresolvedIds = linkedFeedback
+    .filter(row => row.status !== 'resolved')
+    .map(row => row.id);
+  const backfillIds = linkedFeedback
+    .filter(row => row.status === 'resolved' && !row.resolved_by_sd_id)
+    .map(row => row.id);
+
+  let resolvedCount = 0;
+  let backfilledCount = 0;
+
+  if (unresolvedIds.length > 0) {
+    const { data: updated, error } = await client
+      .from('leo_feedback')
+      .update({
+        status: 'resolved',
+        resolved_at: resolvedAt,
+        resolved_by_sd_id: sdId
+      })
+      .in('id', unresolvedIds)
+      .select('id');
+
+    if (error) {
+      throw new Error(`Failed to resolve feedback: ${error.message}`);
+    }
+
+    resolvedCount = updated?.length || 0;
+  }
+
+  if (backfillIds.length > 0) {
+    const { data: updated, error } = await client
+      .from('leo_feedback')
+      .update({ resolved_by_sd_id: sdId })
+      .in('id', backfillIds)
+      .select('id');
+
+    if (error) {
+      throw new Error(`Failed to backfill resolved_by_sd_id: ${error.message}`);
+    }
+
+    backfilledCount = updated?.length || 0;
+  }
+
+  await ensureSdCompletionSignal(client, sdId, {
+    actor,
+    source: 'recordSdCompleted',
+    resolved_feedback_count: linkedFeedback.length,
+    no_linked_feedback: linkedFeedback.length === 0
+  });
+
+  await computeEffectiveness({
+    supabase: client,
+    sdId,
+    completionTime,
+    linkedFeedbackCount: linkedFeedback.length
+  });
+
+  return {
+    linkedFeedbackCount: linkedFeedback.length,
+    resolvedCount,
+    backfilledCount
+  };
+}
+
+export async function computeEffectiveness({
+  supabase,
+  sdId,
+  completionTime,
+  windowDays = DEFAULT_WINDOW_DAYS,
+  linkedFeedbackCount = null
+}) {
+  const client = await getSupabaseClient(supabase);
+  const sd = await fetchSd(client, sdId);
+  const completion = completionTime || sd.completion_date || new Date();
+
+  const { preStart, preEnd, postStart, postEnd } = buildWindowBounds(completion, windowDays);
+
+  let scope = { type: 'linked', category: null };
+  if (linkedFeedbackCount === 0) {
+    scope = { type: sd.category ? 'category' : 'global', category: sd.category || null };
+  }
+
+  const preCount = await countFeedbackInWindow(client, {
+    start: preStart,
+    end: preEnd,
+    sdId: scope.type === 'linked' ? sdId : null,
+    category: scope.type === 'category' ? scope.category : null
+  });
+
+  const postCount = await countFeedbackInWindow(client, {
+    start: postStart,
+    end: postEnd,
+    sdId: scope.type === 'linked' ? sdId : null,
+    category: scope.type === 'category' ? scope.category : null
+  });
+
+  const delta = postCount - preCount;
+  const pctChange = computePercentChange(preCount, postCount);
+
+  const metadata = {
+    window_days: windowDays,
+    scope_type: scope.type,
+    scope_category: scope.category,
+    no_linked_feedback: linkedFeedbackCount === 0,
+    pct_change_null_reason: preCount === 0 ? 'pre_count_zero' : null
+  };
+
+  const { error } = await client
+    .from('sd_effectiveness_metrics')
+    .upsert({
+      sd_id: sdId,
+      window_start: preStart.toISOString(),
+      window_end: postEnd.toISOString(),
+      pre_feedback_count: preCount,
+      post_feedback_count: postCount,
+      delta_count: delta,
+      pct_change: pctChange,
+      computed_at: new Date().toISOString(),
+      metadata
+    }, { onConflict: 'sd_id,window_start,window_end' });
+
+  if (error) {
+    throw new Error(`Failed to upsert effectiveness metrics: ${error.message}`);
+  }
+
+  return {
+    preCount,
+    postCount,
+    delta,
+    pctChange,
+    scope
+  };
+}
+
+export async function detectRecurrence({
+  supabase,
+  newFeedbackId,
+  matchThreshold = DEFAULT_MATCH_THRESHOLD
+}) {
+  const client = await getSupabaseClient(supabase);
+
+  const { data: feedback, error: feedbackError } = await client
+    .from('leo_feedback')
+    .select('id, title, description, created_at')
+    .eq('id', newFeedbackId)
+    .single();
+
+  if (feedbackError) {
+    throw new Error(`Failed to load feedback: ${feedbackError.message}`);
+  }
+
+  const createdAt = new Date(feedback.created_at || Date.now());
+  const windowStart = new Date(createdAt);
+  windowStart.setDate(windowStart.getDate() - DEFAULT_WINDOW_DAYS);
+
+  const { data: candidateSds, error: sdError } = await client
+    .from('strategic_directives_v2')
+    .select('id, completion_date')
+    .eq('status', 'completed')
+    .gte('completion_date', windowStart.toISOString())
+    .lte('completion_date', createdAt.toISOString());
+
+  if (sdError) {
+    throw new Error(`Failed to load completed SDs: ${sdError.message}`);
+  }
+
+  if (!candidateSds || candidateSds.length === 0) {
+    return { matched: false, reason: 'no_completed_sd_window' };
+  }
+
+  const candidateSdIds = candidateSds.map(sd => sd.id);
+
+  const { data: resolvedPatterns, error: patternError } = await client
+    .from('leo_feedback')
+    .select('id, title, description, resolved_by_sd_id')
+    .eq('status', 'resolved')
+    .in('resolved_by_sd_id', candidateSdIds);
+
+  if (patternError) {
+    throw new Error(`Failed to load resolved feedback patterns: ${patternError.message}`);
+  }
+
+  if (!resolvedPatterns || resolvedPatterns.length === 0) {
+    return { matched: false, reason: 'no_resolved_patterns' };
+  }
+
+  const newTokens = tokenize([feedback.title, feedback.description].filter(Boolean).join(' '));
+
+  let bestMatch = null;
+  for (const pattern of resolvedPatterns) {
+    const patternTokens = tokenize([pattern.title, pattern.description].filter(Boolean).join(' '));
+    const score = jaccardSimilarity(newTokens, patternTokens);
+    if (score >= matchThreshold && (!bestMatch || score > bestMatch.score)) {
+      bestMatch = {
+        score,
+        resolvedFeedbackId: pattern.id,
+        sdId: pattern.resolved_by_sd_id
+      };
+    }
+  }
+
+  if (!bestMatch) {
+    return { matched: false, reason: 'no_match' };
+  }
+
+  const { error: insertError } = await client
+    .from('outcome_signals')
+    .insert({
+      signal_type: 'pattern_recurrence',
+      sd_id: bestMatch.sdId,
+      source_feedback_id: newFeedbackId,
+      metadata: {
+        match_score: bestMatch.score,
+        matched_pattern_id: bestMatch.resolvedFeedbackId,
+        match_version: MATCH_VERSION,
+        matcher: 'jaccard_tokens'
+      }
+    });
+
+  if (insertError && insertError.code !== '23505') {
+    throw new Error(`Failed to insert pattern_recurrence signal: ${insertError.message}`);
+  }
+
+  return {
+    matched: true,
+    matchScore: bestMatch.score,
+    matchedPatternId: bestMatch.resolvedFeedbackId,
+    sdId: bestMatch.sdId
+  };
+}
+
+export async function getOutcomeSummary({ supabase, sdId, windowDays = DEFAULT_WINDOW_DAYS }) {
+  const client = await getSupabaseClient(supabase);
+  const sd = await fetchSd(client, sdId);
+  const completion = sd.completion_date ? new Date(sd.completion_date) : null;
+
+  const completionSignalQuery = client
+    .from('outcome_signals')
+    .select('id')
+    .eq('signal_type', 'sd_completion')
+    .eq('sd_id', sdId)
+    .is('source_feedback_id', null)
+    .limit(1);
+
+  const resolvedFeedbackQuery = client
+    .from('leo_feedback')
+    .select('id', { count: 'exact', head: true })
+    .eq('resolved_by_sd_id', sdId)
+    .eq('status', 'resolved');
+
+  const metricsQuery = client
+    .from('sd_effectiveness_metrics')
+    .select('*')
+    .eq('sd_id', sdId)
+    .order('computed_at', { ascending: false })
+    .limit(1);
+
+  const recurrenceQuery = completion
+    ? client
+      .from('outcome_signals')
+      .select('id', { count: 'exact', head: true })
+      .eq('signal_type', 'pattern_recurrence')
+      .eq('sd_id', sdId)
+      .gte('created_at', completion.toISOString())
+      .lte('created_at', new Date(completion.getTime() + windowDays * 24 * 60 * 60 * 1000).toISOString())
+    : client
+      .from('outcome_signals')
+      .select('id', { count: 'exact', head: true })
+      .eq('signal_type', 'pattern_recurrence')
+      .eq('sd_id', sdId);
+
+  const [
+    completionResult,
+    resolvedResult,
+    metricsResult,
+    recurrenceResult
+  ] = await Promise.all([
+    completionSignalQuery,
+    resolvedFeedbackQuery,
+    metricsQuery,
+    recurrenceQuery
+  ]);
+
+  return {
+    sd_id: sdId,
+    sd_status: sd.status,
+    completion_signal: (completionResult.data || []).length > 0,
+    resolved_feedback_count: resolvedResult.count || 0,
+    recurrence_signal_count: recurrenceResult.count || 0,
+    latest_metrics: metricsResult.data?.[0] || null,
+    missing_components: {
+      completion_signal: (completionResult.data || []).length === 0,
+      effectiveness_metrics: !metricsResult.data || metricsResult.data.length === 0
+    }
+  };
+}
+
+export {
+  normalizeText,
+  tokenize,
+  jaccardSimilarity,
+  computePercentChange,
+  buildWindowBounds
+};
+

--- a/scripts/modules/implementation-fidelity/index.js
+++ b/scripts/modules/implementation-fidelity/index.js
@@ -177,10 +177,11 @@ export async function validateGate2ExecToPlan(sd_id, supabase) {
 
   try {
     // Fetch PRD metadata
+    // SD-LEO-FIX-PRD-FETCH-001: Use sd_id column (UUID) instead of directive_id (SD key string)
     const { data: prdData, error: prdError } = await supabase
       .from('product_requirements_v2')
-      .select('metadata, directive_id, title')
-      .eq('directive_id', resolvedSdUuid)
+      .select('metadata, directive_id, sd_id, title')
+      .eq('sd_id', resolvedSdUuid)
       .single();
 
     if (prdError) {

--- a/scripts/prd/config.js
+++ b/scripts/prd/config.js
@@ -72,11 +72,26 @@ Your PRD must be IMPLEMENTATION-READY. The development team will use this docume
 
 ${PRD_QUALITY_RUBRIC_CRITERIA}
 
+## FIELD CONSTRAINTS (MANDATORY - Validation will FAIL if violated)
+
+These constraints are enforced by validation gates. Violating them blocks handoffs.
+
+| Field | Min | Max | Notes |
+|-------|-----|-----|-------|
+| executive_summary | 100 chars | 300 chars | Used as goal_summary - MUST be concise |
+| functional_requirements | 5 items | - | Each with id, requirement, acceptance_criteria |
+| technical_requirements | 3 items | - | Each with id, requirement, rationale |
+| test_scenarios | 5 items | - | Cover happy path, edge cases, error conditions |
+| risks | 3 items | - | Each with mitigation and rollback_plan |
+| acceptance_criteria | 3 items | - | Specific, measurable, verifiable |
+
+**CRITICAL**: executive_summary MUST be ≤300 characters. This is a hard limit.
+
 ## OUTPUT REQUIREMENTS
 
 Return a JSON object with exactly these fields:
 {
-  "executive_summary": "string - 200-500 chars describing WHAT, WHY, and IMPACT",
+  "executive_summary": "string - EXACTLY 100-300 chars (HARD LIMIT) describing WHAT, WHY, and IMPACT concisely",
   "functional_requirements": [
     {
       "id": "FR-1",
@@ -137,6 +152,49 @@ Return a JSON object with exactly these fields:
       }
     ],
     "technical_decisions": ["Key decision 1 with rationale", "Key decision 2"]
+  },
+  "integration_operationalization": {
+    "consumers": [
+      {
+        "name": "Consumer name (user role, system, or service)",
+        "interaction": "How they consume this functionality",
+        "frequency": "How often they interact"
+      }
+    ],
+    "dependencies": [
+      {
+        "name": "Upstream or downstream system name",
+        "type": "upstream|downstream",
+        "contract": "How the dependency is managed",
+        "failure_handling": "What happens if this dependency fails"
+      }
+    ],
+    "data_contracts": [
+      {
+        "contract_name": "Name of the data contract",
+        "schema": "Brief schema description or reference",
+        "validation": "How data is validated",
+        "versioning": "How contract changes are managed"
+      }
+    ],
+    "runtime_config": {
+      "environment_variables": ["ENV_VAR_1", "ENV_VAR_2"],
+      "feature_flags": ["Flag name and purpose"],
+      "deployment_considerations": "Deployment-specific notes"
+    },
+    "observability_rollout": {
+      "monitoring": ["What metrics/logs to monitor"],
+      "alerts": ["Alert conditions to set up"],
+      "rollout_strategy": "Phased rollout, feature flag, etc.",
+      "rollback_trigger": "When to trigger rollback",
+      "rollback_procedure": "How to rollback safely"
+    }
+  },
+  "exploration_summary": {
+    "files_read": ["List of files that were analyzed to understand the codebase"],
+    "patterns_identified": ["Key patterns and conventions discovered"],
+    "key_decisions": ["Important design decisions based on exploration"],
+    "exploration_date": "ISO date string of when exploration was done"
   }
 }
 
@@ -153,5 +211,18 @@ ${sdType === 'database' ? '- Focus heavily on schema design, migration safety, R
 ${sdType === 'infrastructure' ? '- Focus on deployment, CI/CD, monitoring, rollback procedures' : ''}
 ${sdType === 'security' ? '- Focus on threat modeling, auth flows, permission boundaries, audit logging' : ''}
 ${sdType === 'documentation' ? '- Focus on content completeness, accuracy verification, maintenance plan' : ''}
-${sdType === 'feature' || !sdType ? '- Balance functional requirements, UX, and technical implementation' : ''}`;
+${sdType === 'feature' || !sdType ? '- Balance functional requirements, UX, and technical implementation' : ''}
+
+## INTEGRATION & OPERATIONALIZATION SECTION (REQUIRED for feature/bugfix SDs)
+
+${['feature', 'bugfix'].includes(sdType) || !sdType ? `The integration_operationalization section is REQUIRED and BLOCKING for this SD type.
+Generate complete, specific content for all 5 subsections:
+1. consumers - Who/what uses this functionality (users, services, systems)
+2. dependencies - All upstream and downstream systems with failure handling
+3. data_contracts - Schema definitions and API contracts with validation
+4. runtime_config - Environment variables, feature flags, deployment notes
+5. observability_rollout - Monitoring, alerting, rollout strategy, rollback plan
+
+DO NOT leave any subsection empty or use placeholder text.` :
+'The integration_operationalization section is optional for this SD type but recommended.'}`;
 }


### PR DESCRIPTION
## Summary

SD-LEO-ORCH-SELF-IMPROVING-LEO-001-C: Outcome Loop Closure Automation

- Adds `outcome_signals` and `sd_effectiveness_metrics` tables for tracking SD outcomes
- Creates `lib/learning/outcome-tracker.js` module with APIs for:
  - `recordSdCompleted()` - auto-resolve linked feedback on SD completion
  - `computeEffectiveness()` - calculate pre/post feedback metrics
  - `detectRecurrence()` - detect pattern recurrence signals
  - `getOutcomeSummary()` - get SD outcome summary
- Integrates outcome tracking into LeadFinalApprovalExecutor

**Bug Fixes:**
- PRD fetch: use `sd_id` column (UUID) instead of `directive_id` (SD key string)
- SD type validation: lower warning threshold from 85% to 65% to catch misclassifications early

**Cross-model experiment:** Part of this work was done by OpenAI GPT-5.2 before provider error.

## Test plan

- [x] Migration executed successfully
- [x] Smoke tests pass
- [x] TESTING sub-agent verification passed
- [x] Retrospective created

🤖 Generated with [Claude Code](https://claude.com/claude-code)