### PR TITLE
fix: SD-type-aware PRD scoring and cross-mode protocol file fallback

### DIFF
--- a/tests/unit/prd-quality-heuristic.test.js
+++ b/tests/unit/prd-quality-heuristic.test.js
@@ -1,0 +1,176 @@
+/**
+ * Unit Tests for PRD Quality Heuristic Validation
+ * SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-030: SD-type-aware scoring
+ *
+ * Tests that infrastructure/fix SDs get reduced penalties for optional fields
+ * while feature SDs retain standard scoring.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the rubric module to avoid AI calls
+vi.mock('../../scripts/modules/rubrics/prd-quality-rubric.js', () => ({
+  PRDQualityRubric: vi.fn()
+}));
+
+const { validatePRDQuality } = await import('../../scripts/modules/prd-quality-validation.js');
+
+/**
+ * Build a minimal PRD that passes all checks at 100
+ */
+function buildFullPRD() {
+  return {
+    id: 'PRD-TEST-001',
+    functional_requirements: [
+      { requirement: 'Implement authentication via OAuth 2.0' },
+      { requirement: 'Create user profile management API' },
+      { requirement: 'Add session token refresh mechanism' }
+    ],
+    acceptance_criteria: [
+      'Users can log in with Google OAuth',
+      'Profile page displays user information',
+      'Tokens refresh automatically before expiry'
+    ],
+    test_scenarios: [
+      { scenario: 'Login with valid credentials' },
+      { scenario: 'Handle expired tokens gracefully' },
+      { scenario: 'Display error for invalid OAuth callback' }
+    ],
+    system_architecture: { components: ['auth-service', 'token-manager'] },
+    implementation_approach: { strategy: 'OAuth 2.0 with PKCE flow' },
+    risks: [{ risk: 'Token theft via XSS', mitigation: 'Use httpOnly cookies' }],
+    executive_summary: 'Implement OAuth 2.0 authentication with token management and user profiles for the application.'
+  };
+}
+
+/**
+ * Build a PRD missing optional fields (system_architecture, implementation_approach, risks)
+ * but with valid core fields
+ */
+function buildMinimalPRD() {
+  return {
+    id: 'PRD-TEST-002',
+    functional_requirements: [
+      { requirement: 'Fix gate validation scoring for infrastructure SDs' },
+      { requirement: 'Add cross-mode fallback for protocol file read gate' },
+      { requirement: 'Update issue patterns with assigned SD ID' }
+    ],
+    acceptance_criteria: [
+      'Infrastructure PRDs score >= 70 without system_architecture',
+      'Protocol file read gate falls back to FULL file',
+      'Both patterns marked as addressed'
+    ],
+    test_scenarios: [
+      { scenario: 'Infrastructure PRD without system_architecture' },
+      { scenario: 'DIGEST file missing but FULL exists' },
+      { scenario: 'Both files missing returns BLOCK' }
+    ],
+    // Missing: system_architecture, implementation_approach, risks
+    executive_summary: 'Address two recurring gate validation failures identified through /learn pattern analysis.'
+  };
+}
+
+describe('PRD Quality Heuristic - SD-Type-Aware Scoring', () => {
+  beforeEach(() => {
+    // Force heuristic mode
+    process.env.PRD_VALIDATION_MODE = 'heuristic';
+  });
+
+  describe('Full PRD scores 100 for any SD type', () => {
+    it('should score 100 for a feature PRD with all fields', async () => {
+      const result = await validatePRDQuality(buildFullPRD(), { sdType: 'feature' });
+      expect(result.score).toBe(100);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should score 100 for an infrastructure PRD with all fields', async () => {
+      const result = await validatePRDQuality(buildFullPRD(), { sdType: 'infrastructure' });
+      expect(result.score).toBe(100);
+      expect(result.passed).toBe(true);
+    });
+  });
+
+  describe('Infrastructure SDs get reduced penalties', () => {
+    it('should deduct only 3 pts per missing optional field for infrastructure', async () => {
+      const prd = buildMinimalPRD();
+      const result = await validatePRDQuality(prd, { sdType: 'infrastructure' });
+      // Missing: system_architecture (-3), implementation_approach (-3), risks (-3) = -9
+      // Score: 100 - 9 = 91
+      expect(result.score).toBe(91);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should deduct only 3 pts per missing optional field for fix/bugfix', async () => {
+      const prd = buildMinimalPRD();
+      const result = await validatePRDQuality(prd, { sdType: 'bugfix' });
+      expect(result.score).toBe(91);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should deduct only 3 pts per missing optional field for documentation', async () => {
+      const prd = buildMinimalPRD();
+      const result = await validatePRDQuality(prd, { sdType: 'documentation' });
+      expect(result.score).toBe(91);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should deduct only 3 pts per missing optional field for refactor', async () => {
+      const prd = buildMinimalPRD();
+      const result = await validatePRDQuality(prd, { sdType: 'refactor' });
+      expect(result.score).toBe(91);
+      expect(result.passed).toBe(true);
+    });
+  });
+
+  describe('Feature SDs retain standard penalties', () => {
+    it('should deduct 5 pts per missing optional field for feature', async () => {
+      const prd = buildMinimalPRD();
+      const result = await validatePRDQuality(prd, { sdType: 'feature' });
+      // Missing: system_architecture (-5), implementation_approach (-5), risks (-5) = -15
+      // Score: 100 - 15 = 85
+      expect(result.score).toBe(85);
+      expect(result.passed).toBe(true);
+    });
+
+    it('should deduct 5 pts for unknown/empty SD type', async () => {
+      const prd = buildMinimalPRD();
+      const result = await validatePRDQuality(prd, { sdType: '' });
+      expect(result.score).toBe(85);
+    });
+  });
+
+  describe('Critical fields always penalize equally', () => {
+    it('should still deduct 15 pts for insufficient functional_requirements regardless of SD type', async () => {
+      const prd = buildFullPRD();
+      prd.functional_requirements = [{ requirement: 'Only one' }];
+      const result = await validatePRDQuality(prd, { sdType: 'infrastructure' });
+      expect(result.score).toBe(85); // 100 - 15
+      expect(result.issues).toHaveLength(1);
+      expect(result.passed).toBe(false); // issues.length > 0
+    });
+
+    it('should still deduct 15 pts for insufficient acceptance_criteria regardless of SD type', async () => {
+      const prd = buildFullPRD();
+      prd.acceptance_criteria = ['Only one'];
+      const result = await validatePRDQuality(prd, { sdType: 'infrastructure' });
+      expect(result.score).toBe(85); // 100 - 15
+      expect(result.issues).toHaveLength(1);
+      expect(result.passed).toBe(false);
+    });
+  });
+
+  describe('Details include SD type info', () => {
+    it('should include sdType and useReducedPenalty in details', async () => {
+      const prd = buildFullPRD();
+      const result = await validatePRDQuality(prd, { sdType: 'infrastructure' });
+      expect(result.details.sdType).toBe('infrastructure');
+      expect(result.details.useReducedPenalty).toBe(true);
+    });
+
+    it('should show useReducedPenalty false for feature type', async () => {
+      const prd = buildFullPRD();
+      const result = await validatePRDQuality(prd, { sdType: 'feature' });
+      expect(result.details.useReducedPenalty).toBe(false);
+    });
+  });
+});

--- a/tests/unit/protocol-file-read-cross-mode.test.js
+++ b/tests/unit/protocol-file-read-cross-mode.test.js
@@ -1,0 +1,124 @@
+/**
+ * Unit Tests for Protocol File Read Gate - Cross-Mode Fallback
+ * SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-030
+ *
+ * Tests the new cross-mode fallback behavior:
+ * When DIGEST file is missing but FULL file exists → PASS_FALLBACK at 85/100
+ * When both missing → BLOCK at 0/100
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// We need to control fs.existsSync and fs.statSync to simulate file presence
+const originalExistsSync = fs.existsSync;
+const originalStatSync = fs.statSync;
+
+// Import the module under test
+import {
+  validateProtocolFileRead,
+  markProtocolFileRead,
+  clearProtocolFileReadState
+} from '../../scripts/modules/handoff/gates/protocol-file-read-gate.js';
+
+describe('Protocol File Read Gate - Cross-Mode Fallback', () => {
+  const PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR || 'C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer';
+
+  beforeEach(() => {
+    clearProtocolFileReadState();
+    // Set DIGEST mode
+    process.env.CLAUDE_PROTOCOL_MODE = 'digest';
+  });
+
+  afterEach(() => {
+    clearProtocolFileReadState();
+    delete process.env.CLAUDE_PROTOCOL_MODE;
+    // Restore fs functions
+    fs.existsSync = originalExistsSync;
+    fs.statSync = originalStatSync;
+  });
+
+  describe('DIGEST file exists on disk (normal path)', () => {
+    it('should use standard fallback when DIGEST file exists on disk', async () => {
+      // Don't mark as read in session state, but file exists on disk
+      // The gate should hit the "file exists on disk" fallback at 90/100
+      // We need the DIGEST file to actually exist - which it does in the project
+      markProtocolFileRead('CLAUDE_EXEC_DIGEST.md');
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC');
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(100); // It's in session state, so 100
+    });
+  });
+
+  describe('Cross-mode fallback (DIGEST missing, FULL exists)', () => {
+    it('should PASS at 85/100 when DIGEST file missing but FULL file exists', async () => {
+      // Mock fs to simulate: DIGEST file missing, FULL file present
+      const digestFile = path.join(PROJECT_DIR, 'CLAUDE_EXEC_DIGEST.md');
+      const fullFile = path.join(PROJECT_DIR, 'CLAUDE_EXEC.md');
+      const sessionStateFile = path.join(PROJECT_DIR, '.claude', 'unified-session-state.json');
+
+      fs.existsSync = vi.fn((filePath) => {
+        const normalized = filePath.replace(/\\/g, '/');
+        // DIGEST file does NOT exist
+        if (normalized.includes('CLAUDE_EXEC_DIGEST.md')) return false;
+        // FULL file DOES exist
+        if (normalized.includes('CLAUDE_EXEC.md') && !normalized.includes('DIGEST')) return true;
+        // Session state file and .claude dir should use real fs
+        return originalExistsSync(filePath);
+      });
+
+      fs.statSync = vi.fn((filePath) => {
+        const normalized = filePath.replace(/\\/g, '/');
+        // FULL file has content (> 100 bytes)
+        if (normalized.includes('CLAUDE_EXEC.md') && !normalized.includes('DIGEST')) {
+          return { size: 50000 };
+        }
+        return originalStatSync(filePath);
+      });
+
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC');
+
+      expect(result.pass).toBe(true);
+      expect(result.score).toBe(85);
+      expect(result.warnings.some(w => w.includes('CROSS-MODE FALLBACK') || w.includes('FULL file'))).toBe(true);
+    });
+  });
+
+  describe('Both files missing (BLOCK)', () => {
+    it('should BLOCK at 0/100 when both DIGEST and FULL files are missing', async () => {
+      // Mock fs to simulate: both files missing
+      fs.existsSync = vi.fn((filePath) => {
+        const normalized = filePath.replace(/\\/g, '/');
+        if (normalized.includes('CLAUDE_EXEC')) return false;
+        return originalExistsSync(filePath);
+      });
+
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC');
+
+      expect(result.pass).toBe(false);
+      expect(result.score).toBe(0);
+      expect(result.issues.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('FULL mode is unaffected', () => {
+    it('should not trigger cross-mode fallback in FULL mode', async () => {
+      process.env.CLAUDE_PROTOCOL_MODE = 'full';
+
+      // In FULL mode, requiredFile is CLAUDE_EXEC.md (no DIGEST suffix)
+      // Mock: FULL file missing
+      fs.existsSync = vi.fn((filePath) => {
+        const normalized = filePath.replace(/\\/g, '/');
+        if (normalized.includes('CLAUDE_EXEC.md')) return false;
+        return originalExistsSync(filePath);
+      });
+
+      const result = await validateProtocolFileRead('PLAN-TO-EXEC');
+
+      // Should BLOCK, no cross-mode fallback
+      expect(result.pass).toBe(false);
+      expect(result.score).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Added SD-type-aware scoring to PRD quality heuristic — infrastructure/fix/documentation/refactor SDs get reduced penalties (3pts vs 5pts) for missing optional fields (system_architecture, implementation_approach, risks)
- Added cross-mode fallback to protocol file read gate — when DIGEST file is missing, falls back to check FULL file equivalent and passes at 85/100
- Addresses PAT-AUTO-73737669 (6 occurrences) and PAT-AUTO-b28c8662 (3 occurrences)

## Test plan
- [x] 12 unit tests for SD-type-aware PRD scoring (prd-quality-heuristic.test.js)
- [x] 4 unit tests for cross-mode fallback (protocol-file-read-cross-mode.test.js)
- [x] All 16 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)