### PR TITLE
feat(eva): add sensitivity analysis engine for weight perturbation

### DIFF
--- a/lib/eva/stage-zero/sensitivity-analysis.js
+++ b/lib/eva/stage-zero/sensitivity-analysis.js
@@ -1,0 +1,137 @@
+/**
+ * Sensitivity Analysis Engine
+ *
+ * Performs one-at-a-time (OAT) weight perturbation analysis to identify
+ * which synthesis component weights most influence composite venture scores.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-F
+ */
+
+import { calculateWeightedScore, VALID_COMPONENTS } from './profile-service.js';
+
+const DEFAULT_DELTA = 0.05;
+
+/**
+ * Run one-at-a-time sensitivity analysis on synthesis results.
+ *
+ * For each component weight, perturb it by ±delta while holding others constant,
+ * then measure the composite score shift. Returns components ranked by influence.
+ *
+ * @param {Object} synthesisResults - Map of component name → result object
+ * @param {Object} weights - Map of component name → weight (0-1)
+ * @param {Object} [options]
+ * @param {number} [options.delta=0.05] - Perturbation amount for each weight
+ * @returns {Array<Object>} Ranked array of { component, influence_score, elasticity, score_delta }
+ */
+export function runSensitivityAnalysis(synthesisResults, weights, options = {}) {
+  const delta = options.delta ?? DEFAULT_DELTA;
+
+  if (!synthesisResults || !weights) {
+    return VALID_COMPONENTS.map(c => ({
+      component: c,
+      influence_score: 0,
+      elasticity: 0,
+      score_delta: 0,
+    }));
+  }
+
+  const results = [];
+  let totalAbsDelta = 0;
+
+  for (const component of VALID_COMPONENTS) {
+    const currentWeight = weights[component] ?? 0;
+    const elasticity = calculateElasticity(component, synthesisResults, weights, delta);
+    const scoreDelta = Math.abs(elasticity * delta);
+
+    results.push({
+      component,
+      influence_score: 0, // placeholder, normalized below
+      elasticity,
+      score_delta: Math.round(scoreDelta * 100) / 100,
+    });
+
+    totalAbsDelta += scoreDelta;
+  }
+
+  // Normalize influence scores to sum to 1.0
+  for (const r of results) {
+    r.influence_score = totalAbsDelta > 0
+      ? Math.round((r.score_delta / totalAbsDelta) * 10000) / 10000
+      : 0;
+  }
+
+  // Sort by influence descending
+  results.sort((a, b) => b.influence_score - a.influence_score);
+
+  return results;
+}
+
+/**
+ * Identify the minimal set of key driver components that explain
+ * at least the given threshold of total score variance.
+ *
+ * @param {Array<Object>} ranking - Output from runSensitivityAnalysis
+ * @param {number} [threshold=0.80] - Minimum cumulative influence to reach
+ * @returns {Array<Object>} Subset of ranking explaining ≥ threshold of variance
+ */
+export function identifyKeyDrivers(ranking, threshold = 0.80) {
+  if (!ranking || ranking.length === 0) return [];
+
+  // Ranking should already be sorted by influence descending
+  const sorted = [...ranking].sort((a, b) => b.influence_score - a.influence_score);
+
+  const drivers = [];
+  let cumulative = 0;
+
+  for (const item of sorted) {
+    drivers.push(item);
+    cumulative += item.influence_score;
+    if (cumulative >= threshold) break;
+  }
+
+  return drivers;
+}
+
+/**
+ * Calculate the elasticity coefficient for a single component.
+ *
+ * Elasticity = (score_at_weight+delta - score_at_weight-delta) / (2 * delta)
+ *
+ * This measures how sensitive the composite score is to changes in this
+ * component's weight, in units of "score points per unit weight change".
+ *
+ * @param {string} component - Component name
+ * @param {Object} synthesisResults - Map of component → result object
+ * @param {Object} weights - Map of component → weight
+ * @param {number} [delta=0.05] - Perturbation amount
+ * @returns {number} Elasticity coefficient
+ */
+export function calculateElasticity(component, synthesisResults, weights, delta = DEFAULT_DELTA) {
+  if (!synthesisResults || !weights) return 0;
+
+  const currentWeight = weights[component] ?? 0;
+
+  // If weight is 0 and delta would go negative, elasticity is 0
+  if (currentWeight === 0 && delta > 0) {
+    // Can only perturb upward from 0
+    const weightsUp = { ...weights, [component]: delta };
+    const scoreUp = calculateWeightedScore(synthesisResults, weightsUp).total_score;
+    const scoreBase = calculateWeightedScore(synthesisResults, weights).total_score;
+    return Math.round(((scoreUp - scoreBase) / delta) * 100) / 100;
+  }
+
+  // Perturb up and down
+  const weightUp = Math.min(1, currentWeight + delta);
+  const weightDown = Math.max(0, currentWeight - delta);
+  const actualDelta = (weightUp - weightDown) / 2;
+
+  if (actualDelta === 0) return 0;
+
+  const weightsUp = { ...weights, [component]: weightUp };
+  const weightsDown = { ...weights, [component]: weightDown };
+
+  const scoreUp = calculateWeightedScore(synthesisResults, weightsUp).total_score;
+  const scoreDown = calculateWeightedScore(synthesisResults, weightsDown).total_score;
+
+  return Math.round(((scoreUp - scoreDown) / (2 * actualDelta)) * 100) / 100;
+}

--- a/tests/unit/eva/stage-zero/sensitivity-analysis.test.js
+++ b/tests/unit/eva/stage-zero/sensitivity-analysis.test.js
@@ -1,0 +1,234 @@
+/**
+ * Sensitivity Analysis Engine Tests
+ *
+ * Tests for OAT perturbation analysis, key driver identification,
+ * and elasticity calculation.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-F
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  runSensitivityAnalysis,
+  identifyKeyDrivers,
+  calculateElasticity,
+} from '../../../../lib/eva/stage-zero/sensitivity-analysis.js';
+
+// Mock synthesis results that produce deterministic scores
+// Using extractComponentScore logic from profile-service.js:
+//   cross_reference: relevance_score → 80
+//   portfolio_evaluation: composite_score → 70
+//   problem_reframing: reframings.length > 0 → 70
+//   moat_architecture: moat_score → 90
+//   chairman_constraints: verdict=pass → 100
+//   time_horizon: position=build_now → 100
+//   archetypes: primary_confidence → 85
+//   build_cost: complexity=simple → 90
+//   virality: virality_score → 75
+const MOCK_RESULTS = {
+  cross_reference: { relevance_score: 80 },
+  portfolio_evaluation: { composite_score: 70 },
+  problem_reframing: { reframings: ['reframe1'] },
+  moat_architecture: { moat_score: 90 },
+  chairman_constraints: { verdict: 'pass' },
+  time_horizon: { position: 'build_now' },
+  archetypes: { primary_confidence: 0.85 },
+  build_cost: { complexity: 'simple' },
+  virality: { virality_score: 75 },
+};
+
+const EQUAL_WEIGHTS = {
+  cross_reference: 1 / 9,
+  portfolio_evaluation: 1 / 9,
+  problem_reframing: 1 / 9,
+  moat_architecture: 1 / 9,
+  chairman_constraints: 1 / 9,
+  time_horizon: 1 / 9,
+  archetypes: 1 / 9,
+  build_cost: 1 / 9,
+  virality: 1 / 9,
+};
+
+const LEGACY_WEIGHTS = {
+  cross_reference: 0.10,
+  portfolio_evaluation: 0.10,
+  problem_reframing: 0.05,
+  moat_architecture: 0.15,
+  chairman_constraints: 0.15,
+  time_horizon: 0.10,
+  archetypes: 0.10,
+  build_cost: 0.10,
+  virality: 0.15,
+};
+
+describe('sensitivity-analysis', () => {
+  describe('runSensitivityAnalysis', () => {
+    it('returns ranked array of 9 components with influence scores', () => {
+      const result = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
+
+      expect(result).toHaveLength(9);
+      expect(result[0]).toHaveProperty('component');
+      expect(result[0]).toHaveProperty('influence_score');
+      expect(result[0]).toHaveProperty('elasticity');
+      expect(result[0]).toHaveProperty('score_delta');
+    });
+
+    it('ranks components by influence descending', () => {
+      const result = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
+
+      for (let i = 0; i < result.length - 1; i++) {
+        expect(result[i].influence_score).toBeGreaterThanOrEqual(result[i + 1].influence_score);
+      }
+    });
+
+    it('normalizes influence scores to sum to 1.0', () => {
+      const result = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
+      const sum = result.reduce((acc, r) => acc + r.influence_score, 0);
+
+      // Allow small floating point rounding
+      expect(sum).toBeCloseTo(1.0, 2);
+    });
+
+    it('with equal weights, ranking reflects raw score differences', () => {
+      const result = runSensitivityAnalysis(MOCK_RESULTS, EQUAL_WEIGHTS);
+
+      // Higher raw score components should have higher influence
+      // chairman_constraints (100) and time_horizon (100) should be near top
+      const topComponents = result.slice(0, 3).map(r => r.component);
+      expect(topComponents).toContain('chairman_constraints');
+      expect(topComponents).toContain('time_horizon');
+    });
+
+    it('handles custom delta option', () => {
+      const small = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS, { delta: 0.01 });
+      const large = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS, { delta: 0.10 });
+
+      // Both should return 9 components
+      expect(small).toHaveLength(9);
+      expect(large).toHaveLength(9);
+    });
+
+    it('returns zero influence for null inputs', () => {
+      const result = runSensitivityAnalysis(null, null);
+
+      expect(result).toHaveLength(9);
+      for (const r of result) {
+        expect(r.influence_score).toBe(0);
+        expect(r.elasticity).toBe(0);
+      }
+    });
+
+    it('returns zero influence when all weights are zero', () => {
+      const zeroWeights = {};
+      for (const c of Object.keys(LEGACY_WEIGHTS)) {
+        zeroWeights[c] = 0;
+      }
+
+      const result = runSensitivityAnalysis(MOCK_RESULTS, zeroWeights);
+
+      // With zero weights, perturbing upward from 0 should still detect influence
+      expect(result).toHaveLength(9);
+      // At least some components should have non-zero influence since we perturb up from 0
+      const totalInfluence = result.reduce((acc, r) => acc + r.influence_score, 0);
+      expect(totalInfluence).toBeCloseTo(1.0, 2);
+    });
+
+    it('handles single dominant weight', () => {
+      const dominantWeights = {};
+      for (const c of Object.keys(LEGACY_WEIGHTS)) {
+        dominantWeights[c] = 0;
+      }
+      dominantWeights.moat_architecture = 1.0;
+
+      const result = runSensitivityAnalysis(MOCK_RESULTS, dominantWeights);
+
+      expect(result).toHaveLength(9);
+      // moat_architecture should have significant influence
+      const moat = result.find(r => r.component === 'moat_architecture');
+      expect(moat).toBeDefined();
+      expect(moat.influence_score).toBeGreaterThan(0);
+    });
+  });
+
+  describe('identifyKeyDrivers', () => {
+    it('returns minimal set explaining 80% of variance', () => {
+      const ranking = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
+      const drivers = identifyKeyDrivers(ranking, 0.80);
+
+      expect(drivers.length).toBeLessThanOrEqual(9);
+      expect(drivers.length).toBeGreaterThan(0);
+
+      const cumulative = drivers.reduce((acc, d) => acc + d.influence_score, 0);
+      expect(cumulative).toBeGreaterThanOrEqual(0.80);
+    });
+
+    it('returns fewer components for lower thresholds', () => {
+      const ranking = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
+      const low = identifyKeyDrivers(ranking, 0.50);
+      const high = identifyKeyDrivers(ranking, 0.90);
+
+      expect(low.length).toBeLessThanOrEqual(high.length);
+    });
+
+    it('returns all components when threshold is 1.0', () => {
+      const ranking = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
+      const drivers = identifyKeyDrivers(ranking, 1.0);
+
+      expect(drivers.length).toBe(9);
+    });
+
+    it('returns empty array for null ranking', () => {
+      expect(identifyKeyDrivers(null)).toEqual([]);
+      expect(identifyKeyDrivers([])).toEqual([]);
+    });
+
+    it('returns sorted by influence descending', () => {
+      const ranking = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
+      const drivers = identifyKeyDrivers(ranking, 0.80);
+
+      for (let i = 0; i < drivers.length - 1; i++) {
+        expect(drivers[i].influence_score).toBeGreaterThanOrEqual(drivers[i + 1].influence_score);
+      }
+    });
+  });
+
+  describe('calculateElasticity', () => {
+    it('returns numeric coefficient for each component', () => {
+      for (const component of Object.keys(LEGACY_WEIGHTS)) {
+        const e = calculateElasticity(component, MOCK_RESULTS, LEGACY_WEIGHTS);
+        expect(typeof e).toBe('number');
+        expect(isNaN(e)).toBe(false);
+      }
+    });
+
+    it('higher raw score components have higher elasticity', () => {
+      // chairman_constraints has raw score 100, problem_reframing has 70
+      const eChairman = calculateElasticity('chairman_constraints', MOCK_RESULTS, EQUAL_WEIGHTS);
+      const eProblem = calculateElasticity('problem_reframing', MOCK_RESULTS, EQUAL_WEIGHTS);
+
+      expect(Math.abs(eChairman)).toBeGreaterThanOrEqual(Math.abs(eProblem));
+    });
+
+    it('returns value for zero-weight component', () => {
+      const zeroWeights = { ...LEGACY_WEIGHTS, virality: 0 };
+      const e = calculateElasticity('virality', MOCK_RESULTS, zeroWeights);
+
+      // Perturbing up from 0 should give a positive elasticity for a component with score
+      expect(typeof e).toBe('number');
+    });
+
+    it('returns 0 for null inputs', () => {
+      expect(calculateElasticity('moat_architecture', null, LEGACY_WEIGHTS)).toBe(0);
+      expect(calculateElasticity('moat_architecture', MOCK_RESULTS, null)).toBe(0);
+    });
+
+    it('respects custom delta', () => {
+      const e1 = calculateElasticity('moat_architecture', MOCK_RESULTS, LEGACY_WEIGHTS, 0.01);
+      const e2 = calculateElasticity('moat_architecture', MOCK_RESULTS, LEGACY_WEIGHTS, 0.10);
+
+      // Both should be numbers (elasticity may differ slightly due to rounding)
+      expect(typeof e1).toBe('number');
+      expect(typeof e2).toBe('number');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements OAT (one-at-a-time) weight perturbation analysis for EVA Stage 0
- `runSensitivityAnalysis` ranks 9 components by their influence on composite scores
- `identifyKeyDrivers` finds the minimal set explaining ≥80% of variance
- `calculateElasticity` computes per-component sensitivity coefficients
- 18 unit tests covering perturbation, key drivers, elasticity, and edge cases
- All 86 EVA stage-zero tests passing (no regressions)

Child F of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001.

## Test plan
- [x] 18 new unit tests pass
- [x] All 86 EVA stage-zero tests pass (no regressions)
- [x] Full handoff chain complete (LEAD→PLAN→EXEC→PLAN→LEAD→APPROVAL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)