### PR TITLE
feat(claim): add /claim command for SD claim management

### DIFF
--- a/.claude/commands/claim.md
+++ b/.claude/commands/claim.md
@@ -1,0 +1,292 @@
+# /claim - SD Claim Management Command
+
+Manage SD session claims: view status, release claims, list all active claims.
+
+## Arguments
+
+Parse `$ARGUMENTS` to determine the subcommand:
+- No args or `status` → Show current claim status
+- `release` → Release current claim
+- `list` → List all active claims
+- `help` → Show usage help
+
+ARGUMENTS: $ARGUMENTS
+
+---
+
+## Instructions for Claude
+
+### Step 1: Parse Arguments
+
+Determine which subcommand to execute based on the arguments provided above.
+
+### Step 2: Execute Subcommand
+
+#### If no args, `status`, or `s`:
+
+Show the current session's claim status by querying `v_active_sessions`.
+
+```bash
+node -e "
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function claimStatus() {
+  // Get current session
+  const { data: session } = await supabase
+    .from('claude_sessions')
+    .select('session_id, sd_id, heartbeat_at, status')
+    .eq('status', 'active')
+    .order('heartbeat_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (!session || !session.sd_id) {
+    console.log('');
+    console.log('  No active claim');
+    console.log('');
+    console.log('  You are not currently working on any SD.');
+    console.log('  Run /leo next to see the SD queue.');
+    console.log('');
+    return;
+  }
+
+  // Get claim details from v_active_sessions
+  const { data: claim } = await supabase
+    .from('v_active_sessions')
+    .select('session_id, sd_id, sd_title, heartbeat_age_human, heartbeat_age_seconds, computed_status, track, hostname, tty, claimed_at, claim_duration_minutes')
+    .eq('session_id', session.session_id)
+    .single();
+
+  if (!claim) {
+    console.log('');
+    console.log('  No active claim found in v_active_sessions');
+    console.log('  Session: ' + session.session_id);
+    console.log('  SD (from session): ' + session.sd_id);
+    console.log('');
+    return;
+  }
+
+  const staleThreshold = 300; // 5 minutes
+  const isStale = claim.heartbeat_age_seconds > staleThreshold;
+  const staleIndicator = isStale ? ' [STALE]' : '';
+
+  console.log('');
+  console.log('  Claim Status');
+  console.log('  ' + '='.repeat(50));
+  console.log('  SD:        ' + claim.sd_id);
+  if (claim.sd_title) console.log('  Title:     ' + claim.sd_title);
+  console.log('  Session:   ' + claim.session_id);
+  console.log('  Heartbeat: ' + (claim.heartbeat_age_human || 'unknown') + staleIndicator);
+  console.log('  Status:    ' + (claim.computed_status || 'unknown'));
+  if (claim.track) console.log('  Track:     ' + claim.track);
+  if (claim.claimed_at) console.log('  Claimed:   ' + new Date(claim.claimed_at).toLocaleString());
+  if (claim.claim_duration_minutes) console.log('  Duration:  ' + Math.round(claim.claim_duration_minutes) + ' min');
+  console.log('  ' + '='.repeat(50));
+  if (isStale) {
+    console.log('');
+    console.log('  Warning: Heartbeat is stale (>' + (staleThreshold / 60) + 'min).');
+    console.log('  Other sessions may take over this claim.');
+  }
+  console.log('');
+}
+
+claimStatus();
+"
+```
+
+Display the results formatted as shown above.
+
+---
+
+#### If `release` or `r`:
+
+Release the current session's claim by calling the `release_sd` RPC.
+
+```bash
+node -e "
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function releaseClaim() {
+  // Get current session
+  const { data: session } = await supabase
+    .from('claude_sessions')
+    .select('session_id, sd_id')
+    .eq('status', 'active')
+    .order('heartbeat_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (!session || !session.sd_id) {
+    console.log('');
+    console.log('  No active claim to release.');
+    console.log('  Run /claim status to check your current state.');
+    console.log('');
+    return;
+  }
+
+  const sdId = session.sd_id;
+  const sessionId = session.session_id;
+
+  // Release via RPC (use single-param overload to avoid ambiguity)
+  const { error: releaseError } = await supabase.rpc('release_sd', {
+    p_session_id: sessionId
+  });
+
+  if (releaseError) {
+    console.log('');
+    console.log('  Error releasing claim: ' + releaseError.message);
+    console.log('');
+
+    // Fallback: try direct update if RPC fails
+    console.log('  Attempting direct release...');
+    const { error: directError } = await supabase
+      .from('sd_claims')
+      .update({ released_at: new Date().toISOString(), release_reason: 'manual' })
+      .eq('session_id', sessionId)
+      .is('released_at', null);
+
+    if (directError) {
+      console.log('  Direct release also failed: ' + directError.message);
+      return;
+    }
+  }
+
+  // Clear claiming_session_id and is_working_on on the SD
+  await supabase
+    .from('strategic_directives_v2')
+    .update({ claiming_session_id: null, is_working_on: false })
+    .eq('sd_key', sdId);
+
+  // Clear sd_id on the session
+  await supabase
+    .from('claude_sessions')
+    .update({ sd_id: null })
+    .eq('session_id', sessionId);
+
+  console.log('');
+  console.log('  Released: ' + sdId);
+  console.log('  Session ' + sessionId + ' no longer claims this SD.');
+  console.log('');
+  console.log('  Run /leo next to pick your next work item.');
+  console.log('');
+}
+
+releaseClaim();
+"
+```
+
+---
+
+#### If `list` or `l`:
+
+List all active claims across all sessions.
+
+```bash
+node -e "
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+const supabase = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function listClaims() {
+  const { data: claims, error } = await supabase
+    .from('v_active_sessions')
+    .select('session_id, sd_id, sd_title, heartbeat_age_human, heartbeat_age_seconds, computed_status, hostname, tty, track')
+    .order('heartbeat_age_seconds', { ascending: true });
+
+  if (error) {
+    console.log('Error querying active sessions: ' + error.message);
+    return;
+  }
+
+  if (!claims || claims.length === 0) {
+    console.log('');
+    console.log('  No active claims.');
+    console.log('  All SDs are available for work.');
+    console.log('');
+    return;
+  }
+
+  const staleThreshold = 300;
+
+  console.log('');
+  console.log('  Active Claims (' + claims.length + ')');
+  console.log('  ' + '='.repeat(90));
+  console.log('  ' + 'SD'.padEnd(40) + 'Session'.padEnd(16) + 'Heartbeat'.padEnd(14) + 'Status');
+  console.log('  ' + '-'.repeat(90));
+
+  claims.forEach(function(c) {
+    const isStale = c.heartbeat_age_seconds > staleThreshold;
+    const staleFlag = isStale ? ' [STALE]' : '';
+    const sd = (c.sd_id || 'unknown').substring(0, 38).padEnd(40);
+    const sess = (c.session_id || '').substring(0, 14).padEnd(16);
+    const hb = ((c.heartbeat_age_human || '?') + staleFlag).padEnd(14);
+    const status = c.computed_status || '?';
+    console.log('  ' + sd + sess + hb + status);
+  });
+
+  console.log('  ' + '='.repeat(90));
+
+  const staleCount = claims.filter(function(c) { return c.heartbeat_age_seconds > staleThreshold; }).length;
+  if (staleCount > 0) {
+    console.log('');
+    console.log('  Warning: ' + staleCount + ' stale claim(s) detected (heartbeat >5min).');
+    console.log('  Stale claims will be auto-released when another session claims the same SD.');
+  }
+  console.log('');
+}
+
+listClaims();
+"
+```
+
+---
+
+#### If `help` or `h`:
+
+Display usage information:
+
+```
+/claim Command - SD Claim Management
+
+Subcommands:
+  /claim              Show current claim status (default)
+  /claim status  (s)  Show current claim status
+  /claim release (r)  Release your current SD claim
+  /claim list    (l)  List all active claims across sessions
+  /claim help    (h)  Show this help
+
+Examples:
+  /claim               Check if you have an active claim
+  /claim release       Free your current SD for other sessions
+  /claim list          See who is working on what
+
+Related:
+  /leo next            Show SD queue and pick next work
+  /leo start <SD-ID>   Claim and start working on an SD
+```
+
+---
+
+## Intent Detection Keywords
+
+When the user mentions any of these phrases, suggest `/claim`:
+- "claim status", "my claim", "what am I working on"
+- "release claim", "release SD", "free SD", "unclaim"
+- "who has", "who is working on", "active claims", "active sessions"
+- "claim stuck", "claim conflict", "stale claim"
+
+---
+
+## Command Ecosystem
+
+After using /claim, consider:
+
+| Action | Suggest |
+|--------|---------|
+| After releasing | `/leo next` to pick new work |
+| Stale claims found | Release via `/claim release` then `/leo next` |
+| Claim conflict | Check `/claim list` to see who owns it |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ LEAD-FINAL-APPROVAL → /restart → Visual Review → /document → /ship → /
 ```
 
 ## DYNAMICALLY GENERATED FROM DATABASE
-**Last Generated**: 2026-02-14 7:50:42 AM
+**Last Generated**: 2026-02-14 8:45:39 AM
 **Source**: Supabase Database (not files)
 **Auto-Update**: Run `node scripts/generate-claude-md-from-db.js` anytime
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -50,7 +50,7 @@ Task tool with subagent_type="rca-agent":
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-14 7:50:42 AM
+**Generated**: 2026-02-14 8:45:39 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions (15-20k chars)
 
@@ -1608,12 +1608,13 @@ Total = EXEC: 30% + LEAD: 35% + PLAN: 35% = 100%
 
 ### Sub-Agents Without Keyword Triggers
 
-- **Orchestrator Child Agent** (`ORCHESTRATOR_CHILD`): Teammate agent for parallel child SD execution within an orchestrator. Each team
 - **Prioritization Planner** (`PRIORITIZATION_PLANNER`): # Prioritization Planner Sub-Agent
 
 **Identity**: You are a Prioritization Plann
+- **Orchestrator Child Agent** (`ORCHESTRATOR_CHILD`): Teammate agent for parallel child SD execution within an orchestrator. Each team
 - **Self-Audit Agent** (`AUDIT`): Read-only audit capability for SD health checks. Evaluates strategic directives 
 - **Constitutional Judge** (`JUDGE`): Resolves conflicts between LEO agent recommendations using constitutional framew
+- **Claim Management** (`CLAIM`): SD claim status, release, and listing via /claim command
 
 ### Keyword-Triggered Sub-Agents
 
@@ -1621,11 +1622,6 @@ Total = EXEC: 30% + LEAD: 35% + PLAN: 35% = 100%
 MUST BE USED PROACTIVELY for all root cause analysis tasks. Handles defect triage, root cause determ
 
 **Trigger Keywords**: `5 whys`, `causal analysis`, `ci_pipeline_failure`, `fault tree`, `fishbone`, `five whys`, `get to the bottom`, `handoff_rejection`, `ishikawa`, `keeps happening`, `pattern detected`, `pattern_recurrence`, `performance_regression`, `quality_degradation`, `quality_gate_critical`, `recurring issue`, `root cause`, `root-cause`, `source of the issue`, `source of the problem`, `sub_agent_blocked`, `sub_agent_fail`, `test_regression`, `what caused this`, `why is this happening`, `debug`, `debugging`, `diagnose`, `diagnose defect`, `diagnostic`, `dig deeper`, `dig into`, `figure out why`, `find out why`, `find the cause`, `investigate`, `investigation`, `rca`, `trace`, `tracing`, `track down`, `understand why`, `what went wrong`
-
-#### Quick-Fix Orchestrator ("LEO Lite" Field Medic) (`QUICKFIX`)
-Lightweight triage and resolution for small UAT-discovered issues (≤50 LOC). Acts as mini-orchestrat
-
-**Trigger Keywords**: `easy fix`, `hotfix`, `minor fix`, `one liner`, `quick fix`, `quickfix`, `simple fix`, `small fix`, `trivial fix`, `adjust`, `fast fix`, `fix`, `minor change`, `patch`, `quick change`, `small change`, `tweak`
 
 #### Regression Validator Sub-Agent (`REGRESSION`)
 Validates that refactoring changes maintain backward compatibility. Captures baseline test results, 
@@ -1639,17 +1635,10 @@ Validates that refactoring changes maintain backward compatibility. Captures bas
 
 **Trigger Keywords**: `DAILY_DOCMON_CHECK`, `EXEC_COMPLETION`, `EXEC_IMPLEMENTATION`, `FILE_CREATED`, `HANDOFF_ACCEPTED`, `HANDOFF_CREATED`, `LEAD_APPROVAL`, `LEAD_HANDOFF_CREATION`, `LEAD_SD_CREATION`, `PHASE_TRANSITION`, `PLAN_PRD_GENERATION`, `PLAN_VERIFICATION`, `RETRO_GENERATED`, `VIOLATION_DETECTED`, `add documentation`, `api documentation`, `document this`, `jsdoc`, `missing docs`, `readme update`, `tsdoc`, `update documentation`, `comment`, `comments`, `describe`, `docs`, `document`, `documentation`, `explain`, `guide`, `howto`, `readme`, `tutorial`
 
-#### DevOps Platform Architect (`GITHUB`)
-# DevOps Platform Architect Sub-Agent
+#### Quick-Fix Orchestrator ("LEO Lite" Field Medic) (`QUICKFIX`)
+Lightweight triage and resolution for small UAT-discovered issues (≤50 LOC). Acts as mini-orchestrat
 
-**Identity**: You are a DevOps Platform Architect with 20 yea
-
-**Trigger Keywords**: `EXEC_IMPLEMENTATION_COMPLETE`, `LEAD_APPROVAL_COMPLETE`, `PLAN_VERIFICATION_PASS`, `ci pipeline`, `code review`, `create pr`, `git merge`, `git rebase`, `github actions`, `github workflow`, `merge pr`, `pull request`, `actions`, `branch`, `cd`, `ci`, `commit`, `create pull request`, `create release`, `deploy`, `deployment ci pattern`, `gh pr create`, `git`, `github`, `github deploy`, `github status`, `merge`, `pipeline`, `pr`, `pull`, `push`, `release`, `workflow`
-
-#### Chief Security Architect (`SECURITY`)
-Former NSA security architect with 25 years experience securing systems from startup to enterprise s
-
-**Trigger Keywords**: `api key exposed`, `authentication bypass`, `csrf vulnerability`, `cve`, `exposed credential`, `hardcoded secret`, `owasp`, `penetration test`, `security audit`, `security vulnerability`, `sql injection`, `xss attack`, `access control`, `auth`, `authentication`, `authorization`, `credential`, `encrypt`, `encryption`, `hash`, `jwt`, `login`, `oauth`, `password`, `permission`, `role`, `secret`, `security`, `security auth pattern`, `token`, `vulnerability`
+**Trigger Keywords**: `easy fix`, `hotfix`, `minor fix`, `one liner`, `quick fix`, `quickfix`, `simple fix`, `small fix`, `trivial fix`, `adjust`, `fast fix`, `fix`, `minor change`, `patch`, `quick change`, `small change`, `tweak`
 
 #### UAT Test Executor (`UAT`)
 Interactive UAT test execution guide for manual testing workflows.
@@ -1657,6 +1646,18 @@ Interactive UAT test execution guide for manual testing workflows.
 **Mission**: Guide human testers
 
 **Trigger Keywords**: `acceptance criteria`, `click through`, `happy path`, `human test`, `manual test`, `test scenario`, `uat test`, `user acceptance test`, `user journey`, `TEST-AUTH`, `TEST-DASH`, `TEST-VENT`, `acceptance`, `check`, `confirm`, `demo`, `execute test`, `manual`, `run uat`, `scenario`, `start testing`, `test execution`, `uat`, `uat testing`, `use case`, `user flow`, `validate`, `verify`, `workflow`
+
+#### Chief Security Architect (`SECURITY`)
+Former NSA security architect with 25 years experience securing systems from startup to enterprise s
+
+**Trigger Keywords**: `api key exposed`, `authentication bypass`, `csrf vulnerability`, `cve`, `exposed credential`, `hardcoded secret`, `owasp`, `penetration test`, `security audit`, `security vulnerability`, `sql injection`, `xss attack`, `access control`, `auth`, `authentication`, `authorization`, `credential`, `encrypt`, `encryption`, `hash`, `jwt`, `login`, `oauth`, `password`, `permission`, `role`, `secret`, `security`, `security auth pattern`, `token`, `vulnerability`
+
+#### DevOps Platform Architect (`GITHUB`)
+# DevOps Platform Architect Sub-Agent
+
+**Identity**: You are a DevOps Platform Architect with 20 yea
+
+**Trigger Keywords**: `EXEC_IMPLEMENTATION_COMPLETE`, `LEAD_APPROVAL_COMPLETE`, `PLAN_VERIFICATION_PASS`, `ci pipeline`, `code review`, `create pr`, `git merge`, `git rebase`, `github actions`, `github workflow`, `merge pr`, `pull request`, `actions`, `branch`, `cd`, `ci`, `commit`, `create pull request`, `create release`, `deploy`, `deployment ci pattern`, `gh pr create`, `git`, `github`, `github deploy`, `github status`, `merge`, `pipeline`, `pr`, `pull`, `push`, `release`, `workflow`
 
 #### Principal Database Architect (`DATABASE`)
 ## Principal Database Architect v2.0.0 - Lessons Learned Edition
@@ -1691,25 +1692,15 @@ Handles production launch orchestration, go-live checklists, launch readiness, a
 
 **Trigger Keywords**: `deploy to production`, `go live checklist`, `launch checklist`, `production deployment`, `ready to launch`, `release to production`, `ship to prod`, `GA release`, `beta release`, `cutover`, `deploy`, `deployment`, `go live`, `go-live`, `golive`, `launch`, `prod`, `production`, `production launch`, `release`, `rollback`, `rollout`, `ship`
 
-#### Financial Modeling Sub-Agent (`FINANCIAL`)
-Handles financial projections, P&L modeling, cash flow analysis, business model canvas financial sec
-
-**Trigger Keywords**: `burn rate`, `cash flow analysis`, `financial model`, `p&l statement`, `profit and loss`, `revenue projection`, `runway calculation`, `EBITDA`, `P&L`, `break even`, `budget`, `burn`, `cash flow`, `cost`, `ebitda`, `finance`, `financial`, `forecast`, `gross margin`, `margin`, `profit`, `projection`, `revenue`, `runway`
-
 #### Monitoring Sub-Agent (`MONITORING`)
 Handles monitoring setup, alerting, SLA definition, health checks, and incident response.
 
 **Trigger Keywords**: `alerting system`, `application monitoring`, `datadog`, `error monitoring`, `health check`, `prometheus`, `sentry`, `system monitoring`, `uptime monitoring`, `Datadog`, `Prometheus`, `SLA`, `alert`, `alerting`, `downtime`, `health`, `incident`, `logging`, `logs`, `monitor`, `monitoring`, `observability`, `tracing`, `uptime`
 
-#### Analytics Sub-Agent (`ANALYTICS`)
-Handles analytics setup, metrics definition, dashboard creation, and data-driven insights.
+#### Financial Modeling Sub-Agent (`FINANCIAL`)
+Handles financial projections, P&L modeling, cash flow analysis, business model canvas financial sec
 
-**Trigger Keywords**: `analytics tracking`, `conversion tracking`, `funnel analysis`, `google analytics`, `kpi dashboard`, `metrics dashboard`, `mixpanel`, `user analytics`, `AARRR`, `KPI`, `analytics`, `churn rate`, `conversion`, `conversion rate`, `dashboard`, `engagement`, `funnel`, `kpi`, `metrics`, `report`, `retention`, `retention rate`, `tracking`, `user behavior`
-
-#### Pricing Strategy Sub-Agent (`PRICING`)
-Handles pricing model development, unit economics, pricing tiers, sensitivity analysis, and competit
-
-**Trigger Keywords**: `cac ltv`, `pricing model`, `pricing page`, `pricing strategy`, `subscription pricing`, `tiered pricing`, `unit economics`, `CAC`, `LTV`, `arpu`, `arr`, `cac`, `freemium`, `ltv`, `mrr`, `plan`, `price`, `price point`, `pricing`, `revenue model`, `subscription`, `tier`
+**Trigger Keywords**: `burn rate`, `cash flow analysis`, `financial model`, `p&l statement`, `profit and loss`, `revenue projection`, `runway calculation`, `EBITDA`, `P&L`, `break even`, `budget`, `burn`, `cash flow`, `cost`, `ebitda`, `finance`, `financial`, `forecast`, `gross margin`, `margin`, `profit`, `projection`, `revenue`, `runway`
 
 #### API Architecture Sub-Agent (`API`)
 ## API Sub-Agent v1.0.0
@@ -1718,13 +1709,6 @@ Handles pricing model development, unit economics, pricing tiers, sensitivity an
 
 **Trigger Keywords**: `add endpoint`, `api design`, `api endpoint`, `api route`, `backend route`, `create endpoint`, `graphql api`, `openapi`, `rest api`, `swagger`, `API`, `GraphQL`, `HTTP method`, `OpenAPI`, `REST`, `RESTful`, `Swagger`, `api`, `controller`, `endpoint`, `graphql`, `handler`, `http`, `json`, `middleware`, `pagination`, `payload`, `request`, `response`, `rest`, `route`, `service`, `status code`, `versioning`
 
-#### Risk Assessment Sub-Agent (`RISK`)
-## Risk Assessment Sub-Agent v1.0.0
-
-**BMAD Enhancement**: Multi-domain risk assessment for Strategi
-
-**Trigger Keywords**: `architecture decision`, `high risk`, `pros and cons`, `risk analysis`, `risk assessment`, `risk mitigation`, `security risk`, `system design`, `tradeoff analysis`, `LEAD_PRE_APPROVAL`, `PLAN_PRD`, `a11y`, `access control`, `accessibility`, `advanced`, `alter`, `api`, `architecture`, `authentication`, `authorization`, `aws`, `bulk`, `cache`, `complex`, `complexity`, `component`, `constraint`, `contingency`, `create table`, `credential`, `dangerous`, `dashboard`, `database`, `decision`, `decrypt`, `design`, `encrypt`, `external`, `foreign key`, `integration`, `interface`, `large dataset`, `latency`, `microservice`, `migration`, `mitigation`, `mobile`, `openai`, `optimization`, `overhaul`, `performance`, `permission`, `postgres`, `real-time`, `redesign`, `refactor`, `responsive`, `restructure`, `risk`, `risky`, `rls`, `scalability`, `schema`, `security`, `sensitive`, `slow`, `sophisticated`, `sql`, `stripe`, `table`, `third-party`, `threat`, `tradeoff`, `twilio`, `ui`, `ux`, `webhook`, `websocket`
-
 #### Principal Systems Analyst (`VALIDATION`)
 ## Principal Systems Analyst v3.0.0 - Retrospective-Informed Edition
 
@@ -1732,27 +1716,32 @@ Handles pricing model development, unit economics, pricing tiers, sensitivity an
 
 **Trigger Keywords**: `already exists`, `already implemented`, `before i build`, `check if exists`, `codebase search`, `duplicate check`, `existing implementation`, `codebase`, `codebase check`, `conflict`, `duplicate`, `exist`, `existing`, `overlap`, `redundant`, `search`, `validate`, `validation`, `verify`
 
-#### Exit Valuation Sub-Agent (`VALUATION`)
-Handles exit valuation modeling, comparable analysis, acquisition scenario planning, and investor re
+#### Pricing Strategy Sub-Agent (`PRICING`)
+Handles pricing model development, unit economics, pricing tiers, sensitivity analysis, and competit
 
-**Trigger Keywords**: `acquisition target`, `company valuation`, `dcf analysis`, `exit strategy`, `fundraising round`, `series a`, `startup valuation`, `DCF`, `IPO`, `Series A`, `acquisition`, `comparable`, `equity`, `exit`, `funding`, `fundraising`, `investor`, `ipo`, `multiple`, `round`, `seed`, `series`, `valuation`
+**Trigger Keywords**: `cac ltv`, `pricing model`, `pricing page`, `pricing strategy`, `subscription pricing`, `tiered pricing`, `unit economics`, `CAC`, `LTV`, `arpu`, `arr`, `cac`, `freemium`, `ltv`, `mrr`, `plan`, `price`, `price point`, `pricing`, `revenue model`, `subscription`, `tier`
 
-#### Sales Process Sub-Agent (`SALES`)
-Handles sales playbook development, pipeline management, objection handling, and sales enablement.
+#### Analytics Sub-Agent (`ANALYTICS`)
+Handles analytics setup, metrics definition, dashboard creation, and data-driven insights.
 
-**Trigger Keywords**: `close deal`, `objection handling`, `sales cycle`, `sales pipeline`, `sales playbook`, `sales process`, `sales strategy`, `close`, `closing`, `deal`, `deal flow`, `demo`, `lead`, `opportunity`, `pipeline`, `prospect`, `quota`, `sales`, `sales enablement`, `sell`, `selling`
+**Trigger Keywords**: `analytics tracking`, `conversion tracking`, `funnel analysis`, `google analytics`, `kpi dashboard`, `metrics dashboard`, `mixpanel`, `user analytics`, `AARRR`, `KPI`, `analytics`, `churn rate`, `conversion`, `conversion rate`, `dashboard`, `engagement`, `funnel`, `kpi`, `metrics`, `report`, `retention`, `retention rate`, `tracking`, `user behavior`
 
-#### Dependency Management Sub-Agent (`DEPENDENCY`)
-# Dependency Management Specialist Sub-Agent
+#### Risk Assessment Sub-Agent (`RISK`)
+## Risk Assessment Sub-Agent v1.0.0
 
-**Identity**: You are a Dependency Management Speciali
+**BMAD Enhancement**: Multi-domain risk assessment for Strategi
 
-**Trigger Keywords**: `dependency update`, `dependency vulnerability`, `npm audit`, `npm install`, `outdated packages`, `package update`, `pnpm add`, `security advisory`, `yarn add`, `CVE`, `CVSS`, `Dependabot`, `Snyk`, `audit`, `dependabot`, `dependencies`, `dependency`, `exploit`, `install`, `npm`, `outdated`, `package`, `package.json`, `patch`, `pnpm`, `update`, `upgrade`, `vulnerability`, `yarn`
+**Trigger Keywords**: `architecture decision`, `high risk`, `pros and cons`, `risk analysis`, `risk assessment`, `risk mitigation`, `security risk`, `system design`, `tradeoff analysis`, `LEAD_PRE_APPROVAL`, `PLAN_PRD`, `a11y`, `access control`, `accessibility`, `advanced`, `alter`, `api`, `architecture`, `authentication`, `authorization`, `aws`, `bulk`, `cache`, `complex`, `complexity`, `component`, `constraint`, `contingency`, `create table`, `credential`, `dangerous`, `dashboard`, `database`, `decision`, `decrypt`, `design`, `encrypt`, `external`, `foreign key`, `integration`, `interface`, `large dataset`, `latency`, `microservice`, `migration`, `mitigation`, `mobile`, `openai`, `optimization`, `overhaul`, `performance`, `permission`, `postgres`, `real-time`, `redesign`, `refactor`, `responsive`, `restructure`, `risk`, `risky`, `rls`, `scalability`, `schema`, `security`, `sensitive`, `slow`, `sophisticated`, `sql`, `stripe`, `table`, `third-party`, `threat`, `tradeoff`, `twilio`, `ui`, `ux`, `webhook`, `websocket`
 
 #### Marketing & GTM Sub-Agent (`MARKETING`)
 Handles go-to-market strategy, marketing campaigns, channel selection, messaging, and brand position
 
 **Trigger Keywords**: `brand awareness`, `content marketing`, `go to market`, `gtm strategy`, `marketing campaign`, `marketing strategy`, `seo strategy`, `GTM`, `SEO`, `advertising`, `brand`, `campaign`, `channel strategy`, `content`, `go-to-market`, `lead generation`, `market`, `marketing`, `messaging`, `positioning`, `promotion`, `seo`, `social`
+
+#### Sales Process Sub-Agent (`SALES`)
+Handles sales playbook development, pipeline management, objection handling, and sales enablement.
+
+**Trigger Keywords**: `close deal`, `objection handling`, `sales cycle`, `sales pipeline`, `sales playbook`, `sales process`, `sales strategy`, `close`, `closing`, `deal`, `deal flow`, `demo`, `lead`, `opportunity`, `pipeline`, `prospect`, `quota`, `sales`, `sales enablement`, `sell`, `selling`
 
 #### Senior Design Sub-Agent (`DESIGN`)
 ## Senior Design Sub-Agent v6.0.0 - Lessons Learned Edition
@@ -1760,6 +1749,18 @@ Handles go-to-market strategy, marketing campaigns, channel selection, messaging
 **🆕 NEW in v6.0.0**: Proactive learnin
 
 **Trigger Keywords**: `a11y`, `accessibility`, `component design`, `dark mode`, `design system`, `mobile layout`, `responsive design`, `shadcn`, `ui design`, `ux design`, `wcag`, `API endpoint`, `ARIA`, `CSS`, `Tailwind`, `UI`, `UX`, `WCAG`, `backend feature`, `business logic`, `button`, `card`, `component`, `controller`, `css`, `dashboard`, `database model`, `database table`, `design`, `desktop`, `dialog`, `feature implementation`, `form`, `frontend`, `interaction`, `interface`, `journey`, `layout`, `light mode`, `mobile`, `modal`, `navbar`, `navigation`, `new endpoint`, `new feature`, `new route`, `page`, `prototype`, `responsive`, `screen reader`, `service layer`, `sidebar`, `style`, `styling`, `tailwind`, `theme`, `ui`, `user experience`, `user flow`, `user-facing`, `ux`, `view`, `wireframe`
+
+#### Exit Valuation Sub-Agent (`VALUATION`)
+Handles exit valuation modeling, comparable analysis, acquisition scenario planning, and investor re
+
+**Trigger Keywords**: `acquisition target`, `company valuation`, `dcf analysis`, `exit strategy`, `fundraising round`, `series a`, `startup valuation`, `DCF`, `IPO`, `Series A`, `acquisition`, `comparable`, `equity`, `exit`, `funding`, `fundraising`, `investor`, `ipo`, `multiple`, `round`, `seed`, `series`, `valuation`
+
+#### Dependency Management Sub-Agent (`DEPENDENCY`)
+# Dependency Management Specialist Sub-Agent
+
+**Identity**: You are a Dependency Management Speciali
+
+**Trigger Keywords**: `dependency update`, `dependency vulnerability`, `npm audit`, `npm install`, `outdated packages`, `package update`, `pnpm add`, `security advisory`, `yarn add`, `CVE`, `CVSS`, `Dependabot`, `Snyk`, `audit`, `dependabot`, `dependencies`, `dependency`, `exploit`, `install`, `npm`, `outdated`, `package`, `package.json`, `patch`, `pnpm`, `update`, `upgrade`, `vulnerability`, `yarn`
 
 #### CRM Sub-Agent (`CRM`)
 Handles customer relationship management, lead tracking, customer success metrics, and retention str

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-14T12:50:42.761Z -->
-<!-- git_commit: 4759585d -->
-<!-- db_snapshot_hash: 09759431152b1c6f -->
+<!-- generated_at: 2026-02-14T13:45:39.448Z -->
+<!-- git_commit: d0e85a94 -->
+<!-- db_snapshot_hash: 22ccf93283573780 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
@@ -826,5 +826,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-02-14 7:50:42 AM*
+*DIGEST generated: 2026-02-14 8:45:39 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-14T12:50:42.761Z -->
-<!-- git_commit: 4759585d -->
-<!-- db_snapshot_hash: 09759431152b1c6f -->
+<!-- generated_at: 2026-02-14T13:45:39.448Z -->
+<!-- git_commit: d0e85a94 -->
+<!-- db_snapshot_hash: 22ccf93283573780 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
@@ -145,5 +145,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-02-14 7:50:42 AM*
+*DIGEST generated: 2026-02-14 8:45:39 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -50,7 +50,7 @@ Task tool with subagent_type="rca-agent":
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-14 7:50:42 AM
+**Generated**: 2026-02-14 8:45:39 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing (20-25k chars)
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-14T12:50:42.761Z -->
-<!-- git_commit: 4759585d -->
-<!-- db_snapshot_hash: 09759431152b1c6f -->
+<!-- generated_at: 2026-02-14T13:45:39.448Z -->
+<!-- git_commit: d0e85a94 -->
+<!-- db_snapshot_hash: 22ccf93283573780 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
@@ -449,5 +449,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-02-14 7:50:42 AM*
+*DIGEST generated: 2026-02-14 8:45:39 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -50,7 +50,7 @@ Task tool with subagent_type="rca-agent":
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-14 7:50:42 AM
+**Generated**: 2026-02-14 8:45:39 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation (25-30k chars)
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-14T12:50:42.761Z -->
-<!-- git_commit: 4759585d -->
-<!-- db_snapshot_hash: 09759431152b1c6f -->
+<!-- generated_at: 2026-02-14T13:45:39.448Z -->
+<!-- git_commit: d0e85a94 -->
+<!-- db_snapshot_hash: 22ccf93283573780 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
@@ -173,5 +173,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-02-14 7:50:42 AM*
+*DIGEST generated: 2026-02-14 8:45:39 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -50,7 +50,7 @@ Task tool with subagent_type="rca-agent":
 
 **The only acceptable response to an issue is understanding WHY it happened.**
 
-**Generated**: 2026-02-14 7:50:42 AM
+**Generated**: 2026-02-14 8:45:39 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates (30-35k chars)
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-14T12:50:42.761Z -->
-<!-- git_commit: 4759585d -->
-<!-- db_snapshot_hash: 09759431152b1c6f -->
+<!-- generated_at: 2026-02-14T13:45:39.448Z -->
+<!-- git_commit: d0e85a94 -->
+<!-- db_snapshot_hash: 22ccf93283573780 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
@@ -334,5 +334,5 @@ Test scenarios only cover happy path ('user logs in successfully'). Missing:
 
 ---
 
-*DIGEST generated: 2026-02-14 7:50:42 AM*
+*DIGEST generated: 2026-02-14 8:45:39 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,77 +1,77 @@
 {
-  "generated_at": "2026-02-14T12:50:42.761Z",
-  "git_commit": "4759585d",
-  "db_snapshot_hash": "09759431152b1c6f",
+  "generated_at": "2026-02-14T13:45:39.448Z",
+  "git_commit": "d0e85a94",
+  "db_snapshot_hash": "22ccf93283573780",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 14699,
       "estimated_tokens": 3675,
-      "content_hash": "7e5591130063a0e1",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE.md"
+      "content_hash": "7428401d0d97d720",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 78238,
-      "estimated_tokens": 19560,
-      "content_hash": "ae6bfb68c854a3dc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_CORE.md"
+      "chars": 78329,
+      "estimated_tokens": 19583,
+      "content_hash": "dcd513bf6344230a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 58834,
       "estimated_tokens": 14709,
-      "content_hash": "7d4f34e895c4d2bc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_LEAD.md"
+      "content_hash": "db4150e8df8dcf03",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 90650,
       "estimated_tokens": 22663,
-      "content_hash": "5482150a33682928",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_PLAN.md"
+      "content_hash": "e6c6db07056e5271",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 69168,
       "estimated_tokens": 17292,
-      "content_hash": "cd7e44b845ce4ca0",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_EXEC.md"
+      "content_hash": "b0103a0475192c4c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 6344,
       "estimated_tokens": 1586,
-      "content_hash": "b57a6e093bb3c849",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_DIGEST.md"
+      "content_hash": "7cf37e670b968eec",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 36446,
       "estimated_tokens": 9112,
-      "content_hash": "e90cff8277c9c205",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "65f1ebb4ba199afb",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 6931,
       "estimated_tokens": 1733,
-      "content_hash": "f2677481c2b326e7",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "3dc520248ef2a6f2",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 14901,
       "estimated_tokens": 3726,
-      "content_hash": "337888ec4ab36ea6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "7be08eb974e28e9d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 18621,
       "estimated_tokens": 4656,
-      "content_hash": "f9d67f38ded97fc3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DISTILL-CLAUDE-FILES-001\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "cc5af729b6b32de5",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001\\CLAUDE_EXEC_DIGEST.md"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `/claim` slash command with `status`, `release`, and `list` subcommands for SD claim management
- Register 13 keyword triggers (`claim stuck`, `release claim`, `who has SD`, etc.) in `leo_sub_agent_triggers` for proactive invocation
- Regenerate CLAUDE.md and CLAUDE_CORE.md to include new CLAIM sub-agent triggers

## SD
SD-LEO-INFRA-CLAIM-MANAGEMENT-COMMAND-001

## Test plan
- [ ] Run `/claim status` with active claim - verify SD ID, session, heartbeat shown
- [ ] Run `/claim status` without claim - verify "No active claim" message
- [ ] Run `/claim release` with active claim - verify claim released
- [ ] Run `/claim list` - verify all active sessions displayed
- [ ] Verify stale indicator appears for heartbeat >5min
- [ ] Verify keyword triggers registered (check CLAUDE_CORE.md for CLAIM entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)