### PR TITLE
feat(SD-EVA-FEAT-TEMPLATES-IDENTITY-001): upgrade Stages 10-12 to v2.0.0 with analysis steps

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/index.js
+++ b/lib/eva/stage-templates/analysis-steps/index.js
@@ -1,6 +1,6 @@
 /**
- * Analysis Steps Registry - Stages 1-16 (THE TRUTH + THE ENGINE + THE BLUEPRINT)
- * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (1-5), ENGINE-001 (6-9), BLUEPRINT-001 (13-16)
+ * Analysis Steps Registry - Stages 1-16
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (1-5), ENGINE-001 (6-9), IDENTITY-001 (10-12), BLUEPRINT-001 (13-16)
  *
  * Provides the active analysis layer for stage templates.
  * Each analysisStep consumes upstream artifacts and generates
@@ -21,6 +21,11 @@ export { analyzeStage06 } from './stage-06-risk-matrix.js';
 export { analyzeStage07 } from './stage-07-pricing-strategy.js';
 export { analyzeStage08 } from './stage-08-bmc-generation.js';
 export { analyzeStage09 } from './stage-09-exit-strategy.js';
+
+// THE IDENTITY (Stages 10-12)
+export { analyzeStage10 } from './stage-10-naming-brand.js';
+export { analyzeStage11 } from './stage-11-gtm.js';
+export { analyzeStage12 } from './stage-12-sales-logic.js';
 
 // THE BLUEPRINT (Stages 13-16)
 export { analyzeStage13 } from './stage-13-product-roadmap.js';
@@ -44,6 +49,9 @@ export async function getAnalysisStep(stageNumber) {
     7: () => import('./stage-07-pricing-strategy.js').then(m => m.analyzeStage07),
     8: () => import('./stage-08-bmc-generation.js').then(m => m.analyzeStage08),
     9: () => import('./stage-09-exit-strategy.js').then(m => m.analyzeStage09),
+    10: () => import('./stage-10-naming-brand.js').then(m => m.analyzeStage10),
+    11: () => import('./stage-11-gtm.js').then(m => m.analyzeStage11),
+    12: () => import('./stage-12-sales-logic.js').then(m => m.analyzeStage12),
     13: () => import('./stage-13-product-roadmap.js').then(m => m.analyzeStage13),
     14: () => import('./stage-14-technical-architecture.js').then(m => m.analyzeStage14),
     15: () => import('./stage-15-resource-planning.js').then(m => m.analyzeStage15),

--- a/lib/eva/stage-templates/analysis-steps/stage-10-naming-brand.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-10-naming-brand.js
@@ -1,0 +1,177 @@
+/**
+ * Stage 10 Analysis Step - Naming / Brand Generation
+ * Part of SD-EVA-FEAT-TEMPLATES-IDENTITY-001
+ *
+ * Consumes Stages 1-9 data and generates brand genome, scoring criteria,
+ * and naming candidates with weighted scoring.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-10-naming-brand
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const MIN_CANDIDATES = 5;
+const MIN_CRITERIA = 3;
+
+const SYSTEM_PROMPT = `You are EVA's Brand Identity Engine. Generate a complete brand naming analysis for a venture based on prior stage data.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "brandGenome": {
+    "archetype": "Brand archetype (e.g., Hero, Explorer, Creator)",
+    "values": ["Core value 1", "Core value 2", "Core value 3"],
+    "tone": "Brand tone description",
+    "audience": "Primary audience description",
+    "differentiators": ["Differentiator 1", "Differentiator 2"]
+  },
+  "scoringCriteria": [
+    { "name": "Criterion name", "weight": 25 }
+  ],
+  "candidates": [
+    {
+      "name": "Brand name candidate",
+      "rationale": "Why this name fits the brand",
+      "scores": { "Criterion name": 85 }
+    }
+  ]
+}
+
+Rules:
+- Generate at least ${MIN_CANDIDATES} naming candidates
+- Generate at least ${MIN_CRITERIA} scoring criteria
+- Scoring criteria weights MUST sum to exactly 100
+- Each candidate MUST have a score (0-100) for every criterion
+- Brand genome must include archetype, values (>= 1), tone, audience, differentiators (>= 1)
+- Names should be creative, memorable, and relevant to the venture
+- Rationale should explain why the name fits the brand genome`;
+
+/**
+ * Generate brand naming analysis from upstream stage data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea
+ * @param {Object} [params.stage3Data] - Stage 3 hybrid scoring
+ * @param {Object} [params.stage5Data] - Stage 5 financial model
+ * @param {Object} [params.stage8Data] - Stage 8 BMC
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Brand naming analysis
+ */
+export async function analyzeStage10({ stage1Data, stage3Data, stage5Data, stage8Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 10 naming/brand requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const scoringContext = stage3Data?.overallScore
+    ? `Viability Score: ${stage3Data.overallScore}/100`
+    : '';
+
+  const financialContext = stage5Data
+    ? `Financial: Initial Investment $${stage5Data.initialInvestment || 'N/A'}, Year 1 Revenue $${stage5Data.year1?.revenue || 'N/A'}`
+    : '';
+
+  const bmcContext = stage8Data
+    ? `BMC Value Proposition: ${stage8Data.value_propositions?.items?.[0] || 'N/A'}`
+    : '';
+
+  const userPrompt = `Generate a brand naming analysis for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Target Market: ${stage1Data.targetMarket || 'N/A'}
+Problem: ${stage1Data.problemStatement || 'N/A'}
+${scoringContext}
+${financialContext}
+${bmcContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize brand genome
+  const brandGenome = {
+    archetype: String(parsed.brandGenome?.archetype || 'Creator').substring(0, 200),
+    values: Array.isArray(parsed.brandGenome?.values) && parsed.brandGenome.values.length > 0
+      ? parsed.brandGenome.values.map(v => String(v).substring(0, 200))
+      : ['Innovation'],
+    tone: String(parsed.brandGenome?.tone || 'Professional').substring(0, 200),
+    audience: String(parsed.brandGenome?.audience || stage1Data.targetMarket || 'General').substring(0, 200),
+    differentiators: Array.isArray(parsed.brandGenome?.differentiators) && parsed.brandGenome.differentiators.length > 0
+      ? parsed.brandGenome.differentiators.map(d => String(d).substring(0, 200))
+      : ['Unique approach'],
+  };
+
+  // Normalize scoring criteria
+  let scoringCriteria = Array.isArray(parsed.scoringCriteria)
+    ? parsed.scoringCriteria.filter(c => c?.name && typeof c?.weight === 'number')
+    : [];
+
+  if (scoringCriteria.length < MIN_CRITERIA) {
+    scoringCriteria = [
+      { name: 'Memorability', weight: 30 },
+      { name: 'Relevance', weight: 30 },
+      { name: 'Uniqueness', weight: 20 },
+      { name: 'Pronounceability', weight: 20 },
+    ];
+  }
+
+  // Ensure weights sum to 100
+  const weightSum = scoringCriteria.reduce((sum, c) => sum + c.weight, 0);
+  if (Math.abs(weightSum - 100) > 0.001) {
+    const factor = 100 / weightSum;
+    scoringCriteria = scoringCriteria.map(c => ({
+      name: String(c.name).substring(0, 200),
+      weight: Math.round(c.weight * factor * 100) / 100,
+    }));
+    // Fix rounding
+    const newSum = scoringCriteria.reduce((sum, c) => sum + c.weight, 0);
+    if (Math.abs(newSum - 100) > 0.001) {
+      scoringCriteria[0].weight += 100 - newSum;
+      scoringCriteria[0].weight = Math.round(scoringCriteria[0].weight * 100) / 100;
+    }
+  } else {
+    scoringCriteria = scoringCriteria.map(c => ({
+      name: String(c.name).substring(0, 200),
+      weight: c.weight,
+    }));
+  }
+
+  // Normalize candidates
+  if (!Array.isArray(parsed.candidates) || parsed.candidates.length === 0) {
+    throw new Error('Stage 10 naming/brand: LLM returned no candidates');
+  }
+
+  const candidates = parsed.candidates.map((c, i) => {
+    const scores = {};
+    for (const criterion of scoringCriteria) {
+      const raw = c.scores?.[criterion.name];
+      scores[criterion.name] = typeof raw === 'number' ? Math.min(100, Math.max(0, Math.round(raw))) : 50;
+    }
+    return {
+      name: String(c.name || `Candidate ${i + 1}`).substring(0, 200),
+      rationale: String(c.rationale || 'Generated candidate').substring(0, 500),
+      scores,
+    };
+  });
+
+  return {
+    brandGenome,
+    scoringCriteria,
+    candidates,
+    totalCandidates: candidates.length,
+    totalCriteria: scoringCriteria.length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse brand naming response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { MIN_CANDIDATES, MIN_CRITERIA };

--- a/lib/eva/stage-templates/analysis-steps/stage-11-gtm.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-gtm.js
@@ -1,0 +1,175 @@
+/**
+ * Stage 11 Analysis Step - Go-To-Market Strategy Generation
+ * Part of SD-EVA-FEAT-TEMPLATES-IDENTITY-001
+ *
+ * Consumes Stages 1-10 data and generates GTM strategy with
+ * market tiers, acquisition channels, and launch timeline.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-11-gtm
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const REQUIRED_TIERS = 3;
+const REQUIRED_CHANNELS = 8;
+
+const SYSTEM_PROMPT = `You are EVA's Go-To-Market Strategy Engine. Generate a complete GTM strategy for a venture.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "tiers": [
+    {
+      "name": "Tier name",
+      "description": "Market tier description",
+      "tam": 1000000,
+      "sam": 500000,
+      "som": 50000
+    }
+  ],
+  "channels": [
+    {
+      "name": "Channel name",
+      "monthly_budget": 5000,
+      "expected_cac": 50,
+      "primary_kpi": "Signups per month"
+    }
+  ],
+  "launch_timeline": [
+    {
+      "milestone": "Milestone description",
+      "date": "YYYY-MM-DD",
+      "owner": "Team or role"
+    }
+  ]
+}
+
+Rules:
+- Generate EXACTLY ${REQUIRED_TIERS} market tiers (Tier 1 = most accessible, Tier 3 = aspirational)
+- Generate EXACTLY ${REQUIRED_CHANNELS} acquisition channels
+- Each tier needs name, description, and TAM/SAM/SOM estimates
+- Each channel needs name, monthly_budget (>= 0), expected_cac (>= 0), primary_kpi
+- Launch timeline needs at least 3 milestones with dates
+- Use upstream financial and market data to inform budget allocation
+- Channels should include a mix of paid and organic strategies`;
+
+/**
+ * Generate GTM strategy from upstream stage data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea
+ * @param {Object} [params.stage5Data] - Stage 5 financial model
+ * @param {Object} [params.stage10Data] - Stage 10 naming/brand
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} GTM strategy
+ */
+export async function analyzeStage11({ stage1Data, stage5Data, stage10Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 11 GTM requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const brandContext = stage10Data?.brandGenome
+    ? `Brand: ${stage10Data.brandGenome.archetype} archetype, targeting ${stage10Data.brandGenome.audience}`
+    : '';
+
+  const financialContext = stage5Data
+    ? `Financial: Initial Investment $${stage5Data.initialInvestment || 'N/A'}, Year 1 Revenue $${stage5Data.year1?.revenue || 'N/A'}`
+    : '';
+
+  const userPrompt = `Generate a Go-To-Market strategy for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Target Market: ${stage1Data.targetMarket || 'N/A'}
+Problem: ${stage1Data.problemStatement || 'N/A'}
+${brandContext}
+${financialContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize tiers (exactly 3)
+  let tiers = Array.isArray(parsed.tiers) ? parsed.tiers : [];
+  while (tiers.length < REQUIRED_TIERS) {
+    tiers.push({
+      name: `Tier ${tiers.length + 1}`,
+      description: 'TBD',
+      tam: 0,
+      sam: 0,
+      som: 0,
+    });
+  }
+  tiers = tiers.slice(0, REQUIRED_TIERS).map((t, i) => ({
+    name: String(t.name || `Tier ${i + 1}`).substring(0, 200),
+    description: String(t.description || 'TBD').substring(0, 500),
+    tam: typeof t.tam === 'number' && t.tam >= 0 ? t.tam : 0,
+    sam: typeof t.sam === 'number' && t.sam >= 0 ? t.sam : 0,
+    som: typeof t.som === 'number' && t.som >= 0 ? t.som : 0,
+  }));
+
+  // Normalize channels (exactly 8)
+  let channels = Array.isArray(parsed.channels) ? parsed.channels : [];
+  const defaultChannelNames = [
+    'Organic Search', 'Paid Search', 'Social Media', 'Content Marketing',
+    'Email Marketing', 'Partnerships', 'Events', 'Direct Sales',
+  ];
+  while (channels.length < REQUIRED_CHANNELS) {
+    channels.push({
+      name: defaultChannelNames[channels.length] || `Channel ${channels.length + 1}`,
+      monthly_budget: 0,
+      expected_cac: 0,
+      primary_kpi: 'TBD',
+    });
+  }
+  channels = channels.slice(0, REQUIRED_CHANNELS).map((ch, i) => ({
+    name: String(ch.name || defaultChannelNames[i] || `Channel ${i + 1}`).substring(0, 200),
+    monthly_budget: typeof ch.monthly_budget === 'number' && ch.monthly_budget >= 0 ? ch.monthly_budget : 0,
+    expected_cac: typeof ch.expected_cac === 'number' && ch.expected_cac >= 0 ? ch.expected_cac : 0,
+    primary_kpi: String(ch.primary_kpi || 'TBD').substring(0, 200),
+  }));
+
+  // Normalize launch timeline
+  let launchTimeline = Array.isArray(parsed.launch_timeline) ? parsed.launch_timeline : [];
+  if (launchTimeline.length === 0) {
+    launchTimeline = [
+      { milestone: 'Soft launch', date: '', owner: 'Founder' },
+      { milestone: 'Public launch', date: '', owner: 'Founder' },
+      { milestone: 'Growth phase', date: '', owner: 'Marketing' },
+    ];
+  }
+  launchTimeline = launchTimeline.map(m => ({
+    milestone: String(m.milestone || 'TBD').substring(0, 200),
+    date: String(m.date || ''),
+    owner: String(m.owner || '').substring(0, 100),
+  }));
+
+  const totalMonthlyBudget = channels.reduce((sum, ch) => sum + ch.monthly_budget, 0);
+  const cacValues = channels.filter(ch => ch.expected_cac > 0);
+  const avgCac = cacValues.length > 0
+    ? Math.round(cacValues.reduce((sum, ch) => sum + ch.expected_cac, 0) / cacValues.length * 100) / 100
+    : 0;
+
+  return {
+    tiers,
+    channels,
+    launch_timeline: launchTimeline,
+    totalMonthlyBudget,
+    avgCac,
+    tierCount: tiers.length,
+    channelCount: channels.length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse GTM response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { REQUIRED_TIERS, REQUIRED_CHANNELS };

--- a/lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js
@@ -1,0 +1,191 @@
+/**
+ * Stage 12 Analysis Step - Sales Logic Generation
+ * Part of SD-EVA-FEAT-TEMPLATES-IDENTITY-001
+ *
+ * Consumes Stages 1-11 data and generates sales process definition
+ * with funnel stages, customer journey, and deal pipeline.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-12-sales-logic
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const VALID_SALES_MODELS = ['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel'];
+const MIN_FUNNEL_STAGES = 4;
+const MIN_JOURNEY_STEPS = 5;
+const MIN_DEAL_STAGES = 3;
+
+const SYSTEM_PROMPT = `You are EVA's Sales Logic Engine. Generate a complete sales process definition for a venture.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "sales_model": "self-serve|inside-sales|enterprise|hybrid|marketplace|channel",
+  "sales_cycle_days": 30,
+  "deal_stages": [
+    {
+      "name": "Stage name",
+      "description": "Stage description",
+      "avg_duration_days": 7
+    }
+  ],
+  "funnel_stages": [
+    {
+      "name": "Funnel stage name",
+      "metric": "Conversion metric name",
+      "target_value": 0.25
+    }
+  ],
+  "customer_journey": [
+    {
+      "step": "Journey step description",
+      "funnel_stage": "Matching funnel stage",
+      "touchpoint": "Channel or interaction point"
+    }
+  ]
+}
+
+Rules:
+- sales_model must be one of: self-serve, inside-sales, enterprise, hybrid, marketplace, channel
+- sales_cycle_days must be >= 1
+- Generate at least ${MIN_DEAL_STAGES} deal stages
+- Generate at least ${MIN_FUNNEL_STAGES} funnel stages with metrics and target values
+- Generate at least ${MIN_JOURNEY_STEPS} customer journey steps mapped to funnel stages
+- Each deal stage needs name and description
+- Each funnel stage needs name, metric, and target_value (numeric, >= 0)
+- Each journey step needs step description, funnel_stage reference, and touchpoint
+- Use upstream GTM and financial data to inform the sales model choice`;
+
+/**
+ * Generate sales logic from upstream stage data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea
+ * @param {Object} [params.stage5Data] - Stage 5 financial model
+ * @param {Object} [params.stage10Data] - Stage 10 naming/brand
+ * @param {Object} [params.stage11Data] - Stage 11 GTM
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Sales logic definition
+ */
+export async function analyzeStage12({ stage1Data, stage5Data, stage10Data, stage11Data, ventureName }) {
+  if (!stage1Data?.description) {
+    throw new Error('Stage 12 sales logic requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const brandContext = stage10Data?.brandGenome
+    ? `Brand: ${stage10Data.brandGenome.archetype}, audience: ${stage10Data.brandGenome.audience}`
+    : '';
+
+  const gtmContext = stage11Data
+    ? `GTM: ${stage11Data.tierCount || stage11Data.tiers?.length || 0} tiers, ${stage11Data.channelCount || stage11Data.channels?.length || 0} channels, avg CAC $${stage11Data.avgCac || stage11Data.avg_cac || 'N/A'}`
+    : '';
+
+  const financialContext = stage5Data
+    ? `Financial: Year 1 Revenue $${stage5Data.year1?.revenue || 'N/A'}`
+    : '';
+
+  const userPrompt = `Generate a sales process definition for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${stage1Data.description}
+Target Market: ${stage1Data.targetMarket || 'N/A'}
+${brandContext}
+${gtmContext}
+${financialContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize sales model
+  const sales_model = VALID_SALES_MODELS.includes(parsed.sales_model)
+    ? parsed.sales_model
+    : 'hybrid';
+
+  // Normalize sales cycle
+  const sales_cycle_days = typeof parsed.sales_cycle_days === 'number' && parsed.sales_cycle_days >= 1
+    ? Math.round(parsed.sales_cycle_days)
+    : 30;
+
+  // Normalize deal stages
+  let dealStages = Array.isArray(parsed.deal_stages) ? parsed.deal_stages : [];
+  if (dealStages.length < MIN_DEAL_STAGES) {
+    const defaults = [
+      { name: 'Qualification', description: 'Initial lead qualification', avg_duration_days: 3 },
+      { name: 'Discovery', description: 'Needs assessment and demo', avg_duration_days: 7 },
+      { name: 'Proposal', description: 'Solution proposal and pricing', avg_duration_days: 5 },
+      { name: 'Negotiation', description: 'Terms negotiation and close', avg_duration_days: 7 },
+    ];
+    while (dealStages.length < MIN_DEAL_STAGES) {
+      dealStages.push(defaults[dealStages.length] || { name: `Stage ${dealStages.length + 1}`, description: 'TBD', avg_duration_days: 5 });
+    }
+  }
+  dealStages = dealStages.map((ds, i) => ({
+    name: String(ds.name || `Stage ${i + 1}`).substring(0, 200),
+    description: String(ds.description || 'TBD').substring(0, 500),
+    avg_duration_days: typeof ds.avg_duration_days === 'number' && ds.avg_duration_days >= 0 ? ds.avg_duration_days : 5,
+  }));
+
+  // Normalize funnel stages
+  let funnelStages = Array.isArray(parsed.funnel_stages) ? parsed.funnel_stages : [];
+  if (funnelStages.length < MIN_FUNNEL_STAGES) {
+    const defaults = [
+      { name: 'Awareness', metric: 'Website visitors', target_value: 10000 },
+      { name: 'Interest', metric: 'Signup rate', target_value: 0.05 },
+      { name: 'Consideration', metric: 'Trial starts', target_value: 500 },
+      { name: 'Purchase', metric: 'Conversion rate', target_value: 0.02 },
+    ];
+    while (funnelStages.length < MIN_FUNNEL_STAGES) {
+      funnelStages.push(defaults[funnelStages.length] || { name: `Stage ${funnelStages.length + 1}`, metric: 'TBD', target_value: 0 });
+    }
+  }
+  funnelStages = funnelStages.map((fs, i) => ({
+    name: String(fs.name || `Stage ${i + 1}`).substring(0, 200),
+    metric: String(fs.metric || 'TBD').substring(0, 200),
+    target_value: typeof fs.target_value === 'number' && fs.target_value >= 0 ? fs.target_value : 0,
+  }));
+
+  // Normalize customer journey
+  let customerJourney = Array.isArray(parsed.customer_journey) ? parsed.customer_journey : [];
+  if (customerJourney.length < MIN_JOURNEY_STEPS) {
+    const defaults = [
+      { step: 'Discovers product via search/social', funnel_stage: 'Awareness', touchpoint: 'Website' },
+      { step: 'Reads content and explores features', funnel_stage: 'Interest', touchpoint: 'Blog/Landing page' },
+      { step: 'Signs up for free trial', funnel_stage: 'Consideration', touchpoint: 'Sign-up form' },
+      { step: 'Engages with product features', funnel_stage: 'Consideration', touchpoint: 'Product' },
+      { step: 'Converts to paid plan', funnel_stage: 'Purchase', touchpoint: 'Checkout' },
+    ];
+    while (customerJourney.length < MIN_JOURNEY_STEPS) {
+      customerJourney.push(defaults[customerJourney.length] || { step: `Step ${customerJourney.length + 1}`, funnel_stage: 'TBD', touchpoint: 'TBD' });
+    }
+  }
+  customerJourney = customerJourney.map(cj => ({
+    step: String(cj.step || 'TBD').substring(0, 300),
+    funnel_stage: String(cj.funnel_stage || 'TBD').substring(0, 200),
+    touchpoint: String(cj.touchpoint || 'TBD').substring(0, 200),
+  }));
+
+  return {
+    sales_model,
+    sales_cycle_days,
+    deal_stages: dealStages,
+    funnel_stages: funnelStages,
+    customer_journey: customerJourney,
+    totalDealStages: dealStages.length,
+    totalFunnelStages: funnelStages.length,
+    totalJourneySteps: customerJourney.length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse sales logic response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { VALID_SALES_MODELS, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS, MIN_DEAL_STAGES };

--- a/lib/eva/stage-templates/stage-10.js
+++ b/lib/eva/stage-templates/stage-10.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateNumber, validateArray, validateInteger, collectErrors } from './validation.js';
+import { analyzeStage10 } from './analysis-steps/stage-10-naming-brand.js';
 
 const MIN_CANDIDATES = 5;
 const WEIGHT_SUM = 100;
@@ -19,7 +20,7 @@ const TEMPLATE = {
   id: 'stage-10',
   slug: 'naming-brand',
   title: 'Naming / Brand',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     brandGenome: {
       type: 'object',
@@ -166,6 +167,8 @@ const TEMPLATE = {
     return { ...data, candidates, ranked_candidates };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage10;
 
 export { MIN_CANDIDATES, WEIGHT_SUM, BRAND_GENOME_KEYS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-11.js
+++ b/lib/eva/stage-templates/stage-11.js
@@ -11,6 +11,7 @@
  */
 
 import { validateString, validateNumber, validateArray, collectErrors } from './validation.js';
+import { analyzeStage11 } from './analysis-steps/stage-11-gtm.js';
 
 const REQUIRED_TIERS = 3;
 const REQUIRED_CHANNELS = 8;
@@ -34,7 +35,7 @@ const TEMPLATE = {
   id: 'stage-11',
   slug: 'gtm',
   title: 'Go-To-Market',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     tiers: {
       type: 'array',
@@ -156,6 +157,8 @@ const TEMPLATE = {
     return { ...data, total_monthly_budget, avg_cac };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage11;
 
 export { REQUIRED_TIERS, REQUIRED_CHANNELS, CHANNEL_NAMES };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-12.js
+++ b/lib/eva/stage-templates/stage-12.js
@@ -17,6 +17,7 @@
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { REQUIRED_TIERS, REQUIRED_CHANNELS } from './stage-11.js';
 import { MIN_CANDIDATES } from './stage-10.js';
+import { analyzeStage12 } from './analysis-steps/stage-12-sales-logic.js';
 
 const SALES_MODELS = ['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel'];
 const MIN_FUNNEL_STAGES = 4;
@@ -27,7 +28,7 @@ const TEMPLATE = {
   id: 'stage-12',
   slug: 'sales-logic',
   title: 'Sales Logic',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     sales_model: { type: 'enum', values: SALES_MODELS, required: true },
     sales_cycle_days: { type: 'number', min: 1, required: true },
@@ -226,6 +227,8 @@ export function evaluateRealityGate({ stage10, stage11, stage12 }) {
 
   return { pass, rationale, blockers, required_next_actions };
 }
+
+TEMPLATE.analysisStep = analyzeStage12;
 
 export { SALES_MODELS, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS, MIN_DEAL_STAGES };
 export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/stage-10.test.js
+++ b/tests/unit/eva/stage-templates/stage-10.test.js
@@ -20,7 +20,7 @@ describe('stage-10.js - Naming/Brand template', () => {
       expect(stage10.id).toBe('stage-10');
       expect(stage10.slug).toBe('naming-brand');
       expect(stage10.title).toBe('Naming / Brand');
-      expect(stage10.version).toBe('1.0.0');
+      expect(stage10.version).toBe('2.0.0');
     });
 
     it('should export MIN_CANDIDATES = 5', () => {

--- a/tests/unit/eva/stage-templates/stage-11.test.js
+++ b/tests/unit/eva/stage-templates/stage-11.test.js
@@ -20,7 +20,7 @@ describe('stage-11.js - GTM template', () => {
       expect(stage11.id).toBe('stage-11');
       expect(stage11.slug).toBe('gtm');
       expect(stage11.title).toBe('Go-To-Market');
-      expect(stage11.version).toBe('1.0.0');
+      expect(stage11.version).toBe('2.0.0');
     });
 
     it('should export REQUIRED_TIERS = 3', () => {

--- a/tests/unit/eva/stage-templates/stage-12.test.js
+++ b/tests/unit/eva/stage-templates/stage-12.test.js
@@ -26,7 +26,7 @@ describe('stage-12.js - Sales Logic template', () => {
       expect(stage12.id).toBe('stage-12');
       expect(stage12.slug).toBe('sales-logic');
       expect(stage12.title).toBe('Sales Logic');
-      expect(stage12.version).toBe('1.0.0');
+      expect(stage12.version).toBe('2.0.0');
     });
 
     it('should export SALES_MODELS', () => {


### PR DESCRIPTION
## Summary
- Add LLM-powered analysis steps for THE IDENTITY phase (Stages 10-12)
- Stage 10 (Naming/Brand): brand genome, scoring criteria, naming candidates with weighted scoring
- Stage 11 (GTM): market tiers (3), acquisition channels (8), launch timeline
- Stage 12 (Sales Logic): sales model enum, deal stages, funnel stages (4+), customer journey (5+)
- Bump template versions from 1.0.0 to 2.0.0 and attach analysisStep functions
- Update analysis-steps/index.js registry with stages 10-12 exports and loaders

## Test plan
- [x] All 1078 stage template unit tests pass (27 test files)
- [x] Version assertions updated from 1.0.0 to 2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)