### PR TITLE
fix: auto-trigger assist on sensemaking disposition

### DIFF
--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -31,7 +31,7 @@ const DEFAULT_STATUS_TOP_N = 10;
 const DEFAULT_ROUND_TIMEOUT_MS = 30_000;
 
 const CADENCE_TO_MS = {
-  frequent: 120_000,       // 2 minutes (sensemaking disposition monitor)
+  frequent: 600_000,       // 10 minutes (sensemaking disposition monitor)
   hourly: 3_600_000,
   daily: 86_400_000,
   weekly: 604_800_000,
@@ -375,15 +375,16 @@ export class EvaMasterScheduler {
 
   /**
    * Register sensemaking disposition monitor round (FR-005).
-   * Polls for new keep-dispositioned sensemaking analyses every 2 minutes.
+   * Polls for new keep-dispositioned sensemaking analyses every 10 minutes.
    * Uses disposition_at cursor for incremental processing.
+   * Auto-triggers assist processing via Telegram notification when new items found.
    */
   _registerSensemakingMonitor() {
     const supabase = this.supabase;
     let highWaterMark = null; // disposition_at cursor
 
     this.registerRound('sensemaking_disposition_monitor', {
-      description: 'Poll for new sensemaking keep-dispositions to surface in assist queue',
+      description: 'Poll for new sensemaking keep-dispositions and auto-trigger assist',
       cadence: 'frequent',
       handler: async () => {
         let query = supabase
@@ -408,6 +409,9 @@ export class EvaMasterScheduler {
           for (const item of items) {
             this.logger.log(`[sensemaking-monitor] Surfaced keep-disposition: ${item.correlation_id} (source: ${item.input_source})`);
           }
+
+          // Auto-trigger: notify via Telegram and flag for assist processing
+          await this._notifyAssistTrigger(supabase, items);
         }
 
         return {
@@ -417,6 +421,41 @@ export class EvaMasterScheduler {
         };
       },
     });
+  }
+
+  /**
+   * Notify chairman via Telegram that new sensemaking items need assist processing,
+   * and flag the corresponding feedback items for priority processing.
+   */
+  async _notifyAssistTrigger(supabase, keepItems) {
+    try {
+      // 1. Flag feedback items linked to these sensemaking analyses for assist priority
+      const correlationIds = keepItems.map(i => i.correlation_id).filter(Boolean);
+      if (correlationIds.length > 0) {
+        // Ensure linked feedback items are in 'new' status so assist picks them up
+        const { count } = await supabase
+          .from('feedback')
+          .update({ status: 'new' })
+          .in('metadata->>sensemaking_correlation_id', correlationIds)
+          .eq('status', 'pending')
+          .select('id', { count: 'exact', head: true });
+
+        if (count > 0) {
+          this.logger.log(`[sensemaking-monitor] Promoted ${count} feedback item(s) to 'new' for assist`);
+        }
+      }
+
+      // 2. Send Telegram notification
+      const { sendTelegramMessage } = await import('../notifications/telegram-adapter.js');
+      const summary = keepItems.map(i => `  - ${i.input_source || 'unknown'}: ${i.correlation_id}`).join('\n');
+      await sendTelegramMessage({
+        text: `🤖 Assist Auto-Trigger\n\n${keepItems.length} new sensemaking item(s) ready for processing:\n${summary}\n\nRun /leo assist to process.`,
+      });
+      this.logger.log(`[sensemaking-monitor] Telegram notification sent for ${keepItems.length} item(s)`);
+    } catch (err) {
+      // Non-blocking: log but don't fail the monitor round
+      this.logger.error(`[sensemaking-monitor] Auto-trigger notification failed: ${err.message}`);
+    }
   }
 
   // ── Poll Cycle ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Sensemaking disposition monitor now auto-triggers assist processing when new keep-dispositioned items are found
- Polling cadence changed from 2min to 10min (production-appropriate)
- Promotes linked feedback items to 'new' status so `/leo assist` picks them up
- Sends Telegram notification to chairman about new items ready

## Test plan
- [ ] Send YouTube URL via Telegram, verify Gemini processes it
- [ ] After disposition, verify Telegram notification received
- [ ] Run `/leo assist` and confirm sensemaking-enriched items appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)