### PR TITLE
feat(post-completion): expand /document trigger to all SD types

### DIFF
--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -57,6 +57,12 @@ Different Strategic Directive types require different documentation approaches.
 | **qa** | Test strategy, coverage report | E2E patterns | `docs/05_testing/` |
 | **orchestrator** | Workflow documentation | Phase transition guide | `docs/workflow/`, LEO protocol sections |
 
+### Relevant Doc Directories by SD Type
+
+When `/document` runs, it should scan these directories for existing documentation that may need updating:
+
+Use `SD_TYPE_DOC_DIRECTORIES` from `lib/utils/post-completion-requirements.js` for the mapping. This constant maps each SD type to an array of directories most likely to contain documentation affected by that SD type's work.
+
 ### SD Type Detection
 
 Detect SD type from context or query database:

--- a/lib/utils/post-completion-requirements.js
+++ b/lib/utils/post-completion-requirements.js
@@ -50,6 +50,27 @@ const MINIMAL_SEQUENCE_TYPES = [
 ];
 
 /**
+ * Relevant documentation directories by SD type.
+ * Used by /document skill to scope existing-doc scanning per SD type.
+ */
+const SD_TYPE_DOC_DIRECTORIES = {
+  feature: ['docs/04_features/', 'docs/02_api/', 'docs/reference/'],
+  enhancement: ['docs/04_features/', 'docs/reference/'],
+  security: ['docs/reference/', 'docs/03_protocols_and_standards/'],
+  bugfix: ['docs/troubleshooting/', 'docs/reference/'],
+  refactor: ['docs/01_architecture/', 'docs/reference/'],
+  performance: ['docs/reference/', 'docs/01_architecture/'],
+  database: ['docs/database/', 'docs/reference/'],
+  infrastructure: ['docs/06_deployment/', 'docs/infrastructure/', 'docs/operations/'],
+  api: ['docs/02_api/', 'docs/reference/'],
+  backend: ['docs/02_api/', 'docs/reference/'],
+  process: ['docs/03_protocols_and_standards/', 'docs/workflow/', 'docs/governance/'],
+  documentation: ['docs/'],
+  docs: ['docs/'],
+  uat: ['docs/05_testing/'],
+};
+
+/**
  * SD source values that should skip /learn to prevent infinite recursion
  */
 const LEARN_SKIP_SOURCES = [
@@ -103,8 +124,8 @@ export function getPostCompletionRequirements(sdType, options = {}) {
     // Ship: Always required for completed SDs
     ship: true,
 
-    // Document: Only for code SDs that may have user-facing changes
-    document: isFullSequence && ['feature', 'enhancement', 'security'].includes(normalizedType),
+    // Document: All SD types except orchestrator (orchestrators don't do direct work)
+    document: normalizedType !== 'orchestrator',
 
     // Learn: For code SDs, unless source indicates skip
     learn: isFullSequence && !skipLearn,
@@ -250,7 +271,7 @@ export function getPostCompletionRequirementsFromSD(sd) {
 }
 
 // Export constants for direct import
-export { FULL_SEQUENCE_TYPES, MINIMAL_SEQUENCE_TYPES, LEARN_SKIP_SOURCES };
+export { FULL_SEQUENCE_TYPES, MINIMAL_SEQUENCE_TYPES, LEARN_SKIP_SOURCES, SD_TYPE_DOC_DIRECTORIES };
 
 // Export all functions and constants as default
 export default {
@@ -261,5 +282,6 @@ export default {
   getPostCompletionRequirementsFromSD,
   FULL_SEQUENCE_TYPES,
   MINIMAL_SEQUENCE_TYPES,
-  LEARN_SKIP_SOURCES
+  LEARN_SKIP_SOURCES,
+  SD_TYPE_DOC_DIRECTORIES
 };

--- a/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
+++ b/scripts/hooks/stop-subagent-enforcement/post-completion-validator.js
@@ -6,7 +6,7 @@
  * Validates that post-completion commands were executed:
  * - /ship (BLOCK if missing) - Required for all completed SDs
  * - /learn (WARN if missing) - Recommended for code SDs
- * - /document (WARN if missing) - Recommended for feature SDs
+ * - /document (WARN if missing) - Recommended for all SD types except orchestrator
  *
  * @module stop-subagent-enforcement/post-completion-validator
  */
@@ -84,8 +84,8 @@ export async function validatePostCompletion(supabase, sd, sdKey) {
       missingRecommended.push('LEARN');
     }
 
-    // Check /document - Recommended for feature SDs
-    if (sd.sd_type === 'feature' || sd.sd_type === 'enhancement') {
+    // Check /document - Recommended for all SD types except orchestrator
+    if (sd.sd_type !== 'orchestrator') {
       const hasDocument = docmonResults && docmonResults.length > 0 &&
         ['PASS', 'CONDITIONAL_PASS'].includes(docmonResults[0].verdict);
       if (!hasDocument) {

--- a/test/unit/post-completion-requirements.test.js
+++ b/test/unit/post-completion-requirements.test.js
@@ -14,7 +14,8 @@ import {
   getPostCompletionRequirementsFromSD,
   FULL_SEQUENCE_TYPES,
   MINIMAL_SEQUENCE_TYPES,
-  LEARN_SKIP_SOURCES
+  LEARN_SKIP_SOURCES,
+  SD_TYPE_DOC_DIRECTORIES
 } from '../../lib/utils/post-completion-requirements.js';
 
 describe('Post-Completion Requirements', () => {
@@ -36,7 +37,7 @@ describe('Post-Completion Requirements', () => {
         // Bugfix doesn't need restart unless hasUIChanges is true
         expect(reqs.restart).toBe(false);
         expect(reqs.ship).toBe(true);
-        expect(reqs.document).toBe(false); // bugfix doesn't need document
+        expect(reqs.document).toBe(true); // all types except orchestrator get document
         expect(reqs.learn).toBe(true);
         expect(reqs.sequenceType).toBe('full');
       });
@@ -75,47 +76,47 @@ describe('Post-Completion Requirements', () => {
 
         expect(reqs.ship).toBe(true);
         expect(reqs.learn).toBe(true);
-        expect(reqs.document).toBe(false); // refactor doesn't need new docs
+        expect(reqs.document).toBe(true); // all types except orchestrator get document
       });
     });
 
     describe('Minimal sequence SD types (documentation, orchestrator, infrastructure)', () => {
-      it('should return minimal sequence for documentation SD', () => {
+      it('should return minimal sequence for documentation SD (with document)', () => {
         const reqs = getPostCompletionRequirements('documentation');
 
         expect(reqs.restart).toBe(false);
         expect(reqs.ship).toBe(true);
-        expect(reqs.document).toBe(false);
+        expect(reqs.document).toBe(true); // all types except orchestrator get document
         expect(reqs.learn).toBe(false);
         expect(reqs.sequenceType).toBe('minimal');
       });
 
-      it('should return minimal sequence for orchestrator SD', () => {
+      it('should return minimal sequence for orchestrator SD (no document)', () => {
         const reqs = getPostCompletionRequirements('orchestrator');
 
         expect(reqs.restart).toBe(false);
         expect(reqs.ship).toBe(true);
-        expect(reqs.document).toBe(false);
+        expect(reqs.document).toBe(false); // orchestrator excluded - children handle docs
         expect(reqs.learn).toBe(false);
         expect(reqs.sequenceType).toBe('minimal');
       });
 
-      it('should return minimal sequence for infrastructure SD', () => {
+      it('should return minimal sequence for infrastructure SD (with document)', () => {
         const reqs = getPostCompletionRequirements('infrastructure');
 
         expect(reqs.restart).toBe(false);
         expect(reqs.ship).toBe(true);
-        expect(reqs.document).toBe(false);
+        expect(reqs.document).toBe(true); // all types except orchestrator get document
         expect(reqs.learn).toBe(false);
         expect(reqs.sequenceType).toBe('minimal');
       });
 
-      it('should return minimal sequence for database SD', () => {
+      it('should return minimal sequence for database SD (with document)', () => {
         const reqs = getPostCompletionRequirements('database');
 
         expect(reqs.restart).toBe(false);
         expect(reqs.ship).toBe(true);
-        expect(reqs.document).toBe(false);
+        expect(reqs.document).toBe(true); // all types except orchestrator get document
         expect(reqs.learn).toBe(false);
         expect(reqs.sequenceType).toBe('minimal');
       });
@@ -175,10 +176,10 @@ describe('Post-Completion Requirements', () => {
       expect(sequence).toEqual(['restart', 'document', 'ship', 'learn']);
     });
 
-    it('should return minimal sequence for infrastructure SD', () => {
+    it('should return sequence with document for infrastructure SD', () => {
       const sequence = getPostCompletionSequence('infrastructure');
 
-      expect(sequence).toEqual(['ship']);
+      expect(sequence).toEqual(['document', 'ship']);
     });
 
     it('should return sequence without learn for learn-source SD', () => {
@@ -291,6 +292,15 @@ describe('Post-Completion Requirements', () => {
       expect(LEARN_SKIP_SOURCES).toContain('learn');
       expect(LEARN_SKIP_SOURCES).toContain('quick-fix');
       expect(LEARN_SKIP_SOURCES).toContain('escalation');
+    });
+
+    it('should export SD_TYPE_DOC_DIRECTORIES mapping', () => {
+      expect(typeof SD_TYPE_DOC_DIRECTORIES).toBe('object');
+      expect(SD_TYPE_DOC_DIRECTORIES.feature).toContain('docs/04_features/');
+      expect(SD_TYPE_DOC_DIRECTORIES.database).toContain('docs/database/');
+      expect(SD_TYPE_DOC_DIRECTORIES.infrastructure).toContain('docs/06_deployment/');
+      expect(SD_TYPE_DOC_DIRECTORIES.api).toContain('docs/02_api/');
+      expect(SD_TYPE_DOC_DIRECTORIES).not.toHaveProperty('orchestrator');
     });
   });
 });

--- a/tests/unit/testing/post-completion-requirements.test.js
+++ b/tests/unit/testing/post-completion-requirements.test.js
@@ -12,7 +12,8 @@ import {
   shouldSkipLearn,
   FULL_SEQUENCE_TYPES,
   MINIMAL_SEQUENCE_TYPES,
-  LEARN_SKIP_SOURCES
+  LEARN_SKIP_SOURCES,
+  SD_TYPE_DOC_DIRECTORIES
 } from '../../../lib/utils/post-completion-requirements.js';
 
 // ============================================================================
@@ -142,6 +143,7 @@ describe('getPostCompletionSequence() - Vision QA step', () => {
       autoProceed: true
     });
     expect(seq).not.toContain('vision-qa');
+    expect(seq).toContain('document'); // infrastructure now gets document
   });
 
   it('should produce full sequence: restart -> vision-qa -> document -> ship -> learn', () => {
@@ -160,9 +162,9 @@ describe('getPostCompletionSequence() - Vision QA step', () => {
     expect(seq).toEqual(['restart', 'document', 'ship', 'learn']);
   });
 
-  it('should produce minimal sequence for infrastructure: ship only', () => {
+  it('should produce sequence with document for infrastructure', () => {
     const seq = getPostCompletionSequence('infrastructure');
-    expect(seq).toEqual(['ship']);
+    expect(seq).toEqual(['document', 'ship']);
   });
 });
 
@@ -257,6 +259,14 @@ describe('Exported constants', () => {
     expect(Array.isArray(LEARN_SKIP_SOURCES)).toBe(true);
     expect(LEARN_SKIP_SOURCES).toContain('learn');
     expect(LEARN_SKIP_SOURCES).toContain('quick-fix');
+  });
+
+  it('should export SD_TYPE_DOC_DIRECTORIES mapping', () => {
+    expect(typeof SD_TYPE_DOC_DIRECTORIES).toBe('object');
+    expect(SD_TYPE_DOC_DIRECTORIES.feature).toContain('docs/04_features/');
+    expect(SD_TYPE_DOC_DIRECTORIES.database).toContain('docs/database/');
+    expect(SD_TYPE_DOC_DIRECTORIES.infrastructure).toContain('docs/06_deployment/');
+    expect(SD_TYPE_DOC_DIRECTORIES).not.toHaveProperty('orchestrator');
   });
 });
 


### PR DESCRIPTION
## Summary

- Expanded `/document` trigger from 3 SD types (feature, enhancement, security) to **all SD types except orchestrator**
- Added `SD_TYPE_DOC_DIRECTORIES` mapping constant for targeted existing-doc scanning per SD type
- Widened post-completion validator document check from feature/enhancement to all types except orchestrator
- Updated `/document` skill with reference to new directory mapping
- All 81 tests pass across both test files

## Behavior Changes

| SD Type | Before | After |
|---------|--------|-------|
| feature, enhancement, security | `document: true` | `document: true` (unchanged) |
| bugfix, refactor, performance | `document: false` | `document: true` |
| infrastructure, database, api, backend, process, docs, documentation, uat | `document: false` | `document: true` |
| orchestrator | `document: false` | `document: false` (unchanged) |

## Test plan
- [x] 81 unit tests pass (both test files)
- [x] Spot check: `getPostCompletionRequirements('database').document === true`
- [x] Spot check: `getPostCompletionRequirements('orchestrator').document === false`
- [x] Spot check: infrastructure sequence = `['document', 'ship']`
- [x] Spot check: feature sequence unchanged = `['restart', 'document', 'ship', 'learn']`
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)