### PR TITLE
feat(eva): add web-grounded search to stages 4, 5, 7, 11

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js
@@ -11,6 +11,7 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 
 const MIN_COMPETITORS = 3;
 
@@ -74,6 +75,19 @@ export async function analyzeStage04({ stage1Data, stage3Data, ventureName, logg
 
   const client = getLLMClient({ purpose: 'content-generation' });
 
+  // Web-grounded search for competitor intelligence
+  let webContext = '';
+  if (isSearchEnabled()) {
+    const queries = [
+      `${stage1Data.targetMarket || ventureName} competitors market landscape 2024 2025`,
+      `${stage1Data.description?.substring(0, 80)} alternative solutions pricing`,
+      `${stage1Data.targetMarket || 'SaaS'} market size competitive analysis`,
+    ];
+    logger.log('[Stage04] Running web search', { queryCount: queries.length });
+    const webResults = await searchBatch(queries, { logger });
+    webContext = formatResultsForPrompt(webResults, 'Competitive Intelligence Research');
+  }
+
   const userPrompt = `Analyze the competitive landscape for this venture.
 
 Venture: ${ventureName || 'Unnamed'}
@@ -83,7 +97,7 @@ Target Market: ${stage1Data.targetMarket}
 Problem: ${stage1Data.problemStatement || 'N/A'}
 ${stage3Data?.overallScore ? `Validation Score: ${stage3Data.overallScore}/100` : ''}
 ${stage3Data?.competitiveBarrier !== undefined ? `Competitive Barrier Score: ${stage3Data.competitiveBarrier}/100` : ''}
-
+${webContext}
 Find at least ${MIN_COMPETITORS} competitors. Include pricing details for each.
 Output ONLY valid JSON.`;
 

--- a/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
@@ -14,6 +14,7 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 
 const ROI_THRESHOLD = 0.25;
 const MAX_PAYBACK_MONTHS = 24;
@@ -80,6 +81,18 @@ export async function analyzeStage05({ stage1Data, stage3Data, stage4Data, ventu
   Competitive density: ${stage4Data.stage5Handoff.competitiveDensity}`
     : 'No competitive pricing data available';
 
+  // Web-grounded search for financial benchmarks
+  let webContext = '';
+  if (isSearchEnabled()) {
+    const queries = [
+      `${stage1Data.targetMarket || ventureName} industry benchmarks revenue growth 2024 2025`,
+      `${stage1Data.targetMarket || 'SaaS'} unit economics CAC LTV benchmarks`,
+    ];
+    logger.log('[Stage05] Running web search', { queryCount: queries.length });
+    const webResults = await searchBatch(queries, { logger });
+    webContext = formatResultsForPrompt(webResults, 'Financial Benchmark Research');
+  }
+
   const userPrompt = `Generate a 3-year financial model for this venture.
 
 Venture: ${ventureName || 'Unnamed'}
@@ -91,7 +104,7 @@ ${stage3Data?.overallScore ? `Validation Score: ${stage3Data.overallScore}/100` 
 ${pricingContext}
 
 ${stage4Data?.competitors ? `Number of competitors: ${stage4Data.competitors.length}` : ''}
-
+${webContext}
 Output ONLY valid JSON.`;
 
   const response = await client.complete(SYSTEM_PROMPT, userPrompt);

--- a/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
@@ -11,6 +11,7 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 
 const PRICING_MODELS = [
   'freemium', 'subscription', 'usage_based', 'per_seat', 'marketplace_commission', 'one_time',
@@ -96,6 +97,18 @@ export async function analyzeStage07({ stage1Data, stage4Data, stage5Data, stage
     ? `Risk Profile: ${stage6Data.totalRisks} risks, ${stage6Data.highRiskCount} high-risk (score >= 15)`
     : '';
 
+  // Web-grounded search for pricing intelligence
+  let webContext = '';
+  if (isSearchEnabled()) {
+    const queries = [
+      `${stage1Data.targetMarket || ventureName} SaaS pricing models benchmarks 2024 2025`,
+      `${stage1Data.description?.substring(0, 80)} pricing strategy competitive pricing`,
+    ];
+    logger.log('[Stage07] Running web search', { queryCount: queries.length });
+    const webResults = await searchBatch(queries, { logger });
+    webContext = formatResultsForPrompt(webResults, 'Pricing Intelligence Research');
+  }
+
   const userPrompt = `Generate a pricing strategy for this venture.
 
 Venture: ${ventureName || 'Unnamed'}
@@ -108,7 +121,7 @@ ${competitiveContext}
 ${financialContext}
 
 ${riskContext}
-
+${webContext}
 Output ONLY valid JSON.`;
 
   const response = await client.complete(SYSTEM_PROMPT, userPrompt);

--- a/lib/eva/stage-templates/analysis-steps/stage-11-gtm.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-gtm.js
@@ -10,6 +10,7 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 
 const REQUIRED_TIERS = 3;
 const REQUIRED_CHANNELS = 8;
@@ -88,6 +89,19 @@ export async function analyzeStage11({ stage1Data, stage5Data, stage10Data, vent
     ? `Financial: Initial Investment $${stage5Data.initialInvestment || 'N/A'}, Year 1 Revenue $${stage5Data.year1?.revenue || 'N/A'}`
     : '';
 
+  // Web-grounded search for GTM intelligence
+  let webContext = '';
+  if (isSearchEnabled()) {
+    const queries = [
+      `${stage1Data.targetMarket || ventureName} go to market strategy channels 2024 2025`,
+      `${stage1Data.targetMarket || 'SaaS'} customer acquisition channels CAC benchmarks`,
+      `${stage1Data.description?.substring(0, 80)} market entry strategy`,
+    ];
+    logger.log('[Stage11] Running web search', { queryCount: queries.length });
+    const webResults = await searchBatch(queries, { logger });
+    webContext = formatResultsForPrompt(webResults, 'GTM Intelligence Research');
+  }
+
   const userPrompt = `Generate a Go-To-Market strategy for this venture.
 
 Venture: ${ventureName || 'Unnamed'}
@@ -96,7 +110,7 @@ Target Market: ${stage1Data.targetMarket || 'N/A'}
 Problem: ${stage1Data.problemStatement || 'N/A'}
 ${brandContext}
 ${financialContext}
-
+${webContext}
 Output ONLY valid JSON.`;
 
   const response = await client.complete(SYSTEM_PROMPT, userPrompt);

--- a/lib/eva/utils/web-search.js
+++ b/lib/eva/utils/web-search.js
@@ -1,0 +1,200 @@
+/**
+ * Web Search Client - Tavily API Integration for EVA
+ * Part of SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-A
+ *
+ * Provides web-grounded search results for EVA analysis steps.
+ * Feature-flagged via SEARCH_ENABLED env var with graceful degradation.
+ *
+ * @module lib/eva/utils/web-search
+ */
+
+const DEFAULT_CACHE_TTL_MS = 3_600_000; // 1 hour
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_RESULTS = 5;
+const MAX_CACHE_SIZE = 1000;
+
+/**
+ * In-memory TTL cache for search results.
+ * Keys are query hashes, values are { results, expiresAt }.
+ */
+const cache = new Map();
+
+/**
+ * Check if web search is enabled via environment variables.
+ * @returns {boolean}
+ */
+export function isSearchEnabled() {
+  return process.env.SEARCH_ENABLED === 'true' && !!process.env.TAVILY_API_KEY;
+}
+
+/**
+ * Generate a cache key from query string.
+ * @param {string} query
+ * @returns {string}
+ */
+function cacheKey(query) {
+  return query.trim().toLowerCase();
+}
+
+/**
+ * Evict expired entries and enforce max cache size.
+ */
+function evictStale() {
+  const now = Date.now();
+  for (const [key, entry] of cache) {
+    if (entry.expiresAt <= now) cache.delete(key);
+  }
+  // If still over limit, remove oldest entries
+  if (cache.size > MAX_CACHE_SIZE) {
+    const excess = cache.size - MAX_CACHE_SIZE;
+    const keys = [...cache.keys()];
+    for (let i = 0; i < excess; i++) cache.delete(keys[i]);
+  }
+}
+
+/**
+ * Execute a single web search query via Tavily API.
+ *
+ * @param {string} query - Search query
+ * @param {Object} [options]
+ * @param {number} [options.maxResults=5] - Max results to return
+ * @param {string} [options.searchDepth='basic'] - 'basic' or 'advanced'
+ * @param {number} [options.timeoutMs] - Per-query timeout
+ * @param {number} [options.cacheTtlMs] - Cache TTL override
+ * @param {Object} [options.logger=console] - Logger instance
+ * @returns {Promise<Array<{title: string, url: string, content: string, score: number}>>}
+ */
+export async function search(query, options = {}) {
+  const {
+    maxResults = DEFAULT_MAX_RESULTS,
+    searchDepth = 'basic',
+    timeoutMs = Number(process.env.SEARCH_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS,
+    cacheTtlMs = Number(process.env.SEARCH_CACHE_TTL_MS) || DEFAULT_CACHE_TTL_MS,
+    logger = console,
+  } = options;
+
+  if (!isSearchEnabled()) {
+    return [];
+  }
+
+  const key = cacheKey(query);
+
+  // Check cache
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > Date.now()) {
+    logger.log('[WebSearch] Cache hit:', query.substring(0, 60));
+    return cached.results;
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch('https://api.tavily.com/search', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        api_key: process.env.TAVILY_API_KEY,
+        query,
+        max_results: maxResults,
+        search_depth: searchDepth,
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      logger.log(`[WebSearch] API error ${response.status} for: ${query.substring(0, 60)}`);
+      return [];
+    }
+
+    const data = await response.json();
+    const results = (data.results || []).map(r => ({
+      title: r.title || '',
+      url: r.url || '',
+      content: r.content || '',
+      score: r.score || 0,
+    }));
+
+    // Cache results
+    evictStale();
+    cache.set(key, { results, expiresAt: Date.now() + cacheTtlMs });
+
+    logger.log(`[WebSearch] ${results.length} results for: ${query.substring(0, 60)}`);
+    return results;
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      logger.log(`[WebSearch] Timeout (${timeoutMs}ms) for: ${query.substring(0, 60)}`);
+    } else {
+      logger.log(`[WebSearch] Error for "${query.substring(0, 60)}": ${err.message}`);
+    }
+    return [];
+  }
+}
+
+/**
+ * Execute multiple search queries in parallel.
+ *
+ * @param {string[]} queries - Array of search queries
+ * @param {Object} [options] - Same options as search()
+ * @returns {Promise<Array<{title: string, url: string, content: string, score: number}>>}
+ */
+export async function searchBatch(queries, options = {}) {
+  if (!isSearchEnabled() || !queries || queries.length === 0) {
+    return [];
+  }
+
+  const results = await Promise.all(
+    queries.map(q => search(q, options))
+  );
+
+  // Flatten and deduplicate by URL
+  const seen = new Set();
+  const combined = [];
+  for (const batch of results) {
+    for (const item of batch) {
+      if (item.url && !seen.has(item.url)) {
+        seen.add(item.url);
+        combined.push(item);
+      }
+    }
+  }
+
+  return combined;
+}
+
+/**
+ * Format search results as context string for LLM prompt injection.
+ *
+ * @param {Array<{title: string, url: string, content: string}>} results
+ * @param {string} [label='Web Research']
+ * @returns {string}
+ */
+export function formatResultsForPrompt(results, label = 'Web Research') {
+  if (!results || results.length === 0) return '';
+
+  const lines = results.map((r, i) =>
+    `[${i + 1}] ${r.title}\n    Source: ${r.url}\n    ${r.content.substring(0, 300)}`
+  );
+
+  return `\n${label}:\n${lines.join('\n\n')}\n`;
+}
+
+/**
+ * Clear the search cache. Useful for testing.
+ */
+export function clearCache() {
+  cache.clear();
+}
+
+/**
+ * Get cache stats. Useful for monitoring.
+ * @returns {{size: number, maxSize: number}}
+ */
+export function getCacheStats() {
+  evictStale();
+  return { size: cache.size, maxSize: MAX_CACHE_SIZE };
+}

--- a/tests/unit/eva/utils/web-search.test.js
+++ b/tests/unit/eva/utils/web-search.test.js
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for Web Search Client - Tavily API Integration
+ * SD: SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-A
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  isSearchEnabled,
+  search,
+  searchBatch,
+  formatResultsForPrompt,
+  clearCache,
+  getCacheStats,
+} from '../../../../lib/eva/utils/web-search.js';
+
+function createMockLogger() {
+  return { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('web-search', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    clearCache();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  describe('isSearchEnabled', () => {
+    it('returns false when SEARCH_ENABLED is not set', () => {
+      delete process.env.SEARCH_ENABLED;
+      delete process.env.TAVILY_API_KEY;
+      expect(isSearchEnabled()).toBe(false);
+    });
+
+    it('returns false when SEARCH_ENABLED is false', () => {
+      process.env.SEARCH_ENABLED = 'false';
+      process.env.TAVILY_API_KEY = 'test-key';
+      expect(isSearchEnabled()).toBe(false);
+    });
+
+    it('returns false when TAVILY_API_KEY is missing', () => {
+      process.env.SEARCH_ENABLED = 'true';
+      delete process.env.TAVILY_API_KEY;
+      expect(isSearchEnabled()).toBe(false);
+    });
+
+    it('returns true when both env vars are set', () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+      expect(isSearchEnabled()).toBe(true);
+    });
+  });
+
+  describe('search', () => {
+    it('returns empty array when search is disabled', async () => {
+      delete process.env.SEARCH_ENABLED;
+      const results = await search('test query');
+      expect(results).toEqual([]);
+    });
+
+    it('calls Tavily API with correct parameters', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key-123';
+
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          results: [
+            { title: 'Result 1', url: 'https://example.com/1', content: 'Content 1', score: 0.9 },
+          ],
+        }),
+      };
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const logger = createMockLogger();
+      const results = await search('test query', { logger });
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        'https://api.tavily.com/search',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      const body = JSON.parse(globalThis.fetch.mock.calls[0][1].body);
+      expect(body.api_key).toBe('test-key-123');
+      expect(body.query).toBe('test query');
+      expect(body.max_results).toBe(5);
+      expect(body.search_depth).toBe('basic');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].title).toBe('Result 1');
+    });
+
+    it('returns empty array on API error', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+
+      const logger = createMockLogger();
+      const results = await search('test query', { logger });
+
+      expect(results).toEqual([]);
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('API error 500'));
+    });
+
+    it('returns empty array on timeout', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+
+      globalThis.fetch = vi.fn().mockRejectedValue(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+
+      const logger = createMockLogger();
+      const results = await search('test query', { timeoutMs: 100, logger });
+
+      expect(results).toEqual([]);
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('Timeout'));
+    });
+
+    it('caches results for subsequent calls', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          results: [{ title: 'Cached', url: 'https://example.com', content: 'C', score: 1 }],
+        }),
+      };
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const logger = createMockLogger();
+      await search('cache test', { logger });
+      await search('cache test', { logger });
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+      expect(logger.log).toHaveBeenCalledWith('[WebSearch] Cache hit:', expect.any(String));
+    });
+
+    it('normalizes cache keys (case insensitive, trimmed)', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          results: [{ title: 'T', url: 'https://a.com', content: 'C', score: 1 }],
+        }),
+      };
+      globalThis.fetch = vi.fn().mockResolvedValue(mockResponse);
+
+      const logger = createMockLogger();
+      await search('Hello World', { logger });
+      await search('  hello world  ', { logger });
+
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('searchBatch', () => {
+    it('returns empty array when disabled', async () => {
+      delete process.env.SEARCH_ENABLED;
+      const results = await searchBatch(['q1', 'q2']);
+      expect(results).toEqual([]);
+    });
+
+    it('returns empty for empty queries', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+      const results = await searchBatch([]);
+      expect(results).toEqual([]);
+    });
+
+    it('deduplicates results by URL', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+
+      const sharedUrl = 'https://example.com/shared';
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          results: [
+            { title: 'Shared', url: sharedUrl, content: 'Content', score: 0.8 },
+            { title: 'Unique', url: 'https://example.com/unique', content: 'U', score: 0.7 },
+          ],
+        }),
+      });
+
+      const logger = createMockLogger();
+      const results = await searchBatch(['q1', 'q2'], { logger });
+
+      const urlCounts = results.filter(r => r.url === sharedUrl);
+      expect(urlCounts).toHaveLength(1);
+    });
+  });
+
+  describe('formatResultsForPrompt', () => {
+    it('returns empty string for empty results', () => {
+      expect(formatResultsForPrompt([])).toBe('');
+      expect(formatResultsForPrompt(null)).toBe('');
+    });
+
+    it('formats results with numbered entries', () => {
+      const results = [
+        { title: 'Title 1', url: 'https://example.com/1', content: 'Content one' },
+        { title: 'Title 2', url: 'https://example.com/2', content: 'Content two' },
+      ];
+      const formatted = formatResultsForPrompt(results);
+      expect(formatted).toContain('[1] Title 1');
+      expect(formatted).toContain('[2] Title 2');
+      expect(formatted).toContain('Source: https://example.com/1');
+      expect(formatted).toContain('Web Research:');
+    });
+
+    it('uses custom label', () => {
+      const results = [{ title: 'T', url: 'u', content: 'c' }];
+      const formatted = formatResultsForPrompt(results, 'Custom Label');
+      expect(formatted).toContain('Custom Label:');
+    });
+
+    it('truncates long content to 300 chars', () => {
+      const longContent = 'A'.repeat(500);
+      const results = [{ title: 'T', url: 'u', content: longContent }];
+      const formatted = formatResultsForPrompt(results);
+      expect(formatted).not.toContain('A'.repeat(500));
+      expect(formatted).toContain('A'.repeat(300));
+    });
+  });
+
+  describe('clearCache and getCacheStats', () => {
+    it('starts with empty cache', () => {
+      expect(getCacheStats().size).toBe(0);
+    });
+
+    it('reports cache size after search', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ results: [] }),
+      });
+
+      const logger = createMockLogger();
+      await search('stats test', { logger });
+
+      expect(getCacheStats().size).toBe(1);
+      expect(getCacheStats().maxSize).toBe(1000);
+    });
+
+    it('clears cache completely', async () => {
+      process.env.SEARCH_ENABLED = 'true';
+      process.env.TAVILY_API_KEY = 'test-key';
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ results: [] }),
+      });
+
+      const logger = createMockLogger();
+      await search('clear test', { logger });
+      expect(getCacheStats().size).toBe(1);
+
+      clearCache();
+      expect(getCacheStats().size).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add Tavily API web search integration (`lib/eva/utils/web-search.js`) with in-memory TTL cache, abort timeout, and feature-flag graceful degradation
- Integrate web search into 4 EVA analysis steps: Stage 04 (competitive landscape), Stage 05 (financial model), Stage 07 (pricing strategy), Stage 11 (GTM)
- Each stage generates targeted search queries and injects web results into LLM prompts for grounded analysis
- 20 unit tests covering search, caching, batch dedup, formatting, and disabled mode

## Test plan
- [x] 20 unit tests pass (`npx vitest run tests/unit/eva/utils/web-search.test.js`)
- [ ] ESLint clean on new/modified files (pre-existing `startTime` warnings only)
- [ ] Verify stages degrade gracefully when `SEARCH_ENABLED` is not set (returns empty, no errors)

SD: SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)