### PR TITLE
feat: Plan Mode guardrail + TDD workflow for LEO Protocol

### DIFF
--- a/.claude/agents/testing-agent.partial
+++ b/.claude/agents/testing-agent.partial
@@ -236,6 +236,84 @@ mcp__ide__getDiagnostics({ uri: "file://<project-root>/tests/e2e/venture-creatio
 
 Note: Replace `<project-root>` with your actual EHG_Engineer path.
 
+## Pre-Implementation TDD
+
+### When to Use This Mode
+
+This mode is triggered when the prompt includes `Mode: pre-implementation` or `TDD PRE-IMPLEMENTATION`. It generates failing tests from PRD acceptance criteria **before any production code is written**.
+
+### TDD Pre-Implementation Workflow
+
+When invoked in pre-implementation mode:
+
+1. **Extract PRD Acceptance Criteria**
+   - Query the PRD from database: `product_requirements_v2` where `sd_id = <SD-ID>`
+   - List all acceptance criteria from `functional_requirements[].acceptance_criteria`
+   - Also extract `test_scenarios` for additional coverage guidance
+
+2. **Map Each Acceptance Criterion to Test Cases**
+   - Each AC maps to at least one test case
+   - Use descriptive test names: `test('AC-1: [criterion description]', ...)`
+   - Group tests by functional requirement (FR-1, FR-2, etc.)
+
+3. **Generate Failing Test Skeletons**
+   - Create test files with proper imports and structure
+   - Tests must reference specific acceptance criteria
+   - Tests must FAIL initially (assert expected behavior that doesn't exist yet)
+   - Do NOT write or modify any production source code
+
+   **Test file naming**: `tests/unit/<sd-id-slug>.test.js` or `tests/e2e/<sd-id-slug>.spec.ts`
+
+4. **Provide Exact Run Commands**
+   ```bash
+   # Unit tests
+   npm run test:unit -- --grep "<sd-id>"
+
+   # E2E tests (if applicable)
+   npm run test:e2e -- --grep "<sd-id>"
+   ```
+
+### Handling Missing Test Harnesses
+
+If the project lacks a test harness for the required test type:
+- **Unit tests**: Verify vitest is configured (`vitest.config.js` exists)
+- **E2E tests**: Verify playwright is configured (`playwright.config.js` exists)
+- If no harness exists, document why tests are exempt rather than creating infrastructure
+
+### Output Format
+
+When completing pre-implementation TDD, output:
+
+```
+TDD Pre-Implementation Results:
+================================
+PRD: <PRD-ID>
+SD: <SD-ID>
+
+Acceptance Criteria Extracted: X
+Test Cases Generated: Y
+
+Test Files:
+- tests/unit/<file1>.test.js (X tests)
+- tests/e2e/<file2>.spec.ts (Y tests)
+
+Run Commands:
+- npm run test:unit
+- npm run test:e2e
+
+Expected Result: All X+Y tests FAIL (no implementation yet)
+```
+
+### Post-Implementation Verification
+
+When invoked with `Mode: post-implementation`, verify:
+1. All pre-implementation tests now pass
+2. No acceptance criteria lack test coverage
+3. Run regression checks on existing test suite
+4. Report coverage summary
+
+This is the existing post-implementation testing behavior and remains unchanged from prior versions.
+
 ## Remember
 
 You are an **Intelligent Trigger** for the QA system. The comprehensive testing logic, test generation, and validation workflows live in the scripts—not in this prompt. Your value is in recognizing testing needs and routing them to the appropriate validation system.

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -418,6 +418,7 @@ Before marking any stage/feature as complete:
 - E2E testing is MANDATORY
 - 100% user story coverage required
 - Both unit tests AND E2E tests must pass
+- **TDD for applicable SD types**: For `feature` (mandatory) and `enhancement`/`bugfix`/`refactor` (recommended) SDs, invoke the TESTING sub-agent **before implementation** to generate failing tests from PRD acceptance criteria, then implement to make tests pass. See CLAUDE_EXEC.md "TDD Workflow (EXEC)" for the full sequence.
 
 ### Database-First (REQUIRED)
 **Zero markdown files.** Database tables are single source of truth:

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -928,6 +928,88 @@ npm run test:e2e
 - **SD-EVA-MEETING-002**: 67% E2E failure rate revealed only when tests finally executed
 - **Impact**: Testing enforcement prevents claiming "done" without proof
 
+## TDD Workflow (EXEC)
+
+### Pre-Implementation Testing via TESTING Sub-Agent
+
+For applicable SD types, EXEC begins by deriving failing tests from PRD acceptance criteria **before writing any production code**. This ensures implementation is driven by verifiable acceptance criteria rather than ad-hoc coding.
+
+### TDD Applicability by SD Type
+
+| SD Type | TDD Level | Required Evidence | Notes |
+|---------|-----------|-------------------|-------|
+| `feature` | **Mandatory** | Failing test output + passing test output | Full TDD cycle required |
+| `enhancement` | **Recommended** | Test output if tests written | Strongly encouraged, skip with justification |
+| `bugfix` | **Recommended** | Reproduction test + fix verification | Write test that reproduces bug first |
+| `fix` | Exempt | N/A | Small fixes, TDD overhead not justified |
+| `documentation` | Exempt | N/A | No production code changes |
+| `infrastructure` | Exempt | N/A | Unless SD explicitly requires tests |
+| `refactor` | **Recommended** | Before/after test parity | Verify existing tests pass before and after |
+| `security` | **Recommended** | Security test + verification | Test the vulnerability, then the fix |
+
+**Override**: Any SD can explicitly set `tdd_required: true` in metadata to force Mandatory level regardless of type.
+
+### TDD Sequence (When Applicable)
+
+Follow this ordered checklist for Mandatory/Recommended SD types:
+
+#### Step 1: Invoke TESTING Sub-Agent (Pre-Implementation)
+```
+Task tool with subagent_type="testing-agent":
+"TDD PRE-IMPLEMENTATION: Generate failing tests from PRD acceptance criteria for <SD-ID>.
+PRD ID: <PRD-ID>
+Mode: pre-implementation
+Extract acceptance criteria and create test skeletons that FAIL initially."
+```
+
+**Evidence to capture**: Copy the test run output showing failures (e.g., `3 failed, 0 passed`).
+
+#### Step 2: Confirm Tests Fail
+```bash
+# Run the generated tests to confirm they fail
+npm run test:unit    # For unit tests
+npm run test:e2e     # For E2E tests (if applicable)
+```
+
+The first test run MUST occur **before the first production code change**. If tests pass before implementation, they are not testing new behavior.
+
+#### Step 3: Implement to Pass
+Write production code targeting the failing tests. Each test that turns green confirms an acceptance criterion is met.
+
+#### Step 4: Run Tests to Green
+```bash
+npm run test:unit    # All tests should pass
+npm run test:e2e     # E2E tests should pass (if applicable)
+```
+
+**Evidence to capture**: Copy the test run output showing all passing (e.g., `3 passed, 0 failed`).
+
+#### Step 5: Invoke TESTING Sub-Agent (Post-Implementation)
+```
+Task tool with subagent_type="testing-agent":
+"TDD POST-IMPLEMENTATION: Verify test coverage and run regression checks for <SD-ID>.
+Mode: post-implementation
+Verify all PRD acceptance criteria are covered by passing tests."
+```
+
+This step is the existing post-implementation TESTING trigger and remains unchanged.
+
+### TDD Evidence in Handoff
+
+When creating the EXEC→PLAN handoff, include TDD evidence:
+
+```
+TDD Evidence:
+- Pre-implementation test run: [X tests failed, 0 passed] (before any code changes)
+- Post-implementation test run: [X tests passed, 0 failed] (all green)
+- Test files created/modified: [list of test file paths]
+- PRD acceptance criteria covered: [X/Y criteria have tests]
+```
+
+### Compatibility Note
+
+This TDD workflow is **additive** to the existing Dual Test Requirement below. The Dual Test Requirement (unit + E2E) remains mandatory for all EXEC→PLAN handoffs. TDD adds the **timing constraint**: tests should be written before production code for applicable SD types.
+
 ## ✅ EXEC UI Parity Verification Checklist
 
 **Added in LEO v4.3.3** - MANDATORY before marking implementation complete

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -260,6 +260,45 @@ Claude: "Found existing user preferences in the EHG app. Let me now run formal v
 node lib/sub-agent-executor.js VALIDATION <SD-ID>
 ```
 
+## Plan Mode (Optional Guardrail)
+
+### Read-Only Exploration with Claude Code Plan Mode
+
+During the LEAD phase, you may use Claude Code's native **Plan Mode** (`Shift+Tab+Tab`) to enforce read-only exploration. This prevents accidental file edits while you are reading files, assessing validators, and drafting your approach.
+
+**How to use:**
+1. Press `Shift+Tab+Tab` to enter Plan Mode
+2. Explore the codebase: read files, search code, run git status
+3. Draft your assessment and approach
+4. Exit Plan Mode before making any changes
+
+**What Plan Mode prevents:**
+- File writes (Edit, Write tools are blocked)
+- File creation (new files cannot be created)
+- Bash commands that modify state (git commit, npm install, etc.)
+
+**What Plan Mode allows:**
+- Reading files (Read tool)
+- Searching code (Grep, Glob tools)
+- Running read-only commands (git log, git status, npm run sd:next)
+- Exploring the codebase (Task tool with Explore agent)
+
+### Important: Plan Mode is Optional
+
+- Plan Mode is a **convenience guardrail**, not a mandatory step
+- Existing LEAD→PLAN handoff gates remain **authoritative** (no threshold changes)
+- The 9-question LEAD validation gate is unchanged
+- You can perform LEAD exploration without Plan Mode and the workflow is identical
+
+### When Plan Mode Adds Value
+
+| Scenario | Plan Mode Helpful? |
+|----------|--------------------|
+| Complex SD with many affected files | Yes - prevents accidental edits during discovery |
+| Simple/known scope SD | No - skip directly to validation |
+| Follow-up work (already explored) | No - context is already established |
+| Emergency/time-critical fixes | No - speed matters more |
+
 ## SD to Quick Fix Reverse Rubric (LEO v4.3.3)
 
 ## SD to Quick Fix Reverse Rubric

--- a/scripts/modules/handoff/gates/tdd-pre-implementation-gate.js
+++ b/scripts/modules/handoff/gates/tdd-pre-implementation-gate.js
@@ -1,0 +1,232 @@
+/**
+ * TDD Pre-Implementation Gate
+ * SD-LEO-INFRA-PLAN-MODE-TDD-001, FR-6
+ *
+ * Optional, opt-in validator that checks for evidence of pre-implementation
+ * tests when the SD type requires TDD (per the SD-type-to-TDD mapping).
+ *
+ * DISABLED BY DEFAULT. Enable via:
+ *   - Environment variable: TDD_PRE_IMPL_GATE_ENABLED=true
+ *   - Or SD metadata: tdd_required=true (overrides type-based exemption)
+ *
+ * When enabled, this gate checks EXEC→PLAN handoffs for:
+ *   1. New/modified test files added before production code
+ *   2. A referenced pre-implementation test run (in handoff notes or metadata)
+ *
+ * Returns standard gate result: { passed, score, max_score, issues, warnings, details }
+ */
+
+// TDD level by SD type (matches CLAUDE_EXEC.md "TDD Applicability by SD Type" table)
+const TDD_LEVEL_BY_TYPE = {
+  feature: 'mandatory',
+  enhancement: 'recommended',
+  bugfix: 'recommended',
+  fix: 'exempt',
+  documentation: 'exempt',
+  infrastructure: 'exempt',
+  refactor: 'recommended',
+  security: 'recommended',
+  uat: 'exempt',
+  qa: 'exempt'
+};
+
+/**
+ * Check if the TDD gate is enabled globally
+ * @returns {boolean}
+ */
+function isGateEnabled() {
+  const envFlag = process.env.TDD_PRE_IMPL_GATE_ENABLED;
+  return envFlag === 'true' || envFlag === '1';
+}
+
+/**
+ * Get TDD requirement level for an SD type
+ * @param {string} sdType - The SD type (feature, enhancement, etc.)
+ * @param {Object} [metadata] - SD metadata (may contain tdd_required override)
+ * @returns {'mandatory'|'recommended'|'exempt'}
+ */
+function getTddLevel(sdType, metadata) {
+  // SD-level override: tdd_required=true forces mandatory
+  if (metadata?.tdd_required === true) {
+    return 'mandatory';
+  }
+  return TDD_LEVEL_BY_TYPE[sdType] || 'exempt';
+}
+
+/**
+ * Validate pre-implementation test evidence for a handoff
+ *
+ * @param {Object} context - Validation context
+ * @param {string} context.sd_id - The SD key
+ * @param {Object} context.supabase - Supabase client
+ * @param {Object} [context.handoff] - Handoff data (if available)
+ * @returns {Promise<Object>} Gate result
+ */
+export async function validateTddPreImplementation(context) {
+  const { sd_id, supabase, handoff } = context;
+
+  // Gate disabled globally → auto-pass
+  if (!isGateEnabled()) {
+    return {
+      passed: true,
+      score: 100,
+      max_score: 100,
+      issues: [],
+      warnings: [],
+      details: {
+        status: 'skipped',
+        reason: 'TDD pre-implementation gate is disabled (TDD_PRE_IMPL_GATE_ENABLED not set)'
+      }
+    };
+  }
+
+  // Fetch SD to get type and metadata
+  const { data: sd, error: sdError } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_type, metadata')
+    .eq('id', sd_id)
+    .single();
+
+  if (sdError || !sd) {
+    return {
+      passed: true,
+      score: 80,
+      max_score: 100,
+      issues: [],
+      warnings: [`Could not fetch SD ${sd_id} for TDD check: ${sdError?.message || 'not found'}`],
+      details: { status: 'warn', reason: 'SD lookup failed, defaulting to pass' }
+    };
+  }
+
+  const tddLevel = getTddLevel(sd.sd_type, sd.metadata);
+
+  // Exempt types → auto-pass with reason
+  if (tddLevel === 'exempt') {
+    return {
+      passed: true,
+      score: 100,
+      max_score: 100,
+      issues: [],
+      warnings: [],
+      details: {
+        status: 'exempt',
+        reason: `Exempt for ${sd.sd_type}`,
+        sd_type: sd.sd_type,
+        tdd_level: tddLevel
+      }
+    };
+  }
+
+  // Check for test evidence in handoff data
+  const issues = [];
+  const warnings = [];
+  let testFilesFound = false;
+  let preImplRunFound = false;
+
+  // Check handoff notes/deliverables for TDD evidence
+  const handoffNotes = handoff?.notes || handoff?.deliverables_manifest || '';
+  const handoffStr = typeof handoffNotes === 'string'
+    ? handoffNotes
+    : JSON.stringify(handoffNotes);
+
+  // Look for test file references
+  const testFilePatterns = [
+    /tests?\/(unit|e2e|integration)\/.*\.(test|spec)\.(js|ts|jsx|tsx)/i,
+    /\.test\.(js|ts|jsx|tsx)/i,
+    /\.spec\.(js|ts|jsx|tsx)/i
+  ];
+
+  for (const pattern of testFilePatterns) {
+    if (pattern.test(handoffStr)) {
+      testFilesFound = true;
+      break;
+    }
+  }
+
+  // Look for pre-implementation test run evidence
+  const preImplPatterns = [
+    /pre-implementation.*test.*run/i,
+    /TDD.*evidence/i,
+    /tests?\s+fail(ed|ing)/i,
+    /\d+\s+(tests?\s+)?failed,\s*0\s+passed/i,
+    /before.*implementation.*test/i
+  ];
+
+  for (const pattern of preImplPatterns) {
+    if (pattern.test(handoffStr)) {
+      preImplRunFound = true;
+      break;
+    }
+  }
+
+  // Also check SD metadata for TDD evidence
+  if (sd.metadata?.tdd_evidence) {
+    testFilesFound = true;
+    preImplRunFound = true;
+  }
+
+  // Build result
+  if (!testFilesFound) {
+    issues.push(
+      `No test files found in handoff deliverables. ` +
+      `Expected: test files matching *.test.{js,ts} or *.spec.{js,ts}. ` +
+      `Fix: Invoke TESTING sub-agent with "Mode: pre-implementation" before writing code, ` +
+      `then include test file paths in the handoff deliverables manifest.`
+    );
+  }
+
+  if (!preImplRunFound) {
+    issues.push(
+      `No pre-implementation test run reference found. ` +
+      `Expected: Evidence of tests failing before implementation (e.g., "3 failed, 0 passed"). ` +
+      `Fix: Run tests after generating skeletons but before writing production code, ` +
+      `and include the output in the handoff notes under "TDD Evidence".`
+    );
+  }
+
+  const isMandatory = tddLevel === 'mandatory';
+  const hasIssues = issues.length > 0;
+  // Mandatory: fail on missing evidence. Recommended: warn only.
+  const passed = isMandatory ? !hasIssues : true;
+
+  // Score: 100 if all evidence, 50 if partial, 0 if none
+  let score = 100;
+  if (!testFilesFound && !preImplRunFound) score = 0;
+  else if (!testFilesFound || !preImplRunFound) score = 50;
+
+  // For recommended level, move issues to warnings
+  if (!isMandatory && hasIssues) {
+    warnings.push(...issues.map(i => `[Recommended] ${i}`));
+    issues.length = 0;
+  }
+
+  return {
+    passed,
+    score,
+    max_score: 100,
+    issues,
+    warnings,
+    details: {
+      status: passed ? 'pass' : 'fail',
+      sd_type: sd.sd_type,
+      tdd_level: tddLevel,
+      test_files_found: testFilesFound,
+      pre_impl_run_found: preImplRunFound,
+      gate_enabled: true
+    }
+  };
+}
+
+/**
+ * Create TDD gate factory for use in handoff executors
+ * @returns {Object} Gate configuration
+ */
+export function createTddPreImplementationGate() {
+  return {
+    name: 'GATE_TDD_PRE_IMPLEMENTATION',
+    description: 'Checks for pre-implementation test evidence (opt-in)',
+    validate: validateTddPreImplementation,
+    enabled: isGateEnabled,
+    blocking: false // Non-blocking by default; only blocks when mandatory + enabled
+  };
+}


### PR DESCRIPTION
## Summary
- Add Plan Mode (`Shift+Tab+Tab`) as optional read-only guardrail during LEAD exploration phase
- Formalize TDD workflow in EXEC phase: pre-implementation TESTING sub-agent invocation to generate failing tests from PRD acceptance criteria, then implement to pass
- Add SD-type-to-TDD applicability mapping (mandatory for feature, recommended for enhancement/bugfix/refactor, exempt for fix/docs/infra)
- Enhance testing-agent with Pre-Implementation TDD mode for PRD-to-test conversion
- Create opt-in pre-implementation test validator gate (disabled by default, zero impact on existing 52 validators)

SD: SD-LEO-INFRA-PLAN-MODE-TDD-001
PRD: PRD-SD-LEO-INFRA-PLAN-MODE-TDD-001

## Test plan
- [ ] Verify all existing validators produce identical outcomes with default config (FR-6 gate disabled)
- [ ] Verify CLAUDE_LEAD.md Plan Mode section is clear and optional
- [ ] Verify CLAUDE_EXEC.md TDD workflow is additive (existing Dual Test Requirement unchanged)
- [ ] Verify testing-agent.partial compiles successfully via `npm run agents:compile`
- [ ] Verify tdd-pre-implementation-gate.js auto-passes when `TDD_PRE_IMPL_GATE_ENABLED` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)