### PR TITLE
feat: port frontend venture services to CLI-compatible modules

### DIFF
--- a/lib/eva/index.js
+++ b/lib/eva/index.js
@@ -10,3 +10,33 @@ export { ChairmanPreferenceStore, createChairmanPreferenceStore } from './chairm
 export { processStage, run } from './eva-orchestrator.js';
 export { getDevilsAdvocateReview, isDevilsAdvocateGate, buildArtifactRecord } from './devils-advocate.js';
 export { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-bridge.js';
+
+// CLI-compatible ports of frontend venture services (SD-LEO-FEAT-SERVICE-PORTS-001)
+export {
+  verifyBackendConnection,
+  createResearchSession,
+  getResearchSession,
+  listResearchSessions,
+  pollResearchSession,
+  runResearch,
+  getLatestResearchSession,
+  createMockResearchSession,
+  CompetitiveIntelligenceService,
+  getBrandGenomesByVenture,
+  getBrandGenomeList,
+  getBrandGenome,
+  getActiveBrandGenomes,
+  getLatestBrandGenome,
+  createBrandGenome,
+  updateBrandGenome,
+  updateBrandData,
+  submitBrandGenome,
+  approveBrandGenome,
+  archiveBrandGenome,
+  deleteBrandGenome,
+  getBrandGenomesByStatus,
+  getBrandCompletenessStats,
+  getCompletenessScore,
+  meetsCompletenessThreshold,
+  getRequiredFieldsMissing,
+} from './services/index.js';

--- a/lib/eva/services/brand-genome.js
+++ b/lib/eva/services/brand-genome.js
@@ -1,0 +1,320 @@
+/**
+ * Brand Genome Service (CLI Port)
+ *
+ * SD-LEO-FEAT-SERVICE-PORTS-001
+ * CLI-compatible port of ehg/src/services/brandGenomeService.ts
+ *
+ * Differences from frontend:
+ * - Supabase client passed to every function (no frontend import)
+ * - createBrandGenome accepts explicit createdBy param (no auth.getUser())
+ * - Pure CRUD operations, no UI-specific logic
+ *
+ * @module lib/eva/services/brand-genome
+ */
+
+/**
+ * Get all brand genomes for a venture.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} ventureId
+ * @returns {Promise<Object[]>}
+ */
+export async function getBrandGenomesByVenture(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('brand_genome_submissions')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .is('archived_at', null)
+    .order('created_at', { ascending: false });
+
+  if (error) throw new Error(`Failed to fetch brand genomes: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get all brand genomes, optionally filtered by venture.
+ *
+ * @param {Object} supabase
+ * @param {string} [ventureId]
+ * @returns {Promise<Object[]>}
+ */
+export async function getBrandGenomeList(supabase, ventureId) {
+  let query = supabase
+    .from('brand_genome_submissions')
+    .select('*')
+    .is('archived_at', null)
+    .order('created_at', { ascending: false });
+
+  if (ventureId) {
+    query = query.eq('venture_id', ventureId);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to fetch brand genome list: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get a single brand genome by ID.
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @returns {Promise<Object|null>}
+ */
+export async function getBrandGenome(supabase, id) {
+  const { data, error } = await supabase
+    .from('brand_genome_submissions')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return null;
+    throw new Error(`Failed to fetch brand genome: ${error.message}`);
+  }
+  return data;
+}
+
+/**
+ * Get active (published) brand genomes.
+ *
+ * @param {Object} supabase
+ * @param {string} [ventureId]
+ * @returns {Promise<Object[]>}
+ */
+export async function getActiveBrandGenomes(supabase, ventureId) {
+  let query = supabase
+    .from('v_active_brand_genomes')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (ventureId) {
+    query = query.eq('venture_id', ventureId);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to fetch active brand genomes: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get latest published brand genome for a venture.
+ *
+ * @param {Object} supabase
+ * @param {string} ventureId
+ * @returns {Promise<Object|null>}
+ */
+export async function getLatestBrandGenome(supabase, ventureId) {
+  const { data, error } = await supabase
+    .from('brand_genome_submissions')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .eq('submission_status', 'published')
+    .is('archived_at', null)
+    .order('published_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to fetch latest brand genome: ${error.message}`);
+  return data;
+}
+
+/**
+ * Create a new brand genome submission (draft).
+ *
+ * @param {Object} supabase
+ * @param {Object} dto - { venture_id, brand_data?, created_by }
+ * @returns {Promise<Object>}
+ */
+export async function createBrandGenome(supabase, dto) {
+  if (!dto.created_by) {
+    throw new Error('created_by is required (no auth.getUser() in CLI context)');
+  }
+
+  const { data, error } = await supabase
+    .from('brand_genome_submissions')
+    .insert({
+      venture_id: dto.venture_id,
+      created_by: dto.created_by,
+      submission_status: 'draft',
+      brand_data: dto.brand_data || {},
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to create brand genome: ${error.message}`);
+  return data;
+}
+
+/**
+ * Update a brand genome submission.
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @param {Object} dto - { brand_data?, submission_status? }
+ * @returns {Promise<Object>}
+ */
+export async function updateBrandGenome(supabase, id, dto) {
+  const updateData = {};
+  if (dto.brand_data !== undefined) updateData.brand_data = dto.brand_data;
+  if (dto.submission_status !== undefined) updateData.submission_status = dto.submission_status;
+
+  const { data, error } = await supabase
+    .from('brand_genome_submissions')
+    .update(updateData)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to update brand genome: ${error.message}`);
+  return data;
+}
+
+/**
+ * Partial update of brand_data (merge with existing).
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @param {Object} brandData - Partial brand data to merge
+ * @returns {Promise<Object>}
+ */
+export async function updateBrandData(supabase, id, brandData) {
+  const current = await getBrandGenome(supabase, id);
+  if (!current) throw new Error('Brand genome not found');
+
+  const mergedBrandData = { ...current.brand_data, ...brandData };
+  return updateBrandGenome(supabase, id, { brand_data: mergedBrandData });
+}
+
+/**
+ * Submit a brand genome (draft → published).
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @returns {Promise<Object>}
+ */
+export async function submitBrandGenome(supabase, id) {
+  return updateBrandGenome(supabase, id, { submission_status: 'published' });
+}
+
+/**
+ * Approve a brand genome (alias for submit).
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @returns {Promise<Object>}
+ */
+export async function approveBrandGenome(supabase, id) {
+  return submitBrandGenome(supabase, id);
+}
+
+/**
+ * Archive a brand genome (soft delete).
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @returns {Promise<boolean>}
+ */
+export async function archiveBrandGenome(supabase, id) {
+  const { error } = await supabase
+    .from('brand_genome_submissions')
+    .update({
+      archived_at: new Date().toISOString(),
+      submission_status: 'archived',
+    })
+    .eq('id', id);
+
+  if (error) throw new Error(`Failed to archive brand genome: ${error.message}`);
+  return true;
+}
+
+/**
+ * Delete a brand genome (hard delete, drafts only).
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @returns {Promise<boolean>}
+ */
+export async function deleteBrandGenome(supabase, id) {
+  const { error } = await supabase
+    .from('brand_genome_submissions')
+    .delete()
+    .eq('id', id)
+    .eq('submission_status', 'draft');
+
+  if (error) throw new Error(`Failed to delete brand genome: ${error.message}`);
+  return true;
+}
+
+/**
+ * Get brand genomes by status.
+ *
+ * @param {Object} supabase
+ * @param {string} ventureId
+ * @param {string} status
+ * @returns {Promise<Object[]>}
+ */
+export async function getBrandGenomesByStatus(supabase, ventureId, status) {
+  const { data, error } = await supabase
+    .from('brand_genome_submissions')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .eq('submission_status', status)
+    .is('archived_at', null)
+    .order('created_at', { ascending: false });
+
+  if (error) throw new Error(`Failed to fetch brand genomes by status: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get brand completeness statistics.
+ *
+ * @param {Object} supabase
+ * @returns {Promise<Object|null>}
+ */
+export async function getBrandCompletenessStats(supabase) {
+  const { data, error } = await supabase
+    .from('v_brand_completeness_stats')
+    .select('*')
+    .maybeSingle();
+
+  if (error) throw new Error(`Failed to fetch brand completeness stats: ${error.message}`);
+  return data;
+}
+
+/**
+ * Get completeness score for a specific brand genome.
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @returns {Promise<number|null>}
+ */
+export async function getCompletenessScore(supabase, id) {
+  const genome = await getBrandGenome(supabase, id);
+  return genome?.completeness_score ?? null;
+}
+
+/**
+ * Check if brand genome meets minimum completeness threshold.
+ *
+ * @param {number|null} completenessScore
+ * @param {number} [threshold=70]
+ * @returns {boolean}
+ */
+export function meetsCompletenessThreshold(completenessScore, threshold = 70) {
+  if (completenessScore === null || completenessScore === undefined) return false;
+  return completenessScore >= threshold;
+}
+
+/**
+ * Get required fields missing for a brand genome.
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @returns {Promise<string[]>}
+ */
+export async function getRequiredFieldsMissing(supabase, id) {
+  const genome = await getBrandGenome(supabase, id);
+  return genome?.required_fields_missing || [];
+}

--- a/lib/eva/services/competitive-intelligence.js
+++ b/lib/eva/services/competitive-intelligence.js
@@ -1,0 +1,254 @@
+/**
+ * Competitive Intelligence Service (CLI Port)
+ *
+ * SD-LEO-FEAT-SERVICE-PORTS-001
+ * CLI-compatible port of ehg/src/services/competitiveIntelligenceService.ts
+ *
+ * Differences from frontend:
+ * - Supabase client injected via constructor (no frontend import)
+ * - Edge Function calls are optional (graceful fallback to local analysis)
+ * - No singleton export - caller creates instances with their own client
+ *
+ * @module lib/eva/services/competitive-intelligence
+ */
+
+/**
+ * Competitive Intelligence Service.
+ *
+ * Provides AI-powered competitive analysis using Supabase Edge Functions
+ * with local fallback analysis when the Edge Function is unavailable.
+ */
+export class CompetitiveIntelligenceService {
+  /**
+   * @param {Object} supabase - Supabase client instance
+   * @param {Object} [options]
+   * @param {Object} [options.logger] - Logger (defaults to console)
+   */
+  constructor(supabase, options = {}) {
+    if (!supabase) throw new Error('Supabase client is required');
+    this.supabase = supabase;
+    this.logger = options.logger || console;
+  }
+
+  /**
+   * Generate AI-powered competitive analysis via Edge Function.
+   * Falls back to local analysis if the Edge Function is unavailable.
+   *
+   * @param {Object} ideaData - Venture/idea data
+   * @param {Object[]} competitors - Array of competitor objects
+   * @param {Object[]} features - Array of feature definitions
+   * @param {Object[]} featureCoverage - Array of feature coverage mappings
+   * @returns {Promise<Object>} AIAnalysisResult
+   */
+  async generateAnalysis(ideaData, competitors, features, featureCoverage) {
+    try {
+      const { data, error } = await this.supabase.functions.invoke('competitive-intelligence', {
+        body: {
+          action: 'analyze',
+          ideaData,
+          competitors,
+          features,
+          featureCoverage,
+        },
+      });
+
+      if (error) throw error;
+      return data;
+    } catch (error) {
+      this.logger.warn?.('[CompetitiveIntelligence] Edge Function unavailable, using fallback analysis');
+      return this.generateFallbackAnalysis(competitors, features, featureCoverage);
+    }
+  }
+
+  /**
+   * Generate fallback analysis from available data when AI is unavailable.
+   *
+   * @param {Object[]} competitors
+   * @param {Object[]} features
+   * @param {Object[]} featureCoverage
+   * @returns {Object} AIAnalysisResult
+   */
+  generateFallbackAnalysis(competitors, features, featureCoverage) {
+    const marketLeaders = (competitors || [])
+      .filter(c => c.marketShareEstimate && c.marketShareEstimate > 20)
+      .map(c => c.name)
+      .slice(0, 3);
+
+    const emergingThreats = (competitors || [])
+      .filter(c => c.marketShareEstimate && c.marketShareEstimate > 5 && c.marketShareEstimate <= 20)
+      .map(c => c.name)
+      .slice(0, 3);
+
+    const coverageScoreMap = { none: 0, basic: 1, advanced: 2, superior: 3 };
+    const competitorCount = Math.max(1, (competitors || []).length);
+
+    const marketGaps = (features || [])
+      .filter(f => {
+        const avgCoverage = (featureCoverage || [])
+          .filter(fc => fc.featureKey === f.key)
+          .reduce((acc, fc) => acc + (coverageScoreMap[fc.coverage] || 0), 0) / competitorCount;
+        return avgCoverage < 1.5;
+      })
+      .map(f => f.label);
+
+    return {
+      competitiveLandscape: {
+        marketLeaders,
+        emergingThreats,
+        marketGaps,
+      },
+      strategicInsights: {
+        differentiationOpportunities: [
+          'Focus on underserved market segments',
+          'Enhance user experience design',
+          'Develop unique integrations',
+        ],
+        competitiveAdvantages: [
+          'Better pricing strategy',
+          'Superior customer support',
+          'More intuitive interface',
+        ],
+        vulnerabilities: [
+          'Limited market presence',
+          'Smaller user base',
+          'Less brand recognition',
+        ],
+      },
+      recommendations: {
+        immediate: ['Conduct deeper competitor research', 'Identify key differentiators', 'Develop unique value proposition'],
+        shortTerm: ['Build strategic partnerships', 'Enhance core features', 'Improve market positioning'],
+        longTerm: ['Establish market leadership', 'Build sustainable competitive moats', 'Scale internationally'],
+      },
+      confidenceScore: 0.6,
+    };
+  }
+
+  /**
+   * Save competitive analysis to database.
+   *
+   * @param {string} ideaId
+   * @param {Object} analysis - CompetitiveAnalysis object
+   */
+  async saveAnalysis(ideaId, analysis) {
+    const strategies = (analysis.strategicRecommendations || []).map((recommendation, index) => ({
+      idea_id: ideaId,
+      recommendation,
+      rationale: `Strategic recommendation ${index + 1} from competitive analysis`,
+      category: 'product',
+    }));
+
+    if (strategies.length > 0) {
+      const { error } = await this.supabase
+        .from('market_defense_strategies')
+        .upsert(strategies);
+
+      if (error) throw error;
+    }
+  }
+
+  /**
+   * Load competitive analysis from database.
+   *
+   * @param {string} ideaId
+   * @returns {Promise<Object>} { competitors, featureCoverage }
+   */
+  async loadAnalysis(ideaId) {
+    const { data: competitors, error: competitorsError } = await this.supabase
+      .from('competitors')
+      .select('*')
+      .eq('idea_id', ideaId);
+
+    if (competitorsError) throw competitorsError;
+
+    const competitorIds = (competitors || []).map(c => c.id);
+    let featureCoverage = [];
+
+    if (competitorIds.length > 0) {
+      const { data: coverage, error: coverageError } = await this.supabase
+        .from('feature_coverage')
+        .select('*')
+        .in('competitor_id', competitorIds);
+
+      if (coverageError) throw coverageError;
+      featureCoverage = coverage || [];
+    }
+
+    return {
+      competitors: (competitors || []).map(c => ({
+        id: c.id,
+        name: c.name,
+        website: c.website || '',
+        marketSegment: c.market_segment || '',
+        marketShareEstimate: c.market_share_estimate_pct || 0,
+        strengths: [],
+        weaknesses: [],
+        pricingModel: c.pricing_notes || '',
+        notes: c.notes || '',
+      })),
+      featureCoverage: featureCoverage.map(fc => ({
+        featureKey: fc.feature_key,
+        competitorId: fc.competitor_id,
+        coverage: fc.coverage,
+        notes: fc.notes || '',
+      })),
+    };
+  }
+
+  /**
+   * Generate competitive KPI tracking via Edge Function.
+   *
+   * @param {string} ventureId
+   * @param {Object[]} competitors
+   * @returns {Promise<Object>}
+   */
+  async generateKPIAnalysis(ventureId, competitors) {
+    try {
+      const { data, error } = await this.supabase.functions.invoke('competitive-intelligence', {
+        body: { action: 'kpi-analysis', ventureId, competitors },
+      });
+
+      if (error) throw error;
+      return data;
+    } catch {
+      return {
+        kpis: (competitors || []).map(comp => ({
+          competitorId: comp.id,
+          estimatedARR: null,
+          growthRate: null,
+          marketShare: comp.marketShareEstimate || 0,
+          lastUpdated: new Date().toISOString(),
+        })),
+        insights: [
+          'Competitor KPI tracking requires real-time data integration',
+          'Consider setting up automated monitoring systems',
+          'Focus on publicly available metrics for accurate tracking',
+        ],
+      };
+    }
+  }
+
+  /**
+   * Generate opportunity signals analysis via Edge Function.
+   *
+   * @param {string} ventureId
+   * @param {Object[]} competitors
+   * @returns {Promise<Object>}
+   */
+  async generateOpportunitySignals(ventureId, competitors) {
+    try {
+      const { data, error } = await this.supabase.functions.invoke('competitive-intelligence', {
+        body: { action: 'opportunity-signals', ventureId, competitors },
+      });
+
+      if (error) throw error;
+      return data;
+    } catch {
+      return {
+        signals: [
+          { type: 'market_gap', confidence: 0.7, description: 'Identified underserved market segment', recommendation: 'Focus on niche market needs' },
+          { type: 'weak_moat', confidence: 0.6, description: 'Competitors have limited differentiation', recommendation: 'Build strong unique value proposition' },
+        ],
+      };
+    }
+  }
+}

--- a/lib/eva/services/index.js
+++ b/lib/eva/services/index.js
@@ -1,0 +1,41 @@
+/**
+ * Eva Services - CLI-compatible ports of frontend venture services
+ *
+ * SD-LEO-FEAT-SERVICE-PORTS-001
+ * Barrel export for all ported services.
+ *
+ * @module lib/eva/services
+ */
+
+export {
+  verifyBackendConnection,
+  createResearchSession,
+  getResearchSession,
+  listResearchSessions,
+  pollResearchSession,
+  runResearch,
+  getLatestResearchSession,
+  createMockResearchSession,
+} from './venture-research.js';
+
+export { CompetitiveIntelligenceService } from './competitive-intelligence.js';
+
+export {
+  getBrandGenomesByVenture,
+  getBrandGenomeList,
+  getBrandGenome,
+  getActiveBrandGenomes,
+  getLatestBrandGenome,
+  createBrandGenome,
+  updateBrandGenome,
+  updateBrandData,
+  submitBrandGenome,
+  approveBrandGenome,
+  archiveBrandGenome,
+  deleteBrandGenome,
+  getBrandGenomesByStatus,
+  getBrandCompletenessStats,
+  getCompletenessScore,
+  meetsCompletenessThreshold,
+  getRequiredFieldsMissing,
+} from './brand-genome.js';

--- a/lib/eva/services/venture-research.js
+++ b/lib/eva/services/venture-research.js
@@ -1,0 +1,445 @@
+/**
+ * Venture Research Service (CLI Port)
+ *
+ * SD-LEO-FEAT-SERVICE-PORTS-001
+ * CLI-compatible port of ehg/src/services/ventureResearch.ts
+ *
+ * Differences from frontend:
+ * - Uses process.env instead of import.meta.env
+ * - Uses Node 18+ global fetch (no browser dependency)
+ * - Mock sessions use in-memory Map (same as frontend)
+ * - All functions accept optional deps for DI/testing
+ *
+ * @module lib/eva/services/venture-research
+ */
+
+const DEFAULT_API_URL = 'http://localhost:8000/api/research';
+const DEFAULT_HEALTH_URL = 'http://localhost:8000/health';
+
+// In-memory mock session store for progress simulation
+const mockSessions = new Map();
+
+/**
+ * Verify Agent Platform backend connectivity.
+ *
+ * @param {Object} [deps]
+ * @param {string} [deps.apiUrl] - Override API URL
+ * @param {string} [deps.healthUrl] - Override health check URL
+ * @param {boolean} [deps.useMock] - Force mock mode
+ * @returns {Promise<{available: boolean, error?: string}>}
+ */
+export async function verifyBackendConnection(deps = {}) {
+  const healthUrl = deps.healthUrl || process.env.AGENT_PLATFORM_HEALTH_URL || DEFAULT_HEALTH_URL;
+  const useMock = deps.useMock ?? (process.env.MOCK_RESEARCH === 'true');
+
+  if (useMock) {
+    return { available: false, error: 'Mock mode enabled (MOCK_RESEARCH=true)' };
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+
+    const response = await fetch(healthUrl, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return { available: true };
+    }
+    return {
+      available: false,
+      error: `Backend returned status ${response.status}: ${response.statusText}`,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      if (error.name === 'AbortError') {
+        return { available: false, error: 'Connection timeout (5s)' };
+      }
+      return { available: false, error: error.message };
+    }
+    return { available: false, error: 'Unknown connection error' };
+  }
+}
+
+/**
+ * Create a new research session via Agent Platform API.
+ *
+ * @param {Object} request - { venture_id, session_type, scope?, priority?, user_context? }
+ * @param {Object} [deps]
+ * @param {string} [deps.apiUrl] - Override API URL
+ * @param {boolean} [deps.useMock] - Force mock mode
+ * @param {Object} [deps.logger] - Logger (defaults to console)
+ * @returns {Promise<Object>} ResearchSession
+ */
+export async function createResearchSession(request, deps = {}) {
+  const apiUrl = deps.apiUrl || process.env.AGENT_PLATFORM_API_URL || DEFAULT_API_URL;
+  const useMock = deps.useMock ?? (process.env.MOCK_RESEARCH === 'true');
+  const logger = deps.logger || console;
+
+  if (useMock) {
+    logger.info?.('[VentureResearch] Mock mode - generating mock session');
+    return generateMockSession(request);
+  }
+
+  try {
+    const response = await fetch(`${apiUrl}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+
+    if (response.status === 501) {
+      throw new Error('Agent Platform research endpoints not fully implemented (HTTP 501)');
+    }
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ detail: 'Failed to create research session' }));
+      throw new Error(err.detail || `HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new Error('Cannot connect to Agent Platform backend on port 8000');
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get research session by ID (supports mock sessions).
+ *
+ * @param {string} sessionId
+ * @param {Object} [deps]
+ * @param {string} [deps.apiUrl] - Override API URL
+ * @returns {Promise<Object>} ResearchSession
+ */
+export async function getResearchSession(sessionId, deps = {}) {
+  const apiUrl = deps.apiUrl || process.env.AGENT_PLATFORM_API_URL || DEFAULT_API_URL;
+
+  if (sessionId.startsWith('mock-')) {
+    const mockData = mockSessions.get(sessionId);
+    if (mockData) {
+      return simulateMockProgress(mockData);
+    }
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 30000);
+
+  try {
+    const response = await fetch(`${apiUrl}/sessions/${sessionId}`, {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ detail: 'Failed to fetch research session' }));
+      throw new Error(err.detail || `HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    if (data.results_summary) {
+      data.results_summary = normalizeResearchResults(data.results_summary);
+    }
+
+    return data;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    throw error;
+  }
+}
+
+/**
+ * List research sessions for a venture.
+ *
+ * @param {string} ventureId
+ * @param {Object} [deps]
+ * @param {string} [deps.apiUrl] - Override API URL
+ * @returns {Promise<Object[]>}
+ */
+export async function listResearchSessions(ventureId, deps = {}) {
+  const apiUrl = deps.apiUrl || process.env.AGENT_PLATFORM_API_URL || DEFAULT_API_URL;
+  const params = new URLSearchParams({ venture_id: ventureId });
+
+  const response = await fetch(`${apiUrl}/sessions?${params}`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({ detail: 'Failed to list research sessions' }));
+    throw new Error(err.detail || `HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+/**
+ * Poll for research session completion.
+ *
+ * @param {string} sessionId
+ * @param {Object} [options]
+ * @param {number} [options.interval=5000] - Polling interval in ms
+ * @param {number} [options.maxAttempts=300] - Max polling attempts
+ * @param {Function} [options.onProgress] - Progress callback
+ * @param {Object} [deps]
+ * @returns {Promise<Object>} Completed ResearchSession
+ */
+export async function pollResearchSession(sessionId, options = {}, deps = {}) {
+  const { interval = 5000, maxAttempts = 300, onProgress } = options;
+
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  let attempts = 0;
+
+  while (attempts < maxAttempts) {
+    attempts++;
+
+    try {
+      const session = await getResearchSession(sessionId, deps);
+
+      if (session && onProgress) {
+        onProgress(session);
+      }
+
+      if (session?.status === 'completed') {
+        return session;
+      }
+
+      if (session?.status === 'failed') {
+        throw new Error('Research session failed');
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        // Timeout on this poll, continue
+      } else if (error.message === 'Research session failed') {
+        throw error;
+      }
+      // Other errors: continue polling
+    }
+
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+
+  throw new Error('Research session polling timed out');
+}
+
+/**
+ * Create session and poll until completion.
+ *
+ * @param {Object} request
+ * @param {Function} [onProgress]
+ * @param {Object} [deps]
+ * @returns {Promise<Object>}
+ */
+export async function runResearch(request, onProgress, deps = {}) {
+  const session = await createResearchSession(request, deps);
+  return pollResearchSession(session.id, {
+    interval: 2000,
+    maxAttempts: 600,
+    onProgress,
+  }, deps);
+}
+
+/**
+ * Get latest research session for a venture.
+ *
+ * @param {string} ventureId
+ * @param {Object} [deps]
+ * @returns {Promise<Object|null>}
+ */
+export async function getLatestResearchSession(ventureId, deps = {}) {
+  const sessions = await listResearchSessions(ventureId, deps);
+  if (sessions.length === 0) return null;
+
+  sessions.sort((a, b) =>
+    new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+  return sessions[0];
+}
+
+/**
+ * Explicitly create a mock research session.
+ *
+ * @param {Object} request
+ * @returns {Object}
+ */
+export function createMockResearchSession(request) {
+  return generateMockSession(request);
+}
+
+// ── Internal Helpers ────────────────────────────────────────────
+
+function generateMockSession(request) {
+  const sessionId = `mock-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  const now = new Date();
+
+  const session = {
+    id: sessionId,
+    venture_id: request.venture_id,
+    session_type: request.session_type,
+    status: 'pending',
+    progress: 0,
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+    estimated_completion: new Date(Date.now() + 30000).toISOString(),
+    results_summary: buildMockResults(),
+    activity_log: buildMockActivityLog(now),
+  };
+
+  mockSessions.set(sessionId, { startTime: Date.now(), session });
+  return session;
+}
+
+function simulateMockProgress(mockData) {
+  const { startTime, session } = mockData;
+  const elapsed = Date.now() - startTime;
+  const progress = Math.min(100, Math.floor((elapsed / 30000) * 100));
+
+  const activityLog = [];
+  if (progress > 0) activityLog.push({ timestamp: new Date(startTime).toISOString(), event_type: 'info', message: 'Research session started' });
+  if (progress >= 25) activityLog.push({ timestamp: new Date(startTime + 7500).toISOString(), event_type: 'agent_complete', message: 'Market Sizing Agent completed' });
+  if (progress >= 50) activityLog.push({ timestamp: new Date(startTime + 15000).toISOString(), event_type: 'agent_complete', message: 'Pain Point Agent completed' });
+  if (progress >= 75) activityLog.push({ timestamp: new Date(startTime + 22500).toISOString(), event_type: 'agent_complete', message: 'Competitive Analysis Agent completed' });
+  if (progress >= 100) activityLog.push({ timestamp: new Date(startTime + 30000).toISOString(), event_type: 'agent_complete', message: 'Strategic Fit Agent completed' });
+
+  return {
+    ...session,
+    progress,
+    status: progress >= 100 ? 'completed' : 'running',
+    updated_at: new Date().toISOString(),
+    activity_log: activityLog,
+  };
+}
+
+function buildMockResults() {
+  return {
+    market_sizing: {
+      tam: 5_000_000_000,
+      sam: 1_000_000_000,
+      som: 50_000_000,
+      confidence: 0.82,
+      sources: ['Industry analysis reports', 'Market databases', 'Competitor financials'],
+    },
+    pain_point: {
+      severity_score: 8,
+      frequency_score: 9,
+      urgency_score: 7,
+      top_pain_points: [
+        { description: 'High customer acquisition costs', evidence: ['Industry surveys', 'Forum discussions'] },
+        { description: 'Lack of integrated analytics', evidence: ['Customer reviews', 'Product feedback'] },
+      ],
+    },
+    competitive: {
+      intensity: 7,
+      competitors: [
+        { name: 'MarketLeader Pro', strengths: ['Established brand'], weaknesses: ['Complex UI'] },
+        { name: 'QuickAnalytics', strengths: ['Simple interface'], weaknesses: ['Limited features'] },
+      ],
+      moat_opportunities: ['Focus on mid-market', 'Superior UX', 'AI-powered insights'],
+    },
+    strategic_fit: {
+      alignment_score: 8,
+      risks: ['Competitive market', 'Customer switching costs'],
+      opportunities: ['Growing demand (23% CAGR)', 'Underserved mid-market'],
+      recommendation: { fit_tier: 'STRONG_FIT', action_items: ['Validate PMF with beta customers'], priority_actions: ['Secure funding'] },
+    },
+  };
+}
+
+function buildMockActivityLog(now) {
+  const base = now.getTime();
+  return [
+    { timestamp: new Date(base - 8000).toISOString(), event_type: 'info', message: 'Research session started (mock data)' },
+    { timestamp: new Date(base - 5000).toISOString(), event_type: 'agent_complete', message: 'Market Sizing Agent completed' },
+    { timestamp: new Date(base - 3000).toISOString(), event_type: 'agent_complete', message: 'Customer Insights Agent completed' },
+    { timestamp: new Date(base - 1500).toISOString(), event_type: 'agent_complete', message: 'Competitive Analysis Agent completed' },
+    { timestamp: now.toISOString(), event_type: 'info', message: 'All research agents completed successfully' },
+  ];
+}
+
+/**
+ * Normalize backend research results to standard shape.
+ */
+function normalizeResearchResults(raw) {
+  if (!raw || typeof raw !== 'object') return {};
+
+  const normalized = {};
+
+  if (raw.market_sizing) {
+    const ms = raw.market_sizing;
+    const marketSize = ms.market_size || {};
+    normalized.market_sizing = {
+      tam: marketSize.tam ?? ms.tam ?? null,
+      sam: marketSize.sam ?? ms.sam ?? null,
+      som: marketSize.som ?? ms.som ?? null,
+      confidence: ms.confidence ?? 0,
+      sources: ms.sources ?? [],
+    };
+  }
+
+  if (raw.pain_point) {
+    normalized.pain_point = raw.pain_point;
+  }
+
+  if (raw.competitive) {
+    const comp = raw.competitive;
+    const metrics = comp.competitive_metrics || {};
+    const intensityMap = { LOW: 3, MEDIUM: 6, HIGH: 9 };
+    const intensityRaw = metrics.competitive_intensity || comp.intensity;
+    const intensity = typeof intensityRaw === 'string'
+      ? intensityMap[intensityRaw] ?? 6
+      : intensityRaw;
+
+    normalized.competitive = {
+      intensity: intensity ?? 0,
+      competitors: comp.competitors ?? [],
+      moat_opportunities: comp.moat_opportunities ?? [],
+    };
+  }
+
+  if (raw.strategic_fit) {
+    const sf = raw.strategic_fit;
+    const fitMetrics = sf.fit_metrics || {};
+    const risksObj = sf.risks || {};
+
+    const extractRisks = (risks) => {
+      if (Array.isArray(risks)) return risks;
+      if (typeof risks === 'object' && risks !== null) {
+        const arr = [];
+        if (risks.overall_risk) arr.push(`Overall risk: ${risks.overall_risk}`);
+        if (risks.resource_risk) arr.push(`Resource risk: ${risks.resource_risk}`);
+        if (risks.expertise_risk) arr.push(`Expertise risk: ${risks.expertise_risk}`);
+        return arr;
+      }
+      return [];
+    };
+
+    normalized.strategic_fit = {
+      alignment_score: sf.alignment_score ?? fitMetrics.strategic_fit_score ?? 0,
+      risks: extractRisks(risksObj),
+      opportunities: sf.opportunities ?? [],
+      recommendation: sf.recommendation ?? '',
+    };
+  }
+
+  return normalized;
+}
+
+// ── Exports for testing ─────────────────────────────────────────
+
+export const _internal = {
+  mockSessions,
+  generateMockSession,
+  simulateMockProgress,
+  normalizeResearchResults,
+};

--- a/tests/unit/services/brand-genome.test.js
+++ b/tests/unit/services/brand-genome.test.js
@@ -1,0 +1,226 @@
+/**
+ * Tests for Brand Genome Service (CLI Port)
+ * SD-LEO-FEAT-SERVICE-PORTS-001
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getBrandGenomesByVenture,
+  getBrandGenomeList,
+  getBrandGenome,
+  getActiveBrandGenomes,
+  getLatestBrandGenome,
+  createBrandGenome,
+  updateBrandGenome,
+  updateBrandData,
+  submitBrandGenome,
+  approveBrandGenome,
+  archiveBrandGenome,
+  deleteBrandGenome,
+  getBrandGenomesByStatus,
+  getBrandCompletenessStats,
+  getCompletenessScore,
+  meetsCompletenessThreshold,
+  getRequiredFieldsMissing,
+} from '../../../lib/eva/services/brand-genome.js';
+
+/**
+ * Build a mock Supabase client with chainable query methods.
+ */
+function createMockSupabase({ data = [], error = null, singleData = null } = {}) {
+  const chainable = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: singleData, error }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: singleData, error }),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    // Default terminal resolution (for queries without single/maybeSingle)
+    then: vi.fn((resolve) => resolve({ data, error })),
+  };
+
+  // Make terminal methods resolve the data by default
+  // Override: when .order() is the last call (list queries), resolve data
+  const orderFn = vi.fn().mockImplementation(() => {
+    return {
+      ...chainable,
+      then: vi.fn((resolve) => resolve({ data, error })),
+      // Allow further chaining for limit().maybeSingle()
+      limit: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({ data: singleData, error }),
+      }),
+    };
+  });
+
+  // Build the mock from builder
+  const fromMock = vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          is: vi.fn().mockReturnValue({
+            order: orderFn,
+          }),
+          order: orderFn,
+          single: vi.fn().mockResolvedValue({ data: singleData, error }),
+        }),
+        is: vi.fn().mockReturnValue({
+          order: orderFn,
+        }),
+        single: vi.fn().mockResolvedValue({ data: singleData, error }),
+      }),
+      is: vi.fn().mockReturnValue({
+        order: orderFn,
+      }),
+      order: orderFn,
+      maybeSingle: vi.fn().mockResolvedValue({ data: singleData, error }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: singleData, error }),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: singleData, error }),
+        }),
+        // For archive/update without select
+        then: vi.fn((resolve) => resolve({ error })),
+      }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error }),
+      }),
+    }),
+  });
+
+  return { from: fromMock };
+}
+
+describe('getBrandGenomesByVenture', () => {
+  it('returns brand genomes for a venture', async () => {
+    const genomes = [{ id: 'bg-1', venture_id: 'v-1' }];
+    const supabase = createMockSupabase({ data: genomes });
+
+    const result = await getBrandGenomesByVenture(supabase, 'v-1');
+    expect(result).toEqual(genomes);
+    expect(supabase.from).toHaveBeenCalledWith('brand_genome_submissions');
+  });
+});
+
+describe('getBrandGenome', () => {
+  it('returns a single brand genome', async () => {
+    const genome = { id: 'bg-1', brand_data: { name: 'Test' } };
+    const supabase = createMockSupabase({ singleData: genome });
+
+    const result = await getBrandGenome(supabase, 'bg-1');
+    expect(result).toEqual(genome);
+  });
+
+  it('returns null when not found (PGRST116)', async () => {
+    const supabase = createMockSupabase({ error: { code: 'PGRST116', message: 'Not found' } });
+
+    const result = await getBrandGenome(supabase, 'nonexistent');
+    expect(result).toBeNull();
+  });
+});
+
+describe('createBrandGenome', () => {
+  it('creates a draft brand genome with explicit createdBy', async () => {
+    const created = { id: 'bg-new', venture_id: 'v-1', submission_status: 'draft' };
+    const supabase = createMockSupabase({ singleData: created });
+
+    const result = await createBrandGenome(supabase, {
+      venture_id: 'v-1',
+      created_by: 'user-123',
+      brand_data: { name: 'My Brand' },
+    });
+
+    expect(result).toEqual(created);
+  });
+
+  it('throws when created_by is missing', async () => {
+    const supabase = createMockSupabase();
+
+    await expect(
+      createBrandGenome(supabase, { venture_id: 'v-1' }),
+    ).rejects.toThrow('created_by is required');
+  });
+});
+
+describe('updateBrandGenome', () => {
+  it('updates brand genome fields', async () => {
+    const updated = { id: 'bg-1', submission_status: 'published' };
+    const supabase = createMockSupabase({ singleData: updated });
+
+    const result = await updateBrandGenome(supabase, 'bg-1', { submission_status: 'published' });
+    expect(result).toEqual(updated);
+  });
+});
+
+describe('submitBrandGenome / approveBrandGenome', () => {
+  it('submitBrandGenome sets status to published', async () => {
+    const updated = { id: 'bg-1', submission_status: 'published' };
+    const supabase = createMockSupabase({ singleData: updated });
+
+    const result = await submitBrandGenome(supabase, 'bg-1');
+    expect(result.submission_status).toBe('published');
+  });
+
+  it('approveBrandGenome delegates to submitBrandGenome', async () => {
+    const updated = { id: 'bg-1', submission_status: 'published' };
+    const supabase = createMockSupabase({ singleData: updated });
+
+    const result = await approveBrandGenome(supabase, 'bg-1');
+    expect(result.submission_status).toBe('published');
+  });
+});
+
+describe('archiveBrandGenome', () => {
+  it('returns true on success', async () => {
+    const supabase = createMockSupabase();
+    const result = await archiveBrandGenome(supabase, 'bg-1');
+    expect(result).toBe(true);
+  });
+});
+
+describe('deleteBrandGenome', () => {
+  it('returns true on success', async () => {
+    const supabase = createMockSupabase();
+    const result = await deleteBrandGenome(supabase, 'bg-1');
+    expect(result).toBe(true);
+  });
+});
+
+describe('meetsCompletenessThreshold', () => {
+  it('returns false for null score', () => {
+    expect(meetsCompletenessThreshold(null)).toBe(false);
+  });
+
+  it('returns false for undefined score', () => {
+    expect(meetsCompletenessThreshold(undefined)).toBe(false);
+  });
+
+  it('returns false below threshold', () => {
+    expect(meetsCompletenessThreshold(50)).toBe(false);
+  });
+
+  it('returns true at threshold', () => {
+    expect(meetsCompletenessThreshold(70)).toBe(true);
+  });
+
+  it('returns true above threshold', () => {
+    expect(meetsCompletenessThreshold(95)).toBe(true);
+  });
+
+  it('uses custom threshold', () => {
+    expect(meetsCompletenessThreshold(50, 50)).toBe(true);
+    expect(meetsCompletenessThreshold(49, 50)).toBe(false);
+  });
+});

--- a/tests/unit/services/competitive-intelligence.test.js
+++ b/tests/unit/services/competitive-intelligence.test.js
@@ -1,0 +1,182 @@
+/**
+ * Tests for Competitive Intelligence Service (CLI Port)
+ * SD-LEO-FEAT-SERVICE-PORTS-001
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CompetitiveIntelligenceService } from '../../../lib/eva/services/competitive-intelligence.js';
+
+function createMockSupabase({ invokeData = null, invokeError = null, queryData = [], queryError = null } = {}) {
+  return {
+    functions: {
+      invoke: vi.fn().mockResolvedValue({ data: invokeData, error: invokeError }),
+    },
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: queryData[0] || null, error: queryError }),
+        }),
+        in: vi.fn().mockResolvedValue({ data: queryData, error: queryError }),
+      }),
+      upsert: vi.fn().mockResolvedValue({ error: queryError }),
+    }),
+  };
+}
+
+function createMockLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn() };
+}
+
+const sampleCompetitors = [
+  { id: 'c1', name: 'Leader', marketShareEstimate: 30, strengths: ['Strong'], weaknesses: ['Slow'] },
+  { id: 'c2', name: 'Newcomer', marketShareEstimate: 8, strengths: ['Fast'], weaknesses: ['Small'] },
+];
+
+const sampleFeatures = [
+  { key: 'analytics', label: 'Analytics Dashboard', category: 'core', weight: 1 },
+  { key: 'ai', label: 'AI Insights', category: 'moat', weight: 2 },
+];
+
+const sampleCoverage = [
+  { featureKey: 'analytics', competitorId: 'c1', coverage: 'advanced' },
+  { featureKey: 'ai', competitorId: 'c1', coverage: 'none' },
+];
+
+describe('CompetitiveIntelligenceService', () => {
+  let service;
+  let mockSupabase;
+  let mockLogger;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogger = createMockLogger();
+  });
+
+  it('requires supabase client', () => {
+    expect(() => new CompetitiveIntelligenceService(null)).toThrow('Supabase client is required');
+  });
+
+  describe('generateAnalysis', () => {
+    it('calls Edge Function and returns data on success', async () => {
+      const aiResult = { competitiveLandscape: {}, strategicInsights: {}, recommendations: {}, confidenceScore: 0.9 };
+      mockSupabase = createMockSupabase({ invokeData: aiResult });
+      service = new CompetitiveIntelligenceService(mockSupabase, { logger: mockLogger });
+
+      const result = await service.generateAnalysis({}, sampleCompetitors, sampleFeatures, sampleCoverage);
+
+      expect(result).toEqual(aiResult);
+      expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('competitive-intelligence', expect.objectContaining({
+        body: expect.objectContaining({ action: 'analyze' }),
+      }));
+    });
+
+    it('falls back to local analysis on Edge Function error', async () => {
+      mockSupabase = createMockSupabase({ invokeError: new Error('Edge Function unavailable') });
+      service = new CompetitiveIntelligenceService(mockSupabase, { logger: mockLogger });
+
+      const result = await service.generateAnalysis({}, sampleCompetitors, sampleFeatures, sampleCoverage);
+
+      expect(result.confidenceScore).toBe(0.6);
+      expect(result.competitiveLandscape.marketLeaders).toContain('Leader');
+      expect(result.competitiveLandscape.emergingThreats).toContain('Newcomer');
+    });
+  });
+
+  describe('generateFallbackAnalysis', () => {
+    it('identifies market leaders (>20% share)', () => {
+      mockSupabase = createMockSupabase();
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      const result = service.generateFallbackAnalysis(sampleCompetitors, sampleFeatures, sampleCoverage);
+      expect(result.competitiveLandscape.marketLeaders).toEqual(['Leader']);
+    });
+
+    it('identifies emerging threats (5-20% share)', () => {
+      mockSupabase = createMockSupabase();
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      const result = service.generateFallbackAnalysis(sampleCompetitors, sampleFeatures, sampleCoverage);
+      expect(result.competitiveLandscape.emergingThreats).toEqual(['Newcomer']);
+    });
+
+    it('identifies market gaps (low average coverage)', () => {
+      mockSupabase = createMockSupabase();
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      const result = service.generateFallbackAnalysis(sampleCompetitors, sampleFeatures, sampleCoverage);
+      // 'ai' has coverage 'none' for c1 only → avg 0 < 1.5 → gap
+      expect(result.competitiveLandscape.marketGaps).toContain('AI Insights');
+    });
+
+    it('handles empty inputs gracefully', () => {
+      mockSupabase = createMockSupabase();
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      const result = service.generateFallbackAnalysis([], [], []);
+      expect(result.competitiveLandscape.marketLeaders).toEqual([]);
+      expect(result.confidenceScore).toBe(0.6);
+    });
+  });
+
+  describe('saveAnalysis', () => {
+    it('upserts strategies to market_defense_strategies', async () => {
+      mockSupabase = createMockSupabase();
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      await service.saveAnalysis('idea-1', {
+        strategicRecommendations: ['Do X', 'Do Y'],
+      });
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('market_defense_strategies');
+    });
+
+    it('skips upsert when no recommendations', async () => {
+      mockSupabase = createMockSupabase();
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      await service.saveAnalysis('idea-1', { strategicRecommendations: [] });
+      // from() should not have been called since strategies array is empty
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('generateKPIAnalysis', () => {
+    it('returns Edge Function data on success', async () => {
+      const kpiData = { kpis: [], insights: ['insight1'] };
+      mockSupabase = createMockSupabase({ invokeData: kpiData });
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      const result = await service.generateKPIAnalysis('v-1', sampleCompetitors);
+      expect(result).toEqual(kpiData);
+    });
+
+    it('returns fallback KPI data on error', async () => {
+      mockSupabase = createMockSupabase({ invokeError: new Error('fail') });
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      const result = await service.generateKPIAnalysis('v-1', sampleCompetitors);
+      expect(result.kpis).toHaveLength(2);
+      expect(result.insights).toBeDefined();
+    });
+  });
+
+  describe('generateOpportunitySignals', () => {
+    it('returns Edge Function data on success', async () => {
+      const signalData = { signals: [{ type: 'custom' }] };
+      mockSupabase = createMockSupabase({ invokeData: signalData });
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      const result = await service.generateOpportunitySignals('v-1', sampleCompetitors);
+      expect(result).toEqual(signalData);
+    });
+
+    it('returns fallback signals on error', async () => {
+      mockSupabase = createMockSupabase({ invokeError: new Error('fail') });
+      service = new CompetitiveIntelligenceService(mockSupabase);
+
+      const result = await service.generateOpportunitySignals('v-1', sampleCompetitors);
+      expect(result.signals).toHaveLength(2);
+      expect(result.signals[0].type).toBe('market_gap');
+    });
+  });
+});

--- a/tests/unit/services/venture-research.test.js
+++ b/tests/unit/services/venture-research.test.js
@@ -1,0 +1,284 @@
+/**
+ * Tests for Venture Research Service (CLI Port)
+ * SD-LEO-FEAT-SERVICE-PORTS-001
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  verifyBackendConnection,
+  createResearchSession,
+  getResearchSession,
+  listResearchSessions,
+  pollResearchSession,
+  getLatestResearchSession,
+  createMockResearchSession,
+  _internal,
+} from '../../../lib/eva/services/venture-research.js';
+
+// Save original fetch
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _internal.mockSessions.clear();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('verifyBackendConnection', () => {
+  it('returns unavailable in mock mode', async () => {
+    const result = await verifyBackendConnection({ useMock: true });
+    expect(result.available).toBe(false);
+    expect(result.error).toContain('Mock mode');
+  });
+
+  it('returns available when health check succeeds', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'ok' }),
+    });
+
+    const result = await verifyBackendConnection({ useMock: false });
+    expect(result.available).toBe(true);
+  });
+
+  it('returns unavailable when health check fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    });
+
+    const result = await verifyBackendConnection({ useMock: false });
+    expect(result.available).toBe(false);
+    expect(result.error).toContain('503');
+  });
+
+  it('returns unavailable on network error', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('fetch failed'));
+
+    const result = await verifyBackendConnection({ useMock: false });
+    expect(result.available).toBe(false);
+    expect(result.error).toContain('fetch failed');
+  });
+});
+
+describe('createResearchSession', () => {
+  it('returns mock session in mock mode', async () => {
+    const result = await createResearchSession(
+      { venture_id: 'v-1', session_type: 'quick' },
+      { useMock: true, logger: { info: vi.fn() } },
+    );
+
+    expect(result.id).toMatch(/^mock-/);
+    expect(result.venture_id).toBe('v-1');
+    expect(result.session_type).toBe('quick');
+    expect(result.status).toBe('pending');
+    expect(result.progress).toBe(0);
+  });
+
+  it('calls API and returns session data', async () => {
+    const mockSession = { id: 'session-1', status: 'pending', progress: 0 };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockSession),
+    });
+
+    const result = await createResearchSession(
+      { venture_id: 'v-1', session_type: 'deep' },
+      { useMock: false, apiUrl: 'http://test:8000/api/research' },
+    );
+
+    expect(result).toEqual(mockSession);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'http://test:8000/api/research/sessions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('throws on 501 (not implemented)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 501,
+    });
+
+    await expect(
+      createResearchSession(
+        { venture_id: 'v-1', session_type: 'quick' },
+        { useMock: false },
+      ),
+    ).rejects.toThrow('not fully implemented');
+  });
+});
+
+describe('getResearchSession', () => {
+  it('returns simulated progress for mock sessions', async () => {
+    const mockSession = createMockResearchSession({ venture_id: 'v-1', session_type: 'quick' });
+
+    // Immediately checking should show low progress
+    const result = await getResearchSession(mockSession.id);
+    expect(result.id).toBe(mockSession.id);
+    expect(result.progress).toBeGreaterThanOrEqual(0);
+    expect(result.activity_log).toBeDefined();
+  });
+
+  it('fetches from API for real sessions', async () => {
+    const mockData = { id: 'real-1', status: 'running', progress: 50 };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    });
+
+    const result = await getResearchSession('real-1', {
+      apiUrl: 'http://test:8000/api/research',
+    });
+
+    expect(result).toEqual(mockData);
+  });
+
+  it('normalizes results_summary from backend', async () => {
+    const rawData = {
+      id: 'real-1',
+      status: 'completed',
+      results_summary: {
+        market_sizing: { market_size: { tam: 100, sam: 50, som: 10 }, confidence: 0.9, sources: [] },
+        competitive: { competitive_metrics: { competitive_intensity: 'HIGH' }, competitors: [], moat_opportunities: [] },
+      },
+    };
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(rawData),
+    });
+
+    const result = await getResearchSession('real-1');
+    expect(result.results_summary.market_sizing.tam).toBe(100);
+    expect(result.results_summary.competitive.intensity).toBe(9); // HIGH maps to 9
+  });
+});
+
+describe('listResearchSessions', () => {
+  it('fetches sessions from API', async () => {
+    const mockList = [{ id: 's-1' }, { id: 's-2' }];
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockList),
+    });
+
+    const result = await listResearchSessions('v-1', { apiUrl: 'http://test:8000/api/research' });
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('getLatestResearchSession', () => {
+  it('returns null when no sessions exist', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    const result = await getLatestResearchSession('v-1');
+    expect(result).toBeNull();
+  });
+
+  it('returns most recent session sorted by created_at', async () => {
+    const sessions = [
+      { id: 'older', created_at: '2026-01-01T00:00:00Z' },
+      { id: 'newer', created_at: '2026-02-01T00:00:00Z' },
+    ];
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(sessions),
+    });
+
+    const result = await getLatestResearchSession('v-1');
+    expect(result.id).toBe('newer');
+  });
+});
+
+describe('pollResearchSession', () => {
+  it('returns completed session immediately', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 's-1', status: 'completed', progress: 100 }),
+    });
+
+    const result = await pollResearchSession('s-1', {
+      interval: 10,
+      maxAttempts: 3,
+    });
+
+    expect(result.status).toBe('completed');
+  });
+
+  it('throws on failed session', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: 's-1', status: 'failed', progress: 0 }),
+    });
+
+    await expect(
+      pollResearchSession('s-1', { interval: 10, maxAttempts: 3 }),
+    ).rejects.toThrow('Research session failed');
+  });
+
+  it('calls onProgress callback', async () => {
+    let callCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          id: 's-1',
+          status: callCount >= 2 ? 'completed' : 'running',
+          progress: callCount >= 2 ? 100 : 50,
+        }),
+      });
+    });
+
+    const onProgress = vi.fn();
+    await pollResearchSession('s-1', { interval: 10, maxAttempts: 5, onProgress });
+
+    expect(onProgress).toHaveBeenCalled();
+  });
+});
+
+describe('normalizeResearchResults (internal)', () => {
+  const { normalizeResearchResults } = _internal;
+
+  it('returns empty object for null/undefined input', () => {
+    expect(normalizeResearchResults(null)).toEqual({});
+    expect(normalizeResearchResults(undefined)).toEqual({});
+  });
+
+  it('flattens nested market_size', () => {
+    const raw = { market_sizing: { market_size: { tam: 100, sam: 50, som: 10 }, confidence: 0.8, sources: ['a'] } };
+    const result = normalizeResearchResults(raw);
+    expect(result.market_sizing.tam).toBe(100);
+    expect(result.market_sizing.confidence).toBe(0.8);
+  });
+
+  it('maps string intensity to number', () => {
+    const raw = { competitive: { competitive_metrics: { competitive_intensity: 'LOW' }, competitors: [], moat_opportunities: [] } };
+    const result = normalizeResearchResults(raw);
+    expect(result.competitive.intensity).toBe(3);
+  });
+
+  it('extracts risks from object format', () => {
+    const raw = { strategic_fit: { risks: { overall_risk: 'High', resource_risk: 'Medium' }, opportunities: [] } };
+    const result = normalizeResearchResults(raw);
+    expect(result.strategic_fit.risks).toContain('Overall risk: High');
+    expect(result.strategic_fit.risks).toContain('Resource risk: Medium');
+  });
+});
+
+describe('createMockResearchSession', () => {
+  it('creates a session with mock- prefix', () => {
+    const session = createMockResearchSession({ venture_id: 'v-1', session_type: 'quick' });
+    expect(session.id).toMatch(/^mock-/);
+    expect(session.results_summary).toBeDefined();
+    expect(session.results_summary.market_sizing).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Port 3 frontend services (ventureResearch, competitiveIntelligence, brandGenome) to CLI-compatible modules in `lib/eva/services/`
- Dependency injection for Supabase client replaces frontend imports
- `process.env` replaces `import.meta.env` for configuration
- Explicit `createdBy` parameter replaces `auth.getUser()` in brand genome creation
- Edge Function fallback analysis logic fully preserved

## Test plan
- [x] 50 unit tests passing across 3 test files
- [x] Smoke tests passing
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)