### PR TITLE
feat: connect assist engine to sensemaking disposition pipeline

### DIFF
--- a/database/migrations/20260223_sensemaking_feedback_view.sql
+++ b/database/migrations/20260223_sensemaking_feedback_view.sql
@@ -1,0 +1,22 @@
+-- Migration: Create v_feedback_with_sensemaking VIEW
+-- SD: SD-LEO-FEAT-CONNECT-ASSIST-ENGINE-001
+-- FR-001: Sensemaking-Aware Feedback Query
+--
+-- LEFT JOINs feedback with sensemaking_analyses on correlation_id.
+-- Leverages existing idx_sensemaking_analyses_correlation index.
+-- Service role bypasses RLS — no new policies needed.
+
+CREATE OR REPLACE VIEW v_feedback_with_sensemaking AS
+SELECT
+  f.*,
+  sa.id AS sensemaking_analysis_id,
+  sa.disposition AS sensemaking_disposition,
+  sa.disposition_at AS sensemaking_disposition_at,
+  sa.overall_confidence AS sensemaking_confidence,
+  sa.status AS sensemaking_status
+FROM feedback f
+LEFT JOIN sensemaking_analyses sa
+  ON f.metadata ->> 'sensemaking_correlation_id' = sa.correlation_id;
+
+COMMENT ON VIEW v_feedback_with_sensemaking IS
+  'Feedback enriched with sensemaking disposition data. Used by assist-engine loadInboxItems(). SD-LEO-FEAT-CONNECT-ASSIST-ENGINE-001 FR-001.';

--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -31,6 +31,7 @@ const DEFAULT_STATUS_TOP_N = 10;
 const DEFAULT_ROUND_TIMEOUT_MS = 30_000;
 
 const CADENCE_TO_MS = {
+  frequent: 120_000,       // 2 minutes (sensemaking disposition monitor)
   hourly: 3_600_000,
   daily: 86_400_000,
   weekly: 604_800_000,
@@ -96,6 +97,7 @@ export class EvaMasterScheduler {
 
     // Register default rounds (FR-3)
     this._registerDefaultRounds();
+    this._registerSensemakingMonitor();
     // Register notification rounds (FR-4)
     this._registerNotificationRounds();
   }
@@ -367,6 +369,52 @@ export class EvaMasterScheduler {
       handler: async () => {
         const { runWeeklySummaryScheduler } = await import('../notifications/scheduler.js');
         return runWeeklySummaryScheduler(supabase);
+      },
+    });
+  }
+
+  /**
+   * Register sensemaking disposition monitor round (FR-005).
+   * Polls for new keep-dispositioned sensemaking analyses every 2 minutes.
+   * Uses disposition_at cursor for incremental processing.
+   */
+  _registerSensemakingMonitor() {
+    const supabase = this.supabase;
+    let highWaterMark = null; // disposition_at cursor
+
+    this.registerRound('sensemaking_disposition_monitor', {
+      description: 'Poll for new sensemaking keep-dispositions to surface in assist queue',
+      cadence: 'frequent',
+      handler: async () => {
+        let query = supabase
+          .from('sensemaking_analyses')
+          .select('id, correlation_id, disposition, disposition_at, input_source')
+          .eq('disposition', 'keep')
+          .order('disposition_at', { ascending: true })
+          .limit(50);
+
+        if (highWaterMark) {
+          query = query.gt('disposition_at', highWaterMark);
+        }
+
+        const { data, error } = await query;
+        if (error) throw new Error(`Sensemaking monitor query failed: ${error.message}`);
+
+        const items = data || [];
+        if (items.length > 0) {
+          // Advance cursor to latest disposition_at
+          highWaterMark = items[items.length - 1].disposition_at;
+
+          for (const item of items) {
+            this.logger.log(`[sensemaking-monitor] Surfaced keep-disposition: ${item.correlation_id} (source: ${item.input_source})`);
+          }
+        }
+
+        return {
+          newKeepItems: items.length,
+          highWaterMark,
+          items: items.map(i => ({ id: i.id, correlationId: i.correlation_id, source: i.input_source })),
+        };
       },
     });
   }

--- a/lib/integrations/dedup-checker.js
+++ b/lib/integrations/dedup-checker.js
@@ -1,9 +1,13 @@
 /**
  * EVA Idea Dedup Checker
  * SD: SD-LEO-ORCH-EVA-IDEA-PROCESSING-001D
+ * Extended: SD-LEO-FEAT-CONNECT-ASSIST-ENGINE-001 (FR-004)
  *
  * Detects duplicate ideas using Jaccard similarity on title tokens.
  * Threshold: 0.7 (configurable).
+ *
+ * FR-004 adds cross-path YouTube URL deduplication: checks
+ * feedback.metadata->>youtube_url for Telegram-path duplicates.
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -12,6 +16,32 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 const DEFAULT_THRESHOLD = 0.7;
+
+/**
+ * Extract YouTube video ID from various URL formats.
+ * Handles youtube.com/watch?v=, youtu.be/, youtube.com/shorts/, and ?si= params.
+ * @param {string} url
+ * @returns {string|null} Video ID or null
+ */
+function extractYouTubeVideoId(url) {
+  if (!url) return null;
+  try {
+    const u = new URL(url);
+    // youtube.com/watch?v=ID or youtube.com/shorts/ID
+    if (u.hostname.includes('youtube.com')) {
+      if (u.searchParams.has('v')) return u.searchParams.get('v');
+      const shortsMatch = u.pathname.match(/\/shorts\/([a-zA-Z0-9_-]+)/);
+      if (shortsMatch) return shortsMatch[1];
+    }
+    // youtu.be/ID
+    if (u.hostname === 'youtu.be') {
+      return u.pathname.slice(1).split('/')[0] || null;
+    }
+  } catch {
+    // Not a valid URL
+  }
+  return null;
+}
 
 /**
  * Tokenize text into normalized words
@@ -92,6 +122,28 @@ export async function checkDuplicate(title, options = {}) {
     for (const item of tdMatches || []) {
       matches.push({ source: 'todoist', id: item.id, title: item.title, similarity: 1.0, status: item.status, matchType: 'video_id' });
     }
+
+    // FR-004: Cross-path YouTube URL dedup — check feedback.metadata->>youtube_url
+    // Catches Telegram-path feedback that has the same YouTube video
+    const { data: feedbackUrlMatches } = await supabase
+      .from('feedback')
+      .select('id, title, status, metadata')
+      .not('status', 'in', '(resolved,shipped)')
+      .not('metadata->>youtube_url', 'is', null);
+
+    for (const item of feedbackUrlMatches || []) {
+      const feedbackVideoId = extractYouTubeVideoId(item.metadata?.youtube_url);
+      if (feedbackVideoId === options.youtubeVideoId) {
+        matches.push({
+          source: 'feedback_cross_path',
+          id: item.id,
+          title: item.title,
+          similarity: 1.0,
+          status: item.status,
+          matchType: 'youtube_url_cross_path',
+        });
+      }
+    }
   }
 
   // Check Todoist intake
@@ -151,7 +203,7 @@ export async function checkDuplicate(title, options = {}) {
   };
 }
 
-// Export Jaccard for testing
-export { jaccardSimilarity, tokenize };
+// Export helpers for testing
+export { jaccardSimilarity, tokenize, extractYouTubeVideoId };
 
-export default { checkDuplicate, jaccardSimilarity, tokenize };
+export default { checkDuplicate, jaccardSimilarity, tokenize, extractYouTubeVideoId };

--- a/lib/quality/assist-engine.js
+++ b/lib/quality/assist-engine.js
@@ -21,6 +21,7 @@ import {
   classifyVerificationLens
 } from './context-analyzer.js';
 import { CentralPlanner } from '../planner/central-planner.js';
+import { enrichWithSensemaking, applyPriorityBoost } from './sensemaking-enricher.js';
 
 dotenv.config();
 
@@ -112,8 +113,9 @@ class AssistEngine {
    * @returns {Promise<Object>} Items separated by type
    */
   async loadInboxItems() {
+    // FR-001: Query v_feedback_with_sensemaking VIEW for disposition-enriched data
     const { data: items, error } = await supabase
-      .from('feedback')
+      .from('v_feedback_with_sensemaking')
       .select('*')
       .not('status', 'in', '(resolved,wont_fix,shipped,snoozed)')
       .order('priority', { ascending: true })
@@ -130,11 +132,14 @@ class AssistEngine {
       console.log(`[assist-engine] Skipped ${skippedLinked} feedback item(s) already linked to SDs`);
     }
 
-    // Separate issues from enhancements
-    const issues = unlinked.filter(i => i.type === 'issue');
-    const enhancements = unlinked.filter(i => i.type === 'enhancement');
+    // FR-002: Enrich with sensemaking dispositions (filter discards, annotate keeps)
+    const { enriched, discardedCount } = enrichWithSensemaking(unlinked);
 
-    return { issues, enhancements, total: unlinked.length };
+    // Separate issues from enhancements
+    const issues = enriched.filter(i => i.type === 'issue');
+    const enhancements = enriched.filter(i => i.type === 'enhancement');
+
+    return { issues, enhancements, total: enriched.length, discardedCount };
   }
 
   /**
@@ -171,6 +176,9 @@ class AssistEngine {
       });
     }
 
+    // FR-003: Apply half-band priority boost to sensemaking-kept items
+    applyPriorityBoost(issues);
+
     // Fallback to simple prioritization
     return issues.sort((a, b) => {
       // P0 always first
@@ -184,10 +192,9 @@ class AssistEngine {
       if (aRelated && !bRelated) return -1;
       if (bRelated && !aRelated) return 1;
 
-      // Then by priority
-      const priorityOrder = { P0: 0, P1: 1, P2: 2, P3: 3 };
-      const aPrio = priorityOrder[a.priority] ?? 2;
-      const bPrio = priorityOrder[b.priority] ?? 2;
+      // Use _sortPriority (includes half-band boost for kept items)
+      const aPrio = a._sortPriority ?? 2;
+      const bPrio = b._sortPriority ?? 2;
 
       if (aPrio !== bPrio) return aPrio - bPrio;
 

--- a/lib/quality/sensemaking-enricher.js
+++ b/lib/quality/sensemaking-enricher.js
@@ -1,0 +1,81 @@
+/**
+ * Sensemaking Enricher
+ * SD: SD-LEO-FEAT-CONNECT-ASSIST-ENGINE-001
+ *
+ * Enriches feedback items with sensemaking disposition data.
+ * - Filters out discarded items (FR-002)
+ * - Annotates kept items with _sensemakingDisposition (FR-002)
+ * - Applies half-band priority boost to kept items (FR-003)
+ *
+ * @module lib/quality/sensemaking-enricher
+ */
+
+/**
+ * Enrich feedback items with sensemaking disposition data and filter discards.
+ *
+ * Expects items queried from v_feedback_with_sensemaking VIEW which includes:
+ * - sensemaking_analysis_id
+ * - sensemaking_disposition ('keep' | 'discard' | null)
+ * - sensemaking_disposition_at
+ * - sensemaking_confidence
+ * - sensemaking_status
+ *
+ * @param {Object[]} items - Feedback items from v_feedback_with_sensemaking
+ * @returns {{ enriched: Object[], discardedCount: number }}
+ */
+export function enrichWithSensemaking(items) {
+  let discardedCount = 0;
+  const enriched = [];
+
+  for (const item of items) {
+    // FR-002: Filter out discarded items
+    if (item.sensemaking_disposition === 'discard') {
+      discardedCount++;
+      continue;
+    }
+
+    // FR-002: Annotate kept items
+    if (item.sensemaking_disposition === 'keep') {
+      item._sensemakingDisposition = 'keep';
+      item._sensemakingAnalysisId = item.sensemaking_analysis_id;
+      item._sensemakingDispositionAt = item.sensemaking_disposition_at;
+    }
+
+    enriched.push(item);
+  }
+
+  if (discardedCount > 0) {
+    console.log(`[sensemaking-enricher] Filtered ${discardedCount} discarded item(s)`);
+  }
+
+  return { enriched, discardedCount };
+}
+
+/**
+ * Apply half-band priority boost to kept sensemaking items (FR-003).
+ *
+ * Kept items get a fractional priority adjustment that sorts them before
+ * non-kept items within the same P-band, but never overrides a higher band.
+ *
+ * Example: kept P2 sorts before non-kept P2, but after any P0 or P1.
+ *
+ * @param {Object[]} items - Items to sort (mutated in place with _sortPriority)
+ * @returns {Object[]} Items with _sortPriority annotation
+ */
+export function applyPriorityBoost(items) {
+  const priorityOrder = { P0: 0, P1: 1, P2: 2, P3: 3 };
+
+  for (const item of items) {
+    const basePriority = priorityOrder[item.priority] ?? 2;
+    // Half-band boost: kept items get -0.5 within their band
+    // This places them before non-kept items in same band
+    // but never crosses band boundaries (e.g., boosted P2 = 1.5, still > P1 = 1)
+    item._sortPriority = item._sensemakingDisposition === 'keep'
+      ? basePriority - 0.5
+      : basePriority;
+  }
+
+  return items;
+}
+
+export default { enrichWithSensemaking, applyPriorityBoost };


### PR DESCRIPTION
## Summary
- Wire `v_feedback_with_sensemaking` VIEW into assist engine's `loadInboxItems()` for disposition-enriched feedback (FR-001)
- Add sensemaking enricher module: filter discarded items, annotate kept items with `_sensemakingDisposition` (FR-002)
- Apply half-band priority boost to kept sensemaking items within same P-band (FR-003)
- Add cross-path YouTube URL deduplication via `extractYouTubeVideoId()` in dedup-checker (FR-004)
- Register 2-minute `sensemaking_disposition_monitor` round in EVA Master Scheduler with cursor-based polling (FR-005)

## Test plan
- [ ] Verify `v_feedback_with_sensemaking` VIEW returns disposition columns
- [ ] Verify discarded items are filtered from assist engine inbox
- [ ] Verify kept items sort before non-kept in same priority band
- [ ] Verify cross-path YouTube URL dedup catches Telegram-path duplicates
- [ ] Verify sensemaking monitor round registers and polls correctly

SD: SD-LEO-FEAT-CONNECT-ASSIST-ENGINE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)