### PR TITLE
fix: add infrastructure SD type filtering to TESTING and DESIGN sub-agents

### DIFF
--- a/lib/sub-agents/design/index.js
+++ b/lib/sub-agents/design/index.js
@@ -70,6 +70,12 @@ export async function execute(sdId, subAgent, options = {}) {
     supabase = await createSupabaseServiceClient('engineer', { verbose: false });
   }
 
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-010: Early-return for non-UI SD types
+  // ROOT CAUSE FIX (SAL-DESIGN-PERF): DESIGN sub-agent ran all UI/UX checks on infrastructure
+  // SDs, causing 40% pass rate since infra SDs have no UI components to validate.
+  const skipResult = await checkForNonUISdType(sdId, options);
+  if (skipResult) return skipResult;
+
   const results = {
     verdict: 'PASS',
     confidence: 100,
@@ -386,6 +392,91 @@ export async function execute(sdId, subAgent, options = {}) {
       error: error.message
     });
     return results;
+  }
+}
+
+/**
+ * Check if SD is a non-UI type that should skip DESIGN validation
+ * SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-010: Prevents running UI/UX checks on infrastructure SDs
+ *
+ * @param {string} sdId - Strategic Directive ID
+ * @param {Object} options - Execution options
+ * @returns {Promise<Object|null>} Skip result if non-UI, null to continue
+ */
+async function checkForNonUISdType(sdId, options) {
+  try {
+    const { data: sdData } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_type, category')
+      .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
+      .single();
+
+    const sdType = (sdData?.sd_type || '').toLowerCase();
+    const sdCategory = (sdData?.category || '').toLowerCase();
+    const effectiveType = sdType || sdCategory;
+
+    // Non-UI SD types that should skip design validation
+    const nonUISdTypes = [
+      'infrastructure', 'database', 'documentation', 'docs',
+      'process', 'uat', 'api', 'backend', 'orchestrator'
+    ];
+
+    if (!nonUISdTypes.includes(effectiveType)) {
+      return null; // Continue with full DESIGN validation
+    }
+
+    const isInfra = ['infrastructure', 'database', 'backend', 'api'].includes(effectiveType);
+
+    console.log(`\n🏗️  SD Type Detection: ${effectiveType.toUpperCase()} (source: ${sdType ? 'sd_type' : 'category'})`);
+    console.log(`   💡 ${effectiveType} SDs do not require UI/UX design validation`);
+    console.log(isInfra
+      ? '   ✅ Infrastructure validation: deployment, CI/CD, monitoring, rollback, config management'
+      : `   ✅ ${effectiveType} SD - design checks skipped (no UI components)`);
+
+    const infraChecklist = isInfra ? [
+      'Deployment strategy documented',
+      'CI/CD pipeline integration verified',
+      'Monitoring and alerting configured',
+      'Rollback procedure defined',
+      'Configuration management approach specified'
+    ] : [];
+
+    return {
+      verdict: 'PASS',
+      confidence: 95,
+      critical_issues: [],
+      warnings: [],
+      recommendations: isInfra ? [{
+        severity: 'INFO',
+        issue: `${effectiveType} SD - UI/UX design checks not applicable`,
+        recommendation: 'Validate infrastructure concerns: deployment, monitoring, rollback, CI/CD integration'
+      }] : [{
+        severity: 'INFO',
+        issue: `${effectiveType} SD - design checks skipped`,
+        recommendation: `No UI components to validate for ${effectiveType} SD type`
+      }],
+      detailed_analysis: {
+        sd_type: effectiveType,
+        sd_type_source: sdType ? 'declared' : 'category_fallback',
+        skip_reason: `Non-UI SD type (${effectiveType}) - UI/UX design validation not applicable`,
+        validation_approach: isInfra
+          ? 'Infrastructure design review: deployment, CI/CD, monitoring, rollback, config management'
+          : `${effectiveType}-appropriate validation (non-UI)`,
+        infra_checklist: infraChecklist
+      },
+      findings: {
+        design_system_check: { skipped: true, reason: `${effectiveType} SD - no UI components` },
+        component_analysis: { skipped: true, reason: `${effectiveType} SD - no UI components` },
+        accessibility_check: { skipped: true, reason: `${effectiveType} SD - no UI components` },
+        responsive_check: { skipped: true, reason: `${effectiveType} SD - no UI components` },
+        consistency_check: { skipped: true, reason: `${effectiveType} SD - no UI components` },
+        workflow_review: { skipped: true, reason: `${effectiveType} SD - no user-facing workflows` }
+      },
+      options
+    };
+  } catch (error) {
+    console.warn(`   ⚠️  SD type detection failed: ${error.message}, continuing with full DESIGN validation`);
+    return null; // On error, fall through to full validation
   }
 }
 

--- a/lib/sub-agents/testing/index.js
+++ b/lib/sub-agents/testing/index.js
@@ -280,25 +280,33 @@ async function fetchSemanticPatterns(sdId) {
 }
 
 async function checkForNonUISdType(sdId, validationMode, options) {
-  // SD-LEARN-FIX-ADDRESS-IMPROVEMENT-LEARN-002: Use sd_key instead of legacy_id (column dropped 2026-01-24)
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-010: Query sd_type (authoritative) AND category (fallback)
+  // ROOT CAUSE FIX (SAL-TESTING-REC): Previously only checked category field, missing infrastructure
+  // SDs that have sd_type='infrastructure' but category='technical'
   const { data: sdData } = await supabase
     .from('strategic_directives_v2')
-    .select('category')
+    .select('sd_type, category')
     .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
     .single();
 
+  // Use sd_type first (declared, authoritative), fall back to category
+  const sdType = sdData?.sd_type?.toLowerCase() || '';
   const sdCategory = sdData?.category?.toLowerCase() || '';
-  const skipE2ESdTypes = ['database', 'infrastructure', 'documentation', 'protocol', 'refactor'];
+  const effectiveType = sdType || sdCategory;
+  const skipE2ESdTypes = ['database', 'infrastructure', 'documentation', 'docs', 'protocol', 'refactor', 'process', 'uat', 'orchestrator', 'api', 'backend'];
 
-  if (skipE2ESdTypes.includes(sdCategory)) {
-    const isRefactor = sdCategory === 'refactor';
-    console.log(`\n🗄️  SD Type Detection: ${sdCategory.toUpperCase()}`);
+  if (skipE2ESdTypes.includes(effectiveType)) {
+    const isRefactor = effectiveType === 'refactor';
+    const isInfra = ['infrastructure', 'database', 'process', 'orchestrator'].includes(effectiveType);
+    console.log(`\n🗄️  SD Type Detection: ${effectiveType.toUpperCase()} (source: ${sdType ? 'sd_type' : 'category'})`);
     console.log(isRefactor
       ? '   💡 Refactor SDs use REGRESSION sub-agent for validation'
-      : '   💡 Database/Infrastructure SDs do not require UI E2E tests');
+      : `   💡 ${effectiveType} SDs do not require UI E2E tests`);
     console.log(isRefactor
       ? '   ✅ Validation via REGRESSION sub-agent (before/after behavior comparison)'
-      : '   ✅ Validation via DATABASE/SECURITY sub-agents + table existence');
+      : isInfra
+        ? '   ✅ Validation via DATABASE/SECURITY sub-agents + schema/table checks'
+        : '   ✅ Validation deferred to appropriate sub-agents');
 
     return {
       verdict: 'PASS',
@@ -308,27 +316,32 @@ async function checkForNonUISdType(sdId, validationMode, options) {
       warnings: [],
       recommendations: [{
         severity: 'INFO',
-        issue: `${sdCategory} SD - UI E2E tests not applicable`,
+        issue: `${effectiveType} SD - UI E2E tests not applicable`,
         recommendation: isRefactor
           ? 'Behavior validated via REGRESSION sub-agent (before/after comparison)'
-          : 'Schema validated via DATABASE sub-agent and table existence checks'
+          : isInfra
+            ? 'Schema validated via DATABASE sub-agent and table existence checks. Run `npm run test:infra` for infrastructure validation.'
+            : `Validation via appropriate sub-agents for ${effectiveType} SD type`
       }],
       detailed_analysis: {
-        sd_type: sdCategory,
+        sd_type: effectiveType,
+        sd_type_source: sdType ? 'declared' : 'category_fallback',
         skip_reason: isRefactor
           ? 'Refactor SD - validation via REGRESSION sub-agent behavior comparison'
-          : 'Non-UI SD type - E2E validation deferred to DATABASE/SECURITY sub-agents',
+          : `Non-UI SD type (${effectiveType}) - E2E validation deferred to appropriate sub-agents`,
         validation_approach: isRefactor
           ? 'REGRESSION sub-agent: before/after behavior comparison, no functional changes'
-          : 'SQL schema validation, RLS policy verification'
+          : isInfra
+            ? 'SQL schema validation, RLS policy verification, table existence checks'
+            : `${effectiveType}-appropriate validation (non-UI)`
       },
       findings: {
-        phase0_intelligence: { skipped: true, reason: `${sdCategory} SD - no UI components` },
+        phase0_intelligence: { skipped: true, reason: `${effectiveType} SD - no UI components` },
         phase1_preflight: { skipped: true },
         phase2_test_generation: { skipped: true },
-        phase3_execution: { skipped: true, reason: 'E2E not applicable for database SDs' },
-        phase4_evidence: { type: 'schema_validation' },
-        phase5_verdict: { auto_pass: true, sd_type: sdCategory }
+        phase3_execution: { skipped: true, reason: `E2E not applicable for ${effectiveType} SDs` },
+        phase4_evidence: { type: isInfra ? 'schema_validation' : 'non_ui_validation' },
+        phase5_verdict: { auto_pass: true, sd_type: effectiveType }
       },
       options
     };


### PR DESCRIPTION
## Summary
- **TESTING sub-agent**: Fixed `checkForNonUISdType()` to query `sd_type` (authoritative) with `category` fallback, resolving SAL-TESTING-REC pattern (7 occurrences of irrelevant E2E test recommendations for infrastructure SDs)
- **DESIGN sub-agent**: Added new `checkForNonUISdType()` early-return function that skips all 6 UI/UX validation phases for non-UI SD types, resolving SAL-DESIGN-PERF pattern (5 occurrences, 40% pass rate)
- Extended skip lists in both sub-agents to match canonical NON_CODE list from `sd-type-checker.js`

## Test plan
- [x] All 180 smoke tests pass
- [x] Both files load without syntax errors
- [x] ESLint passes with auto-fix
- [ ] Verify SAL-TESTING-REC stops recurring (monitor issue_patterns for 30 days)
- [ ] Verify SAL-DESIGN-PERF pass rate improves from 40% to >=90% for infrastructure SDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)