### PR TITLE
docs(worktree): update docs and tests for safe cleanup mode

### DIFF
--- a/docs/guides/working-with-worktrees.md
+++ b/docs/guides/working-with-worktrees.md
@@ -258,18 +258,23 @@ git checkout feat/SD-XXX-001-title
 ⚠️  Worktree cleanup failed: uncommitted changes detected
 ```
 
-**Cause**: Worktree has uncommitted changes and `force: false`.
+**Cause**: Worktree has uncommitted changes. Both LEAD-FINAL-APPROVAL automatic cleanup and manual cleanup (without `--force`) will abort to protect your work.
 
 **Solution**:
 ```bash
-# Commit changes first
+# Option 1: Commit changes first (recommended)
 cd .worktrees/SD-XXX-001
 git add . && git commit -m "WIP"
 cd ../..
 
-# Then cleanup
+# Then cleanup (automatic cleanup will succeed on next LEAD-FINAL-APPROVAL run)
+npm run session:cleanup -- --sd-key SD-XXX-001
+
+# Option 2: Force cleanup (manual only — discards uncommitted changes)
 npm run session:cleanup -- --sd-key SD-XXX-001 --force
 ```
+
+**Note**: LEAD-FINAL-APPROVAL handles cleanup automatically without `--force`. If uncommitted changes are detected, it aborts gracefully and prompts you to run `/ship` first.
 
 ## Best Practices
 

--- a/tests/unit/worktree-handoff-integration.test.js
+++ b/tests/unit/worktree-handoff-integration.test.js
@@ -141,22 +141,31 @@ describe('Worktree-Handoff Integration', () => {
   });
 
   describe('cleanupWorktree call contract', () => {
-    it('should call cleanupWorktree with force on LEAD-FINAL-APPROVAL', () => {
+    it('should call cleanupWorktree without force on LEAD-FINAL-APPROVAL', () => {
       cleanupWorktree.mockReturnValue({ cleaned: true, reason: 'success' });
 
-      const result = cleanupWorktree('SD-TEST-001', { force: true });
+      const result = cleanupWorktree('SD-TEST-001');
 
-      expect(cleanupWorktree).toHaveBeenCalledWith('SD-TEST-001', { force: true });
+      expect(cleanupWorktree).toHaveBeenCalledWith('SD-TEST-001');
       expect(result.cleaned).toBe(true);
     });
 
     it('should handle worktree_not_found gracefully', () => {
       cleanupWorktree.mockReturnValue({ cleaned: false, reason: 'worktree_not_found' });
 
-      const result = cleanupWorktree('SD-TEST-001', { force: true });
+      const result = cleanupWorktree('SD-TEST-001');
 
       expect(result.cleaned).toBe(false);
       expect(result.reason).toBe('worktree_not_found');
+    });
+
+    it('should handle dirty_worktree by aborting cleanup', () => {
+      cleanupWorktree.mockReturnValue({ cleaned: false, reason: 'dirty_worktree' });
+
+      const result = cleanupWorktree('SD-TEST-001');
+
+      expect(result.cleaned).toBe(false);
+      expect(result.reason).toBe('dirty_worktree');
     });
 
     it('should handle cleanup failure without throwing', () => {
@@ -167,7 +176,7 @@ describe('Worktree-Handoff Integration', () => {
       let cleanupResult = null;
       let warning = null;
       try {
-        cleanupResult = cleanupWorktree('SD-TEST-001', { force: true });
+        cleanupResult = cleanupWorktree('SD-TEST-001');
       } catch (err) {
         warning = err.message;
       }


### PR DESCRIPTION
## Summary
- Updated architecture doc (`worktree-first-isolation-integration.md`) to reflect removal of `force: true` from LEAD-FINAL-APPROVAL cleanup
- Updated user guide (`working-with-worktrees.md`) with clarification about automatic vs manual cleanup behavior
- Updated unit tests to match new call contract (no `force` parameter) and added `dirty_worktree` test case

Follow-up to PR #1207 which removed `force: true` from worktree cleanup.

## Test plan
- [x] 12/12 worktree integration tests pass (added dirty_worktree test)
- [x] 15/15 smoke tests pass
- [x] DOCMON validation passes (0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)