### PR TITLE
feat: align enum values between EVA Phase 5 templates and analysis steps

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js
@@ -13,7 +13,7 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
-const SD_TYPES = ['feature', 'infrastructure', 'fix', 'documentation', 'refactor'];
+const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];
 const ARCHITECTURE_LAYERS = ['frontend', 'backend', 'database', 'infrastructure', 'integration', 'security'];
 const MIN_SPRINT_ITEMS = 1;
 
@@ -26,7 +26,7 @@ You MUST output valid JSON with exactly this structure:
     {
       "title": "Sprint item title",
       "description": "What needs to be built (2-3 sentences)",
-      "type": "feature|infrastructure|fix|documentation|refactor",
+      "type": "feature|bugfix|enhancement|refactor|infra",
       "priority": "critical|high|medium|low",
       "estimatedLoc": 150,
       "acceptanceCriteria": "How to verify this item is done",

--- a/lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js
@@ -14,7 +14,7 @@ import { parseJSON } from '../../utils/parse-json.js';
 
 const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
 const ISSUE_SEVERITIES = ['critical', 'high', 'medium', 'low'];
-const ISSUE_STATUSES = ['open', 'in_progress', 'resolved', 'wontfix'];
+const ISSUE_STATUSES = ['open', 'investigating', 'resolved', 'deferred'];
 const COMPLETION_DECISIONS = ['complete', 'continue', 'blocked'];
 
 const SYSTEM_PROMPT = `You are EVA's Build Execution Analyst. Synthesize build progress from sprint items and generate a sprint completion assessment.
@@ -33,7 +33,7 @@ You MUST output valid JSON with exactly this structure:
     {
       "description": "Issue description",
       "severity": "critical|high|medium|low",
-      "status": "open|in_progress|resolved|wontfix"
+      "status": "open|investigating|resolved|deferred"
     }
   ],
   "sprintCompletion": {

--- a/lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js
@@ -15,7 +15,7 @@ import { parseJSON } from '../../utils/parse-json.js';
 const QUALITY_DECISIONS = ['pass', 'conditional_pass', 'fail'];
 const TEST_SUITE_TYPES = ['unit', 'integration', 'e2e'];
 const DEFECT_SEVERITIES = ['critical', 'high', 'medium', 'low'];
-const DEFECT_STATUSES = ['open', 'in_progress', 'resolved', 'wontfix'];
+const DEFECT_STATUSES = ['open', 'investigating', 'resolved', 'deferred', 'wont_fix'];
 const MIN_PASS_RATE = 95;
 const MIN_COVERAGE_PCT = 60;
 
@@ -37,7 +37,7 @@ You MUST output valid JSON with exactly this structure:
     {
       "description": "Defect description",
       "severity": "critical|high|medium|low",
-      "status": "open|in_progress|resolved|wontfix",
+      "status": "open|investigating|resolved|deferred|wont_fix",
       "testSuiteRef": "Which test suite found this"
     }
   ],

--- a/lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js
@@ -13,7 +13,7 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
 
 const RELEASE_DECISIONS = ['release', 'hold', 'cancel'];
-const RELEASE_CATEGORIES = ['feature', 'bugfix', 'infrastructure', 'documentation', 'configuration'];
+const RELEASE_CATEGORIES = ['feature', 'bugfix', 'infrastructure', 'documentation', 'security', 'performance', 'configuration'];
 
 const SYSTEM_PROMPT = `You are EVA's Release Readiness Analyst. Synthesize the entire BUILD LOOP (Stages 17-21) into a release decision, sprint retrospective, and sprint summary.
 
@@ -22,7 +22,7 @@ You MUST output valid JSON with exactly this structure:
   "releaseItems": [
     {
       "name": "Release item name",
-      "category": "feature|bugfix|infrastructure|documentation|configuration",
+      "category": "feature|bugfix|infrastructure|documentation|security|performance|configuration",
       "status": "pending|approved|rejected",
       "approver": "Role or name of approver"
     }

--- a/lib/eva/stage-templates/stage-18.js
+++ b/lib/eva/stage-templates/stage-18.js
@@ -97,6 +97,12 @@ const TEMPLATE = {
           validateString(item?.success_criteria, `${prefix}.success_criteria`, 1),
           validateString(item?.target_application, `${prefix}.target_application`, 1),
         ];
+        if (item?.architectureLayer != null) {
+          results.push(validateString(item.architectureLayer, `${prefix}.architectureLayer`, 1));
+        }
+        if (item?.milestoneRef != null) {
+          results.push(validateString(item.milestoneRef, `${prefix}.milestoneRef`, 1));
+        }
         errors.push(...collectErrors(results));
       }
     }

--- a/lib/eva/stage-templates/stage-20.js
+++ b/lib/eva/stage-templates/stage-20.js
@@ -82,6 +82,9 @@ const TEMPLATE = {
           validateNumber(ts?.total_tests, `${prefix}.total_tests`, 0),
           validateNumber(ts?.passing_tests, `${prefix}.passing_tests`, 0),
         ];
+        if (ts?.type != null) {
+          results.push(validateEnum(ts.type, `${prefix}.type`, TEST_SUITE_TYPES));
+        }
         errors.push(...collectErrors(results));
 
         if (typeof ts?.passing_tests === 'number' && typeof ts?.total_tests === 'number' && ts.passing_tests > ts.total_tests) {


### PR DESCRIPTION
## Summary
- Fix 4 enum mismatches in EVA Phase 5 Build Loop (stages 17-22) where analysis step LLM prompts used different enum values than template validators
- Add 2 missing optional field validations (architectureLayer, milestoneRef in stage-18; test suite type in stage-20)
- Part of SD-EVA-R2-FIX-ENUM-ALIGN-P5-001 (child of EVA R2 remediation orchestrator)

## Test plan
- [x] All 8 modified files import successfully without errors
- [x] All 4 enum alignments verified programmatically (template === analysis step)
- [x] Validation logic tested: valid with/without optional fields, invalid optional fields correctly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)