### PR TITLE
fix: sd:next CONTINUE now detects session claim conflicts

### DIFF
--- a/scripts/modules/sd-next/colors.js
+++ b/scripts/modules/sd-next/colors.js
@@ -14,6 +14,7 @@ export const colors = {
   cyan: '\x1b[36m',
   red: '\x1b[31m',
   white: '\x1b[37m',
+  bgRed: '\x1b[41m',
   bgGreen: '\x1b[42m',
   bgYellow: '\x1b[43m',
   bgBlue: '\x1b[44m',


### PR DESCRIPTION
## Summary
- `sd:next` CONTINUE recommendation now cross-references active session claims before recommending an SD
- Shows **CLAIMED** badge (red) with session details when the working-on SD is owned by another terminal
- Prevents AUTO-PROCEED from attempting to start an SD that will be rejected by `sd:start`
- Falls through to START recommendations when working-on SD is unavailable

**Root cause**: Multi-session coordination (SD-LEO-INFRA-MULTI-SESSION-COORDINATION-001) added claim awareness to `sd:start` and track displays, but missed the CONTINUE recommendation path in `getWorkingOnSD()`.

## Test plan
- [x] Verified CLAIMED badge displays with session ID, heartbeat age, and hostname
- [x] Verified AUTO_PROCEED_ACTION does not return `action:'continue'` for claimed SDs
- [x] Verified clean run (no claims) shows normal CONTINUE behavior
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)