### PR TITLE
feat: unified work-item router with tiered thresholds

### DIFF
--- a/database/migrations/20260211_work_item_thresholds.sql
+++ b/database/migrations/20260211_work_item_thresholds.sql
@@ -1,0 +1,50 @@
+-- Migration: work_item_thresholds table
+-- SD: SD-LEO-ENH-IMPLEMENT-TIERED-QUICK-001
+-- Purpose: Database-driven tier boundaries for unified work-item routing
+-- Date: 2026-02-11
+
+-- Create the thresholds table
+CREATE TABLE IF NOT EXISTS work_item_thresholds (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tier1_max_loc INTEGER NOT NULL DEFAULT 30,
+  tier2_max_loc INTEGER NOT NULL DEFAULT 75,
+  is_active BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by TEXT,
+  change_reason TEXT,
+  supersedes_id UUID REFERENCES work_item_thresholds(id)
+);
+
+-- Enable RLS
+ALTER TABLE work_item_thresholds ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies
+CREATE POLICY authenticated_read_work_item_thresholds ON work_item_thresholds
+  FOR SELECT TO authenticated USING (true);
+
+CREATE POLICY service_role_all_work_item_thresholds ON work_item_thresholds
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Partial unique index: only one active row at a time
+CREATE UNIQUE INDEX idx_work_item_thresholds_single_active
+  ON work_item_thresholds (is_active) WHERE is_active = true;
+
+-- Index for quick lookups
+CREATE INDEX idx_work_item_thresholds_active
+  ON work_item_thresholds (is_active, created_at DESC);
+
+-- Seed the default active row
+INSERT INTO work_item_thresholds (tier1_max_loc, tier2_max_loc, is_active, created_by, change_reason)
+VALUES (30, 75, true, 'migration', 'Initial default thresholds: Tier 1 <=30 LOC, Tier 2 <=75 LOC, Tier 3 >75 LOC');
+
+-- Add routing_tier and routing_threshold_id columns to quick_fixes table for audit trail
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'quick_fixes' AND column_name = 'routing_tier') THEN
+    ALTER TABLE quick_fixes ADD COLUMN routing_tier INTEGER;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'quick_fixes' AND column_name = 'routing_threshold_id') THEN
+    ALTER TABLE quick_fixes ADD COLUMN routing_threshold_id UUID REFERENCES work_item_thresholds(id);
+  END IF;
+END $$;

--- a/lib/utils/work-item-router.js
+++ b/lib/utils/work-item-router.js
@@ -1,0 +1,244 @@
+/**
+ * Unified Work-Item Router
+ * SD-LEO-ENH-IMPLEMENT-TIERED-QUICK-001
+ *
+ * Single authoritative routing function that determines whether a work item
+ * becomes a Tier 1 auto-approve QF, Tier 2 standard QF, or Tier 3 full SD.
+ *
+ * Tiers:
+ *   Tier 1 (<=tier1_max_loc): Auto-approve QF, skip compliance rubric
+ *   Tier 2 (<=tier2_max_loc): Standard QF, requires compliance rubric >=70
+ *   Tier 3 (>tier2_max_loc):  Full SD workflow with LEAD approval
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// Default thresholds (fallback when DB is unavailable)
+const DEFAULT_THRESHOLDS = {
+  tier1_max_loc: 30,
+  tier2_max_loc: 75,
+};
+
+// Cache for active thresholds (5-minute TTL)
+let _cachedThresholds = null;
+let _cacheTimestamp = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// Keywords that force escalation regardless of LOC
+const RISK_KEYWORDS = ['security', 'auth', 'authentication', 'authorization', 'rls', 'payments', 'credentials'];
+const SCHEMA_KEYWORDS = ['migration', 'schema', 'alter table', 'create table', 'drop table'];
+
+/**
+ * @typedef {Object} RouterInput
+ * @property {number} estimatedLoc - Estimated lines of code
+ * @property {string} [type] - Work item type (bug, polish, feature, etc.)
+ * @property {string} [entryPoint] - Which entry point called the router
+ * @property {string[]} [riskTags] - Optional risk tags to force escalation
+ * @property {string} [description] - Description text for keyword scanning
+ */
+
+/**
+ * @typedef {Object} RoutingDecision
+ * @property {number} tier - 1, 2, or 3
+ * @property {string} tierLabel - 'TIER_1', 'TIER_2', or 'TIER_3'
+ * @property {string} workItemType - 'QUICK_FIX' or 'STRATEGIC_DIRECTIVE'
+ * @property {boolean} requiresComplianceRubric - Whether compliance scoring is needed
+ * @property {number|null} complianceMinScore - Minimum compliance score (null if not required)
+ * @property {boolean} requiresLeadReview - Whether LEAD approval is needed
+ * @property {string|null} sdType - SD type for Tier 3 (null for Tier 1/2)
+ * @property {string} thresholdId - ID of the threshold config used
+ * @property {number} tier1MaxLoc - Tier 1 boundary used
+ * @property {number} tier2MaxLoc - Tier 2 boundary used
+ * @property {string|null} escalationReason - Why escalated (null if not escalated)
+ * @property {number} decisionLatencyMs - How long the routing decision took
+ */
+
+/**
+ * Get active thresholds from database with caching and fallback.
+ * @param {Object} [supabase] - Optional Supabase client (created if not provided)
+ * @returns {Promise<{id: string, tier1_max_loc: number, tier2_max_loc: number}>}
+ */
+export async function getActiveThresholds(supabase) {
+  const now = Date.now();
+
+  // Return cached if still valid
+  if (_cachedThresholds && (now - _cacheTimestamp) < CACHE_TTL_MS) {
+    return _cachedThresholds;
+  }
+
+  try {
+    const client = supabase || createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+
+    const { data, error } = await client
+      .from('work_item_thresholds')
+      .select('id, tier1_max_loc, tier2_max_loc')
+      .eq('is_active', true);
+
+    if (error) {
+      console.error('[work-item-router] DB error fetching thresholds:', error.message);
+      return { id: 'fallback', ...DEFAULT_THRESHOLDS };
+    }
+
+    if (!data || data.length === 0) {
+      console.warn('[work-item-router] No active thresholds found, using defaults');
+      return { id: 'fallback', ...DEFAULT_THRESHOLDS };
+    }
+
+    if (data.length > 1) {
+      // Multiple active rows - fail closed to Tier 3
+      console.error(`[work-item-router] THRESHOLD_CONFIG_INVALID: ${data.length} active rows found. Fail-closed.`);
+      return { id: 'error-multiple-active', tier1_max_loc: 0, tier2_max_loc: 0 };
+    }
+
+    _cachedThresholds = data[0];
+    _cacheTimestamp = now;
+    return _cachedThresholds;
+  } catch (err) {
+    console.error('[work-item-router] Failed to fetch thresholds:', err.message);
+    return { id: 'fallback', ...DEFAULT_THRESHOLDS };
+  }
+}
+
+/**
+ * Clear the threshold cache (useful for testing or after DB updates).
+ */
+export function clearThresholdCache() {
+  _cachedThresholds = null;
+  _cacheTimestamp = 0;
+}
+
+/**
+ * Check if input has risk keywords that should force escalation.
+ * @param {RouterInput} input
+ * @returns {string|null} Escalation reason or null
+ */
+function checkRiskEscalation(input) {
+  const { type, riskTags, description } = input;
+
+  // Feature type always requires full SD
+  if (type === 'feature') {
+    return 'Type "feature" requires full Strategic Directive workflow';
+  }
+
+  // Explicit risk tags
+  if (riskTags && riskTags.length > 0) {
+    const matchedTags = riskTags.filter(tag => RISK_KEYWORDS.includes(tag.toLowerCase()));
+    if (matchedTags.length > 0) {
+      return `Risk tags detected: ${matchedTags.join(', ')}`;
+    }
+  }
+
+  // Description keyword scanning for schema changes
+  if (description) {
+    const lowerDesc = description.toLowerCase();
+    for (const keyword of SCHEMA_KEYWORDS) {
+      if (lowerDesc.includes(keyword)) {
+        return `Schema change keyword detected: "${keyword}"`;
+      }
+    }
+    for (const keyword of RISK_KEYWORDS) {
+      if (lowerDesc.includes(keyword)) {
+        return `Security/risk keyword detected: "${keyword}"`;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Route a work item to the appropriate tier and workflow.
+ *
+ * @param {RouterInput} input - Work item details
+ * @param {Object} [supabase] - Optional Supabase client
+ * @returns {Promise<RoutingDecision>} The routing decision
+ */
+export async function routeWorkItem(input, supabase) {
+  const startTime = Date.now();
+  const { estimatedLoc = 0, type, entryPoint } = input;
+
+  // Check for forced escalation via risk keywords
+  const riskReason = checkRiskEscalation(input);
+  if (riskReason) {
+    const thresholds = await getActiveThresholds(supabase);
+    return {
+      tier: 3,
+      tierLabel: 'TIER_3',
+      workItemType: 'STRATEGIC_DIRECTIVE',
+      requiresComplianceRubric: false,
+      complianceMinScore: null,
+      requiresLeadReview: true,
+      sdType: type || 'enhancement',
+      thresholdId: thresholds.id,
+      tier1MaxLoc: thresholds.tier1_max_loc,
+      tier2MaxLoc: thresholds.tier2_max_loc,
+      escalationReason: riskReason,
+      decisionLatencyMs: Date.now() - startTime,
+    };
+  }
+
+  // Get active thresholds
+  const thresholds = await getActiveThresholds(supabase);
+
+  let tier, tierLabel, workItemType, requiresComplianceRubric, complianceMinScore, requiresLeadReview, sdType, escalationReason;
+
+  if (estimatedLoc <= thresholds.tier1_max_loc) {
+    // Tier 1: Auto-approve QF, skip compliance
+    tier = 1;
+    tierLabel = 'TIER_1';
+    workItemType = 'QUICK_FIX';
+    requiresComplianceRubric = false;
+    complianceMinScore = null;
+    requiresLeadReview = false;
+    sdType = null;
+    escalationReason = null;
+  } else if (estimatedLoc <= thresholds.tier2_max_loc) {
+    // Tier 2: Standard QF with compliance rubric
+    tier = 2;
+    tierLabel = 'TIER_2';
+    workItemType = 'QUICK_FIX';
+    requiresComplianceRubric = true;
+    complianceMinScore = 70;
+    requiresLeadReview = false;
+    sdType = null;
+    escalationReason = null;
+  } else {
+    // Tier 3: Full SD workflow
+    tier = 3;
+    tierLabel = 'TIER_3';
+    workItemType = 'STRATEGIC_DIRECTIVE';
+    requiresComplianceRubric = false;
+    complianceMinScore = null;
+    requiresLeadReview = true;
+    sdType = type || 'enhancement';
+    escalationReason = `Estimated LOC (${estimatedLoc}) exceeds Tier 2 max (${thresholds.tier2_max_loc})`;
+  }
+
+  const decision = {
+    tier,
+    tierLabel,
+    workItemType,
+    requiresComplianceRubric,
+    complianceMinScore,
+    requiresLeadReview,
+    sdType,
+    thresholdId: thresholds.id,
+    tier1MaxLoc: thresholds.tier1_max_loc,
+    tier2MaxLoc: thresholds.tier2_max_loc,
+    escalationReason,
+    decisionLatencyMs: Date.now() - startTime,
+  };
+
+  // Structured logging
+  console.log(`[work-item-router] Decision: tier=${tier} loc=${estimatedLoc} type=${type || 'unspecified'} entry=${entryPoint || 'unknown'} threshold=${thresholds.id} latency=${decision.decisionLatencyMs}ms`);
+
+  return decision;
+}
+
+export default { routeWorkItem, getActiveThresholds, clearThresholdCache };

--- a/tests/unit/work-item-router.test.js
+++ b/tests/unit/work-item-router.test.js
@@ -1,0 +1,344 @@
+/**
+ * Unit Tests: Unified Work-Item Router
+ * SD-LEO-ENH-IMPLEMENT-TIERED-QUICK-001
+ *
+ * Test Coverage:
+ * - Tier 1/2/3 boundary routing (TS-1, TS-2, TS-3)
+ * - Boundary conditions (TS-4)
+ * - Risk keyword escalation
+ * - DB misconfiguration fail-closed (TS-5)
+ * - DB unavailability fallback (TS-6)
+ * - Threshold caching
+ * - Routing decision contract
+ */
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+// Mock Supabase before importing router
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => mockSupabase),
+}));
+
+// Mock dotenv
+vi.mock('dotenv', () => ({
+  default: { config: vi.fn() },
+  config: vi.fn(),
+}));
+
+// Shared mock Supabase client
+const mockSupabase = {
+  from: vi.fn(),
+};
+
+// Helper to set up mock response
+function mockThresholds(data, error = null) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockResolvedValue({ data, error }),
+  };
+  mockSupabase.from.mockReturnValue(chain);
+  return chain;
+}
+
+// Import after mocks are set up
+let routeWorkItem, getActiveThresholds, clearThresholdCache;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const mod = await import('../../lib/utils/work-item-router.js');
+  routeWorkItem = mod.routeWorkItem;
+  getActiveThresholds = mod.getActiveThresholds;
+  clearThresholdCache = mod.clearThresholdCache;
+  clearThresholdCache();
+  mockSupabase.from.mockReset();
+});
+
+describe('Unified Work-Item Router', () => {
+
+  describe('Tier 1: Auto-approve QF (<=tier1_max_loc)', () => {
+    test('routes 10 LOC bug to Tier 1', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 10,
+        type: 'bug',
+        entryPoint: 'create-quick-fix',
+      }, mockSupabase);
+
+      expect(decision.tier).toBe(1);
+      expect(decision.tierLabel).toBe('TIER_1');
+      expect(decision.workItemType).toBe('QUICK_FIX');
+      expect(decision.requiresComplianceRubric).toBe(false);
+      expect(decision.complianceMinScore).toBeNull();
+      expect(decision.requiresLeadReview).toBe(false);
+      expect(decision.sdType).toBeNull();
+      expect(decision.escalationReason).toBeNull();
+      expect(decision.thresholdId).toBe('thresh-1');
+    });
+
+    test('routes 0 LOC to Tier 1', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({ estimatedLoc: 0 }, mockSupabase);
+      expect(decision.tier).toBe(1);
+    });
+
+    test('routes exactly tier1_max_loc to Tier 1 (boundary)', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({ estimatedLoc: 30 }, mockSupabase);
+      expect(decision.tier).toBe(1);
+      expect(decision.tierLabel).toBe('TIER_1');
+    });
+  });
+
+  describe('Tier 2: Standard QF with compliance (<=tier2_max_loc)', () => {
+    test('routes 50 LOC to Tier 2', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 50,
+        type: 'polish',
+      }, mockSupabase);
+
+      expect(decision.tier).toBe(2);
+      expect(decision.tierLabel).toBe('TIER_2');
+      expect(decision.workItemType).toBe('QUICK_FIX');
+      expect(decision.requiresComplianceRubric).toBe(true);
+      expect(decision.complianceMinScore).toBe(70);
+      expect(decision.requiresLeadReview).toBe(false);
+      expect(decision.sdType).toBeNull();
+      expect(decision.escalationReason).toBeNull();
+    });
+
+    test('routes tier1_max_loc + 1 to Tier 2 (boundary)', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({ estimatedLoc: 31 }, mockSupabase);
+      expect(decision.tier).toBe(2);
+    });
+
+    test('routes exactly tier2_max_loc to Tier 2 (boundary)', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({ estimatedLoc: 75 }, mockSupabase);
+      expect(decision.tier).toBe(2);
+      expect(decision.tierLabel).toBe('TIER_2');
+    });
+  });
+
+  describe('Tier 3: Full SD workflow (>tier2_max_loc)', () => {
+    test('routes 100 LOC to Tier 3', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 100,
+        type: 'enhancement',
+      }, mockSupabase);
+
+      expect(decision.tier).toBe(3);
+      expect(decision.tierLabel).toBe('TIER_3');
+      expect(decision.workItemType).toBe('STRATEGIC_DIRECTIVE');
+      expect(decision.requiresComplianceRubric).toBe(false);
+      expect(decision.requiresLeadReview).toBe(true);
+      expect(decision.sdType).toBe('enhancement');
+      expect(decision.escalationReason).toContain('exceeds Tier 2 max');
+    });
+
+    test('routes tier2_max_loc + 1 to Tier 3 (boundary)', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({ estimatedLoc: 76 }, mockSupabase);
+      expect(decision.tier).toBe(3);
+      expect(decision.tierLabel).toBe('TIER_3');
+    });
+  });
+
+  describe('Risk keyword escalation', () => {
+    test('feature type always escalates to Tier 3', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 5,
+        type: 'feature',
+      }, mockSupabase);
+
+      expect(decision.tier).toBe(3);
+      expect(decision.escalationReason).toContain('feature');
+    });
+
+    test('security risk tag escalates to Tier 3', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 5,
+        type: 'bug',
+        riskTags: ['security'],
+      }, mockSupabase);
+
+      expect(decision.tier).toBe(3);
+      expect(decision.escalationReason).toContain('security');
+    });
+
+    test('schema keyword in description escalates to Tier 3', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 10,
+        type: 'bug',
+        description: 'Need to alter table to add column',
+      }, mockSupabase);
+
+      expect(decision.tier).toBe(3);
+      expect(decision.escalationReason).toContain('alter table');
+    });
+
+    test('auth keyword in description escalates to Tier 3', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 10,
+        description: 'Fix authentication bypass in login flow',
+      }, mockSupabase);
+
+      expect(decision.tier).toBe(3);
+      expect(decision.escalationReason).toContain('auth');
+    });
+
+    test('non-risk description does not escalate', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 10,
+        type: 'bug',
+        description: 'Fix button color on dashboard page',
+      }, mockSupabase);
+
+      expect(decision.tier).toBe(1);
+      expect(decision.escalationReason).toBeNull();
+    });
+  });
+
+  describe('Database misconfiguration (fail-closed)', () => {
+    test('multiple active rows fail-closed to Tier 3', async () => {
+      mockThresholds([
+        { id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 },
+        { id: 'thresh-2', tier1_max_loc: 40, tier2_max_loc: 100 },
+      ]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 10,
+        type: 'bug',
+      }, mockSupabase);
+
+      // With tier1_max_loc=0 and tier2_max_loc=0, any LOC > 0 → Tier 3
+      expect(decision.tier).toBe(3);
+    });
+  });
+
+  describe('Database unavailability (fallback)', () => {
+    test('DB error falls back to default thresholds', async () => {
+      mockThresholds(null, { message: 'connection refused' });
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 10,
+        type: 'bug',
+      }, mockSupabase);
+
+      // Default: tier1=30, tier2=75 → 10 LOC is Tier 1
+      expect(decision.tier).toBe(1);
+      expect(decision.thresholdId).toBe('fallback');
+    });
+
+    test('empty result falls back to default thresholds', async () => {
+      mockThresholds([]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 50,
+      }, mockSupabase);
+
+      // Default: tier1=30, tier2=75 → 50 LOC is Tier 2
+      expect(decision.tier).toBe(2);
+      expect(decision.thresholdId).toBe('fallback');
+    });
+  });
+
+  describe('Threshold caching', () => {
+    test('second call uses cached thresholds', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      await routeWorkItem({ estimatedLoc: 10 }, mockSupabase);
+      await routeWorkItem({ estimatedLoc: 10 }, mockSupabase);
+
+      // from() should only be called once (second call uses cache)
+      expect(mockSupabase.from).toHaveBeenCalledTimes(1);
+    });
+
+    test('clearThresholdCache forces re-fetch', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      await routeWorkItem({ estimatedLoc: 10 }, mockSupabase);
+      clearThresholdCache();
+
+      mockThresholds([{ id: 'thresh-2', tier1_max_loc: 20, tier2_max_loc: 60 }]);
+      const decision = await routeWorkItem({ estimatedLoc: 10 }, mockSupabase);
+
+      expect(mockSupabase.from).toHaveBeenCalledTimes(2);
+      expect(decision.thresholdId).toBe('thresh-2');
+    });
+  });
+
+  describe('Routing decision contract', () => {
+    test('decision includes all required fields', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({
+        estimatedLoc: 10,
+        type: 'bug',
+        entryPoint: 'test',
+      }, mockSupabase);
+
+      expect(decision).toHaveProperty('tier');
+      expect(decision).toHaveProperty('tierLabel');
+      expect(decision).toHaveProperty('workItemType');
+      expect(decision).toHaveProperty('requiresComplianceRubric');
+      expect(decision).toHaveProperty('complianceMinScore');
+      expect(decision).toHaveProperty('requiresLeadReview');
+      expect(decision).toHaveProperty('sdType');
+      expect(decision).toHaveProperty('thresholdId');
+      expect(decision).toHaveProperty('tier1MaxLoc');
+      expect(decision).toHaveProperty('tier2MaxLoc');
+      expect(decision).toHaveProperty('escalationReason');
+      expect(decision).toHaveProperty('decisionLatencyMs');
+      expect(typeof decision.decisionLatencyMs).toBe('number');
+    });
+
+    test('defaults to 0 estimatedLoc when missing', async () => {
+      mockThresholds([{ id: 'thresh-1', tier1_max_loc: 30, tier2_max_loc: 75 }]);
+
+      const decision = await routeWorkItem({}, mockSupabase);
+      expect(decision.tier).toBe(1); // 0 LOC → Tier 1
+    });
+  });
+
+  describe('Custom thresholds', () => {
+    test('respects custom tier boundaries from database', async () => {
+      mockThresholds([{ id: 'custom-1', tier1_max_loc: 10, tier2_max_loc: 50 }]);
+
+      const d1 = await routeWorkItem({ estimatedLoc: 10 }, mockSupabase);
+      expect(d1.tier).toBe(1);
+
+      clearThresholdCache();
+      mockThresholds([{ id: 'custom-1', tier1_max_loc: 10, tier2_max_loc: 50 }]);
+
+      const d2 = await routeWorkItem({ estimatedLoc: 11 }, mockSupabase);
+      expect(d2.tier).toBe(2);
+
+      clearThresholdCache();
+      mockThresholds([{ id: 'custom-1', tier1_max_loc: 10, tier2_max_loc: 50 }]);
+
+      const d3 = await routeWorkItem({ estimatedLoc: 51 }, mockSupabase);
+      expect(d3.tier).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `lib/utils/work-item-router.js` - central routing module with 3-tier classification (Tier 1: auto-approve <=30 LOC, Tier 2: standard QF 31-75 LOC, Tier 3: full SD >75 LOC)
- Add `work_item_thresholds` database table with DB-driven tier boundaries, single-active-row enforcement, and 5-min cache TTL
- Update `scripts/create-quick-fix.js` to use router instead of hardcoded 50 LOC threshold
- Update `scripts/leo-create-sd.js` QF prefix detection to use router
- Add 21 unit tests covering boundary routing, risk keyword escalation, DB fallback, and caching
- Update protocol documentation with tiered routing section

SD-LEO-ENH-IMPLEMENT-TIERED-QUICK-001

## Test plan
- [x] 21/21 unit tests passing (work-item-router.test.js)
- [x] Tier 1/2/3 boundary conditions verified (30/31, 75/76 LOC)
- [x] Risk keyword escalation (security, auth, schema) forces Tier 3
- [x] DB misconfiguration fail-closed to Tier 3
- [x] DB unavailability falls back to defaults (30/75)
- [x] Threshold caching and cache invalidation tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)