### PR TITLE
fix(learn): correct scoreSDAtConception import path

### DIFF
--- a/scripts/modules/learning/sd-creation.js
+++ b/scripts/modules/learning/sd-creation.js
@@ -117,7 +117,7 @@ export async function createSDFromLearning(items, type, options = {}) {
 
   // SD-MAN-INFRA-VISION-SCORING-COVERAGE-001: score at conception so GATE_VISION_SCORE doesn't block LEAD-TO-PLAN
   // Non-blocking — failure logs a warning but never fails SD creation
-  import('../../../leo-create-sd.js')
+  import('../../leo-create-sd.js')
     .then(({ scoreSDAtConception }) => {
       if (typeof scoreSDAtConception === 'function') {
         return scoreSDAtConception(data.sd_key, data.title, sdData.description || '', supabase);


### PR DESCRIPTION
## Summary
- Fix wrong relative import path in `scripts/modules/learning/sd-creation.js`
- `../../../leo-create-sd.js` → `../../leo-create-sd.js`
- Resolves: "Cannot find module EHG_Engineer/leo-create-sd.js" when /learn creates SDs

## Test plan
- [x] /learn SD creation no longer warns about missing module

🤖 Generated with [Claude Code](https://claude.com/claude-code)