### PR TITLE
fix(handoff): auto-generate retrospective in PLAN-TO-LEAD to prevent gate failure

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -76,9 +76,8 @@ export class PlanToLeadExecutor extends BaseExecutor {
           stdio: 'pipe'
         });
 
-        let retroOutput = '';
-        retroProcess.stdout.on('data', (data) => { retroOutput += data.toString(); });
-        retroProcess.stderr.on('data', (data) => { retroOutput += data.toString(); });
+        retroProcess.stdout.on('data', () => {});
+        retroProcess.stderr.on('data', () => {});
 
         await new Promise((resolve, reject) => {
           retroProcess.on('close', (code) => {


### PR DESCRIPTION
## Summary
- Fixes PAT-WORKFLOW-GAP-001: "Validation Without Generation" pattern where gates validate retrospective existence but the workflow never generated one
- Auto-generates retrospective in PLAN-TO-LEAD executor `setup()` method (before gates run) if no retrospective exists for the SD
- Non-fatal: if generation fails, gate will still report it and user can generate manually

## Root Cause Analysis
- RCA identified that LEAD-FINAL-APPROVAL consistently failed with "No retrospective found" because no step in the workflow ever created one
- Pattern recorded as PAT-WORKFLOW-GAP-001 in issue_patterns table
- Fix is preventive: applies to ALL future SDs, not just the one that triggered the failure

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint clean
- [x] DOCMON compliance verified
- [x] Verified fix works: LEAD-FINAL-APPROVAL passed at 97% after applying this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)