### PR TITLE
fix(gates): register 'fix' SD type in runtime config files

### DIFF
--- a/scripts/modules/handoff/validation/sd-type-applicability-policy.js
+++ b/scripts/modules/handoff/validation/sd-type-applicability-policy.js
@@ -46,6 +46,7 @@ export const LIGHTWEIGHT_SD_TYPES = [
 
   // Code-producing but scope-limited SD types
   'bugfix',
+  'fix',       // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-022: 'fix' is database equivalent of bugfix
   'refactor',
   'ux_debt',          // Similar to refactor but for UX
   'implementation'    // Typically follows a pre-defined spec
@@ -188,6 +189,17 @@ const SD_TYPE_POLICY = {
   },
 
   bugfix: {
+    TESTING: RequirementLevel.REQUIRED,        // Must verify fix
+    DESIGN: RequirementLevel.NON_APPLICABLE,   // Usually no design changes
+    GITHUB: RequirementLevel.REQUIRED,
+    DATABASE: RequirementLevel.OPTIONAL,
+    REGRESSION: RequirementLevel.OPTIONAL,
+    DOCMON: RequirementLevel.OPTIONAL,
+    STORIES: RequirementLevel.OPTIONAL
+  },
+
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-022: 'fix' is the database sd_type equivalent of bugfix
+  fix: {
     TESTING: RequirementLevel.REQUIRED,        // Must verify fix
     DESIGN: RequirementLevel.NON_APPLICABLE,   // Usually no design changes
     GITHUB: RequirementLevel.REQUIRED,

--- a/scripts/modules/handoff/verifiers/plan-to-exec/story-quality.js
+++ b/scripts/modules/handoff/verifiers/plan-to-exec/story-quality.js
@@ -37,6 +37,7 @@ export const CATEGORY_THRESHOLDS = {
   // Bugfix stories are targeted fixes, not full feature narratives
   'bugfix': 55,
   'bug_fix': 55,  // Handle underscore variant
+  'fix': 55,      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-022: 'fix' is the database sd_type equivalent of bugfix
 
   // Stricter for data/security work
   'database': 68,

--- a/scripts/modules/user-story-quality-validation.js
+++ b/scripts/modules/user-story-quality-validation.js
@@ -154,7 +154,7 @@ export async function validateUserStoryQuality(story, options = {}) {
   // AI scoring is too strict for these SD types - database SDs focus on schema/migrations, not user narratives
   // Added 'theming', 'ux', 'design', 'ui' - these focus on visual/style fixes, not complex user narratives
   // Check both sdType and sdCategory since SDs can have type='implementation' but category='theming'
-  const heuristicTypes = ['bugfix', 'bug_fix', 'infrastructure', 'database', 'quality assurance', 'quality_assurance', 'orchestrator', 'documentation', 'theming', 'ux', 'design', 'ui', 'layout', 'state-management'];
+  const heuristicTypes = ['bugfix', 'bug_fix', 'fix', 'infrastructure', 'database', 'quality assurance', 'quality_assurance', 'orchestrator', 'documentation', 'theming', 'ux', 'design', 'ui', 'layout', 'state-management'];
   const usesHeuristic = process.env.STORY_VALIDATION_MODE === 'heuristic' ||
                         heuristicTypes.includes(sdType) ||
                         heuristicTypes.includes(sdCategory);


### PR DESCRIPTION
## Summary
- Register `fix` SD type in 3 runtime configuration files where it was missing despite being valid in the database CHECK constraint
- Add `fix` to `CATEGORY_THRESHOLDS` (55% threshold, matching `bugfix`)
- Add `fix` to `LIGHTWEIGHT_SD_TYPES` and `SD_TYPE_POLICY` (matching `bugfix` configuration)
- Add `fix` to `heuristicTypes` array for lenient story quality scoring

**Root Cause**: The `fix` SD type existed in the database but was missing from runtime config, causing silent fallback to stricter defaults (70% threshold instead of 55%, required smoke tests, AI scoring instead of heuristic).

**Resolves**: PAT-AUTO-602b2446, PAT-AUTO-c9111fd2

## Test plan
- [x] `getStoryMinimumScoreByCategory('', 'fix')` returns 55 (was 70)
- [x] `isLightweightSDType('fix')` returns true (was false)
- [x] `getValidatorRequirements('fix')` matches `getValidatorRequirements('bugfix')`
- [x] Smoke test gate correctly skips for `fix` SD type
- [x] All 15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)