### PR TITLE
feat: add intelligent triage gate for /leo create

### DIFF
--- a/docs/03_protocols_and_standards/quick-fix-protocol.md
+++ b/docs/03_protocols_and_standards/quick-fix-protocol.md
@@ -81,10 +81,14 @@ Think of it like **emergency surgery** - fast execution, maximum precision.
 
 ## Quick-Fix vs Strategic Directive
 
-| Attribute | Quick-Fix | Strategic Directive |
-|-----------|-----------|-------------------|
-| **Scope** | ≤50 LOC | >50 LOC |
-| **Planning** | Lightweight (auto-triage) | Full LEAD→PLAN→EXEC |
+Thresholds are DB-driven via `work_item_thresholds` table. Defaults: Tier 1 ≤30 LOC, Tier 2 31–75 LOC.
+The [Triage Gate](../../docs/reference/triage-gate-guide.md) (`scripts/modules/triage-gate.js`) proactively recommends QF vs SD before creation.
+
+| Attribute | Tier 1 Quick-Fix | Tier 2 Quick-Fix | Strategic Directive |
+|-----------|-----------------|------------------|-------------------|
+| **Scope** | ≤30 LOC (default) | 31–75 LOC (default) | >75 LOC or risk keyword |
+| **Approval** | Auto-approve (no rubric) | Compliance rubric ≥70 | LEAD approval required |
+| **Planning** | No LEAD, no PRD | No LEAD, no PRD | Full LEAD→PLAN→EXEC |
 | **Approval** | No LEAD approval needed | LEAD approval required |
 | **PRD** | Auto-generated from error | Full PRD creation |
 | **Implementation Speed** | Minutes | Hours to days |

--- a/docs/reference/triage-gate-guide.md
+++ b/docs/reference/triage-gate-guide.md
@@ -1,0 +1,222 @@
+# Triage Gate Guide
+
+## Metadata
+- **Category**: Reference
+- **Status**: Approved
+- **Version**: 1.0.0
+- **Author**: LEO Orchestrator
+- **Last Updated**: 2026-02-18
+- **Tags**: triage, quick-fix, work-item-router, leo-create, sd-creation
+
+## Overview
+
+The Triage Gate (`scripts/modules/triage-gate.js`) is an intelligent pre-screening layer that fires before `/leo create` creates a Strategic Directive. It wires together the AI LOC estimator (`lib/ai-loc-estimator.js`) and the Unified Work-Item Router (`lib/utils/work-item-router.js`) to determine whether a work item belongs in the Quick Fix workflow or the full SD workflow — before anything is written to the database.
+
+## Table of Contents
+
+- [Why Triage Gate?](#why-triage-gate)
+- [Tier System](#tier-system)
+- [Source Behavior](#source-behavior)
+- [CLI Usage](#cli-usage)
+- [API Reference](#api-reference)
+- [Integration with /leo create](#integration-with-leo-create)
+- [Verification Tests](#verification-tests)
+
+---
+
+## Why Triage Gate?
+
+Before this module, `/leo create` always created a full Strategic Directive regardless of scope. A 1-line typo fix would go through LEAD→PLAN→EXEC just like a major feature. The LOC estimator (`lib/ai-loc-estimator.js`) and work-item router (`lib/utils/work-item-router.js`) existed but were disconnected from the SD creation path.
+
+The Triage Gate bridges this gap: it runs the LOC estimator, passes the result through the router, and presents an `AskUserQuestion` gating the user toward Quick Fix for small work items.
+
+---
+
+## Tier System
+
+Thresholds are DB-driven, loaded from the `work_item_thresholds` table (5-minute cache, falls back to defaults on error):
+
+| Tier | Default LOC Ceiling | Workflow | LEAD Required | PRD Required |
+|------|---------------------|----------|:---:|:---:|
+| **Tier 1** | ≤30 LOC | Quick Fix (auto-approve) | No | No |
+| **Tier 2** | 31–75 LOC | Quick Fix (compliance rubric ≥70) | No | No |
+| **Tier 3** | >75 LOC | Full SD (LEAD→PLAN→EXEC) | Yes | Yes |
+
+Risk keywords always force Tier 3 regardless of LOC:
+- **Security keywords**: `security`, `auth`, `authentication`, `authorization`, `rls`, `payments`, `credentials`
+- **Schema keywords**: `migration`, `schema`, `alter table`, `create table`, `drop table`
+- **Type `feature`**: Always requires full SD workflow
+
+---
+
+## Source Behavior
+
+The `source` parameter controls how aggressively the gate fires:
+
+| Source | Gate Behavior | Use Case |
+|--------|--------------|----------|
+| `interactive` | **Hard gate** — presents `AskUserQuestion` for Tier 1/2 | `/leo create` interactive wizard |
+| `feedback` | **Soft** — logs info note only, continues to SD creation | `--from-feedback` flag |
+| `uat` | **Soft** — logs info note only, continues to SD creation | `--from-uat` flag |
+| `learn` | **Soft** — logs info note only, continues to SD creation | `--from-learn` flag |
+| `plan` | **Exempt** — skips triage entirely | `--from-plan` flag |
+| `child` | **Exempt** — skips triage entirely | `--child` flag |
+
+---
+
+## CLI Usage
+
+```bash
+# Basic triage check
+node scripts/modules/triage-gate.js --title "Fix typo in button label" --type fix --source interactive
+
+# JSON output (machine-readable to stdout, human summary to stderr)
+node scripts/modules/triage-gate.js --title "Fix typo in button label" --type fix --source interactive --output-json
+
+# Options
+--title <text>     Work item title (required)
+--type <type>      SD type: fix, feature, infrastructure, refactor, etc.
+--source <source>  Entry source: interactive, uat, feedback, learn, plan, child
+--output-json      JSON to stdout, human summary to stderr
+--help             Show help
+```
+
+### Example Outputs
+
+**Tier 1 — Quick Fix recommended**:
+```json
+{
+  "tier": 1,
+  "tierLabel": "TIER_1",
+  "shouldGate": true,
+  "workItemType": "QUICK_FIX",
+  "estimatedLoc": 1,
+  "confidence": 95,
+  "reasoning": "Text change - single line",
+  "escalationReason": null,
+  "askUserQuestionPayload": { ... }
+}
+```
+
+**Tier 3 — Full SD (risk keyword)**:
+```json
+{
+  "tier": 3,
+  "tierLabel": "TIER_3",
+  "shouldGate": false,
+  "workItemType": "STRATEGIC_DIRECTIVE",
+  "escalationReason": "Type \"feature\" requires full Strategic Directive workflow"
+}
+```
+
+**Exempt source**:
+```json
+{
+  "tier": 3,
+  "shouldGate": false,
+  "reasoning": "Source \"plan\" is exempt from triage"
+}
+```
+
+---
+
+## API Reference
+
+### `runTriageGate(input, supabaseClient?) → Promise<TriageResult>`
+
+Core triage function. Call before SD creation to get a routing recommendation.
+
+```javascript
+import { runTriageGate } from './scripts/modules/triage-gate.js';
+
+const result = await runTriageGate({
+  title: 'Fix typo in button label',
+  description: 'The submit button says "Sbumit" on the login page',
+  type: 'fix',
+  source: 'interactive'
+});
+
+if (result.shouldGate) {
+  // Present result.askUserQuestionPayload to user
+} else if (result.tier <= 2) {
+  // Log soft recommendation
+  console.log(formatTriageSummary(result));
+}
+// Tier 3 or exempt: proceed with SD creation normally
+```
+
+### `formatTriageSummary(result) → string`
+
+Formats a human-readable multi-line summary of a triage result for CLI output.
+
+### `isHardGateSource(source) → boolean`
+
+Returns `true` for `interactive` (presents AskUserQuestion), `false` for all other sources (soft or exempt).
+
+### TriageResult shape
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `tier` | number | 1, 2, or 3 |
+| `tierLabel` | string | 'TIER_1', 'TIER_2', 'TIER_3' |
+| `shouldGate` | boolean | Whether to present AskUserQuestion |
+| `workItemType` | string | 'QUICK_FIX' or 'STRATEGIC_DIRECTIVE' |
+| `estimatedLoc` | number | AI-estimated lines of code |
+| `confidence` | number | LOC confidence (0–100) |
+| `reasoning` | string | Why this LOC estimate |
+| `escalationReason` | string\|null | Why escalated (Tier 3 only) |
+| `askUserQuestionPayload` | Object\|null | Ready for AskUserQuestion (Tier 1/2 interactive only) |
+| `routingDecision` | Object\|null | Full decision from `work-item-router.js` |
+
+---
+
+## Integration with /leo create
+
+Step 0 of the `/leo create` flow runs the triage gate before type inference:
+
+```
+/leo create "Fix typo in button"
+  → Step 0: node triage-gate.js --source interactive
+    → tier 1, shouldGate true
+    → AskUserQuestion: "Quick Fix (Recommended)" or "Full SD (Override)"
+      → User picks QF → node scripts/create-quick-fix.js ...
+      → User picks SD → proceed to type inference → createSD()
+```
+
+For flag-based creation paths:
+- `--from-plan`, `--child` → triage skipped (exempt sources)
+- `--from-feedback`, `--from-uat`, `--from-learn` → triage runs but only logs a one-line info note; SD creation continues regardless
+
+Within `leo-create-sd.js` direct creation path, if `--force` is passed, triage is also skipped.
+
+---
+
+## Verification Tests
+
+```bash
+# Tier 1 — should return tier 1, shouldGate true
+node scripts/modules/triage-gate.js \
+  --title "Fix typo in button label" --type fix --source interactive --output-json
+
+# Tier 3 (risk escalation) — feature type forces full SD
+node scripts/modules/triage-gate.js \
+  --title "Migrate authentication to SSO" --type feature --source interactive --output-json
+
+# Exempt — plan source, shouldGate false
+node scripts/modules/triage-gate.js \
+  --title "anything" --type fix --source plan --output-json
+```
+
+---
+
+## Related Files
+
+| File | Role |
+|------|------|
+| `scripts/modules/triage-gate.js` | This module |
+| `lib/ai-loc-estimator.js` | LOC estimation (called by triage gate) |
+| `lib/utils/work-item-router.js` | Tier routing with DB-driven thresholds |
+| `scripts/leo-create-sd.js` | SD creation — calls triage gate |
+| `.claude/commands/leo.md` | `/leo create` command — Step 0 triage |
+| `scripts/create-quick-fix.js` | Quick Fix creation (recommended for Tier 1/2) |
+| `docs/03_protocols_and_standards/quick-fix-protocol.md` | QF workflow documentation |

--- a/lib/ai-loc-estimator.js
+++ b/lib/ai-loc-estimator.js
@@ -136,6 +136,9 @@ export function estimateLOC(params) {
 
 /**
  * Determine if estimated LOC suggests escalation
+ * @deprecated Use routeWorkItem() from lib/utils/work-item-router.js for tier-based routing.
+ * This function uses a hardcoded 50 LOC threshold. The router uses DB-driven 30/75 thresholds.
+ * Retained for backward compatibility with the QUICKFIX sub-agent.
  * @param {number} estimatedLoc - Estimated lines of code
  * @param {number} confidence - Confidence level (0-100)
  * @returns {Object} { shouldEscalate: boolean, reason: string }

--- a/scripts/modules/triage-gate.js
+++ b/scripts/modules/triage-gate.js
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+/**
+ * Triage Gate - Intelligent Work Item Triage for /leo create
+ *
+ * Wires together the AI LOC estimator and the Unified Work-Item Router
+ * so that /leo create can proactively recommend Quick Fix vs full SD
+ * before creating anything.
+ *
+ * @module scripts/modules/triage-gate
+ */
+
+import { estimateLOC } from '../../lib/ai-loc-estimator.js';
+import { routeWorkItem } from '../../lib/utils/work-item-router.js';
+
+/**
+ * @typedef {Object} TriageInput
+ * @property {string} title - Work item title
+ * @property {string} [description] - Work item description
+ * @property {string} [type] - SD type (fix, feature, infrastructure, etc.)
+ * @property {string} [source] - Entry source: interactive, uat, feedback, learn, plan, child
+ */
+
+/**
+ * @typedef {Object} TriageResult
+ * @property {number} tier - 1, 2, or 3
+ * @property {string} tierLabel - 'TIER_1', 'TIER_2', or 'TIER_3'
+ * @property {boolean} shouldGate - Whether to present AskUserQuestion gate
+ * @property {string} workItemType - 'QUICK_FIX' or 'STRATEGIC_DIRECTIVE'
+ * @property {number} estimatedLoc - Estimated lines of code
+ * @property {number} confidence - LOC confidence (0-100)
+ * @property {string} reasoning - LOC estimation reasoning
+ * @property {string|null} escalationReason - Why escalated to Tier 3 (if applicable)
+ * @property {Object|null} askUserQuestionPayload - AskUserQuestion payload for Tier 1/2 gates
+ * @property {Object} routingDecision - Full routing decision from work-item-router
+ */
+
+/**
+ * Determine if a source triggers a hard gate (AskUserQuestion).
+ *
+ * @param {string} source - Entry source
+ * @returns {boolean} true if this source should present an interactive gate
+ */
+export function isHardGateSource(source) {
+  switch ((source || '').toLowerCase()) {
+    case 'interactive':
+      return true;
+    case 'uat':
+    case 'feedback':
+    case 'learn':
+      return false; // soft recommendation only
+    case 'plan':
+    case 'child':
+      return false; // exempt
+    default:
+      return false;
+  }
+}
+
+/**
+ * Run the triage gate to determine if a work item should be a Quick Fix or full SD.
+ *
+ * @param {TriageInput} input - Work item details
+ * @param {Object} [supabaseClient] - Optional Supabase client for threshold lookup
+ * @returns {Promise<TriageResult>}
+ */
+export async function runTriageGate(input, supabaseClient) {
+  const { title = '', description = '', type = 'bug', source = 'interactive' } = input;
+
+  // Exempt sources skip triage entirely
+  const lowerSource = (source || '').toLowerCase();
+  if (lowerSource === 'plan' || lowerSource === 'child') {
+    return {
+      tier: 3,
+      tierLabel: 'TIER_3',
+      shouldGate: false,
+      workItemType: 'STRATEGIC_DIRECTIVE',
+      estimatedLoc: 0,
+      confidence: 0,
+      reasoning: `Source "${source}" is exempt from triage`,
+      escalationReason: null,
+      askUserQuestionPayload: null,
+      routingDecision: null,
+    };
+  }
+
+  // Step 1: Estimate LOC
+  const combinedDescription = [title, description].filter(Boolean).join(' — ');
+  const locResult = estimateLOC({
+    title,
+    description: combinedDescription,
+    type,
+  });
+
+  // Step 2: Route through work-item-router
+  const routingDecision = await routeWorkItem(
+    {
+      estimatedLoc: locResult.estimatedLoc,
+      type,
+      description: combinedDescription,
+      entryPoint: 'triage-gate',
+    },
+    supabaseClient
+  );
+
+  // Step 3: Determine if we should gate
+  const shouldGate = routingDecision.tier <= 2 && isHardGateSource(lowerSource);
+
+  // Step 4: Build AskUserQuestion payload for Tier 1/2 interactive gates
+  let askUserQuestionPayload = null;
+  if (shouldGate) {
+    askUserQuestionPayload = buildAskUserQuestionPayload(
+      routingDecision,
+      locResult,
+      title,
+      type
+    );
+  }
+
+  return {
+    tier: routingDecision.tier,
+    tierLabel: routingDecision.tierLabel,
+    shouldGate,
+    workItemType: routingDecision.workItemType,
+    estimatedLoc: locResult.estimatedLoc,
+    confidence: locResult.confidence,
+    reasoning: locResult.reasoning,
+    escalationReason: routingDecision.escalationReason,
+    askUserQuestionPayload,
+    routingDecision,
+  };
+}
+
+/**
+ * Build AskUserQuestion payload for Tier 1/2 triage gate.
+ */
+function buildAskUserQuestionPayload(routingDecision, locResult, title, type) {
+  const { tier, tier1MaxLoc, tier2MaxLoc, requiresComplianceRubric } = routingDecision;
+
+  let questionText;
+  if (tier === 1) {
+    questionText =
+      `Triage: estimated ~${locResult.estimatedLoc} LOC (${locResult.confidence}% confidence). ` +
+      `This looks like a Quick Fix (Tier 1 — auto-approve, no LEAD review). ` +
+      `Max ${tier1MaxLoc} LOC. How would you like to proceed?`;
+  } else {
+    questionText =
+      `Triage: estimated ~${locResult.estimatedLoc} LOC (${locResult.confidence}% confidence). ` +
+      `This looks like a Standard Quick Fix (Tier 2 — compliance rubric ≥70 required). ` +
+      `Max ${tier2MaxLoc} LOC. How would you like to proceed?`;
+  }
+
+  const qfDescription =
+    tier === 1
+      ? 'Auto-approved quick fix. No LEAD review, no PRD. Fast track.'
+      : 'Standard quick fix with compliance rubric (min score 70). No LEAD review.';
+
+  return {
+    questions: [
+      {
+        question: questionText,
+        header: 'Work Item',
+        multiSelect: false,
+        options: [
+          {
+            label: 'Create Quick Fix (Recommended)',
+            description: qfDescription,
+          },
+          {
+            label: 'Create Full SD (Override)',
+            description:
+              'Full LEAD→PLAN→EXEC workflow. Use if scope is larger than estimated or involves risk.',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Format a human-readable triage summary for CLI/log output.
+ *
+ * @param {TriageResult} result - Triage result
+ * @returns {string} Multi-line summary
+ */
+export function formatTriageSummary(result) {
+  const lines = [];
+  lines.push('╔══════════════════════════════════════════════╗');
+  lines.push('║           WORK ITEM TRIAGE RESULT            ║');
+  lines.push('╚══════════════════════════════════════════════╝');
+  lines.push(`  Tier:          ${result.tierLabel} (Tier ${result.tier})`);
+  lines.push(`  Work Type:     ${result.workItemType}`);
+  lines.push(`  Estimated LOC: ~${result.estimatedLoc}`);
+  lines.push(`  Confidence:    ${result.confidence}%`);
+  lines.push(`  Reasoning:     ${result.reasoning}`);
+  lines.push(`  Should Gate:   ${result.shouldGate ? 'YES' : 'NO'}`);
+
+  if (result.escalationReason) {
+    lines.push(`  Escalation:    ${result.escalationReason}`);
+  }
+
+  if (result.tier <= 2) {
+    lines.push('');
+    lines.push('  💡 Recommendation: Use Quick Fix workflow');
+    lines.push('     node scripts/create-quick-fix.js --title "<title>" --type <type>');
+  }
+
+  return lines.join('\n');
+}
+
+// ============================================================================
+// CLI Entrypoint
+// ============================================================================
+
+function parseCliArgs(args) {
+  const parsed = { title: '', type: 'bug', source: 'interactive', outputJson: false };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--title':
+        parsed.title = args[++i] || '';
+        break;
+      case '--type':
+        parsed.type = args[++i] || 'bug';
+        break;
+      case '--source':
+        parsed.source = args[++i] || 'interactive';
+        break;
+      case '--output-json':
+        parsed.outputJson = true;
+        break;
+      case '--help':
+        console.log(`
+Triage Gate - Intelligent Work Item Triage
+
+Usage:
+  node scripts/modules/triage-gate.js --title "Fix typo" --type fix --source interactive
+  node scripts/modules/triage-gate.js --title "Add SSO" --type feature --source interactive --output-json
+
+Options:
+  --title <text>     Work item title (required)
+  --type <type>      SD type: fix, feature, infrastructure, refactor, etc.
+  --source <source>  Entry source: interactive, uat, feedback, learn, plan, child
+  --output-json      Output JSON to stdout (human summary to stderr)
+  --help             Show this help
+`);
+        process.exit(0);
+    }
+  }
+
+  return parsed;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const { title, type, source, outputJson } = parseCliArgs(args);
+
+  if (!title) {
+    console.error('Error: --title is required');
+    process.exit(1);
+  }
+
+  const result = await runTriageGate({ title, description: title, type, source });
+
+  if (outputJson) {
+    // JSON to stdout, human-readable to stderr
+    console.error(formatTriageSummary(result));
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatTriageSummary(result));
+  }
+}
+
+// ESM entry point detection (Windows-compatible)
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+
+if (isMain) {
+  main().catch((err) => {
+    console.error('Triage gate error:', err.message);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- **New module** `scripts/modules/triage-gate.js` — wires `estimateLOC()` + `routeWorkItem()` to determine Tier 1/2/3 before SD creation; includes `runTriageGate()`, `formatTriageSummary()`, `isHardGateSource()` exports and a CLI entrypoint
- **`/leo create` Step 0 triage** — inserted before Context-Based Type Inference in `.claude/commands/leo.md`; Tier 1/2 interactive sources get an `AskUserQuestion` offering Quick Fix vs SD; exempt sources (`plan`, `child`) skip entirely; soft sources (`uat`, `feedback`, `learn`) log recommendation only
- **`scripts/leo-create-sd.js`** — imports triage gate; direct creation path logs QF recommendation for Tier ≤2 (respects `--force`); `createFromFeedback` and `createFromUAT` log one-line soft notes
- **`lib/ai-loc-estimator.js`** — `@deprecated` JSDoc on `shouldEscalateByLOC` pointing to `routeWorkItem()` (DB-driven 30/75 vs hardcoded 50 threshold)
- **`docs/reference/triage-gate-guide.md`** — full reference: tier system, source behavior table, CLI usage, API reference, integration diagram, verification tests
- **`docs/03_protocols_and_standards/quick-fix-protocol.md`** — updated comparison table to reflect Tier 1 (≤30 LOC) / Tier 2 (31–75 LOC) DB-driven thresholds; links to triage-gate-guide

## Test plan

- [x] `node scripts/modules/triage-gate.js --title "Fix typo in button label" --type fix --source interactive --output-json` → tier 1, shouldGate true, ~1 LOC
- [x] `node scripts/modules/triage-gate.js --title "Migrate authentication to SSO" --type feature --source interactive --output-json` → tier 3, shouldGate false (feature type)
- [x] `node scripts/modules/triage-gate.js --title "anything" --type fix --source plan --output-json` → shouldGate false (exempt)
- [x] `node --check scripts/leo-create-sd.js` → no syntax errors
- [ ] Integration: `/leo create` interactively with a small fix description → AskUserQuestion appears with QF recommendation
- [ ] Non-regression: `node scripts/leo-create-sd.js LEO fix "Test title" --force` → skips triage and creates SD

🤖 Generated with [Claude Code](https://claude.com/claude-code)