### PR TITLE
feat: add assumption-reality tracker for EVA calibration loop

### DIFF
--- a/lib/eva/cross-venture-learning.js
+++ b/lib/eva/cross-venture-learning.js
@@ -512,11 +512,111 @@ async function searchSimilar(supabase, options = {}) {
   return results;
 }
 
+/**
+ * Analyze assumption calibration accuracy across ventures.
+ * Portfolio-level view: which assumption categories are most/least accurate.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} [options]
+ * @param {number} [options.minVentures=MIN_VENTURES] - Minimum ventures for analysis
+ * @returns {Promise<Object>} Portfolio calibration analysis
+ */
+async function analyzeAssumptionCalibration(supabase, options = {}) {
+  const minVentures = options.minVentures ?? MIN_VENTURES;
+
+  const { data: sets, error } = await supabase
+    .from('assumption_sets')
+    .select('venture_id, status, calibration_report, confidence_scores')
+    .not('calibration_report', 'is', null);
+
+  if (error) {
+    throw new ServiceError(`Failed to query assumption_sets: ${error.message}`, 'ASSUMPTION_QUERY_FAILED');
+  }
+
+  if (!sets || sets.length === 0) {
+    return { ventures_analyzed: 0, min_ventures_required: minVentures, categories: {}, sufficient_data: false };
+  }
+
+  // Group by venture
+  const byVenture = {};
+  for (const s of sets) {
+    if (!byVenture[s.venture_id]) byVenture[s.venture_id] = [];
+    byVenture[s.venture_id].push(s);
+  }
+
+  const ventureCount = Object.keys(byVenture).length;
+  if (ventureCount < minVentures) {
+    return { ventures_analyzed: ventureCount, min_ventures_required: minVentures, categories: {}, sufficient_data: false };
+  }
+
+  // Aggregate per-category accuracy across all ventures
+  const categoryAgg = {};
+  let totalAccuracy = 0;
+  let reportCount = 0;
+
+  for (const ventureId of Object.keys(byVenture)) {
+    for (const s of byVenture[ventureId]) {
+      const report = s.calibration_report;
+      if (!report || typeof report !== 'object') continue;
+
+      if (report.aggregate_accuracy != null) {
+        totalAccuracy += report.aggregate_accuracy;
+        reportCount++;
+      }
+
+      const scores = report.category_scores;
+      if (!scores || typeof scores !== 'object') continue;
+
+      for (const [cat, catScore] of Object.entries(scores)) {
+        if (!categoryAgg[cat]) {
+          categoryAgg[cat] = { totalAccuracy: 0, count: 0, totalError: 0 };
+        }
+        categoryAgg[cat].totalAccuracy += catScore.accuracy ?? 0;
+        categoryAgg[cat].totalError += catScore.error_magnitude ?? 0;
+        categoryAgg[cat].count++;
+      }
+    }
+  }
+
+  // Build category summaries
+  const categories = {};
+  for (const [cat, agg] of Object.entries(categoryAgg)) {
+    categories[cat] = {
+      avg_accuracy: agg.count > 0 ? round2(agg.totalAccuracy / agg.count) : 0,
+      avg_error_magnitude: agg.count > 0 ? round2(agg.totalError / agg.count) : 1,
+      sample_size: agg.count,
+    };
+  }
+
+  // Rank by accuracy (worst first — most improvement needed)
+  const rankedCategories = Object.entries(categories)
+    .sort(([, a], [, b]) => a.avg_accuracy - b.avg_accuracy)
+    .map(([cat, stats], i) => ({ category: cat, rank: i + 1, ...stats }));
+
+  // Status distribution
+  const statusCounts = {};
+  for (const s of sets) {
+    statusCounts[s.status] = (statusCounts[s.status] || 0) + 1;
+  }
+
+  return {
+    ventures_analyzed: ventureCount,
+    min_ventures_required: minVentures,
+    sufficient_data: true,
+    portfolio_accuracy: reportCount > 0 ? round2(totalAccuracy / reportCount) : 0,
+    total_calibration_reports: reportCount,
+    categories,
+    ranked_categories: rankedCategories,
+    status_distribution: statusCounts,
+  };
+}
+
 export {
   analyzeCrossVenturePatterns,
   analyzeKillStageFrequency,
   analyzeFailedAssumptions,
   analyzeSuccessPatterns,
+  analyzeAssumptionCalibration,
   searchSimilar,
   MODULE_VERSION,
   MIN_VENTURES,

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -29,6 +29,7 @@ import { VentureStateMachine } from '../agents/venture-state-machine.js';
 import { validateStageGate } from '../agents/modules/venture-state-machine/stage-gates.js';
 import { getContract, validatePreStage, validatePostStage } from './contracts/stage-contracts.js';
 import { recordTokenUsage, checkBudget, buildTokenSummary } from './utils/token-tracker.js';
+import { runRealityTracking } from './utils/assumption-reality-tracker.js';
 
 // ── Status Constants ────────────────────────────────────────────
 
@@ -409,6 +410,21 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       if (bridgeErr) logger.warn(`[Eva] Bridge artifact persist failed: ${bridgeErr.message}`);
     } catch (err) {
       logger.warn(`[Eva] Lifecycle-to-SD Bridge failed (non-fatal): ${err.message}`);
+    }
+  }
+
+  // ── 7c. Assumptions vs Reality tracking (Stage >= 17) ──
+  if (resolvedStage >= 17 && !options.dryRun) {
+    try {
+      const calibrationReport = await runRealityTracking(
+        { ventureId, stageId: resolvedStage },
+        { supabase, logger },
+      );
+      if (calibrationReport) {
+        logger.log(`[Eva] Reality tracking: accuracy=${calibrationReport.aggregate_accuracy} for venture ${ventureId}`);
+      }
+    } catch (err) {
+      logger.warn(`[Eva] Reality tracking failed (non-fatal): ${err.message}`);
     }
   }
 

--- a/lib/eva/utils/assumption-reality-tracker.js
+++ b/lib/eva/utils/assumption-reality-tracker.js
@@ -1,0 +1,418 @@
+/**
+ * Assumption-Reality Tracker for EVA Pipeline
+ * SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-D
+ *
+ * Closes the assumptions-vs-reality loop:
+ *   1. Collects reality measurements from venture_artifacts at stage >= 17
+ *   2. Builds calibration reports comparing assumptions vs reality
+ *   3. Updates assumption_sets with reality_data, calibration_report, status
+ *
+ * Design principles (matching token-tracker.js):
+ *   - Fire-and-forget for writes (errors logged, never thrown)
+ *   - Dependency-injected supabase client
+ *   - Pure analysis functions where possible
+ *   - Deterministic rounding via round2()
+ */
+
+import { round2 } from '../cross-venture-learning.js';
+
+const REALITY_STAGE_THRESHOLD = 17;
+
+const ASSUMPTION_CATEGORIES = [
+  'market_assumptions',
+  'competitor_assumptions',
+  'product_assumptions',
+  'timing_assumptions',
+];
+
+const STATUS_THRESHOLDS = {
+  VALIDATED: 0.7,
+  INVALIDATED: 0.3,
+};
+
+/**
+ * Collect reality measurements from venture_artifacts at stages >= 17.
+ * Extracts factual data points that correspond to assumption categories.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {number} stageId - Current lifecycle stage
+ * @param {Object} [logger=console] - Logger
+ * @returns {Promise<Object|null>} Reality measurements keyed by category, or null on error
+ */
+export async function collectRealityMeasurements(supabase, ventureId, stageId, logger = console) {
+  if (stageId < REALITY_STAGE_THRESHOLD) {
+    return null;
+  }
+
+  try {
+    const { data: artifacts, error } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_type, artifact_data, lifecycle_stage')
+      .eq('venture_id', ventureId)
+      .eq('is_current', true)
+      .gte('lifecycle_stage', REALITY_STAGE_THRESHOLD)
+      .order('lifecycle_stage', { ascending: true });
+
+    if (error) {
+      logger.warn(`[RealityTracker] Artifact query failed: ${error.message}`);
+      return null;
+    }
+
+    if (!artifacts || artifacts.length === 0) {
+      return null;
+    }
+
+    const measurements = {
+      market_assumptions: [],
+      competitor_assumptions: [],
+      product_assumptions: [],
+      timing_assumptions: [],
+    };
+
+    for (const art of artifacts) {
+      const data = art.artifact_data;
+      if (!data || typeof data !== 'object') continue;
+
+      // Extract market reality data
+      if (data.market_validation || data.market_metrics || data.tam_sam_som) {
+        measurements.market_assumptions.push({
+          stage: art.lifecycle_stage,
+          type: art.artifact_type,
+          data: data.market_validation || data.market_metrics || data.tam_sam_som,
+        });
+      }
+
+      // Extract competitor reality data
+      if (data.competitive_analysis || data.competitor_data) {
+        measurements.competitor_assumptions.push({
+          stage: art.lifecycle_stage,
+          type: art.artifact_type,
+          data: data.competitive_analysis || data.competitor_data,
+        });
+      }
+
+      // Extract product reality data
+      if (data.product_metrics || data.user_feedback || data.feature_usage) {
+        measurements.product_assumptions.push({
+          stage: art.lifecycle_stage,
+          type: art.artifact_type,
+          data: data.product_metrics || data.user_feedback || data.feature_usage,
+        });
+      }
+
+      // Extract timing reality data
+      if (data.timeline_actual || data.milestone_tracking || data.sprint_velocity) {
+        measurements.timing_assumptions.push({
+          stage: art.lifecycle_stage,
+          type: art.artifact_type,
+          data: data.timeline_actual || data.milestone_tracking || data.sprint_velocity,
+        });
+      }
+    }
+
+    return measurements;
+  } catch (err) {
+    logger.warn(`[RealityTracker] collectRealityMeasurements failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Build a calibration report comparing original assumptions vs reality.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} [logger=console] - Logger
+ * @returns {Promise<Object|null>} Calibration report or null on error
+ */
+export async function buildCalibrationReport(supabase, ventureId, logger = console) {
+  try {
+    // Load active assumption sets
+    const { data: assumptionSets, error: asErr } = await supabase
+      .from('assumption_sets')
+      .select('id, market_assumptions, competitor_assumptions, product_assumptions, timing_assumptions, confidence_scores, status')
+      .eq('venture_id', ventureId)
+      .in('status', ['active', 'draft']);
+
+    if (asErr) {
+      logger.warn(`[RealityTracker] Assumption sets query failed: ${asErr.message}`);
+      return null;
+    }
+
+    if (!assumptionSets || assumptionSets.length === 0) {
+      return null;
+    }
+
+    // Load reality measurements from artifacts
+    const { data: artifacts, error: artErr } = await supabase
+      .from('venture_artifacts')
+      .select('artifact_type, artifact_data, lifecycle_stage')
+      .eq('venture_id', ventureId)
+      .eq('is_current', true)
+      .gte('lifecycle_stage', REALITY_STAGE_THRESHOLD);
+
+    if (artErr) {
+      logger.warn(`[RealityTracker] Reality artifacts query failed: ${artErr.message}`);
+      return null;
+    }
+
+    const realityData = extractRealityFromArtifacts(artifacts || []);
+
+    // Build per-category calibration
+    const categoryScores = {};
+    let totalScore = 0;
+    let categoryCount = 0;
+
+    for (const category of ASSUMPTION_CATEGORIES) {
+      const assumptionData = mergeAssumptionCategory(assumptionSets, category);
+      const reality = realityData[category] || {};
+
+      if (Object.keys(assumptionData).length === 0 && Object.keys(reality).length === 0) {
+        continue;
+      }
+
+      const score = computeCategoryAccuracy(assumptionData, reality);
+      categoryScores[category] = {
+        accuracy: round2(score.accuracy),
+        matched_fields: score.matchedFields,
+        total_fields: score.totalFields,
+        error_magnitude: round2(score.errorMagnitude),
+      };
+
+      totalScore += score.accuracy;
+      categoryCount++;
+    }
+
+    const aggregateAccuracy = categoryCount > 0 ? round2(totalScore / categoryCount) : 0;
+
+    return {
+      venture_id: ventureId,
+      aggregate_accuracy: aggregateAccuracy,
+      category_scores: categoryScores,
+      reality_artifact_count: (artifacts || []).length,
+      assumption_set_count: assumptionSets.length,
+      calibrated_at: new Date().toISOString(),
+      calibrator_version: '1.0.0',
+    };
+  } catch (err) {
+    logger.warn(`[RealityTracker] buildCalibrationReport failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Update assumption_sets with reality data, calibration report, and status.
+ * Fire-and-forget: errors are logged but never thrown.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {number} stageId - Current lifecycle stage
+ * @param {Object} calibrationReport - Result from buildCalibrationReport
+ * @param {Object} [logger=console] - Logger
+ */
+export function updateAssumptionSetStatus(supabase, ventureId, stageId, calibrationReport, logger = console) {
+  if (!supabase || !calibrationReport) return;
+
+  const newStatus = deriveStatus(calibrationReport.aggregate_accuracy);
+
+  // Fire-and-forget
+  supabase
+    .from('assumption_sets')
+    .update({
+      reality_data: calibrationReport.category_scores,
+      calibration_report: calibrationReport,
+      status: newStatus,
+      finalized_at_stage: stageId,
+    })
+    .eq('venture_id', ventureId)
+    .in('status', ['active', 'draft', 'partially_validated'])
+    .then(({ error }) => {
+      if (error) {
+        logger.warn(`[RealityTracker] Update failed (non-fatal): ${error.message}`);
+      }
+    })
+    .catch((err) => {
+      logger.warn(`[RealityTracker] Update error (non-fatal): ${err.message}`);
+    });
+}
+
+/**
+ * Run the full reality tracking pipeline for a venture at the current stage.
+ * Orchestrates collect → calibrate → update in sequence.
+ *
+ * @param {Object} params
+ * @param {string} params.ventureId
+ * @param {number} params.stageId
+ * @param {Object} deps
+ * @param {Object} deps.supabase
+ * @param {Object} [deps.logger]
+ * @returns {Promise<Object|null>} Calibration report or null if not applicable
+ */
+export async function runRealityTracking({ ventureId, stageId }, deps = {}) {
+  const { supabase, logger = console } = deps;
+
+  if (!supabase || stageId < REALITY_STAGE_THRESHOLD) {
+    return null;
+  }
+
+  const measurements = await collectRealityMeasurements(supabase, ventureId, stageId, logger);
+  if (!measurements) {
+    return null;
+  }
+
+  const report = await buildCalibrationReport(supabase, ventureId, logger);
+  if (!report) {
+    return null;
+  }
+
+  // Fire-and-forget status update
+  updateAssumptionSetStatus(supabase, ventureId, stageId, report, logger);
+
+  return report;
+}
+
+// ── Internal helpers ──
+
+/**
+ * Extract reality data from artifacts into category buckets.
+ */
+function extractRealityFromArtifacts(artifacts) {
+  const reality = {};
+  for (const cat of ASSUMPTION_CATEGORIES) {
+    reality[cat] = {};
+  }
+
+  for (const art of artifacts) {
+    const data = art.artifact_data;
+    if (!data || typeof data !== 'object') continue;
+
+    if (data.market_validation) Object.assign(reality.market_assumptions, flattenObject(data.market_validation));
+    if (data.market_metrics) Object.assign(reality.market_assumptions, flattenObject(data.market_metrics));
+    if (data.competitive_analysis) Object.assign(reality.competitor_assumptions, flattenObject(data.competitive_analysis));
+    if (data.product_metrics) Object.assign(reality.product_assumptions, flattenObject(data.product_metrics));
+    if (data.user_feedback) Object.assign(reality.product_assumptions, flattenObject(data.user_feedback));
+    if (data.timeline_actual) Object.assign(reality.timing_assumptions, flattenObject(data.timeline_actual));
+    if (data.milestone_tracking) Object.assign(reality.timing_assumptions, flattenObject(data.milestone_tracking));
+  }
+
+  return reality;
+}
+
+/**
+ * Flatten a nested object to single-level key-value pairs.
+ */
+function flattenObject(obj, prefix = '') {
+  const result = {};
+  if (!obj || typeof obj !== 'object') return result;
+
+  for (const [key, value] of Object.entries(obj)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      Object.assign(result, flattenObject(value, fullKey));
+    } else {
+      result[fullKey] = value;
+    }
+  }
+  return result;
+}
+
+/**
+ * Merge assumption data from multiple assumption sets for a given category.
+ */
+function mergeAssumptionCategory(assumptionSets, category) {
+  const merged = {};
+  for (const as of assumptionSets) {
+    const catData = as[category];
+    if (catData && typeof catData === 'object') {
+      Object.assign(merged, flattenObject(catData));
+    }
+  }
+  return merged;
+}
+
+/**
+ * Compute accuracy score for a single category by comparing assumptions vs reality.
+ *
+ * accuracy_score = 1 - avg(error_magnitude)
+ * where error_magnitude for each field is normalized to 0-1 range.
+ */
+function computeCategoryAccuracy(assumptions, reality) {
+  const assumptionKeys = Object.keys(assumptions);
+  const realityKeys = Object.keys(reality);
+
+  if (assumptionKeys.length === 0) {
+    return { accuracy: 0, matchedFields: 0, totalFields: 0, errorMagnitude: 1 };
+  }
+
+  let totalError = 0;
+  let matchedFields = 0;
+
+  for (const key of assumptionKeys) {
+    if (key in reality) {
+      matchedFields++;
+      const assumed = assumptions[key];
+      const actual = reality[key];
+      totalError += computeFieldError(assumed, actual);
+    }
+  }
+
+  if (matchedFields === 0) {
+    return { accuracy: 0, matchedFields: 0, totalFields: assumptionKeys.length, errorMagnitude: 1 };
+  }
+
+  const avgError = totalError / matchedFields;
+  return {
+    accuracy: round2(1 - avgError),
+    matchedFields,
+    totalFields: assumptionKeys.length,
+    errorMagnitude: round2(avgError),
+  };
+}
+
+/**
+ * Compute error magnitude for a single field (0 = exact match, 1 = max divergence).
+ */
+function computeFieldError(assumed, actual) {
+  // Both numeric: relative error capped at 1
+  if (typeof assumed === 'number' && typeof actual === 'number') {
+    if (assumed === 0 && actual === 0) return 0;
+    const denom = Math.max(Math.abs(assumed), Math.abs(actual), 1);
+    return Math.min(Math.abs(assumed - actual) / denom, 1);
+  }
+
+  // Both strings: exact match = 0, mismatch = 1
+  if (typeof assumed === 'string' && typeof actual === 'string') {
+    return assumed.toLowerCase() === actual.toLowerCase() ? 0 : 1;
+  }
+
+  // Both booleans: match = 0, mismatch = 1
+  if (typeof assumed === 'boolean' && typeof actual === 'boolean') {
+    return assumed === actual ? 0 : 1;
+  }
+
+  // Type mismatch = full error
+  return 1;
+}
+
+/**
+ * Derive assumption set status from aggregate accuracy.
+ */
+function deriveStatus(accuracy) {
+  if (accuracy >= STATUS_THRESHOLDS.VALIDATED) return 'validated';
+  if (accuracy < STATUS_THRESHOLDS.INVALIDATED) return 'invalidated';
+  return 'partially_validated';
+}
+
+// Exported for testing
+export const _internal = {
+  extractRealityFromArtifacts,
+  flattenObject,
+  mergeAssumptionCategory,
+  computeCategoryAccuracy,
+  computeFieldError,
+  deriveStatus,
+  REALITY_STAGE_THRESHOLD,
+  STATUS_THRESHOLDS,
+  ASSUMPTION_CATEGORIES,
+};

--- a/tests/unit/eva/assumption-reality-tracker.test.js
+++ b/tests/unit/eva/assumption-reality-tracker.test.js
@@ -1,0 +1,773 @@
+/**
+ * Assumption-Reality Tracker Unit Tests
+ * SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-D
+ *
+ * Tests: collectRealityMeasurements, buildCalibrationReport,
+ *        updateAssumptionSetStatus, runRealityTracking, and internal helpers
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  collectRealityMeasurements,
+  buildCalibrationReport,
+  updateAssumptionSetStatus,
+  runRealityTracking,
+  _internal,
+} from '../../../lib/eva/utils/assumption-reality-tracker.js';
+
+const {
+  computeFieldError,
+  computeCategoryAccuracy,
+  deriveStatus,
+  flattenObject,
+  mergeAssumptionCategory,
+  extractRealityFromArtifacts,
+  REALITY_STAGE_THRESHOLD,
+  STATUS_THRESHOLDS,
+  ASSUMPTION_CATEGORIES,
+} = _internal;
+
+// ── Mock factories ──
+
+function createMockLogger() {
+  return { warn: vi.fn(), log: vi.fn(), error: vi.fn(), info: vi.fn() };
+}
+
+/**
+ * Create a chainable mock supabase client.
+ * Each chain method returns `this` so .from().select().eq().gte().order() works.
+ * Call `mockSupabase._resolve(data, error)` to set the final resolved value.
+ */
+function createMockSupabase(resolvedData = [], resolvedError = null) {
+  const chain = {
+    _resolvedData: resolvedData,
+    _resolvedError: resolvedError,
+    from: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockImplementation(function () {
+      return Promise.resolve({ data: this._resolvedData, error: this._resolvedError });
+    }),
+    then: vi.fn().mockImplementation(function (cb) {
+      return Promise.resolve({ data: this._resolvedData, error: this._resolvedError }).then(cb);
+    }),
+    catch: vi.fn().mockReturnThis(),
+  };
+  return chain;
+}
+
+/**
+ * Multi-query supabase mock: returns different results for sequential .from() calls.
+ * Usage: createMultiQuerySupabase([
+ *   { data: [...], error: null },  // first query result
+ *   { data: [...], error: null },  // second query result
+ * ])
+ */
+function createMultiQuerySupabase(results) {
+  let callIndex = 0;
+  const chain = {
+    from: vi.fn().mockImplementation(() => {
+      const idx = callIndex++;
+      const result = results[idx] || { data: null, error: null };
+      const queryChain = {
+        select: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockReturnThis(),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        in: vi.fn().mockReturnThis(),
+        gte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockImplementation(() => {
+          return Promise.resolve({ data: result.data, error: result.error });
+        }),
+        then: vi.fn().mockImplementation((cb) => {
+          return Promise.resolve({ data: result.data, error: result.error }).then(cb);
+        }),
+        catch: vi.fn().mockReturnThis(),
+      };
+      return queryChain;
+    }),
+  };
+  return chain;
+}
+
+// ── Pure function tests ──
+
+describe('Assumption-Reality Tracker', () => {
+  let mockLogger;
+
+  beforeEach(() => {
+    mockLogger = createMockLogger();
+  });
+
+  // ── computeFieldError ──
+
+  describe('computeFieldError', () => {
+    it('returns 0 for identical numbers', () => {
+      expect(computeFieldError(100, 100)).toBe(0);
+    });
+
+    it('returns 0 for both zeros', () => {
+      expect(computeFieldError(0, 0)).toBe(0);
+    });
+
+    it('computes relative error for numeric values', () => {
+      // |100 - 80| / max(100, 80, 1) = 20/100 = 0.2
+      expect(computeFieldError(100, 80)).toBeCloseTo(0.2, 5);
+    });
+
+    it('caps numeric error at 1', () => {
+      // |1 - 1000| / max(1, 1000, 1) = 999/1000 = 0.999
+      expect(computeFieldError(1, 1000)).toBeLessThanOrEqual(1);
+    });
+
+    it('returns 0 for matching strings (case-insensitive)', () => {
+      expect(computeFieldError('High', 'high')).toBe(0);
+    });
+
+    it('returns 1 for mismatched strings', () => {
+      expect(computeFieldError('High', 'Low')).toBe(1);
+    });
+
+    it('returns 0 for matching booleans', () => {
+      expect(computeFieldError(true, true)).toBe(0);
+      expect(computeFieldError(false, false)).toBe(0);
+    });
+
+    it('returns 1 for mismatched booleans', () => {
+      expect(computeFieldError(true, false)).toBe(1);
+    });
+
+    it('returns 1 for type mismatch', () => {
+      expect(computeFieldError(100, 'hundred')).toBe(1);
+      expect(computeFieldError(true, 1)).toBe(1);
+      expect(computeFieldError('yes', true)).toBe(1);
+    });
+  });
+
+  // ── deriveStatus ──
+
+  describe('deriveStatus', () => {
+    it('returns validated for accuracy >= 0.7', () => {
+      expect(deriveStatus(0.7)).toBe('validated');
+      expect(deriveStatus(0.85)).toBe('validated');
+      expect(deriveStatus(1.0)).toBe('validated');
+    });
+
+    it('returns invalidated for accuracy < 0.3', () => {
+      expect(deriveStatus(0.0)).toBe('invalidated');
+      expect(deriveStatus(0.1)).toBe('invalidated');
+      expect(deriveStatus(0.29)).toBe('invalidated');
+    });
+
+    it('returns partially_validated for accuracy between 0.3 and 0.7', () => {
+      expect(deriveStatus(0.3)).toBe('partially_validated');
+      expect(deriveStatus(0.5)).toBe('partially_validated');
+      expect(deriveStatus(0.69)).toBe('partially_validated');
+    });
+  });
+
+  // ── flattenObject ──
+
+  describe('flattenObject', () => {
+    it('returns empty object for null/undefined input', () => {
+      expect(flattenObject(null)).toEqual({});
+      expect(flattenObject(undefined)).toEqual({});
+    });
+
+    it('returns empty object for non-object input', () => {
+      expect(flattenObject('string')).toEqual({});
+      expect(flattenObject(42)).toEqual({});
+    });
+
+    it('flattens a single-level object', () => {
+      expect(flattenObject({ a: 1, b: 'x' })).toEqual({ a: 1, b: 'x' });
+    });
+
+    it('flattens nested objects to dot-notation keys', () => {
+      const input = { market: { size: 1000, growth: 0.15 } };
+      expect(flattenObject(input)).toEqual({
+        'market.size': 1000,
+        'market.growth': 0.15,
+      });
+    });
+
+    it('flattens deeply nested objects', () => {
+      const input = { a: { b: { c: 42 } } };
+      expect(flattenObject(input)).toEqual({ 'a.b.c': 42 });
+    });
+
+    it('preserves arrays as leaf values', () => {
+      const input = { tags: ['a', 'b'], nested: { items: [1, 2] } };
+      expect(flattenObject(input)).toEqual({
+        tags: ['a', 'b'],
+        'nested.items': [1, 2],
+      });
+    });
+
+    it('preserves null values as leaves', () => {
+      const input = { a: null, b: { c: null } };
+      expect(flattenObject(input)).toEqual({ a: null, 'b.c': null });
+    });
+
+    it('uses prefix when provided', () => {
+      expect(flattenObject({ x: 1 }, 'root')).toEqual({ 'root.x': 1 });
+    });
+  });
+
+  // ── computeCategoryAccuracy ──
+
+  describe('computeCategoryAccuracy', () => {
+    it('returns zero accuracy for empty assumptions', () => {
+      const result = computeCategoryAccuracy({}, { tam: 5000 });
+      expect(result.accuracy).toBe(0);
+      expect(result.matchedFields).toBe(0);
+      expect(result.totalFields).toBe(0);
+      expect(result.errorMagnitude).toBe(1);
+    });
+
+    it('returns zero accuracy when no fields match', () => {
+      const assumptions = { tam: 5000, growth: 0.2 };
+      const reality = { revenue: 1000, churn: 0.05 };
+      const result = computeCategoryAccuracy(assumptions, reality);
+      expect(result.accuracy).toBe(0);
+      expect(result.matchedFields).toBe(0);
+      expect(result.totalFields).toBe(2);
+      expect(result.errorMagnitude).toBe(1);
+    });
+
+    it('computes accuracy for fully matched fields', () => {
+      const assumptions = { tam: 5000, growth: 0.2 };
+      const reality = { tam: 5000, growth: 0.2 };
+      const result = computeCategoryAccuracy(assumptions, reality);
+      expect(result.accuracy).toBe(1);
+      expect(result.matchedFields).toBe(2);
+      expect(result.totalFields).toBe(2);
+      expect(result.errorMagnitude).toBe(0);
+    });
+
+    it('computes partial accuracy for partially matched fields', () => {
+      const assumptions = { tam: 5000, growth: 0.2, segment: 'enterprise' };
+      const reality = { tam: 4000, growth: 0.2 };
+      // tam: |5000-4000|/5000 = 0.2, growth: 0 => avg error = 0.1 => accuracy = 0.9
+      const result = computeCategoryAccuracy(assumptions, reality);
+      expect(result.matchedFields).toBe(2);
+      expect(result.totalFields).toBe(3);
+      expect(result.accuracy).toBeCloseTo(0.9, 1);
+    });
+  });
+
+  // ── mergeAssumptionCategory ──
+
+  describe('mergeAssumptionCategory', () => {
+    it('merges data from multiple assumption sets', () => {
+      const sets = [
+        { market_assumptions: { tam: 5000 } },
+        { market_assumptions: { growth: 0.15 } },
+      ];
+      const result = mergeAssumptionCategory(sets, 'market_assumptions');
+      expect(result).toEqual({ tam: 5000, growth: 0.15 });
+    });
+
+    it('later sets override earlier sets for same key', () => {
+      const sets = [
+        { market_assumptions: { tam: 5000 } },
+        { market_assumptions: { tam: 6000 } },
+      ];
+      const result = mergeAssumptionCategory(sets, 'market_assumptions');
+      expect(result.tam).toBe(6000);
+    });
+
+    it('returns empty object when no sets have the category', () => {
+      const sets = [{ market_assumptions: null }, {}];
+      const result = mergeAssumptionCategory(sets, 'market_assumptions');
+      expect(result).toEqual({});
+    });
+
+    it('flattens nested assumption data', () => {
+      const sets = [{ market_assumptions: { detail: { tam: 5000 } } }];
+      const result = mergeAssumptionCategory(sets, 'market_assumptions');
+      expect(result).toEqual({ 'detail.tam': 5000 });
+    });
+  });
+
+  // ── extractRealityFromArtifacts ──
+
+  describe('extractRealityFromArtifacts', () => {
+    it('returns empty category buckets for empty artifacts', () => {
+      const result = extractRealityFromArtifacts([]);
+      expect(result).toEqual({
+        market_assumptions: {},
+        competitor_assumptions: {},
+        product_assumptions: {},
+        timing_assumptions: {},
+      });
+    });
+
+    it('extracts market_validation into market_assumptions', () => {
+      const artifacts = [{
+        artifact_data: { market_validation: { tam: 8000, growth: 0.12 } },
+      }];
+      const result = extractRealityFromArtifacts(artifacts);
+      expect(result.market_assumptions).toEqual({ tam: 8000, growth: 0.12 });
+    });
+
+    it('extracts competitive_analysis into competitor_assumptions', () => {
+      const artifacts = [{
+        artifact_data: { competitive_analysis: { players: 5 } },
+      }];
+      const result = extractRealityFromArtifacts(artifacts);
+      expect(result.competitor_assumptions).toEqual({ players: 5 });
+    });
+
+    it('extracts product_metrics into product_assumptions', () => {
+      const artifacts = [{
+        artifact_data: { product_metrics: { dau: 500 } },
+      }];
+      const result = extractRealityFromArtifacts(artifacts);
+      expect(result.product_assumptions).toEqual({ dau: 500 });
+    });
+
+    it('extracts timeline_actual into timing_assumptions', () => {
+      const artifacts = [{
+        artifact_data: { timeline_actual: { months_to_mvp: 4 } },
+      }];
+      const result = extractRealityFromArtifacts(artifacts);
+      expect(result.timing_assumptions).toEqual({ months_to_mvp: 4 });
+    });
+
+    it('skips artifacts with null or non-object data', () => {
+      const artifacts = [
+        { artifact_data: null },
+        { artifact_data: 'not an object' },
+        { artifact_data: { market_metrics: { tam: 1000 } } },
+      ];
+      const result = extractRealityFromArtifacts(artifacts);
+      expect(result.market_assumptions).toEqual({ tam: 1000 });
+    });
+
+    it('merges multiple artifacts into same category', () => {
+      const artifacts = [
+        { artifact_data: { market_validation: { tam: 5000 } } },
+        { artifact_data: { market_metrics: { growth: 0.1 } } },
+      ];
+      const result = extractRealityFromArtifacts(artifacts);
+      expect(result.market_assumptions).toEqual({ tam: 5000, growth: 0.1 });
+    });
+  });
+
+  // ── Constants ──
+
+  describe('Constants', () => {
+    it('exposes REALITY_STAGE_THRESHOLD as 17', () => {
+      expect(REALITY_STAGE_THRESHOLD).toBe(17);
+    });
+
+    it('exposes STATUS_THRESHOLDS with correct values', () => {
+      expect(STATUS_THRESHOLDS.VALIDATED).toBe(0.7);
+      expect(STATUS_THRESHOLDS.INVALIDATED).toBe(0.3);
+    });
+
+    it('exposes four ASSUMPTION_CATEGORIES', () => {
+      expect(ASSUMPTION_CATEGORIES).toHaveLength(4);
+      expect(ASSUMPTION_CATEGORIES).toContain('market_assumptions');
+      expect(ASSUMPTION_CATEGORIES).toContain('competitor_assumptions');
+      expect(ASSUMPTION_CATEGORIES).toContain('product_assumptions');
+      expect(ASSUMPTION_CATEGORIES).toContain('timing_assumptions');
+    });
+  });
+
+  // ── collectRealityMeasurements ──
+
+  describe('collectRealityMeasurements', () => {
+    it('returns null for stages below threshold', async () => {
+      const result = await collectRealityMeasurements({}, 'v-1', 16, mockLogger);
+      expect(result).toBeNull();
+    });
+
+    it('returns null for stage exactly at threshold - 1', async () => {
+      const result = await collectRealityMeasurements({}, 'v-1', REALITY_STAGE_THRESHOLD - 1, mockLogger);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when supabase query errors', async () => {
+      const mockSb = createMockSupabase(null, { message: 'query failed' });
+      const result = await collectRealityMeasurements(mockSb, 'v-1', 17, mockLogger);
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Artifact query failed'));
+    });
+
+    it('returns null when no artifacts found', async () => {
+      const mockSb = createMockSupabase([], null);
+      const result = await collectRealityMeasurements(mockSb, 'v-1', 17, mockLogger);
+      expect(result).toBeNull();
+    });
+
+    it('extracts market data from artifacts', async () => {
+      const artifacts = [
+        {
+          lifecycle_stage: 18,
+          artifact_type: 'market_report',
+          artifact_data: { market_validation: { tam: 10000 } },
+        },
+      ];
+      const mockSb = createMockSupabase(artifacts, null);
+      const result = await collectRealityMeasurements(mockSb, 'v-1', 18, mockLogger);
+      expect(result).not.toBeNull();
+      expect(result.market_assumptions).toHaveLength(1);
+      expect(result.market_assumptions[0].data).toEqual({ tam: 10000 });
+      expect(result.market_assumptions[0].stage).toBe(18);
+    });
+
+    it('extracts competitor data from artifacts', async () => {
+      const artifacts = [{
+        lifecycle_stage: 17,
+        artifact_type: 'competitive',
+        artifact_data: { competitive_analysis: { players: 3 } },
+      }];
+      const mockSb = createMockSupabase(artifacts, null);
+      const result = await collectRealityMeasurements(mockSb, 'v-1', 17, mockLogger);
+      expect(result.competitor_assumptions).toHaveLength(1);
+      expect(result.competitor_assumptions[0].data).toEqual({ players: 3 });
+    });
+
+    it('extracts product data from user_feedback', async () => {
+      const artifacts = [{
+        lifecycle_stage: 20,
+        artifact_type: 'feedback',
+        artifact_data: { user_feedback: { nps: 45 } },
+      }];
+      const mockSb = createMockSupabase(artifacts, null);
+      const result = await collectRealityMeasurements(mockSb, 'v-1', 20, mockLogger);
+      expect(result.product_assumptions).toHaveLength(1);
+      expect(result.product_assumptions[0].data).toEqual({ nps: 45 });
+    });
+
+    it('extracts timing data from milestone_tracking', async () => {
+      const artifacts = [{
+        lifecycle_stage: 19,
+        artifact_type: 'timeline',
+        artifact_data: { milestone_tracking: { on_track: true } },
+      }];
+      const mockSb = createMockSupabase(artifacts, null);
+      const result = await collectRealityMeasurements(mockSb, 'v-1', 19, mockLogger);
+      expect(result.timing_assumptions).toHaveLength(1);
+    });
+
+    it('skips artifacts with non-object artifact_data', async () => {
+      const artifacts = [
+        { lifecycle_stage: 17, artifact_type: 'x', artifact_data: null },
+        { lifecycle_stage: 17, artifact_type: 'y', artifact_data: 'bad' },
+      ];
+      const mockSb = createMockSupabase(artifacts, null);
+      const result = await collectRealityMeasurements(mockSb, 'v-1', 17, mockLogger);
+      // All categories should be empty arrays
+      expect(result.market_assumptions).toHaveLength(0);
+      expect(result.competitor_assumptions).toHaveLength(0);
+      expect(result.product_assumptions).toHaveLength(0);
+      expect(result.timing_assumptions).toHaveLength(0);
+    });
+
+    it('queries from venture_artifacts with correct filters', async () => {
+      const mockSb = createMockSupabase([], null);
+      await collectRealityMeasurements(mockSb, 'v-abc', 17, mockLogger);
+      expect(mockSb.from).toHaveBeenCalledWith('venture_artifacts');
+      expect(mockSb.select).toHaveBeenCalledWith('artifact_type, artifact_data, lifecycle_stage');
+      expect(mockSb.eq).toHaveBeenCalledWith('venture_id', 'v-abc');
+      expect(mockSb.eq).toHaveBeenCalledWith('is_current', true);
+      expect(mockSb.gte).toHaveBeenCalledWith('lifecycle_stage', 17);
+    });
+  });
+
+  // ── buildCalibrationReport ──
+
+  describe('buildCalibrationReport', () => {
+    it('returns null when assumption_sets query fails', async () => {
+      const mockSb = createMultiQuerySupabase([
+        { data: null, error: { message: 'db error' } },
+      ]);
+      const result = await buildCalibrationReport(mockSb, 'v-1', mockLogger);
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Assumption sets query failed'));
+    });
+
+    it('returns null when no assumption sets exist', async () => {
+      const mockSb = createMultiQuerySupabase([
+        { data: [], error: null },
+      ]);
+      const result = await buildCalibrationReport(mockSb, 'v-1', mockLogger);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when artifact query fails', async () => {
+      const mockSb = createMultiQuerySupabase([
+        { data: [{ id: 'as-1', market_assumptions: { tam: 5000 } }], error: null },
+        { data: null, error: { message: 'artifact error' } },
+      ]);
+      const result = await buildCalibrationReport(mockSb, 'v-1', mockLogger);
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Reality artifacts query failed'));
+    });
+
+    it('computes per-category accuracy scores', async () => {
+      const mockSb = createMultiQuerySupabase([
+        {
+          data: [{
+            id: 'as-1',
+            market_assumptions: { tam: 5000, growth: 0.2 },
+            competitor_assumptions: null,
+            product_assumptions: null,
+            timing_assumptions: null,
+            confidence_scores: {},
+            status: 'active',
+          }],
+          error: null,
+        },
+        {
+          data: [{
+            artifact_type: 'market_report',
+            artifact_data: { market_validation: { tam: 5000, growth: 0.2 } },
+            lifecycle_stage: 18,
+          }],
+          error: null,
+        },
+      ]);
+
+      const result = await buildCalibrationReport(mockSb, 'v-1', mockLogger);
+      expect(result).not.toBeNull();
+      expect(result.venture_id).toBe('v-1');
+      expect(result.aggregate_accuracy).toBe(1);
+      expect(result.category_scores.market_assumptions).toBeDefined();
+      expect(result.category_scores.market_assumptions.accuracy).toBe(1);
+      expect(result.assumption_set_count).toBe(1);
+      expect(result.calibrator_version).toBe('1.0.0');
+      expect(result.calibrated_at).toBeDefined();
+    });
+
+    it('handles empty artifacts gracefully', async () => {
+      const mockSb = createMultiQuerySupabase([
+        {
+          data: [{
+            id: 'as-1',
+            market_assumptions: { tam: 5000 },
+            competitor_assumptions: null,
+            product_assumptions: null,
+            timing_assumptions: null,
+            confidence_scores: {},
+            status: 'active',
+          }],
+          error: null,
+        },
+        { data: [], error: null },
+      ]);
+
+      const result = await buildCalibrationReport(mockSb, 'v-1', mockLogger);
+      expect(result).not.toBeNull();
+      // No reality data, so accuracy should be 0 for any category with assumptions
+      expect(result.aggregate_accuracy).toBe(0);
+      expect(result.reality_artifact_count).toBe(0);
+    });
+  });
+
+  // ── updateAssumptionSetStatus ──
+
+  describe('updateAssumptionSetStatus', () => {
+    it('does nothing when supabase is null', () => {
+      updateAssumptionSetStatus(null, 'v-1', 18, { aggregate_accuracy: 0.8 }, mockLogger);
+      // Should not throw
+    });
+
+    it('does nothing when calibrationReport is null', () => {
+      const mockSb = createMockSupabase();
+      updateAssumptionSetStatus(mockSb, 'v-1', 18, null, mockLogger);
+      expect(mockSb.from).not.toHaveBeenCalled();
+    });
+
+    it('calls supabase update with validated status for accuracy >= 0.7', async () => {
+      const report = { aggregate_accuracy: 0.85, category_scores: {} };
+      const mockSb = createMockSupabase();
+      // Override update chain to be thenable
+      mockSb.in.mockReturnValue({
+        then: vi.fn().mockImplementation((cb) => {
+          cb({ error: null });
+          return { catch: vi.fn() };
+        }),
+      });
+
+      updateAssumptionSetStatus(mockSb, 'v-1', 20, report, mockLogger);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockSb.from).toHaveBeenCalledWith('assumption_sets');
+      expect(mockSb.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'validated',
+          finalized_at_stage: 20,
+          calibration_report: report,
+        }),
+      );
+    });
+
+    it('calls supabase update with invalidated status for accuracy < 0.3', async () => {
+      const report = { aggregate_accuracy: 0.1, category_scores: {} };
+      const mockSb = createMockSupabase();
+      mockSb.in.mockReturnValue({
+        then: vi.fn().mockImplementation((cb) => {
+          cb({ error: null });
+          return { catch: vi.fn() };
+        }),
+      });
+
+      updateAssumptionSetStatus(mockSb, 'v-1', 20, report, mockLogger);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockSb.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'invalidated' }),
+      );
+    });
+
+    it('calls supabase update with partially_validated status for accuracy between thresholds', async () => {
+      const report = { aggregate_accuracy: 0.5, category_scores: {} };
+      const mockSb = createMockSupabase();
+      mockSb.in.mockReturnValue({
+        then: vi.fn().mockImplementation((cb) => {
+          cb({ error: null });
+          return { catch: vi.fn() };
+        }),
+      });
+
+      updateAssumptionSetStatus(mockSb, 'v-1', 20, report, mockLogger);
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(mockSb.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'partially_validated' }),
+      );
+    });
+
+    it('does not throw on supabase error (fire-and-forget)', async () => {
+      const report = { aggregate_accuracy: 0.8, category_scores: {} };
+      const mockSb = createMockSupabase();
+      mockSb.in.mockReturnValue({
+        then: vi.fn().mockImplementation((cb) => {
+          cb({ error: { message: 'update failed' } });
+          return { catch: vi.fn() };
+        }),
+      });
+
+      // Should not throw
+      expect(() => {
+        updateAssumptionSetStatus(mockSb, 'v-1', 20, report, mockLogger);
+      }).not.toThrow();
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Update failed (non-fatal)'));
+    });
+
+    it('does not throw on promise rejection (fire-and-forget)', async () => {
+      const report = { aggregate_accuracy: 0.8, category_scores: {} };
+      const mockSb = createMockSupabase();
+      mockSb.in.mockReturnValue({
+        then: vi.fn().mockImplementation(() => {
+          return {
+            catch: vi.fn().mockImplementation((handler) => {
+              handler(new Error('network error'));
+            }),
+          };
+        }),
+      });
+
+      expect(() => {
+        updateAssumptionSetStatus(mockSb, 'v-1', 20, report, mockLogger);
+      }).not.toThrow();
+
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('Update error (non-fatal)'));
+    });
+  });
+
+  // ── runRealityTracking ──
+
+  describe('runRealityTracking', () => {
+    it('returns null when supabase is not provided', async () => {
+      const result = await runRealityTracking({ ventureId: 'v-1', stageId: 18 }, { logger: mockLogger });
+      expect(result).toBeNull();
+    });
+
+    it('returns null when stageId is below threshold', async () => {
+      const mockSb = createMockSupabase();
+      const result = await runRealityTracking(
+        { ventureId: 'v-1', stageId: 10 },
+        { supabase: mockSb, logger: mockLogger },
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns null when collectRealityMeasurements returns null (no artifacts)', async () => {
+      // First query (collectRealityMeasurements) returns empty
+      const mockSb = createMultiQuerySupabase([
+        { data: [], error: null },
+      ]);
+      const result = await runRealityTracking(
+        { ventureId: 'v-1', stageId: 18 },
+        { supabase: mockSb, logger: mockLogger },
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns calibration report for full pipeline success', async () => {
+      // We need 3 queries: collectRealityMeasurements, then buildCalibrationReport (2 queries)
+      const artifacts = [{
+        lifecycle_stage: 18,
+        artifact_type: 'market_report',
+        artifact_data: { market_validation: { tam: 5000 } },
+      }];
+      const assumptionSets = [{
+        id: 'as-1',
+        market_assumptions: { tam: 5000 },
+        competitor_assumptions: null,
+        product_assumptions: null,
+        timing_assumptions: null,
+        confidence_scores: {},
+        status: 'active',
+      }];
+
+      const mockSb = createMultiQuerySupabase([
+        { data: artifacts, error: null },       // collectRealityMeasurements
+        { data: assumptionSets, error: null },  // buildCalibrationReport - assumption_sets
+        { data: artifacts, error: null },        // buildCalibrationReport - artifacts
+      ]);
+
+      const result = await runRealityTracking(
+        { ventureId: 'v-1', stageId: 18 },
+        { supabase: mockSb, logger: mockLogger },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.venture_id).toBe('v-1');
+      expect(result.aggregate_accuracy).toBeDefined();
+      expect(result.category_scores).toBeDefined();
+    });
+
+    it('returns null when buildCalibrationReport fails', async () => {
+      const artifacts = [{
+        lifecycle_stage: 18,
+        artifact_type: 'x',
+        artifact_data: { market_validation: { tam: 5000 } },
+      }];
+
+      const mockSb = createMultiQuerySupabase([
+        { data: artifacts, error: null },                       // collectRealityMeasurements
+        { data: null, error: { message: 'assumption error' } }, // buildCalibrationReport fails
+      ]);
+
+      const result = await runRealityTracking(
+        { ventureId: 'v-1', stageId: 18 },
+        { supabase: mockSb, logger: mockLogger },
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements the assumptions-vs-reality end-to-end loop for EVA pipeline (SD-MAN-ORCH-EVA-INTELLIGENCE-LAYER-001-D)
- New module `lib/eva/utils/assumption-reality-tracker.js` with fire-and-forget DB writes matching token-tracker pattern
- Wired into `eva-orchestrator.js` at stage >= 17 post-stage hook
- Extended `cross-venture-learning.js` with portfolio-level `analyzeAssumptionCalibration()`
- 65 unit tests covering all functions, edge cases, and fire-and-forget error handling

## Test plan
- [x] 65 unit tests pass (assumption-reality-tracker.test.js)
- [x] All 2607 EVA tests pass (96 test files)
- [x] Pre-existing failures unchanged (60 files, all environment/config related)

🤖 Generated with [Claude Code](https://claude.com/claude-code)