### PR TITLE
fix(SD-LEARN-FIX-011): fix 5 learning system improvements

### DIFF
--- a/database/migrations/20260207_fix_v_patterns_with_decay_scalar_bug.sql
+++ b/database/migrations/20260207_fix_v_patterns_with_decay_scalar_bug.sql
@@ -1,0 +1,87 @@
+-- Migration: Fix v_patterns_with_decay scalar bug
+-- Date: 2026-02-07
+-- SD: SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-011
+-- Item: #1 - Fix jsonb_array_length() crash on non-array proven_solutions
+--
+-- Root Cause: The view uses jsonb_array_length(p.proven_solutions) which crashes
+-- when proven_solutions is a scalar (string, object, number) instead of a JSON array.
+-- Error: "cannot get array length of a scalar"
+--
+-- Fix: Guard with jsonb_typeof() = 'array' check before calling jsonb_array_length()
+
+CREATE OR REPLACE VIEW v_patterns_with_decay AS
+SELECT
+    p.*,
+    EXTRACT(DAY FROM NOW() - COALESCE(p.updated_at, p.created_at)) AS days_since_update,
+
+    -- Severity weight calculation
+    CASE LOWER(COALESCE(p.severity, 'unknown'))
+        WHEN 'critical' THEN 10
+        WHEN 'high' THEN 5
+        WHEN 'medium' THEN 2
+        WHEN 'low' THEN 1
+        ELSE 1  -- unknown/null defaults to low
+    END AS severity_weight,
+
+    -- Composite score: severity_weight*20 + occurrence_count*5 + actionability_bonus
+    -- actionability_bonus: 15 if proven_solutions is a non-empty array, 0 otherwise
+    (
+        CASE LOWER(COALESCE(p.severity, 'unknown'))
+            WHEN 'critical' THEN 10
+            WHEN 'high' THEN 5
+            WHEN 'medium' THEN 2
+            WHEN 'low' THEN 1
+            ELSE 1
+        END * 20
+        + (COALESCE(p.occurrence_count, 1) * 5)
+        + CASE
+            WHEN p.proven_solutions IS NOT NULL
+                 AND jsonb_typeof(p.proven_solutions) = 'array'
+                 AND jsonb_array_length(p.proven_solutions) > 0
+            THEN 15
+            ELSE 0
+          END
+    ) AS composite_score,
+
+    -- Legacy decay_adjusted_confidence (kept for backward compatibility)
+    ROUND(
+        (50 + (COALESCE(p.occurrence_count, 1) * 5)) *
+        EXP(-0.023 * EXTRACT(DAY FROM NOW() - COALESCE(p.updated_at, p.created_at)))
+    )::INTEGER AS decay_adjusted_confidence,
+
+    -- Recency status
+    CASE
+        WHEN EXTRACT(DAY FROM NOW() - COALESCE(p.updated_at, p.created_at)) > 60 THEN 'stale'
+        WHEN EXTRACT(DAY FROM NOW() - COALESCE(p.updated_at, p.created_at)) > 30 THEN 'aging'
+        ELSE 'fresh'
+    END AS recency_status,
+
+    -- Minimum occurrence threshold bypass for critical/high severity
+    CASE LOWER(COALESCE(p.severity, 'unknown'))
+        WHEN 'critical' THEN 1
+        WHEN 'high' THEN 1
+        ELSE 3
+    END AS min_occurrence_threshold,
+
+    -- Flag: Does this pattern meet its severity-adjusted threshold?
+    CASE
+        WHEN LOWER(COALESCE(p.severity, 'unknown')) IN ('critical', 'high') THEN true
+        WHEN COALESCE(p.occurrence_count, 1) >= 3 THEN true
+        ELSE false
+    END AS meets_threshold
+
+FROM issue_patterns p
+WHERE p.status = 'active';
+
+COMMENT ON VIEW v_patterns_with_decay IS
+'Patterns with severity-weighted composite scoring. Critical/high severity patterns surface with 1 occurrence.
+Composite score = severity_weight*20 + occurrence_count*5 + actionability_bonus.
+Severity weights: critical=10, high=5, medium=2, low=1.
+Fix: Guards jsonb_array_length() with jsonb_typeof() check to prevent scalar crashes.';
+
+-- Verification: This should not crash even if proven_solutions contains non-array values
+-- SELECT pattern_id, severity, composite_score, proven_solutions,
+--        jsonb_typeof(proven_solutions) as solutions_type
+-- FROM v_patterns_with_decay
+-- ORDER BY composite_score DESC
+-- LIMIT 10;

--- a/lib/sub-agents/retro/generators.js
+++ b/lib/sub-agents/retro/generators.js
@@ -56,8 +56,12 @@ export function generateRetrospective(sdData, prdData, handoffs, subAgentResults
   const protocolImprovements = generateProtocolImprovements(sdData, prdData, handoffs, subAgentResults, whatNeedsImprovement);
   const actionItems = generateSmartActionItems(sdData, prdData, handoffs, subAgentResults, whatNeedsImprovement, protocolImprovements);
 
+  // SD-LEARN-FIX-011: Only add protocol improvement action item if there are
+  // specific, non-generic improvements to apply. Summarize actual categories
+  // instead of generic "Apply N improvement(s)" which triggers boilerplate detection.
   if (protocolImprovements.length > 0) {
-    actionItems.push(`Apply ${protocolImprovements.length} LEO Protocol improvement(s) to leo_protocol_sections table`);
+    const categories = [...new Set(protocolImprovements.map(i => i.category))];
+    actionItems.push(`Address ${protocolImprovements.length} protocol finding(s) in: ${categories.join(', ')}`);
   }
 
   const improvementAreas = generateImprovementAreas(sdData, prdData, handoffs, subAgentResults, whatNeedsImprovement, testEvidence);

--- a/lib/sub-agents/testing/index.js
+++ b/lib/sub-agents/testing/index.js
@@ -161,7 +161,13 @@ export async function execute(sdId, subAgent, options = {}) {
     results.findings.phase4_evidence = phase4;
 
     // Phase 4.5: User Story Verification
-    const phase4_5 = await verifyUserStories(sdId, supabase);
+    // SD-LEARN-FIX-011: Pass sdType so exempt types skip e2e_test_path requirement
+    const { data: sdTypeData } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_type')
+      .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
+      .single();
+    const phase4_5 = await verifyUserStories(sdId, supabase, { sdType: sdTypeData?.sd_type || '' });
     if (!phase4_5.verified && phase4_5.incomplete?.length > 0) {
       results.critical_issues.push({
         severity: 'CRITICAL',

--- a/lib/sub-agents/testing/phases/phase4-evidence.js
+++ b/lib/sub-agents/testing/phases/phase4-evidence.js
@@ -48,9 +48,11 @@ export async function collectEvidence(sdId, phase3Results) {
  * Verify user stories for Phase 4.5
  * @param {string} sdId - Strategic Directive ID
  * @param {Object} supabase - Supabase client
+ * @param {Object} [options] - Verification options
+ * @param {string} [options.sdType] - SD type (e.g., 'uat', 'infrastructure', 'documentation')
  * @returns {Promise<Object>} User story verification results
  */
-export async function verifyUserStories(sdId, supabase) {
+export async function verifyUserStories(sdId, supabase, options = {}) {
   console.log('\n📋 Phase 4.5: User Story Verification...');
 
   const { data: stories, error: storyError } = await supabase
@@ -75,12 +77,19 @@ export async function verifyUserStories(sdId, supabase) {
     };
   }
 
+  // SD types that verify existing functionality rather than implementing new stories
+  // These don't require e2e_test_path mapping since they validate, not create
+  const E2E_EXEMPT_SD_TYPES = ['uat', 'infrastructure', 'documentation', 'docs', 'orchestrator'];
+  const sdType = (options.sdType || '').toLowerCase();
+  const requireE2EMapping = !E2E_EXEMPT_SD_TYPES.includes(sdType);
+
   // A story is complete if:
   // 1. status is 'completed' or 'validated'
-  // 2. AND (e2e_test_status = 'passing' OR validation_status = 'validated')
+  // 2. AND e2e_test_path exists (unless sd_type is exempt)
+  // 3. AND (e2e_test_status = 'passing' OR validation_status = 'validated')
   const incomplete = stories.filter(s =>
     !['completed', 'validated'].includes(s.status) ||
-    !s.e2e_test_path ||
+    (requireE2EMapping && !s.e2e_test_path) ||
     (s.e2e_test_status !== 'passing' && s.validation_status !== 'validated')
   );
 

--- a/scripts/modules/learning/index.js
+++ b/scripts/modules/learning/index.js
@@ -108,6 +108,18 @@ async function autoApproveCommand(threshold = 50, sdId = null) {
     qualifying.push(improvement);
   }
 
+  // SD-LEARN-FIX-011: Include sub-agent learnings (SAL-* items)
+  // These were previously invisible to auto-approve, causing silent drops
+  for (const sal of (reviewed.sub_agent_learnings || [])) {
+    // SAL items with high confidence (>=threshold) are auto-approved
+    const score = sal.confidence || 0;
+    if (score >= threshold) {
+      qualifying.push(sal);
+    } else {
+      deferred.push({ ...sal, reason: `confidence ${score} < ${threshold}` });
+    }
+  }
+
   // Display what was found
   console.log('  ' + '-'.repeat(40));
   console.log(`  Items found:       ${qualifying.length + deferred.length}`);


### PR DESCRIPTION
## Summary
- Fix `v_patterns_with_decay` view crash: guard `jsonb_array_length()` with `jsonb_typeof()` check to prevent "cannot get array length of a scalar" error
- Add sd_type awareness to TESTING sub-agent `verifyUserStories`: UAT/infrastructure/documentation SDs skip `e2e_test_path` requirement
- Replace generic RETRO action item ("Apply N improvements") with category-specific summary to avoid boilerplate detection
- Fix SAL apply gap: `executeSDCreationWorkflow` and `autoApproveCommand` now search `sub_agent_learnings`, `feedback_learnings`, and `feedback_patterns`
- Widen `context-builder.js` fallback to catch scalar/array errors gracefully when view has data issues

## Test plan
- [x] Migration executed and verified - view returns correct composite scores
- [x] All JS files pass syntax check (`node -c`)
- [x] Smoke tests pass (15/15)
- [x] ESLint auto-fix clean
- [x] DOCMON compliance check passed
- [x] Gate 0 validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)