### PR TITLE
feat(orchestrator): route sd:start to unclaimed children

### DIFF
--- a/scripts/orchestrator-preflight.js
+++ b/scripts/orchestrator-preflight.js
@@ -576,6 +576,19 @@ async function main() {
     console.log('');
     console.log('PROCEEDING: Full LEAD→PLAN→EXEC workflow for each child.');
     console.log('');
+
+    // Emit RECOMMENDED_CHILD for agent consumption
+    // Find first unclaimed, non-completed child
+    const unclaimed = children.filter(c =>
+      !c.claiming_session_id &&
+      c.status !== 'completed' &&
+      c.status !== 'blocked'
+    );
+    if (unclaimed.length > 0) {
+      const recommended = unclaimed[0];
+      const childKey = recommended.sd_key || recommended.id;
+      console.log(`>>> RECOMMENDED_CHILD=${childKey}`);
+    }
   }
 
   // Exit code based on validation


### PR DESCRIPTION
## Summary
- **sd:start** now detects orchestrator SDs and routes to the first unclaimed child instead of claiming the parent, eliminating the single-threaded mutex bottleneck
- **sd:next** displays orchestrator children as individual START candidates with ORCHESTRATOR badge
- **orchestrator-preflight** emits `RECOMMENDED_CHILD` machine-readable output for automation

## Test plan
- [ ] Run `npm run sd:start SD-EVA-QA-AUDIT-ORCH-001` and verify it routes to first unclaimed child
- [ ] Run `npm run sd:next` with an orchestrator as top recommendation and verify children shown
- [ ] Run `node scripts/orchestrator-preflight.js SD-EVA-QA-AUDIT-ORCH-001` and verify RECOMMENDED_CHILD output
- [ ] Verify `--child` flag still allows explicit child selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)