### PR TITLE
feat(SD-MAN-FEAT-CORRECTIVE-VISION-GAP-011): add EVA vision governance scripts

### DIFF
--- a/scripts/eva/capability-verifier.mjs
+++ b/scripts/eva/capability-verifier.mjs
@@ -1,0 +1,154 @@
+/**
+ * EVA Capability Verifier
+ * SD-MAN-FEAT-CORRECTIVE-VISION-GAP-011 / FR-003
+ *
+ * Dynamically imports EVA modules and verifies exported function signatures.
+ *
+ * Usage:
+ *   node scripts/eva/capability-verifier.mjs
+ *
+ * Output: JSON to stdout with capabilities and coverage percentage
+ * Exit: 0 if coverage >= 90%, 1 otherwise
+ */
+
+import { resolve } from 'path';
+import { existsSync } from 'fs';
+import { pathToFileURL } from 'url';
+
+const PROJECT_ROOT = process.cwd();
+
+/**
+ * Capabilities to verify — each defines a module path and expected exports
+ */
+const CAPABILITIES = [
+  {
+    name: 'validateSchemaShape',
+    module: 'lib/eva/contract-validator.js',
+    verification_method: 'typeof export === "function"',
+    export_name: 'validateSchemaShape'
+  },
+  {
+    name: 'validateContracts',
+    module: 'lib/eva/contract-validator.js',
+    verification_method: 'typeof export === "function"',
+    export_name: 'validateContracts'
+  },
+  {
+    name: 'extractOutputSchema',
+    module: 'lib/eva/stage-templates/output-schema-extractor.js',
+    verification_method: 'typeof export === "function"',
+    export_name: 'extractOutputSchema'
+  },
+  {
+    name: 'ensureOutputSchema',
+    module: 'lib/eva/stage-templates/output-schema-extractor.js',
+    verification_method: 'typeof export === "function"',
+    export_name: 'ensureOutputSchema'
+  }
+];
+
+// Add stage template checks (stages 1 through 25)
+for (let i = 1; i <= 25; i++) {
+  const num = String(i).padStart(2, '0');
+  CAPABILITIES.push({
+    name: `stage-${num}-outputSchema`,
+    module: `lib/eva/stage-templates/stage-${num}.js`,
+    verification_method: 'default.outputSchema is array with length > 0',
+    export_name: 'default',
+    check: 'outputSchema'
+  });
+}
+
+/**
+ * Verify a single capability
+ */
+async function verifyCapability(cap) {
+  const result = {
+    name: cap.name,
+    module: cap.module,
+    status: 'missing',
+    verification_method: cap.verification_method
+  };
+
+  const fullPath = resolve(PROJECT_ROOT, cap.module);
+
+  // Check file exists first
+  if (!existsSync(fullPath)) {
+    result.status = 'missing';
+    result.detail = 'Module file does not exist';
+    return result;
+  }
+
+  try {
+    const mod = await import(pathToFileURL(fullPath).href);
+
+    if (cap.check === 'outputSchema') {
+      // For stage templates, check default.outputSchema
+      const defaultExport = mod.default;
+      if (!defaultExport) {
+        result.status = 'error';
+        result.detail = 'No default export found';
+        return result;
+      }
+      if (Array.isArray(defaultExport.outputSchema) && defaultExport.outputSchema.length > 0) {
+        result.status = 'present';
+        result.detail = `outputSchema has ${defaultExport.outputSchema.length} fields`;
+      } else {
+        result.status = 'missing';
+        result.detail = 'outputSchema is empty or not an array';
+      }
+    } else {
+      // For named exports, check typeof
+      const exportValue = mod[cap.export_name];
+      if (typeof exportValue === 'function') {
+        result.status = 'present';
+        result.detail = `Export "${cap.export_name}" is a function`;
+      } else if (exportValue !== undefined) {
+        result.status = 'present';
+        result.detail = `Export "${cap.export_name}" exists (type: ${typeof exportValue})`;
+      } else {
+        result.status = 'missing';
+        result.detail = `Export "${cap.export_name}" not found`;
+      }
+    }
+  } catch (err) {
+    result.status = 'error';
+    result.detail = `Import error: ${err.message}`;
+  }
+
+  return result;
+}
+
+async function main() {
+  try {
+    const results = [];
+
+    for (const cap of CAPABILITIES) {
+      results.push(await verifyCapability(cap));
+    }
+
+    const total = results.length;
+    const present = results.filter(r => r.status === 'present').length;
+    const missing = results.filter(r => r.status === 'missing').length;
+    const errors = results.filter(r => r.status === 'error').length;
+    const coveragePercent = total > 0 ? Math.round((present / total) * 100) : 0;
+
+    console.log(JSON.stringify({
+      capabilities: results,
+      coverage_percent: coveragePercent,
+      total,
+      present,
+      missing,
+      errors,
+      verified_at: new Date().toISOString()
+    }, null, 2));
+
+    process.exit(coveragePercent >= 90 ? 0 : 1);
+
+  } catch (err) {
+    console.log(JSON.stringify({ error: true, message: err.message, exit_code: 1 }, null, 2));
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/eva/smoke-test-runner.mjs
+++ b/scripts/eva/smoke-test-runner.mjs
@@ -1,0 +1,219 @@
+/**
+ * EVA Smoke Test Runner
+ * SD-MAN-FEAT-CORRECTIVE-VISION-GAP-011 / FR-001
+ *
+ * Reads smoke_test_steps from strategic_directives_v2 for a specified SD
+ * and evaluates each step programmatically.
+ *
+ * Usage:
+ *   node scripts/eva/smoke-test-runner.mjs <sd-key-or-uuid>
+ *
+ * Output: JSON to stdout with step results and summary
+ * Exit: 0 if all pass, 1 if any fail or error
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+import { pathToFileURL } from 'url';
+
+dotenv.config();
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.log(JSON.stringify({ error: true, message: 'Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in environment', exit_code: 1 }, null, 2));
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+/**
+ * Evaluate a single smoke test step
+ */
+async function evaluateStep(step, stepIndex, sd) {
+  const result = {
+    step_number: step.step_number || stepIndex + 1,
+    instruction: step.instruction || step.step || 'No instruction',
+    expected_outcome: step.expected_outcome || step.expected || 'No expected outcome',
+    verdict: 'skip',
+    evidence: ''
+  };
+
+  try {
+    const instruction = (result.instruction || '').toLowerCase();
+    const expected = (result.expected_outcome || '').toLowerCase();
+
+    // File existence checks
+    if (instruction.includes('check') && instruction.includes('file') ||
+        instruction.includes('verify') && instruction.includes('exist') ||
+        instruction.includes('confirm') && instruction.includes('creat')) {
+      const filePatterns = instruction.match(/`([^`]+\.[a-z]{1,4})`/g) ||
+                          instruction.match(/(scripts\/[^\s,]+|lib\/[^\s,]+)/g);
+      if (filePatterns) {
+        const files = filePatterns.map(f => f.replace(/`/g, ''));
+        const checks = files.map(f => ({
+          file: f,
+          exists: existsSync(resolve(process.cwd(), f))
+        }));
+        const allExist = checks.every(c => c.exists);
+        result.verdict = allExist ? 'pass' : 'fail';
+        result.evidence = checks.map(c => `${c.file}: ${c.exists ? 'exists' : 'MISSING'}`).join('; ');
+        return result;
+      }
+    }
+
+    // Module export checks
+    if (instruction.includes('export') || instruction.includes('import') ||
+        instruction.includes('function') && instruction.includes('signature')) {
+      const modulePatterns = instruction.match(/`([^`]+\.[a-z]{1,4})`/g) ||
+                            instruction.match(/(lib\/[^\s,]+\.js)/g);
+      if (modulePatterns) {
+        const modPath = modulePatterns[0].replace(/`/g, '');
+        try {
+          const mod = await import(pathToFileURL(resolve(process.cwd(), modPath)).href);
+          const exports = Object.keys(mod).filter(k => k !== '__esModule');
+          result.verdict = exports.length > 0 ? 'pass' : 'fail';
+          result.evidence = `Module exports: ${exports.join(', ')}`;
+        } catch (e) {
+          result.verdict = 'fail';
+          result.evidence = `Import error: ${e.message}`;
+        }
+        return result;
+      }
+    }
+
+    // DB record checks
+    if (instruction.includes('query') || instruction.includes('database') ||
+        instruction.includes('record') || instruction.includes('table')) {
+      const tableMatch = instruction.match(/(?:from|table|in)\s+`?(\w+)`?/i);
+      if (tableMatch) {
+        const table = tableMatch[1];
+        const { count, error } = await supabase.from(table).select('*', { count: 'exact', head: true });
+        if (error) {
+          result.verdict = 'fail';
+          result.evidence = `DB error: ${error.message}`;
+        } else {
+          result.verdict = count > 0 ? 'pass' : 'fail';
+          result.evidence = `Table ${table}: ${count} records`;
+        }
+        return result;
+      }
+    }
+
+    // SD field checks
+    if (instruction.includes('success_criteria') || instruction.includes('key_changes') ||
+        instruction.includes('smoke_test_steps') || instruction.includes('success_metrics')) {
+      const fieldMatch = instruction.match(/(success_criteria|key_changes|smoke_test_steps|success_metrics|delivers_capabilities)/);
+      if (fieldMatch && sd) {
+        const field = fieldMatch[1];
+        const value = sd[field];
+        const hasValue = Array.isArray(value) ? value.length > 0 : !!value;
+        result.verdict = hasValue ? 'pass' : 'fail';
+        result.evidence = `SD.${field}: ${hasValue ? (Array.isArray(value) ? `${value.length} items` : 'present') : 'empty/missing'}`;
+        return result;
+      }
+    }
+
+    // Generic pass check based on expected outcome matching SD status
+    if (expected.includes('complete') || expected.includes('pass') || expected.includes('success')) {
+      if (sd && (sd.status === 'completed' || sd.progress >= 100)) {
+        result.verdict = 'pass';
+        result.evidence = `SD status: ${sd.status}, progress: ${sd.progress}%`;
+        return result;
+      }
+    }
+
+    // Could not evaluate programmatically
+    result.verdict = 'skip';
+    result.evidence = 'Step requires manual verification — cannot evaluate programmatically';
+
+  } catch (err) {
+    result.verdict = 'fail';
+    result.evidence = `Evaluation error: ${err.message}`;
+  }
+
+  return result;
+}
+
+async function main() {
+  const sdIdentifier = process.argv[2];
+  if (!sdIdentifier) {
+    console.log(JSON.stringify({ error: true, message: 'Usage: smoke-test-runner.mjs <sd-key-or-uuid>', exit_code: 1 }, null, 2));
+    process.exit(1);
+  }
+
+  try {
+    // Query SD by key or UUID
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sdIdentifier);
+    const query = supabase.from('strategic_directives_v2')
+      .select('id, sd_key, title, status, progress, smoke_test_steps, success_criteria, key_changes, success_metrics, delivers_capabilities');
+
+    const { data: sd, error } = isUuid
+      ? await query.eq('id', sdIdentifier).single()
+      : await query.eq('sd_key', sdIdentifier).single();
+
+    if (error || !sd) {
+      console.log(JSON.stringify({ error: true, message: `SD not found: ${sdIdentifier}`, exit_code: 1 }, null, 2));
+      process.exit(1);
+    }
+
+    const steps = sd.smoke_test_steps;
+    if (!Array.isArray(steps) || steps.length === 0) {
+      console.log(JSON.stringify({
+        sd_key: sd.sd_key,
+        steps: [],
+        summary: { total: 0, passed: 0, failed: 0, skipped: 0, passed_percent: 0 },
+        warning: 'No smoke_test_steps found for this SD'
+      }, null, 2));
+      process.exit(0);
+    }
+
+    // Evaluate each step
+    const results = [];
+    for (let i = 0; i < steps.length; i++) {
+      const step = steps[i];
+      if (!step || typeof step !== 'object') {
+        results.push({
+          step_number: i + 1,
+          instruction: 'Malformed step',
+          expected_outcome: '',
+          verdict: 'skip',
+          evidence: 'Step data is not a valid object'
+        });
+        continue;
+      }
+      results.push(await evaluateStep(step, i, sd));
+    }
+
+    const passed = results.filter(r => r.verdict === 'pass').length;
+    const failed = results.filter(r => r.verdict === 'fail').length;
+    const skipped = results.filter(r => r.verdict === 'skip').length;
+    const total = results.length;
+    const evaluable = total - skipped;
+    const passedPercent = evaluable > 0 ? Math.round((passed / evaluable) * 100) : 0;
+
+    const output = {
+      sd_key: sd.sd_key,
+      steps: results,
+      summary: {
+        total,
+        passed,
+        failed,
+        skipped,
+        passed_percent: passedPercent
+      }
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+    process.exit(failed > 0 ? 1 : 0);
+
+  } catch (err) {
+    console.log(JSON.stringify({ error: true, message: err.message, exit_code: 1 }, null, 2));
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/eva/success-metrics-collector.mjs
+++ b/scripts/eva/success-metrics-collector.mjs
@@ -1,0 +1,324 @@
+/**
+ * EVA Success Metrics Collector
+ * SD-MAN-FEAT-CORRECTIVE-VISION-GAP-011 / FR-002
+ *
+ * Queries the database for 6 quantifiable success metrics with
+ * baselines, targets, and trend directions.
+ *
+ * Usage:
+ *   node scripts/eva/success-metrics-collector.mjs
+ *
+ * Output: JSON to stdout with metrics array and overall health
+ * Exit: 0 on success, 1 on error
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.log(JSON.stringify({ error: true, message: 'Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in environment', exit_code: 1 }, null, 2));
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+/**
+ * Get the date 30 days ago in ISO format
+ */
+function thirtyDaysAgo() {
+  const d = new Date();
+  d.setDate(d.getDate() - 30);
+  return d.toISOString();
+}
+
+/**
+ * Determine trend direction from two values
+ */
+function trend(current, previous) {
+  if (previous === null || previous === undefined) return 'neutral';
+  if (current > previous) return 'improving';
+  if (current < previous) return 'declining';
+  return 'stable';
+}
+
+/**
+ * Metric 1: SD completion rate (completed/total) for last 30 days
+ */
+async function sdCompletionRate() {
+  const since = thirtyDaysAgo();
+
+  const { count: total } = await supabase
+    .from('strategic_directives_v2')
+    .select('*', { count: 'exact', head: true })
+    .gte('created_at', since);
+
+  const { count: completed } = await supabase
+    .from('strategic_directives_v2')
+    .select('*', { count: 'exact', head: true })
+    .gte('created_at', since)
+    .eq('status', 'completed');
+
+  const rate = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  return {
+    name: 'sd_completion_rate',
+    value: rate,
+    unit: 'percent',
+    target: 80,
+    baseline: 0,
+    trend: 'neutral',
+    measured_at: new Date().toISOString(),
+    detail: { total: total || 0, completed: completed || 0 }
+  };
+}
+
+/**
+ * Metric 2: Average vision score across last 5 scoring runs
+ */
+async function avgVisionScore() {
+  const { data, error } = await supabase
+    .from('eva_vision_scores')
+    .select('total_score, created_at')
+    .order('created_at', { ascending: false })
+    .limit(10);
+
+  if (error || !data || data.length === 0) {
+    return {
+      name: 'avg_vision_score',
+      value: null,
+      unit: 'score',
+      target: 93,
+      baseline: 50,
+      trend: 'neutral',
+      measured_at: new Date().toISOString(),
+      detail: { scores_found: 0 }
+    };
+  }
+
+  const last5 = data.slice(0, 5);
+  const prev5 = data.slice(5, 10);
+
+  const avgLast = Math.round(last5.reduce((s, d) => s + (d.total_score || 0), 0) / last5.length);
+  const avgPrev = prev5.length > 0
+    ? Math.round(prev5.reduce((s, d) => s + (d.total_score || 0), 0) / prev5.length)
+    : null;
+
+  return {
+    name: 'avg_vision_score',
+    value: avgLast,
+    unit: 'score',
+    target: 93,
+    baseline: 50,
+    trend: trend(avgLast, avgPrev),
+    measured_at: new Date().toISOString(),
+    detail: { last5_avg: avgLast, prev5_avg: avgPrev, scores_found: data.length }
+  };
+}
+
+/**
+ * Metric 3: Gate pass rate across last 20 handoffs
+ */
+async function gatePassRate() {
+  const { data, error } = await supabase
+    .from('leo_handoff_executions')
+    .select('result, validation_score')
+    .order('created_at', { ascending: false })
+    .limit(20);
+
+  if (error || !data || data.length === 0) {
+    return {
+      name: 'gate_pass_rate',
+      value: null,
+      unit: 'percent',
+      target: 85,
+      baseline: 0,
+      trend: 'neutral',
+      measured_at: new Date().toISOString(),
+      detail: { handoffs_found: 0 }
+    };
+  }
+
+  const passed = data.filter(d => d.result === 'accepted' || d.result === 'success').length;
+  const rate = Math.round((passed / data.length) * 100);
+
+  // Compare first half vs second half for trend
+  const half = Math.floor(data.length / 2);
+  const recentPassed = data.slice(0, half).filter(d => d.result === 'accepted' || d.result === 'success').length;
+  const olderPassed = data.slice(half).filter(d => d.result === 'accepted' || d.result === 'success').length;
+  const recentRate = half > 0 ? (recentPassed / half) * 100 : 0;
+  const olderRate = (data.length - half) > 0 ? (olderPassed / (data.length - half)) * 100 : 0;
+
+  return {
+    name: 'gate_pass_rate',
+    value: rate,
+    unit: 'percent',
+    target: 85,
+    baseline: 0,
+    trend: trend(recentRate, olderRate),
+    measured_at: new Date().toISOString(),
+    detail: { total: data.length, passed, recent_rate: Math.round(recentRate), older_rate: Math.round(olderRate) }
+  };
+}
+
+/**
+ * Metric 4: Mean time to SD completion (minutes)
+ */
+async function meanTimeToCompletion() {
+  const since = thirtyDaysAgo();
+
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('created_at, completion_date')
+    .eq('status', 'completed')
+    .gte('completion_date', since)
+    .not('completion_date', 'is', null);
+
+  if (error || !data || data.length === 0) {
+    return {
+      name: 'mean_time_to_completion',
+      value: null,
+      unit: 'minutes',
+      target: 120,
+      baseline: null,
+      trend: 'neutral',
+      measured_at: new Date().toISOString(),
+      detail: { sds_measured: 0 }
+    };
+  }
+
+  const durations = data.map(d => {
+    const start = new Date(d.created_at);
+    const end = new Date(d.completion_date);
+    return (end - start) / (1000 * 60); // minutes
+  }).filter(d => d > 0 && d < 60 * 24 * 30); // exclude outliers > 30 days
+
+  const mean = durations.length > 0
+    ? Math.round(durations.reduce((s, d) => s + d, 0) / durations.length)
+    : null;
+
+  return {
+    name: 'mean_time_to_completion',
+    value: mean,
+    unit: 'minutes',
+    target: 120,
+    baseline: null,
+    trend: 'neutral',
+    measured_at: new Date().toISOString(),
+    detail: { sds_measured: durations.length, min: Math.min(...durations), max: Math.max(...durations) }
+  };
+}
+
+/**
+ * Metric 5: Corrective SD resolution rate
+ */
+async function correctiveResolutionRate() {
+  const { count: total } = await supabase
+    .from('strategic_directives_v2')
+    .select('*', { count: 'exact', head: true })
+    .ilike('sd_key', '%CORRECTIVE%');
+
+  const { count: completed } = await supabase
+    .from('strategic_directives_v2')
+    .select('*', { count: 'exact', head: true })
+    .ilike('sd_key', '%CORRECTIVE%')
+    .eq('status', 'completed');
+
+  const rate = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  return {
+    name: 'corrective_sd_resolution_rate',
+    value: rate,
+    unit: 'percent',
+    target: 90,
+    baseline: 0,
+    trend: 'neutral',
+    measured_at: new Date().toISOString(),
+    detail: { total: total || 0, completed: completed || 0 }
+  };
+}
+
+/**
+ * Metric 6: Dimension improvement delta (latest vs first vision score)
+ */
+async function dimensionImprovementDelta() {
+  const { data: latest } = await supabase
+    .from('eva_vision_scores')
+    .select('total_score, created_at')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  const { data: first } = await supabase
+    .from('eva_vision_scores')
+    .select('total_score, created_at')
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .single();
+
+  if (!latest || !first) {
+    return {
+      name: 'dimension_improvement_delta',
+      value: 0,
+      unit: 'points',
+      target: 15,
+      baseline: 0,
+      trend: 'neutral',
+      measured_at: new Date().toISOString(),
+      detail: { latest_score: null, first_score: null }
+    };
+  }
+
+  const delta = (latest.total_score || 0) - (first.total_score || 0);
+
+  return {
+    name: 'dimension_improvement_delta',
+    value: delta,
+    unit: 'points',
+    target: 15,
+    baseline: 0,
+    trend: delta > 0 ? 'improving' : delta < 0 ? 'declining' : 'stable',
+    measured_at: new Date().toISOString(),
+    detail: { latest_score: latest.total_score, first_score: first.total_score }
+  };
+}
+
+async function main() {
+  try {
+    const metrics = await Promise.all([
+      sdCompletionRate(),
+      avgVisionScore(),
+      gatePassRate(),
+      meanTimeToCompletion(),
+      correctiveResolutionRate(),
+      dimensionImprovementDelta()
+    ]);
+
+    // Compute overall health as average of metrics that met their targets
+    const scorable = metrics.filter(m => m.value !== null && m.target !== null);
+    const metTarget = scorable.filter(m => {
+      if (m.unit === 'minutes') return m.value <= m.target;
+      return m.value >= m.target;
+    });
+    const overallHealth = scorable.length > 0
+      ? Math.round((metTarget.length / scorable.length) * 100)
+      : 0;
+
+    console.log(JSON.stringify({
+      metrics,
+      overall_health: overallHealth,
+      collected_at: new Date().toISOString()
+    }, null, 2));
+
+    process.exit(0);
+  } catch (err) {
+    console.log(JSON.stringify({ error: true, message: err.message, exit_code: 1 }, null, 2));
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add `scripts/eva/smoke-test-runner.mjs` — reads smoke_test_steps from SDs and evaluates each step with pass/fail/skip verdicts
- Add `scripts/eva/success-metrics-collector.mjs` — queries 6 DB metrics (SD completion rate, vision scores, gate pass rates, etc.) with 30-day rolling windows
- Add `scripts/eva/capability-verifier.mjs` — checks 29 EVA module exports (4 core functions + 25 stage templates) and reports coverage percentage

## Test plan
- [x] smoke-test-runner.mjs outputs valid JSON with step results
- [x] success-metrics-collector.mjs returns 6 metrics from DB
- [x] capability-verifier.mjs verifies 29 capabilities (12 present, 17 missing outputSchema on stages 9-25)
- [x] All scripts handle Windows ESM paths via pathToFileURL

🤖 Generated with [Claude Code](https://claude.com/claude-code)