### PR TITLE
feat(agents): per-agent tool policy profiles

### DIFF
--- a/database/migrations/20260213_add_tool_policy_profile.sql
+++ b/database/migrations/20260213_add_tool_policy_profile.sql
@@ -1,0 +1,15 @@
+-- Migration: Add tool_policy_profile to leo_sub_agents
+-- SD: SD-EVA-FEAT-TOOL-POLICIES-001
+-- Purpose: Per-agent tool policy profiles (full/coding/readonly/minimal)
+
+-- Add column with default 'full' for backward compatibility
+ALTER TABLE leo_sub_agents
+ADD COLUMN IF NOT EXISTS tool_policy_profile VARCHAR(20) NOT NULL DEFAULT 'full';
+
+-- Add CHECK constraint for allowed values
+ALTER TABLE leo_sub_agents
+ADD CONSTRAINT chk_tool_policy_profile
+CHECK (tool_policy_profile IN ('full', 'coding', 'readonly', 'minimal'));
+
+-- Comment
+COMMENT ON COLUMN leo_sub_agents.tool_policy_profile IS 'Tool policy profile controlling which tools this sub-agent can use. full=all tools, coding=read+write+bash (no web), readonly=read-only tools, minimal=Read only.';

--- a/lib/team/agent-creator.js
+++ b/lib/team/agent-creator.js
@@ -28,6 +28,7 @@ const TEAMMATE_TOOLS = ['Bash', 'Read', 'Write', 'SendMessage', 'TaskUpdate', 'T
  * @param {string} [options.teamRole='teammate'] - Role (only 'teammate' allowed for dynamic agents)
  * @param {string} [options.modelTier='opus'] - Model tier
  * @param {string[]} [options.categoryMappings] - Issue pattern categories
+ * @param {string} [options.toolPolicyProfile='full'] - Tool policy profile (full/coding/readonly/minimal)
  * @returns {Promise<{agentCode: string, agentName: string, compiled: boolean, existing: boolean}>}
  */
 export async function createDynamicAgent({
@@ -39,6 +40,7 @@ export async function createDynamicAgent({
   teamRole = 'teammate',
   modelTier = 'opus',
   categoryMappings = [],
+  toolPolicyProfile = 'full',
 }) {
   if (!code || !name || !description || !instructions) {
     throw new Error('Required fields: code, name, description, instructions');
@@ -83,6 +85,7 @@ export async function createDynamicAgent({
       model_tier: modelTier,
       allowed_tools: TEAMMATE_TOOLS,
       team_role: 'teammate',
+      tool_policy_profile: toolPolicyProfile,
       category_mappings: categoryMappings,
       activation_type: 'manual',
       active: true,

--- a/lib/tool-policy.js
+++ b/lib/tool-policy.js
@@ -1,0 +1,102 @@
+/**
+ * Tool Policy Module - Per-Agent Tool Policy Profiles
+ * SD: SD-EVA-FEAT-TOOL-POLICIES-001
+ *
+ * Canonical source of truth for tool allowlists per profile.
+ * Used by both the agent compiler and runtime validation gate.
+ */
+
+/** @typedef {'full' | 'coding' | 'readonly' | 'minimal'} ToolPolicyProfile */
+
+/**
+ * Canonical tool allowlists per profile.
+ * Order: most permissive → most restrictive.
+ */
+const PROFILE_ALLOWLISTS = {
+  full: null, // null means ALL tools allowed (no filtering)
+  coding: [
+    'Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'NotebookEdit',
+    'Task', 'TeamCreate', 'TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet', 'SendMessage'
+  ],
+  readonly: ['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch'],
+  minimal: ['Read']
+};
+
+/**
+ * Check if a tool is allowed for a given profile.
+ * @param {ToolPolicyProfile} profile
+ * @param {string} toolName
+ * @returns {boolean}
+ */
+export function canUseTool(profile, toolName) {
+  const allowlist = PROFILE_ALLOWLISTS[profile];
+  if (allowlist === null || allowlist === undefined) return true; // full profile
+  return allowlist.includes(toolName);
+}
+
+/**
+ * Get the allowlist for a profile.
+ * @param {ToolPolicyProfile} profile
+ * @returns {string[] | null} null means all tools allowed
+ */
+export function getAllowedTools(profile) {
+  return PROFILE_ALLOWLISTS[profile] ?? null;
+}
+
+/**
+ * Filter an array of tool names by profile.
+ * Returns only the tools that are allowed for the given profile.
+ * If profile is 'full' or unknown, returns the original array unchanged.
+ *
+ * @param {ToolPolicyProfile} profile
+ * @param {string[]} tools - Current tool list
+ * @returns {string[]} Filtered tool list
+ */
+export function filterToolsByProfile(profile, tools) {
+  const allowlist = PROFILE_ALLOWLISTS[profile];
+  if (!allowlist) return tools; // full profile or unknown → no filtering
+  return tools.filter(t => allowlist.includes(t));
+}
+
+/**
+ * Validate a profile name.
+ * @param {string} profile
+ * @returns {boolean}
+ */
+export function isValidProfile(profile) {
+  return profile in PROFILE_ALLOWLISTS;
+}
+
+/**
+ * Create a structured TOOL_NOT_ALLOWED error.
+ * @param {string} subAgentId
+ * @param {ToolPolicyProfile} profile
+ * @param {string} toolName
+ * @returns {{ type: string, subAgentId: string, profile: string, toolName: string, allowed: string[], reason: string }}
+ */
+export function createToolNotAllowedError(subAgentId, profile, toolName) {
+  const allowed = PROFILE_ALLOWLISTS[profile] || [];
+  return {
+    type: 'TOOL_NOT_ALLOWED',
+    subAgentId,
+    profile,
+    toolName,
+    allowed,
+    reason: `Tool '${toolName}' is not allowed for profile '${profile}'. Allowed tools: ${allowed.join(', ')}`
+  };
+}
+
+/**
+ * All valid profile names.
+ */
+export const VALID_PROFILES = Object.keys(PROFILE_ALLOWLISTS);
+
+export default {
+  canUseTool,
+  getAllowedTools,
+  filterToolsByProfile,
+  isValidProfile,
+  createToolNotAllowedError,
+  VALID_PROFILES,
+  PROFILE_ALLOWLISTS
+};

--- a/tests/integration/tool-policy-enforcement.test.js
+++ b/tests/integration/tool-policy-enforcement.test.js
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { filterToolsByProfile, canUseTool, isValidProfile } from '../../lib/tool-policy.js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+describe('Tool Policy E2E: Compile-Time Enforcement', () => {
+  let agents;
+
+  beforeAll(async () => {
+    const { data, error } = await supabase
+      .from('leo_sub_agents')
+      .select('code, name, allowed_tools, tool_policy_profile')
+      .eq('active', true)
+      .order('code');
+
+    expect(error).toBeNull();
+    agents = data;
+  });
+
+  it('all agents have a valid tool_policy_profile', () => {
+    for (const agent of agents) {
+      expect(isValidProfile(agent.tool_policy_profile),
+        `Agent ${agent.code} has invalid profile: ${agent.tool_policy_profile}`
+      ).toBe(true);
+    }
+  });
+
+  it('agents with full profile have unrestricted tools', () => {
+    const fullAgents = agents.filter(a => a.tool_policy_profile === 'full');
+    expect(fullAgents.length).toBeGreaterThan(0);
+
+    for (const agent of fullAgents) {
+      const filtered = filterToolsByProfile('full', agent.allowed_tools);
+      expect(filtered).toEqual(agent.allowed_tools);
+    }
+  });
+
+  it('readonly profile filters to only read-only tools', () => {
+    const baseTools = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'WebFetch', 'WebSearch', 'Task', 'SendMessage'];
+    const result = filterToolsByProfile('readonly', baseTools);
+    expect(result).toEqual(['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch']);
+    expect(result).not.toContain('Bash');
+    expect(result).not.toContain('Write');
+    expect(result).not.toContain('Edit');
+  });
+
+  it('minimal profile filters to only Read', () => {
+    const baseTools = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'];
+    const result = filterToolsByProfile('minimal', baseTools);
+    expect(result).toEqual(['Read']);
+  });
+
+  it('coding profile blocks WebFetch and WebSearch', () => {
+    const baseTools = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'WebFetch', 'WebSearch'];
+    const result = filterToolsByProfile('coding', baseTools);
+    expect(result).not.toContain('WebFetch');
+    expect(result).not.toContain('WebSearch');
+    expect(result).toContain('Bash');
+    expect(result).toContain('Edit');
+  });
+
+  it('DB constraint rejects invalid profile values', async () => {
+    const { error } = await supabase
+      .from('leo_sub_agents')
+      .update({ tool_policy_profile: 'superuser' })
+      .eq('code', 'QUICKFIX'); // Use a real agent for the test
+
+    expect(error).not.toBeNull();
+    expect(error.message).toContain('chk_tool_policy_profile');
+  });
+
+  it('backward compatibility: default full profile exists for all agents', () => {
+    for (const agent of agents) {
+      expect(agent.tool_policy_profile).toBeDefined();
+      // All existing agents should have 'full' since we just added the column
+      expect(agent.tool_policy_profile).toBe('full');
+    }
+  });
+
+  it('canUseTool returns correct results for runtime validation', () => {
+    // Readonly: allowed
+    expect(canUseTool('readonly', 'Read')).toBe(true);
+    expect(canUseTool('readonly', 'Glob')).toBe(true);
+    // Readonly: blocked
+    expect(canUseTool('readonly', 'Write')).toBe(false);
+    expect(canUseTool('readonly', 'Bash')).toBe(false);
+
+    // Minimal: only Read
+    expect(canUseTool('minimal', 'Read')).toBe(true);
+    expect(canUseTool('minimal', 'Glob')).toBe(false);
+  });
+});

--- a/tests/unit/tool-policy.test.js
+++ b/tests/unit/tool-policy.test.js
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canUseTool,
+  getAllowedTools,
+  filterToolsByProfile,
+  isValidProfile,
+  createToolNotAllowedError,
+  VALID_PROFILES
+} from '../../lib/tool-policy.js';
+
+describe('Tool Policy Module', () => {
+  describe('VALID_PROFILES', () => {
+    it('contains all four profiles', () => {
+      expect(VALID_PROFILES).toEqual(['full', 'coding', 'readonly', 'minimal']);
+    });
+  });
+
+  describe('isValidProfile', () => {
+    it('returns true for valid profiles', () => {
+      expect(isValidProfile('full')).toBe(true);
+      expect(isValidProfile('coding')).toBe(true);
+      expect(isValidProfile('readonly')).toBe(true);
+      expect(isValidProfile('minimal')).toBe(true);
+    });
+
+    it('returns false for invalid profiles', () => {
+      expect(isValidProfile('superuser')).toBe(false);
+      expect(isValidProfile('')).toBe(false);
+      expect(isValidProfile('FULL')).toBe(false);
+    });
+  });
+
+  describe('canUseTool', () => {
+    describe('full profile', () => {
+      it('allows all tools', () => {
+        expect(canUseTool('full', 'Read')).toBe(true);
+        expect(canUseTool('full', 'Write')).toBe(true);
+        expect(canUseTool('full', 'Bash')).toBe(true);
+        expect(canUseTool('full', 'Edit')).toBe(true);
+        expect(canUseTool('full', 'WebFetch')).toBe(true);
+        expect(canUseTool('full', 'NotebookEdit')).toBe(true);
+      });
+    });
+
+    describe('readonly profile', () => {
+      it('allows Read, Glob, Grep, WebFetch, WebSearch', () => {
+        expect(canUseTool('readonly', 'Read')).toBe(true);
+        expect(canUseTool('readonly', 'Glob')).toBe(true);
+        expect(canUseTool('readonly', 'Grep')).toBe(true);
+        expect(canUseTool('readonly', 'WebFetch')).toBe(true);
+        expect(canUseTool('readonly', 'WebSearch')).toBe(true);
+      });
+
+      it('blocks Edit, Write, Bash, NotebookEdit', () => {
+        expect(canUseTool('readonly', 'Edit')).toBe(false);
+        expect(canUseTool('readonly', 'Write')).toBe(false);
+        expect(canUseTool('readonly', 'Bash')).toBe(false);
+        expect(canUseTool('readonly', 'NotebookEdit')).toBe(false);
+      });
+
+      it('blocks Task, TeamCreate, SendMessage', () => {
+        expect(canUseTool('readonly', 'Task')).toBe(false);
+        expect(canUseTool('readonly', 'TeamCreate')).toBe(false);
+        expect(canUseTool('readonly', 'SendMessage')).toBe(false);
+      });
+    });
+
+    describe('minimal profile', () => {
+      it('allows only Read', () => {
+        expect(canUseTool('minimal', 'Read')).toBe(true);
+      });
+
+      it('blocks everything else', () => {
+        expect(canUseTool('minimal', 'Glob')).toBe(false);
+        expect(canUseTool('minimal', 'Grep')).toBe(false);
+        expect(canUseTool('minimal', 'Write')).toBe(false);
+        expect(canUseTool('minimal', 'Edit')).toBe(false);
+        expect(canUseTool('minimal', 'Bash')).toBe(false);
+        expect(canUseTool('minimal', 'WebFetch')).toBe(false);
+        expect(canUseTool('minimal', 'WebSearch')).toBe(false);
+        expect(canUseTool('minimal', 'NotebookEdit')).toBe(false);
+      });
+    });
+
+    describe('coding profile', () => {
+      it('allows code-related tools', () => {
+        expect(canUseTool('coding', 'Bash')).toBe(true);
+        expect(canUseTool('coding', 'Read')).toBe(true);
+        expect(canUseTool('coding', 'Write')).toBe(true);
+        expect(canUseTool('coding', 'Edit')).toBe(true);
+        expect(canUseTool('coding', 'Glob')).toBe(true);
+        expect(canUseTool('coding', 'Grep')).toBe(true);
+      });
+
+      it('blocks web access tools', () => {
+        expect(canUseTool('coding', 'WebFetch')).toBe(false);
+        expect(canUseTool('coding', 'WebSearch')).toBe(false);
+      });
+    });
+  });
+
+  describe('getAllowedTools', () => {
+    it('returns null for full profile (all tools allowed)', () => {
+      expect(getAllowedTools('full')).toBeNull();
+    });
+
+    it('returns specific tools for readonly', () => {
+      const tools = getAllowedTools('readonly');
+      expect(tools).toEqual(['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch']);
+    });
+
+    it('returns only Read for minimal', () => {
+      expect(getAllowedTools('minimal')).toEqual(['Read']);
+    });
+  });
+
+  describe('filterToolsByProfile', () => {
+    const allTools = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'WebFetch', 'WebSearch', 'NotebookEdit', 'Task', 'SendMessage'];
+
+    it('returns all tools for full profile', () => {
+      expect(filterToolsByProfile('full', allTools)).toEqual(allTools);
+    });
+
+    it('filters to readonly tools', () => {
+      const result = filterToolsByProfile('readonly', allTools);
+      expect(result).toEqual(['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch']);
+    });
+
+    it('filters to minimal tools', () => {
+      const result = filterToolsByProfile('minimal', allTools);
+      expect(result).toEqual(['Read']);
+    });
+
+    it('returns original for unknown profile', () => {
+      expect(filterToolsByProfile('unknown', allTools)).toEqual(allTools);
+    });
+
+    it('filters coding profile (no web tools)', () => {
+      const result = filterToolsByProfile('coding', allTools);
+      expect(result).not.toContain('WebFetch');
+      expect(result).not.toContain('WebSearch');
+      expect(result).toContain('Bash');
+      expect(result).toContain('Read');
+      expect(result).toContain('Write');
+    });
+  });
+
+  describe('createToolNotAllowedError', () => {
+    it('creates structured error for readonly violation', () => {
+      const error = createToolNotAllowedError('agent-123', 'readonly', 'Write');
+      expect(error.type).toBe('TOOL_NOT_ALLOWED');
+      expect(error.subAgentId).toBe('agent-123');
+      expect(error.profile).toBe('readonly');
+      expect(error.toolName).toBe('Write');
+      expect(error.allowed).toEqual(['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch']);
+      expect(error.reason).toContain('not allowed');
+    });
+
+    it('creates structured error for minimal violation', () => {
+      const error = createToolNotAllowedError('agent-456', 'minimal', 'Glob');
+      expect(error.type).toBe('TOOL_NOT_ALLOWED');
+      expect(error.profile).toBe('minimal');
+      expect(error.toolName).toBe('Glob');
+      expect(error.allowed).toEqual(['Read']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `tool_policy_profile` column to `leo_sub_agents` with CHECK constraint (`full`, `coding`, `readonly`, `minimal`)
- New `lib/tool-policy.js` module: canonical allowlists, `canUseTool()`, `filterToolsByProfile()`, `getAllowedTools()`
- Agent compiler (`generate-agent-md-from-db.js`) filters tools through policy profiles at compile time
- Dynamic agent creator (`agent-creator.js`) accepts `toolPolicyProfile` parameter
- 21 unit tests + 8 integration tests covering all profiles, DB constraints, and backward compatibility

## Test plan
- [x] Unit tests: all 4 profiles validated (full/coding/readonly/minimal)
- [x] Integration tests: live Supabase validation, DB constraint rejection, compiler filtering
- [x] Manual verification: set VALIDATION agent to readonly → compiler outputs `tools: Read` only
- [x] DB constraint verified: invalid profile 'superuser' rejected by CHECK constraint
- [x] Backward compatibility: existing agents with no profile default to 'full'

SD: SD-EVA-FEAT-TOOL-POLICIES-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)