### PR TITLE
fix: use correct persona_name field from sensemaking analysis

### DIFF
--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -501,7 +501,7 @@ export class EvaMasterScheduler {
           const personas = r.persona_insights || [];
           if (personas.length > 0) {
             const personaLines = personas.map(p =>
-              `**${p.persona || p.name}**: ${p.key_takeaway || p.implications?.[0] || ''}`
+              `**${p.persona_name || p.persona || p.name}**: ${p.key_takeaway || p.implications?.[0] || ''}`
             ).join('\n');
             description = `${r.summary || ''}\n\nPersona Insights:\n${personaLines}`;
             if (r.next_steps?.length) {


### PR DESCRIPTION
## Summary
- Persona objects in `sensemaking_analyses` use `persona_name`, not `persona` or `name`
- Fixes `undefined` showing as persona labels in auto-created SD descriptions
- Follow-up to PR #1588

## Test plan
- [ ] Verify next auto-created SD shows "Venture Strategist", "Growth Operator", etc. instead of "undefined"

🤖 Generated with [Claude Code](https://claude.com/claude-code)