### PR TITLE
feat: add department-based organizational structure (EHG-ORCH-001)

### DIFF
--- a/database/migrations/20260221_department_agent_mapping_and_messaging.sql
+++ b/database/migrations/20260221_department_agent_mapping_and_messaging.sql
@@ -1,0 +1,163 @@
+-- SD-LEO-ORCH-EHG-ORGANIZATIONAL-STRUCTURE-001-B: Department-Agent Mapping and Message Routing
+-- Builds on departments and department_agents tables from Child A.
+--
+-- Creates:
+--   1. assign_agent_to_department() function
+--   2. remove_agent_from_department() function
+--   3. get_department_agents() function
+--   4. v_department_membership view
+--   5. department_messages table
+--   6. send_department_message() function
+
+-- ============================================================================
+-- STEP 1: Agent-Department Assignment Functions
+-- ============================================================================
+
+-- Assign an agent to a department (upsert on conflict updates role)
+CREATE OR REPLACE FUNCTION assign_agent_to_department(
+  p_agent_id UUID,
+  p_department_id UUID,
+  p_role TEXT DEFAULT 'member'
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_id UUID;
+BEGIN
+  INSERT INTO department_agents (agent_id, department_id, role_in_department)
+  VALUES (p_agent_id, p_department_id, p_role)
+  ON CONFLICT (department_id, agent_id)
+  DO UPDATE SET role_in_department = p_role, assigned_at = now()
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$;
+
+-- Remove an agent from a department
+CREATE OR REPLACE FUNCTION remove_agent_from_department(
+  p_agent_id UUID,
+  p_department_id UUID
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_deleted BOOLEAN;
+BEGIN
+  DELETE FROM department_agents
+  WHERE agent_id = p_agent_id AND department_id = p_department_id;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted > 0;
+END;
+$$;
+
+-- Get all agents in a department with their roles
+CREATE OR REPLACE FUNCTION get_department_agents(p_department_id UUID)
+RETURNS TABLE (
+  agent_id UUID,
+  display_name VARCHAR(255),
+  agent_type VARCHAR(50),
+  role_in_department TEXT,
+  assigned_at TIMESTAMPTZ
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  SELECT
+    ar.id AS agent_id,
+    ar.display_name,
+    ar.agent_type,
+    da.role_in_department,
+    da.assigned_at
+  FROM department_agents da
+  JOIN agent_registry ar ON ar.id = da.agent_id
+  WHERE da.department_id = p_department_id
+  ORDER BY da.role_in_department, ar.display_name;
+$$;
+
+-- ============================================================================
+-- STEP 2: Department Membership View
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_department_membership AS
+SELECT
+  d.id AS department_id,
+  d.name AS department_name,
+  d.slug AS department_slug,
+  d.hierarchy_path,
+  da.agent_id,
+  ar.display_name AS agent_name,
+  ar.agent_type,
+  da.role_in_department,
+  da.assigned_at
+FROM departments d
+JOIN department_agents da ON da.department_id = d.id
+JOIN agent_registry ar ON ar.id = da.agent_id
+WHERE d.is_active = true;
+
+-- ============================================================================
+-- STEP 3: Department Messages Table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS department_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  department_id UUID NOT NULL REFERENCES departments(id) ON DELETE CASCADE,
+  sender_agent_id UUID NOT NULL REFERENCES agent_registry(id) ON DELETE CASCADE,
+  content TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for querying messages by department
+CREATE INDEX IF NOT EXISTS idx_department_messages_dept
+  ON department_messages(department_id, created_at DESC);
+
+-- Index for querying messages by sender
+CREATE INDEX IF NOT EXISTS idx_department_messages_sender
+  ON department_messages(sender_agent_id);
+
+-- ============================================================================
+-- STEP 4: RLS for department_messages
+-- ============================================================================
+
+ALTER TABLE department_messages ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY department_messages_select_authenticated ON department_messages
+  FOR SELECT TO authenticated
+  USING (true);
+
+CREATE POLICY department_messages_all_service ON department_messages
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ============================================================================
+-- STEP 5: Send Department Message Function
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION send_department_message(
+  p_department_id UUID,
+  p_sender_id UUID,
+  p_content TEXT,
+  p_metadata JSONB DEFAULT '{}'
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_message_id UUID;
+BEGIN
+  INSERT INTO department_messages (department_id, sender_agent_id, content, metadata)
+  VALUES (p_department_id, p_sender_id, p_content, p_metadata)
+  RETURNING id INTO v_message_id;
+
+  RETURN v_message_id;
+END;
+$$;

--- a/database/migrations/20260221_department_capability_inheritance.sql
+++ b/database/migrations/20260221_department_capability_inheritance.sql
@@ -1,0 +1,170 @@
+-- SD-LEO-ORCH-EHG-ORGANIZATIONAL-STRUCTURE-001-C: Department Capability Inheritance
+-- Builds on departments, department_agents tables from Child A.
+--
+-- Creates:
+--   1. department_capabilities table
+--   2. add_department_capability() function
+--   3. remove_department_capability() function
+--   4. get_effective_capabilities() function (LTREE hierarchy traversal)
+--   5. v_agent_effective_capabilities view
+
+-- ============================================================================
+-- STEP 1: Create department_capabilities table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS department_capabilities (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  department_id UUID NOT NULL REFERENCES departments(id) ON DELETE CASCADE,
+  capability_name TEXT NOT NULL,
+  description TEXT,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT uq_department_capability UNIQUE (department_id, capability_name)
+);
+
+-- Index for looking up capabilities by name
+CREATE INDEX IF NOT EXISTS idx_department_capabilities_name
+  ON department_capabilities(capability_name);
+
+-- ============================================================================
+-- STEP 2: RLS for department_capabilities
+-- ============================================================================
+
+ALTER TABLE department_capabilities ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY department_capabilities_select_authenticated ON department_capabilities
+  FOR SELECT TO authenticated
+  USING (true);
+
+CREATE POLICY department_capabilities_all_service ON department_capabilities
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ============================================================================
+-- STEP 3: Add capability to a department (upsert)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION add_department_capability(
+  p_department_id UUID,
+  p_capability_name TEXT,
+  p_description TEXT DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_id UUID;
+BEGIN
+  INSERT INTO department_capabilities (department_id, capability_name, description)
+  VALUES (p_department_id, p_capability_name, p_description)
+  ON CONFLICT ON CONSTRAINT uq_department_capability
+  DO UPDATE SET description = COALESCE(p_description, department_capabilities.description)
+  RETURNING id INTO v_id;
+
+  RETURN v_id;
+END;
+$$;
+
+-- ============================================================================
+-- STEP 4: Remove capability from a department
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION remove_department_capability(
+  p_department_id UUID,
+  p_capability_name TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_count INT;
+BEGIN
+  DELETE FROM department_capabilities
+  WHERE department_id = p_department_id AND capability_name = p_capability_name;
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count > 0;
+END;
+$$;
+
+-- ============================================================================
+-- STEP 5: Get effective capabilities for an agent (LTREE hierarchy traversal)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_effective_capabilities(p_agent_id UUID)
+RETURNS TABLE (
+  capability_name TEXT,
+  source_department_id UUID,
+  source_department_name TEXT,
+  inheritance_type TEXT
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+AS $$
+  WITH agent_departments AS (
+    -- Get all departments this agent belongs to
+    SELECT d.id AS department_id, d.name, d.hierarchy_path
+    FROM department_agents da
+    JOIN departments d ON d.id = da.department_id
+    WHERE da.agent_id = p_agent_id
+      AND d.is_active = true
+  ),
+  ancestor_departments AS (
+    -- For each agent department, find all ancestor departments via LTREE
+    SELECT DISTINCT
+      anc.id AS department_id,
+      anc.name,
+      anc.hierarchy_path,
+      ad.department_id AS origin_department_id
+    FROM agent_departments ad
+    JOIN departments anc ON ad.hierarchy_path <@ anc.hierarchy_path
+    WHERE anc.is_active = true
+      AND anc.id != ad.department_id
+  ),
+  direct_capabilities AS (
+    -- Capabilities from departments the agent directly belongs to
+    SELECT
+      dc.capability_name,
+      dc.department_id AS source_department_id,
+      ad.name AS source_department_name,
+      'direct'::TEXT AS inheritance_type
+    FROM agent_departments ad
+    JOIN department_capabilities dc ON dc.department_id = ad.department_id
+  ),
+  inherited_capabilities AS (
+    -- Capabilities inherited from ancestor departments
+    SELECT
+      dc.capability_name,
+      dc.department_id AS source_department_id,
+      anc.name AS source_department_name,
+      'inherited'::TEXT AS inheritance_type
+    FROM ancestor_departments anc
+    JOIN department_capabilities dc ON dc.department_id = anc.department_id
+    WHERE dc.capability_name NOT IN (
+      SELECT dcap.capability_name FROM direct_capabilities dcap
+    )
+  )
+  SELECT * FROM direct_capabilities
+  UNION ALL
+  SELECT * FROM inherited_capabilities
+  ORDER BY inheritance_type, capability_name;
+$$;
+
+-- ============================================================================
+-- STEP 6: Agent effective capabilities view
+-- ============================================================================
+
+CREATE OR REPLACE VIEW v_agent_effective_capabilities AS
+SELECT
+  ar.id AS agent_id,
+  ar.display_name AS agent_name,
+  ec.capability_name,
+  ec.source_department_id,
+  ec.source_department_name,
+  ec.inheritance_type
+FROM agent_registry ar
+CROSS JOIN LATERAL get_effective_capabilities(ar.id) ec;

--- a/database/migrations/20260221_department_registry_schema.sql
+++ b/database/migrations/20260221_department_registry_schema.sql
@@ -1,0 +1,116 @@
+-- SD-LEO-ORCH-EHG-ORGANIZATIONAL-STRUCTURE-001-A: Department Registry Schema
+-- Creates the foundational department-based organizational structure for EHG.
+--
+-- Tables Created:
+--   1. departments - Department registry with LTREE hierarchy
+--   2. department_agents - Junction table mapping agents to departments
+--
+-- Dependencies:
+--   - LTREE extension (already enabled via agent_registry migration)
+--   - agent_registry table (FK reference)
+
+-- ============================================================================
+-- STEP 1: Create departments table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS departments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  slug TEXT NOT NULL UNIQUE,
+  hierarchy_path LTREE NOT NULL,
+  description TEXT,
+  parent_department_id UUID REFERENCES departments(id) ON DELETE RESTRICT,
+  metadata JSONB DEFAULT '{}',
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Auto-update updated_at on modification
+CREATE OR REPLACE FUNCTION update_departments_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_departments_updated_at
+  BEFORE UPDATE ON departments
+  FOR EACH ROW
+  EXECUTE FUNCTION update_departments_updated_at();
+
+-- ============================================================================
+-- STEP 2: Create department_agents junction table
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS department_agents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  department_id UUID NOT NULL REFERENCES departments(id) ON DELETE CASCADE,
+  agent_id UUID NOT NULL REFERENCES agent_registry(id) ON DELETE CASCADE,
+  role_in_department TEXT NOT NULL DEFAULT 'member'
+    CHECK (role_in_department IN ('lead', 'member', 'advisor')),
+  assigned_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  metadata JSONB DEFAULT '{}'
+);
+
+-- Prevent duplicate agent-department assignments
+CREATE UNIQUE INDEX IF NOT EXISTS idx_department_agents_unique
+  ON department_agents(department_id, agent_id);
+
+-- ============================================================================
+-- STEP 3: Create indexes
+-- ============================================================================
+
+-- GiST index for LTREE hierarchy queries
+CREATE INDEX IF NOT EXISTS idx_departments_hierarchy_path
+  ON departments USING gist(hierarchy_path);
+
+-- B-tree index on parent for tree traversal
+CREATE INDEX IF NOT EXISTS idx_departments_parent
+  ON departments(parent_department_id);
+
+-- Index for looking up departments by agent
+CREATE INDEX IF NOT EXISTS idx_department_agents_agent
+  ON department_agents(agent_id);
+
+-- ============================================================================
+-- STEP 4: Enable RLS
+-- ============================================================================
+
+ALTER TABLE departments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE department_agents ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users can read all departments
+CREATE POLICY departments_select_authenticated ON departments
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Service role has full access to departments
+CREATE POLICY departments_all_service ON departments
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Authenticated users can read department_agents
+CREATE POLICY department_agents_select_authenticated ON department_agents
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Service role has full access to department_agents
+CREATE POLICY department_agents_all_service ON department_agents
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ============================================================================
+-- STEP 5: Seed initial departments
+-- ============================================================================
+
+INSERT INTO departments (name, slug, hierarchy_path, description)
+VALUES
+  ('Engineering', 'engineering', 'engineering', 'Software engineering, infrastructure, and technical operations'),
+  ('Marketing', 'marketing', 'marketing', 'Brand strategy, content creation, and market analysis'),
+  ('Finance', 'finance', 'finance', 'Financial planning, accounting, and budget management'),
+  ('Operations', 'operations', 'operations', 'Business operations, HR, and organizational management')
+ON CONFLICT (slug) DO NOTHING;

--- a/scripts/department-hierarchy.cjs
+++ b/scripts/department-hierarchy.cjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * department-hierarchy.cjs - ASCII tree visualization of department structure
+ * SD-LEO-ORCH-EHG-ORGANIZATIONAL-STRUCTURE-001-D
+ *
+ * Usage:
+ *   node scripts/department-hierarchy.cjs
+ */
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+async function main() {
+  // Fetch all departments ordered by hierarchy path
+  const { data: departments, error } = await supabase
+    .from('departments')
+    .select('id, name, slug, hierarchy_path, parent_department_id, is_active, description')
+    .order('hierarchy_path');
+
+  if (error) {
+    console.error('Error fetching departments:', error.message);
+    process.exit(1);
+  }
+
+  if (!departments || departments.length === 0) {
+    console.log('No departments found.');
+    return;
+  }
+
+  // Get agent counts per department
+  const { data: agentData } = await supabase
+    .from('department_agents')
+    .select('department_id');
+
+  const agentCounts = {};
+  if (agentData) {
+    for (const row of agentData) {
+      agentCounts[row.department_id] = (agentCounts[row.department_id] || 0) + 1;
+    }
+  }
+
+  // Get capability counts per department
+  const { data: capData } = await supabase
+    .from('department_capabilities')
+    .select('department_id');
+
+  const capCounts = {};
+  if (capData) {
+    for (const row of capData) {
+      capCounts[row.department_id] = (capCounts[row.department_id] || 0) + 1;
+    }
+  }
+
+  // Build tree structure
+  const byId = {};
+  const roots = [];
+
+  for (const dept of departments) {
+    byId[dept.id] = { ...dept, children: [] };
+  }
+
+  for (const dept of departments) {
+    if (dept.parent_department_id && byId[dept.parent_department_id]) {
+      byId[dept.parent_department_id].children.push(byId[dept.id]);
+    } else {
+      roots.push(byId[dept.id]);
+    }
+  }
+
+  console.log('\n' + '='.repeat(70));
+  console.log('  EHG DEPARTMENT HIERARCHY');
+  console.log('='.repeat(70));
+  console.log('');
+
+  function renderTree(node, prefix, isLast) {
+    const connector = isLast ? '└── ' : '├── ';
+    const agents = agentCounts[node.id] || 0;
+    const caps = capCounts[node.id] || 0;
+    const status = node.is_active ? '' : ' [INACTIVE]';
+    const meta = [];
+    if (agents > 0) meta.push(`${agents} agent${agents > 1 ? 's' : ''}`);
+    if (caps > 0) meta.push(`${caps} cap${caps > 1 ? 's' : ''}`);
+    const metaStr = meta.length > 0 ? ` (${meta.join(', ')})` : '';
+
+    console.log(`  ${prefix}${connector}${node.name}${metaStr}${status}`);
+
+    if (node.description) {
+      const descPrefix = isLast ? '    ' : '│   ';
+      console.log(`  ${prefix}${descPrefix}  ${node.description.substring(0, 60)}`);
+    }
+
+    const childPrefix = prefix + (isLast ? '    ' : '│   ');
+    for (let i = 0; i < node.children.length; i++) {
+      renderTree(node.children[i], childPrefix, i === node.children.length - 1);
+    }
+  }
+
+  // Render each root
+  for (let i = 0; i < roots.length; i++) {
+    const root = roots[i];
+    const agents = agentCounts[root.id] || 0;
+    const caps = capCounts[root.id] || 0;
+    const status = root.is_active ? '' : ' [INACTIVE]';
+    const meta = [];
+    if (agents > 0) meta.push(`${agents} agent${agents > 1 ? 's' : ''}`);
+    if (caps > 0) meta.push(`${caps} cap${caps > 1 ? 's' : ''}`);
+    const metaStr = meta.length > 0 ? ` (${meta.join(', ')})` : '';
+
+    console.log(`  ${root.name}${metaStr}${status}`);
+    if (root.description) {
+      console.log(`    ${root.description.substring(0, 60)}`);
+    }
+
+    for (let j = 0; j < root.children.length; j++) {
+      renderTree(root.children[j], '', j === root.children.length - 1);
+    }
+
+    if (i < roots.length - 1) console.log('');
+  }
+
+  console.log('');
+
+  // Summary
+  const total = departments.length;
+  const active = departments.filter(d => d.is_active).length;
+  const totalAgents = Object.values(agentCounts).reduce((a, b) => a + b, 0);
+  const totalCaps = Object.values(capCounts).reduce((a, b) => a + b, 0);
+
+  console.log(`  Summary: ${total} departments (${active} active), ${totalAgents} agent assignments, ${totalCaps} capabilities`);
+  console.log('='.repeat(70) + '\n');
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});

--- a/scripts/list-departments.cjs
+++ b/scripts/list-departments.cjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * list-departments.cjs - List all departments with hierarchy and agent counts
+ * SD-LEO-ORCH-EHG-ORGANIZATIONAL-STRUCTURE-001-D
+ */
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+async function main() {
+  const { data: departments, error } = await supabase
+    .from('departments')
+    .select('id, name, slug, hierarchy_path, description, parent_department_id, is_active')
+    .order('hierarchy_path');
+
+  if (error) {
+    console.error('Error fetching departments:', error.message);
+    process.exit(1);
+  }
+
+  if (!departments || departments.length === 0) {
+    console.log('No departments found.');
+    return;
+  }
+
+  // Get agent counts per department
+  const { data: agentCounts, error: countError } = await supabase
+    .from('department_agents')
+    .select('department_id');
+
+  if (countError) {
+    console.error('Warning: Could not fetch agent counts:', countError.message);
+  }
+
+  const counts = {};
+  if (agentCounts) {
+    for (const row of agentCounts) {
+      counts[row.department_id] = (counts[row.department_id] || 0) + 1;
+    }
+  }
+
+  console.log('\n' + '='.repeat(80));
+  console.log('  DEPARTMENTS');
+  console.log('='.repeat(80));
+  console.log('');
+
+  const nameWidth = 20;
+  const slugWidth = 15;
+  const pathWidth = 25;
+  const countWidth = 8;
+  const statusWidth = 8;
+
+  console.log(
+    '  ' +
+    'Name'.padEnd(nameWidth) +
+    'Slug'.padEnd(slugWidth) +
+    'Hierarchy Path'.padEnd(pathWidth) +
+    'Agents'.padEnd(countWidth) +
+    'Active'.padEnd(statusWidth)
+  );
+  console.log('  ' + '-'.repeat(nameWidth + slugWidth + pathWidth + countWidth + statusWidth));
+
+  for (const dept of departments) {
+    const agentCount = counts[dept.id] || 0;
+    const active = dept.is_active ? 'Yes' : 'No';
+
+    console.log(
+      '  ' +
+      dept.name.substring(0, nameWidth - 1).padEnd(nameWidth) +
+      dept.slug.substring(0, slugWidth - 1).padEnd(slugWidth) +
+      (dept.hierarchy_path || '').substring(0, pathWidth - 1).padEnd(pathWidth) +
+      String(agentCount).padEnd(countWidth) +
+      active.padEnd(statusWidth)
+    );
+  }
+
+  console.log('');
+  console.log(`  Total: ${departments.length} department(s)`);
+  console.log('='.repeat(80) + '\n');
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});

--- a/scripts/manage-department-agents.cjs
+++ b/scripts/manage-department-agents.cjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * manage-department-agents.cjs - Assign/remove agents to/from departments
+ * SD-LEO-ORCH-EHG-ORGANIZATIONAL-STRUCTURE-001-D
+ *
+ * Usage:
+ *   node scripts/manage-department-agents.cjs --assign --agent-id <UUID> --department-id <UUID> [--role <role>]
+ *   node scripts/manage-department-agents.cjs --remove --agent-id <UUID> --department-id <UUID>
+ *   node scripts/manage-department-agents.cjs --list --department-id <UUID>
+ */
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--assign') parsed.action = 'assign';
+    else if (args[i] === '--remove') parsed.action = 'remove';
+    else if (args[i] === '--list') parsed.action = 'list';
+    else if (args[i] === '--agent-id' && args[i + 1]) parsed.agentId = args[++i];
+    else if (args[i] === '--department-id' && args[i + 1]) parsed.departmentId = args[++i];
+    else if (args[i] === '--role' && args[i + 1]) parsed.role = args[++i];
+    else if (args[i] === '--help' || args[i] === '-h') parsed.help = true;
+  }
+  return parsed;
+}
+
+function showUsage() {
+  console.log(`
+Usage:
+  node scripts/manage-department-agents.cjs --assign --agent-id <UUID> --department-id <UUID> [--role <role>]
+  node scripts/manage-department-agents.cjs --remove --agent-id <UUID> --department-id <UUID>
+  node scripts/manage-department-agents.cjs --list --department-id <UUID>
+
+Options:
+  --assign          Assign an agent to a department
+  --remove          Remove an agent from a department
+  --list            List all agents in a department
+  --agent-id        Agent UUID from agent_registry
+  --department-id   Department UUID from departments table
+  --role            Role in department: lead, member, advisor (default: member)
+  --help, -h        Show this help message
+`);
+}
+
+async function assignAgent(agentId, departmentId, role) {
+  const { data, error } = await supabase.rpc('assign_agent_to_department', {
+    p_agent_id: agentId,
+    p_department_id: departmentId,
+    p_role: role || 'member'
+  });
+
+  if (error) {
+    console.error('Error assigning agent:', error.message);
+    process.exit(1);
+  }
+
+  console.log(`Agent ${agentId} assigned to department ${departmentId} as ${role || 'member'}`);
+  console.log(`Assignment ID: ${data}`);
+}
+
+async function removeAgent(agentId, departmentId) {
+  const { data, error } = await supabase.rpc('remove_agent_from_department', {
+    p_agent_id: agentId,
+    p_department_id: departmentId
+  });
+
+  if (error) {
+    console.error('Error removing agent:', error.message);
+    process.exit(1);
+  }
+
+  if (data) {
+    console.log(`Agent ${agentId} removed from department ${departmentId}`);
+  } else {
+    console.log(`Agent ${agentId} was not in department ${departmentId}`);
+  }
+}
+
+async function listAgents(departmentId) {
+  const { data, error } = await supabase.rpc('get_department_agents', {
+    p_department_id: departmentId
+  });
+
+  if (error) {
+    console.error('Error listing agents:', error.message);
+    process.exit(1);
+  }
+
+  // Get department name
+  const { data: dept } = await supabase
+    .from('departments')
+    .select('name')
+    .eq('id', departmentId)
+    .single();
+
+  const deptName = dept ? dept.name : departmentId;
+
+  console.log('\n' + '='.repeat(70));
+  console.log(`  AGENTS IN: ${deptName}`);
+  console.log('='.repeat(70));
+
+  if (!data || data.length === 0) {
+    console.log('  No agents assigned to this department.');
+  } else {
+    const nameW = 25;
+    const typeW = 15;
+    const roleW = 12;
+
+    console.log('  ' + 'Name'.padEnd(nameW) + 'Type'.padEnd(typeW) + 'Role'.padEnd(roleW) + 'Assigned');
+    console.log('  ' + '-'.repeat(nameW + typeW + roleW + 20));
+
+    for (const agent of data) {
+      const assigned = new Date(agent.assigned_at).toLocaleDateString();
+      console.log(
+        '  ' +
+        (agent.display_name || 'Unknown').substring(0, nameW - 1).padEnd(nameW) +
+        (agent.agent_type || 'N/A').substring(0, typeW - 1).padEnd(typeW) +
+        (agent.role_in_department || 'member').padEnd(roleW) +
+        assigned
+      );
+    }
+  }
+
+  console.log('='.repeat(70) + '\n');
+}
+
+async function main() {
+  const args = parseArgs();
+
+  if (args.help || !args.action) {
+    showUsage();
+    return;
+  }
+
+  if (args.action === 'list') {
+    if (!args.departmentId) {
+      console.error('Error: --department-id is required for --list');
+      process.exit(1);
+    }
+    await listAgents(args.departmentId);
+  } else if (args.action === 'assign') {
+    if (!args.agentId || !args.departmentId) {
+      console.error('Error: --agent-id and --department-id are required for --assign');
+      process.exit(1);
+    }
+    await assignAgent(args.agentId, args.departmentId, args.role);
+  } else if (args.action === 'remove') {
+    if (!args.agentId || !args.departmentId) {
+      console.error('Error: --agent-id and --department-id are required for --remove');
+      process.exit(1);
+    }
+    await removeAgent(args.agentId, args.departmentId);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});

--- a/scripts/query-capabilities.cjs
+++ b/scripts/query-capabilities.cjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * query-capabilities.cjs - View effective capabilities per agent with inheritance source
+ * SD-LEO-ORCH-EHG-ORGANIZATIONAL-STRUCTURE-001-D
+ *
+ * Usage:
+ *   node scripts/query-capabilities.cjs --agent-id <UUID>
+ *   node scripts/query-capabilities.cjs --all
+ */
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {};
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--agent-id' && args[i + 1]) parsed.agentId = args[++i];
+    else if (args[i] === '--all') parsed.all = true;
+    else if (args[i] === '--help' || args[i] === '-h') parsed.help = true;
+  }
+  return parsed;
+}
+
+function showUsage() {
+  console.log(`
+Usage:
+  node scripts/query-capabilities.cjs --agent-id <UUID>   Show capabilities for a specific agent
+  node scripts/query-capabilities.cjs --all               Show capabilities for all agents
+  node scripts/query-capabilities.cjs --help              Show this help message
+`);
+}
+
+async function queryAgentCapabilities(agentId) {
+  const { data, error } = await supabase.rpc('get_effective_capabilities', {
+    p_agent_id: agentId
+  });
+
+  if (error) {
+    console.error('Error querying capabilities:', error.message);
+    process.exit(1);
+  }
+
+  // Get agent name
+  const { data: agent } = await supabase
+    .from('agent_registry')
+    .select('display_name')
+    .eq('id', agentId)
+    .single();
+
+  const agentName = agent ? agent.display_name : agentId;
+
+  console.log('\n' + '='.repeat(80));
+  console.log(`  EFFECTIVE CAPABILITIES: ${agentName}`);
+  console.log('='.repeat(80));
+
+  if (!data || data.length === 0) {
+    console.log('  No capabilities found (agent may not be assigned to any department).');
+  } else {
+    const capW = 25;
+    const srcW = 20;
+    const typeW = 12;
+
+    console.log('  ' + 'Capability'.padEnd(capW) + 'Source Dept'.padEnd(srcW) + 'Type'.padEnd(typeW));
+    console.log('  ' + '-'.repeat(capW + srcW + typeW));
+
+    for (const cap of data) {
+      const typeLabel = cap.inheritance_type === 'direct' ? 'DIRECT' : 'INHERITED';
+      console.log(
+        '  ' +
+        (cap.capability_name || '').substring(0, capW - 1).padEnd(capW) +
+        (cap.source_department_name || '').substring(0, srcW - 1).padEnd(srcW) +
+        typeLabel.padEnd(typeW)
+      );
+    }
+  }
+
+  console.log('='.repeat(80) + '\n');
+}
+
+async function queryAllCapabilities() {
+  const { data, error } = await supabase
+    .from('v_agent_effective_capabilities')
+    .select('*')
+    .order('agent_name')
+    .order('inheritance_type')
+    .order('capability_name');
+
+  if (error) {
+    console.error('Error querying capabilities:', error.message);
+    process.exit(1);
+  }
+
+  console.log('\n' + '='.repeat(90));
+  console.log('  ALL AGENT EFFECTIVE CAPABILITIES');
+  console.log('='.repeat(90));
+
+  if (!data || data.length === 0) {
+    console.log('  No capabilities assigned to any agents.');
+  } else {
+    const agentW = 20;
+    const capW = 25;
+    const srcW = 20;
+    const typeW = 12;
+
+    console.log(
+      '  ' +
+      'Agent'.padEnd(agentW) +
+      'Capability'.padEnd(capW) +
+      'Source Dept'.padEnd(srcW) +
+      'Type'.padEnd(typeW)
+    );
+    console.log('  ' + '-'.repeat(agentW + capW + srcW + typeW));
+
+    for (const row of data) {
+      const typeLabel = row.inheritance_type === 'direct' ? 'DIRECT' : 'INHERITED';
+      console.log(
+        '  ' +
+        (row.agent_name || '').substring(0, agentW - 1).padEnd(agentW) +
+        (row.capability_name || '').substring(0, capW - 1).padEnd(capW) +
+        (row.source_department_name || '').substring(0, srcW - 1).padEnd(srcW) +
+        typeLabel.padEnd(typeW)
+      );
+    }
+  }
+
+  console.log(`\n  Total: ${data ? data.length : 0} capability assignment(s)`);
+  console.log('='.repeat(90) + '\n');
+}
+
+async function main() {
+  const args = parseArgs();
+
+  if (args.help) {
+    showUsage();
+    return;
+  }
+
+  if (args.agentId) {
+    await queryAgentCapabilities(args.agentId);
+  } else if (args.all) {
+    await queryAllCapabilities();
+  } else {
+    showUsage();
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Implements EHG organizational structure as code via orchestrator SD with 4 children
- Creates `departments` table with LTREE hierarchy, `department_agents` junction table, `department_capabilities` with inheritance
- Adds agent assignment/removal functions, department messaging, and capability inheritance via LTREE ancestor traversal
- Provides 4 CLI scripts: list-departments, manage-department-agents, query-capabilities, department-hierarchy

## Test plan
- [x] `list-departments.cjs` returns all seeded departments (Engineering, Marketing, Finance, Operations)
- [x] `department-hierarchy.cjs` renders ASCII tree matching LTREE hierarchy paths
- [x] All 3 migrations applied successfully to Supabase (verified via database-agent)
- [x] RLS policies enabled on all new tables
- [x] All 4 children completed through full LEAD→PLAN→EXEC→LEAD-FINAL-APPROVAL workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)