### PR TITLE
feat: add growth experiments, retention cohorts, and engagement scoring to Stage 24

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,12 +1,13 @@
 {
-  "isActive": false,
+  "isActive": true,
   "wasInterrupted": false,
-  "currentSd": null,
-  "currentPhase": null,
-  "currentTask": null,
+  "currentSd": "SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-15",
+  "currentPhase": "EXEC",
+  "currentTask": "Implementing V1-Growth: Venture Growth Automation Enhancement",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-02-22T16:30:58.391Z"
+  "clearedAt": "2026-02-22T16:30:58.391Z",
+  "lastUpdatedAt": "2026-02-27T20:34:31.562Z"
 }

--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-13",
-  "expectedBranch": "feat/SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-13",
-  "createdAt": "2026-02-27T17:49:02.764Z",
+  "sdKey": "SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-15",
+  "expectedBranch": "feat/SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-15",
+  "createdAt": "2026-02-27T19:15:10.817Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js
@@ -19,6 +19,10 @@ const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', '
 const TREND_DIRECTIONS = ['up', 'flat', 'down'];
 const OUTCOME_ASSESSMENTS = ['success', 'partial', 'failure', 'indeterminate'];
 const IMPACT_LEVELS = ['high', 'medium', 'low'];
+const EXPERIMENT_STATUSES = ['running', 'concluded', 'cancelled'];
+const EXPERIMENT_OUTCOMES = ['positive', 'negative', 'inconclusive'];
+const COHORT_PERIODS = ['day_1', 'day_7', 'day_14', 'day_30', 'day_60', 'day_90'];
+const ENGAGEMENT_LEVELS = ['highly_engaged', 'engaged', 'casual', 'at_risk', 'churned'];
 
 const SYSTEM_PROMPT = `You are EVA's Metrics & Learning Analyst. Evaluate launch success criteria against AARRR metrics and produce a launch scorecard.
 
@@ -60,7 +64,57 @@ Rules:
 - At least 1 learning required
 - launchOutcome.criteriaMetRate = percentage of criteria met (0-100)
 - For beta launches, lower targets are acceptable
-- trendDirection reflects whether the metric is improving`;
+- trendDirection reflects whether the metric is improving
+
+Additionally, evaluate these growth dimensions:
+
+"growthExperiments": [
+  {
+    "name": "Experiment name",
+    "hypothesis": "If we do X, then Y will increase by Z%",
+    "status": "running|concluded|cancelled",
+    "outcome": "positive|negative|inconclusive",
+    "metric": "Primary metric tracked",
+    "baselineValue": 0,
+    "currentValue": 0,
+    "targetLift": 10,
+    "actualLift": 5,
+    "sampleSize": 1000,
+    "confidence": 95
+  }
+],
+"retentionCohorts": [
+  {
+    "cohortName": "Week 1 users",
+    "cohortSize": 100,
+    "periods": {
+      "day_1": 80, "day_7": 50, "day_14": 35, "day_30": 25, "day_60": 18, "day_90": 12
+    },
+    "churnRisk": "low|medium|high"
+  }
+],
+"engagementScoring": {
+  "overallScore": 65,
+  "segments": [
+    {
+      "level": "highly_engaged|engaged|casual|at_risk|churned",
+      "userCount": 100,
+      "percentage": 25,
+      "avgSessionDepth": 5,
+      "avgSessionDuration": 300,
+      "featureAdoption": 80
+    }
+  ],
+  "topFeatures": [
+    { "name": "Feature name", "adoptionRate": 85, "engagementImpact": "high|medium|low" }
+  ]
+}
+
+Rules for growth dimensions:
+- At least 1 growth experiment (can be hypothetical for pre-launch)
+- At least 1 retention cohort
+- Engagement scoring must have overallScore (0-100) and at least 1 segment
+- Retention periods are percentages (0-100) of original cohort retained`;
 
 /**
  * Generate launch scorecard from Stage 23 success criteria and AARRR metrics.
@@ -162,6 +216,94 @@ Output ONLY valid JSON.`;
     }));
   }
 
+  // Normalize growth experiments
+  let growthExperiments = Array.isArray(parsed.growthExperiments)
+    ? parsed.growthExperiments.filter(e => e?.name)
+    : [];
+
+  if (growthExperiments.length === 0) {
+    growthExperiments = [{
+      name: 'Baseline growth tracking',
+      hypothesis: 'Establish baseline metrics for future experiments',
+      status: 'running',
+      outcome: 'inconclusive',
+      metric: 'User acquisition rate',
+      baselineValue: 0, currentValue: 0, targetLift: 10, actualLift: 0,
+      sampleSize: 0, confidence: 0,
+    }];
+  } else {
+    growthExperiments = growthExperiments.map(e => ({
+      name: String(e.name).substring(0, 200),
+      hypothesis: String(e.hypothesis || '').substring(0, 500),
+      status: EXPERIMENT_STATUSES.includes(e.status) ? e.status : 'running',
+      outcome: EXPERIMENT_OUTCOMES.includes(e.outcome) ? e.outcome : 'inconclusive',
+      metric: String(e.metric || 'Unknown metric').substring(0, 200),
+      baselineValue: typeof e.baselineValue === 'number' ? e.baselineValue : 0,
+      currentValue: typeof e.currentValue === 'number' ? e.currentValue : 0,
+      targetLift: typeof e.targetLift === 'number' ? e.targetLift : 10,
+      actualLift: typeof e.actualLift === 'number' ? e.actualLift : 0,
+      sampleSize: typeof e.sampleSize === 'number' ? e.sampleSize : 0,
+      confidence: typeof e.confidence === 'number' ? Math.min(100, Math.max(0, e.confidence)) : 0,
+    }));
+  }
+
+  // Normalize retention cohorts
+  let retentionCohorts = Array.isArray(parsed.retentionCohorts)
+    ? parsed.retentionCohorts.filter(c => c?.cohortName)
+    : [];
+
+  if (retentionCohorts.length === 0) {
+    retentionCohorts = [{
+      cohortName: 'Initial cohort',
+      cohortSize: 0,
+      periods: { day_1: 100, day_7: 0, day_14: 0, day_30: 0, day_60: 0, day_90: 0 },
+      churnRisk: 'medium',
+    }];
+  } else {
+    retentionCohorts = retentionCohorts.map(c => {
+      const periods = {};
+      for (const p of COHORT_PERIODS) {
+        const val = c.periods?.[p];
+        periods[p] = typeof val === 'number' ? Math.min(100, Math.max(0, val)) : 0;
+      }
+      return {
+        cohortName: String(c.cohortName).substring(0, 200),
+        cohortSize: typeof c.cohortSize === 'number' ? c.cohortSize : 0,
+        periods,
+        churnRisk: ['low', 'medium', 'high'].includes(c.churnRisk) ? c.churnRisk : 'medium',
+      };
+    });
+  }
+
+  // Normalize engagement scoring
+  const rawEngagement = parsed.engagementScoring || {};
+  const segments = Array.isArray(rawEngagement.segments)
+    ? rawEngagement.segments.filter(s => s?.level).map(s => ({
+        level: ENGAGEMENT_LEVELS.includes(s.level) ? s.level : 'casual',
+        userCount: typeof s.userCount === 'number' ? s.userCount : 0,
+        percentage: typeof s.percentage === 'number' ? Math.min(100, Math.max(0, s.percentage)) : 0,
+        avgSessionDepth: typeof s.avgSessionDepth === 'number' ? s.avgSessionDepth : 0,
+        avgSessionDuration: typeof s.avgSessionDuration === 'number' ? s.avgSessionDuration : 0,
+        featureAdoption: typeof s.featureAdoption === 'number' ? Math.min(100, Math.max(0, s.featureAdoption)) : 0,
+      }))
+    : [{ level: 'casual', userCount: 0, percentage: 100, avgSessionDepth: 0, avgSessionDuration: 0, featureAdoption: 0 }];
+
+  const topFeatures = Array.isArray(rawEngagement.topFeatures)
+    ? rawEngagement.topFeatures.filter(f => f?.name).map(f => ({
+        name: String(f.name).substring(0, 200),
+        adoptionRate: typeof f.adoptionRate === 'number' ? Math.min(100, Math.max(0, f.adoptionRate)) : 0,
+        engagementImpact: IMPACT_LEVELS.includes(f.engagementImpact) ? f.engagementImpact : 'medium',
+      }))
+    : [];
+
+  const engagementScoring = {
+    overallScore: typeof rawEngagement.overallScore === 'number'
+      ? Math.min(100, Math.max(0, rawEngagement.overallScore))
+      : 0,
+    segments,
+    topFeatures,
+  };
+
   // Normalize launch outcome
   const lo = parsed.launchOutcome || {};
   const criteriaMet = criteriaEvaluation.filter(ce => ce.met).length;
@@ -204,21 +346,46 @@ Output ONLY valid JSON.`;
     }
   }
 
+  // Compute growth experiment derived metrics
+  const concludedExperiments = growthExperiments.filter(e => e.status === 'concluded');
+  const positiveExperiments = concludedExperiments.filter(e => e.outcome === 'positive');
+
+  // Compute retention health
+  const avgDay30Retention = retentionCohorts.length > 0
+    ? Math.round(retentionCohorts.reduce((sum, c) => sum + c.periods.day_30, 0) / retentionCohorts.length)
+    : 0;
+  const highChurnCohorts = retentionCohorts.filter(c => c.churnRisk === 'high').length;
+
   logger.log('[Stage24] Analysis complete', { duration: Date.now() - startTime });
   return {
     aarrr,
     criteriaEvaluation,
     learnings,
     launchOutcome,
+    growthExperiments,
+    retentionCohorts,
+    engagementScoring,
     totalMetrics,
     metricsOnTarget,
     metricsBelowTarget,
     categoriesComplete: categoriesComplete === AARRR_CATEGORIES.length,
     totalLearnings: learnings.length,
     highImpactLearnings: learnings.filter(l => l.impactLevel === 'high').length,
+    totalExperiments: growthExperiments.length,
+    concludedExperiments: concludedExperiments.length,
+    positiveExperimentRate: concludedExperiments.length > 0
+      ? Math.round((positiveExperiments.length / concludedExperiments.length) * 100)
+      : 0,
+    totalCohorts: retentionCohorts.length,
+    avgDay30Retention,
+    highChurnCohorts,
+    engagementScore: engagementScoring.overallScore,
     fourBuckets, usage,
   };
 }
 
 
-export { AARRR_CATEGORIES, TREND_DIRECTIONS, OUTCOME_ASSESSMENTS, IMPACT_LEVELS };
+export {
+  AARRR_CATEGORIES, TREND_DIRECTIONS, OUTCOME_ASSESSMENTS, IMPACT_LEVELS,
+  EXPERIMENT_STATUSES, EXPERIMENT_OUTCOMES, COHORT_PERIODS, ENGAGEMENT_LEVELS,
+};


### PR DESCRIPTION
## Summary
- Adds growth experiment framework with hypothesis validation and A/B test tracking to Stage 24 metrics analysis
- Adds retention cohort analysis with day-1/7/14/30/60/90 tracking and churn risk identification
- Adds engagement scoring with user segments, feature adoption metrics, and session depth tracking

## Test plan
- [x] All 48 unit tests pass (up from 30)
- [x] Growth experiment normalization with defaults and clamping
- [x] Retention cohort period validation
- [x] Engagement scoring segment defaults

(#SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)