### PR TITLE
fix: handle empty smoke_test_steps in heal vision scoring

### DIFF
--- a/scripts/eva/heal-command.mjs
+++ b/scripts/eva/heal-command.mjs
@@ -160,6 +160,7 @@ async function cmdSDQuery(opts) {
       '  - success_criteria_met (0-100): Are the success_criteria verifiable in the codebase?',
       '  - success_metrics_achieved (0-100): Do the success_metrics hold true?',
       '  - smoke_tests_pass (0-100): Would the smoke_test_steps pass if executed?',
+      '    NOTE: If smoke_test_steps is empty/null/[], score 100 with reasoning "N/A: no smoke test steps defined".',
       '  - capabilities_present (0-100): Are delivers_capabilities actually functional?',
       '',
       'Include the classification in each dimension\'s reasoning field (e.g., "DESCOPED: zero callers in codebase").',


### PR DESCRIPTION
## Summary
- Add N/A instruction to heal-command.mjs scoring prompt for empty smoke_test_steps
- SDs without smoke test steps now score 100/100 instead of 50/100 on smoke_tests_pass dimension
- Resolves VGAP-smoketestspass pattern (6 occurrences, increasing trend)

## Test plan
- [ ] Run heal scoring on SD without smoke_test_steps, verify score = 100
- [ ] Run heal scoring on SD with smoke_test_steps, verify normal scoring
- [ ] Verify other dimensions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)