### PR TITLE
feat(SD-LEO-FDBK-FEAT-VIDEO-EMPHASIZES-CEO-002): add Marketing Asset Generator

### DIFF
--- a/lib/integrations/__tests__/marketing-asset-generator.test.js
+++ b/lib/integrations/__tests__/marketing-asset-generator.test.js
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests for Marketing Asset Generator.
+ * SD: SD-LEO-FDBK-FEAT-VIDEO-EMPHASIZES-CEO-002
+ */
+
+vi.mock('../../llm/client-factory.js', () => ({
+  getFastClient: vi.fn()
+}));
+
+import { generateLandingPage, generateAdCopy } from '../marketing-asset-generator.js';
+import { getFastClient } from '../../llm/client-factory.js';
+
+describe('generateLandingPage', () => {
+  let mockClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = { complete: vi.fn() };
+    getFastClient.mockResolvedValue(mockClient);
+  });
+
+  it('returns LLM-generated HTML when available', async () => {
+    const mockHtml = '<!DOCTYPE html><html lang="en"><head><title>Test</title></head><body><h1>Test</h1></body></html>';
+    mockClient.complete.mockResolvedValue(mockHtml);
+
+    const result = await generateLandingPage({ title: 'My Campaign' });
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('<html');
+  });
+
+  it('passes campaign parameters to LLM prompt', async () => {
+    mockClient.complete.mockResolvedValue('<!DOCTYPE html><html><body></body></html>');
+
+    await generateLandingPage({
+      title: 'Launch Event',
+      description: 'Join our webinar',
+      ctaText: 'Register Now',
+      stage: 'selling_event'
+    });
+
+    const prompt = mockClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('Launch Event');
+    expect(prompt).toContain('Join our webinar');
+    expect(prompt).toContain('Register Now');
+    expect(prompt).toContain('selling_event');
+  });
+
+  it('returns fallback HTML when LLM fails', async () => {
+    getFastClient.mockRejectedValue(new Error('API unavailable'));
+
+    const result = await generateLandingPage({ title: 'Fallback Test', ctaText: 'Click Here' });
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('Fallback Test');
+    expect(result).toContain('Click Here');
+  });
+
+  it('returns fallback when LLM returns non-HTML', async () => {
+    mockClient.complete.mockResolvedValue('Sorry, I cannot generate HTML right now.');
+
+    const result = await generateLandingPage({ title: 'Non-HTML Response' });
+    expect(result).toContain('<!DOCTYPE html>');
+    expect(result).toContain('Non-HTML Response');
+  });
+
+  it('fallback HTML is mobile-responsive', async () => {
+    getFastClient.mockRejectedValue(new Error('API unavailable'));
+
+    const result = await generateLandingPage({ title: 'Mobile Test' });
+    expect(result).toContain('viewport');
+    expect(result).toContain('@media');
+  });
+
+  it('fallback HTML has self-contained styles', async () => {
+    getFastClient.mockRejectedValue(new Error('API unavailable'));
+
+    const result = await generateLandingPage({ title: 'Style Test' });
+    expect(result).toContain('<style>');
+    expect(result).not.toContain('stylesheet');
+  });
+
+  it('escapes HTML in parameters to prevent XSS', async () => {
+    getFastClient.mockRejectedValue(new Error('API unavailable'));
+
+    const result = await generateLandingPage({ title: '<script>alert("xss")</script>' });
+    expect(result).not.toContain('<script>alert');
+    expect(result).toContain('&lt;script&gt;');
+  });
+
+  it('uses default values when parameters are missing', async () => {
+    getFastClient.mockRejectedValue(new Error('API unavailable'));
+
+    const result = await generateLandingPage({});
+    expect(result).toContain('Your Next Step');
+    expect(result).toContain('Get Started');
+  });
+});
+
+describe('generateAdCopy', () => {
+  let mockClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = { complete: vi.fn() };
+    getFastClient.mockResolvedValue(mockClient);
+  });
+
+  it('returns LLM-generated ad copy variants', async () => {
+    const mockResponse = JSON.stringify([
+      { headline: 'Boost Your Revenue', body: 'Start today with our proven system.' },
+      { headline: 'Traffic That Converts', body: 'Drive qualified leads to your offer.' },
+      { headline: 'Scale Your Business', body: 'From zero to hero in 30 days.' }
+    ]);
+    mockClient.complete.mockResolvedValue(mockResponse);
+
+    const result = await generateAdCopy({ product: 'Marketing Suite' });
+    expect(result).toHaveLength(3);
+    expect(result[0].headline).toBe('Boost Your Revenue');
+    expect(result[0].body).toContain('proven system');
+  });
+
+  it('returns at least 3 variants', async () => {
+    const mockResponse = JSON.stringify([
+      { headline: 'A', body: 'A body' },
+      { headline: 'B', body: 'B body' },
+      { headline: 'C', body: 'C body' }
+    ]);
+    mockClient.complete.mockResolvedValue(mockResponse);
+
+    const result = await generateAdCopy({ product: 'Test' });
+    expect(result.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('each variant has headline and body', async () => {
+    const mockResponse = JSON.stringify([
+      { headline: 'H1', body: 'B1' },
+      { headline: 'H2', body: 'B2' },
+      { headline: 'H3', body: 'B3' }
+    ]);
+    mockClient.complete.mockResolvedValue(mockResponse);
+
+    const result = await generateAdCopy({ product: 'Widget' });
+    result.forEach(variant => {
+      expect(variant).toHaveProperty('headline');
+      expect(variant).toHaveProperty('body');
+      expect(typeof variant.headline).toBe('string');
+      expect(typeof variant.body).toBe('string');
+    });
+  });
+
+  it('returns fallback ad copy when LLM fails', async () => {
+    getFastClient.mockRejectedValue(new Error('API unavailable'));
+
+    const result = await generateAdCopy({ product: 'My Product', benefit: 'save time' });
+    expect(result).toHaveLength(3);
+    expect(result[0].headline).toContain('My Product');
+    expect(result[0].body).toContain('save time');
+  });
+
+  it('returns fallback when LLM returns invalid JSON', async () => {
+    mockClient.complete.mockResolvedValue('This is not JSON');
+
+    const result = await generateAdCopy({ product: 'Fallback Product' });
+    expect(result).toHaveLength(3);
+    expect(result[0]).toHaveProperty('headline');
+    expect(result[0]).toHaveProperty('body');
+  });
+
+  it('passes product details to LLM prompt', async () => {
+    mockClient.complete.mockResolvedValue(JSON.stringify([
+      { headline: 'A', body: 'B' },
+      { headline: 'C', body: 'D' },
+      { headline: 'E', body: 'F' }
+    ]));
+
+    await generateAdCopy({
+      product: 'EHG Platform',
+      benefit: 'automate your business',
+      audience: 'startup founders',
+      stage: 'traffic'
+    });
+
+    const prompt = mockClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('EHG Platform');
+    expect(prompt).toContain('automate your business');
+    expect(prompt).toContain('startup founders');
+    expect(prompt).toContain('traffic');
+  });
+
+  it('strips markdown code fences from LLM response', async () => {
+    mockClient.complete.mockResolvedValue('```json\n[{"headline":"H","body":"B"},{"headline":"H2","body":"B2"},{"headline":"H3","body":"B3"}]\n```');
+
+    const result = await generateAdCopy({ product: 'Test' });
+    expect(result).toHaveLength(3);
+    expect(result[0].headline).toBe('H');
+  });
+
+  it('returns fallback when LLM returns incomplete variants', async () => {
+    mockClient.complete.mockResolvedValue(JSON.stringify([
+      { headline: 'Only one' }
+    ]));
+
+    const result = await generateAdCopy({ product: 'Test' });
+    expect(result).toHaveLength(3);
+    // Should be fallback since response was incomplete
+    expect(result[0]).toHaveProperty('body');
+  });
+
+  it('requests more variants when params.variants > 3', async () => {
+    mockClient.complete.mockResolvedValue(JSON.stringify([
+      { headline: 'A', body: 'B' },
+      { headline: 'C', body: 'D' },
+      { headline: 'E', body: 'F' },
+      { headline: 'G', body: 'H' },
+      { headline: 'I', body: 'J' }
+    ]));
+
+    await generateAdCopy({ product: 'Test', variants: 5 });
+    const prompt = mockClient.complete.mock.calls[0][1];
+    expect(prompt).toContain('5 ad copy variants');
+  });
+});

--- a/lib/integrations/marketing-asset-generator.js
+++ b/lib/integrations/marketing-asset-generator.js
@@ -1,0 +1,174 @@
+/**
+ * Marketing Asset Generator
+ * SD: SD-LEO-FDBK-FEAT-VIDEO-EMPHASIZES-CEO-002
+ *
+ * Generates HTML landing pages and ad copy variants for Promoter Blueprint
+ * campaigns using LLM completion with fallback templates.
+ */
+
+import { getFastClient } from '../llm/client-factory.js';
+
+/**
+ * Fallback landing page template when LLM is unavailable
+ * @param {Object} params
+ * @returns {string} HTML string
+ */
+function fallbackLandingPage(params) {
+  const title = params.title || 'Your Next Step';
+  const description = params.description || 'Discover how we can help you achieve your goals.';
+  const ctaText = params.ctaText || 'Get Started';
+  const ctaUrl = params.ctaUrl || '#';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1a1a2e;background:#f8f9fa}
+.hero{max-width:640px;margin:60px auto;padding:40px 24px;text-align:center}
+h1{font-size:2rem;margin-bottom:16px;line-height:1.3}
+p{font-size:1.125rem;color:#4a4a6a;margin-bottom:32px;line-height:1.6}
+.cta{display:inline-block;padding:14px 32px;background:#2563eb;color:#fff;text-decoration:none;border-radius:8px;font-size:1rem;font-weight:600}
+.cta:hover{background:#1d4ed8}
+@media(max-width:480px){.hero{padding:32px 16px}h1{font-size:1.5rem}}
+</style>
+</head>
+<body>
+<div class="hero">
+<h1>${escapeHtml(title)}</h1>
+<p>${escapeHtml(description)}</p>
+<a href="${escapeHtml(ctaUrl)}" class="cta">${escapeHtml(ctaText)}</a>
+</div>
+</body>
+</html>`;
+}
+
+/**
+ * Fallback ad copy when LLM is unavailable
+ * @param {Object} params
+ * @returns {Array<{headline: string, body: string}>}
+ */
+function fallbackAdCopy(params) {
+  const product = params.product || params.title || 'our solution';
+  const benefit = params.benefit || 'transform your results';
+  return [
+    { headline: `Discover ${product}`, body: `Ready to ${benefit}? Start today and see the difference.` },
+    { headline: `Why ${product} works`, body: `Join others who have already achieved results with ${product}.` },
+    { headline: `${product} — limited time`, body: `Act now to ${benefit}. Don't miss this opportunity.` }
+  ];
+}
+
+/**
+ * Escape HTML entities to prevent XSS in generated output
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Generate an HTML landing page for a campaign.
+ * @param {Object} params - Campaign parameters
+ * @param {string} params.title - Campaign/product title
+ * @param {string} [params.description] - Campaign description
+ * @param {string} [params.ctaText] - Call-to-action button text
+ * @param {string} [params.ctaUrl] - CTA destination URL
+ * @param {string} [params.stage] - Promoter Blueprint stage (traffic|holding_pattern|selling_event|outcomes)
+ * @param {string} [params.tone] - Desired tone (professional|casual|urgent)
+ * @returns {Promise<string>} Self-contained HTML string
+ */
+export async function generateLandingPage(params = {}) {
+  try {
+    const client = await getFastClient();
+    const stage = params.stage || 'selling_event';
+    const tone = params.tone || 'professional';
+
+    const systemPrompt = 'You are a marketing landing page generator. Return ONLY valid HTML. No markdown, no explanation, no code fences.';
+    const userPrompt = `Create a self-contained HTML landing page with these requirements:
+- Title: ${params.title || 'Campaign Page'}
+- Description: ${params.description || 'A compelling campaign page'}
+- CTA button text: ${params.ctaText || 'Get Started'}
+- CTA URL: ${params.ctaUrl || '#'}
+- Promoter Blueprint stage: ${stage}
+- Tone: ${tone}
+
+Requirements:
+- Valid HTML5 with DOCTYPE
+- All CSS inline in a <style> tag (no external stylesheets)
+- Mobile-responsive (use media queries)
+- Clean, modern design
+- Prominent CTA button
+- lang="en" on html tag`;
+
+    const html = await client.complete(systemPrompt, userPrompt, { maxTokens: 2000 });
+
+    // Basic validation: must contain <!DOCTYPE or <html
+    if (html && (html.includes('<!DOCTYPE') || html.includes('<html'))) {
+      return html.trim();
+    }
+
+    // LLM returned non-HTML, use fallback
+    return fallbackLandingPage(params);
+  } catch (err) {
+    // LLM unavailable, use fallback template
+    return fallbackLandingPage(params);
+  }
+}
+
+/**
+ * Generate ad copy variants for a campaign.
+ * @param {Object} params - Product/offer details
+ * @param {string} params.product - Product or service name
+ * @param {string} [params.benefit] - Key benefit/value proposition
+ * @param {string} [params.audience] - Target audience description
+ * @param {string} [params.stage] - Promoter Blueprint stage
+ * @param {number} [params.variants] - Number of variants (default: 3, min: 3)
+ * @returns {Promise<Array<{headline: string, body: string}>>} Ad copy variants
+ */
+export async function generateAdCopy(params = {}) {
+  const variantCount = Math.max(3, params.variants || 3);
+
+  try {
+    const client = await getFastClient();
+
+    const systemPrompt = 'You are an ad copywriter. Return ONLY a valid JSON array. No markdown, no explanation, no code fences.';
+    const userPrompt = `Generate ${variantCount} ad copy variants as a JSON array.
+
+Product: ${params.product || params.title || 'Our Product'}
+Key benefit: ${params.benefit || 'achieve better results'}
+Target audience: ${params.audience || 'business professionals'}
+Promoter Blueprint stage: ${params.stage || 'traffic'}
+
+Return format (JSON array only):
+[{"headline": "...", "body": "..."}, ...]
+
+Each variant should have a different angle or hook. Headlines should be under 60 characters. Body text should be 1-2 sentences.`;
+
+    const response = await client.complete(systemPrompt, userPrompt, { maxTokens: 1000 });
+
+    // Parse JSON response
+    const cleaned = response.replace(/```json?\n?/g, '').replace(/```/g, '').trim();
+    const variants = JSON.parse(cleaned);
+
+    if (Array.isArray(variants) && variants.length >= 3 &&
+        variants.every(v => v.headline && v.body)) {
+      return variants;
+    }
+
+    return fallbackAdCopy(params);
+  } catch (err) {
+    // LLM unavailable or parse failure, use fallback
+    return fallbackAdCopy(params);
+  }
+}
+
+export default { generateLandingPage, generateAdCopy };


### PR DESCRIPTION
## Summary
- Adds `lib/integrations/marketing-asset-generator.js` with LLM-powered landing page and ad copy generation
- Includes fallback HTML templates when LLM is unavailable
- XSS prevention via HTML entity escaping in all user-facing output
- 17 unit tests covering success paths, fallbacks, and edge cases

## Test plan
- [x] All 17 new tests pass (`vitest marketing-asset-generator`)
- [x] Existing 22 tests unaffected (39 total pass)
- [x] Fallback templates render valid HTML5 with viewport meta
- [x] XSS injection in parameters is escaped

🤖 Generated with [Claude Code](https://claude.com/claude-code)