### PR TITLE
feat(vision-qa): integrate Vision QA into AUTO-PROCEED post-completion

### DIFF
--- a/scripts/execute-vision-qa.js
+++ b/scripts/execute-vision-qa.js
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+/**
+ * Vision QA Execution Wrapper
+ * SD: SD-LEO-ENH-VISION-QA-AUTO-PROCEED-001
+ *
+ * Called by leo-continuous.js commandMap entry for 'vision-qa'.
+ * Loads the current working SD and runs the Vision QA pipeline.
+ *
+ * Usage:
+ *   node scripts/execute-vision-qa.js              # Run for current working SD
+ *   node scripts/execute-vision-qa.js --sd-id UUID  # Run for specific SD
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import dotenv from 'dotenv';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+
+const envPath = path.join(ROOT, '.env');
+if (fs.existsSync(envPath)) {
+  dotenv.config({ path: envPath });
+} else {
+  dotenv.config();
+}
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  let sdId = null;
+  const sdIdIdx = args.indexOf('--sd-id');
+  if (sdIdIdx >= 0 && args[sdIdIdx + 1]) {
+    sdId = args[sdIdIdx + 1];
+  }
+
+  // Find the SD to test
+  let sd;
+  if (sdId) {
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('*')
+      .eq('id', sdId)
+      .single();
+
+    if (error || !data) {
+      console.error(`SD not found: ${sdId}`);
+      process.exit(1);
+    }
+    sd = data;
+  } else {
+    // Find the currently-working SD
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('*')
+      .eq('is_working_on', true)
+      .eq('is_active', true)
+      .limit(1)
+      .single();
+
+    if (error || !data) {
+      console.error('No active working SD found. Use --sd-id to specify one.');
+      process.exit(1);
+    }
+    sd = data;
+  }
+
+  console.log(`Vision QA target: ${sd.sd_key} (${sd.title})`);
+
+  // Dynamic import to avoid loading pipeline at module level
+  const { executeVisionQAPipeline } = await import('../lib/testing/vision-qa-pipeline.js');
+
+  const result = await executeVisionQAPipeline(sd, {
+    supabase,
+    autoProceed: true
+  });
+
+  if (result.executed) {
+    console.log(`\nVision QA completed: ${result.clean_pass ? 'CLEAN PASS' : 'ISSUES FOUND'}`);
+    process.exit(result.clean_pass ? 0 : 1);
+  } else {
+    console.log(`\nVision QA skipped: ${result.reason}`);
+    process.exit(0); // Skip is not an error
+  }
+}
+
+main().catch(err => {
+  console.error('Vision QA execution failed:', err.message);
+  process.exit(1);
+});

--- a/tests/unit/testing/post-completion-requirements.test.js
+++ b/tests/unit/testing/post-completion-requirements.test.js
@@ -1,0 +1,291 @@
+/**
+ * Unit Tests for Post-Completion Requirements (Vision QA Integration)
+ * SD: SD-LEO-ENH-VISION-QA-AUTO-PROCEED-001
+ *
+ * Tests: getPostCompletionRequirements, getPostCompletionSequence,
+ * shouldSkipLearn, Vision QA conditional logic.
+ */
+
+import {
+  getPostCompletionRequirements,
+  getPostCompletionSequence,
+  shouldSkipLearn,
+  FULL_SEQUENCE_TYPES,
+  MINIMAL_SEQUENCE_TYPES,
+  LEARN_SKIP_SOURCES
+} from '../../../lib/utils/post-completion-requirements.js';
+
+// ============================================================================
+// TEST GROUP 1: Vision QA in post-completion requirements
+// ============================================================================
+describe('getPostCompletionRequirements() - Vision QA', () => {
+  it('should enable visionQA for feature SD with UI changes and AUTO-PROCEED', () => {
+    const req = getPostCompletionRequirements('feature', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(req.visionQA).toBe(true);
+  });
+
+  it('should disable visionQA when AUTO-PROCEED is off', () => {
+    const req = getPostCompletionRequirements('feature', {
+      hasUIChanges: true,
+      autoProceed: false
+    });
+    expect(req.visionQA).toBe(false);
+    expect(req.visionQASkipReason).toBe('AUTO-PROCEED not active');
+  });
+
+  it('should disable visionQA when no UI changes', () => {
+    const req = getPostCompletionRequirements('feature', {
+      hasUIChanges: false,
+      autoProceed: true
+    });
+    expect(req.visionQA).toBe(false);
+    expect(req.visionQASkipReason).toBe('no UI changes detected');
+  });
+
+  it('should disable visionQA for minimal sequence types', () => {
+    const req = getPostCompletionRequirements('infrastructure', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(req.visionQA).toBe(false);
+    expect(req.visionQASkipReason).toBe('minimal sequence SD');
+  });
+
+  it('should disable visionQA for documentation SD', () => {
+    const req = getPostCompletionRequirements('documentation', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(req.visionQA).toBe(false);
+  });
+
+  it('should enable visionQA for bugfix SD with UI changes and AUTO-PROCEED', () => {
+    const req = getPostCompletionRequirements('bugfix', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(req.visionQA).toBe(true);
+  });
+
+  it('should enable visionQA for enhancement SD with UI changes and AUTO-PROCEED', () => {
+    const req = getPostCompletionRequirements('enhancement', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(req.visionQA).toBe(true);
+  });
+
+  it('should enable visionQA for security SD with UI changes and AUTO-PROCEED', () => {
+    const req = getPostCompletionRequirements('security', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(req.visionQA).toBe(true);
+  });
+
+  it('should default autoProceed to false', () => {
+    const req = getPostCompletionRequirements('feature', {
+      hasUIChanges: true
+    });
+    expect(req.visionQA).toBe(false);
+  });
+
+  it('should default hasUIChanges to false', () => {
+    const req = getPostCompletionRequirements('feature', {
+      autoProceed: true
+    });
+    expect(req.visionQA).toBe(false);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 2: Post-completion sequence with Vision QA
+// ============================================================================
+describe('getPostCompletionSequence() - Vision QA step', () => {
+  it('should include vision-qa in sequence for UI-touching feature SD', () => {
+    const seq = getPostCompletionSequence('feature', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(seq).toContain('vision-qa');
+  });
+
+  it('should place vision-qa after restart and before document', () => {
+    const seq = getPostCompletionSequence('feature', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    const restartIdx = seq.indexOf('restart');
+    const visionIdx = seq.indexOf('vision-qa');
+    const docIdx = seq.indexOf('document');
+    const shipIdx = seq.indexOf('ship');
+
+    expect(restartIdx).toBeLessThan(visionIdx);
+    expect(visionIdx).toBeLessThan(docIdx);
+    expect(docIdx).toBeLessThan(shipIdx);
+  });
+
+  it('should not include vision-qa for backend-only feature SD', () => {
+    const seq = getPostCompletionSequence('feature', {
+      hasUIChanges: false,
+      autoProceed: true
+    });
+    expect(seq).not.toContain('vision-qa');
+  });
+
+  it('should not include vision-qa for infrastructure SD', () => {
+    const seq = getPostCompletionSequence('infrastructure', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(seq).not.toContain('vision-qa');
+  });
+
+  it('should produce full sequence: restart -> vision-qa -> document -> ship -> learn', () => {
+    const seq = getPostCompletionSequence('feature', {
+      hasUIChanges: true,
+      autoProceed: true
+    });
+    expect(seq).toEqual(['restart', 'vision-qa', 'document', 'ship', 'learn']);
+  });
+
+  it('should produce sequence without vision-qa: restart -> document -> ship -> learn', () => {
+    const seq = getPostCompletionSequence('feature', {
+      hasUIChanges: false,
+      autoProceed: true
+    });
+    expect(seq).toEqual(['restart', 'document', 'ship', 'learn']);
+  });
+
+  it('should produce minimal sequence for infrastructure: ship only', () => {
+    const seq = getPostCompletionSequence('infrastructure');
+    expect(seq).toEqual(['ship']);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 3: Full sequence type requirements
+// ============================================================================
+describe('getPostCompletionRequirements() - full sequence types', () => {
+  for (const sdType of FULL_SEQUENCE_TYPES) {
+    it(`should return full sequence for ${sdType}`, () => {
+      const req = getPostCompletionRequirements(sdType);
+      expect(req.sequenceType).toBe('full');
+    });
+  }
+});
+
+// ============================================================================
+// TEST GROUP 4: Minimal sequence type requirements
+// ============================================================================
+describe('getPostCompletionRequirements() - minimal sequence types', () => {
+  for (const sdType of MINIMAL_SEQUENCE_TYPES) {
+    it(`should return minimal sequence for ${sdType}`, () => {
+      const req = getPostCompletionRequirements(sdType);
+      expect(req.sequenceType).toBe('minimal');
+    });
+  }
+});
+
+// ============================================================================
+// TEST GROUP 5: shouldSkipLearn
+// ============================================================================
+describe('shouldSkipLearn()', () => {
+  it('should skip learn for "learn" source', () => {
+    const result = shouldSkipLearn({ source: 'learn', sd_type: 'feature' });
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain('learn');
+  });
+
+  it('should skip learn for "quick-fix" source', () => {
+    const result = shouldSkipLearn({ source: 'quick-fix', sd_type: 'feature' });
+    expect(result.skip).toBe(true);
+  });
+
+  it('should skip learn for "rca" source', () => {
+    const result = shouldSkipLearn({ source: 'rca', sd_type: 'feature' });
+    expect(result.skip).toBe(true);
+  });
+
+  it('should skip learn for documentation SD type', () => {
+    const result = shouldSkipLearn({ source: '', sd_type: 'documentation' });
+    expect(result.skip).toBe(true);
+  });
+
+  it('should skip learn for infrastructure SD type', () => {
+    const result = shouldSkipLearn({ source: '', sd_type: 'infrastructure' });
+    expect(result.skip).toBe(true);
+  });
+
+  it('should NOT skip learn for normal feature SD', () => {
+    const result = shouldSkipLearn({ source: '', sd_type: 'feature' });
+    expect(result.skip).toBe(false);
+    expect(result.reason).toBeNull();
+  });
+
+  it('should handle missing source', () => {
+    const result = shouldSkipLearn({ sd_type: 'feature' });
+    expect(result.skip).toBe(false);
+  });
+
+  it('should handle missing sd_type (defaults to feature)', () => {
+    const result = shouldSkipLearn({});
+    expect(result.skip).toBe(false);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 6: Constants
+// ============================================================================
+describe('Exported constants', () => {
+  it('should export FULL_SEQUENCE_TYPES as array', () => {
+    expect(Array.isArray(FULL_SEQUENCE_TYPES)).toBe(true);
+    expect(FULL_SEQUENCE_TYPES).toContain('feature');
+    expect(FULL_SEQUENCE_TYPES).toContain('bugfix');
+  });
+
+  it('should export MINIMAL_SEQUENCE_TYPES as array', () => {
+    expect(Array.isArray(MINIMAL_SEQUENCE_TYPES)).toBe(true);
+    expect(MINIMAL_SEQUENCE_TYPES).toContain('infrastructure');
+    expect(MINIMAL_SEQUENCE_TYPES).toContain('documentation');
+  });
+
+  it('should export LEARN_SKIP_SOURCES as array', () => {
+    expect(Array.isArray(LEARN_SKIP_SOURCES)).toBe(true);
+    expect(LEARN_SKIP_SOURCES).toContain('learn');
+    expect(LEARN_SKIP_SOURCES).toContain('quick-fix');
+  });
+});
+
+// ============================================================================
+// TEST GROUP 7: Restart requirements
+// ============================================================================
+describe('getPostCompletionRequirements() - restart', () => {
+  it('should require restart for feature SD (always)', () => {
+    const req = getPostCompletionRequirements('feature');
+    expect(req.restart).toBe(true);
+  });
+
+  it('should require restart for enhancement with UI changes', () => {
+    const req = getPostCompletionRequirements('enhancement', { hasUIChanges: true });
+    expect(req.restart).toBe(true);
+  });
+
+  it('should NOT require restart for enhancement without UI changes', () => {
+    const req = getPostCompletionRequirements('enhancement', { hasUIChanges: false });
+    expect(req.restart).toBe(false);
+  });
+
+  it('should NOT require restart for infrastructure SD', () => {
+    const req = getPostCompletionRequirements('infrastructure');
+    expect(req.restart).toBe(false);
+  });
+
+  it('should NOT require restart for documentation SD', () => {
+    const req = getPostCompletionRequirements('documentation');
+    expect(req.restart).toBe(false);
+  });
+});

--- a/tests/unit/testing/ui-touching-classifier.test.js
+++ b/tests/unit/testing/ui-touching-classifier.test.js
@@ -1,0 +1,255 @@
+/**
+ * Unit Tests for UI-Touching SD Classifier
+ * SD: SD-LEO-ENH-VISION-QA-AUTO-PROCEED-001
+ *
+ * Tests: classifySDAsUITouching, classifyFromScope (via classifySD fallback),
+ * pattern matching, order-insensitivity, edge cases.
+ */
+
+import {
+  classifySDAsUITouching,
+  DEFAULT_UI_PATTERNS,
+  DEFAULT_BACKEND_PATTERNS
+} from '../../../lib/testing/ui-touching-classifier.js';
+
+// ============================================================================
+// TEST GROUP 1: classifySDAsUITouching - UI file detection
+// ============================================================================
+describe('classifySDAsUITouching()', () => {
+  it('should detect .tsx files as UI-touching', () => {
+    const result = classifySDAsUITouching(['src/components/Button.tsx']);
+    expect(result.ui_touching).toBe(true);
+    expect(result.matched_paths.length).toBe(1);
+  });
+
+  it('should detect .jsx files as UI-touching', () => {
+    const result = classifySDAsUITouching(['pages/dashboard.jsx']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect .css files as UI-touching', () => {
+    const result = classifySDAsUITouching(['styles/global.css']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect .scss files as UI-touching', () => {
+    const result = classifySDAsUITouching(['src/styles/theme.scss']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect app/ directory as UI-touching', () => {
+    const result = classifySDAsUITouching(['app/layout.ts']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect pages/ directory as UI-touching', () => {
+    const result = classifySDAsUITouching(['pages/index.ts']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect src/components/ directory as UI-touching', () => {
+    const result = classifySDAsUITouching(['src/components/Header.tsx']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect public/ directory as UI-touching', () => {
+    const result = classifySDAsUITouching(['public/logo.svg']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect layout files as UI-touching', () => {
+    const result = classifySDAsUITouching(['layout.tsx']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect theme files as UI-touching', () => {
+    const result = classifySDAsUITouching(['theme.config.ts']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect tailwind config as UI-touching', () => {
+    const result = classifySDAsUITouching(['tailwind.config.ts']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should detect .svg files as UI-touching', () => {
+    const result = classifySDAsUITouching(['assets/icon.svg']);
+    expect(result.ui_touching).toBe(true);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 2: Backend-only detection
+// ============================================================================
+describe('classifySDAsUITouching() - backend only', () => {
+  it('should NOT classify lib/ .js files as UI-touching', () => {
+    const result = classifySDAsUITouching(['lib/utils/helper.js']);
+    expect(result.ui_touching).toBe(false);
+    expect(result.matched_paths.length).toBe(0);
+  });
+
+  it('should NOT classify scripts/ as UI-touching', () => {
+    const result = classifySDAsUITouching(['scripts/migration.js']);
+    expect(result.ui_touching).toBe(false);
+  });
+
+  it('should NOT classify database/ as UI-touching', () => {
+    const result = classifySDAsUITouching(['database/migrations/001.sql']);
+    expect(result.ui_touching).toBe(false);
+  });
+
+  it('should NOT classify config files as UI-touching', () => {
+    const result = classifySDAsUITouching(['config/settings.json']);
+    expect(result.ui_touching).toBe(false);
+  });
+
+  it('should NOT classify test files as UI-touching', () => {
+    const result = classifySDAsUITouching(['tests/unit/helper.test.js']);
+    expect(result.ui_touching).toBe(false);
+  });
+
+  it('should NOT classify .env files as UI-touching', () => {
+    const result = classifySDAsUITouching(['.env.example']);
+    expect(result.ui_touching).toBe(false);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 3: Mixed file sets
+// ============================================================================
+describe('classifySDAsUITouching() - mixed files', () => {
+  it('should detect UI-touching when mixed with backend files', () => {
+    const result = classifySDAsUITouching([
+      'lib/api/handler.js',
+      'src/components/Dashboard.tsx',
+      'scripts/deploy.js'
+    ]);
+    expect(result.ui_touching).toBe(true);
+    expect(result.matched_paths.length).toBe(1);
+    expect(result.matched_paths[0]).toContain('dashboard.tsx');
+  });
+
+  it('should count multiple UI matches', () => {
+    const result = classifySDAsUITouching([
+      'src/components/Header.tsx',
+      'src/components/Footer.tsx',
+      'styles/global.css'
+    ]);
+    expect(result.ui_touching).toBe(true);
+    expect(result.matched_paths.length).toBe(3);
+  });
+
+  it('should return reason with match count', () => {
+    const result = classifySDAsUITouching([
+      'src/components/A.tsx',
+      'src/components/B.tsx'
+    ]);
+    expect(result.reason).toContain('2 file(s) match UI patterns');
+  });
+});
+
+// ============================================================================
+// TEST GROUP 4: Order insensitivity (FR-2 requirement)
+// ============================================================================
+describe('classifySDAsUITouching() - order insensitivity', () => {
+  it('should produce same result regardless of path order', () => {
+    const paths = [
+      'lib/api/handler.js',
+      'src/components/Dashboard.tsx',
+      'scripts/deploy.js'
+    ];
+    const reversed = [...paths].reverse();
+    const shuffled = [paths[1], paths[2], paths[0]];
+
+    const result1 = classifySDAsUITouching(paths);
+    const result2 = classifySDAsUITouching(reversed);
+    const result3 = classifySDAsUITouching(shuffled);
+
+    expect(result1.ui_touching).toBe(result2.ui_touching);
+    expect(result2.ui_touching).toBe(result3.ui_touching);
+    expect(result1.matched_paths.length).toBe(result2.matched_paths.length);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 5: Edge cases
+// ============================================================================
+describe('classifySDAsUITouching() - edge cases', () => {
+  it('should handle null input', () => {
+    const result = classifySDAsUITouching(null);
+    expect(result.ui_touching).toBe(false);
+    expect(result.reason).toBe('no_changed_paths');
+  });
+
+  it('should handle empty array', () => {
+    const result = classifySDAsUITouching([]);
+    expect(result.ui_touching).toBe(false);
+    expect(result.reason).toBe('no_changed_paths');
+  });
+
+  it('should handle undefined input', () => {
+    const result = classifySDAsUITouching(undefined);
+    expect(result.ui_touching).toBe(false);
+    expect(result.reason).toBe('no_changed_paths');
+  });
+
+  it('should be case-insensitive for paths', () => {
+    const result = classifySDAsUITouching(['SRC/Components/Button.TSX']);
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should normalize backslashes to forward slashes', () => {
+    const result = classifySDAsUITouching(['src\\components\\Button.tsx']);
+    expect(result.ui_touching).toBe(true);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 6: Custom patterns
+// ============================================================================
+describe('classifySDAsUITouching() - custom patterns', () => {
+  it('should accept custom UI patterns', () => {
+    const result = classifySDAsUITouching(
+      ['custom-ui/widget.ts'],
+      { uiPatterns: ['custom-ui/'] }
+    );
+    expect(result.ui_touching).toBe(true);
+  });
+
+  it('should not match default patterns when custom patterns provided', () => {
+    const result = classifySDAsUITouching(
+      ['src/components/Button.tsx'],
+      { uiPatterns: ['custom-only/'] }
+    );
+    expect(result.ui_touching).toBe(false);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 7: Constants exported
+// ============================================================================
+describe('DEFAULT_UI_PATTERNS', () => {
+  it('should be an array', () => {
+    expect(Array.isArray(DEFAULT_UI_PATTERNS)).toBe(true);
+  });
+
+  it('should include common UI patterns', () => {
+    expect(DEFAULT_UI_PATTERNS).toContain('.tsx');
+    expect(DEFAULT_UI_PATTERNS).toContain('.jsx');
+    expect(DEFAULT_UI_PATTERNS).toContain('.css');
+    expect(DEFAULT_UI_PATTERNS).toContain('app/');
+    expect(DEFAULT_UI_PATTERNS).toContain('pages/');
+  });
+});
+
+describe('DEFAULT_BACKEND_PATTERNS', () => {
+  it('should be an array', () => {
+    expect(Array.isArray(DEFAULT_BACKEND_PATTERNS)).toBe(true);
+  });
+
+  it('should include common backend patterns', () => {
+    expect(DEFAULT_BACKEND_PATTERNS).toContain('lib/');
+    expect(DEFAULT_BACKEND_PATTERNS).toContain('scripts/');
+    expect(DEFAULT_BACKEND_PATTERNS).toContain('database/');
+  });
+});

--- a/tests/unit/testing/vision-qa-finding-router.test.js
+++ b/tests/unit/testing/vision-qa-finding-router.test.js
@@ -1,0 +1,203 @@
+/**
+ * Unit Tests for Vision QA Finding Router
+ * SD: SD-LEO-ENH-VISION-QA-AUTO-PROCEED-001
+ *
+ * Tests: classifyFinding, generateIssueSignature, routing logic,
+ * deduplication, a11y routing, performance routing.
+ *
+ * Note: Tests for routeFindings() and registerSkipEntry() require
+ * database mocking and are covered in integration tests.
+ */
+
+import {
+  classifyFinding,
+  generateIssueSignature,
+  MAX_QUICKFIX_CYCLES,
+  CRITICAL_CONFIDENCE_THRESHOLD
+} from '../../../lib/testing/vision-qa-finding-router.js';
+
+// ============================================================================
+// TEST GROUP 1: classifyFinding - routing rules
+// ============================================================================
+describe('classifyFinding()', () => {
+  it('should route critical + high-confidence to quickfix', () => {
+    const result = classifyFinding({
+      severity: 'critical',
+      confidence: 0.90
+    });
+    expect(result.route).toBe('quickfix');
+    expect(result.reason).toContain('critical severity');
+    expect(result.reason).toContain('0.9');
+  });
+
+  it('should route critical + exactly threshold confidence to quickfix', () => {
+    const result = classifyFinding({
+      severity: 'critical',
+      confidence: CRITICAL_CONFIDENCE_THRESHOLD
+    });
+    expect(result.route).toBe('quickfix');
+  });
+
+  it('should route critical + low-confidence to debt', () => {
+    const result = classifyFinding({
+      severity: 'critical',
+      confidence: 0.50
+    });
+    expect(result.route).toBe('debt');
+    expect(result.reason).toContain('low confidence');
+  });
+
+  it('should route critical + below-threshold confidence to debt', () => {
+    const result = classifyFinding({
+      severity: 'critical',
+      confidence: 0.84
+    });
+    expect(result.route).toBe('debt');
+  });
+
+  it('should route high severity to debt', () => {
+    const result = classifyFinding({
+      severity: 'high',
+      confidence: 0.95
+    });
+    expect(result.route).toBe('debt');
+    expect(result.reason).toContain('non-critical');
+  });
+
+  it('should route medium severity to debt', () => {
+    const result = classifyFinding({
+      severity: 'medium',
+      confidence: 0.95
+    });
+    expect(result.route).toBe('debt');
+  });
+
+  it('should route low severity to debt', () => {
+    const result = classifyFinding({
+      severity: 'low',
+      confidence: 1.0
+    });
+    expect(result.route).toBe('debt');
+  });
+
+  it('should handle missing severity as non-critical (debt)', () => {
+    const result = classifyFinding({ confidence: 0.95 });
+    expect(result.route).toBe('debt');
+  });
+
+  it('should handle missing confidence as 0 (debt for critical)', () => {
+    const result = classifyFinding({ severity: 'critical' });
+    expect(result.route).toBe('debt');
+  });
+
+  it('should be case-insensitive for severity', () => {
+    const result = classifyFinding({
+      severity: 'CRITICAL',
+      confidence: 0.90
+    });
+    expect(result.route).toBe('quickfix');
+  });
+});
+
+// ============================================================================
+// TEST GROUP 2: generateIssueSignature - determinism
+// ============================================================================
+describe('generateIssueSignature()', () => {
+  it('should return a hex string', () => {
+    const sig = generateIssueSignature({
+      category: 'bug',
+      description: 'Button not visible'
+    });
+    expect(typeof sig).toBe('string');
+    expect(sig).toMatch(/^[a-f0-9]+$/);
+  });
+
+  it('should return 16-character hash', () => {
+    const sig = generateIssueSignature({
+      category: 'bug',
+      description: 'Test issue'
+    });
+    expect(sig.length).toBe(16);
+  });
+
+  it('should produce same signature for same input', () => {
+    const finding = { category: 'bug', description: 'Login button missing' };
+    const sig1 = generateIssueSignature(finding);
+    const sig2 = generateIssueSignature(finding);
+    expect(sig1).toBe(sig2);
+  });
+
+  it('should produce different signatures for different descriptions', () => {
+    const sig1 = generateIssueSignature({ category: 'bug', description: 'Issue A' });
+    const sig2 = generateIssueSignature({ category: 'bug', description: 'Issue B' });
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('should produce different signatures for different categories', () => {
+    const sig1 = generateIssueSignature({ category: 'bug', description: 'Same issue' });
+    const sig2 = generateIssueSignature({ category: 'a11y', description: 'Same issue' });
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('should be case-insensitive for description', () => {
+    const sig1 = generateIssueSignature({ category: 'bug', description: 'Hello World' });
+    const sig2 = generateIssueSignature({ category: 'bug', description: 'hello world' });
+    expect(sig1).toBe(sig2);
+  });
+
+  it('should trim whitespace from description', () => {
+    const sig1 = generateIssueSignature({ category: 'bug', description: 'test' });
+    const sig2 = generateIssueSignature({ category: 'bug', description: '  test  ' });
+    expect(sig1).toBe(sig2);
+  });
+
+  it('should handle missing fields gracefully', () => {
+    const sig = generateIssueSignature({});
+    expect(typeof sig).toBe('string');
+    expect(sig.length).toBe(16);
+  });
+
+  it('should default category to "bug" when missing', () => {
+    const sig1 = generateIssueSignature({ description: 'test' });
+    const sig2 = generateIssueSignature({ category: 'bug', description: 'test' });
+    expect(sig1).toBe(sig2);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 3: Constants
+// ============================================================================
+describe('Constants', () => {
+  it('should export MAX_QUICKFIX_CYCLES as 2', () => {
+    expect(MAX_QUICKFIX_CYCLES).toBe(2);
+  });
+
+  it('should export CRITICAL_CONFIDENCE_THRESHOLD as 0.85', () => {
+    expect(CRITICAL_CONFIDENCE_THRESHOLD).toBe(0.85);
+  });
+});
+
+// ============================================================================
+// TEST GROUP 4: Routing boundary conditions
+// ============================================================================
+describe('classifyFinding() - boundary conditions', () => {
+  it('should route to quickfix at exactly 0.85 confidence for critical', () => {
+    const result = classifyFinding({ severity: 'critical', confidence: 0.85 });
+    expect(result.route).toBe('quickfix');
+  });
+
+  it('should route to debt at 0.8499 confidence for critical', () => {
+    const result = classifyFinding({ severity: 'critical', confidence: 0.8499 });
+    expect(result.route).toBe('debt');
+  });
+
+  it('should route to quickfix at confidence 1.0 for critical', () => {
+    const result = classifyFinding({ severity: 'critical', confidence: 1.0 });
+    expect(result.route).toBe('quickfix');
+  });
+
+  it('should route to debt at confidence 0 for critical', () => {
+    const result = classifyFinding({ severity: 'critical', confidence: 0 });
+    expect(result.route).toBe('debt');
+  });
+});


### PR DESCRIPTION
## Summary
- Integrate Vision QA pipeline into AUTO-PROCEED post-completion sequence in `leo-continuous.js`
- Add `execute-vision-qa.js` wrapper script for the Vision QA commandMap entry
- Classify SD as UI-touching before post-completion to conditionally include vision-qa step
- Add 106 unit tests across 3 test files covering UI classifier, finding router, and post-completion requirements

## Changes
- **scripts/leo-continuous.js**: Import UI classifier, add `vision-qa` commandMap entry, pass `hasUIChanges` to post-completion sequence
- **scripts/execute-vision-qa.js**: New execution wrapper that finds active SD and runs Vision QA pipeline
- **tests/unit/testing/ui-touching-classifier.test.js**: 33 tests for file-path-based UI detection
- **tests/unit/testing/vision-qa-finding-router.test.js**: 25 tests for finding classification and signature generation
- **tests/unit/testing/post-completion-requirements.test.js**: 48 tests for Vision QA conditional logic in sequences

## Test plan
- [x] All 106 unit tests pass (`NODE_OPTIONS=--experimental-vm-modules npx jest tests/unit/testing/`)
- [x] ESLint passes (no new warnings from our changes)
- [x] Vision QA step only included when `hasUIChanges=true` AND `autoProceed=true`
- [x] Minimal sequence types (infrastructure, documentation) correctly exclude vision-qa

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>