### PR TITLE
feat: add Chairman Preference Store (SD-LEO-INFRA-CHAIRMAN-PREFS-001)

### DIFF
--- a/database/migrations/20260207_chairman_preferences.sql
+++ b/database/migrations/20260207_chairman_preferences.sql
@@ -1,0 +1,92 @@
+-- ============================================================================
+-- Chairman Preferences Table & chairman_decisions Extension
+-- SD-LEO-INFRA-CHAIRMAN-PREFS-001
+-- ============================================================================
+
+BEGIN;
+
+-- ============================================================================
+-- 1. Create chairman_preferences table
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS chairman_preferences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  chairman_id TEXT NOT NULL,
+  venture_id TEXT,  -- NULL = global preference
+  preference_key TEXT NOT NULL,
+  preference_value JSONB NOT NULL,
+  value_type TEXT NOT NULL CHECK (value_type IN ('number', 'string', 'boolean', 'object', 'array')),
+  source TEXT NOT NULL DEFAULT 'chairman_directive',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- Each key defined at most once per scope
+  CONSTRAINT uq_chairman_pref_scope UNIQUE (chairman_id, venture_id, preference_key)
+);
+
+-- Indexes for Filter Engine read patterns
+CREATE INDEX IF NOT EXISTS idx_chairman_prefs_chairman_venture
+  ON chairman_preferences (chairman_id, venture_id);
+
+CREATE INDEX IF NOT EXISTS idx_chairman_prefs_chairman_key
+  ON chairman_preferences (chairman_id, preference_key);
+
+-- Enable RLS
+ALTER TABLE chairman_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "chairman_preferences_select" ON chairman_preferences
+  FOR SELECT USING (true);
+
+CREATE POLICY "chairman_preferences_insert" ON chairman_preferences
+  FOR INSERT WITH CHECK (true);
+
+CREATE POLICY "chairman_preferences_update" ON chairman_preferences
+  FOR UPDATE USING (true);
+
+CREATE POLICY "chairman_preferences_delete" ON chairman_preferences
+  FOR DELETE USING (true);
+
+-- ============================================================================
+-- 2. Extend chairman_decisions with preference linkage
+-- ============================================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'chairman_decisions' AND column_name = 'preference_key'
+  ) THEN
+    ALTER TABLE chairman_decisions ADD COLUMN preference_key TEXT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'chairman_decisions' AND column_name = 'preference_ref_id'
+  ) THEN
+    ALTER TABLE chairman_decisions ADD COLUMN preference_ref_id UUID
+      REFERENCES chairman_preferences(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'chairman_decisions' AND column_name = 'preference_snapshot'
+  ) THEN
+    ALTER TABLE chairman_decisions ADD COLUMN preference_snapshot JSONB;
+  END IF;
+END $$;
+
+-- ============================================================================
+-- 3. Updated_at trigger
+-- ============================================================================
+CREATE OR REPLACE FUNCTION update_chairman_preferences_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_chairman_preferences_updated_at ON chairman_preferences;
+CREATE TRIGGER trg_chairman_preferences_updated_at
+  BEFORE UPDATE ON chairman_preferences
+  FOR EACH ROW EXECUTE FUNCTION update_chairman_preferences_updated_at();
+
+COMMIT;

--- a/lib/eva/chairman-preference-store.js
+++ b/lib/eva/chairman-preference-store.js
@@ -1,0 +1,295 @@
+/**
+ * ChairmanPreferenceStore - CRUD and scoped resolution for chairman preferences
+ *
+ * SD-LEO-INFRA-CHAIRMAN-PREFS-001
+ *
+ * Resolution order:
+ *   1. (chairman_id, venture_id, key) — venture-specific
+ *   2. (chairman_id, null, key)       — global fallback
+ *
+ * Database table: chairman_preferences
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const VALID_VALUE_TYPES = new Set(['number', 'string', 'boolean', 'object', 'array']);
+
+const KNOWN_KEY_VALIDATORS = {
+  'risk.max_drawdown_pct': (v) => {
+    if (typeof v !== 'number') return 'must be a number';
+    if (v < 0 || v > 100) return 'must be between 0 and 100';
+    return null;
+  },
+  'budget.max_monthly_usd': (v) => {
+    if (typeof v !== 'number') return 'must be a number';
+    if (v < 0) return 'must be >= 0';
+    return null;
+  },
+  'tech.stack_directive': (v) => {
+    if (typeof v !== 'string') return 'must be a string';
+    if (v.trim().length === 0) return 'must be non-empty';
+    return null;
+  },
+};
+
+function validateValueType(value, valueType) {
+  switch (valueType) {
+    case 'number': return typeof value === 'number';
+    case 'string': return typeof value === 'string';
+    case 'boolean': return typeof value === 'boolean';
+    case 'object': return typeof value === 'object' && value !== null && !Array.isArray(value);
+    case 'array': return Array.isArray(value);
+    default: return false;
+  }
+}
+
+export class ChairmanPreferenceStore {
+  constructor(options = {}) {
+    this.supabase = options.supabaseClient || createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+    this.logger = options.logger || console;
+  }
+
+  /**
+   * Set (upsert) a preference.
+   * @param {object} params
+   * @param {string} params.chairmanId
+   * @param {string|null} params.ventureId - null for global
+   * @param {string} params.key
+   * @param {*} params.value
+   * @param {string} params.valueType
+   * @param {string} [params.source='chairman_directive']
+   * @returns {Promise<{success: boolean, record?: object, error?: string}>}
+   */
+  async setPreference({ chairmanId, ventureId = null, key, value, valueType, source = 'chairman_directive' }) {
+    if (!VALID_VALUE_TYPES.has(valueType)) {
+      return { success: false, error: `Invalid valueType '${valueType}'. Must be one of: ${[...VALID_VALUE_TYPES].join(', ')}` };
+    }
+
+    if (!validateValueType(value, valueType)) {
+      return { success: false, error: `Value does not match declared valueType '${valueType}' for key '${key}'` };
+    }
+
+    // Run known-key validators
+    const validator = KNOWN_KEY_VALIDATORS[key];
+    if (validator) {
+      const err = validator(value);
+      if (err) {
+        return { success: false, error: `Validation failed for '${key}': ${err}` };
+      }
+    }
+
+    const { data, error } = await this.supabase
+      .from('chairman_preferences')
+      .upsert({
+        chairman_id: chairmanId,
+        venture_id: ventureId,
+        preference_key: key,
+        preference_value: value,
+        value_type: valueType,
+        source,
+        updated_at: new Date().toISOString(),
+      }, {
+        onConflict: 'chairman_id,venture_id,preference_key',
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return { success: false, error: `Failed to set preference: ${error.message}` };
+    }
+
+    this.logger.debug?.('chairman_preference.upsert', {
+      chairmanId, ventureId, key, valueType, source, recordId: data.id,
+    });
+
+    return { success: true, record: data };
+  }
+
+  /**
+   * Get a single preference with scoped resolution.
+   * Checks venture-specific first, then global fallback.
+   * @param {object} params
+   * @param {string} params.chairmanId
+   * @param {string|null} params.ventureId
+   * @param {string} params.key
+   * @returns {Promise<object|null>}
+   */
+  async getPreference({ chairmanId, ventureId = null, key }) {
+    // Try venture-specific first
+    if (ventureId) {
+      const { data: ventureRow } = await this.supabase
+        .from('chairman_preferences')
+        .select('*')
+        .eq('chairman_id', chairmanId)
+        .eq('venture_id', ventureId)
+        .eq('preference_key', key)
+        .single();
+
+      if (ventureRow) {
+        return this._formatResult(ventureRow, 'venture');
+      }
+    }
+
+    // Fall back to global
+    const { data: globalRow } = await this.supabase
+      .from('chairman_preferences')
+      .select('*')
+      .eq('chairman_id', chairmanId)
+      .is('venture_id', null)
+      .eq('preference_key', key)
+      .single();
+
+    if (globalRow) {
+      return this._formatResult(globalRow, 'global');
+    }
+
+    return null;
+  }
+
+  /**
+   * Batch-get preferences with scoped resolution.
+   * At most 2 SQL queries regardless of key count.
+   * @param {object} params
+   * @param {string} params.chairmanId
+   * @param {string|null} params.ventureId
+   * @param {string[]} params.keys
+   * @returns {Promise<Map<string, object>>}
+   */
+  async getPreferences({ chairmanId, ventureId = null, keys }) {
+    const start = Date.now();
+    const resolved = new Map();
+
+    // Query 1: venture-specific (if ventureId provided)
+    if (ventureId) {
+      const { data: ventureRows } = await this.supabase
+        .from('chairman_preferences')
+        .select('*')
+        .eq('chairman_id', chairmanId)
+        .eq('venture_id', ventureId)
+        .in('preference_key', keys);
+
+      if (ventureRows) {
+        for (const row of ventureRows) {
+          resolved.set(row.preference_key, this._formatResult(row, 'venture'));
+        }
+      }
+    }
+
+    // Query 2: global fallback for remaining keys
+    const remainingKeys = keys.filter(k => !resolved.has(k));
+    if (remainingKeys.length > 0) {
+      const { data: globalRows } = await this.supabase
+        .from('chairman_preferences')
+        .select('*')
+        .eq('chairman_id', chairmanId)
+        .is('venture_id', null)
+        .in('preference_key', remainingKeys);
+
+      if (globalRows) {
+        for (const row of globalRows) {
+          resolved.set(row.preference_key, this._formatResult(row, 'global'));
+        }
+      }
+    }
+
+    const durationMs = Date.now() - start;
+    this.logger.debug?.('chairman_preference.resolve', {
+      chairmanId, ventureId,
+      requestedKeysCount: keys.length,
+      resolvedCount: resolved.size,
+      queryDurationMs: durationMs,
+    });
+
+    return resolved;
+  }
+
+  /**
+   * Delete a preference.
+   * @param {object} params
+   * @param {string} params.chairmanId
+   * @param {string|null} params.ventureId
+   * @param {string} params.key
+   * @returns {Promise<{success: boolean, error?: string}>}
+   */
+  async deletePreference({ chairmanId, ventureId = null, key }) {
+    let query = this.supabase
+      .from('chairman_preferences')
+      .delete()
+      .eq('chairman_id', chairmanId)
+      .eq('preference_key', key);
+
+    if (ventureId) {
+      query = query.eq('venture_id', ventureId);
+    } else {
+      query = query.is('venture_id', null);
+    }
+
+    const { error } = await query;
+    if (error) {
+      return { success: false, error: `Failed to delete preference: ${error.message}` };
+    }
+    return { success: true };
+  }
+
+  /**
+   * Link a decision to resolved preferences for audit trail.
+   * @param {object} params
+   * @param {string} params.decisionId - UUID of chairman_decisions row
+   * @param {Map<string, object>} params.resolvedPreferences - from getPreferences
+   * @returns {Promise<{success: boolean, error?: string}>}
+   */
+  async linkDecisionToPreferences({ decisionId, resolvedPreferences }) {
+    // Take the first resolved preference for the primary linkage
+    const entries = [...resolvedPreferences.entries()];
+    if (entries.length === 0) {
+      return { success: true }; // nothing to link
+    }
+
+    const [primaryKey, primaryPref] = entries[0];
+    const snapshot = Object.fromEntries(
+      entries.map(([k, v]) => [k, { value: v.value, scope: v.scope, valueType: v.valueType }])
+    );
+
+    const { error } = await this.supabase
+      .from('chairman_decisions')
+      .update({
+        preference_key: primaryKey,
+        preference_ref_id: primaryPref.id || null,
+        preference_snapshot: snapshot,
+      })
+      .eq('id', decisionId);
+
+    if (error) {
+      return { success: false, error: `Failed to link decision: ${error.message}` };
+    }
+    return { success: true };
+  }
+
+  // --- Private helpers ---
+
+  _formatResult(row, scope) {
+    return {
+      id: row.id,
+      key: row.preference_key,
+      value: row.preference_value,
+      valueType: row.value_type,
+      source: row.source,
+      scope,
+      updatedAt: row.updated_at,
+    };
+  }
+}
+
+/**
+ * Create a ChairmanPreferenceStore with default configuration
+ * @param {object} [options]
+ * @returns {ChairmanPreferenceStore}
+ */
+export function createChairmanPreferenceStore(options = {}) {
+  return new ChairmanPreferenceStore(options);
+}
+
+export default ChairmanPreferenceStore;

--- a/lib/eva/index.js
+++ b/lib/eva/index.js
@@ -6,3 +6,4 @@
  */
 
 export { VentureContextManager, createVentureContextManager } from './venture-context-manager.js';
+export { ChairmanPreferenceStore, createChairmanPreferenceStore } from './chairman-preference-store.js';

--- a/tests/unit/eva/chairman-preference-store.test.js
+++ b/tests/unit/eva/chairman-preference-store.test.js
@@ -1,0 +1,282 @@
+/**
+ * Tests for ChairmanPreferenceStore
+ * SD-LEO-INFRA-CHAIRMAN-PREFS-001
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ChairmanPreferenceStore } from '../../../lib/eva/chairman-preference-store.js';
+
+function createMockSupabase(overrides = {}) {
+  const mockQuery = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    upsert: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+  };
+
+  return {
+    from: vi.fn(() => ({ ...mockQuery, ...overrides })),
+    _mockQuery: mockQuery,
+  };
+}
+
+describe('ChairmanPreferenceStore', () => {
+  let store;
+  let mockSupabase;
+
+  beforeEach(() => {
+    mockSupabase = createMockSupabase();
+    store = new ChairmanPreferenceStore({
+      supabaseClient: mockSupabase,
+      logger: { debug: vi.fn() },
+    });
+  });
+
+  describe('constructor', () => {
+    it('should create instance with custom supabase client', () => {
+      expect(store).toBeInstanceOf(ChairmanPreferenceStore);
+      expect(store.supabase).toBe(mockSupabase);
+    });
+  });
+
+  describe('setPreference', () => {
+    it('should reject invalid valueType', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'test', value: 'x', valueType: 'invalid',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid valueType');
+    });
+
+    it('should reject value/type mismatch', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'test', value: 'not-a-number', valueType: 'number',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('does not match');
+    });
+
+    it('should reject risk.max_drawdown_pct > 100', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'risk.max_drawdown_pct', value: 150, valueType: 'number',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('between 0 and 100');
+    });
+
+    it('should reject negative budget', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'budget.max_monthly_usd', value: -100, valueType: 'number',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('>= 0');
+    });
+
+    it('should reject empty tech stack directive', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'tech.stack_directive', value: '  ', valueType: 'string',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('non-empty');
+    });
+
+    it('should succeed with valid preference', async () => {
+      const mockRecord = { id: 'pref-1', preference_key: 'budget.max_monthly_usd', preference_value: 5000 };
+      const mockFrom = vi.fn().mockReturnValue({
+        upsert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: mockRecord, error: null }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'budget.max_monthly_usd', value: 5000, valueType: 'number',
+      });
+      expect(result.success).toBe(true);
+      expect(result.record).toEqual(mockRecord);
+    });
+  });
+
+  describe('getPreference', () => {
+    it('should return null when no preference found', async () => {
+      const result = await store.getPreference({ chairmanId: 'c1', key: 'missing' });
+      expect(result).toBeNull();
+    });
+
+    it('should return venture-specific preference over global', async () => {
+      const ventureRow = {
+        id: 'v1', preference_key: 'risk.max_drawdown_pct',
+        preference_value: 10, value_type: 'number',
+        source: 'chairman_directive', updated_at: '2026-01-01',
+      };
+
+      const mockFrom = vi.fn().mockImplementation(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
+      }));
+      store.supabase = { from: mockFrom };
+
+      const result = await store.getPreference({
+        chairmanId: 'c1', ventureId: 'venture-1', key: 'risk.max_drawdown_pct',
+      });
+      expect(result.scope).toBe('venture');
+      expect(result.value).toBe(10);
+    });
+
+    it('should fall back to global when venture-specific not found', async () => {
+      let callCount = 0;
+      const globalRow = {
+        id: 'g1', preference_key: 'risk.max_drawdown_pct',
+        preference_value: 20, value_type: 'number',
+        source: 'chairman_directive', updated_at: '2026-01-01',
+      };
+
+      const mockFrom = vi.fn().mockImplementation(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        single: vi.fn().mockImplementation(() => {
+          callCount++;
+          // First call = venture-specific (miss), second = global (hit)
+          if (callCount === 1) return Promise.resolve({ data: null, error: null });
+          return Promise.resolve({ data: globalRow, error: null });
+        }),
+      }));
+      store.supabase = { from: mockFrom };
+
+      const result = await store.getPreference({
+        chairmanId: 'c1', ventureId: 'venture-1', key: 'risk.max_drawdown_pct',
+      });
+      expect(result.scope).toBe('global');
+      expect(result.value).toBe(20);
+    });
+  });
+
+  describe('getPreferences', () => {
+    it('should return resolved map with scope metadata', async () => {
+      const ventureRows = [
+        { id: 'v1', preference_key: 'key1', preference_value: 'val1', value_type: 'string', source: 'test', updated_at: '2026-01-01' },
+      ];
+      const globalRows = [
+        { id: 'g1', preference_key: 'key2', preference_value: 42, value_type: 'number', source: 'test', updated_at: '2026-01-01' },
+      ];
+
+      let queryCount = 0;
+      const mockFrom = vi.fn().mockImplementation(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        in: vi.fn().mockImplementation(function () {
+          queryCount++;
+          if (queryCount === 1) return Promise.resolve({ data: ventureRows, error: null });
+          return Promise.resolve({ data: globalRows, error: null });
+        }),
+      }));
+      store.supabase = { from: mockFrom };
+
+      const result = await store.getPreferences({
+        chairmanId: 'c1', ventureId: 'v1', keys: ['key1', 'key2', 'key3'],
+      });
+
+      expect(result.get('key1').scope).toBe('venture');
+      expect(result.get('key2').scope).toBe('global');
+      expect(result.has('key3')).toBe(false);
+    });
+  });
+
+  describe('deletePreference', () => {
+    it('should delete a preference successfully', async () => {
+      const mockFrom = vi.fn().mockReturnValue({
+        delete: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              is: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const result = await store.deletePreference({
+        chairmanId: 'c1', key: 'budget.max_monthly_usd',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('linkDecisionToPreferences', () => {
+    it('should succeed with empty preferences map', async () => {
+      const result = await store.linkDecisionToPreferences({
+        decisionId: 'd1', resolvedPreferences: new Map(),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should update decision with preference snapshot', async () => {
+      const mockFrom = vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const prefs = new Map([
+        ['risk.max_drawdown_pct', { id: 'p1', value: 10, scope: 'venture', valueType: 'number' }],
+      ]);
+
+      const result = await store.linkDecisionToPreferences({
+        decisionId: 'd1', resolvedPreferences: prefs,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('value type validation', () => {
+    it('should accept object type', async () => {
+      const mockFrom = vi.fn().mockReturnValue({
+        upsert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'x' }, error: null }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'custom.obj', value: { nested: true }, valueType: 'object',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept array type', async () => {
+      const mockFrom = vi.fn().mockReturnValue({
+        upsert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'x' }, error: null }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'custom.arr', value: [1, 2, 3], valueType: 'array',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject array when type is object', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'test', value: [1], valueType: 'object',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Created `chairman_preferences` table with venture/global scoping and unique constraint
- Extended `chairman_decisions` with preference linkage columns (preference_key, preference_ref_id FK, preference_snapshot)
- Implemented `ChairmanPreferenceStore` in `lib/eva/chairman-preference-store.js` with CRUD, scoped resolution (venture overrides global), and batch reads
- Known-key validators for risk tolerance, budget limits, tech stack directives
- 17 unit tests passing

## Test plan
- [x] 17 unit tests pass (validation, scoped resolution, batch reads, delete, decision linkage)
- [x] Migration executed successfully on Supabase
- [ ] Integration test with real DB (deferred to QA SD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)