### PR TITLE
feat: add CONST-014 decomposition check gate to PLAN-TO-EXEC

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-exec/gates/decomposition-check.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/decomposition-check.js
@@ -1,0 +1,139 @@
+/**
+ * Decomposition Check Gate (CONST-014)
+ * Part of SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001-D
+ *
+ * Blocks PLAN-TO-EXEC when PRD reveals multi-phase complexity,
+ * recommending SD decomposition into orchestrator + children.
+ */
+
+const PHASE_SIGNALS = [
+  'phase 1', 'phase 2', 'phase 3', 'phase 4',
+  'step 1', 'step 2', 'step 3', 'step 4',
+  'stage 1', 'stage 2', 'stage 3', 'stage 4',
+  'layer 1', 'layer 2', 'layer 3'
+];
+
+const PHASE_THRESHOLD = 3;
+const FR_THRESHOLD = 8;
+
+/**
+ * Create the DECOMPOSITION_CHECK gate validator
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Object} Gate configuration
+ */
+export function createDecompositionCheckGate(supabase) {
+  return {
+    name: 'DECOMPOSITION_CHECK',
+    validator: async (ctx) => {
+      console.log('\n🔒 GATE: Decomposition Check (CONST-014)');
+      console.log('-'.repeat(50));
+
+      const sdUuid = ctx.sd?.id || ctx.sdId;
+
+      // Orchestrator SDs (with children) skip this gate
+      const { data: children } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sdUuid);
+
+      if (children && children.length > 0) {
+        console.log('   ℹ️  Orchestrator SD — decomposition already applied');
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: ['Orchestrator SD — decomposition check skipped']
+        };
+      }
+
+      // Child SDs skip this gate (already decomposed)
+      if (ctx.sd?.parent_sd_id) {
+        console.log('   ℹ️  Child SD — decomposition check not applicable');
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: ['Child SD — decomposition check skipped']
+        };
+      }
+
+      // Look up PRD
+      const { data: prdData, error } = await supabase
+        .from('product_requirements_v2')
+        .select('id, functional_requirements, implementation_approach')
+        .eq('sd_id', sdUuid)
+        .order('created_at', { ascending: false })
+        .limit(1);
+
+      if (error || !prdData || prdData.length === 0) {
+        console.log('   ⚠️  No PRD found — skipping decomposition check');
+        return {
+          passed: true,
+          score: 80,
+          max_score: 100,
+          issues: [],
+          warnings: ['No PRD found — decomposition check skipped']
+        };
+      }
+
+      const prd = prdData[0];
+
+      // Count functional requirements
+      const frs = prd.functional_requirements || [];
+      const frCount = frs.length;
+
+      // Count phase signals in implementation_approach
+      const approachText = (prd.implementation_approach || '').toLowerCase();
+      const phaseCount = PHASE_SIGNALS.filter(s => approachText.includes(s)).length;
+
+      console.log(`   📊 PRD Complexity Analysis:`);
+      console.log(`      Functional Requirements: ${frCount} (threshold: ${FR_THRESHOLD})`);
+      console.log(`      Phase signals detected: ${phaseCount} (threshold: ${PHASE_THRESHOLD})`);
+
+      const exceedsThreshold = phaseCount >= PHASE_THRESHOLD || frCount >= FR_THRESHOLD;
+
+      if (exceedsThreshold) {
+        const reasons = [];
+        if (phaseCount >= PHASE_THRESHOLD) {
+          reasons.push(`${phaseCount} implementation phases detected (max ${PHASE_THRESHOLD - 1})`);
+        }
+        if (frCount >= FR_THRESHOLD) {
+          reasons.push(`${frCount} functional requirements (max ${FR_THRESHOLD - 1})`);
+        }
+
+        console.log(`   ❌ DECOMPOSITION RECOMMENDED`);
+        console.log(`      Reasons: ${reasons.join(', ')}`);
+        console.log('');
+        console.log('   💡 Recommendation: Convert this SD to an orchestrator with children.');
+        console.log('      Each implementation phase should be a separate child SD.');
+        console.log('      Run: node scripts/leo-create-sd.js --child <parent-key>');
+
+        return {
+          passed: false,
+          score: 0,
+          max_score: 100,
+          issues: [
+            `CONST-014: SD complexity exceeds decomposition threshold — ${reasons.join('; ')}`
+          ],
+          warnings: [],
+          remediation: 'Decompose this SD into an orchestrator with child SDs. Each phase should be a separate child.',
+          details: { phaseCount, frCount, reasons }
+        };
+      }
+
+      console.log('   ✅ SD complexity within acceptable bounds');
+      return {
+        passed: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings: [],
+        details: { phaseCount, frCount }
+      };
+    },
+    required: true
+  };
+}

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/index.js
@@ -16,3 +16,4 @@ export { createInfrastructureConsumerCheckGate, generateFollowUpSD, REASON_CODES
 export { createIntegrationSectionValidationGate, REQUIRED_SUBSECTIONS, SUBSECTION_NAMES, BLOCKING_SD_TYPES, WARNING_SD_TYPES, SKIP_SD_TYPES, ERROR_CODE_PREFIX } from './integration-section-validation.js';
 export { createMigrationDataVerificationGate } from './migration-data-verification.js';
 export { createArchitecturalPatternChecklistGate } from './architectural-pattern-checklist.js';
+export { createDecompositionCheckGate } from './decomposition-check.js';

--- a/scripts/modules/handoff/executors/plan-to-exec/index.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/index.js
@@ -22,7 +22,8 @@ import {
   createInfrastructureConsumerCheckGate,
   createIntegrationSectionValidationGate,
   createMigrationDataVerificationGate,
-  createArchitecturalPatternChecklistGate
+  createArchitecturalPatternChecklistGate,
+  createDecompositionCheckGate
 } from './gates/index.js';
 
 // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
@@ -170,6 +171,10 @@ export class PlanToExecExecutor extends BaseExecutor {
     // ADVISORY: Scans PRD for state management, error handling, observability patterns
     // Only runs for complex SDs (story_points >= 8 OR LOC >= 500 OR hasChildren)
     gates.push(createArchitecturalPatternChecklistGate(this.prdRepo, sd, this.supabase));
+
+    // Decomposition Check (CONST-014)
+    // Blocks PLAN-TO-EXEC when PRD reveals multi-phase complexity
+    gates.push(createDecompositionCheckGate(this.supabase));
 
     return gates;
   }


### PR DESCRIPTION
## Summary
- Adds DECOMPOSITION_CHECK gate to PLAN-TO-EXEC handoff enforcing CONST-014
- Blocks when PRD reveals 3+ implementation phases or 8+ functional requirements
- Orchestrator and child SDs automatically bypass the gate
- Registered in validation_gate_registry as REQUIRED for all SD types
- Part of SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001 (Child D)

## Test plan
- [x] Gate integrates into PlanToExecExecutor gate array
- [x] Gate registered in validation_gate_registry
- [x] LEAD-FINAL-APPROVAL passed at 95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)