### PR TITLE
fix: resolve 6 inbox patterns from /leo assist session

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -510,6 +510,14 @@ function mapPriority(feedbackPriority) {
  * orchestrator, qa, refactor, security, implementation, strategic_observation,
  * architectural_review, discovery_spike, ux_debt, product_decision
  */
+// PAT-SDCREATE-001: Valid SD types that exist in all registration points
+// Keep in sync with: sd-type-validation.js VALID_SD_TYPES, type-classifier.js SD_TYPE_PROFILES
+const VALID_DB_SD_TYPES = [
+  'feature', 'infrastructure', 'bugfix', 'database', 'security',
+  'refactor', 'documentation', 'docs', 'orchestrator', 'performance',
+  'enhancement', 'uat', 'library', 'fix', 'implementation', 'qa'
+];
+
 function mapToDbType(userType) {
   const map = {
     // User-friendly -> Database type
@@ -533,7 +541,14 @@ function mapToDbType(userType) {
     implementation: 'implementation',
     enhancement: 'feature'  // Map enhancement to feature
   };
-  return map[userType?.toLowerCase()] || 'feature';
+  const mapped = map[userType?.toLowerCase()] || 'feature';
+
+  // PAT-SDCREATE-001: Validate the mapped type exists in VALID_DB_SD_TYPES
+  if (!VALID_DB_SD_TYPES.includes(mapped)) {
+    console.warn(`⚠️  Mapped sd_type '${mapped}' not in VALID_DB_SD_TYPES list. Defaulting to 'feature'.`);
+    return 'feature';
+  }
+  return mapped;
 }
 
 /**

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -275,6 +275,12 @@ export function createRetrospectiveExistsGate(supabase) {
 
 /**
  * Create Gate 4: PR merge verification
+ *
+ * PAT-SHIP-ORDER-001: Correct ordering is:
+ *   EXEC complete → /ship (commit, PR, merge) → LEAD-FINAL-APPROVAL
+ * This gate enforces that PRs are merged BEFORE final approval.
+ * If this gate fails, run /ship first.
+ *
  * @returns {Object} Gate definition
  */
 export function createPRMergeVerificationGate() {
@@ -282,6 +288,7 @@ export function createPRMergeVerificationGate() {
     name: 'PR_MERGE_VERIFICATION',
     validator: async (ctx) => {
       console.log('\n🔒 GATE 4: PR Merge Verification');
+      console.log('   ℹ️  Required order: EXEC → /ship (merge PR) → LEAD-FINAL-APPROVAL');
       console.log('-'.repeat(50));
 
       const sdId = ctx.sd.sd_key || ctx.sd.id;

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -91,7 +91,8 @@ export class LeadToPlanExecutor extends BaseExecutor {
 
   async executeSpecific(sdId, sd, _options, _gateResults) {
     // Display pre-handoff warnings from recent retrospectives
-    await displayPreHandoffWarnings('LEAD_TO_PLAN', this.supabase);
+    // PAT-LATE-REQ-001: Pass SD to surface type-specific requirements early
+    await displayPreHandoffWarnings('LEAD_TO_PLAN', this.supabase, sd);
 
     // Delegate to existing LeadToPlanVerifier
     const verifier = this.verifier || new LeadToPlanVerifier();

--- a/scripts/modules/handoff/executors/lead-to-plan/pre-handoff-warnings.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/pre-handoff-warnings.js
@@ -7,13 +7,54 @@
  */
 
 /**
+ * PAT-LATE-REQ-001 + PAT-E2E-EARLY-001: Surface SD-type-specific requirements
+ * BEFORE LEAD approval so implementers know what's expected upfront.
+ *
+ * @param {Object} sd - Strategic Directive
+ */
+function displayTypeRequirements(sd) {
+  // Import inline to avoid circular deps at module level
+  const SD_TYPE_REQUIREMENTS = {
+    feature:        { prd: true,  e2e: true,  design: true,  minHandoffs: 4, threshold: '85%' },
+    infrastructure: { prd: true,  e2e: false, design: false, minHandoffs: 3, threshold: '80%' },
+    bugfix:         { prd: false, e2e: false, design: false, minHandoffs: 1, threshold: '70%' },
+    fix:            { prd: false, e2e: false, design: false, minHandoffs: 1, threshold: '70%' },
+    database:       { prd: true,  e2e: false, design: false, minHandoffs: 2, threshold: '80%' },
+    security:       { prd: true,  e2e: true,  design: false, minHandoffs: 3, threshold: '90%' },
+    refactor:       { prd: false, e2e: true,  design: false, minHandoffs: 2, threshold: '80%' },
+    documentation:  { prd: false, e2e: false, design: false, minHandoffs: 1, threshold: '60%' },
+    enhancement:    { prd: false, e2e: false, design: false, minHandoffs: 2, threshold: '75%' },
+    library:        { prd: false, e2e: false, design: false, minHandoffs: 2, threshold: '75%' },
+  };
+
+  const sdType = (sd?.sd_type || 'feature').toLowerCase();
+  const reqs = SD_TYPE_REQUIREMENTS[sdType] || SD_TYPE_REQUIREMENTS.feature;
+
+  console.log('\n📋 SD TYPE REQUIREMENTS (surfaced at LEAD for early awareness):');
+  console.log('='.repeat(70));
+  console.log(`   SD Type:       ${sdType}`);
+  console.log(`   PRD Required:  ${reqs.prd ? '✅ YES' : '⏭️  No'}`);
+  console.log(`   E2E Required:  ${reqs.e2e ? '✅ YES - plan E2E strategy early' : '⏭️  No'}`);
+  console.log(`   DESIGN Review: ${reqs.design ? '✅ YES' : '⏭️  No'}`);
+  console.log(`   Min Handoffs:  ${reqs.minHandoffs}`);
+  console.log(`   Gate Threshold: ${reqs.threshold}`);
+  console.log('');
+}
+
+/**
  * Display pre-handoff warnings from recent retrospectives
  *
  * @param {string} handoffType - Type of handoff
  * @param {Object} supabase - Supabase client
+ * @param {Object} [sd] - Strategic Directive (optional, for type-specific requirements)
  */
-export async function displayPreHandoffWarnings(handoffType, supabase) {
+export async function displayPreHandoffWarnings(handoffType, supabase, sd) {
   try {
+    // PAT-LATE-REQ-001 + PAT-E2E-EARLY-001: Show type requirements first
+    if (sd && handoffType === 'LEAD-TO-PLAN') {
+      displayTypeRequirements(sd);
+    }
+
     console.log('\n⚠️  PRE-HANDOFF WARNINGS: Recent Friction Points');
     console.log('='.repeat(70));
 


### PR DESCRIPTION
## Summary
- **PAT-DESIGN-001**: Add category override in subagent-selection.js - infrastructure-category SDs now skip DESIGN sub-agent even when sd_type profile says designRequired=true
- **PAT-GATE2-BE-001**: Add target_application awareness to design-fidelity.js - EHG_Engineer (backend-only repo) auto-exempts from UI component checks in Gate 2
- **PAT-SDCREATE-001**: Add VALID_DB_SD_TYPES validation in leo-create-sd.js mapToDbType() to catch invalid sd_type values at creation time
- **PAT-LATE-REQ-001 + PAT-E2E-EARLY-001**: Surface SD-type-specific requirements (PRD, E2E, DESIGN, min handoffs, gate threshold) in pre-handoff-warnings.js during LEAD-TO-PLAN for early awareness
- **PAT-SHIP-ORDER-001**: Add ordering documentation and inline message in LEAD-FINAL-APPROVAL Gate 4

## Test plan
- [x] Smoke tests pass (30/30)
- [x] All 6 modified modules import cleanly (syntax verified)
- [x] All 6 issue patterns resolved in database
- [ ] Verify DESIGN sub-agent skipped for infrastructure-category SDs
- [ ] Verify Gate 2 auto-exempts EHG_Engineer target_application
- [ ] Verify LEAD-TO-PLAN shows type requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)