### PR TITLE
feat: add sd.completed return path from LEO to Stage 19 progress

### DIFF
--- a/database/migrations/20260213_sd_completed_return_path.sql
+++ b/database/migrations/20260213_sd_completed_return_path.sql
@@ -1,0 +1,103 @@
+-- Migration: SD Completed Return Path
+-- SD: SD-EVA-FEAT-RETURN-PATH-001
+-- Purpose: Add sd.completed event type and trigger for LEO SD completion → Stage 19 progress sync
+
+-- Step 1: Expand event_type constraint to include sd.completed
+ALTER TABLE eva_events DROP CONSTRAINT IF EXISTS eva_events_event_type_check;
+ALTER TABLE eva_events ADD CONSTRAINT eva_events_event_type_check
+  CHECK (event_type IN (
+    -- Original types
+    'metric_update', 'health_change', 'decision_required',
+    'alert_triggered', 'automation_executed', 'status_change',
+    'milestone_reached', 'risk_detected', 'user_action',
+    'stage_processing_started', 'stage_processing_completed',
+    'stage_processing_started', 'stage_processing_failed',
+    -- Event bus handler types (SD-EVA-FEAT-EVENT-BUS-001)
+    'stage.completed', 'decision.submitted', 'gate.evaluated',
+    -- Return path type (SD-EVA-FEAT-RETURN-PATH-001)
+    'sd.completed'
+  ));
+
+-- Step 2: Create trigger function to emit sd.completed event
+-- Fires when strategic_directives_v2.status transitions to 'completed'
+-- Only emits for SDs that have venture metadata (created via lifecycle-sd-bridge)
+CREATE OR REPLACE FUNCTION fn_emit_sd_completed_event()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_venture_id UUID;
+  v_parent_sd_key TEXT;
+  v_parent_uuid UUID;
+  v_event_id UUID;
+  v_idempotency_key TEXT;
+BEGIN
+  -- Only fire on status transition to 'completed'
+  IF NEW.status != 'completed' THEN
+    RETURN NEW;
+  END IF;
+  IF OLD.status = 'completed' THEN
+    RETURN NEW; -- Already completed, no re-emit
+  END IF;
+
+  -- Extract venture_id from metadata (only lifecycle-bridge SDs have this)
+  v_venture_id := (NEW.metadata->>'venture_id')::UUID;
+
+  -- If no venture_id, this SD is not part of EVA lifecycle - skip
+  IF v_venture_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Find parent SD key if this is a child
+  IF NEW.parent_sd_id IS NOT NULL THEN
+    SELECT sd_key INTO v_parent_sd_key
+    FROM strategic_directives_v2
+    WHERE id = NEW.parent_sd_id;
+
+    v_parent_uuid := NEW.parent_sd_id;
+  END IF;
+
+  -- Build idempotency key
+  v_idempotency_key := 'sd.completed:' || NEW.sd_key || ':' || NEW.id;
+
+  -- Insert event into eva_events
+  INSERT INTO eva_events (
+    eva_venture_id,
+    event_type,
+    event_data,
+    idempotency_key,
+    processed,
+    retry_count
+  ) VALUES (
+    v_venture_id,
+    'sd.completed',
+    jsonb_build_object(
+      'sdKey', NEW.sd_key,
+      'sdId', NEW.id,
+      'ventureId', v_venture_id::TEXT,
+      'parentSdId', v_parent_uuid::TEXT,
+      'parentSdKey', v_parent_sd_key,
+      'sdType', NEW.sd_type,
+      'title', NEW.title,
+      'completedAt', NOW()::TEXT,
+      'progress', NEW.progress
+    ),
+    v_idempotency_key,
+    FALSE,
+    0
+  )
+  ON CONFLICT (idempotency_key) DO NOTHING; -- Idempotent
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 3: Create trigger on strategic_directives_v2
+DROP TRIGGER IF EXISTS tr_sd_completed_event ON strategic_directives_v2;
+CREATE TRIGGER tr_sd_completed_event
+  AFTER UPDATE OF status ON strategic_directives_v2
+  FOR EACH ROW
+  WHEN (NEW.status = 'completed' AND OLD.status IS DISTINCT FROM 'completed')
+  EXECUTE FUNCTION fn_emit_sd_completed_event();
+
+-- Step 4: Add index for venture_stage_work lookups by venture + stage
+CREATE INDEX IF NOT EXISTS idx_venture_stage_work_venture_stage
+  ON venture_stage_work (venture_id, lifecycle_stage);

--- a/lib/eva/event-bus/event-router.js
+++ b/lib/eva/event-bus/event-router.js
@@ -37,6 +37,11 @@ function validatePayload(eventType, payload) {
       }
       return { valid: true };
 
+    case 'sd.completed':
+      if (!payload.sdKey) return { valid: false, reason: 'Missing required sdKey' };
+      if (!payload.ventureId) return { valid: false, reason: 'Missing required ventureId' };
+      return { valid: true };
+
     default:
       return { valid: true };
   }

--- a/lib/eva/event-bus/handlers/sd-completed.js
+++ b/lib/eva/event-bus/handlers/sd-completed.js
@@ -1,0 +1,275 @@
+/**
+ * Handler: sd.completed
+ * SD: SD-EVA-FEAT-RETURN-PATH-001
+ *
+ * When a LEO SD completes, update Stage 19 (Build Execution) progress.
+ * Maps SD completion status to build task status and evaluates
+ * sprint completion when all SDs resolve.
+ *
+ * Handles three user stories:
+ * 1. SD completion triggers Stage 19 task status update (idempotent)
+ * 2. Partial completion updates progress percentage
+ * 3. Failed SDs create issues with severity classification
+ */
+
+// SD types that trigger HIGH severity when they fail
+const HIGH_SEVERITY_TYPES = ['security', 'fix', 'infrastructure'];
+
+/**
+ * Handle an sd.completed event.
+ *
+ * @param {object} payload - { sdKey, ventureId, parentSdId, parentSdKey, sdType, title }
+ * @param {object} context - { supabase, ventureId }
+ * @returns {Promise<{ outcome: string, tasksUpdated?: number, sprintComplete?: boolean }>}
+ */
+export async function handleSdCompleted(payload, context) {
+  const { supabase } = context;
+  const { sdKey, ventureId, parentSdId, parentSdKey } = payload;
+
+  if (!ventureId) {
+    const err = new Error('Missing ventureId in sd.completed payload');
+    err.retryable = false;
+    throw err;
+  }
+
+  if (!sdKey) {
+    const err = new Error('Missing sdKey in sd.completed payload');
+    err.retryable = false;
+    throw err;
+  }
+
+  // Only process child SDs (children of orchestrators map to sprint tasks)
+  if (!parentSdId) {
+    console.log(`[SdCompleted] SD ${sdKey} has no parent - orchestrator-level completion, skipping task update`);
+    return { outcome: 'no_parent', sdKey };
+  }
+
+  // Find the Stage 19 work record for this venture
+  const { data: stageWork, error: stageError } = await supabase
+    .from('venture_stage_work')
+    .select('id, stage_status, sd_id')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', 19)
+    .maybeSingle();
+
+  if (stageError) {
+    throw new Error(`Failed to query venture_stage_work: ${stageError.message}`);
+  }
+
+  if (!stageWork) {
+    console.log(`[SdCompleted] No Stage 19 record for venture ${ventureId} - creating one`);
+    const { error: insertError } = await supabase
+      .from('venture_stage_work')
+      .insert({
+        venture_id: ventureId,
+        lifecycle_stage: 19,
+        stage_status: 'in_progress',
+        work_type: 'sd_required',
+        sd_id: parentSdKey,
+        started_at: new Date().toISOString(),
+        health_score: 'green',
+        advisory_data: {
+          tasks: [],
+          issues: [],
+          total_tasks: 0,
+          completed_tasks: 0,
+          blocked_tasks: 0,
+          completion_pct: 0,
+          tasks_by_status: {},
+        },
+      });
+
+    if (insertError && !insertError.message.includes('duplicate')) {
+      throw new Error(`Failed to create Stage 19 record: ${insertError.message}`);
+    }
+  }
+
+  // Fetch all sibling SDs (children of the same parent) to assess sprint completion
+  const { data: siblings, error: sibError } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, status, sd_type, progress')
+    .eq('parent_sd_id', parentSdId)
+    .order('sd_key', { ascending: true });
+
+  if (sibError) {
+    throw new Error(`Failed to query sibling SDs: ${sibError.message}`);
+  }
+
+  // Build tasks array from sibling SD statuses
+  const tasks = (siblings || []).map(s => ({
+    name: s.title,
+    status: mapSdStatusToTaskStatus(s.status),
+    assignee: 'leo-protocol',
+    sprint_item_ref: s.sd_key,
+  }));
+
+  // Compute derived fields (matching stage-19 template)
+  const totalTasks = tasks.length;
+  const completedTasks = tasks.filter(t => t.status === 'done').length;
+  const blockedTasks = tasks.filter(t => t.status === 'blocked').length;
+  const completionPct = totalTasks > 0
+    ? Math.round((completedTasks / totalTasks) * 10000) / 100
+    : 0;
+
+  const tasksByStatus = {
+    todo: tasks.filter(t => t.status === 'todo').length,
+    in_progress: tasks.filter(t => t.status === 'in_progress').length,
+    done: completedTasks,
+    blocked: blockedTasks,
+  };
+
+  // All terminal = all SDs in done or blocked
+  const allTerminal = tasks.every(t => t.status === 'done' || t.status === 'blocked');
+  const sprintComplete = completedTasks === totalTasks && totalTasks > 0;
+
+  // Build advisory data
+  const advisoryData = {
+    tasks,
+    issues: [],
+    total_tasks: totalTasks,
+    completed_tasks: completedTasks,
+    blocked_tasks: blockedTasks,
+    completion_pct: completionPct,
+    tasks_by_status: tasksByStatus,
+    last_sd_completed: sdKey,
+    last_updated: new Date().toISOString(),
+  };
+
+  // Story 3: Failed SDs create issues with severity classification
+  const failedSiblings = (siblings || []).filter(s =>
+    s.status === 'cancelled' || s.status === 'on_hold',
+  );
+
+  if (failedSiblings.length > 0) {
+    advisoryData.issues = failedSiblings.map(s => ({
+      description: `SD ${s.sd_key} (${s.title}) has status: ${s.status}`,
+      severity: classifyIssueSeverity(s),
+      status: 'open',
+      sd_type: s.sd_type,
+    }));
+  }
+
+  // Determine stage status and health
+  let stageStatus = 'in_progress';
+  let healthScore = 'green';
+
+  if (sprintComplete) {
+    stageStatus = 'completed';
+  } else if (allTerminal && !sprintComplete) {
+    // All SDs resolved but some failed — sprint complete with issues
+    stageStatus = 'completed';
+  }
+
+  if (blockedTasks > 0) {
+    healthScore = 'yellow';
+  }
+  if (failedSiblings.some(s => classifyIssueSeverity(s) === 'high')) {
+    healthScore = 'red';
+  } else if (failedSiblings.length > 0) {
+    healthScore = 'yellow';
+  }
+
+  // Sprint completion evaluation
+  if (allTerminal && totalTasks > 0) {
+    advisoryData.sprint_evaluation = {
+      result: failedSiblings.length === 0 ? 'PASS' : 'FAIL',
+      total: totalTasks,
+      completed: completedTasks,
+      failed: failedSiblings.length,
+      high_severity_failures: failedSiblings.filter(s => classifyIssueSeverity(s) === 'high').length,
+      evaluated_at: new Date().toISOString(),
+    };
+  }
+
+  // Update venture_stage_work
+  const updatePayload = {
+    stage_status: stageStatus,
+    health_score: healthScore,
+    advisory_data: advisoryData,
+  };
+
+  if (stageStatus === 'completed') {
+    updatePayload.completed_at = new Date().toISOString();
+  }
+
+  const { error: updateError } = await supabase
+    .from('venture_stage_work')
+    .update(updatePayload)
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', 19);
+
+  if (updateError) {
+    throw new Error(`Failed to update Stage 19: ${updateError.message}`);
+  }
+
+  // Record in audit log
+  await supabase.from('eva_audit_log').insert({
+    eva_venture_id: ventureId,
+    action_type: 'sd_completion_synced',
+    action_data: {
+      sdKey,
+      parentSdKey,
+      completionPct,
+      totalTasks,
+      completedTasks,
+      sprintComplete: stageStatus === 'completed',
+      issueCount: failedSiblings.length,
+      syncedAt: new Date().toISOString(),
+    },
+  }).then(() => {}).catch(() => {}); // Best-effort audit logging
+
+  console.log(
+    `[SdCompleted] Updated Stage 19 for venture ${ventureId}: ` +
+    `${completedTasks}/${totalTasks} tasks done (${completionPct}%)` +
+    (stageStatus === 'completed' ? ' - SPRINT COMPLETE' : ''),
+  );
+
+  return {
+    outcome: stageStatus === 'completed' ? 'sprint_complete' : 'task_updated',
+    sdKey,
+    tasksUpdated: 1,
+    totalTasks,
+    completedTasks,
+    completionPct,
+    sprintComplete: stageStatus === 'completed',
+    issueCount: failedSiblings.length,
+  };
+}
+
+/**
+ * Classify issue severity based on SD type.
+ * HIGH for security/infrastructure/fix types, MEDIUM for others.
+ *
+ * @param {object} sd - { sd_type, status }
+ * @returns {'high'|'medium'}
+ */
+function classifyIssueSeverity(sd) {
+  if (HIGH_SEVERITY_TYPES.includes(sd.sd_type)) return 'high';
+  if (sd.status === 'cancelled') return 'high';
+  return 'medium';
+}
+
+/**
+ * Map strategic_directives_v2.status to Stage 19 task status.
+ *
+ * @param {string} sdStatus
+ * @returns {'todo'|'in_progress'|'done'|'blocked'}
+ */
+function mapSdStatusToTaskStatus(sdStatus) {
+  switch (sdStatus) {
+    case 'completed':
+      return 'done';
+    case 'draft':
+    case 'lead_review':
+      return 'todo';
+    case 'plan_active':
+    case 'exec_active':
+    case 'in_progress':
+      return 'in_progress';
+    case 'on_hold':
+    case 'cancelled':
+      return 'blocked';
+    default:
+      return 'todo';
+  }
+}

--- a/lib/eva/event-bus/index.js
+++ b/lib/eva/event-bus/index.js
@@ -11,6 +11,7 @@ import { processEvent, replayDLQEntry } from './event-router.js';
 import { handleStageCompleted } from './handlers/stage-completed.js';
 import { handleDecisionSubmitted } from './handlers/decision-submitted.js';
 import { handleGateEvaluated } from './handlers/gate-evaluated.js';
+import { handleSdCompleted } from './handlers/sd-completed.js';
 
 let _initialized = false;
 
@@ -70,6 +71,12 @@ export async function initializeEventBus(supabase) {
 
   registerHandler('gate.evaluated', handleGateEvaluated, {
     name: 'GateEvaluatedHandler',
+    retryable: true,
+    maxRetries: 3,
+  });
+
+  registerHandler('sd.completed', handleSdCompleted, {
+    name: 'SdCompletedHandler',
     retryable: true,
     maxRetries: 3,
   });


### PR DESCRIPTION
## Summary
- Add database trigger (`fn_emit_sd_completed_event`) that emits `sd.completed` events when LEO SDs transition to completed status, closing the loop from LEO back to EVA lifecycle
- Add event bus handler (`handleSdCompleted`) that syncs SD completion to Stage 19 Build Execution, mapping sibling SD statuses to sprint tasks with progress tracking
- Register handler in event bus with retry/DLQ/idempotency support and add payload validation for `sd.completed` events
- Migration adds composite index on `venture_stage_work(venture_id, lifecycle_stage)` for efficient lookups

## Test plan
- [x] All 14 integration tests pass (11 existing + 3 new sd.completed tests)
- [x] Migration executed and validated (CHECK constraint, trigger function, trigger, index)
- [x] Orchestrator-level completions correctly skipped (no parent → no task update)
- [x] Payload validation rejects missing sdKey and ventureId
- [x] Handler maps SD statuses to task statuses matching Stage 19 template schema

SD: SD-EVA-FEAT-RETURN-PATH-001
Parent: SD-EVA-ORCH-PHASE-A-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)