### PR TITLE
fix(docmon): handle undefined efficiencyScore for new/moved files

### DIFF
--- a/scripts/docmon.js
+++ b/scripts/docmon.js
@@ -503,6 +503,7 @@ async function main() {
     console.log('─────────────────────────────────────────────────────────────────');
 
     for (const result of results) {
+      if (!result.efficiencyScore) continue;
       const { beforeWords, afterWords, percentChange } = result.efficiencyScore;
       const pct = typeof percentChange === 'number' ? `${percentChange}%` : percentChange;
       console.log(`  ${result.filePath}: ${beforeWords} words → ${afterWords} words (${pct} change)`);


### PR DESCRIPTION
## Summary
- Adds null check before destructuring `result.efficiencyScore` in DOCMON's human-readable output
- Prevents crash when processing files that are new (e.g., moved during docs consolidation) and have no before-state for word count comparison

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Push with DOCMON hook succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)