### PR TITLE
fix: strengthen kill gate logic with two-tier scoring and prerequisites

### DIFF
--- a/lib/eva/decision-filter-engine.js
+++ b/lib/eva/decision-filter-engine.js
@@ -35,6 +35,7 @@ const TRIGGER_TYPES = [
 const PREFERENCE_KEYS = {
   cost_threshold: 'filter.cost_max_usd',
   low_score: 'filter.min_score',
+  chairman_review_score: 'filter.chairman_review_score',
   approved_tech: 'filter.approved_tech_list',
   approved_vendors: 'filter.approved_vendor_list',
   pivot_keywords: 'filter.pivot_keywords',
@@ -45,6 +46,7 @@ const PREFERENCE_KEYS = {
 const DEFAULTS = {
   'filter.cost_max_usd': 10000,
   'filter.min_score': 7,
+  'filter.chairman_review_score': 9,
   'filter.approved_tech_list': [],
   'filter.approved_vendor_list': [],
   'filter.pivot_keywords': ['pivot', 'rebrand', 'abandon', 'restart', 'scrap'],
@@ -145,15 +147,26 @@ export function evaluateDecision(input = {}, options = {}) {
     }
   }
 
-  // --- Rule 4: low_score ---
-  if (input.score != null) {
+  // --- Rule 4: low_score (two-tier per Vision v4.7) ---
+  // score < min_score (default 7) → HIGH severity (requires chairman)
+  // min_score ≤ score < chairman_review_score (default 9) → MEDIUM (proceed with caution)
+  // score ≥ chairman_review_score → no trigger
+  if (input.score != null && typeof input.score === 'number') {
     const minScore = getPref(PREFERENCE_KEYS.low_score);
-    if (typeof input.score === 'number' && input.score < minScore.value) {
+    const chairmanScore = getPref(PREFERENCE_KEYS.chairman_review_score);
+    if (input.score < minScore.value) {
+      triggers.push({
+        type: 'low_score',
+        severity: 'HIGH',
+        message: `Score ${input.score}/10 below minimum threshold ${minScore.value}/10 — requires chairman review`,
+        details: { score: input.score, threshold: minScore.value, chairmanThreshold: chairmanScore.value, thresholdSource: minScore.source },
+      });
+    } else if (input.score < chairmanScore.value) {
       triggers.push({
         type: 'low_score',
         severity: 'MEDIUM',
-        message: `Score ${input.score}/10 below threshold ${minScore.value}/10`,
-        details: { score: input.score, threshold: minScore.value, thresholdSource: minScore.source },
+        message: `Score ${input.score}/10 below chairman review threshold ${chairmanScore.value}/10 — proceed with caution`,
+        details: { score: input.score, threshold: minScore.value, chairmanThreshold: chairmanScore.value, thresholdSource: chairmanScore.source },
       });
     }
   }

--- a/lib/eva/stage-templates/stage-13.js
+++ b/lib/eva/stage-templates/stage-13.js
@@ -8,6 +8,7 @@
  *   - Kill if < 3 milestones
  *   - Kill if any milestone missing name, date, or deliverables
  *   - Kill if timeline_months < 3
+ *   - Kill if no milestone has priority='now' (Blueprint #8)
  *
  * @module lib/eva/stage-templates/stage-13
  */
@@ -34,6 +35,7 @@ const TEMPLATE = {
         date: { type: 'string', required: true },
         deliverables: { type: 'array', minItems: MIN_DELIVERABLES_PER_MILESTONE },
         dependencies: { type: 'array' },
+        priority: { type: 'string' },
       },
     },
     phases: {
@@ -154,7 +156,8 @@ const TEMPLATE = {
 
 /**
  * Pure function: evaluate kill gate for Stage 13.
- * Kill if < 3 milestones, any milestone missing deliverables, or timeline < 3 months.
+ * Kill if < 3 milestones, any milestone missing deliverables, timeline < 3 months,
+ * or no milestone has priority='now'.
  *
  * @param {{ milestone_count: number, milestones: Object[], timeline_months: number }} params
  * @returns {{ decision: 'pass'|'kill', blockProgression: boolean, reasons: Object[] }}
@@ -189,6 +192,15 @@ export function evaluateKillGate({ milestone_count, milestones, timeline_months 
       message: `Timeline of ${timeline_months} month(s) is below minimum ${MIN_TIMELINE_MONTHS} months`,
       threshold: MIN_TIMELINE_MONTHS,
       actual: timeline_months,
+    });
+  }
+
+  // Blueprint #8: At least one milestone must have priority='now'
+  const hasNowPriority = milestones.some(m => m.priority === 'now');
+  if (milestones.length > 0 && !hasNowPriority) {
+    reasons.push({
+      type: 'no_now_priority_milestone',
+      message: 'No milestone has priority="now" — roadmap must identify immediate execution priority',
     });
   }
 

--- a/lib/eva/stage-templates/stage-23.js
+++ b/lib/eva/stage-templates/stage-23.js
@@ -92,12 +92,13 @@ const TEMPLATE = {
     return { valid: errors.length === 0, errors };
   },
 
-  computeDerived(data) {
+  computeDerived(data, prerequisites) {
     const { decision, blockProgression, reasons } = evaluateKillGate({
       go_decision: data.go_decision,
       incident_response_plan: data.incident_response_plan,
       monitoring_setup: data.monitoring_setup,
       rollback_plan: data.rollback_plan,
+      stage22Data: prerequisites?.stage22,
     });
 
     return { ...data, decision, blockProgression, reasons };
@@ -107,11 +108,20 @@ const TEMPLATE = {
 /**
  * Pure function: evaluate Go/No-Go kill gate for Stage 23.
  *
- * @param {{ go_decision: string, incident_response_plan: string, monitoring_setup: string, rollback_plan: string }} params
+ * @param {{ go_decision: string, incident_response_plan: string, monitoring_setup: string, rollback_plan: string, stage22Data?: Object }} params
  * @returns {{ decision: 'pass'|'kill', blockProgression: boolean, reasons: Object[] }}
  */
-export function evaluateKillGate({ go_decision, incident_response_plan, monitoring_setup, rollback_plan }) {
+export function evaluateKillGate({ go_decision, incident_response_plan, monitoring_setup, rollback_plan, stage22Data }) {
   const reasons = [];
+
+  // Launch CC-3: Stage 22 release readiness must be confirmed before launch
+  if (stage22Data && !stage22Data.promotion_gate?.pass) {
+    const blockerCount = stage22Data.promotion_gate?.blockers?.length || 0;
+    reasons.push({
+      type: 'stage22_not_complete',
+      message: `Stage 22 release readiness not confirmed${blockerCount > 0 ? ` (${blockerCount} blocker(s))` : ''}`,
+    });
+  }
 
   if (go_decision !== 'go') {
     reasons.push({


### PR DESCRIPTION
## Summary
- **Stage 13 (Product Roadmap)**: Added Blueprint #8 now-priority milestone check — roadmap kill gate now requires at least one milestone with `priority="now"`
- **Stage 23 (Launch Execution)**: Added Launch CC-3 prerequisite — kill gate checks Stage 22 release readiness (`promotion_gate.pass`) before allowing launch
- **Decision Filter Engine**: Replaced single-threshold `low_score` with two-tier system per Vision v4.7 spec: score < 7 → HIGH (chairman required), 7 ≤ score < 9 → MEDIUM (proceed with caution), ≥ 9 → pass

## Test plan
- [x] 105 unit tests passing across all 3 modified files
- [x] Stage 13: kill gate fires for missing now-priority milestone, passes when present
- [x] Stage 23: kill gate fires when Stage 22 not confirmed, passes when confirmed
- [x] Decision filter: two-tier scoring tested (HIGH, MEDIUM, pass, default threshold)
- [x] Trigger ordering preserved in deterministic order

**SD**: SD-EVA-FIX-KILL-GATES-001 (child 8/12 of SD-EVA-REMEDIATION-ORCH-001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)