### PR TITLE
feat(eva): add archetype-profile interaction matrix

### DIFF
--- a/database/migrations/20260210_archetype_profile_interactions.sql
+++ b/database/migrations/20260210_archetype_profile_interactions.sql
@@ -1,0 +1,94 @@
+-- Migration: Archetype x Profile Interaction Matrix
+-- SD: SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-E
+-- Purpose: Store interaction data between 6 EHG archetypes and evaluation profiles
+
+-- Create archetype_profile_interactions table
+CREATE TABLE IF NOT EXISTS archetype_profile_interactions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  archetype_key TEXT NOT NULL,
+  profile_id UUID NOT NULL REFERENCES evaluation_profiles(id) ON DELETE CASCADE,
+  weight_adjustments JSONB NOT NULL DEFAULT '{}',
+  execution_guidance TEXT[] NOT NULL DEFAULT '{}',
+  compatibility_score NUMERIC(3,2) NOT NULL DEFAULT 0.50 CHECK (compatibility_score >= 0 AND compatibility_score <= 1),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(archetype_key, profile_id)
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_api_archetype ON archetype_profile_interactions(archetype_key);
+CREATE INDEX IF NOT EXISTS idx_api_profile ON archetype_profile_interactions(profile_id);
+
+-- RLS
+ALTER TABLE archetype_profile_interactions ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "api_read_all" ON archetype_profile_interactions FOR SELECT USING (true);
+CREATE POLICY "api_write_service" ON archetype_profile_interactions FOR ALL USING (true) WITH CHECK (true);
+
+-- Comments
+COMMENT ON TABLE archetype_profile_interactions IS 'Interaction matrix between 6 EHG venture archetypes and evaluation profiles, defining weight adjustments and execution guidance';
+COMMENT ON COLUMN archetype_profile_interactions.archetype_key IS 'Archetype identifier: democratizer, automator, capability_productizer, first_principles_rebuilder, vertical_specialist, portfolio_connector';
+COMMENT ON COLUMN archetype_profile_interactions.weight_adjustments IS 'JSONB of component_name → multiplier (0.5-2.0) adjustments for this archetype-profile pair';
+COMMENT ON COLUMN archetype_profile_interactions.execution_guidance IS 'Array of execution strategy hints for this archetype under this profile';
+COMMENT ON COLUMN archetype_profile_interactions.compatibility_score IS 'How well this profile suits this archetype (0.0-1.0)';
+
+-- Seed data: 18 combinations (6 archetypes x 3 profiles)
+-- Get profile IDs
+DO $$
+DECLARE
+  v_balanced UUID;
+  v_aggressive UUID;
+  v_capital UUID;
+BEGIN
+  SELECT id INTO v_balanced FROM evaluation_profiles WHERE name = 'balanced' AND is_active = true LIMIT 1;
+  SELECT id INTO v_aggressive FROM evaluation_profiles WHERE name = 'aggressive_growth' LIMIT 1;
+  SELECT id INTO v_capital FROM evaluation_profiles WHERE name = 'capital_efficient' LIMIT 1;
+
+  -- If profiles don't exist yet, skip seed data
+  IF v_balanced IS NULL OR v_aggressive IS NULL OR v_capital IS NULL THEN
+    RAISE NOTICE 'Evaluation profiles not found - skipping seed data';
+    RETURN;
+  END IF;
+
+  -- Democratizer: Makes expensive capabilities accessible
+  INSERT INTO archetype_profile_interactions (archetype_key, profile_id, weight_adjustments, execution_guidance, compatibility_score) VALUES
+  ('democratizer', v_balanced, '{"virality": 1.2, "moat": 0.9, "market_size": 1.3, "build_cost": 1.0, "time_horizon": 1.0, "cross_reference": 1.0, "portfolio": 0.8, "reframing": 1.1, "constraints": 1.0}'::jsonb, ARRAY['Focus on distribution channels and accessibility', 'Measure adoption rate over revenue initially', 'Build for scale from day one'], 0.70),
+  ('democratizer', v_aggressive, '{"virality": 1.5, "moat": 0.7, "market_size": 1.4, "build_cost": 0.8, "time_horizon": 0.9, "cross_reference": 0.9, "portfolio": 0.7, "reframing": 1.2, "constraints": 0.8}'::jsonb, ARRAY['Prioritize viral growth loops', 'Accept lower margins for market share', 'Speed over perfection in early stages'], 0.85),
+  ('democratizer', v_capital, '{"virality": 1.0, "moat": 1.1, "market_size": 1.2, "build_cost": 1.3, "time_horizon": 1.1, "cross_reference": 1.0, "portfolio": 0.9, "reframing": 1.0, "constraints": 1.2}'::jsonb, ARRAY['Validate unit economics before scaling', 'Focus on premium segment first', 'Build defensible pricing moat'], 0.55)
+  ON CONFLICT (archetype_key, profile_id) DO UPDATE SET weight_adjustments = EXCLUDED.weight_adjustments, execution_guidance = EXCLUDED.execution_guidance, compatibility_score = EXCLUDED.compatibility_score;
+
+  -- Automator: Replaces manual processes with AI
+  INSERT INTO archetype_profile_interactions (archetype_key, profile_id, weight_adjustments, execution_guidance, compatibility_score) VALUES
+  ('automator', v_balanced, '{"virality": 0.9, "moat": 1.2, "market_size": 1.0, "build_cost": 1.1, "time_horizon": 1.0, "cross_reference": 1.1, "portfolio": 1.0, "reframing": 1.0, "constraints": 1.1}'::jsonb, ARRAY['Emphasize ROI and time savings metrics', 'Build integration ecosystem', 'Document automation accuracy rates'], 0.75),
+  ('automator', v_aggressive, '{"virality": 1.1, "moat": 1.0, "market_size": 1.2, "build_cost": 0.9, "time_horizon": 0.8, "cross_reference": 1.0, "portfolio": 0.9, "reframing": 1.1, "constraints": 0.7}'::jsonb, ARRAY['Move fast with imperfect automation', 'Capture market before competitors automate', 'Use AI capabilities as differentiator'], 0.70),
+  ('automator', v_capital, '{"virality": 0.8, "moat": 1.3, "market_size": 0.9, "build_cost": 1.4, "time_horizon": 1.2, "cross_reference": 1.1, "portfolio": 1.1, "reframing": 0.9, "constraints": 1.3}'::jsonb, ARRAY['Prove cost reduction before scaling', 'Build deep technical moat', 'Target high-value enterprise workflows'], 0.80)
+  ON CONFLICT (archetype_key, profile_id) DO UPDATE SET weight_adjustments = EXCLUDED.weight_adjustments, execution_guidance = EXCLUDED.execution_guidance, compatibility_score = EXCLUDED.compatibility_score;
+
+  -- Capability Productizer: Internal capability → external product
+  INSERT INTO archetype_profile_interactions (archetype_key, profile_id, weight_adjustments, execution_guidance, compatibility_score) VALUES
+  ('capability_productizer', v_balanced, '{"virality": 1.0, "moat": 1.3, "market_size": 0.9, "build_cost": 1.2, "time_horizon": 1.1, "cross_reference": 1.2, "portfolio": 1.3, "reframing": 0.9, "constraints": 1.0}'::jsonb, ARRAY['Leverage existing internal expertise', 'Package capability with clear API', 'Build on proven internal track record'], 0.80),
+  ('capability_productizer', v_aggressive, '{"virality": 1.2, "moat": 1.1, "market_size": 1.1, "build_cost": 0.9, "time_horizon": 0.8, "cross_reference": 1.1, "portfolio": 1.2, "reframing": 1.0, "constraints": 0.8}'::jsonb, ARRAY['Launch with existing capability MVP', 'Iterate based on external feedback', 'Cross-sell into existing portfolio'], 0.65),
+  ('capability_productizer', v_capital, '{"virality": 0.8, "moat": 1.4, "market_size": 0.8, "build_cost": 1.3, "time_horizon": 1.2, "cross_reference": 1.3, "portfolio": 1.4, "reframing": 0.8, "constraints": 1.2}'::jsonb, ARRAY['Validate external demand independently', 'Price based on value not cost', 'Build IP protection layer'], 0.75)
+  ON CONFLICT (archetype_key, profile_id) DO UPDATE SET weight_adjustments = EXCLUDED.weight_adjustments, execution_guidance = EXCLUDED.execution_guidance, compatibility_score = EXCLUDED.compatibility_score;
+
+  -- First Principles Rebuilder: Rebuilds broken industry from scratch
+  INSERT INTO archetype_profile_interactions (archetype_key, profile_id, weight_adjustments, execution_guidance, compatibility_score) VALUES
+  ('first_principles_rebuilder', v_balanced, '{"virality": 0.8, "moat": 1.4, "market_size": 1.1, "build_cost": 1.3, "time_horizon": 1.3, "cross_reference": 1.0, "portfolio": 0.8, "reframing": 1.4, "constraints": 1.1}'::jsonb, ARRAY['Invest heavily in problem understanding', 'Build foundational technology layer', 'Plan for multi-year execution'], 0.65),
+  ('first_principles_rebuilder', v_aggressive, '{"virality": 1.0, "moat": 1.2, "market_size": 1.3, "build_cost": 0.7, "time_horizon": 0.7, "cross_reference": 0.9, "portfolio": 0.7, "reframing": 1.3, "constraints": 0.7}'::jsonb, ARRAY['Find narrow wedge to enter market', 'Rebuild incrementally not all at once', 'Challenge industry assumptions publicly'], 0.50),
+  ('first_principles_rebuilder', v_capital, '{"virality": 0.7, "moat": 1.5, "market_size": 1.0, "build_cost": 1.4, "time_horizon": 1.4, "cross_reference": 1.1, "portfolio": 0.9, "reframing": 1.3, "constraints": 1.3}'::jsonb, ARRAY['Validate rebuild economics rigorously', 'Secure long-term funding commitment', 'Build switching costs into architecture'], 0.70)
+  ON CONFLICT (archetype_key, profile_id) DO UPDATE SET weight_adjustments = EXCLUDED.weight_adjustments, execution_guidance = EXCLUDED.execution_guidance, compatibility_score = EXCLUDED.compatibility_score;
+
+  -- Vertical Specialist: Deep niche expertise
+  INSERT INTO archetype_profile_interactions (archetype_key, profile_id, weight_adjustments, execution_guidance, compatibility_score) VALUES
+  ('vertical_specialist', v_balanced, '{"virality": 0.7, "moat": 1.4, "market_size": 0.8, "build_cost": 1.1, "time_horizon": 1.1, "cross_reference": 0.9, "portfolio": 0.9, "reframing": 0.8, "constraints": 1.2}'::jsonb, ARRAY['Become the definitive authority in niche', 'Build deep domain-specific features', 'Create high switching costs through specialization'], 0.75),
+  ('vertical_specialist', v_aggressive, '{"virality": 0.9, "moat": 1.2, "market_size": 1.0, "build_cost": 0.9, "time_horizon": 0.9, "cross_reference": 0.8, "portfolio": 0.8, "reframing": 0.9, "constraints": 0.9}'::jsonb, ARRAY['Capture niche quickly before generalists arrive', 'Expand vertically before horizontally', 'Build community-driven growth in niche'], 0.55),
+  ('vertical_specialist', v_capital, '{"virality": 0.6, "moat": 1.5, "market_size": 0.7, "build_cost": 1.2, "time_horizon": 1.2, "cross_reference": 1.0, "portfolio": 1.0, "reframing": 0.7, "constraints": 1.3}'::jsonb, ARRAY['Prove unit economics in narrow market', 'Build enterprise-grade vertical solution', 'Maximize revenue per customer over volume'], 0.85)
+  ON CONFLICT (archetype_key, profile_id) DO UPDATE SET weight_adjustments = EXCLUDED.weight_adjustments, execution_guidance = EXCLUDED.execution_guidance, compatibility_score = EXCLUDED.compatibility_score;
+
+  -- Portfolio Connector: Bridges gaps between EHG ventures
+  INSERT INTO archetype_profile_interactions (archetype_key, profile_id, weight_adjustments, execution_guidance, compatibility_score) VALUES
+  ('portfolio_connector', v_balanced, '{"virality": 0.9, "moat": 1.1, "market_size": 0.9, "build_cost": 1.0, "time_horizon": 1.0, "cross_reference": 1.4, "portfolio": 1.5, "reframing": 1.0, "constraints": 1.0}'::jsonb, ARRAY['Map integration points between ventures', 'Create shared data infrastructure', 'Measure cross-venture synergies'], 0.80),
+  ('portfolio_connector', v_aggressive, '{"virality": 1.1, "moat": 0.9, "market_size": 1.0, "build_cost": 0.8, "time_horizon": 0.8, "cross_reference": 1.3, "portfolio": 1.4, "reframing": 1.1, "constraints": 0.8}'::jsonb, ARRAY['Launch MVP connecting two ventures', 'Iterate on connection value rapidly', 'Use network effects across portfolio'], 0.60),
+  ('portfolio_connector', v_capital, '{"virality": 0.7, "moat": 1.2, "market_size": 0.8, "build_cost": 1.1, "time_horizon": 1.1, "cross_reference": 1.5, "portfolio": 1.5, "reframing": 0.9, "constraints": 1.2}'::jsonb, ARRAY['Validate connector economics independently', 'Build robust integration architecture', 'Prove portfolio-level ROI before scaling'], 0.70)
+  ON CONFLICT (archetype_key, profile_id) DO UPDATE SET weight_adjustments = EXCLUDED.weight_adjustments, execution_guidance = EXCLUDED.execution_guidance, compatibility_score = EXCLUDED.compatibility_score;
+
+END $$;

--- a/lib/eva/stage-zero/archetype-profile-matrix.js
+++ b/lib/eva/stage-zero/archetype-profile-matrix.js
@@ -1,0 +1,141 @@
+/**
+ * Archetype x Profile Interaction Matrix Service
+ *
+ * Provides weight adjustments and execution guidance based on how
+ * each of the 6 EHG venture archetypes interacts with each
+ * evaluation profile (balanced, aggressive_growth, capital_efficient).
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-E
+ */
+
+import { VALID_ARCHETYPE_KEYS } from './synthesis/archetypes.js';
+
+/** Multiplier bounds to prevent extreme distortion. */
+const MIN_MULTIPLIER = 0.5;
+const MAX_MULTIPLIER = 2.0;
+
+/**
+ * Clamp a multiplier to valid bounds.
+ * @param {number} value
+ * @returns {number}
+ */
+function clampMultiplier(value) {
+  if (typeof value !== 'number' || isNaN(value)) return 1.0;
+  return Math.min(MAX_MULTIPLIER, Math.max(MIN_MULTIPLIER, value));
+}
+
+/**
+ * Get the archetype-profile interaction matrix entry for a given pair.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {string} archetypeKey - One of the 6 EHG archetype keys
+ * @param {Object|null} profile - Resolved evaluation profile (from resolveProfile)
+ * @returns {Promise<Object>} Matrix entry with adjusted_weights, execution_modifiers, compatibility_score
+ */
+export async function getArchetypeProfileMatrix(deps, archetypeKey, profile) {
+  const { supabase, logger = console } = deps;
+
+  if (!archetypeKey || !VALID_ARCHETYPE_KEYS.includes(archetypeKey)) {
+    return defaultMatrix(archetypeKey || 'unknown', 'Invalid archetype key');
+  }
+
+  if (!profile?.id || !supabase) {
+    return defaultMatrix(archetypeKey, 'No profile or supabase client');
+  }
+
+  const { data, error } = await supabase
+    .from('archetype_profile_interactions')
+    .select('weight_adjustments, execution_guidance, compatibility_score')
+    .eq('archetype_key', archetypeKey)
+    .eq('profile_id', profile.id)
+    .single();
+
+  if (error || !data) {
+    logger.warn(`Archetype-profile matrix: No entry for ${archetypeKey} + ${profile.name}: ${error?.message || 'not found'}`);
+    return defaultMatrix(archetypeKey, `No matrix entry for ${profile.name}`);
+  }
+
+  return {
+    archetype_key: archetypeKey,
+    profile_name: profile.name,
+    adjusted_weights: data.weight_adjustments || {},
+    execution_modifiers: data.execution_guidance || [],
+    compatibility_score: parseFloat(data.compatibility_score) || 0.5,
+  };
+}
+
+/**
+ * Apply matrix weight adjustments to raw component scores.
+ *
+ * @param {Object} rawScores - Component name → score (0-1)
+ * @param {Object} matrixData - From getArchetypeProfileMatrix
+ * @returns {Object} Adjusted scores with multipliers applied and clamped
+ */
+export function applyMatrixAdjustments(rawScores, matrixData) {
+  if (!rawScores || !matrixData?.adjusted_weights) {
+    return { ...(rawScores || {}) };
+  }
+
+  const adjusted = {};
+  for (const [component, score] of Object.entries(rawScores)) {
+    const multiplier = clampMultiplier(matrixData.adjusted_weights[component]);
+    adjusted[component] = Math.round(score * multiplier * 100) / 100;
+  }
+
+  return adjusted;
+}
+
+/**
+ * Get compatibility report: ranked profiles for a given archetype.
+ *
+ * @param {Object} deps - { supabase }
+ * @param {string} archetypeKey - Archetype to query
+ * @returns {Promise<Array>} Sorted array of { profile_name, profile_id, compatibility_score }
+ */
+export async function getCompatibilityReport(deps, archetypeKey) {
+  const { supabase } = deps;
+
+  if (!supabase || !archetypeKey) return [];
+
+  const { data, error } = await supabase
+    .from('archetype_profile_interactions')
+    .select('profile_id, compatibility_score, execution_guidance')
+    .eq('archetype_key', archetypeKey)
+    .order('compatibility_score', { ascending: false });
+
+  if (error) throw new Error(`Failed to fetch compatibility report: ${error.message}`);
+  if (!data || data.length === 0) return [];
+
+  // Fetch profile names
+  const profileIds = data.map(d => d.profile_id);
+  const { data: profiles } = await supabase
+    .from('evaluation_profiles')
+    .select('id, name')
+    .in('id', profileIds);
+
+  const profileMap = new Map((profiles || []).map(p => [p.id, p.name]));
+
+  return data.map(d => ({
+    profile_name: profileMap.get(d.profile_id) || 'unknown',
+    profile_id: d.profile_id,
+    compatibility_score: parseFloat(d.compatibility_score) || 0,
+    execution_guidance: d.execution_guidance || [],
+  }));
+}
+
+/**
+ * Default matrix returned when no interaction data exists.
+ */
+function defaultMatrix(archetypeKey, reason) {
+  return {
+    archetype_key: archetypeKey,
+    profile_name: null,
+    adjusted_weights: {},
+    execution_modifiers: [],
+    compatibility_score: 0.5,
+    _default: true,
+    _reason: reason,
+  };
+}
+
+export { MIN_MULTIPLIER, MAX_MULTIPLIER, clampMultiplier };

--- a/tests/unit/eva/stage-zero/archetype-profile-matrix.test.js
+++ b/tests/unit/eva/stage-zero/archetype-profile-matrix.test.js
@@ -1,0 +1,251 @@
+/**
+ * Unit Tests: Archetype x Profile Interaction Matrix
+ * SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-E
+ *
+ * Test Coverage:
+ * - getArchetypeProfileMatrix (valid pair, null profile, invalid archetype, db error)
+ * - applyMatrixAdjustments (normal, clamping, null inputs)
+ * - getCompatibilityReport (ranked results, empty, error)
+ * - clampMultiplier (bounds, NaN, normal)
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  getArchetypeProfileMatrix,
+  applyMatrixAdjustments,
+  getCompatibilityReport,
+  clampMultiplier,
+  MIN_MULTIPLIER,
+  MAX_MULTIPLIER,
+} from '../../../../lib/eva/stage-zero/archetype-profile-matrix.js';
+
+// --- Mock helpers ---
+
+function createMockSupabase(singleResponse = { data: null, error: null }) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(singleResponse),
+    order: vi.fn().mockResolvedValue(singleResponse),
+    in: vi.fn().mockResolvedValue({ data: [], error: null }),
+  };
+  return { from: vi.fn().mockReturnValue(chain), _chain: chain };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+// --- Tests ---
+
+describe('clampMultiplier', () => {
+  test('returns value when within bounds', () => {
+    expect(clampMultiplier(1.0)).toBe(1.0);
+    expect(clampMultiplier(1.5)).toBe(1.5);
+    expect(clampMultiplier(0.5)).toBe(0.5);
+    expect(clampMultiplier(2.0)).toBe(2.0);
+  });
+
+  test('clamps values below minimum', () => {
+    expect(clampMultiplier(0.1)).toBe(MIN_MULTIPLIER);
+    expect(clampMultiplier(0)).toBe(MIN_MULTIPLIER);
+    expect(clampMultiplier(-1)).toBe(MIN_MULTIPLIER);
+  });
+
+  test('clamps values above maximum', () => {
+    expect(clampMultiplier(3.0)).toBe(MAX_MULTIPLIER);
+    expect(clampMultiplier(5.0)).toBe(MAX_MULTIPLIER);
+  });
+
+  test('returns 1.0 for NaN and non-numbers', () => {
+    expect(clampMultiplier(NaN)).toBe(1.0);
+    expect(clampMultiplier(undefined)).toBe(1.0);
+    expect(clampMultiplier('abc')).toBe(1.0);
+  });
+});
+
+describe('getArchetypeProfileMatrix', () => {
+  test('returns matrix entry for valid archetype-profile pair', async () => {
+    const matrixRow = {
+      weight_adjustments: { virality: 1.5, moat: 0.7 },
+      execution_guidance: ['Prioritize viral growth', 'Speed over perfection'],
+      compatibility_score: 0.85,
+    };
+    const supabase = createMockSupabase({ data: matrixRow, error: null });
+
+    const result = await getArchetypeProfileMatrix(
+      { supabase, logger: silentLogger },
+      'democratizer',
+      { id: 'profile-uuid', name: 'aggressive_growth' }
+    );
+
+    expect(result.archetype_key).toBe('democratizer');
+    expect(result.profile_name).toBe('aggressive_growth');
+    expect(result.adjusted_weights).toEqual({ virality: 1.5, moat: 0.7 });
+    expect(result.execution_modifiers).toHaveLength(2);
+    expect(result.compatibility_score).toBe(0.85);
+    expect(result._default).toBeUndefined();
+  });
+
+  test('returns default matrix when profile is null', async () => {
+    const supabase = createMockSupabase();
+
+    const result = await getArchetypeProfileMatrix(
+      { supabase, logger: silentLogger },
+      'automator',
+      null
+    );
+
+    expect(result.archetype_key).toBe('automator');
+    expect(result.profile_name).toBeNull();
+    expect(result.adjusted_weights).toEqual({});
+    expect(result.compatibility_score).toBe(0.5);
+    expect(result._default).toBe(true);
+  });
+
+  test('returns default matrix for invalid archetype key', async () => {
+    const supabase = createMockSupabase();
+
+    const result = await getArchetypeProfileMatrix(
+      { supabase, logger: silentLogger },
+      'invalid_type',
+      { id: 'profile-uuid', name: 'balanced' }
+    );
+
+    expect(result._default).toBe(true);
+    expect(result.archetype_key).toBe('invalid_type');
+  });
+
+  test('returns default matrix on database error', async () => {
+    const supabase = createMockSupabase({
+      data: null,
+      error: { message: 'connection error' },
+    });
+
+    const result = await getArchetypeProfileMatrix(
+      { supabase, logger: silentLogger },
+      'democratizer',
+      { id: 'profile-uuid', name: 'balanced' }
+    );
+
+    expect(result._default).toBe(true);
+    expect(silentLogger.warn).toHaveBeenCalled();
+  });
+
+  test('returns default matrix when no supabase client', async () => {
+    const result = await getArchetypeProfileMatrix(
+      { supabase: null, logger: silentLogger },
+      'automator',
+      { id: 'profile-uuid', name: 'balanced' }
+    );
+
+    expect(result._default).toBe(true);
+  });
+});
+
+describe('applyMatrixAdjustments', () => {
+  test('applies multipliers to raw scores', () => {
+    const rawScores = { virality: 0.8, moat: 0.6, market_size: 0.5 };
+    const matrixData = {
+      adjusted_weights: { virality: 1.3, moat: 0.7, market_size: 1.0 },
+    };
+
+    const result = applyMatrixAdjustments(rawScores, matrixData);
+
+    expect(result.virality).toBe(1.04); // 0.8 * 1.3
+    expect(result.moat).toBe(0.42); // 0.6 * 0.7
+    expect(result.market_size).toBe(0.5); // 0.5 * 1.0
+  });
+
+  test('clamps extreme multipliers to bounds', () => {
+    const rawScores = { virality: 0.5 };
+    const matrixData = {
+      adjusted_weights: { virality: 5.0 }, // Should be clamped to 2.0
+    };
+
+    const result = applyMatrixAdjustments(rawScores, matrixData);
+    expect(result.virality).toBe(1.0); // 0.5 * 2.0 (clamped)
+  });
+
+  test('uses 1.0 multiplier for components not in matrix', () => {
+    const rawScores = { virality: 0.8, unknown_component: 0.6 };
+    const matrixData = {
+      adjusted_weights: { virality: 1.2 },
+    };
+
+    const result = applyMatrixAdjustments(rawScores, matrixData);
+    expect(result.virality).toBe(0.96); // 0.8 * 1.2
+    expect(result.unknown_component).toBe(0.6); // 0.6 * 1.0 (default)
+  });
+
+  test('returns copy of raw scores when no matrix data', () => {
+    const rawScores = { virality: 0.8 };
+
+    const result = applyMatrixAdjustments(rawScores, null);
+    expect(result).toEqual({ virality: 0.8 });
+  });
+
+  test('returns empty object when no raw scores', () => {
+    const result = applyMatrixAdjustments(null, { adjusted_weights: {} });
+    expect(result).toEqual({});
+  });
+});
+
+describe('getCompatibilityReport', () => {
+  test('returns ranked profiles for archetype', async () => {
+    const interactions = [
+      { profile_id: 'p1', compatibility_score: 0.85, execution_guidance: ['tip1'] },
+      { profile_id: 'p2', compatibility_score: 0.70, execution_guidance: ['tip2'] },
+      { profile_id: 'p3', compatibility_score: 0.55, execution_guidance: ['tip3'] },
+    ];
+    const profiles = [
+      { id: 'p1', name: 'aggressive_growth' },
+      { id: 'p2', name: 'balanced' },
+      { id: 'p3', name: 'capital_efficient' },
+    ];
+
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: interactions, error: null }),
+      in: vi.fn().mockResolvedValue({ data: profiles, error: null }),
+    };
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+
+    const result = await getCompatibilityReport({ supabase }, 'democratizer');
+
+    expect(result).toHaveLength(3);
+    expect(result[0].profile_name).toBe('aggressive_growth');
+    expect(result[0].compatibility_score).toBe(0.85);
+    expect(result[1].profile_name).toBe('balanced');
+    expect(result[2].profile_name).toBe('capital_efficient');
+  });
+
+  test('returns empty array when no data', async () => {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+
+    const result = await getCompatibilityReport({ supabase }, 'automator');
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array when no supabase', async () => {
+    const result = await getCompatibilityReport({ supabase: null }, 'automator');
+    expect(result).toEqual([]);
+  });
+
+  test('throws on database error', async () => {
+    const chain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: null, error: { message: 'db fail' } }),
+    };
+    const supabase = { from: vi.fn().mockReturnValue(chain) };
+
+    await expect(
+      getCompatibilityReport({ supabase }, 'automator')
+    ).rejects.toThrow('Failed to fetch compatibility report: db fail');
+  });
+});


### PR DESCRIPTION
## Summary
- Create `archetype_profile_interactions` table with 18 seed rows (6 archetypes x 3 profiles)
- Implement `archetype-profile-matrix.js` with matrix lookup, weight adjustment, and compatibility reporting
- Add 18 unit tests (68 total across EVA stage-zero suite)
- Multipliers clamped to 0.5-2.0 range to prevent score distortion

## SD
SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-E (Child E of orchestrator)

## Test plan
- [x] 18 unit tests covering getArchetypeProfileMatrix, applyMatrixAdjustments, getCompatibilityReport
- [x] Tests verify null profile fallback, clamping, DB error handling
- [x] All 68 EVA stage-zero tests passing
- [x] Migration executed with 18 seed rows verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)