### PR TITLE
feat(eva): add Todoist task hierarchy for improved classification

### DIFF
--- a/database/migrations/20260209_todoist_task_hierarchy.sql
+++ b/database/migrations/20260209_todoist_task_hierarchy.sql
@@ -1,0 +1,32 @@
+-- Migration: Add task hierarchy columns to eva_todoist_intake
+-- Purpose: Store Todoist parent-child relationships and ordering so the
+--          classifier can read sibling/parent context when evaluating ideas.
+-- Columns: todoist_parent_id, todoist_section_id, todoist_child_order
+
+-- ============================================================================
+-- Add hierarchy columns
+-- ============================================================================
+
+ALTER TABLE eva_todoist_intake
+  ADD COLUMN IF NOT EXISTS todoist_parent_id TEXT,
+  ADD COLUMN IF NOT EXISTS todoist_section_id TEXT,
+  ADD COLUMN IF NOT EXISTS todoist_child_order INTEGER DEFAULT 0;
+
+-- Index for efficient parent lookups (find children of a task)
+CREATE INDEX IF NOT EXISTS idx_eva_todoist_intake_parent
+  ON eva_todoist_intake(todoist_parent_id)
+  WHERE todoist_parent_id IS NOT NULL;
+
+-- Index for section grouping
+CREATE INDEX IF NOT EXISTS idx_eva_todoist_intake_section
+  ON eva_todoist_intake(todoist_section_id)
+  WHERE todoist_section_id IS NOT NULL;
+
+-- ============================================================================
+-- MIGRATION COMPLETE
+-- ============================================================================
+-- Summary:
+-- 1. Added todoist_parent_id (TEXT, nullable) - links to parent task's todoist_task_id
+-- 2. Added todoist_section_id (TEXT, nullable) - Todoist section grouping
+-- 3. Added todoist_child_order (INTEGER, default 0) - sort order among siblings
+-- 4. Added partial indexes for parent and section lookups

--- a/lib/integrations/evaluation-bridge.js
+++ b/lib/integrations/evaluation-bridge.js
@@ -53,8 +53,8 @@ async function evaluateItem(item, sourceType, options = {}) {
     // 1. Mark as evaluating
     await supabase.from(tableName).update({ status: 'evaluating' }).eq('id', item.id);
 
-    // 2. Classify
-    const classification = await classifyIdea(item.title, item.description, { supabase, verbose: options.verbose });
+    // 2. Classify (pass full item for hierarchy context)
+    const classification = await classifyIdea(item.title, item.description, { supabase, verbose: options.verbose, item });
     result.classification = classification;
 
     await supabase.from(tableName).update({

--- a/lib/integrations/idea-classifier.js
+++ b/lib/integrations/idea-classifier.js
@@ -34,9 +34,10 @@ async function loadCategories(supabase) {
  * @param {string} title
  * @param {string} description
  * @param {Object} categories
+ * @param {Object} [hierarchy] - Parent and sibling context
  * @returns {string}
  */
-function buildClassificationPrompt(title, description, categories) {
+function buildClassificationPrompt(title, description, categories, hierarchy = {}) {
   const ventureOptions = categories.ventureTags
     .map(c => `  - ${c.code}: ${c.label} (keywords: ${c.classification_keywords.join(', ')})`)
     .join('\n');
@@ -45,10 +46,21 @@ function buildClassificationPrompt(title, description, categories) {
     .map(c => `  - ${c.code}: ${c.label} (keywords: ${c.classification_keywords.join(', ')})`)
     .join('\n');
 
+  let hierarchySection = '';
+  if (hierarchy.parentTitle) {
+    hierarchySection += `\nParent Task: ${hierarchy.parentTitle}`;
+  }
+  if (hierarchy.siblingTitles?.length > 0) {
+    hierarchySection += `\nSibling Tasks: ${hierarchy.siblingTitles.join('; ')}`;
+  }
+  if (hierarchySection) {
+    hierarchySection = `\nHierarchy Context (use to improve classification):${hierarchySection}\n`;
+  }
+
   return `Classify this idea into exactly one venture_tag and one business_function.
 
 Title: ${title}
-Description: ${description || 'No description'}
+Description: ${description || 'No description'}${hierarchySection}
 
 Venture Tags (pick one):
 ${ventureOptions}
@@ -117,11 +129,45 @@ function keywordClassify(text, categories) {
 }
 
 /**
+ * Load hierarchy context (parent title + sibling titles) for a task
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} item - Intake row with todoist_parent_id and todoist_task_id
+ * @returns {Promise<{parentTitle: string|null, siblingTitles: string[]}>}
+ */
+async function loadHierarchyContext(supabase, item) {
+  const result = { parentTitle: null, siblingTitles: [] };
+  if (!item?.todoist_parent_id) return result;
+
+  // Fetch parent task
+  const { data: parent } = await supabase
+    .from('eva_todoist_intake')
+    .select('title')
+    .eq('todoist_task_id', item.todoist_parent_id)
+    .maybeSingle();
+
+  if (parent) result.parentTitle = parent.title;
+
+  // Fetch siblings (same parent, excluding self)
+  const { data: siblings } = await supabase
+    .from('eva_todoist_intake')
+    .select('title')
+    .eq('todoist_parent_id', item.todoist_parent_id)
+    .neq('todoist_task_id', item.todoist_task_id)
+    .order('todoist_child_order')
+    .limit(10);
+
+  if (siblings) result.siblingTitles = siblings.map(s => s.title);
+
+  return result;
+}
+
+/**
  * Classify an intake item
  * @param {string} title
  * @param {string} description
  * @param {Object} [options]
  * @param {import('@supabase/supabase-js').SupabaseClient} [options.supabase]
+ * @param {Object} [options.item] - Full intake row (for hierarchy context)
  * @returns {Promise<{venture_tag: string, business_function: string, confidence_score: number}>}
  */
 export async function classifyIdea(title, description, options = {}) {
@@ -131,14 +177,20 @@ export async function classifyIdea(title, description, options = {}) {
   );
 
   const categories = await loadCategories(supabase);
-  const combinedText = `${title} ${description || ''}`;
+
+  // Load hierarchy context if item provided
+  const hierarchy = options.item
+    ? await loadHierarchyContext(supabase, options.item)
+    : { parentTitle: null, siblingTitles: [] };
+
+  const combinedText = `${hierarchy.parentTitle ? hierarchy.parentTitle + ' > ' : ''}${title} ${description || ''}`;
 
   // Try LLM classification first
   try {
     const { getClassificationClient } = await import('../llm/client-factory.js');
     const client = await getClassificationClient();
 
-    const prompt = buildClassificationPrompt(title, description, categories);
+    const prompt = buildClassificationPrompt(title, description, categories, hierarchy);
     const content = await client.complete(
       'You are a precise classification system. Respond with only valid JSON.',
       prompt,

--- a/lib/integrations/todoist/todoist-sync.js
+++ b/lib/integrations/todoist/todoist-sync.js
@@ -76,6 +76,9 @@ function mapTaskToIntakeRow(task, project) {
     todoist_priority: task.priority || 1,
     todoist_url: task.url || null,
     todoist_due_date: task.due?.datetime || task.due?.date || null,
+    todoist_parent_id: task.parentId || null,
+    todoist_section_id: task.sectionId || null,
+    todoist_child_order: task.childOrder ?? 0,
     raw_data: task
   };
 }
@@ -122,6 +125,9 @@ async function upsertTasks(supabase, rows, knownTasks) {
             todoist_priority: row.todoist_priority,
             todoist_url: row.todoist_url,
             todoist_due_date: row.todoist_due_date,
+            todoist_parent_id: row.todoist_parent_id,
+            todoist_section_id: row.todoist_section_id,
+            todoist_child_order: row.todoist_child_order,
             raw_data: row.raw_data
           })
           .eq('id', existing.id);


### PR DESCRIPTION
## Summary

- Add `todoist_parent_id`, `todoist_section_id`, `todoist_child_order` columns to `eva_todoist_intake` table via migration
- Update Todoist sync to capture parent-child hierarchy fields from Todoist API
- Add `loadHierarchyContext()` to idea classifier that fetches parent title and up to 10 sibling titles
- Enhance LLM classification prompt with hierarchy context (parent task + sibling tasks)
- Improve keyword fallback classification by prepending parent title to search text
- Pass full intake item through evaluation bridge to classifier for hierarchy lookup

## Test plan
- [x] Migration executed successfully (adds columns + indexes)
- [x] Smoke tests pass (105/105)
- [ ] Verify Todoist sync captures parentId/sectionId/childOrder for sub-tasks
- [ ] Verify classifier uses parent context to improve classification of ambiguous sub-tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)