### PR TITLE
feat: make GR-GOVERNANCE-CASCADE blocking and add bidirectional OKR cascade validation (#SD-MAN-FEAT-CORRECTIVE-VISION-GAP-067)

### DIFF
--- a/lib/governance/guardrail-registry.js
+++ b/lib/governance/guardrail-registry.js
@@ -69,18 +69,21 @@ const DEFAULT_GUARDRAILS = [
   {
     id: 'GR-GOVERNANCE-CASCADE',
     name: 'Strategic Governance Cascade',
-    mode: MODES.ADVISORY,
-    description: 'SD should trace to a strategic theme or OKR',
+    mode: MODES.BLOCKING,
+    description: 'SD must trace to a strategic theme or OKR via strategic_objectives or parent_sd_id',
     check: (sdData) => {
+      // SD-MAN-FEAT-CORRECTIVE-VISION-GAP-067 US-001: BLOCKING enforcement
+      // SD must have at least one cascade link: strategic_objectives OR parent_sd_id
       const hasStrategicLink = sdData.strategic_objectives
         && Array.isArray(sdData.strategic_objectives)
         && sdData.strategic_objectives.length > 0;
+      const hasParentLink = !!sdData.parent_sd_id;
 
-      if (!hasStrategicLink) {
+      if (!hasStrategicLink && !hasParentLink) {
         return {
           violated: true,
-          severity: 'low',
-          message: 'SD has no strategic_objectives linking it to OKRs or strategic themes. Consider adding strategic alignment.',
+          severity: 'high',
+          message: 'SD has no strategic_objectives and no parent_sd_id. Every SD must trace to a strategic theme, OKR, or parent orchestrator.',
         };
       }
       return { violated: false };


### PR DESCRIPTION
## Summary
- Changed GR-GOVERNANCE-CASCADE guardrail from ADVISORY to BLOCKING mode — SDs without strategic_objectives or parent_sd_id are now blocked at creation
- Enhanced cascade check to accept parent_sd_id as valid cascade link (supports orchestrator children)
- Added bidirectional OKR validation in cascade-validator.js: orphaned objective references produce blocking violations instead of warnings
- Updated guardrail-registry tests: 34/34 pass with new blocking assertions and parent_sd_id coverage

## Test plan
- [x] 34/34 guardrail registry tests pass
- [x] 15/15 smoke tests pass
- [x] New test: blocks when no strategic_objectives and no parent_sd_id
- [x] New test: passes cascade when parent_sd_id provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)