### PR TITLE
feat(sd-next): add dependency QA check and field documentation

### DIFF
--- a/scripts/modules/sd-next/index.js
+++ b/scripts/modules/sd-next/index.js
@@ -25,7 +25,8 @@ export {
   checkDependenciesResolved,
   getUnresolvedDependencies,
   checkMetadataDependency,
-  resolveMetadataBlocker
+  resolveMetadataBlocker,
+  scanMetadataForMisplacedDependencies
 } from './dependency-resolver.js';
 
 // Data loaders


### PR DESCRIPTION
## Summary
- Add `scanMetadataForMisplacedDependencies()` function to detect when SD dependencies are stored in metadata keys (`depends_on`, `dependencies`, `blocked_by`, `prerequisite_sds`, etc.) instead of the proper `dependencies` column
- Add post-creation QA warning in `leo-create-sd.js` that fires when metadata contains dependency info but the dependencies column is empty, with a ready-to-run SQL fix
- Add summary warning in `sd:next` queue display showing affected active SDs
- Add "Dependency Field Guide" section to `leo-create-sd.js --help` explaining what the dependencies column is, its format, and common mistakes

## Context
Investigation found 64 existing SDs with dependency info stuck in metadata (e.g., `metadata.depends_on`, `metadata.dependencies`) but empty `dependencies` columns. These dependencies are invisible to the queue system — SDs appear READY when they should be BLOCKED.

## Test plan
- [x] `scanMetadataForMisplacedDependencies()` correctly detects all misplaced patterns
- [x] Function correctly skips `blocked_by_sd_key` (already handled), nulls, and empty arrays
- [x] `npm run sd:next` runs cleanly with new scan code
- [x] `node scripts/leo-create-sd.js --help` shows Dependency Field Guide
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)