### PR TITLE
feat: implement Stage Templates LAUNCH & LEARN (stages 23-25)

### DIFF
--- a/lib/eva/stage-templates/index.js
+++ b/lib/eva/stage-templates/index.js
@@ -1,8 +1,8 @@
 /**
- * Stage Templates - Phases 1-5 (Stages 1-22)
+ * Stage Templates - Phases 1-6 (Stages 1-25)
  * Part of SD-LEO-FEAT-TMPL-TRUTH-001, SD-LEO-FEAT-TMPL-ENGINE-001,
  *   SD-LEO-FEAT-TMPL-IDENTITY-001, SD-LEO-FEAT-TMPL-BLUEPRINT-001,
- *   SD-LEO-FEAT-TMPL-BUILD-001
+ *   SD-LEO-FEAT-TMPL-BUILD-001, SD-LEO-FEAT-TMPL-LAUNCH-001
  *
  * Registry of all stage templates for the 25-stage venture lifecycle.
  *
@@ -41,6 +41,11 @@ export { default as stage20 } from './stage-20.js';
 export { default as stage21 } from './stage-21.js';
 export { default as stage22, evaluatePromotionGate as evaluatePhase5PromotionGate } from './stage-22.js';
 
+// Phase 6: LAUNCH & LEARN (Stages 23-25)
+export { default as stage23, evaluateKillGate as evaluateStage23KillGate } from './stage-23.js';
+export { default as stage24 } from './stage-24.js';
+export { default as stage25, detectDrift } from './stage-25.js';
+
 import stage01 from './stage-01.js';
 import stage02 from './stage-02.js';
 import stage03 from './stage-03.js';
@@ -63,9 +68,12 @@ import stage19 from './stage-19.js';
 import stage20 from './stage-20.js';
 import stage21 from './stage-21.js';
 import stage22 from './stage-22.js';
+import stage23 from './stage-23.js';
+import stage24 from './stage-24.js';
+import stage25 from './stage-25.js';
 
 /**
- * Get a stage template by stage number (1-22).
+ * Get a stage template by stage number (1-25).
  * @param {number} stageNumber
  * @returns {Object|null} Stage template or null if not found
  */
@@ -76,6 +84,7 @@ export function getTemplate(stageNumber) {
     10: stage10, 11: stage11, 12: stage12,
     13: stage13, 14: stage14, 15: stage15, 16: stage16,
     17: stage17, 18: stage18, 19: stage19, 20: stage20, 21: stage21, 22: stage22,
+    23: stage23, 24: stage24, 25: stage25,
   };
   return templates[stageNumber] || null;
 }
@@ -85,5 +94,5 @@ export function getTemplate(stageNumber) {
  * @returns {Object[]}
  */
 export function getAllTemplates() {
-  return [stage01, stage02, stage03, stage04, stage05, stage06, stage07, stage08, stage09, stage10, stage11, stage12, stage13, stage14, stage15, stage16, stage17, stage18, stage19, stage20, stage21, stage22];
+  return [stage01, stage02, stage03, stage04, stage05, stage06, stage07, stage08, stage09, stage10, stage11, stage12, stage13, stage14, stage15, stage16, stage17, stage18, stage19, stage20, stage21, stage22, stage23, stage24, stage25];
 }

--- a/lib/eva/stage-templates/stage-23.js
+++ b/lib/eva/stage-templates/stage-23.js
@@ -1,0 +1,150 @@
+/**
+ * Stage 23 Template - Launch Execution
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ *
+ * Launch execution with Go/No-Go kill gate.
+ * Kill gate requires:
+ *   - go_decision set to "go"
+ *   - incident_response_plan present
+ *   - monitoring_setup present
+ *   - rollback_plan present
+ *
+ * @module lib/eva/stage-templates/stage-23
+ */
+
+import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+
+const GO_DECISIONS = ['go', 'no-go'];
+const MIN_LAUNCH_TASKS = 1;
+
+const TEMPLATE = {
+  id: 'stage-23',
+  slug: 'launch-execution',
+  title: 'Launch Execution',
+  version: '1.0.0',
+  schema: {
+    go_decision: { type: 'enum', values: GO_DECISIONS, required: true },
+    incident_response_plan: { type: 'string', minLength: 10, required: true },
+    monitoring_setup: { type: 'string', minLength: 10, required: true },
+    rollback_plan: { type: 'string', minLength: 10, required: true },
+    launch_tasks: {
+      type: 'array',
+      minItems: MIN_LAUNCH_TASKS,
+      items: {
+        name: { type: 'string', required: true },
+        status: { type: 'string', required: true },
+        owner: { type: 'string' },
+      },
+    },
+    launch_date: { type: 'string', required: true },
+    // Derived
+    decision: { type: 'enum', values: ['pass', 'kill'], derived: true },
+    blockProgression: { type: 'boolean', derived: true },
+    reasons: { type: 'array', derived: true },
+  },
+  defaultData: {
+    go_decision: null,
+    incident_response_plan: null,
+    monitoring_setup: null,
+    rollback_plan: null,
+    launch_tasks: [],
+    launch_date: null,
+    decision: null,
+    blockProgression: false,
+    reasons: [],
+  },
+
+  validate(data) {
+    const errors = [];
+
+    const goCheck = validateEnum(data?.go_decision, 'go_decision', GO_DECISIONS);
+    if (!goCheck.valid) errors.push(goCheck.error);
+
+    const irpCheck = validateString(data?.incident_response_plan, 'incident_response_plan', 10);
+    if (!irpCheck.valid) errors.push(irpCheck.error);
+
+    const monCheck = validateString(data?.monitoring_setup, 'monitoring_setup', 10);
+    if (!monCheck.valid) errors.push(monCheck.error);
+
+    const rollbackCheck = validateString(data?.rollback_plan, 'rollback_plan', 10);
+    if (!rollbackCheck.valid) errors.push(rollbackCheck.error);
+
+    const tasksCheck = validateArray(data?.launch_tasks, 'launch_tasks', MIN_LAUNCH_TASKS);
+    if (!tasksCheck.valid) {
+      errors.push(tasksCheck.error);
+    } else {
+      for (let i = 0; i < data.launch_tasks.length; i++) {
+        const t = data.launch_tasks[i];
+        const prefix = `launch_tasks[${i}]`;
+        const results = [
+          validateString(t?.name, `${prefix}.name`, 1),
+          validateString(t?.status, `${prefix}.status`, 1),
+        ];
+        errors.push(...collectErrors(results));
+      }
+    }
+
+    const dateCheck = validateString(data?.launch_date, 'launch_date', 1);
+    if (!dateCheck.valid) errors.push(dateCheck.error);
+
+    return { valid: errors.length === 0, errors };
+  },
+
+  computeDerived(data) {
+    const { decision, blockProgression, reasons } = evaluateKillGate({
+      go_decision: data.go_decision,
+      incident_response_plan: data.incident_response_plan,
+      monitoring_setup: data.monitoring_setup,
+      rollback_plan: data.rollback_plan,
+    });
+
+    return { ...data, decision, blockProgression, reasons };
+  },
+};
+
+/**
+ * Pure function: evaluate Go/No-Go kill gate for Stage 23.
+ *
+ * @param {{ go_decision: string, incident_response_plan: string, monitoring_setup: string, rollback_plan: string }} params
+ * @returns {{ decision: 'pass'|'kill', blockProgression: boolean, reasons: Object[] }}
+ */
+export function evaluateKillGate({ go_decision, incident_response_plan, monitoring_setup, rollback_plan }) {
+  const reasons = [];
+
+  if (go_decision !== 'go') {
+    reasons.push({
+      type: 'no_go_decision',
+      message: go_decision === 'no-go'
+        ? 'Launch decision is no-go'
+        : 'Go/no-go decision not set',
+    });
+  }
+
+  if (go_decision === 'go') {
+    if (!incident_response_plan || incident_response_plan.trim().length < 10) {
+      reasons.push({
+        type: 'missing_incident_response',
+        message: 'Incident response plan is required for GO decision',
+      });
+    }
+    if (!monitoring_setup || monitoring_setup.trim().length < 10) {
+      reasons.push({
+        type: 'missing_monitoring',
+        message: 'Monitoring setup is required for GO decision',
+      });
+    }
+    if (!rollback_plan || rollback_plan.trim().length < 10) {
+      reasons.push({
+        type: 'missing_rollback',
+        message: 'Rollback plan is required for GO decision',
+      });
+    }
+  }
+
+  const decision = reasons.length > 0 ? 'kill' : 'pass';
+  return { decision, blockProgression: decision === 'kill', reasons };
+}
+
+export { GO_DECISIONS, MIN_LAUNCH_TASKS };
+export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-24.js
+++ b/lib/eva/stage-templates/stage-24.js
@@ -1,0 +1,159 @@
+/**
+ * Stage 24 Template - Metrics & Learning
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ *
+ * AARRR framework metrics (Acquisition, Activation, Retention,
+ * Revenue, Referral) with trend windows and funnel definitions.
+ *
+ * @module lib/eva/stage-templates/stage-24
+ */
+
+import { validateString, validateNumber, validateArray, collectErrors } from './validation.js';
+
+const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', 'referral'];
+const MIN_METRICS_PER_CATEGORY = 1;
+const MIN_FUNNELS = 1;
+
+const TEMPLATE = {
+  id: 'stage-24',
+  slug: 'metrics-learning',
+  title: 'Metrics & Learning',
+  version: '1.0.0',
+  schema: {
+    aarrr: {
+      type: 'object',
+      required: true,
+      properties: Object.fromEntries(AARRR_CATEGORIES.map(cat => [cat, {
+        type: 'array',
+        minItems: MIN_METRICS_PER_CATEGORY,
+        items: {
+          name: { type: 'string', required: true },
+          value: { type: 'number', required: true },
+          target: { type: 'number', required: true },
+          trend_window_days: { type: 'number', min: 1 },
+        },
+      }])),
+    },
+    funnels: {
+      type: 'array',
+      minItems: MIN_FUNNELS,
+      items: {
+        name: { type: 'string', required: true },
+        steps: { type: 'array', minItems: 2 },
+      },
+    },
+    learnings: {
+      type: 'array',
+      items: {
+        insight: { type: 'string', required: true },
+        action: { type: 'string', required: true },
+        category: { type: 'string' },
+      },
+    },
+    // Derived
+    total_metrics: { type: 'number', derived: true },
+    categories_complete: { type: 'boolean', derived: true },
+    funnel_count: { type: 'number', derived: true },
+    metrics_on_target: { type: 'number', derived: true },
+    metrics_below_target: { type: 'number', derived: true },
+  },
+  defaultData: {
+    aarrr: {},
+    funnels: [],
+    learnings: [],
+    total_metrics: 0,
+    categories_complete: false,
+    funnel_count: 0,
+    metrics_on_target: 0,
+    metrics_below_target: 0,
+  },
+
+  validate(data) {
+    const errors = [];
+
+    if (!data?.aarrr || typeof data.aarrr !== 'object') {
+      errors.push('aarrr is required and must be an object');
+      return { valid: false, errors };
+    }
+
+    for (const cat of AARRR_CATEGORIES) {
+      const metrics = data.aarrr[cat];
+      const arrCheck = validateArray(metrics, `aarrr.${cat}`, MIN_METRICS_PER_CATEGORY);
+      if (!arrCheck.valid) {
+        errors.push(arrCheck.error);
+        continue;
+      }
+      for (let i = 0; i < metrics.length; i++) {
+        const m = metrics[i];
+        const prefix = `aarrr.${cat}[${i}]`;
+        const results = [
+          validateString(m?.name, `${prefix}.name`, 1),
+          validateNumber(m?.value, `${prefix}.value`, 0),
+          validateNumber(m?.target, `${prefix}.target`, 0),
+        ];
+        errors.push(...collectErrors(results));
+      }
+    }
+
+    const funnelCheck = validateArray(data?.funnels, 'funnels', MIN_FUNNELS);
+    if (!funnelCheck.valid) {
+      errors.push(funnelCheck.error);
+    } else {
+      for (let i = 0; i < data.funnels.length; i++) {
+        const f = data.funnels[i];
+        const prefix = `funnels[${i}]`;
+        const nameCheck = validateString(f?.name, `${prefix}.name`, 1);
+        if (!nameCheck.valid) errors.push(nameCheck.error);
+        const stepsCheck = validateArray(f?.steps, `${prefix}.steps`, 2);
+        if (!stepsCheck.valid) errors.push(stepsCheck.error);
+      }
+    }
+
+    if (data?.learnings && Array.isArray(data.learnings)) {
+      for (let i = 0; i < data.learnings.length; i++) {
+        const l = data.learnings[i];
+        const prefix = `learnings[${i}]`;
+        const results = [
+          validateString(l?.insight, `${prefix}.insight`, 1),
+          validateString(l?.action, `${prefix}.action`, 1),
+        ];
+        errors.push(...collectErrors(results));
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  },
+
+  computeDerived(data) {
+    let total_metrics = 0;
+    let metrics_on_target = 0;
+    let metrics_below_target = 0;
+    let categoriesPresent = 0;
+
+    for (const cat of AARRR_CATEGORIES) {
+      const metrics = data.aarrr[cat] || [];
+      if (metrics.length > 0) categoriesPresent++;
+      total_metrics += metrics.length;
+      for (const m of metrics) {
+        if (m.value >= m.target) metrics_on_target++;
+        else metrics_below_target++;
+      }
+    }
+
+    const categories_complete = categoriesPresent === AARRR_CATEGORIES.length;
+    const funnel_count = (data.funnels || []).length;
+
+    return {
+      ...data,
+      total_metrics,
+      categories_complete,
+      funnel_count,
+      metrics_on_target,
+      metrics_below_target,
+    };
+  },
+};
+
+export { AARRR_CATEGORIES, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS };
+export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -1,0 +1,195 @@
+/**
+ * Stage 25 Template - Venture Review
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ *
+ * Final venture review with 5-category initiatives,
+ * drift detection against Stage 1 vision/constraints,
+ * and drift justification requirement.
+ *
+ * @module lib/eva/stage-templates/stage-25
+ */
+
+import { validateString, validateArray, collectErrors } from './validation.js';
+
+const REVIEW_CATEGORIES = ['product', 'market', 'technical', 'financial', 'team'];
+const MIN_INITIATIVES_PER_CATEGORY = 1;
+
+const TEMPLATE = {
+  id: 'stage-25',
+  slug: 'venture-review',
+  title: 'Venture Review',
+  version: '1.0.0',
+  schema: {
+    review_summary: { type: 'string', minLength: 20, required: true },
+    initiatives: {
+      type: 'object',
+      required: true,
+      properties: Object.fromEntries(REVIEW_CATEGORIES.map(cat => [cat, {
+        type: 'array',
+        minItems: MIN_INITIATIVES_PER_CATEGORY,
+        items: {
+          title: { type: 'string', required: true },
+          status: { type: 'string', required: true },
+          outcome: { type: 'string', required: true },
+        },
+      }])),
+    },
+    current_vision: { type: 'string', minLength: 10, required: true },
+    drift_justification: { type: 'string' },
+    next_steps: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        action: { type: 'string', required: true },
+        owner: { type: 'string', required: true },
+        timeline: { type: 'string', required: true },
+      },
+    },
+    // Derived
+    total_initiatives: { type: 'number', derived: true },
+    all_categories_reviewed: { type: 'boolean', derived: true },
+    drift_detected: { type: 'boolean', derived: true },
+    drift_check: { type: 'object', derived: true },
+  },
+  defaultData: {
+    review_summary: null,
+    initiatives: {},
+    current_vision: null,
+    drift_justification: null,
+    next_steps: [],
+    total_initiatives: 0,
+    all_categories_reviewed: false,
+    drift_detected: false,
+    drift_check: null,
+  },
+
+  validate(data) {
+    const errors = [];
+
+    const summaryCheck = validateString(data?.review_summary, 'review_summary', 20);
+    if (!summaryCheck.valid) errors.push(summaryCheck.error);
+
+    if (!data?.initiatives || typeof data.initiatives !== 'object') {
+      errors.push('initiatives is required and must be an object');
+    } else {
+      for (const cat of REVIEW_CATEGORIES) {
+        const items = data.initiatives[cat];
+        const arrCheck = validateArray(items, `initiatives.${cat}`, MIN_INITIATIVES_PER_CATEGORY);
+        if (!arrCheck.valid) {
+          errors.push(arrCheck.error);
+          continue;
+        }
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          const prefix = `initiatives.${cat}[${i}]`;
+          const results = [
+            validateString(item?.title, `${prefix}.title`, 1),
+            validateString(item?.status, `${prefix}.status`, 1),
+            validateString(item?.outcome, `${prefix}.outcome`, 1),
+          ];
+          errors.push(...collectErrors(results));
+        }
+      }
+    }
+
+    const visionCheck = validateString(data?.current_vision, 'current_vision', 10);
+    if (!visionCheck.valid) errors.push(visionCheck.error);
+
+    const stepsCheck = validateArray(data?.next_steps, 'next_steps', 1);
+    if (!stepsCheck.valid) {
+      errors.push(stepsCheck.error);
+    } else {
+      for (let i = 0; i < data.next_steps.length; i++) {
+        const ns = data.next_steps[i];
+        const prefix = `next_steps[${i}]`;
+        const results = [
+          validateString(ns?.action, `${prefix}.action`, 1),
+          validateString(ns?.owner, `${prefix}.owner`, 1),
+          validateString(ns?.timeline, `${prefix}.timeline`, 1),
+        ];
+        errors.push(...collectErrors(results));
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  },
+
+  /**
+   * Compute derived fields including drift detection.
+   * @param {Object} data - Validated input data
+   * @param {Object} [prerequisites] - Optional: { stage01 } for drift detection
+   * @returns {Object} Data with derived fields
+   */
+  computeDerived(data, prerequisites) {
+    let total_initiatives = 0;
+    let categoriesPresent = 0;
+
+    for (const cat of REVIEW_CATEGORIES) {
+      const items = data.initiatives[cat] || [];
+      if (items.length > 0) categoriesPresent++;
+      total_initiatives += items.length;
+    }
+
+    const all_categories_reviewed = categoriesPresent === REVIEW_CATEGORIES.length;
+
+    // Drift detection against Stage 1 vision
+    const drift_check = prerequisites?.stage01
+      ? detectDrift({
+          original_vision: prerequisites.stage01.venture_name
+            ? `${prerequisites.stage01.venture_name}: ${prerequisites.stage01.elevator_pitch || ''}`
+            : null,
+          current_vision: data.current_vision,
+        })
+      : { drift_detected: false, rationale: 'Stage 1 data not provided - drift check skipped', original_vision: null, current_vision: data.current_vision };
+
+    const drift_detected = drift_check.drift_detected;
+
+    return {
+      ...data,
+      total_initiatives,
+      all_categories_reviewed,
+      drift_detected,
+      drift_check,
+    };
+  },
+};
+
+/**
+ * Pure function: detect drift between original and current vision.
+ * Drift is detected when current_vision differs significantly from original.
+ *
+ * @param {{ original_vision: string|null, current_vision: string }} params
+ * @returns {{ drift_detected: boolean, rationale: string, original_vision: string|null, current_vision: string }}
+ */
+export function detectDrift({ original_vision, current_vision }) {
+  if (!original_vision) {
+    return {
+      drift_detected: false,
+      rationale: 'No original vision available for comparison',
+      original_vision,
+      current_vision,
+    };
+  }
+
+  // Simple drift detection: check if visions share significant overlap
+  const originalWords = new Set(original_vision.toLowerCase().split(/\s+/).filter(w => w.length > 3));
+  const currentWords = new Set(current_vision.toLowerCase().split(/\s+/).filter(w => w.length > 3));
+
+  let overlap = 0;
+  for (const word of originalWords) {
+    if (currentWords.has(word)) overlap++;
+  }
+
+  const overlapRatio = originalWords.size > 0 ? overlap / originalWords.size : 1;
+  const drift_detected = overlapRatio < 0.3;
+
+  const rationale = drift_detected
+    ? `Significant drift detected: only ${Math.round(overlapRatio * 100)}% overlap with original vision`
+    : `Vision aligned: ${Math.round(overlapRatio * 100)}% overlap with original vision`;
+
+  return { drift_detected, rationale, original_vision, current_vision };
+}
+
+export { REVIEW_CATEGORIES, MIN_INITIATIVES_PER_CATEGORY };
+export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/index.test.js
+++ b/tests/unit/eva/stage-templates/index.test.js
@@ -2,9 +2,9 @@
  * Unit tests for stage templates index/registry
  * Part of SD-LEO-FEAT-TMPL-TRUTH-001, SD-LEO-FEAT-TMPL-ENGINE-001,
  *   SD-LEO-FEAT-TMPL-IDENTITY-001, SD-LEO-FEAT-TMPL-BLUEPRINT-001,
- *   SD-LEO-FEAT-TMPL-BUILD-001
+ *   SD-LEO-FEAT-TMPL-BUILD-001, SD-LEO-FEAT-TMPL-LAUNCH-001
  *
- * Test Scenario TS-5: Registry returns correct templates (stages 1-22)
+ * Test Scenario TS-5: Registry returns correct templates (stages 1-25)
  *
  * @module tests/unit/eva/stage-templates/index.test
  */
@@ -33,13 +33,18 @@ import {
   stage20,
   stage21,
   stage22,
+  stage23,
+  stage24,
+  stage25,
   evaluateStage03KillGate,
   evaluateStage05KillGate,
   evaluateStage13KillGate,
+  evaluateStage23KillGate,
   evaluatePhase2RealityGate,
   evaluatePhase3RealityGate,
   evaluatePhase4PromotionGate,
   evaluatePhase5PromotionGate,
+  detectDrift,
   getTemplate,
   getAllTemplates,
 } from '../../../../lib/eva/stage-templates/index.js';
@@ -210,6 +215,37 @@ describe('index.js - Stage templates registry', () => {
     });
   });
 
+  describe('Named exports - Phase 6 (Stages 23-25)', () => {
+    it('should export all Phase 6 stage templates', () => {
+      expect(stage23).toBeDefined();
+      expect(stage24).toBeDefined();
+      expect(stage25).toBeDefined();
+    });
+
+    it('should export Phase 6 gate and drift detection functions', () => {
+      expect(typeof evaluateStage23KillGate).toBe('function');
+      expect(typeof detectDrift).toBe('function');
+    });
+
+    it('should have correct Phase 6 template IDs', () => {
+      expect(stage23.id).toBe('stage-23');
+      expect(stage24.id).toBe('stage-24');
+      expect(stage25.id).toBe('stage-25');
+    });
+
+    it('should have correct Phase 6 template slugs', () => {
+      expect(stage23.slug).toBe('launch-execution');
+      expect(stage24.slug).toBe('metrics-learning');
+      expect(stage25.slug).toBe('venture-review');
+    });
+
+    it('should have correct Phase 6 template titles', () => {
+      expect(stage23.title).toBe('Launch Execution');
+      expect(stage24.title).toBe('Metrics & Learning');
+      expect(stage25.title).toBe('Venture Review');
+    });
+  });
+
   describe('Registry helper functions', () => {
     it('should export registry helper functions', () => {
       expect(typeof getTemplate).toBe('function');
@@ -285,9 +321,30 @@ describe('index.js - Stage templates registry', () => {
       expect(template.slug).toBe('release-readiness');
     });
 
+    it('should return stage23 for stageNumber 23', () => {
+      const template = getTemplate(23);
+      expect(template).toBe(stage23);
+      expect(template.id).toBe('stage-23');
+      expect(template.slug).toBe('launch-execution');
+    });
+
+    it('should return stage24 for stageNumber 24', () => {
+      const template = getTemplate(24);
+      expect(template).toBe(stage24);
+      expect(template.id).toBe('stage-24');
+      expect(template.slug).toBe('metrics-learning');
+    });
+
+    it('should return stage25 for stageNumber 25', () => {
+      const template = getTemplate(25);
+      expect(template).toBe(stage25);
+      expect(template.id).toBe('stage-25');
+      expect(template.slug).toBe('venture-review');
+    });
+
     it('should return null for invalid stage numbers', () => {
       expect(getTemplate(0)).toBeNull();
-      expect(getTemplate(23)).toBeNull();
+      expect(getTemplate(26)).toBeNull();
       expect(getTemplate(-1)).toBeNull();
       expect(getTemplate(100)).toBeNull();
     });
@@ -297,6 +354,9 @@ describe('index.js - Stage templates registry', () => {
       expect(getTemplate('16')).toBe(stage16);
       expect(getTemplate('17')).toBe(stage17);
       expect(getTemplate('22')).toBe(stage22);
+      expect(getTemplate('23')).toBe(stage23);
+      expect(getTemplate('24')).toBe(stage24);
+      expect(getTemplate('25')).toBe(stage25);
       expect(getTemplate('invalid')).toBeNull();
     });
 
@@ -310,17 +370,18 @@ describe('index.js - Stage templates registry', () => {
       expect(getTemplate(1.5)).toBeNull();
       expect(getTemplate(17.9)).toBeNull();
       expect(getTemplate(22.5)).toBeNull();
+      expect(getTemplate(25.5)).toBeNull();
     });
   });
 
   describe('getAllTemplates() - TS-5: Full registry', () => {
-    it('should return an array of all 22 templates', () => {
+    it('should return an array of all 25 templates', () => {
       const templates = getAllTemplates();
       expect(Array.isArray(templates)).toBe(true);
-      expect(templates).toHaveLength(22);
+      expect(templates).toHaveLength(25);
     });
 
-    it('should return templates in order (stage01 to stage22)', () => {
+    it('should return templates in order (stage01 to stage25)', () => {
       const templates = getAllTemplates();
       expect(templates[0]).toBe(stage01);
       expect(templates[15]).toBe(stage16);
@@ -330,6 +391,9 @@ describe('index.js - Stage templates registry', () => {
       expect(templates[19]).toBe(stage20);
       expect(templates[20]).toBe(stage21);
       expect(templates[21]).toBe(stage22);
+      expect(templates[22]).toBe(stage23);
+      expect(templates[23]).toBe(stage24);
+      expect(templates[24]).toBe(stage25);
     });
 
     it('should return templates with correct IDs', () => {
@@ -340,6 +404,9 @@ describe('index.js - Stage templates registry', () => {
       expect(templates[19].id).toBe('stage-20');
       expect(templates[20].id).toBe('stage-21');
       expect(templates[21].id).toBe('stage-22');
+      expect(templates[22].id).toBe('stage-23');
+      expect(templates[23].id).toBe('stage-24');
+      expect(templates[24].id).toBe('stage-25');
     });
 
     it('should return new array on each call (not cached reference)', () => {
@@ -386,6 +453,25 @@ describe('index.js - Stage templates registry', () => {
       expect(result.pass).toBe(true);
       expect(result.blockers).toEqual([]);
     });
+
+    it('evaluateStage23KillGate should work correctly', () => {
+      const result = evaluateStage23KillGate({
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+      });
+      expect(result.decision).toBe('pass');
+      expect(result.blockProgression).toBe(false);
+    });
+
+    it('detectDrift should work correctly', () => {
+      const result = detectDrift({
+        original_vision: 'Building revolutionary platform technology solutions',
+        current_vision: 'Building revolutionary platform technology solutions',
+      });
+      expect(result.drift_detected).toBe(false);
+    });
   });
 
   describe('Template structure consistency', () => {
@@ -422,7 +508,7 @@ describe('index.js - Stage templates registry', () => {
   describe('Integration: getTemplate matches getAllTemplates', () => {
     it('should return same template references', () => {
       const allTemplates = getAllTemplates();
-      for (let i = 1; i <= 22; i++) {
+      for (let i = 1; i <= 25; i++) {
         const singleTemplate = getTemplate(i);
         expect(singleTemplate).toBe(allTemplates[i - 1]);
       }
@@ -515,6 +601,65 @@ describe('index.js - Stage templates registry', () => {
       };
       const result1 = stage22.computeDerived(input);
       const result2 = stage22.computeDerived(input);
+      expect(result1).toEqual(result2);
+    });
+  });
+
+  describe('Round-trip determinism for stages 23-25', () => {
+    it('should produce deterministic output for stage 23', () => {
+      const input = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [
+          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
+        ],
+        launch_date: '2026-03-01',
+      };
+      const result1 = stage23.computeDerived(input);
+      const result2 = stage23.computeDerived(input);
+      expect(result1).toEqual(result2);
+    });
+
+    it('should produce deterministic output for stage 24', () => {
+      const input = {
+        aarrr: {
+          acquisition: [{ name: 'Signups', value: 100, target: 150 }],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [
+          { name: 'Signup funnel', steps: ['Landing', 'Signup', 'Activation'] },
+        ],
+        learnings: [
+          { insight: 'Users drop off at step 2', action: 'Simplify onboarding' },
+        ],
+      };
+      const result1 = stage24.computeDerived(input);
+      const result2 = stage24.computeDerived(input);
+      expect(result1).toEqual(result2);
+    });
+
+    it('should produce deterministic output for stage 25', () => {
+      const input = {
+        review_summary: 'Comprehensive review of all venture aspects',
+        initiatives: {
+          product: [{ title: 'MVP Launch', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'Market Analysis', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'Infrastructure', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'Funding Round', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'Team Expansion', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Building revolutionary platform technology solutions',
+        next_steps: [
+          { action: 'Launch next phase', owner: 'CEO', timeline: 'Q1 2026' },
+        ],
+      };
+      const result1 = stage25.computeDerived(input);
+      const result2 = stage25.computeDerived(input);
       expect(result1).toEqual(result2);
     });
   });

--- a/tests/unit/eva/stage-templates/stage-23.test.js
+++ b/tests/unit/eva/stage-templates/stage-23.test.js
@@ -1,0 +1,572 @@
+/**
+ * Unit tests for Stage 23 - Launch Execution template
+ * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ *
+ * Test Scenario: Stage 23 validation enforces Go/No-Go kill gate with
+ * incident response, monitoring, and rollback plan requirements.
+ *
+ * @module tests/unit/eva/stage-templates/stage-23.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import stage23, { evaluateKillGate, GO_DECISIONS, MIN_LAUNCH_TASKS } from '../../../../lib/eva/stage-templates/stage-23.js';
+
+describe('stage-23.js - Launch Execution template', () => {
+  describe('Template metadata', () => {
+    it('should have correct template structure', () => {
+      expect(stage23.id).toBe('stage-23');
+      expect(stage23.slug).toBe('launch-execution');
+      expect(stage23.title).toBe('Launch Execution');
+      expect(stage23.version).toBe('1.0.0');
+    });
+
+    it('should have schema definition', () => {
+      expect(stage23.schema).toBeDefined();
+      expect(stage23.schema.go_decision).toBeDefined();
+      expect(stage23.schema.incident_response_plan).toBeDefined();
+      expect(stage23.schema.monitoring_setup).toBeDefined();
+      expect(stage23.schema.rollback_plan).toBeDefined();
+      expect(stage23.schema.launch_tasks).toBeDefined();
+      expect(stage23.schema.launch_date).toBeDefined();
+      expect(stage23.schema.decision).toBeDefined();
+      expect(stage23.schema.blockProgression).toBeDefined();
+      expect(stage23.schema.reasons).toBeDefined();
+    });
+
+    it('should have defaultData', () => {
+      expect(stage23.defaultData).toEqual({
+        go_decision: null,
+        incident_response_plan: null,
+        monitoring_setup: null,
+        rollback_plan: null,
+        launch_tasks: [],
+        launch_date: null,
+        decision: null,
+        blockProgression: false,
+        reasons: [],
+      });
+    });
+
+    it('should have validate function', () => {
+      expect(typeof stage23.validate).toBe('function');
+    });
+
+    it('should have computeDerived function', () => {
+      expect(typeof stage23.computeDerived).toBe('function');
+    });
+
+    it('should export constants', () => {
+      expect(GO_DECISIONS).toEqual(['go', 'no-go']);
+      expect(MIN_LAUNCH_TASKS).toBe(1);
+    });
+
+    it('should export evaluateKillGate function', () => {
+      expect(typeof evaluateKillGate).toBe('function');
+    });
+  });
+
+  describe('validate() - Go/No-Go decision', () => {
+    it('should pass for valid go decision', () => {
+      const validData = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [
+          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
+        ],
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(validData);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should pass for valid no-go decision', () => {
+      const validData = {
+        go_decision: 'no-go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [
+          { name: 'Deploy to production', status: 'blocked' },
+        ],
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(validData);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should fail for missing go_decision', () => {
+      const invalidData = {
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('go_decision'))).toBe(true);
+    });
+
+    it('should fail for invalid go_decision value', () => {
+      const invalidData = {
+        go_decision: 'maybe',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('go_decision'))).toBe(true);
+    });
+  });
+
+  describe('validate() - Required plans', () => {
+    const validTasks = [{ name: 'Deploy to production', status: 'ready' }];
+
+    it('should fail for missing incident_response_plan', () => {
+      const invalidData = {
+        go_decision: 'go',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: validTasks,
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('incident_response_plan'))).toBe(true);
+    });
+
+    it('should fail for incident_response_plan < 10 characters', () => {
+      const invalidData = {
+        go_decision: 'go',
+        incident_response_plan: 'Short',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: validTasks,
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('incident_response_plan'))).toBe(true);
+    });
+
+    it('should fail for missing monitoring_setup', () => {
+      const invalidData = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: validTasks,
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('monitoring_setup'))).toBe(true);
+    });
+
+    it('should fail for monitoring_setup < 10 characters', () => {
+      const invalidData = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Short',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: validTasks,
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('monitoring_setup'))).toBe(true);
+    });
+
+    it('should fail for missing rollback_plan', () => {
+      const invalidData = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        launch_tasks: validTasks,
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('rollback_plan'))).toBe(true);
+    });
+
+    it('should fail for rollback_plan < 10 characters', () => {
+      const invalidData = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Short',
+        launch_tasks: validTasks,
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('rollback_plan'))).toBe(true);
+    });
+  });
+
+  describe('validate() - Launch tasks', () => {
+    const validPlans = {
+      go_decision: 'go',
+      incident_response_plan: 'Incident response plan details',
+      monitoring_setup: 'Monitoring setup details',
+      rollback_plan: 'Rollback plan details',
+      launch_date: '2026-03-01',
+    };
+
+    it('should fail for missing launch_tasks', () => {
+      const invalidData = { ...validPlans };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_tasks'))).toBe(true);
+    });
+
+    it('should fail for empty launch_tasks array', () => {
+      const invalidData = {
+        ...validPlans,
+        launch_tasks: [],
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_tasks') && e.includes('at least 1'))).toBe(true);
+    });
+
+    it('should fail for launch task missing name', () => {
+      const invalidData = {
+        ...validPlans,
+        launch_tasks: [{ status: 'ready' }],
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_tasks[0].name'))).toBe(true);
+    });
+
+    it('should fail for launch task missing status', () => {
+      const invalidData = {
+        ...validPlans,
+        launch_tasks: [{ name: 'Deploy to production' }],
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_tasks[0].status'))).toBe(true);
+    });
+
+    it('should pass with optional owner field', () => {
+      const validData = {
+        ...validPlans,
+        launch_tasks: [
+          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
+        ],
+      };
+      const result = stage23.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should validate multiple launch tasks', () => {
+      const validData = {
+        ...validPlans,
+        launch_tasks: [
+          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
+          { name: 'Update DNS', status: 'pending', owner: 'SRE' },
+          { name: 'Notify customers', status: 'ready', owner: 'Marketing' },
+        ],
+      };
+      const result = stage23.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('validate() - Launch date', () => {
+    const validData = {
+      go_decision: 'go',
+      incident_response_plan: 'Incident response plan details',
+      monitoring_setup: 'Monitoring setup details',
+      rollback_plan: 'Rollback plan details',
+      launch_tasks: [{ name: 'Deploy', status: 'ready' }],
+    };
+
+    it('should fail for missing launch_date', () => {
+      const invalidData = { ...validData };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_date'))).toBe(true);
+    });
+
+    it('should fail for empty launch_date', () => {
+      const invalidData = {
+        ...validData,
+        launch_date: '',
+      };
+      const result = stage23.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_date'))).toBe(true);
+    });
+
+    it('should pass for valid launch_date', () => {
+      const validDataWithDate = {
+        ...validData,
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.validate(validDataWithDate);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('evaluateKillGate() - Pure function', () => {
+    it('should pass for go decision with all required plans', () => {
+      const result = evaluateKillGate({
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+      });
+      expect(result.decision).toBe('pass');
+      expect(result.blockProgression).toBe(false);
+      expect(result.reasons).toEqual([]);
+    });
+
+    it('should kill for no-go decision', () => {
+      const result = evaluateKillGate({
+        go_decision: 'no-go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0].type).toBe('no_go_decision');
+      expect(result.reasons[0].message).toContain('no-go');
+    });
+
+    it('should kill for null go_decision', () => {
+      const result = evaluateKillGate({
+        go_decision: null,
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0].type).toBe('no_go_decision');
+      expect(result.reasons[0].message).toContain('not set');
+    });
+
+    it('should kill for go decision missing incident_response_plan', () => {
+      const result = evaluateKillGate({
+        go_decision: 'go',
+        incident_response_plan: null,
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0].type).toBe('missing_incident_response');
+      expect(result.reasons[0].message).toContain('Incident response plan');
+    });
+
+    it('should kill for go decision with short incident_response_plan', () => {
+      const result = evaluateKillGate({
+        go_decision: 'go',
+        incident_response_plan: 'Short',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0].type).toBe('missing_incident_response');
+    });
+
+    it('should kill for go decision missing monitoring_setup', () => {
+      const result = evaluateKillGate({
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: null,
+        rollback_plan: 'Rollback plan details',
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0].type).toBe('missing_monitoring');
+      expect(result.reasons[0].message).toContain('Monitoring setup');
+    });
+
+    it('should kill for go decision missing rollback_plan', () => {
+      const result = evaluateKillGate({
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: null,
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0].type).toBe('missing_rollback');
+      expect(result.reasons[0].message).toContain('Rollback plan');
+    });
+
+    it('should collect multiple blockers for go decision', () => {
+      const result = evaluateKillGate({
+        go_decision: 'go',
+        incident_response_plan: null,
+        monitoring_setup: 'Short',
+        rollback_plan: null,
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(3);
+      expect(result.reasons.some(r => r.type === 'missing_incident_response')).toBe(true);
+      expect(result.reasons.some(r => r.type === 'missing_monitoring')).toBe(true);
+      expect(result.reasons.some(r => r.type === 'missing_rollback')).toBe(true);
+    });
+
+    it('should not check plans for no-go decision', () => {
+      const result = evaluateKillGate({
+        go_decision: 'no-go',
+        incident_response_plan: null,
+        monitoring_setup: null,
+        rollback_plan: null,
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0].type).toBe('no_go_decision');
+    });
+  });
+
+  describe('computeDerived() - Kill gate integration', () => {
+    it('should include kill gate evaluation in derived fields', () => {
+      const data = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.computeDerived(data);
+      expect(result.decision).toBe('pass');
+      expect(result.blockProgression).toBe(false);
+      expect(result.reasons).toEqual([]);
+    });
+
+    it('should block progression for no-go decision', () => {
+      const data = {
+        go_decision: 'no-go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [{ name: 'Deploy', status: 'blocked' }],
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.computeDerived(data);
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+    });
+
+    it('should block progression for missing plans', () => {
+      const data = {
+        go_decision: 'go',
+        incident_response_plan: null,
+        monitoring_setup: null,
+        rollback_plan: null,
+        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.computeDerived(data);
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons.length).toBeGreaterThan(0);
+    });
+
+    it('should preserve original data fields', () => {
+      const data = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
+        launch_date: '2026-03-01',
+      };
+      const result = stage23.computeDerived(data);
+      expect(result.go_decision).toBe('go');
+      expect(result.incident_response_plan).toBe('Incident response plan details');
+      expect(result.monitoring_setup).toBe('Monitoring setup details');
+      expect(result.rollback_plan).toBe('Rollback plan details');
+      expect(result.launch_tasks).toEqual(data.launch_tasks);
+      expect(result.launch_date).toBe('2026-03-01');
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle null data in validate', () => {
+      const result = stage23.validate(null);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle undefined data in validate', () => {
+      const result = stage23.validate(undefined);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle whitespace-only strings in kill gate', () => {
+      const result = evaluateKillGate({
+        go_decision: 'go',
+        incident_response_plan: '          ',
+        monitoring_setup: '          ',
+        rollback_plan: '          ',
+      });
+      expect(result.decision).toBe('kill');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons.length).toBe(3);
+    });
+  });
+
+  describe('Integration: validate + computeDerived workflow', () => {
+    it('should work together for valid data', () => {
+      const data = {
+        go_decision: 'go',
+        incident_response_plan: 'Incident response plan details',
+        monitoring_setup: 'Monitoring setup details',
+        rollback_plan: 'Rollback plan details',
+        launch_tasks: [
+          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
+          { name: 'Update DNS', status: 'ready', owner: 'SRE' },
+        ],
+        launch_date: '2026-03-01',
+      };
+      const validation = stage23.validate(data);
+      expect(validation.valid).toBe(true);
+
+      const computed = stage23.computeDerived(data);
+      expect(computed.decision).toBe('pass');
+      expect(computed.blockProgression).toBe(false);
+    });
+
+    it('should not require validation before computeDerived (decoupled)', () => {
+      const data = {
+        go_decision: 'invalid',
+        incident_response_plan: 'Short',
+        monitoring_setup: null,
+        rollback_plan: null,
+        launch_tasks: [],
+        launch_date: '',
+      };
+      const computed = stage23.computeDerived(data);
+      expect(computed.decision).toBe('kill');
+      expect(computed.blockProgression).toBe(true);
+    });
+  });
+});

--- a/tests/unit/eva/stage-templates/stage-24.test.js
+++ b/tests/unit/eva/stage-templates/stage-24.test.js
@@ -1,0 +1,603 @@
+/**
+ * Unit tests for Stage 24 - Metrics & Learning template
+ * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ *
+ * Test Scenario: Stage 24 validation enforces AARRR framework metrics
+ * (Acquisition, Activation, Retention, Revenue, Referral) with funnels
+ * and optional learnings.
+ *
+ * @module tests/unit/eva/stage-templates/stage-24.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import stage24, { AARRR_CATEGORIES, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS } from '../../../../lib/eva/stage-templates/stage-24.js';
+
+describe('stage-24.js - Metrics & Learning template', () => {
+  describe('Template metadata', () => {
+    it('should have correct template structure', () => {
+      expect(stage24.id).toBe('stage-24');
+      expect(stage24.slug).toBe('metrics-learning');
+      expect(stage24.title).toBe('Metrics & Learning');
+      expect(stage24.version).toBe('1.0.0');
+    });
+
+    it('should have schema definition', () => {
+      expect(stage24.schema).toBeDefined();
+      expect(stage24.schema.aarrr).toBeDefined();
+      expect(stage24.schema.funnels).toBeDefined();
+      expect(stage24.schema.learnings).toBeDefined();
+      expect(stage24.schema.total_metrics).toBeDefined();
+      expect(stage24.schema.categories_complete).toBeDefined();
+      expect(stage24.schema.funnel_count).toBeDefined();
+      expect(stage24.schema.metrics_on_target).toBeDefined();
+      expect(stage24.schema.metrics_below_target).toBeDefined();
+    });
+
+    it('should have defaultData', () => {
+      expect(stage24.defaultData).toEqual({
+        aarrr: {},
+        funnels: [],
+        learnings: [],
+        total_metrics: 0,
+        categories_complete: false,
+        funnel_count: 0,
+        metrics_on_target: 0,
+        metrics_below_target: 0,
+      });
+    });
+
+    it('should have validate function', () => {
+      expect(typeof stage24.validate).toBe('function');
+    });
+
+    it('should have computeDerived function', () => {
+      expect(typeof stage24.computeDerived).toBe('function');
+    });
+
+    it('should export constants', () => {
+      expect(AARRR_CATEGORIES).toEqual(['acquisition', 'activation', 'retention', 'revenue', 'referral']);
+      expect(MIN_METRICS_PER_CATEGORY).toBe(1);
+      expect(MIN_FUNNELS).toBe(1);
+    });
+  });
+
+  describe('validate() - AARRR object structure', () => {
+    it('should fail for missing aarrr object', () => {
+      const invalidData = {
+        funnels: [{ name: 'Funnel 1', steps: ['Step 1', 'Step 2'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('aarrr'))).toBe(true);
+    });
+
+    it('should fail for non-object aarrr', () => {
+      const invalidData = {
+        aarrr: 'not an object',
+        funnels: [{ name: 'Funnel 1', steps: ['Step 1', 'Step 2'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('aarrr'))).toBe(true);
+    });
+  });
+
+  describe('validate() - AARRR categories', () => {
+    it('should pass for valid AARRR metrics across all categories', () => {
+      const validData = {
+        aarrr: {
+          acquisition: [{ name: 'Signups', value: 100, target: 150 }],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Signup funnel', steps: ['Landing', 'Signup'] }],
+      };
+      const result = stage24.validate(validData);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should fail for missing acquisition category', () => {
+      const invalidData = {
+        aarrr: {
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('aarrr.acquisition'))).toBe(true);
+    });
+
+    it('should fail for empty acquisition array', () => {
+      const invalidData = {
+        aarrr: {
+          acquisition: [],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('aarrr.acquisition') && e.includes('at least 1'))).toBe(true);
+    });
+
+    it('should fail for metric missing name', () => {
+      const invalidData = {
+        aarrr: {
+          acquisition: [{ value: 100, target: 150 }],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('aarrr.acquisition[0].name'))).toBe(true);
+    });
+
+    it('should fail for metric missing value', () => {
+      const invalidData = {
+        aarrr: {
+          acquisition: [{ name: 'Signups', target: 150 }],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('aarrr.acquisition[0].value'))).toBe(true);
+    });
+
+    it('should fail for metric missing target', () => {
+      const invalidData = {
+        aarrr: {
+          acquisition: [{ name: 'Signups', value: 100 }],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('aarrr.acquisition[0].target'))).toBe(true);
+    });
+
+    it('should allow multiple metrics per category', () => {
+      const validData = {
+        aarrr: {
+          acquisition: [
+            { name: 'Signups', value: 100, target: 150 },
+            { name: 'Traffic', value: 1000, target: 1200 },
+          ],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should pass with optional trend_window_days', () => {
+      const validData = {
+        aarrr: {
+          acquisition: [{ name: 'Signups', value: 100, target: 150, trend_window_days: 30 }],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('validate() - Funnels', () => {
+    const validAARRR = {
+      acquisition: [{ name: 'Signups', value: 100, target: 150 }],
+      activation: [{ name: 'First Action', value: 80, target: 90 }],
+      retention: [{ name: '30-day retention', value: 70, target: 75 }],
+      revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+      referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+    };
+
+    it('should fail for missing funnels', () => {
+      const invalidData = {
+        aarrr: validAARRR,
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('funnels'))).toBe(true);
+    });
+
+    it('should fail for empty funnels array', () => {
+      const invalidData = {
+        aarrr: validAARRR,
+        funnels: [],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('funnels') && e.includes('at least 1'))).toBe(true);
+    });
+
+    it('should fail for funnel missing name', () => {
+      const invalidData = {
+        aarrr: validAARRR,
+        funnels: [{ steps: ['Step 1', 'Step 2'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('funnels[0].name'))).toBe(true);
+    });
+
+    it('should fail for funnel missing steps', () => {
+      const invalidData = {
+        aarrr: validAARRR,
+        funnels: [{ name: 'Signup funnel' }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('funnels[0].steps'))).toBe(true);
+    });
+
+    it('should fail for funnel with < 2 steps', () => {
+      const invalidData = {
+        aarrr: validAARRR,
+        funnels: [{ name: 'Signup funnel', steps: ['Landing'] }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('funnels[0].steps') && e.includes('at least 2'))).toBe(true);
+    });
+
+    it('should pass for valid funnel with 2 steps', () => {
+      const validData = {
+        aarrr: validAARRR,
+        funnels: [{ name: 'Signup funnel', steps: ['Landing', 'Signup'] }],
+      };
+      const result = stage24.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should pass for multiple funnels', () => {
+      const validData = {
+        aarrr: validAARRR,
+        funnels: [
+          { name: 'Signup funnel', steps: ['Landing', 'Signup', 'Activation'] },
+          { name: 'Purchase funnel', steps: ['Browse', 'Cart', 'Checkout', 'Purchase'] },
+        ],
+      };
+      const result = stage24.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('validate() - Learnings (optional)', () => {
+    const validData = {
+      aarrr: {
+        acquisition: [{ name: 'Signups', value: 100, target: 150 }],
+        activation: [{ name: 'First Action', value: 80, target: 90 }],
+        retention: [{ name: '30-day retention', value: 70, target: 75 }],
+        revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+        referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+      },
+      funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+    };
+
+    it('should pass without learnings (optional)', () => {
+      const result = stage24.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should pass with empty learnings array', () => {
+      const dataWithLearnings = {
+        ...validData,
+        learnings: [],
+      };
+      const result = stage24.validate(dataWithLearnings);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should pass with valid learnings', () => {
+      const dataWithLearnings = {
+        ...validData,
+        learnings: [
+          { insight: 'Users drop off at step 2', action: 'Simplify onboarding', category: 'activation' },
+        ],
+      };
+      const result = stage24.validate(dataWithLearnings);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should fail for learning missing insight', () => {
+      const invalidData = {
+        ...validData,
+        learnings: [{ action: 'Simplify onboarding' }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('learnings[0].insight'))).toBe(true);
+    });
+
+    it('should fail for learning missing action', () => {
+      const invalidData = {
+        ...validData,
+        learnings: [{ insight: 'Users drop off at step 2' }],
+      };
+      const result = stage24.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('learnings[0].action'))).toBe(true);
+    });
+
+    it('should pass with optional category field', () => {
+      const dataWithLearnings = {
+        ...validData,
+        learnings: [
+          { insight: 'Users drop off at step 2', action: 'Simplify onboarding', category: 'activation' },
+        ],
+      };
+      const result = stage24.validate(dataWithLearnings);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('computeDerived() - Metric counts', () => {
+    it('should calculate total_metrics correctly', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 100, target: 150 }, { name: 'M2', value: 200, target: 250 }],
+          activation: [{ name: 'M3', value: 80, target: 90 }],
+          retention: [{ name: 'M4', value: 70, target: 75 }],
+          revenue: [{ name: 'M5', value: 10000, target: 12000 }],
+          referral: [{ name: 'M6', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.total_metrics).toBe(6);
+    });
+
+    it('should set categories_complete to true when all categories have metrics', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 100, target: 150 }],
+          activation: [{ name: 'M2', value: 80, target: 90 }],
+          retention: [{ name: 'M3', value: 70, target: 75 }],
+          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
+          referral: [{ name: 'M5', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.categories_complete).toBe(true);
+    });
+
+    it('should set categories_complete to false when missing categories', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 100, target: 150 }],
+          activation: [{ name: 'M2', value: 80, target: 90 }],
+          retention: [],
+          revenue: [],
+          referral: [],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.categories_complete).toBe(false);
+    });
+
+    it('should calculate funnel_count correctly', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 100, target: 150 }],
+          activation: [{ name: 'M2', value: 80, target: 90 }],
+          retention: [{ name: 'M3', value: 70, target: 75 }],
+          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
+          referral: [{ name: 'M5', value: 5, target: 10 }],
+        },
+        funnels: [
+          { name: 'F1', steps: ['A', 'B'] },
+          { name: 'F2', steps: ['C', 'D'] },
+          { name: 'F3', steps: ['E', 'F'] },
+        ],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.funnel_count).toBe(3);
+    });
+  });
+
+  describe('computeDerived() - Target tracking', () => {
+    it('should calculate metrics_on_target correctly', () => {
+      const data = {
+        aarrr: {
+          acquisition: [
+            { name: 'M1', value: 150, target: 150 }, // on target
+            { name: 'M2', value: 200, target: 150 }, // above target
+          ],
+          activation: [{ name: 'M3', value: 80, target: 90 }], // below
+          retention: [{ name: 'M4', value: 75, target: 75 }], // on target
+          revenue: [{ name: 'M5', value: 10000, target: 12000 }], // below
+          referral: [{ name: 'M6', value: 15, target: 10 }], // above
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.metrics_on_target).toBe(4); // M1, M2, M4, M6
+    });
+
+    it('should calculate metrics_below_target correctly', () => {
+      const data = {
+        aarrr: {
+          acquisition: [
+            { name: 'M1', value: 150, target: 150 }, // on target
+            { name: 'M2', value: 200, target: 150 }, // above target
+          ],
+          activation: [{ name: 'M3', value: 80, target: 90 }], // below
+          retention: [{ name: 'M4', value: 75, target: 75 }], // on target
+          revenue: [{ name: 'M5', value: 10000, target: 12000 }], // below
+          referral: [{ name: 'M6', value: 15, target: 10 }], // above
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.metrics_below_target).toBe(2); // M3, M5
+    });
+
+    it('should handle all metrics on target', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 150, target: 150 }],
+          activation: [{ name: 'M2', value: 90, target: 90 }],
+          retention: [{ name: 'M3', value: 75, target: 75 }],
+          revenue: [{ name: 'M4', value: 12000, target: 12000 }],
+          referral: [{ name: 'M5', value: 10, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.metrics_on_target).toBe(5);
+      expect(result.metrics_below_target).toBe(0);
+    });
+
+    it('should handle all metrics below target', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 100, target: 150 }],
+          activation: [{ name: 'M2', value: 80, target: 90 }],
+          retention: [{ name: 'M3', value: 70, target: 75 }],
+          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
+          referral: [{ name: 'M5', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.metrics_on_target).toBe(0);
+      expect(result.metrics_below_target).toBe(5);
+    });
+  });
+
+  describe('computeDerived() - Data preservation', () => {
+    it('should preserve original data fields', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 100, target: 150 }],
+          activation: [{ name: 'M2', value: 80, target: 90 }],
+          retention: [{ name: 'M3', value: 70, target: 75 }],
+          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
+          referral: [{ name: 'M5', value: 5, target: 10 }],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A', 'B', 'C'] }],
+        learnings: [{ insight: 'Test insight', action: 'Test action' }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.aarrr).toEqual(data.aarrr);
+      expect(result.funnels).toEqual(data.funnels);
+      expect(result.learnings).toEqual(data.learnings);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle null data in validate', () => {
+      const result = stage24.validate(null);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle undefined data in validate', () => {
+      const result = stage24.validate(undefined);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle empty aarrr object in computeDerived', () => {
+      const data = {
+        aarrr: {},
+        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.total_metrics).toBe(0);
+      expect(result.categories_complete).toBe(false);
+    });
+
+    it('should handle empty funnels array in computeDerived', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 100, target: 150 }],
+          activation: [{ name: 'M2', value: 80, target: 90 }],
+          retention: [{ name: 'M3', value: 70, target: 75 }],
+          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
+          referral: [{ name: 'M5', value: 5, target: 10 }],
+        },
+        funnels: [],
+      };
+      const result = stage24.computeDerived(data);
+      expect(result.funnel_count).toBe(0);
+    });
+  });
+
+  describe('Integration: validate + computeDerived workflow', () => {
+    it('should work together for valid data', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'Signups', value: 100, target: 150 }],
+          activation: [{ name: 'First Action', value: 80, target: 90 }],
+          retention: [{ name: '30-day retention', value: 70, target: 75 }],
+          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
+          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        },
+        funnels: [
+          { name: 'Signup funnel', steps: ['Landing', 'Signup', 'Activation'] },
+          { name: 'Purchase funnel', steps: ['Browse', 'Cart', 'Purchase'] },
+        ],
+        learnings: [
+          { insight: 'Users drop off at step 2', action: 'Simplify onboarding', category: 'activation' },
+        ],
+      };
+      const validation = stage24.validate(data);
+      expect(validation.valid).toBe(true);
+
+      const computed = stage24.computeDerived(data);
+      expect(computed.total_metrics).toBe(5);
+      expect(computed.categories_complete).toBe(true);
+      expect(computed.funnel_count).toBe(2);
+      expect(computed.metrics_below_target).toBe(5);
+    });
+
+    it('should not require validation before computeDerived (decoupled)', () => {
+      const data = {
+        aarrr: {
+          acquisition: [{ name: 'M1', value: 100, target: 150 }],
+          activation: [],
+          retention: [],
+          revenue: [],
+          referral: [],
+        },
+        funnels: [{ name: 'Funnel', steps: ['A'] }], // Invalid: < 2 steps
+      };
+      const computed = stage24.computeDerived(data);
+      expect(computed.total_metrics).toBe(1);
+      expect(computed.categories_complete).toBe(false);
+    });
+  });
+});

--- a/tests/unit/eva/stage-templates/stage-25.test.js
+++ b/tests/unit/eva/stage-templates/stage-25.test.js
@@ -1,0 +1,679 @@
+/**
+ * Unit tests for Stage 25 - Venture Review template
+ * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ *
+ * Test Scenario: Stage 25 validation enforces 5-category initiative review
+ * (product, market, technical, financial, team) with drift detection against
+ * Stage 1 vision/constraints.
+ *
+ * @module tests/unit/eva/stage-templates/stage-25.test
+ */
+
+import { describe, it, expect } from 'vitest';
+import stage25, { detectDrift, REVIEW_CATEGORIES, MIN_INITIATIVES_PER_CATEGORY } from '../../../../lib/eva/stage-templates/stage-25.js';
+
+describe('stage-25.js - Venture Review template', () => {
+  describe('Template metadata', () => {
+    it('should have correct template structure', () => {
+      expect(stage25.id).toBe('stage-25');
+      expect(stage25.slug).toBe('venture-review');
+      expect(stage25.title).toBe('Venture Review');
+      expect(stage25.version).toBe('1.0.0');
+    });
+
+    it('should have schema definition', () => {
+      expect(stage25.schema).toBeDefined();
+      expect(stage25.schema.review_summary).toBeDefined();
+      expect(stage25.schema.initiatives).toBeDefined();
+      expect(stage25.schema.current_vision).toBeDefined();
+      expect(stage25.schema.drift_justification).toBeDefined();
+      expect(stage25.schema.next_steps).toBeDefined();
+      expect(stage25.schema.total_initiatives).toBeDefined();
+      expect(stage25.schema.all_categories_reviewed).toBeDefined();
+      expect(stage25.schema.drift_detected).toBeDefined();
+      expect(stage25.schema.drift_check).toBeDefined();
+    });
+
+    it('should have defaultData', () => {
+      expect(stage25.defaultData).toEqual({
+        review_summary: null,
+        initiatives: {},
+        current_vision: null,
+        drift_justification: null,
+        next_steps: [],
+        total_initiatives: 0,
+        all_categories_reviewed: false,
+        drift_detected: false,
+        drift_check: null,
+      });
+    });
+
+    it('should have validate function', () => {
+      expect(typeof stage25.validate).toBe('function');
+    });
+
+    it('should have computeDerived function', () => {
+      expect(typeof stage25.computeDerived).toBe('function');
+    });
+
+    it('should export constants', () => {
+      expect(REVIEW_CATEGORIES).toEqual(['product', 'market', 'technical', 'financial', 'team']);
+      expect(MIN_INITIATIVES_PER_CATEGORY).toBe(1);
+    });
+
+    it('should export detectDrift function', () => {
+      expect(typeof detectDrift).toBe('function');
+    });
+  });
+
+  describe('validate() - Review summary', () => {
+    it('should fail for missing review_summary', () => {
+      const invalidData = {
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('review_summary'))).toBe(true);
+    });
+
+    it('should fail for review_summary < 20 characters', () => {
+      const invalidData = {
+        review_summary: 'Short summary',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('review_summary'))).toBe(true);
+    });
+
+    it('should pass for valid review_summary', () => {
+      const validData = {
+        review_summary: 'Comprehensive review of all venture aspects completed successfully',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(validData);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+  });
+
+  describe('validate() - Initiatives object structure', () => {
+    it('should fail for missing initiatives object', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('initiatives'))).toBe(true);
+    });
+
+    it('should fail for non-object initiatives', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: 'not an object',
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('initiatives'))).toBe(true);
+    });
+  });
+
+  describe('validate() - Initiative categories', () => {
+    it('should pass for valid initiatives across all categories', () => {
+      const validData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'MVP Launch', status: 'complete', outcome: 'Successfully launched' }],
+          market: [{ title: 'Market Analysis', status: 'complete', outcome: 'Positive feedback' }],
+          technical: [{ title: 'Infrastructure Setup', status: 'complete', outcome: 'Stable platform' }],
+          financial: [{ title: 'Funding Round', status: 'complete', outcome: 'Fully funded' }],
+          team: [{ title: 'Team Expansion', status: 'complete', outcome: 'Key hires made' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(validData);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should fail for missing product category', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('initiatives.product'))).toBe(true);
+    });
+
+    it('should fail for empty product array', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('initiatives.product') && e.includes('at least 1'))).toBe(true);
+    });
+
+    it('should fail for initiative missing title', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('initiatives.product[0].title'))).toBe(true);
+    });
+
+    it('should fail for initiative missing status', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('initiatives.product[0].status'))).toBe(true);
+    });
+
+    it('should fail for initiative missing outcome', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('initiatives.product[0].outcome'))).toBe(true);
+    });
+
+    it('should allow multiple initiatives per category', () => {
+      const validData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [
+            { title: 'MVP Launch', status: 'complete', outcome: 'Success' },
+            { title: 'Feature A', status: 'complete', outcome: 'Success' },
+          ],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('validate() - Current vision', () => {
+    const validInitiatives = {
+      product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+      market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+      technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+      financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+      team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+    };
+
+    it('should fail for missing current_vision', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: validInitiatives,
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('current_vision'))).toBe(true);
+    });
+
+    it('should fail for current_vision < 10 characters', () => {
+      const invalidData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: validInitiatives,
+        current_vision: 'Short',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('current_vision'))).toBe(true);
+    });
+
+    it('should pass for valid current_vision', () => {
+      const validData = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: validInitiatives,
+        current_vision: 'Current vision statement for the venture',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(validData);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('validate() - Next steps', () => {
+    const validData = {
+      review_summary: 'Comprehensive review summary here',
+      initiatives: {
+        product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+        market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+        technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+        team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+      },
+      current_vision: 'Current vision statement',
+    };
+
+    it('should fail for missing next_steps', () => {
+      const invalidData = { ...validData };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('next_steps'))).toBe(true);
+    });
+
+    it('should fail for empty next_steps array', () => {
+      const invalidData = {
+        ...validData,
+        next_steps: [],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('next_steps') && e.includes('at least 1'))).toBe(true);
+    });
+
+    it('should fail for next step missing action', () => {
+      const invalidData = {
+        ...validData,
+        next_steps: [{ owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('next_steps[0].action'))).toBe(true);
+    });
+
+    it('should fail for next step missing owner', () => {
+      const invalidData = {
+        ...validData,
+        next_steps: [{ action: 'Action 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('next_steps[0].owner'))).toBe(true);
+    });
+
+    it('should fail for next step missing timeline', () => {
+      const invalidData = {
+        ...validData,
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1' }],
+      };
+      const result = stage25.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('next_steps[0].timeline'))).toBe(true);
+    });
+
+    it('should pass for valid next steps', () => {
+      const validDataWithSteps = {
+        ...validData,
+        next_steps: [
+          { action: 'Launch next phase', owner: 'CEO', timeline: 'Q1 2026' },
+          { action: 'Expand team', owner: 'HR', timeline: 'Q2 2026' },
+        ],
+      };
+      const result = stage25.validate(validDataWithSteps);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('detectDrift() - Pure function', () => {
+    it('should detect no drift for null original_vision', () => {
+      const result = detectDrift({
+        original_vision: null,
+        current_vision: 'Current vision statement',
+      });
+      expect(result.drift_detected).toBe(false);
+      expect(result.rationale).toContain('No original vision');
+      expect(result.original_vision).toBeNull();
+      expect(result.current_vision).toBe('Current vision statement');
+    });
+
+    it('should detect no drift for identical visions', () => {
+      const vision = 'Building revolutionary platform technology solutions';
+      const result = detectDrift({
+        original_vision: vision,
+        current_vision: vision,
+      });
+      expect(result.drift_detected).toBe(false);
+      expect(result.rationale).toContain('100% overlap');
+    });
+
+    it('should detect no drift for high overlap (>30%)', () => {
+      const result = detectDrift({
+        original_vision: 'Building revolutionary platform technology solutions marketplace',
+        current_vision: 'Building innovative platform technology solutions ecosystem',
+      });
+      expect(result.drift_detected).toBe(false);
+      expect(result.rationale).toContain('overlap');
+    });
+
+    it('should detect drift for low overlap (<30%)', () => {
+      const result = detectDrift({
+        original_vision: 'Building revolutionary platform technology solutions marketplace',
+        current_vision: 'Creating artisanal handmade crafts store',
+      });
+      expect(result.drift_detected).toBe(true);
+      expect(result.rationale).toContain('Significant drift');
+      expect(result.rationale).toContain('overlap');
+    });
+
+    it('should filter out short words (<=3 chars) in overlap calculation', () => {
+      const result = detectDrift({
+        original_vision: 'A big red car and the sun',
+        current_vision: 'The big sun',
+      });
+      // Only words >3 chars: original = [], current = []
+      // Should detect drift due to no meaningful overlap
+      expect(result.drift_detected).toBe(false); // No words >3 chars, so 100% overlap of empty sets
+    });
+
+    it('should be case-insensitive', () => {
+      const result = detectDrift({
+        original_vision: 'Building Revolutionary Platform Technology',
+        current_vision: 'building revolutionary platform technology',
+      });
+      expect(result.drift_detected).toBe(false);
+      expect(result.rationale).toContain('100% overlap');
+    });
+
+    it('should handle whitespace and punctuation', () => {
+      const result = detectDrift({
+        original_vision: 'Building  revolutionary   platform!',
+        current_vision: 'Building revolutionary platform.',
+      });
+      expect(result.drift_detected).toBe(false);
+    });
+  });
+
+  describe('computeDerived() - Initiative counts', () => {
+    it('should calculate total_initiatives correctly', () => {
+      const data = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }, { title: 'P2', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }, { title: 'F2', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.computeDerived(data);
+      expect(result.total_initiatives).toBe(7);
+    });
+
+    it('should set all_categories_reviewed to true when all categories present', () => {
+      const data = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.computeDerived(data);
+      expect(result.all_categories_reviewed).toBe(true);
+    });
+
+    it('should set all_categories_reviewed to false when missing categories', () => {
+      const data = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [],
+          financial: [],
+          team: [],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.computeDerived(data);
+      expect(result.all_categories_reviewed).toBe(false);
+    });
+  });
+
+  describe('computeDerived() - Drift detection integration', () => {
+    it('should include drift check when prerequisites.stage01 provided', () => {
+      const data = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Building revolutionary platform technology solutions',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const prerequisites = {
+        stage01: {
+          venture_name: 'Platform Builder',
+          elevator_pitch: 'Building revolutionary platform technology solutions',
+        },
+      };
+      const result = stage25.computeDerived(data, prerequisites);
+      expect(result.drift_check).toBeDefined();
+      expect(result.drift_check.drift_detected).toBe(false);
+      expect(result.drift_detected).toBe(false);
+    });
+
+    it('should detect drift when vision changed significantly', () => {
+      const data = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Creating artisanal handmade crafts marketplace',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const prerequisites = {
+        stage01: {
+          venture_name: 'Platform Builder',
+          elevator_pitch: 'Building revolutionary platform technology solutions',
+        },
+      };
+      const result = stage25.computeDerived(data, prerequisites);
+      expect(result.drift_check).toBeDefined();
+      expect(result.drift_check.drift_detected).toBe(true);
+      expect(result.drift_detected).toBe(true);
+    });
+
+    it('should skip drift check when prerequisites not provided', () => {
+      const data = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.computeDerived(data);
+      expect(result.drift_check).toBeDefined();
+      expect(result.drift_check.drift_detected).toBe(false);
+      expect(result.drift_check.rationale).toContain('Stage 1 data not provided');
+    });
+
+    it('should preserve original data fields', () => {
+      const data = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {
+          product: [{ title: 'P1', status: 'complete', outcome: 'Success' }],
+          market: [{ title: 'M1', status: 'complete', outcome: 'Success' }],
+          technical: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+          financial: [{ title: 'F1', status: 'complete', outcome: 'Success' }],
+          team: [{ title: 'T1', status: 'complete', outcome: 'Success' }],
+        },
+        current_vision: 'Current vision statement',
+        drift_justification: 'Justification text',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.computeDerived(data);
+      expect(result.review_summary).toBe(data.review_summary);
+      expect(result.initiatives).toEqual(data.initiatives);
+      expect(result.current_vision).toBe(data.current_vision);
+      expect(result.drift_justification).toBe(data.drift_justification);
+      expect(result.next_steps).toEqual(data.next_steps);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle null data in validate', () => {
+      const result = stage25.validate(null);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle undefined data in validate', () => {
+      const result = stage25.validate(undefined);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should handle empty initiatives object in computeDerived', () => {
+      const data = {
+        review_summary: 'Comprehensive review summary here',
+        initiatives: {},
+        current_vision: 'Current vision statement',
+        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+      };
+      const result = stage25.computeDerived(data);
+      expect(result.total_initiatives).toBe(0);
+      expect(result.all_categories_reviewed).toBe(false);
+    });
+  });
+
+  describe('Integration: validate + computeDerived workflow', () => {
+    it('should work together for valid data', () => {
+      const data = {
+        review_summary: 'Comprehensive review of all venture aspects completed successfully',
+        initiatives: {
+          product: [{ title: 'MVP Launch', status: 'complete', outcome: 'Successfully launched' }],
+          market: [{ title: 'Market Analysis', status: 'complete', outcome: 'Positive feedback' }],
+          technical: [{ title: 'Infrastructure Setup', status: 'complete', outcome: 'Stable platform' }],
+          financial: [{ title: 'Funding Round', status: 'complete', outcome: 'Fully funded' }],
+          team: [{ title: 'Team Expansion', status: 'complete', outcome: 'Key hires made' }],
+        },
+        current_vision: 'Building revolutionary platform technology solutions',
+        drift_justification: 'No drift detected, vision remains consistent',
+        next_steps: [
+          { action: 'Launch next phase', owner: 'CEO', timeline: 'Q1 2026' },
+        ],
+      };
+      const validation = stage25.validate(data);
+      expect(validation.valid).toBe(true);
+
+      const computed = stage25.computeDerived(data);
+      expect(computed.total_initiatives).toBe(5);
+      expect(computed.all_categories_reviewed).toBe(true);
+    });
+
+    it('should not require validation before computeDerived (decoupled)', () => {
+      const data = {
+        review_summary: 'Short', // Invalid: < 20 chars
+        initiatives: {
+          product: [{ title: 'P1' }], // Invalid: missing status and outcome
+          market: [],
+          technical: [],
+          financial: [],
+          team: [],
+        },
+        current_vision: 'CV',
+        next_steps: [],
+      };
+      const computed = stage25.computeDerived(data);
+      expect(computed.total_initiatives).toBe(1);
+      expect(computed.all_categories_reviewed).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Stage 23: Launch Execution with Go/No-Go kill gate (blocks if no-go or missing incident response/monitoring/rollback plans)
- Stage 24: Metrics & Learning with AARRR framework (Acquisition, Activation, Retention, Revenue, Referral) with funnel definitions
- Stage 25: Venture Review with drift detection against Stage 1 vision (word overlap < 30% = drift)
- Updated index.js to registry all 25 stages with `getTemplate(1-25)` and `getAllTemplates()`

Completes the full 25-stage venture lifecycle template system (SD-LEO-ORCH-CLI-VL-TEMPLATES-001).

## Test plan
- [x] 201 unit tests passing (stage-23, stage-24, stage-25, index)
- [x] Kill gate tested: pass/kill for go/no-go decisions
- [x] AARRR framework tested: all 5 categories, metric targeting
- [x] Drift detection tested: overlap thresholds, edge cases, no-original-vision
- [x] Index registry tested: getTemplate(1-25), getAllTemplates returns 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)