### PR TITLE
fix(SD-LEO-FIX-CLOSE-FOUNDATION-CLEANUP-001): close foundation cleanup residual gaps

### DIFF
--- a/database/migrations/20260221_expand_eva_scheduler_event_type_check.sql
+++ b/database/migrations/20260221_expand_eva_scheduler_event_type_check.sql
@@ -1,0 +1,18 @@
+-- Migration: Expand eva_scheduler_metrics event_type CHECK constraint
+-- SD: SD-LEO-FIX-CLOSE-FOUNDATION-CLEANUP-001
+-- Purpose: Allow OKR event types (okr.objective.scored, okr.snapshot.completed, okr.mid_month_review.completed)
+-- Applied: 2026-02-21
+
+ALTER TABLE eva_scheduler_metrics DROP CONSTRAINT eva_scheduler_metrics_event_type_check;
+
+ALTER TABLE eva_scheduler_metrics ADD CONSTRAINT eva_scheduler_metrics_event_type_check
+CHECK ((event_type = ANY (ARRAY[
+  'scheduler_poll'::text,
+  'scheduler_dispatch'::text,
+  'scheduler_cadence_limited'::text,
+  'scheduler_circuit_breaker_pause'::text,
+  'scheduler_error'::text,
+  'okr.objective.scored'::text,
+  'okr.snapshot.completed'::text,
+  'okr.mid_month_review.completed'::text
+])));

--- a/lib/agents/performance-optimizer.js
+++ b/lib/agents/performance-optimizer.js
@@ -4,7 +4,7 @@
  * Ensures the invisible sub-agent system operates at maximum efficiency
  */
 
-import Redis from 'ioredis';
+
 
 class PerformanceOptimizer {
   constructor(config = {}) {

--- a/lib/governance/semantic-diff-validator.js
+++ b/lib/governance/semantic-diff-validator.js
@@ -378,30 +378,8 @@ export class SemanticDiffValidator {
   /**
    * Store validation result in database
    */
-  async _storeValidationResult(crewOutput, context, result) {
-    try {
-      const { error } = await this.supabase
-        .from('crew_semantic_diffs')
-        .insert({
-          execution_id: context.executionId || null,
-          venture_id: context.ventureId,
-          prd_id: context.prdId || null,
-          sd_id: context.sdId || null,
-          crew_output: typeof crewOutput === 'string' ? { content: crewOutput } : crewOutput,
-          business_accuracy: result.businessAccuracy,
-          technical_accuracy: result.technicalAccuracy,
-          passed_gate: result.passedGate,
-          gate_threshold: result.gateThreshold,
-          rejection_reason: result.rejectionReason,
-          validated_by: 'SemanticDiffValidator-v5.1.0'
-        });
-
-      if (error) {
-        console.error(`[SEMANTIC-GATE] Failed to store validation result: ${error.message}`);
-      }
-    } catch (err) {
-      console.error(`[SEMANTIC-GATE] Error storing validation result: ${err.message}`);
-    }
+  async _storeValidationResult(_crewOutput, _context, _result) {
+    // crew_semantic_diffs table was dropped; storage is now a no-op
   }
 }
 

--- a/lib/marketing/index.js
+++ b/lib/marketing/index.js
@@ -9,7 +9,7 @@ export { generateContent, transitionContentState } from './content-generator.js'
 export { publish, getSupportedPlatforms } from './publisher/index.js';
 export { generateUTMParams, buildUTMQueryString, appendUTMToUrl } from './utm.js';
 export { checkBudget, recordSpend, getBudgetSummary, resetDailySpend } from './budget-governor.js';
-export { createQueues, createWorkers, addJob, getQueueHealth, shutdown, getQueueConfigs } from './queues/index.js';
+
 
 // AI-powered marketing (SD-EVA-FEAT-MARKETING-AI-001)
 export {


### PR DESCRIPTION
## Summary
- Expand `eva_scheduler_metrics` CHECK constraint to accept OKR event types (`okr.objective.scored`, `okr.snapshot.completed`, `okr.mid_month_review.completed`)
- Remove dead queue exports from `lib/marketing/index.js` (queues directory was previously deleted)
- Remove dead `ioredis` import from `lib/agents/performance-optimizer.js` (package not installed)
- Replace orphaned `crew_semantic_diffs` Supabase insert with no-op in `lib/governance/semantic-diff-validator.js` (table was dropped)

## Test plan
- [x] Verified CHECK constraint accepts all 3 OKR event types via test INSERT/DELETE
- [x] Marketing module loads successfully (29/29 unit tests pass)
- [x] Governance module loads successfully (55/55 tests pass)
- [x] All 3 modified modules load without import errors
- [x] Zero residual references to removed code in active codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)