### PR TITLE
feat(eva): add counterfactual scoring engine for profile comparison

### DIFF
--- a/database/migrations/20260210_counterfactual_scores.sql
+++ b/database/migrations/20260210_counterfactual_scores.sql
@@ -1,0 +1,48 @@
+-- Counterfactual Scores
+-- Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-I
+-- Stores batch counterfactual re-scoring results: venture × profile comparisons
+
+CREATE TABLE IF NOT EXISTS counterfactual_scores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL,
+  profile_id UUID NOT NULL REFERENCES evaluation_profiles(id),
+  original_score NUMERIC(6,2) NOT NULL,
+  counterfactual_score NUMERIC(6,2) NOT NULL,
+  delta NUMERIC(6,2) NOT NULL,
+  breakdown JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(venture_id, profile_id)
+);
+
+-- Indexes for query performance
+CREATE INDEX IF NOT EXISTS idx_counterfactual_scores_venture ON counterfactual_scores(venture_id);
+CREATE INDEX IF NOT EXISTS idx_counterfactual_scores_profile ON counterfactual_scores(profile_id);
+CREATE INDEX IF NOT EXISTS idx_counterfactual_scores_delta ON counterfactual_scores(delta DESC);
+
+-- Enable RLS
+ALTER TABLE counterfactual_scores ENABLE ROW LEVEL SECURITY;
+
+-- Allow service role full access
+DROP POLICY IF EXISTS "service_role_full_access_counterfactual_scores" ON counterfactual_scores;
+CREATE POLICY "service_role_full_access_counterfactual_scores"
+  ON counterfactual_scores
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION update_counterfactual_scores_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_update_counterfactual_scores_timestamp ON counterfactual_scores;
+CREATE TRIGGER trg_update_counterfactual_scores_timestamp
+  BEFORE UPDATE ON counterfactual_scores
+  FOR EACH ROW
+  EXECUTE FUNCTION update_counterfactual_scores_timestamp();

--- a/lib/eva/stage-zero/counterfactual-engine.js
+++ b/lib/eva/stage-zero/counterfactual-engine.js
@@ -1,0 +1,284 @@
+/**
+ * Counterfactual Scoring Engine
+ *
+ * Generates what-if scores by applying different evaluation profile weights
+ * to venture synthesis results. Enables the chairman to understand how
+ * different assumptions would change venture evaluation outcomes.
+ *
+ * Key capabilities:
+ * - Single venture counterfactual: compare original vs alternative profile scores
+ * - Batch historical re-scoring: N ventures × P profiles
+ * - Predictive accuracy: which profiles best predicted actual outcomes
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-I
+ */
+
+import { calculateWeightedScore, VALID_COMPONENTS } from './profile-service.js';
+
+/**
+ * Generate a counterfactual score for a single venture under alternative weights.
+ *
+ * @param {Object} params
+ * @param {Object} params.synthesisResults - Map of component name → result object
+ * @param {Object} params.currentWeights - Original profile weights used for scoring
+ * @param {Object} params.scenarioWeights - Alternative profile weights to evaluate
+ * @returns {Object} { original_score, counterfactual_score, delta, breakdown }
+ */
+export function generateCounterfactual({ synthesisResults, currentWeights, scenarioWeights }) {
+  if (!synthesisResults) {
+    throw new Error('synthesisResults is required');
+  }
+  if (!currentWeights || !scenarioWeights) {
+    throw new Error('Both currentWeights and scenarioWeights are required');
+  }
+
+  validateWeights(currentWeights);
+  validateWeights(scenarioWeights);
+
+  const original = calculateWeightedScore(synthesisResults, currentWeights);
+  const counterfactual = calculateWeightedScore(synthesisResults, scenarioWeights);
+
+  // Build per-component comparison
+  const componentComparison = VALID_COMPONENTS.map(component => {
+    const origItem = original.breakdown.find(b => b.component === component) || { contribution: 0, raw_score: 0, weight: 0 };
+    const cfItem = counterfactual.breakdown.find(b => b.component === component) || { contribution: 0, raw_score: 0, weight: 0 };
+
+    return {
+      component,
+      raw_score: origItem.raw_score,
+      original_weight: origItem.weight,
+      original_contribution: origItem.contribution,
+      counterfactual_weight: cfItem.weight,
+      counterfactual_contribution: cfItem.contribution,
+      contribution_delta: Math.round((cfItem.contribution - origItem.contribution) * 100) / 100,
+    };
+  }).sort((a, b) => Math.abs(b.contribution_delta) - Math.abs(a.contribution_delta));
+
+  return {
+    original_score: original.total_score,
+    counterfactual_score: counterfactual.total_score,
+    delta: counterfactual.total_score - original.total_score,
+    breakdown: componentComparison,
+  };
+}
+
+/**
+ * Batch re-score multiple ventures across multiple profiles.
+ *
+ * @param {Object} params
+ * @param {Array<Object>} params.ventures - Array of { id, synthesisResults, currentWeights }
+ * @param {Array<Object>} params.profiles - Array of { id, name, weights }
+ * @param {Object} [params.logger] - Optional logger
+ * @returns {Array<Object>} Array of counterfactual results per venture-profile pair
+ */
+export function runBatchCounterfactual({ ventures, profiles, logger = console }) {
+  if (!ventures?.length) throw new Error('ventures array is required');
+  if (!profiles?.length) throw new Error('profiles array is required');
+
+  const results = [];
+
+  for (const venture of ventures) {
+    if (!venture.synthesisResults) {
+      logger.warn(`   Skipping venture ${venture.id}: missing synthesis results`);
+      continue;
+    }
+
+    for (const profile of profiles) {
+      try {
+        validateWeights(profile.weights);
+
+        const cf = generateCounterfactual({
+          synthesisResults: venture.synthesisResults,
+          currentWeights: venture.currentWeights,
+          scenarioWeights: profile.weights,
+        });
+
+        results.push({
+          venture_id: venture.id,
+          profile_id: profile.id,
+          profile_name: profile.name,
+          original_score: cf.original_score,
+          counterfactual_score: cf.counterfactual_score,
+          delta: cf.delta,
+          breakdown: cf.breakdown,
+        });
+      } catch (err) {
+        logger.warn(`   Skipping venture ${venture.id} × profile ${profile.name}: ${err.message}`);
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Generate a predictive accuracy report comparing counterfactual scores
+ * against actual venture outcomes.
+ *
+ * For each profile, calculates what percentage of venture pairs are
+ * correctly ordered (higher score = better outcome).
+ *
+ * @param {Array<Object>} counterfactualResults - Output from runBatchCounterfactual
+ * @param {Object} outcomes - Map of venture_id → outcome ('completed'|'killed'|'parked')
+ * @returns {Object} Per-profile accuracy metrics
+ */
+export function generatePredictiveReport(counterfactualResults, outcomes) {
+  if (!counterfactualResults?.length) {
+    return { profiles: {}, total_ventures: 0, total_pairs: 0 };
+  }
+
+  // Group results by profile
+  const byProfile = {};
+  for (const result of counterfactualResults) {
+    if (!byProfile[result.profile_id]) {
+      byProfile[result.profile_id] = {
+        profile_name: result.profile_name,
+        scores: [],
+      };
+    }
+    byProfile[result.profile_id].scores.push({
+      venture_id: result.venture_id,
+      score: result.counterfactual_score,
+      outcome: outcomeToNumeric(outcomes[result.venture_id]),
+    });
+  }
+
+  // Calculate pairwise concordance per profile
+  const profileMetrics = {};
+  for (const [profileId, data] of Object.entries(byProfile)) {
+    const { concordant, discordant, tied } = pairwiseConcordance(data.scores);
+    const totalPairs = concordant + discordant + tied;
+    const accuracy = totalPairs > 0
+      ? Math.round((concordant / totalPairs) * 10000) / 10000
+      : 0;
+
+    // Kendall's tau-b
+    const tau = totalPairs > 0
+      ? Math.round(((concordant - discordant) / totalPairs) * 10000) / 10000
+      : 0;
+
+    profileMetrics[profileId] = {
+      profile_name: data.profile_name,
+      ventures_scored: data.scores.length,
+      concordant_pairs: concordant,
+      discordant_pairs: discordant,
+      tied_pairs: tied,
+      accuracy,
+      kendall_tau: tau,
+    };
+  }
+
+  const ventureIds = new Set(counterfactualResults.map(r => r.venture_id));
+
+  return {
+    profiles: profileMetrics,
+    total_ventures: ventureIds.size,
+    total_pairs: Object.values(profileMetrics)[0]?.concordant_pairs
+      + Object.values(profileMetrics)[0]?.discordant_pairs
+      + Object.values(profileMetrics)[0]?.tied_pairs || 0,
+  };
+}
+
+/**
+ * Persist batch counterfactual results to the database.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {Array<Object>} results - Output from runBatchCounterfactual
+ * @returns {Promise<Object>} { inserted, skipped, errors }
+ */
+export async function persistCounterfactualResults(deps, results) {
+  const { supabase, logger = console } = deps;
+  if (!supabase) throw new Error('supabase client is required');
+
+  let inserted = 0;
+  let skipped = 0;
+  const errors = [];
+
+  for (const result of results) {
+    const { error } = await supabase
+      .from('counterfactual_scores')
+      .upsert({
+        venture_id: result.venture_id,
+        profile_id: result.profile_id,
+        original_score: result.original_score,
+        counterfactual_score: result.counterfactual_score,
+        delta: result.delta,
+        breakdown: result.breakdown,
+      }, { onConflict: 'venture_id,profile_id' });
+
+    if (error) {
+      errors.push({ venture_id: result.venture_id, profile_id: result.profile_id, error: error.message });
+      skipped++;
+    } else {
+      inserted++;
+    }
+  }
+
+  logger.info?.(`   Persisted ${inserted} counterfactual scores (${skipped} skipped)`);
+  return { inserted, skipped, errors };
+}
+
+// --- Internal helpers ---
+
+/**
+ * Validate that weights are non-negative and sum > 0.
+ */
+function validateWeights(weights) {
+  if (!weights || typeof weights !== 'object') {
+    throw new Error('Weights must be a non-null object');
+  }
+
+  let sum = 0;
+  for (const [key, value] of Object.entries(weights)) {
+    if (typeof value !== 'number' || value < 0) {
+      throw new Error(`Weight for "${key}" must be a non-negative number, got ${value}`);
+    }
+    sum += value;
+  }
+
+  if (sum === 0) {
+    throw new Error('Sum of weights must be greater than 0');
+  }
+}
+
+/**
+ * Convert outcome string to numeric value for correlation.
+ */
+function outcomeToNumeric(outcome) {
+  switch (outcome) {
+    case 'completed': return 1;
+    case 'parked': return 0.5;
+    case 'killed': return 0;
+    default: return 0.5; // unknown treated as neutral
+  }
+}
+
+/**
+ * Calculate pairwise concordance between scores and outcomes.
+ * A pair is concordant if higher score → better outcome.
+ */
+function pairwiseConcordance(scoreOutcomePairs) {
+  let concordant = 0;
+  let discordant = 0;
+  let tied = 0;
+
+  for (let i = 0; i < scoreOutcomePairs.length; i++) {
+    for (let j = i + 1; j < scoreOutcomePairs.length; j++) {
+      const a = scoreOutcomePairs[i];
+      const b = scoreOutcomePairs[j];
+
+      const scoreDiff = a.score - b.score;
+      const outcomeDiff = a.outcome - b.outcome;
+
+      if (scoreDiff === 0 || outcomeDiff === 0) {
+        tied++;
+      } else if ((scoreDiff > 0 && outcomeDiff > 0) || (scoreDiff < 0 && outcomeDiff < 0)) {
+        concordant++;
+      } else {
+        discordant++;
+      }
+    }
+  }
+
+  return { concordant, discordant, tied };
+}

--- a/lib/eva/stage-zero/index.js
+++ b/lib/eva/stage-zero/index.js
@@ -35,6 +35,13 @@ export { runSynthesis } from './synthesis/index.js';
 export { generateForecast, calculateVentureScore } from './modeling.js';
 
 export {
+  generateCounterfactual,
+  runBatchCounterfactual,
+  generatePredictiveReport,
+  persistCounterfactualResults,
+} from './counterfactual-engine.js';
+
+export {
   parkVenture,
   reactivateVenture,
   recordSynthesisFeedback,

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/smoke-test-specification.js
@@ -38,7 +38,11 @@ export async function validateSmokeTestSpecification(sd) {
   console.log(`   SD Type: ${sdType} - smoke test specification REQUIRED`);
 
   // Check if smoke_test_steps exists and is valid
-  const smokeTestSteps = sd.smoke_test_steps || [];
+  // Handle TEXT column returning JSON string (not pre-parsed JSONB)
+  let smokeTestSteps = sd.smoke_test_steps || [];
+  if (typeof smokeTestSteps === 'string') {
+    try { smokeTestSteps = JSON.parse(smokeTestSteps); } catch { smokeTestSteps = []; }
+  }
   const isArray = Array.isArray(smokeTestSteps);
   const stepCount = isArray ? smokeTestSteps.length : 0;
 

--- a/tests/unit/eva/stage-zero/counterfactual-engine.test.js
+++ b/tests/unit/eva/stage-zero/counterfactual-engine.test.js
@@ -1,0 +1,383 @@
+/**
+ * Counterfactual Scoring Engine Tests
+ *
+ * Tests for single venture counterfactual, batch re-scoring,
+ * predictive accuracy reporting, and persistence.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-I
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  generateCounterfactual,
+  runBatchCounterfactual,
+  generatePredictiveReport,
+  persistCounterfactualResults,
+} from '../../../../lib/eva/stage-zero/counterfactual-engine.js';
+
+// Mock synthesis results (same as sensitivity-analysis tests)
+const MOCK_RESULTS = {
+  cross_reference: { relevance_score: 80 },
+  portfolio_evaluation: { composite_score: 70 },
+  problem_reframing: { reframings: ['reframe1'] },
+  moat_architecture: { moat_score: 90 },
+  chairman_constraints: { verdict: 'pass' },
+  time_horizon: { position: 'build_now' },
+  archetypes: { primary_confidence: 0.85 },
+  build_cost: { complexity: 'simple' },
+  virality: { virality_score: 75 },
+};
+
+const LEGACY_WEIGHTS = {
+  cross_reference: 0.10,
+  portfolio_evaluation: 0.10,
+  problem_reframing: 0.05,
+  moat_architecture: 0.15,
+  chairman_constraints: 0.15,
+  time_horizon: 0.10,
+  archetypes: 0.10,
+  build_cost: 0.10,
+  virality: 0.15,
+};
+
+const AGGRESSIVE_WEIGHTS = {
+  cross_reference: 0.05,
+  portfolio_evaluation: 0.05,
+  problem_reframing: 0.05,
+  moat_architecture: 0.20,
+  chairman_constraints: 0.10,
+  time_horizon: 0.05,
+  archetypes: 0.10,
+  build_cost: 0.05,
+  virality: 0.35,
+};
+
+describe('counterfactual-engine', () => {
+  describe('generateCounterfactual', () => {
+    it('returns original, counterfactual, delta, and breakdown', () => {
+      const result = generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: AGGRESSIVE_WEIGHTS,
+      });
+
+      expect(result).toHaveProperty('original_score');
+      expect(result).toHaveProperty('counterfactual_score');
+      expect(result).toHaveProperty('delta');
+      expect(result).toHaveProperty('breakdown');
+      expect(typeof result.original_score).toBe('number');
+      expect(typeof result.counterfactual_score).toBe('number');
+    });
+
+    it('delta equals counterfactual minus original', () => {
+      const result = generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: AGGRESSIVE_WEIGHTS,
+      });
+
+      expect(result.delta).toBe(result.counterfactual_score - result.original_score);
+    });
+
+    it('breakdown contains all 9 components', () => {
+      const result = generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: AGGRESSIVE_WEIGHTS,
+      });
+
+      expect(result.breakdown).toHaveLength(9);
+      const components = result.breakdown.map(b => b.component);
+      expect(components).toContain('moat_architecture');
+      expect(components).toContain('virality');
+    });
+
+    it('breakdown is sorted by absolute contribution delta', () => {
+      const result = generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: AGGRESSIVE_WEIGHTS,
+      });
+
+      for (let i = 0; i < result.breakdown.length - 1; i++) {
+        expect(Math.abs(result.breakdown[i].contribution_delta))
+          .toBeGreaterThanOrEqual(Math.abs(result.breakdown[i + 1].contribution_delta));
+      }
+    });
+
+    it('returns zero delta when weights are identical', () => {
+      const result = generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: { ...LEGACY_WEIGHTS },
+      });
+
+      expect(result.delta).toBe(0);
+      expect(result.original_score).toBe(result.counterfactual_score);
+    });
+
+    it('throws when synthesisResults is missing', () => {
+      expect(() => generateCounterfactual({
+        synthesisResults: null,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: AGGRESSIVE_WEIGHTS,
+      })).toThrow('synthesisResults is required');
+    });
+
+    it('throws when weights are missing', () => {
+      expect(() => generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: null,
+        scenarioWeights: AGGRESSIVE_WEIGHTS,
+      })).toThrow('Both currentWeights and scenarioWeights are required');
+    });
+
+    it('throws on negative weights', () => {
+      expect(() => generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: { ...AGGRESSIVE_WEIGHTS, virality: -0.1 },
+      })).toThrow('non-negative number');
+    });
+
+    it('throws when weights sum to zero', () => {
+      const zeroWeights = {};
+      for (const c of Object.keys(LEGACY_WEIGHTS)) zeroWeights[c] = 0;
+
+      expect(() => generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: zeroWeights,
+      })).toThrow('Sum of weights must be greater than 0');
+    });
+
+    it('each breakdown item has expected fields', () => {
+      const result = generateCounterfactual({
+        synthesisResults: MOCK_RESULTS,
+        currentWeights: LEGACY_WEIGHTS,
+        scenarioWeights: AGGRESSIVE_WEIGHTS,
+      });
+
+      for (const item of result.breakdown) {
+        expect(item).toHaveProperty('component');
+        expect(item).toHaveProperty('raw_score');
+        expect(item).toHaveProperty('original_weight');
+        expect(item).toHaveProperty('original_contribution');
+        expect(item).toHaveProperty('counterfactual_weight');
+        expect(item).toHaveProperty('counterfactual_contribution');
+        expect(item).toHaveProperty('contribution_delta');
+      }
+    });
+  });
+
+  describe('runBatchCounterfactual', () => {
+    const ventures = [
+      { id: 'v1', synthesisResults: MOCK_RESULTS, currentWeights: LEGACY_WEIGHTS },
+      { id: 'v2', synthesisResults: MOCK_RESULTS, currentWeights: LEGACY_WEIGHTS },
+    ];
+
+    const profiles = [
+      { id: 'p1', name: 'Aggressive', weights: AGGRESSIVE_WEIGHTS },
+      { id: 'p2', name: 'Legacy', weights: LEGACY_WEIGHTS },
+    ];
+
+    it('returns N×P results for N ventures and P profiles', () => {
+      const results = runBatchCounterfactual({ ventures, profiles });
+
+      // 2 ventures × 2 profiles = 4 results
+      expect(results).toHaveLength(4);
+    });
+
+    it('each result has venture_id and profile_id', () => {
+      const results = runBatchCounterfactual({ ventures, profiles });
+
+      for (const r of results) {
+        expect(r).toHaveProperty('venture_id');
+        expect(r).toHaveProperty('profile_id');
+        expect(r).toHaveProperty('profile_name');
+        expect(r).toHaveProperty('original_score');
+        expect(r).toHaveProperty('counterfactual_score');
+        expect(r).toHaveProperty('delta');
+      }
+    });
+
+    it('skips ventures with missing synthesis results', () => {
+      const venturesWithMissing = [
+        { id: 'v1', synthesisResults: MOCK_RESULTS, currentWeights: LEGACY_WEIGHTS },
+        { id: 'v2', synthesisResults: null, currentWeights: LEGACY_WEIGHTS },
+      ];
+
+      const logger = { warn: vi.fn(), info: vi.fn() };
+      const results = runBatchCounterfactual({ ventures: venturesWithMissing, profiles, logger });
+
+      // Only v1 × 2 profiles = 2 results
+      expect(results).toHaveLength(2);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('v2'));
+    });
+
+    it('throws when ventures array is empty', () => {
+      expect(() => runBatchCounterfactual({ ventures: [], profiles }))
+        .toThrow('ventures array is required');
+    });
+
+    it('throws when profiles array is empty', () => {
+      expect(() => runBatchCounterfactual({ ventures, profiles: [] }))
+        .toThrow('profiles array is required');
+    });
+
+    it('same-weight profile produces zero delta', () => {
+      const sameProfiles = [
+        { id: 'p1', name: 'Same', weights: LEGACY_WEIGHTS },
+      ];
+
+      const results = runBatchCounterfactual({ ventures, profiles: sameProfiles });
+
+      for (const r of results) {
+        expect(r.delta).toBe(0);
+      }
+    });
+  });
+
+  describe('generatePredictiveReport', () => {
+    it('returns profiles with accuracy metrics', () => {
+      const cfResults = [
+        { venture_id: 'v1', profile_id: 'p1', profile_name: 'Aggressive', counterfactual_score: 85 },
+        { venture_id: 'v2', profile_id: 'p1', profile_name: 'Aggressive', counterfactual_score: 60 },
+        { venture_id: 'v3', profile_id: 'p1', profile_name: 'Aggressive', counterfactual_score: 40 },
+      ];
+
+      const outcomes = {
+        v1: 'completed',
+        v2: 'parked',
+        v3: 'killed',
+      };
+
+      const report = generatePredictiveReport(cfResults, outcomes);
+
+      expect(report).toHaveProperty('profiles');
+      expect(report).toHaveProperty('total_ventures');
+      expect(report.total_ventures).toBe(3);
+
+      const p1 = report.profiles.p1;
+      expect(p1).toHaveProperty('accuracy');
+      expect(p1).toHaveProperty('kendall_tau');
+      expect(p1).toHaveProperty('concordant_pairs');
+      expect(p1).toHaveProperty('discordant_pairs');
+      expect(p1).toHaveProperty('tied_pairs');
+      expect(p1.ventures_scored).toBe(3);
+    });
+
+    it('perfectly ordered scores produce accuracy 1.0', () => {
+      const cfResults = [
+        { venture_id: 'v1', profile_id: 'p1', profile_name: 'Test', counterfactual_score: 90 },
+        { venture_id: 'v2', profile_id: 'p1', profile_name: 'Test', counterfactual_score: 50 },
+        { venture_id: 'v3', profile_id: 'p1', profile_name: 'Test', counterfactual_score: 10 },
+      ];
+
+      const outcomes = { v1: 'completed', v2: 'parked', v3: 'killed' };
+      const report = generatePredictiveReport(cfResults, outcomes);
+
+      expect(report.profiles.p1.accuracy).toBe(1);
+      expect(report.profiles.p1.kendall_tau).toBe(1);
+    });
+
+    it('perfectly inverted scores produce tau -1.0', () => {
+      const cfResults = [
+        { venture_id: 'v1', profile_id: 'p1', profile_name: 'Test', counterfactual_score: 10 },
+        { venture_id: 'v2', profile_id: 'p1', profile_name: 'Test', counterfactual_score: 50 },
+        { venture_id: 'v3', profile_id: 'p1', profile_name: 'Test', counterfactual_score: 90 },
+      ];
+
+      const outcomes = { v1: 'completed', v2: 'parked', v3: 'killed' };
+      const report = generatePredictiveReport(cfResults, outcomes);
+
+      expect(report.profiles.p1.accuracy).toBe(0);
+      expect(report.profiles.p1.kendall_tau).toBe(-1);
+    });
+
+    it('returns empty report for null input', () => {
+      const report = generatePredictiveReport(null, {});
+
+      expect(report.total_ventures).toBe(0);
+      expect(report.profiles).toEqual({});
+    });
+
+    it('handles multiple profiles in same result set', () => {
+      const cfResults = [
+        { venture_id: 'v1', profile_id: 'p1', profile_name: 'A', counterfactual_score: 80 },
+        { venture_id: 'v2', profile_id: 'p1', profile_name: 'A', counterfactual_score: 40 },
+        { venture_id: 'v1', profile_id: 'p2', profile_name: 'B', counterfactual_score: 60 },
+        { venture_id: 'v2', profile_id: 'p2', profile_name: 'B', counterfactual_score: 70 },
+      ];
+
+      const outcomes = { v1: 'completed', v2: 'killed' };
+      const report = generatePredictiveReport(cfResults, outcomes);
+
+      expect(Object.keys(report.profiles)).toHaveLength(2);
+      expect(report.profiles.p1).toBeDefined();
+      expect(report.profiles.p2).toBeDefined();
+    });
+
+    it('unknown outcomes treated as neutral (0.5)', () => {
+      const cfResults = [
+        { venture_id: 'v1', profile_id: 'p1', profile_name: 'Test', counterfactual_score: 90 },
+        { venture_id: 'v2', profile_id: 'p1', profile_name: 'Test', counterfactual_score: 10 },
+      ];
+
+      const outcomes = { v1: 'completed' }; // v2 missing → 0.5
+      const report = generatePredictiveReport(cfResults, outcomes);
+
+      expect(report.profiles.p1).toBeDefined();
+      // v1: score=90, outcome=1.0; v2: score=10, outcome=0.5
+      // concordant: higher score → better outcome → 1 pair concordant
+      expect(report.profiles.p1.concordant_pairs).toBe(1);
+    });
+  });
+
+  describe('persistCounterfactualResults', () => {
+    it('upserts results to database', async () => {
+      const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          upsert: mockUpsert,
+        }),
+      };
+      const logger = { info: vi.fn() };
+
+      const results = [
+        { venture_id: 'v1', profile_id: 'p1', original_score: 80, counterfactual_score: 85, delta: 5, breakdown: [] },
+      ];
+
+      const outcome = await persistCounterfactualResults({ supabase, logger }, results);
+
+      expect(outcome.inserted).toBe(1);
+      expect(outcome.skipped).toBe(0);
+      expect(supabase.from).toHaveBeenCalledWith('counterfactual_scores');
+    });
+
+    it('counts errors as skipped', async () => {
+      const mockUpsert = vi.fn().mockResolvedValue({ error: { message: 'fk violation' } });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          upsert: mockUpsert,
+        }),
+      };
+      const logger = { info: vi.fn() };
+
+      const results = [
+        { venture_id: 'v1', profile_id: 'p1', original_score: 80, counterfactual_score: 85, delta: 5, breakdown: [] },
+      ];
+
+      const outcome = await persistCounterfactualResults({ supabase, logger }, results);
+
+      expect(outcome.inserted).toBe(0);
+      expect(outcome.skipped).toBe(1);
+      expect(outcome.errors).toHaveLength(1);
+    });
+
+    it('throws when supabase is missing', async () => {
+      await expect(persistCounterfactualResults({}, []))
+        .rejects.toThrow('supabase client is required');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements counterfactual scoring engine for EVA Stage 0 evaluation profiles (SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-I)
- `generateCounterfactual()`: Compare venture scores under original vs alternative profile weights
- `runBatchCounterfactual()`: Batch re-score N ventures × P profiles with skip-on-error resilience
- `generatePredictiveReport()`: Pairwise concordance (Kendall's tau) to measure which profiles best predict actual outcomes
- `persistCounterfactualResults()`: Upsert results to `counterfactual_scores` table
- Database migration creates `counterfactual_scores` table with FK to `evaluation_profiles`, unique constraint on (venture_id, profile_id)
- Fixes systemic bug: smoke test specification gate now correctly parses JSON from TEXT columns
- 25 unit tests covering all functions, edge cases, and error paths

## Test plan
- [x] 25 unit tests pass (`npx vitest run tests/unit/eva/stage-zero/counterfactual-engine.test.js`)
- [x] Migration executed successfully (table, indexes, RLS, trigger verified)
- [x] Smoke tests pass (15/15)
- [x] ESLint clean
- [x] No secrets detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)