### PR TITLE
feat(eva): add portfolio-level profile allocation with nudge logic

### DIFF
--- a/database/migrations/20260210_portfolio_profile_allocations.sql
+++ b/database/migrations/20260210_portfolio_profile_allocations.sql
@@ -1,0 +1,71 @@
+-- Portfolio Profile Allocations
+-- Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-G
+-- Tracks target and current allocation percentages per evaluation profile
+
+CREATE TABLE IF NOT EXISTS portfolio_profile_allocations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  profile_id UUID NOT NULL REFERENCES evaluation_profiles(id) ON DELETE CASCADE,
+  target_pct NUMERIC(5,2) NOT NULL DEFAULT 33.33 CHECK (target_pct >= 0 AND target_pct <= 100),
+  current_pct NUMERIC(5,2) NOT NULL DEFAULT 0 CHECK (current_pct >= 0 AND current_pct <= 100),
+  description TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(profile_id)
+);
+
+-- Enable RLS
+ALTER TABLE portfolio_profile_allocations ENABLE ROW LEVEL SECURITY;
+
+-- Allow service role full access
+DROP POLICY IF EXISTS "service_role_full_access_portfolio_alloc" ON portfolio_profile_allocations;
+CREATE POLICY "service_role_full_access_portfolio_alloc"
+  ON portfolio_profile_allocations
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Seed default allocations using existing evaluation profiles
+DO $$
+DECLARE
+  v_aggressive UUID;
+  v_balanced UUID;
+  v_capital UUID;
+BEGIN
+  SELECT id INTO v_aggressive FROM evaluation_profiles WHERE name = 'aggressive_growth' LIMIT 1;
+  SELECT id INTO v_balanced FROM evaluation_profiles WHERE name = 'balanced' LIMIT 1;
+  SELECT id INTO v_capital FROM evaluation_profiles WHERE name = 'capital_efficient' LIMIT 1;
+
+  IF v_aggressive IS NOT NULL THEN
+    INSERT INTO portfolio_profile_allocations (profile_id, target_pct, current_pct, description)
+    VALUES (v_aggressive, 40.00, 0, 'Aggressive growth ventures targeting rapid scale')
+    ON CONFLICT (profile_id) DO NOTHING;
+  END IF;
+
+  IF v_balanced IS NOT NULL THEN
+    INSERT INTO portfolio_profile_allocations (profile_id, target_pct, current_pct, description)
+    VALUES (v_balanced, 30.00, 0, 'Balanced ventures with moderate risk/reward')
+    ON CONFLICT (profile_id) DO NOTHING;
+  END IF;
+
+  IF v_capital IS NOT NULL THEN
+    INSERT INTO portfolio_profile_allocations (profile_id, target_pct, current_pct, description)
+    VALUES (v_capital, 30.00, 0, 'Capital efficient ventures with lower burn')
+    ON CONFLICT (profile_id) DO NOTHING;
+  END IF;
+END $$;
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION update_portfolio_allocation_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_update_portfolio_allocation_timestamp ON portfolio_profile_allocations;
+CREATE TRIGGER trg_update_portfolio_allocation_timestamp
+  BEFORE UPDATE ON portfolio_profile_allocations
+  FOR EACH ROW
+  EXECUTE FUNCTION update_portfolio_allocation_timestamp();

--- a/lib/eva/stage-zero/portfolio-allocation.js
+++ b/lib/eva/stage-zero/portfolio-allocation.js
@@ -1,0 +1,189 @@
+/**
+ * Portfolio-Level Profile Allocation Service
+ *
+ * Manages portfolio-level target allocation across evaluation profiles.
+ * When the portfolio is overweight in one profile style, nudges profile
+ * selection toward underrepresented styles for balance.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-G
+ */
+
+/**
+ * Get current portfolio allocation snapshot.
+ *
+ * Returns target vs current allocation for each evaluation profile,
+ * with gap calculation (positive gap = underrepresented).
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @returns {Promise<Array<Object>>} Allocations with { profile_id, profile_name, target_pct, current_pct, gap }
+ */
+export async function getPortfolioAllocation(deps) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    logger.warn('   Portfolio allocation: No supabase client, returning empty');
+    return [];
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('portfolio_profile_allocations')
+      .select('id, profile_id, target_pct, current_pct, description')
+      .order('target_pct', { ascending: false });
+
+    if (error) {
+      logger.warn(`   Portfolio allocation: Query error: ${error.message}`);
+      return [];
+    }
+
+    // Fetch profile names
+    const profileIds = (data || []).map(d => d.profile_id);
+    let profileNames = {};
+
+    if (profileIds.length > 0) {
+      const { data: profiles } = await supabase
+        .from('evaluation_profiles')
+        .select('id, name')
+        .in('id', profileIds);
+
+      if (profiles) {
+        profileNames = Object.fromEntries(profiles.map(p => [p.id, p.name]));
+      }
+    }
+
+    return (data || []).map(d => ({
+      profile_id: d.profile_id,
+      profile_name: profileNames[d.profile_id] || 'unknown',
+      target_pct: parseFloat(d.target_pct) || 0,
+      current_pct: parseFloat(d.current_pct) || 0,
+      gap: Math.round((parseFloat(d.target_pct) - parseFloat(d.current_pct)) * 100) / 100,
+      description: d.description,
+    }));
+  } catch (err) {
+    logger.warn(`   Portfolio allocation: Error: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Recommend a profile based on portfolio gaps.
+ *
+ * When multiple profiles score similarly, nudge toward the profile
+ * with the largest positive gap (most underrepresented). If gaps
+ * are negligible, return the highest-scoring profile.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {Object} scores - Map of profile_id → score (0-100)
+ * @param {Object} [options]
+ * @param {number} [options.nudgeWeight=0.20] - How much to weight the gap vs raw score
+ * @returns {Promise<Object>} { recommended_profile_id, profile_name, raw_score, nudged_score, gap, reason }
+ */
+export async function recommendProfile(deps, scores, options = {}) {
+  const { logger = console } = deps;
+  const nudgeWeight = options.nudgeWeight ?? 0.20;
+
+  if (!scores || Object.keys(scores).length === 0) {
+    return { recommended_profile_id: null, reason: 'no_scores_provided' };
+  }
+
+  const allocations = await getPortfolioAllocation(deps);
+
+  if (allocations.length === 0) {
+    // No allocation data — pick the highest raw score
+    const best = Object.entries(scores).sort((a, b) => b[1] - a[1])[0];
+    return {
+      recommended_profile_id: best[0],
+      profile_name: null,
+      raw_score: best[1],
+      nudged_score: best[1],
+      gap: 0,
+      reason: 'no_allocation_data',
+    };
+  }
+
+  // Calculate nudged scores
+  const candidates = [];
+
+  for (const alloc of allocations) {
+    const rawScore = scores[alloc.profile_id] ?? 0;
+    const normalizedGap = alloc.gap / 100; // Convert pct to 0-1 range
+    const nudgedScore = rawScore * (1 - nudgeWeight) + rawScore * normalizedGap * nudgeWeight * 10;
+
+    candidates.push({
+      recommended_profile_id: alloc.profile_id,
+      profile_name: alloc.profile_name,
+      raw_score: rawScore,
+      nudged_score: Math.round(nudgedScore * 100) / 100,
+      gap: alloc.gap,
+      reason: alloc.gap > 5 ? 'nudged_toward_underrepresented' : 'highest_score',
+    });
+  }
+
+  // Sort by nudged score descending
+  candidates.sort((a, b) => b.nudged_score - a.nudged_score);
+
+  return candidates[0];
+}
+
+/**
+ * Recalculate current allocation percentages from active ventures.
+ *
+ * Counts ventures grouped by profile_id in venture_briefs,
+ * then updates current_pct in portfolio_profile_allocations.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @returns {Promise<Object>} { updated: number, total_ventures: number }
+ */
+export async function updateAllocationCounts(deps) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    logger.warn('   Portfolio allocation: No supabase client');
+    return { updated: 0, total_ventures: 0 };
+  }
+
+  try {
+    // Get all ventures with profile_ids
+    const { data: ventures, error: vErr } = await supabase
+      .from('venture_briefs')
+      .select('profile_id')
+      .not('profile_id', 'is', null);
+
+    if (vErr) {
+      logger.warn(`   Portfolio allocation: Venture query error: ${vErr.message}`);
+      return { updated: 0, total_ventures: 0 };
+    }
+
+    const total = (ventures || []).length;
+
+    // Count by profile_id
+    const counts = {};
+    for (const v of (ventures || [])) {
+      counts[v.profile_id] = (counts[v.profile_id] || 0) + 1;
+    }
+
+    // Get all allocations
+    const { data: allocs } = await supabase
+      .from('portfolio_profile_allocations')
+      .select('id, profile_id');
+
+    let updated = 0;
+
+    for (const alloc of (allocs || [])) {
+      const count = counts[alloc.profile_id] || 0;
+      const pct = total > 0 ? Math.round((count / total) * 10000) / 100 : 0;
+
+      const { error } = await supabase
+        .from('portfolio_profile_allocations')
+        .update({ current_pct: pct })
+        .eq('id', alloc.id);
+
+      if (!error) updated++;
+    }
+
+    return { updated, total_ventures: total };
+  } catch (err) {
+    logger.warn(`   Portfolio allocation: Update error: ${err.message}`);
+    return { updated: 0, total_ventures: 0 };
+  }
+}

--- a/tests/unit/eva/stage-zero/portfolio-allocation.test.js
+++ b/tests/unit/eva/stage-zero/portfolio-allocation.test.js
@@ -1,0 +1,248 @@
+/**
+ * Portfolio-Level Profile Allocation Tests
+ *
+ * Tests for portfolio allocation retrieval, nudged recommendations,
+ * and allocation count updates.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-G
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getPortfolioAllocation,
+  recommendProfile,
+  updateAllocationCounts,
+} from '../../../../lib/eva/stage-zero/portfolio-allocation.js';
+
+const PROFILE_IDS = {
+  aggressive: 'aaaa-1111',
+  balanced: 'bbbb-2222',
+  capital: 'cccc-3333',
+};
+
+function mockSupabase(overrides = {}) {
+  const mockFrom = (table) => {
+    if (table === 'portfolio_profile_allocations') {
+      const defaultAllocs = [
+        { id: 'a1', profile_id: PROFILE_IDS.aggressive, target_pct: '40.00', current_pct: '60.00', description: 'Aggressive' },
+        { id: 'a2', profile_id: PROFILE_IDS.balanced, target_pct: '30.00', current_pct: '20.00', description: 'Balanced' },
+        { id: 'a3', profile_id: PROFILE_IDS.capital, target_pct: '30.00', current_pct: '20.00', description: 'Capital' },
+      ];
+      const allocData = overrides.allocations ?? defaultAllocs;
+      const selectResult = {
+        order: () => Promise.resolve({ data: allocData, error: overrides.allocError ?? null }),
+        eq: () => Promise.resolve({ error: null }),
+        in: () => Promise.resolve({ data: allocData }),
+        then: (resolve) => resolve({ data: allocData, error: overrides.allocError ?? null }),
+      };
+      return {
+        select: () => selectResult,
+        update: () => ({
+          eq: () => Promise.resolve({ error: overrides.updateError ?? null }),
+        }),
+      };
+    }
+    if (table === 'evaluation_profiles') {
+      return {
+        select: () => ({
+          in: () => Promise.resolve({
+            data: [
+              { id: PROFILE_IDS.aggressive, name: 'aggressive_growth' },
+              { id: PROFILE_IDS.balanced, name: 'balanced' },
+              { id: PROFILE_IDS.capital, name: 'capital_efficient' },
+            ],
+            error: null,
+          }),
+        }),
+      };
+    }
+    if (table === 'venture_briefs') {
+      return {
+        select: () => ({
+          not: () => Promise.resolve({
+            data: overrides.ventures ?? [],
+            error: overrides.ventureError ?? null,
+          }),
+        }),
+      };
+    }
+    return { select: () => ({ order: () => Promise.resolve({ data: [], error: null }) }) };
+  };
+  return { from: mockFrom };
+}
+
+const silentLogger = { warn: () => {}, log: () => {}, error: () => {} };
+
+describe('portfolio-allocation', () => {
+  describe('getPortfolioAllocation', () => {
+    it('returns allocation snapshot with gap calculation', async () => {
+      const result = await getPortfolioAllocation({ supabase: mockSupabase(), logger: silentLogger });
+
+      expect(result).toHaveLength(3);
+      expect(result[0]).toHaveProperty('profile_id');
+      expect(result[0]).toHaveProperty('target_pct');
+      expect(result[0]).toHaveProperty('current_pct');
+      expect(result[0]).toHaveProperty('gap');
+    });
+
+    it('calculates gap as target minus current', async () => {
+      const result = await getPortfolioAllocation({ supabase: mockSupabase(), logger: silentLogger });
+
+      const aggressive = result.find(r => r.profile_id === PROFILE_IDS.aggressive);
+      expect(aggressive.gap).toBe(-20); // 40 target - 60 current = -20 (overweight)
+
+      const balanced = result.find(r => r.profile_id === PROFILE_IDS.balanced);
+      expect(balanced.gap).toBe(10); // 30 target - 20 current = 10 (underweight)
+    });
+
+    it('returns empty array when supabase is null', async () => {
+      const result = await getPortfolioAllocation({ supabase: null, logger: silentLogger });
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array on query error', async () => {
+      const sb = mockSupabase({ allocError: { message: 'test error' } });
+      const result = await getPortfolioAllocation({ supabase: sb, logger: silentLogger });
+      expect(result).toEqual([]);
+    });
+
+    it('includes profile names from evaluation_profiles', async () => {
+      const result = await getPortfolioAllocation({ supabase: mockSupabase(), logger: silentLogger });
+
+      const aggressive = result.find(r => r.profile_id === PROFILE_IDS.aggressive);
+      expect(aggressive.profile_name).toBe('aggressive_growth');
+    });
+  });
+
+  describe('recommendProfile', () => {
+    it('nudges toward underrepresented profiles', async () => {
+      const scores = {
+        [PROFILE_IDS.aggressive]: 80,
+        [PROFILE_IDS.balanced]: 78,
+        [PROFILE_IDS.capital]: 78,
+      };
+
+      const result = await recommendProfile(
+        { supabase: mockSupabase(), logger: silentLogger },
+        scores
+      );
+
+      // balanced or capital should win over aggressive since aggressive is overweight (-20 gap)
+      expect(result.recommended_profile_id).not.toBe(PROFILE_IDS.aggressive);
+      expect(result.reason).toBe('nudged_toward_underrepresented');
+    });
+
+    it('returns highest score when all at target', async () => {
+      const atTarget = mockSupabase({
+        allocations: [
+          { id: 'a1', profile_id: PROFILE_IDS.aggressive, target_pct: '33.33', current_pct: '33.33', description: 'Aggressive' },
+          { id: 'a2', profile_id: PROFILE_IDS.balanced, target_pct: '33.33', current_pct: '33.33', description: 'Balanced' },
+          { id: 'a3', profile_id: PROFILE_IDS.capital, target_pct: '33.34', current_pct: '33.34', description: 'Capital' },
+        ],
+      });
+
+      const scores = {
+        [PROFILE_IDS.aggressive]: 90,
+        [PROFILE_IDS.balanced]: 70,
+        [PROFILE_IDS.capital]: 60,
+      };
+
+      const result = await recommendProfile(
+        { supabase: atTarget, logger: silentLogger },
+        scores
+      );
+
+      expect(result.recommended_profile_id).toBe(PROFILE_IDS.aggressive);
+      expect(result.reason).toBe('highest_score');
+    });
+
+    it('returns null for empty scores', async () => {
+      const result = await recommendProfile(
+        { supabase: mockSupabase(), logger: silentLogger },
+        {}
+      );
+      expect(result.recommended_profile_id).toBeNull();
+      expect(result.reason).toBe('no_scores_provided');
+    });
+
+    it('falls back to highest score when no allocation data', async () => {
+      const emptySb = mockSupabase({ allocations: [] });
+      const scores = {
+        'prof-1': 80,
+        'prof-2': 90,
+      };
+
+      const result = await recommendProfile(
+        { supabase: emptySb, logger: silentLogger },
+        scores
+      );
+
+      expect(result.recommended_profile_id).toBe('prof-2');
+      expect(result.reason).toBe('no_allocation_data');
+    });
+
+    it('returns null for null scores', async () => {
+      const result = await recommendProfile(
+        { supabase: mockSupabase(), logger: silentLogger },
+        null
+      );
+      expect(result.recommended_profile_id).toBeNull();
+    });
+
+    it('includes raw_score and nudged_score in result', async () => {
+      const scores = {
+        [PROFILE_IDS.aggressive]: 80,
+        [PROFILE_IDS.balanced]: 75,
+        [PROFILE_IDS.capital]: 70,
+      };
+
+      const result = await recommendProfile(
+        { supabase: mockSupabase(), logger: silentLogger },
+        scores
+      );
+
+      expect(result).toHaveProperty('raw_score');
+      expect(result).toHaveProperty('nudged_score');
+      expect(result).toHaveProperty('gap');
+      expect(typeof result.raw_score).toBe('number');
+      expect(typeof result.nudged_score).toBe('number');
+    });
+  });
+
+  describe('updateAllocationCounts', () => {
+    it('recalculates current_pct from active ventures', async () => {
+      const sb = mockSupabase({
+        ventures: [
+          { profile_id: PROFILE_IDS.aggressive },
+          { profile_id: PROFILE_IDS.aggressive },
+          { profile_id: PROFILE_IDS.aggressive },
+          { profile_id: PROFILE_IDS.balanced },
+          { profile_id: PROFILE_IDS.capital },
+        ],
+      });
+
+      const result = await updateAllocationCounts({ supabase: sb, logger: silentLogger });
+
+      expect(result.total_ventures).toBe(5);
+      expect(result.updated).toBeGreaterThan(0);
+    });
+
+    it('returns zero for empty portfolio', async () => {
+      const sb = mockSupabase({ ventures: [] });
+      const result = await updateAllocationCounts({ supabase: sb, logger: silentLogger });
+
+      expect(result.total_ventures).toBe(0);
+    });
+
+    it('returns zero when supabase is null', async () => {
+      const result = await updateAllocationCounts({ supabase: null, logger: silentLogger });
+      expect(result).toEqual({ updated: 0, total_ventures: 0 });
+    });
+
+    it('handles venture query error gracefully', async () => {
+      const sb = mockSupabase({ ventureError: { message: 'test error' } });
+      const result = await updateAllocationCounts({ supabase: sb, logger: silentLogger });
+      expect(result).toEqual({ updated: 0, total_ventures: 0 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements portfolio allocation tracking and profile recommendation nudging for EVA Stage 0
- `getPortfolioAllocation`: current vs target allocation snapshot with gap calculation
- `recommendProfile`: nudges profile selection toward underrepresented evaluation styles
- `updateAllocationCounts`: recalculates allocation percentages from active ventures
- Migration seeds 3 default allocations (aggressive_growth 40%, balanced 30%, capital_efficient 30%)
- 15 unit tests, all 101 EVA stage-zero tests passing

Child G of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001.

## Test plan
- [x] 15 new unit tests pass
- [x] All 101 EVA stage-zero tests pass (no regressions)
- [x] Migration executes and seeds 3 rows
- [x] Full handoff chain complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)