### PR TITLE
feat: align Phase 6 Launch enums/schemas with Architecture v1.6

### DIFF
--- a/lib/eva/stage-templates/stage-23.js
+++ b/lib/eva/stage-templates/stage-23.js
@@ -17,7 +17,7 @@ import { validateString, validateArray, validateEnum, collectErrors } from './va
 import { analyzeStage23 } from './analysis-steps/stage-23-launch-execution.js';
 
 const GO_DECISIONS = ['go', 'no-go', 'conditional_go'];
-const LAUNCH_TYPES = ['soft_launch', 'hard_launch', 'staged_rollout', 'beta_release'];
+const LAUNCH_TYPES = ['soft_launch', 'beta', 'general_availability'];
 const MIN_LAUNCH_TASKS = 1;
 
 const TEMPLATE = {
@@ -46,10 +46,10 @@ const TEMPLATE = {
     successCriteria: {
       type: 'array',
       items: {
-        criterion: { type: 'string', required: true },
         metric: { type: 'string', required: true },
         target: { type: 'string', required: true },
-        timeframe: { type: 'string' },
+        measurementWindow: { type: 'string' },
+        priority: { type: 'enum', values: ['primary', 'secondary'] },
       },
     },
     rollbackTriggers: {
@@ -147,6 +147,17 @@ export function evaluateKillGate({ go_decision, incident_response_plan, monitori
       type: 'stage22_not_complete',
       message: `Stage 22 release readiness not confirmed${blockerCount > 0 ? ` (${blockerCount} blocker(s))` : ''}`,
     });
+  }
+
+  // Launch CC-4: Stage 22 releaseDecision must approve before launch
+  if (stage22Data && stage22Data.releaseDecision) {
+    const rd = stage22Data.releaseDecision;
+    if (rd.decision !== 'approve' && rd.decision !== 'approved') {
+      reasons.push({
+        type: 'release_not_approved',
+        message: `Stage 22 release decision: ${rd.decision}${rd.rationale ? ` — ${rd.rationale}` : ''}`,
+      });
+    }
   }
 
   if (go_decision !== 'go' && go_decision !== 'conditional_go') {

--- a/lib/eva/stage-templates/stage-24.js
+++ b/lib/eva/stage-templates/stage-24.js
@@ -15,6 +15,7 @@ import { analyzeStage24 } from './analysis-steps/stage-24-metrics-learning.js';
 const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', 'referral'];
 const TREND_DIRECTIONS = ['up', 'down', 'flat'];
 const IMPACT_LEVELS = ['high', 'medium', 'low'];
+const OUTCOME_ASSESSMENTS = ['success', 'partial', 'failure', 'indeterminate'];
 const MIN_METRICS_PER_CATEGORY = 1;
 const MIN_FUNNELS = 1;
 
@@ -37,6 +38,7 @@ const TEMPLATE = {
           previousValue: { type: 'number' },
           trendDirection: { type: 'enum', values: TREND_DIRECTIONS },
           trend_window_days: { type: 'number', min: 1 },
+          criterionRef: { type: 'string' },
         },
       }])),
     },
@@ -158,11 +160,13 @@ const TEMPLATE = {
       : 0;
     let assessment;
     if (criteriaMetRate >= 80) {
-      assessment = 'successful';
+      assessment = 'success';
     } else if (criteriaMetRate >= 50) {
       assessment = 'partial';
+    } else if (total_metrics === 0) {
+      assessment = 'indeterminate';
     } else {
-      assessment = 'underperforming';
+      assessment = 'failure';
     }
     const launchOutcome = {
       assessment,
@@ -183,5 +187,5 @@ const TEMPLATE = {
 
 TEMPLATE.analysisStep = analyzeStage24;
 
-export { AARRR_CATEGORIES, TREND_DIRECTIONS, IMPACT_LEVELS, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS };
+export { AARRR_CATEGORIES, TREND_DIRECTIONS, IMPACT_LEVELS, OUTCOME_ASSESSMENTS, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -16,11 +16,12 @@ import { extractTemplate } from '../template-extractor.js';
 import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
 const REVIEW_CATEGORIES = ['product', 'market', 'technical', 'financial', 'team'];
-const INITIATIVE_STATUSES = ['planned', 'in_progress', 'completed', 'cancelled'];
-const VENTURE_DECISIONS = ['proceed', 'pivot', 'pause', 'terminate'];
+const INITIATIVE_STATUSES = ['planned', 'in_progress', 'completed', 'abandoned', 'deferred'];
+const VENTURE_DECISIONS = ['continue', 'pivot', 'expand', 'sunset', 'exit'];
 const CONFIDENCE_LEVELS = ['high', 'medium', 'low'];
 const NEXT_STEP_PRIORITIES = ['critical', 'high', 'medium', 'low'];
-const SEMANTIC_DRIFT_LEVELS = ['none', 'minor', 'moderate', 'severe'];
+const SEMANTIC_DRIFT_LEVELS = ['aligned', 'moderate_drift', 'major_drift'];
+const HEALTH_BANDS = ['critical', 'fragile', 'viable', 'strong'];
 const MIN_INITIATIVES_PER_CATEGORY = 1;
 
 const TEMPLATE = {
@@ -68,8 +69,30 @@ const TEMPLATE = {
     financialComparison: {
       type: 'object',
       fields: {
-        projected: { type: 'object' },
-        actual: { type: 'object' },
+        projectedRevenue: { type: 'string' },
+        actualRevenue: { type: 'string' },
+        projectedCosts: { type: 'string' },
+        actualCosts: { type: 'string' },
+        revenueVariancePct: { type: 'number' },
+        financialTrajectory: { type: 'enum', values: ['above_plan', 'on_plan', 'below_plan', 'critical'] },
+        variance: { type: 'string' },
+        assessment: { type: 'string' },
+      },
+    },
+    ventureHealth: {
+      type: 'object',
+      fields: {
+        overallRating: { type: 'enum', values: HEALTH_BANDS },
+        dimensions: {
+          type: 'object',
+          properties: Object.fromEntries(REVIEW_CATEGORIES.map(cat => [cat, {
+            type: 'object',
+            fields: {
+              score: { type: 'number', min: 0, max: 100 },
+              rationale: { type: 'string' },
+            },
+          }])),
+        },
       },
     },
     // Derived
@@ -85,7 +108,8 @@ const TEMPLATE = {
     current_vision: null,
     drift_justification: null,
     next_steps: [],
-    financialComparison: { projected: null, actual: null },
+    financialComparison: { projectedRevenue: null, actualRevenue: null, projectedCosts: null, actualCosts: null, revenueVariancePct: null, financialTrajectory: null, variance: null, assessment: null },
+    ventureHealth: { overallRating: null, dimensions: {} },
     chairmanGate: { status: 'pending', rationale: null, decision_id: null },
     total_initiatives: 0,
     all_categories_reviewed: false,
@@ -183,22 +207,21 @@ const TEMPLATE = {
 
     const drift_detected = drift_check.drift_detected;
 
-    // Semantic drift level classification
-    let semanticDrift = 'none';
+    // Semantic drift level classification (spec: aligned, moderate_drift, major_drift)
+    let semanticDrift = 'aligned';
     if (drift_check.drift_detected) {
       const overlapMatch = drift_check.rationale?.match(/(\d+)%/);
       const overlap = overlapMatch ? parseInt(overlapMatch[1]) : 0;
-      if (overlap < 10) semanticDrift = 'severe';
-      else if (overlap < 20) semanticDrift = 'moderate';
-      else semanticDrift = 'minor';
+      if (overlap < 15) semanticDrift = 'major_drift';
+      else semanticDrift = 'moderate_drift';
     }
 
-    // Venture decision object (derived from review completeness and drift)
+    // Venture decision object (spec: continue, pivot, expand, sunset, exit)
     const completedInitiatives = Object.values(data.initiatives)
       .flat()
       .filter(i => i.status === 'completed').length;
     const ventureDecision = {
-      decision: all_categories_reviewed && !drift_detected ? 'proceed' : (drift_detected ? 'pivot' : 'pause'),
+      decision: all_categories_reviewed && !drift_detected ? 'continue' : (drift_detected ? 'pivot' : 'continue'),
       rationale: all_categories_reviewed
         ? (drift_detected
           ? `Drift detected (${semanticDrift}): review and pivot recommended`
@@ -291,5 +314,5 @@ TEMPLATE.onComplete = async function onComplete(supabase, ventureId) {
   }
 };
 
-export { REVIEW_CATEGORIES, INITIATIVE_STATUSES, VENTURE_DECISIONS, CONFIDENCE_LEVELS, NEXT_STEP_PRIORITIES, SEMANTIC_DRIFT_LEVELS, MIN_INITIATIVES_PER_CATEGORY };
+export { REVIEW_CATEGORIES, INITIATIVE_STATUSES, VENTURE_DECISIONS, CONFIDENCE_LEVELS, NEXT_STEP_PRIORITIES, SEMANTIC_DRIFT_LEVELS, HEALTH_BANDS, MIN_INITIATIVES_PER_CATEGORY };
 export default TEMPLATE;


### PR DESCRIPTION
## Summary
- **Stage 23**: Fixed LAUNCH_TYPES enum to match spec (`soft_launch`, `beta`, `general_availability`), aligned successCriteria fields (`metric`/`measurementWindow`/`priority`), added `releaseDecision` check to kill gate
- **Stage 24**: Added `criterionRef` field to AARRR metrics, fixed `launchOutcome.assessment` enum to spec values (`success`/`partial`/`failure`/`indeterminate`), exported `OUTCOME_ASSESSMENTS`
- **Stage 25**: Fixed VENTURE_DECISIONS (`continue`/`pivot`/`expand`/`sunset`/`exit`), INITIATIVE_STATUSES (added `abandoned`/`deferred`, removed `cancelled`), SEMANTIC_DRIFT_LEVELS (`aligned`/`moderate_drift`/`major_drift`), added `ventureHealth` schema with 0-100 scores and `HEALTH_BANDS` enum, restructured `financialComparison` with `revenueVariancePct`/`financialTrajectory`

Part of SD-EVA-REMEDIATION-R2-ORCH-001 (child 5/13)

## Test plan
- [x] All 3 templates import successfully with correct enum values
- [x] `validate()` passes with spec-compliant data
- [x] `computeDerived()` produces spec-compliant output
- [x] `evaluateKillGate()` correctly blocks on rejected releaseDecision
- [x] Backward compatible when releaseDecision absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)