### PR TITLE
feat: add CONST-012/013/014 scope integrity rules and Gemini fallback

### DIFF
--- a/database/migrations/insert-const-012-013-014-scope-integrity.sql
+++ b/database/migrations/insert-const-012-013-014-scope-integrity.sql
@@ -1,0 +1,48 @@
+-- Migration: Insert CONST-012, CONST-013, CONST-014 into protocol_constitution
+-- SD: SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001-A
+-- Idempotent: Uses ON CONFLICT DO NOTHING
+-- These rules enforce SD scope integrity at the constitutional level
+
+-- CONST-012: Every FR listed in the PRD must have delivery evidence before SD completion
+INSERT INTO protocol_constitution (rule_code, rule_text, category, rationale)
+VALUES (
+  'CONST-012',
+  'Every functional requirement (FR) listed in the PRD must have delivery evidence (test result, screenshot, or code diff) before the SD can reach LEAD-FINAL-APPROVAL. Missing FR delivery is a blocking gate failure.',
+  'governance',
+  'SDs were reaching completion with FRs silently dropped. Without delivery verification, scope promises made in PLAN phase are not enforceable. Root cause: SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001.'
+) ON CONFLICT (rule_code) DO NOTHING;
+
+-- CONST-013: Gate thresholds and skip-lists cannot be modified during EXEC phase
+INSERT INTO protocol_constitution (rule_code, rule_text, category, rationale)
+VALUES (
+  'CONST-013',
+  'Gate thresholds and gate skip-lists must not be modified during EXEC phase execution. Any gate configuration change requires a new SD or escalation to LEAD phase. Runtime bypass of gates is a CRITICAL violation.',
+  'safety',
+  'Gate thresholds were being lowered or gates skipped during EXEC to pass failing validations. This defeats the purpose of quality gates. Root cause: SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001.'
+) ON CONFLICT (rule_code) DO NOTHING;
+
+-- CONST-014: SDs with 3+ phases or 8+ FRs must decompose into child SDs
+INSERT INTO protocol_constitution (rule_code, rule_text, category, rationale)
+VALUES (
+  'CONST-014',
+  'Any SD with 3 or more distinct implementation phases or 8 or more functional requirements must be decomposed into child SDs via the orchestrator pattern. Monolithic SDs that exceed these thresholds must not proceed past LEAD approval.',
+  'governance',
+  'Large monolithic SDs accumulate scope that cannot be tracked or verified. Decomposition ensures each child has a focused scope with verifiable deliverables. Root cause: SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001.'
+) ON CONFLICT (rule_code) DO NOTHING;
+
+-- Mirror as aegis_rules for runtime enforcement
+-- First check if aegis_rules table exists and insert
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'aegis_rules') THEN
+    INSERT INTO aegis_rules (rule_key, rule_type, title, description, severity, is_active, validation_config)
+    VALUES
+      ('CONST-012', 'constitution', 'FR Delivery Verification', 'Every FR must have delivery evidence before SD completion', 'HIGH', true,
+       '{"check_type": "fr_delivery_audit", "trigger_phase": "LEAD-FINAL-APPROVAL", "blocking": true}'::jsonb),
+      ('CONST-013', 'constitution', 'Gate Immutability During EXEC', 'Gate thresholds cannot be modified during EXEC phase', 'CRITICAL', true,
+       '{"check_type": "gate_config_freeze", "trigger_phase": "EXEC", "blocking": true}'::jsonb),
+      ('CONST-014', 'constitution', 'Mandatory Decomposition', 'SDs with 3+ phases or 8+ FRs must use orchestrator pattern', 'HIGH', true,
+       '{"check_type": "scope_decomposition", "trigger_phase": "LEAD-TO-PLAN", "blocking": true, "thresholds": {"max_phases": 3, "max_frs": 8}}'::jsonb)
+    ON CONFLICT (rule_key) DO NOTHING;
+  END IF;
+END $$;

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -349,6 +349,8 @@ const GEMINI_THINKING_LEVELS = {
 };
 
 export class GoogleAdapter {
+  static FALLBACK_MODELS = ['gemini-2.5-pro', 'gemini-2.5-flash'];
+
   constructor(options = {}) {
     this.apiKey = options.apiKey || process.env.GOOGLE_AI_API_KEY || process.env.GEMINI_API_KEY;
     this.baseUrl = options.baseUrl || 'https://generativelanguage.googleapis.com/v1beta';
@@ -356,6 +358,7 @@ export class GoogleAdapter {
     this.model = this.defaultModel;
     this.provider = 'google';
     this.family = 'google';
+    this.fallbackEnabled = options.fallbackEnabled !== false;
     addOpenAICompatLayer(this);
   }
 
@@ -442,6 +445,24 @@ export class GoogleAdapter {
         if (attempt < MAX_RETRIES) {
           console.warn(`[GoogleAdapter] Attempt ${attempt + 1} failed, retrying...`, lastError.message);
           await sleep(RETRY_DELAY_MS * (attempt + 1));
+        }
+      }
+    }
+
+    // Fallback: if rate-limited (429), try fallback models before giving up
+    if (this.fallbackEnabled && !options._fallbackAttempt && lastError?.message?.includes('429')) {
+      const triedModel = model;
+      const fallbacks = GoogleAdapter.FALLBACK_MODELS.filter(m => m !== triedModel);
+      for (const fallbackModel of fallbacks) {
+        try {
+          console.warn(`[GoogleAdapter] Rate-limited on ${triedModel}, falling back to ${fallbackModel}`);
+          return await this.complete(systemPrompt, userPrompt, {
+            ...options,
+            model: fallbackModel,
+            _fallbackAttempt: true
+          });
+        } catch (fallbackError) {
+          console.warn(`[GoogleAdapter] Fallback ${fallbackModel} also failed: ${fallbackError.message?.slice(0, 100)}`);
         }
       }
     }

--- a/scripts/modules/ai-quality-judge/config.js
+++ b/scripts/modules/ai-quality-judge/config.js
@@ -85,7 +85,10 @@ export const CONSTITUTION_RULE_CODES = [
   'CONST-008', // Chesterton's Fence
   'CONST-009', // Human FREEZE command
   'CONST-010', // Non-Manipulation Principle (SD-LEO-INFRA-CONST-AMEND-001)
-  'CONST-011'  // Value Priority Hierarchy (SD-LEO-INFRA-CONST-AMEND-001)
+  'CONST-011', // Value Priority Hierarchy (SD-LEO-INFRA-CONST-AMEND-001)
+  'CONST-012', // FR Delivery Verification (SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001-A)
+  'CONST-013', // Gate Immutability During EXEC (SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001-A)
+  'CONST-014'  // Mandatory Decomposition (SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001-A)
 ];
 
 /**
@@ -94,11 +97,11 @@ export const CONSTITUTION_RULE_CODES = [
 export const VIOLATION_SEVERITY = {
   CRITICAL: {
     description: 'Auto-reject, no human override allowed',
-    rules: ['CONST-001', 'CONST-002', 'CONST-007', 'CONST-009']
+    rules: ['CONST-001', 'CONST-002', 'CONST-007', 'CONST-009', 'CONST-013']
   },
   HIGH: {
     description: 'Flag for mandatory human review',
-    rules: ['CONST-003', 'CONST-004', 'CONST-005']
+    rules: ['CONST-003', 'CONST-004', 'CONST-005', 'CONST-012', 'CONST-014']
   },
   MEDIUM: {
     description: 'Warning, human review recommended',


### PR DESCRIPTION
## Summary
- Insert CONST-012 (FR delivery verification), CONST-013 (gate immutability during EXEC), CONST-014 (mandatory decomposition) into protocol_constitution
- Register new rules in ai-quality-judge config.js with correct severity mappings
- Add automatic Gemini model fallback in GoogleAdapter (3.1 Pro → 2.5 Pro → 2.5 Flash on 429)

## Test plan
- [x] Constitution validator loads all 14 rules from database
- [x] Severity mappings verified: CONST-013=CRITICAL, CONST-012/014=HIGH
- [x] Gemini fallback tested: 3.1 Pro 429 → 2.5 Pro succeeds
- [x] Smoke tests pass (15/15)
- [x] Pre-commit hooks pass (Gate 0, LOC check, secrets scan)

SD: SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)