### PR TITLE
feat: add ServiceFactory DI container

### DIFF
--- a/lib/eva/vision-governance-service.js
+++ b/lib/eva/vision-governance-service.js
@@ -6,32 +6,41 @@
  * into a single domain service, separating domain logic from EVA orchestration.
  */
 
-import { createClient } from '@supabase/supabase-js';
-import dotenv from 'dotenv';
-
-dotenv.config();
+import { getServiceFactory } from '../service-factory.js';
 
 export class VisionGovernanceService {
   constructor(options = {}) {
-    this.supabase = options.supabase || createClient(
-      process.env.SUPABASE_URL,
-      process.env.SUPABASE_SERVICE_ROLE_KEY
-    );
+    this._factory = options.factory || getServiceFactory();
+    // Legacy: options.supabase still works for backward compatibility
+    this._supabaseOverride = options.supabase || null;
+    this._supabaseClient = null;
     this.visionKey = options.visionKey || 'VISION-EHG-L1-001';
     this.archKey = options.archKey || 'ARCH-EHG-L1-001';
   }
+
+  /** @private Lazy-init Supabase client */
+  async _getSupabase() {
+    if (!this._supabaseClient) {
+      this._supabaseClient = this._supabaseOverride || await this._factory.getSupabase();
+    }
+    return this._supabaseClient;
+  }
+
+  /** @deprecated Use _getSupabase() — kept for any code reading .supabase directly */
+  get supabase() { return this._supabaseClient; }
 
   /**
    * Score the portfolio against vision and architecture dimensions.
    * Delegates to vision-scorer.js scoreSD().
    */
   async scorePortfolio(sdKey = null, options = {}) {
+    const supabase = await this._getSupabase();
     const { scoreSD } = await import('./../../scripts/eva/vision-scorer.js');
     return scoreSD({
       sdKey,
       visionKey: this.visionKey,
       archKey: this.archKey,
-      supabase: this.supabase,
+      supabase,
       ...options,
     });
   }
@@ -46,7 +55,8 @@ export class VisionGovernanceService {
   async getGaps(filters = {}) {
     const { status = 'open', sdId } = filters;
 
-    let query = this.supabase
+    const supabase = await this._getSupabase();
+    let query = supabase
       .from('eva_vision_gaps')
       .select('*')
       .order('dimension_score', { ascending: true });
@@ -73,7 +83,8 @@ export class VisionGovernanceService {
    * @returns {Promise<Object|null>} Latest score or null
    */
   async getLatestScore() {
-    const { data, error } = await this.supabase
+    const supabase = await this._getSupabase();
+    const { data, error } = await supabase
       .from('eva_vision_scores')
       .select('id, total_score, dimension_scores, threshold_action, rubric_snapshot, scored_at')
       .order('scored_at', { ascending: false })
@@ -90,7 +101,8 @@ export class VisionGovernanceService {
    * @returns {Promise<Array>} Score records ordered by date desc
    */
   async getScoreHistory(limit = 10) {
-    const { data, error } = await this.supabase
+    const supabase = await this._getSupabase();
+    const { data, error } = await supabase
       .from('eva_vision_scores')
       .select('id, total_score, dimension_scores, threshold_action, scored_at')
       .order('scored_at', { ascending: false })
@@ -105,7 +117,8 @@ export class VisionGovernanceService {
    * @returns {Promise<Array>} Active corrective SD records
    */
   async getActiveCorrectiveSDs() {
-    const { data, error } = await this.supabase
+    const supabase = await this._getSupabase();
+    const { data, error } = await supabase
       .from('strategic_directives_v2')
       .select('sd_key, title, status, progress, vision_origin_score_id')
       .not('vision_origin_score_id', 'is', null)
@@ -124,7 +137,8 @@ export class VisionGovernanceService {
    * @returns {Promise<Object>} Progression with completed/pending stages
    */
   async getVentureProgression(ventureId) {
-    const { data, error } = await this.supabase
+    const supabase = await this._getSupabase();
+    const { data, error } = await supabase
       .from('venture_artifacts')
       .select('lifecycle_stage')
       .eq('venture_id', ventureId)

--- a/lib/service-factory.js
+++ b/lib/service-factory.js
@@ -1,0 +1,95 @@
+/**
+ * ServiceFactory — Unified Dependency Injection Container
+ * SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-01
+ *
+ * Wraps existing supabase-factory.js and llm/client-factory.js into a
+ * unified container with mock injection for testing.
+ *
+ * USAGE:
+ *   import { getServiceFactory } from '../lib/service-factory.js';
+ *   const factory = getServiceFactory();
+ *   const supabase = await factory.getSupabase();
+ *   const llm = factory.getLLMClient({ purpose: 'classification' });
+ *
+ * TESTING:
+ *   import { ServiceFactory } from '../lib/service-factory.js';
+ *   const factory = ServiceFactory.withOverrides({ supabase: mockClient });
+ *   const svc = new VisionGovernanceService({ factory });
+ */
+
+import { getServiceClient } from './supabase-factory.js';
+import { getLLMClient } from './llm/client-factory.js';
+
+export class ServiceFactory {
+  #supabaseOverride = null;
+  #llmOverride = null;
+
+  /**
+   * Create a factory with injected mock dependencies.
+   * @param {Object} overrides
+   * @param {Object} [overrides.supabase] - Mock Supabase client
+   * @param {Object|Function} [overrides.llm] - Mock LLM client or factory function
+   * @returns {ServiceFactory}
+   */
+  static withOverrides({ supabase = null, llm = null } = {}) {
+    const f = new ServiceFactory();
+    f.#supabaseOverride = supabase;
+    f.#llmOverride = llm;
+    return f;
+  }
+
+  /**
+   * Get Supabase service client.
+   * In production: delegates to supabase-factory.getServiceClient().
+   * In test mode: returns the injected mock.
+   * @param {Object} [options] - Passed to getServiceClient()
+   * @returns {Promise<Object>} Supabase client
+   */
+  async getSupabase(options = {}) {
+    if (this.#supabaseOverride) return this.#supabaseOverride;
+    return getServiceClient(options);
+  }
+
+  /**
+   * Get LLM client.
+   * In production: delegates to llm/client-factory.getLLMClient().
+   * In test mode: returns the injected mock (or calls it if it's a function).
+   * @param {Object} [options] - Passed to getLLMClient()
+   * @returns {Object} LLM adapter
+   */
+  getLLMClient(options = {}) {
+    if (this.#llmOverride) {
+      return typeof this.#llmOverride === 'function'
+        ? this.#llmOverride(options)
+        : this.#llmOverride;
+    }
+    return getLLMClient(options);
+  }
+
+  /**
+   * Check if any override is active (i.e., running in test mode).
+   * @returns {boolean}
+   */
+  isTestMode() {
+    return this.#supabaseOverride !== null || this.#llmOverride !== null;
+  }
+}
+
+// Process-scoped singleton
+let _defaultFactory = null;
+
+/**
+ * Get the process-scoped singleton ServiceFactory.
+ * @returns {ServiceFactory}
+ */
+export function getServiceFactory() {
+  if (!_defaultFactory) _defaultFactory = new ServiceFactory();
+  return _defaultFactory;
+}
+
+/**
+ * Reset the singleton (for test isolation).
+ */
+export function resetServiceFactory() {
+  _defaultFactory = null;
+}

--- a/tests/unit/service-factory.test.js
+++ b/tests/unit/service-factory.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  ServiceFactory,
+  getServiceFactory,
+  resetServiceFactory
+} from '../../lib/service-factory.js';
+
+describe('ServiceFactory', () => {
+  beforeEach(() => {
+    resetServiceFactory();
+  });
+
+  describe('withOverrides', () => {
+    it('injects mock Supabase client', async () => {
+      const mockClient = { from: () => 'mock' };
+      const factory = ServiceFactory.withOverrides({ supabase: mockClient });
+      const result = await factory.getSupabase();
+      expect(result).toBe(mockClient);
+    });
+
+    it('injects mock LLM client (object)', () => {
+      const mockLLM = { complete: async () => ({ content: 'test' }) };
+      const factory = ServiceFactory.withOverrides({ llm: mockLLM });
+      const result = factory.getLLMClient({ purpose: 'fast' });
+      expect(result).toBe(mockLLM);
+    });
+
+    it('injects mock LLM client (factory function)', () => {
+      const mockLLM = (opts) => ({ model: opts.purpose });
+      const factory = ServiceFactory.withOverrides({ llm: mockLLM });
+      const result = factory.getLLMClient({ purpose: 'classification' });
+      expect(result).toEqual({ model: 'classification' });
+    });
+  });
+
+  describe('isTestMode', () => {
+    it('returns false for default factory', () => {
+      const factory = new ServiceFactory();
+      expect(factory.isTestMode()).toBe(false);
+    });
+
+    it('returns true when supabase override is active', () => {
+      const factory = ServiceFactory.withOverrides({ supabase: {} });
+      expect(factory.isTestMode()).toBe(true);
+    });
+
+    it('returns true when llm override is active', () => {
+      const factory = ServiceFactory.withOverrides({ llm: {} });
+      expect(factory.isTestMode()).toBe(true);
+    });
+  });
+
+  describe('singleton', () => {
+    it('getServiceFactory returns same instance across calls', () => {
+      const a = getServiceFactory();
+      const b = getServiceFactory();
+      expect(a).toBe(b);
+    });
+
+    it('resetServiceFactory clears singleton', () => {
+      const a = getServiceFactory();
+      resetServiceFactory();
+      const b = getServiceFactory();
+      expect(a).not.toBe(b);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `lib/service-factory.js` (~95 LOC) wrapping supabase-factory and llm/client-factory into unified DI container
- `ServiceFactory.withOverrides()` enables mock injection for testing
- Process-scoped singleton via `getServiceFactory()` / `resetServiceFactory()`
- Migrated `VisionGovernanceService` to accept optional factory parameter (backward compatible)
- 8 unit tests covering overrides, singleton, test mode detection

## Test plan
- [x] All 8 unit tests pass (`vitest run tests/unit/service-factory.test.js`)
- [x] Existing call sites using `new VisionGovernanceService()` continue working unchanged
- [x] `ServiceFactory.withOverrides({ supabase: mock })` returns mock from `getSupabase()`

SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)