### PR TITLE
fix(handoff): improve retrospective quality and PR merge gate remediation

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -208,11 +208,22 @@ export async function claimGuard(sdKey, sessionId) {
     // Stale session → release it first
     console.log(`[claimGuard] Releasing stale claim from session ${claim.session_id} (${claim.heartbeat_age_human})`);
     const { error: releaseError } = await supabase.rpc('release_sd', {
-      p_session_id: claim.session_id
+      p_session_id: claim.session_id,
+      p_reason: 'manual'
     });
     if (releaseError) {
       console.warn(`[claimGuard] Failed to release stale session ${claim.session_id}: ${releaseError.message}`);
-      // Continue anyway — the claim_sd RPC will handle the conflict
+      // Fallback: direct update if RPC fails (same pattern as dead-process case)
+      const { error: directErr } = await supabase
+        .from('sd_claims')
+        .update({ released_at: new Date().toISOString(), release_reason: 'stale_session' })
+        .eq('session_id', claim.session_id)
+        .is('released_at', null);
+      if (directErr) {
+        console.warn(`[claimGuard] Direct release also failed: ${directErr.message}`);
+      } else {
+        console.log(`[claimGuard] Released stale claim via direct update`);
+      }
     }
   }
 

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -352,7 +352,11 @@ export function createPRMergeVerificationGate() {
             max_score: 100,
             issues: [
               `${openPRs.length} open PR(s) must be merged before SD completion`,
-              ...openPRs.map(pr => `  → PR #${pr.number} (${pr.repo}): ${pr.url}`)
+              ...openPRs.map(pr => `  → PR #${pr.number} (${pr.repo}): ${pr.url}`),
+              '',
+              'REMEDIATION: Run /ship to merge open PRs before running LEAD-FINAL-APPROVAL.',
+              'Required order: EXEC → /ship (merge PR) → LEAD-FINAL-APPROVAL',
+              ...openPRs.map(pr => `  → gh pr merge ${pr.number} --repo ${pr.repo} --merge --delete-branch`)
             ],
             warnings: [],
             details: { openPRs: openPRs.map(pr => ({ number: pr.number, repo: pr.repo, url: pr.url })) }
@@ -413,7 +417,11 @@ export function createPRMergeVerificationGate() {
             max_score: 100,
             issues: [
               `${unmergedBranches.length} unmerged branch(es) with commits - create PRs and merge before completion`,
-              ...unmergedBranches.map(b => `  → ${b.branch} (${b.commits} commits) in ${b.repo}`)
+              ...unmergedBranches.map(b => `  → ${b.branch} (${b.commits} commits) in ${b.repo}`),
+              '',
+              'REMEDIATION: Run /ship to create PRs and merge branches before running LEAD-FINAL-APPROVAL.',
+              'Required order: EXEC → /ship (merge PR) → LEAD-FINAL-APPROVAL',
+              ...unmergedBranches.map(b => `  → cd to ${b.repo} repo, then: git push -u origin ${b.branch} && gh pr create && gh pr merge --merge --delete-branch`)
             ],
             warnings: [],
             details: {

--- a/scripts/modules/handoff/rejection-subagent-mapping.js
+++ b/scripts/modules/handoff/rejection-subagent-mapping.js
@@ -582,13 +582,13 @@ const REJECTION_MAP = {
     category: 'workflow',
     promptFn: (ctx) => {
       const brief = fivePointBrief({
-        symptom: `Retrospective quality insufficient for ${ctx.sdId}. Contains boilerplate or generic learnings.`,
-        location: `sd_retrospectives table WHERE sd_id='${ctx.sdId}'`,
-        frequency: 'Blocking PLAN-TO-LEAD handoff',
-        priorAttempts: 'Retrospective exists but quality is too low',
-        desiredOutcome: 'Replace boilerplate learnings with SD-specific insights. Add at least one concrete improvement area. Ensure key_learnings are not generic phrases.'
+        symptom: `Retrospective quality insufficient for ${ctx.sdId}. Contains boilerplate or metric-only learnings (e.g., "EXEC phase quality score: 80%").`,
+        location: `retrospectives table WHERE sd_id='${ctx.sdId}'`,
+        frequency: 'Blocking PLAN-TO-LEAD handoff — common with auto-generated retrospectives',
+        priorAttempts: 'Retrospective exists but quality is too low. Key learnings need SD-specific context instead of just gate metrics.',
+        desiredOutcome: `Replace metric-only learnings with SD-specific insights. Include: (1) What was implemented and why (reference SD title/description), (2) What files were changed and their purpose, (3) Specific implementation challenges encountered, (4) Concrete action items referencing the SD. Example good learning: "Implemented claim guard by adding p_reason parameter to release_sd RPC calls in lib/claim-guard.mjs to fix PostgREST function overload ambiguity."`
       });
-      return 'Retrospective quality insufficient. Improve with specific insights.' +
+      return 'Retrospective needs SD-specific insights, not metric-only learnings.' +
         taskInvocation('retro-agent', brief);
     }
   },
@@ -599,12 +599,12 @@ const REJECTION_MAP = {
     promptFn: (ctx) => {
       const brief = fivePointBrief({
         symptom: `Unmerged code for ${ctx.sdId}. LEAD-FINAL-APPROVAL requires all PRs merged to main.`,
-        location: 'GitHub PRs, feature branches',
-        frequency: 'Blocking final approval',
-        priorAttempts: 'Code is on feature branch but not merged',
-        desiredOutcome: `Merge all open PRs for ${ctx.sdId}. For unmerged branches: push, create PR, merge, then verify on main.`
+        location: 'GitHub PRs, feature branches for rickfelix/ehg and rickfelix/EHG_Engineer',
+        frequency: 'Blocking final approval — this is the #1 cause of LEAD-FINAL-APPROVAL failure',
+        priorAttempts: 'Code is on feature branch but not merged. Run /ship BEFORE LEAD-FINAL-APPROVAL.',
+        desiredOutcome: `Run /ship to commit, create PR, and merge all changes for ${ctx.sdId}. Required order: EXEC → /ship → LEAD-FINAL-APPROVAL. For each open PR: gh pr merge <number> --merge --delete-branch`
       });
-      return 'All code must be merged to main before completion.' +
+      return 'Run /ship BEFORE LEAD-FINAL-APPROVAL. All code must be merged to main first.' +
         taskInvocation('github-agent', brief);
     }
   },

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -334,7 +334,8 @@ async function main() {
 
           // Auto-release the orphaned claim and retry
           const { error: releaseError } = await supabase.rpc('release_sd', {
-            p_session_id: claimResult.owner.session_id
+            p_session_id: claimResult.owner.session_id,
+            p_reason: 'manual'
           });
 
           if (releaseError) {


### PR DESCRIPTION
## Summary
- Enhanced `createExecToPlanRetrospective()` with SD-specific learnings (title, description, git context) instead of metric-only boilerplate — addresses RETROSPECTIVE_QUALITY_GATE failures (PAT-AUTO-ae348342)
- Added REMEDIATION messages to PR_MERGE_VERIFICATION gate with `gh pr merge` commands and /ship workflow ordering — addresses 0/100 scores (PAT-AUTO-811a990b)
- Updated rejection-subagent-mapping.js with improved remediation examples for both gate types
- Fixed release_sd RPC overload ambiguity in claim-guard.mjs and sd-start.js by always passing p_reason parameter

## Test plan
- [ ] Run next SD through PLAN-TO-LEAD and verify RETROSPECTIVE_QUALITY_GATE >= 55/100
- [ ] Trigger PR_MERGE_VERIFICATION failure and verify REMEDIATION messages appear
- [ ] Verify claim-guard release_sd calls no longer fail with overload ambiguity

🤖 Generated with [Claude Code](https://claude.com/claude-code)