### PR TITLE
feat: stale worktree detection and automated cleanup

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -650,6 +650,172 @@ function branchExistsRemotely(branch) {
 }
 
 /**
+ * SD-LEO-INFRA-STALE-WORKTREE-LIFECYCLE-001
+ * Detect stale worktrees eligible for cleanup.
+ *
+ * Stale criteria:
+ * - concurrent-auto-* worktrees older than maxAgeMs (default 24h)
+ * - SD worktrees where the SD is completed in the database
+ * - Orphaned git worktree entries (directory missing)
+ *
+ * Never touches Cursor IDE worktrees (.cursor/worktrees/).
+ *
+ * @param {Object} [options]
+ * @param {number} [options.maxAgeMs=86400000] - Max age in ms for concurrent-auto-* worktrees (default 24h)
+ * @param {Object} [options.supabase] - Supabase client for checking SD completion status
+ * @returns {Promise<Array<{ key: string, path: string, reason: string, age?: number, isCursor?: boolean }>>}
+ */
+export async function detectStaleWorktrees({ maxAgeMs = 24 * 60 * 60 * 1000, supabase } = {}) {
+  const repoRoot = getRepoRoot();
+  const worktreesDir = getWorktreesDir(repoRoot);
+  const stale = [];
+  const cursorWarnings = [];
+
+  // 1. Check .worktrees/ directory entries
+  if (fs.existsSync(worktreesDir)) {
+    const entries = fs.readdirSync(worktreesDir, { withFileTypes: true })
+      .filter(e => e.isDirectory());
+
+    for (const entry of entries) {
+      const wtPath = path.join(worktreesDir, entry.name);
+
+      // Check age from metadata files
+      let createdAt = null;
+      for (const metaFile of ['.worktree.json', '.ehg-session.json']) {
+        const metaPath = path.join(wtPath, metaFile);
+        if (fs.existsSync(metaPath)) {
+          try {
+            const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
+            if (meta.createdAt) createdAt = new Date(meta.createdAt);
+          } catch { /* ignore */ }
+          break;
+        }
+      }
+
+      // Fallback: use directory mtime
+      if (!createdAt) {
+        try {
+          const stat = fs.statSync(wtPath);
+          createdAt = stat.mtime;
+        } catch { /* ignore */ }
+      }
+
+      const ageMs = createdAt ? Date.now() - createdAt.getTime() : Infinity;
+
+      // concurrent-auto-* worktrees: stale if older than maxAgeMs
+      if (entry.name.startsWith('concurrent-auto-') && ageMs > maxAgeMs) {
+        stale.push({ key: entry.name, path: wtPath, reason: 'concurrent-auto-expired', age: ageMs });
+        continue;
+      }
+
+      // SD worktrees: stale if SD is completed
+      if (entry.name.startsWith('SD-') && supabase) {
+        try {
+          const { data } = await supabase.from('strategic_directives_v2')
+            .select('status')
+            .eq('sd_key', entry.name)
+            .single();
+          if (data && (data.status === 'completed' || data.status === 'cancelled')) {
+            stale.push({ key: entry.name, path: wtPath, reason: `sd-${data.status}`, age: ageMs });
+          }
+        } catch { /* DB unavailable or SD not found - skip */ }
+      }
+    }
+  }
+
+  // 2. Check git worktree list for orphaned entries
+  try {
+    const porcelain = execSync('git worktree list --porcelain', {
+      cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
+    });
+    const blocks = porcelain.split('\n\n').filter(b => b.trim());
+    for (const block of blocks) {
+      const lines = block.split('\n');
+      const wtLine = lines.find(l => l.startsWith('worktree '));
+      if (!wtLine) continue;
+      const wtPath = wtLine.replace('worktree ', '');
+
+      // Detect Cursor worktrees - warn but never touch
+      if (wtPath.includes('.cursor') || wtPath.includes('cursor/worktrees')) {
+        cursorWarnings.push({ key: path.basename(wtPath), path: wtPath, reason: 'cursor-worktree', isCursor: true });
+        continue;
+      }
+
+      // Check if directory still exists
+      if (!fs.existsSync(wtPath)) {
+        stale.push({ key: path.basename(wtPath), path: wtPath, reason: 'orphaned-directory-missing' });
+      }
+    }
+  } catch { /* git worktree list failed - skip */ }
+
+  return { stale, cursorWarnings };
+}
+
+/**
+ * SD-LEO-INFRA-STALE-WORKTREE-LIFECYCLE-001
+ * Clean up stale worktrees identified by detectStaleWorktrees.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.dryRun=false] - If true, only report what would be cleaned
+ * @param {number} [options.maxAgeMs=86400000] - Max age for concurrent-auto-* worktrees
+ * @param {Object} [options.supabase] - Supabase client
+ * @returns {Promise<{ cleaned: string[], skipped: string[], cursorWarnings: string[], errors: string[] }>}
+ */
+export async function cleanupStaleWorktrees({ dryRun = false, maxAgeMs, supabase } = {}) {
+  const { stale, cursorWarnings } = await detectStaleWorktrees({ maxAgeMs, supabase });
+  const repoRoot = getRepoRoot();
+  const result = { cleaned: [], skipped: [], cursorWarnings: cursorWarnings.map(w => w.path), errors: [] };
+
+  for (const item of stale) {
+    if (dryRun) {
+      result.cleaned.push(`[DRY RUN] ${item.key} (${item.reason})`);
+      continue;
+    }
+
+    try {
+      // Check for uncommitted changes before removing
+      if (fs.existsSync(item.path)) {
+        try {
+          const status = execSync('git status --porcelain', {
+            cwd: item.path, encoding: 'utf8', stdio: 'pipe'
+          }).trim();
+          if (status.length > 0) {
+            result.skipped.push(`${item.key}: uncommitted changes`);
+            continue;
+          }
+        } catch {
+          // Can't check status - proceed with removal
+        }
+      }
+
+      // Remove worktree
+      try {
+        execSync(`git worktree remove --force "${item.path}"`, {
+          cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
+        });
+      } catch {
+        // If git worktree remove fails, clean up manually
+        if (fs.existsSync(item.path)) {
+          fs.rmSync(item.path, { recursive: true, force: true });
+        }
+      }
+      result.cleaned.push(`${item.key} (${item.reason})`);
+    } catch (err) {
+      result.errors.push(`${item.key}: ${err.message}`);
+    }
+  }
+
+  // Run git worktree prune to clean up orphaned entries
+  if (!dryRun && stale.length > 0) {
+    try {
+      execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' });
+    } catch { /* best effort */ }
+  }
+
+  return result;
+}
+
+/**
  * Reset deprecation warning state (for testing).
  * @internal
  */


### PR DESCRIPTION
## Summary
- Add `detectStaleWorktrees()` and `cleanupStaleWorktrees()` to `lib/worktree-manager.js`
- Three stale criteria: concurrent-auto-* > 24h, completed SD worktrees, orphaned git entries
- Cursor IDE worktrees detected and warned but never touched (10 found, 0 affected)
- CLI: `node scripts/session-worktree.js --cleanup-stale [--dry-run] [--max-age-hours N]`
- Tested: correctly identified 15 stale concurrent-auto-*, 1 completed SD, 10 Cursor worktrees

## Test plan
- [x] Dry-run mode identifies stale worktrees correctly
- [x] Cursor worktrees reported but not touched
- [x] 270/270 smoke tests pass
- [x] Pre-commit hooks pass (ESLint, secrets, LOC check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)