### PR TITLE
feat(eva): add profile blending engine for continuous weighted evaluation profiles

### DIFF
--- a/lib/eva/stage-zero/profile-blender.js
+++ b/lib/eva/stage-zero/profile-blender.js
@@ -1,0 +1,377 @@
+/**
+ * Profile Blending Engine
+ *
+ * Enables continuous, weighted evaluation profile blends (e.g., 65/35)
+ * instead of discrete presets. Stores raw weight vectors and treats
+ * presets as labeled bookmarks in continuous weight space.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-K
+ */
+
+import { createHash } from 'crypto';
+import { VALID_COMPONENTS, LEGACY_WEIGHTS } from './profile-service.js';
+
+/** Precision for weight rounding (6 decimal places per PRD TR-1) */
+const PRECISION = 6;
+
+/** Tolerance for normalization checks */
+const TOLERANCE = 0.0001;
+
+/**
+ * Validate a weight vector.
+ *
+ * Checks:
+ * - All values are numbers
+ * - No negative values
+ * - At least one value > 0
+ * - Only valid dimension keys
+ *
+ * @param {Object} weights - Map of dimension → weight
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateWeightVector(weights) {
+  const errors = [];
+
+  if (!weights || typeof weights !== 'object') {
+    return { valid: false, errors: ['weights must be a non-null object'] };
+  }
+
+  const negatives = [];
+  let hasPositive = false;
+
+  for (const [key, value] of Object.entries(weights)) {
+    if (!VALID_COMPONENTS.includes(key)) {
+      errors.push(`Unknown dimension: ${key}`);
+      continue;
+    }
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+      errors.push(`${key}: weight must be a number`);
+      continue;
+    }
+    if (value < 0) {
+      negatives.push(key);
+    }
+    if (value > 0) {
+      hasPositive = true;
+    }
+  }
+
+  if (negatives.length > 0) {
+    errors.push(`Negative weights on: ${negatives.join(', ')}`);
+  }
+
+  if (!hasPositive && errors.length === 0) {
+    errors.push('At least one dimension must have weight > 0');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Normalize a weight vector to canonical form.
+ *
+ * Canonical form:
+ * - All VALID_COMPONENTS present (missing → 0)
+ * - Keys sorted alphabetically
+ * - Values sum to 1.0
+ * - Rounded to PRECISION decimal places
+ *
+ * @param {Object} weights - Raw weight values
+ * @returns {Object} Canonical normalized vector
+ * @throws {Error} If validation fails
+ */
+export function normalizeVector(weights) {
+  const validation = validateWeightVector(weights);
+  if (!validation.valid) {
+    throw new Error(`Invalid weight vector: ${validation.errors.join('; ')}`);
+  }
+
+  // Build full vector with all components
+  const raw = {};
+  for (const comp of VALID_COMPONENTS) {
+    raw[comp] = (typeof weights[comp] === 'number' && weights[comp] >= 0)
+      ? weights[comp]
+      : 0;
+  }
+
+  // Normalize to sum = 1.0
+  const sum = Object.values(raw).reduce((s, v) => s + v, 0);
+  if (sum === 0) {
+    throw new Error('Cannot normalize: all weights are zero');
+  }
+
+  const normalized = {};
+  // Sort keys for canonical ordering
+  const sortedKeys = Object.keys(raw).sort();
+  for (const key of sortedKeys) {
+    normalized[key] = roundTo(raw[key] / sum, PRECISION);
+  }
+
+  // Fix rounding drift: adjust largest component so sum is exactly 1.0
+  const currentSum = Object.values(normalized).reduce((s, v) => s + v, 0);
+  const drift = roundTo(1.0 - currentSum, PRECISION);
+  if (Math.abs(drift) > 0) {
+    const largestKey = sortedKeys.reduce((a, b) =>
+      normalized[a] >= normalized[b] ? a : b
+    );
+    normalized[largestKey] = roundTo(normalized[largestKey] + drift, PRECISION);
+  }
+
+  return normalized;
+}
+
+/**
+ * Blend two weight vectors by ratio.
+ *
+ * Formula: V = ratio * weightsA + (1 - ratio) * weightsB
+ * Result is normalized to canonical form.
+ *
+ * @param {Object} weightsA - First weight vector
+ * @param {Object} weightsB - Second weight vector
+ * @param {number} ratio - Blend ratio (0.0 = all B, 1.0 = all A)
+ * @returns {Object} Canonical normalized blended vector
+ * @throws {Error} If inputs invalid or ratio out of range
+ */
+export function blendProfiles(weightsA, weightsB, ratio) {
+  if (typeof ratio !== 'number' || ratio < 0 || ratio > 1) {
+    throw new Error('Blend ratio must be a number between 0 and 1');
+  }
+
+  // Validate both inputs
+  const valA = validateWeightVector(weightsA);
+  if (!valA.valid) {
+    throw new Error(`Profile A invalid: ${valA.errors.join('; ')}`);
+  }
+  const valB = validateWeightVector(weightsB);
+  if (!valB.valid) {
+    throw new Error(`Profile B invalid: ${valB.errors.join('; ')}`);
+  }
+
+  // Compute blend
+  const blended = {};
+  for (const comp of VALID_COMPONENTS) {
+    const a = (typeof weightsA[comp] === 'number' && weightsA[comp] >= 0) ? weightsA[comp] : 0;
+    const b = (typeof weightsB[comp] === 'number' && weightsB[comp] >= 0) ? weightsB[comp] : 0;
+    blended[comp] = ratio * a + (1 - ratio) * b;
+  }
+
+  return normalizeVector(blended);
+}
+
+/**
+ * Blend two profiles by preset IDs (fetched from database).
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {string} presetIdA - UUID or name of preset A
+ * @param {string} presetIdB - UUID or name of preset B
+ * @param {number} ratio - Blend ratio (0-1)
+ * @returns {Promise<Object>} { vector, hash, source: { preset_a, preset_b, ratio } }
+ */
+export async function blendByPresetIds(deps, presetIdA, presetIdB, ratio) {
+  const vectorA = await resolvePresetToVector(deps, presetIdA);
+  const vectorB = await resolvePresetToVector(deps, presetIdB);
+
+  if (!vectorA) throw new Error(`Preset not found: ${presetIdA}`);
+  if (!vectorB) throw new Error(`Preset not found: ${presetIdB}`);
+
+  const vector = blendProfiles(vectorA.weights, vectorB.weights, ratio);
+  const hash = computeVectorHash(vector);
+
+  return {
+    vector,
+    hash,
+    source: {
+      preset_a: { id: vectorA.id, name: vectorA.name },
+      preset_b: { id: vectorB.id, name: vectorB.name },
+      ratio,
+    },
+  };
+}
+
+/**
+ * Resolve a preset identifier to its weight vector.
+ *
+ * Looks up by UUID first, then by name. Returns the canonical
+ * weight vector from the evaluation_profiles table.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {string} presetIdOrName - UUID or profile name
+ * @returns {Promise<Object|null>} { id, name, weights } or null
+ */
+export async function resolvePresetToVector(deps, presetIdOrName) {
+  const { supabase, logger = console } = deps;
+  if (!supabase) return null;
+
+  // Try UUID lookup first
+  const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(presetIdOrName);
+
+  let data, error;
+  if (isUuid) {
+    ({ data, error } = await supabase
+      .from('evaluation_profiles')
+      .select('id, name, weights')
+      .eq('id', presetIdOrName)
+      .single());
+  } else {
+    ({ data, error } = await supabase
+      .from('evaluation_profiles')
+      .select('id, name, weights')
+      .eq('name', presetIdOrName)
+      .order('version', { ascending: false })
+      .limit(1)
+      .single());
+  }
+
+  if (error || !data) {
+    logger.warn?.(`Profile blender: Preset ${presetIdOrName} not found`);
+    return null;
+  }
+
+  return {
+    id: data.id,
+    name: data.name,
+    weights: data.weights,
+  };
+}
+
+/**
+ * Compute a deterministic hash of a canonical weight vector.
+ *
+ * Used for caching and deduplication of evaluation runs.
+ * Input must be a normalized canonical vector (sorted keys, 6 decimals).
+ *
+ * @param {Object} vector - Canonical weight vector
+ * @returns {string} SHA-256 hex hash
+ */
+export function computeVectorHash(vector) {
+  const canonical = JSON.stringify(vector, Object.keys(vector).sort());
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+/**
+ * Check if two weight vectors are effectively equal within tolerance.
+ *
+ * @param {Object} vectorA - First vector
+ * @param {Object} vectorB - Second vector
+ * @returns {boolean} True if all dimensions match within TOLERANCE
+ */
+export function vectorsEqual(vectorA, vectorB) {
+  for (const comp of VALID_COMPONENTS) {
+    const a = vectorA[comp] ?? 0;
+    const b = vectorB[comp] ?? 0;
+    if (Math.abs(a - b) > TOLERANCE) return false;
+  }
+  return true;
+}
+
+/**
+ * Save a blended profile as a new named preset.
+ *
+ * @param {Object} deps - { supabase, logger }
+ * @param {Object} params
+ * @param {string} params.name - Preset name
+ * @param {Object} params.weights - Weight vector (will be normalized)
+ * @param {string} [params.description] - Optional description
+ * @param {Object} [params.source_blend] - Optional source blend metadata
+ * @returns {Promise<Object>} Created profile record
+ */
+export async function saveBlendAsPreset(deps, { name, weights, description, source_blend }) {
+  const { supabase } = deps;
+  if (!supabase) throw new Error('supabase client is required');
+  if (!name) throw new Error('Preset name is required');
+
+  const normalizedWeights = normalizeVector(weights);
+  const hash = computeVectorHash(normalizedWeights);
+
+  const { data, error } = await supabase
+    .from('evaluation_profiles')
+    .insert({
+      name,
+      version: 1,
+      description: description || `Blended profile: ${name}`,
+      weights: normalizedWeights,
+      is_active: false,
+      created_by: source_blend ? 'blend' : 'manual',
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to save preset: ${error.message}`);
+
+  return {
+    ...data,
+    weight_vector_hash: hash,
+  };
+}
+
+/**
+ * Get a profile by ID, returning canonical weight vector.
+ *
+ * @param {Object} deps - { supabase }
+ * @param {string} profileId - UUID of profile
+ * @returns {Promise<Object|null>} Profile with normalized weights, or null
+ */
+export async function getProfile(deps, profileId) {
+  const { supabase } = deps;
+  if (!supabase) return null;
+
+  const { data, error } = await supabase
+    .from('evaluation_profiles')
+    .select('id, name, version, description, weights, is_active, gate_thresholds, created_at, updated_at, created_by')
+    .eq('id', profileId)
+    .single();
+
+  if (error || !data) return null;
+
+  return {
+    ...data,
+    weight_vector_hash: computeVectorHash(data.weights),
+  };
+}
+
+/**
+ * Update an existing profile's weights and/or metadata.
+ *
+ * @param {Object} deps - { supabase }
+ * @param {string} profileId - UUID
+ * @param {Object} updates - { name?, weights?, description? }
+ * @returns {Promise<Object>} Updated profile
+ */
+export async function updateProfile(deps, profileId, updates) {
+  const { supabase } = deps;
+  if (!supabase) throw new Error('supabase client is required');
+
+  const patch = {};
+  if (updates.name) patch.name = updates.name;
+  if (updates.description !== undefined) patch.description = updates.description;
+  if (updates.weights) {
+    patch.weights = normalizeVector(updates.weights);
+  }
+
+  if (Object.keys(patch).length === 0) {
+    throw new Error('No valid fields to update');
+  }
+
+  const { data, error } = await supabase
+    .from('evaluation_profiles')
+    .update(patch)
+    .eq('id', profileId)
+    .select()
+    .single();
+
+  if (error) throw new Error(`Failed to update profile: ${error.message}`);
+
+  return {
+    ...data,
+    weight_vector_hash: computeVectorHash(data.weights),
+  };
+}
+
+// --- Internal helpers ---
+
+function roundTo(value, decimals) {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}
+
+export { PRECISION, TOLERANCE };

--- a/tests/unit/eva/stage-zero/profile-blender.test.js
+++ b/tests/unit/eva/stage-zero/profile-blender.test.js
@@ -1,0 +1,517 @@
+/**
+ * Profile Blending Engine Tests
+ *
+ * Tests for vector validation, normalization, blending,
+ * hashing, preset resolution, and persistence.
+ *
+ * Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-K
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  validateWeightVector,
+  normalizeVector,
+  blendProfiles,
+  blendByPresetIds,
+  resolvePresetToVector,
+  computeVectorHash,
+  vectorsEqual,
+  saveBlendAsPreset,
+  getProfile,
+  updateProfile,
+  PRECISION,
+  TOLERANCE,
+} from '../../../../lib/eva/stage-zero/profile-blender.js';
+import { VALID_COMPONENTS } from '../../../../lib/eva/stage-zero/profile-service.js';
+
+// --- Test fixtures ---
+
+const BALANCED_WEIGHTS = {
+  cross_reference: 0.10,
+  portfolio_evaluation: 0.10,
+  problem_reframing: 0.05,
+  moat_architecture: 0.15,
+  chairman_constraints: 0.15,
+  time_horizon: 0.10,
+  archetypes: 0.10,
+  build_cost: 0.10,
+  virality: 0.15,
+};
+
+const AGGRESSIVE_WEIGHTS = {
+  cross_reference: 0.05,
+  portfolio_evaluation: 0.05,
+  problem_reframing: 0.05,
+  moat_architecture: 0.20,
+  chairman_constraints: 0.10,
+  time_horizon: 0.05,
+  archetypes: 0.05,
+  build_cost: 0.10,
+  virality: 0.35,
+};
+
+// --- Tests ---
+
+describe('profile-blender', () => {
+  describe('validateWeightVector', () => {
+    it('accepts valid weight vector', () => {
+      const result = validateWeightVector(BALANCED_WEIGHTS);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('rejects null input', () => {
+      const result = validateWeightVector(null);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('non-null');
+    });
+
+    it('rejects negative weights', () => {
+      const result = validateWeightVector({
+        ...BALANCED_WEIGHTS,
+        virality: -0.1,
+        moat_architecture: -0.05,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Negative'))).toBe(true);
+      expect(result.errors.some(e => e.includes('virality'))).toBe(true);
+    });
+
+    it('rejects all-zero weights', () => {
+      const zeros = {};
+      for (const comp of VALID_COMPONENTS) zeros[comp] = 0;
+      const result = validateWeightVector(zeros);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('> 0'))).toBe(true);
+    });
+
+    it('rejects unknown dimensions', () => {
+      const result = validateWeightVector({
+        ...BALANCED_WEIGHTS,
+        unknown_dim: 0.5,
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Unknown'))).toBe(true);
+    });
+
+    it('rejects non-number values', () => {
+      const result = validateWeightVector({
+        ...BALANCED_WEIGHTS,
+        virality: 'high',
+      });
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts partial vector (missing components)', () => {
+      const result = validateWeightVector({ virality: 0.5, moat_architecture: 0.5 });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('normalizeVector', () => {
+    it('normalizes to sum 1.0', () => {
+      const result = normalizeVector(BALANCED_WEIGHTS);
+      const sum = Object.values(result).reduce((s, v) => s + v, 0);
+      expect(Math.abs(sum - 1.0)).toBeLessThan(TOLERANCE);
+    });
+
+    it('preserves relative proportions', () => {
+      const input = { virality: 3, moat_architecture: 2, build_cost: 1 };
+      const result = normalizeVector(input);
+      // virality should be ~0.5, moat ~0.333, build ~0.167
+      expect(result.virality).toBeCloseTo(0.5, 3);
+      expect(result.moat_architecture).toBeCloseTo(0.333333, 3);
+    });
+
+    it('returns sorted keys', () => {
+      const result = normalizeVector(BALANCED_WEIGHTS);
+      const keys = Object.keys(result);
+      const sorted = [...keys].sort();
+      expect(keys).toEqual(sorted);
+    });
+
+    it('includes all VALID_COMPONENTS', () => {
+      const result = normalizeVector({ virality: 1 });
+      expect(Object.keys(result)).toHaveLength(VALID_COMPONENTS.length);
+      for (const comp of VALID_COMPONENTS) {
+        expect(result).toHaveProperty(comp);
+      }
+    });
+
+    it('fills missing components with 0', () => {
+      const result = normalizeVector({ virality: 1 });
+      expect(result.virality).toBe(1);
+      expect(result.cross_reference).toBe(0);
+    });
+
+    it('rounds to 6 decimal places', () => {
+      const result = normalizeVector({ virality: 1, moat_architecture: 2 });
+      for (const val of Object.values(result)) {
+        const decimals = val.toString().split('.')[1]?.length ?? 0;
+        expect(decimals).toBeLessThanOrEqual(PRECISION);
+      }
+    });
+
+    it('throws on invalid input', () => {
+      expect(() => normalizeVector({ virality: -1 })).toThrow('Invalid weight vector');
+    });
+
+    it('throws on all-zero input', () => {
+      const zeros = {};
+      for (const comp of VALID_COMPONENTS) zeros[comp] = 0;
+      expect(() => normalizeVector(zeros)).toThrow();
+    });
+
+    it('already-normalized vector unchanged', () => {
+      const result = normalizeVector(BALANCED_WEIGHTS);
+      const result2 = normalizeVector(result);
+      expect(result).toEqual(result2);
+    });
+  });
+
+  describe('blendProfiles', () => {
+    it('ratio=1.0 returns profile A', () => {
+      const result = blendProfiles(BALANCED_WEIGHTS, AGGRESSIVE_WEIGHTS, 1.0);
+      const normalA = normalizeVector(BALANCED_WEIGHTS);
+      expect(vectorsEqual(result, normalA)).toBe(true);
+    });
+
+    it('ratio=0.0 returns profile B', () => {
+      const result = blendProfiles(BALANCED_WEIGHTS, AGGRESSIVE_WEIGHTS, 0.0);
+      const normalB = normalizeVector(AGGRESSIVE_WEIGHTS);
+      expect(vectorsEqual(result, normalB)).toBe(true);
+    });
+
+    it('ratio=0.5 returns midpoint', () => {
+      const result = blendProfiles(BALANCED_WEIGHTS, AGGRESSIVE_WEIGHTS, 0.5);
+      // Virality: (0.5*0.15 + 0.5*0.35) = 0.25 → after normalization should be 0.25
+      // Both sum to 1.0, so blend also sums to 1.0
+      const sum = Object.values(result).reduce((s, v) => s + v, 0);
+      expect(Math.abs(sum - 1.0)).toBeLessThan(TOLERANCE);
+      // Virality should be between the two values
+      expect(result.virality).toBeGreaterThan(normalizeVector(BALANCED_WEIGHTS).virality);
+      expect(result.virality).toBeLessThan(normalizeVector(AGGRESSIVE_WEIGHTS).virality);
+    });
+
+    it('result is normalized', () => {
+      const result = blendProfiles(BALANCED_WEIGHTS, AGGRESSIVE_WEIGHTS, 0.7);
+      const sum = Object.values(result).reduce((s, v) => s + v, 0);
+      expect(Math.abs(sum - 1.0)).toBeLessThan(TOLERANCE);
+    });
+
+    it('result has sorted keys', () => {
+      const result = blendProfiles(BALANCED_WEIGHTS, AGGRESSIVE_WEIGHTS, 0.5);
+      const keys = Object.keys(result);
+      expect(keys).toEqual([...keys].sort());
+    });
+
+    it('throws on invalid ratio', () => {
+      expect(() => blendProfiles(BALANCED_WEIGHTS, AGGRESSIVE_WEIGHTS, -0.1)).toThrow('ratio');
+      expect(() => blendProfiles(BALANCED_WEIGHTS, AGGRESSIVE_WEIGHTS, 1.1)).toThrow('ratio');
+      expect(() => blendProfiles(BALANCED_WEIGHTS, AGGRESSIVE_WEIGHTS, 'half')).toThrow('ratio');
+    });
+
+    it('throws on invalid profile A', () => {
+      expect(() => blendProfiles({ virality: -1 }, AGGRESSIVE_WEIGHTS, 0.5)).toThrow('Profile A');
+    });
+
+    it('throws on invalid profile B', () => {
+      expect(() => blendProfiles(BALANCED_WEIGHTS, null, 0.5)).toThrow('Profile B');
+    });
+
+    it('blending identical profiles returns same profile', () => {
+      const result = blendProfiles(BALANCED_WEIGHTS, BALANCED_WEIGHTS, 0.5);
+      const normalB = normalizeVector(BALANCED_WEIGHTS);
+      expect(vectorsEqual(result, normalB)).toBe(true);
+    });
+  });
+
+  describe('computeVectorHash', () => {
+    it('returns 64-char hex string', () => {
+      const hash = computeVectorHash(normalizeVector(BALANCED_WEIGHTS));
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('same vector produces same hash', () => {
+      const v = normalizeVector(BALANCED_WEIGHTS);
+      expect(computeVectorHash(v)).toBe(computeVectorHash(v));
+    });
+
+    it('different vectors produce different hashes', () => {
+      const hashA = computeVectorHash(normalizeVector(BALANCED_WEIGHTS));
+      const hashB = computeVectorHash(normalizeVector(AGGRESSIVE_WEIGHTS));
+      expect(hashA).not.toBe(hashB);
+    });
+
+    it('key order does not affect hash (canonical ordering)', () => {
+      const v1 = { archetypes: 0.1, build_cost: 0.1, virality: 0.8 };
+      const v2 = { virality: 0.8, archetypes: 0.1, build_cost: 0.1 };
+      expect(computeVectorHash(v1)).toBe(computeVectorHash(v2));
+    });
+  });
+
+  describe('vectorsEqual', () => {
+    it('identical vectors are equal', () => {
+      const v = normalizeVector(BALANCED_WEIGHTS);
+      expect(vectorsEqual(v, v)).toBe(true);
+    });
+
+    it('different vectors are not equal', () => {
+      const vA = normalizeVector(BALANCED_WEIGHTS);
+      const vB = normalizeVector(AGGRESSIVE_WEIGHTS);
+      expect(vectorsEqual(vA, vB)).toBe(false);
+    });
+
+    it('vectors within tolerance are equal', () => {
+      const v1 = normalizeVector(BALANCED_WEIGHTS);
+      const v2 = { ...v1 };
+      v2.virality += 0.00005; // Within TOLERANCE
+      expect(vectorsEqual(v1, v2)).toBe(true);
+    });
+
+    it('vectors beyond tolerance are not equal', () => {
+      const v1 = normalizeVector(BALANCED_WEIGHTS);
+      const v2 = { ...v1 };
+      v2.virality += 0.001; // Beyond TOLERANCE
+      expect(vectorsEqual(v1, v2)).toBe(false);
+    });
+  });
+
+  describe('resolvePresetToVector', () => {
+    it('resolves by UUID', async () => {
+      const mockSingle = vi.fn().mockResolvedValue({
+        data: { id: 'uuid-1', name: 'balanced', weights: BALANCED_WEIGHTS },
+        error: null,
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: mockSingle,
+            }),
+          }),
+        }),
+      };
+
+      const result = await resolvePresetToVector({ supabase }, '7037129a-5b29-49d3-917c-f38b324fba5d');
+      expect(result).not.toBeNull();
+      expect(result.name).toBe('balanced');
+      expect(result.weights).toEqual(BALANCED_WEIGHTS);
+    });
+
+    it('resolves by name', async () => {
+      const mockSingle = vi.fn().mockResolvedValue({
+        data: { id: 'uuid-1', name: 'balanced', weights: BALANCED_WEIGHTS },
+        error: null,
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  single: mockSingle,
+                }),
+              }),
+            }),
+          }),
+        }),
+      };
+
+      const result = await resolvePresetToVector({ supabase }, 'balanced');
+      expect(result).not.toBeNull();
+      expect(result.name).toBe('balanced');
+    });
+
+    it('returns null when not found', async () => {
+      const mockSingle = vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  single: mockSingle,
+                }),
+              }),
+            }),
+          }),
+        }),
+      };
+      const logger = { warn: vi.fn() };
+
+      const result = await resolvePresetToVector({ supabase, logger }, 'nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('returns null with no supabase', async () => {
+      const result = await resolvePresetToVector({}, 'balanced');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('blendByPresetIds', () => {
+    it('blends two presets by ID', async () => {
+      const uuidA = '7037129a-5b29-49d3-917c-f38b324fba5d';
+      const uuidB = '4c4917f7-974f-4761-89f2-dccb541a796d';
+      const profiles = {
+        [uuidA]: { id: uuidA, name: 'balanced', weights: BALANCED_WEIGHTS },
+        [uuidB]: { id: uuidB, name: 'aggressive', weights: AGGRESSIVE_WEIGHTS },
+      };
+
+      // UUID path: .select().eq().single()
+      let queryId = null;
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockImplementation((col, val) => {
+              queryId = val;
+              return {
+                single: vi.fn().mockImplementation(() => {
+                  const profile = profiles[queryId];
+                  if (profile) return Promise.resolve({ data: profile, error: null });
+                  return Promise.resolve({ data: null, error: { message: 'not found' } });
+                }),
+              };
+            }),
+          }),
+        }),
+      };
+
+      const result = await blendByPresetIds({ supabase }, uuidA, uuidB, 0.5);
+      expect(result.vector).toBeDefined();
+      expect(result.hash).toMatch(/^[0-9a-f]{64}$/);
+      expect(result.source.preset_a.name).toBe('balanced');
+      expect(result.source.preset_b.name).toBe('aggressive');
+      expect(result.source.ratio).toBe(0.5);
+    });
+
+    it('throws when preset A not found', async () => {
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  single: vi.fn().mockResolvedValue({ data: null, error: { message: 'nope' } }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      };
+      const logger = { warn: vi.fn() };
+
+      await expect(blendByPresetIds({ supabase, logger }, 'bad', 'bad2', 0.5))
+        .rejects.toThrow('Preset not found');
+    });
+  });
+
+  describe('saveBlendAsPreset', () => {
+    it('saves normalized vector as new preset', async () => {
+      const mockSingle = vi.fn().mockResolvedValue({
+        data: { id: 'new-uuid', name: 'my_blend', weights: normalizeVector(BALANCED_WEIGHTS) },
+        error: null,
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: mockSingle,
+            }),
+          }),
+        }),
+      };
+
+      const result = await saveBlendAsPreset({ supabase }, {
+        name: 'my_blend',
+        weights: BALANCED_WEIGHTS,
+      });
+
+      expect(result.name).toBe('my_blend');
+      expect(result.weight_vector_hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('throws without supabase', async () => {
+      await expect(saveBlendAsPreset({}, { name: 'x', weights: BALANCED_WEIGHTS }))
+        .rejects.toThrow('supabase client is required');
+    });
+
+    it('throws without name', async () => {
+      await expect(saveBlendAsPreset({ supabase: {} }, { weights: BALANCED_WEIGHTS }))
+        .rejects.toThrow('name is required');
+    });
+  });
+
+  describe('getProfile', () => {
+    it('returns profile with hash', async () => {
+      const mockSingle = vi.fn().mockResolvedValue({
+        data: {
+          id: 'uuid-1', name: 'balanced', version: 1, description: 'test',
+          weights: BALANCED_WEIGHTS, is_active: true, gate_thresholds: {},
+          created_at: '2026-01-01', updated_at: '2026-01-01', created_by: 'test',
+        },
+        error: null,
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: mockSingle,
+            }),
+          }),
+        }),
+      };
+
+      const result = await getProfile({ supabase }, 'uuid-1');
+      expect(result).not.toBeNull();
+      expect(result.weight_vector_hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('returns null when not found', async () => {
+      const mockSingle = vi.fn().mockResolvedValue({ data: null, error: { message: 'nope' } });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: mockSingle,
+            }),
+          }),
+        }),
+      };
+
+      const result = await getProfile({ supabase }, 'bad-uuid');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('normalizes weights on update', async () => {
+      const mockSingle = vi.fn().mockResolvedValue({
+        data: { id: 'uuid-1', name: 'updated', weights: normalizeVector({ virality: 0.5, moat_architecture: 0.5 }) },
+        error: null,
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockReturnValue({
+                single: mockSingle,
+              }),
+            }),
+          }),
+        }),
+      };
+
+      const result = await updateProfile({ supabase }, 'uuid-1', {
+        weights: { virality: 3, moat_architecture: 2 },
+      });
+      expect(result.weight_vector_hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('throws with no fields to update', async () => {
+      await expect(updateProfile({ supabase: {} }, 'uuid-1', {}))
+        .rejects.toThrow('No valid fields');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add profile blending engine (`lib/eva/stage-zero/profile-blender.js`) for continuous weighted evaluation profiles
- Implements weight vector validation, canonical normalization (6 decimal precision), and linear interpolation blending
- Includes SHA-256 vector hashing for caching/deduplication, preset resolution from DB, and CRUD operations
- Part of SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-K (Dynamic Profile Blending)

## Test plan
- [x] 46 unit tests covering all functions (validation, normalization, blending, hashing, DB operations)
- [x] 212 total stage-zero tests pass with zero regressions
- [x] Edge cases: negative weights, zero vectors, unknown dimensions, boundary blend ratios

🤖 Generated with [Claude Code](https://claude.com/claude-code)