### PR TITLE
feat: add vision score badge to sd:next queue

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -352,7 +352,7 @@ export class SDNextSelector {
     // This ensures SDs appear even if baseline sync trigger failed (SD-LEO-INFRA-QUEUE-SIMPLIFY-001)
     const { data: allSDs, error: sdError } = await this.supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, title, status, current_phase, progress_percentage, is_working_on, dependencies, is_active, parent_sd_id, category, metadata')
+      .select('id, sd_key, title, status, current_phase, progress_percentage, is_working_on, dependencies, is_active, parent_sd_id, category, metadata, vision_alignment_score')
       .eq('is_active', true)
       .in('status', ['draft', 'active', 'in_progress', 'planning'])
       .order('created_at', { ascending: true });

--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -91,8 +91,10 @@ function displaySDItem(item, indent, childItems, allItems, sessionContext) {
   const workingIcon = item.is_working_on ? `${colors.bgYellow} ACTIVE ${colors.reset} ` : '';
   const claimedIcon = isClaimedByOther ? `${colors.bgBlue} CLAIMED ${colors.reset} ` : '';
   const title = (item.title || '').substring(0, 40 - indent.length);
+  const visionScore = item.vision_alignment_score;
+  const visionBadge = visionScore != null ?   + colors.cyan + '[V:' + Math.round(visionScore) + ']' + colors.reset : '';
 
-  console.log(`${indent}${claimedIcon}${workingIcon}${rankStr} ${sdId} - ${title}... ${statusIcon}`);
+  console.log(`${indent}${claimedIcon}${workingIcon}${rankStr} ${sdId} - ${title}${visionBadge}... ${statusIcon}`);
 
   // Show who claimed it with enhanced details (FR-6)
   if (isClaimedByOther) {
@@ -166,8 +168,10 @@ function displaySDItemSimple(item, prefix, nextIndent, childItems, allItems) {
 
   const workingIcon = item.is_working_on ? `${colors.bgYellow}◆${colors.reset}` : '';
   const title = (item.title || '').substring(0, 30);
+  const simpleVisionScore = item.vision_alignment_score;
+  const simpleVisionBadge = simpleVisionScore != null ? ' ' + colors.cyan + '[V:' + Math.round(simpleVisionScore) + ']' + colors.reset : '';
 
-  console.log(`${prefix}${workingIcon}${sdId} - ${title}... ${statusIcon}`);
+  console.log(`${prefix}${workingIcon}${sdId} - ${title}${simpleVisionBadge}... ${statusIcon}`);
 
   // Recursively show grandchildren
   const children = childItems.get(sdId) || childItems.get(item.id) || [];


### PR DESCRIPTION
Adds [V:NN] cyan badge to sd:next for SDs with vision_alignment_score. Graceful null fallback. 7 LOC in SDNextSelector.js and display/tracks.js.