### PR TITLE
feat: implement constraint drift detection for venture stage comparison

### DIFF
--- a/lib/eva/constraint-drift-detector.js
+++ b/lib/eva/constraint-drift-detector.js
@@ -1,0 +1,468 @@
+/**
+ * Constraint Drift Detector
+ *
+ * SD-LEO-FEAT-CONSTRAINT-DRIFT-001
+ * Detects when later stage outputs contradict or drift from earlier
+ * stage assumptions. Compares current venture stage outputs against
+ * Stage 1 baseline assumptions stored in assumption_sets table.
+ *
+ * Integration: Results feed into Decision Filter Engine's constraint_drift
+ * trigger via buildFilterEnginePayload().
+ *
+ * @module lib/eva/constraint-drift-detector
+ */
+
+const SEVERITY = { NONE: 'NONE', LOW: 'LOW', MEDIUM: 'MEDIUM', HIGH: 'HIGH' };
+const DRIFT_TYPE = {
+  NO_CHANGE: 'NO_CHANGE',
+  DRIFT: 'DRIFT',
+  CONTRADICTION: 'CONTRADICTION',
+  NO_BASELINE: 'NO_BASELINE',
+  NO_CURRENT_DATA: 'NO_CURRENT_DATA',
+  ERROR: 'ERROR',
+};
+
+/** Artifact types in priority order for constraint extraction. */
+const ARTIFACT_TYPE_PRIORITY = ['stage_output', 'constraints', 'plan', 'decision'];
+
+/** Categories compared for drift. */
+const ASSUMPTION_CATEGORIES = [
+  'market_assumptions',
+  'competitor_assumptions',
+  'product_assumptions',
+  'timing_assumptions',
+];
+
+/**
+ * Detect constraint drift between baseline assumptions and current stage.
+ *
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture UUID
+ * @param {number} params.currentStage - Current stage number
+ * @param {number} [params.baselineStage=1] - Baseline stage (default: Stage 1)
+ * @param {Object} params.db - Supabase client
+ * @param {Object} [params.logger=console] - Logger
+ * @returns {Promise<Object>} Drift result
+ */
+export async function detectConstraintDrift({
+  ventureId,
+  currentStage,
+  baselineStage = 1,
+  db,
+  logger = console,
+}) {
+  try {
+    // 1. Load baseline assumptions
+    const baseline = await loadBaselineAssumptions({ ventureId, baselineStage, db, logger });
+    if (!baseline) {
+      logger.info?.(
+        `[ConstraintDrift] No baseline assumption_set for venture=${ventureId} stage=${baselineStage}`
+      );
+      return {
+        ventureId,
+        baselineStage,
+        currentStage,
+        baselineAssumptionSetId: null,
+        driftDetected: false,
+        severity: SEVERITY.NONE,
+        findings: [],
+      };
+    }
+
+    // 2. Extract current-stage constraints from venture_artifacts
+    const current = await extractCurrentConstraints({ ventureId, currentStage, db, logger });
+    if (!current.categories || Object.keys(current.categories).length === 0) {
+      return {
+        ventureId,
+        baselineStage,
+        currentStage,
+        baselineAssumptionSetId: baseline.id,
+        driftDetected: false,
+        severity: SEVERITY.NONE,
+        findings: [
+          {
+            category: 'stage_output',
+            baselineValue: null,
+            currentValue: null,
+            driftType: DRIFT_TYPE.NO_CURRENT_DATA,
+            rationale: `No artifacts found for venture=${ventureId} stage=${currentStage}`,
+            confidence: 1.0,
+          },
+        ],
+      };
+    }
+
+    // 3. Compare categories
+    const findings = compareCategories(baseline, current.categories, currentStage);
+
+    // 4. Compute severity
+    const driftDetected = findings.some(
+      f => f.driftType === DRIFT_TYPE.DRIFT || f.driftType === DRIFT_TYPE.CONTRADICTION
+    );
+    const severity = computeSeverity(findings);
+
+    return {
+      ventureId,
+      baselineStage,
+      currentStage,
+      baselineAssumptionSetId: baseline.id,
+      driftDetected,
+      severity,
+      findings,
+    };
+  } catch (error) {
+    logger.error?.(
+      `[ConstraintDrift] Error for venture=${ventureId} stage=${currentStage}: ${error.message}`
+    );
+    return {
+      ventureId,
+      baselineStage,
+      currentStage,
+      baselineAssumptionSetId: null,
+      driftDetected: false,
+      severity: SEVERITY.NONE,
+      findings: [
+        {
+          category: 'error',
+          baselineValue: null,
+          currentValue: null,
+          driftType: DRIFT_TYPE.ERROR,
+          rationale: `${error.constructor.name}: ${error.message}`,
+          confidence: 0,
+        },
+      ],
+    };
+  }
+}
+
+/**
+ * Build a payload compatible with Decision Filter Engine's constraint_drift trigger.
+ *
+ * @param {Object} driftResult - Output of detectConstraintDrift
+ * @returns {Object|null} Filter engine payload or null if severity < MEDIUM
+ */
+export function buildFilterEnginePayload(driftResult) {
+  if (!driftResult || !driftResult.driftDetected) return null;
+  if (
+    driftResult.severity === SEVERITY.NONE ||
+    driftResult.severity === SEVERITY.LOW
+  ) {
+    return null;
+  }
+
+  const driftFindings = driftResult.findings.filter(
+    f => f.driftType === DRIFT_TYPE.DRIFT || f.driftType === DRIFT_TYPE.CONTRADICTION
+  );
+
+  const categories = driftFindings.map(f => f.category).join(', ');
+  let summary = `Constraint drift detected in ${driftFindings.length} categor${driftFindings.length === 1 ? 'y' : 'ies'}: ${categories}`;
+  if (summary.length > 240) {
+    summary = summary.slice(0, 237) + '...';
+  }
+
+  return {
+    type: 'CONSTRAINT_DRIFT',
+    ventureId: driftResult.ventureId,
+    stage: driftResult.currentStage,
+    severity: driftResult.severity,
+    summary,
+    findings: driftFindings.map(f => ({
+      category: f.category,
+      driftType: f.driftType,
+      rationale: f.rationale,
+    })),
+  };
+}
+
+// ── Internal Helpers ────────────────────────────────────────────
+
+/**
+ * Load baseline assumptions from assumption_sets table.
+ */
+async function loadBaselineAssumptions({ ventureId, baselineStage, db }) {
+  const { data, error } = await db
+    .from('assumption_sets')
+    .select('id, market_assumptions, competitor_assumptions, product_assumptions, timing_assumptions, confidence_scores')
+    .eq('venture_id', ventureId)
+    .eq('created_at_stage', baselineStage)
+    .in('status', ['active', 'validated'])
+    .order('version', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data;
+}
+
+/**
+ * Extract constraint-relevant content from venture_artifacts.
+ */
+async function extractCurrentConstraints({ ventureId, currentStage, db }) {
+  const { data, error } = await db
+    .from('venture_artifacts')
+    .select('id, artifact_type, content, created_at')
+    .eq('venture_id', ventureId)
+    .eq('stage', currentStage)
+    .order('created_at', { ascending: false });
+
+  if (error) throw error;
+  if (!data || data.length === 0) {
+    return { categories: {}, sources: [] };
+  }
+
+  // Select best artifact by type priority
+  let selected = null;
+  for (const type of ARTIFACT_TYPE_PRIORITY) {
+    const match = data.find(a => a.artifact_type === type);
+    if (match) {
+      selected = match;
+      break;
+    }
+  }
+  // Fallback to most recent artifact
+  if (!selected) {
+    selected = data[0];
+  }
+
+  const content = selected.content || {};
+  const categories = {};
+
+  // Extract assumption-like categories from artifact content
+  if (content.market_assumptions || content.market) {
+    categories.market_assumptions = content.market_assumptions || content.market;
+  }
+  if (content.competitor_assumptions || content.competitors || content.competitive) {
+    categories.competitor_assumptions =
+      content.competitor_assumptions || content.competitors || content.competitive;
+  }
+  if (content.product_assumptions || content.product) {
+    categories.product_assumptions = content.product_assumptions || content.product;
+  }
+  if (content.timing_assumptions || content.timing || content.timeline) {
+    categories.timing_assumptions =
+      content.timing_assumptions || content.timing || content.timeline;
+  }
+  // Also check for explicit constraints block
+  if (content.constraints) {
+    for (const [key, val] of Object.entries(content.constraints)) {
+      const catKey = ASSUMPTION_CATEGORIES.includes(key) ? key : null;
+      if (catKey) {
+        categories[catKey] = categories[catKey] || val;
+      } else {
+        categories[key] = val;
+      }
+    }
+  }
+
+  return {
+    categories,
+    sources: [
+      {
+        artifactId: selected.id,
+        artifactType: selected.artifact_type,
+        createdAt: selected.created_at,
+      },
+    ],
+  };
+}
+
+/**
+ * Compare baseline assumptions with current-stage extracted categories.
+ */
+function compareCategories(baseline, currentCategories, currentStage) {
+  const findings = [];
+  const allKeys = new Set([
+    ...ASSUMPTION_CATEGORIES,
+    ...Object.keys(currentCategories),
+  ]);
+
+  for (const category of allKeys) {
+    const baselineVal = baseline[category];
+    const currentVal = currentCategories[category];
+
+    // Skip if neither side has this category
+    if (baselineVal === undefined && currentVal === undefined) continue;
+
+    // Stage 25 must always check vision if present in baseline
+    if (currentStage === 25 && category === 'vision') {
+      if (!baselineVal) {
+        findings.push({
+          category: 'vision',
+          baselineValue: null,
+          currentValue: currentVal || null,
+          driftType: DRIFT_TYPE.NO_BASELINE,
+          rationale: 'No vision category in baseline assumptions',
+          confidence: 1.0,
+        });
+      } else {
+        const drift = computeDrift(baselineVal, currentVal);
+        findings.push({
+          category: 'vision',
+          baselineValue: baselineVal,
+          currentValue: currentVal || null,
+          driftType: drift.driftType,
+          rationale: drift.rationale,
+          confidence: drift.confidence,
+        });
+      }
+      continue;
+    }
+
+    // One side has data, the other doesn't
+    if (baselineVal === undefined) continue; // New category in current, no baseline to compare
+    if (currentVal === undefined) continue; // Baseline category not in current, skip
+
+    const drift = computeDrift(baselineVal, currentVal);
+    if (drift.driftType !== DRIFT_TYPE.NO_CHANGE) {
+      findings.push({
+        category,
+        baselineValue: baselineVal,
+        currentValue: currentVal,
+        driftType: drift.driftType,
+        rationale: drift.rationale,
+        confidence: drift.confidence,
+      });
+    }
+  }
+
+  return findings;
+}
+
+/**
+ * Compare two values and determine drift type.
+ */
+function computeDrift(baseline, current) {
+  const normalizedBaseline = normalize(baseline);
+  const normalizedCurrent = normalize(current);
+
+  if (deepEqual(normalizedBaseline, normalizedCurrent)) {
+    return { driftType: DRIFT_TYPE.NO_CHANGE, rationale: 'Values match after normalization', confidence: 1.0 };
+  }
+
+  // Check for contradiction vs drift
+  if (isContradiction(normalizedBaseline, normalizedCurrent)) {
+    return {
+      driftType: DRIFT_TYPE.CONTRADICTION,
+      rationale: buildDiffRationale(normalizedBaseline, normalizedCurrent, 'contradicts'),
+      confidence: 0.85,
+    };
+  }
+
+  return {
+    driftType: DRIFT_TYPE.DRIFT,
+    rationale: buildDiffRationale(normalizedBaseline, normalizedCurrent, 'differs from'),
+    confidence: 0.7,
+  };
+}
+
+/**
+ * Determine if current value contradicts baseline (not just differs).
+ * Contradiction = direct negation or opposite category.
+ */
+function isContradiction(baseline, current) {
+  if (typeof baseline === 'string' && typeof current === 'string') {
+    const bLower = baseline.toLowerCase();
+    const cLower = current.toLowerCase();
+    // Direct negation patterns
+    const opposites = [
+      ['subscription', 'one_time'], ['subscription', 'perpetual'],
+      ['b2b', 'b2c'], ['enterprise', 'consumer'],
+      ['premium', 'freemium'], ['high', 'low'],
+      ['domestic', 'international'], ['global', 'local'],
+    ];
+    for (const [a, b] of opposites) {
+      if ((bLower.includes(a) && cLower.includes(b)) || (bLower.includes(b) && cLower.includes(a))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Normalize a value for comparison: trim strings, sort arrays, lowercase.
+ */
+function normalize(val) {
+  if (val === null || val === undefined) return null;
+  if (typeof val === 'string') return val.trim().toLowerCase();
+  if (Array.isArray(val)) {
+    return val.map(normalize).sort((a, b) => {
+      const sa = typeof a === 'string' ? a : JSON.stringify(a);
+      const sb = typeof b === 'string' ? b : JSON.stringify(b);
+      return sa.localeCompare(sb);
+    });
+  }
+  if (typeof val === 'object') {
+    const sorted = {};
+    for (const key of Object.keys(val).sort()) {
+      sorted[key] = normalize(val[key]);
+    }
+    return sorted;
+  }
+  return val;
+}
+
+/**
+ * Deep equality check for normalized values.
+ */
+function deepEqual(a, b) {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => deepEqual(item, b[i]));
+  }
+  if (typeof a === 'object') {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return false;
+    return keysA.every(k => deepEqual(a[k], b[k]));
+  }
+  return false;
+}
+
+/**
+ * Build a human-readable rationale for a drift finding.
+ */
+function buildDiffRationale(baseline, current, verb) {
+  const bStr = typeof baseline === 'string' ? baseline : JSON.stringify(baseline);
+  const cStr = typeof current === 'string' ? current : JSON.stringify(current);
+  const bShort = bStr.length > 60 ? bStr.slice(0, 57) + '...' : bStr;
+  const cShort = cStr.length > 60 ? cStr.slice(0, 57) + '...' : cStr;
+  return `Current value "${cShort}" ${verb} baseline "${bShort}"`;
+}
+
+/**
+ * Compute overall severity from findings.
+ */
+function computeSeverity(findings) {
+  const hasContradiction = findings.some(f => f.driftType === DRIFT_TYPE.CONTRADICTION);
+  const driftCount = findings.filter(
+    f => f.driftType === DRIFT_TYPE.DRIFT || f.driftType === DRIFT_TYPE.CONTRADICTION
+  ).length;
+
+  if (hasContradiction) return SEVERITY.HIGH;
+  if (driftCount >= 3) return SEVERITY.HIGH;
+  if (driftCount >= 2) return SEVERITY.MEDIUM;
+  if (driftCount >= 1) return SEVERITY.LOW;
+  return SEVERITY.NONE;
+}
+
+// ── Exports for testing ─────────────────────────────────────────
+
+export const _internal = {
+  normalize,
+  deepEqual,
+  isContradiction,
+  computeDrift,
+  computeSeverity,
+  compareCategories,
+  loadBaselineAssumptions,
+  extractCurrentConstraints,
+  buildDiffRationale,
+  SEVERITY,
+  DRIFT_TYPE,
+  ASSUMPTION_CATEGORIES,
+  ARTIFACT_TYPE_PRIORITY,
+};

--- a/lib/eva/index.js
+++ b/lib/eva/index.js
@@ -10,6 +10,7 @@ export { ChairmanPreferenceStore, createChairmanPreferenceStore } from './chairm
 export { processStage, run } from './eva-orchestrator.js';
 export { getDevilsAdvocateReview, isDevilsAdvocateGate, buildArtifactRecord } from './devils-advocate.js';
 export { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-bridge.js';
+export { detectConstraintDrift, buildFilterEnginePayload } from './constraint-drift-detector.js';
 
 // CLI-compatible ports of frontend venture services (SD-LEO-FEAT-SERVICE-PORTS-001)
 export {

--- a/tests/unit/eva/constraint-drift-detector.test.js
+++ b/tests/unit/eva/constraint-drift-detector.test.js
@@ -1,0 +1,446 @@
+/**
+ * Tests for Constraint Drift Detector
+ * SD-LEO-FEAT-CONSTRAINT-DRIFT-001
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  detectConstraintDrift,
+  buildFilterEnginePayload,
+  _internal,
+} from '../../../lib/eva/constraint-drift-detector.js';
+
+const { normalize, deepEqual, isContradiction, computeDrift, computeSeverity, SEVERITY, DRIFT_TYPE } = _internal;
+
+// ── Mock Supabase helpers ──────────────────────────────────
+
+function createMockDb({
+  assumptionData = null,
+  assumptionError = null,
+  artifactData = [],
+  artifactError = null,
+} = {}) {
+  return {
+    from: vi.fn((table) => {
+      if (table === 'assumption_sets') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                in: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockReturnValue({
+                      maybeSingle: vi.fn().mockResolvedValue({
+                        data: assumptionData,
+                        error: assumptionError,
+                      }),
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'venture_artifacts') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockResolvedValue({
+                  data: artifactData,
+                  error: artifactError,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      return {};
+    }),
+  };
+}
+
+function createMockLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+// ── normalize ────────────────────────────────────────────────
+
+describe('normalize', () => {
+  it('trims and lowercases strings', () => {
+    expect(normalize('  Hello World  ')).toBe('hello world');
+  });
+
+  it('sorts arrays', () => {
+    expect(normalize(['SEO', 'Email'])).toEqual(['email', 'seo']);
+  });
+
+  it('sorts object keys recursively', () => {
+    expect(normalize({ b: 'Two', a: 'One' })).toEqual({ a: 'one', b: 'two' });
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(normalize(null)).toBeNull();
+    expect(normalize(undefined)).toBeNull();
+  });
+
+  it('passes numbers through', () => {
+    expect(normalize(42)).toBe(42);
+  });
+});
+
+// ── deepEqual ────────────────────────────────────────────────
+
+describe('deepEqual', () => {
+  it('returns true for identical primitives', () => {
+    expect(deepEqual('a', 'a')).toBe(true);
+    expect(deepEqual(1, 1)).toBe(true);
+  });
+
+  it('returns false for different primitives', () => {
+    expect(deepEqual('a', 'b')).toBe(false);
+  });
+
+  it('compares arrays element by element', () => {
+    expect(deepEqual(['a', 'b'], ['a', 'b'])).toBe(true);
+    expect(deepEqual(['a', 'b'], ['b', 'a'])).toBe(false);
+  });
+
+  it('compares objects by keys and values', () => {
+    expect(deepEqual({ a: 1 }, { a: 1 })).toBe(true);
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+  });
+
+  it('handles null comparisons', () => {
+    expect(deepEqual(null, null)).toBe(true);
+    expect(deepEqual(null, 'a')).toBe(false);
+  });
+});
+
+// ── isContradiction ──────────────────────────────────────────
+
+describe('isContradiction', () => {
+  it('detects subscription vs one_time as contradiction', () => {
+    expect(isContradiction('subscription_model', 'one_time_payment')).toBe(true);
+  });
+
+  it('detects b2b vs b2c', () => {
+    expect(isContradiction('B2B enterprise', 'B2C consumer')).toBe(true);
+  });
+
+  it('returns false for similar but non-contradicting strings', () => {
+    expect(isContradiction('subscription annual', 'subscription monthly')).toBe(false);
+  });
+
+  it('returns false for non-string types', () => {
+    expect(isContradiction(123, 456)).toBe(false);
+  });
+});
+
+// ── computeDrift ─────────────────────────────────────────────
+
+describe('computeDrift', () => {
+  it('returns NO_CHANGE for identical values after normalization', () => {
+    const result = computeDrift('Hello', '  hello  ');
+    expect(result.driftType).toBe(DRIFT_TYPE.NO_CHANGE);
+  });
+
+  it('returns CONTRADICTION for opposite values', () => {
+    const result = computeDrift('subscription_only', 'one_time_license');
+    expect(result.driftType).toBe(DRIFT_TYPE.CONTRADICTION);
+  });
+
+  it('returns DRIFT for different but non-contradicting values', () => {
+    const result = computeDrift('north_america', 'emea');
+    expect(result.driftType).toBe(DRIFT_TYPE.DRIFT);
+  });
+
+  it('handles array comparison with reordering', () => {
+    const result = computeDrift(['SEO', 'Email'], ['Email', 'SEO']);
+    expect(result.driftType).toBe(DRIFT_TYPE.NO_CHANGE);
+  });
+
+  it('detects drift in arrays with different elements', () => {
+    const result = computeDrift(['SEO', 'Email'], ['Social', 'Email']);
+    expect(result.driftType).toBe(DRIFT_TYPE.DRIFT);
+  });
+});
+
+// ── computeSeverity ──────────────────────────────────────────
+
+describe('computeSeverity', () => {
+  it('returns NONE for no findings', () => {
+    expect(computeSeverity([])).toBe(SEVERITY.NONE);
+  });
+
+  it('returns HIGH for contradiction', () => {
+    const findings = [{ driftType: DRIFT_TYPE.CONTRADICTION }];
+    expect(computeSeverity(findings)).toBe(SEVERITY.HIGH);
+  });
+
+  it('returns MEDIUM for 2 drifts', () => {
+    const findings = [{ driftType: DRIFT_TYPE.DRIFT }, { driftType: DRIFT_TYPE.DRIFT }];
+    expect(computeSeverity(findings)).toBe(SEVERITY.MEDIUM);
+  });
+
+  it('returns LOW for single drift', () => {
+    const findings = [{ driftType: DRIFT_TYPE.DRIFT }];
+    expect(computeSeverity(findings)).toBe(SEVERITY.LOW);
+  });
+
+  it('returns HIGH for 3+ drifts', () => {
+    const findings = [
+      { driftType: DRIFT_TYPE.DRIFT },
+      { driftType: DRIFT_TYPE.DRIFT },
+      { driftType: DRIFT_TYPE.DRIFT },
+    ];
+    expect(computeSeverity(findings)).toBe(SEVERITY.HIGH);
+  });
+});
+
+// ── detectConstraintDrift ────────────────────────────────────
+
+describe('detectConstraintDrift', () => {
+  let logger;
+
+  beforeEach(() => {
+    logger = createMockLogger();
+  });
+
+  it('returns no-drift when no baseline exists', async () => {
+    const db = createMockDb({ assumptionData: null });
+
+    const result = await detectConstraintDrift({
+      ventureId: 'v-1',
+      currentStage: 10,
+      db,
+      logger,
+    });
+
+    expect(result.baselineAssumptionSetId).toBeNull();
+    expect(result.driftDetected).toBe(false);
+    expect(result.severity).toBe('NONE');
+    expect(logger.info).toHaveBeenCalled();
+  });
+
+  it('returns NO_CURRENT_DATA when no artifacts exist', async () => {
+    const db = createMockDb({
+      assumptionData: {
+        id: 'as-1',
+        market_assumptions: { tam: 1000000 },
+        competitor_assumptions: null,
+        product_assumptions: null,
+        timing_assumptions: null,
+      },
+      artifactData: [],
+    });
+
+    const result = await detectConstraintDrift({
+      ventureId: 'v-1',
+      currentStage: 10,
+      db,
+      logger,
+    });
+
+    expect(result.driftDetected).toBe(false);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].driftType).toBe('NO_CURRENT_DATA');
+  });
+
+  it('detects drift when pricing changes', async () => {
+    const db = createMockDb({
+      assumptionData: {
+        id: 'as-1',
+        market_assumptions: { pricing: 'subscription_only' },
+        competitor_assumptions: null,
+        product_assumptions: null,
+        timing_assumptions: null,
+      },
+      artifactData: [
+        {
+          id: 'art-1',
+          artifact_type: 'stage_output',
+          content: { market_assumptions: { pricing: 'one_time_license' } },
+          created_at: '2026-02-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const result = await detectConstraintDrift({
+      ventureId: 'v-1',
+      currentStage: 25,
+      db,
+      logger,
+    });
+
+    expect(result.driftDetected).toBe(true);
+    expect(result.severity).not.toBe('NONE');
+    expect(result.findings.some(f => f.category === 'market_assumptions')).toBe(true);
+  });
+
+  it('detects no drift when values match after normalization', async () => {
+    const db = createMockDb({
+      assumptionData: {
+        id: 'as-1',
+        market_assumptions: { channels: ['SEO', 'Email'] },
+        competitor_assumptions: null,
+        product_assumptions: null,
+        timing_assumptions: null,
+      },
+      artifactData: [
+        {
+          id: 'art-1',
+          artifact_type: 'stage_output',
+          content: { market_assumptions: { channels: ['Email', 'SEO'] } },
+          created_at: '2026-02-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const result = await detectConstraintDrift({
+      ventureId: 'v-1',
+      currentStage: 10,
+      db,
+      logger,
+    });
+
+    expect(result.driftDetected).toBe(false);
+    expect(result.severity).toBe('NONE');
+  });
+
+  it('returns error result on database failure', async () => {
+    const db = createMockDb({
+      assumptionError: new Error('Connection refused'),
+    });
+
+    const result = await detectConstraintDrift({
+      ventureId: 'v-1',
+      currentStage: 10,
+      db,
+      logger,
+    });
+
+    expect(result.driftDetected).toBe(false);
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].driftType).toBe('ERROR');
+    expect(result.findings[0].rationale).toContain('Connection refused');
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('handles multiple category drifts', async () => {
+    const db = createMockDb({
+      assumptionData: {
+        id: 'as-1',
+        market_assumptions: { region: 'north_america' },
+        competitor_assumptions: { intensity: 'low' },
+        product_assumptions: { model: 'B2B enterprise' },
+        timing_assumptions: null,
+      },
+      artifactData: [
+        {
+          id: 'art-1',
+          artifact_type: 'stage_output',
+          content: {
+            market_assumptions: { region: 'emea' },
+            competitor_assumptions: { intensity: 'high' },
+            product_assumptions: { model: 'B2C consumer' },
+          },
+          created_at: '2026-02-01T00:00:00Z',
+        },
+      ],
+    });
+
+    const result = await detectConstraintDrift({
+      ventureId: 'v-1',
+      currentStage: 15,
+      db,
+      logger,
+    });
+
+    expect(result.driftDetected).toBe(true);
+    const driftFindings = result.findings.filter(
+      f => f.driftType === 'DRIFT' || f.driftType === 'CONTRADICTION'
+    );
+    expect(driftFindings.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── buildFilterEnginePayload ─────────────────────────────────
+
+describe('buildFilterEnginePayload', () => {
+  it('returns null when no drift detected', () => {
+    const result = buildFilterEnginePayload({
+      driftDetected: false,
+      severity: 'NONE',
+      findings: [],
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null for LOW severity', () => {
+    const result = buildFilterEnginePayload({
+      driftDetected: true,
+      severity: 'LOW',
+      findings: [{ driftType: 'DRIFT', category: 'market' }],
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns payload for MEDIUM severity', () => {
+    const result = buildFilterEnginePayload({
+      ventureId: 'v-1',
+      currentStage: 25,
+      driftDetected: true,
+      severity: 'MEDIUM',
+      findings: [
+        { category: 'pricing', driftType: 'DRIFT', rationale: 'Pricing changed' },
+        { category: 'market', driftType: 'DRIFT', rationale: 'Market shifted' },
+      ],
+    });
+
+    expect(result.type).toBe('CONSTRAINT_DRIFT');
+    expect(result.ventureId).toBe('v-1');
+    expect(result.stage).toBe(25);
+    expect(result.severity).toBe('MEDIUM');
+    expect(result.summary.length).toBeLessThanOrEqual(240);
+    expect(result.findings).toHaveLength(2);
+  });
+
+  it('returns payload for HIGH severity with contradiction', () => {
+    const result = buildFilterEnginePayload({
+      ventureId: 'v-1',
+      currentStage: 25,
+      driftDetected: true,
+      severity: 'HIGH',
+      findings: [
+        { category: 'pricing', driftType: 'CONTRADICTION', rationale: 'Subscription vs one-time' },
+        { category: 'geo', driftType: 'NO_CHANGE', rationale: 'No change' },
+      ],
+    });
+
+    expect(result.type).toBe('CONSTRAINT_DRIFT');
+    expect(result.severity).toBe('HIGH');
+    // Should only include drift/contradiction findings, not NO_CHANGE
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].category).toBe('pricing');
+  });
+
+  it('truncates summary to 240 chars', () => {
+    const findings = Array.from({ length: 20 }, (_, i) => ({
+      category: `very_long_category_name_${i}`,
+      driftType: 'DRIFT',
+      rationale: 'changed',
+    }));
+
+    const result = buildFilterEnginePayload({
+      ventureId: 'v-1',
+      currentStage: 10,
+      driftDetected: true,
+      severity: 'HIGH',
+      findings,
+    });
+
+    expect(result.summary.length).toBeLessThanOrEqual(240);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `lib/eva/constraint-drift-detector.js` - compares current venture stage outputs against Stage 1 baseline assumptions from `assumption_sets` table
- Detects contradictions (e.g., subscription vs one-time pricing) and drift across market, competitor, product, and timing categories
- `buildFilterEnginePayload()` generates payloads compatible with Decision Filter Engine's `constraint_drift` trigger
- Graceful handling of missing baselines, missing artifacts, and database errors
- 35 unit tests covering normalization, comparison, severity computation, edge cases
- Updated `lib/eva/index.js` barrel export

## Test plan
- [x] 35 vitest unit tests passing
- [x] Normalization prevents false positives (array reordering, whitespace)
- [x] Contradiction detection for known opposite pairs
- [x] Missing baseline returns graceful no-drift result
- [x] Database errors return controlled error objects
- [x] Filter payload truncated to 240 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)