### PR TITLE
feat(tech-trajectory): add Technology Trajectory Model as synthesis Component 12

### DIFF
--- a/lib/eva/stage-zero/profile-service.js
+++ b/lib/eva/stage-zero/profile-service.js
@@ -17,12 +17,13 @@ const LEGACY_WEIGHTS = {
   cross_reference: 0.10,
   portfolio_evaluation: 0.10,
   problem_reframing: 0.05,
-  moat_architecture: 0.15,
-  chairman_constraints: 0.15,
+  moat_architecture: 0.13,
+  chairman_constraints: 0.14,
   time_horizon: 0.10,
   archetypes: 0.10,
   build_cost: 0.10,
-  virality: 0.15,
+  virality: 0.13,
+  tech_trajectory: 0.05,
 };
 
 /**
@@ -239,6 +240,8 @@ function extractComponentScore(component, result) {
         : result.complexity === 'complex' ? 30 : 50;
     case 'virality':
       return clamp(result.virality_score ?? 0, 0, 100);
+    case 'tech_trajectory':
+      return clamp(result.trajectory_score ?? 0, 0, 100);
     default:
       return 0;
   }

--- a/lib/eva/stage-zero/synthesis/index.js
+++ b/lib/eva/stage-zero/synthesis/index.js
@@ -28,6 +28,9 @@
  * Component 11 (SD-LEO-FIX-BRAINSTORM-NARRATIVE-RISK-001):
  * 11. Narrative Risk Analysis (advisory signal — not in weighted composite)
  *
+ * Component 12 (SD-LEO-FEAT-TECHNOLOGY-TRAJECTORY-MODEL-001):
+ * 12. Technology Trajectory Model (advisory weight 0.05 in weighted composite)
+ *
  * Profile System (SD-LEO-ORCH-EVA-STAGE-CONFIGURABLE-001-B):
  * - Resolves evaluation profile (explicit, active, or legacy defaults)
  * - Calculates weighted venture score from component results
@@ -47,10 +50,11 @@ import { estimateBuildCost } from './build-cost-estimation.js';
 import { analyzeVirality } from './virality.js';
 import { evaluateDesignPotential } from './design-evaluation.js';
 import { analyzeNarrativeRisk } from './narrative-risk.js';
+import { analyzeTechTrajectory } from './tech-trajectory.js';
 import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 
 /**
- * Run all 11 synthesis components on a PathOutput.
+ * Run all 12 synthesis components on a PathOutput.
  *
  * @param {Object} pathOutput - PathOutput from entry path
  * @param {Object} deps - Injected dependencies
@@ -63,7 +67,7 @@ import { resolveProfile, calculateWeightedScore } from '../profile-service.js';
 export async function runSynthesis(pathOutput, deps = {}) {
   const { logger = console, profileId } = deps;
 
-  logger.log('   Running synthesis engine (11/11 components)...');
+  logger.log('   Running synthesis engine (12/12 components)...');
 
   // Resolve evaluation profile (parallel with component execution)
   const profilePromise = resolveProfile(deps, profileId).catch(err => {
@@ -74,7 +78,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
   // Run all 10 components - grouped by dependency
   // Group 1 (no inter-dependencies): components 1-4, 6-10
   // Group 2 (depends on nothing but run separately): component 5 (chairman constraints)
-  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk] = await Promise.all([
+  const [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk, techTrajectory] = await Promise.all([
     crossReferenceIntellectualCapital(pathOutput, deps).catch(err => {
       logger.warn(`   Warning: Cross-reference failed: ${err.message}`);
       return { component: 'cross_reference', matches: [], lessons: [], relevance_score: 0, summary: `Failed: ${err.message}` };
@@ -115,6 +119,10 @@ export async function runSynthesis(pathOutput, deps = {}) {
       logger.warn(`   Warning: Narrative risk analysis failed: ${err.message}`);
       return { component: 'narrative_risk', nr_score: 0, nr_band: 'NR-Unknown', nr_interpretation: 'Analysis unavailable', component_scores: { decision_sensitivity: 0, demand_distortion: 0, hype_persistence: 0, influence_exposure: 0 }, narrative_flags: [], confidence: 0, confidence_caveat: 'Analysis failed.', summary: `Failed: ${err.message}` };
     }),
+    analyzeTechTrajectory(pathOutput, deps).catch(err => {
+      logger.warn(`   Warning: Technology trajectory analysis failed: ${err.message}`);
+      return { component: 'tech_trajectory', trajectory_score: 0, axes: { reasoning_autonomy: { current: 0, bull_6m: 0, base_6m: 0, bear_6m: 0, venture_impact: '' }, cost_deflation: { current: 0, bull_6m: 0, base_6m: 0, bear_6m: 0, venture_impact: '' }, multimodal_expansion: { current: 0, bull_6m: 0, base_6m: 0, bear_6m: 0, venture_impact: '' } }, competitive_timing: { signal: 'contested', confidence: 0, window_months: 0, rationale: '' }, next_disruption_event: { event: 'Unknown', estimated_months: 0, invalidation_scope: 'Unknown' }, gap_windows: [], confidence_caveat: 'Analysis failed.', summary: `Failed: ${err.message}`, data_feed_active: false };
+    }),
   ]);
 
   // Chairman constraints run after others (uses pathOutput directly, no inter-dependency)
@@ -139,6 +147,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
     build_cost: buildCost,
     virality: virality,
     design_evaluation: design,
+    tech_trajectory: techTrajectory,
   };
 
   let profileMetadata = null;
@@ -157,7 +166,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
   }
 
   // Aggregate token usage from all components
-  const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk]
+  const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk, techTrajectory]
     .map(c => c.usage)
     .filter(Boolean);
   const usage = componentUsages.length > 0 ? {
@@ -165,7 +174,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
     outputTokens: componentUsages.reduce((sum, u) => sum + (u.outputTokens || 0), 0),
   } : null;
 
-  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}, virality=${virality.virality_score || 0}, design=${design.composite_score || 0}, narrative_risk=${narrativeRisk.nr_score || 0} (${narrativeRisk.nr_band || 'unknown'})`);
+  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}, virality=${virality.virality_score || 0}, design=${design.composite_score || 0}, narrative_risk=${narrativeRisk.nr_score || 0} (${narrativeRisk.nr_band || 'unknown'}), tech_trajectory=${techTrajectory.trajectory_score || 0} (${techTrajectory.competitive_timing?.signal || 'unknown'})`);
 
   // Build enriched brief
   const recommendedProblem = reframing.recommended_framing?.framing || pathOutput.suggested_problem;
@@ -201,8 +210,9 @@ export async function runSynthesis(pathOutput, deps = {}) {
         virality: virality,
         design_evaluation: design,
         narrative_risk: narrativeRisk,
-        components_run: 11,
-        components_total: 11,
+        tech_trajectory: techTrajectory,
+        components_run: 12,
+        components_total: 12,
         profile: profileMetadata,
         weighted_score: weightedScore,
       },
@@ -222,4 +232,5 @@ export {
   analyzeVirality,
   evaluateDesignPotential,
   analyzeNarrativeRisk,
+  analyzeTechTrajectory,
 };

--- a/lib/eva/stage-zero/synthesis/tech-trajectory.js
+++ b/lib/eva/stage-zero/synthesis/tech-trajectory.js
@@ -1,0 +1,232 @@
+/**
+ * Synthesis Component 12: Technology Trajectory Model
+ *
+ * Projects technology capability trajectories across 3 axes with bull/base/bear
+ * confidence bands over a 6-month horizon:
+ * - Reasoning & Autonomy (RA, 40%): Agent capability, multi-step planning, tool use
+ * - Cost Deflation (CD, 35%): Token economics, model efficiency, inference cost trends
+ * - Multimodal Expansion (ME, 25%): Vision, audio, video, real-time processing
+ *
+ * Competitive Timing Signals:
+ * - opening: Technology enables new moats (build now)
+ * - closing: Commoditization approaching (build fast)
+ * - contested: No definitive advantage window (validate first)
+ *
+ * Ships with advisory weight 0.05 in weighted composite.
+ *
+ * Part of SD-LEO-FEAT-TECHNOLOGY-TRAJECTORY-MODEL-001
+ */
+
+import { getValidationClient } from '../../../llm/client-factory.js';
+import { extractUsage } from '../../utils/parse-json.js';
+
+const AXIS_WEIGHTS = {
+  reasoning_autonomy: 0.40,
+  cost_deflation: 0.35,
+  multimodal_expansion: 0.25,
+};
+
+const TIMING_SIGNALS = ['opening', 'closing', 'contested'];
+
+/**
+ * Analyze technology trajectory for a venture candidate.
+ *
+ * @param {Object} pathOutput - PathOutput from entry path
+ * @param {Object} deps - Injected dependencies
+ * @param {Object} [deps.logger] - Logger
+ * @param {Object} [deps.llmClient] - LLM client override (for testing)
+ * @param {Object} [deps.dataFeed] - External data feed (stubbed for future use)
+ * @returns {Promise<Object>} Technology trajectory analysis result
+ */
+export async function analyzeTechTrajectory(pathOutput, deps = {}) {
+  const { logger = console, llmClient, dataFeed = null } = deps;
+  const client = llmClient || getValidationClient();
+
+  logger.log('   Analyzing technology trajectory...');
+
+  const externalSignals = dataFeed ? await dataFeed.getTechSignals() : null;
+  const signalContext = externalSignals
+    ? `\nExternal signals available: ${JSON.stringify(externalSignals)}`
+    : '';
+
+  const prompt = `You are an EHG technology trajectory analyst. Project how frontier AI capability trends affect this venture's timing and defensibility over the next 6 months.
+
+VENTURE:
+Name: ${pathOutput.suggested_name}
+Problem: ${pathOutput.suggested_problem}
+Solution: ${pathOutput.suggested_solution}
+Market: ${pathOutput.target_market}
+${signalContext}
+
+EHG Chairman Directives:
+- Technology trajectory determines build-vs-wait timing decisions
+- Cost deflation curves make previously impossible ventures viable
+- Reasoning gains create new automation possibilities quarterly
+- Multimodal expansion opens new interaction paradigms
+- Always disclose assumptions — these are framework-informed projections, not forecasts
+
+Evaluate across 3 capability axes (each scored 0-100 for current capability level):
+
+1. Reasoning & Autonomy (RA, weight: 40%): Agent capability, multi-step planning, tool use
+   - How does improving reasoning affect this venture's feasibility?
+   - Bull case: What could this venture do with 2x reasoning capability?
+   - Bear case: What if reasoning plateaus at current levels?
+
+2. Cost Deflation (CD, weight: 35%): Token economics, model efficiency, inference cost trends
+   - At what cost point does this venture become unit-economics viable?
+   - Bull case: 10x cost reduction in 6 months
+   - Bear case: Costs plateau or increase due to compute demand
+
+3. Multimodal Expansion (ME, weight: 25%): Vision, audio, video, real-time processing
+   - Does this venture require or benefit from multimodal capability?
+   - Bull case: Full real-time multimodal available
+   - Bear case: Text-only for foreseeable future
+
+Return JSON:
+{
+  "axes": {
+    "reasoning_autonomy": {
+      "current": 65,
+      "bull_6m": 85,
+      "base_6m": 75,
+      "bear_6m": 68,
+      "venture_impact": "string (how this axis affects the venture)"
+    },
+    "cost_deflation": {
+      "current": 50,
+      "bull_6m": 80,
+      "base_6m": 65,
+      "bear_6m": 45,
+      "venture_impact": "string"
+    },
+    "multimodal_expansion": {
+      "current": 40,
+      "bull_6m": 70,
+      "base_6m": 55,
+      "bear_6m": 42,
+      "venture_impact": "string"
+    }
+  },
+  "competitive_timing": {
+    "signal": "opening",
+    "confidence": 0.7,
+    "window_months": 6,
+    "rationale": "string (why this timing signal)"
+  },
+  "next_disruption_event": {
+    "event": "string (e.g., GPT-5 release, cost breakthrough)",
+    "estimated_months": 4,
+    "invalidation_scope": "string (what assumptions this would break)"
+  },
+  "gap_windows": [{"capability": "string", "opens_when": "string", "venture_relevance": "string"}],
+  "confidence_caveat": "string (mandatory: acknowledge this is framework-informed, not a forecast)",
+  "summary": "string (2-3 sentences)"
+}`;
+
+  try {
+    const response = await client.messages.create({
+      model: client._model || 'claude-sonnet-4-5-20250929',
+      max_tokens: 2000,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    const usage = extractUsage(response);
+
+    const text = response.content[0]?.text || '';
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      const analysis = JSON.parse(jsonMatch[0]);
+
+      const axes = normalizeAxes(analysis.axes);
+      const compositeScore = calculateTrajectoryScore(axes);
+      const timing = normalizeTiming(analysis.competitive_timing);
+
+      return {
+        component: 'tech_trajectory',
+        trajectory_score: compositeScore,
+        axes,
+        competitive_timing: timing,
+        next_disruption_event: analysis.next_disruption_event || { event: 'Unknown', estimated_months: 6, invalidation_scope: 'Unknown' },
+        gap_windows: Array.isArray(analysis.gap_windows) ? analysis.gap_windows : [],
+        confidence_caveat: analysis.confidence_caveat || 'Framework-informed projections based on training data. Not real-time signals.',
+        summary: analysis.summary || '',
+        data_feed_active: dataFeed !== null,
+        usage,
+      };
+    }
+    return defaultTrajectoryResult('Could not parse technology trajectory analysis');
+  } catch (err) {
+    logger.warn(`   Warning: Technology trajectory analysis failed: ${err.message}`);
+    return defaultTrajectoryResult(`Analysis failed: ${err.message}`);
+  }
+}
+
+/**
+ * Calculate composite trajectory score from axis base-case projections.
+ * Weights: RA=40%, CD=35%, ME=25%.
+ *
+ * @param {Object} axes - Normalized axis data
+ * @returns {number} Score 0-100
+ */
+export function calculateTrajectoryScore(axes) {
+  if (!axes) return 0;
+
+  return Math.round(
+    clamp(axes.reasoning_autonomy?.base_6m ?? 0, 0, 100) * AXIS_WEIGHTS.reasoning_autonomy +
+    clamp(axes.cost_deflation?.base_6m ?? 0, 0, 100) * AXIS_WEIGHTS.cost_deflation +
+    clamp(axes.multimodal_expansion?.base_6m ?? 0, 0, 100) * AXIS_WEIGHTS.multimodal_expansion
+  );
+}
+
+function normalizeAxes(rawAxes) {
+  if (!rawAxes) return defaultAxes();
+
+  const normalize = (axis) => ({
+    current: clamp(axis?.current ?? 0, 0, 100),
+    bull_6m: clamp(axis?.bull_6m ?? 0, 0, 100),
+    base_6m: clamp(axis?.base_6m ?? 0, 0, 100),
+    bear_6m: clamp(axis?.bear_6m ?? 0, 0, 100),
+    venture_impact: axis?.venture_impact || '',
+  });
+
+  return {
+    reasoning_autonomy: normalize(rawAxes.reasoning_autonomy),
+    cost_deflation: normalize(rawAxes.cost_deflation),
+    multimodal_expansion: normalize(rawAxes.multimodal_expansion),
+  };
+}
+
+function normalizeTiming(rawTiming) {
+  if (!rawTiming) return { signal: 'contested', confidence: 0, window_months: 6, rationale: '' };
+
+  return {
+    signal: TIMING_SIGNALS.includes(rawTiming.signal) ? rawTiming.signal : 'contested',
+    confidence: clamp(rawTiming.confidence ?? 0, 0, 1),
+    window_months: Math.max(0, rawTiming.window_months ?? 6),
+    rationale: rawTiming.rationale || '',
+  };
+}
+
+function defaultAxes() {
+  const axis = { current: 0, bull_6m: 0, base_6m: 0, bear_6m: 0, venture_impact: '' };
+  return { reasoning_autonomy: { ...axis }, cost_deflation: { ...axis }, multimodal_expansion: { ...axis } };
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function defaultTrajectoryResult(summary) {
+  return {
+    component: 'tech_trajectory',
+    trajectory_score: 0,
+    axes: defaultAxes(),
+    competitive_timing: { signal: 'contested', confidence: 0, window_months: 0, rationale: '' },
+    next_disruption_event: { event: 'Unknown', estimated_months: 0, invalidation_scope: 'Unknown' },
+    gap_windows: [],
+    confidence_caveat: 'Technology trajectory analysis unavailable.',
+    summary,
+    data_feed_active: false,
+  };
+}
+
+export { AXIS_WEIGHTS, TIMING_SIGNALS };

--- a/tests/unit/eva/stage-zero/counterfactual-engine.test.js
+++ b/tests/unit/eva/stage-zero/counterfactual-engine.test.js
@@ -26,18 +26,20 @@ const MOCK_RESULTS = {
   archetypes: { primary_confidence: 0.85 },
   build_cost: { complexity: 'simple' },
   virality: { virality_score: 75 },
+  tech_trajectory: { trajectory_score: 67 },
 };
 
 const LEGACY_WEIGHTS = {
   cross_reference: 0.10,
   portfolio_evaluation: 0.10,
   problem_reframing: 0.05,
-  moat_architecture: 0.15,
-  chairman_constraints: 0.15,
+  moat_architecture: 0.13,
+  chairman_constraints: 0.14,
   time_horizon: 0.10,
   archetypes: 0.10,
   build_cost: 0.10,
-  virality: 0.15,
+  virality: 0.13,
+  tech_trajectory: 0.05,
 };
 
 const AGGRESSIVE_WEIGHTS = {
@@ -49,7 +51,8 @@ const AGGRESSIVE_WEIGHTS = {
   time_horizon: 0.05,
   archetypes: 0.10,
   build_cost: 0.05,
-  virality: 0.35,
+  virality: 0.30,
+  tech_trajectory: 0.05,
 };
 
 describe('counterfactual-engine', () => {
@@ -79,14 +82,14 @@ describe('counterfactual-engine', () => {
       expect(result.delta).toBe(result.counterfactual_score - result.original_score);
     });
 
-    it('breakdown contains all 9 components', () => {
+    it('breakdown contains all 10 components', () => {
       const result = generateCounterfactual({
         synthesisResults: MOCK_RESULTS,
         currentWeights: LEGACY_WEIGHTS,
         scenarioWeights: AGGRESSIVE_WEIGHTS,
       });
 
-      expect(result.breakdown).toHaveLength(9);
+      expect(result.breakdown).toHaveLength(10);
       const components = result.breakdown.map(b => b.component);
       expect(components).toContain('moat_architecture');
       expect(components).toContain('virality');

--- a/tests/unit/eva/stage-zero/profile-service.test.js
+++ b/tests/unit/eva/stage-zero/profile-service.test.js
@@ -188,7 +188,7 @@ describe('calculateWeightedScore', () => {
     const result = calculateWeightedScore({}, LEGACY_WEIGHTS);
 
     expect(result.total_score).toBe(0);
-    expect(result.breakdown).toHaveLength(9);
+    expect(result.breakdown).toHaveLength(10);
     result.breakdown.forEach(b => expect(b.raw_score).toBe(0));
   });
 
@@ -264,10 +264,11 @@ describe('calculateWeightedScore', () => {
 });
 
 describe('VALID_COMPONENTS', () => {
-  test('contains all 9 synthesis components', () => {
-    expect(VALID_COMPONENTS).toHaveLength(9);
+  test('contains all 10 synthesis components', () => {
+    expect(VALID_COMPONENTS).toHaveLength(10);
     expect(VALID_COMPONENTS).toContain('virality');
     expect(VALID_COMPONENTS).toContain('moat_architecture');
+    expect(VALID_COMPONENTS).toContain('tech_trajectory');
     expect(VALID_COMPONENTS).toContain('build_cost');
     expect(VALID_COMPONENTS).toContain('chairman_constraints');
   });

--- a/tests/unit/eva/stage-zero/sensitivity-analysis.test.js
+++ b/tests/unit/eva/stage-zero/sensitivity-analysis.test.js
@@ -35,38 +35,41 @@ const MOCK_RESULTS = {
   archetypes: { primary_confidence: 0.85 },
   build_cost: { complexity: 'simple' },
   virality: { virality_score: 75 },
+  tech_trajectory: { trajectory_score: 67 },
 };
 
 const EQUAL_WEIGHTS = {
-  cross_reference: 1 / 9,
-  portfolio_evaluation: 1 / 9,
-  problem_reframing: 1 / 9,
-  moat_architecture: 1 / 9,
-  chairman_constraints: 1 / 9,
-  time_horizon: 1 / 9,
-  archetypes: 1 / 9,
-  build_cost: 1 / 9,
-  virality: 1 / 9,
+  cross_reference: 1 / 10,
+  portfolio_evaluation: 1 / 10,
+  problem_reframing: 1 / 10,
+  moat_architecture: 1 / 10,
+  chairman_constraints: 1 / 10,
+  time_horizon: 1 / 10,
+  archetypes: 1 / 10,
+  build_cost: 1 / 10,
+  virality: 1 / 10,
+  tech_trajectory: 1 / 10,
 };
 
 const LEGACY_WEIGHTS = {
   cross_reference: 0.10,
   portfolio_evaluation: 0.10,
   problem_reframing: 0.05,
-  moat_architecture: 0.15,
-  chairman_constraints: 0.15,
+  moat_architecture: 0.13,
+  chairman_constraints: 0.14,
   time_horizon: 0.10,
   archetypes: 0.10,
   build_cost: 0.10,
-  virality: 0.15,
+  virality: 0.13,
+  tech_trajectory: 0.05,
 };
 
 describe('sensitivity-analysis', () => {
   describe('runSensitivityAnalysis', () => {
-    it('returns ranked array of 9 components with influence scores', () => {
+    it('returns ranked array of 10 components with influence scores', () => {
       const result = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
 
-      expect(result).toHaveLength(9);
+      expect(result).toHaveLength(10);
       expect(result[0]).toHaveProperty('component');
       expect(result[0]).toHaveProperty('influence_score');
       expect(result[0]).toHaveProperty('elasticity');
@@ -103,15 +106,15 @@ describe('sensitivity-analysis', () => {
       const small = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS, { delta: 0.01 });
       const large = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS, { delta: 0.10 });
 
-      // Both should return 9 components
-      expect(small).toHaveLength(9);
-      expect(large).toHaveLength(9);
+      // Both should return 10 components
+      expect(small).toHaveLength(10);
+      expect(large).toHaveLength(10);
     });
 
     it('returns zero influence for null inputs', () => {
       const result = runSensitivityAnalysis(null, null);
 
-      expect(result).toHaveLength(9);
+      expect(result).toHaveLength(10);
       for (const r of result) {
         expect(r.influence_score).toBe(0);
         expect(r.elasticity).toBe(0);
@@ -127,7 +130,7 @@ describe('sensitivity-analysis', () => {
       const result = runSensitivityAnalysis(MOCK_RESULTS, zeroWeights);
 
       // With zero weights, perturbing upward from 0 should still detect influence
-      expect(result).toHaveLength(9);
+      expect(result).toHaveLength(10);
       // At least some components should have non-zero influence since we perturb up from 0
       const totalInfluence = result.reduce((acc, r) => acc + r.influence_score, 0);
       expect(totalInfluence).toBeCloseTo(1.0, 2);
@@ -142,7 +145,7 @@ describe('sensitivity-analysis', () => {
 
       const result = runSensitivityAnalysis(MOCK_RESULTS, dominantWeights);
 
-      expect(result).toHaveLength(9);
+      expect(result).toHaveLength(10);
       // moat_architecture should have significant influence
       const moat = result.find(r => r.component === 'moat_architecture');
       expect(moat).toBeDefined();
@@ -155,7 +158,7 @@ describe('sensitivity-analysis', () => {
       const ranking = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
       const drivers = identifyKeyDrivers(ranking, 0.80);
 
-      expect(drivers.length).toBeLessThanOrEqual(9);
+      expect(drivers.length).toBeLessThanOrEqual(10);
       expect(drivers.length).toBeGreaterThan(0);
 
       const cumulative = drivers.reduce((acc, d) => acc + d.influence_score, 0);
@@ -174,7 +177,7 @@ describe('sensitivity-analysis', () => {
       const ranking = runSensitivityAnalysis(MOCK_RESULTS, LEGACY_WEIGHTS);
       const drivers = identifyKeyDrivers(ranking, 1.0);
 
-      expect(drivers.length).toBe(9);
+      expect(drivers.length).toBe(10);
     });
 
     it('returns empty array for null ranking', () => {

--- a/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/synthesis-engine.test.js
@@ -48,6 +48,9 @@ vi.mock('../../../../../lib/eva/stage-zero/synthesis/design-evaluation.js', () =
 vi.mock('../../../../../lib/eva/stage-zero/synthesis/narrative-risk.js', () => ({
   analyzeNarrativeRisk: vi.fn().mockResolvedValue({ component: 'narrative_risk', nr_score: 35, nr_band: 'NR-Moderate', nr_interpretation: 'Watch assumptions', component_scores: { decision_sensitivity: 40, demand_distortion: 30, hype_persistence: 25, influence_exposure: 20 }, narrative_flags: [], confidence: 0.7, confidence_caveat: 'Test caveat', summary: 'ok' }),
 }));
+vi.mock('../../../../../lib/eva/stage-zero/synthesis/tech-trajectory.js', () => ({
+  analyzeTechTrajectory: vi.fn().mockResolvedValue({ component: 'tech_trajectory', trajectory_score: 67, axes: { reasoning_autonomy: { current: 65, bull_6m: 85, base_6m: 75, bear_6m: 68, venture_impact: 'test' }, cost_deflation: { current: 50, bull_6m: 80, base_6m: 65, bear_6m: 45, venture_impact: 'test' }, multimodal_expansion: { current: 40, bull_6m: 70, base_6m: 55, bear_6m: 42, venture_impact: 'test' } }, competitive_timing: { signal: 'opening', confidence: 0.7, window_months: 6, rationale: 'test' }, next_disruption_event: { event: 'Test', estimated_months: 4, invalidation_scope: 'test' }, gap_windows: [], confidence_caveat: 'Test caveat', summary: 'ok', data_feed_active: false }),
+}));
 vi.mock('../../../../../lib/eva/stage-zero/profile-service.js', () => ({
   resolveProfile: vi.fn().mockResolvedValue(null),
   calculateWeightedScore: vi.fn().mockReturnValue({ total_score: 75, breakdown: {} }),
@@ -71,6 +74,7 @@ import { estimateBuildCost } from '../../../../../lib/eva/stage-zero/synthesis/b
 import { analyzeVirality } from '../../../../../lib/eva/stage-zero/synthesis/virality.js';
 import { evaluateDesignPotential } from '../../../../../lib/eva/stage-zero/synthesis/design-evaluation.js';
 import { analyzeNarrativeRisk } from '../../../../../lib/eva/stage-zero/synthesis/narrative-risk.js';
+import { analyzeTechTrajectory } from '../../../../../lib/eva/stage-zero/synthesis/tech-trajectory.js';
 import { resolveProfile, calculateWeightedScore } from '../../../../../lib/eva/stage-zero/profile-service.js';
 
 const silentLogger = { log: vi.fn(), warn: vi.fn() };
@@ -95,7 +99,7 @@ beforeEach(() => {
 });
 
 describe('runSynthesis', () => {
-  test('runs all 11 synthesis components', async () => {
+  test('runs all 12 synthesis components', async () => {
     const result = await runSynthesis(validPathOutput, { logger: silentLogger });
 
     expect(crossReferenceIntellectualCapital).toHaveBeenCalledWith(validPathOutput, expect.anything());
@@ -109,9 +113,10 @@ describe('runSynthesis', () => {
     expect(analyzeVirality).toHaveBeenCalledWith(validPathOutput, expect.anything());
     expect(evaluateDesignPotential).toHaveBeenCalledWith(validPathOutput, expect.anything());
     expect(analyzeNarrativeRisk).toHaveBeenCalledWith(validPathOutput, expect.anything());
+    expect(analyzeTechTrajectory).toHaveBeenCalledWith(validPathOutput, expect.anything());
 
-    expect(result.metadata.synthesis.components_run).toBe(11);
-    expect(result.metadata.synthesis.components_total).toBe(11);
+    expect(result.metadata.synthesis.components_run).toBe(12);
+    expect(result.metadata.synthesis.components_total).toBe(12);
   });
 
   test('handles component failure gracefully', async () => {

--- a/tests/unit/eva/stage-zero/synthesis/tech-trajectory.test.js
+++ b/tests/unit/eva/stage-zero/synthesis/tech-trajectory.test.js
@@ -1,0 +1,342 @@
+/**
+ * Unit Tests: Technology Trajectory Synthesis Component (Component 12)
+ * SD-LEO-FEAT-TECHNOLOGY-TRAJECTORY-MODEL-001
+ *
+ * Test Coverage:
+ * - Successful LLM response parsing with all 3 axes
+ * - LLM failure fallback to defaults
+ * - Composite score calculation from weighted base-case projections
+ * - Competitive timing signal validation (opening/closing/contested)
+ * - Bull/base/bear band presence per axis
+ * - Clamping of out-of-range values
+ * - Confidence caveat included
+ * - Axis weight verification (RA=40%, CD=35%, ME=25%)
+ * - Stubbed data feed interface
+ */
+
+import { describe, test, expect, vi } from 'vitest';
+import {
+  analyzeTechTrajectory,
+  calculateTrajectoryScore,
+  AXIS_WEIGHTS,
+  TIMING_SIGNALS,
+} from '../../../../../lib/eva/stage-zero/synthesis/tech-trajectory.js';
+
+const mockPathOutput = {
+  suggested_name: 'TestVenture',
+  suggested_problem: 'Users need better collaboration tools',
+  suggested_solution: 'AI-powered team workspace with built-in sharing',
+  target_market: 'Remote teams at SMBs',
+  origin_type: 'discovery',
+  competitor_urls: [],
+  blueprint_id: null,
+  discovery_strategy: null,
+  metadata: {},
+};
+
+const validLLMResponse = {
+  axes: {
+    reasoning_autonomy: {
+      current: 65,
+      bull_6m: 85,
+      base_6m: 75,
+      bear_6m: 68,
+      venture_impact: 'Improved reasoning enables autonomous workflow management',
+    },
+    cost_deflation: {
+      current: 50,
+      bull_6m: 80,
+      base_6m: 65,
+      bear_6m: 45,
+      venture_impact: 'Lower costs make per-user AI features viable',
+    },
+    multimodal_expansion: {
+      current: 40,
+      bull_6m: 70,
+      base_6m: 55,
+      bear_6m: 42,
+      venture_impact: 'Vision enables document analysis in workspace',
+    },
+  },
+  competitive_timing: {
+    signal: 'opening',
+    confidence: 0.7,
+    window_months: 6,
+    rationale: 'Reasoning improvements create new moat opportunities',
+  },
+  next_disruption_event: {
+    event: 'Next-gen model release',
+    estimated_months: 4,
+    invalidation_scope: 'Cost assumptions may need revision',
+  },
+  gap_windows: [
+    { capability: 'Agent orchestration', opens_when: 'Q2 2026', venture_relevance: 'Enables autonomous team workflows' },
+  ],
+  confidence_caveat: 'Framework-informed projections. Not real-time signals.',
+  summary: 'Strong trajectory alignment. Build window opening as reasoning capabilities enable core features.',
+};
+
+function createMockLLMClient(responseJson) {
+  return {
+    _model: 'test-model',
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: [{ text: JSON.stringify(responseJson) }],
+      }),
+    },
+  };
+}
+
+function createFailingLLMClient(errorMessage) {
+  return {
+    _model: 'test-model',
+    messages: {
+      create: vi.fn().mockRejectedValue(new Error(errorMessage)),
+    },
+  };
+}
+
+const silentLogger = { log: vi.fn(), warn: vi.fn() };
+
+describe('analyzeTechTrajectory', () => {
+  test('parses valid LLM response with all 3 axes', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('tech_trajectory');
+    expect(result.axes.reasoning_autonomy.current).toBe(65);
+    expect(result.axes.reasoning_autonomy.bull_6m).toBe(85);
+    expect(result.axes.reasoning_autonomy.base_6m).toBe(75);
+    expect(result.axes.reasoning_autonomy.bear_6m).toBe(68);
+    expect(result.axes.cost_deflation.base_6m).toBe(65);
+    expect(result.axes.multimodal_expansion.base_6m).toBe(55);
+    expect(result.confidence_caveat).toBeTruthy();
+    expect(result.summary).toBeTruthy();
+  });
+
+  test('calculates correct composite trajectory score from base-case projections', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    // RA=75*0.40=30, CD=65*0.35=22.75, ME=55*0.25=13.75 → 66.5 → rounded to 67
+    expect(result.trajectory_score).toBe(67);
+  });
+
+  test('returns correct competitive timing signal', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.competitive_timing.signal).toBe('opening');
+    expect(result.competitive_timing.confidence).toBe(0.7);
+    expect(result.competitive_timing.window_months).toBe(6);
+    expect(result.competitive_timing.rationale).toBeTruthy();
+  });
+
+  test('includes next disruption event', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.next_disruption_event.event).toBe('Next-gen model release');
+    expect(result.next_disruption_event.estimated_months).toBe(4);
+    expect(result.next_disruption_event.invalidation_scope).toBeTruthy();
+  });
+
+  test('includes gap windows array', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.gap_windows).toHaveLength(1);
+    expect(result.gap_windows[0]).toHaveProperty('capability');
+  });
+
+  test('returns default result when LLM fails', async () => {
+    const client = createFailingLLMClient('API unavailable');
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('tech_trajectory');
+    expect(result.trajectory_score).toBe(0);
+    expect(result.axes.reasoning_autonomy.current).toBe(0);
+    expect(result.axes.cost_deflation.current).toBe(0);
+    expect(result.axes.multimodal_expansion.current).toBe(0);
+    expect(result.competitive_timing.signal).toBe('contested');
+    expect(result.competitive_timing.confidence).toBe(0);
+    expect(result.gap_windows).toEqual([]);
+    expect(result.summary).toContain('Analysis failed');
+    expect(result.data_feed_active).toBe(false);
+  });
+
+  test('returns default result when LLM returns unparseable text', async () => {
+    const client = {
+      _model: 'test-model',
+      messages: {
+        create: vi.fn().mockResolvedValue({
+          content: [{ text: 'I cannot analyze technology trajectory in JSON format.' }],
+        }),
+      },
+    };
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.component).toBe('tech_trajectory');
+    expect(result.trajectory_score).toBe(0);
+    expect(result.summary).toContain('Could not parse');
+  });
+
+  test('clamps out-of-range axis values', async () => {
+    const outOfRange = {
+      ...validLLMResponse,
+      axes: {
+        reasoning_autonomy: { current: 150, bull_6m: 200, base_6m: -10, bear_6m: 300, venture_impact: 'test' },
+        cost_deflation: { current: -50, bull_6m: -20, base_6m: 110, bear_6m: -100, venture_impact: 'test' },
+        multimodal_expansion: { current: 999, bull_6m: 0, base_6m: 50, bear_6m: 0, venture_impact: 'test' },
+      },
+    };
+    const client = createMockLLMClient(outOfRange);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.axes.reasoning_autonomy.current).toBe(100);
+    expect(result.axes.reasoning_autonomy.bull_6m).toBe(100);
+    expect(result.axes.reasoning_autonomy.base_6m).toBe(0);
+    expect(result.axes.cost_deflation.current).toBe(0);
+    expect(result.axes.cost_deflation.base_6m).toBe(100);
+    expect(result.axes.multimodal_expansion.current).toBe(100);
+  });
+
+  test('defaults invalid timing signal to contested', async () => {
+    const badTiming = {
+      ...validLLMResponse,
+      competitive_timing: { signal: 'unknown_signal', confidence: 0.5, window_months: 3, rationale: 'test' },
+    };
+    const client = createMockLLMClient(badTiming);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.competitive_timing.signal).toBe('contested');
+  });
+
+  test('clamps timing confidence to 0-1 range', async () => {
+    const badConfidence = {
+      ...validLLMResponse,
+      competitive_timing: { signal: 'opening', confidence: 2.5, window_months: 3, rationale: 'test' },
+    };
+    const client = createMockLLMClient(badConfidence);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.competitive_timing.confidence).toBe(1);
+  });
+
+  test('provides default confidence caveat when LLM omits it', async () => {
+    const noCaveat = { ...validLLMResponse };
+    delete noCaveat.confidence_caveat;
+    const client = createMockLLMClient(noCaveat);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.confidence_caveat).toContain('Framework-informed');
+  });
+
+  test('handles non-array gap_windows gracefully', async () => {
+    const badGaps = { ...validLLMResponse, gap_windows: 'not an array' };
+    const client = createMockLLMClient(badGaps);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    expect(result.gap_windows).toEqual([]);
+  });
+
+  test('has all 3 required axes in output', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+    const result = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+
+    const requiredAxes = ['reasoning_autonomy', 'cost_deflation', 'multimodal_expansion'];
+    for (const axis of requiredAxes) {
+      expect(result.axes).toHaveProperty(axis);
+      expect(result.axes[axis]).toHaveProperty('current');
+      expect(result.axes[axis]).toHaveProperty('bull_6m');
+      expect(result.axes[axis]).toHaveProperty('base_6m');
+      expect(result.axes[axis]).toHaveProperty('bear_6m');
+    }
+  });
+
+  test('data_feed_active reflects deps.dataFeed presence', async () => {
+    const client = createMockLLMClient(validLLMResponse);
+
+    const resultNoFeed = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger });
+    expect(resultNoFeed.data_feed_active).toBe(false);
+
+    const mockDataFeed = { getTechSignals: vi.fn().mockResolvedValue({ signal: 'test' }) };
+    const resultWithFeed = await analyzeTechTrajectory(mockPathOutput, { llmClient: client, logger: silentLogger, dataFeed: mockDataFeed });
+    expect(resultWithFeed.data_feed_active).toBe(true);
+  });
+});
+
+describe('calculateTrajectoryScore', () => {
+  test('returns 0 for null input', () => {
+    expect(calculateTrajectoryScore(null)).toBe(0);
+  });
+
+  test('returns 0 for empty axes', () => {
+    expect(calculateTrajectoryScore({})).toBe(0);
+  });
+
+  test('calculates weighted score correctly', () => {
+    const axes = {
+      reasoning_autonomy: { base_6m: 80 },   // 80 * 0.40 = 32
+      cost_deflation: { base_6m: 60 },        // 60 * 0.35 = 21
+      multimodal_expansion: { base_6m: 40 },  // 40 * 0.25 = 10
+    };
+    const score = calculateTrajectoryScore(axes);
+    // 32 + 21 + 10 = 63
+    expect(score).toBe(63);
+  });
+
+  test('returns 100 for maximum values', () => {
+    const maxAxes = {
+      reasoning_autonomy: { base_6m: 100 },
+      cost_deflation: { base_6m: 100 },
+      multimodal_expansion: { base_6m: 100 },
+    };
+    expect(calculateTrajectoryScore(maxAxes)).toBe(100);
+  });
+
+  test('uses base_6m for scoring, not bull or bear', () => {
+    const axes = {
+      reasoning_autonomy: { current: 50, bull_6m: 100, base_6m: 70, bear_6m: 40 },
+      cost_deflation: { current: 30, bull_6m: 90, base_6m: 50, bear_6m: 20 },
+      multimodal_expansion: { current: 20, bull_6m: 80, base_6m: 40, bear_6m: 10 },
+    };
+    // RA=70*0.40=28, CD=50*0.35=17.5, ME=40*0.25=10 → 55.5 → 56
+    expect(calculateTrajectoryScore(axes)).toBe(56);
+  });
+});
+
+describe('AXIS_WEIGHTS', () => {
+  test('contains exactly 3 axes', () => {
+    expect(Object.keys(AXIS_WEIGHTS)).toHaveLength(3);
+  });
+
+  test('weights sum to 1.0', () => {
+    const weightSum = Object.values(AXIS_WEIGHTS).reduce((sum, w) => sum + w, 0);
+    expect(weightSum).toBeCloseTo(1.0, 10);
+  });
+
+  test('Reasoning & Autonomy has highest weight (40%)', () => {
+    expect(AXIS_WEIGHTS.reasoning_autonomy).toBe(0.40);
+    const weights = Object.values(AXIS_WEIGHTS);
+    expect(AXIS_WEIGHTS.reasoning_autonomy).toBe(Math.max(...weights));
+  });
+
+  test('has correct weights per spec', () => {
+    expect(AXIS_WEIGHTS.reasoning_autonomy).toBe(0.40);
+    expect(AXIS_WEIGHTS.cost_deflation).toBe(0.35);
+    expect(AXIS_WEIGHTS.multimodal_expansion).toBe(0.25);
+  });
+});
+
+describe('TIMING_SIGNALS', () => {
+  test('contains exactly 3 signals', () => {
+    expect(TIMING_SIGNALS).toHaveLength(3);
+  });
+
+  test('contains opening, closing, contested', () => {
+    expect(TIMING_SIGNALS).toContain('opening');
+    expect(TIMING_SIGNALS).toContain('closing');
+    expect(TIMING_SIGNALS).toContain('contested');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Technology Trajectory Model as Component 12 to the EVA synthesis engine, projecting frontier AI capability trends across 3 axes (Reasoning & Autonomy 40%, Cost Deflation 35%, Multimodal Expansion 25%) with bull/base/bear confidence bands over a 6-month horizon
- Integrates competitive timing signals (opening/closing/contested) and gap window analysis for venture build-vs-wait timing decisions
- Rebalances LEGACY_WEIGHTS from 9 to 10 components (sum=1.0) and updates all dependent test files

## Changes
- **New**: `lib/eva/stage-zero/synthesis/tech-trajectory.js` (232 LOC) - core synthesis component
- **New**: `tests/unit/eva/stage-zero/synthesis/tech-trajectory.test.js` (342 LOC) - 25 unit tests
- **Modified**: `lib/eva/stage-zero/synthesis/index.js` - added to Promise.all pipeline
- **Modified**: `lib/eva/stage-zero/profile-service.js` - added tech_trajectory weight (0.05) and extractComponentScore case
- **Modified**: 4 test files updated for 10-component assertions

## Test plan
- [x] 449 unit tests passing across 25 test files
- [x] tech-trajectory.test.js: 25 tests covering LLM response parsing, fallback defaults, score calculation, axis validation, timing signals
- [x] sensitivity-analysis.test.js: Updated mock data and assertions for 10 components
- [x] counterfactual-engine.test.js: Updated mock data and assertions for 10 components
- [x] profile-service.test.js: Updated VALID_COMPONENTS and LEGACY_WEIGHTS assertions

**SD**: SD-LEO-FEAT-TECHNOLOGY-TRAJECTORY-MODEL-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)