### PR TITLE
fix(gates): fix Gate 2 sub-validator key mismatches and normalization

### DIFF
--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
@@ -20,7 +20,9 @@ export function registerGate2Validators(registry) {
     const sectionA = result?.sections?.A || result?.sectionScores?.A ||
       result?.details?.design_fidelity || {};
     const scoreFromGateScores = result?.gate_scores?.design_fidelity;
-    const finalScore = sectionA.score ?? scoreFromGateScores ?? 0;
+    // Normalize section score (max 25) to 0-100 scale
+    const rawScore = sectionA.score ?? scoreFromGateScores ?? 0;
+    const finalScore = Math.round((rawScore / 25) * 100);
     const passed = result?.passed ?? (finalScore >= 70);
 
     return {
@@ -49,7 +51,9 @@ export function registerGate2Validators(registry) {
     const sectionB = result?.sections?.B || result?.sectionScores?.B ||
       result?.details?.database_fidelity || {};
     const scoreFromGateScores = result?.gate_scores?.database_fidelity;
-    const finalScore = sectionB.score ?? scoreFromGateScores ?? 0;
+    // Normalize section score (max 35) to 0-100 scale
+    const rawScore = sectionB.score ?? scoreFromGateScores ?? 0;
+    const finalScore = Math.round((rawScore / 35) * 100);
     const passed = result?.passed ?? (finalScore >= 50); // Lower threshold for DB
 
     return {
@@ -76,9 +80,11 @@ export function registerGate2Validators(registry) {
     const result = await validateGate2ExecToPlan(sd_id, supabase);
 
     const sectionC = result?.sections?.C || result?.sectionScores?.C ||
-      result?.details?.data_flow || {};
-    const scoreFromGateScores = result?.gate_scores?.data_flow;
-    const finalScore = sectionC.score ?? scoreFromGateScores ?? 0;
+      result?.details?.data_flow_alignment || {};
+    const scoreFromGateScores = result?.gate_scores?.data_flow_alignment;
+    // Normalize section score (max 25) to 0-100 scale
+    const rawScore = sectionC.score ?? scoreFromGateScores ?? 0;
+    const finalScore = Math.round((rawScore / 25) * 100);
     const passed = result?.passed ?? (finalScore >= 70);
 
     return {
@@ -105,9 +111,11 @@ export function registerGate2Validators(registry) {
     const result = await validateGate2ExecToPlan(sd_id, supabase);
 
     const sectionD = result?.sections?.D || result?.sectionScores?.D ||
-      result?.details?.testing || {};
-    const scoreFromGateScores = result?.gate_scores?.testing;
-    const finalScore = sectionD.score ?? scoreFromGateScores ?? 0;
+      result?.details?.enhanced_testing || {};
+    const scoreFromGateScores = result?.gate_scores?.enhanced_testing;
+    // Normalize section score (max 25) to 0-100 scale
+    const rawScore = sectionD.score ?? scoreFromGateScores ?? 0;
+    const finalScore = Math.round((rawScore / 25) * 100);
     const passed = result?.passed ?? (finalScore >= 70);
 
     return {

--- a/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
+++ b/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
@@ -36,34 +36,60 @@ export async function validateDataFlowAlignment(sd_id, designAnalysis, databaseA
       sd = sdBySdKey;
     }
 
-    if (sd?.sd_type === 'database') {
-      let scopeToCheck = '';
-      if (typeof sd.scope === 'object' && sd.scope?.included) {
-        scopeToCheck = Array.isArray(sd.scope.included)
-          ? sd.scope.included.join(' ')
-          : String(sd.scope.included);
-      } else if (typeof sd.scope === 'string') {
-        try {
-          const parsed = JSON.parse(sd.scope);
-          if (parsed?.included) {
-            scopeToCheck = Array.isArray(parsed.included)
-              ? parsed.included.join(' ')
-              : String(parsed.included);
-          }
-        } catch {
-          scopeToCheck = sd.scope;
+    // Extract scope text for analysis (moved above database-type check for reuse)
+    let scopeToCheck = '';
+    if (typeof sd?.scope === 'object' && sd.scope?.included) {
+      scopeToCheck = Array.isArray(sd.scope.included)
+        ? sd.scope.included.join(' ')
+        : String(sd.scope.included);
+    } else if (typeof sd?.scope === 'string') {
+      try {
+        const parsed = JSON.parse(sd.scope);
+        if (parsed?.included) {
+          scopeToCheck = Array.isArray(parsed.included)
+            ? parsed.included.join(' ')
+            : String(parsed.included);
         }
+      } catch {
+        scopeToCheck = sd.scope;
       }
+    }
 
-      const hasUIScope = /component|ui\s|frontend|form|page|view/i.test(scopeToCheck);
+    const hasUIScope = /component|ui\s|frontend|form|page|view/i.test(scopeToCheck);
 
-      if (!hasUIScope) {
-        console.log('   ✅ Database SD without UI/form requirements - Section C not applicable (25/25)');
+    // SD types that never require UI/form data flow validation
+    if (sd?.sd_type === 'database' && !hasUIScope) {
+      console.log('   ✅ Database SD without UI/form requirements - Section C not applicable (25/25)');
+      validation.score += 25;
+      validation.gate_scores.data_flow_alignment = 25;
+      validation.details.data_flow_alignment = {
+        skipped: true,
+        reason: 'Database SD without UI/form requirements - data flow alignment not applicable'
+      };
+      return;
+    }
+
+    // PAT-GATE2-BE-001: target_application-aware exemption for Section C
+    // EHG_Engineer is a backend-only repo (CLI, scripts, tooling) - never has form/UI integration
+    // Mirrors the same exemption already applied in Section A (design-fidelity.js)
+    if (!hasUIScope) {
+      let targetApp = null;
+      try {
+        const { data: fullSd } = await supabase
+          .from('strategic_directives_v2')
+          .select('target_application')
+          .or(`id.eq.${sd_id},sd_key.eq.${sd_id}`)
+          .single();
+        targetApp = fullSd?.target_application;
+      } catch { /* continue with other checks */ }
+
+      if (targetApp === 'EHG_Engineer') {
+        console.log('   ✅ EHG_Engineer target application (backend-only) - Section C not applicable (25/25)');
         validation.score += 25;
         validation.gate_scores.data_flow_alignment = 25;
         validation.details.data_flow_alignment = {
           skipped: true,
-          reason: 'Database SD without UI/form requirements - data flow alignment not applicable'
+          reason: 'EHG_Engineer target application - backend-only repo, no form/UI integration expected'
         };
         return;
       }


### PR DESCRIPTION
## Summary
- Fix key name mismatches in Gate 2 sub-validators (data_flow → data_flow_alignment, testing → enhanced_testing)
- Add score normalization from section-specific scales (/25, /35) to 0-100
- Add backend exemption (PAT-GATE2-BE-001) in data-flow-alignment.js for EHG_Engineer SDs

## Test plan
- [x] Gate 2 sub-validators now correctly read section scores
- [x] Backend SDs get full credit for Section C (no form/UI expected)
- [x] EXEC-TO-PLAN handoff passes with corrected scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)