### PR TITLE
feat(llm): replace GPT 5.2 with Opus 4.6 for PRD generation

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEO-FIX-REMEDIATE-LEARNING-PIPELINE-001",
-  "expectedBranch": "feat/SD-LEO-FIX-REMEDIATE-LEARNING-PIPELINE-001",
-  "createdAt": "2026-02-12T04:13:31.340Z",
+  "sdKey": "SD-LEO-INFRA-REPLACE-GPT-OPUS-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-REPLACE-GPT-OPUS-001",
+  "createdAt": "2026-02-14T01:11:31.208Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/llm/client-factory.js
+++ b/lib/llm/client-factory.js
@@ -358,9 +358,12 @@ function getPurposeTier(purpose) {
 
     // Sonnet-tier (balanced)
     validation: 'sonnet',
-    generation: 'sonnet',
     analysis: 'sonnet',
     design: 'sonnet',
+
+    // Generation uses effort-based routing → Opus 4.6 (replaces GPT 5.2)
+    // SD-LEO-INFRA-REPLACE-GPT-OPUS-001: Opus has codebase context, no timeouts
+    generation: 'high',
 
     // Opus-tier (highest quality)
     security: 'opus',

--- a/scripts/prd/llm-generator.js
+++ b/scripts/prd/llm-generator.js
@@ -1,13 +1,13 @@
 /**
  * LLM-Based PRD Content Generation
- * Uses GPT to generate actual PRD content instead of placeholder text
+ * Uses Opus 4.6 to generate actual PRD content with codebase grounding
  *
  * Extracted from add-prd-to-database.js for modularity
  * SD-LEO-REFACTOR-PRD-DB-002
+ * SD-LEO-INFRA-REPLACE-GPT-OPUS-001: Switched from GPT 5.2 to Opus 4.6
  */
 
 import { getLLMClient } from '../../lib/llm/client-factory.js';
-import { PROVIDER_TIMEOUT_LONG_MS } from '../../lib/sub-agents/vetting/provider-adapters.js';
 import { LLM_PRD_CONFIG, buildSystemPrompt } from './config.js';
 import {
   formatObjectives,
@@ -19,7 +19,7 @@ import {
 } from './formatters.js';
 
 /**
- * Generate PRD content using LLM (GPT 5.2)
+ * Generate PRD content using LLM (Opus 4.6 via effort-based routing)
  *
  * @param {Object} sd - Strategic Directive data
  * @param {Object} context - Additional context (design analysis, database analysis, personas)
@@ -48,12 +48,11 @@ export async function generatePRDContentWithLLM(sd, context = {}) {
     // Build user prompt with context
     const userPrompt = buildPRDGenerationContext(sd, context);
 
-    // Use adapter interface .complete() instead of OpenAI SDK interface
-    // PRD generation produces 5-30K tokens and needs much longer than the 30s default
+    // Use adapter interface .complete()
+    // Opus 4.6 completes in seconds; standard 60s timeout is sufficient
     const response = await llmClient.complete(systemPrompt, userPrompt, {
       temperature: LLM_PRD_CONFIG.temperature,
-      max_tokens: LLM_PRD_CONFIG.maxTokens,
-      timeout: PROVIDER_TIMEOUT_LONG_MS // 3 minutes - PRD generation is a long-form content task
+      max_tokens: LLM_PRD_CONFIG.maxTokens
     });
 
     // Parse adapter response format


### PR DESCRIPTION
## Summary
- Route PRD generation (`purpose: 'generation'`) through Anthropic effort-based routing (Opus 4.6) instead of OpenAI legacy sonnet tier (GPT 5.2)
- Remove 180-second timeout workaround (`PROVIDER_TIMEOUT_LONG_MS`) — Opus completes in seconds
- No impact on other LLM routes: EVA stages use `content-generation`, story generators use `story-generation`/`prd-generation`

## Changes
- `lib/llm/client-factory.js`: `getPurposeTier('generation')` → `'high'` (was `'sonnet'`)
- `scripts/prd/llm-generator.js`: Remove `PROVIDER_TIMEOUT_LONG_MS` import, use default 60s timeout

## Test plan
- [ ] Run `add-prd-to-database.js` on a test SD — verify PRD generated via Opus in <30s
- [ ] Verify other LLM routes unchanged (classification → haiku, validation → sonnet)
- [ ] Confirm no OpenAI API calls for `generation` purpose

SD-LEO-INFRA-REPLACE-GPT-OPUS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)