### PR TITLE
docs: Chairman Web UI vision, architecture, and brainstorm

### DIFF
--- a/brainstorm/2026-02-25-chairman-web-ui-hybrid-dashboard.md
+++ b/brainstorm/2026-02-25-chairman-web-ui-hybrid-dashboard.md
@@ -1,0 +1,142 @@
+# Brainstorm: Chairman Web UI — Hybrid Dashboard + Claude Code Remote
+
+## Metadata
+- **Date**: 2026-02-25
+- **Domain**: Architecture
+- **Phase**: Explore
+- **Mode**: Conversational
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: All active ventures (portfolio-wide governance surface)
+
+---
+
+## Problem Statement
+
+The EHG venture lifecycle (25 stages, 6 phases) requires chairman governance at specific intervention points: 3 blocking gates (stages 10, 22, 25), 1 routing decision (stage 0), and 5 advisory notifications. Currently there is no dedicated governance UI — the existing EHG app is cluttered, Telegram was explored but rejected by the chairman, and the CLI serves the builder persona but not the governance persona.
+
+The chairman and solo entrepreneur are the **same person wearing different hats**. The UI must serve both personas with clean context-switching, support both desktop and mobile equally, and optimize for **batched daily review** (not real-time). Anthropic's new Claude Code on the Web provides browser/mobile access to Claude Code, enabling a hybrid pattern: read state in the dashboard, change state via Claude Code Remote.
+
+## Discovery Summary
+
+### Personas
+- **Chairman**: Governance decisions, portfolio oversight, vision alignment, venture lifecycle monitoring
+- **Solo Entrepreneur**: Build queue, active SDs, brainstorm capture, protocol enhancement
+- Same person, different cognitive modes — the UI adapts context, not access control
+
+### Decision Timing
+- Batched daily review preferred
+- 24h auto-approve timeout exists as backstop for blocking gates
+- Low urgency, high information density needed
+
+### Information Architecture (from Telegram Forum Topics)
+Already designed and validated:
+
+| Topic | Persona | Read/Write | Description |
+|-------|---------|-----------|-------------|
+| Daily Briefing | Chairman | Read | Morning summary, portfolio pulse, aggregate health |
+| Decisions | Chairman | Write | Approve/reject/park with context, audit trail |
+| Venture Lifecycle | Chairman | Read | 25-stage touchpoints, kill gates, stage progression |
+| Vision & Alignment | Chairman | Read | HEAL scores, drift detection, correction alerts |
+| Active SDs | Builder | Read | In-progress SD details, phase, progress, blockers |
+| Build Queue | Builder | Read | SD pipeline, prioritized queue |
+| Inbox | Builder | Write | Unified inbox + brainstorm capture |
+| Alerts | Shared | Read | Proactive push notifications for both personas |
+
+### Claude Code on the Web Integration
+- Not an embed — Claude Code Remote is a link-out / context-handoff
+- Pattern: Dashboard shows context → "Open in Claude Code" button → copies structured context or deep-links
+- Enables: see state (dashboard) → change state (Claude Code) → see result (dashboard)
+
+### Repo Decision
+- **Build in `rickfelix/ehg`** as `/chairman` route group
+- Reuses: Auth, Supabase client, Shadcn UI, Tailwind, Vite
+- Can extract to standalone if it outgrows the EHG app
+
+## Analysis
+
+### Arguments For
+1. **Forces the protocol to develop a governance layer** — human-readable summaries, decision abstractions, governance APIs
+2. **The IA is already designed** — Telegram topics map 1:1 to UI views, reducing design risk to near zero
+3. **Only 4 actual decision surfaces** — scope is genuinely small (3 blocking gates + 1 routing)
+4. **Closes the governance loop** — see state (dashboard) → change state (Claude Code Remote) → see result (dashboard)
+5. **PWA evolution is trivial** — manifest.json + service worker + HTTPS (Vercel) = afternoon of work
+
+### Arguments Against
+1. **Auto-approve backstop + Telegram may already be sufficient** — especially for batched daily review
+2. **Low-frequency tools get abandoned** — if opened once a day, habit formation is hard; needs very high information density
+3. **"Hybrid" is two separate tools** — Claude Code Remote doesn't embed; integration is deep-link at best
+4. **Existing EHG app could be refactored** — targeted declutter may achieve 80% of the value at 20% of the cost
+
+## Architecture: Tradeoff Matrix
+
+### Repo/Deployment Options Evaluated
+
+| Dimension | Weight | A: EHG app routes | B: EHG_Engineer subfolder | C: Fresh repo |
+|-----------|--------|-------------------|--------------------------|---------------|
+| Complexity | 20% | 9 | 5 | 4 |
+| Maintainability | 25% | 6 | 8 | 7 |
+| Performance | 20% | 8 | 8 | 8 |
+| Migration effort | 15% | 9 | 6 | 4 |
+| Future flexibility | 20% | 7 | 9 | 8 |
+| **Weighted** | | **7.65** | **7.35** | **6.30** |
+
+**Decision**: Option A (EHG app `/chairman` routes) — fastest path, auth/Supabase/Shadcn ready
+
+### Proposed View Architecture
+
+```
+/chairman (landing — Daily Briefing + Decision Queue summary)
+  /chairman/decisions (blocking gates with full context)
+  /chairman/ventures (lifecycle stage map across all ventures)
+  /chairman/vision (HEAL scores, drift, alignment)
+  /chairman/preferences (risk tolerance, budget caps, notifications)
+
+/builder (landing — Active SDs + Build Queue)
+  /builder/queue (prioritized SD pipeline)
+  /builder/inbox (brainstorm capture, unified notifications)
+```
+
+### Phase Plan
+
+| Phase | Scope | Est. Hours |
+|-------|-------|-----------|
+| 1: Read-only dashboard | 5 advisory views wired to Supabase | 8-12h |
+| 2: Decision gates | 4 interactive decision surfaces | 6-10h |
+| 3: PWA shell | Service worker, manifest, install prompt | 4-6h |
+| 4: Claude Code Remote | Context-passing pattern (deep-link/clipboard) | 2-4h |
+| **Total** | | **20-32h** |
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: (1) Telegram already surfaces the same info — why isn't it enough? (2) Same-person persona switching is cognitively expensive — UI may optimize for wrong interaction pattern. (3) Desktop-first won't gracefully evolve to mobile PWA.
+- **Assumptions at Risk**: (1) Claude Code Remote creates a coherent hybrid — in practice it's two separate tools. (2) Existing EHG app is a liability — refactoring may be cheaper. (3) Low urgency = forgiving UI quality — actually means low usage frequency = abandonment risk.
+- **Worst Case**: UI built, used 3 weeks, abandoned in favor of Telegram + auto-approve. Becomes maintenance debt.
+
+### Visionary
+- **Opportunities**: (1) Chairman UI forces LEO to graduate from dev tool to governance system. (2) Dual-persona toggle is a reusable product archetype for solo founders. (3) Claude Code Remote enables spawning protocol actions from the governance surface.
+- **Synergies**: HEAL loop → Daily Briefing narrative signals. EVA pipeline → decision queue with 4 intervention points. Telegram as notification bus, UI as action surface.
+- **Upside Scenario**: Chairman reviews Daily Briefing on mobile → HEAL flags venture drift → taps into Claude Code Remote → issues protocol directive → LEO picks it up → next briefing reflects correction. Full governance loop in under 10 minutes from a phone.
+
+### Pragmatist
+- **Feasibility**: 3/10 difficulty (very achievable)
+- **Resource Requirements**: ~20-32h, zero additional cost (Supabase running, Vercel free tier)
+- **Constraints**: (1) Repo choice compounds — build in EHG app to avoid re-wiring auth. (2) PWA is a deployment decision, not architecture — add it in an afternoon. (3) Check RLS policies on chairman_decisions, venture_artifacts before writing components.
+- **Recommended Path**: Start with one read-only view (Active SDs), prove data flows, then expand.
+
+### Synthesis
+- **Consensus**: Telegram IA is the blueprint. PWA is trivial. Claude Code Remote is a link-out, not an embed.
+- **Tension**: Build vs. don't build at all. Dashboard vs. decision queue. New app vs. refactor existing.
+- **Composite Risk**: Low-Medium (technical: low, adoption: medium)
+
+## Open Questions
+1. Should the Daily Briefing be auto-generated by EVA and stored in a table, or computed on-render?
+2. What RLS policies exist on chairman_decisions, venture_artifacts, chairman_preferences?
+3. Should the builder views expose LEO protocol enhancement capabilities (e.g., editing gate thresholds from UI)?
+4. How should Claude Code Remote context be structured for handoff (JSON blob? natural language summary? URL params?)
+
+## Suggested Next Steps
+1. **Create an SD** for the Chairman Web UI build (Phase 1: read-only dashboard)
+2. **Audit RLS policies** on relevant Supabase tables before any UI work
+3. **Prototype**: Add `/chairman` route to EHG app with one Supabase query to validate the approach

--- a/docs/plans/chairman-web-ui-architecture.md
+++ b/docs/plans/chairman-web-ui-architecture.md
@@ -1,0 +1,513 @@
+# Chairman Web UI — Architecture Plan
+
+**Version**: 1.0.0
+**Date**: 2026-02-25
+**Status**: Draft
+**Companion**: `docs/plans/chairman-web-ui-vision.md`
+
+---
+
+## 1. Overview
+
+This document defines the technical architecture for the Chairman Web UI: a focused governance and portfolio management interface built as new route groups in the existing EHG app (`rickfelix/ehg`).
+
+---
+
+## 2. Repository & Stack
+
+### 2.1 Repo: `rickfelix/ehg`
+
+**Rationale** (from tradeoff matrix, weighted score 7.65/10):
+- Auth (Supabase Auth) already wired
+- Supabase client configured
+- Shadcn UI + Tailwind + Vite + React + TypeScript proven
+- Zero migration effort — add new route groups
+
+### 2.2 Tech Stack (inherited)
+
+| Layer | Technology | Notes |
+|-------|-----------|-------|
+| Framework | React 18+ | Existing |
+| Build | Vite | Existing |
+| Language | TypeScript | Existing |
+| UI Components | Shadcn UI | Existing — Card, Table, Badge, Button, Sheet, Tabs |
+| Styling | Tailwind CSS | Existing — responsive utilities for mobile |
+| Data | Supabase JS Client | Existing — `@supabase/supabase-js` |
+| Auth | Supabase Auth | Existing — `ProtectedRoute` component |
+| State | @tanstack/react-query | Existing — cache, refetch, stale-while-revalidate |
+| Routing | react-router-dom | Existing |
+| Charts | Recharts | Existing — for HEAL score trends, health visualizations |
+| Hosting | Vercel | Existing — HTTPS, edge CDN |
+
+### 2.3 New Dependencies
+
+None required. The existing stack covers all needs.
+
+---
+
+## 3. Legacy Deprecation Plan
+
+### 3.1 Existing Chairman Pages (to be superseded)
+
+The current EHG app has 10+ chairman routes built across multiple SDs. These are **not deleted immediately** but are superseded by the new views:
+
+| Existing Route | Existing Component | Superseded By | Deprecation Action |
+|---|---|---|---|
+| `/chairman` | BriefingDashboard | `/chairman` (new Daily Briefing) | Replace — same route, new component |
+| `/chairman/overview` | ChairmanOverview | `/chairman` (new Daily Briefing) | Remove route |
+| `/chairman/decisions` | DecisionsInbox | `/chairman/decisions` (new Decision Queue) | Replace — same route, new component |
+| `/chairman/settings` | ChairmanSettingsPage | `/chairman/preferences` (new) | Redirect old → new |
+| `/chairman/escalations` | ChairmanEscalationPage | `/chairman/decisions` (merged into queue) | Remove route |
+| `/chairman/analytics` | DecisionAnalyticsDashboard | Future enhancement or remove | Keep temporarily |
+| `/chairman/risk-review` | ChairmanRiskReviewPage | `/chairman/ventures` (merged into lifecycle) | Remove route |
+| `/chairman/vision` | VisionDashboard | `/chairman/vision` (new, streamlined) | Replace — same route, new component |
+| `/chairman/governance` | GovernanceOverview | `/chairman` (merged into briefing) | Remove route |
+| `/chairman/okr-analytics` | OKRAnalyticsPage | Future enhancement or remove | Keep temporarily |
+
+### 3.2 Deprecation Strategy
+
+**Phase 1**: Build new components alongside existing ones. New routes use a `v3/` component directory.
+**Phase 2**: Once new views are stable (2+ weeks daily use), swap route definitions to point to new components.
+**Phase 3**: Delete old components, remove unused routes. Target: 5 chairman routes (briefing, decisions, ventures, vision, preferences) + 3 builder routes (dashboard, queue, inbox).
+
+### 3.3 Existing Components to Reuse
+
+Some existing chairman-v2 components are well-built and should be preserved or adapted:
+
+| Component | Reuse Strategy |
+|-----------|---------------|
+| `StageTimeline` | Adapt for venture lifecycle view |
+| `TokenBudgetBar` | Reuse in preferences view |
+| `EVAGreeting` | Reuse in daily briefing |
+| `QuickStatCard` | Reuse for summary metrics |
+| `DecisionStack` | Adapt for new decision queue (core logic is solid) |
+
+---
+
+## 4. Route Structure
+
+### 4.1 New Route Groups
+
+```
+/chairman                    → Daily Briefing (landing)
+/chairman/decisions          → Decision Queue (blocking gates)
+/chairman/decisions/:id      → Decision Detail (full context for one gate)
+/chairman/ventures           → Venture Lifecycle Map
+/chairman/ventures/:id       → Single Venture Detail (25-stage view)
+/chairman/vision             → Vision & Alignment (HEAL scores)
+/chairman/preferences        → Chairman Preferences
+
+/builder                     → Builder Dashboard (Active SDs)
+/builder/queue               → Build Queue (SD pipeline)
+/builder/inbox               → Brainstorm Inbox
+```
+
+### 4.2 Route File
+
+New file: `src/routes/chairmanRoutesV3.tsx` (coexists with existing during transition)
+
+### 4.3 Layout
+
+New layout component: `src/components/chairman-v3/ChairmanShell.tsx`
+
+```
+┌─────────────────────────────────────────────────┐
+│  EHG  [Chairman ▼]  [Builder]        [⚙️] [👤]  │  ← Top nav with persona toggle
+├──────────┬──────────────────────────────────────┤
+│ Briefing │                                      │
+│ Decisions│         Main Content Area            │
+│ Ventures │                                      │
+│ Vision   │                                      │
+│ Prefs    │                                      │
+│──────────│                                      │
+│ ── or ── │                                      │
+│ Active   │                                      │
+│ Queue    │                                      │
+│ Inbox    │                                      │
+├──────────┴──────────────────────────────────────┤
+│  [Alerts sidebar / toast area]                  │
+└─────────────────────────────────────────────────┘
+```
+
+**Mobile**: Sidebar collapses to bottom tab bar (5 tabs for active persona).
+
+---
+
+## 5. Component Architecture
+
+### 5.1 Directory Structure
+
+```
+src/components/chairman-v3/
+  ChairmanShell.tsx          # Layout with sidebar + persona toggle
+  DailyBriefing.tsx          # Landing page
+  DecisionQueue.tsx          # List of pending blocking decisions
+  DecisionDetail.tsx         # Full context for one decision
+  VentureLifecycle.tsx       # All ventures with stage indicators
+  VentureDetail.tsx          # Single venture 25-stage view
+  VisionAlignment.tsx        # HEAL scores + drift
+  Preferences.tsx            # Chairman preference editor
+
+  builder/
+    BuilderDashboard.tsx     # Active SDs overview
+    BuildQueue.tsx           # Prioritized SD pipeline
+    BrainstormInbox.tsx      # Brainstorm capture + history
+
+  shared/
+    AlertToast.tsx           # Notification toasts
+    StageIndicator.tsx       # Small stage badge (reusable)
+    HealthScore.tsx          # Color-coded 0-100 score display
+    ClaudeCodeLink.tsx       # "Open in Claude Code" button with context assembly
+    DecisionActions.tsx      # Approve/Reject/Park button group
+```
+
+### 5.2 Key Shared Components
+
+**ClaudeCodeLink**: Assembles context and provides clipboard copy or deep-link.
+
+```tsx
+interface ClaudeCodeLinkProps {
+  ventureId: string;
+  context: string;      // Pre-formatted prompt context
+  action?: string;      // Suggested action for Claude Code
+}
+```
+
+**DecisionActions**: Standardized approve/reject/park interface with confirmation.
+
+```tsx
+interface DecisionActionsProps {
+  decisionId: string;
+  gateType: 'stage0' | 'stage10' | 'stage22' | 'stage25';
+  onDecision: (decision: string, rationale?: string) => void;
+}
+```
+
+---
+
+## 6. Data Layer
+
+### 6.1 Supabase Queries by View
+
+#### Daily Briefing (`/chairman`)
+```sql
+-- Pending decisions count
+SELECT count(*) FROM chairman_decisions WHERE status = 'pending';
+
+-- Active ventures summary
+SELECT id, name, current_lifecycle_stage, status, metadata
+FROM ventures WHERE status = 'active';
+
+-- Latest HEAL scores
+SELECT * FROM vision_scores
+ORDER BY created_at DESC LIMIT 1;
+
+-- Recent SD completions (last 7 days)
+SELECT sd_key, title, status, completion_date
+FROM strategic_directives_v2
+WHERE status = 'completed' AND completion_date > NOW() - INTERVAL '7 days';
+```
+
+#### Decision Queue (`/chairman/decisions`)
+```sql
+-- All pending blocking decisions with venture context
+SELECT cd.*, v.name as venture_name, v.current_lifecycle_stage
+FROM chairman_decisions cd
+LEFT JOIN ventures v ON cd.venture_id = v.id
+WHERE cd.status = 'pending'
+ORDER BY cd.created_at ASC;
+```
+
+#### Decision Detail (`/chairman/decisions/:id`)
+```sql
+-- Decision with full brief data
+SELECT * FROM chairman_decisions WHERE id = :id;
+
+-- Related venture artifacts for context
+SELECT * FROM venture_artifacts
+WHERE venture_id = :ventureId AND is_current = true
+ORDER BY lifecycle_stage DESC;
+```
+
+#### Venture Lifecycle (`/chairman/ventures`)
+```sql
+-- All active ventures with latest stage artifact
+SELECT v.*,
+  (SELECT max(lifecycle_stage) FROM venture_artifacts
+   WHERE venture_id = v.id AND is_current = true) as latest_stage
+FROM ventures v WHERE v.status = 'active'
+ORDER BY v.name;
+```
+
+#### Vision & Alignment (`/chairman/vision`)
+```sql
+-- HEAL score history (last 30 entries)
+SELECT * FROM vision_scores ORDER BY created_at DESC LIMIT 30;
+
+-- Dimension breakdown for latest score
+SELECT * FROM vision_score_dimensions
+WHERE score_id = :latestScoreId;
+
+-- Corrective SDs
+SELECT sd_key, title, status FROM strategic_directives_v2
+WHERE sd_key LIKE 'SD-MAN-FEAT-CORRECTIVE%' AND status != 'completed'
+ORDER BY created_at DESC;
+```
+
+#### Preferences (`/chairman/preferences`)
+```sql
+-- All global preferences (venture_id IS NULL)
+SELECT * FROM chairman_preferences
+WHERE venture_id IS NULL
+ORDER BY preference_key;
+
+-- Venture-specific overrides
+SELECT cp.*, v.name as venture_name
+FROM chairman_preferences cp
+LEFT JOIN ventures v ON cp.venture_id = v.id
+WHERE cp.venture_id IS NOT NULL
+ORDER BY v.name, cp.preference_key;
+```
+
+#### Builder Dashboard (`/builder`)
+```sql
+-- Active SDs with phase info
+SELECT sd.sd_key, sd.title, sd.status, sd.priority,
+  h.phase, h.status as phase_status
+FROM strategic_directives_v2 sd
+LEFT JOIN sd_phase_handoffs h ON h.sd_id = sd.id
+WHERE sd.status IN ('in_progress', 'ready', 'planning')
+ORDER BY sd.priority DESC, sd.created_at;
+```
+
+### 6.2 React Query Hooks
+
+```
+src/hooks/chairman-v3/
+  useChairmanBriefing.ts     # Combines pending count + ventures + HEAL
+  useDecisionQueue.ts        # Pending blocking decisions
+  useDecisionDetail.ts       # Single decision with artifacts
+  useVentureLifecycle.ts     # All ventures with stage info
+  useVisionScores.ts         # HEAL history + dimensions
+  useChairmanPreferences.ts  # Preferences CRUD
+  useBuilderSDs.ts           # Active SDs for builder view
+  useBuildQueue.ts           # SD pipeline
+  useBrainstormInbox.ts      # Brainstorm sessions
+```
+
+### 6.3 Mutations
+
+| Action | Table | Operation |
+|--------|-------|-----------|
+| Approve gate | chairman_decisions | UPDATE status='approved', decision='proceed' |
+| Reject gate | chairman_decisions | UPDATE status='rejected', decision='reject', rationale=... |
+| Park venture | chairman_decisions + venture_nursery | UPDATE + INSERT |
+| Update preference | chairman_preferences | UPSERT |
+| Override score | chairman_overrides | INSERT |
+
+### 6.4 Real-Time (Phase 2+)
+
+```ts
+// Supabase realtime subscription for decision queue updates
+supabase
+  .channel('chairman-decisions')
+  .on('postgres_changes', {
+    event: '*',
+    schema: 'public',
+    table: 'chairman_decisions',
+    filter: 'status=eq.pending'
+  }, handleDecisionChange)
+  .subscribe();
+```
+
+**Phase 1**: Polling with react-query `refetchInterval: 60000` (1 min)
+**Phase 2+**: Supabase Realtime for instant updates
+
+---
+
+## 7. Governance API Surface
+
+### 7.1 New RPC Functions Needed
+
+The UI needs clean API boundaries for decision actions. These should be Supabase RPC functions (not direct table writes) for audit safety:
+
+```sql
+-- Approve a blocking gate decision
+CREATE OR REPLACE FUNCTION approve_chairman_decision(
+  p_decision_id UUID,
+  p_rationale TEXT DEFAULT NULL
+) RETURNS JSONB AS $$ ... $$;
+
+-- Reject a blocking gate decision
+CREATE OR REPLACE FUNCTION reject_chairman_decision(
+  p_decision_id UUID,
+  p_rationale TEXT
+) RETURNS JSONB AS $$ ... $$;
+
+-- Park a venture (Stage 0 routing)
+CREATE OR REPLACE FUNCTION park_venture_decision(
+  p_decision_id UUID,
+  p_park_type TEXT,  -- 'blocked' | 'nursery'
+  p_reason TEXT
+) RETURNS JSONB AS $$ ... $$;
+
+-- Override a score
+CREATE OR REPLACE FUNCTION chairman_score_override(
+  p_venture_id UUID,
+  p_component TEXT,
+  p_system_score NUMERIC,
+  p_override_score NUMERIC,
+  p_reason TEXT
+) RETURNS JSONB AS $$ ... $$;
+```
+
+### 7.2 RLS Policy Requirements
+
+| Table | Policy Needed | Notes |
+|-------|--------------|-------|
+| chairman_decisions | SELECT for authenticated | Read all decisions |
+| chairman_decisions | UPDATE for authenticated | Only status, decision, rationale fields |
+| chairman_preferences | SELECT, INSERT, UPDATE, DELETE for authenticated | Full CRUD |
+| chairman_overrides | SELECT, INSERT for authenticated | Insert new, read history |
+| ventures | SELECT for authenticated | Read all ventures |
+| venture_artifacts | SELECT for authenticated | Read artifacts for context |
+| vision_scores | SELECT for authenticated | Read HEAL scores |
+| vision_score_dimensions | SELECT for authenticated | Read score breakdowns |
+| strategic_directives_v2 | SELECT for authenticated | Read SD queue |
+| brainstorm_sessions | SELECT for authenticated | Read brainstorm history |
+
+**Action item**: Audit existing RLS policies before building any views.
+
+---
+
+## 8. Claude Code Remote Context Protocol
+
+### 8.1 Context Assembly
+
+When the user clicks "Open in Claude Code," the UI assembles a structured context block:
+
+```typescript
+interface ClaudeCodeContext {
+  type: 'gate_decision' | 'venture_review' | 'corrective_action';
+  ventureId: string;
+  ventureName: string;
+  stage?: number;
+  summary: string;         // 2-3 sentence human-readable summary
+  suggestedAction?: string; // "Review HEAL drift and consider corrective SD"
+  dataSnapshot: Record<string, unknown>; // Relevant data for context
+}
+```
+
+### 8.2 Handoff Options
+
+1. **Clipboard copy** (MVP): Format as markdown prompt, copy to clipboard, user pastes into Claude Code
+2. **URL scheme** (future): If Anthropic provides deep-link support for Claude Code sessions
+3. **`claude --remote` CLI** (future): Programmatic session creation via API
+
+---
+
+## 9. Mobile Considerations (Phase C responsive, Phase D PWA)
+
+### 9.1 Phase C: Responsive Layout
+
+- Sidebar → bottom tab bar on mobile (5 tabs)
+- Decision cards stack vertically
+- Venture lifecycle → horizontal scroll with stage pills
+- Tables → card layout on mobile
+- "Open in Claude Code" → opens Claude iOS/Android app
+
+### 9.2 Phase D: PWA Additions
+
+```json
+// manifest.json
+{
+  "name": "EHG Chairman",
+  "short_name": "Chairman",
+  "start_url": "/chairman",
+  "display": "standalone",
+  "theme_color": "#1a1a2e",
+  "background_color": "#16213e"
+}
+```
+
+- Service worker: Cache briefing data for offline reading
+- Web Push: Notify on new blocking decisions via Supabase Edge Function → Web Push API
+- Install prompt: Show after 3+ visits
+
+---
+
+## 10. Implementation Phases
+
+### Phase 1: Read-Only Dashboard (8-12h)
+
+| Task | Est. |
+|------|------|
+| Create `chairman-v3/` component directory | 0.5h |
+| ChairmanShell layout with sidebar + persona toggle | 2h |
+| DailyBriefing view (pending count, venture summary, HEAL) | 2h |
+| VentureLifecycle view (all ventures, stage indicators) | 2h |
+| VisionAlignment view (HEAL scores, drift) | 2h |
+| BuilderDashboard + BuildQueue (read-only) | 2h |
+| Route registration + responsive testing | 1h |
+
+### Phase 2: Decision Gates (6-10h)
+
+| Task | Est. |
+|------|------|
+| DecisionQueue list view | 2h |
+| DecisionDetail with gate-specific context rendering | 3h |
+| DecisionActions component (approve/reject/park) | 2h |
+| RPC functions for decision mutations | 1.5h |
+| RLS policy audit + fixes | 1.5h |
+
+### Phase 3: PWA Shell (4-6h)
+
+| Task | Est. |
+|------|------|
+| manifest.json + icons | 1h |
+| Service worker (Vite PWA plugin) | 2h |
+| Mobile-specific layout refinements | 1.5h |
+| Push notification setup (Edge Function + Web Push) | 1.5h |
+
+### Phase 4: Claude Code Remote (2-4h)
+
+| Task | Est. |
+|------|------|
+| ClaudeCodeLink component | 1h |
+| Context assembly logic per gate type | 1.5h |
+| Clipboard + deep-link integration | 1h |
+
+### Phase 5: Legacy Cleanup (2-4h)
+
+| Task | Est. |
+|------|------|
+| Swap chairman routes to v3 components | 1h |
+| Delete superseded components | 1h |
+| Update navigation + remove dead routes | 1h |
+| Verify no broken links/imports | 1h |
+
+**Total estimated: 22-36h across 5 phases**
+
+---
+
+## 11. Testing Strategy
+
+| Level | Approach |
+|-------|----------|
+| Component | Vitest + React Testing Library for each view |
+| Integration | Supabase query validation with test data |
+| E2E | Manual testing of all 4 decision flows |
+| Mobile | Browser DevTools responsive mode + real device |
+| Accessibility | Keyboard navigation, screen reader basics |
+
+---
+
+## 12. Risk Mitigation
+
+| Risk | Mitigation |
+|------|-----------|
+| RLS policies block reads | Audit before Phase 1; use service role key in dev, auth key in prod |
+| Existing routes conflict | v3 components coexist; swap only when stable |
+| Low adoption (Challenger concern) | Track daily opens; if < 3/week after 2 weeks, reassess |
+| Claude Code Remote API changes | Clipboard-first approach; URL scheme is additive |
+| Scope creep into builder execution | Vision doc Section 8 "What This UI Is NOT" — enforce boundary |

--- a/docs/plans/chairman-web-ui-vision.md
+++ b/docs/plans/chairman-web-ui-vision.md
@@ -1,0 +1,731 @@
+# Chairman Web UI — Vision Document
+
+**Version**: 1.0.0
+**Date**: 2026-02-25
+**Status**: Draft
+**Origin**: Brainstorm session `8724b615-5e99-4980-a56c-33965d4a9df5`
+
+---
+
+## 1. Executive Summary
+
+Build a focused governance and portfolio management interface for the EHG venture lifecycle. The UI serves two personas (same person, different cognitive modes) and integrates with Claude Code on the Web for conversational decision-making.
+
+**Phase C** (current): Hybrid Dashboard + Claude Code Remote
+**Phase D** (future): Progressive Web App with mobile-first interactions
+
+---
+
+## 2. Problem Statement
+
+The EHG venture lifecycle (25 stages, 6 phases) requires human governance at specific intervention points. Today, these interventions are handled through CLI commands, which works for the builder persona but creates friction for the chairman persona — governance decisions need context-rich summaries, not terminal output.
+
+The existing EHG web app (`rickfelix/ehg`) has 10+ chairman-related pages built across multiple SDs, but the user describes it as "cluttered." The pages were built incrementally without a unified information architecture, resulting in overlapping views that don't align to actual decision workflows.
+
+Telegram was explored as an alternative (brainstorm sessions `11d895f1`, `8bb12106`) but rejected by the chairman — the medium doesn't match the governance context.
+
+**Core insight**: The Telegram forum topic design *did* produce a clean information architecture. We adopt that IA as the blueprint for the web UI.
+
+---
+
+## 3. Personas
+
+### 3.1 Chairman (Governance Mode)
+
+**Goal**: Make informed decisions that keep ventures aligned with strategic vision.
+
+**Mindset**: Executive review. Wants synthesized information, not raw data. Comfortable with approve/reject/park decisions when given sufficient context. Reviews in batches, not real-time.
+
+**Key activities**:
+- Daily briefing review (portfolio pulse, aggregate health)
+- Blocking gate decisions (approve/reject ventures at stages 0, 10, 22, 25)
+- Vision alignment monitoring (HEAL scores, drift detection)
+- Venture lifecycle overview (where is each venture in the 25-stage pipeline)
+- Preference management (risk tolerance, budget caps, tech stack directives)
+
+**Decision frequency**: ~1-4 blocking decisions per week across all ventures. Batched daily review.
+
+### 3.2 Solo Entrepreneur (Builder Mode)
+
+**Goal**: Execute efficiently across the venture portfolio using LEO protocol.
+
+**Mindset**: Operational. Wants to know what's next, what's blocked, and what just completed. Uses CLI as primary tool but needs a visual overview of the build pipeline.
+
+**Key activities**:
+- SD queue monitoring (what's ready, what's blocked, what's in progress)
+- Active SD tracking (current phase, progress, blockers)
+- Brainstorm capture and review (ideas inbox)
+- Protocol health monitoring (shared alerts)
+
+**Primary tool**: CLI (`npm run sd:next`, Claude Code). The web UI is supplementary for the builder — a monitoring surface, not an execution surface.
+
+### 3.3 Persona Switching
+
+Both personas are the same person. The UI does not require separate login or role switching — it uses **route-based context**:
+
+- `/chairman/*` routes → chairman governance mode (calm, information-dense, decision-oriented)
+- `/builder/*` routes → builder operational mode (active, queue-focused, progress-oriented)
+- Landing page shows both at a glance, with the chairman decision queue prominent
+
+---
+
+## 4. Information Architecture
+
+Adopted from the Telegram forum topic design, mapped to web routes:
+
+### 4.1 Chairman Views
+
+| View | Route | Type | Source Tables | Purpose |
+|------|-------|------|---------------|---------|
+| **Daily Briefing** | `/chairman` | Read | ventures, venture_artifacts, vision_scores, chairman_decisions | Morning summary: portfolio pulse, health scores, pending decisions count |
+| **Decisions** | `/chairman/decisions` | Read/Write | chairman_decisions, venture_artifacts, ventures | Blocking gate queue with full context. Approve/reject/park actions. |
+| **Venture Lifecycle** | `/chairman/ventures` | Read | ventures, venture_artifacts | 25-stage pipeline view per venture. Kill gate status. Stage progression. |
+| **Vision & Alignment** | `/chairman/vision` | Read | vision_scores, vision_score_dimensions | HEAL scores, drift detection, correction SD alerts |
+| **Preferences** | `/chairman/preferences` | Read/Write | chairman_preferences | Risk tolerance, budget caps, notification settings |
+
+### 4.2 Builder Views
+
+| View | Route | Type | Source Tables | Purpose |
+|------|-------|------|---------------|---------|
+| **Active SDs** | `/builder` | Read | strategic_directives_v2, sd_phase_handoffs | In-progress SD details, phase, progress, blockers |
+| **Build Queue** | `/builder/queue` | Read | strategic_directives_v2 | Prioritized SD pipeline (mirrors `npm run sd:next`) |
+| **Inbox** | `/builder/inbox` | Read/Write | brainstorm_sessions | Brainstorm capture, past brainstorm viewer |
+
+### 4.3 Shared
+
+| View | Route | Type | Source Tables | Purpose |
+|------|-------|------|---------------|---------|
+| **Alerts** | (sidebar/toast) | Read | chairman_decisions, strategic_directives_v2 | Proactive notifications for both personas |
+
+---
+
+## 5. Chairman Decision Points
+
+The UI's highest-value feature is the **Decision Queue** — the 4 points where the EVA pipeline blocks for human judgment:
+
+### 5.1 Stage 0: Venture Routing Decision
+
+**Trigger**: New venture synthesized from ideation pipeline
+**Data shown**: Venture name, problem statement, solution, target market, archetype, moat strategy, portfolio synergy score (0-100), time horizon, chairman constraint scores (10 strategic filters)
+**Actions**: Approve (→ Stage 1) | Park as Blocked (30d review) | Park as Nursery (90d review)
+**Auto-resolve**: N/A (synchronous in current flow)
+
+### 5.2 Stage 10: Brand Approval Gate
+
+**Trigger**: Brand naming analysis complete with 5+ candidates
+**Data shown**: Brand genome (archetype, values, tone), 5+ naming candidates with per-criterion weighted scores, narrative extension (vision, mission, brand voice), naming strategy type
+**Actions**: Approve top candidate | Select different candidate (override) | Reject with rationale
+**Auto-resolve**: 24h → auto-approve with flag
+
+### 5.3 Stage 22: Release Readiness Gate
+
+**Trigger**: Build loop complete, release package assembled
+**Data shown**: Release items (features/bugfixes/infra) with status, release notes, target date, sprint retrospective, build quality checks from stages 17-21
+**Actions**: Approve release | Reject with rationale | Hold
+**Auto-resolve**: 24h → auto-approve with flag
+
+### 5.4 Stage 25: Venture Portfolio Review
+
+**Trigger**: Post-launch data collected, venture review complete
+**Data shown**: Review summary, initiative outcomes by category, current vs original vision, drift analysis, financial comparison (projected vs actual), venture health scores (5 dimensions, 0-100 each), proposed next steps
+**Actions**: Continue | Pivot | Expand | Sunset | Exit — each with rationale
+**Auto-resolve**: 24h → auto-approve with flag
+
+---
+
+## 6. Claude Code Remote Integration
+
+### 6.1 Pattern: Dashboard Reads, Claude Code Writes
+
+The UI is primarily a **read surface** for governance context. When the chairman needs to take action beyond approve/reject (e.g., issue a protocol directive, investigate a drift, create a corrective SD), the UI hands off to Claude Code on the Web.
+
+### 6.2 Handoff Mechanism
+
+Each decision card and venture detail view includes an "Open in Claude Code" action that:
+
+1. Assembles structured context (venture ID, stage, relevant data summary)
+2. Copies to clipboard as a formatted prompt OR opens Claude Code web with pre-filled context
+3. The chairman works conversationally in Claude Code to execute the decision
+4. Results appear in the dashboard on next refresh
+
+### 6.3 Example Flows
+
+**Gate Decision (simple)**: Chairman opens `/chairman/decisions` → reviews Stage 10 brand candidates → taps "Approve" directly in the UI → done.
+
+**Corrective Action (complex)**: Chairman opens `/chairman/vision` → sees HEAL drift on venture X → taps "Investigate in Claude Code" → Claude Code opens with context → chairman directs LEO to create corrective SD → next day's briefing reflects the correction.
+
+---
+
+## 7. Phase C → Phase D Evolution
+
+### 7.1 Phase C: Hybrid Dashboard (current target)
+
+- Desktop and mobile responsive (Tailwind breakpoints)
+- Deployed on Vercel (HTTPS by default)
+- Built in `rickfelix/ehg` as new route groups
+- Real-time via Supabase subscriptions (or polling as MVP)
+
+### 7.2 Phase D: Progressive Web App (future enhancement)
+
+Added after Phase C is stable and actively used:
+
+- `manifest.json` with app name, icons, theme color
+- Service worker for offline-capable read views (cached briefings)
+- Install prompt for home screen
+- Push notifications for blocking gates via Supabase Edge Functions + Web Push API
+- Swipe gestures for quick approve/reject on mobile
+
+**Phase D prerequisites**:
+- Phase C is complete and used daily for 2+ weeks
+- All 4 decision surfaces work correctly
+- Mobile responsive layout verified
+
+---
+
+## 8. What This UI Is NOT
+
+Explicitly out of scope (from brainstorm un-done analysis):
+
+1. **Not an execution surface for LEO** — no SD creation, no phase handoffs, no code review. That's CLI + Claude Code.
+2. **Not a replacement for `npm run sd:next`** — the builder queue is a visual mirror, not a replacement for the authoritative CLI command.
+3. **Not a real-time monitoring dashboard** — batched daily review, not live streaming. Polling or manual refresh is acceptable.
+4. **Not multi-user** — single chairman, single builder, same person. No RBAC, no team features.
+5. **Not the existing chairman pages refactored** — this is a clean redesign using the Telegram IA as blueprint. Existing pages remain but are superseded.
+
+---
+
+## 9. UI/UX Wireframes
+
+### 9.1 Shell Layout (Desktop)
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ◆ EHG    [Chairman]  [Builder]                      ⚙ Settings  👤 │
+├────────────┬─────────────────────────────────────────────────────────┤
+│            │                                                         │
+│  CHAIRMAN  │              Main Content Area                          │
+│  ────────  │              (route-dependent)                          │
+│  Briefing  │                                                         │
+│  Decisions │                                                         │
+│  Ventures  │                                                         │
+│  Vision    │                                                         │
+│  Prefs     │                                                         │
+│            │                                                         │
+│  BUILDER   │                                                         │
+│  ────────  │                                                         │
+│  Active    │                                                         │
+│  Queue     │                                                         │
+│  Inbox     │                                                         │
+│            │                                                         │
+└────────────┴─────────────────────────────────────────────────────────┘
+```
+
+**Behavior**: Clicking [Chairman] or [Builder] in the top nav scrolls the sidebar to that section and navigates to the persona's landing page. Active route is highlighted in the sidebar.
+
+### 9.2 Shell Layout (Mobile)
+
+```
+┌────────────────────────────┐
+│  ◆ EHG              ⚙  👤 │
+├────────────────────────────┤
+│                            │
+│                            │
+│     Main Content Area      │
+│     (full width)           │
+│                            │
+│                            │
+│                            │
+│                            │
+│                            │
+├────────────────────────────┤
+│ Brief │ Dec │ Vent │ Vis │⋯│  ← Bottom tab bar (swipe for more)
+└────────────────────────────┘
+```
+
+**Behavior**: Bottom tabs show current persona's views. Tap the `⋯` (more) tab to switch persona or access overflow items (Prefs, Inbox).
+
+### 9.3 Daily Briefing (`/chairman`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Good morning, Chairman.                     Feb 25, 2026  ☀️   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐   │
+│  │ PENDING  │  │ ACTIVE   │  │  HEAL    │  │ COMPLETED    │   │
+│  │ DECISIONS│  │ VENTURES │  │  SCORE   │  │ THIS WEEK    │   │
+│  │          │  │          │  │          │  │              │   │
+│  │    2     │  │    6     │  │   78%    │  │     3 SDs    │   │
+│  │          │  │          │  │          │  │              │   │
+│  └──────────┘  └──────────┘  └──────────┘  └──────────────┘   │
+│                                                                 │
+│  DECISION QUEUE (2 pending)                      View All →     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  🔴 Stage 10 — Brand Approval         NicheBrief AI    │   │
+│  │     5 candidates scored. Top: "NicheBrief"              │   │
+│  │     Waiting since: 2h ago            [Review →]         │   │
+│  ├─────────────────────────────────────────────────────────┤   │
+│  │  🟡 Stage 0 — Venture Routing        FinTrack Pro      │   │
+│  │     Synergy: 72/100  Horizon: 18mo                      │   │
+│  │     Waiting since: 45m ago           [Review →]         │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  PORTFOLIO PULSE                                                │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  NicheBrief AI    ██████████░░  Stage 10/25  Active     │   │
+│  │  MedSync          ████░░░░░░░░  Stage 5/25   Active     │   │
+│  │  Solara Energy    ██████████████ Stage 22/25  Review     │   │
+│  │  EduPath          ██░░░░░░░░░░  Stage 3/25   Active     │   │
+│  │  LogiFlow         ░░░░░░░░░░░░  Stage 0      Nursery    │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  VISION ALIGNMENT                                               │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  HEAL Score: 78% ████████████████░░░░  (↑ 3% this week)│   │
+│  │  ⚠ 1 venture drifting: MedSync (moderate drift)         │   │
+│  │  2 corrective SDs active                  [Details →]   │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.4 Decision Queue (`/chairman/decisions`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Decisions                                    2 pending · 0 held│
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌─ BLOCKING ───────────────────────────────────────────────┐  │
+│  │                                                           │  │
+│  │  ┌─────────────────────────────────────────────────────┐ │  │
+│  │  │ 🔴 STAGE 10 · Brand Approval                       │ │  │
+│  │  │ NicheBrief AI                                       │ │  │
+│  │  │                                                     │ │  │
+│  │  │ Brand Genome: Innovator archetype · Professional    │ │  │
+│  │  │ Strategy: Descriptive naming                        │ │  │
+│  │  │                                                     │ │  │
+│  │  │ CANDIDATES                         SCORE            │ │  │
+│  │  │ ┌─────────────────────────────────────────────┐    │ │  │
+│  │  │ │ 1. NicheBrief     ████████████░  82/100 ★  │    │ │  │
+│  │  │ │ 2. BriefNiche     ████████░░░░░  67/100    │    │ │  │
+│  │  │ │ 3. NicheForge     ███████░░░░░░  61/100    │    │ │  │
+│  │  │ │ 4. BriefLens      ██████░░░░░░░  55/100    │    │ │  │
+│  │  │ │ 5. ScopeAI        █████░░░░░░░░  48/100    │    │ │  │
+│  │  │ └─────────────────────────────────────────────┘    │ │  │
+│  │  │                                                     │ │  │
+│  │  │  [✓ Approve #1]  [Select Other ▼]  [✗ Reject]     │ │  │
+│  │  │                                                     │ │  │
+│  │  │  ───────────────────────────────────────────────── │ │  │
+│  │  │  Waiting: 2h · Auto-approve in: 21h 58m            │ │  │
+│  │  │  [Open in Claude Code]                              │ │  │
+│  │  └─────────────────────────────────────────────────────┘ │  │
+│  │                                                           │  │
+│  │  ┌─────────────────────────────────────────────────────┐ │  │
+│  │  │ 🟡 STAGE 0 · Venture Routing                       │ │  │
+│  │  │ FinTrack Pro                                        │ │  │
+│  │  │                                                     │ │  │
+│  │  │ Problem: Manual financial tracking for freelancers  │ │  │
+│  │  │ Market:  Solo professionals, 2M+ TAM               │ │  │
+│  │  │ Synergy: 72/100  Horizon: 18 months                │ │  │
+│  │  │ Archetype: Efficiency Tool                          │ │  │
+│  │  │                                                     │ │  │
+│  │  │ CHAIRMAN CONSTRAINTS          PASS/FAIL             │ │  │
+│  │  │ ┌─────────────────────────────────────────────┐    │ │  │
+│  │  │ │ Fully Automatable        ✅ Pass             │    │ │  │
+│  │  │ │ Proprietary Data         ✅ Pass             │    │ │  │
+│  │  │ │ Narrow Specialization    ✅ Pass             │    │ │  │
+│  │  │ │ Niche Over Crowded       ⚠️ Warning          │    │ │  │
+│  │  │ │ Moat First               ✅ Pass             │    │ │  │
+│  │  │ │ Values Alignment         ✅ Pass             │    │ │  │
+│  │  │ └─────────────────────────────────────────────┘    │ │  │
+│  │  │                                                     │ │  │
+│  │  │  [✓ Approve → Stage 1] [Park: Blocked] [Park: 🌱]  │ │  │
+│  │  │                                                     │ │  │
+│  │  │  [Open in Claude Code]                              │ │  │
+│  │  └─────────────────────────────────────────────────────┘ │  │
+│  │                                                           │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌─ RECENT (last 7 days) ───────────────────────────────────┐  │
+│  │  ✅ Stage 22 · Solara Energy · Approved · Feb 23         │  │
+│  │  ✅ Stage 0  · EduPath      · Approved · Feb 21         │  │
+│  │  🅿️ Stage 0  · LogiFlow     · Parked (nursery) · Feb 20 │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.5 Decision Detail — Reject/Rationale Modal
+
+```
+┌─────────────────────────────────────────────┐
+│  Reject: Stage 10 Brand Approval            │
+│  NicheBrief AI                         [✕]  │
+├─────────────────────────────────────────────┤
+│                                             │
+│  Rationale (required):                      │
+│  ┌─────────────────────────────────────┐   │
+│  │ Names don't convey the AI-powered   │   │
+│  │ nature of the product. Need options │   │
+│  │ that emphasize automation.          │   │
+│  │                                     │   │
+│  └─────────────────────────────────────┘   │
+│                                             │
+│  This will:                                 │
+│  · Block pipeline at Stage 10               │
+│  · Send venture back for re-analysis        │
+│  · Record rejection in audit trail          │
+│                                             │
+│        [Cancel]    [Confirm Rejection]      │
+│                                             │
+└─────────────────────────────────────────────┘
+```
+
+### 9.6 Venture Lifecycle (`/chairman/ventures`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Venture Lifecycle                              6 active · 1 🌱 │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌─ NicheBrief AI ──────────────────────── Stage 10/25 ─────┐  │
+│  │                                                           │  │
+│  │  THE TRUTH    THE ENGINE   IDENTITY   BLUEPRINT  BUILD  L │  │
+│  │  ●─●─●────── ●─●─●─●──── ●─◐─○───── ○─○─○───── ○──── ○ │  │
+│  │  0 1 2       3 4 5 6     7 8 9  [10]  11 12 13   14-21 22│  │
+│  │                            ▲                               │  │
+│  │                     🔴 BLOCKING — Brand Approval           │  │
+│  │                                                           │  │
+│  │  Health: 74/100   HEAL: Aligned   [View Detail →]         │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌─ MedSync ────────────────────────────── Stage 5/25 ──────┐  │
+│  │                                                           │  │
+│  │  THE TRUTH    THE ENGINE   IDENTITY   BLUEPRINT  BUILD  L │  │
+│  │  ●─●─●────── ●─●─◐─○──── ○─○─○───── ○─○─○───── ○──── ○ │  │
+│  │  0 1 2       3 4 [5] 6    7 8 9      10-13      14-21 22│  │
+│  │                ▲                                           │  │
+│  │         ⚡ IN PROGRESS — Unit Economics                     │  │
+│  │                                                           │  │
+│  │  Health: 61/100   HEAL: ⚠ Moderate Drift  [View Detail →]│  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌─ Solara Energy ──────────────────────── Stage 22/25 ─────┐  │
+│  │                                                           │  │
+│  │  THE TRUTH    THE ENGINE   IDENTITY   BLUEPRINT  BUILD  L │  │
+│  │  ●─●─●────── ●─●─●─●──── ●─●─●───── ●─●─●─●─── ●──── ◐ │  │
+│  │  0 1 2       3 4 5 6     7 8 9  10   11-13      14-21[22]│  │
+│  │                                                     ▲      │  │
+│  │                                    ✅ Approved 2d ago      │  │
+│  │                                                           │  │
+│  │  Health: 88/100   HEAL: Aligned   [View Detail →]         │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌─ LogiFlow ───────────────────────────── 🌱 Nursery ──────┐  │
+│  │  Parked: Feb 20 · Review in: 68 days · Reason: Time      │  │
+│  │  horizon — market not ready            [Wake Up] [Detail] │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+
+Legend: ● Complete  ◐ In Progress  ○ Future  [N] Current Stage
+```
+
+### 9.7 Vision & Alignment (`/chairman/vision`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Vision & Alignment                          HEAL Score: 78%    │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  SCORE TREND (30 days)                                          │
+│  100│                                                           │
+│   90│                                                           │
+│   80│          ╭──╮    ╭───╮  ╭─────╮  ╭──────                 │
+│   70│    ╭─────╯  ╰────╯   ╰──╯     ╰──╯                      │
+│   60│────╯                                                      │
+│   50│                                                           │
+│     └──────────────────────────────────────────────             │
+│      Jan 26                              Feb 25                 │
+│                                                                 │
+│  DIMENSION BREAKDOWN                                            │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Strategic Alignment  ██████████████████░░  85%  ↑ 2%   │   │
+│  │  Execution Quality    ████████████████░░░░  76%  ─ 0%   │   │
+│  │  Innovation Velocity  ███████████████░░░░░  72%  ↑ 5%   │   │
+│  │  Portfolio Coherence  ████████████████░░░░  78%  ↓ 1%   │   │
+│  │  Risk Management      █████████████████░░░  80%  ↑ 3%   │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  DRIFT ALERTS                                                   │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  ⚠ MedSync — Moderate Drift                             │   │
+│  │    Original: B2B health data platform                    │   │
+│  │    Current:  Pivoting toward B2C wellness app            │   │
+│  │    Drift since: Stage 4 (Feb 18)                         │   │
+│  │    [Investigate in Claude Code]  [Accept Drift]          │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  CORRECTIVE SDs                                                 │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  SD-MAN-FEAT-CORRECTIVE-030  In Progress  Gap: V07      │   │
+│  │  SD-MAN-FEAT-CORRECTIVE-029  Planning     Gap: V12      │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.8 Builder Dashboard (`/builder`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Builder                                     3 active · 5 ready │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ACTIVE SDs                                                     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  SD-FDBK-FEAT-VIDEO-003           EXEC 45%             │   │
+│  │  YouTube Metadata Enrichment                             │   │
+│  │  Phase: EXEC · Child: B of D · Est: 2h remaining        │   │
+│  │  ████████████████████░░░░░░░░░░░░░░░░░░░                │   │
+│  │  Blocker: none                      [Open in Claude Code]│   │
+│  ├─────────────────────────────────────────────────────────┤   │
+│  │  SD-MAN-FEAT-CORRECTIVE-030       PLANNING              │   │
+│  │  Vision Gap V07 Correction                               │   │
+│  │  Phase: PLAN · PRD drafting                              │   │
+│  │  ██████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░                │   │
+│  │  Blocker: none                      [Open in Claude Code]│   │
+│  ├─────────────────────────────────────────────────────────┤   │
+│  │  SD-EVA-FEAT-TEMPLATES-002        EXEC 80%              │   │
+│  │  Stage Templates 3-8                                     │   │
+│  │  Phase: EXEC · Child: D of E                             │   │
+│  │  █████████████████████████████████░░░░░░░                │   │
+│  │  Blocker: none                      [Open in Claude Code]│   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  READY QUEUE (next 3)                        View Full Queue →  │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  1. SD-INFRA-AUTH-MIGRATION-001    Priority: HIGH       │   │
+│  │  2. SD-EVA-FEAT-STAGE-ZERO-002    Priority: MEDIUM     │   │
+│  │  3. SD-FDBK-ENH-TELEGRAM-004     Priority: MEDIUM      │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  RECENT COMPLETIONS                                             │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  ✅ SD-FDBK-FEAT-VIDEO-002  Completed Feb 25  PR #1592  │   │
+│  │  ✅ SD-FDBK-FEAT-VIDEO-001  Completed Feb 25  PR #1591  │   │
+│  │  ✅ SD-FDBK-FIX-YOUTUBE-001 Completed Feb 24  PR #1590  │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.9 Preferences (`/chairman/preferences`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Chairman Preferences                                           │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  RISK & BUDGET                                                  │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Max Drawdown Tolerance     [====●=======] 35%          │   │
+│  │  Monthly Budget Cap         [$____500____] USD          │   │
+│  │  Tech Stack Directive       [React + Supabase    ▼]     │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  NOTIFICATIONS                                                  │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Email                      [chairman@ehg.com      ]    │   │
+│  │  Immediate Notifications    [●  ON  ○ OFF]              │   │
+│  │  Daily Digest               [●  ON  ○ OFF]              │   │
+│  │  Digest Time                [08:00 ▼]  Timezone [EST ▼] │   │
+│  │  Quiet Hours                [22:00] to [07:00]          │   │
+│  │  Rate Limit                 [__10__] per hour           │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  VENTURE-SPECIFIC OVERRIDES                                     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  NicheBrief AI     Max drawdown: 25%        [Edit] [✕]  │   │
+│  │  Solara Energy     Budget cap: $1000/mo     [Edit] [✕]  │   │
+│  │                                                          │   │
+│  │  [+ Add Venture Override]                                │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│                                           [Save Changes]        │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.10 User Flow: Chairman Daily Review
+
+```
+                    Chairman opens app
+                          │
+                          ▼
+                  ┌───────────────┐
+                  │ Daily Briefing│
+                  │  /chairman    │
+                  └───────┬───────┘
+                          │
+              ┌───────────┴───────────┐
+              │                       │
+        Decisions > 0?          HEAL drift?
+              │                       │
+         YES  │                  YES  │
+              ▼                       ▼
+    ┌─────────────────┐    ┌──────────────────┐
+    │ Decision Queue  │    │ Vision & Align   │
+    │ /chairman/dec   │    │ /chairman/vision │
+    └────────┬────────┘    └────────┬─────────┘
+             │                      │
+        For each:              [Investigate in
+             │                  Claude Code]
+             ▼                      │
+    ┌─────────────────┐            ▼
+    │ Review Context  │    ┌──────────────────┐
+    │ (inline card)   │    │ Claude Code Web  │
+    └────────┬────────┘    │ (external)       │
+             │             │ Issue directive  │
+     ┌───────┼────────┐   └──────────────────┘
+     │       │        │
+     ▼       ▼        ▼
+  Approve  Reject   Park
+     │       │        │
+     └───────┴────────┘
+             │
+             ▼
+    Pipeline unblocked
+    (appears in next briefing)
+```
+
+### 9.11 User Flow: Builder Check-In
+
+```
+              Builder opens app
+                    │
+                    ▼
+            ┌───────────────┐
+            │ Builder Dash  │
+            │  /builder     │
+            └───────┬───────┘
+                    │
+         ┌──────────┴──────────┐
+         │                     │
+    Active SDs            Ready Queue
+    need attention?       pick next?
+         │                     │
+    YES  │                YES  │
+         ▼                     ▼
+  ┌─────────────┐    ┌─────────────────┐
+  │ View blocker│    │ View SD detail  │
+  │ or progress │    │ in queue        │
+  └──────┬──────┘    └────────┬────────┘
+         │                    │
+         ▼                    ▼
+  [Open in Claude Code]  [Open in Claude Code]
+         │                    │
+         ▼                    ▼
+  Continue work in       Start SD via CLI
+  Claude Code terminal   (npm run sd:next)
+```
+
+---
+
+## 10. Data Freshness Strategy
+
+The dashboard serves a **batched daily review** workflow, not real-time monitoring. This shapes every data-fetching decision.
+
+### Freshness Tiers
+
+| Tier | Refresh Model | Staleness Tolerance | Views |
+|------|--------------|---------------------|-------|
+| **Live** | Supabase Realtime subscription | 0s | Decision Queue (new decisions arriving) |
+| **Near-live** | Poll every 60s while tab is active | 1 min | Active SDs (phase transitions), Alerts |
+| **Session** | Fetch on view mount, cache for session | 5-15 min | Daily Briefing, Venture Lifecycle, Vision & Alignment |
+| **Manual** | Fetch on explicit refresh or navigation | Unlimited | Build Queue, Preferences |
+
+### Why Not All Realtime?
+
+Supabase Realtime uses WebSocket connections per subscription. For a single-user daily-review tool:
+- Most data changes infrequently (venture stages move once every few days)
+- Realtime subscriptions add connection overhead and reconnection complexity on mobile
+- Only the Decision Queue benefits from instant updates — a new blocking gate decision should appear immediately
+
+### Stale Data Indicator
+
+When data is older than its staleness tolerance, show a subtle indicator:
+```
+Last updated: 3 min ago  [↻ Refresh]
+```
+No aggressive "stale data" warnings — the chairman knows this is a daily tool.
+
+### Background Prefetch (Phase D / PWA)
+
+When the PWA service worker is active:
+- Prefetch Daily Briefing data on app open (before the user navigates)
+- Cache the last successful response for each view — show cached data instantly, then refresh in background
+- This enables offline-capable read views in Phase D
+
+---
+
+## 11. Notification & Alert Delivery
+
+### The Problem
+
+The dashboard is a pull-based tool — the chairman must open it to see updates. But some events need to push to the chairman:
+- A new blocking gate decision is waiting (Stages 10, 22, 25)
+- A venture's HEAL score drops below threshold
+- An auto-approve timeout is approaching (< 4h remaining)
+
+### Delivery Strategy (Phased)
+
+| Phase | Channel | Events | Implementation |
+|-------|---------|--------|----------------|
+| **C (MVP)** | Dashboard badge | All alerts | Red dot on Alerts nav icon, count in tab title: `(3) Chairman` |
+| **C (MVP)** | Email digest | Blocking decisions only | Daily email at configured time (morning) via Supabase Edge Function + Resend |
+| **D (PWA)** | Push notification | Blocking decisions, critical HEAL drops | Web Push API via service worker |
+| **D (PWA)** | App badge | Unread count | Navigator Badge API (where supported) |
+
+### Alert Priority Levels
+
+| Priority | Trigger | Phase C Behavior | Phase D Behavior |
+|----------|---------|-----------------|-----------------|
+| **Critical** | New blocking gate decision | Email + badge | Push + badge |
+| **Warning** | HEAL score < threshold, auto-approve < 4h | Badge only | Push + badge |
+| **Info** | Stage progression, SD completion, advisory touchpoint | Badge only | Badge only |
+
+### Chairman Preferences Integration
+
+The Preferences view (Section 4 IA) controls:
+- Email digest time (default: 08:00 local)
+- Email digest enabled/disabled
+- Push notification opt-in (Phase D)
+- Alert priority threshold (receive Critical only, or Critical + Warning)
+
+These preferences are stored in `chairman_preferences` table and respected by the Edge Function / service worker.
+
+### No Telegram, No SMS
+
+Per the brainstorm: Telegram was explicitly rejected by the chairman. SMS adds cost and complexity for a single-user system. Email is the sole push channel in Phase C; Web Push supplements it in Phase D.
+
+---
+
+## 12. Success Criteria
+
+1. **Daily habit formation**: Chairman opens the briefing view at least 5 of 7 days per week after 2 weeks
+2. **Decision queue clearance**: All blocking gate decisions resolved through the UI (not CLI or auto-approve)
+3. **Context sufficiency**: Chairman can make gate decisions without needing to open CLI for additional context
+4. **Mobile usable**: All views render and function correctly on iPhone/Android browser
+5. **Sub-second loads**: Dashboard views load in < 1s with cached Supabase queries
+
+---
+
+## 13. Related Documents
+
+- Brainstorm: `brainstorm/2026-02-25-chairman-web-ui-hybrid-dashboard.md`
+- Architecture Plan: `docs/plans/chairman-web-ui-architecture.md`
+- EVA Lifecycle Vision: `docs/plans/eva-venture-lifecycle-vision.md`
+- Phase 01 Guide: `docs/guides/workflow/cli-venture-lifecycle/stages/phase-01-the-truth.md`
+- SD-MAN-FEAT-CORRECTIVE-VISION-GAP-005 (V07: GUI limited to Chairman governance)


### PR DESCRIPTION
## Summary
- Add vision document with 13 sections: personas, IA, decision points, Claude Code integration, data freshness strategy, notification delivery, wireframes, Phase C→D evolution
- Add architecture plan: route structure, component design, legacy deprecation mapping, 5-phase implementation (~22-36h)
- Add brainstorm document capturing team analysis and tradeoff matrix
- Enhance brainstorm skill with auto-detection for vision/architecture needs (Steps 8.5, 9.5)

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Vision document reviewed by chairman
- [ ] Architecture plan aligns with existing EHG app structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that extend the `/brainstorm` playbook and add planning artifacts; no production code paths or data handling logic are modified.
> 
> **Overview**
> Updates `.claude/commands/brainstorm.md` to add a new scope-assessment step (8.5) that prompts for planning docs, plus a follow-on pipeline step (9.5) describing how to draft and register *vision* and *architecture plan* documents in EVA and adjust “Ready for SD” next-step prompts based on whether those docs were created.
> 
> Adds three new documents: a Chairman Web UI brainstorm (`brainstorm/2026-02-25-...`), and corresponding `docs/plans/chairman-web-ui-vision.md` + `docs/plans/chairman-web-ui-architecture.md` capturing the proposed IA, phased rollout, and implementation/deprecation plan.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05cdbf4d0feb8e46a1cb930f268e2247b6887785. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->