### PR TITLE
fix: add json-summary reporter to vitest coverage config

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reportsDirectory: 'coverage',
+      reporter: ['text', 'json-summary', 'html'],
       include: [
         'lib/**/*.js',
         'scripts/**/*.js',


### PR DESCRIPTION
## Summary
- Added `json-summary` to vitest coverage reporters so `coverage-summary.json` is generated
- Without this, `GATE_TEST_COVERAGE_QUALITY` gate always fails (no coverage data file)

## Test plan
- [x] `npx vitest run --coverage` now generates `coverage/coverage-summary.json`
- [x] All smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)