### PR TITLE
feat(eva): add virality synthesis component (Component 9)

### DIFF
--- a/lib/eva/stage-zero/synthesis/index.js
+++ b/lib/eva/stage-zero/synthesis/index.js
@@ -1,7 +1,7 @@
 /**
  * Stage 0 Synthesis Engine
  *
- * Runs all 8 synthesis components on a PathOutput to enrich it
+ * Runs all 9 synthesis components on a PathOutput to enrich it
  * before chairman review. Optionally applies an evaluation profile
  * for weighted scoring.
  *
@@ -19,6 +19,9 @@
  * 7. Venture Archetype Recognition
  * 8. Build Cost Estimation
  *
+ * Component 9 (SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-A):
+ * 9. Virality Analysis
+ *
  * Profile System (SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-B):
  * - Resolves evaluation profile (explicit, active, or legacy defaults)
  * - Calculates weighted venture score from component results
@@ -35,10 +38,11 @@ import { applyChairmanConstraints } from './chairman-constraints.js';
 import { assessTimeHorizon } from './time-horizon.js';
 import { classifyArchetype } from './archetypes.js';
 import { estimateBuildCost } from './build-cost-estimation.js';
+import { analyzeVirality } from './virality.js';
 import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 
 /**
- * Run all 8 synthesis components on a PathOutput.
+ * Run all 9 synthesis components on a PathOutput.
  *
  * @param {Object} pathOutput - PathOutput from entry path
  * @param {Object} deps - Injected dependencies
@@ -51,7 +55,7 @@ import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 export async function runSynthesis(pathOutput, deps = {}) {
   const { logger = console, profileId } = deps;
 
-  logger.log('   Running synthesis engine (8/8 components)...');
+  logger.log('   Running synthesis engine (9/9 components)...');
 
   // Resolve evaluation profile (parallel with component execution)
   const profilePromise = resolveProfile(deps, profileId).catch(err => {
@@ -59,10 +63,10 @@ export async function runSynthesis(pathOutput, deps = {}) {
     return null;
   });
 
-  // Run all 8 components - grouped by dependency
-  // Group 1 (no inter-dependencies): components 1-4, 6-8
+  // Run all 9 components - grouped by dependency
+  // Group 1 (no inter-dependencies): components 1-4, 6-9
   // Group 2 (depends on nothing but run separately): component 5 (chairman constraints)
-  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost] = await Promise.all([
+  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality] = await Promise.all([
     crossReferenceIntellectualCapital(pathOutput, deps).catch(err => {
       logger.warn(`   Warning: Cross-reference failed: ${err.message}`);
       return { component: 'cross_reference', matches: [], lessons: [], relevance_score: 0, summary: `Failed: ${err.message}` };
@@ -91,6 +95,10 @@ export async function runSynthesis(pathOutput, deps = {}) {
       logger.warn(`   Warning: Build cost estimation failed: ${err.message}`);
       return { component: 'build_cost', complexity: 'moderate', summary: `Failed: ${err.message}` };
     }),
+    analyzeVirality(pathOutput, deps).catch(err => {
+      logger.warn(`   Warning: Virality analysis failed: ${err.message}`);
+      return { component: 'virality_analysis', virality_score: 0, k_factor: 0, cycle_time_days: 0, mechanic_type: 'word_of_mouth', channel_fit: 0, shareability: 0, decay_rate: 0, organic_ratio: 0, growth_loops: [], viral_channels: [], compounding_factors: '', risks: [], summary: `Failed: ${err.message}` };
+    }),
   ]);
 
   // Chairman constraints run after others (uses pathOutput directly, no inter-dependency)
@@ -112,6 +120,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
     time_horizon: timeHorizon,
     archetypes: archetype,
     build_cost: buildCost,
+    virality: virality,
   };
 
   let profileMetadata = null;
@@ -129,7 +138,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
     logger.log(`   Profile: ${profile.name} v${profile.version} (${profile.source}) → weighted score: ${scoreResult.total_score}/100`);
   }
 
-  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}`);
+  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}, virality=${virality.virality_score || 0}`);
 
   // Build enriched brief
   const recommendedProblem = reframing.recommended_framing?.framing || pathOutput.suggested_problem;
@@ -161,8 +170,9 @@ export async function runSynthesis(pathOutput, deps = {}) {
         time_horizon: timeHorizon,
         archetypes: archetype,
         build_cost: buildCost,
-        components_run: 8,
-        components_total: 8,
+        virality: virality,
+        components_run: 9,
+        components_total: 9,
         profile: profileMetadata,
         weighted_score: weightedScore,
       },
@@ -179,4 +189,5 @@ export {
   assessTimeHorizon,
   classifyArchetype,
   estimateBuildCost,
+  analyzeVirality,
 };

--- a/lib/eva/stage-zero/synthesis/virality.js
+++ b/lib/eva/stage-zero/synthesis/virality.js
@@ -1,0 +1,179 @@
+/**
+ * Synthesis Component 9: Virality Analysis
+ *
+ * Evaluates venture candidates for viral growth potential across 7 dimensions:
+ * - K-factor: Expected viral coefficient (users brought per user)
+ * - Cycle time: Days for one viral loop to complete
+ * - Mechanic type: inherent | manufactured | word_of_mouth | incentivized
+ * - Channel fit: How well the product fits viral distribution channels (0-100)
+ * - Shareability: How naturally the product gets shared (0-100)
+ * - Decay rate: How quickly viral momentum fades (0-1, lower is better)
+ * - Organic ratio: Proportion of growth that's organic vs paid (0-1)
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-A
+ */
+
+import { getValidationClient } from '../../../llm/client-factory.js';
+
+const MECHANIC_TYPES = ['inherent', 'manufactured', 'word_of_mouth', 'incentivized'];
+
+/**
+ * Analyze virality potential for a venture candidate.
+ *
+ * @param {Object} pathOutput - PathOutput from entry path
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} [deps.logger] - Logger
+ * @param {Object} [deps.llmClient] - LLM client override (for testing)
+ * @returns {Promise<Object>} Virality analysis result
+ */
+export async function analyzeVirality(pathOutput, deps = {}) {
+  const { logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+
+  logger.log('   Analyzing virality potential...');
+
+  const prompt = `You are an EHG growth analyst. Evaluate the viral potential of this venture.
+
+VENTURE:
+Name: ${pathOutput.suggested_name}
+Problem: ${pathOutput.suggested_problem}
+Solution: ${pathOutput.suggested_solution}
+Market: ${pathOutput.target_market}
+
+EHG Chairman Directives:
+- Viral potential is a key evaluation factor
+- Prefer ventures with inherent virality over manufactured
+- Data collection and network effects compound virality
+- Narrow niche virality is more valuable than broad shallow virality
+
+Evaluate across 7 dimensions:
+
+1. K-factor (0-10): How many new users does each user bring?
+   - <1 = decaying, 1 = stable, >1 = growing, >3 = exceptional
+2. Cycle time (days): How long for one viral loop?
+   - <1 day = instant (social), 1-7 = fast, 7-30 = moderate, >30 = slow
+3. Mechanic type: Primary viral mechanic
+   - inherent: Product requires sharing to function (e.g., messaging)
+   - manufactured: Built-in sharing features (e.g., referral program)
+   - word_of_mouth: Quality drives organic discussion
+   - incentivized: Rewards for sharing (e.g., discounts)
+4. Channel fit (0-100): How well does this fit viral channels?
+5. Shareability (0-100): How naturally does this get shared?
+6. Decay rate (0-1): How quickly does viral momentum fade? (lower = better)
+7. Organic ratio (0-1): What fraction of growth is organic? (higher = better)
+
+Return JSON:
+{
+  "k_factor": 1.5,
+  "cycle_time_days": 7,
+  "mechanic_type": "word_of_mouth",
+  "channel_fit": 65,
+  "shareability": 70,
+  "decay_rate": 0.3,
+  "organic_ratio": 0.6,
+  "virality_score": 62,
+  "growth_loops": [{"name": "string", "description": "string", "strength": 75}],
+  "viral_channels": ["string"],
+  "compounding_factors": "string (how virality compounds with data/network effects)",
+  "risks": ["string"],
+  "summary": "string (2-3 sentences)"
+}`;
+
+  try {
+    const response = await client.messages.create({
+      model: client._model || 'claude-sonnet-4-5-20250929',
+      max_tokens: 1500,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = response.content[0]?.text || '';
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const analysis = JSON.parse(jsonMatch[0]);
+      return {
+        component: 'virality_analysis',
+        k_factor: clamp(analysis.k_factor ?? 0, 0, 10),
+        cycle_time_days: Math.max(0, analysis.cycle_time_days ?? 30),
+        mechanic_type: MECHANIC_TYPES.includes(analysis.mechanic_type) ? analysis.mechanic_type : 'word_of_mouth',
+        channel_fit: clamp(analysis.channel_fit ?? 0, 0, 100),
+        shareability: clamp(analysis.shareability ?? 0, 0, 100),
+        decay_rate: clamp(analysis.decay_rate ?? 0.5, 0, 1),
+        organic_ratio: clamp(analysis.organic_ratio ?? 0.5, 0, 1),
+        virality_score: clamp(analysis.virality_score ?? calculateViralityScore(analysis), 0, 100),
+        growth_loops: analysis.growth_loops || [],
+        viral_channels: analysis.viral_channels || [],
+        compounding_factors: analysis.compounding_factors || '',
+        risks: analysis.risks || [],
+        summary: analysis.summary || '',
+      };
+    }
+    return defaultViralityResult('Could not parse virality analysis');
+  } catch (err) {
+    logger.warn(`   Warning: Virality analysis failed: ${err.message}`);
+    return defaultViralityResult(`Analysis failed: ${err.message}`);
+  }
+}
+
+/**
+ * Calculate virality score from sub-dimensions when LLM doesn't provide one.
+ *
+ * Weighted formula:
+ * - K-factor: 30% (normalized to 0-100 from 0-10 scale)
+ * - Shareability: 20%
+ * - Channel fit: 15%
+ * - Organic ratio: 15% (scaled to 0-100)
+ * - Cycle time: 10% (inverse - shorter is better)
+ * - Decay rate: 10% (inverse - lower is better)
+ *
+ * @param {Object} dims - Sub-dimension values
+ * @returns {number} Score 0-100
+ */
+export function calculateViralityScore(dims) {
+  if (!dims) return 0;
+
+  const kScore = clamp((dims.k_factor ?? 0) / 10 * 100, 0, 100);
+  const shareScore = clamp(dims.shareability ?? 0, 0, 100);
+  const channelScore = clamp(dims.channel_fit ?? 0, 0, 100);
+  const organicScore = clamp((dims.organic_ratio ?? 0) * 100, 0, 100);
+
+  // Cycle time: <1 day = 100, 30+ days = 0
+  const cycleTime = dims.cycle_time_days ?? 30;
+  const cycleScore = cycleTime >= 30 ? 0 : Math.round(((30 - cycleTime) / 30) * 100);
+
+  // Decay rate: 0 = 100 (no decay), 1 = 0 (instant decay)
+  const decayScore = Math.round((1 - clamp(dims.decay_rate ?? 0.5, 0, 1)) * 100);
+
+  return Math.round(
+    kScore * 0.30 +
+    shareScore * 0.20 +
+    channelScore * 0.15 +
+    organicScore * 0.15 +
+    cycleScore * 0.10 +
+    decayScore * 0.10
+  );
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function defaultViralityResult(summary) {
+  return {
+    component: 'virality_analysis',
+    k_factor: 0,
+    cycle_time_days: 0,
+    mechanic_type: 'word_of_mouth',
+    channel_fit: 0,
+    shareability: 0,
+    decay_rate: 0,
+    organic_ratio: 0,
+    virality_score: 0,
+    growth_loops: [],
+    viral_channels: [],
+    compounding_factors: '',
+    risks: [],
+    summary,
+  };
+}
+
+export { MECHANIC_TYPES };

--- a/tests/unit/eva/stage-zero/synthesis/virality.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/virality.test.js
@@ -1,0 +1,210 @@
+/**
+ * Unit Tests: Virality Synthesis Component (Component 9)
+ * SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-A
+ *
+ * Test Coverage:
+ * - Successful LLM response parsing
+ * - LLM failure fallback to defaults
+ * - Score calculation from sub-dimensions
+ * - All 7 sub-dimensions present in output
+ * - Component field validation
+ * - Clamping of out-of-range values
+ * - Invalid mechanic type handling
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import { analyzeVirality, calculateViralityScore, MECHANIC_TYPES } from '../../../../../lib/eva/stage-zero/synthesis/virality.js';
+
+const mockPathOutput = {
+  suggested_name: 'TestVenture',
+  suggested_problem: 'Users need better collaboration tools',
+  suggested_solution: 'AI-powered team workspace with built-in sharing',
+  target_market: 'Remote teams at SMBs',
+  origin_type: 'discovery',
+  competitor_urls: [],
+  blueprint_id: null,
+  discovery_strategy: null,
+  metadata: {},
+};
+
+const validLLMResponse = {
+  k_factor: 2.5,
+  cycle_time_days: 3,
+  mechanic_type: 'inherent',
+  channel_fit: 75,
+  shareability: 80,
+  decay_rate: 0.2,
+  organic_ratio: 0.7,
+  virality_score: 72,
+  growth_loops: [{ name: 'Team invite', description: 'Users invite teammates', strength: 85 }],
+  viral_channels: ['email', 'slack'],
+  compounding_factors: 'Network effects compound as more teams join',
+  risks: ['Requires critical mass per team'],
+  summary: 'Strong inherent virality through team collaboration mechanics.',
+};
+
+function createMockLLMClient(responseJson) {
+  return {
+    _model: 'test-model',
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ text: JSON.stringify(responseJson) }],
+      }),
+    },
+  };
+}
+
+function createFailingLLMClient(errorMessage) {
+  return {
+    _model: 'test-model',
+    messages: {
+      create: vi.fn().mockRejectedValue(new Error(errorMessage)),
+    },
+  };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn() };
+
+describe('analyzeVirality', () => {
+  test('parses valid LLM response with all sub-dimensions', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeVirality(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('virality_analysis');
+    expect(result.k_factor).toBe(2.5);
+    expect(result.cycle_time_days).toBe(3);
+    expect(result.mechanic_type).toBe('inherent');
+    expect(result.channel_fit).toBe(75);
+    expect(result.shareability).toBe(80);
+    expect(result.decay_rate).toBe(0.2);
+    expect(result.organic_ratio).toBe(0.7);
+    expect(result.virality_score).toBe(72);
+    expect(result.growth_loops).toHaveLength(1);
+    expect(result.viral_channels).toEqual(['email', 'slack']);
+    expect(result.summary).toBeTruthy();
+  });
+
+  test('returns default result when LLM fails', async () => {
+    const client = createFailingLLMClient('API unavailable');
+    const result = await analyzeVirality(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('virality_analysis');
+    expect(result.virality_score).toBe(0);
+    expect(result.k_factor).toBe(0);
+    expect(result.cycle_time_days).toBe(0);
+    expect(result.shareability).toBe(0);
+    expect(result.channel_fit).toBe(0);
+    expect(result.decay_rate).toBe(0);
+    expect(result.organic_ratio).toBe(0);
+    expect(result.growth_loops).toEqual([]);
+    expect(result.viral_channels).toEqual([]);
+    expect(result.summary).toContain('Analysis failed');
+  });
+
+  test('returns default result when LLM returns unparseable text', async () => {
+    const client = {
+      _model: 'test-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: 'I cannot analyze this venture in JSON format.' }],
+        }),
+      },
+    };
+    const result = await analyzeVirality(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('virality_analysis');
+    expect(result.virality_score).toBe(0);
+    expect(result.summary).toContain('Could not parse');
+  });
+
+  test('clamps out-of-range values', async () => {
+    const outOfRange = {
+      ...validLLMResponse,
+      k_factor: 15,        // max 10
+      channel_fit: 150,     // max 100
+      shareability: -20,    // min 0
+      decay_rate: 2.0,      // max 1
+      organic_ratio: -0.5,  // min 0
+      virality_score: 120,  // max 100
+    };
+    const client = createMockLLMClient(outOfRange);
+    const result = await analyzeVirality(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.k_factor).toBe(10);
+    expect(result.channel_fit).toBe(100);
+    expect(result.shareability).toBe(0);
+    expect(result.decay_rate).toBe(1);
+    expect(result.organic_ratio).toBe(0);
+    expect(result.virality_score).toBe(100);
+  });
+
+  test('defaults invalid mechanic_type to word_of_mouth', async () => {
+    const badMechanic = { ...validLLMResponse, mechanic_type: 'nonexistent_type' };
+    const client = createMockLLMClient(badMechanic);
+    const result = await analyzeVirality(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.mechanic_type).toBe('word_of_mouth');
+  });
+
+  test('has all 7 required sub-dimensions', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeVirality(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    const requiredFields = ['k_factor', 'cycle_time_days', 'mechanic_type', 'channel_fit', 'shareability', 'decay_rate', 'organic_ratio'];
+    for (const field of requiredFields) {
+      expect(result).toHaveProperty(field);
+    }
+  });
+});
+
+describe('calculateViralityScore', () => {
+  test('returns 0 for null input', () => {
+    expect(calculateViralityScore(null)).toBe(0);
+  });
+
+  test('returns near-zero for empty input', () => {
+    // Empty object uses default decay_rate=0.5 → (1-0.5)*100*0.10 = 5
+    expect(calculateViralityScore({})).toBe(5);
+  });
+
+  test('calculates weighted score correctly', () => {
+    const dims = {
+      k_factor: 5,           // 50/100 * 0.30 = 15
+      shareability: 80,      // 80/100 * 0.20 = 16
+      channel_fit: 60,       // 60/100 * 0.15 = 9
+      organic_ratio: 0.8,    // 80/100 * 0.15 = 12
+      cycle_time_days: 3,    // (30-3)/30 * 100 = 90 * 0.10 = 9
+      decay_rate: 0.2,       // (1-0.2)*100 = 80 * 0.10 = 8
+    };
+    const score = calculateViralityScore(dims);
+    // Expected: 15 + 16 + 9 + 12 + 9 + 8 = 69
+    expect(score).toBe(69);
+  });
+
+  test('returns score in 0-100 range for extreme values', () => {
+    const maxDims = {
+      k_factor: 10,
+      shareability: 100,
+      channel_fit: 100,
+      organic_ratio: 1.0,
+      cycle_time_days: 0,
+      decay_rate: 0,
+    };
+    const score = calculateViralityScore(maxDims);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  test('handles 30+ day cycle time as zero contribution', () => {
+    const dims = { cycle_time_days: 45, decay_rate: 1 };
+    const score = calculateViralityScore(dims);
+    // cycle_time at 45 days = 0, decay_rate at 1 (full decay) = 0
+    expect(score).toBe(0);
+  });
+});
+
+describe('MECHANIC_TYPES', () => {
+  test('contains all 4 mechanic types', () => {
+    expect(MECHANIC_TYPES).toEqual(['inherent', 'manufactured', 'word_of_mouth', 'incentivized']);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds virality analysis as the 9th synthesis component for EVA Stage 0
- Evaluates venture candidates across 7 dimensions: K-factor, cycle time, mechanic type, channel fit, shareability, decay rate, organic ratio
- Integrated into synthesis engine running in parallel with existing 8 components

## Changes
- **New**: `lib/eva/stage-zero/synthesis/virality.js` - Virality analysis component
- **Modified**: `lib/eva/stage-zero/synthesis/index.js` - Integration as component 9
- **New**: `tests/unit/eva/stage-zero/synthesis/virality.test.js` - 12 unit tests

## Test plan
- [x] 12 unit tests passing (vitest)
- [x] LLM response parsing verified
- [x] Failure fallback to defaults verified
- [x] Score calculation with weighted formula verified
- [x] Value clamping for out-of-range inputs verified
- [x] Backward compatibility with existing 8 components maintained

SD: SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)