### PR TITLE
fix(claim-guard): handle terminal_id mismatch from broken process ancestry chains

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -8,6 +8,10 @@
  *   claimGuard(sdKey, sessionId)
  *     ├── This session owns claim? → PROCEED
  *     ├── No claim exists? → Acquire → PROCEED
+ *     ├── Same conversation (terminal_id match)? → Adopt → PROCEED
+ *     ├── Ambiguous (same SSE port, missing PID suffix)?
+ *     │   ├── Claim holder process dead? → Release → Acquire → PROCEED
+ *     │   └── Claim holder process alive? → HARD STOP (safe default)
  *     ├── Another ACTIVE session owns it? → HARD STOP
  *     └── Stale session owns it? → Release → Acquire → PROCEED
  */
@@ -36,6 +40,45 @@ function getSupabase() {
 }
 
 /**
+ * RCA-TERMINAL-IDENTITY-CHAIN-BREAK-001: Determine if two terminal_ids
+ * represent the same Claude Code conversation.
+ *
+ * Terminal IDs follow the pattern: win-cc-{ssePort}-{ccPid}
+ * When findClaudeCodePid() fails (broken process chain), the PID suffix
+ * is omitted, producing just: win-cc-{ssePort}
+ *
+ * @returns {true} Same SSE port + same PID suffix (definitely same conversation)
+ * @returns {false} Different SSE port, or same port + different PID suffixes
+ * @returns {'ambiguous'} Same SSE port + one has no PID suffix (need liveness check)
+ */
+function isSameConversation(tidA, tidB) {
+  if (tidA === tidB) return true;
+
+  // Parse win-cc-{port}[-{pid}] format
+  const parseWinCC = (tid) => {
+    const match = tid?.match(/^win-cc-(\d+)(?:-(\d+))?$/);
+    return match ? { port: match[1], pid: match[2] || null } : null;
+  };
+
+  const a = parseWinCC(tidA);
+  const b = parseWinCC(tidB);
+
+  // Non-Windows or unparseable → can't determine, treat as different
+  if (!a || !b) return false;
+
+  // Different SSE port → definitely different VS Code windows
+  if (a.port !== b.port) return false;
+
+  // Same port, both have PID suffix
+  if (a.pid && b.pid) {
+    return a.pid === b.pid; // Same PID = same conversation
+  }
+
+  // Same port, one or both missing PID suffix → ambiguous
+  return 'ambiguous';
+}
+
+/**
  * Centralized claim enforcement gate.
  *
  * @param {string} sdKey - The SD key (e.g., 'SD-LEO-INFRA-CLAIM-GUARD-001')
@@ -52,7 +95,7 @@ export async function claimGuard(sdKey, sessionId) {
   // Step 1: Check existing claims for this SD
   const { data: existingClaims, error: queryError } = await supabase
     .from('v_active_sessions')
-    .select('session_id, sd_id, heartbeat_age_seconds, heartbeat_age_human, hostname, tty, codebase, computed_status')
+    .select('session_id, sd_id, terminal_id, pid, heartbeat_age_seconds, heartbeat_age_human, hostname, tty, codebase, computed_status')
     .eq('sd_id', sdKey);
 
   if (queryError) {
@@ -79,8 +122,73 @@ export async function claimGuard(sdKey, sessionId) {
   // Case 2: Another session holds the claim
   const otherClaims = activeClaims.filter(c => c.session_id !== sessionId);
 
+  // Get current session's terminal_id for same-conversation detection
+  let myTerminalId = null;
+  if (otherClaims.length > 0) {
+    const { data: mySession } = await supabase
+      .from('claude_sessions')
+      .select('terminal_id')
+      .eq('session_id', sessionId)
+      .single();
+    myTerminalId = mySession?.terminal_id || null;
+  }
+
   for (const claim of otherClaims) {
     const heartbeatAge = claim.heartbeat_age_seconds || 0;
+
+    // RCA-TERMINAL-IDENTITY-CHAIN-BREAK-001: Three-case terminal_id matching.
+    // When findClaudeCodePid() fails due to broken process ancestry chains
+    // (e.g., npm run subprocess), terminal_id falls back to SSE-port-only
+    // (e.g., "win-cc-30738" instead of "win-cc-30738-12872"). This causes
+    // the same conversation to create multiple sessions with different IDs.
+    if (heartbeatAge < STALE_THRESHOLD_SECONDS && myTerminalId && claim.terminal_id) {
+      const sameConversation = isSameConversation(myTerminalId, claim.terminal_id);
+
+      if (sameConversation === true) {
+        // Case A: Same SSE port + same PID suffix → definitely same conversation
+        console.log(`[claimGuard] Same-conversation match: adopting claim from ${claim.session_id} (terminal: ${claim.terminal_id})`);
+        await supabase
+          .from('claude_sessions')
+          .update({ heartbeat_at: new Date().toISOString() })
+          .eq('session_id', sessionId);
+        return {
+          success: true,
+          claim: { session_id: sessionId, sd_id: sdKey, status: 'adopted_same_conversation' }
+        };
+      }
+
+      if (sameConversation === 'ambiguous') {
+        // Case C: Same SSE port but one has null PID suffix (fallback).
+        // Check if the claim holder's process is still alive.
+        const claimPid = claim.pid;
+        let processAlive = false;
+        if (claimPid) {
+          try { process.kill(claimPid, 0); processAlive = true; } catch { /* dead */ }
+        }
+
+        if (!processAlive) {
+          console.log(`[claimGuard] Ambiguous terminal match, claim holder PID ${claimPid} is dead — releasing ${claim.session_id}`);
+          // Use 'manual' reason (valid per sd_claims_release_reason_check constraint)
+          const { error: releaseError } = await supabase.rpc('release_sd', {
+            p_session_id: claim.session_id,
+            p_reason: 'manual'
+          });
+          if (releaseError) {
+            // Fallback: direct update if RPC fails
+            console.warn(`[claimGuard] RPC release failed, using direct update: ${releaseError.message}`);
+            await supabase
+              .from('sd_claims')
+              .update({ released_at: new Date().toISOString(), release_reason: 'manual' })
+              .eq('session_id', claim.session_id)
+              .eq('sd_id', sdKey)
+              .is('released_at', null);
+          }
+          continue; // Proceed to acquire
+        }
+        // Process alive + ambiguous → fall through to HARD STOP (safer)
+      }
+      // Case B: Same SSE port + different PID suffix → different conversation → HARD STOP
+    }
 
     if (heartbeatAge < STALE_THRESHOLD_SECONDS) {
       // Active session owns it → HARD STOP

--- a/scripts/one-time/debug-process-tree.ps1
+++ b/scripts/one-time/debug-process-tree.ps1
@@ -1,0 +1,24 @@
+param([int]$RootPid = 12872)
+
+function Show-Children {
+  param([int]$ParentPid, [int]$Depth = 0)
+  $indent = "  " * $Depth
+  $children = Get-CimInstance Win32_Process -Filter "ParentProcessId=$ParentPid" -ErrorAction SilentlyContinue
+  foreach ($c in $children) {
+    $cmd = if ($c.CommandLine.Length -gt 120) { $c.CommandLine.Substring(0, 120) + "..." } else { $c.CommandLine }
+    Write-Output "${indent}PID=$($c.ProcessId) Name=$($c.Name) PPID=$ParentPid Cmd=$cmd"
+    if ($Depth -lt 8) {
+      Show-Children -ParentPid $c.ProcessId -Depth ($Depth + 1)
+    }
+  }
+}
+
+Write-Output "=== Process tree from PID $RootPid ==="
+$root = Get-CimInstance Win32_Process -Filter "ProcessId=$RootPid" -ErrorAction SilentlyContinue
+if ($root) {
+  $cmd = if ($root.CommandLine.Length -gt 120) { $root.CommandLine.Substring(0, 120) + "..." } else { $root.CommandLine }
+  Write-Output "ROOT: PID=$($root.ProcessId) Name=$($root.Name) PPID=$($root.ParentProcessId) Cmd=$cmd"
+} else {
+  Write-Output "ROOT PID $RootPid not found!"
+}
+Show-Children -ParentPid $RootPid

--- a/scripts/one-time/debug-terminal-identity.mjs
+++ b/scripts/one-time/debug-terminal-identity.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Diagnostic: trace findClaudeCodePid() process chain and result.
+ * Run directly: node scripts/one-time/debug-terminal-identity.mjs
+ * Run via npm:  npm run debug:tid
+ */
+import { execSync } from 'child_process';
+import { getTerminalId } from '../../lib/terminal-identity.js';
+
+// Step 1: Show environment
+console.log('=== Environment ===');
+console.log('PID:', process.pid);
+console.log('PPID:', process.ppid);
+console.log('CLAUDE_CODE_SSE_PORT:', process.env.CLAUDE_CODE_SSE_PORT || 'NOT_SET');
+
+// Step 2: Walk process tree manually with diagnostics
+console.log('\n=== Process Chain (walking from PID ' + process.pid + ') ===');
+try {
+  const script = `
+$p = ${process.pid}
+$chain = @()
+while ($p -and $p -ne 0) {
+  $proc = Get-CimInstance Win32_Process -Filter "ProcessId=$p" -ErrorAction SilentlyContinue
+  if (-not $proc) { break }
+  $chain += "$($proc.ProcessId)|$($proc.Name)|$($proc.ParentProcessId)"
+  $p = $proc.ParentProcessId
+}
+$chain -join ";"
+`;
+  const encoded = Buffer.from(script, 'utf16le').toString('base64');
+  const raw = execSync(`powershell -NoProfile -EncodedCommand ${encoded}`, {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'ignore'],
+    timeout: 10000
+  }).trim();
+
+  const chain = raw.split(';').map(entry => {
+    const [pid, name, ppid] = entry.split('|');
+    return { pid, name: (name || '').toLowerCase(), ppid };
+  });
+
+  chain.forEach((p, i) => {
+    // Mark chain break if this node's PPID doesn't match the next node's PID
+    const nextNode = chain[i + 1];
+    const chainBreak = nextNode && p.ppid !== nextNode.pid ? ` *** CHAIN BREAK: PPID=${p.ppid} but next PID=${nextNode.pid}` : '';
+    const deadParent = !nextNode && i < chain.length - 1 ? ' *** DEAD PARENT' : '';
+    console.log(`  [${i}] PID=${p.pid}  Name=${p.name}  PPID=${p.ppid}${chainBreak}${deadParent}`);
+  });
+
+  // Check: did the walk reach Claude Code?
+  const lastEntry = chain[chain.length - 1];
+  console.log(`\n  Chain depth: ${chain.length} entries`);
+  console.log(`  Chain ends at: PID=${lastEntry.pid} Name=${lastEntry.name}`);
+  console.log(`  Last entry's PPID: ${lastEntry.ppid}`);
+
+  // Check if lastEntry's parent is alive
+  try {
+    const parentScript = `
+$proc = Get-CimInstance Win32_Process -Filter "ProcessId=${lastEntry.ppid}" -ErrorAction SilentlyContinue
+if ($proc) { Write-Output "$($proc.ProcessId)|$($proc.Name)|$($proc.ParentProcessId)" } else { Write-Output "DEAD" }
+`;
+    const parentEncoded = Buffer.from(parentScript, 'utf16le').toString('base64');
+    const parentResult = execSync(`powershell -NoProfile -EncodedCommand ${parentEncoded}`, {
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'], timeout: 5000
+    }).trim();
+    console.log(`  Parent of last entry (PID=${lastEntry.ppid}): ${parentResult}`);
+  } catch { /* ignore */ }
+
+  // Apply the findClaudeCodePid algorithm
+  console.log('\n=== Algorithm Walk ===');
+  let matched = false;
+  for (let i = 1; i < chain.length; i++) {
+    const proc = chain[i];
+    if (proc.name === 'node.exe' || proc.name === 'node') {
+      const parent = chain[i + 1];
+      const parentName = parent ? parent.name : 'NONE';
+      const shellNames = ['node.exe', 'node', 'bash.exe', 'bash', 'sh.exe', 'sh'];
+      const isShellParent = parent && shellNames.includes(parent.name);
+      console.log(`  [${i}] node PID=${proc.pid}, parent=[${i+1}] ${parentName}, isShell=${isShellParent}`);
+      if (!isShellParent) {
+        console.log(`  >> MATCH: Claude Code PID = ${proc.pid}`);
+        matched = true;
+        break;
+      } else {
+        console.log(`  >> SKIP: parent is shell/node`);
+      }
+    }
+  }
+  if (!matched) {
+    console.log('  >> NO MATCH: findClaudeCodePid() returns null');
+
+    // Additional: check if the known Claude Code PID (from SSE port session files) is reachable
+    console.log('\n=== Fallback: Check known CC processes ===');
+    try {
+      const ccScript = `
+Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -like '*claude-code*' } | ForEach-Object { "$($_.ProcessId)|$($_.Name)|$($_.ParentProcessId)|$($_.CommandLine.Substring(0, [Math]::Min(80, $_.CommandLine.Length)))" }
+`;
+      const ccEncoded = Buffer.from(ccScript, 'utf16le').toString('base64');
+      const ccResult = execSync(`powershell -NoProfile -EncodedCommand ${ccEncoded}`, {
+        encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'], timeout: 10000
+      }).trim();
+      console.log('  Claude Code processes found:');
+      ccResult.split('\n').forEach(line => console.log('    ' + line));
+    } catch (e) {
+      console.log('  Failed to scan:', e.message);
+    }
+  }
+} catch (err) {
+  console.error('Process chain walk failed:', err.message);
+}
+
+// Step 3: Show actual result from getTerminalId()
+console.log('\n=== Result ===');
+console.log('getTerminalId():', getTerminalId());


### PR DESCRIPTION
## Summary
- Fixes claim guard falsely rejecting handoff scripts with "CLAIMED BY ANOTHER SESSION" when the subprocess resolves a different `terminal_id` than the parent session
- Root cause: `findClaudeCodePid()` fails when run via `npm run` because intermediate bash processes exit, breaking the process tree walk. Falls back to SSE-port-only terminal_id which doesn't match the claim owner's full terminal_id
- Adds three-case `isSameConversation()` matching to handle: exact match (allow), different conversation (reject), and ambiguous/fallback (PID liveness check)

## Root Cause Analysis
Two failure modes identified (cross-validated by two independent Claude Code instances):

**Mode A**: Two sessions share the same `terminal_id` from a reused PID. `findExistingSession()` picks the wrong one.

**Mode B**: `npm run` subprocess tree breaks at a dead intermediate PID. `findClaudeCodePid()` returns null, terminal_id falls back to `win-cc-{port}` without PID suffix, potentially matching a different instance's session.

## Changes
- `lib/claim-guard.mjs`: Added `isSameConversation()` with three-case terminal_id matching (Case A: same PID → allow, Case B: different PID → reject, Case C: null suffix → liveness check)
- `scripts/one-time/debug-terminal-identity.mjs`: Diagnostic for tracing process chain and terminal_id resolution
- `scripts/one-time/debug-process-tree.ps1`: PowerShell diagnostic for viewing Claude Code child process tree

## Test plan
- [x] Unit tests: 8/8 `isSameConversation()` cases pass (identical, different PID, null suffix, both null, different port, unix TTY, cross-platform)
- [x] Integration test: `npm run test:claim-guard` via Mode B path — claim guard now passes where it previously rejected
- [x] Smoke tests: 15/15 pass
- [x] Negative test: Different PID suffixes (genuinely different conversations) still correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

RCA-TERMINAL-IDENTITY-CHAIN-BREAK-001