### PR TITLE
fix: harden worktree hook against MSYS2 pipe corruption and terminal identity chain break

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -163,7 +163,7 @@ function _findClaudeCodePidViaTreeWalk() {
         const parent = chain[i + 1];
         // Claude Code's node parent is typically cmd.exe, powershell.exe,
         // or a terminal host — not another node or bash
-        if (!parent || !['node.exe', 'node', 'bash.exe', 'bash', 'sh.exe', 'sh'].includes(parent.name)) {
+        if (!parent || !['node.exe', 'node', 'bash.exe', 'bash', 'sh.exe', 'sh', 'powershell.exe', 'pwsh.exe'].includes(parent.name)) {
           return proc.pid;
         }
       }

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -193,6 +193,24 @@ export function createWorkTypeWorktree({ workType, workKey, branch, force = fals
   const subDir = workType.toLowerCase(); // sd, qf, or adhoc
   const repoRoot = getRepoRoot();
   const worktreesDir = getWorktreesDir(repoRoot);
+
+  // US-005: Hard cap on total worktree count to prevent unbounded growth
+  const MAX_WORKTREE_COUNT = 10;
+  try {
+    if (fs.existsSync(worktreesDir)) {
+      const allEntries = fs.readdirSync(worktreesDir);
+      const worktreeCount = allEntries.filter(e => {
+        const p = path.join(worktreesDir, e);
+        try { return fs.statSync(p).isDirectory(); } catch { return false; }
+      }).length;
+      if (worktreeCount >= MAX_WORKTREE_COUNT) {
+        throw new Error(`Worktree limit reached (${worktreeCount}/${MAX_WORKTREE_COUNT}). Run cleanup or remove stale worktrees before creating new ones.`);
+      }
+    }
+  } catch (e) {
+    if (e.message.includes('Worktree limit reached')) throw e;
+    // Ignore other errors (e.g., permission issues) — don't block creation
+  }
   const worktreeDir = path.join(worktreesDir, subDir);
   const worktreePath = path.join(worktreeDir, sanitizedKey);
 


### PR DESCRIPTION
## Summary

- **Fix MSYS2 pipe corruption** (Mode B): Replace `execSync('git ...')` in worktree cleanup hook with PowerShell-based invocations to prevent MSYS2 shared stdio pipe corruption that breaks ALL bash commands for the entire session
- **Fix CWD deletion** (Mode A): Add active session check before worktree deletion so cleanup never removes a worktree with an active session CWD inside it
- **Bound cleanup loop**: Limit to 3 worktrees per session start (`MAX_CLEANUP_PER_SESSION`) to prevent subprocess storms
- **Harden terminal identity**: Add `powershell.exe`/`pwsh.exe` to `findClaudeCodePid()` ancestry recognition so PowerShell-routed commands don't break the identity chain
- **Worktree count cap**: Add hard limit of 10 total worktrees in `createWorkTypeWorktree()` to prevent unbounded disk growth
- **CWD validation**: After cleanup, verify process CWD still exists and reset to repo root if deleted

## Root Cause

RCA-MSYS2-PIPE-CORRUPTION-001 (confidence: 0.92). The `cleanupStaleConcurrentWorktrees()` function spawns unbounded git/bash subprocesses (30+ worktrees x 3 commands = 90+ spawns), corrupting MSYS2's `msys-2.0.dll` shared pipe state. Hidden error: "write error: Bad file descriptor". The PowerShell workaround then breaks process ancestry chain, degrading terminal identity and causing claim guard rejections.

## Files Changed

| File | Changes |
|------|---------|
| `scripts/hooks/concurrent-session-worktree.cjs` | PowerShell git ops, bounded cleanup, active session protection, CWD validation |
| `lib/terminal-identity.js` | Add powershell.exe/pwsh.exe to ancestry recognition |
| `lib/worktree-manager.js` | Add MAX_WORKTREE_COUNT=10 hard cap |

## Test plan

- [ ] Start 2 concurrent Claude Code sessions — verify bash commands work in both
- [ ] Verify `getTerminalId()` returns consistent ID when commands route through PowerShell
- [ ] Verify cleanup processes at most 3 worktrees per session start
- [ ] Verify active session worktrees are never deleted by cleanup
- [ ] Verify worktree creation fails gracefully at count limit (10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
