### PR TITLE
fix(SD-LEO-FIX-FIX-MULTI-SESSION-001): add terminal_id to claim gate discriminator

### DIFF
--- a/tests/unit/multi-session-claim-gate.test.js
+++ b/tests/unit/multi-session-claim-gate.test.js
@@ -1,7 +1,8 @@
 /**
  * Tests for Multi-Session Claim Conflict Gate
  * PAT-MSESS-BYP-001 corrective action
- * PAT-SESSION-IDENTITY-001: Updated to test hostname-based comparison
+ * PAT-SESSION-IDENTITY-002: Updated to test hostname + terminal_id comparison
+ * SD-LEO-FIX-FIX-MULTI-SESSION-001: Added terminal_id discriminator tests
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -101,14 +102,15 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.issues).toHaveLength(0);
     });
 
-    it('should PASS when claim is from different session on SAME hostname (same-machine)', async () => {
-      // PAT-SESSION-IDENTITY-001: sd:start creates session A, handoff.js creates session B,
-      // but both are on the same machine (same developer) → allow
+    it('should PASS when claim is from same hostname + same terminal_id (same conversation)', async () => {
+      // PAT-SESSION-IDENTITY-002: sd:start creates session A, handoff.js creates session B,
+      // both share hostname AND terminal_id (same parent Claude Code process) → allow
       const sessions = [{
         session_id: 'sd-start-session-111',
         sd_id: 'SD-TEST-001',
         sd_title: 'Test SD',
         hostname: 'MY-LAPTOP',
+        terminal_id: 'win-ppid-43456',
         tty: 'win-12345',
         heartbeat_age_human: '20s ago',
         heartbeat_age_seconds: 20,
@@ -120,12 +122,72 @@ describe('Multi-Session Claim Conflict Gate', () => {
 
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
         currentSessionId: 'handoff-session-222',
-        currentHostname: 'MY-LAPTOP'
+        currentHostname: 'MY-LAPTOP',
+        currentTerminalId: 'win-ppid-43456'
       });
 
       expect(result.pass).toBe(true);
       expect(result.score).toBe(100);
       expect(result.issues).toHaveLength(0);
+    });
+
+    it('should BLOCK when claim is from same hostname but DIFFERENT terminal_id (different conversation)', async () => {
+      // SD-LEO-FIX-FIX-MULTI-SESSION-001: Two Claude Code conversations on same machine
+      // have same hostname but different terminal_ids → must block
+      const sessions = [{
+        session_id: 'other-conversation-session',
+        sd_id: 'SD-TEST-001',
+        sd_title: 'Test SD',
+        hostname: 'MY-LAPTOP',
+        terminal_id: 'win-ppid-99999', // Different terminal_id
+        tty: 'win-99999',
+        heartbeat_age_human: '15s ago',
+        heartbeat_age_seconds: 15,
+        computed_status: 'active',
+        codebase: 'EHG_Engineer'
+      }];
+
+      const supabase = createMockSupabase(sessions);
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
+        currentSessionId: 'my-session-456',
+        currentHostname: 'MY-LAPTOP',
+        currentTerminalId: 'win-ppid-43456'
+      });
+
+      expect(result.pass).toBe(false);
+      expect(result.score).toBe(0);
+      expect(result.issues).toHaveLength(1);
+      expect(result.claimDetails.isSameMachine).toBe(true);
+      expect(result.claimDetails.terminalId).toBe('win-ppid-99999');
+    });
+
+    it('should BLOCK when claim has null terminal_id on same hostname (safe default)', async () => {
+      // Legacy sessions without terminal_id should be treated as conflicts
+      const sessions = [{
+        session_id: 'legacy-session-333',
+        sd_id: 'SD-TEST-001',
+        sd_title: 'Test SD',
+        hostname: 'MY-LAPTOP',
+        terminal_id: null, // Legacy session, no terminal_id
+        tty: 'win-33333',
+        heartbeat_age_human: '30s ago',
+        heartbeat_age_seconds: 30,
+        computed_status: 'active',
+        codebase: 'EHG_Engineer'
+      }];
+
+      const supabase = createMockSupabase(sessions);
+
+      const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
+        currentSessionId: 'handoff-session-222',
+        currentHostname: 'MY-LAPTOP',
+        currentTerminalId: 'win-ppid-43456'
+      });
+
+      // Cannot confirm same conversation → treat as conflict
+      expect(result.pass).toBe(false);
+      expect(result.score).toBe(0);
     });
 
     it('should fail-open on DB error (score 80)', async () => {
@@ -186,12 +248,13 @@ describe('Multi-Session Claim Conflict Gate', () => {
       expect(result.issues).toHaveLength(1);
     });
 
-    it('should PASS when no currentSessionId but claim from same hostname', async () => {
+    it('should PASS when no currentSessionId but claim from same hostname + same terminal_id', async () => {
       const sessions = [{
         session_id: 'other-session-123',
         sd_id: 'SD-TEST-001',
         sd_title: 'Test SD',
         hostname: 'MY-LAPTOP',
+        terminal_id: 'win-ppid-43456',
         tty: '/dev/pts/1',
         heartbeat_age_human: '1m ago',
         heartbeat_age_seconds: 60,
@@ -201,9 +264,10 @@ describe('Multi-Session Claim Conflict Gate', () => {
 
       const supabase = createMockSupabase(sessions);
 
-      // No currentSessionId but same hostname → same machine → pass
+      // No currentSessionId but same hostname + terminal_id → same conversation → pass
       const result = await validateMultiSessionClaim(supabase, 'SD-TEST-001', {
-        currentHostname: 'MY-LAPTOP'
+        currentHostname: 'MY-LAPTOP',
+        currentTerminalId: 'win-ppid-43456'
       });
 
       expect(result.pass).toBe(true);


### PR DESCRIPTION
## Summary
- Fixes multi-session claim gate to use `terminal_id` (based on `process.ppid`) alongside hostname for same-conversation detection
- Previously, two different Claude Code conversations on the same machine silently bypassed the claim conflict check (same hostname = allow), causing duplicate work on the same SD
- Now: same hostname + same terminal_id = same conversation (allow), same hostname + different terminal_id = different conversation (block)
- Added 3 new test scenarios (different conversation block, null terminal_id block, mixed claims)
- Updated BaseExecutor.js to pass `currentTerminalId` when invoking the gate

## Test plan
- [x] Unit tests: 13 tests pass in `multi-session-claim-gate.test.js` (354 total across worktrees)
- [x] Smoke tests: 510 passed
- [x] Multi-session coordination tests: 18 tests pass
- [ ] Manual: Start two Claude Code instances on same machine, verify second is blocked from claiming same SD

🤖 Generated with [Claude Code](https://claude.com/claude-code)