### PR TITLE
fix: add blocking chairman governance gates to stages 10, 22, 25

### DIFF
--- a/lib/eva/stage-templates/stage-10.js
+++ b/lib/eva/stage-templates/stage-10.js
@@ -11,6 +11,7 @@
 
 import { validateString, validateNumber, validateArray, validateInteger, collectErrors } from './validation.js';
 import { analyzeStage10 } from './analysis-steps/stage-10-naming-brand.js';
+import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
 const MIN_CANDIDATES = 5;
 const WEIGHT_SUM = 100;
@@ -51,6 +52,15 @@ const TEMPLATE = {
         weighted_score: { type: 'number', derived: true },
       },
     },
+    // Chairman governance gate (SD-EVA-FIX-CHAIRMAN-GATES-001)
+    chairmanGate: {
+      type: 'object',
+      fields: {
+        status: { type: 'string' },
+        rationale: { type: 'string' },
+        decision_id: { type: 'string' },
+      },
+    },
     // Derived
     ranked_candidates: { type: 'array', derived: true },
   },
@@ -65,6 +75,7 @@ const TEMPLATE = {
     scoringCriteria: [],
     candidates: [],
     ranked_candidates: [],
+    chairmanGate: { status: 'pending', rationale: null, decision_id: null },
   },
 
   /**
@@ -144,6 +155,14 @@ const TEMPLATE = {
       }
     }
 
+    // Chairman governance gate check
+    const gateStatus = data?.chairmanGate?.status;
+    if (gateStatus === 'rejected') {
+      errors.push(`Chairman gate rejected: ${data.chairmanGate.rationale || 'No rationale provided'}`);
+    } else if (gateStatus !== 'approved') {
+      errors.push('Chairman brand approval gate is pending — awaiting chairman decision');
+    }
+
     return { valid: errors.length === 0, errors };
   },
 
@@ -166,6 +185,20 @@ const TEMPLATE = {
 
     return { ...data, candidates, ranked_candidates };
   },
+};
+
+/**
+ * Pre-analysis hook: create or reuse a PENDING chairman decision.
+ * Blocks venture progression until chairman approves brand direction.
+ */
+TEMPLATE.onBeforeAnalysis = async function onBeforeAnalysis(supabase, ventureId) {
+  const { id, isNew } = await createOrReusePendingDecision({
+    ventureId,
+    stageNumber: 10,
+    summary: 'Chairman brand approval required for Stage 10 (Naming/Brand)',
+    supabase,
+  });
+  return { chairmanDecisionId: id, isNew };
 };
 
 TEMPLATE.analysisStep = analyzeStage10;

--- a/lib/eva/stage-templates/stage-22.js
+++ b/lib/eva/stage-templates/stage-22.js
@@ -23,6 +23,7 @@ import { validateString, validateArray, validateEnum, collectErrors } from './va
 import { analyzeStage22 } from './analysis-steps/stage-22-release-readiness.js';
 import { CHECKLIST_CATEGORIES } from './stage-17.js';
 import { MIN_COVERAGE_PCT } from './stage-20.js';
+import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
 const APPROVAL_STATUSES = ['pending', 'approved', 'rejected'];
 const MIN_RELEASE_ITEMS = 1;
@@ -47,6 +48,15 @@ const TEMPLATE = {
     },
     release_notes: { type: 'string', minLength: 10, required: true },
     target_date: { type: 'string', required: true },
+    // Chairman governance gate (SD-EVA-FIX-CHAIRMAN-GATES-001)
+    chairmanGate: {
+      type: 'object',
+      fields: {
+        status: { type: 'string' },
+        rationale: { type: 'string' },
+        decision_id: { type: 'string' },
+      },
+    },
     // Derived
     total_items: { type: 'number', derived: true },
     approved_items: { type: 'number', derived: true },
@@ -61,6 +71,7 @@ const TEMPLATE = {
     approved_items: 0,
     all_approved: false,
     promotion_gate: null,
+    chairmanGate: { status: 'pending', rationale: null, decision_id: null },
   },
 
   validate(data) {
@@ -87,6 +98,14 @@ const TEMPLATE = {
 
     const dateCheck = validateString(data?.target_date, 'target_date', 1);
     if (!dateCheck.valid) errors.push(dateCheck.error);
+
+    // Chairman governance gate check
+    const gateStatus = data?.chairmanGate?.status;
+    if (gateStatus === 'rejected') {
+      errors.push(`Chairman gate rejected: ${data.chairmanGate.rationale || 'No rationale provided'}`);
+    } else if (gateStatus !== 'approved') {
+      errors.push('Chairman release readiness gate is pending — awaiting chairman decision');
+    }
 
     return { valid: errors.length === 0, errors };
   },
@@ -244,6 +263,20 @@ export function evaluatePromotionGate({ stage17, stage18, stage19, stage20, stag
 
   return { pass, rationale, blockers, warnings, required_next_actions };
 }
+
+/**
+ * Pre-analysis hook: create or reuse a PENDING chairman decision.
+ * Blocks venture progression until chairman confirms release readiness.
+ */
+TEMPLATE.onBeforeAnalysis = async function onBeforeAnalysis(supabase, ventureId) {
+  const { id, isNew } = await createOrReusePendingDecision({
+    ventureId,
+    stageNumber: 22,
+    summary: 'Chairman release readiness approval required for Stage 22',
+    supabase,
+  });
+  return { chairmanDecisionId: id, isNew };
+};
 
 TEMPLATE.analysisStep = analyzeStage22;
 

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -13,6 +13,7 @@
 import { validateString, validateArray, collectErrors } from './validation.js';
 import { analyzeStage25 } from './analysis-steps/stage-25-venture-review.js';
 import { extractTemplate } from '../template-extractor.js';
+import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
 const REVIEW_CATEGORIES = ['product', 'market', 'technical', 'financial', 'team'];
 const MIN_INITIATIVES_PER_CATEGORY = 1;
@@ -48,6 +49,15 @@ const TEMPLATE = {
         timeline: { type: 'string', required: true },
       },
     },
+    // Chairman governance gate (SD-EVA-FIX-CHAIRMAN-GATES-001)
+    chairmanGate: {
+      type: 'object',
+      fields: {
+        status: { type: 'string' },
+        rationale: { type: 'string' },
+        decision_id: { type: 'string' },
+      },
+    },
     // Derived
     total_initiatives: { type: 'number', derived: true },
     all_categories_reviewed: { type: 'boolean', derived: true },
@@ -60,6 +70,7 @@ const TEMPLATE = {
     current_vision: null,
     drift_justification: null,
     next_steps: [],
+    chairmanGate: { status: 'pending', rationale: null, decision_id: null },
     total_initiatives: 0,
     all_categories_reviewed: false,
     drift_detected: false,
@@ -112,6 +123,14 @@ const TEMPLATE = {
         ];
         errors.push(...collectErrors(results));
       }
+    }
+
+    // Chairman governance gate check
+    const gateStatus = data?.chairmanGate?.status;
+    if (gateStatus === 'rejected') {
+      errors.push(`Chairman gate rejected: ${data.chairmanGate.rationale || 'No rationale provided'}`);
+    } else if (gateStatus !== 'approved') {
+      errors.push('Chairman venture review gate is pending — awaiting chairman decision');
     }
 
     return { valid: errors.length === 0, errors };
@@ -192,6 +211,20 @@ export function detectDrift({ original_vision, current_vision }) {
 
   return { drift_detected, rationale, original_vision, current_vision };
 }
+
+/**
+ * Pre-analysis hook: create or reuse a PENDING chairman decision.
+ * Blocks venture progression until chairman reviews venture and approves continued investment.
+ */
+TEMPLATE.onBeforeAnalysis = async function onBeforeAnalysis(supabase, ventureId) {
+  const { id, isNew } = await createOrReusePendingDecision({
+    ventureId,
+    stageNumber: 25,
+    summary: 'Chairman venture review approval required for Stage 25',
+    supabase,
+  });
+  return { chairmanDecisionId: id, isNew };
+};
 
 TEMPLATE.analysisStep = analyzeStage25;
 

--- a/tests/unit/eva/stage-templates/chairman-gates.test.js
+++ b/tests/unit/eva/stage-templates/chairman-gates.test.js
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for Chairman Governance Gates (SD-EVA-FIX-CHAIRMAN-GATES-001)
+ *
+ * Tests that stages 10, 22, and 25 have blocking chairman decision gates
+ * that use createOrReusePendingDecision/waitForDecision pattern.
+ *
+ * @module tests/unit/eva/stage-templates/chairman-gates.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import stage10 from '../../../../lib/eva/stage-templates/stage-10.js';
+import stage22 from '../../../../lib/eva/stage-templates/stage-22.js';
+import stage25 from '../../../../lib/eva/stage-templates/stage-25.js';
+
+// Helper: valid stage 10 data with approved chairman gate
+function validStage10Data(gateOverride = {}) {
+  return {
+    brandGenome: {
+      archetype: 'Explorer',
+      values: ['innovation'],
+      tone: 'bold',
+      audience: 'startups',
+      differentiators: ['speed'],
+    },
+    scoringCriteria: [
+      { name: 'memorability', weight: 50 },
+      { name: 'relevance', weight: 50 },
+    ],
+    candidates: Array.from({ length: 5 }, (_, i) => ({
+      name: `Brand${i + 1}`,
+      rationale: `Rationale for Brand${i + 1}`,
+      scores: { memorability: 80, relevance: 70 },
+    })),
+    chairmanGate: { status: 'approved', rationale: 'Brand direction approved', decision_id: 'dec-1' },
+    ...gateOverride,
+  };
+}
+
+// Helper: valid stage 22 data with approved chairman gate
+function validStage22Data(gateOverride = {}) {
+  return {
+    release_items: [
+      { name: 'Feature A', category: 'core', status: 'approved', approver: 'QA' },
+    ],
+    release_notes: 'Release notes for version 1.0 with improvements and fixes.',
+    target_date: '2026-03-01',
+    chairmanGate: { status: 'approved', rationale: 'Release approved', decision_id: 'dec-2' },
+    ...gateOverride,
+  };
+}
+
+// Helper: valid stage 25 data with approved chairman gate
+function validStage25Data(gateOverride = {}) {
+  return {
+    review_summary: 'Comprehensive venture review covering all categories and outcomes.',
+    initiatives: {
+      product: [{ title: 'MVP', status: 'complete', outcome: 'Shipped' }],
+      market: [{ title: 'Launch', status: 'complete', outcome: 'Validated' }],
+      technical: [{ title: 'Platform', status: 'complete', outcome: 'Stable' }],
+      financial: [{ title: 'Revenue', status: 'on-track', outcome: 'Growing' }],
+      team: [{ title: 'Hiring', status: 'complete', outcome: 'Full team' }],
+    },
+    current_vision: 'Building the next generation platform for startups',
+    next_steps: [{ action: 'Scale', owner: 'CEO', timeline: 'Q2' }],
+    chairmanGate: { status: 'approved', rationale: 'Venture review approved', decision_id: 'dec-3' },
+    ...gateOverride,
+  };
+}
+
+describe('Chairman Governance Gates', () => {
+  describe('Stage 10 - Brand Approval Gate', () => {
+    it('should have chairmanGate in defaultData', () => {
+      expect(stage10.defaultData.chairmanGate).toEqual({
+        status: 'pending',
+        rationale: null,
+        decision_id: null,
+      });
+    });
+
+    it('should have chairmanGate in schema', () => {
+      expect(stage10.schema.chairmanGate).toBeDefined();
+      expect(stage10.schema.chairmanGate.type).toBe('object');
+    });
+
+    it('should pass validation when chairman gate is approved', () => {
+      const result = stage10.validate(validStage10Data());
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail validation when chairman gate is pending', () => {
+      const data = validStage10Data({ chairmanGate: { status: 'pending', rationale: null, decision_id: null } });
+      const result = stage10.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Chairman brand approval gate is pending — awaiting chairman decision');
+    });
+
+    it('should fail validation when chairman gate is rejected', () => {
+      const data = validStage10Data({ chairmanGate: { status: 'rejected', rationale: 'Brand not ready', decision_id: 'dec-x' } });
+      const result = stage10.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Chairman gate rejected'))).toBe(true);
+      expect(result.errors.some(e => e.includes('Brand not ready'))).toBe(true);
+    });
+
+    it('should fail validation when chairmanGate is missing', () => {
+      const data = validStage10Data({ chairmanGate: undefined });
+      const result = stage10.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('pending'))).toBe(true);
+    });
+
+    it('should have onBeforeAnalysis hook', () => {
+      expect(typeof stage10.onBeforeAnalysis).toBe('function');
+    });
+  });
+
+  describe('Stage 22 - Release Readiness Gate', () => {
+    it('should have chairmanGate in defaultData', () => {
+      expect(stage22.defaultData.chairmanGate).toEqual({
+        status: 'pending',
+        rationale: null,
+        decision_id: null,
+      });
+    });
+
+    it('should have chairmanGate in schema', () => {
+      expect(stage22.schema.chairmanGate).toBeDefined();
+      expect(stage22.schema.chairmanGate.type).toBe('object');
+    });
+
+    it('should pass validation when chairman gate is approved', () => {
+      const result = stage22.validate(validStage22Data());
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail validation when chairman gate is pending', () => {
+      const data = validStage22Data({ chairmanGate: { status: 'pending', rationale: null, decision_id: null } });
+      const result = stage22.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Chairman release readiness gate is pending — awaiting chairman decision');
+    });
+
+    it('should fail validation when chairman gate is rejected', () => {
+      const data = validStage22Data({ chairmanGate: { status: 'rejected', rationale: 'Not ready for release', decision_id: 'dec-y' } });
+      const result = stage22.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Chairman gate rejected'))).toBe(true);
+    });
+
+    it('should have onBeforeAnalysis hook', () => {
+      expect(typeof stage22.onBeforeAnalysis).toBe('function');
+    });
+  });
+
+  describe('Stage 25 - Venture Review Gate', () => {
+    it('should have chairmanGate in defaultData', () => {
+      expect(stage25.defaultData.chairmanGate).toEqual({
+        status: 'pending',
+        rationale: null,
+        decision_id: null,
+      });
+    });
+
+    it('should have chairmanGate in schema', () => {
+      expect(stage25.schema.chairmanGate).toBeDefined();
+      expect(stage25.schema.chairmanGate.type).toBe('object');
+    });
+
+    it('should pass validation when chairman gate is approved', () => {
+      const result = stage25.validate(validStage25Data());
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it('should fail validation when chairman gate is pending', () => {
+      const data = validStage25Data({ chairmanGate: { status: 'pending', rationale: null, decision_id: null } });
+      const result = stage25.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Chairman venture review gate is pending — awaiting chairman decision');
+    });
+
+    it('should fail validation when chairman gate is rejected', () => {
+      const data = validStage25Data({ chairmanGate: { status: 'rejected', rationale: 'Venture not viable', decision_id: 'dec-z' } });
+      const result = stage25.validate(data);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Chairman gate rejected'))).toBe(true);
+      expect(result.errors.some(e => e.includes('Venture not viable'))).toBe(true);
+    });
+
+    it('should have onBeforeAnalysis hook', () => {
+      expect(typeof stage25.onBeforeAnalysis).toBe('function');
+    });
+  });
+
+  describe('Cross-stage consistency', () => {
+    it('all three stages should have identical chairmanGate schema structure', () => {
+      const schemas = [stage10.schema.chairmanGate, stage22.schema.chairmanGate, stage25.schema.chairmanGate];
+      for (const schema of schemas) {
+        expect(schema.type).toBe('object');
+        expect(schema.fields.status.type).toBe('string');
+        expect(schema.fields.rationale.type).toBe('string');
+        expect(schema.fields.decision_id.type).toBe('string');
+      }
+    });
+
+    it('all three stages should have identical chairmanGate default values', () => {
+      const defaults = [stage10.defaultData.chairmanGate, stage22.defaultData.chairmanGate, stage25.defaultData.chairmanGate];
+      for (const def of defaults) {
+        expect(def).toEqual({ status: 'pending', rationale: null, decision_id: null });
+      }
+    });
+  });
+});

--- a/tests/unit/eva/stage-templates/stage-10.test.js
+++ b/tests/unit/eva/stage-templates/stage-10.test.js
@@ -80,6 +80,7 @@ describe('stage-10.js - Naming/Brand template', () => {
         { name: 'Candidate4', rationale: 'Reason 4', scores: { Memorability: 75, Relevance: 85, Availability: 75 } },
         { name: 'Candidate5', rationale: 'Reason 5', scores: { Memorability: 90, Relevance: 70, Availability: 85 } },
       ],
+      chairmanGate: { status: 'approved', rationale: null, decision_id: null },
     });
 
     it('should pass for valid data', () => {
@@ -170,6 +171,7 @@ describe('stage-10.js - Naming/Brand template', () => {
         { name: 'C4', rationale: 'R4', scores: { Memorability: 75, Relevance: 85 } },
         { name: 'C5', rationale: 'R5', scores: { Memorability: 90, Relevance: 70 } },
       ],
+      chairmanGate: { status: 'approved', rationale: null, decision_id: null },
     });
 
     it('should pass when weights sum to exactly 100', () => {
@@ -276,6 +278,7 @@ describe('stage-10.js - Naming/Brand template', () => {
         { name: 'C4', rationale: 'R4', scores: { Memorability: 75, Relevance: 85 } },
         { name: 'C5', rationale: 'R5', scores: { Memorability: 90, Relevance: 70 } },
       ],
+      chairmanGate: { status: 'approved', rationale: null, decision_id: null },
     });
 
     it('should pass with exactly 5 candidates', () => {
@@ -389,6 +392,7 @@ describe('stage-10.js - Naming/Brand template', () => {
         { name: 'Delta', rationale: 'R4', scores: { Memorability: 85, Relevance: 85, Availability: 85 } },
         { name: 'Epsilon', rationale: 'R5', scores: { Memorability: 75, Relevance: 95, Availability: 65 } },
       ],
+      chairmanGate: { status: 'approved', rationale: null, decision_id: null },
     });
 
     it('should compute weighted scores for all candidates (TS-3)', () => {
@@ -513,6 +517,7 @@ describe('stage-10.js - Naming/Brand template', () => {
         { name: 'C4', rationale: 'R4', scores: { M: 75, R: 85 } },
         { name: 'C5', rationale: 'R5', scores: { M: 90, R: 70 } },
       ],
+      chairmanGate: { status: 'approved', rationale: null, decision_id: null },
     });
 
     it('should work together for valid data', () => {

--- a/tests/unit/eva/stage-templates/stage-22.test.js
+++ b/tests/unit/eva/stage-templates/stage-22.test.js
@@ -38,6 +38,7 @@ describe('stage-22.js - Release Readiness template', () => {
         approved_items: 0,
         all_approved: false,
         promotion_gate: null,
+        chairmanGate: { status: 'pending', rationale: null, decision_id: null },
       });
     });
 
@@ -69,6 +70,7 @@ describe('stage-22.js - Release Readiness template', () => {
         ],
         release_notes: 'Release notes for v1.0',
         target_date: '2026-03-01',
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const result = stage22.validate(validData);
       expect(result.valid).toBe(true);
@@ -147,6 +149,7 @@ describe('stage-22.js - Release Readiness template', () => {
         ],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const result = stage22.validate(validData);
       expect(result.valid).toBe(true);
@@ -547,6 +550,7 @@ describe('stage-22.js - Release Readiness template', () => {
         ],
         release_notes: 'Major release with new features',
         target_date: '2026-03-01',
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const validation = stage22.validate(data);
       expect(validation.valid).toBe(true);

--- a/tests/unit/eva/stage-templates/stage-25.test.js
+++ b/tests/unit/eva/stage-templates/stage-25.test.js
@@ -41,6 +41,7 @@ describe('stage-25.js - Venture Review template', () => {
         current_vision: null,
         drift_justification: null,
         next_steps: [],
+        chairmanGate: { status: 'pending', rationale: null, decision_id: null },
         total_initiatives: 0,
         all_categories_reviewed: false,
         drift_detected: false,
@@ -114,6 +115,7 @@ describe('stage-25.js - Venture Review template', () => {
         },
         current_vision: 'Current vision statement',
         next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const result = stage25.validate(validData);
       expect(result.valid).toBe(true);
@@ -159,6 +161,7 @@ describe('stage-25.js - Venture Review template', () => {
         },
         current_vision: 'Current vision statement',
         next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const result = stage25.validate(validData);
       expect(result.valid).toBe(true);
@@ -269,6 +272,7 @@ describe('stage-25.js - Venture Review template', () => {
         },
         current_vision: 'Current vision statement',
         next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const result = stage25.validate(validData);
       expect(result.valid).toBe(true);
@@ -313,6 +317,7 @@ describe('stage-25.js - Venture Review template', () => {
         initiatives: validInitiatives,
         current_vision: 'Current vision statement for the venture',
         next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const result = stage25.validate(validData);
       expect(result.valid).toBe(true);
@@ -386,6 +391,7 @@ describe('stage-25.js - Venture Review template', () => {
           { action: 'Launch next phase', owner: 'CEO', timeline: 'Q1 2026' },
           { action: 'Expand team', owner: 'HR', timeline: 'Q2 2026' },
         ],
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const result = stage25.validate(validDataWithSteps);
       expect(result.valid).toBe(true);
@@ -649,6 +655,7 @@ describe('stage-25.js - Venture Review template', () => {
         next_steps: [
           { action: 'Launch next phase', owner: 'CEO', timeline: 'Q1 2026' },
         ],
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const validation = stage25.validate(data);
       expect(validation.valid).toBe(true);


### PR DESCRIPTION
## Summary
- Add blocking chairman governance gates to EVA stages 10 (Brand Approval), 22 (Release Readiness), and 25 (Venture Review)
- Each stage now includes `chairmanGate` in schema/defaultData, validates gate status in `validate()`, and creates pending decisions via `onBeforeAnalysis` hook
- 21 new unit tests covering all gate states (approved/pending/rejected/missing) across all 3 stages
- Updated 17 existing tests to include approved chairmanGate in valid test data

## Test plan
- [x] 21 new chairman-gates tests pass
- [x] 135 existing stage template tests pass (0 regressions)
- [x] All 156 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)