### PR TITLE
fix: sd-next reads chain_orchestrators from global defaults

### DIFF
--- a/scripts/sd-next.js
+++ b/scripts/sd-next.js
@@ -46,8 +46,15 @@ async function emitSessionSettings() {
       .limit(1)
       .single();
 
+    // Fall back to global defaults from DB if no session metadata
+    let globalChaining = false;
+    if (data?.metadata?.chain_orchestrators === undefined) {
+      const { data: globalData } = await supabase.rpc('get_leo_global_defaults');
+      globalChaining = globalData?.[0]?.chain_orchestrators ?? false;
+    }
+
     const autoProceed = data?.metadata?.auto_proceed ?? true;
-    const chainOrchestrators = data?.metadata?.chain_orchestrators ?? false;
+    const chainOrchestrators = data?.metadata?.chain_orchestrators ?? globalChaining;
     console.log(`SESSION_SETTINGS:${JSON.stringify({ auto_proceed: autoProceed, chain_orchestrators: chainOrchestrators })}`);
   } catch {
     // Non-fatal — settings query failure doesn't block queue display


### PR DESCRIPTION
## Summary
- sd-next.js had a hardcoded false fallback for chain_orchestrators that ignored the get_leo_global_defaults RPC
- When no active session metadata exists, the global default is now consulted
- Enables set_leo_global_defaults to actually affect SESSION_SETTINGS output

## Test plan
- [x] Set global chaining ON -> sd:next reports chain_orchestrators: true
- [ ] Active session with explicit metadata still takes precedence over global default

🤖 Generated with [Claude Code](https://claude.com/claude-code)