### PR TITLE
fix(infra): centralize terminal identity and add handoff resolution tracking

### DIFF
--- a/database/migrations/20260209_handoff_resolution_tracking.sql
+++ b/database/migrations/20260209_handoff_resolution_tracking.sql
@@ -1,0 +1,38 @@
+-- Migration: Add resolution tracking to sd_phase_handoffs
+-- RCA: RCA-MULTI-SESSION-CASCADE-001
+-- Purpose: Allow rejected/failed handoffs to be marked as resolved
+-- instead of permanently blocking future handoff attempts.
+--
+-- The transition readiness gate should check for UNRESOLVED failures,
+-- not ALL historical failures. This enables a proper failure lifecycle:
+-- rejected → under_investigation → fix_applied → resolved
+
+-- Add resolution tracking columns
+ALTER TABLE sd_phase_handoffs ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ;
+ALTER TABLE sd_phase_handoffs ADD COLUMN IF NOT EXISTS resolution_type TEXT;
+ALTER TABLE sd_phase_handoffs ADD COLUMN IF NOT EXISTS resolution_notes TEXT;
+
+-- Add constraint for valid resolution types
+-- DO NOT add constraint yet - let it be freeform initially
+-- Types: infrastructure_fix, code_fix, config_change, false_positive, manual_override
+
+-- Resolve all cascaded failures from the multi-session claim conflict
+-- These were caused by unstable Windows terminal_id (ppid → console session ID fix)
+UPDATE sd_phase_handoffs
+SET
+  resolved_at = NOW(),
+  resolution_type = 'infrastructure_fix',
+  resolution_notes = 'RCA-MULTI-SESSION-CASCADE-001: Windows terminal_id stabilized from process.ppid to console session ID. False positives caused by ppid changing per subprocess.'
+WHERE
+  status IN ('rejected', 'failed', 'blocked')
+  AND resolved_at IS NULL
+  AND (
+    rejection_reason LIKE '%claimed by another active session%'
+    OR rejection_reason LIKE '%GATE_MULTI_SESSION_CLAIM_CONFLICT%'
+    OR rejection_reason LIKE '%GATE_SD_TRANSITION_READINESS%claimed by another%'
+  );
+
+-- Add index for efficient resolution queries
+CREATE INDEX IF NOT EXISTS idx_sd_phase_handoffs_unresolved
+ON sd_phase_handoffs (sd_id, handoff_type, status)
+WHERE resolved_at IS NULL AND status IN ('rejected', 'failed', 'blocked');

--- a/docs/reference/schema/engineer/tables/sd_phase_handoffs.md
+++ b/docs/reference/schema/engineer/tables/sd_phase_handoffs.md
@@ -4,8 +4,8 @@
 **Database**: dedlbzhpgkmetvhbkyzq
 **Repository**: EHG_Engineer (this repository)
 **Purpose**: Strategic Directive management, PRD tracking, retrospectives, LEO Protocol configuration
-**Generated**: 2026-02-09T14:43:56.070Z
-**Rows**: 5,588
+**Generated**: 2026-02-09T16:45:30.736Z
+**Rows**: 5,598
 **RLS**: Enabled (8 policies)
 
 ⚠️ **This is a REFERENCE document** - Query database directly for validation
@@ -14,7 +14,7 @@
 
 ---
 
-## Columns (23 total)
+## Columns (26 total)
 
 | Column | Type | Nullable | Default | Description |
 |--------|------|----------|---------|-------------|
@@ -41,6 +41,9 @@
 | validation_details | `jsonb` | YES | `'{}'::jsonb` | Detailed validation results from handoff verification including sub-agent outputs, gate checks, and quality metrics. |
 | validation_score | `integer(32)` | YES | - | Quality score from handoff validation (0-100). Higher scores indicate better handoff quality. |
 | validation_passed | `boolean` | YES | - | Boolean indicating whether handoff passed all validation gates. NULL = not yet validated. |
+| resolved_at | `timestamp with time zone` | YES | - | - |
+| resolution_type | `text` | YES | - | - |
+| resolution_notes | `text` | YES | - | - |
 
 ## Constraints
 
@@ -87,6 +90,10 @@
 - `idx_sd_phase_handoffs_type`
   ```sql
   CREATE INDEX idx_sd_phase_handoffs_type ON public.sd_phase_handoffs USING btree (handoff_type)
+  ```
+- `idx_sd_phase_handoffs_unresolved`
+  ```sql
+  CREATE INDEX idx_sd_phase_handoffs_unresolved ON public.sd_phase_handoffs USING btree (sd_id, handoff_type, status) WHERE ((resolved_at IS NULL) AND ((status)::text = ANY ((ARRAY['rejected'::character varying, 'failed'::character varying, 'blocked'::character varying])::text[])))
   ```
 - `idx_sd_phase_handoffs_validation_details`
   ```sql

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -67,24 +67,15 @@ function getMachineId() {
   }
 }
 
+// PAT-SESSION-IDENTITY-003: Import centralized terminal identity
+import { getTerminalId as _getTerminalId } from './terminal-identity.js';
+
 /**
  * SD-LEO-INFRA-ISL-001: Get terminal identifier
- * Uses TTY path or window ID on Windows
+ * Delegated to centralized lib/terminal-identity.js
  */
 function getTerminalId() {
-  try {
-    if (process.platform === 'win32') {
-      // Use parent PID as terminal identifier on Windows
-      return `win-ppid-${process.ppid || process.pid}`;
-    }
-    // On Unix, use the TTY device path
-    const tty = execSync('tty', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
-    // Hash the TTY path for cleaner ID
-    return crypto.createHash('sha256').update(tty).digest('hex').substring(0, 12);
-  } catch {
-    // Fallback to PID-based
-    return `pid-${process.ppid || process.pid}`;
-  }
+  return _getTerminalId();
 }
 
 /**

--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -1,0 +1,93 @@
+/**
+ * Terminal Identity - Single Source of Truth
+ * PAT-SESSION-IDENTITY-003 / RCA-MULTI-SESSION-CASCADE-001
+ *
+ * Centralized terminal identity computation for multi-session coordination.
+ * ALL code that needs terminal_id MUST import from this module.
+ *
+ * Identity Model:
+ *   Windows: Console session ID (stable across Node.js subprocesses)
+ *   Unix: TTY device path (hashed for privacy)
+ *   Fallback: Parent PID (unstable but functional)
+ *
+ * Why centralized:
+ *   Previously duplicated in 3 locations (session-manager, claim-gate, BaseExecutor).
+ *   When ppid→sessionId fix was applied, BaseExecutor's inline copy was missed,
+ *   causing a cascade of false claim conflicts and permanently blocked handoffs.
+ */
+
+import { execSync } from 'child_process';
+import crypto from 'crypto';
+import os from 'os';
+
+/**
+ * Get stable terminal identifier for session coordination.
+ *
+ * On Windows: Uses PowerShell to query the console session ID, which is
+ * stable across all Node.js subprocesses spawned from the same terminal.
+ *
+ * On Unix: Uses the TTY device path, hashed for cleaner IDs.
+ *
+ * @returns {string} Terminal identifier (e.g., "win-session-1" or "tty-a4b3c2d1")
+ */
+export function getTerminalId() {
+  try {
+    if (process.platform === 'win32') {
+      try {
+        const cmd = `powershell -Command "(Get-Process -Id ${process.pid}).SessionId"`;
+        const sessionId = execSync(cmd, {
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'ignore']
+        }).trim();
+        if (sessionId && /^\d+$/.test(sessionId)) {
+          return `win-session-${sessionId}`;
+        }
+      } catch {
+        // PowerShell unavailable or failed - fall through to ppid
+      }
+      return `win-ppid-${process.ppid || process.pid}`;
+    }
+    // Unix: Use TTY device path, hashed for cleaner ID
+    const tty = execSync('tty', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore']
+    }).trim();
+    return `tty-${crypto.createHash('sha256').update(tty).digest('hex').substring(0, 12)}`;
+  } catch {
+    return `pid-${process.ppid || process.pid}`;
+  }
+}
+
+/**
+ * Get raw TTY identifier (for session manager backward compat).
+ * On Unix: returns the TTY path. On Windows: returns win-{pid}.
+ * @returns {string}
+ */
+export function getTTY() {
+  try {
+    if (process.platform === 'win32') {
+      return `win-${process.pid}`;
+    }
+    return execSync('tty', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Get machine identifier (hostname hash).
+ * @returns {string} Machine ID (e.g., "923879b6d20f949c")
+ */
+export function getMachineId() {
+  try {
+    const hostname = os.hostname();
+    const platform = os.platform();
+    const arch = os.arch();
+    const machineString = `${hostname}-${platform}-${arch}`;
+    return crypto.createHash('sha256').update(machineString).digest('hex').substring(0, 16);
+  } catch {
+    return 'unknown';
+  }
+}
+
+export default { getTerminalId, getTTY, getMachineId };

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -594,20 +594,10 @@ export class BaseExecutor {
       // Use sd_key for claim lookup (matches how claims are stored)
       const claimId = sd?.sd_key || sdId;
 
-      // PAT-SESSION-IDENTITY-002: Pass hostname + terminal_id for same-conversation detection
-      // Multiple CLI processes from same Claude Code instance share hostname AND terminal_id
+      // PAT-SESSION-IDENTITY-003: Use centralized terminal identity
       const os = await import('os');
-      let currentTerminalId;
-      try {
-        if (process.platform === 'win32') {
-          currentTerminalId = `win-ppid-${process.ppid || process.pid}`;
-        } else {
-          const { execSync } = await import('child_process');
-          currentTerminalId = execSync('tty', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
-        }
-      } catch {
-        currentTerminalId = `pid-${process.ppid || process.pid}`;
-      }
+      const { getTerminalId } = await import('../../../../lib/terminal-identity.js');
+      const currentTerminalId = getTerminalId();
       const result = await validateMultiSessionClaim(this.supabase, claimId, {
         currentSessionId,
         currentHostname: os.hostname(),

--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -25,26 +25,10 @@
  */
 
 import os from 'os';
-import { execSync } from 'child_process';
 
-/**
- * Get the current terminal identifier (stable per Claude Code conversation).
- * On Windows: uses process.ppid (parent PID = Claude Code process).
- * On Unix: uses the TTY device path.
- * This matches the terminal_id stored in claude_sessions by session-manager.
- */
-function getTerminalId() {
-  try {
-    if (process.platform === 'win32') {
-      return `win-ppid-${process.ppid || process.pid}`;
-    }
-    const tty = execSync('tty', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
-    // Hash not needed here — just need the raw value to match
-    return tty;
-  } catch {
-    return `pid-${process.ppid || process.pid}`;
-  }
-}
+// PAT-SESSION-IDENTITY-003: Centralized terminal identity
+// Import from single source of truth to prevent duplication cascade
+import { getTerminalId } from '../../../../lib/terminal-identity.js';
 
 /**
  * Validate that no session on another machine has claimed this SD

--- a/tests/unit/transition-readiness-rejection.test.js
+++ b/tests/unit/transition-readiness-rejection.test.js
@@ -27,6 +27,8 @@ function createSD(overrides = {}) {
 }
 
 // Helper: mock Supabase with chainable API
+// Chain: from → select → eq → eq → in → is → order → limit
+// The .is() call filters resolved_at IS NULL (RCA-MULTI-SESSION-CASCADE-001)
 function createMockSupabase(handoffs = [], handoffError = null) {
   return {
     from: vi.fn().mockReturnValue({
@@ -34,10 +36,12 @@ function createMockSupabase(handoffs = [], handoffError = null) {
         eq: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
             in: vi.fn().mockReturnValue({
-              order: vi.fn().mockReturnValue({
-                limit: vi.fn().mockResolvedValue({
-                  data: handoffs,
-                  error: handoffError
+              is: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue({
+                    data: handoffs,
+                    error: handoffError
+                  })
                 })
               })
             })
@@ -99,8 +103,10 @@ describe('PAT-HANDOFF-PHZ-001: Transition Readiness Rejection Check', () => {
           eq: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
               in: vi.fn().mockReturnValue({
-                order: vi.fn().mockReturnValue({
-                  limit: vi.fn().mockRejectedValue(new Error('Connection refused'))
+                is: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockRejectedValue(new Error('Connection refused'))
+                  })
                 })
               })
             })


### PR DESCRIPTION
## Summary
- Centralize terminal identity into `lib/terminal-identity.js` (single source of truth), eliminating duplication across session-manager, claim-gate, and BaseExecutor that caused false multi-session claim conflicts
- Add `resolved_at`, `resolution_type`, `resolution_notes` columns to `sd_phase_handoffs` for failure lifecycle tracking with partial index for efficient unresolved-only queries
- Update transition-readiness gate to filter only unresolved failures (`.is('resolved_at', null)`)
- Fix test mock chain in `transition-readiness-rejection.test.js` to include `.is()` method
- Bulk-resolve 12 cascaded failure records from RCA-MULTI-SESSION-CASCADE-001

## Patterns Addressed
- PAT-AUTO-e646ab92: Terminal identity duplication across 3 locations
- PAT-AUTO-e74d3e36: Permanently blocked handoffs from unresolved failure records

## Test plan
- [x] All 4 transition-readiness-rejection tests pass
- [x] All 13 multi-session-claim-gate tests pass
- [x] 15 smoke tests pass
- [x] Pre-commit hooks pass (ESLint, secret scan, DOCMON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)