### PR TITLE
docs: update LLM provider docs for Google Gemini 3.x migration

### DIFF
--- a/docs/guides/windows-setup-guide.md
+++ b/docs/guides/windows-setup-guide.md
@@ -6,7 +6,7 @@
 - **Status**: Draft
 - **Version**: 1.0.0
 - **Author**: DOCMON
-- **Last Updated**: 2026-01-13
+- **Last Updated**: 2026-02-23
 - **Tags**: database, api, e2e, unit
 
 This guide covers setting up EHG_Engineer for native Windows development without WSL.
@@ -71,9 +71,17 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
-# OpenAI (for LLM features)
+# Google Gemini (primary LLM — required for all AI features)
+# Get your key: https://aistudio.google.com/apikey
+GEMINI_API_KEY=your-gemini-api-key
+
+# OpenAI (optional — fallback LLM and voice/WebRTC only)
 OPENAI_API_KEY=your-openai-key
 ```
+
+> **Note**: As of 2026-02-23, Google Gemini 3.x is the default LLM provider.
+> `GEMINI_API_KEY` is sufficient for all non-voice features.
+> `OPENAI_API_KEY` is only required for voice/WebRTC (`supabase/functions/openai-realtime-token`).
 
 ## Starting Development Servers
 


### PR DESCRIPTION
## Summary

- **windows-setup-guide.md**: `GEMINI_API_KEY` is now the primary/required LLM key. `OPENAI_API_KEY` is optional (fallback + voice/WebRTC only). Added explanatory note.
- **MODEL-VERSION-UPGRADE-RUNBOOK.md** (Section 10): Full update for Gemini-first architecture — cascade priority, current model defaults table (all 6 purposes), Gemini env var overrides, and `getLLMClient()` factory usage pattern replacing the OpenAI-centric examples.

Companion to PR #1576 (feat: replace OpenAI with Google Gemini 3.x as default LLM).

## Test plan

- [x] DOCMON validation passed (0 Strunkian violations)
- [x] 15/15 smoke tests pass
- [ ] Verify env var names match `.env.example` (GEMINI_API_KEY ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)