### PR TITLE
fix(statusline): add Opus 4.6 model name recognition

### DIFF
--- a/.claude/agents/_model-tracking-section.md
+++ b/.claude/agents/_model-tracking-section.md
@@ -8,8 +8,8 @@ node scripts/track-model-usage.js "<AGENT_NAME>" "<YOUR_MODEL_NAME>" "<YOUR_MODE
 
 Replace:
 - `<AGENT_NAME>`: This agent's name (from filename, e.g., `testing-agent`)
-- `<YOUR_MODEL_NAME>`: Your model name (e.g., "Sonnet 4.5" or "Opus 4.5")
-- `<YOUR_MODEL_ID>`: Your exact model ID from system context (e.g., `claude-sonnet-4-5-20250929`)
+- `<YOUR_MODEL_NAME>`: Your model name (e.g., "Sonnet 4.5" or "Opus 4.6")
+- `<YOUR_MODEL_ID>`: Your exact model ID from system context (e.g., `claude-opus-4-6`)
 - `<SD_ID>`: The Strategic Directive ID if provided, or "STANDALONE"
 - `<PHASE>`: Current phase (LEAD, PLAN, EXEC) if known, or "UNKNOWN"
 

--- a/.claude/statusline-context-tracker.ps1
+++ b/.claude/statusline-context-tracker.ps1
@@ -57,6 +57,7 @@ $modelId = if ($data.model.id) { $data.model.id } else { "unknown" }
 
 # Abbreviate model name
 $modelShort = switch -Regex ($model) {
+    "Opus.*4\.6" { "O4.6" }
     "Opus.*4\.5" { "O4.5" }
     "Opus.*4" { "O4" }
     "Sonnet.*4" { "S4" }

--- a/.claude/statusline-context-tracker.sh
+++ b/.claude/statusline-context-tracker.sh
@@ -119,6 +119,7 @@ fi
 
 # Abbreviate model name
 case "$MODEL" in
+    *"Opus"*"4.6"*) MODEL_SHORT="O4.6" ;;
     *"Opus"*"4.5"*) MODEL_SHORT="O4.5" ;;
     *"Opus"*"4"*) MODEL_SHORT="O4" ;;
     *"Sonnet"*"4"*) MODEL_SHORT="S4" ;;


### PR DESCRIPTION
## Summary
- Add `Opus 4.6` pattern matching to PowerShell and Bash status line trackers so the model displays as `O4.6`
- Update model tracking documentation to reference Opus 4.6 as the current example

## Test plan
- [x] Verified pattern ordering: 4.6 checked before 4.5 before generic 4
- [x] Context window confirmed still 200K (no progress bar changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)