### PR TITLE
fix(test): exclude worktree directories from vitest test discovery

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
       '**/press-kit/**',
       '**/agents/**',
       '**/archive/**',
+      '**/.worktrees/**',
+      '**/.cursor/worktrees/**',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary
- Adds `.worktrees/**` and `.cursor/worktrees/**` to vitest `exclude` array
- Prevents test runner from scanning parallel workspace branches, which caused ~218 false-positive test failures
- Root cause: worktree workflow was adopted after initial test config was written, exclusions were never added

## RCA
- **Pattern**: PAT-TEST-CONFIG-ISOLATION-001
- **Root Cause**: Test config manually maintained without validation that workspace isolation directories are excluded
- **5-Whys**: Worktree dirs scanned → missing from exclude list → no sync process → config predates worktree adoption → no automated exclusion validation

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Run full `npm test` and verify test file count drops from ~732 to ~500
- [ ] Verify no worktree paths appear in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)