### PR TITLE
feat: implement Claude Code release monitor

### DIFF
--- a/scripts/claude-code-release-check.mjs
+++ b/scripts/claude-code-release-check.mjs
@@ -1,0 +1,168 @@
+/**
+ * Claude Code Release Monitor
+ *
+ * Checks npm registry for new @anthropic-ai/claude-code releases,
+ * compares against stored versions, and logs new releases.
+ *
+ * Usage: node scripts/claude-code-release-check.mjs
+ *
+ * Part of SD-LEO-INFRA-IMPLEMENT-CLAUDE-CODE-001
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org/@anthropic-ai/claude-code';
+const PACKAGE_NAME = '@anthropic-ai/claude-code';
+
+/**
+ * Fetch latest version info from npm registry.
+ * @returns {Promise<{version: string, date: string}|null>}
+ */
+async function fetchLatestVersion() {
+  try {
+    const res = await fetch(NPM_REGISTRY_URL);
+    if (!res.ok) {
+      console.error(`[ReleaseMonitor] npm registry returned ${res.status}`);
+      return null;
+    }
+    const data = await res.json();
+    const latest = data['dist-tags']?.latest;
+    if (!latest) {
+      console.error('[ReleaseMonitor] No latest dist-tag found');
+      return null;
+    }
+    const releaseDate = data.time?.[latest] || null;
+    return { version: latest, date: releaseDate };
+  } catch (err) {
+    console.error(`[ReleaseMonitor] Failed to fetch from npm: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Get the most recent known version from the database.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<string|null>}
+ */
+async function getLatestKnownVersion(supabase) {
+  const { data, error } = await supabase
+    .from('claude_code_releases')
+    .select('version')
+    .order('detected_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`[ReleaseMonitor] DB query error: ${error.message}`);
+    return null;
+  }
+  return data?.version || null;
+}
+
+/**
+ * Store a new release in the database.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {{version: string, date: string}} release
+ */
+async function storeRelease(supabase, release) {
+  const { error } = await supabase
+    .from('claude_code_releases')
+    .upsert({
+      version: release.version,
+      release_date: release.date,
+      changelog_url: `https://www.npmjs.com/package/${PACKAGE_NAME}/v/${release.version}`,
+      status: 'new',
+    }, { onConflict: 'version' });
+
+  if (error) {
+    console.error(`[ReleaseMonitor] Failed to store release: ${error.message}`);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Get currently installed version from local CLI.
+ * @returns {Promise<string|null>}
+ */
+async function getInstalledVersion() {
+  try {
+    const { execSync } = await import('child_process');
+    const version = execSync('claude --version 2>/dev/null || echo unknown', { encoding: 'utf8' }).trim();
+    return version === 'unknown' ? null : version;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('[ReleaseMonitor] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  console.log('═══════════════════════════════════════════════');
+  console.log('  CLAUDE CODE RELEASE MONITOR');
+  console.log('═══════════════════════════════════════════════');
+  console.log();
+
+  // Fetch latest from npm
+  const latest = await fetchLatestVersion();
+  if (!latest) {
+    console.log('  ❌ Could not fetch latest version from npm registry');
+    process.exit(1);
+  }
+
+  console.log(`  📦 Latest on npm: ${latest.version}`);
+  if (latest.date) {
+    console.log(`  📅 Released: ${new Date(latest.date).toLocaleDateString()}`);
+  }
+
+  // Check installed version
+  const installed = await getInstalledVersion();
+  if (installed) {
+    console.log(`  💻 Installed: ${installed}`);
+    if (installed !== latest.version) {
+      console.log(`  ⚠️  Update available: ${installed} → ${latest.version}`);
+    } else {
+      console.log('  ✅ You are on the latest version');
+    }
+  }
+
+  // Check against DB
+  const known = await getLatestKnownVersion(supabase);
+  console.log();
+
+  if (known === latest.version) {
+    console.log('  ✅ No new releases since last check');
+    console.log(`  📋 Latest known: ${known}`);
+  } else {
+    console.log(`  🆕 New release detected: ${latest.version}`);
+    if (known) {
+      console.log(`  📋 Previous known: ${known}`);
+    } else {
+      console.log('  📋 First check — storing baseline');
+    }
+
+    const stored = await storeRelease(supabase, latest);
+    if (stored) {
+      console.log('  ✅ Release record stored in database');
+    }
+  }
+
+  console.log();
+  console.log('═══════════════════════════════════════════════');
+}
+
+main().catch(err => {
+  console.error(`[ReleaseMonitor] Unexpected error: ${err.message}`);
+  process.exit(1);
+});

--- a/supabase/migrations/20260228_claude_code_releases.sql
+++ b/supabase/migrations/20260228_claude_code_releases.sql
@@ -1,0 +1,26 @@
+-- Claude Code Release Monitor table
+-- Stores detected Claude Code releases from npm registry
+-- Part of SD-LEO-INFRA-IMPLEMENT-CLAUDE-CODE-001
+
+CREATE TABLE IF NOT EXISTS claude_code_releases (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  version TEXT NOT NULL,
+  detected_at TIMESTAMPTZ DEFAULT now(),
+  release_date TIMESTAMPTZ,
+  changelog_url TEXT,
+  status TEXT DEFAULT 'new' CHECK (status IN ('new', 'acknowledged', 'applied')),
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Prevent duplicate version entries
+CREATE UNIQUE INDEX IF NOT EXISTS idx_claude_code_releases_version
+  ON claude_code_releases (version);
+
+-- RLS policies
+ALTER TABLE claude_code_releases ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Service role full access on claude_code_releases"
+  ON claude_code_releases FOR ALL
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Add `claude_code_releases` table migration with unique version constraint and RLS
- Create `scripts/claude-code-release-check.mjs` that queries npm registry for `@anthropic-ai/claude-code`
- Compares against stored versions, detects new releases, reports installed vs latest version

## Test plan
- [x] Script handles network failure gracefully
- [x] Duplicate version inserts prevented by unique constraint
- [x] First run stores baseline version

🤖 Generated with [Claude Code](https://claude.com/claude-code)