### PR TITLE
fix: sanitize Unicode surrogates before LLM API calls

### DIFF
--- a/lib/sub-agents/modules/stories/llm-story-generator.js
+++ b/lib/sub-agents/modules/stories/llm-story-generator.js
@@ -460,12 +460,16 @@ JSON response:`;
     let lastError;
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
+        // Sanitize prompt to remove invalid Unicode surrogates that cause JSON serialization errors
+        const sanitizedPrompt = typeof prompt === 'string' ? prompt.replace(
+          /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '\uFFFD'
+        ) : prompt;
         const response = await this.client.messages.create({
           model: this.model,
           max_tokens: maxTokens,
           temperature: temperature,
           messages: [
-            { role: 'user', content: prompt }
+            { role: 'user', content: sanitizedPrompt }
           ],
         });
 

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -31,6 +31,40 @@ function sleep(ms) {
 }
 
 /**
+ * Sanitize string by removing invalid Unicode surrogates.
+ * Prevents JSON serialization errors when sending to LLM APIs.
+ *
+ * Node.js JSON.stringify encodes lone surrogates as \uDXXX which is
+ * invalid JSON per RFC 8259. API servers (Anthropic, OpenAI) reject these.
+ *
+ * @param {string} value - String to sanitize
+ * @returns {string} Sanitized string with invalid surrogates replaced by U+FFFD
+ */
+function sanitizeUnicode(value) {
+  if (typeof value !== 'string') return value;
+
+  let result = '';
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+
+    if (code >= 0xD800 && code <= 0xDBFF) {
+      const nextCode = value.charCodeAt(i + 1);
+      if (nextCode >= 0xDC00 && nextCode <= 0xDFFF) {
+        result += value[i] + value[i + 1];
+        i++;
+      } else {
+        result += '\uFFFD';
+      }
+    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+      result += '\uFFFD';
+    } else {
+      result += value[i];
+    }
+  }
+  return result;
+}
+
+/**
  * Anthropic Provider Adapter
  */
 export class AnthropicAdapter {
@@ -54,8 +88,8 @@ export class AnthropicAdapter {
           this.client.messages.create({
             model,
             max_tokens: options.maxTokens || 2000,
-            system: systemPrompt,
-            messages: [{ role: 'user', content: userPrompt }]
+            system: sanitizeUnicode(systemPrompt),
+            messages: [{ role: 'user', content: sanitizeUnicode(userPrompt) }]
           }),
           new Promise((_, reject) =>
             setTimeout(() => reject(new Error('TIMEOUT')), PROVIDER_TIMEOUT_MS)
@@ -121,8 +155,8 @@ export class OpenAIAdapter {
             model,
             max_tokens: options.maxTokens || 2000,
             messages: [
-              { role: 'system', content: systemPrompt },
-              { role: 'user', content: userPrompt }
+              { role: 'system', content: sanitizeUnicode(systemPrompt) },
+              { role: 'user', content: sanitizeUnicode(userPrompt) }
             ]
           }),
           signal: controller.signal
@@ -196,8 +230,8 @@ export class GoogleAdapter {
               'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-              systemInstruction: { parts: [{ text: systemPrompt }] },
-              contents: [{ parts: [{ text: userPrompt }] }],
+              systemInstruction: { parts: [{ text: sanitizeUnicode(systemPrompt) }] },
+              contents: [{ parts: [{ text: sanitizeUnicode(userPrompt) }] }],
               generationConfig: {
                 maxOutputTokens: options.maxTokens || 2000
               }
@@ -312,8 +346,8 @@ export class OllamaAdapter {
             max_tokens: options.maxTokens || 2000,
             temperature: options.temperature ?? 0.1,
             messages: [
-              { role: 'system', content: systemPrompt },
-              { role: 'user', content: userPrompt }
+              { role: 'system', content: sanitizeUnicode(systemPrompt) },
+              { role: 'user', content: sanitizeUnicode(userPrompt) }
             ]
           }),
           signal: controller.signal


### PR DESCRIPTION
## Summary
- Add Unicode surrogate sanitization to all 4 LLM provider adapters (Anthropic, OpenAI, Google, Ollama) in `provider-adapters.js`
- Fix `cli-main.js` output sanitizer's object handling — the previous JSON round-trip was ineffective because ES2019 `JSON.stringify` escapes surrogates as ASCII, bypassing detection
- Add surrogate sanitization to direct `messages.create()` call in `llm-story-generator.js`

## Root Cause
Database content (SD JSONB fields) can contain unpaired UTF-16 surrogates. When included in LLM API request bodies, Node.js `JSON.stringify` encodes them as `\uDXXX` which is invalid JSON per RFC 8259. The Anthropic API correctly rejects these with "invalid high surrogate in string".

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint auto-fix clean
- [x] No secrets detected
- [ ] Verify handoff LEAD-TO-PLAN no longer triggers surrogate API errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)