### PR TITLE
feat(eva): reality gate failure recovery with retry logic

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -20,7 +20,8 @@ import { randomUUID } from 'crypto';
 import { VentureContextManager } from './venture-context-manager.js';
 import { ChairmanPreferenceStore } from './chairman-preference-store.js';
 import { evaluateDecision } from './decision-filter-engine.js';
-import { evaluateRealityGate } from './reality-gates.js';
+import { evaluateRealityGate, isGatedBoundary } from './reality-gates.js';
+import { attemptGateRecovery } from './gate-failure-recovery.js';
 import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord } from './devils-advocate.js';
 import { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-bridge.js';
 import { handlePostLifecycleDecision, isFinalStage } from './post-lifecycle-decisions.js';
@@ -312,7 +313,27 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       { supabase, httpClient, now: () => new Date() }
     );
     gateResults.push({ type: 'reality_gate', ...realityGateResult });
-    if (!realityGateResult.passed) gateBlocked = true;
+    if (!realityGateResult.passed && isGatedBoundary(resolvedStage, nextStage)) {
+      // Attempt gate recovery before declaring blocked
+      const rerunAnalysisFn = async (vid, stage, retryContext) => {
+        return evaluateRealityGateFn(
+          { from: stage, to: nextStage, ventureId: vid, _retryContext: retryContext },
+          { supabase, httpClient, now: () => new Date() }
+        );
+      };
+      const recovery = await attemptGateRecovery(
+        { ventureId, fromStage: resolvedStage, toStage: nextStage, gateResult: realityGateResult, rerunAnalysisFn },
+        { supabase, logger }
+      );
+      if (recovery.recovered && recovery.gateResult) {
+        // Replace gate result with the successful retry
+        gateResults[gateResults.length - 1] = { type: 'reality_gate', ...recovery.gateResult };
+      } else {
+        gateBlocked = true;
+      }
+    } else if (!realityGateResult.passed) {
+      gateBlocked = true;
+    }
   } catch (err) {
     logger.error(`[Eva] Gate evaluation error: ${err.message}`);
     gateResults.push({ type: 'error', passed: false, error: err.message });

--- a/lib/eva/gate-failure-recovery.js
+++ b/lib/eva/gate-failure-recovery.js
@@ -1,0 +1,332 @@
+/**
+ * Gate Failure Recovery
+ *
+ * SD-MAN-ORCH-EVA-LIFECYCLE-COMPLETION-001-C
+ *
+ * Provides retry logic for Reality Gate failures:
+ * - Classifies failure reasons by severity (critical vs non-critical)
+ * - Retries failed analysis steps up to 3 times with failure context
+ * - Routes exhausted failures by severity (DFE for critical, auto-track for non-critical)
+ * - Marks ventures as killed_at_reality_gate after retry exhaustion
+ *
+ * @module lib/eva/gate-failure-recovery
+ */
+
+import { REASON_CODES } from './reality-gates.js';
+
+const MAX_RETRIES = 3;
+
+// US-001: Severity classification mapping
+const CRITICAL_REASON_CODES = new Set([
+  REASON_CODES.ARTIFACT_MISSING,
+  REASON_CODES.DB_ERROR,
+  REASON_CODES.CONFIG_ERROR,
+  REASON_CODES.QUALITY_SCORE_MISSING,
+]);
+
+const NON_CRITICAL_REASON_CODES = new Set([
+  REASON_CODES.QUALITY_SCORE_BELOW_THRESHOLD,
+  REASON_CODES.URL_UNREACHABLE,
+]);
+
+/**
+ * US-001: Classify gate failure reasons by severity.
+ * Unknown reason codes default to critical (fail-safe).
+ *
+ * @param {Array<{code: string}>} reasons - Array of failure reason objects
+ * @returns {'critical'|'non-critical'} Severity classification
+ */
+export function classifyFailureSeverity(reasons) {
+  if (!Array.isArray(reasons) || reasons.length === 0) {
+    return 'critical'; // fail-safe
+  }
+
+  for (const reason of reasons) {
+    const code = reason?.code;
+    if (CRITICAL_REASON_CODES.has(code)) {
+      return 'critical';
+    }
+    if (!NON_CRITICAL_REASON_CODES.has(code)) {
+      // Unknown code → critical (fail-safe)
+      return 'critical';
+    }
+  }
+
+  return 'non-critical';
+}
+
+/**
+ * US-002: Retry a gate failure by re-running the analysis step with failure context.
+ *
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture UUID
+ * @param {number} params.fromStage - Stage the gate is on
+ * @param {number} params.toStage - Target stage
+ * @param {Array} params.failureReasons - Reasons from the failed gate
+ * @param {Function} params.rerunAnalysisFn - async (ventureId, stageId, retryContext) => gateResult
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @param {Object} [deps.logger] - Logger
+ * @returns {Promise<{status: 'recovered'|'exhausted', attempts: number, lastReasons: Array, gateResult?: Object}>}
+ */
+export async function retryGateFailure(params, deps) {
+  const { ventureId, fromStage, toStage, failureReasons, rerunAnalysisFn } = params;
+  const { supabase, logger = console } = deps;
+
+  let lastReasons = failureReasons;
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const retryContext = {
+      attempt,
+      maxRetries: MAX_RETRIES,
+      previousReasons: lastReasons,
+      fromStage,
+      toStage,
+    };
+
+    logger.info(`[GateRecovery] Retry ${attempt}/${MAX_RETRIES} for venture ${ventureId} gate ${fromStage}->${toStage}`);
+
+    // Log the retry attempt
+    await logRetryEvent(supabase, ventureId, {
+      event: 'gate_retry_attempt',
+      attempt,
+      fromStage,
+      toStage,
+      previousReasons: lastReasons,
+    }, logger);
+
+    try {
+      const gateResult = await rerunAnalysisFn(ventureId, fromStage, retryContext);
+
+      if (gateResult.status === 'PASS') {
+        logger.info(`[GateRecovery] Retry ${attempt} succeeded for venture ${ventureId}`);
+        await logRetryEvent(supabase, ventureId, {
+          event: 'gate_retry_success',
+          attempt,
+          fromStage,
+          toStage,
+        }, logger);
+        return { status: 'recovered', attempts: attempt, lastReasons: [], gateResult };
+      }
+
+      // Failed again - capture new reasons for next attempt
+      lastReasons = gateResult.reasons || lastReasons;
+    } catch (err) {
+      logger.warn(`[GateRecovery] Retry ${attempt} error: ${err.message}`);
+      lastReasons = [{ code: 'RETRY_ERROR', message: err.message }];
+    }
+  }
+
+  // All retries exhausted
+  logger.warn(`[GateRecovery] All ${MAX_RETRIES} retries exhausted for venture ${ventureId} gate ${fromStage}->${toStage}`);
+  await logRetryEvent(supabase, ventureId, {
+    event: 'gate_retries_exhausted',
+    attempts: MAX_RETRIES,
+    fromStage,
+    toStage,
+    lastReasons,
+  }, logger);
+
+  return { status: 'exhausted', attempts: MAX_RETRIES, lastReasons };
+}
+
+/**
+ * US-003: Mark a venture as killed_at_reality_gate.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} [opts]
+ * @param {Array} [opts.reasons] - Final failure reasons
+ * @param {number} [opts.fromStage] - Stage where the gate failed
+ * @param {Object} [opts.logger] - Logger
+ * @returns {Promise<{killed: boolean, error?: string}>}
+ */
+export async function markKilledAtGate(supabase, ventureId, opts = {}) {
+  const { reasons = [], fromStage, logger = console } = opts;
+
+  if (!supabase || !ventureId) {
+    return { killed: false, error: 'Missing supabase client or ventureId' };
+  }
+
+  try {
+    const { error } = await supabase
+      .from('eva_ventures')
+      .update({
+        orchestrator_state: 'killed_at_reality_gate',
+        orchestrator_lock_id: null,
+        orchestrator_lock_acquired_at: null,
+      })
+      .eq('id', ventureId);
+
+    if (error) {
+      logger.error(`[GateRecovery] markKilledAtGate DB error: ${error.message}`);
+      return { killed: false, error: error.message };
+    }
+
+    // Log terminal event
+    await logRetryEvent(supabase, ventureId, {
+      event: 'killed_at_reality_gate',
+      fromStage,
+      reasons,
+    }, logger);
+
+    logger.info(`[GateRecovery] Venture ${ventureId} marked killed_at_reality_gate`);
+    return { killed: true };
+  } catch (err) {
+    logger.error(`[GateRecovery] markKilledAtGate error: ${err.message}`);
+    return { killed: false, error: err.message };
+  }
+}
+
+/**
+ * US-004: Route gate outcome by severity.
+ * Critical → DFE escalation record.
+ * Non-critical → stored in venture metadata for auto-retry on next cycle.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {string} severity - 'critical' or 'non-critical'
+ * @param {Object} context - { reasons, fromStage, toStage }
+ * @param {Object} deps - { supabase, logger }
+ * @returns {Promise<{routed: boolean, path: 'dfe'|'auto_track', error?: string}>}
+ */
+export async function routeGateOutcome(ventureId, severity, context, deps) {
+  const { supabase, logger = console } = deps;
+  const { reasons = [], fromStage, toStage } = context;
+
+  if (!supabase || !ventureId) {
+    return { routed: false, error: 'Missing supabase client or ventureId' };
+  }
+
+  if (severity === 'critical') {
+    // Create DFE escalation record
+    try {
+      const { error } = await supabase.from('chairman_decisions').insert({
+        venture_id: ventureId,
+        decision_type: 'gate_failure_escalation',
+        status: 'pending',
+        context: {
+          source: 'gate_failure_recovery',
+          fromStage,
+          toStage,
+          reasons,
+          severity: 'critical',
+        },
+      });
+
+      if (error) {
+        logger.error(`[GateRecovery] DFE escalation insert failed: ${error.message}`);
+        return { routed: false, path: 'dfe', error: error.message };
+      }
+
+      logger.info(`[GateRecovery] Critical failure for ${ventureId} routed to DFE`);
+      return { routed: true, path: 'dfe' };
+    } catch (err) {
+      logger.error(`[GateRecovery] DFE routing error: ${err.message}`);
+      return { routed: false, path: 'dfe', error: err.message };
+    }
+  }
+
+  // Non-critical: store in venture metadata for auto-retry
+  try {
+    const { data: venture } = await supabase
+      .from('eva_ventures')
+      .select('metadata')
+      .eq('id', ventureId)
+      .single();
+
+    const updatedMetadata = {
+      ...(venture?.metadata || {}),
+      gate_retry_context: {
+        fromStage,
+        toStage,
+        reasons,
+        severity: 'non-critical',
+        stored_at: new Date().toISOString(),
+      },
+    };
+
+    const { error } = await supabase
+      .from('eva_ventures')
+      .update({ metadata: updatedMetadata })
+      .eq('id', ventureId);
+
+    if (error) {
+      logger.error(`[GateRecovery] Metadata update failed: ${error.message}`);
+      return { routed: false, path: 'auto_track', error: error.message };
+    }
+
+    logger.info(`[GateRecovery] Non-critical failure for ${ventureId} stored for auto-retry`);
+    return { routed: true, path: 'auto_track' };
+  } catch (err) {
+    logger.error(`[GateRecovery] Auto-track routing error: ${err.message}`);
+    return { routed: false, path: 'auto_track', error: err.message };
+  }
+}
+
+/**
+ * US-005: Attempt gate recovery in the orchestrator flow.
+ * Called when a reality gate fails in processStage.
+ *
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture UUID
+ * @param {number} params.fromStage - Current stage
+ * @param {number} params.toStage - Target stage
+ * @param {Object} params.gateResult - Failed gate result with reasons
+ * @param {Function} params.rerunAnalysisFn - Function to re-run analysis
+ * @param {Object} deps - { supabase, logger }
+ * @returns {Promise<{recovered: boolean, gateResult?: Object, killed?: boolean}>}
+ */
+export async function attemptGateRecovery(params, deps) {
+  const { ventureId, fromStage, toStage, gateResult, rerunAnalysisFn } = params;
+  const { supabase, logger = console } = deps;
+
+  const reasons = gateResult?.reasons || [];
+  const severity = classifyFailureSeverity(reasons);
+
+  // Only retry non-critical failures
+  if (severity === 'critical') {
+    logger.info(`[GateRecovery] Critical failure for ${ventureId} — skipping retry, routing to DFE`);
+    await routeGateOutcome(ventureId, 'critical', { reasons, fromStage, toStage }, deps);
+    await markKilledAtGate(supabase, ventureId, { reasons, fromStage, logger });
+    return { recovered: false, killed: true };
+  }
+
+  // Non-critical: attempt retries
+  const retryResult = await retryGateFailure(
+    { ventureId, fromStage, toStage, failureReasons: reasons, rerunAnalysisFn },
+    deps
+  );
+
+  if (retryResult.status === 'recovered') {
+    return { recovered: true, gateResult: retryResult.gateResult };
+  }
+
+  // Retries exhausted — route and kill
+  await routeGateOutcome(ventureId, severity, { reasons: retryResult.lastReasons, fromStage, toStage }, deps);
+  await markKilledAtGate(supabase, ventureId, { reasons: retryResult.lastReasons, fromStage, logger });
+  return { recovered: false, killed: true };
+}
+
+// ── Internal helpers ────────────────────────────────────────
+
+async function logRetryEvent(supabase, ventureId, eventData, logger) {
+  try {
+    await supabase.from('eva_event_log').insert({
+      venture_id: ventureId,
+      event_type: eventData.event,
+      event_data: eventData,
+      created_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    logger.warn(`[GateRecovery] Event log failed: ${err.message}`);
+  }
+}
+
+// ── Exports ─────────────────────────────────────────────────
+
+export const _internal = {
+  MAX_RETRIES,
+  CRITICAL_REASON_CODES,
+  NON_CRITICAL_REASON_CODES,
+  logRetryEvent,
+};

--- a/lib/eva/orchestrator-state-machine.js
+++ b/lib/eva/orchestrator-state-machine.js
@@ -22,6 +22,7 @@ export const ORCHESTRATOR_STATES = Object.freeze({
   BLOCKED: 'blocked',
   FAILED: 'failed',
   COMPLETED: 'completed',
+  KILLED_AT_REALITY_GATE: 'killed_at_reality_gate',
 });
 
 /**
@@ -34,6 +35,7 @@ export const VALID_TRANSITIONS = Object.freeze({
     ORCHESTRATOR_STATES.BLOCKED,
     ORCHESTRATOR_STATES.FAILED,
     ORCHESTRATOR_STATES.COMPLETED,
+    ORCHESTRATOR_STATES.KILLED_AT_REALITY_GATE,
   ],
   [ORCHESTRATOR_STATES.BLOCKED]: [
     ORCHESTRATOR_STATES.IDLE,
@@ -44,6 +46,7 @@ export const VALID_TRANSITIONS = Object.freeze({
     ORCHESTRATOR_STATES.PROCESSING,
   ],
   [ORCHESTRATOR_STATES.COMPLETED]: [], // Terminal state - no outbound transitions
+  [ORCHESTRATOR_STATES.KILLED_AT_REALITY_GATE]: [], // Terminal state - venture killed after gate retry exhaustion
 });
 
 // ── Validation ──────────────────────────────────────────────

--- a/tests/unit/eva/gate-failure-recovery.test.js
+++ b/tests/unit/eva/gate-failure-recovery.test.js
@@ -1,0 +1,328 @@
+/**
+ * Tests for Gate Failure Recovery
+ * SD-MAN-ORCH-EVA-LIFECYCLE-COMPLETION-001-C
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  classifyFailureSeverity,
+  retryGateFailure,
+  markKilledAtGate,
+  routeGateOutcome,
+  attemptGateRecovery,
+  _internal,
+} from '../../../lib/eva/gate-failure-recovery.js';
+
+const silentLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn() };
+
+function mockSupabase(overrides = {}) {
+  const insertFn = vi.fn().mockResolvedValue({ error: null });
+  const updateFn = vi.fn().mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  });
+  const selectFn = vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnValue({
+      single: vi.fn().mockResolvedValue({ data: { metadata: {} }, error: null }),
+    }),
+  });
+
+  return {
+    from: vi.fn((table) => {
+      if (overrides[table]) return overrides[table];
+      return {
+        insert: insertFn,
+        update: updateFn,
+        select: selectFn,
+      };
+    }),
+    _insertFn: insertFn,
+  };
+}
+
+// ── US-001: classifyFailureSeverity ─────────────────────────
+
+describe('classifyFailureSeverity', () => {
+  it('returns critical for ARTIFACT_MISSING', () => {
+    expect(classifyFailureSeverity([{ code: 'ARTIFACT_MISSING' }])).toBe('critical');
+  });
+
+  it('returns critical for DB_ERROR', () => {
+    expect(classifyFailureSeverity([{ code: 'DB_ERROR' }])).toBe('critical');
+  });
+
+  it('returns critical for CONFIG_ERROR', () => {
+    expect(classifyFailureSeverity([{ code: 'CONFIG_ERROR' }])).toBe('critical');
+  });
+
+  it('returns critical for QUALITY_SCORE_MISSING', () => {
+    expect(classifyFailureSeverity([{ code: 'QUALITY_SCORE_MISSING' }])).toBe('critical');
+  });
+
+  it('returns non-critical for QUALITY_SCORE_BELOW_THRESHOLD', () => {
+    expect(classifyFailureSeverity([{ code: 'QUALITY_SCORE_BELOW_THRESHOLD' }])).toBe('non-critical');
+  });
+
+  it('returns non-critical for URL_UNREACHABLE', () => {
+    expect(classifyFailureSeverity([{ code: 'URL_UNREACHABLE' }])).toBe('non-critical');
+  });
+
+  it('returns critical for unknown reason code (fail-safe)', () => {
+    expect(classifyFailureSeverity([{ code: 'UNKNOWN_CODE' }])).toBe('critical');
+  });
+
+  it('returns critical for empty reasons array', () => {
+    expect(classifyFailureSeverity([])).toBe('critical');
+  });
+
+  it('returns critical for null/undefined', () => {
+    expect(classifyFailureSeverity(null)).toBe('critical');
+    expect(classifyFailureSeverity(undefined)).toBe('critical');
+  });
+
+  it('returns critical if any reason is critical (mixed)', () => {
+    expect(classifyFailureSeverity([
+      { code: 'QUALITY_SCORE_BELOW_THRESHOLD' },
+      { code: 'DB_ERROR' },
+    ])).toBe('critical');
+  });
+
+  it('returns non-critical only when all reasons are non-critical', () => {
+    expect(classifyFailureSeverity([
+      { code: 'QUALITY_SCORE_BELOW_THRESHOLD' },
+      { code: 'URL_UNREACHABLE' },
+    ])).toBe('non-critical');
+  });
+});
+
+// ── US-002: retryGateFailure ────────────────────────────────
+
+describe('retryGateFailure', () => {
+  it('returns recovered on first retry success', async () => {
+    const supabase = mockSupabase();
+    const rerunFn = vi.fn().mockResolvedValue({ status: 'PASS', reasons: [] });
+
+    const result = await retryGateFailure(
+      { ventureId: 'v1', fromStage: 5, toStage: 6, failureReasons: [{ code: 'URL_UNREACHABLE' }], rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.status).toBe('recovered');
+    expect(result.attempts).toBe(1);
+    expect(rerunFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns recovered on third retry', async () => {
+    const supabase = mockSupabase();
+    const rerunFn = vi.fn()
+      .mockResolvedValueOnce({ status: 'FAIL', reasons: [{ code: 'URL_UNREACHABLE' }] })
+      .mockResolvedValueOnce({ status: 'FAIL', reasons: [{ code: 'URL_UNREACHABLE' }] })
+      .mockResolvedValueOnce({ status: 'PASS', reasons: [] });
+
+    const result = await retryGateFailure(
+      { ventureId: 'v1', fromStage: 5, toStage: 6, failureReasons: [{ code: 'URL_UNREACHABLE' }], rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.status).toBe('recovered');
+    expect(result.attempts).toBe(3);
+  });
+
+  it('returns exhausted after 3 failed retries', async () => {
+    const supabase = mockSupabase();
+    const rerunFn = vi.fn().mockResolvedValue({ status: 'FAIL', reasons: [{ code: 'URL_UNREACHABLE' }] });
+
+    const result = await retryGateFailure(
+      { ventureId: 'v1', fromStage: 5, toStage: 6, failureReasons: [{ code: 'URL_UNREACHABLE' }], rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.status).toBe('exhausted');
+    expect(result.attempts).toBe(3);
+    expect(rerunFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('passes retry context with attempt number and previous reasons', async () => {
+    const supabase = mockSupabase();
+    const rerunFn = vi.fn().mockResolvedValue({ status: 'PASS', reasons: [] });
+
+    await retryGateFailure(
+      { ventureId: 'v1', fromStage: 9, toStage: 10, failureReasons: [{ code: 'URL_UNREACHABLE' }], rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    const retryContext = rerunFn.mock.calls[0][2];
+    expect(retryContext.attempt).toBe(1);
+    expect(retryContext.maxRetries).toBe(3);
+    expect(retryContext.previousReasons).toEqual([{ code: 'URL_UNREACHABLE' }]);
+    expect(retryContext.fromStage).toBe(9);
+    expect(retryContext.toStage).toBe(10);
+  });
+
+  it('logs each retry attempt to eva_event_log', async () => {
+    const supabase = mockSupabase();
+    const rerunFn = vi.fn().mockResolvedValue({ status: 'PASS', reasons: [] });
+
+    await retryGateFailure(
+      { ventureId: 'v1', fromStage: 5, toStage: 6, failureReasons: [{ code: 'URL_UNREACHABLE' }], rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    // Should log attempt + success events
+    const eventLogCalls = supabase.from.mock.calls.filter(c => c[0] === 'eva_event_log');
+    expect(eventLogCalls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handles rerun function throwing errors', async () => {
+    const supabase = mockSupabase();
+    const rerunFn = vi.fn().mockRejectedValue(new Error('analysis failed'));
+
+    const result = await retryGateFailure(
+      { ventureId: 'v1', fromStage: 5, toStage: 6, failureReasons: [{ code: 'URL_UNREACHABLE' }], rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.status).toBe('exhausted');
+    expect(result.attempts).toBe(3);
+  });
+});
+
+// ── US-003: markKilledAtGate ────────────────────────────────
+
+describe('markKilledAtGate', () => {
+  it('updates venture orchestrator_state to killed_at_reality_gate', async () => {
+    const updateEq = vi.fn().mockResolvedValue({ error: null });
+    const supabase = mockSupabase({
+      eva_ventures: { update: vi.fn().mockReturnValue({ eq: updateEq }) },
+      eva_event_log: { insert: vi.fn().mockResolvedValue({ error: null }) },
+    });
+
+    const result = await markKilledAtGate(supabase, 'v1', { reasons: [{ code: 'DB_ERROR' }], fromStage: 5, logger: silentLogger });
+    expect(result.killed).toBe(true);
+  });
+
+  it('returns error on missing supabase', async () => {
+    const result = await markKilledAtGate(null, 'v1');
+    expect(result.killed).toBe(false);
+    expect(result.error).toContain('Missing');
+  });
+
+  it('returns error on DB failure', async () => {
+    const supabase = mockSupabase({
+      eva_ventures: { update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({ error: { message: 'db fail' } }) }) },
+    });
+
+    const result = await markKilledAtGate(supabase, 'v1', { logger: silentLogger });
+    expect(result.killed).toBe(false);
+    expect(result.error).toBe('db fail');
+  });
+});
+
+// ── US-004: routeGateOutcome ────────────────────────────────
+
+describe('routeGateOutcome', () => {
+  it('routes critical failure to DFE (chairman_decisions)', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const supabase = mockSupabase({
+      chairman_decisions: { insert: insertFn },
+    });
+
+    const result = await routeGateOutcome('v1', 'critical', { reasons: [{ code: 'DB_ERROR' }], fromStage: 5, toStage: 6 }, { supabase, logger: silentLogger });
+    expect(result.routed).toBe(true);
+    expect(result.path).toBe('dfe');
+    expect(insertFn).toHaveBeenCalled();
+  });
+
+  it('routes non-critical failure to venture metadata (auto-track)', async () => {
+    const updateEq = vi.fn().mockResolvedValue({ error: null });
+    const supabase = mockSupabase({
+      eva_ventures: {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { metadata: { existing: true } }, error: null }),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({ eq: updateEq }),
+      },
+    });
+
+    const result = await routeGateOutcome('v1', 'non-critical', { reasons: [{ code: 'URL_UNREACHABLE' }], fromStage: 5, toStage: 6 }, { supabase, logger: silentLogger });
+    expect(result.routed).toBe(true);
+    expect(result.path).toBe('auto_track');
+  });
+
+  it('returns error on missing inputs', async () => {
+    const result = await routeGateOutcome(null, 'critical', {}, { supabase: null, logger: silentLogger });
+    expect(result.routed).toBe(false);
+  });
+});
+
+// ── US-005: attemptGateRecovery ─────────────────────────────
+
+describe('attemptGateRecovery', () => {
+  it('skips retry for critical failures and kills venture', async () => {
+    const insertFn = vi.fn().mockResolvedValue({ error: null });
+    const updateEq = vi.fn().mockResolvedValue({ error: null });
+    const supabase = mockSupabase({
+      chairman_decisions: { insert: insertFn },
+      eva_ventures: {
+        update: vi.fn().mockReturnValue({ eq: updateEq }),
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { metadata: {} }, error: null }),
+          }),
+        }),
+      },
+      eva_event_log: { insert: vi.fn().mockResolvedValue({ error: null }) },
+    });
+    const rerunFn = vi.fn();
+
+    const result = await attemptGateRecovery(
+      { ventureId: 'v1', fromStage: 5, toStage: 6, gateResult: { reasons: [{ code: 'DB_ERROR' }] }, rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.recovered).toBe(false);
+    expect(result.killed).toBe(true);
+    expect(rerunFn).not.toHaveBeenCalled(); // No retry for critical
+  });
+
+  it('retries non-critical failures and recovers on success', async () => {
+    const supabase = mockSupabase({
+      eva_event_log: { insert: vi.fn().mockResolvedValue({ error: null }) },
+    });
+    const rerunFn = vi.fn().mockResolvedValue({ status: 'PASS', reasons: [] });
+
+    const result = await attemptGateRecovery(
+      { ventureId: 'v1', fromStage: 5, toStage: 6, gateResult: { reasons: [{ code: 'QUALITY_SCORE_BELOW_THRESHOLD' }] }, rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.recovered).toBe(true);
+    expect(result.gateResult).toBeDefined();
+  });
+
+  it('kills venture when non-critical retries are exhausted', async () => {
+    const updateEq = vi.fn().mockResolvedValue({ error: null });
+    const supabase = mockSupabase({
+      eva_event_log: { insert: vi.fn().mockResolvedValue({ error: null }) },
+      eva_ventures: {
+        update: vi.fn().mockReturnValue({ eq: updateEq }),
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { metadata: {} }, error: null }),
+          }),
+        }),
+      },
+    });
+    const rerunFn = vi.fn().mockResolvedValue({ status: 'FAIL', reasons: [{ code: 'QUALITY_SCORE_BELOW_THRESHOLD' }] });
+
+    const result = await attemptGateRecovery(
+      { ventureId: 'v1', fromStage: 5, toStage: 6, gateResult: { reasons: [{ code: 'QUALITY_SCORE_BELOW_THRESHOLD' }] }, rerunAnalysisFn: rerunFn },
+      { supabase, logger: silentLogger }
+    );
+
+    expect(result.recovered).toBe(false);
+    expect(result.killed).toBe(true);
+    expect(rerunFn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/tests/unit/eva/orchestrator-state-machine.test.js
+++ b/tests/unit/eva/orchestrator-state-machine.test.js
@@ -19,8 +19,8 @@ import {
 const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
 describe('ORCHESTRATOR_STATES', () => {
-  it('should have exactly 5 states', () => {
-    expect(Object.keys(ORCHESTRATOR_STATES)).toHaveLength(5);
+  it('should have exactly 6 states', () => {
+    expect(Object.keys(ORCHESTRATOR_STATES)).toHaveLength(6);
   });
 
   it('should contain idle, processing, blocked, failed, completed', () => {


### PR DESCRIPTION
## Summary
- Create `gate-failure-recovery.js` with severity classifier, retry logic (max 3 attempts), `killed_at_reality_gate` terminal state, and conditional outcome routing (DFE for critical, auto-track for non-critical)
- Add `KILLED_AT_REALITY_GATE` to orchestrator state machine with valid transitions from `processing`
- Integrate `attemptGateRecovery` into `eva-orchestrator.js` `processStage()` gate evaluation section
- 26 new tests, 2781 total EVA tests passing, zero regressions

## Test plan
- [x] 26 unit tests covering all 5 user stories
- [x] Full EVA test suite (2781 tests, 103 files) passes
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)