### PR TITLE
fix(gate3): use sdKey instead of UUID for git commit grep

### DIFF
--- a/scripts/modules/traceability-validation/index.js
+++ b/scripts/modules/traceability-validation/index.js
@@ -126,7 +126,7 @@ export async function validateGate3PlanToLead(sd_id, supabase, gate2Results = nu
     // Section C: Traceability Mapping
     console.log('\n[C] Traceability Mapping');
     console.log('-'.repeat(60));
-    await validateTraceabilityMapping(sd_id, sdUuid, designAnalysis, databaseAnalysis, validation, supabase, sdCategory, gitRepoPath, sdType);
+    await validateTraceabilityMapping(sdKey, sdUuid, designAnalysis, databaseAnalysis, validation, supabase, sdCategory, gitRepoPath, sdType);
 
     // Section D: Sub-Agent Effectiveness
     console.log('\n[D] Sub-Agent Effectiveness');


### PR DESCRIPTION
## Summary
- Fix Gate 3 C1 traceability scoring: was using UUID to grep git commits, but commits use human-readable sd_key
- One-line change in traceability-validation/index.js

## Test plan
- [x] Gate 3 C1 now scores 7/7 for SD-LEO-FEAT-CHAIRMAN-WEB-UI-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)