### PR TITLE
fix: resolve 5 EVA infrastructure bugs in event bus, CLI, and handlers

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,13 +1,13 @@
 {
   "isActive": true,
   "wasInterrupted": false,
-  "currentSd": "SD-EVA-QA-AUDIT-ENGINE-001",
+  "currentSd": "SD-EVA-FIX-INFRA-BUGS-001",
   "currentPhase": "EXEC",
-  "currentTask": "Implementing Phase 2 THE ENGINE Audit (Stages 6-9)",
+  "currentTask": "Implementing PRD: Infrastructure Bug Fixes - Event Bus, CLI, and Handler Corrections",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
   "clearedAt": "2026-02-14T17:30:00.418Z",
-  "lastUpdatedAt": "2026-02-14T18:31:26.013Z"
+  "lastUpdatedAt": "2026-02-14T22:02:10.676Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-EVA-QA-AUDIT-BUILDLOOP-001",
-  "expectedBranch": "feat/SD-EVA-QA-AUDIT-BUILDLOOP-001",
-  "createdAt": "2026-02-14T16:24:28.954Z",
+  "sdKey": "SD-EVA-FIX-INFRA-BUGS-001",
+  "expectedBranch": "feat/SD-EVA-FIX-INFRA-BUGS-001",
+  "createdAt": "2026-02-14T21:49:16.491Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/event-bus/event-router.js
+++ b/lib/eva/event-bus/event-router.js
@@ -88,11 +88,15 @@ async function recordLedgerEntry(supabase, { eventId, eventType, handlerName, st
  * @param {object} supabase
  * @param {object} params
  */
-async function routeToDLQ(supabase, { eventId, eventType, payload, errorMessage, errorStack, attemptCount, failureReason }) {
+async function routeToDLQ(supabase, { eventId, eventType, payload, errorMessage, errorStack, attemptCount, failureReason, originalErrorMessage }) {
+  const enrichedPayload = { ...(payload || {}) };
+  if (originalErrorMessage) {
+    enrichedPayload._original_error_message = originalErrorMessage;
+  }
   await supabase.from('eva_events_dlq').insert({
     event_id: eventId,
     event_type: eventType,
-    payload: payload || {},
+    payload: enrichedPayload,
     error_message: errorMessage,
     error_stack: errorStack || null,
     attempt_count: attemptCount || 1,
@@ -184,6 +188,7 @@ export async function processEvent(supabase, event, options = {}) {
 
   // 4. Execute handler with retry
   const context = { supabase, ventureId: event.eva_venture_id || payload.ventureId };
+  let firstError = null;
   let lastError = null;
   let attempts = 0;
 
@@ -209,11 +214,12 @@ export async function processEvent(supabase, event, options = {}) {
       return { success: true, status: 'success', attempts };
 
     } catch (error) {
+      if (!firstError) firstError = error;
       lastError = error;
       console.log(`[EventRouter] Handler ${handler.name} failed (attempt ${attempt}/${maxRetries}): ${error.message}`);
 
-      if (!isRetryableError(error) || !handler.retryable) {
-        // Non-retryable - go directly to DLQ
+      if (!isRetryableError(error) || handler.retryable === false) {
+        // Non-retryable error OR handler explicitly marked non-retryable
         break;
       }
 
@@ -233,6 +239,7 @@ export async function processEvent(supabase, event, options = {}) {
     errorStack: lastError?.stack || null,
     attemptCount: attempts,
     failureReason,
+    originalErrorMessage: firstError?.message || null,
   });
 
   await recordLedgerEntry(supabase, {
@@ -242,6 +249,7 @@ export async function processEvent(supabase, event, options = {}) {
     attempts,
     errorMessage: lastError?.message,
     errorStack: lastError?.stack,
+    metadata: { originalError: firstError?.message || null },
   });
 
   // Update eva_events with retry count and last error

--- a/lib/eva/event-bus/handlers/decision-submitted.js
+++ b/lib/eva/event-bus/handlers/decision-submitted.js
@@ -19,7 +19,7 @@ export async function handleDecisionSubmitted(payload, context) {
   // Verify the decision exists
   const { data: decision, error: decisionError } = await supabase
     .from('chairman_decisions')
-    .select('id, status, venture_id, stage')
+    .select('id, status, venture_id, lifecycle_stage')
     .eq('id', decisionId)
     .single();
 

--- a/lib/eva/event-bus/handlers/sd-completed.js
+++ b/lib/eva/event-bus/handlers/sd-completed.js
@@ -79,7 +79,7 @@ export async function handleSdCompleted(payload, context) {
         },
       });
 
-    if (insertError && !insertError.message.includes('duplicate')) {
+    if (insertError && insertError.code !== '23505') {
       throw new Error(`Failed to create Stage 19 record: ${insertError.message}`);
     }
   }

--- a/scripts/eva-run.js
+++ b/scripts/eva-run.js
@@ -48,7 +48,9 @@ const EXIT = Object.freeze({
 function getArg(name) {
   const idx = process.argv.indexOf(`--${name}`);
   if (idx === -1) return undefined;
-  return process.argv[idx + 1];
+  const next = process.argv[idx + 1];
+  if (next === undefined || next.startsWith('--')) return undefined;
+  return next;
 }
 
 function hasFlag(name) {


### PR DESCRIPTION
## Summary
- Fix retry logic dead code in event-router.js: `!handler.retryable` always true for undefined, changed to explicit `handler.retryable === false`
- Track first error in retry loop and preserve in DLQ payload as `_original_error_message` for debugging
- Add boundary validation to `getArg()` in eva-run.js to prevent consuming next flag as value
- Fix column name `stage` → `lifecycle_stage` in decision-submitted handler (matches DB schema)
- Replace string-based duplicate detection with Postgres error code `23505` in sd-completed handler

## Test plan
- [x] Verify retry logic correctly retries when handler.retryable is undefined (default retryable)
- [x] Verify retry logic breaks when handler.retryable === false (explicit opt-out)
- [x] Verify first error is preserved in DLQ payload after multiple retries
- [x] Verify `getArg('stage')` returns undefined when followed by another flag
- [x] Verify decision-submitted handler queries `lifecycle_stage` column successfully
- [x] Verify sd-completed handler catches duplicate inserts via error code 23505

🤖 Generated with [Claude Code](https://claude.com/claude-code)