### PR TITLE
fix: resolve sd:start claim failures from view schema drift and error masking

### DIFF
--- a/database/migrations/20260213_restore_v_active_sessions_columns.sql
+++ b/database/migrations/20260213_restore_v_active_sessions_columns.sql
@@ -1,0 +1,111 @@
+-- ============================================================
+-- Migration: Restore v_active_sessions columns lost in ship-safety migration
+-- RCA: sd-start claim failures due to schema drift
+-- Date: 2026-02-13
+-- Purpose: Restore sd_title, track, heartbeat_age_minutes, and other
+--          columns that were removed when the view was recreated in
+--          20260211_ship_safety_branch_tracking_v2.sql.
+--          Also adds current_branch which that migration intended to add.
+-- ============================================================
+
+-- Drop and recreate with FULL column set (original + current_branch)
+DROP VIEW IF EXISTS v_active_sessions CASCADE;
+
+CREATE VIEW v_active_sessions AS
+SELECT
+  cs.id,
+  cs.session_id,
+  cs.sd_id,
+  sd.title as sd_title,
+  cs.track,
+  cs.tty,
+  cs.pid,
+  cs.hostname,
+  cs.codebase,
+  cs.current_branch,
+  cs.machine_id,
+  cs.terminal_id,
+  cs.terminal_identity,
+  cs.claimed_at,
+  cs.heartbeat_at,
+  cs.status,
+  cs.released_reason,
+  cs.released_at,
+  cs.stale_reason,
+  cs.stale_at,
+  cs.metadata,
+  cs.created_at,
+  EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) as heartbeat_age_seconds,
+  EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 60 as heartbeat_age_minutes,
+  GREATEST(0, 300 - EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at))) as seconds_until_stale,
+  CASE
+    WHEN cs.status = 'released' THEN 'released'
+    WHEN cs.status = 'stale' THEN 'stale'
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) > 300 THEN 'stale'
+    WHEN cs.sd_id IS NULL THEN 'idle'
+    ELSE 'active'
+  END as computed_status,
+  CASE
+    WHEN cs.claimed_at IS NOT NULL
+    THEN EXTRACT(EPOCH FROM (NOW() - cs.claimed_at)) / 60
+    ELSE NULL
+  END as claim_duration_minutes,
+  CASE
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 60 THEN
+      EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at))::int || 's ago'
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 3600 THEN
+      (EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 60)::int || 'm ago'
+    ELSE
+      (EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 3600)::int || 'h ago'
+  END as heartbeat_age_human
+FROM claude_sessions cs
+LEFT JOIN strategic_directives_v2 sd ON cs.sd_id = sd.sd_key
+WHERE cs.status NOT IN ('released')
+ORDER BY cs.track NULLS LAST, cs.claimed_at DESC;
+
+COMMENT ON VIEW v_active_sessions IS
+  'Active sessions with SD title, terminal identity, staleness info, branch tracking, and lifecycle timestamps. Restored from 20260201 + current_branch from 20260211.';
+
+-- Verification
+DO $$
+BEGIN
+  -- Verify sd_title column exists
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v_active_sessions' AND column_name = 'sd_title'
+  ) THEN
+    RAISE NOTICE 'SUCCESS: v_active_sessions.sd_title column restored';
+  ELSE
+    RAISE WARNING 'FAILED: v_active_sessions.sd_title not found';
+  END IF;
+
+  -- Verify track column exists
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v_active_sessions' AND column_name = 'track'
+  ) THEN
+    RAISE NOTICE 'SUCCESS: v_active_sessions.track column restored';
+  ELSE
+    RAISE WARNING 'FAILED: v_active_sessions.track not found';
+  END IF;
+
+  -- Verify heartbeat_age_minutes column exists
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v_active_sessions' AND column_name = 'heartbeat_age_minutes'
+  ) THEN
+    RAISE NOTICE 'SUCCESS: v_active_sessions.heartbeat_age_minutes column restored';
+  ELSE
+    RAISE WARNING 'FAILED: v_active_sessions.heartbeat_age_minutes not found';
+  END IF;
+
+  -- Verify current_branch column exists (from ship-safety migration)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'v_active_sessions' AND column_name = 'current_branch'
+  ) THEN
+    RAISE NOTICE 'SUCCESS: v_active_sessions.current_branch column present';
+  ELSE
+    RAISE WARNING 'FAILED: v_active_sessions.current_branch not found';
+  END IF;
+END $$;

--- a/lib/session-conflict-checker.mjs
+++ b/lib/session-conflict-checker.mjs
@@ -47,7 +47,7 @@ export async function isSDClaimed(sdId, excludeSessionId = null) {
 
   if (error) {
     console.error('Error checking SD claim:', error.message);
-    return { claimed: false, error: error.message };
+    return { claimed: null, queryFailed: true, error: error.message };
   }
 
   const claims = data?.filter(c => c.session_id !== excludeSessionId) || [];
@@ -166,7 +166,7 @@ export async function isTrackOccupied(track, excludeSessionId = null) {
 
   if (error) {
     console.error('Error checking track occupancy:', error.message);
-    return { occupied: false, error: error.message };
+    return { occupied: null, queryFailed: true, error: error.message };
   }
 
   const occupiers = data?.filter(c => c.session_id !== excludeSessionId) || [];
@@ -201,6 +201,14 @@ export async function canClaimSd(sdId, sessionId) {
 
   // 1. Check if SD is already claimed
   const claimStatus = await isSDClaimed(sdId, sessionId);
+  if (claimStatus.queryFailed) {
+    result.canClaim = false;
+    result.blockingReasons.push({
+      type: 'query_failed',
+      message: `Could not verify claim status: ${claimStatus.error}. Database view may be out of sync.`
+    });
+    return result;
+  }
   if (claimStatus.claimed) {
     result.canClaim = false;
     result.blockingReasons.push({

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -277,7 +277,14 @@ export async function getOrCreateSession() {
       }, { onConflict: 'session_id' });
 
     if (upsertError) {
-      console.error('Warning: Could not register session in database:', upsertError.message);
+      console.error('Error: Could not register session in database:', upsertError.message);
+      console.error('Session will not be able to claim SDs without a database record.');
+      // Clean up local file since DB record doesn't exist
+      try {
+        const filePath = getSessionFilePath(sessionId);
+        if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+      } catch { /* best-effort cleanup */ }
+      return null;
     }
   } else if (dbResult?.auto_released) {
     // Log auto-release event for observability (FR-5)

--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -33,6 +33,11 @@ import os from 'os';
 export function getTerminalId() {
   try {
     if (process.platform === 'win32') {
+      // Use PPID to differentiate concurrent Claude Code instances.
+      // Windows console session ID is the same for all processes in the same
+      // desktop session, causing unique constraint collisions when multiple
+      // Claude instances run concurrently. PPID is unique per parent process.
+      const ppid = process.ppid || process.pid;
       try {
         const cmd = `powershell -Command "(Get-Process -Id ${process.pid}).SessionId"`;
         const sessionId = execSync(cmd, {
@@ -40,12 +45,12 @@ export function getTerminalId() {
           stdio: ['pipe', 'pipe', 'ignore']
         }).trim();
         if (sessionId && /^\d+$/.test(sessionId)) {
-          return `win-session-${sessionId}`;
+          return `win-session-${sessionId}-ppid-${ppid}`;
         }
       } catch {
         // PowerShell unavailable or failed - fall through to ppid
       }
-      return `win-ppid-${process.ppid || process.pid}`;
+      return `win-ppid-${ppid}`;
     }
     // Unix: Use TTY device path, hashed for cleaner ID
     const tty = execSync('tty', {

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -110,6 +110,13 @@ async function main() {
   // 3. Check current claim status
   const claimStatus = await isSDClaimed(effectiveId, session.session_id);
 
+  if (claimStatus.queryFailed) {
+    console.log(`\n${colors.red}Error checking SD claim: ${claimStatus.error}${colors.reset}`);
+    console.log(`\n${colors.yellow}This may indicate a database schema issue.${colors.reset}`);
+    console.log(`Try running: node scripts/run-sql-migration.js database/migrations/20260213_restore_v_active_sessions_columns.sql`);
+    process.exit(1);
+  }
+
   if (claimStatus.claimed && claimStatus.claimedBy !== session.session_id) {
     // FR-2: Enhanced output showing owner session details and heartbeat age
     console.log(`\n${colors.red}❌ SD is already claimed by another session${colors.reset}`);


### PR DESCRIPTION
## Summary
- **Restore v_active_sessions view** — Migration 20260211 recreated the view without `sd_title`, `track`, `heartbeat_age_minutes` columns. New migration restores all 28 columns including `current_branch`.
- **Fix error masking in isSDClaimed()** — Query failures now return `{queryFailed: true}` instead of `{claimed: false}`, preventing silent cascade to FK violations.
- **Fix getOrCreateSession() silent failure** — Returns `null` when both RPC and fallback DB writes fail, so sd-start.js can abort cleanly.
- **Fix Windows terminal_identity collisions** — PPID now included in terminal ID to differentiate concurrent Claude instances sharing the same desktop session.

## Root Cause
Migration `20260211_ship_safety_branch_tracking_v2.sql` used `DROP VIEW ... CASCADE` + recreate with reduced columns, breaking `session-conflict-checker.mjs` which still selected the removed columns. The error was masked (returned as "not claimed"), allowing `claimSD()` to proceed with a phantom session ID → FK violation.

## Test plan
- [x] `npm run sd:start SD-EVA-ORCH-TEMPLATE-GAPFILL-001` succeeds (verified)
- [x] Migration executed and verified (all 4 columns confirmed present)
- [ ] Concurrent sessions can each claim different SDs without terminal_identity collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)