### PR TITLE
fix: align image generator to Gemini generateContent API (Nano Banana Pro)

### DIFF
--- a/lib/marketing/ai/image-generator.js
+++ b/lib/marketing/ai/image-generator.js
@@ -2,14 +2,16 @@
  * AI Image Generation Pipeline
  * SD-EVA-FEAT-MARKETING-AI-001 (US-003)
  *
- * Generates marketing images using Gemini Imagen API
- * with Sharp.js brand overlay compositing.
+ * Generates marketing images using Gemini generateContent API
+ * (Nano Banana Pro / gemini-3-pro-image-preview) with Sharp.js
+ * brand overlay compositing.
  * Falls back to branded placeholder on API failure.
  */
 
 const DEFAULT_WIDTH = 1200;
 const DEFAULT_HEIGHT = 628;
 const GENERATION_TIMEOUT_MS = 30_000;
+const GEMINI_IMAGE_MODEL = process.env.GEMINI_IMAGE_MODEL || 'gemini-3-pro-image-preview';
 
 /**
  * Create an image generator instance.
@@ -79,7 +81,8 @@ export function createImageGenerator(deps = {}) {
 }
 
 /**
- * Generate base image via Gemini Imagen API.
+ * Generate base image via Gemini generateContent API (Nano Banana Pro).
+ * Uses the same API pattern as scripts/lib/visualization-provider.js.
  */
 async function generateWithGemini({ prompt, width, height, apiKey, geminiClient }) {
   if (geminiClient) {
@@ -95,32 +98,44 @@ async function generateWithGemini({ prompt, width, height, apiKey, geminiClient 
   const timeout = setTimeout(() => controller.abort(), GENERATION_TIMEOUT_MS);
 
   try {
-    const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/imagen-3.0-generate-001:predict', {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_IMAGE_MODEL}:generateContent?key=${apiKey}`;
+
+    const response = await fetch(url, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'x-goog-api-key': apiKey
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        instances: [{ prompt }],
-        parameters: {
-          sampleCount: 1,
-          aspectRatio: width > height ? '16:9' : '1:1',
-          outputOptions: { mimeType: 'image/png' }
+        contents: [{
+          parts: [{
+            text: `${prompt} (${width}x${height})`
+          }]
+        }],
+        generationConfig: {
+          responseModalities: ['TEXT', 'IMAGE']
         }
       }),
       signal: controller.signal
     });
 
     if (!response.ok) {
-      throw new Error(`Gemini API error: ${response.status} ${response.statusText}`);
+      const errorText = await response.text();
+      throw new Error(`Gemini API error: ${response.status} - ${errorText.substring(0, 200)}`);
     }
 
     const data = await response.json();
-    const base64 = data.predictions?.[0]?.bytesBase64Encoded;
-    if (!base64) throw new Error('No image data in Gemini response');
+    const candidates = data.candidates || [];
+    if (candidates.length === 0) {
+      throw new Error('Gemini returned no candidates');
+    }
 
-    return Buffer.from(base64, 'base64');
+    const parts = candidates[0].content?.parts || [];
+    const imagePart = parts.find(p => p.inlineData?.mimeType?.startsWith('image/'));
+    if (!imagePart) {
+      throw new Error('No image data in Gemini response');
+    }
+
+    return Buffer.from(imagePart.inlineData.data, 'base64');
   } finally {
     clearTimeout(timeout);
   }
@@ -201,4 +216,4 @@ async function applyBrandOverlay({ buffer, brand, width, height, sharpModule }) 
   return sharp(buffer).composite(composites).toBuffer();
 }
 
-export { DEFAULT_WIDTH, DEFAULT_HEIGHT, GENERATION_TIMEOUT_MS };
+export { DEFAULT_WIDTH, DEFAULT_HEIGHT, GENERATION_TIMEOUT_MS, GEMINI_IMAGE_MODEL };


### PR DESCRIPTION
## Summary
- Migrate marketing AI image generator from Imagen API to vision-specified Nano Banana Pro (gemini-3-pro-image-preview)
- Change endpoint from :predict to :generateContent, request/response format, and auth method
- Add GEMINI_IMAGE_MODEL env var for configurability
- All 8 existing unit tests pass

## Changes
- **Model**: imagen-3.0-generate-001 -> gemini-3-pro-image-preview
- **API**: :predict (Imagen) -> :generateContent (Gemini)
- **Request**: instances/parameters -> contents/generationConfig
- **Response**: predictions[0].bytesBase64Encoded -> candidates[0].content.parts[].inlineData
- **Auth**: x-goog-api-key header -> key= query parameter

## Test plan
- [x] All 8 unit tests pass (vitest)
- [x] Fallback to placeholder still works
- [x] Brand overlay compositing unchanged
- [x] Custom dimensions forwarded correctly

SD: SD-MAN-FIX-ALIGN-IMAGE-GENERATOR-001

Generated with [Claude Code](https://claude.com/claude-code)