### PR TITLE
feat(eva): add Four Buckets epistemic classification to all 25 analysis steps

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -530,13 +530,46 @@ async function persistArtifacts(supabase, ventureId, stageId, artifacts, idempot
       row.idempotency_key = idempotencyKey;
     }
 
-    const { data, error } = await supabase
+    // Four Buckets: populate epistemic columns when classification data is present
+    const fb = art.payload?.fourBuckets;
+    if (fb?.classifications?.length > 0) {
+      // Dominant bucket = highest count in summary
+      const s = fb.summary || {};
+      const bucketCounts = [
+        ['fact', s.facts || 0],
+        ['assumption', s.assumptions || 0],
+        ['simulation', s.simulations || 0],
+        ['unknown', s.unknowns || 0],
+      ];
+      bucketCounts.sort((a, b) => b[1] - a[1]);
+      row.epistemic_classification = bucketCounts[0][0];
+      row.epistemic_evidence = fb.classifications;
+    }
+
+    let insertError;
+    let data;
+    const insertResult = await supabase
       .from('venture_artifacts')
       .insert(row)
       .select('id')
       .single();
+    data = insertResult.data;
+    insertError = insertResult.error;
 
-    if (error) throw new Error(`Failed to persist artifact: ${error.message}`);
+    // Graceful degradation: if epistemic columns cause constraint violation, retry without them
+    if (insertError && row.epistemic_classification) {
+      delete row.epistemic_classification;
+      delete row.epistemic_evidence;
+      const retryResult = await supabase
+        .from('venture_artifacts')
+        .insert(row)
+        .select('id')
+        .single();
+      data = retryResult.data;
+      insertError = retryResult.error;
+    }
+
+    if (insertError) throw new Error(`Failed to persist artifact: ${insertError.message}`);
     ids.push(data.id);
   }
   return ids;

--- a/lib/eva/stage-templates/analysis-steps/stage-01-hydration.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-01-hydration.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const ARCHETYPES = [
   'saas', 'marketplace', 'deeptech', 'hardware', 'services', 'media', 'fintech',
@@ -67,8 +69,9 @@ ${templateHint}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize description (min 50 chars)
   const description = String(parsed.description || synthesis.description || '').substring(0, 2000);
@@ -123,6 +126,7 @@ Output ONLY valid JSON.`;
     moatStrategy,
     successCriteria,
     sourceProvenance,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
@@ -12,6 +12,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 /**
  * Persona definitions aligned to Stage 3 kill-gate metrics.
@@ -99,6 +101,7 @@ Problem Statement: ${stage1Data.problemStatement || 'Not specified'}`;
 
   // Run all personas (sequentially to avoid rate limits)
   const critiques = [];
+  let fourBuckets = { classifications: [], summary: { facts: 0, assumptions: 0, simulations: 0, unknowns: 0 } };
   for (const persona of PERSONAS) {
     const userPrompt = `Evaluate this venture as the "${persona.name}" persona.
 Your focus area: ${persona.focus}
@@ -107,8 +110,9 @@ ${ventureContext}
 
 Output ONLY valid JSON.`;
 
-    const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+    const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
     const parsed = parseJSON(response);
+    fourBuckets = parseFourBuckets(parsed, { logger });
 
     critiques.push({
       model: persona.id,
@@ -124,7 +128,7 @@ Output ONLY valid JSON.`;
   const compositeScore = Math.round(sum / critiques.length);
 
   logger.log('[Stage02] Analysis complete', { duration: Date.now() - startTime });
-  return { critiques, compositeScore };
+  return { critiques, compositeScore, fourBuckets };
 }
 
 /**

--- a/lib/eva/stage-templates/analysis-steps/stage-03-hybrid-scoring.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-03-hybrid-scoring.js
@@ -15,6 +15,8 @@
 import { getLLMClient } from '../../../llm/index.js';
 import { METRICS } from '../stage-03.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const KILL_THRESHOLD = 40;
 
@@ -55,7 +57,7 @@ export async function analyzeStage03({ stage1Data, stage2Data, ventureName, logg
   const deterministicScores = extractDeterministicScores(stage2Data.critiques);
 
   // Get independent AI scores
-  const aiScores = await getAIScores({ stage1Data, stage2Data, ventureName });
+  const { scores: aiScores, fourBuckets } = await getAIScores({ stage1Data, stage2Data, ventureName });
 
   // Blend 50/50
   const blended = {};
@@ -104,6 +106,7 @@ export async function analyzeStage03({ stage1Data, stage2Data, ventureName, logg
       ai: aiScores,
       weights: { deterministic: 0.5, ai: 0.5 },
     },
+    fourBuckets,
   };
 }
 
@@ -150,14 +153,15 @@ Prior persona composite: ${stage2Data?.compositeScore ?? 'N/A'}/100
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed);
 
   const scores = {};
   for (const metric of METRICS) {
     scores[metric] = clampScore(parsed[metric]);
   }
-  return scores;
+  return { scores, fourBuckets };
 }
 
 function clampScore(score) {

--- a/lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-04-competitive-landscape.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 
 const MIN_COMPETITORS = 3;
@@ -101,8 +103,9 @@ ${webContext}
 Find at least ${MIN_COMPETITORS} competitors. Include pricing details for each.
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Validate minimum competitors
   if (!Array.isArray(parsed.competitors) || parsed.competitors.length < MIN_COMPETITORS) {
@@ -128,7 +131,7 @@ Output ONLY valid JSON.`;
   // Build stage5Handoff
   const stage5Handoff = parsed.stage5Handoff || buildStage5Handoff(competitors);
 
-  return { competitors, stage5Handoff };
+  return { competitors, stage5Handoff, fourBuckets };
 }
 
 /**

--- a/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
@@ -14,6 +14,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 
 const ROI_THRESHOLD = 0.25;
@@ -107,8 +109,9 @@ ${stage4Data?.competitors ? `Number of competitors: ${stage4Data.competitors.len
 ${webContext}
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Extract and validate core financials
   const model = {
@@ -196,6 +199,7 @@ Output ONLY valid JSON.`;
     },
     roiBands,
     assumptions: Array.isArray(parsed.assumptions) ? parsed.assumptions : [],
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-06-risk-matrix.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-06-risk-matrix.js
@@ -10,6 +10,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const MIN_RISKS = 8;
 const MIN_CATEGORIES = 3;
@@ -102,8 +104,9 @@ ${competitiveContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   if (!Array.isArray(parsed.risks) || parsed.risks.length === 0) {
     throw new Error('Stage 06 risk matrix: LLM returned no risks');
@@ -142,6 +145,7 @@ Output ONLY valid JSON.`;
     highRiskCount,
     totalRisks: risks.length,
     categoryCoverage: Object.keys(risksByCategory).length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 
 const PRICING_MODELS = [
@@ -124,8 +126,9 @@ ${riskContext}
 ${webContext}
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize pricingModel
   const pricingModel = PRICING_MODELS.includes(parsed.pricingModel)
@@ -172,6 +175,7 @@ Output ONLY valid JSON.`;
     tiers,
     unitEconomics,
     rationale: String(parsed.rationale || ''),
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-08-bmc-generation.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-08-bmc-generation.js
@@ -10,6 +10,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const BMC_BLOCKS = [
   'customerSegments',
@@ -112,8 +114,9 @@ ${financialContext}
 
 Output ONLY valid JSON with all 9 BMC blocks.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize all 9 blocks
   const result = {};
@@ -141,6 +144,7 @@ Output ONLY valid JSON with all 9 BMC blocks.`;
   }
 
   logger.log('[Stage08] Analysis complete', { duration: Date.now() - startTime });
+  result.fourBuckets = fourBuckets;
   return result;
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-09-exit-strategy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-09-exit-strategy.js
@@ -10,6 +10,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const EXIT_TYPES = ['acquisition', 'ipo', 'merger', 'mbo', 'liquidation'];
 
@@ -116,8 +118,9 @@ Revenue base for valuation: $${revenueBase}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize exit paths
   const exit_paths = Array.isArray(parsed.exit_paths) ? parsed.exit_paths.map(p => ({
@@ -166,6 +169,7 @@ Output ONLY valid JSON.`;
     target_acquirers,
     valuationEstimate,
     milestones,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-10-naming-brand.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-10-naming-brand.js
@@ -10,6 +10,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const MIN_CANDIDATES = 5;
 const MIN_CRITERIA = 3;
@@ -112,8 +114,9 @@ ${bmcContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize brand genome
   const brandGenome = {
@@ -228,6 +231,7 @@ Output ONLY valid JSON.`;
     decision,
     totalCandidates: candidates.length,
     totalCriteria: scoringCriteria.length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-11-gtm.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-gtm.js
@@ -10,6 +10,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
 
 const REQUIRED_TIERS = 3;
@@ -113,8 +115,9 @@ ${financialContext}
 ${webContext}
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize tiers (exactly 3)
   let tiers = Array.isArray(parsed.tiers) ? parsed.tiers : [];
@@ -205,6 +208,7 @@ Output ONLY valid JSON.`;
     channelCount: channels.length,
     activeChannelCount: activeChannels.length,
     backlogChannelCount: backlogChannels.length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js
@@ -10,6 +10,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const VALID_SALES_MODELS = ['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel'];
 const MIN_FUNNEL_STAGES = 4;
@@ -108,8 +110,9 @@ ${pricingContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize sales model
   const sales_model = VALID_SALES_MODELS.includes(parsed.sales_model)
@@ -216,6 +219,7 @@ Output ONLY valid JSON.`;
       avgConversionRate,
       pricingAvailable: !!stage7Data,
     },
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js
@@ -10,6 +10,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const MIN_MILESTONES = 3;
 const VALID_PRIORITIES = ['now', 'next', 'later'];
@@ -95,8 +97,9 @@ ${exitContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   if (!Array.isArray(parsed.milestones) || parsed.milestones.length === 0) {
     throw new Error('Stage 13 product roadmap: LLM returned no milestones');
@@ -140,6 +143,7 @@ Output ONLY valid JSON.`;
     priorityCounts,
     totalMilestones: milestones.length,
     totalPhases: phases.length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-14-technical-architecture.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-14-technical-architecture.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const REQUIRED_LAYERS = ['presentation', 'api', 'business_logic', 'data', 'infrastructure'];
 const CONSTRAINT_CATEGORIES = ['performance', 'security', 'compliance', 'operational'];
@@ -123,8 +125,9 @@ ${roadmapContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Validate layers
   if (!parsed.layers || typeof parsed.layers !== 'object') {
@@ -206,6 +209,7 @@ Output ONLY valid JSON.`;
     totalComponents: Object.values(layers).reduce((sum, l) => sum + l.components.length, 0),
     allLayersDefined: REQUIRED_LAYERS.every(l => layers[l] && layers[l].technology !== 'TBD'),
     entityCount: dataEntities.length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-15-risk-register.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-15-risk-register.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const MIN_RISKS = 1;
 const SEVERITY_ENUM = ['critical', 'high', 'medium', 'low'];
@@ -95,8 +97,9 @@ ${archContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   if (!Array.isArray(parsed.risks) || parsed.risks.length === 0) {
     throw new Error('Stage 15 risk register: LLM returned no risks');
@@ -128,6 +131,7 @@ Output ONLY valid JSON.`;
       aligned: true,
       notes: `${risks.length} risk(s) identified with mitigation plans`,
     },
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const MIN_PROJECTION_MONTHS = 6;
 
@@ -115,8 +117,9 @@ ${riskContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Validate initial_capital
   const initial_capital = Math.max(0, Number(parsed.initial_capital) || 0);
@@ -181,6 +184,7 @@ Output ONLY valid JSON.`;
     totalProjectedRevenue: revenue_projections.reduce((sum, rp) => sum + rp.revenue, 0),
     totalProjectedCosts: revenue_projections.reduce((sum, rp) => sum + rp.costs, 0),
     projectionMonths: revenue_projections.length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-17-build-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-build-readiness.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const READINESS_DECISIONS = ['go', 'conditional_go', 'no_go'];
 const PRIORITY_LEVELS = ['critical', 'high', 'medium', 'low'];
@@ -100,8 +102,9 @@ ${financialContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize readiness items
   let readinessItems = Array.isArray(parsed.readinessItems)
@@ -154,6 +157,7 @@ Output ONLY valid JSON.`;
     totalItems: readinessItems.length,
     completedItems: readinessItems.filter(i => i.status === 'complete').length,
     blockerCount: blockers.length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];
@@ -86,8 +88,9 @@ ${archContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize sprint goal
   const sprintGoal = String(parsed.sprintGoal || 'Complete initial build sprint').substring(0, 300);
@@ -131,6 +134,7 @@ Output ONLY valid JSON.`;
     sprintItems,
     totalItems: sprintItems.length,
     totalEstimatedLoc: sprintItems.reduce((sum, i) => sum + i.estimatedLoc, 0),
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
 const ISSUE_SEVERITIES = ['critical', 'high', 'medium', 'low'];
@@ -89,8 +91,9 @@ ${readinessContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize tasks
   let tasks = Array.isArray(parsed.tasks)
@@ -151,6 +154,7 @@ Output ONLY valid JSON.`;
     completedTasks: doneTasks,
     blockedTasks,
     openIssues: issues.filter(i => i.status === 'open').length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const QUALITY_DECISIONS = ['pass', 'conditional_pass', 'fail'];
 const TEST_SUITE_TYPES = ['unit', 'integration', 'e2e'];
@@ -95,8 +97,9 @@ ${sprintContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize test suites
   let testSuites = Array.isArray(parsed.testSuites)
@@ -181,6 +184,7 @@ Output ONLY valid JSON.`;
     totalFailures,
     totalDefects: knownDefects.length,
     openDefects: knownDefects.filter(d => d.status === 'open').length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-21-build-review.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-21-build-review.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const INTEGRATION_STATUSES = ['pass', 'fail', 'skip', 'pending'];
 const SEVERITY_LEVELS = ['critical', 'high', 'medium', 'low'];
@@ -87,8 +89,9 @@ ${tasksContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize integrations
   let integrations = Array.isArray(parsed.integrations)
@@ -164,6 +167,7 @@ Output ONLY valid JSON.`;
     failingIntegrations,
     passRate,
     allPassing,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const RELEASE_DECISIONS = ['release', 'hold', 'cancel'];
 const RELEASE_CATEGORIES = ['feature', 'bugfix', 'infrastructure', 'documentation', 'security', 'performance', 'configuration'];
@@ -108,8 +110,9 @@ ${reviewContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize release items
   let releaseItems = Array.isArray(parsed.releaseItems)
@@ -197,6 +200,7 @@ Output ONLY valid JSON.`;
     totalItems: releaseItems.length,
     approvedItems: releaseItems.filter(ri => ri.status === 'approved').length,
     allApproved: releaseItems.every(ri => ri.status === 'approved'),
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js
@@ -11,6 +11,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const LAUNCH_TYPES = ['soft_launch', 'beta', 'general_availability'];
 const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
@@ -98,8 +100,9 @@ ${stage1Criteria}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize launchType
   const launchType = LAUNCH_TYPES.includes(parsed.launchType)
@@ -186,6 +189,7 @@ Output ONLY valid JSON.`;
     blockedTasks: launchTasks.filter(lt => lt.status === 'blocked').length,
     primaryCriteria: successCriteria.filter(sc => sc.priority === 'primary').length,
     totalCriteria: successCriteria.length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js
@@ -12,6 +12,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', 'referral'];
 const TREND_DIRECTIONS = ['up', 'flat', 'down'];
@@ -99,8 +101,9 @@ ${financialContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize AARRR metrics
   const aarrr = {};
@@ -212,6 +215,7 @@ Output ONLY valid JSON.`;
     categoriesComplete: categoriesComplete === AARRR_CATEGORIES.length,
     totalLearnings: learnings.length,
     highImpactLearnings: learnings.filter(l => l.impactLevel === 'high').length,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js
@@ -14,6 +14,8 @@
 
 import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const VENTURE_DECISIONS = ['continue', 'pivot', 'expand', 'sunset', 'exit'];
 const HEALTH_RATINGS = ['excellent', 'good', 'fair', 'poor', 'critical'];
@@ -139,8 +141,9 @@ ${roadmapContext}
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT, userPrompt);
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt);
   const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
 
   // Normalize journey summary
   const journeySummary = String(parsed.journeySummary || 'Venture journey summary pending review.').substring(0, 2000);
@@ -251,6 +254,7 @@ Output ONLY valid JSON.`;
     totalInitiatives,
     allCategoriesReviewed: categoriesReviewed === REVIEW_CATEGORIES.length,
     healthScore: Math.round(avgScore * 10) / 10,
+    fourBuckets,
   };
 }
 

--- a/lib/eva/utils/__tests__/four-buckets-parser.test.js
+++ b/lib/eva/utils/__tests__/four-buckets-parser.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseFourBuckets } from '../four-buckets-parser.js';
+
+describe('parseFourBuckets', () => {
+  describe('missing or invalid input', () => {
+    it('returns empty result when parsed is null', () => {
+      const result = parseFourBuckets(null);
+      expect(result.classifications).toEqual([]);
+      expect(result.summary).toEqual({ facts: 0, assumptions: 0, simulations: 0, unknowns: 0 });
+    });
+
+    it('returns empty result when epistemicClassification is missing', () => {
+      const result = parseFourBuckets({ description: 'test' });
+      expect(result.classifications).toEqual([]);
+      expect(result.summary.facts).toBe(0);
+    });
+
+    it('returns empty result and logs warning when epistemicClassification is a string', () => {
+      const logger = { warn: vi.fn() };
+      const result = parseFourBuckets({ epistemicClassification: 'not an array' }, { logger });
+      expect(result.classifications).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('not an array')
+      );
+    });
+
+    it('returns empty result when epistemicClassification is empty array', () => {
+      const result = parseFourBuckets({ epistemicClassification: [] });
+      expect(result.classifications).toEqual([]);
+      expect(result.summary).toEqual({ facts: 0, assumptions: 0, simulations: 0, unknowns: 0 });
+    });
+  });
+
+  describe('valid classification parsing', () => {
+    it('parses valid classifications correctly', () => {
+      const parsed = {
+        epistemicClassification: [
+          { claim: 'Market size is $10B', bucket: 'fact', evidence: 'From industry report' },
+          { claim: 'Users will pay $50/mo', bucket: 'assumption', evidence: 'Based on surveys' },
+          { claim: 'Revenue reaches $1M in Y2', bucket: 'simulation', evidence: 'Financial model' },
+        ],
+      };
+      const result = parseFourBuckets(parsed);
+      expect(result.classifications).toHaveLength(3);
+      expect(result.summary).toEqual({ facts: 1, assumptions: 1, simulations: 1, unknowns: 0 });
+    });
+
+    it('normalizes bucket values to lowercase', () => {
+      const parsed = {
+        epistemicClassification: [
+          { claim: 'Test', bucket: 'FACT', evidence: '' },
+          { claim: 'Test2', bucket: 'Assumption', evidence: '' },
+        ],
+      };
+      const result = parseFourBuckets(parsed);
+      expect(result.classifications[0].bucket).toBe('fact');
+      expect(result.classifications[1].bucket).toBe('assumption');
+      expect(result.summary.facts).toBe(1);
+      expect(result.summary.assumptions).toBe(1);
+    });
+
+    it('truncates long claims and evidence', () => {
+      const longClaim = 'a'.repeat(600);
+      const longEvidence = 'b'.repeat(1200);
+      const result = parseFourBuckets({
+        epistemicClassification: [
+          { claim: longClaim, bucket: 'fact', evidence: longEvidence },
+        ],
+      });
+      expect(result.classifications[0].claim.length).toBe(500);
+      expect(result.classifications[0].evidence.length).toBe(1000);
+    });
+  });
+
+  describe('invalid bucket normalization', () => {
+    it('normalizes invalid bucket to unknown with warning', () => {
+      const logger = { warn: vi.fn() };
+      const result = parseFourBuckets({
+        epistemicClassification: [
+          { claim: 'Some claim', bucket: 'guess', evidence: 'just guessing' },
+        ],
+      }, { logger });
+      expect(result.classifications[0].bucket).toBe('unknown');
+      expect(result.summary.unknowns).toBe(1);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid bucket "guess"')
+      );
+    });
+
+    it('normalizes empty bucket to unknown', () => {
+      const logger = { warn: vi.fn() };
+      const result = parseFourBuckets({
+        epistemicClassification: [
+          { claim: 'Some claim', bucket: '', evidence: '' },
+        ],
+      }, { logger });
+      expect(result.classifications[0].bucket).toBe('unknown');
+    });
+  });
+
+  describe('malformed entries', () => {
+    it('skips entries without claim', () => {
+      const result = parseFourBuckets({
+        epistemicClassification: [
+          { bucket: 'fact', evidence: 'no claim' },
+          { claim: 'Valid claim', bucket: 'fact', evidence: 'present' },
+        ],
+      });
+      expect(result.classifications).toHaveLength(1);
+      expect(result.classifications[0].claim).toBe('Valid claim');
+    });
+
+    it('skips null entries', () => {
+      const result = parseFourBuckets({
+        epistemicClassification: [null, undefined, { claim: 'Valid', bucket: 'fact', evidence: '' }],
+      });
+      expect(result.classifications).toHaveLength(1);
+    });
+  });
+});

--- a/lib/eva/utils/__tests__/four-buckets-prompt.test.js
+++ b/lib/eva/utils/__tests__/four-buckets-prompt.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { getFourBucketsPrompt } from '../four-buckets-prompt.js';
+
+describe('getFourBucketsPrompt', () => {
+  it('returns a non-empty string', () => {
+    const prompt = getFourBucketsPrompt();
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(50);
+  });
+
+  it('contains all four bucket types', () => {
+    const prompt = getFourBucketsPrompt();
+    expect(prompt).toContain('fact');
+    expect(prompt).toContain('assumption');
+    expect(prompt).toContain('simulation');
+    expect(prompt).toContain('unknown');
+  });
+
+  it('contains the epistemicClassification instruction', () => {
+    const prompt = getFourBucketsPrompt();
+    expect(prompt).toContain('epistemicClassification');
+  });
+
+  it('is under 200 tokens (approximated as <1000 chars)', () => {
+    const prompt = getFourBucketsPrompt();
+    expect(prompt.length).toBeLessThan(1000);
+  });
+});

--- a/lib/eva/utils/four-buckets-parser.js
+++ b/lib/eva/utils/four-buckets-parser.js
@@ -1,0 +1,66 @@
+/**
+ * Four Buckets Epistemic Classification - Parser
+ * SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-B (FR-3)
+ *
+ * Parses and normalizes the epistemicClassification array from LLM responses.
+ * Validates bucket values against the allowed set (fact/assumption/simulation/unknown).
+ * Returns normalized classifications + summary counts.
+ *
+ * @module lib/eva/utils/four-buckets-parser
+ */
+
+const VALID_BUCKETS = new Set(['fact', 'assumption', 'simulation', 'unknown']);
+
+/**
+ * Parse and normalize Four Buckets epistemic classification from LLM output.
+ *
+ * @param {Object} parsed - The parsed LLM response object
+ * @param {Object} [options]
+ * @param {Object} [options.logger=console] - Logger instance
+ * @returns {{ classifications: Array, summary: { facts: number, assumptions: number, simulations: number, unknowns: number } }}
+ */
+export function parseFourBuckets(parsed, { logger = console } = {}) {
+  const raw = parsed?.epistemicClassification;
+
+  if (!raw) {
+    return {
+      classifications: [],
+      summary: { facts: 0, assumptions: 0, simulations: 0, unknowns: 0 },
+    };
+  }
+
+  if (!Array.isArray(raw)) {
+    logger.warn('[FourBuckets] epistemicClassification is not an array, ignoring');
+    return {
+      classifications: [],
+      summary: { facts: 0, assumptions: 0, simulations: 0, unknowns: 0 },
+    };
+  }
+
+  const classifications = [];
+  const summary = { facts: 0, assumptions: 0, simulations: 0, unknowns: 0 };
+
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+
+    const claim = String(entry.claim || '').substring(0, 500);
+    if (!claim) continue;
+
+    let bucket = String(entry.bucket || '').toLowerCase().trim();
+    if (!VALID_BUCKETS.has(bucket)) {
+      logger.warn(`[FourBuckets] Invalid bucket "${entry.bucket}" for claim "${claim.substring(0, 60)}...", normalizing to unknown`);
+      bucket = 'unknown';
+    }
+
+    const evidence = String(entry.evidence || '').substring(0, 1000);
+
+    classifications.push({ claim, bucket, evidence });
+
+    if (bucket === 'fact') summary.facts++;
+    else if (bucket === 'assumption') summary.assumptions++;
+    else if (bucket === 'simulation') summary.simulations++;
+    else summary.unknowns++;
+  }
+
+  return { classifications, summary };
+}

--- a/lib/eva/utils/four-buckets-prompt.js
+++ b/lib/eva/utils/four-buckets-prompt.js
@@ -1,0 +1,31 @@
+/**
+ * Four Buckets Epistemic Classification - Prompt Fragment
+ * SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-B (FR-1)
+ *
+ * Shared prompt fragment injected into all 25 EVA analysis steps.
+ * Instructs LLM to classify each key claim as fact/assumption/simulation/unknown.
+ *
+ * @module lib/eva/utils/four-buckets-prompt
+ */
+
+/**
+ * Returns the Four Buckets classification instruction fragment.
+ * Append this to the end of any analysis step's system prompt.
+ *
+ * @returns {string} Prompt fragment (~150 tokens)
+ */
+export function getFourBucketsPrompt() {
+  return `
+
+EPISTEMIC CLASSIFICATION (Four Buckets):
+For each key claim in your output, add an "epistemicClassification" array to your JSON response.
+Each entry must have: { "claim": "<the claim>", "bucket": "<fact|assumption|simulation|unknown>", "evidence": "<basis for classification>" }
+
+Bucket definitions:
+- fact: Directly stated in input data or verifiable from provided sources
+- assumption: Inferred from data but requires validation; not directly stated
+- simulation: Modeled or projected outcome (forecasts, estimates, scenarios)
+- unknown: Insufficient data to classify; flagged for further research
+
+Include 3-8 classifications covering your most significant claims.`;
+}


### PR DESCRIPTION
## Summary
- Add `four-buckets-prompt.js` and `four-buckets-parser.js` utility modules for epistemic classification
- Wire Four Buckets (fact/assumption/simulation/unknown) into all 25 EVA stage analysis steps
- Update `persistArtifacts()` to write `epistemic_classification` and `epistemic_evidence` columns
- Add 15 unit tests covering parser edge cases and prompt content

## Test plan
- [x] All 2514 EVA tests pass (94 files)
- [x] 15 new Four Buckets tests pass
- [x] All 28 modified modules import successfully
- [x] No regressions vs main branch baseline

Part of SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-B (Child B of EVA Intelligence Layer orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)