### PR TITLE
fix: remove incorrect blocks dependency from Chairman Gates SD

### DIFF
--- a/scripts/one-time/insert-eva-remediation-sds.cjs
+++ b/scripts/one-time/insert-eva-remediation-sds.cjs
@@ -33,7 +33,7 @@ ${AUDIT_SOURCE}`,
     priority: 'critical',
     est_loc: 150,
     tier: 1,
-    blocks: ['SD-EVA-FIX-TEMPLATE-ALIGN-001'],
+    blocks: [],
     blocked_by: []
   },
   {


### PR DESCRIPTION
## Summary
- Removes erroneous `blocks: ['SD-EVA-FIX-TEMPLATE-ALIGN-001']` from Chairman Gates SD
- Per the plan, Template Align is only blocked by Error/Logging (Child 3) and Utility Dedup (Child 4), not Chairman Gates (Child 1)
- DB already corrected via direct update; this fixes the insertion script for idempotency

## Test plan
- [x] DB verified: Chairman Gates now has `blocks: []`
- [x] Template Align `blocked_by` unchanged (still [ERROR-LOGGING, UTILITY-DEDUP])

🤖 Generated with [Claude Code](https://claude.com/claude-code)