### PR TITLE
refactor: rename db→supabase DI params and dedup parseJSON in EVA core

### DIFF
--- a/lib/eva/constraint-drift-detector.js
+++ b/lib/eva/constraint-drift-detector.js
@@ -40,7 +40,7 @@ const ASSUMPTION_CATEGORIES = [
  * @param {string} params.ventureId - Venture UUID
  * @param {number} params.currentStage - Current stage number
  * @param {number} [params.baselineStage=1] - Baseline stage (default: Stage 1)
- * @param {Object} params.db - Supabase client
+ * @param {Object} params.supabase - Supabase client
  * @param {Object} [params.logger=console] - Logger
  * @returns {Promise<Object>} Drift result
  */
@@ -48,12 +48,12 @@ export async function detectConstraintDrift({
   ventureId,
   currentStage,
   baselineStage = 1,
-  db,
+  supabase,
   logger = console,
 }) {
   try {
     // 1. Load baseline assumptions
-    const baseline = await loadBaselineAssumptions({ ventureId, baselineStage, db, logger });
+    const baseline = await loadBaselineAssumptions({ ventureId, baselineStage, supabase, logger });
     if (!baseline) {
       logger.info?.(
         `[ConstraintDrift] No baseline assumption_set for venture=${ventureId} stage=${baselineStage}`
@@ -70,7 +70,7 @@ export async function detectConstraintDrift({
     }
 
     // 2. Extract current-stage constraints from venture_artifacts
-    const current = await extractCurrentConstraints({ ventureId, currentStage, db, logger });
+    const current = await extractCurrentConstraints({ ventureId, currentStage, supabase, logger });
     if (!current.categories || Object.keys(current.categories).length === 0) {
       return {
         ventureId,
@@ -179,8 +179,8 @@ export function buildFilterEnginePayload(driftResult) {
 /**
  * Load baseline assumptions from assumption_sets table.
  */
-async function loadBaselineAssumptions({ ventureId, baselineStage, db }) {
-  const { data, error } = await db
+async function loadBaselineAssumptions({ ventureId, baselineStage, supabase }) {
+  const { data, error } = await supabase
     .from('assumption_sets')
     .select('id, market_assumptions, competitor_assumptions, product_assumptions, timing_assumptions, confidence_scores')
     .eq('venture_id', ventureId)
@@ -197,8 +197,8 @@ async function loadBaselineAssumptions({ ventureId, baselineStage, db }) {
 /**
  * Extract constraint-relevant content from venture_artifacts.
  */
-async function extractCurrentConstraints({ ventureId, currentStage, db }) {
-  const { data, error } = await db
+async function extractCurrentConstraints({ ventureId, currentStage, supabase }) {
+  const { data, error } = await supabase
     .from('venture_artifacts')
     .select('id, artifact_type, content, created_at')
     .eq('venture_id', ventureId)

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -204,7 +204,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     // Reality gates
     const realityGateResult = await evaluateRealityGateFn(
       { from: resolvedStage, to: nextStage, ventureId },
-      { db: supabase, httpClient, now: () => new Date() }
+      { supabase, httpClient, now: () => new Date() }
     );
     gateResults.push({ type: 'reality_gate', ...realityGateResult });
     if (!realityGateResult.passed) gateBlocked = true;
@@ -444,7 +444,7 @@ export async function run({ ventureId, options = {} }, deps = {}) {
           });
 
           if (resolution.status === 'approved') {
-            logger.log(`[Eva] Decision approved, continuing loop`);
+            logger.log('[Eva] Decision approved, continuing loop');
             continue; // Resume loop at next stage
           }
           logger.log(`[Eva] Decision ${resolution.status}, stopping loop`);

--- a/lib/eva/observability.js
+++ b/lib/eva/observability.js
@@ -134,18 +134,18 @@ export class OrchestratorTracer {
   /**
    * Persist the trace to the eva_trace_log table.
    *
-   * @param {Object} db - Supabase client
+   * @param {Object} supabase - Supabase client
    * @returns {Promise<{ persisted: boolean, id?: string, error?: string }>}
    */
-  async persistTrace(db) {
-    if (!db) {
+  async persistTrace(supabase) {
+    if (!supabase) {
       return { persisted: false, error: 'No database client provided' };
     }
 
     const trace = this.getTrace();
 
     try {
-      const { data, error } = await db
+      const { data, error } = await supabase
         .from('eva_trace_log')
         .insert({
           trace_id: trace.traceId,
@@ -178,12 +178,12 @@ export class OrchestratorTracer {
   /**
    * Persist events to the eva_events table (bulk insert).
    *
-   * @param {Object} db - Supabase client
+   * @param {Object} supabase - Supabase client
    * @returns {Promise<{ persisted: boolean, count: number, error?: string }>}
    */
-  async persistEvents(db) {
-    if (!db || this.events.length === 0) {
-      return { persisted: false, count: 0, error: !db ? 'No database client' : 'No events' };
+  async persistEvents(supabase) {
+    if (!supabase || this.events.length === 0) {
+      return { persisted: false, count: 0, error: !supabase ? 'No database client' : 'No events' };
     }
 
     try {
@@ -195,7 +195,7 @@ export class OrchestratorTracer {
         event_source: 'eva_orchestrator',
       }));
 
-      const { error } = await db.from('eva_events').insert(rows);
+      const { error } = await supabase.from('eva_events').insert(rows);
 
       if (error) {
         this.logger.warn(`[Tracer] Event persist failed: ${error.message}`);

--- a/lib/eva/orchestrator-state-machine.js
+++ b/lib/eva/orchestrator-state-machine.js
@@ -87,10 +87,10 @@ export function validateStateTransition(from, to) {
  * @param {Object} [options.logger] - Logger
  * @returns {Promise<{ acquired: boolean, lockId?: string, error?: string, previousState?: string }>}
  */
-export async function acquireProcessingLock(db, ventureId, options = {}) {
+export async function acquireProcessingLock(supabase, ventureId, options = {}) {
   const { correlationId, logger = console } = options;
 
-  if (!db || !ventureId) {
+  if (!supabase || !ventureId) {
     return { acquired: false, error: 'Missing db client or ventureId' };
   }
 
@@ -98,7 +98,7 @@ export async function acquireProcessingLock(db, ventureId, options = {}) {
 
   try {
     // Atomic conditional update: only succeed if current state is idle
-    const { data, error } = await db
+    const { data, error } = await supabase
       .from('eva_ventures')
       .update({
         orchestrator_state: ORCHESTRATOR_STATES.PROCESSING,
@@ -112,7 +112,7 @@ export async function acquireProcessingLock(db, ventureId, options = {}) {
 
     if (error || !data) {
       // Check current state for diagnostics
-      const { data: current } = await db
+      const { data: current } = await supabase
         .from('eva_ventures')
         .select('orchestrator_state')
         .eq('id', ventureId)
@@ -139,7 +139,7 @@ export async function acquireProcessingLock(db, ventureId, options = {}) {
 /**
  * Release a processing lock, transitioning back to idle (or to a specified state).
  *
- * @param {Object} db - Supabase client
+ * @param {Object} supabase - Supabase client
  * @param {string} ventureId - Venture UUID
  * @param {Object} [options]
  * @param {string} [options.lockId] - Expected lock ID (safety check)
@@ -147,14 +147,14 @@ export async function acquireProcessingLock(db, ventureId, options = {}) {
  * @param {Object} [options.logger] - Logger
  * @returns {Promise<{ released: boolean, newState?: string, error?: string }>}
  */
-export async function releaseProcessingLock(db, ventureId, options = {}) {
+export async function releaseProcessingLock(supabase, ventureId, options = {}) {
   const {
     lockId,
     targetState = ORCHESTRATOR_STATES.IDLE,
     logger = console,
   } = options;
 
-  if (!db || !ventureId) {
+  if (!supabase || !ventureId) {
     return { released: false, error: 'Missing db client or ventureId' };
   }
 
@@ -165,7 +165,7 @@ export async function releaseProcessingLock(db, ventureId, options = {}) {
   }
 
   try {
-    let query = db
+    let query = supabase
       .from('eva_ventures')
       .update({
         orchestrator_state: targetState,
@@ -200,17 +200,17 @@ export async function releaseProcessingLock(db, ventureId, options = {}) {
 /**
  * Get the current orchestrator state for a venture.
  *
- * @param {Object} db - Supabase client
+ * @param {Object} supabase - Supabase client
  * @param {string} ventureId - Venture UUID
  * @returns {Promise<{ state: string, lockId?: string, lockAcquiredAt?: string, error?: string }>}
  */
-export async function getOrchestratorState(db, ventureId) {
-  if (!db || !ventureId) {
+export async function getOrchestratorState(supabase, ventureId) {
+  if (!supabase || !ventureId) {
     return { state: ORCHESTRATOR_STATES.IDLE, error: 'Missing db client or ventureId' };
   }
 
   try {
-    const { data, error } = await db
+    const { data, error } = await supabase
       .from('eva_ventures')
       .select('orchestrator_state, orchestrator_lock_id, orchestrator_lock_acquired_at')
       .eq('id', ventureId)

--- a/lib/eva/reality-gates.js
+++ b/lib/eva/reality-gates.js
@@ -88,7 +88,7 @@ const MAX_URL_RETRIES = 1; // Single retry on network timeout only
  * @param {string} params.ventureId - Venture UUID
  * @param {number} params.fromStage - Current stage number
  * @param {number} params.toStage - Target stage number
- * @param {Object} params.db - Database client with .from().select()... API
+ * @param {Object} params.supabase - Supabase client with .from().select()... API
  * @param {Function} [params.httpClient] - async (url, opts) => { status, ok }
  * @param {Function} [params.now] - () => Date (defaults to () => new Date())
  * @param {Object} [params.logger] - { info, warn, error } (defaults to console)
@@ -101,7 +101,7 @@ async function evaluateRealityGate({
   ventureId,
   fromStage,
   toStage,
-  db,
+  supabase,
   httpClient,
   now = () => new Date(),
   logger = console,
@@ -138,11 +138,11 @@ async function evaluateRealityGate({
     return result;
   }
 
-  if (!db) {
+  if (!supabase) {
     result.status = 'FAIL';
     result.reasons.push({
       code: REASON_CODES.CONFIG_ERROR,
-      message: 'Database client (db) is required for Reality Gate evaluation',
+      message: 'Database client (supabase) is required for Reality Gate evaluation',
     });
     return result;
   }
@@ -151,7 +151,7 @@ async function evaluateRealityGate({
   let artifacts;
   try {
     const artifactTypes = config.required_artifacts.map(a => a.artifact_type);
-    const { data, error } = await db
+    const { data, error } = await supabase
       .from('venture_artifacts')
       .select('artifact_type, quality_score, file_url, is_current')
       .eq('venture_id', ventureId)

--- a/lib/eva/saga-coordinator.js
+++ b/lib/eva/saga-coordinator.js
@@ -126,17 +126,17 @@ export class SagaCoordinator {
   /**
    * Persist saga execution log to eva_saga_log table.
    *
-   * @param {Object} db - Supabase client
+   * @param {Object} supabase - Supabase client
    * @param {Object} result - Result from execute()
    * @returns {Promise<{ persisted: boolean, id?: string, error?: string }>}
    */
-  async persistLog(db, result) {
-    if (!db) {
+  async persistLog(supabase, result) {
+    if (!supabase) {
       return { persisted: false, error: 'No database client provided' };
     }
 
     try {
-      const { data, error } = await db
+      const { data, error } = await supabase
         .from('eva_saga_log')
         .insert({
           saga_id: this.sagaId,
@@ -174,14 +174,14 @@ export class SagaCoordinator {
 /**
  * Create a compensation function that marks artifacts as not current.
  *
- * @param {Object} db - Supabase client
+ * @param {Object} supabase - Supabase client
  * @param {string[]} artifactIds - IDs of artifacts to roll back
  * @returns {Function}
  */
-export function createArtifactCompensation(db, artifactIds) {
+export function createArtifactCompensation(supabase, artifactIds) {
   return async () => {
-    if (!db || !artifactIds || artifactIds.length === 0) return;
-    const { error } = await db
+    if (!supabase || !artifactIds || artifactIds.length === 0) return;
+    const { error } = await supabase
       .from('venture_artifacts')
       .update({ is_current: false })
       .in('id', artifactIds);
@@ -192,15 +192,15 @@ export function createArtifactCompensation(db, artifactIds) {
 /**
  * Create a compensation function that reverts stage advancement.
  *
- * @param {Object} db - Supabase client
+ * @param {Object} supabase - Supabase client
  * @param {string} ventureId - Venture UUID
  * @param {number} previousStage - Stage to revert to
  * @returns {Function}
  */
-export function createStageCompensation(db, ventureId, previousStage) {
+export function createStageCompensation(supabase, ventureId, previousStage) {
   return async () => {
-    if (!db || !ventureId) return;
-    const { error } = await db
+    if (!supabase || !ventureId) return;
+    const { error } = await supabase
       .from('ventures')
       .update({ current_lifecycle_stage: previousStage })
       .eq('id', ventureId);

--- a/lib/eva/stage-templates/analysis-steps/stage-15-risk-register.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-risk-register.js
@@ -10,6 +10,7 @@
  */
 
 import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON } from '../../utils/parse-json.js';
 
 const MIN_RISKS = 1;
 const SEVERITY_ENUM = ['critical', 'high', 'medium', 'low'];
@@ -128,16 +129,6 @@ Output ONLY valid JSON.`;
       notes: `${risks.length} risk(s) identified with mitigation plans`,
     },
   };
-}
-
-function parseJSON(text) {
-  const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
-  try {
-    return JSON.parse(cleaned);
-  } catch (error) {
-    logger.error('[Stage15] Analysis failed', { error: error.message, duration: Date.now() - startTime });
-    throw new Error(`Failed to parse risk register response: ${cleaned.substring(0, 200)}`);
-  }
 }
 
 export { MIN_RISKS, SEVERITY_ENUM, PRIORITY_ENUM };

--- a/tests/unit/eva/constraint-drift-detector.test.js
+++ b/tests/unit/eva/constraint-drift-detector.test.js
@@ -214,7 +214,7 @@ describe('detectConstraintDrift', () => {
     const result = await detectConstraintDrift({
       ventureId: 'v-1',
       currentStage: 10,
-      db,
+      supabase: db,
       logger,
     });
 
@@ -239,7 +239,7 @@ describe('detectConstraintDrift', () => {
     const result = await detectConstraintDrift({
       ventureId: 'v-1',
       currentStage: 10,
-      db,
+      supabase: db,
       logger,
     });
 
@@ -270,7 +270,7 @@ describe('detectConstraintDrift', () => {
     const result = await detectConstraintDrift({
       ventureId: 'v-1',
       currentStage: 25,
-      db,
+      supabase: db,
       logger,
     });
 
@@ -301,7 +301,7 @@ describe('detectConstraintDrift', () => {
     const result = await detectConstraintDrift({
       ventureId: 'v-1',
       currentStage: 10,
-      db,
+      supabase: db,
       logger,
     });
 
@@ -317,7 +317,7 @@ describe('detectConstraintDrift', () => {
     const result = await detectConstraintDrift({
       ventureId: 'v-1',
       currentStage: 10,
-      db,
+      supabase: db,
       logger,
     });
 
@@ -354,7 +354,7 @@ describe('detectConstraintDrift', () => {
     const result = await detectConstraintDrift({
       ventureId: 'v-1',
       currentStage: 15,
-      db,
+      supabase: db,
       logger,
     });
 

--- a/tests/unit/eva/reality-gates.test.js
+++ b/tests/unit/eva/reality-gates.test.js
@@ -73,7 +73,7 @@ describe('RealityGates', () => {
         ventureId: 'v1',
         fromStage: 1,
         toStage: 2,
-        db: createMockDb(),
+        supabase: createMockDb(),
         logger: silentLogger,
       });
       expect(result.status).toBe('NOT_APPLICABLE');
@@ -87,19 +87,19 @@ describe('RealityGates', () => {
         ventureId: null,
         fromStage: 5,
         toStage: 6,
-        db: createMockDb(),
+        supabase: createMockDb(),
         logger: silentLogger,
       });
       expect(result.status).toBe('FAIL');
       expect(result.reasons[0].code).toBe(REASON_CODES.CONFIG_ERROR);
     });
 
-    it('should FAIL when db is missing', async () => {
+    it('should FAIL when supabase is missing', async () => {
       const result = await evaluateRealityGate({
         ventureId: 'v1',
         fromStage: 5,
         toStage: 6,
-        db: null,
+        supabase: null,
         logger: silentLogger,
       });
       expect(result.status).toBe('FAIL');
@@ -118,7 +118,7 @@ describe('RealityGates', () => {
         ventureId: 'v1',
         fromStage: 5,
         toStage: 6,
-        db: createMockDb(artifacts),
+        supabase: createMockDb(artifacts),
         logger: silentLogger,
       });
       expect(result.status).toBe('PASS');
@@ -133,7 +133,7 @@ describe('RealityGates', () => {
         ventureId: 'v1',
         fromStage: 5,
         toStage: 6,
-        db: createMockDb(artifacts),
+        supabase: createMockDb(artifacts),
         logger: silentLogger,
       });
       expect(result.status).toBe('FAIL');
@@ -151,7 +151,7 @@ describe('RealityGates', () => {
         ventureId: 'v1',
         fromStage: 5,
         toStage: 6,
-        db: createMockDb(artifacts),
+        supabase: createMockDb(artifacts),
         logger: silentLogger,
       });
       expect(result.status).toBe('FAIL');
@@ -169,7 +169,7 @@ describe('RealityGates', () => {
         ventureId: 'v1',
         fromStage: 5,
         toStage: 6,
-        db: createMockDb(artifacts),
+        supabase: createMockDb(artifacts),
         logger: silentLogger,
       });
       expect(result.status).toBe('FAIL');
@@ -184,7 +184,7 @@ describe('RealityGates', () => {
         ventureId: 'v1',
         fromStage: 5,
         toStage: 6,
-        db: createErrorDb('Connection timeout'),
+        supabase: createErrorDb('Connection timeout'),
         logger: silentLogger,
       });
       expect(result.status).toBe('FAIL');
@@ -204,7 +204,7 @@ describe('RealityGates', () => {
         ventureId: 'v1',
         fromStage: 16,
         toStage: 17,
-        db: createMockDb(artifacts),
+        supabase: createMockDb(artifacts),
         httpClient,
         logger: silentLogger,
       });
@@ -223,7 +223,7 @@ describe('RealityGates', () => {
         ventureId: 'v1',
         fromStage: 16,
         toStage: 17,
-        db: createMockDb(artifacts),
+        supabase: createMockDb(artifacts),
         httpClient,
         logger: silentLogger,
       });


### PR DESCRIPTION
## Summary
- Renamed `db` → `supabase` parameter in 5 EVA core modules (observability, saga-coordinator, orchestrator-state-machine, reality-gates, constraint-drift-detector) for naming consistency
- Updated call site in eva-orchestrator.js
- Removed duplicate `parseJSON` from stage-15-risk-register.js, now imports shared utility
- Updated corresponding test files (reality-gates, constraint-drift-detector)

## Test plan
- [x] 130 unit tests pass (reality-gates: 20, orchestrator-state-machine: 42, constraint-drift-detector: 35, saga-coordinator: 33)
- [x] 15 smoke tests pass
- [x] ESLint auto-fix clean
- [x] No secret detection violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)