### PR TITLE
feat: implement Eva Orchestrator v1 with single-stage and loop execution

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -1,0 +1,446 @@
+/**
+ * Eva Orchestrator v1
+ *
+ * SD-LEO-FEAT-EVA-ORCHESTRATOR-001
+ * Core orchestration loop: load venture context, determine current stage,
+ * load stage template, execute sub-agents, run through filter engine,
+ * persist artifacts, advance stage.
+ *
+ * Integrates:
+ *   - VentureContextManager (context loading)
+ *   - ChairmanPreferenceStore (preference loading)
+ *   - VentureStateMachine (stage resolution & transitions)
+ *   - Decision Filter Engine (auto-proceed/review/stop)
+ *   - Stage Gates & Reality Gates (transition validation)
+ *
+ * @module lib/eva/eva-orchestrator
+ */
+
+import { randomUUID } from 'crypto';
+import { VentureContextManager } from './venture-context-manager.js';
+import { ChairmanPreferenceStore } from './chairman-preference-store.js';
+import { evaluateDecision } from './decision-filter-engine.js';
+import { evaluateRealityGate } from './reality-gates.js';
+import { VentureStateMachine } from '../agents/venture-state-machine.js';
+import { validateStageGate } from '../agents/modules/venture-state-machine/stage-gates.js';
+
+// ── Status Constants ────────────────────────────────────────────
+
+const STATUS = Object.freeze({
+  COMPLETED: 'COMPLETED',
+  BLOCKED: 'BLOCKED',
+  FAILED: 'FAILED',
+});
+
+const FILTER_ACTION = Object.freeze({
+  AUTO_PROCEED: 'AUTO_PROCEED',
+  REQUIRE_REVIEW: 'REQUIRE_REVIEW',
+  STOP: 'STOP',
+});
+
+// Filter Engine preference keys
+const FILTER_PREFERENCE_KEYS = [
+  'filter.cost_max_usd',
+  'filter.min_score',
+  'filter.approved_tech_list',
+  'filter.approved_vendor_list',
+  'filter.pivot_keywords',
+];
+
+// ── Public API ──────────────────────────────────────────────────
+
+/**
+ * Execute a single venture stage.
+ *
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture UUID
+ * @param {number} [params.stageId] - Stage to execute (resolved from state machine if omitted)
+ * @param {Object} [params.options]
+ * @param {boolean} [params.options.autoProceed=true] - Auto-advance on filter AUTO_PROCEED
+ * @param {boolean} [params.options.dryRun=false] - Skip persistence and transitions
+ * @param {string} [params.options.idempotencyKey] - Dedup key for artifact persistence
+ * @param {string} [params.options.chairmanId] - Chairman ID for preference loading
+ * @param {Object} [params.options.stageTemplate] - Override stage template (testing)
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger (defaults to console)
+ * @param {Function} [deps.httpClient] - HTTP client for reality gates
+ * @returns {Promise<Object>} Stage result
+ */
+export async function processStage({ ventureId, stageId, options = {} }, deps = {}) {
+  const {
+    supabase, logger = console, httpClient,
+    evaluateDecisionFn = evaluateDecision,
+    evaluateRealityGateFn = evaluateRealityGate,
+    validateStageGateFn = validateStageGate,
+  } = deps;
+  const correlationId = randomUUID();
+  const startedAt = new Date().toISOString();
+  const autoProceed = options.autoProceed !== false;
+
+  if (!supabase) {
+    return buildResult({ ventureId, stageId, startedAt, correlationId, status: STATUS.FAILED, errors: [{ code: 'MISSING_DEPENDENCY', message: 'supabase client is required' }] });
+  }
+
+  // ── Idempotency check ──
+  if (options.idempotencyKey) {
+    const existing = await checkIdempotency(supabase, ventureId, stageId, options.idempotencyKey);
+    if (existing) {
+      logger.log(`[Eva] Idempotent hit for key=${options.idempotencyKey}, returning cached result`);
+      return existing;
+    }
+  }
+
+  // ── 1. Load venture context ──
+  let ventureContext;
+  try {
+    const ctxMgr = new VentureContextManager({ supabaseClient: supabase });
+    const { data: venture, error } = await supabase
+      .from('ventures')
+      .select('id, name, status, current_lifecycle_stage, archetype, created_at')
+      .eq('id', ventureId)
+      .single();
+    if (error || !venture) throw new Error(error?.message || 'Venture not found');
+    ventureContext = venture;
+  } catch (err) {
+    logger.error(`[Eva] Context load failed: ${err.message}`);
+    return buildResult({ ventureId, stageId, startedAt, correlationId, status: STATUS.FAILED, errors: [{ code: 'CONTEXT_LOAD_FAILED', message: err.message }] });
+  }
+
+  // ── 2. Resolve stage ──
+  const resolvedStage = stageId ?? ventureContext.current_lifecycle_stage ?? 1;
+  logger.log(`[Eva] Processing stage ${resolvedStage} for venture ${ventureId} [${correlationId}]`);
+
+  // ── 3. Load chairman preferences ──
+  let preferences = {};
+  try {
+    if (options.chairmanId) {
+      const prefStore = new ChairmanPreferenceStore({ supabaseClient: supabase });
+      const resolved = await prefStore.getPreferences({
+        chairmanId: options.chairmanId,
+        ventureId,
+        keys: FILTER_PREFERENCE_KEYS,
+      });
+      for (const [key, pref] of resolved) {
+        preferences[key] = pref.value;
+      }
+    }
+  } catch (err) {
+    logger.warn(`[Eva] Preference loading failed (non-fatal): ${err.message}`);
+  }
+
+  // ── 4. Load and execute stage template ──
+  let artifacts = [];
+  let stageOutput = {};
+  try {
+    const template = options.stageTemplate || await loadStageTemplate(supabase, resolvedStage);
+    const steps = template?.analysisSteps || [];
+
+    for (const step of steps) {
+      try {
+        const stepResult = typeof step.execute === 'function'
+          ? await step.execute({ ventureContext, preferences, stage: resolvedStage })
+          : { artifactType: step.artifactType || 'generic', payload: {}, source: step.id || 'unknown' };
+
+        artifacts.push({
+          artifactType: stepResult.artifactType || step.artifactType || 'stage_output',
+          stageId: resolvedStage,
+          createdAt: new Date().toISOString(),
+          payload: stepResult.payload || stepResult,
+          source: stepResult.source || step.id || 'template',
+        });
+      } catch (stepErr) {
+        logger.error(`[Eva] Analysis step failed: ${step.id || 'unknown'}: ${stepErr.message}`);
+        return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.FAILED, artifacts, errors: [{ code: 'ANALYSIS_STEP_FAILED', step: step.id, message: stepErr.message }] });
+      }
+    }
+
+    stageOutput = mergeArtifactOutputs(artifacts, ventureContext);
+  } catch (err) {
+    logger.error(`[Eva] Template execution failed: ${err.message}`);
+    return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.FAILED, artifacts, errors: [{ code: 'TEMPLATE_EXECUTION_FAILED', message: err.message }] });
+  }
+
+  // ── 5. Evaluate gates ──
+  const nextStage = resolvedStage + 1;
+  const gateResults = [];
+  let gateBlocked = false;
+
+  try {
+    // Stage gates
+    const stageGateResult = await validateStageGateFn(supabase, ventureId, resolvedStage, nextStage, {
+      chairmanId: options.chairmanId,
+      stageOutput,
+      logger,
+    });
+    gateResults.push({ type: 'stage_gate', ...stageGateResult });
+    if (!stageGateResult.passed) gateBlocked = true;
+
+    // Reality gates
+    const realityGateResult = await evaluateRealityGateFn(
+      { from: resolvedStage, to: nextStage, ventureId },
+      { db: supabase, httpClient, now: () => new Date() }
+    );
+    gateResults.push({ type: 'reality_gate', ...realityGateResult });
+    if (!realityGateResult.passed) gateBlocked = true;
+  } catch (err) {
+    logger.error(`[Eva] Gate evaluation error: ${err.message}`);
+    gateResults.push({ type: 'error', passed: false, error: err.message });
+    gateBlocked = true;
+  }
+
+  if (gateBlocked) {
+    // Persist artifacts even on gate failure
+    if (!options.dryRun) {
+      await persistArtifacts(supabase, ventureId, resolvedStage, artifacts, options.idempotencyKey);
+    }
+    return buildResult({
+      ventureId, stageId: resolvedStage, startedAt, correlationId,
+      status: STATUS.BLOCKED, artifacts, gateResults,
+      errors: gateResults.filter(g => !g.passed).map(g => ({
+        code: g.type === 'stage_gate' ? 'STAGE_GATE_FAILED' : 'REALITY_GATE_FAILED',
+        message: g.summary || g.error || 'Gate check failed',
+      })),
+    });
+  }
+
+  // ── 6. Decision Filter Engine ──
+  let filterDecision;
+  try {
+    const filterInput = {
+      stage: String(resolvedStage),
+      cost: stageOutput.cost,
+      score: stageOutput.score,
+      technologies: stageOutput.technologies || [],
+      vendors: stageOutput.vendors || [],
+      description: stageOutput.description || '',
+      patterns: stageOutput.patterns || [],
+      priorPatterns: stageOutput.priorPatterns || [],
+      constraints: stageOutput.constraints || {},
+      approvedConstraints: stageOutput.approvedConstraints || {},
+    };
+
+    const filterResult = evaluateDecisionFn(filterInput, { preferences, logger });
+
+    // Map filter engine output to PRD-specified action enum
+    let action;
+    if (filterResult.auto_proceed) {
+      action = FILTER_ACTION.AUTO_PROCEED;
+    } else if (filterResult.triggers.some(t => t.severity === 'HIGH')) {
+      action = FILTER_ACTION.STOP;
+    } else {
+      action = FILTER_ACTION.REQUIRE_REVIEW;
+    }
+
+    filterDecision = {
+      action,
+      reasons: filterResult.triggers.map(t => t.message),
+      recommendation: filterResult.recommendation,
+      raw: filterResult,
+    };
+  } catch (err) {
+    logger.error(`[Eva] Filter engine error: ${err.message}`);
+    filterDecision = { action: FILTER_ACTION.REQUIRE_REVIEW, reasons: [`Filter error: ${err.message}`] };
+  }
+
+  // ── 7. Persist artifacts ──
+  if (!options.dryRun) {
+    try {
+      const persistedIds = await persistArtifacts(supabase, ventureId, resolvedStage, artifacts, options.idempotencyKey);
+      artifacts = artifacts.map((a, i) => ({ ...a, id: persistedIds[i] }));
+    } catch (err) {
+      logger.error(`[Eva] Artifact persist failed: ${err.message}`);
+      return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.FAILED, artifacts, filterDecision, gateResults, errors: [{ code: 'ARTIFACT_PERSIST_FAILED', message: err.message }] });
+    }
+  }
+
+  // ── 8. Advance stage (conditional) ──
+  let nextStageId = null;
+  if (filterDecision.action === FILTER_ACTION.AUTO_PROCEED && autoProceed && !options.dryRun) {
+    try {
+      const sm = new VentureStateMachine({ supabaseClient: supabase, ventureId });
+      await sm.initialize();
+      await supabase
+        .from('ventures')
+        .update({ current_lifecycle_stage: nextStage })
+        .eq('id', ventureId);
+      nextStageId = nextStage;
+      logger.log(`[Eva] Advanced venture ${ventureId} to stage ${nextStage}`);
+    } catch (err) {
+      logger.warn(`[Eva] Stage advance failed (non-fatal): ${err.message}`);
+    }
+  } else if (filterDecision.action === FILTER_ACTION.AUTO_PROCEED) {
+    nextStageId = nextStage; // Suggested but not applied
+  }
+
+  return buildResult({
+    ventureId, stageId: resolvedStage, startedAt, correlationId,
+    status: STATUS.COMPLETED, artifacts, filterDecision, gateResults, nextStageId,
+  });
+}
+
+/**
+ * Run the orchestration loop: repeatedly call processStage until a stop condition.
+ *
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture UUID
+ * @param {Object} [params.options]
+ * @param {number} [params.options.maxStages=25] - Max stages to process
+ * @param {boolean} [params.options.autoProceed=true]
+ * @param {string} [params.options.chairmanId]
+ * @param {Object} deps - Injected dependencies
+ * @returns {Promise<Object[]>} Ordered array of stage results
+ */
+export async function run({ ventureId, options = {} }, deps = {}) {
+  const { logger = console } = deps;
+  const maxStages = options.maxStages || 25;
+  const results = [];
+
+  logger.log(`[Eva] Starting orchestration loop for venture ${ventureId} (max ${maxStages} stages)`);
+
+  for (let i = 0; i < maxStages; i++) {
+    const result = await processStage({ ventureId, options }, deps);
+    results.push(result);
+
+    if (result.status === STATUS.FAILED || result.status === STATUS.BLOCKED) {
+      logger.log(`[Eva] Loop stopped: ${result.status} at stage ${result.stageId}`);
+      break;
+    }
+
+    if (result.filterDecision?.action === FILTER_ACTION.STOP) {
+      logger.log(`[Eva] Loop stopped: filter decision STOP at stage ${result.stageId}`);
+      break;
+    }
+
+    if (result.filterDecision?.action === FILTER_ACTION.REQUIRE_REVIEW) {
+      logger.log(`[Eva] Loop stopped: review required at stage ${result.stageId}`);
+      break;
+    }
+
+    if (!result.nextStageId) {
+      logger.log(`[Eva] Loop complete: no next stage after ${result.stageId}`);
+      break;
+    }
+
+    // Next iteration uses the new stage
+    options = { ...options, idempotencyKey: undefined };
+  }
+
+  return results;
+}
+
+// ── Internal Helpers ────────────────────────────────────────────
+
+function buildResult({ ventureId, stageId, startedAt, correlationId, status, artifacts = [], filterDecision = null, gateResults = [], nextStageId = null, errors = [] }) {
+  return {
+    ventureId,
+    stageId,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    correlationId,
+    status,
+    artifacts,
+    filterDecision,
+    gateResults,
+    nextStageId,
+    errors,
+  };
+}
+
+function mergeArtifactOutputs(artifacts, ventureContext) {
+  const output = { description: ventureContext.name || '' };
+  for (const art of artifacts) {
+    if (art.payload) {
+      if (art.payload.cost !== undefined) output.cost = art.payload.cost;
+      if (art.payload.score !== undefined) output.score = art.payload.score;
+      if (art.payload.technologies) output.technologies = art.payload.technologies;
+      if (art.payload.vendors) output.vendors = art.payload.vendors;
+      if (art.payload.patterns) output.patterns = art.payload.patterns;
+    }
+  }
+  return output;
+}
+
+async function loadStageTemplate(supabase, stageId) {
+  const { data } = await supabase
+    .from('venture_stage_templates')
+    .select('template_data')
+    .eq('lifecycle_stage', stageId)
+    .eq('is_active', true)
+    .single();
+
+  if (data?.template_data) return data.template_data;
+
+  // Default minimal template
+  return { stageId, version: '1.0.0', analysisSteps: [] };
+}
+
+async function persistArtifacts(supabase, ventureId, stageId, artifacts, idempotencyKey) {
+  const ids = [];
+  for (const art of artifacts) {
+    const row = {
+      venture_id: ventureId,
+      lifecycle_stage: stageId,
+      artifact_type: art.artifactType,
+      artifact_data: art.payload,
+      is_current: true,
+      source: art.source || 'eva-orchestrator',
+    };
+    if (idempotencyKey) {
+      row.idempotency_key = idempotencyKey;
+    }
+
+    const { data, error } = await supabase
+      .from('venture_artifacts')
+      .insert(row)
+      .select('id')
+      .single();
+
+    if (error) throw new Error(`Failed to persist artifact: ${error.message}`);
+    ids.push(data.id);
+  }
+  return ids;
+}
+
+async function checkIdempotency(supabase, ventureId, stageId, idempotencyKey) {
+  const { data } = await supabase
+    .from('venture_artifacts')
+    .select('id, artifact_type, artifact_data, lifecycle_stage, created_at')
+    .eq('venture_id', ventureId)
+    .eq('idempotency_key', idempotencyKey);
+
+  if (data && data.length > 0) {
+    return {
+      ventureId,
+      stageId: stageId || data[0].lifecycle_stage,
+      startedAt: data[0].created_at,
+      completedAt: data[0].created_at,
+      status: STATUS.COMPLETED,
+      artifacts: data.map(d => ({
+        id: d.id,
+        artifactType: d.artifact_type,
+        stageId: d.lifecycle_stage,
+        createdAt: d.created_at,
+        payload: d.artifact_data,
+        source: 'cached',
+      })),
+      filterDecision: null,
+      gateResults: [],
+      nextStageId: null,
+      errors: [],
+    };
+  }
+  return null;
+}
+
+// ── Exported for testing ────────────────────────────────────────
+
+export const _internal = {
+  buildResult,
+  mergeArtifactOutputs,
+  loadStageTemplate,
+  persistArtifacts,
+  checkIdempotency,
+  STATUS,
+  FILTER_ACTION,
+};

--- a/lib/eva/index.js
+++ b/lib/eva/index.js
@@ -7,3 +7,4 @@
 
 export { VentureContextManager, createVentureContextManager } from './venture-context-manager.js';
 export { ChairmanPreferenceStore, createChairmanPreferenceStore } from './chairman-preference-store.js';
+export { processStage, run } from './eva-orchestrator.js';

--- a/tests/unit/eva-orchestrator.test.js
+++ b/tests/unit/eva-orchestrator.test.js
@@ -1,0 +1,292 @@
+/**
+ * Unit tests for Eva Orchestrator v1
+ * SD-LEO-FEAT-EVA-ORCHESTRATOR-001
+ *
+ * Uses dependency injection (not module mocking) for gate/filter functions.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { processStage, run, _internal } from '../../lib/eva/eva-orchestrator.js';
+
+// ── Test helpers ────────────────────────────────────────────────
+
+function makeChain(resolveValue) {
+  const chain = {
+    select() { return chain; },
+    insert() { return chain; },
+    update() { return chain; },
+    delete() { return chain; },
+    eq() { return chain; },
+    single() { return Promise.resolve(resolveValue); },
+  };
+  return chain;
+}
+
+function mockSupabase() {
+  const ventureData = {
+    id: 'v-001', name: 'Test Venture', status: 'active',
+    current_lifecycle_stage: 3, archetype: 'saas', created_at: '2026-01-01',
+  };
+  return {
+    from: (table) => {
+      if (table === 'ventures') return makeChain({ data: ventureData, error: null });
+      if (table === 'venture_artifacts') return makeChain({ data: { id: 'art-001' }, error: null });
+      if (table === 'venture_stage_templates') return makeChain({ data: null, error: null });
+      return makeChain({ data: null, error: null });
+    },
+  };
+}
+
+const silentLogger = { log: () => {}, error: () => {}, warn: () => {} };
+
+function baseDeps(overrides = {}) {
+  return {
+    supabase: mockSupabase(),
+    logger: silentLogger,
+    evaluateDecisionFn: () => ({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+    evaluateRealityGateFn: async () => ({ passed: true, reasons: [] }),
+    validateStageGateFn: async () => ({ passed: true, gate_name: null, details: {} }),
+    ...overrides,
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+describe('Eva Orchestrator', () => {
+  describe('processStage', () => {
+    it('returns FAILED when supabase is missing', async () => {
+      const result = await processStage({ ventureId: 'v-001' }, {});
+      expect(result.status).toBe('FAILED');
+      expect(result.errors[0].code).toBe('MISSING_DEPENDENCY');
+    });
+
+    it('returns COMPLETED on happy path with auto-proceed', async () => {
+      const result = await processStage(
+        { ventureId: 'v-001', options: { autoProceed: true, dryRun: true } },
+        baseDeps()
+      );
+      expect(result.status).toBe('COMPLETED');
+      expect(result.ventureId).toBe('v-001');
+      expect(result.stageId).toBe(3);
+      expect(result.filterDecision.action).toBe('AUTO_PROCEED');
+    });
+
+    it('uses provided stageId over venture current stage', async () => {
+      const result = await processStage(
+        { ventureId: 'v-001', stageId: 7, options: { dryRun: true } },
+        baseDeps()
+      );
+      expect(result.stageId).toBe(7);
+      expect(result.status).toBe('COMPLETED');
+    });
+
+    it('returns FAILED when venture context load fails', async () => {
+      const failSb = {
+        from: () => makeChain({ data: null, error: { message: 'Not found' } }),
+      };
+      const result = await processStage(
+        { ventureId: 'v-missing' },
+        baseDeps({ supabase: failSb })
+      );
+      expect(result.status).toBe('FAILED');
+      expect(result.errors[0].code).toBe('CONTEXT_LOAD_FAILED');
+    });
+
+    it('returns BLOCKED when stage gate fails', async () => {
+      const result = await processStage(
+        { ventureId: 'v-001', options: { dryRun: true } },
+        baseDeps({
+          validateStageGateFn: async () => ({
+            passed: false, gate_name: 'KILL_GATE_STAGE_5',
+            summary: 'Kill gate failed', status: 'REQUIRES_CHAIRMAN_DECISION',
+          }),
+        })
+      );
+      expect(result.status).toBe('BLOCKED');
+      expect(result.errors.some(e => e.code === 'STAGE_GATE_FAILED')).toBe(true);
+    });
+
+    it('returns BLOCKED when reality gate fails', async () => {
+      const result = await processStage(
+        { ventureId: 'v-001', options: { dryRun: true } },
+        baseDeps({
+          evaluateRealityGateFn: async () => ({
+            passed: false, reasons: [{ code: 'ARTIFACT_MISSING', message: 'missing' }],
+          }),
+        })
+      );
+      expect(result.status).toBe('BLOCKED');
+      expect(result.errors.some(e => e.code === 'REALITY_GATE_FAILED')).toBe(true);
+    });
+
+    it('sets REQUIRE_REVIEW when filter engine has non-HIGH triggers', async () => {
+      const result = await processStage(
+        { ventureId: 'v-001', options: { dryRun: true } },
+        baseDeps({
+          evaluateDecisionFn: () => ({
+            auto_proceed: false,
+            triggers: [{ type: 'low_score', severity: 'MEDIUM', message: 'Score below threshold' }],
+            recommendation: 'PRESENT_TO_CHAIRMAN',
+          }),
+        })
+      );
+      expect(result.status).toBe('COMPLETED');
+      expect(result.filterDecision.action).toBe('REQUIRE_REVIEW');
+    });
+
+    it('sets STOP when filter engine has HIGH triggers', async () => {
+      const result = await processStage(
+        { ventureId: 'v-001', options: { dryRun: true } },
+        baseDeps({
+          evaluateDecisionFn: () => ({
+            auto_proceed: false,
+            triggers: [{ type: 'cost_threshold', severity: 'HIGH', message: 'Cost too high' }],
+            recommendation: 'STOP',
+          }),
+        })
+      );
+      expect(result.filterDecision.action).toBe('STOP');
+    });
+
+    it('executes stage template analysis steps', async () => {
+      const stepExecute = vi.fn().mockResolvedValue({
+        artifactType: 'analysis', payload: { score: 8 }, source: 'test-step',
+      });
+      const result = await processStage(
+        {
+          ventureId: 'v-001',
+          options: {
+            dryRun: true,
+            stageTemplate: {
+              stageId: 3, version: '1.0.0',
+              analysisSteps: [{ id: 'step-1', execute: stepExecute }],
+            },
+          },
+        },
+        baseDeps()
+      );
+      expect(stepExecute).toHaveBeenCalledOnce();
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].artifactType).toBe('analysis');
+    });
+
+    it('returns FAILED when analysis step throws', async () => {
+      const result = await processStage(
+        {
+          ventureId: 'v-001',
+          options: {
+            dryRun: true,
+            stageTemplate: {
+              stageId: 3, version: '1.0.0',
+              analysisSteps: [{
+                id: 'bad-step',
+                execute: async () => { throw new Error('Step exploded'); },
+              }],
+            },
+          },
+        },
+        baseDeps()
+      );
+      expect(result.status).toBe('FAILED');
+      expect(result.errors[0].code).toBe('ANALYSIS_STEP_FAILED');
+      expect(result.errors[0].step).toBe('bad-step');
+    });
+
+    it('does not advance stage when autoProceed is false', async () => {
+      const result = await processStage(
+        { ventureId: 'v-001', options: { autoProceed: false, dryRun: true } },
+        baseDeps()
+      );
+      expect(result.status).toBe('COMPLETED');
+      expect(result.nextStageId).toBe(4);
+    });
+
+    it('includes correlationId and timestamps', async () => {
+      const result = await processStage(
+        { ventureId: 'v-001', options: { dryRun: true } },
+        baseDeps()
+      );
+      expect(result.correlationId).toBeDefined();
+      expect(result.startedAt).toBeDefined();
+      expect(result.completedAt).toBeDefined();
+    });
+  });
+
+  describe('run', () => {
+    it('stops on BLOCKED status', async () => {
+      let callCount = 0;
+      const results = await run(
+        { ventureId: 'v-001', options: { maxStages: 5, dryRun: true } },
+        baseDeps({
+          validateStageGateFn: async () => {
+            callCount++;
+            if (callCount > 1) return { passed: false, summary: 'blocked' };
+            return { passed: true, details: {} };
+          },
+        })
+      );
+      expect(results.length).toBe(2);
+      expect(results[0].status).toBe('COMPLETED');
+      expect(results[1].status).toBe('BLOCKED');
+    });
+
+    it('stops on REQUIRE_REVIEW', async () => {
+      const results = await run(
+        { ventureId: 'v-001', options: { maxStages: 10, dryRun: true } },
+        baseDeps({
+          evaluateDecisionFn: () => ({
+            auto_proceed: false,
+            triggers: [{ type: 'low_score', severity: 'MEDIUM', message: 'review' }],
+            recommendation: 'PRESENT_TO_CHAIRMAN',
+          }),
+        })
+      );
+      expect(results).toHaveLength(1);
+      expect(results[0].filterDecision.action).toBe('REQUIRE_REVIEW');
+    });
+
+    it('respects maxStages limit', async () => {
+      const results = await run(
+        { ventureId: 'v-001', options: { maxStages: 1, dryRun: true } },
+        baseDeps()
+      );
+      expect(results.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('_internal helpers', () => {
+    it('buildResult produces correct shape', () => {
+      const result = _internal.buildResult({
+        ventureId: 'v-001', stageId: 5, startedAt: 'now', correlationId: 'c-1',
+        status: 'COMPLETED',
+      });
+      expect(result).toHaveProperty('ventureId', 'v-001');
+      expect(result).toHaveProperty('stageId', 5);
+      expect(result).toHaveProperty('status', 'COMPLETED');
+      expect(result).toHaveProperty('completedAt');
+      expect(result).toHaveProperty('correlationId', 'c-1');
+      expect(result).toHaveProperty('artifacts');
+      expect(result).toHaveProperty('errors');
+    });
+
+    it('mergeArtifactOutputs combines artifact payloads', () => {
+      const output = _internal.mergeArtifactOutputs(
+        [
+          { payload: { cost: 500, score: 8, technologies: ['React'] } },
+          { payload: { vendors: ['AWS'], patterns: ['microservices'] } },
+        ],
+        { name: 'Test Venture' }
+      );
+      expect(output.cost).toBe(500);
+      expect(output.score).toBe(8);
+      expect(output.technologies).toEqual(['React']);
+      expect(output.vendors).toEqual(['AWS']);
+      expect(output.description).toBe('Test Venture');
+    });
+
+    it('STATUS and FILTER_ACTION constants are frozen', () => {
+      expect(Object.isFrozen(_internal.STATUS)).toBe(true);
+      expect(Object.isFrozen(_internal.FILTER_ACTION)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `processStage()` for single-stage venture lifecycle execution and `run()` for multi-stage looping
- Integrates Stage Gates, Reality Gates, and Decision Filter Engine via dependency injection
- Handles stage template analysis steps with error isolation and artifact persistence with idempotency

## SD Reference
SD-LEO-FEAT-EVA-ORCHESTRATOR-001 (child of SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-001)

## Files Changed
- `lib/eva/eva-orchestrator.js` (new) - Core orchestrator with processStage() and run() exports
- `lib/eva/index.js` (modified) - Added eva-orchestrator exports
- `tests/unit/eva-orchestrator.test.js` (new) - 18 unit tests using DI pattern (no module mocking)

## Test plan
- [x] 18 unit tests passing (6ms execution)
- [x] Happy path: processStage returns COMPLETED with auto-proceed
- [x] Gate failures: stage gate, reality gate produce BLOCKED status
- [x] Filter decisions: REQUIRE_REVIEW and STOP actions work correctly
- [x] Error handling: missing deps, context load failure, analysis step failure
- [x] Loop control: run() stops on BLOCKED, respects maxStages

🤖 Generated with [Claude Code](https://claude.com/claude-code)