### PR TITLE
fix: auto-proceed protocol binding for vision heal loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,20 @@ Invoke the RCA Sub-Agent (`subagent_type="rca-agent"`). Your prompt MUST contain
 AUTO-PROCEED is **ON by default**. Phase transitions execute automatically, no confirmation prompts.
 **Pause points** (even when ON): Orchestrator completion, blocking errors, test failures (2 retries), merge conflicts, all children blocked.
 
+## Vision Heal Loop (Auto-Continue)
+
+When running the vision self-healing loop (`vision-heal.js`), parse output signals and auto-continue:
+
+| Signal | Action (AUTO-PROCEED ON) |
+|--------|--------------------------|
+| `HEAL_STATUS=NEEDS_CORRECTION` + `HEAL_SCORE_ID=<id>` | Run `node scripts/eva/vision-heal.js generate <id>` |
+| Corrective SDs generated | Work each SD through LEAD→PLAN→EXEC→completion |
+| All corrective SDs completed | Run `node scripts/eva/vision-heal.js score` → inline score → persist |
+| `HEAL_STATUS=PASS` | Loop complete. Report final scores. Stop. |
+
+**DO NOT ASK** between rounds when AUTO-PROCEED is ON. Parse signals and proceed.
+Max 10 rounds safety limit. Use `npm run eva:heal status` to check state.
+
 ## SD Continuation
 
 | Transition | AUTO-PROCEED | Chaining | Behavior |

--- a/scripts/eva/vision-heal.js
+++ b/scripts/eva/vision-heal.js
@@ -197,9 +197,12 @@ async function cmdPersist(scoreJson) {
     console.log(`\n   🎉 All dimensions at or above ${ACCEPT_THRESHOLD}! No corrective action needed.`);
   }
 
-  // Output machine-readable status
+  // Output machine-readable status (consumed by Claude Code auto-proceed protocol)
   console.log(`\nHEAL_STATUS=${thresholdAction === 'accept' ? 'PASS' : 'NEEDS_CORRECTION'}`);
   console.log(`HEAL_SCORE_ID=${inserted.id}`);
+  if (thresholdAction !== 'accept') {
+    console.log(`HEAL_NEXT_CMD=node scripts/eva/vision-heal.js generate ${inserted.id}`);
+  }
 }
 
 // ─── GENERATE: Create corrective SDs from a score ────────────────────────────


### PR DESCRIPTION
## Summary
- Add HEAL_NEXT_CMD machine-actionable signal to vision-heal.js persist output
- Add Vision Heal Loop auto-continue rules to CLAUDE.md
- RCA: Claude Code paused between heal rounds because the loop had no protocol binding

## Test plan
- [x] Smoke tests pass
- [x] HEAL_NEXT_CMD output verified in persist command

🤖 Generated with [Claude Code](https://claude.com/claude-code)