### PR TITLE
fix(session): disambiguate terminal_id for multi-conversation VS Code windows

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -6,7 +6,7 @@
  * ALL code that needs terminal_id MUST import from this module.
  *
  * Identity Model:
- *   Windows: Console session ID (stable across Node.js subprocesses)
+ *   Windows: SSE port + Claude Code ancestor PID (unique per conversation)
  *   Unix: TTY device path (hashed for privacy)
  *   Fallback: Parent PID (unstable but functional)
  *
@@ -14,42 +14,113 @@
  *   Previously duplicated in 3 locations (session-manager, claim-gate, BaseExecutor).
  *   When ppid→sessionId fix was applied, BaseExecutor's inline copy was missed,
  *   causing a cascade of false claim conflicts and permanently blocked handoffs.
+ *
+ * RCA-MULTI-SESSION-IDENTITY-COLLISION-001 (2026-02-13):
+ *   CLAUDE_CODE_SSE_PORT is per-extension, NOT per-conversation. Two Claude Code
+ *   conversations in the same VS Code window share the same SSE port, causing
+ *   identical terminal_ids and session adoption collisions. Fix: walk the process
+ *   tree to find the Claude Code node process PID (unique per conversation).
  */
 
 import { execSync } from 'child_process';
 import crypto from 'crypto';
 import os from 'os';
 
+// Cache the Claude Code ancestor PID — stable for the lifetime of this process
+let _cachedCCPid = null;
+
+/**
+ * Find the Claude Code node process PID by walking up the process tree.
+ * The Claude Code process is the node.exe ancestor whose parent is cmd.exe
+ * (or another non-node process). In the tree:
+ *   node(us) → bash → bash → bash → node(Claude Code) → cmd → ...
+ *
+ * @returns {string|null} The Claude Code process PID, or null if not found
+ */
+function findClaudeCodePid() {
+  if (_cachedCCPid !== null) return _cachedCCPid;
+  try {
+    // Single PowerShell call to get full process ancestry chain.
+    // Uses -EncodedCommand to avoid all shell escaping issues.
+    // Note: $pid is read-only in PowerShell, so we use $p instead
+    const script = [
+      `$p = ${process.pid}`,
+      '$chain = @()',
+      'while ($p -and $p -ne 0) {',
+      '  $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$p" -ErrorAction SilentlyContinue',
+      '  if (-not $proc) { break }',
+      '  $chain += "$($proc.ProcessId)|$($proc.Name)|$($proc.ParentProcessId)"',
+      '  $p = $proc.ParentProcessId',
+      '}',
+      '$chain -join ";"'
+    ].join('\n');
+    const encoded = Buffer.from(script, 'utf16le').toString('base64');
+    const raw = execSync(`powershell -NoProfile -EncodedCommand ${encoded}`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 10000
+    }).trim();
+    if (!raw) return null;
+
+    const chain = raw.split(';').map(entry => {
+      const [pid, name, ppid] = entry.split('|');
+      return { pid, name: (name || '').toLowerCase(), ppid };
+    });
+
+    // Walk from our process upward. Find the first node.exe whose parent
+    // is NOT node.exe/bash/sh — that's the Claude Code process.
+    // Skip index 0 (that's us).
+    for (let i = 1; i < chain.length; i++) {
+      const proc = chain[i];
+      if (proc.name === 'node.exe' || proc.name === 'node') {
+        const parent = chain[i + 1];
+        // Claude Code's node parent is typically cmd.exe, powershell.exe,
+        // or a terminal host — not another node or bash
+        if (!parent || !['node.exe', 'node', 'bash.exe', 'bash', 'sh.exe', 'sh'].includes(parent.name)) {
+          _cachedCCPid = proc.pid;
+          return _cachedCCPid;
+        }
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Get stable terminal identifier for session coordination.
  *
- * On Windows: Uses CLAUDE_CODE_SSE_PORT env var to uniquely identify each
- * Claude Code conversation. This is stable across all subprocesses spawned
- * by the same Claude Code instance, yet unique per conversation.
+ * On Windows: Uses CLAUDE_CODE_SSE_PORT + Claude Code ancestor PID to
+ * uniquely identify each conversation. SSE port alone is shared across
+ * conversations in the same VS Code window; the ancestor PID disambiguates.
  * Falls back to Windows console session ID if env var is unavailable.
  *
  * On Unix: Uses the TTY device path, hashed for cleaner IDs.
  *
- * @returns {string} Terminal identifier (e.g., "win-cc-55188" or "tty-a4b3c2d1")
+ * @returns {string} Terminal identifier (e.g., "win-cc-55188-4468" or "tty-a4b3c2d1")
  */
 export function getTerminalId() {
   try {
     if (process.platform === 'win32') {
-      // CLAUDE_CODE_SSE_PORT: Set by Claude Code, unique per conversation,
-      // inherited by all subprocesses. This is the ideal identifier because:
-      // - Stable across subprocesses (unlike PPID which changes per shell)
-      // - Unique per conversation (unlike Windows session ID which is shared)
       const ssePort = process.env.CLAUDE_CODE_SSE_PORT;
       if (ssePort) {
+        // Disambiguate with Claude Code ancestor PID (unique per conversation)
+        const ccPid = findClaudeCodePid();
+        if (ccPid) {
+          return `win-cc-${ssePort}-${ccPid}`;
+        }
+        // If ancestor walk fails, fall back to SSE port only (legacy behavior)
         return `win-cc-${ssePort}`;
       }
       // Fallback: Windows console session ID (shared across all instances
       // in the same desktop session - less ideal for multi-instance)
       try {
-        const cmd = `powershell -Command "(Get-Process -Id ${process.pid}).SessionId"`;
+        const cmd = `powershell -NoProfile -Command "(Get-Process -Id ${process.pid}).SessionId"`;
         const sessionId = execSync(cmd, {
           encoding: 'utf8',
-          stdio: ['pipe', 'pipe', 'ignore']
+          stdio: ['pipe', 'pipe', 'ignore'],
+          timeout: 5000
         }).trim();
         if (sessionId && /^\d+$/.test(sessionId)) {
           return `win-session-${sessionId}`;


### PR DESCRIPTION
## Summary
- **Root cause**: `CLAUDE_CODE_SSE_PORT` is per-VS-Code-extension, not per-conversation. Two Claude Code conversations in the same window share the same port, producing identical `terminal_id` values (`win-cc-53776`). This causes session adoption collisions where both sessions claim the same SD.
- **Fix**: Walk the process tree via PowerShell `Get-CimInstance Win32_Process` to find the Claude Code `node.exe` ancestor PID (unique per conversation) and append it to terminal_id. Format: `win-cc-{port}-{ccPid}` (e.g., `win-cc-53776-4468`).
- **Performance**: Single PowerShell call (~1.3s) with per-process caching. Subsequent calls return in 0ms.
- **Graceful fallback**: If process tree walk fails, falls back to SSE-port-only format (legacy behavior).

## Verified
- Session A: `win-cc-53776-4468`
- Session B: `win-cc-53776-17324`
- Both sessions confirmed different terminal_ids with the fix applied.

## Test plan
- [x] Verified both sessions produce unique terminal_ids
- [x] Verified cache works (first call ~1.3s, second call 0ms)
- [x] Smoke tests pass (15/15)
- [ ] Verify SD claiming correctly rejects duplicate claims from different sessions

RCA-MULTI-SESSION-IDENTITY-COLLISION-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)