### PR TITLE
feat(SD-LEO-FDBK-FEAT-VIDEO-EMPHASIZES-CEO-001): add Promoter Blueprint framework classification

### DIFF
--- a/lib/integrations/__tests__/promoter-blueprint.test.js
+++ b/lib/integrations/__tests__/promoter-blueprint.test.js
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for Promoter Blueprint framework integration.
+ * SD: SD-LEO-FDBK-FEAT-VIDEO-EMPHASIZES-CEO-001
+ */
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn()
+}));
+
+vi.mock('dotenv', () => ({
+  default: { config: vi.fn() },
+  config: vi.fn()
+}));
+
+vi.mock('../../llm/client-factory.js', () => ({
+  getClassificationClient: vi.fn()
+}));
+
+import { classifyIdea, detectFrameworkStage } from '../idea-classifier.js';
+import { formatPromotionContext } from '../evaluation-bridge.js';
+import { getClassificationClient } from '../../llm/client-factory.js';
+
+describe('detectFrameworkStage', () => {
+  it('detects traffic stage', () => {
+    expect(detectFrameworkStage('Drive more traffic with SEO and social media ads')).toBe('traffic');
+  });
+
+  it('detects holding_pattern stage', () => {
+    expect(detectFrameworkStage('Build an email sequence for nurture and engagement')).toBe('holding_pattern');
+  });
+
+  it('detects selling_event stage', () => {
+    expect(detectFrameworkStage('Create a landing page with call to action for the launch')).toBe('selling_event');
+  });
+
+  it('detects outcomes stage', () => {
+    expect(detectFrameworkStage('Track revenue and ROI from upsell campaigns')).toBe('outcomes');
+  });
+
+  it('returns null for non-promotion content', () => {
+    expect(detectFrameworkStage('Refactor the database migration script')).toBeNull();
+  });
+
+  it('picks the stage with most keyword matches', () => {
+    // "traffic" + "ad campaign" = 2 matches for traffic
+    // "landing page" = 1 match for selling_event
+    expect(detectFrameworkStage('Run an ad campaign to drive traffic to the landing page')).toBe('traffic');
+  });
+});
+
+describe('formatPromotionContext', () => {
+  it('returns null for non-promotion items', () => {
+    const item = { title: 'Fix database bug', description: 'Schema error in users table' };
+    expect(formatPromotionContext(item)).toBeNull();
+  });
+
+  it('detects promotion keywords in item title', () => {
+    const item = { title: 'Marketing campaign for product launch', description: '' };
+    const ctx = formatPromotionContext(item);
+    expect(ctx).not.toBeNull();
+    expect(ctx.isPromotionRelated).toBe(true);
+    expect(ctx.matchedKeywords).toContain('marketing');
+    expect(ctx.matchedKeywords).toContain('campaign');
+    expect(ctx.matchedKeywords).toContain('launch');
+    expect(ctx.source).toBe('text_analysis');
+  });
+
+  it('detects promotion keywords in description', () => {
+    const item = { title: 'Strategy doc', description: 'Build a funnel for lead generation and conversion' };
+    const ctx = formatPromotionContext(item);
+    expect(ctx).not.toBeNull();
+    expect(ctx.matchedKeywords).toContain('funnel');
+    expect(ctx.matchedKeywords).toContain('lead generation');
+    expect(ctx.matchedKeywords).toContain('conversion');
+  });
+
+  it('includes YouTube metadata in keyword detection', () => {
+    const item = { title: 'Watch this video', description: '' };
+    const ytMeta = { title: 'Go To Market Launch Strategy', description: 'Traffic generation tips' };
+    const ctx = formatPromotionContext(item, ytMeta);
+    expect(ctx).not.toBeNull();
+    expect(ctx.matchedKeywords).toContain('traffic');
+    expect(ctx.matchedKeywords).toContain('go to market');
+    expect(ctx.source).toBe('youtube_enriched');
+  });
+
+  it('returns correct keywordCount', () => {
+    const item = { title: 'Revenue and conversion from marketing campaigns', description: '' };
+    const ctx = formatPromotionContext(item);
+    expect(ctx.keywordCount).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('classifyIdea with promoter_blueprint categories', () => {
+  let mockSupabase;
+  let mockLLMClient;
+
+  const categories = [
+    { category_type: 'venture_tag', code: 'ehg_core', label: 'EHG Core', classification_keywords: ['platform', 'core'] },
+    { category_type: 'venture_tag', code: 'promoter_blueprint', label: 'Promoter Blueprint', classification_keywords: ['traffic', 'promotion', 'GTM', 'launch', 'conversion', 'selling', 'revenue generation', 'campaign', 'marketing'] },
+    { category_type: 'business_function', code: 'feature_idea', label: 'Feature', classification_keywords: ['feature', 'add'] },
+    { category_type: 'business_function', code: 'promotion_strategy', label: 'Promotion Strategy', classification_keywords: ['promote', 'marketing strategy', 'GTM strategy', 'campaign strategy'] },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSupabase = {
+      from: vi.fn().mockImplementation(() => ({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockImplementation((col) => {
+            if (col === 'is_active') {
+              return { order: vi.fn().mockResolvedValue({ data: categories }) };
+            }
+            return {
+              maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+              neq: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue({ data: [] })
+                })
+              })
+            };
+          })
+        })
+      }))
+    };
+
+    mockLLMClient = { complete: vi.fn() };
+    getClassificationClient.mockResolvedValue(mockLLMClient);
+  });
+
+  it('includes promotion framework hint in LLM prompt', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "promoter_blueprint", "business_function": "promotion_strategy", "confidence": 0.9}'
+    );
+
+    await classifyIdea('Launch a traffic campaign for revenue growth', 'Drive conversion through marketing', {
+      supabase: mockSupabase,
+      item: { todoist_task_id: '123' }
+    });
+
+    const prompt = mockLLMClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('Promotion Framework Signal');
+    expect(prompt).toContain('Promoter Blueprint');
+  });
+
+  it('adds framework_stage when classified as promoter_blueprint', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "promoter_blueprint", "business_function": "promotion_strategy", "confidence": 0.85}'
+    );
+
+    const result = await classifyIdea('Build a landing page with conversion tracking', '', {
+      supabase: mockSupabase,
+      item: { todoist_task_id: '123' }
+    });
+
+    expect(result.venture_tag).toBe('promoter_blueprint');
+    expect(result.framework_stage).toBe('selling_event');
+  });
+
+  it('uses keyword fallback for promotion classification when LLM fails', async () => {
+    getClassificationClient.mockRejectedValue(new Error('API unavailable'));
+
+    const result = await classifyIdea('Marketing campaign strategy', 'GTM launch promotion selling', {
+      supabase: mockSupabase,
+      item: { todoist_task_id: '123' }
+    });
+
+    expect(result.venture_tag).toBe('promoter_blueprint');
+    expect(result.confidence_score).toBe(0.5);
+  });
+
+  it('does not add framework_stage for non-promotion items', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "ehg_core", "business_function": "feature_idea", "confidence": 0.8}'
+    );
+
+    const result = await classifyIdea('Refactor database queries', '', {
+      supabase: mockSupabase,
+      item: { todoist_task_id: '123' }
+    });
+
+    expect(result.venture_tag).toBe('ehg_core');
+    expect(result.framework_stage).toBeUndefined();
+  });
+
+  it('does not include promotion hint for non-marketing content', async () => {
+    mockLLMClient.complete.mockResolvedValue(
+      '{"venture_tag": "ehg_core", "business_function": "feature_idea", "confidence": 0.8}'
+    );
+
+    await classifyIdea('Fix the CI pipeline', 'Build system is broken', {
+      supabase: mockSupabase,
+      item: { todoist_task_id: '123' }
+    });
+
+    const prompt = mockLLMClient.complete.mock.calls[0][1];
+    expect(prompt).not.toContain('Promotion Framework Signal');
+  });
+});

--- a/lib/integrations/evaluation-bridge.js
+++ b/lib/integrations/evaluation-bridge.js
@@ -18,6 +18,34 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 /**
+ * Format promotion context for classification enrichment.
+ * When an item has marketing/promotion signals, this builds additional
+ * context that helps the classifier assign the correct category.
+ * @param {Object} item - Intake row
+ * @param {Object|null} youtubeMetadata - YouTube metadata if available
+ * @returns {Object|null} Promotion context or null
+ */
+export function formatPromotionContext(item, youtubeMetadata = null) {
+  const promotionKeywords = [
+    'traffic', 'promotion', 'gtm', 'launch', 'conversion', 'selling',
+    'revenue', 'campaign', 'marketing', 'funnel', 'landing page',
+    'go to market', 'content marketing', 'lead generation'
+  ];
+
+  const text = `${item.title || ''} ${item.description || ''} ${youtubeMetadata?.title || ''} ${youtubeMetadata?.description || ''}`.toLowerCase();
+  const matches = promotionKeywords.filter(kw => text.includes(kw));
+
+  if (matches.length === 0) return null;
+
+  return {
+    isPromotionRelated: true,
+    matchedKeywords: matches,
+    keywordCount: matches.length,
+    source: youtubeMetadata ? 'youtube_enriched' : 'text_analysis'
+  };
+}
+
+/**
  * Create Supabase client
  * @returns {import('@supabase/supabase-js').SupabaseClient}
  */
@@ -126,9 +154,11 @@ async function evaluateItem(item, sourceType, options = {}) {
       }
     }
 
-    // 2. Classify (pass full item for hierarchy context + YouTube metadata)
+    // 2. Classify (pass full item for hierarchy context + YouTube metadata + promotion context)
     const classifyItem = extractedYouTubeId ? { ...item, extracted_youtube_id: extractedYouTubeId } : item;
     if (youtubeMetadata) classifyItem.youtube_metadata = youtubeMetadata;
+    const promotionContext = formatPromotionContext(item, youtubeMetadata);
+    if (promotionContext) classifyItem.promotion_context = promotionContext;
     const classification = await classifyIdea(item.title, item.description, { supabase, verbose: options.verbose, item: classifyItem });
     result.classification = classification;
 

--- a/lib/integrations/idea-classifier.js
+++ b/lib/integrations/idea-classifier.js
@@ -30,6 +30,33 @@ async function loadCategories(supabase) {
 }
 
 /**
+ * Detect which Promoter Blueprint framework stage an item maps to.
+ * Stages: traffic → holding_pattern → selling_event → outcomes
+ * @param {string} text - Combined title + description
+ * @returns {string|null} Framework stage or null if not promotion-related
+ */
+function detectFrameworkStage(text) {
+  const lower = text.toLowerCase();
+  const stageKeywords = {
+    traffic: ['traffic', 'audience growth', 'lead generation', 'content marketing', 'seo', 'social media', 'ad campaign'],
+    holding_pattern: ['holding pattern', 'nurture', 'email sequence', 'newsletter', 'community', 'engagement', 'follow-up'],
+    selling_event: ['selling event', 'launch', 'webinar', 'sales page', 'landing page', 'conversion', 'call to action', 'checkout'],
+    outcomes: ['revenue', 'roi', 'retention', 'lifetime value', 'upsell', 'referral', 'customer success']
+  };
+
+  let bestStage = null;
+  let bestScore = 0;
+  for (const [stage, keywords] of Object.entries(stageKeywords)) {
+    const score = keywords.filter(kw => lower.includes(kw)).length;
+    if (score > bestScore) {
+      bestStage = stage;
+      bestScore = score;
+    }
+  }
+  return bestScore > 0 ? bestStage : null;
+}
+
+/**
  * Build classification prompt for the LLM
  * @param {string} title
  * @param {string} description
@@ -72,10 +99,18 @@ function buildClassificationPrompt(title, description, categories, hierarchy = {
     }
   }
 
+  // Detect promotion framework stage for enrichment
+  let promotionHint = '';
+  const combinedForDetection = `${title} ${description || ''}`;
+  const frameworkStage = detectFrameworkStage(combinedForDetection);
+  if (frameworkStage) {
+    promotionHint = `\nPromotion Framework Signal: This item maps to the "${frameworkStage}" stage of the Promoter Blueprint (Traffic → Holding Pattern → Selling Event → Outcomes). Consider promoter_blueprint as venture_tag and promotion_strategy as business_function.\n`;
+  }
+
   return `Classify this idea into exactly one venture_tag and one business_function.
 
 Title: ${title}
-Description: ${description || 'No description'}${hierarchySection}${youtubeHint}
+Description: ${description || 'No description'}${hierarchySection}${youtubeHint}${promotionHint}
 
 Venture Tags (pick one):
 ${ventureOptions}
@@ -221,7 +256,14 @@ export async function classifyIdea(title, description, options = {}) {
     );
     const result = parseClassificationResponse(content);
 
-    if (result) return result;
+    if (result) {
+      // Enrich with framework stage if promoter_blueprint
+      if (result.venture_tag === 'promoter_blueprint' || result.business_function === 'promotion_strategy') {
+        const stage = detectFrameworkStage(combinedText);
+        if (stage) result.framework_stage = stage;
+      }
+      return result;
+    }
   } catch (err) {
     // LLM unavailable - fall through to keyword-based
     if (options.verbose) {
@@ -230,7 +272,14 @@ export async function classifyIdea(title, description, options = {}) {
   }
 
   // Fallback to keyword-based classification
-  return keywordClassify(combinedText, categories);
+  const fallback = keywordClassify(combinedText, categories);
+  // Enrich fallback with framework stage if promoter_blueprint
+  if (fallback.venture_tag === 'promoter_blueprint' || fallback.business_function === 'promotion_strategy') {
+    const stage = detectFrameworkStage(combinedText);
+    if (stage) fallback.framework_stage = stage;
+  }
+  return fallback;
 }
 
-export default { classifyIdea };
+export { detectFrameworkStage };
+export default { classifyIdea, detectFrameworkStage };


### PR DESCRIPTION
## Summary
- Add `detectFrameworkStage()` to classify intake items into Promoter Blueprint stages (Traffic → Holding Pattern → Selling Event → Outcomes)
- Add `formatPromotionContext()` to detect promotion keywords in items and YouTube metadata
- Enrich LLM classification prompt with promotion framework signals when keywords are detected
- Add 16 unit tests covering all framework stages, keyword detection, and classification integration

## Test plan
- [x] All 30 tests pass (16 new + 14 existing)
- [x] `detectFrameworkStage` correctly identifies all 4 stages and returns null for non-promotion content
- [x] `formatPromotionContext` detects keywords in title, description, and YouTube metadata
- [x] `classifyIdea` includes promotion hint in LLM prompt and adds `framework_stage` for promoter_blueprint items

🤖 Generated with [Claude Code](https://claude.com/claude-code)