### PR TITLE
fix: filter TESTING E2E mandate boilerplate from /learn pipeline

### DIFF
--- a/scripts/modules/learning/context-builder.js
+++ b/scripts/modules/learning/context-builder.js
@@ -143,6 +143,10 @@ const NON_ACTIONABLE_SAL_PATTERNS = [
   /critical risk mitigation required/i,
   /data migration risk management/i,
   /develop mitigation plan before proceeding to exec/i,
+  // SD-LEARN-FIX-ADDRESS-SAL-TESTING-001: TESTING E2E mandate boilerplate (SAL-TESTING-REC)
+  /execute e2e tests before approval.*mandatory/i,
+  /e2e testing is not optional per protocol/i,
+  /node scripts\/execute-subagent\.js --code testing/i,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Added 3 regex patterns to NON_ACTIONABLE_SAL_PATTERNS in context-builder.js to filter TESTING sub-agent E2E mandate boilerplate
- Patterns filter: "Execute E2E tests before approval (MANDATORY)", "E2E testing is NOT optional per protocol", and execute-subagent.js TESTING invocation lines
- Total pattern count: 57 → 60
- 13/13 inline tests pass, 315/315 smoke tests pass

## Test plan
- [x] New TESTING E2E mandate phrases correctly filtered
- [x] Legitimate testing items (coverage drops, CI failures) still pass through
- [x] Prior SD-014 TESTING patterns still work
- [x] Prior SD-016 RISK patterns still work
- [x] Full smoke test suite passes (315/315)

🤖 Generated with [Claude Code](https://claude.com/claude-code)