### PR TITLE
feat(SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-E): add integration test requirement gate

### DIFF
--- a/database/migrations/20260209_register_integration_test_requirement_gate.sql
+++ b/database/migrations/20260209_register_integration_test_requirement_gate.sql
@@ -1,0 +1,24 @@
+-- Migration: Register GATE_INTEGRATION_TEST_REQUIREMENT in validation_gate_registry
+-- SD: SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-E
+-- Date: 2026-02-09
+--
+-- This gate checks for integration tests in tests/integration/ for complex SDs.
+-- BLOCKING (REQUIRED) for feature/refactor with story_points >= 5.
+-- ADVISORY (OPTIONAL) for other complex SDs.
+
+INSERT INTO validation_gate_registry (gate_key, sd_type, applicability, reason)
+VALUES
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'feature', 'REQUIRED', 'Feature SDs with SP>=5 require integration tests (BLOCKING)'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'refactor', 'REQUIRED', 'Refactor SDs with SP>=5 require integration tests (BLOCKING)'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'bugfix', 'OPTIONAL', 'Advisory integration test check for complex bugfix SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'security', 'OPTIONAL', 'Advisory integration test check for complex security SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'infrastructure', 'OPTIONAL', 'Advisory integration test check for complex infrastructure SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'enhancement', 'OPTIONAL', 'Advisory integration test check for complex enhancement SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'orchestrator', 'OPTIONAL', 'Advisory integration test check for complex orchestrator SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'uat', 'OPTIONAL', 'Advisory integration test check for complex UAT SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'database', 'OPTIONAL', 'Advisory integration test check for complex database SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'documentation', 'OPTIONAL', 'Advisory integration test check for complex documentation SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'docs', 'OPTIONAL', 'Advisory integration test check for complex docs SDs'),
+  ('GATE_INTEGRATION_TEST_REQUIREMENT', 'process', 'OPTIONAL', 'Advisory integration test check for complex process SDs')
+ON CONFLICT (gate_key, COALESCE(sd_type, '*'), COALESCE(validation_profile, '*'))
+DO NOTHING;

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/index.js
@@ -17,3 +17,4 @@ export { createSubAgentEnforcementValidationGate } from './subagent-enforcement-
 export { createLOCThresholdValidationGate } from './loc-threshold-validation.js';
 export { createPerformanceCriticalGate } from './performance-critical-gate.js';
 export { createTestCoverageQualityGate } from './test-coverage-quality.js';
+export { createIntegrationTestRequirementGate } from './integration-test-requirement.js';

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js
@@ -1,0 +1,469 @@
+/**
+ * Integration Test Requirement Gate for EXEC-TO-PLAN
+ * Part of SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-E
+ *
+ * For complex SDs (story_points >= 5 OR has_children OR modifies 3+ modules),
+ * checks for integration test files in tests/integration/.
+ *
+ * BLOCKING for feature/refactor with SP >= 5.
+ * NON-BLOCKING (advisory) for other complex SDs.
+ *
+ * Fixes GAP-003 (zero integration tests).
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync, realpathSync } from 'fs';
+import { resolve, relative, extname } from 'path';
+import { execSync } from 'child_process';
+
+/**
+ * Valid integration test file extensions
+ */
+const TEST_FILE_EXTENSIONS = new Set(['.js', '.ts', '.mjs', '.cjs']);
+
+/**
+ * Minimum number of lines containing `test(` across all integration test files
+ * to be considered non-trivial.
+ */
+const MIN_TEST_CALL_COUNT = 10;
+
+/**
+ * SD types where missing integration tests are BLOCKING when SP >= 5.
+ */
+const BLOCKING_SD_TYPES = new Set(['feature', 'refactor']);
+
+/**
+ * Determine if an SD is "complex" based on the criteria:
+ * - story_points >= 5
+ * - has children (parent_sd_id is referenced by other SDs)
+ * - modifies 3+ modules
+ *
+ * @param {Object} sd - Strategic directive object
+ * @param {Object} options - Additional context
+ * @returns {{ isComplex: boolean, reasons: string[] }}
+ */
+function classifyComplexity(sd, options = {}) {
+  const reasons = [];
+  const storyPoints = sd.story_points || sd.metadata?.story_points || 0;
+  const hasChildren = !!(options.hasChildren || sd.has_children);
+
+  // Count modified modules from git diff
+  const modifiedModulesCount = options.modifiedModulesCount !== undefined
+    ? options.modifiedModulesCount
+    : countModifiedModules();
+
+  if (storyPoints >= 5) {
+    reasons.push(`story_points=${storyPoints} (>= 5)`);
+  }
+  if (hasChildren) {
+    reasons.push('SD has child SDs');
+  }
+  if (modifiedModulesCount >= 3) {
+    reasons.push(`modified_modules=${modifiedModulesCount} (>= 3)`);
+  }
+
+  return {
+    isComplex: reasons.length > 0,
+    reasons,
+    storyPoints,
+    hasChildren,
+    modifiedModulesCount
+  };
+}
+
+/**
+ * Count distinct top-level modules modified in the current branch.
+ * A "module" is the first path segment (e.g., "scripts/", "lib/", "tests/").
+ *
+ * @returns {number} Number of distinct modified modules
+ */
+function countModifiedModules() {
+  try {
+    const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf8', timeout: 10000
+    }).trim();
+
+    let diffOutput;
+    if (currentBranch === 'main' || currentBranch === 'master') {
+      diffOutput = execSync('git diff --name-only HEAD', {
+        encoding: 'utf8', timeout: 10000
+      });
+    } else {
+      diffOutput = execSync('git diff --name-only main...HEAD', {
+        encoding: 'utf8', timeout: 10000
+      });
+    }
+
+    const files = diffOutput.split('\n').map(f => f.trim()).filter(Boolean);
+    const modules = new Set();
+    for (const file of files) {
+      const firstSegment = file.split('/')[0];
+      if (firstSegment) modules.add(firstSegment);
+    }
+    return modules.size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Recursively find integration test files under a directory.
+ * Does NOT follow symlinks outside the repo root (security).
+ *
+ * @param {string} dir - Directory to scan
+ * @param {string} repoRoot - Repository root for symlink boundary check
+ * @returns {string[]} Array of absolute file paths
+ */
+function findIntegrationTestFiles(dir, repoRoot) {
+  const files = [];
+
+  if (!existsSync(dir)) return files;
+
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+
+  for (const entry of entries) {
+    const fullPath = resolve(dir, entry.name);
+
+    // Security: check for symlinks escaping repo root
+    if (entry.isSymbolicLink()) {
+      try {
+        const realPath = realpathSync(fullPath);
+        const rel = relative(repoRoot, realPath);
+        if (rel.startsWith('..') || rel.startsWith('/') || /^[a-zA-Z]:/.test(rel)) {
+          console.log(`   ⚠️  Skipping symlink escaping repo: ${entry.name} → ${realPath}`);
+          continue;
+        }
+      } catch {
+        console.log(`   ⚠️  Skipping unresolvable symlink: ${entry.name}`);
+        continue;
+      }
+    }
+
+    if (entry.isDirectory() || (entry.isSymbolicLink() && statSync(fullPath).isDirectory())) {
+      files.push(...findIntegrationTestFiles(fullPath, repoRoot));
+    } else if (entry.isFile() || (entry.isSymbolicLink() && statSync(fullPath).isFile())) {
+      const ext = extname(entry.name);
+      if (TEST_FILE_EXTENSIONS.has(ext)) {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Count lines containing `test(` in a set of files.
+ *
+ * @param {string[]} files - Array of absolute file paths
+ * @returns {{ totalTestCalls: number, perFile: Array<{file: string, count: number}> }}
+ */
+function countTestCalls(files) {
+  const perFile = [];
+  let totalTestCalls = 0;
+
+  for (const filePath of files) {
+    try {
+      const content = readFileSync(filePath, 'utf8');
+      const lines = content.split('\n');
+      const count = lines.filter(line => line.includes('test(')).length;
+      perFile.push({ file: filePath, count });
+      totalTestCalls += count;
+    } catch {
+      perFile.push({ file: filePath, count: 0 });
+    }
+  }
+
+  return { totalTestCalls, perFile };
+}
+
+/**
+ * Check if SD has children by querying Supabase.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdId - SD UUID
+ * @returns {Promise<boolean>}
+ */
+async function checkHasChildren(supabase, sdId) {
+  if (!supabase) return false;
+  try {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .eq('parent_sd_id', sdId)
+      .limit(1);
+    return data && data.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create the GATE_INTEGRATION_TEST_REQUIREMENT gate validator.
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Object} Gate configuration { name, validator, required }
+ */
+export function createIntegrationTestRequirementGate(supabase) {
+  return {
+    name: 'GATE_INTEGRATION_TEST_REQUIREMENT',
+
+    validator: async (ctx) => {
+      console.log('\n🧪 GATE: Integration Test Requirement');
+      console.log('-'.repeat(50));
+
+      const sd = ctx.sd || {};
+      const sdType = (sd.sd_type || 'feature').toLowerCase();
+      const sdId = sd.id || sd.sd_key;
+
+      console.log(`   SD Type: ${sdType}`);
+
+      // Check if SD has children
+      const hasChildren = await checkHasChildren(supabase, sdId);
+
+      // Classify complexity
+      const complexity = classifyComplexity(sd, {
+        hasChildren,
+        modifiedModulesCount: undefined // auto-detect from git
+      });
+
+      console.log(`   Complex: ${complexity.isComplex}`);
+      if (complexity.isComplex) {
+        console.log(`   Reasons: ${complexity.reasons.join(', ')}`);
+      }
+
+      // If not complex, gate passes automatically
+      if (!complexity.isComplex) {
+        console.log('   ✅ SD is not complex - integration test check not required');
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: [],
+          details: {
+            status: 'PASS',
+            blocking: false,
+            complexity: complexity,
+            summary: 'SD complexity criteria not met - integration tests not required'
+          }
+        };
+      }
+
+      // Determine enforcement mode
+      const isBlocking = complexity.storyPoints >= 5 && BLOCKING_SD_TYPES.has(sdType);
+      console.log(`   Enforcement: ${isBlocking ? 'BLOCKING' : 'ADVISORY'}`);
+
+      // Scan for integration test files
+      const repoRoot = process.cwd();
+      const integrationDir = resolve(repoRoot, 'tests', 'integration');
+
+      if (!existsSync(integrationDir)) {
+        const message = 'No integration test directory found at tests/integration/. ' +
+          `Complex SDs (${complexity.reasons.join(', ')}) should include integration tests. ` +
+          `Create tests/integration/ and add test files with > ${MIN_TEST_CALL_COUNT} test() calls.`;
+
+        if (isBlocking) {
+          console.log(`   ❌ BLOCKING: ${message}`);
+          return {
+            passed: false,
+            score: 0,
+            max_score: 100,
+            issues: [message],
+            warnings: [],
+            details: {
+              status: 'FAIL',
+              blocking: true,
+              complexity,
+              integration_dir_exists: false,
+              files_found: 0,
+              test_call_count: 0,
+              threshold: MIN_TEST_CALL_COUNT,
+              summary: message
+            }
+          };
+        } else {
+          console.log(`   ⚠️  ADVISORY: ${message}`);
+          return {
+            passed: true,
+            score: 50,
+            max_score: 100,
+            issues: [],
+            warnings: [message],
+            details: {
+              status: 'WARN',
+              blocking: false,
+              complexity,
+              integration_dir_exists: false,
+              files_found: 0,
+              test_call_count: 0,
+              threshold: MIN_TEST_CALL_COUNT,
+              summary: message
+            }
+          };
+        }
+      }
+
+      // Find integration test files
+      const testFiles = findIntegrationTestFiles(integrationDir, repoRoot);
+      console.log(`   📄 Integration test files found: ${testFiles.length}`);
+
+      if (testFiles.length === 0) {
+        const message = 'No integration test files found in tests/integration/ ' +
+          '(expected .js, .ts, .mjs, or .cjs files). ' +
+          `Complex SDs (${complexity.reasons.join(', ')}) should include integration tests with > ${MIN_TEST_CALL_COUNT} test() calls.`;
+
+        if (isBlocking) {
+          console.log(`   ❌ BLOCKING: ${message}`);
+          return {
+            passed: false,
+            score: 0,
+            max_score: 100,
+            issues: [message],
+            warnings: [],
+            details: {
+              status: 'FAIL',
+              blocking: true,
+              complexity,
+              integration_dir_exists: true,
+              files_found: 0,
+              test_call_count: 0,
+              threshold: MIN_TEST_CALL_COUNT,
+              summary: message
+            }
+          };
+        } else {
+          console.log(`   ⚠️  ADVISORY: ${message}`);
+          return {
+            passed: true,
+            score: 50,
+            max_score: 100,
+            issues: [],
+            warnings: [message],
+            details: {
+              status: 'WARN',
+              blocking: false,
+              complexity,
+              integration_dir_exists: true,
+              files_found: 0,
+              test_call_count: 0,
+              threshold: MIN_TEST_CALL_COUNT,
+              summary: message
+            }
+          };
+        }
+      }
+
+      // Count test() calls
+      const { totalTestCalls, perFile } = countTestCalls(testFiles);
+      console.log(`   🧪 Total test() calls: ${totalTestCalls} (threshold: > ${MIN_TEST_CALL_COUNT})`);
+
+      // Log per-file breakdown
+      for (const entry of perFile) {
+        const relPath = relative(repoRoot, entry.file).replace(/\\/g, '/');
+        console.log(`      ${relPath}: ${entry.count} test() calls`);
+      }
+
+      const relFilePaths = testFiles.map(f => relative(repoRoot, f).replace(/\\/g, '/'));
+
+      if (totalTestCalls <= MIN_TEST_CALL_COUNT) {
+        const message = `Integration tests are trivial: ${totalTestCalls} test() calls found ` +
+          `(required: > ${MIN_TEST_CALL_COUNT}). ` +
+          'Add more integration tests in tests/integration/ to meet the threshold.' +
+          (isBlocking ? ' This is BLOCKING for this SD type.' : '');
+
+        if (isBlocking) {
+          console.log(`   ❌ BLOCKING: ${message}`);
+          return {
+            passed: false,
+            score: Math.max(0, Math.round((totalTestCalls / MIN_TEST_CALL_COUNT) * 50)),
+            max_score: 100,
+            issues: [message],
+            warnings: [],
+            details: {
+              status: 'FAIL',
+              blocking: true,
+              complexity,
+              integration_dir_exists: true,
+              files_found: testFiles.length,
+              files: relFilePaths,
+              per_file_counts: perFile.map(e => ({
+                file: relative(repoRoot, e.file).replace(/\\/g, '/'),
+                count: e.count
+              })),
+              test_call_count: totalTestCalls,
+              threshold: MIN_TEST_CALL_COUNT,
+              summary: message
+            }
+          };
+        } else {
+          console.log(`   ⚠️  ADVISORY: ${message}`);
+          return {
+            passed: true,
+            score: 50 + Math.round((totalTestCalls / MIN_TEST_CALL_COUNT) * 25),
+            max_score: 100,
+            issues: [],
+            warnings: [message],
+            details: {
+              status: 'WARN',
+              blocking: false,
+              complexity,
+              integration_dir_exists: true,
+              files_found: testFiles.length,
+              files: relFilePaths,
+              per_file_counts: perFile.map(e => ({
+                file: relative(repoRoot, e.file).replace(/\\/g, '/'),
+                count: e.count
+              })),
+              test_call_count: totalTestCalls,
+              threshold: MIN_TEST_CALL_COUNT,
+              summary: message
+            }
+          };
+        }
+      }
+
+      // All checks passed
+      console.log('   ✅ Integration tests meet requirements');
+      return {
+        passed: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings: [],
+        details: {
+          status: 'PASS',
+          blocking: false,
+          complexity,
+          integration_dir_exists: true,
+          files_found: testFiles.length,
+          files: relFilePaths,
+          per_file_counts: perFile.map(e => ({
+            file: relative(repoRoot, e.file).replace(/\\/g, '/'),
+            count: e.count
+          })),
+          test_call_count: totalTestCalls,
+          threshold: MIN_TEST_CALL_COUNT,
+          summary: `PASS: ${totalTestCalls} test() calls across ${testFiles.length} files (> ${MIN_TEST_CALL_COUNT} required)`
+        }
+      };
+    },
+
+    required: true
+  };
+}
+
+// Exported for testing
+export {
+  classifyComplexity,
+  countModifiedModules,
+  findIntegrationTestFiles,
+  countTestCalls,
+  MIN_TEST_CALL_COUNT,
+  BLOCKING_SD_TYPES,
+  TEST_FILE_EXTENSIONS
+};

--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -21,7 +21,8 @@ import {
   createSubAgentEnforcementValidationGate,
   createLOCThresholdValidationGate,
   createPerformanceCriticalGate,
-  createTestCoverageQualityGate
+  createTestCoverageQualityGate,
+  createIntegrationTestRequirementGate
 } from './gates/index.js';
 
 // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
@@ -137,6 +138,10 @@ export class ExecToPlanExecutor extends BaseExecutor {
     // Test coverage quality gate (SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-B)
     // Checks coverage thresholds for changed files, flags 0% coverage
     gates.push(createTestCoverageQualityGate(this.supabase));
+
+    // Integration test requirement gate (SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-E)
+    // For complex SDs, checks for non-trivial integration tests in tests/integration/
+    gates.push(createIntegrationTestRequirementGate(this.supabase));
 
     return gates;
   }

--- a/tests/unit/integration-test-requirement-gate.test.js
+++ b/tests/unit/integration-test-requirement-gate.test.js
@@ -1,0 +1,261 @@
+/**
+ * Unit Tests for Integration Test Requirement Gate
+ * Part of SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-E
+ *
+ * Tests:
+ * - Complexity classification (SP>=5, has_children, modified_modules>=3)
+ * - Integration test file detection
+ * - Non-trivial test validation (>10 test() calls)
+ * - BLOCKING for feature/refactor with SP>=5, ADVISORY for others
+ * - Security: symlink boundary check
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  classifyComplexity,
+  countTestCalls,
+  MIN_TEST_CALL_COUNT,
+  BLOCKING_SD_TYPES,
+  TEST_FILE_EXTENSIONS,
+  createIntegrationTestRequirementGate
+} from '../../scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js';
+
+import { existsSync, writeFileSync, mkdirSync, rmSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir } from 'os';
+
+describe('Integration Test Requirement Gate', () => {
+
+  describe('classifyComplexity', () => {
+    it('should classify SD with story_points >= 5 as complex', () => {
+      const result = classifyComplexity({ story_points: 5 });
+      expect(result.isComplex).toBe(true);
+      expect(result.reasons).toContain('story_points=5 (>= 5)');
+    });
+
+    it('should classify SD with story_points >= 8 as complex', () => {
+      const result = classifyComplexity({ story_points: 8 });
+      expect(result.isComplex).toBe(true);
+      expect(result.storyPoints).toBe(8);
+    });
+
+    it('should classify SD with has_children as complex', () => {
+      const result = classifyComplexity({}, { hasChildren: true });
+      expect(result.isComplex).toBe(true);
+      expect(result.reasons).toContain('SD has child SDs');
+    });
+
+    it('should classify SD with 3+ modified modules as complex', () => {
+      const result = classifyComplexity({}, { modifiedModulesCount: 3 });
+      expect(result.isComplex).toBe(true);
+      expect(result.reasons).toContain('modified_modules=3 (>= 3)');
+    });
+
+    it('should not classify SD with SP < 5, no children, < 3 modules as complex', () => {
+      const result = classifyComplexity(
+        { story_points: 2 },
+        { hasChildren: false, modifiedModulesCount: 1 }
+      );
+      expect(result.isComplex).toBe(false);
+      expect(result.reasons).toHaveLength(0);
+    });
+
+    it('should handle missing story_points (defaults to 0)', () => {
+      const result = classifyComplexity({}, { hasChildren: false, modifiedModulesCount: 0 });
+      expect(result.isComplex).toBe(false);
+      expect(result.storyPoints).toBe(0);
+    });
+
+    it('should report multiple complexity reasons', () => {
+      const result = classifyComplexity(
+        { story_points: 5 },
+        { hasChildren: true, modifiedModulesCount: 4 }
+      );
+      expect(result.isComplex).toBe(true);
+      expect(result.reasons).toHaveLength(3);
+    });
+
+    it('should read story_points from metadata fallback', () => {
+      const result = classifyComplexity({ metadata: { story_points: 7 } });
+      expect(result.isComplex).toBe(true);
+      expect(result.storyPoints).toBe(7);
+    });
+  });
+
+  describe('countTestCalls', () => {
+    const tempDir = join(tmpdir(), 'gate-test-' + Date.now());
+
+    beforeEach(() => {
+      mkdirSync(tempDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    it('should count lines containing test( in files', () => {
+      const filePath = join(tempDir, 'example.test.js');
+      const content = [
+        'import { describe, it } from "vitest";',
+        'describe("example", () => {',
+        '  test("first", () => {});',
+        '  test("second", () => {});',
+        '  test("third", () => {});',
+        '});'
+      ].join('\n');
+      writeFileSync(filePath, content);
+
+      const result = countTestCalls([filePath]);
+      expect(result.totalTestCalls).toBe(3);
+      expect(result.perFile).toHaveLength(1);
+      expect(result.perFile[0].count).toBe(3);
+    });
+
+    it('should count across multiple files', () => {
+      const file1 = join(tempDir, 'a.test.js');
+      const file2 = join(tempDir, 'b.test.js');
+      writeFileSync(file1, 'test("one", () => {});\ntest("two", () => {});');
+      writeFileSync(file2, 'test("three", () => {});\ntest("four", () => {});\ntest("five", () => {});');
+
+      const result = countTestCalls([file1, file2]);
+      expect(result.totalTestCalls).toBe(5);
+      expect(result.perFile[0].count).toBe(2);
+      expect(result.perFile[1].count).toBe(3);
+    });
+
+    it('should return 0 for files with no test( calls', () => {
+      const filePath = join(tempDir, 'empty.test.js');
+      writeFileSync(filePath, 'console.log("no tests here");');
+
+      const result = countTestCalls([filePath]);
+      expect(result.totalTestCalls).toBe(0);
+    });
+
+    it('should return 0 for empty file array', () => {
+      const result = countTestCalls([]);
+      expect(result.totalTestCalls).toBe(0);
+      expect(result.perFile).toHaveLength(0);
+    });
+
+    it('should handle unreadable files gracefully', () => {
+      const result = countTestCalls(['/nonexistent/path/file.js']);
+      expect(result.totalTestCalls).toBe(0);
+      expect(result.perFile[0].count).toBe(0);
+    });
+  });
+
+  describe('constants', () => {
+    it('should have MIN_TEST_CALL_COUNT of 10', () => {
+      expect(MIN_TEST_CALL_COUNT).toBe(10);
+    });
+
+    it('should have BLOCKING_SD_TYPES include feature and refactor', () => {
+      expect(BLOCKING_SD_TYPES.has('feature')).toBe(true);
+      expect(BLOCKING_SD_TYPES.has('refactor')).toBe(true);
+    });
+
+    it('should not block for infrastructure type', () => {
+      expect(BLOCKING_SD_TYPES.has('infrastructure')).toBe(false);
+    });
+
+    it('should recognize standard test file extensions', () => {
+      expect(TEST_FILE_EXTENSIONS.has('.js')).toBe(true);
+      expect(TEST_FILE_EXTENSIONS.has('.ts')).toBe(true);
+      expect(TEST_FILE_EXTENSIONS.has('.mjs')).toBe(true);
+      expect(TEST_FILE_EXTENSIONS.has('.cjs')).toBe(true);
+      expect(TEST_FILE_EXTENSIONS.has('.py')).toBe(false);
+    });
+  });
+
+  describe('createIntegrationTestRequirementGate', () => {
+    let gate;
+
+    beforeEach(() => {
+      gate = createIntegrationTestRequirementGate(null);
+    });
+
+    it('should have correct gate name', () => {
+      expect(gate.name).toBe('GATE_INTEGRATION_TEST_REQUIREMENT');
+    });
+
+    it('should be required', () => {
+      expect(gate.required).toBe(true);
+    });
+
+    it('should have an async validator', () => {
+      expect(typeof gate.validator).toBe('function');
+    });
+
+    it('should pass for non-complex SDs (low story_points)', async () => {
+      const result = await gate.validator({
+        sd: { sd_type: 'feature', story_points: 2, id: 'test-id' }
+      });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(100);
+      expect(result.details.status).toBe('PASS');
+    });
+
+    it('should pass for non-complex enhancement SD', async () => {
+      const result = await gate.validator({
+        sd: { sd_type: 'enhancement', story_points: 3, id: 'test-id' }
+      });
+      expect(result.passed).toBe(true);
+    });
+
+    it('should return advisory (passed=true) for complex non-feature SDs without tests', async () => {
+      // infrastructure SD with SP=5 but no integration tests dir
+      // Since infrastructure is not in BLOCKING_SD_TYPES, should be advisory
+      const result = await gate.validator({
+        sd: { sd_type: 'infrastructure', story_points: 5, id: 'test-id' }
+      });
+      // Should pass (advisory) since infrastructure is not in BLOCKING_SD_TYPES
+      expect(result.passed).toBe(true);
+      expect(result.details.blocking).toBe(false);
+    });
+  });
+
+  describe('enforcement policy', () => {
+    let gate;
+
+    beforeEach(() => {
+      gate = createIntegrationTestRequirementGate(null);
+    });
+
+    it('should be BLOCKING for feature with SP>=5', async () => {
+      const result = await gate.validator({
+        sd: { sd_type: 'feature', story_points: 5, id: 'test-id' }
+      });
+      // Will fail because no tests/integration/ dir exists
+      // But should be blocking
+      if (!result.passed) {
+        expect(result.details.blocking).toBe(true);
+      }
+    });
+
+    it('should be BLOCKING for refactor with SP>=5', async () => {
+      const result = await gate.validator({
+        sd: { sd_type: 'refactor', story_points: 5, id: 'test-id' }
+      });
+      if (!result.passed) {
+        expect(result.details.blocking).toBe(true);
+      }
+    });
+
+    it('should be NON-BLOCKING for bugfix with SP>=5', async () => {
+      const result = await gate.validator({
+        sd: { sd_type: 'bugfix', story_points: 5, id: 'test-id' }
+      });
+      // Should pass (advisory) since bugfix is not in BLOCKING_SD_TYPES
+      expect(result.passed).toBe(true);
+      expect(result.details.blocking).toBe(false);
+    });
+
+    it('should be NON-BLOCKING for enhancement with children', async () => {
+      const result = await gate.validator({
+        sd: { sd_type: 'enhancement', story_points: 2, has_children: true, id: 'test-id' }
+      });
+      // has_children makes it complex, but enhancement + SP<5 = not blocking
+      expect(result.passed).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add GATE_INTEGRATION_TEST_REQUIREMENT for EXEC-TO-PLAN handoffs
- Complex SDs (SP>=5, has children, or 3+ modified modules) require non-trivial integration tests in tests/integration/
- Gate counts lines containing `test(` across integration test files, requires >10 to pass
- BLOCKING for feature/refactor with SP>=5, ADVISORY for all other complex SDs
- Security: symlink/path traversal protection (does not follow links outside repo root)
- Registered gate in validation_gate_registry for 12 SD types via migration
- 27 unit tests covering complexity classification, test counting, enforcement policy, and constants

## Test plan
- [x] 27 unit tests pass (vitest)
- [x] 405 smoke tests pass (no regressions)
- [x] Migration executed: 12 SD type registrations in validation_gate_registry
- [x] Gate integrated into ExecToPlanExecutor.getRequiredGates()
- [x] Gate exported from exec-to-plan/gates/index.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)