### PR TITLE
feat(sd-next): add metadata dependency awareness to recommendations

### DIFF
--- a/scripts/modules/sd-next/index.js
+++ b/scripts/modules/sd-next/index.js
@@ -23,7 +23,9 @@ export { getPhaseAwareStatus, isActionableForLead } from './status-helpers.js';
 export {
   parseDependencies,
   checkDependenciesResolved,
-  getUnresolvedDependencies
+  getUnresolvedDependencies,
+  checkMetadataDependency,
+  resolveMetadataBlocker
 } from './dependency-resolver.js';
 
 // Data loaders


### PR DESCRIPTION
## Summary
- Added `checkMetadataDependency()` and `resolveMetadataBlocker()` to dependency-resolver for soft/conditional dependency detection via `metadata.blocked_by_sd_key`
- Enhanced `categorizeBaselineSDs()` to separate metadata-blocked SDs from truly ready ones, with fail-open for completed or non-existent blockers
- Added `displayUnblockRecommendations()` showing cyan UNBLOCK badges with blocker progress, remaining children count, and conditional notes before START recommendations
- Updated action priority: continue > verify > unblock target > start > none (unblock targets use `action: 'start'` for AUTO-PROCEED compatibility)

## Test plan
- [x] `npm run sd:next` shows UNBLOCK for Phase B's dependency on Phase A
- [x] UNBLOCK appears before START in recommendations
- [x] Conditional notes from metadata displayed correctly
- [x] 15 smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)