### PR TITLE
fix: prevent worktree nesting and accumulation

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -62,11 +62,20 @@ export function validateSdKey(sdKey) {
 }
 
 /**
- * Get the repository root (where .git lives)
+ * Get the repository root (where .git lives).
+ * When called from inside a worktree, navigates up past .worktrees/ to the
+ * actual repo root. Without this, createWorktree() would nest worktrees
+ * inside existing worktrees (e.g., .worktrees/SD-A/.worktrees/SD-B/).
  * @returns {string} Absolute path to repo root
  */
 export function getRepoRoot() {
-  return execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  let toplevel = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+  const normalized = toplevel.replace(/\\/g, '/');
+  const wtIdx = normalized.indexOf('/' + WORKTREES_DIR + '/');
+  if (wtIdx >= 0) {
+    toplevel = toplevel.substring(0, wtIdx);
+  }
+  return toplevel;
 }
 
 /**

--- a/tests/unit/worktree-manager.test.js
+++ b/tests/unit/worktree-manager.test.js
@@ -38,6 +38,21 @@ describe('Worktree Manager', () => {
       expect(getRepoRoot()).toBe('/home/user/project');
       expect(execSync).toHaveBeenCalledWith('git rev-parse --show-toplevel', { encoding: 'utf8' });
     });
+
+    it('should strip .worktrees/ path when called from inside a worktree', () => {
+      execSync.mockReturnValue('/home/user/project/.worktrees/SD-XXX-001\n');
+      expect(getRepoRoot()).toBe('/home/user/project');
+    });
+
+    it('should strip nested .worktrees/ path', () => {
+      execSync.mockReturnValue('/home/user/project/.worktrees/SD-A/.worktrees/SD-B\n');
+      expect(getRepoRoot()).toBe('/home/user/project');
+    });
+
+    it('should handle Windows backslash paths inside worktrees', () => {
+      execSync.mockReturnValue('C:\\Users\\user\\project\\.worktrees\\SD-XXX\n');
+      expect(getRepoRoot()).toBe('C:\\Users\\user\\project');
+    });
   });
 
   describe('getWorktreesDir', () => {


### PR DESCRIPTION
## Summary
- Fix `getRepoRoot()` in `worktree-manager.js` to strip `.worktrees/` path when called from inside a worktree — prevents nested worktree creation (worktree-in-worktree)
- Raise `MAX_CLEANUP_PER_SESSION` from 3 to 50 in SessionStart hook — old cap caused cleanup rate < creation rate
- Extend SessionStart cleanup to also remove SD worktrees whose branches are fully merged to main (not just expired `concurrent-*`)
- Move `isInsideWorktree()` check before concurrent detection logic (belt-and-suspenders for nesting prevention)

## Root Cause
37 worktrees accumulated with only 2 active sessions because:
1. `getRepoRoot()` returned the worktree root (not main repo) when called from within a worktree, so `createWorktree()` nested `.worktrees/` inside existing worktrees
2. SessionStart cleanup was capped at 3 per session, while worktrees were created faster than they were cleaned

## Test plan
- [x] 26/26 worktree-manager unit tests pass (3 new tests for path stripping)
- [x] 15/15 smoke tests pass
- [x] New tests cover: worktree path stripping, nested path stripping, Windows backslash paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)