### PR TITLE
feat: add shouldSkipCodeValidation to Gate 2 validators

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEO-FIX-ADD-MISSION-VISION-001",
-  "expectedBranch": "feat/SD-LEO-FIX-ADD-MISSION-VISION-001",
-  "createdAt": "2026-02-21T02:11:50.757Z",
+  "sdKey": "SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-037",
+  "expectedBranch": "feat/SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-037",
+  "createdAt": "2026-02-21T08:03:34.244Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
@@ -13,7 +13,16 @@ import { shouldSkipCodeValidation } from '../../../../../../lib/utils/sd-type-va
 export function registerGate2Validators(registry) {
   // Section A: UI Components Implementation
   registry.register('uiComponentsImplemented', async (context) => {
-    const { sd_id, supabase } = context;
+    const { sd_id, supabase, sd } = context;
+
+    // PAT-AUTO-4fa618ac: Skip UI validation for non-code SDs (infrastructure, documentation)
+    if (sd && shouldSkipCodeValidation(sd)) {
+      return {
+        passed: true, score: 100, max_score: 100, issues: [],
+        warnings: [`UI component validation skipped for ${sd.sd_type} SD`]
+      };
+    }
+
     const result = await validateGate2ExecToPlan(sd_id, supabase);
 
     // Extract Section A score - check multiple paths for compatibility
@@ -45,7 +54,16 @@ export function registerGate2Validators(registry) {
 
   // Section B: Database Migrations
   registry.register('migrationsCreatedAndExecuted', async (context) => {
-    const { sd_id, supabase } = context;
+    const { sd_id, supabase, sd } = context;
+
+    // PAT-AUTO-0bd90c7f: Skip DB migration validation for non-code SDs
+    if (sd && shouldSkipCodeValidation(sd)) {
+      return {
+        passed: true, score: 100, max_score: 100, issues: [],
+        warnings: [`Database migration validation skipped for ${sd.sd_type} SD`]
+      };
+    }
+
     const result = await validateGate2ExecToPlan(sd_id, supabase);
 
     const sectionB = result?.sections?.B || result?.sectionScores?.B ||
@@ -76,7 +94,16 @@ export function registerGate2Validators(registry) {
 
   // Section C: Data Flow
   registry.register('databaseQueriesIntegrated', async (context) => {
-    const { sd_id, supabase } = context;
+    const { sd_id, supabase, sd } = context;
+
+    // PAT-AUTO-0bd90c7f: Skip data flow validation for non-code SDs
+    if (sd && shouldSkipCodeValidation(sd)) {
+      return {
+        passed: true, score: 100, max_score: 100, issues: [],
+        warnings: [`Data flow validation skipped for ${sd.sd_type} SD`]
+      };
+    }
+
     const result = await validateGate2ExecToPlan(sd_id, supabase);
 
     const sectionC = result?.sections?.C || result?.sectionScores?.C ||
@@ -107,7 +134,16 @@ export function registerGate2Validators(registry) {
 
   // Section D: E2E Testing
   registry.register('e2eTestCoverage', async (context) => {
-    const { sd_id, supabase } = context;
+    const { sd_id, supabase, sd } = context;
+
+    // PAT-AUTO-0bd90c7f: Skip E2E test validation for non-code SDs
+    if (sd && shouldSkipCodeValidation(sd)) {
+      return {
+        passed: true, score: 100, max_score: 100, issues: [],
+        warnings: [`E2E test validation skipped for ${sd.sd_type} SD`]
+      };
+    }
+
     const result = await validateGate2ExecToPlan(sd_id, supabase);
 
     const sectionD = result?.sections?.D || result?.sectionScores?.D ||


### PR DESCRIPTION
## Summary
- Adds `shouldSkipCodeValidation()` early-return checks to all 4 Gate 2 section validators (A-D) in `gate-2-implementation-fidelity.js`
- Infrastructure and documentation SDs now return `passed:true` with score 100 instead of failing with low scores (52/100, 68/100)
- Matches existing pattern already used by `testingSubAgentVerified` in the same file

## Patterns Resolved
- **PAT-AUTO-4fa618ac**: Gate 2A uiComponentsImplemented scored 52/100 for infrastructure SDs (5 occurrences)
- **PAT-AUTO-0bd90c7f**: Gate GATE2_IMPLEMENTATION_FIDELITY scored 68/100 for infrastructure SDs (3 occurrences)

## Test plan
- [x] Infrastructure SDs return passed:true with score 100 for all Gate 2 validators
- [x] Warning messages include SD type for audit trail
- [x] Feature/fix SDs continue running full validation unchanged
- [x] Null sd context falls through to normal validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)