### PR TITLE
feat: add quality scoring columns to feedback table

### DIFF
--- a/database/migrations/20260207_add_quality_scoring_columns_to_feedback.sql
+++ b/database/migrations/20260207_add_quality_scoring_columns_to_feedback.sql
@@ -1,0 +1,35 @@
+-- Migration: Add quality scoring columns to feedback table
+-- SD: SD-FDBK-ENH-ADD-QUALITY-SCORING-001
+-- Purpose: Add rubric_score and quality_assessment columns for efficient
+--          quality-based querying, filtering, and display in /leo inbox
+
+-- Step 1: Add rubric_score column (INT 0-100, nullable for backwards compat)
+ALTER TABLE feedback ADD COLUMN IF NOT EXISTS rubric_score INTEGER;
+
+-- Step 2: Add quality_assessment column (JSONB for 5-dimension breakdown)
+ALTER TABLE feedback ADD COLUMN IF NOT EXISTS quality_assessment JSONB;
+
+-- Step 3: Add CHECK constraint for score range
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'feedback_rubric_score_range'
+  ) THEN
+    ALTER TABLE feedback ADD CONSTRAINT feedback_rubric_score_range
+      CHECK (rubric_score IS NULL OR (rubric_score >= 0 AND rubric_score <= 100));
+  END IF;
+END $$;
+
+-- Step 4: Add index for quality-based queries (filter + sort)
+CREATE INDEX IF NOT EXISTS idx_feedback_rubric_score
+  ON feedback (rubric_score DESC NULLS LAST)
+  WHERE rubric_score IS NOT NULL;
+
+-- Step 5: Add composite index for common query pattern (status + quality)
+CREATE INDEX IF NOT EXISTS idx_feedback_status_rubric_score
+  ON feedback (status, rubric_score DESC NULLS LAST)
+  WHERE rubric_score IS NOT NULL;
+
+-- Step 6: Add comment for documentation
+COMMENT ON COLUMN feedback.rubric_score IS 'Quality score 0-100 from quality-scorer.js 5-dimension assessment (clarity, actionability, specificity, relevance, completeness)';
+COMMENT ON COLUMN feedback.quality_assessment IS 'JSONB with dimension scores: {score, tier, dimensions: {clarity, actionability, specificity, relevance, completeness}, suggestions}';

--- a/lib/feedback-capture.js
+++ b/lib/feedback-capture.js
@@ -184,6 +184,14 @@ export async function captureError(error, options = {}, supabase) {
       error_hash: hash,
       error_type: error.name || 'Error',
       occurrence_count: 1,
+      // SD-FDBK-ENH-ADD-QUALITY-SCORING-001: Persist quality scores to dedicated columns
+      rubric_score: qualityResult?.qualityScore?.score ?? null,
+      quality_assessment: qualityResult?.processed?.metadata?.quality ? {
+        score: qualityResult.processed.metadata.quality.score,
+        tier: qualityResult.processed.metadata.quality.tier,
+        dimensions: qualityResult.processed.metadata.quality.dimensions,
+        suggestions: qualityResult.processed.metadata.quality.suggestions || null
+      } : null,
       metadata: {
         ...options.metadata,
         error_name: error.name,

--- a/lib/inbox/format-inbox.js
+++ b/lib/inbox/format-inbox.js
@@ -42,6 +42,15 @@ function truncate(str, max) {
   return str.length > max ? str.substring(0, max - 1) + '\u2026' : str;
 }
 
+// SD-FDBK-ENH-ADD-QUALITY-SCORING-001: Quality score badge for feedback items
+function getQualityBadge(item) {
+  if (item.item_type !== 'feedback' || item.rubric_score == null) return '';
+  const score = item.rubric_score;
+  if (score >= 70) return ` Q:${score}`;
+  if (score >= 40) return ` Q:${score}!`;
+  return ` Q:${score}!!`;
+}
+
 function getIdentifier(item) {
   if (item.item_type === 'sd') return item.metadata?.sd_key || item.source_ref.pk;
   if (item.item_type === 'pattern') return item.source_ref.pk;
@@ -82,7 +91,8 @@ function formatText(result, options = {}) {
         const title = truncate(item.title, verbose ? 80 : 55);
         const updated = formatDate(item.updated_at);
 
-        lines.push(`  [${badge}] ${title} - ${updated} - ${id}`);
+        const quality = getQualityBadge(item);
+        lines.push(`  [${badge}] ${title} - ${updated} - ${id}${quality}`);
 
         // Show linked items for SDs in verbose mode
         if (verbose && item.item_type === 'sd' && item.linked_items && item.linked_items.length > 0) {

--- a/lib/inbox/unified-inbox-builder.js
+++ b/lib/inbox/unified-inbox-builder.js
@@ -69,6 +69,8 @@ function normalizeFeedback(row) {
     assigned_sd_id: row.strategic_directive_id || row.resolution_sd_id || null,
     linked_items: null,
     priority: row.priority || null,
+    // SD-FDBK-ENH-ADD-QUALITY-SCORING-001: Quality score for display
+    rubric_score: row.rubric_score ?? null,
     metadata: {
       type: row.type,
       category: row.category,
@@ -154,7 +156,7 @@ function normalizeSD(row) {
 async function loadFeedback(supabase) {
   const { data, error } = await supabase
     .from('feedback')
-    .select('id, type, title, description, status, priority, category, severity, sd_id, resolution_sd_id, strategic_directive_id, created_at, updated_at');
+    .select('id, type, title, description, status, priority, category, severity, sd_id, resolution_sd_id, strategic_directive_id, rubric_score, created_at, updated_at');
   if (error) throw new Error(`Failed to load feedback: ${error.message}`);
   return data || [];
 }

--- a/scripts/backfill-quality-scores.js
+++ b/scripts/backfill-quality-scores.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * Backfill Quality Scores for Existing Feedback
+ * SD-FDBK-ENH-ADD-QUALITY-SCORING-001
+ *
+ * Processes existing feedback rows that have no rubric_score,
+ * runs them through the quality scorer, and persists results
+ * to the rubric_score and quality_assessment columns.
+ *
+ * Usage:
+ *   node scripts/backfill-quality-scores.js [--batch-size 50] [--dry-run]
+ */
+
+import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import { createClient } from '@supabase/supabase-js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Try worktree root first, then main repo root (worktrees don't have .env)
+const envPath = [
+  path.resolve(__dirname, '..', '.env'),
+  path.resolve(__dirname, '..', '..', '..', '.env')
+].find(p => fs.existsSync(p));
+dotenv.config({ path: envPath });
+import { calculateQualityScore, getQualityTier, generateImprovementSuggestions } from '../lib/quality/quality-scorer.js';
+
+const BATCH_SIZE = parseInt(process.argv.find((_, i, a) => a[i - 1] === '--batch-size') || '50', 10);
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+async function backfill() {
+  console.log(`[Backfill] Starting quality score backfill (batch=${BATCH_SIZE}, dry-run=${DRY_RUN})`);
+
+  // Count total unscored rows
+  const { count, error: countErr } = await supabase
+    .from('feedback')
+    .select('id', { count: 'exact', head: true })
+    .is('rubric_score', null);
+
+  if (countErr) {
+    console.error('[Backfill] Failed to count rows:', countErr.message);
+    process.exit(1);
+  }
+
+  console.log(`[Backfill] Found ${count} feedback rows without quality scores`);
+  if (count === 0) {
+    console.log('[Backfill] Nothing to backfill. Done.');
+    return;
+  }
+
+  let processed = 0;
+  let scored = 0;
+  let failed = 0;
+  let offset = 0;
+
+  while (offset < count) {
+    const { data: batch, error: fetchErr } = await supabase
+      .from('feedback')
+      .select('id, title, description, type, source_type')
+      .is('rubric_score', null)
+      .order('created_at', { ascending: true })
+      .range(offset, offset + BATCH_SIZE - 1);
+
+    if (fetchErr) {
+      console.error(`[Backfill] Fetch error at offset ${offset}:`, fetchErr.message);
+      break;
+    }
+
+    if (!batch || batch.length === 0) break;
+
+    for (const row of batch) {
+      processed++;
+      try {
+        const feedbackForScoring = {
+          title: row.title || '',
+          description: row.description || '',
+          type: row.type,
+          source_type: row.source_type
+        };
+
+        const qualityScore = await calculateQualityScore(feedbackForScoring);
+        const tier = getQualityTier(qualityScore.score);
+        const suggestions = tier === 'low'
+          ? generateImprovementSuggestions(qualityScore.dimensions)
+          : null;
+
+        const qualityAssessment = {
+          score: qualityScore.score,
+          tier,
+          dimensions: qualityScore.dimensions,
+          suggestions
+        };
+
+        if (!DRY_RUN) {
+          const { error: updateErr } = await supabase
+            .from('feedback')
+            .update({
+              rubric_score: qualityScore.score,
+              quality_assessment: qualityAssessment
+            })
+            .eq('id', row.id);
+
+          if (updateErr) {
+            console.error(`[Backfill] Update failed for ${row.id}:`, updateErr.message);
+            failed++;
+            continue;
+          }
+        }
+
+        scored++;
+        if (scored % 10 === 0) {
+          console.log(`[Backfill] Progress: ${scored}/${count} scored (${failed} failed)`);
+        }
+      } catch (err) {
+        console.error(`[Backfill] Score failed for ${row.id}:`, err.message);
+        failed++;
+      }
+    }
+
+    // Use fixed offset increment since we're querying IS NULL rows
+    // that get updated (no longer NULL) after each batch
+    if (DRY_RUN) {
+      offset += BATCH_SIZE;
+    }
+    // When not dry-run, offset stays at 0 because scored rows drop out of the IS NULL filter
+  }
+
+  console.log('');
+  console.log('[Backfill] Complete!');
+  console.log(`  Processed: ${processed}`);
+  console.log(`  Scored:    ${scored}`);
+  console.log(`  Failed:    ${failed}`);
+  if (DRY_RUN) console.log('  (DRY RUN - no changes written)');
+}
+
+backfill().catch(err => {
+  console.error('[Backfill] Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `rubric_score` (INT 0-100) and `quality_assessment` (JSONB) columns to feedback table via migration
- Wire quality scorer pipeline into `feedback-capture.js` to persist scores on new feedback creation
- Add `rubric_score` to unified inbox builder query and display quality badges (`Q:82`, `Q:45!`, `Q:20!!`) in `/leo inbox`
- Include backfill script for existing rows (21/21 scored, 0 failures)

## Test plan
- [x] All 36 inbox unit tests pass
- [x] All 47 quality unit tests pass (83/83 total)
- [x] Migration applied successfully (rubric_score + quality_assessment columns)
- [x] Backfill: 21/21 existing rows scored
- [x] Database verified: 0 unscored rows remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)