### PR TITLE
feat: add strategy CLI -- strategic themes table, vision derivation

### DIFF
--- a/database/migrations/20260220_create_strategic_themes.sql
+++ b/database/migrations/20260220_create_strategic_themes.sql
@@ -1,0 +1,93 @@
+-- Migration: Create strategic_themes table
+-- Date: 2026-02-20
+-- Purpose: Annual strategic themes derived from EVA vision documents
+-- Pattern: Matches constitutional_amendments (RLS, triggers, naming)
+
+-- =============================================================================
+-- Phase 1: Create table
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.strategic_themes (
+    id              UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+    theme_key       TEXT            NOT NULL UNIQUE,
+    title           TEXT            NOT NULL,
+    description     TEXT,
+    year            INTEGER         NOT NULL,
+    status          TEXT            NOT NULL DEFAULT 'draft'
+                                    CHECK (status IN ('draft', 'active', 'archived')),
+    vision_key      TEXT            REFERENCES public.eva_vision_documents(vision_key),
+    derived_from_vision BOOLEAN     DEFAULT false,
+    source_dimensions   JSONB,
+    created_by      TEXT            DEFAULT 'chairman',
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ     DEFAULT NOW()
+);
+
+-- =============================================================================
+-- Phase 2: Indexes
+-- =============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_strategic_themes_year
+    ON public.strategic_themes USING btree (year);
+
+-- =============================================================================
+-- Phase 3: Row Level Security
+-- =============================================================================
+
+ALTER TABLE public.strategic_themes ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access (matches constitutional_amendments pattern)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE tablename = 'strategic_themes'
+          AND policyname = 'service_role_all'
+    ) THEN
+        CREATE POLICY service_role_all
+            ON public.strategic_themes
+            FOR ALL
+            TO service_role
+            USING (true)
+            WITH CHECK (true);
+    END IF;
+END
+$$;
+
+-- =============================================================================
+-- Phase 4: Updated_at trigger
+-- =============================================================================
+
+-- Reuse existing trigger_set_updated_at() function (already exists in DB)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.triggers
+        WHERE event_object_table = 'strategic_themes'
+          AND trigger_name = 'set_strategic_themes_updated_at'
+    ) THEN
+        CREATE TRIGGER set_strategic_themes_updated_at
+            BEFORE UPDATE ON public.strategic_themes
+            FOR EACH ROW
+            EXECUTE FUNCTION trigger_set_updated_at();
+    END IF;
+END
+$$;
+
+-- =============================================================================
+-- Phase 5: Table and column comments
+-- =============================================================================
+
+COMMENT ON TABLE public.strategic_themes IS 'Annual strategic themes derived from EVA vision dimensions, used to group and prioritize Strategic Directives';
+COMMENT ON COLUMN public.strategic_themes.theme_key IS 'Human-readable unique key, e.g. THEME-2026-001';
+COMMENT ON COLUMN public.strategic_themes.vision_key IS 'FK to eva_vision_documents.vision_key - the vision this theme was derived from';
+COMMENT ON COLUMN public.strategic_themes.derived_from_vision IS 'Whether this theme was auto-derived from a vision document';
+COMMENT ON COLUMN public.strategic_themes.source_dimensions IS 'JSONB array of vision dimension keys used to derive this theme';
+COMMENT ON COLUMN public.strategic_themes.created_by IS 'Who created this theme (default: chairman)';
+
+-- =============================================================================
+-- Rollback SQL (for reference):
+-- DROP TRIGGER IF EXISTS set_strategic_themes_updated_at ON public.strategic_themes;
+-- DROP POLICY IF EXISTS service_role_all ON public.strategic_themes;
+-- DROP TABLE IF EXISTS public.strategic_themes;
+-- =============================================================================

--- a/scripts/eva/strategy-command.mjs
+++ b/scripts/eva/strategy-command.mjs
@@ -1,0 +1,422 @@
+#!/usr/bin/env node
+/**
+ * EVA Strategy Command - Strategic Theme Management
+ * SD: SD-EHG-ORCH-GOVERNANCE-STACK-001-C
+ *
+ * Manages annual strategic themes derived from vision documents.
+ * Follows the EVA CLI pattern (vision-command, mission-command, constitution-command).
+ *
+ * Subcommands:
+ *   view                             List all strategic themes
+ *   detail <id-or-title>             Show full detail for a single theme
+ *   derive [--year <year>]           Auto-derive themes from active vision documents
+ *          [--vision-key <key>]
+ *   create --title <title>           Manually create a strategic theme
+ *          --year <year>
+ *          --description <desc>
+ *          [--vision-key <key>]
+ *
+ * Usage:
+ *   node scripts/eva/strategy-command.mjs view
+ *   node scripts/eva/strategy-command.mjs detail THEME-2026-001
+ *   node scripts/eva/strategy-command.mjs derive
+ *   node scripts/eva/strategy-command.mjs derive --year 2026 --vision-key VISION-EHG-L1-001
+ *   node scripts/eva/strategy-command.mjs create --title "AI-First Operations" --year 2026 --description "..."
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// ============================================================================
+// Argument parsing
+// ============================================================================
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const subcommand = args[0];
+  const opts = {};
+  const positional = [];
+  for (let i = 1; i < args.length; i++) {
+    if (args[i].startsWith('--')) {
+      const key = args[i].slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      opts[key] = args[i + 1] && !args[i + 1].startsWith('--') ? args[++i] : true;
+    } else {
+      positional.push(args[i]);
+    }
+  }
+  return { subcommand, opts, positional };
+}
+
+// ============================================================================
+// Supabase client
+// ============================================================================
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Error: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required');
+    process.exit(1);
+  }
+  return createClient(url, key);
+}
+
+// ============================================================================
+// Status icons
+// ============================================================================
+
+const STATUS_ICONS = {
+  draft: '📝',
+  active: '✅',
+  archived: '📦'
+};
+
+// ============================================================================
+// Subcommand: view
+// ============================================================================
+
+async function cmdView(supabase) {
+  const { data, error } = await supabase
+    .from('strategic_themes')
+    .select('theme_key, title, year, status, derived_from_vision, vision_key')
+    .order('year', { ascending: false });
+
+  if (error || !data || data.length === 0) {
+    console.log('\n  No strategic themes found.\n');
+    return;
+  }
+
+  console.log('');
+  console.log('  ═══════════════════════════════════════════════════════');
+  console.log('  STRATEGIC THEMES');
+  console.log('  ═══════════════════════════════════════════════════════');
+  console.log(`  ${data.length} theme(s) loaded`);
+
+  for (const t of data) {
+    const icon = STATUS_ICONS[t.status] || '📌';
+    const source = t.derived_from_vision ? `derived from ${t.vision_key}` : 'manual';
+    console.log('');
+    console.log(`  ${icon} ${t.theme_key} [${t.year}] [${t.status.toUpperCase()}]`);
+    console.log(`     ${t.title}`);
+    console.log(`     Source: ${source}`);
+  }
+  console.log('');
+  console.log('  Use: strategy-command.mjs detail <THEME-KEY> for full detail');
+  console.log('');
+}
+
+// ============================================================================
+// Subcommand: detail
+// ============================================================================
+
+async function cmdDetail(supabase, identifier) {
+  if (!identifier) {
+    console.error('Error: theme key or ID required (e.g., THEME-2026-001)');
+    process.exit(1);
+  }
+
+  // Try by theme_key first, then by id
+  let query = supabase
+    .from('strategic_themes')
+    .select('*')
+    .eq('theme_key', identifier.toUpperCase());
+
+  let { data, error } = await query.single();
+
+  if (error || !data) {
+    // Try partial title match
+    const { data: titleMatch } = await supabase
+      .from('strategic_themes')
+      .select('*')
+      .ilike('title', `%${identifier}%`)
+      .limit(1)
+      .single();
+
+    if (!titleMatch) {
+      console.log(`\n  Theme "${identifier}" not found.\n`);
+      return;
+    }
+    data = titleMatch;
+  }
+
+  const icon = STATUS_ICONS[data.status] || '📌';
+
+  console.log('');
+  console.log('  ═══════════════════════════════════════════════════════');
+  console.log(`  ${icon} ${data.theme_key} [${data.year}] [${data.status.toUpperCase()}]`);
+  console.log('  ═══════════════════════════════════════════════════════');
+  console.log('');
+  console.log(`  Title: ${data.title}`);
+  console.log('');
+  if (data.description) {
+    console.log('  Description:');
+    console.log(`  ${data.description}`);
+    console.log('');
+  }
+  console.log(`  Source:  ${data.derived_from_vision ? 'Derived from vision' : 'Manual entry'}`);
+  if (data.vision_key) {
+    console.log(`  Vision:  ${data.vision_key}`);
+  }
+  if (data.source_dimensions && Array.isArray(data.source_dimensions) && data.source_dimensions.length > 0) {
+    console.log('  Dimensions:');
+    for (const dim of data.source_dimensions) {
+      console.log(`    - ${dim.name || dim.key} (weight: ${dim.weight || 'N/A'})`);
+    }
+  }
+  console.log('');
+  console.log(`  Created: ${new Date(data.created_at).toLocaleDateString()}`);
+  console.log(`  By:      ${data.created_by}`);
+  console.log(`  ID:      ${data.id}`);
+  console.log('');
+}
+
+// ============================================================================
+// Subcommand: derive
+// ============================================================================
+
+async function cmdDerive(supabase, opts) {
+  const year = parseInt(opts.year) || new Date().getFullYear();
+  const visionKeyFilter = opts.visionKey;
+
+  // Fetch active vision documents
+  let query = supabase
+    .from('eva_vision_documents')
+    .select('vision_key, level, content, extracted_dimensions, status')
+    .eq('status', 'active');
+
+  if (visionKeyFilter) {
+    query = query.eq('vision_key', visionKeyFilter.toUpperCase());
+  }
+
+  const { data: visionDocs, error: fetchErr } = await query;
+
+  if (fetchErr || !visionDocs || visionDocs.length === 0) {
+    console.log('\n  No active vision documents found.\n');
+    return;
+  }
+
+  console.log('');
+  console.log('  ═══════════════════════════════════════════════════════');
+  console.log('  DERIVING STRATEGIC THEMES FROM VISION');
+  console.log('  ═══════════════════════════════════════════════════════');
+  console.log(`  Year: ${year}`);
+  console.log(`  Vision documents: ${visionDocs.length}`);
+
+  // Get the highest existing theme index for this year
+  const { data: maxExisting } = await supabase
+    .from('strategic_themes')
+    .select('theme_key')
+    .eq('year', year)
+    .order('theme_key', { ascending: false })
+    .limit(1);
+
+  let nextIndex = 1;
+  if (maxExisting && maxExisting.length > 0) {
+    const match = maxExisting[0].theme_key.match(/THEME-\d+-(\d+)/);
+    if (match) nextIndex = parseInt(match[1]) + 1;
+  }
+
+  let totalCreated = 0;
+
+  for (const doc of visionDocs) {
+    const dims = doc.extracted_dimensions;
+    if (!dims || !Array.isArray(dims) || dims.length === 0) {
+      console.log(`\n  ⚠️  ${doc.vision_key}: No extracted dimensions, skipping`);
+      continue;
+    }
+
+    console.log(`\n  Processing ${doc.vision_key} (${dims.length} dimensions)...`);
+
+    // Check which themes already exist for this vision+year
+    const { data: existing } = await supabase
+      .from('strategic_themes')
+      .select('source_dimensions')
+      .eq('vision_key', doc.vision_key)
+      .eq('year', year);
+
+    const existingKeys = new Set();
+    if (existing) {
+      for (const e of existing) {
+        if (e.source_dimensions && Array.isArray(e.source_dimensions)) {
+          for (const d of e.source_dimensions) {
+            existingKeys.add(d.key || d.name);
+          }
+        }
+      }
+    }
+
+    // Group dimensions by weight (top dimensions become themes)
+    const sorted = [...dims].sort((a, b) => (b.weight || 0) - (a.weight || 0));
+
+    for (let i = 0; i < sorted.length; i++) {
+      const dim = sorted[i];
+      const dimKey = dim.key || dim.name;
+
+      if (existingKeys.has(dimKey)) {
+        console.log(`     ⏭️  ${dimKey}: already derived, skipping`);
+        continue;
+      }
+
+      // Generate theme_key
+      const themeKey = `THEME-${year}-${String(nextIndex).padStart(3, '0')}`;
+
+      // Convert dimension name to title case
+      const title = dimKey
+        .replace(/_/g, ' ')
+        .replace(/\b\w/g, c => c.toUpperCase());
+
+      const { data: inserted, error: insertErr } = await supabase
+        .from('strategic_themes')
+        .insert({
+          theme_key: themeKey,
+          title,
+          description: dim.description || `Derived from ${doc.vision_key} dimension: ${dimKey}`,
+          year,
+          status: 'draft',
+          vision_key: doc.vision_key,
+          derived_from_vision: true,
+          source_dimensions: [dim],
+          created_by: 'eva-derive'
+        })
+        .select('theme_key, title')
+        .single();
+
+      if (insertErr) {
+        console.log(`     ❌ ${themeKey}: ${insertErr.message}`);
+        continue;
+      }
+
+      console.log(`     ✅ ${inserted.theme_key}: ${inserted.title} (weight: ${dim.weight || 'N/A'})`);
+      totalCreated++;
+      nextIndex++;
+    }
+  }
+
+  console.log('');
+  console.log('  ───────────────────────────────────────────────────────');
+  console.log(`  Created ${totalCreated} theme(s) for ${year}`);
+  if (totalCreated > 0) {
+    console.log('  Status: draft (activate via DB or future activate subcommand)');
+  }
+  console.log('');
+}
+
+// ============================================================================
+// Subcommand: create
+// ============================================================================
+
+async function cmdCreate(supabase, opts) {
+  const title = opts.title;
+  const year = parseInt(opts.year);
+  const description = opts.description;
+
+  if (!title || title === true) {
+    console.error('Error: --title <title> is required');
+    process.exit(1);
+  }
+  if (!year || isNaN(year)) {
+    console.error('Error: --year <year> is required (e.g., 2026)');
+    process.exit(1);
+  }
+
+  // Get next theme index for this year
+  const { data: existing } = await supabase
+    .from('strategic_themes')
+    .select('theme_key')
+    .eq('year', year)
+    .order('theme_key', { ascending: false })
+    .limit(1);
+
+  let nextIndex = 1;
+  if (existing && existing.length > 0) {
+    const match = existing[0].theme_key.match(/THEME-\d+-(\d+)/);
+    if (match) nextIndex = parseInt(match[1]) + 1;
+  }
+
+  const themeKey = `THEME-${year}-${String(nextIndex).padStart(3, '0')}`;
+
+  const insertData = {
+    theme_key: themeKey,
+    title,
+    year,
+    status: 'draft',
+    derived_from_vision: false,
+    created_by: 'chairman'
+  };
+
+  if (description && description !== true) insertData.description = description;
+  if (opts.visionKey && opts.visionKey !== true) {
+    insertData.vision_key = opts.visionKey.toUpperCase();
+  }
+
+  const { data: theme, error: insertErr } = await supabase
+    .from('strategic_themes')
+    .insert(insertData)
+    .select('theme_key, title, year, status')
+    .single();
+
+  if (insertErr) {
+    console.error(`Error creating theme: ${insertErr.message}`);
+    process.exit(1);
+  }
+
+  console.log('');
+  console.log('  ═══════════════════════════════════════════════════════');
+  console.log('  STRATEGIC THEME CREATED');
+  console.log('  ═══════════════════════════════════════════════════════');
+  console.log('');
+  console.log(`  Key:    ${theme.theme_key}`);
+  console.log(`  Title:  ${theme.title}`);
+  console.log(`  Year:   ${theme.year}`);
+  console.log(`  Status: ${theme.status}`);
+  console.log('');
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  const { subcommand, opts, positional } = parseArgs(process.argv);
+  const supabase = getSupabase();
+
+  switch (subcommand) {
+    case 'view':
+      await cmdView(supabase);
+      break;
+    case 'detail':
+      await cmdDetail(supabase, positional[0] || opts.id);
+      break;
+    case 'derive':
+      await cmdDerive(supabase, opts);
+      break;
+    case 'create':
+      await cmdCreate(supabase, opts);
+      break;
+    default:
+      console.log('');
+      console.log('  EVA Strategy Command');
+      console.log('  ────────────────────');
+      console.log('  Usage:');
+      console.log('    node scripts/eva/strategy-command.mjs view                  List all themes');
+      console.log('    node scripts/eva/strategy-command.mjs detail THEME-2026-001 Show theme detail');
+      console.log('    node scripts/eva/strategy-command.mjs derive                Auto-derive from vision');
+      console.log('    node scripts/eva/strategy-command.mjs derive --year 2026 --vision-key VISION-EHG-L1-001');
+      console.log('    node scripts/eva/strategy-command.mjs create --title "..." --year 2026 --description "..."');
+      console.log('');
+      console.log('  Options:');
+      console.log('    --year <year>          Target year (default: current year)');
+      console.log('    --vision-key <key>     Filter by vision document key');
+      console.log('    --title <text>         Theme title (for create)');
+      console.log('    --description <text>   Theme description (for create)');
+      console.log('');
+      process.exit(subcommand ? 1 : 0);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err.message);
+  process.exit(1);
+});

--- a/scripts/temp/insert-prd-001-C.cjs
+++ b/scripts/temp/insert-prd-001-C.cjs
@@ -1,0 +1,75 @@
+const { createClient } = require('@supabase/supabase-js');
+const crypto = require('crypto');
+require('dotenv').config();
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function main() {
+  const prdId = crypto.randomUUID();
+  const sdUuid = '1566a2ed-ef0f-43eb-9c9c-7d9d873ececf';
+
+  const { data, error } = await supabase
+    .from('product_requirements_v2')
+    .insert({
+      id: prdId,
+      sd_id: sdUuid,
+      title: 'Strategy Layer - Annual Themes and Vision Derivation PRD',
+      status: 'approved',
+      version: '1.0',
+      executive_summary: 'Create strategic_themes table for annual strategic themes that can be auto-derived from vision documents. Add strategy-command.mjs to the EVA CLI suite, providing CLI access to view, create, and derive strategic themes. Follows established EVA CLI patterns (vision-command, mission-command, constitution-command). Subcommands: view (list themes), derive (auto-extract from vision), create (manual theme entry), detail (show single theme). Architecture supports future annual strategic planning sessions with Eva.',
+      functional_requirements: [
+        'view subcommand: List all strategic themes with year, title, status, and source',
+        'derive subcommand: Extract strategic themes from active vision documents (eva_vision_documents.extracted_dimensions)',
+        'create subcommand: Manually create a strategic theme with --title, --year, --description, --vision-key flags',
+        'detail subcommand: Show full detail for a single theme by ID or title match',
+        'Follow parseArgs + subcommand dispatch pattern from constitution-command.mjs',
+        'Strategic themes reference source vision document via vision_key FK'
+      ],
+      system_architecture: {
+        components: [
+          'scripts/eva/strategy-command.mjs - CLI entry point',
+          'Supabase: strategic_themes table (new, CRUD)',
+          'Supabase: eva_vision_documents table (existing, read for derivation)'
+        ],
+        patterns: ['EVA CLI parseArgs pattern', 'Supabase service role client', 'Formatted console output'],
+        dependencies: ['@supabase/supabase-js', 'dotenv']
+      },
+      acceptance_criteria: [
+        'strategy-command.mjs view lists all strategic themes',
+        'strategy-command.mjs derive extracts themes from active vision documents',
+        'strategy-command.mjs create --title "..." --year 2026 --description "..." creates manual theme',
+        'strategy-command.mjs detail <id> shows full theme detail',
+        'No args shows help text with usage examples',
+        'Follows exact same CLI patterns as constitution-command.mjs'
+      ],
+      test_scenarios: [
+        { scenario: 'View all themes', expected: 'Lists themes with year, title, status' },
+        { scenario: 'Derive from vision', expected: 'Extracts dimensions from active vision documents into strategic themes' },
+        { scenario: 'Create manual theme', expected: 'Inserts theme with all required fields' },
+        { scenario: 'View single theme detail', expected: 'Shows full description and source info' },
+        { scenario: 'Invalid subcommand', expected: 'Shows help text' }
+      ],
+      implementation_approach: 'Single file CLI command following established EVA pattern. Create strategic_themes table via database-agent. Read from eva_vision_documents for derive subcommand. Formatted console output matching constitution-command.mjs style.',
+      risks: [
+        { risk: 'strategic_themes table does not exist', mitigation: 'Create via database-agent with proper constraints', severity: 'low' },
+        { risk: 'Vision document dimensions format varies', mitigation: 'Handle JSONB extracted_dimensions gracefully with fallbacks', severity: 'low' }
+      ],
+      integration_operationalization: {
+        consumers: ['Chairman via CLI', 'EVA governance workflows', 'Future annual planning sessions'],
+        dependencies: ['eva_vision_documents table (existing)', 'strategic_themes table (new)'],
+        data_contracts: { input: 'CLI args (--title, --year, --description, --vision-key)', output: 'Formatted console output' },
+        runtime_config: { env_vars: ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY'] },
+        observability_rollout: { logging: 'Console output', monitoring: 'N/A for CLI tool' }
+      }
+    })
+    .select('id, status');
+
+  if (error) {
+    console.error('PRD error:', error.message);
+    process.exit(1);
+  }
+  console.log('PRD created:', JSON.stringify(data, null, 2));
+  console.log('PRD ID:', prdId);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/temp/insert-stories-001-C.cjs
+++ b/scripts/temp/insert-stories-001-C.cjs
@@ -1,0 +1,80 @@
+const { createClient } = require('@supabase/supabase-js');
+const crypto = require('crypto');
+require('dotenv').config();
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function main() {
+  const prdId = '2e291c7a-b7c1-4a99-882c-ee1543fcb128';
+  const sdUuid = '1566a2ed-ef0f-43eb-9c9c-7d9d873ececf';
+
+  const stories = [
+    {
+      id: crypto.randomUUID(),
+      prd_id: prdId,
+      sd_id: sdUuid,
+      story_key: 'GOV-C:US-001',
+      title: 'View Strategic Themes via CLI',
+      user_role: 'Chairman/Operator',
+      user_want: 'view all strategic themes from the CLI',
+      user_benefit: 'I can review annual strategic direction without querying the database directly',
+      acceptance_criteria: [
+        'Running view subcommand lists all strategic themes',
+        'Each theme shows year, title, status, and source vision key',
+        'Running detail <id> shows full detail including description'
+      ],
+      priority: 'critical',
+      status: 'draft',
+      implementation_context: 'Read from strategic_themes table. Format output matching constitution-command.mjs style with box drawing characters.'
+    },
+    {
+      id: crypto.randomUUID(),
+      prd_id: prdId,
+      sd_id: sdUuid,
+      story_key: 'GOV-C:US-002',
+      title: 'Derive Strategic Themes from Vision Documents',
+      user_role: 'Chairman/Operator',
+      user_want: 'auto-derive strategic themes from vision documents',
+      user_benefit: 'I can automatically generate strategic themes from existing vision dimensions without manual entry',
+      acceptance_criteria: [
+        'Running derive subcommand reads active vision documents',
+        'Extracted dimensions are converted into strategic theme entries',
+        'Derived themes reference the source vision document via vision_key'
+      ],
+      priority: 'critical',
+      status: 'draft',
+      implementation_context: 'Read from eva_vision_documents where status=active. Parse extracted_dimensions JSONB. Insert into strategic_themes with derived_from_vision=true.'
+    },
+    {
+      id: crypto.randomUUID(),
+      prd_id: prdId,
+      sd_id: sdUuid,
+      story_key: 'GOV-C:US-003',
+      title: 'Create Manual Strategic Themes via CLI',
+      user_role: 'Chairman/Operator',
+      user_want: 'manually create strategic themes via CLI',
+      user_benefit: 'I can add strategic themes that are not derived from vision documents for ad-hoc planning',
+      acceptance_criteria: [
+        'Running create --title "..." --year 2026 --description "..." creates a theme',
+        'Theme is stored in strategic_themes table with status=draft',
+        'Supports optional --vision-key to link to a vision document'
+      ],
+      priority: 'critical',
+      status: 'draft',
+      implementation_context: 'Insert into strategic_themes with manual flag. Support --vision-key optional FK to eva_vision_documents.'
+    }
+  ];
+
+  const { data, error } = await supabase
+    .from('user_stories')
+    .insert(stories)
+    .select('id, story_key, status');
+
+  if (error) {
+    console.error('Stories error:', error.message);
+    process.exit(1);
+  }
+  console.log('Stories created:', JSON.stringify(data, null, 2));
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- Add `strategy-command.mjs` to EVA CLI suite with 4 subcommands (view, detail, derive, create)
- Add `strategic_themes` table migration (12 columns, RLS, FK to eva_vision_documents)
- Derive subcommand auto-extracts themes from vision document dimensions sorted by weight
- Follows established EVA CLI pattern (parseArgs, subcommand dispatch, formatted console output)

## Test plan
- [x] `view` lists all strategic themes with year, title, status, source
- [x] `detail <key>` shows full theme detail including dimensions and source vision
- [x] `detail <partial-title>` finds by partial title match
- [x] `derive --vision-key VISION-EHG-L1-001` extracts 11 dimensions into themes
- [x] `create --title "..." --year 2026 --description "..."` creates manual theme
- [x] No args shows help text; invalid subcommand exits with code 1
- [x] Derive skips already-derived dimensions (deduplication)

SD: SD-EHG-ORCH-GOVERNANCE-STACK-001-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)