### PR TITLE
feat(eva): inline LLM fallback and venture progression tracking

### DIFF
--- a/lib/eva/vision-governance-service.js
+++ b/lib/eva/vision-governance-service.js
@@ -115,6 +115,39 @@ export class VisionGovernanceService {
     if (error) throw new Error(`Corrective SD query failed: ${error.message}`);
     return data || [];
   }
+
+  /**
+   * Get venture lifecycle progression — which stages have artifacts.
+   * SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-004: FR-002
+   *
+   * @param {string} ventureId - Venture UUID
+   * @returns {Promise<Object>} Progression with completed/pending stages
+   */
+  async getVentureProgression(ventureId) {
+    const { data, error } = await this.supabase
+      .from('venture_artifacts')
+      .select('lifecycle_stage')
+      .eq('venture_id', ventureId)
+      .eq('is_current', true);
+
+    if (error) throw new Error(`Progression query failed: ${error.message}`);
+
+    const completedStages = new Set((data || []).map(a => a.lifecycle_stage));
+    const stages = [];
+    for (let i = 1; i <= 25; i++) {
+      stages.push({
+        stage: i,
+        status: completedStages.has(i) ? 'completed' : 'pending',
+      });
+    }
+
+    return {
+      ventureId,
+      completedCount: completedStages.size,
+      pendingCount: 25 - completedStages.size,
+      stages,
+    };
+  }
 }
 
 export function createVisionGovernanceService(options = {}) {

--- a/lib/llm/client-factory.js
+++ b/lib/llm/client-factory.js
@@ -312,6 +312,29 @@ export function getLLMClient(options = {}) {
   // Effort-based routing: use Anthropic Opus with thinking budget
   if (isEffortLevel) {
     const budgetTokens = EFFORT_TO_BUDGET[effortOrTier];
+
+    // Check if Anthropic API key is available
+    if (!process.env.ANTHROPIC_API_KEY) {
+      // No API key — return a stub adapter that signals inline processing needed
+      console.log(`   📋 LLM Factory: No ANTHROPIC_API_KEY — inline processing required for ${label}`);
+      return {
+        thinkingBudget: budgetTokens,
+        effortLevel: effortOrTier,
+        isInlineOnly: true,
+        async complete(systemPrompt, userPrompt) {
+          // Return a structured response indicating inline processing is needed
+          return {
+            content: JSON.stringify({
+              _inline_required: true,
+              _message: 'No LLM API key available. This analysis should be processed inline by Claude Code.',
+              _system_prompt: systemPrompt?.substring(0, 500),
+              _user_prompt: userPrompt?.substring(0, 500),
+            }),
+          };
+        },
+      };
+    }
+
     console.log(`   🧠 LLM Factory: Opus with ${effortOrTier} effort (${budgetTokens} thinking tokens) for ${label}`);
     const adapter = new AnthropicAdapter({ model: THINKING_MODEL });
     // Attach thinking config so callers can pass it through to .complete()
@@ -366,6 +389,7 @@ function getPurposeTier(purpose) {
     // Generation uses high effort → Opus 4.6
     // SD-LEO-INFRA-REPLACE-GPT-OPUS-001: Opus has codebase context, no timeouts
     generation: 'high',
+    'content-generation': 'high',
 
     // Opus-tier (highest quality)
     security: 'opus',


### PR DESCRIPTION
## Summary
- Add `content-generation` to LLM purpose routing (→ Opus high effort)
- Add inline stub adapter fallback when no ANTHROPIC_API_KEY available
- Stage analysisSteps now fail gracefully with `_inline_required` signal
- Add `getVentureProgression()` to vision-governance-service for lifecycle tracking
- Round 8 of vision self-healing loop

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Both Round 8 corrective SDs completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)