### PR TITLE
feat(vision-governance): inject live VGAP patterns into CLAUDE_LEAD.md and CLAUDE_EXEC.md

### DIFF
--- a/scripts/modules/claude-md-generator/file-generators.js
+++ b/scripts/modules/claude-md-generator/file-generators.js
@@ -212,7 +212,7 @@ ${subAgentSection}
  * @returns {string} Generated markdown content
  */
 function generateLead(data, fileMapping) {
-  const { protocol, autonomousDirectives } = data;
+  const { protocol, autonomousDirectives, visionGapInsights = [] } = data;
   const sections = protocol.sections;
   const { today, time } = getMetadata(protocol);
 
@@ -220,6 +220,17 @@ function generateLead(data, fileMapping) {
   const leadContent = leadSections.map(s => formatSection(s)).join('\n\n');
 
   const directivesSection = generateAutonomousDirectivesSection(autonomousDirectives, 'LEAD');
+
+  // SD-LEO-INFRA-VISION-PROTOCOL-FEEDBACK-001: live VGAP injection
+  const visionGapSection = visionGapInsights.length > 0
+    ? `## ⚠️ Current Vision Gaps (Live — from issue_patterns)\n\n` +
+      `| Pattern ID | Dimension / Summary | Severity |\n` +
+      `|------------|--------------------|-----------|\n` +
+      visionGapInsights.map(g =>
+        `| ${g.pattern_id} | ${g.issue_summary ?? g.category} | ${g.severity?.toUpperCase() ?? 'unknown'} |`
+      ).join('\n') +
+      `\n\n**Action**: When approving SDs, consider whether the SD addresses or exacerbates these gaps.\n`
+    : '';
 
   // RCA Mandate is in the router — not duplicated here (LEAN LEAD)
 
@@ -235,7 +246,7 @@ function generateLead(data, fileMapping) {
 ---
 
 ${directivesSection}
-
+${visionGapSection ? '\n' + visionGapSection : ''}
 ${leadContent}
 
 ---
@@ -311,7 +322,7 @@ ${generateValidationRules(validationRules)}
  * @returns {string} Generated markdown content
  */
 function generateExec(data, fileMapping) {
-  const { protocol, schemaConstraints, processScripts, autonomousDirectives } = data;
+  const { protocol, schemaConstraints, processScripts, autonomousDirectives, visionGapInsights = [] } = data;
   const sections = protocol.sections;
   const { today, time } = getMetadata(protocol);
 
@@ -321,6 +332,15 @@ function generateExec(data, fileMapping) {
   const constraintsSection = generateSchemaConstraintsSection(schemaConstraints);
   const scriptsSection = generateProcessScriptsSection(processScripts);
   const directivesSection = generateAutonomousDirectivesSection(autonomousDirectives, 'EXEC');
+
+  // SD-LEO-INFRA-VISION-PROTOCOL-FEEDBACK-001: live VGAP implementation reminders
+  const visionRemindersSection = visionGapInsights.length > 0
+    ? `## 🔍 Implementation Reminders — Active Vision Gaps\n\n` +
+      visionGapInsights.map(g =>
+        `- **${g.pattern_id}** (${g.severity?.toUpperCase() ?? 'UNKNOWN'}): ${g.issue_summary ?? g.category} — ensure implementation does not worsen this gap`
+      ).join('\n') +
+      `\n`
+    : '';
 
   // RCA Mandate is in the router — not duplicated here (LEAN EXEC)
 
@@ -336,7 +356,7 @@ function generateExec(data, fileMapping) {
 ---
 
 ${directivesSection}
-
+${visionRemindersSection ? '\n' + visionRemindersSection : ''}
 ${execContent}
 
 ${constraintsSection}

--- a/scripts/modules/claude-md-generator/index.js
+++ b/scripts/modules/claude-md-generator/index.js
@@ -23,7 +23,8 @@ import {
   getRecentRetrospectives,
   getGateHealth,
   getPendingProposals,
-  getAutonomousDirectives
+  getAutonomousDirectives,
+  getVisionGapInsights
 } from './db-queries.js';
 
 import {
@@ -165,6 +166,8 @@ class CLAUDEMDGeneratorV3 {
       const gateHealth = await getGateHealth(this.supabase);
       const pendingProposals = await getPendingProposals(this.supabase, 5);
       const autonomousDirectives = await getAutonomousDirectives(this.supabase);
+      // SD-LEO-INFRA-VISION-PROTOCOL-FEEDBACK-001: live VGAP data for protocol injection
+      const visionGapInsights = await getVisionGapInsights(this.supabase, 3);
 
       const data = {
         protocol,
@@ -178,7 +181,8 @@ class CLAUDEMDGeneratorV3 {
         recentRetrospectives,
         gateHealth,
         pendingProposals,
-        autonomousDirectives
+        autonomousDirectives,
+        visionGapInsights
       };
 
       // Initialize manifest

--- a/tests/unit/claude-md-generator/vision-gap-insights.test.js
+++ b/tests/unit/claude-md-generator/vision-gap-insights.test.js
@@ -1,0 +1,92 @@
+/**
+ * Tests for vision gap insights injection
+ * SD-LEO-INFRA-VISION-PROTOCOL-FEEDBACK-001
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+
+// Mock all heavy dependencies before importing
+vi.mock('dotenv', () => ({ config: vi.fn(), default: { config: vi.fn() } }));
+vi.mock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => ({})) }));
+vi.mock('fs', () => ({ default: { existsSync: vi.fn(() => true), readFileSync: vi.fn(() => '{}'), writeFileSync: vi.fn() }, existsSync: vi.fn(() => true), readFileSync: vi.fn(() => '{}'), writeFileSync: vi.fn() }));
+vi.mock('child_process', () => ({ execSync: vi.fn(() => 'abc12345') }));
+
+let generateLead, generateExec;
+
+beforeAll(async () => {
+  const mod = await import('../../../scripts/modules/claude-md-generator/file-generators.js');
+  generateLead = mod.generateLead;
+  generateExec = mod.generateExec;
+});
+
+const MOCK_DATA_BASE = {
+  protocol: {
+    id: 'p1', version: '4.3.3',
+    sections: [],
+    updated_at: '2026-02-19T00:00:00Z',
+    name: 'LEO'
+  },
+  autonomousDirectives: [],
+  schemaConstraints: [],
+  processScripts: [],
+  agents: [],
+  subAgents: [],
+};
+
+const MOCK_GAPS = [
+  { pattern_id: 'VGAP-A04', issue_summary: 'event_rounds_priority_queue_work_routing', category: 'infrastructure', severity: 'high' },
+  { pattern_id: 'VGAP-V05', issue_summary: 'cross_stage_data_contracts', category: 'infrastructure', severity: 'critical' },
+];
+
+describe('generateLead — vision gap injection', () => {
+  it('injects Current Vision Gaps section when visionGapInsights has entries', () => {
+    const output = generateLead({ ...MOCK_DATA_BASE, visionGapInsights: MOCK_GAPS }, {});
+    expect(output).toContain('Current Vision Gaps');
+    expect(output).toContain('VGAP-A04');
+    expect(output).toContain('VGAP-V05');
+    expect(output).toContain('HIGH');
+    expect(output).toContain('CRITICAL');
+  });
+
+  it('omits Current Vision Gaps section when visionGapInsights is empty', () => {
+    const output = generateLead({ ...MOCK_DATA_BASE, visionGapInsights: [] }, {});
+    expect(output).not.toContain('Current Vision Gaps');
+    expect(output).not.toContain('VGAP-');
+  });
+
+  it('omits section when visionGapInsights is absent (backward compat)', () => {
+    const output = generateLead({ ...MOCK_DATA_BASE }, {});
+    expect(output).not.toContain('Current Vision Gaps');
+  });
+
+  it('contains standard LEAD header fields regardless of gaps', () => {
+    const output = generateLead({ ...MOCK_DATA_BASE, visionGapInsights: MOCK_GAPS }, {});
+    expect(output).toContain('CLAUDE_LEAD.md - LEAD Phase Operations');
+    expect(output).toContain('LEO 4.3.3');
+  });
+});
+
+describe('generateExec — implementation reminders injection', () => {
+  it('injects Implementation Reminders section when visionGapInsights has entries', () => {
+    const output = generateExec({ ...MOCK_DATA_BASE, visionGapInsights: MOCK_GAPS }, {});
+    expect(output).toContain('Implementation Reminders');
+    expect(output).toContain('VGAP-A04');
+    expect(output).toContain('event_rounds_priority_queue_work_routing');
+  });
+
+  it('omits Implementation Reminders section when visionGapInsights is empty', () => {
+    const output = generateExec({ ...MOCK_DATA_BASE, visionGapInsights: [] }, {});
+    expect(output).not.toContain('Implementation Reminders');
+  });
+
+  it('omits section when visionGapInsights is absent (backward compat)', () => {
+    const output = generateExec({ ...MOCK_DATA_BASE }, {});
+    expect(output).not.toContain('Implementation Reminders');
+  });
+
+  it('contains standard EXEC header fields regardless of gaps', () => {
+    const output = generateExec({ ...MOCK_DATA_BASE, visionGapInsights: MOCK_GAPS }, {});
+    expect(output).toContain('CLAUDE_EXEC.md - EXEC Phase Operations');
+    expect(output).toContain('LEO 4.3.3');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `getVisionGapInsights()` to `scripts/modules/claude-md-generator/db-queries.js`: queries `issue_patterns WHERE pattern_id LIKE 'VGAP-%' AND status='active'`, limit 3, non-blocking (returns `[]` on failure)
- `index.js`: import and call `getVisionGapInsights()` during `generate()`, add to `data` object
- `file-generators.js`: `generateLead()` injects **Current Vision Gaps** table into `CLAUDE_LEAD.md`; `generateExec()` injects **Implementation Reminders** bullets into `CLAUDE_EXEC.md`
- Both sections omit gracefully when no active VGAP patterns exist
- Backward-compatible: `visionGapInsights` defaults to `[]` so callers without it see no change

## Test plan
- [x] 8/8 unit tests passing (`tests/unit/claude-md-generator/vision-gap-insights.test.js`)
- [x] Tests cover: injection with gaps, empty array, absent field, standard header fields

SD: SD-LEO-INFRA-VISION-PROTOCOL-FEEDBACK-001
Parent: SD-MAN-ORCH-EVA-VISION-IMPROVEMENT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>