### PR TITLE
feat(SD-MAN-GEN-TITLE-REMEDIATE-SECURITY-001): remediate SECURITY DEFINER views and enable RLS

### DIFF
--- a/supabase/migrations/20260222_remediate_security_definer_views_and_rls.sql
+++ b/supabase/migrations/20260222_remediate_security_definer_views_and_rls.sql
@@ -1,0 +1,44 @@
+-- Migration: Remediate SECURITY DEFINER Views and Enable RLS on agent_skills
+-- SD: SD-MAN-GEN-TITLE-REMEDIATE-SECURITY-001
+-- Date: 2026-02-22
+--
+-- This migration addresses two security issues:
+-- 1. 11 views using SECURITY DEFINER (bypasses RLS) - switch to SECURITY INVOKER
+-- 2. agent_skills table missing RLS - enable RLS with service_role-only policy
+
+BEGIN;
+
+-- PHASE 1: Fix SECURITY DEFINER views
+-- These views currently bypass RLS because they run as the view creator's role.
+-- Setting security_invoker = on makes them respect the calling user's permissions.
+ALTER VIEW public.v_active_sessions SET (security_invoker = on);
+ALTER VIEW public.v_agent_departments SET (security_invoker = on);
+ALTER VIEW public.v_agent_effective_capabilities SET (security_invoker = on);
+ALTER VIEW public.v_chairman_escalation_events SET (security_invoker = on);
+ALTER VIEW public.v_chairman_pending_decisions SET (security_invoker = on);
+ALTER VIEW public.v_cross_venture_patterns SET (security_invoker = on);
+ALTER VIEW public.v_department_membership SET (security_invoker = on);
+ALTER VIEW public.v_eva_accuracy SET (security_invoker = on);
+ALTER VIEW public.v_flywheel_velocity SET (security_invoker = on);
+ALTER VIEW public.v_live_sessions SET (security_invoker = on);
+ALTER VIEW public.v_okr_hierarchy SET (security_invoker = on);
+
+-- PHASE 2: Enable RLS on agent_skills
+-- This table had no RLS policy, meaning any authenticated user could read/write.
+ALTER TABLE public.agent_skills ENABLE ROW LEVEL SECURITY;
+
+-- Create service_role-only access policy
+CREATE POLICY service_role_full_access
+  ON public.agent_skills
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- PHASE 3: Revoke excess grants
+-- Remove direct grants to anon and authenticated roles.
+-- Access should only be through service_role via the API.
+REVOKE ALL ON public.agent_skills FROM anon;
+REVOKE ALL ON public.agent_skills FROM authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260222_remediate_security_definer_views_and_rls_rollback.sql
+++ b/supabase/migrations/20260222_remediate_security_definer_views_and_rls_rollback.sql
@@ -1,0 +1,30 @@
+-- Rollback: Remediate SECURITY DEFINER Views and Enable RLS on agent_skills
+-- SD: SD-MAN-GEN-TITLE-REMEDIATE-SECURITY-001
+-- Date: 2026-02-22
+--
+-- Reverses all changes from the forward migration.
+
+BEGIN;
+
+-- PHASE 3 ROLLBACK: Restore grants to anon and authenticated
+GRANT SELECT ON public.agent_skills TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.agent_skills TO authenticated;
+
+-- PHASE 2 ROLLBACK: Remove RLS policy and disable RLS
+DROP POLICY IF EXISTS service_role_full_access ON public.agent_skills;
+ALTER TABLE public.agent_skills DISABLE ROW LEVEL SECURITY;
+
+-- PHASE 1 ROLLBACK: Revert views to SECURITY DEFINER (remove security_invoker)
+ALTER VIEW public.v_active_sessions RESET (security_invoker);
+ALTER VIEW public.v_agent_departments RESET (security_invoker);
+ALTER VIEW public.v_agent_effective_capabilities RESET (security_invoker);
+ALTER VIEW public.v_chairman_escalation_events RESET (security_invoker);
+ALTER VIEW public.v_chairman_pending_decisions RESET (security_invoker);
+ALTER VIEW public.v_cross_venture_patterns RESET (security_invoker);
+ALTER VIEW public.v_department_membership RESET (security_invoker);
+ALTER VIEW public.v_eva_accuracy RESET (security_invoker);
+ALTER VIEW public.v_flywheel_velocity RESET (security_invoker);
+ALTER VIEW public.v_live_sessions RESET (security_invoker);
+ALTER VIEW public.v_okr_hierarchy RESET (security_invoker);
+
+COMMIT;

--- a/tests/security/security-definer-remediation.test.js
+++ b/tests/security/security-definer-remediation.test.js
@@ -1,0 +1,148 @@
+/**
+ * Security Definer Remediation Tests
+ * SD: SD-MAN-GEN-TITLE-REMEDIATE-SECURITY-001
+ *
+ * Verifies:
+ * 1. All 11 views have security_invoker=on
+ * 2. agent_skills has RLS enabled
+ * 3. service_role_full_access policy exists
+ * 4. anon/authenticated grants revoked from agent_skills
+ * 5. service_role can still query remediated views
+ * 6. service_role can still query agent_skills
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const REMEDIATED_VIEWS = [
+  'v_active_sessions',
+  'v_agent_departments',
+  'v_agent_effective_capabilities',
+  'v_chairman_escalation_events',
+  'v_chairman_pending_decisions',
+  'v_cross_venture_patterns',
+  'v_department_membership',
+  'v_eva_accuracy',
+  'v_flywheel_velocity',
+  'v_live_sessions',
+  'v_okr_hierarchy',
+];
+
+/**
+ * Helper to execute raw SQL via exec_sql RPC or fallback
+ */
+async function execSql(sql) {
+  // Try exec_sql RPC first
+  const { data, error } = await supabase.rpc('exec_sql', { sql });
+  if (!error) return data;
+
+  // Fallback: try raw_query
+  const { data: d2, error: e2 } = await supabase.rpc('raw_query', { query_text: sql });
+  if (!e2) return d2;
+
+  throw new Error(`SQL execution failed: ${error.message} / ${e2.message}`);
+}
+
+describe('Security Definer Remediation', () => {
+  describe('Phase 1: View Security Invoker', () => {
+    it('should have zero public views without security_invoker=on', async () => {
+      const sql = `
+        SELECT viewname
+        FROM pg_views
+        WHERE schemaname = 'public'
+          AND viewname IN (${REMEDIATED_VIEWS.map(v => `'${v}'`).join(',')})
+          AND NOT EXISTS (
+            SELECT 1
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public'
+              AND c.relname = pg_views.viewname
+              AND c.relkind = 'v'
+              AND (c.reloptions IS NOT NULL AND 'security_invoker=on' = ANY(c.reloptions))
+          )
+      `;
+
+      const result = await execSql(sql);
+      const insecureViews = Array.isArray(result) ? result : [];
+      expect(insecureViews).toHaveLength(0);
+    });
+  });
+
+  describe('Phase 2: RLS on agent_skills', () => {
+    it('should have RLS enabled on agent_skills', async () => {
+      const sql = `
+        SELECT relrowsecurity
+        FROM pg_class
+        WHERE relname = 'agent_skills'
+          AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+      `;
+
+      const result = await execSql(sql);
+      const rows = Array.isArray(result) ? result : [result];
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows[0].relrowsecurity).toBe(true);
+    });
+
+    it('should have service_role_full_access policy on agent_skills', async () => {
+      const sql = `
+        SELECT polname
+        FROM pg_policy
+        WHERE polrelid = (
+          SELECT oid FROM pg_class
+          WHERE relname = 'agent_skills'
+            AND relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'public')
+        )
+        AND polname = 'service_role_full_access'
+      `;
+
+      const result = await execSql(sql);
+      const rows = Array.isArray(result) ? result : [result];
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows[0].polname).toBe('service_role_full_access');
+    });
+  });
+
+  describe('Phase 3: Grant Revocation', () => {
+    it('should have no anon or authenticated grants on agent_skills', async () => {
+      const sql = `
+        SELECT grantee, privilege_type
+        FROM information_schema.role_table_grants
+        WHERE table_schema = 'public'
+          AND table_name = 'agent_skills'
+          AND grantee IN ('anon', 'authenticated')
+      `;
+
+      const result = await execSql(sql);
+      const grants = Array.isArray(result) ? result : [];
+      expect(grants).toHaveLength(0);
+    });
+  });
+
+  describe('Functional Verification', () => {
+    it('should allow service_role to query all remediated views', async () => {
+      const errors = [];
+
+      for (const view of REMEDIATED_VIEWS) {
+        const { error } = await supabase.from(view).select('*').limit(1);
+        if (error) {
+          errors.push(`${view}: ${error.message}`);
+        }
+      }
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('should allow service_role to query agent_skills after RLS', async () => {
+      const { error } = await supabase.from('agent_skills').select('*').limit(1);
+      expect(error).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Set `security_invoker=on` on 11 public views that were bypassing RLS via SECURITY DEFINER mode
- Enable RLS on `agent_skills` table with `service_role_full_access` policy
- Revoke all grants from `anon` and `authenticated` roles on `agent_skills`
- Include rollback migration for safe reversion if needed

## Changes
- `supabase/migrations/20260222_remediate_security_definer_views_and_rls.sql` - Forward migration (3 phases)
- `supabase/migrations/20260222_remediate_security_definer_views_and_rls_rollback.sql` - Rollback migration
- `tests/security/security-definer-remediation.test.js` - 6 Vitest verification tests

## Test plan
- [x] Migration executed against production Supabase database
- [x] All 11 views verified to have `security_invoker=on` via `pg_class.reloptions`
- [x] `agent_skills.relrowsecurity` confirmed `true`
- [x] `service_role_full_access` policy verified in `pg_policy`
- [x] Zero grants for `anon`/`authenticated` confirmed in `information_schema.role_table_grants`
- [x] service_role can still query all 11 remediated views
- [x] service_role can still query `agent_skills` after RLS
- [x] 6/6 Vitest tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)