### PR TITLE
feat(eva): add unified /eva CLI router and dashboard command

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-F",
-  "expectedBranch": "feat/SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-F",
-  "createdAt": "2026-02-20T21:25:30.164Z",
+  "sdKey": "SD-EHG-ORCH-INTERFACE-AGENTS-001-A",
+  "expectedBranch": "feat/SD-EHG-ORCH-INTERFACE-AGENTS-001-A",
+  "createdAt": "2026-02-20T21:58:41.062Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }


### PR DESCRIPTION
## Summary
- Added unified `/eva` CLI router skill that displays submenu and routes to 9 subcommands (mission, constitution, strategy, okr, vision, archplan, score, research, dashboard)
- Added 4 new skill files: `eva-mission.skill.md`, `eva-constitution.skill.md`, `eva-strategy.skill.md`, `eva-okr.skill.md`
- Added `scripts/eva/dashboard-command.mjs` - consolidated governance metrics dashboard querying 6 tables in parallel

## Test plan
- [ ] Run `node scripts/eva/dashboard-command.mjs` to verify dashboard output
- [ ] Verify `/eva` skill routing via Claude Code skill invocation
- [ ] Confirm all 4 individual eva-*.skill.md files are discoverable

SD: SD-EHG-ORCH-INTERFACE-AGENTS-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)