### PR TITLE
feat(eva): add stage-of-death prediction engine

### DIFF
--- a/database/migrations/20260210_stage_of_death_predictions.sql
+++ b/database/migrations/20260210_stage_of_death_predictions.sql
@@ -1,0 +1,53 @@
+-- Stage-of-Death Predictions
+-- Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-J
+-- Stores predicted death stage per venture × profile × archetype
+
+CREATE TABLE IF NOT EXISTS stage_of_death_predictions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL,
+  archetype_key TEXT NOT NULL,
+  profile_id UUID NOT NULL REFERENCES evaluation_profiles(id),
+  predicted_death_stage INTEGER NOT NULL CHECK (predicted_death_stage BETWEEN 1 AND 25),
+  predicted_probability NUMERIC(5,4) NOT NULL CHECK (predicted_probability BETWEEN 0 AND 1),
+  death_factors JSONB,
+  confidence_score NUMERIC(4,3) CHECK (confidence_score BETWEEN 0 AND 1),
+  mortality_curve JSONB,
+  actual_death_stage INTEGER CHECK (actual_death_stage IS NULL OR actual_death_stage BETWEEN 1 AND 25),
+  prediction_accuracy NUMERIC(5,2),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(venture_id, profile_id)
+);
+
+-- Indexes for query performance
+CREATE INDEX IF NOT EXISTS idx_sod_predictions_venture ON stage_of_death_predictions(venture_id);
+CREATE INDEX IF NOT EXISTS idx_sod_predictions_archetype ON stage_of_death_predictions(archetype_key);
+CREATE INDEX IF NOT EXISTS idx_sod_predictions_profile ON stage_of_death_predictions(profile_id);
+CREATE INDEX IF NOT EXISTS idx_sod_predictions_stage ON stage_of_death_predictions(predicted_death_stage);
+
+-- Enable RLS
+ALTER TABLE stage_of_death_predictions ENABLE ROW LEVEL SECURITY;
+
+-- Allow service role full access
+DROP POLICY IF EXISTS "service_role_full_access_sod_predictions" ON stage_of_death_predictions;
+CREATE POLICY "service_role_full_access_sod_predictions"
+  ON stage_of_death_predictions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Updated_at trigger
+CREATE OR REPLACE FUNCTION update_sod_predictions_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_update_sod_predictions_timestamp ON stage_of_death_predictions;
+CREATE TRIGGER trg_update_sod_predictions_timestamp
+  BEFORE UPDATE ON stage_of_death_predictions
+  FOR EACH ROW
+  EXECUTE FUNCTION update_sod_predictions_timestamp();

--- a/database/migrations/20260210_stage_of_death_predictions_SUMMARY.md
+++ b/database/migrations/20260210_stage_of_death_predictions_SUMMARY.md
@@ -1,0 +1,51 @@
+# Migration Summary: 20260210_stage_of_death_predictions.sql
+
+**Executed**: 2026-02-10
+**Status**: ✅ SUCCESS
+**Part of**: SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-J
+
+## Changes Applied
+
+### Table Created
+- **stage_of_death_predictions** - Stores predicted death stage per venture × profile × archetype
+
+### Schema Details
+- **13 columns** including:
+  - Primary key: `id` (UUID)
+  - Unique constraint: `(venture_id, profile_id)`
+  - Foreign key: `profile_id → evaluation_profiles(id)`
+  - Death stage range: 1-25 (CHECK constraint)
+  - Probability range: 0-1 (CHECK constraint)
+  - JSONB fields: `death_factors`, `mortality_curve`
+
+### Indexes Created (5)
+1. `idx_sod_predictions_venture` - On venture_id
+2. `idx_sod_predictions_archetype` - On archetype_key
+3. `idx_sod_predictions_profile` - On profile_id
+4. `idx_sod_predictions_stage` - On predicted_death_stage
+5. `stage_of_death_predictions_venture_id_profile_id_key` - UNIQUE constraint index
+
+### Security
+- **RLS Enabled**: YES
+- **Policy**: `service_role_full_access_sod_predictions` (FOR ALL to service_role)
+
+### Triggers
+- **trg_update_sod_predictions_timestamp** - Auto-updates `updated_at` on UPDATE
+
+## Execution Method
+- Used `SUPABASE_POOLER_URL` (password-less connection)
+- Direct `pg.Client` execution via Node.js
+
+## Verification
+All components verified:
+- ✅ Table structure matches spec
+- ✅ All indexes created
+- ✅ RLS policy active
+- ✅ Trigger function registered
+
+## Purpose
+Enables stage-of-death prediction storage for EVA's portfolio analysis:
+- Predicts at which funding stage a venture is most likely to fail
+- Tracks prediction accuracy against actual outcomes
+- Stores mortality curves and death factors per archetype
+- Supports profile-specific predictions for sensitivity analysis

--- a/lib/eva/stage-zero/index.js
+++ b/lib/eva/stage-zero/index.js
@@ -42,6 +42,13 @@ export {
 } from './counterfactual-engine.js';
 
 export {
+  predictStageOfDeath,
+  buildMortalityCurve,
+  calibratePredictions,
+  persistPredictions,
+} from './stage-of-death-predictor.js';
+
+export {
   parkVenture,
   reactivateVenture,
   recordSynthesisFeedback,

--- a/lib/eva/stage-zero/stage-of-death-predictor.js
+++ b/lib/eva/stage-zero/stage-of-death-predictor.js
@@ -1,0 +1,373 @@
+/**
+ * Stage-of-Death Prediction Engine
+ *
+ * Predicts WHERE a venture will die (which stage), not just IF.
+ * Uses historical kill gate data per profile+archetype combination
+ * to generate mortality curves and death predictions.
+ *
+ * Example output: "Democratizers with viral-first that score below 60
+ * on moat have 80% chance of dying at Stage 5."
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-J
+ */
+
+import { calculateWeightedScore, VALID_COMPONENTS } from './profile-service.js';
+
+/** Default stage boundaries matching EHG 25-stage venture lifecycle */
+const TOTAL_STAGES = 25;
+
+/** Stage groupings for mortality curve generation */
+const STAGE_PHASES = {
+  filtering: { start: 1, end: 5, label: 'Filtering & Validation' },
+  building: { start: 6, end: 12, label: 'Planning & Building' },
+  testing: { start: 13, end: 18, label: 'Testing & Launch' },
+  scaling: { start: 19, end: 25, label: 'Scaling & Optimization' },
+};
+
+/**
+ * Predict the most likely stage of death for a venture.
+ *
+ * @param {Object} params
+ * @param {string} params.archetype - Archetype key (e.g., 'democratizer')
+ * @param {Object} params.componentScores - Map of component name → score (0-100)
+ * @param {Object} params.profileWeights - Profile weights for scoring
+ * @param {Object} [params.archetypeData] - Historical archetype data with common_kill_stages
+ * @param {Object} [params.options]
+ * @returns {Object} { death_stage, probability, death_factors, confidence, message }
+ */
+export function predictStageOfDeath({ archetype, componentScores, profileWeights, archetypeData, options = {} }) {
+  if (!archetype || !componentScores || !profileWeights) {
+    throw new Error('archetype, componentScores, and profileWeights are required');
+  }
+
+  // Build mortality curve from historical data
+  const mortalityCurve = buildMortalityCurve({
+    archetypeData,
+    profileWeights,
+    componentScores,
+  });
+
+  // Find the peak mortality stage
+  let peakStage = 5; // default fallback
+  let peakProbability = 0;
+
+  for (let stage = 1; stage <= TOTAL_STAGES; stage++) {
+    if (mortalityCurve[stage] > peakProbability) {
+      peakProbability = mortalityCurve[stage];
+      peakStage = stage;
+    }
+  }
+
+  // Identify death factors from component scores
+  const deathFactors = identifyDeathFactors(componentScores, profileWeights);
+
+  // Calculate confidence based on data availability
+  const confidence = calculateConfidence(archetypeData);
+
+  // Generate human-readable message
+  const topFactor = deathFactors[0];
+  const phaseLabel = getPhaseLabel(peakStage);
+  const message = `${capitalize(archetype)}s scoring ${topFactor ? `below ${Math.round(topFactor.threshold)} on ${topFactor.component}` : 'poorly overall'} have ${Math.round(peakProbability * 100)}% chance of dying at Stage ${peakStage} (${phaseLabel}).`;
+
+  return {
+    death_stage: peakStage,
+    probability: Math.round(peakProbability * 1000) / 1000,
+    death_factors: deathFactors,
+    confidence: Math.round(confidence * 100) / 100,
+    mortality_curve: mortalityCurve,
+    message,
+    archetype,
+  };
+}
+
+/**
+ * Build a per-stage mortality curve for an archetype-profile combination.
+ *
+ * Mortality rates are computed by combining:
+ * 1. Historical common_kill_stages from the archetype
+ * 2. Profile weight emphasis (high-weight weak components → earlier death)
+ * 3. Component score weakness amplification
+ *
+ * @param {Object} params
+ * @param {Object} [params.archetypeData] - Historical data with common_kill_stages, killed_count, etc.
+ * @param {Object} params.profileWeights - Profile weights
+ * @param {Object} params.componentScores - Per-component scores (0-100)
+ * @returns {Object} Map of stage (1-25) → mortality rate (0-1), sums to <= 1.0
+ */
+export function buildMortalityCurve({ archetypeData, profileWeights, componentScores }) {
+  const curve = {};
+  for (let s = 1; s <= TOTAL_STAGES; s++) {
+    curve[s] = 0;
+  }
+
+  // Layer 1: Historical kill stages from archetype data
+  if (archetypeData?.common_kill_stages?.length > 0) {
+    const killStages = archetypeData.common_kill_stages;
+    const historicalWeight = 0.5; // 50% weight for historical data
+    const perStage = historicalWeight / killStages.length;
+
+    for (const stage of killStages) {
+      if (stage >= 1 && stage <= TOTAL_STAGES) {
+        curve[stage] += perStage;
+        // Spread some probability to adjacent stages (Gaussian-like)
+        if (stage > 1) curve[stage - 1] += perStage * 0.3;
+        if (stage < TOTAL_STAGES) curve[stage + 1] += perStage * 0.3;
+      }
+    }
+  } else {
+    // No historical data: use default lifecycle mortality distribution
+    // Higher mortality at phase transitions (stages 5, 12, 18, 24)
+    const defaults = { 5: 0.15, 12: 0.12, 18: 0.10, 24: 0.08 };
+    for (const [stage, rate] of Object.entries(defaults)) {
+      curve[Number(stage)] = rate;
+    }
+  }
+
+  // Layer 2: Score-weighted mortality amplification
+  // Weak component scores shift mortality curve toward earlier stages.
+  // Uses multiplicative adjustment so normalization preserves the relative boost.
+  if (componentScores && profileWeights) {
+    const weaknesses = identifyWeaknesses(componentScores, profileWeights);
+
+    if (weaknesses.length > 0) {
+      const totalWeight = weaknesses.reduce((s, w) => s + w.weight, 0);
+      const avgSeverity = weaknesses.reduce(
+        (s, w) => s + (1 - w.score / 100) * w.weight, 0,
+      ) / Math.max(totalWeight, 0.01);
+
+      for (let s = 1; s <= TOTAL_STAGES; s++) {
+        // earlyFactor: 1.0 at stage 1, 0.0 at stage 25
+        const earlyFactor = Math.max(0, 1 - (s - 1) / (TOTAL_STAGES - 1));
+        curve[s] *= (1 + avgSeverity * earlyFactor);
+      }
+    }
+  }
+
+  // Normalize so total mortality <= 1.0
+  const total = Object.values(curve).reduce((sum, v) => sum + v, 0);
+  if (total > 1.0) {
+    for (const stage of Object.keys(curve)) {
+      curve[stage] = Math.round((curve[stage] / total) * 10000) / 10000;
+    }
+  } else {
+    // Round all values
+    for (const stage of Object.keys(curve)) {
+      curve[stage] = Math.round(curve[stage] * 10000) / 10000;
+    }
+  }
+
+  return curve;
+}
+
+/**
+ * Calibrate predictions by comparing past predictions against actual outcomes.
+ *
+ * @param {Array<Object>} predictions - Array of { venture_id, predicted_stage, actual_stage, actual_outcome }
+ * @returns {Object} { accuracy_score, mean_absolute_error, directional_accuracy, per_archetype }
+ */
+export function calibratePredictions(predictions) {
+  if (!predictions?.length) {
+    return {
+      accuracy_score: 0,
+      mean_absolute_error: 0,
+      directional_accuracy: 0,
+      total_predictions: 0,
+      per_archetype: {},
+      message: 'Insufficient data for calibration',
+    };
+  }
+
+  let totalError = 0;
+  let directionalCorrect = 0;
+  const killedPredictions = predictions.filter(p => p.actual_outcome === 'killed');
+  const byArchetype = {};
+
+  for (const pred of killedPredictions) {
+    const error = Math.abs(pred.predicted_stage - pred.actual_stage);
+    totalError += error;
+
+    // Directionally correct: predicted within 5 stages of actual
+    if (error <= 5) directionalCorrect++;
+
+    // Group by archetype
+    const arch = pred.archetype || 'unknown';
+    if (!byArchetype[arch]) {
+      byArchetype[arch] = { count: 0, total_error: 0, directional_correct: 0 };
+    }
+    byArchetype[arch].count++;
+    byArchetype[arch].total_error += error;
+    if (error <= 5) byArchetype[arch].directional_correct++;
+  }
+
+  const n = killedPredictions.length;
+  const mae = n > 0 ? Math.round((totalError / n) * 100) / 100 : 0;
+  const dirAccuracy = n > 0 ? Math.round((directionalCorrect / n) * 1000) / 1000 : 0;
+
+  // Accuracy score: inverse of MAE normalized to 0-1
+  // Perfect prediction (MAE=0) → 1.0, MAE=25 → 0
+  const accuracyScore = n > 0 ? Math.round(Math.max(0, 1 - mae / TOTAL_STAGES) * 1000) / 1000 : 0;
+
+  // Per-archetype breakdown
+  const perArchetype = {};
+  for (const [arch, data] of Object.entries(byArchetype)) {
+    perArchetype[arch] = {
+      predictions: data.count,
+      mean_absolute_error: Math.round((data.total_error / data.count) * 100) / 100,
+      directional_accuracy: Math.round((data.directional_correct / data.count) * 1000) / 1000,
+    };
+  }
+
+  return {
+    accuracy_score: accuracyScore,
+    mean_absolute_error: mae,
+    directional_accuracy: dirAccuracy,
+    total_predictions: n,
+    per_archetype: perArchetype,
+  };
+}
+
+/**
+ * Persist stage-of-death predictions to the database.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {Array<Object>} predictions - Array of prediction results
+ * @returns {Promise<Object>} { inserted, skipped, errors }
+ */
+export async function persistPredictions(deps, predictions) {
+  const { supabase, logger = console } = deps;
+  if (!supabase) throw new Error('supabase client is required');
+
+  let inserted = 0;
+  let skipped = 0;
+  const errors = [];
+
+  for (const pred of predictions) {
+    const { error } = await supabase
+      .from('stage_of_death_predictions')
+      .upsert({
+        venture_id: pred.venture_id,
+        archetype_key: pred.archetype,
+        profile_id: pred.profile_id,
+        predicted_death_stage: pred.death_stage,
+        predicted_probability: pred.probability,
+        death_factors: pred.death_factors,
+        confidence_score: pred.confidence,
+        mortality_curve: pred.mortality_curve,
+      }, { onConflict: 'venture_id,profile_id' });
+
+    if (error) {
+      errors.push({ venture_id: pred.venture_id, error: error.message });
+      skipped++;
+    } else {
+      inserted++;
+    }
+  }
+
+  logger.info?.(`   Persisted ${inserted} predictions (${skipped} skipped)`);
+  return { inserted, skipped, errors };
+}
+
+// --- Internal helpers ---
+
+/**
+ * Identify the top death factors from component scores weighted by profile.
+ * A death factor is a component where the score is low relative to its weight.
+ */
+function identifyDeathFactors(componentScores, profileWeights) {
+  const factors = [];
+
+  for (const component of VALID_COMPONENTS) {
+    const score = extractScore(component, componentScores);
+    const weight = profileWeights[component] || 0;
+
+    if (weight === 0) continue;
+
+    // Risk = weight * (1 - normalized_score)
+    const risk = weight * (1 - score / 100);
+    const threshold = score < 50 ? score + 10 : 60; // What score would make this safe
+
+    factors.push({
+      component,
+      score,
+      weight,
+      risk: Math.round(risk * 1000) / 1000,
+      threshold,
+    });
+  }
+
+  // Sort by risk descending, return top 5
+  return factors
+    .sort((a, b) => b.risk - a.risk)
+    .slice(0, 5);
+}
+
+/**
+ * Identify weakness scores: components with high weight but low score.
+ */
+function identifyWeaknesses(componentScores, profileWeights) {
+  const weaknesses = [];
+
+  for (const component of VALID_COMPONENTS) {
+    const score = extractScore(component, componentScores);
+    const weight = profileWeights[component] || 0;
+
+    if (weight > 0 && score < 70) {
+      weaknesses.push({ component, score, weight });
+    }
+  }
+
+  return weaknesses.sort((a, b) => (a.score * a.weight) - (b.score * b.weight));
+}
+
+/**
+ * Extract a numeric score from component scores (handles both raw numbers and objects).
+ */
+function extractScore(component, componentScores) {
+  const val = componentScores[component];
+  if (typeof val === 'number') return val;
+  if (val?.score != null) return val.score;
+  if (val?.raw_score != null) return val.raw_score;
+  return 0;
+}
+
+/**
+ * Calculate prediction confidence based on data availability.
+ */
+function calculateConfidence(archetypeData) {
+  if (!archetypeData) return 0.2; // Low confidence without data
+
+  let confidence = 0.3; // Base confidence
+
+  // More historical ventures = higher confidence
+  const totalVentures = archetypeData.total_ventures || 0;
+  if (totalVentures >= 20) confidence += 0.3;
+  else if (totalVentures >= 10) confidence += 0.2;
+  else if (totalVentures >= 5) confidence += 0.1;
+
+  // Having kill stage data adds confidence
+  if (archetypeData.common_kill_stages?.length > 0) confidence += 0.15;
+
+  // Having kill reason data adds confidence
+  if (archetypeData.common_kill_reasons?.length > 0) confidence += 0.1;
+
+  // Having killed count adds confidence
+  if (archetypeData.killed_count > 0) confidence += 0.05;
+
+  return Math.min(1.0, confidence);
+}
+
+/**
+ * Get the phase label for a given stage number.
+ */
+function getPhaseLabel(stage) {
+  for (const [, phase] of Object.entries(STAGE_PHASES)) {
+    if (stage >= phase.start && stage <= phase.end) return phase.label;
+  }
+  return 'Unknown Phase';
+}
+
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export { TOTAL_STAGES, STAGE_PHASES };

--- a/tests/unit/eva/stage-zero/stage-of-death-predictor.test.js
+++ b/tests/unit/eva/stage-zero/stage-of-death-predictor.test.js
@@ -1,0 +1,400 @@
+/**
+ * Stage-of-Death Prediction Engine Tests
+ *
+ * Tests for death prediction, mortality curve building,
+ * calibration, and persistence.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-J
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  predictStageOfDeath,
+  buildMortalityCurve,
+  calibratePredictions,
+  persistPredictions,
+  TOTAL_STAGES,
+} from '../../../../lib/eva/stage-zero/stage-of-death-predictor.js';
+
+const LEGACY_WEIGHTS = {
+  cross_reference: 0.10,
+  portfolio_evaluation: 0.10,
+  problem_reframing: 0.05,
+  moat_architecture: 0.15,
+  chairman_constraints: 0.15,
+  time_horizon: 0.10,
+  archetypes: 0.10,
+  build_cost: 0.10,
+  virality: 0.15,
+};
+
+const STRONG_SCORES = {
+  cross_reference: 80,
+  portfolio_evaluation: 70,
+  problem_reframing: 70,
+  moat_architecture: 90,
+  chairman_constraints: 100,
+  time_horizon: 100,
+  archetypes: 85,
+  build_cost: 90,
+  virality: 75,
+};
+
+const WEAK_MOAT_SCORES = {
+  cross_reference: 60,
+  portfolio_evaluation: 50,
+  problem_reframing: 40,
+  moat_architecture: 25,
+  chairman_constraints: 50,
+  time_horizon: 75,
+  archetypes: 60,
+  build_cost: 70,
+  virality: 30,
+};
+
+const ARCHETYPE_WITH_HISTORY = {
+  archetype_key: 'democratizer',
+  total_ventures: 15,
+  graduated_count: 5,
+  killed_count: 7,
+  common_kill_stages: [5, 12],
+  common_kill_reasons: ['Weak moat', 'Insufficient viral mechanics'],
+};
+
+const ARCHETYPE_NO_HISTORY = {
+  archetype_key: 'new_archetype',
+  total_ventures: 0,
+  graduated_count: 0,
+  killed_count: 0,
+  common_kill_stages: [],
+  common_kill_reasons: [],
+};
+
+describe('stage-of-death-predictor', () => {
+  describe('predictStageOfDeath', () => {
+    it('returns prediction with all required fields', () => {
+      const result = predictStageOfDeath({
+        archetype: 'democratizer',
+        componentScores: STRONG_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+      });
+
+      expect(result).toHaveProperty('death_stage');
+      expect(result).toHaveProperty('probability');
+      expect(result).toHaveProperty('death_factors');
+      expect(result).toHaveProperty('confidence');
+      expect(result).toHaveProperty('mortality_curve');
+      expect(result).toHaveProperty('message');
+      expect(result).toHaveProperty('archetype', 'democratizer');
+    });
+
+    it('death_stage is between 1 and 25', () => {
+      const result = predictStageOfDeath({
+        archetype: 'democratizer',
+        componentScores: WEAK_MOAT_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+      });
+
+      expect(result.death_stage).toBeGreaterThanOrEqual(1);
+      expect(result.death_stage).toBeLessThanOrEqual(25);
+    });
+
+    it('probability is between 0 and 1', () => {
+      const result = predictStageOfDeath({
+        archetype: 'democratizer',
+        componentScores: WEAK_MOAT_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+      });
+
+      expect(result.probability).toBeGreaterThanOrEqual(0);
+      expect(result.probability).toBeLessThanOrEqual(1);
+    });
+
+    it('weak moat scores produce moat as top death factor', () => {
+      const result = predictStageOfDeath({
+        archetype: 'democratizer',
+        componentScores: WEAK_MOAT_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+      });
+
+      expect(result.death_factors.length).toBeGreaterThan(0);
+      // moat_architecture should be among top factors due to low score + high weight
+      const moatFactor = result.death_factors.find(f => f.component === 'moat_architecture');
+      expect(moatFactor).toBeDefined();
+      expect(moatFactor.risk).toBeGreaterThan(0);
+    });
+
+    it('returns fallback prediction with null archetype data', () => {
+      const result = predictStageOfDeath({
+        archetype: 'unknown',
+        componentScores: WEAK_MOAT_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: null,
+      });
+
+      expect(result.death_stage).toBeGreaterThanOrEqual(1);
+      expect(result.confidence).toBeLessThanOrEqual(0.3);
+    });
+
+    it('higher confidence with more historical data', () => {
+      const withHistory = predictStageOfDeath({
+        archetype: 'democratizer',
+        componentScores: STRONG_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+      });
+
+      const withoutHistory = predictStageOfDeath({
+        archetype: 'unknown',
+        componentScores: STRONG_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: ARCHETYPE_NO_HISTORY,
+      });
+
+      expect(withHistory.confidence).toBeGreaterThan(withoutHistory.confidence);
+    });
+
+    it('generates human-readable message', () => {
+      const result = predictStageOfDeath({
+        archetype: 'democratizer',
+        componentScores: WEAK_MOAT_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+      });
+
+      expect(result.message).toContain('Democratizer');
+      expect(result.message).toContain('Stage');
+      expect(result.message).toContain('%');
+    });
+
+    it('death_factors has at most 5 entries', () => {
+      const result = predictStageOfDeath({
+        archetype: 'democratizer',
+        componentScores: WEAK_MOAT_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+      });
+
+      expect(result.death_factors.length).toBeLessThanOrEqual(5);
+    });
+
+    it('throws when required params missing', () => {
+      expect(() => predictStageOfDeath({
+        archetype: null,
+        componentScores: STRONG_SCORES,
+        profileWeights: LEGACY_WEIGHTS,
+      })).toThrow('required');
+    });
+  });
+
+  describe('buildMortalityCurve', () => {
+    it('returns 25 stage entries', () => {
+      const curve = buildMortalityCurve({
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+        profileWeights: LEGACY_WEIGHTS,
+        componentScores: STRONG_SCORES,
+      });
+
+      expect(Object.keys(curve)).toHaveLength(25);
+    });
+
+    it('all mortality rates are non-negative', () => {
+      const curve = buildMortalityCurve({
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+        profileWeights: LEGACY_WEIGHTS,
+        componentScores: STRONG_SCORES,
+      });
+
+      for (const rate of Object.values(curve)) {
+        expect(rate).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it('total mortality sums to <= 1.0', () => {
+      const curve = buildMortalityCurve({
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+        profileWeights: LEGACY_WEIGHTS,
+        componentScores: STRONG_SCORES,
+      });
+
+      const total = Object.values(curve).reduce((sum, v) => sum + v, 0);
+      expect(total).toBeLessThanOrEqual(1.01); // Allow minor rounding
+    });
+
+    it('common_kill_stages have highest rates', () => {
+      const curve = buildMortalityCurve({
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+        profileWeights: LEGACY_WEIGHTS,
+        componentScores: STRONG_SCORES,
+      });
+
+      // Stages 5 and 12 should be among the highest
+      const stage5 = curve[5];
+      const stage12 = curve[12];
+      const avgOther = Object.entries(curve)
+        .filter(([s]) => s !== '5' && s !== '12')
+        .reduce((sum, [, v]) => sum + v, 0) / 23;
+
+      expect(stage5).toBeGreaterThan(avgOther);
+      expect(stage12).toBeGreaterThan(avgOther);
+    });
+
+    it('uses default distribution when no historical data', () => {
+      const curve = buildMortalityCurve({
+        archetypeData: null,
+        profileWeights: LEGACY_WEIGHTS,
+        componentScores: STRONG_SCORES,
+      });
+
+      // Default high-mortality stages: 5, 12, 18, 24
+      expect(curve[5]).toBeGreaterThan(0);
+      expect(curve[12]).toBeGreaterThan(0);
+      expect(curve[18]).toBeGreaterThan(0);
+    });
+
+    it('weak scores amplify early-stage mortality', () => {
+      const strongCurve = buildMortalityCurve({
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+        profileWeights: LEGACY_WEIGHTS,
+        componentScores: STRONG_SCORES,
+      });
+
+      const weakCurve = buildMortalityCurve({
+        archetypeData: ARCHETYPE_WITH_HISTORY,
+        profileWeights: LEGACY_WEIGHTS,
+        componentScores: WEAK_MOAT_SCORES,
+      });
+
+      // Weak scores should have more early-stage mortality
+      const earlyMortWeak = weakCurve[3] + weakCurve[4] + weakCurve[5] + weakCurve[6] + weakCurve[7];
+      const earlyMortStrong = strongCurve[3] + strongCurve[4] + strongCurve[5] + strongCurve[6] + strongCurve[7];
+
+      expect(earlyMortWeak).toBeGreaterThan(earlyMortStrong);
+    });
+  });
+
+  describe('calibratePredictions', () => {
+    it('returns accuracy metrics for killed ventures', () => {
+      const predictions = [
+        { venture_id: 'v1', predicted_stage: 5, actual_stage: 5, actual_outcome: 'killed', archetype: 'democratizer' },
+        { venture_id: 'v2', predicted_stage: 12, actual_stage: 10, actual_outcome: 'killed', archetype: 'automator' },
+        { venture_id: 'v3', predicted_stage: 8, actual_stage: 20, actual_outcome: 'completed', archetype: 'democratizer' },
+      ];
+
+      const result = calibratePredictions(predictions);
+
+      expect(result).toHaveProperty('accuracy_score');
+      expect(result).toHaveProperty('mean_absolute_error');
+      expect(result).toHaveProperty('directional_accuracy');
+      expect(result).toHaveProperty('total_predictions');
+      expect(result.total_predictions).toBe(2); // Only killed ventures count
+    });
+
+    it('perfect predictions produce accuracy 1.0', () => {
+      const predictions = [
+        { venture_id: 'v1', predicted_stage: 5, actual_stage: 5, actual_outcome: 'killed', archetype: 'demo' },
+        { venture_id: 'v2', predicted_stage: 12, actual_stage: 12, actual_outcome: 'killed', archetype: 'auto' },
+      ];
+
+      const result = calibratePredictions(predictions);
+
+      expect(result.accuracy_score).toBe(1);
+      expect(result.mean_absolute_error).toBe(0);
+      expect(result.directional_accuracy).toBe(1);
+    });
+
+    it('error of 3 stages counts as directionally correct', () => {
+      const predictions = [
+        { venture_id: 'v1', predicted_stage: 5, actual_stage: 8, actual_outcome: 'killed', archetype: 'demo' },
+      ];
+
+      const result = calibratePredictions(predictions);
+
+      expect(result.mean_absolute_error).toBe(3);
+      expect(result.directional_accuracy).toBe(1); // Within 5 stages
+    });
+
+    it('returns empty report for null input', () => {
+      const result = calibratePredictions(null);
+
+      expect(result.total_predictions).toBe(0);
+      expect(result.accuracy_score).toBe(0);
+      expect(result.message).toContain('Insufficient');
+    });
+
+    it('returns empty report for empty array', () => {
+      const result = calibratePredictions([]);
+
+      expect(result.total_predictions).toBe(0);
+      expect(result.message).toContain('Insufficient');
+    });
+
+    it('per_archetype breakdown is provided', () => {
+      const predictions = [
+        { venture_id: 'v1', predicted_stage: 5, actual_stage: 5, actual_outcome: 'killed', archetype: 'democratizer' },
+        { venture_id: 'v2', predicted_stage: 12, actual_stage: 14, actual_outcome: 'killed', archetype: 'democratizer' },
+        { venture_id: 'v3', predicted_stage: 8, actual_stage: 10, actual_outcome: 'killed', archetype: 'automator' },
+      ];
+
+      const result = calibratePredictions(predictions);
+
+      expect(result.per_archetype.democratizer).toBeDefined();
+      expect(result.per_archetype.automator).toBeDefined();
+      expect(result.per_archetype.democratizer.predictions).toBe(2);
+      expect(result.per_archetype.automator.predictions).toBe(1);
+    });
+  });
+
+  describe('persistPredictions', () => {
+    it('upserts predictions to database', async () => {
+      const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+      const supabase = {
+        from: vi.fn().mockReturnValue({ upsert: mockUpsert }),
+      };
+      const logger = { info: vi.fn() };
+
+      const predictions = [
+        {
+          venture_id: 'v1',
+          archetype: 'democratizer',
+          profile_id: 'p1',
+          death_stage: 5,
+          probability: 0.8,
+          death_factors: [],
+          confidence: 0.7,
+          mortality_curve: {},
+        },
+      ];
+
+      const result = await persistPredictions({ supabase, logger }, predictions);
+
+      expect(result.inserted).toBe(1);
+      expect(supabase.from).toHaveBeenCalledWith('stage_of_death_predictions');
+    });
+
+    it('counts errors as skipped', async () => {
+      const mockUpsert = vi.fn().mockResolvedValue({ error: { message: 'fk violation' } });
+      const supabase = {
+        from: vi.fn().mockReturnValue({ upsert: mockUpsert }),
+      };
+      const logger = { info: vi.fn() };
+
+      const result = await persistPredictions({ supabase, logger }, [
+        { venture_id: 'v1', archetype: 'demo', profile_id: 'p1', death_stage: 5, probability: 0.8, death_factors: [], confidence: 0.7, mortality_curve: {} },
+      ]);
+
+      expect(result.inserted).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toHaveLength(1);
+    });
+
+    it('throws when supabase is missing', async () => {
+      await expect(persistPredictions({}, []))
+        .rejects.toThrow('supabase client is required');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add stage-of-death prediction engine (`stage-of-death-predictor.js`) that forecasts which lifecycle stage (1-25) a venture is most likely to die at
- Predictions use historical archetype kill data, profile-weighted component scores, and mortality curve generation
- Includes calibration against actual outcomes and database persistence via `stage_of_death_predictions` table
- 24 unit tests covering prediction, mortality curves, calibration, and persistence

## Test plan
- [x] All 24 unit tests passing
- [x] Migration executed successfully
- [x] Smoke tests passing

Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-J

🤖 Generated with [Claude Code](https://claude.com/claude-code)