### PR TITLE
fix(SD-LEARN-FIX-008): add existence verification to /learn improvements

### DIFF
--- a/lib/utils/sd-type-detection.js
+++ b/lib/utils/sd-type-detection.js
@@ -88,7 +88,14 @@ export function detectSDType(sd) {
       'automation',
       'script',
       'tool',
-      'infrastructure'
+      'infrastructure',
+      'hook',
+      'hooks',
+      'state management',
+      'internal tooling',
+      'cli',
+      'command-line',
+      'developer tool'
     ];
 
     const featureKeywords = [

--- a/scripts/modules/handoff/verifiers/lead-to-plan/sd-type-detection.js
+++ b/scripts/modules/handoff/verifiers/lead-to-plan/sd-type-detection.js
@@ -26,8 +26,10 @@ export const TYPE_PATTERNS = {
   infrastructure: {
     keywords: ['ci/cd', 'pipeline', 'github action', 'workflow', 'deploy', 'docker',
                'script', 'tooling', 'automation', 'build', 'bundle', 'lint', 'prettier',
-               'eslint', 'pre-commit', 'hook', 'protocol', 'handoff', 'agent system',
-               'mcp', 'leo protocol', 'devops', 'monitoring', 'logging'],
+               'eslint', 'pre-commit', 'hook', 'hooks', 'protocol', 'handoff', 'agent system',
+               'mcp', 'leo protocol', 'devops', 'monitoring', 'logging',
+               'state management', 'internal tooling', 'cli', 'command-line',
+               'cli enhancement', 'developer tool', 'dev tool'],
     weight: 1.0
   },
   documentation: {


### PR DESCRIPTION
## Summary
- Add centralized `SURFACEABLE_IMPROVEMENT_STATUSES` allowlist to `getPendingImprovements()` preventing already-applied improvements from re-surfacing in `/learn`
- Add orphan detection for `SD_CREATED` items whose assigned SD has completed but wasn't transitioned to APPLIED
- Expand infrastructure SD type detection keywords for better auto-classification
- All 5 improvement items from `/learn` verified and marked APPLIED with evidence

## Test plan
- [x] `context-builder.js` loads and runs without errors
- [x] SURFACEABLE_IMPROVEMENT_STATUSES only contains 'PENDING'
- [x] Orphan detection correctly identifies 13 orphaned improvements
- [x] `/learn process` command works end-to-end
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)