### PR TITLE
feat: enforce claim guard as hard blocker across all SD operations

### DIFF
--- a/database/migrations/20260218_claim_sd_for_update.sql
+++ b/database/migrations/20260218_claim_sd_for_update.sql
@@ -1,0 +1,133 @@
+-- Migration: 20260218_claim_sd_for_update.sql
+-- SD: SD-LEO-INFRA-CLAIM-GUARD-001 / US-007
+-- Purpose: Eliminate TOCTOU race condition in claim_sd function
+--
+-- Problem: When two concurrent sessions claim the same unclaimed SD, the first
+-- SELECT ... FOR UPDATE finds no existing claim row (nothing to lock). Both
+-- transactions pass the check, both INSERT via ON CONFLICT DO UPDATE, and the
+-- second writer silently steals the claim from the first.
+--
+-- Fix: Add pg_advisory_xact_lock(hashtext(p_sd_id)) at the top of the function.
+-- This acquires a transaction-scoped advisory lock keyed on the SD ID, serializing
+-- all concurrent claim attempts for the same SD. The lock is automatically released
+-- when the transaction commits or rolls back.
+--
+-- Rollback: Re-deploy the previous version of claim_sd without the advisory lock line.
+
+CREATE OR REPLACE FUNCTION public.claim_sd(p_sd_id text, p_session_id text, p_track text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_existing_claim RECORD;
+  v_conflict RECORD;
+  v_parent_sd_id TEXT;
+  v_result JSONB;
+BEGIN
+  -- TOCTOU FIX (US-007): Acquire advisory lock to serialize concurrent claims
+  -- for the same SD. Without this, two sessions can both pass the "is claimed?"
+  -- check when no existing claim row exists, and both INSERT successfully.
+  -- The lock is transaction-scoped and released automatically on COMMIT/ROLLBACK.
+  PERFORM pg_advisory_xact_lock(hashtext(p_sd_id));
+
+  -- Check if SD is already claimed by another active session
+  SELECT sc.session_id, sc.sd_id
+  INTO v_existing_claim
+  FROM sd_claims sc
+  JOIN claude_sessions cs ON sc.session_id = cs.session_id
+  WHERE sc.sd_id = p_sd_id
+    AND sc.released_at IS NULL
+    AND sc.session_id != p_session_id
+    AND cs.status IN ('active', 'idle')
+    AND EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 900
+  LIMIT 1
+  FOR UPDATE OF sc SKIP LOCKED;
+
+  IF v_existing_claim IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'already_claimed',
+      'message', format('SD %s is already claimed by session %s', p_sd_id, v_existing_claim.session_id),
+      'claimed_by', v_existing_claim.session_id
+    );
+  END IF;
+
+  -- Check for blocking conflicts with active SDs
+  SELECT cm.*, sc.sd_id as active_sd, sc.session_id as active_session
+  INTO v_conflict
+  FROM sd_conflict_matrix cm
+  JOIN sd_claims sc ON (
+    (cm.sd_id_a = p_sd_id AND cm.sd_id_b = sc.sd_id) OR
+    (cm.sd_id_b = p_sd_id AND cm.sd_id_a = sc.sd_id)
+  )
+  JOIN claude_sessions cs ON sc.session_id = cs.session_id
+  WHERE cm.conflict_severity = 'blocking'
+    AND cm.resolved_at IS NULL
+    AND sc.released_at IS NULL
+    AND cs.status IN ('active', 'idle')
+    AND EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 900
+    AND sc.session_id != p_session_id
+  LIMIT 1;
+
+  IF v_conflict IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'blocking_conflict',
+      'message', format('SD %s has blocking conflict with active SD %s', p_sd_id, v_conflict.active_sd),
+      'conflict_type', v_conflict.conflict_type,
+      'conflicting_sd', v_conflict.active_sd,
+      'conflicting_session', v_conflict.active_session
+    );
+  END IF;
+
+  -- Look up the parent SD of the SD being claimed (if it is a child)
+  SELECT parent_sd_id INTO v_parent_sd_id
+  FROM strategic_directives_v2
+  WHERE sd_key = p_sd_id;
+
+  -- Release any existing active claims for this session (switching SDs)
+  -- BUT preserve the parent orchestrator claim when claiming a child SD
+  UPDATE sd_claims
+  SET released_at = NOW(), release_reason = 'claim_switch'
+  WHERE session_id = p_session_id
+    AND released_at IS NULL
+    AND sd_id != p_sd_id
+    AND (v_parent_sd_id IS NULL OR sd_id != v_parent_sd_id);
+
+  -- Record the claim in sd_claims table
+  INSERT INTO sd_claims (sd_id, session_id, track, claimed_at)
+  VALUES (p_sd_id, p_session_id, p_track, NOW())
+  ON CONFLICT (sd_id) WHERE released_at IS NULL
+  DO UPDATE SET session_id = p_session_id, track = p_track, claimed_at = NOW();
+
+  -- Update session with SD (denormalized cache for backward compatibility)
+  UPDATE claude_sessions
+  SET sd_id = p_sd_id,
+      track = p_track,
+      heartbeat_at = NOW()
+  WHERE session_id = p_session_id;
+
+  -- Set claiming_session_id + is_working_on on the SD
+  UPDATE strategic_directives_v2
+  SET claiming_session_id = p_session_id,
+      active_session_id = p_session_id,
+      is_working_on = true
+  WHERE sd_key = p_sd_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'message', format('SD %s claimed successfully', p_sd_id),
+    'sd_id', p_sd_id,
+    'session_id', p_session_id,
+    'track', p_track,
+    'parent_preserved', v_parent_sd_id IS NOT NULL
+  );
+END;
+$function$;
+
+-- Add comment documenting the advisory lock pattern
+COMMENT ON FUNCTION public.claim_sd(text, text, text) IS
+  'Atomically claim an SD for a session. Uses pg_advisory_xact_lock to serialize '
+  'concurrent claims for the same SD, preventing TOCTOU race conditions. '
+  'SD-LEO-INFRA-CLAIM-GUARD-001 / US-007.';

--- a/lib/context/unified-state-manager.js
+++ b/lib/context/unified-state-manager.js
@@ -27,6 +27,31 @@ const STATE_FILE_NAME = 'unified-session-state.json';
 const STATE_DIR = '.claude';
 const MAX_AGE_MINUTES = 30; // Consider state "recent" if less than this
 
+/**
+ * Get session-scoped state filename (SD-LEO-INFRA-CLAIM-GUARD-001: US-004).
+ * Prevents cross-session state contamination on shared machines.
+ * Falls back to legacy shared filename if session ID unavailable.
+ * @returns {string} Session-scoped or legacy filename
+ */
+function getSessionScopedStateFileName() {
+  try {
+    const sessionDir = path.join(os.homedir(), '.claude-sessions');
+    if (fs.existsSync(sessionDir)) {
+      const pid = process.ppid || process.pid;
+      const files = fs.readdirSync(sessionDir).filter(f => f.endsWith('.json'));
+      for (const file of files) {
+        try {
+          const data = JSON.parse(fs.readFileSync(path.join(sessionDir, file), 'utf8'));
+          if (data.pid === pid && data.session_id) {
+            return `unified-session-state.${data.session_id}.json`;
+          }
+        } catch { /* skip */ }
+      }
+    }
+  } catch { /* fallback to legacy */ }
+  return STATE_FILE_NAME; // Legacy fallback
+}
+
 // Token budget configuration (ReSum/RECOMP research)
 const TOKEN_BUDGET = {
   min: 300,      // Minimum tokens for meaningful context
@@ -178,7 +203,11 @@ class UnifiedStateManager {
   constructor(projectDir = null) {
     this.projectDir = projectDir || process.env.CLAUDE_PROJECT_DIR || process.cwd();
     this.stateDir = path.join(this.projectDir, STATE_DIR);
-    this.stateFile = path.join(this.stateDir, STATE_FILE_NAME);
+    // SD-LEO-INFRA-CLAIM-GUARD-001: Session-scoped state file
+    const scopedName = getSessionScopedStateFileName();
+    this.stateFile = path.join(this.stateDir, scopedName);
+    // Legacy path for read fallback (if scoped file doesn't exist yet)
+    this.legacyStateFile = path.join(this.stateDir, STATE_FILE_NAME);
   }
 
   /**
@@ -667,12 +696,17 @@ class UnifiedStateManager {
    * Load state from unified file
    */
   loadState() {
-    if (!fs.existsSync(this.stateFile)) {
+    // SD-LEO-INFRA-CLAIM-GUARD-001: Try session-scoped file first, fall back to legacy
+    let targetFile = this.stateFile;
+    if (!fs.existsSync(targetFile) && this.legacyStateFile && fs.existsSync(this.legacyStateFile)) {
+      targetFile = this.legacyStateFile; // Read-only fallback to legacy shared file
+    }
+    if (!fs.existsSync(targetFile)) {
       return null;
     }
 
     try {
-      let content = fs.readFileSync(this.stateFile, 'utf8');
+      let content = fs.readFileSync(targetFile, 'utf8');
       // Remove BOM if present
       if (content.charCodeAt(0) === 0xFEFF) {
         content = content.slice(1);


### PR DESCRIPTION
## Summary

- **BaseExecutor: fail-closed on claim errors** — Changed from non-blocking (`return null`) to hard blocker that rejects handoffs without verified claim ownership
- **Session-scoped state files** — Both `unified-session-state.json` and `auto-proceed-state.json` now use `{filename}.{sessionId}.json` pattern to prevent cross-session contamination on shared machines
- **Claim verification on branch detection** — `session-init.cjs` now calls `claimGuard()` when detecting SD from git branch name, preventing silent resume of claimed SDs
- **Advisory lock in claim_sd SQL** — Added `pg_advisory_xact_lock(hashtext(p_sd_id))` to serialize concurrent claim attempts, eliminating the TOCTOU race condition

## 7 Collision Vectors Addressed

| # | Vector | Fix |
|---|--------|-----|
| 1 | Direct-update fallbacks | Already fixed (prior PR) — uses claimGuard |
| 2 | Shared unified-session-state.json | Session-scoped with legacy fallback |
| 3 | BaseExecutor non-blocking claim failure | Hard blocker with retry |
| 4 | Branch detection without claim check | claimGuard verification added |
| 5 | is_working_on global boolean | Uses claiming_session_id (existing) |
| 6 | Shared auto-proceed-state.json | Session-scoped with legacy fallback |
| 7 | TOCTOU in claim_sd SQL | pg_advisory_xact_lock added |

## Files Changed

| File | Changes | LOC |
|------|---------|-----|
| `scripts/modules/handoff/executors/BaseExecutor.js` | Fail-closed claim errors | +8/-3 |
| `lib/context/unified-state-manager.js` | Session-scoped state files | +37/-3 |
| `scripts/hooks/session-state-sync.cjs` | Session-scoped auto-proceed state | +33/-10 |
| `scripts/hooks/session-init.cjs` | Claim verification on branch detection | +30/-1 |
| `database/migrations/20260218_claim_sd_for_update.sql` | Advisory lock migration | +20 |

## Test plan

- [ ] Start 2 concurrent sessions targeting same SD — verify only one can proceed
- [ ] Verify BaseExecutor rejects handoff when claim is not held
- [ ] Verify two sessions on same machine read/write independent state files
- [ ] Verify legacy state file fallback works when no session-scoped file exists
- [ ] Verify concurrent claim_sd calls serialize (only one succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
