### PR TITLE
feat(sd-next): add action semantics for AUTO-PROCEED

### DIFF
--- a/scripts/modules/sd-next/index.js
+++ b/scripts/modules/sd-next/index.js
@@ -4,6 +4,10 @@
  *
  * This module provides the SD-Next intelligent strategic directive selection system,
  * broken down into focused modules for maintainability.
+ *
+ * Action Semantics (PAT-AUTO-PROCEED-002):
+ * runSDNext() returns { action, sd_id, reason } for programmatic consumers.
+ * Actions: 'start' | 'continue' | 'verify' | 'none'
  */
 
 // Main orchestrator class

--- a/scripts/sd-next.js
+++ b/scripts/sd-next.js
@@ -18,6 +18,7 @@
  * 6. Conflict detection - Warns about parallel execution risks
  * 7. Track visibility - Shows parallel execution tracks
  * 8. Parallel opportunities - Proactively suggests opening new terminals
+ * 9. AUTO-PROCEED action semantics - Returns structured next-action data (PAT-AUTO-PROCEED-002)
  *
  * @see scripts/modules/sd-next/ for implementation
  */
@@ -25,7 +26,17 @@
 import { runSDNext, colors } from './modules/sd-next/index.js';
 
 // Main execution
-runSDNext().catch(err => {
-  console.error(`${colors.red}Error: ${err.message}${colors.reset}`);
-  process.exit(1);
-});
+runSDNext()
+  .then(result => {
+    // PAT-AUTO-PROCEED-002 CAPA: Output structured action data
+    // This machine-readable line enables autonomous workflow continuation
+    // when AUTO-PROCEED is active. Claude parses this to determine next action
+    // without relying on display-only output.
+    if (result && result.action !== 'none') {
+      console.log(`\nAUTO_PROCEED_ACTION:${JSON.stringify(result)}`);
+    }
+  })
+  .catch(err => {
+    console.error(`${colors.red}Error: ${err.message}${colors.reset}`);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- `runSDNext()` now returns structured `{ action, sd_id, reason }` data for programmatic consumers
- Enables AUTO-PROCEED flows to determine next action without parsing display output
- Actions: `start` (next in queue), `continue` (resume working SD), `verify` (needs verification), `none` (nothing actionable)
- Outputs `AUTO_PROCEED_ACTION:` JSON line for machine-readable consumption
- PAT-AUTO-PROCEED-002 CAPA implementation

## Test plan
- [x] Smoke tests pass
- [x] ESLint auto-fix passes
- [x] `npm run sd:next` still displays queue correctly (display unchanged)
- [x] Return values include correct action type based on queue state

🤖 Generated with [Claude Code](https://claude.com/claude-code)