### PR TITLE
feat: make CI test coverage blocking and enforce thresholds

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -4,8 +4,12 @@ on:
   pull_request:
     paths:
       - 'src/**'
+      - 'lib/**'
       - 'scripts/**'
+      - 'tests/**'
       - 'server.js'
+      - 'vitest.config.js'
+      - 'config/coverage.json'
   push:
     branches: [main, develop]
 
@@ -37,39 +41,31 @@ jobs:
       - name: Run tests with coverage
         env:
           NODE_OPTIONS: --experimental-vm-modules
-        run: |
-          npm run test:coverage -- --json --outputFile=test-results.json || {
-            echo "⚠️ Test coverage encountered errors"
-            echo "This is informational - workflow will continue"
-            echo "Known issues: Jest environment teardown, missing exports, ESM conflicts"
-            exit 0
-          }
-        continue-on-error: true  # Informational only during test infrastructure fixes
+        run: npm run test:coverage -- --json --outputFile=test-results.json
 
       - name: Check coverage threshold
         run: |
           if [ ! -f coverage/coverage-summary.json ]; then
-            echo "⚠️ Coverage report not generated (tests may have failed)"
-            echo "This is informational - workflow will continue"
-            exit 0
+            echo "❌ Coverage report not generated - tests may have failed"
+            exit 1
           fi
 
-          THRESHOLD=$(cat config/coverage.json | jq '.threshold' 2>/dev/null || echo "80")
+          THRESHOLD=$(cat config/coverage.json | jq '.threshold' 2>/dev/null || echo "50")
           COVERAGE=$(cat coverage/coverage-summary.json | jq '.total.statements.pct' 2>/dev/null || echo "0")
           HAS_GRACE="${{ contains(github.event.pull_request.labels.*.name, 'coverage-grace') }}"
 
+          echo "📊 Coverage: ${COVERAGE}% | Threshold: ${THRESHOLD}%"
+
           if [ "$HAS_GRACE" = "true" ]; then
-            echo "⚠️ WARNING: Coverage grace period used (max 2 PRs allowed)"
+            echo "⚠️ WARNING: Coverage grace period active"
             echo "⚠️ Current: ${COVERAGE}%, Required: ${THRESHOLD}%"
-            echo "⚠️ Remove 'coverage-grace' label once coverage improves"
           elif (( $(echo "$COVERAGE < $THRESHOLD" | bc -l) )); then
-            echo "⚠️ Coverage ${COVERAGE}% below threshold ${THRESHOLD}%"
-            echo "💡 Add 'coverage-grace' label for temporary bypass (2 uses max)"
-            echo "ℹ️ This is informational during test infrastructure improvements"
+            echo "❌ Coverage ${COVERAGE}% below threshold ${THRESHOLD}%"
+            echo "💡 Add 'coverage-grace' label for temporary bypass"
+            exit 1
           else
             echo "✅ Coverage ${COVERAGE}% meets threshold ${THRESHOLD}%"
           fi
-        continue-on-error: true  # Informational only during test infrastructure fixes
 
       - name: Capture test results to database
         if: always()

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEO-FEAT-FILTER-CALIBRATE-001",
-  "expectedBranch": "feat/SD-LEO-FEAT-FILTER-CALIBRATE-001",
-  "createdAt": "2026-02-16T15:07:05.053Z",
+  "sdKey": "SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-A",
+  "expectedBranch": "feat/SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-A",
+  "createdAt": "2026-02-16T18:05:16.332Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -35,6 +35,12 @@ export default defineConfig({
         '**/node_modules/**',
         '**/client/**',
       ],
+      thresholds: {
+        statements: 50,
+        branches: 40,
+        functions: 40,
+        lines: 50,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from test-coverage CI workflow so test failures block PR merges
- Add vitest coverage thresholds (50% statements/lines, 40% branches/functions) as baseline enforcement
- Widen CI trigger paths to include `lib/`, `tests/`, `vitest.config.js`, and `config/coverage.json`

## Context
Child A of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001 (EVA Codebase A-Plus Scorecard Remediation).
Targets scorecard subcriterion 4A (Test Coverage & Reliability): 3 → 7+.

## Test plan
- [ ] Verify CI workflow blocks on test failures (no more continue-on-error)
- [ ] Verify coverage threshold check exits with code 1 when below 50%
- [ ] Verify `coverage-grace` label bypasses threshold check
- [ ] Confirm all 25 stage template tests pass (243 tests)
- [ ] Confirm all core integration tests pass (166 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)