### PR TITLE
fix(statusline): include output tokens in context usage calculation

### DIFF
--- a/.claude/statusline-context-tracker.ps1
+++ b/.claude/statusline-context-tracker.ps1
@@ -82,7 +82,7 @@ $cacheCreation = if ($currentUsage.cache_creation_input_tokens) { [int]$currentU
 $cacheRead = if ($currentUsage.cache_read_input_tokens) { [int]$currentUsage.cache_read_input_tokens } else { 0 }
 
 # Calculate context usage — progress bar fills to 100% at the auto-compaction threshold
-$contextUsed = $inputTokens + $cacheCreation + $cacheRead
+$contextUsed = $inputTokens + $outputTokens + $cacheCreation + $cacheRead
 $usableContext = [int]($contextSize * $AutocompactPct / 100)
 if ($usableContext -le 0) { $usableContext = $contextSize }
 

--- a/.claude/statusline-context-tracker.sh
+++ b/.claude/statusline-context-tracker.sh
@@ -144,7 +144,7 @@ if [ "$CURRENT_USAGE" != "null" ]; then
     [[ "$CACHE_READ" =~ ^[0-9]+$ ]] || CACHE_READ=0
 
     # The accurate context usage calculation
-    CONTEXT_USED=$((INPUT_TOKENS + CACHE_CREATION + CACHE_READ))
+    CONTEXT_USED=$((INPUT_TOKENS + OUTPUT_TOKENS + CACHE_CREATION + CACHE_READ))
 
     # Calculate USABLE context (total minus auto-compact buffer)
     # This gives accurate "% until compaction" rather than misleading raw %


### PR DESCRIPTION
## Summary
- Added output tokens to context usage calculation in both PowerShell and shell status line trackers
- Previously only input + cache tokens were counted, causing the progress bar to show ~89% when compaction triggered (should show 100%)

## Test plan
- [x] Verify progress bar reaches ~100% when auto-compaction triggers at the 80% threshold
- [x] Both `.ps1` and `.sh` versions updated in parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)