### PR TITLE
feat(eva): implement discovery mode with 4 AI research strategies

### DIFF
--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -5,72 +5,380 @@
  * Supports multiple discovery strategies: trend scanner, democratization finder,
  * capability overhang exploit, and nursery re-evaluation.
  *
- * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-E (stub for Child B framework)
+ * Flow:
+ * 1. Load strategy config from discovery_strategies table
+ * 2. Run strategy-specific AI research pipeline
+ * 3. Generate ranked venture candidates with scoring
+ * 4. Select top candidate for synthesis
+ * 5. Return PathOutput with discovery-derived venture brief
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-E
  */
 
 import { createPathOutput } from '../interfaces.js';
+import { getValidationClient } from '../../../llm/client-factory.js';
+
+const VALID_STRATEGIES = ['trend_scanner', 'democratization_finder', 'capability_overhang', 'nursery_reeval'];
 
 /**
  * Execute the discovery mode path.
  *
  * @param {Object} params
  * @param {string} params.strategy - Discovery strategy to use
- * @param {Object} [params.constraints] - Optional constraints for the search
+ * @param {Object} [params.constraints] - Optional constraints (budget_range, industries, automation_level)
+ * @param {number} [params.candidateCount] - Number of candidates to generate (default: 5)
  * @param {Object} deps - Injected dependencies
  * @param {Object} deps.supabase - Supabase client
  * @param {Object} [deps.logger] - Logger
+ * @param {Object} [deps.llmClient] - LLM client override (for testing)
  * @returns {Promise<Object>} PathOutput
  */
-export async function executeDiscoveryMode({ strategy, constraints = {} }, deps = {}) {
-  const { supabase, logger = console } = deps;
+export async function executeDiscoveryMode({ strategy, constraints = {}, candidateCount = 5 }, deps = {}) {
+  const { supabase, logger = console, llmClient } = deps;
 
   if (!supabase) {
     throw new Error('supabase client is required');
   }
 
-  // Validate strategy exists
-  const validStrategies = ['trend_scanner', 'democratization_finder', 'capability_overhang', 'nursery_reeval'];
-  if (!validStrategies.includes(strategy)) {
-    throw new Error(`Invalid strategy: ${strategy}. Must be one of: ${validStrategies.join(', ')}`);
+  if (!VALID_STRATEGIES.includes(strategy)) {
+    throw new Error(`Invalid strategy: ${strategy}. Must be one of: ${VALID_STRATEGIES.join(', ')}`);
   }
 
-  // Load strategy config from database
-  const { data: strategyConfig, error } = await supabase
-    .from('discovery_strategies')
-    .select('*')
-    .eq('strategy_key', strategy)
-    .eq('is_active', true)
-    .single();
-
-  if (error || !strategyConfig) {
-    throw new Error(`Strategy not found or inactive: ${strategy}`);
-  }
-
+  // Step 1: Load strategy config
+  const strategyConfig = await loadStrategyConfig(supabase, strategy);
   logger.log(`   Running discovery strategy: ${strategyConfig.name}`);
 
-  // Stub: Full implementation in Child E (SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-E)
-  // Each strategy will use AI research pipelines to generate ranked candidates.
-  // The chairman will select from the ranked list.
+  // Step 2: Run strategy-specific pipeline
+  const runners = {
+    trend_scanner: runTrendScanner,
+    democratization_finder: runDemocratizationFinder,
+    capability_overhang: runCapabilityOverhang,
+    nursery_reeval: runNurseryReeval,
+  };
+
+  const runner = runners[strategy];
+  const candidates = await runner({ constraints, candidateCount, strategyConfig }, { supabase, logger, llmClient });
+
+  if (!candidates || candidates.length === 0) {
+    logger.log('   No candidates found. Try different constraints or strategy.');
+    return null;
+  }
+
+  // Step 3: Rank candidates
+  const ranked = rankCandidates(candidates);
+  logger.log(`   Generated ${ranked.length} candidate(s), top: ${ranked[0].name} (score: ${ranked[0].score})`);
+
+  // Step 4: Select top candidate
+  const top = ranked[0];
 
   return createPathOutput({
     origin_type: 'discovery',
     raw_material: {
       strategy: strategyConfig,
       constraints,
-      candidates: [], // Populated by full implementation
-      analysis_status: 'pending_implementation',
+      candidates: ranked,
+      top_candidate: top,
+      analyzed_at: new Date().toISOString(),
     },
     discovery_strategy: strategy,
-    suggested_name: '',
-    suggested_problem: '',
-    suggested_solution: '',
-    target_market: '',
+    suggested_name: top.name || '',
+    suggested_problem: top.problem_statement || '',
+    suggested_solution: top.solution || '',
+    target_market: top.target_market || '',
     metadata: {
       path: 'discovery_mode',
       strategy_key: strategy,
       strategy_name: strategyConfig.name,
+      candidates_generated: ranked.length,
+      top_score: top.score,
+      constraints_applied: Object.keys(constraints),
     },
   });
+}
+
+/**
+ * Load strategy configuration from database.
+ */
+async function loadStrategyConfig(supabase, strategy) {
+  const { data, error } = await supabase
+    .from('discovery_strategies')
+    .select('*')
+    .eq('strategy_key', strategy)
+    .eq('is_active', true)
+    .single();
+
+  if (error || !data) {
+    throw new Error(`Strategy not found or inactive: ${strategy}`);
+  }
+
+  return data;
+}
+
+/**
+ * Trend Scanner: Finds trending products, emerging markets, undermarketed products
+ * generating $1K+/month that are fully automatable.
+ */
+async function runTrendScanner({ constraints, candidateCount, strategyConfig }, deps = {}) {
+  const { logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+
+  const constraintText = Object.keys(constraints).length > 0
+    ? `\nConstraints: ${JSON.stringify(constraints)}`
+    : '';
+
+  const prompt = `You are an AI venture scout for EHG, a fully automated holding group.
+
+EHG's advantage: Everything is AI-operated. No human employees. Lower costs, faster iteration, 24/7 operation.
+
+STRATEGY: Trend Scanner
+${strategyConfig.description || 'Scan for trending products, emerging markets, and undermarketed opportunities.'}
+${constraintText}
+
+Generate ${candidateCount} venture candidates that:
+1. Target products/services trending upward in demand
+2. Can generate $1K+/month revenue
+3. Are fully automatable (no human labor required for operations)
+4. Have clear paths to profitability
+
+For each candidate, provide:
+- name: Venture name
+- problem_statement: The customer problem being solved
+- solution: How EHG would solve it with automation
+- target_market: Who the customers are
+- revenue_model: How it makes money
+- automation_approach: How it runs without humans
+- monthly_revenue_potential: Estimated $/month
+- competition_level: low/medium/high
+- automation_feasibility: Score 1-10
+
+Return a JSON array:
+[{ "name": "string", "problem_statement": "string", "solution": "string", "target_market": "string", "revenue_model": "string", "automation_approach": "string", "monthly_revenue_potential": "string", "competition_level": "string", "automation_feasibility": 8 }]`;
+
+  return callLLMForCandidates(client, prompt, { logger, strategyName: 'Trend Scanner' });
+}
+
+/**
+ * Democratization Finder: Identifies premium services available to the wealthy
+ * that can be made accessible through automation.
+ */
+async function runDemocratizationFinder({ constraints, candidateCount, strategyConfig }, deps = {}) {
+  const { logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+
+  const constraintText = Object.keys(constraints).length > 0
+    ? `\nConstraints: ${JSON.stringify(constraints)}`
+    : '';
+
+  const prompt = `You are an AI venture scout for EHG, a fully automated holding group.
+
+EHG's advantage: Everything is AI-operated. Dramatically lower costs enable democratizing premium services.
+
+STRATEGY: Democratization Finder
+${strategyConfig.description || 'Find premium services only available to the wealthy that can be made accessible through automation.'}
+${constraintText}
+
+Generate ${candidateCount} venture candidates that:
+1. Target services currently only affordable by wealthy individuals ($500+/session)
+2. Can be automated to offer at 1/10th the cost
+3. Maintain quality through AI sophistication
+4. Address large underserved markets
+
+Examples of democratization: personal financial advisor → robo-advisor, personal stylist → AI styling, executive coach → AI coaching
+
+For each candidate, provide:
+- name: Venture name
+- problem_statement: What the average person cannot access
+- solution: How EHG democratizes it with AI
+- target_market: The underserved population
+- revenue_model: Pricing and business model
+- automation_approach: How AI replaces the human expert
+- current_premium_cost: What the wealthy pay now
+- democratized_cost: What EHG would charge
+- automation_feasibility: Score 1-10
+
+Return a JSON array:
+[{ "name": "string", "problem_statement": "string", "solution": "string", "target_market": "string", "revenue_model": "string", "automation_approach": "string", "current_premium_cost": "string", "democratized_cost": "string", "automation_feasibility": 8 }]`;
+
+  return callLLMForCandidates(client, prompt, { logger, strategyName: 'Democratization Finder' });
+}
+
+/**
+ * Capability Overhang Exploit: Scans for existing AI capabilities
+ * that have not been productized.
+ */
+async function runCapabilityOverhang({ constraints, candidateCount, strategyConfig }, deps = {}) {
+  const { logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+
+  const constraintText = Object.keys(constraints).length > 0
+    ? `\nConstraints: ${JSON.stringify(constraints)}`
+    : '';
+
+  const prompt = `You are an AI venture scout for EHG, a fully automated holding group.
+
+EHG's advantage: Deep AI expertise and automated operations. Can productize AI capabilities faster than incumbents.
+
+STRATEGY: Capability Overhang Exploit
+${strategyConfig.description || 'Find gaps between what AI can do and what products currently offer.'}
+${constraintText}
+
+Generate ${candidateCount} venture candidates that exploit capability overhangs:
+1. Identify AI/tech capabilities that exist but are NOT productized
+2. Find gaps between what is technically possible and what is commercially available
+3. Target opportunities where incumbents are slow to adopt AI
+4. Focus on capabilities mature enough for production use
+
+For each candidate, provide:
+- name: Venture name
+- problem_statement: The gap between capability and availability
+- solution: The productized offering
+- target_market: Who needs this capability
+- revenue_model: How it makes money
+- automation_approach: Technical approach to productization
+- capability_source: What existing AI capability is being exploited
+- incumbent_gap_reason: Why incumbents haven't done this yet
+- automation_feasibility: Score 1-10
+
+Return a JSON array:
+[{ "name": "string", "problem_statement": "string", "solution": "string", "target_market": "string", "revenue_model": "string", "automation_approach": "string", "capability_source": "string", "incumbent_gap_reason": "string", "automation_feasibility": 8 }]`;
+
+  return callLLMForCandidates(client, prompt, { logger, strategyName: 'Capability Overhang' });
+}
+
+/**
+ * Nursery Re-evaluation: Re-scores parked ideas from the Venture Nursery
+ * whose conditions may have changed.
+ */
+async function runNurseryReeval({ constraints, candidateCount }, deps = {}) {
+  const { supabase, logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+
+  // Load parked ventures from nursery
+  const { data: nurseryItems, error } = await supabase
+    .from('venture_nursery')
+    .select('id, name, problem_statement, solution, target_market, parked_reason, original_score, parked_at, metadata')
+    .eq('status', 'parked')
+    .order('parked_at', { ascending: true })
+    .limit(candidateCount * 2);
+
+  if (error) {
+    throw new Error(`Failed to load nursery items: ${error.message}`);
+  }
+
+  if (!nurseryItems || nurseryItems.length === 0) {
+    logger.log('   No parked ventures in nursery to re-evaluate.');
+    return [];
+  }
+
+  logger.log(`   Re-evaluating ${nurseryItems.length} parked venture(s)...`);
+
+  const constraintText = Object.keys(constraints).length > 0
+    ? `\nConstraints: ${JSON.stringify(constraints)}`
+    : '';
+
+  const itemSummaries = nurseryItems.map(item =>
+    `- ${item.name}: "${item.problem_statement}" (Parked: ${item.parked_reason || 'unknown reason'}, Original score: ${item.original_score || 'N/A'})`
+  ).join('\n');
+
+  const prompt = `You are an AI venture analyst for EHG re-evaluating parked venture ideas.
+
+These ventures were previously parked in EHG's Venture Nursery. Conditions may have changed:
+- New AI capabilities available
+- Market shifts
+- Portfolio gaps emerged
+- Technology costs decreased
+
+Parked ventures:
+${itemSummaries}
+${constraintText}
+
+For each venture, re-evaluate whether conditions have changed enough to warrant revival.
+Score each venture on:
+1. Market readiness (has the market shifted favorably?)
+2. Technology readiness (are new capabilities available?)
+3. Portfolio fit (does EHG need this now?)
+4. Automation feasibility (can it run fully automated?)
+
+Return a JSON array (only include ventures worth reviving, up to ${candidateCount}):
+[{
+  "nursery_id": "string (original ID)",
+  "name": "string",
+  "problem_statement": "string (updated if market changed)",
+  "solution": "string (updated with new capabilities)",
+  "target_market": "string",
+  "revival_reason": "string (what changed)",
+  "new_score": 8,
+  "automation_feasibility": 8
+}]
+
+If no ventures are worth reviving, return an empty array: []`;
+
+  try {
+    const response = await client.messages.create({
+      model: client._model || 'claude-sonnet-4-5-20250929',
+      max_tokens: 2000,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = response.content[0]?.text || '';
+    const jsonMatch = text.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      return parsed.map(c => ({
+        ...c,
+        source: 'nursery_reeval',
+        automation_feasibility: c.automation_feasibility || c.new_score || 5,
+      }));
+    }
+    logger.warn('   Warning: Could not parse nursery re-evaluation response');
+    return [];
+  } catch (err) {
+    logger.warn(`   Warning: Nursery re-evaluation failed: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Common LLM call handler for candidate generation strategies.
+ */
+async function callLLMForCandidates(client, prompt, { logger = console, strategyName = 'unknown' } = {}) {
+  try {
+    const response = await client.messages.create({
+      model: client._model || 'claude-sonnet-4-5-20250929',
+      max_tokens: 3000,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = response.content[0]?.text || '';
+    const jsonMatch = text.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      return parsed.map(c => ({ ...c, source: strategyName }));
+    }
+    logger.warn(`   Warning: Could not parse ${strategyName} response`);
+    return [];
+  } catch (err) {
+    logger.warn(`   Warning: ${strategyName} analysis failed: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Rank candidates by composite score.
+ * Score = automation_feasibility * 10 + bonus factors.
+ *
+ * @param {Object[]} candidates - Raw candidates from strategy
+ * @returns {Object[]} Sorted candidates with scores
+ */
+export function rankCandidates(candidates) {
+  return candidates
+    .map(c => {
+      const feasibility = Number(c.automation_feasibility) || 5;
+      const competitionBonus = c.competition_level === 'low' ? 10 : c.competition_level === 'medium' ? 5 : 0;
+      const score = feasibility * 10 + competitionBonus;
+      return { ...c, score };
+    })
+    .sort((a, b) => b.score - a.score);
 }
 
 /**

--- a/test/unit/discovery-mode.test.js
+++ b/test/unit/discovery-mode.test.js
@@ -1,0 +1,462 @@
+/**
+ * Discovery Mode Path - Full Implementation Tests
+ *
+ * Tests the AI-driven discovery pipeline:
+ * - Strategy validation and config loading
+ * - Trend Scanner strategy
+ * - Democratization Finder strategy
+ * - Capability Overhang strategy
+ * - Nursery Re-evaluation strategy
+ * - Candidate ranking
+ * - Error handling and graceful degradation
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-E
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  executeDiscoveryMode,
+  rankCandidates,
+  listDiscoveryStrategies,
+} from '../../lib/eva/stage-zero/paths/discovery-mode.js';
+
+// ── Mock LLM Client ──────────────────────────────────────────
+
+function createMockLLMClient(candidates = null) {
+  const defaultCandidates = [
+    {
+      name: 'AutoReview AI',
+      problem_statement: 'Businesses struggle to manage online reviews',
+      solution: 'AI-powered review management platform',
+      target_market: 'Small businesses',
+      revenue_model: 'Monthly subscription',
+      automation_approach: 'LLM-driven response generation',
+      automation_feasibility: 9,
+      competition_level: 'medium',
+    },
+    {
+      name: 'DataClean Pro',
+      problem_statement: 'Data quality is poor across enterprises',
+      solution: 'Automated data cleansing pipeline',
+      target_market: 'Mid-market enterprises',
+      revenue_model: 'Usage-based pricing',
+      automation_approach: 'ML-powered data validation',
+      automation_feasibility: 8,
+      competition_level: 'low',
+    },
+    {
+      name: 'ContentForge',
+      problem_statement: 'Content creation is expensive and slow',
+      solution: 'AI content factory for marketing teams',
+      target_market: 'Marketing agencies',
+      revenue_model: 'Per-piece pricing',
+      automation_approach: 'Multi-modal content generation',
+      automation_feasibility: 7,
+      competition_level: 'high',
+    },
+  ];
+
+  return {
+    _model: 'mock-model',
+    messages: {
+      create: vi.fn().mockImplementation(async () => ({
+        content: [{ text: JSON.stringify(candidates || defaultCandidates) }],
+      })),
+    },
+  };
+}
+
+// ── Mock Supabase ──────────────────────────────────────────
+
+const STRATEGY_CONFIGS = {
+  trend_scanner: { strategy_key: 'trend_scanner', name: 'Trend Scanner', description: 'Scan trending products', is_active: true },
+  democratization_finder: { strategy_key: 'democratization_finder', name: 'Democratization Finder', description: 'Find premium services to democratize', is_active: true },
+  capability_overhang: { strategy_key: 'capability_overhang', name: 'Capability Overhang', description: 'Exploit capability gaps', is_active: true },
+  nursery_reeval: { strategy_key: 'nursery_reeval', name: 'Nursery Re-evaluation', description: 'Re-score parked ideas', is_active: true },
+};
+
+const DEFAULT_NURSERY_ITEMS = [
+  { id: 'n-1', name: 'OldVenture A', problem_statement: 'Problem A', solution: 'Solution A', target_market: 'Market A', parked_reason: 'Market not ready', original_score: 60, parked_at: '2025-06-01', metadata: {} },
+  { id: 'n-2', name: 'OldVenture B', problem_statement: 'Problem B', solution: 'Solution B', target_market: 'Market B', parked_reason: 'Tech limitations', original_score: 45, parked_at: '2025-03-01', metadata: {} },
+];
+
+function createMockSupabase({ strategies = STRATEGY_CONFIGS, nurseryItems = DEFAULT_NURSERY_ITEMS, dbError = null, nurseryError = null, strategyError = null } = {}) {
+  return {
+    from: vi.fn().mockImplementation((table) => {
+      if (table === 'discovery_strategies') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockImplementation((field, value) => {
+              if (field === 'strategy_key') {
+                const config = strategies[value];
+                return {
+                  eq: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({
+                      data: config || null,
+                      error: strategyError || (config ? null : { message: 'Not found' }),
+                    }),
+                  }),
+                };
+              }
+              if (field === 'is_active') {
+                return {
+                  order: vi.fn().mockResolvedValue({
+                    data: Object.values(strategies),
+                    error: dbError,
+                  }),
+                };
+              }
+              return { single: vi.fn().mockResolvedValue({ data: null, error: { message: 'Unknown filter' } }) };
+            }),
+          }),
+        };
+      }
+      if (table === 'venture_nursery') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({
+                  data: nurseryError ? null : nurseryItems,
+                  error: nurseryError,
+                }),
+              }),
+            }),
+          }),
+        };
+      }
+      return { select: vi.fn().mockReturnValue({ eq: vi.fn() }) };
+    }),
+  };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// ── Core Functionality Tests ──────────────────────────────
+
+describe('Discovery Mode - executeDiscoveryMode', () => {
+  test('requires supabase client', async () => {
+    await expect(
+      executeDiscoveryMode({ strategy: 'trend_scanner' }, { logger: silentLogger })
+    ).rejects.toThrow('supabase client is required');
+  });
+
+  test('rejects invalid strategy', async () => {
+    const supabase = createMockSupabase();
+    await expect(
+      executeDiscoveryMode({ strategy: 'invalid' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('Invalid strategy: invalid');
+  });
+
+  test('throws when strategy not found in database', async () => {
+    const supabase = createMockSupabase({ strategies: {} });
+    await expect(
+      executeDiscoveryMode({ strategy: 'trend_scanner' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('Strategy not found or inactive: trend_scanner');
+  });
+
+  test('returns null when no candidates generated', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = createMockLLMClient([]);
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test('runs trend_scanner and returns PathOutput', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = createMockLLMClient();
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result.origin_type).toBe('discovery');
+    expect(result.discovery_strategy).toBe('trend_scanner');
+    expect(result.suggested_name).toBeTruthy();
+    expect(result.suggested_problem).toBeTruthy();
+    expect(result.raw_material.candidates).toHaveLength(3);
+    expect(result.raw_material.top_candidate).toBeDefined();
+    expect(result.metadata.path).toBe('discovery_mode');
+    expect(result.metadata.strategy_key).toBe('trend_scanner');
+    expect(result.metadata.candidates_generated).toBe(3);
+  });
+
+  test('runs democratization_finder strategy', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = createMockLLMClient();
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'democratization_finder' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result.origin_type).toBe('discovery');
+    expect(result.discovery_strategy).toBe('democratization_finder');
+    expect(result.metadata.strategy_name).toBe('Democratization Finder');
+  });
+
+  test('runs capability_overhang strategy', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = createMockLLMClient();
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'capability_overhang' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result.origin_type).toBe('discovery');
+    expect(result.discovery_strategy).toBe('capability_overhang');
+    expect(result.metadata.strategy_name).toBe('Capability Overhang');
+  });
+
+  test('passes constraints to strategy', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = createMockLLMClient();
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner', constraints: { industries: ['fintech'], budget_range: '$10K-$50K' } },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result.raw_material.constraints).toEqual({ industries: ['fintech'], budget_range: '$10K-$50K' });
+    expect(result.metadata.constraints_applied).toContain('industries');
+    expect(result.metadata.constraints_applied).toContain('budget_range');
+    // Verify LLM was called with constraints in the prompt
+    const callArgs = llmClient.messages.create.mock.calls[0][0];
+    expect(callArgs.messages[0].content).toContain('fintech');
+  });
+
+  test('selects highest-scored candidate as top', async () => {
+    const supabase = createMockSupabase();
+    // DataClean Pro has feasibility=8 + competition_level=low bonus=10 → score=90
+    // AutoReview AI has feasibility=9 + medium bonus=5 → score=95
+    const llmClient = createMockLLMClient();
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result.raw_material.top_candidate.name).toBe('AutoReview AI');
+    expect(result.metadata.top_score).toBe(95);
+  });
+
+  test('includes analyzed_at timestamp', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = createMockLLMClient();
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result.raw_material.analyzed_at).toBeDefined();
+  });
+
+  test('logs progress during execution', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = createMockLLMClient();
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    await executeDiscoveryMode(
+      { strategy: 'trend_scanner' },
+      { supabase, logger, llmClient }
+    );
+
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Trend Scanner'));
+    expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('3 candidate'));
+  });
+});
+
+// ── Nursery Re-evaluation Tests ──────────────────────────────
+
+describe('Discovery Mode - nursery_reeval strategy', () => {
+  test('loads parked ventures from venture_nursery table', async () => {
+    const supabase = createMockSupabase();
+    const revivedCandidates = [
+      { nursery_id: 'n-1', name: 'OldVenture A Revived', problem_statement: 'Updated problem', solution: 'Updated solution', target_market: 'Market A', revival_reason: 'New AI capabilities', new_score: 8, automation_feasibility: 8 },
+    ];
+    const llmClient = createMockLLMClient(revivedCandidates);
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'nursery_reeval' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result.origin_type).toBe('discovery');
+    expect(result.discovery_strategy).toBe('nursery_reeval');
+    expect(result.raw_material.candidates).toHaveLength(1);
+    expect(supabase.from).toHaveBeenCalledWith('venture_nursery');
+  });
+
+  test('returns null when no parked ventures exist', async () => {
+    const supabase = createMockSupabase({ nurseryItems: [] });
+    const llmClient = createMockLLMClient();
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'nursery_reeval' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test('handles nursery database error', async () => {
+    const supabase = createMockSupabase({ nurseryError: { message: 'Connection failed' } });
+    await expect(
+      executeDiscoveryMode(
+        { strategy: 'nursery_reeval' },
+        { supabase, logger: silentLogger, llmClient: createMockLLMClient() }
+      )
+    ).rejects.toThrow('Failed to load nursery items: Connection failed');
+  });
+
+  test('handles LLM returning empty array for re-evaluation', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = createMockLLMClient([]);
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'nursery_reeval' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+// ── Error Handling Tests ──────────────────────────────────
+
+describe('Discovery Mode - Error Handling', () => {
+  test('handles LLM returning non-JSON gracefully', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = {
+      _model: 'mock-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: 'I cannot generate venture candidates right now.' }],
+        }),
+      },
+    };
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner' },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test('handles LLM error gracefully', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = {
+      _model: 'mock-model',
+      messages: {
+        create: vi.fn().mockRejectedValue(new Error('Rate limited')),
+      },
+    };
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'trend_scanner' },
+      { supabase, logger, llmClient }
+    );
+
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Rate limited'));
+  });
+
+  test('handles LLM error in nursery_reeval gracefully', async () => {
+    const supabase = createMockSupabase();
+    const llmClient = {
+      _model: 'mock-model',
+      messages: {
+        create: vi.fn().mockRejectedValue(new Error('Context too long')),
+      },
+    };
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const result = await executeDiscoveryMode(
+      { strategy: 'nursery_reeval' },
+      { supabase, logger, llmClient }
+    );
+
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Context too long'));
+  });
+});
+
+// ── Ranking Tests ──────────────────────────────────────────
+
+describe('Discovery Mode - rankCandidates', () => {
+  test('ranks by automation_feasibility * 10', () => {
+    const ranked = rankCandidates([
+      { name: 'Low', automation_feasibility: 3 },
+      { name: 'High', automation_feasibility: 9 },
+      { name: 'Mid', automation_feasibility: 6 },
+    ]);
+
+    expect(ranked[0].name).toBe('High');
+    expect(ranked[0].score).toBe(90);
+    expect(ranked[1].name).toBe('Mid');
+    expect(ranked[2].name).toBe('Low');
+  });
+
+  test('adds competition bonus for low competition', () => {
+    const ranked = rankCandidates([
+      { name: 'Low Comp', automation_feasibility: 7, competition_level: 'low' },
+      { name: 'High Comp', automation_feasibility: 8, competition_level: 'high' },
+    ]);
+
+    // Low Comp: 7*10 + 10 = 80, High Comp: 8*10 + 0 = 80 → tied, original order preserved
+    expect(ranked[0].score).toBe(80);
+    expect(ranked[1].score).toBe(80);
+  });
+
+  test('adds medium competition bonus', () => {
+    const ranked = rankCandidates([
+      { name: 'A', automation_feasibility: 5, competition_level: 'medium' },
+    ]);
+    expect(ranked[0].score).toBe(55); // 5*10 + 5
+  });
+
+  test('handles missing automation_feasibility', () => {
+    const ranked = rankCandidates([
+      { name: 'No Score' },
+    ]);
+    expect(ranked[0].score).toBe(50); // default 5 * 10
+  });
+
+  test('handles empty array', () => {
+    expect(rankCandidates([])).toHaveLength(0);
+  });
+});
+
+// ── List Strategies Tests ──────────────────────────────────
+
+describe('Discovery Mode - listDiscoveryStrategies', () => {
+  test('lists active strategies', async () => {
+    const supabase = createMockSupabase();
+    const strategies = await listDiscoveryStrategies({ supabase });
+
+    expect(strategies.length).toBeGreaterThanOrEqual(4);
+    expect(strategies[0].strategy_key).toBeDefined();
+    expect(strategies[0].name).toBeDefined();
+  });
+
+  test('requires supabase', async () => {
+    await expect(listDiscoveryStrategies()).rejects.toThrow('supabase client is required');
+  });
+
+  test('handles database error', async () => {
+    const supabase = createMockSupabase({ dbError: { message: 'Connection failed' } });
+    await expect(
+      listDiscoveryStrategies({ supabase })
+    ).rejects.toThrow('Failed to load strategies: Connection failed');
+  });
+});

--- a/test/unit/stage-zero.test.js
+++ b/test/unit/stage-zero.test.js
@@ -255,10 +255,18 @@ describe('Path Router', () => {
 
   test('routes to discovery mode', async () => {
     const supabase = createMockSupabase();
+    const llmClient = {
+      _model: 'mock-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: JSON.stringify([{ name: 'TestVenture', problem_statement: 'Test problem', solution: 'Test solution', target_market: 'SMBs', automation_feasibility: 8 }]) }],
+        }),
+      },
+    };
     const result = await routePath(
       ENTRY_PATHS.DISCOVERY_MODE,
       { strategy: 'trend_scanner' },
-      { supabase, logger: silentLogger }
+      { supabase, logger: silentLogger, llmClient }
     );
     expect(result.origin_type).toBe('discovery');
     expect(result.discovery_strategy).toBe('trend_scanner');
@@ -355,13 +363,21 @@ describe('Stage 0 Orchestrator', () => {
 
   test('executes full flow with discovery path', async () => {
     const supabase = createMockSupabase();
+    const llmClient = {
+      _model: 'mock-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: JSON.stringify([{ name: 'TestVenture', problem_statement: 'Test problem', solution: 'Test solution', target_market: 'SMBs', automation_feasibility: 8 }]) }],
+        }),
+      },
+    };
     const result = await executeStageZero(
       {
         path: ENTRY_PATHS.DISCOVERY_MODE,
         pathParams: { strategy: 'trend_scanner' },
         options: { dryRun: true },
       },
-      { supabase, logger: silentLogger }
+      { supabase, logger: silentLogger, llmClient }
     );
 
     expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary
- Implements full discovery mode (Path 3) with 4 AI-driven research strategies: trend scanner, democratization finder, capability overhang exploit, and nursery re-evaluation
- Each strategy generates ranked venture candidates via LLM with composite scoring (automation feasibility + competition bonus)
- Nursery re-eval loads parked ventures from `venture_nursery` table and re-scores with current conditions
- 26 new tests + 2 updated existing tests, 82/82 passing across all Stage 0 test files

## Test plan
- [x] 26 new unit tests for discovery mode (all strategies, ranking, error handling)
- [x] 2 existing stage-zero tests updated for new llmClient dependency
- [x] 82/82 tests passing across 4 test files (stage-zero, blueprint-browse, competitor-teardown, discovery-mode)
- [x] 15/15 smoke tests passing

Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-E

🤖 Generated with [Claude Code](https://claude.com/claude-code)