### PR TITLE
feat(SD-EVA-FEAT-TEMPLATES-TRUTH-001): Stage Templates THE TRUTH Stages 1-5 v2.0.0

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/index.js
+++ b/lib/eva/stage-templates/analysis-steps/index.js
@@ -1,0 +1,33 @@
+/**
+ * Analysis Steps Registry - Stages 1-5 (THE TRUTH)
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
+ *
+ * Provides the active analysis layer for stage templates.
+ * Each analysisStep consumes upstream artifacts and generates
+ * structured output via LLM calls.
+ *
+ * @module lib/eva/stage-templates/analysis-steps
+ */
+
+export { analyzeStage01 } from './stage-01-hydration.js';
+export { analyzeStage02 } from './stage-02-multi-persona.js';
+export { analyzeStage03 } from './stage-03-hybrid-scoring.js';
+export { analyzeStage04 } from './stage-04-competitive-landscape.js';
+export { analyzeStage05 } from './stage-05-financial-model.js';
+
+/**
+ * Get the analysis step function for a given stage number (1-5).
+ * @param {number} stageNumber
+ * @returns {Promise<Function|null>}
+ */
+export async function getAnalysisStep(stageNumber) {
+  const loaders = {
+    1: () => import('./stage-01-hydration.js').then(m => m.analyzeStage01),
+    2: () => import('./stage-02-multi-persona.js').then(m => m.analyzeStage02),
+    3: () => import('./stage-03-hybrid-scoring.js').then(m => m.analyzeStage03),
+    4: () => import('./stage-04-competitive-landscape.js').then(m => m.analyzeStage04),
+    5: () => import('./stage-05-financial-model.js').then(m => m.analyzeStage05),
+  };
+  const loader = loaders[stageNumber];
+  return loader ? loader() : null;
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-01-hydration.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-01-hydration.js
@@ -1,0 +1,94 @@
+/**
+ * Stage 01 Analysis Step - Hydration from Stage 0 Synthesis
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
+ *
+ * Consumes Stage 0 synthesis output and hydrates into a structured
+ * Draft Idea with description, value proposition, target market,
+ * and a required problemStatement field.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-01-hydration
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const SYSTEM_PROMPT = `You are EVA's Stage 1 Hydration Engine. Your job is to transform a raw venture synthesis from Stage 0 into a structured draft idea.
+
+You MUST output valid JSON with exactly these fields:
+- description (string, min 50 chars): A clear description of the venture idea
+- valueProp (string, min 20 chars): The core value proposition
+- targetMarket (string, min 10 chars): Who this is for
+- problemStatement (string, min 30 chars): The specific problem being solved
+
+Rules:
+- Use the synthesis data to ground every field
+- problemStatement is REQUIRED and must be specific, not generic
+- If the synthesis includes a reframed problem, prefer that over the raw intent
+- Keep language crisp and actionable
+- Do NOT invent claims not supported by the synthesis`;
+
+/**
+ * Hydrate a venture from Stage 0 synthesis into Stage 1 Draft Idea.
+ *
+ * @param {Object} params
+ * @param {Object} params.synthesis - Stage 0 synthesis output
+ * @param {string} params.synthesis.name - Venture name
+ * @param {string} params.synthesis.problem_statement - Problem statement
+ * @param {string} params.synthesis.solution - Proposed solution
+ * @param {string} params.synthesis.target_market - Target market
+ * @param {string} [params.synthesis.raw_chairman_intent] - Original intent
+ * @param {Object} [params.synthesis.metadata] - Synthesis metadata
+ * @returns {Promise<{description: string, valueProp: string, targetMarket: string, problemStatement: string}>}
+ */
+export async function analyzeStage01({ synthesis }) {
+  if (!synthesis) {
+    throw new Error('Stage 01 hydration requires Stage 0 synthesis output');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const userPrompt = `Hydrate this venture synthesis into a structured draft idea.
+
+Venture Name: ${synthesis.name || 'Unknown'}
+Problem Statement: ${synthesis.problem_statement || synthesis.raw_chairman_intent || 'Not provided'}
+Solution: ${synthesis.solution || 'Not provided'}
+Target Market: ${synthesis.target_market || 'Not provided'}
+Origin: ${synthesis.origin_type || 'Unknown'}
+${synthesis.metadata?.synthesis?.problem_reframing ? `Reframed Problem: ${JSON.stringify(synthesis.metadata.synthesis.problem_reframing)}` : ''}
+${synthesis.metadata?.synthesis?.moat_architecture ? `Moat: ${JSON.stringify(synthesis.metadata.synthesis.moat_architecture)}` : ''}
+${synthesis.metadata?.synthesis?.archetypes ? `Archetype: ${JSON.stringify(synthesis.metadata.synthesis.archetypes)}` : ''}
+
+Output ONLY valid JSON matching the required schema.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Validate minimum field requirements
+  if (!parsed.problemStatement || parsed.problemStatement.length < 30) {
+    throw new Error('Stage 01 hydration failed: problemStatement is required (min 30 chars)');
+  }
+  if (!parsed.description || parsed.description.length < 50) {
+    throw new Error('Stage 01 hydration failed: description must be at least 50 chars');
+  }
+
+  return {
+    description: parsed.description,
+    valueProp: parsed.valueProp,
+    targetMarket: parsed.targetMarket,
+    problemStatement: parsed.problemStatement,
+  };
+}
+
+/**
+ * Parse JSON from an LLM response, handling markdown fences.
+ * @param {string} text
+ * @returns {Object}
+ */
+function parseJSON(text) {
+  // Strip markdown code fences if present
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse LLM response as JSON: ${cleaned.substring(0, 200)}`);
+  }
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
@@ -1,0 +1,151 @@
+/**
+ * Stage 02 Analysis Step - Multi-Persona Analysis (MoA)
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
+ *
+ * Runs a Mixture-of-Agents multi-persona analysis on the Stage 1
+ * draft idea. Each persona evaluates the venture from a different
+ * perspective and assigns a 0-100 integer score. The six persona
+ * scores align to Stage 3's kill-gate metrics.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-02-multi-persona
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+/**
+ * Persona definitions aligned to Stage 3 kill-gate metrics.
+ * Each persona maps 1:1 to a Stage 3 metric.
+ */
+const PERSONAS = [
+  {
+    id: 'market-strategist',
+    name: 'Market Strategist',
+    stage3Metric: 'marketFit',
+    focus: 'market size, timing, product-market fit signals',
+  },
+  {
+    id: 'customer-advocate',
+    name: 'Customer Advocate',
+    stage3Metric: 'customerNeed',
+    focus: 'pain severity, willingness to pay, frequency of need',
+  },
+  {
+    id: 'growth-hacker',
+    name: 'Growth Hacker',
+    stage3Metric: 'momentum',
+    focus: 'virality potential, distribution channels, early traction signals',
+  },
+  {
+    id: 'revenue-analyst',
+    name: 'Revenue Analyst',
+    stage3Metric: 'revenuePotential',
+    focus: 'monetization model, pricing power, revenue ceiling',
+  },
+  {
+    id: 'moat-architect',
+    name: 'Moat Architect',
+    stage3Metric: 'competitiveBarrier',
+    focus: 'defensibility, network effects, switching costs, IP',
+  },
+  {
+    id: 'ops-realist',
+    name: 'Operations Realist',
+    stage3Metric: 'executionFeasibility',
+    focus: 'technical complexity, resource requirements, time to market',
+  },
+];
+
+const SYSTEM_PROMPT = `You are an AI venture analyst running a multi-persona evaluation. You will evaluate a venture idea from a specific perspective.
+
+You MUST output valid JSON with exactly these fields:
+- model (string): The persona identifier
+- summary (string, min 20 chars): Your assessment summary
+- strengths (string[]): At least 1 strength
+- risks (string[]): At least 1 risk
+- score (integer 0-100): Your honest score from this perspective
+
+Rules:
+- Be brutally honest - do not inflate scores
+- Score 0-30: fundamentally flawed from this perspective
+- Score 31-50: significant concerns that could be fatal
+- Score 51-70: viable but with notable gaps
+- Score 71-85: strong with minor concerns
+- Score 86-100: exceptional (rare, requires strong evidence)
+- Ground every claim in the provided data`;
+
+/**
+ * Run multi-persona analysis on a Stage 1 draft idea.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 output (description, valueProp, targetMarket, problemStatement)
+ * @param {string} [params.ventureName] - Venture name for context
+ * @returns {Promise<{critiques: Array, compositeScore: number}>}
+ */
+export async function analyzeStage02({ stage1Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 02 requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const ventureContext = `Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Value Proposition: ${stage1Data.valueProp}
+Target Market: ${stage1Data.targetMarket}
+Problem Statement: ${stage1Data.problemStatement || 'Not specified'}`;
+
+  // Run all personas (sequentially to avoid rate limits)
+  const critiques = [];
+  for (const persona of PERSONAS) {
+    const userPrompt = `Evaluate this venture as the "${persona.name}" persona.
+Your focus area: ${persona.focus}
+
+${ventureContext}
+
+Output ONLY valid JSON.`;
+
+    const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+    const parsed = parseJSON(response);
+
+    critiques.push({
+      model: persona.id,
+      summary: parsed.summary || `${persona.name} analysis`,
+      strengths: Array.isArray(parsed.strengths) ? parsed.strengths : [parsed.strengths || 'N/A'],
+      risks: Array.isArray(parsed.risks) ? parsed.risks : [parsed.risks || 'N/A'],
+      score: clampScore(parsed.score),
+    });
+  }
+
+  // Compute composite score (average, rounded)
+  const sum = critiques.reduce((acc, c) => acc + c.score, 0);
+  const compositeScore = Math.round(sum / critiques.length);
+
+  return { critiques, compositeScore };
+}
+
+/**
+ * Clamp a score to integer 0-100.
+ * @param {*} score
+ * @returns {number}
+ */
+function clampScore(score) {
+  const n = Number(score);
+  if (!Number.isFinite(n)) return 50; // default to neutral if parsing fails
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+/**
+ * Parse JSON from an LLM response, handling markdown fences.
+ * @param {string} text
+ * @returns {Object}
+ */
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse persona response as JSON: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { PERSONAS };

--- a/lib/eva/stage-templates/analysis-steps/stage-03-hybrid-scoring.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-03-hybrid-scoring.js
@@ -1,0 +1,174 @@
+/**
+ * Stage 03 Analysis Step - Hybrid Scoring (50% Deterministic + 50% AI)
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
+ *
+ * Combines deterministic scores from Stage 2 persona pre-scores (50%)
+ * with an independent AI assessment (50%) to produce the 6 kill-gate
+ * metrics. Kill gate fires when overallScore < 40 OR any metric < 40.
+ *
+ * The SD specifies threshold above 40 (not 70 as in the original template).
+ * This analysis step uses the updated threshold.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-03-hybrid-scoring
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { METRICS } from '../stage-03.js';
+
+const KILL_THRESHOLD = 40;
+
+const SYSTEM_PROMPT = `You are EVA's independent validation engine for venture scoring. You will assess a venture across 6 dimensions, independent of prior persona scores.
+
+You MUST output valid JSON with exactly these fields:
+- marketFit (integer 0-100)
+- customerNeed (integer 0-100)
+- momentum (integer 0-100)
+- revenuePotential (integer 0-100)
+- competitiveBarrier (integer 0-100)
+- executionFeasibility (integer 0-100)
+- reasoning (object with one string per metric explaining your score)
+
+Rules:
+- Score independently - do NOT just copy the persona pre-scores
+- Be calibrated: 50 = average, not "passing"
+- Provide specific reasoning for each score
+- Ground scores in the venture data provided`;
+
+/**
+ * Run hybrid scoring: 50% deterministic (Stage 2 persona scores) + 50% AI.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 output
+ * @param {Object} params.stage2Data - Stage 2 output (critiques with scores)
+ * @param {string} [params.ventureName] - Venture name
+ * @returns {Promise<{marketFit: number, customerNeed: number, momentum: number, revenuePotential: number, competitiveBarrier: number, executionFeasibility: number, overallScore: number, decision: string, blockProgression: boolean, reasons: Array, hybridBreakdown: Object}>}
+ */
+export async function analyzeStage03({ stage1Data, stage2Data, ventureName }) {
+  if (!stage2Data?.critiques || !Array.isArray(stage2Data.critiques)) {
+    throw new Error('Stage 03 requires Stage 2 data with critiques array');
+  }
+
+  // Extract deterministic scores from Stage 2 personas
+  const deterministicScores = extractDeterministicScores(stage2Data.critiques);
+
+  // Get independent AI scores
+  const aiScores = await getAIScores({ stage1Data, stage2Data, ventureName });
+
+  // Blend 50/50
+  const blended = {};
+  for (const metric of METRICS) {
+    const det = deterministicScores[metric] ?? 50;
+    const ai = aiScores[metric] ?? 50;
+    blended[metric] = Math.round((det + ai) / 2);
+  }
+
+  // Compute overall and kill gate
+  const scores = METRICS.map(m => blended[m]);
+  const overallScore = Math.round(scores.reduce((a, b) => a + b, 0) / METRICS.length);
+
+  const reasons = [];
+  if (overallScore < KILL_THRESHOLD) {
+    reasons.push({
+      type: 'overall_below_threshold',
+      message: `Overall score ${overallScore} is below kill threshold ${KILL_THRESHOLD}`,
+      threshold: KILL_THRESHOLD,
+      actual: overallScore,
+    });
+  }
+  for (const metric of METRICS) {
+    if (blended[metric] < KILL_THRESHOLD) {
+      reasons.push({
+        type: 'metric_below_threshold',
+        metric,
+        message: `${metric} score ${blended[metric]} is below threshold ${KILL_THRESHOLD}`,
+        threshold: KILL_THRESHOLD,
+        actual: blended[metric],
+      });
+    }
+  }
+
+  const decision = reasons.length > 0 ? 'kill' : 'pass';
+
+  return {
+    ...blended,
+    overallScore,
+    decision,
+    blockProgression: decision === 'kill',
+    reasons,
+    hybridBreakdown: {
+      deterministic: deterministicScores,
+      ai: aiScores,
+      weights: { deterministic: 0.5, ai: 0.5 },
+    },
+  };
+}
+
+/**
+ * Map Stage 2 persona critiques to Stage 3 metric names.
+ * Persona IDs align 1:1 with metrics via the PERSONAS mapping.
+ */
+const PERSONA_TO_METRIC = {
+  'market-strategist': 'marketFit',
+  'customer-advocate': 'customerNeed',
+  'growth-hacker': 'momentum',
+  'revenue-analyst': 'revenuePotential',
+  'moat-architect': 'competitiveBarrier',
+  'ops-realist': 'executionFeasibility',
+};
+
+function extractDeterministicScores(critiques) {
+  const scores = {};
+  for (const critique of critiques) {
+    const metric = PERSONA_TO_METRIC[critique.model];
+    if (metric) {
+      scores[metric] = clampScore(critique.score);
+    }
+  }
+  // Fill defaults for any missing
+  for (const metric of METRICS) {
+    if (scores[metric] === undefined) scores[metric] = 50;
+  }
+  return scores;
+}
+
+async function getAIScores({ stage1Data, stage2Data, ventureName }) {
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const userPrompt = `Independently score this venture across 6 dimensions.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data?.description || 'N/A'}
+Value Proposition: ${stage1Data?.valueProp || 'N/A'}
+Target Market: ${stage1Data?.targetMarket || 'N/A'}
+Problem: ${stage1Data?.problemStatement || 'N/A'}
+
+Prior persona composite: ${stage2Data?.compositeScore ?? 'N/A'}/100
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  const scores = {};
+  for (const metric of METRICS) {
+    scores[metric] = clampScore(parsed[metric]);
+  }
+  return scores;
+}
+
+function clampScore(score) {
+  const n = Number(score);
+  if (!Number.isFinite(n)) return 50;
+  return Math.max(0, Math.min(100, Math.round(n)));
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse AI scoring response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { KILL_THRESHOLD, PERSONA_TO_METRIC };

--- a/lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js
@@ -1,0 +1,161 @@
+/**
+ * Stage 04 Analysis Step - Competitive Landscape with Pricing
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
+ *
+ * Discovers competitors, analyzes positioning, threat levels,
+ * SWOT, and critically: pricing model per competitor.
+ * Feeds Stage 5 with competitive pricing data for financial modeling.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const MIN_COMPETITORS = 3;
+
+const SYSTEM_PROMPT = `You are EVA's competitive intelligence engine. Analyze the competitive landscape for a venture idea.
+
+You MUST output valid JSON with this structure:
+{
+  "competitors": [
+    {
+      "name": "Competitor Name",
+      "position": "Brief market positioning (1-2 sentences)",
+      "threat": "H" | "M" | "L",
+      "strengths": ["strength1", "strength2"],
+      "weaknesses": ["weakness1", "weakness2"],
+      "swot": {
+        "strengths": ["..."],
+        "weaknesses": ["..."],
+        "opportunities": ["..."],
+        "threats": ["..."]
+      },
+      "pricingModel": {
+        "type": "subscription" | "freemium" | "one-time" | "usage-based" | "marketplace" | "advertising" | "enterprise" | "hybrid",
+        "lowTier": "$X/mo or $X one-time",
+        "highTier": "$X/mo or $X one-time",
+        "freeOption": true | false,
+        "notes": "Pricing details or caveats"
+      }
+    }
+  ],
+  "stage5Handoff": {
+    "avgMarketPrice": "estimated average price point",
+    "pricingModels": ["subscription", "freemium"],
+    "priceRange": {"low": number, "high": number},
+    "competitiveDensity": "low" | "medium" | "high"
+  }
+}
+
+Rules:
+- Identify at least ${MIN_COMPETITORS} competitors
+- Be specific about pricing - ranges are OK but no "unknown"
+- threat level: H = direct competitor with strong overlap, M = partial overlap, L = tangential
+- The stage5Handoff object is critical - Stage 5 depends on it for financial modeling
+- pricingModel.type must be one of the listed enum values
+- priceRange values should be monthly equivalent numbers (no currency symbols)`;
+
+/**
+ * Analyze the competitive landscape for a venture.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 output
+ * @param {Object} params.stage3Data - Stage 3 output (validation scores for context)
+ * @param {string} [params.ventureName]
+ * @returns {Promise<{competitors: Array, stage5Handoff: Object}>}
+ */
+export async function analyzeStage04({ stage1Data, stage3Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 04 requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const userPrompt = `Analyze the competitive landscape for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Value Proposition: ${stage1Data.valueProp}
+Target Market: ${stage1Data.targetMarket}
+Problem: ${stage1Data.problemStatement || 'N/A'}
+${stage3Data?.overallScore ? `Validation Score: ${stage3Data.overallScore}/100` : ''}
+${stage3Data?.competitiveBarrier !== undefined ? `Competitive Barrier Score: ${stage3Data.competitiveBarrier}/100` : ''}
+
+Find at least ${MIN_COMPETITORS} competitors. Include pricing details for each.
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Validate minimum competitors
+  if (!Array.isArray(parsed.competitors) || parsed.competitors.length < MIN_COMPETITORS) {
+    throw new Error(`Stage 04 requires at least ${MIN_COMPETITORS} competitors (got ${parsed.competitors?.length || 0})`);
+  }
+
+  // Normalize competitors
+  const competitors = parsed.competitors.map(c => ({
+    name: c.name || 'Unknown',
+    position: c.position || 'N/A',
+    threat: ['H', 'M', 'L'].includes(c.threat) ? c.threat : 'M',
+    strengths: ensureArray(c.strengths),
+    weaknesses: ensureArray(c.weaknesses),
+    swot: {
+      strengths: ensureArray(c.swot?.strengths),
+      weaknesses: ensureArray(c.swot?.weaknesses),
+      opportunities: ensureArray(c.swot?.opportunities),
+      threats: ensureArray(c.swot?.threats),
+    },
+    pricingModel: c.pricingModel || null,
+  }));
+
+  // Build stage5Handoff
+  const stage5Handoff = parsed.stage5Handoff || buildStage5Handoff(competitors);
+
+  return { competitors, stage5Handoff };
+}
+
+/**
+ * Build stage5Handoff from competitor data if LLM didn't provide it.
+ */
+function buildStage5Handoff(competitors) {
+  const pricingTypes = new Set();
+  const prices = [];
+
+  for (const c of competitors) {
+    if (c.pricingModel?.type) pricingTypes.add(c.pricingModel.type);
+    if (c.pricingModel?.lowTier) {
+      const num = parseFloat(c.pricingModel.lowTier.replace(/[^0-9.]/g, ''));
+      if (Number.isFinite(num)) prices.push(num);
+    }
+    if (c.pricingModel?.highTier) {
+      const num = parseFloat(c.pricingModel.highTier.replace(/[^0-9.]/g, ''));
+      if (Number.isFinite(num)) prices.push(num);
+    }
+  }
+
+  const density = competitors.filter(c => c.threat === 'H').length >= 2 ? 'high'
+    : competitors.filter(c => c.threat !== 'L').length >= 2 ? 'medium' : 'low';
+
+  return {
+    avgMarketPrice: prices.length > 0 ? `$${Math.round(prices.reduce((a, b) => a + b, 0) / prices.length)}/mo` : 'N/A',
+    pricingModels: [...pricingTypes],
+    priceRange: prices.length > 0 ? { low: Math.min(...prices), high: Math.max(...prices) } : { low: 0, high: 0 },
+    competitiveDensity: density,
+  };
+}
+
+function ensureArray(val) {
+  if (Array.isArray(val) && val.length > 0) return val;
+  return ['N/A'];
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse competitive analysis response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { MIN_COMPETITORS };

--- a/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
@@ -1,0 +1,213 @@
+/**
+ * Stage 05 Analysis Step - Financial Model with Unit Economics
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
+ *
+ * Generates a 3-year financial model with unit economics:
+ * CAC, LTV, LTV:CAC ratio, payback period, and ROI with bands.
+ * Kill gate fires when ROI < 25% (SD-specified) OR payback > 24 months.
+ *
+ * Consumes Stage 4 competitive pricing data (stage5Handoff) and
+ * Stage 3 validation scores for revenue assumptions.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-05-financial-model
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const ROI_THRESHOLD = 0.25;
+const MAX_PAYBACK_MONTHS = 24;
+
+const SYSTEM_PROMPT = `You are EVA's financial modeling engine. Generate a 3-year financial projection with unit economics.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "initialInvestment": number (> 0),
+  "year1": { "revenue": number, "cogs": number, "opex": number },
+  "year2": { "revenue": number, "cogs": number, "opex": number },
+  "year3": { "revenue": number, "cogs": number, "opex": number },
+  "unitEconomics": {
+    "cac": number (Customer Acquisition Cost),
+    "ltv": number (Lifetime Value),
+    "ltvCacRatio": number (LTV / CAC),
+    "paybackMonths": number (months to recover CAC),
+    "monthlyChurn": number (0-1, e.g. 0.05 = 5%)
+  },
+  "roiBands": {
+    "pessimistic": number (decimal, e.g. 0.15 = 15%),
+    "base": number,
+    "optimistic": number
+  },
+  "assumptions": [
+    "Key assumption 1",
+    "Key assumption 2"
+  ]
+}
+
+Rules:
+- All monetary values in USD
+- Use competitive pricing data to calibrate revenue assumptions
+- Unit economics must be internally consistent (LTV = monthly revenue per customer / churn * margin)
+- ROI bands: pessimistic = -20% of base, optimistic = +30% of base
+- CAC should reflect the target market and acquisition channels
+- Be conservative - do not inflate projections
+- Include at least 3 assumptions`;
+
+/**
+ * Generate a financial model with unit economics.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 output
+ * @param {Object} params.stage3Data - Stage 3 validation scores
+ * @param {Object} params.stage4Data - Stage 4 output (competitors, stage5Handoff)
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Financial model with kill gate evaluation
+ */
+export async function analyzeStage05({ stage1Data, stage3Data, stage4Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 05 requires Stage 1 data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const pricingContext = stage4Data?.stage5Handoff
+    ? `Competitive Pricing:
+  Average market price: ${stage4Data.stage5Handoff.avgMarketPrice}
+  Price range: $${stage4Data.stage5Handoff.priceRange?.low}-$${stage4Data.stage5Handoff.priceRange?.high}/mo
+  Pricing models in market: ${stage4Data.stage5Handoff.pricingModels?.join(', ') || 'N/A'}
+  Competitive density: ${stage4Data.stage5Handoff.competitiveDensity}`
+    : 'No competitive pricing data available';
+
+  const userPrompt = `Generate a 3-year financial model for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Target Market: ${stage1Data.targetMarket}
+Problem: ${stage1Data.problemStatement || 'N/A'}
+${stage3Data?.overallScore ? `Validation Score: ${stage3Data.overallScore}/100` : ''}
+
+${pricingContext}
+
+${stage4Data?.competitors ? `Number of competitors: ${stage4Data.competitors.length}` : ''}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Extract and validate core financials
+  const model = {
+    initialInvestment: ensurePositive(parsed.initialInvestment, 10000),
+    year1: normalizeYear(parsed.year1),
+    year2: normalizeYear(parsed.year2),
+    year3: normalizeYear(parsed.year3),
+  };
+
+  // Compute derived fields (same as stage-05 template)
+  const grossProfitY1 = model.year1.revenue - model.year1.cogs;
+  const grossProfitY2 = model.year2.revenue - model.year2.cogs;
+  const grossProfitY3 = model.year3.revenue - model.year3.cogs;
+  const netProfitY1 = grossProfitY1 - model.year1.opex;
+  const netProfitY2 = grossProfitY2 - model.year2.opex;
+  const netProfitY3 = grossProfitY3 - model.year3.opex;
+  const totalNetProfit = netProfitY1 + netProfitY2 + netProfitY3;
+  const roi3y = (totalNetProfit - model.initialInvestment) / model.initialInvestment;
+
+  const monthlyNetProfit = netProfitY1 / 12;
+  const breakEvenMonth = monthlyNetProfit > 0
+    ? Math.ceil(model.initialInvestment / monthlyNetProfit)
+    : null;
+
+  // Unit economics from LLM
+  const unitEconomics = parsed.unitEconomics || {};
+  const cac = ensurePositive(unitEconomics.cac, 100);
+  const ltv = ensurePositive(unitEconomics.ltv, 500);
+  const ltvCacRatio = cac > 0 ? ltv / cac : 0;
+  const paybackMonths = ensurePositive(unitEconomics.paybackMonths, breakEvenMonth || 12);
+  const monthlyChurn = Math.max(0, Math.min(1, unitEconomics.monthlyChurn || 0.05));
+
+  // ROI bands
+  const roiBands = {
+    pessimistic: roi3y * 0.8,
+    base: roi3y,
+    optimistic: roi3y * 1.3,
+  };
+
+  // Kill gate evaluation (SD specifies ROI 25%)
+  const reasons = [];
+  if (roi3y < ROI_THRESHOLD) {
+    reasons.push({
+      type: 'roi_below_threshold',
+      message: `3-year ROI of ${(roi3y * 100).toFixed(1)}% is below threshold ${ROI_THRESHOLD * 100}%`,
+      threshold: ROI_THRESHOLD,
+      actual: roi3y,
+    });
+  }
+  if (breakEvenMonth === null) {
+    reasons.push({
+      type: 'no_break_even_year1',
+      message: 'Year 1 net profit is non-positive; break-even cannot be calculated',
+    });
+  } else if (breakEvenMonth > MAX_PAYBACK_MONTHS) {
+    reasons.push({
+      type: 'break_even_too_late',
+      message: `Break-even at month ${breakEvenMonth} exceeds maximum ${MAX_PAYBACK_MONTHS} months`,
+      threshold: MAX_PAYBACK_MONTHS,
+      actual: breakEvenMonth,
+    });
+  }
+
+  const decision = reasons.length > 0 ? 'kill' : 'pass';
+
+  return {
+    ...model,
+    grossProfitY1,
+    grossProfitY2,
+    grossProfitY3,
+    netProfitY1,
+    netProfitY2,
+    netProfitY3,
+    breakEvenMonth,
+    roi3y,
+    decision,
+    blockProgression: decision === 'kill',
+    reasons,
+    unitEconomics: {
+      cac,
+      ltv,
+      ltvCacRatio: Math.round(ltvCacRatio * 100) / 100,
+      paybackMonths,
+      monthlyChurn,
+    },
+    roiBands,
+    assumptions: Array.isArray(parsed.assumptions) ? parsed.assumptions : [],
+  };
+}
+
+function normalizeYear(year) {
+  return {
+    revenue: ensureNonNegative(year?.revenue, 0),
+    cogs: ensureNonNegative(year?.cogs, 0),
+    opex: ensureNonNegative(year?.opex, 0),
+  };
+}
+
+function ensurePositive(val, fallback) {
+  const n = Number(val);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function ensureNonNegative(val, fallback) {
+  const n = Number(val);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse financial model response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { ROI_THRESHOLD, MAX_PAYBACK_MONTHS };

--- a/lib/eva/stage-templates/index.js
+++ b/lib/eva/stage-templates/index.js
@@ -10,10 +10,10 @@
  */
 
 // Phase 1: THE TRUTH (Stages 1-5)
-export { default as stage01 } from './stage-01.js';
-export { default as stage02 } from './stage-02.js';
+export { default as stage01, ARCHETYPES } from './stage-01.js';
+export { default as stage02, METRIC_NAMES as STAGE02_METRIC_NAMES } from './stage-02.js';
 export { default as stage03, evaluateKillGate as evaluateStage03KillGate } from './stage-03.js';
-export { default as stage04 } from './stage-04.js';
+export { default as stage04, PRICING_MODELS } from './stage-04.js';
 export { default as stage05, evaluateKillGate as evaluateStage05KillGate } from './stage-05.js';
 
 // Phase 2: THE ENGINE (Stages 6-9)

--- a/lib/eva/stage-templates/stage-01.js
+++ b/lib/eva/stage-templates/stage-01.js
@@ -1,30 +1,53 @@
 /**
  * Stage 01 Template - Draft Idea
  * Phase: THE TRUTH (Stages 1-5)
- * Part of SD-LEO-FEAT-TMPL-TRUTH-001
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
  * Captures a minimally viable venture idea with required fields
  * and enforces input constraints for consistent downstream scoring.
+ * Hydrates from Stage 0 synthesis output.
+ *
+ * Cross-stage contracts:
+ *   → Stage 2: context/description for MoA analysis
+ *   → Stage 3: problemStatement (customerNeed), archetype (scoring weights), keyAssumptions
+ *   → Stage 23: successCriteria
  *
  * @module lib/eva/stage-templates/stage-01
  */
 
-import { validateString, collectErrors } from './validation.js';
+import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage01 } from './analysis-steps/stage-01-hydration.js';
+
+const ARCHETYPES = [
+  'saas', 'marketplace', 'deeptech', 'hardware', 'services', 'media', 'fintech',
+];
 
 const TEMPLATE = {
   id: 'stage-01',
   slug: 'draft-idea',
   title: 'Draft Idea',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     description: { type: 'string', minLength: 50, required: true },
+    problemStatement: { type: 'string', minLength: 20, required: true },
     valueProp: { type: 'string', minLength: 20, required: true },
     targetMarket: { type: 'string', minLength: 10, required: true },
+    archetype: { type: 'enum', values: ARCHETYPES, required: true },
+    keyAssumptions: { type: 'array', items: { type: 'string' }, required: false },
+    moatStrategy: { type: 'string', required: false },
+    successCriteria: { type: 'array', items: { type: 'string' }, required: false },
+    sourceProvenance: { type: 'object', derived: true },
   },
   defaultData: {
     description: '',
+    problemStatement: '',
     valueProp: '',
     targetMarket: '',
+    archetype: null,
+    keyAssumptions: [],
+    moatStrategy: '',
+    successCriteria: [],
+    sourceProvenance: {},
   },
 
   /**
@@ -35,21 +58,51 @@ const TEMPLATE = {
   validate(data) {
     const results = [
       validateString(data?.description, 'description', 50),
+      validateString(data?.problemStatement, 'problemStatement', 20),
       validateString(data?.valueProp, 'valueProp', 20),
       validateString(data?.targetMarket, 'targetMarket', 10),
+      validateEnum(data?.archetype, 'archetype', ARCHETYPES),
     ];
+
+    // Optional arrays: validate only if provided
+    if (data?.keyAssumptions !== undefined && data.keyAssumptions !== null) {
+      if (!Array.isArray(data.keyAssumptions)) {
+        results.push({ valid: false, error: 'keyAssumptions must be an array' });
+      }
+    }
+    if (data?.successCriteria !== undefined && data.successCriteria !== null) {
+      if (!Array.isArray(data.successCriteria)) {
+        results.push({ valid: false, error: 'successCriteria must be an array' });
+      }
+    }
+
     const errors = collectErrors(results);
     return { valid: errors.length === 0, errors };
   },
 
   /**
-   * Compute derived fields (none for Stage 01).
+   * Compute derived fields: sourceProvenance tracks field origins.
    * @param {Object} data - Validated input data
-   * @returns {Object} Data with any derived fields
+   * @param {Object} [stage0Output] - Optional Stage 0 synthesis output for provenance tracking
+   * @returns {Object} Data with sourceProvenance
    */
-  computeDerived(data) {
-    return { ...data };
+  computeDerived(data, stage0Output) {
+    const provenance = {};
+    const stage0Fields = stage0Output ? Object.keys(stage0Output) : [];
+
+    for (const field of ['description', 'problemStatement', 'valueProp', 'targetMarket', 'archetype', 'moatStrategy']) {
+      if (stage0Fields.includes(field) && data[field]) {
+        provenance[field] = 'stage0';
+      } else if (data[field]) {
+        provenance[field] = 'user';
+      }
+    }
+
+    return { ...data, sourceProvenance: provenance };
   },
 };
 
+TEMPLATE.analysisStep = analyzeStage01;
+
+export { ARCHETYPES };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-02.js
+++ b/lib/eva/stage-templates/stage-02.js
@@ -1,38 +1,87 @@
 /**
- * Stage 02 Template - AI Review
+ * Stage 02 Template - Idea Validation (MoA Multi-Persona Analysis)
  * Phase: THE TRUTH (Stages 1-5)
- * Part of SD-LEO-FEAT-TMPL-TRUTH-001
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
- * Stores critiques from multiple AI models/agents and computes
- * a deterministic composite score as the rounded average.
+ * MoA (Mixture of Agents) multi-persona analysis producing 6 pre-scores
+ * aligned with Stage 3 metrics. Does NOT make gate decisions — feeds Stage 3.
+ *
+ * Cross-stage contracts:
+ *   ← Stage 1: description, problemStatement, valueProp, targetMarket, archetype, keyAssumptions
+ *   → Stage 3: 6 pre-scores (0-100 integer), evidence packs per domain
  *
  * @module lib/eva/stage-templates/stage-02
  */
 
-import { validateString, validateInteger, validateArray, collectErrors } from './validation.js';
+import { validateString, validateInteger, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage02 } from './analysis-steps/stage-02-multi-persona.js';
+
+const METRIC_NAMES = [
+  'marketFit', 'customerNeed', 'momentum',
+  'revenuePotential', 'competitiveBarrier', 'executionFeasibility',
+];
+
+const SUGGESTION_TYPES = ['immediate', 'strategic'];
 
 const TEMPLATE = {
   id: 'stage-02',
-  slug: 'ai-review',
-  title: 'AI Review',
-  version: '1.0.0',
+  slug: 'idea-validation',
+  title: 'Idea Validation',
+  version: '2.0.0',
   schema: {
-    critiques: {
+    analysis: {
+      type: 'object',
+      required: true,
+      properties: {
+        strategic: { type: 'string', minLength: 20, required: true },
+        technical: { type: 'string', minLength: 20, required: true },
+        tactical: { type: 'string', minLength: 20, required: true },
+      },
+    },
+    metrics: {
+      type: 'object',
+      required: true,
+      properties: Object.fromEntries(
+        METRIC_NAMES.map(m => [m, { type: 'integer', min: 0, max: 100, required: true }])
+      ),
+    },
+    evidence: {
+      type: 'object',
+      required: true,
+      properties: {
+        market: { type: 'string', required: true },
+        customer: { type: 'string', required: true },
+        competitive: { type: 'string', required: true },
+        execution: { type: 'string', required: true },
+      },
+    },
+    suggestions: {
       type: 'array',
-      minItems: 1,
+      minItems: 0,
       items: {
-        model: { type: 'string', required: true },
-        summary: { type: 'string', minLength: 20, required: true },
-        strengths: { type: 'array', minItems: 1, items: { type: 'string' } },
-        risks: { type: 'array', minItems: 1, items: { type: 'string' } },
-        score: { type: 'integer', min: 0, max: 100, required: true },
+        type: { type: 'enum', values: SUGGESTION_TYPES, required: true },
+        text: { type: 'string', minLength: 10, required: true },
       },
     },
     compositeScore: { type: 'integer', min: 0, max: 100, derived: true },
+    provenance: {
+      type: 'object',
+      required: false,
+      properties: {
+        promptHash: { type: 'string' },
+        modelVersion: { type: 'string' },
+        temperature: { type: 'number' },
+        seed: { type: 'number' },
+      },
+    },
   },
   defaultData: {
-    critiques: [],
+    analysis: { strategic: '', technical: '', tactical: '' },
+    metrics: Object.fromEntries(METRIC_NAMES.map(m => [m, null])),
+    evidence: { market: '', customer: '', competitive: '', execution: '' },
+    suggestions: [],
     compositeScore: null,
+    provenance: {},
   },
 
   /**
@@ -43,42 +92,75 @@ const TEMPLATE = {
   validate(data) {
     const errors = [];
 
-    const arrayCheck = validateArray(data?.critiques, 'critiques', 1);
-    if (!arrayCheck.valid) {
-      return { valid: false, errors: [arrayCheck.error] };
+    // Validate analysis perspectives
+    if (!data?.analysis || typeof data.analysis !== 'object') {
+      errors.push('analysis is required and must be an object');
+    } else {
+      for (const perspective of ['strategic', 'technical', 'tactical']) {
+        const r = validateString(data.analysis[perspective], `analysis.${perspective}`, 20);
+        if (!r.valid) errors.push(r.error);
+      }
     }
 
-    for (let i = 0; i < data.critiques.length; i++) {
-      const c = data.critiques[i];
-      const prefix = `critiques[${i}]`;
-      const results = [
-        validateString(c?.model, `${prefix}.model`, 1),
-        validateString(c?.summary, `${prefix}.summary`, 20),
-        validateArray(c?.strengths, `${prefix}.strengths`, 1),
-        validateArray(c?.risks, `${prefix}.risks`, 1),
-        validateInteger(c?.score, `${prefix}.score`, 0, 100),
-      ];
-      errors.push(...collectErrors(results));
+    // Validate 6 metrics (0-100 integer)
+    if (!data?.metrics || typeof data.metrics !== 'object') {
+      errors.push('metrics is required and must be an object');
+    } else {
+      for (const metric of METRIC_NAMES) {
+        const r = validateInteger(data.metrics[metric], `metrics.${metric}`, 0, 100);
+        if (!r.valid) errors.push(r.error);
+      }
+    }
+
+    // Validate evidence domains
+    if (!data?.evidence || typeof data.evidence !== 'object') {
+      errors.push('evidence is required and must be an object');
+    } else {
+      for (const domain of ['market', 'customer', 'competitive', 'execution']) {
+        const r = validateString(data.evidence[domain], `evidence.${domain}`, 1);
+        if (!r.valid) errors.push(r.error);
+      }
+    }
+
+    // Validate suggestions (optional but must be well-formed if present)
+    if (data?.suggestions !== undefined && data.suggestions !== null) {
+      if (!Array.isArray(data.suggestions)) {
+        errors.push('suggestions must be an array');
+      } else {
+        for (let i = 0; i < data.suggestions.length; i++) {
+          const s = data.suggestions[i];
+          const prefix = `suggestions[${i}]`;
+          const typeCheck = validateEnum(s?.type, `${prefix}.type`, SUGGESTION_TYPES);
+          if (!typeCheck.valid) errors.push(typeCheck.error);
+          const textCheck = validateString(s?.text, `${prefix}.text`, 10);
+          if (!textCheck.valid) errors.push(textCheck.error);
+        }
+      }
     }
 
     return { valid: errors.length === 0, errors };
   },
 
   /**
-   * Compute derived fields: compositeScore as rounded average of critique scores.
-   * Ties round .5 up (Math.round behavior).
+   * Compute derived fields: compositeScore as rounded average of 6 metrics.
    * @param {Object} data - Validated input data
    * @returns {Object} Data with compositeScore
    */
   computeDerived(data) {
-    const critiques = data.critiques || [];
-    if (critiques.length === 0) {
+    const metrics = data.metrics || {};
+    const scores = METRIC_NAMES.map(m => metrics[m]).filter(v => Number.isInteger(v));
+
+    if (scores.length === 0) {
       return { ...data, compositeScore: null };
     }
-    const sum = critiques.reduce((acc, c) => acc + c.score, 0);
-    const compositeScore = Math.round(sum / critiques.length);
+
+    const sum = scores.reduce((acc, s) => acc + s, 0);
+    const compositeScore = Math.round(sum / scores.length);
     return { ...data, compositeScore };
   },
 };
 
+TEMPLATE.analysisStep = analyzeStage02;
+
+export { METRIC_NAMES, SUGGESTION_TYPES };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-03.js
+++ b/lib/eva/stage-templates/stage-03.js
@@ -1,15 +1,24 @@
 /**
- * Stage 03 Template - Market Validation
+ * Stage 03 Template - Individual Validation (KILL GATE)
  * Phase: THE TRUTH (Stages 1-5)
- * Part of SD-LEO-FEAT-TMPL-TRUTH-001
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
- * 6-metric validation rubric with deterministic KILL GATE enforcement.
- * Kill gate triggers when overallScore < 70 OR any single metric < 40.
+ * Hybrid scoring (50% deterministic + 50% AI calibration) with 3-way gate:
+ *   PASS:   overallScore ≥ 70 AND all metrics ≥ 50
+ *   REVISE: overallScore ≥ 50 AND < 70 AND no metric < 50 → re-route to Stage 2
+ *   KILL:   overallScore < 50 OR any metric < 50
+ *
+ * Cross-stage contracts:
+ *   ← Stage 2: 6 pre-scores, evidence packs, composite analysis
+ *   ← Stage 1: archetype (scoring weights), problemStatement, keyAssumptions
+ *   → Stage 4: competitorEntities (name, positioning, threat_level)
+ *   → Stage 5: market validation result, archetype-driven weighting
  *
  * @module lib/eva/stage-templates/stage-03
  */
 
-import { validateInteger, collectErrors } from './validation.js';
+import { validateInteger, validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage03 } from './analysis-steps/stage-03-hybrid-scoring.js';
 
 const METRICS = [
   'marketFit',
@@ -20,23 +29,44 @@ const METRICS = [
   'executionFeasibility',
 ];
 
-const OVERALL_THRESHOLD = 70;
-const METRIC_THRESHOLD = 40;
+const PASS_THRESHOLD = 70;
+const REVISE_THRESHOLD = 50;
+const METRIC_THRESHOLD = 50;
+
+const THREAT_LEVELS = ['H', 'M', 'L'];
 
 const TEMPLATE = {
   id: 'stage-03',
   slug: 'validation',
-  title: 'Market Validation',
-  version: '1.0.0',
+  title: 'Individual Validation',
+  version: '2.0.0',
   schema: {
+    // 6 core metrics (0-100 integer)
     marketFit: { type: 'integer', min: 0, max: 100, required: true },
     customerNeed: { type: 'integer', min: 0, max: 100, required: true },
     momentum: { type: 'integer', min: 0, max: 100, required: true },
     revenuePotential: { type: 'integer', min: 0, max: 100, required: true },
     competitiveBarrier: { type: 'integer', min: 0, max: 100, required: true },
     executionFeasibility: { type: 'integer', min: 0, max: 100, required: true },
+    // Competitor entities for Stage 4 handoff
+    competitorEntities: {
+      type: 'array',
+      required: false,
+      items: {
+        name: { type: 'string', required: true },
+        positioning: { type: 'string', required: true },
+        threat_level: { type: 'enum', values: THREAT_LEVELS, required: true },
+      },
+    },
+    // Per-metric confidence levels
+    confidenceScores: {
+      type: 'object',
+      required: false,
+    },
+    // Derived fields
     overallScore: { type: 'integer', min: 0, max: 100, derived: true },
-    decision: { type: 'enum', values: ['pass', 'kill'], derived: true },
+    rollupDimensions: { type: 'object', derived: true },
+    decision: { type: 'enum', values: ['pass', 'revise', 'kill'], derived: true },
     blockProgression: { type: 'boolean', derived: true },
     reasons: { type: 'array', derived: true },
   },
@@ -47,7 +77,10 @@ const TEMPLATE = {
     revenuePotential: null,
     competitiveBarrier: null,
     executionFeasibility: null,
+    competitorEntities: [],
+    confidenceScores: {},
     overallScore: null,
+    rollupDimensions: null,
     decision: null,
     blockProgression: false,
     reasons: [],
@@ -60,19 +93,38 @@ const TEMPLATE = {
    */
   validate(data) {
     const results = METRICS.map(m => validateInteger(data?.[m], m, 0, 100));
+
+    // Validate competitor entities if present
+    if (data?.competitorEntities && Array.isArray(data.competitorEntities)) {
+      for (let i = 0; i < data.competitorEntities.length; i++) {
+        const ce = data.competitorEntities[i];
+        const prefix = `competitorEntities[${i}]`;
+        results.push(validateString(ce?.name, `${prefix}.name`, 1));
+        results.push(validateString(ce?.positioning, `${prefix}.positioning`, 1));
+        results.push(validateEnum(ce?.threat_level, `${prefix}.threat_level`, THREAT_LEVELS));
+      }
+    }
+
     const errors = collectErrors(results);
     return { valid: errors.length === 0, errors };
   },
 
   /**
-   * Compute derived fields: overallScore and kill gate decision.
+   * Compute derived fields: overallScore, rollup dimensions, and 3-way gate decision.
    * @param {Object} data - Validated input data
-   * @returns {Object} Data with overallScore, decision, blockProgression, reasons
+   * @returns {Object} Data with overallScore, rollupDimensions, decision, blockProgression, reasons
    */
   computeDerived(data) {
     const scores = METRICS.map(m => data[m]);
     const sum = scores.reduce((acc, s) => acc + s, 0);
     const overallScore = Math.round(sum / METRICS.length);
+
+    // 3 rollup dimensions for governance readability
+    const rollupDimensions = {
+      market: Math.round((data.marketFit + data.momentum) / 2),
+      technical: Math.round((data.executionFeasibility + data.competitiveBarrier) / 2),
+      financial: Math.round((data.revenuePotential + data.customerNeed) / 2),
+    };
 
     const { decision, blockProgression, reasons } = evaluateKillGate({
       overallScore,
@@ -82,6 +134,7 @@ const TEMPLATE = {
     return {
       ...data,
       overallScore,
+      rollupDimensions,
       decision,
       blockProgression,
       reasons,
@@ -90,28 +143,24 @@ const TEMPLATE = {
 };
 
 /**
- * Pure function: evaluate kill gate for Stage 03.
- * Kill if overallScore < 70 OR any metric < 40.
+ * Pure function: evaluate 3-way kill gate for Stage 03.
+ *
+ * PASS:   overallScore ≥ 70 AND all metrics ≥ 50
+ * REVISE: overallScore ≥ 50 AND < 70 AND no metric < 50 → re-route to Stage 2
+ * KILL:   overallScore < 50 OR any metric < 50
  *
  * @param {{ overallScore: number, metrics: Object }} params
- * @returns {{ decision: 'pass'|'kill', blockProgression: boolean, reasons: Object[] }}
+ * @returns {{ decision: 'pass'|'revise'|'kill', blockProgression: boolean, reasons: Object[] }}
  */
 export function evaluateKillGate({ overallScore, metrics }) {
   const reasons = [];
-
-  if (overallScore < OVERALL_THRESHOLD) {
-    reasons.push({
-      type: 'overall_below_threshold',
-      message: `Overall score ${overallScore} is below threshold ${OVERALL_THRESHOLD}`,
-      threshold: OVERALL_THRESHOLD,
-      actual: overallScore,
-    });
-  }
+  let hasMetricBelowThreshold = false;
 
   for (const [metric, value] of Object.entries(metrics)) {
     if (value < METRIC_THRESHOLD) {
+      hasMetricBelowThreshold = true;
       reasons.push({
-        type: 'metric_below_40',
+        type: 'metric_below_threshold',
         metric,
         message: `${metric} score ${value} is below per-metric threshold ${METRIC_THRESHOLD}`,
         threshold: METRIC_THRESHOLD,
@@ -120,13 +169,35 @@ export function evaluateKillGate({ overallScore, metrics }) {
     }
   }
 
-  const decision = reasons.length > 0 ? 'kill' : 'pass';
-  return {
-    decision,
-    blockProgression: decision === 'kill',
-    reasons,
-  };
+  // Kill: any metric below 50 OR overall below 50
+  if (hasMetricBelowThreshold || overallScore < REVISE_THRESHOLD) {
+    if (overallScore < REVISE_THRESHOLD) {
+      reasons.push({
+        type: 'overall_below_kill_threshold',
+        message: `Overall score ${overallScore} is below kill threshold ${REVISE_THRESHOLD}`,
+        threshold: REVISE_THRESHOLD,
+        actual: overallScore,
+      });
+    }
+    return { decision: 'kill', blockProgression: true, reasons };
+  }
+
+  // Revise: overall 50-69 with no single metric below 50
+  if (overallScore < PASS_THRESHOLD) {
+    reasons.push({
+      type: 'overall_in_revise_band',
+      message: `Overall score ${overallScore} is in revise band (${REVISE_THRESHOLD}-${PASS_THRESHOLD - 1}). Re-route to Stage 2.`,
+      threshold: PASS_THRESHOLD,
+      actual: overallScore,
+    });
+    return { decision: 'revise', blockProgression: true, reasons };
+  }
+
+  // Pass: overall ≥ 70 and all metrics ≥ 50
+  return { decision: 'pass', blockProgression: false, reasons: [] };
 }
 
-export { METRICS, OVERALL_THRESHOLD, METRIC_THRESHOLD };
+TEMPLATE.analysisStep = analyzeStage03;
+
+export { METRICS, PASS_THRESHOLD, REVISE_THRESHOLD, METRIC_THRESHOLD, THREAT_LEVELS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-04.js
+++ b/lib/eva/stage-templates/stage-04.js
@@ -1,23 +1,34 @@
 /**
  * Stage 04 Template - Competitive Intel
  * Phase: THE TRUTH (Stages 1-5)
- * Part of SD-LEO-FEAT-TMPL-TRUTH-001
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
- * Captures competitor cards with positioning, threat level,
- * strengths/weaknesses, and SWOT analysis per competitor.
+ * Competitive landscape analysis with structured pricing models,
+ * SWOT per competitor, and Stage 5 handoff artifact.
+ *
+ * Cross-stage contracts:
+ *   ← Stage 3: competitorEntities (name, positioning, threat_level)
+ *   ← Stage 1: description, valueProp, targetMarket
+ *   → Stage 5: stage5Handoff (pricingLandscape, competitivePositioning, marketGaps)
+ *   → Stage 7: pricing context for pricing strategy
  *
  * @module lib/eva/stage-templates/stage-04
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage04 } from './analysis-steps/stage-04-competitive-landscape.js';
 
 const THREAT_LEVELS = ['H', 'M', 'L'];
+
+const PRICING_MODELS = [
+  'freemium', 'subscription', 'one_time', 'usage_based', 'marketplace_commission', 'hybrid',
+];
 
 const TEMPLATE = {
   id: 'stage-04',
   slug: 'competitive-intel',
   title: 'Competitive Intel',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     competitors: {
       type: 'array',
@@ -25,7 +36,9 @@ const TEMPLATE = {
       items: {
         name: { type: 'string', required: true },
         position: { type: 'string', required: true },
-        threat: { type: 'enum', values: ['H', 'M', 'L'], required: true },
+        threat: { type: 'enum', values: THREAT_LEVELS, required: true },
+        pricingModel: { type: 'enum', values: PRICING_MODELS, required: true },
+        marketPosition: { type: 'string', required: false },
         strengths: { type: 'array', minItems: 1, items: { type: 'string' } },
         weaknesses: { type: 'array', minItems: 1, items: { type: 'string' } },
         swot: {
@@ -36,9 +49,24 @@ const TEMPLATE = {
         },
       },
     },
+    blueOceanAnalysis: {
+      type: 'object',
+      required: false,
+    },
+    stage5Handoff: {
+      type: 'object',
+      derived: true,
+      properties: {
+        pricingLandscape: { type: 'string' },
+        competitivePositioning: { type: 'string' },
+        marketGaps: { type: 'array', items: { type: 'string' } },
+      },
+    },
   },
   defaultData: {
     competitors: [],
+    blueOceanAnalysis: null,
+    stage5Handoff: null,
   },
 
   /**
@@ -78,6 +106,7 @@ const TEMPLATE = {
         validateString(c?.name, `${prefix}.name`, 1),
         validateString(c?.position, `${prefix}.position`, 1),
         validateEnum(c?.threat, `${prefix}.threat`, THREAT_LEVELS),
+        validateEnum(c?.pricingModel, `${prefix}.pricingModel`, PRICING_MODELS),
         validateArray(c?.strengths, `${prefix}.strengths`, 1),
         validateArray(c?.weaknesses, `${prefix}.weaknesses`, 1),
       ];
@@ -101,14 +130,46 @@ const TEMPLATE = {
   },
 
   /**
-   * Compute derived fields (none for Stage 04).
+   * Compute derived fields: stage5Handoff artifact for downstream consumption.
    * @param {Object} data - Validated input data
-   * @returns {Object} Data unchanged
+   * @returns {Object} Data with stage5Handoff
    */
   computeDerived(data) {
-    return { ...data };
+    const competitors = data.competitors || [];
+
+    // Build pricing landscape summary
+    const pricingModels = competitors.map(c => `${c.name}: ${c.pricingModel}`);
+    const pricingLandscape = pricingModels.length > 0
+      ? `Pricing models: ${pricingModels.join('; ')}`
+      : '';
+
+    // Build competitive positioning summary
+    const highThreats = competitors.filter(c => c.threat === 'H');
+    const competitivePositioning = highThreats.length > 0
+      ? `${highThreats.length} high-threat competitor(s): ${highThreats.map(c => c.name).join(', ')}`
+      : 'No high-threat competitors identified';
+
+    // Extract market gaps from competitor weaknesses
+    const marketGaps = [];
+    for (const c of competitors) {
+      if (c.swot?.opportunities) {
+        marketGaps.push(...c.swot.opportunities);
+      }
+    }
+    // Deduplicate
+    const uniqueGaps = [...new Set(marketGaps)];
+
+    const stage5Handoff = {
+      pricingLandscape,
+      competitivePositioning,
+      marketGaps: uniqueGaps,
+    };
+
+    return { ...data, stage5Handoff };
   },
 };
 
-export { THREAT_LEVELS };
+TEMPLATE.analysisStep = analyzeStage04;
+
+export { THREAT_LEVELS, PRICING_MODELS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-05.js
+++ b/lib/eva/stage-templates/stage-05.js
@@ -1,29 +1,44 @@
 /**
- * Stage 05 Template - Profitability
+ * Stage 05 Template - Profitability Kill Gate
  * Phase: THE TRUTH (Stages 1-5)
- * Part of SD-LEO-FEAT-TMPL-TRUTH-001
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
- * 3-year financial model with break-even calculation, ROI threshold,
- * and deterministic KILL GATE enforcement.
+ * Financial model with unit economics, scenario analysis, and banded ROI gate:
+ *   PASS:             roi3y ≥ 0.25 AND breakEvenMonth ≤ 24 AND ltvCacRatio ≥ 2 AND paybackMonths ≤ 18
+ *   CONDITIONAL_PASS: 0.15 ≤ roi3y < 0.25 AND ltvCacRatio ≥ 3 AND paybackMonths ≤ 12 → Chairman Review
+ *   KILL:             roi3y < 0.15 OR breakEvenMonth > 24 OR breakEvenMonth === null
  *
- * Kill gate triggers when:
- * - ROI3Y < 0.5
- * - breakEvenMonth is null (non-profitable Year 1)
- * - breakEvenMonth > 24
+ * Cross-stage contracts:
+ *   ← Stage 4: stage5Handoff (pricingLandscape, competitivePositioning, marketGaps)
+ *   ← Stage 3: market validation metrics, competitiveBarrier score
+ *   ← Stage 1: archetype, targetMarket
+ *   → Stage 6: unit economics (cac, ltv, churnRate)
+ *   → Stage 9: financial profile (projections, unitEconomics, scenarioAnalysis)
+ *   → Stage 16: projection baseline for financial tracking
  *
  * @module lib/eva/stage-templates/stage-05
  */
 
-import { validateNumber, collectErrors } from './validation.js';
+import { validateNumber, validateString, collectErrors } from './validation.js';
+import { analyzeStage05 } from './analysis-steps/stage-05-financial-model.js';
 
-const ROI_THRESHOLD = 0.5;
+// Banded ROI thresholds (architecture spec)
+const ROI_PASS_THRESHOLD = 0.25;
+const ROI_CONDITIONAL_THRESHOLD = 0.15;
 const MAX_BREAKEVEN_MONTHS = 24;
+const LTV_CAC_THRESHOLD = 2;
+const PAYBACK_THRESHOLD = 18;
+// Conditional pass supplementary thresholds
+const CONDITIONAL_LTV_CAC_THRESHOLD = 3;
+const CONDITIONAL_PAYBACK_THRESHOLD = 12;
+
+const ROBUSTNESS_LEVELS = ['fragile', 'normal', 'resilient'];
 
 const TEMPLATE = {
   id: 'stage-05',
   slug: 'profitability',
-  title: 'Profitability',
-  version: '1.0.0',
+  title: 'Profitability Kill Gate',
+  version: '2.0.0',
   schema: {
     initialInvestment: { type: 'number', min: 0.01, required: true },
     year1: {
@@ -41,6 +56,39 @@ const TEMPLATE = {
       cogs: { type: 'number', min: 0, required: true },
       opex: { type: 'number', min: 0, required: true },
     },
+    // Unit economics
+    unitEconomics: {
+      type: 'object',
+      required: true,
+      properties: {
+        cac: { type: 'number', min: 0, required: true },
+        ltv: { type: 'number', min: 0, required: true },
+        ltvCacRatio: { type: 'number', derived: true },
+        churnRate: { type: 'number', min: 0, max: 1, required: true },
+        paybackMonths: { type: 'number', min: 0, required: true },
+        grossMargin: { type: 'number', min: 0, max: 1, required: true },
+      },
+    },
+    // Scenario analysis
+    scenarioAnalysis: {
+      type: 'object',
+      required: false,
+      properties: {
+        pessimisticMultiplier: { type: 'number' },
+        optimisticMultiplier: { type: 'number' },
+        robustness: { type: 'enum', values: ROBUSTNESS_LEVELS },
+      },
+    },
+    // Documented assumptions
+    assumptions: {
+      type: 'object',
+      required: false,
+    },
+    // Stage 4 context carried forward
+    stage4Context: {
+      type: 'object',
+      required: false,
+    },
     // Derived fields
     grossProfitY1: { type: 'number', derived: true },
     grossProfitY2: { type: 'number', derived: true },
@@ -50,15 +98,20 @@ const TEMPLATE = {
     netProfitY3: { type: 'number', derived: true },
     breakEvenMonth: { type: 'number', nullable: true, derived: true },
     roi3y: { type: 'number', derived: true },
-    decision: { type: 'enum', values: ['pass', 'kill'], derived: true },
+    decision: { type: 'enum', values: ['pass', 'conditional_pass', 'kill'], derived: true },
     blockProgression: { type: 'boolean', derived: true },
     reasons: { type: 'array', derived: true },
+    remediationRoute: { type: 'string', derived: true },
   },
   defaultData: {
     initialInvestment: null,
     year1: { revenue: 0, cogs: 0, opex: 0 },
     year2: { revenue: 0, cogs: 0, opex: 0 },
     year3: { revenue: 0, cogs: 0, opex: 0 },
+    unitEconomics: { cac: 0, ltv: 0, ltvCacRatio: null, churnRate: 0, paybackMonths: 0, grossMargin: 0 },
+    scenarioAnalysis: null,
+    assumptions: null,
+    stage4Context: null,
     grossProfitY1: null,
     grossProfitY2: null,
     grossProfitY3: null,
@@ -70,6 +123,7 @@ const TEMPLATE = {
     decision: null,
     blockProgression: false,
     reasons: [],
+    remediationRoute: null,
   },
 
   /**
@@ -98,11 +152,34 @@ const TEMPLATE = {
       errors.push(...collectErrors(results));
     }
 
+    // Unit economics validation
+    if (!data?.unitEconomics || typeof data.unitEconomics !== 'object') {
+      errors.push('unitEconomics is required and must be an object');
+    } else {
+      const ue = data.unitEconomics;
+      const ueResults = [
+        validateNumber(ue.cac, 'unitEconomics.cac', 0),
+        validateNumber(ue.ltv, 'unitEconomics.ltv', 0),
+        validateNumber(ue.churnRate, 'unitEconomics.churnRate', 0),
+        validateNumber(ue.paybackMonths, 'unitEconomics.paybackMonths', 0),
+        validateNumber(ue.grossMargin, 'unitEconomics.grossMargin', 0),
+      ];
+      errors.push(...collectErrors(ueResults));
+
+      // churnRate and grossMargin must be 0-1
+      if (typeof ue.churnRate === 'number' && (ue.churnRate < 0 || ue.churnRate > 1)) {
+        errors.push('unitEconomics.churnRate must be between 0 and 1');
+      }
+      if (typeof ue.grossMargin === 'number' && (ue.grossMargin < 0 || ue.grossMargin > 1)) {
+        errors.push('unitEconomics.grossMargin must be between 0 and 1');
+      }
+    }
+
     return { valid: errors.length === 0, errors };
   },
 
   /**
-   * Compute derived fields: gross/net profit, break-even, ROI, kill gate.
+   * Compute derived fields: profit, break-even, ROI, unit economics, kill gate.
    * @param {Object} data - Validated input data
    * @returns {Object} Data with all derived fields
    */
@@ -125,9 +202,20 @@ const TEMPLATE = {
       breakEvenMonth = Math.ceil(data.initialInvestment / monthlyNetProfit);
     }
 
-    const { decision, blockProgression, reasons } = evaluateKillGate({
+    // Compute LTV/CAC ratio
+    const ue = data.unitEconomics || {};
+    const ltvCacRatio = ue.cac > 0 ? ue.ltv / ue.cac : null;
+
+    const updatedUnitEconomics = {
+      ...ue,
+      ltvCacRatio,
+    };
+
+    const { decision, blockProgression, reasons, remediationRoute } = evaluateKillGate({
       roi3y,
       breakEvenMonth,
+      ltvCacRatio,
+      paybackMonths: ue.paybackMonths,
     });
 
     return {
@@ -140,23 +228,30 @@ const TEMPLATE = {
       netProfitY3,
       breakEvenMonth,
       roi3y,
+      unitEconomics: updatedUnitEconomics,
       decision,
       blockProgression,
       reasons,
+      remediationRoute,
     };
   },
 };
 
 /**
- * Pure function: evaluate kill gate for Stage 05.
- * Kill if ROI3Y < 0.5 OR breakEvenMonth is null OR breakEvenMonth > 24.
+ * Pure function: evaluate banded kill gate for Stage 05.
  *
- * @param {{ roi3y: number, breakEvenMonth: number|null }} params
- * @returns {{ decision: 'pass'|'kill', blockProgression: boolean, reasons: Object[] }}
+ * PASS:             roi3y ≥ 0.25 AND breakEvenMonth ≤ 24 AND ltvCacRatio ≥ 2 AND paybackMonths ≤ 18
+ * CONDITIONAL_PASS: 0.15 ≤ roi3y < 0.25 AND ltvCacRatio ≥ 3 AND paybackMonths ≤ 12
+ * KILL:             roi3y < 0.15 OR breakEvenMonth > 24 OR breakEvenMonth === null
+ *
+ * @param {{ roi3y: number, breakEvenMonth: number|null, ltvCacRatio: number|null, paybackMonths: number }} params
+ * @returns {{ decision: string, blockProgression: boolean, reasons: Object[], remediationRoute: string|null }}
  */
-export function evaluateKillGate({ roi3y, breakEvenMonth }) {
+export function evaluateKillGate({ roi3y, breakEvenMonth, ltvCacRatio, paybackMonths }) {
   const reasons = [];
+  let remediationRoute = null;
 
+  // Hard kill conditions
   if (breakEvenMonth === null) {
     reasons.push({
       type: 'no_break_even_year1',
@@ -171,22 +266,88 @@ export function evaluateKillGate({ roi3y, breakEvenMonth }) {
     });
   }
 
-  if (roi3y < ROI_THRESHOLD) {
+  if (roi3y < ROI_CONDITIONAL_THRESHOLD) {
     reasons.push({
-      type: 'roi_below_threshold',
-      message: `3-year ROI of ${(roi3y * 100).toFixed(1)}% is below threshold ${ROI_THRESHOLD * 100}%`,
-      threshold: ROI_THRESHOLD,
+      type: 'roi_below_kill_threshold',
+      message: `3-year ROI of ${(roi3y * 100).toFixed(1)}% is below kill threshold ${ROI_CONDITIONAL_THRESHOLD * 100}%`,
+      threshold: ROI_CONDITIONAL_THRESHOLD,
       actual: roi3y,
     });
   }
 
-  const decision = reasons.length > 0 ? 'kill' : 'pass';
-  return {
-    decision,
-    blockProgression: decision === 'kill',
-    reasons,
-  };
+  // Kill: hard conditions triggered
+  if (reasons.length > 0) {
+    remediationRoute = roi3y < 0
+      ? 'Revisit Stage 1 problem definition and target market'
+      : 'Revisit Stage 2 assumptions and market sizing';
+    return { decision: 'kill', blockProgression: true, reasons, remediationRoute };
+  }
+
+  // Conditional pass band: 0.15 ≤ ROI < 0.25
+  if (roi3y < ROI_PASS_THRESHOLD) {
+    // Check supplementary metrics for conditional pass
+    const supplementaryPass =
+      ltvCacRatio !== null && ltvCacRatio >= CONDITIONAL_LTV_CAC_THRESHOLD &&
+      paybackMonths <= CONDITIONAL_PAYBACK_THRESHOLD;
+
+    if (supplementaryPass) {
+      reasons.push({
+        type: 'roi_in_conditional_band',
+        message: `3-year ROI of ${(roi3y * 100).toFixed(1)}% is in conditional band (${ROI_CONDITIONAL_THRESHOLD * 100}%-${ROI_PASS_THRESHOLD * 100}%). Supplementary metrics strong — routing to Chairman Review.`,
+        threshold: ROI_PASS_THRESHOLD,
+        actual: roi3y,
+      });
+      return { decision: 'conditional_pass', blockProgression: true, reasons, remediationRoute: null };
+    }
+
+    // Supplementary metrics too weak for conditional pass → kill
+    reasons.push({
+      type: 'roi_conditional_supplementary_fail',
+      message: `3-year ROI of ${(roi3y * 100).toFixed(1)}% is in conditional band but supplementary metrics insufficient (ltvCacRatio: ${ltvCacRatio?.toFixed(1) ?? 'N/A'}, paybackMonths: ${paybackMonths})`,
+      threshold: ROI_PASS_THRESHOLD,
+      actual: roi3y,
+    });
+    remediationRoute = 'Improve unit economics: reduce CAC or increase LTV';
+    return { decision: 'kill', blockProgression: true, reasons, remediationRoute };
+  }
+
+  // Full pass: ROI ≥ 0.25
+  // Check additional pass criteria
+  if (ltvCacRatio !== null && ltvCacRatio < LTV_CAC_THRESHOLD) {
+    reasons.push({
+      type: 'ltv_cac_below_threshold',
+      message: `LTV/CAC ratio ${ltvCacRatio.toFixed(1)} is below minimum ${LTV_CAC_THRESHOLD}`,
+      threshold: LTV_CAC_THRESHOLD,
+      actual: ltvCacRatio,
+    });
+    remediationRoute = 'Improve unit economics: reduce CAC or increase LTV';
+    return { decision: 'kill', blockProgression: true, reasons, remediationRoute };
+  }
+
+  if (paybackMonths > PAYBACK_THRESHOLD) {
+    reasons.push({
+      type: 'payback_too_long',
+      message: `Payback period ${paybackMonths} months exceeds maximum ${PAYBACK_THRESHOLD} months`,
+      threshold: PAYBACK_THRESHOLD,
+      actual: paybackMonths,
+    });
+    remediationRoute = 'Reduce customer acquisition cost or increase early revenue';
+    return { decision: 'kill', blockProgression: true, reasons, remediationRoute };
+  }
+
+  return { decision: 'pass', blockProgression: false, reasons: [], remediationRoute: null };
 }
 
-export { ROI_THRESHOLD, MAX_BREAKEVEN_MONTHS };
+TEMPLATE.analysisStep = analyzeStage05;
+
+export {
+  ROI_PASS_THRESHOLD,
+  ROI_CONDITIONAL_THRESHOLD,
+  MAX_BREAKEVEN_MONTHS,
+  LTV_CAC_THRESHOLD,
+  PAYBACK_THRESHOLD,
+  CONDITIONAL_LTV_CAC_THRESHOLD,
+  CONDITIONAL_PAYBACK_THRESHOLD,
+  ROBUSTNESS_LEVELS,
+};
 export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/index.test.js
+++ b/tests/unit/eva/stage-templates/index.test.js
@@ -74,7 +74,7 @@ describe('index.js - Stage templates registry', () => {
 
     it('should have correct Phase 1 template slugs', () => {
       expect(stage01.slug).toBe('draft-idea');
-      expect(stage02.slug).toBe('ai-review');
+      expect(stage02.slug).toBe('idea-validation');
       expect(stage03.slug).toBe('validation');
       expect(stage04.slug).toBe('competitive-intel');
       expect(stage05.slug).toBe('profitability');
@@ -489,10 +489,10 @@ describe('index.js - Stage templates registry', () => {
       });
     });
 
-    it('all templates should have version 1.0.0', () => {
+    it('all templates should have a valid version', () => {
       const templates = getAllTemplates();
       templates.forEach(template => {
-        expect(template.version).toBe('1.0.0');
+        expect(template.version).toMatch(/^\d+\.\d+\.\d+$/);
       });
     });
 

--- a/tests/unit/eva/stage-templates/stage-01.test.js
+++ b/tests/unit/eva/stage-templates/stage-01.test.js
@@ -1,14 +1,16 @@
 /**
- * Unit tests for Stage 01 - Draft Idea template
- * Part of SD-LEO-FEAT-TMPL-TRUTH-001
+ * Unit tests for Stage 01 - Draft Idea template (v2.0.0)
+ * Phase: THE TRUTH (Stages 1-5)
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
- * Test Scenario TS-1: Stage 01 validation enforces minimum lengths and required fields
+ * Tests: validation (required fields, archetype enum, optional arrays),
+ *        computeDerived (sourceProvenance tracking), ARCHETYPES export
  *
  * @module tests/unit/eva/stage-templates/stage-01.test
  */
 
 import { describe, it, expect } from 'vitest';
-import stage01 from '../../../../lib/eva/stage-templates/stage-01.js';
+import stage01, { ARCHETYPES } from '../../../../lib/eva/stage-templates/stage-01.js';
 
 describe('stage-01.js - Draft Idea template', () => {
   describe('Template metadata', () => {
@@ -16,155 +18,135 @@ describe('stage-01.js - Draft Idea template', () => {
       expect(stage01.id).toBe('stage-01');
       expect(stage01.slug).toBe('draft-idea');
       expect(stage01.title).toBe('Draft Idea');
-      expect(stage01.version).toBe('1.0.0');
+      expect(stage01.version).toBe('2.0.0');
     });
 
-    it('should have schema definition', () => {
+    it('should export ARCHETYPES enum', () => {
+      expect(ARCHETYPES).toEqual([
+        'saas', 'marketplace', 'deeptech', 'hardware', 'services', 'media', 'fintech',
+      ]);
+    });
+
+    it('should have schema definition with new fields', () => {
       expect(stage01.schema).toBeDefined();
       expect(stage01.schema.description).toEqual({
-        type: 'string',
-        minLength: 50,
-        required: true,
+        type: 'string', minLength: 50, required: true,
+      });
+      expect(stage01.schema.problemStatement).toEqual({
+        type: 'string', minLength: 20, required: true,
       });
       expect(stage01.schema.valueProp).toEqual({
-        type: 'string',
-        minLength: 20,
-        required: true,
+        type: 'string', minLength: 20, required: true,
       });
       expect(stage01.schema.targetMarket).toEqual({
-        type: 'string',
-        minLength: 10,
-        required: true,
+        type: 'string', minLength: 10, required: true,
       });
+      expect(stage01.schema.archetype.type).toBe('enum');
+      expect(stage01.schema.archetype.values).toEqual(ARCHETYPES);
+      expect(stage01.schema.sourceProvenance.derived).toBe(true);
     });
 
-    it('should have defaultData', () => {
+    it('should have defaultData with all fields', () => {
       expect(stage01.defaultData).toEqual({
         description: '',
+        problemStatement: '',
         valueProp: '',
         targetMarket: '',
+        archetype: null,
+        keyAssumptions: [],
+        moatStrategy: '',
+        successCriteria: [],
+        sourceProvenance: {},
       });
     });
 
-    it('should have validate function', () => {
+    it('should have validate and computeDerived functions', () => {
       expect(typeof stage01.validate).toBe('function');
+      expect(typeof stage01.computeDerived).toBe('function');
     });
 
-    it('should have computeDerived function', () => {
-      expect(typeof stage01.computeDerived).toBe('function');
+    it('should have analysisStep attached', () => {
+      expect(typeof stage01.analysisStep).toBe('function');
     });
   });
 
-  describe('validate() - TS-1: Minimum lengths and required fields', () => {
+  const makeValid = (overrides = {}) => ({
+    description: 'x'.repeat(50),
+    problemStatement: 'y'.repeat(20),
+    valueProp: 'z'.repeat(20),
+    targetMarket: 'w'.repeat(10),
+    archetype: 'saas',
+    ...overrides,
+  });
+
+  describe('validate() - Required fields', () => {
     it('should pass for valid data meeting all requirements', () => {
-      const validData = {
-        description: 'A' + 'x'.repeat(50), // 51 chars
-        valueProp: 'B' + 'y'.repeat(20), // 21 chars
-        targetMarket: 'C' + 'z'.repeat(10), // 11 chars
-      };
-      const result = stage01.validate(validData);
+      const result = stage01.validate(makeValid());
       expect(result.valid).toBe(true);
       expect(result.errors).toEqual([]);
     });
 
     it('should pass for data at exact minimum lengths', () => {
-      const validData = {
-        description: 'x'.repeat(50), // exactly 50 chars
-        valueProp: 'y'.repeat(20), // exactly 20 chars
-        targetMarket: 'z'.repeat(10), // exactly 10 chars
-      };
-      const result = stage01.validate(validData);
+      const result = stage01.validate(makeValid());
       expect(result.valid).toBe(true);
-      expect(result.errors).toEqual([]);
     });
 
     it('should fail for description below minimum length (50)', () => {
-      const invalidData = {
-        description: 'Too short',
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'z'.repeat(10),
-      };
-      const result = stage01.validate(invalidData);
+      const result = stage01.validate(makeValid({ description: 'Too short' }));
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toContain('description');
-      expect(result.errors[0]).toContain('must be at least 50 characters');
+    });
+
+    it('should fail for problemStatement below minimum length (20)', () => {
+      const result = stage01.validate(makeValid({ problemStatement: 'Short' }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('problemStatement');
     });
 
     it('should fail for valueProp below minimum length (20)', () => {
-      const invalidData = {
-        description: 'x'.repeat(50),
-        valueProp: 'Short value',
-        targetMarket: 'z'.repeat(10),
-      };
-      const result = stage01.validate(invalidData);
+      const result = stage01.validate(makeValid({ valueProp: 'Short' }));
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toContain('valueProp');
-      expect(result.errors[0]).toContain('must be at least 20 characters');
     });
 
     it('should fail for targetMarket below minimum length (10)', () => {
-      const invalidData = {
-        description: 'x'.repeat(50),
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'SMB',
-      };
-      const result = stage01.validate(invalidData);
+      const result = stage01.validate(makeValid({ targetMarket: 'SMB' }));
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toContain('targetMarket');
-      expect(result.errors[0]).toContain('must be at least 10 characters');
     });
 
-    it('should fail for missing description', () => {
-      const invalidData = {
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'z'.repeat(10),
-      };
-      const result = stage01.validate(invalidData);
+    it('should fail for invalid archetype', () => {
+      const result = stage01.validate(makeValid({ archetype: 'invalid_type' }));
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toContain('description');
-      expect(result.errors[0]).toContain('is required');
+      expect(result.errors[0]).toContain('archetype');
+      expect(result.errors[0]).toContain('must be one of');
     });
 
-    it('should fail for missing valueProp', () => {
-      const invalidData = {
-        description: 'x'.repeat(50),
-        targetMarket: 'z'.repeat(10),
-      };
-      const result = stage01.validate(invalidData);
+    it('should fail for missing archetype', () => {
+      const data = makeValid();
+      delete data.archetype;
+      const result = stage01.validate(data);
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toContain('valueProp');
-      expect(result.errors[0]).toContain('is required');
+      expect(result.errors[0]).toContain('archetype');
     });
 
-    it('should fail for missing targetMarket', () => {
-      const invalidData = {
-        description: 'x'.repeat(50),
-        valueProp: 'y'.repeat(20),
-      };
-      const result = stage01.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toContain('targetMarket');
-      expect(result.errors[0]).toContain('is required');
+    it('should accept all valid archetypes', () => {
+      for (const archetype of ARCHETYPES) {
+        const result = stage01.validate(makeValid({ archetype }));
+        expect(result.valid).toBe(true);
+      }
     });
 
     it('should collect multiple validation errors', () => {
-      const invalidData = {
+      const result = stage01.validate({
         description: 'Short',
-        valueProp: 'Short',
-        targetMarket: 'SMB',
-      };
-      const result = stage01.validate(invalidData);
+        problemStatement: 'S',
+        valueProp: 'S',
+        targetMarket: 'S',
+        archetype: 'invalid',
+      });
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(3);
-      expect(result.errors[0]).toContain('description');
-      expect(result.errors[1]).toContain('valueProp');
-      expect(result.errors[2]).toContain('targetMarket');
+      expect(result.errors.length).toBeGreaterThanOrEqual(4);
     });
 
     it('should fail for null data', () => {
@@ -178,90 +160,85 @@ describe('stage-01.js - Draft Idea template', () => {
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
     });
+  });
 
-    it('should trim whitespace when validating lengths', () => {
-      const invalidData = {
-        description: '   ' + 'x'.repeat(45) + '   ', // 45 non-whitespace chars
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'z'.repeat(10),
-      };
-      const result = stage01.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('description');
-      expect(result.errors[0]).toContain('got 45');
+  describe('validate() - Optional arrays', () => {
+    it('should pass when keyAssumptions is omitted', () => {
+      const result = stage01.validate(makeValid());
+      expect(result.valid).toBe(true);
     });
 
-    it('should fail for non-string fields', () => {
-      const invalidData = {
-        description: 12345,
-        valueProp: true,
-        targetMarket: { text: 'SMB' },
-      };
-      const result = stage01.validate(invalidData);
+    it('should pass when keyAssumptions is a valid array', () => {
+      const result = stage01.validate(makeValid({ keyAssumptions: ['assumption 1'] }));
+      expect(result.valid).toBe(true);
+    });
+
+    it('should fail when keyAssumptions is not an array', () => {
+      const result = stage01.validate(makeValid({ keyAssumptions: 'not array' }));
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(3);
-      expect(result.errors[0]).toContain('must be a string');
-      expect(result.errors[1]).toContain('must be a string');
-      expect(result.errors[2]).toContain('must be a string');
+      expect(result.errors[0]).toContain('keyAssumptions');
+    });
+
+    it('should pass when successCriteria is a valid array', () => {
+      const result = stage01.validate(makeValid({ successCriteria: ['criterion 1'] }));
+      expect(result.valid).toBe(true);
+    });
+
+    it('should fail when successCriteria is not an array', () => {
+      const result = stage01.validate(makeValid({ successCriteria: 'not array' }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('successCriteria');
     });
   });
 
-  describe('computeDerived()', () => {
-    it('should return data unchanged (no derived fields)', () => {
-      const inputData = {
-        description: 'x'.repeat(50),
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'z'.repeat(10),
-      };
-      const result = stage01.computeDerived(inputData);
-      expect(result).toEqual(inputData);
+  describe('computeDerived() - Source provenance tracking', () => {
+    it('should mark all fields as user when no stage0Output', () => {
+      const data = makeValid();
+      const result = stage01.computeDerived(data);
+      expect(result.sourceProvenance).toBeDefined();
+      expect(result.sourceProvenance.description).toBe('user');
+      expect(result.sourceProvenance.archetype).toBe('user');
+    });
+
+    it('should mark fields as stage0 when present in stage0Output', () => {
+      const data = makeValid();
+      const stage0 = { description: 'from stage0', archetype: 'saas' };
+      const result = stage01.computeDerived(data, stage0);
+      expect(result.sourceProvenance.description).toBe('stage0');
+      expect(result.sourceProvenance.archetype).toBe('stage0');
+      expect(result.sourceProvenance.valueProp).toBe('user');
+    });
+
+    it('should not include empty fields in provenance', () => {
+      const data = makeValid({ moatStrategy: '' });
+      const result = stage01.computeDerived(data);
+      expect(result.sourceProvenance.moatStrategy).toBeUndefined();
     });
 
     it('should not mutate original data', () => {
-      const inputData = {
-        description: 'x'.repeat(50),
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'z'.repeat(10),
-      };
-      const original = { ...inputData };
-      stage01.computeDerived(inputData);
-      expect(inputData).toEqual(original);
+      const data = makeValid();
+      const original = { ...data };
+      stage01.computeDerived(data);
+      expect(data).toEqual(original);
     });
 
-    it('should preserve additional properties', () => {
-      const inputData = {
-        description: 'x'.repeat(50),
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'z'.repeat(10),
-        extraField: 'preserved',
-      };
-      const result = stage01.computeDerived(inputData);
-      expect(result.extraField).toBe('preserved');
+    it('should preserve all input fields', () => {
+      const data = makeValid({ keyAssumptions: ['a1'], successCriteria: ['c1'] });
+      const result = stage01.computeDerived(data);
+      expect(result.description).toBe(data.description);
+      expect(result.archetype).toBe('saas');
+      expect(result.keyAssumptions).toEqual(['a1']);
     });
   });
 
   describe('Integration: validate + computeDerived workflow', () => {
     it('should work together for valid data', () => {
-      const data = {
-        description: 'x'.repeat(50),
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'z'.repeat(10),
-      };
+      const data = makeValid();
       const validation = stage01.validate(data);
       expect(validation.valid).toBe(true);
 
       const computed = stage01.computeDerived(data);
-      expect(computed).toEqual(data);
-    });
-
-    it('should not require validation before computeDerived (decoupled)', () => {
-      const data = {
-        description: 'Short', // Invalid but computeDerived should still work
-        valueProp: 'y'.repeat(20),
-        targetMarket: 'z'.repeat(10),
-      };
-      const computed = stage01.computeDerived(data);
-      expect(computed).toEqual(data);
+      expect(computed.sourceProvenance).toBeDefined();
     });
   });
 });

--- a/tests/unit/eva/stage-templates/stage-02.test.js
+++ b/tests/unit/eva/stage-templates/stage-02.test.js
@@ -1,360 +1,294 @@
 /**
- * Unit tests for Stage 02 - AI Review template
- * Part of SD-LEO-FEAT-TMPL-TRUTH-001
+ * Unit tests for Stage 02 - Idea Validation (MoA Multi-Persona Analysis) template (v2.0.0)
+ * Phase: THE TRUTH (Stages 1-5)
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
- * Test Scenario TS-2: Stage 02 compositeScore is deterministic across critique ordering
+ * Tests: validation (analysis perspectives, 6 metrics, evidence domains, suggestions),
+ *        computeDerived (compositeScore from metrics average), METRIC_NAMES export
  *
  * @module tests/unit/eva/stage-templates/stage-02.test
  */
 
 import { describe, it, expect } from 'vitest';
-import stage02 from '../../../../lib/eva/stage-templates/stage-02.js';
+import stage02, { METRIC_NAMES, SUGGESTION_TYPES } from '../../../../lib/eva/stage-templates/stage-02.js';
 
-describe('stage-02.js - AI Review template', () => {
+describe('stage-02.js - Idea Validation template', () => {
   describe('Template metadata', () => {
     it('should have correct template structure', () => {
       expect(stage02.id).toBe('stage-02');
-      expect(stage02.slug).toBe('ai-review');
-      expect(stage02.title).toBe('AI Review');
-      expect(stage02.version).toBe('1.0.0');
+      expect(stage02.slug).toBe('idea-validation');
+      expect(stage02.title).toBe('Idea Validation');
+      expect(stage02.version).toBe('2.0.0');
     });
 
-    it('should have schema definition', () => {
-      expect(stage02.schema).toBeDefined();
-      expect(stage02.schema.critiques).toBeDefined();
-      expect(stage02.schema.compositeScore).toEqual({
-        type: 'integer',
-        min: 0,
-        max: 100,
-        derived: true,
-      });
+    it('should export METRIC_NAMES aligned with Stage 3', () => {
+      expect(METRIC_NAMES).toEqual([
+        'marketFit', 'customerNeed', 'momentum',
+        'revenuePotential', 'competitiveBarrier', 'executionFeasibility',
+      ]);
+    });
+
+    it('should export SUGGESTION_TYPES', () => {
+      expect(SUGGESTION_TYPES).toEqual(['immediate', 'strategic']);
+    });
+
+    it('should have schema with analysis, metrics, evidence, suggestions', () => {
+      expect(stage02.schema.analysis).toBeDefined();
+      expect(stage02.schema.metrics).toBeDefined();
+      expect(stage02.schema.evidence).toBeDefined();
+      expect(stage02.schema.suggestions).toBeDefined();
+      expect(stage02.schema.compositeScore.derived).toBe(true);
     });
 
     it('should have defaultData', () => {
-      expect(stage02.defaultData).toEqual({
-        critiques: [],
-        compositeScore: null,
+      expect(stage02.defaultData.analysis).toEqual({ strategic: '', technical: '', tactical: '' });
+      expect(stage02.defaultData.compositeScore).toBeNull();
+      expect(stage02.defaultData.suggestions).toEqual([]);
+    });
+
+    it('should have analysisStep attached', () => {
+      expect(typeof stage02.analysisStep).toBe('function');
+    });
+  });
+
+  const makeValid = (overrides = {}) => ({
+    analysis: {
+      strategic: 'x'.repeat(20),
+      technical: 'y'.repeat(20),
+      tactical: 'z'.repeat(20),
+    },
+    metrics: {
+      marketFit: 75, customerNeed: 80, momentum: 70,
+      revenuePotential: 85, competitiveBarrier: 65, executionFeasibility: 90,
+    },
+    evidence: {
+      market: 'Market evidence here',
+      customer: 'Customer evidence here',
+      competitive: 'Competitive evidence here',
+      execution: 'Execution evidence here',
+    },
+    suggestions: [],
+    ...overrides,
+  });
+
+  describe('validate() - Analysis perspectives', () => {
+    it('should pass for valid data', () => {
+      const result = stage02.validate(makeValid());
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should fail for missing analysis object', () => {
+      const result = stage02.validate(makeValid({ analysis: undefined }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('analysis');
+    });
+
+    it('should fail for analysis.strategic below min length (20)', () => {
+      const result = stage02.validate(makeValid({
+        analysis: { strategic: 'Short', technical: 'y'.repeat(20), tactical: 'z'.repeat(20) },
+      }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('analysis.strategic');
+    });
+
+    it('should fail for analysis.technical below min length', () => {
+      const result = stage02.validate(makeValid({
+        analysis: { strategic: 'x'.repeat(20), technical: 'Short', tactical: 'z'.repeat(20) },
+      }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('analysis.technical');
+    });
+
+    it('should fail for analysis.tactical below min length', () => {
+      const result = stage02.validate(makeValid({
+        analysis: { strategic: 'x'.repeat(20), technical: 'y'.repeat(20), tactical: 'Short' },
+      }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('analysis.tactical');
+    });
+  });
+
+  describe('validate() - 6 metrics (0-100 integer)', () => {
+    it('should fail for missing metrics object', () => {
+      const result = stage02.validate(makeValid({ metrics: undefined }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('metrics');
+    });
+
+    it('should fail for metric below 0', () => {
+      const data = makeValid();
+      data.metrics.marketFit = -1;
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('metrics.marketFit');
+    });
+
+    it('should fail for metric above 100', () => {
+      const data = makeValid();
+      data.metrics.customerNeed = 101;
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('metrics.customerNeed');
+    });
+
+    it('should fail for non-integer metric', () => {
+      const data = makeValid();
+      data.metrics.momentum = 75.5;
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('metrics.momentum');
+    });
+
+    it('should pass for boundary values (0 and 100)', () => {
+      const data = makeValid();
+      data.metrics.marketFit = 0;
+      data.metrics.executionFeasibility = 100;
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe('validate() - Evidence domains', () => {
+    it('should fail for missing evidence object', () => {
+      const result = stage02.validate(makeValid({ evidence: undefined }));
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('evidence');
+    });
+
+    it('should fail for empty evidence.market', () => {
+      const data = makeValid();
+      data.evidence.market = '';
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('evidence.market');
+    });
+
+    it('should fail for empty evidence.customer', () => {
+      const data = makeValid();
+      data.evidence.customer = '';
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('evidence.customer');
+    });
+  });
+
+  describe('validate() - Suggestions (optional)', () => {
+    it('should pass with valid suggestions', () => {
+      const data = makeValid({
+        suggestions: [
+          { type: 'immediate', text: 'Do this first thing to validate' },
+          { type: 'strategic', text: 'Long term plan for market entry' },
+        ],
       });
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should pass with empty suggestions array', () => {
+      const result = stage02.validate(makeValid({ suggestions: [] }));
+      expect(result.valid).toBe(true);
+    });
+
+    it('should fail for suggestions with invalid type', () => {
+      const data = makeValid({
+        suggestions: [{ type: 'invalid', text: 'Some text here please' }],
+      });
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('suggestions[0].type');
+    });
+
+    it('should fail for suggestions with short text', () => {
+      const data = makeValid({
+        suggestions: [{ type: 'immediate', text: 'Short' }],
+      });
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('suggestions[0].text');
+    });
+
+    it('should fail for non-array suggestions', () => {
+      const data = makeValid({ suggestions: 'not an array' });
+      const result = stage02.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('suggestions');
     });
   });
 
-  describe('validate() - Critiques array validation', () => {
-    const validCritique = {
-      model: 'GPT-4',
-      summary: 'A' + 'x'.repeat(20), // 21 chars
-      strengths: ['Strong point 1'],
-      risks: ['Risk 1'],
-      score: 75,
-    };
-
-    it('should pass for valid data with single critique', () => {
-      const data = { critiques: [validCritique] };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toEqual([]);
-    });
-
-    it('should pass for valid data with multiple critiques', () => {
-      const data = {
-        critiques: [
-          { ...validCritique, model: 'GPT-4', score: 80 },
-          { ...validCritique, model: 'Claude', score: 70 },
-          { ...validCritique, model: 'Gemini', score: 85 },
-        ],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toEqual([]);
-    });
-
-    it('should fail for empty critiques array', () => {
-      const data = { critiques: [] };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toContain('critiques');
-      expect(result.errors[0]).toContain('must have at least 1 item');
-    });
-
-    it('should fail for missing critiques field', () => {
-      const data = {};
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques');
-    });
-
-    it('should fail for non-array critiques', () => {
-      const data = { critiques: 'not an array' };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('must be an array');
-    });
-
-    it('should fail for critique with missing model', () => {
-      const data = {
-        critiques: [{
-          summary: 'x'.repeat(20),
-          strengths: ['S1'],
-          risks: ['R1'],
-          score: 75,
-        }],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques[0].model');
-      expect(result.errors[0]).toContain('is required');
-    });
-
-    it('should fail for critique with summary below minimum length', () => {
-      const data = {
-        critiques: [{
-          model: 'GPT-4',
-          summary: 'Too short',
-          strengths: ['S1'],
-          risks: ['R1'],
-          score: 75,
-        }],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques[0].summary');
-      expect(result.errors[0]).toContain('must be at least 20 characters');
-    });
-
-    it('should fail for critique with empty strengths array', () => {
-      const data = {
-        critiques: [{
-          model: 'GPT-4',
-          summary: 'x'.repeat(20),
-          strengths: [],
-          risks: ['R1'],
-          score: 75,
-        }],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques[0].strengths');
-      expect(result.errors[0]).toContain('must have at least 1 item');
-    });
-
-    it('should fail for critique with empty risks array', () => {
-      const data = {
-        critiques: [{
-          model: 'GPT-4',
-          summary: 'x'.repeat(20),
-          strengths: ['S1'],
-          risks: [],
-          score: 75,
-        }],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques[0].risks');
-      expect(result.errors[0]).toContain('must have at least 1 item');
-    });
-
-    it('should fail for critique with missing score', () => {
-      const data = {
-        critiques: [{
-          model: 'GPT-4',
-          summary: 'x'.repeat(20),
-          strengths: ['S1'],
-          risks: ['R1'],
-        }],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques[0].score');
-      expect(result.errors[0]).toContain('is required');
-    });
-
-    it('should fail for critique with score below 0', () => {
-      const data = {
-        critiques: [{
-          ...validCritique,
-          score: -1,
-        }],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques[0].score');
-      expect(result.errors[0]).toContain('must be between 0 and 100');
-    });
-
-    it('should fail for critique with score above 100', () => {
-      const data = {
-        critiques: [{
-          ...validCritique,
-          score: 101,
-        }],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques[0].score');
-      expect(result.errors[0]).toContain('must be between 0 and 100');
-    });
-
-    it('should fail for critique with non-integer score', () => {
-      const data = {
-        critiques: [{
-          ...validCritique,
-          score: 75.5,
-        }],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors[0]).toContain('critiques[0].score');
-      expect(result.errors[0]).toContain('must be an integer');
-    });
-
-    it('should collect multiple errors across multiple critiques', () => {
-      const data = {
-        critiques: [
-          { ...validCritique, score: 101 },
-          { ...validCritique, summary: 'Short' },
-          { ...validCritique, strengths: [] },
-        ],
-      };
-      const result = stage02.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors.length).toBeGreaterThan(0);
-      expect(result.errors.some(e => e.includes('[0]'))).toBe(true);
-      expect(result.errors.some(e => e.includes('[1]'))).toBe(true);
-      expect(result.errors.some(e => e.includes('[2]'))).toBe(true);
-    });
-  });
-
-  describe('computeDerived() - TS-2: Deterministic compositeScore', () => {
-    it('should compute compositeScore as rounded average', () => {
-      const data = {
-        critiques: [
-          { model: 'A', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 70 },
-          { model: 'B', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 80 },
-          { model: 'C', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 90 },
-        ],
-      };
+  describe('computeDerived() - compositeScore', () => {
+    it('should compute compositeScore as rounded average of 6 metrics', () => {
+      const data = makeValid();
+      // (75+80+70+85+65+90)/6 = 465/6 = 77.5 → 78
       const result = stage02.computeDerived(data);
-      expect(result.compositeScore).toBe(80); // (70+80+90)/3 = 80
+      expect(result.compositeScore).toBe(78);
     });
 
-    it('should be deterministic across different critique orderings', () => {
-      const critiques1 = [
-        { model: 'GPT-4', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 75 },
-        { model: 'Claude', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 85 },
-        { model: 'Gemini', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 70 },
-      ];
-      const critiques2 = [
-        { model: 'Gemini', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 70 },
-        { model: 'GPT-4', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 75 },
-        { model: 'Claude', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 85 },
-      ];
-      const critiques3 = [
-        { model: 'Claude', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 85 },
-        { model: 'Gemini', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 70 },
-        { model: 'GPT-4', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 75 },
-      ];
-
-      const result1 = stage02.computeDerived({ critiques: critiques1 });
-      const result2 = stage02.computeDerived({ critiques: critiques2 });
-      const result3 = stage02.computeDerived({ critiques: critiques3 });
-
-      expect(result1.compositeScore).toBe(77); // (75+85+70)/3 = 76.67 rounds to 77
-      expect(result2.compositeScore).toBe(77);
-      expect(result3.compositeScore).toBe(77);
-      expect(result1.compositeScore).toBe(result2.compositeScore);
-      expect(result2.compositeScore).toBe(result3.compositeScore);
+    it('should be deterministic across metric orderings', () => {
+      const data1 = makeValid();
+      const data2 = makeValid();
+      expect(stage02.computeDerived(data1).compositeScore)
+        .toBe(stage02.computeDerived(data2).compositeScore);
     });
 
-    it('should round .5 up (Math.round behavior)', () => {
-      const data = {
-        critiques: [
-          { model: 'A', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 76 },
-          { model: 'B', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 77 },
-        ],
+    it('should round correctly (.5 rounds up)', () => {
+      const data = makeValid();
+      data.metrics = {
+        marketFit: 76, customerNeed: 77, momentum: 76,
+        revenuePotential: 77, competitiveBarrier: 76, executionFeasibility: 77,
       };
+      // (76+77+76+77+76+77)/6 = 459/6 = 76.5 → 77
       const result = stage02.computeDerived(data);
-      expect(result.compositeScore).toBe(77); // (76+77)/2 = 76.5 rounds to 77
+      expect(result.compositeScore).toBe(77);
     });
 
-    it('should round .49 down', () => {
-      const data = {
-        critiques: [
-          { model: 'A', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 75 },
-          { model: 'B', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 76 },
-        ],
-      };
-      const result = stage02.computeDerived(data);
-      expect(result.compositeScore).toBe(76); // (75+76)/2 = 75.5 rounds to 76
-    });
-
-    it('should return null compositeScore for empty critiques', () => {
-      const data = { critiques: [] };
+    it('should return null when no valid metrics', () => {
+      const data = makeValid();
+      data.metrics = {};
       const result = stage02.computeDerived(data);
       expect(result.compositeScore).toBeNull();
     });
 
-    it('should return null compositeScore when critiques is undefined', () => {
-      const data = {};
-      const result = stage02.computeDerived(data);
-      expect(result.compositeScore).toBeNull();
-    });
-
-    it('should handle single critique (no rounding needed)', () => {
-      const data = {
-        critiques: [
-          { model: 'A', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 88 },
-        ],
+    it('should handle boundary scores (all 0, all 100)', () => {
+      const allZero = makeValid();
+      allZero.metrics = {
+        marketFit: 0, customerNeed: 0, momentum: 0,
+        revenuePotential: 0, competitiveBarrier: 0, executionFeasibility: 0,
       };
-      const result = stage02.computeDerived(data);
-      expect(result.compositeScore).toBe(88);
+      expect(stage02.computeDerived(allZero).compositeScore).toBe(0);
+
+      const allMax = makeValid();
+      allMax.metrics = {
+        marketFit: 100, customerNeed: 100, momentum: 100,
+        revenuePotential: 100, competitiveBarrier: 100, executionFeasibility: 100,
+      };
+      expect(stage02.computeDerived(allMax).compositeScore).toBe(100);
     });
 
     it('should preserve original data fields', () => {
-      const data = {
-        critiques: [
-          { model: 'A', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 80 },
-        ],
-      };
+      const data = makeValid();
       const result = stage02.computeDerived(data);
-      expect(result.critiques).toEqual(data.critiques);
+      expect(result.analysis).toEqual(data.analysis);
+      expect(result.metrics).toEqual(data.metrics);
+      expect(result.evidence).toEqual(data.evidence);
     });
 
     it('should not mutate original data', () => {
-      const data = {
-        critiques: [
-          { model: 'A', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 80 },
-        ],
-      };
+      const data = makeValid();
       const original = JSON.parse(JSON.stringify(data));
       stage02.computeDerived(data);
       expect(data).toEqual(original);
-    });
-
-    it('should handle boundary scores (0 and 100)', () => {
-      const data = {
-        critiques: [
-          { model: 'A', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 0 },
-          { model: 'B', summary: 'x'.repeat(20), strengths: ['S'], risks: ['R'], score: 100 },
-        ],
-      };
-      const result = stage02.computeDerived(data);
-      expect(result.compositeScore).toBe(50); // (0+100)/2 = 50
     });
   });
 
   describe('Integration: validate + computeDerived workflow', () => {
     it('should work together for valid data', () => {
-      const data = {
-        critiques: [
-          { model: 'GPT-4', summary: 'x'.repeat(20), strengths: ['S1'], risks: ['R1'], score: 75 },
-          { model: 'Claude', summary: 'y'.repeat(20), strengths: ['S2'], risks: ['R2'], score: 85 },
-        ],
-      };
+      const data = makeValid();
       const validation = stage02.validate(data);
       expect(validation.valid).toBe(true);
 
       const computed = stage02.computeDerived(data);
-      expect(computed.compositeScore).toBe(80);
+      expect(computed.compositeScore).toBe(78);
     });
   });
 });

--- a/tests/unit/eva/stage-templates/stage-03.test.js
+++ b/tests/unit/eva/stage-templates/stage-03.test.js
@@ -1,9 +1,10 @@
 /**
- * Unit tests for Stage 03 - Market Validation template
- * Part of SD-LEO-FEAT-TMPL-TRUTH-001
+ * Unit tests for Stage 03 - Individual Validation (KILL GATE) template (v2.0.0)
+ * Phase: THE TRUTH (Stages 1-5)
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
- * Test Scenario TS-3: Stage 03 kill gate triggers when any metric is below 40
- *                    (even if overall >= 70)
+ * Tests: 3-way kill gate (pass/revise/kill), updated thresholds (50 per-metric),
+ *        competitorEntities validation, rollupDimensions, confidenceScores
  *
  * @module tests/unit/eva/stage-templates/stage-03.test
  */
@@ -12,123 +13,141 @@ import { describe, it, expect } from 'vitest';
 import stage03, {
   evaluateKillGate,
   METRICS,
-  OVERALL_THRESHOLD,
+  PASS_THRESHOLD,
+  REVISE_THRESHOLD,
   METRIC_THRESHOLD,
+  THREAT_LEVELS,
 } from '../../../../lib/eva/stage-templates/stage-03.js';
 
-describe('stage-03.js - Market Validation template', () => {
+describe('stage-03.js - Individual Validation template', () => {
   describe('Template metadata', () => {
     it('should have correct template structure', () => {
       expect(stage03.id).toBe('stage-03');
       expect(stage03.slug).toBe('validation');
-      expect(stage03.title).toBe('Market Validation');
-      expect(stage03.version).toBe('1.0.0');
+      expect(stage03.title).toBe('Individual Validation');
+      expect(stage03.version).toBe('2.0.0');
     });
 
     it('should have correct thresholds', () => {
-      expect(OVERALL_THRESHOLD).toBe(70);
-      expect(METRIC_THRESHOLD).toBe(40);
+      expect(PASS_THRESHOLD).toBe(70);
+      expect(REVISE_THRESHOLD).toBe(50);
+      expect(METRIC_THRESHOLD).toBe(50);
     });
 
     it('should have all 6 metrics defined', () => {
       expect(METRICS).toEqual([
-        'marketFit',
-        'customerNeed',
-        'momentum',
-        'revenuePotential',
-        'competitiveBarrier',
-        'executionFeasibility',
+        'marketFit', 'customerNeed', 'momentum',
+        'revenuePotential', 'competitiveBarrier', 'executionFeasibility',
       ]);
-      expect(METRICS).toHaveLength(6);
+    });
+
+    it('should export THREAT_LEVELS', () => {
+      expect(THREAT_LEVELS).toEqual(['H', 'M', 'L']);
+    });
+
+    it('should have analysisStep attached', () => {
+      expect(typeof stage03.analysisStep).toBe('function');
     });
   });
 
-  describe('validate() - 6-metric validation', () => {
-    const validData = {
-      marketFit: 75,
-      customerNeed: 80,
-      momentum: 70,
-      revenuePotential: 85,
-      competitiveBarrier: 65,
-      executionFeasibility: 90,
-    };
+  const makeValidMetrics = (overrides = {}) => ({
+    marketFit: 75, customerNeed: 80, momentum: 70,
+    revenuePotential: 85, competitiveBarrier: 65, executionFeasibility: 90,
+    ...overrides,
+  });
 
+  describe('validate() - 6-metric validation', () => {
     it('should pass for valid data with all metrics in range', () => {
-      const result = stage03.validate(validData);
+      const result = stage03.validate(makeValidMetrics());
       expect(result.valid).toBe(true);
       expect(result.errors).toEqual([]);
     });
 
     it('should pass for all metrics at boundary values (0 and 100)', () => {
       const data = {
-        marketFit: 0,
-        customerNeed: 100,
-        momentum: 0,
-        revenuePotential: 100,
-        competitiveBarrier: 0,
-        executionFeasibility: 100,
+        marketFit: 0, customerNeed: 100, momentum: 0,
+        revenuePotential: 100, competitiveBarrier: 0, executionFeasibility: 100,
       };
       const result = stage03.validate(data);
       expect(result.valid).toBe(true);
     });
 
     it('should fail for missing metric', () => {
-      const data = { ...validData };
+      const data = makeValidMetrics();
       delete data.marketFit;
       const result = stage03.validate(data);
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('marketFit');
-      expect(result.errors[0]).toContain('is required');
     });
 
     it('should fail for metric below 0', () => {
-      const data = { ...validData, marketFit: -1 };
-      const result = stage03.validate(data);
+      const result = stage03.validate(makeValidMetrics({ marketFit: -1 }));
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('marketFit');
-      expect(result.errors[0]).toContain('must be between 0 and 100');
     });
 
     it('should fail for metric above 100', () => {
-      const data = { ...validData, customerNeed: 101 };
-      const result = stage03.validate(data);
+      const result = stage03.validate(makeValidMetrics({ customerNeed: 101 }));
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('customerNeed');
-      expect(result.errors[0]).toContain('must be between 0 and 100');
     });
 
     it('should fail for non-integer metric', () => {
-      const data = { ...validData, momentum: 75.5 };
-      const result = stage03.validate(data);
+      const result = stage03.validate(makeValidMetrics({ momentum: 75.5 }));
       expect(result.valid).toBe(false);
       expect(result.errors[0]).toContain('momentum');
-      expect(result.errors[0]).toContain('must be an integer');
-    });
-
-    it('should collect errors for all invalid metrics', () => {
-      const data = {
-        marketFit: -1,
-        customerNeed: 101,
-        momentum: 75.5,
-        revenuePotential: 'invalid',
-      };
-      const result = stage03.validate(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors.length).toBeGreaterThanOrEqual(4);
     });
   });
 
-  describe('evaluateKillGate() - TS-3: Kill gate logic', () => {
-    it('should pass when overallScore >= 70 and all metrics >= 40', () => {
+  describe('validate() - competitorEntities (optional)', () => {
+    it('should pass when competitorEntities is omitted', () => {
+      const result = stage03.validate(makeValidMetrics());
+      expect(result.valid).toBe(true);
+    });
+
+    it('should pass for valid competitorEntities', () => {
+      const data = {
+        ...makeValidMetrics(),
+        competitorEntities: [
+          { name: 'Acme', positioning: 'Market leader', threat_level: 'H' },
+        ],
+      };
+      const result = stage03.validate(data);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should fail for competitorEntity with missing name', () => {
+      const data = {
+        ...makeValidMetrics(),
+        competitorEntities: [
+          { positioning: 'Leader', threat_level: 'H' },
+        ],
+      };
+      const result = stage03.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('competitorEntities[0].name');
+    });
+
+    it('should fail for invalid threat_level', () => {
+      const data = {
+        ...makeValidMetrics(),
+        competitorEntities: [
+          { name: 'Acme', positioning: 'Leader', threat_level: 'X' },
+        ],
+      };
+      const result = stage03.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('competitorEntities[0].threat_level');
+    });
+  });
+
+  describe('evaluateKillGate() - 3-way gate', () => {
+    it('should pass when overallScore >= 70 and all metrics >= 50', () => {
       const result = evaluateKillGate({
         overallScore: 75,
         metrics: {
-          marketFit: 70,
-          customerNeed: 75,
-          momentum: 80,
-          revenuePotential: 75,
-          competitiveBarrier: 70,
-          executionFeasibility: 80,
+          marketFit: 70, customerNeed: 75, momentum: 80,
+          revenuePotential: 75, competitiveBarrier: 70, executionFeasibility: 80,
         },
       });
       expect(result.decision).toBe('pass');
@@ -136,129 +155,89 @@ describe('stage-03.js - Market Validation template', () => {
       expect(result.reasons).toEqual([]);
     });
 
-    it('should pass at exact threshold boundaries (70 overall, all metrics 40)', () => {
+    it('should pass at exact boundary (70 overall, all metrics 50)', () => {
       const result = evaluateKillGate({
         overallScore: 70,
         metrics: {
-          marketFit: 40,
-          customerNeed: 40,
-          momentum: 40,
-          revenuePotential: 40,
-          competitiveBarrier: 40,
-          executionFeasibility: 40,
+          marketFit: 50, customerNeed: 50, momentum: 50,
+          revenuePotential: 50, competitiveBarrier: 50, executionFeasibility: 50,
         },
       });
       expect(result.decision).toBe('pass');
       expect(result.blockProgression).toBe(false);
-      expect(result.reasons).toEqual([]);
     });
 
-    it('should kill when overallScore is 69 (one below threshold)', () => {
+    it('should revise when overallScore 50-69 and no metric below 50', () => {
       const result = evaluateKillGate({
-        overallScore: 69,
+        overallScore: 65,
         metrics: {
-          marketFit: 69,
-          customerNeed: 69,
-          momentum: 69,
-          revenuePotential: 69,
-          competitiveBarrier: 69,
-          executionFeasibility: 69,
+          marketFit: 65, customerNeed: 65, momentum: 65,
+          revenuePotential: 65, competitiveBarrier: 65, executionFeasibility: 65,
+        },
+      });
+      expect(result.decision).toBe('revise');
+      expect(result.blockProgression).toBe(true);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0].type).toBe('overall_in_revise_band');
+    });
+
+    it('should revise at exact boundary (50 overall, all metrics 50)', () => {
+      const result = evaluateKillGate({
+        overallScore: 50,
+        metrics: {
+          marketFit: 50, customerNeed: 50, momentum: 50,
+          revenuePotential: 50, competitiveBarrier: 50, executionFeasibility: 50,
+        },
+      });
+      expect(result.decision).toBe('revise');
+      expect(result.blockProgression).toBe(true);
+    });
+
+    it('should kill when overallScore < 50', () => {
+      const result = evaluateKillGate({
+        overallScore: 49,
+        metrics: {
+          marketFit: 50, customerNeed: 50, momentum: 50,
+          revenuePotential: 50, competitiveBarrier: 50, executionFeasibility: 50,
         },
       });
       expect(result.decision).toBe('kill');
       expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('overall_below_threshold');
-      expect(result.reasons[0].actual).toBe(69);
-      expect(result.reasons[0].threshold).toBe(70);
+      expect(result.reasons.some(r => r.type === 'overall_below_kill_threshold')).toBe(true);
     });
 
-    it('should kill when ANY single metric is 39 (even if overall >= 70)', () => {
+    it('should kill when ANY metric < 50 (even if overall >= 70)', () => {
       const result = evaluateKillGate({
-        overallScore: 75, // Overall is good
+        overallScore: 75,
         metrics: {
-          marketFit: 90,
-          customerNeed: 90,
-          momentum: 90,
-          revenuePotential: 90,
-          competitiveBarrier: 90,
-          executionFeasibility: 39, // This one metric fails
+          marketFit: 90, customerNeed: 90, momentum: 90,
+          revenuePotential: 90, competitiveBarrier: 90, executionFeasibility: 49,
         },
       });
       expect(result.decision).toBe('kill');
       expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('metric_below_40');
+      expect(result.reasons[0].type).toBe('metric_below_threshold');
       expect(result.reasons[0].metric).toBe('executionFeasibility');
-      expect(result.reasons[0].actual).toBe(39);
-      expect(result.reasons[0].threshold).toBe(40);
     });
 
-    it('should kill when multiple metrics are below 40', () => {
+    it('should kill when multiple metrics < 50', () => {
       const result = evaluateKillGate({
         overallScore: 70,
         metrics: {
-          marketFit: 39,
-          customerNeed: 38,
-          momentum: 90,
-          revenuePotential: 90,
-          competitiveBarrier: 90,
-          executionFeasibility: 90,
+          marketFit: 49, customerNeed: 48, momentum: 90,
+          revenuePotential: 90, competitiveBarrier: 90, executionFeasibility: 90,
         },
       });
       expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(2);
       expect(result.reasons.some(r => r.metric === 'marketFit')).toBe(true);
       expect(result.reasons.some(r => r.metric === 'customerNeed')).toBe(true);
-    });
-
-    it('should kill when both overall < 70 AND metrics < 40', () => {
-      const result = evaluateKillGate({
-        overallScore: 65,
-        metrics: {
-          marketFit: 35,
-          customerNeed: 40,
-          momentum: 70,
-          revenuePotential: 80,
-          competitiveBarrier: 75,
-          executionFeasibility: 90,
-        },
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons.length).toBeGreaterThanOrEqual(2);
-      expect(result.reasons.some(r => r.type === 'overall_below_threshold')).toBe(true);
-      expect(result.reasons.some(r => r.type === 'metric_below_40')).toBe(true);
-    });
-
-    it('should provide detailed reason messages', () => {
-      const result = evaluateKillGate({
-        overallScore: 65,
-        metrics: {
-          marketFit: 35,
-          customerNeed: 70,
-          momentum: 70,
-          revenuePotential: 70,
-          competitiveBarrier: 70,
-          executionFeasibility: 70,
-        },
-      });
-      expect(result.reasons[0].message).toContain('Overall score 65 is below threshold 70');
-      expect(result.reasons[1].message).toContain('marketFit score 35 is below per-metric threshold 40');
     });
 
     it('should be pure (no side effects)', () => {
       const input = {
         overallScore: 75,
-        metrics: {
-          marketFit: 70,
-          customerNeed: 75,
-          momentum: 80,
-          revenuePotential: 75,
-          competitiveBarrier: 70,
-          executionFeasibility: 80,
-        },
+        metrics: { marketFit: 70, customerNeed: 75, momentum: 80,
+          revenuePotential: 75, competitiveBarrier: 70, executionFeasibility: 80 },
       };
       const original = JSON.parse(JSON.stringify(input));
       evaluateKillGate(input);
@@ -266,133 +245,54 @@ describe('stage-03.js - Market Validation template', () => {
     });
   });
 
-  describe('computeDerived() - Integration with kill gate', () => {
+  describe('computeDerived()', () => {
     it('should compute overallScore as rounded average', () => {
-      const data = {
-        marketFit: 70,
-        customerNeed: 75,
-        momentum: 80,
-        revenuePotential: 75,
-        competitiveBarrier: 70,
-        executionFeasibility: 80,
-      };
-      const result = stage03.computeDerived(data);
-      // (70+75+80+75+70+80)/6 = 450/6 = 75
-      expect(result.overallScore).toBe(75);
+      const result = stage03.computeDerived(makeValidMetrics());
+      // (75+80+70+85+65+90)/6 = 465/6 = 77.5 → 78
+      expect(result.overallScore).toBe(78);
+    });
+
+    it('should compute rollupDimensions', () => {
+      const result = stage03.computeDerived(makeValidMetrics());
+      expect(result.rollupDimensions.market).toBe(Math.round((75 + 70) / 2)); // marketFit + momentum
+      expect(result.rollupDimensions.technical).toBe(Math.round((90 + 65) / 2)); // executionFeasibility + competitiveBarrier
+      expect(result.rollupDimensions.financial).toBe(Math.round((85 + 80) / 2)); // revenuePotential + customerNeed
     });
 
     it('should include pass decision when all criteria met', () => {
-      const data = {
-        marketFit: 70,
-        customerNeed: 75,
-        momentum: 80,
-        revenuePotential: 75,
-        competitiveBarrier: 70,
-        executionFeasibility: 80,
-      };
-      const result = stage03.computeDerived(data);
+      const result = stage03.computeDerived(makeValidMetrics());
       expect(result.decision).toBe('pass');
       expect(result.blockProgression).toBe(false);
-      expect(result.reasons).toEqual([]);
     });
 
-    it('should include kill decision when overall < 70', () => {
+    it('should include revise decision for borderline scores', () => {
       const data = {
-        marketFit: 69,
-        customerNeed: 69,
-        momentum: 69,
-        revenuePotential: 69,
-        competitiveBarrier: 69,
-        executionFeasibility: 69,
+        marketFit: 60, customerNeed: 60, momentum: 60,
+        revenuePotential: 60, competitiveBarrier: 60, executionFeasibility: 60,
       };
       const result = stage03.computeDerived(data);
-      expect(result.overallScore).toBe(69);
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
+      expect(result.overallScore).toBe(60);
+      expect(result.decision).toBe('revise');
     });
 
-    it('should include kill decision when any metric < 40', () => {
-      const data = {
-        marketFit: 90,
-        customerNeed: 90,
-        momentum: 90,
-        revenuePotential: 90,
-        competitiveBarrier: 90,
-        executionFeasibility: 39,
-      };
-      const result = stage03.computeDerived(data);
-      expect(result.overallScore).toBe(82); // (90*5+39)/6 = 489/6 = 81.5 rounds to 82
+    it('should include kill decision when metric < 50', () => {
+      const result = stage03.computeDerived(makeValidMetrics({ executionFeasibility: 49 }));
       expect(result.decision).toBe('kill');
       expect(result.blockProgression).toBe(true);
     });
 
     it('should preserve original input fields', () => {
-      const data = {
-        marketFit: 70,
-        customerNeed: 75,
-        momentum: 80,
-        revenuePotential: 75,
-        competitiveBarrier: 70,
-        executionFeasibility: 80,
-      };
+      const data = makeValidMetrics();
       const result = stage03.computeDerived(data);
-      expect(result.marketFit).toBe(70);
-      expect(result.customerNeed).toBe(75);
-      expect(result.momentum).toBe(80);
-      expect(result.revenuePotential).toBe(75);
-      expect(result.competitiveBarrier).toBe(70);
-      expect(result.executionFeasibility).toBe(80);
+      expect(result.marketFit).toBe(75);
+      expect(result.customerNeed).toBe(80);
     });
 
     it('should not mutate original data', () => {
-      const data = {
-        marketFit: 70,
-        customerNeed: 75,
-        momentum: 80,
-        revenuePotential: 75,
-        competitiveBarrier: 70,
-        executionFeasibility: 80,
-      };
+      const data = makeValidMetrics();
       const original = { ...data };
       stage03.computeDerived(data);
       expect(data).toEqual(original);
-    });
-  });
-
-  describe('Integration: validate + computeDerived workflow', () => {
-    it('should work together for passing scenario', () => {
-      const data = {
-        marketFit: 75,
-        customerNeed: 80,
-        momentum: 70,
-        revenuePotential: 85,
-        competitiveBarrier: 65,
-        executionFeasibility: 90,
-      };
-      const validation = stage03.validate(data);
-      expect(validation.valid).toBe(true);
-
-      const computed = stage03.computeDerived(data);
-      expect(computed.decision).toBe('pass');
-      expect(computed.blockProgression).toBe(false);
-    });
-
-    it('should work together for kill scenario (low metric)', () => {
-      const data = {
-        marketFit: 90,
-        customerNeed: 90,
-        momentum: 90,
-        revenuePotential: 90,
-        competitiveBarrier: 90,
-        executionFeasibility: 39,
-      };
-      const validation = stage03.validate(data);
-      expect(validation.valid).toBe(true); // Valid input
-
-      const computed = stage03.computeDerived(data);
-      expect(computed.decision).toBe('kill'); // But fails kill gate
-      expect(computed.blockProgression).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Upgrade EVA Stage 1-5 templates from v1.0.0 to v2.0.0 with rich schemas
- Add 6 LLM-powered analysis step files for active venture evaluation
- Wire analysisStep functions into all 5 stage templates
- Update all unit tests (1078 passing across 27 files)

## Changes
**Stage Templates (v2.0.0):**
- Stage 01: archetype enum, problemStatement, moatStrategy, sourceProvenance
- Stage 02: MoA multi-persona analysis, 6 unified metrics, evidence domains
- Stage 03: 3-way kill gate (pass/revise/kill), rollupDimensions, competitorEntities
- Stage 04: SWOT per competitor, pricingModel enum, stage5Handoff artifact
- Stage 05: banded ROI gate (pass/conditional_pass/kill), unitEconomics

**Analysis Steps (NEW):**
- stage-01-hydration.js: Hydrates Stage 0 synthesis into draft idea
- stage-02-multi-persona.js: 6 personas sequential analysis
- stage-03-hybrid-scoring.js: 50% deterministic + 50% AI scoring
- stage-04-competitive-landscape.js: Competitor discovery with pricing
- stage-05-financial-model.js: Unit economics and financial projections
- index.js: Registry with getAnalysisStep(stageNumber)

## Test plan
- [x] 1078 unit tests pass across 27 test files
- [x] All 5 stage template tests updated for v2.0.0 schemas
- [x] Index registry test updated for new slugs and mixed versions

Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (child of SD-EVA-ORCH-TEMPLATE-GAPFILL-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)