### PR TITLE
fix: resolve sd_claims FK violation from ghost sessions

### DIFF
--- a/database/migrations/20260213_fix_sd_claims_release_reason_constraint.sql
+++ b/database/migrations/20260213_fix_sd_claims_release_reason_constraint.sql
@@ -1,0 +1,11 @@
+-- Fix sd_claims.release_reason CHECK constraint
+-- RCA: create_or_replace_session RPC uses 'AUTO_REPLACED' and cleanup_stale_sessions
+-- uses 'STALE_CLEANUP', but the CHECK constraint only allows 5 values.
+-- This causes the RPC to fail silently, creating ghost sessions that trigger FK violations.
+
+-- Drop the existing constraint
+ALTER TABLE sd_claims DROP CONSTRAINT IF EXISTS sd_claims_release_reason_check;
+
+-- Re-create with all valid values including those used by RPC functions
+ALTER TABLE sd_claims ADD CONSTRAINT sd_claims_release_reason_check
+  CHECK (release_reason IN ('completed', 'timeout', 'manual', 'conflict', 'session_ended', 'AUTO_REPLACED', 'STALE_CLEANUP'));

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -243,11 +243,9 @@ export async function getOrCreateSession() {
     metadata
   };
 
-  // Save to local file
-  ensureSessionDir();
-  fs.writeFileSync(getSessionFilePath(sessionId), JSON.stringify(sessionData, null, 2));
-
   // SD-LEO-INFRA-ISL-001: Use create_or_replace_session for atomic auto-release
+  // NOTE: Local file written AFTER successful DB registration (not before)
+  // to prevent ghost sessions where local file exists but DB record doesn't.
   const { data: dbResult, error } = await supabase.rpc('create_or_replace_session', {
     p_session_id: sessionId,
     p_machine_id: machineId,
@@ -279,11 +277,30 @@ export async function getOrCreateSession() {
     if (upsertError) {
       console.error('Error: Could not register session in database:', upsertError.message);
       console.error('Session will not be able to claim SDs without a database record.');
-      // Clean up local file since DB record doesn't exist
-      try {
-        const filePath = getSessionFilePath(sessionId);
-        if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
-      } catch { /* best-effort cleanup */ }
+      return null;
+    }
+  } else if (dbResult && dbResult.success === false) {
+    // RCA-SD-CLAIMS-FK-001: RPC returned application-level failure
+    // (e.g., CHECK constraint violation on sd_claims.release_reason).
+    // Supabase returns {data: {success: false}, error: null} in this case.
+    console.warn('Warning: create_or_replace_session returned failure:', dbResult.message || dbResult.error || 'unknown');
+    console.warn('Falling back to direct upsert...');
+    const { error: upsertError } = await supabase
+      .from('claude_sessions')
+      .upsert({
+        session_id: sessionId,
+        machine_id: machineId,
+        terminal_id: terminalId,
+        tty,
+        pid,
+        hostname,
+        codebase,
+        status: 'idle',
+        metadata
+      }, { onConflict: 'session_id' });
+
+    if (upsertError) {
+      console.error('Error: Fallback upsert also failed:', upsertError.message);
       return null;
     }
   } else if (dbResult?.auto_released) {
@@ -315,6 +332,19 @@ export async function getOrCreateSession() {
       p_metadata: { codebase, hostname }
     });
   } catch { /* telemetry - silent fail */ }
+
+  // RCA-SD-CLAIMS-FK-001: Write local file AFTER successful DB registration
+  // to prevent ghost sessions where local file exists but DB record doesn't.
+  try {
+    const sessDir = path.dirname(getSessionFilePath(sessionId));
+    if (!fs.existsSync(sessDir)) {
+      fs.mkdirSync(sessDir, { recursive: true });
+    }
+    fs.writeFileSync(getSessionFilePath(sessionId), JSON.stringify(sessionData, null, 2));
+  } catch (writeErr) {
+    console.warn('Warning: Could not write local session file:', writeErr.message);
+    // Non-fatal: DB record exists, local file is optional
+  }
 
   return sessionData;
 }

--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -23,24 +23,28 @@ import os from 'os';
 /**
  * Get stable terminal identifier for session coordination.
  *
- * On Windows: Uses PowerShell to query the console session ID, which is
- * stable across all Node.js subprocesses spawned from the same terminal.
- * IMPORTANT: Do NOT include PPID - it changes per subprocess, breaking
- * the multi-session claim gate's "same conversation" detection.
- * The create_or_replace_session RPC handles concurrent instance collisions
- * by auto-releasing the previous session with the same terminal_identity.
+ * On Windows: Uses CLAUDE_CODE_SSE_PORT env var to uniquely identify each
+ * Claude Code conversation. This is stable across all subprocesses spawned
+ * by the same Claude Code instance, yet unique per conversation.
+ * Falls back to Windows console session ID if env var is unavailable.
  *
  * On Unix: Uses the TTY device path, hashed for cleaner IDs.
  *
- * @returns {string} Terminal identifier (e.g., "win-session-1" or "tty-a4b3c2d1")
+ * @returns {string} Terminal identifier (e.g., "win-cc-55188" or "tty-a4b3c2d1")
  */
 export function getTerminalId() {
   try {
     if (process.platform === 'win32') {
-      // Windows console session ID: stable across all Node.js subprocesses
-      // in the same desktop session. Two concurrent Claude Code instances
-      // share the same session ID, but create_or_replace_session RPC handles
-      // this by auto-releasing the previous session.
+      // CLAUDE_CODE_SSE_PORT: Set by Claude Code, unique per conversation,
+      // inherited by all subprocesses. This is the ideal identifier because:
+      // - Stable across subprocesses (unlike PPID which changes per shell)
+      // - Unique per conversation (unlike Windows session ID which is shared)
+      const ssePort = process.env.CLAUDE_CODE_SSE_PORT;
+      if (ssePort) {
+        return `win-cc-${ssePort}`;
+      }
+      // Fallback: Windows console session ID (shared across all instances
+      // in the same desktop session - less ideal for multi-instance)
       try {
         const cmd = `powershell -Command "(Get-Process -Id ${process.pid}).SessionId"`;
         const sessionId = execSync(cmd, {
@@ -51,7 +55,7 @@ export function getTerminalId() {
           return `win-session-${sessionId}`;
         }
       } catch {
-        // PowerShell unavailable or failed - fall through to pid fallback
+        // PowerShell unavailable or failed
       }
       return `win-pid-${process.pid}`;
     }


### PR DESCRIPTION
## Summary
- Fix `sd_claims_session_id_fkey` FK violation caused by ghost sessions (local file exists, no DB record)
- Root cause: `sd_claims.release_reason` CHECK constraint missing `AUTO_REPLACED` value, causing `create_or_replace_session` RPC to fail silently
- `getOrCreateSession()` only checked HTTP-level errors, not application-level `{success: false}`
- Local session file was written BEFORE DB registration, creating ghost sessions on RPC failure

## Changes
- **Migration**: Add `AUTO_REPLACED` and `STALE_CLEANUP` to `sd_claims.release_reason` CHECK constraint
- **session-manager.mjs**: Check `dbResult.success === false` with fallback to direct upsert; write local file AFTER DB success
- **terminal-identity.js**: Use `CLAUDE_CODE_SSE_PORT` for per-conversation identity on Windows

## Test plan
- [x] Migration executed successfully (2,406 existing rows verified compatible)
- [x] `npm run sd:start SD-EVA-FEAT-TEMPLATES-TRUTH-001` succeeds without FK violation
- [x] Smoke tests pass (15/15)

RCA: RCA-SD-CLAIMS-FK-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)