### PR TITLE
fix(eva): harden SD generators - occurrence threshold, enriched content, sort fix

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-MAN-INFRA-VISION-SCORE-GATE-001",
-  "expectedBranch": "feat/SD-MAN-INFRA-VISION-SCORE-GATE-001",
-  "createdAt": "2026-02-18T22:02:36.576Z",
+  "sdKey": "SD-FIX-EVA-CORRECTIVE-QUALITY-001",
+  "expectedBranch": "feat/SD-FIX-EVA-CORRECTIVE-QUALITY-001",
+  "createdAt": "2026-02-18T22:42:56.012Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/auto-fix-sd-generator.js
+++ b/scripts/auto-fix-sd-generator.js
@@ -36,14 +36,14 @@ class AutoFixSDGenerator {
         test_case: issue.test_case_id
       },
       strategic_objectives: [
-        'Fix the identified issue',
-        'Prevent regression',
-        'Maintain ≥85% pass rate'
+        { objective: 'Fix the identified issue and verify with UAT test', metric: 'UAT test passes after fix' },
+        { objective: 'Prevent regression in related functionality', metric: '0 existing tests broken' },
+        { objective: 'Maintain ≥85% overall UAT pass rate', metric: 'UAT pass rate >= 85%' }
       ],
       success_criteria: [
-        'Issue resolved and test passes',
-        'No regression in other tests',
-        'Fix deployed to production'
+        { criterion: 'Issue resolved and UAT test passes', measure: 'Test status = pass' },
+        { criterion: 'No regression in other tests', measure: '0 previously-passing tests now failing' },
+        { criterion: 'Fix deployed to production', measure: 'Deployment confirmed in prod environment' }
       ],
       dependencies: [issue.issue_key],
       target_application: 'EHG',


### PR DESCRIPTION
## Summary

Hardens all three SD auto-generators that were doing raw Supabase inserts with low-quality content:

**corrective-sd-generator.mjs** (4 fixes):
- `MIN_OCCURRENCES=2` threshold — only generates corrective SD after 2+ sub-threshold scoring runs, preventing test inserts from creating real SDs
- Test data filter — skips `eva_vision_scores` records where `created_by` matches `test-*` patterns
- Enriched SD description — pulls `dimension_scores[dim].reasoning` (LLM explanation of WHY score was low), `rubric_snapshot` criteria `description` and `source_section` via new `buildEnrichedDescription()` helper
- Sort bug fix — `_extractLowestDimension()` now compares `a.score` vs `b.score` (dimension values are `{score, weight, ...}` objects, not numbers — old code compared objects yielding NaN and random order)

**auto-fix-sd-generator.js**:
- `strategic_objectives`: `string[]` -> `[{objective, metric}]` objects
- `success_criteria`: `string[]` -> `[{criterion, measure}]` objects

**modules/learning/sd-creation.js**:
- Adds informational `runTriageGate()` call before insert (non-blocking)

## Context
Two bogus corrective SDs (SD-CORR-VIS-2ED5AE, SD-CORR-VIS-DFB639) were created from smoke test score inserts — both now cancelled. This fix prevents recurrence.

## Test plan
- [x] `_extractLowestDimension({V01:62, V02:28, A01:55})` returns `V02` (lowest, correct)
- [x] `MIN_OCCURRENCES=2`, `classifyScore`, `THRESHOLDS` all export correctly
- [x] All 3 files compile without errors

SD: SD-FIX-EVA-CORRECTIVE-QUALITY-001 (COMPLETED)

Generated with Claude Code
