### PR TITLE
fix(eva): wire Stage 0 integration gaps and harden PRD generation

### DIFF
--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -10,6 +10,7 @@
  */
 
 import { validateVentureBrief } from './interfaces.js';
+import { parkVenture } from './venture-nursery.js';
 
 /**
  * Present brief to the chairman and process their decision.
@@ -47,9 +48,9 @@ export async function conductChairmanReview(brief, deps = {}) {
   }
   logger.log('   ' + '─'.repeat(50));
 
-  // In non-interactive mode, auto-approve with the brief as-is
-  // Interactive mode (Child B full implementation) will present edit/approve/nursery options
-  const decision = brief.maturity || 'ready';
+  // Map maturity to decision: blocked/nursery → park, everything else → direct maturity
+  const maturity = brief.maturity || 'ready';
+  const decision = (maturity === 'blocked' || maturity === 'nursery') ? 'park' : maturity;
 
   // Validate the brief before proceeding
   const validation = validateVentureBrief({
@@ -58,11 +59,11 @@ export async function conductChairmanReview(brief, deps = {}) {
   });
 
   return {
-    decision, // 'ready' | 'seed' | 'sprout'
+    decision, // 'ready' | 'seed' | 'sprout' | 'park'
     brief: {
       ...brief,
       raw_chairman_intent: rawChairmanIntent,
-      maturity: decision,
+      maturity,
     },
     validation,
     reviewed_at: new Date().toISOString(),
@@ -133,32 +134,18 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
     return venture;
   }
 
-  // Park in Venture Nursery (seed or sprout)
-  const { data: nurseryEntry, error } = await supabase
-    .from('venture_nursery')
-    .insert({
-      name: brief.name,
-      problem_statement: brief.problem_statement,
-      solution: brief.solution,
-      target_market: brief.target_market,
-      origin_type: brief.origin_type,
-      raw_chairman_intent: brief.raw_chairman_intent,
-      maturity: decision,
-      archetype: brief.archetype,
-      moat_strategy: brief.moat_strategy,
-      metadata: {
-        stage_zero_brief: brief,
-      },
-    })
-    .select()
-    .single();
+  // Park in Venture Nursery via parkVenture() for proper trigger/review tracking
+  const parkReason = buildParkReason(brief);
+  const triggerConditions = brief.metadata?.synthesis?.chairman_constraints?.conditions || [];
+  const reviewSchedule = brief.maturity === 'blocked' ? '30d' : '90d';
 
-  if (error) {
-    throw new Error(`Failed to create nursery entry: ${error.message}`);
-  }
+  const nurseryEntry = await parkVenture(
+    brief,
+    { reason: parkReason, triggerConditions, reviewSchedule },
+    { supabase, logger }
+  );
 
-  logger.log(`   Nursery entry created: ${nurseryEntry.id}`);
-  logger.log(`   Maturity: ${decision}`);
+  logger.log(`   Maturity: ${brief.maturity}`);
 
   return nurseryEntry;
 }
@@ -200,4 +187,19 @@ async function persistBriefRecord(brief, ventureId, deps) {
   if (error) {
     logger.warn(`   Warning: Failed to create brief record: ${error.message}`);
   }
+}
+
+/**
+ * Build a human-readable parking reason from brief metadata.
+ */
+function buildParkReason(brief) {
+  if (brief.maturity === 'blocked') {
+    const verdict = brief.metadata?.synthesis?.chairman_constraints?.summary;
+    return verdict ? `Chairman constraints failed: ${verdict}` : 'Failed chairman constraint checks';
+  }
+  if (brief.maturity === 'nursery') {
+    const horizon = brief.metadata?.synthesis?.time_horizon?.summary;
+    return horizon ? `Time horizon: ${horizon}` : 'Time horizon: park and build later';
+  }
+  return `Early maturity stage: ${brief.maturity}`;
 }

--- a/lib/eva/stage-zero/index.js
+++ b/lib/eva/stage-zero/index.js
@@ -29,3 +29,15 @@ export {
   validateVentureBrief,
   createPathOutput,
 } from './interfaces.js';
+
+export { runSynthesis } from './synthesis/index.js';
+
+export { generateForecast, calculateVentureScore } from './modeling.js';
+
+export {
+  parkVenture,
+  reactivateVenture,
+  recordSynthesisFeedback,
+  checkNurseryTriggers,
+  getNurseryHealth,
+} from './venture-nursery.js';

--- a/lib/eva/stage-zero/interfaces.js
+++ b/lib/eva/stage-zero/interfaces.js
@@ -43,7 +43,7 @@ export function validatePathOutput(output) {
   }
 
   // Validate origin_type enum
-  const validOrigins = ['competitor_teardown', 'blueprint', 'discovery', 'manual'];
+  const validOrigins = ['competitor_teardown', 'blueprint', 'discovery', 'manual', 'nursery_reeval'];
   if (output.origin_type && !validOrigins.includes(output.origin_type)) {
     errors.push(`origin_type must be one of: ${validOrigins.join(', ')}`);
   }
@@ -106,7 +106,7 @@ export function validateVentureBrief(brief) {
   }
 
   // maturity determines where the venture goes
-  const validMaturities = ['ready', 'seed', 'sprout'];
+  const validMaturities = ['ready', 'seed', 'sprout', 'blocked', 'nursery'];
   if (brief.maturity && !validMaturities.includes(brief.maturity)) {
     errors.push(`maturity must be one of: ${validMaturities.join(', ')}`);
   }

--- a/lib/eva/stage-zero/stage-zero-orchestrator.js
+++ b/lib/eva/stage-zero/stage-zero-orchestrator.js
@@ -14,8 +14,8 @@
 
 import { routePath, ENTRY_PATHS, PATH_OPTIONS, listDiscoveryStrategies } from './path-router.js';
 import { conductChairmanReview, persistVentureBrief } from './chairman-review.js';
-// Interfaces used by path router and chairman review (re-exported for consumers)
-// import { validatePathOutput, validateVentureBrief } from './interfaces.js';
+import { runSynthesis } from './synthesis/index.js';
+import { generateForecast, calculateVentureScore } from './modeling.js';
 
 /**
  * Execute the full Stage 0 flow.
@@ -64,13 +64,29 @@ export async function executeStageZero(params, deps = {}) {
 
   // Step 2: Run synthesis (enriches path output with cross-references, portfolio context, etc.)
   let synthesisResult;
-  if (!options.skipSynthesis && synthesize) {
+  const synthesizeFn = synthesize || runSynthesis;
+  if (!options.skipSynthesis) {
     logger.log('\n   Running synthesis...');
-    synthesisResult = await synthesize(pathOutput, deps);
+    synthesisResult = await synthesizeFn(pathOutput, deps);
   } else {
-    // Default: pass through path output as-is
-    // Full synthesis implementation in Children F/G/H
     synthesisResult = buildDefaultBrief(pathOutput);
+  }
+
+  // Step 2b: Run horizontal forecast (financial projections)
+  if (!options.skipSynthesis) {
+    try {
+      logger.log('\n   Generating financial forecast...');
+      const forecast = await generateForecast(synthesisResult, deps);
+      const score = calculateVentureScore(forecast);
+      synthesisResult.metadata = {
+        ...synthesisResult.metadata,
+        forecast,
+        venture_score: score,
+      };
+      logger.log(`   Venture score: ${score}/100`);
+    } catch (err) {
+      logger.warn(`   Warning: Forecast generation failed: ${err.message}`);
+    }
   }
 
   // Step 3: Chairman review


### PR DESCRIPTION
## Summary
- Wire `runSynthesis` as default synthesize function in Stage 0 orchestrator (was only used if explicitly injected)
- Replace direct `venture_nursery` DB inserts in chairman review with `parkVenture()` for proper trigger conditions, review schedules, and next-review dates
- Add `blocked` and `nursery` to valid maturities, `nursery_reeval` to valid origins in interfaces
- Re-export synthesis engine, modeling, and venture nursery from barrel `index.js`
- Wire `generateForecast` + `calculateVentureScore` into orchestrator pipeline between synthesis and chairman review
- Harden detached PRD generation: file-based logging replaces `stdio: 'ignore'`, 90-second post-spawn verification polling, error reporting with last 10 log lines

## Test plan
- [x] 63 unit tests pass (30 stage-zero, 22 venture-nursery, 11 modeling)
- [x] Smoke tests pass (15 tests)
- [x] New tests for `blocked`/`nursery` maturity mapping to `park` decision
- [x] New tests for `nursery_reeval` origin type validation
- [x] Existing orchestrator tests updated for default synthesis wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)