### PR TITLE
fix(SD-LEARN-FIX-001): fix 3 critical handoff/gate validation patterns

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -219,7 +219,8 @@ export class PlanToExecExecutor extends BaseExecutor {
     await transitionSdToExec(this.supabase, sdId, sd);
 
     // Display EXEC phase requirements (proactive guidance)
-    await displayExecPhaseRequirements(this.supabase, sdId, prd);
+    // PAT-E2E-STATUS-001: Pass SD type so E2E requirements are skipped for infra SDs
+    await displayExecPhaseRequirements(this.supabase, sdId, prd, { sdType: sd?.sd_type });
 
     // Merge validation details
     const branchResults = gateResults.gateResults.GATE6_BRANCH_ENFORCEMENT?.details || {};

--- a/tests/unit/display-helpers-e2e-infra.test.js
+++ b/tests/unit/display-helpers-e2e-infra.test.js
@@ -1,0 +1,94 @@
+/**
+ * Tests for PAT-E2E-STATUS-001 fix: Display helpers E2E requirements
+ *
+ * Validates that displayExecPhaseRequirements skips E2E test requirements
+ * for infrastructure SD types.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { displayExecPhaseRequirements } from '../../scripts/modules/handoff/executors/plan-to-exec/display-helpers.js';
+
+// Capture console.log output
+let logOutput = [];
+const originalLog = console.log;
+
+function createMockSupabase(stories = []) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({
+            data: stories,
+            error: null
+          })
+        })
+      })
+    })
+  };
+}
+
+describe('PAT-E2E-STATUS-001: Display Helpers E2E for Infra SDs', () => {
+  beforeEach(() => {
+    logOutput = [];
+    console.log = (...args) => {
+      logOutput.push(args.join(' '));
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+  });
+
+  const storiesWithoutE2E = [
+    { id: '1', title: 'Story 1', status: 'in_progress', e2e_test_path: null, e2e_test_status: null },
+    { id: '2', title: 'Story 2', status: 'in_progress', e2e_test_path: null, e2e_test_status: null }
+  ];
+
+  it('should show E2E requirements for feature SDs', async () => {
+    const supabase = createMockSupabase(storiesWithoutE2E);
+
+    await displayExecPhaseRequirements(supabase, 'test-sd', null, { sdType: 'feature' });
+
+    const output = logOutput.join('\n');
+    expect(output).toContain('Create E2E tests');
+    expect(output).toContain('e2e_test_status');
+    expect(output).not.toContain('NOT REQUIRED');
+  });
+
+  it('should skip E2E requirements for infrastructure SDs', async () => {
+    const supabase = createMockSupabase(storiesWithoutE2E);
+
+    await displayExecPhaseRequirements(supabase, 'test-sd', null, { sdType: 'infrastructure' });
+
+    const output = logOutput.join('\n');
+    expect(output).toContain('NOT REQUIRED');
+    expect(output).not.toContain('Create E2E tests');
+  });
+
+  it('should skip E2E requirements for documentation SDs', async () => {
+    const supabase = createMockSupabase(storiesWithoutE2E);
+
+    await displayExecPhaseRequirements(supabase, 'test-sd', null, { sdType: 'documentation' });
+
+    const output = logOutput.join('\n');
+    expect(output).toContain('NOT REQUIRED');
+  });
+
+  it('should skip E2E requirements for uat SDs', async () => {
+    const supabase = createMockSupabase(storiesWithoutE2E);
+
+    await displayExecPhaseRequirements(supabase, 'test-sd', null, { sdType: 'uat' });
+
+    const output = logOutput.join('\n');
+    expect(output).toContain('NOT REQUIRED');
+  });
+
+  it('should show E2E requirements when no sdType provided (default behavior)', async () => {
+    const supabase = createMockSupabase(storiesWithoutE2E);
+
+    await displayExecPhaseRequirements(supabase, 'test-sd', null);
+
+    const output = logOutput.join('\n');
+    expect(output).toContain('Create E2E tests');
+  });
+});

--- a/tests/unit/gate4-bypass-acceptance.test.js
+++ b/tests/unit/gate4-bypass-acceptance.test.js
@@ -1,0 +1,156 @@
+/**
+ * Tests for PAT-GATE4-BYPASS-001 fix: Gate 4 bypass acceptance
+ *
+ * Validates that Gate 4 (workflow ROI validation) correctly credits
+ * governance-approved bypasses as valid gate completions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateGate4LeadFinal } from '../../scripts/modules/workflow-roi-validation.js';
+
+// Mock child_process and adaptive-threshold-calculator
+vi.mock('child_process', () => ({
+  exec: vi.fn((cmd, cb) => cb && cb(null, '', ''))
+}));
+vi.mock('util', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    promisify: (fn) => vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+  };
+});
+vi.mock('../../scripts/modules/adaptive-threshold-calculator.js', () => ({
+  calculateAdaptiveThreshold: vi.fn().mockResolvedValue({ threshold: 60 })
+}));
+vi.mock('../../scripts/modules/pattern-tracking.js', () => ({
+  getPatternStats: vi.fn().mockResolvedValue({ total: 0, resolved: 0 })
+}));
+
+function createMockSupabase({ prdData = null, handoffs = [], retroData = null } = {}) {
+  const mockSingle = (data) => ({
+    data,
+    error: data ? null : { message: 'Not found', code: 'PGRST116' }
+  });
+
+  return {
+    from: vi.fn((table) => {
+      if (table === 'product_requirements_v2') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue(mockSingle(prdData))
+            })
+          })
+        };
+      }
+      if (table === 'sd_phase_handoffs') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: handoffs, error: null }),
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue({ data: [], error: null })
+                })
+              })
+            })
+          })
+        };
+      }
+      if (table === 'retrospectives') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue(mockSingle(retroData))
+            })
+          })
+        };
+      }
+      // Default: empty results
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: null }),
+            order: vi.fn().mockResolvedValue({ data: [], error: null })
+          })
+        })
+      };
+    })
+  };
+}
+
+describe('PAT-GATE4-BYPASS-001: Gate 4 Bypass Acceptance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should give full D1 credit when all gates passed directly', async () => {
+    const gateResults = {
+      gate1: { passed: true, score: 95 },
+      gate2: { passed: true, score: 90 },
+      gate3: { passed: true, score: 85 }
+    };
+
+    const supabase = createMockSupabase({
+      prdData: {
+        metadata: { design_analysis: { exists: true } },
+        directive_id: 'test-sd',
+        title: 'Test',
+        created_at: new Date().toISOString()
+      },
+      retroData: { id: 'retro-1', quality_score: 80 }
+    });
+
+    const result = await validateGate4LeadFinal('test-sd', supabase, gateResults);
+
+    // Section D1 should get full 10 points
+    expect(result.details.executive_validation?.gates_passed).toBe(3);
+  });
+
+  it('should credit bypassed handoffs as accepted in D1', async () => {
+    // Gates show passed=false (because bypass overrode them)
+    // But handoffs are accepted
+    const gateResults = {};
+
+    const handoffs = [
+      { handoff_type: 'PLAN-TO-EXEC', status: 'accepted', metadata: { gate1_validation: { passed: false, score: 50 } }, created_at: '2026-01-01' },
+      { handoff_type: 'EXEC-TO-PLAN', status: 'accepted', metadata: { gate2_validation: { passed: false, score: 60 } }, created_at: '2026-01-02' },
+      { handoff_type: 'PLAN-TO-LEAD', status: 'accepted', metadata: { gate3_validation: { passed: false, score: 55 } }, created_at: '2026-01-03' }
+    ];
+
+    const supabase = createMockSupabase({
+      prdData: {
+        metadata: { design_analysis: { exists: true } },
+        directive_id: 'test-sd',
+        title: 'Test',
+        created_at: new Date().toISOString()
+      },
+      handoffs,
+      retroData: { id: 'retro-1', quality_score: 80 }
+    });
+
+    const result = await validateGate4LeadFinal('test-sd', supabase, gateResults);
+
+    // gates_passed should be 0 (none truly passed)
+    // But gates_accepted_with_bypass should be 3
+    expect(result.details.executive_validation?.gates_passed).toBe(0);
+    expect(result.details.executive_validation?.gates_accepted_with_bypass).toBe(3);
+  });
+
+  it('should return score 100 when no design/database analysis found', async () => {
+    const supabase = createMockSupabase({
+      prdData: {
+        metadata: {},  // No design or database analysis
+        directive_id: 'test-sd',
+        title: 'Test',
+        created_at: new Date().toISOString()
+      }
+    });
+
+    const result = await validateGate4LeadFinal('test-sd', supabase, {});
+
+    // Should auto-pass (Gate 4 is only for design/database pattern)
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+  });
+});

--- a/tests/unit/transition-readiness-rejection.test.js
+++ b/tests/unit/transition-readiness-rejection.test.js
@@ -1,0 +1,118 @@
+/**
+ * Tests for PAT-HANDOFF-PHZ-001 fix: Transition readiness rejection check
+ *
+ * Validates that the transition readiness gate correctly queries sd_phase_handoffs
+ * (not the non-existent sd_handoffs table) and uses correct lowercase status values.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { validateTransitionReadiness } from '../../scripts/modules/handoff/executors/lead-to-plan/gates/transition-readiness.js';
+
+// Mock quickPreflightCheck to avoid import side effects
+vi.mock('../../scripts/lib/handoff-preflight.js', () => ({
+  quickPreflightCheck: vi.fn().mockResolvedValue({ ready: true })
+}));
+
+// Helper: create a valid SD object
+function createSD(overrides = {}) {
+  return {
+    id: 'test-sd-uuid',
+    sd_key: 'SD-TEST-001',
+    title: 'Test SD',
+    description: 'A test strategic directive',
+    status: 'active',
+    success_metrics: [{ metric: 'test', target: '100%' }],
+    ...overrides
+  };
+}
+
+// Helper: mock Supabase with chainable API
+function createMockSupabase(handoffs = [], handoffError = null) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            in: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({
+                  data: handoffs,
+                  error: handoffError
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  };
+}
+
+describe('PAT-HANDOFF-PHZ-001: Transition Readiness Rejection Check', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should query sd_phase_handoffs table (not sd_handoffs)', async () => {
+    const supabase = createMockSupabase([]);
+    const sd = createSD();
+
+    await validateTransitionReadiness(sd, supabase);
+
+    // Verify the correct table is queried
+    expect(supabase.from).toHaveBeenCalledWith('sd_phase_handoffs');
+  });
+
+  it('should PASS when no previous rejected handoffs exist', async () => {
+    const supabase = createMockSupabase([]);
+    const sd = createSD();
+
+    const result = await validateTransitionReadiness(sd, supabase);
+
+    expect(result.pass).toBe(true);
+    expect(result.issues.filter(i => i.includes('REJECTED'))).toHaveLength(0);
+  });
+
+  it('should BLOCK when previous LEAD-TO-PLAN handoff was rejected (lowercase)', async () => {
+    const rejectedHandoffs = [{
+      id: 'handoff-123',
+      status: 'rejected',
+      created_at: new Date().toISOString(),
+      rejection_reason: 'Gate validation failed'
+    }];
+
+    const supabase = createMockSupabase(rejectedHandoffs);
+    const sd = createSD();
+
+    const result = await validateTransitionReadiness(sd, supabase);
+
+    // Should have blocking issues due to rejected handoff
+    expect(result.pass).toBe(false);
+    expect(result.issues.some(i => i.includes('REJECTED'))).toBe(true);
+  });
+
+  it('should handle database errors gracefully', async () => {
+    // Make the chain throw to exercise the catch block
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockRejectedValue(new Error('Connection refused'))
+                })
+              })
+            })
+          })
+        })
+      })
+    };
+    const sd = createSD();
+
+    const result = await validateTransitionReadiness(sd, supabase);
+
+    // Should not crash - adds warning instead
+    expect(result.warnings.some(w => w.includes('Could not check'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- **PAT-HANDOFF-PHZ-001**: Fixed transition-readiness gate querying non-existent `sd_handoffs` table (correct: `sd_phase_handoffs`) and using uppercase status values (correct: lowercase). Handoff rejections now properly block subsequent attempts.
- **PAT-E2E-STATUS-001**: Made `displayExecPhaseRequirements` SD-type-aware. Infrastructure, documentation, orchestrator, discovery_spike, uat, and refactor SDs now skip E2E test requirements that could never be satisfied.
- **PAT-GATE4-BYPASS-001**: Added bypass tracking in Gate 4 Section D1. Governance-approved bypasses now receive credit, preventing false rejection at LEAD-FINAL-APPROVAL.

## Test plan
- [x] 4 tests for transition-readiness rejection check (table name, pass/block, error handling)
- [x] 5 tests for display-helpers E2E infra types (feature shows E2E, infra/docs/uat skip)
- [x] 3 tests for Gate 4 bypass acceptance (direct pass, bypass credit, auto-pass)
- [x] All 12 tests passing
- [x] Smoke tests passing (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)