### PR TITLE
feat: add inter-venture dependency management to EVA orchestrator

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-MAN-ORCH-EVA-GOVERNANCE-POLISH-001-A",
-  "expectedBranch": "feat/SD-MAN-ORCH-EVA-GOVERNANCE-POLISH-001-A",
-  "createdAt": "2026-02-16T12:13:03.555Z",
+  "sdKey": "SD-MAN-ORCH-EVA-PORTFOLIO-INTELLIGENCE-001-D",
+  "expectedBranch": "feat/SD-MAN-ORCH-EVA-PORTFOLIO-INTELLIGENCE-001-D",
+  "createdAt": "2026-02-16T14:16:12.049Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -34,6 +34,8 @@ import { getTemplate } from './stage-templates/index.js';
 import { getContract, validatePreStage, validatePostStage } from './contracts/stage-contracts.js';
 import { recordTokenUsage, checkBudget, buildTokenSummary } from './utils/token-tracker.js';
 import { runRealityTracking } from './utils/assumption-reality-tracker.js';
+import { checkDependencies } from './dependency-manager.js';
+import { emit } from './shared-services.js';
 
 // ── Status Constants ────────────────────────────────────────────
 
@@ -135,6 +137,49 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   // ── 2. Resolve stage ──
   const resolvedStage = stageId ?? ventureContext.current_lifecycle_stage ?? 1;
   logger.log(`[Eva] Processing stage ${resolvedStage} for venture ${ventureId} [${correlationId}]`);
+
+  // ── 2b. Dependency check ──
+  const depSpan = tracer.startSpan('dependency_check');
+  try {
+    const unresolvedDeps = await checkDependencies(supabase, ventureId, resolvedStage);
+    const hardBlocks = unresolvedDeps.filter(d => d.blocking);
+    const softWarnings = unresolvedDeps.filter(d => !d.blocking);
+
+    if (hardBlocks.length > 0) {
+      tracer.endSpan(depSpan.spanId, { status: 'blocked', metadata: { hardBlocks: hardBlocks.length } });
+      logger.warn(`[Eva] Stage ${resolvedStage} BLOCKED by ${hardBlocks.length} hard dependency(ies) for venture ${ventureId}`);
+      await emit(supabase, 'dependency_blocked', {
+        ventureId,
+        stage: resolvedStage,
+        hardBlocks: hardBlocks.map(d => ({ id: d.id, providerId: d.providerId, requiredStage: d.requiredStage })),
+      }, 'eva-orchestrator').catch(() => {});
+      return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.BLOCKED, errors: hardBlocks.map(d => ({ code: 'DEPENDENCY_BLOCKED', message: `Hard dependency on venture ${d.providerId} (stage ${d.requiredStage}) is unresolved` })), traceId: tracer.traceId });
+    }
+
+    if (softWarnings.length > 0) {
+      logger.log(`[Eva] Stage ${resolvedStage} has ${softWarnings.length} soft dependency warning(s) — proceeding`);
+      for (const dep of softWarnings) {
+        createAdvisoryNotification({
+          ventureId,
+          stageNumber: resolvedStage,
+          summary: `Soft dependency on venture ${dep.providerId} (stage ${dep.requiredStage}) is unresolved`,
+          briefData: { type: 'soft_dependency', dependencyId: dep.id, providerId: dep.providerId },
+          supabase,
+        }).catch(() => {});
+      }
+    }
+
+    tracer.endSpan(depSpan.spanId, { status: 'completed', metadata: { hardBlocks: 0, softWarnings: softWarnings.length } });
+    await emit(supabase, 'dependency_check_passed', {
+      ventureId,
+      stage: resolvedStage,
+      softWarnings: softWarnings.length,
+    }, 'eva-orchestrator').catch(() => {});
+  } catch (depErr) {
+    tracer.endSpan(depSpan.spanId, { status: 'failed', metadata: { error: depErr.message } });
+    logger.error(`[Eva] Dependency check failed: ${depErr.message}`);
+    return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.FAILED, errors: [{ code: 'DEPENDENCY_CHECK_FAILED', message: depErr.message }], traceId: tracer.traceId });
+  }
 
   // ── 3. Load chairman preferences ──
   let preferences = {};

--- a/lib/eva/portfolio-optimizer.js
+++ b/lib/eva/portfolio-optimizer.js
@@ -10,8 +10,9 @@
 
 import { emit, ServiceError } from './shared-services.js';
 import { createAdvisoryNotification } from './chairman-decision-watcher.js';
+import { getDependencyGraph } from './dependency-manager.js';
 
-export const MODULE_VERSION = '1.1.0';
+export const MODULE_VERSION = '1.2.0';
 
 /** @type {{urgency: number, roi: number}} */
 const DEFAULT_WEIGHTS = {
@@ -20,6 +21,12 @@ const DEFAULT_WEIGHTS = {
 };
 
 const DEFAULT_BALANCE_CAP = 0.40;
+
+// ── Dependency Provider Boost ────────────────────────────
+
+/** Points added per dependent venture (capped at PROVIDER_BOOST_CAP) */
+const PROVIDER_BOOST_PER_DEPENDENT = 5;
+const PROVIDER_BOOST_CAP = 15;
 
 // ── Weight Validation ───────────────────────────────────
 
@@ -118,26 +125,36 @@ const STRATEGY_MAP = {
 
 /**
  * Select a resolution strategy for a contention conflict.
+ * Provider ventures (those with dependents) are protected from deferral.
  *
  * @param {{resourceType: string, severity: string, ventureIds: string[], totalDemand: number}} conflict
  * @param {Array<{ventureId: string, priorityScore: number}>} rankings - Scored ventures
+ * @param {Set<string>} [providerVentureIds] - Venture IDs that provide dependencies to others
  * @returns {{strategy: string, details: object}}
  */
-function selectStrategy(conflict, rankings) {
+function selectStrategy(conflict, rankings, providerVentureIds = new Set()) {
   const candidates = STRATEGY_MAP[conflict.severity] || ['log_only'];
   const strategy = candidates[0];
 
   const details = { resourceType: conflict.resourceType, severity: conflict.severity };
 
   if (strategy === 'suggest_realloc' || strategy === 'defer') {
-    // Suggest deferring the lowest-priority venture in this conflict
+    // Suggest deferring the lowest-priority non-provider venture in this conflict
     const ranked = conflict.ventureIds
       .map(id => rankings.find(r => r.ventureId === id))
       .filter(Boolean)
       .sort((a, b) => a.priorityScore - b.priorityScore);
-    if (ranked.length > 0) {
-      details.targetVentureId = ranked[0].ventureId;
-      details.targetPriorityScore = ranked[0].priorityScore;
+
+    // Filter out provider ventures — deferring them would cascade-block dependents
+    const nonProviders = ranked.filter(r => !providerVentureIds.has(r.ventureId));
+
+    if (nonProviders.length > 0) {
+      details.targetVentureId = nonProviders[0].ventureId;
+      details.targetPriorityScore = nonProviders[0].priorityScore;
+    } else if (ranked.length > 0) {
+      // All ventures are providers — escalate instead of deferring
+      details.escalatedReason = 'all_ventures_are_providers';
+      return { strategy: 'escalate', details };
     }
   }
 
@@ -149,11 +166,12 @@ function selectStrategy(conflict, rankings) {
  *
  * @param {Array<{resourceType: string, ventureIds: string[], totalDemand: number, severity: string}>} conflicts
  * @param {Array<{ventureId: string, priorityScore: number}>} rankings
+ * @param {Set<string>} [providerVentureIds] - Venture IDs that provide dependencies
  * @returns {Array<{resourceType: string, severity: string, strategy: string, details: object}>}
  */
-function resolveContention(conflicts, rankings) {
+function resolveContention(conflicts, rankings, providerVentureIds = new Set()) {
   return conflicts.map(conflict => {
-    const { strategy, details } = selectStrategy(conflict, rankings);
+    const { strategy, details } = selectStrategy(conflict, rankings, providerVentureIds);
     return {
       resourceType: conflict.resourceType,
       severity: conflict.severity,
@@ -350,21 +368,41 @@ export async function optimize(supabase, ventureIds, config = {}) {
   // Step 1: Detect contention with severity scoring
   const contention = detectContention(ventures, capacities);
 
-  // Step 2: Score and rank ventures
+  // Step 2: Score and rank ventures (with provider boost)
+  const providerVentureIds = new Set();
+  const providerDependentCounts = {};
+
+  // Load dependency graphs to identify providers
+  const depGraphResults = await Promise.allSettled(
+    ventures.map(v => getDependencyGraph(supabase, v.id)),
+  );
+  for (let i = 0; i < ventures.length; i++) {
+    const result = depGraphResults[i];
+    if (result.status === 'fulfilled' && result.value.providesTo.length > 0) {
+      providerVentureIds.add(ventures[i].id);
+      providerDependentCounts[ventures[i].id] = result.value.providesTo.length;
+    }
+  }
+
   const scored = ventures.map(v => {
     const scores = scoreVenture(v, weights);
+    // Apply provider boost
+    const dependentCount = providerDependentCounts[v.id] || 0;
+    const providerBoost = Math.min(dependentCount * PROVIDER_BOOST_PER_DEPENDENT, PROVIDER_BOOST_CAP);
     return {
       ventureId: v.id,
       name: v.name,
       ...scores,
+      providerBoost,
+      priorityScore: Math.min(100, scores.priorityScore + providerBoost),
     };
   });
   const rankings = scored.sort((a, b) => b.priorityScore - a.priorityScore);
 
-  // Step 3: Resolve contention conflicts
+  // Step 3: Resolve contention conflicts (with provider protection)
   let resolutions = [];
   if (contention.hasContention) {
-    resolutions = resolveContention(contention.conflicts, rankings);
+    resolutions = resolveContention(contention.conflicts, rankings, providerVentureIds);
 
     // Emit contention detected event
     await emit(supabase, 'contention_detected', {


### PR DESCRIPTION
## Summary
- Add dependency checking step in EVA orchestrator `processStage`: hard dependencies block stage transitions (BLOCKED status), soft dependencies fire advisory notifications and proceed
- Add provider priority boosting in portfolio optimizer: +5 points per dependent venture (capped at 15), protecting provider ventures from contention deferral
- Escalate contention resolution when all contending ventures are providers
- Add 12 new tests (5 orchestrator + 7 portfolio optimizer) covering dependency blocking, soft advisories, provider boost, deferral protection, error handling

## Test plan
- [x] All 2800 EVA tests pass (103 test files)
- [x] 27 orchestrator tests pass (22 existing + 5 new)
- [x] 29 portfolio optimizer tests pass (23 existing + 6 new + getDependencyGraph mock)
- [x] Provider boost capped at 15 verified
- [x] All-providers escalation path verified

SD: SD-MAN-ORCH-EVA-PORTFOLIO-INTELLIGENCE-001-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)