### PR TITLE
fix: enrich auto-created SDs with sensemaking persona insights

### DIFF
--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -480,16 +480,52 @@ export class EvaMasterScheduler {
     const { generateSDKey } = await import('../../scripts/modules/sd-key-generator.js');
     const { createSD } = await import('../../scripts/leo-create-sd.js');
 
+    // Enrich from sensemaking analysis when available (persona-driven title/description)
+    let title = feedback.title;
+    let description = feedback.description || feedback.title;
+    let effectiveType = feedback.type;
+    const correlationId = feedback.metadata?.sensemaking_correlation_id;
+    if (correlationId) {
+      try {
+        const { data: sa } = await supabase
+          .from('sensemaking_analyses')
+          .select('disposition, analysis_result')
+          .eq('correlation_id', correlationId)
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .single();
+        if (sa?.analysis_result) {
+          const r = sa.analysis_result;
+          if (r.summary) title = r.summary.slice(0, 200);
+          // Build description from persona insights
+          const personas = r.persona_insights || [];
+          if (personas.length > 0) {
+            const personaLines = personas.map(p =>
+              `**${p.persona || p.name}**: ${p.key_takeaway || p.implications?.[0] || ''}`
+            ).join('\n');
+            description = `${r.summary || ''}\n\nPersona Insights:\n${personaLines}`;
+            if (r.next_steps?.length) {
+              description += '\n\nNext Steps:\n' + r.next_steps.map((s, i) => `${i + 1}. ${s}`).join('\n');
+            }
+          } else if (r.summary) {
+            description = r.summary;
+          }
+          // keep-dispositioned sensemaking items are enhancements, not issues
+          if (sa.disposition === 'keep') effectiveType = 'enhancement';
+        }
+      } catch { /* non-fatal — fall back to feedback fields */ }
+    }
+
     // Map feedback type to SD type
-    const typeMap = { issue: 'fix', enhancement: 'enhancement', bug: 'fix' };
-    const type = typeMap[feedback.type] || 'feature';
+    const typeMap = { issue: 'fix', enhancement: 'feature', bug: 'fix' };
+    const type = typeMap[effectiveType] || 'feature';
 
     // Triage: if tiny, still create SD (autonomous mode processes everything)
     let tier = 3;
     try {
       const triage = await runTriageGate({
-        title: feedback.title,
-        description: feedback.description || feedback.title,
+        title,
+        description,
         type,
         source: 'sensemaking-monitor'
       }, supabase);
@@ -500,7 +536,7 @@ export class EvaMasterScheduler {
     const sdKey = await generateSDKey({
       source: 'FEEDBACK',
       type,
-      title: feedback.title,
+      title,
       venturePrefix: 'LEO',
       skipLeadValidation: true  // headless — no interactive session
     });
@@ -508,8 +544,8 @@ export class EvaMasterScheduler {
     // Create SD
     const sd = await createSD({
       sdKey,
-      title: feedback.title,
-      description: feedback.description || feedback.title,
+      title,
+      description,
       type,
       priority: feedback.priority === 'P0' ? 'critical' : feedback.priority === 'P1' ? 'high' : 'medium',
       rationale: 'Auto-created from sensemaking-enriched feedback. Source: telegram/sensemaking',
@@ -519,7 +555,8 @@ export class EvaMasterScheduler {
         feedback_type: feedback.type,
         feedback_priority: feedback.priority,
         triage_tier: tier,
-        auto_created: true
+        auto_created: true,
+        sensemaking_enriched: !!correlationId
       }
     });
 


### PR DESCRIPTION
## Summary
- When sensemaking monitor auto-creates SDs from feedback, it now fetches the linked sensemaking analysis via `correlation_id`
- SD title uses the analysis summary instead of the stale feedback title
- SD description is built from **persona insights** (each persona's key takeaway) plus next steps
- `keep`-dispositioned items are forced to `enhancement` type, producing `FEAT` SD keys instead of `FIX`
- Fixed `enhancement` → `'feature'` mapping (was `'enhancement'`, inconsistent with `sd-from-feedback.js`)

## Test plan
- [ ] Submit a YouTube URL via Telegram, verify sensemaking analysis completes
- [ ] Verify auto-created SD title reflects video content summary, not generic feedback title
- [ ] Verify SD description contains persona insights
- [ ] Verify SD key contains `FEAT` (not `FIX`) for keep-dispositioned items
- [ ] Verify fallback works when no sensemaking analysis exists (uses feedback fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)