### PR TITLE
feat(eva): interval rounds scheduler and LLM cache invalidation

### DIFF
--- a/lib/eva/rounds-scheduler.js
+++ b/lib/eva/rounds-scheduler.js
@@ -78,6 +78,54 @@ export async function runRound(roundType, options = {}) {
 }
 
 /**
+ * Start an interval-based scheduler that runs rounds on their declared cadence.
+ * SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-006: FR-001
+ *
+ * @param {Object} [options]
+ * @param {number} [options.intervalMs=3600000] - Check interval in ms (default: 1 hour)
+ * @param {Function} [options.logger] - Logger (default: console.log)
+ * @returns {{ stop: Function }} Controller to stop the scheduler
+ */
+export function startScheduler(options = {}) {
+  const { intervalMs = 3600000, logger = console.log } = options;
+
+  const cadenceToMs = {
+    hourly: 3600000,
+    daily: 86400000,
+    weekly: 604800000,
+    monthly: 2592000000,
+  };
+
+  const lastRun = new Map();
+
+  const tick = async () => {
+    for (const [type, round] of roundRegistry) {
+      const cadenceMs = cadenceToMs[round.cadence];
+      if (!cadenceMs) continue; // on_demand rounds skip
+
+      const last = lastRun.get(type) || 0;
+      if (Date.now() - last >= cadenceMs) {
+        logger(`[RoundsScheduler] Running scheduled round: ${type}`);
+        await runRound(type).catch(err =>
+          logger(`[RoundsScheduler] Round ${type} failed: ${err.message}`)
+        );
+        lastRun.set(type, Date.now());
+      }
+    }
+  };
+
+  const intervalId = setInterval(tick, intervalMs);
+  logger(`[RoundsScheduler] Started with ${intervalMs}ms check interval`);
+
+  return {
+    stop() {
+      clearInterval(intervalId);
+      logger('[RoundsScheduler] Stopped');
+    },
+  };
+}
+
+/**
  * List all registered rounds.
  * @returns {Array<Object>} Registered round configurations
  */

--- a/lib/llm/client-factory.js
+++ b/lib/llm/client-factory.js
@@ -215,6 +215,16 @@ export async function refreshModelRegistry() {
 }
 
 /**
+ * Invalidate the model registry cache without reloading.
+ * SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-006: Makes cache request-scoped.
+ * Next getLLMClient() call will reload from DB.
+ */
+export function invalidateCache() {
+  modelRegistryCache = null;
+  cacheExpiry = 0;
+}
+
+/**
  * Initialize the LLM client factory (loads registry from database)
  * Call this once at application startup for optimal performance.
  * If not called, the registry will be loaded lazily on first getLLMClient call.


### PR DESCRIPTION
## Summary
- Add `startScheduler()` to rounds-scheduler.js for cadence-based round execution
- Add `invalidateCache()` to LLM client-factory for request-scoped cache control
- Legacy GUI component inventory documented in DB (62 components, deprecation plan)
- Round 10 of vision self-healing loop: V07, A04, A01

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Both Round 10 SDs completed
- [x] Orchestrator 25/25 children complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)