### PR TITLE
fix(SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-A): fix sub-agent orchestration gate query

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/sub-agent-orchestration.js
@@ -33,7 +33,7 @@ export function createSubAgentOrchestrationGate(supabase) {
       // Query database for SD type validation profile
       const { data: validationProfile } = await supabase
         .from('sd_type_validation_profiles')
-        .select('requires_sub_agents, validation_requirements')
+        .select('requires_sub_agents')
         .eq('sd_type', sdType)
         .single();
 


### PR DESCRIPTION
## Summary
- Remove non-existent `validation_requirements` column from EXEC-TO-PLAN sub-agent-orchestration gate query
- The query against `sd_type_validation_profiles` failed silently, bypassing the `requires_sub_agents` check
- Also added `enhancement` type to `sd_type_validation_profiles` (database change)

## Test plan
- [x] Smoke tests: 345/345 passing
- [x] EXEC-TO-PLAN handoff now correctly skips sub-agent orchestration for enhancement SDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)