### PR TITLE
feat: intelligent claim health system (collision guard + self-heal)

### DIFF
--- a/lib/heartbeat-manager.mjs
+++ b/lib/heartbeat-manager.mjs
@@ -20,6 +20,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { updateHeartbeat as dbUpdateHeartbeat, endSession } from './session-manager.mjs';
+import { selfHeal } from '../scripts/modules/claim-health/self-heal.js';
 
 const __hb_filename = fileURLToPath(import.meta.url);
 const __hb_dirname = path.dirname(__hb_filename);
@@ -259,6 +260,17 @@ async function sendHeartbeat() {
     if (result.success || result.heartbeat_at) {
       consecutiveFailures = 0;
       lastSuccessfulHeartbeat = new Date();
+
+      // SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001: Run self-heal on every successful heartbeat
+      // Non-blocking — fire and forget, must complete within 2s
+      selfHeal(hbSupabase, currentSessionId).then(healResult => {
+        if (healResult.released.length > 0) {
+          console.log(`[Heartbeat] Self-heal released ${healResult.released.length} ghost claim(s): ${healResult.released.join(', ')}`);
+        }
+        if (healResult.errors.length > 0) {
+          console.warn(`[Heartbeat] Self-heal errors: ${healResult.errors.join('; ')}`);
+        }
+      }).catch(() => { /* silent fail — self-heal is best-effort */ });
     } else {
       consecutiveFailures++;
       console.warn(`[Heartbeat] Update returned no success (attempt ${consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES})`);

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -70,6 +70,9 @@ function getMachineId() {
 // PAT-SESSION-IDENTITY-003: Import centralized terminal identity
 import { getTerminalId as _getTerminalId } from './terminal-identity.js';
 
+// SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001: Collision guard
+import { shouldCreateNewSession } from '../scripts/modules/claim-health/collision-guard.js';
+
 /**
  * SD-LEO-INFRA-ISL-001: Get terminal identifier
  * Delegated to centralized lib/terminal-identity.js
@@ -260,9 +263,18 @@ export async function getOrCreateSession() {
   const existing = findExistingSession();
 
   if (existing) {
-    // Update heartbeat and return
-    await updateHeartbeat(existing.session_id);
-    return existing;
+    // SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001: Check collision guard
+    // If existing session has an active SD claim, create a NEW session
+    // instead of reusing (prevents claim clobbering in multi-session workflows)
+    const collisionCheck = shouldCreateNewSession(existing);
+    if (collisionCheck.shouldCreateNew) {
+      console.log(`[session-manager] Collision guard: existing session ${existing.session_id} has active claim on ${collisionCheck.claimedSd}, creating new session`);
+      // Fall through to create new session below
+    } else {
+      // Update heartbeat and return
+      await updateHeartbeat(existing.session_id);
+      return existing;
+    }
   }
 
   // Create new session

--- a/scripts/modules/claim-health/collision-guard.js
+++ b/scripts/modules/claim-health/collision-guard.js
@@ -1,0 +1,35 @@
+/**
+ * Collision Guard Module
+ * SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001
+ *
+ * Prevents session reuse from clobbering existing claims.
+ * When a new session registers with a terminal_id that matches an existing
+ * session which has an active SD claim, a NEW session row should be created
+ * instead of reusing the existing one.
+ */
+
+/**
+ * Check if a new session should be created instead of reusing an existing one.
+ *
+ * @param {object} existingSession - The existing session data from findExistingSession()
+ *   Must have: { session_id, sd_id, status }
+ * @returns {{shouldCreateNew: boolean, reason: string}}
+ */
+export function shouldCreateNewSession(existingSession) {
+  if (!existingSession) {
+    return { shouldCreateNew: false, reason: 'no_existing_session' };
+  }
+
+  // If existing session has an active SD claim, don't reuse — create new
+  if (existingSession.sd_id && ['active', 'idle'].includes(existingSession.status)) {
+    return {
+      shouldCreateNew: true,
+      reason: `existing_session_has_claim`,
+      claimedSd: existingSession.sd_id,
+      existingSessionId: existingSession.session_id
+    };
+  }
+
+  // No active claim — safe to reuse
+  return { shouldCreateNew: false, reason: 'no_active_claim' };
+}

--- a/scripts/modules/claim-health/index.js
+++ b/scripts/modules/claim-health/index.js
@@ -1,0 +1,10 @@
+/**
+ * Claim Health Module Index
+ * SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001
+ *
+ * Exports all claim health submodules for centralized access.
+ */
+
+export { triangulate, formatHealthReport } from './triangulate.js';
+export { shouldCreateNewSession } from './collision-guard.js';
+export { selfHeal } from './self-heal.js';

--- a/scripts/modules/claim-health/self-heal.js
+++ b/scripts/modules/claim-health/self-heal.js
@@ -1,0 +1,108 @@
+/**
+ * Self-Heal Module
+ * SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001
+ *
+ * Auto-releases ghost claims and flags orphans during heartbeat ticks.
+ * Designed to complete within 2 seconds to not delay heartbeat cycle.
+ */
+
+/**
+ * Check if a process is running by PID
+ * @param {number} pid
+ * @returns {boolean}
+ */
+function isProcessRunning(pid) {
+  if (!pid || isNaN(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code === 'EPERM';
+  }
+}
+
+/**
+ * Extract PID from session_id string
+ * @param {string} sessionId
+ * @returns {number|null}
+ */
+function extractPid(sessionId) {
+  if (!sessionId) return null;
+  const match = sessionId.match(/_(\d+)$/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+const STALE_THRESHOLD_SECONDS = 300; // 5 minutes
+
+/**
+ * Run self-heal check during heartbeat tick.
+ * Releases ghost claims (stale heartbeat + dead PID).
+ * Logs orphaned work for visibility.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {string} currentSessionId - The current session's ID (to avoid self-release)
+ * @param {object} [options]
+ * @param {boolean} [options.dryRun=false] - If true, don't actually release, just report
+ * @returns {Promise<{released: string[], orphans: string[], errors: string[]}>}
+ */
+export async function selfHeal(supabase, currentSessionId, options = {}) {
+  const { dryRun = false } = options;
+  const released = [];
+  const orphans = [];
+  const errors = [];
+
+  try {
+    // Find all sessions with SD claims that have stale heartbeats
+    const staleThreshold = new Date(Date.now() - STALE_THRESHOLD_SECONDS * 1000).toISOString();
+    const { data: staleSessions, error: queryErr } = await supabase
+      .from('claude_sessions')
+      .select('session_id, sd_id, heartbeat_at, pid, hostname')
+      .in('status', ['active', 'idle'])
+      .not('sd_id', 'is', null)
+      .lt('heartbeat_at', staleThreshold);
+
+    if (queryErr) {
+      errors.push(`Query error: ${queryErr.message}`);
+      return { released, orphans, errors };
+    }
+
+    const os = await import('os');
+    const myHostname = os.hostname();
+
+    for (const session of (staleSessions || [])) {
+      // Never release our own session
+      if (session.session_id === currentSessionId) continue;
+
+      // Only auto-release if same host (can verify PID)
+      if (session.hostname !== myHostname) continue;
+
+      const pid = session.pid || extractPid(session.session_id);
+      if (!pid) continue;
+
+      // Only release if PID is confirmed dead
+      if (isProcessRunning(pid)) continue;
+
+      // Ghost claim confirmed: stale heartbeat + same host + dead PID
+      if (dryRun) {
+        released.push(`[dry-run] Would release ${session.sd_id} from ${session.session_id} (PID ${pid} dead)`);
+        continue;
+      }
+
+      // Release via RPC
+      const { error: releaseErr } = await supabase.rpc('release_sd', {
+        p_session_id: session.session_id
+      });
+
+      if (releaseErr) {
+        errors.push(`Failed to release ${session.sd_id}: ${releaseErr.message}`);
+      } else {
+        released.push(session.sd_id);
+        console.log(`[self-heal] Ghost claim released: ${session.sd_id} (session ${session.session_id}, PID ${pid} dead)`);
+      }
+    }
+  } catch (e) {
+    errors.push(`Self-heal error: ${e.message}`);
+  }
+
+  return { released, orphans, errors };
+}

--- a/scripts/modules/claim-health/triangulate.js
+++ b/scripts/modules/claim-health/triangulate.js
@@ -1,0 +1,288 @@
+/**
+ * Claim Health Triangulation Module
+ * SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001
+ *
+ * Cross-references multiple signal sources to detect claim discrepancies:
+ * 1. claude_sessions (DB) — what sessions think they own
+ * 2. strategic_directives_v2.is_working_on — what SDs think is active
+ * 3. .worktrees/ directory — physical evidence of in-progress work
+ * 4. OS process table — PID liveness check
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
+const WORKTREES_DIR = path.join(PROJECT_ROOT, '.worktrees');
+
+/**
+ * Check if a process is running by PID
+ * @param {number} pid
+ * @returns {boolean}
+ */
+function isProcessRunning(pid) {
+  if (!pid || isNaN(pid)) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code === 'EPERM'; // EPERM = process exists but no permission
+  }
+}
+
+/**
+ * Get active worktrees with SD keys
+ * @returns {Map<string, {path: string, hasChanges: boolean, mtime: Date}>}
+ */
+function getActiveWorktrees() {
+  const result = new Map();
+  if (!fs.existsSync(WORKTREES_DIR)) return result;
+
+  const entries = fs.readdirSync(WORKTREES_DIR, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !entry.name.startsWith('SD-')) continue;
+
+    const wtPath = path.join(WORKTREES_DIR, entry.name);
+    let hasChanges = false;
+    let mtime = new Date(0);
+
+    try {
+      const stat = fs.statSync(wtPath);
+      mtime = stat.mtime;
+
+      // Check for uncommitted changes by looking at git status
+      const gitDir = path.join(wtPath, '.git');
+      if (fs.existsSync(gitDir)) {
+        // Simple heuristic: check if index file was recently modified
+        const indexPath = typeof gitDir === 'string' && fs.statSync(gitDir).isFile()
+          ? path.join(fs.readFileSync(gitDir, 'utf8').replace('gitdir: ', '').trim(), 'index')
+          : path.join(gitDir, 'index');
+        if (fs.existsSync(indexPath)) {
+          const indexStat = fs.statSync(indexPath);
+          // If git index was modified in last hour, likely has changes
+          hasChanges = (Date.now() - indexStat.mtimeMs) < 3600000;
+        }
+      }
+    } catch {
+      // Skip problematic worktrees
+    }
+
+    result.set(entry.name, { path: wtPath, hasChanges, mtime });
+  }
+
+  return result;
+}
+
+/**
+ * Extract PID from session_id string (format: session_{hash}_{platform}{winPid}_{ccPid})
+ * @param {string} sessionId
+ * @returns {number|null}
+ */
+function extractPidFromSessionId(sessionId) {
+  if (!sessionId) return null;
+  const match = sessionId.match(/_(\d+)$/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * Triangulate claim health across all signal sources
+ * @param {object} supabase - Supabase client
+ * @param {string} [sdKey] - Optional specific SD key to check (null = all)
+ * @returns {Promise<{healthy: Array, orphaned: Array, ghost: Array, discrepancies: Array}>}
+ */
+export async function triangulate(supabase, sdKey = null) {
+  const healthy = [];
+  const orphaned = [];
+  const ghost = [];
+  const discrepancies = [];
+
+  // Signal 1: Get all active/idle session claims from DB
+  let sessionQuery = supabase
+    .from('claude_sessions')
+    .select('session_id, sd_id, status, heartbeat_at, terminal_id, pid, hostname')
+    .in('status', ['active', 'idle'])
+    .not('sd_id', 'is', null);
+
+  if (sdKey) {
+    sessionQuery = sessionQuery.eq('sd_id', sdKey);
+  }
+
+  const { data: sessions } = await sessionQuery;
+
+  // Signal 2: Get all SDs with is_working_on = true
+  let sdQuery = supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, is_working_on, claiming_session_id, status')
+    .eq('is_working_on', true);
+
+  if (sdKey) {
+    sdQuery = sdQuery.eq('sd_key', sdKey);
+  }
+
+  const { data: workingSDs } = await sdQuery;
+
+  // Signal 3: Get active worktrees
+  const worktrees = getActiveWorktrees();
+
+  // Build claim map from sessions
+  const sessionClaims = new Map();
+  for (const s of (sessions || [])) {
+    sessionClaims.set(s.sd_id, s);
+  }
+
+  // Build working-on map from SDs
+  const sdWorkingOn = new Map();
+  for (const sd of (workingSDs || [])) {
+    sdWorkingOn.set(sd.sd_key, sd);
+  }
+
+  // Collect all unique SD keys from all sources
+  const allSdKeys = new Set([
+    ...sessionClaims.keys(),
+    ...sdWorkingOn.keys(),
+    ...worktrees.keys()
+  ]);
+
+  for (const key of allSdKeys) {
+    const sessionClaim = sessionClaims.get(key);
+    const sdRecord = sdWorkingOn.get(key);
+    const worktree = worktrees.get(key);
+
+    const signals = {
+      hasSessionClaim: !!sessionClaim,
+      hasIsWorkingOn: !!sdRecord,
+      hasWorktree: !!worktree,
+      pidAlive: false,
+      heartbeatStale: false
+    };
+
+    // Check PID liveness and heartbeat staleness
+    if (sessionClaim) {
+      const pid = sessionClaim.pid || extractPidFromSessionId(sessionClaim.session_id);
+      signals.pidAlive = pid ? isProcessRunning(pid) : false;
+      const heartbeatAge = sessionClaim.heartbeat_at
+        ? (Date.now() - new Date(sessionClaim.heartbeat_at).getTime()) / 1000
+        : Infinity;
+      signals.heartbeatStale = heartbeatAge > 300; // 5 minutes
+    }
+
+    const entry = {
+      sdKey: key,
+      signals,
+      sessionId: sessionClaim?.session_id || null,
+      heartbeatAge: sessionClaim?.heartbeat_at
+        ? Math.round((Date.now() - new Date(sessionClaim.heartbeat_at).getTime()) / 1000)
+        : null,
+      worktreePath: worktree?.path || null,
+      worktreeHasChanges: worktree?.hasChanges || false
+    };
+
+    // Classify
+    if (signals.hasSessionClaim && signals.pidAlive && !signals.heartbeatStale) {
+      // All good — healthy claim
+      healthy.push({ ...entry, category: 'healthy', action: null });
+    } else if (signals.hasSessionClaim && signals.heartbeatStale && !signals.pidAlive) {
+      // Ghost: session claims SD but PID is dead and heartbeat stale
+      ghost.push({
+        ...entry,
+        category: 'ghost',
+        action: `Safe to release: PID dead, heartbeat ${entry.heartbeatAge}s stale`,
+        autoReleasable: true
+      });
+    } else if (signals.hasSessionClaim && signals.heartbeatStale && signals.pidAlive) {
+      // Stale but alive — may be under heavy load
+      discrepancies.push({
+        ...entry,
+        category: 'stale_alive',
+        action: `Heartbeat stale (${entry.heartbeatAge}s) but PID alive — may be busy`
+      });
+    } else if (!signals.hasSessionClaim && (signals.hasIsWorkingOn || signals.hasWorktree)) {
+      // Orphan: no session claim but evidence of work
+      const evidence = [];
+      if (signals.hasIsWorkingOn) evidence.push('is_working_on=true');
+      if (signals.hasWorktree) evidence.push(`worktree exists at ${worktree.path}`);
+      orphaned.push({
+        ...entry,
+        category: 'orphaned',
+        action: `Re-claim with: npm run sd:start ${key}`,
+        evidence
+      });
+    } else if (signals.hasSessionClaim && !signals.hasWorktree && !signals.hasIsWorkingOn) {
+      // Session claims it but nothing else agrees
+      discrepancies.push({
+        ...entry,
+        category: 'session_only',
+        action: 'Session claims SD but no worktree or is_working_on flag — possible stale claim'
+      });
+    }
+  }
+
+  return { healthy, orphaned, ghost, discrepancies };
+}
+
+/**
+ * Format triangulation results as human-readable report
+ * @param {object} results - Output from triangulate()
+ * @returns {string}
+ */
+export function formatHealthReport(results) {
+  const { healthy, orphaned, ghost, discrepancies } = results;
+  const lines = [];
+
+  lines.push('');
+  lines.push('  \x1b[1mClaim Health Report\x1b[0m');
+  lines.push('  ' + '='.repeat(60));
+
+  if (healthy.length > 0) {
+    lines.push('');
+    lines.push('  \x1b[32m✅ HEALTHY (' + healthy.length + ')\x1b[0m');
+    for (const h of healthy) {
+      lines.push('    ' + h.sdKey);
+      lines.push('      Session: ' + h.sessionId + ' | Heartbeat: ' + h.heartbeatAge + 's');
+      if (h.worktreePath) lines.push('      Worktree: ✓');
+    }
+  }
+
+  if (orphaned.length > 0) {
+    lines.push('');
+    lines.push('  \x1b[33m⚠️  ORPHANED (' + orphaned.length + ')\x1b[0m');
+    for (const o of orphaned) {
+      lines.push('    ' + o.sdKey);
+      lines.push('      Evidence: ' + o.evidence.join(', '));
+      lines.push('      → ACTION: ' + o.action);
+    }
+  }
+
+  if (ghost.length > 0) {
+    lines.push('');
+    lines.push('  \x1b[31m👻 GHOST (' + ghost.length + ')\x1b[0m');
+    for (const g of ghost) {
+      lines.push('    ' + g.sdKey);
+      lines.push('      Session: ' + g.sessionId + ' | Heartbeat: ' + g.heartbeatAge + 's');
+      lines.push('      → ' + g.action);
+    }
+  }
+
+  if (discrepancies.length > 0) {
+    lines.push('');
+    lines.push('  \x1b[35m🔍 DISCREPANCIES (' + discrepancies.length + ')\x1b[0m');
+    for (const d of discrepancies) {
+      lines.push('    ' + d.sdKey + ' [' + d.category + ']');
+      lines.push('      → ' + d.action);
+    }
+  }
+
+  if (healthy.length === 0 && orphaned.length === 0 && ghost.length === 0 && discrepancies.length === 0) {
+    lines.push('');
+    lines.push('  No active claims found.');
+  }
+
+  const total = healthy.length + orphaned.length + ghost.length + discrepancies.length;
+  lines.push('');
+  lines.push('  \x1b[2mSummary: ' + total + ' SD(s) | ' + healthy.length + ' healthy | ' + orphaned.length + ' orphaned | ' + ghost.length + ' ghost | ' + discrepancies.length + ' discrepancies\x1b[0m');
+  lines.push('');
+
+  return lines.join('\n');
+}

--- a/tests/claim-health.test.js
+++ b/tests/claim-health.test.js
@@ -1,0 +1,55 @@
+/**
+ * Tests for Claim Health modules
+ * SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldCreateNewSession } from '../scripts/modules/claim-health/collision-guard.js';
+
+describe('collision-guard: shouldCreateNewSession', () => {
+  it('returns false when no existing session', () => {
+    const result = shouldCreateNewSession(null);
+    expect(result.shouldCreateNew).toBe(false);
+    expect(result.reason).toBe('no_existing_session');
+  });
+
+  it('returns false when existing session has no SD claim', () => {
+    const result = shouldCreateNewSession({
+      session_id: 'session_abc',
+      sd_id: null,
+      status: 'active'
+    });
+    expect(result.shouldCreateNew).toBe(false);
+    expect(result.reason).toBe('no_active_claim');
+  });
+
+  it('returns true when existing session has active SD claim', () => {
+    const result = shouldCreateNewSession({
+      session_id: 'session_abc',
+      sd_id: 'SD-FEATURE-001',
+      status: 'active'
+    });
+    expect(result.shouldCreateNew).toBe(true);
+    expect(result.reason).toBe('existing_session_has_claim');
+    expect(result.claimedSd).toBe('SD-FEATURE-001');
+  });
+
+  it('returns true when existing session has idle SD claim', () => {
+    const result = shouldCreateNewSession({
+      session_id: 'session_abc',
+      sd_id: 'SD-FIX-002',
+      status: 'idle'
+    });
+    expect(result.shouldCreateNew).toBe(true);
+  });
+
+  it('returns false when existing session is released with SD', () => {
+    const result = shouldCreateNewSession({
+      session_id: 'session_abc',
+      sd_id: 'SD-FIX-002',
+      status: 'released'
+    });
+    expect(result.shouldCreateNew).toBe(false);
+    expect(result.reason).toBe('no_active_claim');
+  });
+});


### PR DESCRIPTION
## Summary
- **Collision guard**: Prevents session reuse from clobbering existing SD claims — when `getOrCreateSession()` finds an existing session with an active claim, it creates a NEW session row instead of reusing
- **Self-heal**: Runs on every 30s heartbeat tick, auto-releases ghost claims (stale heartbeat + dead PID on same host)
- **Triangulation**: Cross-references claude_sessions, strategic_directives_v2.is_working_on, .worktrees/ directory, and OS PID liveness to classify claims as healthy/orphaned/ghost/discrepant

## Test plan
- [x] 5/5 unit tests passing for collision guard
- [ ] Verify collision guard prevents claim clobbering in multi-session workflow
- [ ] Verify self-heal releases ghost claims during heartbeat
- [ ] Verify triangulate correctly classifies claim states

🤖 Generated with [Claude Code](https://claude.com/claude-code)