### PR TITLE
feat(eva): add CLI commands for vision governance monitoring

### DIFF
--- a/scripts/eva/eva-gaps.mjs
+++ b/scripts/eva/eva-gaps.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * eva-gaps.mjs
+ * Lists vision dimensions scoring below threshold across the portfolio.
+ * Aggregates dimension_scores JSONB from eva_vision_scores and ranks by worst.
+ *
+ * Usage:
+ *   node scripts/eva/eva-gaps.mjs [--threshold <N>]
+ *
+ * Part of: SD-CORR-VIS-V06-CLI-WORKFLOW-001
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, '../../.env') });
+
+const threshold = parseInt(process.argv.find((a, i) => process.argv[i - 1] === '--threshold') || '70', 10);
+
+async function main() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+
+  const supabase = createClient(url, key);
+  const { data, error } = await supabase
+    .from('eva_vision_scores')
+    .select('sd_id, dimension_scores, total_score, created_by')
+    .not('created_by', 'eq', 'synthetic-LEAD-workaround')
+    .order('scored_at', { ascending: false });
+
+  if (error) { console.error('Query error:', error.message); process.exit(1); }
+  if (!data || data.length === 0) { console.log('No vision scores found.'); process.exit(0); }
+
+  // Aggregate dimension scores across all SDs
+  const dims = {};
+  for (const row of data) {
+    if (!row.dimension_scores || typeof row.dimension_scores !== 'object') continue;
+    for (const [key, val] of Object.entries(row.dimension_scores)) {
+      const score = typeof val === 'number' ? val : val?.score;
+      if (typeof score !== 'number') continue;
+      if (!dims[key]) dims[key] = { scores: [], belowThreshold: 0 };
+      dims[key].scores.push(score);
+      if (score < threshold) dims[key].belowThreshold++;
+    }
+  }
+
+  // Calculate averages and sort by worst
+  const ranked = Object.entries(dims)
+    .map(([key, d]) => ({
+      dimension: key,
+      avg: Math.round(d.scores.reduce((a, b) => a + b, 0) / d.scores.length),
+      min: Math.min(...d.scores),
+      max: Math.max(...d.scores),
+      count: d.scores.length,
+      belowThreshold: d.belowThreshold,
+    }))
+    .sort((a, b) => a.avg - b.avg);
+
+  console.log('\n\x1b[1m\x1b[36m═══════════════════════════════════════════════════════════\x1b[0m');
+  console.log('\x1b[1m VISION DIMENSION GAP ANALYSIS\x1b[0m');
+  console.log(`\x1b[2m Threshold: ${threshold}/100 | SDs scored: ${data.length}\x1b[0m`);
+  console.log('\x1b[36m═══════════════════════════════════════════════════════════\x1b[0m\n');
+
+  if (ranked.length === 0) {
+    console.log('No dimension scores found in eva_vision_scores.');
+    process.exit(0);
+  }
+
+  const gapDims = ranked.filter(d => d.avg < threshold);
+  const passDims = ranked.filter(d => d.avg >= threshold);
+
+  if (gapDims.length > 0) {
+    console.log(`\x1b[31m\x1b[1m  BELOW THRESHOLD (${gapDims.length} dimensions)\x1b[0m\n`);
+    for (const d of gapDims) {
+      const bar = '█'.repeat(Math.round(d.avg / 5)) + '░'.repeat(20 - Math.round(d.avg / 5));
+      console.log(`  \x1b[31m${d.dimension.padEnd(45)}\x1b[0m ${bar} \x1b[1m${d.avg}\x1b[0m/100`);
+      console.log(`  \x1b[2m  min: ${d.min} | max: ${d.max} | n: ${d.count} | below ${threshold}: ${d.belowThreshold}\x1b[0m\n`);
+    }
+  }
+
+  if (passDims.length > 0) {
+    console.log(`\x1b[32m\x1b[1m  ABOVE THRESHOLD (${passDims.length} dimensions)\x1b[0m\n`);
+    for (const d of passDims) {
+      const bar = '█'.repeat(Math.round(d.avg / 5)) + '░'.repeat(20 - Math.round(d.avg / 5));
+      console.log(`  \x1b[32m${d.dimension.padEnd(45)}\x1b[0m ${bar} \x1b[1m${d.avg}\x1b[0m/100`);
+    }
+  }
+
+  console.log(`\n\x1b[2m  Portfolio: ${gapDims.length} gaps | ${passDims.length} passing | ${ranked.length} total dimensions\x1b[0m\n`);
+}
+
+main().catch(err => { console.error(err.message); process.exit(1); });

--- a/scripts/eva/eva-portfolio.mjs
+++ b/scripts/eva/eva-portfolio.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * eva-portfolio.mjs
+ * Portfolio-level vision health dashboard.
+ * Shows avg score, tier distribution, top/bottom SDs.
+ *
+ * Usage:
+ *   node scripts/eva/eva-portfolio.mjs [--exclude-synthetic]
+ *
+ * Part of: SD-CORR-VIS-V06-CLI-WORKFLOW-001
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, '../../.env') });
+
+const excludeSynthetic = process.argv.includes('--exclude-synthetic');
+
+async function main() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+
+  const supabase = createClient(url, key);
+  let query = supabase
+    .from('eva_vision_scores')
+    .select('sd_id, total_score, threshold_action, created_by, scored_at')
+    .order('scored_at', { ascending: false });
+
+  if (excludeSynthetic) {
+    query = query.not('created_by', 'in', '("synthetic-LEAD-workaround","manual-chairman-override")');
+  }
+
+  const { data, error } = await query;
+  if (error) { console.error('Query error:', error.message); process.exit(1); }
+  if (!data || data.length === 0) { console.log('No vision scores found.'); process.exit(0); }
+
+  // Deduplicate: keep latest score per SD
+  const latest = new Map();
+  for (const row of data) {
+    if (!latest.has(row.sd_id)) latest.set(row.sd_id, row);
+  }
+  const scores = [...latest.values()];
+
+  const avg = Math.round(scores.reduce((a, r) => a + r.total_score, 0) / scores.length * 10) / 10;
+  const min = Math.min(...scores.map(r => r.total_score));
+  const max = Math.max(...scores.map(r => r.total_score));
+
+  // Tier distribution
+  const tiers = { accept: [], minor_sd: [], gap_closure_sd: [], escalate: [] };
+  for (const s of scores) {
+    const tier = tiers[s.threshold_action] || tiers.escalate;
+    tier.push(s);
+  }
+
+  // Top/bottom SDs
+  const sorted = [...scores].sort((a, b) => a.total_score - b.total_score);
+  const bottom5 = sorted.slice(0, 5);
+  const top5 = sorted.slice(-5).reverse();
+
+  console.log('\n\x1b[1m\x1b[36m═══════════════════════════════════════════════════════════\x1b[0m');
+  console.log('\x1b[1m EVA VISION PORTFOLIO HEALTH\x1b[0m');
+  console.log(`\x1b[2m ${scores.length} unique SDs scored${excludeSynthetic ? ' (synthetic excluded)' : ''}\x1b[0m`);
+  console.log('\x1b[36m═══════════════════════════════════════════════════════════\x1b[0m\n');
+
+  // Summary bar
+  const avgBar = '█'.repeat(Math.round(avg / 5)) + '░'.repeat(20 - Math.round(avg / 5));
+  console.log(`  \x1b[1mPortfolio Average:\x1b[0m ${avgBar} \x1b[1m${avg}\x1b[0m/100`);
+  console.log(`  \x1b[2mRange: ${min} — ${max}\x1b[0m\n`);
+
+  // Tier distribution
+  console.log('\x1b[1m  TIER DISTRIBUTION\x1b[0m\n');
+  const tierConfig = [
+    { key: 'accept', label: 'Accept (93+)', color: '\x1b[32m' },
+    { key: 'minor_sd', label: 'Minor (83-92)', color: '\x1b[33m' },
+    { key: 'gap_closure_sd', label: 'Gap Closure (70-82)', color: '\x1b[33m' },
+    { key: 'escalate', label: 'Escalate (<70)', color: '\x1b[31m' },
+  ];
+  for (const t of tierConfig) {
+    const count = tiers[t.key].length;
+    const pct = Math.round(count / scores.length * 100);
+    const bar = '▓'.repeat(Math.round(count / scores.length * 30));
+    console.log(`  ${t.color}${t.label.padEnd(22)}\x1b[0m ${String(count).padStart(3)} (${String(pct).padStart(2)}%) ${t.color}${bar}\x1b[0m`);
+  }
+
+  // Bottom 5
+  console.log('\n\x1b[1m  WEAKEST SDs\x1b[0m\n');
+  for (const s of bottom5) {
+    const sdShort = s.sd_id.length > 50 ? s.sd_id.substring(0, 47) + '...' : s.sd_id;
+    console.log(`  \x1b[31m${String(s.total_score).padStart(3)}\x1b[0m  ${sdShort}`);
+  }
+
+  // Top 5
+  console.log('\n\x1b[1m  STRONGEST SDs\x1b[0m\n');
+  for (const s of top5) {
+    const sdShort = s.sd_id.length > 50 ? s.sd_id.substring(0, 47) + '...' : s.sd_id;
+    console.log(`  \x1b[32m${String(s.total_score).padStart(3)}\x1b[0m  ${sdShort}`);
+  }
+
+  console.log('');
+}
+
+main().catch(err => { console.error(err.message); process.exit(1); });

--- a/scripts/eva/eva-report.mjs
+++ b/scripts/eva/eva-report.mjs
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * eva-report.mjs
+ * Vision governance summary report.
+ * Shows round history, corrective SD status, dimension trends, open gaps.
+ *
+ * Usage:
+ *   node scripts/eva/eva-report.mjs [--json]
+ *
+ * Part of: SD-CORR-VIS-V06-CLI-WORKFLOW-001
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { config } from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+config({ path: join(__dirname, '../../.env') });
+
+const jsonOutput = process.argv.includes('--json');
+
+async function main() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+
+  const supabase = createClient(url, key);
+
+  // 1. Round history (orchestrator SDs)
+  const rounds = [
+    { key: 'SD-MAN-ORCH-EVA-VISION-GOVERNANCE-001', label: 'Round 1', purpose: 'Build governance system' },
+    { key: 'SD-MAN-ORCH-EVA-VISION-IMPROVEMENT-001', label: 'Round 2', purpose: 'Close gaps (53→85 target)' },
+    { key: 'SD-MAN-ORCH-EVA-VISION-VALIDATION-001', label: 'Round 3', purpose: 'Validate & fix infrastructure' },
+    { key: 'SD-MAN-ORCH-EVA-VISION-ROUND4-001', label: 'Round 4', purpose: 'Targeted dimension improvement' },
+  ];
+
+  const { data: orchSDs } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, status, current_phase')
+    .in('sd_key', rounds.map(r => r.key));
+
+  const orchMap = new Map((orchSDs || []).map(s => [s.sd_key, s]));
+
+  // 2. Corrective SDs
+  const { data: corrSDs } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, status')
+    .like('sd_key', 'SD-CORR-%')
+    .order('created_at', { ascending: false })
+    .limit(10);
+
+  // 3. Portfolio scores
+  const { data: scores } = await supabase
+    .from('eva_vision_scores')
+    .select('total_score, threshold_action, created_by')
+    .not('created_by', 'eq', 'synthetic-LEAD-workaround');
+
+  const organic = (scores || []).filter(s => s.created_by !== 'manual-chairman-override');
+  const avg = organic.length > 0
+    ? Math.round(organic.reduce((a, r) => a + r.total_score, 0) / organic.length * 10) / 10
+    : 0;
+  const escalateCount = (scores || []).filter(s => s.threshold_action === 'escalate').length;
+  const acceptCount = (scores || []).filter(s => s.threshold_action === 'accept').length;
+
+  // 4. Open gaps (from eva_vision_gaps if it exists)
+  let openGaps = 0;
+  try {
+    const { data: gaps } = await supabase
+      .from('eva_vision_gaps')
+      .select('id')
+      .eq('status', 'open');
+    openGaps = gaps?.length || 0;
+  } catch { /* table may not have data yet */ }
+
+  const report = {
+    generated_at: new Date().toISOString(),
+    portfolio: { avg_score: avg, total_scored: organic.length, escalate_count: escalateCount, accept_count: acceptCount, open_gaps: openGaps },
+    rounds: rounds.map(r => {
+      const sd = orchMap.get(r.key);
+      return { ...r, status: sd?.status || 'not found', phase: sd?.current_phase || 'unknown' };
+    }),
+    corrective_sds: (corrSDs || []).map(s => ({ sd_key: s.sd_key, title: s.title, status: s.status })),
+  };
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  console.log('\n\x1b[1m\x1b[36m═══════════════════════════════════════════════════════════\x1b[0m');
+  console.log('\x1b[1m EVA VISION GOVERNANCE REPORT\x1b[0m');
+  console.log(`\x1b[2m Generated: ${new Date().toLocaleString()}\x1b[0m`);
+  console.log('\x1b[36m═══════════════════════════════════════════════════════════\x1b[0m\n');
+
+  // Portfolio summary
+  console.log('\x1b[1m  PORTFOLIO HEALTH\x1b[0m\n');
+  const avgColor = avg >= 80 ? '\x1b[32m' : avg >= 70 ? '\x1b[33m' : '\x1b[31m';
+  console.log(`  Average Score:  ${avgColor}\x1b[1m${avg}/100\x1b[0m (${organic.length} SDs scored organically)`);
+  console.log(`  Escalate Tier:  \x1b[31m${escalateCount}\x1b[0m SDs | Accept Tier: \x1b[32m${acceptCount}\x1b[0m SDs`);
+  console.log(`  Open Gaps:      ${openGaps}`);
+
+  // Round history
+  console.log('\n\x1b[1m  ROUND HISTORY\x1b[0m\n');
+  for (const r of report.rounds) {
+    const statusIcon = r.status === 'completed' ? '\x1b[32m✓\x1b[0m' : r.status === 'draft' ? '\x1b[33m○\x1b[0m' : '\x1b[36m→\x1b[0m';
+    console.log(`  ${statusIcon} \x1b[1m${r.label}\x1b[0m — ${r.purpose}`);
+    console.log(`    \x1b[2mStatus: ${r.status} | Phase: ${r.phase}\x1b[0m`);
+  }
+
+  // Corrective SDs
+  if (report.corrective_sds.length > 0) {
+    console.log('\n\x1b[1m  CORRECTIVE SDs\x1b[0m\n');
+    for (const s of report.corrective_sds) {
+      const icon = s.status === 'completed' ? '\x1b[32m✓\x1b[0m' : s.status === 'cancelled' ? '\x1b[31m✗\x1b[0m' : '\x1b[33m→\x1b[0m';
+      const titleShort = s.title.length > 55 ? s.title.substring(0, 52) + '...' : s.title;
+      console.log(`  ${icon} ${s.sd_key.padEnd(30)} ${titleShort}`);
+    }
+  }
+
+  console.log('\n\x1b[2m  Run with --json for machine-readable output\x1b[0m\n');
+}
+
+main().catch(err => { console.error(err.message); process.exit(1); });


### PR DESCRIPTION
## Summary

- Adds 3 CLI scripts to scripts/eva/ for vision governance monitoring (SD-CORR-VIS-V06-CLI-WORKFLOW-001)
- Closes V06 dimension gap (cli_authoritative_workflow, avg 48-60)
- `eva-gaps.mjs`: Dimension gap analysis ranked by worst, `--threshold` flag
- `eva-portfolio.mjs`: Portfolio health dashboard with tier distribution, `--exclude-synthetic` flag
- `eva-report.mjs`: Governance summary with round history (R1-R4), corrective SD status, `--json` flag
- All follow existing scripts/eva/ patterns (ESM, dotenv, Supabase, ANSI output)

## Test plan

- [x] `node scripts/eva/eva-gaps.mjs` — shows 14 dimensions below threshold
- [x] `node scripts/eva/eva-portfolio.mjs --exclude-synthetic` — shows portfolio avg 66.9
- [x] `node scripts/eva/eva-report.mjs` — shows R1-R3 complete, R4 draft, 4 corrective SDs in progress
- [x] `node scripts/eva/eva-report.mjs --json` — outputs valid JSON
- [x] Smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)