### PR TITLE
feat: add /brainstorm standalone skill

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -1,0 +1,375 @@
+# /brainstorm - EHG-Aware Strategic Brainstorming
+
+EHG-aware brainstorming with structured output. Produces a document in `brainstorm/`.
+
+**Arguments**: `$ARGUMENTS`
+
+---
+
+## Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` for:
+- **Topic**: Everything that isn't a flag (e.g., "AI-powered customer support chatbot")
+- **`--structured`**: If present, use Structured Mode (full Phase 0 rigor). Otherwise, use Conversational Mode (default).
+- **`--stage <stage>`**: One of `ideation`, `validation`, `mvp`, `growth`, `scale`. If not provided, ask the user.
+
+If no topic is provided, ask the user: "What would you like to brainstorm?"
+
+---
+
+## Step 2: Determine EHG Stage
+
+If `--stage` was not provided in arguments, ask the user using AskUserQuestion:
+
+```
+question: "What EHG lifecycle stage is this venture/idea in?"
+header: "EHG Stage"
+options:
+  - label: "Ideation"
+    description: "Exploring the problem space, no committed solution yet"
+  - label: "Validation"
+    description: "Testing a specific hypothesis with minimal investment"
+  - label: "MVP"
+    description: "Building the minimum viable product for real users"
+  - label: "Growth"
+    description: "Scaling what works, improving retention and engagement"
+```
+
+(The 5th option "Scale" is available via "Other" if needed: optimizing efficiency, automation, enterprise readiness)
+
+---
+
+## Step 3: Route to Mode
+
+- If `--structured` flag is present → Go to **Structured Mode** (Step 4)
+- Otherwise → Go to **Conversational Mode** (Step 5)
+
+---
+
+## Step 4: Structured Mode (`--structured`)
+
+Full Phase 0 rigor: one-question-at-a-time, checkpoints, un-done proposals, crystallization scoring.
+
+### 4A: Discovery Questions (One at a Time)
+
+Ask questions ONE AT A TIME from the stage-appropriate question bank below. Wait for the user's answer before asking the next question. Ask all required questions (minimum 3), then offer optional ones.
+
+**After each answer**, briefly acknowledge the response before asking the next question.
+
+### 4B: STAGED_CHECKPOINT - Intent Synthesis
+
+After all required questions are answered, synthesize an intent summary:
+
+Present to the user:
+```
+**Intent Summary** (max 500 chars):
+[Your synthesis of the brainstorm topic based on answers so far]
+
+Does this capture the core intent? (yes / refine)
+```
+
+Use AskUserQuestion with options: "Yes, that captures it" and "Let me refine" (which lets them correct the summary).
+
+### 4C: UN_DONE_PROPOSAL - Out of Scope List
+
+Generate a list of at least 3 things that are explicitly OUT OF SCOPE for this idea. Present as:
+
+```
+**Explicitly Out of Scope:**
+1. [Thing that might seem related but isn't part of this]
+2. [Adjacent feature/capability we're NOT building]
+3. [Scale/complexity we're NOT targeting yet]
+```
+
+Ask user to confirm or adjust the out-of-scope list.
+
+### 4D: Crystallization Score
+
+Evaluate the crystallization of the idea on a 0.0-1.0 scale:
+
+| Factor | Weight | Score |
+|--------|--------|-------|
+| Problem clarity | 25% | 0.0-1.0 |
+| User/audience defined | 20% | 0.0-1.0 |
+| Success criteria exist | 20% | 0.0-1.0 |
+| Scope boundaries clear | 20% | 0.0-1.0 |
+| Risk/unknowns identified | 15% | 0.0-1.0 |
+
+**Threshold: 0.7** - Below this, note that more discovery is recommended before committing to implementation.
+
+Present the score breakdown to the user.
+
+### 4E: Four-Plane Evaluation Matrix
+
+Walk through all four planes of the EHG Venture Evaluation Matrix:
+
+**Plane 1: Capability Graph Impact** (Score 0-25)
+For each dimension, assess and score:
+- New Capability Node (0-5): Does this introduce a genuinely new capability?
+- Capability Reuse Potential (0-5): Likely to be reused by 2+ other ventures?
+- Graph Centrality Gain (0-5): Increases importance of existing core capabilities?
+- Maturity Lift (0-5): Hardens reliability, speed, or quality of existing capability?
+- Extraction Clarity (0-5): Can be abstracted cleanly (API, service, playbook)?
+
+Hard Rule: If Plane 1 < 10, venture must justify itself as a time-boxed exception or be rejected.
+
+**Plane 2: External Vector Alignment** (Score -10 to +25)
+Assess each vector as Tailwind / Neutral / Headwind with strength 0-5:
+- Market Demand Gradient
+- Technology Cost Curve
+- Regulatory Trajectory
+- Competitive Density
+- Timing Window (Now vs Later)
+
+Declare: Primary tailwind, Primary headwind, Headwind mitigation strategy.
+
+**Plane 3: Control & Constraint Exposure** (Pass / Block / Escalate)
+Assess exposure level (Low/Medium/High) for:
+- Spend Risk
+- Legal / Regulatory Risk
+- Brand Risk
+- Security / Data Risk
+- Autonomy Risk (agent misfire)
+
+Hard Rules: Any High exposure = escalation required. Missing kill-switch = automatic block.
+
+**Plane 4: Exploration vs Exploitation Position**
+Select dial position: Pure Exploration | Skewed Exploration | Balanced | Skewed Exploitation | Pure Exploitation
+
+Declare review interval and auto-expiry date (if exploratory).
+
+Present the full matrix assessment, then proceed to document generation (Step 6).
+
+---
+
+## Step 5: Conversational Mode (Default)
+
+Lighter brainstorming flow with 2-3 questions at a time.
+
+### 5A: Initial Questions
+
+Ask 2-3 stage-appropriate questions from the question bank below (pick the required ones for the selected stage). Present them together in a single message.
+
+### 5B: Follow-Up Questions
+
+Based on the answers, ask 1-2 follow-up questions to deepen understanding. These can be from the optional questions in the bank or generated based on the conversation.
+
+### 5C: Arguments For and Against
+
+Based on answers so far, present:
+
+**Arguments For:**
+- [3-4 compelling reasons to pursue this]
+
+**Arguments Against:**
+- [2-3 honest risks, challenges, or reasons to pause]
+
+### 5D: Optional Four-Plane Evaluation
+
+Ask the user using AskUserQuestion:
+
+```
+question: "Would you like a Four-Plane Evaluation Matrix analysis?"
+header: "Evaluation"
+options:
+  - label: "Yes, full evaluation"
+    description: "Walk through all 4 planes: Capability Impact, Vector Alignment, Constraints, Explore/Exploit"
+  - label: "Skip for now"
+    description: "Save evaluation for later, proceed to document"
+```
+
+If yes, run through the Four-Plane matrix from Step 4E.
+
+Then proceed to document generation (Step 6).
+
+---
+
+## Step 6: Generate and Save Document
+
+### File Naming
+
+Generate a slug from the topic (lowercase, hyphens, no special chars, max 50 chars).
+
+**File path**: `brainstorm/YYYY-MM-DD-<topic-slug>.md`
+
+Example: `brainstorm/2026-02-09-ai-customer-support-chatbot.md`
+
+### Document Template
+
+Write the document using the Write tool with this structure:
+
+```markdown
+# Brainstorm: [Topic Title]
+
+## Metadata
+- **Date**: YYYY-MM-DD
+- **EHG Stage**: [stage]
+- **Mode**: [Conversational / Structured]
+- **Crystallization Score**: [score/1.0] (structured mode only)
+
+---
+
+## Problem Statement
+[Synthesized from discovery answers - what problem does this solve and for whom?]
+
+## Discovery Summary
+[Key insights from the Q&A, organized by theme]
+
+## Analysis
+
+### Arguments For
+- [Compelling reasons to pursue]
+
+### Arguments Against
+- [Honest risks and challenges]
+
+## Four-Plane Evaluation Matrix
+(Include if evaluation was performed)
+
+### Plane 1: Capability Graph Impact
+| Dimension | Score |
+|-----------|-------|
+| New Capability Node | X/5 |
+| Capability Reuse Potential | X/5 |
+| Graph Centrality Gain | X/5 |
+| Maturity Lift | X/5 |
+| Extraction Clarity | X/5 |
+| **Total** | **X/25** |
+
+### Plane 2: External Vector Alignment
+| Vector | Direction | Strength |
+|--------|-----------|----------|
+| Market Demand | Tailwind/Headwind | X/5 |
+| Technology Cost | Tailwind/Headwind | X/5 |
+| Regulatory | Tailwind/Headwind | X/5 |
+| Competitive Density | Tailwind/Headwind | X/5 |
+| Timing Window | Tailwind/Headwind | X/5 |
+| **Net Score** | | **X** |
+
+Primary tailwind: [X]
+Primary headwind: [X]
+Mitigation: [X]
+
+### Plane 3: Constraints
+| Area | Exposure |
+|------|----------|
+| Spend Risk | Low/Medium/High |
+| Legal/Regulatory | Low/Medium/High |
+| Brand Risk | Low/Medium/High |
+| Security/Data | Low/Medium/High |
+| Autonomy Risk | Low/Medium/High |
+
+**Status**: Pass / Block / Escalate
+
+### Plane 4: Exploration vs Exploitation
+- **Dial Position**: [position]
+- **Review Interval**: [X weeks]
+- **Auto-Expiry**: [date, if exploratory]
+
+## Out of Scope
+(Structured mode only)
+- [Item 1]
+- [Item 2]
+- [Item 3]
+
+## Open Questions
+- [Unresolved questions that emerged during brainstorming]
+
+## Suggested Next Steps
+- [Actionable next steps based on the brainstorm]
+```
+
+### After Saving
+
+Confirm the file was saved:
+```
+Brainstorm saved to: brainstorm/YYYY-MM-DD-<topic-slug>.md
+```
+
+---
+
+## Step 7: Command Ecosystem Integration
+
+After the document is saved, suggest next steps based on context:
+
+Use AskUserQuestion:
+
+```
+question: "What would you like to do next?"
+header: "Next Steps"
+options:
+  - label: "Create an SD"
+    description: "Turn this brainstorm into a Strategic Directive via /leo create"
+  - label: "Triangulate"
+    description: "Get external AI opinions on open questions via /triangulation-protocol"
+  - label: "Capture pattern"
+    description: "Record insights as learnings via /learn"
+  - label: "Done for now"
+    description: "End brainstorming session"
+```
+
+**Auto-invoke behavior**: When user selects a command option, immediately invoke that skill using the Skill tool.
+
+---
+
+## Question Bank (by EHG Stage)
+
+### Ideation
+| ID | Question | Required |
+|----|----------|----------|
+| problem | What specific problem are you trying to solve? | Yes |
+| user | Who is the primary user affected by this problem? | Yes |
+| outcome | What outcome would success look like for this feature? | Yes |
+| validation | How would you validate that this solves the problem? | No |
+| risk | What is the biggest risk or unknown for this work? | No |
+
+### Validation
+| ID | Question | Required |
+|----|----------|----------|
+| hypothesis | What hypothesis are you testing with this feature? | Yes |
+| metric | What metric will prove/disprove the hypothesis? | Yes |
+| mvp | What is the minimum implementation to test this? | Yes |
+| pivot | What would trigger a pivot or change in direction? | No |
+
+### MVP
+| ID | Question | Required |
+|----|----------|----------|
+| user_value | What user value does this feature provide? | Yes |
+| integration | How does this integrate with existing features? | Yes |
+| success_metric | What metric defines success for this feature? | Yes |
+| dependencies | What dependencies or blockers exist? | No |
+
+### Growth
+| ID | Question | Required |
+|----|----------|----------|
+| retention | How does this improve user retention or engagement? | Yes |
+| scalability | What scalability considerations are there? | Yes |
+| measurement | How will you measure impact? | Yes |
+| iteration | What iteration plan exists after launch? | No |
+
+### Scale
+| ID | Question | Required |
+|----|----------|----------|
+| efficiency | How does this improve operational efficiency? | Yes |
+| automation | What can be automated in this feature? | Yes |
+| enterprise | How does this support enterprise requirements? | Yes |
+| maintenance | What is the long-term maintenance burden? | No |
+
+---
+
+## Command Ecosystem Integration
+
+### Cross-Reference
+
+This command is part of the **Command Ecosystem**. For full workflow context, see:
+- **[Command Ecosystem Reference](../../docs/reference/command-ecosystem.md)** - Complete inter-command flow diagram and relationships
+
+**Note**: `/brainstorm` is typically invoked at the start of new venture/feature exploration, before SD creation.
+
+### Related Commands
+| Command | Relationship |
+|---------|-------------|
+| `/leo create` | Create SD from crystallized brainstorm |
+| `/triangulation-protocol` | Validate open questions with external AIs |
+| `/learn` | Capture patterns discovered during brainstorming |
+| `/quick-fix` | If brainstorm reveals a small fix needed first |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -658,6 +658,14 @@ PAT-WORKFLOW-ROUTING-001: Quick-Fix and SD systems are separate. Route correctly
 - "compact the conversation", "running out of context"
 
 **Action**: Use Skill tool with 
+### Brainstorm Triggers → - "brainstorm", "brainstorm this", "let's brainstorm"
+- "explore this idea", "think through this", "venture idea"
+- "strategic thinking", "evaluate this concept", "should we build"
+- "four-plane", "capability graph", "venture evaluation"
+- When exploring new features, ventures, or strategic ideas
+
+**Action**: Use Skill tool with `skill: "brainstorm"` and pass the topic as `args`
+
 ---
 
 ### Command Ecosystem Flow (Quick Reference)
@@ -704,7 +712,7 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 ```
 
 ## DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2026-02-09 5:48:15 AM
+**Last Generated**: 2026-02-09 9:04:45 AM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -22,7 +22,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-09 5:48:15 AM
+**Generated**: 2026-02-09 9:04:45 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions (15-20k chars)
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-09T10:48:15.445Z -->
-<!-- git_commit: ed8fb913 -->
+<!-- generated_at: 2026-02-09T14:04:45.437Z -->
+<!-- git_commit: ac426f22 -->
 <!-- db_snapshot_hash: a218161803a78bba -->
 <!-- file_content_hash: pending -->
 
@@ -354,5 +354,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-02-09 5:48:15 AM*
+*DIGEST generated: 2026-02-09 9:04:45 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-09T10:48:15.445Z -->
-<!-- git_commit: ed8fb913 -->
+<!-- generated_at: 2026-02-09T14:04:45.437Z -->
+<!-- git_commit: ac426f22 -->
 <!-- db_snapshot_hash: a218161803a78bba -->
 <!-- file_content_hash: pending -->
 
@@ -121,5 +121,5 @@ Read tool: PRD file with limit: 100  ← VIOLATION
 
 ---
 
-*DIGEST generated: 2026-02-09 5:48:15 AM*
+*DIGEST generated: 2026-02-09 9:04:45 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -22,7 +22,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-09 5:48:15 AM
+**Generated**: 2026-02-09 9:04:45 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing (20-25k chars)
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-09T10:48:15.445Z -->
-<!-- git_commit: ed8fb913 -->
+<!-- generated_at: 2026-02-09T14:04:45.437Z -->
+<!-- git_commit: ac426f22 -->
 <!-- db_snapshot_hash: a218161803a78bba -->
 <!-- file_content_hash: pending -->
 
@@ -364,5 +364,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-02-09 5:48:15 AM*
+*DIGEST generated: 2026-02-09 9:04:45 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -22,7 +22,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-09 5:48:15 AM
+**Generated**: 2026-02-09 9:04:45 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-09T10:48:15.445Z -->
-<!-- git_commit: ed8fb913 -->
+<!-- generated_at: 2026-02-09T14:04:45.437Z -->
+<!-- git_commit: ac426f22 -->
 <!-- db_snapshot_hash: a218161803a78bba -->
 <!-- file_content_hash: pending -->
 
@@ -150,5 +150,5 @@ LEAD MUST answer these questions BEFORE approval:
 
 ---
 
-*DIGEST generated: 2026-02-09 5:48:15 AM*
+*DIGEST generated: 2026-02-09 9:04:45 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -22,7 +22,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-09 5:48:15 AM
+**Generated**: 2026-02-09 9:04:45 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates (30-35k chars)
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-09T10:48:15.445Z -->
-<!-- git_commit: ed8fb913 -->
+<!-- generated_at: 2026-02-09T14:04:45.437Z -->
+<!-- git_commit: ac426f22 -->
 <!-- db_snapshot_hash: a218161803a78bba -->
 <!-- file_content_hash: pending -->
 
@@ -334,5 +334,5 @@ Test scenarios only cover happy path ('user logs in successfully'). Missing:
 
 ---
 
-*DIGEST generated: 2026-02-09 5:48:15 AM*
+*DIGEST generated: 2026-02-09 9:04:45 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,76 +1,76 @@
 {
-  "generated_at": "2026-02-09T10:48:15.445Z",
-  "git_commit": "ed8fb913",
+  "generated_at": "2026-02-09T14:04:45.437Z",
+  "git_commit": "ac426f22",
   "db_snapshot_hash": "a218161803a78bba",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 40174,
-      "estimated_tokens": 10044,
-      "content_hash": "1ed7f473a404d972",
+      "chars": 40583,
+      "estimated_tokens": 10146,
+      "content_hash": "232daae05cafc185",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 74279,
       "estimated_tokens": 18570,
-      "content_hash": "c126f0d8fb3020b4",
+      "content_hash": "6f9467f19bb74ca2",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 57645,
       "estimated_tokens": 14412,
-      "content_hash": "e45dabdace7b2760",
+      "content_hash": "e1dd893460bb2624",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 89446,
       "estimated_tokens": 22362,
-      "content_hash": "bdfab835b2fd8066",
+      "content_hash": "f4f67f0a3420ec1f",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 67940,
       "estimated_tokens": 16985,
-      "content_hash": "04f9c81e4d5f388c",
+      "content_hash": "77bf0d499d614e38",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 4637,
       "estimated_tokens": 1160,
-      "content_hash": "24c791b5f2702e46",
+      "content_hash": "576df494c8aff952",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 16887,
       "estimated_tokens": 4222,
-      "content_hash": "97e8ce23b1834099",
+      "content_hash": "26c9e9dbf5d10dd0",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 6254,
       "estimated_tokens": 1564,
-      "content_hash": "c8b6bcb51afa5e77",
+      "content_hash": "2c861d41a7983ee4",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 14901,
       "estimated_tokens": 3726,
-      "content_hash": "7040bf5ae4ca535e",
+      "content_hash": "17bb88c158647adf",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 15753,
       "estimated_tokens": 3939,
-      "content_hash": "cac3190981ac0ae9",
+      "content_hash": "e60d178ce8d8e4d3",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     }
   }


### PR DESCRIPTION
## Summary
- New `/brainstorm` slash command for EHG-aware strategic brainstorming
- **Default mode**: Conversational (2-3 questions at a time, lighter flow)
- **`--structured` flag**: Full Phase 0 rigor (one-at-a-time questions, checkpoints, un-done proposals, crystallization scoring)
- **EHG stage awareness**: Question bank adapted per lifecycle stage (ideation/validation/mvp/growth/scale)
- **Four-Plane Evaluation Matrix**: Optional in conversational, full walkthrough in structured mode
- **Structured output**: Saves to `brainstorm/YYYY-MM-DD-<topic-slug>.md`
- **Command ecosystem**: Suggests `/leo create`, `/triangulation-protocol`, or `/learn` as next steps
- Added brainstorm trigger keywords to Skill Intent Detection section (via DB update + CLAUDE.md regeneration)

## Test plan
- [ ] Run `/brainstorm AI-powered customer support chatbot` - verify conversational mode
- [ ] Run `/brainstorm --structured --stage validation Revenue attribution model` - verify structured mode
- [ ] Verify output file saved with correct naming convention
- [ ] Verify command ecosystem suggestions appear at end

🤖 Generated with [Claude Code](https://claude.com/claude-code)