### PR TITLE
fix(gates): resolve sd_key for PRD lookups in Gate 3/4 validators

### DIFF
--- a/scripts/modules/traceability-validation/utils.js
+++ b/scripts/modules/traceability-validation/utils.js
@@ -21,10 +21,11 @@ export const EHG_ROOT = path.resolve(__dirname, '../../../../ehg');
  * SD-LEO-GEN-RENAME-COLUMNS-SELF-001-D1: Removed legacy_id (column dropped 2026-01-24)
  * @param {string} sd_id - SD ID (may be sd_key or UUID)
  * @param {Object} supabase - Supabase client
- * @returns {Promise<{sdUuid: string, sdCategory: string|null, sdType: string|null, gitRepoPath: string}>}
+ * @returns {Promise<{sdUuid: string, sdKey: string, sdCategory: string|null, sdType: string|null, gitRepoPath: string}>}
  */
 export async function resolveSDContext(sd_id, supabase) {
   let sdUuid = sd_id;
+  let sdKey = sd_id;
   let sdCategory = null;
   let sdType = null;
   let gitRepoPath = process.cwd();
@@ -37,6 +38,7 @@ export async function resolveSDContext(sd_id, supabase) {
 
   if (sdData) {
     sdUuid = sdData.id;
+    sdKey = sdData.sd_key || sdData.id;
     sdCategory = sdData.category?.toLowerCase() || sdData.metadata?.category?.toLowerCase() || null;
     sdType = sdData.sd_type?.toLowerCase() || null;
     console.log(`   SD Category: ${sdCategory || 'unknown'} | Type: ${sdType || 'unknown'}`);
@@ -50,5 +52,5 @@ export async function resolveSDContext(sd_id, supabase) {
     console.log(`   Git Repo: ${gitRepoPath}`);
   }
 
-  return { sdUuid, sdCategory, sdType, gitRepoPath };
+  return { sdUuid, sdKey, sdCategory, sdType, gitRepoPath };
 }


### PR DESCRIPTION
## Summary
- Fixed PRD query mismatch in Gate 3 (traceability) and Gate 4 (workflow-roi) validators
- `product_requirements_v2.directive_id` stores `sd_key` (human-readable) but gate context passes UUID
- Added `sdKey` to `resolveSDContext()` return value for proper PRD lookups
- Populated `gate_scores`/`sections` on skip path for correct sub-gate scoring

## Test plan
- [x] Gate 3 traceability validation passes for SDs without design/database analysis
- [x] Gate 4 workflow-roi validation passes for SDs without design/database analysis
- [x] PLAN-TO-LEAD handoff passes (verified at 88%)
- [x] LEAD-FINAL-APPROVAL passes (verified at 93%)
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)