### PR TITLE
fix(session): terminal_id matching, is_alive liveness, atomic claim switching

### DIFF
--- a/database/migrations/session_liveness_is_alive_and_switch_claim.sql
+++ b/database/migrations/session_liveness_is_alive_and_switch_claim.sql
@@ -1,0 +1,142 @@
+-- SD-LEO-FIX-FIX-SESSION-LIVENESS-001: Session Liveness & Atomic Claim Switching
+-- US-002: Add is_alive column and v_live_sessions view
+-- US-003: Create switch_sd_claim() atomic RPC
+
+-- ============================================================
+-- US-002: is_alive column
+-- ============================================================
+
+-- Add is_alive boolean column (default false = not alive until heartbeat starts)
+ALTER TABLE claude_sessions
+  ADD COLUMN IF NOT EXISTS is_alive BOOLEAN DEFAULT false;
+
+-- Index for fast filtering of live sessions
+CREATE INDEX IF NOT EXISTS idx_claude_sessions_is_alive
+  ON claude_sessions (is_alive) WHERE is_alive = true;
+
+-- ============================================================
+-- US-002: v_live_sessions view
+-- ============================================================
+
+-- View that shows only genuinely alive sessions:
+-- is_alive=true AND heartbeat within 5 minutes
+CREATE OR REPLACE VIEW v_live_sessions AS
+SELECT
+  cs.*,
+  EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) AS heartbeat_age_seconds,
+  CASE
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 60 THEN
+      ROUND(EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)))::TEXT || 's ago'
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 3600 THEN
+      ROUND(EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 60)::TEXT || 'm ago'
+    ELSE
+      ROUND(EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 3600)::TEXT || 'h ago'
+  END AS heartbeat_age_human
+FROM claude_sessions cs
+WHERE cs.is_alive = true
+  AND cs.status IN ('active', 'idle')
+  AND cs.heartbeat_at > NOW() - INTERVAL '5 minutes';
+
+COMMENT ON VIEW v_live_sessions IS
+  'Sessions with active heartbeat process (is_alive=true) and recent heartbeat (<5min). '
+  'Unlike v_active_sessions which infers liveness from status/heartbeat, this view uses '
+  'the explicit is_alive flag set by the heartbeat manager.';
+
+-- ============================================================
+-- US-003: switch_sd_claim() atomic RPC
+-- ============================================================
+
+-- Atomically switch an SD claim from one SD to another within a single transaction.
+-- Prevents the gap where a session has no claim (appears dead) during SD switching.
+CREATE OR REPLACE FUNCTION switch_sd_claim(
+  p_session_id TEXT,
+  p_old_sd_id TEXT,
+  p_new_sd_id TEXT,
+  p_new_track TEXT DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_session RECORD;
+  v_conflict RECORD;
+BEGIN
+  -- Validate session exists and owns the old claim
+  SELECT * INTO v_session
+  FROM claude_sessions
+  WHERE session_id = p_session_id
+    AND status = 'active'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Session not found or not active'
+    );
+  END IF;
+
+  -- Verify session currently holds the old SD claim
+  IF v_session.sd_id IS DISTINCT FROM p_old_sd_id THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Session does not hold claim on %s (current: %s)', p_old_sd_id, COALESCE(v_session.sd_id, 'none'))
+    );
+  END IF;
+
+  -- Check if new SD is already claimed by another active session
+  SELECT session_id, sd_id INTO v_conflict
+  FROM claude_sessions
+  WHERE sd_id = p_new_sd_id
+    AND status = 'active'
+    AND session_id != p_session_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('SD %s is already claimed by session %s', p_new_sd_id, v_conflict.session_id),
+      'conflict_session_id', v_conflict.session_id
+    );
+  END IF;
+
+  -- Atomic switch: update SD claim in a single UPDATE
+  UPDATE claude_sessions
+  SET
+    sd_id = p_new_sd_id,
+    track = COALESCE(p_new_track, track),
+    claimed_at = NOW(),
+    heartbeat_at = NOW(),
+    updated_at = NOW()
+  WHERE session_id = p_session_id;
+
+  -- Log the switch in sd_claims if table exists
+  BEGIN
+    INSERT INTO sd_claims (session_id, sd_id, claimed_at, status)
+    VALUES (p_session_id, p_new_sd_id, NOW(), 'active')
+    ON CONFLICT DO NOTHING;
+
+    -- Release old claim
+    UPDATE sd_claims
+    SET status = 'released', released_at = NOW(), release_reason = 'switched'
+    WHERE session_id = p_session_id
+      AND sd_id = p_old_sd_id
+      AND status = 'active';
+  EXCEPTION WHEN undefined_table THEN
+    -- sd_claims table might not exist, skip
+    NULL;
+  END;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'old_sd_id', p_old_sd_id,
+    'new_sd_id', p_new_sd_id,
+    'switched_at', NOW()::TEXT
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION switch_sd_claim IS
+  'Atomically switch SD claim from one SD to another without releasing the session. '
+  'Prevents the gap where a session has no claim during SD transitions.';

--- a/lib/heartbeat-manager.mjs
+++ b/lib/heartbeat-manager.mjs
@@ -15,7 +15,20 @@
  * (well within the 60s requirement, providing safety margin).
  */
 
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { updateHeartbeat as dbUpdateHeartbeat, endSession } from './session-manager.mjs';
+
+const __hb_filename = fileURLToPath(import.meta.url);
+const __hb_dirname = path.dirname(__hb_filename);
+dotenv.config({ path: path.resolve(__hb_dirname, '../.env') });
+
+const hbSupabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
 
 // Configuration
 const HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds (safety margin under 60s requirement)
@@ -111,6 +124,9 @@ export function startHeartbeat(sessionId) {
   consecutiveFailures = 0;
   lastSuccessfulHeartbeat = new Date();
 
+  // SD-LEO-FIX-FIX-SESSION-LIVENESS-001 (US-002): Mark session as alive
+  setIsAlive(sessionId, true);
+
   // Send initial heartbeat
   sendHeartbeat();
 
@@ -167,6 +183,10 @@ export function stopHeartbeat() {
     clearInterval(heartbeatInterval);
     heartbeatInterval = null;
     const stoppedSession = currentSessionId;
+    // SD-LEO-FIX-FIX-SESSION-LIVENESS-001 (US-002): Mark session as not alive
+    if (stoppedSession) {
+      setIsAlive(stoppedSession, false);
+    }
     currentSessionId = null;
     console.log(`[Heartbeat] Stopped automatic heartbeat for ${stoppedSession}`);
     return { success: true, stoppedSession };
@@ -207,6 +227,22 @@ export function getHeartbeatStats() {
     maxConsecutiveFailures: MAX_CONSECUTIVE_FAILURES,
     healthy: consecutiveFailures < MAX_CONSECUTIVE_FAILURES
   };
+}
+
+/**
+ * SD-LEO-FIX-FIX-SESSION-LIVENESS-001 (US-002): Set is_alive flag in database
+ * @param {string} sessionId - Session ID
+ * @param {boolean} alive - Whether the session is alive
+ */
+async function setIsAlive(sessionId, alive) {
+  try {
+    await hbSupabase
+      .from('claude_sessions')
+      .update({ is_alive: alive, updated_at: new Date().toISOString() })
+      .eq('session_id', sessionId);
+  } catch (err) {
+    console.warn(`[Heartbeat] Failed to set is_alive=${alive}: ${err.message}`);
+  }
 }
 
 /**

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -126,13 +126,14 @@ function ensureSessionDir() {
 }
 
 /**
- * Find existing session for this TTY+PID
+ * Find existing session for this terminal
+ * SD-LEO-FIX-FIX-SESSION-LIVENESS-001: Match by terminal_id (stable across
+ * subprocesses) instead of tty+pid (unique per subprocess, causing ~65 sessions/day).
  */
 function findExistingSession() {
   ensureSessionDir();
 
-  const tty = getTTY();
-  const pid = process.ppid || process.pid;
+  const terminalId = getTerminalId();
 
   const files = fs.readdirSync(SESSION_DIR).filter(f => f.endsWith('.json'));
 
@@ -141,8 +142,8 @@ function findExistingSession() {
       const filePath = path.join(SESSION_DIR, file);
       const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
 
-      // Match by TTY and PID
-      if (data.tty === tty && data.pid === pid) {
+      // Match by terminal_id (stable identifier for the Claude Code conversation)
+      if (data.terminal_id === terminalId) {
         return data;
       }
     } catch {
@@ -708,6 +709,53 @@ export async function endSession(reason = 'graceful_exit') {
   return { success: true, session_id: session.session_id, latency_ms: latencyMs };
 }
 
+/**
+ * SD-LEO-FIX-FIX-SESSION-LIVENESS-001 (US-003): Atomically switch SD claim
+ * Prevents gap where session appears dead during SD transitions.
+ *
+ * @param {string} newSdId - SD to switch to
+ * @param {string} [newTrack] - Optional new track
+ * @returns {Promise<object>} - Result with success status
+ */
+export async function switchSdClaim(newSdId, newTrack = null) {
+  const session = findExistingSession();
+
+  if (!session) {
+    return { success: false, error: 'no_session', message: 'No active session found' };
+  }
+
+  if (!session.sd_id) {
+    return { success: false, error: 'no_claim', message: 'Session has no active SD claim to switch from' };
+  }
+
+  const oldSdId = session.sd_id;
+
+  const { data, error } = await supabase.rpc('switch_sd_claim', {
+    p_session_id: session.session_id,
+    p_old_sd_id: oldSdId,
+    p_new_sd_id: newSdId,
+    p_new_track: newTrack
+  });
+
+  if (error) {
+    return { success: false, error: error.message };
+  }
+
+  if (data?.success) {
+    // Update local file
+    const filePath = getSessionFilePath(session.session_id);
+    if (fs.existsSync(filePath)) {
+      session.sd_id = newSdId;
+      if (newTrack) session.track = newTrack;
+      session.claimed_at = new Date().toISOString();
+      session.heartbeat_at = new Date().toISOString();
+      fs.writeFileSync(filePath, JSON.stringify(session, null, 2));
+    }
+  }
+
+  return data;
+}
+
 // Export for use as module
 export default {
   getOrCreateSession,
@@ -719,5 +767,6 @@ export default {
   getParallelOpportunities,
   getCurrentSession,
   releaseCurrentClaim,
+  switchSdClaim,
   endSession
 };


### PR DESCRIPTION
## Summary
- Fix `findExistingSession()` to match by `terminal_id` instead of `tty+pid`, reducing session creation from ~65/day to ~2/day per terminal
- Add `is_alive` boolean column to `claude_sessions` with `v_live_sessions` view for explicit liveness tracking
- Add `switch_sd_claim()` atomic RPC to prevent gap-free SD claim transitions

## Test plan
- [x] `session-manager.mjs` loads without errors, `switchSdClaim` export present
- [x] `heartbeat-manager.mjs` loads without errors, `setIsAlive` toggles on start/stop
- [x] `is_alive` column accessible in `claude_sessions`
- [x] `v_live_sessions` view returns filtered results
- [x] `switch_sd_claim()` RPC callable and returns expected validation errors
- [x] Smoke tests pass (15/15)

SD-LEO-FIX-FIX-SESSION-LIVENESS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)