### PR TITLE
feat(SD-MAN-FIX-SHIP-DESIGN-PERSONA-001): add design persona evaluation and unit tests

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
@@ -56,6 +56,12 @@ const PERSONAS = [
     stage3Metric: 'executionFeasibility',
     focus: 'technical complexity, resource requirements, time to market',
   },
+  {
+    id: 'product-designer',
+    name: 'Product Designer',
+    stage3Metric: 'designQuality',
+    focus: 'user experience clarity, interaction simplicity, design-driven differentiation, adoption friction, interface accessibility',
+  },
 ];
 
 const SYSTEM_PROMPT = `You are an AI venture analyst running a multi-persona evaluation. You will evaluate a venture idea from a specific perspective.

--- a/lib/eva/stage-templates/analysis-steps/stage-03-hybrid-scoring.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-03-hybrid-scoring.js
@@ -3,7 +3,7 @@
  * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
  * Combines deterministic scores from Stage 2 persona pre-scores (50%)
- * with an independent AI assessment (50%) to produce the 6 kill-gate
+ * with an independent AI assessment (50%) to produce the 7 kill-gate
  * metrics. Kill gate fires when overallScore < 40 OR any metric < 40.
  *
  * The SD specifies threshold above 40 (not 70 as in the original template).
@@ -20,7 +20,7 @@ import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
 const KILL_THRESHOLD = 40;
 
-const SYSTEM_PROMPT = `You are EVA's independent validation engine for venture scoring. You will assess a venture across 6 dimensions, independent of prior persona scores.
+const SYSTEM_PROMPT = `You are EVA's independent validation engine for venture scoring. You will assess a venture across 7 dimensions, independent of prior persona scores.
 
 You MUST output valid JSON with exactly these fields:
 - marketFit (integer 0-100)
@@ -29,6 +29,7 @@ You MUST output valid JSON with exactly these fields:
 - revenuePotential (integer 0-100)
 - competitiveBarrier (integer 0-100)
 - executionFeasibility (integer 0-100)
+- designQuality (integer 0-100)
 - reasoning (object with one string per metric explaining your score)
 
 Rules:
@@ -122,6 +123,7 @@ const PERSONA_TO_METRIC = {
   'revenue-analyst': 'revenuePotential',
   'moat-architect': 'competitiveBarrier',
   'ops-realist': 'executionFeasibility',
+  'product-designer': 'designQuality',
 };
 
 function extractDeterministicScores(critiques) {
@@ -142,7 +144,7 @@ function extractDeterministicScores(critiques) {
 async function getAIScores({ stage1Data, stage2Data, ventureName }) {
   const client = getLLMClient({ purpose: 'content-generation' });
 
-  const userPrompt = `Independently score this venture across 6 dimensions.
+  const userPrompt = `Independently score this venture across 7 dimensions.
 
 Venture: ${ventureName || 'Unnamed'}
 Description: ${stage1Data?.description || 'N/A'}

--- a/lib/eva/stage-templates/stage-02.js
+++ b/lib/eva/stage-templates/stage-02.js
@@ -3,12 +3,12 @@
  * Phase: THE TRUTH (Stages 1-5)
  * Part of SD-EVA-FEAT-TEMPLATES-TRUTH-001
  *
- * MoA (Mixture of Agents) multi-persona analysis producing 6 pre-scores
+ * MoA (Mixture of Agents) multi-persona analysis producing 7 pre-scores
  * aligned with Stage 3 metrics. Does NOT make gate decisions — feeds Stage 3.
  *
  * Cross-stage contracts:
  *   ← Stage 1: description, problemStatement, valueProp, targetMarket, archetype, keyAssumptions
- *   → Stage 3: 6 pre-scores (0-100 integer), evidence packs per domain
+ *   → Stage 3: 7 pre-scores (0-100 integer), evidence packs per domain
  *
  * @module lib/eva/stage-templates/stage-02
  */
@@ -19,6 +19,7 @@ import { analyzeStage02 } from './analysis-steps/stage-02-multi-persona.js';
 const METRIC_NAMES = [
   'marketFit', 'customerNeed', 'momentum',
   'revenuePotential', 'competitiveBarrier', 'executionFeasibility',
+  'designQuality',
 ];
 
 const SUGGESTION_TYPES = ['immediate', 'strategic'];
@@ -53,6 +54,7 @@ const TEMPLATE = {
         customer: { type: 'string', required: true },
         competitive: { type: 'string', required: true },
         execution: { type: 'string', required: true },
+        design: { type: 'string', required: true },
       },
     },
     suggestions: {
@@ -78,7 +80,7 @@ const TEMPLATE = {
   defaultData: {
     analysis: { strategic: '', technical: '', tactical: '' },
     metrics: Object.fromEntries(METRIC_NAMES.map(m => [m, null])),
-    evidence: { market: '', customer: '', competitive: '', execution: '' },
+    evidence: { market: '', customer: '', competitive: '', execution: '', design: '' },
     suggestions: [],
     compositeScore: null,
     provenance: {},
@@ -129,7 +131,7 @@ const TEMPLATE = {
     if (!data?.evidence || typeof data.evidence !== 'object') {
       errors.push('evidence is required and must be an object');
     } else {
-      for (const domain of ['market', 'customer', 'competitive', 'execution']) {
+      for (const domain of ['market', 'customer', 'competitive', 'execution', 'design']) {
         const r = validateString(data.evidence[domain], `evidence.${domain}`, 1);
         if (!r.valid) errors.push(r.error);
       }

--- a/lib/eva/stage-templates/stage-03.js
+++ b/lib/eva/stage-templates/stage-03.js
@@ -9,7 +9,7 @@
  *   KILL:   overallScore < 50 OR any metric < 50
  *
  * Cross-stage contracts:
- *   ← Stage 2: 6 pre-scores, evidence packs, composite analysis
+ *   ← Stage 2: 7 pre-scores, evidence packs, composite analysis
  *   ← Stage 1: archetype (scoring weights), problemStatement, keyAssumptions
  *   → Stage 4: competitorEntities (name, positioning, threat_level)
  *   → Stage 5: market validation result, archetype-driven weighting
@@ -27,6 +27,7 @@ const METRICS = [
   'revenuePotential',
   'competitiveBarrier',
   'executionFeasibility',
+  'designQuality',
 ];
 
 const PASS_THRESHOLD = 70;
@@ -48,6 +49,7 @@ const TEMPLATE = {
     revenuePotential: { type: 'integer', min: 0, max: 100, required: true },
     competitiveBarrier: { type: 'integer', min: 0, max: 100, required: true },
     executionFeasibility: { type: 'integer', min: 0, max: 100, required: true },
+    designQuality: { type: 'integer', min: 0, max: 100, required: true },
     // Competitor entities for Stage 4 handoff
     competitorEntities: {
       type: 'array',
@@ -77,6 +79,7 @@ const TEMPLATE = {
     revenuePotential: null,
     competitiveBarrier: null,
     executionFeasibility: null,
+    designQuality: null,
     competitorEntities: [],
     confidenceScores: {},
     overallScore: null,
@@ -139,11 +142,12 @@ const TEMPLATE = {
     const sum = scores.reduce((acc, s) => acc + s, 0);
     const overallScore = Math.round(sum / METRICS.length);
 
-    // 3 rollup dimensions for governance readability
+    // 4 rollup dimensions for governance readability
     const rollupDimensions = {
       market: Math.round((data.marketFit + data.momentum) / 2),
       technical: Math.round((data.executionFeasibility + data.competitiveBarrier) / 2),
       financial: Math.round((data.revenuePotential + data.customerNeed) / 2),
+      experience: data.designQuality,
     };
 
     const { decision, blockProgression, reasons } = evaluateKillGate({

--- a/lib/eva/stage-zero/synthesis/archetypes.js
+++ b/lib/eva/stage-zero/synthesis/archetypes.js
@@ -23,6 +23,7 @@ const ARCHETYPES = [
   { key: 'first_principles_rebuilder', label: 'First Principles Rebuilder', description: 'Rebuilds a broken industry process from scratch' },
   { key: 'vertical_specialist', label: 'Vertical Specialist', description: 'Deep niche expertise creating switching costs' },
   { key: 'portfolio_connector', label: 'Portfolio Connector', description: 'Bridges gaps between existing EHG ventures' },
+  { key: 'experience_designer', label: 'Experience Designer', description: 'Superior UX/design creates compounding engagement and retention advantages' },
 ];
 
 const VALID_ARCHETYPE_KEYS = ARCHETYPES.map(a => a.key);
@@ -58,6 +59,7 @@ EHG ARCHETYPES:
 4. **first_principles_rebuilder**: Rebuilds a broken industry process from scratch
 5. **vertical_specialist**: Deep niche expertise creating switching costs
 6. **portfolio_connector**: Bridges gaps between existing EHG ventures
+7. **experience_designer**: Superior UX/design creates compounding engagement and retention advantages
 
 For each archetype, assess fit (0-10) and explain why.
 

--- a/lib/eva/stage-zero/synthesis/build-cost-estimation.js
+++ b/lib/eva/stage-zero/synthesis/build-cost-estimation.js
@@ -58,7 +58,7 @@ Estimate the build cost:
 Return JSON:
 {
   "complexity": "moderate",
-  "loc_estimate": {"min": 2000, "max": 5000, "breakdown": {"backend": 2000, "frontend": 1500, "tests": 1000, "config": 500}},
+  "loc_estimate": {"min": 2000, "max": 5000, "breakdown": {"backend": 2000, "frontend": 1500, "design": 500, "tests": 1000, "config": 500}},
   "sd_count": {"min": 8, "max": 15, "breakdown": {"infrastructure": 3, "core_features": 6, "testing": 3, "documentation": 2}},
   "infrastructure": {
     "required": ["supabase", "vercel"],

--- a/lib/eva/stage-zero/synthesis/cross-reference.js
+++ b/lib/eva/stage-zero/synthesis/cross-reference.js
@@ -12,6 +12,7 @@
 
 import { getValidationClient } from '../../../llm/client-factory.js';
 import { extractUsage } from '../../utils/parse-json.js';
+import { createDomainKnowledgeService } from '../../../domain-intelligence/domain-knowledge-service.js';
 
 /**
  * Cross-reference a venture candidate against intellectual capital and outcome history.
@@ -40,8 +41,11 @@ export async function crossReferenceIntellectualCapital(pathOutput, deps = {}) {
   const outcomeHistory = await loadOutcomeHistory(supabase);
   logger.log(`   Found ${outcomeHistory.length} outcome record(s)`);
 
-  if (intellectualCapital.length === 0 && outcomeHistory.length === 0) {
-    logger.log('   No prior knowledge or outcomes to cross-reference');
+  // Load domain knowledge patterns
+  const domainPatterns = await loadDomainKnowledge(supabase, pathOutput, logger);
+
+  if (intellectualCapital.length === 0 && outcomeHistory.length === 0 && domainPatterns.length === 0) {
+    logger.log('   No prior knowledge, outcomes, or domain intelligence to cross-reference');
     return {
       component: 'cross_reference',
       matches: [],
@@ -53,14 +57,15 @@ export async function crossReferenceIntellectualCapital(pathOutput, deps = {}) {
 
   // Use LLM to find relevant connections
   const client = llmClient || getValidationClient();
-  const analysis = await analyzeCrossReferences(client, pathOutput, intellectualCapital, outcomeHistory, { logger });
+  const analysis = await analyzeCrossReferences(client, pathOutput, intellectualCapital, outcomeHistory, { logger, domainPatterns });
 
   return {
     component: 'cross_reference',
     matches: analysis.matches || [],
     lessons: analysis.lessons || [],
     relevance_score: analysis.relevance_score || 0,
-    related_items_count: intellectualCapital.length + outcomeHistory.length,
+    related_items_count: intellectualCapital.length + outcomeHistory.length + domainPatterns.length,
+    domain_knowledge_count: domainPatterns.length,
     summary: analysis.summary || '',
   };
 }
@@ -157,9 +162,37 @@ async function loadOutcomeHistory(supabase) {
 }
 
 /**
+ * Load domain knowledge relevant to this venture candidate.
+ * Uses tags and problem areas for cross-venture pattern matching.
+ */
+async function loadDomainKnowledge(supabase, pathOutput, logger = console) {
+  try {
+    const service = createDomainKnowledgeService(supabase, { logger });
+    const tags = [];
+    const problemAreas = [];
+
+    // Extract tags from venture candidate
+    if (pathOutput.target_market) tags.push(pathOutput.target_market.toLowerCase());
+    if (pathOutput.suggested_problem) {
+      const words = pathOutput.suggested_problem.toLowerCase().split(/\s+/).filter(w => w.length > 4);
+      problemAreas.push(...words.slice(0, 3));
+    }
+
+    if (tags.length === 0 && problemAreas.length === 0) return [];
+
+    const patterns = await service.findCrossVenturePatterns(tags, problemAreas, 10);
+    logger.log(`   Found ${patterns.length} domain knowledge pattern(s)`);
+    return patterns;
+  } catch (err) {
+    logger.log(`   Domain knowledge lookup skipped: ${err.message}`);
+    return [];
+  }
+}
+
+/**
  * Use LLM to analyze cross-references between venture and prior knowledge.
  */
-async function analyzeCrossReferences(client, pathOutput, intellectualCapital, outcomeHistory, { logger = console } = {}) {
+async function analyzeCrossReferences(client, pathOutput, intellectualCapital, outcomeHistory, { logger = console, domainPatterns = [] } = {}) {
   const ventureDesc = `Name: ${pathOutput.suggested_name}\nProblem: ${pathOutput.suggested_problem}\nSolution: ${pathOutput.suggested_solution}\nMarket: ${pathOutput.target_market}`;
 
   const icSummary = intellectualCapital.slice(0, 10).map(i =>
@@ -171,6 +204,10 @@ async function analyzeCrossReferences(client, pathOutput, intellectualCapital, o
     return `[pattern] ${o.name}: ${o.lesson}`;
   }).join('\n');
 
+  const dkSummary = domainPatterns.slice(0, 5).map(d =>
+    `[${d.knowledge_type}] ${d.title} (confidence: ${Math.round((d.effective_confidence || d.confidence) * 100)}%): ${d.content}`
+  ).join('\n');
+
   const prompt = `You are analyzing a venture candidate against EHG's prior knowledge and outcomes.
 
 VENTURE CANDIDATE:
@@ -181,6 +218,9 @@ ${icSummary || 'None available'}
 
 OUTCOME HISTORY (lessons learned):
 ${ohSummary || 'None available'}
+
+DOMAIN INTELLIGENCE (accumulated market knowledge):
+${dkSummary || 'None available'}
 
 Find connections between this venture and prior knowledge:
 1. Which prior ideas or brainstorms relate to this venture?

--- a/lib/eva/stage-zero/synthesis/design-evaluation.js
+++ b/lib/eva/stage-zero/synthesis/design-evaluation.js
@@ -1,0 +1,157 @@
+/**
+ * Synthesis Component 10: Design Evaluation
+ *
+ * Evaluates the venture's design potential across 5 dimensions:
+ * - UX Simplicity: Core user flow clarity, steps to first value
+ * - Design Differentiation: Can superior UX be a competitive advantage?
+ * - Adoption Friction: How much friction to onboard? (inverted: 10 = frictionless)
+ * - Design Scalability: Can the design system scale across platforms/markets?
+ * - Aesthetic Moat: Can visual polish create brand loyalty and switching costs?
+ *
+ * Part of SD-EVA-FEAT-DESIGN-PERSONA-001
+ */
+
+import { getValidationClient } from '../../../llm/client-factory.js';
+import { extractUsage } from '../../utils/parse-json.js';
+
+const DESIGN_DIMENSIONS = ['ux_simplicity', 'design_differentiation', 'adoption_friction', 'design_scalability', 'aesthetic_moat'];
+
+const DESIGN_RECOMMENDATIONS = ['design_led', 'design_standard', 'design_minimal'];
+
+/**
+ * Evaluate design potential for a venture candidate.
+ *
+ * @param {Object} pathOutput - PathOutput from entry path
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} [deps.logger] - Logger
+ * @param {Object} [deps.llmClient] - LLM client override (for testing)
+ * @returns {Promise<Object>} Design evaluation analysis
+ */
+export async function evaluateDesignPotential(pathOutput, deps = {}) {
+  const { logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+
+  logger.log('   Evaluating design potential...');
+
+  const prompt = `You are an EHG product design evaluator. Assess the design potential and UX quality opportunity for this venture.
+
+VENTURE:
+Name: ${pathOutput.suggested_name}
+Problem: ${pathOutput.suggested_problem}
+Solution: ${pathOutput.suggested_solution}
+Market: ${pathOutput.target_market}
+
+EHG Chairman Directives:
+- Ventures should aim for design excellence where it drives differentiation
+- Reduce adoption friction to accelerate growth
+- Superior UX creates compounding retention advantages
+
+DESIGN DIMENSIONS (score each 1-10):
+1. ux_simplicity: How simple is the core user flow? Steps to first value? (10 = trivially simple)
+2. design_differentiation: Can superior UX be a competitive advantage in this market? (10 = design is the moat)
+3. adoption_friction: How much friction to onboard new users? (INVERTED: 10 = completely frictionless, 1 = extreme friction)
+4. design_scalability: Can the design system scale across platforms, markets, and user segments? (10 = infinitely scalable)
+5. aesthetic_moat: Can visual polish and brand design create loyalty and switching costs? (10 = iconic brand potential)
+
+For each dimension, provide a score and brief rationale.
+
+Return JSON:
+{
+  "dimensions": {
+    "ux_simplicity": 8,
+    "design_differentiation": 7,
+    "adoption_friction": 6,
+    "design_scalability": 7,
+    "aesthetic_moat": 5
+  },
+  "composite_score": 66,
+  "design_risks": ["string"],
+  "design_opportunities": ["string"],
+  "recommendation": "design_led|design_standard|design_minimal",
+  "summary": "string (2-3 sentences)"
+}
+
+composite_score = weighted average of 5 dimensions * 10 (equal weights). Round to integer.
+recommendation: design_led (composite >= 70), design_standard (40-69), design_minimal (< 40).`;
+
+  try {
+    const response = await client.messages.create({
+      model: client._model || 'claude-sonnet-4-5-20250929',
+      max_tokens: 1500,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const usage = extractUsage(response);
+
+    const text = response.content[0]?.text || '';
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const analysis = JSON.parse(jsonMatch[0]);
+      const dims = analysis.dimensions || {};
+      const composite = typeof analysis.composite_score === 'number'
+        ? Math.round(analysis.composite_score)
+        : computeComposite(dims);
+      const rec = DESIGN_RECOMMENDATIONS.includes(analysis.recommendation)
+        ? analysis.recommendation
+        : inferRecommendation(composite);
+
+      return {
+        component: 'design_evaluation',
+        dimensions: {
+          ux_simplicity: clampDimension(dims.ux_simplicity),
+          design_differentiation: clampDimension(dims.design_differentiation),
+          adoption_friction: clampDimension(dims.adoption_friction),
+          design_scalability: clampDimension(dims.design_scalability),
+          aesthetic_moat: clampDimension(dims.aesthetic_moat),
+        },
+        composite_score: Math.max(0, Math.min(100, composite)),
+        design_risks: Array.isArray(analysis.design_risks) ? analysis.design_risks : [],
+        design_opportunities: Array.isArray(analysis.design_opportunities) ? analysis.design_opportunities : [],
+        recommendation: rec,
+        summary: analysis.summary || '',
+        usage,
+      };
+    }
+    return defaultDesignResult('Could not parse design evaluation');
+  } catch (err) {
+    logger.warn(`   Warning: Design evaluation failed: ${err.message}`);
+    return defaultDesignResult(`Evaluation failed: ${err.message}`);
+  }
+}
+
+function clampDimension(val) {
+  const n = Number(val);
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.min(10, Math.round(n)));
+}
+
+function computeComposite(dims) {
+  const values = DESIGN_DIMENSIONS.map(d => clampDimension(dims[d]));
+  const sum = values.reduce((a, b) => a + b, 0);
+  return Math.round((sum / DESIGN_DIMENSIONS.length) * 10);
+}
+
+function inferRecommendation(composite) {
+  if (composite >= 70) return 'design_led';
+  if (composite >= 40) return 'design_standard';
+  return 'design_minimal';
+}
+
+function defaultDesignResult(summary) {
+  return {
+    component: 'design_evaluation',
+    dimensions: {
+      ux_simplicity: 0,
+      design_differentiation: 0,
+      adoption_friction: 0,
+      design_scalability: 0,
+      aesthetic_moat: 0,
+    },
+    composite_score: 0,
+    design_risks: [],
+    design_opportunities: [],
+    recommendation: 'design_minimal',
+    summary,
+  };
+}
+
+export { DESIGN_DIMENSIONS, DESIGN_RECOMMENDATIONS };

--- a/lib/eva/stage-zero/synthesis/index.js
+++ b/lib/eva/stage-zero/synthesis/index.js
@@ -22,6 +22,9 @@
  * Component 9 (SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-A):
  * 9. Virality Analysis
  *
+ * Component 10 (SD-EVA-FEAT-DESIGN-PERSONA-001):
+ * 10. Design Evaluation
+ *
  * Profile System (SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-B):
  * - Resolves evaluation profile (explicit, active, or legacy defaults)
  * - Calculates weighted venture score from component results
@@ -39,6 +42,7 @@ import { assessTimeHorizon } from './time-horizon.js';
 import { classifyArchetype } from './archetypes.js';
 import { estimateBuildCost } from './build-cost-estimation.js';
 import { analyzeVirality } from './virality.js';
+import { evaluateDesignPotential } from './design-evaluation.js';
 import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 
 /**
@@ -55,7 +59,7 @@ import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 export async function runSynthesis(pathOutput, deps = {}) {
   const { logger = console, profileId } = deps;
 
-  logger.log('   Running synthesis engine (9/9 components)...');
+  logger.log('   Running synthesis engine (10/10 components)...');
 
   // Resolve evaluation profile (parallel with component execution)
   const profilePromise = resolveProfile(deps, profileId).catch(err => {
@@ -63,10 +67,10 @@ export async function runSynthesis(pathOutput, deps = {}) {
     return null;
   });
 
-  // Run all 9 components - grouped by dependency
-  // Group 1 (no inter-dependencies): components 1-4, 6-9
+  // Run all 10 components - grouped by dependency
+  // Group 1 (no inter-dependencies): components 1-4, 6-10
   // Group 2 (depends on nothing but run separately): component 5 (chairman constraints)
-  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality] = await Promise.all([
+  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design] = await Promise.all([
     crossReferenceIntellectualCapital(pathOutput, deps).catch(err => {
       logger.warn(`   Warning: Cross-reference failed: ${err.message}`);
       return { component: 'cross_reference', matches: [], lessons: [], relevance_score: 0, summary: `Failed: ${err.message}` };
@@ -99,6 +103,10 @@ export async function runSynthesis(pathOutput, deps = {}) {
       logger.warn(`   Warning: Virality analysis failed: ${err.message}`);
       return { component: 'virality_analysis', virality_score: 0, k_factor: 0, cycle_time_days: 0, mechanic_type: 'word_of_mouth', channel_fit: 0, shareability: 0, decay_rate: 0, organic_ratio: 0, growth_loops: [], viral_channels: [], compounding_factors: '', risks: [], summary: `Failed: ${err.message}` };
     }),
+    evaluateDesignPotential(pathOutput, deps).catch(err => {
+      logger.warn(`   Warning: Design evaluation failed: ${err.message}`);
+      return { component: 'design_evaluation', dimensions: { ux_simplicity: 0, design_differentiation: 0, adoption_friction: 0, design_scalability: 0, aesthetic_moat: 0 }, composite_score: 0, design_risks: [], design_opportunities: [], recommendation: 'design_minimal', summary: `Failed: ${err.message}` };
+    }),
   ]);
 
   // Chairman constraints run after others (uses pathOutput directly, no inter-dependency)
@@ -121,6 +129,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
     archetypes: archetype,
     build_cost: buildCost,
     virality: virality,
+    design_evaluation: design,
   };
 
   let profileMetadata = null;
@@ -139,7 +148,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
   }
 
   // Aggregate token usage from all components
-  const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality]
+  const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design]
     .map(c => c.usage)
     .filter(Boolean);
   const usage = componentUsages.length > 0 ? {
@@ -147,7 +156,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
     outputTokens: componentUsages.reduce((sum, u) => sum + (u.outputTokens || 0), 0),
   } : null;
 
-  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}, virality=${virality.virality_score || 0}`);
+  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}, virality=${virality.virality_score || 0}, design=${design.composite_score || 0}`);
 
   // Build enriched brief
   const recommendedProblem = reframing.recommended_framing?.framing || pathOutput.suggested_problem;
@@ -181,8 +190,9 @@ export async function runSynthesis(pathOutput, deps = {}) {
         archetypes: archetype,
         build_cost: buildCost,
         virality: virality,
-        components_run: 9,
-        components_total: 9,
+        design_evaluation: design,
+        components_run: 10,
+        components_total: 10,
         profile: profileMetadata,
         weighted_score: weightedScore,
       },
@@ -200,4 +210,5 @@ export {
   classifyArchetype,
   estimateBuildCost,
   analyzeVirality,
+  evaluateDesignPotential,
 };

--- a/lib/eva/stage-zero/synthesis/moat-architecture.js
+++ b/lib/eva/stage-zero/synthesis/moat-architecture.js
@@ -14,7 +14,7 @@
 import { getValidationClient } from '../../../llm/client-factory.js';
 import { extractUsage } from '../../utils/parse-json.js';
 
-const MOAT_TYPES = ['data_moat', 'automation_speed', 'vertical_expertise', 'network_effects', 'switching_costs'];
+const MOAT_TYPES = ['data_moat', 'automation_speed', 'vertical_expertise', 'network_effects', 'switching_costs', 'design_moat'];
 
 /**
  * Design a moat strategy for a venture candidate.
@@ -51,6 +51,7 @@ MOAT TYPES (choose primary + secondary):
 3. vertical_expertise: Deep domain knowledge from customer engagement
 4. network_effects: Value increases with user count
 5. switching_costs: Integration depth, data lock-in
+6. design_moat: Superior UX creating brand loyalty and switching costs
 
 For each applicable moat type, explain:
 - How it applies to this venture

--- a/lib/integrations/brainstorm-retrospective.js
+++ b/lib/integrations/brainstorm-retrospective.js
@@ -8,6 +8,7 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { accumulateFromSession } from '../domain-intelligence/knowledge-accumulator.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -309,6 +310,27 @@ export async function completeRetrospective(sessionId, retroData = {}) {
   // Recalculate effectiveness for the domain
   if (session?.domain) {
     await updateQuestionEffectiveness(session.domain);
+  }
+
+  // Domain Intelligence: extract and accumulate knowledge from session
+  if (retroData.venture) {
+    try {
+      const fullSession = await supabase
+        .from('brainstorm_sessions')
+        .select('id, topic, conclusion, metadata')
+        .eq('id', sessionId)
+        .single();
+      if (fullSession.data) {
+        await accumulateFromSession({
+          session: fullSession.data,
+          venture: retroData.venture,
+          supabase,
+        });
+      }
+    } catch (err) {
+      // Non-blocking: log but don't fail the retrospective
+      console.log(`[DomainIntelligence] Knowledge accumulation skipped: ${err.message}`);
+    }
   }
 
   return session;

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-02-multi-persona.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-02-multi-persona.test.js
@@ -39,8 +39,8 @@ function makePersonaResponse(personaId, score = 75) {
 }
 
 describe('PERSONAS', () => {
-  it('has exactly 6 personas', () => {
-    expect(PERSONAS).toHaveLength(6);
+  it('has exactly 7 personas', () => {
+    expect(PERSONAS).toHaveLength(7);
   });
 
   it('each persona has required fields', () => {
@@ -92,9 +92,9 @@ describe('analyzeStage02', () => {
     ).rejects.toThrow();
   });
 
-  it('runs all 6 personas and returns critiques with composite score', async () => {
+  it('runs all 7 personas and returns critiques with composite score', async () => {
     // Each persona call returns a different score
-    const scores = [80, 70, 60, 90, 50, 75];
+    const scores = [80, 70, 60, 90, 50, 75, 65];
     PERSONAS.forEach((persona, i) => {
       mockComplete.mockResolvedValueOnce(makePersonaResponse(persona.id, scores[i]));
     });
@@ -105,8 +105,8 @@ describe('analyzeStage02', () => {
       logger,
     });
 
-    expect(result.critiques).toHaveLength(6);
-    expect(mockComplete).toHaveBeenCalledTimes(6);
+    expect(result.critiques).toHaveLength(7);
+    expect(mockComplete).toHaveBeenCalledTimes(7);
 
     // Composite = average of scores, rounded
     const expectedComposite = Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);

--- a/tests/unit/eva/stage-templates/stage-02.test.js
+++ b/tests/unit/eva/stage-templates/stage-02.test.js
@@ -25,6 +25,7 @@ describe('stage-02.js - Idea Validation template', () => {
       expect(METRIC_NAMES).toEqual([
         'marketFit', 'customerNeed', 'momentum',
         'revenuePotential', 'competitiveBarrier', 'executionFeasibility',
+        'designQuality',
       ]);
     });
 
@@ -60,12 +61,14 @@ describe('stage-02.js - Idea Validation template', () => {
     metrics: {
       marketFit: 75, customerNeed: 80, momentum: 70,
       revenuePotential: 85, competitiveBarrier: 65, executionFeasibility: 90,
+      designQuality: 70,
     },
     evidence: {
       market: 'Market evidence here',
       customer: 'Customer evidence here',
       competitive: 'Competitive evidence here',
       execution: 'Execution evidence here',
+      design: 'Design evidence here',
     },
     suggestions: [],
     ...overrides,
@@ -217,11 +220,11 @@ describe('stage-02.js - Idea Validation template', () => {
   });
 
   describe('computeDerived() - compositeScore', () => {
-    it('should compute compositeScore as rounded average of 6 metrics', () => {
+    it('should compute compositeScore as rounded average of 7 metrics', () => {
       const data = makeValid();
-      // (75+80+70+85+65+90)/6 = 465/6 = 77.5 → 78
+      // (75+80+70+85+65+90+70)/7 = 535/7 = 76.43 → 76
       const result = stage02.computeDerived(data);
-      expect(result.compositeScore).toBe(78);
+      expect(result.compositeScore).toBe(76);
     });
 
     it('should be deterministic across metric orderings', () => {
@@ -236,10 +239,11 @@ describe('stage-02.js - Idea Validation template', () => {
       data.metrics = {
         marketFit: 76, customerNeed: 77, momentum: 76,
         revenuePotential: 77, competitiveBarrier: 76, executionFeasibility: 77,
+        designQuality: 76,
       };
-      // (76+77+76+77+76+77)/6 = 459/6 = 76.5 → 77
+      // (76+77+76+77+76+77+76)/7 = 535/7 = 76.43 → 76
       const result = stage02.computeDerived(data);
-      expect(result.compositeScore).toBe(77);
+      expect(result.compositeScore).toBe(76);
     });
 
     it('should return null when no valid metrics', () => {
@@ -254,6 +258,7 @@ describe('stage-02.js - Idea Validation template', () => {
       allZero.metrics = {
         marketFit: 0, customerNeed: 0, momentum: 0,
         revenuePotential: 0, competitiveBarrier: 0, executionFeasibility: 0,
+        designQuality: 0,
       };
       expect(stage02.computeDerived(allZero).compositeScore).toBe(0);
 
@@ -261,6 +266,7 @@ describe('stage-02.js - Idea Validation template', () => {
       allMax.metrics = {
         marketFit: 100, customerNeed: 100, momentum: 100,
         revenuePotential: 100, competitiveBarrier: 100, executionFeasibility: 100,
+        designQuality: 100,
       };
       expect(stage02.computeDerived(allMax).compositeScore).toBe(100);
     });
@@ -288,7 +294,7 @@ describe('stage-02.js - Idea Validation template', () => {
       expect(validation.valid).toBe(true);
 
       const computed = stage02.computeDerived(data);
-      expect(computed.compositeScore).toBe(78);
+      expect(computed.compositeScore).toBe(76);
     });
   });
 });

--- a/tests/unit/eva/stage-templates/stage-03.test.js
+++ b/tests/unit/eva/stage-templates/stage-03.test.js
@@ -34,10 +34,11 @@ describe('stage-03.js - Individual Validation template', () => {
       expect(METRIC_THRESHOLD).toBe(50);
     });
 
-    it('should have all 6 metrics defined', () => {
+    it('should have all 7 metrics defined', () => {
       expect(METRICS).toEqual([
         'marketFit', 'customerNeed', 'momentum',
         'revenuePotential', 'competitiveBarrier', 'executionFeasibility',
+        'designQuality',
       ]);
     });
 
@@ -53,6 +54,7 @@ describe('stage-03.js - Individual Validation template', () => {
   const makeValidMetrics = (overrides = {}) => ({
     marketFit: 75, customerNeed: 80, momentum: 70,
     revenuePotential: 85, competitiveBarrier: 65, executionFeasibility: 90,
+    designQuality: 70,
     ...overrides,
   });
 
@@ -67,6 +69,7 @@ describe('stage-03.js - Individual Validation template', () => {
       const data = {
         marketFit: 0, customerNeed: 100, momentum: 0,
         revenuePotential: 100, competitiveBarrier: 0, executionFeasibility: 100,
+        designQuality: 50,
       };
       const result = stage03.validate(data);
       expect(result.valid).toBe(true);
@@ -148,6 +151,7 @@ describe('stage-03.js - Individual Validation template', () => {
         metrics: {
           marketFit: 70, customerNeed: 75, momentum: 80,
           revenuePotential: 75, competitiveBarrier: 70, executionFeasibility: 80,
+          designQuality: 70,
         },
       });
       expect(result.decision).toBe('pass');
@@ -161,6 +165,7 @@ describe('stage-03.js - Individual Validation template', () => {
         metrics: {
           marketFit: 50, customerNeed: 50, momentum: 50,
           revenuePotential: 50, competitiveBarrier: 50, executionFeasibility: 50,
+          designQuality: 50,
         },
       });
       expect(result.decision).toBe('pass');
@@ -173,6 +178,7 @@ describe('stage-03.js - Individual Validation template', () => {
         metrics: {
           marketFit: 65, customerNeed: 65, momentum: 65,
           revenuePotential: 65, competitiveBarrier: 65, executionFeasibility: 65,
+          designQuality: 65,
         },
       });
       expect(result.decision).toBe('revise');
@@ -187,6 +193,7 @@ describe('stage-03.js - Individual Validation template', () => {
         metrics: {
           marketFit: 50, customerNeed: 50, momentum: 50,
           revenuePotential: 50, competitiveBarrier: 50, executionFeasibility: 50,
+          designQuality: 50,
         },
       });
       expect(result.decision).toBe('revise');
@@ -199,6 +206,7 @@ describe('stage-03.js - Individual Validation template', () => {
         metrics: {
           marketFit: 50, customerNeed: 50, momentum: 50,
           revenuePotential: 50, competitiveBarrier: 50, executionFeasibility: 50,
+          designQuality: 50,
         },
       });
       expect(result.decision).toBe('kill');
@@ -212,6 +220,7 @@ describe('stage-03.js - Individual Validation template', () => {
         metrics: {
           marketFit: 90, customerNeed: 90, momentum: 90,
           revenuePotential: 90, competitiveBarrier: 90, executionFeasibility: 49,
+          designQuality: 90,
         },
       });
       expect(result.decision).toBe('kill');
@@ -226,6 +235,7 @@ describe('stage-03.js - Individual Validation template', () => {
         metrics: {
           marketFit: 49, customerNeed: 48, momentum: 90,
           revenuePotential: 90, competitiveBarrier: 90, executionFeasibility: 90,
+          designQuality: 90,
         },
       });
       expect(result.decision).toBe('kill');
@@ -237,7 +247,8 @@ describe('stage-03.js - Individual Validation template', () => {
       const input = {
         overallScore: 75,
         metrics: { marketFit: 70, customerNeed: 75, momentum: 80,
-          revenuePotential: 75, competitiveBarrier: 70, executionFeasibility: 80 },
+          revenuePotential: 75, competitiveBarrier: 70, executionFeasibility: 80,
+          designQuality: 70 },
       };
       const original = JSON.parse(JSON.stringify(input));
       evaluateKillGate(input);
@@ -248,8 +259,8 @@ describe('stage-03.js - Individual Validation template', () => {
   describe('computeDerived()', () => {
     it('should compute overallScore as rounded average', () => {
       const result = stage03.computeDerived(makeValidMetrics());
-      // (75+80+70+85+65+90)/6 = 465/6 = 77.5 → 78
-      expect(result.overallScore).toBe(78);
+      // (75+80+70+85+65+90+70)/7 = 535/7 = 76.43 → 76
+      expect(result.overallScore).toBe(76);
     });
 
     it('should compute rollupDimensions', () => {
@@ -257,6 +268,7 @@ describe('stage-03.js - Individual Validation template', () => {
       expect(result.rollupDimensions.market).toBe(Math.round((75 + 70) / 2)); // marketFit + momentum
       expect(result.rollupDimensions.technical).toBe(Math.round((90 + 65) / 2)); // executionFeasibility + competitiveBarrier
       expect(result.rollupDimensions.financial).toBe(Math.round((85 + 80) / 2)); // revenuePotential + customerNeed
+      expect(result.rollupDimensions.experience).toBe(70); // designQuality
     });
 
     it('should include pass decision when all criteria met', () => {
@@ -269,6 +281,7 @@ describe('stage-03.js - Individual Validation template', () => {
       const data = {
         marketFit: 60, customerNeed: 60, momentum: 60,
         revenuePotential: 60, competitiveBarrier: 60, executionFeasibility: 60,
+        designQuality: 60,
       };
       const result = stage03.computeDerived(data);
       expect(result.overallScore).toBe(60);

--- a/tests/unit/eva/stage-zero/synthesis/design-evaluation.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/design-evaluation.test.js
@@ -1,0 +1,339 @@
+import { describe, test, expect, vi } from 'vitest';
+import {
+  evaluateDesignPotential,
+  DESIGN_DIMENSIONS,
+  DESIGN_RECOMMENDATIONS,
+} from '../../../../../lib/eva/stage-zero/synthesis/design-evaluation.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockLLMClient(responseJson) {
+  return {
+    _model: 'test-model',
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ text: JSON.stringify(responseJson) }],
+        usage: { input_tokens: 100, output_tokens: 200 },
+      }),
+    },
+  };
+}
+
+function createFailingLLMClient(errorMessage) {
+  return {
+    _model: 'test-model',
+    messages: {
+      create: vi.fn().mockRejectedValue(new Error(errorMessage)),
+    },
+  };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn() };
+
+const mockPathOutput = {
+  suggested_name: 'DesignFirst',
+  suggested_problem: 'Poor UX in enterprise dashboards',
+  suggested_solution: 'AI-powered adaptive interfaces',
+  target_market: 'Enterprise SaaS teams',
+};
+
+const validLLMResponse = {
+  dimensions: {
+    ux_simplicity: 8,
+    design_differentiation: 7,
+    adoption_friction: 6,
+    design_scalability: 7,
+    aesthetic_moat: 5,
+  },
+  composite_score: 66,
+  design_risks: ['Complex onboarding flow'],
+  design_opportunities: ['AI-driven personalization'],
+  recommendation: 'design_standard',
+  summary: 'Solid design potential with room for improvement in aesthetic moat.',
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('evaluateDesignPotential', () => {
+  test('returns valid result for a well-formed LLM response', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result.component).toBe('design_evaluation');
+    expect(result.dimensions.ux_simplicity).toBe(8);
+    expect(result.dimensions.design_differentiation).toBe(7);
+    expect(result.dimensions.adoption_friction).toBe(6);
+    expect(result.dimensions.design_scalability).toBe(7);
+    expect(result.dimensions.aesthetic_moat).toBe(5);
+    expect(result.composite_score).toBe(66);
+    expect(result.recommendation).toBe('design_standard');
+    expect(result.design_risks).toEqual(['Complex onboarding flow']);
+    expect(result.design_opportunities).toEqual(['AI-driven personalization']);
+    expect(result.summary).toBeTruthy();
+  });
+
+  test('calls LLM client with correct structure', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(client.messages.create).toHaveBeenCalledTimes(1);
+    const callArgs = client.messages.create.mock.calls[0][0];
+    expect(callArgs.model).toBe('test-model');
+    expect(callArgs.max_tokens).toBe(1500);
+    expect(callArgs.messages).toHaveLength(1);
+    expect(callArgs.messages[0].role).toBe('user');
+    expect(callArgs.messages[0].content).toContain('DesignFirst');
+  });
+
+  test('returns default result when LLM response is unparseable', async () => {
+    const client = {
+      _model: 'test-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: 'This is not JSON at all' }],
+          usage: { input_tokens: 50, output_tokens: 30 },
+        }),
+      },
+    };
+
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result.component).toBe('design_evaluation');
+    expect(result.composite_score).toBe(0);
+    expect(result.recommendation).toBe('design_minimal');
+    expect(result.summary).toContain('Could not parse');
+  });
+
+  test('returns default result when LLM throws an error', async () => {
+    const client = createFailingLLMClient('API rate limit exceeded');
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result.component).toBe('design_evaluation');
+    expect(result.composite_score).toBe(0);
+    expect(result.recommendation).toBe('design_minimal');
+    expect(result.summary).toContain('Evaluation failed');
+    expect(result.summary).toContain('API rate limit exceeded');
+  });
+
+  test('clamps out-of-range dimension values', async () => {
+    const response = {
+      ...validLLMResponse,
+      dimensions: {
+        ux_simplicity: 15,
+        design_differentiation: -3,
+        adoption_friction: 10.7,
+        design_scalability: 0,
+        aesthetic_moat: 100,
+      },
+    };
+    const client = createMockLLMClient(response);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result.dimensions.ux_simplicity).toBe(10);
+    expect(result.dimensions.design_differentiation).toBe(0);
+    expect(result.dimensions.adoption_friction).toBe(10);
+    expect(result.dimensions.design_scalability).toBe(0);
+    expect(result.dimensions.aesthetic_moat).toBe(10);
+  });
+
+  test('handles non-finite dimension values gracefully', async () => {
+    const response = {
+      ...validLLMResponse,
+      dimensions: {
+        ux_simplicity: 'not a number',
+        design_differentiation: null,
+        adoption_friction: undefined,
+        design_scalability: NaN,
+        aesthetic_moat: Infinity,
+      },
+    };
+    const client = createMockLLMClient(response);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    // NaN, null, undefined, non-numeric strings → 0
+    expect(result.dimensions.ux_simplicity).toBe(0);
+    expect(result.dimensions.design_differentiation).toBe(0);
+    expect(result.dimensions.adoption_friction).toBe(0);
+    expect(result.dimensions.design_scalability).toBe(0);
+    // Infinity is not finite → 0
+    expect(result.dimensions.aesthetic_moat).toBe(0);
+  });
+
+  test('recomputes composite_score when LLM returns non-numeric value', async () => {
+    const response = {
+      ...validLLMResponse,
+      composite_score: 'high',
+    };
+    const client = createMockLLMClient(response);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    // Falls back to computeComposite: (8+7+6+7+5)/5 * 10 = 66
+    expect(result.composite_score).toBe(66);
+  });
+
+  test('infers recommendation when LLM returns invalid value', async () => {
+    const response = {
+      ...validLLMResponse,
+      recommendation: 'something_invalid',
+      composite_score: 75,
+    };
+    const client = createMockLLMClient(response);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    // composite >= 70 → design_led
+    expect(result.recommendation).toBe('design_led');
+  });
+
+  test('infers design_minimal for low composite scores', async () => {
+    const response = {
+      ...validLLMResponse,
+      recommendation: 'bogus',
+      composite_score: 30,
+    };
+    const client = createMockLLMClient(response);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result.recommendation).toBe('design_minimal');
+  });
+
+  test('clamps composite_score to 0-100 range', async () => {
+    const response = {
+      ...validLLMResponse,
+      composite_score: 150,
+    };
+    const client = createMockLLMClient(response);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result.composite_score).toBeLessThanOrEqual(100);
+    expect(result.composite_score).toBeGreaterThanOrEqual(0);
+  });
+
+  test('defaults design_risks and design_opportunities to empty arrays', async () => {
+    const response = {
+      ...validLLMResponse,
+      design_risks: 'not an array',
+      design_opportunities: null,
+    };
+    const client = createMockLLMClient(response);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result.design_risks).toEqual([]);
+    expect(result.design_opportunities).toEqual([]);
+  });
+
+  test('handles empty content array from LLM', async () => {
+    const client = {
+      _model: 'test-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [],
+          usage: { input_tokens: 10, output_tokens: 0 },
+        }),
+      },
+    };
+
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result.component).toBe('design_evaluation');
+    expect(result.composite_score).toBe(0);
+    expect(result.recommendation).toBe('design_minimal');
+  });
+
+  test('extracts usage from LLM response', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    expect(result).toHaveProperty('usage');
+  });
+
+  test('returns all required fields in result shape', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await evaluateDesignPotential(mockPathOutput, {
+      logger: silentLogger,
+      llmClient: client,
+    });
+
+    const requiredFields = [
+      'component',
+      'dimensions',
+      'composite_score',
+      'design_risks',
+      'design_opportunities',
+      'recommendation',
+      'summary',
+      'usage',
+    ];
+    for (const field of requiredFields) {
+      expect(result).toHaveProperty(field);
+    }
+  });
+});
+
+describe('DESIGN_DIMENSIONS', () => {
+  test('contains exactly 5 dimensions', () => {
+    expect(DESIGN_DIMENSIONS).toHaveLength(5);
+  });
+
+  test('includes all expected dimension keys', () => {
+    expect(DESIGN_DIMENSIONS).toContain('ux_simplicity');
+    expect(DESIGN_DIMENSIONS).toContain('design_differentiation');
+    expect(DESIGN_DIMENSIONS).toContain('adoption_friction');
+    expect(DESIGN_DIMENSIONS).toContain('design_scalability');
+    expect(DESIGN_DIMENSIONS).toContain('aesthetic_moat');
+  });
+});
+
+describe('DESIGN_RECOMMENDATIONS', () => {
+  test('contains exactly 3 recommendation types', () => {
+    expect(DESIGN_RECOMMENDATIONS).toHaveLength(3);
+  });
+
+  test('includes all expected recommendation values', () => {
+    expect(DESIGN_RECOMMENDATIONS).toContain('design_led');
+    expect(DESIGN_RECOMMENDATIONS).toContain('design_standard');
+    expect(DESIGN_RECOMMENDATIONS).toContain('design_minimal');
+  });
+});

--- a/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
@@ -42,6 +42,9 @@ vi.mock('../../../../../lib/eva/stage-zero/synthesis/build-cost-estimation.js', 
 vi.mock('../../../../../lib/eva/stage-zero/synthesis/virality.js', () => ({
   analyzeVirality: vi.fn().mockResolvedValue({ component: 'virality_analysis', virality_score: 6, summary: 'ok' }),
 }));
+vi.mock('../../../../../lib/eva/stage-zero/synthesis/design-evaluation.js', () => ({
+  evaluateDesignPotential: vi.fn().mockResolvedValue({ component: 'design_evaluation', dimensions: {}, composite_score: 66, recommendation: 'design_standard', summary: 'ok' }),
+}));
 vi.mock('../../../../../lib/eva/stage-zero/profile-service.js', () => ({
   resolveProfile: vi.fn().mockResolvedValue(null),
   calculateWeightedScore: vi.fn().mockReturnValue({ total_score: 75, breakdown: {} }),
@@ -63,6 +66,7 @@ import { assessTimeHorizon } from '../../../../../lib/eva/stage-zero/synthesis/t
 import { classifyArchetype } from '../../../../../lib/eva/stage-zero/synthesis/archetypes.js';
 import { estimateBuildCost } from '../../../../../lib/eva/stage-zero/synthesis/build-cost-estimation.js';
 import { analyzeVirality } from '../../../../../lib/eva/stage-zero/synthesis/virality.js';
+import { evaluateDesignPotential } from '../../../../../lib/eva/stage-zero/synthesis/design-evaluation.js';
 import { resolveProfile, calculateWeightedScore } from '../../../../../lib/eva/stage-zero/profile-service.js';
 
 const silentLogger = { log: vi.fn(), warn: vi.fn() };
@@ -87,7 +91,7 @@ beforeEach(() => {
 });
 
 describe('runSynthesis', () => {
-  test('runs all 9 synthesis components', async () => {
+  test('runs all 10 synthesis components', async () => {
     const result = await runSynthesis(validPathOutput, { logger: silentLogger });
 
     expect(crossReferenceIntellectualCapital).toHaveBeenCalledWith(validPathOutput, expect.anything());
@@ -99,9 +103,10 @@ describe('runSynthesis', () => {
     expect(classifyArchetype).toHaveBeenCalledWith(validPathOutput, expect.anything());
     expect(estimateBuildCost).toHaveBeenCalledWith(validPathOutput, expect.anything());
     expect(analyzeVirality).toHaveBeenCalledWith(validPathOutput, expect.anything());
+    expect(evaluateDesignPotential).toHaveBeenCalledWith(validPathOutput, expect.anything());
 
-    expect(result.metadata.synthesis.components_run).toBe(9);
-    expect(result.metadata.synthesis.components_total).toBe(9);
+    expect(result.metadata.synthesis.components_run).toBe(10);
+    expect(result.metadata.synthesis.components_total).toBe(10);
   });
 
   test('handles component failure gracefully', async () => {


### PR DESCRIPTION
## Summary
- Add `design-evaluation.js` as the 10th synthesis component, scoring ventures across 5 UX dimensions (ux_simplicity, design_differentiation, adoption_friction, design_scalability, aesthetic_moat)
- Update synthesis engine index.js to include design evaluation in the component pipeline (9 → 10 components)
- Integrate design persona into stage-02 multi-persona analysis and stage-03 hybrid scoring
- Add 18-test unit test suite for design-evaluation.js with full mock coverage (happy path, error handling, clamping, edge cases)
- Update synthesis-engine.test.js to expect 10 components

## Test plan
- [x] All 18 design-evaluation tests pass
- [x] All 55 synthesis tests pass (4 files)
- [x] All 1468 stage template tests pass (40 files, 0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)