### PR TITLE
refactor: lean CLAUDE digest files — remove phase-transition duplicates

### DIFF
--- a/.claude/.protocol-sync
+++ b/.claude/.protocol-sync
@@ -1,1 +1,1 @@
-{"timestamp":"2026-02-16T13:34:53.873Z","pid":24264,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}
+{"timestamp":"2026-02-16T13:41:25.310Z","pid":18564,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,4 +111,4 @@ Escalate to full files (e.g. `CLAUDE_CORE.md`) only when digest is insufficient.
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-02-16 8:39:05 AM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-02-16 8:44:35 AM | Protocol: LEO 4.3.3 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-02-16 8:39:05 AM
+**Generated**: 2026-02-16 8:44:35 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-16T13:39:05.049Z -->
-<!-- git_commit: b22f9b27 -->
+<!-- generated_at: 2026-02-16T13:44:35.875Z -->
+<!-- git_commit: d86162ab -->
 <!-- db_snapshot_hash: 6c0e5841d5dacd55 -->
 <!-- file_content_hash: pending -->
 
@@ -826,5 +826,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-02-16 8:39:05 AM*
+*DIGEST generated: 2026-02-16 8:44:35 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-16T13:39:05.049Z -->
-<!-- git_commit: b22f9b27 -->
+<!-- generated_at: 2026-02-16T13:44:35.875Z -->
+<!-- git_commit: d86162ab -->
 <!-- db_snapshot_hash: 6c0e5841d5dacd55 -->
 <!-- file_content_hash: pending -->
 
@@ -145,5 +145,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-02-16 8:39:05 AM*
+*DIGEST generated: 2026-02-16 8:44:35 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-02-16 8:39:05 AM
+**Generated**: 2026-02-16 8:44:35 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-16T13:39:05.049Z -->
-<!-- git_commit: b22f9b27 -->
+<!-- generated_at: 2026-02-16T13:44:35.875Z -->
+<!-- git_commit: d86162ab -->
 <!-- db_snapshot_hash: 6c0e5841d5dacd55 -->
 <!-- file_content_hash: pending -->
 
@@ -10,53 +10,6 @@
 **Purpose**: Implementation requirements and constraints (<5k chars)
 
 ---
-
-## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
-
-**Anti-Bypass Protocol**: These commands MUST be run for ALL phase transitions. Do NOT use database-agent to create handoffs directly.
-
-### ⛔ NEVER DO THIS:
-- Using `database-agent` to directly insert into `sd_phase_handoffs`
-- Creating handoff records without running validation scripts
-- Skipping preflight knowledge retrieval
-
-### ✅ ALWAYS DO THIS:
-
-#### Pre-flight Batch Validation (RECOMMENDED)
-#### LEAD → PLAN Transition
-#### PLAN → EXEC Transition
-#### EXEC → PLAN Transition (Verification)
-#### PLAN → LEAD Transition (Final Approval)
-### Emergency Bypass (SD-LEARN-010)
-For emergencies ONLY. Bypasses require audit logging and are rate-limited.
-
-**Rate Limits:**
-- 3 bypasses per SD maximum
-- 10 bypasses per day globally
-- All bypasses logged to `audit_log` table with severity=warning
-
-### What These Scripts Enforce
-| Script | Validations |
-|--------|-------------|
-| `phase-preflight.js` | Loads context, patterns, and lessons from database |
-| `handoff.js precheck` | **Batch validation** - runs ALL gates, git checks, reports ALL issues at once |
-| `handoff.js LEAD-TO-PLAN` | SD completeness (100% required), strategic objectives |
-| `handoff.js PLAN-TO-EXEC` | PRD exists (`ERR_NO_PRD`), chain completeness (`ERR_CHAIN_INCOMPLETE`) |
-| `handoff.js EXEC-TO-PLAN` | TESTING enforcement (`ERR_TESTING_REQUIRED`), chain completeness |
-| `handoff.js PLAN-TO-LEAD` | Traceability, workflow ROI, retrospective quality |
-
-### Error Codes (SD-LEARN-010)
-| Code | Meaning | Remediation |
-|------|---------|-------------|
-| `ERR_TESTING_REQUIRED` | TESTING sub-agent must run before EXEC-TO-PLAN (feature/qa SDs) | Run TESTING sub-agent first |
-| `ERR_CHAIN_INCOMPLETE` | Missing prerequisite handoff in chain | Complete missing handoff first |
-| `ERR_NO_PRD` | No PRD found for PLAN-TO-EXEC | Create PRD before proceeding |
-
-### Compliance Marker
-Valid handoffs are recorded with `created_by: 'UNIFIED-HANDOFF-SYSTEM'`. Handoffs with other `created_by` values indicate process bypass.
-
-### Check Compliance
-**FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
 ## 🚨 EXEC Agent Implementation Requirements
 
@@ -301,43 +254,6 @@ These anti-patterns are specific to the EXEC phase. Violating them leads to fail
 **Correct Approach**: Every backend field must have corresponding UI component
 </negative_constraints>
 
-## Migration Execution - DATABASE Sub-Agent Delegation
-
-### CRITICAL: Delegate Migration Execution to DATABASE Sub-Agent
-
-**CRITICAL**: When you need to execute a migration, INVOKE the DATABASE sub-agent rather than writing execution scripts yourself.
-
-The DATABASE sub-agent handles common blockers automatically:
-- **Missing SUPABASE_DB_PASSWORD**: Uses `SUPABASE_POOLER_URL` instead (no password required)
-- **Connection issues**: Uses proven connection patterns
-- **Execution failures**: Tries alternative scripts before giving up
-
-**Never give up on migration execution** - the sub-agent has multiple fallback methods.
-
-**Trigger the DATABASE sub-agent when you need to**:
-- Apply a migration file to the database
-- Execute schema changes
-- Run SQL statements against Supabase
-
-**Invocation pattern**:
-```
-Task tool with subagent_type="database-agent":
-"Execute the migration file: database/migrations/YYYYMMDD_name.sql"
-```
-
-The DATABASE sub-agent (v1.3.0+) has autonomous execution capability and will:
-1. Determine if operation is safe (AUTO-EXECUTE) or needs routing
-2. Use the correct connection pattern (SUPABASE_POOLER_URL - no password needed)
-3. Split and execute SQL statements properly
-4. Verify success and report results
-
-**Only write your own migration script if**:
-- DATABASE sub-agent is unavailable
-- You need custom pre/post processing logic
-- The migration has special transaction requirements
-
-The next section ("Migration Script Pattern") provides the FALLBACK pattern if sub-agent is unavailable.
-
 ## EXEC Dual Test Requirement
 
 ### ⚠️ MANDATORY: Dual Test Execution
@@ -449,5 +365,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-02-16 8:39:05 AM*
+*DIGEST generated: 2026-02-16 8:44:35 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-02-16 8:39:05 AM
+**Generated**: 2026-02-16 8:44:35 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-16T13:39:05.049Z -->
-<!-- git_commit: b22f9b27 -->
+<!-- generated_at: 2026-02-16T13:44:35.875Z -->
+<!-- git_commit: d86162ab -->
 <!-- db_snapshot_hash: 6c0e5841d5dacd55 -->
 <!-- file_content_hash: pending -->
 
@@ -10,53 +10,6 @@
 **Purpose**: LEAD approval gates and constraints (<5k chars)
 
 ---
-
-## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
-
-**Anti-Bypass Protocol**: These commands MUST be run for ALL phase transitions. Do NOT use database-agent to create handoffs directly.
-
-### ⛔ NEVER DO THIS:
-- Using `database-agent` to directly insert into `sd_phase_handoffs`
-- Creating handoff records without running validation scripts
-- Skipping preflight knowledge retrieval
-
-### ✅ ALWAYS DO THIS:
-
-#### Pre-flight Batch Validation (RECOMMENDED)
-#### LEAD → PLAN Transition
-#### PLAN → EXEC Transition
-#### EXEC → PLAN Transition (Verification)
-#### PLAN → LEAD Transition (Final Approval)
-### Emergency Bypass (SD-LEARN-010)
-For emergencies ONLY. Bypasses require audit logging and are rate-limited.
-
-**Rate Limits:**
-- 3 bypasses per SD maximum
-- 10 bypasses per day globally
-- All bypasses logged to `audit_log` table with severity=warning
-
-### What These Scripts Enforce
-| Script | Validations |
-|--------|-------------|
-| `phase-preflight.js` | Loads context, patterns, and lessons from database |
-| `handoff.js precheck` | **Batch validation** - runs ALL gates, git checks, reports ALL issues at once |
-| `handoff.js LEAD-TO-PLAN` | SD completeness (100% required), strategic objectives |
-| `handoff.js PLAN-TO-EXEC` | PRD exists (`ERR_NO_PRD`), chain completeness (`ERR_CHAIN_INCOMPLETE`) |
-| `handoff.js EXEC-TO-PLAN` | TESTING enforcement (`ERR_TESTING_REQUIRED`), chain completeness |
-| `handoff.js PLAN-TO-LEAD` | Traceability, workflow ROI, retrospective quality |
-
-### Error Codes (SD-LEARN-010)
-| Code | Meaning | Remediation |
-|------|---------|-------------|
-| `ERR_TESTING_REQUIRED` | TESTING sub-agent must run before EXEC-TO-PLAN (feature/qa SDs) | Run TESTING sub-agent first |
-| `ERR_CHAIN_INCOMPLETE` | Missing prerequisite handoff in chain | Complete missing handoff first |
-| `ERR_NO_PRD` | No PRD found for PLAN-TO-EXEC | Create PRD before proceeding |
-
-### Compliance Marker
-Valid handoffs are recorded with `created_by: 'UNIFIED-HANDOFF-SYSTEM'`. Handoffs with other `created_by` values indicate process bypass.
-
-### Check Compliance
-**FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
 ## 6-Step SD Evaluation Checklist
 
@@ -173,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-02-16 8:39:05 AM*
+*DIGEST generated: 2026-02-16 8:44:35 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-02-16 8:39:05 AM
+**Generated**: 2026-02-16 8:44:35 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-02-16T13:39:05.049Z -->
-<!-- git_commit: b22f9b27 -->
+<!-- generated_at: 2026-02-16T13:44:35.875Z -->
+<!-- git_commit: d86162ab -->
 <!-- db_snapshot_hash: 6c0e5841d5dacd55 -->
 <!-- file_content_hash: pending -->
 
@@ -10,53 +10,6 @@
 **Purpose**: PRD requirements and validation gates (<5k chars)
 
 ---
-
-## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
-
-**Anti-Bypass Protocol**: These commands MUST be run for ALL phase transitions. Do NOT use database-agent to create handoffs directly.
-
-### ⛔ NEVER DO THIS:
-- Using `database-agent` to directly insert into `sd_phase_handoffs`
-- Creating handoff records without running validation scripts
-- Skipping preflight knowledge retrieval
-
-### ✅ ALWAYS DO THIS:
-
-#### Pre-flight Batch Validation (RECOMMENDED)
-#### LEAD → PLAN Transition
-#### PLAN → EXEC Transition
-#### EXEC → PLAN Transition (Verification)
-#### PLAN → LEAD Transition (Final Approval)
-### Emergency Bypass (SD-LEARN-010)
-For emergencies ONLY. Bypasses require audit logging and are rate-limited.
-
-**Rate Limits:**
-- 3 bypasses per SD maximum
-- 10 bypasses per day globally
-- All bypasses logged to `audit_log` table with severity=warning
-
-### What These Scripts Enforce
-| Script | Validations |
-|--------|-------------|
-| `phase-preflight.js` | Loads context, patterns, and lessons from database |
-| `handoff.js precheck` | **Batch validation** - runs ALL gates, git checks, reports ALL issues at once |
-| `handoff.js LEAD-TO-PLAN` | SD completeness (100% required), strategic objectives |
-| `handoff.js PLAN-TO-EXEC` | PRD exists (`ERR_NO_PRD`), chain completeness (`ERR_CHAIN_INCOMPLETE`) |
-| `handoff.js EXEC-TO-PLAN` | TESTING enforcement (`ERR_TESTING_REQUIRED`), chain completeness |
-| `handoff.js PLAN-TO-LEAD` | Traceability, workflow ROI, retrospective quality |
-
-### Error Codes (SD-LEARN-010)
-| Code | Meaning | Remediation |
-|------|---------|-------------|
-| `ERR_TESTING_REQUIRED` | TESTING sub-agent must run before EXEC-TO-PLAN (feature/qa SDs) | Run TESTING sub-agent first |
-| `ERR_CHAIN_INCOMPLETE` | Missing prerequisite handoff in chain | Complete missing handoff first |
-| `ERR_NO_PRD` | No PRD found for PLAN-TO-EXEC | Create PRD before proceeding |
-
-### Compliance Marker
-Valid handoffs are recorded with `created_by: 'UNIFIED-HANDOFF-SYSTEM'`. Handoffs with other `created_by` values indicate process bypass.
-
-### Check Compliance
-**FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
 ## PLAN Phase Negative Constraints
 
@@ -334,5 +287,5 @@ Test scenarios only cover happy path ('user logs in successfully'). Missing:
 
 ---
 
-*DIGEST generated: 2026-02-16 8:39:05 AM*
+*DIGEST generated: 2026-02-16 8:44:35 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,76 +1,76 @@
 {
-  "generated_at": "2026-02-16T13:39:05.049Z",
-  "git_commit": "b22f9b27",
+  "generated_at": "2026-02-16T13:44:35.875Z",
+  "git_commit": "d86162ab",
   "db_snapshot_hash": "6c0e5841d5dacd55",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 5343,
       "estimated_tokens": 1336,
-      "content_hash": "90ae3425dad3daf9",
+      "content_hash": "e06d11f97f25827e",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 45307,
       "estimated_tokens": 11327,
-      "content_hash": "a01c6f246476a4d3",
+      "content_hash": "ff1676dda1afd54f",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 52377,
       "estimated_tokens": 13095,
-      "content_hash": "61444b4805438e00",
+      "content_hash": "7d950d97d4d7d370",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 77342,
       "estimated_tokens": 19336,
-      "content_hash": "4a142f66b38cb1ce",
+      "content_hash": "890a2198ff510b84",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 61824,
       "estimated_tokens": 15456,
-      "content_hash": "81b30a144364614a",
+      "content_hash": "d0f651b6aed8a055",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 6358,
       "estimated_tokens": 1590,
-      "content_hash": "c0c5bb2ae393dbaa",
+      "content_hash": "efa62c1623b91ca4",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 36391,
       "estimated_tokens": 9098,
-      "content_hash": "084bb41c5d2302e8",
+      "content_hash": "3521380f91cedd06",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 6931,
-      "estimated_tokens": 1733,
-      "content_hash": "621266cdbd3c4445",
+      "chars": 4801,
+      "estimated_tokens": 1201,
+      "content_hash": "ed1a601fe7236038",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 14901,
-      "estimated_tokens": 3726,
-      "content_hash": "448c17aa2f13a5a7",
+      "chars": 12771,
+      "estimated_tokens": 3193,
+      "content_hash": "e1a5c39d9c396d4e",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 18621,
-      "estimated_tokens": 4656,
-      "content_hash": "4e54268936fb0567",
+      "chars": 14966,
+      "estimated_tokens": 3742,
+      "content_hash": "20b127a60e9f5bb3",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     }
   }

--- a/scripts/section-file-mapping-digest.json
+++ b/scripts/section-file-mapping-digest.json
@@ -31,35 +31,34 @@
     ]
   },
   "CLAUDE_LEAD_DIGEST.md": {
-    "description": "LEAD phase essentials (~4-5k chars) - approval gates and validation requirements",
+    "description": "LEAD phase essentials (~3-4k chars) - approval gates and validation requirements",
     "sections": [
-      "mandatory_phase_transitions_lead",
       "simplicity_first_enforcement",
       "lead_pre_approval_simplicity_gate",
       "sd_evaluation",
       "sd_creation_anti_pattern"
-    ]
+    ],
+    "_removed_sections_note": "mandatory_phase_transitions_lead (duplicate of CORE_DIGEST mandatory_phase_transitions)"
   },
   "CLAUDE_PLAN_DIGEST.md": {
-    "description": "PLAN phase essentials (~5-6k chars) - PRD requirements and validation gates",
+    "description": "PLAN phase essentials (~4-5k chars) - PRD requirements and validation gates",
     "sections": [
-      "mandatory_phase_transitions_plan",
       "prd_creation_anti_pattern",
       "plan_pre_exec_checklist",
       "handoff_quality_gates",
       "negative_constraints_plan"
-    ]
+    ],
+    "_removed_sections_note": "mandatory_phase_transitions_plan (duplicate of CORE_DIGEST mandatory_phase_transitions)"
   },
   "CLAUDE_EXEC_DIGEST.md": {
-    "description": "EXEC phase essentials (~5-6k chars) - implementation requirements and constraints",
+    "description": "EXEC phase essentials (~4-5k chars) - implementation requirements and constraints",
     "sections": [
-      "mandatory_phase_transitions_exec",
       "exec_implementation_requirements",
       "exec_dual_test_requirement",
       "branch_hygiene_gate",
       "negative_constraints_exec",
-      "migration_execution_delegation",
       "exec_retrospective_anti_patterns"
-    ]
+    ],
+    "_removed_sections_note": "mandatory_phase_transitions_exec (duplicate of CORE_DIGEST mandatory_phase_transitions), migration_execution_delegation (duplicate of CORE migration_execution_protocol)"
   }
 }


### PR DESCRIPTION
## Summary
- Applies same deduplication to digest mapping (`section-file-mapping-digest.json`) as PR #1353 did for full files
- Removes `mandatory_phase_transitions_*` from phase digests (already in CORE_DIGEST)
- Removes `migration_execution_delegation` from EXEC_DIGEST (already in CORE)

**Token impact on digests (loaded every session):**
| Digest | Before | After | Saved |
|--------|--------|-------|-------|
| LEAD_DIGEST | 1,733 | 1,201 | -31% |
| PLAN_DIGEST | 3,726 | 3,193 | -14% |
| EXEC_DIGEST | 4,656 | 3,742 | -20% |
| **Budget usage** | **83%** | **75%** | **-1,979 tokens** |

## Test plan
- [x] Smoke tests pass (15/15)
- [x] DOCMON Strunkian validation pass
- [x] Digest budget within 25k cap (75%)
- [x] All files regenerated via `generate-claude-md-from-db.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)