### PR TITLE
fix: correct Reality Gate boundaries per Vision v4.7

### DIFF
--- a/lib/eva/reality-gates.js
+++ b/lib/eva/reality-gates.js
@@ -6,7 +6,7 @@
  * artifacts exist, meet quality thresholds, and (where configured)
  * deployed URLs are reachable.
  *
- * Enforced boundaries: 5→6, 9→10, 12→13, 16→17, 20→21
+ * Enforced boundaries: 5→6, 9→10, 12→13, 16→17, 22→23
  *
  * Design: Pure dependency injection (db, httpClient, now) for
  * deterministic testing without production bypass flags.
@@ -31,7 +31,7 @@ const REASON_CODES = Object.freeze({
 // their minimum quality score and optional URL verification.
 const BOUNDARY_CONFIG = Object.freeze({
   '5->6': {
-    description: 'Ideation → Validation',
+    description: 'SPARK → ENGINE',
     required_artifacts: [
       { artifact_type: 'problem_statement', min_quality_score: 0.6, url_verification_required: false },
       { artifact_type: 'target_market_analysis', min_quality_score: 0.5, url_verification_required: false },
@@ -39,15 +39,19 @@ const BOUNDARY_CONFIG = Object.freeze({
     ],
   },
   '9->10': {
-    description: 'Validation → Planning',
+    description: 'ENGINE → IDENTITY',
     required_artifacts: [
-      { artifact_type: 'customer_interviews', min_quality_score: 0.5, url_verification_required: false },
-      { artifact_type: 'competitive_analysis', min_quality_score: 0.5, url_verification_required: false },
-      { artifact_type: 'pricing_model', min_quality_score: 0.6, url_verification_required: false },
+      { artifact_type: 'risk_assessment', min_quality_score: 0.5, url_verification_required: false },
+      { artifact_type: 'revenue_model', min_quality_score: 0.5, url_verification_required: false },
+      { artifact_type: 'business_model_canvas', min_quality_score: 0.6, url_verification_required: false },
     ],
   },
+  // System gate: checks artifact existence in venture_artifacts table.
+  // Stage 12 also has a local data-based gate (in stage-12.js evaluateRealityGate)
+  // that validates data completeness (funnel stages, journey steps, naming candidates).
+  // Both gates must pass for the phase transition to succeed.
   '12->13': {
-    description: 'Planning → Build',
+    description: 'IDENTITY → BLUEPRINT',
     required_artifacts: [
       { artifact_type: 'business_model_canvas', min_quality_score: 0.7, url_verification_required: false },
       { artifact_type: 'technical_architecture', min_quality_score: 0.6, url_verification_required: false },
@@ -55,15 +59,15 @@ const BOUNDARY_CONFIG = Object.freeze({
     ],
   },
   '16->17': {
-    description: 'Build → Launch',
+    description: 'BLUEPRINT → BUILD LOOP',
     required_artifacts: [
       { artifact_type: 'mvp_build', min_quality_score: 0.7, url_verification_required: true },
       { artifact_type: 'test_coverage_report', min_quality_score: 0.6, url_verification_required: false },
       { artifact_type: 'deployment_runbook', min_quality_score: 0.5, url_verification_required: false },
     ],
   },
-  '20->21': {
-    description: 'Launch → Scale',
+  '22->23': {
+    description: 'BUILD LOOP → LAUNCH & LEARN',
     required_artifacts: [
       { artifact_type: 'launch_metrics', min_quality_score: 0.6, url_verification_required: false },
       { artifact_type: 'user_feedback_summary', min_quality_score: 0.5, url_verification_required: false },

--- a/lib/eva/stage-templates/stage-12.js
+++ b/lib/eva/stage-templates/stage-12.js
@@ -6,7 +6,16 @@
  * Sales process definition with funnel stages, metrics,
  * customer journey mapping, and Phase 3→4 Reality Gate.
  *
- * Reality gate pass requires:
+ * DUAL-GATE DESIGN (G12-6):
+ * This stage participates in two separate gates for the 12→13 boundary:
+ *   1. LOCAL gate (this file, evaluateRealityGate): Validates data completeness
+ *      across Stages 10-12 (naming candidates, tiers, channels, funnel, journey).
+ *   2. SYSTEM gate (reality-gates.js, BOUNDARY_CONFIG '12->13'): Validates
+ *      artifact existence in venture_artifacts table (business_model_canvas,
+ *      technical_architecture, project_plan).
+ * Both gates must pass for a venture to transition from IDENTITY to BLUEPRINT.
+ *
+ * Local gate pass requires:
  *   - Stage 10: >= 5 scored naming candidates
  *   - Stage 11: exactly 3 tiers and 8 channels
  *   - Stage 12: >= 4 funnel stages with metrics, >= 5 journey steps

--- a/tests/unit/eva/reality-gates.test.js
+++ b/tests/unit/eva/reality-gates.test.js
@@ -43,12 +43,13 @@ describe('RealityGates', () => {
       expect(isGatedBoundary(9, 10)).toBe(true);
       expect(isGatedBoundary(12, 13)).toBe(true);
       expect(isGatedBoundary(16, 17)).toBe(true);
-      expect(isGatedBoundary(20, 21)).toBe(true);
+      expect(isGatedBoundary(22, 23)).toBe(true);
     });
 
     it('should return false for non-gated transitions', () => {
       expect(isGatedBoundary(1, 2)).toBe(false);
       expect(isGatedBoundary(7, 8)).toBe(false);
+      expect(isGatedBoundary(20, 21)).toBe(false);
       expect(isGatedBoundary(24, 25)).toBe(false);
     });
   });
@@ -57,7 +58,7 @@ describe('RealityGates', () => {
     it('should return config for valid boundary', () => {
       const config = getBoundaryConfig(5, 6);
       expect(config).toBeDefined();
-      expect(config.description).toBe('Ideation → Validation');
+      expect(config.description).toBe('SPARK → ENGINE');
       expect(config.required_artifacts).toHaveLength(3);
     });
 

--- a/tests/unit/reality-gates.test.js
+++ b/tests/unit/reality-gates.test.js
@@ -100,7 +100,7 @@ describe('Reality Gates', () => {
 
     it('has config for exactly 5 boundaries', () => {
       const boundaries = Object.keys(BOUNDARY_CONFIG);
-      expect(boundaries).toEqual(['5->6', '9->10', '12->13', '16->17', '20->21']);
+      expect(boundaries).toEqual(['5->6', '9->10', '12->13', '16->17', '22->23']);
     });
   });
 
@@ -110,7 +110,7 @@ describe('Reality Gates', () => {
       expect(isGatedBoundary(9, 10)).toBe(true);
       expect(isGatedBoundary(12, 13)).toBe(true);
       expect(isGatedBoundary(16, 17)).toBe(true);
-      expect(isGatedBoundary(20, 21)).toBe(true);
+      expect(isGatedBoundary(22, 23)).toBe(true);
     });
 
     it('returns false for non-boundary transitions', () => {
@@ -124,7 +124,7 @@ describe('Reality Gates', () => {
     it('returns config for a valid boundary', () => {
       const config = getBoundaryConfig(5, 6);
       expect(config).not.toBeNull();
-      expect(config.description).toBe('Ideation → Validation');
+      expect(config.description).toBe('SPARK → ENGINE');
       expect(config.required_artifacts.length).toBeGreaterThan(0);
     });
 
@@ -321,8 +321,8 @@ describe('Reality Gates', () => {
     });
   });
 
-  describe('evaluateRealityGate - 20→21 Launch → Scale', () => {
-    const boundary = { fromStage: 20, toStage: 21 };
+  describe('evaluateRealityGate - 22→23 BUILD LOOP → LAUNCH & LEARN', () => {
+    const boundary = { fromStage: 22, toStage: 23 };
     const requiredTypes = ['launch_metrics', 'user_feedback_summary', 'production_app'];
 
     it('PASS when all artifacts present with URL check', async () => {


### PR DESCRIPTION
## Summary
- Fix gate 9→10 artifacts to match Vision v4.7 (risk_assessment, revenue_model, business_model_canvas)
- Move gate 20→21 to 22→23 (BUILD LOOP → LAUNCH & LEARN)
- Update all 5 boundary descriptions to Vision v4.7 phase names (SPARK, ENGINE, IDENTITY, BLUEPRINT, BUILD LOOP, LAUNCH & LEARN)
- Add dual-gate coordination documentation for stage 12 (local + system gates)
- Update both test files for corrected boundaries and assertions

## Test plan
- [x] All 52 reality gate tests pass
- [x] 15 smoke tests pass
- [x] ESLint clean on source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)