### PR TITLE
feat(eva): enhance stages 10-12 analysis steps to v2.0

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-10-naming-brand.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-10-naming-brand.js
@@ -12,6 +12,8 @@ import { getLLMClient } from '../../../llm/index.js';
 
 const MIN_CANDIDATES = 5;
 const MIN_CRITERIA = 3;
+const NAMING_STRATEGIES = ['descriptive', 'abstract', 'acronym', 'founder', 'metaphorical'];
+const AVAILABILITY_STATUSES = ['pending', 'available', 'taken', 'unknown'];
 
 const SYSTEM_PROMPT = `You are EVA's Brand Identity Engine. Generate a complete brand naming analysis for a venture based on prior stage data.
 
@@ -24,6 +26,12 @@ You MUST output valid JSON with exactly this structure:
     "audience": "Primary audience description",
     "differentiators": ["Differentiator 1", "Differentiator 2"]
   },
+  "narrativeExtension": {
+    "vision": "Company vision statement (aspirational future state)",
+    "mission": "Company mission statement (how you get there)",
+    "brandVoice": "Detailed brand voice guidelines (tone, style, personality)"
+  },
+  "namingStrategy": "descriptive|abstract|acronym|founder|metaphorical",
   "scoringCriteria": [
     { "name": "Criterion name", "weight": 25 }
   ],
@@ -33,7 +41,17 @@ You MUST output valid JSON with exactly this structure:
       "rationale": "Why this name fits the brand",
       "scores": { "Criterion name": 85 }
     }
-  ]
+  ],
+  "decision": {
+    "selectedName": "Top-scoring candidate name",
+    "workingTitle": true,
+    "rationale": "Why this name is recommended (2-3 sentences)",
+    "availabilityChecks": {
+      "domain": "pending",
+      "trademark": "pending",
+      "social": "pending"
+    }
+  }
 }
 
 Rules:
@@ -42,6 +60,10 @@ Rules:
 - Scoring criteria weights MUST sum to exactly 100
 - Each candidate MUST have a score (0-100) for every criterion
 - Brand genome must include archetype, values (>= 1), tone, audience, differentiators (>= 1)
+- narrativeExtension: vision and mission must be specific to this venture, not generic
+- namingStrategy: choose the approach that best fits the venture (descriptive, abstract, acronym, founder, metaphorical)
+- decision.selectedName must match one of the candidate names
+- decision.workingTitle should be true (pending availability checks)
 - Names should be creative, memorable, and relevant to the venture
 - Rationale should explain why the name fits the brand genome`;
 
@@ -156,10 +178,50 @@ Output ONLY valid JSON.`;
     };
   });
 
+  // Normalize narrativeExtension
+  const ne = parsed.narrativeExtension || {};
+  const narrativeExtension = {
+    vision: String(ne.vision || '').substring(0, 500) || null,
+    mission: String(ne.mission || '').substring(0, 500) || null,
+    brandVoice: String(ne.brandVoice || '').substring(0, 500) || null,
+  };
+
+  // Normalize namingStrategy
+  const namingStrategy = NAMING_STRATEGIES.includes(parsed.namingStrategy)
+    ? parsed.namingStrategy
+    : 'descriptive';
+
+  // Normalize decision — select top-scoring candidate if LLM didn't provide one
+  const dec = parsed.decision || {};
+  const topCandidate = candidates.length > 0
+    ? [...candidates].sort((a, b) => {
+        const scoreA = scoringCriteria.reduce((sum, cr) => sum + (a.scores[cr.name] || 0) * cr.weight / 100, 0);
+        const scoreB = scoringCriteria.reduce((sum, cr) => sum + (b.scores[cr.name] || 0) * cr.weight / 100, 0);
+        return scoreB - scoreA;
+      })[0]
+    : null;
+  const selectedName = dec.selectedName && candidates.some(c => c.name === dec.selectedName)
+    ? dec.selectedName
+    : topCandidate?.name || '';
+  const ac = dec.availabilityChecks || {};
+  const decision = {
+    selectedName,
+    workingTitle: dec.workingTitle !== false,
+    rationale: String(dec.rationale || 'Top-scoring candidate based on weighted criteria').substring(0, 500),
+    availabilityChecks: {
+      domain: AVAILABILITY_STATUSES.includes(ac.domain) ? ac.domain : 'pending',
+      trademark: AVAILABILITY_STATUSES.includes(ac.trademark) ? ac.trademark : 'pending',
+      social: AVAILABILITY_STATUSES.includes(ac.social) ? ac.social : 'pending',
+    },
+  };
+
   return {
     brandGenome,
+    narrativeExtension,
+    namingStrategy,
     scoringCriteria,
     candidates,
+    decision,
     totalCandidates: candidates.length,
     totalCriteria: scoringCriteria.length,
   };
@@ -174,4 +236,4 @@ function parseJSON(text) {
   }
 }
 
-export { MIN_CANDIDATES, MIN_CRITERIA };
+export { MIN_CANDIDATES, MIN_CRITERIA, NAMING_STRATEGIES };

--- a/lib/eva/stage-templates/analysis-steps/stage-11-gtm.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-gtm.js
@@ -12,6 +12,7 @@ import { getLLMClient } from '../../../llm/index.js';
 
 const REQUIRED_TIERS = 3;
 const REQUIRED_CHANNELS = 8;
+const CHANNEL_TYPES = ['paid', 'organic', 'earned', 'owned'];
 
 const SYSTEM_PROMPT = `You are EVA's Go-To-Market Strategy Engine. Generate a complete GTM strategy for a venture.
 
@@ -23,7 +24,9 @@ You MUST output valid JSON with exactly this structure:
       "description": "Market tier description",
       "tam": 1000000,
       "sam": 500000,
-      "som": 50000
+      "som": 50000,
+      "persona": "Ideal customer persona for this tier (job title, company size, pain level)",
+      "painPoints": ["Specific pain point 1", "Specific pain point 2"]
     }
   ],
   "channels": [
@@ -31,7 +34,9 @@ You MUST output valid JSON with exactly this structure:
       "name": "Channel name",
       "monthly_budget": 5000,
       "expected_cac": 50,
-      "primary_kpi": "Signups per month"
+      "primary_kpi": "Signups per month",
+      "channelType": "paid|organic|earned|owned",
+      "primaryTier": "Tier name this channel primarily targets"
     }
   ],
   "launch_timeline": [
@@ -46,8 +51,11 @@ You MUST output valid JSON with exactly this structure:
 Rules:
 - Generate EXACTLY ${REQUIRED_TIERS} market tiers (Tier 1 = most accessible, Tier 3 = aspirational)
 - Generate EXACTLY ${REQUIRED_CHANNELS} acquisition channels
-- Each tier needs name, description, and TAM/SAM/SOM estimates
-- Each channel needs name, monthly_budget (>= 0), expected_cac (>= 0), primary_kpi
+- Each tier needs name, description, TAM/SAM/SOM estimates, persona, and painPoints (>= 1)
+- Each channel needs name, monthly_budget (>= 0), expected_cac (>= 0), primary_kpi, channelType, primaryTier
+- channelType must be one of: paid, organic, earned, owned
+- primaryTier must reference one of the tier names
+- Channels with monthly_budget = 0 are valid (BACKLOG items to activate later)
 - Launch timeline needs at least 3 milestones with dates
 - Use upstream financial and market data to inform budget allocation
 - Channels should include a mix of paid and organic strategies`;
@@ -108,7 +116,12 @@ Output ONLY valid JSON.`;
     tam: typeof t.tam === 'number' && t.tam >= 0 ? t.tam : 0,
     sam: typeof t.sam === 'number' && t.sam >= 0 ? t.sam : 0,
     som: typeof t.som === 'number' && t.som >= 0 ? t.som : 0,
+    persona: String(t.persona || '').substring(0, 500) || null,
+    painPoints: Array.isArray(t.painPoints) && t.painPoints.length > 0
+      ? t.painPoints.map(p => String(p).substring(0, 300))
+      : [],
   }));
+  const tierNames = tiers.map(t => t.name);
 
   // Normalize channels (exactly 8)
   let channels = Array.isArray(parsed.channels) ? parsed.channels : [];
@@ -124,12 +137,21 @@ Output ONLY valid JSON.`;
       primary_kpi: 'TBD',
     });
   }
-  channels = channels.slice(0, REQUIRED_CHANNELS).map((ch, i) => ({
-    name: String(ch.name || defaultChannelNames[i] || `Channel ${i + 1}`).substring(0, 200),
-    monthly_budget: typeof ch.monthly_budget === 'number' && ch.monthly_budget >= 0 ? ch.monthly_budget : 0,
-    expected_cac: typeof ch.expected_cac === 'number' && ch.expected_cac >= 0 ? ch.expected_cac : 0,
-    primary_kpi: String(ch.primary_kpi || 'TBD').substring(0, 200),
-  }));
+  channels = channels.slice(0, REQUIRED_CHANNELS).map((ch, i) => {
+    const budget = typeof ch.monthly_budget === 'number' && ch.monthly_budget >= 0 ? ch.monthly_budget : 0;
+    const primaryTier = tierNames.includes(ch.primaryTier)
+      ? ch.primaryTier
+      : tierNames[0] || 'Tier 1';
+    return {
+      name: String(ch.name || defaultChannelNames[i] || `Channel ${i + 1}`).substring(0, 200),
+      monthly_budget: budget,
+      expected_cac: typeof ch.expected_cac === 'number' && ch.expected_cac >= 0 ? ch.expected_cac : 0,
+      primary_kpi: String(ch.primary_kpi || 'TBD').substring(0, 200),
+      channelType: CHANNEL_TYPES.includes(ch.channelType) ? ch.channelType : 'organic',
+      primaryTier,
+      status: budget === 0 ? 'BACKLOG' : 'ACTIVE',
+    };
+  });
 
   // Normalize launch timeline
   let launchTimeline = Array.isArray(parsed.launch_timeline) ? parsed.launch_timeline : [];
@@ -152,6 +174,9 @@ Output ONLY valid JSON.`;
     ? Math.round(cacValues.reduce((sum, ch) => sum + ch.expected_cac, 0) / cacValues.length * 100) / 100
     : 0;
 
+  const activeChannels = channels.filter(ch => ch.status === 'ACTIVE');
+  const backlogChannels = channels.filter(ch => ch.status === 'BACKLOG');
+
   return {
     tiers,
     channels,
@@ -160,6 +185,8 @@ Output ONLY valid JSON.`;
     avgCac,
     tierCount: tiers.length,
     channelCount: channels.length,
+    activeChannelCount: activeChannels.length,
+    backlogChannelCount: backlogChannels.length,
   };
 }
 
@@ -172,4 +199,4 @@ function parseJSON(text) {
   }
 }
 
-export { REQUIRED_TIERS, REQUIRED_CHANNELS };
+export { REQUIRED_TIERS, REQUIRED_CHANNELS, CHANNEL_TYPES };

--- a/lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js
@@ -25,14 +25,16 @@ You MUST output valid JSON with exactly this structure:
     {
       "name": "Stage name",
       "description": "Stage description",
-      "avg_duration_days": 7
+      "avg_duration_days": 7,
+      "mappedFunnelStage": "Matching funnel stage name"
     }
   ],
   "funnel_stages": [
     {
       "name": "Funnel stage name",
       "metric": "Conversion metric name",
-      "target_value": 0.25
+      "target_value": 0.25,
+      "conversionRateEstimate": 0.25
     }
   ],
   "customer_journey": [
@@ -50,8 +52,9 @@ Rules:
 - Generate at least ${MIN_DEAL_STAGES} deal stages
 - Generate at least ${MIN_FUNNEL_STAGES} funnel stages with metrics and target values
 - Generate at least ${MIN_JOURNEY_STEPS} customer journey steps mapped to funnel stages
-- Each deal stage needs name and description
-- Each funnel stage needs name, metric, and target_value (numeric, >= 0)
+- Each deal stage needs name, description, and mappedFunnelStage referencing a funnel stage name
+- Each funnel stage needs name, metric, target_value (numeric, >= 0), and conversionRateEstimate (0-1)
+- conversionRateEstimate represents the estimated conversion rate at each funnel stage
 - Each journey step needs step description, funnel_stage reference, and touchpoint
 - Use upstream GTM and financial data to inform the sales model choice`;
 
@@ -61,12 +64,13 @@ Rules:
  * @param {Object} params
  * @param {Object} params.stage1Data - Stage 1 Draft Idea
  * @param {Object} [params.stage5Data] - Stage 5 financial model
+ * @param {Object} [params.stage7Data] - Stage 7 pricing strategy
  * @param {Object} [params.stage10Data] - Stage 10 naming/brand
  * @param {Object} [params.stage11Data] - Stage 11 GTM
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Sales logic definition
  */
-export async function analyzeStage12({ stage1Data, stage5Data, stage10Data, stage11Data, ventureName }) {
+export async function analyzeStage12({ stage1Data, stage5Data, stage7Data, stage10Data, stage11Data, ventureName }) {
   if (!stage1Data?.description) {
     throw new Error('Stage 12 sales logic requires Stage 1 data with description');
   }
@@ -85,6 +89,10 @@ export async function analyzeStage12({ stage1Data, stage5Data, stage10Data, stag
     ? `Financial: Year 1 Revenue $${stage5Data.year1?.revenue || 'N/A'}`
     : '';
 
+  const pricingContext = stage7Data
+    ? `Pricing: ${stage7Data.pricingModel || 'N/A'}, ARPA $${stage7Data.unitEconomics?.arpa || 'N/A'}`
+    : '';
+
   const userPrompt = `Generate a sales process definition for this venture.
 
 Venture: ${ventureName || 'Unnamed'}
@@ -93,6 +101,7 @@ Target Market: ${stage1Data.targetMarket || 'N/A'}
 ${brandContext}
 ${gtmContext}
 ${financialContext}
+${pricingContext}
 
 Output ONLY valid JSON.`;
 
@@ -126,6 +135,7 @@ Output ONLY valid JSON.`;
     name: String(ds.name || `Stage ${i + 1}`).substring(0, 200),
     description: String(ds.description || 'TBD').substring(0, 500),
     avg_duration_days: typeof ds.avg_duration_days === 'number' && ds.avg_duration_days >= 0 ? ds.avg_duration_days : 5,
+    mappedFunnelStage: String(ds.mappedFunnelStage || '').substring(0, 200) || null,
   }));
 
   // Normalize funnel stages
@@ -145,6 +155,9 @@ Output ONLY valid JSON.`;
     name: String(fs.name || `Stage ${i + 1}`).substring(0, 200),
     metric: String(fs.metric || 'TBD').substring(0, 200),
     target_value: typeof fs.target_value === 'number' && fs.target_value >= 0 ? fs.target_value : 0,
+    conversionRateEstimate: typeof fs.conversionRateEstimate === 'number' && fs.conversionRateEstimate >= 0 && fs.conversionRateEstimate <= 1
+      ? Math.round(fs.conversionRateEstimate * 10000) / 10000
+      : null,
   }));
 
   // Normalize customer journey
@@ -167,6 +180,24 @@ Output ONLY valid JSON.`;
     touchpoint: String(cj.touchpoint || 'TBD').substring(0, 200),
   }));
 
+  // Back-link: validate mappedFunnelStage references valid funnel stage names
+  const funnelNames = funnelStages.map(fs => fs.name);
+  dealStages = dealStages.map(ds => ({
+    ...ds,
+    mappedFunnelStage: ds.mappedFunnelStage && funnelNames.includes(ds.mappedFunnelStage)
+      ? ds.mappedFunnelStage
+      : funnelNames[0] || null,
+  }));
+
+  // Economy check: compute pipeline metrics for Reality Gate
+  const totalPipelineValue = funnelStages.reduce((sum, fs) => sum + fs.target_value, 0);
+  const avgConversionRate = (() => {
+    const rates = funnelStages.filter(fs => fs.conversionRateEstimate !== null);
+    return rates.length > 0
+      ? Math.round(rates.reduce((sum, fs) => sum + fs.conversionRateEstimate, 0) / rates.length * 10000) / 10000
+      : null;
+  })();
+
   return {
     sales_model,
     sales_cycle_days,
@@ -176,6 +207,11 @@ Output ONLY valid JSON.`;
     totalDealStages: dealStages.length,
     totalFunnelStages: funnelStages.length,
     totalJourneySteps: customerJourney.length,
+    economyCheck: {
+      totalPipelineValue,
+      avgConversionRate,
+      pricingAvailable: !!stage7Data,
+    },
   };
 }
 

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-10-naming-brand.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-10-naming-brand.test.js
@@ -1,0 +1,535 @@
+/**
+ * Unit tests for Stage 10 Analysis Step - Naming/Brand (v2.0 enhancements)
+ * Part of SD-EVA-FEAT-TEMPLATES-IDENTITY-001
+ *
+ * Tests v2.0 features:
+ * - narrativeExtension normalization (vision, mission, brandVoice)
+ * - namingStrategy enum validation and fallback
+ * - decision auto-selection logic (top-scoring candidate)
+ * - availabilityChecks defaults and validation
+ *
+ * @module tests/unit/eva/stage-templates/analysis-steps/stage-10-naming-brand.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the LLM client before importing the module under test
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+import { analyzeStage10, MIN_CANDIDATES, MIN_CRITERIA, NAMING_STRATEGIES } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-10-naming-brand.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+/**
+ * Helper: create a well-formed LLM response JSON string.
+ */
+function createLLMResponse(overrides = {}) {
+  const base = {
+    brandGenome: {
+      archetype: 'Explorer',
+      values: ['Innovation', 'Freedom'],
+      tone: 'Bold and adventurous',
+      audience: 'Tech-savvy millennials',
+      differentiators: ['AI-first', 'Open source'],
+    },
+    narrativeExtension: {
+      vision: 'To democratize AI for every business',
+      mission: 'We build accessible AI tools that empower small teams',
+      brandVoice: 'Confident, clear, and human-centric',
+    },
+    namingStrategy: 'abstract',
+    scoringCriteria: [
+      { name: 'Memorability', weight: 30 },
+      { name: 'Relevance', weight: 40 },
+      { name: 'Uniqueness', weight: 30 },
+    ],
+    candidates: [
+      { name: 'Lumina', rationale: 'Light and clarity', scores: { Memorability: 90, Relevance: 85, Uniqueness: 95 } },
+      { name: 'Forge', rationale: 'Building and creation', scores: { Memorability: 80, Relevance: 75, Uniqueness: 70 } },
+      { name: 'Nexus', rationale: 'Connection point', scores: { Memorability: 85, Relevance: 90, Uniqueness: 60 } },
+      { name: 'Aether', rationale: 'Ethereal and expansive', scores: { Memorability: 70, Relevance: 65, Uniqueness: 85 } },
+      { name: 'Prism', rationale: 'Multiple perspectives', scores: { Memorability: 88, Relevance: 80, Uniqueness: 75 } },
+    ],
+    decision: {
+      selectedName: 'Lumina',
+      workingTitle: true,
+      rationale: 'Lumina scored highest across all weighted criteria, especially in uniqueness.',
+      availabilityChecks: {
+        domain: 'pending',
+        trademark: 'pending',
+        social: 'pending',
+      },
+    },
+    ...overrides,
+  };
+  return JSON.stringify(base);
+}
+
+function setupMock(responseOverrides = {}) {
+  const mockComplete = vi.fn().mockResolvedValue(createLLMResponse(responseOverrides));
+  getLLMClient.mockReturnValue({ complete: mockComplete });
+  return mockComplete;
+}
+
+const VALID_PARAMS = {
+  stage1Data: { description: 'An AI-powered analytics platform', targetMarket: 'SMBs', problemStatement: 'Data chaos' },
+};
+
+describe('stage-10-naming-brand.js - Analysis Step v2.0', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Exported constants', () => {
+    it('should export MIN_CANDIDATES = 5', () => {
+      expect(MIN_CANDIDATES).toBe(5);
+    });
+
+    it('should export MIN_CRITERIA = 3', () => {
+      expect(MIN_CRITERIA).toBe(3);
+    });
+
+    it('should export NAMING_STRATEGIES with 5 valid values', () => {
+      expect(NAMING_STRATEGIES).toEqual(['descriptive', 'abstract', 'acronym', 'founder', 'metaphorical']);
+    });
+  });
+
+  describe('Input validation', () => {
+    it('should throw when stage1Data is missing', async () => {
+      await expect(analyzeStage10({})).rejects.toThrow('Stage 10 naming/brand requires Stage 1 data with description');
+    });
+
+    it('should throw when stage1Data.description is missing', async () => {
+      await expect(analyzeStage10({ stage1Data: {} })).rejects.toThrow('Stage 10 naming/brand requires Stage 1 data with description');
+    });
+
+    it('should throw when stage1Data.description is empty string', async () => {
+      await expect(analyzeStage10({ stage1Data: { description: '' } })).rejects.toThrow('Stage 10 naming/brand requires Stage 1 data with description');
+    });
+  });
+
+  describe('narrativeExtension normalization', () => {
+    it('should include narrativeExtension in output when LLM provides it', async () => {
+      setupMock();
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.narrativeExtension).toBeDefined();
+      expect(result.narrativeExtension.vision).toBe('To democratize AI for every business');
+      expect(result.narrativeExtension.mission).toBe('We build accessible AI tools that empower small teams');
+      expect(result.narrativeExtension.brandVoice).toBe('Confident, clear, and human-centric');
+    });
+
+    it('should set narrativeExtension fields to null when LLM omits them', async () => {
+      setupMock({ narrativeExtension: {} });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.narrativeExtension.vision).toBeNull();
+      expect(result.narrativeExtension.mission).toBeNull();
+      expect(result.narrativeExtension.brandVoice).toBeNull();
+    });
+
+    it('should set narrativeExtension fields to null when narrativeExtension is missing entirely', async () => {
+      const mockComplete = vi.fn().mockResolvedValue(JSON.stringify({
+        brandGenome: { archetype: 'Creator', values: ['Innovation'], tone: 'Professional', audience: 'B2B', differentiators: ['Fast'] },
+        scoringCriteria: [{ name: 'M', weight: 50 }, { name: 'R', weight: 50 }],
+        candidates: [
+          { name: 'C1', rationale: 'R1', scores: { M: 80, R: 90 } },
+          { name: 'C2', rationale: 'R2', scores: { M: 70, R: 80 } },
+          { name: 'C3', rationale: 'R3', scores: { M: 85, R: 75 } },
+          { name: 'C4', rationale: 'R4', scores: { M: 75, R: 85 } },
+          { name: 'C5', rationale: 'R5', scores: { M: 90, R: 70 } },
+        ],
+      }));
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.narrativeExtension.vision).toBeNull();
+      expect(result.narrativeExtension.mission).toBeNull();
+      expect(result.narrativeExtension.brandVoice).toBeNull();
+    });
+
+    it('should truncate narrativeExtension fields to 500 characters', async () => {
+      const longText = 'A'.repeat(600);
+      setupMock({
+        narrativeExtension: {
+          vision: longText,
+          mission: longText,
+          brandVoice: longText,
+        },
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.narrativeExtension.vision.length).toBe(500);
+      expect(result.narrativeExtension.mission.length).toBe(500);
+      expect(result.narrativeExtension.brandVoice.length).toBe(500);
+    });
+
+    it('should coerce non-string narrativeExtension fields to string', async () => {
+      setupMock({
+        narrativeExtension: {
+          vision: 12345,
+          mission: true,
+          brandVoice: null,
+        },
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.narrativeExtension.vision).toBe('12345');
+      expect(result.narrativeExtension.mission).toBe('true');
+      expect(result.narrativeExtension.brandVoice).toBeNull();
+    });
+  });
+
+  describe('namingStrategy enum validation', () => {
+    it('should accept valid namingStrategy values', async () => {
+      for (const strategy of NAMING_STRATEGIES) {
+        setupMock({ namingStrategy: strategy });
+        const result = await analyzeStage10(VALID_PARAMS);
+        expect(result.namingStrategy).toBe(strategy);
+      }
+    });
+
+    it('should default to "descriptive" for invalid namingStrategy', async () => {
+      setupMock({ namingStrategy: 'invalid-strategy' });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.namingStrategy).toBe('descriptive');
+    });
+
+    it('should default to "descriptive" when namingStrategy is missing', async () => {
+      setupMock({ namingStrategy: undefined });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.namingStrategy).toBe('descriptive');
+    });
+
+    it('should default to "descriptive" for numeric namingStrategy', async () => {
+      setupMock({ namingStrategy: 42 });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.namingStrategy).toBe('descriptive');
+    });
+  });
+
+  describe('decision auto-selection logic', () => {
+    it('should use LLM-provided selectedName when it matches a candidate', async () => {
+      setupMock({ decision: { selectedName: 'Forge' } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.selectedName).toBe('Forge');
+    });
+
+    it('should auto-select top-scoring candidate when LLM selectedName does not match any candidate', async () => {
+      setupMock({ decision: { selectedName: 'NonExistent' } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      // Top-scoring: Lumina = 0.30*90 + 0.40*85 + 0.30*95 = 27+34+28.5 = 89.5
+      expect(result.decision.selectedName).toBe('Lumina');
+    });
+
+    it('should auto-select top-scoring candidate when decision is missing entirely', async () => {
+      setupMock({ decision: undefined });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.selectedName).toBe('Lumina');
+    });
+
+    it('should auto-select top-scoring candidate when decision.selectedName is empty', async () => {
+      setupMock({ decision: { selectedName: '' } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.selectedName).toBe('Lumina');
+    });
+
+    it('should default workingTitle to true when not explicitly false', async () => {
+      setupMock({ decision: { workingTitle: undefined } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.workingTitle).toBe(true);
+    });
+
+    it('should set workingTitle to false only when explicitly false', async () => {
+      setupMock({ decision: { workingTitle: false } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.workingTitle).toBe(false);
+    });
+
+    it('should provide default rationale when decision.rationale is missing', async () => {
+      setupMock({ decision: { rationale: undefined } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.rationale).toContain('Top-scoring candidate');
+    });
+
+    it('should truncate decision.rationale to 500 characters', async () => {
+      setupMock({ decision: { rationale: 'R'.repeat(600) } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.rationale.length).toBe(500);
+    });
+  });
+
+  describe('availabilityChecks defaults', () => {
+    it('should default all availability checks to "pending"', async () => {
+      setupMock({ decision: {} });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.availabilityChecks).toEqual({
+        domain: 'pending',
+        trademark: 'pending',
+        social: 'pending',
+      });
+    });
+
+    it('should accept valid availability status values', async () => {
+      setupMock({
+        decision: {
+          availabilityChecks: {
+            domain: 'available',
+            trademark: 'taken',
+            social: 'unknown',
+          },
+        },
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.availabilityChecks.domain).toBe('available');
+      expect(result.decision.availabilityChecks.trademark).toBe('taken');
+      expect(result.decision.availabilityChecks.social).toBe('unknown');
+    });
+
+    it('should default invalid availability status values to "pending"', async () => {
+      setupMock({
+        decision: {
+          availabilityChecks: {
+            domain: 'checked',
+            trademark: 'reserved',
+            social: 'blocked',
+          },
+        },
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.decision.availabilityChecks.domain).toBe('pending');
+      expect(result.decision.availabilityChecks.trademark).toBe('pending');
+      expect(result.decision.availabilityChecks.social).toBe('pending');
+    });
+  });
+
+  describe('brandGenome normalization', () => {
+    it('should truncate all brandGenome string fields to 200 characters', async () => {
+      setupMock({
+        brandGenome: {
+          archetype: 'A'.repeat(300),
+          values: ['V'.repeat(300)],
+          tone: 'T'.repeat(300),
+          audience: 'U'.repeat(300),
+          differentiators: ['D'.repeat(300)],
+        },
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.brandGenome.archetype.length).toBe(200);
+      expect(result.brandGenome.values[0].length).toBe(200);
+      expect(result.brandGenome.tone.length).toBe(200);
+      expect(result.brandGenome.audience.length).toBe(200);
+      expect(result.brandGenome.differentiators[0].length).toBe(200);
+    });
+
+    it('should default archetype to "Creator" when missing', async () => {
+      setupMock({ brandGenome: { values: ['V'], tone: 'T', audience: 'A', differentiators: ['D'] } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.brandGenome.archetype).toBe('Creator');
+    });
+
+    it('should default values to ["Innovation"] when empty array', async () => {
+      setupMock({ brandGenome: { archetype: 'Hero', values: [], tone: 'T', audience: 'A', differentiators: ['D'] } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.brandGenome.values).toEqual(['Innovation']);
+    });
+
+    it('should default differentiators to ["Unique approach"] when empty', async () => {
+      setupMock({ brandGenome: { archetype: 'Hero', values: ['V'], tone: 'T', audience: 'A', differentiators: [] } });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.brandGenome.differentiators).toEqual(['Unique approach']);
+    });
+
+    it('should use stage1Data.targetMarket as audience fallback', async () => {
+      setupMock({ brandGenome: { archetype: 'Hero', values: ['V'], tone: 'T', differentiators: ['D'] } });
+      const result = await analyzeStage10({ stage1Data: { description: 'Test', targetMarket: 'Enterprise B2B' } });
+      expect(result.brandGenome.audience).toBe('Enterprise B2B');
+    });
+  });
+
+  describe('scoringCriteria normalization', () => {
+    it('should normalize weights to sum to 100 when they do not', async () => {
+      setupMock({
+        scoringCriteria: [
+          { name: 'A', weight: 50 },
+          { name: 'B', weight: 50 },
+          { name: 'C', weight: 50 },
+        ],
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      const weightSum = result.scoringCriteria.reduce((sum, c) => sum + c.weight, 0);
+      expect(Math.abs(weightSum - 100)).toBeLessThan(0.01);
+    });
+
+    it('should use default criteria when LLM provides fewer than MIN_CRITERIA', async () => {
+      setupMock({
+        scoringCriteria: [
+          { name: 'Only', weight: 100 },
+        ],
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.scoringCriteria.length).toBe(4); // Default set
+      expect(result.scoringCriteria[0].name).toBe('Memorability');
+    });
+
+    it('should filter out criteria missing name or weight', async () => {
+      setupMock({
+        scoringCriteria: [
+          { name: 'Valid1', weight: 40 },
+          { weight: 30 }, // missing name
+          { name: 'Valid2' }, // missing weight
+        ],
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      // Only 1 valid criterion (< MIN_CRITERIA), so defaults are used
+      expect(result.scoringCriteria.length).toBe(4);
+    });
+  });
+
+  describe('candidates normalization', () => {
+    it('should throw when LLM returns no candidates', async () => {
+      setupMock({ candidates: [] });
+      await expect(analyzeStage10(VALID_PARAMS)).rejects.toThrow('LLM returned no candidates');
+    });
+
+    it('should clamp candidate scores to 0-100 range', async () => {
+      setupMock({
+        candidates: [
+          { name: 'C1', rationale: 'R1', scores: { Memorability: 150, Relevance: -20, Uniqueness: 50 } },
+          { name: 'C2', rationale: 'R2', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C3', rationale: 'R3', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C4', rationale: 'R4', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C5', rationale: 'R5', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+        ],
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.candidates[0].scores.Memorability).toBe(100);
+      expect(result.candidates[0].scores.Relevance).toBe(0);
+    });
+
+    it('should default missing scores to 50', async () => {
+      setupMock({
+        candidates: [
+          { name: 'C1', rationale: 'R1', scores: { Memorability: 80 } }, // missing Relevance and Uniqueness
+          { name: 'C2', rationale: 'R2', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C3', rationale: 'R3', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C4', rationale: 'R4', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C5', rationale: 'R5', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+        ],
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.candidates[0].scores.Relevance).toBe(50);
+      expect(result.candidates[0].scores.Uniqueness).toBe(50);
+    });
+
+    it('should truncate candidate name and rationale', async () => {
+      setupMock({
+        candidates: [
+          { name: 'N'.repeat(300), rationale: 'R'.repeat(600), scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C2', rationale: 'R2', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C3', rationale: 'R3', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C4', rationale: 'R4', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C5', rationale: 'R5', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+        ],
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.candidates[0].name.length).toBe(200);
+      expect(result.candidates[0].rationale.length).toBe(500);
+    });
+
+    it('should default candidate name when missing', async () => {
+      setupMock({
+        candidates: [
+          { rationale: 'R1', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C2', rationale: 'R2', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C3', rationale: 'R3', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C4', rationale: 'R4', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+          { name: 'C5', rationale: 'R5', scores: { Memorability: 80, Relevance: 80, Uniqueness: 80 } },
+        ],
+      });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.candidates[0].name).toBe('Candidate 1');
+    });
+  });
+
+  describe('Output shape', () => {
+    it('should return all expected top-level fields', async () => {
+      setupMock();
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result).toHaveProperty('brandGenome');
+      expect(result).toHaveProperty('narrativeExtension');
+      expect(result).toHaveProperty('namingStrategy');
+      expect(result).toHaveProperty('scoringCriteria');
+      expect(result).toHaveProperty('candidates');
+      expect(result).toHaveProperty('decision');
+      expect(result).toHaveProperty('totalCandidates');
+      expect(result).toHaveProperty('totalCriteria');
+    });
+
+    it('should set totalCandidates to match candidates array length', async () => {
+      setupMock();
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.totalCandidates).toBe(result.candidates.length);
+    });
+
+    it('should set totalCriteria to match scoringCriteria array length', async () => {
+      setupMock();
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.totalCriteria).toBe(result.scoringCriteria.length);
+    });
+  });
+
+  describe('Optional upstream data integration', () => {
+    it('should include stage3 scoring context in prompt when available', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage10({
+        ...VALID_PARAMS,
+        stage3Data: { overallScore: 78 },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('78');
+    });
+
+    it('should include stage5 financial context in prompt when available', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage10({
+        ...VALID_PARAMS,
+        stage5Data: { initialInvestment: 50000, year1: { revenue: 200000 } },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('50000');
+      expect(userPrompt).toContain('200000');
+    });
+
+    it('should include stage8 BMC context in prompt when available', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage10({
+        ...VALID_PARAMS,
+        stage8Data: { value_propositions: { items: ['Affordable AI analytics'] } },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('Affordable AI analytics');
+    });
+
+    it('should include ventureName in prompt when provided', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage10({ ...VALID_PARAMS, ventureName: 'TestVenture' });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('TestVenture');
+    });
+  });
+
+  describe('JSON parsing', () => {
+    it('should handle LLM response wrapped in markdown code block', async () => {
+      const response = createLLMResponse();
+      const mockComplete = vi.fn().mockResolvedValue('```json\n' + response + '\n```');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      const result = await analyzeStage10(VALID_PARAMS);
+      expect(result.brandGenome.archetype).toBe('Explorer');
+    });
+
+    it('should throw on unparseable LLM response', async () => {
+      const mockComplete = vi.fn().mockResolvedValue('This is not JSON at all');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      await expect(analyzeStage10(VALID_PARAMS)).rejects.toThrow('Failed to parse brand naming response');
+    });
+  });
+});

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-11-gtm.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-11-gtm.test.js
@@ -1,0 +1,578 @@
+/**
+ * Unit tests for Stage 11 Analysis Step - GTM (v2.0 enhancements)
+ * Part of SD-EVA-FEAT-TEMPLATES-IDENTITY-001
+ *
+ * Tests v2.0 features:
+ * - persona/painPoints per tier
+ * - channelType enum validation and fallback
+ * - primaryTier cross-referencing against tier names
+ * - BACKLOG/ACTIVE status logic based on budget
+ *
+ * @module tests/unit/eva/stage-templates/analysis-steps/stage-11-gtm.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the LLM client before importing the module under test
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+import { analyzeStage11, REQUIRED_TIERS, REQUIRED_CHANNELS, CHANNEL_TYPES } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-11-gtm.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+/**
+ * Helper: create a well-formed LLM response JSON string.
+ */
+function createLLMResponse(overrides = {}) {
+  const base = {
+    tiers: [
+      { name: 'Enterprise', description: 'Large companies', tam: 10000000, sam: 1000000, som: 100000, persona: 'CTO at Fortune 500', painPoints: ['Complex data pipelines', 'Vendor lock-in'] },
+      { name: 'Mid-Market', description: 'Growing companies', tam: 5000000, sam: 500000, som: 50000, persona: 'VP Engineering at Series B+', painPoints: ['Scaling challenges'] },
+      { name: 'SMB', description: 'Small businesses', tam: 2000000, sam: 200000, som: 20000, persona: 'Technical founder', painPoints: ['Limited budget', 'No dedicated ops team'] },
+    ],
+    channels: [
+      { name: 'Organic Search', monthly_budget: 5000, expected_cac: 100, primary_kpi: 'Organic traffic', channelType: 'organic', primaryTier: 'SMB' },
+      { name: 'Paid Search', monthly_budget: 10000, expected_cac: 150, primary_kpi: 'Conversions', channelType: 'paid', primaryTier: 'Mid-Market' },
+      { name: 'Social Media', monthly_budget: 3000, expected_cac: 80, primary_kpi: 'Engagement', channelType: 'organic', primaryTier: 'SMB' },
+      { name: 'Content Marketing', monthly_budget: 4000, expected_cac: 90, primary_kpi: 'Leads', channelType: 'owned', primaryTier: 'Enterprise' },
+      { name: 'Email Marketing', monthly_budget: 2000, expected_cac: 50, primary_kpi: 'Open rate', channelType: 'owned', primaryTier: 'Mid-Market' },
+      { name: 'Partnerships', monthly_budget: 0, expected_cac: 120, primary_kpi: 'Referrals', channelType: 'earned', primaryTier: 'Enterprise' },
+      { name: 'Events', monthly_budget: 8000, expected_cac: 200, primary_kpi: 'Attendees', channelType: 'paid', primaryTier: 'Enterprise' },
+      { name: 'Direct Sales', monthly_budget: 12000, expected_cac: 250, primary_kpi: 'Deals closed', channelType: 'paid', primaryTier: 'Enterprise' },
+    ],
+    launch_timeline: [
+      { milestone: 'Soft launch', date: '2026-06-01', owner: 'Founder' },
+      { milestone: 'Public launch', date: '2026-09-01', owner: 'Marketing' },
+      { milestone: 'Growth phase', date: '2027-01-01', owner: 'Growth Team' },
+    ],
+    ...overrides,
+  };
+  return JSON.stringify(base);
+}
+
+function setupMock(responseOverrides = {}) {
+  const mockComplete = vi.fn().mockResolvedValue(createLLMResponse(responseOverrides));
+  getLLMClient.mockReturnValue({ complete: mockComplete });
+  return mockComplete;
+}
+
+const VALID_PARAMS = {
+  stage1Data: { description: 'An AI-powered analytics platform', targetMarket: 'SMBs', problemStatement: 'Data chaos' },
+};
+
+describe('stage-11-gtm.js - Analysis Step v2.0', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Exported constants', () => {
+    it('should export REQUIRED_TIERS = 3', () => {
+      expect(REQUIRED_TIERS).toBe(3);
+    });
+
+    it('should export REQUIRED_CHANNELS = 8', () => {
+      expect(REQUIRED_CHANNELS).toBe(8);
+    });
+
+    it('should export CHANNEL_TYPES with 4 valid values', () => {
+      expect(CHANNEL_TYPES).toEqual(['paid', 'organic', 'earned', 'owned']);
+    });
+  });
+
+  describe('Input validation', () => {
+    it('should throw when stage1Data is missing', async () => {
+      await expect(analyzeStage11({})).rejects.toThrow('Stage 11 GTM requires Stage 1 data with description');
+    });
+
+    it('should throw when stage1Data.description is empty', async () => {
+      await expect(analyzeStage11({ stage1Data: { description: '' } })).rejects.toThrow('Stage 11 GTM requires Stage 1 data with description');
+    });
+  });
+
+  describe('Tier persona/painPoints normalization', () => {
+    it('should include persona in tier output when LLM provides it', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].persona).toBe('CTO at Fortune 500');
+      expect(result.tiers[1].persona).toBe('VP Engineering at Series B+');
+      expect(result.tiers[2].persona).toBe('Technical founder');
+    });
+
+    it('should include painPoints in tier output when LLM provides them', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].painPoints).toEqual(['Complex data pipelines', 'Vendor lock-in']);
+      expect(result.tiers[1].painPoints).toEqual(['Scaling challenges']);
+      expect(result.tiers[2].painPoints).toEqual(['Limited budget', 'No dedicated ops team']);
+    });
+
+    it('should set persona to null when LLM omits it', async () => {
+      setupMock({
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].persona).toBeNull();
+      expect(result.tiers[1].persona).toBeNull();
+      expect(result.tiers[2].persona).toBeNull();
+    });
+
+    it('should set painPoints to empty array when LLM omits them', async () => {
+      setupMock({
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].painPoints).toEqual([]);
+      expect(result.tiers[1].painPoints).toEqual([]);
+      expect(result.tiers[2].painPoints).toEqual([]);
+    });
+
+    it('should truncate persona to 500 characters', async () => {
+      setupMock({
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10, persona: 'P'.repeat(600) },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].persona.length).toBe(500);
+    });
+
+    it('should truncate painPoints items to 300 characters', async () => {
+      setupMock({
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10, painPoints: ['X'.repeat(400)] },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].painPoints[0].length).toBe(300);
+    });
+  });
+
+  describe('channelType enum validation', () => {
+    it('should accept valid channelType values', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      for (const ch of result.channels) {
+        expect(CHANNEL_TYPES).toContain(ch.channelType);
+      }
+    });
+
+    it('should default to "organic" for invalid channelType', async () => {
+      const channels = [];
+      for (let i = 0; i < 8; i++) {
+        channels.push({
+          name: `Ch${i + 1}`,
+          monthly_budget: 1000,
+          expected_cac: 50,
+          primary_kpi: `KPI${i + 1}`,
+          channelType: 'invalid-type',
+          primaryTier: 'T1',
+        });
+      }
+      setupMock({
+        channels,
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      for (const ch of result.channels) {
+        expect(ch.channelType).toBe('organic');
+      }
+    });
+
+    it('should default to "organic" when channelType is missing', async () => {
+      const channels = [];
+      for (let i = 0; i < 8; i++) {
+        channels.push({
+          name: `Ch${i + 1}`,
+          monthly_budget: 1000,
+          expected_cac: 50,
+          primary_kpi: `KPI${i + 1}`,
+        });
+      }
+      setupMock({
+        channels,
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      for (const ch of result.channels) {
+        expect(ch.channelType).toBe('organic');
+      }
+    });
+  });
+
+  describe('primaryTier cross-referencing', () => {
+    it('should keep primaryTier when it matches an existing tier name', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      // First channel has primaryTier: 'SMB' which matches tier name
+      expect(result.channels[0].primaryTier).toBe('SMB');
+    });
+
+    it('should default primaryTier to first tier name when it does not match any tier', async () => {
+      const channels = [];
+      for (let i = 0; i < 8; i++) {
+        channels.push({
+          name: `Ch${i + 1}`,
+          monthly_budget: 1000,
+          expected_cac: 50,
+          primary_kpi: `KPI${i + 1}`,
+          channelType: 'organic',
+          primaryTier: 'NonExistentTier',
+        });
+      }
+      setupMock({
+        channels,
+        tiers: [
+          { name: 'Alpha', description: 'First', tam: 1000, sam: 100, som: 10 },
+          { name: 'Beta', description: 'Second', tam: 500, sam: 50, som: 5 },
+          { name: 'Gamma', description: 'Third', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      for (const ch of result.channels) {
+        expect(ch.primaryTier).toBe('Alpha'); // defaults to first tier
+      }
+    });
+
+    it('should default primaryTier to first tier name when primaryTier is missing', async () => {
+      const channels = [];
+      for (let i = 0; i < 8; i++) {
+        channels.push({
+          name: `Ch${i + 1}`,
+          monthly_budget: 1000,
+          expected_cac: 50,
+          primary_kpi: `KPI${i + 1}`,
+          channelType: 'paid',
+          // no primaryTier
+        });
+      }
+      setupMock({
+        channels,
+        tiers: [
+          { name: 'FirstTier', description: 'First', tam: 1000, sam: 100, som: 10 },
+          { name: 'SecondTier', description: 'Second', tam: 500, sam: 50, som: 5 },
+          { name: 'ThirdTier', description: 'Third', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      for (const ch of result.channels) {
+        expect(ch.primaryTier).toBe('FirstTier');
+      }
+    });
+  });
+
+  describe('BACKLOG/ACTIVE status logic', () => {
+    it('should set status to "BACKLOG" when monthly_budget is 0', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      // Channel index 5 ("Partnerships") has budget 0
+      const backlogChannel = result.channels.find(ch => ch.name === 'Partnerships');
+      expect(backlogChannel.status).toBe('BACKLOG');
+    });
+
+    it('should set status to "ACTIVE" when monthly_budget > 0', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      const activeChannel = result.channels.find(ch => ch.name === 'Paid Search');
+      expect(activeChannel.status).toBe('ACTIVE');
+    });
+
+    it('should compute activeChannelCount and backlogChannelCount correctly', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      // In the mock, 7 channels have budget > 0 and 1 has budget = 0
+      expect(result.activeChannelCount).toBe(7);
+      expect(result.backlogChannelCount).toBe(1);
+    });
+
+    it('should mark all channels as BACKLOG when all budgets are 0', async () => {
+      const channels = [];
+      for (let i = 0; i < 8; i++) {
+        channels.push({
+          name: `Ch${i + 1}`,
+          monthly_budget: 0,
+          expected_cac: 50,
+          primary_kpi: `KPI${i + 1}`,
+          channelType: 'organic',
+          primaryTier: 'T1',
+        });
+      }
+      setupMock({
+        channels,
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      for (const ch of result.channels) {
+        expect(ch.status).toBe('BACKLOG');
+      }
+      expect(result.activeChannelCount).toBe(0);
+      expect(result.backlogChannelCount).toBe(8);
+    });
+  });
+
+  describe('Tier normalization', () => {
+    it('should pad to exactly 3 tiers when LLM provides fewer', async () => {
+      setupMock({ tiers: [{ name: 'Only', description: 'One tier', tam: 1000, sam: 100, som: 10 }] });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers.length).toBe(3);
+      expect(result.tiers[1].name).toBe('Tier 2');
+      expect(result.tiers[2].name).toBe('Tier 3');
+    });
+
+    it('should truncate to exactly 3 tiers when LLM provides more', async () => {
+      setupMock({
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+          { name: 'T4', description: 'D4', tam: 100, sam: 10, som: 1 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers.length).toBe(3);
+    });
+
+    it('should clamp negative TAM/SAM/SOM to 0', async () => {
+      setupMock({
+        tiers: [
+          { name: 'T1', description: 'D1', tam: -5000, sam: -100, som: -10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].tam).toBe(0);
+      expect(result.tiers[0].sam).toBe(0);
+      expect(result.tiers[0].som).toBe(0);
+    });
+
+    it('should truncate tier name to 200 and description to 500 characters', async () => {
+      setupMock({
+        tiers: [
+          { name: 'N'.repeat(300), description: 'D'.repeat(600), tam: 1000, sam: 100, som: 10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].name.length).toBe(200);
+      expect(result.tiers[0].description.length).toBe(500);
+    });
+  });
+
+  describe('Channel normalization', () => {
+    it('should pad to exactly 8 channels when LLM provides fewer', async () => {
+      setupMock({ channels: [{ name: 'Only One', monthly_budget: 1000, expected_cac: 50, primary_kpi: 'Leads' }] });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.channels.length).toBe(8);
+    });
+
+    it('should truncate to exactly 8 channels when LLM provides more', async () => {
+      const channels = [];
+      for (let i = 0; i < 12; i++) {
+        channels.push({ name: `Ch${i}`, monthly_budget: 1000, expected_cac: 50, primary_kpi: `KPI${i}`, channelType: 'paid', primaryTier: 'Enterprise' });
+      }
+      setupMock({ channels });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.channels.length).toBe(8);
+    });
+
+    it('should clamp negative budget and CAC to 0', async () => {
+      const channels = [];
+      channels.push({ name: 'NegBudget', monthly_budget: -5000, expected_cac: -100, primary_kpi: 'Leads', channelType: 'paid', primaryTier: 'Enterprise' });
+      for (let i = 1; i < 8; i++) {
+        channels.push({ name: `Ch${i}`, monthly_budget: 1000, expected_cac: 50, primary_kpi: `KPI${i}`, channelType: 'paid', primaryTier: 'Enterprise' });
+      }
+      setupMock({ channels });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.channels[0].monthly_budget).toBe(0);
+      expect(result.channels[0].expected_cac).toBe(0);
+    });
+  });
+
+  describe('Derived metrics', () => {
+    it('should compute totalMonthlyBudget correctly', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      // 5000 + 10000 + 3000 + 4000 + 2000 + 0 + 8000 + 12000 = 44000
+      expect(result.totalMonthlyBudget).toBe(44000);
+    });
+
+    it('should compute avgCac excluding zero-CAC channels', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      // All 8 channels have non-zero CAC: (100+150+80+90+50+120+200+250)/8 = 1040/8 = 130
+      expect(result.avgCac).toBe(130);
+    });
+
+    it('should return avgCac as 0 when all channels have zero CAC', async () => {
+      const channels = [];
+      for (let i = 0; i < 8; i++) {
+        channels.push({
+          name: `Ch${i + 1}`,
+          monthly_budget: 1000,
+          expected_cac: 0,
+          primary_kpi: `KPI${i + 1}`,
+          channelType: 'organic',
+          primaryTier: 'T1',
+        });
+      }
+      setupMock({
+        channels,
+        tiers: [
+          { name: 'T1', description: 'D1', tam: 1000, sam: 100, som: 10 },
+          { name: 'T2', description: 'D2', tam: 500, sam: 50, som: 5 },
+          { name: 'T3', description: 'D3', tam: 200, sam: 20, som: 2 },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.avgCac).toBe(0);
+    });
+
+    it('should include tierCount and channelCount in output', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tierCount).toBe(3);
+      expect(result.channelCount).toBe(8);
+    });
+  });
+
+  describe('Launch timeline normalization', () => {
+    it('should use LLM-provided timeline when available', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.launch_timeline.length).toBe(3);
+      expect(result.launch_timeline[0].milestone).toBe('Soft launch');
+    });
+
+    it('should provide default timeline when LLM returns empty array', async () => {
+      setupMock({ launch_timeline: [] });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.launch_timeline.length).toBe(3);
+      expect(result.launch_timeline[0].milestone).toBe('Soft launch');
+      expect(result.launch_timeline[1].milestone).toBe('Public launch');
+      expect(result.launch_timeline[2].milestone).toBe('Growth phase');
+    });
+
+    it('should truncate milestone to 200 and owner to 100 characters', async () => {
+      setupMock({
+        launch_timeline: [
+          { milestone: 'M'.repeat(300), date: '2026-06-01', owner: 'O'.repeat(200) },
+        ],
+      });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.launch_timeline[0].milestone.length).toBe(200);
+      expect(result.launch_timeline[0].owner.length).toBe(100);
+    });
+  });
+
+  describe('Optional upstream data integration', () => {
+    it('should include stage10 brand context in prompt when available', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage11({
+        ...VALID_PARAMS,
+        stage10Data: { brandGenome: { archetype: 'Hero', audience: 'Tech professionals' } },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('Hero');
+      expect(userPrompt).toContain('Tech professionals');
+    });
+
+    it('should include stage5 financial context in prompt when available', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage11({
+        ...VALID_PARAMS,
+        stage5Data: { initialInvestment: 75000, year1: { revenue: 300000 } },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('75000');
+      expect(userPrompt).toContain('300000');
+    });
+  });
+
+  describe('Output shape', () => {
+    it('should return all expected top-level fields', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result).toHaveProperty('tiers');
+      expect(result).toHaveProperty('channels');
+      expect(result).toHaveProperty('launch_timeline');
+      expect(result).toHaveProperty('totalMonthlyBudget');
+      expect(result).toHaveProperty('avgCac');
+      expect(result).toHaveProperty('tierCount');
+      expect(result).toHaveProperty('channelCount');
+      expect(result).toHaveProperty('activeChannelCount');
+      expect(result).toHaveProperty('backlogChannelCount');
+    });
+
+    it('should ensure each channel has all v2.0 fields', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      for (const ch of result.channels) {
+        expect(ch).toHaveProperty('name');
+        expect(ch).toHaveProperty('monthly_budget');
+        expect(ch).toHaveProperty('expected_cac');
+        expect(ch).toHaveProperty('primary_kpi');
+        expect(ch).toHaveProperty('channelType');
+        expect(ch).toHaveProperty('primaryTier');
+        expect(ch).toHaveProperty('status');
+      }
+    });
+
+    it('should ensure each tier has all v2.0 fields', async () => {
+      setupMock();
+      const result = await analyzeStage11(VALID_PARAMS);
+      for (const tier of result.tiers) {
+        expect(tier).toHaveProperty('name');
+        expect(tier).toHaveProperty('description');
+        expect(tier).toHaveProperty('tam');
+        expect(tier).toHaveProperty('sam');
+        expect(tier).toHaveProperty('som');
+        expect(tier).toHaveProperty('persona');
+        expect(tier).toHaveProperty('painPoints');
+      }
+    });
+  });
+
+  describe('JSON parsing', () => {
+    it('should handle LLM response wrapped in markdown code block', async () => {
+      const response = createLLMResponse();
+      const mockComplete = vi.fn().mockResolvedValue('```json\n' + response + '\n```');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      const result = await analyzeStage11(VALID_PARAMS);
+      expect(result.tiers[0].name).toBe('Enterprise');
+    });
+
+    it('should throw on unparseable LLM response', async () => {
+      const mockComplete = vi.fn().mockResolvedValue('Not JSON');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      await expect(analyzeStage11(VALID_PARAMS)).rejects.toThrow('Failed to parse GTM response');
+    });
+  });
+});

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-12-sales-logic.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-12-sales-logic.test.js
@@ -1,0 +1,597 @@
+/**
+ * Unit tests for Stage 12 Analysis Step - Sales Logic (v2.0 enhancements)
+ * Part of SD-EVA-FEAT-TEMPLATES-IDENTITY-001
+ *
+ * Tests v2.0 features:
+ * - mappedFunnelStage back-linking validation
+ * - conversionRateEstimate range clamping (0-1)
+ * - economyCheck computation (totalPipelineValue, avgConversionRate, pricingAvailable)
+ * - stage7Data integration (pricing context in prompt)
+ *
+ * @module tests/unit/eva/stage-templates/analysis-steps/stage-12-sales-logic.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the LLM client before importing the module under test
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+import { analyzeStage12, VALID_SALES_MODELS, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS, MIN_DEAL_STAGES } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+/**
+ * Helper: create a well-formed LLM response JSON string.
+ */
+function createLLMResponse(overrides = {}) {
+  const base = {
+    sales_model: 'inside-sales',
+    sales_cycle_days: 45,
+    deal_stages: [
+      { name: 'Qualification', description: 'Initial lead qualification', avg_duration_days: 3, mappedFunnelStage: 'Awareness' },
+      { name: 'Discovery', description: 'Needs assessment and demo', avg_duration_days: 7, mappedFunnelStage: 'Interest' },
+      { name: 'Proposal', description: 'Solution proposal and pricing', avg_duration_days: 5, mappedFunnelStage: 'Consideration' },
+      { name: 'Negotiation', description: 'Terms negotiation and close', avg_duration_days: 7, mappedFunnelStage: 'Purchase' },
+    ],
+    funnel_stages: [
+      { name: 'Awareness', metric: 'Website visitors', target_value: 10000, conversionRateEstimate: 0.10 },
+      { name: 'Interest', metric: 'Signup rate', target_value: 1000, conversionRateEstimate: 0.25 },
+      { name: 'Consideration', metric: 'Trial starts', target_value: 250, conversionRateEstimate: 0.40 },
+      { name: 'Purchase', metric: 'Customers', target_value: 100, conversionRateEstimate: 0.50 },
+    ],
+    customer_journey: [
+      { step: 'Discovers via search', funnel_stage: 'Awareness', touchpoint: 'Website' },
+      { step: 'Reads blog content', funnel_stage: 'Interest', touchpoint: 'Blog' },
+      { step: 'Signs up for trial', funnel_stage: 'Consideration', touchpoint: 'Signup form' },
+      { step: 'Engages with features', funnel_stage: 'Consideration', touchpoint: 'Product' },
+      { step: 'Converts to paid', funnel_stage: 'Purchase', touchpoint: 'Checkout' },
+    ],
+    ...overrides,
+  };
+  return JSON.stringify(base);
+}
+
+function setupMock(responseOverrides = {}) {
+  const mockComplete = vi.fn().mockResolvedValue(createLLMResponse(responseOverrides));
+  getLLMClient.mockReturnValue({ complete: mockComplete });
+  return mockComplete;
+}
+
+const VALID_PARAMS = {
+  stage1Data: { description: 'An AI-powered analytics platform', targetMarket: 'SMBs', problemStatement: 'Data chaos' },
+};
+
+describe('stage-12-sales-logic.js - Analysis Step v2.0', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Exported constants', () => {
+    it('should export VALID_SALES_MODELS with 6 values', () => {
+      expect(VALID_SALES_MODELS).toEqual(['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel']);
+    });
+
+    it('should export MIN_FUNNEL_STAGES = 4', () => {
+      expect(MIN_FUNNEL_STAGES).toBe(4);
+    });
+
+    it('should export MIN_JOURNEY_STEPS = 5', () => {
+      expect(MIN_JOURNEY_STEPS).toBe(5);
+    });
+
+    it('should export MIN_DEAL_STAGES = 3', () => {
+      expect(MIN_DEAL_STAGES).toBe(3);
+    });
+  });
+
+  describe('Input validation', () => {
+    it('should throw when stage1Data is missing', async () => {
+      await expect(analyzeStage12({})).rejects.toThrow('Stage 12 sales logic requires Stage 1 data with description');
+    });
+
+    it('should throw when stage1Data.description is empty', async () => {
+      await expect(analyzeStage12({ stage1Data: { description: '' } })).rejects.toThrow('Stage 12 sales logic requires Stage 1 data with description');
+    });
+  });
+
+  describe('mappedFunnelStage back-linking validation', () => {
+    it('should keep mappedFunnelStage when it matches a funnel stage name', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.deal_stages[0].mappedFunnelStage).toBe('Awareness');
+      expect(result.deal_stages[1].mappedFunnelStage).toBe('Interest');
+      expect(result.deal_stages[2].mappedFunnelStage).toBe('Consideration');
+      expect(result.deal_stages[3].mappedFunnelStage).toBe('Purchase');
+    });
+
+    it('should default mappedFunnelStage to first funnel stage when it does not match', async () => {
+      setupMock({
+        deal_stages: [
+          { name: 'D1', description: 'Desc1', avg_duration_days: 3, mappedFunnelStage: 'NonExistent' },
+          { name: 'D2', description: 'Desc2', avg_duration_days: 5, mappedFunnelStage: 'AlsoNonExistent' },
+          { name: 'D3', description: 'Desc3', avg_duration_days: 7, mappedFunnelStage: 'Nope' },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      for (const ds of result.deal_stages) {
+        expect(ds.mappedFunnelStage).toBe('Awareness'); // first funnel stage name
+      }
+    });
+
+    it('should default mappedFunnelStage to first funnel stage when it is missing', async () => {
+      setupMock({
+        deal_stages: [
+          { name: 'D1', description: 'Desc1', avg_duration_days: 3 },
+          { name: 'D2', description: 'Desc2', avg_duration_days: 5 },
+          { name: 'D3', description: 'Desc3', avg_duration_days: 7 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      for (const ds of result.deal_stages) {
+        expect(ds.mappedFunnelStage).toBe('Awareness');
+      }
+    });
+
+    it('should set mappedFunnelStage to null when empty string and no funnel stages match', async () => {
+      setupMock({
+        deal_stages: [
+          { name: 'D1', description: 'Desc1', avg_duration_days: 3, mappedFunnelStage: '' },
+          { name: 'D2', description: 'Desc2', avg_duration_days: 5, mappedFunnelStage: '' },
+          { name: 'D3', description: 'Desc3', avg_duration_days: 7, mappedFunnelStage: '' },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      // Empty string -> normalized to null via String('').substring(0,200) || null -> null
+      // Then back-link check: null is not in funnelNames -> defaults to funnelNames[0] = 'Awareness'
+      for (const ds of result.deal_stages) {
+        expect(ds.mappedFunnelStage).toBe('Awareness');
+      }
+    });
+
+    it('should truncate mappedFunnelStage to 200 characters', async () => {
+      setupMock({
+        deal_stages: [
+          { name: 'D1', description: 'Desc1', avg_duration_days: 3, mappedFunnelStage: 'M'.repeat(300) },
+          { name: 'D2', description: 'Desc2', avg_duration_days: 5 },
+          { name: 'D3', description: 'Desc3', avg_duration_days: 7 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      // Long string won't match any funnel stage, so it defaults to first
+      expect(result.deal_stages[0].mappedFunnelStage).toBe('Awareness');
+    });
+  });
+
+  describe('conversionRateEstimate range clamping', () => {
+    it('should keep conversionRateEstimate when in 0-1 range', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages[0].conversionRateEstimate).toBe(0.10);
+      expect(result.funnel_stages[1].conversionRateEstimate).toBe(0.25);
+      expect(result.funnel_stages[2].conversionRateEstimate).toBe(0.40);
+      expect(result.funnel_stages[3].conversionRateEstimate).toBe(0.50);
+    });
+
+    it('should set conversionRateEstimate to null when negative', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: 100, conversionRateEstimate: -0.5 },
+          { name: 'F2', metric: 'M2', target_value: 50, conversionRateEstimate: 0.25 },
+          { name: 'F3', metric: 'M3', target_value: 25, conversionRateEstimate: 0.40 },
+          { name: 'F4', metric: 'M4', target_value: 10, conversionRateEstimate: 0.50 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages[0].conversionRateEstimate).toBeNull();
+    });
+
+    it('should set conversionRateEstimate to null when greater than 1', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: 100, conversionRateEstimate: 1.5 },
+          { name: 'F2', metric: 'M2', target_value: 50, conversionRateEstimate: 0.25 },
+          { name: 'F3', metric: 'M3', target_value: 25, conversionRateEstimate: 0.40 },
+          { name: 'F4', metric: 'M4', target_value: 10, conversionRateEstimate: 0.50 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages[0].conversionRateEstimate).toBeNull();
+    });
+
+    it('should set conversionRateEstimate to null when missing', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: 100 },
+          { name: 'F2', metric: 'M2', target_value: 50 },
+          { name: 'F3', metric: 'M3', target_value: 25 },
+          { name: 'F4', metric: 'M4', target_value: 10 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      for (const fs of result.funnel_stages) {
+        expect(fs.conversionRateEstimate).toBeNull();
+      }
+    });
+
+    it('should accept conversionRateEstimate = 0 (boundary)', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: 100, conversionRateEstimate: 0 },
+          { name: 'F2', metric: 'M2', target_value: 50, conversionRateEstimate: 0.25 },
+          { name: 'F3', metric: 'M3', target_value: 25, conversionRateEstimate: 0.40 },
+          { name: 'F4', metric: 'M4', target_value: 10, conversionRateEstimate: 0.50 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages[0].conversionRateEstimate).toBe(0);
+    });
+
+    it('should accept conversionRateEstimate = 1 (boundary)', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: 100, conversionRateEstimate: 1.0 },
+          { name: 'F2', metric: 'M2', target_value: 50, conversionRateEstimate: 0.25 },
+          { name: 'F3', metric: 'M3', target_value: 25, conversionRateEstimate: 0.40 },
+          { name: 'F4', metric: 'M4', target_value: 10, conversionRateEstimate: 0.50 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages[0].conversionRateEstimate).toBe(1.0);
+    });
+
+    it('should round conversionRateEstimate to 4 decimal places', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: 100, conversionRateEstimate: 0.123456789 },
+          { name: 'F2', metric: 'M2', target_value: 50, conversionRateEstimate: 0.25 },
+          { name: 'F3', metric: 'M3', target_value: 25, conversionRateEstimate: 0.40 },
+          { name: 'F4', metric: 'M4', target_value: 10, conversionRateEstimate: 0.50 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages[0].conversionRateEstimate).toBe(0.1235);
+    });
+  });
+
+  describe('economyCheck computation', () => {
+    it('should compute totalPipelineValue as sum of funnel target_values', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      // 10000 + 1000 + 250 + 100 = 11350
+      expect(result.economyCheck.totalPipelineValue).toBe(11350);
+    });
+
+    it('should compute avgConversionRate as average of non-null conversionRateEstimates', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      // (0.10 + 0.25 + 0.40 + 0.50) / 4 = 1.25 / 4 = 0.3125
+      expect(result.economyCheck.avgConversionRate).toBe(0.3125);
+    });
+
+    it('should return avgConversionRate as null when all estimates are null', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: 100 },
+          { name: 'F2', metric: 'M2', target_value: 50 },
+          { name: 'F3', metric: 'M3', target_value: 25 },
+          { name: 'F4', metric: 'M4', target_value: 10 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.economyCheck.avgConversionRate).toBeNull();
+    });
+
+    it('should set pricingAvailable to true when stage7Data is provided', async () => {
+      setupMock();
+      const result = await analyzeStage12({
+        ...VALID_PARAMS,
+        stage7Data: { pricingModel: 'subscription', unitEconomics: { arpa: 99 } },
+      });
+      expect(result.economyCheck.pricingAvailable).toBe(true);
+    });
+
+    it('should set pricingAvailable to false when stage7Data is not provided', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.economyCheck.pricingAvailable).toBe(false);
+    });
+
+    it('should round avgConversionRate to 4 decimal places', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: 100, conversionRateEstimate: 0.333 },
+          { name: 'F2', metric: 'M2', target_value: 50, conversionRateEstimate: 0.333 },
+          { name: 'F3', metric: 'M3', target_value: 25, conversionRateEstimate: 0.333 },
+          { name: 'F4', metric: 'M4', target_value: 10, conversionRateEstimate: 0.001 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      // (0.333 + 0.333 + 0.333 + 0.001) / 4 = 1.0 / 4 = 0.25
+      expect(result.economyCheck.avgConversionRate).toBe(0.25);
+    });
+  });
+
+  describe('stage7Data integration', () => {
+    it('should include pricing context in prompt when stage7Data is provided', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage12({
+        ...VALID_PARAMS,
+        stage7Data: { pricingModel: 'subscription', unitEconomics: { arpa: 99 } },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('subscription');
+      expect(userPrompt).toContain('99');
+    });
+
+    it('should not include pricing context when stage7Data is absent', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage12(VALID_PARAMS);
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).not.toContain('Pricing:');
+    });
+  });
+
+  describe('Sales model normalization', () => {
+    it('should accept all valid sales models', async () => {
+      for (const model of VALID_SALES_MODELS) {
+        setupMock({ sales_model: model });
+        const result = await analyzeStage12(VALID_PARAMS);
+        expect(result.sales_model).toBe(model);
+      }
+    });
+
+    it('should default to "hybrid" for invalid sales model', async () => {
+      setupMock({ sales_model: 'invalid-model' });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.sales_model).toBe('hybrid');
+    });
+
+    it('should default to "hybrid" when sales model is missing', async () => {
+      setupMock({ sales_model: undefined });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.sales_model).toBe('hybrid');
+    });
+  });
+
+  describe('Sales cycle days normalization', () => {
+    it('should use LLM-provided value when valid', async () => {
+      setupMock({ sales_cycle_days: 90 });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.sales_cycle_days).toBe(90);
+    });
+
+    it('should default to 30 when sales_cycle_days < 1', async () => {
+      setupMock({ sales_cycle_days: 0 });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.sales_cycle_days).toBe(30);
+    });
+
+    it('should default to 30 when sales_cycle_days is not a number', async () => {
+      setupMock({ sales_cycle_days: 'not a number' });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.sales_cycle_days).toBe(30);
+    });
+
+    it('should round non-integer sales_cycle_days', async () => {
+      setupMock({ sales_cycle_days: 45.7 });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.sales_cycle_days).toBe(46);
+    });
+  });
+
+  describe('Deal stages normalization', () => {
+    it('should pad deal stages to MIN_DEAL_STAGES when LLM provides fewer', async () => {
+      setupMock({
+        deal_stages: [
+          { name: 'Only', description: 'One stage', avg_duration_days: 5 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.deal_stages.length).toBeGreaterThanOrEqual(MIN_DEAL_STAGES);
+    });
+
+    it('should truncate deal stage name to 200 and description to 500 characters', async () => {
+      setupMock({
+        deal_stages: [
+          { name: 'N'.repeat(300), description: 'D'.repeat(600), avg_duration_days: 5 },
+          { name: 'D2', description: 'Desc2', avg_duration_days: 5 },
+          { name: 'D3', description: 'Desc3', avg_duration_days: 5 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.deal_stages[0].name.length).toBe(200);
+      expect(result.deal_stages[0].description.length).toBe(500);
+    });
+
+    it('should clamp negative avg_duration_days to 0', async () => {
+      setupMock({
+        deal_stages: [
+          { name: 'D1', description: 'Desc1', avg_duration_days: -10 },
+          { name: 'D2', description: 'Desc2', avg_duration_days: 5 },
+          { name: 'D3', description: 'Desc3', avg_duration_days: 7 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      // Non-negative check: -10 fails, defaults to 5
+      expect(result.deal_stages[0].avg_duration_days).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('Funnel stages normalization', () => {
+    it('should pad funnel stages to MIN_FUNNEL_STAGES when LLM provides fewer', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'Only', metric: 'M', target_value: 100, conversionRateEstimate: 0.5 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages.length).toBeGreaterThanOrEqual(MIN_FUNNEL_STAGES);
+    });
+
+    it('should clamp negative target_value to 0', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'F1', metric: 'M1', target_value: -500, conversionRateEstimate: 0.10 },
+          { name: 'F2', metric: 'M2', target_value: 50, conversionRateEstimate: 0.25 },
+          { name: 'F3', metric: 'M3', target_value: 25, conversionRateEstimate: 0.40 },
+          { name: 'F4', metric: 'M4', target_value: 10, conversionRateEstimate: 0.50 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages[0].target_value).toBe(0);
+    });
+
+    it('should truncate funnel stage name to 200 and metric to 200 characters', async () => {
+      setupMock({
+        funnel_stages: [
+          { name: 'N'.repeat(300), metric: 'M'.repeat(300), target_value: 100, conversionRateEstimate: 0.10 },
+          { name: 'F2', metric: 'M2', target_value: 50, conversionRateEstimate: 0.25 },
+          { name: 'F3', metric: 'M3', target_value: 25, conversionRateEstimate: 0.40 },
+          { name: 'F4', metric: 'M4', target_value: 10, conversionRateEstimate: 0.50 },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.funnel_stages[0].name.length).toBe(200);
+      expect(result.funnel_stages[0].metric.length).toBe(200);
+    });
+  });
+
+  describe('Customer journey normalization', () => {
+    it('should pad customer journey to MIN_JOURNEY_STEPS when LLM provides fewer', async () => {
+      setupMock({
+        customer_journey: [
+          { step: 'Only one step', funnel_stage: 'Awareness', touchpoint: 'Website' },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.customer_journey.length).toBeGreaterThanOrEqual(MIN_JOURNEY_STEPS);
+    });
+
+    it('should truncate step to 300, funnel_stage to 200, touchpoint to 200 characters', async () => {
+      setupMock({
+        customer_journey: [
+          { step: 'S'.repeat(400), funnel_stage: 'F'.repeat(300), touchpoint: 'T'.repeat(300) },
+          { step: 'S2', funnel_stage: 'Awareness', touchpoint: 'Web' },
+          { step: 'S3', funnel_stage: 'Interest', touchpoint: 'Email' },
+          { step: 'S4', funnel_stage: 'Decision', touchpoint: 'Demo' },
+          { step: 'S5', funnel_stage: 'Purchase', touchpoint: 'Checkout' },
+        ],
+      });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.customer_journey[0].step.length).toBe(300);
+      expect(result.customer_journey[0].funnel_stage.length).toBe(200);
+      expect(result.customer_journey[0].touchpoint.length).toBe(200);
+    });
+  });
+
+  describe('Optional upstream data integration', () => {
+    it('should include stage10 brand context in prompt when available', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage12({
+        ...VALID_PARAMS,
+        stage10Data: { brandGenome: { archetype: 'Explorer', audience: 'Digital nomads' } },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('Explorer');
+      expect(userPrompt).toContain('Digital nomads');
+    });
+
+    it('should include stage11 GTM context in prompt when available', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage12({
+        ...VALID_PARAMS,
+        stage11Data: { tierCount: 3, channelCount: 8, avgCac: 150 },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('3 tiers');
+      expect(userPrompt).toContain('8 channels');
+      expect(userPrompt).toContain('150');
+    });
+
+    it('should include stage5 financial context in prompt when available', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage12({
+        ...VALID_PARAMS,
+        stage5Data: { year1: { revenue: 500000 } },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('500000');
+    });
+
+    it('should include ventureName in prompt when provided', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage12({ ...VALID_PARAMS, ventureName: 'TestCorp' });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('TestCorp');
+    });
+  });
+
+  describe('Output shape', () => {
+    it('should return all expected top-level fields', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result).toHaveProperty('sales_model');
+      expect(result).toHaveProperty('sales_cycle_days');
+      expect(result).toHaveProperty('deal_stages');
+      expect(result).toHaveProperty('funnel_stages');
+      expect(result).toHaveProperty('customer_journey');
+      expect(result).toHaveProperty('totalDealStages');
+      expect(result).toHaveProperty('totalFunnelStages');
+      expect(result).toHaveProperty('totalJourneySteps');
+      expect(result).toHaveProperty('economyCheck');
+    });
+
+    it('should set count fields to match array lengths', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.totalDealStages).toBe(result.deal_stages.length);
+      expect(result.totalFunnelStages).toBe(result.funnel_stages.length);
+      expect(result.totalJourneySteps).toBe(result.customer_journey.length);
+    });
+
+    it('should have economyCheck with correct structure', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.economyCheck).toHaveProperty('totalPipelineValue');
+      expect(result.economyCheck).toHaveProperty('avgConversionRate');
+      expect(result.economyCheck).toHaveProperty('pricingAvailable');
+      expect(typeof result.economyCheck.totalPipelineValue).toBe('number');
+      expect(typeof result.economyCheck.pricingAvailable).toBe('boolean');
+    });
+
+    it('should ensure each deal stage has mappedFunnelStage field', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      for (const ds of result.deal_stages) {
+        expect(ds).toHaveProperty('mappedFunnelStage');
+      }
+    });
+
+    it('should ensure each funnel stage has conversionRateEstimate field', async () => {
+      setupMock();
+      const result = await analyzeStage12(VALID_PARAMS);
+      for (const fs of result.funnel_stages) {
+        expect(fs).toHaveProperty('conversionRateEstimate');
+      }
+    });
+  });
+
+  describe('JSON parsing', () => {
+    it('should handle LLM response wrapped in markdown code block', async () => {
+      const response = createLLMResponse();
+      const mockComplete = vi.fn().mockResolvedValue('```json\n' + response + '\n```');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      const result = await analyzeStage12(VALID_PARAMS);
+      expect(result.sales_model).toBe('inside-sales');
+    });
+
+    it('should throw on unparseable LLM response', async () => {
+      const mockComplete = vi.fn().mockResolvedValue('This is garbage');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      await expect(analyzeStage12(VALID_PARAMS)).rejects.toThrow('Failed to parse sales logic response');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Stage 10 (Naming/Brand)**: Added `narrativeExtension` (vision/mission/brandVoice), `namingStrategy` enum validation, `decision` object with auto-selection of top-scoring candidate and availability checks
- **Stage 11 (GTM)**: Added `persona`/`painPoints` per tier, `channelType` enum (paid/organic/earned/owned), `primaryTier` cross-referencing against tier names, BACKLOG/ACTIVE status flagging for zero-budget channels
- **Stage 12 (Sales Logic)**: Added `mappedFunnelStage` with back-linking validation against funnel stage names, `conversionRateEstimate` per funnel stage (0-1 range clamping), `economyCheck` computation, `stage7Data` (pricing) integration
- 142 new tests covering all v2.0 enhancements across 3 test files

Part of SD-EVA-FEAT-TEMPLATES-IDENTITY-001 (child of SD-EVA-ORCH-TEMPLATE-GAPFILL-001)

## Test plan
- [x] All 148 existing stage-10/11/12 tests pass (no regressions)
- [x] 142 new v2.0 enhancement tests pass
- [x] 15 smoke tests pass
- [x] TESTING sub-agent verdict: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)