### PR TITLE
fix: emit SESSION_SETTINGS from sd:next for chaining visibility

### DIFF
--- a/scripts/sd-next.js
+++ b/scripts/sd-next.js
@@ -24,10 +24,39 @@
  */
 
 import { runSDNext, colors } from './modules/sd-next/index.js';
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * Query session settings (auto_proceed + chain_orchestrators) and emit
+ * a machine-readable SESSION_SETTINGS line so autonomous flows know
+ * both settings without a separate query.
+ */
+async function emitSessionSettings() {
+  try {
+    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !key) return;
+
+    const supabase = createClient(url, key);
+    const { data } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('status', 'active')
+      .order('heartbeat_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    const autoProceed = data?.metadata?.auto_proceed ?? true;
+    const chainOrchestrators = data?.metadata?.chain_orchestrators ?? false;
+    console.log(`SESSION_SETTINGS:${JSON.stringify({ auto_proceed: autoProceed, chain_orchestrators: chainOrchestrators })}`);
+  } catch {
+    // Non-fatal — settings query failure doesn't block queue display
+  }
+}
 
 // Main execution
 runSDNext()
-  .then(result => {
+  .then(async (result) => {
     // PAT-AUTO-PROCEED-002 CAPA: Output structured action data
     // This machine-readable line enables autonomous workflow continuation
     // when AUTO-PROCEED is active. Claude parses this to determine next action
@@ -35,6 +64,10 @@ runSDNext()
     if (result && result.action !== 'none') {
       console.log(`\nAUTO_PROCEED_ACTION:${JSON.stringify(result)}`);
     }
+
+    // Emit session settings so autonomous flows see both auto_proceed
+    // AND chain_orchestrators without a separate query.
+    await emitSessionSettings();
   })
   .catch(err => {
     console.error(`${colors.red}Error: ${err.message}${colors.reset}`);


### PR DESCRIPTION
## Summary
- `sd:next` now emits a `SESSION_SETTINGS` line with both `auto_proceed` and `chain_orchestrators` values
- Prevents autonomous flows from assuming default chaining=OFF when session has chaining enabled
- Root cause: orchestrator boundary pause occurred despite `chain_orchestrators=true` because the setting was never queried

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Run `npm run sd:next` and verify `SESSION_SETTINGS:{"auto_proceed":true,"chain_orchestrators":true}` appears in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)