### PR TITLE
audit(phase-6): EVA Stages 23-25 Launch & Learn audit

### DIFF
--- a/docs/audits/eva-comprehensive/phase-6-launch/audit-report.md
+++ b/docs/audits/eva-comprehensive/phase-6-launch/audit-report.md
@@ -1,0 +1,314 @@
+# EVA Comprehensive Audit — Phase 6: LAUNCH & LEARN (Stages 23-25)
+
+**SD**: SD-EVA-QA-AUDIT-LAUNCH-001
+**Auditor**: Claude Opus 4.6 (automated)
+**Date**: 2026-02-14
+**Gold Standard**: Architecture v1.6 (`docs/plans/eva-platform-architecture.md` Section 8.6, lines 999-1082)
+**Scope**: Stage templates (schema + kill gates) and analysis steps (LLM-driven generation)
+
+---
+
+## Executive Summary
+
+Phase 6 covers the final three stages of the EVA pipeline: Launch Execution (23), Metrics & Learning (24), and Venture Review (25). These stages form the capstone of the evaluation workflow — launching validated ventures, measuring outcomes, and making go/no-go decisions.
+
+**Overall Phase Score: 62/100** (Moderate Gaps)
+
+| Stage | Template Score | Analysis Step Score | Combined |
+|-------|---------------|-------------------|----------|
+| 23 — Launch Execution | 55/100 | 75/100 | 65/100 |
+| 24 — Metrics & Learning | 50/100 | 70/100 | 60/100 |
+| 25 — Venture Review | 55/100 | 75/100 | 62/100 |
+
+**Key Pattern**: Analysis steps are consistently more complete than their template schemas. The LLM analysis generates v1.6-compliant fields that the template schemas cannot store or validate — a schema-generation gap.
+
+---
+
+## Stage 23: Launch Execution (Kill Gate)
+
+### Gold Standard Requirements (v1.6 Section 8.6.1)
+
+| Field | v1.6 Spec | Type | Required |
+|-------|-----------|------|----------|
+| `launchType` | Enum: `soft_launch`, `hard_launch`, `staged_rollout`, `beta_release` | string | YES |
+| `goDecision` | Enum: `go`, `no_go`, `conditional_go` | string | YES |
+| `launchTasks[]` | Array with `task`, `owner`, `deadline`, `status` | array | YES |
+| `successCriteria[]` | Array with `criterion`, `metric`, `target`, `timeframe` | array | YES |
+| `rollbackTriggers[]` | Array with `trigger`, `threshold`, `action` | array | YES |
+| `plannedLaunchDate` | ISO 8601 date | string | YES |
+| `actualLaunchDate` | ISO 8601 date | string | NO |
+| `incidentResponsePlan` | Structured object | object | YES |
+| `monitoringSetup` | Structured object | object | YES |
+| `rollbackPlan` | Structured object | object | YES |
+| **Kill Gate** | Upstream Stage 22 `promotionGate=pass` AND `releaseDecision='release'` | prerequisite | YES |
+
+### Template Implementation (`lib/eva/stage-templates/stage-23.js`)
+
+| Field | Status | Notes |
+|-------|--------|-------|
+| `launchType` | MISSING | Not in schema. Analysis step generates it but template can't validate. |
+| `goDecision` → `go_decision` | PARTIAL | Exists but no enum validation (accepts any string). |
+| `launchTasks` → `launch_tasks` | PRESENT | Array with task/owner/deadline/status — matches v1.6. |
+| `successCriteria` | MISSING | Not in schema. Analysis step generates it but not stored. |
+| `rollbackTriggers` | MISSING | Not in schema. Analysis step generates it but not stored. |
+| `plannedLaunchDate` | MISSING | No ISO date field. Only `launch_date` (no planned vs actual). |
+| `actualLaunchDate` | MISSING | No separate actual date field. |
+| `incidentResponsePlan` → `incident_response_plan` | PRESENT | Object — matches v1.6. |
+| `monitoringSetup` → `monitoring_setup` | PRESENT | Object — matches v1.6. |
+| `rollbackPlan` → `rollback_plan` | PRESENT | Object — matches v1.6. |
+| **Kill Gate prerequisite** | MISSING | Does not check Stage 22 `promotionGate` or `releaseDecision`. Only checks `go_decision` and plan presence. |
+
+**Template Conformance: 55/100**
+- 4/10 fields fully present
+- 1/10 partially present (no enum validation)
+- 5/10 missing entirely
+- Kill gate prerequisite check absent
+
+### Analysis Step (`lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js`)
+
+| Output Field | Status | Notes |
+|-------------|--------|-------|
+| `launchType` | GENERATED | Enum-correct output from LLM. |
+| `launchBrief` | GENERATED | Summary — not in v1.6 but useful. |
+| `successCriteria` | GENERATED | Array with criterion/metric/target/timeframe — v1.6 compliant. |
+| `rollbackTriggers` | GENERATED | Array with trigger/threshold/action — v1.6 compliant. |
+| `launchTasks` | GENERATED | Array — v1.6 compliant. |
+| `plannedLaunchDate` | GENERATED | ISO date from LLM. |
+| Stage 22 dependency | NOT CHECKED | No upstream gate validation. |
+
+**Analysis Step Conformance: 75/100**
+- Generates most v1.6 fields but template can't persist them
+- No upstream prerequisite validation
+- `parseJSON()` duplicated (cross-cutting issue)
+
+### Stage 23 Gap Summary
+
+| Gap ID | Severity | Description | Est. LOC |
+|--------|----------|-------------|----------|
+| S23-G1 | HIGH | Add `launchType` enum field to schema with validation | 15 |
+| S23-G2 | HIGH | Add `successCriteria[]` array field to schema | 10 |
+| S23-G3 | HIGH | Add `rollbackTriggers[]` array field to schema | 10 |
+| S23-G4 | MEDIUM | Split `launch_date` into `plannedLaunchDate`/`actualLaunchDate` with ISO validation | 12 |
+| S23-G5 | MEDIUM | Add enum validation for `go_decision` (go/no_go/conditional_go) | 8 |
+| S23-G6 | HIGH | Add kill gate prerequisite check (Stage 22 promotionGate + releaseDecision) | 20 |
+| S23-G7 | LOW | Deduplicate `parseJSON()` to shared utility | 15 |
+
+---
+
+## Stage 24: Metrics & Learning
+
+### Gold Standard Requirements (v1.6 Section 8.6.2)
+
+| Field | v1.6 Spec | Type | Required |
+|-------|-----------|------|----------|
+| `aarrr` | 5-category object (acquisition, activation, retention, revenue, referral) | object | YES |
+| — each metric | `current`, `target`, `trendWindowDays`, `previousValue`, `trendDirection`, `criterionRef` | object | YES |
+| `funnels[]` | Array with `name`, `stages[]`, `conversionRate` | array | YES |
+| `learnings[]` | Array with `insight`, `evidence`, `category`, `impactLevel` | array | YES |
+| `launchOutcome` | Object with `assessment`, `criteriaMetRate` | object | YES |
+
+### Template Implementation (`lib/eva/stage-templates/stage-24.js`)
+
+| Field | Status | Notes |
+|-------|--------|-------|
+| `aarrr` (5 categories) | PRESENT | All 5 AARRR categories with `current`/`target` per metric. |
+| — `trendWindowDays` | MISSING | Not in metric schema. |
+| — `previousValue` | MISSING | Not in metric schema. |
+| — `trendDirection` | MISSING | Not in metric schema. Analysis step generates it. |
+| — `criterionRef` | MISSING | No linking to Stage 23 success criteria. |
+| `funnels[]` | PRESENT | Array with name/stages/conversionRate — matches v1.6. |
+| `learnings[]` | PARTIAL | Has `insight`/`evidence` but MISSING `category` and `impactLevel`. |
+| `launchOutcome` | MISSING | Not in template schema. Analysis step generates it. |
+
+**Template Conformance: 50/100**
+- Core AARRR structure present but missing trend/reference fields
+- Funnels fully compliant
+- Learnings missing classification fields
+- launchOutcome entirely absent from schema
+
+### Analysis Step (`lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js`)
+
+| Output Field | Status | Notes |
+|-------------|--------|-------|
+| AARRR metrics | GENERATED | All 5 categories with current/target. |
+| `trendDirection` | GENERATED | Included in LLM output. |
+| `criteriaEvaluation` | GENERATED | Maps to `launchOutcome.criteriaMetRate`. |
+| `launchOutcome` | GENERATED | Object with assessment — v1.6 aligned. |
+| `learnings` | GENERATED | Array but missing `category`/`impactLevel` in prompt. |
+| `criterionRef` | NOT GENERATED | No Stage 23 criterion linking. |
+| `trendWindowDays`/`previousValue` | NOT GENERATED | Not requested from LLM. |
+
+**Analysis Step Conformance: 70/100**
+- Good AARRR generation with trend direction
+- launchOutcome generated but not persisted in template
+- Missing criterion cross-references and trend window data
+
+### Stage 24 Gap Summary
+
+| Gap ID | Severity | Description | Est. LOC |
+|--------|----------|-------------|----------|
+| S24-G1 | HIGH | Add `trendWindowDays`, `previousValue`, `trendDirection` to each AARRR metric | 20 |
+| S24-G2 | MEDIUM | Add `criterionRef` field linking metrics to Stage 23 success criteria | 12 |
+| S24-G3 | HIGH | Add `launchOutcome` object (assessment, criteriaMetRate) to schema | 10 |
+| S24-G4 | MEDIUM | Add `category` and `impactLevel` fields to learnings schema | 8 |
+| S24-G5 | LOW | Update analysis step prompt to request `criterionRef` and trend window data | 10 |
+| S24-G6 | LOW | Deduplicate `parseJSON()` to shared utility | 15 |
+
+---
+
+## Stage 25: Venture Review (Capstone)
+
+### Gold Standard Requirements (v1.6 Section 8.6.3)
+
+| Field | v1.6 Spec | Type | Required |
+|-------|-----------|------|----------|
+| `reviewSummary` | Narrative summary object | object | YES |
+| `initiatives` | 5-category object (product, marketing, engineering, operations, growth) | object | YES |
+| — each initiative | `items[]` with `title`, `status` (enum), `priority` | array | YES |
+| `ventureDecision` | Object: `decision` (enum: proceed/pivot/pause/terminate), `rationale`, `confidence` (enum: high/medium/low), `keyFactors[]` | object | YES |
+| `nextSteps[]` | Array with `action`, `owner`, `deadline`, `priority` (enum), `category` (enum) | array | YES |
+| `ventureHealth` | 5-dimension 0-100 scoring: market, product, financial, team, technical. Band enum: critical/fragile/viable/strong | object | YES |
+| `financialComparison` | Object comparing projected vs actual financial metrics | object | YES |
+| `driftCheck` | Object with `semanticDrift` (enum: none/minor/moderate/severe), `rationale`, magnitude | object | YES |
+
+### Template Implementation (`lib/eva/stage-templates/stage-25.js`)
+
+| Field | Status | Notes |
+|-------|--------|-------|
+| `reviewSummary` → `review_summary` | PRESENT | Object — matches v1.6. |
+| `initiatives` (5 categories) | PRESENT | 5-category object with items. |
+| — initiative `status` | PARTIAL | Free text, not enum. v1.6 requires enum (planned/in_progress/completed/cancelled). |
+| `ventureDecision` | MISSING | Not in template schema. Analysis step generates it. |
+| `nextSteps` → `next_steps` | PARTIAL | Has action/owner/deadline but MISSING `priority` and `category` enums. |
+| `ventureHealth` → `venture_health` | PARTIAL | Present but uses **1-10 scale** with string ratings (excellent/good/fair/poor/critical). v1.6 requires **0-100 scale** with band enum (critical/fragile/viable/strong). |
+| `financialComparison` | MISSING | Not in template schema. Analysis step generates it. |
+| `driftCheck` → `drift_detection` | PARTIAL | Has `driftDetected` boolean and `driftAreas`. MISSING `semanticDrift` enum and structured rationale. |
+| `onComplete` hook | PRESENT | Template extraction (FR-8) — good implementation. |
+
+**Template Conformance: 55/100**
+- Core structure present but key objects missing (ventureDecision, financialComparison)
+- Scale mismatch on ventureHealth (1-10 vs 0-100)
+- Enum fields using free text instead
+- drift_detection is simplified boolean instead of severity enum
+
+### Analysis Step (`lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js`)
+
+| Output Field | Status | Notes |
+|-------------|--------|-------|
+| `journeySummary` | GENERATED | Maps to reviewSummary. |
+| `financialComparison` | GENERATED | Projected vs actual — v1.6 aligned. |
+| `ventureHealth` (5-dim) | GENERATED | **Uses 1-10 scale** and string ratings. v1.6 wants 0-100 and band enum. |
+| `driftAnalysis` | GENERATED | Has driftDetected + areas. Missing `semanticDrift` enum. |
+| `ventureDecision` | GENERATED | Has decision/rationale/confidence. **Confidence is 0-100 number**, v1.6 wants enum (high/medium/low). |
+| `initiatives` (5 categories) | GENERATED | Good coverage. Status as free text. |
+| Multi-stage consumption | PRESENT | Consumes stages 1, 5, 13, 16, 23, 24 — comprehensive. |
+
+**Analysis Step Conformance: 75/100**
+- Most v1.6 fields generated
+- Scale mismatches (1-10 vs 0-100 for ventureHealth)
+- Type mismatches (number vs enum for confidence)
+- Good multi-stage data consumption
+
+### Stage 25 Gap Summary
+
+| Gap ID | Severity | Description | Est. LOC |
+|--------|----------|-------------|----------|
+| S25-G1 | HIGH | Add `ventureDecision` object to schema (decision enum, rationale, confidence enum, keyFactors[]) | 18 |
+| S25-G2 | HIGH | Rescale `ventureHealth` from 1-10 to 0-100 with band enum (critical/fragile/viable/strong) | 25 |
+| S25-G3 | HIGH | Add `financialComparison` object to schema | 12 |
+| S25-G4 | MEDIUM | Enhance `drift_detection` with `semanticDrift` enum (none/minor/moderate/severe) and rationale | 10 |
+| S25-G5 | MEDIUM | Add enum validation for initiative `status` (planned/in_progress/completed/cancelled) | 8 |
+| S25-G6 | MEDIUM | Add `priority` and `category` enums to `next_steps` | 8 |
+| S25-G7 | LOW | Fix ventureDecision.confidence from 0-100 number to enum (high/medium/low) in analysis step | 5 |
+| S25-G8 | LOW | Deduplicate `parseJSON()` to shared utility | 15 |
+
+---
+
+## Cross-Cutting Findings
+
+### CC-1: Schema-Generation Gap (HIGH)
+
+**Pattern**: Analysis steps generate v1.6-compliant fields that template schemas cannot store or validate.
+
+| Stage | Fields Generated but Not Persisted |
+|-------|-----------------------------------|
+| 23 | `launchType`, `successCriteria`, `rollbackTriggers`, `plannedLaunchDate` |
+| 24 | `launchOutcome`, `trendDirection` (on metrics) |
+| 25 | `ventureDecision`, `financialComparison` |
+
+**Impact**: LLM-generated data is lost after analysis. Future pipeline stages consuming these stages won't find the fields.
+**Remediation**: Extend template schemas to include all fields the analysis steps generate.
+
+### CC-2: `parseJSON()` Duplication (LOW)
+
+All 3 analysis steps contain identical `parseJSON()` helper function (regex-based JSON extraction from LLM output).
+
+**Files affected**:
+- `stage-23-launch-execution.js` (line ~185)
+- `stage-24-metrics-learning.js` (line ~210)
+- `stage-25-venture-review.js` (line ~250)
+
+**Remediation**: Extract to `lib/eva/utils/parse-json.js` shared utility. ~15 LOC per file saved.
+
+### CC-3: No Upstream Prerequisite Validation (MEDIUM)
+
+Stage 23 kill gate does not verify Stage 22 `promotionGate=pass` and `releaseDecision='release'`. The kill gate only checks its own fields.
+
+**Impact**: A venture could bypass Stage 22 quality gates and still proceed to launch.
+**Remediation**: Add prerequisite check in `evaluateKillGate()` to verify upstream stage data.
+
+### CC-4: Scale Inconsistency (MEDIUM)
+
+`ventureHealth` uses 1-10 scale in both template and analysis step, while v1.6 specifies 0-100 with band classification. This affects:
+- Template validation bounds
+- Analysis step LLM prompt
+- Any downstream consumers expecting 0-100 scores
+
+**Remediation**: Update both template schema validation and analysis step prompt to use 0-100 scale with band enum mapping.
+
+---
+
+## Remediation Roadmap
+
+### Priority 1 — Schema Alignment (HIGH, ~90 LOC total)
+
+| Task | Stage | LOC | Dependency |
+|------|-------|-----|------------|
+| Add `launchType`, `successCriteria`, `rollbackTriggers` to Stage 23 | 23 | 35 | None |
+| Add `launchOutcome` + trend fields to Stage 24 | 24 | 30 | None |
+| Add `ventureDecision`, `financialComparison` to Stage 25 | 25 | 30 | None |
+
+### Priority 2 — Validation & Scale Fixes (MEDIUM, ~65 LOC total)
+
+| Task | Stage | LOC | Dependency |
+|------|-------|-----|------------|
+| Add kill gate upstream prerequisite check | 23 | 20 | None |
+| Rescale ventureHealth to 0-100 with band enum | 25 | 25 | None |
+| Add enum validation for go_decision, initiative status, next_steps | 23,25 | 20 | None |
+
+### Priority 3 — Analysis Step Alignment (LOW, ~45 LOC total)
+
+| Task | Stage | LOC | Dependency |
+|------|-------|-----|------------|
+| Extract `parseJSON()` to shared utility | All | 15 | None |
+| Add criterionRef and trendWindow to Stage 24 prompt | 24 | 10 | P1 done |
+| Fix confidence type in Stage 25 prompt | 25 | 5 | P1 done |
+| Add date field splitting (planned vs actual) to Stage 23 | 23 | 12 | P1 done |
+
+**Total estimated remediation: ~200 LOC across 6 files**
+
+---
+
+## Appendix: Files Audited
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `lib/eva/stage-templates/stage-23.js` | 153 | Launch Execution template + kill gate |
+| `lib/eva/stage-templates/stage-24.js` | 163 | Metrics & Learning template |
+| `lib/eva/stage-templates/stage-25.js` | 220 | Venture Review template + onComplete hook |
+| `lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js` | 198 | Launch analysis (LLM-driven) |
+| `lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js` | 224 | Metrics analysis (LLM-driven) |
+| `lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js` | 263 | Venture review analysis (LLM-driven) |
+| `docs/plans/eva-platform-architecture.md` | 1148 | Gold standard (Section 8.6, lines 999-1082) |
+
+**Total lines audited: 1,221 (implementation) + 84 (spec) = 1,305 lines**


### PR DESCRIPTION
## Summary
- Comprehensive audit of EVA Phase 6 (Stages 23-25: Launch Execution, Metrics & Learning, Venture Review) against Architecture v1.6 gold standard
- Overall Phase Score: 62/100 (Moderate Gaps)
- Key finding: Schema-generation gap — analysis steps generate v1.6-compliant fields that template schemas cannot store

## Findings
- **Stage 23** (65/100): Missing `launchType`, `successCriteria[]`, `rollbackTriggers[]`; kill gate missing upstream prerequisite check
- **Stage 24** (60/100): Missing trend fields on AARRR metrics, `launchOutcome` object, classification on learnings  
- **Stage 25** (62/100): Missing `ventureDecision` object, `financialComparison`; scale mismatch on `ventureHealth` (1-10 vs 0-100)
- **Cross-cutting**: `parseJSON()` duplicated in all 3 analysis steps

## Remediation
- ~200 LOC across 6 files in 3 priority tiers
- P1: Schema alignment (90 LOC)
- P2: Validation & scale fixes (65 LOC)  
- P3: Analysis step alignment (45 LOC)

## Test plan
- [x] Audit report written with field-by-field comparison
- [x] Gap severity ratings assigned (HIGH/MEDIUM/LOW)
- [x] LOC estimates provided for each remediation item

🤖 Generated with [Claude Code](https://claude.com/claude-code)