### PR TITLE
feat(dfe): wire vision score signals into Decision Filter Engine stage gates

### DIFF
--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -320,11 +320,13 @@ async function evaluatePromotionGate(supabase, ventureId, fromStage, toStage, op
  * @param {Object} supabase - Supabase client
  * @param {string} ventureId - Venture ID
  * @param {number} toStage - Target stage
- * @param {Object} options - { chairmanId, stageOutput }
+ * @param {Object} options - { chairmanId, stageOutput, sdId, sdPhase }
+ * @param {string} [options.sdId] - SD key for vision score lookup
+ * @param {string} [options.sdPhase] - SD phase override (if not provided, read from DB)
  * @returns {Promise<{ preferences: Object, stageInput: Object }>}
  */
 async function resolveGateContext(supabase, ventureId, toStage, options = {}) {
-  const { chairmanId, stageOutput = {} } = options;
+  const { chairmanId, stageOutput = {}, sdId, sdPhase } = options;
 
   // Load chairman preferences for Filter Engine
   let preferences = {};
@@ -340,6 +342,24 @@ async function resolveGateContext(supabase, ventureId, toStage, options = {}) {
     }
   }
 
+  // Load vision score from strategic_directives_v2 when SD context is available
+  let visionScore = null;
+  let resolvedSdPhase = sdPhase || null;
+  if (sdId) {
+    const { data: sdData } = await supabase
+      .from('strategic_directives_v2')
+      .select('vision_score, current_phase')
+      .eq('sd_key', sdId)
+      .single();
+
+    if (sdData) {
+      visionScore = sdData.vision_score ?? null;
+      if (!resolvedSdPhase) {
+        resolvedSdPhase = sdData.current_phase || null;
+      }
+    }
+  }
+
   // Build stage input for Filter Engine
   const stageInput = {
     stage: String(toStage),
@@ -352,6 +372,8 @@ async function resolveGateContext(supabase, ventureId, toStage, options = {}) {
     priorPatterns: stageOutput.priorPatterns ?? [],
     constraints: stageOutput.constraints ?? {},
     approvedConstraints: stageOutput.approvedConstraints ?? {},
+    visionScore,
+    sdPhase: resolvedSdPhase,
   };
 
   return { preferences, stageInput };

--- a/lib/eva/escalation-event-persister.js
+++ b/lib/eva/escalation-event-persister.js
@@ -26,6 +26,7 @@ import { generateForEscalation } from './mitigation-generator.js';
  * @param {string} [params.ventureName] - Venture display name
  * @param {number} [params.stageNumber] - Current lifecycle stage number
  * @param {string} [params.eventSource] - Source identifier (default: 'decision_filter_engine')
+ * @param {string} [params.sdId] - SD key for vision dimension gap lookup
  * @returns {Promise<{ eventId: string }>} The inserted event's ID
  * @throws {Error} If Supabase insert fails
  */
@@ -35,6 +36,7 @@ export async function persistEscalationEvent(supabase, {
   ventureName = null,
   stageNumber = null,
   eventSource = 'decision_filter_engine',
+  sdId = null,
 } = {}) {
   if (!supabase) throw new ServiceError('INVALID_ARGS', 'supabase client is required', 'EscalationEventPersister');
   if (!dfeResult) throw new ServiceError('INVALID_ARGS', 'dfeResult is required', 'EscalationEventPersister');
@@ -49,6 +51,28 @@ export async function persistEscalationEvent(supabase, {
 
   const isEscalation = dfeResult.recommendation !== 'AUTO_PROCEED';
 
+  // Fetch vision dimension gaps if a vision_score_signal trigger fired
+  let visionDimensionGaps = null;
+  const hasVisionTrigger = (dfeResult.triggers || []).some(t => t.type === 'vision_score_signal');
+  if (hasVisionTrigger && sdId) {
+    const { data: gaps } = await supabase
+      .from('eva_vision_gaps')
+      .select('dimension_key, dimension_label, current_score, target_score, gap_severity, corrective_sd_key')
+      .eq('sd_id', sdId)
+      .order('current_score', { ascending: true });
+
+    if (gaps && gaps.length > 0) {
+      visionDimensionGaps = gaps.map(g => ({
+        dimensionKey: g.dimension_key,
+        dimensionLabel: g.dimension_label,
+        currentScore: g.current_score,
+        targetScore: g.target_score,
+        gapSeverity: g.gap_severity,
+        correctiveSdKey: g.corrective_sd_key,
+      }));
+    }
+  }
+
   const eventData = {
     triggers: presentation.triggers,
     mitigations: mitigations.byTrigger,
@@ -59,6 +83,7 @@ export async function persistEscalationEvent(supabase, {
     stage_number: stageNumber,
     trigger_count: presentation.triggerCount,
     max_severity_score: presentation.maxSeverityScore,
+    ...(visionDimensionGaps && { vision_dimension_gaps: visionDimensionGaps }),
   };
 
   const { data, error } = await supabase

--- a/lib/services/dfe-escalation-service.js
+++ b/lib/services/dfe-escalation-service.js
@@ -18,6 +18,7 @@ const TRIGGER_TYPE_LABELS = {
   low_score: 'Below Score Threshold',
   novel_pattern: 'Novel Pattern Detected',
   constraint_drift: 'Constraint Drift',
+  vision_score_signal: 'Vision Score Below Exec Threshold',
 };
 
 const SEVERITY_ORDER = { HIGH: 0, MEDIUM: 1, INFO: 2 };
@@ -106,6 +107,26 @@ export class DfeEscalationService {
       }))
       .sort((a, b) => (SEVERITY_ORDER[a.severity] ?? 99) - (SEVERITY_ORDER[b.severity] ?? 99));
 
+    // 5b. Fetch vision dimension gaps if a vision_score_signal trigger is present
+    let visionDimensionGaps = [];
+    const hasVisionTrigger = triggers.some(t => t.type === 'vision_score_signal');
+    if (hasVisionTrigger && decision.venture_id) {
+      const { data: gaps } = await this.supabase
+        .from('eva_vision_gaps')
+        .select('dimension_key, dimension_label, current_score, target_score, gap_severity, corrective_sd_key')
+        .eq('sd_id', decision.venture_id)
+        .order('current_score', { ascending: true });
+
+      visionDimensionGaps = (gaps || []).map(g => ({
+        dimensionKey: g.dimension_key,
+        dimensionLabel: g.dimension_label,
+        currentScore: g.current_score,
+        targetScore: g.target_score,
+        gapSeverity: g.gap_severity,
+        correctiveSdKey: g.corrective_sd_key,
+      }));
+    }
+
     // 6. Assemble payload
     return {
       success: true,
@@ -126,6 +147,8 @@ export class DfeEscalationService {
 
         historicalPatterns,
         patternCount: historicalPatterns.length,
+
+        visionDimensionGaps,
 
         recentEvents: (events || []).map(e => ({
           eventId: e.event_id,


### PR DESCRIPTION
## Summary
- Add vision score and SD phase lookup in `resolveGateContext()` (stage-gates.js) so the DFE `vision_score_signal` trigger fires for SDs in EXEC with low vision scores
- Enrich `dfe-escalation-service.js` escalation context with per-dimension gap data from `eva_vision_gaps` when vision triggers fire
- Include vision dimension gaps in persisted escalation events via `escalation-event-persister.js`
- Add `vision_score_signal` label to trigger type labels map

## Test plan
- [x] Existing unit tests pass (3 pre-existing failures unrelated to changes)
- [x] Smoke tests pass (15/15)
- [x] No regressions: `sdId`/`sdPhase` are optional params with null defaults
- [ ] Integration: verify low vision score SD in EXEC triggers escalation with dimension data

🤖 Generated with [Claude Code](https://claude.com/claude-code)