### PR TITLE
feat: extend worktree isolation to QF and ad-hoc work

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -205,29 +205,116 @@ do
   fi
 
   # ========================================================================
-  # CASE 3: No tracking - BLOCKED
+  # CASE 3: No tracking - Interactive wizard (TTY) or block (non-TTY)
   # ========================================================================
-  echo "❌ Push blocked: No work tracking found"
-  echo ""
-  echo "   Branch: $BRANCH"
-  echo ""
-  echo "All changes to main must be tracked as either:"
-  echo ""
-  echo "  📋 STRATEGIC DIRECTIVE (for substantial work >50 LOC)"
-  echo "     npm run sd:create"
-  echo "     Then: git checkout -b feat/SD-XXX-description"
-  echo ""
-  echo "  🔧 QUICK-FIX (for small fixes ≤50 LOC)"
-  echo "     node scripts/create-quick-fix.js --interactive"
-  echo "     Then: git checkout -b quick-fix/QF-YYYYMMDD-NNN"
-  echo ""
-  echo "  🚨 EMERGENCY (with logged justification)"
-  echo "     EMERGENCY_PUSH=\"critical: reason\" git push"
-  echo ""
-  echo "This ensures all work is tracked, lessons are captured,"
-  echo "and quality gates are enforced."
-  echo ""
-  exit 1
+
+  # Check if EHG_ALLOW_MAIN_PUSH is set (for automation)
+  if [ "$EHG_ALLOW_MAIN_PUSH" = "1" ]; then
+    echo "⚠️  EHG_ALLOW_MAIN_PUSH=1 - allowing untracked push"
+    continue
+  fi
+
+  # Detect interactive vs non-interactive
+  if [ -t 0 ] && [ -t 1 ] && [ "$CI" != "true" ]; then
+    # ====== INTERACTIVE MODE: Show wizard ======
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  UNTRACKED WORK DETECTED"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+    echo "  Branch: $BRANCH"
+    echo "  No SD or QF tracking found for this push."
+    echo ""
+    echo "  Choose an option:"
+    echo ""
+    echo "  1) Create Quick-Fix worktree   (small fix, ≤50 LOC)"
+    echo "  2) Create SD worktree          (substantial work, >50 LOC)"
+    echo "  3) EMERGENCY_PUSH              (requires confirmation phrase)"
+    echo "  4) Cancel                       (abort push)"
+    echo ""
+    printf "  Choice [1-4]: "
+    read WIZARD_CHOICE
+
+    case "$WIZARD_CHOICE" in
+      1)
+        # Generate QF ID and create worktree
+        QF_AUTO_ID="QF-$(date +%Y%m%d-%H%M%S)"
+        echo ""
+        echo "  Creating Quick-Fix worktree: $QF_AUTO_ID"
+        echo ""
+        node -e "
+          const { createWorkTypeWorktree } = await import('./lib/worktree-manager.js');
+          const result = createWorkTypeWorktree({ workType: 'QF', workKey: '$QF_AUTO_ID' });
+          if (result.mode === 'worktree') {
+            console.log('WORKTREE_PATH=' + result.path);
+            console.log('WORKTREE_BRANCH=' + result.branch);
+          } else {
+            console.log('WORKTREE_FAILED=1');
+            console.log('WORKTREE_REASON=' + result.reason);
+          }
+        " 2>/dev/null || echo "WORKTREE_FAILED=1"
+        echo ""
+        echo "  To push from the worktree:"
+        echo "    cd <worktree-path>"
+        echo "    git add . && git commit -m \"fix: description\""
+        echo "    git push -u origin qf/$QF_AUTO_ID"
+        echo ""
+        exit 1
+        ;;
+      2)
+        echo ""
+        echo "  Create an SD using:"
+        echo "    /leo create"
+        echo "  Then work in the automatically created worktree."
+        echo ""
+        exit 1
+        ;;
+      3)
+        echo ""
+        printf "  Type EMERGENCY_PUSH to confirm: "
+        read CONFIRM
+        if [ "$CONFIRM" = "EMERGENCY_PUSH" ]; then
+          # Log the emergency
+          EMERG_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          EMERG_COMMIT=$(git rev-parse --short HEAD)
+          echo "{\"event\":\"emergency_push\",\"branch\":\"$EMERG_BRANCH\",\"commit\":\"$EMERG_COMMIT\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"emergencyPush\":true}" >&2
+          echo ""
+          echo "  ⚠️  Emergency push confirmed. Please create SD/QF retroactively."
+          echo ""
+          continue
+        else
+          echo ""
+          echo "  ❌ Confirmation failed. Push aborted."
+          echo ""
+          exit 1
+        fi
+        ;;
+      *)
+        echo ""
+        echo "  Push cancelled."
+        echo ""
+        exit 1
+        ;;
+    esac
+  else
+    # ====== NON-INTERACTIVE MODE: Deterministic failure ======
+    echo "❌ Push blocked: No work tracking found (non-interactive)"
+    echo ""
+    echo "   Branch: $BRANCH"
+    echo ""
+    echo "This push was blocked because no SD or QF tracking was detected."
+    echo "In non-interactive mode (CI or no TTY), set one of:"
+    echo ""
+    echo "  EHG_CONCURRENT_OVERRIDE=1   - Override concurrent session check"
+    echo "  EHG_ALLOW_MAIN_PUSH=1       - Allow untracked pushes"
+    echo "  EMERGENCY_PUSH=\"reason\"      - Emergency bypass with logging"
+    echo ""
+    echo "Or create proper tracking:"
+    echo "  SD: node scripts/leo-create-sd.js LEO fix \"description\""
+    echo "  QF: node scripts/create-quick-fix.js --title \"description\" --type bug"
+    echo ""
+    exit 1
+  fi
 
 done
 

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -1,9 +1,12 @@
 /**
- * Worktree Manager - SD-Keyed Isolation
+ * Worktree Manager - Multi-WorkType Isolation
  * SD-LEO-INFRA-REFACTOR-WORKTREE-MANAGER-001
+ * SD-LEO-INFRA-EXTEND-WORKTREE-ISOLATION-001
  *
- * Manages git worktree lifecycle keyed by SD (Strategic Directive).
- * Worktrees live at .worktrees/<sdKey>/ for cross-session persistence.
+ * Manages git worktree lifecycle keyed by work identifier.
+ * Supports SD, QF, and ad-hoc work types.
+ * Worktrees live at .worktrees/<workType>/<workKey>/ for cross-session persistence.
+ * Legacy flat layout (.worktrees/<sdKey>/) is still supported.
  *
  * Legacy session-keyed API is supported via deprecation adapter.
  */
@@ -14,6 +17,20 @@ import path from 'path';
 import os from 'os';
 
 const WORKTREES_DIR = '.worktrees';
+
+/** @typedef {'SD'|'QF'|'ADHOC'} WorkType */
+
+/**
+ * @typedef {Object} WorktreeResult
+ * @property {'worktree'|'main-fallback'} mode - Whether a worktree was used or fell back to main
+ * @property {string} path - Absolute path to working directory
+ * @property {string} branch - Branch name
+ * @property {WorkType} workType - Type of work
+ * @property {string} workKey - Work identifier (SD key, QF ID, or ad-hoc token)
+ * @property {boolean} [created] - Whether worktree was freshly created
+ * @property {boolean} [reused] - Whether an existing worktree was reused
+ * @property {string} [reason] - Reason for fallback (only when mode='main-fallback')
+ */
 
 // Rate-limit deprecation warnings to once per process
 let _deprecationWarningEmitted = false;
@@ -142,6 +159,202 @@ export function createWorktree({ sdKey, session, branch, force = false }) {
   );
 
   return { path: worktreePath, branch, sdKey: resolvedKey, created: true, reused: false };
+}
+
+/**
+ * Create a worktree for any work type (SD, QF, or ADHOC).
+ * Returns a structured result with fallback semantics.
+ *
+ * @param {Object} options
+ * @param {WorkType} options.workType - Type of work: 'SD', 'QF', or 'ADHOC'
+ * @param {string} options.workKey - Identifier (SD key, QF ID, or ad-hoc token)
+ * @param {string} [options.branch] - Branch name (auto-generated if not provided)
+ * @param {boolean} [options.force=false] - Force recreate if exists with different branch
+ * @returns {WorktreeResult}
+ */
+export function createWorkTypeWorktree({ workType, workKey, branch, force = false }) {
+  if (!['SD', 'QF', 'ADHOC'].includes(workType)) {
+    throw new Error(`Invalid workType: ${workType}. Must be SD, QF, or ADHOC`);
+  }
+  if (!workKey || typeof workKey !== 'string') {
+    throw new Error('workKey must be a non-empty string');
+  }
+
+  const startTime = Date.now();
+  const sanitizedKey = workKey.replace(/[^a-zA-Z0-9_-]/g, '-').substring(0, 128);
+
+  // Auto-generate branch if not provided
+  const resolvedBranch = branch || generateBranchName(workType, sanitizedKey);
+
+  // Determine worktree subdirectory based on work type
+  const subDir = workType.toLowerCase(); // sd, qf, or adhoc
+  const repoRoot = getRepoRoot();
+  const worktreesDir = getWorktreesDir(repoRoot);
+  const worktreeDir = path.join(worktreesDir, subDir);
+  const worktreePath = path.join(worktreeDir, sanitizedKey);
+
+  // For SD type, also check legacy flat layout (.worktrees/<sdKey>/)
+  if (workType === 'SD') {
+    const legacyPath = path.join(worktreesDir, sanitizedKey);
+    if (fs.existsSync(legacyPath) && !fs.existsSync(worktreePath)) {
+      // Legacy worktree exists - reuse it
+      const existingBranch = safeGetWorktreeBranch(legacyPath);
+      logWorktreeEvent('worktree.reuse_legacy', { workType, workKey: sanitizedKey, path: legacyPath, durationMs: Date.now() - startTime });
+      return {
+        mode: 'worktree',
+        path: legacyPath,
+        branch: existingBranch || resolvedBranch,
+        workType,
+        workKey: sanitizedKey,
+        created: false,
+        reused: true
+      };
+    }
+  }
+
+  try {
+    // Ensure subdirectory exists
+    if (!fs.existsSync(worktreeDir)) {
+      fs.mkdirSync(worktreeDir, { recursive: true });
+    }
+
+    // Check if worktree already exists
+    if (fs.existsSync(worktreePath)) {
+      const existingBranch = safeGetWorktreeBranch(worktreePath);
+
+      if (!existingBranch) {
+        // Invalid worktree - return fallback
+        logWorktreeEvent('worktree.invalid', { workType, workKey: sanitizedKey, reason: 'cannot-resolve-HEAD', durationMs: Date.now() - startTime });
+        return {
+          mode: 'main-fallback',
+          path: repoRoot,
+          branch: resolvedBranch,
+          workType,
+          workKey: sanitizedKey,
+          reason: 'invalid-worktree'
+        };
+      }
+
+      if (existingBranch === resolvedBranch || !force) {
+        logWorktreeEvent('worktree.reuse', { workType, workKey: sanitizedKey, mode: 'worktree', durationMs: Date.now() - startTime });
+        return {
+          mode: 'worktree',
+          path: worktreePath,
+          branch: existingBranch,
+          workType,
+          workKey: sanitizedKey,
+          created: false,
+          reused: true
+        };
+      }
+
+      // Force recreate
+      removeWorktree(path.relative(worktreesDir, worktreePath).replace(/\\/g, '/'));
+    }
+
+    // Create worktree
+    const branchExists = branchExistsLocally(resolvedBranch) || branchExistsRemotely(resolvedBranch);
+
+    if (branchExists) {
+      execSync(`git worktree add "${worktreePath}" "${resolvedBranch}"`, {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: 'pipe'
+      });
+    } else {
+      execSync(`git worktree add -b "${resolvedBranch}" "${worktreePath}"`, {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        stdio: 'pipe'
+      });
+    }
+
+    // Write metadata file
+    const metadataFile = path.join(worktreePath, '.ehg-session.json');
+    fs.writeFileSync(metadataFile, JSON.stringify({
+      workType,
+      workKey: sanitizedKey,
+      expectedBranch: resolvedBranch,
+      createdAt: new Date().toISOString(),
+      hostname: os.hostname()
+    }, null, 2));
+
+    // Also write .worktree.json for backward compatibility
+    fs.writeFileSync(path.join(worktreePath, '.worktree.json'), JSON.stringify({
+      sdKey: sanitizedKey,
+      workType,
+      workKey: sanitizedKey,
+      expectedBranch: resolvedBranch,
+      createdAt: new Date().toISOString(),
+      hostname: os.hostname(),
+      repoRoot
+    }, null, 2));
+
+    logWorktreeEvent('worktree.create', { workType, workKey: sanitizedKey, mode: 'worktree', durationMs: Date.now() - startTime });
+
+    return {
+      mode: 'worktree',
+      path: worktreePath,
+      branch: resolvedBranch,
+      workType,
+      workKey: sanitizedKey,
+      created: true,
+      reused: false
+    };
+  } catch (err) {
+    logWorktreeEvent('worktree.fallback', { workType, workKey: sanitizedKey, mode: 'main-fallback', reason: err.message, durationMs: Date.now() - startTime });
+
+    return {
+      mode: 'main-fallback',
+      path: repoRoot,
+      branch: resolvedBranch,
+      workType,
+      workKey: sanitizedKey,
+      reason: err.message
+    };
+  }
+}
+
+/**
+ * Generate a branch name based on work type and key.
+ * @param {WorkType} workType
+ * @param {string} workKey
+ * @returns {string}
+ */
+function generateBranchName(workType, workKey) {
+  switch (workType) {
+    case 'SD': return `feat/${workKey}`;
+    case 'QF': return `qf/${workKey}`;
+    case 'ADHOC': return `adhoc/${workKey}`;
+    default: return `work/${workKey}`;
+  }
+}
+
+/**
+ * Safely get a worktree's current branch without throwing.
+ * @param {string} worktreePath
+ * @returns {string|null}
+ */
+function safeGetWorktreeBranch(worktreePath) {
+  try {
+    return execSync('git rev-parse --abbrev-ref HEAD', {
+      cwd: worktreePath,
+      encoding: 'utf8',
+      stdio: 'pipe'
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Emit a single-line JSON log for worktree operations.
+ * @param {string} event
+ * @param {Object} fields
+ */
+function logWorktreeEvent(event, fields = {}) {
+  const entry = { event, timestamp: new Date().toISOString(), ...fields };
+  console.error(JSON.stringify(entry));
 }
 
 /**


### PR DESCRIPTION
## Summary

- Added `createWorkTypeWorktree()` to `worktree-manager.js` supporting SD/QF/ADHOC work types with structured `WorktreeResult` objects and graceful main-fallback semantics
- Updated `create-quick-fix.js` to auto-create worktree isolation before implementation begins, with fallback to branch-only mode if worktree creation fails
- Expanded `concurrent-session-worktree.cjs` to detect work type from branch prefix (`qf/`, `adhoc/`) and `.ehg-session.json` markers, plus `EHG_CONCURRENT_OVERRIDE=1` support
- Replaced pre-push dead-end block with interactive wizard (TTY) or deterministic failure (non-TTY) for untracked work, supporting Create QF / Create SD / EMERGENCY_PUSH options

Closes SD-LEO-INFRA-EXTEND-WORKTREE-ISOLATION-001

## Test plan
- [x] All 69 existing worktree-manager unit tests pass
- [x] All 30 smoke tests pass
- [ ] Manual: Run `create-quick-fix.js` and verify worktree is created under `.worktrees/qf/`
- [ ] Manual: Test pre-push wizard with untracked branch push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)