### PR TITLE
refactor: standardize grade scale thresholds across LEO pipeline

### DIFF
--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -4,5 +4,5 @@
   "form_validation": [],
   "loading_patterns": [],
   "navigation": [],
-  "last_scan": "2026-02-16T12:40:35.172Z"
+  "last_scan": "2026-02-19T12:11:06.446Z"
 }

--- a/lib/sub-agents/vetting/rubric-evaluator.js
+++ b/lib/sub-agents/vetting/rubric-evaluator.js
@@ -121,11 +121,11 @@ RUBRIC CRITERIA:
 ${criteriaDesc}
 
 SCORING SCALE: ${rubric.scoringScale.min}-${rubric.scoringScale.max} mapped to 0-100.
-- 0-20: Poor - Fails to meet basic requirements
-- 21-40: Below Average - Significant gaps
-- 41-60: Average - Meets minimum requirements
-- 61-80: Good - Solid implementation
-- 81-100: Excellent - Exceeds expectations
+- 0-59:  F — Failing — Does not meet requirements
+- 60-69: D — Poor — Significant gaps
+- 70-79: C — Acceptable — Meets minimum requirements
+- 80-89: B — Good — Solid implementation
+- 90-100: A — Excellent — Exceeds expectations (A-: 90-92, A: 93-96, A+: 97-100)
 
 RESPOND WITH ONLY valid JSON matching this exact structure:
 {

--- a/lib/uat/result-recorder.js
+++ b/lib/uat/result-recorder.js
@@ -23,6 +23,7 @@ import {
   getRCATriggerRecommendation,
   recordPatternOccurrence
 } from './issue-pattern-matcher.js';
+import { GRADE } from '../standards/grade-scale.js';
 
 let supabase = null;
 
@@ -380,12 +381,12 @@ export async function completeSession(testRunId) {
   // Calculate pass rate
   const passRate = total > 0 ? (passed / total) * 100 : 0;
 
-  // Calculate quality gate
-  // GREEN: 0 failures AND pass_rate >= 85%
-  // YELLOW: Has failures BUT pass_rate >= 85%
-  // RED: pass_rate < 85%
+  // Calculate quality gate — A grade (93) per lib/standards/grade-scale.js
+  // GREEN: 0 failures AND pass_rate >= A (93%)
+  // YELLOW: Has failures BUT pass_rate >= A (93%)
+  // RED: pass_rate < A (93%)
   let qualityGate = 'GREEN';
-  if (passRate < 85) {
+  if (passRate < GRADE.A) {
     qualityGate = 'RED';
   } else if (failed > 0) {
     qualityGate = 'YELLOW';

--- a/lib/uat/route-aware-reporter.js
+++ b/lib/uat/route-aware-reporter.js
@@ -27,6 +27,7 @@ import {
   getPatternStatistics,
   SEVERITY_CONFIG
 } from './issue-pattern-matcher.js';
+import { GRADE } from '../standards/grade-scale.js';
 
 /**
  * Generate route-aware UAT header
@@ -222,8 +223,8 @@ export async function generateRouteAwareSummary(session) {
   let qualityGate = 'GREEN';
   let gateIcon = '🟢';
   if (failures > 0) {
-    qualityGate = passRate >= 85 ? 'YELLOW' : 'RED';
-    gateIcon = passRate >= 85 ? '🟡' : '🔴';
+    qualityGate = passRate >= GRADE.A ? 'YELLOW' : 'RED';
+    gateIcon = passRate >= GRADE.A ? '🟡' : '🔴';
   }
 
   const lines = [
@@ -260,7 +261,7 @@ export async function generateRouteAwareSummary(session) {
   }
 
   if (failures > 0 && qualityGate === 'RED') {
-    recommendations.push('📌 Pass rate below 85% - address failures before shipping');
+    recommendations.push(`📌 Pass rate below ${GRADE.A}% (A grade) - address failures before shipping`);
   }
 
   if (recommendations.length > 0) {

--- a/lib/websocket/leo-events.ts
+++ b/lib/websocket/leo-events.ts
@@ -73,7 +73,7 @@ export function emitGateUpdated(event: Omit<WSGateUpdatedEventType, 'v' | 'ts'>)
     v: 1,
     ts: new Date().toISOString(),
     ...event,
-    passed: event.score >= 85  // Add passed flag
+    passed: event.score >= 83  // B grade minimum (lib/standards/grade-scale.js GRADE.B)
   };
   
   queueEvent('leo/gate:updated', payload, `gate:${event.prd_id}:${event.gate}`);

--- a/scripts/leo-sd-validator.js
+++ b/scripts/leo-sd-validator.js
@@ -303,13 +303,17 @@ class SDValidator {
    * Get letter grade for score
    */
   getGrade(score) {
-    if (score >= 95) return '🌟 A+';
-    if (score >= 90) return '⭐ A';
-    if (score >= 85) return '✨ B+';
-    if (score >= 80) return '✓ B';
-    if (score >= 75) return '⚡ C+';
-    if (score >= 70) return '🔸 C';
-    return '⚠️ D';
+    if (score >= 97) return '🌟 A+';
+    if (score >= 93) return '⭐ A';
+    if (score >= 90) return '✨ A-';
+    if (score >= 87) return '✨ B+';
+    if (score >= 83) return '✓ B';
+    if (score >= 80) return '✓ B-';
+    if (score >= 77) return '⚡ C+';
+    if (score >= 73) return '⚡ C';
+    if (score >= 70) return '🔸 C-';
+    if (score >= 63) return '⚠️ D';
+    return '❌ F';
   }
 
   /**

--- a/scripts/modules/leo-summary/compliance-scorer.js
+++ b/scripts/modules/leo-summary/compliance-scorer.js
@@ -4,10 +4,12 @@
  * Calculates compliance scores across 5 dimensions:
  * 1. Handoff Completeness (25%) - Required handoffs per SD type present
  * 2. Handoff Quality (25%) - All 7 mandatory elements filled
- * 3. Gate Compliance (25%) - Met 85% threshold, 70% PRD quality
+ * 3. Gate Compliance (25%) - Met B grade (83%) threshold, C- (70%) PRD quality
  * 4. Sequence Compliance (15%) - Correct phase order maintained
  * 5. Duration Efficiency (10%) - Reasonable time per phase
  */
+
+import { GRADE } from '../../../lib/standards/grade-scale.js';
 
 // Dimension weights (must sum to 1.0)
 const WEIGHTS = {
@@ -196,12 +198,12 @@ function calcGateCompliance(data) {
   let checks = [];
   let passed = 0;
 
-  // Check 1: Handoff validation scores >= 85%
+  // Check 1: Handoff validation scores >= B grade (83%)
   const handoffsWithScores = acceptedHandoffs.filter(h => h.validation_score !== null);
   if (handoffsWithScores.length > 0) {
     const avgScore = handoffsWithScores.reduce((sum, h) => sum + h.validation_score, 0) / handoffsWithScores.length;
-    const handoffPass = avgScore >= 85;
-    checks.push({ name: 'Handoff Validation (>=85%)', passed: handoffPass, value: Math.round(avgScore) });
+    const handoffPass = avgScore >= GRADE.B;
+    checks.push({ name: 'Handoff Validation (>=83% / B)', passed: handoffPass, value: Math.round(avgScore) });
     if (handoffPass) passed++;
   }
 
@@ -440,7 +442,7 @@ export function calculateComplianceScores(data) {
  * Get status label based on score
  */
 export function getScoreStatus(score) {
-  if (score >= 85) return 'PASS';
-  if (score >= 70) return 'WARN';
+  if (score >= GRADE.B)       return 'PASS';  // B (83) or better
+  if (score >= GRADE.C_MINUS) return 'WARN';  // C- (70) to B-
   return 'FAIL';
 }

--- a/scripts/uat-quality-gate-checker.js
+++ b/scripts/uat-quality-gate-checker.js
@@ -13,6 +13,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 import chalk from 'chalk';
+import { GRADE } from '../lib/standards/grade-scale.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,12 +28,12 @@ class QualityGateChecker {
       ...options
     };
 
-    // Quality gate thresholds (configurable)
+    // Quality gate thresholds (configurable) — A grade (93) per lib/standards/grade-scale.js
     this.thresholds = {
       overall_pass_rate: {
-        target: 85,
+        target: GRADE.A,
         critical: true,
-        description: 'Overall test pass rate must be >= 85%'
+        description: `Overall test pass rate must be >= ${GRADE.A}% (A grade)`
       },
       authentication_failures: {
         target: 0,


### PR DESCRIPTION
## Summary
- Replace hardcoded `85%` pass/fail thresholds with centralized `GRADE` constants from `lib/standards/grade-scale.js`
- Align rubric evaluator, UAT quality gates, compliance scorer, SD validator, and websocket events to the A/B/C/D/F grade scale
- Grade breakpoints: A=93, B=83, C=73, D=63, F<60

## Files changed (8)
- `lib/sub-agents/vetting/rubric-evaluator.js` — scoring scale labels
- `lib/uat/result-recorder.js` — quality gate threshold → GRADE.A
- `lib/uat/route-aware-reporter.js` — pass rate threshold → GRADE.A
- `lib/websocket/leo-events.ts` — gate pass flag → GRADE.B (83)
- `scripts/leo-sd-validator.js` — expanded grade display (11 levels)
- `scripts/modules/leo-summary/compliance-scorer.js` — gate compliance → GRADE.B, status → GRADE.C_MINUS
- `scripts/uat-quality-gate-checker.js` — overall pass rate → GRADE.A

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint clean
- [x] No secrets detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)