### PR TITLE
fix(gates): resolve 7 systemic issues for worktree/library SDs

### DIFF
--- a/lib/utils/sd-type-validation.js
+++ b/lib/utils/sd-type-validation.js
@@ -532,9 +532,10 @@ export function autoDetectSdType(sd) {
   }
 
   // Check for infrastructure type
+  // SD-LEO-INFRA-GATE-WORKTREE-FIXES-001: Require 2+ keyword matches to prevent false reclassification
   const infraKeywords = ['ci/cd', 'pipeline', 'workflow', 'tooling', 'protocol', 'script setup', 'handoff', 'gate'];
   const infraMatches = infraKeywords.filter(kw => combinedText.includes(kw));
-  if (infraMatches.length >= 1 && !combinedText.includes('feature')) {
+  if (infraMatches.length >= 2 && !combinedText.includes('feature')) {
     return {
       detected: true,
       sd_type: 'infrastructure',
@@ -554,12 +555,16 @@ export function autoDetectSdType(sd) {
   }
 
   // Check for security type
-  if (combinedText.includes('auth') || combinedText.includes('rls') || combinedText.includes('security')) {
+  // SD-LEO-INFRA-GATE-WORKTREE-FIXES-001: Require 2+ security keywords to prevent false reclassification
+  // (e.g., 'auth' alone appears in many non-security contexts like 'authentication flow docs')
+  const securityKeywords = ['auth', 'rls', 'security', 'credential', 'vulnerability', 'owasp'];
+  const securityMatches = securityKeywords.filter(kw => combinedText.includes(kw));
+  if (securityMatches.length >= 2) {
     return {
       detected: true,
       sd_type: 'security',
       confidence: 75,
-      reason: 'Contains security/auth keywords'
+      reason: `Matched security keywords: ${securityMatches.join(', ')}`
     };
   }
 

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -158,6 +158,9 @@ export function createWorktree({ sdKey, session, branch, force = false }) {
     JSON.stringify(worktreeConfig, null, 2)
   );
 
+  // SD-LEO-INFRA-GATE-WORKTREE-FIXES-001: Propagate .env to worktree
+  propagateEnvFile(repoRoot, worktreePath);
+
   return { path: worktreePath, branch, sdKey: resolvedKey, created: true, reused: false };
 }
 
@@ -290,6 +293,9 @@ export function createWorkTypeWorktree({ workType, workKey, branch, force = fals
       repoRoot
     }, null, 2));
 
+    // SD-LEO-INFRA-GATE-WORKTREE-FIXES-001: Propagate .env to worktree
+    propagateEnvFile(repoRoot, worktreePath);
+
     logWorktreeEvent('worktree.create', { workType, workKey: sanitizedKey, mode: 'worktree', durationMs: Date.now() - startTime });
 
     return {
@@ -327,6 +333,26 @@ function generateBranchName(workType, workKey) {
     case 'QF': return `qf/${workKey}`;
     case 'ADHOC': return `adhoc/${workKey}`;
     default: return `work/${workKey}`;
+  }
+}
+
+/**
+ * Propagate .env file from repo root to worktree.
+ * SD-LEO-INFRA-GATE-WORKTREE-FIXES-001: Worktrees need .env for Supabase connections.
+ * Copies the file (symlinks unreliable on Windows).
+ * @param {string} repoRoot - Repo root path
+ * @param {string} worktreePath - Worktree destination path
+ */
+function propagateEnvFile(repoRoot, worktreePath) {
+  const sourceEnv = path.join(repoRoot, '.env');
+  const destEnv = path.join(worktreePath, '.env');
+  try {
+    if (fs.existsSync(sourceEnv) && !fs.existsSync(destEnv)) {
+      fs.copyFileSync(sourceEnv, destEnv);
+    }
+  } catch (err) {
+    // Non-fatal: log but don't fail worktree creation
+    console.error(`Warning: Could not copy .env to worktree: ${err.message}`);
   }
 }
 

--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -94,8 +94,8 @@ export async function checkBypassRateLimits(sdId, handoffType, bypassReason) {
     console.log('⚠️  BYPASS MODE ENABLED (SD-LEARN-010:US-005)');
     console.log('─'.repeat(50));
     console.log(`   Reason: ${bypassReason}`);
-    console.log(`   SD Bypasses Today: ${(sdBypasses?.length || 0) + 1}/3`);
-    console.log(`   Global Bypasses Today: ${(globalBypasses?.length || 0) + 1}/10`);
+    console.log(`   SD Bypasses Today: ${(sdBypasses?.length || 0) + 1}/10`);
+    console.log(`   Global Bypasses Today: ${(globalBypasses?.length || 0) + 1}/2000`);
     console.log('   ⚠️  Bypass logged to validation_audit_log for review');
     console.log('─'.repeat(50));
   }

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js
@@ -20,10 +20,13 @@ export async function validateTargetApplication(sd, supabase) {
   const combinedText = `${scope} ${title}`;
 
   // Patterns that indicate EHG_Engineer (LEO Protocol infrastructure)
+  // SD-LEO-INFRA-GATE-WORKTREE-FIXES-001: Added EVA template/library paths
   const engineerPatterns = [
     'claude.md', 'claude_', 'leo protocol', 'handoff.js', 'phase-preflight',
     'sub-agent', 'subagent', 'leo_protocol', 'retrospective', 'verification gate',
-    'handoff system', 'bmad', 'scripts/modules', 'lib/sub-agents'
+    'handoff system', 'bmad', 'scripts/modules', 'lib/sub-agents',
+    'lib/eva', 'eva/stage-template', 'stage-template', 'eva template',
+    'eva analysis', 'lib/llm', 'lib/team', 'lib/utils', 'lib/telemetry'
   ];
 
   // Patterns that indicate EHG (main application)

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/exploration-audit.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/exploration-audit.js
@@ -71,17 +71,26 @@ export async function validateExplorationAudit(prdRepo, sd) {
     }
 
     // Check for exploration_summary in multiple locations (backward compatibility)
-    // Priority: top-level > metadata.exploration_summary > metadata.files_explored
+    // SD-LEO-INFRA-GATE-WORKTREE-FIXES-001: Handle both array and object formats
+    // Priority: top-level > metadata.exploration_summary > metadata.files_explored > SD metadata
     let filesExplored = [];
     let source = 'none';
 
     if (prd.exploration_summary && Array.isArray(prd.exploration_summary)) {
       filesExplored = prd.exploration_summary;
       source = 'exploration_summary';
+    } else if (prd.exploration_summary && typeof prd.exploration_summary === 'object' && prd.exploration_summary.files_explored) {
+      // Object format: { files_explored: [...], summary: "..." }
+      filesExplored = Array.isArray(prd.exploration_summary.files_explored) ? prd.exploration_summary.files_explored : [];
+      source = 'exploration_summary.files_explored';
     } else if (prd.metadata?.exploration_summary && Array.isArray(prd.metadata.exploration_summary)) {
       // SYSTEMIC FIX: Also check metadata.exploration_summary (common storage location)
       filesExplored = prd.metadata.exploration_summary;
       source = 'metadata.exploration_summary';
+    } else if (prd.metadata?.exploration_summary && typeof prd.metadata.exploration_summary === 'object' && prd.metadata.exploration_summary.files_explored) {
+      // Object format in metadata
+      filesExplored = Array.isArray(prd.metadata.exploration_summary.files_explored) ? prd.metadata.exploration_summary.files_explored : [];
+      source = 'metadata.exploration_summary.files_explored';
     } else if (prd.metadata?.files_explored && Array.isArray(prd.metadata.files_explored)) {
       filesExplored = prd.metadata.files_explored;
       source = 'metadata.files_explored';

--- a/scripts/modules/handoff/validation/sd-type-applicability-policy.js
+++ b/scripts/modules/handoff/validation/sd-type-applicability-policy.js
@@ -581,7 +581,23 @@ export function checkSkipCondition(validatorName, context, options = {}) {
     return decision;
   }
 
-  // Check 4: Already completed (if context provides completion info)
+  // Check 4: Library-only SDs skip UI/DESIGN gates
+  // SD-LEO-INFRA-GATE-WORKTREE-FIXES-001: Feature SDs that only modify lib/ files
+  // (e.g., EVA templates) should not require DESIGN validation
+  const uiDesignValidators = ['DESIGN', 'UI_REVIEW', 'ACCESSIBILITY', 'RESPONSIVE'];
+  const implementationContext = sd?.metadata?.implementation_context || sd?.metadata?.scope_type;
+  if (uiDesignValidators.includes(validatorName.toUpperCase()) && implementationContext === 'library-only') {
+    decision.shouldSkip = true;
+    decision.reason = SkipReasonCode.NON_APPLICABLE_SD_TYPE;
+    decision.result = createSkippedResult(validatorName, sdType, `Library-only implementation: no UI components`);
+
+    if (logDecision) {
+      console.log(`   ⏭️  SKIP ${validatorName}: Library-only SD (no UI components)`);
+    }
+    return decision;
+  }
+
+  // Check 5: Already completed (if context provides completion info)
   if (context?.completedValidators?.includes(validatorName)) {
     decision.shouldSkip = true;
     decision.reason = SkipReasonCode.ALREADY_COMPLETED;


### PR DESCRIPTION
## Summary
- **P0**: Fix `BaseExecutor.getRepoPath()` to use `git rev-parse --show-toplevel` for worktree-safe path resolution
- **P0**: Auto-propagate `.env` file when creating worktrees (prevents Supabase connection failures)
- **P0**: Add EVA/lib path patterns to `target-application.js` for correct `target_application` detection
- **P1**: Handle object format for `exploration_summary` in exploration audit gate (not just arrays)
- **P2**: Add `implementation_context: library-only` support to skip DESIGN gates for library-only SDs
- **P2**: Require 2+ keyword matches for infrastructure/security auto-detection (prevents false reclassification)
- **P3**: Fix bypass counter display to show actual limits (10/2000 not 3/10)

## Files Changed (7)
| File | Fix |
|------|-----|
| `scripts/modules/handoff/executors/BaseExecutor.js` | Worktree-safe path resolution |
| `lib/worktree-manager.js` | .env propagation to worktrees |
| `scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js` | EVA/lib path patterns |
| `scripts/modules/handoff/executors/plan-to-exec/gates/exploration-audit.js` | Object format handling |
| `scripts/modules/handoff/validation/sd-type-applicability-policy.js` | Library-only SD awareness |
| `lib/utils/sd-type-validation.js` | Keyword threshold fix |
| `scripts/modules/handoff/cli/execution-helpers.js` | Bypass counter display |

## Test plan
- [x] All 7 files modified within scope (~90 LOC)
- [x] LEAD-TO-PLAN approved at 97%
- [x] PLAN-TO-EXEC approved at 97%
- [x] EXEC-TO-PLAN approved at 93%
- [x] PLAN-TO-LEAD approved at 95%
- [x] LEAD-FINAL-APPROVAL approved at 97%

SD-LEO-INFRA-GATE-WORKTREE-FIXES-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)