### PR TITLE
feat: merge schedulers into unified EvaMasterScheduler

### DIFF
--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -24,6 +24,14 @@ const VISION_SCORING_BATCH_SIZE = 5;
 const DEFAULT_DISPATCH_BATCH_SIZE = 20;
 const DEFAULT_MAX_STAGES_PER_CYCLE = 5;
 const DEFAULT_STATUS_TOP_N = 10;
+const DEFAULT_ROUND_TIMEOUT_MS = 30_000;
+
+const CADENCE_TO_MS = {
+  hourly: 3_600_000,
+  daily: 86_400_000,
+  weekly: 604_800_000,
+  monthly: 2_592_000_000,
+};
 
 // ── EvaMasterScheduler ──────────────────────────────────────
 
@@ -59,6 +67,12 @@ export class EvaMasterScheduler {
     // Periodic vision scoring configuration (US-001)
     this.visionScoringIntervalMs = cfg.visionScoringIntervalMs || DEFAULT_VISION_SCORING_INTERVAL_MS;
 
+    // Round registry (FR-1, FR-3, FR-4)
+    this._roundRegistry = new Map();
+    this._lastRoundRun = new Map();
+    this._totalRoundExecutions = 0;
+    this._totalRoundErrors = 0;
+
     // Internal state
     this._timer = null;
     this._running = false;
@@ -68,6 +82,11 @@ export class EvaMasterScheduler {
     this._totalErrors = 0;
     this._metricsWriteFailures = 0;
     this._lastVisionScoringAt = null;
+
+    // Register default rounds (FR-3)
+    this._registerDefaultRounds();
+    // Register notification rounds (FR-4)
+    this._registerNotificationRounds();
   }
 
   // ── Lifecycle ──────────────────────────────────────────────
@@ -124,6 +143,218 @@ export class EvaMasterScheduler {
     }
 
     this.logger.log(`[Scheduler] Stopped. Polls: ${this._pollCount}, Dispatches: ${this._totalDispatches}, Errors: ${this._totalErrors}`);
+  }
+
+  // ── Round Registry (FR-1) ─────────────────────────────────
+
+  /**
+   * Register a round type with its handler.
+   * @param {string} roundType - Unique round type name (e.g., 'vision_rescore')
+   * @param {Object} config
+   * @param {string} config.description - Human-readable description
+   * @param {Function} config.handler - async function(options) => result
+   * @param {string} [config.cadence] - Cadence: 'hourly', 'daily', 'weekly', 'monthly', 'on_demand'
+   */
+  registerRound(roundType, config) {
+    if (!roundType || !config?.handler) {
+      throw new Error('roundType and config.handler are required');
+    }
+    this._roundRegistry.set(roundType, {
+      type: roundType,
+      description: config.description || '',
+      handler: config.handler,
+      cadence: config.cadence || 'on_demand',
+      registeredAt: new Date().toISOString(),
+    });
+  }
+
+  /**
+   * Execute a registered round by type.
+   * @param {string} roundType
+   * @param {Object} [options]
+   * @returns {Promise<Object>} Execution result with timing
+   */
+  async runRound(roundType, options = {}) {
+    const round = this._roundRegistry.get(roundType);
+    if (!round) {
+      throw new Error(`Round type '${roundType}' not registered. Available: ${this.listRounds().map(r => r.type).join(', ')}`);
+    }
+
+    const startTime = Date.now();
+    this.logger.log(`[Scheduler] Round: ${roundType} - ${round.description}`);
+
+    try {
+      const result = await Promise.race([
+        round.handler(options),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('Round timeout')), DEFAULT_ROUND_TIMEOUT_MS)
+        ),
+      ]);
+      const latencyMs = Date.now() - startTime;
+      this._totalRoundExecutions++;
+      this._lastRoundRun.set(roundType, Date.now());
+
+      await this._emitMetric({
+        event_type: 'scheduler_round',
+        metadata: { round_type: roundType, outcome: 'success', latency_ms: latencyMs },
+      });
+
+      return { roundType, success: true, result, latencyMs, executedAt: new Date().toISOString() };
+    } catch (err) {
+      const latencyMs = Date.now() - startTime;
+      this._totalRoundErrors++;
+      this.logger.error(`[Scheduler] Round ${roundType} failed after ${latencyMs}ms: ${err.message}`);
+
+      await this._recordCircuitBreakerFailure(`round:${roundType}: ${err.message}`);
+      await this._emitMetric({
+        event_type: 'scheduler_round',
+        metadata: { round_type: roundType, outcome: 'failure', error: err.message, latency_ms: latencyMs },
+      });
+
+      return { roundType, success: false, error: err.message, latencyMs, executedAt: new Date().toISOString() };
+    }
+  }
+
+  /**
+   * List all registered rounds.
+   * @returns {Array<Object>}
+   */
+  listRounds() {
+    return Array.from(this._roundRegistry.values()).map(r => ({
+      type: r.type,
+      description: r.description,
+      cadence: r.cadence,
+      registeredAt: r.registeredAt,
+    }));
+  }
+
+  /**
+   * Execute all rounds whose cadence interval has elapsed (FR-2).
+   * Called at the end of each poll() cycle.
+   */
+  async _executeScheduledRounds() {
+    const breakerState = await this._getCircuitBreakerState();
+    if (breakerState === 'OPEN') {
+      this.logger.log('[Scheduler] Circuit breaker OPEN - skipping rounds');
+      return;
+    }
+
+    for (const [type, round] of this._roundRegistry) {
+      if (this._stopping) break;
+
+      const cadenceMs = CADENCE_TO_MS[round.cadence];
+      if (!cadenceMs) continue; // on_demand rounds skip automatic execution
+
+      const lastRun = this._lastRoundRun.get(type) || 0;
+      if (Date.now() - lastRun < cadenceMs) continue;
+
+      if (this.observeOnly) {
+        this.logger.log(`[Scheduler] OBSERVE: Would run round ${type}`);
+        this._lastRoundRun.set(type, Date.now());
+        continue;
+      }
+
+      await this.runRound(type);
+    }
+  }
+
+  /**
+   * Register the 4 default EVA rounds (FR-3).
+   */
+  _registerDefaultRounds() {
+    this.registerRound('vision_rescore', {
+      description: 'Rescore portfolio vision alignment via inline Claude Code evaluation',
+      cadence: 'weekly',
+      handler: async () => {
+        const { createVisionGovernanceService } = await import('./vision-governance-service.js');
+        const service = createVisionGovernanceService();
+        const latest = await service.getLatestScore();
+        return {
+          action: 'rescore_needed',
+          lastScore: latest?.total_score || null,
+          lastScoredAt: latest?.scored_at || null,
+          instruction: 'Run: node scripts/eva/vision-heal.js score',
+        };
+      },
+    });
+
+    this.registerRound('gap_analysis', {
+      description: 'Analyze open vision gaps and check for corrective SD progress',
+      cadence: 'weekly',
+      handler: async () => {
+        const { createVisionGovernanceService } = await import('./vision-governance-service.js');
+        const service = createVisionGovernanceService();
+        const [gaps, correctives] = await Promise.all([
+          service.getGaps(),
+          service.getActiveCorrectiveSDs(),
+        ]);
+        return {
+          openGaps: gaps.length,
+          activeCorrectiveSDs: correctives.length,
+          gaps: gaps.slice(0, 5),
+          correctives: correctives.slice(0, 5),
+        };
+      },
+    });
+
+    this.registerRound('stage_health', {
+      description: 'Check stage template completeness across all 25 lifecycle stages',
+      cadence: 'monthly',
+      handler: async () => {
+        const { readdirSync } = await import('fs');
+        const { join, dirname } = await import('path');
+        const { fileURLToPath } = await import('url');
+        const __dirname = dirname(fileURLToPath(import.meta.url));
+        const templatesDir = join(__dirname, 'stage-templates');
+
+        const files = readdirSync(templatesDir).filter(f => f.match(/^stage-\d{2}\.js$/));
+        const found = files.map(f => parseInt(f.match(/stage-(\d{2})/)[1]));
+        const missing = [];
+        for (let i = 1; i <= 25; i++) {
+          if (!found.includes(i)) missing.push(i);
+        }
+        return { totalStages: 25, templatesFound: found.length, templatesMissing: missing.length, found: found.sort((a, b) => a - b), missing };
+      },
+    });
+
+    this.registerRound('corrective_generation', {
+      description: 'Generate corrective SDs from latest vision score gaps',
+      cadence: 'weekly',
+      handler: async () => {
+        const { createVisionGovernanceService } = await import('./vision-governance-service.js');
+        const service = createVisionGovernanceService();
+        const latest = await service.getLatestScore();
+        if (!latest) return { action: 'no_scores', message: 'No vision scores found. Run eva:heal score first.' };
+        if (latest.threshold_action === 'accept') return { action: 'accept', score: latest.total_score, message: 'All dimensions pass. No correctives needed.' };
+        const result = await service.generateCorrectiveSDs(latest.id);
+        return { action: result.created ? 'created' : 'deferred', scoreId: latest.id, totalScore: latest.total_score, ...result };
+      },
+    });
+  }
+
+  /**
+   * Register notification digest/summary as rounds (FR-4).
+   */
+  _registerNotificationRounds() {
+    const supabase = this.supabase;
+
+    this.registerRound('daily_digest', {
+      description: 'Send daily digest notifications to chairmen',
+      cadence: 'daily',
+      handler: async () => {
+        const { runDailyDigestScheduler } = await import('../notifications/scheduler.js');
+        return runDailyDigestScheduler(supabase);
+      },
+    });
+
+    this.registerRound('weekly_summary', {
+      description: 'Send weekly summary notifications to chairmen',
+      cadence: 'weekly',
+      handler: async () => {
+        const { runWeeklySummaryScheduler } = await import('../notifications/scheduler.js');
+        return runWeeklySummaryScheduler(supabase);
+      },
+    });
   }
 
   // ── Poll Cycle ─────────────────────────────────────────────
@@ -183,6 +414,8 @@ export class EvaMasterScheduler {
         duration_ms: Date.now() - pollStart,
       });
       await this._updateHeartbeat('running', { circuit_breaker_state: breakerState || 'CLOSED' });
+      // Still run scheduled rounds even with no ventures (FR-2)
+      await this._executeScheduledRounds();
       return;
     }
 
@@ -215,6 +448,9 @@ export class EvaMasterScheduler {
 
     // Run periodic vision scoring (daily cadence, feature-flag gated — US-001)
     await this.runPeriodicVisionScoring();
+
+    // Execute scheduled rounds (FR-2)
+    await this._executeScheduledRounds();
   }
 
   // ── Periodic Vision Scoring ────────────────────────────────
@@ -599,6 +835,9 @@ export class EvaMasterScheduler {
           metadata: {
             observe_only: this.observeOnly,
             metrics_write_failures: this._metricsWriteFailures,
+            round_execution_count: this._totalRoundExecutions,
+            round_error_count: this._totalRoundErrors,
+            registered_rounds: this.listRounds().map(r => r.type),
           },
         }, { onConflict: 'id' });
     } catch (err) {
@@ -657,6 +896,9 @@ export class EvaMasterScheduler {
       poll_count: heartbeat?.poll_count || 0,
       dispatch_count: heartbeat?.dispatch_count || 0,
       error_count: heartbeat?.error_count || 0,
+      round_execution_count: heartbeat?.metadata?.round_execution_count || 0,
+      round_error_count: heartbeat?.metadata?.round_error_count || 0,
+      registered_rounds: heartbeat?.metadata?.registered_rounds || [],
       circuit_breaker_state: heartbeat?.circuit_breaker_state || 'UNKNOWN',
       paused_reason: heartbeat?.paused_reason || null,
       queue_depth: queueDepth || 0,

--- a/lib/eva/rounds-scheduler.js
+++ b/lib/eva/rounds-scheduler.js
@@ -1,121 +1,65 @@
 /**
- * Rounds Scheduler
- * SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-002: FR-002
+ * Rounds Scheduler - Thin Wrapper
+ * SD-EHG-ORCH-FOUNDATION-CLEANUP-001-E: FR-7
  *
- * Implements the "Rounds" scheduling mode from the EVA architecture:
- * periodic batch operations that run on a cadence (vs Events for urgent,
- * Priority Queue for planned work).
+ * Backward-compatible re-export layer. All round registration and execution
+ * is now handled by EvaMasterScheduler. This module maintains the original
+ * API surface for existing consumers (e.g., scripts/eva/run-rounds.js).
  *
- * Round types are registered with handler functions. The scheduler
- * executes them on demand via CLI or programmatically.
+ * Original: SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-002: FR-002
  */
 
-const roundRegistry = new Map();
+import { EvaMasterScheduler } from './eva-master-scheduler.js';
+
+// Singleton instance for module-level API compatibility.
+// Uses a minimal config (no supabase needed for round registry operations).
+const _sharedInstance = new EvaMasterScheduler({ config: { pollIntervalMs: 60_000 } });
 
 /**
  * Register a round type with its handler.
- * @param {string} roundType - Unique round type name (e.g., 'vision_rescore')
- * @param {Object} config
- * @param {string} config.description - Human-readable description
- * @param {Function} config.handler - async function(options) => result
- * @param {string} [config.cadence] - Suggested cadence (e.g., 'daily', 'weekly')
+ * Delegates to the shared EvaMasterScheduler instance.
+ * @param {string} roundType
+ * @param {Object} config - { description, handler, cadence }
  */
 export function registerRound(roundType, config) {
-  if (!roundType || !config?.handler) {
-    throw new Error('roundType and config.handler are required');
-  }
-
-  roundRegistry.set(roundType, {
-    type: roundType,
-    description: config.description || '',
-    handler: config.handler,
-    cadence: config.cadence || 'on_demand',
-    registeredAt: new Date().toISOString(),
-  });
+  _sharedInstance.registerRound(roundType, config);
 }
 
 /**
  * Execute a registered round.
- * @param {string} roundType - Round type to execute
- * @param {Object} [options] - Options passed to the handler
- * @returns {Promise<Object>} Execution result with timing
+ * @param {string} roundType
+ * @param {Object} [options]
+ * @returns {Promise<Object>}
  */
-export async function runRound(roundType, options = {}) {
-  const round = roundRegistry.get(roundType);
-  if (!round) {
-    throw new Error(`Round type '${roundType}' not registered. Available: ${listRounds().map(r => r.type).join(', ')}`);
-  }
-
-  const startTime = Date.now();
-  console.log(`\n🔄 Round: ${roundType}`);
-  console.log(`   Description: ${round.description}`);
-
-  try {
-    const result = await round.handler(options);
-    const latencyMs = Date.now() - startTime;
-
-    console.log(`   ✅ Completed in ${latencyMs}ms`);
-
-    return {
-      roundType,
-      success: true,
-      result,
-      latencyMs,
-      executedAt: new Date().toISOString(),
-    };
-  } catch (err) {
-    const latencyMs = Date.now() - startTime;
-    console.error(`   ❌ Failed after ${latencyMs}ms: ${err.message}`);
-
-    return {
-      roundType,
-      success: false,
-      error: err.message,
-      latencyMs,
-      executedAt: new Date().toISOString(),
-    };
-  }
+export function runRound(roundType, options = {}) {
+  return _sharedInstance.runRound(roundType, options);
 }
 
 /**
- * Start an interval-based scheduler that runs rounds on their declared cadence.
- * SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-006: FR-001
- *
+ * List all registered rounds.
+ * @returns {Array<Object>}
+ */
+export function listRounds() {
+  return _sharedInstance.listRounds();
+}
+
+/**
+ * Start an interval-based scheduler (legacy convenience function).
+ * Creates a new EvaMasterScheduler for the interval loop.
  * @param {Object} [options]
- * @param {number} [options.intervalMs=3600000] - Check interval in ms (default: 1 hour)
- * @param {Function} [options.logger] - Logger (default: console.log)
- * @returns {{ stop: Function }} Controller to stop the scheduler
+ * @param {number} [options.intervalMs=3600000]
+ * @param {Function} [options.logger]
+ * @returns {{ stop: Function }}
  */
 export function startScheduler(options = {}) {
-  const { intervalMs = 3600000, logger = console.log } = options;
-
-  const cadenceToMs = {
-    hourly: 3600000,
-    daily: 86400000,
-    weekly: 604800000,
-    monthly: 2592000000,
-  };
-
-  const lastRun = new Map();
+  const { intervalMs = 3_600_000, logger = console.log } = options;
 
   const tick = async () => {
-    for (const [type, round] of roundRegistry) {
-      const cadenceMs = cadenceToMs[round.cadence];
-      if (!cadenceMs) continue; // on_demand rounds skip
-
-      const last = lastRun.get(type) || 0;
-      if (Date.now() - last >= cadenceMs) {
-        logger(`[RoundsScheduler] Running scheduled round: ${type}`);
-        await runRound(type).catch(err =>
-          logger(`[RoundsScheduler] Round ${type} failed: ${err.message}`)
-        );
-        lastRun.set(type, Date.now());
-      }
-    }
+    await _sharedInstance._executeScheduledRounds();
   };
 
   const intervalId = setInterval(tick, intervalMs);
-  logger(`[RoundsScheduler] Started with ${intervalMs}ms check interval`);
+  logger(`[RoundsScheduler] Started with ${intervalMs}ms check interval (delegating to EvaMasterScheduler)`);
 
   return {
     stop() {
@@ -124,106 +68,3 @@ export function startScheduler(options = {}) {
     },
   };
 }
-
-/**
- * List all registered rounds.
- * @returns {Array<Object>} Registered round configurations
- */
-export function listRounds() {
-  return Array.from(roundRegistry.values()).map(r => ({
-    type: r.type,
-    description: r.description,
-    cadence: r.cadence,
-    registeredAt: r.registeredAt,
-  }));
-}
-
-// ── Default Round Types ──────────────────────────────────────────────────────
-
-registerRound('vision_rescore', {
-  description: 'Rescore portfolio vision alignment via inline Claude Code evaluation',
-  cadence: 'weekly',
-  handler: async (options = {}) => {
-    const { createVisionGovernanceService } = await import('./vision-governance-service.js');
-    const service = createVisionGovernanceService();
-    const latest = await service.getLatestScore();
-    return {
-      action: 'rescore_needed',
-      lastScore: latest?.total_score || null,
-      lastScoredAt: latest?.scored_at || null,
-      instruction: 'Run: node scripts/eva/vision-heal.js score',
-    };
-  },
-});
-
-registerRound('gap_analysis', {
-  description: 'Analyze open vision gaps and check for corrective SD progress',
-  cadence: 'weekly',
-  handler: async () => {
-    const { createVisionGovernanceService } = await import('./vision-governance-service.js');
-    const service = createVisionGovernanceService();
-    const [gaps, correctives] = await Promise.all([
-      service.getGaps(),
-      service.getActiveCorrectiveSDs(),
-    ]);
-    return {
-      openGaps: gaps.length,
-      activeCorrectiveSDs: correctives.length,
-      gaps: gaps.slice(0, 5),
-      correctives: correctives.slice(0, 5),
-    };
-  },
-});
-
-registerRound('stage_health', {
-  description: 'Check stage template completeness across all 25 lifecycle stages',
-  cadence: 'monthly',
-  handler: async () => {
-    const { readdirSync } = await import('fs');
-    const { join, dirname } = await import('path');
-    const { fileURLToPath } = await import('url');
-    const __dirname = dirname(fileURLToPath(import.meta.url));
-    const templatesDir = join(__dirname, 'stage-templates');
-
-    const files = readdirSync(templatesDir).filter(f => f.match(/^stage-\d{2}\.js$/));
-    const found = files.map(f => parseInt(f.match(/stage-(\d{2})/)[1]));
-    const missing = [];
-    for (let i = 1; i <= 25; i++) {
-      if (!found.includes(i)) missing.push(i);
-    }
-
-    return {
-      totalStages: 25,
-      templatesFound: found.length,
-      templatesMissing: missing.length,
-      found: found.sort((a, b) => a - b),
-      missing,
-    };
-  },
-});
-
-registerRound('corrective_generation', {
-  description: 'Generate corrective SDs from latest vision score gaps',
-  cadence: 'weekly',
-  handler: async () => {
-    const { createVisionGovernanceService } = await import('./vision-governance-service.js');
-    const service = createVisionGovernanceService();
-    const latest = await service.getLatestScore();
-
-    if (!latest) {
-      return { action: 'no_scores', message: 'No vision scores found. Run eva:heal score first.' };
-    }
-
-    if (latest.threshold_action === 'accept') {
-      return { action: 'accept', score: latest.total_score, message: 'All dimensions pass. No correctives needed.' };
-    }
-
-    const result = await service.generateCorrectiveSDs(latest.id);
-    return {
-      action: result.created ? 'created' : 'deferred',
-      scoreId: latest.id,
-      totalScore: latest.total_score,
-      ...result,
-    };
-  },
-});


### PR DESCRIPTION
## Summary
- Consolidate RoundsScheduler and NotificationScheduler into EvaMasterScheduler's round registry system (SD-EHG-ORCH-FOUNDATION-CLEANUP-001-E)
- Add round registry with registerRound/runRound/listRounds API, 6 default rounds, cadence enforcement, circuit breaker respect, observe-only mode, and 30s timeout protection
- Convert rounds-scheduler.js to thin backward-compatible wrapper delegating to EvaMasterScheduler
- 75 tests passing (16 new tests added)

## Test plan
- [x] All 75 unit tests passing (vitest)
- [x] Existing observe-only tests properly isolated from round OBSERVE logs
- [x] Round registry: register, run, list, error tracking, metric emission
- [x] Scheduled execution: cadence enforcement, on_demand skip, circuit breaker, observe-only
- [x] Poll integration: _executeScheduledRounds called during poll cycle
- [x] Backward compatibility: run-rounds.js CLI unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)