### PR TITLE
feat: wire onBeforeAnalysis hooks into EVA processStage pipeline

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -29,6 +29,7 @@ import { OrchestratorTracer } from './observability.js';
 import { VentureStateMachine } from '../agents/venture-state-machine.js';
 import { validateStageGate } from '../agents/modules/venture-state-machine/stage-gates.js';
 import { retrieveKnowledge } from './utils/knowledge-retriever.js';
+import { getTemplate } from './stage-templates/index.js';
 import { getContract, validatePreStage, validatePostStage } from './contracts/stage-contracts.js';
 import { recordTokenUsage, checkBudget, buildTokenSummary } from './utils/token-tracker.js';
 import { runRealityTracking } from './utils/assumption-reality-tracker.js';
@@ -195,10 +196,25 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     const template = options.stageTemplate || await loadStageTemplate(supabase, resolvedStage);
     const steps = template?.analysisSteps || [];
 
+    // ── 4a. Run onBeforeAnalysis hook from JS stage template ──
+    let hookContext = {};
+    try {
+      const jsTemplate = getTemplate(resolvedStage);
+      if (jsTemplate?.onBeforeAnalysis) {
+        const hookResult = await jsTemplate.onBeforeAnalysis({ ventureContext, supabase, logger });
+        if (hookResult) {
+          hookContext = hookResult;
+          logger.log(`[Eva] onBeforeAnalysis hook executed for stage ${resolvedStage}`);
+        }
+      }
+    } catch (hookErr) {
+      logger.warn(`[Eva] onBeforeAnalysis hook failed (non-fatal): ${hookErr.message}`);
+    }
+
     for (const step of steps) {
       try {
         const stepResult = typeof step.execute === 'function'
-          ? await step.execute({ ventureContext, preferences, stage: resolvedStage })
+          ? await step.execute({ ventureContext, preferences, stage: resolvedStage, ...hookContext })
           : { artifactType: step.artifactType || 'generic', payload: {}, source: step.id || 'unknown' };
 
         // Track token usage from this step (fire-and-forget)


### PR DESCRIPTION
## Summary
- Import `getTemplate` from `stage-templates/index.js` into `eva-orchestrator.js`
- Call `onBeforeAnalysis` hooks before analysis step iteration in `processStage()`
- Spread hook context (templateContext, recommendations) into `step.execute()` params
- Graceful degradation: hook failures are caught and logged, never blocking processing
- 3 new unit tests covering hook integration, error handling, and skip behavior

## Test plan
- [x] All 22 unit tests pass (19 existing + 3 new)
- [x] Backward compatible: stages without onBeforeAnalysis unaffected (empty object spread)
- [x] Graceful degradation verified: hook errors logged, stage completes normally

SD: SD-MAN-ORCH-EVA-PORTFOLIO-INTELLIGENCE-001-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)