### PR TITLE
feat(learn): add auto-approve for AUTO-PROCEED mode

### DIFF
--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -136,9 +136,21 @@ supabase.from('claude_sessions')
 ```
 
 **If AUTO-PROCEED is ACTIVE:**
-- Skip AskUserQuestion
-- Output status: `🤖 AUTO-PROCEED: Learning captured, continuing to next SD...`
-- Auto-invoke `/leo next` to continue with next SD in queue
+- **Do NOT skip learning entirely** - use auto-approve to act on high-value items
+- Run the auto-approve command instead of interactive approval:
+  ```bash
+  node scripts/modules/learning/index.js auto-approve --threshold=50
+  ```
+- This will:
+  1. Build learning context (same filtering as interactive mode)
+  2. Auto-approve all patterns with composite_score >= 50
+  3. Auto-approve all pending improvements (already filtered by getPendingImprovements)
+  4. Create an SD from approved items (if any qualify)
+  5. Defer low-score items for future interactive review
+- After auto-approve completes:
+  - If SD was created: Output `AUTO-PROCEED: SD created from learning: <SD-KEY>`
+  - If nothing qualified: Output `AUTO-PROCEED: No high-value learning items to act on`
+  - Auto-invoke `/leo next` to continue with next SD in queue
 
 **If AUTO-PROCEED is INACTIVE:**
 **After SD creation - Use AskUserQuestion:**

--- a/scripts/modules/learning/classification.js
+++ b/scripts/modules/learning/classification.js
@@ -75,9 +75,11 @@ export function classifyComplexity(selectedItems) {
  * Generate the next available SD key or QF ID
  * @param {'quick-fix' | 'full-sd'} type
  * @param {string} title - Title for semantic content extraction
+ * @param {Object} [options] - Additional options
+ * @param {boolean} [options.skipLeadValidation] - Skip protocol file read check (for CLI/auto-approve)
  * @returns {Promise<string>}
  */
-export async function generateSDId(type, title = 'Learning Improvement') {
+export async function generateSDId(type, title = 'Learning Improvement', options = {}) {
   if (type === 'quick-fix') {
     const now = new Date();
     const year = now.getFullYear();
@@ -90,7 +92,8 @@ export async function generateSDId(type, title = 'Learning Improvement') {
   return generateCentralizedSDKey({
     source: 'LEARN',
     type: 'bugfix',
-    title
+    title,
+    skipLeadValidation: options.skipLeadValidation || false
   });
 }
 

--- a/scripts/modules/learning/executor.js
+++ b/scripts/modules/learning/executor.js
@@ -56,10 +56,12 @@ export { resolvePatterns } from './improvement-appliers.js';
  *
  * @param {Object} reviewedContext - The reviewed learning context
  * @param {Object} decisions - User decisions: { itemId: { status, reason } }
+ * @param {Object} [options] - Additional options
+ * @param {boolean} [options.skipLeadValidation] - Skip protocol file read check (for CLI/auto-approve)
  * @returns {Promise<{sd_id: string, success: boolean, ...}>}
  */
-export async function executeSDCreationWorkflow(reviewedContext, decisions) {
-  return executeSDCreationWorkflowInternal(reviewedContext, decisions, createDecisionRecord);
+export async function executeSDCreationWorkflow(reviewedContext, decisions, options = {}) {
+  return executeSDCreationWorkflowInternal(reviewedContext, decisions, createDecisionRecord, options);
 }
 
 /**

--- a/scripts/modules/learning/sd-creation.js
+++ b/scripts/modules/learning/sd-creation.js
@@ -35,11 +35,13 @@ const supabase = createClient(
  * Create SD in strategic_directives_v2 from learning items
  * @param {Array} items - Selected patterns and improvements
  * @param {'quick-fix' | 'full-sd'} type
+ * @param {Object} [options] - Additional options
+ * @param {boolean} [options.skipLeadValidation] - Skip protocol file read check (for CLI/auto-approve)
  * @returns {Promise<{id: string, success: boolean, error?: string}>}
  */
-export async function createSDFromLearning(items, type) {
+export async function createSDFromLearning(items, type, options = {}) {
   const title = buildSDTitle(items);
-  const sdKey = await generateSDId(type, title);
+  const sdKey = await generateSDId(type, title, { skipLeadValidation: options.skipLeadValidation });
   const description = buildSDDescription(items);
   const successMetrics = buildSuccessMetrics(items);
   const successCriteria = buildSuccessCriteria(items);
@@ -160,9 +162,11 @@ export async function tagSourceItems(items, sdKey) {
  * @param {Object} reviewedContext - The reviewed learning context
  * @param {Object} decisions - User decisions: { itemId: { status, reason } }
  * @param {Function} createDecisionRecord - Function to create decision records
+ * @param {Object} [options] - Additional options
+ * @param {boolean} [options.skipLeadValidation] - Skip protocol file read check (for CLI/auto-approve)
  * @returns {Promise<{sd_id: string, success: boolean, ...}>}
  */
-export async function executeSDCreationWorkflow(reviewedContext, decisions, createDecisionRecord) {
+export async function executeSDCreationWorkflow(reviewedContext, decisions, createDecisionRecord, options = {}) {
   console.log('\n============================================================');
   console.log('  /learn → SD Creation Workflow');
   console.log('============================================================\n');
@@ -219,7 +223,7 @@ export async function executeSDCreationWorkflow(reviewedContext, decisions, crea
   console.log(`\nClassification: ${classification.toUpperCase()}`);
 
   // 4. Create the SD
-  const sdResult = await createSDFromLearning(approvedItems, classification);
+  const sdResult = await createSDFromLearning(approvedItems, classification, { skipLeadValidation: options.skipLeadValidation });
   if (!sdResult.success) {
     return {
       sd_id: null,


### PR DESCRIPTION
## Summary

- Add `auto-approve` command to `/learn` module for AUTO-PROCEED mode
- Under AUTO-PROCEED, `/learn` previously skipped approval entirely, meaning learning items were surfaced but never acted on
- Now auto-approves patterns with composite_score >= threshold (default: 50) and all pre-filtered improvements
- Creates SDs from high-value items without human review
- Defers low-score items for future interactive review
- Thread `skipLeadValidation` through call chain so CLI scripts can generate SD keys without session protocol file check

## Files Changed

| File | Change |
|------|--------|
| `scripts/modules/learning/index.js` | Add `autoApproveCommand()`, CLI handler, export |
| `scripts/modules/learning/executor.js` | Forward `options` parameter through wrapper |
| `scripts/modules/learning/sd-creation.js` | Accept `options` in `createSDFromLearning` and `executeSDCreationWorkflow` |
| `scripts/modules/learning/classification.js` | Accept `options` in `generateSDId` |
| `.claude/commands/learn.md` | Update AUTO-PROCEED behavior to use auto-approve |

## Test plan

- [x] `node scripts/modules/learning/index.js auto-approve --threshold=50` creates SD from qualifying items
- [x] `node scripts/modules/learning/index.js auto-approve --threshold=999` defers all patterns, still approves improvements
- [x] Interactive `process` command unchanged
- [x] Help text shows new command
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)