### PR TITLE
refactor(eva): unified SD creation for corrective SDs

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1069,6 +1069,9 @@ async function createSD(options) {
   return data;
 }
 
+// Export for programmatic use (e.g., corrective-sd-generator)
+export { createSD };
+
 // ============================================================================
 // CLI Handler
 // ============================================================================
@@ -1209,7 +1212,7 @@ Note: SD keys starting with QF- will prompt to use create-quick-fix.js instead.
           const triageResult = await runTriageGate({ title, description: title, type, source: 'interactive' }, supabase);
           if (triageResult.tier <= 2) {
             console.log('\n' + formatTriageSummary(triageResult));
-            console.log(`\n   💡 Consider using Quick Fix instead:`);
+            console.log('\n   💡 Consider using Quick Fix instead:');
             console.log(`      node scripts/create-quick-fix.js --title "${title}" --type ${type}`);
             console.log('   Continuing with full SD creation...\n');
           }


### PR DESCRIPTION
## Summary
- Export `createSD()` from `leo-create-sd.js` for programmatic use
- Refactor `corrective-sd-generator.mjs` to use `createSD()` instead of raw Supabase insert
- Corrective SDs now go through the same pipeline as `/leo create`: proper key generation via `generateSDKey`, type mapping, category alignment, success field defaults, and `scoreSDAtConception()` vision pre-screen

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint clean
- [x] `createSD` export verified
- [ ] Generate corrective SD and verify it has vision score at conception

🤖 Generated with [Claude Code](https://claude.com/claude-code)