### PR TITLE
fix: auto-create SDs from sensemaking-enriched feedback

### DIFF
--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -424,38 +424,112 @@ export class EvaMasterScheduler {
   }
 
   /**
-   * Notify chairman via Telegram that new sensemaking items need assist processing,
-   * and flag the corresponding feedback items for priority processing.
+   * Auto-process new sensemaking items: create SDs from linked feedback
+   * and notify chairman via Telegram.
    */
   async _notifyAssistTrigger(supabase, keepItems) {
     try {
-      // 1. Flag feedback items linked to these sensemaking analyses for assist priority
+      // 1. Find feedback items linked to these sensemaking analyses
       const correlationIds = keepItems.map(i => i.correlation_id).filter(Boolean);
-      if (correlationIds.length > 0) {
-        // Ensure linked feedback items are in 'new' status so assist picks them up
-        const { count } = await supabase
-          .from('feedback')
-          .update({ status: 'new' })
-          .in('metadata->>sensemaking_correlation_id', correlationIds)
-          .eq('status', 'pending')
-          .select('id', { count: 'exact', head: true });
+      if (correlationIds.length === 0) return;
 
-        if (count > 0) {
-          this.logger.log(`[sensemaking-monitor] Promoted ${count} feedback item(s) to 'new' for assist`);
+      const { data: feedbackRows } = await supabase
+        .from('feedback')
+        .select('id, title, description, type, priority, strategic_directive_id, resolution_sd_id, metadata')
+        .in('metadata->>sensemaking_correlation_id', correlationIds)
+        .is('strategic_directive_id', null)
+        .is('resolution_sd_id', null);
+
+      const actionable = feedbackRows || [];
+      if (actionable.length === 0) {
+        this.logger.log('[sensemaking-monitor] No unlinked feedback items to process');
+        return;
+      }
+
+      // 2. Auto-create SDs from each feedback item
+      const created = [];
+      for (const fb of actionable) {
+        try {
+          const sd = await this._createSDFromFeedback(supabase, fb);
+          if (sd) created.push({ feedbackId: fb.id, sdKey: sd.sd_key, title: fb.title });
+        } catch (err) {
+          this.logger.error(`[sensemaking-monitor] Failed to create SD for feedback ${fb.id}: ${err.message}`);
         }
       }
 
-      // 2. Send Telegram notification
-      const { sendTelegramMessage } = await import('../notifications/telegram-adapter.js');
-      const summary = keepItems.map(i => `  - ${i.input_source || 'unknown'}: ${i.correlation_id}`).join('\n');
-      await sendTelegramMessage({
-        text: `🤖 Assist Auto-Trigger\n\n${keepItems.length} new sensemaking item(s) ready for processing:\n${summary}\n\nRun /leo assist to process.`,
-      });
-      this.logger.log(`[sensemaking-monitor] Telegram notification sent for ${keepItems.length} item(s)`);
+      // 3. Send Telegram notification with results
+      if (created.length > 0) {
+        const { sendTelegramMessage } = await import('../notifications/telegram-adapter.js');
+        const summary = created.map(c => `  - ${c.sdKey}: ${c.title}`).join('\n');
+        await sendTelegramMessage({
+          text: `🤖 Auto-Assist: ${created.length} SD(s) created\n\n${summary}\n\nQueued for next leo:continuous run.`,
+        });
+        this.logger.log(`[sensemaking-monitor] Auto-created ${created.length} SD(s) from sensemaking items`);
+      }
     } catch (err) {
       // Non-blocking: log but don't fail the monitor round
-      this.logger.error(`[sensemaking-monitor] Auto-trigger notification failed: ${err.message}`);
+      this.logger.error(`[sensemaking-monitor] Auto-trigger failed: ${err.message}`);
     }
+  }
+
+  /**
+   * Create an SD from a feedback item (headless version of createFromFeedback).
+   */
+  async _createSDFromFeedback(supabase, feedback) {
+    const { runTriageGate } = await import('../../scripts/modules/triage-gate.js');
+    const { generateSDKey } = await import('../../scripts/modules/sd-key-generator.js');
+    const { createSD } = await import('../../scripts/leo-create-sd.js');
+
+    // Map feedback type to SD type
+    const typeMap = { issue: 'fix', enhancement: 'enhancement', bug: 'fix' };
+    const type = typeMap[feedback.type] || 'feature';
+
+    // Triage: if tiny, still create SD (autonomous mode processes everything)
+    let tier = 3;
+    try {
+      const triage = await runTriageGate({
+        title: feedback.title,
+        description: feedback.description || feedback.title,
+        type,
+        source: 'sensemaking-monitor'
+      }, supabase);
+      tier = triage.tier;
+    } catch { /* non-fatal */ }
+
+    // Generate SD key
+    const sdKey = await generateSDKey({
+      source: 'FEEDBACK',
+      type,
+      title: feedback.title,
+      venturePrefix: 'LEO'
+    });
+
+    // Create SD
+    const sd = await createSD({
+      sdKey,
+      title: feedback.title,
+      description: feedback.description || feedback.title,
+      type,
+      priority: feedback.priority === 'P0' ? 'critical' : feedback.priority === 'P1' ? 'high' : 'medium',
+      rationale: 'Auto-created from sensemaking-enriched feedback. Source: telegram/sensemaking',
+      metadata: {
+        source: 'sensemaking-monitor',
+        source_id: feedback.id,
+        feedback_type: feedback.type,
+        feedback_priority: feedback.priority,
+        triage_tier: tier,
+        auto_created: true
+      }
+    });
+
+    // Link feedback to SD
+    await supabase
+      .from('feedback')
+      .update({ status: 'in_progress', strategic_directive_id: sd.id })
+      .eq('id', feedback.id);
+
+    this.logger.log(`[sensemaking-monitor] Created ${sdKey} from feedback ${feedback.id} (tier ${tier})`);
+    return sd;
   }
 
   // ── Poll Cycle ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Sensemaking monitor now auto-creates Strategic Directives from keep-dispositioned feedback
- Closes the full automation loop: YouTube URL → Telegram → Gemini → sensemaking → auto-SD creation → queued for leo:continuous
- Replaces notification-only behavior with actual SD creation
- Duplicate guard: skips feedback already linked to an SD

## Test plan
- [ ] Send YouTube URL via Telegram
- [ ] Verify Gemini processes and creates sensemaking analysis
- [ ] Disposition as "keep" via inline keyboard
- [ ] Wait for 10-min monitor cycle (or manually trigger)
- [ ] Verify SD created in strategic_directives_v2
- [ ] Verify Telegram notification received with SD key

🤖 Generated with [Claude Code](https://claude.com/claude-code)