### PR TITLE
fix: remove duplicate git:recover key in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ehg-engineer",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.63.0",
         "@babel/parser": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,6 @@
     "sd:new": "node scripts/create-sd.js",
     "sd:from-feedback": "node scripts/sd-from-feedback.js",
     "gap:analyze:verbose": "node scripts/retroactive-gap-analysis.js --verbose",
-    "git:recover": "node scripts/git-commit-recovery.js",
     "leo:continuous": "node scripts/leo-continuous.js",
     "leo:checkpoint": "node scripts/lib/leo-checkpoint.js",
     "baseline:list": "node scripts/baseline.js list",


### PR DESCRIPTION
## Summary
- Removed duplicate `git:recover` npm script key at line 230 of package.json
- The original entry at line 203 is preserved
- Duplicate was introduced during SD-LEO-FIX-MULTI-SESSION-SHIP-001 implementation

## Test plan
- [x] `npm run test:smoke` passes (15/15)
- [x] `npm run git:recover` still works (original entry intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)