### PR TITLE
feat(eva): add event-driven venture monitor

### DIFF
--- a/database/migrations/20260213_eva_event_log.sql
+++ b/database/migrations/20260213_eva_event_log.sql
@@ -1,0 +1,36 @@
+-- EVA Event Log for Venture Monitor Audit Trail
+-- SD: SD-EVA-FEAT-EVENT-MONITOR-001
+-- Creates the eva_event_log table for tracking all realtime/cron-triggered actions
+
+CREATE TABLE IF NOT EXISTS eva_event_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type TEXT NOT NULL,
+  trigger_source TEXT NOT NULL CHECK (trigger_source IN ('realtime', 'cron', 'manual')),
+  venture_id UUID,
+  correlation_id UUID NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('succeeded', 'failed', 'suppressed')),
+  error_message TEXT,
+  job_name TEXT,
+  scheduled_time TIMESTAMPTZ,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_eva_event_log_correlation ON eva_event_log(correlation_id);
+CREATE INDEX IF NOT EXISTS idx_eva_event_log_created ON eva_event_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_eva_event_log_venture ON eva_event_log(venture_id) WHERE venture_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_eva_event_log_type ON eva_event_log(event_type);
+CREATE INDEX IF NOT EXISTS idx_eva_event_log_status ON eva_event_log(status);
+CREATE INDEX IF NOT EXISTS idx_eva_event_log_job ON eva_event_log(job_name) WHERE job_name IS NOT NULL;
+
+-- RLS
+ALTER TABLE eva_event_log ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on eva_event_log"
+  ON eva_event_log FOR ALL
+  USING (auth.role() = 'service_role');
+
+CREATE POLICY "Authenticated users can read eva_event_log"
+  ON eva_event_log FOR SELECT
+  USING (auth.role() = 'authenticated');

--- a/lib/eva/venture-monitor.js
+++ b/lib/eva/venture-monitor.js
@@ -1,0 +1,512 @@
+/**
+ * Event-Driven Venture Monitor
+ *
+ * Hybrid realtime + cron scheduler for automated venture monitoring.
+ * - Supabase Realtime: Detects chairman_decisions approvals, new venture_artifacts
+ * - Cron (setInterval): Portfolio health sweep, ops cycle checks, release scheduling
+ * - All actions logged to eva_event_log with correlation_id for audit trail
+ *
+ * SD: SD-EVA-FEAT-EVENT-MONITOR-001
+ * Implements: Vision Section 3 (Hybrid Runtime Model)
+ */
+
+import { randomUUID } from 'crypto';
+
+const ADVISORY_LOCK_BASE = 0x45564D4F; // "EVMO" in hex
+
+/**
+ * @typedef {Object} VentureMonitorConfig
+ * @property {number} [healthSweepHourUtc=2] - Hour (UTC) for daily health sweep
+ * @property {number} [opsCycleIntervalHours=6] - Hours between ops cycle checks
+ * @property {number} [cronPollIntervalMs=60000] - How often cron checks if a job is due
+ * @property {number} [maxProcessStageRetries=2] - Max retries for processStage failures
+ */
+
+export class VentureMonitor {
+  /**
+   * @param {Object} params
+   * @param {Object} params.supabase - Supabase client
+   * @param {Function} params.processStage - processStage function from eva-orchestrator
+   * @param {VentureMonitorConfig} [params.config]
+   * @param {Object} [params.logger]
+   */
+  constructor({ supabase, processStage, config = {}, logger = console }) {
+    this.supabase = supabase;
+    this.processStage = processStage;
+    this.logger = logger;
+    this.config = {
+      healthSweepHourUtc: config.healthSweepHourUtc ?? 2,
+      opsCycleIntervalHours: config.opsCycleIntervalHours ?? 6,
+      cronPollIntervalMs: config.cronPollIntervalMs ?? 60_000,
+      maxProcessStageRetries: config.maxProcessStageRetries ?? 2,
+      ...config,
+    };
+
+    this.channels = [];
+    this.cronTimer = null;
+    this.running = false;
+    this.processedEvents = new Set();
+    this._shutdownRequested = false;
+    this._activeJobs = 0;
+
+    // Track last execution times for cron jobs
+    this._lastRun = {
+      healthSweep: null,
+      opsCycle: null,
+      releaseScheduling: null,
+      nurseryReeval: null,
+    };
+  }
+
+  /**
+   * Start the venture monitor (Realtime subscriptions + cron scheduler).
+   */
+  async start() {
+    if (this.running) return;
+    this.running = true;
+    this._shutdownRequested = false;
+    this.logger.log('[VentureMonitor] Starting...');
+
+    this._subscribeToDecisions();
+    this._subscribeToArtifacts();
+    this._startCronScheduler();
+
+    this.logger.log('[VentureMonitor] Started successfully');
+  }
+
+  /**
+   * Gracefully stop the monitor.
+   * Waits for active jobs to complete before shutting down.
+   */
+  async stop() {
+    if (!this.running) return;
+    this._shutdownRequested = true;
+    this.logger.log('[VentureMonitor] Stopping...');
+
+    // Remove realtime channels
+    for (const channel of this.channels) {
+      this.supabase.removeChannel(channel);
+    }
+    this.channels = [];
+
+    // Stop cron
+    if (this.cronTimer) {
+      clearInterval(this.cronTimer);
+      this.cronTimer = null;
+    }
+
+    // Wait for active jobs (max 30s)
+    const deadline = Date.now() + 30_000;
+    while (this._activeJobs > 0 && Date.now() < deadline) {
+      await new Promise(r => setTimeout(r, 500));
+    }
+
+    this.running = false;
+    this.processedEvents.clear();
+    this.logger.log('[VentureMonitor] Stopped');
+  }
+
+  // ─── Realtime Subscriptions ────────────────────────────────────
+
+  _subscribeToDecisions() {
+    const channel = this.supabase
+      .channel('venture-monitor-decisions')
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'chairman_decisions',
+        },
+        (payload) => this._handleDecisionChange(payload)
+      )
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          this.logger.log('[VentureMonitor] Subscribed to chairman_decisions');
+        } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+          this.logger.warn('[VentureMonitor] chairman_decisions subscription error:', status);
+        }
+      });
+
+    this.channels.push(channel);
+  }
+
+  _subscribeToArtifacts() {
+    const channel = this.supabase
+      .channel('venture-monitor-artifacts')
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'venture_artifacts',
+        },
+        (payload) => this._handleNewArtifact(payload)
+      )
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          this.logger.log('[VentureMonitor] Subscribed to venture_artifacts');
+        }
+      });
+
+    this.channels.push(channel);
+  }
+
+  // ─── Event Handlers ────────────────────────────────────────────
+
+  async _handleDecisionChange(payload) {
+    const { new: row, old: oldRow } = payload;
+    if (!row || row.status !== 'approved') return;
+    if (oldRow && oldRow.status === 'approved') return; // Already approved
+
+    const eventKey = `decision:${row.id}`;
+    if (this.processedEvents.has(eventKey)) {
+      const correlationId = randomUUID();
+      await this._logEvent({
+        eventType: 'realtime_trigger',
+        triggerSource: 'realtime',
+        ventureId: row.venture_id,
+        correlationId,
+        status: 'suppressed',
+        metadata: { reason: 'duplicate', decision_id: row.id },
+      });
+      return;
+    }
+    this.processedEvents.add(eventKey);
+
+    const correlationId = randomUUID();
+    this.logger.log(`[VentureMonitor] Decision approved: ${row.id} for venture ${row.venture_id}`);
+
+    try {
+      this._activeJobs++;
+      const result = await this.processStage(
+        { ventureId: row.venture_id, options: { parentTraceId: correlationId } },
+        { supabase: this.supabase }
+      );
+
+      await this._logEvent({
+        eventType: 'venture_advancement',
+        triggerSource: 'realtime',
+        ventureId: row.venture_id,
+        correlationId,
+        status: 'succeeded',
+        metadata: {
+          decision_id: row.id,
+          stage_id: result?.stageId,
+          result_status: result?.status,
+        },
+      });
+    } catch (err) {
+      await this._logEvent({
+        eventType: 'venture_advancement',
+        triggerSource: 'realtime',
+        ventureId: row.venture_id,
+        correlationId,
+        status: 'failed',
+        errorMessage: err.message,
+        metadata: { decision_id: row.id },
+      });
+    } finally {
+      this._activeJobs--;
+    }
+  }
+
+  async _handleNewArtifact(payload) {
+    const { new: row } = payload;
+    if (!row) return;
+
+    const correlationId = randomUUID();
+    await this._logEvent({
+      eventType: 'artifact_created',
+      triggerSource: 'realtime',
+      ventureId: row.venture_id,
+      correlationId,
+      status: 'succeeded',
+      metadata: {
+        artifact_type: row.artifact_type,
+        lifecycle_stage: row.lifecycle_stage,
+        title: row.title,
+      },
+    });
+  }
+
+  // ─── Cron Scheduler ────────────────────────────────────────────
+
+  _startCronScheduler() {
+    this.cronTimer = setInterval(
+      () => this._cronTick(),
+      this.config.cronPollIntervalMs
+    );
+  }
+
+  async _cronTick() {
+    if (this._shutdownRequested) return;
+    const now = new Date();
+
+    // Daily health sweep (at configured hour UTC)
+    if (this._isDue(now, 'healthSweep', 24)) {
+      if (now.getUTCHours() === this.config.healthSweepHourUtc) {
+        await this._runCronJob('portfolio_health_sweep', () => this._portfolioHealthSweep());
+      }
+    }
+
+    // Ops cycle check (every N hours)
+    if (this._isDue(now, 'opsCycle', this.config.opsCycleIntervalHours)) {
+      await this._runCronJob('ops_cycle_check', () => this._opsCycleCheck());
+    }
+
+    // Release scheduling (weekly, Monday)
+    if (this._isDue(now, 'releaseScheduling', 168) && now.getUTCDay() === 1) {
+      await this._runCronJob('release_scheduling', () => this._releaseScheduling());
+    }
+
+    // Nursery re-evaluation (weekly, Wednesday)
+    if (this._isDue(now, 'nurseryReeval', 168) && now.getUTCDay() === 3) {
+      await this._runCronJob('nursery_reevaluation', () => this._nurseryReEvaluation());
+    }
+  }
+
+  _isDue(now, jobKey, intervalHours) {
+    const last = this._lastRun[jobKey];
+    if (!last) return true;
+    const elapsedMs = now.getTime() - last.getTime();
+    return elapsedMs >= intervalHours * 3600_000;
+  }
+
+  async _runCronJob(jobName, fn) {
+    if (this._shutdownRequested) return;
+
+    const lockId = ADVISORY_LOCK_BASE + this._hashJobName(jobName);
+    const correlationId = randomUUID();
+    const scheduledTime = new Date();
+
+    // Try to acquire advisory lock
+    const locked = await this._acquireAdvisoryLock(lockId);
+    if (!locked) {
+      await this._logEvent({
+        eventType: 'cron_trigger',
+        triggerSource: 'cron',
+        correlationId,
+        status: 'suppressed',
+        jobName,
+        scheduledTime,
+        metadata: { reason: 'lock_contention' },
+      });
+      return;
+    }
+
+    this._activeJobs++;
+    try {
+      this.logger.log(`[VentureMonitor] Running cron job: ${jobName}`);
+      await fn(correlationId);
+
+      // Update last run time
+      const jobKey = this._jobNameToKey(jobName);
+      if (jobKey) this._lastRun[jobKey] = scheduledTime;
+
+      await this._logEvent({
+        eventType: 'cron_trigger',
+        triggerSource: 'cron',
+        correlationId,
+        status: 'succeeded',
+        jobName,
+        scheduledTime,
+      });
+    } catch (err) {
+      await this._logEvent({
+        eventType: 'cron_trigger',
+        triggerSource: 'cron',
+        correlationId,
+        status: 'failed',
+        jobName,
+        scheduledTime,
+        errorMessage: err.message,
+      });
+    } finally {
+      await this._releaseAdvisoryLock(lockId);
+      this._activeJobs--;
+    }
+  }
+
+  // ─── Cron Job Implementations ──────────────────────────────────
+
+  async _portfolioHealthSweep(correlationId) {
+    const { data: ventures, error } = await this.supabase
+      .from('eva_ventures')
+      .select('id, current_stage')
+      .eq('status', 'active');
+
+    if (error) throw new Error(`Health sweep query failed: ${error.message}`);
+    if (!ventures?.length) return;
+
+    for (const venture of ventures) {
+      if (this._shutdownRequested) break;
+      try {
+        await this.processStage(
+          { ventureId: venture.id, options: { parentTraceId: correlationId } },
+          { supabase: this.supabase }
+        );
+        await this._logEvent({
+          eventType: 'venture_check',
+          triggerSource: 'cron',
+          ventureId: venture.id,
+          correlationId,
+          status: 'succeeded',
+          jobName: 'portfolio_health_sweep',
+        });
+      } catch (err) {
+        await this._logEvent({
+          eventType: 'venture_check',
+          triggerSource: 'cron',
+          ventureId: venture.id,
+          correlationId,
+          status: 'failed',
+          jobName: 'portfolio_health_sweep',
+          errorMessage: err.message,
+        });
+      }
+    }
+  }
+
+  async _opsCycleCheck(correlationId) {
+    const { data: ventures, error } = await this.supabase
+      .from('eva_ventures')
+      .select('id, current_stage')
+      .eq('status', 'active')
+      .gte('current_stage', 24);
+
+    if (error) throw new Error(`Ops cycle query failed: ${error.message}`);
+    if (!ventures?.length) return;
+
+    for (const venture of ventures) {
+      if (this._shutdownRequested) break;
+      try {
+        await this.processStage(
+          { ventureId: venture.id, options: { parentTraceId: correlationId } },
+          { supabase: this.supabase }
+        );
+      } catch (err) {
+        this.logger.warn(`[VentureMonitor] Ops cycle check failed for ${venture.id}: ${err.message}`);
+      }
+    }
+  }
+
+  async _releaseScheduling(correlationId) {
+    const { data: ventures, error } = await this.supabase
+      .from('eva_ventures')
+      .select('id, current_stage')
+      .eq('status', 'active')
+      .eq('current_stage', 22);
+
+    if (error) throw new Error(`Release scheduling query failed: ${error.message}`);
+    if (!ventures?.length) return;
+
+    for (const venture of ventures) {
+      if (this._shutdownRequested) break;
+      try {
+        await this.processStage(
+          { ventureId: venture.id, options: { parentTraceId: correlationId } },
+          { supabase: this.supabase }
+        );
+      } catch (err) {
+        this.logger.warn(`[VentureMonitor] Release scheduling failed for ${venture.id}: ${err.message}`);
+      }
+    }
+  }
+
+  async _nurseryReEvaluation(correlationId) {
+    const { data: ventures, error } = await this.supabase
+      .from('eva_ventures')
+      .select('id, current_stage')
+      .eq('status', 'active')
+      .lte('current_stage', 2);
+
+    if (error) throw new Error(`Nursery re-eval query failed: ${error.message}`);
+    if (!ventures?.length) return;
+
+    for (const venture of ventures) {
+      if (this._shutdownRequested) break;
+      try {
+        await this.processStage(
+          { ventureId: venture.id, options: { parentTraceId: correlationId } },
+          { supabase: this.supabase }
+        );
+      } catch (err) {
+        this.logger.warn(`[VentureMonitor] Nursery re-eval failed for ${venture.id}: ${err.message}`);
+      }
+    }
+  }
+
+  // ─── Advisory Lock ─────────────────────────────────────────────
+
+  async _acquireAdvisoryLock(lockId) {
+    try {
+      const { data, error } = await this.supabase.rpc('pg_try_advisory_lock', { lock_id: lockId });
+      if (error) {
+        this.logger.warn(`[VentureMonitor] Advisory lock query failed: ${error.message}`);
+        return false;
+      }
+      return data === true;
+    } catch {
+      return false;
+    }
+  }
+
+  async _releaseAdvisoryLock(lockId) {
+    try {
+      await this.supabase.rpc('pg_advisory_unlock', { lock_id: lockId });
+    } catch {
+      // Best-effort unlock
+    }
+  }
+
+  // ─── Event Logging ─────────────────────────────────────────────
+
+  async _logEvent({
+    eventType,
+    triggerSource,
+    ventureId = null,
+    correlationId,
+    status,
+    errorMessage = null,
+    jobName = null,
+    scheduledTime = null,
+    metadata = {},
+  }) {
+    try {
+      await this.supabase.from('eva_event_log').insert({
+        event_type: eventType,
+        trigger_source: triggerSource,
+        venture_id: ventureId,
+        correlation_id: correlationId,
+        status,
+        error_message: errorMessage,
+        job_name: jobName,
+        scheduled_time: scheduledTime?.toISOString() ?? null,
+        metadata,
+      });
+    } catch (err) {
+      this.logger.warn(`[VentureMonitor] Failed to log event: ${err.message}`);
+    }
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────
+
+  _hashJobName(name) {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+    }
+    return Math.abs(hash) % 1_000_000;
+  }
+
+  _jobNameToKey(jobName) {
+    const map = {
+      portfolio_health_sweep: 'healthSweep',
+      ops_cycle_check: 'opsCycle',
+      release_scheduling: 'releaseScheduling',
+      nursery_reevaluation: 'nurseryReeval',
+    };
+    return map[jobName] || null;
+  }
+}

--- a/scripts/eva-venture-monitor.js
+++ b/scripts/eva-venture-monitor.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+/**
+ * EVA Venture Monitor CLI
+ *
+ * Starts the event-driven venture monitor service.
+ * Usage: node scripts/eva-venture-monitor.js [start|stop|status]
+ *
+ * SD: SD-EVA-FEAT-EVENT-MONITOR-001
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { config as dotenvConfig } from 'dotenv';
+import { VentureMonitor } from '../lib/eva/venture-monitor.js';
+import { processStage } from '../lib/eva/eva-orchestrator.js';
+
+dotenvConfig();
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+const monitor = new VentureMonitor({
+  supabase,
+  processStage,
+  config: {
+    healthSweepHourUtc: parseInt(process.env.EVA_HEALTH_SWEEP_HOUR_UTC || '2', 10),
+    opsCycleIntervalHours: parseInt(process.env.EVA_OPS_CYCLE_INTERVAL_HOURS || '6', 10),
+    cronPollIntervalMs: parseInt(process.env.EVA_CRON_POLL_INTERVAL_MS || '60000', 10),
+  },
+});
+
+// Graceful shutdown
+function handleShutdown(signal) {
+  console.log(`\n[VentureMonitor] Received ${signal}, shutting down...`);
+  monitor.stop().then(() => {
+    console.log('[VentureMonitor] Clean shutdown complete');
+    process.exit(0);
+  });
+}
+
+process.on('SIGTERM', () => handleShutdown('SIGTERM'));
+process.on('SIGINT', () => handleShutdown('SIGINT'));
+
+// Start
+console.log('============================================================');
+console.log('  EVA Venture Monitor');
+console.log('============================================================');
+console.log(`  Health sweep hour (UTC): ${monitor.config.healthSweepHourUtc}`);
+console.log(`  Ops cycle interval: ${monitor.config.opsCycleIntervalHours}h`);
+console.log(`  Cron poll interval: ${monitor.config.cronPollIntervalMs}ms`);
+console.log('============================================================');
+
+monitor.start().then(() => {
+  console.log('[VentureMonitor] Service running. Press Ctrl+C to stop.');
+});

--- a/tests/unit/eva/venture-monitor.test.js
+++ b/tests/unit/eva/venture-monitor.test.js
@@ -1,0 +1,505 @@
+/**
+ * Tests for lib/eva/venture-monitor.js
+ * SD: SD-EVA-FEAT-EVENT-MONITOR-001
+ *
+ * Covers: VentureMonitor class
+ * Focus: Realtime event handling, cron scheduling, deduplication,
+ *        advisory locks, graceful shutdown, event logging
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { VentureMonitor } from '../../../lib/eva/venture-monitor.js';
+
+function createMockSupabase() {
+  const channels = [];
+  const insertedEvents = [];
+
+  const mockChannel = {
+    on: vi.fn().mockReturnThis(),
+    subscribe: vi.fn((cb) => {
+      if (cb) cb('SUBSCRIBED');
+      return mockChannel;
+    }),
+  };
+
+  const supabase = {
+    channel: vi.fn(() => {
+      channels.push(mockChannel);
+      return mockChannel;
+    }),
+    removeChannel: vi.fn(),
+    from: vi.fn((table) => {
+      if (table === 'eva_event_log') {
+        return {
+          insert: vi.fn((data) => {
+            insertedEvents.push(data);
+            return Promise.resolve({ error: null });
+          }),
+        };
+      }
+      // Default: query builder for eva_ventures
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            gte: vi.fn().mockResolvedValue({ data: [], error: null }),
+            lte: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+          gte: vi.fn().mockReturnValue({
+            // For chained .gte().lte() etc
+            mockResolvedValue: vi.fn(),
+          }),
+        }),
+      };
+    }),
+    rpc: vi.fn().mockResolvedValue({ data: true, error: null }),
+    _channels: channels,
+    _insertedEvents: insertedEvents,
+    _mockChannel: mockChannel,
+  };
+
+  return supabase;
+}
+
+describe('VentureMonitor', () => {
+  let monitor;
+  let mockSupabase;
+  let mockProcessStage;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockSupabase = createMockSupabase();
+    mockProcessStage = vi.fn().mockResolvedValue({
+      ventureId: 'v1',
+      stageId: 5,
+      status: 'COMPLETED',
+    });
+    mockLogger = {
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    monitor = new VentureMonitor({
+      supabase: mockSupabase,
+      processStage: mockProcessStage,
+      config: {
+        cronPollIntervalMs: 999_999_999, // Very high so cron never fires during tests
+        healthSweepHourUtc: 2,
+        opsCycleIntervalHours: 6,
+      },
+      logger: mockLogger,
+    });
+  });
+
+  afterEach(async () => {
+    if (monitor.running) {
+      await monitor.stop();
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe('start and stop', () => {
+    it('subscribes to realtime channels on start', async () => {
+      await monitor.start();
+
+      expect(mockSupabase.channel).toHaveBeenCalledWith('venture-monitor-decisions');
+      expect(mockSupabase.channel).toHaveBeenCalledWith('venture-monitor-artifacts');
+      expect(monitor.running).toBe(true);
+    });
+
+    it('removes channels and stops cron on stop', async () => {
+      await monitor.start();
+      await monitor.stop();
+
+      expect(mockSupabase.removeChannel).toHaveBeenCalledTimes(2);
+      expect(monitor.running).toBe(false);
+    });
+
+    it('is idempotent - multiple starts do not duplicate subscriptions', async () => {
+      await monitor.start();
+      await monitor.start(); // second call should be no-op
+
+      // Only 2 channels created (decisions + artifacts)
+      expect(mockSupabase.channel).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears processed events set on stop', async () => {
+      await monitor.start();
+      monitor.processedEvents.add('test:1');
+      expect(monitor.processedEvents.size).toBe(1);
+
+      await monitor.stop();
+      expect(monitor.processedEvents.size).toBe(0);
+    });
+  });
+
+  describe('Realtime: chairman_decisions approval', () => {
+    it('calls processStage when decision status changes to approved', async () => {
+      await monitor.start();
+
+      // Get the handler registered for chairman_decisions
+      const decisionsChannel = mockSupabase._mockChannel;
+      const handler = decisionsChannel.on.mock.calls[0][2];
+
+      // Simulate approved decision
+      await handler({
+        new: { id: 'd1', venture_id: 'v1', status: 'approved' },
+        old: { id: 'd1', venture_id: 'v1', status: 'pending' },
+      });
+
+      expect(mockProcessStage).toHaveBeenCalledTimes(1);
+      expect(mockProcessStage).toHaveBeenCalledWith(
+        expect.objectContaining({ ventureId: 'v1' }),
+        expect.objectContaining({ supabase: mockSupabase })
+      );
+    });
+
+    it('logs succeeded event after successful processStage', async () => {
+      await monitor.start();
+      const handler = mockSupabase._mockChannel.on.mock.calls[0][2];
+
+      await handler({
+        new: { id: 'd1', venture_id: 'v1', status: 'approved' },
+        old: { id: 'd1', venture_id: 'v1', status: 'pending' },
+      });
+
+      // Check event was logged
+      const eventInsert = mockSupabase._insertedEvents.find(
+        e => e.event_type === 'venture_advancement' && e.status === 'succeeded'
+      );
+      expect(eventInsert).toBeDefined();
+      expect(eventInsert.trigger_source).toBe('realtime');
+      expect(eventInsert.venture_id).toBe('v1');
+      expect(eventInsert.correlation_id).toBeTruthy();
+    });
+
+    it('deduplicates - same decision ID triggers processStage only once', async () => {
+      await monitor.start();
+      const handler = mockSupabase._mockChannel.on.mock.calls[0][2];
+
+      const payload = {
+        new: { id: 'd1', venture_id: 'v1', status: 'approved' },
+        old: { id: 'd1', venture_id: 'v1', status: 'pending' },
+      };
+
+      await handler(payload);
+      await handler(payload); // duplicate
+
+      expect(mockProcessStage).toHaveBeenCalledTimes(1);
+
+      // Second call should log suppressed
+      const suppressed = mockSupabase._insertedEvents.find(
+        e => e.status === 'suppressed'
+      );
+      expect(suppressed).toBeDefined();
+      expect(suppressed.metadata.reason).toBe('duplicate');
+    });
+
+    it('ignores non-approved status changes', async () => {
+      await monitor.start();
+      const handler = mockSupabase._mockChannel.on.mock.calls[0][2];
+
+      await handler({
+        new: { id: 'd2', venture_id: 'v2', status: 'rejected' },
+        old: { id: 'd2', venture_id: 'v2', status: 'pending' },
+      });
+
+      expect(mockProcessStage).not.toHaveBeenCalled();
+    });
+
+    it('ignores already-approved to approved (no-op update)', async () => {
+      await monitor.start();
+      const handler = mockSupabase._mockChannel.on.mock.calls[0][2];
+
+      await handler({
+        new: { id: 'd3', venture_id: 'v3', status: 'approved' },
+        old: { id: 'd3', venture_id: 'v3', status: 'approved' },
+      });
+
+      expect(mockProcessStage).not.toHaveBeenCalled();
+    });
+
+    it('logs failed event when processStage throws', async () => {
+      mockProcessStage.mockRejectedValueOnce(new Error('Stage execution failed'));
+
+      await monitor.start();
+      const handler = mockSupabase._mockChannel.on.mock.calls[0][2];
+
+      await handler({
+        new: { id: 'd4', venture_id: 'v4', status: 'approved' },
+        old: { id: 'd4', venture_id: 'v4', status: 'pending' },
+      });
+
+      const failed = mockSupabase._insertedEvents.find(
+        e => e.event_type === 'venture_advancement' && e.status === 'failed'
+      );
+      expect(failed).toBeDefined();
+      expect(failed.error_message).toBe('Stage execution failed');
+    });
+  });
+
+  describe('Realtime: venture_artifacts', () => {
+    it('logs artifact creation event', async () => {
+      await monitor.start();
+      // Artifacts handler is the second .on() call
+      const handler = mockSupabase._mockChannel.on.mock.calls[1][2];
+
+      await handler({
+        new: {
+          id: 'a1',
+          venture_id: 'v1',
+          artifact_type: 'critique_report',
+          lifecycle_stage: 3,
+          title: 'Critique for Stage 3',
+        },
+      });
+
+      const logged = mockSupabase._insertedEvents.find(
+        e => e.event_type === 'artifact_created'
+      );
+      expect(logged).toBeDefined();
+      expect(logged.status).toBe('succeeded');
+      expect(logged.metadata.artifact_type).toBe('critique_report');
+    });
+
+    it('handles null payload gracefully', async () => {
+      await monitor.start();
+      const handler = mockSupabase._mockChannel.on.mock.calls[1][2];
+
+      // Should not throw
+      await handler({ new: null });
+      expect(mockSupabase._insertedEvents).toHaveLength(0);
+    });
+  });
+
+  describe('Cron scheduler', () => {
+    it('starts cron timer on start', async () => {
+      await monitor.start();
+      expect(monitor.cronTimer).toBeTruthy();
+    });
+
+    it('stops cron timer on stop', async () => {
+      await monitor.start();
+      await monitor.stop();
+      expect(monitor.cronTimer).toBeNull();
+    });
+
+    it('acquires advisory lock before running cron job', async () => {
+      // Setup: make _isDue return true for opsCycle
+      monitor._lastRun.opsCycle = null;
+
+      // Mock eva_ventures query to return empty (so job completes quickly)
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === 'eva_event_log') {
+          return {
+            insert: vi.fn((data) => {
+              mockSupabase._insertedEvents.push(data);
+              return Promise.resolve({ error: null });
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              gte: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        };
+      });
+
+      await monitor._runCronJob('ops_cycle_check', async () => {});
+
+      // Should have called rpc for advisory lock
+      expect(mockSupabase.rpc).toHaveBeenCalledWith(
+        'pg_try_advisory_lock',
+        expect.objectContaining({ lock_id: expect.any(Number) })
+      );
+    });
+
+    it('skips job and logs suppressed when lock not acquired', async () => {
+      // Lock acquisition fails
+      mockSupabase.rpc.mockResolvedValueOnce({ data: false, error: null });
+
+      await monitor._runCronJob('test_job', async () => {
+        throw new Error('Should not run');
+      });
+
+      const suppressed = mockSupabase._insertedEvents.find(
+        e => e.status === 'suppressed' && e.metadata?.reason === 'lock_contention'
+      );
+      expect(suppressed).toBeDefined();
+      expect(suppressed.job_name).toBe('test_job');
+    });
+
+    it('logs failed event when cron job throws', async () => {
+      mockSupabase.rpc.mockResolvedValue({ data: true, error: null });
+
+      await monitor._runCronJob('failing_job', async () => {
+        throw new Error('Cron job exploded');
+      });
+
+      const failed = mockSupabase._insertedEvents.find(
+        e => e.status === 'failed' && e.job_name === 'failing_job'
+      );
+      expect(failed).toBeDefined();
+      expect(failed.error_message).toBe('Cron job exploded');
+    });
+
+    it('releases advisory lock after job completion', async () => {
+      mockSupabase.rpc
+        .mockResolvedValueOnce({ data: true, error: null }) // acquire
+        .mockResolvedValueOnce({ data: true, error: null }); // release
+
+      await monitor._runCronJob('test_release', async () => {});
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith(
+        'pg_advisory_unlock',
+        expect.objectContaining({ lock_id: expect.any(Number) })
+      );
+    });
+
+    it('releases advisory lock even if job throws', async () => {
+      mockSupabase.rpc
+        .mockResolvedValueOnce({ data: true, error: null }) // acquire
+        .mockResolvedValueOnce({ data: true, error: null }); // release
+
+      await monitor._runCronJob('test_release_on_error', async () => {
+        throw new Error('boom');
+      });
+
+      // Second rpc call should be unlock
+      expect(mockSupabase.rpc).toHaveBeenCalledTimes(2);
+      expect(mockSupabase.rpc.mock.calls[1][0]).toBe('pg_advisory_unlock');
+    });
+  });
+
+  describe('_isDue', () => {
+    it('returns true when job has never run', () => {
+      expect(monitor._isDue(new Date(), 'healthSweep', 24)).toBe(true);
+    });
+
+    it('returns false when job ran recently', () => {
+      const now = new Date();
+      monitor._lastRun.healthSweep = new Date(now.getTime() - 3600_000); // 1h ago
+      expect(monitor._isDue(now, 'healthSweep', 24)).toBe(false);
+    });
+
+    it('returns true when enough time has elapsed', () => {
+      const now = new Date();
+      monitor._lastRun.opsCycle = new Date(now.getTime() - 7 * 3600_000); // 7h ago
+      expect(monitor._isDue(now, 'opsCycle', 6)).toBe(true);
+    });
+  });
+
+  describe('Graceful shutdown', () => {
+    it('sets _shutdownRequested to prevent new job starts', async () => {
+      await monitor.start();
+      expect(monitor._shutdownRequested).toBe(false);
+
+      const stopPromise = monitor.stop();
+      expect(monitor._shutdownRequested).toBe(true);
+      await stopPromise;
+    });
+
+    it('waits for active jobs before completing stop', async () => {
+      await monitor.start();
+
+      // Simulate an active job
+      monitor._activeJobs = 1;
+
+      const stopPromise = monitor.stop();
+
+      // Job completes after 50ms (well within 30s deadline)
+      setTimeout(() => { monitor._activeJobs = 0; }, 50);
+
+      await stopPromise;
+
+      expect(monitor.running).toBe(false);
+    });
+  });
+
+  describe('Event logging', () => {
+    it('inserts event into eva_event_log table', async () => {
+      await monitor._logEvent({
+        eventType: 'test_event',
+        triggerSource: 'manual',
+        ventureId: 'v1',
+        correlationId: '00000000-0000-0000-0000-000000000001',
+        status: 'succeeded',
+        metadata: { test: true },
+      });
+
+      expect(mockSupabase._insertedEvents).toHaveLength(1);
+      const event = mockSupabase._insertedEvents[0];
+      expect(event.event_type).toBe('test_event');
+      expect(event.trigger_source).toBe('manual');
+      expect(event.venture_id).toBe('v1');
+      expect(event.status).toBe('succeeded');
+    });
+
+    it('handles logging failure gracefully', async () => {
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === 'eva_event_log') {
+          return {
+            insert: vi.fn().mockRejectedValue(new Error('DB down')),
+          };
+        }
+        return { select: vi.fn().mockReturnThis() };
+      });
+
+      // Should not throw
+      await monitor._logEvent({
+        eventType: 'test',
+        triggerSource: 'manual',
+        correlationId: 'c1',
+        status: 'succeeded',
+      });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to log event')
+      );
+    });
+
+    it('includes optional fields when provided', async () => {
+      const scheduledTime = new Date('2026-02-13T02:00:00Z');
+      await monitor._logEvent({
+        eventType: 'cron_trigger',
+        triggerSource: 'cron',
+        correlationId: 'c2',
+        status: 'succeeded',
+        jobName: 'portfolio_health_sweep',
+        scheduledTime,
+        errorMessage: null,
+      });
+
+      const event = mockSupabase._insertedEvents[0];
+      expect(event.job_name).toBe('portfolio_health_sweep');
+      expect(event.scheduled_time).toBe(scheduledTime.toISOString());
+    });
+  });
+
+  describe('Helper functions', () => {
+    it('_hashJobName returns consistent hash for same input', () => {
+      const hash1 = monitor._hashJobName('portfolio_health_sweep');
+      const hash2 = monitor._hashJobName('portfolio_health_sweep');
+      expect(hash1).toBe(hash2);
+    });
+
+    it('_hashJobName returns different hashes for different inputs', () => {
+      const hash1 = monitor._hashJobName('portfolio_health_sweep');
+      const hash2 = monitor._hashJobName('ops_cycle_check');
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('_jobNameToKey maps known job names', () => {
+      expect(monitor._jobNameToKey('portfolio_health_sweep')).toBe('healthSweep');
+      expect(monitor._jobNameToKey('ops_cycle_check')).toBe('opsCycle');
+      expect(monitor._jobNameToKey('release_scheduling')).toBe('releaseScheduling');
+      expect(monitor._jobNameToKey('nursery_reevaluation')).toBe('nurseryReeval');
+    });
+
+    it('_jobNameToKey returns null for unknown job names', () => {
+      expect(monitor._jobNameToKey('unknown_job')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `VentureMonitor` class (`lib/eva/venture-monitor.js`) implementing hybrid realtime + cron monitoring for EVA ventures
- Supabase Realtime subscriptions detect chairman_decisions approvals and new venture_artifacts
- Cron scheduler with PostgreSQL advisory locks runs portfolio health sweeps, ops cycle checks, release scheduling, and nursery re-evaluation
- Event deduplication via in-memory Set, graceful shutdown with active job draining
- All actions logged to `eva_event_log` table with correlation IDs for full audit trail
- CLI entry point (`scripts/eva-venture-monitor.js`) with env-configurable settings and signal handlers
- Migration creates `eva_event_log` table with 6 indexes and RLS policies

## Test plan
- [x] 31 unit tests passing (venture-monitor.test.js)
- [x] Migration executed and verified (table, indexes, RLS policies)
- [ ] Integration test with live Supabase Realtime (manual)

SD: SD-EVA-FEAT-EVENT-MONITOR-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)