### PR TITLE
feat: add orchestrator state machine for Eva venture processing

### DIFF
--- a/database/migrations/20260208_eva_orchestrator_state.sql
+++ b/database/migrations/20260208_eva_orchestrator_state.sql
@@ -1,0 +1,26 @@
+-- Eva Orchestrator State Machine - Formalized Execution States
+-- SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-G
+--
+-- Adds orchestrator_state column to eva_ventures to prevent concurrent
+-- processStage() calls for the same venture via atomic state transitions.
+
+-- Add orchestrator state columns
+ALTER TABLE eva_ventures
+  ADD COLUMN IF NOT EXISTS orchestrator_state TEXT DEFAULT 'idle'
+    CHECK (orchestrator_state IN ('idle', 'processing', 'blocked', 'failed')),
+  ADD COLUMN IF NOT EXISTS orchestrator_lock_id UUID,
+  ADD COLUMN IF NOT EXISTS orchestrator_lock_acquired_at TIMESTAMPTZ;
+
+-- Index for lock queries (find ventures in processing state)
+CREATE INDEX IF NOT EXISTS idx_eva_ventures_orchestrator_state
+  ON eva_ventures(orchestrator_state)
+  WHERE orchestrator_state = 'processing';
+
+-- Partial index for lock safety (ensure only one lock per venture)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_eva_ventures_orchestrator_lock
+  ON eva_ventures(id)
+  WHERE orchestrator_lock_id IS NOT NULL;
+
+COMMENT ON COLUMN eva_ventures.orchestrator_state IS 'Current execution state: idle, processing, blocked, failed';
+COMMENT ON COLUMN eva_ventures.orchestrator_lock_id IS 'UUID of the processing lock holder (null when idle)';
+COMMENT ON COLUMN eva_ventures.orchestrator_lock_acquired_at IS 'When the processing lock was acquired';

--- a/lib/eva/index.js
+++ b/lib/eva/index.js
@@ -10,6 +10,7 @@ export { ChairmanPreferenceStore, createChairmanPreferenceStore } from './chairm
 export { processStage, run } from './eva-orchestrator.js';
 export { OrchestratorTracer, createOrchestratorTracer } from './observability.js';
 export { SagaCoordinator, createSagaCoordinator, createArtifactCompensation, createStageCompensation } from './saga-coordinator.js';
+export { ORCHESTRATOR_STATES, VALID_TRANSITIONS, validateStateTransition, acquireProcessingLock, releaseProcessingLock, getOrchestratorState } from './orchestrator-state-machine.js';
 export { getDevilsAdvocateReview, isDevilsAdvocateGate, buildArtifactRecord } from './devils-advocate.js';
 export { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-bridge.js';
 export { detectConstraintDrift, buildFilterEnginePayload } from './constraint-drift-detector.js';

--- a/lib/eva/orchestrator-state-machine.js
+++ b/lib/eva/orchestrator-state-machine.js
@@ -1,0 +1,238 @@
+/**
+ * Orchestrator State Machine - Formalized Execution States
+ *
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-G
+ *
+ * Formalizes orchestrator execution states (idle/processing/blocked/failed)
+ * which were previously implicit. Prevents concurrent processStage() calls
+ * for the same venture via atomic state transitions.
+ *
+ * @module lib/eva/orchestrator-state-machine
+ */
+
+import { randomUUID } from 'crypto';
+
+// ── Constants ───────────────────────────────────────────────
+
+export const MODULE_VERSION = '1.0.0';
+
+export const ORCHESTRATOR_STATES = Object.freeze({
+  IDLE: 'idle',
+  PROCESSING: 'processing',
+  BLOCKED: 'blocked',
+  FAILED: 'failed',
+});
+
+/**
+ * Valid state transitions. Each key maps to an array of allowed target states.
+ */
+export const VALID_TRANSITIONS = Object.freeze({
+  [ORCHESTRATOR_STATES.IDLE]: [ORCHESTRATOR_STATES.PROCESSING],
+  [ORCHESTRATOR_STATES.PROCESSING]: [
+    ORCHESTRATOR_STATES.IDLE,
+    ORCHESTRATOR_STATES.BLOCKED,
+    ORCHESTRATOR_STATES.FAILED,
+  ],
+  [ORCHESTRATOR_STATES.BLOCKED]: [
+    ORCHESTRATOR_STATES.IDLE,
+    ORCHESTRATOR_STATES.PROCESSING,
+  ],
+  [ORCHESTRATOR_STATES.FAILED]: [
+    ORCHESTRATOR_STATES.IDLE,
+    ORCHESTRATOR_STATES.PROCESSING,
+  ],
+});
+
+// ── Validation ──────────────────────────────────────────────
+
+/**
+ * Validate whether a state transition is allowed.
+ *
+ * @param {string} from - Current state
+ * @param {string} to - Target state
+ * @returns {{ valid: boolean, error?: string }}
+ */
+export function validateStateTransition(from, to) {
+  const allStates = Object.values(ORCHESTRATOR_STATES);
+
+  if (!allStates.includes(from)) {
+    return { valid: false, error: `Unknown state: ${from}` };
+  }
+  if (!allStates.includes(to)) {
+    return { valid: false, error: `Unknown state: ${to}` };
+  }
+  if (from === to) {
+    return { valid: false, error: `Cannot transition to same state: ${from}` };
+  }
+
+  const allowed = VALID_TRANSITIONS[from] || [];
+  if (!allowed.includes(to)) {
+    return { valid: false, error: `Invalid transition: ${from} → ${to}` };
+  }
+
+  return { valid: true };
+}
+
+// ── Lock Operations ─────────────────────────────────────────
+
+/**
+ * Acquire a processing lock for a venture.
+ * Atomically transitions idle → processing. Returns false if venture is
+ * not in idle state (already being processed).
+ *
+ * @param {Object} db - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} [options]
+ * @param {string} [options.correlationId] - Correlation ID for audit
+ * @param {Object} [options.logger] - Logger
+ * @returns {Promise<{ acquired: boolean, lockId?: string, error?: string, previousState?: string }>}
+ */
+export async function acquireProcessingLock(db, ventureId, options = {}) {
+  const { correlationId, logger = console } = options;
+
+  if (!db || !ventureId) {
+    return { acquired: false, error: 'Missing db client or ventureId' };
+  }
+
+  const lockId = randomUUID();
+
+  try {
+    // Atomic conditional update: only succeed if current state is idle
+    const { data, error } = await db
+      .from('eva_ventures')
+      .update({
+        orchestrator_state: ORCHESTRATOR_STATES.PROCESSING,
+        orchestrator_lock_id: lockId,
+        orchestrator_lock_acquired_at: new Date().toISOString(),
+      })
+      .eq('id', ventureId)
+      .eq('orchestrator_state', ORCHESTRATOR_STATES.IDLE)
+      .select('id, orchestrator_state')
+      .single();
+
+    if (error || !data) {
+      // Check current state for diagnostics
+      const { data: current } = await db
+        .from('eva_ventures')
+        .select('orchestrator_state')
+        .eq('id', ventureId)
+        .single();
+
+      const currentState = current?.orchestrator_state || 'unknown';
+      logger.warn(`[StateMachine] Lock denied for ${ventureId}: state=${currentState}, correlationId=${correlationId}`);
+
+      return {
+        acquired: false,
+        error: `CONCURRENT_EXECUTION`,
+        previousState: currentState,
+      };
+    }
+
+    logger.log(`[StateMachine] Lock acquired for ${ventureId}: lockId=${lockId}`);
+    return { acquired: true, lockId };
+  } catch (err) {
+    logger.error(`[StateMachine] Lock acquisition error: ${err.message}`);
+    return { acquired: false, error: err.message };
+  }
+}
+
+/**
+ * Release a processing lock, transitioning back to idle (or to a specified state).
+ *
+ * @param {Object} db - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} [options]
+ * @param {string} [options.lockId] - Expected lock ID (safety check)
+ * @param {string} [options.targetState] - State to transition to (default: idle)
+ * @param {Object} [options.logger] - Logger
+ * @returns {Promise<{ released: boolean, newState?: string, error?: string }>}
+ */
+export async function releaseProcessingLock(db, ventureId, options = {}) {
+  const {
+    lockId,
+    targetState = ORCHESTRATOR_STATES.IDLE,
+    logger = console,
+  } = options;
+
+  if (!db || !ventureId) {
+    return { released: false, error: 'Missing db client or ventureId' };
+  }
+
+  // Validate target state transition
+  const validation = validateStateTransition(ORCHESTRATOR_STATES.PROCESSING, targetState);
+  if (!validation.valid) {
+    return { released: false, error: validation.error };
+  }
+
+  try {
+    let query = db
+      .from('eva_ventures')
+      .update({
+        orchestrator_state: targetState,
+        orchestrator_lock_id: null,
+        orchestrator_lock_acquired_at: null,
+      })
+      .eq('id', ventureId)
+      .eq('orchestrator_state', ORCHESTRATOR_STATES.PROCESSING);
+
+    // If lockId provided, also verify it matches (prevents stale releases)
+    if (lockId) {
+      query = query.eq('orchestrator_lock_id', lockId);
+    }
+
+    const { data, error } = await query
+      .select('id, orchestrator_state')
+      .single();
+
+    if (error || !data) {
+      logger.warn(`[StateMachine] Lock release failed for ${ventureId}: lockId=${lockId}`);
+      return { released: false, error: 'Lock release failed - state or lockId mismatch' };
+    }
+
+    logger.log(`[StateMachine] Lock released for ${ventureId}: newState=${targetState}`);
+    return { released: true, newState: targetState };
+  } catch (err) {
+    logger.error(`[StateMachine] Lock release error: ${err.message}`);
+    return { released: false, error: err.message };
+  }
+}
+
+/**
+ * Get the current orchestrator state for a venture.
+ *
+ * @param {Object} db - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @returns {Promise<{ state: string, lockId?: string, lockAcquiredAt?: string, error?: string }>}
+ */
+export async function getOrchestratorState(db, ventureId) {
+  if (!db || !ventureId) {
+    return { state: ORCHESTRATOR_STATES.IDLE, error: 'Missing db client or ventureId' };
+  }
+
+  try {
+    const { data, error } = await db
+      .from('eva_ventures')
+      .select('orchestrator_state, orchestrator_lock_id, orchestrator_lock_acquired_at')
+      .eq('id', ventureId)
+      .single();
+
+    if (error || !data) {
+      return { state: ORCHESTRATOR_STATES.IDLE, error: error?.message || 'Venture not found' };
+    }
+
+    return {
+      state: data.orchestrator_state || ORCHESTRATOR_STATES.IDLE,
+      lockId: data.orchestrator_lock_id,
+      lockAcquiredAt: data.orchestrator_lock_acquired_at,
+    };
+  } catch (err) {
+    return { state: ORCHESTRATOR_STATES.IDLE, error: err.message };
+  }
+}
+
+// ── Exported for testing ────────────────────────────────────
+
+export const _internal = {
+  ORCHESTRATOR_STATES,
+  VALID_TRANSITIONS,
+};

--- a/tests/unit/eva/orchestrator-state-machine.test.js
+++ b/tests/unit/eva/orchestrator-state-machine.test.js
@@ -1,0 +1,481 @@
+/**
+ * Tests for Orchestrator State Machine
+ * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-G
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ORCHESTRATOR_STATES,
+  VALID_TRANSITIONS,
+  validateStateTransition,
+  acquireProcessingLock,
+  releaseProcessingLock,
+  getOrchestratorState,
+  MODULE_VERSION,
+  _internal,
+} from '../../../lib/eva/orchestrator-state-machine.js';
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+describe('ORCHESTRATOR_STATES', () => {
+  it('should have exactly 4 states', () => {
+    expect(Object.keys(ORCHESTRATOR_STATES)).toHaveLength(4);
+  });
+
+  it('should contain idle, processing, blocked, failed', () => {
+    expect(ORCHESTRATOR_STATES.IDLE).toBe('idle');
+    expect(ORCHESTRATOR_STATES.PROCESSING).toBe('processing');
+    expect(ORCHESTRATOR_STATES.BLOCKED).toBe('blocked');
+    expect(ORCHESTRATOR_STATES.FAILED).toBe('failed');
+  });
+
+  it('should be frozen', () => {
+    expect(Object.isFrozen(ORCHESTRATOR_STATES)).toBe(true);
+  });
+});
+
+describe('VALID_TRANSITIONS', () => {
+  it('should allow idle → processing', () => {
+    expect(VALID_TRANSITIONS[ORCHESTRATOR_STATES.IDLE]).toContain(ORCHESTRATOR_STATES.PROCESSING);
+  });
+
+  it('should allow processing → idle, blocked, failed', () => {
+    const targets = VALID_TRANSITIONS[ORCHESTRATOR_STATES.PROCESSING];
+    expect(targets).toContain(ORCHESTRATOR_STATES.IDLE);
+    expect(targets).toContain(ORCHESTRATOR_STATES.BLOCKED);
+    expect(targets).toContain(ORCHESTRATOR_STATES.FAILED);
+  });
+
+  it('should allow blocked → idle, processing', () => {
+    const targets = VALID_TRANSITIONS[ORCHESTRATOR_STATES.BLOCKED];
+    expect(targets).toContain(ORCHESTRATOR_STATES.IDLE);
+    expect(targets).toContain(ORCHESTRATOR_STATES.PROCESSING);
+  });
+
+  it('should allow failed → idle, processing', () => {
+    const targets = VALID_TRANSITIONS[ORCHESTRATOR_STATES.FAILED];
+    expect(targets).toContain(ORCHESTRATOR_STATES.IDLE);
+    expect(targets).toContain(ORCHESTRATOR_STATES.PROCESSING);
+  });
+
+  it('should NOT allow idle → blocked directly', () => {
+    expect(VALID_TRANSITIONS[ORCHESTRATOR_STATES.IDLE]).not.toContain(ORCHESTRATOR_STATES.BLOCKED);
+  });
+
+  it('should NOT allow idle → failed directly', () => {
+    expect(VALID_TRANSITIONS[ORCHESTRATOR_STATES.IDLE]).not.toContain(ORCHESTRATOR_STATES.FAILED);
+  });
+
+  it('should be frozen', () => {
+    expect(Object.isFrozen(VALID_TRANSITIONS)).toBe(true);
+  });
+});
+
+describe('validateStateTransition', () => {
+  it('should accept valid transition idle → processing', () => {
+    const result = validateStateTransition('idle', 'processing');
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('should accept valid transition processing → idle', () => {
+    const result = validateStateTransition('processing', 'idle');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept valid transition processing → blocked', () => {
+    const result = validateStateTransition('processing', 'blocked');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept valid transition processing → failed', () => {
+    const result = validateStateTransition('processing', 'failed');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept valid transition blocked → processing (retry)', () => {
+    const result = validateStateTransition('blocked', 'processing');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should accept valid transition failed → idle (reset)', () => {
+    const result = validateStateTransition('failed', 'idle');
+    expect(result.valid).toBe(true);
+  });
+
+  it('should reject invalid transition idle → blocked', () => {
+    const result = validateStateTransition('idle', 'blocked');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Invalid transition');
+  });
+
+  it('should reject invalid transition idle → failed', () => {
+    const result = validateStateTransition('idle', 'failed');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Invalid transition');
+  });
+
+  it('should reject same-state transition', () => {
+    const result = validateStateTransition('idle', 'idle');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Cannot transition to same state');
+  });
+
+  it('should reject unknown source state', () => {
+    const result = validateStateTransition('unknown', 'idle');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unknown state');
+  });
+
+  it('should reject unknown target state', () => {
+    const result = validateStateTransition('idle', 'unknown');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('Unknown state');
+  });
+});
+
+describe('acquireProcessingLock', () => {
+  let mockDb;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should acquire lock when venture is idle', async () => {
+    mockDb = {
+      from: vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'venture-1', orchestrator_state: 'processing' },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await acquireProcessingLock(mockDb, 'venture-1', { logger: silentLogger });
+    expect(result.acquired).toBe(true);
+    expect(result.lockId).toBeDefined();
+    expect(result.lockId).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('should reject lock when venture is already processing', async () => {
+    mockDb = {
+      from: vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: null,
+                  error: { message: 'No rows' },
+                }),
+              }),
+            }),
+          }),
+        }),
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { orchestrator_state: 'processing' },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await acquireProcessingLock(mockDb, 'venture-1', { logger: silentLogger });
+    expect(result.acquired).toBe(false);
+    expect(result.error).toBe('CONCURRENT_EXECUTION');
+    expect(result.previousState).toBe('processing');
+  });
+
+  it('should return error when no db client', async () => {
+    const result = await acquireProcessingLock(null, 'venture-1', { logger: silentLogger });
+    expect(result.acquired).toBe(false);
+    expect(result.error).toContain('Missing');
+  });
+
+  it('should return error when no ventureId', async () => {
+    const result = await acquireProcessingLock({}, null, { logger: silentLogger });
+    expect(result.acquired).toBe(false);
+    expect(result.error).toContain('Missing');
+  });
+
+  it('should handle thrown exceptions', async () => {
+    mockDb = {
+      from: vi.fn().mockImplementation(() => { throw new Error('Connection lost'); }),
+    };
+
+    const result = await acquireProcessingLock(mockDb, 'venture-1', { logger: silentLogger });
+    expect(result.acquired).toBe(false);
+    expect(result.error).toBe('Connection lost');
+  });
+});
+
+describe('releaseProcessingLock', () => {
+  let mockDb;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should release lock and transition to idle', async () => {
+    mockDb = {
+      from: vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'venture-1', orchestrator_state: 'idle' },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await releaseProcessingLock(mockDb, 'venture-1', { logger: silentLogger });
+    expect(result.released).toBe(true);
+    expect(result.newState).toBe('idle');
+  });
+
+  it('should release lock with specific lockId', async () => {
+    mockDb = {
+      from: vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({
+                    data: { id: 'venture-1', orchestrator_state: 'idle' },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await releaseProcessingLock(mockDb, 'venture-1', {
+      lockId: 'lock-123',
+      logger: silentLogger,
+    });
+    expect(result.released).toBe(true);
+  });
+
+  it('should transition to blocked state', async () => {
+    mockDb = {
+      from: vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'venture-1', orchestrator_state: 'blocked' },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await releaseProcessingLock(mockDb, 'venture-1', {
+      targetState: 'blocked',
+      logger: silentLogger,
+    });
+    expect(result.released).toBe(true);
+    expect(result.newState).toBe('blocked');
+  });
+
+  it('should transition to failed state', async () => {
+    mockDb = {
+      from: vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { id: 'venture-1', orchestrator_state: 'failed' },
+                  error: null,
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await releaseProcessingLock(mockDb, 'venture-1', {
+      targetState: 'failed',
+      logger: silentLogger,
+    });
+    expect(result.released).toBe(true);
+    expect(result.newState).toBe('failed');
+  });
+
+  it('should reject invalid target state from processing', async () => {
+    const result = await releaseProcessingLock({}, 'venture-1', {
+      targetState: 'processing',
+      logger: silentLogger,
+    });
+    expect(result.released).toBe(false);
+    expect(result.error).toContain('Cannot transition to same state');
+  });
+
+  it('should fail when lock mismatch', async () => {
+    mockDb = {
+      from: vi.fn().mockReturnValue({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                select: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({
+                    data: null,
+                    error: { message: 'No rows' },
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await releaseProcessingLock(mockDb, 'venture-1', {
+      lockId: 'wrong-lock',
+      logger: silentLogger,
+    });
+    expect(result.released).toBe(false);
+    expect(result.error).toContain('Lock release failed');
+  });
+
+  it('should return error when no db client', async () => {
+    const result = await releaseProcessingLock(null, 'venture-1', { logger: silentLogger });
+    expect(result.released).toBe(false);
+    expect(result.error).toContain('Missing');
+  });
+
+  it('should handle thrown exceptions', async () => {
+    mockDb = {
+      from: vi.fn().mockImplementation(() => { throw new Error('DB error'); }),
+    };
+
+    const result = await releaseProcessingLock(mockDb, 'venture-1', { logger: silentLogger });
+    expect(result.released).toBe(false);
+    expect(result.error).toBe('DB error');
+  });
+});
+
+describe('getOrchestratorState', () => {
+  it('should return current state', async () => {
+    const mockDb = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: {
+                orchestrator_state: 'processing',
+                orchestrator_lock_id: 'lock-1',
+                orchestrator_lock_acquired_at: '2026-02-08T12:00:00Z',
+              },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await getOrchestratorState(mockDb, 'venture-1');
+    expect(result.state).toBe('processing');
+    expect(result.lockId).toBe('lock-1');
+    expect(result.lockAcquiredAt).toBe('2026-02-08T12:00:00Z');
+  });
+
+  it('should default to idle when state is null', async () => {
+    const mockDb = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: {
+                orchestrator_state: null,
+                orchestrator_lock_id: null,
+                orchestrator_lock_acquired_at: null,
+              },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await getOrchestratorState(mockDb, 'venture-1');
+    expect(result.state).toBe('idle');
+  });
+
+  it('should return idle with error when no db', async () => {
+    const result = await getOrchestratorState(null, 'venture-1');
+    expect(result.state).toBe('idle');
+    expect(result.error).toContain('Missing');
+  });
+
+  it('should return idle with error when venture not found', async () => {
+    const mockDb = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'Not found' },
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await getOrchestratorState(mockDb, 'venture-1');
+    expect(result.state).toBe('idle');
+    expect(result.error).toBe('Not found');
+  });
+
+  it('should handle thrown exceptions', async () => {
+    const mockDb = {
+      from: vi.fn().mockImplementation(() => { throw new Error('Boom'); }),
+    };
+
+    const result = await getOrchestratorState(mockDb, 'venture-1');
+    expect(result.state).toBe('idle');
+    expect(result.error).toBe('Boom');
+  });
+});
+
+describe('exports', () => {
+  it('should export MODULE_VERSION', () => {
+    expect(MODULE_VERSION).toBe('1.0.0');
+  });
+
+  it('should export _internal with ORCHESTRATOR_STATES', () => {
+    expect(_internal.ORCHESTRATOR_STATES).toBe(ORCHESTRATOR_STATES);
+  });
+
+  it('should export _internal with VALID_TRANSITIONS', () => {
+    expect(_internal.VALID_TRANSITIONS).toBe(VALID_TRANSITIONS);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements formalized execution states for Eva Orchestrator (SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-G)
- `ORCHESTRATOR_STATES` enum: idle, processing, blocked, failed
- `VALID_TRANSITIONS` map with enforced state transition rules
- `acquireProcessingLock()` / `releaseProcessingLock()` for atomic concurrency control
- Migration adds `orchestrator_state` column to `eva_ventures` with partial unique index
- 42 unit tests covering all states, transitions, lock operations, and edge cases
- **Completes all 7 children of orchestrator SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002**

## Test plan
- [x] All 42 orchestrator-state-machine tests pass
- [x] All 21,657 Eva tests pass (zero regressions)
- [x] Migration executed successfully on Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)