### PR TITLE
fix: add validate() enforcement for Phase 3 template fields

### DIFF
--- a/lib/eva/stage-templates/stage-10.js
+++ b/lib/eva/stage-templates/stage-10.js
@@ -9,7 +9,7 @@
  * @module lib/eva/stage-templates/stage-10
  */
 
-import { validateString, validateNumber, validateArray, validateInteger, collectErrors } from './validation.js';
+import { validateString, validateNumber, validateArray, validateInteger, validateEnum, collectErrors } from './validation.js';
 import { analyzeStage10 } from './analysis-steps/stage-10-naming-brand.js';
 import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
@@ -167,6 +167,23 @@ const TEMPLATE = {
           }
         }
       }
+    }
+
+    // Narrative extension (G10-1)
+    const ne = data?.narrativeExtension;
+    if (ne && typeof ne === 'object') {
+      for (const field of ['vision', 'mission', 'brandVoice']) {
+        if (ne[field] !== null && ne[field] !== undefined) {
+          const neCheck = validateString(ne[field], `narrativeExtension.${field}`, 1);
+          if (!neCheck.valid) errors.push(neCheck.error);
+        }
+      }
+    }
+
+    // Naming strategy enum (G10-2)
+    if (data?.namingStrategy !== null && data?.namingStrategy !== undefined) {
+      const nsCheck = validateEnum(data.namingStrategy, 'namingStrategy', NAMING_STRATEGIES);
+      if (!nsCheck.valid) errors.push(nsCheck.error);
     }
 
     // Chairman governance gate check

--- a/lib/eva/stage-templates/stage-11.js
+++ b/lib/eva/stage-templates/stage-11.js
@@ -107,6 +107,18 @@ const TEMPLATE = {
           validateString(t?.description, `${prefix}.description`, 1),
         ];
         errors.push(...collectErrors(results));
+
+        // G11-1: persona validation
+        if (t?.persona !== null && t?.persona !== undefined) {
+          const personaCheck = validateString(t.persona, `${prefix}.persona`, 1);
+          if (!personaCheck.valid) errors.push(personaCheck.error);
+        }
+
+        // G11-2: painPoints validation
+        if (t?.painPoints !== undefined) {
+          const ppCheck = validateArray(t.painPoints, `${prefix}.painPoints`, 1);
+          if (!ppCheck.valid) errors.push(ppCheck.error);
+        }
       }
     }
 
@@ -126,6 +138,18 @@ const TEMPLATE = {
           validateString(ch?.primary_kpi, `${prefix}.primary_kpi`, 1),
         ];
         errors.push(...collectErrors(results));
+
+        // G11-3: channelType enum validation
+        if (ch?.channelType !== null && ch?.channelType !== undefined) {
+          const ctCheck = validateEnum(ch.channelType, `${prefix}.channelType`, CHANNEL_TYPES);
+          if (!ctCheck.valid) errors.push(ctCheck.error);
+        }
+
+        // G11-4: primaryTier validation
+        if (ch?.primaryTier !== null && ch?.primaryTier !== undefined) {
+          const ptCheck = validateString(ch.primaryTier, `${prefix}.primaryTier`, 1);
+          if (!ptCheck.valid) errors.push(ptCheck.error);
+        }
       }
     }
 

--- a/lib/eva/stage-templates/stage-12.js
+++ b/lib/eva/stage-templates/stage-12.js
@@ -58,7 +58,7 @@ const TEMPLATE = {
         name: { type: 'string', required: true },
         metric: { type: 'string', required: true },
         target_value: { type: 'number', min: 0, required: true },
-        conversionRateEstimate: { type: 'number', min: 0, max: 100 },
+        conversionRateEstimate: { type: 'number', min: 0, max: 1 },
       },
     },
     customer_journey: {
@@ -114,6 +114,12 @@ const TEMPLATE = {
           validateString(ds?.description, `${prefix}.description`, 1),
         ];
         errors.push(...collectErrors(results));
+
+        // G12-2: mappedFunnelStage validation
+        if (ds?.mappedFunnelStage !== null && ds?.mappedFunnelStage !== undefined) {
+          const mfsCheck = validateString(ds.mappedFunnelStage, `${prefix}.mappedFunnelStage`, 1);
+          if (!mfsCheck.valid) errors.push(mfsCheck.error);
+        }
       }
     }
 
@@ -131,6 +137,16 @@ const TEMPLATE = {
           validateNumber(fs?.target_value, `${prefix}.target_value`, 0),
         ];
         errors.push(...collectErrors(results));
+
+        // G12-3: conversionRateEstimate validation (0-1 ratio range)
+        if (fs?.conversionRateEstimate !== null && fs?.conversionRateEstimate !== undefined) {
+          const crCheck = validateNumber(fs.conversionRateEstimate, `${prefix}.conversionRateEstimate`, 0);
+          if (!crCheck.valid) {
+            errors.push(crCheck.error);
+          } else if (fs.conversionRateEstimate > 1) {
+            errors.push(`${prefix}.conversionRateEstimate must be <= 1 (ratio), got ${fs.conversionRateEstimate}`);
+          }
+        }
       }
     }
 
@@ -173,11 +189,11 @@ const TEMPLATE = {
     const economyCheck = {
       totalPipelineValue,
       avgConversionRate,
-      pricingAvailable: !!(prerequisites?.stage07?.tiers?.length > 0),
+      pricingAvailable: !!prerequisites?.stage07,
     };
 
     const reality_gate = prerequisites
-      ? evaluateRealityGate({ ...prerequisites, stage12: data })
+      ? evaluateRealityGate({ ...prerequisites, stage12: { ...data, economyCheck } })
       : { pass: false, rationale: 'Prerequisites not provided', blockers: ['Stage 10-11 data required'], required_next_actions: ['Complete stages 10-11 before evaluating reality gate'] };
 
     return { ...data, economyCheck, reality_gate };
@@ -246,6 +262,19 @@ export function evaluateRealityGate({ stage10, stage11, stage12 }) {
   if (journeyCount < MIN_JOURNEY_STEPS) {
     blockers.push(`Insufficient customer journey steps: ${journeyCount} < ${MIN_JOURNEY_STEPS} required`);
     required_next_actions.push(`Add ${MIN_JOURNEY_STEPS - journeyCount} more customer journey steps mapped to funnel stages`);
+  }
+
+  // G12-4: Economy check validation
+  const econ = stage12?.economyCheck;
+  if (econ) {
+    if (typeof econ.totalPipelineValue === 'number' && econ.totalPipelineValue <= 0) {
+      blockers.push('Economy check: totalPipelineValue must be > 0');
+      required_next_actions.push('Ensure funnel stages have positive target values');
+    }
+    if (typeof econ.avgConversionRate === 'number' && (econ.avgConversionRate <= 0 || econ.avgConversionRate > 1)) {
+      blockers.push(`Economy check: avgConversionRate ${econ.avgConversionRate} is out of expected range (0-1)`);
+      required_next_actions.push('Review funnel stage conversion rate estimates');
+    }
   }
 
   const pass = blockers.length === 0;


### PR DESCRIPTION
## Summary
- Add `validate()` checks for 7 previously unenforced schema-declared fields across Stage 10-12 templates
- Fix `conversionRateEstimate` schema range from 0-100 to 0-1 (ratio convention matching analysis step)
- Add `economyCheck` validation to `evaluateRealityGate()` (totalPipelineValue > 0, avgConversionRate range)
- Fix `pricingAvailable` prerequisite check (was checking `stage07.tiers`, now checks `stage07` existence)

## Test plan
- [x] All 3 files import successfully (syntax check)
- [x] New validations catch invalid data (narrativeExtension, namingStrategy, persona, painPoints, channelType, primaryTier, mappedFunnelStage, conversionRateEstimate)
- [x] evaluateRealityGate blocks on zero pipeline value
- [x] evaluateRealityGate passes with valid economics
- [x] Existing 45 stage-11 tests pass

SD: SD-EVA-R2-FIX-TEMPLATE-VALIDATE-P3-001
Addresses: G10-1, G10-2, G11-1, G11-2, G11-3, G11-4, G12-2, G12-3, G12-3b, G12-4, G12-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)