### PR TITLE
fix: standardize error handling with ServiceError across 9 EVA modules

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -7,6 +7,8 @@
  * Part of SD-EVA-FEAT-CHAIRMAN-API-001
  */
 
+import { ServiceError } from './shared-services.js';
+
 const POLLING_INTERVAL_MS = 10_000; // 10 seconds
 const REALTIME_CHANNEL = 'chairman-decisions';
 
@@ -22,7 +24,7 @@ const REALTIME_CHANNEL = 'chairman-decisions';
  */
 export async function waitForDecision({ decisionId, supabase, logger = console, timeoutMs = 0 }) {
   if (!decisionId || !supabase) {
-    throw new Error('decisionId and supabase are required');
+    throw new ServiceError('INVALID_ARGS', 'decisionId and supabase are required', 'ChairmanDecisionWatcher');
   }
 
   // First check if already resolved
@@ -137,7 +139,7 @@ export async function waitForDecision({ decisionId, supabase, logger = console, 
       timeoutTimer = setTimeout(() => {
         if (!resolved) {
           cleanup();
-          reject(new Error(`Decision ${decisionId} timed out after ${timeoutMs}ms`));
+          reject(new ServiceError('DECISION_TIMEOUT', `Decision ${decisionId} timed out after ${timeoutMs}ms`, 'ChairmanDecisionWatcher'));
         }
       }, timeoutMs);
     }
@@ -168,7 +170,7 @@ export async function createOrReusePendingDecision({
   logger = console,
 }) {
   if (!ventureId || stageNumber === undefined || !supabase) {
-    throw new Error('ventureId, stageNumber, and supabase are required');
+    throw new ServiceError('INVALID_ARGS', 'ventureId, stageNumber, and supabase are required', 'ChairmanDecisionWatcher');
   }
 
   // Check for existing PENDING decision first
@@ -222,7 +224,7 @@ export async function createOrReusePendingDecision({
         return { id: raced.id, isNew: false };
       }
     }
-    throw new Error(`Failed to create decision: ${error.message}`);
+    throw new ServiceError('DECISION_CREATE_FAILED', `Failed to create decision: ${error.message}`, 'ChairmanDecisionWatcher');
   }
 
   logger.log(`   New PENDING decision created: ${created.id}`);

--- a/lib/eva/cross-venture-learning.js
+++ b/lib/eva/cross-venture-learning.js
@@ -16,6 +16,8 @@
  *   - Rounding: Math.round(value * 100) / 100 for all rates
  */
 
+import { ServiceError } from './shared-services.js';
+
 const MODULE_VERSION = '1.0.0';
 const MIN_VENTURES = 5;
 
@@ -42,7 +44,7 @@ async function analyzeKillStageFrequency(supabase, ventureIds) {
     .in('venture_id', ventureIds)
     .or('decision.eq.kill,recommendation.eq.kill');
 
-  if (error) throw new Error(`Failed to query chairman_decisions: ${error.message}`);
+  if (error) throw new ServiceError('DECISION_QUERY_FAILED', `Failed to query chairman_decisions: ${error.message}`, 'CrossVentureLearning');
   if (!decisions || decisions.length === 0) return [];
 
   // Only count actual kill decisions (not just recommendations)
@@ -102,7 +104,7 @@ async function analyzeFailedAssumptions(supabase, ventureIds) {
     .in('venture_id', ventureIds)
     .in('status', ['invalidated', 'validated']);
 
-  if (error) throw new Error(`Failed to query assumption_sets: ${error.message}`);
+  if (error) throw new ServiceError('ASSUMPTION_QUERY_FAILED', `Failed to query assumption_sets: ${error.message}`, 'CrossVentureLearning');
   if (!assumptions || assumptions.length === 0) return [];
 
   const CATEGORIES = ['market', 'competitor', 'product', 'timing'];
@@ -295,7 +297,7 @@ async function analyzeCrossVenturePatterns(supabase, options = {}) {
 
   const { data: ventures, error } = await query.order('created_at', { ascending: true });
 
-  if (error) throw new Error(`Failed to query ventures: ${error.message}`);
+  if (error) throw new ServiceError('VENTURE_QUERY_FAILED', `Failed to query ventures: ${error.message}`, 'CrossVentureLearning');
 
   if (!ventures || ventures.length < MIN_VENTURES) {
     return {
@@ -381,7 +383,7 @@ async function searchSimilar(supabase, options = {}) {
   } = options;
 
   if (!query && !queryEmbedding) {
-    throw new Error('searchSimilar requires at least query or queryEmbedding');
+    throw new ServiceError('INVALID_ARGS', 'searchSimilar requires at least query or queryEmbedding', 'CrossVentureLearning');
   }
 
   const resultMap = new Map(); // key: "table:id" → merged result

--- a/lib/eva/dependency-manager.js
+++ b/lib/eva/dependency-manager.js
@@ -10,6 +10,8 @@
  * @module lib/eva/dependency-manager
  */
 
+import { ServiceError } from './shared-services.js';
+
 export const MODULE_VERSION = '1.0.0';
 
 /**
@@ -31,8 +33,8 @@ export async function getDependencyGraph(supabase, ventureId) {
       .eq('provider_venture_id', ventureId),
   ]);
 
-  if (dependsOnResult.error) throw new Error(`Failed to query dependencies: ${dependsOnResult.error.message}`);
-  if (providesToResult.error) throw new Error(`Failed to query dependents: ${providesToResult.error.message}`);
+  if (dependsOnResult.error) throw new ServiceError('DEPENDENCY_QUERY_FAILED', `Failed to query dependencies: ${dependsOnResult.error.message}`, 'DependencyManager');
+  if (providesToResult.error) throw new ServiceError('DEPENDENT_QUERY_FAILED', `Failed to query dependents: ${providesToResult.error.message}`, 'DependencyManager');
 
   return {
     dependsOn: (dependsOnResult.data || []).map(d => ({
@@ -71,7 +73,7 @@ export async function wouldCreateCycle(supabase, dependentId, providerId) {
     .from('venture_dependencies')
     .select('dependent_venture_id, provider_venture_id');
 
-  if (error) throw new Error(`Failed to load dependency graph: ${error.message}`);
+  if (error) throw new ServiceError('GRAPH_LOAD_FAILED', `Failed to load dependency graph: ${error.message}`, 'DependencyManager');
 
   // Build adjacency list: for each node, who does it depend on?
   // We need to traverse: if providerId depends on X, and X depends on Y... does it reach dependentId?
@@ -120,7 +122,7 @@ export async function checkDependencies(supabase, ventureId, targetStage) {
     .lte('required_stage', targetStage)
     .neq('status', 'resolved');
 
-  if (error) throw new Error(`Failed to check dependencies: ${error.message}`);
+  if (error) throw new ServiceError('DEPENDENCY_CHECK_FAILED', `Failed to check dependencies: ${error.message}`, 'DependencyManager');
 
   return (data || []).map(d => ({
     id: d.id,
@@ -143,7 +145,7 @@ export async function addDependency(supabase, { dependentId, providerId, require
   // Cycle check
   const cycleDetected = await wouldCreateCycle(supabase, dependentId, providerId);
   if (cycleDetected) {
-    throw new Error(`Adding dependency would create a cycle: ${dependentId} → ${providerId}`);
+    throw new ServiceError('CYCLE_DETECTED', `Adding dependency would create a cycle: ${dependentId} → ${providerId}`, 'DependencyManager');
   }
 
   const { data, error } = await supabase
@@ -158,7 +160,7 @@ export async function addDependency(supabase, { dependentId, providerId, require
     .select('id, dependent_venture_id, provider_venture_id, required_stage, dependency_type, status')
     .single();
 
-  if (error) throw new Error(`Failed to add dependency: ${error.message}`);
+  if (error) throw new ServiceError('DEPENDENCY_INSERT_FAILED', `Failed to add dependency: ${error.message}`, 'DependencyManager');
   return data;
 }
 
@@ -177,7 +179,7 @@ export async function resolveDependency(supabase, dependencyId) {
     .select('id, status, resolved_at')
     .single();
 
-  if (error) throw new Error(`Failed to resolve dependency: ${error.message}`);
+  if (error) throw new ServiceError('DEPENDENCY_RESOLVE_FAILED', `Failed to resolve dependency: ${error.message}`, 'DependencyManager');
   return data;
 }
 
@@ -194,5 +196,5 @@ export async function removeDependency(supabase, dependencyId) {
     .delete()
     .eq('id', dependencyId);
 
-  if (error) throw new Error(`Failed to remove dependency: ${error.message}`);
+  if (error) throw new ServiceError('DEPENDENCY_DELETE_FAILED', `Failed to remove dependency: ${error.message}`, 'DependencyManager');
 }

--- a/lib/eva/devils-advocate.js
+++ b/lib/eva/devils-advocate.js
@@ -203,8 +203,9 @@ function parseReviewResponse(content) {
       alternatives: Array.isArray(parsed.alternatives) ? parsed.alternatives : [],
       summary: parsed.summary || '',
     };
-  } catch (_err) {
+  } catch (err) {
     // If JSON parsing fails, treat the raw text as a single counter-argument
+    console.warn(`[DevilsAdvocate] JSON parse failed for review response: ${err.message}`);
     return {
       overallAssessment: 'concern',
       counterArguments: [content.substring(0, 500)],

--- a/lib/eva/escalation-event-persister.js
+++ b/lib/eva/escalation-event-persister.js
@@ -12,6 +12,7 @@
  *   - Throws on errors (does not silently swallow)
  */
 
+import { ServiceError } from './shared-services.js';
 import { transformForPresentation } from './dfe-context-adapter.js';
 import { generateForEscalation } from './mitigation-generator.js';
 
@@ -35,8 +36,8 @@ export async function persistEscalationEvent(supabase, {
   stageNumber = null,
   eventSource = 'decision_filter_engine',
 } = {}) {
-  if (!supabase) throw new Error('Failed to persist escalation event: supabase client is required');
-  if (!dfeResult) throw new Error('Failed to persist escalation event: dfeResult is required');
+  if (!supabase) throw new ServiceError('INVALID_ARGS', 'supabase client is required', 'EscalationEventPersister');
+  if (!dfeResult) throw new ServiceError('INVALID_ARGS', 'dfeResult is required', 'EscalationEventPersister');
 
   const presentation = transformForPresentation(dfeResult, {
     ventureId,
@@ -73,7 +74,7 @@ export async function persistEscalationEvent(supabase, {
     .single();
 
   if (error) {
-    throw new Error(`Failed to persist escalation event: ${error.message}`);
+    throw new ServiceError('EVENT_PERSIST_FAILED', `Failed to persist escalation event: ${error.message}`, 'EscalationEventPersister');
   }
 
   return { eventId: data.event_id };

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -13,6 +13,7 @@
  * @module lib/eva/lifecycle-sd-bridge
  */
 
+import { ServiceError } from './shared-services.js';
 import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
 import {
@@ -271,7 +272,7 @@ async function findExistingOrchestrator(supabase, ventureId, sprintName) {
 function getSupabaseClient() {
   const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !key) throw new Error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+  if (!url || !key) throw new ServiceError('MISSING_CONFIG', 'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required', 'LifecycleSDBridge');
   return createClient(url, key);
 }
 

--- a/lib/eva/saga-coordinator.js
+++ b/lib/eva/saga-coordinator.js
@@ -14,6 +14,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import { ServiceError } from './shared-services.js';
 
 // ── Constants ───────────────────────────────────────────────
 
@@ -184,7 +185,7 @@ export function createArtifactCompensation(db, artifactIds) {
       .from('venture_artifacts')
       .update({ is_current: false })
       .in('id', artifactIds);
-    if (error) throw new Error(`Artifact compensation failed: ${error.message}`);
+    if (error) throw new ServiceError('ARTIFACT_COMPENSATION_FAILED', `Artifact compensation failed: ${error.message}`, 'SagaCoordinator');
   };
 }
 
@@ -203,7 +204,7 @@ export function createStageCompensation(db, ventureId, previousStage) {
       .from('ventures')
       .update({ current_lifecycle_stage: previousStage })
       .eq('id', ventureId);
-    if (error) throw new Error(`Stage compensation failed: ${error.message}`);
+    if (error) throw new ServiceError('STAGE_COMPENSATION_FAILED', `Stage compensation failed: ${error.message}`, 'SagaCoordinator');
   };
 }
 

--- a/lib/eva/stage-zero/gate-signal-service.js
+++ b/lib/eva/stage-zero/gate-signal-service.js
@@ -14,6 +14,8 @@
 /**
  * Gate boundaries tracked for signal recording.
  */
+import { ServiceError } from '../shared-services.js';
+
 const TRACKED_BOUNDARIES = [
   'stage_3',   // Early signal
   '5->6',      // Ideation → Validation
@@ -44,7 +46,7 @@ export async function recordGateSignal(deps, signal) {
   }
 
   if (!ventureId || !gateBoundary || !signalType) {
-    throw new Error('ventureId, gateBoundary, and signalType are required');
+    throw new ServiceError('INVALID_ARGS', 'ventureId, gateBoundary, and signalType are required', 'GateSignalService');
   }
 
   const { data, error } = await supabase
@@ -85,7 +87,7 @@ export async function getSignalsByProfile(deps, profileId) {
     .eq('profile_id', profileId)
     .order('evaluated_at', { ascending: false });
 
-  if (error) throw new Error(`Failed to fetch signals: ${error.message}`);
+  if (error) throw new ServiceError('SIGNAL_FETCH_FAILED', `Failed to fetch signals: ${error.message}`, 'GateSignalService');
   return data || [];
 }
 
@@ -111,7 +113,7 @@ export async function getSignalsSummary(deps, profileId, boundary = null) {
 
   const { data, error } = await query;
 
-  if (error) throw new Error(`Failed to fetch signal summary: ${error.message}`);
+  if (error) throw new ServiceError('SUMMARY_FETCH_FAILED', `Failed to fetch signal summary: ${error.message}`, 'GateSignalService');
 
   const signals = data || [];
   const passed = signals.filter(s => s.signal_type === 'pass').length;

--- a/lib/eva/venture-monitor.js
+++ b/lib/eva/venture-monitor.js
@@ -447,7 +447,8 @@ export class VentureMonitor {
         return false;
       }
       return data === true;
-    } catch {
+    } catch (err) {
+      this.logger.warn(`[VentureMonitor] Advisory lock acquire failed: ${err.message}`);
       return false;
     }
   }
@@ -455,8 +456,8 @@ export class VentureMonitor {
   async _releaseAdvisoryLock(lockId) {
     try {
       await this.supabase.rpc('pg_advisory_unlock', { lock_id: lockId });
-    } catch {
-      // Best-effort unlock
+    } catch (err) {
+      this.logger.warn(`[VentureMonitor] Advisory lock release failed (best-effort): ${err.message}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Adopt `ServiceError` class in 7 EVA modules replacing raw `throw new Error()` with structured error codes and service names
- Fix 2 silent catches in `devils-advocate.js` (JSON parse fallback) and `venture-monitor.js` (advisory lock acquire/release) by adding diagnostic logging
- 24 error throw sites converted to ServiceError pattern across: dependency-manager, chairman-decision-watcher, cross-venture-learning, escalation-event-persister, saga-coordinator, lifecycle-sd-bridge, gate-signal-service

## Test plan
- [x] All modified files use consistent `ServiceError(code, message, serviceName)` pattern
- [x] Silent catches now emit `console.warn()` or `logger.warn()` diagnostics
- [x] No behavioral changes — only error class and logging additions

Part of SD-EVA-FIX-ERROR-LOGGING-001 (child of SD-EVA-REMEDIATION-ORCH-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)