### PR TITLE
fix: GoogleAdapter 503 fallback resilience

### DIFF
--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -445,18 +445,22 @@ export class GoogleAdapter {
         }
         if (attempt < MAX_RETRIES) {
           console.warn(`[GoogleAdapter] Attempt ${attempt + 1} failed, retrying...`, lastError.message);
-          await sleep(RETRY_DELAY_MS * (attempt + 1));
+          const is503 = lastError?.message?.includes('503');
+          const baseDelay = is503 ? 3000 : RETRY_DELAY_MS;
+          await sleep(baseDelay * (attempt + 1));
         }
       }
     }
 
-    // Fallback: if rate-limited (429), try fallback models before giving up
-    if (this.fallbackEnabled && !options._fallbackAttempt && lastError?.message?.includes('429')) {
+    // Fallback: if rate-limited (429) or service unavailable (503), try fallback models before giving up
+    const isRetryableError = lastError?.message?.includes('429') || lastError?.message?.includes('503');
+    if (this.fallbackEnabled && !options._fallbackAttempt && isRetryableError) {
       const triedModel = model;
       const fallbacks = GoogleAdapter.FALLBACK_MODELS.filter(m => m !== triedModel);
       for (const fallbackModel of fallbacks) {
         try {
-          console.warn(`[GoogleAdapter] Rate-limited on ${triedModel}, falling back to ${fallbackModel}`);
+          const reason = lastError?.message?.includes('503') ? 'Service unavailable (503)' : 'Rate-limited (429)';
+          console.warn(`[GoogleAdapter] ${reason} on ${triedModel}, falling back to ${fallbackModel}`);
           return await this.complete(systemPrompt, userPrompt, {
             ...options,
             model: fallbackModel,


### PR DESCRIPTION
## Summary
- Extend GoogleAdapter model fallback to trigger on HTTP 503 (Service Unavailable) errors, not just 429 (Rate Limited)
- Add 503-specific retry delay (3s base vs 1s) to allow service recovery time
- Resolve 3 vision delta patterns (PAT-VDELTA-V03/V04/A01) as feature-level gaps in issue_patterns DB

## Test plan
- [ ] Verify GoogleAdapter falls back on 503 errors (matches MultimodalClient behavior)
- [ ] Verify 429 fallback behavior unchanged (regression)
- [ ] Verify 503 retry uses 3s base delay
- [ ] Confirm 3 vision delta patterns show status=resolved in issue_patterns

SD: SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-043

🤖 Generated with [Claude Code](https://claude.com/claude-code)