### PR TITLE
fix: add STORIES failure pattern to SAL noise filtering

### DIFF
--- a/scripts/modules/learning/context-builder.js
+++ b/scripts/modules/learning/context-builder.js
@@ -130,6 +130,9 @@ const NON_ACTIONABLE_SAL_PATTERNS = [
   /relaxed CI\/CD validation/i,
   // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-012: Sub-agent performance meta-observations (SAL-*-PERF)
   /has low pass rate.*review triggers/i,
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-013: STORIES failure on non-feature SDs (SAL-STORIES-ISS)
+  /failed to create (?:any )?user stories/i,
+  /no user stories (?:could be )?(?:generated|created)/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Add 2 regex patterns to `NON_ACTIONABLE_SAL_PATTERNS` for STORIES sub-agent user story creation failures
- Filter `Failed to create any user stories` and `No user stories could be generated` as non-actionable for infrastructure SDs
- Resolve PAT-AUTO-8e520595 (SMOKE_TEST_SPECIFICATION gate false positive)
- 3/5 SD items were already resolved by SD-011 and SD-012

## Test plan
- [x] 4/4 STORIES-specific pattern tests pass
- [x] 17/17 prior pattern tests still pass
- [x] 225/225 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)