### PR TITLE
fix: prevent claim guard from stealing claims when stale session PID is alive

### DIFF
--- a/.claude/.protocol-sync
+++ b/.claude/.protocol-sync
@@ -1,1 +1,0 @@
-{"timestamp":"2026-02-18T20:45:45.217Z","pid":33216,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}

--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,13 +1,13 @@
 {
   "isActive": true,
   "wasInterrupted": false,
-  "currentSd": "SD-MAN-ENH-COMPLETE-VISUAL-PLAYGROUND-001",
+  "currentSd": "SD-LEO-FEAT-STAND-RESEARCH-DEPARTMENT-001",
   "currentPhase": "EXEC",
-  "currentTask": "Implementing Complete Visual Playground Dashboard Panels and Tests",
+  "currentTask": "Implementing Stand Up Research Department as Internal EHG Service",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-02-18T17:31:07.095Z",
-  "lastUpdatedAt": "2026-02-22T05:51:46.475Z"
+  "clearedAt": "2026-02-22T04:24:53.633Z",
+  "lastUpdatedAt": "2026-02-22T04:50:13.165Z"
 }

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -13,7 +13,9 @@
  *     │   ├── Claim holder process dead? → Release → Acquire → PROCEED
  *     │   └── Claim holder process alive? → HARD STOP (safe default)
  *     ├── Another ACTIVE session owns it? → HARD STOP
- *     └── Stale session owns it? → Release → Acquire → PROCEED
+ *     ├── Stale session owns it?
+ *     │   ├── Stale but PID alive (same host)? → HARD STOP (heartbeat lag, not dead)
+ *     │   └── Stale and PID dead (or different host)? → Release → Acquire → PROCEED
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -21,6 +23,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import { getStaleThresholdSeconds } from './claim/stale-threshold.js';
+import { isProcessRunning } from './heartbeat-manager.mjs';
+import os from 'os';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -255,8 +259,30 @@ export async function claimGuard(sdKey, sessionId) {
       };
     }
 
-    // Stale session → release it first
-    console.log(`[claimGuard] Releasing stale claim from session ${claim.session_id} (${claim.heartbeat_age_human})`);
+    // Stale session → check PID liveness before releasing
+    // QF: A stale heartbeat does NOT mean the process is dead. The session may
+    // have been busy (long LLM call, context compaction) and missed heartbeats.
+    // If the PID is alive on the same host, treat as active → HARD STOP.
+    const sameHost = claim.hostname === os.hostname();
+    const claimPid = claim.pid ? parseInt(claim.pid, 10) : null;
+    if (sameHost && claimPid && isProcessRunning(claimPid)) {
+      console.log(`[claimGuard] Stale session ${claim.session_id} (${claim.heartbeat_age_human}) but PID ${claimPid} is ALIVE → HARD STOP`);
+      return {
+        success: false,
+        error: 'claimed_by_stale_but_alive_session',
+        owner: {
+          session_id: claim.session_id,
+          heartbeat_age_human: claim.heartbeat_age_human || `${Math.round(heartbeatAge)}s ago`,
+          hostname: claim.hostname || 'unknown',
+          tty: claim.tty || 'unknown',
+          codebase: claim.codebase || 'unknown',
+          pid: claimPid,
+          note: 'Heartbeat stale but process alive — likely busy, not dead'
+        }
+      };
+    }
+
+    console.log(`[claimGuard] Releasing stale claim from session ${claim.session_id} (${claim.heartbeat_age_human})${sameHost && claimPid ? ` — PID ${claimPid} is dead` : ' — different host or no PID'}`);
     const { error: releaseError } = await supabase.rpc('release_sd', {
       p_session_id: claim.session_id,
       p_reason: 'manual'
@@ -358,6 +384,13 @@ export function formatClaimFailure(result) {
     lines.push(`  Hostname:  ${result.owner.hostname || 'unknown'}`);
     lines.push(`  TTY:       ${result.owner.tty || 'unknown'}`);
     lines.push(`  Codebase:  ${result.owner.codebase || 'unknown'}`);
+  }
+
+  if (result.owner?.pid) {
+    lines.push(`  PID:       ${result.owner.pid}`);
+  }
+  if (result.owner?.note) {
+    lines.push(`  Note:      ${result.owner.note}`);
   }
 
   lines.push('');

--- a/lib/claim-guard.test.js
+++ b/lib/claim-guard.test.js
@@ -529,6 +529,154 @@ describe('verifyClaimOwnership', () => {
   });
 });
 
+describe('claimGuard - stale PID liveness check', () => {
+  let claimGuard;
+  const mockIsProcessRunning = vi.fn();
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: vi.fn(() => mockSupabase)
+    }));
+    vi.doMock('dotenv', () => ({
+      default: { config: vi.fn() },
+      config: vi.fn()
+    }));
+    vi.doMock('./heartbeat-manager.mjs', () => ({
+      isProcessRunning: mockIsProcessRunning
+    }));
+
+    const mod = await import('./claim-guard.mjs');
+    claimGuard = mod.claimGuard;
+  });
+
+  it('returns hard stop when stale session PID is alive on same host', async () => {
+    const staleTime = new Date(Date.now() - 1000 * 1000).toISOString(); // 1000s ago
+    const currentHostname = (await import('os')).default.hostname();
+    mockIsProcessRunning.mockReturnValue(true);
+
+    let claudeSessionsCallCount = 0;
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        claudeSessionsCallCount++;
+        if (claudeSessionsCallCount === 1) {
+          return mockClaudeSessionsClaimQuery([{
+            sd_id: 'SD-TEST-001', session_id: 'stale-session', track: 'A', claimed_at: staleTime
+          }]);
+        }
+        if (claudeSessionsCallCount === 2) {
+          // Enrichment: stale heartbeat, same hostname, has PID
+          return mockClaudeSessionsEnrichmentQuery([{
+            session_id: 'stale-session', terminal_id: 'win-cc-11111-8900', pid: 8900,
+            hostname: currentHostname, tty: '/dev/pts/2', codebase: '/test',
+            heartbeat_at: staleTime, status: 'active'
+          }]);
+        }
+        // Third call: myTerminalId lookup
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { terminal_id: 'win-cc-22222-1111' },
+                error: null
+              })
+            })
+          })
+        };
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    const result = await claimGuard('SD-TEST-001', 'session-1');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('claimed_by_stale_but_alive_session');
+    expect(result.owner.session_id).toBe('stale-session');
+    expect(result.owner.pid).toBe(8900);
+    expect(result.owner.note).toContain('process alive');
+    expect(mockIsProcessRunning).toHaveBeenCalledWith(8900);
+  });
+
+  it('releases stale session when PID is dead on same host', async () => {
+    const staleTime = new Date(Date.now() - 1000 * 1000).toISOString();
+    const currentHostname = (await import('os')).default.hostname();
+    mockIsProcessRunning.mockReturnValue(false);
+
+    let claudeSessionsCallCount = 0;
+    mockFrom.mockImplementation((table) => {
+      if (table === 'claude_sessions') {
+        claudeSessionsCallCount++;
+        if (claudeSessionsCallCount === 1) {
+          return mockClaudeSessionsClaimQuery([{
+            sd_id: 'SD-TEST-001', session_id: 'stale-session', track: 'A', claimed_at: staleTime
+          }]);
+        }
+        if (claudeSessionsCallCount === 2) {
+          return mockClaudeSessionsEnrichmentQuery([{
+            session_id: 'stale-session', terminal_id: 'win-cc-11111-8900', pid: 8900,
+            hostname: currentHostname, tty: '/dev/pts/2', codebase: '/test',
+            heartbeat_at: staleTime, status: 'active'
+          }]);
+        }
+        if (claudeSessionsCallCount === 3) {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                single: vi.fn().mockResolvedValue({
+                  data: { terminal_id: 'win-cc-22222-1111' },
+                  error: null
+                })
+              })
+            })
+          };
+        }
+        // Fourth call: verifyClaimOwnership read-back
+        return mockClaudeSessionsClaimQuery([{
+          session_id: 'session-1', sd_id: 'SD-TEST-001', status: 'active'
+        }]);
+      }
+      if (table === 'sd_baseline_items') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { track: 'A' }, error: null })
+            })
+          })
+        };
+      }
+      if (table === 'strategic_directives_v2') {
+        return {
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: null, error: null })
+          })
+        };
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+    });
+
+    mockRpc.mockImplementation((funcName) => {
+      if (funcName === 'release_sd') return Promise.resolve({ data: null, error: null });
+      if (funcName === 'claim_sd') return Promise.resolve({
+        data: { success: true, sd_id: 'SD-TEST-001', session_id: 'session-1' },
+        error: null
+      });
+      return Promise.resolve({ data: null, error: null });
+    });
+
+    const result = await claimGuard('SD-TEST-001', 'session-1');
+
+    expect(result.success).toBe(true);
+    expect(result.claim.status).toBe('newly_acquired');
+    expect(mockIsProcessRunning).toHaveBeenCalledWith(8900);
+    expect(mockRpc).toHaveBeenCalledWith('release_sd', { p_session_id: 'stale-session', p_reason: 'manual' });
+  });
+});
+
 describe('formatClaimFailure', () => {
   let formatClaimFailure;
 
@@ -569,5 +717,25 @@ describe('formatClaimFailure', () => {
     expect(formatted).toContain('other-session');
     expect(formatted).toContain('30s ago');
     expect(formatted).toContain('testhost');
+  });
+
+  it('includes PID and note for stale-but-alive failures', () => {
+    const result = {
+      success: false,
+      error: 'claimed_by_stale_but_alive_session',
+      owner: {
+        session_id: 'stale-session',
+        heartbeat_age_human: '8m ago',
+        hostname: 'myhost',
+        tty: '/dev/pts/2',
+        codebase: '/test',
+        pid: 8900,
+        note: 'Heartbeat stale but process alive — likely busy, not dead'
+      }
+    };
+
+    const formatted = formatClaimFailure(result);
+    expect(formatted).toContain('8900');
+    expect(formatted).toContain('process alive');
   });
 });


### PR DESCRIPTION
## Summary
- Adds PID liveness check to `claimGuard()` before releasing stale claims on the same host
- If a session's heartbeat is stale but its process is still alive (busy with LLM call or context compaction), returns HARD STOP instead of stealing the claim
- Adds `pid` and `note` fields to `formatClaimFailure` output for better diagnostics
- Adds 3 new unit tests: stale+alive PID → HARD STOP, stale+dead PID → release, formatClaimFailure with PID/note

## Test plan
- [x] All 20 claim-guard tests pass (17 existing + 3 new)
- [x] Smoke tests pass (15/15)
- [ ] Manual: Run two concurrent sessions claiming the same SD — second session should see HARD STOP with PID info

🤖 Generated with [Claude Code](https://claude.com/claude-code)