### PR TITLE
feat: wire vision event handlers with DB operations on unified event bus

### DIFF
--- a/lib/eva/event-bus/handlers/leo-pattern-resolved.js
+++ b/lib/eva/event-bus/handlers/leo-pattern-resolved.js
@@ -1,0 +1,57 @@
+/**
+ * Handler: leo.pattern_resolved
+ * SD: SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-D (US-001)
+ *
+ * Handles events when /learn workflow resolves issue_patterns via resolveLearningItems().
+ * Marks resolved patterns in issue_patterns table and logs for memory pruning triggers.
+ *
+ * Payload: { sdKey, resolvedPatternIds, resolvedCount, supabase }
+ */
+
+import { subscribeVisionEvent, VISION_EVENTS } from '../vision-events.js';
+
+let _registered = false;
+
+/**
+ * Register leo.pattern_resolved subscribers.
+ * Idempotent — safe to call multiple times.
+ */
+export function registerLeoPatternResolvedHandlers() {
+  if (_registered) return;
+
+  // Subscriber 1: Log for observability
+  subscribeVisionEvent(VISION_EVENTS.PATTERN_RESOLVED, async ({ sdKey, resolvedPatternIds, resolvedCount }) => {
+    const count = resolvedCount || (resolvedPatternIds || []).length;
+    console.log(`[VisionBus] Patterns resolved: ${count} pattern(s) via SD ${sdKey || '(unknown)'}`);
+  });
+
+  // Subscriber 2: Mark patterns as resolved in issue_patterns
+  subscribeVisionEvent(VISION_EVENTS.PATTERN_RESOLVED, async ({ sdKey, resolvedPatternIds, supabase }) => {
+    if (!supabase) return;
+    if (!resolvedPatternIds || resolvedPatternIds.length === 0) return;
+
+    try {
+      const { error } = await supabase
+        .from('issue_patterns')
+        .update({
+          status: 'resolved',
+          resolution_notes: `Resolved by SD ${sdKey || '(unknown)'}`,
+          updated_at: new Date().toISOString(),
+        })
+        .in('id', resolvedPatternIds);
+
+      if (error) {
+        console.warn(`[VisionBus] Failed to resolve patterns: ${error.message}`);
+      }
+    } catch (err) {
+      console.warn(`[VisionBus] issue_patterns resolve error: ${err.message}`);
+    }
+  });
+
+  _registered = true;
+}
+
+/** Reset registration flag (for testing only). */
+export function _resetLeoPatternResolvedHandlers() {
+  _registered = false;
+}

--- a/lib/eva/event-bus/handlers/vision-corrective-sd-created.js
+++ b/lib/eva/event-bus/handlers/vision-corrective-sd-created.js
@@ -1,11 +1,11 @@
 /**
  * Handler: vision.corrective_sd_created
- * SD: SD-CORR-VIS-A05-EVENT-BUS-001
+ * SD: SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-D (US-002)
  *
  * Handles events when corrective SDs are generated from vision scoring gaps.
- * Logs for observability and tracks corrective actions.
+ * Logs for observability and links corrective SDs to their source vision gaps.
  *
- * Payload: { originSdKey, correctiveSdKey, scoreId, action, dimensions, label }
+ * Payload: { originSdKey, correctiveSdKey, scoreId, action, dimensions, label, supabase }
  */
 
 import { subscribeVisionEvent, VISION_EVENTS } from '../vision-events.js';
@@ -19,10 +19,36 @@ let _registered = false;
 export function registerVisionCorrectiveSdCreatedHandlers() {
   if (_registered) return;
 
+  // Subscriber 1: Log for observability
   subscribeVisionEvent(VISION_EVENTS.CORRECTIVE_SD_CREATED, async ({ originSdKey, correctiveSdKey, action, dimensions, label }) => {
     const origin = originSdKey || '(portfolio-level)';
     const dims = (dimensions || []).join(', ');
     console.log(`[VisionBus] Corrective SD created: ${correctiveSdKey} from ${origin} (action=${action}, dims=${dims}, label=${label})`);
+  });
+
+  // Subscriber 2: Link corrective SD to vision gaps in eva_vision_gaps
+  subscribeVisionEvent(VISION_EVENTS.CORRECTIVE_SD_CREATED, async ({ originSdKey, correctiveSdKey, dimensions, supabase }) => {
+    if (!supabase) return;
+    if (!dimensions || dimensions.length === 0) return;
+
+    try {
+      const { error } = await supabase
+        .from('eva_vision_gaps')
+        .update({
+          corrective_sd_key: correctiveSdKey,
+          status: 'in_progress',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('sd_id', originSdKey || '')
+        .in('dimension_id', dimensions)
+        .eq('status', 'open');
+
+      if (error) {
+        console.warn(`[VisionBus] Failed to link corrective SD to gaps: ${error.message}`);
+      }
+    } catch (err) {
+      console.warn(`[VisionBus] eva_vision_gaps link error: ${err.message}`);
+    }
   });
 
   _registered = true;

--- a/lib/eva/event-bus/handlers/vision-rescore-completed.js
+++ b/lib/eva/event-bus/handlers/vision-rescore-completed.js
@@ -1,16 +1,19 @@
 /**
  * Handler: vision.rescore_completed
- * SD: SD-CORR-VIS-A05-EVENT-BUS-001
+ * SD: SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-D (US-003)
  *
  * Handles events when post-completion rescoring finishes.
- * Logs dimension improvement for tracking.
+ * Logs dimension improvement, updates gap scores, closes resolved gaps,
+ * and updates OKR key_results for vision-linked KRs.
  *
- * Payload: { sdKey, previousScore, newScore, dimensionDelta, scoreId }
+ * Payload: { sdKey, previousScore, newScore, dimensionDelta, scoreId, supabase }
  */
 
 import { subscribeVisionEvent, VISION_EVENTS } from '../vision-events.js';
 
 let _registered = false;
+
+const GAP_RESOLUTION_THRESHOLD = 80;
 
 /**
  * Register vision.rescore_completed subscribers.
@@ -19,6 +22,7 @@ let _registered = false;
 export function registerVisionRescoreCompletedHandlers() {
   if (_registered) return;
 
+  // Subscriber 1: Log for observability
   subscribeVisionEvent(VISION_EVENTS.RESCORE_COMPLETED, async ({ sdKey, previousScore, newScore, dimensionDelta }) => {
     const delta = newScore - previousScore;
     const direction = delta >= 0 ? '+' : '';
@@ -28,6 +32,84 @@ export function registerVisionRescoreCompletedHandlers() {
         const d = change >= 0 ? '+' : '';
         console.log(`  ${dim}: ${d}${change}`);
       }
+    }
+  });
+
+  // Subscriber 2: Update eva_vision_gaps scores and close resolved gaps
+  subscribeVisionEvent(VISION_EVENTS.RESCORE_COMPLETED, async ({ sdKey, dimensionDelta, supabase }) => {
+    if (!supabase) return;
+    if (!dimensionDelta || Object.keys(dimensionDelta).length === 0) return;
+
+    try {
+      // Fetch open gaps for this SD's dimensions
+      const dimensionIds = Object.keys(dimensionDelta);
+      const { data: gaps, error: fetchError } = await supabase
+        .from('eva_vision_gaps')
+        .select('id, dimension_id, score')
+        .eq('sd_id', sdKey || '')
+        .in('dimension_id', dimensionIds)
+        .in('status', ['open', 'in_progress']);
+
+      if (fetchError || !gaps) return;
+
+      for (const gap of gaps) {
+        const delta = dimensionDelta[gap.dimension_id] || 0;
+        const newScore = (gap.score || 0) + delta;
+        const newStatus = newScore >= GAP_RESOLUTION_THRESHOLD ? 'closed' : gap.score < GAP_RESOLUTION_THRESHOLD ? 'open' : 'in_progress';
+
+        const { error: updateError } = await supabase
+          .from('eva_vision_gaps')
+          .update({
+            score: newScore,
+            status: newStatus,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', gap.id);
+
+        if (updateError) {
+          console.warn(`[VisionBus] Failed to update gap ${gap.id}: ${updateError.message}`);
+        }
+      }
+    } catch (err) {
+      console.warn(`[VisionBus] eva_vision_gaps rescore update error: ${err.message}`);
+    }
+  });
+
+  // Subscriber 3: Update OKR key_results for vision-linked KRs
+  subscribeVisionEvent(VISION_EVENTS.RESCORE_COMPLETED, async ({ dimensionDelta, supabase }) => {
+    if (!supabase) return;
+    if (!dimensionDelta || Object.keys(dimensionDelta).length === 0) return;
+
+    try {
+      const dimensionCodes = Object.keys(dimensionDelta);
+
+      // Find active KRs linked to these vision dimensions
+      const { data: krs, error: krFetchError } = await supabase
+        .from('key_results')
+        .select('id, vision_dimension_code, current_value')
+        .in('vision_dimension_code', dimensionCodes)
+        .eq('is_active', true);
+
+      if (krFetchError || !krs) return;
+
+      for (const kr of krs) {
+        const delta = dimensionDelta[kr.vision_dimension_code] || 0;
+        const newValue = (kr.current_value || 0) + delta;
+
+        const { error: updateError } = await supabase
+          .from('key_results')
+          .update({
+            current_value: newValue,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', kr.id);
+
+        if (updateError) {
+          console.warn(`[VisionBus] Failed to update KR ${kr.id}: ${updateError.message}`);
+        }
+      }
+    } catch (err) {
+      console.warn(`[VisionBus] key_results rescore update error: ${err.message}`);
     }
   });
 

--- a/lib/eva/event-bus/index.js
+++ b/lib/eva/event-bus/index.js
@@ -23,6 +23,7 @@ import { registerVisionGapDetectedHandlers } from './handlers/vision-gap-detecte
 import { registerVisionProcessGapDetectedHandlers } from './handlers/vision-process-gap-detected.js';
 import { registerVisionCorrectiveSdCreatedHandlers } from './handlers/vision-corrective-sd-created.js';
 import { registerVisionRescoreCompletedHandlers } from './handlers/vision-rescore-completed.js';
+import { registerLeoPatternResolvedHandlers } from './handlers/leo-pattern-resolved.js';
 
 let _initialized = false;
 
@@ -141,6 +142,7 @@ export async function initializeEventBus(supabase) {
   registerVisionProcessGapDetectedHandlers();
   registerVisionCorrectiveSdCreatedHandlers();
   registerVisionRescoreCompletedHandlers();
+  registerLeoPatternResolvedHandlers();
 
   _initialized = true;
 
@@ -183,3 +185,4 @@ export { registerVisionGapDetectedHandlers } from './handlers/vision-gap-detecte
 export { registerVisionProcessGapDetectedHandlers } from './handlers/vision-process-gap-detected.js';
 export { registerVisionCorrectiveSdCreatedHandlers } from './handlers/vision-corrective-sd-created.js';
 export { registerVisionRescoreCompletedHandlers } from './handlers/vision-rescore-completed.js';
+export { registerLeoPatternResolvedHandlers } from './handlers/leo-pattern-resolved.js';


### PR DESCRIPTION
## Summary
- Create `leo.pattern_resolved` handler — marks issue_patterns as resolved when /learn resolves patterns
- Enhance `vision.corrective_sd_created` handler — links corrective SDs to eva_vision_gaps, updates gap status to in_progress
- Enhance `vision.rescore_completed` handler — updates gap scores from dimension deltas, closes gaps above 80% threshold, updates OKR key_results for vision-linked KRs
- Register new handler in event bus initialization (index.js)

SD: SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-D (Orch 2, Child D)

## Test plan
- [x] All imports resolve cleanly
- [x] Handler registration is idempotent (double-call safe)
- [x] Subscriber counts correct (CORRECTIVE: 2, PATTERN_RESOLVED: 2, RESCORE: 3)
- [x] Fire-and-forget works: events without supabase log but don't throw
- [x] Empty arrays handled gracefully (no DB ops)
- [x] 15/15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)