### PR TITLE
fix(agents): add team coordination tools to RCA agent

### DIFF
--- a/.claude/agents/rca-agent.partial
+++ b/.claude/agents/rca-agent.partial
@@ -1,7 +1,7 @@
 ---
 name: rca-agent
 description: "MUST BE USED PROACTIVELY for all root cause analysis tasks. Handles defect triage, root cause determination, and CAPA generation. Trigger on keywords: root cause, 5 whys, diagnose, debug, investigate, why is this happening, what caused this, rca, defect analysis, recurring issue, keeps happening."
-tools: Bash, Read, Write, Task
+tools: Bash, Read, Write, Task, TeamCreate, TaskCreate, TaskUpdate, TaskList, TaskGet, SendMessage
 model: opus
 ---
 


### PR DESCRIPTION
## Summary

- Added TeamCreate, TaskCreate, TaskUpdate, TaskList, TaskGet, and SendMessage tools to the RCA agent's tool declaration
- Enables RCA agent to create investigation teams where teammates can communicate with each other, not just report back to the lead

## Test plan

- [x] Verified RCA agent previously lacked team tools (test showed BLOCKED on TeamCreate, TaskCreate, SendMessage)
- [x] Updated `.partial` file and recompiled — tools line confirmed in compiled `.md`
- [x] Smoke tests pass (15/15)
- [ ] Full team coordination test in next session (Claude Code caches agent defs at session start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)