### PR TITLE
feat: implement app rankings data pipeline

### DIFF
--- a/scripts/run-ranking-pipeline.mjs
+++ b/scripts/run-ranking-pipeline.mjs
@@ -1,0 +1,61 @@
+/**
+ * Standalone Ranking Pipeline Runner
+ *
+ * Entry point for cron/scheduled execution of the app rankings pipeline.
+ * Initializes Supabase client and runs all ranking data pollers.
+ *
+ * Usage: node scripts/run-ranking-pipeline.mjs
+ *
+ * Part of SD-LEO-INFRA-IMPLEMENT-APP-RANKINGS-001
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { runRankingPipeline } from '../lib/eva/stage-zero/ranking-pipeline.js';
+
+dotenv.config();
+
+async function main() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    console.error('[RankingPipeline] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  const startTime = Date.now();
+
+  console.log('═══════════════════════════════════════════════');
+  console.log('  APP RANKINGS PIPELINE');
+  console.log('═══════════════════════════════════════════════');
+  console.log(`  Started: ${new Date().toISOString()}`);
+  console.log();
+
+  try {
+    const result = await runRankingPipeline({
+      supabase,
+      logger: console,
+      apiToken: process.env.PRODUCT_HUNT_API_TOKEN,
+    });
+
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
+    console.log();
+    console.log('═══════════════════════════════════════════════');
+    console.log('  PIPELINE SUMMARY');
+    console.log('═══════════════════════════════════════════════');
+    console.log(`  Total records collected: ${result.totalNewRecords}`);
+    console.log(`  Duration: ${elapsed}s`);
+    console.log(`  Status: ✅ Complete`);
+    console.log('═══════════════════════════════════════════════');
+  } catch (err) {
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    console.error();
+    console.error(`  ❌ Pipeline failed after ${elapsed}s: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/supabase/migrations/20260228_app_rankings.sql
+++ b/supabase/migrations/20260228_app_rankings.sql
@@ -1,0 +1,44 @@
+-- App Rankings table for ranking data pipeline
+-- Stores normalized app store ranking data from multiple sources
+-- Part of SD-LEO-INFRA-IMPLEMENT-APP-RANKINGS-001
+
+CREATE TABLE IF NOT EXISTS app_rankings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  snapshot_id UUID,
+  app_name TEXT NOT NULL,
+  developer TEXT,
+  app_url TEXT NOT NULL,
+  website_url TEXT,
+  category TEXT,
+  chart_position INTEGER,
+  chart_type TEXT,
+  source TEXT NOT NULL CHECK (source IN ('apple_appstore', 'google_play', 'product_hunt')),
+  rating NUMERIC(3,1),
+  review_count INTEGER,
+  installs_range TEXT,
+  vote_count INTEGER,
+  description TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  metadata JSONB DEFAULT '{}'
+);
+
+-- Index for source-based queries
+CREATE INDEX IF NOT EXISTS idx_app_rankings_source
+  ON app_rankings (source);
+
+-- Index for category lookups
+CREATE INDEX IF NOT EXISTS idx_app_rankings_category
+  ON app_rankings (category);
+
+-- Index for time-series queries
+CREATE INDEX IF NOT EXISTS idx_app_rankings_created
+  ON app_rankings (created_at DESC);
+
+-- RLS policies
+ALTER TABLE app_rankings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY IF NOT EXISTS "Service role full access on app_rankings"
+  ON app_rankings FOR ALL
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Add `app_rankings` table migration with source check constraint (apple_appstore/google_play/product_hunt), indexes, and RLS
- Create standalone `scripts/run-ranking-pipeline.mjs` entry point for cron/scheduled execution
- Chains existing pollers through `ranking-pipeline.js` orchestrator

## Test plan
- [x] Migration follows existing Supabase patterns
- [x] Script initializes Supabase client and calls existing pipeline
- [x] Graceful error handling for missing env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)