### PR TITLE
feat: add account handoff exchange commands

### DIFF
--- a/.claude/commands/handoff-in.md
+++ b/.claude/commands/handoff-in.md
@@ -1,0 +1,88 @@
+# Handoff In — Import Session Context After Account Switch
+
+Restore session context from a handoff package created by `/handoff-out` on the other account.
+
+## Instructions
+
+### Step 1: Run the Import Script
+
+```bash
+node scripts/handoff-import.cjs
+```
+
+This reads the handoff package from `.claude/handoff/` and:
+- Validates the package exists and checks its age
+- Restores session state files to `.claude/`
+- Copies memory files that only exist in the handoff (no conflict)
+- Identifies memory files that need intelligent merging
+- Displays the briefing from the source account
+- Outputs a structured `HANDOFF_IMPORT_RESULT=` JSON line
+
+### Step 2: Handle Memory Merges
+
+Parse the `HANDOFF_IMPORT_RESULT` JSON from the script output. Check `memoryAnalysis.needsMerge`.
+
+**If `needsMerge` is empty** — all memory files are resolved. Skip to Step 3.
+
+**If `needsMerge` has files** — merge each one:
+
+For each file in `needsMerge`:
+
+1. Read the handoff version from `.claude/handoff/memory/<filename>`
+2. Read the destination version from `~/.claude/projects/C--Users-rickf-Projects--EHG-EHG-Engineer/memory/<filename>`
+3. Merge intelligently based on file type:
+
+**For MEMORY.md:**
+- Merge by section (`## ` headers)
+- For each section that exists in BOTH versions:
+  - Keep all unique entries from both
+  - For duplicate entries, keep the more recent or more detailed version
+  - Preserve section order from the handoff version (it's newer)
+  - Remove any entries explicitly marked as outdated in either version
+- For sections only in one version: include them
+- Ensure the final file stays under 200 lines (the system limit). If it exceeds 200 lines, move the least-recently-relevant content into topic files.
+
+**For topic files (other .md files):**
+- Compare the two versions
+- If one is clearly a superset of the other, keep the superset
+- If both have unique content, merge the sections together
+- Keep the most recent information from each
+
+4. Write the merged result to `~/.claude/projects/C--Users-rickf-Projects--EHG-EHG-Engineer/memory/<filename>`
+5. Report what was merged
+
+### Step 3: Display the Briefing
+
+The script already printed the briefing. Summarize the key points for the user:
+- What SD was active (if any), its phase and progress
+- Session settings (AUTO-PROCEED state)
+- Git state (branch, recent commits)
+- Any pending actions
+
+### Step 4: Suggest Next Action
+
+Based on the briefing:
+- **If active SD exists**: Suggest running `/leo continue` or `npm run sd:next`
+- **If no active SD**: Suggest running `npm run sd:next` to see the queue
+- **If handoff is stale (>24h)**: Warn that the context may be outdated and suggest checking `npm run sd:next` fresh
+
+### Step 5: Summary
+
+Display a clean summary:
+
+```
+Handoff Import Complete
+
+Memory: X copied, Y merged, Z identical, W kept
+State: N file(s) restored
+Active SD: <sd-key> (<phase>, <progress>%) — or "None"
+Age: <time since export>
+
+Ready to continue. Run /leo next to see the queue.
+```
+
+## Error Handling
+
+- **No handoff package**: Tell the user to run `/handoff-out` on the other account first
+- **Stale package (>24h)**: Warn but proceed — context is better than nothing
+- **Database unreachable during export**: The package still contains memory + git state, which is the most valuable part

--- a/.claude/commands/handoff-out.md
+++ b/.claude/commands/handoff-out.md
@@ -1,0 +1,46 @@
+# Handoff Out — Export Session Context Before Account Switch
+
+Export your current session context so another Claude Code account can pick up where you left off.
+
+## Instructions
+
+### Step 1: Run the Export Script
+
+```bash
+node scripts/handoff-export.cjs
+```
+
+This creates a handoff package at `.claude/handoff/` containing:
+- Memory files from `~/.claude/projects/C--Users-rickf-Projects--EHG-EHG-Engineer/memory/`
+- Session state files (auto-proceed-state.json, unified-session-state.json)
+- Active SD information (queried from database)
+- Git state (branch, recent commits, uncommitted changes)
+- A human-readable briefing (`briefing.md`)
+- Package metadata (`metadata.json`)
+
+### Step 2: Confirm the Package
+
+After the script runs, display the summary output to the user. Verify:
+- Memory files were copied
+- Active SD was detected (if any)
+- Git state was captured
+
+### Step 3: Remind the User
+
+Tell the user:
+
+```
+Handoff package ready at .claude/handoff/
+
+To continue on the other account:
+1. Log out of this account
+2. Log in with the other account
+3. Run /handoff-in
+```
+
+## Notes
+
+- The handoff package is gitignored — it stays local
+- Re-running `/handoff-out` replaces the previous package
+- The package includes everything needed for session continuity
+- Database state (SDs, handoffs, etc.) is shared across accounts already — only session context needs transfer

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,9 @@ src/client/dist/
 !.claude/agents/_model-tracking-section.md
 .claude/.agent-gen-hash
 
+# Account handoff exchange (local session state between account switches)
+.claude/handoff/
+
 # Claude session state (modified during protocol operations, local only)
 .claude/unified-session-state.json
 .claude/auto-proceed-state.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -354,10 +354,10 @@ if [ ! -z "$STAGED_MD_FILES" ]; then
   # Check for PRD markdown files
   PRD_FILES=$(echo "$STAGED_MD_FILES" | grep -E '^(docs/)?PRD-.*\.md$' || true)
 
-  # Check for handoff markdown files (exclude design docs, retrospectives, and reference docs)
-  # Excludes: retrospectives/, docs/vision/, docs/plans/, docs/specs/, docs/reference/
+  # Check for handoff markdown files (exclude design docs, retrospectives, reference docs, and slash commands)
+  # Excludes: retrospectives/, docs/vision/, docs/plans/, docs/specs/, docs/reference/, .claude/commands/
   # SD-LEO-STREAMS-001: Added docs/reference/ exclusion for schema documentation
-  HANDOFF_FILES=$(echo "$STAGED_MD_FILES" | grep -i 'handoff' | grep -v 'retrospectives/' | grep -v 'docs/vision/' | grep -v 'docs/plans/' | grep -v 'docs/specs/' | grep -v 'docs/reference/' || true)
+  HANDOFF_FILES=$(echo "$STAGED_MD_FILES" | grep -i 'handoff' | grep -v 'retrospectives/' | grep -v 'docs/vision/' | grep -v 'docs/plans/' | grep -v 'docs/specs/' | grep -v 'docs/reference/' | grep -v '\.claude/commands/' || true)
 
   VIOLATIONS=""
 

--- a/scripts/handoff-export.cjs
+++ b/scripts/handoff-export.cjs
@@ -1,0 +1,362 @@
+#!/usr/bin/env node
+
+/**
+ * Handoff Export Script
+ *
+ * Creates a handoff package at .claude/handoff/ containing:
+ * - Memory files (from ~/.claude/projects/<path-hash>/memory/)
+ * - Session state files (unified-session-state.json, auto-proceed-state.json)
+ * - Active SD information (from database)
+ * - Git state (branch, recent commits, modified files)
+ * - A human-readable briefing.md
+ * - metadata.json with timestamp and manifest
+ *
+ * Usage: node scripts/handoff-export.cjs
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const HANDOFF_DIR = path.join(PROJECT_ROOT, '.claude', 'handoff');
+const MEMORY_SRC = path.join(
+  os.homedir(),
+  '.claude',
+  'projects',
+  'C--Users-rickf-Projects--EHG-EHG-Engineer',
+  'memory'
+);
+const CLAUDE_DIR = path.join(PROJECT_ROOT, '.claude');
+
+function ensureDir(dir) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function safeExec(cmd, opts = {}) {
+  try {
+    return execSync(cmd, { encoding: 'utf8', cwd: PROJECT_ROOT, timeout: 15000, ...opts }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function copyMemoryFiles() {
+  const memoryDest = path.join(HANDOFF_DIR, 'memory');
+  ensureDir(memoryDest);
+
+  const copied = [];
+  if (fs.existsSync(MEMORY_SRC)) {
+    const files = fs.readdirSync(MEMORY_SRC).filter(f => f.endsWith('.md'));
+    for (const file of files) {
+      fs.copyFileSync(path.join(MEMORY_SRC, file), path.join(memoryDest, file));
+      copied.push(file);
+    }
+  }
+  return copied;
+}
+
+function copyStateFiles() {
+  const stateDest = path.join(HANDOFF_DIR, 'state');
+  ensureDir(stateDest);
+
+  const stateFiles = ['unified-session-state.json', 'auto-proceed-state.json'];
+  const copied = [];
+  for (const file of stateFiles) {
+    const src = path.join(CLAUDE_DIR, file);
+    if (fs.existsSync(src)) {
+      fs.copyFileSync(src, path.join(stateDest, file));
+      copied.push(file);
+    }
+  }
+  return copied;
+}
+
+async function getActiveSD() {
+  try {
+    require('dotenv').config({ path: path.join(PROJECT_ROOT, '.env') });
+    const { createClient } = require('@supabase/supabase-js');
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    );
+
+    // Check for SD marked as working on
+    const { data: workingOn } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, title, status, priority, current_phase, progress, description')
+      .eq('is_working_on', true)
+      .lt('progress', 100);
+
+    if (workingOn && workingOn.length > 0) {
+      return workingOn[0];
+    }
+
+    // Check for active session claim
+    const { data: session } = await supabase
+      .from('claude_sessions')
+      .select('sd_id, metadata')
+      .eq('status', 'active')
+      .order('heartbeat_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (session && session.sd_id) {
+      const { data: sd } = await supabase
+        .from('strategic_directives_v2')
+        .select('id, sd_key, title, status, priority, current_phase, progress, description')
+        .eq('sd_key', session.sd_id)
+        .single();
+
+      if (sd) {
+        return { ...sd, sessionMetadata: session.metadata };
+      }
+    }
+
+    return null;
+  } catch (err) {
+    console.error('  Warning: Could not query database:', err.message);
+    return null;
+  }
+}
+
+function getSessionSettings() {
+  const settings = {};
+
+  // Read auto-proceed state
+  const apPath = path.join(CLAUDE_DIR, 'auto-proceed-state.json');
+  if (fs.existsSync(apPath)) {
+    try {
+      const ap = JSON.parse(fs.readFileSync(apPath, 'utf8'));
+      settings.autoProceed = ap.isActive || false;
+      settings.currentSd = ap.currentSd || null;
+      settings.currentPhase = ap.currentPhase || null;
+    } catch { /* ignore parse errors */ }
+  }
+
+  // Read unified session state
+  const ussPath = path.join(CLAUDE_DIR, 'unified-session-state.json');
+  if (fs.existsSync(ussPath)) {
+    try {
+      settings.unifiedState = JSON.parse(fs.readFileSync(ussPath, 'utf8'));
+    } catch { /* ignore parse errors */ }
+  }
+
+  return settings;
+}
+
+function getGitState() {
+  const branch = safeExec('git branch --show-current') || 'unknown';
+  const recentCommits = safeExec('git log --oneline -5') || 'No recent commits';
+  const modifiedFiles = safeExec('git status --porcelain') || 'No modified files';
+  const lastCommitFull = safeExec('git log -1 --format="%H %s"') || 'unknown';
+
+  return { branch, recentCommits, modifiedFiles, lastCommitFull };
+}
+
+function generateBriefing({ memoryFiles, stateFiles, activeSD, sessionSettings, gitState, timestamp }) {
+  const lines = [];
+
+  lines.push('# Account Handoff Briefing');
+  lines.push(`\n**Generated**: ${timestamp}`);
+  lines.push(`**Source Account**: Exported before account switch`);
+
+  // Active SD
+  lines.push('\n## Active Strategic Directive');
+  if (activeSD) {
+    const sdId = activeSD.sd_key || activeSD.id;
+    lines.push(`- **SD**: ${sdId}`);
+    lines.push(`- **Title**: ${activeSD.title}`);
+    lines.push(`- **Status**: ${activeSD.status}`);
+    lines.push(`- **Phase**: ${activeSD.current_phase || 'not set'}`);
+    lines.push(`- **Progress**: ${activeSD.progress || 0}%`);
+    lines.push(`- **Priority**: ${activeSD.priority || 'not set'}`);
+    if (activeSD.description) {
+      lines.push(`- **Description**: ${activeSD.description.substring(0, 200)}${activeSD.description.length > 200 ? '...' : ''}`);
+    }
+  } else {
+    lines.push('No active SD detected. Run `npm run sd:next` to see the queue.');
+  }
+
+  // Session Settings
+  lines.push('\n## Session Settings');
+  lines.push(`- **AUTO-PROCEED**: ${sessionSettings.autoProceed ? 'ON' : 'OFF'}`);
+  if (sessionSettings.currentSd) {
+    lines.push(`- **Current SD (auto-proceed)**: ${sessionSettings.currentSd}`);
+  }
+  if (sessionSettings.currentPhase) {
+    lines.push(`- **Current Phase**: ${sessionSettings.currentPhase}`);
+  }
+
+  // Git State
+  lines.push('\n## Git State');
+  lines.push(`- **Branch**: ${gitState.branch}`);
+  lines.push(`- **Last Commit**: ${gitState.lastCommitFull}`);
+  lines.push('\n### Recent Commits');
+  lines.push('```');
+  lines.push(gitState.recentCommits);
+  lines.push('```');
+  if (gitState.modifiedFiles && gitState.modifiedFiles !== 'No modified files') {
+    lines.push('\n### Uncommitted Changes');
+    lines.push('```');
+    lines.push(gitState.modifiedFiles);
+    lines.push('```');
+  }
+
+  // Memory Files
+  lines.push('\n## Exported Memory Files');
+  if (memoryFiles.length > 0) {
+    for (const f of memoryFiles) {
+      lines.push(`- ${f}`);
+    }
+  } else {
+    lines.push('No memory files found.');
+  }
+
+  // State Files
+  lines.push('\n## Exported State Files');
+  if (stateFiles.length > 0) {
+    for (const f of stateFiles) {
+      lines.push(`- ${f}`);
+    }
+  } else {
+    lines.push('No state files found.');
+  }
+
+  // Pending Actions
+  if (sessionSettings.unifiedState) {
+    lines.push('\n## Pending Actions');
+    const uss = sessionSettings.unifiedState;
+    if (uss.pendingActions && uss.pendingActions.length > 0) {
+      for (const action of uss.pendingActions) {
+        lines.push(`- ${action}`);
+      }
+    } else {
+      lines.push('No pending actions.');
+    }
+  }
+
+  // Next Steps
+  lines.push('\n## Suggested Next Steps');
+  if (activeSD) {
+    const sdId = activeSD.sd_key || activeSD.id;
+    lines.push(`1. Resume work on **${sdId}** — run \`/leo continue\``);
+    lines.push(`2. Or check the queue — run \`npm run sd:next\``);
+  } else {
+    lines.push('1. Check the SD queue — run `npm run sd:next`');
+    lines.push('2. Or start fresh — run `/leo next`');
+  }
+
+  return lines.join('\n');
+}
+
+async function main() {
+  console.log('');
+  console.log('========================================');
+  console.log('  HANDOFF EXPORT');
+  console.log('========================================');
+  console.log('');
+
+  // Clean previous handoff
+  if (fs.existsSync(HANDOFF_DIR)) {
+    fs.rmSync(HANDOFF_DIR, { recursive: true, force: true });
+  }
+  ensureDir(HANDOFF_DIR);
+
+  // 1. Copy memory files
+  console.log('  Copying memory files...');
+  const memoryFiles = copyMemoryFiles();
+  console.log(`    ${memoryFiles.length} memory file(s) copied`);
+
+  // 2. Copy state files
+  console.log('  Copying state files...');
+  const stateFiles = copyStateFiles();
+  console.log(`    ${stateFiles.length} state file(s) copied`);
+
+  // 3. Query active SD
+  console.log('  Querying active SD...');
+  const activeSD = await getActiveSD();
+  if (activeSD) {
+    const sdId = activeSD.sd_key || activeSD.id;
+    console.log(`    Active SD: ${sdId} (${activeSD.current_phase || 'no phase'}, ${activeSD.progress || 0}%)`);
+  } else {
+    console.log('    No active SD found');
+  }
+
+  // 4. Get session settings
+  const sessionSettings = getSessionSettings();
+
+  // 5. Get git state
+  console.log('  Capturing git state...');
+  const gitState = getGitState();
+  console.log(`    Branch: ${gitState.branch}`);
+
+  // 6. Generate briefing
+  const timestamp = new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+  const briefing = generateBriefing({
+    memoryFiles, stateFiles, activeSD, sessionSettings, gitState, timestamp
+  });
+  fs.writeFileSync(path.join(HANDOFF_DIR, 'briefing.md'), briefing, 'utf8');
+
+  // 7. Write metadata
+  const metadata = {
+    version: '1.0.0',
+    timestamp,
+    timestampISO: new Date().toISOString(),
+    sourceProject: 'EHG_Engineer',
+    manifest: {
+      memoryFiles,
+      stateFiles,
+      briefing: 'briefing.md',
+      metadata: 'metadata.json'
+    },
+    activeSD: activeSD ? {
+      sdKey: activeSD.sd_key || activeSD.id,
+      title: activeSD.title,
+      phase: activeSD.current_phase,
+      progress: activeSD.progress
+    } : null,
+    sessionSettings: {
+      autoProceed: sessionSettings.autoProceed || false,
+      currentSd: sessionSettings.currentSd || null,
+      currentPhase: sessionSettings.currentPhase || null
+    },
+    gitState: {
+      branch: gitState.branch,
+      lastCommit: gitState.lastCommitFull
+    }
+  };
+  fs.writeFileSync(
+    path.join(HANDOFF_DIR, 'metadata.json'),
+    JSON.stringify(metadata, null, 2),
+    'utf8'
+  );
+
+  // Summary
+  console.log('');
+  console.log('========================================');
+  console.log('  Handoff Package Created');
+  console.log('========================================');
+  console.log(`    ${memoryFiles.length} memory file(s) (${memoryFiles.join(', ') || 'none'})`);
+  if (activeSD) {
+    console.log(`    Active SD: ${activeSD.sd_key || activeSD.id} (${activeSD.current_phase || 'N/A'}, ${activeSD.progress || 0}%)`);
+  } else {
+    console.log('    No active SD');
+  }
+  console.log(`    Session: AUTO-PROCEED ${sessionSettings.autoProceed ? 'ON' : 'OFF'}`);
+  console.log(`    Git: branch=${gitState.branch}, ${stateFiles.length} state file(s)`);
+  console.log('');
+  console.log(`  Location: .claude/handoff/`);
+  console.log(`  Timestamp: ${timestamp}`);
+  console.log('');
+  console.log('  To import on new account: /handoff-in');
+  console.log('========================================');
+}
+
+main().catch(err => {
+  console.error('Handoff export failed:', err);
+  process.exit(1);
+});

--- a/scripts/handoff-import.cjs
+++ b/scripts/handoff-import.cjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+
+/**
+ * Handoff Import Script
+ *
+ * Reads the handoff package from .claude/handoff/ and:
+ * - Validates the package exists and is recent
+ * - Copies state files back to .claude/
+ * - Detects memory file merge scenarios (for Claude to resolve)
+ * - Displays the briefing
+ * - Suggests next action
+ *
+ * Memory merging is handled by Claude (via the /handoff-in command),
+ * NOT by this script. This script only detects conflicts.
+ *
+ * Usage: node scripts/handoff-import.cjs
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const HANDOFF_DIR = path.join(PROJECT_ROOT, '.claude', 'handoff');
+const MEMORY_DEST = path.join(
+  os.homedir(),
+  '.claude',
+  'projects',
+  'C--Users-rickf-Projects--EHG-EHG-Engineer',
+  'memory'
+);
+const CLAUDE_DIR = path.join(PROJECT_ROOT, '.claude');
+
+function fileHash(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function formatAge(ms) {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds} seconds ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} minute(s) ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour(s) ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day(s) ago`;
+}
+
+function restoreStateFiles() {
+  const stateDir = path.join(HANDOFF_DIR, 'state');
+  const restored = [];
+
+  if (!fs.existsSync(stateDir)) return restored;
+
+  const files = fs.readdirSync(stateDir).filter(f => f.endsWith('.json'));
+  for (const file of files) {
+    const src = path.join(stateDir, file);
+    const dest = path.join(CLAUDE_DIR, file);
+    fs.copyFileSync(src, dest);
+    restored.push(file);
+  }
+  return restored;
+}
+
+function analyzeMemoryFiles() {
+  const handoffMemDir = path.join(HANDOFF_DIR, 'memory');
+  const results = {
+    copy: [],      // Only in handoff → copy directly
+    keep: [],      // Only at destination → keep as-is
+    identical: [], // Same content → skip
+    merge: []      // Different content → Claude must merge
+  };
+
+  if (!fs.existsSync(handoffMemDir)) return results;
+
+  const handoffFiles = fs.readdirSync(handoffMemDir).filter(f => f.endsWith('.md'));
+  const destFiles = fs.existsSync(MEMORY_DEST)
+    ? fs.readdirSync(MEMORY_DEST).filter(f => f.endsWith('.md'))
+    : [];
+
+  const destSet = new Set(destFiles);
+  const handoffSet = new Set(handoffFiles);
+
+  for (const file of handoffFiles) {
+    const handoffPath = path.join(handoffMemDir, file);
+    const destPath = path.join(MEMORY_DEST, file);
+
+    if (!destSet.has(file)) {
+      // Only in handoff — copy directly
+      results.copy.push(file);
+    } else {
+      // Exists in both — compare
+      const handoffHash = fileHash(handoffPath);
+      const destHash = fileHash(destPath);
+      if (handoffHash === destHash) {
+        results.identical.push(file);
+      } else {
+        results.merge.push(file);
+      }
+    }
+  }
+
+  // Files only at destination
+  for (const file of destFiles) {
+    if (!handoffSet.has(file)) {
+      results.keep.push(file);
+    }
+  }
+
+  return results;
+}
+
+function copyNonConflictingMemory(analysis) {
+  const handoffMemDir = path.join(HANDOFF_DIR, 'memory');
+
+  if (!fs.existsSync(MEMORY_DEST)) {
+    fs.mkdirSync(MEMORY_DEST, { recursive: true });
+  }
+
+  // Copy files that only exist in handoff
+  for (const file of analysis.copy) {
+    fs.copyFileSync(
+      path.join(handoffMemDir, file),
+      path.join(MEMORY_DEST, file)
+    );
+  }
+}
+
+function main() {
+  console.log('');
+  console.log('========================================');
+  console.log('  HANDOFF IMPORT');
+  console.log('========================================');
+  console.log('');
+
+  // 1. Check handoff package exists
+  const metadataPath = path.join(HANDOFF_DIR, 'metadata.json');
+  if (!fs.existsSync(metadataPath)) {
+    console.error('  ERROR: No handoff package found at .claude/handoff/');
+    console.error('  Run /handoff-out on the other account first.');
+    process.exit(1);
+  }
+
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+
+  // 2. Check age
+  const handoffTime = new Date(metadata.timestampISO || metadata.timestamp);
+  const ageMs = Date.now() - handoffTime.getTime();
+  const ageStr = formatAge(ageMs);
+  const isStale = ageMs > 24 * 60 * 60 * 1000; // >24 hours
+
+  console.log(`  Package timestamp: ${metadata.timestamp}`);
+  console.log(`  Handoff age: ${ageStr}`);
+  if (isStale) {
+    console.log('  WARNING: Handoff package is over 24 hours old!');
+    console.log('  Consider running /handoff-out again on the source account.');
+  }
+  console.log('');
+
+  // 3. Restore state files
+  console.log('  Restoring state files...');
+  const restoredState = restoreStateFiles();
+  for (const f of restoredState) {
+    console.log(`    Restored: ${f}`);
+  }
+  if (restoredState.length === 0) {
+    console.log('    No state files to restore');
+  }
+  console.log('');
+
+  // 4. Analyze memory files
+  console.log('  Analyzing memory files...');
+  const analysis = analyzeMemoryFiles();
+
+  // Copy non-conflicting files
+  copyNonConflictingMemory(analysis);
+
+  // Report
+  console.log('');
+  console.log('  Memory Merge Results:');
+  for (const f of analysis.copy) {
+    console.log(`    ${f}: COPIED (not present at destination)`);
+  }
+  for (const f of analysis.keep) {
+    console.log(`    ${f}: KEPT (only at destination, not in handoff)`);
+  }
+  for (const f of analysis.identical) {
+    console.log(`    ${f}: IDENTICAL (no changes needed)`);
+  }
+  for (const f of analysis.merge) {
+    console.log(`    ${f}: NEEDS MERGE (different in handoff vs destination)`);
+  }
+
+  if (analysis.copy.length === 0 && analysis.keep.length === 0 &&
+      analysis.identical.length === 0 && analysis.merge.length === 0) {
+    console.log('    No memory files found');
+  }
+  console.log('');
+
+  // 5. Display briefing
+  const briefingPath = path.join(HANDOFF_DIR, 'briefing.md');
+  if (fs.existsSync(briefingPath)) {
+    const briefing = fs.readFileSync(briefingPath, 'utf8');
+    console.log('--- BRIEFING ---');
+    console.log(briefing);
+    console.log('--- END BRIEFING ---');
+  }
+  console.log('');
+
+  // 6. Output structured data for Claude to use
+  const output = {
+    success: true,
+    age: ageStr,
+    isStale,
+    restoredState,
+    memoryAnalysis: {
+      copied: analysis.copy,
+      kept: analysis.keep,
+      identical: analysis.identical,
+      needsMerge: analysis.merge
+    },
+    activeSD: metadata.activeSD,
+    sessionSettings: metadata.sessionSettings,
+    handoffMemoryDir: path.join(HANDOFF_DIR, 'memory'),
+    memoryDestDir: MEMORY_DEST
+  };
+
+  console.log('HANDOFF_IMPORT_RESULT=' + JSON.stringify(output));
+  console.log('');
+
+  // 7. Suggest next action
+  if (analysis.merge.length > 0) {
+    console.log(`  ACTION REQUIRED: ${analysis.merge.length} memory file(s) need merging.`);
+    console.log('  Claude will handle this automatically via /handoff-in.');
+  }
+
+  if (metadata.activeSD) {
+    console.log(`  Suggested: /leo continue (to resume ${metadata.activeSD.sdKey})`);
+  } else {
+    console.log('  Suggested: npm run sd:next (to see the queue)');
+  }
+
+  console.log('');
+  console.log('========================================');
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `/handoff-out` and `/handoff-in` slash commands for session continuity when switching between two Claude Code Max accounts
- Export script captures: memory files, session state (auto-proceed, unified-session), active SD from database, git context (branch, commits, modified files), and generates a human-readable briefing
- Import script restores state, detects memory merge scenarios (copy/keep/identical/merge), and displays the briefing with suggested next action
- Intelligent memory merge is handled by Claude via the `/handoff-in` command instructions (semantic markdown merge, not textual diff)
- Pre-commit hook updated to exclude `.claude/commands/` from DOCMON handoff file false positive

## Test plan
- [x] `/handoff-out` creates `.claude/handoff/` with all expected files (memory, state, briefing, metadata)
- [x] `/handoff-in` reads package, restores state, detects merge scenarios, displays briefing
- [x] `.claude/handoff/` properly gitignored
- [x] Pre-commit hook passes with handoff command files staged
- [x] Both scripts use CJS (no Windows ESM entry point issues)

:robot: Generated with [Claude Code](https://claude.com/claude-code)