### PR TITLE
fix: use dynamic import for domain-intelligence in cross-reference

### DIFF
--- a/lib/eva/stage-zero/synthesis/cross-reference.js
+++ b/lib/eva/stage-zero/synthesis/cross-reference.js
@@ -12,7 +12,7 @@
 
 import { getValidationClient } from '../../../llm/client-factory.js';
 import { extractUsage } from '../../utils/parse-json.js';
-import { createDomainKnowledgeService } from '../../../domain-intelligence/domain-knowledge-service.js';
+
 
 /**
  * Cross-reference a venture candidate against intellectual capital and outcome history.
@@ -167,6 +167,7 @@ async function loadOutcomeHistory(supabase) {
  */
 async function loadDomainKnowledge(supabase, pathOutput, logger = console) {
   try {
+    const { createDomainKnowledgeService } = await import('../../../domain-intelligence/domain-knowledge-service.js');
     const service = createDomainKnowledgeService(supabase, { logger });
     const tags = [];
     const problemAreas = [];


### PR DESCRIPTION
## Summary
- Convert static import of `domain-knowledge-service.js` to dynamic `import()` in `cross-reference.js`
- Fixes `components.test.js` suite failure caused by missing module (domain-intelligence is part of an in-flight SD)
- The dynamic import gracefully degrades via the existing try/catch when the module is not yet available

## Test plan
- [x] All 55 synthesis tests pass (4 files)
- [x] `components.test.js` passes (was broken before fix)
- [x] 15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)