### PR TITLE
fix(hooks): prevent worktree accumulation from context compaction

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,13 +38,18 @@
           },
           {
             "type": "command",
-            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/concurrent-session-worktree.cjs",
-            "timeout": 5
-          },
-          {
-            "type": "command",
             "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/telemetry-auto-trigger.cjs",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/hooks/concurrent-session-worktree.cjs",
+            "timeout": 10
           }
         ]
       }


### PR DESCRIPTION
## Summary
- **Root cause**: `SessionStart` hooks fire on context compaction, not just new CLI processes. The concurrent-session-worktree hook was creating a new worktree on every compaction event, causing 33+ stale `concurrent-auto-*` worktrees to accumulate in 36 hours.
- **Fix 1**: Add `matcher: "startup"` to the hook registration so it only fires on actual new process starts, not compaction/resume/clear events
- **Fix 2**: Add inline `cleanupStaleConcurrentWorktrees()` that runs on each startup — removes concurrent worktrees older than 1 hour, handles locked entries, force-removes dirty worktrees

## Test plan
- [x] Verified 33 stale worktrees cleaned up (from 46 to 13 worktrees)
- [x] Smoke tests pass (60/60)
- [ ] Next session should NOT create a worktree on compaction
- [ ] Worktrees from genuine concurrent sessions should still be created on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)