### PR TITLE
test: add 57 unit tests for EVA event bus and chairman decision watcher

### DIFF
--- a/tests/unit/eva/chairman-decision-watcher.test.js
+++ b/tests/unit/eva/chairman-decision-watcher.test.js
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for Chairman Decision Watcher
+ * SD: SD-EVA-FIX-POST-LAUNCH-001 (FR-5)
+ *
+ * Tests: waitForDecision, createOrReusePendingDecision
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock shared-services
+vi.mock('../../../lib/eva/shared-services.js', () => ({
+  ServiceError: class ServiceError extends Error {
+    constructor(code, message, source) {
+      super(message);
+      this.code = code;
+      this.source = source;
+    }
+  },
+}));
+
+import { waitForDecision, createOrReusePendingDecision } from '../../../lib/eva/chairman-decision-watcher.js';
+
+function createMockLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('waitForDecision', () => {
+  it('throws on missing decisionId', async () => {
+    await expect(
+      waitForDecision({ supabase: {} }),
+    ).rejects.toThrow('decisionId and supabase are required');
+  });
+
+  it('throws on missing supabase', async () => {
+    await expect(
+      waitForDecision({ decisionId: 'd1' }),
+    ).rejects.toThrow('decisionId and supabase are required');
+  });
+
+  it('returns immediately if decision already resolved', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: { status: 'approved', rationale: 'good idea', decision: 'approve' },
+        }),
+      }),
+    };
+    const logger = createMockLogger();
+
+    const result = await waitForDecision({ decisionId: 'd1', supabase, logger });
+    expect(result.status).toBe('approved');
+    expect(result.rationale).toBe('good idea');
+    expect(result.decision).toBe('approve');
+  });
+
+  it('rejects with timeout when timeoutMs is exceeded', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { status: 'pending' } }),
+      }),
+      channel: vi.fn().mockReturnValue({
+        on: vi.fn().mockReturnThis(),
+        subscribe: vi.fn((cb) => { cb('CHANNEL_ERROR'); return {}; }),
+      }),
+      removeChannel: vi.fn(),
+    };
+    const logger = createMockLogger();
+
+    await expect(
+      waitForDecision({ decisionId: 'd1', supabase, logger, timeoutMs: 50 }),
+    ).rejects.toThrow('timed out');
+  }, 5000);
+});
+
+describe('createOrReusePendingDecision', () => {
+  const logger = createMockLogger();
+
+  it('throws on missing required arguments', async () => {
+    await expect(
+      createOrReusePendingDecision({ supabase: {}, stageNumber: 10, logger }),
+    ).rejects.toThrow('ventureId, stageNumber, and supabase are required');
+
+    await expect(
+      createOrReusePendingDecision({ ventureId: 'v1', supabase: {}, logger }),
+    ).rejects.toThrow('ventureId, stageNumber, and supabase are required');
+  });
+
+  it('reuses existing pending decision', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { id: 'existing-id' } }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }),
+      }),
+    };
+
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 10, supabase, logger,
+    });
+    expect(result.id).toBe('existing-id');
+    expect(result.isNew).toBe(false);
+  });
+
+  it('creates new decision when none exists', async () => {
+    let callCount = 0;
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) {
+            // First call (check existing) - none found
+            return Promise.resolve({ data: null });
+          }
+          // Second call (after insert) - return created
+          return Promise.resolve({ data: { id: 'new-id' }, error: null });
+        }),
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'new-id' }, error: null }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 22, supabase, logger,
+    });
+    expect(result.id).toBe('new-id');
+    expect(result.isNew).toBe(true);
+  });
+
+  it('handles race condition (23505 unique constraint)', async () => {
+    let callCount = 0;
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockImplementation(() => {
+          callCount++;
+          if (callCount === 1) return Promise.resolve({ data: null }); // No existing
+          // After race condition, find the winner
+          return Promise.resolve({ data: { id: 'raced-id' } });
+        }),
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: { code: '23505', message: 'unique_violation' } }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 10, supabase, logger,
+    });
+    expect(result.id).toBe('raced-id');
+    expect(result.isNew).toBe(false);
+  });
+
+  it('throws on non-race-condition insert error', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null }),
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: null, error: { code: '42P01', message: 'table not found' } }),
+          }),
+        }),
+      }),
+    };
+
+    await expect(
+      createOrReusePendingDecision({
+        ventureId: 'v1', stageNumber: 10, supabase, logger,
+      }),
+    ).rejects.toThrow('Failed to create decision');
+  });
+
+  it('updates brief_data when reusing existing decision', async () => {
+    const updateFn = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { id: 'existing-id' } }),
+        update: updateFn,
+      }),
+    };
+
+    await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 10,
+      briefData: { key: 'value' }, summary: 'updated',
+      supabase, logger,
+    });
+
+    expect(updateFn).toHaveBeenCalledWith({
+      brief_data: { key: 'value' },
+      summary: 'updated',
+    });
+  });
+});

--- a/tests/unit/eva/event-bus/event-router.test.js
+++ b/tests/unit/eva/event-bus/event-router.test.js
@@ -1,0 +1,320 @@
+/**
+ * Unit tests for Event Router
+ * SD: SD-EVA-FIX-POST-LAUNCH-001 (FR-1)
+ *
+ * Tests: processEvent pipeline, retry logic, DLQ routing, idempotency
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock handler-registry before importing event-router
+vi.mock('../../../../lib/eva/event-bus/handler-registry.js', () => ({
+  getHandler: vi.fn(),
+}));
+
+import { processEvent, replayDLQEntry } from '../../../../lib/eva/event-bus/event-router.js';
+import { getHandler } from '../../../../lib/eva/event-bus/handler-registry.js';
+
+function createMockSupabase(overrides = {}) {
+  const insert = vi.fn().mockResolvedValue({ error: null });
+  const update = vi.fn().mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  });
+  const selectChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data: [] }),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+
+  return {
+    from: vi.fn((table) => {
+      if (overrides[table]) return overrides[table];
+      return { ...selectChain, insert, update };
+    }),
+  };
+}
+
+describe('processEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns duplicate_event when already processed', async () => {
+    const supabase = createMockSupabase({
+      eva_event_ledger: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [{ id: '1' }] }),
+      },
+    });
+
+    const event = { id: 'evt-1', event_type: 'stage.completed', event_data: { ventureId: 'v1', stageId: 's1' } };
+    const result = await processEvent(supabase, event);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('duplicate_event');
+    expect(result.attempts).toBe(0);
+  });
+
+  it('returns no_handler when no handler registered', async () => {
+    const supabase = createMockSupabase();
+    getHandler.mockReturnValue(null);
+
+    const event = { id: 'evt-2', event_type: 'unknown.type', event_data: {} };
+    const result = await processEvent(supabase, event);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('no_handler');
+  });
+
+  it('routes to DLQ on validation failure', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const supabase = createMockSupabase({
+      eva_event_ledger: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [] }),
+        insert: insertFn,
+      },
+      eva_events_dlq: { insert: insertFn },
+    });
+    getHandler.mockReturnValue({ name: 'testHandler', handlerFn: vi.fn() });
+
+    // stage.completed requires ventureId and stageId
+    const event = { id: 'evt-3', event_type: 'stage.completed', event_data: {} };
+    const result = await processEvent(supabase, event);
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe('validation_error');
+    expect(result.error).toContain('Missing required ventureId');
+  });
+
+  it('executes handler successfully on first attempt', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const updateFn = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    const supabase = createMockSupabase({
+      eva_event_ledger: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [] }),
+        insert: insertFn,
+      },
+      eva_events: { update: updateFn },
+    });
+
+    const handlerFn = vi.fn().mockResolvedValue({ outcome: 'ok' });
+    getHandler.mockReturnValue({ name: 'testHandler', handlerFn });
+
+    const event = { id: 'evt-4', event_type: 'stage.completed', event_data: { ventureId: 'v1', stageId: 's1' } };
+    const result = await processEvent(supabase, event);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('success');
+    expect(result.attempts).toBe(1);
+    expect(handlerFn).toHaveBeenCalledOnce();
+  });
+
+  it('retries on transient errors with exponential backoff', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const updateFn = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    const supabase = createMockSupabase({
+      eva_event_ledger: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [] }),
+        insert: insertFn,
+      },
+      eva_events: { update: updateFn },
+    });
+
+    let callCount = 0;
+    const handlerFn = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount < 3) throw new Error('503 service unavailable');
+      return { outcome: 'ok' };
+    });
+    getHandler.mockReturnValue({ name: 'retryHandler', handlerFn });
+
+    const event = { id: 'evt-5', event_type: 'stage.completed', event_data: { ventureId: 'v1', stageId: 's1' } };
+    const result = await processEvent(supabase, event, { maxRetries: 3, baseDelayMs: 1 });
+
+    expect(result.success).toBe(true);
+    expect(result.attempts).toBe(3);
+    expect(handlerFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry non-retryable errors', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const updateFn = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    const supabase = createMockSupabase({
+      eva_event_ledger: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [] }),
+        insert: insertFn,
+      },
+      eva_events_dlq: { insert: insertFn },
+      eva_events: { update: updateFn },
+    });
+
+    const handlerFn = vi.fn().mockRejectedValue(new Error('not found'));
+    getHandler.mockReturnValue({ name: 'failHandler', handlerFn });
+
+    const event = { id: 'evt-6', event_type: 'stage.completed', event_data: { ventureId: 'v1', stageId: 's1' } };
+    const result = await processEvent(supabase, event, { maxRetries: 3, baseDelayMs: 1 });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe('handler_error');
+    expect(result.attempts).toBe(1);
+    expect(handlerFn).toHaveBeenCalledOnce();
+  });
+
+  it('routes to DLQ after max retries exhausted', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const updateFn = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    const supabase = createMockSupabase({
+      eva_event_ledger: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [] }),
+        insert: insertFn,
+      },
+      eva_events_dlq: { insert: insertFn },
+      eva_events: { update: updateFn },
+    });
+
+    const handlerFn = vi.fn().mockRejectedValue(new Error('timeout'));
+    getHandler.mockReturnValue({ name: 'timeoutHandler', handlerFn });
+
+    const event = { id: 'evt-7', event_type: 'stage.completed', event_data: { ventureId: 'v1', stageId: 's1' } };
+    const result = await processEvent(supabase, event, { maxRetries: 2, baseDelayMs: 1 });
+
+    expect(result.success).toBe(false);
+    expect(result.status).toBe('max_retries_exhausted');
+    expect(result.attempts).toBe(2);
+  });
+
+  it('skips retry when handler.retryable is false', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const updateFn = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    const supabase = createMockSupabase({
+      eva_event_ledger: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [] }),
+        insert: insertFn,
+      },
+      eva_events_dlq: { insert: insertFn },
+      eva_events: { update: updateFn },
+    });
+
+    const handlerFn = vi.fn().mockRejectedValue(new Error('timeout'));
+    getHandler.mockReturnValue({ name: 'noRetry', handlerFn, retryable: false });
+
+    const event = { id: 'evt-8', event_type: 'stage.completed', event_data: { ventureId: 'v1', stageId: 's1' } };
+    const result = await processEvent(supabase, event, { maxRetries: 3, baseDelayMs: 1 });
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(1);
+  });
+});
+
+describe('payload validation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('validates stage.completed requires ventureId and stageId', async () => {
+    const supabase = createMockSupabase();
+    getHandler.mockReturnValue({ name: 'h', handlerFn: vi.fn() });
+
+    const r1 = await processEvent(supabase, { id: '1', event_type: 'stage.completed', event_data: { stageId: 's1' } });
+    expect(r1.error).toContain('ventureId');
+
+    const r2 = await processEvent(supabase, { id: '2', event_type: 'stage.completed', event_data: { ventureId: 'v1' } });
+    expect(r2.error).toContain('stageId');
+  });
+
+  it('validates gate.evaluated requires valid outcome', async () => {
+    const supabase = createMockSupabase();
+    getHandler.mockReturnValue({ name: 'h', handlerFn: vi.fn() });
+
+    const r = await processEvent(supabase, {
+      id: '3', event_type: 'gate.evaluated',
+      event_data: { ventureId: 'v1', gateId: 'g1', outcome: 'invalid' },
+    });
+    expect(r.error).toContain('Invalid outcome');
+  });
+
+  it('validates decision.submitted requires decisionId', async () => {
+    const supabase = createMockSupabase();
+    getHandler.mockReturnValue({ name: 'h', handlerFn: vi.fn() });
+
+    const r = await processEvent(supabase, {
+      id: '4', event_type: 'decision.submitted',
+      event_data: { ventureId: 'v1' },
+    });
+    expect(r.error).toContain('decisionId');
+  });
+
+  it('validates sd.completed requires sdKey and ventureId', async () => {
+    const supabase = createMockSupabase();
+    getHandler.mockReturnValue({ name: 'h', handlerFn: vi.fn() });
+
+    const r = await processEvent(supabase, {
+      id: '5', event_type: 'sd.completed',
+      event_data: {},
+    });
+    expect(r.error).toContain('sdKey');
+  });
+
+  it('passes validation for unknown event types', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const updateFn = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: null }) });
+    const supabase = createMockSupabase({
+      eva_event_ledger: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [] }),
+        insert: insertFn,
+      },
+      eva_events: { update: updateFn },
+    });
+    const handlerFn = vi.fn().mockResolvedValue({ outcome: 'ok' });
+    getHandler.mockReturnValue({ name: 'h', handlerFn });
+
+    const r = await processEvent(supabase, { id: '6', event_type: 'custom.event', event_data: {} });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('replayDLQEntry', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns dlq_entry_not_found for missing entry', async () => {
+    const supabase = createMockSupabase({
+      eva_events_dlq: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+      },
+    });
+
+    const result = await replayDLQEntry(supabase, 'nonexistent');
+    expect(result.success).toBe(false);
+    expect(result.status).toBe('dlq_entry_not_found');
+  });
+
+  it('returns already_replayed for non-dead entries', async () => {
+    const supabase = createMockSupabase({
+      eva_events_dlq: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: { status: 'replayed' }, error: null }),
+      },
+    });
+
+    const result = await replayDLQEntry(supabase, 'already-done');
+    expect(result.success).toBe(false);
+    expect(result.status).toBe('already_replayed');
+  });
+});

--- a/tests/unit/eva/event-bus/handler-registry.test.js
+++ b/tests/unit/eva/event-bus/handler-registry.test.js
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for Event Bus Handler Registry
+ * SD: SD-EVA-FIX-POST-LAUNCH-001 (FR-2)
+ *
+ * Tests: register, get, list, clear, count, re-register overwrites
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerHandler,
+  getHandler,
+  getRegistryCounts,
+  listRegisteredTypes,
+  clearHandlers,
+  getHandlerCount,
+} from '../../../../lib/eva/event-bus/handler-registry.js';
+
+describe('handler-registry', () => {
+  beforeEach(() => {
+    clearHandlers();
+  });
+
+  describe('registerHandler', () => {
+    it('registers a handler for an event type', () => {
+      const fn = async () => ({ outcome: 'ok' });
+      registerHandler('stage.completed', fn, { name: 'stageHandler' });
+
+      const handler = getHandler('stage.completed');
+      expect(handler).not.toBeNull();
+      expect(handler.name).toBe('stageHandler');
+      expect(handler.handlerFn).toBe(fn);
+    });
+
+    it('defaults retryable to true', () => {
+      registerHandler('test.event', async () => {});
+      const handler = getHandler('test.event');
+      expect(handler.retryable).toBe(true);
+    });
+
+    it('respects retryable=false option', () => {
+      registerHandler('test.event', async () => {}, { retryable: false });
+      const handler = getHandler('test.event');
+      expect(handler.retryable).toBe(false);
+    });
+
+    it('defaults maxRetries to 3', () => {
+      registerHandler('test.event', async () => {});
+      expect(getHandler('test.event').maxRetries).toBe(3);
+    });
+
+    it('uses function name when no name option provided', () => {
+      async function myHandler() {}
+      registerHandler('test.event', myHandler);
+      expect(getHandler('test.event').name).toBe('myHandler');
+    });
+
+    it('falls back to eventType as name for anonymous functions', () => {
+      registerHandler('test.event', async () => {});
+      expect(getHandler('test.event').name).toBe('test.event');
+    });
+
+    it('sets registeredAt timestamp', () => {
+      registerHandler('test.event', async () => {});
+      const handler = getHandler('test.event');
+      expect(handler.registeredAt).toBeDefined();
+      expect(new Date(handler.registeredAt).getTime()).not.toBeNaN();
+    });
+  });
+
+  describe('getHandler', () => {
+    it('returns null for unregistered types', () => {
+      expect(getHandler('nonexistent')).toBeNull();
+    });
+
+    it('returns the correct handler for registered types', () => {
+      const fn1 = async () => 'a';
+      const fn2 = async () => 'b';
+      registerHandler('type.a', fn1);
+      registerHandler('type.b', fn2);
+
+      expect(getHandler('type.a').handlerFn).toBe(fn1);
+      expect(getHandler('type.b').handlerFn).toBe(fn2);
+    });
+  });
+
+  describe('re-registration (idempotent)', () => {
+    it('overwrites previous handler on re-register', () => {
+      const fn1 = async () => 'first';
+      const fn2 = async () => 'second';
+
+      registerHandler('stage.completed', fn1, { name: 'first' });
+      registerHandler('stage.completed', fn2, { name: 'second' });
+
+      const handler = getHandler('stage.completed');
+      expect(handler.name).toBe('second');
+      expect(handler.handlerFn).toBe(fn2);
+      expect(getHandlerCount()).toBe(1);
+    });
+  });
+
+  describe('getRegistryCounts', () => {
+    it('returns empty map when no handlers registered', () => {
+      const counts = getRegistryCounts();
+      expect(counts.size).toBe(0);
+    });
+
+    it('returns 1 per registered event type', () => {
+      registerHandler('type.a', async () => {});
+      registerHandler('type.b', async () => {});
+
+      const counts = getRegistryCounts();
+      expect(counts.get('type.a')).toBe(1);
+      expect(counts.get('type.b')).toBe(1);
+    });
+  });
+
+  describe('listRegisteredTypes', () => {
+    it('returns empty array when no handlers registered', () => {
+      expect(listRegisteredTypes()).toEqual([]);
+    });
+
+    it('returns all registered event types', () => {
+      registerHandler('stage.completed', async () => {});
+      registerHandler('decision.submitted', async () => {});
+      registerHandler('gate.evaluated', async () => {});
+
+      const types = listRegisteredTypes();
+      expect(types).toContain('stage.completed');
+      expect(types).toContain('decision.submitted');
+      expect(types).toContain('gate.evaluated');
+      expect(types).toHaveLength(3);
+    });
+  });
+
+  describe('clearHandlers', () => {
+    it('removes all registered handlers', () => {
+      registerHandler('type.a', async () => {});
+      registerHandler('type.b', async () => {});
+      expect(getHandlerCount()).toBe(2);
+
+      clearHandlers();
+      expect(getHandlerCount()).toBe(0);
+      expect(getHandler('type.a')).toBeNull();
+    });
+  });
+
+  describe('getHandlerCount', () => {
+    it('returns 0 when empty', () => {
+      expect(getHandlerCount()).toBe(0);
+    });
+
+    it('returns correct count', () => {
+      registerHandler('a', async () => {});
+      registerHandler('b', async () => {});
+      registerHandler('c', async () => {});
+      expect(getHandlerCount()).toBe(3);
+    });
+  });
+});

--- a/tests/unit/eva/event-bus/handlers.test.js
+++ b/tests/unit/eva/event-bus/handlers.test.js
@@ -1,0 +1,230 @@
+/**
+ * Unit tests for Event Bus Handlers
+ * SD: SD-EVA-FIX-POST-LAUNCH-001 (FR-3)
+ *
+ * Tests all 4 handlers: stage-completed, decision-submitted,
+ * gate-evaluated, sd-completed
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleStageCompleted } from '../../../../lib/eva/event-bus/handlers/stage-completed.js';
+import { handleDecisionSubmitted } from '../../../../lib/eva/event-bus/handlers/decision-submitted.js';
+import { handleGateEvaluated } from '../../../../lib/eva/event-bus/handlers/gate-evaluated.js';
+import { handleSdCompleted } from '../../../../lib/eva/event-bus/handlers/sd-completed.js';
+
+function mockSupabase(tableData = {}) {
+  return {
+    from: vi.fn((table) => {
+      const data = tableData[table];
+      const chain = {
+        select: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: data?.single ?? null, error: data?.error ?? null }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: data?.maybeSingle ?? null, error: data?.error ?? null }),
+      };
+      // Allow chaining after select
+      chain.select.mockReturnValue(chain);
+      return chain;
+    }),
+  };
+}
+
+// ── stage-completed handler ──
+
+describe('handleStageCompleted', () => {
+  it('returns no_stages_configured when no stages found', async () => {
+    const supabase = mockSupabase({
+      eva_ventures: { single: { id: 'v1', status: 'active' } },
+    });
+
+    const result = await handleStageCompleted(
+      { ventureId: 'v1', stageId: 's1' },
+      { supabase },
+    );
+    expect(result.outcome).toBe('no_stages_configured');
+  });
+
+  it('throws non-retryable error when venture not found', async () => {
+    const supabase = mockSupabase({
+      eva_ventures: { single: null, error: { message: 'not found' } },
+    });
+
+    await expect(
+      handleStageCompleted({ ventureId: 'v1', stageId: 's1' }, { supabase }),
+    ).rejects.toThrow('Venture not found');
+  });
+});
+
+// ── decision-submitted handler ──
+
+describe('handleDecisionSubmitted', () => {
+  it('unblocks venture when decision is approved', async () => {
+    const supabase = mockSupabase({
+      chairman_decisions: { single: { id: 'd1', status: 'approved', venture_id: 'v1', lifecycle_stage: 10 } },
+      eva_ventures: { single: { id: 'v1', status: 'blocked', current_stage: 10 } },
+    });
+
+    const result = await handleDecisionSubmitted(
+      { ventureId: 'v1', decisionId: 'd1' },
+      { supabase },
+    );
+    expect(result.outcome).toBe('unblocked');
+    expect(result.newStatus).toBe('active');
+  });
+
+  it('cancels venture when decision is rejected', async () => {
+    const supabase = mockSupabase({
+      chairman_decisions: { single: { id: 'd1', status: 'rejected', venture_id: 'v1', lifecycle_stage: 10 } },
+      eva_ventures: { single: { id: 'v1', status: 'pending_review', current_stage: 10 } },
+    });
+
+    const result = await handleDecisionSubmitted(
+      { ventureId: 'v1', decisionId: 'd1' },
+      { supabase },
+    );
+    expect(result.outcome).toBe('unblocked');
+    expect(result.newStatus).toBe('cancelled');
+  });
+
+  it('returns no_change when decision still pending', async () => {
+    const supabase = mockSupabase({
+      chairman_decisions: { single: { id: 'd1', status: 'pending', venture_id: 'v1' } },
+      eva_ventures: { single: { id: 'v1', status: 'blocked' } },
+    });
+
+    const result = await handleDecisionSubmitted(
+      { ventureId: 'v1', decisionId: 'd1' },
+      { supabase },
+    );
+    expect(result.outcome).toBe('no_change');
+    expect(result.reason).toBe('decision_still_pending');
+  });
+
+  it('returns no_change when venture not blocked', async () => {
+    const supabase = mockSupabase({
+      chairman_decisions: { single: { id: 'd1', status: 'approved', venture_id: 'v1' } },
+      eva_ventures: { single: { id: 'v1', status: 'active' } },
+    });
+
+    const result = await handleDecisionSubmitted(
+      { ventureId: 'v1', decisionId: 'd1' },
+      { supabase },
+    );
+    expect(result.outcome).toBe('no_change');
+    expect(result.reason).toBe('venture_not_blocked');
+  });
+
+  it('throws non-retryable error when decision not found', async () => {
+    const supabase = mockSupabase({
+      chairman_decisions: { single: null, error: { message: 'not found' } },
+    });
+
+    await expect(
+      handleDecisionSubmitted({ ventureId: 'v1', decisionId: 'bad' }, { supabase }),
+    ).rejects.toThrow('Decision not found');
+  });
+
+  it('throws non-retryable error when venture not found', async () => {
+    const supabase = mockSupabase({
+      chairman_decisions: { single: { id: 'd1', status: 'approved', venture_id: 'v1' } },
+      eva_ventures: { single: null },
+    });
+
+    await expect(
+      handleDecisionSubmitted({ ventureId: 'v1', decisionId: 'd1' }, { supabase }),
+    ).rejects.toThrow('Venture not found');
+  });
+});
+
+// ── gate-evaluated handler ──
+
+describe('handleGateEvaluated', () => {
+  it('handles proceed outcome', async () => {
+    const supabase = mockSupabase({
+      eva_ventures: { single: { id: 'v1', status: 'active' } },
+    });
+
+    const result = await handleGateEvaluated(
+      { ventureId: 'v1', gateId: 'g1', outcome: 'proceed' },
+      { supabase },
+    );
+    // Should return pipeline_complete when no stages found
+    expect(result.outcome).toBe('proceed');
+    expect(result.action).toBe('pipeline_complete');
+  });
+
+  it('handles block outcome', async () => {
+    const supabase = mockSupabase({
+      eva_ventures: { single: { id: 'v1', status: 'active' } },
+    });
+
+    const result = await handleGateEvaluated(
+      { ventureId: 'v1', gateId: 'g1', outcome: 'block', reason: 'metrics below threshold' },
+      { supabase },
+    );
+    expect(result.outcome).toBe('block');
+    expect(result.action).toBe('blocked');
+    expect(result.reason).toContain('metrics');
+  });
+
+  it('handles kill outcome', async () => {
+    const supabase = mockSupabase({
+      eva_ventures: { single: { id: 'v1', status: 'active' } },
+    });
+
+    const result = await handleGateEvaluated(
+      { ventureId: 'v1', gateId: 'g1', outcome: 'kill' },
+      { supabase },
+    );
+    expect(result.outcome).toBe('kill');
+    expect(result.action).toBe('terminated');
+  });
+
+  it('throws on invalid outcome', async () => {
+    const supabase = mockSupabase();
+
+    await expect(
+      handleGateEvaluated(
+        { ventureId: 'v1', gateId: 'g1', outcome: 'invalid' },
+        { supabase },
+      ),
+    ).rejects.toThrow('Invalid gate outcome');
+  });
+});
+
+// ── sd-completed handler ──
+
+describe('handleSdCompleted', () => {
+  it('returns no_parent for orchestrator-level completion', async () => {
+    const supabase = mockSupabase();
+
+    const result = await handleSdCompleted(
+      { sdKey: 'SD-ORCH-001', ventureId: 'v1' },
+      { supabase },
+    );
+    expect(result.outcome).toBe('no_parent');
+  });
+
+  it('throws when ventureId missing', async () => {
+    const supabase = mockSupabase();
+
+    await expect(
+      handleSdCompleted({ sdKey: 'SD-1' }, { supabase }),
+    ).rejects.toThrow('Missing ventureId');
+  });
+
+  it('throws when sdKey missing', async () => {
+    const supabase = mockSupabase();
+
+    await expect(
+      handleSdCompleted({ ventureId: 'v1' }, { supabase }),
+    ).rejects.toThrow('Missing sdKey');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 57 new unit tests across 4 test files for EVA post-launch operations (SD-EVA-FIX-POST-LAUNCH-001)
- **event-router.test.js** (15 tests): processEvent pipeline, retry with exponential backoff, DLQ routing, idempotency, payload validation for all 4 event types
- **handler-registry.test.js** (17 tests): register/get/list/clear/count, re-registration overwrites, defaults
- **handlers.test.js** (15 tests): stage-completed, decision-submitted, gate-evaluated, sd-completed handlers
- **chairman-decision-watcher.test.js** (10 tests): waitForDecision, createOrReusePendingDecision, race condition handling (23505)

## Test plan
- [x] All 60 tests pass (57 new + 3 existing eva-run)
- [x] Tests use vitest with vi.mock() for Supabase isolation
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)