### PR TITLE
feat(SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A): workflow telemetry collection infrastructure

### DIFF
--- a/database/migrations/20260209_workflow_trace_log.sql
+++ b/database/migrations/20260209_workflow_trace_log.sql
@@ -1,0 +1,61 @@
+-- Migration: workflow_trace_log
+-- SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A
+-- Purpose: Create workflow_trace_log table for storing telemetry spans
+-- Date: 2026-02-09
+
+-- ============================================================
+-- UP MIGRATION
+-- ============================================================
+
+-- Create workflow_trace_log table
+CREATE TABLE IF NOT EXISTS workflow_trace_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  trace_id uuid NOT NULL,
+  span_id uuid NOT NULL,
+  parent_span_id uuid,
+  workflow_execution_id text NOT NULL,
+  sd_id text,
+  phase text,
+  gate_name text,
+  subagent_name text,
+  span_name text NOT NULL,
+  span_type text NOT NULL,
+  start_time_ms bigint NOT NULL,
+  end_time_ms bigint,
+  duration_ms bigint,
+  queue_wait_ms bigint,
+  attributes jsonb DEFAULT '{}'::jsonb,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Add comment
+COMMENT ON TABLE workflow_trace_log IS 'Stores workflow telemetry spans for bottleneck detection (SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A)';
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_workflow_trace_log_execution_time
+  ON workflow_trace_log (workflow_execution_id, start_time_ms DESC);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_trace_log_trace_id
+  ON workflow_trace_log (trace_id);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_trace_log_span_type_name
+  ON workflow_trace_log (span_type, span_name);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_trace_log_created_at
+  ON workflow_trace_log (created_at DESC);
+
+-- RLS: Allow service_role full access
+ALTER TABLE workflow_trace_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY service_role_all_workflow_trace_log
+  ON workflow_trace_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ============================================================
+-- DOWN MIGRATION (run manually if rollback needed)
+-- ============================================================
+-- DROP POLICY IF EXISTS service_role_all_workflow_trace_log ON workflow_trace_log;
+-- DROP TABLE IF EXISTS workflow_trace_log;

--- a/lib/telemetry/index.js
+++ b/lib/telemetry/index.js
@@ -1,0 +1,14 @@
+/**
+ * Telemetry module - public exports
+ * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A
+ */
+
+export {
+  createTraceContext,
+  startSpan,
+  endSpan,
+  persist,
+  getMetrics,
+  resetMetrics,
+  default as WorkflowTimer,
+} from './workflow-timer.js';

--- a/lib/telemetry/workflow-timer.js
+++ b/lib/telemetry/workflow-timer.js
@@ -1,0 +1,364 @@
+/**
+ * WorkflowTimer - Non-blocking telemetry for LEO Protocol workflow execution
+ *
+ * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A
+ *
+ * Creates timing spans for workflow phases, gates, and sub-agent calls.
+ * All public APIs are exception-safe (no-throw). Persistence is async
+ * and never blocks workflow execution.
+ *
+ * Usage:
+ *   import { startSpan, endSpan, persist, createTraceContext } from './workflow-timer.js';
+ *
+ *   const ctx = createTraceContext(workflowExecutionId);
+ *   const root = startSpan('workflow.execute', { span_type: 'workflow' }, ctx);
+ *   const phase = startSpan('step.loadSD', { span_type: 'phase', step_name: 'loadSD' }, ctx, root);
+ *   endSpan(phase);
+ *   endSpan(root);
+ *   await persist(ctx); // fire-and-forget in production
+ */
+
+import { randomUUID } from 'crypto';
+
+// ============================================================
+// Configuration (env-driven, checked at call time)
+// ============================================================
+
+function isEnabled() {
+  return process.env.TELEMETRY_WORKFLOW_TRACE_ENABLED !== 'false';
+}
+
+function getBatchSize() {
+  return parseInt(process.env.TELEMETRY_PERSIST_BATCH_SIZE || '100', 10);
+}
+
+function getMaxQueueSize() {
+  return parseInt(process.env.TELEMETRY_PERSIST_MAX_QUEUE_SIZE || '5000', 10);
+}
+
+// ============================================================
+// Metrics counters (in-process, lightweight)
+// ============================================================
+
+const metrics = {
+  spans_created: 0,
+  spans_persisted: 0,
+  spans_dropped: 0,
+  persist_errors: 0,
+  persist_batches: 0,
+};
+
+/**
+ * Get current telemetry pipeline metrics
+ * @returns {object} Copy of metrics counters
+ */
+export function getMetrics() {
+  return { ...metrics };
+}
+
+/**
+ * Reset metrics (for testing)
+ */
+export function resetMetrics() {
+  metrics.spans_created = 0;
+  metrics.spans_persisted = 0;
+  metrics.spans_dropped = 0;
+  metrics.persist_errors = 0;
+  metrics.persist_batches = 0;
+}
+
+// ============================================================
+// Attribute allowlist (TR-4: prevent PII leakage)
+// ============================================================
+
+const ALLOWED_ATTRIBUTES = new Set([
+  'workflow_execution_id',
+  'sd_id',
+  'step_name',
+  'executor_class',
+  'gate_name',
+  'gate_runner_class',
+  'result',
+  'error_class',
+  'error_message',
+  'subagent_name',
+  'request_id',
+  'transport',
+  'span_type',
+  'handoff_type',
+  'phase',
+  'telemetry_version',
+]);
+
+function sanitizeAttributes(attrs) {
+  if (!attrs || typeof attrs !== 'object') return {};
+  const sanitized = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (ALLOWED_ATTRIBUTES.has(key)) {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+// ============================================================
+// Trace Context
+// ============================================================
+
+/**
+ * Create a trace context for a workflow execution.
+ * All spans within a single workflow share a trace_id.
+ *
+ * @param {string} workflowExecutionId - Unique ID for this workflow run
+ * @param {object} [opts] - Optional overrides
+ * @param {string} [opts.sdId] - Strategic directive ID
+ * @returns {object} Trace context with spans buffer
+ */
+export function createTraceContext(workflowExecutionId, opts = {}) {
+  try {
+    return {
+      trace_id: randomUUID(),
+      workflow_execution_id: workflowExecutionId || randomUUID(),
+      sd_id: opts.sdId || null,
+      spans: [],
+    };
+  } catch {
+    return {
+      trace_id: 'fallback-' + Date.now(),
+      workflow_execution_id: workflowExecutionId || 'unknown',
+      sd_id: opts.sdId || null,
+      spans: [],
+    };
+  }
+}
+
+// ============================================================
+// Span APIs (exception-safe)
+// ============================================================
+
+/**
+ * Start a new timing span.
+ *
+ * @param {string} name - Span name (e.g. 'workflow.execute', 'gate.execute')
+ * @param {object} [attrs={}] - Span attributes (filtered by allowlist)
+ * @param {object} [traceCtx] - Trace context from createTraceContext()
+ * @param {object} [parentSpan] - Parent span (for nesting)
+ * @returns {object} Span object
+ */
+export function startSpan(name, attrs = {}, traceCtx = null, parentSpan = null) {
+  try {
+    const now = Date.now();
+    const span = {
+      span_id: randomUUID(),
+      name: name || 'unknown',
+      span_type: attrs.span_type || 'unknown',
+      start_time_ms: now,
+      end_time_ms: null,
+      duration_ms: null,
+      queue_wait_ms: null,
+      attributes: sanitizeAttributes(attrs),
+      parent_span_id: parentSpan?.span_id || null,
+      trace_id: traceCtx?.trace_id || null,
+      workflow_execution_id: traceCtx?.workflow_execution_id || attrs.workflow_execution_id || null,
+      sd_id: traceCtx?.sd_id || attrs.sd_id || null,
+      phase: attrs.phase || null,
+      gate_name: attrs.gate_name || null,
+      subagent_name: attrs.subagent_name || null,
+      _ended: false,
+    };
+
+    // Add to trace context buffer
+    if (traceCtx && Array.isArray(traceCtx.spans)) {
+      const maxQueue = getMaxQueueSize();
+      if (traceCtx.spans.length < maxQueue) {
+        traceCtx.spans.push(span);
+      } else {
+        metrics.spans_dropped++;
+      }
+    }
+
+    metrics.spans_created++;
+    return span;
+  } catch {
+    metrics.spans_created++;
+    return {
+      span_id: 'err-' + Date.now(),
+      name: name || 'unknown',
+      span_type: 'unknown',
+      start_time_ms: Date.now(),
+      end_time_ms: null,
+      duration_ms: null,
+      queue_wait_ms: null,
+      attributes: {},
+      parent_span_id: null,
+      trace_id: null,
+      workflow_execution_id: null,
+      sd_id: null,
+      phase: null,
+      gate_name: null,
+      subagent_name: null,
+      _ended: false,
+    };
+  }
+}
+
+/**
+ * End a span. Idempotent: calling twice keeps the first end time.
+ *
+ * @param {object} span - Span object from startSpan()
+ * @param {object} [attrs={}] - Additional attributes to merge
+ * @returns {object} The span (mutated)
+ */
+export function endSpan(span, attrs = {}) {
+  try {
+    if (!span || typeof span !== 'object') return span;
+    if (span._ended) return span; // Idempotent
+
+    const now = Date.now();
+    span.end_time_ms = now;
+    span.duration_ms = Math.max(0, now - (span.start_time_ms || now));
+    span._ended = true;
+
+    // Merge additional attributes (e.g., gate result, error info)
+    if (attrs && typeof attrs === 'object') {
+      const sanitized = sanitizeAttributes(attrs);
+      span.attributes = { ...span.attributes, ...sanitized };
+
+      // Special handling for queue_wait_ms
+      if (attrs.pickup_time_ms && span.start_time_ms) {
+        span.queue_wait_ms = Math.max(0, attrs.pickup_time_ms - span.start_time_ms);
+      }
+
+      // Update top-level fields if provided
+      if (attrs.gate_name) span.gate_name = attrs.gate_name;
+      if (attrs.subagent_name) span.subagent_name = attrs.subagent_name;
+      if (attrs.phase) span.phase = attrs.phase;
+    }
+
+    return span;
+  } catch {
+    if (span && typeof span === 'object') {
+      span._ended = true;
+      span.end_time_ms = Date.now();
+      span.duration_ms = 0;
+    }
+    return span;
+  }
+}
+
+// ============================================================
+// Persistence (async, non-blocking)
+// ============================================================
+
+/**
+ * Persist spans to database. Non-blocking by default.
+ *
+ * @param {object|object[]} spansOrCtx - Trace context (with .spans) or array of span objects
+ * @param {object} [opts={}] - Persistence options
+ * @param {object} [opts.supabase] - Supabase client (required for DB writes)
+ * @param {boolean} [opts.sync=false] - If true, await DB writes (for testing)
+ * @returns {Promise<object>} Persistence result { persisted, dropped, errors }
+ */
+export async function persist(spansOrCtx, opts = {}) {
+  const result = { persisted: 0, dropped: 0, errors: [] };
+
+  try {
+    if (!isEnabled()) {
+      return result;
+    }
+
+    // Extract spans array
+    let spans;
+    if (Array.isArray(spansOrCtx)) {
+      spans = spansOrCtx;
+    } else if (spansOrCtx && Array.isArray(spansOrCtx.spans)) {
+      spans = spansOrCtx.spans;
+    } else {
+      return result;
+    }
+
+    if (spans.length === 0) return result;
+
+    const supabase = opts.supabase;
+    if (!supabase) {
+      // No client - log warning, don't persist
+      console.warn('[Telemetry] No Supabase client provided for persist - spans will be lost');
+      result.dropped = spans.length;
+      metrics.spans_dropped += spans.length;
+      return result;
+    }
+
+    // Prepare rows (strip internal fields)
+    const rows = spans
+      .filter(s => s && s.span_id && s.name)
+      .map(s => ({
+        trace_id: s.trace_id,
+        span_id: s.span_id,
+        parent_span_id: s.parent_span_id,
+        workflow_execution_id: s.workflow_execution_id,
+        sd_id: s.sd_id,
+        phase: s.phase,
+        gate_name: s.gate_name,
+        subagent_name: s.subagent_name,
+        span_name: s.name,
+        span_type: s.span_type || 'unknown',
+        start_time_ms: s.start_time_ms,
+        end_time_ms: s.end_time_ms,
+        duration_ms: s.duration_ms,
+        queue_wait_ms: s.queue_wait_ms,
+        attributes: s.attributes || {},
+      }));
+
+    if (rows.length === 0) return result;
+
+    // Batch insert
+    const batchSize = getBatchSize();
+    const insertOp = async () => {
+      for (let i = 0; i < rows.length; i += batchSize) {
+        const batch = rows.slice(i, i + batchSize);
+        const { error } = await supabase
+          .from('workflow_trace_log')
+          .insert(batch);
+
+        if (error) {
+          metrics.persist_errors++;
+          result.errors.push(error.message);
+          result.dropped += batch.length;
+          metrics.spans_dropped += batch.length;
+          console.warn(`[Telemetry] Persist batch error: ${error.message}`);
+        } else {
+          result.persisted += batch.length;
+          metrics.spans_persisted += batch.length;
+          metrics.persist_batches++;
+        }
+      }
+    };
+
+    if (opts.sync) {
+      await insertOp();
+    } else {
+      // Fire-and-forget: don't await, catch errors
+      insertOp().catch(err => {
+        metrics.persist_errors++;
+        console.warn(`[Telemetry] Async persist error: ${err.message}`);
+      });
+    }
+
+    return result;
+  } catch (err) {
+    metrics.persist_errors++;
+    result.errors.push(err.message);
+    console.warn(`[Telemetry] Persist error: ${err.message}`);
+    return result;
+  }
+}
+
+export default {
+  createTraceContext,
+  startSpan,
+  endSpan,
+  persist,
+  getMetrics,
+  resetMetrics,
+  isEnabled,
+};

--- a/tests/unit/telemetry/workflow-timer.test.js
+++ b/tests/unit/telemetry/workflow-timer.test.js
@@ -1,0 +1,430 @@
+/**
+ * Unit tests for WorkflowTimer (lib/telemetry/workflow-timer.js)
+ * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A
+ *
+ * Covers: TS-6 (endSpan idempotency, out-of-order closures), FR-1, FR-6, TR-1
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  createTraceContext,
+  startSpan,
+  endSpan,
+  persist,
+  getMetrics,
+  resetMetrics,
+} from '../../../lib/telemetry/workflow-timer.js';
+
+describe('WorkflowTimer', () => {
+  beforeEach(() => {
+    resetMetrics();
+    delete process.env.TELEMETRY_WORKFLOW_TRACE_ENABLED;
+    delete process.env.TELEMETRY_PERSIST_MAX_QUEUE_SIZE;
+  });
+
+  describe('createTraceContext', () => {
+    it('creates a trace context with unique trace_id', () => {
+      const ctx = createTraceContext('exec-123');
+      expect(ctx.trace_id).toBeTruthy();
+      expect(ctx.workflow_execution_id).toBe('exec-123');
+      expect(ctx.spans).toEqual([]);
+    });
+
+    it('accepts optional sdId', () => {
+      const ctx = createTraceContext('exec-123', { sdId: 'SD-TEST-001' });
+      expect(ctx.sd_id).toBe('SD-TEST-001');
+    });
+
+    it('generates workflow_execution_id if not provided', () => {
+      const ctx = createTraceContext(null);
+      expect(ctx.workflow_execution_id).toBeTruthy();
+    });
+
+    it('two contexts have different trace_ids', () => {
+      const ctx1 = createTraceContext('a');
+      const ctx2 = createTraceContext('b');
+      expect(ctx1.trace_id).not.toBe(ctx2.trace_id);
+    });
+  });
+
+  describe('startSpan', () => {
+    it('returns a span with required fields (FR-1)', () => {
+      const ctx = createTraceContext('exec-1');
+      const span = startSpan('workflow.execute', { span_type: 'workflow' }, ctx);
+
+      expect(span.span_id).toBeTruthy();
+      expect(span.name).toBe('workflow.execute');
+      expect(span.span_type).toBe('workflow');
+      expect(span.start_time_ms).toBeGreaterThan(0);
+      expect(span.end_time_ms).toBeNull();
+      expect(span.duration_ms).toBeNull();
+      expect(span.parent_span_id).toBeNull();
+      expect(span.trace_id).toBe(ctx.trace_id);
+      expect(span.attributes).toBeDefined();
+    });
+
+    it('adds span to trace context buffer', () => {
+      const ctx = createTraceContext('exec-1');
+      startSpan('s1', { span_type: 'phase' }, ctx);
+      startSpan('s2', { span_type: 'phase' }, ctx);
+      expect(ctx.spans).toHaveLength(2);
+    });
+
+    it('sets parent_span_id when parent provided', () => {
+      const ctx = createTraceContext('exec-1');
+      const root = startSpan('root', { span_type: 'workflow' }, ctx);
+      const child = startSpan('child', { span_type: 'phase' }, ctx, root);
+      expect(child.parent_span_id).toBe(root.span_id);
+    });
+
+    it('sanitizes attributes via allowlist (TR-4)', () => {
+      const ctx = createTraceContext('exec-1');
+      const span = startSpan('test', {
+        span_type: 'phase',
+        step_name: 'loadSD',
+        secret_key: 'SHOULD_BE_REMOVED',
+        password: 'SHOULD_BE_REMOVED',
+      }, ctx);
+
+      expect(span.attributes.step_name).toBe('loadSD');
+      expect(span.attributes.secret_key).toBeUndefined();
+      expect(span.attributes.password).toBeUndefined();
+    });
+
+    it('increments metrics.spans_created', () => {
+      const ctx = createTraceContext('exec-1');
+      startSpan('s1', {}, ctx);
+      startSpan('s2', {}, ctx);
+      expect(getMetrics().spans_created).toBe(2);
+    });
+
+    it('drops spans when queue is full', () => {
+      process.env.TELEMETRY_PERSIST_MAX_QUEUE_SIZE = '2';
+      const ctx = createTraceContext('exec-1');
+      startSpan('s1', {}, ctx);
+      startSpan('s2', {}, ctx);
+      startSpan('s3', {}, ctx); // Should be dropped
+
+      expect(ctx.spans).toHaveLength(2);
+      expect(getMetrics().spans_dropped).toBe(1);
+    });
+
+    it('never throws even with invalid input (TR-1)', () => {
+      expect(() => startSpan(null, null, null, null)).not.toThrow();
+      expect(() => startSpan(undefined)).not.toThrow();
+      const span = startSpan(null);
+      expect(span.name).toBe('unknown');
+    });
+
+    it('works without trace context', () => {
+      const span = startSpan('standalone', { span_type: 'test' });
+      expect(span.span_id).toBeTruthy();
+      expect(span.trace_id).toBeNull();
+    });
+  });
+
+  describe('endSpan', () => {
+    it('sets end_time_ms and duration_ms', () => {
+      const ctx = createTraceContext('exec-1');
+      const span = startSpan('test', { span_type: 'phase' }, ctx);
+      endSpan(span);
+
+      expect(span.end_time_ms).toBeGreaterThan(0);
+      expect(span.duration_ms).toBeGreaterThanOrEqual(0);
+      expect(span._ended).toBe(true);
+    });
+
+    it('is idempotent - second call preserves first end time (TS-6)', () => {
+      const ctx = createTraceContext('exec-1');
+      const span = startSpan('test', { span_type: 'phase' }, ctx);
+
+      endSpan(span);
+      const firstEndTime = span.end_time_ms;
+      const firstDuration = span.duration_ms;
+
+      // Second call should be no-op
+      endSpan(span, { result: 'different' });
+      expect(span.end_time_ms).toBe(firstEndTime);
+      expect(span.duration_ms).toBe(firstDuration);
+    });
+
+    it('merges additional attributes', () => {
+      const ctx = createTraceContext('exec-1');
+      const span = startSpan('gate', { span_type: 'gate' }, ctx);
+      endSpan(span, { result: 'pass', gate_name: 'MY_GATE' });
+
+      expect(span.attributes.result).toBe('pass');
+      expect(span.gate_name).toBe('MY_GATE');
+    });
+
+    it('computes queue_wait_ms from pickup_time_ms', () => {
+      const ctx = createTraceContext('exec-1');
+      const span = startSpan('subagent', { span_type: 'subagent' }, ctx);
+      const pickupTime = span.start_time_ms + 150;
+      endSpan(span, { pickup_time_ms: pickupTime });
+
+      expect(span.queue_wait_ms).toBe(150);
+    });
+
+    it('never throws even with null/undefined input (TR-1)', () => {
+      expect(() => endSpan(null)).not.toThrow();
+      expect(() => endSpan(undefined)).not.toThrow();
+      expect(() => endSpan({})).not.toThrow();
+      expect(() => endSpan('not a span')).not.toThrow();
+    });
+
+    it('handles out-of-order closures gracefully (TS-6)', () => {
+      const ctx = createTraceContext('exec-1');
+      const parent = startSpan('parent', { span_type: 'workflow' }, ctx);
+      const child = startSpan('child', { span_type: 'phase' }, ctx, parent);
+
+      // End parent first (out of order)
+      endSpan(parent);
+      // Then end child
+      endSpan(child);
+
+      expect(parent._ended).toBe(true);
+      expect(child._ended).toBe(true);
+      expect(parent.duration_ms).toBeGreaterThanOrEqual(0);
+      expect(child.duration_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it('duration_ms is always non-negative', () => {
+      const ctx = createTraceContext('exec-1');
+      const span = startSpan('test', { span_type: 'phase' }, ctx);
+      // Force start_time_ms into the future to test edge case
+      span.start_time_ms = Date.now() + 100000;
+      endSpan(span);
+      expect(span.duration_ms).toBe(0); // Math.max(0, ...) ensures non-negative
+    });
+  });
+
+  describe('persist', () => {
+    it('returns empty result when disabled', async () => {
+      process.env.TELEMETRY_WORKFLOW_TRACE_ENABLED = 'false';
+      const ctx = createTraceContext('exec-1');
+      startSpan('test', { span_type: 'phase' }, ctx);
+
+      const result = await persist(ctx);
+      expect(result.persisted).toBe(0);
+      expect(result.dropped).toBe(0);
+    });
+
+    it('returns empty result when no supabase client', async () => {
+      const ctx = createTraceContext('exec-1');
+      startSpan('test', { span_type: 'phase' }, ctx);
+
+      const result = await persist(ctx, { sync: true });
+      expect(result.dropped).toBe(1);
+    });
+
+    it('persists spans to database with mock client (sync mode)', async () => {
+      const inserted = [];
+      const mockSupabase = {
+        from: () => ({
+          insert: (rows) => {
+            inserted.push(...rows);
+            return { error: null };
+          }
+        })
+      };
+
+      const ctx = createTraceContext('exec-1', { sdId: 'SD-TEST' });
+      const root = startSpan('workflow.execute', { span_type: 'workflow' }, ctx);
+      const phase = startSpan('step.loadSD', { span_type: 'phase', step_name: 'loadSD' }, ctx, root);
+      endSpan(phase);
+      endSpan(root);
+
+      const result = await persist(ctx, { supabase: mockSupabase, sync: true });
+      expect(result.persisted).toBe(2);
+      expect(inserted).toHaveLength(2);
+
+      // Verify row structure
+      const row = inserted[0];
+      expect(row.trace_id).toBe(ctx.trace_id);
+      expect(row.span_name).toBeTruthy();
+      expect(row.span_type).toBeTruthy();
+      expect(row.start_time_ms).toBeGreaterThan(0);
+    });
+
+    it('handles database errors gracefully', async () => {
+      const mockSupabase = {
+        from: () => ({
+          insert: () => ({ error: { message: 'connection refused' } })
+        })
+      };
+
+      const ctx = createTraceContext('exec-1');
+      startSpan('test', { span_type: 'phase' }, ctx);
+
+      const result = await persist(ctx, { supabase: mockSupabase, sync: true });
+      expect(result.errors).toHaveLength(1);
+      expect(result.dropped).toBe(1);
+      expect(getMetrics().persist_errors).toBe(1);
+    });
+
+    it('batches inserts', async () => {
+      process.env.TELEMETRY_PERSIST_BATCH_SIZE = '3';
+      let insertCalls = 0;
+      const mockSupabase = {
+        from: () => ({
+          insert: (rows) => {
+            insertCalls++;
+            return { error: null };
+          }
+        })
+      };
+
+      const ctx = createTraceContext('exec-1');
+      for (let i = 0; i < 7; i++) {
+        startSpan(`span-${i}`, { span_type: 'phase' }, ctx);
+      }
+
+      await persist(ctx, { supabase: mockSupabase, sync: true });
+      // 7 spans / batch size 3 = 3 batches (3+3+1)
+      expect(insertCalls).toBe(3);
+    });
+
+    it('accepts array of spans directly', async () => {
+      const inserted = [];
+      const mockSupabase = {
+        from: () => ({
+          insert: (rows) => {
+            inserted.push(...rows);
+            return { error: null };
+          }
+        })
+      };
+
+      const span1 = startSpan('s1', { span_type: 'phase' });
+      const span2 = startSpan('s2', { span_type: 'phase' });
+      endSpan(span1);
+      endSpan(span2);
+
+      await persist([span1, span2], { supabase: mockSupabase, sync: true });
+      expect(inserted).toHaveLength(2);
+    });
+
+    it('never throws (TR-1)', async () => {
+      await expect(persist(null)).resolves.toBeDefined();
+      await expect(persist(undefined)).resolves.toBeDefined();
+      await expect(persist([])).resolves.toBeDefined();
+      await expect(persist('invalid')).resolves.toBeDefined();
+    });
+  });
+
+  describe('getMetrics / resetMetrics', () => {
+    it('tracks spans_created', () => {
+      startSpan('a', {});
+      startSpan('b', {});
+      expect(getMetrics().spans_created).toBe(2);
+    });
+
+    it('resetMetrics clears all counters', () => {
+      startSpan('a', {});
+      resetMetrics();
+      expect(getMetrics().spans_created).toBe(0);
+      expect(getMetrics().spans_dropped).toBe(0);
+      expect(getMetrics().persist_errors).toBe(0);
+    });
+  });
+
+  describe('integration: full workflow trace', () => {
+    it('produces correct span hierarchy for a 7-step workflow (FR-3)', () => {
+      const ctx = createTraceContext('LEAD-TO-PLAN-SD-TEST-001-1234');
+      const root = startSpan('workflow.execute', {
+        span_type: 'workflow',
+        executor_class: 'LeadToPlanExecutor',
+        handoff_type: 'LEAD-TO-PLAN',
+      }, ctx);
+
+      const steps = [
+        'loadSD', 'migrationCheck', 'claimConflictCheck',
+        'setup', 'claimAndPrepare', 'gateValidation', 'executeSpecific'
+      ];
+
+      const stepSpans = steps.map(step =>
+        startSpan(`step.${step}`, {
+          span_type: 'phase',
+          step_name: step,
+          sd_id: 'SD-TEST-001',
+        }, ctx, root)
+      );
+
+      // End all step spans
+      stepSpans.forEach(s => endSpan(s));
+      endSpan(root);
+
+      // Verify: 1 root + 7 phase spans = 8 total
+      expect(ctx.spans).toHaveLength(8);
+
+      // All share same trace_id
+      const traceIds = new Set(ctx.spans.map(s => s.trace_id));
+      expect(traceIds.size).toBe(1);
+
+      // Root has no parent, children have root as parent
+      expect(root.parent_span_id).toBeNull();
+      stepSpans.forEach(s => {
+        expect(s.parent_span_id).toBe(root.span_id);
+      });
+
+      // All have non-null duration_ms
+      ctx.spans.forEach(s => {
+        expect(s.duration_ms).toBeGreaterThanOrEqual(0);
+      });
+    });
+
+    it('gate spans are children of the gateValidation phase (FR-4)', () => {
+      const ctx = createTraceContext('exec-1');
+      const root = startSpan('workflow.execute', { span_type: 'workflow' }, ctx);
+      const gatePhase = startSpan('step.gateValidation', { span_type: 'phase' }, ctx, root);
+
+      // Two gates execute within the gate phase
+      const gate1 = startSpan('gate.execute', {
+        span_type: 'gate',
+        gate_name: 'GATE_SD_COMPLETENESS',
+        gate_runner_class: 'ValidationOrchestrator',
+      }, ctx, gatePhase);
+      endSpan(gate1, { result: 'pass' });
+
+      const gate2 = startSpan('gate.execute', {
+        span_type: 'gate',
+        gate_name: 'GATE_PRD_QUALITY',
+        gate_runner_class: 'ValidationOrchestrator',
+      }, ctx, gatePhase);
+      endSpan(gate2, { result: 'fail' });
+
+      endSpan(gatePhase);
+      endSpan(root);
+
+      expect(gate1.parent_span_id).toBe(gatePhase.span_id);
+      expect(gate2.parent_span_id).toBe(gatePhase.span_id);
+      expect(gate1.gate_name).toBe('GATE_SD_COMPLETENESS');
+      expect(gate2.attributes.result).toBe('fail');
+    });
+
+    it('sub-agent spans capture RTT and queue_wait_ms (FR-5)', () => {
+      const ctx = createTraceContext('exec-1');
+      const root = startSpan('workflow.execute', { span_type: 'workflow' }, ctx);
+
+      const saSpan = startSpan('subagent.call', {
+        span_type: 'subagent',
+        subagent_name: 'DATABASE',
+        transport: 'internal',
+      }, ctx, root);
+
+      // Simulate pickup after 200ms
+      const pickupTime = saSpan.start_time_ms + 200;
+      endSpan(saSpan, {
+        pickup_time_ms: pickupTime,
+        subagent_name: 'DATABASE',
+      });
+      endSpan(root);
+
+      expect(saSpan.queue_wait_ms).toBe(200);
+      expect(saSpan.duration_ms).toBeGreaterThanOrEqual(0);
+      expect(saSpan.subagent_name).toBe('DATABASE');
+      expect(saSpan.attributes.transport).toBe('internal');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Creates `workflow_trace_log` table for storing span-based telemetry data (17 columns, 4 indexes, RLS policy)
- Adds `lib/telemetry/workflow-timer.js` utility with no-throw guarantee: `createTraceContext`, `startSpan`, `endSpan`, `persist`
- Instruments `BaseExecutor.execute()` with root workflow span + 7 phase spans (loadSD, migrationCheck, claimConflictCheck, setup, claimAndPrepare, gateValidation, executeSpecific)
- Instruments `ValidationOrchestrator.validateGate()` with gate spans capturing pass/fail/error results
- 31 unit tests covering all functional requirements (FR-1–FR-6), technical requirements (TR-1–TR-4), and test scenarios (TS-6)

## Test plan
- [x] 31 unit tests pass (vitest) - span creation, idempotent endSpan, attribute allowlist, batch persist, queue bounds, no-throw
- [x] Migration executed and verified (INSERT/SELECT/DELETE on workflow_trace_log)
- [ ] Integration test: run a handoff with `TELEMETRY_WORKFLOW_TRACE_ENABLED=true` and verify spans in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)