### PR TITLE
fix: use score threshold instead of zero-issues check in userStoryQualityValidation gate (#SD-LEARN-FIX-ADDRESS-PAT-AUTO-045)

### DIFF
--- a/scripts/modules/user-story-quality-validation.js
+++ b/scripts/modules/user-story-quality-validation.js
@@ -112,7 +112,7 @@ function validateUserStoryHeuristic(story) {
 
   // Ensure score is within bounds
   score = Math.max(0, Math.min(100, score));
-  const passed = score >= 65 && issues.length === 0;
+  const passed = score >= 65;
 
   return {
     story_key: storyKey,
@@ -352,11 +352,7 @@ export async function validateUserStoriesForHandoff(stories, options = {}) {
   // Calculate average score
   result.averageScore = Math.round(totalScore / stories.length);
 
-  // Determine overall validity
-  if (result.issues.length > 0) {
-    result.valid = false;
-  }
-
+  // Determine overall validity based on score threshold (not issue count)
   if (result.averageScore < minimumScore) {
     result.valid = false;
     result.issues.push(`Average user story quality score (${result.averageScore}%) is below minimum (${minimumScore}%)`);


### PR DESCRIPTION
## Summary
- Removed `issues.length === 0` from individual story pass condition (line 115) — score threshold (65%) is now the sole determinant
- Removed aggregate `if (result.issues.length > 0) result.valid = false` override (lines 356-358) — average score check handles validity
- Same class of fix as SD-LEARN-FIX-ADDRESS-PAT-AUTO-043 (sdObjectivesDefined gate)

## Test plan
- [x] 15/15 smoke tests passing
- [ ] Verify gates pass with score >= 65 even when informational issues exist
- [ ] Confirm gates still fail when score < 65

🤖 Generated with [Claude Code](https://claude.com/claude-code)