### PR TITLE
fix: filter non-actionable SAL patterns from /learn auto-approve

### DIFF
--- a/scripts/modules/learning/index.js
+++ b/scripts/modules/learning/index.js
@@ -109,14 +109,16 @@ async function autoApproveCommand(threshold = 50, sdId = null) {
   }
 
   // SD-LEARN-FIX-011: Include sub-agent learnings (SAL-* items)
-  // These were previously invisible to auto-approve, causing silent drops
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-008: SAL items use a HIGHER threshold
+  // than patterns/improvements because they originate from sub-agent execution
+  // history, not from actual issue pattern analysis. This prevents noise SDs.
+  const salThreshold = Math.max(threshold, 75); // SAL minimum: 75%
   for (const sal of (reviewed.sub_agent_learnings || [])) {
-    // SAL items with high confidence (>=threshold) are auto-approved
     const score = sal.confidence || 0;
-    if (score >= threshold) {
+    if (score >= salThreshold) {
       qualifying.push(sal);
     } else {
-      deferred.push({ ...sal, reason: `confidence ${score} < ${threshold}` });
+      deferred.push({ ...sal, reason: `SAL confidence ${score} < ${salThreshold} (SAL-specific threshold)` });
     }
   }
 


### PR DESCRIPTION
## Summary
- Added `NON_ACTIONABLE_SAL_PATTERNS` regex list (14 patterns) to `context-builder.js` that filters out normal sub-agent status reports ("no migrations needed", "low risk profile", etc.) before they become learning items
- Added confidence penalty for high-pass-rate (>80%) sub-agents whose recurring recommendations are informational, not urgent
- Raised SAL-specific auto-approve threshold from 50% to 75% minimum in `index.js`, preventing low-confidence SAL items from auto-creating SDs

## Test plan
- [x] `node --check` syntax verification on both files
- [x] 9/9 unit tests pass (5 noise patterns correctly filtered, 4 actionable patterns pass through)
- [x] Smoke tests pass (30/30)
- [x] Pre-commit hooks pass (ESLint, secrets, DOCMON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)