### PR TITLE
feat(vision-governance): Chairman Vision Dashboard (/chairman/vision)

### DIFF
--- a/docs/implementations/chairman-vision-dashboard.md
+++ b/docs/implementations/chairman-vision-dashboard.md
@@ -1,0 +1,32 @@
+# Chairman Vision Dashboard Implementation
+
+**SD**: SD-MAN-FEAT-CHAIRMAN-DASHBOARD-VISION-001
+**Route**: `/chairman/vision`
+**Target**: EHG frontend app (`../ehg/`)
+
+## Files Created
+
+### New Components (`src/components/chairman-v2/VisionDashboard/`)
+- `VisionDashboard.tsx` — compositor, composes all 4 sections
+- `VisionScoreCard.tsx` — portfolio vision score (0-100) with delta vs 30d
+- `DimensionBreakdownPanel.tsx` — per-dimension average scores, sorted ascending (weakest first)
+- `VisionTrendChart.tsx` — Recharts LineChart with 30/60/90d toggle
+- `CorrectiveSDsTable.tsx` — active corrective SDs table with info drawer
+- `index.ts` — barrel exports
+
+### New Hook (`src/hooks/`)
+- `useVisionDashboardData.ts` — fetches eva_vision_scores + strategic_directives_v2
+
+### Modified Files
+- `src/routes/chairmanRoutes.tsx` — added `/chairman/vision` route
+- `src/components/chairman-v2/ChairmanLayout.tsx` — added Vision nav item (Eye icon)
+
+## Data Sources
+- `eva_vision_scores` — portfolio score, dimension breakdown, trend (direct Supabase query)
+- `strategic_directives_v2` WHERE `vision_origin_score_id IS NOT NULL AND status NOT IN (completed,cancelled)`
+
+## Key Implementation Notes
+- `dimension_scores` is a JSONB **array** format: `[{dimension, score, weight, reasoning}]`
+- Latest score per SD = row with MAX(scored_at) per sd_id
+- Delta vs 30d ago: compare current avg to avg of rows older than 30 days ago
+- EHG app has no git repo — changes live on disk at `C:\Users\rickf\Projects\_EHG\ehg\`


### PR DESCRIPTION
## Summary

- New `/chairman/vision` route in EHG frontend app
- 4 components in `src/components/chairman-v2/VisionDashboard/`:
  - `VisionScoreCard` — portfolio avg score (0-100) with ±delta vs 30d ago
  - `DimensionBreakdownPanel` — per-dimension avg scores, sorted weakest-first, color-coded
  - `VisionTrendChart` — Recharts LineChart with 30/60/90d toggle
  - `CorrectiveSDsTable` — active SDs with `vision_origin_score_id`, info drawer on click
- New `useVisionDashboardData` hook — aggregates `eva_vision_scores` + corrective SDs
- Route registered in `chairmanRoutes.tsx`; Vision nav link added to `ChairmanLayout.tsx`
- Note: EHG app has no git tracking — component files live at `../ehg/src/`; implementation manifest in `docs/implementations/chairman-vision-dashboard.md`

## Data source
- `eva_vision_scores.dimension_scores` is a JSONB **array** `[{dimension, score, weight}]` (not object keyed by name)
- Latest score per SD = `MAX(scored_at)` per `sd_id`
- Corrective SDs: `WHERE vision_origin_score_id IS NOT NULL AND status NOT IN (completed, cancelled)`

## Test plan
- [x] DESIGN analysis: component sizing (all 100-450 LOC), WCAG 2.1 AA, Shadcn patterns validated
- [x] DATABASE analysis: no schema changes needed, RLS allows reads, existing indexes adequate
- [x] TESTING analysis: 22 E2E + 29 unit tests defined; implementation follows chairman-v2 patterns
- [ ] E2E tests to be written against Playwright mock pattern from `tests/e2e/chairman-dashboard-v2.spec.ts`

SD: SD-MAN-FEAT-CHAIRMAN-DASHBOARD-VISION-001
Parent: SD-MAN-ORCH-EVA-VISION-IMPROVEMENT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>