### PR TITLE
fix: cross-check actual session holder on already_owned claim (#SD-LEO-FIX-FIX-START-ALREADY-001)

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -164,6 +164,30 @@ export async function claimGuard(sdKey, sessionId) {
   // Case 1: This session already owns the claim
   const ownClaim = activeClaims.find(c => c.session_id === sessionId);
   if (ownClaim) {
+    // SD-LEO-FIX-FIX-START-ALREADY-001: Check for conflicting claims from OTHER active sessions.
+    // The partial unique index should prevent this, but session reuse via terminal_id
+    // can create scenarios where multiple sessions claim the same SD.
+    const conflictingClaims = activeClaims.filter(c =>
+      c.session_id !== sessionId && c.computed_status === 'active'
+    );
+    if (conflictingClaims.length > 0) {
+      const conflict = conflictingClaims[0];
+      console.log(`[claimGuard] WARNING: Own session claims SD but ${conflictingClaims.length} other active session(s) also claim it`);
+      console.log(`[claimGuard] Conflict: ${conflict.session_id} (${conflict.hostname || 'unknown'}, heartbeat: ${conflict.heartbeat_age_human || 'unknown'})`);
+      return {
+        success: false,
+        error: 'claimed_by_active_session',
+        owner: {
+          session_id: conflict.session_id,
+          heartbeat_age_human: conflict.heartbeat_age_human || 'unknown',
+          hostname: conflict.hostname || 'unknown',
+          tty: conflict.tty || 'unknown',
+          codebase: conflict.codebase || 'unknown',
+          note: 'Another active session also claims this SD (dual-claim conflict)'
+        }
+      };
+    }
+
     // Update heartbeat to keep claim alive
     await supabase
       .from('claude_sessions')


### PR DESCRIPTION
## Summary
- When claimGuard returns `already_owned`, now verifies no other active session also claims the SD
- Prevents dual-claim conflicts from session reuse via terminal_id
- Returns clear error with conflicting session details when mismatch detected

## Test plan
- [x] Verified conflictingClaims filter logic detects active dual claims
- [x] Verified already_owned still works for single-session claims

🤖 Generated with [Claude Code](https://claude.com/claude-code)