### PR TITLE
fix: wire all handoff retrospective modules to use enricher consistently

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
@@ -310,17 +310,13 @@ export async function createHandoffRetrospective(sdId, sd, handoffResult, retros
         ...(handoffResult.success ? [`All ${retrospectiveType} gates passed for ${sdType} type`] : [])
       ],
       failure_patterns: whatNeedsImprovement.slice(0, 3),
-      // PAT-AUTO-a7aa772c fix: rubric expects {area, analysis, prevention} — NOT root_cause
-      improvement_areas: whatNeedsImprovement.slice(0, 3).map(item =>
-        typeof item === 'string'
-          ? { area: item, analysis: 'Identified during handoff analysis — review for systemic pattern', prevention: 'Monitor for recurrence and address proactively' }
-          : (item.root_cause && !item.analysis ? { ...item, analysis: item.root_cause } : item)
-      ),
+      // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-035: Use enricher for SD-specific improvement areas
+      improvement_areas: buildSDSpecificImprovementAreas(sd, allIssues),
       // PAT-RETRO-BOILERPLATE-001 fix: Include actual issues in protocol_improvements
       protocol_improvements: discoveredIssues.length > 0
         ? discoveredIssues.map(i => `[${i.pattern_id}] ${i.summary}`)
         : null,
-      generated_by: 'MANUAL',
+      generated_by: isInteractive ? 'MANUAL' : 'AUTO_HANDOFF',
       trigger_event: 'HANDOFF_COMPLETION',
       status: 'PUBLISHED',
       performance_impact: 'Standard',

--- a/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
@@ -227,7 +227,7 @@ export async function createHandoffRetrospective(supabase, sdId, sd, handoffResu
       protocol_improvements: discoveredIssues.length > 0
         ? discoveredIssues.map(i => `[${i.pattern_id}] ${i.summary}`)
         : null,
-      generated_by: 'MANUAL',
+      generated_by: 'AUTO_HANDOFF',
       trigger_event: 'HANDOFF_COMPLETION',
       status: 'PUBLISHED',
       performance_impact: 'Standard',


### PR DESCRIPTION
## Summary
- Wire `lead-to-plan/retrospective.js` improvement_areas to use `buildSDSpecificImprovementAreas()` instead of generic boilerplate strings
- Add missing `retrospective-enricher.js` import to `exec-to-plan/retrospective.js` and replace plain-string improvement_areas with enricher returning `{area, analysis, prevention}` objects
- Fix `generated_by` field from hardcoded `'MANUAL'` to `'AUTO_HANDOFF'` across all 3 retrospective modules

Addresses 3 recurring patterns (13 total occurrences):
- PAT-AUTO-4fef75fb: RETROSPECTIVE_EXISTS failed at 40/100
- PAT-AUTO-d0ef98c5: RETROSPECTIVE_QUALITY_GATE failed at 51/100
- PAT-AUTO-76981e79: RETROSPECTIVE_QUALITY_GATE failed at 54/100

SD: SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-035

## Test plan
- [x] All 3 modified files parse without errors (`node -e "import(...)"`)
- [x] LEAD-TO-PLAN handoff passed at 98%
- [x] PLAN-TO-LEAD handoff passed (retrospective quality gate >= 55%)
- [x] LEAD-FINAL-APPROVAL passed at 97%

🤖 Generated with [Claude Code](https://claude.com/claude-code)