### PR TITLE
docs(learn): fix RETROSPECTIVE_QUALITY_GATE newest-row update pattern (LEARN-028)

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEARN-FIX-ADDRESS-PAT-AUTO-026",
-  "expectedBranch": "feat/SD-LEARN-FIX-ADDRESS-PAT-AUTO-026",
-  "createdAt": "2026-02-19T13:27:01.322Z",
+  "sdKey": "SD-LEARN-FIX-ADDRESS-PAT-AUTO-028",
+  "expectedBranch": "feat/SD-LEARN-FIX-ADDRESS-PAT-AUTO-028",
+  "createdAt": "2026-02-19T18:37:16.164Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }


### PR DESCRIPTION
## Summary

Documents the root cause of PAT-AUTO-97a78c88 (RETROSPECTIVE_QUALITY_GATE failed: score 42-53/100, 4 occurrences) and adds the fix to MEMORY.md.

**Root cause**: The gate reads the NEWEST retrospective row (ORDER BY created_at DESC), not the original. Each failed PLAN-TO-LEAD auto-creates a new row with boilerplate content.

**Fix in MEMORY.md**:
- Warning: update ALL retrospective rows for the SD, not just the original
- SQL pattern: `SELECT id FROM retrospectives WHERE sd_id=X ORDER BY created_at DESC LIMIT 1`
- Status constraint note: only `PUBLISHED` is valid (not `completed`)

**Database changes (not in this PR)**:
- PAT-AUTO-97a78c88 marked `resolved` in `issue_patterns`
- All 2 retrospective rows for SD-028 enriched with SD-specific content
- All 4 LEO Protocol handoffs accepted (LEAD→PLAN→EXEC→PLAN→LEAD→FINAL, 96%)

## Test plan
- [x] MEMORY.md updated with RETROSPECTIVE_QUALITY_GATE newest-row warning
- [x] PAT-AUTO-97a78c88 status=resolved in issue_patterns
- [x] LEAD-FINAL-APPROVAL passed at 96%
- [ ] Monitor next 2 LEARN SDs to verify gate passes on ≤2 attempts without manual patching

🤖 Generated with [Claude Code](https://claude.com/claude-code)