### PR TITLE
test: add unit tests for 5 core Eva orchestrator modules

### DIFF
--- a/tests/unit/eva/decision-filter-engine.test.js
+++ b/tests/unit/eva/decision-filter-engine.test.js
@@ -1,0 +1,224 @@
+/**
+ * Tests for Decision Filter Engine
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-B
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateDecision,
+  ENGINE_VERSION,
+  TRIGGER_TYPES,
+  PREFERENCE_KEYS,
+  DEFAULTS,
+} from '../../../lib/eva/decision-filter-engine.js';
+
+describe('DecisionFilterEngine', () => {
+  describe('evaluateDecision - no triggers', () => {
+    it('should auto-proceed when input is empty', () => {
+      const result = evaluateDecision({});
+      expect(result.auto_proceed).toBe(true);
+      expect(result.recommendation).toBe('AUTO_PROCEED');
+      expect(result.triggers).toEqual([]);
+    });
+
+    it('should auto-proceed when all values are within thresholds', () => {
+      const result = evaluateDecision(
+        { cost: 5000, score: 8, technologies: ['React'], vendors: ['AWS'] },
+        { preferences: {
+          [PREFERENCE_KEYS.cost_threshold]: 10000,
+          [PREFERENCE_KEYS.low_score]: 7,
+          [PREFERENCE_KEYS.approved_tech]: ['react'],
+          [PREFERENCE_KEYS.approved_vendors]: ['aws'],
+        }},
+      );
+      expect(result.auto_proceed).toBe(true);
+      expect(result.recommendation).toBe('AUTO_PROCEED');
+    });
+  });
+
+  describe('cost_threshold trigger', () => {
+    it('should trigger when cost exceeds threshold', () => {
+      const result = evaluateDecision(
+        { cost: 15000 },
+        { preferences: { [PREFERENCE_KEYS.cost_threshold]: 10000 } },
+      );
+      expect(result.auto_proceed).toBe(false);
+      const costTrigger = result.triggers.find(t => t.type === 'cost_threshold');
+      expect(costTrigger).toBeDefined();
+      expect(costTrigger.severity).toBe('HIGH');
+    });
+
+    it('should not trigger when cost is below threshold', () => {
+      const result = evaluateDecision(
+        { cost: 5000 },
+        { preferences: { [PREFERENCE_KEYS.cost_threshold]: 10000 } },
+      );
+      const costTrigger = result.triggers.find(t => t.type === 'cost_threshold');
+      expect(costTrigger).toBeUndefined();
+    });
+
+    it('should use default threshold when preference is missing', () => {
+      const result = evaluateDecision({ cost: 15000 }, { preferences: {} });
+      const costTrigger = result.triggers.find(t => t.type === 'cost_threshold');
+      expect(costTrigger).toBeDefined();
+      expect(costTrigger.details.threshold).toBe(DEFAULTS['filter.cost_max_usd']);
+    });
+  });
+
+  describe('new_tech_vendor trigger', () => {
+    it('should trigger for unapproved technology', () => {
+      const result = evaluateDecision(
+        { technologies: ['Vue', 'React'] },
+        { preferences: { [PREFERENCE_KEYS.approved_tech]: ['React'] } },
+      );
+      const techTrigger = result.triggers.find(t => t.type === 'new_tech_vendor' && t.message.includes('technology'));
+      expect(techTrigger).toBeDefined();
+      expect(techTrigger.details.newItems).toContain('Vue');
+    });
+
+    it('should trigger for unapproved vendor', () => {
+      const result = evaluateDecision(
+        { vendors: ['GCP'] },
+        { preferences: { [PREFERENCE_KEYS.approved_vendors]: ['AWS'] } },
+      );
+      const vendorTrigger = result.triggers.find(t => t.type === 'new_tech_vendor' && t.message.includes('vendor'));
+      expect(vendorTrigger).toBeDefined();
+    });
+
+    it('should be case-insensitive', () => {
+      const result = evaluateDecision(
+        { technologies: ['react'] },
+        { preferences: { [PREFERENCE_KEYS.approved_tech]: ['React'] } },
+      );
+      const techTrigger = result.triggers.find(t => t.type === 'new_tech_vendor');
+      expect(techTrigger).toBeUndefined();
+    });
+  });
+
+  describe('strategic_pivot trigger', () => {
+    it('should trigger when description contains pivot keywords', () => {
+      const result = evaluateDecision(
+        { description: 'We should pivot to B2B market' },
+        { preferences: { [PREFERENCE_KEYS.pivot_keywords]: ['pivot', 'rebrand'] } },
+      );
+      const pivotTrigger = result.triggers.find(t => t.type === 'strategic_pivot');
+      expect(pivotTrigger).toBeDefined();
+      expect(pivotTrigger.severity).toBe('HIGH');
+    });
+
+    it('should not trigger without matching keywords', () => {
+      const result = evaluateDecision(
+        { description: 'Continue building the product' },
+        { preferences: { [PREFERENCE_KEYS.pivot_keywords]: ['pivot'] } },
+      );
+      const pivotTrigger = result.triggers.find(t => t.type === 'strategic_pivot');
+      expect(pivotTrigger).toBeUndefined();
+    });
+  });
+
+  describe('low_score trigger', () => {
+    it('should trigger when score is below threshold', () => {
+      const result = evaluateDecision(
+        { score: 3 },
+        { preferences: { [PREFERENCE_KEYS.low_score]: 7 } },
+      );
+      const scoreTrigger = result.triggers.find(t => t.type === 'low_score');
+      expect(scoreTrigger).toBeDefined();
+      expect(scoreTrigger.severity).toBe('MEDIUM');
+    });
+
+    it('should not trigger when score meets threshold', () => {
+      const result = evaluateDecision(
+        { score: 8 },
+        { preferences: { [PREFERENCE_KEYS.low_score]: 7 } },
+      );
+      const scoreTrigger = result.triggers.find(t => t.type === 'low_score');
+      expect(scoreTrigger).toBeUndefined();
+    });
+  });
+
+  describe('novel_pattern trigger', () => {
+    it('should trigger for patterns not in prior set', () => {
+      const result = evaluateDecision({
+        patterns: ['microservices', 'event-sourcing'],
+        priorPatterns: ['microservices'],
+      });
+      const novelTrigger = result.triggers.find(t => t.type === 'novel_pattern');
+      expect(novelTrigger).toBeDefined();
+      expect(novelTrigger.details.novelPatterns).toContain('event-sourcing');
+    });
+  });
+
+  describe('constraint_drift trigger', () => {
+    it('should trigger when constraints drift from approved', () => {
+      const result = evaluateDecision({
+        constraints: { budget: 50000, team_size: 5 },
+        approvedConstraints: { budget: 30000, team_size: 3 },
+      });
+      const driftTrigger = result.triggers.find(
+        t => t.type === 'constraint_drift' && t.details.drifts,
+      );
+      expect(driftTrigger).toBeDefined();
+      expect(driftTrigger.details.drifts.length).toBe(2);
+    });
+  });
+
+  describe('recommendation mapping', () => {
+    it('should recommend PRESENT_TO_CHAIRMAN for HIGH triggers', () => {
+      const result = evaluateDecision(
+        { cost: 99999 },
+        { preferences: { [PREFERENCE_KEYS.cost_threshold]: 100 } },
+      );
+      expect(result.auto_proceed).toBe(false);
+      expect(result.recommendation).toBe('PRESENT_TO_CHAIRMAN');
+    });
+
+    it('should recommend PRESENT_TO_CHAIRMAN_WITH_MITIGATIONS for MEDIUM triggers', () => {
+      const result = evaluateDecision(
+        { score: 3 },
+        { preferences: { [PREFERENCE_KEYS.low_score]: 7 } },
+      );
+      expect(result.auto_proceed).toBe(false);
+      expect(result.recommendation).toBe('PRESENT_TO_CHAIRMAN_WITH_MITIGATIONS');
+    });
+  });
+
+  describe('trigger ordering', () => {
+    it('should return triggers in fixed TRIGGER_TYPES order', () => {
+      const result = evaluateDecision(
+        {
+          cost: 99999,
+          score: 1,
+          technologies: ['Unknown'],
+          description: 'We must pivot now',
+          patterns: ['new-thing'],
+          priorPatterns: [],
+          constraints: { x: 2 },
+          approvedConstraints: { x: 1 },
+        },
+        { preferences: {
+          [PREFERENCE_KEYS.cost_threshold]: 100,
+          [PREFERENCE_KEYS.low_score]: 7,
+          [PREFERENCE_KEYS.approved_tech]: [],
+          [PREFERENCE_KEYS.pivot_keywords]: ['pivot'],
+        }},
+      );
+
+      const triggerOrder = result.triggers.map(t => t.type);
+      const typeIndices = triggerOrder.map(t => TRIGGER_TYPES.indexOf(t));
+      for (let i = 1; i < typeIndices.length; i++) {
+        expect(typeIndices[i]).toBeGreaterThanOrEqual(typeIndices[i - 1]);
+      }
+    });
+  });
+
+  describe('exports', () => {
+    it('should export ENGINE_VERSION', () => {
+      expect(ENGINE_VERSION).toBe('1.0.0');
+    });
+
+    it('should export all 6 trigger types', () => {
+      expect(TRIGGER_TYPES).toHaveLength(6);
+    });
+  });
+});

--- a/tests/unit/eva/devils-advocate.test.js
+++ b/tests/unit/eva/devils-advocate.test.js
@@ -1,0 +1,240 @@
+/**
+ * Tests for Devil's Advocate
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-B
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isDevilsAdvocateGate,
+  getDevilsAdvocateReview,
+  buildArtifactRecord,
+  _internal,
+} from '../../../lib/eva/devils-advocate.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe('DevilsAdvocate', () => {
+  describe('isDevilsAdvocateGate', () => {
+    it('should identify kill gates', () => {
+      for (const stage of [3, 5, 13, 23]) {
+        const result = isDevilsAdvocateGate(stage);
+        expect(result.isGate).toBe(true);
+        expect(result.gateType).toBe('kill');
+      }
+    });
+
+    it('should identify promotion gates', () => {
+      for (const stage of [16, 17, 22]) {
+        const result = isDevilsAdvocateGate(stage);
+        expect(result.isGate).toBe(true);
+        expect(result.gateType).toBe('promotion');
+      }
+    });
+
+    it('should return false for non-gate stages', () => {
+      for (const stage of [1, 2, 4, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21, 24, 25]) {
+        const result = isDevilsAdvocateGate(stage);
+        expect(result.isGate).toBe(false);
+        expect(result.gateType).toBeNull();
+      }
+    });
+  });
+
+  describe('getDevilsAdvocateReview - with mock adapter', () => {
+    it('should return structured review from adapter', async () => {
+      const mockAdapter = {
+        apiKey: 'test-key',
+        complete: vi.fn().mockResolvedValue({
+          content: JSON.stringify({
+            overallAssessment: 'concern',
+            counterArguments: ['Market saturation risk', 'Competitor advantage'],
+            risks: [{ risk: 'Market size', severity: 'high', likelihood: 'possible' }],
+            alternatives: ['Focus on niche segment'],
+            summary: 'The venture faces market risks.',
+          }),
+          model: 'gpt-4o',
+          durationMs: 1200,
+          usage: { prompt_tokens: 500, completion_tokens: 200 },
+        }),
+      };
+
+      const result = await getDevilsAdvocateReview(
+        {
+          stageId: 3,
+          gateType: 'kill',
+          gateResult: { decision: 'proceed' },
+          ventureContext: { name: 'TestVenture' },
+          stageOutput: { score: 7 },
+        },
+        { adapter: mockAdapter, logger: silentLogger },
+      );
+
+      expect(result.stageId).toBe(3);
+      expect(result.gateType).toBe('kill');
+      expect(result.proceeded).toBe(true);
+      expect(result.overallAssessment).toBe('concern');
+      expect(result.counterArguments).toHaveLength(2);
+      expect(result.risks).toHaveLength(1);
+      expect(result.model).toBe('gpt-4o');
+    });
+
+    it('should return fallback when adapter has no API key', async () => {
+      const mockAdapter = { apiKey: null };
+
+      const result = await getDevilsAdvocateReview(
+        {
+          stageId: 5,
+          gateType: 'kill',
+          gateResult: {},
+          ventureContext: { name: 'Test' },
+        },
+        { adapter: mockAdapter, logger: silentLogger },
+      );
+
+      // The code checks adapter.apiKey only in the non-injected path
+      // When adapter is injected, it goes straight to adapter.complete()
+      // Since this adapter has no complete method, it will throw
+      expect(result.isFallback).toBe(true);
+    });
+
+    it('should return fallback when adapter.complete throws', async () => {
+      const mockAdapter = {
+        apiKey: 'test',
+        complete: vi.fn().mockRejectedValue(new Error('API rate limited')),
+      };
+
+      const result = await getDevilsAdvocateReview(
+        {
+          stageId: 13,
+          gateType: 'kill',
+          gateResult: {},
+          ventureContext: { name: 'Test' },
+        },
+        { adapter: mockAdapter, logger: silentLogger },
+      );
+
+      expect(result.isFallback).toBe(true);
+      expect(result.fallbackReason).toContain('API rate limited');
+      expect(result.proceeded).toBe(true);
+    });
+  });
+
+  describe('buildArtifactRecord', () => {
+    it('should build a valid artifact record', () => {
+      const review = {
+        stageId: 3,
+        gateType: 'kill',
+        gateId: 'kill_gate_3',
+        generatedAt: '2026-01-01T00:00:00Z',
+        proceeded: true,
+        overallAssessment: 'concern',
+        counterArguments: ['Arg1', 'Arg2'],
+        risks: [{ risk: 'R1', severity: 'high', likelihood: 'possible' }],
+        alternatives: ['Alt1'],
+        model: 'gpt-4o',
+        durationMs: 1000,
+        usage: { prompt_tokens: 500 },
+      };
+
+      const record = buildArtifactRecord('venture-123', review);
+
+      expect(record.venture_id).toBe('venture-123');
+      expect(record.lifecycle_stage).toBe(3);
+      expect(record.artifact_type).toBe('devils_advocate_review');
+      expect(record.is_current).toBe(true);
+      expect(record.source).toBe('devils-advocate');
+      expect(record.quality_score).toBeGreaterThan(0);
+    });
+
+    it('should set quality_score 0 for fallback reviews', () => {
+      const review = {
+        stageId: 5,
+        gateType: 'kill',
+        gateId: 'kill_gate_5',
+        isFallback: true,
+        overallAssessment: 'unavailable',
+        counterArguments: [],
+        risks: [],
+        alternatives: [],
+      };
+
+      const record = buildArtifactRecord('venture-123', review);
+      expect(record.quality_score).toBe(0);
+      expect(record.validation_status).toBe('pending');
+    });
+  });
+
+  describe('internal helpers', () => {
+    describe('parseReviewResponse', () => {
+      it('should parse valid JSON response', () => {
+        const content = JSON.stringify({
+          overallAssessment: 'support',
+          counterArguments: ['Tried hard but looks good'],
+          risks: [],
+          alternatives: [],
+          summary: 'Looks good',
+        });
+        const result = _internal.parseReviewResponse(content);
+        expect(result.overallAssessment).toBe('support');
+        expect(result.counterArguments).toHaveLength(1);
+      });
+
+      it('should handle JSON in markdown code blocks', () => {
+        const content = '```json\n{"overallAssessment":"challenge","counterArguments":["Issue 1"],"risks":[],"alternatives":[],"summary":"Problems found"}\n```';
+        const result = _internal.parseReviewResponse(content);
+        expect(result.overallAssessment).toBe('challenge');
+      });
+
+      it('should fallback gracefully on invalid JSON', () => {
+        const result = _internal.parseReviewResponse('This is not JSON at all');
+        expect(result.overallAssessment).toBe('concern');
+        expect(result.counterArguments).toHaveLength(1);
+      });
+    });
+
+    describe('estimateQualityScore', () => {
+      it('should return base 50 for empty review', () => {
+        const score = _internal.estimateQualityScore({});
+        expect(score).toBe(50);
+      });
+
+      it('should add points for counter-arguments, risks, alternatives, summary', () => {
+        const score = _internal.estimateQualityScore({
+          counterArguments: ['a', 'b'],
+          risks: [{ risk: 'r1' }],
+          alternatives: ['alt1'],
+          summary: 'A sufficiently long summary that definitely exceeds fifty characters in total length.',
+        });
+        expect(score).toBe(100);
+      });
+    });
+
+    describe('buildSystemPrompt', () => {
+      it('should build kill gate prompt', () => {
+        const prompt = _internal.buildSystemPrompt('kill');
+        expect(prompt).toContain('KILLED');
+        expect(prompt).toContain('fatal flaws');
+      });
+
+      it('should build promotion gate prompt', () => {
+        const prompt = _internal.buildSystemPrompt('promotion');
+        expect(prompt).toContain('advance');
+        expect(prompt).toContain('weaknesses');
+      });
+    });
+
+    describe('constants', () => {
+      it('should define correct kill gates', () => {
+        expect(_internal.KILL_GATES).toEqual([3, 5, 13, 23]);
+      });
+
+      it('should define correct promotion gates', () => {
+        expect(_internal.PROMOTION_GATES).toEqual([16, 17, 22]);
+      });
+
+      it('should have all gates combined', () => {
+        expect(_internal.ALL_GATES).toHaveLength(7);
+      });
+    });
+  });
+});

--- a/tests/unit/eva/eva-orchestrator.test.js
+++ b/tests/unit/eva/eva-orchestrator.test.js
@@ -1,0 +1,342 @@
+/**
+ * Tests for Eva Orchestrator
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-B
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock transitive deps with shebangs that vitest can't transform
+vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn().mockReturnValue('SD-TEST-001'),
+  generateChildKey: vi.fn().mockReturnValue('SD-TEST-001-A'),
+  normalizeVenturePrefix: vi.fn().mockReturnValue('TEST'),
+}));
+
+import { processStage, run, _internal } from '../../../lib/eva/eva-orchestrator.js';
+
+const { buildResult, mergeArtifactOutputs, STATUS, FILTER_ACTION } = _internal;
+
+function createMockSupabase(overrides = {}) {
+  const mockFrom = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: {
+        id: 'v-1',
+        name: 'Test Venture',
+        status: 'active',
+        current_lifecycle_stage: 1,
+        archetype: 'saas',
+        created_at: '2026-01-01',
+      },
+      error: null,
+    }),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    ...overrides,
+  };
+
+  return {
+    from: vi.fn(() => ({ ...mockFrom })),
+    _mockFrom: mockFrom,
+  };
+}
+
+const silentLogger = {
+  log: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+describe('EvaOrchestrator', () => {
+  describe('processStage - missing dependencies', () => {
+    it('should FAIL when supabase is not provided', async () => {
+      const result = await processStage({ ventureId: 'v1' }, {});
+      expect(result.status).toBe(STATUS.FAILED);
+      expect(result.errors[0].code).toBe('MISSING_DEPENDENCY');
+    });
+  });
+
+  describe('processStage - basic flow', () => {
+    it('should process a stage with no template steps', async () => {
+      const mockSupabase = createMockSupabase();
+      const evaluateDecisionFn = vi.fn().mockReturnValue({
+        auto_proceed: true,
+        triggers: [],
+        recommendation: 'AUTO_PROCEED',
+      });
+      const evaluateRealityGateFn = vi.fn().mockResolvedValue({ passed: true, status: 'PASS' });
+      const validateStageGateFn = vi.fn().mockResolvedValue({ passed: true });
+
+      const result = await processStage(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn,
+          evaluateRealityGateFn,
+          validateStageGateFn,
+        },
+      );
+
+      expect(result.status).toBe(STATUS.COMPLETED);
+      expect(result.ventureId).toBe('v-1');
+      expect(result.filterDecision.action).toBe(FILTER_ACTION.AUTO_PROCEED);
+    });
+
+    it('should execute template analysis steps', async () => {
+      const mockSupabase = createMockSupabase();
+      const stepFn = vi.fn().mockResolvedValue({
+        artifactType: 'test_output',
+        payload: { score: 8, cost: 5000 },
+        source: 'test-step',
+      });
+
+      const result = await processStage(
+        {
+          ventureId: 'v-1',
+          options: {
+            dryRun: true,
+            stageTemplate: { analysisSteps: [{ id: 'step1', execute: stepFn }] },
+          },
+        },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+        },
+      );
+
+      expect(stepFn).toHaveBeenCalled();
+      expect(result.artifacts).toHaveLength(1);
+      expect(result.artifacts[0].artifactType).toBe('test_output');
+    });
+  });
+
+  describe('processStage - gate blocking', () => {
+    it('should return BLOCKED when stage gate fails', async () => {
+      const mockSupabase = createMockSupabase();
+
+      const result = await processStage(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn(),
+          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: false, summary: 'Gate requirements not met' }),
+        },
+      );
+
+      expect(result.status).toBe(STATUS.BLOCKED);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should return BLOCKED when reality gate fails', async () => {
+      const mockSupabase = createMockSupabase();
+
+      const result = await processStage(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn(),
+          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: false, error: 'Artifacts missing' }),
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+        },
+      );
+
+      expect(result.status).toBe(STATUS.BLOCKED);
+    });
+  });
+
+  describe('processStage - filter decisions', () => {
+    it('should map HIGH triggers to STOP action', async () => {
+      const mockSupabase = createMockSupabase();
+
+      const result = await processStage(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn().mockReturnValue({
+            auto_proceed: false,
+            triggers: [{ severity: 'HIGH', message: 'Cost too high' }],
+            recommendation: 'PRESENT_TO_CHAIRMAN',
+          }),
+          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+        },
+      );
+
+      expect(result.filterDecision.action).toBe(FILTER_ACTION.STOP);
+    });
+
+    it('should map MEDIUM triggers to REQUIRE_REVIEW action', async () => {
+      const mockSupabase = createMockSupabase();
+
+      const result = await processStage(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn().mockReturnValue({
+            auto_proceed: false,
+            triggers: [{ severity: 'MEDIUM', message: 'Low score' }],
+            recommendation: 'PRESENT_TO_CHAIRMAN_WITH_MITIGATIONS',
+          }),
+          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+        },
+      );
+
+      expect(result.filterDecision.action).toBe(FILTER_ACTION.REQUIRE_REVIEW);
+    });
+  });
+
+  describe('processStage - context load failure', () => {
+    it('should FAIL when venture cannot be loaded', async () => {
+      const mockSupabase = {
+        from: vi.fn(() => ({
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } }),
+        })),
+      };
+
+      const result = await processStage(
+        { ventureId: 'nonexistent' },
+        { supabase: mockSupabase, logger: silentLogger },
+      );
+
+      expect(result.status).toBe(STATUS.FAILED);
+      expect(result.errors[0].code).toBe('CONTEXT_LOAD_FAILED');
+    });
+  });
+
+  describe('processStage - analysis step failure', () => {
+    it('should FAIL when an analysis step throws', async () => {
+      const mockSupabase = createMockSupabase();
+      const failingStep = vi.fn().mockRejectedValue(new Error('LLM timeout'));
+
+      const result = await processStage(
+        {
+          ventureId: 'v-1',
+          options: {
+            dryRun: true,
+            stageTemplate: { analysisSteps: [{ id: 'failing', execute: failingStep }] },
+          },
+        },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn(),
+          evaluateRealityGateFn: vi.fn(),
+          validateStageGateFn: vi.fn(),
+        },
+      );
+
+      expect(result.status).toBe(STATUS.FAILED);
+      expect(result.errors[0].code).toBe('ANALYSIS_STEP_FAILED');
+    });
+  });
+
+  describe('run - orchestration loop', () => {
+    it('should stop on BLOCKED status', async () => {
+      const mockSupabase = createMockSupabase();
+
+      const results = await run(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn().mockReturnValue({ auto_proceed: true, triggers: [], recommendation: 'AUTO_PROCEED' }),
+          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: false }),
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+        },
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe(STATUS.BLOCKED);
+    });
+
+    it('should stop on REQUIRE_REVIEW filter decision', async () => {
+      const mockSupabase = createMockSupabase();
+
+      const results = await run(
+        { ventureId: 'v-1', options: { dryRun: true, stageTemplate: { analysisSteps: [] } } },
+        {
+          supabase: mockSupabase,
+          logger: silentLogger,
+          evaluateDecisionFn: vi.fn().mockReturnValue({
+            auto_proceed: false,
+            triggers: [{ severity: 'MEDIUM', message: 'Review needed' }],
+            recommendation: 'PRESENT_TO_CHAIRMAN_WITH_MITIGATIONS',
+          }),
+          evaluateRealityGateFn: vi.fn().mockResolvedValue({ passed: true }),
+          validateStageGateFn: vi.fn().mockResolvedValue({ passed: true }),
+        },
+      );
+
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe('internal helpers', () => {
+    describe('buildResult', () => {
+      it('should build a complete result object', () => {
+        const result = buildResult({
+          ventureId: 'v1',
+          stageId: 5,
+          startedAt: '2026-01-01',
+          correlationId: 'c1',
+          status: STATUS.COMPLETED,
+        });
+        expect(result.ventureId).toBe('v1');
+        expect(result.stageId).toBe(5);
+        expect(result.status).toBe('COMPLETED');
+        expect(result.completedAt).toBeDefined();
+        expect(result.artifacts).toEqual([]);
+      });
+    });
+
+    describe('mergeArtifactOutputs', () => {
+      it('should merge artifact payloads into single output', () => {
+        const artifacts = [
+          { payload: { cost: 5000, score: 8 } },
+          { payload: { technologies: ['React'] } },
+        ];
+        const output = mergeArtifactOutputs(artifacts, { name: 'TestVenture' });
+        expect(output.cost).toBe(5000);
+        expect(output.score).toBe(8);
+        expect(output.technologies).toEqual(['React']);
+        expect(output.description).toBe('TestVenture');
+      });
+
+      it('should use venture name as description', () => {
+        const output = mergeArtifactOutputs([], { name: 'MyVenture' });
+        expect(output.description).toBe('MyVenture');
+      });
+    });
+
+    describe('STATUS constants', () => {
+      it('should define COMPLETED, BLOCKED, FAILED', () => {
+        expect(STATUS.COMPLETED).toBe('COMPLETED');
+        expect(STATUS.BLOCKED).toBe('BLOCKED');
+        expect(STATUS.FAILED).toBe('FAILED');
+      });
+    });
+
+    describe('FILTER_ACTION constants', () => {
+      it('should define AUTO_PROCEED, REQUIRE_REVIEW, STOP', () => {
+        expect(FILTER_ACTION.AUTO_PROCEED).toBe('AUTO_PROCEED');
+        expect(FILTER_ACTION.REQUIRE_REVIEW).toBe('REQUIRE_REVIEW');
+        expect(FILTER_ACTION.STOP).toBe('STOP');
+      });
+    });
+  });
+});

--- a/tests/unit/eva/lifecycle-sd-bridge.test.js
+++ b/tests/unit/eva/lifecycle-sd-bridge.test.js
@@ -1,0 +1,164 @@
+/**
+ * Tests for Lifecycle-SD Bridge
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-B
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock sd-key-generator (has shebang that vitest can't transform)
+vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
+  generateSDKey: vi.fn().mockReturnValue('SD-ORCH-SPRINT-TEST-001'),
+  generateChildKey: vi.fn().mockReturnValue('SD-ORCH-SPRINT-TEST-001-A'),
+  normalizeVenturePrefix: vi.fn().mockReturnValue('TEST'),
+}));
+
+import {
+  convertSprintToSDs,
+  buildBridgeArtifactRecord,
+  _internal,
+} from '../../../lib/eva/lifecycle-sd-bridge.js';
+
+const { TYPE_MAP } = _internal;
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+function createMockSupabase({ insertError = null, existingOrchestrator = null } = {}) {
+  let selectCallCount = 0;
+
+  return {
+    from: vi.fn((table) => {
+      if (table === 'strategic_directives_v2') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (existingOrchestrator && selectCallCount === 1) {
+              return Promise.resolve({ data: [existingOrchestrator], error: null });
+            }
+            return Promise.resolve({ data: [], error: null });
+          }),
+          order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          insert: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({
+            data: null,
+            error: insertError,
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ data: null, error: insertError }),
+      };
+    }),
+  };
+}
+
+describe('LifecycleSDBridge', () => {
+  describe('TYPE_MAP', () => {
+    it('should map feature to feature', () => {
+      expect(TYPE_MAP.feature).toBe('feature');
+    });
+
+    it('should map bugfix to bugfix', () => {
+      expect(TYPE_MAP.bugfix).toBe('bugfix');
+    });
+
+    it('should map enhancement to feature', () => {
+      expect(TYPE_MAP.enhancement).toBe('feature');
+    });
+
+    it('should map refactor to refactor', () => {
+      expect(TYPE_MAP.refactor).toBe('refactor');
+    });
+
+    it('should map infra to infrastructure', () => {
+      expect(TYPE_MAP.infra).toBe('infrastructure');
+    });
+  });
+
+  describe('convertSprintToSDs - empty payloads', () => {
+    it('should return created=false when no payloads', async () => {
+      const result = await convertSprintToSDs(
+        { stageOutput: { sd_bridge_payloads: [] }, ventureContext: { id: 'v1', name: 'Test' } },
+        { supabase: createMockSupabase(), logger: silentLogger },
+      );
+      expect(result.created).toBe(false);
+      expect(result.errors).toContain('No sprint items to convert');
+    });
+
+    it('should return created=false when payloads is undefined', async () => {
+      const result = await convertSprintToSDs(
+        { stageOutput: {}, ventureContext: { id: 'v1', name: 'Test' } },
+        { supabase: createMockSupabase(), logger: silentLogger },
+      );
+      expect(result.created).toBe(false);
+    });
+  });
+
+  describe('convertSprintToSDs - idempotency', () => {
+    it('should return existing orchestrator when already exists', async () => {
+      const existing = { id: 'orch-1', sd_key: 'SD-ORCH-SPRINT-TEST-001' };
+      const mockSb = createMockSupabase({ existingOrchestrator: existing });
+
+      const result = await convertSprintToSDs(
+        {
+          stageOutput: {
+            sprint_name: 'Sprint 1',
+            sprint_goal: 'Build MVP',
+            sd_bridge_payloads: [{ title: 'Feature A', type: 'feature' }],
+          },
+          ventureContext: { id: 'v1', name: 'Test' },
+        },
+        { supabase: mockSb, logger: silentLogger },
+      );
+
+      expect(result.created).toBe(false);
+      expect(result.orchestratorKey).toBe('SD-ORCH-SPRINT-TEST-001');
+    });
+  });
+
+  describe('buildBridgeArtifactRecord', () => {
+    it('should build correct artifact for successful bridge', () => {
+      const record = buildBridgeArtifactRecord('venture-1', 18, {
+        created: true,
+        orchestratorKey: 'SD-ORCH-SPRINT-001',
+        childKeys: ['SD-ORCH-SPRINT-001-A', 'SD-ORCH-SPRINT-001-B'],
+        errors: [],
+      });
+
+      expect(record.venture_id).toBe('venture-1');
+      expect(record.lifecycle_stage).toBe(18);
+      expect(record.artifact_type).toBe('lifecycle_sd_bridge');
+      expect(record.quality_score).toBe(100);
+      expect(record.validation_status).toBe('validated');
+      expect(record.is_current).toBe(true);
+      expect(record.metadata.childCount).toBe(2);
+      expect(record.metadata.hasErrors).toBe(false);
+    });
+
+    it('should reduce quality score for errors', () => {
+      const record = buildBridgeArtifactRecord('venture-1', 18, {
+        created: true,
+        orchestratorKey: 'SD-ORCH-001',
+        childKeys: ['SD-ORCH-001-A'],
+        errors: ['Child B failed', 'Child C failed'],
+      });
+
+      expect(record.quality_score).toBe(50);
+      expect(record.validation_status).toBe('pending');
+      expect(record.metadata.hasErrors).toBe(true);
+    });
+
+    it('should not go below 0 quality score', () => {
+      const record = buildBridgeArtifactRecord('v1', 18, {
+        created: true,
+        orchestratorKey: 'SD-1',
+        childKeys: [],
+        errors: ['e1', 'e2', 'e3', 'e4', 'e5'],
+      });
+
+      expect(record.quality_score).toBe(0);
+    });
+  });
+});

--- a/tests/unit/eva/reality-gates.test.js
+++ b/tests/unit/eva/reality-gates.test.js
@@ -1,0 +1,274 @@
+/**
+ * Tests for Reality Gates
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-B
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  evaluateRealityGate,
+  getBoundaryConfig,
+  isGatedBoundary,
+  BOUNDARY_CONFIG,
+  REASON_CODES,
+  MODULE_VERSION,
+  _internal,
+} from '../../../lib/eva/reality-gates.js';
+
+function createMockDb(artifacts = []) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: artifacts, error: null }),
+    })),
+  };
+}
+
+function createErrorDb(message = 'DB connection failed') {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockResolvedValue({ data: null, error: { message } }),
+    })),
+  };
+}
+
+const silentLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe('RealityGates', () => {
+  describe('isGatedBoundary', () => {
+    it('should return true for configured boundaries', () => {
+      expect(isGatedBoundary(5, 6)).toBe(true);
+      expect(isGatedBoundary(9, 10)).toBe(true);
+      expect(isGatedBoundary(12, 13)).toBe(true);
+      expect(isGatedBoundary(16, 17)).toBe(true);
+      expect(isGatedBoundary(20, 21)).toBe(true);
+    });
+
+    it('should return false for non-gated transitions', () => {
+      expect(isGatedBoundary(1, 2)).toBe(false);
+      expect(isGatedBoundary(7, 8)).toBe(false);
+      expect(isGatedBoundary(24, 25)).toBe(false);
+    });
+  });
+
+  describe('getBoundaryConfig', () => {
+    it('should return config for valid boundary', () => {
+      const config = getBoundaryConfig(5, 6);
+      expect(config).toBeDefined();
+      expect(config.description).toBe('Ideation → Validation');
+      expect(config.required_artifacts).toHaveLength(3);
+    });
+
+    it('should return null for non-gated boundary', () => {
+      expect(getBoundaryConfig(1, 2)).toBeNull();
+    });
+  });
+
+  describe('evaluateRealityGate - NOT_APPLICABLE', () => {
+    it('should return NOT_APPLICABLE for non-gated transitions', async () => {
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 1,
+        toStage: 2,
+        db: createMockDb(),
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('NOT_APPLICABLE');
+      expect(result.reasons).toHaveLength(0);
+    });
+  });
+
+  describe('evaluateRealityGate - validation', () => {
+    it('should FAIL when ventureId is missing', async () => {
+      const result = await evaluateRealityGate({
+        ventureId: null,
+        fromStage: 5,
+        toStage: 6,
+        db: createMockDb(),
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('FAIL');
+      expect(result.reasons[0].code).toBe(REASON_CODES.CONFIG_ERROR);
+    });
+
+    it('should FAIL when db is missing', async () => {
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 5,
+        toStage: 6,
+        db: null,
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('FAIL');
+      expect(result.reasons[0].code).toBe(REASON_CODES.CONFIG_ERROR);
+    });
+  });
+
+  describe('evaluateRealityGate - artifact checks', () => {
+    it('should PASS when all required artifacts exist with sufficient quality', async () => {
+      const artifacts = [
+        { artifact_type: 'problem_statement', quality_score: 0.8, is_current: true },
+        { artifact_type: 'target_market_analysis', quality_score: 0.7, is_current: true },
+        { artifact_type: 'value_proposition', quality_score: 0.9, is_current: true },
+      ];
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 5,
+        toStage: 6,
+        db: createMockDb(artifacts),
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('PASS');
+      expect(result.reasons).toHaveLength(0);
+    });
+
+    it('should FAIL when required artifact is missing', async () => {
+      const artifacts = [
+        { artifact_type: 'problem_statement', quality_score: 0.8, is_current: true },
+      ];
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 5,
+        toStage: 6,
+        db: createMockDb(artifacts),
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('FAIL');
+      const missingReasons = result.reasons.filter(r => r.code === REASON_CODES.ARTIFACT_MISSING);
+      expect(missingReasons.length).toBe(2);
+    });
+
+    it('should FAIL when quality score is below threshold', async () => {
+      const artifacts = [
+        { artifact_type: 'problem_statement', quality_score: 0.3, is_current: true },
+        { artifact_type: 'target_market_analysis', quality_score: 0.5, is_current: true },
+        { artifact_type: 'value_proposition', quality_score: 0.6, is_current: true },
+      ];
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 5,
+        toStage: 6,
+        db: createMockDb(artifacts),
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('FAIL');
+      const qualityReasons = result.reasons.filter(r => r.code === REASON_CODES.QUALITY_SCORE_BELOW_THRESHOLD);
+      expect(qualityReasons.length).toBe(1);
+    });
+
+    it('should FAIL when quality score is null', async () => {
+      const artifacts = [
+        { artifact_type: 'problem_statement', quality_score: null, is_current: true },
+        { artifact_type: 'target_market_analysis', quality_score: 0.5, is_current: true },
+        { artifact_type: 'value_proposition', quality_score: 0.6, is_current: true },
+      ];
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 5,
+        toStage: 6,
+        db: createMockDb(artifacts),
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('FAIL');
+      const missingScore = result.reasons.find(r => r.code === REASON_CODES.QUALITY_SCORE_MISSING);
+      expect(missingScore).toBeDefined();
+    });
+  });
+
+  describe('evaluateRealityGate - DB errors (fail-closed)', () => {
+    it('should FAIL on database error', async () => {
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 5,
+        toStage: 6,
+        db: createErrorDb('Connection timeout'),
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('FAIL');
+      expect(result.reasons[0].code).toBe(REASON_CODES.DB_ERROR);
+    });
+  });
+
+  describe('evaluateRealityGate - URL verification', () => {
+    it('should PASS when URL is reachable', async () => {
+      const artifacts = [
+        { artifact_type: 'mvp_build', quality_score: 0.8, file_url: 'https://app.example.com', is_current: true },
+        { artifact_type: 'test_coverage_report', quality_score: 0.7, is_current: true },
+        { artifact_type: 'deployment_runbook', quality_score: 0.6, is_current: true },
+      ];
+      const httpClient = vi.fn().mockResolvedValue({ status: 200 });
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 16,
+        toStage: 17,
+        db: createMockDb(artifacts),
+        httpClient,
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('PASS');
+      expect(httpClient).toHaveBeenCalled();
+    });
+
+    it('should FAIL when URL is unreachable', async () => {
+      const artifacts = [
+        { artifact_type: 'mvp_build', quality_score: 0.8, file_url: 'https://app.example.com', is_current: true },
+        { artifact_type: 'test_coverage_report', quality_score: 0.7, is_current: true },
+        { artifact_type: 'deployment_runbook', quality_score: 0.6, is_current: true },
+      ];
+      const httpClient = vi.fn().mockResolvedValue({ status: 500 });
+      const result = await evaluateRealityGate({
+        ventureId: 'v1',
+        fromStage: 16,
+        toStage: 17,
+        db: createMockDb(artifacts),
+        httpClient,
+        logger: silentLogger,
+      });
+      expect(result.status).toBe('FAIL');
+      const urlReason = result.reasons.find(r => r.code === REASON_CODES.URL_UNREACHABLE);
+      expect(urlReason).toBeDefined();
+    });
+  });
+
+  describe('verifyUrl (internal)', () => {
+    it('should retry on timeout', async () => {
+      const httpClient = vi.fn()
+        .mockRejectedValueOnce({ code: 'ETIMEDOUT', message: 'timeout' })
+        .mockResolvedValueOnce({ status: 200 });
+      const result = await _internal.verifyUrl('https://example.com', httpClient, silentLogger);
+      expect(result.reachable).toBe(true);
+      expect(httpClient).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not retry on non-timeout errors', async () => {
+      const httpClient = vi.fn().mockRejectedValue({ code: 'ECONNREFUSED', message: 'refused' });
+      const result = await _internal.verifyUrl('https://example.com', httpClient, silentLogger);
+      expect(result.reachable).toBe(false);
+      expect(httpClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('BOUNDARY_CONFIG', () => {
+    it('should have exactly 5 configured boundaries', () => {
+      expect(Object.keys(BOUNDARY_CONFIG)).toHaveLength(5);
+    });
+
+    it('should require 3 artifacts per boundary', () => {
+      for (const [_key, config] of Object.entries(BOUNDARY_CONFIG)) {
+        expect(config.required_artifacts).toHaveLength(3);
+      }
+    });
+  });
+
+  describe('exports', () => {
+    it('should export MODULE_VERSION', () => {
+      expect(MODULE_VERSION).toBe('1.0.0');
+    });
+
+    it('should export all REASON_CODES', () => {
+      expect(Object.keys(REASON_CODES)).toHaveLength(6);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 84 unit tests across 5 test files for previously untested Eva orchestrator modules
- Covers GAP-002 from CLI Venture Lifecycle audit (SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-B)
- Modules tested: decision-filter-engine, reality-gates, devils-advocate, eva-orchestrator, lifecycle-sd-bridge
- Tests cover all public APIs, internal helpers, error handling, and edge cases

## Test plan
- [x] All 84 tests pass (`npx vitest run tests/unit/eva/`)
- [x] No regressions in existing test suite (16,108 eva tests pass)
- [x] Smoke tests pass
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)