### PR TITLE
docs(protocol): add Five-Point Brief and fix context loading

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -584,11 +584,12 @@ Resume work on the current working SD.
 
 2. **If SD found (is_working_on = true and progress < 100):**
    - Display the SD info from the script output
-   - Determine the appropriate context file based on `current_phase`:
+   - **ALWAYS read `CLAUDE_CORE.md` first** (sub-agent prompt quality standard, SD type requirements)
+   - Then read the phase-specific context file based on `current_phase`:
      - LEAD phases (LEAD_APPROVAL, LEAD_FINAL_APPROVAL) → Read `CLAUDE_LEAD.md`
      - PLAN phases (PLAN_*, PRD_*) → Read `CLAUDE_PLAN.md`
      - EXEC phases (EXEC_*, IMPLEMENTATION_*) → Read `CLAUDE_EXEC.md`
-   - Load that context file using the Read tool
+   - Load BOTH context files using the Read tool
    - Show recommended next action based on phase:
      - LEAD phases: "Continue LEAD approval workflow"
      - PLAN phases: "Continue PRD/planning work"
@@ -769,7 +770,8 @@ Restore session state after a crash, compaction, or interruption using the Unifi
 4. **After displaying state, determine next action:**
 
    **If RESUME_SD_ID is set:**
-   - Load the appropriate CLAUDE context file based on RESUME_SD_PHASE:
+   - **ALWAYS read `CLAUDE_CORE.md` first** (sub-agent prompt quality standard, SD type requirements)
+   - Then read the phase-specific context file based on RESUME_SD_PHASE:
      - LEAD phases (LEAD_APPROVAL, LEAD_FINAL_APPROVAL) → Read `CLAUDE_LEAD.md`
      - PLAN phases (PLAN_*, PRD_*) → Read `CLAUDE_PLAN.md`
      - EXEC phases (EXEC_*, IMPLEMENTATION_*) → Read `CLAUDE_EXEC.md`
@@ -902,14 +904,22 @@ This is the RECOMMENDED way to begin work on an SD. It combines claiming + conte
 
 4. **MANDATORY: Read protocol files based on phase:**
 
+   **Step 1: ALWAYS read CLAUDE_CORE.md first (contains sub-agent prompt quality standard, SD type requirements, gate thresholds):**
+   ```
+   Read tool: CLAUDE_CORE.md
+   ```
+
+   **Step 2: Read phase-specific file:**
+
    | Phase | Files to Read (use Read tool) |
    |-------|-------------------------------|
    | LEAD | `CLAUDE_LEAD.md` |
    | PLAN | `CLAUDE_PLAN.md` |
    | EXEC | `CLAUDE_EXEC.md` |
 
-   **Execute the file read immediately** - do not just mention it, actually use the Read tool:
+   **Execute BOTH file reads immediately** - do not just mention them, actually use the Read tool:
    ```
+   Read tool: CLAUDE_CORE.md   (ALWAYS - contains Five-Point Brief, model routing, SD types)
    Read tool: CLAUDE_LEAD.md   (if phase is LEAD)
    Read tool: CLAUDE_PLAN.md   (if phase is PLAN)
    Read tool: CLAUDE_EXEC.md   (if phase is EXEC)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,39 @@
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**
@@ -876,7 +904,7 @@ npm run agents:compile
 This generates all agent .md files from .partial.md sources + database metadata, with team collaboration and spawning protocols auto-injected.
 
 ## DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2026-02-13 8:49:22 AM
+**Last Generated**: 2026-02-13 10:07:42 AM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 
@@ -1010,11 +1038,39 @@ Read tool: PRD file with limit: 100  ← VIOLATION
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -8,11 +8,39 @@
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**
@@ -22,7 +50,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-13 8:49:22 AM
+**Generated**: 2026-02-13 10:07:42 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions (15-20k chars)
 
@@ -1769,11 +1797,39 @@ Constitutional vetting of proposals using AEGIS framework. Routes feedback throu
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-13T13:49:22.220Z -->
-<!-- git_commit: da881fa2 -->
+<!-- generated_at: 2026-02-13T15:07:42.259Z -->
+<!-- git_commit: 2acb69ad -->
 <!-- db_snapshot_hash: 09759431152b1c6f -->
 <!-- file_content_hash: pending -->
 
@@ -354,5 +354,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-02-13 8:49:22 AM*
+*DIGEST generated: 2026-02-13 10:07:42 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-13T13:49:22.220Z -->
-<!-- git_commit: da881fa2 -->
+<!-- generated_at: 2026-02-13T15:07:42.259Z -->
+<!-- git_commit: 2acb69ad -->
 <!-- db_snapshot_hash: 09759431152b1c6f -->
 <!-- file_content_hash: pending -->
 
@@ -121,5 +121,5 @@ Read tool: PRD file with limit: 100  ← VIOLATION
 
 ---
 
-*DIGEST generated: 2026-02-13 8:49:22 AM*
+*DIGEST generated: 2026-02-13 10:07:42 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -8,11 +8,39 @@
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**
@@ -22,7 +50,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-13 8:49:22 AM
+**Generated**: 2026-02-13 10:07:42 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing (20-25k chars)
 
@@ -1915,11 +1943,39 @@ Verifies LEAD to PLAN handoff requirements are met before allowing transition.
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-13T13:49:22.220Z -->
-<!-- git_commit: da881fa2 -->
+<!-- generated_at: 2026-02-13T15:07:42.259Z -->
+<!-- git_commit: 2acb69ad -->
 <!-- db_snapshot_hash: 09759431152b1c6f -->
 <!-- file_content_hash: pending -->
 
@@ -364,5 +364,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-02-13 8:49:22 AM*
+*DIGEST generated: 2026-02-13 10:07:42 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -8,11 +8,39 @@
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**
@@ -22,7 +50,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-13 8:49:22 AM
+**Generated**: 2026-02-13 10:07:42 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 
@@ -1591,11 +1619,39 @@ npm run sd:status    # Overall progress by track
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-13T13:49:22.220Z -->
-<!-- git_commit: da881fa2 -->
+<!-- generated_at: 2026-02-13T15:07:42.259Z -->
+<!-- git_commit: 2acb69ad -->
 <!-- db_snapshot_hash: 09759431152b1c6f -->
 <!-- file_content_hash: pending -->
 
@@ -150,5 +150,5 @@ LEAD MUST answer these questions BEFORE approval:
 
 ---
 
-*DIGEST generated: 2026-02-13 8:49:22 AM*
+*DIGEST generated: 2026-02-13 10:07:42 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -8,11 +8,39 @@
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**
@@ -22,7 +50,7 @@ Perform 5-whys analysis and identify the root cause."
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-13 8:49:22 AM
+**Generated**: 2026-02-13 10:07:42 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates (30-35k chars)
 
@@ -2623,11 +2651,39 @@ Test scenarios only cover happy path ('user logs in successfully'). Missing:
 2. **DO NOT ignore it** - Every issue is a signal that something needs attention
 3. **INVOKE the RCA Sub-Agent** - Use `subagent_type="rca-agent"` via the Task tool
 
-**Example invocation:**
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
 ```
 Task tool with subagent_type="rca-agent":
-"Analyze why [describe the issue] is occurring.
-Perform 5-whys analysis and identify the root cause."
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+```
+
+**Example invocation (BAD - too vague):**
+```
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
 ```
 
 **Why this matters:**

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-13T13:49:22.220Z -->
-<!-- git_commit: da881fa2 -->
+<!-- generated_at: 2026-02-13T15:07:42.259Z -->
+<!-- git_commit: 2acb69ad -->
 <!-- db_snapshot_hash: 09759431152b1c6f -->
 <!-- file_content_hash: pending -->
 
@@ -334,5 +334,5 @@ Test scenarios only cover happy path ('user logs in successfully'). Missing:
 
 ---
 
-*DIGEST generated: 2026-02-13 8:49:22 AM*
+*DIGEST generated: 2026-02-13 10:07:42 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,76 +1,76 @@
 {
-  "generated_at": "2026-02-13T13:49:22.220Z",
-  "git_commit": "da881fa2",
+  "generated_at": "2026-02-13T15:07:42.259Z",
+  "git_commit": "2acb69ad",
   "db_snapshot_hash": "09759431152b1c6f",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 47930,
-      "estimated_tokens": 11983,
-      "content_hash": "d9b05082ec11c24a",
+      "chars": 51579,
+      "estimated_tokens": 12895,
+      "content_hash": "27867efd96e0dc16",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 77223,
-      "estimated_tokens": 19306,
-      "content_hash": "ed0b82305b0714d5",
+      "chars": 80872,
+      "estimated_tokens": 20218,
+      "content_hash": "8f30e1b91e48180d",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 57819,
-      "estimated_tokens": 14455,
-      "content_hash": "9a894f6f96ad4ba9",
+      "chars": 61468,
+      "estimated_tokens": 15367,
+      "content_hash": "ce36e9e949dae73e",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 89635,
-      "estimated_tokens": 22409,
-      "content_hash": "5984ea7e785cd803",
+      "chars": 93284,
+      "estimated_tokens": 23321,
+      "content_hash": "ba07f3a6158c264c",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 68153,
-      "estimated_tokens": 17039,
-      "content_hash": "1d8a52465c97e2a7",
+      "chars": 71802,
+      "estimated_tokens": 17951,
+      "content_hash": "2af78ef2e6e7c255",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 4637,
+      "chars": 4638,
       "estimated_tokens": 1160,
-      "content_hash": "820c350de2bef0af",
+      "content_hash": "4ff39167a34a50d9",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 16887,
+      "chars": 16888,
       "estimated_tokens": 4222,
-      "content_hash": "1452c2d67ea11933",
+      "content_hash": "7260b6cef87bab58",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 6254,
+      "chars": 6255,
       "estimated_tokens": 1564,
-      "content_hash": "313da1a12b0a3c8b",
+      "content_hash": "103d51e44a98c531",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 14901,
+      "chars": 14902,
       "estimated_tokens": 3726,
-      "content_hash": "c04d12e183ae34ce",
+      "content_hash": "ec044ba1f3e1c599",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 15753,
+      "chars": 15754,
       "estimated_tokens": 3939,
-      "content_hash": "aa6745f49904d51a",
+      "content_hash": "bc341fd5eed37bfa",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     }
   }

--- a/scripts/one-time/update-rca-mandate.cjs
+++ b/scripts/one-time/update-rca-mandate.cjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * One-time script: Update RCA Issue Resolution Mandate with Five-Point Brief
+ * Updates leo_protocol_sections id=424
+ */
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const newContent = `## ⚠️ CRITICAL: Issue Resolution Protocol
+
+**When you encounter ANY issue, error, or unexpected behavior:**
+
+1. **DO NOT work around it** - Workarounds hide problems and create technical debt
+2. **DO NOT ignore it** - Every issue is a signal that something needs attention
+3. **INVOKE the RCA Sub-Agent** - Use \`subagent_type="rca-agent"\` via the Task tool
+
+### Sub-Agent Prompt Quality Standard (Five-Point Brief)
+
+**CRITICAL**: The prompt you write when spawning ANY sub-agent is the highest-impact point in the entire agent chain. Everything downstream — team composition, investigation direction, finding quality — inherits from it.
+
+Every sub-agent invocation MUST include these five elements:
+
+| Element | What to Include | Example |
+|---------|----------------|---------|
+| **Symptom** | Observable behavior (what IS happening) | "The /users endpoint returns 504 after 30s" |
+| **Location** | Files, endpoints, DB tables involved | "routes/users.js line 45, lib/queries/user-lookup.js" |
+| **Frequency** | How often, when it started, pattern | "Started 2h ago, every 3rd request fails" |
+| **Prior attempts** | What was already tried (so agent doesn't repeat) | "Server restart didn't help, DNS is fine" |
+| **Desired outcome** | What success looks like | "Identify root cause, propose fix with <30min implementation" |
+
+**Anti-patterns** (NEVER do these):
+- ❌ "Analyze why [issue] is occurring" — too vague, agent has nothing to anchor on
+- ❌ Dumping entire conversation context — unrelated tokens waste investigation capacity
+- ❌ Omitting prior attempts — agent repeats your failed approaches
+
+**Example invocation (GOOD - RCA agent):**
+\`\`\`
+Task tool with subagent_type="rca-agent":
+"Symptom: SD cannot be marked completed. DB trigger rejects with 'Progress: 20% (need 100%)'.
+Location: get_progress_breakdown() function, trigger on strategic_directives_v2, UUID: 7d2aa25e
+Frequency: 6th child of orchestrator. First 5 siblings completed. Only this one stuck.
+Prior attempts: Direct status update blocked. Checked sd_phase_handoffs — empty for all siblings.
+Desired outcome: Identify what mechanism marked sibling phases complete, apply same to this SD."
+\`\`\`
+
+**Example invocation (BAD - too vague):**
+\`\`\`
+Task tool with subagent_type="rca-agent":
+"Analyze why the SD completion is failing. Perform 5-whys analysis and identify the root cause."
+\`\`\`
+
+**Why this matters:**
+- Root cause fixes prevent recurrence
+- Issues captured in \`issue_patterns\` table benefit future sessions
+- Systematic analysis produces better solutions than quick fixes
+
+**The only acceptable response to an issue is understanding WHY it happened.**`;
+
+async function main() {
+  const { error } = await supabase
+    .from('leo_protocol_sections')
+    .update({ content: newContent })
+    .eq('id', 424);
+
+  if (error) {
+    console.error('Error updating section 424:', error.message);
+    process.exit(1);
+  }
+  console.log('✅ Section 424 (RCA mandate) updated with Five-Point Brief');
+
+  // Verify
+  const { data } = await supabase
+    .from('leo_protocol_sections')
+    .select('content')
+    .eq('id', 424)
+    .single();
+
+  const hasBackticks = data.content.includes('subagent_type="rca-agent"');
+  const hasFivePoint = data.content.includes('Five-Point Brief');
+  const hasIssuePatterns = data.content.includes('issue_patterns');
+  const hasGoodExample = data.content.includes('Symptom: SD cannot be marked');
+  const hasBadExample = data.content.includes('too vague');
+
+  console.log('Verification:');
+  console.log('  subagent_type reference:', hasBackticks ? '✅' : '❌');
+  console.log('  Five-Point Brief:', hasFivePoint ? '✅' : '❌');
+  console.log('  issue_patterns:', hasIssuePatterns ? '✅' : '❌');
+  console.log('  Good example:', hasGoodExample ? '✅' : '❌');
+  console.log('  Bad example:', hasBadExample ? '✅' : '❌');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Adds the Five-Point Brief sub-agent prompt quality standard (Symptom, Location, Frequency, Prior attempts, Desired outcome) to the RCA Issue Resolution Mandate in CLAUDE.md
- Fixes `/leo start`, `/leo continue`, and `/leo resume` to always read CLAUDE_CORE.md before phase-specific files
- Prevents sessions from skipping the sub-agent prompt standard and SD type requirements

## Test plan
- [x] Database section 424 updated with Five-Point Brief content
- [x] CLAUDE.md regenerated from database (both RCA mandate locations updated)
- [x] `/leo` skill updated in 3 entry points (start, continue, resume)
- [x] Smoke tests passing (15/15)
- [ ] Verify next session loads Five-Point Brief from system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)