### PR TITLE
feat(SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001C): add session start auto-trigger for telemetry analysis

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,11 @@
             "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/concurrent-session-worktree.cjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/telemetry-auto-trigger.cjs",
+            "timeout": 5
           }
         ]
       }

--- a/database/migrations/20260209_telemetry_analysis_runs.sql
+++ b/database/migrations/20260209_telemetry_analysis_runs.sql
@@ -1,0 +1,63 @@
+-- Migration: telemetry_analysis_runs
+-- SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001C
+-- Purpose: Track analysis run lifecycle for auto-trigger integration
+-- Depends on: 20260209_telemetry_thresholds.sql
+
+-- Create table
+CREATE TABLE IF NOT EXISTS telemetry_analysis_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL UNIQUE,
+  scope_type TEXT NOT NULL DEFAULT 'workspace' CHECK (scope_type IN ('workspace', 'user', 'global')),
+  scope_id TEXT,
+  status TEXT NOT NULL DEFAULT 'QUEUED' CHECK (status IN ('QUEUED', 'RUNNING', 'SUCCEEDED', 'FAILED', 'TIMED_OUT', 'CANCELLED', 'FAILED_ENQUEUE')),
+  triggered_by TEXT NOT NULL DEFAULT 'SESSION_START' CHECK (triggered_by IN ('SESSION_START', 'MANUAL', 'SCHEDULED', 'CLI')),
+  triggered_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  started_at TIMESTAMPTZ,
+  finished_at TIMESTAMPTZ,
+  correlation_id TEXT,
+  output_ref JSONB,
+  findings_count INTEGER DEFAULT 0,
+  top_bottleneck_category TEXT,
+  reason_code TEXT,
+  error_class TEXT,
+  error_message TEXT,
+  duration_ms INTEGER,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for staleness check (find most recent SUCCEEDED run per scope)
+CREATE INDEX IF NOT EXISTS idx_telemetry_runs_scope_status ON telemetry_analysis_runs (scope_type, scope_id, status, finished_at DESC);
+
+-- Index for dedup check (find active runs)
+CREATE INDEX IF NOT EXISTS idx_telemetry_runs_active ON telemetry_analysis_runs (scope_type, scope_id, status) WHERE status IN ('QUEUED', 'RUNNING');
+
+-- Index for correlation lookups
+CREATE INDEX IF NOT EXISTS idx_telemetry_runs_correlation ON telemetry_analysis_runs (correlation_id) WHERE correlation_id IS NOT NULL;
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION update_telemetry_runs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_telemetry_runs_updated_at ON telemetry_analysis_runs;
+CREATE TRIGGER trg_telemetry_runs_updated_at
+BEFORE UPDATE ON telemetry_analysis_runs
+FOR EACH ROW EXECUTE FUNCTION update_telemetry_runs_updated_at();
+
+-- RLS
+ALTER TABLE telemetry_analysis_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY telemetry_analysis_runs_service_all ON telemetry_analysis_runs
+  FOR ALL USING (auth.role() = 'service_role');
+
+CREATE POLICY telemetry_analysis_runs_anon_read ON telemetry_analysis_runs
+  FOR SELECT USING (true);
+
+-- Comment
+COMMENT ON TABLE telemetry_analysis_runs IS 'Tracks lifecycle of telemetry auto-analysis runs (QUEUED->RUNNING->SUCCEEDED/FAILED/TIMED_OUT)';

--- a/lib/telemetry/auto-trigger.js
+++ b/lib/telemetry/auto-trigger.js
@@ -1,0 +1,326 @@
+/**
+ * Telemetry Auto-Trigger - Session start integration for bottleneck analysis
+ *
+ * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001C
+ *
+ * Checks staleness of last analysis run and enqueues a new run if stale.
+ * Designed to be called from session initialization hooks without blocking startup.
+ *
+ * @module telemetry/auto-trigger
+ */
+
+import { randomUUID } from 'crypto';
+import { analyzeBottlenecks } from './bottleneck-analyzer.js';
+
+const DEFAULT_STALENESS_DAYS = 7;
+const DEFAULT_TIMEOUT_MS = 120000;
+const DEDUP_WINDOW_MINUTES = 10;
+
+/**
+ * Check if telemetry analysis is stale and needs to run.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {object} [opts={}]
+ * @param {string} [opts.scopeType='workspace'] - Scope type
+ * @param {string} [opts.scopeId] - Scope identifier
+ * @param {number} [opts.stalenessDays] - Override staleness threshold
+ * @returns {Promise<{isStale: boolean, lastSuccessAt: string|null, decision: string, durationMs: number}>}
+ */
+export async function checkStaleness(supabase, opts = {}) {
+  const startMs = Date.now();
+  const scopeType = opts.scopeType || 'workspace';
+  const scopeId = opts.scopeId || process.cwd();
+  const stalenessDays = opts.stalenessDays || DEFAULT_STALENESS_DAYS;
+
+  const cutoff = new Date(Date.now() - stalenessDays * 86400000).toISOString();
+
+  const { data, error } = await supabase
+    .from('telemetry_analysis_runs')
+    .select('finished_at')
+    .eq('scope_type', scopeType)
+    .eq('status', 'SUCCEEDED')
+    .or(`scope_id.eq.${scopeId},scope_id.is.null`)
+    .gte('finished_at', cutoff)
+    .order('finished_at', { ascending: false })
+    .limit(1);
+
+  const durationMs = Date.now() - startMs;
+
+  if (error) {
+    return { isStale: true, lastSuccessAt: null, decision: 'stale_query_error', durationMs };
+  }
+
+  if (!data || data.length === 0) {
+    return { isStale: true, lastSuccessAt: null, decision: 'stale_no_recent_run', durationMs };
+  }
+
+  return { isStale: false, lastSuccessAt: data[0].finished_at, decision: 'fresh', durationMs };
+}
+
+/**
+ * Check if there's already an active (QUEUED/RUNNING) run for this scope.
+ *
+ * @param {object} supabase
+ * @param {object} opts
+ * @returns {Promise<{isDuplicate: boolean, existingRunId: string|null}>}
+ */
+async function checkDuplicate(supabase, opts = {}) {
+  const scopeType = opts.scopeType || 'workspace';
+  const scopeId = opts.scopeId || process.cwd();
+  const cutoff = new Date(Date.now() - DEDUP_WINDOW_MINUTES * 60000).toISOString();
+
+  const { data } = await supabase
+    .from('telemetry_analysis_runs')
+    .select('run_id')
+    .eq('scope_type', scopeType)
+    .in('status', ['QUEUED', 'RUNNING'])
+    .or(`scope_id.eq.${scopeId},scope_id.is.null`)
+    .gte('triggered_at', cutoff)
+    .limit(1);
+
+  if (data && data.length > 0) {
+    return { isDuplicate: true, existingRunId: data[0].run_id };
+  }
+  return { isDuplicate: false, existingRunId: null };
+}
+
+/**
+ * Enqueue a telemetry analysis run. Creates a tracking record and
+ * starts analysis asynchronously (fire-and-forget with timeout).
+ *
+ * @param {object} supabase
+ * @param {object} [opts={}]
+ * @param {string} [opts.scopeType='workspace']
+ * @param {string} [opts.scopeId]
+ * @param {string} [opts.triggeredBy='SESSION_START']
+ * @param {string} [opts.correlationId]
+ * @param {number} [opts.timeoutMs]
+ * @returns {Promise<{enqueued: boolean, runId: string|null, decision: string, error: string|null}>}
+ */
+export async function enqueueAnalysis(supabase, opts = {}) {
+  const scopeType = opts.scopeType || 'workspace';
+  const scopeId = opts.scopeId || process.cwd();
+  const triggeredBy = opts.triggeredBy || 'SESSION_START';
+  const correlationId = opts.correlationId || randomUUID();
+  const timeoutMs = opts.timeoutMs || DEFAULT_TIMEOUT_MS;
+  const runId = randomUUID();
+
+  // Dedup check
+  const { isDuplicate, existingRunId } = await checkDuplicate(supabase, { scopeType, scopeId });
+  if (isDuplicate) {
+    return { enqueued: false, runId: existingRunId, decision: 'already_queued', error: null };
+  }
+
+  // Create tracking record
+  const { error: insertError } = await supabase
+    .from('telemetry_analysis_runs')
+    .insert({
+      run_id: runId,
+      scope_type: scopeType,
+      scope_id: scopeId,
+      status: 'QUEUED',
+      triggered_by: triggeredBy,
+      triggered_at: new Date().toISOString(),
+      correlation_id: correlationId,
+      metadata: { timeout_ms: timeoutMs },
+    });
+
+  if (insertError) {
+    return { enqueued: false, runId: null, decision: 'enqueue_failed', error: insertError.message };
+  }
+
+  // Fire-and-forget: execute analysis asynchronously with timeout
+  executeAnalysisAsync(supabase, runId, timeoutMs).catch(() => {
+    // Errors handled inside executeAnalysisAsync
+  });
+
+  return { enqueued: true, runId, decision: 'enqueued', error: null };
+}
+
+/**
+ * Execute the bottleneck analysis with timeout and lifecycle tracking.
+ * This runs asynchronously after enqueue.
+ */
+async function executeAnalysisAsync(supabase, runId, timeoutMs) {
+  const startedAt = new Date().toISOString();
+
+  // Mark RUNNING
+  await supabase
+    .from('telemetry_analysis_runs')
+    .update({ status: 'RUNNING', started_at: startedAt })
+    .eq('run_id', runId);
+
+  try {
+    // Run with timeout
+    const result = await Promise.race([
+      analyzeBottlenecks(supabase, { runId, enableAutoCreate: true }),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('TIMEOUT')), timeoutMs)
+      ),
+    ]);
+
+    const finishedAt = new Date().toISOString();
+    const durationMs = Date.now() - new Date(startedAt).getTime();
+
+    // Determine reason code
+    let reasonCode = null;
+    if (result.traces_scanned === 0) {
+      reasonCode = 'INSUFFICIENT_DATA';
+    }
+
+    await supabase
+      .from('telemetry_analysis_runs')
+      .update({
+        status: 'SUCCEEDED',
+        finished_at: finishedAt,
+        duration_ms: durationMs,
+        findings_count: result.bottlenecks.length,
+        top_bottleneck_category: result.bottlenecks[0]?.dimension_type || null,
+        reason_code: reasonCode,
+        output_ref: {
+          bottlenecks: result.bottlenecks,
+          traces_scanned: result.traces_scanned,
+          dimensions_evaluated: result.dimensions_evaluated,
+          items_created: result.items_created,
+        },
+      })
+      .eq('run_id', runId);
+
+    process.stderr.write(
+      `[telemetry:auto] Analysis complete: ${result.bottlenecks.length} bottleneck(s), ${result.traces_scanned} traces, ${durationMs}ms\n`
+    );
+  } catch (err) {
+    const finishedAt = new Date().toISOString();
+    const durationMs = Date.now() - new Date(startedAt).getTime();
+    const isTimeout = err.message === 'TIMEOUT';
+
+    const sanitizedMsg = (err.message || '').replace(/password=[^&\s]+/gi, 'password=***');
+
+    await supabase
+      .from('telemetry_analysis_runs')
+      .update({
+        status: isTimeout ? 'TIMED_OUT' : 'FAILED',
+        finished_at: finishedAt,
+        duration_ms: durationMs,
+        error_class: isTimeout ? 'TimeoutError' : err.constructor?.name || 'Error',
+        error_message: sanitizedMsg,
+      })
+      .eq('run_id', runId);
+
+    process.stderr.write(
+      `[telemetry:auto] Analysis ${isTimeout ? 'timed out' : 'failed'}: ${sanitizedMsg}\n`
+    );
+  }
+}
+
+/**
+ * Main entry point for session start integration.
+ * Checks staleness and enqueues analysis if needed.
+ * Designed to be non-blocking and safe (never throws).
+ *
+ * @param {object} supabase
+ * @param {object} [opts={}]
+ * @returns {Promise<{decision: string, correlationId: string, durationMs: number}>}
+ */
+export async function triggerIfStale(supabase, opts = {}) {
+  const correlationId = opts.correlationId || randomUUID();
+  const startMs = Date.now();
+
+  try {
+    // FR-6: Structured log for decision
+    const staleness = await checkStaleness(supabase, opts);
+
+    const logEvent = {
+      event: 'telemetry_auto_analysis_decision',
+      scope: opts.scopeType || 'workspace',
+      is_stale: staleness.isStale,
+      last_success_at: staleness.lastSuccessAt,
+      decision: staleness.decision,
+      correlation_id: correlationId,
+      duration_ms: staleness.durationMs,
+    };
+
+    if (!staleness.isStale) {
+      process.stderr.write(`[telemetry:auto] ${JSON.stringify(logEvent)}\n`);
+      return { decision: 'skipped_fresh', correlationId, durationMs: Date.now() - startMs };
+    }
+
+    // Enqueue analysis
+    const enqueueResult = await enqueueAnalysis(supabase, {
+      ...opts,
+      correlationId,
+    });
+
+    logEvent.decision = enqueueResult.decision;
+    logEvent.run_id = enqueueResult.runId;
+    process.stderr.write(`[telemetry:auto] ${JSON.stringify(logEvent)}\n`);
+
+    if (enqueueResult.error) {
+      process.stderr.write(
+        `[telemetry:auto] Enqueue failed: ${enqueueResult.error}\n`
+      );
+    }
+
+    return {
+      decision: enqueueResult.decision,
+      correlationId,
+      durationMs: Date.now() - startMs,
+    };
+  } catch (err) {
+    // FR-4: Never crash the session
+    const sanitized = (err.message || '').replace(/password=[^&\s]+/gi, 'password=***');
+    process.stderr.write(`[telemetry:auto] Error (non-fatal): ${sanitized}\n`);
+    return { decision: 'error_non_fatal', correlationId, durationMs: Date.now() - startMs };
+  }
+}
+
+/**
+ * Get the latest successful analysis findings for sd:next display (FR-5).
+ *
+ * @param {object} supabase
+ * @param {object} [opts={}]
+ * @returns {Promise<{hasFreshFindings: boolean, run: object|null, ageInDays: number|null, activeRun: object|null}>}
+ */
+export async function getLatestFindings(supabase, opts = {}) {
+  const scopeType = opts.scopeType || 'workspace';
+  const maxAgeDays = opts.maxAgeDays || 30;
+  const cutoff = new Date(Date.now() - maxAgeDays * 86400000).toISOString();
+
+  // Get latest SUCCEEDED run
+  const { data: succeeded } = await supabase
+    .from('telemetry_analysis_runs')
+    .select('run_id, finished_at, findings_count, top_bottleneck_category, output_ref, reason_code, duration_ms')
+    .eq('scope_type', scopeType)
+    .eq('status', 'SUCCEEDED')
+    .gte('finished_at', cutoff)
+    .order('finished_at', { ascending: false })
+    .limit(1);
+
+  // Check for active runs
+  const { data: active } = await supabase
+    .from('telemetry_analysis_runs')
+    .select('run_id, status, triggered_at')
+    .eq('scope_type', scopeType)
+    .in('status', ['QUEUED', 'RUNNING'])
+    .order('triggered_at', { ascending: false })
+    .limit(1);
+
+  if (!succeeded || succeeded.length === 0) {
+    return {
+      hasFreshFindings: false,
+      run: null,
+      ageInDays: null,
+      activeRun: active?.[0] || null,
+    };
+  }
+
+  const run = succeeded[0];
+  const ageInDays = Math.round((Date.now() - new Date(run.finished_at).getTime()) / 86400000);
+
+  return {
+    hasFreshFindings: true,
+    run,
+    ageInDays,
+    activeRun: active?.[0] || null,
+  };
+}

--- a/lib/telemetry/index.js
+++ b/lib/telemetry/index.js
@@ -1,6 +1,6 @@
 /**
  * Telemetry module - public exports
- * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A, 001B
+ * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001A, 001B, 001C
  */
 
 export {
@@ -14,3 +14,10 @@ export {
 } from './workflow-timer.js';
 
 export { analyzeBottlenecks } from './bottleneck-analyzer.js';
+
+export {
+  checkStaleness,
+  enqueueAnalysis,
+  triggerIfStale,
+  getLatestFindings,
+} from './auto-trigger.js';

--- a/scripts/hooks/telemetry-auto-trigger.cjs
+++ b/scripts/hooks/telemetry-auto-trigger.cjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Session start hook: Telemetry auto-trigger
+ * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001C
+ *
+ * Checks if telemetry analysis is stale and enqueues a run if needed.
+ * Runs during SessionStart hook - must complete within 5s timeout.
+ * Analysis itself runs asynchronously and does NOT block session startup.
+ */
+
+const path = require('path');
+
+async function main() {
+  // Check feature flag
+  if (process.env.TELEMETRY_AUTO_ANALYSIS_ENABLED === 'false') {
+    return;
+  }
+
+  try {
+    require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
+  } catch {
+    // dotenv not critical
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    return; // Silent exit if no DB config
+  }
+
+  let createClient;
+  try {
+    ({ createClient } = require('@supabase/supabase-js'));
+  } catch {
+    return; // Silent exit if dependency missing
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  // Dynamic import for ESM module
+  let triggerIfStale;
+  try {
+    const mod = await import('../../lib/telemetry/auto-trigger.js');
+    triggerIfStale = mod.triggerIfStale;
+  } catch (err) {
+    process.stderr.write(`[telemetry:auto] Module load error: ${err.message}\n`);
+    return;
+  }
+
+  const result = await triggerIfStale(supabase, {
+    scopeType: 'workspace',
+    scopeId: process.env.CLAUDE_PROJECT_DIR || process.cwd(),
+  });
+
+  if (result.decision === 'enqueued') {
+    console.log(`[TELEMETRY] Auto-analysis enqueued (stale > 7 days)`);
+  } else if (result.decision === 'already_queued') {
+    // Silent - don't clutter session start
+  }
+  // 'skipped_fresh' and 'error_non_fatal' are silent
+}
+
+main().catch(() => {
+  // Never fail session start
+});

--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -38,7 +38,8 @@ import {
   showFallbackQueue,
   showExhaustedBaselineMessage,
   displayBlockedStateBanner,
-  isOrchestratorBlocked
+  isOrchestratorBlocked,
+  displayTelemetryFindings
 } from './display/index.js';
 import {
   detectAllBlockedState,
@@ -182,6 +183,9 @@ export class SDNextSelector {
     // Display session context
     displaySessionContext(this.recentActivity);
 
+    // Display telemetry findings (SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001C)
+    await this.displayTelemetryFindings();
+
     console.log(`\n${colors.cyan}═══════════════════════════════════════════════════════════════════${colors.reset}\n`);
 
     return recommendation || { action: 'none', sd_id: null, reason: 'No recommendation available' };
@@ -316,6 +320,17 @@ export class SDNextSelector {
       currentSession: this.currentSession,
       activeSessions: this.activeSessions
     };
+  }
+
+  async displayTelemetryFindings() {
+    try {
+      const { getLatestFindings } = await import('../../../lib/telemetry/auto-trigger.js');
+      const verbose = process.argv.includes('--verbose');
+      const findings = await getLatestFindings(this.supabase);
+      displayTelemetryFindings(findings, { verbose });
+    } catch {
+      // Non-critical - silently skip if telemetry module unavailable
+    }
   }
 
   getSDRepos(sd) {

--- a/scripts/modules/sd-next/display/index.js
+++ b/scripts/modules/sd-next/display/index.js
@@ -24,3 +24,4 @@ export {
   getBlockedStateIndicator,
   isOrchestratorBlocked
 } from './blocked-state.js';
+export { displayTelemetryFindings } from './telemetry-findings.js';

--- a/scripts/modules/sd-next/display/telemetry-findings.js
+++ b/scripts/modules/sd-next/display/telemetry-findings.js
@@ -1,0 +1,93 @@
+/**
+ * Telemetry Findings Display for SD-Next
+ * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001C
+ *
+ * Renders latest bottleneck analysis findings in the sd:next output.
+ */
+
+import { colors } from '../colors.js';
+
+/**
+ * Display telemetry findings section in sd:next output.
+ *
+ * @param {object} findings - Result from getLatestFindings()
+ * @param {object} [opts={}]
+ * @param {boolean} [opts.verbose=false] - Show detailed bottleneck data
+ */
+export function displayTelemetryFindings(findings, opts = {}) {
+  if (!findings) return;
+
+  console.log(`${colors.bold}${colors.cyan}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold} WORKFLOW TELEMETRY${colors.reset}`);
+  console.log(`${colors.cyan}───────────────────────────────────────────────────────────────────${colors.reset}`);
+
+  if (!findings.hasFreshFindings) {
+    const msg = 'No workflow telemetry analysis available yet';
+    if (findings.activeRun) {
+      const status = findings.activeRun.status === 'RUNNING' ? 'running' : 'queued';
+      console.log(`  ${colors.dim}${msg} (analysis ${status})${colors.reset}`);
+    } else {
+      console.log(`  ${colors.dim}${msg}${colors.reset}`);
+    }
+    console.log('');
+    return;
+  }
+
+  const run = findings.run;
+  const age = findings.ageInDays;
+  const ageLabel = age === 0 ? 'today' : age === 1 ? '1 day ago' : `${age} days ago`;
+  const finishedDate = new Date(run.finished_at).toLocaleDateString();
+
+  console.log(`  ${colors.dim}Last analysis: ${finishedDate} (${ageLabel})${colors.reset}`);
+
+  if (run.reason_code === 'INSUFFICIENT_DATA') {
+    console.log(`  ${colors.dim}Insufficient trace data for analysis${colors.reset}`);
+    console.log('');
+    return;
+  }
+
+  if (run.findings_count === 0) {
+    console.log(`  ${colors.green}No bottlenecks detected${colors.reset}`);
+    console.log('');
+    return;
+  }
+
+  console.log(`  ${colors.yellow}${run.findings_count} bottleneck(s) detected${colors.reset}`);
+
+  // Compact summary (max 5 lines per FR-5)
+  const bottlenecks = run.output_ref?.bottlenecks || [];
+  const summaryItems = bottlenecks.slice(0, 5);
+
+  for (const b of summaryItems) {
+    const ratioColor = b.ratio >= 5 ? colors.red : colors.yellow;
+    console.log(
+      `  ${ratioColor}${b.ratio}x${colors.reset} ${b.dimension_type}:${b.dimension_key} ` +
+      `${colors.dim}(p50=${b.observed_p50_ms}ms vs baseline=${b.baseline_p50_ms}ms)${colors.reset}`
+    );
+  }
+
+  if (bottlenecks.length > 5) {
+    console.log(`  ${colors.dim}... and ${bottlenecks.length - 5} more${colors.reset}`);
+  }
+
+  // Verbose: full details
+  if (opts.verbose && bottlenecks.length > 0) {
+    console.log(`\n  ${colors.bold}Details:${colors.reset}`);
+    for (const b of bottlenecks) {
+      console.log(`  ${colors.bold}${b.dimension_type}:${b.dimension_key}${colors.reset}`);
+      console.log(`    Observed P50: ${b.observed_p50_ms}ms | Baseline P50: ${b.baseline_p50_ms}ms | Ratio: ${b.ratio}x`);
+      console.log(`    Samples: ${b.sample_count} | Exceedances: ${b.exceedance_count}`);
+      if (b.improvement_id) {
+        console.log(`    Improvement: ${b.improvement_id}`);
+      }
+    }
+  }
+
+  // Metadata line
+  const meta = run.output_ref || {};
+  if (meta.traces_scanned) {
+    console.log(`  ${colors.dim}(${meta.traces_scanned} traces, ${meta.dimensions_evaluated} dimensions, ${run.duration_ms}ms)${colors.reset}`);
+  }
+
+  console.log('');
+}

--- a/scripts/modules/sd-next/index.js
+++ b/scripts/modules/sd-next/index.js
@@ -51,7 +51,8 @@ export {
   showExhaustedBaselineMessage,
   displayBlockedStateBanner,
   getBlockedStateIndicator,
-  isOrchestratorBlocked
+  isOrchestratorBlocked,
+  displayTelemetryFindings
 } from './display/index.js';
 
 // Blocked state detection (SD-LEO-ENH-AUTO-PROCEED-001-12)

--- a/tests/unit/telemetry/auto-trigger.test.js
+++ b/tests/unit/telemetry/auto-trigger.test.js
@@ -1,0 +1,229 @@
+/**
+ * Unit tests for auto-trigger.js
+ * SD: SD-LEO-ENH-WORKFLOW-TELEMETRY-AUTO-001C
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { checkStaleness, enqueueAnalysis, triggerIfStale, getLatestFindings } from '../../../lib/telemetry/auto-trigger.js';
+
+// Mock bottleneck-analyzer to avoid real analysis in tests
+vi.mock('../../../lib/telemetry/bottleneck-analyzer.js', () => ({
+  analyzeBottlenecks: vi.fn().mockResolvedValue({
+    run_id: 'mock-run',
+    traces_scanned: 100,
+    dimensions_evaluated: 10,
+    bottlenecks: [],
+    items_created: 0,
+    items_skipped_rate_limit: 0,
+    items_skipped_dedupe: 0,
+    errors: [],
+  }),
+}));
+
+function createMockSupabase(overrides = {}) {
+  const mockChain = (tableName) => {
+    const state = { table: tableName, filters: [], insertData: null };
+    const chainObj = {
+      select: () => chainObj,
+      insert: (data) => { state.insertData = data; return chainObj; },
+      update: (data) => { state.updateData = data; return chainObj; },
+      eq: (col, val) => { state.filters.push({ col, val }); return chainObj; },
+      in: (col, vals) => { state.filters.push({ col, vals }); return chainObj; },
+      gte: (col, val) => { state.filters.push({ type: 'gte', col, val }); return chainObj; },
+      or: (expr) => { state.filters.push({ type: 'or', expr }); return chainObj; },
+      order: () => chainObj,
+      limit: () => chainObj,
+      single: () => {
+        if (state.insertData) {
+          return { data: { id: 'mock-id' }, error: overrides.insertError ?? null };
+        }
+        return { data: null, error: null };
+      },
+      then: (resolve) => {
+        let result;
+        if (state.table === 'telemetry_analysis_runs') {
+          if (state.insertData) {
+            result = { data: null, error: overrides.insertError ?? null };
+          } else if (state.updateData) {
+            result = { data: null, error: null };
+          } else {
+            // Query - check status filter to determine what we're looking for
+            const statusFilter = state.filters.find(f => f.col === 'status' && f.val === 'SUCCEEDED');
+            const activeFilter = state.filters.find(f => f.vals && f.vals.includes('QUEUED'));
+
+            if (statusFilter) {
+              result = { data: overrides.succeededRuns ?? [], error: null };
+            } else if (activeFilter) {
+              result = { data: overrides.activeRuns ?? [], error: null };
+            } else {
+              result = { data: [], error: null };
+            }
+          }
+        } else {
+          result = { data: [], error: null };
+        }
+        return Promise.resolve(resolve(result));
+      },
+    };
+    return chainObj;
+  };
+
+  return { from: mockChain };
+}
+
+describe('checkStaleness', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns stale when no recent SUCCEEDED run exists', async () => {
+    const supabase = createMockSupabase({ succeededRuns: [] });
+    const result = await checkStaleness(supabase);
+
+    expect(result.isStale).toBe(true);
+    expect(result.lastSuccessAt).toBeNull();
+    expect(result.decision).toBe('stale_no_recent_run');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns fresh when recent SUCCEEDED run exists', async () => {
+    const recentDate = new Date().toISOString();
+    const supabase = createMockSupabase({
+      succeededRuns: [{ finished_at: recentDate }],
+    });
+    const result = await checkStaleness(supabase);
+
+    expect(result.isStale).toBe(false);
+    expect(result.lastSuccessAt).toBe(recentDate);
+    expect(result.decision).toBe('fresh');
+  });
+});
+
+describe('enqueueAnalysis', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('enqueues when no active run exists', async () => {
+    const supabase = createMockSupabase({ activeRuns: [] });
+    const result = await enqueueAnalysis(supabase);
+
+    expect(result.enqueued).toBe(true);
+    expect(result.runId).toBeTruthy();
+    expect(result.decision).toBe('enqueued');
+    expect(result.error).toBeNull();
+  });
+
+  it('skips when active run already exists (dedup)', async () => {
+    const supabase = createMockSupabase({
+      activeRuns: [{ run_id: 'existing-run-123' }],
+    });
+    const result = await enqueueAnalysis(supabase);
+
+    expect(result.enqueued).toBe(false);
+    expect(result.runId).toBe('existing-run-123');
+    expect(result.decision).toBe('already_queued');
+  });
+
+  it('handles insert error gracefully', async () => {
+    const supabase = createMockSupabase({
+      activeRuns: [],
+      insertError: { message: 'connection refused' },
+    });
+    const result = await enqueueAnalysis(supabase);
+
+    expect(result.enqueued).toBe(false);
+    expect(result.decision).toBe('enqueue_failed');
+    expect(result.error).toContain('connection refused');
+  });
+});
+
+describe('triggerIfStale', () => {
+  let stderrSpy;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+  });
+
+  it('skips when analysis is fresh', async () => {
+    const supabase = createMockSupabase({
+      succeededRuns: [{ finished_at: new Date().toISOString() }],
+    });
+    const result = await triggerIfStale(supabase);
+
+    expect(result.decision).toBe('skipped_fresh');
+    expect(result.correlationId).toBeTruthy();
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('enqueues when analysis is stale', async () => {
+    const supabase = createMockSupabase({
+      succeededRuns: [],
+      activeRuns: [],
+    });
+    const result = await triggerIfStale(supabase);
+
+    expect(result.decision).toBe('enqueued');
+  });
+
+  it('never throws (returns error_non_fatal)', async () => {
+    // Pass a broken supabase that throws
+    const brokenSupabase = {
+      from: () => { throw new Error('totally broken'); },
+    };
+
+    const result = await triggerIfStale(brokenSupabase);
+
+    expect(result.decision).toBe('error_non_fatal');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('getLatestFindings', () => {
+  it('returns hasFreshFindings=false when no SUCCEEDED run', async () => {
+    const supabase = createMockSupabase({ succeededRuns: [], activeRuns: [] });
+    const result = await getLatestFindings(supabase);
+
+    expect(result.hasFreshFindings).toBe(false);
+    expect(result.run).toBeNull();
+    expect(result.ageInDays).toBeNull();
+  });
+
+  it('returns findings with age when SUCCEEDED run exists', async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString();
+    const supabase = createMockSupabase({
+      succeededRuns: [{
+        run_id: 'run-123',
+        finished_at: yesterday,
+        findings_count: 2,
+        top_bottleneck_category: 'phase',
+        output_ref: { bottlenecks: [{}, {}] },
+        duration_ms: 500,
+      }],
+      activeRuns: [],
+    });
+    const result = await getLatestFindings(supabase);
+
+    expect(result.hasFreshFindings).toBe(true);
+    expect(result.run.run_id).toBe('run-123');
+    expect(result.ageInDays).toBe(1);
+    expect(result.activeRun).toBeNull();
+  });
+
+  it('includes active run info when analysis is queued', async () => {
+    const supabase = createMockSupabase({
+      succeededRuns: [],
+      activeRuns: [{ run_id: 'active-456', status: 'RUNNING', triggered_at: new Date().toISOString() }],
+    });
+    const result = await getLatestFindings(supabase);
+
+    expect(result.hasFreshFindings).toBe(false);
+    expect(result.activeRun).toBeTruthy();
+    expect(result.activeRun.run_id).toBe('active-456');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `auto-trigger.js` - staleness check (7-day threshold), dedup (10-min window), and async execution with 120s timeout
- Add `telemetry_analysis_runs` table for run lifecycle tracking (QUEUED -> RUNNING -> SUCCEEDED/FAILED/TIMED_OUT)
- Add SessionStart hook that auto-enqueues analysis when stale, without blocking session startup
- Add telemetry findings display in `sd:next` output (compact summary + `--verbose` details mode)
- Feature flag `TELEMETRY_AUTO_ANALYSIS_ENABLED` (default: enabled)
- Completes the orchestrator's autonomous feedback loop: collect (001A) -> analyze (001B) -> trigger (001C)

## Test plan
- [x] 11 unit tests passing (staleness, dedup, error handling, findings)
- [x] 525 smoke tests passing
- [x] Hook tested against live DB: 1000 traces, 91 dimensions, 171ms
- [x] ESLint clean, no secrets detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)