### PR TITLE
feat(eva): add analysis steps for LAUNCH & LEARN stages 23-25

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/index.js
+++ b/lib/eva/stage-templates/analysis-steps/index.js
@@ -1,6 +1,6 @@
 /**
- * Analysis Steps Registry - Stages 1-22
- * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (1-5), ENGINE-001 (6-9), IDENTITY-001 (10-12), BLUEPRINT-001 (13-16), BUILDLOOP-001 (17-22)
+ * Analysis Steps Registry - Stages 1-25
+ * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001 (1-5), ENGINE-001 (6-9), IDENTITY-001 (10-12), BLUEPRINT-001 (13-16), BUILDLOOP-001 (17-22), LAUNCH-001 (23-25)
  *
  * Provides the active analysis layer for stage templates.
  * Each analysisStep consumes upstream artifacts and generates
@@ -41,8 +41,13 @@ export { analyzeStage20 } from './stage-20-quality-assurance.js';
 export { analyzeStage21 } from './stage-21-build-review.js';
 export { analyzeStage22 } from './stage-22-release-readiness.js';
 
+// LAUNCH & LEARN (Stages 23-25)
+export { analyzeStage23 } from './stage-23-launch-execution.js';
+export { analyzeStage24 } from './stage-24-metrics-learning.js';
+export { analyzeStage25 } from './stage-25-venture-review.js';
+
 /**
- * Get the analysis step function for a given stage number (1-22).
+ * Get the analysis step function for a given stage number (1-25).
  * @param {number} stageNumber
  * @returns {Promise<Function|null>}
  */
@@ -70,6 +75,9 @@ export async function getAnalysisStep(stageNumber) {
     20: () => import('./stage-20-quality-assurance.js').then(m => m.analyzeStage20),
     21: () => import('./stage-21-build-review.js').then(m => m.analyzeStage21),
     22: () => import('./stage-22-release-readiness.js').then(m => m.analyzeStage22),
+    23: () => import('./stage-23-launch-execution.js').then(m => m.analyzeStage23),
+    24: () => import('./stage-24-metrics-learning.js').then(m => m.analyzeStage24),
+    25: () => import('./stage-25-venture-review.js').then(m => m.analyzeStage25),
   };
   const loader = loaders[stageNumber];
   return loader ? loader() : null;

--- a/lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js
@@ -1,0 +1,197 @@
+/**
+ * Stage 23 Analysis Step - Launch Execution (LAUNCH & LEARN)
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-EVA-FEAT-TEMPLATES-LAUNCH-001
+ *
+ * Consumes Stage 22 release readiness data and generates a launch brief
+ * with success criteria as a contract with Stage 24.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-23-launch-execution
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const LAUNCH_TYPES = ['soft_launch', 'beta', 'general_availability'];
+const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
+const CRITERION_PRIORITIES = ['primary', 'secondary'];
+
+const SYSTEM_PROMPT = `You are EVA's Launch Execution Analyst. Synthesize Stage 22 release readiness data into a launch brief with success criteria.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "launchType": "soft_launch|beta|general_availability",
+  "launchBrief": "2-4 sentence summary of what is being launched and why",
+  "successCriteria": [
+    {
+      "metric": "Name of the metric to track",
+      "target": "Specific measurable target (e.g., '100 signups in 7 days')",
+      "measurementWindow": "Time window for measurement (e.g., '7 days', '30 days')",
+      "priority": "primary|secondary"
+    }
+  ],
+  "rollbackTriggers": [
+    {
+      "condition": "When this condition is met, rollback should be considered",
+      "severity": "critical|warning"
+    }
+  ],
+  "launchTasks": [
+    {
+      "name": "Task description",
+      "owner": "Role responsible",
+      "status": "pending|in_progress|done|blocked"
+    }
+  ],
+  "plannedLaunchDate": "YYYY-MM-DD"
+}
+
+Rules:
+- launchType should reflect the venture's maturity and release scope
+- At least 2 success criteria required (at least 1 primary)
+- At least 1 rollback trigger required
+- At least 1 launch task required
+- plannedLaunchDate should be reasonable (within 1-4 weeks)
+- Success criteria become the contract with Stage 24 for evaluation`;
+
+/**
+ * Generate launch execution brief from Stage 22 release readiness data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage22Data - Release readiness (releaseDecision, releaseItems, etc.)
+ * @param {Object} [params.stage01Data] - Venture hydration (successCriteria from Stage 1)
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Launch brief with success criteria and tasks
+ */
+export async function analyzeStage23({ stage22Data, stage01Data, ventureName }) {
+  if (!stage22Data) {
+    throw new Error('Stage 23 launch execution requires Stage 22 (release readiness) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const releaseContext = stage22Data.releaseDecision
+    ? `Release: ${stage22Data.releaseDecision.decision} — ${stage22Data.releaseDecision.rationale}`
+    : '';
+
+  const itemsContext = Array.isArray(stage22Data.releaseItems)
+    ? `Items: ${stage22Data.releaseItems.map(ri => `${ri.name} (${ri.status})`).join(', ')}`
+    : '';
+
+  const retroContext = stage22Data.sprintRetrospective
+    ? `Retro highlights: ${(stage22Data.sprintRetrospective.wentWell || []).slice(0, 2).join('; ')}`
+    : '';
+
+  const stage1Criteria = stage01Data?.successCriteria
+    ? `Stage 1 success criteria: ${JSON.stringify(stage01Data.successCriteria)}`
+    : '';
+
+  const userPrompt = `Generate launch execution brief for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+${releaseContext}
+${itemsContext}
+${retroContext}
+${stage1Criteria}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize launchType
+  const launchType = LAUNCH_TYPES.includes(parsed.launchType)
+    ? parsed.launchType
+    : 'soft_launch';
+
+  // Normalize launch brief
+  const launchBrief = String(parsed.launchBrief || 'Launch brief pending.').substring(0, 1000);
+
+  // Normalize success criteria
+  let successCriteria = Array.isArray(parsed.successCriteria)
+    ? parsed.successCriteria.filter(sc => sc?.metric)
+    : [];
+
+  if (successCriteria.length < 2) {
+    successCriteria = [
+      { metric: 'User signups', target: '50 in first week', measurementWindow: '7 days', priority: 'primary' },
+      { metric: 'Error rate', target: 'Below 5%', measurementWindow: '7 days', priority: 'secondary' },
+    ];
+  } else {
+    successCriteria = successCriteria.map(sc => ({
+      metric: String(sc.metric).substring(0, 200),
+      target: String(sc.target || 'TBD').substring(0, 200),
+      measurementWindow: String(sc.measurementWindow || '30 days').substring(0, 100),
+      priority: CRITERION_PRIORITIES.includes(sc.priority) ? sc.priority : 'secondary',
+    }));
+  }
+
+  // Ensure at least one primary criterion
+  if (!successCriteria.some(sc => sc.priority === 'primary')) {
+    successCriteria[0].priority = 'primary';
+  }
+
+  // Normalize rollback triggers
+  let rollbackTriggers = Array.isArray(parsed.rollbackTriggers)
+    ? parsed.rollbackTriggers.filter(rt => rt?.condition)
+    : [];
+
+  if (rollbackTriggers.length === 0) {
+    rollbackTriggers = [{
+      condition: 'Error rate exceeds 10% for 1 hour',
+      severity: 'critical',
+    }];
+  } else {
+    rollbackTriggers = rollbackTriggers.map(rt => ({
+      condition: String(rt.condition).substring(0, 300),
+      severity: ['critical', 'warning'].includes(rt.severity) ? rt.severity : 'warning',
+    }));
+  }
+
+  // Normalize launch tasks
+  let launchTasks = Array.isArray(parsed.launchTasks)
+    ? parsed.launchTasks.filter(lt => lt?.name)
+    : [];
+
+  if (launchTasks.length === 0) {
+    launchTasks = [{
+      name: 'Execute launch checklist',
+      owner: 'Product Owner',
+      status: 'pending',
+    }];
+  } else {
+    launchTasks = launchTasks.map(lt => ({
+      name: String(lt.name).substring(0, 200),
+      owner: String(lt.owner || 'Unassigned').substring(0, 200),
+      status: TASK_STATUSES.includes(lt.status) ? lt.status : 'pending',
+    }));
+  }
+
+  // Normalize planned launch date
+  const plannedLaunchDate = parsed.plannedLaunchDate && /^\d{4}-\d{2}-\d{2}$/.test(parsed.plannedLaunchDate)
+    ? parsed.plannedLaunchDate
+    : new Date(Date.now() + 14 * 86400000).toISOString().split('T')[0];
+
+  return {
+    launchType,
+    launchBrief,
+    successCriteria,
+    rollbackTriggers,
+    launchTasks,
+    plannedLaunchDate,
+    totalTasks: launchTasks.length,
+    blockedTasks: launchTasks.filter(lt => lt.status === 'blocked').length,
+    primaryCriteria: successCriteria.filter(sc => sc.priority === 'primary').length,
+    totalCriteria: successCriteria.length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse launch execution response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { LAUNCH_TYPES, TASK_STATUSES, CRITERION_PRIORITIES };

--- a/lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js
@@ -1,0 +1,223 @@
+/**
+ * Stage 24 Analysis Step - Metrics & Learning (Launch Scorecard)
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-EVA-FEAT-TEMPLATES-LAUNCH-001
+ *
+ * Evaluates Stage 23 success criteria against AARRR metrics.
+ * Produces launch scorecard with per-criterion assessment.
+ * Interprets metrics in context of launchType.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', 'referral'];
+const TREND_DIRECTIONS = ['up', 'flat', 'down'];
+const OUTCOME_ASSESSMENTS = ['success', 'partial', 'failure', 'indeterminate'];
+const IMPACT_LEVELS = ['high', 'medium', 'low'];
+
+const SYSTEM_PROMPT = `You are EVA's Metrics & Learning Analyst. Evaluate launch success criteria against AARRR metrics and produce a launch scorecard.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "aarrr": {
+    "acquisition": [{ "name": "Metric name", "value": 100, "target": 200, "trendDirection": "up|flat|down" }],
+    "activation": [{ "name": "Metric name", "value": 50, "target": 60, "trendDirection": "up|flat|down" }],
+    "retention": [{ "name": "Metric name", "value": 30, "target": 40, "trendDirection": "up|flat|down" }],
+    "revenue": [{ "name": "Metric name", "value": 1000, "target": 5000, "trendDirection": "up|flat|down" }],
+    "referral": [{ "name": "Metric name", "value": 5, "target": 10, "trendDirection": "up|flat|down" }]
+  },
+  "criteriaEvaluation": [
+    {
+      "metric": "Success criterion metric name (from Stage 23)",
+      "target": "The target from Stage 23",
+      "actual": "What was actually achieved",
+      "met": true,
+      "notes": "Brief explanation"
+    }
+  ],
+  "learnings": [
+    {
+      "insight": "What was learned",
+      "action": "What to do about it",
+      "impactLevel": "high|medium|low"
+    }
+  ],
+  "launchOutcome": {
+    "assessment": "success|partial|failure|indeterminate",
+    "criteriaMetRate": 75,
+    "summary": "1-2 sentence summary of launch outcome"
+  }
+}
+
+Rules:
+- Each AARRR category must have at least 1 metric
+- criteriaEvaluation must reference Stage 23 success criteria
+- At least 1 learning required
+- launchOutcome.criteriaMetRate = percentage of criteria met (0-100)
+- For beta launches, lower targets are acceptable
+- trendDirection reflects whether the metric is improving`;
+
+/**
+ * Generate launch scorecard from Stage 23 success criteria and AARRR metrics.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage23Data - Launch execution data (successCriteria, launchType)
+ * @param {Object} [params.stage05Data] - Financial model (projected metrics)
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Launch scorecard with AARRR metrics and outcome
+ */
+export async function analyzeStage24({ stage23Data, stage05Data, ventureName }) {
+  if (!stage23Data) {
+    throw new Error('Stage 24 metrics & learning requires Stage 23 (launch execution) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const criteriaContext = Array.isArray(stage23Data.successCriteria)
+    ? `Success criteria from Stage 23:\n${stage23Data.successCriteria.map(sc => `- ${sc.metric}: ${sc.target} (${sc.priority}, window: ${sc.measurementWindow})`).join('\n')}`
+    : '';
+
+  const launchContext = stage23Data.launchType
+    ? `Launch type: ${stage23Data.launchType}`
+    : '';
+
+  const financialContext = stage05Data
+    ? `Stage 5 financial projections available for comparison`
+    : '';
+
+  const userPrompt = `Generate launch scorecard for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+${launchContext}
+${criteriaContext}
+${financialContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize AARRR metrics
+  const aarrr = {};
+  for (const cat of AARRR_CATEGORIES) {
+    const metrics = Array.isArray(parsed.aarrr?.[cat])
+      ? parsed.aarrr[cat].filter(m => m?.name)
+      : [];
+
+    if (metrics.length === 0) {
+      aarrr[cat] = [{
+        name: `${cat} metric`,
+        value: 0,
+        target: 1,
+        trendDirection: 'flat',
+      }];
+    } else {
+      aarrr[cat] = metrics.map(m => ({
+        name: String(m.name).substring(0, 200),
+        value: typeof m.value === 'number' ? m.value : 0,
+        target: typeof m.target === 'number' ? m.target : 1,
+        trendDirection: TREND_DIRECTIONS.includes(m.trendDirection) ? m.trendDirection : 'flat',
+      }));
+    }
+  }
+
+  // Normalize criteria evaluation
+  let criteriaEvaluation = Array.isArray(parsed.criteriaEvaluation)
+    ? parsed.criteriaEvaluation.filter(ce => ce?.metric)
+    : [];
+
+  criteriaEvaluation = criteriaEvaluation.map(ce => ({
+    metric: String(ce.metric).substring(0, 200),
+    target: String(ce.target || 'Not specified').substring(0, 200),
+    actual: String(ce.actual || 'Not measured').substring(0, 200),
+    met: typeof ce.met === 'boolean' ? ce.met : false,
+    notes: String(ce.notes || '').substring(0, 300),
+  }));
+
+  // Normalize learnings
+  let learnings = Array.isArray(parsed.learnings)
+    ? parsed.learnings.filter(l => l?.insight)
+    : [];
+
+  if (learnings.length === 0) {
+    learnings = [{
+      insight: 'Launch metrics collected for baseline',
+      action: 'Review metrics in next cycle',
+      impactLevel: 'medium',
+    }];
+  } else {
+    learnings = learnings.map(l => ({
+      insight: String(l.insight).substring(0, 300),
+      action: String(l.action).substring(0, 300),
+      impactLevel: IMPACT_LEVELS.includes(l.impactLevel) ? l.impactLevel : 'medium',
+    }));
+  }
+
+  // Normalize launch outcome
+  const lo = parsed.launchOutcome || {};
+  const criteriaMet = criteriaEvaluation.filter(ce => ce.met).length;
+  const criteriaMetRate = criteriaEvaluation.length > 0
+    ? Math.round((criteriaMet / criteriaEvaluation.length) * 100)
+    : (typeof lo.criteriaMetRate === 'number' ? lo.criteriaMetRate : 0);
+
+  let assessment;
+  if (OUTCOME_ASSESSMENTS.includes(lo.assessment)) {
+    assessment = lo.assessment;
+  } else if (criteriaMetRate >= 80) {
+    assessment = 'success';
+  } else if (criteriaMetRate >= 50) {
+    assessment = 'partial';
+  } else if (criteriaEvaluation.length === 0) {
+    assessment = 'indeterminate';
+  } else {
+    assessment = 'failure';
+  }
+
+  const launchOutcome = {
+    assessment,
+    criteriaMetRate,
+    summary: String(lo.summary || `Launch ${assessment}: ${criteriaMetRate}% of criteria met`).substring(0, 500),
+  };
+
+  // Compute derived metrics
+  let totalMetrics = 0;
+  let metricsOnTarget = 0;
+  let metricsBelowTarget = 0;
+  let categoriesComplete = 0;
+
+  for (const cat of AARRR_CATEGORIES) {
+    const metrics = aarrr[cat];
+    if (metrics.length > 0) categoriesComplete++;
+    totalMetrics += metrics.length;
+    for (const m of metrics) {
+      if (m.value >= m.target) metricsOnTarget++;
+      else metricsBelowTarget++;
+    }
+  }
+
+  return {
+    aarrr,
+    criteriaEvaluation,
+    learnings,
+    launchOutcome,
+    totalMetrics,
+    metricsOnTarget,
+    metricsBelowTarget,
+    categoriesComplete: categoriesComplete === AARRR_CATEGORIES.length,
+    totalLearnings: learnings.length,
+    highImpactLearnings: learnings.filter(l => l.impactLevel === 'high').length,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse metrics & learning response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { AARRR_CATEGORIES, TREND_DIRECTIONS, OUTCOME_ASSESSMENTS, IMPACT_LEVELS };

--- a/lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js
@@ -1,0 +1,262 @@
+/**
+ * Stage 25 Analysis Step - Venture Review (Capstone)
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-EVA-FEAT-TEMPLATES-LAUNCH-001
+ *
+ * The most complex analysis step in the pipeline.
+ * Consumes Stages 1 (origin vision), 5/16 (projections), 13 (roadmap),
+ * 20-22 (quality/review/release), 23 (launch), 24 (metrics).
+ * Produces: journey summary, financial comparison, drift analysis,
+ * venture health assessment, and decision recommendation.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-25-venture-review
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+
+const VENTURE_DECISIONS = ['continue', 'pivot', 'expand', 'sunset', 'exit'];
+const HEALTH_RATINGS = ['excellent', 'good', 'fair', 'poor', 'critical'];
+const REVIEW_CATEGORIES = ['product', 'market', 'technical', 'financial', 'team'];
+
+const SYSTEM_PROMPT = `You are EVA's Venture Review Analyst conducting the capstone Stage 25 review. Synthesize the ENTIRE venture journey into a comprehensive decision recommendation.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "journeySummary": "3-5 sentence narrative of the venture's journey from idea to launch",
+  "financialComparison": {
+    "projectedRevenue": "From Stage 5/16 financial projections",
+    "actualRevenue": "From Stage 24 metrics",
+    "projectedCosts": "From Stage 5/16",
+    "actualCosts": "From Stage 24",
+    "variance": "Summary of variance between projected and actual",
+    "assessment": "On track / Below expectations / Above expectations"
+  },
+  "ventureHealth": {
+    "overallRating": "excellent|good|fair|poor|critical",
+    "dimensions": {
+      "product": { "score": 8, "rationale": "Brief explanation" },
+      "market": { "score": 7, "rationale": "Brief explanation" },
+      "technical": { "score": 9, "rationale": "Brief explanation" },
+      "financial": { "score": 6, "rationale": "Brief explanation" },
+      "team": { "score": 7, "rationale": "Brief explanation" }
+    }
+  },
+  "driftAnalysis": {
+    "originalVision": "From Stage 1",
+    "currentState": "Current venture state",
+    "driftDetected": true,
+    "driftSummary": "Description of how the venture has evolved from original vision"
+  },
+  "ventureDecision": {
+    "recommendation": "continue|pivot|expand|sunset|exit",
+    "confidence": 85,
+    "rationale": "2-3 sentence justification for the recommendation",
+    "nextActions": ["Action 1", "Action 2"]
+  },
+  "initiatives": {
+    "product": [{ "title": "Initiative", "status": "completed|in_progress|planned", "outcome": "Result" }],
+    "market": [{ "title": "Initiative", "status": "completed", "outcome": "Result" }],
+    "technical": [{ "title": "Initiative", "status": "completed", "outcome": "Result" }],
+    "financial": [{ "title": "Initiative", "status": "completed", "outcome": "Result" }],
+    "team": [{ "title": "Initiative", "status": "completed", "outcome": "Result" }]
+  }
+}
+
+Rules:
+- journeySummary must reference specific stages/phases
+- financialComparison must include both projected and actual data
+- ventureHealth dimensions scored 1-10
+- Each initiatives category must have at least 1 entry
+- ventureDecision.confidence is 0-100
+- Decision should be based on financial, health, and metric data
+- "continue" = proceed with next BUILD LOOP iteration
+- "pivot" = revisit ENGINE/IDENTITY phases
+- "expand" = scale current venture
+- "sunset" = wind down gracefully
+- "exit" = lifecycle complete (sale, shutdown, or spinoff)`;
+
+/**
+ * Generate comprehensive venture review from full lifecycle data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage24Data - Metrics & learning (AARRR, launch outcome)
+ * @param {Object} [params.stage23Data] - Launch execution (success criteria)
+ * @param {Object} [params.stage01Data] - Venture hydration (original vision)
+ * @param {Object} [params.stage05Data] - Financial model (projections)
+ * @param {Object} [params.stage16Data] - Financial projections (detailed)
+ * @param {Object} [params.stage13Data] - Product roadmap
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Comprehensive venture review with decision
+ */
+export async function analyzeStage25({ stage24Data, stage23Data, stage01Data, stage05Data, stage16Data, stage13Data, ventureName }) {
+  if (!stage24Data) {
+    throw new Error('Stage 25 venture review requires Stage 24 (metrics & learning) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const metricsContext = stage24Data.launchOutcome
+    ? `Launch outcome: ${stage24Data.launchOutcome.assessment} (${stage24Data.launchOutcome.criteriaMetRate}% criteria met)`
+    : '';
+
+  const learningsContext = Array.isArray(stage24Data.learnings)
+    ? `Key learnings: ${stage24Data.learnings.slice(0, 3).map(l => l.insight).join('; ')}`
+    : '';
+
+  const stage1Context = stage01Data
+    ? `Original vision: ${stage01Data.venture_name || 'Unknown'} — ${stage01Data.elevator_pitch || 'No pitch'}`
+    : '';
+
+  const financialContext = stage05Data
+    ? `Stage 5 financial projections available`
+    : '';
+
+  const projectionContext = stage16Data
+    ? `Stage 16 detailed projections available`
+    : '';
+
+  const roadmapContext = stage13Data
+    ? `Stage 13 product roadmap available`
+    : '';
+
+  const launchContext = stage23Data
+    ? `Launch type: ${stage23Data.launchType || 'unknown'}, Tasks: ${stage23Data.totalTasks || 0}`
+    : '';
+
+  const userPrompt = `Generate comprehensive venture review (Stage 25 capstone).
+
+Venture: ${ventureName || 'Unnamed'}
+${stage1Context}
+${launchContext}
+${metricsContext}
+${learningsContext}
+${financialContext}
+${projectionContext}
+${roadmapContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const parsed = parseJSON(response);
+
+  // Normalize journey summary
+  const journeySummary = String(parsed.journeySummary || 'Venture journey summary pending review.').substring(0, 2000);
+
+  // Normalize financial comparison
+  const fc = parsed.financialComparison || {};
+  const financialComparison = {
+    projectedRevenue: String(fc.projectedRevenue || 'Not available').substring(0, 200),
+    actualRevenue: String(fc.actualRevenue || 'Not measured').substring(0, 200),
+    projectedCosts: String(fc.projectedCosts || 'Not available').substring(0, 200),
+    actualCosts: String(fc.actualCosts || 'Not measured').substring(0, 200),
+    variance: String(fc.variance || 'Variance analysis pending').substring(0, 500),
+    assessment: String(fc.assessment || 'Assessment pending').substring(0, 200),
+  };
+
+  // Normalize venture health
+  const vh = parsed.ventureHealth || {};
+  const dimensions = {};
+  for (const cat of REVIEW_CATEGORIES) {
+    const dim = vh.dimensions?.[cat] || {};
+    dimensions[cat] = {
+      score: typeof dim.score === 'number' ? Math.max(1, Math.min(10, Math.round(dim.score))) : 5,
+      rationale: String(dim.rationale || `${cat} assessment pending`).substring(0, 300),
+    };
+  }
+
+  const avgScore = REVIEW_CATEGORIES.reduce((sum, cat) => sum + dimensions[cat].score, 0) / REVIEW_CATEGORIES.length;
+  let overallRating;
+  if (HEALTH_RATINGS.includes(vh.overallRating)) {
+    overallRating = vh.overallRating;
+  } else if (avgScore >= 8.5) {
+    overallRating = 'excellent';
+  } else if (avgScore >= 7) {
+    overallRating = 'good';
+  } else if (avgScore >= 5) {
+    overallRating = 'fair';
+  } else if (avgScore >= 3) {
+    overallRating = 'poor';
+  } else {
+    overallRating = 'critical';
+  }
+
+  const ventureHealth = { overallRating, dimensions };
+
+  // Normalize drift analysis
+  const da = parsed.driftAnalysis || {};
+  const driftAnalysis = {
+    originalVision: String(da.originalVision || stage01Data?.elevator_pitch || 'Not available').substring(0, 500),
+    currentState: String(da.currentState || 'Current state assessment pending').substring(0, 500),
+    driftDetected: typeof da.driftDetected === 'boolean' ? da.driftDetected : false,
+    driftSummary: String(da.driftSummary || 'No significant drift detected').substring(0, 500),
+  };
+
+  // Normalize venture decision
+  const vd = parsed.ventureDecision || {};
+  const recommendation = VENTURE_DECISIONS.includes(vd.recommendation)
+    ? vd.recommendation
+    : 'continue';
+  const confidence = typeof vd.confidence === 'number'
+    ? Math.max(0, Math.min(100, Math.round(vd.confidence)))
+    : 50;
+
+  const ventureDecision = {
+    recommendation,
+    confidence,
+    rationale: String(vd.rationale || `Recommended ${recommendation} based on available data`).substring(0, 500),
+    nextActions: Array.isArray(vd.nextActions) && vd.nextActions.length > 0
+      ? vd.nextActions.map(a => String(a).substring(0, 200))
+      : ['Review venture metrics in next cycle'],
+  };
+
+  // Normalize initiatives
+  const initiatives = {};
+  let totalInitiatives = 0;
+  let categoriesReviewed = 0;
+
+  for (const cat of REVIEW_CATEGORIES) {
+    const items = Array.isArray(parsed.initiatives?.[cat])
+      ? parsed.initiatives[cat].filter(i => i?.title)
+      : [];
+
+    if (items.length === 0) {
+      initiatives[cat] = [{
+        title: `${cat} initiative review pending`,
+        status: 'planned',
+        outcome: 'Pending review',
+      }];
+    } else {
+      initiatives[cat] = items.map(i => ({
+        title: String(i.title).substring(0, 200),
+        status: String(i.status || 'planned').substring(0, 50),
+        outcome: String(i.outcome || 'Pending').substring(0, 300),
+      }));
+    }
+
+    totalInitiatives += initiatives[cat].length;
+    categoriesReviewed++;
+  }
+
+  return {
+    journeySummary,
+    financialComparison,
+    ventureHealth,
+    driftAnalysis,
+    ventureDecision,
+    initiatives,
+    totalInitiatives,
+    allCategoriesReviewed: categoriesReviewed === REVIEW_CATEGORIES.length,
+    healthScore: Math.round(avgScore * 10) / 10,
+  };
+}
+
+function parseJSON(text) {
+  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    throw new Error(`Failed to parse venture review response: ${cleaned.substring(0, 200)}`);
+  }
+}
+
+export { VENTURE_DECISIONS, HEALTH_RATINGS, REVIEW_CATEGORIES };

--- a/lib/eva/stage-templates/stage-23.js
+++ b/lib/eva/stage-templates/stage-23.js
@@ -14,6 +14,7 @@
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { analyzeStage23 } from './analysis-steps/stage-23-launch-execution.js';
 
 const GO_DECISIONS = ['go', 'no-go'];
 const MIN_LAUNCH_TASKS = 1;
@@ -145,6 +146,8 @@ export function evaluateKillGate({ go_decision, incident_response_plan, monitori
   const decision = reasons.length > 0 ? 'kill' : 'pass';
   return { decision, blockProgression: decision === 'kill', reasons };
 }
+
+TEMPLATE.analysisStep = analyzeStage23;
 
 export { GO_DECISIONS, MIN_LAUNCH_TASKS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-24.js
+++ b/lib/eva/stage-templates/stage-24.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateNumber, validateArray, collectErrors } from './validation.js';
+import { analyzeStage24 } from './analysis-steps/stage-24-metrics-learning.js';
 
 const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', 'referral'];
 const MIN_METRICS_PER_CATEGORY = 1;
@@ -154,6 +155,8 @@ const TEMPLATE = {
     };
   },
 };
+
+TEMPLATE.analysisStep = analyzeStage24;
 
 export { AARRR_CATEGORIES, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -11,6 +11,7 @@
  */
 
 import { validateString, validateArray, collectErrors } from './validation.js';
+import { analyzeStage25 } from './analysis-steps/stage-25-venture-review.js';
 
 const REVIEW_CATEGORIES = ['product', 'market', 'technical', 'financial', 'team'];
 const MIN_INITIATIVES_PER_CATEGORY = 1;
@@ -190,6 +191,8 @@ export function detectDrift({ original_vision, current_vision }) {
 
   return { drift_detected, rationale, original_vision, current_vision };
 }
+
+TEMPLATE.analysisStep = analyzeStage25;
 
 export { REVIEW_CATEGORIES, MIN_INITIATIVES_PER_CATEGORY };
 export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-23-launch-execution.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-23-launch-execution.test.js
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for Stage 23 Analysis Step - Launch Execution
+ * Part of SD-EVA-FEAT-TEMPLATES-LAUNCH-001
+ *
+ * @module tests/unit/eva/stage-templates/analysis-steps/stage-23-launch-execution.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+import { analyzeStage23, LAUNCH_TYPES, TASK_STATUSES, CRITERION_PRIORITIES } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+function createLLMResponse(overrides = {}) {
+  const base = {
+    launchType: 'beta',
+    launchBrief: 'Launching the MVP to a closed beta group of 50 users for initial feedback.',
+    successCriteria: [
+      { metric: 'User signups', target: '50 in 7 days', measurementWindow: '7 days', priority: 'primary' },
+      { metric: 'Error rate', target: 'Below 5%', measurementWindow: '7 days', priority: 'secondary' },
+      { metric: 'NPS score', target: 'Above 30', measurementWindow: '14 days', priority: 'secondary' },
+    ],
+    rollbackTriggers: [
+      { condition: 'Error rate exceeds 10% for 1 hour', severity: 'critical' },
+      { condition: 'Zero signups in first 48 hours', severity: 'warning' },
+    ],
+    launchTasks: [
+      { name: 'Deploy to production', owner: 'Engineering', status: 'done' },
+      { name: 'Send beta invites', owner: 'Marketing', status: 'pending' },
+      { name: 'Configure monitoring', owner: 'DevOps', status: 'in_progress' },
+    ],
+    plannedLaunchDate: '2026-03-01',
+    ...overrides,
+  };
+  return JSON.stringify(base);
+}
+
+function setupMock(responseOverrides = {}) {
+  const mockComplete = vi.fn().mockResolvedValue(createLLMResponse(responseOverrides));
+  getLLMClient.mockReturnValue({ complete: mockComplete });
+  return mockComplete;
+}
+
+const VALID_PARAMS = {
+  stage22Data: {
+    releaseDecision: { decision: 'release', rationale: 'QA passed' },
+    releaseItems: [{ name: 'Feature A', status: 'approved' }],
+    sprintRetrospective: { wentWell: ['Velocity improved'] },
+  },
+};
+
+describe('stage-23-launch-execution.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Exported constants', () => {
+    it('should export LAUNCH_TYPES', () => {
+      expect(LAUNCH_TYPES).toEqual(['soft_launch', 'beta', 'general_availability']);
+    });
+
+    it('should export TASK_STATUSES', () => {
+      expect(TASK_STATUSES).toEqual(['pending', 'in_progress', 'done', 'blocked']);
+    });
+
+    it('should export CRITERION_PRIORITIES', () => {
+      expect(CRITERION_PRIORITIES).toEqual(['primary', 'secondary']);
+    });
+  });
+
+  describe('Input validation', () => {
+    it('should throw when stage22Data is missing', async () => {
+      await expect(analyzeStage23({})).rejects.toThrow('Stage 23 launch execution requires Stage 22');
+    });
+  });
+
+  describe('Launch type normalization', () => {
+    it('should accept valid launch types', async () => {
+      for (const lt of LAUNCH_TYPES) {
+        setupMock({ launchType: lt });
+        const result = await analyzeStage23(VALID_PARAMS);
+        expect(result.launchType).toBe(lt);
+      }
+    });
+
+    it('should default to soft_launch for invalid type', async () => {
+      setupMock({ launchType: 'invalid' });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.launchType).toBe('soft_launch');
+    });
+  });
+
+  describe('Launch brief normalization', () => {
+    it('should use LLM-provided brief', async () => {
+      setupMock();
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.launchBrief).toContain('MVP');
+    });
+
+    it('should truncate to 1000 characters', async () => {
+      setupMock({ launchBrief: 'X'.repeat(2000) });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.launchBrief.length).toBe(1000);
+    });
+
+    it('should default when missing', async () => {
+      setupMock({ launchBrief: undefined });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.launchBrief).toBe('Launch brief pending.');
+    });
+  });
+
+  describe('Success criteria normalization', () => {
+    it('should use LLM-provided criteria', async () => {
+      setupMock();
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.successCriteria.length).toBe(3);
+      expect(result.successCriteria[0].metric).toBe('User signups');
+    });
+
+    it('should provide defaults when fewer than 2 criteria', async () => {
+      setupMock({ successCriteria: [{ metric: 'Only one' }] });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.successCriteria.length).toBe(2);
+      expect(result.successCriteria[0].priority).toBe('primary');
+    });
+
+    it('should ensure at least one primary criterion', async () => {
+      setupMock({
+        successCriteria: [
+          { metric: 'M1', target: 'T1', measurementWindow: '7 days', priority: 'secondary' },
+          { metric: 'M2', target: 'T2', measurementWindow: '7 days', priority: 'secondary' },
+        ],
+      });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.successCriteria.some(sc => sc.priority === 'primary')).toBe(true);
+    });
+
+    it('should default invalid priority to secondary', async () => {
+      setupMock({
+        successCriteria: [
+          { metric: 'M1', target: 'T1', measurementWindow: '7 days', priority: 'primary' },
+          { metric: 'M2', target: 'T2', measurementWindow: '7 days', priority: 'invalid' },
+        ],
+      });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.successCriteria[1].priority).toBe('secondary');
+    });
+
+    it('should truncate metric to 200 characters', async () => {
+      setupMock({
+        successCriteria: [
+          { metric: 'M'.repeat(300), target: 'T1', measurementWindow: '7 days', priority: 'primary' },
+          { metric: 'M2', target: 'T2', measurementWindow: '7 days', priority: 'secondary' },
+        ],
+      });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.successCriteria[0].metric.length).toBe(200);
+    });
+  });
+
+  describe('Rollback triggers normalization', () => {
+    it('should use LLM-provided triggers', async () => {
+      setupMock();
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.rollbackTriggers.length).toBe(2);
+    });
+
+    it('should provide default when empty', async () => {
+      setupMock({ rollbackTriggers: [] });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.rollbackTriggers.length).toBe(1);
+      expect(result.rollbackTriggers[0].severity).toBe('critical');
+    });
+
+    it('should default invalid severity to warning', async () => {
+      setupMock({
+        rollbackTriggers: [{ condition: 'Something bad', severity: 'invalid' }],
+      });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.rollbackTriggers[0].severity).toBe('warning');
+    });
+  });
+
+  describe('Launch tasks normalization', () => {
+    it('should use LLM-provided tasks', async () => {
+      setupMock();
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.launchTasks.length).toBe(3);
+    });
+
+    it('should provide default when empty', async () => {
+      setupMock({ launchTasks: [] });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.launchTasks.length).toBe(1);
+    });
+
+    it('should default invalid status to pending', async () => {
+      setupMock({
+        launchTasks: [{ name: 'Task', owner: 'Owner', status: 'invalid' }],
+      });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.launchTasks[0].status).toBe('pending');
+    });
+
+    it('should accept all valid task statuses', async () => {
+      for (const status of TASK_STATUSES) {
+        setupMock({
+          launchTasks: [{ name: 'Task', owner: 'Owner', status }],
+        });
+        const result = await analyzeStage23(VALID_PARAMS);
+        expect(result.launchTasks[0].status).toBe(status);
+      }
+    });
+  });
+
+  describe('Planned launch date normalization', () => {
+    it('should accept valid YYYY-MM-DD date', async () => {
+      setupMock({ plannedLaunchDate: '2026-03-15' });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.plannedLaunchDate).toBe('2026-03-15');
+    });
+
+    it('should generate default date for invalid format', async () => {
+      setupMock({ plannedLaunchDate: 'not-a-date' });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.plannedLaunchDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('Output shape', () => {
+    it('should return all expected fields', async () => {
+      setupMock();
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result).toHaveProperty('launchType');
+      expect(result).toHaveProperty('launchBrief');
+      expect(result).toHaveProperty('successCriteria');
+      expect(result).toHaveProperty('rollbackTriggers');
+      expect(result).toHaveProperty('launchTasks');
+      expect(result).toHaveProperty('plannedLaunchDate');
+      expect(result).toHaveProperty('totalTasks');
+      expect(result).toHaveProperty('blockedTasks');
+      expect(result).toHaveProperty('primaryCriteria');
+      expect(result).toHaveProperty('totalCriteria');
+    });
+
+    it('should compute derived counts correctly', async () => {
+      setupMock();
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.totalTasks).toBe(result.launchTasks.length);
+      expect(result.blockedTasks).toBe(result.launchTasks.filter(lt => lt.status === 'blocked').length);
+      expect(result.primaryCriteria).toBe(result.successCriteria.filter(sc => sc.priority === 'primary').length);
+      expect(result.totalCriteria).toBe(result.successCriteria.length);
+    });
+  });
+
+  describe('Upstream data integration', () => {
+    it('should include stage22 release context in prompt', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage23(VALID_PARAMS);
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('release');
+    });
+
+    it('should include stage01 criteria in prompt when provided', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage23({
+        ...VALID_PARAMS,
+        stage01Data: { successCriteria: [{ metric: 'Revenue', target: '$10K MRR' }] },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('Revenue');
+    });
+
+    it('should include ventureName in prompt', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage23({ ...VALID_PARAMS, ventureName: 'TestVenture' });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('TestVenture');
+    });
+  });
+
+  describe('JSON parsing', () => {
+    it('should handle markdown code block wrapping', async () => {
+      const response = createLLMResponse();
+      const mockComplete = vi.fn().mockResolvedValue('```json\n' + response + '\n```');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      const result = await analyzeStage23(VALID_PARAMS);
+      expect(result.launchType).toBe('beta');
+    });
+
+    it('should throw on unparseable response', async () => {
+      const mockComplete = vi.fn().mockResolvedValue('Not JSON');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      await expect(analyzeStage23(VALID_PARAMS)).rejects.toThrow('Failed to parse launch execution response');
+    });
+  });
+});

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-24-metrics-learning.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-24-metrics-learning.test.js
@@ -1,0 +1,340 @@
+/**
+ * Unit tests for Stage 24 Analysis Step - Metrics & Learning
+ * Part of SD-EVA-FEAT-TEMPLATES-LAUNCH-001
+ *
+ * @module tests/unit/eva/stage-templates/analysis-steps/stage-24-metrics-learning.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+import { analyzeStage24, AARRR_CATEGORIES, TREND_DIRECTIONS, OUTCOME_ASSESSMENTS, IMPACT_LEVELS } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+function createLLMResponse(overrides = {}) {
+  const base = {
+    aarrr: {
+      acquisition: [{ name: 'Website visitors', value: 5000, target: 10000, trendDirection: 'up' }],
+      activation: [{ name: 'Signup rate', value: 400, target: 500, trendDirection: 'up' }],
+      retention: [{ name: 'Day-7 retention', value: 35, target: 40, trendDirection: 'flat' }],
+      revenue: [{ name: 'MRR', value: 2000, target: 5000, trendDirection: 'up' }],
+      referral: [{ name: 'Referral rate', value: 8, target: 10, trendDirection: 'flat' }],
+    },
+    criteriaEvaluation: [
+      { metric: 'User signups', target: '50 in 7 days', actual: '62 in 7 days', met: true, notes: 'Exceeded target' },
+      { metric: 'Error rate', target: 'Below 5%', actual: '3.2%', met: true, notes: 'Well within target' },
+      { metric: 'NPS score', target: 'Above 30', actual: '25', met: false, notes: 'Slightly below target' },
+    ],
+    learnings: [
+      { insight: 'Users prefer mobile onboarding', action: 'Prioritize mobile UX improvements', impactLevel: 'high' },
+      { insight: 'Referral flow has friction', action: 'Simplify sharing mechanism', impactLevel: 'medium' },
+    ],
+    launchOutcome: {
+      assessment: 'partial',
+      criteriaMetRate: 67,
+      summary: 'Launch partially successful: 67% of success criteria met.',
+    },
+    ...overrides,
+  };
+  return JSON.stringify(base);
+}
+
+function setupMock(responseOverrides = {}) {
+  const mockComplete = vi.fn().mockResolvedValue(createLLMResponse(responseOverrides));
+  getLLMClient.mockReturnValue({ complete: mockComplete });
+  return mockComplete;
+}
+
+const VALID_PARAMS = {
+  stage23Data: {
+    launchType: 'beta',
+    successCriteria: [
+      { metric: 'User signups', target: '50 in 7 days', priority: 'primary', measurementWindow: '7 days' },
+      { metric: 'Error rate', target: 'Below 5%', priority: 'secondary', measurementWindow: '7 days' },
+    ],
+  },
+};
+
+describe('stage-24-metrics-learning.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Exported constants', () => {
+    it('should export AARRR_CATEGORIES', () => {
+      expect(AARRR_CATEGORIES).toEqual(['acquisition', 'activation', 'retention', 'revenue', 'referral']);
+    });
+
+    it('should export TREND_DIRECTIONS', () => {
+      expect(TREND_DIRECTIONS).toEqual(['up', 'flat', 'down']);
+    });
+
+    it('should export OUTCOME_ASSESSMENTS', () => {
+      expect(OUTCOME_ASSESSMENTS).toEqual(['success', 'partial', 'failure', 'indeterminate']);
+    });
+
+    it('should export IMPACT_LEVELS', () => {
+      expect(IMPACT_LEVELS).toEqual(['high', 'medium', 'low']);
+    });
+  });
+
+  describe('Input validation', () => {
+    it('should throw when stage23Data is missing', async () => {
+      await expect(analyzeStage24({})).rejects.toThrow('Stage 24 metrics & learning requires Stage 23');
+    });
+  });
+
+  describe('AARRR metrics normalization', () => {
+    it('should populate all 5 AARRR categories', async () => {
+      setupMock();
+      const result = await analyzeStage24(VALID_PARAMS);
+      for (const cat of AARRR_CATEGORIES) {
+        expect(result.aarrr[cat]).toBeDefined();
+        expect(result.aarrr[cat].length).toBeGreaterThanOrEqual(1);
+      }
+    });
+
+    it('should provide default metric for missing categories', async () => {
+      setupMock({ aarrr: { acquisition: [{ name: 'Visitors', value: 100, target: 200, trendDirection: 'up' }] } });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.aarrr.retention[0].name).toBe('retention metric');
+      expect(result.aarrr.retention[0].value).toBe(0);
+    });
+
+    it('should default invalid trendDirection to flat', async () => {
+      setupMock({
+        aarrr: {
+          acquisition: [{ name: 'Visitors', value: 100, target: 200, trendDirection: 'invalid' }],
+          activation: [{ name: 'A', value: 1, target: 2, trendDirection: 'up' }],
+          retention: [{ name: 'R', value: 1, target: 2, trendDirection: 'flat' }],
+          revenue: [{ name: 'Rev', value: 1, target: 2, trendDirection: 'down' }],
+          referral: [{ name: 'Ref', value: 1, target: 2, trendDirection: 'up' }],
+        },
+      });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.aarrr.acquisition[0].trendDirection).toBe('flat');
+    });
+
+    it('should accept all valid trend directions', async () => {
+      for (const dir of TREND_DIRECTIONS) {
+        setupMock({
+          aarrr: {
+            acquisition: [{ name: 'A', value: 1, target: 2, trendDirection: dir }],
+            activation: [{ name: 'A', value: 1, target: 2, trendDirection: dir }],
+            retention: [{ name: 'R', value: 1, target: 2, trendDirection: dir }],
+            revenue: [{ name: 'Rev', value: 1, target: 2, trendDirection: dir }],
+            referral: [{ name: 'Ref', value: 1, target: 2, trendDirection: dir }],
+          },
+        });
+        const result = await analyzeStage24(VALID_PARAMS);
+        expect(result.aarrr.acquisition[0].trendDirection).toBe(dir);
+      }
+    });
+
+    it('should truncate metric name to 200 characters', async () => {
+      setupMock({
+        aarrr: {
+          acquisition: [{ name: 'N'.repeat(300), value: 100, target: 200, trendDirection: 'up' }],
+          activation: [{ name: 'A', value: 1, target: 2, trendDirection: 'up' }],
+          retention: [{ name: 'R', value: 1, target: 2, trendDirection: 'up' }],
+          revenue: [{ name: 'Rev', value: 1, target: 2, trendDirection: 'up' }],
+          referral: [{ name: 'Ref', value: 1, target: 2, trendDirection: 'up' }],
+        },
+      });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.aarrr.acquisition[0].name.length).toBe(200);
+    });
+  });
+
+  describe('Criteria evaluation normalization', () => {
+    it('should normalize criteria from LLM response', async () => {
+      setupMock();
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.criteriaEvaluation.length).toBe(3);
+      expect(result.criteriaEvaluation[0].met).toBe(true);
+      expect(result.criteriaEvaluation[2].met).toBe(false);
+    });
+
+    it('should default met to false when not boolean', async () => {
+      setupMock({
+        criteriaEvaluation: [
+          { metric: 'M1', target: 'T1', actual: 'A1', met: 'yes', notes: 'Note' },
+        ],
+      });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.criteriaEvaluation[0].met).toBe(false);
+    });
+
+    it('should filter out entries without metric', async () => {
+      setupMock({
+        criteriaEvaluation: [
+          { metric: 'Valid', target: 'T', actual: 'A', met: true, notes: '' },
+          { target: 'T', actual: 'A', met: true, notes: '' },
+        ],
+      });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.criteriaEvaluation.length).toBe(1);
+    });
+  });
+
+  describe('Learnings normalization', () => {
+    it('should use LLM-provided learnings', async () => {
+      setupMock();
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.learnings.length).toBe(2);
+      expect(result.learnings[0].impactLevel).toBe('high');
+    });
+
+    it('should provide default learning when empty', async () => {
+      setupMock({ learnings: [] });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.learnings.length).toBe(1);
+      expect(result.learnings[0].impactLevel).toBe('medium');
+    });
+
+    it('should default invalid impactLevel to medium', async () => {
+      setupMock({
+        learnings: [{ insight: 'Test', action: 'Do something', impactLevel: 'extreme' }],
+      });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.learnings[0].impactLevel).toBe('medium');
+    });
+
+    it('should accept all valid impact levels', async () => {
+      for (const level of IMPACT_LEVELS) {
+        setupMock({
+          learnings: [{ insight: 'Test', action: 'Act', impactLevel: level }],
+        });
+        const result = await analyzeStage24(VALID_PARAMS);
+        expect(result.learnings[0].impactLevel).toBe(level);
+      }
+    });
+  });
+
+  describe('Launch outcome normalization', () => {
+    it('should use LLM-provided assessment when valid', async () => {
+      for (const assessment of OUTCOME_ASSESSMENTS) {
+        setupMock({ launchOutcome: { assessment, criteriaMetRate: 50, summary: 'Test' } });
+        const result = await analyzeStage24(VALID_PARAMS);
+        expect(result.launchOutcome.assessment).toBe(assessment);
+      }
+    });
+
+    it('should compute criteriaMetRate from criteria evaluation', async () => {
+      setupMock();
+      const result = await analyzeStage24(VALID_PARAMS);
+      // 2 met out of 3 = 67%
+      expect(result.launchOutcome.criteriaMetRate).toBe(67);
+    });
+
+    it('should derive assessment from criteriaMetRate when LLM gives invalid', async () => {
+      setupMock({
+        launchOutcome: { assessment: 'invalid', criteriaMetRate: 50, summary: 'Test' },
+        criteriaEvaluation: [
+          { metric: 'M1', target: 'T1', actual: 'A1', met: true, notes: '' },
+          { metric: 'M2', target: 'T2', actual: 'A2', met: true, notes: '' },
+          { metric: 'M3', target: 'T3', actual: 'A3', met: true, notes: '' },
+          { metric: 'M4', target: 'T4', actual: 'A4', met: true, notes: '' },
+          { metric: 'M5', target: 'T5', actual: 'A5', met: false, notes: '' },
+        ],
+      });
+      const result = await analyzeStage24(VALID_PARAMS);
+      // 4/5 = 80% -> success
+      expect(result.launchOutcome.assessment).toBe('success');
+    });
+
+    it('should assess indeterminate when no criteria', async () => {
+      setupMock({
+        launchOutcome: { assessment: 'invalid' },
+        criteriaEvaluation: [],
+      });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.launchOutcome.assessment).toBe('indeterminate');
+    });
+  });
+
+  describe('Derived metrics', () => {
+    it('should compute totalMetrics, metricsOnTarget, metricsBelowTarget', async () => {
+      setupMock();
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.totalMetrics).toBe(5); // 1 per category
+      expect(typeof result.metricsOnTarget).toBe('number');
+      expect(typeof result.metricsBelowTarget).toBe('number');
+      expect(result.metricsOnTarget + result.metricsBelowTarget).toBe(result.totalMetrics);
+    });
+
+    it('should report categoriesComplete when all 5 have metrics', async () => {
+      setupMock();
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.categoriesComplete).toBe(true);
+    });
+
+    it('should count totalLearnings and highImpactLearnings', async () => {
+      setupMock();
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.totalLearnings).toBe(2);
+      expect(result.highImpactLearnings).toBe(1);
+    });
+  });
+
+  describe('Output shape', () => {
+    it('should return all expected fields', async () => {
+      setupMock();
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result).toHaveProperty('aarrr');
+      expect(result).toHaveProperty('criteriaEvaluation');
+      expect(result).toHaveProperty('learnings');
+      expect(result).toHaveProperty('launchOutcome');
+      expect(result).toHaveProperty('totalMetrics');
+      expect(result).toHaveProperty('metricsOnTarget');
+      expect(result).toHaveProperty('metricsBelowTarget');
+      expect(result).toHaveProperty('categoriesComplete');
+      expect(result).toHaveProperty('totalLearnings');
+      expect(result).toHaveProperty('highImpactLearnings');
+    });
+  });
+
+  describe('Upstream data integration', () => {
+    it('should include launch type in prompt', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage24(VALID_PARAMS);
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('beta');
+    });
+
+    it('should include success criteria in prompt', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage24(VALID_PARAMS);
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('User signups');
+    });
+
+    it('should include ventureName in prompt', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage24({ ...VALID_PARAMS, ventureName: 'LaunchCo' });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('LaunchCo');
+    });
+  });
+
+  describe('JSON parsing', () => {
+    it('should handle markdown code block wrapping', async () => {
+      const response = createLLMResponse();
+      const mockComplete = vi.fn().mockResolvedValue('```json\n' + response + '\n```');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      const result = await analyzeStage24(VALID_PARAMS);
+      expect(result.launchOutcome.assessment).toBe('partial');
+    });
+
+    it('should throw on unparseable response', async () => {
+      const mockComplete = vi.fn().mockResolvedValue('Not valid JSON');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      await expect(analyzeStage24(VALID_PARAMS)).rejects.toThrow('Failed to parse metrics & learning response');
+    });
+  });
+});

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-25-venture-review.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-25-venture-review.test.js
@@ -1,0 +1,392 @@
+/**
+ * Unit tests for Stage 25 Analysis Step - Venture Review (Capstone)
+ * Part of SD-EVA-FEAT-TEMPLATES-LAUNCH-001
+ *
+ * @module tests/unit/eva/stage-templates/analysis-steps/stage-25-venture-review.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+import { analyzeStage25, VENTURE_DECISIONS, HEALTH_RATINGS, REVIEW_CATEGORIES } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+function createLLMResponse(overrides = {}) {
+  const base = {
+    journeySummary: 'The venture began as an idea in Stage 1, progressed through validation in Stage 5, and launched in Stage 23 with strong early traction.',
+    financialComparison: {
+      projectedRevenue: '$50,000 ARR by month 6',
+      actualRevenue: '$35,000 ARR at month 6',
+      projectedCosts: '$120,000 for first year',
+      actualCosts: '$95,000 spent so far',
+      variance: 'Revenue 30% below projection, costs 21% under budget',
+      assessment: 'Below expectations on revenue, but cost discipline is strong',
+    },
+    ventureHealth: {
+      overallRating: 'good',
+      dimensions: {
+        product: { score: 8, rationale: 'Core features well-received' },
+        market: { score: 7, rationale: 'Good fit, slower adoption than expected' },
+        technical: { score: 9, rationale: 'Solid architecture, low error rate' },
+        financial: { score: 6, rationale: 'Revenue below projections' },
+        team: { score: 7, rationale: 'Small but effective team' },
+      },
+    },
+    driftAnalysis: {
+      originalVision: 'AI-powered analytics for SMBs',
+      currentState: 'Pivoted slightly to mid-market with self-serve onboarding',
+      driftDetected: true,
+      driftSummary: 'Moderate drift from pure SMB to mid-market segment',
+    },
+    ventureDecision: {
+      recommendation: 'continue',
+      confidence: 78,
+      rationale: 'Revenue trends are positive despite being below initial projections. Product-market fit indicators are strong.',
+      nextActions: ['Increase marketing spend', 'Launch referral program', 'Hire sales rep'],
+    },
+    initiatives: {
+      product: [{ title: 'Core MVP', status: 'completed', outcome: 'All features shipped' }],
+      market: [{ title: 'Beta program', status: 'completed', outcome: '62 beta users acquired' }],
+      technical: [{ title: 'Infrastructure setup', status: 'completed', outcome: '99.9% uptime' }],
+      financial: [{ title: 'Seed funding', status: 'completed', outcome: '$150K raised' }],
+      team: [{ title: 'Founding team', status: 'completed', outcome: '3 co-founders aligned' }],
+    },
+    ...overrides,
+  };
+  return JSON.stringify(base);
+}
+
+function setupMock(responseOverrides = {}) {
+  const mockComplete = vi.fn().mockResolvedValue(createLLMResponse(responseOverrides));
+  getLLMClient.mockReturnValue({ complete: mockComplete });
+  return mockComplete;
+}
+
+const VALID_PARAMS = {
+  stage24Data: {
+    launchOutcome: { assessment: 'partial', criteriaMetRate: 67 },
+    learnings: [
+      { insight: 'Mobile onboarding preferred', action: 'Improve mobile UX', impactLevel: 'high' },
+    ],
+  },
+};
+
+describe('stage-25-venture-review.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Exported constants', () => {
+    it('should export VENTURE_DECISIONS', () => {
+      expect(VENTURE_DECISIONS).toEqual(['continue', 'pivot', 'expand', 'sunset', 'exit']);
+    });
+
+    it('should export HEALTH_RATINGS', () => {
+      expect(HEALTH_RATINGS).toEqual(['excellent', 'good', 'fair', 'poor', 'critical']);
+    });
+
+    it('should export REVIEW_CATEGORIES', () => {
+      expect(REVIEW_CATEGORIES).toEqual(['product', 'market', 'technical', 'financial', 'team']);
+    });
+  });
+
+  describe('Input validation', () => {
+    it('should throw when stage24Data is missing', async () => {
+      await expect(analyzeStage25({})).rejects.toThrow('Stage 25 venture review requires Stage 24');
+    });
+  });
+
+  describe('Journey summary normalization', () => {
+    it('should use LLM-provided summary', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.journeySummary).toContain('venture began');
+    });
+
+    it('should truncate to 2000 characters', async () => {
+      setupMock({ journeySummary: 'X'.repeat(3000) });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.journeySummary.length).toBe(2000);
+    });
+
+    it('should default when missing', async () => {
+      setupMock({ journeySummary: undefined });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.journeySummary).toBe('Venture journey summary pending review.');
+    });
+  });
+
+  describe('Financial comparison normalization', () => {
+    it('should normalize all financial fields', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.financialComparison).toHaveProperty('projectedRevenue');
+      expect(result.financialComparison).toHaveProperty('actualRevenue');
+      expect(result.financialComparison).toHaveProperty('projectedCosts');
+      expect(result.financialComparison).toHaveProperty('actualCosts');
+      expect(result.financialComparison).toHaveProperty('variance');
+      expect(result.financialComparison).toHaveProperty('assessment');
+    });
+
+    it('should provide defaults when missing', async () => {
+      setupMock({ financialComparison: {} });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.financialComparison.projectedRevenue).toBe('Not available');
+      expect(result.financialComparison.actualRevenue).toBe('Not measured');
+    });
+  });
+
+  describe('Venture health normalization', () => {
+    it('should normalize all 5 dimension scores', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      for (const cat of REVIEW_CATEGORIES) {
+        expect(result.ventureHealth.dimensions[cat]).toHaveProperty('score');
+        expect(result.ventureHealth.dimensions[cat]).toHaveProperty('rationale');
+        expect(result.ventureHealth.dimensions[cat].score).toBeGreaterThanOrEqual(1);
+        expect(result.ventureHealth.dimensions[cat].score).toBeLessThanOrEqual(10);
+      }
+    });
+
+    it('should clamp scores to 1-10 range', async () => {
+      setupMock({
+        ventureHealth: {
+          overallRating: 'good',
+          dimensions: {
+            product: { score: 15, rationale: 'Over max' },
+            market: { score: -5, rationale: 'Under min' },
+            technical: { score: 0, rationale: 'Zero' },
+            financial: { score: 5.7, rationale: 'Decimal' },
+            team: { score: 10, rationale: 'Max' },
+          },
+        },
+      });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.ventureHealth.dimensions.product.score).toBe(10);
+      expect(result.ventureHealth.dimensions.market.score).toBe(1);
+      expect(result.ventureHealth.dimensions.technical.score).toBe(1);
+      expect(result.ventureHealth.dimensions.financial.score).toBe(6);
+      expect(result.ventureHealth.dimensions.team.score).toBe(10);
+    });
+
+    it('should default score to 5 when not a number', async () => {
+      setupMock({
+        ventureHealth: {
+          dimensions: {
+            product: { score: 'not a number', rationale: 'Test' },
+            market: { score: 7, rationale: 'Test' },
+            technical: { score: 7, rationale: 'Test' },
+            financial: { score: 7, rationale: 'Test' },
+            team: { score: 7, rationale: 'Test' },
+          },
+        },
+      });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.ventureHealth.dimensions.product.score).toBe(5);
+    });
+
+    it('should use LLM overallRating when valid', async () => {
+      for (const rating of HEALTH_RATINGS) {
+        setupMock({ ventureHealth: { overallRating: rating, dimensions: {} } });
+        const result = await analyzeStage25(VALID_PARAMS);
+        expect(result.ventureHealth.overallRating).toBe(rating);
+      }
+    });
+
+    it('should derive overallRating from average score when LLM gives invalid', async () => {
+      setupMock({
+        ventureHealth: {
+          overallRating: 'invalid',
+          dimensions: {
+            product: { score: 9, rationale: '' },
+            market: { score: 9, rationale: '' },
+            technical: { score: 9, rationale: '' },
+            financial: { score: 8, rationale: '' },
+            team: { score: 9, rationale: '' },
+          },
+        },
+      });
+      const result = await analyzeStage25(VALID_PARAMS);
+      // avg = 8.8 >= 8.5 -> excellent
+      expect(result.ventureHealth.overallRating).toBe('excellent');
+    });
+  });
+
+  describe('Drift analysis normalization', () => {
+    it('should normalize drift fields', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.driftAnalysis).toHaveProperty('originalVision');
+      expect(result.driftAnalysis).toHaveProperty('currentState');
+      expect(result.driftAnalysis).toHaveProperty('driftDetected');
+      expect(result.driftAnalysis).toHaveProperty('driftSummary');
+    });
+
+    it('should default driftDetected to false when not boolean', async () => {
+      setupMock({ driftAnalysis: { driftDetected: 'yes' } });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.driftAnalysis.driftDetected).toBe(false);
+    });
+
+    it('should use stage01Data elevator_pitch as fallback for originalVision', async () => {
+      setupMock({ driftAnalysis: {} });
+      const result = await analyzeStage25({
+        ...VALID_PARAMS,
+        stage01Data: { elevator_pitch: 'AI for analytics' },
+      });
+      expect(result.driftAnalysis.originalVision).toBe('AI for analytics');
+    });
+  });
+
+  describe('Venture decision normalization', () => {
+    it('should accept all valid decisions', async () => {
+      for (const decision of VENTURE_DECISIONS) {
+        setupMock({ ventureDecision: { recommendation: decision, confidence: 80, rationale: 'Test', nextActions: ['Act'] } });
+        const result = await analyzeStage25(VALID_PARAMS);
+        expect(result.ventureDecision.recommendation).toBe(decision);
+      }
+    });
+
+    it('should default to continue for invalid decision', async () => {
+      setupMock({ ventureDecision: { recommendation: 'invalid' } });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.ventureDecision.recommendation).toBe('continue');
+    });
+
+    it('should clamp confidence to 0-100', async () => {
+      setupMock({ ventureDecision: { recommendation: 'continue', confidence: 150, rationale: 'R', nextActions: ['A'] } });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.ventureDecision.confidence).toBe(100);
+    });
+
+    it('should default confidence to 50 when not a number', async () => {
+      setupMock({ ventureDecision: { recommendation: 'continue', confidence: 'high' } });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.ventureDecision.confidence).toBe(50);
+    });
+
+    it('should provide default nextActions when empty', async () => {
+      setupMock({ ventureDecision: { recommendation: 'continue', confidence: 80, rationale: 'R', nextActions: [] } });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.ventureDecision.nextActions.length).toBe(1);
+    });
+  });
+
+  describe('Initiatives normalization', () => {
+    it('should normalize all 5 initiative categories', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      for (const cat of REVIEW_CATEGORIES) {
+        expect(result.initiatives[cat]).toBeDefined();
+        expect(result.initiatives[cat].length).toBeGreaterThanOrEqual(1);
+      }
+    });
+
+    it('should provide default initiatives for missing categories', async () => {
+      setupMock({ initiatives: { product: [{ title: 'Test', status: 'completed', outcome: 'Done' }] } });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.initiatives.market[0].title).toContain('market');
+      expect(result.initiatives.market[0].status).toBe('planned');
+    });
+
+    it('should truncate title to 200 characters', async () => {
+      setupMock({
+        initiatives: {
+          product: [{ title: 'T'.repeat(300), status: 'done', outcome: 'OK' }],
+          market: [{ title: 'M', status: 'done', outcome: 'OK' }],
+          technical: [{ title: 'T', status: 'done', outcome: 'OK' }],
+          financial: [{ title: 'F', status: 'done', outcome: 'OK' }],
+          team: [{ title: 'Te', status: 'done', outcome: 'OK' }],
+        },
+      });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.initiatives.product[0].title.length).toBe(200);
+    });
+  });
+
+  describe('Derived fields', () => {
+    it('should compute totalInitiatives', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.totalInitiatives).toBe(5); // 1 per category
+    });
+
+    it('should set allCategoriesReviewed to true when all categories present', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.allCategoriesReviewed).toBe(true);
+    });
+
+    it('should compute healthScore as rounded average', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      // (8+7+9+6+7)/5 = 37/5 = 7.4
+      expect(result.healthScore).toBe(7.4);
+    });
+  });
+
+  describe('Output shape', () => {
+    it('should return all expected fields', async () => {
+      setupMock();
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result).toHaveProperty('journeySummary');
+      expect(result).toHaveProperty('financialComparison');
+      expect(result).toHaveProperty('ventureHealth');
+      expect(result).toHaveProperty('driftAnalysis');
+      expect(result).toHaveProperty('ventureDecision');
+      expect(result).toHaveProperty('initiatives');
+      expect(result).toHaveProperty('totalInitiatives');
+      expect(result).toHaveProperty('allCategoriesReviewed');
+      expect(result).toHaveProperty('healthScore');
+    });
+  });
+
+  describe('Upstream data integration', () => {
+    it('should include stage24 metrics context in prompt', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage25(VALID_PARAMS);
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('partial');
+      expect(userPrompt).toContain('67');
+    });
+
+    it('should include stage01 vision in prompt when provided', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage25({
+        ...VALID_PARAMS,
+        stage01Data: { venture_name: 'TestCo', elevator_pitch: 'AI for everyone' },
+      });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('TestCo');
+      expect(userPrompt).toContain('AI for everyone');
+    });
+
+    it('should include ventureName in prompt', async () => {
+      const mockComplete = setupMock();
+      await analyzeStage25({ ...VALID_PARAMS, ventureName: 'ReviewCo' });
+      const userPrompt = mockComplete.mock.calls[0][1];
+      expect(userPrompt).toContain('ReviewCo');
+    });
+  });
+
+  describe('JSON parsing', () => {
+    it('should handle markdown code block wrapping', async () => {
+      const response = createLLMResponse();
+      const mockComplete = vi.fn().mockResolvedValue('```json\n' + response + '\n```');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      const result = await analyzeStage25(VALID_PARAMS);
+      expect(result.ventureDecision.recommendation).toBe('continue');
+    });
+
+    it('should throw on unparseable response', async () => {
+      const mockComplete = vi.fn().mockResolvedValue('Garbage data');
+      getLLMClient.mockReturnValue({ complete: mockComplete });
+      await expect(analyzeStage25(VALID_PARAMS)).rejects.toThrow('Failed to parse venture review response');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add LLM-powered analysis steps for the final EVA pipeline phase (LAUNCH & LEARN)
- **Stage 23** (Launch Execution): Generates launch brief with success criteria contract for Stage 24
- **Stage 24** (Metrics & Learning): AARRR scorecard with criteria evaluation and launch outcome assessment
- **Stage 25** (Venture Review): Capstone review with financial comparison, health dimensions, drift analysis, and venture decision recommendation
- Register all 3 in analysis-steps/index.js and wire analysisStep property in stage templates
- 94 unit tests covering normalization, validation, edge cases, and JSON parsing

## Test plan
- [x] 94 unit tests pass (vitest)
- [x] All 5 AARRR categories populated with defaults for missing data
- [x] Venture decision clamped to valid enum values
- [x] Health scores clamped to 1-10 range
- [x] Success criteria ensure at least 1 primary criterion
- [x] JSON code block wrapping handled correctly

Part of SD-EVA-FEAT-TEMPLATES-LAUNCH-001 (child of SD-EVA-ORCH-TEMPLATE-GAPFILL-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)