### PR TITLE
feat(eva): contract validation event emission

### DIFF
--- a/lib/eva/contract-validator.js
+++ b/lib/eva/contract-validator.js
@@ -105,7 +105,7 @@ export async function validateContracts(options = {}) {
       reason: `No current artifact found for stage ${s}`,
     }));
 
-  return {
+  const result = {
     passed: missingContracts.length === 0,
     targetStage,
     ventureId,
@@ -114,4 +114,27 @@ export async function validateContracts(options = {}) {
     missingContracts,
     latencyMs: Date.now() - startTime,
   };
+
+  // SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-007: Emit contract validation event
+  if (ventureId) {
+    try {
+      await supabase.from('eva_orchestration_events').insert({
+        event_type: 'contract_validation_completed',
+        event_source: 'contract_validator',
+        venture_id: ventureId,
+        event_data: {
+          target_stage: targetStage,
+          passed: result.passed,
+          satisfied_count: satisfiedContracts.length,
+          missing_count: missingContracts.length,
+          latency_ms: result.latencyMs,
+        },
+        chairman_flagged: false,
+      });
+    } catch (_eventErr) {
+      // Non-blocking
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
## Summary
- Emit `contract_validation_completed` event after contract validation in contract-validator.js
- Events include target_stage, passed status, satisfied/missing counts, latency
- Round 11 of vision self-healing loop targeting A05 (event bus, 80)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Round 11 SD completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)