### PR TITLE
fix(QF-20260211-111): add post-merge worktree cleanup to /ship

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -410,6 +410,33 @@ This step runs automatically via PostToolUse hook - no manual action required.
 
 **Why this matters**: Previously, learnings from documentation fixes, ad-hoc improvements, and polish sessions were lost because they didn't go through the full SD workflow. Now all valuable work contributes to the learning system.
 
+### Step 6.7: Worktree Cleanup (AUTOMATED)
+
+**After a successful merge, if running inside a worktree, clean it up automatically.**
+
+This prevents zombie worktree directories that point at deleted branches.
+
+```bash
+node scripts/modules/shipping/post-merge-worktree-cleanup.js
+```
+
+**If output contains `"cleaned": true`:**
+1. The worktree directory has been removed
+2. `cd` to the `mainRepoPath` from the output to return to the main repo
+3. Run `git checkout main && git pull` from the main repo
+
+**If output contains `"cleaned": false`:**
+- No action needed (not inside a worktree)
+- Continue to Step 7
+
+**Example outputs:**
+```json
+{"cleaned":true,"mainRepoPath":"C:/Users/rickf/Projects/_EHG/EHG_Engineer","workKey":"QF-20260211-001"}
+{"cleaned":false,"reason":"not_in_worktree"}
+```
+
+**Note:** The existing LEAD-FINAL-APPROVAL cleanup is kept as a safety net. It is idempotent — if this step already cleaned up, it reports "worktree_not_found" and moves on.
+
 ### Step 7: Post-Merge Command Ecosystem (NEW)
 
 **After a successful merge, present contextual suggestions using AskUserQuestion:**

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -1,0 +1,50 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+// Quick-fix QF-20260211-111: Post-merge worktree cleanup for /ship
+const gitExec = (cmd, opts = {}) =>
+  execSync(cmd, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'], ...opts }).trim();
+
+function isInsideWorktree() {
+  try { return gitExec('git rev-parse --show-toplevel').includes('.worktrees'); }
+  catch { return false; }
+}
+
+function getWorktreeMetadata(wtPath) {
+  for (const name of ['.ehg-session.json', '.worktree.json']) {
+    const fp = path.join(wtPath, name);
+    if (fs.existsSync(fp)) {
+      try { return JSON.parse(fs.readFileSync(fp, 'utf8')); } catch { /* skip */ }
+    }
+  }
+  return null;
+}
+
+function getMainRepoPath(meta, wtPath) {
+  if (meta?.repoRoot) return meta.repoRoot;
+  const idx = wtPath.indexOf('.worktrees');
+  return idx > 0 ? wtPath.slice(0, idx - 1) : null;
+}
+
+function cleanupCurrentWorktree() {
+  if (!isInsideWorktree()) return { cleaned: false, reason: 'not_in_worktree' };
+  const wtPath = gitExec('git rev-parse --show-toplevel');
+  const meta = getWorktreeMetadata(wtPath);
+  const mainRepoPath = getMainRepoPath(meta, wtPath);
+  if (!mainRepoPath) return { cleaned: false, reason: 'cannot_resolve_main_repo' };
+  try {
+    execSync(`git worktree remove --force "${wtPath}"`, { cwd: mainRepoPath, encoding: 'utf8', stdio: 'pipe' });
+  } catch {
+    if (fs.existsSync(wtPath)) {
+      fs.rmSync(wtPath, { recursive: true, force: true });
+      execSync('git worktree prune', { cwd: mainRepoPath, stdio: 'pipe' });
+    }
+  }
+  return { cleaned: true, mainRepoPath, workKey: meta?.workKey || meta?.sdKey || null };
+}
+
+const _e = process.argv[1] || '', isMain = _e && (import.meta.url === `file://${_e}` ||
+  import.meta.url === `file:///${_e.replace(/\\/g, '/')}`);
+if (isMain) process.stdout.write(JSON.stringify(cleanupCurrentWorktree()));
+export { isInsideWorktree, getWorktreeMetadata, getMainRepoPath, cleanupCurrentWorktree };


### PR DESCRIPTION
## Summary
- Adds `scripts/modules/shipping/post-merge-worktree-cleanup.js` — detects if running inside a worktree, removes it after merge, reports main repo path
- Adds Step 6.7 to `ship.md` instructing Claude to run cleanup after merge and cd back to main repo
- Keeps existing LEAD-FINAL-APPROVAL cleanup as idempotent safety net

## Test plan
- [x] `isInsideWorktree()` returns true when cwd is a worktree
- [x] Metadata resolved from `.ehg-session.json` with correct workKey/workType
- [x] `getMainRepoPath()` correctly resolves main repo from worktree path
- [x] Returns `{ cleaned: false, reason: "not_in_worktree" }` when not in worktree
- [x] Cross-platform `isMain` guard handles Windows paths and module imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)