### PR TITLE
fix(db): lifecycle-aware sd_claims unique constraint (QF-20260213-620)

### DIFF
--- a/database/migrations/20260213_fix_sd_claims_lifecycle_aware_unique.sql
+++ b/database/migrations/20260213_fix_sd_claims_lifecycle_aware_unique.sql
@@ -1,0 +1,62 @@
+-- Quick-Fix QF-20260213-620: Fix sd_claims unique constraint to be lifecycle-aware
+-- Root cause: sd_claims_sd_session_unique enforces UNIQUE(sd_id, session_id) across ALL rows,
+-- including released claims. Released rows block re-claims for the same (sd_id, session_id) pair.
+-- Fix: Replace with partial unique index on (sd_id) WHERE released_at IS NULL.
+
+-- Step 1: Clean up duplicate active claims before creating the new unique index
+-- (71 orphaned claims from stale sessions, 12 SDs with duplicate active claims)
+UPDATE sd_claims
+SET released_at = NOW(), release_reason = 'STALE_CLEANUP'
+WHERE released_at IS NULL
+  AND session_id NOT IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status IN ('active', 'idle')
+  );
+
+-- Step 2: For remaining duplicates (multiple active sessions claiming same SD),
+-- keep only the most recent claim per SD
+WITH ranked AS (
+  SELECT id, sd_id, ROW_NUMBER() OVER (PARTITION BY sd_id ORDER BY claimed_at DESC) as rn
+  FROM sd_claims
+  WHERE released_at IS NULL
+)
+UPDATE sd_claims
+SET released_at = NOW(), release_reason = 'conflict'
+FROM ranked
+WHERE sd_claims.id = ranked.id AND ranked.rn > 1;
+
+-- Step 3: Drop the lifecycle-unaware unique constraint
+ALTER TABLE sd_claims DROP CONSTRAINT IF EXISTS sd_claims_sd_session_unique;
+
+-- Step 4: Drop the old non-unique active index (superseded by new unique index)
+DROP INDEX IF EXISTS idx_sd_claims_active;
+
+-- Step 5: Create the lifecycle-aware partial unique index
+-- Only ONE active (unreleased) claim per SD at any time
+CREATE UNIQUE INDEX sd_claims_active_unique
+  ON sd_claims (sd_id)
+  WHERE released_at IS NULL;
+
+-- Verification
+DO $$
+DECLARE
+  v_old_exists BOOLEAN;
+  v_new_exists BOOLEAN;
+BEGIN
+  SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'sd_claims_sd_session_unique')
+    INTO v_old_exists;
+  SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'sd_claims_active_unique')
+    INTO v_new_exists;
+
+  IF v_old_exists THEN
+    RAISE WARNING 'FAILED: Old constraint sd_claims_sd_session_unique still exists';
+  ELSE
+    RAISE NOTICE 'SUCCESS: Old constraint removed';
+  END IF;
+
+  IF v_new_exists THEN
+    RAISE NOTICE 'SUCCESS: New partial unique index sd_claims_active_unique created';
+  ELSE
+    RAISE WARNING 'FAILED: New index not created';
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Replace lifecycle-unaware `UNIQUE(sd_id, session_id)` constraint on `sd_claims` with partial unique index `(sd_id) WHERE released_at IS NULL`
- Clean up 71 orphaned unreleased claims from stale sessions
- Deduplicate remaining active claims (12 SDs had multiple active claims, up to 7 per SD)

## Root Cause
The `sd_claims_sd_session_unique` constraint covered ALL rows including released claims. When a session released a claim (setting `released_at`), the released row still occupied the constraint slot, blocking re-claims for the same `(sd_id, session_id)` pair. This caused `duplicate key value violates unique constraint` errors during LEAD-TO-PLAN handoffs when sessions were recycled.

## Fix
1. Bulk cleanup orphaned claims from stale/inactive sessions
2. Deduplicate remaining active claims (keep most recent per SD)
3. Drop `sd_claims_sd_session_unique` constraint
4. Create `sd_claims_active_unique` partial unique index on `(sd_id) WHERE released_at IS NULL`

This matches the pattern already used on `claude_sessions` (`idx_claude_sessions_unique_active_claim`).

## Test plan
- [x] Migration executed successfully against production database
- [x] Verified: 0 orphaned unreleased claims remaining (was 71)
- [x] Verified: 0 duplicate active claims per SD (was 12 SDs affected)
- [x] Verified: Old constraint removed, new index created
- [x] QF classification passed (Tier 2, no escalation triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)