### PR TITLE
test: Eva service module unit tests (002-D)

### DIFF
--- a/tests/unit/eva/chairman-preference-store.test.js
+++ b/tests/unit/eva/chairman-preference-store.test.js
@@ -1,10 +1,17 @@
 /**
  * Tests for ChairmanPreferenceStore
- * SD-LEO-INFRA-CHAIRMAN-PREFS-001
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-D
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ChairmanPreferenceStore } from '../../../lib/eva/chairman-preference-store.js';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}));
+
+import { ChairmanPreferenceStore, createChairmanPreferenceStore } from '../../../lib/eva/chairman-preference-store.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() };
 
 function createMockSupabase(overrides = {}) {
   const mockQuery = {
@@ -32,7 +39,7 @@ describe('ChairmanPreferenceStore', () => {
     mockSupabase = createMockSupabase();
     store = new ChairmanPreferenceStore({
       supabaseClient: mockSupabase,
-      logger: { debug: vi.fn() },
+      logger: silentLogger,
     });
   });
 
@@ -41,9 +48,13 @@ describe('ChairmanPreferenceStore', () => {
       expect(store).toBeInstanceOf(ChairmanPreferenceStore);
       expect(store.supabase).toBe(mockSupabase);
     });
+
+    it('should accept logger option', () => {
+      expect(store.logger).toBe(silentLogger);
+    });
   });
 
-  describe('setPreference', () => {
+  describe('setPreference - type validation', () => {
     it('should reject invalid valueType', async () => {
       const result = await store.setPreference({
         chairmanId: 'c1', key: 'test', value: 'x', valueType: 'invalid',
@@ -52,7 +63,7 @@ describe('ChairmanPreferenceStore', () => {
       expect(result.error).toContain('Invalid valueType');
     });
 
-    it('should reject value/type mismatch', async () => {
+    it('should reject value/type mismatch (string as number)', async () => {
       const result = await store.setPreference({
         chairmanId: 'c1', key: 'test', value: 'not-a-number', valueType: 'number',
       });
@@ -60,186 +71,20 @@ describe('ChairmanPreferenceStore', () => {
       expect(result.error).toContain('does not match');
     });
 
-    it('should reject risk.max_drawdown_pct > 100', async () => {
+    it('should reject null for object type', async () => {
       const result = await store.setPreference({
-        chairmanId: 'c1', key: 'risk.max_drawdown_pct', value: 150, valueType: 'number',
+        chairmanId: 'c1', key: 'test', value: null, valueType: 'object',
       });
       expect(result.success).toBe(false);
-      expect(result.error).toContain('between 0 and 100');
     });
 
-    it('should reject negative budget', async () => {
+    it('should reject array when type is object', async () => {
       const result = await store.setPreference({
-        chairmanId: 'c1', key: 'budget.max_monthly_usd', value: -100, valueType: 'number',
+        chairmanId: 'c1', key: 'test', value: [1], valueType: 'object',
       });
       expect(result.success).toBe(false);
-      expect(result.error).toContain('>= 0');
     });
 
-    it('should reject empty tech stack directive', async () => {
-      const result = await store.setPreference({
-        chairmanId: 'c1', key: 'tech.stack_directive', value: '  ', valueType: 'string',
-      });
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('non-empty');
-    });
-
-    it('should succeed with valid preference', async () => {
-      const mockRecord = { id: 'pref-1', preference_key: 'budget.max_monthly_usd', preference_value: 5000 };
-      const mockFrom = vi.fn().mockReturnValue({
-        upsert: vi.fn().mockReturnValue({
-          select: vi.fn().mockReturnValue({
-            single: vi.fn().mockResolvedValue({ data: mockRecord, error: null }),
-          }),
-        }),
-      });
-      store.supabase = { from: mockFrom };
-
-      const result = await store.setPreference({
-        chairmanId: 'c1', key: 'budget.max_monthly_usd', value: 5000, valueType: 'number',
-      });
-      expect(result.success).toBe(true);
-      expect(result.record).toEqual(mockRecord);
-    });
-  });
-
-  describe('getPreference', () => {
-    it('should return null when no preference found', async () => {
-      const result = await store.getPreference({ chairmanId: 'c1', key: 'missing' });
-      expect(result).toBeNull();
-    });
-
-    it('should return venture-specific preference over global', async () => {
-      const ventureRow = {
-        id: 'v1', preference_key: 'risk.max_drawdown_pct',
-        preference_value: 10, value_type: 'number',
-        source: 'chairman_directive', updated_at: '2026-01-01',
-      };
-
-      const mockFrom = vi.fn().mockImplementation(() => ({
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        is: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
-      }));
-      store.supabase = { from: mockFrom };
-
-      const result = await store.getPreference({
-        chairmanId: 'c1', ventureId: 'venture-1', key: 'risk.max_drawdown_pct',
-      });
-      expect(result.scope).toBe('venture');
-      expect(result.value).toBe(10);
-    });
-
-    it('should fall back to global when venture-specific not found', async () => {
-      let callCount = 0;
-      const globalRow = {
-        id: 'g1', preference_key: 'risk.max_drawdown_pct',
-        preference_value: 20, value_type: 'number',
-        source: 'chairman_directive', updated_at: '2026-01-01',
-      };
-
-      const mockFrom = vi.fn().mockImplementation(() => ({
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        is: vi.fn().mockReturnThis(),
-        single: vi.fn().mockImplementation(() => {
-          callCount++;
-          // First call = venture-specific (miss), second = global (hit)
-          if (callCount === 1) return Promise.resolve({ data: null, error: null });
-          return Promise.resolve({ data: globalRow, error: null });
-        }),
-      }));
-      store.supabase = { from: mockFrom };
-
-      const result = await store.getPreference({
-        chairmanId: 'c1', ventureId: 'venture-1', key: 'risk.max_drawdown_pct',
-      });
-      expect(result.scope).toBe('global');
-      expect(result.value).toBe(20);
-    });
-  });
-
-  describe('getPreferences', () => {
-    it('should return resolved map with scope metadata', async () => {
-      const ventureRows = [
-        { id: 'v1', preference_key: 'key1', preference_value: 'val1', value_type: 'string', source: 'test', updated_at: '2026-01-01' },
-      ];
-      const globalRows = [
-        { id: 'g1', preference_key: 'key2', preference_value: 42, value_type: 'number', source: 'test', updated_at: '2026-01-01' },
-      ];
-
-      let queryCount = 0;
-      const mockFrom = vi.fn().mockImplementation(() => ({
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        is: vi.fn().mockReturnThis(),
-        in: vi.fn().mockImplementation(function () {
-          queryCount++;
-          if (queryCount === 1) return Promise.resolve({ data: ventureRows, error: null });
-          return Promise.resolve({ data: globalRows, error: null });
-        }),
-      }));
-      store.supabase = { from: mockFrom };
-
-      const result = await store.getPreferences({
-        chairmanId: 'c1', ventureId: 'v1', keys: ['key1', 'key2', 'key3'],
-      });
-
-      expect(result.get('key1').scope).toBe('venture');
-      expect(result.get('key2').scope).toBe('global');
-      expect(result.has('key3')).toBe(false);
-    });
-  });
-
-  describe('deletePreference', () => {
-    it('should delete a preference successfully', async () => {
-      const mockFrom = vi.fn().mockReturnValue({
-        delete: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              is: vi.fn().mockResolvedValue({ error: null }),
-            }),
-          }),
-        }),
-      });
-      store.supabase = { from: mockFrom };
-
-      const result = await store.deletePreference({
-        chairmanId: 'c1', key: 'budget.max_monthly_usd',
-      });
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe('linkDecisionToPreferences', () => {
-    it('should succeed with empty preferences map', async () => {
-      const result = await store.linkDecisionToPreferences({
-        decisionId: 'd1', resolvedPreferences: new Map(),
-      });
-      expect(result.success).toBe(true);
-    });
-
-    it('should update decision with preference snapshot', async () => {
-      const mockFrom = vi.fn().mockReturnValue({
-        update: vi.fn().mockReturnValue({
-          eq: vi.fn().mockResolvedValue({ error: null }),
-        }),
-      });
-      store.supabase = { from: mockFrom };
-
-      const prefs = new Map([
-        ['risk.max_drawdown_pct', { id: 'p1', value: 10, scope: 'venture', valueType: 'number' }],
-      ]);
-
-      const result = await store.linkDecisionToPreferences({
-        decisionId: 'd1', resolvedPreferences: prefs,
-      });
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe('value type validation', () => {
     it('should accept object type', async () => {
       const mockFrom = vi.fn().mockReturnValue({
         upsert: vi.fn().mockReturnValue({
@@ -272,11 +117,459 @@ describe('ChairmanPreferenceStore', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should reject array when type is object', async () => {
+    it('should accept boolean type', async () => {
+      const mockFrom = vi.fn().mockReturnValue({
+        upsert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'x' }, error: null }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
       const result = await store.setPreference({
-        chairmanId: 'c1', key: 'test', value: [1], valueType: 'object',
+        chairmanId: 'c1', key: 'flag', value: true, valueType: 'boolean',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('setPreference - known key validators', () => {
+    it('should reject risk.max_drawdown_pct > 100', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'risk.max_drawdown_pct', value: 150, valueType: 'number',
       });
       expect(result.success).toBe(false);
+      expect(result.error).toContain('between 0 and 100');
+    });
+
+    it('should reject risk.max_drawdown_pct < 0', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'risk.max_drawdown_pct', value: -5, valueType: 'number',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('between 0 and 100');
+    });
+
+    it('should reject negative budget', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'budget.max_monthly_usd', value: -100, valueType: 'number',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('>= 0');
+    });
+
+    it('should accept zero budget', async () => {
+      const mockFrom = vi.fn().mockReturnValue({
+        upsert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'x' }, error: null }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'budget.max_monthly_usd', value: 0, valueType: 'number',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject empty tech stack directive', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'tech.stack_directive', value: '  ', valueType: 'string',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('non-empty');
+    });
+
+    it('should reject non-string tech stack directive', async () => {
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'tech.stack_directive', value: 123, valueType: 'number',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('must be a string');
+    });
+  });
+
+  describe('setPreference - upsert', () => {
+    it('should succeed with valid preference', async () => {
+      const mockRecord = { id: 'pref-1', preference_key: 'budget.max_monthly_usd', preference_value: 5000 };
+      const mockFrom = vi.fn().mockReturnValue({
+        upsert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: mockRecord, error: null }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'budget.max_monthly_usd', value: 5000, valueType: 'number',
+      });
+      expect(result.success).toBe(true);
+      expect(result.record).toEqual(mockRecord);
+    });
+
+    it('should use default source "chairman_directive"', async () => {
+      const upsertFn = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { id: 'r1' }, error: null }),
+        }),
+      });
+      store.supabase = { from: vi.fn().mockReturnValue({ upsert: upsertFn }) };
+
+      await store.setPreference({
+        chairmanId: 'c1', key: 'k', value: 'v', valueType: 'string',
+      });
+
+      expect(upsertFn).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'chairman_directive' }),
+        expect.any(Object),
+      );
+    });
+
+    it('should pass ventureId and onConflict to upsert', async () => {
+      const upsertFn = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { id: 'r1' }, error: null }),
+        }),
+      });
+      store.supabase = { from: vi.fn().mockReturnValue({ upsert: upsertFn }) };
+
+      await store.setPreference({
+        chairmanId: 'c1', ventureId: 'v1', key: 'k', value: 1, valueType: 'number',
+      });
+
+      expect(upsertFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chairman_id: 'c1',
+          venture_id: 'v1',
+          preference_key: 'k',
+          preference_value: 1,
+          value_type: 'number',
+        }),
+        expect.objectContaining({ onConflict: 'chairman_id,venture_id,preference_key' }),
+      );
+    });
+
+    it('should return error on DB failure', async () => {
+      store.supabase = {
+        from: vi.fn().mockReturnValue({
+          upsert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Conflict' } }),
+            }),
+          }),
+        }),
+      };
+
+      const result = await store.setPreference({
+        chairmanId: 'c1', key: 'k', value: 1, valueType: 'number',
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to set preference');
+    });
+  });
+
+  describe('getPreference - scoped resolution', () => {
+    it('should return null when no preference found', async () => {
+      const result = await store.getPreference({ chairmanId: 'c1', key: 'missing' });
+      expect(result).toBeNull();
+    });
+
+    it('should return venture-specific preference first', async () => {
+      const ventureRow = {
+        id: 'v1', preference_key: 'risk.max_drawdown_pct',
+        preference_value: 10, value_type: 'number',
+        source: 'chairman_directive', updated_at: '2026-01-01',
+      };
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: ventureRow, error: null }),
+      });
+
+      const result = await store.getPreference({
+        chairmanId: 'c1', ventureId: 'venture-1', key: 'risk.max_drawdown_pct',
+      });
+      expect(result.scope).toBe('venture');
+      expect(result.value).toBe(10);
+      expect(result.key).toBe('risk.max_drawdown_pct');
+    });
+
+    it('should fall back to global when venture-specific not found', async () => {
+      let callCount = 0;
+      const globalRow = {
+        id: 'g1', preference_key: 'risk.max_drawdown_pct',
+        preference_value: 20, value_type: 'number',
+        source: 'chairman_directive', updated_at: '2026-01-01',
+      };
+
+      mockSupabase.from.mockImplementation(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        single: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) return Promise.resolve({ data: null, error: null });
+          return Promise.resolve({ data: globalRow, error: null });
+        }),
+      }));
+
+      const result = await store.getPreference({
+        chairmanId: 'c1', ventureId: 'venture-1', key: 'risk.max_drawdown_pct',
+      });
+      expect(result.scope).toBe('global');
+      expect(result.value).toBe(20);
+    });
+
+    it('should skip venture query when ventureId is null', async () => {
+      const globalRow = {
+        id: 'g1', preference_key: 'key', preference_value: 'val',
+        value_type: 'string', source: 'default', updated_at: '2026-01-01',
+      };
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: globalRow, error: null }),
+      });
+
+      const result = await store.getPreference({ chairmanId: 'c1', key: 'key' });
+      expect(result.scope).toBe('global');
+      expect(mockSupabase.from).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getPreferences - batch resolution', () => {
+    it('should return resolved map with scope metadata', async () => {
+      const ventureRows = [
+        { id: 'v1', preference_key: 'key1', preference_value: 'val1', value_type: 'string', source: 'test', updated_at: '2026-01-01' },
+      ];
+      const globalRows = [
+        { id: 'g1', preference_key: 'key2', preference_value: 42, value_type: 'number', source: 'test', updated_at: '2026-01-01' },
+      ];
+
+      let queryCount = 0;
+      mockSupabase.from.mockImplementation(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        in: vi.fn().mockImplementation(function () {
+          queryCount++;
+          if (queryCount === 1) return Promise.resolve({ data: ventureRows, error: null });
+          return Promise.resolve({ data: globalRows, error: null });
+        }),
+      }));
+
+      const result = await store.getPreferences({
+        chairmanId: 'c1', ventureId: 'v1', keys: ['key1', 'key2', 'key3'],
+      });
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get('key1').scope).toBe('venture');
+      expect(result.get('key2').scope).toBe('global');
+      expect(result.has('key3')).toBe(false);
+    });
+
+    it('should skip venture query when ventureId is null', async () => {
+      const globalRows = [
+        { id: 'g1', preference_key: 'k1', preference_value: 'v1', value_type: 'string', source: 's', updated_at: '2026', },
+      ];
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        in: vi.fn().mockResolvedValue({ data: globalRows, error: null }),
+      });
+
+      const result = await store.getPreferences({ chairmanId: 'c1', keys: ['k1'] });
+      expect(result.size).toBe(1);
+      expect(mockSupabase.from).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip global query when all keys resolved at venture level', async () => {
+      const ventureRows = [
+        { id: 'v1', preference_key: 'k1', preference_value: 'v1', value_type: 'string', source: 's', updated_at: '2026' },
+        { id: 'v2', preference_key: 'k2', preference_value: 'v2', value_type: 'string', source: 's', updated_at: '2026' },
+      ];
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        in: vi.fn().mockResolvedValue({ data: ventureRows, error: null }),
+      });
+
+      const result = await store.getPreferences({
+        chairmanId: 'c1', ventureId: 'v1', keys: ['k1', 'k2'],
+      });
+      expect(result.size).toBe(2);
+      expect(mockSupabase.from).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deletePreference', () => {
+    it('should delete with venture_id IS NULL when not provided', async () => {
+      const mockFrom = vi.fn().mockReturnValue({
+        delete: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              is: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const result = await store.deletePreference({
+        chairmanId: 'c1', key: 'budget.max_monthly_usd',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should delete with venture_id eq when provided', async () => {
+      const mockFrom = vi.fn().mockReturnValue({
+        delete: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ error: null }),
+            }),
+          }),
+        }),
+      });
+      store.supabase = { from: mockFrom };
+
+      const result = await store.deletePreference({
+        chairmanId: 'c1', ventureId: 'v1', key: 'test.key',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should return error on DB failure', async () => {
+      store.supabase = {
+        from: vi.fn().mockReturnValue({
+          delete: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockResolvedValue({ error: { message: 'Delete failed' } }),
+              }),
+            }),
+          }),
+        }),
+      };
+
+      const result = await store.deletePreference({ chairmanId: 'c1', key: 'test.key' });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to delete preference');
+    });
+  });
+
+  describe('linkDecisionToPreferences', () => {
+    it('should succeed with empty preferences map', async () => {
+      const result = await store.linkDecisionToPreferences({
+        decisionId: 'd1', resolvedPreferences: new Map(),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should update decision with preference snapshot', async () => {
+      const updateFn = vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      });
+      store.supabase = { from: vi.fn().mockReturnValue({ update: updateFn }) };
+
+      const prefs = new Map([
+        ['budget.max_monthly_usd', { id: 'p1', value: 5000, scope: 'venture', valueType: 'number' }],
+        ['risk.max_drawdown_pct', { id: 'p2', value: 25, scope: 'global', valueType: 'number' }],
+      ]);
+
+      const result = await store.linkDecisionToPreferences({
+        decisionId: 'd1', resolvedPreferences: prefs,
+      });
+
+      expect(result.success).toBe(true);
+      expect(updateFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preference_key: 'budget.max_monthly_usd',
+          preference_ref_id: 'p1',
+          preference_snapshot: expect.objectContaining({
+            'budget.max_monthly_usd': { value: 5000, scope: 'venture', valueType: 'number' },
+            'risk.max_drawdown_pct': { value: 25, scope: 'global', valueType: 'number' },
+          }),
+        }),
+      );
+    });
+
+    it('should handle null preference id', async () => {
+      const updateFn = vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      });
+      store.supabase = { from: vi.fn().mockReturnValue({ update: updateFn }) };
+
+      const prefs = new Map([
+        ['k1', { id: null, value: 'v', scope: 'global', valueType: 'string' }],
+      ]);
+
+      const result = await store.linkDecisionToPreferences({
+        decisionId: 'd1', resolvedPreferences: prefs,
+      });
+
+      expect(result.success).toBe(true);
+      expect(updateFn).toHaveBeenCalledWith(
+        expect.objectContaining({ preference_ref_id: null }),
+      );
+    });
+
+    it('should return error on DB failure', async () => {
+      store.supabase = {
+        from: vi.fn().mockReturnValue({
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: { message: 'Update failed' } }),
+          }),
+        }),
+      };
+
+      const prefs = new Map([['k1', { id: null, value: 'v', scope: 'global', valueType: 'string' }]]);
+
+      const result = await store.linkDecisionToPreferences({
+        decisionId: 'd1', resolvedPreferences: prefs,
+      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to link decision');
+    });
+  });
+
+  describe('_formatResult', () => {
+    it('should map DB row to formatted result', () => {
+      const row = {
+        id: 'pref-1', preference_key: 'budget.max_monthly_usd',
+        preference_value: 5000, value_type: 'number',
+        source: 'chairman_directive', updated_at: '2026-01-01T00:00:00Z',
+      };
+
+      const result = store._formatResult(row, 'venture');
+
+      expect(result).toEqual({
+        id: 'pref-1',
+        key: 'budget.max_monthly_usd',
+        value: 5000,
+        valueType: 'number',
+        source: 'chairman_directive',
+        scope: 'venture',
+        updatedAt: '2026-01-01T00:00:00Z',
+      });
+    });
+  });
+
+  describe('createChairmanPreferenceStore factory', () => {
+    it('should return a ChairmanPreferenceStore instance', () => {
+      const s = createChairmanPreferenceStore({ supabaseClient: mockSupabase });
+      expect(s).toBeInstanceOf(ChairmanPreferenceStore);
     });
   });
 });

--- a/tests/unit/eva/venture-context-manager.test.js
+++ b/tests/unit/eva/venture-context-manager.test.js
@@ -1,16 +1,21 @@
 /**
  * Tests for VentureContextManager
- * SD-LEO-INFRA-VENTURE-CONTEXT-001
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-D
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { VentureContextManager } from '../../../lib/eva/venture-context-manager.js';
 
-// Mock Supabase client
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}));
+
+import { VentureContextManager, createVentureContextManager } from '../../../lib/eva/venture-context-manager.js';
+
 function createMockSupabase(overrides = {}) {
   const mockQuery = {
     select: vi.fn().mockReturnThis(),
     eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
     or: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
@@ -30,13 +35,17 @@ describe('VentureContextManager', () => {
 
   beforeEach(() => {
     mockSupabase = createMockSupabase();
-    manager = new VentureContextManager({ supabaseClient: mockSupabase });
+    manager = new VentureContextManager({ supabaseClient: mockSupabase, sessionId: 'test-session' });
   });
 
   describe('constructor', () => {
     it('should create instance with custom supabase client', () => {
       expect(manager).toBeInstanceOf(VentureContextManager);
       expect(manager.supabase).toBe(mockSupabase);
+    });
+
+    it('should accept sessionId option', () => {
+      expect(manager.sessionId).toBe('test-session');
     });
 
     it('should initialize with null cache', () => {
@@ -55,63 +64,200 @@ describe('VentureContextManager', () => {
       manager._cachedVentureId = 'test-venture-id';
       const result = await manager.getActiveVentureId();
       expect(result).toBe('test-venture-id');
-      // Should not call supabase when cached
       expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+
+    it('should return null when session has no active_venture_id in metadata', async () => {
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { session_id: 's1', metadata: {}, status: 'active' },
+          error: null,
+        }),
+      });
+
+      const result = await manager.getActiveVentureId();
+      expect(result).toBeNull();
+    });
+
+    it('should return and cache ventureId from session metadata', async () => {
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { session_id: 's1', metadata: { active_venture_id: 'v-123' }, status: 'active' },
+          error: null,
+        }),
+      });
+
+      const result = await manager.getActiveVentureId();
+      expect(result).toBe('v-123');
+      expect(manager._cachedVentureId).toBe('v-123');
+    });
+  });
+
+  describe('getActiveVenture', () => {
+    it('should return null when no active venture id', async () => {
+      const result = await manager.getActiveVenture();
+      expect(result).toBeNull();
+    });
+
+    it('should return cached venture on second call', async () => {
+      const venture = { id: 'v-1', name: 'TestVenture', status: 'active' };
+      manager._cachedVentureId = 'v-1';
+      manager._cachedVenture = venture;
+
+      const result = await manager.getActiveVenture();
+      expect(result).toBe(venture);
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+
+    it('should fetch and cache venture from database', async () => {
+      const venture = {
+        id: 'v-1', name: 'TestVenture', status: 'active',
+        current_lifecycle_stage: 5, archetype: 'saas', created_at: '2026-01-01',
+      };
+      manager._cachedVentureId = 'v-1';
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: venture, error: null }),
+      });
+
+      const result = await manager.getActiveVenture();
+      expect(result).toEqual(venture);
+      expect(manager._cachedVenture).toEqual(venture);
+    });
+
+    it('should return null when venture query errors', async () => {
+      manager._cachedVentureId = 'v-1';
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } }),
+      });
+
+      const result = await manager.getActiveVenture();
+      expect(result).toBeNull();
     });
   });
 
   describe('setActiveVenture', () => {
     it('should fail when venture does not exist', async () => {
-      // Mock venture lookup returns no data
-      const mockFrom = vi.fn().mockImplementation((table) => {
-        if (table === 'ventures') {
-          return {
-            select: vi.fn().mockReturnThis(),
-            eq: vi.fn().mockReturnThis(),
-            single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } }),
-          };
-        }
-        return createMockSupabase().from(table);
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } }),
       });
-      manager.supabase = { from: mockFrom };
 
       const result = await manager.setActiveVenture('nonexistent-id');
       expect(result.success).toBe(false);
       expect(result.error).toContain('Venture not found');
     });
 
+    it('should fail when no active session', async () => {
+      let callCount = 0;
+      mockSupabase.from.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'v-1', name: 'Test', status: 'active', current_lifecycle_stage: 1 },
+              error: null,
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: null, error: { message: 'No session' } }),
+        };
+      });
+
+      const result = await manager.setActiveVenture('v-1');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('No active session found');
+    });
+
     it('should succeed when venture exists and session is active', async () => {
       const mockVenture = { id: 'v-123', name: 'TestVenture', status: 'active', current_lifecycle_stage: 3 };
       const mockSession = { session_id: 'sess-1', metadata: { auto_proceed: true }, status: 'active' };
 
-      const mockFrom = vi.fn().mockImplementation((table) => {
-        if (table === 'ventures') {
+      let callCount = 0;
+      mockSupabase.from.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
           return {
             select: vi.fn().mockReturnThis(),
             eq: vi.fn().mockReturnThis(),
             single: vi.fn().mockResolvedValue({ data: mockVenture, error: null }),
           };
         }
-        if (table === 'claude_sessions') {
+        if (callCount === 2) {
           return {
             select: vi.fn().mockReturnThis(),
             eq: vi.fn().mockReturnThis(),
             order: vi.fn().mockReturnThis(),
             limit: vi.fn().mockReturnThis(),
             single: vi.fn().mockResolvedValue({ data: mockSession, error: null }),
-            update: vi.fn().mockReturnValue({
-              eq: vi.fn().mockResolvedValue({ error: null }),
-            }),
           };
         }
-        return createMockSupabase().from(table);
+        return {
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        };
       });
-      manager.supabase = { from: mockFrom };
 
       const result = await manager.setActiveVenture('v-123');
       expect(result.success).toBe(true);
       expect(result.venture).toEqual(mockVenture);
       expect(manager._cachedVentureId).toBe('v-123');
+      expect(manager._cachedVenture).toEqual(mockVenture);
+    });
+
+    it('should return error when session update fails', async () => {
+      const mockVenture = { id: 'v-1', name: 'Test', status: 'active', current_lifecycle_stage: 1 };
+      const mockSession = { session_id: 's1', metadata: {}, status: 'active' };
+
+      let callCount = 0;
+      mockSupabase.from.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockVenture, error: null }),
+          };
+        }
+        if (callCount === 2) {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: mockSession, error: null }),
+          };
+        }
+        return {
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: { message: 'DB timeout' } }),
+        };
+      });
+
+      const result = await manager.setActiveVenture('v-1');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to update session');
     });
   });
 
@@ -121,13 +267,72 @@ describe('VentureContextManager', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('No active session');
     });
+
+    it('should clear venture and reset cache', async () => {
+      const session = {
+        session_id: 's1',
+        metadata: { active_venture_id: 'v-1', active_venture_name: 'Test', venture_set_at: '2026-01-01' },
+        status: 'active',
+      };
+
+      let callCount = 0;
+      mockSupabase.from.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: session, error: null }),
+          };
+        }
+        return {
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        };
+      });
+
+      manager._cachedVentureId = 'v-1';
+      manager._cachedVenture = { id: 'v-1' };
+
+      const result = await manager.clearActiveVenture();
+      expect(result.success).toBe(true);
+      expect(manager._cachedVentureId).toBeNull();
+      expect(manager._cachedVenture).toBeNull();
+    });
+
+    it('should return error on update failure', async () => {
+      const session = { session_id: 's1', metadata: {}, status: 'active' };
+
+      let callCount = 0;
+      mockSupabase.from.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: session, error: null }),
+          };
+        }
+        return {
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: { message: 'Update failed' } }),
+        };
+      });
+
+      const result = await manager.clearActiveVenture();
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to clear venture');
+    });
   });
 
   describe('switchVenture', () => {
-    it('should track previous venture ID', async () => {
+    it('should track previous venture ID on success', async () => {
       manager._cachedVentureId = 'old-venture';
 
-      // Mock setActiveVenture
       manager.setActiveVenture = vi.fn().mockResolvedValue({
         success: true,
         venture: { id: 'new-venture', name: 'New' },
@@ -136,6 +341,107 @@ describe('VentureContextManager', () => {
       const result = await manager.switchVenture('new-venture');
       expect(result.success).toBe(true);
       expect(result.previousVentureId).toBe('old-venture');
+    });
+
+    it('should not include previousVentureId on failure', async () => {
+      manager._cachedVentureId = 'old-venture';
+
+      manager.setActiveVenture = vi.fn().mockResolvedValue({
+        success: false,
+        error: 'Venture not found',
+      });
+
+      const result = await manager.switchVenture('nonexistent');
+      expect(result.success).toBe(false);
+      expect(result.previousVentureId).toBeUndefined();
+    });
+  });
+
+  describe('listVentures', () => {
+    it('should return all ventures', async () => {
+      const ventures = [
+        { id: 'v-1', name: 'A', status: 'active' },
+        { id: 'v-2', name: 'B', status: 'ideation' },
+      ];
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: ventures, error: null }),
+      });
+
+      const result = await manager.listVentures();
+      expect(result).toEqual(ventures);
+    });
+
+    it('should filter by status when provided', async () => {
+      const ventures = [{ id: 'v-1', name: 'A', status: 'active' }];
+      const mockEq = vi.fn().mockResolvedValue({ data: ventures, error: null });
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        eq: mockEq,
+      });
+
+      const result = await manager.listVentures({ status: 'active' });
+      expect(result).toEqual(ventures);
+    });
+
+    it('should return empty array on error', async () => {
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+      });
+
+      const result = await manager.listVentures();
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when data is null', async () => {
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: null, error: null }),
+      });
+
+      const result = await manager.listVentures();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getVentureScopedSDs', () => {
+    it('should return empty array when no active venture', async () => {
+      const result = await manager.getVentureScopedSDs();
+      expect(result).toEqual([]);
+    });
+
+    it('should return SDs scoped to active venture', async () => {
+      const venture = { id: 'v-1', name: 'TestV', status: 'active', current_lifecycle_stage: 3, archetype: 'saas', created_at: '2026-01-01' };
+      const sds = [{ sd_key: 'SD-001', title: 'Test SD', status: 'in_progress' }];
+
+      manager._cachedVentureId = 'v-1';
+      manager._cachedVenture = venture;
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: sds, error: null }),
+      });
+
+      const result = await manager.getVentureScopedSDs();
+      expect(result).toEqual(sds);
+    });
+
+    it('should return empty array on query error', async () => {
+      manager._cachedVentureId = 'v-1';
+      manager._cachedVenture = { id: 'v-1', name: 'Test' };
+
+      mockSupabase.from.mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: null, error: { message: 'Query failed' } }),
+      });
+
+      const result = await manager.getVentureScopedSDs();
+      expect(result).toEqual([]);
     });
   });
 
@@ -155,7 +461,23 @@ describe('VentureContextManager', () => {
   describe('getStatusDisplay', () => {
     it('should show no active venture message', async () => {
       const display = await manager.getStatusDisplay();
-      expect(display).toContain('No active venture');
+      expect(display).toBe('No active venture (global context)');
+    });
+
+    it('should show formatted venture status', async () => {
+      manager._cachedVentureId = 'v-1';
+      manager._cachedVenture = { id: 'v-1', name: 'ProvenFlow', status: 'active', current_lifecycle_stage: 5 };
+
+      const display = await manager.getStatusDisplay();
+      expect(display).toBe('Active venture: ProvenFlow (Stage 5, active)');
+    });
+
+    it('should default to Stage 1 when lifecycle_stage is null', async () => {
+      manager._cachedVentureId = 'v-1';
+      manager._cachedVenture = { id: 'v-1', name: 'New', status: 'ideation', current_lifecycle_stage: null };
+
+      const display = await manager.getStatusDisplay();
+      expect(display).toBe('Active venture: New (Stage 1, ideation)');
     });
   });
 
@@ -168,6 +490,13 @@ describe('VentureContextManager', () => {
 
       expect(manager._cachedVentureId).toBeNull();
       expect(manager._cachedVenture).toBeNull();
+    });
+  });
+
+  describe('createVentureContextManager factory', () => {
+    it('should return a VentureContextManager instance', () => {
+      const mgr = createVentureContextManager({ supabaseClient: mockSupabase });
+      expect(mgr).toBeInstanceOf(VentureContextManager);
     });
   });
 });

--- a/tests/unit/eva/venture-state-machine.test.js
+++ b/tests/unit/eva/venture-state-machine.test.js
@@ -1,0 +1,570 @@
+/**
+ * Tests for VentureStateMachine
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-D
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('../../../lib/agents/modules/venture-state-machine/handoff-operations.js', () => ({
+  validateHandoffPackage: vi.fn(),
+  verifyCeoAuthority: vi.fn(),
+  approveHandoff: vi.fn(),
+  rejectHandoff: vi.fn(),
+  requestChanges: vi.fn(),
+  getStageRequirements: vi.fn().mockReturnValue({ artifacts: [], quality_gates: [] }),
+}));
+
+import {
+  VentureStateMachine,
+  StateStalenessError,
+  GoldenNuggetValidationError,
+  StageGateValidationError,
+} from '../../../lib/agents/venture-state-machine.js';
+import {
+  validateHandoffPackage,
+  verifyCeoAuthority,
+  approveHandoff,
+  rejectHandoff,
+  requestChanges,
+} from '../../../lib/agents/modules/venture-state-machine/handoff-operations.js';
+
+const origConsole = {};
+
+function createMockSupabase({ ventureData, stageWorkData, pendingHandoffsData } = {}) {
+  const venture = ventureData || { id: 'v-1', name: 'TestVenture', current_lifecycle_stage: 5, status: 'active' };
+  const stageWork = stageWorkData || [];
+  const pendingHandoffs = pendingHandoffsData || [];
+
+  return {
+    from: vi.fn((table) => {
+      if (table === 'ventures') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: venture, error: null }),
+        };
+      }
+      if (table === 'venture_stage_work') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ data: stageWork, error: null }),
+        };
+      }
+      if (table === 'pending_ceo_handoffs') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: pendingHandoffs, error: null }),
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    }),
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+}
+
+describe('VentureStateMachine', () => {
+  let mockSb;
+  let sm;
+
+  beforeEach(() => {
+    mockSb = createMockSupabase({
+      stageWorkData: [
+        { lifecycle_stage: 3, stage_status: 'completed', health_score: 'green' },
+        { lifecycle_stage: 4, stage_status: 'completed', health_score: 'green' },
+      ],
+      pendingHandoffsData: [
+        {
+          id: 'h-1', vp_agent_id: 'vp-1', from_stage: 5, to_stage: 6,
+          handoff_data: { artifacts: [{ type: 'analysis', content: 'done' }] },
+          proposed_at: '2026-01-01', status: 'pending',
+        },
+      ],
+    });
+
+    sm = new VentureStateMachine({
+      supabaseClient: mockSb,
+      ventureId: 'v-1',
+      ceoAgentId: 'ceo-1',
+    });
+
+    // Silence console output during tests
+    origConsole.log = console.log;
+    origConsole.warn = console.warn;
+    origConsole.error = console.error;
+    console.log = vi.fn();
+    console.warn = vi.fn();
+    console.error = vi.fn();
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    console.log = origConsole.log;
+    console.warn = origConsole.warn;
+    console.error = origConsole.error;
+  });
+
+  describe('constructor', () => {
+    it('should set ventureId and ceoAgentId', () => {
+      expect(sm.ventureId).toBe('v-1');
+      expect(sm.ceoAgentId).toBe('ceo-1');
+    });
+
+    it('should initialize with uninitialized state', () => {
+      expect(sm._initialized).toBe(false);
+      expect(sm.currentStage).toBeNull();
+      expect(sm.stageStates.size).toBe(0);
+      expect(sm.pendingHandoffsCache.size).toBe(0);
+    });
+  });
+
+  describe('initialize', () => {
+    it('should load venture, stage work, and pending handoffs', async () => {
+      await sm.initialize();
+
+      expect(sm._initialized).toBe(true);
+      expect(sm.currentStage).toBe(5);
+      expect(sm.stageStates.size).toBe(2);
+      expect(sm.stageStates.get(3)).toEqual({ status: 'completed', health_score: 'green' });
+      expect(sm.pendingHandoffsCache.size).toBe(1);
+    });
+
+    it('should throw when venture not found', async () => {
+      const errorSb = createMockSupabase();
+      errorSb.from = vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } }),
+      }));
+
+      const errorSm = new VentureStateMachine({
+        supabaseClient: errorSb, ventureId: 'nonexistent', ceoAgentId: 'ceo-1',
+      });
+
+      await expect(errorSm.initialize()).rejects.toThrow('Failed to load venture');
+    });
+
+    it('should default to stage 1 when current_lifecycle_stage is null', async () => {
+      const sbNull = createMockSupabase({
+        ventureData: { id: 'v-1', name: 'Test', current_lifecycle_stage: null, status: 'active' },
+      });
+
+      const smNull = new VentureStateMachine({
+        supabaseClient: sbNull, ventureId: 'v-1', ceoAgentId: 'ceo-1',
+      });
+
+      await smNull.initialize();
+      expect(smNull.currentStage).toBe(1);
+    });
+
+    it('should return this for chaining', async () => {
+      const result = await sm.initialize();
+      expect(result).toBe(sm);
+    });
+
+    it('should handle empty stage work gracefully', async () => {
+      const sbEmpty = createMockSupabase({ stageWorkData: null });
+      const smEmpty = new VentureStateMachine({
+        supabaseClient: sbEmpty, ventureId: 'v-1', ceoAgentId: 'ceo-1',
+      });
+
+      await smEmpty.initialize();
+      expect(smEmpty.stageStates.size).toBe(0);
+    });
+  });
+
+  describe('verifyStateFreshness', () => {
+    it('should pass when DB stage matches cached stage', async () => {
+      await sm.initialize();
+      const result = await sm.verifyStateFreshness();
+      expect(result).toBe(true);
+    });
+
+    it('should throw StateStalenessError when stages differ', async () => {
+      await sm.initialize();
+      expect(sm.currentStage).toBe(5);
+
+      // DB now returns stage 6 (someone advanced it externally)
+      mockSb.from = vi.fn((table) => {
+        if (table === 'ventures') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'v-1', name: 'TestVenture', current_lifecycle_stage: 6, status: 'active' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'venture_stage_work') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          };
+        }
+        if (table === 'pending_ceo_handoffs') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      });
+
+      try {
+        await sm.verifyStateFreshness();
+        expect.fail('Should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(StateStalenessError);
+        expect(err.isRetryable).toBe(true);
+      }
+    });
+
+    it('should throw when DB query fails', async () => {
+      await sm.initialize();
+
+      mockSb.from = vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Connection lost' } }),
+      }));
+
+      await expect(sm.verifyStateFreshness()).rejects.toThrow('JIT Truth Check failed');
+    });
+  });
+
+  describe('getCurrentStage', () => {
+    it('should return current stage after initialization', async () => {
+      await sm.initialize();
+      expect(sm.getCurrentStage()).toBe(5);
+    });
+
+    it('should return null before initialization', () => {
+      expect(sm.getCurrentStage()).toBeNull();
+    });
+  });
+
+  describe('getStageState', () => {
+    it('should return state for known stage', async () => {
+      await sm.initialize();
+      const state = sm.getStageState(3);
+      expect(state).toEqual({ status: 'completed', health_score: 'green' });
+    });
+
+    it('should return default for unknown stage', () => {
+      const state = sm.getStageState(99);
+      expect(state).toEqual({ status: 'pending', health_score: null });
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should return summary with correct counts', async () => {
+      await sm.initialize();
+      const summary = sm.getSummary();
+
+      expect(summary.venture_id).toBe('v-1');
+      expect(summary.ceo_agent_id).toBe('ceo-1');
+      expect(summary.current_stage).toBe(5);
+      expect(summary.stages_completed).toBe(2);
+      expect(summary.pending_handoffs).toBe(1);
+    });
+
+    it('should return zero counts before initialization', () => {
+      const summary = sm.getSummary();
+      expect(summary.current_stage).toBeNull();
+      expect(summary.stages_completed).toBe(0);
+      expect(summary.pending_handoffs).toBe(0);
+    });
+  });
+
+  describe('proposeHandoff', () => {
+    it('should return rejected when validation fails', async () => {
+      await sm.initialize();
+
+      validateHandoffPackage.mockReturnValue({
+        valid: false,
+        errors: ['Missing required field: artifacts'],
+      });
+
+      const result = await sm.proposeHandoff({
+        vpAgentId: 'vp-1',
+        fromStage: 5,
+        artifacts: [],
+        key_decisions: [],
+      });
+
+      expect(result.accepted).toBe(false);
+      expect(result.status).toBe('rejected');
+      expect(result.errors).toContain('Missing required field: artifacts');
+    });
+
+    it('should persist handoff and return accepted on valid package', async () => {
+      await sm.initialize();
+
+      validateHandoffPackage.mockReturnValue({ valid: true, errors: [] });
+      mockSb.rpc.mockResolvedValue({ data: 'h-new', error: null });
+
+      const result = await sm.proposeHandoff({
+        vpAgentId: 'vp-1',
+        fromStage: 5,
+        artifacts: [{ type: 'analysis', content: 'data' }],
+        key_decisions: [{ decision: 'proceed' }],
+      });
+
+      expect(result.accepted).toBe(true);
+      expect(result.handoff_id).toBe('h-new');
+      expect(result.status).toBe('pending_ceo_review');
+      expect(sm.pendingHandoffsCache.has('h-new')).toBe(true);
+    });
+
+    it('should cache the new handoff with correct fields', async () => {
+      await sm.initialize();
+
+      validateHandoffPackage.mockReturnValue({ valid: true, errors: [] });
+      mockSb.rpc.mockResolvedValue({ data: 'h-new', error: null });
+
+      await sm.proposeHandoff({
+        vpAgentId: 'vp-1',
+        fromStage: 5,
+        artifacts: [{ type: 'a', content: 'c' }],
+        key_decisions: [{ d: 'ok' }],
+      });
+
+      const cached = sm.pendingHandoffsCache.get('h-new');
+      expect(cached.vp_agent_id).toBe('vp-1');
+      expect(cached.from_stage).toBe(5);
+      expect(cached.to_stage).toBe(6);
+      expect(cached.status).toBe('pending');
+    });
+
+    it('should return rejected on RPC failure', async () => {
+      await sm.initialize();
+
+      validateHandoffPackage.mockReturnValue({ valid: true, errors: [] });
+      mockSb.rpc.mockResolvedValue({ data: null, error: { message: 'RPC timeout' } });
+
+      const result = await sm.proposeHandoff({
+        vpAgentId: 'vp-1',
+        fromStage: 5,
+        artifacts: [{ type: 'a', content: 'c' }],
+        key_decisions: [{ d: 'ok' }],
+      });
+
+      expect(result.accepted).toBe(false);
+      expect(result.errors[0]).toContain('Database persistence failed');
+    });
+
+    it('should auto-initialize when not initialized', async () => {
+      validateHandoffPackage.mockReturnValue({ valid: false, errors: ['test'] });
+
+      expect(sm._initialized).toBe(false);
+      await sm.proposeHandoff({ vpAgentId: 'vp', fromStage: 5 });
+      expect(sm._initialized).toBe(true);
+    });
+  });
+
+  describe('commitStageTransition', () => {
+    it('should throw on unauthorized CEO', async () => {
+      await sm.initialize();
+      verifyCeoAuthority.mockResolvedValue(false);
+
+      await expect(sm.commitStageTransition({
+        handoffId: 'h-1',
+        ceoAgentId: 'fake-ceo',
+        decision: 'approve',
+      })).rejects.toThrow('UNAUTHORIZED');
+    });
+
+    it('should delegate approve to approveHandoff', async () => {
+      await sm.initialize();
+      verifyCeoAuthority.mockResolvedValue(true);
+      approveHandoff.mockResolvedValue({ success: true, new_stage: 6 });
+
+      const result = await sm.commitStageTransition({
+        handoffId: 'h-1',
+        ceoAgentId: 'ceo-1',
+        decision: 'approve',
+        ceo_notes: 'Good work',
+      });
+
+      expect(approveHandoff).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+
+    it('should delegate reject to rejectHandoff', async () => {
+      await sm.initialize();
+      verifyCeoAuthority.mockResolvedValue(true);
+      rejectHandoff.mockResolvedValue({ success: true, status: 'rejected' });
+
+      const result = await sm.commitStageTransition({
+        handoffId: 'h-1',
+        ceoAgentId: 'ceo-1',
+        decision: 'reject',
+        ceo_notes: 'Needs more work',
+      });
+
+      expect(rejectHandoff).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+
+    it('should delegate request_changes to requestChanges', async () => {
+      await sm.initialize();
+      verifyCeoAuthority.mockResolvedValue(true);
+      requestChanges.mockResolvedValue({ success: true, status: 'changes_requested' });
+
+      const result = await sm.commitStageTransition({
+        handoffId: 'h-1',
+        ceoAgentId: 'ceo-1',
+        decision: 'request_changes',
+        ceo_notes: 'Fix artifact quality',
+      });
+
+      expect(requestChanges).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+    });
+
+    it('should throw on invalid decision', async () => {
+      await sm.initialize();
+      verifyCeoAuthority.mockResolvedValue(true);
+
+      await expect(sm.commitStageTransition({
+        handoffId: 'h-1',
+        ceoAgentId: 'ceo-1',
+        decision: 'invalid_decision',
+      })).rejects.toThrow('Invalid decision: invalid_decision');
+    });
+
+    it('should throw when handoff not found in cache or DB', async () => {
+      await sm.initialize();
+      sm.pendingHandoffsCache.clear();
+      verifyCeoAuthority.mockResolvedValue(true);
+
+      // pending_ceo_handoffs query returns not found
+      mockSb.from = vi.fn((table) => {
+        if (table === 'ventures') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'v-1', current_lifecycle_stage: 5 },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'pending_ceo_handoffs') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } }),
+              }),
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      });
+
+      await expect(sm.commitStageTransition({
+        handoffId: 'nonexistent',
+        ceoAgentId: 'ceo-1',
+        decision: 'approve',
+      })).rejects.toThrow('not found or already processed');
+    });
+
+    it('should pass context with updateLocalState and cache helpers to handlers', async () => {
+      await sm.initialize();
+      verifyCeoAuthority.mockResolvedValue(true);
+      approveHandoff.mockResolvedValue({ success: true });
+
+      await sm.commitStageTransition({
+        handoffId: 'h-1',
+        ceoAgentId: 'ceo-1',
+        decision: 'approve',
+      });
+
+      // Verify context was passed with required functions
+      const context = approveHandoff.mock.calls[0][0];
+      expect(context.supabase).toBe(mockSb);
+      expect(context.ventureId).toBe('v-1');
+      expect(typeof context.verifyStateFreshness).toBe('function');
+      expect(typeof context.updateLocalState).toBe('function');
+    });
+  });
+
+  describe('getPendingHandoffs', () => {
+    it('should return handoffs from RPC', async () => {
+      const handoffs = [{ id: 'h-1', from_stage: 5 }];
+      mockSb.rpc.mockResolvedValue({ data: handoffs, error: null });
+
+      const result = await sm.getPendingHandoffs();
+      expect(result).toEqual(handoffs);
+    });
+
+    it('should fall back to cache on RPC error', async () => {
+      await sm.initialize();
+      mockSb.rpc.mockResolvedValue({ data: null, error: { message: 'RPC error' } });
+
+      const result = await sm.getPendingHandoffs();
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('h-1');
+    });
+
+    it('should return empty array when RPC returns null data and no cache', async () => {
+      mockSb.rpc.mockResolvedValue({ data: null, error: null });
+
+      const result = await sm.getPendingHandoffs();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('error class exports', () => {
+    it('should export StateStalenessError with correct properties', () => {
+      const err = new StateStalenessError('test', { cachedStage: 1, dbStage: 2, ventureId: 'v-1' });
+      expect(err.name).toBe('StateStalenessError');
+      expect(err.isRetryable).toBe(true);
+      expect(err.cachedStage).toBe(1);
+      expect(err.dbStage).toBe(2);
+      expect(err.ventureId).toBe('v-1');
+      expect(err.message).toBe('test');
+    });
+
+    it('should export GoldenNuggetValidationError', () => {
+      const err = new GoldenNuggetValidationError('bad artifacts', { passed: false });
+      expect(err.name).toBe('GoldenNuggetValidationError');
+      expect(err.validationResults.passed).toBe(false);
+    });
+
+    it('should export StageGateValidationError', () => {
+      const err = new StageGateValidationError('gate failed', { gate_name: 'Revenue Gate' });
+      expect(err.name).toBe('StageGateValidationError');
+      expect(err.gateResults.gate_name).toBe('Revenue Gate');
+    });
+  });
+
+  describe('getStageRequirements', () => {
+    it('should delegate to handoff-operations module', () => {
+      const result = sm.getStageRequirements(5);
+      expect(result).toEqual({ artifacts: [], quality_gates: [] });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Enhanced `venture-context-manager.test.js` from 12 to 34 tests (caching, error paths, factory function)
- Enhanced `chairman-preference-store.test.js` from 17 to 35 tests (validation, scoped resolution, upsert)
- Created `venture-state-machine.test.js` with 35 tests (initialization, staleness detection, handoff delegation)
- Total: 104 unit tests covering 3 core Eva service modules

## Context
Part of SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-D (GAP-004: untested service modules).
These modules had zero or minimal test coverage despite being critical Eva orchestrator components.

## Test plan
- [x] All 104 tests pass via `npx vitest run tests/unit/eva/`
- [x] Full suite (17,544 tests) passes
- [x] Pre-commit hooks pass (smoke, ESLint, secret scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)