### PR TITLE
fix: remove headless SD creation blockers for EVA scheduler

### DIFF
--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -31,7 +31,7 @@ const DEFAULT_STATUS_TOP_N = 10;
 const DEFAULT_ROUND_TIMEOUT_MS = 30_000;
 
 const CADENCE_TO_MS = {
-  frequent: 600_000,       // 10 minutes (sensemaking disposition monitor)
+  frequent: 600_000,       // 10 minutes
   hourly: 3_600_000,
   daily: 86_400_000,
   weekly: 604_800_000,
@@ -501,7 +501,8 @@ export class EvaMasterScheduler {
       source: 'FEEDBACK',
       type,
       title: feedback.title,
-      venturePrefix: 'LEO'
+      venturePrefix: 'LEO',
+      skipLeadValidation: true  // headless — no interactive session
     });
 
     // Create SD

--- a/scripts/eva/vision-scorer.js
+++ b/scripts/eva/vision-scorer.js
@@ -554,8 +554,8 @@ ${rawResponse.substring(0, 1000)}`;
 // CLI entry point
 // ============================================================================
 
-const isMainModule = import.meta.url === `file://${process.argv[1]}` ||
-                     import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+const isMainModule = process.argv[1] && (import.meta.url === `file://${process.argv[1]}` ||
+                     import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`);
 
 /**
  * Inline mode: output context for Claude Code to process in-conversation.

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1109,8 +1109,11 @@ async function createSD(options) {
     .single();
 
   if (error) {
-    console.error('Failed to create SD:', error.message);
-    process.exit(1);
+    const msg = `Failed to create SD: ${error.message}`;
+    console.error(msg);
+    // Throw instead of process.exit — callers (EVA, corrective-sd-generator) must not be killed
+    if (typeof globalThis.__LEO_CLI_MODE !== 'undefined') process.exit(1);
+    throw new Error(msg);
   }
 
   // Vision pre-screen at SD conception (SD-LEO-INFRA-VISION-SD-CONCEPTION-GATE-001)

--- a/scripts/modules/triage-gate.js
+++ b/scripts/modules/triage-gate.js
@@ -141,12 +141,12 @@ function buildAskUserQuestionPayload(routingDecision, locResult, title, type) {
   if (tier === 1) {
     questionText =
       `Triage: estimated ~${locResult.estimatedLoc} LOC (${locResult.confidence}% confidence). ` +
-      `This looks like a Quick Fix (Tier 1 — auto-approve, no LEAD review). ` +
+      'This looks like a Quick Fix (Tier 1 — auto-approve, no LEAD review). ' +
       `Max ${tier1MaxLoc} LOC. How would you like to proceed?`;
   } else {
     questionText =
       `Triage: estimated ~${locResult.estimatedLoc} LOC (${locResult.confidence}% confidence). ` +
-      `This looks like a Standard Quick Fix (Tier 2 — compliance rubric ≥70 required). ` +
+      'This looks like a Standard Quick Fix (Tier 2 — compliance rubric ≥70 required). ' +
       `Max ${tier2MaxLoc} LOC. How would you like to proceed?`;
   }
 
@@ -272,9 +272,9 @@ async function main() {
 }
 
 // ESM entry point detection (Windows-compatible)
-const isMain =
+const isMain = process.argv[1] && (
   import.meta.url === `file://${process.argv[1]}` ||
-  import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`);
 
 if (isMain) {
   main().catch((err) => {


### PR DESCRIPTION
## Summary
- Guard `process.argv[1]` null access in `triage-gate.js` and `vision-scorer.js` (crashes when imported as ESM module, not run as CLI)
- Replace `process.exit(1)` with `throw Error` in `leo-create-sd.js` `createSD()` (was killing EVA scheduler process on DB insert failure)
- Add `skipLeadValidation` to EVA's `generateSDKey` call (protocol validation gate blocked autonomous/headless execution)

These 4 fixes enable the full automation pipeline: YouTube URL → Telegram Bot → Sensemaking → EVA Monitor → Auto SD Creation.

## Test plan
- [x] Verified end-to-end: EVA auto-created SD-LEO-FDBK-FIX-EVALUATE-YOUTUBE-VIDEO-001 from keep-dispositioned sensemaking item
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)