### PR TITLE
feat(eva): add intermediate gate signal tracking

### DIFF
--- a/database/migrations/20260210_gate_signal_tracking.sql
+++ b/database/migrations/20260210_gate_signal_tracking.sql
@@ -1,0 +1,40 @@
+-- Migration: Intermediate Gate Signal Tracking
+-- SD: SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-D
+-- Purpose: Track per-gate survival signals linking profile+version to venture outcomes
+
+-- Create evaluation_profile_outcomes table
+CREATE TABLE IF NOT EXISTS evaluation_profile_outcomes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id UUID REFERENCES evaluation_profiles(id) ON DELETE SET NULL,
+  profile_version INTEGER,
+  venture_id UUID NOT NULL,
+  gate_boundary TEXT NOT NULL,
+  signal_type TEXT NOT NULL CHECK (signal_type IN ('pass', 'fail', 'review', 'skip')),
+  outcome JSONB NOT NULL DEFAULT '{}',
+  evaluated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_epo_profile_id ON evaluation_profile_outcomes(profile_id);
+CREATE INDEX IF NOT EXISTS idx_epo_venture_id ON evaluation_profile_outcomes(venture_id);
+CREATE INDEX IF NOT EXISTS idx_epo_boundary ON evaluation_profile_outcomes(gate_boundary);
+CREATE INDEX IF NOT EXISTS idx_epo_profile_boundary ON evaluation_profile_outcomes(profile_id, gate_boundary);
+
+-- RLS
+ALTER TABLE evaluation_profile_outcomes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "epo_read_all" ON evaluation_profile_outcomes FOR SELECT USING (true);
+CREATE POLICY "epo_write_service" ON evaluation_profile_outcomes FOR ALL USING (true) WITH CHECK (true);
+
+-- Add profile_id to venture_briefs
+ALTER TABLE venture_briefs
+  ADD COLUMN IF NOT EXISTS profile_id UUID REFERENCES evaluation_profiles(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_venture_briefs_profile_id ON venture_briefs(profile_id);
+
+COMMENT ON TABLE evaluation_profile_outcomes IS 'Per-gate survival signals linking evaluation profile+version to venture outcomes at tracked boundaries';
+COMMENT ON COLUMN evaluation_profile_outcomes.gate_boundary IS 'Stage boundary key (e.g. "5->6", "stage_3", "graduation")';
+COMMENT ON COLUMN evaluation_profile_outcomes.signal_type IS 'Gate outcome signal: pass, fail, review, or skip';
+COMMENT ON COLUMN evaluation_profile_outcomes.outcome IS 'Detailed outcome data including scores, reasons, and metadata';
+COMMENT ON COLUMN venture_briefs.profile_id IS 'Evaluation profile active when this brief was created (nullable for pre-profile briefs)';

--- a/lib/eva/stage-zero/gate-signal-service.js
+++ b/lib/eva/stage-zero/gate-signal-service.js
@@ -1,0 +1,143 @@
+/**
+ * Gate Signal Tracking Service
+ *
+ * Records per-gate survival signals linking evaluation profiles to
+ * venture outcomes at tracked boundaries. Produces 5-6 data points
+ * per venture instead of one (graduation/kill), cutting learning
+ * cycles from months to weeks.
+ *
+ * Tracked boundaries: stage_3, 5->6, 12->13, 20->21, graduation
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-D
+ */
+
+/**
+ * Gate boundaries tracked for signal recording.
+ */
+const TRACKED_BOUNDARIES = [
+  'stage_3',   // Early signal
+  '5->6',      // Ideation → Validation
+  '12->13',    // Planning → Build
+  '20->21',    // Launch → Scale
+  'graduation', // Full completion
+];
+
+/**
+ * Record a gate signal for a venture at a specific boundary.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {Object} signal
+ * @param {string} signal.ventureId - Venture UUID
+ * @param {string} signal.gateBoundary - Boundary key (e.g. "5->6", "stage_3")
+ * @param {string} signal.signalType - 'pass' | 'fail' | 'review' | 'skip'
+ * @param {Object} [signal.outcome] - Detailed outcome data
+ * @param {Object} [signal.profile] - Resolved profile (from resolveProfile)
+ * @returns {Promise<Object>} Created signal record
+ */
+export async function recordGateSignal(deps, signal) {
+  const { supabase, logger = console } = deps;
+  const { ventureId, gateBoundary, signalType, outcome = {}, profile = null } = signal;
+
+  if (!supabase) {
+    logger.warn('Gate signal service: No supabase client, signal not recorded');
+    return null;
+  }
+
+  if (!ventureId || !gateBoundary || !signalType) {
+    throw new Error('ventureId, gateBoundary, and signalType are required');
+  }
+
+  const { data, error } = await supabase
+    .from('evaluation_profile_outcomes')
+    .insert({
+      profile_id: profile?.id || null,
+      profile_version: profile?.version || null,
+      venture_id: ventureId,
+      gate_boundary: gateBoundary,
+      signal_type: signalType,
+      outcome,
+    })
+    .select('id, profile_id, venture_id, gate_boundary, signal_type')
+    .single();
+
+  if (error) {
+    logger.warn(`Gate signal service: Failed to record signal: ${error.message}`);
+    return null;
+  }
+
+  logger.log(`   Gate signal: ${gateBoundary} → ${signalType} (venture=${ventureId.slice(0, 8)})`);
+  return data;
+}
+
+/**
+ * Get all gate signals for a specific profile.
+ *
+ * @param {Object} deps - { supabase }
+ * @param {string} profileId - Profile UUID
+ * @returns {Promise<Array>} Signal records
+ */
+export async function getSignalsByProfile(deps, profileId) {
+  const { supabase } = deps;
+
+  const { data, error } = await supabase
+    .from('evaluation_profile_outcomes')
+    .select('id, profile_id, profile_version, venture_id, gate_boundary, signal_type, outcome, evaluated_at')
+    .eq('profile_id', profileId)
+    .order('evaluated_at', { ascending: false });
+
+  if (error) throw new Error(`Failed to fetch signals: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get aggregated pass/fail summary for a profile at a specific boundary.
+ *
+ * @param {Object} deps - { supabase }
+ * @param {string} profileId - Profile UUID
+ * @param {string} [boundary] - Optional boundary filter
+ * @returns {Promise<Object>} { total, passed, failed, reviewed, skipped, pass_rate }
+ */
+export async function getSignalsSummary(deps, profileId, boundary = null) {
+  const { supabase } = deps;
+
+  let query = supabase
+    .from('evaluation_profile_outcomes')
+    .select('signal_type')
+    .eq('profile_id', profileId);
+
+  if (boundary) {
+    query = query.eq('gate_boundary', boundary);
+  }
+
+  const { data, error } = await query;
+
+  if (error) throw new Error(`Failed to fetch signal summary: ${error.message}`);
+
+  const signals = data || [];
+  const passed = signals.filter(s => s.signal_type === 'pass').length;
+  const failed = signals.filter(s => s.signal_type === 'fail').length;
+  const reviewed = signals.filter(s => s.signal_type === 'review').length;
+  const skipped = signals.filter(s => s.signal_type === 'skip').length;
+  const total = signals.length;
+
+  return {
+    total,
+    passed,
+    failed,
+    reviewed,
+    skipped,
+    pass_rate: total > 0 ? Math.round((passed / total) * 100) / 100 : 0,
+  };
+}
+
+/**
+ * Check if a boundary is tracked for signal recording.
+ *
+ * @param {string} boundary - Boundary key
+ * @returns {boolean}
+ */
+export function isTrackedBoundary(boundary) {
+  return TRACKED_BOUNDARIES.includes(boundary);
+}
+
+export { TRACKED_BOUNDARIES };

--- a/tests/unit/eva/stage-zero/gate-signal-service.test.js
+++ b/tests/unit/eva/stage-zero/gate-signal-service.test.js
@@ -1,0 +1,333 @@
+/**
+ * Unit Tests: Gate Signal Tracking Service
+ * SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-D
+ *
+ * Test Coverage:
+ * - recordGateSignal (with profile, without profile, missing fields, no supabase)
+ * - getSignalsByProfile (results, errors)
+ * - getSignalsSummary (aggregation, boundary filter)
+ * - isTrackedBoundary / TRACKED_BOUNDARIES
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  recordGateSignal,
+  getSignalsByProfile,
+  getSignalsSummary,
+  isTrackedBoundary,
+  TRACKED_BOUNDARIES,
+} from '../../../../lib/eva/stage-zero/gate-signal-service.js';
+
+// --- Mock helpers ---
+
+function createMockSupabase(response = { data: null, error: null }) {
+  const chain = {
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(response),
+    eq: vi.fn().mockReturnThis(),
+    order: vi.fn().mockResolvedValue(response),
+  };
+  return {
+    from: vi.fn().mockReturnValue(chain),
+    _chain: chain,
+  };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// --- Tests ---
+
+describe('TRACKED_BOUNDARIES', () => {
+  test('contains 5 tracked boundaries', () => {
+    expect(TRACKED_BOUNDARIES).toHaveLength(5);
+  });
+
+  test('includes expected boundaries', () => {
+    expect(TRACKED_BOUNDARIES).toContain('stage_3');
+    expect(TRACKED_BOUNDARIES).toContain('5->6');
+    expect(TRACKED_BOUNDARIES).toContain('12->13');
+    expect(TRACKED_BOUNDARIES).toContain('20->21');
+    expect(TRACKED_BOUNDARIES).toContain('graduation');
+  });
+});
+
+describe('isTrackedBoundary', () => {
+  test('returns true for tracked boundaries', () => {
+    expect(isTrackedBoundary('stage_3')).toBe(true);
+    expect(isTrackedBoundary('5->6')).toBe(true);
+    expect(isTrackedBoundary('graduation')).toBe(true);
+  });
+
+  test('returns false for non-tracked boundaries', () => {
+    expect(isTrackedBoundary('1->2')).toBe(false);
+    expect(isTrackedBoundary('stage_1')).toBe(false);
+    expect(isTrackedBoundary('unknown')).toBe(false);
+  });
+});
+
+describe('recordGateSignal', () => {
+  test('records signal with profile context', async () => {
+    const insertedRow = {
+      id: 'signal-uuid-1',
+      profile_id: 'profile-uuid',
+      venture_id: 'venture-uuid',
+      gate_boundary: '5->6',
+      signal_type: 'pass',
+    };
+    const supabase = createMockSupabase({ data: insertedRow, error: null });
+
+    const result = await recordGateSignal(
+      { supabase, logger: silentLogger },
+      {
+        ventureId: 'venture-uuid',
+        gateBoundary: '5->6',
+        signalType: 'pass',
+        outcome: { score: 0.85 },
+        profile: { id: 'profile-uuid', version: 2 },
+      }
+    );
+
+    expect(result).toEqual(insertedRow);
+    expect(supabase.from).toHaveBeenCalledWith('evaluation_profile_outcomes');
+    expect(supabase._chain.insert).toHaveBeenCalledWith({
+      profile_id: 'profile-uuid',
+      profile_version: 2,
+      venture_id: 'venture-uuid',
+      gate_boundary: '5->6',
+      signal_type: 'pass',
+      outcome: { score: 0.85 },
+    });
+  });
+
+  test('records signal with null profile (legacy mode)', async () => {
+    const insertedRow = {
+      id: 'signal-uuid-2',
+      profile_id: null,
+      venture_id: 'venture-uuid',
+      gate_boundary: 'stage_3',
+      signal_type: 'fail',
+    };
+    const supabase = createMockSupabase({ data: insertedRow, error: null });
+
+    const result = await recordGateSignal(
+      { supabase, logger: silentLogger },
+      {
+        ventureId: 'venture-uuid',
+        gateBoundary: 'stage_3',
+        signalType: 'fail',
+      }
+    );
+
+    expect(result).toEqual(insertedRow);
+    expect(supabase._chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profile_id: null,
+        profile_version: null,
+      })
+    );
+  });
+
+  test('returns null when no supabase client', async () => {
+    const result = await recordGateSignal(
+      { supabase: null, logger: silentLogger },
+      {
+        ventureId: 'venture-uuid',
+        gateBoundary: '5->6',
+        signalType: 'pass',
+      }
+    );
+
+    expect(result).toBeNull();
+    expect(silentLogger.warn).toHaveBeenCalled();
+  });
+
+  test('throws when required fields are missing', async () => {
+    const supabase = createMockSupabase();
+
+    await expect(
+      recordGateSignal({ supabase, logger: silentLogger }, { ventureId: 'v', gateBoundary: '5->6' })
+    ).rejects.toThrow('ventureId, gateBoundary, and signalType are required');
+
+    await expect(
+      recordGateSignal({ supabase, logger: silentLogger }, { ventureId: 'v', signalType: 'pass' })
+    ).rejects.toThrow('ventureId, gateBoundary, and signalType are required');
+
+    await expect(
+      recordGateSignal({ supabase, logger: silentLogger }, { gateBoundary: '5->6', signalType: 'pass' })
+    ).rejects.toThrow('ventureId, gateBoundary, and signalType are required');
+  });
+
+  test('returns null on database error', async () => {
+    const supabase = createMockSupabase({
+      data: null,
+      error: { message: 'insert failed' },
+    });
+
+    const result = await recordGateSignal(
+      { supabase, logger: silentLogger },
+      {
+        ventureId: 'venture-uuid',
+        gateBoundary: '5->6',
+        signalType: 'pass',
+      }
+    );
+
+    expect(result).toBeNull();
+    expect(silentLogger.warn).toHaveBeenCalled();
+  });
+});
+
+describe('getSignalsByProfile', () => {
+  test('returns signals for a profile', async () => {
+    const signals = [
+      { id: '1', profile_id: 'p1', venture_id: 'v1', gate_boundary: '5->6', signal_type: 'pass' },
+      { id: '2', profile_id: 'p1', venture_id: 'v2', gate_boundary: 'stage_3', signal_type: 'fail' },
+    ];
+    const supabase = createMockSupabase({ data: signals, error: null });
+    // Override the chain for order to return the mock data
+    supabase._chain.order = vi.fn().mockResolvedValue({ data: signals, error: null });
+
+    const result = await getSignalsByProfile({ supabase }, 'p1');
+
+    expect(result).toEqual(signals);
+    expect(result).toHaveLength(2);
+    expect(supabase.from).toHaveBeenCalledWith('evaluation_profile_outcomes');
+  });
+
+  test('returns empty array when no data', async () => {
+    const supabase = createMockSupabase({ data: null, error: null });
+    supabase._chain.order = vi.fn().mockResolvedValue({ data: null, error: null });
+
+    const result = await getSignalsByProfile({ supabase }, 'unknown-profile');
+    expect(result).toEqual([]);
+  });
+
+  test('throws on database error', async () => {
+    const supabase = createMockSupabase();
+    supabase._chain.order = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: 'query failed' },
+    });
+
+    await expect(
+      getSignalsByProfile({ supabase }, 'p1')
+    ).rejects.toThrow('Failed to fetch signals: query failed');
+  });
+});
+
+describe('getSignalsSummary', () => {
+  function createSummarySupabase(signalTypes) {
+    const data = signalTypes.map(t => ({ signal_type: t }));
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    };
+    // Last call in chain resolves with data (when no boundary filter)
+    // With boundary filter, eq is called twice, so we need the second eq to resolve
+    let eqCallCount = 0;
+    chain.eq = vi.fn((...args) => {
+      eqCallCount++;
+      if (eqCallCount >= 2) {
+        // After boundary filter, resolve
+        return Promise.resolve({ data, error: null });
+      }
+      return chain;
+    });
+    // For no-boundary case, first eq returns a thenable
+    const sb = {
+      from: vi.fn().mockReturnValue(chain),
+      _chain: chain,
+      _data: data,
+    };
+    return sb;
+  }
+
+  test('aggregates pass/fail/review/skip counts', async () => {
+    const signals = ['pass', 'pass', 'pass', 'fail', 'fail', 'review', 'skip'];
+    const data = signals.map(t => ({ signal_type: t }));
+
+    // Simple mock: eq resolves on first call (profile_id filter, no boundary)
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data, error: null }),
+    };
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+
+    const result = await getSignalsSummary({ supabase }, 'profile-1');
+
+    expect(result.total).toBe(7);
+    expect(result.passed).toBe(3);
+    expect(result.failed).toBe(2);
+    expect(result.reviewed).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.pass_rate).toBeCloseTo(0.43, 2);
+  });
+
+  test('returns zeros when no signals exist', async () => {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+
+    const result = await getSignalsSummary({ supabase }, 'empty-profile');
+
+    expect(result.total).toBe(0);
+    expect(result.passed).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.pass_rate).toBe(0);
+  });
+
+  test('calculates perfect pass rate', async () => {
+    const data = [{ signal_type: 'pass' }, { signal_type: 'pass' }, { signal_type: 'pass' }];
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data, error: null }),
+    };
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+
+    const result = await getSignalsSummary({ supabase }, 'prof-1');
+
+    expect(result.pass_rate).toBe(1);
+    expect(result.total).toBe(3);
+    expect(result.passed).toBe(3);
+  });
+
+  test('filters by boundary when provided', async () => {
+    const data = [{ signal_type: 'pass' }, { signal_type: 'fail' }];
+    // When boundary is provided, eq is called twice (profile_id then gate_boundary)
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    };
+    // Second eq call should resolve
+    let callCount = 0;
+    chain.eq = vi.fn((...args) => {
+      callCount++;
+      if (callCount === 1) return chain; // First eq (profile_id) returns chain
+      return Promise.resolve({ data, error: null }); // Second eq (boundary) resolves
+    });
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+
+    const result = await getSignalsSummary({ supabase }, 'prof-1', '5->6');
+
+    expect(result.total).toBe(2);
+    expect(result.passed).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.pass_rate).toBe(0.5);
+    expect(chain.eq).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws on database error', async () => {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ data: null, error: { message: 'db fail' } }),
+    };
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+
+    await expect(
+      getSignalsSummary({ supabase }, 'prof-1')
+    ).rejects.toThrow('Failed to fetch signal summary: db fail');
+  });
+});


### PR DESCRIPTION
## Summary
- Create `evaluation_profile_outcomes` table for per-gate survival signals linking profiles to venture outcomes
- Add `profile_id` column to `venture_briefs` for profile linkage
- Implement `gate-signal-service.js` with record, query, and summary functions
- Add 17 unit tests (50 total across EVA stage-zero suite)

## SD
SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-D (Child D of orchestrator)

## Test plan
- [x] 17 unit tests covering recordGateSignal, getSignalsByProfile, getSignalsSummary
- [x] Tests verify null profile (legacy) and active profile scenarios
- [x] All 50 EVA stage-zero tests passing
- [x] Migration executed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)