### PR TITLE
feat(eva): wire stage execution into venture state machine

### DIFF
--- a/lib/agents/venture-state-machine.js
+++ b/lib/agents/venture-state-machine.js
@@ -25,6 +25,8 @@ import {
   requestChanges,
   getStageRequirements
 } from './modules/venture-state-machine/handoff-operations.js';
+import { validateContracts } from '../eva/contract-validator.js';
+import { executeStage } from '../eva/stage-execution-engine.js';
 
 // Re-export error classes for consumers
 export { StateStalenessError, GoldenNuggetValidationError, StageGateValidationError };
@@ -286,9 +288,50 @@ export class VentureStateMachine {
       }
     };
 
+    // SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-001: Contract validation pre-check (advisory)
+    if (decision === 'approve') {
+      try {
+        const contracts = await validateContracts({
+          targetStage: handoff.to_stage,
+          ventureId: this.ventureId,
+          supabase: this.supabase,
+        });
+        if (!contracts.passed) {
+          console.log(`   ⚠️  Contract validation: ${contracts.missingContracts.length} missing upstream artifact(s)`);
+          for (const m of contracts.missingContracts) {
+            console.log(`      Stage ${m.stage}: ${m.reason}`);
+          }
+        } else {
+          console.log(`   ✅ Contract validation: all ${contracts.requiredStages.length} upstream contracts satisfied`);
+        }
+      } catch (err) {
+        console.warn(`   ⚠️  Contract validation skipped: ${err.message}`);
+      }
+    }
+
     switch (decision) {
-      case 'approve':
-        return approveHandoff(context, handoff, ceo_notes);
+      case 'approve': {
+        const result = await approveHandoff(context, handoff, ceo_notes);
+
+        // SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-001: Execute analysisStep after approval
+        if (result.accepted) {
+          try {
+            const execResult = await executeStage({
+              stageNumber: handoff.to_stage,
+              ventureId: this.ventureId,
+              supabase: this.supabase,
+              logger: { log: () => {}, warn: console.warn, error: console.error },
+            });
+            if (execResult.persisted) {
+              console.log(`   ✅ Stage ${handoff.to_stage} analysisStep executed, artifact: ${execResult.artifactId}`);
+            }
+          } catch (err) {
+            console.warn(`   ⚠️  Stage execution skipped: ${err.message}`);
+          }
+        }
+
+        return result;
+      }
       case 'reject':
         return rejectHandoff(context, handoff, ceo_notes);
       case 'request_changes':

--- a/package.json
+++ b/package.json
@@ -102,6 +102,8 @@
     "llm:canary:quality": "node scripts/llm-canary-control.js quality",
     "llm:canary:history": "node scripts/llm-canary-control.js history",
     "eva:run": "node scripts/eva-run.js",
+    "eva:stage": "node scripts/eva/run-stage.js",
+    "eva:heal": "node scripts/eva/vision-heal.js",
     "eva:decisions": "node scripts/eva-decisions.js",
     "eva:venture:new": "node scripts/eva-venture-new.js",
     "eva:ideas:sync": "node scripts/eva-idea-sync.js",


### PR DESCRIPTION
## Summary
- Wire `contract-validator.js` into `commitStageTransition()` as advisory pre-check
- Wire `stage-execution-engine.js` into `commitStageTransition()` for post-approval analysisStep execution
- Add `npm run eva:stage` and `npm run eva:heal` convenience scripts
- Targets A06 (lifecycle stage orchestration) vision dimension

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint clean
- [x] Contract validation is advisory (non-blocking)
- [x] Stage execution is wrapped in try-catch (non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)