### PR TITLE
feat(eva): add /eva score skill and score-command.mjs orchestrator

### DIFF
--- a/.claude/skills/eva-score.skill.md
+++ b/.claude/skills/eva-score.skill.md
@@ -1,0 +1,109 @@
+# /eva score - EVA Vision Alignment Scorer
+
+Score a Strategic Directive or build scope against the active EVA Vision and Architecture
+documents. Produces per-dimension scores, a total alignment score, threshold action,
+and optionally auto-generates a corrective SD for any gap.
+
+## Usage
+
+```
+/eva score --sd-id <SD-KEY> [--vision-key <KEY>] [--arch-key <KEY>] [--dry-run]
+/eva score --scope "<description>" [--vision-key <KEY>] [--arch-key <KEY>] [--dry-run]
+```
+
+## Instructions for Claude
+
+### Step 1: Parse Arguments
+
+From `$ARGUMENTS`, extract:
+- **`--sd-id`**: SD key to score (e.g. `SD-MAN-INFRA-001`). Mutually exclusive with `--scope`.
+- **`--scope`**: Free-text description of what to score (alternative to --sd-id).
+- **`--vision-key`**: Optional. Vision document key (e.g. `VISION-EHG-L1-001`). Auto-loaded from DB if omitted.
+- **`--arch-key`**: Optional. Architecture plan key (e.g. `ARCH-EHG-L1-001`). Auto-loaded from DB if omitted.
+- **`--dry-run`**: Optional. Preview scores without writing to database.
+
+If neither `--sd-id` nor `--scope` is provided, show error:
+```
+❌ Usage: /eva score --sd-id <SD-KEY> [options]
+         /eva score --scope "<description>" [options]
+
+Options:
+  --vision-key <KEY>   Vision document key (auto-loads latest if omitted)
+  --arch-key <KEY>     Architecture plan key (auto-loads latest if omitted)
+  --dry-run            Preview scores without writing to database
+```
+
+---
+
+### Step 2: Run the Scoring Command
+
+```bash
+node scripts/eva/score-command.mjs \
+  [--sd-id <sdKey>] \
+  [--scope "<scope>"] \
+  [--vision-key <visionKey>] \
+  [--arch-key <archKey>] \
+  [--dry-run]
+```
+
+Display the command output directly to the user. The script handles:
+- Loading default vision/arch keys from DB when flags are omitted
+- Calling `scoreSD()` to produce LLM-based dimension scores
+- Calling `generateCorrectiveSD()` when score is below accept threshold
+- Formatting the results table
+
+---
+
+### Step 3: After Scoring
+
+If the command succeeds, offer next steps using AskUserQuestion:
+
+```javascript
+{
+  "questions": [{
+    "question": "Scoring complete. What would you like to do next?",
+    "header": "Next Step",
+    "multiSelect": false,
+    "options": [
+      {"label": "View corrective SD", "description": "Open the auto-generated corrective SD in the queue"},
+      {"label": "Score another SD", "description": "Run /eva score on a different SD"},
+      {"label": "View vision document", "description": "Run /eva vision list to see all vision documents"},
+      {"label": "Done", "description": "No further action"}
+    ]
+  }]
+}
+```
+
+**If "View corrective SD"**: Run `/leo next` to show the SD queue where the corrective SD appears.
+**If "Score another SD"**: Ask "Which SD key would you like to score?" then restart from Step 2.
+
+---
+
+### Step 4: Error Handling
+
+| Error | User message |
+|-------|-------------|
+| Vision document not found | "❌ Vision document '<key>' not found. Run `/eva vision list` to see available documents." |
+| Architecture plan not found | "❌ Architecture plan '<key>' not found. Run `/eva archplan list` to see available plans." |
+| SD not found | "❌ SD '<key>' not found in the database. Check the SD key and try again." |
+| LLM scoring failed | "❌ Scoring failed: <error>. Check LLM provider connectivity." |
+
+---
+
+## Score Tiers
+
+| Score | Action | Result |
+|-------|--------|--------|
+| ≥ 85 | **Accept** | No corrective SD created |
+| 70–84 | **Minor** | Corrective SD created (priority: medium) |
+| 50–69 | **Gap Closure** | Corrective SD created (priority: high) |
+| < 50 | **Escalation** | Corrective SD created (priority: critical) |
+
+---
+
+## Related Commands
+
+- `/eva vision` — Manage vision documents
+- `/eva archplan` — Manage architecture plans
+- `/eva research` — Research questions against vision dimensions
+- `/leo next` — View SD queue (includes any corrective SDs generated)

--- a/scripts/eva/score-command.mjs
+++ b/scripts/eva/score-command.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * score-command.mjs
+ * Orchestrates a full EVA vision scoring run:
+ *   1. Calls scoreSD() from vision-scorer.js
+ *   2. Calls generateCorrectiveSD() from corrective-sd-generator.mjs (if not dry-run)
+ *   3. Returns a combined result object
+ *
+ * Usage:
+ *   node scripts/eva/score-command.mjs --sd-id <SD-KEY> [--vision-key <KEY>] [--arch-key <KEY>] [--dry-run]
+ *
+ * Part of: SD-MAN-INFRA-EVA-SCORE-COMMAND-001
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, '../../.env') });
+
+// ─── Lazy imports (dynamic to avoid circular refs) ───────────────────────────
+
+async function getScoreSD() {
+  const mod = await import('./vision-scorer.js');
+  return mod.scoreSD;
+}
+
+async function getGenerateCorrectiveSD() {
+  const mod = await import('./corrective-sd-generator.mjs');
+  return mod.generateCorrectiveSD;
+}
+
+// ─── Default key loading ──────────────────────────────────────────────────────
+
+/**
+ * Load the most-recently-published vision key from eva_vision_documents.
+ */
+async function loadDefaultVisionKey(supabase) {
+  const { data } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key')
+    .eq('status', 'published')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+  return data?.vision_key ?? 'VISION-EHG-L1-001';
+}
+
+/**
+ * Load the most-recently-published arch key from eva_architecture_plans.
+ */
+async function loadDefaultArchKey(supabase) {
+  const { data } = await supabase
+    .from('eva_architecture_plans')
+    .select('plan_key')
+    .eq('status', 'published')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+  return data?.plan_key ?? 'ARCH-EHG-L1-001';
+}
+
+// ─── Main exported function ───────────────────────────────────────────────────
+
+/**
+ * Run a full EVA scoring cycle: score → optionally generate corrective SD.
+ *
+ * @param {Object} options
+ * @param {string} [options.sdKey] - SD key to score (e.g. 'SD-X')
+ * @param {string} [options.visionKey] - Vision doc key. Auto-loads from DB if omitted.
+ * @param {string} [options.archKey] - Architecture plan key. Auto-loads from DB if omitted.
+ * @param {string} [options.scope] - Custom scope description (alternative to sdKey)
+ * @param {boolean} [options.dryRun=false] - Preview without DB writes
+ * @returns {Promise<{score: Object, corrective: Object|null, visionKey: string, archKey: string}>}
+ */
+export async function runScore(options = {}) {
+  const { sdKey, scope, dryRun = false } = options;
+
+  if (!sdKey && !scope) {
+    throw new Error('--sd-id or --scope is required');
+  }
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  // Resolve keys (dynamic defaults if not provided)
+  const visionKey = options.visionKey || await loadDefaultVisionKey(supabase);
+  const archKey = options.archKey || await loadDefaultArchKey(supabase);
+
+  // Step 1: Score
+  const scoreSD = await getScoreSD();
+  const score = await scoreSD({ sdKey, visionKey, archKey, scope, dryRun });
+
+  // Step 2: Generate corrective SD (only when score has a DB record)
+  let corrective = null;
+  if (!dryRun && score.id) {
+    const generateCorrectiveSD = await getGenerateCorrectiveSD();
+    corrective = await generateCorrectiveSD(score.id);
+  }
+
+  return { score, corrective, visionKey, archKey };
+}
+
+// ─── CLI output formatter ─────────────────────────────────────────────────────
+
+function formatResult({ score, corrective, visionKey, archKey, dryRun }) {
+  const divider = '═'.repeat(62);
+  const lines = [
+    '',
+    divider,
+    `  /eva score${dryRun ? ' [DRY RUN]' : ''}`,
+    divider,
+    `  Vision:       ${visionKey}`,
+    `  Architecture: ${archKey}`,
+    score.sd_id ? `  SD:           ${score.sd_id}` : `  Scope:        (custom)`,
+    '',
+    '┌─ DIMENSION SCORES ─────────────────────────────────────────┐',
+  ];
+
+  const dims = score.dimension_scores || {};
+  for (const [id, dim] of Object.entries(dims)) {
+    const bar = '█'.repeat(Math.round((dim.score / 100) * 10)) + '░'.repeat(10 - Math.round((dim.score / 100) * 10));
+    lines.push(`│  ${id.padEnd(5)} [${bar}] ${String(dim.score).padStart(3)}/100  ${dim.name || ''}`);
+  }
+
+  lines.push('└────────────────────────────────────────────────────────────┘');
+  lines.push('');
+  lines.push(`  Total Score:  ${score.total_score}/100`);
+  lines.push(`  Action:       ${score.threshold_action?.toUpperCase() ?? 'UNKNOWN'}`);
+
+  if (score.summary) {
+    lines.push(`  Summary:      ${score.summary.slice(0, 120)}`);
+  }
+
+  lines.push('');
+
+  if (dryRun) {
+    lines.push('  ⚠️  DRY RUN — no records written to database');
+  } else if (score.id) {
+    lines.push(`  Score ID:     ${score.id}`);
+  }
+
+  if (corrective) {
+    if (corrective.created) {
+      lines.push(`  Corrective SD: ${corrective.sdKey} (${corrective.action})`);
+    } else {
+      lines.push(`  Corrective SD: none (score ${corrective.action === 'accept' ? 'above threshold' : `→ existing: ${corrective.sdKey}`})`);
+    }
+  }
+
+  lines.push(divider);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+// ─── CLI Entry Point ──────────────────────────────────────────────────────────
+
+const argv1 = process.argv[1];
+const isMain = argv1 && (
+  import.meta.url === `file://${argv1}` ||
+  import.meta.url === `file:///${argv1.replace(/\\/g, '/')}`
+);
+
+if (isMain) {
+  const args = process.argv.slice(2);
+  const getArg = (flag) => { const i = args.indexOf(flag); return i !== -1 ? args[i + 1] : null; };
+
+  const sdKey = getArg('--sd-id');
+  const visionKey = getArg('--vision-key') || undefined;
+  const archKey = getArg('--arch-key') || undefined;
+  const scope = getArg('--scope') || undefined;
+  const dryRun = args.includes('--dry-run');
+
+  if (!sdKey && !scope) {
+    console.error('Usage: node scripts/eva/score-command.mjs --sd-id <SD-KEY> [--vision-key <KEY>] [--arch-key <KEY>] [--scope <text>] [--dry-run]');
+    process.exit(1);
+  }
+
+  runScore({ sdKey, visionKey, archKey, scope, dryRun })
+    .then(({ score, corrective, visionKey: vk, archKey: ak }) => {
+      console.log(formatResult({ score, corrective, visionKey: vk, archKey: ak, dryRun }));
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('Error:', err.message);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary

- **New skill**: `.claude/skills/eva-score.skill.md` — `/eva score` subcommand with `--sd-id`, `--vision-key`, `--arch-key`, `--scope`, `--dry-run` flags
- **New script**: `scripts/eva/score-command.mjs` — thin orchestration layer that:
  1. Calls `scoreSD()` from `vision-scorer.js` (dynamic vision alignment scoring engine)
  2. Calls `generateCorrectiveSD()` from `corrective-sd-generator.mjs` if score is below accept threshold
  3. Auto-loads default vision/arch keys from DB when flags omitted
  4. Formats dimension score bars with threshold action and corrective SD result

## Test plan

- [x] Module imports correctly: `runScore` exported function verified
- [x] Dynamic imports of `vision-scorer.js` and `corrective-sd-generator.mjs` work
- [ ] Manual: `/eva score --sd-id SD-X --dry-run` shows preview without DB writes
- [ ] Manual: `/eva score --sd-id SD-X` creates score record and corrective SD if score < 85

Closes SD-MAN-INFRA-EVA-SCORE-COMMAND-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)