### PR TITLE
fix(handoff): correct import path for getParentFinalizationCommands

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -144,7 +144,8 @@ export class PlanToLeadExecutor extends BaseExecutor {
 
       // SD-LEO-ORCH-AUTO-PROCEED-INTELLIGENCE-001-E: Parent orchestrator completion
       // When all children complete, parent gets finalization commands
-      const { getParentFinalizationCommands } = await import('./state-transitions.js');
+      // PAT-PRD-DUP-001: Import from source module (state-transitions.js doesn't re-export this)
+      const { getParentFinalizationCommands } = await import('../../../../../lib/utils/orchestrator-child-completion.js');
       const parentCommands = getParentFinalizationCommands({ sd_key: sd.sd_key || sd.id });
 
       return {


### PR DESCRIPTION
## Summary
- Fix `getParentFinalizationCommands is not a function` error during orchestrator PLAN-TO-LEAD handoffs
- Root cause: `state-transitions.js` imports the function internally but doesn't re-export it
- Fix: Import directly from source module `orchestrator-child-completion.js`

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Orchestrator PLAN-TO-LEAD handoff now succeeds (verified with SD-LEO-INFRA-INTELLIGENT-LOCAL-LLM-001)
- [x] 3-line change, minimal risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)