### PR TITLE
test(SD-LEO-INFRA-ORG-STRUCTURE-DEPARTMENT-001): add department CLI unit tests

### DIFF
--- a/scripts/department-hierarchy.cjs
+++ b/scripts/department-hierarchy.cjs
@@ -6,15 +6,18 @@
  * Usage:
  *   node scripts/department-hierarchy.cjs
  */
-require('dotenv').config();
-const { createClient } = require('@supabase/supabase-js');
 
-const supabase = createClient(
-  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-);
+function getClient() {
+  require('dotenv').config();
+  const { createClient } = require('@supabase/supabase-js');
+  return createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+}
 
-async function main() {
+async function main(supabase) {
+  if (!supabase) supabase = getClient();
   // Fetch all departments ordered by hierarchy path
   const { data: departments, error } = await supabase
     .from('departments')
@@ -134,7 +137,11 @@ async function main() {
   console.log('='.repeat(70) + '\n');
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Fatal error:', err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/scripts/list-departments.cjs
+++ b/scripts/list-departments.cjs
@@ -3,15 +3,18 @@
  * list-departments.cjs - List all departments with hierarchy and agent counts
  * SD-LEO-ORCH-EHG-ORGANIZATIONAL-STRUCTURE-001-D
  */
-require('dotenv').config();
-const { createClient } = require('@supabase/supabase-js');
 
-const supabase = createClient(
-  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.SUPABASE_SERVICE_ROLE_KEY
-);
+function getClient() {
+  require('dotenv').config();
+  const { createClient } = require('@supabase/supabase-js');
+  return createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+}
 
-async function main() {
+async function main(supabase) {
+  if (!supabase) supabase = getClient();
   const { data: departments, error } = await supabase
     .from('departments')
     .select('id, name, slug, hierarchy_path, description, parent_department_id, is_active')
@@ -83,7 +86,11 @@ async function main() {
   console.log('='.repeat(80) + '\n');
 }
 
-main().catch(err => {
-  console.error('Fatal error:', err.message);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('Fatal error:', err.message);
+    process.exit(1);
+  });
+}
+
+module.exports = { main };

--- a/tests/unit/departments/department-hierarchy.test.js
+++ b/tests/unit/departments/department-hierarchy.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+function makeChain(resolvedValue) {
+  const handler = {
+    get(_, prop) {
+      if (prop === 'then') return (cb) => Promise.resolve(resolvedValue).then(cb);
+      if (prop === 'catch') return (cb) => Promise.resolve(resolvedValue).catch(cb);
+      return (...args) => new Proxy({}, handler);
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+function makeMockSupabase(fromResults) {
+  return {
+    from(table) {
+      const result = fromResults[table] || { data: null, error: null };
+      return makeChain(result);
+    },
+  };
+}
+
+let main;
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  main = require('../../../scripts/department-hierarchy.cjs').main;
+});
+
+describe('department-hierarchy', () => {
+  it('renders a tree with parent and child', async () => {
+    const parentId = 'p1';
+    const childId = 'c1';
+    const sb = makeMockSupabase({
+      departments: {
+        data: [
+          {
+            id: parentId,
+            name: 'EHG Corp',
+            slug: 'ehg',
+            hierarchy_path: 'ehg',
+            parent_department_id: null,
+            is_active: true,
+            description: 'Top level',
+          },
+          {
+            id: childId,
+            name: 'Engineering',
+            slug: 'eng',
+            hierarchy_path: 'ehg.eng',
+            parent_department_id: parentId,
+            is_active: true,
+            description: 'Dev team',
+          },
+        ],
+        error: null,
+      },
+      department_agents: { data: [{ department_id: childId }], error: null },
+      department_capabilities: { data: [{ department_id: childId }], error: null },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('EHG Corp');
+    expect(output).toContain('Engineering');
+    expect(output).toContain('1 agent');
+  });
+
+  it('shows message when no departments', async () => {
+    const sb = makeMockSupabase({
+      departments: { data: [], error: null },
+    });
+    await main(sb);
+    expect(console.log).toHaveBeenCalledWith('No departments found.');
+  });
+
+  it('handles database error', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase({
+      departments: { data: null, error: { message: 'db error' } },
+    });
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith('Error fetching departments:', 'db error');
+    mockExit.mockRestore();
+  });
+
+  it('marks inactive departments', async () => {
+    const sb = makeMockSupabase({
+      departments: {
+        data: [
+          {
+            id: 'x',
+            name: 'Old Dept',
+            slug: 'old',
+            hierarchy_path: 'old',
+            parent_department_id: null,
+            is_active: false,
+            description: null,
+          },
+        ],
+        error: null,
+      },
+      department_agents: { data: [], error: null },
+      department_capabilities: { data: [], error: null },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('[INACTIVE]');
+  });
+
+  it('shows summary with counts', async () => {
+    const sb = makeMockSupabase({
+      departments: {
+        data: [
+          {
+            id: 'd1',
+            name: 'Dept A',
+            slug: 'a',
+            hierarchy_path: 'a',
+            parent_department_id: null,
+            is_active: true,
+            description: null,
+          },
+        ],
+        error: null,
+      },
+      department_agents: { data: [{ department_id: 'd1' }], error: null },
+      department_capabilities: { data: [{ department_id: 'd1' }, { department_id: 'd1' }], error: null },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Summary:');
+    expect(output).toContain('1 departments');
+    expect(output).toContain('1 agent assignments');
+    expect(output).toContain('2 capabilities');
+  });
+});

--- a/tests/unit/departments/list-departments.test.js
+++ b/tests/unit/departments/list-departments.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+function makeChain(resolvedValue) {
+  const handler = {
+    get(_, prop) {
+      if (prop === 'then') return (cb) => Promise.resolve(resolvedValue).then(cb);
+      if (prop === 'catch') return (cb) => Promise.resolve(resolvedValue).catch(cb);
+      return (...args) => new Proxy({}, handler);
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+function makeMockSupabase(fromResults) {
+  return {
+    from(table) {
+      const result = fromResults[table] || { data: null, error: null };
+      return makeChain(result);
+    },
+  };
+}
+
+let main;
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  main = require('../../../scripts/list-departments.cjs').main;
+});
+
+describe('list-departments', () => {
+  it('shows message when no departments found', async () => {
+    const sb = makeMockSupabase({
+      departments: { data: [], error: null },
+      department_agents: { data: [], error: null },
+    });
+    await main(sb);
+    expect(console.log).toHaveBeenCalledWith('No departments found.');
+  });
+
+  it('lists departments with agent counts', async () => {
+    const deptId = '111-222';
+    const sb = makeMockSupabase({
+      departments: {
+        data: [
+          { id: deptId, name: 'Engineering', slug: 'eng', hierarchy_path: 'eng', is_active: true },
+        ],
+        error: null,
+      },
+      department_agents: {
+        data: [{ department_id: deptId }, { department_id: deptId }],
+        error: null,
+      },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Engineering');
+    expect(output).toContain('Total: 1 department(s)');
+  });
+
+  it('handles departments query error', async () => {
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase({
+      departments: { data: null, error: { message: 'connection refused' } },
+    });
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith(
+      'Error fetching departments:',
+      'connection refused'
+    );
+    mockExit.mockRestore();
+  });
+
+  it('handles agent count error gracefully', async () => {
+    const sb = makeMockSupabase({
+      departments: {
+        data: [
+          { id: 'x', name: 'Ops', slug: 'ops', hierarchy_path: 'ops', is_active: true },
+        ],
+        error: null,
+      },
+      department_agents: { data: null, error: { message: 'no access' } },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Ops');
+  });
+
+  it('shows active/inactive status', async () => {
+    const sb = makeMockSupabase({
+      departments: {
+        data: [
+          { id: 'a', name: 'Active Dept', slug: 'act', hierarchy_path: 'act', is_active: true },
+          { id: 'b', name: 'Inactive Dept', slug: 'ina', hierarchy_path: 'ina', is_active: false },
+        ],
+        error: null,
+      },
+      department_agents: { data: [], error: null },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Yes');
+    expect(output).toContain('No');
+  });
+});

--- a/tests/unit/departments/manage-department-agents.test.js
+++ b/tests/unit/departments/manage-department-agents.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+function makeChain(resolvedValue) {
+  const handler = {
+    get(_, prop) {
+      if (prop === 'then') return (cb) => Promise.resolve(resolvedValue).then(cb);
+      if (prop === 'catch') return (cb) => Promise.resolve(resolvedValue).catch(cb);
+      return (...args) => new Proxy({}, handler);
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+function makeMockSupabase(rpcResults = {}, fromResults = {}) {
+  return {
+    rpc(fnName, params) {
+      const result = rpcResults[fnName] || { data: null, error: null };
+      return makeChain(result);
+    },
+    from(table) {
+      const result = fromResults[table] || { data: null, error: null };
+      return makeChain(result);
+    },
+  };
+}
+
+let main, parseArgs;
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  const mod = require('../../../scripts/manage-department-agents.cjs');
+  main = mod.main;
+  parseArgs = mod.parseArgs;
+});
+
+describe('manage-department-agents', () => {
+  it('shows usage when no action provided', async () => {
+    process.argv = ['node', 'script'];
+    const sb = makeMockSupabase();
+    await main(sb);
+    expect(console.log).toHaveBeenCalled();
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Usage:');
+  });
+
+  it('shows usage with --help flag', async () => {
+    process.argv = ['node', 'script', '--help'];
+    const sb = makeMockSupabase();
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Usage:');
+  });
+
+  it('assigns agent with specified role', async () => {
+    process.argv = [
+      'node', 'script', '--assign',
+      '--agent-id', 'agent-uuid',
+      '--department-id', 'dept-uuid',
+      '--role', 'lead',
+    ];
+    const sb = makeMockSupabase({
+      assign_agent_to_department: { data: 'assignment-id', error: null },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('assigned');
+    expect(output).toContain('lead');
+  });
+
+  it('assigns agent with default member role', async () => {
+    process.argv = [
+      'node', 'script', '--assign',
+      '--agent-id', 'agent-uuid',
+      '--department-id', 'dept-uuid',
+    ];
+    const sb = makeMockSupabase({
+      assign_agent_to_department: { data: 'assignment-id', error: null },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('member');
+  });
+
+  it('handles assign RPC error', async () => {
+    process.argv = [
+      'node', 'script', '--assign',
+      '--agent-id', 'a1',
+      '--department-id', 'd1',
+    ];
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase({
+      assign_agent_to_department: { data: null, error: { message: 'duplicate' } },
+    });
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith('Error assigning agent:', 'duplicate');
+    mockExit.mockRestore();
+  });
+
+  it('removes agent successfully', async () => {
+    process.argv = [
+      'node', 'script', '--remove',
+      '--agent-id', 'a1',
+      '--department-id', 'd1',
+    ];
+    const sb = makeMockSupabase({
+      remove_agent_from_department: { data: true, error: null },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('removed');
+  });
+
+  it('handles remove when agent not in department', async () => {
+    process.argv = [
+      'node', 'script', '--remove',
+      '--agent-id', 'a1',
+      '--department-id', 'd1',
+    ];
+    const sb = makeMockSupabase({
+      remove_agent_from_department: { data: false, error: null },
+    });
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('was not in');
+  });
+
+  it('lists agents in department', async () => {
+    process.argv = ['node', 'script', '--list', '--department-id', 'dept-uuid'];
+    const sb = makeMockSupabase(
+      {
+        get_department_agents: {
+          data: [
+            {
+              display_name: 'Test Agent',
+              agent_type: 'orchestrator',
+              role_in_department: 'lead',
+              assigned_at: '2026-01-15T00:00:00Z',
+            },
+          ],
+          error: null,
+        },
+      },
+      {
+        departments: { data: { name: 'Engineering' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('AGENTS IN');
+    expect(output).toContain('Test Agent');
+  });
+
+  it('lists empty department', async () => {
+    process.argv = ['node', 'script', '--list', '--department-id', 'dept-uuid'];
+    const sb = makeMockSupabase(
+      {
+        get_department_agents: { data: [], error: null },
+      },
+      {
+        departments: { data: { name: 'Empty Dept' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('No agents assigned');
+  });
+
+  it('errors when --department-id missing for list', async () => {
+    process.argv = ['node', 'script', '--list'];
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase();
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith('Error: --department-id is required for --list');
+    mockExit.mockRestore();
+  });
+
+  it('errors when --agent-id or --department-id missing for assign', async () => {
+    process.argv = ['node', 'script', '--assign', '--agent-id', 'a1'];
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase();
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith(
+      'Error: --agent-id and --department-id are required for --assign'
+    );
+    mockExit.mockRestore();
+  });
+});

--- a/tests/unit/departments/manage-department-capabilities.test.js
+++ b/tests/unit/departments/manage-department-capabilities.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+function makeChain(resolvedValue) {
+  const handler = {
+    get(_, prop) {
+      if (prop === 'then') return (cb) => Promise.resolve(resolvedValue).then(cb);
+      if (prop === 'catch') return (cb) => Promise.resolve(resolvedValue).catch(cb);
+      return (...args) => new Proxy({}, handler);
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+function makeMockSupabase(rpcResults = {}, fromResults = {}) {
+  return {
+    rpc(fnName, params) {
+      const result = rpcResults[fnName] || { data: null, error: null };
+      return makeChain(result);
+    },
+    from(table) {
+      const result = fromResults[table] || { data: null, error: null };
+      return makeChain(result);
+    },
+  };
+}
+
+let main, parseArgs;
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  const mod = require('../../../scripts/manage-department-capabilities.cjs');
+  main = mod.main;
+  parseArgs = mod.parseArgs;
+});
+
+describe('manage-department-capabilities', () => {
+  it('shows usage when no action provided', async () => {
+    process.argv = ['node', 'script'];
+    const sb = makeMockSupabase();
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Usage:');
+  });
+
+  it('adds capability with description', async () => {
+    process.argv = [
+      'node', 'script', '--add',
+      '--department-id', 'dept-1',
+      '--name', 'code-review',
+      '--description', 'Review pull requests',
+    ];
+    const sb = makeMockSupabase(
+      {
+        add_department_capability: { data: 'cap-uuid', error: null },
+      },
+      {
+        departments: { data: { name: 'Engineering' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('code-review');
+    expect(output).toContain('Engineering');
+    expect(output).toContain('Review pull requests');
+  });
+
+  it('adds capability without description', async () => {
+    process.argv = [
+      'node', 'script', '--add',
+      '--department-id', 'dept-1',
+      '--name', 'testing',
+    ];
+    const sb = makeMockSupabase(
+      {
+        add_department_capability: { data: 'cap-uuid', error: null },
+      },
+      {
+        departments: { data: { name: 'QA' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('testing');
+    expect(output).toContain('QA');
+  });
+
+  it('removes capability successfully', async () => {
+    process.argv = [
+      'node', 'script', '--remove',
+      '--department-id', 'dept-1',
+      '--name', 'old-cap',
+    ];
+    const sb = makeMockSupabase(
+      {
+        remove_department_capability: { data: true, error: null },
+      },
+      {
+        departments: { data: { name: 'Ops' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('removed');
+    expect(output).toContain('Ops');
+  });
+
+  it('handles remove when capability not found', async () => {
+    process.argv = [
+      'node', 'script', '--remove',
+      '--department-id', 'dept-1',
+      '--name', 'nonexistent',
+    ];
+    const sb = makeMockSupabase(
+      {
+        remove_department_capability: { data: false, error: null },
+      },
+      {
+        departments: { data: { name: 'Ops' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('was not found');
+  });
+
+  it('lists direct capabilities', async () => {
+    process.argv = ['node', 'script', '--list', '--department-id', 'dept-1'];
+    const sb = makeMockSupabase(
+      {},
+      {
+        department_capabilities: {
+          data: [
+            { capability_name: 'testing', description: 'Run tests' },
+            { capability_name: 'deploy', description: 'Deploy services' },
+          ],
+          error: null,
+        },
+        departments: { data: { name: 'DevOps', hierarchy_path: 'devops' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('CAPABILITIES');
+    expect(output).toContain('testing');
+    expect(output).toContain('deploy');
+  });
+
+  it('errors when --name missing for add', async () => {
+    process.argv = ['node', 'script', '--add', '--department-id', 'dept-1'];
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase();
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith('Error: --name is required for --add');
+    mockExit.mockRestore();
+  });
+
+  it('errors when --department-id missing', async () => {
+    process.argv = ['node', 'script', '--add', '--name', 'test'];
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase();
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith('Error: --department-id is required');
+    mockExit.mockRestore();
+  });
+
+  it('handles add RPC error', async () => {
+    process.argv = [
+      'node', 'script', '--add',
+      '--department-id', 'dept-1',
+      '--name', 'test',
+    ];
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase({
+      add_department_capability: { data: null, error: { message: 'rpc failed' } },
+    });
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith('Error adding capability:', 'rpc failed');
+    mockExit.mockRestore();
+  });
+});

--- a/tests/unit/departments/query-capabilities.test.js
+++ b/tests/unit/departments/query-capabilities.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+function makeChain(resolvedValue) {
+  const handler = {
+    get(_, prop) {
+      if (prop === 'then') return (cb) => Promise.resolve(resolvedValue).then(cb);
+      if (prop === 'catch') return (cb) => Promise.resolve(resolvedValue).catch(cb);
+      return (...args) => new Proxy({}, handler);
+    },
+  };
+  return new Proxy({}, handler);
+}
+
+function makeMockSupabase(rpcResults = {}, fromResults = {}) {
+  return {
+    rpc(fnName, params) {
+      const result = rpcResults[fnName] || { data: null, error: null };
+      return makeChain(result);
+    },
+    from(table) {
+      const result = fromResults[table] || { data: null, error: null };
+      return makeChain(result);
+    },
+  };
+}
+
+let main, parseArgs;
+
+beforeEach(() => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  const mod = require('../../../scripts/query-capabilities.cjs');
+  main = mod.main;
+  parseArgs = mod.parseArgs;
+});
+
+describe('query-capabilities', () => {
+  it('shows usage when no args provided', async () => {
+    process.argv = ['node', 'script'];
+    const sb = makeMockSupabase();
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Usage:');
+  });
+
+  it('shows usage with --help', async () => {
+    process.argv = ['node', 'script', '--help'];
+    const sb = makeMockSupabase();
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('Usage:');
+  });
+
+  it('queries single agent capabilities via RPC', async () => {
+    process.argv = ['node', 'script', '--agent-id', 'agent-uuid'];
+    const sb = makeMockSupabase(
+      {
+        get_effective_capabilities: {
+          data: [
+            {
+              capability_name: 'code-review',
+              source_department_name: 'Engineering',
+              inheritance_type: 'direct',
+            },
+            {
+              capability_name: 'deploy',
+              source_department_name: 'DevOps',
+              inheritance_type: 'inherited',
+            },
+          ],
+          error: null,
+        },
+      },
+      {
+        agent_registry: { data: { display_name: 'Test Agent' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('EFFECTIVE CAPABILITIES');
+    expect(output).toContain('code-review');
+    expect(output).toContain('DIRECT');
+    expect(output).toContain('INHERITED');
+  });
+
+  it('shows message for agent with no capabilities', async () => {
+    process.argv = ['node', 'script', '--agent-id', 'agent-uuid'];
+    const sb = makeMockSupabase(
+      {
+        get_effective_capabilities: { data: [], error: null },
+      },
+      {
+        agent_registry: { data: { display_name: 'Empty Agent' }, error: null },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('No capabilities found');
+  });
+
+  it('queries all capabilities via view', async () => {
+    process.argv = ['node', 'script', '--all'];
+    const sb = makeMockSupabase(
+      {},
+      {
+        v_agent_effective_capabilities: {
+          data: [
+            {
+              agent_name: 'Agent A',
+              capability_name: 'testing',
+              source_department_name: 'QA',
+              inheritance_type: 'direct',
+            },
+          ],
+          error: null,
+        },
+      }
+    );
+    await main(sb);
+    const output = console.log.mock.calls.map((c) => c[0]).join('\n');
+    expect(output).toContain('ALL AGENT EFFECTIVE CAPABILITIES');
+    expect(output).toContain('Agent A');
+    expect(output).toContain('Total: 1');
+  });
+
+  it('handles RPC error for single agent', async () => {
+    process.argv = ['node', 'script', '--agent-id', 'bad-uuid'];
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase({
+      get_effective_capabilities: { data: null, error: { message: 'rpc failed' } },
+    });
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith('Error querying capabilities:', 'rpc failed');
+    mockExit.mockRestore();
+  });
+
+  it('handles view error for --all', async () => {
+    process.argv = ['node', 'script', '--all'];
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit');
+    });
+    const sb = makeMockSupabase(
+      {},
+      {
+        v_agent_effective_capabilities: { data: null, error: { message: 'view error' } },
+      }
+    );
+    await expect(main(sb)).rejects.toThrow('exit');
+    expect(console.error).toHaveBeenCalledWith('Error querying capabilities:', 'view error');
+    mockExit.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Refactored 5 department CLI scripts to use dependency injection pattern (accept `supabase` client as parameter to `main()`)
- Added 37 unit tests across 5 test files covering all department CLI operations
- Test files: `list-departments`, `department-hierarchy`, `manage-department-agents`, `manage-department-capabilities`, `query-capabilities`
- Uses proxy-based chainable mock for Supabase fluent API — no `vi.mock()` needed for CJS modules

## Test plan
- [x] All 37 tests pass (`vitest run tests/unit/departments/`)
- [x] Smoke tests pass (pre-commit hook verified)
- [x] ESLint clean (auto-fixed by pre-commit)
- [x] Scripts still work as CLI tools (DI pattern preserves `require.main === module` behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)