### PR TITLE
fix: add OpenAI compatibility layer to all LLM provider adapters

### DIFF
--- a/lib/llm/client-factory.js
+++ b/lib/llm/client-factory.js
@@ -299,9 +299,31 @@ export function getLLMClient(options = {}) {
     });
   }
 
-  // Return cloud Anthropic adapter with appropriate model
+  // Return cloud adapter with appropriate model, with API key fallback
   const cloudModel = getTierModel(tier);
-  console.log(`   ☁️  LLM Factory: Using cloud ${tier} (${cloudModel}) for ${subAgent || purpose || 'request'}`);
+  const label = subAgent || purpose || 'request';
+
+  // Prefer Anthropic, fall back to OpenAI if no Anthropic key
+  if (process.env.ANTHROPIC_API_KEY) {
+    console.log(`   ☁️  LLM Factory: Using cloud ${tier} (${cloudModel}) for ${label}`);
+    return new AnthropicAdapter({ model: cloudModel });
+  }
+
+  if (process.env.OPENAI_API_KEY) {
+    const openaiModel = tier === 'opus' ? 'gpt-4o' : tier === 'haiku' ? 'gpt-4o-mini' : 'gpt-4o';
+    console.log(`   ☁️  LLM Factory: Using OpenAI fallback (${openaiModel}) for ${label} [ANTHROPIC_API_KEY not set]`);
+    return new OpenAIAdapter({ model: openaiModel });
+  }
+
+  // No cloud keys available - try local as last resort
+  if (isLocalLLMEnabledInternal()) {
+    const localModel = getLocalModel(tier) || FALLBACK_LOCAL_MODEL;
+    console.log(`   🏠 LLM Factory: Using local fallback (${localModel}) for ${label} [no cloud API keys]`);
+    return new OllamaAdapter({ model: localModel, fallbackEnabled: false });
+  }
+
+  // No options - return Anthropic adapter (will fail with clear error message)
+  console.log(`   ☁️  LLM Factory: Using cloud ${tier} (${cloudModel}) for ${label}`);
   return new AnthropicAdapter({ model: cloudModel });
 }
 

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -9,7 +9,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 
 // Timeout and retry configuration
-const PROVIDER_TIMEOUT_MS = 15000; // 15 seconds per call
+const PROVIDER_TIMEOUT_MS = 30000; // 30 seconds per call (increased from 15s for complex evaluations)
 const MAX_RETRIES = 2;
 const RETRY_DELAY_MS = 1000;
 
@@ -65,6 +65,55 @@ function sanitizeUnicode(value) {
 }
 
 /**
+ * Add OpenAI-compatible `.chat.completions.create()` interface to any adapter.
+ *
+ * Many callers were written against the OpenAI SDK format but now receive
+ * factory adapters that only expose `.complete()`. This shim bridges the gap
+ * so both calling patterns work on any adapter.
+ *
+ * @param {Object} adapter - Adapter instance with `.complete()` method
+ */
+function addOpenAICompatLayer(adapter) {
+  adapter.chat = {
+    completions: {
+      create: async (params = {}) => {
+        const { messages = [], model, response_format, max_completion_tokens, max_tokens, temperature } = params;
+
+        // Extract system and user prompts from messages array
+        const systemMsg = messages.find(m => m.role === 'system');
+        const userMsg = messages.find(m => m.role === 'user');
+        const systemPrompt = systemMsg?.content || '';
+        const userPrompt = userMsg?.content || '';
+
+        const options = {};
+        if (model) options.model = model;
+        if (max_completion_tokens) options.maxTokens = max_completion_tokens;
+        if (max_tokens) options.maxTokens = max_tokens;
+        if (temperature !== undefined) options.temperature = temperature;
+        if (response_format) options.response_format = response_format;
+
+        const result = await adapter.complete(systemPrompt, userPrompt, options);
+
+        // Return OpenAI-compatible response format
+        return {
+          choices: [{
+            message: { content: result.content, role: 'assistant' },
+            index: 0,
+            finish_reason: 'stop'
+          }],
+          usage: {
+            prompt_tokens: result.usage?.inputTokens || 0,
+            completion_tokens: result.usage?.outputTokens || 0,
+            total_tokens: (result.usage?.inputTokens || 0) + (result.usage?.outputTokens || 0)
+          },
+          model: result.model || adapter.defaultModel
+        };
+      }
+    }
+  };
+}
+
+/**
  * Anthropic Provider Adapter
  */
 export class AnthropicAdapter {
@@ -75,6 +124,7 @@ export class AnthropicAdapter {
     this.defaultModel = options.model || 'claude-sonnet-4-20250514';
     this.provider = 'anthropic';
     this.family = 'anthropic';
+    addOpenAICompatLayer(this);
   }
 
   async complete(systemPrompt, userPrompt, options = {}) {
@@ -134,6 +184,7 @@ export class OpenAIAdapter {
     this.defaultModel = options.model || 'gpt-4o';
     this.provider = 'openai';
     this.family = 'openai';
+    addOpenAICompatLayer(this);
   }
 
   async complete(systemPrompt, userPrompt, options = {}) {
@@ -146,20 +197,28 @@ export class OpenAIAdapter {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), PROVIDER_TIMEOUT_MS);
 
-        const response = await fetch(`${this.baseUrl}/chat/completions`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${this.apiKey}`
-          },
-          body: JSON.stringify({
+        const requestBody = {
             model,
             max_tokens: options.maxTokens || 2000,
             messages: [
               { role: 'system', content: sanitizeUnicode(systemPrompt) },
               { role: 'user', content: sanitizeUnicode(userPrompt) }
             ]
-          }),
+          };
+        if (options.response_format) {
+          requestBody.response_format = options.response_format;
+        }
+        if (options.temperature !== undefined) {
+          requestBody.temperature = options.temperature;
+        }
+
+        const response = await fetch(`${this.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${this.apiKey}`
+          },
+          body: JSON.stringify(requestBody),
           signal: controller.signal
         });
 
@@ -212,6 +271,7 @@ export class GoogleAdapter {
     this.defaultModel = options.model || 'gemini-1.5-pro';
     this.provider = 'google';
     this.family = 'google';
+    addOpenAICompatLayer(this);
   }
 
   async complete(systemPrompt, userPrompt, options = {}) {
@@ -309,6 +369,7 @@ export class OllamaAdapter {
     this.fallbackModel = options.fallbackModel || 'claude-haiku-3-5-20241022';
     this.timeoutMs = options.timeoutMs ||
       parseInt(process.env.OLLAMA_TIMEOUT_MS, 10) || 30000;
+    addOpenAICompatLayer(this);
   }
 
   /**

--- a/scripts/modules/ai-quality-evaluator/api.js
+++ b/scripts/modules/ai-quality-evaluator/api.js
@@ -7,13 +7,25 @@
  * Call OpenAI API with retry logic and rate limit handling
  * Note: gpt-5-mini doesn't support function/tool calling, so we use json_object mode
  *
- * @param {Object} openai - OpenAI client instance
- * @param {string} model - Model name to use
- * @param {Array} messages - Array of message objects
- * @param {number} retries - Number of retries (default 3)
+ * Supports two calling patterns:
+ *   callOpenAI(client, model, messages)  - explicit model
+ *   callOpenAI(client, messages)         - model from client.defaultModel
+ *
+ * @param {Object} openai - OpenAI client instance or factory adapter with .chat.completions.create()
+ * @param {string|Array} modelOrMessages - Model name or messages array (if 2-arg call)
+ * @param {Array} [messages] - Array of message objects (if 3-arg call)
+ * @param {number} [retries=3] - Number of retries
  * @returns {Promise<Object>} API response
  */
-export async function callOpenAI(openai, model, messages, retries = 3) {
+export async function callOpenAI(openai, modelOrMessages, messages, retries = 3) {
+  // Support 2-arg call: callOpenAI(client, messages)
+  let model;
+  if (Array.isArray(modelOrMessages)) {
+    messages = modelOrMessages;
+    model = openai.defaultModel;
+  } else {
+    model = modelOrMessages;
+  }
   const timeoutMs = parseInt(process.env.AI_API_TIMEOUT_MS) || 60000; // Default 60s timeout
   const DEBUG = process.env.AI_DEBUG === 'true';
 

--- a/tests/unit/llm/openai-compat-layer.test.js
+++ b/tests/unit/llm/openai-compat-layer.test.js
@@ -1,0 +1,168 @@
+/**
+ * OpenAI Compatibility Layer Tests
+ *
+ * Validates that all provider adapters support both calling patterns:
+ * 1. adapter.complete(systemPrompt, userPrompt, options)  - native interface
+ * 2. adapter.chat.completions.create({ messages, ... })   - OpenAI-compatible interface
+ *
+ * Root cause: Half-migrated callers use getLLMClient() from factory but call
+ * .chat.completions.create() (OpenAI SDK format) on the returned adapter.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the Anthropic SDK before importing adapters
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    constructor() {
+      this.messages = {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: '{"result": "test"}' }],
+          usage: { input_tokens: 100, output_tokens: 50 }
+        })
+      };
+    }
+  }
+}));
+
+const { AnthropicAdapter, OpenAIAdapter, OllamaAdapter, GoogleAdapter } = await import(
+  '../../../lib/sub-agents/vetting/provider-adapters.js'
+);
+
+describe('OpenAI Compatibility Layer', () => {
+  describe('AnthropicAdapter', () => {
+    it('should have .chat.completions.create() method', () => {
+      const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+      expect(adapter.chat).toBeDefined();
+      expect(adapter.chat.completions).toBeDefined();
+      expect(typeof adapter.chat.completions.create).toBe('function');
+    });
+
+    it('should return OpenAI-formatted response from .chat.completions.create()', async () => {
+      const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+
+      const response = await adapter.chat.completions.create({
+        messages: [
+          { role: 'system', content: 'You are a test assistant.' },
+          { role: 'user', content: 'Say hello' }
+        ],
+        response_format: { type: 'json_object' }
+      });
+
+      expect(response.choices).toBeDefined();
+      expect(response.choices).toHaveLength(1);
+      expect(response.choices[0].message.content).toBe('{"result": "test"}');
+      expect(response.choices[0].message.role).toBe('assistant');
+      expect(response.choices[0].finish_reason).toBe('stop');
+      expect(response.usage).toBeDefined();
+      expect(response.usage.prompt_tokens).toBe(100);
+      expect(response.usage.completion_tokens).toBe(50);
+      expect(response.usage.total_tokens).toBe(150);
+      expect(response.model).toBeDefined();
+    });
+
+    it('should extract system and user prompts from messages array', async () => {
+      const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+
+      await adapter.chat.completions.create({
+        messages: [
+          { role: 'system', content: 'system-prompt' },
+          { role: 'user', content: 'user-prompt' }
+        ]
+      });
+
+      // Verify the underlying Anthropic SDK was called correctly
+      expect(adapter.client.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          system: 'system-prompt',
+          messages: [{ role: 'user', content: 'user-prompt' }]
+        })
+      );
+    });
+
+    it('should handle missing system message gracefully', async () => {
+      const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+
+      const response = await adapter.chat.completions.create({
+        messages: [
+          { role: 'user', content: 'just user prompt' }
+        ]
+      });
+
+      expect(response.choices[0].message.content).toBe('{"result": "test"}');
+    });
+
+    it('should pass max_completion_tokens as maxTokens', async () => {
+      const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+
+      await adapter.chat.completions.create({
+        messages: [{ role: 'user', content: 'test' }],
+        max_completion_tokens: 8000
+      });
+
+      expect(adapter.client.messages.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          max_tokens: 8000
+        })
+      );
+    });
+  });
+
+  describe('All adapters have compat layer', () => {
+    it('OpenAIAdapter should have .chat.completions.create()', () => {
+      const adapter = new OpenAIAdapter({ apiKey: 'test-key' });
+      expect(adapter.chat).toBeDefined();
+      expect(typeof adapter.chat.completions.create).toBe('function');
+    });
+
+    it('GoogleAdapter should have .chat.completions.create()', () => {
+      const adapter = new GoogleAdapter({ apiKey: 'test-key' });
+      expect(adapter.chat).toBeDefined();
+      expect(typeof adapter.chat.completions.create).toBe('function');
+    });
+
+    it('OllamaAdapter should have .chat.completions.create()', () => {
+      const adapter = new OllamaAdapter();
+      expect(adapter.chat).toBeDefined();
+      expect(typeof adapter.chat.completions.create).toBe('function');
+    });
+  });
+
+  describe('callOpenAI 2-arg pattern', () => {
+    it('should handle callOpenAI(client, messages) without model arg', async () => {
+      // Import the API function
+      const { callOpenAI } = await import(
+        '../../../scripts/modules/ai-quality-evaluator/api.js'
+      );
+
+      const adapter = new AnthropicAdapter({ apiKey: 'test-key', model: 'test-model' });
+
+      const messages = [
+        { role: 'system', content: 'You evaluate quality.' },
+        { role: 'user', content: 'Rate this: test content' }
+      ];
+
+      const response = await callOpenAI(adapter, messages);
+
+      expect(response.choices).toBeDefined();
+      expect(response.choices[0].message.content).toBe('{"result": "test"}');
+    });
+
+    it('should handle callOpenAI(client, model, messages) with explicit model', async () => {
+      const { callOpenAI } = await import(
+        '../../../scripts/modules/ai-quality-evaluator/api.js'
+      );
+
+      const adapter = new AnthropicAdapter({ apiKey: 'test-key' });
+
+      const messages = [
+        { role: 'system', content: 'test' },
+        { role: 'user', content: 'test' }
+      ];
+
+      const response = await callOpenAI(adapter, 'explicit-model', messages);
+
+      expect(response.choices).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `addOpenAICompatLayer()` shim so all adapters support both `.complete()` and `.chat.completions.create()` calling patterns
- Fix `callOpenAI` to handle 2-arg pattern `(client, messages)` used by modules migrated to `getLLMClient()` factory
- Add API key fallback chain: Anthropic → OpenAI → local Ollama
- Increase provider timeout from 15s to 30s
- Add 10 unit tests covering compat layer and callOpenAI patterns

## Test plan
- [x] 10 unit tests passing (openai-compat-layer.test.js)
- [x] 15 smoke tests passing
- [x] ESLint clean (2 pre-existing unused-var warnings in client-factory.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)