### PR TITLE
fix(EVA): incremental sync caching and Windows OAuth fix

### DIFF
--- a/lib/integrations/todoist/todoist-sync.js
+++ b/lib/integrations/todoist/todoist-sync.js
@@ -81,21 +81,34 @@ function mapTaskToIntakeRow(task, project) {
 }
 
 /**
- * Upsert tasks to eva_todoist_intake table
+ * Load known task IDs from database for incremental sync
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<Map<string, {id: string, status: string}>>} Map of todoist_task_id to {id, status}
+ */
+async function loadKnownTasks(supabase) {
+  const known = new Map();
+  const { data } = await supabase
+    .from('eva_todoist_intake')
+    .select('id, todoist_task_id, status');
+
+  for (const row of data || []) {
+    known.set(row.todoist_task_id, { id: row.id, status: row.status });
+  }
+  return known;
+}
+
+/**
+ * Upsert tasks to eva_todoist_intake table (incremental - skips known non-pending items)
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  * @param {Array} rows - Mapped intake rows
- * @returns {Promise<{inserted: number, updated: number, errors: Array}>}
+ * @param {Map} knownTasks - Pre-loaded known task map
+ * @returns {Promise<{inserted: number, updated: number, skipped: number, errors: Array}>}
  */
-async function upsertTasks(supabase, rows) {
-  const results = { inserted: 0, updated: 0, errors: [] };
+async function upsertTasks(supabase, rows, knownTasks) {
+  const results = { inserted: 0, updated: 0, skipped: 0, errors: [] };
 
   for (const row of rows) {
-    // Check if exists
-    const { data: existing } = await supabase
-      .from('eva_todoist_intake')
-      .select('id, status')
-      .eq('todoist_task_id', row.todoist_task_id)
-      .maybeSingle();
+    const existing = knownTasks.get(row.todoist_task_id);
 
     if (existing) {
       // Update only if still in pending state (don't overwrite evaluated items)
@@ -118,6 +131,8 @@ async function upsertTasks(supabase, rows) {
         } else {
           results.updated++;
         }
+      } else {
+        results.skipped++;
       }
     } else {
       // Insert new
@@ -221,6 +236,7 @@ export async function syncTodoist(options = {}) {
     projects: [],
     totalInserted: 0,
     totalUpdated: 0,
+    totalSkipped: 0,
     totalErrors: 0,
     dryRun
   };
@@ -233,6 +249,13 @@ export async function syncTodoist(options = {}) {
     return results;
   }
 
+  // Pre-load known tasks for incremental sync (single DB query)
+  const knownTasks = await loadKnownTasks(supabase);
+
+  if (verbose) {
+    console.log(`  Already in database: ${knownTasks.size} tasks`);
+  }
+
   for (const project of projects) {
     const projectResult = {
       name: project.name,
@@ -240,6 +263,7 @@ export async function syncTodoist(options = {}) {
       tasksFound: 0,
       inserted: 0,
       updated: 0,
+      skipped: 0,
       errors: []
     };
 
@@ -268,17 +292,20 @@ export async function syncTodoist(options = {}) {
       const rows = tasks.map(t => mapTaskToIntakeRow(t, project));
 
       if (dryRun) {
-        console.log(`  [DRY RUN] "${project.name}": ${rows.length} tasks would be synced`);
-        rows.forEach(r => console.log(`    - ${r.title}`));
+        const newRows = rows.filter(r => !knownTasks.has(r.todoist_task_id));
+        console.log(`  [DRY RUN] "${project.name}": ${rows.length} tasks (${newRows.length} new)`);
+        newRows.forEach(r => console.log(`    + ${r.title}`));
       } else {
-        // Upsert to database
-        const upsertResult = await upsertTasks(supabase, rows);
+        // Upsert to database (uses pre-loaded cache instead of per-row queries)
+        const upsertResult = await upsertTasks(supabase, rows, knownTasks);
         projectResult.inserted = upsertResult.inserted;
         projectResult.updated = upsertResult.updated;
+        projectResult.skipped = upsertResult.skipped;
         projectResult.errors = upsertResult.errors;
 
         results.totalInserted += upsertResult.inserted;
         results.totalUpdated += upsertResult.updated;
+        results.totalSkipped = (results.totalSkipped || 0) + upsertResult.skipped;
         results.totalErrors += upsertResult.errors.length;
 
         // Update sync state (success)

--- a/lib/integrations/youtube/oauth-manager.js
+++ b/lib/integrations/youtube/oauth-manager.js
@@ -139,9 +139,13 @@ export async function runOAuthFlow() {
   // Open browser
   const { exec } = await import('child_process');
   const platform = process.platform;
-  const cmd = platform === 'win32' ? 'start' :
-              platform === 'darwin' ? 'open' : 'xdg-open';
-  exec(`${cmd} "${authUrl}"`);
+  if (platform === 'win32') {
+    // Windows: start "" "url" - first quoted arg is window title
+    exec(`start "" "${authUrl}"`);
+  } else {
+    const cmd = platform === 'darwin' ? 'open' : 'xdg-open';
+    exec(`${cmd} "${authUrl}"`);
+  }
 
   // Start local server to catch callback
   const code = await new Promise((resolve, reject) => {
@@ -170,11 +174,11 @@ export async function runOAuthFlow() {
       console.log(`  Waiting for authorization callback on port ${REDIRECT_PORT}...`);
     });
 
-    // Timeout after 2 minutes
+    // Timeout after 5 minutes
     setTimeout(() => {
       server.close();
-      reject(new Error('OAuth timeout - no callback received within 2 minutes'));
-    }, 120000);
+      reject(new Error('OAuth timeout - no callback received within 5 minutes'));
+    }, 300000);
   });
 
   // Exchange code for tokens

--- a/lib/integrations/youtube/playlist-sync.js
+++ b/lib/integrations/youtube/playlist-sync.js
@@ -147,20 +147,34 @@ function mapVideoToIntakeRow(item, videoDetail = {}) {
 }
 
 /**
- * Upsert videos to eva_youtube_intake table
+ * Load known video IDs from database for incremental sync
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<Map<string, {id: string, status: string}>>} Map of youtube_video_id to {id, status}
+ */
+async function loadKnownVideos(supabase) {
+  const known = new Map();
+  const { data } = await supabase
+    .from('eva_youtube_intake')
+    .select('id, youtube_video_id, status');
+
+  for (const row of data || []) {
+    known.set(row.youtube_video_id, { id: row.id, status: row.status });
+  }
+  return known;
+}
+
+/**
+ * Upsert videos to eva_youtube_intake table (incremental - skips known non-pending items)
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  * @param {Array} rows - Mapped intake rows
- * @returns {Promise<{inserted: number, updated: number, errors: Array}>}
+ * @param {Map} knownVideos - Pre-loaded known video map
+ * @returns {Promise<{inserted: number, updated: number, skipped: number, errors: Array}>}
  */
-async function upsertVideos(supabase, rows) {
-  const results = { inserted: 0, updated: 0, errors: [] };
+async function upsertVideos(supabase, rows, knownVideos) {
+  const results = { inserted: 0, updated: 0, skipped: 0, errors: [] };
 
   for (const row of rows) {
-    const { data: existing } = await supabase
-      .from('eva_youtube_intake')
-      .select('id, status')
-      .eq('youtube_video_id', row.youtube_video_id)
-      .maybeSingle();
+    const existing = knownVideos.get(row.youtube_video_id);
 
     if (existing) {
       if (existing.status === 'pending') {
@@ -184,6 +198,8 @@ async function upsertVideos(supabase, rows) {
         } else {
           results.updated++;
         }
+      } else {
+        results.skipped++;
       }
     } else {
       const { error } = await supabase
@@ -309,22 +325,39 @@ export async function syncYouTube(options = {}) {
       console.log(`  Found playlist: "${playlist.snippet.title}" (${playlist.id})`);
     }
 
-    // Fetch all videos
+    // Pre-load known videos for incremental sync
+    const knownVideos = await loadKnownVideos(supabase);
+
+    // Fetch all playlist items (1 unit per 50 items - cheap)
     let items = await fetchPlaylistVideos(youtube, playlist.id);
 
     if (verbose) {
-      console.log(`  Videos found: ${items.length}`);
+      console.log(`  Videos in playlist: ${items.length}`);
+      console.log(`  Already in database: ${knownVideos.size}`);
     }
 
     if (limit && items.length > limit) {
       items = items.slice(0, limit);
     }
 
-    // Get video details (duration, tags)
-    const videoIds = items
+    // Filter to only new videos for detail API calls (saves quota)
+    const newItems = items.filter(item => {
+      const videoId = item.snippet?.resourceId?.videoId || item.contentDetails?.videoId;
+      return !knownVideos.has(videoId);
+    });
+
+    const newVideoIds = newItems
       .map(i => i.snippet?.resourceId?.videoId || i.contentDetails?.videoId)
       .filter(Boolean);
-    const videoDetails = await getVideoDetails(youtube, videoIds);
+
+    if (verbose) {
+      console.log(`  New videos to fetch details: ${newVideoIds.length}`);
+    }
+
+    // Only call videos.list for new videos (1 unit per 50 - skip for known)
+    const videoDetails = newVideoIds.length > 0
+      ? await getVideoDetails(youtube, newVideoIds)
+      : new Map();
 
     // Map to intake rows
     const rows = items.map(item => {
@@ -333,12 +366,17 @@ export async function syncYouTube(options = {}) {
     });
 
     if (dryRun) {
-      console.log(`  [DRY RUN] "${TARGET_PLAYLIST_NAME}": ${rows.length} videos would be synced`);
-      rows.forEach(r => console.log(`    - ${r.title} (${r.channel_name || 'unknown channel'})`));
+      console.log(`  [DRY RUN] "${TARGET_PLAYLIST_NAME}": ${rows.length} videos (${newItems.length} new)`);
+      newItems.forEach(item => {
+        const title = item.snippet?.title || 'Untitled';
+        const channel = item.snippet?.videoOwnerChannelTitle || 'unknown';
+        console.log(`    + ${title} (${channel})`);
+      });
     } else {
-      const upsertResult = await upsertVideos(supabase, rows);
+      const upsertResult = await upsertVideos(supabase, rows, knownVideos);
       results.totalInserted = upsertResult.inserted;
       results.totalUpdated = upsertResult.updated;
+      results.totalSkipped = upsertResult.skipped;
       results.totalErrors = upsertResult.errors.length;
 
       await updateSyncState(supabase, TARGET_PLAYLIST_NAME, upsertResult.inserted + upsertResult.updated);

--- a/scripts/eva-idea-sync.js
+++ b/scripts/eva-idea-sync.js
@@ -47,6 +47,7 @@ async function main() {
       results.todoist = await syncTodoist({ dryRun, limit, verbose });
       console.log(`  Inserted: ${results.todoist.totalInserted}`);
       console.log(`  Updated:  ${results.todoist.totalUpdated}`);
+      if (results.todoist.totalSkipped) console.log(`  Skipped:  ${results.todoist.totalSkipped} (already processed)`);
       console.log(`  Errors:   ${results.todoist.totalErrors}`);
     } catch (err) {
       console.error(`  Todoist sync failed: ${err.message}`);
@@ -62,6 +63,7 @@ async function main() {
       results.youtube = await syncYouTube({ dryRun, limit, verbose });
       console.log(`  Inserted: ${results.youtube.totalInserted}`);
       console.log(`  Updated:  ${results.youtube.totalUpdated}`);
+      if (results.youtube.totalSkipped) console.log(`  Skipped:  ${results.youtube.totalSkipped} (already synced)`);
       console.log(`  Errors:   ${results.youtube.totalErrors}`);
     } catch (err) {
       console.error(`  YouTube sync not yet available: ${err.message}`);


### PR DESCRIPTION
## Summary
- Pre-load known items from DB in single bulk query instead of per-item lookups (eliminates N+1 queries)
- Skip `videos.list` API calls for already-synced YouTube videos (saves API quota on repeat syncs)
- Fix Windows `start` command treating OAuth URL as window title (now uses `start ""`)
- Increase OAuth timeout from 2 to 5 minutes for browser authorization
- Show incremental sync stats (new/skipped counts) in CLI output

## Test plan
- [x] YouTube incremental sync: 101 videos, 0 new detail API calls on re-sync
- [x] Todoist incremental sync: 100 tasks, 4 new inserts detected on re-sync
- [x] YouTube OAuth flow with new GCP project credentials
- [x] Smoke tests pass (510/510)

🤖 Generated with [Claude Code](https://claude.com/claude-code)