### PR TITLE
feat: implement L0-L4 autonomy model for EVA ventures

### DIFF
--- a/database/migrations/20260216_eva_autonomy_levels.sql
+++ b/database/migrations/20260216_eva_autonomy_levels.sql
@@ -1,0 +1,24 @@
+-- Migration: Add autonomy_level to eva_ventures
+-- Date: 2026-02-16
+-- Description: Creates eva_autonomy_level enum type and adds autonomy_level column
+--              to eva_ventures table for EVA autonomy classification (L0-L4).
+
+-- Step 1: Create enum type (idempotent)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'eva_autonomy_level') THEN
+    CREATE TYPE eva_autonomy_level AS ENUM ('L0', 'L1', 'L2', 'L3', 'L4');
+  END IF;
+END
+$$;
+
+-- Step 2: Add column if not exists
+ALTER TABLE eva_ventures
+  ADD COLUMN IF NOT EXISTS autonomy_level eva_autonomy_level NOT NULL DEFAULT 'L0';
+
+-- Step 3: Add comment
+COMMENT ON COLUMN eva_ventures.autonomy_level IS 'EVA autonomy level: L0=Manual, L1=Assisted, L2=Partial, L3=Conditional, L4=Full';
+
+-- Rollback:
+-- ALTER TABLE eva_ventures DROP COLUMN IF EXISTS autonomy_level;
+-- DROP TYPE IF EXISTS eva_autonomy_level;

--- a/lib/eva/autonomy-model.js
+++ b/lib/eva/autonomy-model.js
@@ -1,0 +1,133 @@
+/**
+ * EVA Autonomy Model — L0-L4 venture autonomy levels
+ *
+ * Defines autonomy levels, gate behavior matrix, and the pre-check
+ * used by the orchestrator before each gate evaluation.
+ *
+ * @module autonomy-model
+ * @version 1.0.0
+ */
+
+import { createLogger } from '../logger.js';
+
+const log = createLogger('AutonomyModel');
+
+// ── Level definitions ──────────────────────────────────────
+export const AUTONOMY_LEVELS = {
+  L0: { level: 'L0', name: 'Manual',          description: 'All gates require chairman approval' },
+  L1: { level: 'L1', name: 'Guided',          description: 'Stage gates auto-approve; reality gates manual' },
+  L2: { level: 'L2', name: 'Supervised',       description: 'All gates auto-approve; chairman notified' },
+  L3: { level: 'L3', name: 'Autonomous',       description: 'All gates auto-approve; chairman notified on exceptions only' },
+  L4: { level: 'L4', name: 'Full Autonomy',    description: 'All gates auto-approve; no notifications' },
+};
+
+export const LEVEL_ORDER = ['L0', 'L1', 'L2', 'L3', 'L4'];
+
+// ── Gate behavior matrix ───────────────────────────────────
+// Maps (level, gate_type) → action
+//   manual       = chairman must approve (existing behavior)
+//   auto_approve = gate passes automatically
+//   skip         = gate is not evaluated at all
+export const GATE_BEHAVIOR_MATRIX = {
+  L0: { stage_gate: 'manual',       reality_gate: 'manual',       devils_advocate: 'manual' },
+  L1: { stage_gate: 'auto_approve', reality_gate: 'manual',       devils_advocate: 'manual' },
+  L2: { stage_gate: 'auto_approve', reality_gate: 'auto_approve', devils_advocate: 'auto_approve' },
+  L3: { stage_gate: 'auto_approve', reality_gate: 'auto_approve', devils_advocate: 'skip' },
+  L4: { stage_gate: 'auto_approve', reality_gate: 'auto_approve', devils_advocate: 'skip' },
+};
+
+/**
+ * Check autonomy level for a venture and determine gate action.
+ *
+ * @param {string} ventureId
+ * @param {string} gateType - 'stage_gate' | 'reality_gate' | 'devils_advocate'
+ * @param {object} deps - { supabase }
+ * @returns {Promise<{action: string, level: string, reason: string}>}
+ */
+export async function checkAutonomy(ventureId, gateType, { supabase }) {
+  const { data, error } = await supabase
+    .from('eva_ventures')
+    .select('autonomy_level')
+    .eq('id', ventureId)
+    .single();
+
+  if (error || !data) {
+    log.warn('Could not fetch autonomy level, defaulting to L0', { ventureId, error: error?.message });
+    return { action: 'manual', level: 'L0', reason: 'Autonomy level not found — defaulting to L0' };
+  }
+
+  const level = data.autonomy_level || 'L0';
+  const matrix = GATE_BEHAVIOR_MATRIX[level];
+  if (!matrix) {
+    log.warn('Unknown autonomy level, defaulting to L0', { ventureId, level });
+    return { action: 'manual', level: 'L0', reason: `Unknown autonomy level ${level}` };
+  }
+
+  const action = matrix[gateType] || 'manual';
+  log.info('Autonomy check', { ventureId, autonomyLevel: level, gateType, action });
+  return { action, level, reason: `${AUTONOMY_LEVELS[level]?.name} (${level}): ${gateType} → ${action}` };
+}
+
+/**
+ * Check if a chairman override exists for this venture's autonomy level.
+ *
+ * @param {string} ventureId
+ * @param {object} deps - { chairmanPreferenceStore }
+ * @returns {Promise<string|null>} Override level or null
+ */
+export async function getAutonomyOverride(ventureId, { chairmanPreferenceStore }) {
+  if (!chairmanPreferenceStore) return null;
+  try {
+    const pref = await chairmanPreferenceStore.getPreference(ventureId, 'autonomy_override');
+    if (pref && LEVEL_ORDER.includes(pref.value)) {
+      log.info('Chairman autonomy override active', { ventureId, override: pref.value });
+      return pref.value;
+    }
+  } catch {
+    // No override set — normal path
+  }
+  return null;
+}
+
+/**
+ * Full autonomy pre-check: resolves override → venture level → gate action.
+ *
+ * @param {string} ventureId
+ * @param {string} gateType
+ * @param {object} deps - { supabase, chairmanPreferenceStore? }
+ * @returns {Promise<{action: string, level: string, reason: string, overridden: boolean}>}
+ */
+export async function autonomyPreCheck(ventureId, gateType, deps) {
+  const override = await getAutonomyOverride(ventureId, deps);
+  if (override) {
+    const matrix = GATE_BEHAVIOR_MATRIX[override];
+    const action = matrix?.[gateType] || 'manual';
+    return {
+      action,
+      level: override,
+      reason: `Chairman override (${override}): ${gateType} → ${action}`,
+      overridden: true,
+    };
+  }
+  const result = await checkAutonomy(ventureId, gateType, deps);
+  return { ...result, overridden: false };
+}
+
+/**
+ * Validate a level transition (can only go up/down by 1).
+ *
+ * @param {string} currentLevel
+ * @param {string} targetLevel
+ * @returns {{valid: boolean, reason?: string}}
+ */
+export function validateLevelTransition(currentLevel, targetLevel) {
+  const currentIdx = LEVEL_ORDER.indexOf(currentLevel);
+  const targetIdx = LEVEL_ORDER.indexOf(targetLevel);
+  if (currentIdx === -1) return { valid: false, reason: `Unknown current level: ${currentLevel}` };
+  if (targetIdx === -1) return { valid: false, reason: `Unknown target level: ${targetLevel}` };
+  const diff = Math.abs(targetIdx - currentIdx);
+  if (diff !== 1) return { valid: false, reason: `Can only change by 1 level at a time (${currentLevel} → ${targetLevel} is ${diff} levels)` };
+  return { valid: true };
+}
+
+export const MODULE_VERSION = '1.0.0';

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -27,6 +27,7 @@ import { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-br
 import { handlePostLifecycleDecision, isFinalStage } from './post-lifecycle-decisions.js';
 import { createOrReusePendingDecision, waitForDecision, createAdvisoryNotification } from './chairman-decision-watcher.js';
 import { OrchestratorTracer } from './observability.js';
+import { autonomyPreCheck } from './autonomy-model.js';
 import { VentureStateMachine } from '../agents/venture-state-machine.js';
 import { validateStageGate } from '../agents/modules/venture-state-machine/stage-gates.js';
 import { retrieveKnowledge } from './utils/knowledge-retriever.js';
@@ -352,27 +353,49 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     }
   }
 
-  // ── 5. Evaluate gates ──
+  // ── 5. Evaluate gates (autonomy-aware) ──
   const nextStage = resolvedStage + 1;
   const gateResults = [];
   let gateBlocked = false;
   const gateSpan = tracer.startSpan('gate_evaluation');
 
   try {
-    // Stage gates
-    const stageGateResult = await validateStageGateFn(supabase, ventureId, resolvedStage, nextStage, {
-      chairmanId: options.chairmanId,
-      stageOutput,
-      logger,
-    });
+    // Autonomy pre-check for stage gates
+    const stageAutonomy = await autonomyPreCheck(ventureId, 'stage_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore });
+    gateResults.push({ type: 'autonomy_check', gateType: 'stage_gate', ...stageAutonomy });
+
+    let stageGateResult;
+    if (stageAutonomy.action === 'auto_approve') {
+      stageGateResult = { passed: true, summary: `Auto-approved at ${stageAutonomy.level}`, autonomyAction: 'auto_approve' };
+    } else if (stageAutonomy.action === 'skip') {
+      stageGateResult = { passed: true, summary: `Skipped at ${stageAutonomy.level}`, autonomyAction: 'skip' };
+    } else {
+      // L0 manual — run gate as before
+      stageGateResult = await validateStageGateFn(supabase, ventureId, resolvedStage, nextStage, {
+        chairmanId: options.chairmanId,
+        stageOutput,
+        logger,
+      });
+    }
     gateResults.push({ type: 'stage_gate', ...stageGateResult });
     if (!stageGateResult.passed) gateBlocked = true;
 
-    // Reality gates
-    const realityGateResult = await evaluateRealityGateFn(
-      { from: resolvedStage, to: nextStage, ventureId },
-      { supabase, httpClient, now: () => new Date() }
-    );
+    // Autonomy pre-check for reality gates
+    const realityAutonomy = await autonomyPreCheck(ventureId, 'reality_gate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore });
+    gateResults.push({ type: 'autonomy_check', gateType: 'reality_gate', ...realityAutonomy });
+
+    let realityGateResult;
+    if (realityAutonomy.action === 'auto_approve') {
+      realityGateResult = { passed: true, summary: `Auto-approved at ${realityAutonomy.level}`, autonomyAction: 'auto_approve' };
+    } else if (realityAutonomy.action === 'skip') {
+      realityGateResult = { passed: true, summary: `Skipped at ${realityAutonomy.level}`, autonomyAction: 'skip' };
+    } else {
+      // L0 manual — run gate as before
+      realityGateResult = await evaluateRealityGateFn(
+        { from: resolvedStage, to: nextStage, ventureId },
+        { supabase, httpClient, now: () => new Date() }
+      );
+    }
     gateResults.push({ type: 'reality_gate', ...realityGateResult });
     if (!realityGateResult.passed && isGatedBoundary(resolvedStage, nextStage)) {
       // Attempt gate recovery before declaring blocked
@@ -402,10 +425,17 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
   }
   tracer.endSpan(gateSpan.spanId, { status: gateBlocked ? 'blocked' : 'completed', metadata: { gateCount: gateResults.length, blocked: gateBlocked } });
 
-  // ── 5b. Devil's Advocate (model-isolated adversarial review) ──
+  // ── 5b. Devil's Advocate (autonomy-aware adversarial review) ──
   const { isGate: hasDAGate, gateType: daGateType } = isDevilsAdvocateGate(resolvedStage);
   let devilsAdvocateReview = null;
   if (hasDAGate) {
+    // Autonomy pre-check for devil's advocate
+    const daAutonomy = await autonomyPreCheck(ventureId, 'devils_advocate', { supabase, chairmanPreferenceStore: deps.chairmanPreferenceStore });
+    if (daAutonomy.action === 'skip') {
+      gateResults.push({ type: 'devils_advocate', passed: true, summary: `Skipped at ${daAutonomy.level}`, autonomyAction: 'skip' });
+    } else if (daAutonomy.action === 'auto_approve') {
+      gateResults.push({ type: 'devils_advocate', passed: true, summary: `Auto-approved at ${daAutonomy.level}`, autonomyAction: 'auto_approve' });
+    } else {
     try {
       const primaryGateResult = gateResults.find(g => g.type === 'stage_gate') || {};
       devilsAdvocateReview = await getDevilsAdvocateReview({
@@ -434,6 +464,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       logger.warn(`[Eva] Devil's Advocate failed (non-fatal): ${err.message}`);
       gateResults.push({ type: 'devils_advocate', passed: true, error: err.message });
     }
+    } // close autonomy else (manual DA)
   }
 
   if (gateBlocked) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,63 @@
+/**
+ * Structured Logger for EVA Platform
+ *
+ * Provides JSON-formatted log output with trace correlation,
+ * log levels, and module context. Replaces direct console.* calls.
+ *
+ * Usage:
+ *   import { createLogger } from '../logger.js';
+ *   const logger = createLogger('EventRouter');
+ *   logger.info('Processing event', { eventId, eventType });
+ *   logger.warn('Handler failed', { error: err.message, attempt: 2 });
+ *
+ * @module lib/logger
+ */
+
+const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 };
+
+const CURRENT_LEVEL = LOG_LEVELS[process.env.LOG_LEVEL?.toLowerCase()] ?? LOG_LEVELS.info;
+
+/**
+ * Create a structured logger for a named module.
+ *
+ * @param {string} module - Module name (e.g., 'EventRouter', 'GateEvaluated')
+ * @param {Object} [context] - Persistent context merged into every log entry
+ * @param {string} [context.traceId] - Trace correlation ID
+ * @param {string} [context.ventureId] - Venture context
+ * @returns {{ debug, info, warn, error, child }}
+ */
+export function createLogger(module, context = {}) {
+  function emit(level, message, data = {}) {
+    if (LOG_LEVELS[level] < CURRENT_LEVEL) return;
+
+    const entry = {
+      ts: new Date().toISOString(),
+      level,
+      module,
+      msg: message,
+      ...context,
+      ...data,
+    };
+
+    const line = JSON.stringify(entry);
+
+    if (level === 'error') process.stderr.write(line + '\n');
+    else if (level === 'warn') process.stderr.write(line + '\n');
+    else process.stdout.write(line + '\n');
+  }
+
+  return {
+    debug: (msg, data) => emit('debug', msg, data),
+    info:  (msg, data) => emit('info', msg, data),
+    warn:  (msg, data) => emit('warn', msg, data),
+    error: (msg, data) => emit('error', msg, data),
+
+    /** Create a child logger with additional context. */
+    child(extra) {
+      return createLogger(module, { ...context, ...extra });
+    },
+
+    /** Console-compatible interface for dependency injection. */
+    log:   (msg, ...args) => emit('info', typeof msg === 'string' ? msg : String(msg), args.length ? { args } : {}),
+  };
+}

--- a/scripts/eva-autonomy.js
+++ b/scripts/eva-autonomy.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * EVA Autonomy CLI — manage venture autonomy levels (L0-L4)
+ *
+ * Usage:
+ *   node scripts/eva-autonomy.js status  --venture <id>
+ *   node scripts/eva-autonomy.js promote --venture <id> --to <L1-L4> --reason "..."
+ *   node scripts/eva-autonomy.js demote  --venture <id> --to <L0-L3> --reason "..."
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import {
+  AUTONOMY_LEVELS,
+  LEVEL_ORDER,
+  GATE_BEHAVIOR_MATRIX,
+  validateLevelTransition,
+} from '../lib/eva/autonomy-model.js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const command = args[0];
+  const flags = {};
+  for (let i = 1; i < args.length; i += 2) {
+    const key = args[i]?.replace(/^--/, '');
+    flags[key] = args[i + 1];
+  }
+  return { command, ...flags };
+}
+
+async function statusCommand(ventureId) {
+  const { data, error } = await supabase
+    .from('eva_ventures')
+    .select('id, name, autonomy_level')
+    .eq('id', ventureId)
+    .single();
+
+  if (error || !data) {
+    console.error(`Venture not found: ${ventureId}`);
+    process.exit(1);
+  }
+
+  const level = data.autonomy_level || 'L0';
+  const info = AUTONOMY_LEVELS[level];
+  const matrix = GATE_BEHAVIOR_MATRIX[level];
+
+  console.log(`\nVenture: ${data.name || data.id}`);
+  console.log(`Autonomy Level: ${level} (${info?.name})`);
+  console.log(`Description: ${info?.description}`);
+  console.log(`\nGate Behavior:`);
+  console.log(`  Stage Gates:      ${matrix.stage_gate}`);
+  console.log(`  Reality Gates:    ${matrix.reality_gate}`);
+  console.log(`  Devil's Advocate: ${matrix.devils_advocate}`);
+}
+
+async function changeLevelCommand(ventureId, targetLevel, reason, direction) {
+  if (!reason) {
+    console.error('--reason is required for autonomy level changes');
+    process.exit(1);
+  }
+
+  // Get current level
+  const { data: venture, error } = await supabase
+    .from('eva_ventures')
+    .select('id, name, autonomy_level')
+    .eq('id', ventureId)
+    .single();
+
+  if (error || !venture) {
+    console.error(`Venture not found: ${ventureId}`);
+    process.exit(1);
+  }
+
+  const currentLevel = venture.autonomy_level || 'L0';
+  const validation = validateLevelTransition(currentLevel, targetLevel);
+  if (!validation.valid) {
+    console.error(`Invalid transition: ${validation.reason}`);
+    process.exit(1);
+  }
+
+  // Check direction
+  const currentIdx = LEVEL_ORDER.indexOf(currentLevel);
+  const targetIdx = LEVEL_ORDER.indexOf(targetLevel);
+  if (direction === 'promote' && targetIdx <= currentIdx) {
+    console.error(`Cannot promote: ${targetLevel} is not higher than ${currentLevel}`);
+    process.exit(1);
+  }
+  if (direction === 'demote' && targetIdx >= currentIdx) {
+    console.error(`Cannot demote: ${targetLevel} is not lower than ${currentLevel}`);
+    process.exit(1);
+  }
+
+  // Update level
+  const { error: updateErr } = await supabase
+    .from('eva_ventures')
+    .update({ autonomy_level: targetLevel })
+    .eq('id', ventureId);
+
+  if (updateErr) {
+    console.error(`Failed to update: ${updateErr.message}`);
+    process.exit(1);
+  }
+
+  // Write audit log
+  const { error: auditErr } = await supabase
+    .from('eva_audit_log')
+    .insert({
+      venture_id: ventureId,
+      action_type: `autonomy_${direction}`,
+      details: {
+        from_level: currentLevel,
+        to_level: targetLevel,
+        reason,
+        direction,
+      },
+      actor: 'cli',
+    });
+
+  if (auditErr) {
+    console.warn(`Audit log failed (non-blocking): ${auditErr.message}`);
+  }
+
+  const info = AUTONOMY_LEVELS[targetLevel];
+  console.log(`\n${direction === 'promote' ? '⬆️' : '⬇️'}  Venture ${direction}d: ${currentLevel} → ${targetLevel}`);
+  console.log(`   Level: ${info?.name} — ${info?.description}`);
+  console.log(`   Reason: ${reason}`);
+  console.log(`   Audit: logged`);
+}
+
+async function main() {
+  const { command, venture, to, reason } = parseArgs();
+
+  if (!command || !['status', 'promote', 'demote'].includes(command)) {
+    console.log('Usage:');
+    console.log('  node scripts/eva-autonomy.js status  --venture <id>');
+    console.log('  node scripts/eva-autonomy.js promote --venture <id> --to <L1-L4> --reason "..."');
+    console.log('  node scripts/eva-autonomy.js demote  --venture <id> --to <L0-L3> --reason "..."');
+    console.log('\nLevels:');
+    for (const [key, val] of Object.entries(AUTONOMY_LEVELS)) {
+      console.log(`  ${key}: ${val.name} — ${val.description}`);
+    }
+    process.exit(0);
+  }
+
+  if (!venture) {
+    console.error('--venture is required');
+    process.exit(1);
+  }
+
+  if (command === 'status') {
+    await statusCommand(venture);
+  } else {
+    if (!to || !LEVEL_ORDER.includes(to)) {
+      console.error(`--to must be one of: ${LEVEL_ORDER.join(', ')}`);
+      process.exit(1);
+    }
+    await changeLevelCommand(venture, to, reason, command);
+  }
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/tests/unit/eva/autonomy-model.test.js
+++ b/tests/unit/eva/autonomy-model.test.js
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  AUTONOMY_LEVELS,
+  LEVEL_ORDER,
+  GATE_BEHAVIOR_MATRIX,
+  checkAutonomy,
+  getAutonomyOverride,
+  autonomyPreCheck,
+  validateLevelTransition,
+  MODULE_VERSION,
+} from '../../../lib/eva/autonomy-model.js';
+
+describe('autonomy-model', () => {
+  describe('AUTONOMY_LEVELS', () => {
+    it('defines all 5 levels L0-L4', () => {
+      expect(Object.keys(AUTONOMY_LEVELS)).toEqual(['L0', 'L1', 'L2', 'L3', 'L4']);
+    });
+
+    it('each level has level, name, description', () => {
+      for (const [key, val] of Object.entries(AUTONOMY_LEVELS)) {
+        expect(val.level).toBe(key);
+        expect(val.name).toBeTruthy();
+        expect(val.description).toBeTruthy();
+      }
+    });
+  });
+
+  describe('LEVEL_ORDER', () => {
+    it('has 5 levels in ascending order', () => {
+      expect(LEVEL_ORDER).toEqual(['L0', 'L1', 'L2', 'L3', 'L4']);
+    });
+  });
+
+  describe('GATE_BEHAVIOR_MATRIX', () => {
+    it('L0 is all manual', () => {
+      expect(GATE_BEHAVIOR_MATRIX.L0).toEqual({
+        stage_gate: 'manual',
+        reality_gate: 'manual',
+        devils_advocate: 'manual',
+      });
+    });
+
+    it('L1 auto-approves stage gates but not reality gates', () => {
+      expect(GATE_BEHAVIOR_MATRIX.L1.stage_gate).toBe('auto_approve');
+      expect(GATE_BEHAVIOR_MATRIX.L1.reality_gate).toBe('manual');
+    });
+
+    it('L4 auto-approves all gates and skips DA', () => {
+      expect(GATE_BEHAVIOR_MATRIX.L4.stage_gate).toBe('auto_approve');
+      expect(GATE_BEHAVIOR_MATRIX.L4.reality_gate).toBe('auto_approve');
+      expect(GATE_BEHAVIOR_MATRIX.L4.devils_advocate).toBe('skip');
+    });
+
+    it('every level has all three gate types', () => {
+      for (const level of LEVEL_ORDER) {
+        expect(GATE_BEHAVIOR_MATRIX[level]).toHaveProperty('stage_gate');
+        expect(GATE_BEHAVIOR_MATRIX[level]).toHaveProperty('reality_gate');
+        expect(GATE_BEHAVIOR_MATRIX[level]).toHaveProperty('devils_advocate');
+      }
+    });
+  });
+
+  describe('checkAutonomy', () => {
+    it('returns manual for L0 venture', async () => {
+      const supabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { autonomy_level: 'L0' }, error: null }),
+            }),
+          }),
+        }),
+      };
+      const result = await checkAutonomy('v1', 'stage_gate', { supabase });
+      expect(result.action).toBe('manual');
+      expect(result.level).toBe('L0');
+    });
+
+    it('returns auto_approve for L2 venture stage gates', async () => {
+      const supabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { autonomy_level: 'L2' }, error: null }),
+            }),
+          }),
+        }),
+      };
+      const result = await checkAutonomy('v1', 'stage_gate', { supabase });
+      expect(result.action).toBe('auto_approve');
+      expect(result.level).toBe('L2');
+    });
+
+    it('defaults to L0 on database error', async () => {
+      const supabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: null, error: { message: 'not found' } }),
+            }),
+          }),
+        }),
+      };
+      const result = await checkAutonomy('v1', 'stage_gate', { supabase });
+      expect(result.action).toBe('manual');
+      expect(result.level).toBe('L0');
+    });
+
+    it('defaults to L0 for null autonomy_level', async () => {
+      const supabase = {
+        from: () => ({
+          select: () => ({
+            eq: () => ({
+              single: () => Promise.resolve({ data: { autonomy_level: null }, error: null }),
+            }),
+          }),
+        }),
+      };
+      const result = await checkAutonomy('v1', 'reality_gate', { supabase });
+      expect(result.action).toBe('manual');
+      expect(result.level).toBe('L0');
+    });
+  });
+
+  describe('getAutonomyOverride', () => {
+    it('returns null when no preference store', async () => {
+      const result = await getAutonomyOverride('v1', {});
+      expect(result).toBeNull();
+    });
+
+    it('returns override level when set', async () => {
+      const chairmanPreferenceStore = {
+        getPreference: vi.fn().mockResolvedValue({ value: 'L3' }),
+      };
+      const result = await getAutonomyOverride('v1', { chairmanPreferenceStore });
+      expect(result).toBe('L3');
+    });
+
+    it('returns null for invalid override value', async () => {
+      const chairmanPreferenceStore = {
+        getPreference: vi.fn().mockResolvedValue({ value: 'INVALID' }),
+      };
+      const result = await getAutonomyOverride('v1', { chairmanPreferenceStore });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('autonomyPreCheck', () => {
+    const makeSupabase = (level) => ({
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: { autonomy_level: level }, error: null }),
+          }),
+        }),
+      }),
+    });
+
+    it('uses chairman override when present', async () => {
+      const chairmanPreferenceStore = {
+        getPreference: vi.fn().mockResolvedValue({ value: 'L4' }),
+      };
+      const result = await autonomyPreCheck('v1', 'stage_gate', {
+        supabase: makeSupabase('L0'),
+        chairmanPreferenceStore,
+      });
+      expect(result.level).toBe('L4');
+      expect(result.action).toBe('auto_approve');
+      expect(result.overridden).toBe(true);
+    });
+
+    it('falls back to venture level when no override', async () => {
+      const result = await autonomyPreCheck('v1', 'reality_gate', {
+        supabase: makeSupabase('L1'),
+      });
+      expect(result.level).toBe('L1');
+      expect(result.action).toBe('manual');
+      expect(result.overridden).toBe(false);
+    });
+  });
+
+  describe('validateLevelTransition', () => {
+    it('allows L0 → L1', () => {
+      expect(validateLevelTransition('L0', 'L1')).toEqual({ valid: true });
+    });
+
+    it('allows L2 → L1 (demotion)', () => {
+      expect(validateLevelTransition('L2', 'L1')).toEqual({ valid: true });
+    });
+
+    it('rejects L0 → L2 (skip)', () => {
+      const result = validateLevelTransition('L0', 'L2');
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('1 level at a time');
+    });
+
+    it('rejects unknown levels', () => {
+      expect(validateLevelTransition('L5', 'L4').valid).toBe(false);
+      expect(validateLevelTransition('L0', 'L9').valid).toBe(false);
+    });
+
+    it('rejects same level', () => {
+      const result = validateLevelTransition('L2', 'L2');
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('MODULE_VERSION', () => {
+    it('is 1.0.0', () => {
+      expect(MODULE_VERSION).toBe('1.0.0');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implement EVA autonomy model with L0-L4 levels controlling gate behavior (manual → auto-approve → skip)
- Add `autonomyPreCheck()` wrapper in eva-orchestrator.js for automatic gate behavior based on venture autonomy level
- Create CLI tool for managing venture autonomy levels (status/promote/demote with audit logging)
- Add database migration for `eva_autonomy_level` enum and column on `eva_ventures`

## Changes
- `lib/eva/autonomy-model.js` — Core module: levels, gate behavior matrix, pre-check functions
- `lib/eva/eva-orchestrator.js` — Wrapped gate evaluation with autonomy pre-check
- `scripts/eva-autonomy.js` — CLI for status/promote/demote
- `database/migrations/20260216_eva_autonomy_levels.sql` — Enum + column migration
- `tests/unit/eva/autonomy-model.test.js` — 22 tests, all passing

## Test plan
- [x] All 22 new autonomy model unit tests pass
- [x] Full test suite (2866 tests) passes with zero regressions
- [x] L0 backward-compatible (existing behavior unchanged)

Child D of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)