### PR TITLE
feat(notifications): Telegram adapter for vision score events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,6 +107,12 @@ RESEND_API_KEY=re_...
 # Email address to receive emergency alerts
 SOVEREIGN_ALERT_EMAIL=chairman@yourdomain.com
 
+# Telegram Bot notifications (SD-MAN-INFRA-TELEGRAM-ADAPTER-VISION-001)
+# 1. Message @BotFather on Telegram, send /newbot, follow prompts → get token
+# 2. Add bot to your channel/chat, then get chat ID via: https://api.telegram.org/bot<TOKEN>/getUpdates
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
 # EVA Idea Processing Pipeline (Optional)
 # Todoist API Token: https://todoist.com/app/settings/integrations/developer
 TODOIST_API_TOKEN=your-todoist-api-token

--- a/lib/notifications/index.js
+++ b/lib/notifications/index.js
@@ -9,5 +9,6 @@
 export { sendEmail } from './resend-adapter.js';
 export { checkRateLimit } from './rate-limiter.js';
 export { immediateTemplate, dailyDigestTemplate, weeklySummaryTemplate, visionScoreTemplate } from './email-templates.js';
-export { sendImmediateNotification, sendDailyDigest, sendWeeklySummary, sendVisionScoreNotification } from './orchestrator.js';
+export { sendImmediateNotification, sendDailyDigest, sendWeeklySummary, sendVisionScoreNotification, sendVisionScoreTelegramNotification } from './orchestrator.js';
+export { sendTelegramMessage } from './telegram-adapter.js';
 export { runDailyDigestScheduler, runWeeklySummaryScheduler } from './scheduler.js';

--- a/lib/notifications/orchestrator.js
+++ b/lib/notifications/orchestrator.js
@@ -8,6 +8,7 @@
  */
 
 import { sendEmail } from './resend-adapter.js';
+import { sendTelegramMessage } from './telegram-adapter.js';
 import { checkRateLimit } from './rate-limiter.js';
 import { immediateTemplate, dailyDigestTemplate, weeklySummaryTemplate, visionScoreTemplate } from './email-templates.js';
 
@@ -308,6 +309,68 @@ export async function sendVisionScoreNotification(supabase, params) {
     subject,
   });
   return { notificationId, status: 'failed' };
+}
+
+/**
+ * Send a Telegram message to the Chairman after vision scoring completes.
+ * SD: SD-MAN-INFRA-TELEGRAM-ADAPTER-VISION-001
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{ sdKey: string, sdTitle: string, totalScore: number, dimensionScores: Object, scoreId: string }} params
+ * @returns {Promise<{ notificationId: string | null, status: string }>}
+ */
+export async function sendVisionScoreTelegramNotification(supabase, params) {
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!process.env.TELEGRAM_BOT_TOKEN || !chatId) {
+    console.warn('[telegram-vision] TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID not set — skipping (see .env.example)');
+    return { notificationId: null, status: 'skipped_not_configured' };
+  }
+
+  const scoreDisplay = params.totalScore != null ? `${Math.round(params.totalScore)}%` : 'N/A';
+
+  // Find top dimension for quick insight
+  const topDim = Object.values(params.dimensionScores || {})
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))[0];
+  const dimLine = topDim
+    ? `\nTop: ${topDim.name} — ${topDim.score != null ? Math.round(topDim.score) + '/100' : 'N/A'}`
+    : '';
+
+  const text = `🎯 EVA Vision Score\nSD: ${params.sdKey}\nScore: ${scoreDisplay}${dimLine}`;
+
+  // Check rate limit using chatId as the recipient key
+  const rateCheck = await checkRateLimit(supabase, chatId);
+
+  // Create chairman_notifications record
+  const { data: notification, error: insertError } = await supabase
+    .from('chairman_notifications')
+    .insert({
+      recipient_email: chatId,
+      notification_type: 'telegram_vision_score',
+      status: rateCheck.allowed ? 'queued' : 'rate_limited',
+      subject: `[Telegram] EVA Vision Score ${params.sdKey}: ${scoreDisplay}`,
+      email_metadata: { sd_key: params.sdKey, score_id: params.scoreId, total_score: params.totalScore, channel: 'telegram' }
+    })
+    .select('id')
+    .single();
+
+  if (insertError) {
+    console.error(`[telegram-vision] Failed to create record: ${insertError.message}`);
+    return { notificationId: null, status: 'failed' };
+  }
+
+  if (!rateCheck.allowed) {
+    return { notificationId: notification.id, status: 'rate_limited' };
+  }
+
+  const result = await sendTelegramMessage({ chatId, text });
+
+  await updateNotificationStatus(supabase, notification.id, result.success ? 'sent' : 'failed', {
+    ...(result.success
+      ? { provider_message_id: result.providerMessageId, sent_at: new Date().toISOString() }
+      : { error_code: result.errorCode, error_message: result.errorMessage })
+  });
+
+  return { notificationId: notification.id, status: result.success ? 'sent' : 'failed' };
 }
 
 // ============================================================

--- a/lib/notifications/telegram-adapter.js
+++ b/lib/notifications/telegram-adapter.js
@@ -1,0 +1,129 @@
+/**
+ * Telegram Adapter
+ * SD: SD-MAN-INFRA-TELEGRAM-ADAPTER-VISION-001
+ *
+ * Provider interface for delivering messages via the Telegram Bot API.
+ * Mirrors the resend-adapter.js pattern: timeout, retry, error mapping.
+ *
+ * Required env vars:
+ *   TELEGRAM_BOT_TOKEN - Bot token from @BotFather
+ *   TELEGRAM_CHAT_ID   - Target chat/channel ID
+ */
+
+const TELEGRAM_API_BASE = 'https://api.telegram.org';
+const DEFAULT_TIMEOUT_MS = 10000;
+const MAX_RETRIES = 1;
+
+/**
+ * @typedef {Object} TelegramPayload
+ * @property {string} chatId - Target chat ID (overrides TELEGRAM_CHAT_ID env var)
+ * @property {string} text   - Message text (plain text or HTML with parse_mode)
+ */
+
+/**
+ * @typedef {Object} SendResult
+ * @property {boolean} success
+ * @property {string} [providerMessageId] - Telegram message_id on success
+ * @property {string} [errorCode]         - Error classification
+ * @property {string} [errorMessage]      - Human-readable error detail
+ */
+
+/**
+ * Send a message via Telegram Bot API with retry and timeout.
+ * @param {TelegramPayload} payload
+ * @returns {Promise<SendResult>}
+ */
+export async function sendTelegramMessage(payload) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = payload.chatId || process.env.TELEGRAM_CHAT_ID;
+
+  if (!token) {
+    return {
+      success: false,
+      errorCode: 'MISSING_BOT_TOKEN',
+      errorMessage: 'TELEGRAM_BOT_TOKEN environment variable not set — see .env.example'
+    };
+  }
+
+  if (!chatId) {
+    return {
+      success: false,
+      errorCode: 'MISSING_CHAT_ID',
+      errorMessage: 'TELEGRAM_CHAT_ID environment variable not set — see .env.example'
+    };
+  }
+
+  const url = `${TELEGRAM_API_BASE}/bot${token}/sendMessage`;
+  const body = { chat_id: chatId, text: payload.text };
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal
+      });
+
+      clearTimeout(timeout);
+
+      if (response.ok) {
+        const data = await response.json();
+        return {
+          success: true,
+          providerMessageId: String(data.result?.message_id || '')
+        };
+      }
+
+      // Non-retryable client errors (4xx except 429)
+      if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+        const errorData = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          errorCode: `HTTP_${response.status}`,
+          errorMessage: errorData.description || response.statusText
+        };
+      }
+
+      // Retryable: 429 or 5xx
+      if (attempt < MAX_RETRIES) {
+        await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+        continue;
+      }
+
+      const errorData = await response.json().catch(() => ({}));
+      return {
+        success: false,
+        errorCode: `HTTP_${response.status}`,
+        errorMessage: errorData.description || `Telegram API returned ${response.status} after ${MAX_RETRIES + 1} attempts`
+      };
+
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        if (attempt < MAX_RETRIES) {
+          await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+          continue;
+        }
+        return {
+          success: false,
+          errorCode: 'TIMEOUT',
+          errorMessage: `Request timed out after ${DEFAULT_TIMEOUT_MS}ms`
+        };
+      }
+
+      if (attempt < MAX_RETRIES) {
+        await new Promise(resolve => setTimeout(resolve, Math.pow(2, attempt) * 1000));
+        continue;
+      }
+
+      return {
+        success: false,
+        errorCode: 'NETWORK_ERROR',
+        errorMessage: err.message
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New  — POST to Telegram Bot API with 10s timeout, 1 retry on 5xx/429, mirrors  pattern
- Add  to  — rate-check → format text (SD key, score %, top dimension) → send → persist  record with 
- Export both from 
- Wire into  after email notification; failure is non-fatal (try/catch)
- Add  /  to  with setup instructions

## Configuration
Set  (from @BotFather) and  in . If either is missing, notification is skipped gracefully with a warning.

## Test plan
- [x] 15/15 smoke tests pass
- [x] LEAD-FINAL-APPROVAL passed
- [x] Failure is non-fatal: scoring pipeline unaffected by Telegram errors

SD: SD-MAN-INFRA-TELEGRAM-ADAPTER-VISION-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)