### PR TITLE
feat(eva): profile-aware gate thresholds for reality gates

### DIFF
--- a/database/migrations/20260210_profile_gate_thresholds.sql
+++ b/database/migrations/20260210_profile_gate_thresholds.sql
@@ -1,0 +1,50 @@
+-- Migration: Profile-Aware Gate Thresholds
+-- SD: SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-C
+-- Purpose: Add gate_thresholds JSONB column to evaluation_profiles
+--          for profile-specific reality gate threshold overrides
+
+-- Add gate_thresholds column
+ALTER TABLE evaluation_profiles
+  ADD COLUMN IF NOT EXISTS gate_thresholds JSONB NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN evaluation_profiles.gate_thresholds IS
+  'Profile-specific reality gate threshold overrides. Keyed by boundary (e.g. "5->6"), each containing artifact_type → min_quality_score overrides.';
+
+-- Update seed profiles with profile-appropriate thresholds
+
+-- balanced: no overrides (uses legacy defaults)
+UPDATE evaluation_profiles
+SET gate_thresholds = '{}'::jsonb
+WHERE name = 'balanced' AND version = 1;
+
+-- aggressive_growth: lower early-stage quality bars, higher virality expectations
+UPDATE evaluation_profiles
+SET gate_thresholds = '{
+  "5->6": {
+    "problem_statement": 0.5,
+    "target_market_analysis": 0.4,
+    "value_proposition": 0.5
+  },
+  "9->10": {
+    "customer_interviews": 0.4,
+    "competitive_analysis": 0.4,
+    "pricing_model": 0.5
+  }
+}'::jsonb
+WHERE name = 'aggressive_growth' AND version = 1;
+
+-- capital_efficient: higher quality bars, stricter build/launch thresholds
+UPDATE evaluation_profiles
+SET gate_thresholds = '{
+  "12->13": {
+    "business_model_canvas": 0.8,
+    "technical_architecture": 0.7,
+    "project_plan": 0.6
+  },
+  "16->17": {
+    "mvp_build": 0.8,
+    "test_coverage_report": 0.7,
+    "deployment_runbook": 0.6
+  }
+}'::jsonb
+WHERE name = 'capital_efficient' AND version = 1;

--- a/lib/eva/reality-gates.js
+++ b/lib/eva/reality-gates.js
@@ -88,6 +88,9 @@ const MAX_URL_RETRIES = 1; // Single retry on network timeout only
  * @param {Function} [params.httpClient] - async (url, opts) => { status, ok }
  * @param {Function} [params.now] - () => Date (defaults to () => new Date())
  * @param {Object} [params.logger] - { info, warn, error } (defaults to console)
+ * @param {Object} [params.profileThresholds] - Profile-specific threshold overrides.
+ *   Map of artifact_type → min_quality_score. Overrides BOUNDARY_CONFIG values.
+ *   (SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-C)
  * @returns {Promise<Object>} Gate result with status PASS|FAIL|NOT_APPLICABLE
  */
 async function evaluateRealityGate({
@@ -98,6 +101,7 @@ async function evaluateRealityGate({
   httpClient,
   now = () => new Date(),
   logger = console,
+  profileThresholds = null,
 }) {
   const transitionKey = `${fromStage}->${toStage}`;
   const evaluatedAt = now().toISOString();
@@ -186,19 +190,23 @@ async function evaluateRealityGate({
     }
 
     // Check 2: Quality score (FR-3)
+    // Use profile threshold override if available, otherwise use BOUNDARY_CONFIG default
+    const effectiveThreshold = profileThresholds?.[req.artifact_type] ?? req.min_quality_score;
+
     if (artifact.quality_score == null) {
       result.reasons.push({
         code: REASON_CODES.QUALITY_SCORE_MISSING,
-        message: `Artifact '${req.artifact_type}' has no quality score; required >= ${req.min_quality_score}`,
+        message: `Artifact '${req.artifact_type}' has no quality score; required >= ${effectiveThreshold}`,
         artifact_type: req.artifact_type,
       });
-    } else if (artifact.quality_score < req.min_quality_score) {
+    } else if (artifact.quality_score < effectiveThreshold) {
       result.reasons.push({
         code: REASON_CODES.QUALITY_SCORE_BELOW_THRESHOLD,
-        message: `Artifact '${req.artifact_type}' quality ${artifact.quality_score} < required ${req.min_quality_score}`,
+        message: `Artifact '${req.artifact_type}' quality ${artifact.quality_score} < required ${effectiveThreshold}`,
         artifact_type: req.artifact_type,
         actual: artifact.quality_score,
-        required: req.min_quality_score,
+        required: effectiveThreshold,
+        profile_override: profileThresholds?.[req.artifact_type] != null,
       });
     }
 
@@ -230,7 +238,13 @@ async function evaluateRealityGate({
     result.status = 'FAIL';
   }
 
-  logger.info(`Reality Gate ${transitionKey}: ${result.status} (${result.reasons.length} issue(s))`);
+  // Include profile threshold metadata if overrides were applied
+  if (profileThresholds) {
+    result.profile_thresholds_applied = true;
+    result.threshold_overrides = profileThresholds;
+  }
+
+  logger.info(`Reality Gate ${transitionKey}: ${result.status} (${result.reasons.length} issue(s))${profileThresholds ? ' [profile thresholds]' : ''}`);
   return result;
 }
 

--- a/lib/eva/stage-zero/profile-service.js
+++ b/lib/eva/stage-zero/profile-service.js
@@ -5,7 +5,8 @@
  * Profiles define weights for each synthesis component, allowing
  * different evaluation strategies (aggressive growth, capital efficient, etc.)
  *
- * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-B
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-B (weights)
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-C (gate thresholds)
  */
 
 /**
@@ -58,7 +59,7 @@ export async function resolveProfile(deps = {}, profileId = null) {
       // Explicit profile requested
       const { data, error } = await supabase
         .from('evaluation_profiles')
-        .select('id, name, version, weights, description')
+        .select('id, name, version, weights, gate_thresholds, description')
         .eq('id', profileId)
         .single();
 
@@ -71,7 +72,7 @@ export async function resolveProfile(deps = {}, profileId = null) {
       // Use active profile
       const { data, error } = await supabase
         .from('evaluation_profiles')
-        .select('id, name, version, weights, description')
+        .select('id, name, version, weights, gate_thresholds, description')
         .eq('is_active', true)
         .limit(1)
         .single();
@@ -92,6 +93,7 @@ export async function resolveProfile(deps = {}, profileId = null) {
       version: profile.version,
       description: profile.description,
       weights,
+      gate_thresholds: profile.gate_thresholds || {},
       source: profileId ? 'explicit' : 'active',
     };
   } catch (err) {
@@ -261,6 +263,7 @@ function makeFallbackProfile(reason) {
     version: 0,
     description: 'Built-in default weights (no database profile)',
     weights: { ...LEGACY_WEIGHTS },
+    gate_thresholds: {},
     source: 'fallback',
     fallback_reason: reason,
   };
@@ -270,4 +273,71 @@ function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value));
 }
 
-export { LEGACY_WEIGHTS, VALID_COMPONENTS };
+/**
+ * Legacy gate thresholds matching the hardcoded BOUNDARY_CONFIG in reality-gates.js.
+ * Used as fallback when no profile is active or profile has no threshold overrides.
+ */
+const LEGACY_GATE_THRESHOLDS = {
+  '5->6': {
+    problem_statement: 0.6,
+    target_market_analysis: 0.5,
+    value_proposition: 0.6,
+  },
+  '9->10': {
+    customer_interviews: 0.5,
+    competitive_analysis: 0.5,
+    pricing_model: 0.6,
+  },
+  '12->13': {
+    business_model_canvas: 0.7,
+    technical_architecture: 0.6,
+    project_plan: 0.5,
+  },
+  '16->17': {
+    mvp_build: 0.7,
+    test_coverage_report: 0.6,
+    deployment_runbook: 0.5,
+  },
+  '20->21': {
+    launch_metrics: 0.6,
+    user_feedback_summary: 0.5,
+    production_app: 0.7,
+  },
+};
+
+/**
+ * Resolve gate threshold for a specific boundary and artifact type.
+ *
+ * Resolution: profile override → legacy default.
+ * If no profile is provided, returns legacy threshold.
+ *
+ * @param {Object} profile - Resolved profile from resolveProfile() (or null)
+ * @param {string} boundary - Boundary key e.g. "5->6"
+ * @param {string} artifactType - Artifact type e.g. "problem_statement"
+ * @returns {number} Min quality score threshold (0-1)
+ */
+export function resolveGateThreshold(profile, boundary, artifactType) {
+  // Check profile override first
+  if (profile?.gate_thresholds?.[boundary]?.[artifactType] != null) {
+    return profile.gate_thresholds[boundary][artifactType];
+  }
+
+  // Fall back to legacy
+  return LEGACY_GATE_THRESHOLDS[boundary]?.[artifactType] ?? 0.5;
+}
+
+/**
+ * Get all thresholds for a boundary, merging profile overrides with legacy defaults.
+ *
+ * @param {Object} profile - Resolved profile (or null)
+ * @param {string} boundary - Boundary key e.g. "5->6"
+ * @returns {Object} Map of artifact_type → min_quality_score
+ */
+export function resolveAllGateThresholds(profile, boundary) {
+  const legacyThresholds = LEGACY_GATE_THRESHOLDS[boundary] || {};
+  const profileOverrides = profile?.gate_thresholds?.[boundary] || {};
+
+  return { ...legacyThresholds, ...profileOverrides };
+}
+
+export { LEGACY_WEIGHTS, VALID_COMPONENTS, LEGACY_GATE_THRESHOLDS };

--- a/tests/unit/eva/stage-zero/gate-thresholds.test.js
+++ b/tests/unit/eva/stage-zero/gate-thresholds.test.js
@@ -1,0 +1,263 @@
+/**
+ * Unit Tests: Profile-Aware Gate Thresholds
+ * SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-C
+ *
+ * Test Coverage:
+ * - resolveGateThreshold (profile override, legacy fallback, missing boundary)
+ * - resolveAllGateThresholds (merge behavior)
+ * - LEGACY_GATE_THRESHOLDS structure
+ * - Reality gate integration with profileThresholds
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  resolveGateThreshold,
+  resolveAllGateThresholds,
+  LEGACY_GATE_THRESHOLDS,
+  LEGACY_WEIGHTS,
+} from '../../../../lib/eva/stage-zero/profile-service.js';
+import {
+  evaluateRealityGate,
+  BOUNDARY_CONFIG,
+} from '../../../../lib/eva/reality-gates.js';
+
+describe('LEGACY_GATE_THRESHOLDS', () => {
+  test('contains all 5 enforced boundaries', () => {
+    expect(Object.keys(LEGACY_GATE_THRESHOLDS)).toEqual([
+      '5->6', '9->10', '12->13', '16->17', '20->21',
+    ]);
+  });
+
+  test('all thresholds are between 0 and 1', () => {
+    for (const [boundary, artifacts] of Object.entries(LEGACY_GATE_THRESHOLDS)) {
+      for (const [type, score] of Object.entries(artifacts)) {
+        expect(score).toBeGreaterThan(0);
+        expect(score).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test('matches BOUNDARY_CONFIG values exactly', () => {
+    for (const [boundary, config] of Object.entries(BOUNDARY_CONFIG)) {
+      for (const artifact of config.required_artifacts) {
+        expect(LEGACY_GATE_THRESHOLDS[boundary][artifact.artifact_type])
+          .toBe(artifact.min_quality_score);
+      }
+    }
+  });
+});
+
+describe('resolveGateThreshold', () => {
+  test('returns profile override when available', () => {
+    const profile = {
+      gate_thresholds: {
+        '5->6': { problem_statement: 0.4 },
+      },
+    };
+
+    const result = resolveGateThreshold(profile, '5->6', 'problem_statement');
+    expect(result).toBe(0.4);
+  });
+
+  test('returns legacy default when profile has no override for boundary', () => {
+    const profile = {
+      gate_thresholds: {
+        '5->6': { problem_statement: 0.4 },
+      },
+    };
+
+    const result = resolveGateThreshold(profile, '9->10', 'customer_interviews');
+    expect(result).toBe(0.5); // Legacy default
+  });
+
+  test('returns legacy default when profile has no override for artifact type', () => {
+    const profile = {
+      gate_thresholds: {
+        '5->6': { problem_statement: 0.4 },
+      },
+    };
+
+    const result = resolveGateThreshold(profile, '5->6', 'value_proposition');
+    expect(result).toBe(0.6); // Legacy default
+  });
+
+  test('returns legacy default when profile is null', () => {
+    const result = resolveGateThreshold(null, '5->6', 'problem_statement');
+    expect(result).toBe(0.6); // Legacy default
+  });
+
+  test('returns legacy default when profile has empty gate_thresholds', () => {
+    const profile = { gate_thresholds: {} };
+
+    const result = resolveGateThreshold(profile, '12->13', 'business_model_canvas');
+    expect(result).toBe(0.7); // Legacy default
+  });
+
+  test('returns 0.5 fallback for unknown boundary/artifact', () => {
+    const result = resolveGateThreshold(null, '99->100', 'unknown_type');
+    expect(result).toBe(0.5); // Default fallback
+  });
+
+  test('handles profile with zero threshold override', () => {
+    const profile = {
+      gate_thresholds: {
+        '5->6': { problem_statement: 0 },
+      },
+    };
+
+    // 0 is a valid override (essentially disables the check)
+    const result = resolveGateThreshold(profile, '5->6', 'problem_statement');
+    expect(result).toBe(0);
+  });
+});
+
+describe('resolveAllGateThresholds', () => {
+  test('returns legacy thresholds when no profile', () => {
+    const result = resolveAllGateThresholds(null, '5->6');
+    expect(result).toEqual(LEGACY_GATE_THRESHOLDS['5->6']);
+  });
+
+  test('merges profile overrides with legacy defaults', () => {
+    const profile = {
+      gate_thresholds: {
+        '5->6': { problem_statement: 0.4 },
+      },
+    };
+
+    const result = resolveAllGateThresholds(profile, '5->6');
+    expect(result.problem_statement).toBe(0.4); // Profile override
+    expect(result.target_market_analysis).toBe(0.5); // Legacy default
+    expect(result.value_proposition).toBe(0.6); // Legacy default
+  });
+
+  test('returns empty object for unknown boundary', () => {
+    const result = resolveAllGateThresholds(null, '99->100');
+    expect(result).toEqual({});
+  });
+
+  test('profile overrides completely replace legacy values', () => {
+    const profile = {
+      gate_thresholds: {
+        '12->13': {
+          business_model_canvas: 0.9,
+          technical_architecture: 0.85,
+          project_plan: 0.8,
+        },
+      },
+    };
+
+    const result = resolveAllGateThresholds(profile, '12->13');
+    expect(result.business_model_canvas).toBe(0.9);
+    expect(result.technical_architecture).toBe(0.85);
+    expect(result.project_plan).toBe(0.8);
+  });
+});
+
+describe('evaluateRealityGate with profileThresholds', () => {
+  const silentLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  function createMockDb(artifacts = []) {
+    return {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockResolvedValue({ data: artifacts, error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+
+  test('uses profile threshold instead of BOUNDARY_CONFIG default', async () => {
+    const artifacts = [
+      { artifact_type: 'problem_statement', quality_score: 0.55, file_url: null, is_current: true },
+      { artifact_type: 'target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
+      { artifact_type: 'value_proposition', quality_score: 0.6, file_url: null, is_current: true },
+    ];
+
+    // Default threshold for problem_statement is 0.6, so 0.55 would fail
+    // But with profile override of 0.5, it should pass
+    const result = await evaluateRealityGate({
+      ventureId: 'test-uuid',
+      fromStage: 5,
+      toStage: 6,
+      db: createMockDb(artifacts),
+      logger: silentLogger,
+      profileThresholds: { problem_statement: 0.5 },
+    });
+
+    expect(result.status).toBe('PASS');
+    expect(result.profile_thresholds_applied).toBe(true);
+  });
+
+  test('fails when score below profile threshold even though above legacy', async () => {
+    const artifacts = [
+      { artifact_type: 'business_model_canvas', quality_score: 0.75, file_url: null, is_current: true },
+      { artifact_type: 'technical_architecture', quality_score: 0.65, file_url: null, is_current: true },
+      { artifact_type: 'project_plan', quality_score: 0.5, file_url: null, is_current: true },
+    ];
+
+    // Legacy threshold for business_model_canvas is 0.7 (would pass at 0.75)
+    // Profile overrides to 0.8 (should fail at 0.75)
+    const result = await evaluateRealityGate({
+      ventureId: 'test-uuid',
+      fromStage: 12,
+      toStage: 13,
+      db: createMockDb(artifacts),
+      logger: silentLogger,
+      profileThresholds: { business_model_canvas: 0.8 },
+    });
+
+    expect(result.status).toBe('FAIL');
+    const failReason = result.reasons.find(r =>
+      r.artifact_type === 'business_model_canvas' &&
+      r.code === 'QUALITY_SCORE_BELOW_THRESHOLD'
+    );
+    expect(failReason).toBeDefined();
+    expect(failReason.required).toBe(0.8);
+    expect(failReason.profile_override).toBe(true);
+  });
+
+  test('uses BOUNDARY_CONFIG default when no profile thresholds provided', async () => {
+    const artifacts = [
+      { artifact_type: 'problem_statement', quality_score: 0.55, file_url: null, is_current: true },
+      { artifact_type: 'target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
+      { artifact_type: 'value_proposition', quality_score: 0.6, file_url: null, is_current: true },
+    ];
+
+    // Without profile, problem_statement at 0.55 < 0.6 default should fail
+    const result = await evaluateRealityGate({
+      ventureId: 'test-uuid',
+      fromStage: 5,
+      toStage: 6,
+      db: createMockDb(artifacts),
+      logger: silentLogger,
+    });
+
+    expect(result.status).toBe('FAIL');
+    expect(result.profile_thresholds_applied).toBeUndefined();
+  });
+
+  test('includes threshold_overrides in result when profile applied', async () => {
+    const artifacts = [
+      { artifact_type: 'problem_statement', quality_score: 0.6, file_url: null, is_current: true },
+      { artifact_type: 'target_market_analysis', quality_score: 0.5, file_url: null, is_current: true },
+      { artifact_type: 'value_proposition', quality_score: 0.6, file_url: null, is_current: true },
+    ];
+
+    const overrides = { problem_statement: 0.5, value_proposition: 0.5 };
+
+    const result = await evaluateRealityGate({
+      ventureId: 'test-uuid',
+      fromStage: 5,
+      toStage: 6,
+      db: createMockDb(artifacts),
+      logger: silentLogger,
+      profileThresholds: overrides,
+    });
+
+    expect(result.threshold_overrides).toEqual(overrides);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `gate_thresholds` JSONB column to `evaluation_profiles` for profile-specific quality threshold overrides
- `resolveGateThreshold()` and `resolveAllGateThresholds()` resolve profile override → legacy fallback
- `evaluateRealityGate()` accepts optional `profileThresholds` param
- Seed profiles: aggressive_growth lowers early-stage bars, capital_efficient raises build/launch bars
- 33 tests passing (15 existing + 18 new)

## Test plan
- [x] 18 gate-thresholds unit tests passing
- [x] 15 existing profile-service tests passing
- [x] Migration executed with seed profile updates verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)