### PR TITLE
feat: implement Lifecycle-to-SD Bridge (SD-LEO-FEAT-LIFECYCLE-SD-BRIDGE-001)

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -22,6 +22,7 @@ import { ChairmanPreferenceStore } from './chairman-preference-store.js';
 import { evaluateDecision } from './decision-filter-engine.js';
 import { evaluateRealityGate } from './reality-gates.js';
 import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord } from './devils-advocate.js';
+import { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-bridge.js';
 import { VentureStateMachine } from '../agents/venture-state-machine.js';
 import { validateStageGate } from '../agents/modules/venture-state-machine/stage-gates.js';
 
@@ -286,6 +287,25 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     } catch (err) {
       logger.error(`[Eva] Artifact persist failed: ${err.message}`);
       return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.FAILED, artifacts, filterDecision, gateResults, errors: [{ code: 'ARTIFACT_PERSIST_FAILED', message: err.message }] });
+    }
+  }
+
+  // ── 7b. Lifecycle-to-SD Bridge (Stage 18 sprint → LEO SDs) ──
+  if (resolvedStage === 18 && stageOutput.sd_bridge_payloads?.length > 0 && !options.dryRun) {
+    try {
+      const bridgeResult = await convertSprintToSDs(
+        { stageOutput, ventureContext },
+        { supabase, logger },
+      );
+      if (bridgeResult.created) {
+        logger.log(`[Eva] Lifecycle-to-SD Bridge: Created orchestrator ${bridgeResult.orchestratorKey} with ${bridgeResult.childKeys.length} children`);
+      }
+      // Persist bridge result as artifact
+      const bridgeArtifact = buildBridgeArtifactRecord(ventureId, resolvedStage, bridgeResult);
+      const { error: bridgeErr } = await supabase.from('venture_artifacts').insert(bridgeArtifact);
+      if (bridgeErr) logger.warn(`[Eva] Bridge artifact persist failed: ${bridgeErr.message}`);
+    } catch (err) {
+      logger.warn(`[Eva] Lifecycle-to-SD Bridge failed (non-fatal): ${err.message}`);
     }
   }
 

--- a/lib/eva/index.js
+++ b/lib/eva/index.js
@@ -9,3 +9,4 @@ export { VentureContextManager, createVentureContextManager } from './venture-co
 export { ChairmanPreferenceStore, createChairmanPreferenceStore } from './chairman-preference-store.js';
 export { processStage, run } from './eva-orchestrator.js';
 export { getDevilsAdvocateReview, isDevilsAdvocateGate, buildArtifactRecord } from './devils-advocate.js';
+export { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-bridge.js';

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -1,0 +1,284 @@
+/**
+ * Lifecycle-to-SD Bridge
+ *
+ * SD-LEO-FEAT-LIFECYCLE-SD-BRIDGE-001
+ * Converts Stage 18 sprint plan payloads into real LEO Strategic Directives.
+ *
+ * Stage 18 generates `sd_bridge_payloads` with structured data for each
+ * sprint item. This module consumes those payloads, creates an orchestrator
+ * SD for the sprint, and creates child SDs for each sprint item.
+ *
+ * Uses sd-key-generator.js for key generation with venture namespace.
+ *
+ * @module lib/eva/lifecycle-sd-bridge
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import {
+  generateSDKey,
+  generateChildKey,
+  normalizeVenturePrefix,
+} from '../../scripts/modules/sd-key-generator.js';
+
+// Type mapping from Stage 18 types to database sd_type
+const TYPE_MAP = {
+  feature: 'feature',
+  bugfix: 'bugfix',
+  enhancement: 'feature',
+  refactor: 'refactor',
+  infra: 'infrastructure',
+};
+
+/**
+ * Convert Stage 18 sprint plan output into LEO Strategic Directives.
+ *
+ * Creates one orchestrator SD for the sprint, plus one child SD per sprint item.
+ * Idempotent: if the orchestrator already exists for this venture+sprint, returns
+ * existing keys without creating duplicates.
+ *
+ * @param {Object} params
+ * @param {Object} params.stageOutput - Output from Stage 18 (includes sd_bridge_payloads)
+ * @param {Object} params.ventureContext - Venture metadata { id, name }
+ * @param {Object} [deps]
+ * @param {Object} [deps.supabase] - Supabase client override (for testing)
+ * @param {Object} [deps.logger] - Logger (defaults to console)
+ * @returns {Promise<Object>} { created, orchestratorKey, childKeys, errors }
+ */
+export async function convertSprintToSDs(params, deps = {}) {
+  const { stageOutput, ventureContext } = params;
+  const { logger = console } = deps;
+  const supabase = deps.supabase || getSupabaseClient();
+
+  const sprintName = stageOutput.sprint_name;
+  const sprintGoal = stageOutput.sprint_goal;
+  const sprintDuration = stageOutput.sprint_duration_days;
+  const payloads = stageOutput.sd_bridge_payloads || [];
+
+  if (!payloads.length) {
+    logger.warn('[LifecycleSDBridge] No sd_bridge_payloads in stage output');
+    return { created: false, orchestratorKey: null, childKeys: [], errors: ['No sprint items to convert'] };
+  }
+
+  const venturePrefix = ventureContext?.name
+    ? normalizeVenturePrefix(ventureContext.name)
+    : null;
+
+  // Idempotency check: look for existing orchestrator for this venture+sprint
+  const existing = await findExistingOrchestrator(supabase, ventureContext?.id, sprintName);
+  if (existing) {
+    logger.log(`[LifecycleSDBridge] Orchestrator already exists: ${existing.orchestratorKey}`);
+    return {
+      created: false,
+      orchestratorKey: existing.orchestratorKey,
+      childKeys: existing.childKeys,
+      errors: [],
+    };
+  }
+
+  // Generate orchestrator SD key
+  const orchestratorKey = await generateSDKey({
+    source: 'LEO',
+    type: 'orchestrator',
+    title: `Sprint ${sprintName}`,
+    venturePrefix,
+    skipLeadValidation: true,
+  });
+
+  // Create orchestrator SD
+  const orchestratorId = randomUUID();
+  const { error: orchError } = await supabase
+    .from('strategic_directives_v2')
+    .insert({
+      id: orchestratorId,
+      sd_key: orchestratorKey,
+      title: `Sprint: ${sprintName}`,
+      description: `Orchestrator for sprint "${sprintName}". Goal: ${sprintGoal}. Duration: ${sprintDuration} days. Items: ${payloads.length}.`,
+      scope: `Sprint orchestrator coordinating ${payloads.length} child SDs for venture ${ventureContext?.name || 'unknown'}.`,
+      rationale: `Stage 18 sprint planning generated ${payloads.length} items requiring LEO workflow execution.`,
+      sd_type: 'orchestrator',
+      status: 'draft',
+      priority: 'medium',
+      category: 'Feature',
+      current_phase: 'LEAD',
+      target_application: 'EHG_Engineer',
+      created_by: 'lifecycle-sd-bridge',
+      success_criteria: payloads.map(p => p.title),
+      success_metrics: [
+        { metric: 'Child SD completion', target: `${payloads.length}/${payloads.length} children completed`, actual: 'TBD' },
+      ],
+      strategic_objectives: [`Complete sprint "${sprintName}" via LEO workflow`],
+      key_principles: ['Follow LEO Protocol for all changes', 'Each sprint item is an independent SD'],
+      key_changes: payloads.map(p => ({ change: p.title, type: p.type })),
+      smoke_test_steps: [],
+      risks: [],
+      metadata: {
+        created_via: 'lifecycle-sd-bridge',
+        venture_id: ventureContext?.id,
+        venture_name: ventureContext?.name,
+        sprint_name: sprintName,
+        sprint_goal: sprintGoal,
+        sprint_duration_days: sprintDuration,
+        created_at: new Date().toISOString(),
+      },
+    });
+
+  if (orchError) {
+    logger.error(`[LifecycleSDBridge] Failed to create orchestrator: ${orchError.message}`);
+    return { created: false, orchestratorKey: null, childKeys: [], errors: [orchError.message] };
+  }
+
+  logger.log(`[LifecycleSDBridge] Created orchestrator: ${orchestratorKey} (${orchestratorId})`);
+
+  // Create child SDs for each sprint item
+  const childKeys = [];
+  const errors = [];
+
+  for (let i = 0; i < payloads.length; i++) {
+    const payload = payloads[i];
+    const childIndex = String.fromCharCode(65 + i); // A, B, C, ...
+    const childKey = generateChildKey(orchestratorKey, childIndex);
+    const dbType = TYPE_MAP[payload.type] || 'feature';
+
+    const childId = randomUUID();
+    const { error: childError } = await supabase
+      .from('strategic_directives_v2')
+      .insert({
+        id: childId,
+        sd_key: childKey,
+        title: payload.title,
+        description: payload.description,
+        scope: payload.scope,
+        rationale: `Sprint item from "${sprintName}": ${payload.description}`,
+        sd_type: dbType,
+        status: 'draft',
+        priority: payload.priority || 'medium',
+        category: dbType.charAt(0).toUpperCase() + dbType.slice(1),
+        current_phase: 'LEAD',
+        target_application: payload.target_application || 'EHG_Engineer',
+        created_by: 'lifecycle-sd-bridge',
+        parent_sd_id: orchestratorId,
+        success_criteria: [payload.success_criteria],
+        success_metrics: [
+          { metric: 'Implementation completeness', target: '100%', actual: 'TBD' },
+        ],
+        strategic_objectives: [`Deliver: ${payload.title}`],
+        key_principles: ['Follow LEO Protocol for all changes'],
+        key_changes: [{ change: payload.title, type: dbType }],
+        smoke_test_steps: [],
+        risks: (payload.risks || []).map(r =>
+          typeof r === 'string' ? { risk: r, mitigation: 'TBD' } : r,
+        ),
+        metadata: {
+          created_via: 'lifecycle-sd-bridge',
+          venture_id: ventureContext?.id,
+          venture_name: ventureContext?.name,
+          sprint_name: sprintName,
+          sprint_item_index: i,
+          dependencies: payload.dependencies || [],
+          created_at: new Date().toISOString(),
+        },
+      });
+
+    if (childError) {
+      logger.error(`[LifecycleSDBridge] Failed to create child ${childKey}: ${childError.message}`);
+      errors.push(`${childKey}: ${childError.message}`);
+    } else {
+      logger.log(`[LifecycleSDBridge] Created child: ${childKey} (${dbType})`);
+      childKeys.push(childKey);
+    }
+  }
+
+  return {
+    created: true,
+    orchestratorKey,
+    childKeys,
+    errors,
+  };
+}
+
+/**
+ * Build an artifact record for persisting bridge results.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {number} stageId - Stage number (18)
+ * @param {Object} result - Result from convertSprintToSDs
+ * @returns {Object} Row for venture_artifacts insert
+ */
+export function buildBridgeArtifactRecord(ventureId, stageId, result) {
+  return {
+    venture_id: ventureId,
+    lifecycle_stage: stageId,
+    artifact_type: 'lifecycle_sd_bridge',
+    title: `Lifecycle-to-SD Bridge - Stage ${stageId}`,
+    content: JSON.stringify({
+      created: result.created,
+      orchestratorKey: result.orchestratorKey,
+      childKeys: result.childKeys,
+      childCount: result.childKeys.length,
+      errors: result.errors,
+      bridgedAt: new Date().toISOString(),
+    }),
+    metadata: {
+      orchestratorKey: result.orchestratorKey,
+      childCount: result.childKeys.length,
+      hasErrors: result.errors.length > 0,
+    },
+    quality_score: result.errors.length === 0 ? 100 : Math.max(0, 100 - result.errors.length * 25),
+    validation_status: result.errors.length === 0 ? 'validated' : 'pending',
+    validated_by: 'lifecycle-sd-bridge',
+    is_current: true,
+    source: 'lifecycle-sd-bridge',
+  };
+}
+
+// ── Internal Helpers ────────────────────────────────────────────
+
+/**
+ * Check if an orchestrator SD already exists for this venture+sprint combination.
+ */
+async function findExistingOrchestrator(supabase, ventureId, sprintName) {
+  if (!ventureId || !sprintName) return null;
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key')
+    .eq('sd_type', 'orchestrator')
+    .eq('metadata->>venture_id', ventureId)
+    .eq('metadata->>sprint_name', sprintName)
+    .limit(1);
+
+  if (error || !data?.length) return null;
+
+  const orchestrator = data[0];
+
+  // Find children
+  const { data: children } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key')
+    .eq('parent_sd_id', orchestrator.id)
+    .order('sd_key', { ascending: true });
+
+  return {
+    orchestratorKey: orchestrator.sd_key,
+    childKeys: (children || []).map(c => c.sd_key),
+  };
+}
+
+/**
+ * Get Supabase client from environment.
+ */
+function getSupabaseClient() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key);
+}
+
+// ── Exports for testing ─────────────────────────────────────────
+
+export const _internal = {
+  TYPE_MAP,
+  findExistingOrchestrator,
+  getSupabaseClient,
+};

--- a/tests/unit/lifecycle-sd-bridge.test.js
+++ b/tests/unit/lifecycle-sd-bridge.test.js
@@ -1,0 +1,354 @@
+/**
+ * Tests for Lifecycle-to-SD Bridge module
+ * SD-LEO-FEAT-LIFECYCLE-SD-BRIDGE-001
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  convertSprintToSDs,
+  buildBridgeArtifactRecord,
+  _internal,
+} from '../../lib/eva/lifecycle-sd-bridge.js';
+
+const { TYPE_MAP, findExistingOrchestrator } = _internal;
+
+// Mock sd-key-generator
+vi.mock('../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn().mockResolvedValue('SD-ACME-LEO-ORCH-SPRINT-001'),
+  generateChildKey: vi.fn((parentKey, index) => `${parentKey}-${index}`),
+  normalizeVenturePrefix: vi.fn(name => name.toUpperCase().replace(/\s+/g, '-')),
+  keyExists: vi.fn().mockResolvedValue(false),
+  SD_SOURCES: { LEO: 'LEO' },
+  SD_TYPES: { feature: 'FEAT', orchestrator: 'ORCH' },
+}));
+
+function createMockSupabase({ insertError = null, selectData = [], selectError = null } = {}) {
+  const mockSelect = vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({ data: selectData, error: selectError }),
+        }),
+      }),
+    }),
+    order: vi.fn().mockReturnValue({
+      then: vi.fn(),
+    }),
+  });
+
+  return {
+    from: vi.fn().mockReturnValue({
+      insert: vi.fn().mockResolvedValue({ error: insertError }),
+      select: mockSelect,
+    }),
+  };
+}
+
+function createMockLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function createStageOutput(itemCount = 2) {
+  const items = Array.from({ length: itemCount }, (_, i) => ({
+    title: `Feature ${i + 1}`,
+    description: `Description for feature ${i + 1}`,
+    priority: 'high',
+    type: 'feature',
+    scope: `Scope for feature ${i + 1}`,
+    success_criteria: `Feature ${i + 1} works correctly`,
+    dependencies: [],
+    risks: [],
+    target_application: 'EHG_Engineer',
+  }));
+
+  return {
+    sprint_name: 'Sprint Alpha',
+    sprint_goal: 'Deliver core features for MVP launch',
+    sprint_duration_days: 14,
+    items,
+    total_items: items.length,
+    total_story_points: items.length * 5,
+    sd_bridge_payloads: items.map(item => ({
+      title: item.title,
+      description: item.description,
+      priority: item.priority,
+      type: item.type,
+      scope: item.scope,
+      success_criteria: item.success_criteria,
+      dependencies: item.dependencies,
+      risks: item.risks,
+      target_application: item.target_application,
+    })),
+  };
+}
+
+describe('TYPE_MAP', () => {
+  it('maps Stage 18 types to database sd_type values', () => {
+    expect(TYPE_MAP.feature).toBe('feature');
+    expect(TYPE_MAP.bugfix).toBe('bugfix');
+    expect(TYPE_MAP.enhancement).toBe('feature');
+    expect(TYPE_MAP.refactor).toBe('refactor');
+    expect(TYPE_MAP.infra).toBe('infrastructure');
+  });
+});
+
+describe('convertSprintToSDs', () => {
+  let mockSupabase;
+  let mockLogger;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase = createMockSupabase();
+    mockLogger = createMockLogger();
+  });
+
+  it('creates orchestrator and child SDs from sprint payloads', async () => {
+    const stageOutput = createStageOutput(2);
+    const ventureContext = { id: 'venture-uuid-123', name: 'Acme Labs' };
+
+    const result = await convertSprintToSDs(
+      { stageOutput, ventureContext },
+      { supabase: mockSupabase, logger: mockLogger },
+    );
+
+    expect(result.created).toBe(true);
+    expect(result.orchestratorKey).toBe('SD-ACME-LEO-ORCH-SPRINT-001');
+    expect(result.childKeys).toHaveLength(2);
+    expect(result.errors).toHaveLength(0);
+
+    // Verify orchestrator insert was called
+    const fromCalls = mockSupabase.from.mock.calls;
+    expect(fromCalls.some(c => c[0] === 'strategic_directives_v2')).toBe(true);
+  });
+
+  it('returns early with empty payloads', async () => {
+    const stageOutput = { sprint_name: 'Sprint', sprint_goal: 'Goal', sd_bridge_payloads: [] };
+    const ventureContext = { id: 'v-1', name: 'Test' };
+
+    const result = await convertSprintToSDs(
+      { stageOutput, ventureContext },
+      { supabase: mockSupabase, logger: mockLogger },
+    );
+
+    expect(result.created).toBe(false);
+    expect(result.orchestratorKey).toBeNull();
+    expect(result.childKeys).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('No sprint items');
+  });
+
+  it('returns existing SDs on idempotency check (no duplicates)', async () => {
+    // Mock findExistingOrchestrator to return existing
+    const selectMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue({
+              data: [{ id: 'existing-uuid', sd_key: 'SD-ACME-LEO-ORCH-SPRINT-001' }],
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    });
+
+    const childSelectMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({
+          data: [{ sd_key: 'SD-ACME-LEO-ORCH-SPRINT-001-A' }, { sd_key: 'SD-ACME-LEO-ORCH-SPRINT-001-B' }],
+          error: null,
+        }),
+      }),
+    });
+
+    let callCount = 0;
+    const idempotentSupabase = {
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockResolvedValue({ error: null }),
+        select: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) return selectMock();
+          return childSelectMock();
+        }),
+      }),
+    };
+
+    const stageOutput = createStageOutput(2);
+    const ventureContext = { id: 'venture-uuid-123', name: 'Acme Labs' };
+
+    const result = await convertSprintToSDs(
+      { stageOutput, ventureContext },
+      { supabase: idempotentSupabase, logger: mockLogger },
+    );
+
+    expect(result.created).toBe(false);
+    expect(result.orchestratorKey).toBe('SD-ACME-LEO-ORCH-SPRINT-001');
+    expect(result.childKeys).toHaveLength(2);
+  });
+
+  it('handles orchestrator creation failure', async () => {
+    const failSupabase = createMockSupabase({ insertError: { message: 'Unique constraint violation' } });
+    const stageOutput = createStageOutput(1);
+    const ventureContext = { id: 'v-1', name: 'Test' };
+
+    const result = await convertSprintToSDs(
+      { stageOutput, ventureContext },
+      { supabase: failSupabase, logger: mockLogger },
+    );
+
+    expect(result.created).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('Unique constraint');
+  });
+
+  it('handles child creation failure gracefully', async () => {
+    let insertCallCount = 0;
+    const partialFailSupabase = {
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockImplementation(() => {
+          insertCallCount++;
+          if (insertCallCount === 1) return Promise.resolve({ error: null }); // Orchestrator succeeds
+          if (insertCallCount === 2) return Promise.resolve({ error: null }); // Child A succeeds
+          return Promise.resolve({ error: { message: 'Child B failed' } }); // Child B fails
+        }),
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const stageOutput = createStageOutput(2);
+    const ventureContext = { id: 'v-1', name: 'Test' };
+
+    const result = await convertSprintToSDs(
+      { stageOutput, ventureContext },
+      { supabase: partialFailSupabase, logger: mockLogger },
+    );
+
+    expect(result.created).toBe(true);
+    expect(result.childKeys).toHaveLength(1); // Only A succeeded
+    expect(result.errors).toHaveLength(1); // B failed
+    expect(result.errors[0]).toContain('Child B failed');
+  });
+
+  it('handles missing venture context gracefully', async () => {
+    const stageOutput = createStageOutput(1);
+
+    const result = await convertSprintToSDs(
+      { stageOutput, ventureContext: {} },
+      { supabase: mockSupabase, logger: mockLogger },
+    );
+
+    // Should still create SDs without venture prefix
+    expect(result.created).toBe(true);
+    expect(result.orchestratorKey).toBeTruthy();
+  });
+
+  it('maps sprint item types correctly', async () => {
+    const stageOutput = {
+      sprint_name: 'Test Sprint',
+      sprint_goal: 'Test various types',
+      sprint_duration_days: 7,
+      sd_bridge_payloads: [
+        { title: 'Bug Fix', description: 'Fix bug', priority: 'high', type: 'bugfix', scope: 's', success_criteria: 'c', target_application: 'EHG_Engineer' },
+        { title: 'Infra', description: 'Setup', priority: 'low', type: 'infra', scope: 's', success_criteria: 'c', target_application: 'EHG_Engineer' },
+      ],
+    };
+
+    const result = await convertSprintToSDs(
+      { stageOutput, ventureContext: { id: 'v-1', name: 'Test' } },
+      { supabase: mockSupabase, logger: mockLogger },
+    );
+
+    expect(result.created).toBe(true);
+    expect(result.childKeys).toHaveLength(2);
+  });
+});
+
+describe('buildBridgeArtifactRecord', () => {
+  it('builds valid venture_artifacts row for successful bridge', () => {
+    const result = {
+      created: true,
+      orchestratorKey: 'SD-ACME-LEO-ORCH-SPRINT-001',
+      childKeys: ['SD-ACME-LEO-ORCH-SPRINT-001-A', 'SD-ACME-LEO-ORCH-SPRINT-001-B'],
+      errors: [],
+    };
+
+    const row = buildBridgeArtifactRecord('venture-uuid-123', 18, result);
+    expect(row.venture_id).toBe('venture-uuid-123');
+    expect(row.lifecycle_stage).toBe(18);
+    expect(row.artifact_type).toBe('lifecycle_sd_bridge');
+    expect(row.is_current).toBe(true);
+    expect(row.quality_score).toBe(100);
+    expect(row.validation_status).toBe('validated');
+
+    const content = JSON.parse(row.content);
+    expect(content.created).toBe(true);
+    expect(content.orchestratorKey).toBe('SD-ACME-LEO-ORCH-SPRINT-001');
+    expect(content.childCount).toBe(2);
+  });
+
+  it('marks artifacts with errors with reduced quality score', () => {
+    const result = {
+      created: true,
+      orchestratorKey: 'SD-TEST-001',
+      childKeys: ['SD-TEST-001-A'],
+      errors: ['Child B failed', 'Child C failed'],
+    };
+
+    const row = buildBridgeArtifactRecord('venture-uuid', 18, result);
+    expect(row.quality_score).toBe(50); // 100 - 2*25
+    expect(row.validation_status).toBe('pending');
+  });
+
+  it('handles no-creation result (idempotency)', () => {
+    const result = {
+      created: false,
+      orchestratorKey: 'SD-EXISTING-001',
+      childKeys: ['SD-EXISTING-001-A'],
+      errors: [],
+    };
+
+    const row = buildBridgeArtifactRecord('venture-uuid', 18, result);
+    expect(row.quality_score).toBe(100);
+    const content = JSON.parse(row.content);
+    expect(content.created).toBe(false);
+  });
+});
+
+describe('findExistingOrchestrator', () => {
+  it('returns null when no match found', async () => {
+    const mockSupabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await findExistingOrchestrator(mockSupabase, 'venture-1', 'Sprint Alpha');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when ventureId is missing', async () => {
+    const result = await findExistingOrchestrator({}, null, 'Sprint Alpha');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when sprintName is missing', async () => {
+    const result = await findExistingOrchestrator({}, 'venture-1', null);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Implement `lifecycle-sd-bridge.js` module that converts Stage 18 sprint planning output into real LEO Strategic Directives
- Creates an orchestrator SD per sprint with child SDs for each sprint item
- Idempotency: checks for existing orchestrator by venture_id + sprint_name before creating
- Non-fatal integration into `eva-orchestrator.js` step 7b (failures logged, not blocking)
- Type mapping from Stage 18 types (feature, bugfix, enhancement, refactor, infra) to database sd_type values
- Bridge results persisted as `lifecycle_sd_bridge` artifact in venture_artifacts

## Test plan
- [x] 14 unit tests passing (lifecycle-sd-bridge.test.js)
- [x] TYPE_MAP validation tests
- [x] convertSprintToSDs: success path, empty payloads, idempotency, orchestrator failure, partial child failure, missing venture context, type mapping
- [x] buildBridgeArtifactRecord: success, errors, idempotency cases
- [x] findExistingOrchestrator: no match, missing params
- [x] ESLint clean
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)