### PR TITLE
feat(eva): implement blueprint browse path with category navigation

### DIFF
--- a/lib/eva/stage-zero/paths/blueprint-browse.js
+++ b/lib/eva/stage-zero/paths/blueprint-browse.js
@@ -4,7 +4,14 @@
  * Browse categorized venture blueprint templates,
  * select a template, and customize parameters.
  *
- * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-D (stub for Child B framework)
+ * Flow:
+ * 1. Load blueprints from venture_blueprints table
+ * 2. Group by category for browsing
+ * 3. Select blueprint (by ID or category filter)
+ * 4. Apply customizations to template parameters
+ * 5. Return PathOutput with blueprint-derived venture brief
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-D
  */
 
 import { createPathOutput } from '../interfaces.js';
@@ -14,54 +21,72 @@ import { createPathOutput } from '../interfaces.js';
  *
  * @param {Object} params
  * @param {string} [params.blueprintId] - Pre-selected blueprint ID (skips browse)
+ * @param {string} [params.category] - Filter by category
  * @param {Object} [params.customizations] - Template parameter overrides
  * @param {Object} deps - Injected dependencies
  * @param {Object} deps.supabase - Supabase client
  * @param {Object} [deps.logger] - Logger
- * @returns {Promise<Object>} PathOutput
+ * @returns {Promise<Object>} PathOutput or null if no blueprints
  */
-export async function executeBlueprintBrowse({ blueprintId, customizations = {} }, deps = {}) {
+export async function executeBlueprintBrowse({ blueprintId, category, customizations = {} }, deps = {}) {
   const { supabase, logger = console } = deps;
 
   if (!supabase) {
     throw new Error('supabase client is required');
   }
 
-  // Load available blueprints
-  const { data: blueprints, error } = await supabase
-    .from('venture_blueprints')
-    .select('id, name, category, description, template_data, is_active')
-    .eq('is_active', true)
-    .order('category', { ascending: true });
-
-  if (error) {
-    throw new Error(`Failed to load blueprints: ${error.message}`);
-  }
+  // Step 1: Load available blueprints
+  const blueprints = await loadBlueprints(supabase, { category });
 
   if (!blueprints || blueprints.length === 0) {
     logger.log('   No blueprints available. Use competitor teardown or discovery mode instead.');
     return null;
   }
 
-  // Stub: Full implementation in Child D (SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-D)
-  // This will present an interactive browse experience with categories,
-  // template preview, and parameter customization.
+  // Step 2: Group by category for display
+  const grouped = groupByCategory(blueprints);
+  logger.log(`   Found ${blueprints.length} blueprint(s) across ${Object.keys(grouped).length} category/categories`);
 
-  const selected = blueprintId
-    ? blueprints.find(b => b.id === blueprintId)
-    : blueprints[0]; // Placeholder: interactive selection in Child D
-
-  if (!selected) {
-    throw new Error(`Blueprint not found: ${blueprintId}`);
+  for (const [cat, items] of Object.entries(grouped)) {
+    logger.log(`   [${cat}] ${items.length} template(s)`);
   }
 
-  const template = selected.template_data || {};
+  // Step 3: Select blueprint
+  let selected;
+  if (blueprintId) {
+    selected = blueprints.find(b => b.id === blueprintId);
+    if (!selected) {
+      throw new Error(`Blueprint not found: ${blueprintId}`);
+    }
+    logger.log(`   Selected: ${selected.name} (${selected.category})`);
+  } else if (category) {
+    const filtered = grouped[category];
+    if (!filtered || filtered.length === 0) {
+      throw new Error(`No blueprints in category: ${category}. Available: ${Object.keys(grouped).join(', ')}`);
+    }
+    selected = filtered[0];
+    logger.log(`   Auto-selected from ${category}: ${selected.name}`);
+  } else {
+    // Non-interactive: pick first blueprint
+    selected = blueprints[0];
+    logger.log(`   Auto-selected: ${selected.name} (${selected.category})`);
+  }
 
+  // Step 4: Apply customizations
+  const template = applyCustomizations(selected.template_data || {}, customizations);
+
+  if (Object.keys(customizations).length > 0) {
+    logger.log(`   Applied ${Object.keys(customizations).length} customization(s)`);
+  }
+
+  // Step 5: Build PathOutput
   return createPathOutput({
     origin_type: 'blueprint',
     raw_material: {
       blueprint: selected,
       customizations,
+      applied_template: template,
+      categories_available: Object.keys(grouped),
     },
     blueprint_id: selected.id,
     suggested_name: template.name || selected.name,
@@ -72,6 +97,89 @@ export async function executeBlueprintBrowse({ blueprintId, customizations = {} 
       path: 'blueprint_browse',
       blueprint_name: selected.name,
       blueprint_category: selected.category,
+      total_blueprints: blueprints.length,
+      categories_browsed: Object.keys(grouped),
+      customizations_applied: Object.keys(customizations),
     },
   });
+}
+
+/**
+ * Load blueprints from the database with optional category filter.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Object} options
+ * @param {string} [options.category] - Filter by category
+ * @returns {Promise<Object[]>} Blueprint records
+ */
+async function loadBlueprints(supabase, { category } = {}) {
+  let query = supabase
+    .from('venture_blueprints')
+    .select('id, name, category, description, template_data, is_active')
+    .eq('is_active', true)
+    .order('category', { ascending: true });
+
+  if (category) {
+    query = query.eq('category', category);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Failed to load blueprints: ${error.message}`);
+  }
+
+  return data || [];
+}
+
+/**
+ * Group blueprints by category.
+ *
+ * @param {Object[]} blueprints - Blueprint records
+ * @returns {Object<string, Object[]>} Grouped blueprints
+ */
+export function groupByCategory(blueprints) {
+  const grouped = {};
+  for (const bp of blueprints) {
+    const cat = bp.category || 'uncategorized';
+    if (!grouped[cat]) grouped[cat] = [];
+    grouped[cat].push(bp);
+  }
+  return grouped;
+}
+
+/**
+ * Apply customizations over template defaults.
+ * Customizations override template_data values at the top level.
+ *
+ * @param {Object} template - Original template_data from blueprint
+ * @param {Object} customizations - User overrides
+ * @returns {Object} Merged template
+ */
+export function applyCustomizations(template, customizations = {}) {
+  return { ...template, ...customizations };
+}
+
+/**
+ * List available blueprint categories.
+ *
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object[]>} Category summary [{category, count}]
+ */
+export async function listBlueprintCategories(deps = {}) {
+  const { supabase } = deps;
+
+  if (!supabase) {
+    throw new Error('supabase client is required');
+  }
+
+  const blueprints = await loadBlueprints(supabase);
+  const grouped = groupByCategory(blueprints);
+
+  return Object.entries(grouped).map(([category, items]) => ({
+    category,
+    count: items.length,
+    blueprints: items.map(b => ({ id: b.id, name: b.name })),
+  }));
 }

--- a/test/unit/blueprint-browse.test.js
+++ b/test/unit/blueprint-browse.test.js
@@ -1,0 +1,227 @@
+/**
+ * Blueprint Browse Path - Full Implementation Tests
+ *
+ * Tests the blueprint browsing, selection, and customization pipeline:
+ * - Loading blueprints from database
+ * - Category grouping and filtering
+ * - Blueprint selection (by ID, category, or auto)
+ * - Template customization
+ * - Error handling
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-D
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  executeBlueprintBrowse,
+  groupByCategory,
+  applyCustomizations,
+  listBlueprintCategories,
+} from '../../lib/eva/stage-zero/paths/blueprint-browse.js';
+
+// ── Mock Supabase ──────────────────────────────────────────
+
+const DEFAULT_BLUEPRINTS = [
+  {
+    id: 'bp-saas-1', name: 'SaaS Starter', category: 'software',
+    description: 'Standard SaaS venture template',
+    template_data: { name: 'SaaS Venture', problem_statement: 'Manual processes waste time', solution: 'Automated SaaS platform', target_market: 'SMBs', pricing_model: 'subscription' },
+    is_active: true,
+  },
+  {
+    id: 'bp-market-1', name: 'Marketplace Template', category: 'marketplace',
+    description: 'Two-sided marketplace template',
+    template_data: { name: 'AI Marketplace', problem_statement: 'Fragmented supply and demand', solution: 'AI-powered matching marketplace', target_market: 'Enterprises' },
+    is_active: true,
+  },
+  {
+    id: 'bp-saas-2', name: 'API-First SaaS', category: 'software',
+    description: 'API-first developer tools',
+    template_data: { name: 'DevTools API', problem_statement: 'Developers lack automation', solution: 'API-first developer platform', target_market: 'Developers' },
+    is_active: true,
+  },
+];
+
+function createMockSupabase(blueprints = DEFAULT_BLUEPRINTS, dbError = null) {
+  // Build a chainable mock that handles:
+  // .from('venture_blueprints').select(...).eq('is_active', true).eq('category', X).order(...)
+  // .from('venture_blueprints').select(...).eq('is_active', true).order(...)
+  const buildChain = (data, error) => {
+    const chain = {};
+    chain.eq = vi.fn().mockImplementation((field, value) => {
+      if (field === 'category') {
+        const filtered = data.filter(b => b.category === value);
+        return { ...chain, _data: filtered, order: vi.fn().mockResolvedValue({ data: filtered, error }) };
+      }
+      return chain;
+    });
+    chain.order = vi.fn().mockResolvedValue({ data, error });
+    return chain;
+  };
+
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue(buildChain(blueprints, dbError)),
+    }),
+  };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// ── Core Functionality Tests ──────────────────────────────
+
+describe('Blueprint Browse - executeBlueprintBrowse', () => {
+  test('requires supabase client', async () => {
+    await expect(
+      executeBlueprintBrowse({}, { logger: silentLogger })
+    ).rejects.toThrow('supabase client is required');
+  });
+
+  test('returns null when no blueprints available', async () => {
+    const supabase = createMockSupabase([]);
+    const result = await executeBlueprintBrowse({}, { supabase, logger: silentLogger });
+    expect(result).toBeNull();
+  });
+
+  test('auto-selects first blueprint when no ID or category given', async () => {
+    const supabase = createMockSupabase();
+    const result = await executeBlueprintBrowse({}, { supabase, logger: silentLogger });
+
+    expect(result.origin_type).toBe('blueprint');
+    expect(result.blueprint_id).toBe('bp-saas-1');
+    expect(result.suggested_name).toBe('SaaS Venture');
+    expect(result.suggested_problem).toBe('Manual processes waste time');
+  });
+
+  test('selects specific blueprint by ID', async () => {
+    const supabase = createMockSupabase();
+    const result = await executeBlueprintBrowse(
+      { blueprintId: 'bp-market-1' },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.blueprint_id).toBe('bp-market-1');
+    expect(result.suggested_name).toBe('AI Marketplace');
+    expect(result.metadata.blueprint_category).toBe('marketplace');
+  });
+
+  test('throws when blueprint ID not found', async () => {
+    const supabase = createMockSupabase();
+    await expect(
+      executeBlueprintBrowse({ blueprintId: 'nonexistent' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('Blueprint not found: nonexistent');
+  });
+
+  test('applies customizations to template', async () => {
+    const supabase = createMockSupabase();
+    const result = await executeBlueprintBrowse(
+      { blueprintId: 'bp-saas-1', customizations: { name: 'My Custom SaaS', target_market: 'Enterprises' } },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.suggested_name).toBe('My Custom SaaS');
+    expect(result.target_market).toBe('Enterprises');
+    expect(result.raw_material.customizations).toEqual({ name: 'My Custom SaaS', target_market: 'Enterprises' });
+  });
+
+  test('includes category metadata in output', async () => {
+    const supabase = createMockSupabase();
+    const result = await executeBlueprintBrowse({}, { supabase, logger: silentLogger });
+
+    expect(result.metadata.total_blueprints).toBe(3);
+    expect(result.metadata.categories_browsed).toContain('software');
+    expect(result.metadata.categories_browsed).toContain('marketplace');
+  });
+
+  test('includes available categories in raw_material', async () => {
+    const supabase = createMockSupabase();
+    const result = await executeBlueprintBrowse({}, { supabase, logger: silentLogger });
+
+    expect(result.raw_material.categories_available).toContain('software');
+    expect(result.raw_material.categories_available).toContain('marketplace');
+  });
+
+  test('handles blueprint with missing template_data', async () => {
+    const supabase = createMockSupabase([
+      { id: 'bp-empty', name: 'Empty Template', category: 'other', description: 'No data', template_data: null, is_active: true },
+    ]);
+
+    const result = await executeBlueprintBrowse({}, { supabase, logger: silentLogger });
+    expect(result.suggested_name).toBe('Empty Template');
+    expect(result.suggested_problem).toBe('');
+  });
+
+  test('handles database error', async () => {
+    const supabase = createMockSupabase(null, { message: 'Connection failed' });
+    await expect(
+      executeBlueprintBrowse({}, { supabase, logger: silentLogger })
+    ).rejects.toThrow('Failed to load blueprints: Connection failed');
+  });
+
+  test('logs category summary', async () => {
+    const supabase = createMockSupabase();
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    await executeBlueprintBrowse({}, { supabase, logger });
+
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('3 blueprint'));
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('[software]'));
+  });
+});
+
+// ── Utility Function Tests ──────────────────────────────
+
+describe('Blueprint Browse - groupByCategory', () => {
+  test('groups blueprints by category', () => {
+    const grouped = groupByCategory([
+      { id: '1', category: 'software' },
+      { id: '2', category: 'marketplace' },
+      { id: '3', category: 'software' },
+    ]);
+    expect(Object.keys(grouped)).toHaveLength(2);
+    expect(grouped.software).toHaveLength(2);
+    expect(grouped.marketplace).toHaveLength(1);
+  });
+
+  test('handles missing category as uncategorized', () => {
+    const grouped = groupByCategory([{ id: '1' }, { id: '2', category: null }]);
+    expect(grouped.uncategorized).toHaveLength(2);
+  });
+
+  test('handles empty array', () => {
+    expect(Object.keys(groupByCategory([]))).toHaveLength(0);
+  });
+});
+
+describe('Blueprint Browse - applyCustomizations', () => {
+  test('merges customizations over template', () => {
+    const result = applyCustomizations({ name: 'Original', market: 'SMBs' }, { name: 'Custom', pricing: 'freemium' });
+    expect(result.name).toBe('Custom');
+    expect(result.market).toBe('SMBs');
+    expect(result.pricing).toBe('freemium');
+  });
+
+  test('returns template when no customizations', () => {
+    expect(applyCustomizations({ name: 'Original' }).name).toBe('Original');
+  });
+
+  test('handles empty template', () => {
+    expect(applyCustomizations({}, { name: 'New' }).name).toBe('New');
+  });
+});
+
+describe('Blueprint Browse - listBlueprintCategories', () => {
+  test('lists categories with counts', async () => {
+    const supabase = createMockSupabase();
+    const categories = await listBlueprintCategories({ supabase });
+
+    expect(categories.length).toBeGreaterThanOrEqual(2);
+    const software = categories.find(c => c.category === 'software');
+    expect(software.count).toBe(2);
+    expect(software.blueprints).toHaveLength(2);
+  });
+
+  test('requires supabase', async () => {
+    await expect(listBlueprintCategories()).rejects.toThrow('supabase client is required');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces stub blueprint browse path with full category-based browsing
- Supports direct blueprint selection by ID, category filter, or auto-select
- Template customization via `applyCustomizations()` merges overrides
- `listBlueprintCategories()` helper for category listing
- 19 new unit tests covering all flows and error cases

## Test plan
- [x] 19 new unit tests pass (`test/unit/blueprint-browse.test.js`)
- [x] 24 existing stage-zero tests still pass
- [x] 13 competitor teardown tests still pass
- [x] 15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)