### PR TITLE
fix(gates): normalize gate scores consistently and remove false partial credit

### DIFF
--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
@@ -216,7 +216,7 @@ export function registerGate2Validators(registry) {
     if (!['PASS', 'CONDITIONAL_PASS'].includes(execution.verdict)) {
       return {
         passed: false,
-        score: 30,
+        score: 0,
         max_score: 100,
         issues: [`${requiredAgent} sub-agent verdict: ${execution.verdict}, expected PASS or CONDITIONAL_PASS`]
       };

--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-3-traceability.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-3-traceability.js
@@ -20,10 +20,9 @@ export function registerGate3Validators(registry) {
     const sectionAScore = sectionAFromSections.score ??
       result?.gate_scores?.recommendation_adherence ?? 0;
 
-    // Gate 3 Section A is scored out of 30, convert to percentage
-    const normalizedScore = result?.gate_scores?.recommendation_adherence !== undefined
-      ? Math.round((result.gate_scores.recommendation_adherence / 30) * 100)
-      : sectionAScore;
+    // Gate 3 Section A is scored out of 30, always normalize to percentage
+    const rawScore = result?.gate_scores?.recommendation_adherence ?? sectionAScore;
+    const normalizedScore = Math.round((rawScore / 30) * 100);
     const passed = result?.passed ?? (normalizedScore >= 70);
 
     return {
@@ -45,10 +44,9 @@ export function registerGate3Validators(registry) {
     const sectionBScore = sectionBFromSections.score ??
       result?.gate_scores?.implementation_quality ?? 0;
 
-    // Gate 3 Section B is scored out of 30, convert to percentage
-    const normalizedScore = result?.gate_scores?.implementation_quality !== undefined
-      ? Math.round((result.gate_scores.implementation_quality / 30) * 100)
-      : sectionBScore;
+    // Gate 3 Section B is scored out of 30, always normalize to percentage
+    const rawScore = result?.gate_scores?.implementation_quality ?? sectionBScore;
+    const normalizedScore = Math.round((rawScore / 30) * 100);
     const passed = result?.passed ?? (normalizedScore >= 70);
 
     return {
@@ -70,10 +68,9 @@ export function registerGate3Validators(registry) {
     const sectionCScore = sectionCFromSections.score ??
       result?.gate_scores?.traceability_mapping ?? 0;
 
-    // Gate 3 Section C is scored out of 25, convert to percentage
-    const normalizedScore = result?.gate_scores?.traceability_mapping !== undefined
-      ? Math.round((result.gate_scores.traceability_mapping / 25) * 100)
-      : sectionCScore;
+    // Gate 3 Section C is scored out of 25, always normalize to percentage
+    const rawScore = result?.gate_scores?.traceability_mapping ?? sectionCScore;
+    const normalizedScore = Math.round((rawScore / 25) * 100);
     const passed = result?.passed ?? (normalizedScore >= 70);
 
     return {
@@ -95,10 +92,9 @@ export function registerGate3Validators(registry) {
     const sectionDScore = sectionDFromSections.score ??
       result?.gate_scores?.sub_agent_effectiveness ?? 0;
 
-    // Gate 3 Section D is scored out of 10, convert to percentage
-    const normalizedScore = result?.gate_scores?.sub_agent_effectiveness !== undefined
-      ? Math.round((result.gate_scores.sub_agent_effectiveness / 10) * 100)
-      : sectionDScore;
+    // Gate 3 Section D is scored out of 10, always normalize to percentage
+    const rawScore = result?.gate_scores?.sub_agent_effectiveness ?? sectionDScore;
+    const normalizedScore = Math.round((rawScore / 10) * 100);
 
     return {
       passed: true, // Non-critical
@@ -119,10 +115,9 @@ export function registerGate3Validators(registry) {
     const sectionEScore = sectionEFromSections.score ??
       result?.gate_scores?.lessons_captured ?? 0;
 
-    // Gate 3 Section E is scored out of 5, convert to percentage
-    const normalizedScore = result?.gate_scores?.lessons_captured !== undefined
-      ? Math.round((result.gate_scores.lessons_captured / 5) * 100)
-      : sectionEScore;
+    // Gate 3 Section E is scored out of 5, always normalize to percentage
+    const rawScore = result?.gate_scores?.lessons_captured ?? sectionEScore;
+    const normalizedScore = Math.round((rawScore / 5) * 100);
 
     return {
       passed: true, // Non-critical


### PR DESCRIPTION
## Summary

- Fix Gate 3 (traceability) score normalization: fallback path now normalizes raw section scores (0-30, 0-25, 0-10, 0-5) to 0-100% consistently, fixing 9+ false `recommendationAdherence: 0/100` pattern detections
- Fix Gate 2D (testingSubAgentVerified): failed sub-agent verdict now scores 0/100 instead of incorrectly receiving 30% partial credit
- Resolves 11 auto-detected issue patterns (PAT-AUTO-*), 5 cancelled as expected behavior, 2 fixed here

## Test plan

- [x] Smoke tests pass (15/15)
- [ ] Verify PLAN-TO-LEAD handoff scores normalize correctly when `gate_scores` path is undefined
- [ ] Verify EXEC-TO-PLAN handoff gives 0% (not 30%) for FAIL verdict on testing sub-agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)