### PR TITLE
feat: add LLM analysis steps for EVA stages 13-16 (THE BLUEPRINT)

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/index.js
+++ b/lib/eva/stage-templates/analysis-steps/index.js
@@ -1,6 +1,6 @@
 /**
- * Analysis Steps Registry - Stages 1-9 (THE TRUTH + THE ENGINE)
- * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (1-5) and SD-EVA-FEAT-TEMPLATES-ENGINE-001 (6-9)
+ * Analysis Steps Registry - Stages 1-16 (THE TRUTH + THE ENGINE + THE BLUEPRINT)
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (1-5), ENGINE-001 (6-9), BLUEPRINT-001 (13-16)
  *
  * Provides the active analysis layer for stage templates.
  * Each analysisStep consumes upstream artifacts and generates
@@ -22,8 +22,14 @@ export { analyzeStage07 } from './stage-07-pricing-strategy.js';
 export { analyzeStage08 } from './stage-08-bmc-generation.js';
 export { analyzeStage09 } from './stage-09-exit-strategy.js';
 
+// THE BLUEPRINT (Stages 13-16)
+export { analyzeStage13 } from './stage-13-product-roadmap.js';
+export { analyzeStage14 } from './stage-14-technical-architecture.js';
+export { analyzeStage15 } from './stage-15-resource-planning.js';
+export { analyzeStage16 } from './stage-16-financial-projections.js';
+
 /**
- * Get the analysis step function for a given stage number (1-9).
+ * Get the analysis step function for a given stage number (1-16).
  * @param {number} stageNumber
  * @returns {Promise<Function|null>}
  */
@@ -38,6 +44,10 @@ export async function getAnalysisStep(stageNumber) {
     7: () => import('./stage-07-pricing-strategy.js').then(m => m.analyzeStage07),
     8: () => import('./stage-08-bmc-generation.js').then(m => m.analyzeStage08),
     9: () => import('./stage-09-exit-strategy.js').then(m => m.analyzeStage09),
+    13: () => import('./stage-13-product-roadmap.js').then(m => m.analyzeStage13),
+    14: () => import('./stage-14-technical-architecture.js').then(m => m.analyzeStage14),
+    15: () => import('./stage-15-resource-planning.js').then(m => m.analyzeStage15),
+    16: () => import('./stage-16-financial-projections.js').then(m => m.analyzeStage16),
   };
   const loader = loaders[stageNumber];
   return loader ? loader() : null;

--- a/lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js
@@ -1,0 +1,151 @@
+/**
+ * Stage 13 Analysis Step - Product Roadmap Generation
+ * Part of SD-EVA-FEAT-TEMPLATES-BLUEPRINT-001
+ *
+ * Consumes Stages 1-12 data and generates a structured product roadmap
+ * with milestones prioritized as now/next/later.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const MIN_MILESTONES = 3;
+const VALID_PRIORITIES = ['now', 'next', 'later'];
+
+const SYSTEM_PROMPT = `You are EVA's Product Roadmap Engine. Generate a structured product roadmap for a venture based on analysis from prior stages.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "vision_statement": "Clear product vision statement (min 20 chars)",
+  "milestones": [
+    {
+      "name": "Milestone name",
+      "date": "YYYY-MM-DD",
+      "deliverables": ["Deliverable 1", "Deliverable 2"],
+      "dependencies": ["Dependency if any"],
+      "priority": "now|next|later"
+    }
+  ],
+  "phases": [
+    {
+      "name": "Phase name",
+      "start_date": "YYYY-MM-DD",
+      "end_date": "YYYY-MM-DD"
+    }
+  ]
+}
+
+Rules:
+- Generate at least ${MIN_MILESTONES} milestones
+- Each milestone MUST have priority: "now", "next", or "later"
+- "now" = immediate (0-3 months), "next" = near-term (3-6 months), "later" = future (6+ months)
+- Each milestone MUST have at least 1 deliverable
+- Dates must span at least 3 months total
+- Use upstream financial/market/competitive data to inform priority
+- Milestones should be concrete and actionable, not vague
+- At least 1 phase grouping the milestones`;
+
+/**
+ * Generate a product roadmap from upstream stage data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea
+ * @param {Object} [params.stage5Data] - Stage 5 financial model
+ * @param {Object} [params.stage8Data] - Stage 8 BMC
+ * @param {Object} [params.stage9Data] - Stage 9 exit strategy
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Product roadmap
+ */
+export async function analyzeStage13({ stage1Data, stage5Data, stage8Data, stage9Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 13 product roadmap requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const financialContext = stage5Data
+    ? `Financial Model:
+  Initial Investment: $${stage5Data.initialInvestment || 'N/A'}
+  Year 1 Revenue: $${stage5Data.year1?.revenue || 'N/A'}
+  Break-even: Month ${stage5Data.breakEvenMonth || 'N/A'}`
+    : 'No financial model available';
+
+  const bmcContext = stage8Data
+    ? `BMC: ${Object.keys(stage8Data).filter(k => stage8Data[k]?.items?.length > 0).length}/9 blocks populated`
+    : '';
+
+  const exitContext = stage9Data?.strategies
+    ? `Exit Strategies: ${stage9Data.strategies.length} defined`
+    : '';
+
+  const userPrompt = `Generate a product roadmap for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Target Market: ${stage1Data.targetMarket || 'N/A'}
+Problem: ${stage1Data.problemStatement || 'N/A'}
+
+${financialContext}
+${bmcContext}
+${exitContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  if (!Array.isArray(parsed.milestones) || parsed.milestones.length === 0) {
+    throw new Error('Stage 13 product roadmap: LLM returned no milestones');
+  }
+
+  // Normalize milestones
+  const milestones = parsed.milestones.map((m, i) => ({
+    name: String(m.name || `Milestone ${i + 1}`).substring(0, 200),
+    date: String(m.date || ''),
+    deliverables: Array.isArray(m.deliverables) && m.deliverables.length > 0
+      ? m.deliverables.map(d => String(d).substring(0, 300))
+      : ['TBD'],
+    dependencies: Array.isArray(m.dependencies) ? m.dependencies.map(d => String(d)) : [],
+    priority: VALID_PRIORITIES.includes(m.priority) ? m.priority : 'later',
+  }));
+
+  // Normalize phases
+  const phases = Array.isArray(parsed.phases) && parsed.phases.length > 0
+    ? parsed.phases.map(p => ({
+      name: String(p.name || 'Phase').substring(0, 200),
+      start_date: String(p.start_date || ''),
+      end_date: String(p.end_date || ''),
+    }))
+    : [{ name: 'Phase 1', start_date: milestones[0]?.date || '', end_date: milestones[milestones.length - 1]?.date || '' }];
+
+  const vision_statement = String(parsed.vision_statement || '').length >= 20
+    ? String(parsed.vision_statement).substring(0, 500)
+    : `Product roadmap for ${ventureName || 'venture'}: ${stage1Data.description.substring(0, 200)}`;
+
+  // Compute aggregate metrics
+  const priorityCounts = { now: 0, next: 0, later: 0 };
+  for (const m of milestones) {
+    priorityCounts[m.priority] = (priorityCounts[m.priority] || 0) + 1;
+  }
+
+  return {
+    vision_statement,
+    milestones,
+    phases,
+    priorityCounts,
+    totalMilestones: milestones.length,
+    totalPhases: phases.length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse roadmap response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { MIN_MILESTONES, VALID_PRIORITIES };

--- a/lib/eva/stage-templates/analysis-steps/stage-14-technical-architecture.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-14-technical-architecture.js
@@ -1,0 +1,172 @@
+/**
+ * Stage 14 Analysis Step - Technical Architecture Generation
+ * Part of SD-EVA-FEAT-TEMPLATES-BLUEPRINT-001
+ *
+ * Consumes Stage 1 idea and Stage 13 roadmap to generate a technical
+ * architecture with all 4 required layers, integration points,
+ * and constraints.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-14-technical-architecture
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const REQUIRED_LAYERS = ['frontend', 'backend', 'data', 'infra'];
+
+const SYSTEM_PROMPT = `You are EVA's Technical Architecture Engine. Generate a structured technical architecture for a venture.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "architecture_summary": "High-level architecture description (min 20 chars)",
+  "layers": {
+    "frontend": {
+      "technology": "React/Vue/etc",
+      "components": ["Component 1", "Component 2"],
+      "rationale": "Why this technology"
+    },
+    "backend": {
+      "technology": "Node.js/Python/etc",
+      "components": ["Service 1", "Service 2"],
+      "rationale": "Why this technology"
+    },
+    "data": {
+      "technology": "PostgreSQL/MongoDB/etc",
+      "components": ["Table 1", "Collection 1"],
+      "rationale": "Why this technology"
+    },
+    "infra": {
+      "technology": "AWS/GCP/Vercel/etc",
+      "components": ["Service 1", "Service 2"],
+      "rationale": "Why this infrastructure"
+    }
+  },
+  "integration_points": [
+    {
+      "name": "Integration name",
+      "source_layer": "frontend|backend|data|infra",
+      "target_layer": "frontend|backend|data|infra",
+      "protocol": "REST|GraphQL|gRPC|WebSocket|SQL|etc"
+    }
+  ],
+  "constraints": [
+    {
+      "name": "Constraint name",
+      "description": "Description of the constraint"
+    }
+  ]
+}
+
+Rules:
+- ALL four layers (frontend, backend, data, infra) MUST be defined
+- Each layer MUST have technology, at least 1 component, and rationale
+- At least 1 integration point between layers
+- Technology choices should be practical and match the venture's scale
+- Rationale should reference specific venture needs, not generic advice
+- Include relevant constraints (performance, security, compliance)`;
+
+/**
+ * Generate a technical architecture from upstream data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea
+ * @param {Object} [params.stage13Data] - Stage 13 product roadmap
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Technical architecture
+ */
+export async function analyzeStage14({ stage1Data, stage13Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 14 technical architecture requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const roadmapContext = stage13Data?.milestones
+    ? `Product Roadmap:
+  Milestones: ${stage13Data.milestones.length}
+  Now priorities: ${stage13Data.milestones.filter(m => m.priority === 'now').map(m => m.name).join(', ') || 'None'}
+  Timeline: ${stage13Data.phases?.[0]?.start_date || 'N/A'} to ${stage13Data.phases?.[stage13Data.phases.length - 1]?.end_date || 'N/A'}`
+    : 'No roadmap available';
+
+  const userPrompt = `Generate a technical architecture for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Target Market: ${stage1Data.targetMarket || 'N/A'}
+Problem: ${stage1Data.problemStatement || 'N/A'}
+
+${roadmapContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Validate layers
+  if (!parsed.layers || typeof parsed.layers !== 'object') {
+    throw new Error('Stage 14 technical architecture: LLM returned no layers');
+  }
+
+  // Normalize layers
+  const layers = {};
+  for (const layer of REQUIRED_LAYERS) {
+    const l = parsed.layers[layer];
+    if (!l || typeof l !== 'object') {
+      layers[layer] = {
+        technology: 'TBD',
+        components: ['TBD'],
+        rationale: `${layer} layer technology to be determined`,
+      };
+    } else {
+      layers[layer] = {
+        technology: String(l.technology || 'TBD').substring(0, 200),
+        components: Array.isArray(l.components) && l.components.length > 0
+          ? l.components.map(c => String(c).substring(0, 200))
+          : ['TBD'],
+        rationale: String(l.rationale || 'TBD').substring(0, 500),
+      };
+    }
+  }
+
+  // Normalize integration points
+  const integration_points = Array.isArray(parsed.integration_points) && parsed.integration_points.length > 0
+    ? parsed.integration_points.map(ip => ({
+      name: String(ip.name || 'Integration').substring(0, 200),
+      source_layer: REQUIRED_LAYERS.includes(ip.source_layer) ? ip.source_layer : 'backend',
+      target_layer: REQUIRED_LAYERS.includes(ip.target_layer) ? ip.target_layer : 'data',
+      protocol: String(ip.protocol || 'REST').substring(0, 100),
+    }))
+    : [{ name: 'API Gateway', source_layer: 'frontend', target_layer: 'backend', protocol: 'REST' }];
+
+  // Normalize constraints
+  const constraints = Array.isArray(parsed.constraints)
+    ? parsed.constraints.map(c => ({
+      name: String(c.name || 'Constraint').substring(0, 200),
+      description: String(c.description || '').substring(0, 500),
+    }))
+    : [];
+
+  const architecture_summary = String(parsed.architecture_summary || '').length >= 20
+    ? String(parsed.architecture_summary).substring(0, 500)
+    : `Technical architecture for ${ventureName || 'venture'}: ${Object.values(layers).map(l => l.technology).join(', ')}`;
+
+  return {
+    architecture_summary,
+    layers,
+    integration_points,
+    constraints,
+    layerCount: Object.keys(layers).length,
+    totalComponents: Object.values(layers).reduce((sum, l) => sum + l.components.length, 0),
+    allLayersDefined: REQUIRED_LAYERS.every(l => layers[l] && layers[l].technology !== 'TBD'),
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse architecture response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { REQUIRED_LAYERS };

--- a/lib/eva/stage-templates/analysis-steps/stage-15-resource-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-resource-planning.js
@@ -1,0 +1,159 @@
+/**
+ * Stage 15 Analysis Step - Resource Planning Generation
+ * Part of SD-EVA-FEAT-TEMPLATES-BLUEPRINT-001
+ *
+ * Consumes Stage 1 idea, Stage 13 roadmap, and Stage 14 architecture
+ * to generate team composition, skill gaps, and hiring plan.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-15-resource-planning
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const MIN_TEAM_MEMBERS = 2;
+const MIN_ROLES = 2;
+
+const SYSTEM_PROMPT = `You are EVA's Resource Planning Engine. Generate a structured resource plan for a venture.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "team_members": [
+    {
+      "role": "Role title",
+      "skills": ["Skill 1", "Skill 2"],
+      "allocation_pct": 50,
+      "cost_monthly": 5000
+    }
+  ],
+  "skill_gaps": [
+    {
+      "skill": "Missing skill",
+      "severity": "critical|high|medium|low",
+      "mitigation": "How to address this gap"
+    }
+  ],
+  "hiring_plan": [
+    {
+      "role": "Role to hire",
+      "timeline": "Q1 2026",
+      "priority": "critical|high|medium|low"
+    }
+  ]
+}
+
+Rules:
+- At least ${MIN_TEAM_MEMBERS} team members required
+- At least ${MIN_ROLES} unique roles required
+- allocation_pct must be 1-100
+- cost_monthly should be realistic for the role and market
+- skills array must have at least 1 skill per team member
+- Skill gaps should be based on the architecture requirements
+- Hiring plan should address gaps and roadmap timeline
+- Consider the venture's stage and funding level for team size`;
+
+/**
+ * Generate a resource plan from upstream data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea
+ * @param {Object} [params.stage13Data] - Stage 13 product roadmap
+ * @param {Object} [params.stage14Data] - Stage 14 technical architecture
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Resource plan
+ */
+export async function analyzeStage15({ stage1Data, stage13Data, stage14Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 15 resource planning requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const roadmapContext = stage13Data?.milestones
+    ? `Roadmap: ${stage13Data.milestones.length} milestones, ${stage13Data.phases?.length || 0} phases`
+    : 'No roadmap available';
+
+  const archContext = stage14Data?.layers
+    ? `Architecture:
+  Frontend: ${stage14Data.layers.frontend?.technology || 'N/A'}
+  Backend: ${stage14Data.layers.backend?.technology || 'N/A'}
+  Data: ${stage14Data.layers.data?.technology || 'N/A'}
+  Infra: ${stage14Data.layers.infra?.technology || 'N/A'}
+  Components: ${stage14Data.totalComponents || 'N/A'}`
+    : 'No architecture available';
+
+  const userPrompt = `Generate a resource plan for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Target Market: ${stage1Data.targetMarket || 'N/A'}
+
+${roadmapContext}
+
+${archContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  if (!Array.isArray(parsed.team_members) || parsed.team_members.length === 0) {
+    throw new Error('Stage 15 resource planning: LLM returned no team members');
+  }
+
+  // Normalize team members
+  const team_members = parsed.team_members.map(tm => ({
+    role: String(tm.role || 'Team Member').substring(0, 200),
+    skills: Array.isArray(tm.skills) && tm.skills.length > 0
+      ? tm.skills.map(s => String(s).substring(0, 200))
+      : ['General'],
+    allocation_pct: clamp(tm.allocation_pct, 1, 100),
+    cost_monthly: Math.max(0, Number(tm.cost_monthly) || 0),
+  }));
+
+  // Normalize skill gaps
+  const skill_gaps = Array.isArray(parsed.skill_gaps)
+    ? parsed.skill_gaps.map(sg => ({
+      skill: String(sg.skill || 'Unknown').substring(0, 200),
+      severity: ['critical', 'high', 'medium', 'low'].includes(sg.severity) ? sg.severity : 'medium',
+      mitigation: String(sg.mitigation || 'TBD').substring(0, 500),
+    }))
+    : [];
+
+  // Normalize hiring plan
+  const hiring_plan = Array.isArray(parsed.hiring_plan)
+    ? parsed.hiring_plan.map(hp => ({
+      role: String(hp.role || 'TBD').substring(0, 200),
+      timeline: String(hp.timeline || 'TBD').substring(0, 100),
+      priority: ['critical', 'high', 'medium', 'low'].includes(hp.priority) ? hp.priority : 'medium',
+    }))
+    : [];
+
+  return {
+    team_members,
+    skill_gaps,
+    hiring_plan,
+    totalHeadcount: team_members.length,
+    totalMonthlyCost: team_members.reduce((sum, tm) => sum + tm.cost_monthly, 0),
+    uniqueRoles: new Set(team_members.map(tm => tm.role)).size,
+    avgAllocation: team_members.length > 0
+      ? Math.round(team_members.reduce((sum, tm) => sum + tm.allocation_pct, 0) / team_members.length * 100) / 100
+      : 0,
+  };
+}
+
+function clamp(val, min, max) {
+  const n = Number(val);
+  if (!Number.isFinite(n)) return min;
+  return Math.max(min, Math.min(max, Math.round(n)));
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse resource plan response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { MIN_TEAM_MEMBERS, MIN_ROLES };

--- a/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
@@ -1,0 +1,146 @@
+/**
+ * Stage 16 Analysis Step - Financial Projections Generation
+ * Part of SD-EVA-FEAT-TEMPLATES-BLUEPRINT-001
+ *
+ * Consumes Stages 1, 13-15 data and generates financial projections
+ * with revenue/cost data, burn rate, and funding rounds.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-16-financial-projections
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const MIN_PROJECTION_MONTHS = 6;
+
+const SYSTEM_PROMPT = `You are EVA's Financial Projections Engine. Generate structured financial projections for a venture.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "initial_capital": 50000,
+  "monthly_burn_rate": 8000,
+  "revenue_projections": [
+    {
+      "month": 1,
+      "revenue": 0,
+      "costs": 8000
+    },
+    {
+      "month": 2,
+      "revenue": 500,
+      "costs": 8000
+    }
+  ],
+  "funding_rounds": [
+    {
+      "round_name": "Pre-seed",
+      "target_amount": 100000,
+      "target_date": "2026-06-01"
+    }
+  ]
+}
+
+Rules:
+- initial_capital must be > 0
+- monthly_burn_rate must be > 0
+- At least ${MIN_PROJECTION_MONTHS} months of revenue projections required
+- Each projection must have month (sequential), revenue (>= 0), and costs (>= 0)
+- Revenue should start low and grow based on the market/product
+- Costs should reflect the team composition from resource planning
+- Funding rounds are optional but recommended if runway < 12 months
+- Be realistic about early-stage revenue (most ventures have $0 in month 1)
+- Consider the venture's market size and pricing strategy`;
+
+/**
+ * Generate financial projections from upstream data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea
+ * @param {Object} [params.stage13Data] - Stage 13 product roadmap
+ * @param {Object} [params.stage14Data] - Stage 14 technical architecture
+ * @param {Object} [params.stage15Data] - Stage 15 resource planning
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Financial projections
+ */
+export async function analyzeStage16({ stage1Data, stage13Data, stage14Data, stage15Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 16 financial projections requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const roadmapContext = stage13Data?.milestones
+    ? `Roadmap: ${stage13Data.milestones.length} milestones over ${stage13Data.phases?.length || 0} phases`
+    : 'No roadmap available';
+
+  const archContext = stage14Data?.layers
+    ? `Architecture: ${stage14Data.totalComponents || 'N/A'} components across ${stage14Data.layerCount || 4} layers`
+    : 'No architecture available';
+
+  const resourceContext = stage15Data?.team_members
+    ? `Team: ${stage15Data.totalHeadcount || stage15Data.team_members.length} members, Monthly cost: $${stage15Data.totalMonthlyCost || 'N/A'}`
+    : 'No resource plan available';
+
+  const userPrompt = `Generate financial projections for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Target Market: ${stage1Data.targetMarket || 'N/A'}
+
+${roadmapContext}
+${archContext}
+${resourceContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Validate initial_capital
+  const initial_capital = Math.max(0, Number(parsed.initial_capital) || 0);
+  if (initial_capital <= 0) {
+    throw new Error('Stage 16 financial projections: LLM returned zero initial capital');
+  }
+
+  const monthly_burn_rate = Math.max(0, Number(parsed.monthly_burn_rate) || 0);
+
+  // Normalize revenue projections
+  if (!Array.isArray(parsed.revenue_projections) || parsed.revenue_projections.length === 0) {
+    throw new Error('Stage 16 financial projections: LLM returned no revenue projections');
+  }
+
+  const revenue_projections = parsed.revenue_projections.map((rp, i) => ({
+    month: Number(rp.month) || (i + 1),
+    revenue: Math.max(0, Number(rp.revenue) || 0),
+    costs: Math.max(0, Number(rp.costs) || 0),
+  }));
+
+  // Normalize funding rounds
+  const funding_rounds = Array.isArray(parsed.funding_rounds)
+    ? parsed.funding_rounds.map(fr => ({
+      round_name: String(fr.round_name || 'Round').substring(0, 200),
+      target_amount: Math.max(0, Number(fr.target_amount) || 0),
+      target_date: String(fr.target_date || '').substring(0, 20),
+    }))
+    : [];
+
+  return {
+    initial_capital,
+    monthly_burn_rate,
+    revenue_projections,
+    funding_rounds,
+    totalProjectedRevenue: revenue_projections.reduce((sum, rp) => sum + rp.revenue, 0),
+    totalProjectedCosts: revenue_projections.reduce((sum, rp) => sum + rp.costs, 0),
+    projectionMonths: revenue_projections.length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse financial projections response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { MIN_PROJECTION_MONTHS };

--- a/lib/eva/stage-templates/stage-13.js
+++ b/lib/eva/stage-templates/stage-13.js
@@ -13,6 +13,7 @@
  */
 
 import { validateString, validateArray, collectErrors } from './validation.js';
+import { analyzeStage13 } from './analysis-steps/stage-13-product-roadmap.js';
 
 const MIN_MILESTONES = 3;
 const MIN_TIMELINE_MONTHS = 3;
@@ -22,7 +23,7 @@ const TEMPLATE = {
   id: 'stage-13',
   slug: 'product-roadmap',
   title: 'Product Roadmap',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     vision_statement: { type: 'string', minLength: 20, required: true },
     milestones: {
@@ -198,6 +199,8 @@ export function evaluateKillGate({ milestone_count, milestones, timeline_months 
     reasons,
   };
 }
+
+TEMPLATE.analysisStep = analyzeStage13;
 
 export { MIN_MILESTONES, MIN_TIMELINE_MONTHS, MIN_DELIVERABLES_PER_MILESTONE };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-14.js
+++ b/lib/eva/stage-templates/stage-14.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateArray, collectErrors } from './validation.js';
+import { analyzeStage14 } from './analysis-steps/stage-14-technical-architecture.js';
 
 const REQUIRED_LAYERS = ['frontend', 'backend', 'data', 'infra'];
 const MIN_INTEGRATION_POINTS = 1;
@@ -18,7 +19,7 @@ const TEMPLATE = {
   id: 'stage-14',
   slug: 'technical-architecture',
   title: 'Technical Architecture',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     architecture_summary: { type: 'string', minLength: 20, required: true },
     layers: {
@@ -151,6 +152,8 @@ const TEMPLATE = {
     };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage14;
 
 export { REQUIRED_LAYERS, MIN_INTEGRATION_POINTS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -9,6 +9,7 @@
  */
 
 import { validateString, validateNumber, validateArray, collectErrors } from './validation.js';
+import { analyzeStage15 } from './analysis-steps/stage-15-resource-planning.js';
 
 const MIN_TEAM_MEMBERS = 2;
 const MIN_ROLES = 2;
@@ -17,7 +18,7 @@ const TEMPLATE = {
   id: 'stage-15',
   slug: 'resource-planning',
   title: 'Resource Planning',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     team_members: {
       type: 'array',
@@ -154,6 +155,8 @@ const TEMPLATE = {
     };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage15;
 
 export { MIN_TEAM_MEMBERS, MIN_ROLES };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-16.js
+++ b/lib/eva/stage-templates/stage-16.js
@@ -16,6 +16,7 @@
  */
 
 import { validateNumber, validateArray, collectErrors } from './validation.js';
+import { analyzeStage16 } from './analysis-steps/stage-16-financial-projections.js';
 import { MIN_MILESTONES } from './stage-13.js';
 import { REQUIRED_LAYERS } from './stage-14.js';
 import { MIN_TEAM_MEMBERS, MIN_ROLES } from './stage-15.js';
@@ -26,7 +27,7 @@ const TEMPLATE = {
   id: 'stage-16',
   slug: 'financial-projections',
   title: 'Financial Projections',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     initial_capital: { type: 'number', min: 0, required: true },
     monthly_burn_rate: { type: 'number', min: 0, required: true },
@@ -225,6 +226,8 @@ export function evaluatePromotionGate({ stage13, stage14, stage15, stage16 }) {
 
   return { pass, rationale, blockers, required_next_actions };
 }
+
+TEMPLATE.analysisStep = analyzeStage16;
 
 export { MIN_PROJECTION_MONTHS };
 export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/stage-13.test.js
+++ b/tests/unit/eva/stage-templates/stage-13.test.js
@@ -17,7 +17,7 @@ describe('stage-13.js - Product Roadmap template', () => {
       expect(stage13.id).toBe('stage-13');
       expect(stage13.slug).toBe('product-roadmap');
       expect(stage13.title).toBe('Product Roadmap');
-      expect(stage13.version).toBe('1.0.0');
+      expect(stage13.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {

--- a/tests/unit/eva/stage-templates/stage-14.test.js
+++ b/tests/unit/eva/stage-templates/stage-14.test.js
@@ -17,7 +17,7 @@ describe('stage-14.js - Technical Architecture template', () => {
       expect(stage14.id).toBe('stage-14');
       expect(stage14.slug).toBe('technical-architecture');
       expect(stage14.title).toBe('Technical Architecture');
-      expect(stage14.version).toBe('1.0.0');
+      expect(stage14.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {

--- a/tests/unit/eva/stage-templates/stage-15.test.js
+++ b/tests/unit/eva/stage-templates/stage-15.test.js
@@ -17,7 +17,7 @@ describe('stage-15.js - Resource Planning template', () => {
       expect(stage15.id).toBe('stage-15');
       expect(stage15.slug).toBe('resource-planning');
       expect(stage15.title).toBe('Resource Planning');
-      expect(stage15.version).toBe('1.0.0');
+      expect(stage15.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {

--- a/tests/unit/eva/stage-templates/stage-16.test.js
+++ b/tests/unit/eva/stage-templates/stage-16.test.js
@@ -20,7 +20,7 @@ describe('stage-16.js - Financial Projections template', () => {
       expect(stage16.id).toBe('stage-16');
       expect(stage16.slug).toBe('financial-projections');
       expect(stage16.title).toBe('Financial Projections');
-      expect(stage16.version).toBe('1.0.0');
+      expect(stage16.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {


### PR DESCRIPTION
## Summary
- Add 4 LLM-powered analysis step modules for EVA stages 13-16 (THE BLUEPRINT phase)
  - Stage 13: Product Roadmap (now/next/later milestone prioritization)
  - Stage 14: Technical Architecture (4 required layers: frontend/backend/data/infra)
  - Stage 15: Resource Planning (team composition, skill gaps, hiring plan)
  - Stage 16: Financial Projections (revenue/cost modeling, runway, break-even)
- Upgrade all 4 stage templates from v1.0.0 to v2.0.0 with `analysisStep` attachment
- Update analysis-steps/index.js registry to cover stages 1-16

## Test plan
- [x] All 154 unit tests passing across stages 13-16
- [x] Version bump verified in test expectations (1.0.0 → 2.0.0)
- [x] Analysis step exports and lazy loaders verified in registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)