### PR TITLE
fix: replace validateString with validateEnum for Build Loop enum fields

### DIFF
--- a/lib/eva/stage-templates/stage-17.js
+++ b/lib/eva/stage-templates/stage-17.js
@@ -20,6 +20,7 @@ const CHECKLIST_CATEGORIES = [
   'dependencies',
 ];
 const ITEM_STATUSES = ['not_started', 'in_progress', 'complete', 'blocked'];
+const SEVERITY_LEVELS = ['critical', 'high', 'medium', 'low'];
 const MIN_ITEMS_PER_CATEGORY = 1;
 
 const TEMPLATE = {
@@ -46,7 +47,7 @@ const TEMPLATE = {
       type: 'array',
       items: {
         description: { type: 'string', required: true },
-        severity: { type: 'string', required: true },
+        severity: { type: 'enum', values: SEVERITY_LEVELS, required: true },
         mitigation: { type: 'string', required: true },
       },
     },
@@ -99,7 +100,7 @@ const TEMPLATE = {
         const prefix = `blockers[${i}]`;
         const results = [
           validateString(b?.description, `${prefix}.description`, 1),
-          validateString(b?.severity, `${prefix}.severity`, 1),
+          validateEnum(b?.severity, `${prefix}.severity`, SEVERITY_LEVELS),
           validateString(b?.mitigation, `${prefix}.mitigation`, 1),
         ];
         errors.push(...collectErrors(results));
@@ -140,5 +141,5 @@ const TEMPLATE = {
 
 TEMPLATE.analysisStep = analyzeStage17;
 
-export { CHECKLIST_CATEGORIES, ITEM_STATUSES, MIN_ITEMS_PER_CATEGORY };
+export { CHECKLIST_CATEGORIES, ITEM_STATUSES, SEVERITY_LEVELS, MIN_ITEMS_PER_CATEGORY };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-19.js
+++ b/lib/eva/stage-templates/stage-19.js
@@ -13,6 +13,8 @@ import { validateString, validateArray, validateEnum, collectErrors } from './va
 import { analyzeStage19 } from './analysis-steps/stage-19-build-execution.js';
 
 const TASK_STATUSES = ['todo', 'in_progress', 'done', 'blocked'];
+const ISSUE_SEVERITIES = ['critical', 'high', 'medium', 'low'];
+const ISSUE_STATUSES = ['open', 'in_progress', 'resolved', 'wont_fix'];
 const MIN_TASKS = 1;
 
 const TEMPLATE = {
@@ -35,8 +37,8 @@ const TEMPLATE = {
       type: 'array',
       items: {
         description: { type: 'string', required: true },
-        severity: { type: 'string', required: true },
-        status: { type: 'string', required: true },
+        severity: { type: 'enum', values: ISSUE_SEVERITIES, required: true },
+        status: { type: 'enum', values: ISSUE_STATUSES, required: true },
       },
     },
     // Derived
@@ -80,8 +82,8 @@ const TEMPLATE = {
         const prefix = `issues[${i}]`;
         const results = [
           validateString(issue?.description, `${prefix}.description`, 1),
-          validateString(issue?.severity, `${prefix}.severity`, 1),
-          validateString(issue?.status, `${prefix}.status`, 1),
+          validateEnum(issue?.severity, `${prefix}.severity`, ISSUE_SEVERITIES),
+          validateEnum(issue?.status, `${prefix}.status`, ISSUE_STATUSES),
         ];
         errors.push(...collectErrors(results));
       }
@@ -116,5 +118,5 @@ const TEMPLATE = {
 
 TEMPLATE.analysisStep = analyzeStage19;
 
-export { TASK_STATUSES, MIN_TASKS };
+export { TASK_STATUSES, ISSUE_SEVERITIES, ISSUE_STATUSES, MIN_TASKS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-20.js
+++ b/lib/eva/stage-templates/stage-20.js
@@ -9,9 +9,11 @@
  * @module lib/eva/stage-templates/stage-20
  */
 
-import { validateString, validateNumber, validateArray, collectErrors } from './validation.js';
+import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { analyzeStage20 } from './analysis-steps/stage-20-quality-assurance.js';
 
+const DEFECT_SEVERITIES = ['critical', 'high', 'medium', 'low'];
+const DEFECT_STATUSES = ['open', 'in_progress', 'resolved', 'wont_fix', 'deferred'];
 const MIN_TEST_SUITES = 1;
 const MIN_COVERAGE_PCT = 60;
 
@@ -35,8 +37,8 @@ const TEMPLATE = {
       type: 'array',
       items: {
         description: { type: 'string', required: true },
-        severity: { type: 'string', required: true },
-        status: { type: 'string', required: true },
+        severity: { type: 'enum', values: DEFECT_SEVERITIES, required: true },
+        status: { type: 'enum', values: DEFECT_STATUSES, required: true },
       },
     },
     // Derived
@@ -87,8 +89,8 @@ const TEMPLATE = {
         const prefix = `known_defects[${i}]`;
         const results = [
           validateString(d?.description, `${prefix}.description`, 1),
-          validateString(d?.severity, `${prefix}.severity`, 1),
-          validateString(d?.status, `${prefix}.status`, 1),
+          validateEnum(d?.severity, `${prefix}.severity`, DEFECT_SEVERITIES),
+          validateEnum(d?.status, `${prefix}.status`, DEFECT_STATUSES),
         ];
         errors.push(...collectErrors(results));
       }
@@ -128,5 +130,5 @@ const TEMPLATE = {
 
 TEMPLATE.analysisStep = analyzeStage20;
 
-export { MIN_TEST_SUITES, MIN_COVERAGE_PCT };
+export { DEFECT_SEVERITIES, DEFECT_STATUSES, MIN_TEST_SUITES, MIN_COVERAGE_PCT };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-22.js
+++ b/lib/eva/stage-templates/stage-22.js
@@ -25,6 +25,7 @@ import { CHECKLIST_CATEGORIES } from './stage-17.js';
 import { MIN_COVERAGE_PCT } from './stage-20.js';
 
 const APPROVAL_STATUSES = ['pending', 'approved', 'rejected'];
+const RELEASE_CATEGORIES = ['feature', 'bugfix', 'infrastructure', 'documentation', 'security', 'performance'];
 const MIN_RELEASE_ITEMS = 1;
 const MIN_READINESS_PCT = 80;
 const MIN_BUILD_COMPLETION_PCT = 80;
@@ -40,7 +41,7 @@ const TEMPLATE = {
       minItems: MIN_RELEASE_ITEMS,
       items: {
         name: { type: 'string', required: true },
-        category: { type: 'string', required: true },
+        category: { type: 'enum', values: RELEASE_CATEGORIES, required: true },
         status: { type: 'enum', values: APPROVAL_STATUSES, required: true },
         approver: { type: 'string' },
       },
@@ -75,7 +76,7 @@ const TEMPLATE = {
         const prefix = `release_items[${i}]`;
         const results = [
           validateString(ri?.name, `${prefix}.name`, 1),
-          validateString(ri?.category, `${prefix}.category`, 1),
+          validateEnum(ri?.category, `${prefix}.category`, RELEASE_CATEGORIES),
           validateEnum(ri?.status, `${prefix}.status`, APPROVAL_STATUSES),
         ];
         errors.push(...collectErrors(results));
@@ -247,5 +248,5 @@ export function evaluatePromotionGate({ stage17, stage18, stage19, stage20, stag
 
 TEMPLATE.analysisStep = analyzeStage22;
 
-export { APPROVAL_STATUSES, MIN_RELEASE_ITEMS, MIN_READINESS_PCT, MIN_BUILD_COMPLETION_PCT };
+export { APPROVAL_STATUSES, RELEASE_CATEGORIES, MIN_RELEASE_ITEMS, MIN_READINESS_PCT, MIN_BUILD_COMPLETION_PCT };
 export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/stage-17.test.js
+++ b/tests/unit/eva/stage-templates/stage-17.test.js
@@ -225,6 +225,16 @@ describe('stage-17.js - Pre-Build Checklist template', () => {
       expect(result.errors.some(e => e.includes('blockers[0].severity'))).toBe(true);
     });
 
+    it('should fail for blocker with invalid severity enum value', () => {
+      const invalidData = {
+        checklist: validChecklist,
+        blockers: [{ description: 'Test', severity: 'urgent', mitigation: 'Escalate' }],
+      };
+      const result = stage17.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('blockers[0].severity'))).toBe(true);
+    });
+
     it('should fail for blocker missing mitigation', () => {
       const invalidData = {
         checklist: validChecklist,

--- a/tests/unit/eva/stage-templates/stage-19.test.js
+++ b/tests/unit/eva/stage-templates/stage-19.test.js
@@ -176,6 +176,25 @@ describe('stage-19.js - Build Execution template', () => {
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.includes('issues[0].status'))).toBe(true);
     });
+    it('should fail for issue with invalid severity enum value', () => {
+      const invalidData = {
+        tasks: [{ name: 'Task 1', status: 'done' }],
+        issues: [{ description: 'Issue 1', severity: 'urgent', status: 'open' }],
+      };
+      const result = stage19.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('issues[0].severity'))).toBe(true);
+    });
+
+    it('should fail for issue with invalid status enum value', () => {
+      const invalidData = {
+        tasks: [{ name: 'Task 1', status: 'done' }],
+        issues: [{ description: 'Issue 1', severity: 'high', status: 'closed' }],
+      };
+      const result = stage19.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('issues[0].status'))).toBe(true);
+    });
   });
 
   describe('computeDerived() - Task metrics', () => {

--- a/tests/unit/eva/stage-templates/stage-20.test.js
+++ b/tests/unit/eva/stage-templates/stage-20.test.js
@@ -203,6 +203,25 @@ describe('stage-20.js - Quality Assurance template', () => {
       expect(result.valid).toBe(false);
       expect(result.errors.some(e => e.includes('known_defects[0].status'))).toBe(true);
     });
+    it('should fail for defect with invalid severity enum value', () => {
+      const invalidData = {
+        test_suites: [{ name: 'Unit Tests', total_tests: 100, passing_tests: 100 }],
+        known_defects: [{ description: 'Defect 1', severity: 'urgent', status: 'open' }],
+      };
+      const result = stage20.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('known_defects[0].severity'))).toBe(true);
+    });
+
+    it('should fail for defect with invalid status enum value', () => {
+      const invalidData = {
+        test_suites: [{ name: 'Unit Tests', total_tests: 100, passing_tests: 100 }],
+        known_defects: [{ description: 'Defect 1', severity: 'low', status: 'closed' }],
+      };
+      const result = stage20.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('known_defects[0].status'))).toBe(true);
+    });
   });
 
   describe('computeDerived() - Test metrics', () => {

--- a/tests/unit/eva/stage-templates/stage-22.test.js
+++ b/tests/unit/eva/stage-templates/stage-22.test.js
@@ -65,7 +65,7 @@ describe('stage-22.js - Release Readiness template', () => {
     it('should pass for valid release items', () => {
       const validData = {
         release_items: [
-          { name: 'Security review', category: 'Security', status: 'approved', approver: 'CISO' },
+          { name: 'Security review', category: 'security', status: 'approved', approver: 'CISO' },
         ],
         release_notes: 'Release notes for v1.0',
         target_date: '2026-03-01',
@@ -98,7 +98,7 @@ describe('stage-22.js - Release Readiness template', () => {
 
     it('should fail for release item missing name', () => {
       const invalidData = {
-        release_items: [{ category: 'Security', status: 'approved' }],
+        release_items: [{ category: 'security', status: 'approved' }],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
       };
@@ -120,7 +120,7 @@ describe('stage-22.js - Release Readiness template', () => {
 
     it('should fail for release item missing status', () => {
       const invalidData = {
-        release_items: [{ name: 'Security review', category: 'Security' }],
+        release_items: [{ name: 'Security review', category: 'security' }],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
       };
@@ -131,7 +131,7 @@ describe('stage-22.js - Release Readiness template', () => {
 
     it('should fail for release item with invalid status', () => {
       const invalidData = {
-        release_items: [{ name: 'Security review', category: 'Security', status: 'invalid' }],
+        release_items: [{ name: 'Security review', category: 'security', status: 'invalid' }],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
       };
@@ -140,10 +140,21 @@ describe('stage-22.js - Release Readiness template', () => {
       expect(result.errors.some(e => e.includes('release_items[0].status'))).toBe(true);
     });
 
+    it('should fail for release item with invalid category enum value', () => {
+      const invalidData = {
+        release_items: [{ name: 'Security review', category: 'InvalidCategory', status: 'approved' }],
+        release_notes: 'Release notes',
+        target_date: '2026-03-01',
+      };
+      const result = stage22.validate(invalidData);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('release_items[0].category'))).toBe(true);
+    });
+
     it('should pass with optional approver field', () => {
       const validData = {
         release_items: [
-          { name: 'Security review', category: 'Security', status: 'approved', approver: 'CISO' },
+          { name: 'Security review', category: 'security', status: 'approved', approver: 'CISO' },
         ],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
@@ -155,7 +166,7 @@ describe('stage-22.js - Release Readiness template', () => {
 
   describe('validate() - Release notes and target date', () => {
     const validItems = [
-      { name: 'Security review', category: 'Security', status: 'approved' },
+      { name: 'Security review', category: 'security', status: 'approved' },
     ];
 
     it('should fail for missing release_notes', () => {
@@ -205,9 +216,9 @@ describe('stage-22.js - Release Readiness template', () => {
     it('should calculate total_items correctly', () => {
       const data = {
         release_items: [
-          { name: 'R1', category: 'C1', status: 'approved' },
-          { name: 'R2', category: 'C2', status: 'pending' },
-          { name: 'R3', category: 'C3', status: 'approved' },
+          { name: 'R1', category: 'feature', status: 'approved' },
+          { name: 'R2', category: 'bugfix', status: 'pending' },
+          { name: 'R3', category: 'infrastructure', status: 'approved' },
         ],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
@@ -219,10 +230,10 @@ describe('stage-22.js - Release Readiness template', () => {
     it('should calculate approved_items correctly', () => {
       const data = {
         release_items: [
-          { name: 'R1', category: 'C1', status: 'approved' },
-          { name: 'R2', category: 'C2', status: 'pending' },
-          { name: 'R3', category: 'C3', status: 'approved' },
-          { name: 'R4', category: 'C4', status: 'rejected' },
+          { name: 'R1', category: 'feature', status: 'approved' },
+          { name: 'R2', category: 'bugfix', status: 'pending' },
+          { name: 'R3', category: 'infrastructure', status: 'approved' },
+          { name: 'R4', category: 'documentation', status: 'rejected' },
         ],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
@@ -234,8 +245,8 @@ describe('stage-22.js - Release Readiness template', () => {
     it('should set all_approved to true when all items approved', () => {
       const data = {
         release_items: [
-          { name: 'R1', category: 'C1', status: 'approved' },
-          { name: 'R2', category: 'C2', status: 'approved' },
+          { name: 'R1', category: 'feature', status: 'approved' },
+          { name: 'R2', category: 'bugfix', status: 'approved' },
         ],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
@@ -247,8 +258,8 @@ describe('stage-22.js - Release Readiness template', () => {
     it('should set all_approved to false when any item not approved', () => {
       const data = {
         release_items: [
-          { name: 'R1', category: 'C1', status: 'approved' },
-          { name: 'R2', category: 'C2', status: 'pending' },
+          { name: 'R1', category: 'feature', status: 'approved' },
+          { name: 'R2', category: 'bugfix', status: 'pending' },
         ],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
@@ -307,7 +318,7 @@ describe('stage-22.js - Release Readiness template', () => {
       },
       stage22: {
         release_items: [
-          { name: 'R1', category: 'C1', status: 'approved' },
+          { name: 'R1', category: 'feature', status: 'approved' },
         ],
       },
     };
@@ -444,8 +455,8 @@ describe('stage-22.js - Release Readiness template', () => {
         ...validPrerequisites,
         stage22: {
           release_items: [
-            { name: 'R1', category: 'C1', status: 'approved' },
-            { name: 'R2', category: 'C2', status: 'pending' },
+            { name: 'R1', category: 'feature', status: 'approved' },
+            { name: 'R2', category: 'bugfix', status: 'pending' },
           ],
         },
       };
@@ -462,7 +473,7 @@ describe('stage-22.js - Release Readiness template', () => {
         stage19: { completion_pct: 50, blocked_tasks: 1 },
         stage20: { quality_gate_passed: false, overall_pass_rate: 90, coverage_pct: 50 },
         stage21: { all_passing: false, failing_integrations: [{ name: 'I1' }] },
-        stage22: { release_items: [{ name: 'R1', category: 'C1', status: 'pending' }] },
+        stage22: { release_items: [{ name: 'R1', category: 'feature', status: 'pending' }] },
       };
       const result = evaluatePromotionGate(prerequisites);
       expect(result.pass).toBe(false);
@@ -474,7 +485,7 @@ describe('stage-22.js - Release Readiness template', () => {
   describe('computeDerived() - Integration with promotion gate', () => {
     it('should include promotion gate evaluation when prerequisites provided', () => {
       const data = {
-        release_items: [{ name: 'R1', category: 'C1', status: 'approved' }],
+        release_items: [{ name: 'R1', category: 'feature', status: 'approved' }],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
       };
@@ -501,7 +512,7 @@ describe('stage-22.js - Release Readiness template', () => {
 
     it('should return default promotion gate when prerequisites not provided', () => {
       const data = {
-        release_items: [{ name: 'R1', category: 'C1', status: 'approved' }],
+        release_items: [{ name: 'R1', category: 'feature', status: 'approved' }],
         release_notes: 'Release notes',
         target_date: '2026-03-01',
       };
@@ -542,8 +553,8 @@ describe('stage-22.js - Release Readiness template', () => {
     it('should work together for valid data', () => {
       const data = {
         release_items: [
-          { name: 'Security review', category: 'Security', status: 'approved' },
-          { name: 'Legal review', category: 'Legal', status: 'approved' },
+          { name: 'Security review', category: 'security', status: 'approved' },
+          { name: 'Legal review', category: 'documentation', status: 'approved' },
         ],
         release_notes: 'Major release with new features',
         target_date: '2026-03-01',
@@ -560,7 +571,7 @@ describe('stage-22.js - Release Readiness template', () => {
     it('should not require validation before computeDerived (decoupled)', () => {
       const data = {
         release_items: [
-          { name: 'R1', category: 'C1', status: 'invalid_status' },
+          { name: 'R1', category: 'feature', status: 'invalid_status' },
         ],
         release_notes: 'Short',
         target_date: '2026-03-01',


### PR DESCRIPTION
## Summary
- Replace `validateString()` with `validateEnum()` for 6 enum fields across EVA Build Loop stages 17-22
- Add exported enum constant arrays: `SEVERITY_LEVELS`, `ISSUE_SEVERITIES`, `ISSUE_STATUSES`, `DEFECT_SEVERITIES`, `DEFECT_STATUSES`, `RELEASE_CATEGORIES`
- Add 6 new enum rejection tests verifying invalid values are properly rejected
- Update test data to use valid enum values (replacing placeholder strings like 'C1', 'Legal')

## Test plan
- [x] 225 tests pass across all 6 Build Loop stage templates (17-22)
- [x] 6 new enum rejection tests confirm invalid values are caught
- [x] No regressions in stages 18, 21 (already using validateEnum)
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)