### PR TITLE
refactor: re-key worktree isolation from session to SD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -704,7 +704,7 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 ```
 
 ## DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2026-02-07 6:01:34 AM
+**Last Generated**: 2026-02-07 9:17:27 AM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -22,7 +22,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-07 6:01:34 AM
+**Generated**: 2026-02-07 9:17:27 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions (15-20k chars)
 
@@ -200,6 +200,48 @@ npm run handoff:compliance SD-ID
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
+## 🤖 Built-in Agent Integration
+
+## Built-in Agent Integration
+
+### Three-Layer Agent Architecture
+
+LEO Protocol uses three complementary agent layers:
+
+| Layer | Source | Agents | Purpose |
+|-------|--------|--------|---------|
+| **Built-in** | Claude Code | `Explore`, `Plan` | Fast discovery & multi-perspective planning |
+| **Sub-Agents** | `.claude/agents/` | DATABASE, TESTING, VALIDATION, etc. | Formal validation & gate enforcement |
+| **Skills** | `~/.claude/skills/` | 54 skills | Creative guidance & patterns |
+
+### Integration Principle
+
+> **Explore** for discovery → **Sub-agents** for validation → **Skills** for implementation patterns
+
+Built-in agents run FIRST (fast, parallel exploration), then sub-agents run for formal validation (database-driven, deterministic).
+
+### When to Use Each Layer
+
+| Task | Use | Example |
+|------|-----|---------|
+| "Does this already exist?" | Explore agent | `Task(subagent_type="Explore", prompt="Search for existing auth implementations")` |
+| "What patterns do we use?" | Explore agent | `Task(subagent_type="Explore", prompt="Find component patterns in src/")` |
+| "Is this schema valid?" | Sub-agent | `node lib/sub-agent-executor.js DATABASE <SD-ID>` |
+| "How should I build this?" | Skills | `skill: "schema-design"` or `skill: "e2e-patterns"` |
+| "What are the trade-offs?" | Plan agent | Launch 2-3 Plan agents with different perspectives |
+
+### Parallel Execution
+
+Built-in agents support parallel execution. Launch multiple Explore agents in a single message:
+
+```
+Task(subagent_type="Explore", prompt="Search for existing implementations")
+Task(subagent_type="Explore", prompt="Find related patterns")
+Task(subagent_type="Explore", prompt="Identify affected areas")
+```
+
+This is faster than sequential exploration and provides comprehensive coverage.
+
 ## Mandatory Agent Invocation Rules
 
 **CRITICAL**: Certain task types REQUIRE specialized agent invocation - NO ad-hoc manual inspection allowed.
@@ -273,48 +315,6 @@ Claude Code's Plan Mode integrates with LEO Protocol to provide:
 
 ### Module Location
 `scripts/modules/plan-mode/` - LEOPlanModeOrchestrator.js, phase-permissions.js
-
-## 🤖 Built-in Agent Integration
-
-## Built-in Agent Integration
-
-### Three-Layer Agent Architecture
-
-LEO Protocol uses three complementary agent layers:
-
-| Layer | Source | Agents | Purpose |
-|-------|--------|--------|---------|
-| **Built-in** | Claude Code | `Explore`, `Plan` | Fast discovery & multi-perspective planning |
-| **Sub-Agents** | `.claude/agents/` | DATABASE, TESTING, VALIDATION, etc. | Formal validation & gate enforcement |
-| **Skills** | `~/.claude/skills/` | 54 skills | Creative guidance & patterns |
-
-### Integration Principle
-
-> **Explore** for discovery → **Sub-agents** for validation → **Skills** for implementation patterns
-
-Built-in agents run FIRST (fast, parallel exploration), then sub-agents run for formal validation (database-driven, deterministic).
-
-### When to Use Each Layer
-
-| Task | Use | Example |
-|------|-----|---------|
-| "Does this already exist?" | Explore agent | `Task(subagent_type="Explore", prompt="Search for existing auth implementations")` |
-| "What patterns do we use?" | Explore agent | `Task(subagent_type="Explore", prompt="Find component patterns in src/")` |
-| "Is this schema valid?" | Sub-agent | `node lib/sub-agent-executor.js DATABASE <SD-ID>` |
-| "How should I build this?" | Skills | `skill: "schema-design"` or `skill: "e2e-patterns"` |
-| "What are the trade-offs?" | Plan agent | Launch 2-3 Plan agents with different perspectives |
-
-### Parallel Execution
-
-Built-in agents support parallel execution. Launch multiple Explore agents in a single message:
-
-```
-Task(subagent_type="Explore", prompt="Search for existing implementations")
-Task(subagent_type="Explore", prompt="Find related patterns")
-Task(subagent_type="Explore", prompt="Identify affected areas")
-```
-
-This is faster than sequential exploration and provides comprehensive coverage.
 
 ## Work Tracking Policy
 
@@ -445,47 +445,6 @@ Before marking any stage/feature as complete:
 
 **BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
-## Sustainable Issue Resolution Philosophy
-
-**CHAIRMAN PREFERENCE**: When encountering issues, bugs, or blockers during implementation:
-
-### Core Principles
-
-1. **Handle Issues Immediately**
-   - Do NOT defer problems to "fix later" or create tech debt
-   - Address issues as they arise, before moving forward
-   - Blocking issues must be resolved before continuing
-
-2. **Resolve Systemically**
-   - Fix the root cause, not just the symptom
-   - Consider why the issue occurred and prevent recurrence
-   - Update patterns, validation rules, or documentation as needed
-
-3. **Prefer Sustainable Solutions**
-   - Choose fixes that will last, not quick patches
-   - Avoid workarounds that need to be revisited
-   - Ensure the solution integrates properly with existing architecture
-
-### Implementation Guidelines
-
-| Scenario | Wrong Approach | Right Approach |
-|----------|----------------|----------------|
-| Test failing | Skip test, add TODO | Fix underlying issue, ensure test passes |
-| Type error | Cast to `any` | Fix types properly, update interfaces |
-| Migration issue | Comment out problematic code | Fix schema, add proper handling |
-| Build warning | Suppress warning | Address root cause of warning |
-| Performance issue | Defer to "optimization SD" | Fix if simple; create SD only if complex |
-
-### Exception Handling
-
-If immediate resolution is truly impossible:
-1. Document the issue thoroughly
-2. Create a high-priority SD for resolution
-3. Add a failing test that captures the issue
-4. Note the workaround as TEMPORARY with removal timeline
-
-**Default behavior**: Resolve now, resolve properly, resolve sustainably.
-
 ## 🎯 Skill Integration (Claude Code Skills)
 
 ## Skill Integration (Claude Code Skills)
@@ -528,6 +487,47 @@ If immediate resolution is truly impossible:
 - **Project**: .claude/skills/ (project-specific)
 - **Index**: ~/.claude/skills/SKILL-INDEX.md
 - **Total**: 54 skills covering all 14 sub-agents
+
+## Sustainable Issue Resolution Philosophy
+
+**CHAIRMAN PREFERENCE**: When encountering issues, bugs, or blockers during implementation:
+
+### Core Principles
+
+1. **Handle Issues Immediately**
+   - Do NOT defer problems to "fix later" or create tech debt
+   - Address issues as they arise, before moving forward
+   - Blocking issues must be resolved before continuing
+
+2. **Resolve Systemically**
+   - Fix the root cause, not just the symptom
+   - Consider why the issue occurred and prevent recurrence
+   - Update patterns, validation rules, or documentation as needed
+
+3. **Prefer Sustainable Solutions**
+   - Choose fixes that will last, not quick patches
+   - Avoid workarounds that need to be revisited
+   - Ensure the solution integrates properly with existing architecture
+
+### Implementation Guidelines
+
+| Scenario | Wrong Approach | Right Approach |
+|----------|----------------|----------------|
+| Test failing | Skip test, add TODO | Fix underlying issue, ensure test passes |
+| Type error | Cast to `any` | Fix types properly, update interfaces |
+| Migration issue | Comment out problematic code | Fix schema, add proper handling |
+| Build warning | Suppress warning | Address root cause of warning |
+| Performance issue | Defer to "optimization SD" | Fix if simple; create SD only if complex |
+
+### Exception Handling
+
+If immediate resolution is truly impossible:
+1. Document the issue thoroughly
+2. Create a high-priority SD for resolution
+3. Add a failing test that captures the issue
+4. Note the workaround as TEMPORARY with removal timeline
+
+**Default behavior**: Resolve now, resolve properly, resolve sustainably.
 
 ## 🚫 Stage 7 Hard Block: UI Coverage Prerequisite
 
@@ -574,38 +574,6 @@ To request an exception to this block:
 
 **No exceptions without explicit LEAD approval.**
 
-## Child SD Pre-Work Validation (MANDATORY)
-
-**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
-
-### Validation Command
-```bash
-node scripts/child-sd-preflight.js SD-XXX-001
-```
-
-### What It Checks
-1. **Is Child SD**: Verifies the SD has a parent_sd_id
-2. **Dependency Chain**: For each dependency SD:
-   - Status must be `completed`
-   - Progress must be `100%`
-   - Required handoffs must be present
-3. **Parent Context**: Loads parent orchestrator for reference
-
-### Results
-**PASS** - Ready to work if:
-- SD is standalone (not a child), OR
-- No dependencies, OR
-- All dependencies complete with required handoffs
-
-**BLOCKED** - Cannot proceed if:
-- One or more dependency SDs incomplete
-- Missing required handoffs on dependencies
-- Action: Complete blocking dependency first
-
-### Integration
-- `npm run sd:next` shows dependency status in queue
-- Child SDs with incomplete dependencies show as BLOCKED
-
 ## Global Negative Constraints
 
 These anti-patterns apply across ALL phases. Violating them leads to failed handoffs and rework.
@@ -638,6 +606,38 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 - `node scripts/handoff.js execute ...`
 - `node scripts/add-prd-to-database.js ...`
 - `node scripts/phase-preflight.js ...`
+
+## Child SD Pre-Work Validation (MANDATORY)
+
+**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
+
+### Validation Command
+```bash
+node scripts/child-sd-preflight.js SD-XXX-001
+```
+
+### What It Checks
+1. **Is Child SD**: Verifies the SD has a parent_sd_id
+2. **Dependency Chain**: For each dependency SD:
+   - Status must be `completed`
+   - Progress must be `100%`
+   - Required handoffs must be present
+3. **Parent Context**: Loads parent orchestrator for reference
+
+### Results
+**PASS** - Ready to work if:
+- SD is standalone (not a child), OR
+- No dependencies, OR
+- All dependencies complete with required handoffs
+
+**BLOCKED** - Cannot proceed if:
+- One or more dependency SDs incomplete
+- Missing required handoffs on dependencies
+- Action: Complete blocking dependency first
+
+### Integration
+- `npm run sd:next` shows dependency status in queue
+- Child SDs with incomplete dependencies show as BLOCKED
 
 ## 🔄 Git Commit Guidelines
 
@@ -1435,10 +1435,10 @@ Task tool with subagent_type="validation-agent":
 | Pattern ID | Category | Severity | Count | Trend | Top Solution |
 |------------|----------|----------|-------|-------|--------------|
 | PAT-PRD-DUP-001 | data_integrity | [HIGH] high | 13 | [STABLE] | Added partial unique index idx_product_r |
+| PAT-VAL-ISSU-001 | quality | [HIGH] high | 6 | [STABLE] | See details |
+| PAT-AUTO-89a22fe5 | process | [HIGH] high | 3 | [STABLE] | N/A |
+| PAT-AUTO-fc4cd518 | process | [HIGH] high | 3 | [STABLE] | N/A |
 | PAT-003 | security | [HIGH] high | 3 | [DOWN] | Add auth.uid() check to RLS policy USING |
-| PAT-008 | deployment | [HIGH] high | 2 | [STABLE] | Check GitHub Actions secrets and package |
-| PAT-DB-SD-E2E-001 | testing | [HIGH] high | 1 | [STABLE] | Update TESTING sub-agent to check SD cat |
-| PAT-MD-001 | database | [CRIT] critical | 1 | [STABLE] | Key Insight: PostgreSQL direct connectio |
 
 ### Prevention Checklists
 
@@ -1447,25 +1447,15 @@ Task tool with subagent_type="validation-agent":
 - [ ] Use createPRDEntry or createPRDWithValidatedContent from prd-creator.js - never insert directly
 - [ ] Database constraint idx_product_requirements_v2_unique_sd_id enforces uniqueness at DB level
 
+**quality**:
+- [ ] [
+- [ ] "
+- [ ] V
+
 **security**:
 - [ ] Verify RLS policies include auth.uid() checks
 - [ ] Test with authenticated user context
 - [ ] Check policy applies to correct operations
-
-**deployment**:
-- [ ] Verify all required secrets are set in GitHub
-- [ ] Test locally with same Node version as CI
-- [ ] Check package-lock.json is committed
-
-**testing**:
-- [ ] Check SD category before requiring E2E tests
-- [ ] For database SDs: validate tables exist via SQL
-- [ ] For infrastructure SDs: validate config/setup
-
-**database**:
-- [ ] Check SUPABASE_POOLER_URL availability in .env
-- [ ] Verify migration file exists before execution
-- [ ] Use SSL with rejectUnauthorized: false
 
 
 *Patterns auto-updated from `issue_patterns` table. Use `npm run pattern:resolve PAT-XXX` to mark resolved.*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-07T11:01:34.677Z -->
-<!-- git_commit: 766cd556 -->
-<!-- db_snapshot_hash: c027b5d1209ddcbe -->
+<!-- generated_at: 2026-02-07T14:17:27.428Z -->
+<!-- git_commit: 826248eb -->
+<!-- db_snapshot_hash: e0c92dff9edd1cbb -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
@@ -354,5 +354,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-02-07 6:01:34 AM*
+*DIGEST generated: 2026-02-07 9:17:27 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-07T11:01:34.677Z -->
-<!-- git_commit: 766cd556 -->
-<!-- db_snapshot_hash: c027b5d1209ddcbe -->
+<!-- generated_at: 2026-02-07T14:17:27.428Z -->
+<!-- git_commit: 826248eb -->
+<!-- db_snapshot_hash: e0c92dff9edd1cbb -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
@@ -121,5 +121,5 @@ Read tool: PRD file with limit: 100  ← VIOLATION
 
 ---
 
-*DIGEST generated: 2026-02-07 6:01:34 AM*
+*DIGEST generated: 2026-02-07 9:17:27 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -22,7 +22,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-07 6:01:34 AM
+**Generated**: 2026-02-07 9:17:27 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing (20-25k chars)
 
@@ -659,11 +659,11 @@ git worktree remove /mnt/c/_EHG/ehg-worktrees/${SD_ID}
 ### Quick Reference
 
 ```bash
-# Helper script (recommended)
-bash scripts/create-sd-worktree.sh SD-STAGE-09-001
+# Node CLI (recommended)
+node scripts/session-worktree.js --sd-key SD-STAGE-09-001 --branch feat/SD-STAGE-09-001
 
 # List active worktrees
-git worktree list
+node scripts/session-worktree.js --list
 
 # Check if directory is worktree
 git rev-parse --is-inside-work-tree
@@ -771,6 +771,24 @@ EXEC→PLAN handoffs now have **intelligent verification**:
 | **300-600** | ✅ **OPTIMAL** | Sweet spot |
 | **>800** | **MUST split** | Too complex |
 
+## TODO Comment Standard
+
+## TODO Comment Standard (When Deferring Work)
+
+**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
+
+### Standard TODO Format
+
+```typescript
+// TODO (SD-ID): Action required
+// Requires: Dependencies, prerequisites
+// Estimated effort: X-Y hours
+// Current state: Mock/temporary/placeholder
+```
+
+**Success Pattern** (SD-UAT-003):
+> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
+
 ## Human-Like E2E Testing Fixtures
 
 ### Human-Like E2E Testing Enhancements (LEO v4.4)
@@ -854,24 +872,6 @@ All human-like test results are automatically included in the LEO evidence pack:
 - `test_results.attachments.accessibility` - axe-core violations
 - `test_results.attachments.chaos` - resilience test results
 - `test_results.attachments.llm_ux` - LLM evaluation scores
-
-## TODO Comment Standard
-
-## TODO Comment Standard (When Deferring Work)
-
-**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
-
-### Standard TODO Format
-
-```typescript
-// TODO (SD-ID): Action required
-// Requires: Dependencies, prerequisites
-// Estimated effort: X-Y hours
-// Current state: Mock/temporary/placeholder
-```
-
-**Success Pattern** (SD-UAT-003):
-> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
 
 ## EXEC Dual Test Requirement
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-07T11:01:34.677Z -->
-<!-- git_commit: 766cd556 -->
-<!-- db_snapshot_hash: c027b5d1209ddcbe -->
+<!-- generated_at: 2026-02-07T14:17:27.428Z -->
+<!-- git_commit: 826248eb -->
+<!-- db_snapshot_hash: e0c92dff9edd1cbb -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
@@ -364,5 +364,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-02-07 6:01:34 AM*
+*DIGEST generated: 2026-02-07 9:17:27 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -22,7 +22,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-07 6:01:34 AM
+**Generated**: 2026-02-07 9:17:27 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 
@@ -68,52 +68,6 @@ The DATABASE sub-agent handles common blockers automatically:
 Task tool with subagent_type="database-agent":
 "Execute the migration file: database/migrations/YYYYMMDD_name.sql"
 ```
-
-## Baseline Issues Management
-
-## Baseline Issues System
-
-Pre-existing codebase issues are tracked in `sd_baseline_issues` table to prevent blocking unrelated SDs.
-
-### LEAD Gate: BASELINE_DEBT_CHECK
-- **BLOCKS** if: Stale critical issues (>30 days) exist without owner
-- **WARNS** if: Total open issues > 10 or stale non-critical > 5
-
-### Lifecycle
-| Status | Meaning |
-|--------|---------|
-| open | Issue identified, no owner assigned |
-| acknowledged | Issue reviewed, owner assigned |
-| in_progress | Remediation SD actively working |
-| resolved | Fixed and verified |
-| wont_fix | Accepted risk (requires LEAD approval + justification) |
-
-### Commands
-```bash
-npm run baseline:list          # Show all open issues
-npm run baseline:assign <key> <SD-ID>  # Assign ownership
-npm run baseline:resolve <key> # Mark resolved
-npm run baseline:summary       # Category summary
-```
-
-### Categories
-security, testing, performance, database, documentation, accessibility, code_quality, dependency, infrastructure
-
-### Issue Key Format
-`BL-{CATEGORY}-{NNN}` where:
-- BL-SEC-001: Security baseline issue #1
-- BL-TST-001: Testing baseline issue #1
-- BL-PRF-001: Performance baseline issue #1
-- BL-DB-001: Database baseline issue #1
-- BL-DOC-001: Documentation baseline issue #1
-- BL-A11Y-001: Accessibility baseline issue #1
-- BL-CQ-001: Code quality baseline issue #1
-- BL-DEP-001: Dependency baseline issue #1
-- BL-INF-001: Infrastructure baseline issue #1
-
-### Functions
-- `check_baseline_gate(p_sd_id)`: Returns PASS/BLOCKED verdict for LEAD gate
-- `generate_baseline_issue_key(p_category)`: Generates unique issue key
 
 ## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
 
@@ -202,6 +156,52 @@ npm run handoff:compliance SD-ID  # Check specific SD
 ```
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
+
+## Baseline Issues Management
+
+## Baseline Issues System
+
+Pre-existing codebase issues are tracked in `sd_baseline_issues` table to prevent blocking unrelated SDs.
+
+### LEAD Gate: BASELINE_DEBT_CHECK
+- **BLOCKS** if: Stale critical issues (>30 days) exist without owner
+- **WARNS** if: Total open issues > 10 or stale non-critical > 5
+
+### Lifecycle
+| Status | Meaning |
+|--------|---------|
+| open | Issue identified, no owner assigned |
+| acknowledged | Issue reviewed, owner assigned |
+| in_progress | Remediation SD actively working |
+| resolved | Fixed and verified |
+| wont_fix | Accepted risk (requires LEAD approval + justification) |
+
+### Commands
+```bash
+npm run baseline:list          # Show all open issues
+npm run baseline:assign <key> <SD-ID>  # Assign ownership
+npm run baseline:resolve <key> # Mark resolved
+npm run baseline:summary       # Category summary
+```
+
+### Categories
+security, testing, performance, database, documentation, accessibility, code_quality, dependency, infrastructure
+
+### Issue Key Format
+`BL-{CATEGORY}-{NNN}` where:
+- BL-SEC-001: Security baseline issue #1
+- BL-TST-001: Testing baseline issue #1
+- BL-PRF-001: Performance baseline issue #1
+- BL-DB-001: Database baseline issue #1
+- BL-DOC-001: Documentation baseline issue #1
+- BL-A11Y-001: Accessibility baseline issue #1
+- BL-CQ-001: Code quality baseline issue #1
+- BL-DEP-001: Dependency baseline issue #1
+- BL-INF-001: Infrastructure baseline issue #1
+
+### Functions
+- `check_baseline_gate(p_sd_id)`: Returns PASS/BLOCKED verdict for LEAD gate
+- `generate_baseline_issue_key(p_category)`: Generates unique issue key
 
 ## 🔍 Explore Before Validation (LEAD Phase)
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-07T11:01:34.677Z -->
-<!-- git_commit: 766cd556 -->
-<!-- db_snapshot_hash: c027b5d1209ddcbe -->
+<!-- generated_at: 2026-02-07T14:17:27.428Z -->
+<!-- git_commit: 826248eb -->
+<!-- db_snapshot_hash: e0c92dff9edd1cbb -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
@@ -150,5 +150,5 @@ LEAD MUST answer these questions BEFORE approval:
 
 ---
 
-*DIGEST generated: 2026-02-07 6:01:34 AM*
+*DIGEST generated: 2026-02-07 9:17:27 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -22,7 +22,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-07 6:01:34 AM
+**Generated**: 2026-02-07 9:17:27 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates (30-35k chars)
 
@@ -59,6 +59,25 @@ Resolve root causes so they do not happen again in the future. Update processes,
 
 *Directives from `leo_autonomous_directives` table (SD-LEO-CONTINUITY-001)*
 
+
+## Migration Execution Protocol
+
+## ⚠️ CRITICAL: Migration Execution Protocol
+
+**CRITICAL**: When you need to execute a migration, INVOKE the DATABASE sub-agent rather than writing execution scripts yourself.
+
+The DATABASE sub-agent handles common blockers automatically:
+- **Missing SUPABASE_DB_PASSWORD**: Uses `SUPABASE_POOLER_URL` instead (no password required)
+- **Connection issues**: Uses proven connection patterns
+- **Execution failures**: Tries alternative scripts before giving up
+
+**Never give up on migration execution** - the sub-agent has multiple fallback methods.
+
+**Invocation**:
+```
+Task tool with subagent_type="database-agent":
+"Execute the migration file: database/migrations/YYYYMMDD_name.sql"
+```
 
 ## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
 
@@ -147,25 +166,6 @@ npm run handoff:compliance SD-ID  # Check specific SD
 ```
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
-
-## Migration Execution Protocol
-
-## ⚠️ CRITICAL: Migration Execution Protocol
-
-**CRITICAL**: When you need to execute a migration, INVOKE the DATABASE sub-agent rather than writing execution scripts yourself.
-
-The DATABASE sub-agent handles common blockers automatically:
-- **Missing SUPABASE_DB_PASSWORD**: Uses `SUPABASE_POOLER_URL` instead (no password required)
-- **Connection issues**: Uses proven connection patterns
-- **Execution failures**: Tries alternative scripts before giving up
-
-**Never give up on migration execution** - the sub-agent has multiple fallback methods.
-
-**Invocation**:
-```
-Task tool with subagent_type="database-agent":
-"Execute the migration file: database/migrations/YYYYMMDD_name.sql"
-```
 
 ## 🎯 Multi-Perspective Planning
 
@@ -1824,6 +1824,34 @@ for (const childId of childIds) {
 > **NOTE**: A database trigger (trg_inherit_parent_metadata) also enforces this automatically as a safety net.
 
 
+## PRD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off PRD creation scripts like:**
+- `create-prd-sd-*.js`
+- `insert-prd-*.js`
+- `enhance-prd-*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/add-prd-to-database.js
+```
+
+### Why This Matters
+- One-off scripts bypass PRD quality validation
+- They create massive maintenance burden (100+ orphaned scripts)
+- They fragment PRD creation patterns
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-prd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/add-prd-to-database.js`
+2. Follow the modular PRD creation system in `scripts/prd/`
+3. PRD is properly validated against quality rubrics
+
 ## Vision V2 PRD Requirements (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Integration in PRDs
@@ -1864,34 +1892,6 @@ Key spec requirements addressed:
 ### Implementation Guidance (from SD metadata)
 
 All Vision V2 SDs have `creation_mode: CREATE_FROM_NEW` - implement fresh per specs, learn from existing code but do not modify it.
-
-## PRD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off PRD creation scripts like:**
-- `create-prd-sd-*.js`
-- `insert-prd-*.js`
-- `enhance-prd-*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/add-prd-to-database.js
-```
-
-### Why This Matters
-- One-off scripts bypass PRD quality validation
-- They create massive maintenance burden (100+ orphaned scripts)
-- They fragment PRD creation patterns
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-prd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/add-prd-to-database.js`
-2. Follow the modular PRD creation system in `scripts/prd/`
-3. PRD is properly validated against quality rubrics
 
 ## Visual Documentation Best Practices
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-07T11:01:34.677Z -->
-<!-- git_commit: 766cd556 -->
-<!-- db_snapshot_hash: c027b5d1209ddcbe -->
+<!-- generated_at: 2026-02-07T14:17:27.428Z -->
+<!-- git_commit: 826248eb -->
+<!-- db_snapshot_hash: e0c92dff9edd1cbb -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
@@ -334,5 +334,5 @@ Test scenarios only cover happy path ('user logs in successfully'). Missing:
 
 ---
 
-*DIGEST generated: 2026-02-07 6:01:34 AM*
+*DIGEST generated: 2026-02-07 9:17:27 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,76 +1,76 @@
 {
-  "generated_at": "2026-02-07T11:01:34.677Z",
-  "git_commit": "766cd556",
-  "db_snapshot_hash": "c027b5d1209ddcbe",
+  "generated_at": "2026-02-07T14:17:27.428Z",
+  "git_commit": "826248eb",
+  "db_snapshot_hash": "e0c92dff9edd1cbb",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 40174,
       "estimated_tokens": 10044,
-      "content_hash": "326a86858026f097",
+      "content_hash": "d65c2804068bca3f",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 76136,
-      "estimated_tokens": 19034,
-      "content_hash": "94718f1565b90cb0",
+      "chars": 75583,
+      "estimated_tokens": 18896,
+      "content_hash": "19644abdbf989bd2",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 57645,
       "estimated_tokens": 14412,
-      "content_hash": "974194152f088eb7",
+      "content_hash": "41426ba3131feee6",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 87894,
       "estimated_tokens": 21974,
-      "content_hash": "d479d285deab9036",
+      "content_hash": "3c0c987b28043ca8",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 64381,
-      "estimated_tokens": 16096,
-      "content_hash": "ec762ce142198801",
+      "chars": 64435,
+      "estimated_tokens": 16109,
+      "content_hash": "cbb57955b97e4767",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 4637,
       "estimated_tokens": 1160,
-      "content_hash": "388005f3a1a8af72",
+      "content_hash": "196b329bedfef8c4",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 16887,
       "estimated_tokens": 4222,
-      "content_hash": "4d6d1eab306cdbb0",
+      "content_hash": "eb8af9f5502af4ce",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 6254,
       "estimated_tokens": 1564,
-      "content_hash": "2c70c55adbc85c8b",
+      "content_hash": "946694f7c724bb1f",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 14901,
       "estimated_tokens": 3726,
-      "content_hash": "25a7a6d87d1e7d21",
+      "content_hash": "70c5aaedc74e94ca",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 15753,
       "estimated_tokens": 3939,
-      "content_hash": "b8a4ec4747fe7d08",
+      "content_hash": "ecf4884317b6bcad",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     }
   }

--- a/docs/06_deployment/multi-session-coordination-ops.md
+++ b/docs/06_deployment/multi-session-coordination-ops.md
@@ -493,16 +493,18 @@ Git worktree automation provides isolated git working trees for concurrent Claud
 ### Components
 
 **CLI Tool**: `scripts/session-worktree.js`
-- Creates isolated worktrees under `.sessions/`
+- Creates isolated worktrees under `.worktrees/<sdKey>/` (SD-keyed)
 - Symlinks node_modules (junction on Windows, symlink on Unix)
 - Manages worktree lifecycle (create, list, cleanup)
+- Supports `--sd-key` (primary) and deprecated `--session` alias
 
 **Core Library**: `lib/worktree-manager.js`
-- `createWorktree()` - Create worktree with branch checkout
+- `createWorktree({sdKey, branch})` - Create SD-keyed worktree
+- `cleanupWorktree(sdKey)` - Safe cleanup with dirty-state protection
 - `symlinkNodeModules()` - Link node_modules to avoid reinstall
 - `removeWorktree()` - Clean up worktree
-- `listWorktrees()` - Show active worktrees
-- `resolveExpectedBranch()` - Resolve expected branch from `.session.json` or `v_active_sessions`
+- `listWorktrees()` - Show active SD worktrees
+- `resolveExpectedBranch()` - Resolve expected branch from `.worktree.json` or `v_active_sessions`
 
 **Branch Guard**: `.husky/pre-commit` Stage 0.1
 - Blocks commits when current branch != expected branch (from `.session.json`)

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -1,9 +1,11 @@
 /**
- * Worktree Manager
- * SD-LEO-INFRA-GIT-WORKTREE-AUTOMATION-001 (FR-4)
+ * Worktree Manager - SD-Keyed Isolation
+ * SD-LEO-INFRA-REFACTOR-WORKTREE-MANAGER-001
  *
- * Manages git worktree lifecycle: create, list, cleanup, and validate.
- * Integrates with v_active_sessions for session→branch resolution.
+ * Manages git worktree lifecycle keyed by SD (Strategic Directive).
+ * Worktrees live at .worktrees/<sdKey>/ for cross-session persistence.
+ *
+ * Legacy session-keyed API is supported via deprecation adapter.
  */
 
 import { execSync } from 'child_process';
@@ -11,7 +13,36 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-const SESSIONS_DIR = '.sessions';
+const WORKTREES_DIR = '.worktrees';
+
+// Rate-limit deprecation warnings to once per process
+let _deprecationWarningEmitted = false;
+
+// Regex: alphanumeric, hyphens, underscores only. Max 128 chars.
+const SD_KEY_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
+
+/**
+ * Validate an sdKey for filesystem safety.
+ * Rejects path traversal characters, empty strings, and overly long keys.
+ *
+ * @param {string} sdKey
+ * @throws {Error} with code INVALID_SD_KEY if invalid
+ */
+export function validateSdKey(sdKey) {
+  if (!sdKey || typeof sdKey !== 'string') {
+    const err = new Error('invalid sdKey: must be a non-empty string');
+    err.code = 'INVALID_SD_KEY';
+    throw err;
+  }
+  if (!SD_KEY_PATTERN.test(sdKey)) {
+    const err = new Error(
+      `invalid sdKey: "${sdKey}" contains disallowed characters. ` +
+      'Only alphanumeric, hyphens, and underscores are allowed (max 128 chars).'
+    );
+    err.code = 'INVALID_SD_KEY';
+    throw err;
+  }
+}
 
 /**
  * Get the repository root (where .git lives)
@@ -22,32 +53,44 @@ export function getRepoRoot() {
 }
 
 /**
- * Get the sessions directory path
+ * Get the worktrees directory path
  * @param {string} [repoRoot] - Optional repo root override
- * @returns {string} Absolute path to .sessions/
+ * @returns {string} Absolute path to .worktrees/
  */
-export function getSessionsDir(repoRoot) {
+export function getWorktreesDir(repoRoot) {
   const root = repoRoot || getRepoRoot();
-  return path.join(root, SESSIONS_DIR);
+  return path.join(root, WORKTREES_DIR);
 }
 
 /**
- * Create a git worktree for a session
+ * @deprecated Use getWorktreesDir instead
+ */
+export function getSessionsDir(repoRoot) {
+  return getWorktreesDir(repoRoot);
+}
+
+/**
+ * Create a git worktree keyed by SD.
  *
  * @param {Object} options
- * @param {string} options.session - Session name (used as directory name)
+ * @param {string} [options.sdKey] - SD key (primary, used as directory name under .worktrees/)
+ * @param {string} [options.session] - DEPRECATED: Session name. Maps to sdKey='session-<sanitized>'.
  * @param {string} options.branch - Branch to check out in the worktree
  * @param {boolean} [options.force=false] - Force recreate if exists with different branch
- * @returns {{ path: string, branch: string, created: boolean, reused: boolean }}
+ * @returns {{ path: string, branch: string, sdKey: string, created: boolean, reused: boolean }}
  */
-export function createWorktree({ session, branch, force = false }) {
-  const repoRoot = getRepoRoot();
-  const sessionsDir = getSessionsDir(repoRoot);
-  const worktreePath = path.join(sessionsDir, session);
+export function createWorktree({ sdKey, session, branch, force = false }) {
+  // Resolve sdKey: explicit sdKey wins, then legacy session adapter
+  const resolvedKey = resolveSdKey(sdKey, session);
+  validateSdKey(resolvedKey);
 
-  // Ensure .sessions/ directory exists
-  if (!fs.existsSync(sessionsDir)) {
-    fs.mkdirSync(sessionsDir, { recursive: true });
+  const repoRoot = getRepoRoot();
+  const worktreesDir = getWorktreesDir(repoRoot);
+  const worktreePath = path.join(worktreesDir, resolvedKey);
+
+  // Ensure .worktrees/ directory exists
+  if (!fs.existsSync(worktreesDir)) {
+    fs.mkdirSync(worktreesDir, { recursive: true });
   }
 
   // Check if worktree already exists
@@ -55,19 +98,17 @@ export function createWorktree({ session, branch, force = false }) {
     const existingBranch = getWorktreeBranch(worktreePath);
 
     if (existingBranch === branch) {
-      // Same branch — reuse (idempotent, FR-5)
-      return { path: worktreePath, branch, created: false, reused: true };
+      return { path: worktreePath, branch, sdKey: resolvedKey, created: false, reused: true };
     }
 
     if (!force) {
       throw new Error(
-        `Worktree '${session}' already exists on branch '${existingBranch}'. ` +
-        `Expected '${branch}'. Use --force to recreate or choose a different session name.`
+        `Worktree '${resolvedKey}' already exists on branch '${existingBranch}'. ` +
+        `Expected '${branch}'. Use --force to recreate or choose a different sdKey.`
       );
     }
 
-    // Force: remove existing worktree and recreate
-    removeWorktree(session);
+    removeWorktree(resolvedKey);
   }
 
   // Check if branch exists (local or remote)
@@ -80,7 +121,6 @@ export function createWorktree({ session, branch, force = false }) {
       stdio: 'pipe'
     });
   } else {
-    // Create new branch from current HEAD
     execSync(`git worktree add -b "${branch}" "${worktreePath}"`, {
       cwd: repoRoot,
       encoding: 'utf8',
@@ -88,24 +128,24 @@ export function createWorktree({ session, branch, force = false }) {
     });
   }
 
-  // Write .session.json for branch guard (FR-3)
-  const sessionConfig = {
-    session,
+  // Write .worktree.json metadata
+  const worktreeConfig = {
+    sdKey: resolvedKey,
     expectedBranch: branch,
     createdAt: new Date().toISOString(),
     hostname: os.hostname(),
     repoRoot
   };
   fs.writeFileSync(
-    path.join(worktreePath, '.session.json'),
-    JSON.stringify(sessionConfig, null, 2)
+    path.join(worktreePath, '.worktree.json'),
+    JSON.stringify(worktreeConfig, null, 2)
   );
 
-  return { path: worktreePath, branch, created: true, reused: false };
+  return { path: worktreePath, branch, sdKey: resolvedKey, created: true, reused: false };
 }
 
 /**
- * Symlink or junction node_modules into a worktree (FR-2)
+ * Symlink or junction node_modules into a worktree
  *
  * @param {string} worktreePath - Path to the worktree
  * @param {string} [repoRoot] - Optional repo root override
@@ -154,16 +194,16 @@ export function symlinkNodeModules(worktreePath, repoRoot) {
 }
 
 /**
- * Remove a worktree and clean up (FR-5)
+ * Remove an SD worktree and deregister it from git.
  *
- * @param {string} session - Session name to remove
+ * @param {string} sdKey - SD key identifying the worktree
  */
-export function removeWorktree(session) {
+export function removeWorktree(sdKey) {
   const repoRoot = getRepoRoot();
-  const worktreePath = path.join(getSessionsDir(repoRoot), session);
+  const worktreePath = path.join(getWorktreesDir(repoRoot), sdKey);
 
   if (!fs.existsSync(worktreePath)) {
-    return; // Already gone — idempotent
+    return; // Already gone - idempotent
   }
 
   try {
@@ -175,7 +215,6 @@ export function removeWorktree(session) {
   } catch {
     // If git worktree remove fails, clean up manually
     fs.rmSync(worktreePath, { recursive: true, force: true });
-    // Prune worktree references
     try {
       execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' });
     } catch {
@@ -185,47 +224,107 @@ export function removeWorktree(session) {
 }
 
 /**
- * List all active worktree sessions
+ * Clean up an SD worktree on SD completion.
+ * Aborts if uncommitted changes exist unless force is true.
  *
- * @returns {Array<{ session: string, path: string, branch: string, exists: boolean }>}
+ * @param {string} sdKey - SD key identifying the worktree
+ * @param {Object} [options]
+ * @param {boolean} [options.force=false] - Force cleanup even with dirty worktree
+ * @returns {{ cleaned: boolean, reason: string }}
+ */
+export function cleanupWorktree(sdKey, { force = false } = {}) {
+  validateSdKey(sdKey);
+  const repoRoot = getRepoRoot();
+  const worktreePath = path.join(getWorktreesDir(repoRoot), sdKey);
+
+  if (!fs.existsSync(worktreePath)) {
+    return { cleaned: false, reason: 'worktree_not_found' };
+  }
+
+  // Check for uncommitted changes
+  if (!force) {
+    try {
+      const status = execSync('git status --porcelain', {
+        cwd: worktreePath,
+        encoding: 'utf8',
+        stdio: 'pipe'
+      }).trim();
+
+      if (status.length > 0) {
+        console.warn(`[worktree-manager] Cleanup aborted for ${sdKey}: uncommitted changes detected`);
+        return { cleaned: false, reason: 'dirty_worktree' };
+      }
+    } catch {
+      // If git status fails, the worktree may be corrupt - proceed with cleanup
+    }
+  }
+
+  console.info(`[worktree-manager] Cleanup started for sdKey=${sdKey}`);
+  removeWorktree(sdKey);
+
+  // Verify removal
+  const porcelain = execSync('git worktree list --porcelain', {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: 'pipe'
+  });
+  const stillExists = porcelain.includes(worktreePath);
+
+  if (stillExists) {
+    console.warn(`[worktree-manager] Worktree ${sdKey} still listed after removal`);
+    return { cleaned: false, reason: 'removal_incomplete' };
+  }
+
+  return { cleaned: true, reason: 'success' };
+}
+
+/**
+ * List all active SD worktrees.
+ *
+ * @returns {Array<{ sdKey: string, path: string, branch: string, exists: boolean }>}
  */
 export function listWorktrees() {
   const repoRoot = getRepoRoot();
-  const sessionsDir = getSessionsDir(repoRoot);
+  const worktreesDir = getWorktreesDir(repoRoot);
 
-  if (!fs.existsSync(sessionsDir)) {
+  if (!fs.existsSync(worktreesDir)) {
     return [];
   }
 
-  const entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+  const entries = fs.readdirSync(worktreesDir, { withFileTypes: true });
   return entries
     .filter(e => e.isDirectory())
     .map(e => {
-      const sessionPath = path.join(sessionsDir, e.name);
-      const configPath = path.join(sessionPath, '.session.json');
+      const wtPath = path.join(worktreesDir, e.name);
+      const configPath = path.join(wtPath, '.worktree.json');
+      // Also check legacy .session.json
+      const legacyConfigPath = path.join(wtPath, '.session.json');
       let branch = null;
       let exists = true;
 
-      // Try .session.json first
-      if (fs.existsSync(configPath)) {
-        try {
-          const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-          branch = config.expectedBranch;
-        } catch {
-          // Fall through to git check
+      // Try .worktree.json first, then legacy .session.json
+      for (const cfgPath of [configPath, legacyConfigPath]) {
+        if (branch) break;
+        if (fs.existsSync(cfgPath)) {
+          try {
+            const config = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+            branch = config.expectedBranch;
+          } catch {
+            // Fall through
+          }
         }
       }
 
       // Validate it's a real worktree
       try {
-        branch = branch || getWorktreeBranch(sessionPath);
+        branch = branch || getWorktreeBranch(wtPath);
       } catch {
         exists = false;
       }
 
       return {
-        session: e.name,
-        path: sessionPath,
+        sdKey: e.name,
+        path: wtPath,
         branch: branch || 'unknown',
         exists
       };
@@ -234,26 +333,29 @@ export function listWorktrees() {
 
 /**
  * Resolve expected branch for a working directory.
- * Used by branch guard (FR-3) to determine what branch a worktree should be on.
+ * Used by branch guard to determine what branch a worktree should be on.
  *
  * Resolution order:
- * 1. .session.json in the worktree
- * 2. v_active_sessions lookup (if supabase provided)
- * 3. null (cannot determine)
+ * 1. .worktree.json in the worktree
+ * 2. .session.json in the worktree (legacy)
+ * 3. v_active_sessions lookup (if supabase provided)
+ * 4. null (cannot determine)
  *
  * @param {string} workdir - Working directory to check
  * @param {Object} [supabase] - Optional Supabase client for v_active_sessions lookup
  * @returns {Promise<string|null>} Expected branch name or null
  */
 export async function resolveExpectedBranch(workdir, supabase) {
-  // 1. Check .session.json
-  const configPath = path.join(workdir, '.session.json');
-  if (fs.existsSync(configPath)) {
-    try {
-      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      if (config.expectedBranch) return config.expectedBranch;
-    } catch {
-      // Fall through
+  // 1. Check .worktree.json, then legacy .session.json
+  for (const filename of ['.worktree.json', '.session.json']) {
+    const configPath = path.join(workdir, filename);
+    if (fs.existsSync(configPath)) {
+      try {
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        if (config.expectedBranch) return config.expectedBranch;
+      } catch {
+        // Fall through
+      }
     }
   }
 
@@ -271,7 +373,7 @@ export async function resolveExpectedBranch(workdir, supabase) {
         return data[0].branch;
       }
     } catch {
-      // DB unavailable — fail-open
+      // DB unavailable - fail-open
     }
   }
 
@@ -279,6 +381,31 @@ export async function resolveExpectedBranch(workdir, supabase) {
 }
 
 // ── Internal helpers ──
+
+/**
+ * Resolve sdKey from explicit value or legacy session adapter.
+ * sdKey always wins over session.
+ */
+function resolveSdKey(sdKey, session) {
+  if (sdKey) return sdKey;
+
+  if (session) {
+    if (!_deprecationWarningEmitted) {
+      console.warn(
+        '[worktree-manager] WARNING: session-keyed worktrees are deprecated. ' +
+        "Use '--sd-key' instead of '--session'."
+      );
+      _deprecationWarningEmitted = true;
+    }
+    // Deterministic mapping: sanitize session name
+    const sanitized = session.replace(/[^a-zA-Z0-9_-]/g, '-').substring(0, 120);
+    return `session-${sanitized}`;
+  }
+
+  const err = new Error('Either sdKey or session must be provided');
+  err.code = 'INVALID_SD_KEY';
+  throw err;
+}
 
 function getWorktreeBranch(worktreePath) {
   return execSync('git rev-parse --abbrev-ref HEAD', {
@@ -307,4 +434,12 @@ function branchExistsRemotely(branch) {
   } catch {
     return false;
   }
+}
+
+/**
+ * Reset deprecation warning state (for testing).
+ * @internal
+ */
+export function _resetDeprecationWarning() {
+  _deprecationWarningEmitted = false;
 }

--- a/scripts/create-sd-worktree.sh
+++ b/scripts/create-sd-worktree.sh
@@ -1,58 +1,59 @@
 #!/bin/bash
-# create-sd-worktree.sh - Create isolated git worktree for SD parallel execution
+# DEPRECATED: create-sd-worktree.sh
 #
-# Usage: bash scripts/create-sd-worktree.sh <SD-ID>
-# Example: bash scripts/create-sd-worktree.sh SD-STAGE-09-001
+# This script is deprecated. Use the Node.js CLI instead:
+#   node scripts/session-worktree.js --sd-key <SD-ID> --branch <branch>
 #
-# Creates a worktree at ../ehg-worktrees/<SD-ID>
-# with a feature branch named feat/<SD-ID>
+# To force use of this deprecated script, pass --allow-deprecated as first arg.
+
+if [ "$1" = "--allow-deprecated" ]; then
+  shift
+  echo "WARNING: Using deprecated Bash worktree script. Migrate to Node CLI."
+else
+  echo "DEPRECATED: create-sd-worktree.sh is no longer the primary workflow."
+  echo ""
+  echo "Use the Node.js CLI instead:"
+  echo "  node scripts/session-worktree.js --sd-key <SD-ID> --branch feat/<SD-ID>"
+  echo ""
+  echo "To force use of this script, pass --allow-deprecated as first arg."
+  exit 1
+fi
 
 set -e
 
 SD_ID="${1:-}"
 
 if [ -z "$SD_ID" ]; then
-  echo "Usage: bash scripts/create-sd-worktree.sh <SD-ID>"
-  echo "Example: bash scripts/create-sd-worktree.sh SD-STAGE-09-001"
+  echo "Usage: bash scripts/create-sd-worktree.sh --allow-deprecated <SD-ID>"
   exit 1
 fi
 
-# Configuration
 MAIN_REPO="../ehg"
 WORKTREE_BASE="../ehg-worktrees"
 WORKTREE_PATH="${WORKTREE_BASE}/${SD_ID}"
 BRANCH_NAME="feat/${SD_ID}"
 
-# Ensure we're in the main repo
 if [ ! -d "$MAIN_REPO/.git" ]; then
   echo "Error: Main repo not found at $MAIN_REPO"
   exit 1
 fi
 
-# Create worktree base directory if it doesn't exist
 mkdir -p "$WORKTREE_BASE"
 
-# Check if worktree already exists
 if [ -d "$WORKTREE_PATH" ]; then
   echo "Worktree already exists at $WORKTREE_PATH"
-  echo ""
   echo "To use it: cd $WORKTREE_PATH"
-  echo "To remove it: git -C $MAIN_REPO worktree remove $WORKTREE_PATH"
   exit 0
 fi
 
-# Go to main repo
 cd "$MAIN_REPO"
 
-# Fetch latest from origin
 echo "Fetching latest from origin..."
 git fetch origin main
 
-# Check if branch already exists remotely
 if git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
   echo "Branch $BRANCH_NAME exists remotely, creating worktree from it..."
   git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
-# Check if branch exists locally
 elif git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
   echo "Branch $BRANCH_NAME exists locally, creating worktree from it..."
   git worktree add "$WORKTREE_PATH" "$BRANCH_NAME"
@@ -62,15 +63,8 @@ else
 fi
 
 echo ""
-echo "=== Worktree Created Successfully ==="
+echo "=== Worktree Created (via deprecated script) ==="
 echo "Location: $WORKTREE_PATH"
 echo "Branch: $BRANCH_NAME"
 echo ""
-echo "Next steps:"
-echo "  1. cd $WORKTREE_PATH"
-echo "  2. Do your SD work"
-echo "  3. Commit and push: git push -u origin $BRANCH_NAME"
-echo "  4. Create PR and merge"
-echo "  5. Cleanup: git -C $MAIN_REPO worktree remove $WORKTREE_PATH"
-echo ""
-echo "List all worktrees: git -C $MAIN_REPO worktree list"
+echo "Migrate to: node scripts/session-worktree.js --sd-key $SD_ID --branch $BRANCH_NAME"

--- a/tests/unit/worktree-manager.test.js
+++ b/tests/unit/worktree-manager.test.js
@@ -1,15 +1,12 @@
 /**
- * Tests for Worktree Manager
- * SD-LEO-INFRA-GIT-WORKTREE-AUTOMATION-001
+ * Tests for Worktree Manager (SD-Keyed)
+ * SD-LEO-INFRA-REFACTOR-WORKTREE-MANAGER-001
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-
-// We test the module functions by mocking child_process.execSync and fs operations
-// since actual git worktree operations require a real git repo.
 
 vi.mock('child_process', () => ({
   execSync: vi.fn()
@@ -17,20 +14,22 @@ vi.mock('child_process', () => ({
 
 import { execSync } from 'child_process';
 
-// Import after mocking
 const {
   getRepoRoot,
+  getWorktreesDir,
   getSessionsDir,
   createWorktree,
-  symlinkNodeModules,
-  removeWorktree,
+  cleanupWorktree,
   listWorktrees,
-  resolveExpectedBranch
+  resolveExpectedBranch,
+  validateSdKey,
+  _resetDeprecationWarning
 } = await import('../../lib/worktree-manager.js');
 
 describe('Worktree Manager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetDeprecationWarning();
   });
 
   describe('getRepoRoot', () => {
@@ -41,33 +40,254 @@ describe('Worktree Manager', () => {
     });
   });
 
-  describe('getSessionsDir', () => {
-    it('should return .sessions under provided repo root', () => {
-      const result = getSessionsDir('/home/user/project');
-      expect(result).toBe(path.join('/home/user/project', '.sessions'));
+  describe('getWorktreesDir', () => {
+    it('should return .worktrees under provided repo root', () => {
+      const result = getWorktreesDir('/home/user/project');
+      expect(result).toBe(path.join('/home/user/project', '.worktrees'));
     });
 
     it('should call getRepoRoot when no root provided', () => {
       execSync.mockReturnValue('/home/user/project\n');
-      const result = getSessionsDir();
-      expect(result).toBe(path.join('/home/user/project', '.sessions'));
+      const result = getWorktreesDir();
+      expect(result).toBe(path.join('/home/user/project', '.worktrees'));
+    });
+  });
+
+  describe('getSessionsDir (deprecated alias)', () => {
+    it('should return same as getWorktreesDir', () => {
+      const a = getWorktreesDir('/home/user/project');
+      const b = getSessionsDir('/home/user/project');
+      expect(a).toBe(b);
+    });
+  });
+
+  describe('validateSdKey', () => {
+    it('should accept valid SD keys', () => {
+      expect(() => validateSdKey('SD-LEO-INFRA-001')).not.toThrow();
+      expect(() => validateSdKey('abc123')).not.toThrow();
+      expect(() => validateSdKey('my_key-test')).not.toThrow();
+    });
+
+    it('should reject empty/null sdKey', () => {
+      expect(() => validateSdKey('')).toThrow('invalid sdKey');
+      expect(() => validateSdKey(null)).toThrow('invalid sdKey');
+      expect(() => validateSdKey(undefined)).toThrow('invalid sdKey');
+    });
+
+    it('should reject path traversal characters', () => {
+      expect(() => validateSdKey('../x')).toThrow('invalid sdKey');
+      expect(() => validateSdKey('a/b')).toThrow('invalid sdKey');
+      expect(() => validateSdKey('a\\b')).toThrow('invalid sdKey');
+    });
+
+    it('should reject keys longer than 128 chars', () => {
+      const longKey = 'a'.repeat(129);
+      expect(() => validateSdKey(longKey)).toThrow('invalid sdKey');
+    });
+
+    it('should set error code to INVALID_SD_KEY', () => {
+      try {
+        validateSdKey('');
+      } catch (err) {
+        expect(err.code).toBe('INVALID_SD_KEY');
+      }
+    });
+  });
+
+  describe('createWorktree', () => {
+    it('should use sdKey for worktree path', () => {
+      execSync.mockImplementation((cmd) => {
+        if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
+        if (cmd.includes('show-ref')) return '';
+        if (cmd.includes('ls-remote')) return '';
+        if (cmd.includes('worktree add')) return '';
+        return '';
+      });
+
+      // Mock fs operations
+      const origExists = fs.existsSync;
+      const origMkdir = fs.mkdirSync;
+      const origWrite = fs.writeFileSync;
+      fs.existsSync = vi.fn().mockReturnValue(false);
+      fs.mkdirSync = vi.fn();
+      fs.writeFileSync = vi.fn();
+
+      try {
+        const result = createWorktree({ sdKey: 'SD-TEST-001', branch: 'feat/test' });
+        expect(result.sdKey).toBe('SD-TEST-001');
+        expect(result.path).toContain('.worktrees');
+        expect(result.path).toContain('SD-TEST-001');
+        expect(result.created).toBe(true);
+      } finally {
+        fs.existsSync = origExists;
+        fs.mkdirSync = origMkdir;
+        fs.writeFileSync = origWrite;
+      }
+    });
+
+    it('should map legacy session to sdKey with deprecation warning', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      execSync.mockImplementation((cmd) => {
+        if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
+        if (cmd.includes('show-ref')) return '';
+        if (cmd.includes('ls-remote')) return '';
+        if (cmd.includes('worktree add')) return '';
+        return '';
+      });
+
+      const origExists = fs.existsSync;
+      const origMkdir = fs.mkdirSync;
+      const origWrite = fs.writeFileSync;
+      fs.existsSync = vi.fn().mockReturnValue(false);
+      fs.mkdirSync = vi.fn();
+      fs.writeFileSync = vi.fn();
+
+      try {
+        const result = createWorktree({ session: 'legacy123', branch: 'feat/test' });
+        expect(result.sdKey).toBe('session-legacy123');
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('session-keyed worktrees are deprecated')
+        );
+      } finally {
+        fs.existsSync = origExists;
+        fs.mkdirSync = origMkdir;
+        fs.writeFileSync = origWrite;
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('should rate-limit deprecation warning to once per process', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      execSync.mockImplementation((cmd) => {
+        if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
+        if (cmd.includes('show-ref')) return '';
+        if (cmd.includes('ls-remote')) return '';
+        if (cmd.includes('worktree add')) return '';
+        return '';
+      });
+
+      const origExists = fs.existsSync;
+      const origMkdir = fs.mkdirSync;
+      const origWrite = fs.writeFileSync;
+      fs.existsSync = vi.fn().mockReturnValue(false);
+      fs.mkdirSync = vi.fn();
+      fs.writeFileSync = vi.fn();
+
+      try {
+        createWorktree({ session: 'call1', branch: 'feat/test1' });
+        createWorktree({ session: 'call2', branch: 'feat/test2' });
+        // Only one deprecation warning
+        const deprecationWarnings = warnSpy.mock.calls.filter(
+          c => c[0].includes('deprecated')
+        );
+        expect(deprecationWarnings).toHaveLength(1);
+      } finally {
+        fs.existsSync = origExists;
+        fs.mkdirSync = origMkdir;
+        fs.writeFileSync = origWrite;
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('should prefer sdKey over session when both provided', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      execSync.mockImplementation((cmd) => {
+        if (cmd === 'git rev-parse --show-toplevel') return '/repo\n';
+        if (cmd.includes('show-ref')) return '';
+        if (cmd.includes('ls-remote')) return '';
+        if (cmd.includes('worktree add')) return '';
+        return '';
+      });
+
+      const origExists = fs.existsSync;
+      const origMkdir = fs.mkdirSync;
+      const origWrite = fs.writeFileSync;
+      fs.existsSync = vi.fn().mockReturnValue(false);
+      fs.mkdirSync = vi.fn();
+      fs.writeFileSync = vi.fn();
+
+      try {
+        const result = createWorktree({
+          sdKey: 'SD-EXPLICIT',
+          session: 'legacy',
+          branch: 'feat/test'
+        });
+        expect(result.sdKey).toBe('SD-EXPLICIT');
+        // No deprecation warning since sdKey was used
+        const deprecationWarnings = warnSpy.mock.calls.filter(
+          c => c[0]?.includes?.('deprecated')
+        );
+        expect(deprecationWarnings).toHaveLength(0);
+      } finally {
+        fs.existsSync = origExists;
+        fs.mkdirSync = origMkdir;
+        fs.writeFileSync = origWrite;
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('should reject invalid sdKey with INVALID_SD_KEY code', () => {
+      expect(() => createWorktree({ sdKey: '../traversal', branch: 'feat/test' }))
+        .toThrow('invalid sdKey');
+    });
+  });
+
+  describe('cleanupWorktree', () => {
+    it('should return worktree_not_found when worktree does not exist', () => {
+      execSync.mockReturnValue('/repo\n');
+      const result = cleanupWorktree('nonexistent-key');
+      expect(result).toEqual({ cleaned: false, reason: 'worktree_not_found' });
+    });
+
+    it('should reject invalid sdKey', () => {
+      expect(() => cleanupWorktree('../bad')).toThrow('invalid sdKey');
     });
   });
 
   describe('resolveExpectedBranch', () => {
-    it('should return branch from .session.json if it exists', async () => {
+    it('should return branch from .worktree.json if it exists', async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-test-'));
-      const configPath = path.join(tmpDir, '.session.json');
-      fs.writeFileSync(configPath, JSON.stringify({ expectedBranch: 'feat/test-branch' }));
+      const configPath = path.join(tmpDir, '.worktree.json');
+      fs.writeFileSync(configPath, JSON.stringify({ expectedBranch: 'feat/sd-branch' }));
 
       const result = await resolveExpectedBranch(tmpDir);
-      expect(result).toBe('feat/test-branch');
+      expect(result).toBe('feat/sd-branch');
 
-      // Cleanup
       fs.rmSync(tmpDir, { recursive: true });
     });
 
-    it('should return null when no .session.json and no supabase', async () => {
+    it('should fall back to .session.json for legacy worktrees', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-test-'));
+      const configPath = path.join(tmpDir, '.session.json');
+      fs.writeFileSync(configPath, JSON.stringify({ expectedBranch: 'feat/legacy-branch' }));
+
+      const result = await resolveExpectedBranch(tmpDir);
+      expect(result).toBe('feat/legacy-branch');
+
+      fs.rmSync(tmpDir, { recursive: true });
+    });
+
+    it('should prefer .worktree.json over .session.json', async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-test-'));
+      fs.writeFileSync(
+        path.join(tmpDir, '.worktree.json'),
+        JSON.stringify({ expectedBranch: 'feat/new-style' })
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, '.session.json'),
+        JSON.stringify({ expectedBranch: 'feat/old-style' })
+      );
+
+      const result = await resolveExpectedBranch(tmpDir);
+      expect(result).toBe('feat/new-style');
+
+      fs.rmSync(tmpDir, { recursive: true });
+    });
+
+    it('should return null when no config and no supabase', async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-test-'));
 
       const result = await resolveExpectedBranch(tmpDir);
@@ -115,7 +335,7 @@ describe('Worktree Manager', () => {
   });
 
   describe('listWorktrees', () => {
-    it('should return empty array when .sessions/ does not exist', () => {
+    it('should return empty array when .worktrees/ does not exist', () => {
       execSync.mockReturnValue('/nonexistent/path\n');
       const result = listWorktrees();
       expect(result).toEqual([]);


### PR DESCRIPTION
## Summary
- Refactor `lib/worktree-manager.js` from session-keyed (`.sessions/<name>`) to SD-keyed (`.worktrees/<sdKey>`) isolation
- Add `validateSdKey()` with path traversal prevention and 128-char limit
- Add `cleanupWorktree(sdKey)` with dirty-state safety for SD completion lifecycle
- Legacy `--session` CLI flag maps to `sdKey=session-<sanitized>` with rate-limited deprecation warning
- Deprecate `scripts/create-sd-worktree.sh` (exits non-zero unless `--allow-deprecated`)
- Update protocol section 305 in database and regenerate CLAUDE files
- Update ops documentation with new API

## Test plan
- [x] 31 unit tests pass (23 new + 8 existing from worktree copy)
- [x] sdKey validation rejects `../x`, `a/b`, `a\b`, empty, and >128 char keys
- [x] Legacy session adapter emits deprecation warning once per process
- [x] sdKey takes precedence when both sdKey and session provided
- [x] cleanupWorktree returns `worktree_not_found` for missing keys
- [x] resolveExpectedBranch prefers `.worktree.json` over legacy `.session.json`
- [x] Smoke tests pass (30 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)