### PR TITLE
fix: stop tracking session-identity files and reduce retention

### DIFF
--- a/.claude/session-identity/19f5b872-b23e-408c-9d0e-50be63fb56a9.json
+++ b/.claude/session-identity/19f5b872-b23e-408c-9d0e-50be63fb56a9.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "19f5b872-b23e-408c-9d0e-50be63fb56a9",
-  "sse_port": "30738",
-  "cc_pid": "15032",
-  "source": "startup",
-  "model": "claude-sonnet-4-5-20250929",
-  "captured_at": "2026-02-16T16:07:13.691Z"
-}

--- a/.claude/session-identity/30056075-d711-418c-9dba-531ffe38d0ed.json
+++ b/.claude/session-identity/30056075-d711-418c-9dba-531ffe38d0ed.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "30056075-d711-418c-9dba-531ffe38d0ed",
-  "sse_port": "22495",
-  "cc_pid": "28444",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T13:13:38.923Z"
-}

--- a/.claude/session-identity/49294686-2f38-441e-82bd-dc85feed3a46.json
+++ b/.claude/session-identity/49294686-2f38-441e-82bd-dc85feed3a46.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "49294686-2f38-441e-82bd-dc85feed3a46",
-  "sse_port": "22495",
-  "cc_pid": "23772",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T12:39:23.188Z"
-}

--- a/.claude/session-identity/53a323ae-eaa6-48ee-8a62-2e4441ef9a02.json
+++ b/.claude/session-identity/53a323ae-eaa6-48ee-8a62-2e4441ef9a02.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "53a323ae-eaa6-48ee-8a62-2e4441ef9a02",
-  "sse_port": "22495",
-  "cc_pid": "29832",
-  "source": "startup",
-  "model": "claude-sonnet-4-6[1m]",
-  "captured_at": "2026-02-18T15:22:00.098Z"
-}

--- a/.claude/session-identity/73994138-7710-4bf1-a7c3-7b67c0c9e622.json
+++ b/.claude/session-identity/73994138-7710-4bf1-a7c3-7b67c0c9e622.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "73994138-7710-4bf1-a7c3-7b67c0c9e622",
-  "sse_port": "22495",
-  "cc_pid": "12852",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T13:07:35.061Z"
-}

--- a/.claude/session-identity/838a096e-74df-41bb-b683-a384af79265b.json
+++ b/.claude/session-identity/838a096e-74df-41bb-b683-a384af79265b.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "838a096e-74df-41bb-b683-a384af79265b",
-  "sse_port": "22495",
-  "cc_pid": "11700",
-  "source": "startup",
-  "model": "claude-sonnet-4-6[1m]",
-  "captured_at": "2026-02-18T15:15:44.439Z"
-}

--- a/.claude/session-identity/b8c20063-5970-4e24-b3a2-f7b3870b3895.json
+++ b/.claude/session-identity/b8c20063-5970-4e24-b3a2-f7b3870b3895.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "b8c20063-5970-4e24-b3a2-f7b3870b3895",
-  "sse_port": "30738",
-  "cc_pid": "16476",
-  "source": "startup",
-  "model": "claude-opus-4-6",
-  "captured_at": "2026-02-18T12:31:49.103Z"
-}

--- a/.claude/session-identity/daffa6c5-4f86-4da8-bd3c-0a9674589da1.json
+++ b/.claude/session-identity/daffa6c5-4f86-4da8-bd3c-0a9674589da1.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "daffa6c5-4f86-4da8-bd3c-0a9674589da1",
-  "sse_port": "22495",
-  "cc_pid": "37784",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T12:43:10.177Z"
-}

--- a/.claude/session-identity/faa85560-0a57-4aeb-b182-0dcc098d9ce5.json
+++ b/.claude/session-identity/faa85560-0a57-4aeb-b182-0dcc098d9ce5.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "faa85560-0a57-4aeb-b182-0dcc098d9ce5",
-  "sse_port": "22495",
-  "cc_pid": "16076",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T13:06:57.735Z"
-}

--- a/.claude/session-identity/ffee3a54-064a-4faa-a6ea-92c0e68a297a.json
+++ b/.claude/session-identity/ffee3a54-064a-4faa-a6ea-92c0e68a297a.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "ffee3a54-064a-4faa-a6ea-92c0e68a297a",
-  "sse_port": "22495",
-  "cc_pid": "22820",
-  "source": "startup",
-  "model": "sonnet-4-5-20250929[1m]",
-  "captured_at": "2026-02-18T12:37:48.508Z"
-}

--- a/.claude/session-identity/pid-11700.json
+++ b/.claude/session-identity/pid-11700.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "838a096e-74df-41bb-b683-a384af79265b",
-  "sse_port": "22495",
-  "cc_pid": "11700",
-  "source": "startup",
-  "model": "claude-sonnet-4-6[1m]",
-  "captured_at": "2026-02-18T15:15:44.439Z"
-}

--- a/.claude/session-identity/pid-12852.json
+++ b/.claude/session-identity/pid-12852.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "73994138-7710-4bf1-a7c3-7b67c0c9e622",
-  "sse_port": "22495",
-  "cc_pid": "12852",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T13:07:35.061Z"
-}

--- a/.claude/session-identity/pid-15032.json
+++ b/.claude/session-identity/pid-15032.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "19f5b872-b23e-408c-9d0e-50be63fb56a9",
-  "sse_port": "30738",
-  "cc_pid": "15032",
-  "source": "startup",
-  "model": "claude-sonnet-4-5-20250929",
-  "captured_at": "2026-02-16T16:07:13.691Z"
-}

--- a/.claude/session-identity/pid-16076.json
+++ b/.claude/session-identity/pid-16076.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "faa85560-0a57-4aeb-b182-0dcc098d9ce5",
-  "sse_port": "22495",
-  "cc_pid": "16076",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T13:06:57.735Z"
-}

--- a/.claude/session-identity/pid-16476.json
+++ b/.claude/session-identity/pid-16476.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "b8c20063-5970-4e24-b3a2-f7b3870b3895",
-  "sse_port": "30738",
-  "cc_pid": "16476",
-  "source": "startup",
-  "model": "claude-opus-4-6",
-  "captured_at": "2026-02-18T12:31:49.103Z"
-}

--- a/.claude/session-identity/pid-22820.json
+++ b/.claude/session-identity/pid-22820.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "ffee3a54-064a-4faa-a6ea-92c0e68a297a",
-  "sse_port": "22495",
-  "cc_pid": "22820",
-  "source": "startup",
-  "model": "sonnet-4-5-20250929[1m]",
-  "captured_at": "2026-02-18T12:37:48.508Z"
-}

--- a/.claude/session-identity/pid-23772.json
+++ b/.claude/session-identity/pid-23772.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "49294686-2f38-441e-82bd-dc85feed3a46",
-  "sse_port": "22495",
-  "cc_pid": "23772",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T12:39:23.188Z"
-}

--- a/.claude/session-identity/pid-28444.json
+++ b/.claude/session-identity/pid-28444.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "30056075-d711-418c-9dba-531ffe38d0ed",
-  "sse_port": "22495",
-  "cc_pid": "28444",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T13:13:38.923Z"
-}

--- a/.claude/session-identity/pid-29832.json
+++ b/.claude/session-identity/pid-29832.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "53a323ae-eaa6-48ee-8a62-2e4441ef9a02",
-  "sse_port": "22495",
-  "cc_pid": "29832",
-  "source": "startup",
-  "model": "claude-sonnet-4-6[1m]",
-  "captured_at": "2026-02-18T15:22:00.098Z"
-}

--- a/.claude/session-identity/pid-37784.json
+++ b/.claude/session-identity/pid-37784.json
@@ -1,8 +1,0 @@
-{
-  "session_id": "daffa6c5-4f86-4da8-bd3c-0a9674589da1",
-  "sse_port": "22495",
-  "cc_pid": "37784",
-  "source": "startup",
-  "model": "claude-opus-4-6[1m]",
-  "captured_at": "2026-02-18T12:43:10.177Z"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -187,6 +187,9 @@ src/client/dist/
 # Account handoff exchange (local session state between account switches)
 .claude/handoff/
 
+# Claude session identity markers (generated per-session, never commit)
+.claude/session-identity/
+
 # Claude session state (modified during protocol operations, local only)
 .claude/unified-session-state.json
 .claude/auto-proceed-state.json

--- a/scripts/hooks/capture-session-id.cjs
+++ b/scripts/hooks/capture-session-id.cjs
@@ -157,13 +157,13 @@ function main() {
           const markerFile = path.join(markerDir, `${sessionId}.json`);
           fs.writeFileSync(markerFile, JSON.stringify(marker, null, 2));
 
-          // Cleanup old markers (keep last 10 of each type)
+          // Cleanup old markers (keep last 3 of each type)
           const cleanup = (prefix) => {
             const files = fs.readdirSync(markerDir)
               .filter(f => f.startsWith(prefix) && f.endsWith('.json'))
               .map(f => ({ name: f, mtime: fs.statSync(path.join(markerDir, f)).mtimeMs }))
               .sort((a, b) => b.mtime - a.mtime);
-            for (const old of files.slice(10)) {
+            for (const old of files.slice(3)) {
               try { fs.unlinkSync(path.join(markerDir, old.name)); } catch { /* best effort */ }
             }
           };
@@ -173,7 +173,7 @@ function main() {
             .filter(f => !f.startsWith('pid-') && !f.startsWith('port-') && f.endsWith('.json'))
             .map(f => ({ name: f, mtime: fs.statSync(path.join(markerDir, f)).mtimeMs }))
             .sort((a, b) => b.mtime - a.mtime);
-          for (const old of sessionMarkers.slice(10)) {
+          for (const old of sessionMarkers.slice(3)) {
             try { fs.unlinkSync(path.join(markerDir, old.name)); } catch { /* best effort */ }
           }
         } catch {


### PR DESCRIPTION
## Summary
- Added `.claude/session-identity/` to `.gitignore` to prevent ephemeral session markers from being tracked
- Reduced session identity file retention from 10 to 3 per type (pid-*, session-*) in `capture-session-id.cjs`
- Removed 20 stale session-identity files from git index

## Test plan
- [x] Pre-commit smoke tests pass (15/15)
- [ ] Verify new sessions only keep 3 most recent markers
- [ ] Verify session-identity files no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)