### PR TITLE
feat: add expansion vector analysis to Stage 25 venture review (#SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-21)

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-25-venture-review.js
@@ -20,6 +20,24 @@ import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 const VENTURE_DECISIONS = ['continue', 'pivot', 'expand', 'sunset', 'exit'];
 const HEALTH_RATINGS = ['excellent', 'good', 'fair', 'poor', 'critical'];
 const REVIEW_CATEGORIES = ['product', 'market', 'technical', 'financial', 'team'];
+const EXPANSION_VECTORS = ['market', 'feature', 'segment'];
+const EXPANSION_WEIGHTS = { market: 0.4, feature: 0.35, segment: 0.25 };
+
+const EXPANSION_SYSTEM_PROMPT = `You are EVA's Expansion Analyst. Given a venture that has been recommended for expansion, score the readiness across three expansion vectors.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "market": { "score": 75, "rationale": "Brief rationale for market expansion readiness" },
+  "feature": { "score": 80, "rationale": "Brief rationale for feature expansion readiness" },
+  "segment": { "score": 60, "rationale": "Brief rationale for segment expansion readiness" }
+}
+
+Rules:
+- Each score is 0-100 (0 = not ready, 100 = fully ready)
+- market: readiness to enter new geographic/demographic markets
+- feature: readiness to add major new product features or product lines
+- segment: readiness to serve new customer segments or verticals
+- Base scores on venture health dimensions, financial trajectory, and team capacity`;
 
 const SYSTEM_PROMPT = `You are EVA's Venture Review Analyst conducting the capstone Stage 25 review. Synthesize the ENTIRE venture journey into a comprehensive decision recommendation.
 
@@ -244,6 +262,16 @@ Output ONLY valid JSON.`;
     categoriesReviewed++;
   }
 
+  // Expansion vector analysis (only when recommendation is 'expand')
+  let expansionAnalysis = null;
+  let expansionReadinessScore = null;
+
+  if (ventureDecision.recommendation === 'expand') {
+    logger.log('[Stage25] Expand recommended — running expansion vector analysis');
+    expansionAnalysis = await analyzeExpansionVectors({ ventureHealth, ventureDecision, ventureName, logger });
+    expansionReadinessScore = expansionAnalysis.readinessScore;
+  }
+
   logger.log('[Stage25] Analysis complete', { duration: Date.now() - startTime });
   return {
     journeySummary,
@@ -255,9 +283,67 @@ Output ONLY valid JSON.`;
     totalInitiatives,
     allCategoriesReviewed: categoriesReviewed === REVIEW_CATEGORIES.length,
     healthScore: Math.round(avgScore * 10) / 10,
+    expansionAnalysis,
+    expansionReadinessScore,
     fourBuckets, usage,
   };
 }
 
 
-export { VENTURE_DECISIONS, HEALTH_RATINGS, REVIEW_CATEGORIES };
+/**
+ * Analyze expansion vectors when venture decision is 'expand'.
+ * Scores market, feature, and segment readiness via LLM.
+ *
+ * @param {Object} params
+ * @param {Object} params.ventureHealth - Health dimensions from main analysis
+ * @param {Object} params.ventureDecision - Decision object with recommendation/rationale
+ * @param {string} [params.ventureName]
+ * @param {Object} [params.logger]
+ * @returns {Promise<Object>} Expansion analysis with per-vector scores and composite readinessScore
+ */
+export async function analyzeExpansionVectors({ ventureHealth, ventureDecision, ventureName, logger = console }) {
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const healthSummary = Object.entries(ventureHealth.dimensions || {})
+    .map(([cat, dim]) => `${cat}: ${dim.score}/10`)
+    .join(', ');
+
+  const userPrompt = `Analyze expansion readiness for venture: ${ventureName || 'Unnamed'}.
+
+Health dimensions: ${healthSummary}
+Overall health: ${ventureHealth.overallRating}
+Decision rationale: ${ventureDecision.rationale}
+Decision confidence: ${ventureDecision.confidence}%
+
+Output ONLY valid JSON.`;
+
+  try {
+    const response = await client.complete(EXPANSION_SYSTEM_PROMPT, userPrompt, { timeout: 60000 });
+    const parsed = parseJSON(response);
+
+    const vectors = {};
+    for (const vec of EXPANSION_VECTORS) {
+      const v = parsed[vec] || {};
+      vectors[vec] = {
+        score: typeof v.score === 'number' ? Math.max(0, Math.min(100, Math.round(v.score))) : 50,
+        rationale: String(v.rationale || `${vec} expansion readiness pending`).substring(0, 300),
+      };
+    }
+
+    const readinessScore = Math.round(
+      EXPANSION_VECTORS.reduce((sum, vec) => sum + vectors[vec].score * EXPANSION_WEIGHTS[vec], 0)
+    );
+
+    logger.log('[Stage25] Expansion analysis complete', { readinessScore });
+    return { vectors, readinessScore };
+  } catch (err) {
+    logger.warn('[Stage25] Expansion analysis failed, using defaults', { error: err.message });
+    const vectors = {};
+    for (const vec of EXPANSION_VECTORS) {
+      vectors[vec] = { score: 50, rationale: `${vec} expansion readiness could not be assessed` };
+    }
+    return { vectors, readinessScore: 50 };
+  }
+}
+
+export { VENTURE_DECISIONS, HEALTH_RATINGS, REVIEW_CATEGORIES, EXPANSION_VECTORS, EXPANSION_WEIGHTS };

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -95,6 +95,15 @@ const TEMPLATE = {
         },
       },
     },
+    // Expansion analysis (populated when ventureDecision is 'expand')
+    expansionAnalysis: {
+      type: 'object',
+      fields: {
+        vectors: { type: 'object' },
+        readinessScore: { type: 'number', min: 0, max: 100 },
+      },
+    },
+    expansionReadinessScore: { type: 'number', min: 0, max: 100 },
     // Derived
     total_initiatives: { type: 'number', derived: true },
     all_categories_reviewed: { type: 'boolean', derived: true },
@@ -110,6 +119,8 @@ const TEMPLATE = {
     next_steps: [],
     financialComparison: { projectedRevenue: null, actualRevenue: null, projectedCosts: null, actualCosts: null, revenueVariancePct: null, financialTrajectory: null, variance: null, assessment: null },
     ventureHealth: { overallRating: null, dimensions: {} },
+    expansionAnalysis: null,
+    expansionReadinessScore: null,
     chairmanGate: { status: 'pending', rationale: null, decision_id: null },
     total_initiatives: 0,
     all_categories_reviewed: false,
@@ -239,6 +250,8 @@ const TEMPLATE = {
       drift_detected,
       drift_check: { ...drift_check, semanticDrift },
       ventureDecision,
+      expansionAnalysis: data.expansionAnalysis || null,
+      expansionReadinessScore: data.expansionReadinessScore || null,
     };
   },
 };


### PR DESCRIPTION
## Summary
- Add expansion vector analysis (market/feature/segment) to Stage 25 venture review
- Scores each vector 0-100 via LLM when ventureDecision is 'expand'
- Computes weighted expansionReadinessScore (market 40%, feature 35%, segment 25%)
- Non-expand decisions skip analysis gracefully with null values
- Updates stage-25.js schema and computeDerived for new fields

## Test plan
- [x] 39 unit tests passing (4 new expansion-specific tests)
- [x] Expand decision triggers expansion analysis
- [x] Non-expand decisions produce null expansion fields
- [x] LLM failure gracefully defaults to score 50
- [x] Vector scores clamped to 0-100

🤖 Generated with [Claude Code](https://claude.com/claude-code)