### PR TITLE
feat: canonicalize 25 EVA stage names to Vision v4.7

### DIFF
--- a/lib/eva/stage-templates/stage-01.js
+++ b/lib/eva/stage-templates/stage-01.js
@@ -26,7 +26,7 @@ const ARCHETYPES = [
 const TEMPLATE = {
   id: 'stage-01',
   slug: 'draft-idea',
-  title: 'Draft Idea',
+  title: 'Idea Capture',
   version: '2.0.0',
   schema: {
     description: { type: 'string', minLength: 50, required: true },

--- a/lib/eva/stage-templates/stage-02.js
+++ b/lib/eva/stage-templates/stage-02.js
@@ -26,7 +26,7 @@ const SUGGESTION_TYPES = ['immediate', 'strategic'];
 const TEMPLATE = {
   id: 'stage-02',
   slug: 'idea-validation',
-  title: 'Idea Validation',
+  title: 'Idea Analysis',
   version: '2.0.0',
   schema: {
     analysis: {

--- a/lib/eva/stage-templates/stage-03.js
+++ b/lib/eva/stage-templates/stage-03.js
@@ -38,7 +38,7 @@ const THREAT_LEVELS = ['H', 'M', 'L'];
 const TEMPLATE = {
   id: 'stage-03',
   slug: 'validation',
-  title: 'Individual Validation',
+  title: 'Kill Gate',
   version: '2.0.0',
   schema: {
     // 6 core metrics (0-100 integer)

--- a/lib/eva/stage-templates/stage-04.js
+++ b/lib/eva/stage-templates/stage-04.js
@@ -27,7 +27,7 @@ const PRICING_MODELS = [
 const TEMPLATE = {
   id: 'stage-04',
   slug: 'competitive-intel',
-  title: 'Competitive Intel',
+  title: 'Competitive Landscape',
   version: '2.0.0',
   schema: {
     competitors: {

--- a/lib/eva/stage-templates/stage-05.js
+++ b/lib/eva/stage-templates/stage-05.js
@@ -37,7 +37,7 @@ const ROBUSTNESS_LEVELS = ['fragile', 'normal', 'resilient'];
 const TEMPLATE = {
   id: 'stage-05',
   slug: 'profitability',
-  title: 'Profitability Kill Gate',
+  title: 'Kill Gate (Financial)',
   version: '2.0.0',
   schema: {
     initialInvestment: { type: 'number', min: 0.01, required: true },

--- a/lib/eva/stage-templates/stage-06.js
+++ b/lib/eva/stage-templates/stage-06.js
@@ -26,7 +26,7 @@ const RISK_STATUSES = ['open', 'mitigated', 'accepted', 'closed'];
 const TEMPLATE = {
   id: 'stage-06',
   slug: 'risk-matrix',
-  title: 'Risk Matrix',
+  title: 'Risk Assessment',
   version: '2.0.0',
   schema: {
     risks: {

--- a/lib/eva/stage-templates/stage-07.js
+++ b/lib/eva/stage-templates/stage-07.js
@@ -23,7 +23,7 @@ const PRICING_MODELS = ['subscription', 'usage_based', 'tiered', 'freemium', 'en
 const TEMPLATE = {
   id: 'stage-07',
   slug: 'pricing',
-  title: 'Pricing',
+  title: 'Revenue Architecture',
   version: '2.0.0',
   schema: {
     currency: { type: 'string', required: true },

--- a/lib/eva/stage-templates/stage-10.js
+++ b/lib/eva/stage-templates/stage-10.js
@@ -21,7 +21,7 @@ const NAMING_STRATEGIES = ['descriptive', 'abstract', 'acronym', 'founder', 'met
 const TEMPLATE = {
   id: 'stage-10',
   slug: 'naming-brand',
-  title: 'Naming / Brand',
+  title: 'Naming/Brand',
   version: '2.0.0',
   schema: {
     brandGenome: {

--- a/lib/eva/stage-templates/stage-11.js
+++ b/lib/eva/stage-templates/stage-11.js
@@ -35,7 +35,7 @@ const CHANNEL_NAMES = [
 const TEMPLATE = {
   id: 'stage-11',
   slug: 'gtm',
-  title: 'Go-To-Market',
+  title: 'GTM Strategy',
   version: '2.0.0',
   schema: {
     tiers: {

--- a/lib/eva/stage-templates/stage-12.js
+++ b/lib/eva/stage-templates/stage-12.js
@@ -36,7 +36,7 @@ const MIN_DEAL_STAGES = 3;
 const TEMPLATE = {
   id: 'stage-12',
   slug: 'sales-logic',
-  title: 'Sales Logic',
+  title: 'Sales Identity',
   version: '2.0.0',
   schema: {
     sales_model: { type: 'enum', values: SALES_MODELS, required: true },

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -19,7 +19,7 @@ const PRIORITY_ENUM = ['immediate', 'short_term', 'long_term'];
 const TEMPLATE = {
   id: 'stage-15',
   slug: 'risk-register',
-  title: 'Risk Register',
+  title: 'Resource Planning',
   version: '3.0.0',
   schema: {
     risks: {

--- a/lib/eva/stage-templates/stage-21.js
+++ b/lib/eva/stage-templates/stage-21.js
@@ -19,7 +19,7 @@ const MIN_INTEGRATIONS = 1;
 const TEMPLATE = {
   id: 'stage-21',
   slug: 'integration-testing',
-  title: 'Integration Testing',
+  title: 'Build Review',
   version: '2.0.0',
   schema: {
     integrations: {

--- a/scripts/seed-canonical-stage-names.js
+++ b/scripts/seed-canonical-stage-names.js
@@ -1,0 +1,153 @@
+/**
+ * Seed script: Canonical Stage Name Synchronization
+ * SD-EVA-R2-FIX-DOSSIER-NAMES-001
+ *
+ * Updates lifecycle_stage_config to match Vision v4.7 canonical stage names
+ * and fixes phase boundaries (BUILD LOOP = stages 17-22).
+ *
+ * Idempotent: safe to run multiple times.
+ *
+ * Usage: node scripts/seed-canonical-stage-names.js [--dry-run] [--verify]
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const CANONICAL_STAGES = [
+  { stage_number: 1,  stage_name: 'Idea Capture',           phase_name: 'THE TRUTH' },
+  { stage_number: 2,  stage_name: 'Idea Analysis',          phase_name: 'THE TRUTH' },
+  { stage_number: 3,  stage_name: 'Kill Gate',              phase_name: 'THE TRUTH' },
+  { stage_number: 4,  stage_name: 'Competitive Landscape',  phase_name: 'THE TRUTH' },
+  { stage_number: 5,  stage_name: 'Kill Gate (Financial)',   phase_name: 'THE TRUTH' },
+  { stage_number: 6,  stage_name: 'Risk Assessment',        phase_name: 'THE ENGINE' },
+  { stage_number: 7,  stage_name: 'Revenue Architecture',   phase_name: 'THE ENGINE' },
+  { stage_number: 8,  stage_name: 'Business Model Canvas',  phase_name: 'THE ENGINE' },
+  { stage_number: 9,  stage_name: 'Exit Strategy',          phase_name: 'THE ENGINE' },
+  { stage_number: 10, stage_name: 'Naming/Brand',           phase_name: 'THE IDENTITY' },
+  { stage_number: 11, stage_name: 'GTM Strategy',           phase_name: 'THE IDENTITY' },
+  { stage_number: 12, stage_name: 'Sales Identity',         phase_name: 'THE IDENTITY' },
+  { stage_number: 13, stage_name: 'Product Roadmap',        phase_name: 'THE BLUEPRINT' },
+  { stage_number: 14, stage_name: 'Technical Architecture', phase_name: 'THE BLUEPRINT' },
+  { stage_number: 15, stage_name: 'Resource Planning',      phase_name: 'THE BLUEPRINT' },
+  { stage_number: 16, stage_name: 'Financial Projections',  phase_name: 'THE BLUEPRINT' },
+  { stage_number: 17, stage_name: 'Pre-Build Checklist',    phase_name: 'THE BUILD LOOP' },
+  { stage_number: 18, stage_name: 'Sprint Planning',        phase_name: 'THE BUILD LOOP' },
+  { stage_number: 19, stage_name: 'Build Execution',        phase_name: 'THE BUILD LOOP' },
+  { stage_number: 20, stage_name: 'Quality Assurance',      phase_name: 'THE BUILD LOOP' },
+  { stage_number: 21, stage_name: 'Build Review',           phase_name: 'THE BUILD LOOP' },
+  { stage_number: 22, stage_name: 'Release Readiness',      phase_name: 'THE BUILD LOOP' },
+  { stage_number: 23, stage_name: 'Launch Execution',       phase_name: 'LAUNCH & LEARN' },
+  { stage_number: 24, stage_name: 'Metrics & Learning',     phase_name: 'LAUNCH & LEARN' },
+  { stage_number: 25, stage_name: 'Venture Review',         phase_name: 'LAUNCH & LEARN' },
+];
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const verifyOnly = process.argv.includes('--verify');
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  if (verifyOnly) {
+    await verify(supabase);
+    return;
+  }
+
+  console.log(`\n=== Canonical Stage Name Seed ${dryRun ? '(DRY RUN)' : ''} ===\n`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const stage of CANONICAL_STAGES) {
+    // Fetch current
+    const { data: current } = await supabase
+      .from('lifecycle_stage_config')
+      .select('stage_name, phase_name')
+      .eq('stage_number', stage.stage_number)
+      .single();
+
+    if (!current) {
+      console.log(`  Stage ${stage.stage_number}: NOT FOUND in DB (skipped)`);
+      skipped++;
+      continue;
+    }
+
+    const nameMatch = current.stage_name === stage.stage_name;
+    const phaseMatch = current.phase_name === stage.phase_name;
+
+    if (nameMatch && phaseMatch) {
+      console.log(`  Stage ${stage.stage_number}: ✅ Already correct (${stage.stage_name})`);
+      skipped++;
+      continue;
+    }
+
+    const changes = [];
+    if (!nameMatch) changes.push(`name: "${current.stage_name}" → "${stage.stage_name}"`);
+    if (!phaseMatch) changes.push(`phase: "${current.phase_name}" → "${stage.phase_name}"`);
+
+    if (dryRun) {
+      console.log(`  Stage ${stage.stage_number}: Would update — ${changes.join(', ')}`);
+    } else {
+      const { error } = await supabase
+        .from('lifecycle_stage_config')
+        .update({ stage_name: stage.stage_name, phase_name: stage.phase_name })
+        .eq('stage_number', stage.stage_number);
+
+      if (error) {
+        console.error(`  Stage ${stage.stage_number}: ❌ Error — ${error.message}`);
+      } else {
+        console.log(`  Stage ${stage.stage_number}: ✅ Updated — ${changes.join(', ')}`);
+      }
+    }
+    updated++;
+  }
+
+  console.log(`\n  Summary: ${updated} updated, ${skipped} unchanged\n`);
+
+  if (!dryRun) {
+    await verify(supabase);
+  }
+}
+
+async function verify(supabase) {
+  console.log('\n=== Verification ===\n');
+
+  const { data: rows } = await supabase
+    .from('lifecycle_stage_config')
+    .select('stage_number, stage_name, phase_name')
+    .order('stage_number');
+
+  let mismatches = 0;
+  for (const canonical of CANONICAL_STAGES) {
+    const dbRow = rows?.find(r => r.stage_number === canonical.stage_number);
+    if (!dbRow) {
+      console.log(`  Stage ${canonical.stage_number}: ❌ Missing from DB`);
+      mismatches++;
+      continue;
+    }
+    const nameOk = dbRow.stage_name === canonical.stage_name;
+    const phaseOk = dbRow.phase_name === canonical.phase_name;
+    if (!nameOk || !phaseOk) {
+      const issues = [];
+      if (!nameOk) issues.push(`name: "${dbRow.stage_name}" (expected "${canonical.stage_name}")`);
+      if (!phaseOk) issues.push(`phase: "${dbRow.phase_name}" (expected "${canonical.phase_name}")`);
+      console.log(`  Stage ${canonical.stage_number}: ❌ ${issues.join(', ')}`);
+      mismatches++;
+    }
+  }
+
+  if (mismatches === 0) {
+    console.log('  ✅ All 25 stages match Vision v4.7 canonical names\n');
+  } else {
+    console.log(`\n  ❌ ${mismatches} stage(s) do not match\n`);
+  }
+}
+
+// ESM entry point
+const isMain = import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}` ||
+               import.meta.url === `file://${process.argv[1]}`;
+if (isMain) { main().catch(console.error); }
+
+export { CANONICAL_STAGES };


### PR DESCRIPTION
## Summary
- Canonicalize all 25 EVA lifecycle stage names to match Vision v4.7 specification
- Update `lifecycle_stage_config` DB table via idempotent seed script (24 of 25 stages renamed)
- Fix phase boundaries: stages 21-22 moved from "LAUNCH & LEARN" to "THE BUILD LOOP"
- Update 12 stage template JS files with corrected `title` fields
- Add `scripts/seed-canonical-stage-names.js` with `--dry-run` and `--verify` flags

## Test plan
- [x] Seed script dry-run previews all 24 changes
- [x] Seed script execution updates all 24 stages
- [x] `--verify` flag confirms all 25 stages match Vision v4.7
- [x] Template title fields match canonical names

🤖 Generated with [Claude Code](https://claude.com/claude-code)