### PR TITLE
fix(PAT-MSESS-BYP-001): blocking multi-session claim conflict gate

### DIFF
--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -1,0 +1,148 @@
+/**
+ * Multi-Session Claim Conflict Gate
+ * PAT-MSESS-BYP-001 corrective action
+ *
+ * BLOCKING gate that prevents handoff execution when the target SD
+ * is already claimed by another active session. This prevents duplicate
+ * work across concurrent Claude Code instances.
+ *
+ * Previously, _claimSDForSession() in BaseExecutor only WARNED about
+ * conflicts but proceeded anyway. This gate makes claim conflicts a
+ * hard block.
+ *
+ * Checks:
+ *   1. Query v_active_sessions for the SD
+ *   2. If claimed by another session with active heartbeat → BLOCK
+ *   3. If claimed by THIS session → PASS
+ *   4. If unclaimed or stale claim → PASS
+ */
+
+/**
+ * Validate that no other active session has claimed this SD
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdId - SD identifier (sd_key like "SD-XXX-001" or UUID)
+ * @param {Object} [options] - Options
+ * @param {string} [options.currentSessionId] - This session's ID (to exclude self)
+ * @returns {Promise<Object>} Gate result { pass, score, max_score, issues, warnings, claimDetails }
+ */
+export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
+  const currentSessionId = options.currentSessionId || null;
+
+  console.log('\n🔒 GATE: Multi-Session Claim Conflict Check');
+  console.log('-'.repeat(50));
+  console.log(`   SD: ${sdId}`);
+
+  try {
+    // Query v_active_sessions for any active claim on this SD
+    const { data, error } = await supabase
+      .from('v_active_sessions')
+      .select('session_id, sd_id, sd_title, hostname, tty, heartbeat_age_human, heartbeat_age_seconds, computed_status, codebase')
+      .eq('sd_id', sdId)
+      .in('computed_status', ['active']);
+
+    if (error) {
+      // DB error → fail-open (don't block on infrastructure issues)
+      console.log(`   ⚠️  Could not check session claims: ${error.message}`);
+      console.log('   → Proceeding (fail-open on DB error)');
+      return {
+        pass: true,
+        score: 80,
+        max_score: 100,
+        issues: [],
+        warnings: [`Could not verify session claims: ${error.message}`]
+      };
+    }
+
+    // Filter out our own session
+    const otherClaims = (data || []).filter(
+      claim => claim.session_id !== currentSessionId
+    );
+
+    if (otherClaims.length === 0) {
+      console.log('   ✅ No conflicting session claims found');
+      return {
+        pass: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings: []
+      };
+    }
+
+    // Another active session has this SD claimed → BLOCK
+    const claim = otherClaims[0];
+
+    console.log('');
+    console.log('   ┌─────────────────────────────────────────────────────────────┐');
+    console.log('   │  🚫 BLOCKED: SD CLAIMED BY ANOTHER ACTIVE SESSION           │');
+    console.log('   ├─────────────────────────────────────────────────────────────┤');
+    console.log(`   │  SD:         ${sdId}`);
+    console.log(`   │  Session:    ${claim.session_id?.substring(0, 36) || 'unknown'}`);
+    console.log(`   │  Hostname:   ${claim.hostname || 'unknown'}`);
+    console.log(`   │  TTY:        ${claim.tty || 'unknown'}`);
+    console.log(`   │  Heartbeat:  ${claim.heartbeat_age_human || 'unknown'}`);
+    console.log(`   │  Codebase:   ${claim.codebase || 'unknown'}`);
+    console.log('   ├─────────────────────────────────────────────────────────────┤');
+    console.log('   │  Another Claude Code instance is actively working on this   │');
+    console.log('   │  SD. Starting work here would cause duplicate effort.       │');
+    console.log('   │                                                             │');
+    console.log('   │  OPTIONS:                                                   │');
+    console.log('   │  1. Pick a different SD (run npm run sd:next)               │');
+    console.log('   │  2. Wait for the other session to finish                    │');
+    console.log('   │  3. Release the claim in the other session first            │');
+    console.log('   └─────────────────────────────────────────────────────────────┘');
+    console.log('');
+
+    return {
+      pass: false,
+      score: 0,
+      max_score: 100,
+      issues: [
+        `SD ${sdId} is claimed by another active session (${claim.hostname || 'unknown'}, heartbeat: ${claim.heartbeat_age_human || 'unknown'})`
+      ],
+      warnings: [],
+      claimDetails: {
+        sessionId: claim.session_id,
+        hostname: claim.hostname,
+        tty: claim.tty,
+        heartbeatAgeHuman: claim.heartbeat_age_human,
+        heartbeatAgeSeconds: claim.heartbeat_age_seconds,
+        codebase: claim.codebase
+      }
+    };
+  } catch (err) {
+    // Unexpected error → fail-open
+    console.log(`   ⚠️  Claim check error: ${err.message}`);
+    console.log('   → Proceeding (fail-open on unexpected error)');
+    return {
+      pass: true,
+      score: 80,
+      max_score: 100,
+      issues: [],
+      warnings: [`Multi-session claim check failed: ${err.message}`]
+    };
+  }
+}
+
+/**
+ * Create Multi-Session Claim Conflict Gate for handoff integration
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdId - SD identifier
+ * @param {Object} [options] - Options including currentSessionId
+ * @returns {Object} Gate configuration
+ */
+export function createMultiSessionClaimGate(supabase, sdId, options = {}) {
+  return {
+    name: 'GATE_MULTI_SESSION_CLAIM_CONFLICT',
+    validator: async () => {
+      return validateMultiSessionClaim(supabase, sdId, options);
+    },
+    required: true,
+    blocking: true,
+    remediation: `SD ${sdId} is claimed by another active session. Pick a different SD with 'npm run sd:next' or release the claim in the other session.`
+  };
+}
+
+export default { validateMultiSessionClaim, createMultiSessionClaimGate };

--- a/tests/unit/multi-session-claim-gate.test.js
+++ b/tests/unit/multi-session-claim-gate.test.js
@@ -1,0 +1,180 @@
+/**
+ * Tests for Multi-Session Claim Conflict Gate
+ * PAT-MSESS-BYP-001 corrective action
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  validateMultiSessionClaim,
+  createMultiSessionClaimGate
+} from '../../scripts/modules/handoff/gates/multi-session-claim-gate.js';
+
+// Helper: mock Supabase that returns active session data
+function createMockSupabase(sessions = []) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          in: vi.fn().mockResolvedValue({ data: sessions, error: null })
+        })
+      })
+    })
+  };
+}
+
+// Helper: mock Supabase that returns a DB error
+function createErrorSupabase(message = 'Connection refused') {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          in: vi.fn().mockResolvedValue({ data: null, error: { message } })
+        })
+      })
+    })
+  };
+}
+
+describe('Multi-Session Claim Conflict Gate', () => {
+  describe('validateMultiSessionClaim', () => {
+    it('should PASS when no sessions claim the SD', async () => {
+      const supabase = createMockSupabase([]);
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001');
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(100);
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it('should BLOCK when another active session claims the SD', async () => {
+      const sessions = [{
+        session_id: 'other-session-123',
+        sd_id: 'SD-TEST-001',
+        sd_title: 'Test SD',
+        hostname: 'DESKTOP-ABC',
+        tty: '/dev/pts/1',
+        heartbeat_age_human: '30s ago',
+        heartbeat_age_seconds: 30,
+        computed_status: 'active',
+        codebase: 'EHG_Engineer'
+      }];
+
+      const supabase = createMockSupabase(sessions);
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
+        currentSessionId: 'my-session-456'
+      });
+
+      expect(result.pass).toBe(false);
+      expect(result.score).toBe(0);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]).toContain('claimed by another active session');
+      expect(result.claimDetails.sessionId).toBe('other-session-123');
+      expect(result.claimDetails.hostname).toBe('DESKTOP-ABC');
+    });
+
+    it('should PASS when the only claim is from the current session', async () => {
+      const sessions = [{
+        session_id: 'my-session-456',
+        sd_id: 'SD-TEST-001',
+        sd_title: 'Test SD',
+        hostname: 'DESKTOP-ABC',
+        tty: '/dev/pts/0',
+        heartbeat_age_human: '10s ago',
+        heartbeat_age_seconds: 10,
+        computed_status: 'active',
+        codebase: 'EHG_Engineer'
+      }];
+
+      const supabase = createMockSupabase(sessions);
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
+        currentSessionId: 'my-session-456'
+      });
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(100);
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it('should fail-open on DB error (score 80)', async () => {
+      const supabase = createErrorSupabase('Connection refused');
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001');
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(80);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('Connection refused');
+    });
+
+    it('should fail-open on unexpected exception', async () => {
+      const supabase = {
+        from: vi.fn().mockImplementation(() => {
+          throw new Error('Unexpected crash');
+        })
+      };
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001');
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(80);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain('Unexpected crash');
+    });
+
+    it('should PASS when no currentSessionId provided and no claims exist', async () => {
+      const supabase = createMockSupabase([]);
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001');
+
+      expect(result.pass).toBe(true);
+    });
+
+    it('should BLOCK even without currentSessionId when another session claims', async () => {
+      const sessions = [{
+        session_id: 'other-session-123',
+        sd_id: 'SD-TEST-001',
+        sd_title: 'Test SD',
+        hostname: 'DESKTOP-ABC',
+        tty: '/dev/pts/1',
+        heartbeat_age_human: '1m ago',
+        heartbeat_age_seconds: 60,
+        computed_status: 'active',
+        codebase: 'EHG_Engineer'
+      }];
+
+      const supabase = createMockSupabase(sessions);
+
+      // No currentSessionId → cannot exclude self → blocks on any active claim
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001');
+
+      expect(result.pass).toBe(false);
+      expect(result.issues).toHaveLength(1);
+    });
+  });
+
+  describe('createMultiSessionClaimGate', () => {
+    it('should create a gate with correct name and properties', () => {
+      const supabase = createMockSupabase([]);
+      const gate = createMultiSessionClaimGate(supabase, 'SD-TEST-001');
+
+      expect(gate.name).toBe('GATE_MULTI_SESSION_CLAIM_CONFLICT');
+      expect(gate.required).toBe(true);
+      expect(gate.blocking).toBe(true);
+      expect(typeof gate.validator).toBe('function');
+      expect(gate.remediation).toContain('SD-TEST-001');
+    });
+
+    it('should execute validator and return results', async () => {
+      const supabase = createMockSupabase([]);
+      const gate = createMultiSessionClaimGate(supabase, 'SD-TEST-001');
+
+      const result = await gate.validator();
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GATE_MULTI_SESSION_CLAIM_CONFLICT` as a blocking pre-check in `BaseExecutor.execute()` (Step 1.8)
- Prevents handoff execution when another active Claude Code session has claimed the target SD
- Previously `_claimSDForSession()` only warned about conflicts — now it hard-blocks before any work begins
- Fail-open on DB errors (proceeds with warning, score 80)
- Self-exclusion: current session's own claims pass through

## Root Cause (PAT-MSESS-BYP-001)
When `sd:next` timed out, the agent fell back to a raw DB query that bypassed multi-session claim checks, leading to attempted duplicate work on an SD already being worked on by another Claude Code instance.

## Test plan
- [x] 9 unit tests covering: block, pass, self-exclusion, fail-open DB error, fail-open exception, no-session edge cases, gate factory
- [x] Gate policy resolver regression tests (9/9 pass)
- [x] Smoke tests (15/15 pass)
- [x] Syntax check on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)