### PR TITLE
feat(vision-gate): harden vision score gate to SD-type-aware hard enforcement

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js
@@ -1,88 +1,205 @@
 /**
  * Vision Score Gate for LEAD-TO-PLAN
- * SD: SD-MAN-INFRA-VISION-SCORE-GATE-001
+ * SD: SD-MAN-INFRA-VISION-SCORE-GATE-HARDEN-001
  *
- * Soft informational gate — never blocks handoff.
- * Displays the SD's vision alignment score (if available) during LEAD-TO-PLAN validation.
+ * Hard SD-type-aware enforcement gate — blocks handoff when vision score is
+ * below the type-specific threshold or when no score exists.
  *
- * Behaviour:
- *   - score present → display score + threshold action classification
- *   - score absent  → pass silently (graceful degradation)
- *   - Always returns score: 100 (non-blocking)
+ * Threshold tiers:
+ *   feature / governance / security    → must score ≥ 90
+ *   infrastructure / enhancement       → must score ≥ 80
+ *   maintenance / protocol / bugfix /
+ *   fix / documentation / refactor /
+ *   orchestrator                       → must score ≥ 70
+ *   unknown / default                  → must score ≥ 80
+ *
+ * Override: A row in validation_gate_registry with
+ *   gate_name='GATE_VISION_SCORE', applicability='OPTIONAL_OVERRIDE',
+ *   and a non-empty justification field bypasses the hard block.
+ *
+ * Per-dimension warnings: Any dimension score < 75 emits a named warning
+ * (non-blocking — valid=true is still returned when overall score passes).
  */
 
+/** Threshold per SD type. Exported for tests. */
+export const SD_TYPE_THRESHOLDS = {
+  // Tier 1 — highest bar
+  feature:        90,
+  governance:     90,
+  security:       90,
+  // Tier 2 — standard bar
+  infrastructure: 80,
+  enhancement:    80,
+  // Tier 3 — lower bar
+  maintenance:    70,
+  protocol:       70,
+  bugfix:         70,
+  fix:            70,
+  documentation:  70,
+  refactor:       70,
+  orchestrator:   70,
+  // Default (unknown types)
+  _default:       80,
+};
+
+/** Minimum dimension score before a named warning is emitted. */
+export const DIMENSION_WARNING_THRESHOLD = 75;
+
 const THRESHOLD_LABELS = {
-  accept:        { emoji: '✅', label: 'ACCEPT',       desc: 'Strong vision alignment' },
-  minor_sd:      { emoji: '🟡', label: 'MINOR GAP',   desc: 'Minor alignment gaps — consider scope adjustments' },
-  gap_closure_sd:{ emoji: '🟠', label: 'GAP',         desc: 'Moderate gaps — corrective SD may be needed' },
-  escalate:      { emoji: '🔴', label: 'ESCALATE',    desc: 'Significant gaps — LEAD review recommended' },
+  accept:        { emoji: '✅', label: 'ACCEPT',      desc: 'Strong vision alignment' },
+  minor_sd:      { emoji: '🟡', label: 'MINOR GAP',  desc: 'Minor alignment gaps — consider scope adjustments' },
+  gap_closure_sd:{ emoji: '🟠', label: 'GAP',        desc: 'Moderate gaps — corrective SD may be needed' },
+  escalate:      { emoji: '🔴', label: 'ESCALATE',   desc: 'Significant gaps — LEAD review recommended' },
 };
 
 /**
- * Validate vision alignment score for the SD (informational only).
+ * Check for a Chairman override in validation_gate_registry.
+ * Returns { active: false } if the table or row is absent (fail-closed: enforce).
  *
- * @param {Object} sd - Strategic Directive (must have sd_key, vision_score, vision_score_action)
- * @param {Object} supabase - Supabase client (for latest score lookup)
- * @returns {Object} Gate result — always passes
+ * @param {string} sdKey
+ * @param {Object} supabase
+ * @returns {Promise<{active: boolean, justification?: string}>}
+ */
+async function checkOverride(sdKey, supabase) {
+  if (!supabase || !sdKey) return { active: false };
+  try {
+    const { data } = await supabase
+      .from('validation_gate_registry')
+      .select('justification')
+      .eq('gate_name', 'GATE_VISION_SCORE')
+      .eq('applicability', 'OPTIONAL_OVERRIDE')
+      .eq('sd_id', sdKey)
+      .limit(1);
+
+    if (data && data.length > 0) {
+      const justification = (data[0].justification || '').trim();
+      if (justification.length > 0) {
+        return { active: true, justification };
+      }
+    }
+    return { active: false };
+  } catch {
+    // Table or columns absent — fail-closed (enforce the gate)
+    return { active: false };
+  }
+}
+
+/**
+ * Return per-dimension warnings for any dimension whose score < DIMENSION_WARNING_THRESHOLD.
+ *
+ * @param {Object|null} dimensionScores - JSONB object of { dimName: score, ... }
+ * @returns {string[]} Warning strings (may be empty)
+ */
+function getDimensionWarnings(dimensionScores) {
+  if (!dimensionScores || typeof dimensionScores !== 'object') return [];
+  return Object.entries(dimensionScores)
+    .filter(([, score]) => typeof score === 'number' && score < DIMENSION_WARNING_THRESHOLD)
+    .map(([dim, score]) =>
+      `Dimension '${dim}': ${score}/100 (below ${DIMENSION_WARNING_THRESHOLD} warning threshold)`
+    );
+}
+
+/**
+ * Validate vision alignment score for the SD (hard enforcement).
+ *
+ * @param {Object} sd - Strategic Directive (must have sd_key, sd_type)
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<Object>} Gate result — may block (valid: false)
  */
 export async function validateVisionScore(sd, supabase) {
-  const warnings = [];
+  const sdKey = sd.sd_key || sd.id;
+  const sdType = (sd.sd_type || 'unknown').toLowerCase();
+  const threshold = SD_TYPE_THRESHOLDS[sdType] ?? SD_TYPE_THRESHOLDS._default;
 
   // Prefer SD-level cached score; fall back to live query
   let visionScore = sd.vision_score ?? null;
   let thresholdAction = sd.vision_score_action ?? null;
+  let dimensionScores = sd.dimension_scores ?? null;
 
-  // If score not on SD object, check eva_vision_scores for latest record
-  if (visionScore === null && supabase && sd.sd_key) {
+  // Fetch latest score from eva_vision_scores if not cached
+  if (visionScore === null && supabase && sdKey) {
     try {
       const { data } = await supabase
         .from('eva_vision_scores')
-        .select('total_score, threshold_action, scored_at')
-        .eq('sd_id', sd.sd_key)
+        .select('total_score, threshold_action, dimension_scores, scored_at')
+        .eq('sd_id', sdKey)
         .order('scored_at', { ascending: false })
         .limit(1);
 
       if (data && data.length > 0) {
         visionScore = data[0].total_score;
         thresholdAction = data[0].threshold_action;
+        dimensionScores = data[0].dimension_scores ?? null;
       }
     } catch {
-      // Graceful degradation — vision score is informational
+      // DB unavailable — proceed to hard block (no score = no pass)
     }
   }
 
+  console.log('\n🔍 GATE: Vision Alignment Score (Hard Enforcement)');
+  console.log(`   SD Type: ${sdType} | Required: ${threshold}/100`);
+  console.log('-'.repeat(50));
+
+  // ── No score present → hard block ───────────────────────────────────────
   if (visionScore === null) {
-    console.log('   ℹ️  No vision alignment score — run `node scripts/eva/vision-scorer.js` to score this SD');
+    console.log('   ❌ No vision alignment score found — handoff BLOCKED');
+    console.log(`   💡 Run: node scripts/eva/vision-scorer.js --sd-id ${sdKey || '<SD-KEY>'}`);
     return {
-      valid: true,
-      score: 100,
-      details: 'Vision score not yet available — pass (soft gate)',
+      valid: false,
+      score: 0,
+      details: `No vision alignment score found for ${sdKey}. Run vision-scorer.js before LEAD-TO-PLAN.`,
+      remediation: `node scripts/eva/vision-scorer.js --sd-id ${sdKey || '<SD-KEY>'}`,
       warnings: [],
     };
   }
 
   const classification = THRESHOLD_LABELS[thresholdAction] || THRESHOLD_LABELS.escalate;
-
   console.log(`   Vision Alignment: ${visionScore}/100  ${classification.emoji} ${classification.label}`);
   console.log(`   ${classification.desc}`);
 
-  if (thresholdAction === 'escalate') {
-    warnings.push(`Vision alignment score ${visionScore}/100 (ESCALATE) — LEAD review recommended before EXEC`);
-    console.log(`   ⚠️  Score below 50 — consider addressing vision gaps before implementation`);
-  } else if (thresholdAction === 'gap_closure_sd') {
-    warnings.push(`Vision alignment score ${visionScore}/100 (GAP_CLOSURE) — corrective SD may be needed`);
-    console.log(`   ⚠️  Moderate vision gaps — review dimension scores for guidance`);
-  } else if (thresholdAction === 'minor_sd') {
-    console.log(`   ✅ Minor gaps only — proceed with awareness`);
+  // ── Score below threshold → check override, then hard block ─────────────
+  if (visionScore < threshold) {
+    const override = await checkOverride(sdKey, supabase);
+    if (override.active) {
+      console.log(`   ⚠️  Score ${visionScore}/100 below ${sdType} threshold ${threshold} — OVERRIDE ACTIVE`);
+      console.log(`   📋 Chairman justification: ${override.justification}`);
+      const dimWarnings = getDimensionWarnings(dimensionScores);
+      dimWarnings.forEach(w => console.log(`   ⚠️  ${w}`));
+      return {
+        valid: true,
+        score: 100,
+        details: `Vision score ${visionScore}/100 below ${sdType} threshold ${threshold} — OVERRIDDEN (Chairman: ${override.justification})`,
+        warnings: dimWarnings,
+      };
+    }
+
+    console.log(`   ❌ Score ${visionScore}/100 BELOW ${sdType} threshold ${threshold} — handoff BLOCKED`);
+    console.log(`   💡 Improve vision alignment: node scripts/eva/vision-scorer.js --sd-id ${sdKey}`);
+    console.log('   💡 Or request Chairman override via validation_gate_registry');
+    return {
+      valid: false,
+      score: 0,
+      details: `Vision score ${visionScore}/100 does not meet ${sdType} threshold ${threshold}/100`,
+      remediation: `Score must reach ${threshold}/100 for ${sdType} SDs. Run: node scripts/eva/vision-scorer.js --sd-id ${sdKey}`,
+      warnings: [],
+    };
+  }
+
+  // ── Score passes — check per-dimension warnings ──────────────────────────
+  const dimWarnings = getDimensionWarnings(dimensionScores);
+  dimWarnings.forEach(w => console.log(`   ⚠️  ${w}`));
+
+  if (dimWarnings.length === 0) {
+    console.log(`   ✅ Score ${visionScore}/100 meets ${sdType} threshold ${threshold}`);
   } else {
-    console.log(`   ✅ Strong vision alignment`);
+    console.log(`   ✅ Score ${visionScore}/100 meets threshold — ${dimWarnings.length} dimension(s) below ${DIMENSION_WARNING_THRESHOLD}`);
   }
 
   return {
     valid: true,
-    score: 100,  // Always pass — soft gate
-    details: `Vision score: ${visionScore}/100 (${thresholdAction || 'unknown'})`,
-    warnings,
+    score: 100,
+    details: `Vision score: ${visionScore}/100 (${thresholdAction || 'unknown'}) — meets ${sdType} threshold ${threshold}`,
+    warnings: dimWarnings,
   };
 }
 
@@ -95,12 +212,8 @@ export async function validateVisionScore(sd, supabase) {
 export function createVisionScoreGate(supabase) {
   return {
     name: 'GATE_VISION_SCORE',
-    validator: async (ctx) => {
-      console.log('\n🔍 GATE: Vision Alignment Score');
-      console.log('-'.repeat(50));
-      return validateVisionScore(ctx.sd, supabase);
-    },
-    required: false,   // Soft gate — never blocks
-    remediation: 'Run `node scripts/eva/vision-scorer.js --sd-id <SD-KEY>` to generate a vision alignment score',
+    validator: async (ctx) => validateVisionScore(ctx.sd, supabase),
+    required: true,   // Hard gate — blocks when score insufficient or absent
+    remediation: 'Run `node scripts/eva/vision-scorer.js --sd-id <SD-KEY>` to generate a vision alignment score, then retry the handoff.',
   };
 }

--- a/tests/unit/vision-score-gate.test.js
+++ b/tests/unit/vision-score-gate.test.js
@@ -1,0 +1,335 @@
+/**
+ * Unit Tests: Vision Score Gate (Hard Enforcement)
+ * SD: SD-MAN-INFRA-VISION-SCORE-GATE-HARDEN-001
+ *
+ * Covers: SD_TYPE_THRESHOLDS map, blocking behavior, dimension warnings,
+ *         override mechanism, createVisionScoreGate factory.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  validateVisionScore,
+  createVisionScoreGate,
+  SD_TYPE_THRESHOLDS,
+  DIMENSION_WARNING_THRESHOLD,
+} from '../../scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Build a minimal SD object for testing. */
+function makeSD(sdKey, sdType, visionScore = null, dimensionScores = null) {
+  return {
+    sd_key: sdKey,
+    sd_type: sdType,
+    vision_score: visionScore,
+    vision_score_action: visionScore !== null ? (visionScore >= 93 ? 'accept' : visionScore >= 83 ? 'minor_sd' : 'gap_closure_sd') : null,
+    dimension_scores: dimensionScores,
+  };
+}
+
+/** Build a Supabase stub that returns a specific vision score record. */
+function makeSupabaseWithScore(totalScore, dimensionScores = null, thresholdAction = null) {
+  const record = totalScore !== null
+    ? [{ total_score: totalScore, threshold_action: thresholdAction || 'accept', dimension_scores: dimensionScores, scored_at: new Date().toISOString() }]
+    : [];
+
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: record }),
+    }),
+  };
+}
+
+/** Build a Supabase stub that returns an override row. */
+function makeSupabaseWithOverride(justification) {
+  let callCount = 0;
+  return {
+    from: vi.fn().mockImplementation((table) => {
+      callCount++;
+      // First call: eva_vision_scores → return low score to trigger threshold check
+      // Override call: validation_gate_registry → return override
+      if (table === 'eva_vision_scores') {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: [{ total_score: 40, threshold_action: 'escalate', dimension_scores: null, scored_at: new Date().toISOString() }] }),
+        };
+      }
+      // validation_gate_registry
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: justification ? [{ justification }] : [] }),
+      };
+    }),
+  };
+}
+
+/** Supabase stub that throws on every call (simulates DB error). */
+function makeFailingSupabase() {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockRejectedValue(new Error('DB error')),
+    }),
+  };
+}
+
+// ─── Tests: SD_TYPE_THRESHOLDS map ────────────────────────────────────────────
+
+describe('SD_TYPE_THRESHOLDS', () => {
+  it('tier-1 types require 90', () => {
+    expect(SD_TYPE_THRESHOLDS.feature).toBe(90);
+    expect(SD_TYPE_THRESHOLDS.governance).toBe(90);
+    expect(SD_TYPE_THRESHOLDS.security).toBe(90);
+  });
+
+  it('tier-2 types require 80', () => {
+    expect(SD_TYPE_THRESHOLDS.infrastructure).toBe(80);
+    expect(SD_TYPE_THRESHOLDS.enhancement).toBe(80);
+  });
+
+  it('tier-3 types require 70', () => {
+    for (const t of ['maintenance', 'protocol', 'bugfix', 'fix', 'documentation', 'refactor', 'orchestrator']) {
+      expect(SD_TYPE_THRESHOLDS[t]).toBe(70);
+    }
+  });
+
+  it('default threshold is 80', () => {
+    expect(SD_TYPE_THRESHOLDS._default).toBe(80);
+  });
+});
+
+// ─── Tests: No vision score → hard block ──────────────────────────────────────
+
+describe('validateVisionScore — no score present', () => {
+  it('blocks when SD has no cached score and DB returns nothing', async () => {
+    const sd = makeSD('SD-TEST-001', 'feature');
+    const supabase = makeSupabaseWithScore(null);
+
+    const result = await validateVisionScore(sd, supabase);
+
+    expect(result.valid).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.details).toMatch(/no vision alignment score/i);
+    expect(result.remediation).toMatch(/vision-scorer\.js/);
+  });
+
+  it('blocks when supabase is null and no cached score', async () => {
+    const sd = makeSD('SD-TEST-002', 'infrastructure');
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(false);
+    expect(result.score).toBe(0);
+  });
+
+  it('blocks when DB throws and no cached score', async () => {
+    const sd = makeSD('SD-TEST-003', 'infrastructure');
+    const result = await validateVisionScore(sd, makeFailingSupabase());
+
+    expect(result.valid).toBe(false);
+    expect(result.score).toBe(0);
+  });
+});
+
+// ─── Tests: Score below threshold → hard block ────────────────────────────────
+
+describe('validateVisionScore — score below threshold', () => {
+  it('blocks feature SD at score=89 (threshold=90)', async () => {
+    const sd = makeSD('SD-TEST-004', 'feature', 89);
+
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(false);
+    expect(result.score).toBe(0);
+    expect(result.details).toMatch(/89.+90/);
+    expect(result.remediation).toMatch(/vision-scorer/);
+  });
+
+  it('blocks infrastructure SD at score=79 (threshold=80)', async () => {
+    const sd = makeSD('SD-TEST-005', 'infrastructure', 79);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(false);
+    expect(result.details).toMatch(/79.+80/);
+  });
+
+  it('blocks fix SD at score=69 (threshold=70)', async () => {
+    const sd = makeSD('SD-TEST-006', 'fix', 69);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(false);
+    expect(result.details).toMatch(/69.+70/);
+  });
+
+  it('unknown sd_type defaults to threshold=80, blocks at 79', async () => {
+    const sd = makeSD('SD-TEST-007', 'custom_unknown', 79);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ─── Tests: Score at or above threshold → passes ─────────────────────────────
+
+describe('validateVisionScore — score meets threshold', () => {
+  it('passes feature SD at exactly 90', async () => {
+    const sd = makeSD('SD-TEST-008', 'feature', 90);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(true);
+    expect(result.score).toBe(100);
+  });
+
+  it('passes infrastructure SD at exactly 80 (boundary)', async () => {
+    const sd = makeSD('SD-TEST-009', 'infrastructure', 80);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes fix SD at exactly 70', async () => {
+    const sd = makeSD('SD-TEST-010', 'fix', 70);
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('prefers cached score over DB lookup', async () => {
+    const sd = makeSD('SD-TEST-011', 'infrastructure', 85); // cached=85 (passes)
+    const supabase = makeSupabaseWithScore(40); // DB would return 40 (fails)
+
+    const result = await validateVisionScore(sd, supabase);
+
+    // Should use cached 85, not DB 40
+    expect(result.valid).toBe(true);
+    expect(supabase.from).not.toHaveBeenCalled(); // never hit DB
+  });
+});
+
+// ─── Tests: Per-dimension warnings ────────────────────────────────────────────
+
+describe('validateVisionScore — per-dimension warnings', () => {
+  it('emits warning for dimension below 75 when overall score passes', async () => {
+    const dims = { strategic_alignment: 70, innovation: 80 };
+    const sd = makeSD('SD-TEST-012', 'feature', 92, dims);
+
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toMatch(/strategic_alignment/);
+    expect(result.warnings[0]).toMatch(/70/);
+  });
+
+  it('emits multiple warnings when multiple dimensions fail', async () => {
+    const dims = { dim_a: 60, dim_b: 70, dim_c: 90 };
+    const sd = makeSD('SD-TEST-013', 'feature', 95, dims);
+
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  it('no warnings when all dimensions >= 75', async () => {
+    const dims = { dim_a: 75, dim_b: 90, dim_c: 100 };
+    const sd = makeSD('SD-TEST-014', 'feature', 95, dims);
+
+    const result = await validateVisionScore(sd, null);
+
+    expect(result.valid).toBe(true);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('DIMENSION_WARNING_THRESHOLD is 75', () => {
+    expect(DIMENSION_WARNING_THRESHOLD).toBe(75);
+  });
+});
+
+// ─── Tests: Override mechanism ────────────────────────────────────────────────
+
+describe('validateVisionScore — Chairman override', () => {
+  it('override with non-empty justification bypasses hard block', async () => {
+    const sd = makeSD('SD-TEST-015', 'feature'); // no cached score → DB returns 40
+    const supabase = makeSupabaseWithOverride('Approved by Chairman for strategic priority Q1');
+
+    const result = await validateVisionScore(sd, supabase);
+
+    expect(result.valid).toBe(true);
+    expect(result.details).toMatch(/overridden/i);
+    expect(result.details).toMatch(/chairman/i);
+  });
+
+  it('override with empty justification does NOT bypass block', async () => {
+    const sd = makeSD('SD-TEST-016', 'feature');
+    const supabase = makeSupabaseWithOverride(''); // empty = not accepted
+
+    const result = await validateVisionScore(sd, supabase);
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('override does not apply when score already passes threshold', async () => {
+    // Score 95 already passes feature threshold 90 — override irrelevant
+    const sd = makeSD('SD-TEST-017', 'feature', 95);
+    const supabase = makeSupabaseWithOverride('Some justification');
+
+    const result = await validateVisionScore(sd, supabase);
+
+    // Valid because score passes, not because of override
+    expect(result.valid).toBe(true);
+    expect(result.details).not.toMatch(/overridden/i);
+  });
+
+  it('override query failure (DB error) is fail-closed — gate still enforces', async () => {
+    // SD score too low, override DB throws → should still block
+    const sd = makeSD('SD-TEST-018', 'feature', 50);
+    const failSupabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockRejectedValue(new Error('DB error')),
+      }),
+    };
+
+    const result = await validateVisionScore(sd, failSupabase);
+
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ─── Tests: createVisionScoreGate factory ─────────────────────────────────────
+
+describe('createVisionScoreGate', () => {
+  it('returns a gate with required=true (hard gate)', () => {
+    const gate = createVisionScoreGate(null);
+    expect(gate.required).toBe(true);
+  });
+
+  it('gate name is GATE_VISION_SCORE', () => {
+    const gate = createVisionScoreGate(null);
+    expect(gate.name).toBe('GATE_VISION_SCORE');
+  });
+
+  it('validator calls validateVisionScore via ctx.sd', async () => {
+    const sd = makeSD('SD-TEST-019', 'infrastructure', 85);
+    const gate = createVisionScoreGate(null);
+
+    const result = await gate.validator({ sd });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('remediation message contains vision-scorer.js', () => {
+    const gate = createVisionScoreGate(null);
+    expect(gate.remediation).toMatch(/vision-scorer\.js/);
+  });
+});


### PR DESCRIPTION
## Summary

- **Hardens** `scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js` from a soft informational gate (always returned `valid=true, score=100`) to a hard SD-type-aware blocking gate
- **SD-type thresholds**: feature/governance/security → ≥90, infrastructure/enhancement → ≥80, maintenance/protocol/bugfix/fix/documentation/refactor/orchestrator → ≥70
- **Missing score** now hard-blocks with remediation command (`node scripts/eva/vision-scorer.js`)
- **Chairman override** via `validation_gate_registry` row with non-empty justification (fail-closed if table absent)
- **Per-dimension warnings** emitted for any dimension < 75 (non-blocking when overall score passes)
- Changed `required: false` → `required: true`

## Files Changed

- `scripts/modules/handoff/executors/lead-to-plan/gates/vision-score.js` — gate implementation
- `tests/unit/vision-score-gate.test.js` — 27 unit tests (all passing)

## Test plan

- [x] 27 unit tests covering all threshold tiers, boundary conditions, override mechanism, dimension warnings, DB error handling
- [x] `npm run test:unit tests/unit/vision-score-gate.test.js` → 27/27 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>