### PR TITLE
fix(terminal-identity): process scan fallback + mtime session ordering

### DIFF
--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -129,6 +129,10 @@ function ensureSessionDir() {
  * Find existing session for this terminal
  * SD-LEO-FIX-FIX-SESSION-LIVENESS-001: Match by terminal_id (stable across
  * subprocesses) instead of tty+pid (unique per subprocess, causing ~65 sessions/day).
+ *
+ * SD-LEO-FIX-TERMINAL-IDENTITY-001 (US-002, US-003):
+ *   When multiple session files match the same terminal_id, return the most
+ *   recently modified file and async-cleanup the older duplicates.
  */
 function findExistingSession() {
   ensureSessionDir();
@@ -137,21 +141,66 @@ function findExistingSession() {
 
   const files = fs.readdirSync(SESSION_DIR).filter(f => f.endsWith('.json'));
 
+  // Collect all matches with their mtimes (US-002)
+  const matches = [];
   for (const file of files) {
     try {
       const filePath = path.join(SESSION_DIR, file);
       const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
 
-      // Match by terminal_id (stable identifier for the Claude Code conversation)
       if (data.terminal_id === terminalId) {
-        return data;
+        const stat = fs.statSync(filePath);
+        matches.push({ filePath, data, mtime: stat.mtimeMs });
       }
     } catch {
       // Invalid file, skip
     }
   }
 
-  return null;
+  if (matches.length === 0) return null;
+
+  // Sort by mtime descending — newest first (US-002)
+  matches.sort((a, b) => b.mtime - a.mtime);
+
+  // If duplicates exist, async-cleanup older ones (US-003)
+  if (matches.length > 1) {
+    const staleMatches = matches.slice(1);
+    console.log(`[session-manager] Found ${matches.length} session files for terminal ${terminalId}, cleaning ${staleMatches.length} duplicates`);
+    // Non-blocking cleanup — fire and forget
+    _cleanupDuplicateSessions(staleMatches).catch(() => { /* silent fail */ });
+  }
+
+  return matches[0].data;
+}
+
+/**
+ * SD-LEO-FIX-TERMINAL-IDENTITY-001 (US-003): Cleanup duplicate session files.
+ * Deletes older local files and releases their DB sessions.
+ * Non-blocking — called async from findExistingSession().
+ *
+ * @param {Array<{filePath: string, data: object}>} staleMatches
+ */
+async function _cleanupDuplicateSessions(staleMatches) {
+  for (const { filePath, data } of staleMatches) {
+    try {
+      // Release DB session (silent fail)
+      if (data.session_id) {
+        await supabase.rpc('release_session', {
+          p_session_id: data.session_id,
+          p_reason: 'duplicate_cleanup'
+        }).catch(() => { /* silent */ });
+        console.log(`[session-manager] Released duplicate session: ${data.session_id}`);
+      }
+
+      // Delete local file
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+        console.log(`[session-manager] Deleted duplicate session file: ${path.basename(filePath)}`);
+      }
+    } catch {
+      // Non-blocking — continue with next
+    }
+  }
 }
 
 /**

--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -30,15 +30,93 @@ import os from 'os';
 let _cachedCCPid = null;
 
 /**
+ * Scan all running node.exe processes for one whose command line contains
+ * the CLAUDE_CODE_SSE_PORT value. This is the fallback when the ancestry
+ * tree walk fails due to orphaned bash shells breaking the chain.
+ *
+ * SD-LEO-FIX-TERMINAL-IDENTITY-001 (FR-1, FR-4)
+ *
+ * @param {string} ssePort - The SSE port to match in command line args
+ * @returns {string|null} The matching process PID, or null if not found
+ */
+function scanForClaudeCodeProcess(ssePort) {
+  try {
+    const script = [
+      '$procs = Get-CimInstance Win32_Process -Filter "Name=\'node.exe\'" -ErrorAction SilentlyContinue',
+      '$results = @()',
+      'foreach ($p in $procs) {',
+      `  if ($p.ProcessId -ne ${process.pid} -and $p.CommandLine -and $p.CommandLine -match '${ssePort}') {`,
+      '    $results += "$($p.ProcessId)|$($p.CommandLine)"',
+      '  }',
+      '}',
+      '$results -join ";"'
+    ].join('\n');
+    const encoded = Buffer.from(script, 'utf16le').toString('base64');
+    const raw = execSync(`powershell -NoProfile -EncodedCommand ${encoded}`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      timeout: 5000
+    }).trim();
+    if (!raw) return null;
+
+    // Parse results and return the first match
+    const entries = raw.split(';').filter(Boolean);
+    for (const entry of entries) {
+      const [pid] = entry.split('|');
+      if (pid && /^\d+$/.test(pid)) {
+        return pid;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Find the Claude Code node process PID by walking up the process tree.
  * The Claude Code process is the node.exe ancestor whose parent is cmd.exe
  * (or another non-node process). In the tree:
  *   node(us) → bash → bash → bash → node(Claude Code) → cmd → ...
  *
+ * Falls back to process scan (scanForClaudeCodeProcess) when the ancestry
+ * walk fails — typically due to orphaned bash shells from Bash tool breaking
+ * the chain (RCA-TERMINAL-IDENTITY-CHAIN-BREAK-001).
+ *
  * @returns {string|null} The Claude Code process PID, or null if not found
  */
 function findClaudeCodePid() {
   if (_cachedCCPid !== null) return _cachedCCPid;
+
+  // Method 1: Walk the process ancestry chain
+  const pidFromTreeWalk = _findClaudeCodePidViaTreeWalk();
+  if (pidFromTreeWalk) {
+    _cachedCCPid = pidFromTreeWalk;
+    return _cachedCCPid;
+  }
+
+  // Method 2: Fallback — scan all node.exe processes for SSE port match
+  // SD-LEO-FIX-TERMINAL-IDENTITY-001 (FR-1)
+  const ssePort = process.env.CLAUDE_CODE_SSE_PORT;
+  if (ssePort) {
+    console.log(`[terminal-identity] Tree walk failed, falling back to process scan for SSE port ${ssePort}`);
+    const pidFromScan = scanForClaudeCodeProcess(ssePort);
+    if (pidFromScan) {
+      console.log(`[terminal-identity] Process scan found Claude Code PID: ${pidFromScan}`);
+      _cachedCCPid = pidFromScan;
+      return _cachedCCPid;
+    }
+    console.log('[terminal-identity] Process scan found no matching process');
+  }
+
+  return null;
+}
+
+/**
+ * Walk the process ancestry chain to find Claude Code's node PID.
+ * @returns {string|null}
+ */
+function _findClaudeCodePidViaTreeWalk() {
   try {
     // Single PowerShell call to get full process ancestry chain.
     // Uses -EncodedCommand to avoid all shell escaping issues.
@@ -77,8 +155,7 @@ function findClaudeCodePid() {
         // Claude Code's node parent is typically cmd.exe, powershell.exe,
         // or a terminal host — not another node or bash
         if (!parent || !['node.exe', 'node', 'bash.exe', 'bash', 'sh.exe', 'sh'].includes(parent.name)) {
-          _cachedCCPid = proc.pid;
-          return _cachedCCPid;
+          return proc.pid;
         }
       }
     }


### PR DESCRIPTION
## Summary
- **Process scan fallback** (`lib/terminal-identity.js`): When ancestry chain walk fails (orphaned bash shells from `npm run`), `findClaudeCodePid()` now scans all `node.exe` processes for SSE port match via PowerShell `Get-CimInstance`
- **Mtime-based session ordering** (`lib/session-manager.mjs`): `findExistingSession()` sorts matching session files by mtime descending, returning the freshest session
- **Duplicate session cleanup** (`lib/session-manager.mjs`): Older duplicate session files are auto-deleted with DB sessions released asynchronously

SD-LEO-FIX-TERMINAL-IDENTITY-001 (US-001 through US-005)

## Test plan
- [x] `npm run debug:tid` — process scan fallback activates when tree walk fails
- [x] `test-claim-guard-fix.mjs` — claim guard accepts own-session claims (PASS)
- [x] `test-same-conversation.mjs` — 8/8 identity matching cases pass
- [x] Smoke tests — 15/15 pass
- [x] ESLint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)