### PR TITLE
feat(eva): add v2.0 analysis steps for Build Loop stages 17-22

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/index.js
+++ b/lib/eva/stage-templates/analysis-steps/index.js
@@ -1,6 +1,6 @@
 /**
- * Analysis Steps Registry - Stages 1-16
- * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (1-5), ENGINE-001 (6-9), IDENTITY-001 (10-12), BLUEPRINT-001 (13-16)
+ * Analysis Steps Registry - Stages 1-22
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (1-5), ENGINE-001 (6-9), IDENTITY-001 (10-12), BLUEPRINT-001 (13-16), BUILDLOOP-001 (17-22)
  *
  * Provides the active analysis layer for stage templates.
  * Each analysisStep consumes upstream artifacts and generates
@@ -33,8 +33,16 @@ export { analyzeStage14 } from './stage-14-technical-architecture.js';
 export { analyzeStage15 } from './stage-15-resource-planning.js';
 export { analyzeStage16 } from './stage-16-financial-projections.js';
 
+// THE BUILD LOOP (Stages 17-22)
+export { analyzeStage17 } from './stage-17-build-readiness.js';
+export { analyzeStage18 } from './stage-18-sprint-planning.js';
+export { analyzeStage19 } from './stage-19-build-execution.js';
+export { analyzeStage20 } from './stage-20-quality-assurance.js';
+export { analyzeStage21 } from './stage-21-build-review.js';
+export { analyzeStage22 } from './stage-22-release-readiness.js';
+
 /**
- * Get the analysis step function for a given stage number (1-16).
+ * Get the analysis step function for a given stage number (1-22).
  * @param {number} stageNumber
  * @returns {Promise<Function|null>}
  */
@@ -56,6 +64,12 @@ export async function getAnalysisStep(stageNumber) {
     14: () => import('./stage-14-technical-architecture.js').then(m => m.analyzeStage14),
     15: () => import('./stage-15-resource-planning.js').then(m => m.analyzeStage15),
     16: () => import('./stage-16-financial-projections.js').then(m => m.analyzeStage16),
+    17: () => import('./stage-17-build-readiness.js').then(m => m.analyzeStage17),
+    18: () => import('./stage-18-sprint-planning.js').then(m => m.analyzeStage18),
+    19: () => import('./stage-19-build-execution.js').then(m => m.analyzeStage19),
+    20: () => import('./stage-20-quality-assurance.js').then(m => m.analyzeStage20),
+    21: () => import('./stage-21-build-review.js').then(m => m.analyzeStage21),
+    22: () => import('./stage-22-release-readiness.js').then(m => m.analyzeStage22),
   };
   const loader = loaders[stageNumber];
   return loader ? loader() : null;

--- a/lib/eva/stage-templates/analysis-steps/stage-17-build-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-build-readiness.js
@@ -1,0 +1,165 @@
+/**
+ * Stage 17 Analysis Step - Build Readiness Assessment
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ * Part of SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001
+ *
+ * Consumes Stages 13-16 (blueprint) data and generates a build readiness
+ * assessment with checklist synthesis, blocker analysis, and go/no-go decision.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-17-build-readiness
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const READINESS_DECISIONS = ['go', 'conditional_go', 'no_go'];
+const PRIORITY_LEVELS = ['critical', 'high', 'medium', 'low'];
+const SEVERITY_LEVELS = ['critical', 'high', 'medium', 'low'];
+const MIN_READINESS_ITEMS = 3;
+const MIN_CATEGORIES = 3;
+
+const SYSTEM_PROMPT = `You are EVA's Build Readiness Analyst. Assess whether a venture is ready to begin its build sprint based on blueprint-phase outputs.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "readinessItems": [
+    {
+      "name": "Item name (e.g., Architecture Design Complete)",
+      "description": "What this item covers",
+      "status": "complete|in_progress|not_started|blocked",
+      "priority": "critical|high|medium|low",
+      "category": "architecture|team_readiness|tooling|environment|dependencies"
+    }
+  ],
+  "blockers": [
+    {
+      "description": "What is blocking progress",
+      "owner": "Who must resolve this",
+      "severity": "critical|high|medium|low"
+    }
+  ],
+  "buildReadiness": {
+    "decision": "go|conditional_go|no_go",
+    "rationale": "2-3 sentence explanation of the decision",
+    "conditions": ["Condition that must be met (only if conditional_go)"]
+  }
+}
+
+Rules:
+- Generate at least ${MIN_READINESS_ITEMS} readiness items across at least ${MIN_CATEGORIES} categories
+- Each item must have a clear status and priority
+- Blockers should only include items with status "blocked"
+- buildReadiness.decision: "go" if all critical/high items complete, "conditional_go" if non-critical items pending, "no_go" if critical blockers exist
+- conditions array is required if decision is "conditional_go", empty otherwise
+- Assess architecture, team readiness, tooling, environment, and dependencies
+- Base assessment on the venture's roadmap, technical architecture, and resource plan`;
+
+/**
+ * Generate build readiness assessment from blueprint-phase data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage13Data - Product roadmap
+ * @param {Object} [params.stage14Data] - Technical architecture
+ * @param {Object} [params.stage15Data] - Resource planning
+ * @param {Object} [params.stage16Data] - Financial projections
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Build readiness assessment
+ */
+export async function analyzeStage17({ stage13Data, stage14Data, stage15Data, stage16Data, ventureName }) {
+  if (!stage13Data) {
+    throw new Error('Stage 17 build readiness requires Stage 13 (product roadmap) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const roadmapContext = stage13Data.milestones
+    ? `Milestones: ${JSON.stringify(stage13Data.milestones.slice(0, 5))}`
+    : `Roadmap: ${JSON.stringify(stage13Data).substring(0, 500)}`;
+
+  const archContext = stage14Data
+    ? `Architecture: ${stage14Data.systemType || 'N/A'}, Components: ${stage14Data.components?.length || 0}`
+    : '';
+
+  const resourceContext = stage15Data
+    ? `Team: ${stage15Data.teamSize || 'N/A'} members, Budget: $${stage15Data.totalBudget || 'N/A'}`
+    : '';
+
+  const financialContext = stage16Data
+    ? `Runway: ${stage16Data.runwayMonths || 'N/A'} months`
+    : '';
+
+  const userPrompt = `Assess build readiness for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+${roadmapContext}
+${archContext}
+${resourceContext}
+${financialContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize readiness items
+  let readinessItems = Array.isArray(parsed.readinessItems)
+    ? parsed.readinessItems.filter(item => item?.name)
+    : [];
+
+  if (readinessItems.length < MIN_READINESS_ITEMS) {
+    readinessItems = [
+      { name: 'Architecture Design', description: 'System architecture defined', status: 'complete', priority: 'critical', category: 'architecture' },
+      { name: 'Development Environment', description: 'Dev environment configured', status: 'complete', priority: 'high', category: 'environment' },
+      { name: 'Dependency Audit', description: 'Dependencies identified and vetted', status: 'in_progress', priority: 'medium', category: 'dependencies' },
+    ];
+  } else {
+    readinessItems = readinessItems.map(item => ({
+      name: String(item.name).substring(0, 200),
+      description: String(item.description || '').substring(0, 500),
+      status: ['complete', 'in_progress', 'not_started', 'blocked'].includes(item.status) ? item.status : 'not_started',
+      priority: PRIORITY_LEVELS.includes(item.priority) ? item.priority : 'medium',
+      category: ['architecture', 'team_readiness', 'tooling', 'environment', 'dependencies'].includes(item.category) ? item.category : 'architecture',
+    }));
+  }
+
+  // Normalize blockers
+  const blockers = Array.isArray(parsed.blockers)
+    ? parsed.blockers.filter(b => b?.description).map(b => ({
+        description: String(b.description).substring(0, 500),
+        owner: String(b.owner || 'Unassigned').substring(0, 200),
+        severity: SEVERITY_LEVELS.includes(b.severity) ? b.severity : 'medium',
+      }))
+    : [];
+
+  // Normalize buildReadiness decision
+  const br = parsed.buildReadiness || {};
+  const decision = READINESS_DECISIONS.includes(br.decision) ? br.decision : (blockers.length > 0 ? 'no_go' : 'go');
+  const conditions = decision === 'conditional_go' && Array.isArray(br.conditions)
+    ? br.conditions.map(c => String(c).substring(0, 300))
+    : [];
+
+  const buildReadiness = {
+    decision,
+    rationale: String(br.rationale || `Build readiness: ${decision}`).substring(0, 500),
+    conditions,
+  };
+
+  return {
+    readinessItems,
+    blockers,
+    buildReadiness,
+    totalItems: readinessItems.length,
+    completedItems: readinessItems.filter(i => i.status === 'complete').length,
+    blockerCount: blockers.length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse build readiness response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { READINESS_DECISIONS, PRIORITY_LEVELS, SEVERITY_LEVELS, MIN_READINESS_ITEMS };

--- a/lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js
@@ -1,0 +1,142 @@
+/**
+ * Stage 18 Analysis Step - Sprint Planning
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ * Part of SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001
+ *
+ * Consumes Stage 17 readiness + Stages 13-14 roadmap/architecture to generate
+ * sprint items with SD bridge payloads, architecture layer mapping, and milestone refs.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
+const SD_TYPES = ['feature', 'infrastructure', 'fix', 'documentation', 'refactor'];
+const ARCHITECTURE_LAYERS = ['frontend', 'backend', 'database', 'infrastructure', 'integration', 'security'];
+const MIN_SPRINT_ITEMS = 1;
+
+const SYSTEM_PROMPT = `You are EVA's Sprint Planning Engine. Generate a sprint plan with actionable items that bridge to the LEO Protocol SD system.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "sprintGoal": "One-sentence goal for this sprint",
+  "sprintItems": [
+    {
+      "title": "Sprint item title",
+      "description": "What needs to be built (2-3 sentences)",
+      "type": "feature|infrastructure|fix|documentation|refactor",
+      "priority": "critical|high|medium|low",
+      "estimatedLoc": 150,
+      "acceptanceCriteria": "How to verify this item is done",
+      "architectureLayer": "frontend|backend|database|infrastructure|integration|security",
+      "milestoneRef": "Which roadmap milestone this supports"
+    }
+  ]
+}
+
+Rules:
+- Generate at least ${MIN_SPRINT_ITEMS} sprint item(s)
+- Each item must have all required fields
+- estimatedLoc should be realistic (50-500 for typical items)
+- architectureLayer must reference the technical architecture from Stage 14
+- milestoneRef should reference a Stage 13 roadmap milestone (use "now" tier milestone if available)
+- Sprint goal should be specific and measurable
+- Items should be ordered by priority (critical first)
+- Each item should be independently deliverable`;
+
+/**
+ * Generate sprint plan from readiness + blueprint data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage17Data - Build readiness assessment
+ * @param {Object} [params.stage13Data] - Product roadmap
+ * @param {Object} [params.stage14Data] - Technical architecture
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Sprint plan with SD bridge items
+ */
+export async function analyzeStage18({ stage17Data, stage13Data, stage14Data, ventureName }) {
+  if (!stage17Data) {
+    throw new Error('Stage 18 sprint planning requires Stage 17 (build readiness) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const readinessContext = stage17Data.buildReadiness
+    ? `Readiness: ${stage17Data.buildReadiness.decision} — ${stage17Data.buildReadiness.rationale || ''}`
+    : '';
+
+  const roadmapContext = stage13Data?.milestones
+    ? `Roadmap milestones: ${JSON.stringify(stage13Data.milestones.slice(0, 3).map(m => m.name || m.title || m))}`
+    : '';
+
+  const archContext = stage14Data
+    ? `Architecture layers: ${stage14Data.components?.map(c => c.name || c).join(', ') || 'N/A'}`
+    : '';
+
+  const userPrompt = `Generate a sprint plan for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+${readinessContext}
+${roadmapContext}
+${archContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize sprint goal
+  const sprintGoal = String(parsed.sprintGoal || 'Complete initial build sprint').substring(0, 300);
+
+  // Normalize sprint items
+  let sprintItems = Array.isArray(parsed.sprintItems)
+    ? parsed.sprintItems.filter(item => item?.title)
+    : [];
+
+  if (sprintItems.length < MIN_SPRINT_ITEMS) {
+    sprintItems = [{
+      title: 'Initial Build Task',
+      description: 'First implementation task from roadmap',
+      type: 'feature',
+      priority: 'high',
+      estimatedLoc: 200,
+      acceptanceCriteria: 'Feature implemented and tested',
+      architectureLayer: 'backend',
+      milestoneRef: 'MVP',
+    }];
+  } else {
+    sprintItems = sprintItems.map(item => ({
+      title: String(item.title).substring(0, 200),
+      description: String(item.description || '').substring(0, 500),
+      type: SD_TYPES.includes(item.type) ? item.type : 'feature',
+      priority: PRIORITY_VALUES.includes(item.priority) ? item.priority : 'medium',
+      estimatedLoc: typeof item.estimatedLoc === 'number' && item.estimatedLoc > 0
+        ? Math.min(2000, Math.round(item.estimatedLoc))
+        : 200,
+      acceptanceCriteria: String(item.acceptanceCriteria || 'Item completed').substring(0, 500),
+      architectureLayer: ARCHITECTURE_LAYERS.includes(item.architectureLayer)
+        ? item.architectureLayer
+        : 'backend',
+      milestoneRef: String(item.milestoneRef || 'MVP').substring(0, 200),
+    }));
+  }
+
+  return {
+    sprintGoal,
+    sprintItems,
+    totalItems: sprintItems.length,
+    totalEstimatedLoc: sprintItems.reduce((sum, i) => sum + i.estimatedLoc, 0),
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse sprint planning response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { PRIORITY_VALUES, SD_TYPES, ARCHITECTURE_LAYERS, MIN_SPRINT_ITEMS };

--- a/lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js
@@ -1,0 +1,162 @@
+/**
+ * Stage 19 Analysis Step - Build Execution Progress
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ * Part of SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001
+ *
+ * Consumes Stage 18 sprint items and synthesizes build progress,
+ * issue tracking, and sprint completion decision.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-19-build-execution
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
+const ISSUE_SEVERITIES = ['critical', 'high', 'medium', 'low'];
+const ISSUE_STATUSES = ['open', 'in_progress', 'resolved', 'wontfix'];
+const COMPLETION_DECISIONS = ['complete', 'continue', 'blocked'];
+
+const SYSTEM_PROMPT = `You are EVA's Build Execution Analyst. Synthesize build progress from sprint items and generate a sprint completion assessment.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "tasks": [
+    {
+      "name": "Task name (maps to sprint item title)",
+      "description": "Current status details",
+      "assignee": "Team member or role",
+      "status": "pending|in_progress|done|blocked"
+    }
+  ],
+  "issues": [
+    {
+      "description": "Issue description",
+      "severity": "critical|high|medium|low",
+      "status": "open|in_progress|resolved|wontfix"
+    }
+  ],
+  "sprintCompletion": {
+    "decision": "complete|continue|blocked",
+    "readyForQa": true,
+    "rationale": "2-3 sentence assessment of sprint status"
+  }
+}
+
+Rules:
+- Map each sprint item to a task with realistic progress status
+- Issues should flag risks, blockers, or concerns discovered during build
+- sprintCompletion.decision: "complete" if all tasks done, "continue" if in-progress work remains, "blocked" if critical blockers exist
+- readyForQa: true only if core functionality is testable (even if not all tasks complete)
+- Be realistic about progress — early-stage ventures likely have tasks still in progress`;
+
+/**
+ * Synthesize build execution progress from sprint data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage18Data - Sprint plan
+ * @param {Object} [params.stage17Data] - Build readiness
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Build execution progress
+ */
+export async function analyzeStage19({ stage18Data, stage17Data, ventureName }) {
+  if (!stage18Data) {
+    throw new Error('Stage 19 build execution requires Stage 18 (sprint planning) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const sprintContext = stage18Data.sprintGoal
+    ? `Sprint Goal: ${stage18Data.sprintGoal}`
+    : '';
+
+  const itemsContext = stage18Data.sprintItems
+    ? `Sprint Items (${stage18Data.sprintItems.length}): ${JSON.stringify(stage18Data.sprintItems.map(i => ({ title: i.title, type: i.type, loc: i.estimatedLoc })))}`
+    : '';
+
+  const readinessContext = stage17Data?.buildReadiness
+    ? `Build Readiness: ${stage17Data.buildReadiness.decision}`
+    : '';
+
+  const userPrompt = `Synthesize build execution progress for this venture's sprint.
+
+Venture: ${ventureName || 'Unnamed'}
+${sprintContext}
+${itemsContext}
+${readinessContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize tasks
+  let tasks = Array.isArray(parsed.tasks)
+    ? parsed.tasks.filter(t => t?.name)
+    : [];
+
+  if (tasks.length === 0 && stage18Data.sprintItems?.length > 0) {
+    tasks = stage18Data.sprintItems.map(item => ({
+      name: item.title,
+      description: item.description || '',
+      assignee: 'Unassigned',
+      status: 'pending',
+    }));
+  } else {
+    tasks = tasks.map(t => ({
+      name: String(t.name).substring(0, 200),
+      description: String(t.description || '').substring(0, 500),
+      assignee: String(t.assignee || 'Unassigned').substring(0, 200),
+      status: TASK_STATUSES.includes(t.status) ? t.status : 'pending',
+    }));
+  }
+
+  // Normalize issues
+  const issues = Array.isArray(parsed.issues)
+    ? parsed.issues.filter(i => i?.description).map(i => ({
+        description: String(i.description).substring(0, 500),
+        severity: ISSUE_SEVERITIES.includes(i.severity) ? i.severity : 'medium',
+        status: ISSUE_STATUSES.includes(i.status) ? i.status : 'open',
+      }))
+    : [];
+
+  // Normalize sprintCompletion decision
+  const sc = parsed.sprintCompletion || {};
+  const doneTasks = tasks.filter(t => t.status === 'done').length;
+  const blockedTasks = tasks.filter(t => t.status === 'blocked').length;
+  const hasBlockers = blockedTasks > 0 || issues.some(i => i.severity === 'critical' && i.status === 'open');
+
+  const decision = COMPLETION_DECISIONS.includes(sc.decision)
+    ? sc.decision
+    : hasBlockers ? 'blocked' : doneTasks === tasks.length ? 'complete' : 'continue';
+
+  const readyForQa = typeof sc.readyForQa === 'boolean'
+    ? sc.readyForQa
+    : doneTasks > 0 && !hasBlockers;
+
+  const sprintCompletion = {
+    decision,
+    readyForQa,
+    rationale: String(sc.rationale || `Sprint ${decision}: ${doneTasks}/${tasks.length} tasks done`).substring(0, 500),
+  };
+
+  return {
+    tasks,
+    issues,
+    sprintCompletion,
+    totalTasks: tasks.length,
+    completedTasks: doneTasks,
+    blockedTasks,
+    openIssues: issues.filter(i => i.status === 'open').length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse build execution response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { TASK_STATUSES, ISSUE_SEVERITIES, ISSUE_STATUSES, COMPLETION_DECISIONS };

--- a/lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js
@@ -1,0 +1,192 @@
+/**
+ * Stage 20 Analysis Step - Quality Assurance
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ * Part of SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001
+ *
+ * Consumes Stage 19 build execution data and generates QA plan
+ * with test suite analysis, defect tracking, and quality decision.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const QUALITY_DECISIONS = ['pass', 'conditional_pass', 'fail'];
+const TEST_SUITE_TYPES = ['unit', 'integration', 'e2e'];
+const DEFECT_SEVERITIES = ['critical', 'high', 'medium', 'low'];
+const DEFECT_STATUSES = ['open', 'in_progress', 'resolved', 'wontfix'];
+const MIN_PASS_RATE = 95;
+const MIN_COVERAGE_PCT = 60;
+
+const SYSTEM_PROMPT = `You are EVA's Quality Assurance Analyst. Generate a QA assessment based on build execution results, including test suite analysis and a quality gate decision.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "testSuites": [
+    {
+      "name": "Test suite name",
+      "type": "unit|integration|e2e",
+      "totalTests": 50,
+      "passingTests": 48,
+      "coveragePct": 85,
+      "taskRefs": ["Task name this suite covers"]
+    }
+  ],
+  "knownDefects": [
+    {
+      "description": "Defect description",
+      "severity": "critical|high|medium|low",
+      "status": "open|in_progress|resolved|wontfix",
+      "testSuiteRef": "Which test suite found this"
+    }
+  ],
+  "qualityDecision": {
+    "decision": "pass|conditional_pass|fail",
+    "rationale": "2-3 sentence quality assessment"
+  }
+}
+
+Rules:
+- Generate at least 1 test suite
+- Test suite type must be one of: unit, integration, e2e
+- passingTests <= totalTests, coveragePct 0-100
+- qualityDecision.decision: "pass" if pass rate >= ${MIN_PASS_RATE}% AND coverage >= ${MIN_COVERAGE_PCT}%, "conditional_pass" if close to thresholds, "fail" if well below
+- taskRefs should reference tasks from Stage 19 build execution
+- Defects should be actionable with clear severity
+- testSuiteRef links defects to the discovering test suite`;
+
+/**
+ * Generate QA assessment from build execution data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage19Data - Build execution progress
+ * @param {Object} [params.stage18Data] - Sprint plan (for item context)
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} QA assessment with quality decision
+ */
+export async function analyzeStage20({ stage19Data, stage18Data, ventureName }) {
+  if (!stage19Data) {
+    throw new Error('Stage 20 QA requires Stage 19 (build execution) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const tasksContext = stage19Data.tasks
+    ? `Tasks (${stage19Data.totalTasks}): ${stage19Data.completedTasks} done, ${stage19Data.blockedTasks} blocked`
+    : '';
+
+  const issuesContext = stage19Data.issues?.length > 0
+    ? `Known issues: ${stage19Data.issues.map(i => `${i.severity}: ${i.description}`).join('; ')}`
+    : '';
+
+  const sprintContext = stage18Data?.sprintGoal
+    ? `Sprint goal: ${stage18Data.sprintGoal}`
+    : '';
+
+  const userPrompt = `Generate a QA assessment for this venture's build sprint.
+
+Venture: ${ventureName || 'Unnamed'}
+${tasksContext}
+${issuesContext}
+${sprintContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize test suites
+  let testSuites = Array.isArray(parsed.testSuites)
+    ? parsed.testSuites.filter(ts => ts?.name)
+    : [];
+
+  if (testSuites.length === 0) {
+    testSuites = [{
+      name: 'Core Test Suite',
+      type: 'unit',
+      totalTests: 0,
+      passingTests: 0,
+      coveragePct: 0,
+      taskRefs: [],
+    }];
+  } else {
+    testSuites = testSuites.map(ts => {
+      const totalTests = typeof ts.totalTests === 'number' && ts.totalTests >= 0 ? Math.round(ts.totalTests) : 0;
+      const passingTests = typeof ts.passingTests === 'number' && ts.passingTests >= 0
+        ? Math.min(Math.round(ts.passingTests), totalTests)
+        : 0;
+      const coveragePct = typeof ts.coveragePct === 'number'
+        ? Math.min(100, Math.max(0, Math.round(ts.coveragePct * 100) / 100))
+        : 0;
+      return {
+        name: String(ts.name).substring(0, 200),
+        type: TEST_SUITE_TYPES.includes(ts.type) ? ts.type : 'unit',
+        totalTests,
+        passingTests,
+        coveragePct,
+        taskRefs: Array.isArray(ts.taskRefs) ? ts.taskRefs.map(r => String(r).substring(0, 200)) : [],
+      };
+    });
+  }
+
+  // Normalize known defects
+  const knownDefects = Array.isArray(parsed.knownDefects)
+    ? parsed.knownDefects.filter(d => d?.description).map(d => ({
+        description: String(d.description).substring(0, 500),
+        severity: DEFECT_SEVERITIES.includes(d.severity) ? d.severity : 'medium',
+        status: DEFECT_STATUSES.includes(d.status) ? d.status : 'open',
+        testSuiteRef: d.testSuiteRef ? String(d.testSuiteRef).substring(0, 200) : null,
+      }))
+    : [];
+
+  // Compute derived metrics
+  const totalTests = testSuites.reduce((sum, ts) => sum + ts.totalTests, 0);
+  const totalPassing = testSuites.reduce((sum, ts) => sum + ts.passingTests, 0);
+  const overallPassRate = totalTests > 0 ? Math.round((totalPassing / totalTests) * 10000) / 100 : 0;
+  const totalFailures = totalTests - totalPassing;
+
+  const weightedCoverage = testSuites.length > 0
+    ? Math.round(testSuites.reduce((sum, ts) => sum + ts.coveragePct, 0) / testSuites.length * 100) / 100
+    : 0;
+
+  // Normalize quality decision
+  const qd = parsed.qualityDecision || {};
+  let decision;
+  if (QUALITY_DECISIONS.includes(qd.decision)) {
+    decision = qd.decision;
+  } else if (overallPassRate >= MIN_PASS_RATE && weightedCoverage >= MIN_COVERAGE_PCT) {
+    decision = 'pass';
+  } else if (overallPassRate >= MIN_PASS_RATE * 0.9 || weightedCoverage >= MIN_COVERAGE_PCT * 0.9) {
+    decision = 'conditional_pass';
+  } else {
+    decision = 'fail';
+  }
+
+  const qualityDecision = {
+    decision,
+    rationale: String(qd.rationale || `Quality: ${overallPassRate}% pass rate, ${weightedCoverage}% coverage`).substring(0, 500),
+  };
+
+  return {
+    testSuites,
+    knownDefects,
+    qualityDecision,
+    overallPassRate,
+    coveragePct: weightedCoverage,
+    totalTests,
+    totalFailures,
+    totalDefects: knownDefects.length,
+    openDefects: knownDefects.filter(d => d.status === 'open').length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse QA assessment response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { QUALITY_DECISIONS, TEST_SUITE_TYPES, DEFECT_SEVERITIES, DEFECT_STATUSES, MIN_PASS_RATE, MIN_COVERAGE_PCT };

--- a/lib/eva/stage-templates/analysis-steps/stage-21-build-review.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-build-review.js
@@ -1,0 +1,175 @@
+/**
+ * Stage 21 Analysis Step - Build Review (Integration Testing)
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ * Part of SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001
+ *
+ * Consumes Stage 20 QA results and generates integration testing
+ * assessment with review decision and environment-specific analysis.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-21-build-review
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const INTEGRATION_STATUSES = ['pass', 'fail', 'skip', 'pending'];
+const SEVERITY_LEVELS = ['critical', 'high', 'medium', 'low'];
+const ENVIRONMENTS = ['development', 'staging', 'production'];
+const REVIEW_DECISIONS = ['approve', 'conditional', 'reject'];
+
+const SYSTEM_PROMPT = `You are EVA's Build Review and Integration Testing Analyst. Assess integration health and provide a technical review decision based on QA results and cross-system integration points.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "integrations": [
+    {
+      "name": "Integration point name",
+      "source": "Source system or component",
+      "target": "Target system or component",
+      "status": "pass|fail|skip|pending",
+      "severity": "critical|high|medium|low",
+      "environment": "development|staging|production",
+      "errorMessage": null
+    }
+  ],
+  "reviewDecision": {
+    "decision": "approve|conditional|reject",
+    "rationale": "2-3 sentence review assessment",
+    "conditions": ["Condition to meet (only if conditional)"]
+  }
+}
+
+Rules:
+- Generate at least 1 integration test result
+- Each integration must specify source, target, status, severity, and environment
+- errorMessage is only set for "fail" status integrations
+- reviewDecision.decision: "approve" if all integrations pass, "conditional" if non-critical failures exist, "reject" if critical integrations fail
+- conditions array is required if decision is "conditional", empty otherwise
+- severity reflects business impact: critical integrations block release, others are advisory
+- environment indicates where the test was run`;
+
+/**
+ * Generate build review from QA and integration data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage20Data - QA assessment
+ * @param {Object} [params.stage19Data] - Build execution
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Build review with integration results and decision
+ */
+export async function analyzeStage21({ stage20Data, stage19Data, ventureName }) {
+  if (!stage20Data) {
+    throw new Error('Stage 21 build review requires Stage 20 (QA) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const qaContext = stage20Data.qualityDecision
+    ? `QA Decision: ${stage20Data.qualityDecision.decision} — Pass rate: ${stage20Data.overallPassRate}%, Coverage: ${stage20Data.coveragePct}%`
+    : '';
+
+  const defectsContext = stage20Data.knownDefects?.length > 0
+    ? `Defects: ${stage20Data.knownDefects.map(d => `${d.severity}: ${d.description}`).join('; ')}`
+    : '';
+
+  const tasksContext = stage19Data?.tasks
+    ? `Build tasks: ${stage19Data.tasks.map(t => `${t.name} (${t.status})`).join(', ')}`
+    : '';
+
+  const userPrompt = `Generate a build review and integration assessment for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+${qaContext}
+${defectsContext}
+${tasksContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize integrations
+  let integrations = Array.isArray(parsed.integrations)
+    ? parsed.integrations.filter(ig => ig?.name)
+    : [];
+
+  if (integrations.length === 0) {
+    integrations = [{
+      name: 'Core System Integration',
+      source: 'Application',
+      target: 'External Services',
+      status: 'pending',
+      severity: 'high',
+      environment: 'development',
+      errorMessage: null,
+    }];
+  } else {
+    integrations = integrations.map(ig => ({
+      name: String(ig.name).substring(0, 200),
+      source: String(ig.source || 'Unknown').substring(0, 200),
+      target: String(ig.target || 'Unknown').substring(0, 200),
+      status: INTEGRATION_STATUSES.includes(ig.status) ? ig.status : 'pending',
+      severity: SEVERITY_LEVELS.includes(ig.severity) ? ig.severity : 'medium',
+      environment: ENVIRONMENTS.includes(ig.environment) ? ig.environment : 'development',
+      errorMessage: ig.status === 'fail' && ig.errorMessage
+        ? String(ig.errorMessage).substring(0, 500)
+        : null,
+    }));
+  }
+
+  // Compute derived fields
+  const totalIntegrations = integrations.length;
+  const passingIntegrations = integrations.filter(ig => ig.status === 'pass').length;
+  const failingIntegrations = integrations
+    .filter(ig => ig.status === 'fail')
+    .map(ig => ({ name: ig.name, source: ig.source, target: ig.target, errorMessage: ig.errorMessage }));
+  const passRate = totalIntegrations > 0
+    ? Math.round((passingIntegrations / totalIntegrations) * 10000) / 100
+    : 0;
+  const allPassing = failingIntegrations.length === 0 && totalIntegrations > 0;
+
+  // Normalize review decision
+  const rd = parsed.reviewDecision || {};
+  const hasCriticalFailure = integrations.some(ig => ig.status === 'fail' && ig.severity === 'critical');
+
+  let decision;
+  if (REVIEW_DECISIONS.includes(rd.decision)) {
+    decision = rd.decision;
+  } else if (allPassing) {
+    decision = 'approve';
+  } else if (hasCriticalFailure) {
+    decision = 'reject';
+  } else {
+    decision = 'conditional';
+  }
+
+  const conditions = decision === 'conditional' && Array.isArray(rd.conditions)
+    ? rd.conditions.map(c => String(c).substring(0, 300))
+    : [];
+
+  const reviewDecision = {
+    decision,
+    rationale: String(rd.rationale || `Review: ${decision} — ${passingIntegrations}/${totalIntegrations} integrations passing`).substring(0, 500),
+    conditions,
+  };
+
+  return {
+    integrations,
+    reviewDecision,
+    totalIntegrations,
+    passingIntegrations,
+    failingIntegrations,
+    passRate,
+    allPassing,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse build review response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { INTEGRATION_STATUSES, SEVERITY_LEVELS, ENVIRONMENTS, REVIEW_DECISIONS };

--- a/lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js
@@ -1,0 +1,208 @@
+/**
+ * Stage 22 Analysis Step - Release Readiness (BUILD LOOP Closeout)
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ * Part of SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001
+ *
+ * Consumes Stages 17-21 data and generates release decision,
+ * sprint retrospective, sprint summary, and Phase 5→6 Promotion Gate evaluation.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-22-release-readiness
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const RELEASE_DECISIONS = ['release', 'hold', 'cancel'];
+const RELEASE_CATEGORIES = ['feature', 'bugfix', 'infrastructure', 'documentation', 'configuration'];
+
+const SYSTEM_PROMPT = `You are EVA's Release Readiness Analyst. Synthesize the entire BUILD LOOP (Stages 17-21) into a release decision, sprint retrospective, and sprint summary.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "releaseItems": [
+    {
+      "name": "Release item name",
+      "category": "feature|bugfix|infrastructure|documentation|configuration",
+      "status": "pending|approved|rejected",
+      "approver": "Role or name of approver"
+    }
+  ],
+  "releaseNotes": "Markdown-formatted release notes summarizing what was built",
+  "targetDate": "YYYY-MM-DD target release date",
+  "releaseDecision": {
+    "decision": "release|hold|cancel",
+    "rationale": "2-3 sentence justification for the release decision",
+    "approver": "Role making the release decision"
+  },
+  "sprintRetrospective": {
+    "wentWell": ["What went well during the build sprint"],
+    "wentPoorly": ["What could be improved"],
+    "actionItems": ["Specific action for next sprint"]
+  },
+  "sprintSummary": {
+    "sprintGoal": "The original sprint goal",
+    "itemsPlanned": 5,
+    "itemsCompleted": 4,
+    "qualityAssessment": "Brief quality summary",
+    "integrationStatus": "Brief integration summary"
+  }
+}
+
+Rules:
+- At least 1 release item required
+- releaseNotes should be at least 10 characters, summarizing the build sprint output
+- releaseDecision.decision: "release" if quality and review both pass, "hold" if conditional, "cancel" if rejected
+- sprintRetrospective should have at least 1 item in each array
+- sprintSummary should reflect actual data from stages 18-21
+- targetDate should be reasonable (within 1-4 weeks for most ventures)`;
+
+/**
+ * Generate release readiness assessment from BUILD LOOP data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage17Data - Build readiness
+ * @param {Object} params.stage18Data - Sprint plan
+ * @param {Object} params.stage19Data - Build execution
+ * @param {Object} params.stage20Data - QA assessment
+ * @param {Object} params.stage21Data - Build review
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Release readiness with decision, retro, and summary
+ */
+export async function analyzeStage22({ stage17Data, stage18Data, stage19Data, stage20Data, stage21Data, ventureName }) {
+  if (!stage20Data || !stage21Data) {
+    throw new Error('Stage 22 release readiness requires Stage 20 (QA) and Stage 21 (review) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const qaContext = stage20Data.qualityDecision
+    ? `QA: ${stage20Data.qualityDecision.decision} (${stage20Data.overallPassRate}% pass, ${stage20Data.coveragePct}% coverage)`
+    : '';
+
+  const reviewContext = stage21Data.reviewDecision
+    ? `Review: ${stage21Data.reviewDecision.decision} (${stage21Data.passingIntegrations}/${stage21Data.totalIntegrations} integrations)`
+    : '';
+
+  const sprintContext = stage18Data?.sprintGoal
+    ? `Sprint Goal: ${stage18Data.sprintGoal}, Items: ${stage18Data.totalItems || 0}`
+    : '';
+
+  const executionContext = stage19Data
+    ? `Execution: ${stage19Data.completedTasks}/${stage19Data.totalTasks} tasks, ${stage19Data.openIssues} open issues`
+    : '';
+
+  const readinessContext = stage17Data?.buildReadiness
+    ? `Build Readiness: ${stage17Data.buildReadiness.decision}`
+    : '';
+
+  const userPrompt = `Generate release readiness assessment for this venture's BUILD LOOP.
+
+Venture: ${ventureName || 'Unnamed'}
+${readinessContext}
+${sprintContext}
+${executionContext}
+${qaContext}
+${reviewContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize release items
+  let releaseItems = Array.isArray(parsed.releaseItems)
+    ? parsed.releaseItems.filter(ri => ri?.name)
+    : [];
+
+  if (releaseItems.length === 0) {
+    releaseItems = [{
+      name: 'Sprint Deliverable',
+      category: 'feature',
+      status: 'pending',
+      approver: 'Product Owner',
+    }];
+  } else {
+    releaseItems = releaseItems.map(ri => ({
+      name: String(ri.name).substring(0, 200),
+      category: RELEASE_CATEGORIES.includes(ri.category) ? ri.category : 'feature',
+      status: ['pending', 'approved', 'rejected'].includes(ri.status) ? ri.status : 'pending',
+      approver: String(ri.approver || 'Unassigned').substring(0, 200),
+    }));
+  }
+
+  // Normalize release notes
+  const releaseNotes = String(parsed.releaseNotes || 'Build sprint completed.').substring(0, 2000);
+
+  // Normalize target date
+  const targetDate = parsed.targetDate && /^\d{4}-\d{2}-\d{2}$/.test(parsed.targetDate)
+    ? parsed.targetDate
+    : new Date(Date.now() + 14 * 86400000).toISOString().split('T')[0];
+
+  // Normalize release decision
+  const rd = parsed.releaseDecision || {};
+  const qaPass = stage20Data.qualityDecision?.decision === 'pass' || stage20Data.qualityDecision?.decision === 'conditional_pass';
+  const reviewPass = stage21Data.reviewDecision?.decision === 'approve' || stage21Data.reviewDecision?.decision === 'conditional';
+
+  let decision;
+  if (RELEASE_DECISIONS.includes(rd.decision)) {
+    decision = rd.decision;
+  } else if (qaPass && reviewPass) {
+    decision = 'release';
+  } else if (qaPass || reviewPass) {
+    decision = 'hold';
+  } else {
+    decision = 'cancel';
+  }
+
+  const releaseDecision = {
+    decision,
+    rationale: String(rd.rationale || `Release ${decision} based on QA and review results`).substring(0, 500),
+    approver: String(rd.approver || 'Product Owner').substring(0, 200),
+  };
+
+  // Normalize sprint retrospective
+  const retro = parsed.sprintRetrospective || {};
+  const sprintRetrospective = {
+    wentWell: Array.isArray(retro.wentWell) && retro.wentWell.length > 0
+      ? retro.wentWell.map(w => String(w).substring(0, 300))
+      : ['Sprint completed on schedule'],
+    wentPoorly: Array.isArray(retro.wentPoorly) && retro.wentPoorly.length > 0
+      ? retro.wentPoorly.map(w => String(w).substring(0, 300))
+      : ['Areas for improvement identified'],
+    actionItems: Array.isArray(retro.actionItems) && retro.actionItems.length > 0
+      ? retro.actionItems.map(a => String(a).substring(0, 300))
+      : ['Review sprint metrics in next planning'],
+  };
+
+  // Normalize sprint summary
+  const ss = parsed.sprintSummary || {};
+  const sprintSummary = {
+    sprintGoal: String(ss.sprintGoal || stage18Data?.sprintGoal || 'Sprint goal').substring(0, 300),
+    itemsPlanned: typeof ss.itemsPlanned === 'number' ? ss.itemsPlanned : (stage18Data?.totalItems || 0),
+    itemsCompleted: typeof ss.itemsCompleted === 'number' ? ss.itemsCompleted : (stage19Data?.completedTasks || 0),
+    qualityAssessment: String(ss.qualityAssessment || `${stage20Data.overallPassRate || 0}% pass rate`).substring(0, 300),
+    integrationStatus: String(ss.integrationStatus || `${stage21Data.passingIntegrations || 0}/${stage21Data.totalIntegrations || 0} passing`).substring(0, 300),
+  };
+
+  return {
+    releaseItems,
+    releaseNotes,
+    targetDate,
+    releaseDecision,
+    sprintRetrospective,
+    sprintSummary,
+    totalItems: releaseItems.length,
+    approvedItems: releaseItems.filter(ri => ri.status === 'approved').length,
+    allApproved: releaseItems.every(ri => ri.status === 'approved'),
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse release readiness response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { RELEASE_DECISIONS, RELEASE_CATEGORIES };

--- a/lib/eva/stage-templates/stage-17.js
+++ b/lib/eva/stage-templates/stage-17.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage17 } from './analysis-steps/stage-17-build-readiness.js';
 
 const CHECKLIST_CATEGORIES = [
   'architecture',
@@ -25,7 +26,7 @@ const TEMPLATE = {
   id: 'stage-17',
   slug: 'pre-build-checklist',
   title: 'Pre-Build Checklist',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     checklist: {
       type: 'object',
@@ -136,6 +137,8 @@ const TEMPLATE = {
     };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage17;
 
 export { CHECKLIST_CATEGORIES, ITEM_STATUSES, MIN_ITEMS_PER_CATEGORY };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-18.js
+++ b/lib/eva/stage-templates/stage-18.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage18 } from './analysis-steps/stage-18-sprint-planning.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];
@@ -26,7 +27,7 @@ const TEMPLATE = {
   id: 'stage-18',
   slug: 'sprint-planning',
   title: 'Sprint Planning',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     sprint_name: { type: 'string', required: true },
     sprint_duration_days: { type: 'number', min: MIN_SPRINT_DURATION_DAYS, max: MAX_SPRINT_DURATION_DAYS, required: true },
@@ -128,6 +129,8 @@ const TEMPLATE = {
     };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage18;
 
 export { PRIORITY_VALUES, SD_TYPES, MIN_SPRINT_ITEMS, SD_BRIDGE_REQUIRED_FIELDS, MIN_SPRINT_DURATION_DAYS, MAX_SPRINT_DURATION_DAYS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-19.js
+++ b/lib/eva/stage-templates/stage-19.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage19 } from './analysis-steps/stage-19-build-execution.js';
 
 const TASK_STATUSES = ['todo', 'in_progress', 'done', 'blocked'];
 const MIN_TASKS = 1;
@@ -18,7 +19,7 @@ const TEMPLATE = {
   id: 'stage-19',
   slug: 'build-execution',
   title: 'Build Execution',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     tasks: {
       type: 'array',
@@ -112,6 +113,8 @@ const TEMPLATE = {
     };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage19;
 
 export { TASK_STATUSES, MIN_TASKS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-20.js
+++ b/lib/eva/stage-templates/stage-20.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateNumber, validateArray, collectErrors } from './validation.js';
+import { analyzeStage20 } from './analysis-steps/stage-20-quality-assurance.js';
 
 const MIN_TEST_SUITES = 1;
 const MIN_COVERAGE_PCT = 60;
@@ -18,7 +19,7 @@ const TEMPLATE = {
   id: 'stage-20',
   slug: 'quality-assurance',
   title: 'Quality Assurance',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     test_suites: {
       type: 'array',
@@ -124,6 +125,8 @@ const TEMPLATE = {
     };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage20;
 
 export { MIN_TEST_SUITES, MIN_COVERAGE_PCT };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-21.js
+++ b/lib/eva/stage-templates/stage-21.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage21 } from './analysis-steps/stage-21-build-review.js';
 
 const INTEGRATION_STATUSES = ['pass', 'fail', 'skip', 'pending'];
 const MIN_INTEGRATIONS = 1;
@@ -18,7 +19,7 @@ const TEMPLATE = {
   id: 'stage-21',
   slug: 'integration-testing',
   title: 'Integration Testing',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     integrations: {
       type: 'array',
@@ -99,6 +100,8 @@ const TEMPLATE = {
     };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage21;
 
 export { INTEGRATION_STATUSES, MIN_INTEGRATIONS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-22.js
+++ b/lib/eva/stage-templates/stage-22.js
@@ -6,18 +6,21 @@
  * Release readiness checklist with approval tracking and
  * Phase 5→6 Promotion Gate evaluation.
  *
- * Promotion gate pass requires:
- *   - Stage 17: all checklist categories present, readiness >= 80%
- *   - Stage 18: >= 1 sprint item with valid SD bridge payload
- *   - Stage 19: completion_pct >= 80%, no blocked tasks
- *   - Stage 20: quality gate passed (100% pass rate, >= 60% coverage)
- *   - Stage 21: all integrations passing
- *   - Stage 22: all release items approved
+ * v2.0.0 Promotion Gate uses decision objects from v2.0 analysis steps:
+ *   - Stage 17: buildReadiness.decision ∈ {go, conditional_go}
+ *   - Stage 18: >= 1 sprint item
+ *   - Stage 19: sprintCompletion.decision ∈ {complete, continue} AND no critical blockers
+ *   - Stage 20: qualityDecision.decision ∈ {pass, conditional_pass}
+ *   - Stage 21: reviewDecision.decision ∈ {approve, conditional}
+ *   - Stage 22: releaseDecision.decision = 'release'
+ *
+ * Backward-compatible: also checks legacy boolean fields if decision objects missing.
  *
  * @module lib/eva/stage-templates/stage-22
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage22 } from './analysis-steps/stage-22-release-readiness.js';
 import { CHECKLIST_CATEGORIES } from './stage-17.js';
 import { MIN_COVERAGE_PCT } from './stage-20.js';
 
@@ -30,7 +33,7 @@ const TEMPLATE = {
   id: 'stage-22',
   slug: 'release-readiness',
   title: 'Release Readiness',
-  version: '1.0.0',
+  version: '2.0.0',
   schema: {
     release_items: {
       type: 'array',
@@ -95,7 +98,7 @@ const TEMPLATE = {
 
     const promotion_gate = prerequisites
       ? evaluatePromotionGate({ ...prerequisites, stage22: data })
-      : { pass: false, rationale: 'Prerequisites not provided', blockers: ['Stage 17-21 data required'], required_next_actions: ['Complete stages 17-21 before evaluating promotion gate'] };
+      : { pass: false, rationale: 'Prerequisites not provided', blockers: ['Stage 17-21 data required'], warnings: [], required_next_actions: ['Complete stages 17-21 before evaluating promotion gate'] };
 
     return {
       ...data,
@@ -108,51 +111,84 @@ const TEMPLATE = {
 };
 
 /**
- * Pure function: evaluate Phase 5→6 Promotion Gate.
+ * Pure function: evaluate Phase 5→6 Promotion Gate (v2.0).
+ *
+ * Uses decision objects from v2.0 analysis steps with backward-compatible
+ * fallback to legacy boolean fields.
  *
  * @param {{ stage17: Object, stage18: Object, stage19: Object, stage20: Object, stage21: Object, stage22: Object }} prerequisites
- * @returns {{ pass: boolean, rationale: string, blockers: string[], required_next_actions: string[] }}
+ * @returns {{ pass: boolean, rationale: string, blockers: string[], warnings: string[], required_next_actions: string[] }}
  */
 export function evaluatePromotionGate({ stage17, stage18, stage19, stage20, stage21, stage22 }) {
   const blockers = [];
+  const warnings = [];
   const required_next_actions = [];
 
-  // Stage 17: all categories present, readiness >= 80%
-  let categoriesPresent = 0;
-  for (const cat of CHECKLIST_CATEGORIES) {
-    if (stage17?.checklist?.[cat]?.length > 0) categoriesPresent++;
-  }
-  if (categoriesPresent < CHECKLIST_CATEGORIES.length) {
-    blockers.push(`Pre-build checklist missing ${CHECKLIST_CATEGORIES.length - categoriesPresent} category(ies)`);
-    required_next_actions.push('Complete all pre-build checklist categories');
-  }
-  const readinessPct = stage17?.readiness_pct ?? 0;
-  if (readinessPct < MIN_READINESS_PCT) {
-    blockers.push(`Pre-build readiness at ${readinessPct}%, minimum ${MIN_READINESS_PCT}% required`);
-    required_next_actions.push('Complete more checklist items to reach readiness threshold');
+  // Stage 17: buildReadiness decision OR legacy checklist check
+  const s17Decision = stage17?.buildReadiness?.decision;
+  if (s17Decision) {
+    if (s17Decision === 'no_go') {
+      blockers.push(`Build readiness: no_go — ${stage17.buildReadiness.rationale || 'Not ready'}`);
+      required_next_actions.push('Resolve build readiness blockers before proceeding');
+    } else if (s17Decision === 'conditional_go') {
+      warnings.push(`Build readiness: conditional_go — ${stage17.buildReadiness.rationale || 'Conditions apply'}`);
+    }
+  } else {
+    // Legacy: check categories and readiness_pct
+    let categoriesPresent = 0;
+    for (const cat of CHECKLIST_CATEGORIES) {
+      if (stage17?.checklist?.[cat]?.length > 0) categoriesPresent++;
+    }
+    if (categoriesPresent < CHECKLIST_CATEGORIES.length) {
+      blockers.push(`Pre-build checklist missing ${CHECKLIST_CATEGORIES.length - categoriesPresent} category(ies)`);
+      required_next_actions.push('Complete all pre-build checklist categories');
+    }
+    const readinessPct = stage17?.readiness_pct ?? 0;
+    if (readinessPct < MIN_READINESS_PCT) {
+      blockers.push(`Pre-build readiness at ${readinessPct}%, minimum ${MIN_READINESS_PCT}% required`);
+      required_next_actions.push('Complete more checklist items to reach readiness threshold');
+    }
   }
 
-  // Stage 18: >= 1 sprint item
-  const sprintItems = stage18?.items?.length || 0;
+  // Stage 18: >= 1 sprint item (same for v1 and v2)
+  const sprintItems = stage18?.sprintItems?.length || stage18?.items?.length || 0;
   if (sprintItems < 1) {
     blockers.push('No sprint items defined');
     required_next_actions.push('Define at least 1 sprint item with SD bridge payload');
   }
 
-  // Stage 19: completion >= 80%, no blocked tasks
-  const completionPct = stage19?.completion_pct ?? 0;
-  if (completionPct < MIN_BUILD_COMPLETION_PCT) {
-    blockers.push(`Build completion at ${completionPct}%, minimum ${MIN_BUILD_COMPLETION_PCT}% required`);
-    required_next_actions.push('Complete more build tasks');
-  }
-  const blockedTasks = stage19?.blocked_tasks ?? 0;
-  if (blockedTasks > 0) {
-    blockers.push(`${blockedTasks} build task(s) are blocked`);
-    required_next_actions.push('Resolve blocked build tasks');
+  // Stage 19: sprintCompletion decision OR legacy completion_pct
+  const s19Decision = stage19?.sprintCompletion?.decision;
+  if (s19Decision) {
+    if (s19Decision === 'blocked') {
+      blockers.push(`Sprint execution: blocked — ${stage19.sprintCompletion.rationale || 'Critical blockers'}`);
+      required_next_actions.push('Resolve sprint blockers');
+    } else if (s19Decision === 'continue') {
+      warnings.push(`Sprint execution: continue — ${stage19.sprintCompletion.rationale || 'Work in progress'}`);
+    }
+  } else {
+    const completionPct = stage19?.completion_pct ?? 0;
+    if (completionPct < MIN_BUILD_COMPLETION_PCT) {
+      blockers.push(`Build completion at ${completionPct}%, minimum ${MIN_BUILD_COMPLETION_PCT}% required`);
+      required_next_actions.push('Complete more build tasks');
+    }
+    const blockedTasks = stage19?.blocked_tasks ?? 0;
+    if (blockedTasks > 0) {
+      blockers.push(`${blockedTasks} build task(s) are blocked`);
+      required_next_actions.push('Resolve blocked build tasks');
+    }
   }
 
-  // Stage 20: quality gate passed
-  if (!stage20?.quality_gate_passed) {
+  // Stage 20: qualityDecision OR legacy quality_gate_passed
+  const s20Decision = stage20?.qualityDecision?.decision;
+  if (s20Decision) {
+    if (s20Decision === 'fail') {
+      blockers.push(`Quality gate: fail — ${stage20.qualityDecision.rationale || 'Below thresholds'}`);
+      required_next_actions.push('Fix failing tests and increase coverage');
+    } else if (s20Decision === 'conditional_pass') {
+      warnings.push(`Quality gate: conditional_pass — ${stage20.qualityDecision.rationale || 'Near thresholds'}`);
+    }
+  } else if (!stage20?.quality_gate_passed) {
     const passRate = stage20?.overall_pass_rate ?? 0;
     const coverage = stage20?.coverage_pct ?? 0;
     if (passRate < 100) {
@@ -165,28 +201,51 @@ export function evaluatePromotionGate({ stage17, stage18, stage19, stage20, stag
     }
   }
 
-  // Stage 21: all integrations passing
-  if (!stage21?.all_passing) {
+  // Stage 21: reviewDecision OR legacy all_passing
+  const s21Decision = stage21?.reviewDecision?.decision;
+  if (s21Decision) {
+    if (s21Decision === 'reject') {
+      blockers.push(`Build review: reject — ${stage21.reviewDecision.rationale || 'Review failed'}`);
+      required_next_actions.push('Address review feedback and re-submit');
+    } else if (s21Decision === 'conditional') {
+      warnings.push(`Build review: conditional — ${stage21.reviewDecision.rationale || 'Conditions apply'}`);
+    }
+  } else if (!stage21?.all_passing) {
     const failCount = stage21?.failing_integrations?.length || 0;
     blockers.push(`${failCount} integration(s) failing`);
     required_next_actions.push('Fix all failing integration tests');
   }
 
-  // Stage 22: all release items approved
-  const releaseItems = stage22?.release_items || [];
-  const unapproved = releaseItems.filter(ri => ri.status !== 'approved').length;
-  if (unapproved > 0) {
-    blockers.push(`${unapproved} release item(s) not yet approved`);
-    required_next_actions.push('Get approval for all release items');
+  // Stage 22: releaseDecision (v2) OR legacy all-approved check
+  const s22Decision = stage22?.releaseDecision?.decision;
+  if (s22Decision) {
+    if (s22Decision === 'cancel') {
+      blockers.push(`Release decision: cancel — ${stage22.releaseDecision.rationale || 'Release cancelled'}`);
+      required_next_actions.push('Return to planning phase for replanning');
+    } else if (s22Decision === 'hold') {
+      blockers.push(`Release decision: hold — ${stage22.releaseDecision.rationale || 'Release on hold'}`);
+      required_next_actions.push('Address hold conditions before release');
+    }
+  } else {
+    const releaseItems = stage22?.release_items || [];
+    const unapproved = releaseItems.filter(ri => ri.status !== 'approved').length;
+    if (unapproved > 0) {
+      blockers.push(`${unapproved} release item(s) not yet approved`);
+      required_next_actions.push('Get approval for all release items');
+    }
   }
 
   const pass = blockers.length === 0;
   const rationale = pass
-    ? 'All Phase 5 prerequisites met. Build loop is complete with quality and integration gates passed.'
+    ? warnings.length > 0
+      ? `Phase 5 prerequisites met with ${warnings.length} advisory warning(s). Build loop complete.`
+      : 'All Phase 5 prerequisites met. Build loop is complete with quality and integration gates passed.'
     : `Phase 5 is incomplete: ${blockers.length} blocker(s) found.`;
 
-  return { pass, rationale, blockers, required_next_actions };
+  return { pass, rationale, blockers, warnings, required_next_actions };
 }
+
+TEMPLATE.analysisStep = analyzeStage22;
 
 export { APPROVAL_STATUSES, MIN_RELEASE_ITEMS, MIN_READINESS_PCT, MIN_BUILD_COMPLETION_PCT };
 export default TEMPLATE;

--- a/test/unit/eva-build-loop-templates.test.js
+++ b/test/unit/eva-build-loop-templates.test.js
@@ -1,0 +1,513 @@
+/**
+ * EVA Build Loop Templates (Stages 17-22) - Unit Tests
+ * Part of SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001
+ *
+ * Tests:
+ * - Passive container validation and computeDerived for stages 17-22
+ * - v2.0 promotion gate with decision objects
+ * - Backward-compatible promotion gate with legacy booleans
+ * - Analysis step output normalization (mocked LLM)
+ * - Index registry for stages 17-22
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+
+// Passive containers
+import stage17, { CHECKLIST_CATEGORIES, ITEM_STATUSES } from '../../lib/eva/stage-templates/stage-17.js';
+import stage18, { PRIORITY_VALUES, SD_TYPES } from '../../lib/eva/stage-templates/stage-18.js';
+import stage19, { TASK_STATUSES } from '../../lib/eva/stage-templates/stage-19.js';
+import stage20, { MIN_TEST_SUITES, MIN_COVERAGE_PCT } from '../../lib/eva/stage-templates/stage-20.js';
+import stage21, { INTEGRATION_STATUSES } from '../../lib/eva/stage-templates/stage-21.js';
+import stage22, { evaluatePromotionGate, APPROVAL_STATUSES } from '../../lib/eva/stage-templates/stage-22.js';
+
+// ── Stage 17: Pre-Build Checklist ───────────────────────────
+
+describe('Stage 17 - Pre-Build Checklist', () => {
+  test('version is 2.0.0', () => {
+    expect(stage17.version).toBe('2.0.0');
+  });
+
+  test('has analysisStep attached', () => {
+    expect(typeof stage17.analysisStep).toBe('function');
+  });
+
+  test('exports all checklist categories', () => {
+    expect(CHECKLIST_CATEGORIES).toEqual([
+      'architecture', 'team_readiness', 'tooling', 'environment', 'dependencies',
+    ]);
+  });
+
+  test('validates valid data', () => {
+    const data = {
+      checklist: Object.fromEntries(CHECKLIST_CATEGORIES.map(cat => [cat, [
+        { name: `${cat} item`, status: 'complete', owner: 'Dev', notes: '' },
+      ]])),
+      blockers: [],
+    };
+    const result = stage17.validate(data);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('rejects missing checklist', () => {
+    const result = stage17.validate({});
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects invalid item status', () => {
+    const data = {
+      checklist: Object.fromEntries(CHECKLIST_CATEGORIES.map(cat => [cat, [
+        { name: 'item', status: 'invalid_status' },
+      ]])),
+    };
+    const result = stage17.validate(data);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('status'))).toBe(true);
+  });
+
+  test('computeDerived calculates readiness correctly', () => {
+    const data = {
+      checklist: {
+        architecture: [{ name: 'A', status: 'complete' }],
+        team_readiness: [{ name: 'B', status: 'complete' }],
+        tooling: [{ name: 'C', status: 'in_progress' }],
+        environment: [{ name: 'D', status: 'not_started' }],
+        dependencies: [{ name: 'E', status: 'complete' }],
+      },
+      blockers: [{ description: 'issue', severity: 'high', mitigation: 'fix' }],
+    };
+    const result = stage17.computeDerived(data);
+    expect(result.total_items).toBe(5);
+    expect(result.completed_items).toBe(3);
+    expect(result.readiness_pct).toBe(60);
+    expect(result.all_categories_present).toBe(true);
+    expect(result.blocker_count).toBe(1);
+  });
+});
+
+// ── Stage 18: Sprint Planning ───────────────────────────────
+
+describe('Stage 18 - Sprint Planning', () => {
+  test('version is 2.0.0', () => {
+    expect(stage18.version).toBe('2.0.0');
+  });
+
+  test('has analysisStep attached', () => {
+    expect(typeof stage18.analysisStep).toBe('function');
+  });
+
+  test('validates valid sprint data', () => {
+    const data = {
+      sprint_name: 'Sprint 1',
+      sprint_duration_days: 14,
+      sprint_goal: 'Complete MVP features for launch',
+      items: [{
+        title: 'Build auth',
+        description: 'Authentication system',
+        priority: 'high',
+        type: 'feature',
+        scope: 'Backend API',
+        success_criteria: 'Users can log in',
+        target_application: 'EHG',
+        story_points: 5,
+      }],
+    };
+    const result = stage18.validate(data);
+    expect(result.valid).toBe(true);
+  });
+
+  test('rejects sprint goal too short', () => {
+    const data = {
+      sprint_name: 'Sprint 1',
+      sprint_duration_days: 14,
+      sprint_goal: 'short',
+      items: [{
+        title: 'Task', description: 'desc', priority: 'high',
+        type: 'feature', scope: 'all', success_criteria: 'done',
+        target_application: 'EHG',
+      }],
+    };
+    const result = stage18.validate(data);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('sprint_goal'))).toBe(true);
+  });
+
+  test('computeDerived generates SD bridge payloads', () => {
+    const data = {
+      items: [
+        { title: 'A', description: 'desc', priority: 'high', type: 'feature', scope: 's', success_criteria: 'c', target_application: 'EHG', story_points: 3 },
+        { title: 'B', description: 'desc', priority: 'low', type: 'bugfix', scope: 's', success_criteria: 'c', target_application: 'EHG', story_points: 2 },
+      ],
+    };
+    const result = stage18.computeDerived(data);
+    expect(result.total_items).toBe(2);
+    expect(result.total_story_points).toBe(5);
+    expect(result.sd_bridge_payloads).toHaveLength(2);
+    expect(result.sd_bridge_payloads[0].title).toBe('A');
+  });
+});
+
+// ── Stage 19: Build Execution ───────────────────────────────
+
+describe('Stage 19 - Build Execution', () => {
+  test('version is 2.0.0', () => {
+    expect(stage19.version).toBe('2.0.0');
+  });
+
+  test('has analysisStep attached', () => {
+    expect(typeof stage19.analysisStep).toBe('function');
+  });
+
+  test('validates valid task data', () => {
+    const data = {
+      tasks: [{ name: 'Build auth', status: 'done' }],
+      issues: [],
+    };
+    expect(stage19.validate(data).valid).toBe(true);
+  });
+
+  test('rejects invalid task status', () => {
+    const data = {
+      tasks: [{ name: 'Task', status: 'invalid' }],
+    };
+    const result = stage19.validate(data);
+    expect(result.valid).toBe(false);
+  });
+
+  test('computeDerived calculates completion', () => {
+    const data = {
+      tasks: [
+        { name: 'A', status: 'done' },
+        { name: 'B', status: 'done' },
+        { name: 'C', status: 'in_progress' },
+        { name: 'D', status: 'blocked' },
+      ],
+      issues: [],
+    };
+    const result = stage19.computeDerived(data);
+    expect(result.total_tasks).toBe(4);
+    expect(result.completed_tasks).toBe(2);
+    expect(result.blocked_tasks).toBe(1);
+    expect(result.completion_pct).toBe(50);
+    expect(result.tasks_by_status.done).toBe(2);
+    expect(result.tasks_by_status.blocked).toBe(1);
+  });
+});
+
+// ── Stage 20: Quality Assurance ─────────────────────────────
+
+describe('Stage 20 - Quality Assurance', () => {
+  test('version is 2.0.0', () => {
+    expect(stage20.version).toBe('2.0.0');
+  });
+
+  test('has analysisStep attached', () => {
+    expect(typeof stage20.analysisStep).toBe('function');
+  });
+
+  test('validates valid test suite data', () => {
+    const data = {
+      test_suites: [{ name: 'Unit', total_tests: 100, passing_tests: 95, coverage_pct: 80 }],
+      known_defects: [],
+    };
+    expect(stage20.validate(data).valid).toBe(true);
+  });
+
+  test('rejects passing > total', () => {
+    const data = {
+      test_suites: [{ name: 'Unit', total_tests: 10, passing_tests: 15 }],
+    };
+    const result = stage20.validate(data);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('cannot exceed'))).toBe(true);
+  });
+
+  test('computeDerived quality gate pass', () => {
+    const data = {
+      test_suites: [{ name: 'Unit', total_tests: 100, passing_tests: 100, coverage_pct: 80 }],
+      known_defects: [],
+    };
+    const result = stage20.computeDerived(data);
+    expect(result.quality_gate_passed).toBe(true);
+    expect(result.overall_pass_rate).toBe(100);
+    expect(result.coverage_pct).toBe(80);
+  });
+
+  test('computeDerived quality gate fail - low coverage', () => {
+    const data = {
+      test_suites: [{ name: 'Unit', total_tests: 100, passing_tests: 100, coverage_pct: 40 }],
+      known_defects: [],
+    };
+    const result = stage20.computeDerived(data);
+    expect(result.quality_gate_passed).toBe(false);
+  });
+});
+
+// ── Stage 21: Integration Testing ───────────────────────────
+
+describe('Stage 21 - Integration Testing', () => {
+  test('version is 2.0.0', () => {
+    expect(stage21.version).toBe('2.0.0');
+  });
+
+  test('has analysisStep attached', () => {
+    expect(typeof stage21.analysisStep).toBe('function');
+  });
+
+  test('validates valid integration data', () => {
+    const data = {
+      environment: 'staging',
+      integrations: [{
+        name: 'API→DB', source: 'API', target: 'Database', status: 'pass',
+      }],
+    };
+    expect(stage21.validate(data).valid).toBe(true);
+  });
+
+  test('computeDerived tracks failures', () => {
+    const data = {
+      integrations: [
+        { name: 'A', source: 'X', target: 'Y', status: 'pass' },
+        { name: 'B', source: 'X', target: 'Z', status: 'fail', error_message: 'timeout' },
+      ],
+      environment: 'staging',
+    };
+    const result = stage21.computeDerived(data);
+    expect(result.total_integrations).toBe(2);
+    expect(result.passing_integrations).toBe(1);
+    expect(result.failing_integrations).toHaveLength(1);
+    expect(result.all_passing).toBe(false);
+    expect(result.pass_rate).toBe(50);
+  });
+});
+
+// ── Stage 22: Release Readiness ─────────────────────────────
+
+describe('Stage 22 - Release Readiness', () => {
+  test('version is 2.0.0', () => {
+    expect(stage22.version).toBe('2.0.0');
+  });
+
+  test('has analysisStep attached', () => {
+    expect(typeof stage22.analysisStep).toBe('function');
+  });
+
+  test('validates valid release data', () => {
+    const data = {
+      release_items: [{ name: 'Feature A', category: 'feature', status: 'approved', approver: 'PM' }],
+      release_notes: 'Initial release with core features',
+      target_date: '2026-03-01',
+    };
+    expect(stage22.validate(data).valid).toBe(true);
+  });
+
+  test('computeDerived tracks approvals', () => {
+    const data = {
+      release_items: [
+        { name: 'A', category: 'feature', status: 'approved' },
+        { name: 'B', category: 'bugfix', status: 'pending' },
+      ],
+      release_notes: 'Release notes here',
+      target_date: '2026-03-01',
+    };
+    const result = stage22.computeDerived(data);
+    expect(result.total_items).toBe(2);
+    expect(result.approved_items).toBe(1);
+    expect(result.all_approved).toBe(false);
+  });
+});
+
+// ── Promotion Gate v2.0 (Decision Objects) ──────────────────
+
+describe('Promotion Gate v2.0 - Decision Objects', () => {
+  const makeV2Prerequisites = (overrides = {}) => ({
+    stage17: {
+      buildReadiness: { decision: 'go', rationale: 'All ready' },
+      ...overrides.stage17,
+    },
+    stage18: {
+      sprintItems: [{ title: 'Item 1' }],
+      ...overrides.stage18,
+    },
+    stage19: {
+      sprintCompletion: { decision: 'complete', readyForQa: true, rationale: 'Done' },
+      ...overrides.stage19,
+    },
+    stage20: {
+      qualityDecision: { decision: 'pass', rationale: 'All tests pass' },
+      ...overrides.stage20,
+    },
+    stage21: {
+      reviewDecision: { decision: 'approve', rationale: 'Approved' },
+      ...overrides.stage21,
+    },
+    stage22: {
+      releaseDecision: { decision: 'release', rationale: 'Ready to ship' },
+      ...overrides.stage22,
+    },
+  });
+
+  test('PASS: all decisions positive', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites());
+    expect(result.pass).toBe(true);
+    expect(result.blockers).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  test('PASS with warnings: conditional decisions', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage17: { buildReadiness: { decision: 'conditional_go', rationale: 'Missing tooling' } },
+      stage20: { qualityDecision: { decision: 'conditional_pass', rationale: '94% pass rate' } },
+      stage21: { reviewDecision: { decision: 'conditional', rationale: 'Minor issues' } },
+    }));
+    expect(result.pass).toBe(true);
+    expect(result.warnings).toHaveLength(3);
+    expect(result.blockers).toHaveLength(0);
+    expect(result.rationale).toContain('3 advisory warning(s)');
+  });
+
+  test('FAIL: no_go readiness', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage17: { buildReadiness: { decision: 'no_go', rationale: 'Critical dependency missing' } },
+    }));
+    expect(result.pass).toBe(false);
+    expect(result.blockers).toHaveLength(1);
+    expect(result.blockers[0]).toContain('no_go');
+  });
+
+  test('FAIL: sprint blocked', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage19: { sprintCompletion: { decision: 'blocked', rationale: 'External API down' } },
+    }));
+    expect(result.pass).toBe(false);
+    expect(result.blockers.some(b => b.includes('blocked'))).toBe(true);
+  });
+
+  test('FAIL: quality fail', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage20: { qualityDecision: { decision: 'fail', rationale: '60% pass rate' } },
+    }));
+    expect(result.pass).toBe(false);
+    expect(result.blockers.some(b => b.includes('Quality gate: fail'))).toBe(true);
+  });
+
+  test('FAIL: review reject', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage21: { reviewDecision: { decision: 'reject', rationale: 'Security issues' } },
+    }));
+    expect(result.pass).toBe(false);
+    expect(result.blockers.some(b => b.includes('reject'))).toBe(true);
+  });
+
+  test('FAIL: release hold', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage22: { releaseDecision: { decision: 'hold', rationale: 'Waiting for legal' } },
+    }));
+    expect(result.pass).toBe(false);
+    expect(result.blockers.some(b => b.includes('hold'))).toBe(true);
+  });
+
+  test('FAIL: release cancel', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage22: { releaseDecision: { decision: 'cancel', rationale: 'Market changed' } },
+    }));
+    expect(result.pass).toBe(false);
+    expect(result.blockers.some(b => b.includes('cancel'))).toBe(true);
+    expect(result.required_next_actions.some(a => a.includes('replanning'))).toBe(true);
+  });
+
+  test('FAIL: no sprint items', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage18: { sprintItems: [] },
+    }));
+    expect(result.pass).toBe(false);
+    expect(result.blockers.some(b => b.includes('No sprint items'))).toBe(true);
+  });
+
+  test('sprint continue produces warning, not blocker', () => {
+    const result = evaluatePromotionGate(makeV2Prerequisites({
+      stage19: { sprintCompletion: { decision: 'continue', rationale: 'Work in progress' } },
+    }));
+    expect(result.pass).toBe(true);
+    expect(result.warnings.some(w => w.includes('continue'))).toBe(true);
+  });
+});
+
+// ── Promotion Gate Backward Compatibility (Legacy Booleans) ─
+
+describe('Promotion Gate - Legacy Backward Compatibility', () => {
+  test('PASS with legacy boolean fields', () => {
+    const result = evaluatePromotionGate({
+      stage17: {
+        checklist: Object.fromEntries(CHECKLIST_CATEGORIES.map(c => [c, [{ name: 'item', status: 'complete' }]])),
+        readiness_pct: 100,
+      },
+      stage18: { items: [{ title: 'Sprint item' }] },
+      stage19: { completion_pct: 100, blocked_tasks: 0 },
+      stage20: { quality_gate_passed: true },
+      stage21: { all_passing: true },
+      stage22: { release_items: [{ name: 'A', status: 'approved' }] },
+    });
+    expect(result.pass).toBe(true);
+  });
+
+  test('FAIL with legacy: low readiness', () => {
+    const result = evaluatePromotionGate({
+      stage17: { checklist: {}, readiness_pct: 50 },
+      stage18: { items: [{ title: 'item' }] },
+      stage19: { completion_pct: 100, blocked_tasks: 0 },
+      stage20: { quality_gate_passed: true },
+      stage21: { all_passing: true },
+      stage22: { release_items: [{ name: 'A', status: 'approved' }] },
+    });
+    expect(result.pass).toBe(false);
+  });
+
+  test('FAIL with legacy: quality gate not passed', () => {
+    const result = evaluatePromotionGate({
+      stage17: {
+        checklist: Object.fromEntries(CHECKLIST_CATEGORIES.map(c => [c, [{ name: 'item', status: 'complete' }]])),
+        readiness_pct: 100,
+      },
+      stage18: { items: [{ title: 'item' }] },
+      stage19: { completion_pct: 100, blocked_tasks: 0 },
+      stage20: { quality_gate_passed: false, overall_pass_rate: 80, coverage_pct: 40 },
+      stage21: { all_passing: true },
+      stage22: { release_items: [{ name: 'A', status: 'approved' }] },
+    });
+    expect(result.pass).toBe(false);
+    expect(result.blockers.some(b => b.includes('pass rate'))).toBe(true);
+    expect(result.blockers.some(b => b.includes('coverage'))).toBe(true);
+  });
+
+  test('v2 decision objects take precedence over legacy booleans', () => {
+    const result = evaluatePromotionGate({
+      stage17: { buildReadiness: { decision: 'go' }, checklist: {}, readiness_pct: 10 },
+      stage18: { sprintItems: [{ title: 'item' }], items: [] },
+      stage19: { sprintCompletion: { decision: 'complete' }, completion_pct: 0 },
+      stage20: { qualityDecision: { decision: 'pass' }, quality_gate_passed: false },
+      stage21: { reviewDecision: { decision: 'approve' }, all_passing: false },
+      stage22: { releaseDecision: { decision: 'release' }, release_items: [] },
+    });
+    // v2 decisions say all good, legacy says all bad — v2 should win
+    expect(result.pass).toBe(true);
+  });
+});
+
+// ── Index Registry ──────────────────────────────────────────
+
+describe('Analysis Steps Index Registry', () => {
+  test('getAnalysisStep returns functions for stages 17-22', async () => {
+    const { getAnalysisStep } = await import('../../lib/eva/stage-templates/analysis-steps/index.js');
+    for (const num of [17, 18, 19, 20, 21, 22]) {
+      const fn = await getAnalysisStep(num);
+      expect(typeof fn).toBe('function');
+    }
+  });
+
+  test('getAnalysisStep returns null for invalid stage', async () => {
+    const { getAnalysisStep } = await import('../../lib/eva/stage-templates/analysis-steps/index.js');
+    const fn = await getAnalysisStep(99);
+    expect(fn).toBeNull();
+  });
+});

--- a/tests/unit/eva/stage-templates/stage-17.test.js
+++ b/tests/unit/eva/stage-templates/stage-17.test.js
@@ -17,7 +17,7 @@ describe('stage-17.js - Pre-Build Checklist template', () => {
       expect(stage17.id).toBe('stage-17');
       expect(stage17.slug).toBe('pre-build-checklist');
       expect(stage17.title).toBe('Pre-Build Checklist');
-      expect(stage17.version).toBe('1.0.0');
+      expect(stage17.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {

--- a/tests/unit/eva/stage-templates/stage-18.test.js
+++ b/tests/unit/eva/stage-templates/stage-18.test.js
@@ -17,7 +17,7 @@ describe('stage-18.js - Sprint Planning template', () => {
       expect(stage18.id).toBe('stage-18');
       expect(stage18.slug).toBe('sprint-planning');
       expect(stage18.title).toBe('Sprint Planning');
-      expect(stage18.version).toBe('1.0.0');
+      expect(stage18.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {

--- a/tests/unit/eva/stage-templates/stage-19.test.js
+++ b/tests/unit/eva/stage-templates/stage-19.test.js
@@ -17,7 +17,7 @@ describe('stage-19.js - Build Execution template', () => {
       expect(stage19.id).toBe('stage-19');
       expect(stage19.slug).toBe('build-execution');
       expect(stage19.title).toBe('Build Execution');
-      expect(stage19.version).toBe('1.0.0');
+      expect(stage19.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {

--- a/tests/unit/eva/stage-templates/stage-20.test.js
+++ b/tests/unit/eva/stage-templates/stage-20.test.js
@@ -17,7 +17,7 @@ describe('stage-20.js - Quality Assurance template', () => {
       expect(stage20.id).toBe('stage-20');
       expect(stage20.slug).toBe('quality-assurance');
       expect(stage20.title).toBe('Quality Assurance');
-      expect(stage20.version).toBe('1.0.0');
+      expect(stage20.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {

--- a/tests/unit/eva/stage-templates/stage-21.test.js
+++ b/tests/unit/eva/stage-templates/stage-21.test.js
@@ -17,7 +17,7 @@ describe('stage-21.js - Integration Testing template', () => {
       expect(stage21.id).toBe('stage-21');
       expect(stage21.slug).toBe('integration-testing');
       expect(stage21.title).toBe('Integration Testing');
-      expect(stage21.version).toBe('1.0.0');
+      expect(stage21.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {

--- a/tests/unit/eva/stage-templates/stage-22.test.js
+++ b/tests/unit/eva/stage-templates/stage-22.test.js
@@ -19,7 +19,7 @@ describe('stage-22.js - Release Readiness template', () => {
       expect(stage22.id).toBe('stage-22');
       expect(stage22.slug).toBe('release-readiness');
       expect(stage22.title).toBe('Release Readiness');
-      expect(stage22.version).toBe('1.0.0');
+      expect(stage22.version).toBe('2.0.0');
     });
 
     it('should have schema definition', () => {


### PR DESCRIPTION
## Summary
- Add 6 active analysis step modules for THE BUILD LOOP phase (stages 17-22)
- Upgrade all 6 passive containers from v1.0.0 to v2.0.0 with `analysisStep` imports
- Rewrite Stage 22 promotion gate for v2.0 decision objects (backward-compatible with legacy booleans)
- Add `warnings` array to promotion gate for conditional states (conditional_go, conditional_pass, etc.)
- New decision objects: buildReadiness, sprintCompletion, qualityDecision, reviewDecision, releaseDecision
- New fields: architectureLayer, milestoneRef, testSuiteType, environment enum, sprintRetrospective

## Test plan
- [x] 47 new unit tests for all 6 stages + promotion gate v2.0 + backward compatibility
- [x] 219 existing tests pass (6 version assertions updated 1.0.0 → 2.0.0)
- [x] 266/266 total tests passing

SD: SD-EVA-FEAT-TEMPLATES-BUILDLOOP-001
Parent: SD-EVA-ORCH-TEMPLATE-GAPFILL-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)