### PR TITLE
fix: filter RISK sub-agent boilerplate from /learn pipeline

### DIFF
--- a/scripts/modules/learning/context-builder.js
+++ b/scripts/modules/learning/context-builder.js
@@ -138,6 +138,11 @@ const NON_ACTIONABLE_SAL_PATTERNS = [
   /expected debugging time savings/i,
   /consult troubleshooting tactics arsenal/i,
   /fix all critical issues before proceeding/i,
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-016: RISK boilerplate for database SDs (SAL-RISK-ISS)
+  /database changes:.*schema migration required/i,
+  /critical risk mitigation required/i,
+  /data migration risk management/i,
+  /develop mitigation plan before proceeding to exec/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Add 4 regex patterns to NON_ACTIONABLE_SAL_PATTERNS for RISK sub-agent boilerplate (SAL-RISK-ISS)
- Filters: database migration required, critical risk mitigation, data migration risk management
- Pattern count grows from 53 to 57
- 2 of 3 source items already resolved by SD-012

## Test plan
- [x] 11/11 inline pattern tests pass (4 new RISK + 7 regression)
- [x] 255/255 smoke tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)