### PR TITLE
fix: use valid generated_by values in retrospective creation

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
@@ -407,7 +407,7 @@ export async function createExecToPlanRetrospective(supabase, sdId, sd, handoffR
       protocol_improvements: discoveredIssues.length > 0
         ? discoveredIssues.map(i => `[${i.pattern_id}] ${i.summary}`)
         : null,
-      generated_by: 'AUTO_HANDOFF',
+      generated_by: 'SUB_AGENT',
       trigger_event: 'HANDOFF_COMPLETION',
       status: 'PUBLISHED',
       performance_impact: 'Standard',

--- a/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
@@ -316,7 +316,7 @@ export async function createHandoffRetrospective(sdId, sd, handoffResult, retros
       protocol_improvements: discoveredIssues.length > 0
         ? discoveredIssues.map(i => `[${i.pattern_id}] ${i.summary}`)
         : null,
-      generated_by: isInteractive ? 'MANUAL' : 'AUTO_HANDOFF',
+      generated_by: isInteractive ? 'MANUAL' : 'SUB_AGENT',
       trigger_event: 'HANDOFF_COMPLETION',
       status: 'PUBLISHED',
       performance_impact: 'Standard',

--- a/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
@@ -227,7 +227,7 @@ export async function createHandoffRetrospective(supabase, sdId, sd, handoffResu
       protocol_improvements: discoveredIssues.length > 0
         ? discoveredIssues.map(i => `[${i.pattern_id}] ${i.summary}`)
         : null,
-      generated_by: 'AUTO_HANDOFF',
+      generated_by: 'SUB_AGENT',
       trigger_event: 'HANDOFF_COMPLETION',
       status: 'PUBLISHED',
       performance_impact: 'Standard',

--- a/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/state-transitions.js
@@ -305,7 +305,7 @@ export async function satisfyOrchestratorTemplateRequirements(supabase, sdId, sd
           title: `Orchestrator Completion: ${sdTitle}`,
           retro_type: 'orchestrator_completion',
           status: 'PUBLISHED',
-          generated_by: 'AUTO_GUARDIAN',
+          generated_by: 'SUB_AGENT',
           trigger_event: 'ORCHESTRATOR_TEMPLATE_SATISFACTION',
           auto_generated: true,
           quality_score: 70,

--- a/scripts/modules/handoff/orchestrator-completion-guardian.js
+++ b/scripts/modules/handoff/orchestrator-completion-guardian.js
@@ -519,7 +519,7 @@ export class OrchestratorCompletionGuardian {
         action_items: [],
         status: 'PUBLISHED',
         quality_score: 80,
-        generated_by: 'ORCHESTRATOR-GUARDIAN',
+        generated_by: 'SUB_AGENT',
         trigger_event: 'Orchestrator auto-completion',
         target_application: 'EHG_Engineer',
         learning_category: 'PROCESS_IMPROVEMENT',


### PR DESCRIPTION
## Summary
- Fixed 5 auto-retrospective creation points that used invalid `generated_by` values violating the `retrospectives_generated_by_check` DB constraint
- Changed `AUTO_HANDOFF`, `AUTO_GUARDIAN`, and `ORCHESTRATOR-GUARDIAN` to `SUB_AGENT` (valid value)
- This eliminates silent insert failures that caused RETROSPECTIVE_EXISTS gate to score 0/100

## Files Changed
- `scripts/modules/handoff/executors/lead-to-plan/retrospective.js`
- `scripts/modules/handoff/executors/plan-to-exec/retrospective.js`
- `scripts/modules/handoff/executors/exec-to-plan/retrospective.js`
- `scripts/modules/handoff/executors/plan-to-lead/state-transitions.js`
- `scripts/modules/handoff/orchestrator-completion-guardian.js`

## Test plan
- [ ] Verify retrospective inserts succeed during LEAD-TO-PLAN handoff
- [ ] Verify retrospective inserts succeed during PLAN-TO-EXEC handoff
- [ ] Verify retrospective inserts succeed during EXEC-TO-PLAN handoff
- [ ] Verify orchestrator completion creates retrospective successfully
- [ ] Confirm RETROSPECTIVE_EXISTS gate passes on subsequent SDs

Resolves: PAT-AUTO-2b3e0356
SD: SD-LEARN-FIX-ADDRESS-PAT-AUTO-033

🤖 Generated with [Claude Code](https://claude.com/claude-code)