### PR TITLE
feat: shared services completion - 6 new factory services

### DIFF
--- a/lib/eva/services/dependency-resolution.js
+++ b/lib/eva/services/dependency-resolution.js
@@ -1,0 +1,43 @@
+/**
+ * Dependency Resolution Service
+ * SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G
+ *
+ * Resolves and validates dependencies between ventures and stages.
+ */
+
+import { createService } from '../shared-services.js';
+
+export const dependencyResolutionService = createService({
+  name: 'dependency-resolution',
+  capabilities: ['dependency-analysis', 'dependency-resolution', 'critical-path'],
+  stages: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  async executeFn(context) {
+    const { venture, stage } = context;
+    const metadata = venture?.metadata || {};
+    const dependencies = metadata.dependencies || [];
+
+    const resolved = dependencies.filter(d => d.status === 'resolved' || d.resolved);
+    const blocked = dependencies.filter(d => d.status === 'blocked' || d.blocked);
+    const pending = dependencies.filter(d => !d.status || d.status === 'pending');
+
+    return {
+      ventureId: venture?.id,
+      stageId: stage?.id,
+      analysis: {
+        totalDependencies: dependencies.length,
+        resolved: resolved.length,
+        blocked: blocked.length,
+        pending: pending.length,
+        blockers: blocked.map(d => ({
+          name: d.name || d.description || 'Unknown',
+          type: d.type || 'external',
+          owner: d.owner || 'unassigned',
+        })),
+        isBlocked: blocked.length > 0,
+      },
+      recommendations: blocked.length > 0
+        ? blocked.map(d => `Resolve blocker: ${d.name || d.description || 'Unknown dependency'}`)
+        : ['All dependencies resolved — proceed to next stage'],
+    };
+  },
+});

--- a/lib/eva/services/financial-modeling.js
+++ b/lib/eva/services/financial-modeling.js
@@ -1,0 +1,38 @@
+/**
+ * Financial Modeling Service
+ * SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G
+ *
+ * Provides financial projections and analysis for ventures.
+ */
+
+import { createService } from '../shared-services.js';
+
+export const financialModelingService = createService({
+  name: 'financial-modeling',
+  capabilities: ['financial-analysis', 'projections', 'revenue-modeling'],
+  stages: [3, 4, 5, 10, 15],
+  async executeFn(context) {
+    const { venture } = context;
+    const metadata = venture?.metadata || {};
+    const financials = metadata.financials || {};
+
+    return {
+      ventureId: venture?.id,
+      analysis: {
+        revenue: financials.projected_revenue || null,
+        costs: financials.projected_costs || null,
+        margin: financials.projected_revenue && financials.projected_costs
+          ? ((financials.projected_revenue - financials.projected_costs) / financials.projected_revenue * 100).toFixed(1) + '%'
+          : null,
+        breakEvenMonths: financials.break_even_months || null,
+        runway: financials.runway_months || null,
+        fundingRequired: financials.funding_required || null,
+      },
+      recommendations: [
+        !financials.projected_revenue ? 'Define revenue projections with supporting assumptions' : null,
+        !financials.break_even_months ? 'Calculate break-even timeline' : null,
+        'Validate financial assumptions with industry benchmarks',
+      ].filter(Boolean),
+    };
+  },
+});

--- a/lib/eva/services/index.js
+++ b/lib/eva/services/index.js
@@ -39,3 +39,11 @@ export {
   meetsCompletenessThreshold,
   getRequiredFieldsMissing,
 } from './brand-genome.js';
+
+// Shared-services-based services (createService factory pattern)
+export { marketSizingService } from './market-sizing.js';
+export { painPointAnalyzerService } from './pain-point-analyzer.js';
+export { strategicFitEvaluatorService } from './strategic-fit-evaluator.js';
+export { riskAssessmentService } from './risk-assessment.js';
+export { financialModelingService } from './financial-modeling.js';
+export { dependencyResolutionService } from './dependency-resolution.js';

--- a/lib/eva/services/market-sizing.js
+++ b/lib/eva/services/market-sizing.js
@@ -1,0 +1,34 @@
+/**
+ * Market Sizing Service
+ * SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G
+ *
+ * Analyzes total addressable market (TAM), serviceable addressable market (SAM),
+ * and serviceable obtainable market (SOM) for a venture.
+ */
+
+import { createService } from '../shared-services.js';
+
+export const marketSizingService = createService({
+  name: 'market-sizing',
+  capabilities: ['market-analysis', 'tam-sam-som', 'market-sizing'],
+  stages: [1, 2, 3],
+  async executeFn(context) {
+    const { venture } = context;
+    const metadata = venture?.metadata || {};
+
+    return {
+      ventureId: venture?.id,
+      analysis: {
+        tam: metadata.market_size_tam || null,
+        sam: metadata.market_size_sam || null,
+        som: metadata.market_size_som || null,
+        methodology: 'top-down',
+        confidence: metadata.market_size_tam ? 'medium' : 'low',
+      },
+      recommendations: [
+        'Validate TAM assumptions with primary research',
+        'Identify key market segments for SAM refinement',
+      ],
+    };
+  },
+});

--- a/lib/eva/services/pain-point-analyzer.js
+++ b/lib/eva/services/pain-point-analyzer.js
@@ -1,0 +1,36 @@
+/**
+ * Pain Point Analyzer Service
+ * SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G
+ *
+ * Analyzes customer pain points for a venture based on research data.
+ */
+
+import { createService } from '../shared-services.js';
+
+export const painPointAnalyzerService = createService({
+  name: 'pain-point-analyzer',
+  capabilities: ['customer-analysis', 'pain-point-identification'],
+  stages: [1, 2, 3, 4],
+  async executeFn(context) {
+    const { venture } = context;
+    const metadata = venture?.metadata || {};
+    const painPoints = metadata.pain_points || [];
+
+    return {
+      ventureId: venture?.id,
+      analysis: {
+        painPointCount: painPoints.length,
+        painPoints: painPoints.map((pp, i) => ({
+          id: `PP-${i + 1}`,
+          description: typeof pp === 'string' ? pp : pp.description || 'Unknown',
+          severity: pp.severity || 'medium',
+          frequency: pp.frequency || 'unknown',
+        })),
+        coverage: painPoints.length >= 3 ? 'adequate' : 'needs-research',
+      },
+      recommendations: painPoints.length < 3
+        ? ['Conduct more customer interviews to identify pain points']
+        : ['Validate pain point severity rankings with quantitative data'],
+    };
+  },
+});

--- a/lib/eva/services/risk-assessment.js
+++ b/lib/eva/services/risk-assessment.js
@@ -1,0 +1,45 @@
+/**
+ * Risk Assessment Engine Service
+ * SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G
+ *
+ * Evaluates venture risks across multiple dimensions.
+ */
+
+import { createService } from '../shared-services.js';
+
+export const riskAssessmentService = createService({
+  name: 'risk-assessment',
+  capabilities: ['risk-analysis', 'risk-scoring'],
+  stages: [2, 3, 4, 5, 10],
+  async executeFn(context) {
+    const { venture } = context;
+    const metadata = venture?.metadata || {};
+    const risks = metadata.risks || [];
+
+    const riskScores = risks.map((r, i) => ({
+      id: `RISK-${i + 1}`,
+      category: r.category || 'general',
+      description: typeof r === 'string' ? r : r.description || 'Unknown',
+      likelihood: r.likelihood || 'medium',
+      impact: r.impact || 'medium',
+      score: (r.likelihood_score || 5) * (r.impact_score || 5),
+      mitigation: r.mitigation || null,
+    }));
+
+    const totalScore = riskScores.reduce((sum, r) => sum + r.score, 0);
+    const avgScore = riskScores.length > 0 ? totalScore / riskScores.length : 0;
+
+    return {
+      ventureId: venture?.id,
+      analysis: {
+        riskCount: riskScores.length,
+        risks: riskScores,
+        overallRiskScore: avgScore,
+        riskLevel: avgScore >= 50 ? 'high' : avgScore >= 25 ? 'medium' : 'low',
+      },
+      recommendations: avgScore >= 50
+        ? ['Develop detailed mitigation plans for high-scoring risks']
+        : ['Monitor identified risks quarterly'],
+    };
+  },
+});

--- a/lib/eva/services/strategic-fit-evaluator.js
+++ b/lib/eva/services/strategic-fit-evaluator.js
@@ -1,0 +1,40 @@
+/**
+ * Strategic Fit Evaluator Service
+ * SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G
+ *
+ * Evaluates how well a venture fits the portfolio strategy.
+ */
+
+import { createService } from '../shared-services.js';
+
+export const strategicFitEvaluatorService = createService({
+  name: 'strategic-fit-evaluator',
+  capabilities: ['strategic-analysis', 'portfolio-fit'],
+  stages: [2, 3, 5],
+  async executeFn(context) {
+    const { venture } = context;
+    const metadata = venture?.metadata || {};
+
+    const factors = {
+      marketAlignment: metadata.market_alignment_score || 0,
+      coreCompetencyMatch: metadata.competency_match_score || 0,
+      synergyPotential: metadata.synergy_score || 0,
+      resourceAvailability: metadata.resource_score || 0,
+    };
+
+    const scores = Object.values(factors);
+    const avgScore = scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : 0;
+
+    return {
+      ventureId: venture?.id,
+      analysis: {
+        factors,
+        overallFit: avgScore,
+        fitCategory: avgScore >= 7 ? 'strong' : avgScore >= 4 ? 'moderate' : 'weak',
+      },
+      recommendations: avgScore < 4
+        ? ['Consider repositioning venture to improve strategic alignment']
+        : ['Proceed with current strategic positioning'],
+    };
+  },
+});

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "eva:scheduler:start": "node scripts/eva-scheduler.js start",
     "eva:scheduler:status": "node scripts/eva-scheduler.js status",
     "eva:events:status": "node scripts/eva-events-status.js",
+    "eva:services:status": "node scripts/eva-services-status.js",
     "eva:recovery:status": "node scripts/eva-recovery-status.js",
     "eva:dlq:replay": "node scripts/eva-dlq-replay.js",
     "genesis:branches": "node scripts/leo-genesis-branches.js list",

--- a/scripts/eva-services-status.js
+++ b/scripts/eva-services-status.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * EVA Services Status Dashboard
+ * SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G
+ *
+ * Displays health and capability status of all shared services.
+ */
+
+import { marketSizingService } from '../lib/eva/services/market-sizing.js';
+import { painPointAnalyzerService } from '../lib/eva/services/pain-point-analyzer.js';
+import { strategicFitEvaluatorService } from '../lib/eva/services/strategic-fit-evaluator.js';
+import { riskAssessmentService } from '../lib/eva/services/risk-assessment.js';
+import { financialModelingService } from '../lib/eva/services/financial-modeling.js';
+import { dependencyResolutionService } from '../lib/eva/services/dependency-resolution.js';
+
+const services = [
+  marketSizingService,
+  painPointAnalyzerService,
+  strategicFitEvaluatorService,
+  riskAssessmentService,
+  financialModelingService,
+  dependencyResolutionService,
+];
+
+// Legacy services (not yet using createService factory)
+const legacyServices = [
+  { name: 'brand-genome', status: 'legacy (CRUD-style, not factory-based)' },
+  { name: 'venture-research', status: 'legacy (direct export)' },
+  { name: 'competitive-intelligence', status: 'legacy (class-based)' },
+];
+
+console.log('\n=== EVA Shared Services Status ===\n');
+console.log(`Factory-based services: ${services.length}/6`);
+console.log(`Legacy services: ${legacyServices.length}/3`);
+console.log(`Total: ${services.length + legacyServices.length}/9\n`);
+
+console.log('--- Factory Services (createService pattern) ---\n');
+for (const svc of services) {
+  const ok = svc.name && svc.execute && svc.loadContext && svc.emit;
+  const caps = svc.capabilities?.join(', ') || 'none';
+  const stages = svc.stages?.join(', ') || 'all';
+  console.log(`  ${ok ? 'OK' : 'ERR'} ${svc.name}`);
+  console.log(`     Capabilities: ${caps}`);
+  console.log(`     Stages: ${stages}`);
+}
+
+console.log('\n--- Legacy Services ---\n');
+for (const svc of legacyServices) {
+  console.log(`  --  ${svc.name} (${svc.status})`);
+}
+
+console.log('');

--- a/tests/unit/eva/shared-services-new.test.js
+++ b/tests/unit/eva/shared-services-new.test.js
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for new shared services (Child G)
+ * SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G
+ */
+
+import { describe, it, expect } from 'vitest';
+import { marketSizingService } from '../../../lib/eva/services/market-sizing.js';
+import { painPointAnalyzerService } from '../../../lib/eva/services/pain-point-analyzer.js';
+import { strategicFitEvaluatorService } from '../../../lib/eva/services/strategic-fit-evaluator.js';
+import { riskAssessmentService } from '../../../lib/eva/services/risk-assessment.js';
+import { financialModelingService } from '../../../lib/eva/services/financial-modeling.js';
+import { dependencyResolutionService } from '../../../lib/eva/services/dependency-resolution.js';
+
+// execute() returns { success, data, duration } — assertions use result.data.*
+
+describe('Market Sizing Service', () => {
+  it('returns analysis with TAM/SAM/SOM from metadata', async () => {
+    const result = await marketSizingService.execute({
+      venture: { id: 'v1', metadata: { market_size_tam: 1000000, market_size_sam: 500000, market_size_som: 100000 } },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.analysis.tam).toBe(1000000);
+    expect(result.data.analysis.sam).toBe(500000);
+    expect(result.data.analysis.som).toBe(100000);
+    expect(result.data.analysis.confidence).toBe('medium');
+  });
+
+  it('returns low confidence when no TAM data', async () => {
+    const result = await marketSizingService.execute({ venture: { id: 'v1', metadata: {} } });
+    expect(result.data.analysis.tam).toBeNull();
+    expect(result.data.analysis.confidence).toBe('low');
+  });
+
+  it('has correct service metadata', () => {
+    expect(marketSizingService.name).toBe('market-sizing');
+    expect(marketSizingService.capabilities).toContain('tam-sam-som');
+  });
+});
+
+describe('Pain Point Analyzer Service', () => {
+  it('analyzes pain points from metadata', async () => {
+    const result = await painPointAnalyzerService.execute({
+      venture: { id: 'v1', metadata: { pain_points: [
+        { description: 'Slow onboarding', severity: 'high', frequency: 'daily' },
+        { description: 'Poor UX', severity: 'medium' },
+        'Simple string pain point',
+      ] } },
+    });
+    expect(result.data.analysis.painPointCount).toBe(3);
+    expect(result.data.analysis.painPoints[0].description).toBe('Slow onboarding');
+    expect(result.data.analysis.painPoints[2].description).toBe('Simple string pain point');
+    expect(result.data.analysis.coverage).toBe('adequate');
+  });
+
+  it('flags needs-research when fewer than 3 pain points', async () => {
+    const result = await painPointAnalyzerService.execute({
+      venture: { id: 'v1', metadata: { pain_points: [{ description: 'One issue' }] } },
+    });
+    expect(result.data.analysis.coverage).toBe('needs-research');
+    expect(result.data.recommendations).toContain('Conduct more customer interviews to identify pain points');
+  });
+});
+
+describe('Strategic Fit Evaluator Service', () => {
+  it('evaluates fit factors and computes overall score', async () => {
+    const result = await strategicFitEvaluatorService.execute({
+      venture: { id: 'v1', metadata: {
+        market_alignment_score: 8, competency_match_score: 7,
+        synergy_score: 9, resource_score: 6,
+      } },
+    });
+    expect(result.data.analysis.overallFit).toBe(7.5);
+    expect(result.data.analysis.fitCategory).toBe('strong');
+  });
+
+  it('returns weak fit for low scores', async () => {
+    const result = await strategicFitEvaluatorService.execute({
+      venture: { id: 'v1', metadata: { market_alignment_score: 2, competency_match_score: 1 } },
+    });
+    expect(result.data.analysis.fitCategory).toBe('weak');
+  });
+});
+
+describe('Risk Assessment Service', () => {
+  it('scores risks and computes overall level', async () => {
+    const result = await riskAssessmentService.execute({
+      venture: { id: 'v1', metadata: { risks: [
+        { category: 'market', description: 'Competition', likelihood_score: 8, impact_score: 7 },
+        { category: 'tech', description: 'Scalability', likelihood_score: 3, impact_score: 4 },
+      ] } },
+    });
+    expect(result.data.analysis.riskCount).toBe(2);
+    expect(result.data.analysis.risks[0].score).toBe(56);
+    expect(result.data.analysis.risks[1].score).toBe(12);
+    expect(result.data.analysis.overallRiskScore).toBe(34);
+    expect(result.data.analysis.riskLevel).toBe('medium');
+  });
+
+  it('returns low risk when no risks present', async () => {
+    const result = await riskAssessmentService.execute({
+      venture: { id: 'v1', metadata: {} },
+    });
+    expect(result.data.analysis.riskCount).toBe(0);
+    expect(result.data.analysis.riskLevel).toBe('low');
+  });
+
+  it('handles string-only risk entries', async () => {
+    const result = await riskAssessmentService.execute({
+      venture: { id: 'v1', metadata: { risks: ['Market saturation'] } },
+    });
+    expect(result.data.analysis.risks[0].description).toBe('Market saturation');
+    expect(result.data.analysis.risks[0].score).toBe(25); // 5*5 defaults
+  });
+});
+
+describe('Financial Modeling Service', () => {
+  it('computes margin from revenue and costs', async () => {
+    const result = await financialModelingService.execute({
+      venture: { id: 'v1', metadata: { financials: {
+        projected_revenue: 200000, projected_costs: 120000,
+        break_even_months: 18, runway_months: 24,
+      } } },
+    });
+    expect(result.data.analysis.revenue).toBe(200000);
+    expect(result.data.analysis.margin).toBe('40.0%');
+    expect(result.data.analysis.breakEvenMonths).toBe(18);
+  });
+
+  it('returns null margin when data missing', async () => {
+    const result = await financialModelingService.execute({
+      venture: { id: 'v1', metadata: {} },
+    });
+    expect(result.data.analysis.margin).toBeNull();
+    expect(result.data.recommendations).toContain('Define revenue projections with supporting assumptions');
+  });
+});
+
+describe('Dependency Resolution Service', () => {
+  it('categorizes dependencies by status', async () => {
+    const result = await dependencyResolutionService.execute({
+      venture: { id: 'v1', metadata: { dependencies: [
+        { name: 'API Ready', status: 'resolved' },
+        { name: 'DB Migration', status: 'blocked', type: 'internal', owner: 'dba-team' },
+        { name: 'Design Review', status: 'pending' },
+      ] } },
+    });
+    expect(result.data.analysis.totalDependencies).toBe(3);
+    expect(result.data.analysis.resolved).toBe(1);
+    expect(result.data.analysis.blocked).toBe(1);
+    expect(result.data.analysis.pending).toBe(1);
+    expect(result.data.analysis.isBlocked).toBe(true);
+    expect(result.data.analysis.blockers[0].name).toBe('DB Migration');
+  });
+
+  it('reports not blocked when all resolved', async () => {
+    const result = await dependencyResolutionService.execute({
+      venture: { id: 'v1', metadata: { dependencies: [
+        { name: 'Done', status: 'resolved' },
+      ] } },
+    });
+    expect(result.data.analysis.isBlocked).toBe(false);
+    expect(result.data.recommendations).toContain('All dependencies resolved — proceed to next stage');
+  });
+
+  it('handles empty dependencies', async () => {
+    const result = await dependencyResolutionService.execute({
+      venture: { id: 'v1', metadata: {} },
+    });
+    expect(result.data.analysis.totalDependencies).toBe(0);
+    expect(result.data.analysis.isBlocked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 6 new EVA shared services using `createService()` factory pattern: market-sizing, pain-point-analyzer, strategic-fit-evaluator, risk-assessment, financial-modeling, dependency-resolution
- Update barrel exports in `lib/eva/services/index.js`
- Add `eva:services:status` CLI dashboard
- 15 unit tests covering all services

## Test plan
- [x] All 15 unit tests pass (`vitest run tests/unit/eva/shared-services-new.test.js`)
- [ ] Verify `npm run eva:services:status` displays service listing

SD: SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-G

🤖 Generated with [Claude Code](https://claude.com/claude-code)