### PR TITLE
feat(agents): add Schema Hazards to 5 sub-agent prompts

### DIFF
--- a/.claude/agents/database-agent.partial
+++ b/.claude/agents/database-agent.partial
@@ -564,3 +564,62 @@ Your role is to eliminate these friction points by:
 2. **Executing safe operations immediately** (don't ask for permission to run existing migrations)
 3. Routing complex operations to orchestration scripts
 4. Asking for approval ONLY on destructive operations
+
+## Schema Hazards — SD Column Disambiguation
+
+> **Last verified**: 2026-02-22 | **Source**: `strategic_directives_v2`, `sd_phase_handoffs`, `product_requirements_v2`
+
+**Problem**: Three columns look similar (`id`, `sd_key`, `uuid_id`) but are used in different contexts. Using the wrong one causes FK violations or silent data mismatches.
+
+| Column | Type | Use For | Example |
+|--------|------|---------|---------|
+| `id` | UUID | Foreign key relationships (`sd_phase_handoffs.sd_id`, `parent_sd_id`) | `a05802ce-49ce-4bfe-...` |
+| `sd_key` | text | Human-readable queries, display, `product_requirements_v2.directive_id` | `SD-LEO-INFRA-001` |
+| `uuid_id` | UUID | Internal auto-generated, rarely referenced directly | (auto) |
+
+**WRONG** — Using `sd_key` where UUID `id` is expected:
+```sql
+-- ❌ sd_phase_handoffs.sd_id expects UUID, not text sd_key
+INSERT INTO sd_phase_handoffs (sd_id, ...) VALUES ('SD-LEO-INFRA-001', ...);
+-- Results in: invalid input syntax for type uuid
+```
+
+**RIGHT** — Resolve sd_key to UUID first, then use UUID for FK relationships:
+```sql
+-- ✅ Step 1: Get the UUID id from sd_key
+SELECT id FROM strategic_directives_v2 WHERE sd_key = 'SD-LEO-INFRA-001';
+-- ✅ Step 2: Use the UUID for relationships
+INSERT INTO sd_phase_handoffs (sd_id, ...) VALUES ('a05802ce-...', ...);
+```
+
+**Cross-table reference**:
+- `product_requirements_v2.directive_id` stores **sd_key** (text), NOT UUID
+- `product_requirements_v2.sd_id` stores **id** (UUID)
+- `sd_phase_handoffs.sd_id` stores **id** (UUID)
+
+## Schema Hazards — PRD Status Lifecycle
+
+> **Last verified**: 2026-02-22 | **Source**: `product_requirements_v2.status` column
+
+**Problem**: Different handoff types require different PRD statuses. Using the wrong status blocks the handoff gate.
+
+**Full lifecycle**: `draft` → `approved` → `in_progress` → `verification` → `completed`
+
+| Handoff | Required PRD Status | Gate |
+|---------|-------------------|------|
+| PLAN-TO-EXEC | `approved`, `ready_for_exec`, or `in_progress` | GATE_PRD_EXISTS |
+| PLAN-TO-LEAD | `verification` or `completed` | GATE_PRD_EXISTS |
+
+**WRONG** — Leaving PRD as `approved` when PLAN-TO-LEAD needs `verification`:
+```sql
+-- ❌ PLAN-TO-LEAD gate checks for status IN ('verification', 'completed')
+-- PRD with status='approved' will BLOCK the handoff
+```
+
+**RIGHT** — Set PRD status to match the target handoff:
+```sql
+-- ✅ Before PLAN-TO-LEAD: set to 'verification'
+UPDATE product_requirements_v2 SET status = 'verification' WHERE sd_id = '<uuid>';
+-- ✅ Before PLAN-TO-EXEC: ensure status is 'approved'
+UPDATE product_requirements_v2 SET status = 'approved' WHERE sd_id = '<uuid>';
+```

--- a/.claude/agents/orchestrator-child-agent.partial
+++ b/.claude/agents/orchestrator-child-agent.partial
@@ -48,3 +48,20 @@ For full Teams Protocol details, see the `Teams Protocol` section in CLAUDE.md.
 - If blocked by a dependency or error, report to team lead immediately via SendMessage
 - Do NOT modify files outside your worktree
 - Do NOT push to remote unless explicitly instructed
+
+## Schema Hazards — Common Child SD Pitfalls
+
+> **Last verified**: 2026-02-22
+
+### Gate Result Format
+Gate validators must return `{ passed, score, maxScore }`, NOT `{ valid, score }`.
+```js
+// ❌ WRONG: return { valid: true, score: 100 };        → normalizer defaults passed=false
+// ✅ RIGHT: return { passed: true, score: 100, maxScore: 100 };
+```
+**Source**: `scripts/modules/handoff/validation/gate-result-schema.js`
+
+### SD Column: id vs sd_key
+- `sd_phase_handoffs.sd_id` expects **UUID** (`id` column), not text `sd_key`
+- `product_requirements_v2.directive_id` expects **sd_key** (text), not UUID
+- Always resolve: `SELECT id FROM strategic_directives_v2 WHERE sd_key = '...'` before using in FK relationships

--- a/.claude/agents/retro-agent.partial
+++ b/.claude/agents/retro-agent.partial
@@ -563,3 +563,41 @@ You are an **Intelligent Trigger** for retrospective generation. The comprehensi
 > "I constantly have to remind that we should use the [sub-agent]. Oftentimes, instead of trying to resolve [the issue], it would try to do a workaround. Whereas what it should do initially is ensure that it's using the [sub-agent]."
 
 Your role is to eliminate the need for these reminders by invoking the retro agent proactively and refusing workaround requests.
+
+## Schema Hazards — Retrospective Column Names
+
+> **Last verified**: 2026-02-22 | **Source**: `retrospectives` table, `information_schema.columns`
+
+**Problem**: Column names are often hallucinated. The wrong names silently fail (Supabase returns empty results) or cause insert errors.
+
+**WRONG** — Using non-existent column names:
+```js
+// ❌ key_takeaways does NOT exist — column is key_learnings
+// ❌ what_went_wrong does NOT exist — column is what_needs_improvement
+await supabase.from('retrospectives').update({
+  key_takeaways: [...],       // silent no-op or error
+  what_went_wrong: '...'      // silent no-op or error
+});
+```
+
+**RIGHT** — Using correct column names with proper JSONB structure:
+```js
+await supabase.from('retrospectives').update({
+  key_learnings: ['Specific file/line reference', 'Behavioral insight'],
+  what_needs_improvement: 'Detailed analysis of friction area',
+  action_items: [{ action: '...', owner: '...', deadline: '...', verification: '...' }],
+  improvement_areas: [{ area: '...', analysis: '...', prevention: '...' }],
+  status: 'PUBLISHED'  // ✅ NOT 'completed' or 'draft'
+});
+```
+
+**Status constraint**: Only `PUBLISHED` is accepted by the quality gate. Using `completed` or `draft` will fail the RETROSPECTIVE_QUALITY_GATE.
+
+**Newest-row-wins**: The gate reads `ORDER BY created_at DESC LIMIT 1`. Each failed PLAN-TO-LEAD attempt auto-creates a NEW row with boilerplate. You must update the NEWEST row, not the original.
+
+```js
+// ✅ Always find newest row first, then update ALL rows for this SD
+const { data } = await supabase.from('retrospectives')
+  .select('id').eq('sd_id', sdUuid)
+  .order('created_at', { ascending: false });
+```

--- a/.claude/agents/testing-agent.partial
+++ b/.claude/agents/testing-agent.partial
@@ -319,3 +319,28 @@ This is the existing post-implementation testing behavior and remains unchanged 
 You are an **Intelligent Trigger** for the QA system. The comprehensive testing logic, test generation, and validation workflows live in the scripts—not in this prompt. Your value is in recognizing testing needs and routing them to the appropriate validation system.
 
 When in doubt: **Execute the full QA workflow** (`qa-engineering-director-enhanced.js --full-e2e`). Over-testing is better than under-testing.
+
+## Schema Hazards — User Story Key Format
+
+> **Last verified**: 2026-02-22 | **Source**: `user_stories` table, `valid_story_key` check constraint
+
+**Problem**: The `user_stories.story_key` column has a check constraint (`valid_story_key`) that enforces a specific format. Using the wrong format causes insert failures.
+
+**WRONG** — Using descriptive prefix format:
+```sql
+-- ❌ Violates valid_story_key constraint
+INSERT INTO user_stories (story_key, ...) VALUES ('US-LEARN019-001', ...);
+-- Error: new row violates check constraint "valid_story_key"
+```
+
+**RIGHT** — Using `NNN:US-NNN` or `TEXT-PREFIX:US-NNN` format:
+```sql
+-- ✅ Numeric prefix format
+INSERT INTO user_stories (story_key, ...) VALUES ('019:US-001', ...);
+-- ✅ Text prefix format (also valid)
+INSERT INTO user_stories (story_key, ...) VALUES ('ATTN-CAPITAL:US-001', ...);
+```
+
+**Priority constraint** (`user_stories_priority_check`): Must use `critical`, `high`, `medium`, or `low`. Do NOT use `must_have`, `should_have`, `nice_to_have`, or `P0/P1/P2`.
+
+**Related**: `implementation_context` column is required (check constraint `implementation_context_required`) — cannot be null or empty for `status='ready'` stories.

--- a/.claude/agents/validation-agent.partial
+++ b/.claude/agents/validation-agent.partial
@@ -471,3 +471,28 @@ You are an **Intelligent Trigger** for validation and duplicate detection. The c
 When in doubt: **Search before building**. Finding existing implementations saves 8-10 hours of duplicate work. Every SD should start with a validation pass to check for existing infrastructure.
 
 **MANDATORY GATES**: All 4 validation gates MUST be passed. Gates are not suggestions—they are BLOCKING enforcement points that prevent duplicate work, scope creep, and late-stage rework.
+
+## Schema Hazards — Gate Result Format
+
+> **Last verified**: 2026-02-22 | **Source**: `scripts/modules/handoff/validation/gate-result-schema.js`
+
+**Problem**: Gate validators return results that get normalized. If you use the wrong field names, the normalizer defaults `passed=false` and the gate shows as FAILED even though your logic passed.
+
+**WRONG** — Uses `valid` instead of `passed`, missing `maxScore`:
+```js
+return { valid: true, score: 100 };
+// ❌ normalizer sees no 'passed' field → defaults passed=false → GATE FAILED
+```
+
+**RIGHT** — Uses required schema fields `passed`, `score`, `maxScore`:
+```js
+return { passed: true, score: 100, maxScore: 100 };
+// ✅ matches GATE_RESULT_SCHEMA.required: ['passed', 'score', 'maxScore']
+```
+
+**Also valid** — With optional fields:
+```js
+return { passed: true, score: 80, maxScore: 100, warnings: ['Advisory only'], issues: [] };
+```
+
+**Related files**: `scripts/modules/handoff/validation/gate-result-schema.js` (lines 12-34)


### PR DESCRIPTION
## Summary
- Adds explicit WRONG/RIGHT schema examples to 5 highest-hallucination sub-agent prompt definitions (.partial files)
- **validation-agent**: Gate result format (`{passed, score, maxScore}` not `{valid, score}`)
- **database-agent**: SD column disambiguation (id vs sd_key vs uuid_id) + PRD status lifecycle per handoff
- **testing-agent**: User story key format (`NNN:US-NNN`) + priority/implementation_context constraints
- **retro-agent**: Retrospective column names (`key_learnings` not `key_takeaways`) + newest-row-wins behavior
- **orchestrator-child**: Cross-cutting gate result + column patterns

## Test plan
- [x] All 5 `.partial` files contain Schema Hazards sections
- [x] Agent compiler regenerates `.md` files successfully (17/17 compiled)
- [x] 15/15 smoke tests pass
- [x] No code changes — markdown-only prompt modifications

SD-LEO-INFRA-ADD-SCHEMA-EXAMPLES-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)