### PR TITLE
fix: add additional non-actionable SAL patterns to /learn filter

### DIFF
--- a/scripts/modules/learning/context-builder.js
+++ b/scripts/modules/learning/context-builder.js
@@ -89,6 +89,16 @@ const NON_ACTIONABLE_SAL_PATTERNS = [
   /maintain test coverage/i,
   /follow existing patterns/i,
   /standard (?:LEO )?workflow/i,
+  // Positive status reports (not problems)
+  /security posture is strong/i,
+  /no (?:critical )?vulnerabilities/i,
+  /continue following.*best practices/i,
+  /regular.*audits? recommended/i,
+  // Vague catch-all recommendations
+  /fix all (?:accessibility|a11y) violations/i,
+  /(?:wcag|aria).*compliance.*required/i,
+  /add missing (?:alt text|aria)/i,
+  /use.*testing tools for.*coverage/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Extends `NON_ACTIONABLE_SAL_PATTERNS` with 8 additional patterns discovered from SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-009 (cancelled as noise)
- Covers: positive security status reports, vulnerability absence reports, boilerplate best practice reminders, vague accessibility catch-alls
- Prevents future noise SDs from being auto-created by `/learn auto-approve`

## Test plan
- [x] `node --check` syntax verification
- [x] Smoke tests pass (30/30)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)