### PR TITLE
docs: replace stale table references with product_requirements_v2

### DIFF
--- a/.claude/agents/docmon-agent.md
+++ b/.claude/agents/docmon-agent.md
@@ -80,7 +80,7 @@ If the user asks general documentation questions without an SD context (e.g., "W
 
 **Key Documentation Patterns**:
 - **Auto-Generation**: AI Documentation Platform auto-generates from SD/PRD
-- **Database Storage**: All docs stored in `ai_generated_documents` table
+- **Database Storage**: All docs stored in `product_requirements_v2` table
 - **Dashboard Access**: `/ai-docs-admin` for review and publishing
 - **EXEC Requirement**: Generate docs before EXEC→PLAN handoff
 - **Version Control**: Docs versioned by SD completion state
@@ -106,7 +106,7 @@ node scripts/search-prior-issues.js "documentation"
 - ✅ PRDs → `product_requirements_v2` table (NOT markdown files)
 - ✅ Handoffs → `sd_phase_handoffs` table (NOT markdown files)
 - ✅ Retrospectives → `retrospectives` table (NOT markdown files)
-- ✅ Documentation → `ai_generated_documents` table
+- ✅ Documentation → `product_requirements_v2` table
 
 **Auto-Trigger Events** (SD-LEO-004):
 1. LEAD_SD_CREATION → Verify SD in database, not file
@@ -164,7 +164,7 @@ From AI Documentation Platform and 74+ retrospectives:
 - Filters: By SD-ID, status, type, date
 
 **Database Tables**:
-- `ai_generated_documents`: Document storage
+- `product_requirements_v2`: Document storage
 - `strategic_directives_v2`: SD context
 - `product_requirements_v2`: PRD context
 

--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -44,7 +44,7 @@ Different Strategic Directive types require different documentation approaches.
 
 | SD Type | Primary Docs | Secondary Docs | Location |
 |---------|--------------|----------------|----------|
-| **feature** | User guide, feature docs | API docs, architecture | `docs/04_features/`, `ai_generated_documents` |
+| **feature** | User guide, feature docs | API docs, architecture | `docs/04_features/`, `product_requirements_v2` |
 | **api** | OpenAPI spec, endpoint docs | Integration guide | `docs/02_api/`, `docs/reference/` |
 | **database** | Schema docs, migration notes | RLS policy docs | `docs/database/`, `docs/reference/` |
 | **infrastructure** | Operational runbook, deployment guide | Architecture diagram | `docs/06_deployment/`, `docs/operations/` |
@@ -81,7 +81,7 @@ supabase.from('strategic_directives_v2')
 2. Update docs/04_features/ with new feature guide
 3. If API involved: Update OpenAPI specs
 4. If UI involved: Update component documentation
-5. Store in `ai_generated_documents` table
+5. Store in `product_requirements_v2` table
 
 **Database SD**:
 1. Update schema documentation in `docs/database/`
@@ -566,12 +566,12 @@ grep -r -l -i "KEYWORD1\|KEYWORD2" docs/ --include="*.md"
 Query existing documentation records:
 
 ```bash
-# Search ai_generated_documents for existing documentation
+# Search product_requirements_v2 for existing documentation
 node -e "
 require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
 const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-supabase.from('ai_generated_documents')
+supabase.from('product_requirements_v2')
   .select('id, title, document_type, file_path, status, created_at')
   .or('title.ilike.%KEYWORD%,content.ilike.%KEYWORD%')
   .then(({data, error}) => {
@@ -746,7 +746,7 @@ gh pr create --title "docs(<scope>): <description>" --body "..."
 │   │   └── Find recently modified docs (git log)
 │   │
 │   ├── Search database:
-│   │   ├── Query ai_generated_documents table
+│   │   ├── Query product_requirements_v2 table
 │   │   └── Query documentation_inventory table
 │   │
 │   ├── Apply Decision Matrix:
@@ -903,7 +903,7 @@ supabase.from('leo_protocol_sections')
 #### Database Records Found
 | Table | ID | Title | Action |
 |-------|-----|-------|--------|
-| ai_generated_documents | 45 | Feature X Guide | Updated |
+| product_requirements_v2 | 45 | Feature X Guide | Updated |
 
 #### Decision Rationale
 - [x] Edited existing: `docs/existing/file.md` (covers same topic)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -59,7 +59,7 @@ grep -n "your change" CLAUDE*.md
 | `leo_sub_agents` | Sub-agent definitions | ~25 agents |
 | `leo_sub_agent_triggers` | Trigger keywords | ~350 triggers |
 | `strategic_directives_v2` | SD metadata | Active SDs |
-| `ai_generated_documents` | AI docs | Generated content |
+| `product_requirements_v2` | PRDs and documentation | Active PRDs |
 
 ### Documentation Principles
 

--- a/docs/prompts/triangulation-sd-review-unified.md
+++ b/docs/prompts/triangulation-sd-review-unified.md
@@ -45,7 +45,7 @@ EHG has created 3 parent Strategic Directives (SDs) based on triangulation resea
 
 3. **Database**: Supabase with tables including:
    - `strategic_directives_v2` - SD storage
-   - `prd_documents` - PRD storage
+   - `product_requirements_v2` - PRD storage
    - `scaffold_patterns` - Pattern library (~45 patterns)
 
 ---

--- a/scripts/analyze-sd-tables.js
+++ b/scripts/analyze-sd-tables.js
@@ -118,29 +118,15 @@ async function analyzeSDTables() {
     console.log('\n\n🔗 TABLE REFERENCES:');
     console.log('─'.repeat(60));
     
-    // Check PRD tables
-    const { data: prdV1 } = await supabase
-        .from('prd_documents')
-        .select('*')
-        .limit(1);
-        
-    const { data: prdV2 } = await supabase
+    // Check PRD table
+    const { data: prdData } = await supabase
         .from('product_requirements_v2')
         .select('*')
         .limit(1);
 
-    console.log('\n📄 PRD Tables:');
-    if (prdV1) {
-        const sample = prdV1[0];
-        if (sample) {
-            console.log('   • prd_documents references:');
-            console.log(`     - Has 'sd_id' field: ${sample.sd_id !== undefined ? '✅' : '❌'}`);
-            console.log(`     - Has 'directive_id' field: ${sample.directive_id !== undefined ? '✅' : '❌'}`);
-        }
-    }
-    
-    if (prdV2) {
-        const sample = prdV2[0];
+    console.log('\n📄 PRD Table:');
+    if (prdData) {
+        const sample = prdData[0];
         if (sample) {
             console.log('   • product_requirements_v2 references:');
             console.log(`     - Has 'sd_id' field: ${sample.sd_id !== undefined ? '✅' : '❌'}`);

--- a/scripts/check-directive-status.js
+++ b/scripts/check-directive-status.js
@@ -17,9 +17,9 @@ async function checkDirectiveStatus() {
     // Check various possible tables
     const tables = [
         'strategic_directives',
-        'directive_submissions', 
+        'directive_submissions',
         'sdip_strategic_directives',
-        'prd_documents',
+        'product_requirements_v2',
         'leo_protocols'
     ];
 
@@ -33,7 +33,7 @@ async function checkDirectiveStatus() {
                 console.log(`✅ Table '${table}' exists - ${count || 0} records`);
                 
                 // Get sample data for strategic tables
-                if (table.includes('directive') || table === 'prd_documents') {
+                if (table.includes('directive') || table === 'product_requirements_v2') {
                     const { data: samples } = await supabase
                         .from(table)
                         .select('*')
@@ -62,7 +62,7 @@ async function checkDirectiveStatus() {
     
     try {
         const { data: prds } = await supabase
-            .from('prd_documents')
+            .from('product_requirements_v2')
             .select('*')
             .in('status', ['draft', 'in_progress', 'pending_review'])
             .order('created_at', { ascending: false })

--- a/scripts/query-active-sds.js
+++ b/scripts/query-active-sds.js
@@ -71,14 +71,14 @@ async function queryActiveStrategicDirectives() {
 
                 // Check for associated PRDs
                 const { data: prds } = await supabase
-                    .from('prd_documents')
-                    .select('prd_id, status')
+                    .from('product_requirements_v2')
+                    .select('id, status')
                     .eq('sd_id', sd.sd_id || sd.id);
                 
                 if (prds && prds.length > 0) {
                     console.log(`   Associated PRDs: ${prds.length}`);
                     prds.forEach(prd => {
-                        console.log(`     • ${prd.prd_id} (${prd.status})`);
+                        console.log(`     • ${prd.id} (${prd.status})`);
                     });
                 }
             }

--- a/scripts/update-docmon-subagent-improvements.js
+++ b/scripts/update-docmon-subagent-improvements.js
@@ -64,7 +64,7 @@ node scripts/search-prior-issues.js "documentation"
 - ✅ PRDs → \`product_requirements_v2\` table (NOT .md files)
 - ✅ Handoffs → \`sd_phase_handoffs\` table (NOT .md files)
 - ✅ Retrospectives → \`retrospectives\` table (NOT .md files)
-- ✅ Documentation → \`ai_generated_documents\` table (NOT .md files)
+- ✅ Documentation → \`product_requirements_v2\` table (NOT .md files)
 
 **Auto-Trigger Events** (SD-LEO-004):
 1. \`LEAD_SD_CREATION\` → Verify SD in database, not file
@@ -79,7 +79,7 @@ node scripts/search-prior-issues.js "documentation"
 ❌ Creating handoff-XXX.md files
 ❌ Saving PRDs as markdown files
 ❌ Writing retrospectives to .md files
-❌ Creating manual documentation outside ai_generated_documents table
+❌ Creating manual documentation outside product_requirements_v2 table
 
 ✅ All data MUST be in database tables
 ✅ Documentation generated via AI Documentation Platform
@@ -133,7 +133,7 @@ node scripts/orchestrate-phase-subagents.js EXEC_IMPL <SD-ID>
 - Search by SD-ID, status, type, date
 
 **Database Tables**:
-- \`ai_generated_documents\`: Document storage
+- \`product_requirements_v2\`: Document storage
 - \`strategic_directives_v2\`: SD context
 - \`product_requirements_v2\`: PRD context
 
@@ -149,7 +149,7 @@ node scripts/orchestrate-phase-subagents.js EXEC_IMPL <SD-ID>
 
 ### Generation
 - [ ] Documentation generated via script
-- [ ] Stored in \`ai_generated_documents\` table (NOT file)
+- [ ] Stored in \`product_requirements_v2\` table (NOT file)
 - [ ] All sections complete (overview, features, usage, technical)
 
 ### Post-Generation
@@ -235,7 +235,7 @@ node scripts/orchestrate-phase-subagents.js EXEC_IMPL <SD-ID>
     'Auto-trigger on SD completion events',
     'Dashboard-based documentation management (/ai-docs-admin)',
     'Multi-type documentation generation (feature, technical, API, workflow)',
-    'Centralized documentation storage (ai_generated_documents table)',
+    'Centralized documentation storage (product_requirements_v2 table)',
     'Documentation review and publishing workflows',
     'Link validation (internal/external)',
     'Code example testing and validation',


### PR DESCRIPTION
## Summary
Replace outdated `prd_documents` and `ai_generated_documents` table references throughout codebase with the correct `product_requirements_v2` table name.

## Changes
- **scripts/analyze-sd-tables.js**: Updated PRD table query from `prd_documents` to `product_requirements_v2`
- **scripts/check-directive-status.js**: Updated table list and queries
- **scripts/query-active-sds.js**: Updated PRD lookup and field references (prd_id → id)
- **scripts/update-docmon-subagent-improvements.js**: Updated 5 references
- **.claude/commands/document.md**: Updated 5 references
- **.claude/agents/docmon-agent.md**: Updated 3 references
- **docs/INDEX.md**: Updated key tables list
- **docs/prompts/triangulation-sd-review-unified.md**: Updated database section

## Root Cause
Schema was migrated to `product_requirements_v2` but stale references remained in documentation and scripts, causing database query hallucinations after context compaction.

## Pattern Reference
PAT-CONTEXT-LOAD-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)