### PR TITLE
feat(eva): Stage 0 CLI entry framework and path router

### DIFF
--- a/lib/eva/index.js
+++ b/lib/eva/index.js
@@ -6,6 +6,20 @@
  */
 
 export { VentureContextManager, createVentureContextManager } from './venture-context-manager.js';
+
+// Stage 0: Venture Entry Process (SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B)
+export {
+  executeStageZero,
+  ENTRY_PATHS,
+  PATH_OPTIONS,
+  routePath,
+  conductChairmanReview,
+  persistVentureBrief,
+  validatePathOutput,
+  validateSynthesisInput,
+  validateVentureBrief,
+  createPathOutput,
+} from './stage-zero/index.js';
 export { ChairmanPreferenceStore, createChairmanPreferenceStore } from './chairman-preference-store.js';
 export { processStage, run } from './eva-orchestrator.js';
 export { OrchestratorTracer, createOrchestratorTracer } from './observability.js';

--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -1,0 +1,203 @@
+/**
+ * Chairman Review Flow
+ *
+ * Presents the synthesized venture brief to the chairman for review.
+ * The chairman can edit, approve (send to Stage 1), or park in the Venture Nursery.
+ *
+ * Captures raw_chairman_intent as an immutable record before any system modifications.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B
+ */
+
+import { validateVentureBrief } from './interfaces.js';
+
+/**
+ * Present brief to the chairman and process their decision.
+ *
+ * @param {Object} brief - The venture brief to review
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object>} Review result with decision and final brief
+ */
+export async function conductChairmanReview(brief, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    throw new Error('supabase client is required');
+  }
+
+  // Capture raw chairman intent BEFORE any modifications
+  const rawChairmanIntent = brief.raw_chairman_intent || brief.problem_statement || '';
+
+  logger.log('\n   Chairman Review');
+  logger.log('   ' + '─'.repeat(50));
+  logger.log(`   Venture: ${brief.name}`);
+  logger.log(`   Problem: ${brief.problem_statement}`);
+  logger.log(`   Solution: ${brief.solution}`);
+  logger.log(`   Market: ${brief.target_market}`);
+  logger.log(`   Origin: ${brief.origin_type}`);
+  if (brief.archetype) logger.log(`   Archetype: ${brief.archetype}`);
+  if (brief.moat_strategy) logger.log(`   Moat: ${JSON.stringify(brief.moat_strategy)}`);
+  if (brief.portfolio_synergy_score !== undefined) {
+    logger.log(`   Portfolio Synergy: ${brief.portfolio_synergy_score}/100`);
+  }
+  if (brief.time_horizon_classification) {
+    logger.log(`   Time Horizon: ${brief.time_horizon_classification}`);
+  }
+  logger.log('   ' + '─'.repeat(50));
+
+  // In non-interactive mode, auto-approve with the brief as-is
+  // Interactive mode (Child B full implementation) will present edit/approve/nursery options
+  const decision = brief.maturity || 'ready';
+
+  // Validate the brief before proceeding
+  const validation = validateVentureBrief({
+    ...brief,
+    raw_chairman_intent: rawChairmanIntent,
+  });
+
+  return {
+    decision, // 'ready' | 'seed' | 'sprout'
+    brief: {
+      ...brief,
+      raw_chairman_intent: rawChairmanIntent,
+      maturity: decision,
+    },
+    validation,
+    reviewed_at: new Date().toISOString(),
+  };
+}
+
+/**
+ * Persist the approved venture brief to the database.
+ *
+ * @param {Object} reviewResult - Result from conductChairmanReview
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object>} Created venture record
+ */
+export async function persistVentureBrief(reviewResult, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    throw new Error('supabase client is required');
+  }
+
+  const { brief, decision } = reviewResult;
+
+  if (decision === 'ready') {
+    // Create venture in ventures table for Stage 1
+    const { data: venture, error } = await supabase
+      .from('ventures')
+      .insert({
+        name: brief.name,
+        description: brief.problem_statement,
+        target_market: brief.target_market,
+        origin_type: brief.origin_type,
+        current_lifecycle_stage: 1,
+        status: 'active',
+        metadata: {
+          stage_zero: {
+            solution: brief.solution,
+            raw_chairman_intent: brief.raw_chairman_intent,
+            archetype: brief.archetype,
+            moat_strategy: brief.moat_strategy,
+            portfolio_synergy_score: brief.portfolio_synergy_score,
+            time_horizon_classification: brief.time_horizon_classification,
+            build_estimate: brief.build_estimate,
+            cross_references: brief.cross_references,
+            chairman_constraint_scores: brief.chairman_constraint_scores,
+            origin_metadata: {
+              competitor_urls: brief.competitor_ref,
+              blueprint_id: brief.blueprint_id,
+              discovery_strategy: brief.discovery_strategy,
+            },
+          },
+        },
+      })
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to create venture: ${error.message}`);
+    }
+
+    // Also create venture_brief record for detailed tracking
+    await persistBriefRecord(brief, venture.id, deps);
+
+    logger.log(`   Venture created: ${venture.id}`);
+    logger.log('   Status: Ready for Stage 1');
+
+    return venture;
+  }
+
+  // Park in Venture Nursery (seed or sprout)
+  const { data: nurseryEntry, error } = await supabase
+    .from('venture_nursery')
+    .insert({
+      name: brief.name,
+      problem_statement: brief.problem_statement,
+      solution: brief.solution,
+      target_market: brief.target_market,
+      origin_type: brief.origin_type,
+      raw_chairman_intent: brief.raw_chairman_intent,
+      maturity: decision,
+      archetype: brief.archetype,
+      moat_strategy: brief.moat_strategy,
+      metadata: {
+        stage_zero_brief: brief,
+      },
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create nursery entry: ${error.message}`);
+  }
+
+  logger.log(`   Nursery entry created: ${nurseryEntry.id}`);
+  logger.log(`   Maturity: ${decision}`);
+
+  return nurseryEntry;
+}
+
+/**
+ * Persist a detailed brief record in venture_briefs table.
+ *
+ * @param {Object} brief - The venture brief
+ * @param {string} ventureId - UUID of the created venture
+ * @param {Object} deps - Injected dependencies
+ */
+async function persistBriefRecord(brief, ventureId, deps) {
+  const { supabase, logger = console } = deps;
+
+  const { error } = await supabase
+    .from('venture_briefs')
+    .insert({
+      venture_id: ventureId,
+      name: brief.name,
+      problem_statement: brief.problem_statement,
+      raw_chairman_intent: brief.raw_chairman_intent,
+      solution: brief.solution,
+      target_market: brief.target_market,
+      origin_type: brief.origin_type,
+      archetype: brief.archetype,
+      moat_strategy: brief.moat_strategy,
+      portfolio_synergy_score: brief.portfolio_synergy_score,
+      time_horizon_classification: brief.time_horizon_classification,
+      build_estimate: brief.build_estimate,
+      cross_references: brief.cross_references,
+      chairman_constraint_scores: brief.chairman_constraint_scores,
+      competitor_ref: brief.competitor_ref,
+      blueprint_id: brief.blueprint_id,
+      discovery_strategy: brief.discovery_strategy,
+      maturity: brief.maturity || 'ready',
+      status: 'approved',
+    });
+
+  if (error) {
+    logger.warn(`   Warning: Failed to create brief record: ${error.message}`);
+  }
+}

--- a/lib/eva/stage-zero/index.js
+++ b/lib/eva/stage-zero/index.js
@@ -1,0 +1,31 @@
+/**
+ * Stage 0 Module - CLI Venture Entry Process
+ *
+ * Central entry point for all Stage 0 functionality.
+ * Transforms raw input into a structured venture brief ready for Stage 1.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B
+ */
+
+export {
+  executeStageZero,
+  ENTRY_PATHS,
+  PATH_OPTIONS,
+  listDiscoveryStrategies,
+} from './stage-zero-orchestrator.js';
+
+export {
+  routePath,
+} from './path-router.js';
+
+export {
+  conductChairmanReview,
+  persistVentureBrief,
+} from './chairman-review.js';
+
+export {
+  validatePathOutput,
+  validateSynthesisInput,
+  validateVentureBrief,
+  createPathOutput,
+} from './interfaces.js';

--- a/lib/eva/stage-zero/interfaces.js
+++ b/lib/eva/stage-zero/interfaces.js
@@ -1,0 +1,137 @@
+/**
+ * Stage 0 Shared Interfaces
+ *
+ * Defines the contract between path handlers and the synthesis step.
+ * All three entry paths (competitor teardown, blueprint browse, discovery mode)
+ * produce a PathOutput that feeds into synthesis.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B
+ */
+
+/**
+ * Validate a PathOutput object.
+ * Every path handler must produce output conforming to this shape.
+ *
+ * @param {Object} output - The path output to validate
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validatePathOutput(output) {
+  const errors = [];
+
+  if (!output || typeof output !== 'object') {
+    return { valid: false, errors: ['PathOutput must be a non-null object'] };
+  }
+
+  // Required fields
+  if (!output.origin_type || typeof output.origin_type !== 'string') {
+    errors.push('origin_type is required (string)');
+  }
+  if (!output.raw_material || typeof output.raw_material !== 'object') {
+    errors.push('raw_material is required (object)');
+  }
+  if (!output.suggested_name || typeof output.suggested_name !== 'string') {
+    errors.push('suggested_name is required (string)');
+  }
+  if (!output.suggested_problem || typeof output.suggested_problem !== 'string') {
+    errors.push('suggested_problem is required (string)');
+  }
+  if (!output.suggested_solution || typeof output.suggested_solution !== 'string') {
+    errors.push('suggested_solution is required (string)');
+  }
+  if (!output.target_market || typeof output.target_market !== 'string') {
+    errors.push('target_market is required (string)');
+  }
+
+  // Validate origin_type enum
+  const validOrigins = ['competitor_teardown', 'blueprint', 'discovery', 'manual'];
+  if (output.origin_type && !validOrigins.includes(output.origin_type)) {
+    errors.push(`origin_type must be one of: ${validOrigins.join(', ')}`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate a SynthesisInput object.
+ * The synthesis step receives path output + additional context.
+ *
+ * @param {Object} input - The synthesis input to validate
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateSynthesisInput(input) {
+  const errors = [];
+
+  if (!input || typeof input !== 'object') {
+    return { valid: false, errors: ['SynthesisInput must be a non-null object'] };
+  }
+
+  const pathValidation = validatePathOutput(input.pathOutput);
+  if (!pathValidation.valid) {
+    errors.push(...pathValidation.errors.map(e => `pathOutput.${e}`));
+  }
+
+  // Optional enrichments (populated by synthesis components)
+  if (input.intellectualCapital !== undefined && !Array.isArray(input.intellectualCapital)) {
+    errors.push('intellectualCapital must be an array if provided');
+  }
+  if (input.portfolioContext !== undefined && typeof input.portfolioContext !== 'object') {
+    errors.push('portfolioContext must be an object if provided');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validate a VentureBrief — the Stage 0 output that feeds Stage 1.
+ *
+ * @param {Object} brief - The venture brief to validate
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateVentureBrief(brief) {
+  const errors = [];
+
+  if (!brief || typeof brief !== 'object') {
+    return { valid: false, errors: ['VentureBrief must be a non-null object'] };
+  }
+
+  const requiredStrings = ['name', 'problem_statement', 'solution', 'target_market', 'origin_type'];
+  for (const field of requiredStrings) {
+    if (!brief[field] || typeof brief[field] !== 'string' || brief[field].trim() === '') {
+      errors.push(`${field} is required (non-empty string)`);
+    }
+  }
+
+  if (!brief.raw_chairman_intent || typeof brief.raw_chairman_intent !== 'string') {
+    errors.push('raw_chairman_intent is required (immutable chairman vision)');
+  }
+
+  // maturity determines where the venture goes
+  const validMaturities = ['ready', 'seed', 'sprout'];
+  if (brief.maturity && !validMaturities.includes(brief.maturity)) {
+    errors.push(`maturity must be one of: ${validMaturities.join(', ')}`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Create a minimal PathOutput with defaults.
+ *
+ * @param {Object} overrides - Fields to set on the path output
+ * @returns {Object} PathOutput
+ */
+export function createPathOutput(overrides = {}) {
+  return {
+    origin_type: 'manual',
+    raw_material: {},
+    suggested_name: '',
+    suggested_problem: '',
+    suggested_solution: '',
+    target_market: '',
+    competitor_urls: [],
+    blueprint_id: null,
+    discovery_strategy: null,
+    metadata: {},
+    ...overrides,
+  };
+}

--- a/lib/eva/stage-zero/path-router.js
+++ b/lib/eva/stage-zero/path-router.js
@@ -1,0 +1,92 @@
+/**
+ * Stage 0 Path Router
+ *
+ * Routes venture creation to the appropriate path handler based on
+ * user selection. All three paths produce a PathOutput that feeds
+ * into the synthesis step.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B
+ */
+
+import { executeCompetitorTeardown } from './paths/competitor-teardown.js';
+import { executeBlueprintBrowse } from './paths/blueprint-browse.js';
+import { executeDiscoveryMode, listDiscoveryStrategies } from './paths/discovery-mode.js';
+import { validatePathOutput } from './interfaces.js';
+
+/**
+ * Available entry paths for venture creation.
+ */
+export const ENTRY_PATHS = Object.freeze({
+  COMPETITOR_TEARDOWN: 'competitor_teardown',
+  BLUEPRINT_BROWSE: 'blueprint_browse',
+  DISCOVERY_MODE: 'discovery_mode',
+});
+
+/**
+ * Path display metadata for CLI presentation.
+ */
+export const PATH_OPTIONS = [
+  {
+    key: ENTRY_PATHS.COMPETITOR_TEARDOWN,
+    label: 'Analyze a competitor',
+    description: 'Deep analysis of competitor products, deconstruct and rebuild with automation advantage',
+    shortcut: '1',
+  },
+  {
+    key: ENTRY_PATHS.BLUEPRINT_BROWSE,
+    label: 'Browse venture blueprints',
+    description: 'Select from pre-made venture templates and customize',
+    shortcut: '2',
+  },
+  {
+    key: ENTRY_PATHS.DISCOVERY_MODE,
+    label: 'Find me opportunities',
+    description: 'AI-driven research pipeline generates ranked venture candidates',
+    shortcut: '3',
+  },
+];
+
+/**
+ * Route to the appropriate path handler based on the selected path.
+ *
+ * @param {string} pathKey - Which path to execute (from ENTRY_PATHS)
+ * @param {Object} params - Path-specific parameters
+ * @param {Object} deps - Injected dependencies (supabase, logger)
+ * @returns {Promise<Object>} Validated PathOutput
+ */
+export async function routePath(pathKey, params = {}, deps = {}) {
+  const { logger = console } = deps;
+
+  let result;
+
+  switch (pathKey) {
+    case ENTRY_PATHS.COMPETITOR_TEARDOWN:
+      result = await executeCompetitorTeardown(params, deps);
+      break;
+
+    case ENTRY_PATHS.BLUEPRINT_BROWSE:
+      result = await executeBlueprintBrowse(params, deps);
+      break;
+
+    case ENTRY_PATHS.DISCOVERY_MODE:
+      result = await executeDiscoveryMode(params, deps);
+      break;
+
+    default:
+      throw new Error(`Unknown entry path: ${pathKey}. Valid paths: ${Object.values(ENTRY_PATHS).join(', ')}`);
+  }
+
+  if (!result) {
+    return null; // Path returned null (e.g., no blueprints available)
+  }
+
+  // Validate path output conforms to interface
+  const validation = validatePathOutput(result);
+  if (!validation.valid) {
+    logger.warn(`   Path output validation warnings: ${validation.errors.join(', ')}`);
+  }
+
+  return result;
+}
+
+export { listDiscoveryStrategies };

--- a/lib/eva/stage-zero/paths/blueprint-browse.js
+++ b/lib/eva/stage-zero/paths/blueprint-browse.js
@@ -1,0 +1,77 @@
+/**
+ * Path 2: Blueprint Browse
+ *
+ * Browse categorized venture blueprint templates,
+ * select a template, and customize parameters.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-D (stub for Child B framework)
+ */
+
+import { createPathOutput } from '../interfaces.js';
+
+/**
+ * Execute the blueprint browse path.
+ *
+ * @param {Object} params
+ * @param {string} [params.blueprintId] - Pre-selected blueprint ID (skips browse)
+ * @param {Object} [params.customizations] - Template parameter overrides
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object>} PathOutput
+ */
+export async function executeBlueprintBrowse({ blueprintId, customizations = {} }, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    throw new Error('supabase client is required');
+  }
+
+  // Load available blueprints
+  const { data: blueprints, error } = await supabase
+    .from('venture_blueprints')
+    .select('id, name, category, description, template_data, is_active')
+    .eq('is_active', true)
+    .order('category', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load blueprints: ${error.message}`);
+  }
+
+  if (!blueprints || blueprints.length === 0) {
+    logger.log('   No blueprints available. Use competitor teardown or discovery mode instead.');
+    return null;
+  }
+
+  // Stub: Full implementation in Child D (SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-D)
+  // This will present an interactive browse experience with categories,
+  // template preview, and parameter customization.
+
+  const selected = blueprintId
+    ? blueprints.find(b => b.id === blueprintId)
+    : blueprints[0]; // Placeholder: interactive selection in Child D
+
+  if (!selected) {
+    throw new Error(`Blueprint not found: ${blueprintId}`);
+  }
+
+  const template = selected.template_data || {};
+
+  return createPathOutput({
+    origin_type: 'blueprint',
+    raw_material: {
+      blueprint: selected,
+      customizations,
+    },
+    blueprint_id: selected.id,
+    suggested_name: template.name || selected.name,
+    suggested_problem: template.problem_statement || '',
+    suggested_solution: template.solution || '',
+    target_market: template.target_market || '',
+    metadata: {
+      path: 'blueprint_browse',
+      blueprint_name: selected.name,
+      blueprint_category: selected.category,
+    },
+  });
+}

--- a/lib/eva/stage-zero/paths/competitor-teardown.js
+++ b/lib/eva/stage-zero/paths/competitor-teardown.js
@@ -1,0 +1,51 @@
+/**
+ * Path 1: Competitor Teardown
+ *
+ * Analyzes competitor URLs, deconstructs into work components,
+ * applies first-principles thinking to rebuild with EHG's automation advantage.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-C (stub for Child B framework)
+ */
+
+import { createPathOutput } from '../interfaces.js';
+
+/**
+ * Execute the competitor teardown path.
+ *
+ * @param {Object} params
+ * @param {string[]} params.urls - Competitor URLs to analyze
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object>} PathOutput
+ */
+export async function executeCompetitorTeardown({ urls }, deps = {}) {
+  const { logger = console } = deps;
+
+  if (!urls || urls.length === 0) {
+    throw new Error('At least one competitor URL is required');
+  }
+
+  logger.log(`   Analyzing ${urls.length} competitor(s)...`);
+
+  // Stub: Full implementation in Child C (SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-C)
+  // This will use deep research to analyze competitors, extract business models,
+  // identify work components, and apply first-principles deconstruction.
+
+  return createPathOutput({
+    origin_type: 'competitor_teardown',
+    raw_material: {
+      competitor_urls: urls,
+      analysis_status: 'pending_implementation',
+    },
+    competitor_urls: urls,
+    suggested_name: '',
+    suggested_problem: '',
+    suggested_solution: '',
+    target_market: '',
+    metadata: {
+      path: 'competitor_teardown',
+      url_count: urls.length,
+    },
+  });
+}

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -1,0 +1,101 @@
+/**
+ * Path 3: Discovery Mode (Find Me Opportunities)
+ *
+ * AI-driven research pipeline that generates ranked venture candidates.
+ * Supports multiple discovery strategies: trend scanner, democratization finder,
+ * capability overhang exploit, and nursery re-evaluation.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-E (stub for Child B framework)
+ */
+
+import { createPathOutput } from '../interfaces.js';
+
+/**
+ * Execute the discovery mode path.
+ *
+ * @param {Object} params
+ * @param {string} params.strategy - Discovery strategy to use
+ * @param {Object} [params.constraints] - Optional constraints for the search
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object>} PathOutput
+ */
+export async function executeDiscoveryMode({ strategy, constraints = {} }, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    throw new Error('supabase client is required');
+  }
+
+  // Validate strategy exists
+  const validStrategies = ['trend_scanner', 'democratization_finder', 'capability_overhang', 'nursery_reeval'];
+  if (!validStrategies.includes(strategy)) {
+    throw new Error(`Invalid strategy: ${strategy}. Must be one of: ${validStrategies.join(', ')}`);
+  }
+
+  // Load strategy config from database
+  const { data: strategyConfig, error } = await supabase
+    .from('discovery_strategies')
+    .select('*')
+    .eq('strategy_key', strategy)
+    .eq('is_active', true)
+    .single();
+
+  if (error || !strategyConfig) {
+    throw new Error(`Strategy not found or inactive: ${strategy}`);
+  }
+
+  logger.log(`   Running discovery strategy: ${strategyConfig.name}`);
+
+  // Stub: Full implementation in Child E (SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-E)
+  // Each strategy will use AI research pipelines to generate ranked candidates.
+  // The chairman will select from the ranked list.
+
+  return createPathOutput({
+    origin_type: 'discovery',
+    raw_material: {
+      strategy: strategyConfig,
+      constraints,
+      candidates: [], // Populated by full implementation
+      analysis_status: 'pending_implementation',
+    },
+    discovery_strategy: strategy,
+    suggested_name: '',
+    suggested_problem: '',
+    suggested_solution: '',
+    target_market: '',
+    metadata: {
+      path: 'discovery_mode',
+      strategy_key: strategy,
+      strategy_name: strategyConfig.name,
+    },
+  });
+}
+
+/**
+ * List available discovery strategies.
+ *
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object[]>} Available strategies
+ */
+export async function listDiscoveryStrategies(deps = {}) {
+  const { supabase } = deps;
+
+  if (!supabase) {
+    throw new Error('supabase client is required');
+  }
+
+  const { data, error } = await supabase
+    .from('discovery_strategies')
+    .select('strategy_key, name, description, is_active')
+    .eq('is_active', true)
+    .order('name', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load strategies: ${error.message}`);
+  }
+
+  return data || [];
+}

--- a/lib/eva/stage-zero/stage-zero-orchestrator.js
+++ b/lib/eva/stage-zero/stage-zero-orchestrator.js
@@ -1,0 +1,148 @@
+/**
+ * Stage 0 Orchestrator
+ *
+ * Coordinates the full Stage 0 venture creation flow:
+ * 1. Present entry path options
+ * 2. Execute selected path
+ * 3. Run synthesis step (enriches path output)
+ * 4. Conduct chairman review
+ * 5. Persist result (venture or nursery entry)
+ * 6. Hand off to Stage 1 if approved
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B
+ */
+
+import { routePath, ENTRY_PATHS, PATH_OPTIONS, listDiscoveryStrategies } from './path-router.js';
+import { conductChairmanReview, persistVentureBrief } from './chairman-review.js';
+// Interfaces used by path router and chairman review (re-exported for consumers)
+// import { validatePathOutput, validateVentureBrief } from './interfaces.js';
+
+/**
+ * Execute the full Stage 0 flow.
+ *
+ * @param {Object} params
+ * @param {string} params.path - Entry path key (from ENTRY_PATHS)
+ * @param {Object} params.pathParams - Parameters for the selected path
+ * @param {Object} [params.options] - Additional options
+ * @param {boolean} [params.options.nonInteractive=false] - Skip interactive prompts
+ * @param {boolean} [params.options.dryRun=false] - Skip persistence
+ * @param {boolean} [params.options.skipSynthesis=false] - Skip synthesis (for testing)
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @param {Function} [deps.synthesize] - Custom synthesis function (for testing)
+ * @returns {Promise<Object>} Stage 0 result
+ */
+export async function executeStageZero(params, deps = {}) {
+  const { path, pathParams = {}, options = {} } = params;
+  const { supabase, logger = console, synthesize } = deps;
+  const startTime = Date.now();
+
+  if (!supabase) {
+    throw new Error('supabase client is required');
+  }
+
+  logger.log('\n══════════════════════════════════════════════════');
+  logger.log('   STAGE 0: VENTURE CREATION');
+  logger.log('══════════════════════════════════════════════════\n');
+
+  // Step 1: Execute the selected path
+  logger.log(`   Path: ${getPathLabel(path)}`);
+  logger.log('   ' + '─'.repeat(50));
+
+  const pathOutput = await routePath(path, pathParams, deps);
+
+  if (!pathOutput) {
+    return {
+      success: false,
+      reason: 'Path returned no output',
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  logger.log('   Path output received');
+
+  // Step 2: Run synthesis (enriches path output with cross-references, portfolio context, etc.)
+  let synthesisResult;
+  if (!options.skipSynthesis && synthesize) {
+    logger.log('\n   Running synthesis...');
+    synthesisResult = await synthesize(pathOutput, deps);
+  } else {
+    // Default: pass through path output as-is
+    // Full synthesis implementation in Children F/G/H
+    synthesisResult = buildDefaultBrief(pathOutput);
+  }
+
+  // Step 3: Chairman review
+  logger.log('\n   Entering chairman review...');
+  const reviewResult = await conductChairmanReview(synthesisResult, deps);
+
+  if (options.dryRun) {
+    logger.log('\n   [DRY RUN] Skipping persistence');
+    return {
+      success: true,
+      dryRun: true,
+      brief: reviewResult.brief,
+      decision: reviewResult.decision,
+      validation: reviewResult.validation,
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  // Step 4: Persist
+  const record = await persistVentureBrief(reviewResult, deps);
+
+  // Step 5: Hand off to Stage 1 if ready
+  if (reviewResult.decision === 'ready') {
+    logger.log(`\n   Venture ready for Stage 1: ${record.id}`);
+    logger.log('   Run: eva venture stage 1 --venture ' + record.id);
+  } else {
+    logger.log(`\n   Venture parked in nursery (${reviewResult.decision}): ${record.id}`);
+  }
+
+  logger.log('\n══════════════════════════════════════════════════');
+  logger.log(`   STAGE 0 COMPLETE (${Date.now() - startTime}ms)`);
+  logger.log('══════════════════════════════════════════════════\n');
+
+  return {
+    success: true,
+    decision: reviewResult.decision,
+    record_id: record.id,
+    record_type: reviewResult.decision === 'ready' ? 'venture' : 'nursery_entry',
+    brief: reviewResult.brief,
+    validation: reviewResult.validation,
+    duration_ms: Date.now() - startTime,
+  };
+}
+
+/**
+ * Build a default venture brief from path output (when synthesis is not available).
+ *
+ * @param {Object} pathOutput - The path output
+ * @returns {Object} Venture brief shape
+ */
+function buildDefaultBrief(pathOutput) {
+  return {
+    name: pathOutput.suggested_name,
+    problem_statement: pathOutput.suggested_problem,
+    solution: pathOutput.suggested_solution,
+    target_market: pathOutput.target_market,
+    origin_type: pathOutput.origin_type,
+    raw_chairman_intent: pathOutput.suggested_problem,
+    competitor_ref: pathOutput.competitor_urls,
+    blueprint_id: pathOutput.blueprint_id,
+    discovery_strategy: pathOutput.discovery_strategy,
+    maturity: 'ready',
+    metadata: pathOutput.metadata,
+  };
+}
+
+/**
+ * Get display label for a path key.
+ */
+function getPathLabel(pathKey) {
+  const option = PATH_OPTIONS.find(o => o.key === pathKey);
+  return option ? option.label : pathKey;
+}
+
+export { ENTRY_PATHS, PATH_OPTIONS, listDiscoveryStrategies };

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "llm:canary:rollback": "node scripts/llm-canary-control.js rollback",
     "llm:canary:quality": "node scripts/llm-canary-control.js quality",
     "llm:canary:history": "node scripts/llm-canary-control.js history",
+    "eva:venture:new": "node scripts/eva-venture-new.js",
     "eva:ideas:sync": "node scripts/eva-idea-sync.js",
     "eva:ideas:evaluate": "node scripts/eva-idea-evaluate.js",
     "eva:ideas:status": "node scripts/eva-idea-status.js",

--- a/scripts/eva-venture-new.js
+++ b/scripts/eva-venture-new.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+/**
+ * eva venture new - CLI Entry Point for Stage 0
+ *
+ * Creates a new venture through one of three paths:
+ *   1. Competitor Teardown - Analyze competitor URLs
+ *   2. Blueprint Browse - Select from venture templates
+ *   3. Discovery Mode - AI-driven opportunity discovery
+ *
+ * Usage:
+ *   node scripts/eva-venture-new.js                           # Interactive mode
+ *   node scripts/eva-venture-new.js --path competitor --urls https://competitor.com
+ *   node scripts/eva-venture-new.js --path blueprint --blueprint-id <uuid>
+ *   node scripts/eva-venture-new.js --path discovery --strategy trend_scanner
+ *   node scripts/eva-venture-new.js --dry-run                 # Preview without persisting
+ *   node scripts/eva-venture-new.js --non-interactive --path competitor --urls https://example.com
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import {
+  executeStageZero,
+  ENTRY_PATHS,
+  PATH_OPTIONS,
+} from '../lib/eva/stage-zero/index.js';
+
+// ── Argument Parsing ──────────────────────────────────────────
+
+function getArg(name) {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) return undefined;
+  return process.argv[idx + 1];
+}
+
+function hasFlag(name) {
+  return process.argv.includes(`--${name}`);
+}
+
+function getArrayArg(name) {
+  const value = getArg(name);
+  if (!value) return [];
+  return value.split(',').map(v => v.trim()).filter(Boolean);
+}
+
+// ── Main ──────────────────────────────────────────────────────
+
+async function main() {
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const dryRun = hasFlag('dry-run');
+  const nonInteractive = hasFlag('non-interactive');
+  const pathArg = getArg('path');
+
+  // Map shorthand path names to keys
+  const pathMap = {
+    competitor: ENTRY_PATHS.COMPETITOR_TEARDOWN,
+    blueprint: ENTRY_PATHS.BLUEPRINT_BROWSE,
+    discovery: ENTRY_PATHS.DISCOVERY_MODE,
+    '1': ENTRY_PATHS.COMPETITOR_TEARDOWN,
+    '2': ENTRY_PATHS.BLUEPRINT_BROWSE,
+    '3': ENTRY_PATHS.DISCOVERY_MODE,
+  };
+
+  let selectedPath = pathMap[pathArg];
+
+  if (!selectedPath && !pathArg) {
+    // Interactive path selection
+    if (nonInteractive) {
+      console.error('Error: --path is required in non-interactive mode');
+      console.error('Options: competitor, blueprint, discovery');
+      process.exit(1);
+    }
+
+    console.log('\n══════════════════════════════════════════════════');
+    console.log('   EVA VENTURE NEW - Stage 0 Entry');
+    console.log('══════════════════════════════════════════════════\n');
+    console.log('   How would you like to start?\n');
+
+    for (const option of PATH_OPTIONS) {
+      console.log(`   ${option.shortcut}. ${option.label}`);
+      console.log(`      ${option.description}\n`);
+    }
+
+    // In non-interactive context (e.g., called from Claude), default to showing options
+    // Full interactive input will be added with readline in the interactive CLI enhancement
+    console.log('   Usage: node scripts/eva-venture-new.js --path <competitor|blueprint|discovery>');
+    console.log('   Or:    node scripts/eva-venture-new.js --path 1|2|3\n');
+    process.exit(0);
+  }
+
+  if (!selectedPath) {
+    console.error(`Error: Unknown path "${pathArg}". Options: competitor, blueprint, discovery`);
+    process.exit(1);
+  }
+
+  // Build path-specific parameters
+  const pathParams = buildPathParams(selectedPath);
+
+  // Execute Stage 0
+  const result = await executeStageZero(
+    {
+      path: selectedPath,
+      pathParams,
+      options: { dryRun, nonInteractive },
+    },
+    { supabase, logger: console }
+  );
+
+  if (!result.success) {
+    console.error(`\n   Stage 0 failed: ${result.reason}`);
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    console.log('\n   [DRY RUN] Brief preview:');
+    console.log(JSON.stringify(result.brief, null, 2));
+  }
+
+  process.exit(0);
+}
+
+function buildPathParams(path) {
+  switch (path) {
+    case ENTRY_PATHS.COMPETITOR_TEARDOWN:
+      return {
+        urls: getArrayArg('urls'),
+      };
+
+    case ENTRY_PATHS.BLUEPRINT_BROWSE:
+      return {
+        blueprintId: getArg('blueprint-id'),
+        customizations: {},
+      };
+
+    case ENTRY_PATHS.DISCOVERY_MODE:
+      return {
+        strategy: getArg('strategy') || 'trend_scanner',
+        constraints: {},
+      };
+
+    default:
+      return {};
+  }
+}
+
+main().catch(err => {
+  console.error('Stage 0 error:', err.message);
+  process.exit(1);
+});

--- a/test/unit/stage-zero.test.js
+++ b/test/unit/stage-zero.test.js
@@ -1,0 +1,406 @@
+/**
+ * Stage 0 - CLI Entry Framework and Path Router Tests
+ *
+ * Tests the core Stage 0 functionality:
+ * - Interface validation (PathOutput, SynthesisInput, VentureBrief)
+ * - Path routing (3-way routing)
+ * - Chairman review flow
+ * - Stage 0 orchestrator
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-B
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  validatePathOutput,
+  validateVentureBrief,
+  createPathOutput,
+} from '../../lib/eva/stage-zero/interfaces.js';
+import {
+  routePath,
+  ENTRY_PATHS,
+  PATH_OPTIONS,
+} from '../../lib/eva/stage-zero/path-router.js';
+import { conductChairmanReview } from '../../lib/eva/stage-zero/chairman-review.js';
+import { executeStageZero } from '../../lib/eva/stage-zero/stage-zero-orchestrator.js';
+
+// ── Mock Supabase ──────────────────────────────────────────
+
+function createMockSupabase(overrides = {}) {
+  const mockFrom = (table) => {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+
+    // Table-specific mocks
+    if (table === 'venture_blueprints') {
+      chain.eq = vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({
+          data: overrides.blueprints || [
+            { id: 'bp-1', name: 'SaaS Blueprint', category: 'software', description: 'Standard SaaS', template_data: { name: 'SaaS Venture', problem_statement: 'test problem', solution: 'test solution', target_market: 'SMBs' }, is_active: true },
+          ],
+          error: null,
+        }),
+      });
+    }
+
+    if (table === 'discovery_strategies') {
+      chain.eq = vi.fn().mockImplementation((field, value) => {
+        if (field === 'strategy_key') {
+          return {
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { strategy_key: value, name: 'Trend Scanner', description: 'Scan trends', is_active: true },
+                error: null,
+              }),
+            }),
+          };
+        }
+        return chain;
+      });
+    }
+
+    if (table === 'ventures') {
+      chain.insert = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'venture-uuid-1', name: 'Test Venture', status: 'active' },
+            error: null,
+          }),
+        }),
+      });
+    }
+
+    if (table === 'venture_nursery') {
+      chain.insert = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'nursery-uuid-1', name: 'Parked Idea', maturity: 'seed' },
+            error: null,
+          }),
+        }),
+      });
+    }
+
+    if (table === 'venture_briefs') {
+      chain.insert = vi.fn().mockResolvedValue({ error: null });
+    }
+
+    return chain;
+  };
+
+  return { from: vi.fn(mockFrom) };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// ── Interface Validation Tests ──────────────────────────────
+
+describe('Stage 0 Interfaces', () => {
+  describe('validatePathOutput', () => {
+    test('accepts valid PathOutput', () => {
+      const output = createPathOutput({
+        origin_type: 'competitor_teardown',
+        raw_material: { urls: ['https://example.com'] },
+        suggested_name: 'Test Venture',
+        suggested_problem: 'Market gap',
+        suggested_solution: 'Automated solution',
+        target_market: 'SMBs',
+      });
+
+      const result = validatePathOutput(output);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    test('rejects null input', () => {
+      const result = validatePathOutput(null);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('PathOutput must be a non-null object');
+    });
+
+    test('rejects missing required fields', () => {
+      const result = validatePathOutput({});
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    test('rejects invalid origin_type', () => {
+      const output = createPathOutput({
+        origin_type: 'invalid_type',
+        raw_material: {},
+        suggested_name: 'Test',
+        suggested_problem: 'Test',
+        suggested_solution: 'Test',
+        target_market: 'Test',
+      });
+
+      const result = validatePathOutput(output);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('origin_type'))).toBe(true);
+    });
+
+    test('accepts all valid origin types', () => {
+      for (const type of ['competitor_teardown', 'blueprint', 'discovery', 'manual']) {
+        const output = createPathOutput({
+          origin_type: type,
+          raw_material: {},
+          suggested_name: 'Test',
+          suggested_problem: 'Test',
+          suggested_solution: 'Test',
+          target_market: 'Test',
+        });
+        expect(validatePathOutput(output).valid).toBe(true);
+      }
+    });
+  });
+
+  describe('validateVentureBrief', () => {
+    test('accepts valid brief', () => {
+      const brief = {
+        name: 'Test Venture',
+        problem_statement: 'A problem',
+        solution: 'A solution',
+        target_market: 'SMBs',
+        origin_type: 'discovery',
+        raw_chairman_intent: 'Build something great',
+        maturity: 'ready',
+      };
+      const result = validateVentureBrief(brief);
+      expect(result.valid).toBe(true);
+    });
+
+    test('rejects missing required fields', () => {
+      const result = validateVentureBrief({ name: 'Test' });
+      expect(result.valid).toBe(false);
+    });
+
+    test('rejects invalid maturity', () => {
+      const brief = {
+        name: 'Test',
+        problem_statement: 'Test',
+        solution: 'Test',
+        target_market: 'Test',
+        origin_type: 'manual',
+        raw_chairman_intent: 'Test',
+        maturity: 'invalid',
+      };
+      const result = validateVentureBrief(brief);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('createPathOutput', () => {
+    test('creates defaults', () => {
+      const output = createPathOutput();
+      expect(output.origin_type).toBe('manual');
+      expect(output.raw_material).toEqual({});
+      expect(output.competitor_urls).toEqual([]);
+    });
+
+    test('applies overrides', () => {
+      const output = createPathOutput({ origin_type: 'blueprint', suggested_name: 'Test' });
+      expect(output.origin_type).toBe('blueprint');
+      expect(output.suggested_name).toBe('Test');
+    });
+  });
+});
+
+// ── Path Router Tests ──────────────────────────────────────
+
+describe('Path Router', () => {
+  test('exposes 3 entry paths', () => {
+    expect(Object.keys(ENTRY_PATHS)).toHaveLength(3);
+    expect(ENTRY_PATHS.COMPETITOR_TEARDOWN).toBe('competitor_teardown');
+    expect(ENTRY_PATHS.BLUEPRINT_BROWSE).toBe('blueprint_browse');
+    expect(ENTRY_PATHS.DISCOVERY_MODE).toBe('discovery_mode');
+  });
+
+  test('PATH_OPTIONS has display metadata for all paths', () => {
+    expect(PATH_OPTIONS).toHaveLength(3);
+    for (const option of PATH_OPTIONS) {
+      expect(option.key).toBeDefined();
+      expect(option.label).toBeDefined();
+      expect(option.description).toBeDefined();
+      expect(option.shortcut).toBeDefined();
+    }
+  });
+
+  test('routes to competitor teardown', async () => {
+    const result = await routePath(
+      ENTRY_PATHS.COMPETITOR_TEARDOWN,
+      { urls: ['https://competitor.com'] },
+      { logger: silentLogger }
+    );
+    expect(result.origin_type).toBe('competitor_teardown');
+    expect(result.competitor_urls).toEqual(['https://competitor.com']);
+  });
+
+  test('routes to blueprint browse', async () => {
+    const supabase = createMockSupabase();
+    const result = await routePath(
+      ENTRY_PATHS.BLUEPRINT_BROWSE,
+      {},
+      { supabase, logger: silentLogger }
+    );
+    expect(result.origin_type).toBe('blueprint');
+    expect(result.blueprint_id).toBe('bp-1');
+  });
+
+  test('routes to discovery mode', async () => {
+    const supabase = createMockSupabase();
+    const result = await routePath(
+      ENTRY_PATHS.DISCOVERY_MODE,
+      { strategy: 'trend_scanner' },
+      { supabase, logger: silentLogger }
+    );
+    expect(result.origin_type).toBe('discovery');
+    expect(result.discovery_strategy).toBe('trend_scanner');
+  });
+
+  test('rejects unknown path', async () => {
+    await expect(
+      routePath('unknown_path', {}, { logger: silentLogger })
+    ).rejects.toThrow('Unknown entry path');
+  });
+});
+
+// ── Chairman Review Tests ──────────────────────────────────
+
+describe('Chairman Review', () => {
+  test('captures raw_chairman_intent', async () => {
+    const supabase = createMockSupabase();
+    const brief = {
+      name: 'Test Venture',
+      problem_statement: 'Original problem framing',
+      solution: 'Test solution',
+      target_market: 'SMBs',
+      origin_type: 'manual',
+    };
+
+    const result = await conductChairmanReview(brief, { supabase, logger: silentLogger });
+    expect(result.brief.raw_chairman_intent).toBe('Original problem framing');
+    expect(result.reviewed_at).toBeDefined();
+  });
+
+  test('defaults to ready maturity', async () => {
+    const supabase = createMockSupabase();
+    const brief = {
+      name: 'Test',
+      problem_statement: 'Test',
+      solution: 'Test',
+      target_market: 'Test',
+      origin_type: 'manual',
+    };
+
+    const result = await conductChairmanReview(brief, { supabase, logger: silentLogger });
+    expect(result.decision).toBe('ready');
+  });
+
+  test('preserves explicit maturity', async () => {
+    const supabase = createMockSupabase();
+    const brief = {
+      name: 'Test',
+      problem_statement: 'Test',
+      solution: 'Test',
+      target_market: 'Test',
+      origin_type: 'manual',
+      maturity: 'seed',
+    };
+
+    const result = await conductChairmanReview(brief, { supabase, logger: silentLogger });
+    expect(result.decision).toBe('seed');
+  });
+});
+
+// ── Stage 0 Orchestrator Tests ──────────────────────────────
+
+describe('Stage 0 Orchestrator', () => {
+  test('executes full flow with competitor teardown path', async () => {
+    const supabase = createMockSupabase();
+    const result = await executeStageZero(
+      {
+        path: ENTRY_PATHS.COMPETITOR_TEARDOWN,
+        pathParams: { urls: ['https://competitor.com'] },
+        options: { dryRun: true },
+      },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.brief.origin_type).toBe('competitor_teardown');
+  });
+
+  test('executes full flow with blueprint path', async () => {
+    const supabase = createMockSupabase();
+    const result = await executeStageZero(
+      {
+        path: ENTRY_PATHS.BLUEPRINT_BROWSE,
+        pathParams: {},
+        options: { dryRun: true },
+      },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.brief.origin_type).toBe('blueprint');
+  });
+
+  test('executes full flow with discovery path', async () => {
+    const supabase = createMockSupabase();
+    const result = await executeStageZero(
+      {
+        path: ENTRY_PATHS.DISCOVERY_MODE,
+        pathParams: { strategy: 'trend_scanner' },
+        options: { dryRun: true },
+      },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.brief.origin_type).toBe('discovery');
+  });
+
+  test('requires supabase client', async () => {
+    await expect(
+      executeStageZero(
+        { path: ENTRY_PATHS.COMPETITOR_TEARDOWN, pathParams: { urls: ['https://test.com'] } },
+        { logger: silentLogger }
+      )
+    ).rejects.toThrow('supabase client is required');
+  });
+
+  test('supports custom synthesis function', async () => {
+    const supabase = createMockSupabase();
+    const customSynthesize = vi.fn().mockResolvedValue({
+      name: 'Synthesized Venture',
+      problem_statement: 'Reframed problem',
+      solution: 'Enhanced solution',
+      target_market: 'Enterprise',
+      origin_type: 'competitor_teardown',
+      raw_chairman_intent: 'Original intent',
+      archetype: 'automator',
+      moat_strategy: { type: 'data_moat' },
+    });
+
+    const result = await executeStageZero(
+      {
+        path: ENTRY_PATHS.COMPETITOR_TEARDOWN,
+        pathParams: { urls: ['https://test.com'] },
+        options: { dryRun: true },
+      },
+      { supabase, logger: silentLogger, synthesize: customSynthesize }
+    );
+
+    expect(customSynthesize).toHaveBeenCalled();
+    expect(result.brief.name).toBe('Synthesized Venture');
+    expect(result.brief.archetype).toBe('automator');
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `eva venture new` CLI entry point with 3-way path routing
- Creates `lib/eva/stage-zero/` module with interfaces, path router, chairman review, and orchestrator
- Adds 24 unit tests (all passing)

## Test plan
- [x] All 24 unit tests pass
- [x] CLI command shows 3 entry paths interactively
- [x] Competitor teardown path routes correctly
- [x] Blueprint browse path routes correctly  
- [x] Discovery mode path routes correctly
- [x] Dry-run mode works without persistence
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)