### PR TITLE
feat(eva): implement modeling module and venture nursery

### DIFF
--- a/lib/eva/stage-zero/modeling.js
+++ b/lib/eva/stage-zero/modeling.js
@@ -1,0 +1,207 @@
+/**
+ * Stage 0 - Modeling Module (Horizontal Forecasting Infrastructure)
+ *
+ * Provides financial and growth projections for venture candidates
+ * during Stage 0 evaluation. Uses synthesis data to generate:
+ * - Revenue projections (monthly, by year for 3 years)
+ * - Market size estimates (TAM, SAM, SOM)
+ * - Unit economics (CAC, LTV, payback period)
+ * - Growth trajectory (user adoption curves)
+ *
+ * All projections are ranges (optimistic/realistic/pessimistic)
+ * to reflect early-stage uncertainty.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-J
+ */
+
+import { getValidationClient } from '../../llm/client-factory.js';
+
+/**
+ * Generate a horizontal forecast for a venture brief.
+ *
+ * @param {Object} brief - Enriched venture brief from synthesis engine
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} [deps.logger] - Logger
+ * @param {Object} [deps.llmClient] - LLM client override (for testing)
+ * @returns {Promise<Object>} Forecast result
+ */
+export async function generateForecast(brief, deps = {}) {
+  const { logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+
+  logger.log('   Generating venture forecast...');
+
+  const buildCost = brief.metadata?.synthesis?.build_cost || {};
+  const archetype = brief.metadata?.synthesis?.archetypes?.primary_archetype || 'unknown';
+  const timeHorizon = brief.metadata?.synthesis?.time_horizon?.position || 'build_now';
+
+  const prompt = `You are a financial modeling analyst for EHG ventures. Generate projections for this venture.
+
+VENTURE:
+Name: ${brief.name}
+Problem: ${brief.problem_statement}
+Solution: ${brief.solution}
+Market: ${brief.target_market}
+Archetype: ${archetype}
+Time Horizon: ${timeHorizon}
+Build Complexity: ${buildCost.complexity || 'moderate'}
+Estimated Timeline: ${buildCost.timeline_weeks?.realistic || 8} weeks to MVP
+
+EHG CONTEXT:
+- AI-first development (lower build costs)
+- Supabase infrastructure (low infra overhead)
+- Portfolio synergies may reduce CAC
+- Chairman requires 2-year positioning horizon
+
+Generate 3-year projections with optimistic/realistic/pessimistic ranges:
+
+Return JSON:
+{
+  "market_sizing": {
+    "tam": {"value": 1000000000, "unit": "USD", "rationale": "string"},
+    "sam": {"value": 100000000, "unit": "USD", "rationale": "string"},
+    "som": {"value": 5000000, "unit": "USD", "rationale": "string"}
+  },
+  "revenue_projections": {
+    "year_1": {"optimistic": 120000, "realistic": 60000, "pessimistic": 15000},
+    "year_2": {"optimistic": 600000, "realistic": 250000, "pessimistic": 80000},
+    "year_3": {"optimistic": 2000000, "realistic": 800000, "pessimistic": 200000}
+  },
+  "unit_economics": {
+    "cac": {"optimistic": 15, "realistic": 40, "pessimistic": 80},
+    "ltv": {"optimistic": 600, "realistic": 350, "pessimistic": 150},
+    "ltv_cac_ratio": {"optimistic": 40, "realistic": 8.75, "pessimistic": 1.88},
+    "payback_months": {"optimistic": 2, "realistic": 5, "pessimistic": 12}
+  },
+  "growth_trajectory": {
+    "month_3_users": {"optimistic": 200, "realistic": 50, "pessimistic": 10},
+    "month_6_users": {"optimistic": 1000, "realistic": 200, "pessimistic": 50},
+    "month_12_users": {"optimistic": 5000, "realistic": 800, "pessimistic": 150},
+    "growth_model": "string (e.g., 'viral', 'sales-led', 'content-led')"
+  },
+  "break_even": {
+    "months_to_break_even": {"optimistic": 8, "realistic": 14, "pessimistic": 24},
+    "monthly_burn_at_launch": 3000,
+    "monthly_burn_at_scale": 8000
+  },
+  "confidence": 65,
+  "key_assumptions": ["string"],
+  "summary": "string (2-3 sentences)"
+}`;
+
+  try {
+    const response = await client.messages.create({
+      model: client._model || 'claude-sonnet-4-5-20250929',
+      max_tokens: 2000,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = response.content[0]?.text || '';
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const forecast = JSON.parse(jsonMatch[0]);
+      return {
+        component: 'forecast',
+        market_sizing: forecast.market_sizing || defaultMarketSizing(),
+        revenue_projections: forecast.revenue_projections || defaultRevenueProjections(),
+        unit_economics: forecast.unit_economics || defaultUnitEconomics(),
+        growth_trajectory: forecast.growth_trajectory || defaultGrowthTrajectory(),
+        break_even: forecast.break_even || defaultBreakEven(),
+        confidence: forecast.confidence || 30,
+        key_assumptions: forecast.key_assumptions || [],
+        summary: forecast.summary || '',
+      };
+    }
+    return defaultForecastResult('Could not parse forecast');
+  } catch (err) {
+    logger.warn(`   Warning: Forecast generation failed: ${err.message}`);
+    return defaultForecastResult(`Forecast failed: ${err.message}`);
+  }
+}
+
+/**
+ * Calculate a simple venture score from forecast data.
+ * Used to compare ventures in the pipeline.
+ *
+ * @param {Object} forecast - Forecast result from generateForecast
+ * @returns {number} Score 0-100
+ */
+export function calculateVentureScore(forecast) {
+  if (!forecast || forecast.confidence === 0) return 0;
+
+  const rev = forecast.revenue_projections?.year_2?.realistic || 0;
+  const ltvCac = forecast.unit_economics?.ltv_cac_ratio?.realistic || 0;
+  const breakEven = forecast.break_even?.months_to_break_even?.realistic || 36;
+
+  // Revenue score (0-35): $250k realistic Y2 = 35
+  const revScore = Math.min(35, Math.round((rev / 250000) * 35));
+
+  // LTV/CAC score (0-30): 8.75x = 30
+  const ltvScore = Math.min(30, Math.round((ltvCac / 8.75) * 30));
+
+  // Break-even speed (0-20): 14 months = 20, 36+ = 0
+  const beScore = breakEven >= 36 ? 0 : Math.round(((36 - breakEven) / 22) * 20);
+
+  // Confidence bonus (0-15)
+  const confScore = Math.round((forecast.confidence / 100) * 15);
+
+  return Math.min(100, revScore + ltvScore + beScore + confScore);
+}
+
+// ── Default Structures ──────────────────────────────
+
+function defaultMarketSizing() {
+  return {
+    tam: { value: 0, unit: 'USD', rationale: 'Unknown' },
+    sam: { value: 0, unit: 'USD', rationale: 'Unknown' },
+    som: { value: 0, unit: 'USD', rationale: 'Unknown' },
+  };
+}
+
+function defaultRevenueProjections() {
+  return {
+    year_1: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    year_2: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    year_3: { optimistic: 0, realistic: 0, pessimistic: 0 },
+  };
+}
+
+function defaultUnitEconomics() {
+  return {
+    cac: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    ltv: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    ltv_cac_ratio: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    payback_months: { optimistic: 0, realistic: 0, pessimistic: 0 },
+  };
+}
+
+function defaultGrowthTrajectory() {
+  return {
+    month_3_users: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    month_6_users: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    month_12_users: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    growth_model: 'unknown',
+  };
+}
+
+function defaultBreakEven() {
+  return {
+    months_to_break_even: { optimistic: 0, realistic: 0, pessimistic: 0 },
+    monthly_burn_at_launch: 0,
+    monthly_burn_at_scale: 0,
+  };
+}
+
+function defaultForecastResult(summary) {
+  return {
+    component: 'forecast',
+    market_sizing: defaultMarketSizing(),
+    revenue_projections: defaultRevenueProjections(),
+    unit_economics: defaultUnitEconomics(),
+    growth_trajectory: defaultGrowthTrajectory(),
+    break_even: defaultBreakEven(),
+    confidence: 0,
+    key_assumptions: [],
+    summary,
+  };
+}

--- a/lib/eva/stage-zero/venture-nursery.js
+++ b/lib/eva/stage-zero/venture-nursery.js
@@ -1,0 +1,318 @@
+/**
+ * Stage 0 - Venture Nursery and Feedback Loop
+ *
+ * Manages ventures that aren't ready for Stage 1:
+ * - Park ventures with trigger conditions for re-evaluation
+ * - Reactivate ventures when conditions are met
+ * - Record synthesis feedback for future cross-referencing
+ * - Track nursery health (stale items, trigger readiness)
+ *
+ * The nursery is a "warm storage" - items aren't abandoned but
+ * periodically re-evaluated based on trigger conditions.
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-I
+ */
+
+/**
+ * Park a venture in the nursery with trigger conditions.
+ *
+ * @param {Object} brief - Venture brief from synthesis/chairman review
+ * @param {Object} params
+ * @param {string} params.reason - Why it's being parked
+ * @param {string[]} [params.triggerConditions] - Conditions that would trigger re-evaluation
+ * @param {string} [params.reviewSchedule] - When to next review (e.g., '30d', '90d')
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object>} Created nursery entry
+ */
+export async function parkVenture(brief, params, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) throw new Error('supabase client is required');
+  if (!params?.reason) throw new Error('reason is required');
+
+  logger.log(`   Parking venture in nursery: ${brief.name}`);
+
+  const triggerConditions = params.triggerConditions || [];
+  const reviewSchedule = params.reviewSchedule || '90d';
+  const nextReviewDate = calculateNextReview(reviewSchedule);
+
+  const { data, error } = await supabase
+    .from('venture_nursery')
+    .insert({
+      name: brief.name,
+      problem_statement: brief.problem_statement,
+      solution: brief.solution,
+      target_market: brief.target_market,
+      origin_type: brief.origin_type,
+      raw_chairman_intent: brief.raw_chairman_intent || brief.problem_statement,
+      maturity: brief.maturity || 'seed',
+      parked_reason: params.reason,
+      status: 'parked',
+      metadata: {
+        stage_zero_brief: brief,
+        trigger_conditions: triggerConditions,
+        review_schedule: reviewSchedule,
+        next_review_date: nextReviewDate,
+        parked_at: new Date().toISOString(),
+        synthesis_snapshot: brief.metadata?.synthesis || null,
+      },
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to park venture: ${error.message}`);
+
+  logger.log(`   Nursery entry created: ${data.id}`);
+  logger.log(`   Next review: ${nextReviewDate}`);
+  logger.log(`   Triggers: ${triggerConditions.length} condition(s)`);
+
+  return data;
+}
+
+/**
+ * Reactivate a nursery item back into Stage 0 for re-evaluation.
+ *
+ * @param {string} nurseryId - ID of the nursery entry
+ * @param {Object} params
+ * @param {string} params.reason - Why it's being reactivated
+ * @param {Object} [params.updatedContext] - New context that triggered reactivation
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object>} Reactivated nursery entry with path output for re-synthesis
+ */
+export async function reactivateVenture(nurseryId, params, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) throw new Error('supabase client is required');
+  if (!nurseryId) throw new Error('nurseryId is required');
+  if (!params?.reason) throw new Error('reason is required');
+
+  // Fetch current nursery entry
+  const { data: entry, error: fetchError } = await supabase
+    .from('venture_nursery')
+    .select('*')
+    .eq('id', nurseryId)
+    .single();
+
+  if (fetchError || !entry) throw new Error(`Nursery entry not found: ${nurseryId}`);
+  if (entry.status === 'reactivated') throw new Error('Venture already reactivated');
+
+  logger.log(`   Reactivating nursery item: ${entry.name}`);
+
+  // Update status
+  const { data: updated, error: updateError } = await supabase
+    .from('venture_nursery')
+    .update({
+      status: 'reactivated',
+      metadata: {
+        ...entry.metadata,
+        reactivation: {
+          reason: params.reason,
+          updated_context: params.updatedContext || null,
+          reactivated_at: new Date().toISOString(),
+          previous_status: entry.status,
+        },
+      },
+    })
+    .eq('id', nurseryId)
+    .select()
+    .single();
+
+  if (updateError) throw new Error(`Failed to reactivate: ${updateError.message}`);
+
+  logger.log('   Status: parked → reactivated');
+
+  // Build path output for re-entry into synthesis
+  const pathOutput = {
+    origin_type: entry.origin_type || 'nursery_reeval',
+    raw_material: {
+      nursery_id: nurseryId,
+      previous_synthesis: entry.metadata?.synthesis_snapshot || null,
+      reactivation_context: params.updatedContext || null,
+    },
+    suggested_name: entry.name,
+    suggested_problem: entry.problem_statement,
+    suggested_solution: entry.solution,
+    target_market: entry.target_market,
+    metadata: {
+      path: 'nursery_reeval',
+      nursery_id: nurseryId,
+      reactivation_reason: params.reason,
+    },
+    competitor_urls: [],
+    blueprint_id: null,
+    discovery_strategy: null,
+  };
+
+  return { entry: updated, pathOutput };
+}
+
+/**
+ * Record synthesis feedback for a venture (used after Stage 0 completes).
+ * This creates a learning record that future cross-referencing can use.
+ *
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture or nursery entry ID
+ * @param {string} params.outcome - 'approved' | 'parked' | 'killed'
+ * @param {Object} [params.synthesisData] - Key synthesis findings
+ * @param {string[]} [params.lessons] - Lessons learned
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object>} Created feedback record
+ */
+export async function recordSynthesisFeedback(params, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) throw new Error('supabase client is required');
+  if (!params?.ventureId) throw new Error('ventureId is required');
+  if (!params?.outcome) throw new Error('outcome is required');
+
+  const validOutcomes = ['approved', 'parked', 'killed'];
+  if (!validOutcomes.includes(params.outcome)) {
+    throw new Error(`Invalid outcome: ${params.outcome}. Must be: ${validOutcomes.join(', ')}`);
+  }
+
+  logger.log(`   Recording synthesis feedback: ${params.outcome}`);
+
+  const { data, error } = await supabase
+    .from('venture_synthesis_feedback')
+    .insert({
+      venture_id: params.ventureId,
+      outcome: params.outcome,
+      synthesis_data: params.synthesisData || {},
+      lessons: params.lessons || [],
+      created_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to record feedback: ${error.message}`);
+
+  logger.log(`   Feedback recorded: ${data.id}`);
+  return data;
+}
+
+/**
+ * Check nursery items for trigger condition readiness.
+ *
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object[]>} Items ready for re-evaluation
+ */
+export async function checkNurseryTriggers(deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) throw new Error('supabase client is required');
+
+  logger.log('   Checking nursery triggers...');
+
+  // Fetch parked items
+  const { data: items, error } = await supabase
+    .from('venture_nursery')
+    .select('id, name, metadata, status')
+    .eq('status', 'parked')
+    .order('created_at', { ascending: true });
+
+  if (error) throw new Error(`Failed to fetch nursery items: ${error.message}`);
+  if (!items || items.length === 0) {
+    logger.log('   No parked items in nursery');
+    return [];
+  }
+
+  const now = new Date();
+  const readyForReview = [];
+
+  for (const item of items) {
+    const nextReview = item.metadata?.next_review_date;
+    if (nextReview && new Date(nextReview) <= now) {
+      readyForReview.push({
+        id: item.id,
+        name: item.name,
+        reason: 'scheduled_review',
+        next_review_date: nextReview,
+        trigger_conditions: item.metadata?.trigger_conditions || [],
+      });
+    }
+  }
+
+  logger.log(`   ${readyForReview.length} of ${items.length} item(s) ready for review`);
+  return readyForReview;
+}
+
+/**
+ * Get nursery health summary.
+ *
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object>} Health summary
+ */
+export async function getNurseryHealth(deps = {}) {
+  const { supabase } = deps;
+
+  if (!supabase) throw new Error('supabase client is required');
+
+  const { data: items, error } = await supabase
+    .from('venture_nursery')
+    .select('id, name, status, maturity, metadata, created_at');
+
+  if (error) throw new Error(`Failed to fetch nursery: ${error.message}`);
+  if (!items) return { total: 0, parked: 0, reactivated: 0, stale: 0, items: [] };
+
+  const now = new Date();
+  const staleThreshold = 180 * 24 * 60 * 60 * 1000; // 180 days
+
+  const parked = items.filter(i => i.status === 'parked');
+  const reactivated = items.filter(i => i.status === 'reactivated');
+  const stale = parked.filter(i => (now - new Date(i.created_at)) > staleThreshold);
+
+  return {
+    total: items.length,
+    parked: parked.length,
+    reactivated: reactivated.length,
+    stale: stale.length,
+    items: items.map(i => ({
+      id: i.id,
+      name: i.name,
+      status: i.status,
+      maturity: i.maturity,
+      age_days: Math.round((now - new Date(i.created_at)) / (24 * 60 * 60 * 1000)),
+      has_triggers: (i.metadata?.trigger_conditions || []).length > 0,
+    })),
+  };
+}
+
+// ── Helpers ──────────────────────────────
+
+function calculateNextReview(schedule) {
+  const now = new Date();
+  const match = schedule.match(/^(\d+)([dhm])$/);
+  if (!match) {
+    // Default: 90 days
+    now.setDate(now.getDate() + 90);
+    return now.toISOString();
+  }
+
+  const [, amount, unit] = match;
+  const num = parseInt(amount, 10);
+
+  switch (unit) {
+    case 'd':
+      now.setDate(now.getDate() + num);
+      break;
+    case 'h':
+      now.setHours(now.getHours() + num);
+      break;
+    case 'm':
+      now.setMonth(now.getMonth() + num);
+      break;
+    default:
+      now.setDate(now.getDate() + 90);
+  }
+
+  return now.toISOString();
+}

--- a/test/unit/modeling.test.js
+++ b/test/unit/modeling.test.js
@@ -1,0 +1,232 @@
+/**
+ * Modeling Module Tests
+ *
+ * Tests the horizontal forecasting infrastructure:
+ * - generateForecast (LLM-powered financial projections)
+ * - calculateVentureScore (scoring from forecast data)
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-J
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import { generateForecast, calculateVentureScore } from '../../lib/eva/stage-zero/modeling.js';
+
+// ── Test Data ──────────────────────────────────────────
+
+const SAMPLE_BRIEF = {
+  name: 'AutoReview AI',
+  problem_statement: 'Businesses lose revenue from unmanaged reputation signals',
+  solution: 'AI-powered review management platform',
+  target_market: 'Small businesses',
+  origin_type: 'competitor_teardown',
+  raw_chairman_intent: 'Businesses struggle to manage online reviews',
+  maturity: 'ready',
+  metadata: {
+    path: 'competitor_teardown',
+    synthesis: {
+      build_cost: { complexity: 'moderate', timeline_weeks: { realistic: 9 } },
+      archetypes: { primary_archetype: 'automator' },
+      time_horizon: { position: 'build_now' },
+    },
+  },
+};
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// ── Mock LLM Client ──────────────────────────────
+
+function createMockLLMClient(overrideResponse = null) {
+  return {
+    _model: 'mock-model',
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ text: JSON.stringify(overrideResponse || {
+          market_sizing: {
+            tam: { value: 5000000000, unit: 'USD', rationale: 'Global review management' },
+            sam: { value: 500000000, unit: 'USD', rationale: 'SMB segment' },
+            som: { value: 10000000, unit: 'USD', rationale: 'Year 3 target' },
+          },
+          revenue_projections: {
+            year_1: { optimistic: 150000, realistic: 60000, pessimistic: 15000 },
+            year_2: { optimistic: 700000, realistic: 250000, pessimistic: 80000 },
+            year_3: { optimistic: 2500000, realistic: 900000, pessimistic: 250000 },
+          },
+          unit_economics: {
+            cac: { optimistic: 12, realistic: 35, pessimistic: 75 },
+            ltv: { optimistic: 700, realistic: 400, pessimistic: 180 },
+            ltv_cac_ratio: { optimistic: 58.3, realistic: 11.4, pessimistic: 2.4 },
+            payback_months: { optimistic: 1, realistic: 4, pessimistic: 10 },
+          },
+          growth_trajectory: {
+            month_3_users: { optimistic: 300, realistic: 80, pessimistic: 15 },
+            month_6_users: { optimistic: 1500, realistic: 300, pessimistic: 60 },
+            month_12_users: { optimistic: 8000, realistic: 1200, pessimistic: 200 },
+            growth_model: 'content-led with viral referral loop',
+          },
+          break_even: {
+            months_to_break_even: { optimistic: 6, realistic: 12, pessimistic: 22 },
+            monthly_burn_at_launch: 2500,
+            monthly_burn_at_scale: 7000,
+          },
+          confidence: 72,
+          key_assumptions: ['SMBs will pay $30-80/mo for review management', 'AI accuracy exceeds 85%'],
+          summary: 'Moderate complexity venture with strong unit economics. Break-even in ~12 months realistic.',
+        }) }],
+      }),
+    },
+  };
+}
+
+// ── generateForecast Tests ──────────────────────────────
+
+describe('Modeling - generateForecast', () => {
+  test('returns complete forecast with all sections', async () => {
+    const llmClient = createMockLLMClient();
+    const result = await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient });
+
+    expect(result.component).toBe('forecast');
+    expect(result.market_sizing.tam.value).toBe(5000000000);
+    expect(result.market_sizing.sam.value).toBe(500000000);
+    expect(result.revenue_projections.year_1.realistic).toBe(60000);
+    expect(result.revenue_projections.year_2.realistic).toBe(250000);
+    expect(result.unit_economics.ltv_cac_ratio.realistic).toBe(11.4);
+    expect(result.growth_trajectory.growth_model).toContain('content-led');
+    expect(result.break_even.months_to_break_even.realistic).toBe(12);
+    expect(result.confidence).toBe(72);
+    expect(result.key_assumptions).toHaveLength(2);
+  });
+
+  test('handles LLM error gracefully', async () => {
+    const llmClient = {
+      _model: 'mock-model',
+      messages: { create: vi.fn().mockRejectedValue(new Error('Rate limited')) },
+    };
+
+    const result = await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient });
+
+    expect(result.component).toBe('forecast');
+    expect(result.confidence).toBe(0);
+    expect(result.revenue_projections.year_1.realistic).toBe(0);
+    expect(result.summary).toContain('Rate limited');
+  });
+
+  test('handles non-JSON response', async () => {
+    const llmClient = {
+      _model: 'mock-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: 'I need more information to generate projections.' }],
+        }),
+      },
+    };
+
+    const result = await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient });
+
+    expect(result.confidence).toBe(0);
+    expect(result.summary).toContain('Could not parse');
+  });
+
+  test('handles brief without synthesis metadata', async () => {
+    const briefNoSynthesis = { ...SAMPLE_BRIEF, metadata: {} };
+    const llmClient = createMockLLMClient();
+
+    const result = await generateForecast(briefNoSynthesis, { logger: silentLogger, llmClient });
+
+    expect(result.component).toBe('forecast');
+    expect(result.confidence).toBe(72);
+  });
+
+  test('handles partial LLM response', async () => {
+    const llmClient = createMockLLMClient({
+      revenue_projections: {
+        year_1: { optimistic: 100000, realistic: 50000, pessimistic: 10000 },
+      },
+      confidence: 40,
+      summary: 'Partial forecast.',
+    });
+
+    const result = await generateForecast(SAMPLE_BRIEF, { logger: silentLogger, llmClient });
+
+    expect(result.revenue_projections.year_1.realistic).toBe(50000);
+    // Missing fields get defaults
+    expect(result.market_sizing.tam.value).toBe(0);
+    expect(result.unit_economics.cac.realistic).toBe(0);
+  });
+});
+
+// ── calculateVentureScore Tests ──────────────────────────────
+
+describe('Modeling - calculateVentureScore', () => {
+  test('calculates score from realistic projections', () => {
+    const forecast = {
+      revenue_projections: {
+        year_2: { optimistic: 700000, realistic: 250000, pessimistic: 80000 },
+      },
+      unit_economics: {
+        ltv_cac_ratio: { optimistic: 58.3, realistic: 8.75, pessimistic: 2.4 },
+      },
+      break_even: {
+        months_to_break_even: { optimistic: 6, realistic: 14, pessimistic: 22 },
+      },
+      confidence: 72,
+    };
+
+    const score = calculateVentureScore(forecast);
+
+    // Revenue: (250000/250000)*35 = 35
+    // LTV/CAC: (8.75/8.75)*30 = 30
+    // Break-even: ((36-14)/22)*20 = 20
+    // Confidence: (72/100)*15 = 10.8 ≈ 11
+    expect(score).toBe(96);
+  });
+
+  test('returns 0 for null forecast', () => {
+    expect(calculateVentureScore(null)).toBe(0);
+  });
+
+  test('returns 0 for zero confidence', () => {
+    const forecast = {
+      revenue_projections: { year_2: { realistic: 100000 } },
+      unit_economics: { ltv_cac_ratio: { realistic: 5 } },
+      break_even: { months_to_break_even: { realistic: 20 } },
+      confidence: 0,
+    };
+
+    expect(calculateVentureScore(forecast)).toBe(0);
+  });
+
+  test('caps score at 100', () => {
+    const forecast = {
+      revenue_projections: { year_2: { realistic: 1000000 } },
+      unit_economics: { ltv_cac_ratio: { realistic: 50 } },
+      break_even: { months_to_break_even: { realistic: 3 } },
+      confidence: 100,
+    };
+
+    const score = calculateVentureScore(forecast);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  test('handles missing fields gracefully', () => {
+    const forecast = { confidence: 50 };
+    const score = calculateVentureScore(forecast);
+
+    // Revenue: 0, LTV/CAC: 0, Break-even: 0 (defaults to 36 → score 0), Confidence: 8
+    expect(score).toBe(8);
+  });
+
+  test('penalizes slow break-even', () => {
+    const fastBE = {
+      revenue_projections: { year_2: { realistic: 250000 } },
+      unit_economics: { ltv_cac_ratio: { realistic: 8.75 } },
+      break_even: { months_to_break_even: { realistic: 6 } },
+      confidence: 72,
+    };
+    const slowBE = {
+      ...fastBE,
+      break_even: { months_to_break_even: { realistic: 30 } },
+    };
+
+    expect(calculateVentureScore(fastBE)).toBeGreaterThan(calculateVentureScore(slowBE));
+  });
+});

--- a/test/unit/venture-nursery.test.js
+++ b/test/unit/venture-nursery.test.js
@@ -1,0 +1,419 @@
+/**
+ * Venture Nursery Tests
+ *
+ * Tests the venture nursery and feedback loop:
+ * - parkVenture
+ * - reactivateVenture
+ * - recordSynthesisFeedback
+ * - checkNurseryTriggers
+ * - getNurseryHealth
+ *
+ * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-I
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  parkVenture,
+  reactivateVenture,
+  recordSynthesisFeedback,
+  checkNurseryTriggers,
+  getNurseryHealth,
+} from '../../lib/eva/stage-zero/venture-nursery.js';
+
+// ── Test Data ──────────────────────────────────────────
+
+const SAMPLE_BRIEF = {
+  name: 'FutureTech AI',
+  problem_statement: 'Market not ready for quantum computing tools',
+  solution: 'Quantum-aware optimization platform',
+  target_market: 'Enterprise R&D departments',
+  origin_type: 'discovery',
+  raw_chairman_intent: 'Quantum computing tools for enterprise',
+  maturity: 'seed',
+  metadata: {
+    synthesis: {
+      time_horizon: { position: 'park_and_build_later' },
+      archetypes: { primary_archetype: 'first_principles_rebuilder' },
+    },
+  },
+};
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// ── Mock Supabase Factory ──────────────────────────────
+
+function createMockSupabase(options = {}) {
+  const {
+    insertResult = { id: 'nursery-1', name: SAMPLE_BRIEF.name, status: 'parked' },
+    insertError = null,
+    selectResult = null,
+    selectError = null,
+    updateResult = null,
+    updateError = null,
+    listResult = [],
+    listError = null,
+  } = options;
+
+  return {
+    from: vi.fn().mockImplementation((_table) => {
+      const chainable = {
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: insertError ? null : insertResult,
+              error: insertError,
+            }),
+          }),
+        }),
+        select: vi.fn().mockImplementation(() => ({
+          eq: vi.fn().mockImplementation(() => ({
+            single: vi.fn().mockResolvedValue({
+              data: selectError ? null : selectResult,
+              error: selectError,
+            }),
+            order: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({
+                data: listError ? null : listResult,
+                error: listError,
+              }),
+            }),
+          })),
+          order: vi.fn().mockReturnValue({
+            data: listResult,
+            error: listError,
+            then: (fn) => Promise.resolve(fn({ data: listError ? null : listResult, error: listError })),
+          }),
+        })),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: updateError ? null : (updateResult || { ...selectResult, status: 'reactivated' }),
+                error: updateError,
+              }),
+            }),
+          }),
+        }),
+      };
+      return chainable;
+    }),
+  };
+}
+
+// ── parkVenture Tests ──────────────────────────────
+
+describe('Venture Nursery - parkVenture', () => {
+  test('requires supabase', async () => {
+    await expect(
+      parkVenture(SAMPLE_BRIEF, { reason: 'Not ready' }, { logger: silentLogger })
+    ).rejects.toThrow('supabase client is required');
+  });
+
+  test('requires reason', async () => {
+    const supabase = createMockSupabase();
+    await expect(
+      parkVenture(SAMPLE_BRIEF, {}, { supabase, logger: silentLogger })
+    ).rejects.toThrow('reason is required');
+  });
+
+  test('parks venture with trigger conditions', async () => {
+    const supabase = createMockSupabase({
+      insertResult: {
+        id: 'nursery-1',
+        name: 'FutureTech AI',
+        status: 'parked',
+        maturity: 'seed',
+      },
+    });
+
+    const result = await parkVenture(
+      SAMPLE_BRIEF,
+      {
+        reason: 'Market not ready',
+        triggerConditions: ['Quantum hardware costs drop 50%', 'First enterprise quantum deployment'],
+        reviewSchedule: '90d',
+      },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.id).toBe('nursery-1');
+    expect(result.status).toBe('parked');
+
+    // Verify supabase was called correctly
+    const insertCall = supabase.from.mock.results[0].value.insert;
+    expect(insertCall).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'FutureTech AI',
+      status: 'parked',
+      maturity: 'seed',
+      parked_reason: 'Market not ready',
+    }));
+  });
+
+  test('handles database error', async () => {
+    const supabase = createMockSupabase({
+      insertError: { message: 'Connection refused' },
+    });
+
+    await expect(
+      parkVenture(SAMPLE_BRIEF, { reason: 'Test' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('Failed to park venture: Connection refused');
+  });
+
+  test('defaults to 90d review schedule', async () => {
+    const supabase = createMockSupabase();
+
+    await parkVenture(
+      SAMPLE_BRIEF,
+      { reason: 'Too early' },
+      { supabase, logger: silentLogger }
+    );
+
+    const insertCall = supabase.from.mock.results[0].value.insert;
+    const insertArg = insertCall.mock.calls[0][0];
+    expect(insertArg.metadata.review_schedule).toBe('90d');
+    expect(insertArg.metadata.next_review_date).toBeDefined();
+  });
+});
+
+// ── reactivateVenture Tests ──────────────────────────────
+
+describe('Venture Nursery - reactivateVenture', () => {
+  test('requires supabase', async () => {
+    await expect(
+      reactivateVenture('id-1', { reason: 'Market changed' }, { logger: silentLogger })
+    ).rejects.toThrow('supabase client is required');
+  });
+
+  test('requires nurseryId', async () => {
+    const supabase = createMockSupabase();
+    await expect(
+      reactivateVenture(null, { reason: 'Test' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('nurseryId is required');
+  });
+
+  test('requires reason', async () => {
+    const supabase = createMockSupabase();
+    await expect(
+      reactivateVenture('id-1', {}, { supabase, logger: silentLogger })
+    ).rejects.toThrow('reason is required');
+  });
+
+  test('reactivates parked venture with path output', async () => {
+    const supabase = createMockSupabase({
+      selectResult: {
+        id: 'nursery-1',
+        name: 'FutureTech AI',
+        problem_statement: 'Quantum tools',
+        solution: 'Platform',
+        target_market: 'Enterprise',
+        origin_type: 'discovery',
+        status: 'parked',
+        metadata: { synthesis_snapshot: { archetypes: { primary: 'rebuilder' } }, trigger_conditions: ['Cost drop'] },
+      },
+      updateResult: {
+        id: 'nursery-1',
+        name: 'FutureTech AI',
+        status: 'reactivated',
+        metadata: {},
+      },
+    });
+
+    const result = await reactivateVenture(
+      'nursery-1',
+      { reason: 'Quantum costs dropped', updatedContext: { new_cost: 'half' } },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.entry.status).toBe('reactivated');
+    expect(result.pathOutput.origin_type).toBe('discovery');
+    expect(result.pathOutput.suggested_name).toBe('FutureTech AI');
+    expect(result.pathOutput.metadata.path).toBe('nursery_reeval');
+    expect(result.pathOutput.raw_material.nursery_id).toBe('nursery-1');
+  });
+
+  test('rejects already reactivated venture', async () => {
+    const supabase = createMockSupabase({
+      selectResult: {
+        id: 'nursery-1',
+        name: 'FutureTech AI',
+        status: 'reactivated',
+        metadata: {},
+      },
+    });
+
+    await expect(
+      reactivateVenture('nursery-1', { reason: 'Again' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('already reactivated');
+  });
+
+  test('handles missing nursery entry', async () => {
+    const supabase = createMockSupabase({
+      selectError: { message: 'Not found' },
+    });
+
+    await expect(
+      reactivateVenture('missing-id', { reason: 'Test' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('Nursery entry not found');
+  });
+});
+
+// ── recordSynthesisFeedback Tests ──────────────────────────────
+
+describe('Venture Nursery - recordSynthesisFeedback', () => {
+  test('requires supabase', async () => {
+    await expect(
+      recordSynthesisFeedback({ ventureId: 'v1', outcome: 'approved' }, { logger: silentLogger })
+    ).rejects.toThrow('supabase client is required');
+  });
+
+  test('requires ventureId and outcome', async () => {
+    const supabase = createMockSupabase();
+    await expect(
+      recordSynthesisFeedback({ outcome: 'approved' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('ventureId is required');
+
+    await expect(
+      recordSynthesisFeedback({ ventureId: 'v1' }, { supabase, logger: silentLogger })
+    ).rejects.toThrow('outcome is required');
+  });
+
+  test('validates outcome values', async () => {
+    const supabase = createMockSupabase();
+    await expect(
+      recordSynthesisFeedback(
+        { ventureId: 'v1', outcome: 'invalid' },
+        { supabase, logger: silentLogger }
+      )
+    ).rejects.toThrow('Invalid outcome');
+  });
+
+  test('records approved feedback', async () => {
+    const supabase = createMockSupabase({
+      insertResult: { id: 'fb-1', venture_id: 'v1', outcome: 'approved' },
+    });
+
+    const result = await recordSynthesisFeedback(
+      {
+        ventureId: 'v1',
+        outcome: 'approved',
+        synthesisData: { moat_score: 82 },
+        lessons: ['Data moat worked well'],
+      },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.id).toBe('fb-1');
+    expect(result.outcome).toBe('approved');
+  });
+
+  test('records parked feedback', async () => {
+    const supabase = createMockSupabase({
+      insertResult: { id: 'fb-2', venture_id: 'v1', outcome: 'parked' },
+    });
+
+    const result = await recordSynthesisFeedback(
+      { ventureId: 'v1', outcome: 'parked' },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.outcome).toBe('parked');
+  });
+});
+
+// ── checkNurseryTriggers Tests ──────────────────────────────
+
+describe('Venture Nursery - checkNurseryTriggers', () => {
+  test('requires supabase', async () => {
+    await expect(checkNurseryTriggers({ logger: silentLogger })).rejects.toThrow('supabase client is required');
+  });
+
+  test('returns empty when no parked items', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await checkNurseryTriggers({ supabase, logger: silentLogger });
+    expect(result).toHaveLength(0);
+  });
+
+  test('identifies items past review date', async () => {
+    const pastDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    const futureDate = new Date(Date.now() + 100 * 24 * 60 * 60 * 1000).toISOString();
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({
+              data: [
+                { id: 'n1', name: 'Ready', status: 'parked', metadata: { next_review_date: pastDate, trigger_conditions: ['Market shift'] } },
+                { id: 'n2', name: 'NotReady', status: 'parked', metadata: { next_review_date: futureDate, trigger_conditions: [] } },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await checkNurseryTriggers({ supabase, logger: silentLogger });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('n1');
+    expect(result[0].reason).toBe('scheduled_review');
+  });
+});
+
+// ── getNurseryHealth Tests ──────────────────────────────
+
+describe('Venture Nursery - getNurseryHealth', () => {
+  test('requires supabase', async () => {
+    await expect(getNurseryHealth({})).rejects.toThrow('supabase client is required');
+  });
+
+  test('returns empty health for no items', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    };
+
+    const health = await getNurseryHealth({ supabase });
+    expect(health.total).toBe(0);
+    expect(health.parked).toBe(0);
+    expect(health.stale).toBe(0);
+  });
+
+  test('calculates health metrics correctly', async () => {
+    const now = new Date();
+    const recentDate = new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString(); // 30 days ago
+    const oldDate = new Date(now - 200 * 24 * 60 * 60 * 1000).toISOString(); // 200 days ago
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockResolvedValue({
+          data: [
+            { id: 'n1', name: 'Fresh', status: 'parked', maturity: 'seed', metadata: { trigger_conditions: ['X'] }, created_at: recentDate },
+            { id: 'n2', name: 'Stale', status: 'parked', maturity: 'sprout', metadata: {}, created_at: oldDate },
+            { id: 'n3', name: 'Active', status: 'reactivated', maturity: 'seed', metadata: {}, created_at: recentDate },
+          ],
+          error: null,
+        }),
+      }),
+    };
+
+    const health = await getNurseryHealth({ supabase });
+    expect(health.total).toBe(3);
+    expect(health.parked).toBe(2);
+    expect(health.reactivated).toBe(1);
+    expect(health.stale).toBe(1); // n2 is >180 days old
+    expect(health.items).toHaveLength(3);
+    expect(health.items[0].has_triggers).toBe(true);
+    expect(health.items[1].has_triggers).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Modeling module (Child J): LLM-powered horizontal forecasting with market sizing (TAM/SAM/SOM), 3-year revenue projections, unit economics (CAC/LTV/payback), growth trajectory, break-even analysis, and calculateVentureScore for pipeline comparison
- Venture nursery (Child I): Park/reactivate workflow with trigger conditions, scheduled review dates, synthesis feedback recording for future cross-referencing, nursery health monitoring (stale item detection)
- 33 new tests (11 modeling + 22 nursery), all 126 Stage 0 tests passing

## Test plan
- [x] 11 modeling tests passing (forecast generation, scoring, edge cases)
- [x] 22 nursery tests passing (park, reactivate, feedback, triggers, health)
- [x] 93 prior Stage 0 tests still passing (synthesis, discovery, paths)
- [x] 15 smoke tests passing
- [x] All error handling paths tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)