### PR TITLE
fix: expand NON_ACTIONABLE_SAL_PATTERNS to filter DOCMON/DESIGN noise

### DIFF
--- a/scripts/modules/learning/context-builder.js
+++ b/scripts/modules/learning/context-builder.js
@@ -99,6 +99,19 @@ const NON_ACTIONABLE_SAL_PATTERNS = [
   /(?:wcag|aria).*compliance.*required/i,
   /add missing (?:alt text|aria)/i,
   /use.*testing tools for.*coverage/i,
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-011: DOCMON positive confirmations (SAL-DOCMON-REC)
+  /no new markdown files/i,
+  /database.?first (?:maintained|compliant|enforced)/i,
+  /consider cleanup SD/i,
+  /migrate legacy markdown/i,
+  /ignored? \d+ pre.?existing/i,
+  /retrospective validation.*ignored/i,
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-011: DESIGN positive confirmations (SAL-DESIGN-REC)
+  /design compliance (?:maintained|at) (?:at )?\d+%/i,
+  /continue following design system/i,
+  /excellent (?:UI\/UX |design )?consistency/i,
+  /ui\/ux consistency/i,
+  /design system guidelines/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Added 11 regex patterns to `NON_ACTIONABLE_SAL_PATTERNS` in `context-builder.js` to filter positive sub-agent confirmations from `/learn` pipeline
- Resolves SAL-DOCMON-REC (20 occurrences) and SAL-DESIGN-REC (9 occurrences) noise patterns
- Verified: 6 noise texts filtered, 3 legitimate violation texts correctly pass through

## Test plan
- [x] All 210 smoke tests pass
- [x] Pattern matching verified with positive and negative test cases
- [ ] Monitor SAL-DOCMON-REC and SAL-DESIGN-REC for 30 days post-deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)