### PR TITLE
fix(handoff): remove force flag from worktree cleanup to prevent data loss

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -223,11 +223,13 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       validateSdKey(sdKey);
       console.log('\n🌲 Worktree Cleanup');
       console.log('-'.repeat(50));
-      worktreeCleanupResult = cleanupWorktree(sdKey, { force: true });
+      worktreeCleanupResult = cleanupWorktree(sdKey);
       if (worktreeCleanupResult.cleaned) {
         console.log(`   ✅ Worktree .worktrees/${sdKey} removed`);
       } else if (worktreeCleanupResult.reason === 'worktree_not_found') {
         console.log(`   ℹ️  No worktree found for ${sdKey} (may not have been created)`);
+      } else if (worktreeCleanupResult.reason === 'dirty_worktree') {
+        console.warn('   ⚠️  Worktree has uncommitted changes — run /ship first, then re-run LEAD-FINAL-APPROVAL');
       } else {
         console.warn(`   ⚠️  Worktree cleanup incomplete: ${worktreeCleanupResult.reason}`);
       }


### PR DESCRIPTION
## Summary
- Removed `force: true` from `cleanupWorktree()` call in LEAD-FINAL-APPROVAL executor
- This re-enables the existing dirty-state protection that checks for uncommitted changes before removing a worktree
- Added explicit handling for the `dirty_worktree` case with a clear message to run `/ship` first

## Root Cause
The LEAD-FINAL-APPROVAL handoff was calling `cleanupWorktree(sdKey, { force: true })`, which bypassed the built-in `git status --porcelain` check. When the handoff chain ran before code was committed, the worktree (with all uncommitted changes) was destroyed.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Verify worktree cleanup aborts gracefully when uncommitted changes exist
- [ ] Verify worktree cleanup succeeds normally when worktree is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)