### PR TITLE
feat: wire token budget tracking into EVA pipeline

### DIFF
--- a/lib/eva/decision-filter-engine.js
+++ b/lib/eva/decision-filter-engine.js
@@ -7,6 +7,7 @@
  *
  * Trigger types (fixed evaluation order):
  *   1. cost_threshold    - Cost exceeds chairman-defined max
+ *   1b. budget_exceeded  - Token budget usage at or over limit
  *   2. new_tech_vendor   - Introduces unapproved technology/vendor
  *   3. strategic_pivot   - Deviates from original venture direction
  *   4. low_score         - Quality/confidence score below threshold
@@ -24,6 +25,7 @@ const ENGINE_VERSION = '1.0.0';
 // Fixed rule evaluation order for deterministic trigger ordering
 const TRIGGER_TYPES = [
   'cost_threshold',
+  'budget_exceeded',
   'new_tech_vendor',
   'strategic_pivot',
   'low_score',
@@ -66,6 +68,7 @@ const DEFAULTS = {
  * @param {string[]} [input.priorPatterns]   - Patterns from previous stages
  * @param {object} [input.constraints]       - Current constraint values
  * @param {object} [input.approvedConstraints] - Originally approved constraints
+ * @param {object} [input.budgetStatus]       - Token budget status from checkBudget()
  * @param {string} [input.stage]             - Stage identifier
  *
  * @param {object} [options]
@@ -100,6 +103,26 @@ export function evaluateDecision(input = {}, options = {}) {
         severity: 'HIGH',
         message: `Cost $${input.cost} exceeds threshold $${costMax.value}`,
         details: { cost: input.cost, threshold: costMax.value, thresholdSource: costMax.source },
+      });
+    }
+  }
+
+  // --- Rule 1b: budget_exceeded (token budget from venture_token_ledger) ---
+  if (input.budgetStatus) {
+    const bs = input.budgetStatus;
+    if (bs.is_over_budget) {
+      triggers.push({
+        type: 'budget_exceeded',
+        severity: 'HIGH',
+        message: `Token budget exceeded: ${bs.usage_percentage}% used (${bs.tokens_used} / ${bs.budget_limit} tokens)`,
+        details: { tokensUsed: bs.tokens_used, budgetLimit: bs.budget_limit, usagePercentage: bs.usage_percentage },
+      });
+    } else if (bs.usage_percentage >= 80) {
+      triggers.push({
+        type: 'budget_exceeded',
+        severity: 'MEDIUM',
+        message: `Token budget at ${bs.usage_percentage}% — approaching limit (${bs.tokens_used} / ${bs.budget_limit} tokens)`,
+        details: { tokensUsed: bs.tokens_used, budgetLimit: bs.budget_limit, usagePercentage: bs.usage_percentage },
       });
     }
   }

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -27,6 +27,7 @@ import { createOrReusePendingDecision, waitForDecision } from './chairman-decisi
 import { OrchestratorTracer } from './observability.js';
 import { VentureStateMachine } from '../agents/venture-state-machine.js';
 import { validateStageGate } from '../agents/modules/venture-state-machine/stage-gates.js';
+import { recordTokenUsage, checkBudget, buildTokenSummary } from './utils/token-tracker.js';
 
 // ── Status Constants ────────────────────────────────────────────
 
@@ -149,9 +150,21 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     logger.warn(`[Eva] Preference loading failed (non-fatal): ${err.message}`);
   }
 
+  // ── 3b. Pre-stage budget check ──
+  let budgetStatus = null;
+  try {
+    budgetStatus = await checkBudget(ventureId, { supabase, logger });
+    if (budgetStatus?.is_over_budget) {
+      logger.warn(`[Eva] Venture ${ventureId} is over token budget (${budgetStatus.usage_percentage}%)`);
+    }
+  } catch (err) {
+    logger.warn(`[Eva] Budget check failed (non-fatal): ${err.message}`);
+  }
+
   // ── 4. Load and execute stage template ──
   let artifacts = [];
   let stageOutput = {};
+  const stageTokenUsages = [];
   const templateSpan = tracer.startSpan('template_execution');
   try {
     const template = options.stageTemplate || await loadStageTemplate(supabase, resolvedStage);
@@ -162,6 +175,22 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
         const stepResult = typeof step.execute === 'function'
           ? await step.execute({ ventureContext, preferences, stage: resolvedStage })
           : { artifactType: step.artifactType || 'generic', payload: {}, source: step.id || 'unknown' };
+
+        // Track token usage from this step (fire-and-forget)
+        if (stepResult.usage) {
+          stageTokenUsages.push(stepResult.usage);
+          recordTokenUsage({
+            ventureId,
+            stageId: resolvedStage,
+            usage: stepResult.usage,
+            metadata: {
+              stepId: step.id,
+              agentType: stepResult.agentType || 'claude',
+              modelId: stepResult.modelId,
+              operationType: step.artifactType || 'analysis',
+            },
+          }, { supabase, logger });
+        }
 
         artifacts.push({
           artifactType: stepResult.artifactType || step.artifactType || 'stage_output',
@@ -268,6 +297,13 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   let filterDecision;
   const filterSpan = tracer.startSpan('filter_evaluation');
   try {
+    // Refresh budget status after stage execution (cache may have been invalidated)
+    if (stageTokenUsages.length > 0) {
+      try {
+        budgetStatus = await checkBudget(ventureId, { supabase, logger });
+      } catch (_) { /* non-fatal */ }
+    }
+
     const filterInput = {
       stage: String(resolvedStage),
       cost: stageOutput.cost,
@@ -279,6 +315,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       priorPatterns: stageOutput.priorPatterns || [],
       constraints: stageOutput.constraints || {},
       approvedConstraints: stageOutput.approvedConstraints || {},
+      budgetStatus: budgetStatus || null,
     };
 
     const filterResult = evaluateDecisionFn(filterInput, { preferences, logger });
@@ -374,10 +411,13 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     await tracer.persistEvents(supabase).catch(() => {});
   }
 
+  // Build token usage summary for stage output
+  const tokenUsageSummary = buildTokenSummary(stageTokenUsages, budgetStatus);
+
   return buildResult({
     ventureId, stageId: resolvedStage, startedAt, correlationId,
     status: STATUS.COMPLETED, artifacts, filterDecision, gateResults, nextStageId, devilsAdvocateReview,
-    traceId: tracer.traceId,
+    traceId: tracer.traceId, tokenUsageSummary,
   });
 }
 
@@ -469,7 +509,7 @@ export async function run({ ventureId, options = {} }, deps = {}) {
 
 // ── Internal Helpers ────────────────────────────────────────────
 
-function buildResult({ ventureId, stageId, startedAt, correlationId, status, artifacts = [], filterDecision = null, gateResults = [], nextStageId = null, errors = [], devilsAdvocateReview = null, traceId = null }) {
+function buildResult({ ventureId, stageId, startedAt, correlationId, status, artifacts = [], filterDecision = null, gateResults = [], nextStageId = null, errors = [], devilsAdvocateReview = null, traceId = null, tokenUsageSummary = null }) {
   return {
     ventureId,
     stageId,
@@ -484,6 +524,7 @@ function buildResult({ ventureId, stageId, startedAt, correlationId, status, art
     errors,
     devilsAdvocateReview,
     traceId,
+    tokenUsageSummary,
   };
 }
 

--- a/lib/eva/utils/token-tracker.js
+++ b/lib/eva/utils/token-tracker.js
@@ -1,0 +1,167 @@
+/**
+ * Token Budget Tracker for EVA Pipeline
+ * SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-C
+ *
+ * Records token usage to venture_token_ledger and checks budget status
+ * via get_venture_token_budget_status RPC. All operations are non-blocking
+ * (fire-and-forget) to avoid impacting pipeline latency.
+ */
+
+import { randomUUID } from 'crypto';
+
+const BUDGET_CHECK_TIMEOUT_MS = 2000;
+const BUDGET_CACHE_TTL_MS = 60_000;
+
+// In-memory budget cache: ventureId → { data, cachedAt }
+const budgetCache = new Map();
+
+/**
+ * Record token usage from an LLM call into venture_token_ledger.
+ * Fire-and-forget: errors are logged but never thrown.
+ *
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture UUID
+ * @param {number} params.stageId - Lifecycle stage number
+ * @param {Object} params.usage - Token usage from LLM response
+ * @param {number} [params.usage.inputTokens=0]
+ * @param {number} [params.usage.outputTokens=0]
+ * @param {Object} [params.metadata] - Additional metadata
+ * @param {string} [params.metadata.agentType] - e.g. 'claude', 'openai'
+ * @param {string} [params.metadata.modelId] - e.g. 'claude-opus-4-6'
+ * @param {string} [params.metadata.operationType] - e.g. 'analysis', 'generation'
+ * @param {string} [params.metadata.stepId] - Analysis step identifier
+ * @param {number} [params.metadata.attempt] - Retry attempt number
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger (defaults to console)
+ */
+export function recordTokenUsage({ ventureId, stageId, usage, metadata = {} }, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    logger.warn('[TokenTracker] No supabase client — skipping token recording');
+    return;
+  }
+
+  const inputTokens = usage?.inputTokens ?? 0;
+  const outputTokens = usage?.outputTokens ?? 0;
+
+  if (inputTokens === 0 && outputTokens === 0 && !usage) {
+    logger.warn('[TokenTracker] Missing usage data — recording zeros');
+  }
+
+  const row = {
+    id: randomUUID(),
+    venture_id: ventureId,
+    lifecycle_stage: stageId,
+    tokens_input: inputTokens,
+    tokens_output: outputTokens,
+    agent_type: metadata.agentType || null,
+    model_id: metadata.modelId || null,
+    operation_type: metadata.operationType || null,
+    budget_profile: metadata.budgetProfile || 'standard',
+    is_simulation: false,
+    metadata: {
+      step_id: metadata.stepId || null,
+      attempt: metadata.attempt || 1,
+      recorded_by: 'eva-token-tracker',
+    },
+    created_at: new Date().toISOString(),
+    created_by: 'eva-orchestrator',
+  };
+
+  // Fire-and-forget: do not await
+  supabase
+    .from('venture_token_ledger')
+    .insert(row)
+    .then(({ error }) => {
+      if (error) {
+        logger.warn(`[TokenTracker] Insert failed (non-fatal): ${error.message}`);
+      }
+    })
+    .catch((err) => {
+      logger.warn(`[TokenTracker] Insert error (non-fatal): ${err.message}`);
+    });
+
+  // Invalidate budget cache for this venture since usage changed
+  budgetCache.delete(ventureId);
+}
+
+/**
+ * Check token budget status for a venture.
+ * Returns budget info or null on timeout/error.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<Object|null>} Budget status or null
+ */
+export async function checkBudget(ventureId, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase) {
+    logger.warn('[TokenTracker] No supabase client — skipping budget check');
+    return null;
+  }
+
+  // Check cache first
+  const cached = budgetCache.get(ventureId);
+  if (cached && (Date.now() - cached.cachedAt) < BUDGET_CACHE_TTL_MS) {
+    return cached.data;
+  }
+
+  try {
+    const result = await Promise.race([
+      supabase.rpc('get_venture_token_budget_status', { p_venture_id: ventureId }),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error('Budget check timeout')), BUDGET_CHECK_TIMEOUT_MS)
+      ),
+    ]);
+
+    if (result.error) {
+      logger.warn(`[TokenTracker] Budget check RPC error: ${result.error.message}`);
+      return null;
+    }
+
+    const budgetData = Array.isArray(result.data) ? result.data[0] : result.data;
+    if (budgetData) {
+      budgetCache.set(ventureId, { data: budgetData, cachedAt: Date.now() });
+    }
+    return budgetData || null;
+  } catch (err) {
+    logger.warn(`[TokenTracker] Budget check failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Build a token usage summary object for stage output metadata.
+ *
+ * @param {Object[]} stageUsages - Array of { inputTokens, outputTokens } from stage steps
+ * @param {Object|null} budgetStatus - Result from checkBudget()
+ * @returns {Object} Token usage summary
+ */
+export function buildTokenSummary(stageUsages, budgetStatus) {
+  const inputTokens = stageUsages.reduce((sum, u) => sum + (u?.inputTokens ?? 0), 0);
+  const outputTokens = stageUsages.reduce((sum, u) => sum + (u?.outputTokens ?? 0), 0);
+  const totalTokens = inputTokens + outputTokens;
+
+  return {
+    input_tokens: inputTokens,
+    output_tokens: outputTokens,
+    total_tokens: totalTokens,
+    cumulative_tokens: budgetStatus?.tokens_used ?? null,
+    budget_remaining_pct: budgetStatus?.usage_percentage != null
+      ? Math.max(0, 100 - budgetStatus.usage_percentage)
+      : null,
+    is_over_budget: budgetStatus?.is_over_budget ?? null,
+  };
+}
+
+// Exported for testing
+export const _internal = {
+  budgetCache,
+  BUDGET_CHECK_TIMEOUT_MS,
+  BUDGET_CACHE_TTL_MS,
+};

--- a/tests/unit/eva/decision-filter-budget.test.js
+++ b/tests/unit/eva/decision-filter-budget.test.js
@@ -1,0 +1,125 @@
+/**
+ * Decision Filter Engine - Budget Exceeded Trigger Tests
+ * SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-C
+ *
+ * Tests the budget_exceeded trigger type added to the DFE.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateDecision, TRIGGER_TYPES } from '../../../lib/eva/decision-filter-engine.js';
+
+describe('Decision Filter Engine - budget_exceeded trigger', () => {
+  it('should include budget_exceeded in TRIGGER_TYPES', () => {
+    expect(TRIGGER_TYPES).toContain('budget_exceeded');
+    // Should come after cost_threshold and before new_tech_vendor
+    const costIdx = TRIGGER_TYPES.indexOf('cost_threshold');
+    const budgetIdx = TRIGGER_TYPES.indexOf('budget_exceeded');
+    const techIdx = TRIGGER_TYPES.indexOf('new_tech_vendor');
+    expect(budgetIdx).toBeGreaterThan(costIdx);
+    expect(budgetIdx).toBeLessThan(techIdx);
+  });
+
+  it('should fire HIGH trigger when over budget', () => {
+    const result = evaluateDecision({
+      budgetStatus: {
+        is_over_budget: true,
+        usage_percentage: 115,
+        tokens_used: 575000,
+        budget_limit: 500000,
+      },
+    });
+
+    const budgetTrigger = result.triggers.find(t => t.type === 'budget_exceeded');
+    expect(budgetTrigger).toBeTruthy();
+    expect(budgetTrigger.severity).toBe('HIGH');
+    expect(budgetTrigger.details.tokensUsed).toBe(575000);
+    expect(budgetTrigger.details.budgetLimit).toBe(500000);
+    expect(result.auto_proceed).toBe(false);
+    expect(result.recommendation).toBe('PRESENT_TO_CHAIRMAN');
+  });
+
+  it('should fire MEDIUM trigger at 80% usage', () => {
+    const result = evaluateDecision({
+      budgetStatus: {
+        is_over_budget: false,
+        usage_percentage: 85,
+        tokens_used: 425000,
+        budget_limit: 500000,
+      },
+    });
+
+    const budgetTrigger = result.triggers.find(t => t.type === 'budget_exceeded');
+    expect(budgetTrigger).toBeTruthy();
+    expect(budgetTrigger.severity).toBe('MEDIUM');
+    expect(budgetTrigger.message).toContain('85%');
+  });
+
+  it('should not fire trigger when under 80%', () => {
+    const result = evaluateDecision({
+      budgetStatus: {
+        is_over_budget: false,
+        usage_percentage: 50,
+        tokens_used: 250000,
+        budget_limit: 500000,
+      },
+    });
+
+    const budgetTrigger = result.triggers.find(t => t.type === 'budget_exceeded');
+    expect(budgetTrigger).toBeUndefined();
+    expect(result.auto_proceed).toBe(true);
+  });
+
+  it('should not fire trigger when budgetStatus is null', () => {
+    const result = evaluateDecision({
+      budgetStatus: null,
+    });
+
+    const budgetTrigger = result.triggers.find(t => t.type === 'budget_exceeded');
+    expect(budgetTrigger).toBeUndefined();
+  });
+
+  it('should not fire trigger when budgetStatus is absent', () => {
+    const result = evaluateDecision({});
+
+    const budgetTrigger = result.triggers.find(t => t.type === 'budget_exceeded');
+    expect(budgetTrigger).toBeUndefined();
+  });
+
+  it('should fire at exactly 80% boundary', () => {
+    const result = evaluateDecision({
+      budgetStatus: {
+        is_over_budget: false,
+        usage_percentage: 80,
+        tokens_used: 400000,
+        budget_limit: 500000,
+      },
+    });
+
+    const budgetTrigger = result.triggers.find(t => t.type === 'budget_exceeded');
+    expect(budgetTrigger).toBeTruthy();
+    expect(budgetTrigger.severity).toBe('MEDIUM');
+  });
+
+  it('should coexist with cost_threshold trigger', () => {
+    const result = evaluateDecision({
+      cost: 50000,
+      budgetStatus: {
+        is_over_budget: true,
+        usage_percentage: 110,
+        tokens_used: 550000,
+        budget_limit: 500000,
+      },
+    }, {
+      preferences: { 'filter.cost_max_usd': 10000 },
+    });
+
+    const costTrigger = result.triggers.find(t => t.type === 'cost_threshold');
+    const budgetTrigger = result.triggers.find(t => t.type === 'budget_exceeded');
+    expect(costTrigger).toBeTruthy();
+    expect(budgetTrigger).toBeTruthy();
+    // budget_exceeded should come after cost_threshold in trigger order
+    const costIdx = result.triggers.indexOf(costTrigger);
+    const budgetIdx = result.triggers.indexOf(budgetTrigger);
+    expect(budgetIdx).toBeGreaterThan(costIdx);
+  });
+});

--- a/tests/unit/eva/decision-filter-engine.test.js
+++ b/tests/unit/eva/decision-filter-engine.test.js
@@ -251,8 +251,8 @@ describe('DecisionFilterEngine', () => {
       expect(ENGINE_VERSION).toBe('1.0.0');
     });
 
-    it('should export all 6 trigger types', () => {
-      expect(TRIGGER_TYPES).toHaveLength(6);
+    it('should export all 7 trigger types', () => {
+      expect(TRIGGER_TYPES).toHaveLength(7);
     });
   });
 });

--- a/tests/unit/eva/token-tracker.test.js
+++ b/tests/unit/eva/token-tracker.test.js
@@ -1,0 +1,259 @@
+/**
+ * Token Tracker Unit Tests
+ * SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-C
+ *
+ * Tests: recordTokenUsage, checkBudget, buildTokenSummary
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { recordTokenUsage, checkBudget, buildTokenSummary, _internal } from '../../../lib/eva/utils/token-tracker.js';
+
+describe('Token Tracker', () => {
+  let mockSupabase;
+  let mockLogger;
+
+  beforeEach(() => {
+    _internal.budgetCache.clear();
+    mockLogger = { warn: vi.fn(), log: vi.fn(), error: vi.fn() };
+    mockSupabase = {
+      from: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+      rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+  });
+
+  describe('recordTokenUsage', () => {
+    it('should insert a row into venture_token_ledger', async () => {
+      recordTokenUsage({
+        ventureId: 'v-123',
+        stageId: 5,
+        usage: { inputTokens: 100, outputTokens: 50 },
+        metadata: { agentType: 'claude', modelId: 'opus-4.6' },
+      }, { supabase: mockSupabase, logger: mockLogger });
+
+      // Fire-and-forget — give the promise a tick to resolve
+      await new Promise(r => setTimeout(r, 10));
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('venture_token_ledger');
+      expect(mockSupabase.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          venture_id: 'v-123',
+          lifecycle_stage: 5,
+          tokens_input: 100,
+          tokens_output: 50,
+          agent_type: 'claude',
+          model_id: 'opus-4.6',
+        })
+      );
+    });
+
+    it('should skip when no supabase client', () => {
+      recordTokenUsage({
+        ventureId: 'v-123',
+        stageId: 1,
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }, { logger: mockLogger });
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('No supabase client')
+      );
+    });
+
+    it('should record zeros when usage is missing', async () => {
+      recordTokenUsage({
+        ventureId: 'v-123',
+        stageId: 1,
+        usage: undefined,
+      }, { supabase: mockSupabase, logger: mockLogger });
+
+      await new Promise(r => setTimeout(r, 10));
+
+      expect(mockSupabase.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tokens_input: 0,
+          tokens_output: 0,
+        })
+      );
+    });
+
+    it('should invalidate budget cache for the venture', () => {
+      _internal.budgetCache.set('v-123', { data: {}, cachedAt: Date.now() });
+
+      recordTokenUsage({
+        ventureId: 'v-123',
+        stageId: 1,
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }, { supabase: mockSupabase, logger: mockLogger });
+
+      expect(_internal.budgetCache.has('v-123')).toBe(false);
+    });
+
+    it('should log warning on insert error without throwing', async () => {
+      mockSupabase.insert = vi.fn().mockResolvedValue({ error: { message: 'DB error' } });
+
+      recordTokenUsage({
+        ventureId: 'v-123',
+        stageId: 1,
+        usage: { inputTokens: 10, outputTokens: 5 },
+      }, { supabase: mockSupabase, logger: mockLogger });
+
+      await new Promise(r => setTimeout(r, 10));
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Insert failed')
+      );
+    });
+  });
+
+  describe('checkBudget', () => {
+    it('should return budget data from RPC', async () => {
+      const budgetData = {
+        budget_limit: 500000,
+        tokens_used: 120000,
+        usage_percentage: 24,
+        is_over_budget: false,
+      };
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: budgetData, error: null });
+
+      const result = await checkBudget('v-123', { supabase: mockSupabase, logger: mockLogger });
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith(
+        'get_venture_token_budget_status',
+        { p_venture_id: 'v-123' }
+      );
+      expect(result).toEqual(budgetData);
+    });
+
+    it('should return cached data within TTL', async () => {
+      const cached = { budget_limit: 500000, tokens_used: 100 };
+      _internal.budgetCache.set('v-123', { data: cached, cachedAt: Date.now() });
+
+      const result = await checkBudget('v-123', { supabase: mockSupabase, logger: mockLogger });
+
+      expect(result).toEqual(cached);
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+    });
+
+    it('should bypass stale cache', async () => {
+      const staleData = { budget_limit: 500000, tokens_used: 100 };
+      _internal.budgetCache.set('v-123', {
+        data: staleData,
+        cachedAt: Date.now() - _internal.BUDGET_CACHE_TTL_MS - 1000,
+      });
+
+      const freshData = { budget_limit: 500000, tokens_used: 200 };
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: freshData, error: null });
+
+      const result = await checkBudget('v-123', { supabase: mockSupabase, logger: mockLogger });
+
+      expect(result).toEqual(freshData);
+      expect(mockSupabase.rpc).toHaveBeenCalled();
+    });
+
+    it('should return null on RPC error', async () => {
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'RPC failed' } });
+
+      const result = await checkBudget('v-123', { supabase: mockSupabase, logger: mockLogger });
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('RPC error')
+      );
+    });
+
+    it('should return null on timeout', async () => {
+      mockSupabase.rpc = vi.fn().mockImplementation(
+        () => new Promise(resolve => setTimeout(() => resolve({ data: {}, error: null }), 5000))
+      );
+
+      const result = await checkBudget('v-123', { supabase: mockSupabase, logger: mockLogger });
+
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Budget check failed')
+      );
+    }, 10000);
+
+    it('should return null when no supabase client', async () => {
+      const result = await checkBudget('v-123', { logger: mockLogger });
+      expect(result).toBeNull();
+    });
+
+    it('should handle array response from RPC', async () => {
+      const budgetData = { budget_limit: 100000, tokens_used: 50000 };
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: [budgetData], error: null });
+
+      const result = await checkBudget('v-123', { supabase: mockSupabase, logger: mockLogger });
+      expect(result).toEqual(budgetData);
+    });
+  });
+
+  describe('buildTokenSummary', () => {
+    it('should sum token usages across steps', () => {
+      const usages = [
+        { inputTokens: 100, outputTokens: 50 },
+        { inputTokens: 200, outputTokens: 100 },
+        { inputTokens: 50, outputTokens: 25 },
+      ];
+
+      const summary = buildTokenSummary(usages, null);
+
+      expect(summary.input_tokens).toBe(350);
+      expect(summary.output_tokens).toBe(175);
+      expect(summary.total_tokens).toBe(525);
+      expect(summary.cumulative_tokens).toBeNull();
+      expect(summary.budget_remaining_pct).toBeNull();
+      expect(summary.is_over_budget).toBeNull();
+    });
+
+    it('should include budget info when available', () => {
+      const usages = [{ inputTokens: 100, outputTokens: 50 }];
+      const budgetStatus = {
+        tokens_used: 120000,
+        usage_percentage: 24,
+        is_over_budget: false,
+      };
+
+      const summary = buildTokenSummary(usages, budgetStatus);
+
+      expect(summary.cumulative_tokens).toBe(120000);
+      expect(summary.budget_remaining_pct).toBe(76);
+      expect(summary.is_over_budget).toBe(false);
+    });
+
+    it('should handle empty usage array', () => {
+      const summary = buildTokenSummary([], null);
+
+      expect(summary.input_tokens).toBe(0);
+      expect(summary.output_tokens).toBe(0);
+      expect(summary.total_tokens).toBe(0);
+    });
+
+    it('should handle null/undefined entries in usage array', () => {
+      const usages = [
+        { inputTokens: 100, outputTokens: 50 },
+        null,
+        undefined,
+        { outputTokens: 30 },
+      ];
+
+      const summary = buildTokenSummary(usages, null);
+
+      expect(summary.input_tokens).toBe(100);
+      expect(summary.output_tokens).toBe(80);
+    });
+
+    it('should clamp budget_remaining_pct to 0 when over 100%', () => {
+      const budgetStatus = {
+        tokens_used: 600000,
+        usage_percentage: 120,
+        is_over_budget: true,
+      };
+
+      const summary = buildTokenSummary([], budgetStatus);
+
+      expect(summary.budget_remaining_pct).toBe(0);
+      expect(summary.is_over_budget).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `token-tracker.js` utility with fire-and-forget recording to `venture_token_ledger`, cached budget checks via RPC, and token usage summary builder
- Wire `recordTokenUsage()` into the EVA orchestrator step execution loop to capture per-step LLM token usage
- Add pre-stage `checkBudget()` call with 2s timeout and 60s in-memory cache
- Include `tokenUsageSummary` in stage result output for downstream consumers
- Add `budget_exceeded` trigger to Decision Filter Engine (HIGH severity at 100%+, MEDIUM at 80%+)
- Pass `budgetStatus` through to DFE for cost-aware chairman escalation

**SD**: SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-C (Token Budget Tracking Wired into Pipeline)

## Test plan
- [x] 17 unit tests for token-tracker (recordTokenUsage, checkBudget, buildTokenSummary)
- [x] 8 unit tests for DFE budget_exceeded trigger
- [x] Updated existing DFE test for 7 trigger types (was 6)
- [x] All 2524 tests pass (94 test files, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)