### PR TITLE
feat(vetting): add AI-powered rubric assessment with heuristic fallback

### DIFF
--- a/lib/sub-agents/vetting/index.js
+++ b/lib/sub-agents/vetting/index.js
@@ -11,6 +11,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { getAegisEnforcer } from '../../governance/aegis/AegisEnforcer.js';
+import { evaluateWithAI } from './rubric-evaluator.js';
 
 // Initialize Supabase client
 const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -143,6 +144,29 @@ export class VettingEngine {
    * @returns {Object} Assessment result with scores
    */
   async assessWithRubric(proposal, rubric = this.rubric) {
+    // Try AI-powered evaluation first (SD-LEO-ORCH-SELF-IMPROVING-LEO-001-A)
+    try {
+      const aiResult = await evaluateWithAI(proposal, rubric, {
+        supabase: this.supabase || supabase,
+        timeoutMs: this.options?.evaluationTimeoutMs
+      });
+      if (aiResult.status === 'SUCCESS') return aiResult;
+      console.warn(`[VettingEngine] AI evaluation ${aiResult.status}: ${aiResult.error}. Using heuristic fallback.`);
+    } catch (err) {
+      console.warn(`[VettingEngine] AI evaluator error: ${err.message}. Using heuristic fallback.`);
+    }
+
+    // Heuristic fallback
+    return this._assessWithHeuristic(proposal, rubric);
+  }
+
+  /**
+   * Heuristic-based rubric assessment (fallback when AI unavailable)
+   * @param {Object} proposal - Proposal to assess
+   * @param {Object} rubric - Rubric to use
+   * @returns {Object} Assessment result with scores
+   */
+  _assessWithHeuristic(proposal, rubric) {
     const scores = {};
     let totalScore = 0;
     let totalWeight = 0;
@@ -159,7 +183,6 @@ export class VettingEngine {
       totalWeight += criterion.weight;
     }
 
-    // Normalize to 0-100 scale
     const normalizedScore = totalWeight > 0
       ? (totalScore / totalWeight / rubric.scoringScale.max) * 100
       : 0;
@@ -168,7 +191,8 @@ export class VettingEngine {
       scores,
       totalScore: Math.round(normalizedScore * 100) / 100,
       rubricVersion: rubric.version || 'default-1.0',
-      assessedAt: new Date().toISOString()
+      assessedAt: new Date().toISOString(),
+      status: 'HEURISTIC_FALLBACK'
     };
   }
 

--- a/lib/sub-agents/vetting/rubric-evaluator.js
+++ b/lib/sub-agents/vetting/rubric-evaluator.js
@@ -1,0 +1,483 @@
+/**
+ * AI-Powered Rubric Evaluator
+ * Part of SD-LEO-ORCH-SELF-IMPROVING-LEO-001-A
+ *
+ * Replaces hardcoded _scoreCriterion() with LLM-based evaluation.
+ * Uses a single structured JSON call per assessment.
+ *
+ * Architecture:
+ *   getValidationClient() → Sonnet tier → single LLM call
+ *   → JSON schema validation → retry with repair prompt (1x)
+ *   → persist to leo_vetting_outcomes + audit_log
+ */
+
+import { getValidationClient } from '../../llm/client-factory.js';
+
+// Default timeout for LLM evaluation (FR-4)
+const DEFAULT_TIMEOUT_MS = 4500;
+
+// Max retry on parse failure (FR-5)
+const MAX_PARSE_RETRIES = 1;
+
+// Rubric evaluator version for audit trail
+const EVALUATOR_VERSION = '1.0.0';
+
+/**
+ * JSON schema for the expected LLM output (FR-5).
+ * Exactly 6 criteria, each with score and reasoning fields.
+ */
+const EVALUATION_SCHEMA = {
+  required: ['criteria', 'overall_score'],
+  criteria_required: ['id', 'name', 'score', 'summary', 'reasoning', 'improvements'],
+  score_range: { min: 0, max: 100 }
+};
+
+/**
+ * Validate the parsed evaluation against the schema (FR-5).
+ * @param {Object} parsed - Parsed JSON from LLM
+ * @param {Array} expectedCriteria - Expected criterion IDs
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validateEvaluationSchema(parsed, expectedCriteria) {
+  const errors = [];
+
+  if (!parsed || typeof parsed !== 'object') {
+    errors.push('Response is not an object');
+    return { valid: false, errors };
+  }
+
+  if (!Array.isArray(parsed.criteria)) {
+    errors.push('Missing or non-array "criteria" field');
+    return { valid: false, errors };
+  }
+
+  if (parsed.criteria.length !== expectedCriteria.length) {
+    errors.push(`Expected ${expectedCriteria.length} criteria, got ${parsed.criteria.length}`);
+  }
+
+  if (typeof parsed.overall_score !== 'number' || parsed.overall_score < 0 || parsed.overall_score > 100) {
+    errors.push(`overall_score must be 0-100 integer, got: ${parsed.overall_score}`);
+  }
+
+  const seenIds = new Set();
+  for (const c of parsed.criteria) {
+    if (!c.id) {
+      errors.push('Criterion missing "id" field');
+      continue;
+    }
+
+    if (seenIds.has(c.id)) {
+      errors.push(`Duplicate criterion id: ${c.id}`);
+    }
+    seenIds.add(c.id);
+
+    for (const field of EVALUATION_SCHEMA.criteria_required) {
+      if (c[field] === undefined || c[field] === null) {
+        errors.push(`Criterion "${c.id}" missing field: ${field}`);
+      }
+    }
+
+    if (typeof c.score !== 'number' || c.score < 0 || c.score > 100) {
+      errors.push(`Criterion "${c.id}" score must be 0-100, got: ${c.score}`);
+    }
+
+    if (typeof c.summary === 'string' && c.summary.length < 20) {
+      errors.push(`Criterion "${c.id}" summary too short (${c.summary.length} chars, min 20)`);
+    }
+
+    if (Array.isArray(c.reasoning) && c.reasoning.length < 2) {
+      errors.push(`Criterion "${c.id}" reasoning needs >=2 bullet points, got ${c.reasoning.length}`);
+    }
+
+    if (!Array.isArray(c.improvements) || c.improvements.length < 1) {
+      errors.push(`Criterion "${c.id}" needs >=1 improvement suggestion`);
+    }
+  }
+
+  // Check all expected criteria are present
+  for (const expectedId of expectedCriteria) {
+    if (!seenIds.has(expectedId)) {
+      errors.push(`Missing expected criterion: ${expectedId}`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Build the system prompt for rubric evaluation.
+ * @param {Object} rubric - Rubric with criteria array and scoringScale
+ * @returns {string}
+ */
+function buildSystemPrompt(rubric) {
+  const criteriaDesc = rubric.criteria.map(c =>
+    `- ${c.id} (${c.name}, weight: ${c.weight}): ${c.description}`
+  ).join('\n');
+
+  return `You are an expert rubric evaluator for the LEO Protocol governance system.
+Your task is to evaluate a proposal against a rubric with ${rubric.criteria.length} criteria.
+
+RUBRIC CRITERIA:
+${criteriaDesc}
+
+SCORING SCALE: ${rubric.scoringScale.min}-${rubric.scoringScale.max} mapped to 0-100.
+- 0-20: Poor - Fails to meet basic requirements
+- 21-40: Below Average - Significant gaps
+- 41-60: Average - Meets minimum requirements
+- 61-80: Good - Solid implementation
+- 81-100: Excellent - Exceeds expectations
+
+RESPOND WITH ONLY valid JSON matching this exact structure:
+{
+  "criteria": [
+    {
+      "id": "<criterion_id>",
+      "name": "<criterion_name>",
+      "score": <0-100>,
+      "summary": "<1-2 sentence summary, minimum 20 characters>",
+      "reasoning": ["<bullet point 1>", "<bullet point 2>", ...],
+      "evidence": ["<quote from proposal>"],
+      "improvements": ["<suggestion 1>", ...]
+    }
+  ],
+  "overall_score": <0-100>,
+  "weighting": {${rubric.criteria.map(c => `"${c.id}": ${c.weight}`).join(', ')}}
+}
+
+You MUST include ALL ${rubric.criteria.length} criteria: ${rubric.criteria.map(c => c.id).join(', ')}.
+Each criterion MUST have at least 2 reasoning bullets and 1 improvement suggestion.
+Do NOT wrap in markdown code fences. Return ONLY the JSON object.`;
+}
+
+/**
+ * Build the user prompt with proposal content.
+ * @param {Object} proposal - Proposal to evaluate
+ * @returns {string}
+ */
+function buildUserPrompt(proposal) {
+  const parts = [];
+
+  parts.push('PROPOSAL TO EVALUATE:');
+  if (proposal.title) parts.push(`Title: ${proposal.title}`);
+  if (proposal.summary) parts.push(`Summary: ${proposal.summary}`);
+  if (proposal.motivation) parts.push(`Motivation: ${proposal.motivation}`);
+  if (proposal.risk_level) parts.push(`Risk Level: ${proposal.risk_level}`);
+
+  if (proposal.affected_components?.length > 0) {
+    parts.push(`Affected Components: ${proposal.affected_components.map(c =>
+      typeof c === 'string' ? c : `${c.name || c.type} (${c.type || 'unknown'})`
+    ).join(', ')}`);
+  }
+
+  if (proposal.constitution_tags?.length > 0) {
+    parts.push(`Constitution Tags: ${proposal.constitution_tags.join(', ')}`);
+  }
+
+  if (proposal.content) parts.push(`\nContent:\n${proposal.content}`);
+  if (proposal.description) parts.push(`\nDescription:\n${proposal.description}`);
+
+  parts.push('\nEvaluate this proposal against ALL rubric criteria. Return ONLY valid JSON.');
+
+  return parts.join('\n');
+}
+
+/**
+ * Build repair prompt when initial parse fails (FR-5).
+ * @param {string} originalResponse - The malformed response
+ * @param {string[]} validationErrors - Errors found
+ * @returns {string}
+ */
+function buildRepairPrompt(originalResponse, validationErrors) {
+  return `Your previous response had validation errors. Please fix and return ONLY valid JSON.
+
+ERRORS FOUND:
+${validationErrors.map(e => `- ${e}`).join('\n')}
+
+YOUR PREVIOUS RESPONSE:
+${originalResponse.substring(0, 2000)}
+
+Fix the errors above and return ONLY the corrected JSON object. No markdown, no explanations.`;
+}
+
+/**
+ * Parse LLM response text to JSON, handling common formatting issues.
+ * @param {string} text - Raw LLM response
+ * @returns {Object} Parsed JSON
+ */
+function parseResponse(text) {
+  let cleaned = text.trim();
+
+  // Strip markdown code fences if present
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+  }
+
+  // Strip any leading/trailing whitespace after fence removal
+  cleaned = cleaned.trim();
+
+  return JSON.parse(cleaned);
+}
+
+/**
+ * Evaluate a proposal against a rubric using AI.
+ *
+ * @param {Object} proposal - Proposal to evaluate
+ * @param {Object} rubric - Rubric with criteria and scoringScale
+ * @param {Object} [options] - Configuration options
+ * @param {number} [options.timeoutMs] - Timeout for LLM call (default: 4500ms)
+ * @param {Object} [options.supabase] - Supabase client for persistence
+ * @param {Object} [options.llmClient] - LLM client override (for testing)
+ * @returns {Promise<Object>} Evaluation result
+ */
+export async function evaluateWithAI(proposal, rubric, options = {}) {
+  const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
+  const correlationId = `eval-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+  const startTime = Date.now();
+
+  const expectedCriteria = rubric.criteria.map(c => c.id);
+  const systemPrompt = buildSystemPrompt(rubric);
+  const userPrompt = buildUserPrompt(proposal);
+
+  let llmClient;
+  try {
+    llmClient = options.llmClient || getValidationClient();
+  } catch (err) {
+    return createFailureResult('FAILED', `LLM client unavailable: ${err.message}`, {
+      correlationId, startTime, proposal, rubric
+    });
+  }
+
+  let rawResponse = null;
+  let parsed = null;
+  let model = 'unknown';
+  let attempt = 0;
+
+  // First attempt
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const result = await llmClient.complete(systemPrompt, userPrompt, {
+        maxTokens: 3000,
+        signal: controller.signal
+      });
+
+      clearTimeout(timer);
+      rawResponse = result.content;
+      model = result.model || 'unknown';
+      attempt = 1;
+
+      parsed = parseResponse(rawResponse);
+    } catch (err) {
+      clearTimeout(timer);
+
+      if (err.message === 'TIMEOUT' || err.name === 'AbortError') {
+        const latencyMs = Date.now() - startTime;
+        await writeAuditLog(options.supabase, {
+          correlationId, proposalId: proposal.id, model,
+          status: 'TIMEOUT', latencyMs, errorCode: 'LLM_TIMEOUT',
+          rawResponse: null
+        });
+        return createFailureResult('TIMEOUT', `LLM call exceeded ${timeoutMs}ms timeout`, {
+          correlationId, startTime, proposal, rubric, latencyMs
+        });
+      }
+
+      // Provider error (4xx/5xx)
+      const errorCode = mapProviderError(err);
+      const latencyMs = Date.now() - startTime;
+      await writeAuditLog(options.supabase, {
+        correlationId, proposalId: proposal.id, model,
+        status: 'FAILED', latencyMs, errorCode,
+        rawResponse: null, providerRequestId: err.requestId
+      });
+      return createFailureResult('FAILED', err.message, {
+        correlationId, startTime, proposal, rubric, latencyMs, errorCode
+      });
+    }
+  } catch (outerErr) {
+    return createFailureResult('FAILED', outerErr.message, {
+      correlationId, startTime, proposal, rubric
+    });
+  }
+
+  // Validate parsed response
+  let validation = validateEvaluationSchema(parsed, expectedCriteria);
+
+  // Retry with repair prompt if validation fails (FR-5)
+  if (!validation.valid && attempt <= MAX_PARSE_RETRIES) {
+    try {
+      const repairPrompt = buildRepairPrompt(rawResponse, validation.errors);
+      const retryResult = await llmClient.complete(systemPrompt, repairPrompt, {
+        maxTokens: 3000
+      });
+
+      rawResponse = retryResult.content;
+      attempt = 2;
+
+      parsed = parseResponse(rawResponse);
+      validation = validateEvaluationSchema(parsed, expectedCriteria);
+    } catch (_retryErr) {
+      // Retry failed - will fall through to PARSE_ERROR below
+    }
+  }
+
+  const latencyMs = Date.now() - startTime;
+
+  if (!validation.valid) {
+    await writeAuditLog(options.supabase, {
+      correlationId, proposalId: proposal.id, model,
+      status: 'PARSE_ERROR', latencyMs,
+      errorCode: 'SCHEMA_VALIDATION_FAILED',
+      rawResponse, validationErrors: validation.errors
+    });
+    return createFailureResult('PARSE_ERROR', `Schema validation failed after ${attempt} attempt(s)`, {
+      correlationId, startTime, proposal, rubric, latencyMs,
+      validationErrors: validation.errors
+    });
+  }
+
+  // Build successful result (FR-1, FR-2)
+  const scores = {};
+  for (const c of parsed.criteria) {
+    const rubricCriterion = rubric.criteria.find(rc => rc.id === c.id);
+    const weight = rubricCriterion?.weight || 0;
+
+    scores[c.id] = {
+      name: c.name,
+      score: c.score,
+      weight,
+      weightedScore: (c.score / 100) * rubric.scoringScale.max * weight,
+      summary: c.summary,
+      reasoning: c.reasoning,
+      evidence: c.evidence || [],
+      improvements: c.improvements
+    };
+  }
+
+  const result = {
+    scores,
+    totalScore: parsed.overall_score,
+    rubricVersion: rubric.version || 'default-1.0',
+    evaluatorVersion: EVALUATOR_VERSION,
+    assessedAt: new Date().toISOString(),
+    model,
+    latencyMs,
+    correlationId,
+    attempt,
+    weighting: parsed.weighting || null,
+    status: 'SUCCESS',
+    rawResponse
+  };
+
+  // Persist to audit_log (FR-3)
+  await writeAuditLog(options.supabase, {
+    correlationId, proposalId: proposal.id, model,
+    status: 'SUCCESS', latencyMs,
+    rawResponse
+  });
+
+  // Persist to leo_vetting_outcomes (FR-3)
+  await writeVettingOutcome(options.supabase, {
+    proposalId: proposal.id,
+    feedbackId: proposal.feedback_id,
+    rubricScore: parsed.overall_score,
+    scores: result.scores,
+    model,
+    latencyMs,
+    correlationId
+  });
+
+  return result;
+}
+
+/**
+ * Create a failure result with consistent structure.
+ */
+function createFailureResult(status, message, ctx) {
+  return {
+    scores: {},
+    totalScore: 0,
+    rubricVersion: ctx.rubric?.version || 'default-1.0',
+    evaluatorVersion: EVALUATOR_VERSION,
+    assessedAt: new Date().toISOString(),
+    model: 'none',
+    latencyMs: Date.now() - ctx.startTime,
+    correlationId: ctx.correlationId,
+    status,
+    error: message,
+    errorCode: ctx.errorCode || status,
+    validationErrors: ctx.validationErrors || null
+  };
+}
+
+/**
+ * Map provider errors to standard error codes (FR-5).
+ */
+function mapProviderError(err) {
+  const msg = err.message || '';
+  if (msg.includes('rate_limit') || err.status === 429) return 'RATE_LIMITED';
+  if (err.status >= 500) return 'PROVIDER_SERVER_ERROR';
+  if (err.status >= 400) return 'PROVIDER_CLIENT_ERROR';
+  if (msg.includes('network') || msg.includes('ECONNREFUSED')) return 'NETWORK_ERROR';
+  return 'UNKNOWN_ERROR';
+}
+
+/**
+ * Write audit log entry (FR-3).
+ */
+async function writeAuditLog(supabase, data) {
+  if (!supabase) return;
+
+  try {
+    await supabase.from('audit_log').insert({
+      event_type: 'rubric_evaluation',
+      severity: data.status === 'SUCCESS' ? 'info' : 'warning',
+      source: 'rubric-evaluator',
+      details: {
+        correlation_id: data.correlationId,
+        proposal_id: data.proposalId,
+        evaluator_version: EVALUATOR_VERSION,
+        model: data.model,
+        latency_ms: data.latencyMs,
+        status: data.status,
+        error_code: data.errorCode || null,
+        provider_request_id: data.providerRequestId || null,
+        validation_errors: data.validationErrors || null,
+        raw_response_length: data.rawResponse?.length || 0
+      }
+    });
+  } catch (err) {
+    console.warn(`[rubric-evaluator] Audit log write failed: ${err.message}`);
+  }
+}
+
+/**
+ * Write vetting outcome record (FR-3).
+ */
+async function writeVettingOutcome(supabase, data) {
+  if (!supabase) return;
+
+  try {
+    await supabase.from('leo_vetting_outcomes').insert({
+      proposal_id: data.proposalId || null,
+      feedback_id: data.feedbackId || null,
+      outcome: 'approved', // Will be overridden by caller based on threshold
+      rubric_score: data.rubricScore,
+      processing_time_ms: data.latencyMs,
+      processed_by: 'rubric-evaluator-ai',
+      metadata: {
+        evaluator_version: EVALUATOR_VERSION,
+        model: data.model,
+        correlation_id: data.correlationId,
+        per_criterion_scores: data.scores
+      }
+    });
+  } catch (err) {
+    console.warn(`[rubric-evaluator] Vetting outcome write failed: ${err.message}`);
+  }
+}
+
+export { validateEvaluationSchema };
+export default { evaluateWithAI, validateEvaluationSchema };

--- a/tests/unit/sub-agents/vetting/rubric-evaluator-integration.test.js
+++ b/tests/unit/sub-agents/vetting/rubric-evaluator-integration.test.js
@@ -1,0 +1,343 @@
+/**
+ * Rubric Evaluator Integration Tests
+ * SD-LEO-ORCH-SELF-IMPROVING-LEO-001-A
+ *
+ * Tests evaluateWithAI() with injectable mock LLM client covering:
+ * TS-1: Happy path (valid response, persistence)
+ * TS-2: Schema validation failure + repair retry
+ * TS-3: Timeout handling
+ * TS-4: Provider error mapping
+ */
+
+import { jest } from '@jest/globals';
+
+const mod = await import(
+  '../../../../lib/sub-agents/vetting/rubric-evaluator.js'
+);
+const evaluateWithAI = mod.evaluateWithAI || mod.default?.evaluateWithAI;
+
+const DEFAULT_RUBRIC = {
+  version: 'test-1.0',
+  criteria: [
+    { id: 'value', name: 'Value Proposition', description: 'Does this provide value?', weight: 0.25 },
+    { id: 'risk', name: 'Risk Assessment', description: 'What is the risk?', weight: 0.20 },
+    { id: 'complexity', name: 'Complexity', description: 'How complex?', weight: 0.15 },
+    { id: 'reversibility', name: 'Reversibility', description: 'Can it be reversed?', weight: 0.15 },
+    { id: 'alignment', name: 'Protocol Alignment', description: 'Does it align?', weight: 0.15 },
+    { id: 'testability', name: 'Testability', description: 'Can it be tested?', weight: 0.10 }
+  ],
+  scoringScale: { min: 1, max: 5 }
+};
+
+const SAMPLE_PROPOSAL = {
+  id: 'test-proposal-1',
+  title: 'Add caching layer for database queries',
+  summary: 'Implement Redis-based caching to reduce database load by 40%',
+  motivation: 'Current query patterns show redundant reads',
+  risk_level: 'medium',
+  content: 'We propose adding a Redis caching layer between the application and database.'
+};
+
+function makeValidLLMResponse() {
+  const criteria = DEFAULT_RUBRIC.criteria.map(c => ({
+    id: c.id,
+    name: c.name,
+    score: 65 + Math.floor(Math.random() * 20),
+    summary: `This criterion evaluates ${c.name.toLowerCase()} and the proposal demonstrates adequate capability.`,
+    reasoning: [
+      `The proposal addresses ${c.name.toLowerCase()} through clear technical approach`,
+      'Evidence of careful consideration in the implementation plan'
+    ],
+    evidence: ['We propose adding a Redis caching layer'],
+    improvements: ['Consider adding fallback strategy for cache misses']
+  }));
+
+  return {
+    criteria,
+    overall_score: 72,
+    weighting: { value: 0.25, risk: 0.20, complexity: 0.15, reversibility: 0.15, alignment: 0.15, testability: 0.10 }
+  };
+}
+
+function makeMockClient(completeFn) {
+  return { complete: completeFn };
+}
+
+describe('evaluateWithAI - Integration Tests', () => {
+  // TS-1: Happy path
+  describe('TS-1: Happy path evaluation', () => {
+    test('returns SUCCESS with all 6 criteria scored', async () => {
+      const validResponse = makeValidLLMResponse();
+      const mockComplete = jest.fn().mockResolvedValue({
+        content: JSON.stringify(validResponse),
+        model: 'claude-sonnet-4-5-20250929',
+        durationMs: 1500
+      });
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result.status).toBe('SUCCESS');
+      expect(Object.keys(result.scores)).toHaveLength(6);
+      expect(result.totalScore).toBe(72);
+      expect(result.model).toBe('claude-sonnet-4-5-20250929');
+      expect(result.rubricVersion).toBe('test-1.0');
+      expect(result.correlationId).toMatch(/^eval-/);
+      expect(result.attempt).toBe(1);
+    });
+
+    test('returns per-criterion structured reasoning', async () => {
+      const validResponse = makeValidLLMResponse();
+      const mockComplete = jest.fn().mockResolvedValue({
+        content: JSON.stringify(validResponse),
+        model: 'claude-sonnet-4-5-20250929'
+      });
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      for (const criterionId of ['value', 'risk', 'complexity', 'reversibility', 'alignment', 'testability']) {
+        const score = result.scores[criterionId];
+        expect(score).toBeDefined();
+        expect(score.score).toBeGreaterThanOrEqual(0);
+        expect(score.score).toBeLessThanOrEqual(100);
+        expect(score.summary.length).toBeGreaterThanOrEqual(20);
+        expect(score.reasoning.length).toBeGreaterThanOrEqual(2);
+        expect(score.improvements.length).toBeGreaterThanOrEqual(1);
+        expect(score.weight).toBeGreaterThan(0);
+      }
+    });
+
+    test('scores vary across distinct proposals (not hardcoded)', async () => {
+      const scores = [];
+
+      for (let i = 0; i < 3; i++) {
+        const response = makeValidLLMResponse();
+        response.overall_score = 50 + i * 15;
+        response.criteria[0].score = 40 + i * 20;
+
+        const mockComplete = jest.fn().mockResolvedValue({
+          content: JSON.stringify(response),
+          model: 'claude-sonnet-4-5-20250929'
+        });
+
+        const result = await evaluateWithAI(
+          { ...SAMPLE_PROPOSAL, id: `proposal-${i}`, title: `Proposal ${i}` },
+          DEFAULT_RUBRIC,
+          { llmClient: makeMockClient(mockComplete) }
+        );
+        scores.push(result.totalScore);
+      }
+
+      const unique = new Set(scores);
+      expect(unique.size).toBeGreaterThanOrEqual(2);
+    });
+
+    test('computes weightedScore for each criterion', async () => {
+      const validResponse = makeValidLLMResponse();
+      validResponse.criteria[0].score = 80; // value, weight 0.25
+      const mockComplete = jest.fn().mockResolvedValue({
+        content: JSON.stringify(validResponse),
+        model: 'claude-sonnet-4-5-20250929'
+      });
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      // weightedScore = (score / 100) * scoringScale.max * weight
+      // For value: (80/100) * 5 * 0.25 = 1.0
+      expect(result.scores.value.weightedScore).toBeCloseTo(1.0, 2);
+    });
+  });
+
+  // TS-2: Schema validation failure + repair retry
+  describe('TS-2: Schema validation failure with repair retry', () => {
+    test('retries once on malformed response and succeeds', async () => {
+      const malformed = { criteria: [], overall_score: 50 };
+      const valid = makeValidLLMResponse();
+
+      const mockComplete = jest.fn()
+        .mockResolvedValueOnce({ content: JSON.stringify(malformed), model: 'claude-sonnet-4-5-20250929' })
+        .mockResolvedValueOnce({ content: JSON.stringify(valid), model: 'claude-sonnet-4-5-20250929' });
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result.status).toBe('SUCCESS');
+      expect(result.attempt).toBe(2);
+      expect(mockComplete).toHaveBeenCalledTimes(2);
+    });
+
+    test('returns PARSE_ERROR after retry also fails', async () => {
+      const malformed = { criteria: [], overall_score: -1 };
+
+      const mockComplete = jest.fn()
+        .mockResolvedValueOnce({ content: JSON.stringify(malformed), model: 'claude-sonnet-4-5-20250929' })
+        .mockResolvedValueOnce({ content: JSON.stringify(malformed), model: 'claude-sonnet-4-5-20250929' });
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result.status).toBe('PARSE_ERROR');
+      expect(result.totalScore).toBe(0);
+      expect(result.validationErrors).toBeDefined();
+      expect(result.validationErrors.length).toBeGreaterThan(0);
+    });
+
+    test('strips markdown code fences from response', async () => {
+      const valid = makeValidLLMResponse();
+      const wrappedResponse = '```json\n' + JSON.stringify(valid) + '\n```';
+
+      const mockComplete = jest.fn().mockResolvedValue({
+        content: wrappedResponse,
+        model: 'claude-sonnet-4-5-20250929'
+      });
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result.status).toBe('SUCCESS');
+      expect(Object.keys(result.scores)).toHaveLength(6);
+    });
+  });
+
+  // TS-3: Timeout handling
+  describe('TS-3: Timeout handling', () => {
+    test('returns TIMEOUT when LLM exceeds timeout', async () => {
+      const mockComplete = jest.fn().mockImplementation((_sys, _user, opts) => {
+        return new Promise((resolve, reject) => {
+          const timer = setTimeout(() => resolve({ content: '{}', model: 'test' }), 10000);
+          if (opts?.signal) {
+            opts.signal.addEventListener('abort', () => {
+              clearTimeout(timer);
+              const err = new Error('TIMEOUT');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          }
+        });
+      });
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete),
+        timeoutMs: 100
+      });
+
+      expect(result.status).toBe('TIMEOUT');
+      expect(result.latencyMs).toBeGreaterThanOrEqual(80);
+      expect(result.totalScore).toBe(0);
+    });
+  });
+
+  // TS-4: Provider error mapping
+  describe('TS-4: Provider error mapping', () => {
+    test('maps 500 error to PROVIDER_SERVER_ERROR', async () => {
+      const err = new Error('Internal Server Error');
+      err.status = 500;
+      err.requestId = 'req-abc-123';
+      const mockComplete = jest.fn().mockRejectedValue(err);
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result.status).toBe('FAILED');
+      expect(result.errorCode).toBe('PROVIDER_SERVER_ERROR');
+    });
+
+    test('maps 429 to RATE_LIMITED', async () => {
+      const err = new Error('rate_limit exceeded');
+      err.status = 429;
+      const mockComplete = jest.fn().mockRejectedValue(err);
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result.status).toBe('FAILED');
+      expect(result.errorCode).toBe('RATE_LIMITED');
+    });
+
+    test('maps 400 to PROVIDER_CLIENT_ERROR', async () => {
+      const err = new Error('Bad Request');
+      err.status = 400;
+      const mockComplete = jest.fn().mockRejectedValue(err);
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result.status).toBe('FAILED');
+      expect(result.errorCode).toBe('PROVIDER_CLIENT_ERROR');
+    });
+
+    test('maps network errors to NETWORK_ERROR', async () => {
+      const err = new Error('ECONNREFUSED');
+      const mockComplete = jest.fn().mockRejectedValue(err);
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result.status).toBe('FAILED');
+      expect(result.errorCode).toBe('NETWORK_ERROR');
+    });
+  });
+
+  // Failure result structure
+  describe('Failure result structure', () => {
+    test('failure result has consistent shape', async () => {
+      const mockComplete = jest.fn().mockRejectedValue(new Error('test error'));
+
+      const result = await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(result).toHaveProperty('scores');
+      expect(result).toHaveProperty('totalScore', 0);
+      expect(result).toHaveProperty('rubricVersion', 'test-1.0');
+      expect(result).toHaveProperty('evaluatorVersion');
+      expect(result).toHaveProperty('assessedAt');
+      expect(result).toHaveProperty('correlationId');
+      expect(result).toHaveProperty('status');
+      expect(result).toHaveProperty('error');
+    });
+  });
+
+  // Single LLM call constraint (FR-4)
+  describe('Single LLM call constraint', () => {
+    test('makes exactly 1 LLM call on success', async () => {
+      const valid = makeValidLLMResponse();
+      const mockComplete = jest.fn().mockResolvedValue({
+        content: JSON.stringify(valid),
+        model: 'claude-sonnet-4-5-20250929'
+      });
+
+      await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(mockComplete).toHaveBeenCalledTimes(1);
+    });
+
+    test('makes at most 2 LLM calls (1 + 1 retry)', async () => {
+      const malformed = { criteria: [], overall_score: -1 };
+      const mockComplete = jest.fn().mockResolvedValue({
+        content: JSON.stringify(malformed),
+        model: 'claude-sonnet-4-5-20250929'
+      });
+
+      await evaluateWithAI(SAMPLE_PROPOSAL, DEFAULT_RUBRIC, {
+        llmClient: makeMockClient(mockComplete)
+      });
+
+      expect(mockComplete).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/unit/sub-agents/vetting/rubric-evaluator.test.js
+++ b/tests/unit/sub-agents/vetting/rubric-evaluator.test.js
@@ -1,0 +1,125 @@
+/**
+ * Rubric Evaluator Tests
+ * SD-LEO-ORCH-SELF-IMPROVING-LEO-001-A
+ *
+ * Tests the schema validation, prompt building, and response parsing
+ * logic of the AI-powered rubric evaluator.
+ */
+
+import { jest } from '@jest/globals';
+
+// We test the validation function directly since the module is ESM
+// Import the module to test schema validation
+const mod = await import(
+  '../../../../lib/sub-agents/vetting/rubric-evaluator.js'
+);
+const validateEvaluationSchema = mod.validateEvaluationSchema || mod.default?.validateEvaluationSchema;
+
+const EXPECTED_CRITERIA = ['value', 'risk', 'complexity', 'reversibility', 'alignment', 'testability'];
+
+function makeValidEvaluation() {
+  return {
+    criteria: EXPECTED_CRITERIA.map(id => ({
+      id,
+      name: `${id} criterion`,
+      score: 75,
+      summary: 'This is a detailed summary that meets the minimum length requirement.',
+      reasoning: ['First detailed reasoning point', 'Second detailed reasoning point'],
+      evidence: ['Quote from the proposal text'],
+      improvements: ['Suggestion for improvement']
+    })),
+    overall_score: 72
+  };
+}
+
+describe('validateEvaluationSchema', () => {
+  test('accepts valid evaluation with all criteria', () => {
+    const result = validateEvaluationSchema(makeValidEvaluation(), EXPECTED_CRITERIA);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('rejects null input', () => {
+    const result = validateEvaluationSchema(null, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Response is not an object');
+  });
+
+  test('rejects missing criteria array', () => {
+    const result = validateEvaluationSchema({ overall_score: 50 }, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('Missing or non-array "criteria" field');
+  });
+
+  test('rejects wrong number of criteria', () => {
+    const eval_ = makeValidEvaluation();
+    eval_.criteria = eval_.criteria.slice(0, 3);
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Expected 6 criteria'))).toBe(true);
+  });
+
+  test('rejects score out of range', () => {
+    const eval_ = makeValidEvaluation();
+    eval_.criteria[0].score = 150;
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('score must be 0-100'))).toBe(true);
+  });
+
+  test('rejects overall_score out of range', () => {
+    const eval_ = makeValidEvaluation();
+    eval_.overall_score = -10;
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('overall_score must be 0-100'))).toBe(true);
+  });
+
+  test('rejects summary too short', () => {
+    const eval_ = makeValidEvaluation();
+    eval_.criteria[0].summary = 'Short';
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('summary too short'))).toBe(true);
+  });
+
+  test('rejects insufficient reasoning bullets', () => {
+    const eval_ = makeValidEvaluation();
+    eval_.criteria[0].reasoning = ['Only one point'];
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('reasoning needs >=2'))).toBe(true);
+  });
+
+  test('rejects missing improvements', () => {
+    const eval_ = makeValidEvaluation();
+    eval_.criteria[0].improvements = [];
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('needs >=1 improvement'))).toBe(true);
+  });
+
+  test('rejects missing expected criterion', () => {
+    const eval_ = makeValidEvaluation();
+    eval_.criteria[0].id = 'unknown_criterion';
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Missing expected criterion: value'))).toBe(true);
+  });
+
+  test('rejects duplicate criterion IDs', () => {
+    const eval_ = makeValidEvaluation();
+    eval_.criteria[1].id = eval_.criteria[0].id;
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Duplicate criterion id'))).toBe(true);
+  });
+
+  test('rejects missing required fields in criterion', () => {
+    const eval_ = makeValidEvaluation();
+    delete eval_.criteria[0].score;
+    const result = validateEvaluationSchema(eval_, EXPECTED_CRITERIA);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('missing field: score'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds AI-powered rubric evaluation via `evaluateWithAI()` in new `rubric-evaluator.js` module
- Integrates with VettingEngine's `assessWithRubric()` - tries AI first, falls back to heuristic scoring
- Uses LLM Client Factory (`getValidationClient()`) for Sonnet-tier evaluation with single structured JSON call

## Changes
- **New**: `lib/sub-agents/vetting/rubric-evaluator.js` - AI evaluator with schema validation, retry, audit logging
- **Modified**: `lib/sub-agents/vetting/index.js` - AI-first with heuristic fallback in `assessWithRubric()`
- **New**: 27 tests (12 schema validation + 15 integration with mock LLM)

## Test plan
- [x] 12 schema validation tests pass (null, missing fields, ranges, duplicates)
- [x] 15 integration tests pass (happy path, retry, timeout, provider errors)
- [x] 24 existing vetting tests pass (no regressions)
- [x] Dependency injection via `options.llmClient` for testability

## SD Reference
SD-LEO-ORCH-SELF-IMPROVING-LEO-001-A (AI-Powered Rubric Assessment Integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)