### PR TITLE
feat(orchestrator): add Agent Experience Factory for dynamic agent composition

### DIFF
--- a/lib/agent-experience-factory/adapters/base-adapter.js
+++ b/lib/agent-experience-factory/adapters/base-adapter.js
@@ -1,0 +1,75 @@
+/**
+ * Base Retrieval Adapter
+ * Shared interface for all knowledge source adapters
+ *
+ * All adapters implement: fetch({domain, category, limit, timeoutMs, queryVersion}) -> AdapterResult
+ * Fail-open: timeouts/errors return empty items with sourceStatus='failed'
+ *
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A (TR-1)
+ */
+
+/**
+ * @typedef {Object} AdapterResult
+ * @property {Array<Object>} items - Retrieved knowledge items
+ * @property {'ok'|'failed'|'timeout'|'empty'} sourceStatus - Retrieval outcome
+ * @property {number} elapsedMs - Time taken for retrieval
+ * @property {string} [error] - Error message if sourceStatus is 'failed' or 'timeout'
+ */
+
+/**
+ * @typedef {Object} FetchParams
+ * @property {string} domain - Domain filter (e.g., 'database', 'testing')
+ * @property {string} [category] - Category filter
+ * @property {number} [limit=5] - Max items to return
+ * @property {number} [timeoutMs=120] - Per-source timeout in ms
+ * @property {string} [queryVersion='v1'] - Query version for cache key stability
+ */
+
+export class BaseAdapter {
+  constructor(sourceName, supabase) {
+    this.sourceName = sourceName;
+    this.supabase = supabase;
+  }
+
+  /**
+   * Fetch knowledge items with timeout and fail-open
+   * @param {FetchParams} params
+   * @returns {Promise<AdapterResult>}
+   */
+  async fetch(params) {
+    const { timeoutMs = 120 } = params;
+    const start = Date.now();
+
+    try {
+      const result = await Promise.race([
+        this._doFetch(params),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('TIMEOUT')), timeoutMs)
+        )
+      ]);
+
+      return {
+        items: result.items || [],
+        sourceStatus: result.items.length > 0 ? 'ok' : 'empty',
+        elapsedMs: Date.now() - start
+      };
+    } catch (err) {
+      const isTimeout = err.message === 'TIMEOUT';
+      return {
+        items: [],
+        sourceStatus: isTimeout ? 'timeout' : 'failed',
+        elapsedMs: Date.now() - start,
+        error: err.message
+      };
+    }
+  }
+
+  /**
+   * Subclasses implement this with actual DB query logic
+   * @param {FetchParams} params
+   * @returns {Promise<{items: Array}>}
+   */
+  async _doFetch(_params) {
+    throw new Error(`${this.sourceName}: _doFetch() not implemented`);
+  }
+}

--- a/lib/agent-experience-factory/adapters/issue-patterns-adapter.js
+++ b/lib/agent-experience-factory/adapters/issue-patterns-adapter.js
@@ -1,0 +1,80 @@
+/**
+ * Issue Patterns Retrieval Adapter
+ * Queries issue_patterns table filtered by domain/category with ranking by occurrence_count
+ *
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A (FR-2)
+ */
+
+import { BaseAdapter } from './base-adapter.js';
+
+export class IssuePatternsAdapter extends BaseAdapter {
+  constructor(supabase) {
+    super('issue_patterns', supabase);
+  }
+
+  async _doFetch({ domain, category, limit = 5 }) {
+    const categories = this._resolveCategories(domain, category);
+
+    if (categories.length === 0) {
+      return { items: [] };
+    }
+
+    const { data, error } = await this.supabase
+      .from('issue_patterns')
+      .select('pattern_id, category, severity, issue_summary, occurrence_count, proven_solutions, prevention_checklist, trend')
+      .eq('status', 'active')
+      .in('category', categories)
+      .order('occurrence_count', { ascending: false })
+      .limit(limit);
+
+    if (error) throw new Error(`issue_patterns query failed: ${error.message}`);
+
+    return {
+      items: (data || []).map(p => ({
+        id: p.pattern_id,
+        source: 'issue_patterns',
+        title: p.issue_summary,
+        severity: p.severity,
+        category: p.category,
+        occurrences: p.occurrence_count,
+        trend: p.trend,
+        solution: this._extractTopSolution(p.proven_solutions),
+        prevention: this._extractPrevention(p.prevention_checklist),
+        _raw: p
+      }))
+    };
+  }
+
+  _resolveCategories(domain, category) {
+    const cats = [];
+    if (category) cats.push(category);
+    if (domain && domain !== category) cats.push(domain);
+    // Map common domains to known issue_patterns categories
+    const DOMAIN_EXPANSIONS = {
+      database: ['database', 'security'],
+      testing: ['testing', 'deployment', 'build'],
+      validation: ['code_structure', 'protocol', 'testing'],
+      security: ['security', 'authentication'],
+      design: ['ui', 'ux', 'accessibility'],
+      performance: ['performance', 'optimization']
+    };
+    const expanded = DOMAIN_EXPANSIONS[domain?.toLowerCase()] || [];
+    expanded.forEach(c => { if (!cats.includes(c)) cats.push(c); });
+    return cats;
+  }
+
+  _extractTopSolution(solutions) {
+    if (!solutions || !Array.isArray(solutions) || solutions.length === 0) return null;
+    const s = solutions[0];
+    return s.solution || s.method || (typeof s === 'string' ? s : null);
+  }
+
+  _extractPrevention(checklist) {
+    if (!checklist) return [];
+    let parsed = checklist;
+    if (typeof parsed === 'string') {
+      try { parsed = JSON.parse(parsed); } catch { return []; }
+    }
+    return Array.isArray(parsed) ? parsed.slice(0, 3) : [];
+  }
+}

--- a/lib/agent-experience-factory/adapters/retrospectives-adapter.js
+++ b/lib/agent-experience-factory/adapters/retrospectives-adapter.js
@@ -1,0 +1,72 @@
+/**
+ * Retrospectives Retrieval Adapter
+ * Queries retrospectives table for relevant learnings filtered by domain/category
+ *
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A (FR-2)
+ */
+
+import { BaseAdapter } from './base-adapter.js';
+
+export class RetrospectivesAdapter extends BaseAdapter {
+  constructor(supabase) {
+    super('retrospectives', supabase);
+  }
+
+  async _doFetch({ domain, category, limit = 5 }) {
+    // Build filter chain before terminal calls (order/limit)
+    let query = this.supabase
+      .from('retrospectives')
+      .select('id, sd_id, title, key_learnings, what_went_well, what_needs_improvement, action_items, success_patterns, failure_patterns, learning_category, quality_score, tags, created_at')
+      .not('key_learnings', 'is', null);
+
+    // Apply filters before order/limit
+    if (category) {
+      query = query.eq('learning_category', category);
+    }
+    if (domain && !category) {
+      query = query.contains('tags', [domain]);
+    }
+
+    const { data, error } = await query
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error) throw new Error(`retrospectives query failed: ${error.message}`);
+
+    return {
+      items: (data || []).map(r => ({
+        id: r.id,
+        source: 'retrospectives',
+        title: r.title || `Retro for ${r.sd_id}`,
+        sdId: r.sd_id,
+        learnings: this._extractLearnings(r),
+        successPatterns: r.success_patterns || [],
+        failurePatterns: r.failure_patterns || [],
+        qualityScore: r.quality_score,
+        category: r.learning_category,
+        createdAt: r.created_at,
+        _raw: r
+      }))
+    };
+  }
+
+  _extractLearnings(retro) {
+    const learnings = [];
+
+    if (retro.key_learnings) {
+      const kl = Array.isArray(retro.key_learnings)
+        ? retro.key_learnings
+        : [retro.key_learnings];
+      learnings.push(...kl.slice(0, 3));
+    }
+
+    if (retro.what_needs_improvement) {
+      const wni = Array.isArray(retro.what_needs_improvement)
+        ? retro.what_needs_improvement
+        : [retro.what_needs_improvement];
+      learnings.push(...wni.slice(0, 2));
+    }
+
+    return learnings.slice(0, 5);
+  }
+}

--- a/lib/agent-experience-factory/adapters/skills-adapter.js
+++ b/lib/agent-experience-factory/adapters/skills-adapter.js
@@ -1,0 +1,74 @@
+/**
+ * Skills Retrieval Adapter
+ * Queries leo_sub_agents metadata for capabilities, success/failure patterns
+ * relevant to the current domain
+ *
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A (FR-2)
+ */
+
+import { BaseAdapter } from './base-adapter.js';
+
+export class SkillsAdapter extends BaseAdapter {
+  constructor(supabase) {
+    super('skills', supabase);
+  }
+
+  async _doFetch({ domain, category, limit = 5 }) {
+    // Query sub-agents whose categories overlap with the requested domain
+    const { data, error } = await this.supabase
+      .from('leo_sub_agents')
+      .select('code, name, description, capabilities, metadata')
+      .eq('is_active', true)
+      .order('priority', { ascending: false })
+      .limit(20); // Fetch more, filter client-side by relevance
+
+    if (error) throw new Error(`leo_sub_agents query failed: ${error.message}`);
+
+    if (!data || data.length === 0) return { items: [] };
+
+    // Score relevance based on domain/category overlap
+    const scored = data
+      .map(agent => ({
+        agent,
+        score: this._relevanceScore(agent, domain, category)
+      }))
+      .filter(s => s.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+
+    return {
+      items: scored.map(({ agent, score }) => ({
+        id: agent.code,
+        source: 'skills',
+        title: agent.name,
+        description: agent.description,
+        capabilities: agent.capabilities || [],
+        successPatterns: agent.metadata?.success_patterns || [],
+        failurePatterns: agent.metadata?.failure_patterns || [],
+        relevanceScore: score,
+        _raw: agent
+      }))
+    };
+  }
+
+  _relevanceScore(agent, domain, category) {
+    let score = 0;
+    const text = `${agent.name} ${agent.description} ${(agent.capabilities || []).join(' ')}`.toLowerCase();
+    const meta = agent.metadata || {};
+
+    // Direct code match
+    if (agent.code.toLowerCase() === domain?.toLowerCase()) score += 10;
+
+    // Domain keyword in text
+    if (domain && text.includes(domain.toLowerCase())) score += 5;
+
+    // Category keyword in text
+    if (category && text.includes(category.toLowerCase())) score += 3;
+
+    // Has success/failure patterns (more experienced)
+    if (meta.success_patterns?.length > 0) score += 2;
+    if (meta.failure_patterns?.length > 0) score += 2;
+
+    return score;
+  }
+}

--- a/lib/agent-experience-factory/cache/session-knowledge-cache.js
+++ b/lib/agent-experience-factory/cache/session-knowledge-cache.js
@@ -1,0 +1,125 @@
+/**
+ * Session Knowledge Cache
+ * LRU cache with TTL for session-scoped knowledge retrieval
+ *
+ * Key: (sessionId, domain, category, source, queryVersion)
+ * Memory-safe with maxEntries and LRU eviction
+ * Concurrency-safe via synchronous Map operations
+ *
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A (FR-3, TR-4)
+ */
+
+export class SessionKnowledgeCache {
+  /**
+   * @param {Object} options
+   * @param {number} [options.ttlMs=300000] - TTL in ms (default 5 minutes)
+   * @param {number} [options.maxEntries=50] - Max cache entries before LRU eviction
+   */
+  constructor({ ttlMs = 300_000, maxEntries = 50 } = {}) {
+    this.ttlMs = ttlMs;
+    this.maxEntries = maxEntries;
+    /** @type {Map<string, {data: any, accessOrder: number, createdAt: number}>} */
+    this._store = new Map();
+    this._stats = { hits: 0, misses: 0, evictions: 0, expired: 0 };
+    this._accessCounter = 0; // Monotonic counter for deterministic LRU ordering
+  }
+
+  /**
+   * Build deterministic cache key
+   * @param {string} sessionId
+   * @param {string} source - Adapter source name
+   * @param {string} domain
+   * @param {string} [category]
+   * @param {string} [queryVersion='v1']
+   * @returns {string}
+   */
+  static buildKey(sessionId, source, domain, category = '', queryVersion = 'v1') {
+    return `${sessionId}|${source}|${domain}|${category}|${queryVersion}`;
+  }
+
+  /**
+   * Get cached value, enforcing TTL on read
+   * @param {string} key
+   * @returns {any|null} Cached data or null if miss/expired
+   */
+  get(key) {
+    const entry = this._store.get(key);
+    if (!entry) {
+      this._stats.misses++;
+      return null;
+    }
+
+    // TTL check on read
+    if (Date.now() - entry.createdAt > this.ttlMs) {
+      this._store.delete(key);
+      this._stats.expired++;
+      this._stats.misses++;
+      return null;
+    }
+
+    // Update access order for LRU (monotonic counter avoids ms-precision ties)
+    entry.accessOrder = ++this._accessCounter;
+    this._stats.hits++;
+    return entry.data;
+  }
+
+  /**
+   * Store value with LRU eviction if at capacity
+   * @param {string} key
+   * @param {any} data
+   */
+  set(key, data) {
+    // Evict if at capacity and key is new
+    if (!this._store.has(key) && this._store.size >= this.maxEntries) {
+      this._evictLRU();
+    }
+
+    this._store.set(key, {
+      data,
+      accessOrder: ++this._accessCounter,
+      createdAt: Date.now()
+    });
+  }
+
+  /**
+   * Evict least recently used entry
+   */
+  _evictLRU() {
+    let oldestKey = null;
+    let lowestOrder = Infinity;
+
+    for (const [key, entry] of this._store) {
+      if (entry.accessOrder < lowestOrder) {
+        lowestOrder = entry.accessOrder;
+        oldestKey = key;
+      }
+    }
+
+    if (oldestKey) {
+      this._store.delete(oldestKey);
+      this._stats.evictions++;
+    }
+  }
+
+  /**
+   * Get cache statistics
+   * @returns {{ hits: number, misses: number, evictions: number, expired: number, size: number }}
+   */
+  getStats() {
+    return {
+      ...this._stats,
+      size: this._store.size,
+      hitRate: this._stats.hits + this._stats.misses > 0
+        ? Math.round((this._stats.hits / (this._stats.hits + this._stats.misses)) * 100)
+        : 0
+    };
+  }
+
+  /**
+   * Clear all entries (e.g., on session end)
+   */
+  clear() {
+    this._store.clear();
+    this._stats = { hits: 0, misses: 0, evictions: 0, expired: 0 };
+  }
+}

--- a/lib/agent-experience-factory/factory.js
+++ b/lib/agent-experience-factory/factory.js
@@ -1,0 +1,285 @@
+/**
+ * Agent Experience Factory
+ * Dynamically assembles experienced agent context at invocation time
+ *
+ * compose(invocationContext) → {promptPreamble, metadata}
+ *
+ * Queries issue_patterns, retrospectives, and skills at invocation time,
+ * applies token budgets with priority-based truncation, and caches
+ * per session to avoid redundant DB queries.
+ *
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A (FR-1, FR-2, FR-3, FR-4, FR-5)
+ */
+
+import { IssuePatternsAdapter } from './adapters/issue-patterns-adapter.js';
+import { RetrospectivesAdapter } from './adapters/retrospectives-adapter.js';
+import { SkillsAdapter } from './adapters/skills-adapter.js';
+import { SessionKnowledgeCache } from './cache/session-knowledge-cache.js';
+import {
+  estimateTokens,
+  allocateTokenBudget,
+  truncateByRank,
+  PRIORITY
+} from './token/token-estimator.js';
+
+/** Hard cap on total compose() time (TR-2) */
+const COMPOSE_TIMEOUT_MS = 600;
+
+/** Default per-source timeout (TR-2) */
+const DEFAULT_SOURCE_TIMEOUT_MS = 120;
+
+/** Default max prompt tokens */
+const DEFAULT_MAX_PROMPT_TOKENS = 1200;
+
+export class AgentExperienceFactory {
+  /**
+   * @param {Object} supabase - Supabase client
+   * @param {Object} [options]
+   * @param {number} [options.cacheTtlMs=300000] - Cache TTL (default 5 min)
+   * @param {number} [options.cacheMaxEntries=50] - Max cache entries
+   */
+  constructor(supabase, options = {}) {
+    this.supabase = supabase;
+    this.adapters = {
+      issue_patterns: new IssuePatternsAdapter(supabase),
+      retrospectives: new RetrospectivesAdapter(supabase),
+      skills: new SkillsAdapter(supabase)
+    };
+    this.cache = new SessionKnowledgeCache({
+      ttlMs: options.cacheTtlMs || 300_000,
+      maxEntries: options.cacheMaxEntries || 50
+    });
+  }
+
+  /**
+   * Compose an experienced agent context bundle
+   * Deterministic for the same invocationContext and knowledge snapshot
+   *
+   * @param {Object} invocationContext
+   * @param {string} invocationContext.agentCode - Sub-agent code (e.g., 'DATABASE')
+   * @param {string} invocationContext.domain - Domain filter (e.g., 'database')
+   * @param {string} [invocationContext.category] - Optional category filter
+   * @param {string} invocationContext.sessionId - Session ID for caching
+   * @param {string} [invocationContext.sdId] - Current SD ID for context
+   * @param {number} [invocationContext.maxPromptTokens=1200] - Token budget
+   * @param {string} [invocationContext.queryVersion='v1'] - Cache version key
+   * @returns {Promise<{promptPreamble: string, metadata: Object}>}
+   */
+  async compose(invocationContext) {
+    const {
+      agentCode,
+      domain,
+      category,
+      sessionId,
+      sdId,
+      maxPromptTokens = DEFAULT_MAX_PROMPT_TOKENS,
+      queryVersion = 'v1'
+    } = invocationContext;
+
+    const composeStart = Date.now();
+    const retrievalSummary = {};
+    const cacheResults = {};
+
+    // Retrieve from all sources (with caching and fail-open)
+    const sources = ['issue_patterns', 'retrospectives', 'skills'];
+    const fetchParams = { domain, category, limit: 5, timeoutMs: DEFAULT_SOURCE_TIMEOUT_MS, queryVersion };
+
+    const results = await Promise.race([
+      Promise.all(sources.map(source =>
+        this._fetchWithCache(source, sessionId, fetchParams)
+      )),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('COMPOSE_TIMEOUT')), COMPOSE_TIMEOUT_MS)
+      )
+    ]).catch(err => {
+      // Hard cap timeout - return whatever we have
+      if (err.message === 'COMPOSE_TIMEOUT') {
+        return sources.map(() => ({
+          items: [],
+          sourceStatus: 'timeout',
+          elapsedMs: COMPOSE_TIMEOUT_MS,
+          error: 'compose() hard cap exceeded',
+          cacheHit: false
+        }));
+      }
+      throw err;
+    });
+
+    // Build retrieval summary
+    sources.forEach((source, i) => {
+      const r = results[i];
+      retrievalSummary[source] = {
+        status: r.sourceStatus,
+        itemCount: r.items?.length || 0,
+        elapsedMs: r.elapsedMs,
+        error: r.error || null
+      };
+      cacheResults[source] = r.cacheHit || false;
+    });
+
+    // Flatten all items and build prompt sections by priority
+    const patternItems = results[0]?.items || [];
+    const retroItems = results[1]?.items || [];
+    const skillItems = results[2]?.items || [];
+
+    const sections = [];
+
+    // P1: Issue Patterns
+    if (patternItems.length > 0) {
+      sections.push({
+        priority: PRIORITY.ISSUE_PATTERNS,
+        source: 'issue_patterns',
+        content: this._formatPatterns(patternItems)
+      });
+    }
+
+    // P2: Retrospectives
+    if (retroItems.length > 0) {
+      sections.push({
+        priority: PRIORITY.RETROSPECTIVES,
+        source: 'retrospectives',
+        content: this._formatRetrospectives(retroItems)
+      });
+    }
+
+    // P3: Skills
+    if (skillItems.length > 0) {
+      sections.push({
+        priority: PRIORITY.SKILLS,
+        source: 'skills',
+        content: this._formatSkills(skillItems)
+      });
+    }
+
+    // Apply token budget with priority-based truncation
+    const { sections: allocated, truncationEvents, totalTokens } = allocateTokenBudget(sections, maxPromptTokens);
+
+    // Build prompt preamble from allocated sections
+    const preambleParts = allocated
+      .filter(s => s.content.length > 0)
+      .map(s => s.content);
+
+    const promptPreamble = preambleParts.length > 0
+      ? `\n════════════════════════════════════════════════════════════════\nDYNAMIC KNOWLEDGE (Agent Experience Factory)\n════════════════════════════════════════════════════════════════\n${preambleParts.join('\n')}\n════════════════════════════════════════════════════════════════\n`
+      : '';
+
+    const composeElapsedMs = Date.now() - composeStart;
+
+    const metadata = {
+      invocationId: `${sessionId}-${agentCode}-${Date.now()}`,
+      agentCode,
+      domain,
+      category: category || null,
+      sdId: sdId || null,
+      sessionId,
+      retrievalSummary,
+      cacheSummary: {
+        ...this.cache.getStats(),
+        perSource: cacheResults
+      },
+      tokenBudgetSummary: {
+        maxPromptTokens,
+        estimatedTokensAfter: totalTokens,
+        sectionsIncluded: allocated.filter(s => s.content.length > 0).length,
+        sectionsDropped: allocated.filter(s => s.truncated && s.content.length === 0).length
+      },
+      truncationEvents,
+      composeElapsedMs,
+      composedAt: new Date().toISOString()
+    };
+
+    return { promptPreamble, metadata };
+  }
+
+  /**
+   * Fetch from adapter with session cache
+   * @private
+   */
+  async _fetchWithCache(source, sessionId, params) {
+    const cacheKey = SessionKnowledgeCache.buildKey(
+      sessionId, source, params.domain, params.category, params.queryVersion
+    );
+
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return { ...cached, cacheHit: true };
+    }
+
+    const adapter = this.adapters[source];
+    const result = await adapter.fetch(params);
+
+    // Cache successful results
+    if (result.sourceStatus === 'ok' || result.sourceStatus === 'empty') {
+      this.cache.set(cacheKey, result);
+    }
+
+    return { ...result, cacheHit: false };
+  }
+
+  /**
+   * Format issue patterns into prompt section
+   * @private
+   */
+  _formatPatterns(items) {
+    let section = '────────────────────────────────────────────────────────────────\nKNOWN ISSUES & PROVEN SOLUTIONS (Dynamic)\n────────────────────────────────────────────────────────────────\n';
+    items.forEach((p, i) => {
+      const icon = p.severity === 'critical' ? '[CRITICAL]' : p.severity === 'high' ? '[HIGH]' : '[MEDIUM]';
+      section += `${i + 1}. ${icon} [${p.id}] ${p.title}\n`;
+      section += `   Occurrences: ${p.occurrences} | Trend: ${p.trend}\n`;
+      if (p.solution) {
+        section += `   Solution: ${p.solution.substring(0, 120)}\n`;
+      }
+    });
+    if (items.some(p => p.prevention?.length > 0)) {
+      section += '\nPREVENTION CHECKLIST:\n';
+      const seen = new Set();
+      items.flatMap(p => p.prevention).forEach(item => {
+        if (!seen.has(item)) {
+          seen.add(item);
+          section += `[ ] ${item}\n`;
+        }
+      });
+    }
+    return section;
+  }
+
+  /**
+   * Format retrospective learnings into prompt section
+   * @private
+   */
+  _formatRetrospectives(items) {
+    let section = '────────────────────────────────────────────────────────────────\nLEARNINGS FROM PAST WORK (Dynamic)\n────────────────────────────────────────────────────────────────\n';
+    items.forEach((r, i) => {
+      section += `${i + 1}. ${r.title}\n`;
+      if (r.learnings.length > 0) {
+        r.learnings.forEach(l => {
+          const text = typeof l === 'string' ? l : (l.learning || l.insight || JSON.stringify(l));
+          section += `   - ${text.substring(0, 150)}\n`;
+        });
+      }
+      if (r.failurePatterns.length > 0) {
+        section += `   Avoid: ${r.failurePatterns[0]}\n`;
+      }
+    });
+    return section;
+  }
+
+  /**
+   * Format skills into prompt section
+   * @private
+   */
+  _formatSkills(items) {
+    let section = '────────────────────────────────────────────────────────────────\nRELEVANT AGENT CAPABILITIES (Dynamic)\n────────────────────────────────────────────────────────────────\n';
+    items.forEach((s, i) => {
+      section += `${i + 1}. ${s.title}`;
+      if (s.capabilities.length > 0) {
+        section += `: ${s.capabilities.slice(0, 3).join(', ')}`;
+      }
+      section += '\n';
+      if (s.successPatterns.length > 0) {
+        section += `   Success: ${s.successPatterns[0]}\n`;
+      }
+    });
+    return section;
+  }
+}

--- a/lib/agent-experience-factory/index.js
+++ b/lib/agent-experience-factory/index.js
@@ -1,0 +1,69 @@
+/**
+ * Agent Experience Factory - Public API
+ *
+ * Dynamically assembles experienced agents at invocation time
+ * by querying accumulated domain knowledge.
+ *
+ * Usage:
+ *   import { compose, getFactory } from './agent-experience-factory/index.js';
+ *
+ *   // Quick API (uses singleton factory)
+ *   const { promptPreamble, metadata } = await compose({
+ *     agentCode: 'DATABASE',
+ *     domain: 'database',
+ *     sessionId: 'session-123',
+ *     maxPromptTokens: 1200
+ *   });
+ *
+ *   // Or get factory instance for custom config
+ *   const factory = await getFactory({ cacheTtlMs: 60000 });
+ *   const result = await factory.compose({ ... });
+ *
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A
+ */
+
+import { AgentExperienceFactory } from './factory.js';
+
+export { AgentExperienceFactory } from './factory.js';
+export { SessionKnowledgeCache } from './cache/session-knowledge-cache.js';
+export { estimateTokens, allocateTokenBudget, PRIORITY } from './token/token-estimator.js';
+export { BaseAdapter } from './adapters/base-adapter.js';
+export { IssuePatternsAdapter } from './adapters/issue-patterns-adapter.js';
+export { RetrospectivesAdapter } from './adapters/retrospectives-adapter.js';
+export { SkillsAdapter } from './adapters/skills-adapter.js';
+
+/** @type {AgentExperienceFactory|null} */
+let _singleton = null;
+
+/**
+ * Get or create singleton factory instance
+ * @param {Object} [options] - Factory options
+ * @returns {Promise<AgentExperienceFactory>}
+ */
+export async function getFactory(options = {}) {
+  if (!_singleton) {
+    const { getSupabaseClient } = await import('../sub-agent-executor/supabase-client.js');
+    const supabase = await getSupabaseClient();
+    _singleton = new AgentExperienceFactory(supabase, options);
+  }
+  return _singleton;
+}
+
+/**
+ * Compose experienced agent context (convenience wrapper)
+ * Uses singleton factory with default config
+ *
+ * @param {Object} invocationContext - See AgentExperienceFactory.compose()
+ * @returns {Promise<{promptPreamble: string, metadata: Object}>}
+ */
+export async function compose(invocationContext) {
+  const factory = await getFactory();
+  return factory.compose(invocationContext);
+}
+
+/**
+ * Reset singleton (for testing)
+ */
+export function resetFactory() {
+  _singleton = null;
+}

--- a/lib/agent-experience-factory/token/token-estimator.js
+++ b/lib/agent-experience-factory/token/token-estimator.js
@@ -1,0 +1,118 @@
+/**
+ * Deterministic Token Estimator
+ * Pure function for token estimation - environment-independent
+ *
+ * Uses conservative heuristic: ~4 chars per token (Claude-family models)
+ * Deterministic: same input always produces same output
+ *
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A (TR-3)
+ */
+
+const CHARS_PER_TOKEN = 4;
+
+/**
+ * Estimate token count for a text string
+ * Deterministic pure function - no external dependencies
+ *
+ * @param {string} text - Text to estimate
+ * @returns {number} Estimated token count
+ */
+export function estimateTokens(text) {
+  if (!text || typeof text !== 'string') return 0;
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Priority levels for token budget allocation
+ * Lower number = higher priority (kept first during truncation)
+ */
+export const PRIORITY = {
+  SAFETY: 0,        // P0: Safety/operating rules - never truncated
+  ISSUE_PATTERNS: 1, // P1: Known issues and proven solutions
+  RETROSPECTIVES: 2, // P2: Learnings from past work
+  SKILLS: 3,         // P3: Agent capabilities and patterns
+  FORMATTING: 4      // P4: Formatting/boilerplate - truncated first
+};
+
+/**
+ * Allocate token budget across priority sections
+ * Higher priority sections get their full allocation first
+ *
+ * @param {Array<{priority: number, content: string, source: string}>} sections
+ * @param {number} maxTokens - Total token budget
+ * @returns {{sections: Array<{priority: number, content: string, source: string, tokens: number, truncated: boolean}>, truncationEvents: Array, totalTokens: number}}
+ */
+export function allocateTokenBudget(sections, maxTokens) {
+  const truncationEvents = [];
+  let totalTokens = 0;
+
+  // Sort by priority (lowest number = highest priority)
+  const sorted = [...sections].sort((a, b) => a.priority - b.priority);
+
+  const allocated = sorted.map(section => {
+    const tokens = estimateTokens(section.content);
+
+    if (totalTokens + tokens <= maxTokens) {
+      // Fits within budget
+      totalTokens += tokens;
+      return { ...section, tokens, truncated: false };
+    }
+
+    // Need to truncate
+    const remaining = Math.max(0, maxTokens - totalTokens);
+
+    if (remaining === 0) {
+      // No budget left - drop entirely
+      truncationEvents.push({
+        source: section.source,
+        priority: section.priority,
+        action: 'dropped',
+        originalTokens: tokens,
+        keptTokens: 0
+      });
+      return { ...section, content: '', tokens: 0, truncated: true };
+    }
+
+    // Partial truncation - keep what fits
+    const keepChars = remaining * CHARS_PER_TOKEN;
+    const truncatedContent = section.content.substring(0, keepChars);
+    totalTokens += remaining;
+
+    truncationEvents.push({
+      source: section.source,
+      priority: section.priority,
+      action: 'truncated',
+      originalTokens: tokens,
+      keptTokens: remaining
+    });
+
+    return { ...section, content: truncatedContent, tokens: remaining, truncated: true };
+  });
+
+  return { sections: allocated, truncationEvents, totalTokens };
+}
+
+/**
+ * Truncate items within a section by rank (lowest ranked dropped first)
+ *
+ * @param {Array<{content: string, rank?: number}>} items - Items sorted by rank (highest first)
+ * @param {number} maxTokens - Token budget for this section
+ * @returns {{kept: Array, dropped: Array, totalTokens: number}}
+ */
+export function truncateByRank(items, maxTokens) {
+  let totalTokens = 0;
+  const kept = [];
+  const dropped = [];
+
+  for (const item of items) {
+    const tokens = estimateTokens(item.content || JSON.stringify(item));
+    if (totalTokens + tokens <= maxTokens) {
+      totalTokens += tokens;
+      kept.push(item);
+    } else {
+      dropped.push(item);
+    }
+  }
+
+  return { kept, dropped, totalTokens };
+}

--- a/lib/sub-agent-executor/executor.js
+++ b/lib/sub-agent-executor/executor.js
@@ -77,8 +77,13 @@ export async function executeSubAgent(code, sdId, options = {}) {
     }
     console.log(`   Recommended model: ${recommendedModel}`);
 
-    // Step 1: Load instructions from database
-    const subAgent = await loadSubAgentInstructions(code);
+    // Step 1: Load instructions from database (with Agent Experience Factory composition)
+    const compositionContext = {
+      sessionId: options.sessionId || `session-${Date.now()}`,
+      sdId: sdKey || sdId,
+      maxPromptTokens: options.maxPromptTokens || 600
+    };
+    const subAgent = await loadSubAgentInstructions(code, compositionContext);
 
     // Attach routing metadata for downstream use
     subAgent.routing = {
@@ -342,7 +347,8 @@ export async function executeSubAgent(code, sdId, options = {}) {
       ...results,
       sub_agent: subAgent,
       stored_result_id: stored.id,
-      task_contract_id: taskContract?.contract_id || null
+      task_contract_id: taskContract?.contract_id || null,
+      composition_metadata: subAgent.compositionResult?.metadata || null
     };
 
   } catch (error) {

--- a/lib/sub-agent-executor/instruction-loader.js
+++ b/lib/sub-agent-executor/instruction-loader.js
@@ -2,19 +2,27 @@
  * Instruction Loader
  * Loads and formats sub-agent instructions from database
  *
- * Extracted from sub-agent-executor.js for modularity
+ * Enhanced with Agent Experience Factory for dynamic knowledge composition
  * SD-LEO-REFACTOR-SUBAGENT-EXEC-001
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A
  */
 
 import { getSupabaseClient } from './supabase-client.js';
 import { loadRelevantPatterns } from './pattern-loader.js';
+import { SUB_AGENT_CATEGORY_MAPPING } from './phase-model-config.js';
 
 /**
  * Load sub-agent instructions from database
+ * Enhanced: Composes dynamic knowledge via Agent Experience Factory
+ *
  * @param {string} code - Sub-agent code (e.g., 'VALIDATION', 'TESTING', 'DATABASE')
+ * @param {Object} [compositionContext] - Context for Agent Experience Factory
+ * @param {string} [compositionContext.sessionId] - Session ID for caching
+ * @param {string} [compositionContext.sdId] - Current SD ID
+ * @param {number} [compositionContext.maxPromptTokens] - Token budget for dynamic knowledge
  * @returns {Promise<Object>} Sub-agent data with formatted instructions
  */
-export async function loadSubAgentInstructions(code) {
+export async function loadSubAgentInstructions(code, compositionContext = {}) {
   console.log(`\nLoading sub-agent instructions: ${code}...`);
 
   const supabase = await getSupabaseClient();
@@ -33,29 +41,70 @@ export async function loadSubAgentInstructions(code) {
     throw new Error(`Sub-agent ${code} not found in database`);
   }
 
-  // LEO Protocol v4.3.2 Enhancement: Load relevant patterns
+  // LEO Protocol v4.3.2 Enhancement: Load relevant patterns (legacy path)
   const relevantPatterns = await loadRelevantPatterns(code);
 
-  // Format instructions for Claude to read (now includes patterns)
-  const formatted = formatInstructionsForClaude(subAgent, relevantPatterns);
+  // Agent Experience Factory: Compose dynamic knowledge
+  let compositionResult = null;
+  if (compositionContext.sessionId) {
+    compositionResult = await _composeExperience(code, compositionContext);
+  }
+
+  // Format instructions for Claude to read (includes patterns + factory preamble)
+  const formatted = formatInstructionsForClaude(subAgent, relevantPatterns, compositionResult);
 
   console.log(`Loaded: ${subAgent.name} (v${subAgent.metadata?.version || '1.0.0'})`);
 
   return {
     ...subAgent,
     relevantPatterns,
+    compositionResult,
     formatted
   };
 }
 
 /**
+ * Compose dynamic knowledge via Agent Experience Factory
+ * Fail-open: returns null on any error (factory is additive, not blocking)
+ * @private
+ */
+async function _composeExperience(code, context) {
+  try {
+    const { compose } = await import('../agent-experience-factory/index.js');
+    const categories = SUB_AGENT_CATEGORY_MAPPING[code] || [];
+    const domain = categories[0] || code.toLowerCase();
+
+    const result = await compose({
+      agentCode: code,
+      domain,
+      category: categories[1] || null,
+      sessionId: context.sessionId,
+      sdId: context.sdId || null,
+      maxPromptTokens: context.maxPromptTokens || 600
+    });
+
+    if (result.promptPreamble) {
+      console.log(`   [Factory] Composed ${result.metadata.tokenBudgetSummary.estimatedTokensAfter} tokens from ${result.metadata.tokenBudgetSummary.sectionsIncluded} sources (${result.metadata.composeElapsedMs}ms)`);
+    }
+
+    return result;
+  } catch (err) {
+    console.log(`   [Factory] Composition skipped: ${err.message}`);
+    return null;
+  }
+}
+
+/**
  * Format sub-agent instructions for Claude to read
  * LEO Protocol v4.3.2: Now includes relevant patterns and prevention checklists
+ * Enhanced: Injects Agent Experience Factory preamble when available
+ *
  * @param {Object} subAgent - Sub-agent record from database
  * @param {Array} relevantPatterns - Relevant issue patterns (optional)
+ * @param {Object|null} compositionResult - Agent Experience Factory result (optional)
  * @returns {string} Formatted instructions
  */
-export function formatInstructionsForClaude(subAgent, relevantPatterns = []) {
+export function formatInstructionsForClaude(subAgent, relevantPatterns = [], compositionResult = null) {
   const metadata = subAgent.metadata || {};
   const capabilities = subAgent.capabilities || [];
   const sources = metadata.sources || [];
@@ -144,7 +193,7 @@ FAILURE PATTERNS TO AVOID
 ────────────────────────────────────────────────────────────────
 ${metadata.failure_patterns.map((p, i) => `${i + 1}. ${p}`).join('\n')}
 ` : ''}
-
+${compositionResult?.promptPreamble || ''}
 ════════════════════════════════════════════════════════════════
 END OF INSTRUCTIONS
 ════════════════════════════════════════════════════════════════

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.63.0",
-        "@babel/parser": "^7.28.4",
+        "@babel/parser": "^7.29.0",
         "@babel/traverse": "^7.28.4",
         "@doist/todoist-api-typescript": "^6.4.0",
         "@octokit/rest": "^22.0.1",

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.63.0",
-    "@babel/parser": "^7.28.4",
+    "@babel/parser": "^7.29.0",
     "@babel/traverse": "^7.28.4",
     "@doist/todoist-api-typescript": "^6.4.0",
     "@octokit/rest": "^22.0.1",

--- a/tests/unit/agent-experience-factory.test.js
+++ b/tests/unit/agent-experience-factory.test.js
@@ -1,0 +1,294 @@
+/**
+ * Agent Experience Factory - Unit Tests
+ *
+ * Covers: compose() interface, caching, token truncation, LRU eviction
+ * SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SessionKnowledgeCache } from '../../lib/agent-experience-factory/cache/session-knowledge-cache.js';
+import {
+  estimateTokens,
+  allocateTokenBudget,
+  truncateByRank,
+  PRIORITY
+} from '../../lib/agent-experience-factory/token/token-estimator.js';
+import { AgentExperienceFactory } from '../../lib/agent-experience-factory/factory.js';
+
+// TS-2: Cache hit avoids redundant adapter calls
+describe('SessionKnowledgeCache', () => {
+  let cache;
+
+  beforeEach(() => {
+    cache = new SessionKnowledgeCache({ ttlMs: 300_000, maxEntries: 100 });
+  });
+
+  it('returns null for cache miss', () => {
+    const result = cache.get('nonexistent');
+    expect(result).toBeNull();
+    expect(cache.getStats().misses).toBe(1);
+  });
+
+  it('returns cached data on hit', () => {
+    cache.set('key1', { items: [{ id: 'p1' }], sourceStatus: 'ok' });
+    const result = cache.get('key1');
+    expect(result).toEqual({ items: [{ id: 'p1' }], sourceStatus: 'ok' });
+    expect(cache.getStats().hits).toBe(1);
+  });
+
+  it('expires entries after TTL', () => {
+    const shortCache = new SessionKnowledgeCache({ ttlMs: 50 });
+    shortCache.set('key1', { items: [] });
+
+    // Immediate get should hit
+    expect(shortCache.get('key1')).not.toBeNull();
+    expect(shortCache.getStats().hits).toBe(1);
+
+    // After TTL, should miss
+    return new Promise(resolve => setTimeout(() => {
+      const result = shortCache.get('key1');
+      expect(result).toBeNull();
+      expect(shortCache.getStats().expired).toBe(1);
+      resolve();
+    }, 60));
+  });
+
+  // TS-5: LRU eviction when cache exceeds max entries
+  it('evicts LRU entry when max entries exceeded', () => {
+    const smallCache = new SessionKnowledgeCache({ maxEntries: 2 });
+
+    smallCache.set('key1', { data: 'first' });
+    smallCache.set('key2', { data: 'second' });
+
+    // Access key1 to make key2 the LRU
+    smallCache.get('key1');
+
+    // Third entry should evict key2 (LRU)
+    smallCache.set('key3', { data: 'third' });
+
+    expect(smallCache.getStats().evictions).toBe(1);
+    expect(smallCache.get('key2')).toBeNull(); // evicted
+    expect(smallCache.get('key1')).not.toBeNull(); // still present
+    expect(smallCache.get('key3')).not.toBeNull(); // just added
+  });
+
+  it('builds deterministic cache keys', () => {
+    const key = SessionKnowledgeCache.buildKey('sess1', 'issue_patterns', 'database', 'security', 'v1');
+    expect(key).toBe('sess1|issue_patterns|database|security|v1');
+
+    // Same inputs = same key
+    const key2 = SessionKnowledgeCache.buildKey('sess1', 'issue_patterns', 'database', 'security', 'v1');
+    expect(key).toBe(key2);
+  });
+
+  it('tracks hit rate correctly', () => {
+    cache.set('key1', { data: 1 });
+    cache.get('key1'); // hit
+    cache.get('key1'); // hit
+    cache.get('miss'); // miss
+
+    const stats = cache.getStats();
+    expect(stats.hits).toBe(2);
+    expect(stats.misses).toBe(1);
+    expect(stats.hitRate).toBe(67); // 2/3
+  });
+});
+
+// TS-4: Token truncation
+describe('Token Estimator', () => {
+  it('estimates tokens from text length', () => {
+    expect(estimateTokens('')).toBe(0);
+    expect(estimateTokens(null)).toBe(0);
+    expect(estimateTokens('hello')).toBe(2); // 5 chars / 4 = 1.25, ceil = 2
+    expect(estimateTokens('a'.repeat(100))).toBe(25); // 100/4 = 25
+  });
+
+  it('is deterministic - same input, same output', () => {
+    const text = 'This is a test string for token estimation.';
+    const result1 = estimateTokens(text);
+    const result2 = estimateTokens(text);
+    expect(result1).toBe(result2);
+  });
+});
+
+describe('Token Budget Allocation', () => {
+  it('allocates within budget without truncation', () => {
+    const sections = [
+      { priority: PRIORITY.ISSUE_PATTERNS, source: 'issue_patterns', content: 'a'.repeat(100) },
+      { priority: PRIORITY.RETROSPECTIVES, source: 'retrospectives', content: 'b'.repeat(100) }
+    ];
+
+    const result = allocateTokenBudget(sections, 1000);
+    expect(result.truncationEvents).toHaveLength(0);
+    expect(result.totalTokens).toBe(50); // 200 chars / 4
+    expect(result.sections.every(s => !s.truncated)).toBe(true);
+  });
+
+  // TS-4: Truncation drops lowest priority first
+  it('drops lowest priority sections first when over budget', () => {
+    const sections = [
+      { priority: PRIORITY.ISSUE_PATTERNS, source: 'issue_patterns', content: 'a'.repeat(200) },
+      { priority: PRIORITY.RETROSPECTIVES, source: 'retrospectives', content: 'b'.repeat(200) },
+      { priority: PRIORITY.SKILLS, source: 'skills', content: 'c'.repeat(200) }
+    ];
+
+    // Budget: 100 tokens = 400 chars. Total content: 600 chars = 150 tokens.
+    // P1 (issue_patterns) = 50 tokens, P2 (retrospectives) = 50 tokens -> 100 tokens
+    // P3 (skills) should be dropped
+    const result = allocateTokenBudget(sections, 100);
+
+    expect(result.truncationEvents.length).toBeGreaterThan(0);
+
+    // Skills (P3) should be truncated/dropped before patterns (P1)
+    const skillsSection = result.sections.find(s => s.source === 'skills');
+    const patternsSection = result.sections.find(s => s.source === 'issue_patterns');
+
+    expect(skillsSection.truncated).toBe(true);
+    expect(patternsSection.truncated).toBe(false);
+  });
+
+  it('logs truncation events with original and kept token counts', () => {
+    const sections = [
+      { priority: PRIORITY.ISSUE_PATTERNS, source: 'issue_patterns', content: 'a'.repeat(800) }
+    ];
+
+    const result = allocateTokenBudget(sections, 50); // Budget less than content
+    expect(result.truncationEvents).toHaveLength(1);
+    expect(result.truncationEvents[0]).toMatchObject({
+      source: 'issue_patterns',
+      action: 'truncated',
+      keptTokens: 50
+    });
+    expect(result.truncationEvents[0].originalTokens).toBeGreaterThan(50);
+  });
+});
+
+describe('Rank-based Truncation', () => {
+  it('keeps highest ranked items within budget', () => {
+    const items = [
+      { content: 'a'.repeat(40), rank: 10 },  // 10 tokens
+      { content: 'b'.repeat(40), rank: 8 },   // 10 tokens
+      { content: 'c'.repeat(40), rank: 5 }    // 10 tokens
+    ];
+
+    const result = truncateByRank(items, 20); // Budget for 2 items
+    expect(result.kept).toHaveLength(2);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.totalTokens).toBe(20);
+  });
+});
+
+// TS-1: Happy path composition + TS-3: Fail-open
+describe('AgentExperienceFactory', () => {
+  let factory;
+  let mockSupabase;
+
+  beforeEach(() => {
+    mockSupabase = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      not: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
+      contains: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnValue({
+        then: vi.fn()
+      })
+    };
+
+    // Default: return empty results for all tables
+    mockSupabase.from.mockImplementation((table) => {
+      const chain = {
+        select: vi.fn().mockReturnValue(chain),
+        eq: vi.fn().mockReturnValue(chain),
+        in: vi.fn().mockReturnValue(chain),
+        not: vi.fn().mockReturnValue(chain),
+        is: vi.fn().mockReturnValue(chain),
+        contains: vi.fn().mockReturnValue(chain),
+        order: vi.fn().mockReturnValue(chain),
+        limit: vi.fn().mockResolvedValue({ data: [], error: null })
+      };
+      return chain;
+    });
+
+    factory = new AgentExperienceFactory(mockSupabase, { cacheTtlMs: 300_000 });
+  });
+
+  it('returns empty preamble when no knowledge found', async () => {
+    const result = await factory.compose({
+      agentCode: 'DATABASE',
+      domain: 'database',
+      sessionId: 'sess-1',
+      maxPromptTokens: 1200
+    });
+
+    expect(result.promptPreamble).toBe('');
+    expect(result.metadata.agentCode).toBe('DATABASE');
+    expect(result.metadata.retrievalSummary).toBeDefined();
+    expect(result.metadata.cacheSummary).toBeDefined();
+    expect(result.metadata.tokenBudgetSummary).toBeDefined();
+  });
+
+  it('returns metadata with retrieval summary for all sources', async () => {
+    const result = await factory.compose({
+      agentCode: 'TESTING',
+      domain: 'testing',
+      sessionId: 'sess-2',
+      maxPromptTokens: 800
+    });
+
+    expect(result.metadata.retrievalSummary).toHaveProperty('issue_patterns');
+    expect(result.metadata.retrievalSummary).toHaveProperty('retrospectives');
+    expect(result.metadata.retrievalSummary).toHaveProperty('skills');
+  });
+
+  it('uses cache on second invocation for same context', async () => {
+    // Pre-populate cache with known data to test cache-hit path directly
+    const cacheKey = SessionKnowledgeCache.buildKey('sess-3', 'issue_patterns', 'database', '', 'v1');
+    factory.cache.set(cacheKey, {
+      items: [{ id: 'cached-p1', source: 'issue_patterns', title: 'Cached pattern', severity: 'medium', occurrences: 3, trend: 'stable', solution: null, prevention: [] }],
+      sourceStatus: 'ok',
+      elapsedMs: 5
+    });
+
+    const result = await factory.compose({
+      agentCode: 'DATABASE',
+      domain: 'database',
+      sessionId: 'sess-3',
+      maxPromptTokens: 1200
+    });
+
+    // Cache should have hits (from the pre-populated entry)
+    const stats = factory.cache.getStats();
+    expect(stats.hits).toBeGreaterThanOrEqual(1);
+
+    // The result should include the cached pattern data
+    expect(result.metadata.cacheSummary.perSource.issue_patterns).toBe(true);
+  });
+
+  it('includes invocationId in metadata', async () => {
+    const result = await factory.compose({
+      agentCode: 'DATABASE',
+      domain: 'database',
+      sessionId: 'sess-4',
+      maxPromptTokens: 1200
+    });
+
+    expect(result.metadata.invocationId).toContain('sess-4');
+    expect(result.metadata.invocationId).toContain('DATABASE');
+  });
+
+  it('respects token budget', async () => {
+    const result = await factory.compose({
+      agentCode: 'DATABASE',
+      domain: 'database',
+      sessionId: 'sess-5',
+      maxPromptTokens: 100
+    });
+
+    expect(result.metadata.tokenBudgetSummary.maxPromptTokens).toBe(100);
+    expect(result.metadata.tokenBudgetSummary.estimatedTokensAfter).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `AgentExperienceFactory.compose()` that dynamically assembles experienced agent context at sub-agent invocation time
- Adds 3 retrieval adapters (issue_patterns, retrospectives, skills) with fail-open behavior and per-source timeouts
- Adds LRU session cache with configurable TTL (5min default) and max entries (50) using monotonic counter for deterministic ordering
- Adds deterministic token estimator with priority-based budget allocation (P0 safety → P1 patterns → P2 retros → P3 skills)
- Integrates with existing sub-agent executor via instruction-loader.js and executor.js
- 17 unit tests covering cache, token estimation, budget allocation, and factory composition

## Test plan
- [x] 17/17 unit tests passing (vitest)
- [x] 15/15 smoke tests passing
- [x] Module loads with all 12 expected exports
- [x] TESTING sub-agent PASS at 85% confidence
- [x] All 6 user stories completed and validated

SD-LEO-ORCH-AGENT-EXPERIENCE-FACTORY-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)