### PR TITLE
docs: fix 6 inconsistencies across EVA vision and architecture docs

### DIFF
--- a/docs/plans/eva-platform-architecture.md
+++ b/docs/plans/eva-platform-architecture.md
@@ -699,7 +699,7 @@ Every state change is logged:
 | **Return Path (LEO → Stages)** | SD completion → stage progress sync | P0 |
 | **Chairman Dashboard** | Decision queue + health heatmap + event feed | P1 |
 | **Chairman Notification Service** | Push + digest notification batching | P1 |
-| **Shared Services Abstraction** | Common service interface (load context, execute, emit) | P1 |
+| **Shared Services Abstraction** | Common service interface (load context, execute, emit) | P3 |
 | **Portfolio Knowledge Base** | Cross-venture learning extraction and application | P2 |
 | **Venture Template System** | Auto-generate and apply templates | P2 |
 | **Inter-Venture Dependency Manager** | Dependency graph with auto-blocking | P2 |

--- a/docs/plans/eva-venture-lifecycle-vision.md
+++ b/docs/plans/eva-venture-lifecycle-vision.md
@@ -4,7 +4,7 @@
 > **Created**: 2026-02-12
 > **Status**: Draft (Revised + 34 Chairman Clarifications)
 > **Supersedes**: `kb/ehg-review/00_unified_vision_2025.md`, `kb/ehg-review/01_vision_ehg_eva.md`, `docs/guides/workflow/25-stage-venture-lifecycle-overview.md`
-> **Companion**: Architecture Document (Step 2, forthcoming)
+> **Companion**: [Architecture Document](eva-platform-architecture.md) (Step 2, complete)
 > **Inputs**: Gemini vision diagrams, 25-stage CLI vs GUI gap analysis (PR #1117), CLI implementation review (`stages_v2.yaml`, Decision Filter Engine, Reality Gates, SD Bridge), brainstorming decisions (2026-02-11)
 
 ---
@@ -611,8 +611,8 @@ After launch (Stage 23), ventures enter the recurring ops loop (24-25). Between 
 | **Infrastructure monitoring** | Existing inbox/feedback system surfaces issues. LEO generates SDs for remediation. | Fully automated |
 | **Infrastructure scaling** | Auto-scale within pre-configured bounds. DFE `cost_threshold` trigger fires for significant cost jumps (e.g., 10x increase). Below threshold, fully autonomous. | Fully automated (DFE gate) |
 | **Feature enhancements** | Stage 24 declining metrics → LEO enhancement SDs. Stage 25 "expand" → new scope SDs. | Fully automated |
-| **Billing & payments** | Stripe (or equivalent) configured at Stage 20 Launch Prep. Subscriptions, invoicing, tax compliance, and dunning automated. Chairman involved only for pricing model changes (routed via DFE `strategic_pivot`). | Fully automated |
-| **Legal & compliance** | Pre-built template library (ToS, privacy policy, GDPR/CCPA, cookie banners) auto-configured per venture at Stage 20. Novel situations (new jurisdictions, regulated industries) escalate to Chairman via DFE. | Automated + DFE |
+| **Billing & payments** | Stripe (or equivalent) configured at Stage 23 (Launch Execution). Subscriptions, invoicing, tax compliance, and dunning automated. Chairman involved only for pricing model changes (routed via DFE `strategic_pivot`). | Fully automated |
+| **Legal & compliance** | Pre-built template library (ToS, privacy policy, GDPR/CCPA, cookie banners) auto-configured per venture at Stage 23 (Launch Execution). Novel situations (new jurisdictions, regulated industries) escalate to Chairman via DFE. | Automated + DFE |
 | **Data & analytics** | Auto-collect AARRR metrics, auto-analyze trends, auto-generate insights. DFE escalates anomalies (retention cliff, revenue decline). EVA auto-adjusts (A/B tests, funnel optimization) without approval. | Fully automated (DFE alerts) |
 
 ### Needs Deep Research (Step 6)
@@ -762,7 +762,7 @@ Four cross-cutting mechanisms are integrated into the lifecycle:
 | Nugget | Purpose | Stages |
 |--------|---------|--------|
 | **Assumptions vs Reality** | Track early assumptions, compare to actual outcomes | 2, 3, 5, 23, 24, 25 |
-| **Token Budget Profiles** | Treat compute as capital with explicit budgets | 5 (profile selection) |
+| **Token Budget Profiles** | Track compute usage for awareness and anomaly detection (not as a constraint — see Unlimited Compute in Section 2) | 5 (profile selection) |
 | **Four Buckets** | Classify outputs as Fact / Assumption / Simulation / Unknown | 3, 5, 16 (epistemic gates) |
 | **Crew Tournament** | Multi-agent competition for brand messaging | 11 (pilot) |
 

--- a/docs/plans/vision-architecture-next-steps.md
+++ b/docs/plans/vision-architecture-next-steps.md
@@ -232,7 +232,7 @@ Per-stage consensus decisions extracted from the 25-stage triangulated analysis.
 |:-----:|------|-------------|-------------|
 | **1** | Idea Capture | Add `problemStatement` (required). Wire Stage 0 synthesis output into Stage 1. Keep `valueProp`. | Stage 0→1 data pipeline closes the synthesis gap |
 | **2** | Idea Analysis | Add active `analysisStep` (the #1 gap). Adopt 0-100 integer scale. Align categories to Stage 3's 6 kill gate metrics. | Every stage gets an analysisStep (pattern established here) |
-| **3** | Kill Gate | Add metric generation `analysisStep`. Hybrid scoring (60% deterministic + 40% AI). Stage 2→3 formal artifact contract. Raise kill threshold from 40. | Deterministic baseline + AI augmentation scoring model |
+| **3** | Kill Gate | Add metric generation `analysisStep`. Hybrid scoring (50% deterministic + 50% AI). Stage 2→3 formal artifact contract. Raise kill threshold from 40. | Deterministic baseline + AI augmentation scoring model |
 | **4** | Competitive Landscape | Add competitor discovery `analysisStep`. Add pricing model per competitor (essential for Stage 5). Eliminate feature comparison matrix. | Cross-stage consumption: Stage 3→4 competitor handoff |
 | **5** | Kill Gate (Financial) | Add financial model generation `analysisStep`. Stage 4 consumption mandatory. Unit economics required (CAC, LTV, LTV:CAC, payback). ROI 25% with bands. | Kill gate evaluates generated data, not user-entered data |
 
@@ -259,7 +259,7 @@ Per-stage consensus decisions extracted from the 25-stage triangulated analysis.
 |:-----:|------|-------------|-------------|
 | **13** | Product Roadmap | Add roadmap generation `analysisStep` consuming Stages 1-12. Wire sales_model → feature generation. Add priority (now/next/later) to milestones. | Sales model drives product priorities |
 | **14** | Technical Architecture | Add architecture generation `analysisStep`. Map Stage 13 deliverable types → architecture layers. Add security section, Schema-Lite data entities. | Structured minimalism: enough to inform Stages 15-16, not premature implementation |
-| **15** | Resource Planning | Add team generation `analysisStep` from Stages 12-14. Phase-aware role bundling (generalists → specialists). Add phase_ref to team/hiring. | "Generalists first, specialize later" principle |
+| **15** | Resource Planning | Add agent allocation `analysisStep` from Stages 12-14. Map AI agent capabilities to build phases. Add service/tool requirements and compute budget per phase. | AI-only operation: agents and compute, not human hiring |
 | **16** | Financial Projections | Add financial model `analysisStep` consuming 7 prior stages. Replace flat projections with "Startup Standard" P&L. Phase-variable costs from Stage 15. Promotion gate checks viability, not just presence. | The synthesis stage of THE BLUEPRINT: all prior stages feed financial truth |
 
 ### Phase 5: THE BUILD LOOP (Stages 17-22)


### PR DESCRIPTION
## Summary
- Fix stale "forthcoming" companion link in vision doc to reference actual architecture doc
- Align kill gate scoring weights to 50/50 (vision is authoritative; master plan had 60/40)
- Correct Stage 20 mislabeling: billing and legal setup now correctly references Stage 23 (Launch Execution)
- Reconcile Token Budget Profiles golden nugget with Decision #20 (Unlimited Compute)
- Fix Shared Services Abstraction priority from P1 to P3 (matches Phase D implementation sequence)
- Update master plan Stage 15 cross-reference from human hiring to AI agent allocation (Decision #19)

## Test plan
- [x] Verify all cross-references between vision, architecture, and master plan are consistent
- [x] Confirm no broken markdown links
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)