### PR TITLE
fix: add chairman governance gates + resolve claim dual source of truth

### DIFF
--- a/tests/unit/eva/stage-templates/chairman-gates.test.js
+++ b/tests/unit/eva/stage-templates/chairman-gates.test.js
@@ -40,7 +40,7 @@ function validStage10Data(gateOverride = {}) {
 function validStage22Data(gateOverride = {}) {
   return {
     release_items: [
-      { name: 'Feature A', category: 'core', status: 'approved', approver: 'QA' },
+      { name: 'Feature A', category: 'feature', status: 'approved', approver: 'QA' },
     ],
     release_notes: 'Release notes for version 1.0 with improvements and fixes.',
     target_date: '2026-03-01',


### PR DESCRIPTION
## Summary
- Add blocking chairman governance gates to EVA stages 10 (Brand Approval), 22 (Release Readiness), and 25 (Venture Review) using `createOrReusePendingDecision`/`waitForDecision` pattern
- Fix claim guard dual source of truth: `BaseExecutor._claimSDForSession()` now queries `sd_claims` directly instead of `v_active_sessions` view, which reads stale `claude_sessions.sd_id`
- Fix cross-SD test coupling: update chairman-gates test data to use valid enum value (`feature` instead of `core`) after sibling SD changed stage-22 category validation

## Test plan
- [x] 21 chairman governance gate tests pass (stages 10, 22, 25)
- [x] 136 stage template tests pass across all three stages
- [x] 1329 total tests passing (13 pre-existing failures in analysis-steps, unrelated)
- [x] PLAN-TO-LEAD handoff passes (95%) with claim fix applied
- [x] LEAD-FINAL-APPROVAL passes (98%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)