### PR TITLE
fix: add Gemini model fallback on quota exhaustion

### DIFF
--- a/lib/ai/multimodal-client.js
+++ b/lib/ai/multimodal-client.js
@@ -36,6 +36,7 @@ class MultimodalClient {
       'claude-opus-4': { input: 15.00, output: 75.00 },  // Claude Opus 4
       'claude-haiku-3': { input: 0.25, output: 1.25 },  // Claude Haiku 3
       'gemini-3.1-pro-preview': { input: 1.25, output: 10.00 },  // Gemini 3.1 Pro
+      'gemini-2.5-pro-preview-05-06': { input: 1.25, output: 10.00 },  // Gemini 2.5 Pro (fallback)
       'gemini-3-flash-preview': { input: 0.10, output: 0.40 },  // Gemini 3 Flash
       'local': { input: 0, output: 0 }
     };
@@ -248,33 +249,49 @@ Respond in JSON format:
    */
   async callGemini(imageData, prompt) {
     const apiKey = this.config.apiKey || process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY;
-    const model = this.config.model || 'gemini-3.1-pro-preview';
-    const response = await axios.post(
-      `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
-      {
-        contents: [{
-          parts: [
-            { text: prompt },
-            {
-              inlineData: {
-                mimeType: 'image/png',
-                data: imageData
-              }
+    const primaryModel = this.config.model || 'gemini-3.1-pro-preview';
+    const fallbackModels = this.config.fallbackModels || ['gemini-2.5-pro-preview-05-06', 'gemini-3-flash-preview'];
+    const modelsToTry = [primaryModel, ...fallbackModels.filter(m => m !== primaryModel)];
+
+    for (const model of modelsToTry) {
+      try {
+        const response = await axios.post(
+          `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+          {
+            contents: [{
+              parts: [
+                { text: prompt },
+                {
+                  inlineData: {
+                    mimeType: 'image/png',
+                    data: imageData
+                  }
+                }
+              ]
+            }],
+            generationConfig: {
+              temperature: this.config.temperature,
+              maxOutputTokens: this.config.maxTokens,
+              responseMimeType: 'application/json'
             }
-          ]
-        }],
-        generationConfig: {
-          temperature: this.config.temperature,
-          maxOutputTokens: this.config.maxTokens,
-          responseMimeType: 'application/json'
+          },
+          {
+            headers: { 'Content-Type': 'application/json' },
+            timeout: this.config.timeout
+          }
+        );
+        return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+      } catch (error) {
+        const status = error.response?.status;
+        const isQuotaError = status === 429 || status === 503 ||
+          error.response?.data?.error?.status === 'RESOURCE_EXHAUSTED';
+        if (isQuotaError && model !== modelsToTry[modelsToTry.length - 1]) {
+          console.warn(`[MultimodalClient] ${model} quota exhausted, falling back to next model...`);
+          continue;
         }
-      },
-      {
-        headers: { 'Content-Type': 'application/json' },
-        timeout: this.config.timeout
+        throw error;
       }
-    );
-    return response.data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- When Gemini 3.1 Pro daily quota is exhausted (429/503/RESOURCE_EXHAUSTED), `callGemini()` now automatically falls back to Gemini 2.5 Pro, then Gemini 3 Flash
- Fallback chain is configurable via `config.fallbackModels`
- Added pricing entry for gemini-2.5-pro-preview-05-06

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Verify fallback triggers on real quota exhaustion

🤖 Generated with [Claude Code](https://claude.com/claude-code)