### PR TITLE
fix(terminal-identity): add negative caching to prevent repeated PowerShell scans

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -27,7 +27,8 @@ import crypto from 'crypto';
 import os from 'os';
 
 // Cache the Claude Code ancestor PID — stable for the lifetime of this process
-let _cachedCCPid = null;
+// Uses undefined as "not yet searched", null as "searched but not found" (negative cache)
+let _cachedCCPid = undefined;
 
 /**
  * Scan all running node.exe processes for one whose command line contains
@@ -86,7 +87,7 @@ function scanForClaudeCodeProcess(ssePort) {
  * @returns {string|null} The Claude Code process PID, or null if not found
  */
 function findClaudeCodePid() {
-  if (_cachedCCPid !== null) return _cachedCCPid;
+  if (_cachedCCPid !== undefined) return _cachedCCPid;
 
   // Method 1: Walk the process ancestry chain
   const pidFromTreeWalk = _findClaudeCodePidViaTreeWalk();
@@ -109,6 +110,8 @@ function findClaudeCodePid() {
     console.log('[terminal-identity] Process scan found no matching process');
   }
 
+  // Negative cache: remember that lookup failed so we don't retry expensive scans
+  _cachedCCPid = null;
   return null;
 }
 


### PR DESCRIPTION
## Summary
- When `findClaudeCodePid()` fails both lookup methods (tree walk + process scan), repeated calls would re-run the expensive PowerShell scans (~5s each)
- `sd:next` calls `getTerminalId()` twice per run, causing ~20s of wasted time
- Added negative caching: uses `undefined` as "not yet searched" vs `null` as "searched but not found"
- Scans now run once per process lifetime, saving ~10-15s on every `sd:next` invocation

## Test plan
- [x] `npm run sd:next` completes within 120s (previously timed out at 60s)
- [x] Terminal-identity log messages appear only once (not twice)
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)