### PR TITLE
feat(eva): risk-adaptive ops cycle frequency

### DIFF
--- a/lib/eva/ops-cadence-mapper.js
+++ b/lib/eva/ops-cadence-mapper.js
@@ -1,0 +1,108 @@
+/**
+ * Ops Cadence Mapper — Risk-Adaptive Monitoring Frequency
+ *
+ * SD-MAN-ORCH-EVA-LIFECYCLE-COMPLETION-001-B
+ *
+ * Maps venture health scores to monitoring cadence (days between ops checks).
+ * Healthier ventures are checked less frequently; struggling ventures more often.
+ *
+ * Tiers:
+ *   0-25  → 7 days  (weekly)
+ *   26-50 → 14 days (biweekly)
+ *   51-75 → 30 days (monthly)
+ *   76-100→ 90 days (quarterly)
+ *
+ * @module lib/eva/ops-cadence-mapper
+ */
+
+// ── Constants ───────────────────────────────────────────────
+
+const CADENCE_TIERS = [
+  { max: 25, days: 7 },
+  { max: 50, days: 14 },
+  { max: 75, days: 30 },
+  { max: 100, days: 90 },
+];
+
+const DEFAULT_CADENCE_DAYS = 30;
+
+const OVERRIDE_MAP = Object.freeze({
+  weekly: 7,
+  biweekly: 14,
+  monthly: 30,
+  quarterly: 90,
+});
+
+// ── US-001: Health Score to Cadence Mapping ─────────────────
+
+/**
+ * Map a health score (0-100) to an ops monitoring cadence in days.
+ *
+ * @param {number|null|undefined} healthScore - Venture health score (0-100)
+ * @returns {number} Cadence in days
+ */
+export function getOpsCadenceDays(healthScore) {
+  if (healthScore == null || typeof healthScore !== 'number' || Number.isNaN(healthScore)) {
+    return DEFAULT_CADENCE_DAYS;
+  }
+
+  const clamped = Math.max(0, Math.min(100, healthScore));
+  for (const tier of CADENCE_TIERS) {
+    if (clamped <= tier.max) return tier.days;
+  }
+  return DEFAULT_CADENCE_DAYS;
+}
+
+// ── US-002: Cadence Override Support ────────────────────────
+
+/**
+ * Resolve the effective ops cadence, checking for a manual override first.
+ *
+ * @param {Object|null} ventureMetadata - Venture metadata JSONB (may contain ops_cadence_override)
+ * @param {number|null} healthScore - Venture health score (0-100)
+ * @returns {number} Cadence in days
+ */
+export function resolveOpsCadenceDays(ventureMetadata, healthScore) {
+  const override = ventureMetadata?.ops_cadence_override;
+  if (override && OVERRIDE_MAP[override] !== undefined) {
+    return OVERRIDE_MAP[override];
+  }
+  return getOpsCadenceDays(healthScore);
+}
+
+// ── US-005: Health Score Retrieval ──────────────────────────
+
+/**
+ * Retrieve the most recent health score for a venture.
+ * Queries venture_artifacts for the latest health_assessment artifact.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @returns {Promise<number|null>} Health score (0-100) or null
+ */
+export async function getVentureHealthScore(supabase, ventureId) {
+  try {
+    const { data, error } = await supabase
+      .from('venture_artifacts')
+      .select('quality_score')
+      .eq('venture_id', ventureId)
+      .eq('artifact_type', 'health_assessment')
+      .eq('is_current', true)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (error || !data) return null;
+    return typeof data.quality_score === 'number' ? data.quality_score : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Exports for testing ─────────────────────────────────────
+
+export const _internal = {
+  CADENCE_TIERS,
+  DEFAULT_CADENCE_DAYS,
+  OVERRIDE_MAP,
+};

--- a/lib/eva/venture-monitor.js
+++ b/lib/eva/venture-monitor.js
@@ -11,6 +11,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import { resolveOpsCadenceDays, getVentureHealthScore } from './ops-cadence-mapper.js';
 
 const ADVISORY_LOCK_BASE = 0x45564D4F; // "EVMO" in hex
 
@@ -377,22 +378,50 @@ export class VentureMonitor {
   async _opsCycleCheck(correlationId) {
     const { data: ventures, error } = await this.supabase
       .from('eva_ventures')
-      .select('id, current_stage')
+      .select('id, current_stage, metadata')
       .eq('status', 'active')
       .gte('current_stage', 24);
 
     if (error) throw new Error(`Ops cycle query failed: ${error.message}`);
     if (!ventures?.length) return;
 
+    const now = new Date();
+
     for (const venture of ventures) {
       if (this._shutdownRequested) break;
+
+      // US-003: Cadence gating — skip ventures whose next check is in the future
+      const nextCycleAt = venture.metadata?.next_ops_cycle_at;
+      if (nextCycleAt && new Date(nextCycleAt) > now) {
+        this.logger.log(`[VentureMonitor] Skipping ${venture.id} — next ops cycle at ${nextCycleAt}`);
+        continue;
+      }
+
       try {
         await this.processStage(
           { ventureId: venture.id, options: { parentTraceId: correlationId } },
           { supabase: this.supabase }
         );
+
+        // US-004: Update next_ops_cycle_at after successful processing
+        const healthScore = await getVentureHealthScore(this.supabase, venture.id);
+        const cadenceDays = resolveOpsCadenceDays(venture.metadata, healthScore);
+        const nextCycle = new Date();
+        nextCycle.setDate(nextCycle.getDate() + cadenceDays);
+
+        const updatedMetadata = {
+          ...(venture.metadata || {}),
+          next_ops_cycle_at: nextCycle.toISOString(),
+          last_ops_cadence_days: cadenceDays,
+        };
+
+        await this.supabase
+          .from('eva_ventures')
+          .update({ metadata: updatedMetadata })
+          .eq('id', venture.id);
       } catch (err) {
         this.logger.warn(`[VentureMonitor] Ops cycle check failed for ${venture.id}: ${err.message}`);
+        // US-004: On failure, do NOT update next_ops_cycle_at (retry on next cycle)
       }
     }
   }

--- a/tests/unit/eva/ops-cadence-mapper.test.js
+++ b/tests/unit/eva/ops-cadence-mapper.test.js
@@ -1,0 +1,141 @@
+/**
+ * Tests for Ops Cadence Mapper
+ * SD-MAN-ORCH-EVA-LIFECYCLE-COMPLETION-001-B
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getOpsCadenceDays,
+  resolveOpsCadenceDays,
+  getVentureHealthScore,
+  _internal,
+} from '../../../lib/eva/ops-cadence-mapper.js';
+
+// ── US-001: getOpsCadenceDays ───────────────────────────────
+
+describe('getOpsCadenceDays', () => {
+  it('returns 7 (weekly) for critical health 0-25', () => {
+    expect(getOpsCadenceDays(0)).toBe(7);
+    expect(getOpsCadenceDays(10)).toBe(7);
+    expect(getOpsCadenceDays(20)).toBe(7);
+    expect(getOpsCadenceDays(25)).toBe(7);
+  });
+
+  it('returns 14 (biweekly) for health 26-50', () => {
+    expect(getOpsCadenceDays(26)).toBe(14);
+    expect(getOpsCadenceDays(35)).toBe(14);
+    expect(getOpsCadenceDays(50)).toBe(14);
+  });
+
+  it('returns 30 (monthly) for health 51-75', () => {
+    expect(getOpsCadenceDays(51)).toBe(30);
+    expect(getOpsCadenceDays(60)).toBe(30);
+    expect(getOpsCadenceDays(75)).toBe(30);
+  });
+
+  it('returns 90 (quarterly) for health 76-100', () => {
+    expect(getOpsCadenceDays(76)).toBe(90);
+    expect(getOpsCadenceDays(90)).toBe(90);
+    expect(getOpsCadenceDays(100)).toBe(90);
+  });
+
+  it('returns 30 (monthly default) for null/undefined', () => {
+    expect(getOpsCadenceDays(null)).toBe(30);
+    expect(getOpsCadenceDays(undefined)).toBe(30);
+  });
+
+  it('returns 30 (monthly default) for NaN', () => {
+    expect(getOpsCadenceDays(NaN)).toBe(30);
+  });
+
+  it('returns 30 (monthly default) for non-number types', () => {
+    expect(getOpsCadenceDays('high')).toBe(30);
+    expect(getOpsCadenceDays({})).toBe(30);
+  });
+
+  it('clamps values below 0 to tier 1 (weekly)', () => {
+    expect(getOpsCadenceDays(-5)).toBe(7);
+  });
+
+  it('clamps values above 100 to tier 4 (quarterly)', () => {
+    expect(getOpsCadenceDays(150)).toBe(90);
+  });
+});
+
+// ── US-002: resolveOpsCadenceDays ───────────────────────────
+
+describe('resolveOpsCadenceDays', () => {
+  it('uses override when valid', () => {
+    expect(resolveOpsCadenceDays({ ops_cadence_override: 'weekly' }, 90)).toBe(7);
+    expect(resolveOpsCadenceDays({ ops_cadence_override: 'biweekly' }, 90)).toBe(14);
+    expect(resolveOpsCadenceDays({ ops_cadence_override: 'monthly' }, 10)).toBe(30);
+    expect(resolveOpsCadenceDays({ ops_cadence_override: 'quarterly' }, 10)).toBe(90);
+  });
+
+  it('ignores invalid override and falls back to health-based mapping', () => {
+    expect(resolveOpsCadenceDays({ ops_cadence_override: 'invalid' }, 20)).toBe(7);
+    expect(resolveOpsCadenceDays({ ops_cadence_override: 'daily' }, 90)).toBe(90);
+  });
+
+  it('falls back to health-based mapping when no override', () => {
+    expect(resolveOpsCadenceDays({}, 20)).toBe(7);
+    expect(resolveOpsCadenceDays({}, 90)).toBe(90);
+  });
+
+  it('handles null/undefined metadata', () => {
+    expect(resolveOpsCadenceDays(null, 50)).toBe(14);
+    expect(resolveOpsCadenceDays(undefined, 50)).toBe(14);
+  });
+});
+
+// ── US-005: getVentureHealthScore ───────────────────────────
+
+describe('getVentureHealthScore', () => {
+  function createMockSupabase(data, error = null) {
+    return {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockReturnValue({
+                    single: vi.fn().mockResolvedValue({ data, error }),
+                  }),
+                }),
+              }),
+            }),
+          }),
+        }),
+      }),
+    };
+  }
+
+  it('returns quality_score from most recent health_assessment', async () => {
+    const supabase = createMockSupabase({ quality_score: 72 });
+    const score = await getVentureHealthScore(supabase, 'venture-123');
+    expect(score).toBe(72);
+  });
+
+  it('returns null when no health data exists', async () => {
+    const supabase = createMockSupabase(null, { message: 'not found' });
+    const score = await getVentureHealthScore(supabase, 'venture-123');
+    expect(score).toBeNull();
+  });
+
+  it('returns null on database error without throwing', async () => {
+    const supabase = {
+      from: vi.fn().mockImplementation(() => {
+        throw new Error('connection failed');
+      }),
+    };
+    const score = await getVentureHealthScore(supabase, 'venture-123');
+    expect(score).toBeNull();
+  });
+
+  it('returns null when quality_score is not a number', async () => {
+    const supabase = createMockSupabase({ quality_score: 'high' });
+    const score = await getVentureHealthScore(supabase, 'venture-123');
+    expect(score).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- SD-MAN-ORCH-EVA-LIFECYCLE-COMPLETION-001-B (Child B of EVA Lifecycle Completion orchestrator)
- New `lib/eva/ops-cadence-mapper.js` — pure function module mapping health scores (0-100) to monitoring cadence (7/14/30/90 days)
- Cadence override support via `ops_cadence_override` in venture metadata
- Modified `venture-monitor.js` `_opsCycleCheck()` to gate by `next_ops_cycle_at` timestamp
- Updates `next_ops_cycle_at` after successful processing; skips on failure for retry

## Test plan
- [x] 17 new unit tests for ops-cadence-mapper (all boundaries, overrides, null handling, DB errors)
- [x] 2755 existing EVA tests pass (102 files, zero regressions)
- [x] Module loads cleanly (`import('./lib/eva/ops-cadence-mapper.js')`)
- [x] venture-monitor.js loads cleanly with new import

🤖 Generated with [Claude Code](https://claude.com/claude-code)