### PR TITLE
fix: move risks to top-level column and enrich /learn SD metadata

### DIFF
--- a/scripts/modules/learning/sd-creation.js
+++ b/scripts/modules/learning/sd-creation.js
@@ -77,12 +77,12 @@ export async function createSDFromLearning(items, type, options = {}) {
     strategic_objectives: strategicObjectives,
     key_principles: keyPrinciples,
     key_changes: keyChanges,
+    risks: risks,
     metadata: {
       source: 'learn_command',
       source_items: items.map(i => i.id || i.pattern_id),
       classification: type,
-      created_via: '/learn apply',
-      risks: risks
+      created_via: '/learn apply'
     }
   };
 


### PR DESCRIPTION
## Summary
- **Bug fix**: Moved `risks` array from `metadata.risks` to top-level `risks` column in `sd-creation.js` — AI rubric was scoring 0/10 on `risk_assessment_depth` because it only evaluates top-level fields
- **Title fix**: Added fallback in `buildSDTitle()` for empty `issue_summary` — prevents truncated titles like "Address PAT-XXX: "
- **Description enrichment**: Added business impact section and root cause analysis to `buildSDDescription()`
- **SMART objectives**: Made `buildStrategicObjectives()` generate measurable, time-bound objectives with a minimum of 2 to pass LEAD-TO-PLAN gate

## Test plan
- [ ] Verify /learn-generated SDs have top-level `risks` field populated
- [ ] Verify SD titles are non-empty when `issue_summary` is null
- [ ] Verify RETROSPECTIVE_QUALITY_GATE scores >= 55% for new /learn SDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)