### PR TITLE
feat: implement tri-modal event dispatch routing (#SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-021)

### DIFF
--- a/lib/eva/event-bus/event-router.js
+++ b/lib/eva/event-bus/event-router.js
@@ -58,6 +58,7 @@ export function classifyRoutingMode(eventType, payload) {
 }
 
 import { getHandlers } from './handler-registry.js';
+import { runRound } from '../rounds-scheduler.js';
 
 /**
  * Validate event payload has required fields.
@@ -226,6 +227,126 @@ async function executeWithRetry(handler, payload, context, retryOpts) {
 }
 
 /**
+ * Enqueue an event into sub_agent_queue with urgent priority and preemption.
+ * Used by PRIORITY_QUEUE routing mode for governance signals.
+ * @param {object} supabase
+ * @param {object} event - { id, event_type, event_data, eva_venture_id }
+ * @returns {Promise<{ success: boolean, status: string, queueId?: string }>}
+ */
+async function enqueueToPriorityQueue(supabase, event) {
+  const { data, error } = await supabase
+    .from('sub_agent_queue')
+    .insert({
+      task_type: event.event_type,
+      payload: {
+        ...event.event_data,
+        _source_event_id: event.id,
+        _routing_mode: ROUTING_MODES.PRIORITY_QUEUE,
+      },
+      priority: 'urgent',
+      status: 'pending',
+      metadata: {
+        preemption: true,
+        source: 'event-router-trimodal',
+        venture_id: event.eva_venture_id || event.event_data?.ventureId || null,
+      },
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error(`[EventRouter] PRIORITY_QUEUE enqueue failed for ${event.event_type}: ${error.message}`);
+    return { success: false, status: 'enqueue_failed', error: error.message };
+  }
+
+  console.log(`[EventRouter] PRIORITY_QUEUE enqueued: ${event.event_type} → queue id ${data.id}`);
+  return { success: true, status: 'enqueued', queueId: data.id };
+}
+
+/**
+ * Defer a ROUND-classified event to the master scheduler.
+ * @param {object} supabase
+ * @param {object} event - { id, event_type, event_data, eva_venture_id }
+ * @returns {Promise<{ success: boolean, status: string }>}
+ */
+async function deferToRoundScheduler(supabase, event) {
+  const roundType = event.event_type.replace(/^(round\.|cadence\.)/, '');
+  try {
+    const result = await runRound(roundType, {
+      supabase,
+      ventureId: event.eva_venture_id || event.event_data?.ventureId,
+      payload: event.event_data,
+    });
+    console.log(`[EventRouter] ROUND deferred to scheduler: ${event.event_type} → ${roundType}`);
+    return { success: true, status: 'deferred_to_scheduler', roundResult: result };
+  } catch (err) {
+    console.warn(`[EventRouter] ROUND scheduler unavailable for ${roundType}, falling back to EVENT mode: ${err.message}`);
+    return { success: false, status: 'scheduler_unavailable', error: err.message };
+  }
+}
+
+/**
+ * Dispatch an event based on its routing mode classification.
+ * This is the tri-modal dispatch entry point.
+ *
+ * - EVENT: Direct handler execution (existing pipeline)
+ * - ROUND: Defers to master scheduler via runRound()
+ * - PRIORITY_QUEUE: Enqueues into sub_agent_queue with urgent priority
+ *
+ * @param {object} supabase - Supabase client
+ * @param {object} event - { id, event_type, event_data, eva_venture_id }
+ * @param {object} [options] - { maxRetries, baseDelayMs, backoffMultiplier, persist }
+ * @returns {Promise<{ success: boolean, routingMode: string, status: string }>}
+ */
+export async function dispatchByMode(supabase, event, options = {}) {
+  const eventType = event.event_type;
+  const payload = event.event_data || {};
+  const routingMode = classifyRoutingMode(eventType, payload);
+
+  switch (routingMode) {
+    case ROUTING_MODES.ROUND: {
+      const result = await deferToRoundScheduler(supabase, event);
+      if (result.success) {
+        // Record in ledger for observability
+        await recordLedgerEntry(supabase, {
+          eventId: event.id,
+          eventType,
+          handlerName: 'round-scheduler',
+          status: 'success',
+          attempts: 1,
+          metadata: { routingMode, roundType: eventType.replace(/^(round\.|cadence\.)/, '') },
+        });
+        return { success: true, routingMode, status: 'deferred_to_scheduler' };
+      }
+      // Fallback: process as EVENT mode if scheduler unavailable
+      return processEventDirect(supabase, event, options);
+    }
+
+    case ROUTING_MODES.PRIORITY_QUEUE: {
+      const result = await enqueueToPriorityQueue(supabase, event);
+      if (result.success) {
+        await recordLedgerEntry(supabase, {
+          eventId: event.id,
+          eventType,
+          handlerName: 'priority-queue-enqueue',
+          status: 'success',
+          attempts: 1,
+          metadata: { routingMode, queueId: result.queueId },
+        });
+        return { success: true, routingMode, status: 'enqueued' };
+      }
+      // Fallback: process as EVENT mode if enqueue fails
+      console.warn('[EventRouter] PRIORITY_QUEUE enqueue failed, falling back to EVENT mode');
+      return processEventDirect(supabase, event, options);
+    }
+
+    case ROUTING_MODES.EVENT:
+    default:
+      return processEventDirect(supabase, event, options);
+  }
+}
+
+/**
  * Process a single event through the handler pipeline.
  *
  * Supports two modes via options.persist:
@@ -242,10 +363,35 @@ async function executeWithRetry(handler, payload, context, retryOpts) {
 export async function processEvent(supabase, event, options = {}) {
   const eventType = event.event_type;
   const payload = event.event_data || {};
+  const routingMode = classifyRoutingMode(eventType, payload);
+
+  // Tri-modal dispatch: route ROUND and PRIORITY_QUEUE events to their dedicated paths
+  if (routingMode === ROUTING_MODES.ROUND || routingMode === ROUTING_MODES.PRIORITY_QUEUE) {
+    return dispatchByMode(supabase, event, options);
+  }
+
+  // EVENT mode: use direct handler pipeline
+  return processEventDirect(supabase, event, options);
+}
+
+/**
+ * Direct handler execution pipeline (EVENT mode).
+ * This is the original processEvent logic, preserved for EVENT-classified events
+ * and as a fallback for ROUND/PRIORITY_QUEUE when their dedicated paths fail.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {object} event - { id, event_type, event_data, eva_venture_id }
+ * @param {object} [options] - { maxRetries, baseDelayMs, backoffMultiplier, persist }
+ * @returns {Promise<{ success: boolean, status: string, routingMode: string, attempts?: number, error?: string, handlerResults?: Array }>}
+ */
+async function processEventDirect(supabase, event, options = {}) {
+  const eventType = event.event_type;
+  const payload = event.event_data || {};
   const persist = options.persist !== false; // default true
   const maxRetries = options.maxRetries ?? 3;
   const baseDelayMs = options.baseDelayMs ?? 250;
   const backoffMultiplier = options.backoffMultiplier ?? 2;
+  const routingMode = ROUTING_MODES.EVENT;
 
   // Get all handlers for this event type
   const handlers = getHandlers(eventType);
@@ -253,15 +399,12 @@ export async function processEvent(supabase, event, options = {}) {
     if (persist) {
       console.log(`[EventRouter] No handler for event type: ${eventType}`);
     }
-    return { success: true, status: 'no_handler', attempts: 0 };
+    return { success: true, status: 'no_handler', routingMode, attempts: 0 };
   }
-
-  // Classify routing mode for tri-modal handling
-  const routingMode = classifyRoutingMode(eventType, payload);
 
   // --- Fire-and-forget mode (Vision events) ---
   // EXCEPTION: Governance events are ALWAYS persisted even in fire-and-forget mode
-  if (!persist && routingMode !== ROUTING_MODES.PRIORITY_QUEUE) {
+  if (!persist && classifyRoutingMode(eventType, payload) !== ROUTING_MODES.PRIORITY_QUEUE) {
     const context = { supabase, ventureId: event.eva_venture_id || payload.ventureId };
     const handlerResults = [];
 
@@ -291,7 +434,7 @@ export async function processEvent(supabase, event, options = {}) {
   const alreadyProcessed = await isAlreadyProcessed(supabase, eventId);
   if (alreadyProcessed) {
     console.log(`[EventRouter] Duplicate event ${eventId} (${eventType}) - skipping`);
-    return { success: true, status: 'duplicate_event', attempts: 0 };
+    return { success: true, status: 'duplicate_event', routingMode, attempts: 0 };
   }
 
   // 2. Validate payload
@@ -314,7 +457,7 @@ export async function processEvent(supabase, event, options = {}) {
       errorMessage: validation.reason,
     });
 
-    return { success: false, status: 'validation_error', error: validation.reason };
+    return { success: false, status: 'validation_error', routingMode, error: validation.reason };
   }
 
   // 3. Execute all handlers with retry

--- a/tests/unit/event-router-trimodal.test.js
+++ b/tests/unit/event-router-trimodal.test.js
@@ -1,0 +1,336 @@
+/**
+ * Tri-Modal Event Router Tests
+ * SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-021
+ *
+ * Verifies that processEvent dispatches events through the correct routing path:
+ * - EVENT: Direct handler execution with retry, ledger, DLQ
+ * - ROUND: Deferred to master scheduler via runRound()
+ * - PRIORITY_QUEUE: Enqueued into sub_agent_queue with urgent priority
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock handler-registry
+vi.mock('../../lib/eva/event-bus/handler-registry.js', () => ({
+  getHandlers: vi.fn(() => []),
+}));
+
+// Mock rounds-scheduler
+vi.mock('../../lib/eva/rounds-scheduler.js', () => ({
+  runRound: vi.fn(),
+}));
+
+import { getHandlers } from '../../lib/eva/event-bus/handler-registry.js';
+import { runRound } from '../../lib/eva/rounds-scheduler.js';
+import {
+  classifyRoutingMode,
+  ROUTING_MODES,
+  processEvent,
+  dispatchByMode,
+} from '../../lib/eva/event-bus/event-router.js';
+
+// Mock supabase client
+function createMockSupabase() {
+  const insertResult = { data: { id: 'queue-123' }, error: null };
+  const selectResult = { data: [], error: null };
+  const updateResult = { data: null, error: null };
+
+  const makeChain = () => ({
+    insert: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue(insertResult),
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue(selectResult),
+        }),
+        limit: vi.fn().mockResolvedValue(selectResult),
+        single: vi.fn().mockResolvedValue({ data: null, error: null }),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue(updateResult),
+    }),
+  });
+
+  const chains = {};
+  return {
+    from: vi.fn((table) => {
+      if (!chains[table]) chains[table] = makeChain();
+      return chains[table];
+    }),
+    _chains: chains,
+    _insertResult: insertResult,
+  };
+}
+
+describe('classifyRoutingMode', () => {
+  it('classifies governance events as PRIORITY_QUEUE', () => {
+    expect(classifyRoutingMode('guardrail.violated', {})).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(classifyRoutingMode('cascade.violated', {})).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(classifyRoutingMode('okr.hard_stop', {})).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(classifyRoutingMode('chairman.decision_required', {})).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+  });
+
+  it('classifies critical/urgent payloads as PRIORITY_QUEUE', () => {
+    expect(classifyRoutingMode('custom.event', { priority: 'critical' })).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(classifyRoutingMode('custom.event', { urgent: true })).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+  });
+
+  it('classifies round.* events as ROUND', () => {
+    expect(classifyRoutingMode('round.vision_rescore', {})).toBe(ROUTING_MODES.ROUND);
+    expect(classifyRoutingMode('round.gap_analysis', {})).toBe(ROUTING_MODES.ROUND);
+  });
+
+  it('classifies cadence.* events as ROUND', () => {
+    expect(classifyRoutingMode('cadence.daily', {})).toBe(ROUTING_MODES.ROUND);
+    expect(classifyRoutingMode('cadence.weekly', {})).toBe(ROUTING_MODES.ROUND);
+  });
+
+  it('classifies payload routingMode=ROUND as ROUND', () => {
+    expect(classifyRoutingMode('custom.event', { routingMode: 'ROUND' })).toBe(ROUTING_MODES.ROUND);
+  });
+
+  it('classifies standard events as EVENT', () => {
+    expect(classifyRoutingMode('stage.completed', {})).toBe(ROUTING_MODES.EVENT);
+    expect(classifyRoutingMode('decision.submitted', {})).toBe(ROUTING_MODES.EVENT);
+    expect(classifyRoutingMode('sd.completed', {})).toBe(ROUTING_MODES.EVENT);
+  });
+});
+
+describe('processEvent — ROUND dispatch', () => {
+  let supabase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabase = createMockSupabase();
+    getHandlers.mockReturnValue([{ name: 'test-handler', handlerFn: vi.fn() }]);
+    runRound.mockResolvedValue({ success: true });
+  });
+
+  it('defers round.* events to scheduler via runRound()', async () => {
+    const event = {
+      id: 'evt-1',
+      event_type: 'round.vision_rescore',
+      event_data: { ventureId: 'v1' },
+    };
+
+    const result = await processEvent(supabase, event);
+
+    expect(result.success).toBe(true);
+    expect(result.routingMode).toBe(ROUTING_MODES.ROUND);
+    expect(result.status).toBe('deferred_to_scheduler');
+    expect(runRound).toHaveBeenCalledWith('vision_rescore', expect.objectContaining({
+      supabase,
+      payload: event.event_data,
+    }));
+  });
+
+  it('does NOT call direct handlers for ROUND events', async () => {
+    const handlerFn = vi.fn();
+    getHandlers.mockReturnValue([{ name: 'test-handler', handlerFn }]);
+
+    const event = {
+      id: 'evt-2',
+      event_type: 'round.gap_analysis',
+      event_data: {},
+    };
+
+    await processEvent(supabase, event);
+
+    expect(handlerFn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to EVENT mode if scheduler unavailable', async () => {
+    runRound.mockRejectedValue(new Error('Scheduler not started'));
+    const handlerFn = vi.fn();
+    getHandlers.mockReturnValue([{ name: 'fallback-handler', handlerFn }]);
+
+    const event = {
+      id: 'evt-3',
+      event_type: 'round.stage_health',
+      event_data: { ventureId: 'v1' },
+    };
+
+    const result = await processEvent(supabase, event);
+
+    // Should still succeed via fallback to EVENT mode
+    expect(result.routingMode).toBe(ROUTING_MODES.EVENT);
+    expect(handlerFn).toHaveBeenCalled();
+  });
+});
+
+describe('processEvent — PRIORITY_QUEUE dispatch', () => {
+  let supabase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabase = createMockSupabase();
+    getHandlers.mockReturnValue([{ name: 'test-handler', handlerFn: vi.fn() }]);
+  });
+
+  it('enqueues governance events into sub_agent_queue', async () => {
+    const event = {
+      id: 'evt-4',
+      event_type: 'guardrail.violated',
+      event_data: { ventureId: 'v1', rule: 'max-spend' },
+    };
+
+    const result = await processEvent(supabase, event);
+
+    expect(result.success).toBe(true);
+    expect(result.routingMode).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(result.status).toBe('enqueued');
+    expect(supabase.from).toHaveBeenCalledWith('sub_agent_queue');
+  });
+
+  it('does NOT call direct handlers for PRIORITY_QUEUE events', async () => {
+    const handlerFn = vi.fn();
+    getHandlers.mockReturnValue([{ name: 'test-handler', handlerFn }]);
+
+    const event = {
+      id: 'evt-5',
+      event_type: 'cascade.violated',
+      event_data: {},
+    };
+
+    await processEvent(supabase, event);
+
+    expect(handlerFn).not.toHaveBeenCalled();
+  });
+
+  it('sets priority=urgent and preemption=true on enqueued events', async () => {
+    const event = {
+      id: 'evt-6',
+      event_type: 'chairman.override',
+      event_data: { decision: 'block' },
+    };
+
+    await processEvent(supabase, event);
+
+    const queueChain = supabase._chains['sub_agent_queue'];
+    expect(queueChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        priority: 'urgent',
+        metadata: expect.objectContaining({ preemption: true }),
+      })
+    );
+  });
+
+  it('persists governance events even in fire-and-forget mode', async () => {
+    const event = {
+      id: 'evt-7',
+      event_type: 'guardrail.violated',
+      event_data: { priority: 'critical' },
+    };
+
+    const result = await processEvent(supabase, event, { persist: false });
+
+    expect(result.routingMode).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(result.status).toBe('enqueued');
+  });
+});
+
+describe('processEvent — EVENT dispatch (backward compatibility)', () => {
+  let supabase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabase = createMockSupabase();
+  });
+
+  it('executes handlers directly for EVENT-classified events', async () => {
+    const handlerFn = vi.fn();
+    getHandlers.mockReturnValue([{ name: 'stage-handler', handlerFn }]);
+
+    const event = {
+      id: 'evt-8',
+      event_type: 'stage.completed',
+      event_data: { ventureId: 'v1', stageId: 's1' },
+    };
+
+    const result = await processEvent(supabase, event);
+
+    expect(result.routingMode).toBe(ROUTING_MODES.EVENT);
+    expect(handlerFn).toHaveBeenCalledWith(event.event_data, expect.objectContaining({ supabase }));
+  });
+
+  it('creates ledger entries for EVENT-mode processing', async () => {
+    const handlerFn = vi.fn();
+    getHandlers.mockReturnValue([{ name: 'ledger-handler', handlerFn }]);
+
+    const event = {
+      id: 'evt-9',
+      event_type: 'decision.submitted',
+      event_data: { ventureId: 'v1', decisionId: 'd1' },
+    };
+
+    await processEvent(supabase, event);
+
+    expect(supabase.from).toHaveBeenCalledWith('eva_event_ledger');
+  });
+
+  it('routes to DLQ on handler failure after max retries', async () => {
+    const handlerFn = vi.fn().mockRejectedValue(new Error('timeout'));
+    getHandlers.mockReturnValue([{ name: 'failing-handler', handlerFn, maxRetries: 2 }]);
+
+    const event = {
+      id: 'evt-10',
+      event_type: 'stage.completed',
+      event_data: { ventureId: 'v1', stageId: 's1' },
+    };
+
+    const result = await processEvent(supabase, event, { maxRetries: 2, baseDelayMs: 1 });
+
+    expect(result.success).toBe(false);
+    expect(supabase.from).toHaveBeenCalledWith('eva_events_dlq');
+  });
+
+  it('returns no_handler for events with no registered handlers', async () => {
+    getHandlers.mockReturnValue([]);
+
+    const event = {
+      id: 'evt-11',
+      event_type: 'unknown.event',
+      event_data: {},
+    };
+
+    const result = await processEvent(supabase, event);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('no_handler');
+  });
+});
+
+describe('dispatchByMode', () => {
+  let supabase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    supabase = createMockSupabase();
+    getHandlers.mockReturnValue([{ name: 'test-handler', handlerFn: vi.fn() }]);
+    runRound.mockResolvedValue({ success: true });
+  });
+
+  it('returns routingMode in all responses', async () => {
+    // EVENT
+    const eventResult = await dispatchByMode(supabase, {
+      id: 'e1', event_type: 'stage.completed', event_data: { ventureId: 'v1', stageId: 's1' },
+    });
+    expect(eventResult.routingMode).toBe(ROUTING_MODES.EVENT);
+
+    // ROUND
+    const roundResult = await dispatchByMode(supabase, {
+      id: 'e2', event_type: 'round.test', event_data: {},
+    });
+    expect(roundResult.routingMode).toBe(ROUTING_MODES.ROUND);
+
+    // PRIORITY_QUEUE
+    const pqResult = await dispatchByMode(supabase, {
+      id: 'e3', event_type: 'guardrail.violated', event_data: {},
+    });
+    expect(pqResult.routingMode).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `dispatchByMode()` function to route events through three distinct paths based on `classifyRoutingMode()` classification
- EVENT mode: Direct handler execution preserving 100% backward compatibility
- ROUND mode: Defers to `EvaMasterScheduler` via `runRound()` with fallback to EVENT on scheduler failure
- PRIORITY_QUEUE mode: Enqueues governance events into `sub_agent_queue` with `priority=urgent` and `preemption=true`
- Extract `processEventDirect()` from `processEvent()` to isolate original handler pipeline
- All three paths create `eva_event_ledger` entries for observability

## Test plan
- [x] 18 vitest unit tests covering all three routing paths
- [x] Backward compatibility verified for EVENT-classified events
- [x] ROUND fallback to EVENT on scheduler failure tested
- [x] PRIORITY_QUEUE persistence even in fire-and-forget mode tested
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)