### PR TITLE
fix: resolve dotenv path for learning modules in worktree directories

### DIFF
--- a/scripts/modules/learning/classification.js
+++ b/scripts/modules/learning/classification.js
@@ -7,9 +7,12 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { generateSDKey as generateCentralizedSDKey } from '../sd-key-generator.js';
 
-dotenv.config();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
 const supabase = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/modules/learning/context-builder.js
+++ b/scripts/modules/learning/context-builder.js
@@ -11,8 +11,11 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-dotenv.config();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
 const supabase = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/modules/learning/decision-management.js
+++ b/scripts/modules/learning/decision-management.js
@@ -9,9 +9,11 @@ import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import { execSync } from 'child_process';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { applyImprovement, resolvePatterns } from './improvement-appliers.js';
 
-dotenv.config();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
 const supabase = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/modules/learning/improvement-appliers.js
+++ b/scripts/modules/learning/improvement-appliers.js
@@ -7,8 +7,11 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-dotenv.config();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
 const supabase = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/modules/learning/insights.js
+++ b/scripts/modules/learning/insights.js
@@ -10,8 +10,11 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-dotenv.config();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
 const supabase = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,

--- a/scripts/modules/learning/sd-creation.js
+++ b/scripts/modules/learning/sd-creation.js
@@ -7,6 +7,8 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 import {
   buildSDDescription,
@@ -26,7 +28,8 @@ import {
   checkExistingAssignments
 } from './classification.js';
 
-dotenv.config();
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 
 const supabase = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,


### PR DESCRIPTION
## Summary
- Fixed 6 learning module files that used bare `dotenv.config()` which resolved `.env` relative to CWD
- When running from `.worktrees/SD-XXX/` directories, no `.env` exists at CWD, causing `supabaseUrl is required` errors
- Applied explicit `path.resolve(__dirname, '../../../.env')` pattern already established in codebase
- Files fixed: `context-builder.js`, `sd-creation.js`, `insights.js`, `improvement-appliers.js`, `classification.js`, `decision-management.js`

## Test plan
- [x] Verified `node scripts/modules/learning/index.js process` works from main repo root
- [x] Verified same command works from `.worktrees/SD-LEO-INFRA-FIX-LEARNING-SYSTEM-001/` directory (previously failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)