### PR TITLE
fix(gates): calibrate sdSuccessCriteria scoring curve

### DIFF
--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-l-sd-creation.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-l-sd-creation.js
@@ -60,13 +60,16 @@ export function registerGateLValidators(registry) {
   registry.register('sdSuccessCriteria', async (context) => {
     const { sd } = context;
     const metrics = sd?.success_metrics || [];
+    const criteria = sd?.success_criteria || [];
+    const totalItems = metrics.length + criteria.length;
 
-    if (metrics.length >= 3) {
+    if (totalItems >= 3) {
       return { passed: true, score: 100, max_score: 100, issues: [] };
-    } else if (metrics.length > 0) {
-      return { passed: false, score: 50, max_score: 100, issues: [`SD has ${metrics.length} success metrics, minimum 3 recommended`] };
+    } else if (totalItems > 0) {
+      // 1-2 items: score 80 (soft warning, not a threshold-breaker)
+      return { passed: true, score: 80, max_score: 100, issues: [], warnings: [`SD has ${totalItems} success criteria/metrics, 3+ recommended`] };
     }
-    return { passed: false, score: 0, max_score: 100, issues: ['No success metrics defined'] };
+    return { passed: false, score: 0, max_score: 100, issues: ['No success metrics or criteria defined'] };
   }, 'Verify SD has measurable success criteria');
 
   registry.register('sdRisksIdentified', async (context) => {


### PR DESCRIPTION
## Summary
- Combines `success_metrics` + `success_criteria` counts when evaluating SD success criteria (both are valid ways to define success)
- Softens scoring from 50 to 80 for SDs with 1-2 items (warning, not a blocker)
- Prevents cascading `SD_TYPE_THRESHOLD` failures caused by harsh scoring

Resolves PAT-AUTO-e646ab92 and PAT-AUTO-e74d3e36 (7 total occurrences).

QF-20260209-591

## Test plan
- [x] All 525 smoke tests pass
- [ ] Verify gate no longer blocks SDs with 1-2 success criteria/metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)