### PR TITLE
fix(rubric): read .analysis with .root_cause fallback in retrospective quality rubric

### DIFF
--- a/scripts/modules/rubrics/retrospective-quality-rubric.js
+++ b/scripts/modules/rubrics/retrospective-quality-rubric.js
@@ -430,7 +430,7 @@ Duration: ${retrospective.duration_days || 'Unknown'} days`;
         if (typeof area === 'string') {
           return `${idx + 1}. ${area}`;
         } else if (area.area) {
-          const rootCause = area.root_cause ? `\n   Root Cause: ${area.root_cause}` : '';
+          const rootCause = (area.analysis || area.root_cause) ? `\n   Root Cause: ${area.analysis || area.root_cause}` : '';
           const prevention = area.prevention ? `\n   Prevention: ${area.prevention}` : '';
           return `${idx + 1}. ${area.area}${rootCause}${prevention}`;
         }


### PR DESCRIPTION
## Summary

- Fixes PAT-AUTO-c85a2f8d: RETROSPECTIVE_QUALITY_GATE scoring 52/100 (3 occurrences)
- Root cause: `retrospective-quality-rubric.js:433` read `.root_cause` but `retrospective-enricher.js` writes `.analysis`
- AI evaluator received "Root Cause: undefined" → improvement_area_depth scored 1-3/10
- Fix: `(area.analysis || area.root_cause)` fallback — handles both enricher and legacy formats
- 1 line changed, backward compatible

## Test plan

- [x] Rubric formatter correctly reads `.analysis` field when present
- [x] Falls back to `.root_cause` for legacy retrospective data
- [x] Smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)