### PR TITLE
fix: PID-based session claim safety

### DIFF
--- a/lib/session-conflict-checker.mjs
+++ b/lib/session-conflict-checker.mjs
@@ -41,7 +41,7 @@ const supabase = createClient(
 export async function isSDClaimed(sdId, excludeSessionId = null) {
   const { data, error } = await supabase
     .from('v_active_sessions')
-    .select('session_id, sd_id, sd_title, track, heartbeat_age_minutes, heartbeat_age_seconds, heartbeat_age_human, hostname, tty, codebase')
+    .select('session_id, sd_id, sd_title, track, heartbeat_age_minutes, heartbeat_age_seconds, heartbeat_age_human, hostname, tty, codebase, pid')
     .eq('sd_id', sdId)
     .eq('computed_status', 'active');
 
@@ -64,7 +64,8 @@ export async function isSDClaimed(sdId, excludeSessionId = null) {
       heartbeatAgeHuman: claim.heartbeat_age_human || formatHeartbeatAge(claim.heartbeat_age_seconds),
       hostname: claim.hostname || 'unknown',
       tty: claim.tty || 'unknown',
-      codebase: claim.codebase || 'unknown'
+      codebase: claim.codebase || 'unknown',
+      pid: claim.pid || null
     };
   }
 


### PR DESCRIPTION
## Summary
- Adds PID-based process liveness check to `sd-start.js` claim conflict handler
- Prevents claim theft between concurrent Claude Code instances on the same machine
- Three conflict scenarios: alive process (hard refuse), dead process (safe release), remote host (fallback)

## Changes
- `lib/session-conflict-checker.mjs`: Added `pid` to `isSDClaimed()` query and return object
- `scripts/sd-start.js`: Added `os` and `isProcessRunning` imports, replaced heuristic conflict handler with PID-aware 3-way check

## Root Cause
A Claude Code instance force-released another active session's SD claim because the heartbeat was >5 minutes old (the other instance was running a long testing operation). The existing conflict handler couldn't distinguish between "stale/abandoned" and "busy with long operation".

## Test plan
- [ ] Verify `npm run sd:start` on an SD claimed by another active instance shows "PROCESS IS RUNNING" with hard refuse
- [ ] Verify `npm run sd:start` on an SD claimed by a dead session shows "PROCESS EXITED" with cleanup instructions
- [ ] Verify unclaimed SD still claims successfully (no regression)
- [ ] Verify null PID sessions (legacy) don't crash, fall back to heartbeat guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)