### PR TITLE
fix: guard leo-create-sd.js entry point for ESM imports

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1268,4 +1268,9 @@ Note: SD keys starting with QF- will prompt to use create-quick-fix.js instead.
   }
 }
 
-main();
+// Only run CLI when invoked directly (not when imported)
+const _isMainModule = import.meta.url === `file://${process.argv[1]}` ||
+                      import.meta.url === `file:///${process.argv[1]?.replace(/\\/g, '/')}`;
+if (_isMainModule) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Add isMainModule guard around `main()` call in leo-create-sd.js
- Prevents CLI execution when `createSD` is imported programmatically (e.g., by corrective-sd-generator.mjs)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Corrective SD generator successfully imports and calls createSD without triggering CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)