### PR TITLE
fix(eva): 13 bug fixes + prompts + review skill for vision/archplan pipeline

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -552,7 +552,7 @@ After outcome classification, assess whether the brainstorm requires formal visi
 | Signal | Indicates |
 |--------|-----------|
 | Topic contains: "new UI", "new system", "platform", "redesign", "from scratch" | New build surface |
-| Outcome is "Ready for SD" AND estimated effort > 20h | Significant scope |
+| Pragmatist feasibility ≤ 5/10 OR 3+ implementation phases identified | Significant scope (complexity-based, not time-based) |
 | Multiple personas or user types identified | Needs UX vision |
 | Team analysis Pragmatist rated feasibility ≤ 5/10 | Complex enough for architecture |
 | Brainstorm domain is "architecture" | Architecture plan inherent |
@@ -731,8 +731,10 @@ node scripts/eva/vision-command.mjs upsert \
 **Dimension derivation** (no LLM needed):
 - Extract 6-10 dimensions from the vision doc's success criteria and key sections
 - Each dimension: `{name, weight, description, source_section}`
-- Weights should sum to ~1.0
+- Weights should sum to ~1.0 — verify before passing (warn if outside 0.9-1.1)
 - Use `timeout: 30000` for the command
+
+**Key format**: `VISION-<CONTEXT>-L2-NNN` where CONTEXT = venture_id when available, topic key otherwise
 
 If upsert succeeds, note the returned vision ID and key for the architecture plan linkage.
 
@@ -759,6 +761,9 @@ node scripts/eva/archplan-command.mjs upsert \
 ```
 
 Architecture dimensions focus on structural/implementation aspects (6-8 dimensions).
+Weights should sum to ~1.0 — verify before passing (warn if outside 0.9-1.1).
+
+**Key format**: `ARCH-<CONTEXT>-NNN` where CONTEXT = venture_id when available, topic key otherwise
 
 ### 9.5E: Confirm Registration
 

--- a/.claude/skills/eva-vision.skill.md
+++ b/.claude/skills/eva-vision.skill.md
@@ -59,6 +59,26 @@ If `--source` not provided, ask:
 "What is the path to the source document? (e.g. docs/plans/eva-venture-lifecycle-vision.md)"
 ```
 
+**Step 1.5: Scope disambiguation**
+
+Ask using AskUserQuestion:
+
+```javascript
+{
+  "questions": [{
+    "question": "Is this vision scoped to a single venture or portfolio-wide?",
+    "header": "Scope",
+    "multiSelect": false,
+    "options": [
+      {"label": "Single venture (Recommended for L2)", "description": "Vision applies to one specific venture"},
+      {"label": "Portfolio-wide (Recommended for L1)", "description": "Vision applies across all EHG ventures"}
+    ]
+  }]
+}
+```
+
+Cross-validate: If the user chose L1 but "Single venture", or L2 but "Portfolio-wide", warn about the mismatch and confirm they want to proceed.
+
 **Step 2: Generate a vision key**
 
 Format: `VISION-<PREFIX>-<LEVEL>-<NNN>`
@@ -75,6 +95,32 @@ node scripts/eva/vision-command.mjs extract --source <source-path>
 
 Capture the JSON output (dimensions array).
 
+**Step 3.5: Required section validation**
+
+After extraction, check the source document for these required sections:
+- Problem Statement
+- Personas / Audience
+- Success Criteria
+- Scope
+
+If any are missing, ask using AskUserQuestion:
+
+```javascript
+{
+  "questions": [{
+    "question": "The source document is missing: [list missing sections]. These improve HEAL scoring quality.",
+    "header": "Missing Sections",
+    "multiSelect": false,
+    "options": [
+      {"label": "Add sections now", "description": "I'll provide the missing content before saving"},
+      {"label": "Proceed without", "description": "Save as-is — sections can be added via addendum later"}
+    ]
+  }]
+}
+```
+
+If the user chooses to add sections, collect the content and append to the source before proceeding.
+
 **Step 4: Chairman approval gate**
 
 Present the dimensions to the user:
@@ -88,6 +134,12 @@ Vision Key: <generated-key>
 Level: <L1|L2>
 Source: <source-path>
 Dimensions: <count>
+Weight Sum: <sum> (should be ~1.0)
+```
+
+If the weight sum is outside 0.9-1.1, display a warning:
+```
+⚠️  Dimension weights sum to <sum> — expected ~1.0. Consider adjusting before approval.
 ```
 
 Then ask:

--- a/.claude/skills/review-vision.skill.md
+++ b/.claude/skills/review-vision.skill.md
@@ -1,0 +1,237 @@
+# /eva review - Post-Creation Vision & Architecture Review
+
+Review existing vision documents and/or architecture plans using a 3-agent team (Challenger, Visionary, Pragmatist) to identify blind spots, opportunities, and feasibility concerns.
+
+## Usage
+
+```
+/eva review --vision-key <key>
+/eva review --plan-key <key>
+/eva review --vision-key <key> --plan-key <key>
+```
+
+## Instructions for Claude
+
+### Step 0: Parse Arguments
+
+From `$ARGUMENTS`, extract:
+- `--vision-key <key>` — vision document to review
+- `--plan-key <key>` — architecture plan to review
+
+If neither key is provided, ask using AskUserQuestion:
+
+```javascript
+{
+  "questions": [{
+    "question": "What would you like to review?",
+    "header": "Review Target",
+    "multiSelect": false,
+    "options": [
+      {"label": "Vision document", "description": "Review a vision document by key"},
+      {"label": "Architecture plan", "description": "Review an architecture plan by key"},
+      {"label": "Both", "description": "Review a vision document and its linked architecture plan"}
+    ]
+  }]
+}
+```
+
+Then ask for the specific key(s). Run `list` commands to help the user choose:
+- `node scripts/eva/vision-command.mjs list`
+- `node scripts/eva/archplan-command.mjs list`
+
+---
+
+### Step 1: Fetch Document(s)
+
+Fetch the document content from the database:
+
+```bash
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+async function main() {
+  const visionKey = process.argv[2] || null;
+  const planKey = process.argv[3] || null;
+  const results = {};
+  if (visionKey) {
+    const { data } = await supabase.from('eva_vision_documents')
+      .select('vision_key, level, content, extracted_dimensions, addendums, status, version')
+      .eq('vision_key', visionKey).single();
+    results.vision = data;
+  }
+  if (planKey) {
+    const { data } = await supabase.from('eva_architecture_plans')
+      .select('plan_key, content, extracted_dimensions, addendums, status, version')
+      .eq('plan_key', planKey).single();
+    results.plan = data;
+  }
+  console.log(JSON.stringify(results, null, 2));
+}
+main().catch(e => console.error(e.message));
+" "<VISION_KEY>" "<PLAN_KEY>"
+```
+
+If document not found, report the error and exit.
+
+---
+
+### Step 2: Spawn 3-Agent Review Team
+
+Use TeamCreate:
+
+```
+team_name: "eva-review"
+description: "3-agent review of EVA vision/architecture documents"
+```
+
+Then spawn 3 teammates using the Task tool with `team_name: "eva-review"`:
+
+**Challenger** (subagent_type: "general-purpose"):
+```
+You are the Challenger reviewing an EVA vision/architecture document. Your job is to stress-test it.
+
+Document(s):
+[DOCUMENT CONTENT]
+
+Analyze for:
+1. BLIND SPOTS: 2-3 things the document fails to address (missing stakeholders, unaddressed failure modes, ignored competitors)
+2. ASSUMPTION TESTING: 2-3 assumptions that could be wrong (market, technical, resource)
+3. SCOPE CREEP RISK: Areas where scope could expand uncontrollably
+4. MISSING STAKEHOLDERS: Who is affected but not mentioned?
+
+Output your analysis as structured markdown sections. Be specific — reference document sections by name.
+```
+
+**Visionary** (subagent_type: "general-purpose"):
+```
+You are the Visionary reviewing an EVA vision/architecture document. Your job is to assess strategic alignment and opportunities.
+
+Document(s):
+[DOCUMENT CONTENT]
+
+Analyze for:
+1. L1 ALIGNMENT: How well does this align with portfolio-level strategic vision? Score 1-10.
+2. HEAL SCORING POTENTIAL: Will the extracted dimensions produce meaningful HEAL scores? Flag weak dimensions.
+3. DOWNSTREAM SD QUALITY: Will SDs created from this document have clear scope and success criteria?
+4. OPPORTUNITIES: 2-3 strategic opportunities the document could better leverage
+
+Output your analysis as structured markdown sections.
+```
+
+**Pragmatist** (subagent_type: "general-purpose"):
+```
+You are the Pragmatist reviewing an EVA vision/architecture document. Your job is to assess feasibility and implementation reality.
+
+Document(s):
+[DOCUMENT CONTENT]
+
+Analyze for:
+1. IMPLEMENTABILITY: Score 1-10. Can this actually be built as described?
+2. RESOURCE REALISM: Are the implied resources (time, people, infrastructure) realistic?
+3. TIMELINE FEASIBILITY: Is the phasing/evolution plan achievable?
+4. RECOMMENDED AMENDMENTS: 2-3 specific changes that would improve implementability
+
+Output your analysis as structured markdown sections. Be concrete — suggest specific amendments.
+```
+
+**Timeout**: 90 seconds per agent. If an agent times out, proceed with available perspectives.
+
+---
+
+### Step 3: Synthesize Results
+
+After all agents respond (or timeout), synthesize:
+
+```
+## Review Synthesis
+
+### Consensus
+[Where 2+ perspectives agree — these are high-confidence findings]
+
+### Tensions
+[Where perspectives conflict — these are the most valuable insights for the chairman]
+
+### Composite Risk Score
+[Low / Medium / High — based on Challenger severity weighted against Pragmatist implementability]
+
+### Key Recommendations
+1. [Most impactful recommendation]
+2. [Second recommendation]
+3. [Third recommendation]
+```
+
+Present the full synthesis to the user.
+
+---
+
+### Step 4: Action Decision
+
+Ask using AskUserQuestion:
+
+```javascript
+{
+  "questions": [{
+    "question": "How would you like to act on these review findings?",
+    "header": "Review Action",
+    "multiSelect": false,
+    "options": [
+      {"label": "Add addendum with findings", "description": "Append review synthesis as an addendum to the document(s)"},
+      {"label": "Update document manually", "description": "I'll make changes myself based on the findings"},
+      {"label": "No changes", "description": "Review noted — no modifications needed"}
+    ]
+  }]
+}
+```
+
+---
+
+### Step 5: Execute Action
+
+**If "Add addendum"**: Format the synthesis as addendum text and run:
+
+For vision documents:
+```bash
+node scripts/eva/vision-command.mjs addendum \
+  --vision-key <key> \
+  --section "<formatted-synthesis>"
+```
+
+For architecture plans:
+```bash
+node scripts/eva/archplan-command.mjs addendum \
+  --plan-key <key> \
+  --section "<formatted-synthesis>"
+```
+
+**If "Update manually"**: Display the key findings in a copy-friendly format.
+
+**If "No changes"**: Acknowledge and proceed.
+
+---
+
+### Step 6: Shutdown Review Team
+
+Send shutdown requests to all 3 teammates:
+
+```
+type: "shutdown_request"
+recipient: "<agent-name>"
+content: "Review complete, shutting down"
+```
+
+---
+
+## Related Commands
+
+- `/eva vision` — Create and manage vision documents
+- `/eva archplan` — Create and manage architecture plans
+- `/brainstorm` — Strategic brainstorming (creates documents that can be reviewed)
+- `/heal` — Score codebase against vision dimensions
+
+## Notes
+
+- This skill is read-only by default — it only writes when the user explicitly chooses "Add addendum"
+- The 3-agent team mirrors the brainstorm analysis team (Challenger/Visionary/Pragmatist) for consistency
+- Review findings are most valuable when the document has been in use for a while and assumptions can be tested
+- Addendums preserve the original document while recording review insights for traceability


### PR DESCRIPTION
## Summary
- **Phase 1**: Fix 13 CLI bugs across `archplan-command.mjs`, `vision-command.mjs`, `brainstorm-to-vision.mjs` — truncation limits (8K→15K), missing fields in upsert records, new `cmdAddendum` for archplan, left join for orphaned plans, weight validation, dynamic L1 key lookup, retry logic, destructive field removal, venture_id key prefix
- **Phase 2**: Add AskUserQuestion prompts and section validation to `eva-vision.skill.md` (scope disambiguation, required sections, weight warning), `eva-archplan.skill.md` (brainstorm linkage, section validation, addendum path), `brainstorm.md` (Pragmatist feasibility signal replaces effort>20h)
- **Phase 3**: New `/eva review` skill (`review-vision.skill.md`) — 3-agent team review (Challenger/Visionary/Pragmatist) with synthesis and optional addendum

## Test plan
- [ ] `archplan-command.mjs upsert` with `--brainstorm-id` stores the value
- [ ] `archplan-command.mjs addendum` works end-to-end
- [ ] `archplan-command.mjs list` shows orphaned plans with `(orphaned)` label
- [ ] `vision-command.mjs upsert` preserves existing addendums on re-upsert
- [ ] Truncation warnings appear for docs > 15K chars
- [ ] Weight warnings appear when sum outside 0.9-1.1
- [ ] `brainstorm-to-vision.mjs --dry-run` resolves L1 key dynamically
- [ ] `/eva vision create` shows scope disambiguation prompt
- [ ] `/eva review --vision-key <key>` spawns 3 agents and produces synthesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)