### PR TITLE
fix(sd-next): skip SDs claimed by other sessions in recommendations

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -159,7 +159,7 @@ export class SDNextSelector {
     await this.displayTracks();
 
     // Display recommendations and get structured action data
-    const recommendation = await displayRecommendations(this.supabase, this.baselineItems, this.conflicts);
+    const recommendation = await displayRecommendations(this.supabase, this.baselineItems, this.conflicts, this.getSessionContext());
 
     // Display proactive proposals (LEO v4.4)
     displayProposals(this.pendingProposals);


### PR DESCRIPTION
## Summary
- `sd:next` recommendations now skip SDs already claimed by other active sessions
- Previously, the recommendation engine could suggest an SD that another session already owns, even though `sd:start` would reject the claim
- The `claimedSDs` map (already loaded by `loadActiveSessions`) is now passed through to `categorizeBaselineSDs` which skips SDs claimed by a different session
- SDs claimed by the *current* session still appear (so your own in-progress work remains visible)

## Test plan
- [x] `npm run sd:next` runs without errors (smoke tested)
- [ ] With two sessions active, verify the claimed SD is excluded from recommendations in the other session

🤖 Generated with [Claude Code](https://claude.com/claude-code)