### PR TITLE
fix(handoff): bypass legacy PlanToExecVerifier when active

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -213,11 +213,18 @@ export class PlanToExecExecutor extends BaseExecutor {
     console.log('🔍 Step 2: Standard PLAN→EXEC Verification');
     console.log('-'.repeat(50));
 
-    const verifier = new PlanToExecVerifier();
-    const verificationResult = await verifier.verifyHandoff(sdId, options.prdId);
+    let verificationResult;
+    if (options.bypassValidation) {
+      console.log('   ⚠️  BYPASS ACTIVE: Skipping PlanToExecVerifier (legacy validation)');
+      console.log(`   📝 Reason: ${options.bypassReason || 'No reason provided'}`);
+      verificationResult = { success: true, bypassed: true };
+    } else {
+      const verifier = new PlanToExecVerifier();
+      verificationResult = await verifier.verifyHandoff(sdId, options.prdId);
 
-    if (!verificationResult.success) {
-      return verificationResult;
+      if (!verificationResult.success) {
+        return verificationResult;
+      }
     }
 
     // Create handoff retrospective after successful handoff


### PR DESCRIPTION
## Summary
- Fixes `--bypass-validation` flag not working for PLAN-TO-EXEC handoffs
- Root cause: dual validation path where BaseExecutor gates respected bypass but legacy PlanToExecVerifier did not
- Now checks `options.bypassValidation` before calling legacy verifier

## Test plan
- [ ] Run PLAN-TO-EXEC with `--bypass-validation` — should skip verifier
- [ ] Run PLAN-TO-EXEC without bypass — should still run full verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)