### PR TITLE
fix: revert PPID from terminal identity to fix handoff gate

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -25,6 +25,10 @@ import os from 'os';
  *
  * On Windows: Uses PowerShell to query the console session ID, which is
  * stable across all Node.js subprocesses spawned from the same terminal.
+ * IMPORTANT: Do NOT include PPID - it changes per subprocess, breaking
+ * the multi-session claim gate's "same conversation" detection.
+ * The create_or_replace_session RPC handles concurrent instance collisions
+ * by auto-releasing the previous session with the same terminal_identity.
  *
  * On Unix: Uses the TTY device path, hashed for cleaner IDs.
  *
@@ -33,11 +37,10 @@ import os from 'os';
 export function getTerminalId() {
   try {
     if (process.platform === 'win32') {
-      // Use PPID to differentiate concurrent Claude Code instances.
-      // Windows console session ID is the same for all processes in the same
-      // desktop session, causing unique constraint collisions when multiple
-      // Claude instances run concurrently. PPID is unique per parent process.
-      const ppid = process.ppid || process.pid;
+      // Windows console session ID: stable across all Node.js subprocesses
+      // in the same desktop session. Two concurrent Claude Code instances
+      // share the same session ID, but create_or_replace_session RPC handles
+      // this by auto-releasing the previous session.
       try {
         const cmd = `powershell -Command "(Get-Process -Id ${process.pid}).SessionId"`;
         const sessionId = execSync(cmd, {
@@ -45,12 +48,12 @@ export function getTerminalId() {
           stdio: ['pipe', 'pipe', 'ignore']
         }).trim();
         if (sessionId && /^\d+$/.test(sessionId)) {
-          return `win-session-${sessionId}-ppid-${ppid}`;
+          return `win-session-${sessionId}`;
         }
       } catch {
-        // PowerShell unavailable or failed - fall through to ppid
+        // PowerShell unavailable or failed - fall through to pid fallback
       }
-      return `win-ppid-${ppid}`;
+      return `win-pid-${process.pid}`;
     }
     // Unix: Use TTY device path, hashed for cleaner ID
     const tty = execSync('tty', {


### PR DESCRIPTION
## Summary
- Reverts PPID inclusion in Windows terminal identity (from PR #1144)
- PPID changes per Node subprocess, causing handoff.js and sd-start.js to appear as different conversations
- This triggered false GATE_MULTI_SESSION_CLAIM_CONFLICT blocks on all handoff operations
- Concurrent instance collisions are handled by `create_or_replace_session` RPC instead

## Test plan
- [x] Verified `sd:start` + `handoff.js` now share same terminal_id (`win-session-1`)
- [x] Verified LEAD-TO-PLAN handoff passes claim conflict gate
- [x] Verified PLAN-TO-EXEC handoff passes claim conflict gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)