### PR TITLE
fix: correct catch variable name in GitCommitVerifier

### DIFF
--- a/scripts/verify-git-commit-status.js
+++ b/scripts/verify-git-commit-status.js
@@ -72,7 +72,7 @@ class GitCommitVerifier {
     try {
       const { stdout, stderr } = await execAsync(command, { cwd: this.appPath });
       return { stdout: stdout.trim(), stderr: stderr.trim(), success: true };
-    } catch (_error) {
+    } catch (error) {
       return {
         stdout: error.stdout?.trim() || '',
         stderr: error.stderr?.trim() || error.message,


### PR DESCRIPTION
## Summary
- Fixed catch variable mismatch in `scripts/verify-git-commit-status.js` line 75-81
- The catch block declared `_error` but the body referenced `error`, causing "error is not defined" ReferenceError during git command failures
- This crashed GATE5_GIT_COMMIT_ENFORCEMENT in Check 3

## Test plan
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)