### PR TITLE
feat: add app rankings and competitive positioning to EVA stage 23

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-launch-execution.js
@@ -23,6 +23,10 @@ const APP_STORE_STATUSES = ['not_submitted', 'submitted', 'in_review', 'approved
 const DOMAIN_STATUSES = ['not_configured', 'dns_pending', 'ssl_pending', 'active', 'error'];
 const CHANNEL_STATUSES = ['not_started', 'drafting', 'scheduled', 'live', 'paused'];
 
+// SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-22: App rankings pipeline constants
+const APP_RANKING_TIERS = ['top10', 'top50', 'top100', 'below100', 'unknown'];
+const COMPETITIVE_POSITIONS = ['leader', 'challenger', 'follower', 'niche', 'unknown'];
+
 const SYSTEM_PROMPT = `You are EVA's Launch Execution Analyst. Synthesize Stage 22 release readiness data into a launch brief with success criteria.
 
 You MUST output valid JSON with exactly this structure:
@@ -74,6 +78,19 @@ You MUST output valid JSON with exactly this structure:
     "requiresApproval": true,
     "reason": "Why Chairman approval is needed (irreversible external actions)",
     "escalationItems": ["List of specific items needing approval"]
+  },
+  "appRankings": {
+    "categoryRank": 15,
+    "overallRank": 250,
+    "rating": 4.2,
+    "reviewCount": 500,
+    "trend": "improving|stable|declining|unknown"
+  },
+  "competitivePosition": {
+    "marketShareEstimate": 12.5,
+    "competitorCount": 8,
+    "differentiationScore": 75,
+    "position": "leader|challenger|follower|niche|unknown"
   }
 }
 
@@ -87,7 +104,11 @@ Rules:
 - appStoreReadiness.complianceScore should be 0-100
 - domainDeployment should reflect actual infrastructure state
 - At least 1 marketing channel required
-- chairmanEscalation.requiresApproval MUST be true if any launch action is irreversible (app store submission, domain going live, press releases)`;
+- chairmanEscalation.requiresApproval MUST be true if any launch action is irreversible (app store submission, domain going live, press releases)
+- appRankings: provide ranking data if available, use null for unknown numeric fields
+- appRankings.trend: "improving" if rankings climbing, "declining" if dropping, "stable" if steady, "unknown" if insufficient data
+- competitivePosition: assess market standing relative to competitors
+- competitivePosition.differentiationScore: 0-100 based on unique value proposition strength`;
 
 /**
  * Generate launch execution brief from Stage 22 release readiness data.
@@ -263,6 +284,56 @@ Output ONLY valid JSON.`;
       : [],
   };
 
+  // Normalize app rankings (SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-22)
+  const categoryRank = Number(parsed.appRankings?.categoryRank) || null;
+  const overallRank = Number(parsed.appRankings?.overallRank) || null;
+  const rating = parsed.appRankings?.rating != null ? Math.max(0, Math.min(5, Number(parsed.appRankings.rating) || 0)) : null;
+  const reviewCount = Number(parsed.appRankings?.reviewCount) || null;
+
+  // Derive tier from category rank
+  let rankingTier = 'unknown';
+  if (categoryRank != null) {
+    if (categoryRank <= 10) rankingTier = 'top10';
+    else if (categoryRank <= 50) rankingTier = 'top50';
+    else if (categoryRank <= 100) rankingTier = 'top100';
+    else rankingTier = 'below100';
+  }
+
+  // Detect trend
+  const trendValues = ['improving', 'stable', 'declining', 'unknown'];
+  const rawTrend = String(parsed.appRankings?.trend || '').toLowerCase();
+  const trend = trendValues.includes(rawTrend) ? rawTrend : 'unknown';
+
+  const appRankings = {
+    categoryRank,
+    overallRank,
+    rating,
+    reviewCount,
+    tier: rankingTier,
+    trend,
+  };
+
+  // Normalize competitive position
+  const marketShareEstimate = parsed.competitivePosition?.marketShareEstimate != null
+    ? Math.max(0, Math.min(100, Number(parsed.competitivePosition.marketShareEstimate) || 0))
+    : null;
+  const competitorCount = Number(parsed.competitivePosition?.competitorCount) || null;
+  const differentiationScore = parsed.competitivePosition?.differentiationScore != null
+    ? Math.max(0, Math.min(100, Number(parsed.competitivePosition.differentiationScore) || 0))
+    : null;
+
+  let competitivePositionValue = 'unknown';
+  if (COMPETITIVE_POSITIONS.includes(parsed.competitivePosition?.position)) {
+    competitivePositionValue = parsed.competitivePosition.position;
+  }
+
+  const competitivePosition = {
+    marketShareEstimate,
+    competitorCount,
+    differentiationScore,
+    position: competitivePositionValue,
+  };
+
   // Derived publish metrics
   const liveChannels = marketingChannels.filter(mc => mc.status === 'live').length;
   const totalChannels = marketingChannels.length;
@@ -293,9 +364,11 @@ Output ONLY valid JSON.`;
     liveChannels,
     totalChannels,
     requiresChairmanApproval: chairmanEscalation.requiresApproval,
+    appRankings,
+    competitivePosition,
     fourBuckets, usage,
   };
 }
 
 
-export { LAUNCH_TYPES, TASK_STATUSES, CRITERION_PRIORITIES, APP_STORE_STATUSES, DOMAIN_STATUSES, CHANNEL_STATUSES };
+export { LAUNCH_TYPES, TASK_STATUSES, CRITERION_PRIORITIES, APP_STORE_STATUSES, DOMAIN_STATUSES, CHANNEL_STATUSES, APP_RANKING_TIERS, COMPETITIVE_POSITIONS };


### PR DESCRIPTION
## Summary
- Add `APP_RANKING_TIERS` and `COMPETITIVE_POSITIONS` constants to stage-23-launch-execution.js
- Add normalization blocks for `appRankings` (categoryRank, overallRank, rating, reviewCount, tier, trend) and `competitivePosition` (marketShareEstimate, competitorCount, differentiationScore, position)
- Extend LLM system prompt with ranking and competitive analysis instructions
- 14 new tests covering all normalization edge cases (57 total, all passing)

## Test plan
- [x] All 57 unit tests pass
- [x] Smoke tests pass
- [x] Existing 43 tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)