### PR TITLE
feat(claims): redundant verification for 3-session workflows

### DIFF
--- a/lib/claim-guard.cjs
+++ b/lib/claim-guard.cjs
@@ -22,4 +22,9 @@ async function formatClaimFailure(result) {
   return mod.formatClaimFailure(result);
 }
 
-module.exports = { claimGuard, formatClaimFailure };
+async function verifyClaimOwnership(sdKey, sessionId) {
+  const mod = await loadModule();
+  return mod.verifyClaimOwnership(sdKey, sessionId);
+}
+
+module.exports = { claimGuard, formatClaimFailure, verifyClaimOwnership };

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -115,7 +115,7 @@ export async function claimGuard(sdKey, sessionId) {
     .from('claude_sessions')
     .select('sd_id, session_id, track, claimed_at')
     .eq('sd_id', sdKey)
-    .eq('status', 'active');
+    .in('status', ['active', 'idle']);
 
   if (claimQueryError) {
     throw new Error(`claimGuard: Failed to query claude_sessions: ${claimQueryError.message}`);
@@ -305,6 +305,16 @@ export async function claimGuard(sdKey, sessionId) {
     };
   }
 
+  // Post-acquisition verification: read back to confirm we actually own the claim
+  const verification = await verifyClaimOwnership(sdKey, sessionId);
+  if (!verification.verified) {
+    return {
+      success: false,
+      error: `claim_verification_failed: ${verification.error}`,
+      owner: undefined
+    };
+  }
+
   // Update claiming_session_id on the SD (new column from migration)
   await supabase
     .from('strategic_directives_v2')
@@ -356,4 +366,64 @@ export function formatClaimFailure(result) {
   return lines.join('\n');
 }
 
-export default { claimGuard, formatClaimFailure, isSameConversation };
+/**
+ * Post-acquisition verification: read back from claude_sessions to confirm
+ * this session actually holds the claim. Catches race conditions where
+ * claim_sd() RPC reports success but another session won the race.
+ *
+ * Fail-open on query errors (Supabase hiccup shouldn't block work).
+ * Fail-closed on data inconsistencies (wrong owner, multiple claims).
+ *
+ * @param {string} sdKey - The SD key
+ * @param {string} sessionId - Expected owner session ID
+ * @returns {Promise<{verified: boolean, error?: string}>}
+ */
+export async function verifyClaimOwnership(sdKey, sessionId) {
+  const supabase = getSupabase();
+
+  let rows, queryError;
+  try {
+    const result = await supabase
+      .from('claude_sessions')
+      .select('session_id, sd_id, status')
+      .eq('sd_id', sdKey)
+      .in('status', ['active', 'idle']);
+
+    rows = result.data;
+    queryError = result.error;
+  } catch (err) {
+    // Network/unexpected error → fail-open
+    console.warn(`[Verify] Query exception (fail-open): ${err.message}`);
+    return { verified: true, error: `query_exception: ${err.message}` };
+  }
+
+  if (queryError) {
+    // Supabase error → fail-open
+    console.warn(`[Verify] Query error (fail-open): ${queryError.message}`);
+    return { verified: true, error: `query_error: ${queryError.message}` };
+  }
+
+  if (!rows || rows.length === 0) {
+    // No claim found — RPC said success but no row exists
+    console.error(`[Verify] FAIL: No active claim found for ${sdKey} after successful RPC`);
+    return { verified: false, error: 'no_claim_after_rpc' };
+  }
+
+  if (rows.length > 1) {
+    // Multiple active claims — index violation or race condition
+    const owners = rows.map(r => r.session_id).join(', ');
+    console.error(`[Verify] FAIL: Multiple active claims for ${sdKey}: [${owners}]`);
+    return { verified: false, error: `multiple_claims: ${owners}` };
+  }
+
+  if (rows[0].session_id !== sessionId) {
+    // Wrong owner — another session won the race
+    console.error(`[Verify] FAIL: Claim for ${sdKey} owned by ${rows[0].session_id}, expected ${sessionId}`);
+    return { verified: false, error: `wrong_owner: ${rows[0].session_id}` };
+  }
+
+  console.log(`[Verify] Claim ownership confirmed: ${sessionId} owns ${sdKey}`);
+  return { verified: true };
+}
+
+export default { claimGuard, formatClaimFailure, isSameConversation, verifyClaimOwnership };

--- a/lib/claim-guard.test.js
+++ b/lib/claim-guard.test.js
@@ -8,8 +8,9 @@
  *   - Active session → HARD STOP
  *   - Stale session → Release → Acquire → PROCEED
  *
- * SD-LEO-FIX-CLAIM-DUAL-TRUTH-001: claimGuard now queries sd_claims (authoritative)
- * instead of v_active_sessions (which reads from claude_sessions.sd_id cache).
+ * SD-LEO-INFRA-CONSOLIDATE-CLAIMS-INTO-001: sd_claims table dropped.
+ * claimGuard queries claude_sessions directly (sd_id column IS the claim).
+ * Status filter includes both 'active' and 'idle' to match the partial unique index.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -35,24 +36,24 @@ vi.mock('@supabase/supabase-js', () => ({
 }));
 
 /**
- * Helper: Build a Supabase query chain mock for sd_claims.
- * sd_claims queries use: .from('sd_claims').select(...).eq('sd_id', key).is('released_at', null)
+ * Helper: Build a Supabase query chain mock for claude_sessions initial claim check.
+ * Query pattern: .from('claude_sessions').select(...).eq('sd_id', key).in('status', ['active', 'idle'])
  */
-function mockSdClaimsQuery(data, error = null) {
+function mockClaudeSessionsClaimQuery(data, error = null) {
   return {
     select: vi.fn().mockReturnValue({
       eq: vi.fn().mockReturnValue({
-        is: vi.fn().mockResolvedValue({ data, error })
+        in: vi.fn().mockResolvedValue({ data, error })
       })
     })
   };
 }
 
 /**
- * Helper: Build a Supabase query chain mock for claude_sessions (enrichment).
- * claude_sessions enrichment: .from('claude_sessions').select(...).in('session_id', ids)
+ * Helper: Build a Supabase query chain mock for claude_sessions enrichment.
+ * Query pattern: .from('claude_sessions').select(...).in('session_id', ids)
  */
-function mockClaudeSessionsQuery(data, error = null) {
+function mockClaudeSessionsEnrichmentQuery(data, error = null) {
   return {
     select: vi.fn().mockReturnValue({
       in: vi.fn().mockResolvedValue({ data, error }),
@@ -67,7 +68,7 @@ function mockClaudeSessionsQuery(data, error = null) {
 }
 
 describe('claimGuard', () => {
-  let claimGuard, formatClaimFailure;
+  let claimGuard;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -86,7 +87,6 @@ describe('claimGuard', () => {
 
     const mod = await import('./claim-guard.mjs');
     claimGuard = mod.claimGuard;
-    formatClaimFailure = mod.formatClaimFailure;
   });
 
   it('throws if sdKey is missing', async () => {
@@ -97,45 +97,103 @@ describe('claimGuard', () => {
     await expect(claimGuard('SD-TEST-001', null)).rejects.toThrow('claimGuard requires both sdKey and sessionId');
   });
 
-  it('queries sd_claims directly, not v_active_sessions (US-001)', async () => {
-    // Setup: sd_claims returns our own session
+  it('queries claude_sessions directly, not v_active_sessions', async () => {
+    const now = new Date().toISOString();
+    let claudeSessionsCallCount = 0;
     mockFrom.mockImplementation((table) => {
-      if (table === 'sd_claims') {
-        return mockSdClaimsQuery([{
-          sd_id: 'SD-TEST-001', session_id: 'session-1', track: 'A', claimed_at: new Date().toISOString()
-        }]);
-      }
       if (table === 'claude_sessions') {
-        return mockClaudeSessionsQuery([{
-          session_id: 'session-1', terminal_id: 'win-cc-30738-1234', pid: 1234,
-          hostname: 'testhost', tty: '/dev/pts/0', codebase: '/test',
-          heartbeat_at: new Date().toISOString(), status: 'active'
-        }]);
+        claudeSessionsCallCount++;
+        if (claudeSessionsCallCount === 1) {
+          // First call: claim check (.select().eq('sd_id').in('status'))
+          return mockClaudeSessionsClaimQuery([{
+            sd_id: 'SD-TEST-001', session_id: 'session-1', track: 'A', claimed_at: now
+          }]);
+        }
+        if (claudeSessionsCallCount === 2) {
+          // Second call: enrichment (.select().in('session_id'))
+          return mockClaudeSessionsEnrichmentQuery([{
+            session_id: 'session-1', terminal_id: 'win-cc-30738-1234', pid: 1234,
+            hostname: 'testhost', tty: '/dev/pts/0', codebase: '/test',
+            heartbeat_at: now, status: 'active'
+          }]);
+        }
+        // Third call: heartbeat update
+        return {
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: null, error: null })
+          })
+        };
       }
       return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
     });
 
     await claimGuard('SD-TEST-001', 'session-1');
 
-    // Verify sd_claims was queried (not v_active_sessions)
-    expect(mockFrom).toHaveBeenCalledWith('sd_claims');
+    // Verify claude_sessions was queried (not v_active_sessions)
+    expect(mockFrom).toHaveBeenCalledWith('claude_sessions');
     expect(mockFrom).not.toHaveBeenCalledWith('v_active_sessions');
+  });
+
+  it('uses status filter including idle (not just active)', async () => {
+    // Use a spy to capture the .in() call arguments
+    const inSpy = vi.fn().mockResolvedValue({
+      data: [{
+        sd_id: 'SD-TEST-001', session_id: 'session-1', track: 'A', claimed_at: new Date().toISOString()
+      }],
+      error: null
+    });
+
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: inSpy
+            }),
+            in: vi.fn().mockResolvedValue({ data: [], error: null })
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: null, error: null })
+          })
+        };
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    await claimGuard('SD-TEST-001', 'session-1');
+
+    // Verify the .in() call includes both 'active' and 'idle'
+    expect(inSpy).toHaveBeenCalledWith('status', ['active', 'idle']);
   });
 
   it('returns success when session already owns claim (Case 1)', async () => {
     const now = new Date().toISOString();
     mockFrom.mockImplementation((table) => {
-      if (table === 'sd_claims') {
-        return mockSdClaimsQuery([{
-          sd_id: 'SD-TEST-001', session_id: 'session-1', track: 'A', claimed_at: now
-        }]);
-      }
       if (table === 'claude_sessions') {
-        return mockClaudeSessionsQuery([{
-          session_id: 'session-1', terminal_id: 'win-cc-30738-1234', pid: 1234,
-          hostname: 'testhost', tty: '/dev/pts/0', codebase: '/test',
-          heartbeat_at: now, status: 'active'
-        }]);
+        // First call: claim check returns own session; subsequent calls: enrichment + heartbeat
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockResolvedValue({
+                data: [{
+                  sd_id: 'SD-TEST-001', session_id: 'session-1', track: 'A', claimed_at: now
+                }],
+                error: null
+              })
+            }),
+            in: vi.fn().mockResolvedValue({
+              data: [{
+                session_id: 'session-1', terminal_id: 'win-cc-30738-1234', pid: 1234,
+                hostname: 'testhost', tty: '/dev/pts/0', codebase: '/test',
+                heartbeat_at: now, status: 'active'
+              }],
+              error: null
+            })
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: null, error: null })
+          })
+        };
       }
       return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
     });
@@ -148,18 +206,18 @@ describe('claimGuard', () => {
 
   it('returns hard stop when active session owns claim (Case 2)', async () => {
     const now = new Date().toISOString();
-    // Track call count to differentiate enrichment (.in) vs my-terminal-id (.eq.single) queries
     let claudeSessionsCallCount = 0;
     mockFrom.mockImplementation((table) => {
-      if (table === 'sd_claims') {
-        return mockSdClaimsQuery([{
-          sd_id: 'SD-TEST-001', session_id: 'other-session', track: 'A', claimed_at: now
-        }]);
-      }
       if (table === 'claude_sessions') {
         claudeSessionsCallCount++;
         if (claudeSessionsCallCount === 1) {
-          // First call: enrichment query with .in()
+          // First call: claim check returns other session
+          return mockClaudeSessionsClaimQuery([{
+            sd_id: 'SD-TEST-001', session_id: 'other-session', track: 'A', claimed_at: now
+          }]);
+        }
+        if (claudeSessionsCallCount === 2) {
+          // Second call: enrichment query with .in()
           return {
             select: vi.fn().mockReturnValue({
               in: vi.fn().mockResolvedValue({
@@ -173,7 +231,7 @@ describe('claimGuard', () => {
             })
           };
         }
-        // Second call: my terminal_id query with .eq().single()
+        // Third call: my terminal_id query with .eq().single()
         return {
           select: vi.fn().mockReturnValue({
             eq: vi.fn().mockReturnValue({
@@ -198,17 +256,40 @@ describe('claimGuard', () => {
 
   it('releases stale session and acquires claim (Case 3)', async () => {
     const staleTime = new Date(Date.now() - 1000 * 1000).toISOString(); // 1000s ago (> 900s threshold)
+    let claudeSessionsCallCount = 0;
     mockFrom.mockImplementation((table) => {
-      if (table === 'sd_claims') {
-        return mockSdClaimsQuery([{
-          sd_id: 'SD-TEST-001', session_id: 'stale-session', track: 'A', claimed_at: staleTime
-        }]);
-      }
       if (table === 'claude_sessions') {
-        return mockClaudeSessionsQuery([{
-          session_id: 'stale-session', terminal_id: 'win-cc-11111-9999', pid: 9999,
-          hostname: 'stalehost', tty: '/dev/pts/2', codebase: '/stale',
-          heartbeat_at: staleTime, status: 'active'
+        claudeSessionsCallCount++;
+        if (claudeSessionsCallCount === 1) {
+          // First call: claim check returns stale session (.select().eq('sd_id').in('status'))
+          return mockClaudeSessionsClaimQuery([{
+            sd_id: 'SD-TEST-001', session_id: 'stale-session', track: 'A', claimed_at: staleTime
+          }]);
+        }
+        if (claudeSessionsCallCount === 2) {
+          // Second call: enrichment (.select().in('session_id'))
+          return mockClaudeSessionsEnrichmentQuery([{
+            session_id: 'stale-session', terminal_id: 'win-cc-11111-9999', pid: 9999,
+            hostname: 'stalehost', tty: '/dev/pts/2', codebase: '/stale',
+            heartbeat_at: staleTime, status: 'active'
+          }]);
+        }
+        if (claudeSessionsCallCount === 3) {
+          // Third call: myTerminalId lookup (.select().eq('session_id').single())
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { terminal_id: 'win-cc-22222-1111' },
+                  error: null
+                })
+              })
+            })
+          };
+        }
+        // Fourth call: verifyClaimOwnership read-back (.select().eq('sd_id').in('status'))
+        return mockClaudeSessionsClaimQuery([{
+          session_id: 'session-1', sd_id: 'SD-TEST-001', status: 'active'
         }]);
       }
       if (table === 'sd_baseline_items') {
@@ -252,9 +333,18 @@ describe('claimGuard', () => {
   });
 
   it('acquires claim when no existing claims (Case 4)', async () => {
+    let claudeSessionsCallCount = 0;
     mockFrom.mockImplementation((table) => {
-      if (table === 'sd_claims') {
-        return mockSdClaimsQuery([]);
+      if (table === 'claude_sessions') {
+        claudeSessionsCallCount++;
+        if (claudeSessionsCallCount === 1) {
+          // First call: no active claims
+          return mockClaudeSessionsClaimQuery([]);
+        }
+        // Second call: verifyClaimOwnership read-back after RPC success
+        return mockClaudeSessionsClaimQuery([{
+          session_id: 'session-1', sd_id: 'SD-TEST-001', status: 'active'
+        }]);
       }
       if (table === 'sd_baseline_items') {
         return {
@@ -287,16 +377,155 @@ describe('claimGuard', () => {
     expect(result.claim.track).toBe('STANDALONE');
   });
 
-  it('handles sd_claims query error gracefully', async () => {
+  it('handles claude_sessions query error gracefully', async () => {
     mockFrom.mockImplementation((table) => {
-      if (table === 'sd_claims') {
-        return mockSdClaimsQuery(null, { message: 'Connection refused' });
+      if (table === 'claude_sessions') {
+        return mockClaudeSessionsClaimQuery(null, { message: 'Connection refused' });
       }
       return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
     });
 
     await expect(claimGuard('SD-TEST-001', 'session-1'))
-      .rejects.toThrow('claimGuard: Failed to query sd_claims: Connection refused');
+      .rejects.toThrow('claimGuard: Failed to query claude_sessions: Connection refused');
+  });
+
+  it('fails when post-acquisition verification detects wrong owner', async () => {
+    let claudeSessionsCallCount = 0;
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        claudeSessionsCallCount++;
+        if (claudeSessionsCallCount === 1) {
+          // First call: no active claims
+          return mockClaudeSessionsClaimQuery([]);
+        }
+        // Second call: verify returns wrong owner (race condition)
+        return mockClaudeSessionsClaimQuery([{
+          session_id: 'race-winner', sd_id: 'SD-TEST-001', status: 'active'
+        }]);
+      }
+      if (table === 'sd_baseline_items') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: null, error: null })
+            })
+          })
+        };
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    mockRpc.mockResolvedValue({
+      data: { success: true, sd_id: 'SD-TEST-001', session_id: 'session-1' },
+      error: null
+    });
+
+    const result = await claimGuard('SD-TEST-001', 'session-1');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('claim_verification_failed');
+    expect(result.error).toContain('wrong_owner');
+  });
+});
+
+describe('verifyClaimOwnership', () => {
+  let verifyClaimOwnership;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: vi.fn(() => mockSupabase)
+    }));
+    vi.doMock('dotenv', () => ({
+      default: { config: vi.fn() },
+      config: vi.fn()
+    }));
+
+    const mod = await import('./claim-guard.mjs');
+    verifyClaimOwnership = mod.verifyClaimOwnership;
+  });
+
+  it('returns verified=true when session owns the claim (happy path)', async () => {
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        return mockClaudeSessionsClaimQuery([{
+          session_id: 'session-1', sd_id: 'SD-TEST-001', status: 'active'
+        }]);
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
+
+    expect(result.verified).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it('returns verified=false when wrong session owns the claim', async () => {
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        return mockClaudeSessionsClaimQuery([{
+          session_id: 'other-session', sd_id: 'SD-TEST-001', status: 'active'
+        }]);
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
+
+    expect(result.verified).toBe(false);
+    expect(result.error).toContain('wrong_owner');
+    expect(result.error).toContain('other-session');
+  });
+
+  it('returns verified=false when no claim exists', async () => {
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        return mockClaudeSessionsClaimQuery([]);
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
+
+    expect(result.verified).toBe(false);
+    expect(result.error).toBe('no_claim_after_rpc');
+  });
+
+  it('returns verified=false when multiple claims exist', async () => {
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        return mockClaudeSessionsClaimQuery([
+          { session_id: 'session-1', sd_id: 'SD-TEST-001', status: 'active' },
+          { session_id: 'session-2', sd_id: 'SD-TEST-001', status: 'idle' }
+        ]);
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
+
+    expect(result.verified).toBe(false);
+    expect(result.error).toContain('multiple_claims');
+  });
+
+  it('returns verified=true (fail-open) on query error', async () => {
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        return mockClaudeSessionsClaimQuery(null, { message: 'timeout' });
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    const result = await verifyClaimOwnership('SD-TEST-001', 'session-1');
+
+    expect(result.verified).toBe(true);
+    expect(result.error).toContain('query_error');
   });
 });
 

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -543,7 +543,7 @@ export class BaseExecutor {
       .from('claude_sessions')
       .select('session_id, sd_id, claimed_at')
       .eq('sd_id', claimId)
-      .eq('status', 'active');
+      .in('status', ['active', 'idle']);
 
     const activeClaim = (existingClaims || []).find(c => {
       const ageSeconds = (Date.now() - new Date(c.claimed_at).getTime()) / 1000;


### PR DESCRIPTION
## Summary
- Fix status filter to include `idle` in `claimGuard()` and `BaseExecutor._claimSDForSession()` — the partial unique index covers both statuses, but the app-layer check only looked for `active`
- Add `verifyClaimOwnership()` post-acquisition read-back after `claim_sd()` RPC succeeds, catching race conditions where another session won
- Add independent cross-path verification in `sd-start.js` via `v_active_sessions` VIEW (different query path than direct table query, non-blocking)
- Update CJS wrapper and rewrite tests to match current `claude_sessions` schema (sd_claims was dropped)

## Test plan
- [x] `npx vitest run lib/claim-guard.test.js` — 17 tests pass (5 new for verifyClaimOwnership)
- [ ] Manual: `npm run sd:start <SD-ID>` should show `[Verify] Independent claim verification passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)