### PR TITLE
fix(EVA): upgrade YouTube OAuth scope for post-processing

### DIFF
--- a/lib/integrations/youtube/oauth-manager.js
+++ b/lib/integrations/youtube/oauth-manager.js
@@ -14,7 +14,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const SCOPES = ['https://www.googleapis.com/auth/youtube.readonly'];
+const SCOPES = ['https://www.googleapis.com/auth/youtube'];
 const REDIRECT_PORT = 3456;
 const REDIRECT_URI = `http://localhost:${REDIRECT_PORT}/oauth2callback`;
 const SYNC_STATE_IDENTIFIER = 'youtube_oauth';


### PR DESCRIPTION
## Summary
- Changed YouTube OAuth scope from `youtube.readonly` to `youtube` (full access)
- Post-processing requires `playlistItems.insert` and `playlistItems.delete` to move videos between playlists, which are write operations not covered by readonly scope

## Test plan
- [x] Re-authenticated with new scope
- [x] 3 YouTube videos successfully moved from "For Processing" to "Processed" playlist
- [x] Smoke tests pass (510/510)

🤖 Generated with [Claude Code](https://claude.com/claude-code)