### PR TITLE
feat(eva): add chairman override tracking for Stage 0

### DIFF
--- a/database/migrations/20260210_chairman_override_tracking.sql
+++ b/database/migrations/20260210_chairman_override_tracking.sql
@@ -1,0 +1,48 @@
+-- Chairman Override Tracking
+-- Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-H
+-- Tracks chairman overrides to system-recommended scores
+
+CREATE TABLE IF NOT EXISTS chairman_overrides (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL,
+  component TEXT NOT NULL,
+  system_score NUMERIC(6,2) NOT NULL,
+  override_score NUMERIC(6,2) NOT NULL,
+  reason TEXT,
+  outcome TEXT CHECK (outcome IS NULL OR outcome IN ('positive', 'negative', 'neutral', 'pending')),
+  outcome_notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes for query performance
+CREATE INDEX IF NOT EXISTS idx_chairman_overrides_venture ON chairman_overrides(venture_id);
+CREATE INDEX IF NOT EXISTS idx_chairman_overrides_component ON chairman_overrides(component);
+CREATE INDEX IF NOT EXISTS idx_chairman_overrides_created ON chairman_overrides(created_at DESC);
+
+-- Enable RLS
+ALTER TABLE chairman_overrides ENABLE ROW LEVEL SECURITY;
+
+-- Allow service role full access
+DROP POLICY IF EXISTS "service_role_full_access_chairman_overrides" ON chairman_overrides;
+CREATE POLICY "service_role_full_access_chairman_overrides"
+  ON chairman_overrides
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION update_chairman_overrides_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_update_chairman_overrides_timestamp ON chairman_overrides;
+CREATE TRIGGER trg_update_chairman_overrides_timestamp
+  BEFORE UPDATE ON chairman_overrides
+  FOR EACH ROW
+  EXECUTE FUNCTION update_chairman_overrides_timestamp();

--- a/lib/eva/stage-zero/chairman-override-tracker.js
+++ b/lib/eva/stage-zero/chairman-override-tracker.js
@@ -1,0 +1,177 @@
+/**
+ * Chairman Override Tracker
+ *
+ * Tracks when the chairman overrides system-recommended scores,
+ * recording both values and enabling pattern analysis of overrides
+ * vs outcomes.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-H
+ */
+
+import { VALID_COMPONENTS } from './profile-service.js';
+
+/**
+ * Record a chairman override of a system-recommended score.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {Object} override
+ * @param {string} override.ventureId - Venture UUID
+ * @param {string} override.component - Synthesis component name
+ * @param {number} override.systemScore - Original system-recommended score
+ * @param {number} override.overrideScore - Chairman's chosen score
+ * @param {string} [override.reason] - Chairman's reasoning for the override
+ * @returns {Promise<Object|null>} Created override record or null on error
+ */
+export async function recordOverride(deps, override) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    logger.warn('   Override tracker: No supabase client');
+    return null;
+  }
+
+  const { ventureId, component, systemScore, overrideScore, reason } = override;
+
+  if (!ventureId || !component) {
+    logger.warn('   Override tracker: ventureId and component are required');
+    return null;
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('chairman_overrides')
+      .insert({
+        venture_id: ventureId,
+        component,
+        system_score: systemScore,
+        override_score: overrideScore,
+        reason: reason || null,
+        outcome: 'pending',
+      })
+      .select('id, venture_id, component, system_score, override_score, reason, outcome')
+      .single();
+
+    if (error) {
+      logger.warn(`   Override tracker: Insert error: ${error.message}`);
+      return null;
+    }
+
+    return data;
+  } catch (err) {
+    logger.warn(`   Override tracker: Error: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Get all overrides for a specific synthesis component.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {string} component - Component name (e.g. 'moat_architecture')
+ * @returns {Promise<Array>} Overrides sorted by created_at descending
+ */
+export async function getOverridesByComponent(deps, component) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    logger.warn('   Override tracker: No supabase client');
+    return [];
+  }
+
+  if (!component) return [];
+
+  try {
+    const { data, error } = await supabase
+      .from('chairman_overrides')
+      .select('id, venture_id, component, system_score, override_score, reason, outcome, outcome_notes, created_at')
+      .eq('component', component)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      logger.warn(`   Override tracker: Query error: ${error.message}`);
+      return [];
+    }
+
+    return data || [];
+  } catch (err) {
+    logger.warn(`   Override tracker: Error: ${err.message}`);
+    return [];
+  }
+}
+
+/**
+ * Generate insights from chairman override patterns.
+ *
+ * Analyzes overrides to identify:
+ * - Per-component override frequency and success rate
+ * - Components where chairman intuition outperforms the algorithm
+ * - Average score deltas (how much the chairman typically adjusts)
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @returns {Promise<Object>} { total_overrides, components: { [name]: { count, success_rate, avg_delta, direction } } }
+ */
+export async function generateOverrideInsights(deps) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    logger.warn('   Override tracker: No supabase client');
+    return { total_overrides: 0, components: {} };
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('chairman_overrides')
+      .select('component, system_score, override_score, outcome')
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      logger.warn(`   Override tracker: Query error: ${error.message}`);
+      return { total_overrides: 0, components: {} };
+    }
+
+    if (!data || data.length === 0) {
+      return { total_overrides: 0, components: {} };
+    }
+
+    // Group by component
+    const grouped = {};
+    for (const row of data) {
+      if (!grouped[row.component]) {
+        grouped[row.component] = [];
+      }
+      grouped[row.component].push(row);
+    }
+
+    // Analyze each component
+    const components = {};
+    for (const [comp, overrides] of Object.entries(grouped)) {
+      const resolved = overrides.filter(o => o.outcome && o.outcome !== 'pending');
+      const positive = resolved.filter(o => o.outcome === 'positive').length;
+      const deltas = overrides.map(o =>
+        parseFloat(o.override_score) - parseFloat(o.system_score)
+      );
+      const avgDelta = deltas.length > 0
+        ? Math.round((deltas.reduce((a, b) => a + b, 0) / deltas.length) * 100) / 100
+        : 0;
+
+      components[comp] = {
+        count: overrides.length,
+        resolved: resolved.length,
+        positive,
+        success_rate: resolved.length > 0
+          ? Math.round((positive / resolved.length) * 100)
+          : null,
+        avg_delta: avgDelta,
+        direction: avgDelta > 0 ? 'upward' : avgDelta < 0 ? 'downward' : 'neutral',
+      };
+    }
+
+    return {
+      total_overrides: data.length,
+      components,
+    };
+  } catch (err) {
+    logger.warn(`   Override tracker: Error: ${err.message}`);
+    return { total_overrides: 0, components: {} };
+  }
+}

--- a/tests/unit/eva/stage-zero/chairman-override-tracker.test.js
+++ b/tests/unit/eva/stage-zero/chairman-override-tracker.test.js
@@ -1,0 +1,219 @@
+/**
+ * Chairman Override Tracker Tests
+ *
+ * Tests for override recording, component queries, and insight generation.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-H
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  recordOverride,
+  getOverridesByComponent,
+  generateOverrideInsights,
+} from '../../../../lib/eva/stage-zero/chairman-override-tracker.js';
+
+const silentLogger = { warn: () => {}, log: () => {}, error: () => {} };
+
+function mockSupabase(overrides = {}) {
+  return {
+    from: (table) => ({
+      insert: (data) => ({
+        select: () => ({
+          single: () => Promise.resolve({
+            data: overrides.insertError ? null : {
+              id: 'override-1',
+              venture_id: data.venture_id,
+              component: data.component,
+              system_score: data.system_score,
+              override_score: data.override_score,
+              reason: data.reason,
+              outcome: data.outcome,
+            },
+            error: overrides.insertError ?? null,
+          }),
+        }),
+      }),
+      select: () => ({
+        eq: (col, val) => ({
+          order: () => Promise.resolve({
+            data: overrides.componentData ?? [
+              { id: 'o1', venture_id: 'v1', component: val, system_score: '60', override_score: '85', reason: 'Network effects', outcome: 'positive', outcome_notes: null, created_at: '2026-01-01' },
+              { id: 'o2', venture_id: 'v2', component: val, system_score: '70', override_score: '90', reason: 'Market timing', outcome: 'negative', outcome_notes: null, created_at: '2026-01-02' },
+            ],
+            error: overrides.queryError ?? null,
+          }),
+        }),
+        order: () => Promise.resolve({
+          data: overrides.allData ?? [
+            { component: 'moat_architecture', system_score: '60', override_score: '85', outcome: 'positive' },
+            { component: 'moat_architecture', system_score: '55', override_score: '80', outcome: 'positive' },
+            { component: 'moat_architecture', system_score: '70', override_score: '90', outcome: 'positive' },
+            { component: 'moat_architecture', system_score: '65', override_score: '75', outcome: 'negative' },
+            { component: 'virality', system_score: '40', override_score: '30', outcome: 'positive' },
+          ],
+          error: overrides.queryError ?? null,
+        }),
+      }),
+    }),
+  };
+}
+
+describe('chairman-override-tracker', () => {
+  describe('recordOverride', () => {
+    it('stores override with system and chairman scores', async () => {
+      const result = await recordOverride(
+        { supabase: mockSupabase(), logger: silentLogger },
+        { ventureId: 'v1', component: 'moat_architecture', systemScore: 60, overrideScore: 85, reason: 'Network effects' }
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.component).toBe('moat_architecture');
+      expect(result.system_score).toBe(60);
+      expect(result.override_score).toBe(85);
+      expect(result.reason).toBe('Network effects');
+    });
+
+    it('returns null when supabase is null', async () => {
+      const result = await recordOverride(
+        { supabase: null, logger: silentLogger },
+        { ventureId: 'v1', component: 'moat', systemScore: 60, overrideScore: 85 }
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null when required fields are missing', async () => {
+      const result = await recordOverride(
+        { supabase: mockSupabase(), logger: silentLogger },
+        { ventureId: null, component: null, systemScore: 60, overrideScore: 85 }
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null on insert error', async () => {
+      const sb = mockSupabase({ insertError: { message: 'test error' } });
+      const result = await recordOverride(
+        { supabase: sb, logger: silentLogger },
+        { ventureId: 'v1', component: 'moat_architecture', systemScore: 60, overrideScore: 85 }
+      );
+      expect(result).toBeNull();
+    });
+
+    it('sets outcome to pending by default', async () => {
+      const result = await recordOverride(
+        { supabase: mockSupabase(), logger: silentLogger },
+        { ventureId: 'v1', component: 'virality', systemScore: 50, overrideScore: 70 }
+      );
+      expect(result.outcome).toBe('pending');
+    });
+  });
+
+  describe('getOverridesByComponent', () => {
+    it('returns overrides for a specific component', async () => {
+      const result = await getOverridesByComponent(
+        { supabase: mockSupabase(), logger: silentLogger },
+        'moat_architecture'
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toHaveProperty('system_score');
+      expect(result[0]).toHaveProperty('override_score');
+      expect(result[0]).toHaveProperty('reason');
+    });
+
+    it('returns empty array when supabase is null', async () => {
+      const result = await getOverridesByComponent(
+        { supabase: null, logger: silentLogger },
+        'moat_architecture'
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array for null component', async () => {
+      const result = await getOverridesByComponent(
+        { supabase: mockSupabase(), logger: silentLogger },
+        null
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array on query error', async () => {
+      const sb = mockSupabase({ queryError: { message: 'test error' } });
+      const result = await getOverridesByComponent(
+        { supabase: sb, logger: silentLogger },
+        'moat_architecture'
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('generateOverrideInsights', () => {
+    it('generates per-component success rates', async () => {
+      const result = await generateOverrideInsights(
+        { supabase: mockSupabase(), logger: silentLogger }
+      );
+
+      expect(result.total_overrides).toBe(5);
+      expect(result.components).toHaveProperty('moat_architecture');
+      expect(result.components.moat_architecture.count).toBe(4);
+      expect(result.components.moat_architecture.success_rate).toBe(75); // 3/4
+      expect(result.components.moat_architecture.direction).toBe('upward');
+    });
+
+    it('calculates average delta', async () => {
+      const result = await generateOverrideInsights(
+        { supabase: mockSupabase(), logger: silentLogger }
+      );
+
+      // moat: (85-60) + (80-55) + (90-70) + (75-65) = 25+25+20+10 = 80, avg = 20
+      expect(result.components.moat_architecture.avg_delta).toBe(20);
+    });
+
+    it('detects downward override direction', async () => {
+      const result = await generateOverrideInsights(
+        { supabase: mockSupabase(), logger: silentLogger }
+      );
+
+      // virality: 30 - 40 = -10 avg_delta
+      expect(result.components.virality.direction).toBe('downward');
+    });
+
+    it('returns empty insights when supabase is null', async () => {
+      const result = await generateOverrideInsights(
+        { supabase: null, logger: silentLogger }
+      );
+      expect(result).toEqual({ total_overrides: 0, components: {} });
+    });
+
+    it('returns empty insights on query error', async () => {
+      const sb = mockSupabase({ queryError: { message: 'test error' } });
+      const result = await generateOverrideInsights(
+        { supabase: sb, logger: silentLogger }
+      );
+      expect(result).toEqual({ total_overrides: 0, components: {} });
+    });
+
+    it('returns empty insights when no overrides exist', async () => {
+      const sb = mockSupabase({ allData: [] });
+      const result = await generateOverrideInsights(
+        { supabase: sb, logger: silentLogger }
+      );
+      expect(result).toEqual({ total_overrides: 0, components: {} });
+    });
+
+    it('handles null success_rate for unresolved overrides', async () => {
+      const sb = mockSupabase({
+        allData: [
+          { component: 'build_cost', system_score: '50', override_score: '70', outcome: 'pending' },
+        ],
+      });
+      const result = await generateOverrideInsights(
+        { supabase: sb, logger: silentLogger }
+      );
+
+      expect(result.components.build_cost.count).toBe(1);
+      expect(result.components.build_cost.resolved).toBe(0);
+      expect(result.components.build_cost.success_rate).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Creates `chairman_overrides` table to track when the chairman overrides system-recommended synthesis scores
- Implements `chairman-override-tracker.js` with `recordOverride`, `getOverridesByComponent`, and `generateOverrideInsights`
- 16 unit tests covering all functions with graceful error handling for null supabase, missing fields, query errors

## Part of
SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-H (Child H of EVA Stage 0 orchestrator)

## Test plan
- [x] All 16 chairman-override-tracker tests pass
- [x] All 117 EVA stage-zero tests pass
- [x] Migration executed successfully (chairman_overrides table created)
- [x] RLS policies and indexes in place

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>