### PR TITLE
fix(prd): replace external API with inline Claude Code PRD generation

### DIFF
--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -161,12 +161,21 @@ export class AnthropicAdapter {
           requestParams.temperature = options.temperature;
         }
 
-        const response = await Promise.race([
-          this.client.messages.create(requestParams),
-          new Promise((_, reject) =>
-            setTimeout(() => reject(new Error('TIMEOUT')), options.timeout || PROVIDER_TIMEOUT_MS)
-          )
-        ]);
+        let response;
+
+        if (options.stream) {
+          // Use streaming for long-running operations (required by Anthropic SDK
+          // for operations that may take >10 minutes)
+          // SD-LEO-FIX-REPLACE-EXTERNAL-API-001
+          response = await this._completeWithStreaming(requestParams, options);
+        } else {
+          response = await Promise.race([
+            this.client.messages.create(requestParams),
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('TIMEOUT')), options.timeout || PROVIDER_TIMEOUT_MS)
+            )
+          ]);
+        }
 
         const durationMs = Date.now() - startTime;
 
@@ -199,6 +208,34 @@ export class AnthropicAdapter {
 
     triggerAPIFailureRCA('anthropic', model, lastError?.message);
     throw new Error(`Anthropic call failed after ${MAX_RETRIES + 1} attempts: ${lastError?.message}`);
+  }
+
+  /**
+   * Complete a request using streaming mode.
+   * Required by Anthropic SDK for operations that may take >10 minutes.
+   * Collects streamed chunks and assembles them into a standard response object.
+   * SD-LEO-FIX-REPLACE-EXTERNAL-API-001
+   *
+   * @param {Object} requestParams - Anthropic API request parameters
+   * @param {Object} options - Options including timeout
+   * @returns {Promise<Object>} Response object matching non-streaming format
+   */
+  async _completeWithStreaming(requestParams, options = {}) {
+    const timeout = options.timeout || PROVIDER_TIMEOUT_MS;
+
+    const stream = this.client.messages.stream(requestParams);
+
+    const finalMessage = await Promise.race([
+      stream.finalMessage(),
+      new Promise((_, reject) =>
+        setTimeout(() => {
+          stream.abort();
+          reject(new Error('TIMEOUT'));
+        }, timeout)
+      )
+    ]);
+
+    return finalMessage;
   }
 }
 

--- a/scripts/prd/index.js
+++ b/scripts/prd/index.js
@@ -408,10 +408,17 @@ async function generateAndValidatePRDContent(supabase, sdId, sdIdValue, sdData, 
     });
 
     if (!llmPrdContent) {
-      // HARD GATE: Exit when LLM generation fails
+      // Check if inline mode is active — null return is expected
+      if (process.env.LLM_PRD_INLINE !== 'false') {
+        console.log('\n   ℹ️  INLINE MODE: PRD prompt output complete.');
+        console.log('   Claude Code should generate and insert the PRD content directly.');
+        console.log('   Exiting without creating PRD record (expected in inline mode).');
+        process.exit(0);
+      }
+      // HARD GATE: Exit when LLM generation fails in external API mode
       console.error('\n   ❌ QUALITY GATE FAILED: LLM PRD generation failed');
       console.error('   No PRD will be created (avoiding placeholder content).');
-      console.error('   Check OPENAI_API_KEY and retry PRD creation.');
+      console.error('   Check API credentials and retry PRD creation.');
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary
- Added inline PRD generation mode to `scripts/prd/llm-generator.js` that outputs structured prompts for Claude Code to process directly, eliminating redundant external API calls since Claude Code IS already Opus 4.6
- Added streaming support to `lib/sub-agents/vetting/provider-adapters.js` (AnthropicAdapter) as a fallback fix for the Anthropic SDK streaming requirement on operations >10 minutes
- Updated `scripts/prd/index.js` to handle inline mode's null return gracefully with clean exit

## Test plan
- [x] Inline mode outputs structured prompt with delimiters when `LLM_PRD_INLINE=true` (default)
- [x] External API fallback preserved when `LLM_PRD_INLINE=false`
- [x] Streaming support added to AnthropicAdapter.complete() for long operations
- [x] No regression in existing LLM client factory usage
- [x] REGRESSION sub-agent verified backward compatibility

SD: SD-LEO-FIX-REPLACE-EXTERNAL-API-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)