### PR TITLE
feat(SD-LEO-FIX-BRAINSTORM-NARRATIVE-RISK-001): add Narrative Risk scoring as 11th synthesis component

### DIFF
--- a/lib/eva/stage-zero/synthesis/index.js
+++ b/lib/eva/stage-zero/synthesis/index.js
@@ -25,6 +25,9 @@
  * Component 10 (SD-EVA-FEAT-DESIGN-PERSONA-001):
  * 10. Design Evaluation
  *
+ * Component 11 (SD-LEO-FIX-BRAINSTORM-NARRATIVE-RISK-001):
+ * 11. Narrative Risk Analysis (advisory signal — not in weighted composite)
+ *
  * Profile System (SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-B):
  * - Resolves evaluation profile (explicit, active, or legacy defaults)
  * - Calculates weighted venture score from component results
@@ -43,10 +46,11 @@ import { classifyArchetype } from './archetypes.js';
 import { estimateBuildCost } from './build-cost-estimation.js';
 import { analyzeVirality } from './virality.js';
 import { evaluateDesignPotential } from './design-evaluation.js';
+import { analyzeNarrativeRisk } from './narrative-risk.js';
 import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 
 /**
- * Run all 9 synthesis components on a PathOutput.
+ * Run all 11 synthesis components on a PathOutput.
  *
  * @param {Object} pathOutput - PathOutput from entry path
  * @param {Object} deps - Injected dependencies
@@ -59,7 +63,7 @@ import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 export async function runSynthesis(pathOutput, deps = {}) {
   const { logger = console, profileId } = deps;
 
-  logger.log('   Running synthesis engine (10/10 components)...');
+  logger.log('   Running synthesis engine (11/11 components)...');
 
   // Resolve evaluation profile (parallel with component execution)
   const profilePromise = resolveProfile(deps, profileId).catch(err => {
@@ -70,7 +74,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
   // Run all 10 components - grouped by dependency
   // Group 1 (no inter-dependencies): components 1-4, 6-10
   // Group 2 (depends on nothing but run separately): component 5 (chairman constraints)
-  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design] = await Promise.all([
+  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk] = await Promise.all([
     crossReferenceIntellectualCapital(pathOutput, deps).catch(err => {
       logger.warn(`   Warning: Cross-reference failed: ${err.message}`);
       return { component: 'cross_reference', matches: [], lessons: [], relevance_score: 0, summary: `Failed: ${err.message}` };
@@ -107,6 +111,10 @@ export async function runSynthesis(pathOutput, deps = {}) {
       logger.warn(`   Warning: Design evaluation failed: ${err.message}`);
       return { component: 'design_evaluation', dimensions: { ux_simplicity: 0, design_differentiation: 0, adoption_friction: 0, design_scalability: 0, aesthetic_moat: 0 }, composite_score: 0, design_risks: [], design_opportunities: [], recommendation: 'design_minimal', summary: `Failed: ${err.message}` };
     }),
+    analyzeNarrativeRisk(pathOutput, deps).catch(err => {
+      logger.warn(`   Warning: Narrative risk analysis failed: ${err.message}`);
+      return { component: 'narrative_risk', nr_score: 0, nr_band: 'NR-Unknown', nr_interpretation: 'Analysis unavailable', component_scores: { decision_sensitivity: 0, demand_distortion: 0, hype_persistence: 0, influence_exposure: 0 }, narrative_flags: [], confidence: 0, confidence_caveat: 'Analysis failed.', summary: `Failed: ${err.message}` };
+    }),
   ]);
 
   // Chairman constraints run after others (uses pathOutput directly, no inter-dependency)
@@ -119,6 +127,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
   const profile = await profilePromise;
 
   // Calculate weighted score if profile is available
+  // Note: narrative_risk is advisory only — excluded from weighted composite
   const synthesisResults = {
     cross_reference: crossRef,
     portfolio_evaluation: portfolio,
@@ -148,7 +157,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
   }
 
   // Aggregate token usage from all components
-  const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design]
+  const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk]
     .map(c => c.usage)
     .filter(Boolean);
   const usage = componentUsages.length > 0 ? {
@@ -156,7 +165,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
     outputTokens: componentUsages.reduce((sum, u) => sum + (u.outputTokens || 0), 0),
   } : null;
 
-  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}, virality=${virality.virality_score || 0}, design=${design.composite_score || 0}`);
+  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}, virality=${virality.virality_score || 0}, design=${design.composite_score || 0}, narrative_risk=${narrativeRisk.nr_score || 0} (${narrativeRisk.nr_band || 'unknown'})`);
 
   // Build enriched brief
   const recommendedProblem = reframing.recommended_framing?.framing || pathOutput.suggested_problem;
@@ -191,8 +200,9 @@ export async function runSynthesis(pathOutput, deps = {}) {
         build_cost: buildCost,
         virality: virality,
         design_evaluation: design,
-        components_run: 10,
-        components_total: 10,
+        narrative_risk: narrativeRisk,
+        components_run: 11,
+        components_total: 11,
         profile: profileMetadata,
         weighted_score: weightedScore,
       },
@@ -211,4 +221,5 @@ export {
   estimateBuildCost,
   analyzeVirality,
   evaluateDesignPotential,
+  analyzeNarrativeRisk,
 };

--- a/lib/eva/stage-zero/synthesis/narrative-risk.js
+++ b/lib/eva/stage-zero/synthesis/narrative-risk.js
@@ -1,0 +1,204 @@
+/**
+ * Synthesis Component 11: Narrative Risk Analysis
+ *
+ * Evaluates venture candidates for narrative-driven demand risk across 4 sub-dimensions:
+ * - Decision Sensitivity (DS, 35%): How badly would this venture suffer if sentiment flipped?
+ * - Demand Distortion (DD, 30%): Would customers still want this without the narrative?
+ * - Hype-Persistence (HP, 20%): Does attention decay faster than problem relevance?
+ * - Influence Exposure (IE, 15%): Presence of coordinated/amplified narratives
+ *
+ * Governance Bands:
+ * - NR-Low (0-24): Structural, durable demand
+ * - NR-Moderate (25-49): Watch assumptions
+ * - NR-High (50-69): Timing & scope risk
+ * - NR-Critical (70-100): Narrative-fragile
+ *
+ * Ships as ADVISORY signal only — not folded into weighted composite score.
+ *
+ * Part of SD-LEO-FIX-BRAINSTORM-NARRATIVE-RISK-001
+ */
+
+import { getValidationClient } from '../../../llm/client-factory.js';
+import { extractUsage } from '../../utils/parse-json.js';
+
+const NR_WEIGHTS = {
+  decision_sensitivity: 0.35,
+  demand_distortion: 0.30,
+  hype_persistence: 0.20,
+  influence_exposure: 0.15,
+};
+
+const GOVERNANCE_BANDS = [
+  { min: 0, max: 24, band: 'NR-Low', interpretation: 'Structural, durable demand' },
+  { min: 25, max: 49, band: 'NR-Moderate', interpretation: 'Watch assumptions' },
+  { min: 50, max: 69, band: 'NR-High', interpretation: 'Timing & scope risk' },
+  { min: 70, max: 100, band: 'NR-Critical', interpretation: 'Narrative-fragile' },
+];
+
+/**
+ * Analyze narrative risk for a venture candidate.
+ *
+ * @param {Object} pathOutput - PathOutput from entry path
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} [deps.logger] - Logger
+ * @param {Object} [deps.llmClient] - LLM client override (for testing)
+ * @returns {Promise<Object>} Narrative risk analysis result
+ */
+export async function analyzeNarrativeRisk(pathOutput, deps = {}) {
+  const { logger = console, llmClient } = deps;
+  const client = llmClient || getValidationClient();
+
+  logger.log('   Analyzing narrative risk...');
+
+  const prompt = `You are an EHG narrative risk analyst. Evaluate whether the perceived demand driving this venture concept is organic or narrative-manufactured.
+
+VENTURE:
+Name: ${pathOutput.suggested_name}
+Problem: ${pathOutput.suggested_problem}
+Solution: ${pathOutput.suggested_solution}
+Market: ${pathOutput.target_market}
+
+EHG Chairman Directives:
+- Distinguish real demand from manufactured perception
+- Vulnerability matters more than exposure (how badly does THIS venture break if narrative shifts?)
+- Ventures built on hype cycles face inflated TAM, temporary demand spikes, and assumption fragility
+- Different venture archetypes have structurally different narrative risk baselines
+
+Evaluate across 4 sub-dimensions (each scored 0-100):
+
+1. Decision Sensitivity (DS, weight: 35%): How badly would this venture suffer if market sentiment flipped?
+   - 0-24: Venture solves a structural need regardless of narrative
+   - 25-49: Some revenue impact but core value persists
+   - 50-69: Significant revenue/adoption risk if narrative shifts
+   - 70-100: Venture viability depends on current narrative continuing
+
+2. Demand Distortion (DD, weight: 30%): Would customers still want this without the narrative?
+   - 0-24: Demand is structurally driven (regulation, cost savings, pain)
+   - 25-49: Some narrative amplification but real underlying need
+   - 50-69: Narrative significantly inflates perceived urgency
+   - 70-100: Without the narrative, demand would not exist
+
+3. Hype-Persistence (HP, weight: 20%): Does attention decay faster than problem relevance?
+   - 0-24: Problem will persist long after media attention fades
+   - 25-49: Moderate staying power, some cyclical attention
+   - 50-69: Attention is fading but problem partially remains
+   - 70-100: Pure hype cycle — attention and problem decay together
+
+4. Influence Exposure (IE, weight: 15%): Presence of coordinated or amplified narratives around this space?
+   - 0-24: Minimal media/influencer amplification
+   - 25-49: Some amplification but organic voices dominate
+   - 50-69: Significant coordinated messaging from vendors/analysts
+   - 70-100: Market narrative dominated by coordinated campaigns
+
+Return JSON:
+{
+  "decision_sensitivity": 45,
+  "demand_distortion": 30,
+  "hype_persistence": 25,
+  "influence_exposure": 35,
+  "narrative_flags": ["string (specific narrative risks identified)"],
+  "confidence": 0.7,
+  "confidence_caveat": "string (acknowledge LLM training data may affect scoring)",
+  "summary": "string (2-3 sentences assessing overall narrative risk)"
+}`;
+
+  try {
+    const response = await client.messages.create({
+      model: client._model || 'claude-sonnet-4-5-20250929',
+      max_tokens: 1500,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const usage = extractUsage(response);
+
+    const text = response.content[0]?.text || '';
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const analysis = JSON.parse(jsonMatch[0]);
+      const components = {
+        decision_sensitivity: clamp(analysis.decision_sensitivity ?? 50, 0, 100),
+        demand_distortion: clamp(analysis.demand_distortion ?? 50, 0, 100),
+        hype_persistence: clamp(analysis.hype_persistence ?? 50, 0, 100),
+        influence_exposure: clamp(analysis.influence_exposure ?? 50, 0, 100),
+      };
+      const nrScore = calculateNarrativeRiskScore(components);
+      const band = classifyGovernanceBand(nrScore);
+
+      return {
+        component: 'narrative_risk',
+        nr_score: nrScore,
+        nr_band: band.band,
+        nr_interpretation: band.interpretation,
+        component_scores: components,
+        narrative_flags: Array.isArray(analysis.narrative_flags) ? analysis.narrative_flags : [],
+        confidence: clamp(analysis.confidence ?? 0.5, 0, 1),
+        confidence_caveat: analysis.confidence_caveat || 'LLM training data may affect scoring in well-represented domains (AI, crypto, sustainability).',
+        summary: analysis.summary || '',
+        usage,
+      };
+    }
+    return defaultNarrativeRiskResult('Could not parse narrative risk analysis');
+  } catch (err) {
+    logger.warn(`   Warning: Narrative risk analysis failed: ${err.message}`);
+    return defaultNarrativeRiskResult(`Analysis failed: ${err.message}`);
+  }
+}
+
+/**
+ * Calculate narrative risk composite score from sub-dimensions.
+ *
+ * Weights: DS=35%, DD=30%, HP=20%, IE=15%
+ *
+ * @param {Object} components - Sub-dimension scores (each 0-100)
+ * @returns {number} Composite NR score 0-100
+ */
+export function calculateNarrativeRiskScore(components) {
+  if (!components) return 0;
+
+  return Math.round(
+    clamp(components.decision_sensitivity ?? 0, 0, 100) * NR_WEIGHTS.decision_sensitivity +
+    clamp(components.demand_distortion ?? 0, 0, 100) * NR_WEIGHTS.demand_distortion +
+    clamp(components.hype_persistence ?? 0, 0, 100) * NR_WEIGHTS.hype_persistence +
+    clamp(components.influence_exposure ?? 0, 0, 100) * NR_WEIGHTS.influence_exposure
+  );
+}
+
+/**
+ * Classify NR score into governance band.
+ *
+ * @param {number} nrScore - Composite NR score 0-100
+ * @returns {Object} Band object with { band, interpretation }
+ */
+export function classifyGovernanceBand(nrScore) {
+  const score = clamp(Math.round(nrScore), 0, 100);
+  for (const band of GOVERNANCE_BANDS) {
+    if (score >= band.min && score <= band.max) {
+      return { band: band.band, interpretation: band.interpretation };
+    }
+  }
+  return { band: 'NR-Critical', interpretation: 'Narrative-fragile' };
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function defaultNarrativeRiskResult(summary) {
+  return {
+    component: 'narrative_risk',
+    nr_score: 0,
+    nr_band: 'NR-Unknown',
+    nr_interpretation: 'Analysis unavailable',
+    component_scores: {
+      decision_sensitivity: 0,
+      demand_distortion: 0,
+      hype_persistence: 0,
+      influence_exposure: 0,
+    },
+    narrative_flags: [],
+    confidence: 0,
+    confidence_caveat: 'LLM analysis unavailable — narrative risk could not be assessed.',
+    summary,
+  };
+}
+
+export { NR_WEIGHTS, GOVERNANCE_BANDS };

--- a/tests/unit/eva/stage-zero/synthesis/narrative-risk.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/narrative-risk.test.js
@@ -1,0 +1,292 @@
+/**
+ * Unit Tests: Narrative Risk Synthesis Component (Component 11)
+ * SD-LEO-FIX-BRAINSTORM-NARRATIVE-RISK-001
+ *
+ * Test Coverage:
+ * - Successful LLM response parsing
+ * - LLM failure fallback to defaults
+ * - Composite score calculation from weighted sub-dimensions
+ * - Governance band classification (NR-Low, NR-Moderate, NR-High, NR-Critical)
+ * - All 4 sub-dimensions present in output
+ * - Clamping of out-of-range values
+ * - Confidence caveat included
+ * - Weight verification (DS=35%, DD=30%, HP=20%, IE=15%)
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  analyzeNarrativeRisk,
+  calculateNarrativeRiskScore,
+  classifyGovernanceBand,
+  NR_WEIGHTS,
+  GOVERNANCE_BANDS,
+} from '../../../../../lib/eva/stage-zero/synthesis/narrative-risk.js';
+
+const mockPathOutput = {
+  suggested_name: 'TestVenture',
+  suggested_problem: 'Users need better collaboration tools',
+  suggested_solution: 'AI-powered team workspace with built-in sharing',
+  target_market: 'Remote teams at SMBs',
+  origin_type: 'discovery',
+  competitor_urls: [],
+  blueprint_id: null,
+  discovery_strategy: null,
+  metadata: {},
+};
+
+const validLLMResponse = {
+  decision_sensitivity: 40,
+  demand_distortion: 25,
+  hype_persistence: 30,
+  influence_exposure: 20,
+  narrative_flags: ['AI hype cycle proximity', 'VC narrative amplification'],
+  confidence: 0.75,
+  confidence_caveat: 'AI-adjacent ventures may receive inflated scores due to training data density.',
+  summary: 'Moderate narrative risk. Core collaboration need is structural, but AI positioning amplifies perceived urgency.',
+};
+
+function createMockLLMClient(responseJson) {
+  return {
+    _model: 'test-model',
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ text: JSON.stringify(responseJson) }],
+      }),
+    },
+  };
+}
+
+function createFailingLLMClient(errorMessage) {
+  return {
+    _model: 'test-model',
+    messages: {
+      create: vi.fn().mockRejectedValue(new Error(errorMessage)),
+    },
+  };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn() };
+
+describe('analyzeNarrativeRisk', () => {
+  test('parses valid LLM response with all sub-dimensions', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('narrative_risk');
+    expect(result.component_scores.decision_sensitivity).toBe(40);
+    expect(result.component_scores.demand_distortion).toBe(25);
+    expect(result.component_scores.hype_persistence).toBe(30);
+    expect(result.component_scores.influence_exposure).toBe(20);
+    expect(result.narrative_flags).toHaveLength(2);
+    expect(result.confidence).toBe(0.75);
+    expect(result.confidence_caveat).toBeTruthy();
+    expect(result.summary).toBeTruthy();
+  });
+
+  test('calculates correct composite NR score from sub-dimensions', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    // DS=40*0.35=14, DD=25*0.30=7.5, HP=30*0.20=6, IE=20*0.15=3 → 30.5 → rounded to 31
+    expect(result.nr_score).toBe(31);
+  });
+
+  test('assigns correct governance band', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    // Score 31 → NR-Moderate (25-49)
+    expect(result.nr_band).toBe('NR-Moderate');
+    expect(result.nr_interpretation).toBe('Watch assumptions');
+  });
+
+  test('returns default result when LLM fails', async () => {
+    const client = createFailingLLMClient('API unavailable');
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('narrative_risk');
+    expect(result.nr_score).toBe(0);
+    expect(result.nr_band).toBe('NR-Unknown');
+    expect(result.component_scores.decision_sensitivity).toBe(0);
+    expect(result.component_scores.demand_distortion).toBe(0);
+    expect(result.component_scores.hype_persistence).toBe(0);
+    expect(result.component_scores.influence_exposure).toBe(0);
+    expect(result.confidence).toBe(0);
+    expect(result.narrative_flags).toEqual([]);
+    expect(result.summary).toContain('Analysis failed');
+  });
+
+  test('returns default result when LLM returns unparseable text', async () => {
+    const client = {
+      _model: 'test-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: 'I cannot analyze narrative risk in JSON format.' }],
+        }),
+      },
+    };
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('narrative_risk');
+    expect(result.nr_score).toBe(0);
+    expect(result.nr_band).toBe('NR-Unknown');
+    expect(result.summary).toContain('Could not parse');
+  });
+
+  test('clamps out-of-range sub-dimension values', async () => {
+    const outOfRange = {
+      ...validLLMResponse,
+      decision_sensitivity: 150,
+      demand_distortion: -20,
+      hype_persistence: 200,
+      influence_exposure: -50,
+      confidence: 2.5,
+    };
+    const client = createMockLLMClient(outOfRange);
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component_scores.decision_sensitivity).toBe(100);
+    expect(result.component_scores.demand_distortion).toBe(0);
+    expect(result.component_scores.hype_persistence).toBe(100);
+    expect(result.component_scores.influence_exposure).toBe(0);
+    expect(result.confidence).toBe(1);
+  });
+
+  test('has all 4 required sub-dimensions in component_scores', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    const requiredFields = ['decision_sensitivity', 'demand_distortion', 'hype_persistence', 'influence_exposure'];
+    for (const field of requiredFields) {
+      expect(result.component_scores).toHaveProperty(field);
+    }
+  });
+
+  test('provides default confidence caveat when LLM omits it', async () => {
+    const noCaveat = { ...validLLMResponse };
+    delete noCaveat.confidence_caveat;
+    const client = createMockLLMClient(noCaveat);
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.confidence_caveat).toContain('LLM training data');
+  });
+
+  test('handles non-array narrative_flags gracefully', async () => {
+    const badFlags = { ...validLLMResponse, narrative_flags: 'not an array' };
+    const client = createMockLLMClient(badFlags);
+    const result = await analyzeNarrativeRisk(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.narrative_flags).toEqual([]);
+  });
+});
+
+describe('calculateNarrativeRiskScore', () => {
+  test('returns 0 for null input', () => {
+    expect(calculateNarrativeRiskScore(null)).toBe(0);
+  });
+
+  test('returns 0 for empty input', () => {
+    expect(calculateNarrativeRiskScore({})).toBe(0);
+  });
+
+  test('calculates weighted score correctly', () => {
+    const components = {
+      decision_sensitivity: 60,  // 60 * 0.35 = 21
+      demand_distortion: 40,     // 40 * 0.30 = 12
+      hype_persistence: 50,      // 50 * 0.20 = 10
+      influence_exposure: 30,    // 30 * 0.15 = 4.5
+    };
+    const score = calculateNarrativeRiskScore(components);
+    // 21 + 12 + 10 + 4.5 = 47.5 → rounded to 48
+    expect(score).toBe(48);
+  });
+
+  test('returns 100 for maximum values', () => {
+    const maxComponents = {
+      decision_sensitivity: 100,
+      demand_distortion: 100,
+      hype_persistence: 100,
+      influence_exposure: 100,
+    };
+    expect(calculateNarrativeRiskScore(maxComponents)).toBe(100);
+  });
+
+  test('weights sum to 1.0', () => {
+    const weightSum = Object.values(NR_WEIGHTS).reduce((sum, w) => sum + w, 0);
+    expect(weightSum).toBeCloseTo(1.0, 10);
+  });
+
+  test('Decision Sensitivity has highest weight (35%)', () => {
+    expect(NR_WEIGHTS.decision_sensitivity).toBe(0.35);
+    const weights = Object.values(NR_WEIGHTS);
+    expect(NR_WEIGHTS.decision_sensitivity).toBe(Math.max(...weights));
+  });
+});
+
+describe('classifyGovernanceBand', () => {
+  test('classifies NR-Low (0-24)', () => {
+    expect(classifyGovernanceBand(0).band).toBe('NR-Low');
+    expect(classifyGovernanceBand(12).band).toBe('NR-Low');
+    expect(classifyGovernanceBand(24).band).toBe('NR-Low');
+  });
+
+  test('classifies NR-Moderate (25-49)', () => {
+    expect(classifyGovernanceBand(25).band).toBe('NR-Moderate');
+    expect(classifyGovernanceBand(37).band).toBe('NR-Moderate');
+    expect(classifyGovernanceBand(49).band).toBe('NR-Moderate');
+  });
+
+  test('classifies NR-High (50-69)', () => {
+    expect(classifyGovernanceBand(50).band).toBe('NR-High');
+    expect(classifyGovernanceBand(60).band).toBe('NR-High');
+    expect(classifyGovernanceBand(69).band).toBe('NR-High');
+  });
+
+  test('classifies NR-Critical (70-100)', () => {
+    expect(classifyGovernanceBand(70).band).toBe('NR-Critical');
+    expect(classifyGovernanceBand(85).band).toBe('NR-Critical');
+    expect(classifyGovernanceBand(100).band).toBe('NR-Critical');
+  });
+
+  test('provides interpretation for each band', () => {
+    expect(classifyGovernanceBand(10).interpretation).toBe('Structural, durable demand');
+    expect(classifyGovernanceBand(30).interpretation).toBe('Watch assumptions');
+    expect(classifyGovernanceBand(55).interpretation).toBe('Timing & scope risk');
+    expect(classifyGovernanceBand(80).interpretation).toBe('Narrative-fragile');
+  });
+
+  test('clamps negative scores to NR-Low', () => {
+    expect(classifyGovernanceBand(-5).band).toBe('NR-Low');
+  });
+
+  test('clamps scores above 100 to NR-Critical', () => {
+    expect(classifyGovernanceBand(150).band).toBe('NR-Critical');
+  });
+});
+
+describe('GOVERNANCE_BANDS', () => {
+  test('contains 4 bands', () => {
+    expect(GOVERNANCE_BANDS).toHaveLength(4);
+  });
+
+  test('bands cover full 0-100 range without gaps', () => {
+    expect(GOVERNANCE_BANDS[0].min).toBe(0);
+    expect(GOVERNANCE_BANDS[GOVERNANCE_BANDS.length - 1].max).toBe(100);
+    for (let i = 1; i < GOVERNANCE_BANDS.length; i++) {
+      expect(GOVERNANCE_BANDS[i].min).toBe(GOVERNANCE_BANDS[i - 1].max + 1);
+    }
+  });
+});
+
+describe('NR_WEIGHTS', () => {
+  test('contains exactly 4 sub-dimensions', () => {
+    expect(Object.keys(NR_WEIGHTS)).toHaveLength(4);
+  });
+
+  test('has correct weights per brainstorm spec', () => {
+    expect(NR_WEIGHTS.decision_sensitivity).toBe(0.35);
+    expect(NR_WEIGHTS.demand_distortion).toBe(0.30);
+    expect(NR_WEIGHTS.hype_persistence).toBe(0.20);
+    expect(NR_WEIGHTS.influence_exposure).toBe(0.15);
+  });
+});

--- a/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
@@ -45,6 +45,9 @@ vi.mock('../../../../../lib/eva/stage-zero/synthesis/virality.js', () => ({
 vi.mock('../../../../../lib/eva/stage-zero/synthesis/design-evaluation.js', () => ({
   evaluateDesignPotential: vi.fn().mockResolvedValue({ component: 'design_evaluation', dimensions: {}, composite_score: 66, recommendation: 'design_standard', summary: 'ok' }),
 }));
+vi.mock('../../../../../lib/eva/stage-zero/synthesis/narrative-risk.js', () => ({
+  analyzeNarrativeRisk: vi.fn().mockResolvedValue({ component: 'narrative_risk', nr_score: 35, nr_band: 'NR-Moderate', nr_interpretation: 'Watch assumptions', component_scores: { decision_sensitivity: 40, demand_distortion: 30, hype_persistence: 25, influence_exposure: 20 }, narrative_flags: [], confidence: 0.7, confidence_caveat: 'Test caveat', summary: 'ok' }),
+}));
 vi.mock('../../../../../lib/eva/stage-zero/profile-service.js', () => ({
   resolveProfile: vi.fn().mockResolvedValue(null),
   calculateWeightedScore: vi.fn().mockReturnValue({ total_score: 75, breakdown: {} }),
@@ -67,6 +70,7 @@ import { classifyArchetype } from '../../../../../lib/eva/stage-zero/synthesis/a
 import { estimateBuildCost } from '../../../../../lib/eva/stage-zero/synthesis/build-cost-estimation.js';
 import { analyzeVirality } from '../../../../../lib/eva/stage-zero/synthesis/virality.js';
 import { evaluateDesignPotential } from '../../../../../lib/eva/stage-zero/synthesis/design-evaluation.js';
+import { analyzeNarrativeRisk } from '../../../../../lib/eva/stage-zero/synthesis/narrative-risk.js';
 import { resolveProfile, calculateWeightedScore } from '../../../../../lib/eva/stage-zero/profile-service.js';
 
 const silentLogger = { log: vi.fn(), warn: vi.fn() };
@@ -91,7 +95,7 @@ beforeEach(() => {
 });
 
 describe('runSynthesis', () => {
-  test('runs all 10 synthesis components', async () => {
+  test('runs all 11 synthesis components', async () => {
     const result = await runSynthesis(validPathOutput, { logger: silentLogger });
 
     expect(crossReferenceIntellectualCapital).toHaveBeenCalledWith(validPathOutput, expect.anything());
@@ -104,9 +108,10 @@ describe('runSynthesis', () => {
     expect(estimateBuildCost).toHaveBeenCalledWith(validPathOutput, expect.anything());
     expect(analyzeVirality).toHaveBeenCalledWith(validPathOutput, expect.anything());
     expect(evaluateDesignPotential).toHaveBeenCalledWith(validPathOutput, expect.anything());
+    expect(analyzeNarrativeRisk).toHaveBeenCalledWith(validPathOutput, expect.anything());
 
-    expect(result.metadata.synthesis.components_run).toBe(10);
-    expect(result.metadata.synthesis.components_total).toBe(10);
+    expect(result.metadata.synthesis.components_run).toBe(11);
+    expect(result.metadata.synthesis.components_total).toBe(11);
   });
 
   test('handles component failure gracefully', async () => {


### PR DESCRIPTION
## Summary
- Add Narrative Risk (NR) analysis as the 11th synthesis component in the Stage 0 venture evaluation engine
- NR evaluates 4 weighted sub-dimensions: Decision Sensitivity (35%), Demand Distortion (30%), Hype-Persistence (20%), Influence Exposure (15%)
- Classifies ventures into governance bands: NR-Low (0-24), NR-Moderate (25-49), NR-High (50-69), NR-Critical (70-100)
- Advisory-only deployment: NR displays as signal but is excluded from weighted composite score
- 26 unit tests across narrative-risk.test.js + updated synthesis-engine.test.js (81 total, 0 regressions)

## Files Changed
- `lib/eva/stage-zero/synthesis/narrative-risk.js` (NEW - 204 lines)
- `lib/eva/stage-zero/synthesis/index.js` (MODIFIED - NR integration)
- `tests/unit/eva/stage-zero/synthesis/narrative-risk.test.js` (NEW - 26 tests)
- `tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js` (MODIFIED - 10→11 components)

## Test plan
- [x] All 81 unit tests pass across 5 synthesis test files
- [x] NR composite score calculation verified (weighted sum with clamping)
- [x] Governance band classification covers full 0-100 range
- [x] LLM failure fallback returns safe defaults
- [x] Out-of-range value clamping verified
- [x] Synthesis engine runs 11/11 components with NR included

🤖 Generated with [Claude Code](https://claude.com/claude-code)