### PR TITLE
feat: add YouTube video metadata enrichment for classification

### DIFF
--- a/lib/integrations/__tests__/youtube-metadata-integration.test.js
+++ b/lib/integrations/__tests__/youtube-metadata-integration.test.js
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for YouTube metadata integration in idea-classifier.js.
+ * SD: SD-LEO-FDBK-FIX-EVALUATE-YOUTUBE-VIDEO-001
+ */
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn()
+}));
+
+vi.mock('dotenv', () => ({
+  default: { config: vi.fn() },
+  config: vi.fn()
+}));
+
+vi.mock('../../llm/client-factory.js', () => ({
+  getClassificationClient: vi.fn()
+}));
+
+import { classifyIdea } from '../idea-classifier.js';
+import { getClassificationClient } from '../../llm/client-factory.js';
+
+describe('idea-classifier YouTube metadata integration', () => {
+  let mockSupabase;
+  let mockLLMClient;
+
+  const categories = [
+    { category_type: 'venture_tag', code: 'ehg_core', label: 'EHG Core', classification_keywords: ['platform', 'core'] },
+    { category_type: 'venture_tag', code: 'learning_resource', label: 'Learning', classification_keywords: ['learn', 'tutorial'] },
+    { category_type: 'business_function', code: 'feature_idea', label: 'Feature', classification_keywords: ['feature', 'add'] },
+    { category_type: 'business_function', code: 'content_strategy', label: 'Content', classification_keywords: ['content', 'video'] },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Build a chainable mock for supabase queries
+    mockSupabase = {
+      from: vi.fn().mockImplementation(() => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockImplementation((col) => {
+            if (col === 'is_active') {
+              return { order: vi.fn().mockResolvedValue({ data: categories }) };
+            }
+            return {
+              maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+              neq: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue({ data: [] })
+                })
+              })
+            };
+          })
+        })
+      }))
+    };
+
+    mockLLMClient = { complete: vi.fn() };
+    getClassificationClient.mockResolvedValue(mockLLMClient);
+  });
+
+  it('includes rich YouTube metadata in LLM prompt', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "learning_resource", "business_function": "content_strategy", "confidence": 0.9}'
+    );
+
+    await classifyIdea('Watch this video', 'Check out this tutorial', {
+      supabase: mockSupabase,
+      item: {
+        extracted_youtube_id: 'dQw4w9WgXcQ',
+        youtube_metadata: {
+          title: 'Advanced React Patterns',
+          description: 'A deep dive into React hooks',
+          channelName: 'Tech Channel',
+          tags: ['react', 'hooks'],
+          durationSeconds: 1200,
+          publishedAt: '2026-01-01T00:00:00Z'
+        }
+      }
+    });
+
+    const prompt = mockLLMClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('YouTube Video Context:');
+    expect(prompt).toContain('Advanced React Patterns');
+    expect(prompt).toContain('Tech Channel');
+    expect(prompt).toContain('react, hooks');
+  });
+
+  it('falls back to generic hint when no metadata available', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "ehg_core", "business_function": "feature_idea", "confidence": 0.7}'
+    );
+
+    await classifyIdea('Some video', '', {
+      supabase: mockSupabase,
+      item: { extracted_youtube_id: 'dQw4w9WgXcQ' }
+    });
+
+    const prompt = mockLLMClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('references a YouTube video');
+    expect(prompt).toContain('dQw4w9WgXcQ');
+    expect(prompt).not.toContain('YouTube Video Context:');
+  });
+
+  it('omits YouTube section when no video context', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "ehg_core", "business_function": "feature_idea", "confidence": 0.8}'
+    );
+
+    await classifyIdea('Regular task', 'No video here', {
+      supabase: mockSupabase,
+      item: { todoist_task_id: '123' }
+    });
+
+    const prompt = mockLLMClient.complete.mock.calls[0][1];
+    expect(prompt).not.toContain('YouTube');
+  });
+
+  it('truncates long descriptions to 500 chars', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "ehg_core", "business_function": "feature_idea", "confidence": 0.8}'
+    );
+
+    const longDesc = 'A'.repeat(1000);
+    await classifyIdea('Test', '', {
+      supabase: mockSupabase,
+      item: {
+        extracted_youtube_id: 'dQw4w9WgXcQ',
+        youtube_metadata: {
+          title: 'Long Video', description: longDesc,
+          channelName: 'Ch', tags: [], durationSeconds: 60, publishedAt: ''
+        }
+      }
+    });
+
+    const prompt = mockLLMClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('A'.repeat(500));
+    expect(prompt).not.toContain('A'.repeat(501));
+  });
+
+  it('limits tags to first 10', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "ehg_core", "business_function": "feature_idea", "confidence": 0.8}'
+    );
+
+    const tags = Array.from({ length: 20 }, (_, i) => `tag${i}`);
+    await classifyIdea('Test', '', {
+      supabase: mockSupabase,
+      item: {
+        extracted_youtube_id: 'dQw4w9WgXcQ',
+        youtube_metadata: {
+          title: 'Many Tags', description: '', channelName: 'Ch',
+          tags, durationSeconds: 60, publishedAt: ''
+        }
+      }
+    });
+
+    const prompt = mockLLMClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('tag9');
+    expect(prompt).not.toContain('tag10');
+  });
+
+  it('uses keyword fallback when LLM fails', async () => {
+    getClassificationClient.mockRejectedValue(new Error('API unavailable'));
+
+    const result = await classifyIdea('Watch tutorial video', 'content about learning', {
+      supabase: mockSupabase,
+      item: {
+        extracted_youtube_id: 'dQw4w9WgXcQ',
+        youtube_metadata: {
+          title: 'Learn Tutorial', description: 'A learning video',
+          channelName: 'Tutorials', tags: ['learn'], durationSeconds: 300, publishedAt: ''
+        }
+      }
+    });
+
+    expect(result).toHaveProperty('venture_tag');
+    expect(result).toHaveProperty('business_function');
+    expect(result.confidence_score).toBe(0.5);
+  });
+});

--- a/lib/integrations/evaluation-bridge.js
+++ b/lib/integrations/evaluation-bridge.js
@@ -10,6 +10,7 @@ import { createClient } from '@supabase/supabase-js';
 import { classifyIdea } from './idea-classifier.js';
 import { checkDuplicate } from './dedup-checker.js';
 import { extractYouTubeVideoId, extractYouTubeUrl } from './url-extractor.js';
+import { fetchVideoMetadata } from './youtube/video-metadata.js';
 import { triageFeedback } from '../quality/triage-engine.js';
 import { routeToAnalysis } from './deeper-analysis-router.js';
 import dotenv from 'dotenv';
@@ -86,8 +87,48 @@ async function evaluateItem(item, sourceType, options = {}) {
       }
     }
 
-    // 2. Classify (pass full item for hierarchy context + YouTube hint)
+    // 1.7. Fetch YouTube video metadata for classification enrichment
+    let youtubeMetadata = null;
+    const videoIdForMetadata = extractedYouTubeId || (sourceType === 'youtube' ? item.youtube_video_id : null);
+    if (videoIdForMetadata) {
+      // Cache-first: use existing eva_youtube_intake data if available
+      if (sourceType === 'youtube' && item.title && item.description) {
+        youtubeMetadata = {
+          title: item.title,
+          description: item.description,
+          channelName: item.channel_name || '',
+          tags: item.tags || [],
+          durationSeconds: item.duration_seconds || 0,
+          publishedAt: item.published_at || ''
+        };
+      } else if (extractedYouTubeId) {
+        // Check cross-linked YouTube intake row for cached metadata
+        const { data: ytRow } = await supabase
+          .from('eva_youtube_intake')
+          .select('title, description, channel_name, tags, duration_seconds, published_at')
+          .eq('youtube_video_id', extractedYouTubeId)
+          .maybeSingle();
+
+        if (ytRow && ytRow.title) {
+          youtubeMetadata = {
+            title: ytRow.title,
+            description: ytRow.description || '',
+            channelName: ytRow.channel_name || '',
+            tags: ytRow.tags || [],
+            durationSeconds: ytRow.duration_seconds || 0,
+            publishedAt: ytRow.published_at || ''
+          };
+          if (options.verbose) console.log(`    YouTube metadata from cache: "${ytRow.title}"`);
+        } else {
+          // API call as last resort
+          youtubeMetadata = await fetchVideoMetadata(extractedYouTubeId, { verbose: options.verbose });
+        }
+      }
+    }
+
+    // 2. Classify (pass full item for hierarchy context + YouTube metadata)
     const classifyItem = extractedYouTubeId ? { ...item, extracted_youtube_id: extractedYouTubeId } : item;
+    if (youtubeMetadata) classifyItem.youtube_metadata = youtubeMetadata;
     const classification = await classifyIdea(item.title, item.description, { supabase, verbose: options.verbose, item: classifyItem });
     result.classification = classification;
 

--- a/lib/integrations/idea-classifier.js
+++ b/lib/integrations/idea-classifier.js
@@ -59,7 +59,17 @@ function buildClassificationPrompt(title, description, categories, hierarchy = {
 
   let youtubeHint = '';
   if (hierarchy.youtubeVideoId) {
-    youtubeHint = `\nNote: This task references a YouTube video (ID: ${hierarchy.youtubeVideoId}). Consider this as potential learning_resource or content_strategy.\n`;
+    if (hierarchy.youtubeMetadata) {
+      const { title: vTitle, description: vDesc, channelName, tags } = hierarchy.youtubeMetadata;
+      const descSnippet = (vDesc || '').slice(0, 500);
+      const tagList = (tags || []).slice(0, 10).join(', ');
+      youtubeHint = `\nYouTube Video Context:\n  Title: ${vTitle}\n  Channel: ${channelName || 'unknown'}`;
+      if (descSnippet) youtubeHint += `\n  Description: ${descSnippet}`;
+      if (tagList) youtubeHint += `\n  Tags: ${tagList}`;
+      youtubeHint += '\n';
+    } else {
+      youtubeHint = `\nNote: This task references a YouTube video (ID: ${hierarchy.youtubeVideoId}). Consider this as potential learning_resource or content_strategy.\n`;
+    }
   }
 
   return `Classify this idea into exactly one venture_tag and one business_function.
@@ -188,9 +198,12 @@ export async function classifyIdea(title, description, options = {}) {
     ? await loadHierarchyContext(supabase, options.item)
     : { parentTitle: null, siblingTitles: [] };
 
-  // Pass YouTube video ID hint if available
+  // Pass YouTube video ID and metadata if available
   if (options.item?.extracted_youtube_id) {
     hierarchy.youtubeVideoId = options.item.extracted_youtube_id;
+  }
+  if (options.item?.youtube_metadata) {
+    hierarchy.youtubeMetadata = options.item.youtube_metadata;
   }
 
   const combinedText = `${hierarchy.parentTitle ? hierarchy.parentTitle + ' > ' : ''}${title} ${description || ''}`;

--- a/lib/integrations/youtube/__tests__/video-metadata.test.js
+++ b/lib/integrations/youtube/__tests__/video-metadata.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('googleapis', () => ({
+  google: {
+    youtube: vi.fn()
+  }
+}));
+
+vi.mock('../oauth-manager.js', () => ({
+  getAuthenticatedClient: vi.fn()
+}));
+
+import { fetchVideoMetadata } from '../video-metadata.js';
+import { google } from 'googleapis';
+import { getAuthenticatedClient } from '../oauth-manager.js';
+
+describe('fetchVideoMetadata', () => {
+  let mockYouTubeClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockYouTubeClient = {
+      videos: { list: vi.fn() }
+    };
+    google.youtube.mockReturnValue(mockYouTubeClient);
+    getAuthenticatedClient.mockResolvedValue({});
+  });
+
+  it('returns null for empty videoId', async () => {
+    expect(await fetchVideoMetadata(null)).toBeNull();
+    expect(await fetchVideoMetadata('')).toBeNull();
+    expect(await fetchVideoMetadata(undefined)).toBeNull();
+  });
+
+  it('returns null for videoId not 11 characters', async () => {
+    expect(await fetchVideoMetadata('short')).toBeNull();
+    expect(await fetchVideoMetadata('toolongvideoidentifier')).toBeNull();
+  });
+
+  it('fetches metadata for valid video ID', async () => {
+    mockYouTubeClient.videos.list.mockResolvedValue({
+      data: {
+        items: [{
+          snippet: {
+            title: 'Test Video Title',
+            description: 'A test description',
+            channelTitle: 'Test Channel',
+            tags: ['tag1', 'tag2'],
+            publishedAt: '2026-01-15T10:00:00Z'
+          },
+          contentDetails: { duration: 'PT1H23M45S' }
+        }]
+      }
+    });
+
+    const result = await fetchVideoMetadata('dQw4w9WgXcQ');
+
+    expect(result).toEqual({
+      title: 'Test Video Title',
+      description: 'A test description',
+      channelName: 'Test Channel',
+      tags: ['tag1', 'tag2'],
+      durationSeconds: 5025,
+      publishedAt: '2026-01-15T10:00:00Z'
+    });
+
+    expect(mockYouTubeClient.videos.list).toHaveBeenCalledWith({
+      part: ['snippet', 'contentDetails'],
+      id: ['dQw4w9WgXcQ']
+    });
+  });
+
+  it('returns null when video not found', async () => {
+    mockYouTubeClient.videos.list.mockResolvedValue({ data: { items: [] } });
+    expect(await fetchVideoMetadata('dQw4w9WgXcQ')).toBeNull();
+  });
+
+  it('returns null on API error (fail-open)', async () => {
+    mockYouTubeClient.videos.list.mockRejectedValue(new Error('Quota exceeded'));
+    expect(await fetchVideoMetadata('dQw4w9WgXcQ')).toBeNull();
+  });
+
+  it('returns null on OAuth error (fail-open)', async () => {
+    getAuthenticatedClient.mockRejectedValue(new Error('No stored tokens'));
+    expect(await fetchVideoMetadata('dQw4w9WgXcQ')).toBeNull();
+  });
+
+  it('handles missing snippet fields gracefully', async () => {
+    mockYouTubeClient.videos.list.mockResolvedValue({
+      data: { items: [{ snippet: { title: 'Minimal' }, contentDetails: {} }] }
+    });
+
+    const result = await fetchVideoMetadata('dQw4w9WgXcQ');
+    expect(result).toEqual({
+      title: 'Minimal',
+      description: '',
+      channelName: '',
+      tags: [],
+      durationSeconds: 0,
+      publishedAt: ''
+    });
+  });
+
+  it('parses various ISO 8601 durations', async () => {
+    const cases = [
+      { duration: 'PT5M30S', expected: 330 },
+      { duration: 'PT2H', expected: 7200 },
+      { duration: 'PT45S', expected: 45 },
+      { duration: 'PT10M', expected: 600 },
+    ];
+
+    for (const { duration, expected } of cases) {
+      mockYouTubeClient.videos.list.mockResolvedValue({
+        data: { items: [{ snippet: { title: 'Test' }, contentDetails: { duration } }] }
+      });
+      const result = await fetchVideoMetadata('dQw4w9WgXcQ');
+      expect(result.durationSeconds).toBe(expected);
+    }
+  });
+});

--- a/lib/integrations/youtube/video-metadata.js
+++ b/lib/integrations/youtube/video-metadata.js
@@ -1,0 +1,77 @@
+/**
+ * YouTube Video Metadata Fetcher
+ * SD: SD-LEO-FDBK-FIX-EVALUATE-YOUTUBE-VIDEO-001
+ *
+ * Fetches video metadata (title, description, channel, tags, duration)
+ * from the YouTube Data API for use in classification enrichment.
+ *
+ * Uses existing OAuth infrastructure from oauth-manager.js.
+ * Fail-open: returns null on any error, never blocks the pipeline.
+ */
+
+import { google } from 'googleapis';
+import { getAuthenticatedClient } from './oauth-manager.js';
+
+/**
+ * Parse ISO 8601 duration (PT1H23M45S) to seconds.
+ * @param {string} duration
+ * @returns {number}
+ */
+function parseDuration(duration) {
+  if (!duration) return 0;
+  const match = duration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  if (!match) return 0;
+  return (parseInt(match[1] || 0) * 3600) +
+         (parseInt(match[2] || 0) * 60) +
+         parseInt(match[3] || 0);
+}
+
+/**
+ * Fetch video metadata from the YouTube Data API.
+ *
+ * @param {string} videoId - 11-character YouTube video ID
+ * @param {Object} [options]
+ * @param {boolean} [options.verbose=false]
+ * @returns {Promise<{title: string, description: string, channelName: string, tags: string[], durationSeconds: number, publishedAt: string}|null>}
+ */
+export async function fetchVideoMetadata(videoId, options = {}) {
+  if (!videoId || videoId.length !== 11) return null;
+
+  try {
+    const oauth2Client = await getAuthenticatedClient();
+    const youtube = google.youtube({ version: 'v3', auth: oauth2Client });
+
+    const response = await youtube.videos.list({
+      part: ['snippet', 'contentDetails'],
+      id: [videoId]
+    });
+
+    const video = response.data.items?.[0];
+    if (!video) {
+      if (options.verbose) console.log(`    YouTube: video ${videoId} not found or private`);
+      return null;
+    }
+
+    const metadata = {
+      title: video.snippet?.title || '',
+      description: video.snippet?.description || '',
+      channelName: video.snippet?.channelTitle || '',
+      tags: video.snippet?.tags || [],
+      durationSeconds: parseDuration(video.contentDetails?.duration),
+      publishedAt: video.snippet?.publishedAt || ''
+    };
+
+    if (options.verbose) {
+      console.log(`    YouTube metadata: "${metadata.title}" by ${metadata.channelName} (${metadata.durationSeconds}s)`);
+    }
+
+    return metadata;
+  } catch (err) {
+    if (options.verbose) {
+      console.log(`    YouTube metadata fetch failed: ${err.message}`);
+    }
+    return null;
+  }
+}
+
+export default { fetchVideoMetadata };


### PR DESCRIPTION
## Summary
- Adds `fetchVideoMetadata()` module using YouTube Data API v3 with OAuth2 authentication
- Integrates cache-first metadata lookup into evaluation-bridge.js (YouTube source → DB cache → API call)
- Enhances idea-classifier.js LLM prompt with rich video context (title, channel, description, tags) instead of generic hint

## SD
SD-LEO-FDBK-FIX-EVALUATE-YOUTUBE-VIDEO-001 — Evaluate YouTube Video Content for Brainstorm Classification

## Files Changed
| File | Change |
|------|--------|
| `lib/integrations/youtube/video-metadata.js` | **NEW** — YouTube Data API metadata fetcher (fail-open) |
| `lib/integrations/evaluation-bridge.js` | **MODIFIED** — Added step 1.7 cache-first metadata fetch |
| `lib/integrations/idea-classifier.js` | **MODIFIED** — Enhanced prompt with rich YouTube context |
| `lib/integrations/youtube/__tests__/video-metadata.test.js` | **NEW** — 8 unit tests |
| `lib/integrations/__tests__/youtube-metadata-integration.test.js` | **NEW** — 6 integration tests |

## Test plan
- [x] 14/14 unit tests passing (vitest)
- [x] Testing sub-agent PASS verdict
- [x] Fail-open behavior verified (null on API/OAuth errors)
- [x] Cache-first strategy minimizes API calls
- [x] Backward compatible (no signature changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)