### PR TITLE
fix: filter TESTING sub-agent boilerplate from /learn pipeline

### DIFF
--- a/scripts/modules/learning/context-builder.js
+++ b/scripts/modules/learning/context-builder.js
@@ -133,6 +133,11 @@ const NON_ACTIONABLE_SAL_PATTERNS = [
   // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-013: STORIES failure on non-feature SDs (SAL-STORIES-ISS)
   /failed to create (?:any )?user stories/i,
   /no user stories (?:could be )?(?:generated|created)/i,
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-014: TESTING boilerplate recommendations (SAL-TESTING-REC)
+  /full troubleshooting arsenal.*\d+ tactics/i,
+  /expected debugging time savings/i,
+  /consult troubleshooting tactics arsenal/i,
+  /fix all critical issues before proceeding/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Add 4 regex patterns to NON_ACTIONABLE_SAL_PATTERNS for TESTING sub-agent boilerplate recommendations (SAL-TESTING-REC)
- Filters: troubleshooting arsenal promotions, debugging time savings, generic fix-all directives
- Pattern count grows from 49 to 53
- 2 of 3 source items already resolved by prior SDs (011, 013)

## Test plan
- [x] 13/13 inline pattern tests pass (4 new TESTING + 9 regression)
- [x] 255/255 smoke tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)