### PR TITLE
fix: PID-keyed session markers for same-window disambiguation

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -196,14 +196,16 @@ export function getTerminalId() {
       return claudeSessionId;
     }
 
-    // Priority 2: Read session ID from port-keyed marker file written by SessionStart hook.
-    // Workaround for Windows CLAUDE_ENV_FILE bug (#5489) where env vars written
-    // by hooks aren't propagated to Bash tool shells.
-    // Each session writes port-{ssePort}.json, so concurrent sessions don't collide.
+    // Priority 2: Read session ID from PID-keyed marker file written by SessionStart hook.
+    // The hook writes pid-{ccPid}.json where ccPid is the Claude Code process PID
+    // (known at hook time as process.ppid). We use findClaudeCodePid() to discover
+    // the same PID and read the correct marker. This works even when two conversations
+    // share the same SSE port (same VS Code window).
+    // Workaround for Windows CLAUDE_ENV_FILE bug (#5489).
     try {
-      const currentPort = process.env.CLAUDE_CODE_SSE_PORT;
-      if (currentPort) {
-        const markerPath = resolve(__dirname, '../.claude/session-identity', `port-${currentPort}.json`);
+      const ccPid = findClaudeCodePid();
+      if (ccPid) {
+        const markerPath = resolve(__dirname, '../.claude/session-identity', `pid-${ccPid}.json`);
         const marker = JSON.parse(readFileSync(markerPath, 'utf8'));
         if (marker.session_id) {
           return marker.session_id;


### PR DESCRIPTION
## Summary
- Port-keyed markers (`port-{ssePort}.json`) failed because SSE port is shared across conversations in the same VS Code window — both sessions got the same UUID
- Now the hook writes `pid-{ccPid}.json` where `ccPid` is the Claude Code process PID (`process.ppid` at hook time, unique per conversation)
- `getTerminalId()` uses `findClaudeCodePid()` to discover its Claude Code ancestor PID and reads the matching marker file

## Test plan
- [x] All 10 claim-guard unit tests pass
- [x] All 15 smoke tests pass
- [ ] Manual: start two sessions in same VS Code window, verify different terminal_ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)