### PR TITLE
feat: add 41 unit tests for EVA analysis steps + fix 2 logger bugs

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js
@@ -139,7 +139,6 @@ function buildStage5Handoff(competitors) {
   const density = competitors.filter(c => c.threat === 'H').length >= 2 ? 'high'
     : competitors.filter(c => c.threat !== 'L').length >= 2 ? 'medium' : 'low';
 
-  logger.log('[Stage04] Analysis complete', { duration: Date.now() - startTime });
   return {
     avgMarketPrice: prices.length > 0 ? `$${Math.round(prices.reduce((a, b) => a + b, 0) / prices.length)}/mo` : 'N/A',
     pricingModels: [...pricingTypes],

--- a/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
@@ -187,7 +187,6 @@ Output ONLY valid JSON.`;
 }
 
 function normalizeYear(year) {
-  logger.log('[Stage05] Analysis complete', { duration: Date.now() - startTime });
   return {
     revenue: ensureNonNegative(year?.revenue, 0),
     cogs: ensureNonNegative(year?.cogs, 0),

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-02-multi-persona.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-02-multi-persona.test.js
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for Stage 02 Analysis Step - Multi-Persona Analysis
+ * SD: SD-EVA-R2-FIX-TEST-COVERAGE-001
+ *
+ * Tests: analyzeStage02, PERSONAS, clampScore behavior
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock LLM client before importing module under test
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+// Mock parseJSON
+vi.mock('../../../../../lib/eva/utils/parse-json.js', () => ({
+  parseJSON: vi.fn((str) => JSON.parse(str)),
+}));
+
+import { analyzeStage02, PERSONAS } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+import { parseJSON } from '../../../../../lib/eva/utils/parse-json.js';
+
+function createMockLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makePersonaResponse(personaId, score = 75) {
+  return JSON.stringify({
+    model: personaId,
+    summary: 'This is a detailed assessment of the venture from this perspective.',
+    strengths: ['Strong market fit', 'Good timing'],
+    risks: ['Competition is fierce'],
+    score,
+  });
+}
+
+describe('PERSONAS', () => {
+  it('has exactly 6 personas', () => {
+    expect(PERSONAS).toHaveLength(6);
+  });
+
+  it('each persona has required fields', () => {
+    for (const p of PERSONAS) {
+      expect(p).toHaveProperty('id');
+      expect(p).toHaveProperty('name');
+      expect(p).toHaveProperty('stage3Metric');
+      expect(p).toHaveProperty('focus');
+    }
+  });
+
+  it('persona IDs are unique', () => {
+    const ids = PERSONAS.map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('stage3Metric values are unique', () => {
+    const metrics = PERSONAS.map(p => p.stage3Metric);
+    expect(new Set(metrics).size).toBe(metrics.length);
+  });
+});
+
+describe('analyzeStage02', () => {
+  let mockComplete;
+  const logger = createMockLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockComplete = vi.fn();
+    getLLMClient.mockReturnValue({ complete: mockComplete });
+  });
+
+  const validStage1Data = {
+    description: 'A SaaS platform for pet grooming appointments',
+    valueProp: 'Seamless booking for pet owners',
+    targetMarket: 'Pet owners in urban areas',
+    problemStatement: 'Scheduling pet grooming is fragmented',
+  };
+
+  it('throws when stage1Data is missing description', async () => {
+    await expect(
+      analyzeStage02({ stage1Data: {}, logger }),
+    ).rejects.toThrow('Stage 02 requires Stage 1 data with description');
+  });
+
+  it('throws when stage1Data is null', async () => {
+    await expect(
+      analyzeStage02({ stage1Data: null, logger }),
+    ).rejects.toThrow();
+  });
+
+  it('runs all 6 personas and returns critiques with composite score', async () => {
+    // Each persona call returns a different score
+    const scores = [80, 70, 60, 90, 50, 75];
+    PERSONAS.forEach((persona, i) => {
+      mockComplete.mockResolvedValueOnce(makePersonaResponse(persona.id, scores[i]));
+    });
+
+    const result = await analyzeStage02({
+      stage1Data: validStage1Data,
+      ventureName: 'PetGroom',
+      logger,
+    });
+
+    expect(result.critiques).toHaveLength(6);
+    expect(mockComplete).toHaveBeenCalledTimes(6);
+
+    // Composite = average of scores, rounded
+    const expectedComposite = Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+    expect(result.compositeScore).toBe(expectedComposite);
+  });
+
+  it('maps persona IDs correctly to critiques', async () => {
+    PERSONAS.forEach((persona) => {
+      mockComplete.mockResolvedValueOnce(makePersonaResponse(persona.id, 70));
+    });
+
+    const result = await analyzeStage02({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    for (let i = 0; i < PERSONAS.length; i++) {
+      expect(result.critiques[i].model).toBe(PERSONAS[i].id);
+    }
+  });
+
+  it('clamps score above 100 to 100', async () => {
+    PERSONAS.forEach((persona) => {
+      mockComplete.mockResolvedValueOnce(JSON.stringify({
+        model: persona.id,
+        summary: 'Assessment text that is long enough to pass.',
+        strengths: ['Good'],
+        risks: ['Bad'],
+        score: 150, // Over 100
+      }));
+    });
+
+    const result = await analyzeStage02({ stage1Data: validStage1Data, logger });
+    for (const critique of result.critiques) {
+      expect(critique.score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('clamps negative score to 0', async () => {
+    PERSONAS.forEach((persona) => {
+      mockComplete.mockResolvedValueOnce(JSON.stringify({
+        model: persona.id,
+        summary: 'Assessment text that is long enough to pass.',
+        strengths: ['Good'],
+        risks: ['Bad'],
+        score: -10,
+      }));
+    });
+
+    const result = await analyzeStage02({ stage1Data: validStage1Data, logger });
+    for (const critique of result.critiques) {
+      expect(critique.score).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('defaults non-numeric score to 50', async () => {
+    PERSONAS.forEach((persona) => {
+      mockComplete.mockResolvedValueOnce(JSON.stringify({
+        model: persona.id,
+        summary: 'Assessment text that is long enough to pass.',
+        strengths: ['Good'],
+        risks: ['Bad'],
+        score: 'not-a-number',
+      }));
+    });
+
+    const result = await analyzeStage02({ stage1Data: validStage1Data, logger });
+    for (const critique of result.critiques) {
+      expect(critique.score).toBe(50);
+    }
+  });
+
+  it('normalizes non-array strengths to array', async () => {
+    PERSONAS.forEach((persona) => {
+      mockComplete.mockResolvedValueOnce(JSON.stringify({
+        model: persona.id,
+        summary: 'Assessment text that is long enough to pass.',
+        strengths: 'single strength string',
+        risks: ['risk'],
+        score: 70,
+      }));
+    });
+
+    const result = await analyzeStage02({ stage1Data: validStage1Data, logger });
+    for (const critique of result.critiques) {
+      expect(Array.isArray(critique.strengths)).toBe(true);
+    }
+  });
+
+  it('handles missing summary with fallback', async () => {
+    PERSONAS.forEach((persona) => {
+      mockComplete.mockResolvedValueOnce(JSON.stringify({
+        model: persona.id,
+        strengths: ['Good'],
+        risks: ['Bad'],
+        score: 70,
+      }));
+    });
+
+    const result = await analyzeStage02({ stage1Data: validStage1Data, logger });
+    for (const critique of result.critiques) {
+      expect(typeof critique.summary).toBe('string');
+      expect(critique.summary.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('passes venture name and stage1Data in prompt', async () => {
+    PERSONAS.forEach((persona) => {
+      mockComplete.mockResolvedValueOnce(makePersonaResponse(persona.id, 70));
+    });
+
+    await analyzeStage02({
+      stage1Data: validStage1Data,
+      ventureName: 'TestVenture',
+      logger,
+    });
+
+    // Check the user prompt (second arg) contains venture info
+    const firstCall = mockComplete.mock.calls[0];
+    expect(firstCall[1]).toContain('TestVenture');
+    expect(firstCall[1]).toContain(validStage1Data.description);
+  });
+});

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.test.js
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for Stage 04 Analysis Step - Competitive Landscape
+ * SD: SD-EVA-R2-FIX-TEST-COVERAGE-001
+ *
+ * Tests: analyzeStage04, MIN_COMPETITORS, competitor normalization, stage5Handoff
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock LLM client
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+// Mock parseJSON
+vi.mock('../../../../../lib/eva/utils/parse-json.js', () => ({
+  parseJSON: vi.fn((str) => JSON.parse(str)),
+}));
+
+import { analyzeStage04, MIN_COMPETITORS } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+function createMockLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeCompetitor(name, threat = 'M') {
+  return {
+    name,
+    position: `${name} is a market leader`,
+    threat,
+    strengths: ['Brand recognition'],
+    weaknesses: ['Slow innovation'],
+    swot: {
+      strengths: ['Market share'],
+      weaknesses: ['Legacy tech'],
+      opportunities: ['New markets'],
+      threats: ['Disruption'],
+    },
+    pricingModel: {
+      type: 'subscription',
+      lowTier: '$10/mo',
+      highTier: '$99/mo',
+      freeOption: true,
+      notes: 'Freemium model',
+    },
+  };
+}
+
+function makeLLMResponse(numCompetitors = 3) {
+  const competitors = [];
+  for (let i = 0; i < numCompetitors; i++) {
+    competitors.push(makeCompetitor(`Competitor ${i + 1}`, ['H', 'M', 'L'][i % 3]));
+  }
+  return JSON.stringify({
+    competitors,
+    stage5Handoff: {
+      avgMarketPrice: '$50/mo',
+      pricingModels: ['subscription', 'freemium'],
+      priceRange: { low: 10, high: 99 },
+      competitiveDensity: 'medium',
+    },
+  });
+}
+
+describe('MIN_COMPETITORS', () => {
+  it('is set to 3', () => {
+    expect(MIN_COMPETITORS).toBe(3);
+  });
+});
+
+describe('analyzeStage04', () => {
+  let mockComplete;
+  const logger = createMockLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockComplete = vi.fn();
+    getLLMClient.mockReturnValue({ complete: mockComplete });
+  });
+
+  const validStage1Data = {
+    description: 'AI-powered project management tool',
+    valueProp: 'Automates task assignment and tracking',
+    targetMarket: 'Software development teams',
+    problemStatement: 'Manual project management is inefficient',
+  };
+
+  const validStage3Data = {
+    overallScore: 75,
+    competitiveBarrier: 60,
+  };
+
+  it('throws when stage1Data is missing description', async () => {
+    await expect(
+      analyzeStage04({ stage1Data: {}, logger }),
+    ).rejects.toThrow('Stage 04 requires Stage 1 data with description');
+  });
+
+  it('throws when fewer than MIN_COMPETITORS returned', async () => {
+    mockComplete.mockResolvedValueOnce(JSON.stringify({
+      competitors: [makeCompetitor('Only One')],
+      stage5Handoff: {},
+    }));
+
+    await expect(
+      analyzeStage04({ stage1Data: validStage1Data, logger }),
+    ).rejects.toThrow(`at least ${MIN_COMPETITORS} competitors`);
+  });
+
+  it('throws when competitors is not an array', async () => {
+    mockComplete.mockResolvedValueOnce(JSON.stringify({
+      competitors: null,
+      stage5Handoff: {},
+    }));
+
+    await expect(
+      analyzeStage04({ stage1Data: validStage1Data, logger }),
+    ).rejects.toThrow(`at least ${MIN_COMPETITORS} competitors`);
+  });
+
+  it('returns competitors and stage5Handoff on valid response', async () => {
+    mockComplete.mockResolvedValueOnce(makeLLMResponse(4));
+
+    const result = await analyzeStage04({
+      stage1Data: validStage1Data,
+      stage3Data: validStage3Data,
+      ventureName: 'AITasker',
+      logger,
+    });
+
+    expect(result.competitors).toHaveLength(4);
+    expect(result.stage5Handoff).toBeDefined();
+    expect(result.stage5Handoff.avgMarketPrice).toBe('$50/mo');
+  });
+
+  it('normalizes invalid threat levels to M', async () => {
+    const response = JSON.stringify({
+      competitors: [
+        { ...makeCompetitor('C1'), threat: 'INVALID' },
+        { ...makeCompetitor('C2'), threat: 'X' },
+        { ...makeCompetitor('C3'), threat: 'H' },
+      ],
+      stage5Handoff: { avgMarketPrice: '$50/mo', pricingModels: [], priceRange: { low: 0, high: 0 }, competitiveDensity: 'low' },
+    });
+    mockComplete.mockResolvedValueOnce(response);
+
+    const result = await analyzeStage04({ stage1Data: validStage1Data, logger });
+
+    expect(result.competitors[0].threat).toBe('M');
+    expect(result.competitors[1].threat).toBe('M');
+    expect(result.competitors[2].threat).toBe('H');
+  });
+
+  it('normalizes missing strengths/weaknesses to [N/A]', async () => {
+    const response = JSON.stringify({
+      competitors: [
+        { name: 'C1', strengths: null, weaknesses: [] },
+        { name: 'C2' },
+        { name: 'C3' },
+      ],
+      stage5Handoff: { avgMarketPrice: '$50/mo', pricingModels: [], priceRange: { low: 0, high: 0 }, competitiveDensity: 'low' },
+    });
+    mockComplete.mockResolvedValueOnce(response);
+
+    const result = await analyzeStage04({ stage1Data: validStage1Data, logger });
+
+    expect(result.competitors[0].strengths).toEqual(['N/A']);
+    expect(result.competitors[0].weaknesses).toEqual(['N/A']);
+    expect(result.competitors[1].strengths).toEqual(['N/A']);
+  });
+
+  it('normalizes missing SWOT fields', async () => {
+    const response = JSON.stringify({
+      competitors: [
+        { name: 'C1', swot: {} },
+        { name: 'C2', swot: null },
+        { name: 'C3' },
+      ],
+      stage5Handoff: { avgMarketPrice: '$50/mo', pricingModels: [], priceRange: { low: 0, high: 0 }, competitiveDensity: 'low' },
+    });
+    mockComplete.mockResolvedValueOnce(response);
+
+    const result = await analyzeStage04({ stage1Data: validStage1Data, logger });
+
+    expect(result.competitors[0].swot.strengths).toEqual(['N/A']);
+    expect(result.competitors[0].swot.weaknesses).toEqual(['N/A']);
+    expect(result.competitors[0].swot.opportunities).toEqual(['N/A']);
+    expect(result.competitors[0].swot.threats).toEqual(['N/A']);
+  });
+
+  it('uses LLM-provided stage5Handoff when available', async () => {
+    const handoff = {
+      avgMarketPrice: '$75/mo',
+      pricingModels: ['enterprise'],
+      priceRange: { low: 50, high: 200 },
+      competitiveDensity: 'high',
+    };
+    mockComplete.mockResolvedValueOnce(JSON.stringify({
+      competitors: [makeCompetitor('C1'), makeCompetitor('C2'), makeCompetitor('C3')],
+      stage5Handoff: handoff,
+    }));
+
+    const result = await analyzeStage04({ stage1Data: validStage1Data, logger });
+    expect(result.stage5Handoff).toEqual(handoff);
+  });
+
+  it('includes stage3Data in prompt when provided', async () => {
+    mockComplete.mockResolvedValueOnce(makeLLMResponse(3));
+
+    await analyzeStage04({
+      stage1Data: validStage1Data,
+      stage3Data: validStage3Data,
+      logger,
+    });
+
+    const prompt = mockComplete.mock.calls[0][1];
+    expect(prompt).toContain('75');
+    expect(prompt).toContain('60');
+  });
+
+  it('handles missing competitor name with Unknown fallback', async () => {
+    const response = JSON.stringify({
+      competitors: [
+        { position: 'Leader' },
+        { name: 'C2' },
+        { name: 'C3' },
+      ],
+      stage5Handoff: { avgMarketPrice: '$50/mo', pricingModels: [], priceRange: { low: 0, high: 0 }, competitiveDensity: 'low' },
+    });
+    mockComplete.mockResolvedValueOnce(response);
+
+    const result = await analyzeStage04({ stage1Data: validStage1Data, logger });
+    expect(result.competitors[0].name).toBe('Unknown');
+  });
+});

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-05-financial-model.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-05-financial-model.test.js
@@ -1,0 +1,309 @@
+/**
+ * Unit tests for Stage 05 Analysis Step - Financial Model
+ * SD: SD-EVA-R2-FIX-TEST-COVERAGE-001
+ *
+ * Tests: analyzeStage05, ROI_THRESHOLD, MAX_PAYBACK_MONTHS, kill gate logic
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock LLM client
+vi.mock('../../../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+// Mock parseJSON
+vi.mock('../../../../../lib/eva/utils/parse-json.js', () => ({
+  parseJSON: vi.fn((str) => JSON.parse(str)),
+}));
+
+import { analyzeStage05, ROI_THRESHOLD, MAX_PAYBACK_MONTHS } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js';
+import { getLLMClient } from '../../../../../lib/llm/index.js';
+
+function createMockLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeFinancialResponse(overrides = {}) {
+  const base = {
+    initialInvestment: 50000,
+    year1: { revenue: 100000, cogs: 30000, opex: 40000 },
+    year2: { revenue: 200000, cogs: 50000, opex: 60000 },
+    year3: { revenue: 350000, cogs: 80000, opex: 80000 },
+    unitEconomics: {
+      cac: 150,
+      ltv: 900,
+      ltvCacRatio: 6,
+      paybackMonths: 8,
+      monthlyChurn: 0.03,
+    },
+    roiBands: {
+      pessimistic: 1.5,
+      base: 2.0,
+      optimistic: 2.6,
+    },
+    assumptions: [
+      'Market grows 15% annually',
+      'Churn stabilizes at 3% monthly',
+      'CAC decreases 10% year-over-year',
+    ],
+  };
+  return JSON.stringify({ ...base, ...overrides });
+}
+
+describe('Constants', () => {
+  it('ROI_THRESHOLD is 0.25 (25%)', () => {
+    expect(ROI_THRESHOLD).toBe(0.25);
+  });
+
+  it('MAX_PAYBACK_MONTHS is 24', () => {
+    expect(MAX_PAYBACK_MONTHS).toBe(24);
+  });
+});
+
+describe('analyzeStage05', () => {
+  let mockComplete;
+  const logger = createMockLogger();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockComplete = vi.fn();
+    getLLMClient.mockReturnValue({ complete: mockComplete });
+  });
+
+  const validStage1Data = {
+    description: 'B2B SaaS for inventory management',
+    targetMarket: 'Small retail businesses',
+    problemStatement: 'Manual inventory tracking causes losses',
+  };
+
+  const validStage3Data = { overallScore: 72 };
+
+  const validStage4Data = {
+    competitors: [{ name: 'C1' }, { name: 'C2' }, { name: 'C3' }],
+    stage5Handoff: {
+      avgMarketPrice: '$50/mo',
+      pricingModels: ['subscription'],
+      priceRange: { low: 20, high: 100 },
+      competitiveDensity: 'medium',
+    },
+  };
+
+  it('throws when stage1Data is missing description', async () => {
+    await expect(
+      analyzeStage05({ stage1Data: {}, logger }),
+    ).rejects.toThrow('Stage 05 requires Stage 1 data');
+  });
+
+  it('returns pass decision when ROI exceeds threshold', async () => {
+    // High-revenue scenario: ROI will be well above 25%
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse());
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      stage3Data: validStage3Data,
+      stage4Data: validStage4Data,
+      ventureName: 'InvenTrack',
+      logger,
+    });
+
+    expect(result.decision).toBe('pass');
+    expect(result.blockProgression).toBe(false);
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it('returns kill decision when ROI is below threshold', async () => {
+    // Low-revenue scenario: revenue barely covers costs
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse({
+      initialInvestment: 500000,
+      year1: { revenue: 10000, cogs: 5000, opex: 8000 },
+      year2: { revenue: 15000, cogs: 7000, opex: 10000 },
+      year3: { revenue: 20000, cogs: 9000, opex: 12000 },
+    }));
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    expect(result.decision).toBe('kill');
+    expect(result.blockProgression).toBe(true);
+    expect(result.reasons.some(r => r.type === 'roi_below_threshold')).toBe(true);
+  });
+
+  it('flags no_break_even_year1 when Y1 net profit is negative', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse({
+      initialInvestment: 100000,
+      year1: { revenue: 10000, cogs: 5000, opex: 20000 }, // net = -15000
+      year2: { revenue: 200000, cogs: 50000, opex: 60000 },
+      year3: { revenue: 350000, cogs: 80000, opex: 80000 },
+    }));
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    expect(result.breakEvenMonth).toBeNull();
+    expect(result.reasons.some(r => r.type === 'no_break_even_year1')).toBe(true);
+  });
+
+  it('computes derived financial fields correctly', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse({
+      initialInvestment: 100000,
+      year1: { revenue: 200000, cogs: 60000, opex: 80000 },
+      year2: { revenue: 300000, cogs: 80000, opex: 100000 },
+      year3: { revenue: 400000, cogs: 100000, opex: 120000 },
+    }));
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    // Y1: GP = 200k-60k = 140k, NP = 140k-80k = 60k
+    expect(result.grossProfitY1).toBe(140000);
+    expect(result.netProfitY1).toBe(60000);
+
+    // Y2: GP = 300k-80k = 220k, NP = 220k-100k = 120k
+    expect(result.grossProfitY2).toBe(220000);
+    expect(result.netProfitY2).toBe(120000);
+
+    // Y3: GP = 400k-100k = 300k, NP = 300k-120k = 180k
+    expect(result.grossProfitY3).toBe(300000);
+    expect(result.netProfitY3).toBe(180000);
+
+    // ROI = (totalNP - initial) / initial = (360k - 100k) / 100k = 2.6
+    expect(result.roi3y).toBe(2.6);
+  });
+
+  it('computes breakEvenMonth from Y1 net profit', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse({
+      initialInvestment: 60000,
+      year1: { revenue: 200000, cogs: 60000, opex: 80000 }, // NP = 60k, monthly = 5k
+    }));
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    // breakEvenMonth = ceil(60000 / 5000) = 12
+    expect(result.breakEvenMonth).toBe(12);
+  });
+
+  it('uses fallback values for missing unit economics', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse({
+      unitEconomics: {}, // All fields missing
+    }));
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    // Fallback: cac=100, ltv=500
+    expect(result.unitEconomics.cac).toBe(100);
+    expect(result.unitEconomics.ltv).toBe(500);
+    expect(result.unitEconomics.monthlyChurn).toBe(0.05); // Default
+  });
+
+  it('clamps monthlyChurn between 0 and 1', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse({
+      unitEconomics: {
+        cac: 200,
+        ltv: 1000,
+        paybackMonths: 6,
+        monthlyChurn: 1.5, // Over 1
+      },
+    }));
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    expect(result.unitEconomics.monthlyChurn).toBeLessThanOrEqual(1);
+  });
+
+  it('computes ROI bands from base ROI', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse());
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    // Bands should be: pessimistic = roi * 0.8, optimistic = roi * 1.3
+    expect(result.roiBands.pessimistic).toBeCloseTo(result.roi3y * 0.8, 2);
+    expect(result.roiBands.base).toBeCloseTo(result.roi3y, 2);
+    expect(result.roiBands.optimistic).toBeCloseTo(result.roi3y * 1.3, 2);
+  });
+
+  it('preserves assumptions array from LLM response', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse());
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    expect(result.assumptions).toHaveLength(3);
+    expect(result.assumptions[0]).toContain('Market grows');
+  });
+
+  it('handles missing assumptions with empty array', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse({
+      assumptions: null,
+    }));
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    expect(result.assumptions).toEqual([]);
+  });
+
+  it('includes competitive pricing in prompt when stage4Data provided', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse());
+
+    await analyzeStage05({
+      stage1Data: validStage1Data,
+      stage4Data: validStage4Data,
+      logger,
+    });
+
+    const prompt = mockComplete.mock.calls[0][1];
+    expect(prompt).toContain('$50/mo');
+    expect(prompt).toContain('subscription');
+  });
+
+  it('handles missing stage4Data gracefully', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse());
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    expect(result).toBeDefined();
+    expect(result.decision).toBeDefined();
+  });
+
+  it('uses fallback for invalid initialInvestment', async () => {
+    mockComplete.mockResolvedValueOnce(makeFinancialResponse({
+      initialInvestment: -5000,
+    }));
+
+    const result = await analyzeStage05({
+      stage1Data: validStage1Data,
+      logger,
+    });
+
+    // Fallback is 10000
+    expect(result.initialInvestment).toBe(10000);
+  });
+});


### PR DESCRIPTION
## Summary
- Added 41 new unit tests across 3 test files for EVA analysis steps (stage-02, stage-04, stage-05)
- Fixed 2 production bugs: misplaced `logger.log` calls in helper functions that referenced out-of-scope variables
- All 41 tests passing

## Test plan
- [x] stage-02-multi-persona: 14 tests (PERSONAS structure, score clamping, normalization)
- [x] stage-04-competitive-landscape: 11 tests (MIN_COMPETITORS, threat normalization, stage5Handoff)
- [x] stage-05-financial-model: 16 tests (ROI threshold, kill gate, derived fields, unit economics)

SD: SD-EVA-R2-FIX-TEST-COVERAGE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)