### PR TITLE
feat: security audit tools and API auth middleware

### DIFF
--- a/lib/middleware/api-auth.js
+++ b/lib/middleware/api-auth.js
@@ -1,0 +1,147 @@
+/**
+ * API Authentication Middleware
+ *
+ * JWT-based authentication for Express routes. Validates tokens
+ * from Supabase Auth and attaches user context to requests.
+ *
+ * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-J
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// Routes that don't require authentication
+const PUBLIC_ROUTES = new Set([
+  '/api/health',
+  '/api/status',
+  '/api/version',
+]);
+
+/**
+ * Create JWT authentication middleware.
+ *
+ * @param {Object} options
+ * @param {Set<string>} [options.publicRoutes] - Additional public routes
+ * @param {boolean} [options.allowServiceRole] - Allow service role key in x-api-key header
+ * @returns {Function} Express middleware
+ */
+export function createAuthMiddleware(options = {}) {
+  const publicRoutes = new Set([...PUBLIC_ROUTES, ...(options.publicRoutes || [])]);
+  const allowServiceRole = options.allowServiceRole ?? true;
+
+  return async function authMiddleware(req, res, next) {
+    // Skip auth for public routes
+    if (publicRoutes.has(req.path)) {
+      return next();
+    }
+
+    // Check for service role API key
+    if (allowServiceRole) {
+      const apiKey = req.headers['x-api-key'];
+      if (apiKey && apiKey === SERVICE_ROLE_KEY) {
+        req.user = { role: 'service_role', isServiceRole: true };
+        return next();
+      }
+    }
+
+    // Extract JWT from Authorization header
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({
+        success: false,
+        error: 'Missing or invalid Authorization header',
+        code: 'AUTH_MISSING',
+      });
+    }
+
+    const token = authHeader.slice(7);
+
+    try {
+      // Verify token using Supabase
+      const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+        global: { headers: { Authorization: `Bearer ${token}` } },
+      });
+
+      const { data: { user }, error } = await supabase.auth.getUser();
+
+      if (error || !user) {
+        return res.status(401).json({
+          success: false,
+          error: 'Invalid or expired token',
+          code: 'AUTH_INVALID',
+        });
+      }
+
+      // Attach user to request
+      req.user = {
+        id: user.id,
+        email: user.email,
+        role: user.user_metadata?.role || 'user',
+        isChairman: user.user_metadata?.role === 'chairman',
+        isServiceRole: false,
+      };
+
+      next();
+    } catch (err) {
+      return res.status(500).json({
+        success: false,
+        error: 'Authentication error',
+        code: 'AUTH_ERROR',
+      });
+    }
+  };
+}
+
+/**
+ * Middleware to require chairman role.
+ * Must be used after createAuthMiddleware.
+ */
+export function requireChairman(req, res, next) {
+  if (!req.user) {
+    return res.status(401).json({
+      success: false,
+      error: 'Authentication required',
+      code: 'AUTH_REQUIRED',
+    });
+  }
+
+  if (!req.user.isChairman && !req.user.isServiceRole) {
+    return res.status(403).json({
+      success: false,
+      error: 'Chairman role required',
+      code: 'FORBIDDEN_NOT_CHAIRMAN',
+    });
+  }
+
+  next();
+}
+
+/**
+ * Check if a user has chairman role via database function.
+ *
+ * @param {Object} supabase - Supabase client with service role
+ * @param {string} userId - User UUID
+ * @returns {Promise<boolean>}
+ */
+export async function isChairman(supabase, userId) {
+  if (!userId) return false;
+
+  try {
+    const { data, error } = await supabase.rpc('fn_is_chairman', {
+      user_uuid: userId,
+    });
+
+    if (error) {
+      // Function may not exist yet — fall back to metadata check
+      const { data: userData } = await supabase.auth.admin.getUserById(userId);
+      return userData?.user?.user_metadata?.role === 'chairman';
+    }
+
+    return data === true;
+  } catch {
+    return false;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -120,6 +120,8 @@
     "schema:migration:stats": "node scripts/migration-stats.js",
     "chairman:dashboard": "node scripts/chairman-dashboard.js",
     "chairman:seed": "node scripts/chairman-seed-data.js",
+    "security:audit": "node scripts/security-audit-dashboard.js",
+    "security:rls": "node scripts/audit-rls-policies.js",
     "eva:dlq:replay": "node scripts/eva-dlq-replay.js",
     "genesis:branches": "node scripts/leo-genesis-branches.js list",
     "genesis:branches:list": "node scripts/leo-genesis-branches.js list",

--- a/scripts/audit-rls-policies.js
+++ b/scripts/audit-rls-policies.js
@@ -1,0 +1,190 @@
+/**
+ * RLS Policy Audit Tool
+ *
+ * Audits Row-Level Security policies across all tables in the public schema.
+ * Reports coverage, missing policies, and potential security gaps.
+ *
+ * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-J
+ *
+ * Usage: node scripts/audit-rls-policies.js [--json]
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const JSON_MODE = process.argv.includes('--json');
+
+function log(msg = '') {
+  if (!JSON_MODE) console.log(msg);
+}
+
+// Tables that are intentionally public or service-role only
+const EXEMPTED_TABLES = new Set([
+  'schema_migrations',
+  'spatial_ref_sys',
+]);
+
+async function getRlsPolicies() {
+  const { data, error } = await supabase.rpc('exec_sql', {
+    sql: `
+      SELECT
+        schemaname,
+        tablename,
+        policyname,
+        permissive,
+        roles,
+        cmd,
+        qual
+      FROM pg_policies
+      WHERE schemaname = 'public'
+      ORDER BY tablename, policyname
+    `
+  });
+
+  if (error) return { data: [], error: error.message };
+  return { data: data || [], error: null };
+}
+
+async function getRlsEnabledTables() {
+  const { data, error } = await supabase.rpc('exec_sql', {
+    sql: `
+      SELECT
+        relname as tablename,
+        relrowsecurity as rls_enabled,
+        relforcerowsecurity as rls_forced
+      FROM pg_class
+      WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+        AND relkind = 'r'
+      ORDER BY relname
+    `
+  });
+
+  if (error) return { data: [], error: error.message };
+  return { data: data || [], error: null };
+}
+
+async function main() {
+  log('');
+  log('='.repeat(60));
+  log('  RLS POLICY AUDIT');
+  log('='.repeat(60));
+
+  const { data: tables, error: tablesErr } = await getRlsEnabledTables();
+  if (tablesErr) {
+    console.error('Failed to get tables:', tablesErr);
+    process.exit(1);
+  }
+
+  const { data: policies, error: policiesErr } = await getRlsPolicies();
+  if (policiesErr) {
+    console.error('Failed to get policies:', policiesErr);
+    process.exit(1);
+  }
+
+  // Build policy map
+  const policyMap = new Map();
+  for (const p of policies) {
+    if (!policyMap.has(p.tablename)) policyMap.set(p.tablename, []);
+    policyMap.get(p.tablename).push(p);
+  }
+
+  // Categorize tables
+  const rlsEnabled = [];
+  const rlsDisabled = [];
+  const withPolicies = [];
+  const withoutPolicies = [];
+
+  for (const t of tables) {
+    const exempt = EXEMPTED_TABLES.has(t.tablename);
+    if (exempt) continue;
+
+    if (t.rls_enabled) {
+      rlsEnabled.push(t.tablename);
+      if (policyMap.has(t.tablename)) {
+        withPolicies.push(t.tablename);
+      } else {
+        withoutPolicies.push(t.tablename);
+      }
+    } else {
+      rlsDisabled.push(t.tablename);
+    }
+  }
+
+  const totalTables = rlsEnabled.length + rlsDisabled.length;
+  const coverage = totalTables > 0 ? Math.round((rlsEnabled.length / totalTables) * 100) : 0;
+
+  // Report
+  log('');
+  log('  Summary');
+  log('  ' + '-'.repeat(40));
+  log(`  Total tables:        ${totalTables}`);
+  log(`  RLS enabled:         ${rlsEnabled.length} (${coverage}%)`);
+  log(`  RLS disabled:        ${rlsDisabled.length}`);
+  log(`  With policies:       ${withPolicies.length}`);
+  log(`  Without policies:    ${withoutPolicies.length}`);
+  log(`  Total policies:      ${policies.length}`);
+
+  if (rlsDisabled.length > 0) {
+    log('');
+    log('  Tables WITHOUT RLS (security gap)');
+    log('  ' + '-'.repeat(40));
+    for (const t of rlsDisabled.slice(0, 20)) {
+      const hasPolicies = policyMap.has(t) ? ' (has policies but RLS disabled!)' : '';
+      log(`  - ${t}${hasPolicies}`);
+    }
+    if (rlsDisabled.length > 20) {
+      log(`  ... and ${rlsDisabled.length - 20} more`);
+    }
+  }
+
+  if (withoutPolicies.length > 0) {
+    log('');
+    log('  RLS enabled but NO policies defined');
+    log('  ' + '-'.repeat(40));
+    for (const t of withoutPolicies) {
+      log(`  - ${t} (all access blocked!)`);
+    }
+  }
+
+  // Policy details for tables with policies
+  if (withPolicies.length > 0) {
+    log('');
+    log('  Policy Coverage Detail (first 10)');
+    log('  ' + '-'.repeat(40));
+    for (const t of withPolicies.slice(0, 10)) {
+      const tablePolicies = policyMap.get(t) || [];
+      const cmds = [...new Set(tablePolicies.map(p => p.cmd))].join(', ');
+      log(`  ${t}: ${tablePolicies.length} policies (${cmds})`);
+    }
+  }
+
+  log('');
+  log('='.repeat(60));
+
+  if (JSON_MODE) {
+    const output = {
+      coverage,
+      totalTables,
+      rlsEnabled: rlsEnabled.length,
+      rlsDisabled: rlsDisabled.length,
+      withPolicies: withPolicies.length,
+      withoutPolicies: withoutPolicies.length,
+      totalPolicies: policies.length,
+      gaps: rlsDisabled,
+      enabledButNoPolicies: withoutPolicies,
+    };
+    console.log(JSON.stringify(output, null, 2));
+  }
+}
+
+main().catch(err => {
+  console.error('Audit error:', err.message);
+  process.exit(1);
+});

--- a/scripts/security-audit-dashboard.js
+++ b/scripts/security-audit-dashboard.js
@@ -1,0 +1,227 @@
+/**
+ * Security Audit Dashboard
+ *
+ * Comprehensive security overview showing:
+ * - RLS policy coverage
+ * - API authentication status
+ * - Secret management (env var check)
+ * - Chairman authorization function status
+ *
+ * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-J
+ *
+ * Usage: node scripts/security-audit-dashboard.js [--json]
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const JSON_MODE = process.argv.includes('--json');
+const ROOT = resolve(import.meta.dirname, '..');
+
+function log(msg = '') {
+  if (!JSON_MODE) console.log(msg);
+}
+
+async function checkRlsCoverage() {
+  const { data: tables } = await supabase.rpc('exec_sql', {
+    sql: `
+      SELECT relname as tablename, relrowsecurity as rls_enabled
+      FROM pg_class
+      WHERE relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+        AND relkind = 'r'
+    `
+  });
+
+  if (!tables) return { total: 0, enabled: 0, coverage: 0 };
+
+  const total = tables.length;
+  const enabled = tables.filter(t => t.rls_enabled).length;
+  return { total, enabled, coverage: total > 0 ? Math.round((enabled / total) * 100) : 0 };
+}
+
+async function checkFnIsChairman() {
+  const { data, error } = await supabase.rpc('exec_sql', {
+    sql: `
+      SELECT routine_name, routine_type
+      FROM information_schema.routines
+      WHERE routine_schema = 'public'
+        AND routine_name = 'fn_is_chairman'
+    `
+  });
+
+  return {
+    exists: data && data.length > 0,
+    type: data?.[0]?.routine_type || 'N/A',
+  };
+}
+
+function checkSecretManagement() {
+  const envPath = resolve(ROOT, '.env');
+  const envExists = existsSync(envPath);
+  const gitignorePath = resolve(ROOT, '.gitignore');
+  const gitignoreExists = existsSync(gitignorePath);
+
+  let envInGitignore = false;
+  if (gitignoreExists) {
+    const gitignore = readFileSync(gitignorePath, 'utf-8');
+    envInGitignore = gitignore.includes('.env');
+  }
+
+  // Check for common secret env vars
+  const requiredSecrets = [
+    'SUPABASE_URL',
+    'SUPABASE_SERVICE_ROLE_KEY',
+    'SUPABASE_ANON_KEY',
+  ];
+
+  const secretStatus = requiredSecrets.map(key => ({
+    key,
+    present: !!process.env[key],
+    // Never expose actual values
+  }));
+
+  return {
+    envFileExists: envExists,
+    envInGitignore,
+    secrets: secretStatus,
+    allSecretsPresent: secretStatus.every(s => s.present),
+  };
+}
+
+function checkApiAuthMiddleware() {
+  const authPath = resolve(ROOT, 'lib/middleware/api-auth.js');
+  const exists = existsSync(authPath);
+
+  if (!exists) return { exists: false, hasJwtValidation: false, hasChairmanCheck: false };
+
+  const src = readFileSync(authPath, 'utf-8');
+  return {
+    exists: true,
+    hasJwtValidation: src.includes('Bearer') && src.includes('getUser'),
+    hasChairmanCheck: src.includes('requireChairman') || src.includes('isChairman'),
+    hasServiceRoleAuth: src.includes('x-api-key') || src.includes('service_role'),
+    hasPublicRoutes: src.includes('PUBLIC_ROUTES'),
+  };
+}
+
+async function checkApiRouteProtection() {
+  // Check if routes use auth middleware
+  const routesDir = resolve(ROOT, 'server/routes');
+  const routeFiles = ['chairman.js', 'ventures.js', 'discovery.js', 'sdip.js', 'calibration.js'];
+
+  const results = [];
+  for (const file of routeFiles) {
+    const path = resolve(routesDir, file);
+    if (!existsSync(path)) continue;
+
+    const src = readFileSync(path, 'utf-8');
+    results.push({
+      route: file,
+      hasAuth: src.includes('auth') || src.includes('authenticate') || src.includes('requireChairman'),
+      hasValidation: src.includes('validate') || src.includes('!decisionId') || src.includes('400'),
+    });
+  }
+
+  return results;
+}
+
+async function main() {
+  log('');
+  log('='.repeat(60));
+  log('  SECURITY AUDIT DASHBOARD');
+  log('='.repeat(60));
+
+  // 1. RLS Coverage
+  const rls = await checkRlsCoverage();
+  const rlsIcon = rls.coverage >= 90 ? 'PASS' : rls.coverage >= 50 ? 'WARN' : 'FAIL';
+  log('');
+  log(`  [${rlsIcon}] RLS Coverage`);
+  log('  ' + '-'.repeat(40));
+  log(`  Total tables:    ${rls.total}`);
+  log(`  RLS enabled:     ${rls.enabled}`);
+  log(`  Coverage:        ${rls.coverage}%`);
+
+  // 2. API Auth
+  const auth = checkApiAuthMiddleware();
+  const authIcon = auth.exists && auth.hasJwtValidation ? 'PASS' : 'FAIL';
+  log('');
+  log(`  [${authIcon}] API Authentication Middleware`);
+  log('  ' + '-'.repeat(40));
+  log(`  Middleware exists:     ${auth.exists}`);
+  log(`  JWT validation:       ${auth.hasJwtValidation || false}`);
+  log(`  Chairman check:       ${auth.hasChairmanCheck || false}`);
+  log(`  Service role auth:    ${auth.hasServiceRoleAuth || false}`);
+  log(`  Public routes:        ${auth.hasPublicRoutes || false}`);
+
+  // 3. fn_is_chairman
+  const fnChairman = await checkFnIsChairman();
+  const fnIcon = fnChairman.exists ? 'PASS' : 'FAIL';
+  log('');
+  log(`  [${fnIcon}] fn_is_chairman Function`);
+  log('  ' + '-'.repeat(40));
+  log(`  Exists:     ${fnChairman.exists}`);
+  log(`  Type:       ${fnChairman.type}`);
+
+  // 4. Secret Management
+  const secrets = checkSecretManagement();
+  const secretIcon = secrets.envInGitignore && secrets.allSecretsPresent ? 'PASS' : 'WARN';
+  log('');
+  log(`  [${secretIcon}] Secret Management`);
+  log('  ' + '-'.repeat(40));
+  log(`  .env exists:         ${secrets.envFileExists}`);
+  log(`  .env in .gitignore:  ${secrets.envInGitignore}`);
+  log(`  All secrets present: ${secrets.allSecretsPresent}`);
+  for (const s of secrets.secrets) {
+    log(`    ${s.key}: ${s.present ? 'SET' : 'MISSING'}`);
+  }
+
+  // 5. Route Protection
+  const routes = await checkApiRouteProtection();
+  const protectedCount = routes.filter(r => r.hasAuth).length;
+  const routeIcon = protectedCount === routes.length ? 'PASS' : 'WARN';
+  log('');
+  log(`  [${routeIcon}] API Route Protection`);
+  log('  ' + '-'.repeat(40));
+  log(`  Protected: ${protectedCount}/${routes.length}`);
+  for (const r of routes) {
+    log(`    ${r.route}: auth=${r.hasAuth}, validation=${r.hasValidation}`);
+  }
+
+  // Overall Score
+  const scores = [
+    rls.coverage >= 50 ? 1 : 0,
+    auth.exists && auth.hasJwtValidation ? 1 : 0,
+    fnChairman.exists ? 1 : 0,
+    secrets.envInGitignore ? 1 : 0,
+    protectedCount > 0 ? 1 : 0,
+  ];
+  const overallScore = Math.round((scores.reduce((a, b) => a + b, 0) / scores.length) * 100);
+
+  log('');
+  log('  Overall Security Score');
+  log('  ' + '-'.repeat(40));
+  log(`  Score: ${overallScore}%`);
+  log(`  Checks passed: ${scores.filter(s => s).length}/${scores.length}`);
+
+  log('');
+  log('='.repeat(60));
+
+  if (JSON_MODE) {
+    const output = { rls, auth, fnChairman, secrets, routes, overallScore };
+    console.log(JSON.stringify(output, null, 2));
+  }
+}
+
+main().catch(err => {
+  console.error('Dashboard error:', err.message);
+  process.exit(1);
+});

--- a/tests/unit/eva/security-auth.test.js
+++ b/tests/unit/eva/security-auth.test.js
@@ -1,0 +1,184 @@
+/**
+ * Security and API Authentication Tests
+ *
+ * Tests for:
+ * - API auth middleware (createAuthMiddleware, requireChairman, isChairman)
+ * - RLS audit script
+ * - Security audit dashboard
+ *
+ * Part of SD-MAN-ORCH-EVA-CODEBASE-PLUS-001-J
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '../../..');
+
+describe('Security and API Authentication', () => {
+  describe('API Auth Middleware', () => {
+    const authPath = resolve(ROOT, 'lib/middleware/api-auth.js');
+
+    it('exists', () => {
+      expect(existsSync(authPath)).toBe(true);
+    });
+
+    it('exports createAuthMiddleware', async () => {
+      const mod = await import(authPath);
+      expect(typeof mod.createAuthMiddleware).toBe('function');
+    });
+
+    it('exports requireChairman', async () => {
+      const mod = await import(authPath);
+      expect(typeof mod.requireChairman).toBe('function');
+    });
+
+    it('exports isChairman', async () => {
+      const mod = await import(authPath);
+      expect(typeof mod.isChairman).toBe('function');
+    });
+
+    it('createAuthMiddleware returns a function', async () => {
+      const { createAuthMiddleware } = await import(authPath);
+      const middleware = createAuthMiddleware();
+      expect(typeof middleware).toBe('function');
+    });
+
+    it('supports public routes configuration', () => {
+      const src = readFileSync(authPath, 'utf-8');
+      expect(src).toContain('PUBLIC_ROUTES');
+      expect(src).toContain('/api/health');
+      expect(src).toContain('/api/status');
+    });
+
+    it('validates Bearer token format', () => {
+      const src = readFileSync(authPath, 'utf-8');
+      expect(src).toContain("startsWith('Bearer ')");
+      expect(src).toContain('AUTH_MISSING');
+    });
+
+    it('supports service role API key', () => {
+      const src = readFileSync(authPath, 'utf-8');
+      expect(src).toContain('x-api-key');
+      expect(src).toContain('service_role');
+    });
+
+    it('requireChairman returns 403 for non-chairman users', async () => {
+      const { requireChairman } = await import(authPath);
+      const req = { user: { isChairman: false, isServiceRole: false } };
+      const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn(),
+      };
+      const next = vi.fn();
+
+      requireChairman(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+        code: 'FORBIDDEN_NOT_CHAIRMAN',
+      }));
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('requireChairman allows chairman users', async () => {
+      const { requireChairman } = await import(authPath);
+      const req = { user: { isChairman: true, isServiceRole: false } };
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+      const next = vi.fn();
+
+      requireChairman(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('requireChairman allows service role', async () => {
+      const { requireChairman } = await import(authPath);
+      const req = { user: { isChairman: false, isServiceRole: true } };
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+      const next = vi.fn();
+
+      requireChairman(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('requireChairman returns 401 without user', async () => {
+      const { requireChairman } = await import(authPath);
+      const req = {};
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn() };
+      const next = vi.fn();
+
+      requireChairman(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('RLS Audit Script', () => {
+    const rlsPath = resolve(ROOT, 'scripts/audit-rls-policies.js');
+
+    it('exists', () => {
+      expect(existsSync(rlsPath)).toBe(true);
+    });
+
+    it('queries pg_policies for RLS information', () => {
+      const src = readFileSync(rlsPath, 'utf-8');
+      expect(src).toContain('pg_policies');
+      expect(src).toContain('relrowsecurity');
+    });
+
+    it('supports --json output', () => {
+      const src = readFileSync(rlsPath, 'utf-8');
+      expect(src).toContain('--json');
+      expect(src).toContain('JSON_MODE');
+    });
+
+    it('tracks exempted tables', () => {
+      const src = readFileSync(rlsPath, 'utf-8');
+      expect(src).toContain('EXEMPTED_TABLES');
+    });
+  });
+
+  describe('Security Audit Dashboard', () => {
+    const dashPath = resolve(ROOT, 'scripts/security-audit-dashboard.js');
+
+    it('exists', () => {
+      expect(existsSync(dashPath)).toBe(true);
+    });
+
+    it('checks RLS coverage', () => {
+      const src = readFileSync(dashPath, 'utf-8');
+      expect(src).toContain('checkRlsCoverage');
+    });
+
+    it('checks fn_is_chairman function', () => {
+      const src = readFileSync(dashPath, 'utf-8');
+      expect(src).toContain('checkFnIsChairman');
+      expect(src).toContain('fn_is_chairman');
+    });
+
+    it('checks secret management', () => {
+      const src = readFileSync(dashPath, 'utf-8');
+      expect(src).toContain('checkSecretManagement');
+      expect(src).toContain('.gitignore');
+      expect(src).toContain('SUPABASE_SERVICE_ROLE_KEY');
+    });
+
+    it('checks API route protection', () => {
+      const src = readFileSync(dashPath, 'utf-8');
+      expect(src).toContain('checkApiRouteProtection');
+    });
+
+    it('calculates overall security score', () => {
+      const src = readFileSync(dashPath, 'utf-8');
+      expect(src).toContain('overallScore');
+    });
+
+    it('supports --json output', () => {
+      const src = readFileSync(dashPath, 'utf-8');
+      expect(src).toContain('--json');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add JWT authentication middleware (`lib/middleware/api-auth.js`) with Bearer token validation, service role API key support, and chairman role gating
- Implement RLS policy audit tool (`npm run security:rls`) scanning pg_policies and pg_class for coverage gaps
- Build comprehensive security dashboard (`npm run security:audit`) with 5-point scoring: RLS, API auth, fn_is_chairman, secrets, route protection
- 23 unit tests covering middleware behavior and script validation

## Test plan
- [x] All 23 tests pass (`npx vitest run tests/unit/eva/security-auth.test.js`)
- [ ] Run `npm run security:audit` to verify dashboard renders
- [ ] Run `npm run security:rls` to check RLS coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)