### PR TITLE
feat: chairman governance dashboard and timeout escalation

### DIFF
--- a/lib/eva/chairman-decision-timeout.js
+++ b/lib/eva/chairman-decision-timeout.js
@@ -1,0 +1,187 @@
+/**
+ * Chairman Decision Timeout Manager
+ *
+ * Monitors pending decisions and auto-escalates after a configurable
+ * timeout threshold. Escalation creates a new decision at the next
+ * authority level or auto-approves based on the decision type.
+ *
+ * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-I
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const DEFAULT_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours
+const ESCALATION_STRATEGIES = {
+  gate_decision: 'auto_approve_with_flag',
+  advisory: 'auto_acknowledge',
+  override: 'revert_to_system',
+};
+
+/**
+ * Check for timed-out decisions and escalate them.
+ *
+ * @param {Object} options
+ * @param {Object} [options.supabase] - Supabase client (auto-created if not provided)
+ * @param {Object} [options.logger] - Logger instance
+ * @param {number} [options.timeoutMs] - Timeout threshold in ms (default: 24h)
+ * @param {boolean} [options.dryRun] - If true, report but don't escalate
+ * @returns {Promise<{checked: number, escalated: Array, errors: Array}>}
+ */
+export async function checkAndEscalateTimeouts({
+  supabase: supabaseClient,
+  logger = console,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  dryRun = false,
+} = {}) {
+  const supabase = supabaseClient || createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const cutoff = new Date(Date.now() - timeoutMs).toISOString();
+
+  // Find pending decisions older than the timeout
+  const { data: timedOut, error } = await supabase
+    .from('chairman_decisions')
+    .select('id, venture_id, lifecycle_stage, status, decision_type, summary, created_at, blocking')
+    .eq('status', 'pending')
+    .lt('created_at', cutoff)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    logger.error(`Timeout check failed: ${error.message}`);
+    return { checked: 0, escalated: [], errors: [error.message] };
+  }
+
+  if (!timedOut || timedOut.length === 0) {
+    logger.log('No timed-out decisions found');
+    return { checked: 0, escalated: [], errors: [] };
+  }
+
+  logger.log(`Found ${timedOut.length} timed-out decision(s)`);
+  const escalated = [];
+  const errors = [];
+
+  for (const decision of timedOut) {
+    const strategy = ESCALATION_STRATEGIES[decision.decision_type] || 'auto_approve_with_flag';
+    const ageMs = Date.now() - new Date(decision.created_at).getTime();
+    const ageHours = Math.round(ageMs / 3600000);
+
+    logger.log(`  Decision ${decision.id.slice(0, 8)}: stage ${decision.lifecycle_stage}, age ${ageHours}h → ${strategy}`);
+
+    if (dryRun) {
+      escalated.push({
+        decisionId: decision.id,
+        strategy,
+        ageHours,
+        wouldEscalate: true,
+      });
+      continue;
+    }
+
+    try {
+      const result = await applyEscalation(supabase, decision, strategy);
+      escalated.push({
+        decisionId: decision.id,
+        strategy,
+        ageHours,
+        result,
+      });
+    } catch (err) {
+      logger.error(`  Escalation failed for ${decision.id}: ${err.message}`);
+      errors.push({ decisionId: decision.id, error: err.message });
+    }
+  }
+
+  return { checked: timedOut.length, escalated, errors };
+}
+
+/**
+ * Apply escalation strategy to a timed-out decision.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Object} decision - The timed-out decision
+ * @param {string} strategy - Escalation strategy name
+ * @returns {Promise<Object>} Escalation result
+ */
+async function applyEscalation(supabase, decision, strategy) {
+  switch (strategy) {
+    case 'auto_approve_with_flag': {
+      const { error } = await supabase
+        .from('chairman_decisions')
+        .update({
+          status: 'approved',
+          decision: 'auto_escalated',
+          rationale: `Auto-escalated: decision timed out after ${formatAge(decision.created_at)}. Requires chairman review.`,
+          resolved_at: new Date().toISOString(),
+          metadata: {
+            ...(decision.metadata || {}),
+            escalation: {
+              type: 'timeout',
+              strategy,
+              escalated_at: new Date().toISOString(),
+              original_created_at: decision.created_at,
+            },
+          },
+        })
+        .eq('id', decision.id);
+
+      if (error) throw new Error(error.message);
+      return { action: 'auto_approved', flagged: true };
+    }
+
+    case 'auto_acknowledge': {
+      const { error } = await supabase
+        .from('chairman_decisions')
+        .update({
+          status: 'info',
+          decision: 'auto_acknowledged',
+          rationale: `Advisory auto-acknowledged after timeout of ${formatAge(decision.created_at)}.`,
+          resolved_at: new Date().toISOString(),
+        })
+        .eq('id', decision.id);
+
+      if (error) throw new Error(error.message);
+      return { action: 'auto_acknowledged' };
+    }
+
+    case 'revert_to_system': {
+      const { error } = await supabase
+        .from('chairman_decisions')
+        .update({
+          status: 'approved',
+          decision: 'system_default',
+          rationale: `Override timed out after ${formatAge(decision.created_at)}. Reverted to system recommendation.`,
+          resolved_at: new Date().toISOString(),
+        })
+        .eq('id', decision.id);
+
+      if (error) throw new Error(error.message);
+      return { action: 'reverted_to_system' };
+    }
+
+    default:
+      throw new Error(`Unknown escalation strategy: ${strategy}`);
+  }
+}
+
+function formatAge(dateStr) {
+  const ms = Date.now() - new Date(dateStr).getTime();
+  const hours = Math.floor(ms / 3600000);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}d ${hours % 24}h`;
+  return `${hours}h`;
+}
+
+/**
+ * Get the timeout configuration for a specific decision type.
+ *
+ * @param {string} decisionType - The decision type
+ * @param {Object} [overrides] - Custom timeout overrides
+ * @returns {{timeoutMs: number, strategy: string}}
+ */
+export function getTimeoutConfig(decisionType, overrides = {}) {
+  const strategy = ESCALATION_STRATEGIES[decisionType] || 'auto_approve_with_flag';
+  const timeoutMs = overrides[decisionType] || DEFAULT_TIMEOUT_MS;
+  return { timeoutMs, strategy };
+}

--- a/package.json
+++ b/package.json
@@ -118,6 +118,8 @@
     "schema:audit:tables": "node scripts/audit-dormant-tables.js",
     "schema:audit:enums": "node scripts/audit-enum-coverage.js",
     "schema:migration:stats": "node scripts/migration-stats.js",
+    "chairman:dashboard": "node scripts/chairman-dashboard.js",
+    "chairman:seed": "node scripts/chairman-seed-data.js",
     "eva:dlq:replay": "node scripts/eva-dlq-replay.js",
     "genesis:branches": "node scripts/leo-genesis-branches.js list",
     "genesis:branches:list": "node scripts/leo-genesis-branches.js list",

--- a/scripts/chairman-dashboard.js
+++ b/scripts/chairman-dashboard.js
@@ -1,0 +1,200 @@
+/**
+ * Chairman Dashboard CLI
+ *
+ * Displays pending decisions, override history, preference summary,
+ * and decision queue status in a terminal-friendly format.
+ *
+ * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-I
+ *
+ * Usage: node scripts/chairman-dashboard.js [--json]
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const JSON_MODE = process.argv.includes('--json');
+
+function log(msg = '') {
+  if (!JSON_MODE) console.log(msg);
+}
+
+async function getPendingDecisions() {
+  const { data, error } = await supabase
+    .from('chairman_decisions')
+    .select('id, venture_id, lifecycle_stage, status, summary, created_at, decision_type, blocking')
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true });
+
+  if (error) return { data: [], error: error.message };
+  return { data: data || [], error: null };
+}
+
+async function getRecentDecisions(limit = 10) {
+  const { data, error } = await supabase
+    .from('chairman_decisions')
+    .select('id, venture_id, lifecycle_stage, status, decision, summary, rationale, created_at, resolved_at')
+    .neq('status', 'pending')
+    .order('resolved_at', { ascending: false })
+    .limit(limit);
+
+  if (error) return { data: [], error: error.message };
+  return { data: data || [], error: null };
+}
+
+async function getOverrideSummary() {
+  const { data, error } = await supabase
+    .from('chairman_overrides')
+    .select('id, component, system_score, override_score, outcome, created_at')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  if (error) return { data: [], error: error.message };
+  return { data: data || [], error: null };
+}
+
+async function getPreferenceSummary() {
+  const { data, error } = await supabase
+    .from('chairman_preferences')
+    .select('preference_key, preference_value, value_type, venture_id, source, updated_at')
+    .order('updated_at', { ascending: false })
+    .limit(20);
+
+  if (error) return { data: [], error: error.message };
+  return { data: data || [], error: null };
+}
+
+async function getDecisionStats() {
+  const { data: all } = await supabase
+    .from('chairman_decisions')
+    .select('status, decision_type, blocking');
+
+  if (!all) return { total: 0, pending: 0, approved: 0, rejected: 0, advisory: 0, blocking: 0 };
+
+  return {
+    total: all.length,
+    pending: all.filter(d => d.status === 'pending').length,
+    approved: all.filter(d => d.status === 'approved').length,
+    rejected: all.filter(d => d.status === 'rejected').length,
+    advisory: all.filter(d => d.decision_type === 'advisory' || d.status === 'info').length,
+    blocking: all.filter(d => d.blocking === true && d.status === 'pending').length,
+  };
+}
+
+function formatAge(dateStr) {
+  const ms = Date.now() - new Date(dateStr).getTime();
+  const hours = Math.floor(ms / 3600000);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}d ${hours % 24}h`;
+  if (hours > 0) return `${hours}h`;
+  return `${Math.floor(ms / 60000)}m`;
+}
+
+async function main() {
+  log('');
+  log('='.repeat(60));
+  log('  CHAIRMAN GOVERNANCE DASHBOARD');
+  log('='.repeat(60));
+
+  // Stats
+  const stats = await getDecisionStats();
+  log('');
+  log('  Decision Stats');
+  log('  ' + '-'.repeat(40));
+  log(`  Total Decisions:  ${stats.total}`);
+  log(`  Pending:          ${stats.pending}${stats.blocking > 0 ? ` (${stats.blocking} blocking)` : ''}`);
+  log(`  Approved:         ${stats.approved}`);
+  log(`  Rejected:         ${stats.rejected}`);
+  log(`  Advisory:         ${stats.advisory}`);
+
+  // Pending Decisions
+  const { data: pending, error: pendingErr } = await getPendingDecisions();
+  log('');
+  log('  Pending Decisions Queue');
+  log('  ' + '-'.repeat(40));
+  if (pendingErr) {
+    log(`  Error: ${pendingErr}`);
+  } else if (pending.length === 0) {
+    log('  No pending decisions');
+  } else {
+    for (const d of pending) {
+      const age = formatAge(d.created_at);
+      const blockTag = d.blocking ? ' [BLOCKING]' : '';
+      const typeTag = d.decision_type === 'advisory' ? ' (advisory)' : '';
+      log(`  [${d.id.slice(0, 8)}] Stage ${d.lifecycle_stage} | Age: ${age}${blockTag}${typeTag}`);
+      log(`           ${d.summary || 'No summary'}`);
+    }
+  }
+
+  // Recent Resolved Decisions
+  const { data: recent } = await getRecentDecisions(5);
+  log('');
+  log('  Recent Decisions (last 5)');
+  log('  ' + '-'.repeat(40));
+  if (recent.length === 0) {
+    log('  No resolved decisions');
+  } else {
+    for (const d of recent) {
+      const status = d.status === 'approved' ? 'APPROVED' : d.status === 'rejected' ? 'REJECTED' : d.status.toUpperCase();
+      log(`  [${d.id.slice(0, 8)}] Stage ${d.lifecycle_stage} → ${status}`);
+      if (d.rationale) log(`           ${d.rationale.slice(0, 60)}`);
+    }
+  }
+
+  // Override Summary
+  const { data: overrides } = await getOverrideSummary();
+  log('');
+  log('  Override History (last 5)');
+  log('  ' + '-'.repeat(40));
+  if (overrides.length === 0) {
+    log('  No overrides recorded');
+  } else {
+    for (const o of overrides.slice(0, 5)) {
+      const delta = (parseFloat(o.override_score) - parseFloat(o.system_score)).toFixed(1);
+      const dir = delta > 0 ? '+' : '';
+      log(`  ${o.component}: ${o.system_score} → ${o.override_score} (${dir}${delta}) [${o.outcome}]`);
+    }
+  }
+
+  // Preferences
+  const { data: prefs } = await getPreferenceSummary();
+  log('');
+  log('  Active Preferences');
+  log('  ' + '-'.repeat(40));
+  if (prefs.length === 0) {
+    log('  No preferences set');
+  } else {
+    const globalPrefs = prefs.filter(p => !p.venture_id);
+    const venturePrefs = prefs.filter(p => p.venture_id);
+    if (globalPrefs.length > 0) {
+      log('  Global:');
+      for (const p of globalPrefs.slice(0, 5)) {
+        const val = typeof p.preference_value === 'object' ? JSON.stringify(p.preference_value) : p.preference_value;
+        log(`    ${p.preference_key} = ${val} (${p.value_type})`);
+      }
+    }
+    if (venturePrefs.length > 0) {
+      log(`  Venture-specific: ${venturePrefs.length} preference(s)`);
+    }
+  }
+
+  log('');
+  log('='.repeat(60));
+
+  // JSON output mode
+  if (JSON_MODE) {
+    const output = { stats, pending, recent, overrides, prefs };
+    console.log(JSON.stringify(output, null, 2));
+  }
+}
+
+main().catch(err => {
+  console.error('Dashboard error:', err.message);
+  process.exit(1);
+});

--- a/scripts/chairman-seed-data.js
+++ b/scripts/chairman-seed-data.js
@@ -1,0 +1,249 @@
+/**
+ * Chairman Governance Seed Data
+ *
+ * Creates sample data demonstrating the end-to-end chairman decision flow:
+ * 1. Creates a test venture
+ * 2. Creates pending decisions at various stages
+ * 3. Creates preferences (global + venture-specific)
+ * 4. Creates override records
+ * 5. Resolves some decisions to show the full lifecycle
+ *
+ * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-I
+ *
+ * Usage: node scripts/chairman-seed-data.js [--clean]
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const SEED_TAG = 'chairman-governance-seed';
+const CLEAN_MODE = process.argv.includes('--clean');
+
+async function cleanSeedData() {
+  console.log('Cleaning seed data...');
+
+  // Clean decisions with seed tag in metadata
+  const { error: e1 } = await supabase
+    .from('chairman_decisions')
+    .delete()
+    .eq('metadata->>seed_tag', SEED_TAG);
+  if (e1) console.warn('  Decisions clean error:', e1.message);
+  else console.log('  Decisions cleaned');
+
+  // Clean overrides with seed tag
+  const { error: e2 } = await supabase
+    .from('chairman_overrides')
+    .delete()
+    .eq('outcome_notes', SEED_TAG);
+  if (e2) console.warn('  Overrides clean error:', e2.message);
+  else console.log('  Overrides cleaned');
+
+  // Clean preferences with seed source
+  const { error: e3 } = await supabase
+    .from('chairman_preferences')
+    .delete()
+    .eq('source', SEED_TAG);
+  if (e3) console.warn('  Preferences clean error:', e3.message);
+  else console.log('  Preferences cleaned');
+
+  console.log('Seed data cleaned');
+}
+
+async function seedData() {
+  console.log('');
+  console.log('Chairman Governance Seed Data');
+  console.log('='.repeat(40));
+
+  // Step 1: Get or create a venture for testing
+  const { data: ventures } = await supabase
+    .from('ventures')
+    .select('id, name')
+    .limit(1);
+
+  let ventureId;
+  if (ventures && ventures.length > 0) {
+    ventureId = ventures[0].id;
+    console.log(`Using existing venture: ${ventures[0].name} (${ventureId.slice(0, 8)})`);
+  } else {
+    console.log('No ventures found. Creating decisions without venture_id.');
+    ventureId = null;
+  }
+
+  // Step 2: Create chairman preferences
+  console.log('\n  Creating preferences...');
+
+  const preferences = [
+    { key: 'risk.max_drawdown_pct', value: 15, value_type: 'number', venture_id: null },
+    { key: 'budget.max_monthly_usd', value: 5000, value_type: 'number', venture_id: null },
+    { key: 'tech.stack_directive', value: 'Prefer Node.js + React. No PHP.', value_type: 'string', venture_id: null },
+    { key: 'notifications.email', value: 'chairman@ehg.test', value_type: 'string', venture_id: null },
+    { key: 'notifications.immediate_enabled', value: true, value_type: 'boolean', venture_id: null },
+  ];
+
+  // Add venture-specific preference if venture exists
+  if (ventureId) {
+    preferences.push({
+      key: 'risk.max_drawdown_pct',
+      value: 25,
+      value_type: 'number',
+      venture_id: ventureId,
+    });
+  }
+
+  for (const pref of preferences) {
+    const { error } = await supabase
+      .from('chairman_preferences')
+      .upsert({
+        chairman_id: 'chairman-default',
+        venture_id: pref.venture_id,
+        preference_key: pref.key,
+        preference_value: pref.value,
+        value_type: pref.value_type,
+        source: SEED_TAG,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'chairman_id,venture_id,preference_key' });
+
+    if (error) {
+      console.warn(`    Pref ${pref.key}: ${error.message}`);
+    } else {
+      const scope = pref.venture_id ? 'venture' : 'global';
+      console.log(`    ${pref.key} = ${pref.value} (${scope})`);
+    }
+  }
+
+  // Step 3: Create chairman decisions showing full lifecycle
+  console.log('\n  Creating decisions...');
+
+  const decisions = [
+    // Pending decision (waiting for chairman)
+    {
+      lifecycle_stage: 5,
+      status: 'pending',
+      decision: 'pending',
+      summary: 'Market validation gate: venture needs chairman review of TAM estimates',
+      blocking: true,
+      decision_type: 'gate_decision',
+      metadata: { seed_tag: SEED_TAG },
+    },
+    // Pending advisory (non-blocking)
+    {
+      lifecycle_stage: 3,
+      status: 'pending',
+      decision: 'pending',
+      decision_type: 'advisory',
+      blocking: false,
+      summary: 'Advisory: competitor landscape has shifted since initial analysis',
+      metadata: { seed_tag: SEED_TAG },
+    },
+    // Approved decision (historical)
+    {
+      lifecycle_stage: 0,
+      status: 'approved',
+      decision: 'proceed',
+      summary: 'Stage 0: Venture approved for Stage 1 pipeline',
+      rationale: 'Strong market fit, aligns with portfolio strategy',
+      resolved_at: new Date(Date.now() - 7 * 86400000).toISOString(),
+      metadata: { seed_tag: SEED_TAG },
+    },
+    // Rejected decision (historical)
+    {
+      lifecycle_stage: 10,
+      status: 'rejected',
+      decision: 'halt',
+      summary: 'Stage 10: Budget exceeded threshold, chairman halted venture',
+      rationale: 'Monthly burn rate 3x above preference threshold. Requires cost restructuring.',
+      resolved_at: new Date(Date.now() - 3 * 86400000).toISOString(),
+      metadata: { seed_tag: SEED_TAG },
+    },
+    // Auto-escalated decision (timed out)
+    {
+      lifecycle_stage: 22,
+      status: 'approved',
+      decision: 'auto_escalated',
+      summary: 'Stage 22: Auto-escalated after 24h timeout',
+      rationale: 'Auto-escalated: decision timed out. Requires chairman review.',
+      resolved_at: new Date(Date.now() - 1 * 86400000).toISOString(),
+      metadata: {
+        seed_tag: SEED_TAG,
+        escalation: {
+          type: 'timeout',
+          strategy: 'auto_approve_with_flag',
+          escalated_at: new Date(Date.now() - 1 * 86400000).toISOString(),
+        },
+      },
+    },
+  ];
+
+  for (const dec of decisions) {
+    const row = { ...dec };
+    if (ventureId) row.venture_id = ventureId;
+
+    const { error } = await supabase
+      .from('chairman_decisions')
+      .insert(row);
+
+    if (error) {
+      console.warn(`    Stage ${dec.lifecycle_stage} (${dec.status}): ${error.message}`);
+    } else {
+      console.log(`    Stage ${dec.lifecycle_stage}: ${dec.status} - ${dec.summary.slice(0, 50)}`);
+    }
+  }
+
+  // Step 4: Create override records
+  console.log('\n  Creating overrides...');
+
+  if (ventureId) {
+    const overrides = [
+      { component: 'moat_architecture', system_score: 65, override_score: 80, reason: 'Network effects undervalued by algorithm', outcome: 'positive' },
+      { component: 'portfolio_evaluation', system_score: 72, override_score: 55, reason: 'Too similar to existing portfolio venture', outcome: 'positive' },
+      { component: 'virality', system_score: 45, override_score: 70, reason: 'B2B virality pattern not captured by consumer model', outcome: 'pending' },
+    ];
+
+    for (const o of overrides) {
+      const { error } = await supabase
+        .from('chairman_overrides')
+        .insert({
+          venture_id: ventureId,
+          component: o.component,
+          system_score: o.system_score,
+          override_score: o.override_score,
+          reason: o.reason,
+          outcome: o.outcome,
+          outcome_notes: SEED_TAG,
+        });
+
+      if (error) {
+        console.warn(`    ${o.component}: ${error.message}`);
+      } else {
+        const delta = o.override_score - o.system_score;
+        console.log(`    ${o.component}: ${o.system_score} → ${o.override_score} (${delta > 0 ? '+' : ''}${delta})`);
+      }
+    }
+  } else {
+    console.log('    Skipped (no venture_id)');
+  }
+
+  console.log('\n' + '='.repeat(40));
+  console.log('Seed data created successfully');
+  console.log('Run: node scripts/chairman-dashboard.js');
+}
+
+async function main() {
+  if (CLEAN_MODE) {
+    await cleanSeedData();
+  } else {
+    await seedData();
+  }
+}
+
+main().catch(err => {
+  console.error('Seed error:', err.message);
+  process.exit(1);
+});

--- a/tests/unit/eva/chairman-governance.test.js
+++ b/tests/unit/eva/chairman-governance.test.js
@@ -1,0 +1,191 @@
+/**
+ * Chairman Governance Tests
+ *
+ * Tests for chairman governance system components:
+ * - Decision timeout and auto-escalation
+ * - Chairman dashboard script
+ * - Chairman seed data script
+ * - Decision watcher (createOrReusePendingDecision, createAdvisoryNotification)
+ * - Preference store validation
+ * - Override tracker insights
+ *
+ * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-I
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+// Path helpers
+const ROOT = resolve(import.meta.dirname, '../../..');
+
+describe('Chairman Governance', () => {
+  describe('Decision Timeout Module', () => {
+    const timeoutPath = resolve(ROOT, 'lib/eva/chairman-decision-timeout.js');
+
+    it('exists and exports checkAndEscalateTimeouts', async () => {
+      expect(existsSync(timeoutPath)).toBe(true);
+      const mod = await import(timeoutPath);
+      expect(typeof mod.checkAndEscalateTimeouts).toBe('function');
+    });
+
+    it('exists and exports getTimeoutConfig', async () => {
+      const mod = await import(timeoutPath);
+      expect(typeof mod.getTimeoutConfig).toBe('function');
+    });
+
+    it('getTimeoutConfig returns correct strategy for gate_decision', async () => {
+      const { getTimeoutConfig } = await import(timeoutPath);
+      const config = getTimeoutConfig('gate_decision');
+      expect(config.strategy).toBe('auto_approve_with_flag');
+      expect(config.timeoutMs).toBe(24 * 60 * 60 * 1000);
+    });
+
+    it('getTimeoutConfig returns correct strategy for advisory', async () => {
+      const { getTimeoutConfig } = await import(timeoutPath);
+      const config = getTimeoutConfig('advisory');
+      expect(config.strategy).toBe('auto_acknowledge');
+    });
+
+    it('getTimeoutConfig returns correct strategy for override', async () => {
+      const { getTimeoutConfig } = await import(timeoutPath);
+      const config = getTimeoutConfig('override');
+      expect(config.strategy).toBe('revert_to_system');
+    });
+
+    it('getTimeoutConfig uses custom timeout overrides', async () => {
+      const { getTimeoutConfig } = await import(timeoutPath);
+      const config = getTimeoutConfig('gate_decision', { gate_decision: 3600000 });
+      expect(config.timeoutMs).toBe(3600000);
+    });
+  });
+
+  describe('Chairman Dashboard Script', () => {
+    const dashboardPath = resolve(ROOT, 'scripts/chairman-dashboard.js');
+
+    it('exists', () => {
+      expect(existsSync(dashboardPath)).toBe(true);
+    });
+
+    it('imports dotenv and supabase', () => {
+      const src = readFileSync(dashboardPath, 'utf-8');
+      expect(src).toContain("import dotenv from 'dotenv'");
+      expect(src).toContain("from '@supabase/supabase-js'");
+    });
+
+    it('has getPendingDecisions function', () => {
+      const src = readFileSync(dashboardPath, 'utf-8');
+      expect(src).toContain('async function getPendingDecisions');
+    });
+
+    it('has getRecentDecisions function', () => {
+      const src = readFileSync(dashboardPath, 'utf-8');
+      expect(src).toContain('async function getRecentDecisions');
+    });
+
+    it('has getDecisionStats function', () => {
+      const src = readFileSync(dashboardPath, 'utf-8');
+      expect(src).toContain('async function getDecisionStats');
+    });
+
+    it('supports --json flag', () => {
+      const src = readFileSync(dashboardPath, 'utf-8');
+      expect(src).toContain('--json');
+      expect(src).toContain('JSON_MODE');
+    });
+  });
+
+  describe('Chairman Seed Data Script', () => {
+    const seedPath = resolve(ROOT, 'scripts/chairman-seed-data.js');
+
+    it('exists', () => {
+      expect(existsSync(seedPath)).toBe(true);
+    });
+
+    it('supports --clean flag', () => {
+      const src = readFileSync(seedPath, 'utf-8');
+      expect(src).toContain('--clean');
+      expect(src).toContain('CLEAN_MODE');
+    });
+
+    it('creates decisions at multiple lifecycle stages', () => {
+      const src = readFileSync(seedPath, 'utf-8');
+      expect(src).toContain('lifecycle_stage: 0');
+      expect(src).toContain('lifecycle_stage: 5');
+      expect(src).toContain('lifecycle_stage: 10');
+      expect(src).toContain('lifecycle_stage: 22');
+    });
+
+    it('demonstrates auto-escalation in seed data', () => {
+      const src = readFileSync(seedPath, 'utf-8');
+      expect(src).toContain('auto_escalated');
+      expect(src).toContain('auto_approve_with_flag');
+    });
+
+    it('creates both pending and resolved decisions', () => {
+      const src = readFileSync(seedPath, 'utf-8');
+      expect(src).toContain("status: 'pending'");
+      expect(src).toContain("status: 'approved'");
+      expect(src).toContain("status: 'rejected'");
+    });
+  });
+
+  describe('Decision Watcher Module', () => {
+    const watcherPath = resolve(ROOT, 'lib/eva/chairman-decision-watcher.js');
+
+    it('exports waitForDecision', async () => {
+      const mod = await import(watcherPath);
+      expect(typeof mod.waitForDecision).toBe('function');
+    });
+
+    it('exports createOrReusePendingDecision', async () => {
+      const mod = await import(watcherPath);
+      expect(typeof mod.createOrReusePendingDecision).toBe('function');
+    });
+
+    it('exports createAdvisoryNotification', async () => {
+      const mod = await import(watcherPath);
+      expect(typeof mod.createAdvisoryNotification).toBe('function');
+    });
+  });
+
+  describe('Preference Store Module', () => {
+    const storePath = resolve(ROOT, 'lib/eva/chairman-preference-store.js');
+
+    it('exports ChairmanPreferenceStore class', async () => {
+      const mod = await import(storePath);
+      expect(typeof mod.ChairmanPreferenceStore).toBe('function');
+    });
+
+    it('exports createChairmanPreferenceStore factory', async () => {
+      const mod = await import(storePath);
+      expect(typeof mod.createChairmanPreferenceStore).toBe('function');
+    });
+
+    it('has known key validators for risk and budget preferences', () => {
+      const src = readFileSync(storePath, 'utf-8');
+      expect(src).toContain("'risk.max_drawdown_pct'");
+      expect(src).toContain("'budget.max_monthly_usd'");
+      expect(src).toContain("'tech.stack_directive'");
+    });
+  });
+
+  describe('Override Tracker Module', () => {
+    const trackerPath = resolve(ROOT, 'lib/eva/stage-zero/chairman-override-tracker.js');
+
+    it('exports recordOverride', async () => {
+      const mod = await import(trackerPath);
+      expect(typeof mod.recordOverride).toBe('function');
+    });
+
+    it('exports getOverridesByComponent', async () => {
+      const mod = await import(trackerPath);
+      expect(typeof mod.getOverridesByComponent).toBe('function');
+    });
+
+    it('exports generateOverrideInsights', async () => {
+      const mod = await import(trackerPath);
+      expect(typeof mod.generateOverrideInsights).toBe('function');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add chairman dashboard CLI (`npm run chairman:dashboard`) showing pending decisions, overrides, preferences, and decision stats
- Implement decision timeout auto-escalation module with 3 strategies: auto-approve, auto-acknowledge, revert-to-system
- Add seed data script (`npm run chairman:seed`) demonstrating end-to-end decision flows across lifecycle stages
- 26 unit tests covering all governance modules

## Test plan
- [x] All 26 tests pass (`npx vitest run tests/unit/eva/chairman-governance.test.js`)
- [ ] Run `npm run chairman:seed` to create sample data
- [ ] Run `npm run chairman:dashboard` to verify dashboard renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)