### PR TITLE
fix(sd-next): supplement claim detection to catch idle sessions with active claims

### DIFF
--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -224,6 +224,15 @@ export class SDNextSelector {
           this.claimedSDs.set(session.sd_id, session.session_id);
         }
       }
+
+      // Supplement with direct claimed-sessions query so idle sessions with
+      // active claims are not shown as available (QF-SD-NEXT-CLAIM-BLIND-SPOT-001)
+      const claimedSessions = await this.sessionManager.getClaimedSessions();
+      for (const session of claimedSessions) {
+        if (session.sd_id && !this.claimedSDs.has(session.sd_id)) {
+          this.claimedSDs.set(session.sd_id, session.session_id);
+        }
+      }
     } catch {
       // Non-fatal - continue without session data
     }


### PR DESCRIPTION
## Summary

- Added supplemental  call in 
- Idle sessions (stale heartbeat) with active SD claims were returning  from , making their claimed SDs appear available
- The supplemental query directly targets sessions where , merging any missing claims into the  map
- Result: sd:next now correctly marks claimed SDs as CLAIMED/ACTIVE regardless of session heartbeat status

## Root Cause

 queries  filtered on . When a session heartbeat goes stale,  returns  even though  is still populated. This caused sd:next to recommend SDs already owned by other sessions.

## Test plan
- [x] Verified sd:next now shows ACTIVE badge on SD-MAN-INFRA-EXTEND-LEARN-COMMAND-001 (previously showed as DRAFT/recommended)
- [x] Verified recommendation changed from a claimed SD to SD-MAN-INFRA-VISION-SCORE-NOTIFICATIONS-001 (truly unclaimed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)