### PR TITLE
feat(vision-scorer): send Chairman email notification after scoring completes

### DIFF
--- a/lib/notifications/email-templates.js
+++ b/lib/notifications/email-templates.js
@@ -149,6 +149,67 @@ export function weeklySummaryTemplate(data) {
   return { html, text, subject };
 }
 
+/**
+ * Vision score notification template.
+ * SD: SD-MAN-INFRA-VISION-SCORE-NOTIFICATIONS-001
+ *
+ * @param {{ sdKey: string, sdTitle: string, totalScore: number, dimensionScores: Object, scoreId: string, scoredAt: string }} data
+ * @returns {{ html: string, text: string, subject: string }}
+ */
+export function visionScoreTemplate(data) {
+  const { sdKey, sdTitle, totalScore, dimensionScores = {}, scoreId, scoredAt } = data;
+  const scoreDisplay = totalScore != null ? `${Math.round(totalScore)}%` : 'N/A';
+  const deepLink = `${APP_URL}/eva/scores?id=${scoreId || ''}`;
+  const scoreColor = totalScore >= 85 ? '#4caf50' : totalScore >= 70 ? '#ff9800' : '#e94560';
+
+  const dimRows = Object.entries(dimensionScores).map(([id, dim]) => {
+    const dimScore = dim.score != null ? `${Math.round(dim.score)}/100` : 'N/A';
+    return `<tr>
+      <td style="padding:6px 12px;color:#b0b0b0;font-size:13px;">${escapeHtml(dim.name || id)}</td>
+      <td style="padding:6px 12px;color:#e0e0e0;text-align:right;font-size:13px;">${dimScore}</td>
+    </tr>`;
+  }).join('');
+
+  const dimText = Object.entries(dimensionScores).map(([id, dim]) => {
+    const dimScore = dim.score != null ? `${Math.round(dim.score)}/100` : 'N/A';
+    return `  ${dim.name || id}: ${dimScore}`;
+  }).join('\n');
+
+  const subject = `[EVA Vision Score] ${sdKey}: ${scoreDisplay}`;
+
+  const html = `
+    <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:600px;margin:0 auto;">
+      <div style="background:#1a1a2e;padding:20px;border-radius:8px 8px 0 0;">
+        <h2 style="color:#e0e0e0;margin:0;">EVA Vision Alignment Score</h2>
+        <p style="color:#888;margin:4px 0 0;">${escapeHtml(scoredAt || new Date().toISOString())}</p>
+      </div>
+      <div style="background:#16213e;padding:24px;color:#e0e0e0;">
+        <p style="font-size:14px;margin-top:0;color:#b0b0b0;">SD: <strong style="color:#e0e0e0;">${escapeHtml(sdKey)}</strong></p>
+        <p style="font-size:14px;margin:4px 0 16px;color:#b0b0b0;">${escapeHtml(sdTitle || '')}</p>
+        <div style="background:#0f3460;padding:16px;border-radius:6px;text-align:center;margin-bottom:20px;">
+          <div style="font-size:48px;font-weight:bold;color:${scoreColor};">${scoreDisplay}</div>
+          <div style="color:#888;font-size:13px;margin-top:4px;">Overall Vision Alignment</div>
+        </div>
+        ${dimRows ? `<h4 style="color:#888;font-size:12px;text-transform:uppercase;margin:0 0 8px;">Dimension Breakdown</h4>
+        <table style="width:100%;border-collapse:collapse;">
+          <thead><tr>
+            <th style="text-align:left;padding:6px 12px;border-bottom:1px solid #333;color:#888;font-size:12px;">Dimension</th>
+            <th style="text-align:right;padding:6px 12px;border-bottom:1px solid #333;color:#888;font-size:12px;">Score</th>
+          </tr></thead>
+          <tbody>${dimRows}</tbody>
+        </table>` : ''}
+        <a href="${deepLink}" style="display:inline-block;margin-top:20px;padding:10px 20px;background:#5b9bd5;color:#fff;text-decoration:none;border-radius:6px;font-size:14px;">View Full Report</a>
+      </div>
+      <div style="background:#1a1a2e;padding:12px 20px;border-radius:0 0 8px 8px;text-align:center;">
+        <p style="color:#666;font-size:12px;margin:0;">EHG Autonomous Venture Orchestrator — EVA Vision Governance</p>
+      </div>
+    </div>`;
+
+  const text = `EVA Vision Alignment Score\n\nSD: ${sdKey}\n${sdTitle || ''}\n\nOverall Score: ${scoreDisplay}\n\nDimension Breakdown:\n${dimText || '(no dimensions)'}\n\nFull Report: ${deepLink}`;
+
+  return { html, text, subject };
+}
+
 function escapeHtml(str) {
   if (!str) return '';
   return String(str)

--- a/lib/notifications/index.js
+++ b/lib/notifications/index.js
@@ -8,6 +8,6 @@
 
 export { sendEmail } from './resend-adapter.js';
 export { checkRateLimit } from './rate-limiter.js';
-export { immediateTemplate, dailyDigestTemplate, weeklySummaryTemplate } from './email-templates.js';
-export { sendImmediateNotification, sendDailyDigest, sendWeeklySummary } from './orchestrator.js';
+export { immediateTemplate, dailyDigestTemplate, weeklySummaryTemplate, visionScoreTemplate } from './email-templates.js';
+export { sendImmediateNotification, sendDailyDigest, sendWeeklySummary, sendVisionScoreNotification } from './orchestrator.js';
 export { runDailyDigestScheduler, runWeeklySummaryScheduler } from './scheduler.js';

--- a/lib/notifications/orchestrator.js
+++ b/lib/notifications/orchestrator.js
@@ -9,7 +9,7 @@
 
 import { sendEmail } from './resend-adapter.js';
 import { checkRateLimit } from './rate-limiter.js';
-import { immediateTemplate, dailyDigestTemplate, weeklySummaryTemplate } from './email-templates.js';
+import { immediateTemplate, dailyDigestTemplate, weeklySummaryTemplate, visionScoreTemplate } from './email-templates.js';
 
 /**
  * Send an immediate notification for a critical chairman decision.
@@ -232,6 +232,82 @@ export async function sendWeeklySummary(supabase, params) {
     subject
   });
   return { notificationId: notification.id, status: 'failed' };
+}
+
+/**
+ * Send a vision score notification to the Chairman after scoring completes.
+ * SD: SD-MAN-INFRA-VISION-SCORE-NOTIFICATIONS-001
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ sdKey: string, sdTitle: string, totalScore: number, dimensionScores: Object, scoreId: string, recipientEmail: string }} params
+ * @returns {Promise<{ notificationId: string | null, status: string }>}
+ */
+export async function sendVisionScoreNotification(supabase, params) {
+  const recipientEmail = params.recipientEmail || process.env.CHAIRMAN_EMAIL;
+  if (!recipientEmail) {
+    console.warn('[vision-score-notif] CHAIRMAN_EMAIL not set — skipping notification');
+    return { notificationId: null, status: 'skipped_no_recipient' };
+  }
+
+  const scoredAt = new Date().toISOString();
+
+  // Create notification record as 'queued'
+  const { data: notification, error: insertError } = await supabase
+    .from('chairman_notifications')
+    .insert({
+      recipient_email: recipientEmail,
+      notification_type: 'vision_score',
+      status: 'queued',
+      subject: `[EVA Vision Score] ${params.sdKey}: ${params.totalScore != null ? Math.round(params.totalScore) + '%' : 'N/A'}`,
+      email_metadata: { sd_key: params.sdKey, score_id: params.scoreId, total_score: params.totalScore }
+    })
+    .select('id')
+    .single();
+
+  if (insertError) {
+    console.error(`[vision-score-notif] Failed to create record: ${insertError.message}`);
+    return { notificationId: null, status: 'failed' };
+  }
+
+  const notificationId = notification.id;
+
+  // Check rate limit
+  const rateCheck = await checkRateLimit(supabase, recipientEmail);
+  if (!rateCheck.allowed) {
+    await updateNotificationStatus(supabase, notificationId, 'rate_limited', {
+      error_code: 'RATE_LIMITED',
+      error_message: `Rate limit exceeded: ${rateCheck.currentCount}/${rateCheck.limit} in last hour`
+    });
+    return { notificationId, status: 'rate_limited' };
+  }
+
+  // Render and send
+  const { html, text, subject } = visionScoreTemplate({
+    sdKey: params.sdKey,
+    sdTitle: params.sdTitle,
+    totalScore: params.totalScore,
+    dimensionScores: params.dimensionScores || {},
+    scoreId: params.scoreId,
+    scoredAt,
+  });
+
+  const result = await sendEmail({ to: recipientEmail, subject, html, text });
+
+  if (result.success) {
+    await updateNotificationStatus(supabase, notificationId, 'sent', {
+      provider_message_id: result.providerMessageId,
+      sent_at: scoredAt,
+      subject,
+    });
+    return { notificationId, status: 'sent' };
+  }
+
+  await updateNotificationStatus(supabase, notificationId, 'failed', {
+    error_code: result.errorCode,
+    error_message: result.errorMessage,
+    subject,
+  });
+  return { notificationId, status: 'failed' };
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Add  to  — HTML/text email with overall score percentage and per-dimension breakdown
- Add  to  — rate-check → template → send → persist to 
- Export both from 
- Wire notification into  after successful score persistence; wrapped in try/catch so scoring runs are never blocked by notification failures

## Behavior
- Email shows overall alignment score percentage + all dimension scores with N/A fallback for null values
- Rate limiting via existing  infrastructure (no duplicate emails)
- Recipient from  env var; gracefully skips if not set
- Failures logged to  table with 

## Test plan
- [x] 15/15 smoke tests pass
- [x] 4 gates passed LEAD-FINAL-APPROVAL at 96%

SD: SD-MAN-INFRA-VISION-SCORE-NOTIFICATIONS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)