### PR TITLE
feat: add semantic modality classification to event router

### DIFF
--- a/lib/eva/event-bus/event-router.js
+++ b/lib/eva/event-bus/event-router.js
@@ -25,6 +25,22 @@ export const ROUTING_MODES = {
 };
 
 /**
+ * Semantic event modalities — orthogonal to routing mode.
+ * Describes the *intent* of an event, not how it is routed.
+ *
+ * - DIRECTIVE: Command/governance signals that require action (guardrails, overrides, blocks)
+ * - INQUIRY: Read-only queries requesting information (status checks, health probes)
+ * - KNOWLEDGE: Data publication events (scores, completions, state changes)
+ * - EVENT: General-purpose notifications (default for unrecognized patterns)
+ */
+export const EVENT_MODALITIES = {
+  DIRECTIVE: 'DIRECTIVE',
+  INQUIRY: 'INQUIRY',
+  KNOWLEDGE: 'KNOWLEDGE',
+  EVENT: 'EVENT',
+};
+
+/**
  * Governance event types that MUST be persisted (never fire-and-forget).
  */
 const GOVERNANCE_EVENT_TYPES = new Set([
@@ -55,6 +71,43 @@ export function classifyRoutingMode(eventType, payload) {
 
   // Everything else is a standard event
   return ROUTING_MODES.EVENT;
+}
+
+/** Inquiry-pattern suffixes */
+const INQUIRY_SUFFIXES = new Set(['query', 'check', 'inspect', 'status', 'probe', 'lookup']);
+
+/** Knowledge-pattern suffixes */
+const KNOWLEDGE_SUFFIXES = new Set(['scored', 'completed', 'published', 'updated', 'created', 'resolved']);
+
+/**
+ * Classify an event's semantic modality (orthogonal to routing mode).
+ * @param {string} eventType
+ * @param {object} payload
+ * @returns {string} EVENT_MODALITIES value
+ */
+export function classifyModality(eventType, payload) {
+  // Explicit payload override
+  if (payload?.modality && EVENT_MODALITIES[payload.modality]) {
+    return EVENT_MODALITIES[payload.modality];
+  }
+
+  // Governance / command events → DIRECTIVE
+  if (GOVERNANCE_EVENT_TYPES.has(eventType)) return EVENT_MODALITIES.DIRECTIVE;
+  if (eventType.startsWith('command.') || eventType.startsWith('directive.')) return EVENT_MODALITIES.DIRECTIVE;
+  if (payload?.priority === 'critical' || payload?.urgent === true) return EVENT_MODALITIES.DIRECTIVE;
+
+  // Suffix-based classification
+  const suffix = eventType.split('.').pop();
+  if (INQUIRY_SUFFIXES.has(suffix)) return EVENT_MODALITIES.INQUIRY;
+  if (KNOWLEDGE_SUFFIXES.has(suffix)) return EVENT_MODALITIES.KNOWLEDGE;
+
+  // Prefix-based classification
+  if (eventType.startsWith('vision.') || eventType.startsWith('score.') || eventType.startsWith('data.')) {
+    return EVENT_MODALITIES.KNOWLEDGE;
+  }
+
+  // Default
+  return EVENT_MODALITIES.EVENT;
 }
 
 import { getHandlers } from './handler-registry.js';
@@ -302,6 +355,7 @@ export async function dispatchByMode(supabase, event, options = {}) {
   const eventType = event.event_type;
   const payload = event.event_data || {};
   const routingMode = classifyRoutingMode(eventType, payload);
+  const modality = classifyModality(eventType, payload);
 
   switch (routingMode) {
     case ROUTING_MODES.ROUND: {
@@ -314,9 +368,9 @@ export async function dispatchByMode(supabase, event, options = {}) {
           handlerName: 'round-scheduler',
           status: 'success',
           attempts: 1,
-          metadata: { routingMode, roundType: eventType.replace(/^(round\.|cadence\.)/, '') },
+          metadata: { routingMode, modality, roundType: eventType.replace(/^(round\.|cadence\.)/, '') },
         });
-        return { success: true, routingMode, status: 'deferred_to_scheduler' };
+        return { success: true, routingMode, modality, status: 'deferred_to_scheduler' };
       }
       // Fallback: process as EVENT mode if scheduler unavailable
       return processEventDirect(supabase, event, options);
@@ -331,9 +385,9 @@ export async function dispatchByMode(supabase, event, options = {}) {
           handlerName: 'priority-queue-enqueue',
           status: 'success',
           attempts: 1,
-          metadata: { routingMode, queueId: result.queueId },
+          metadata: { routingMode, modality, queueId: result.queueId },
         });
-        return { success: true, routingMode, status: 'enqueued' };
+        return { success: true, routingMode, modality, status: 'enqueued' };
       }
       // Fallback: process as EVENT mode if enqueue fails
       console.warn('[EventRouter] PRIORITY_QUEUE enqueue failed, falling back to EVENT mode');
@@ -370,7 +424,7 @@ export async function processEvent(supabase, event, options = {}) {
     return dispatchByMode(supabase, event, options);
   }
 
-  // EVENT mode: use direct handler pipeline
+  // EVENT mode: use direct handler pipeline (modality added inside processEventDirect)
   return processEventDirect(supabase, event, options);
 }
 
@@ -392,6 +446,7 @@ async function processEventDirect(supabase, event, options = {}) {
   const baseDelayMs = options.baseDelayMs ?? 250;
   const backoffMultiplier = options.backoffMultiplier ?? 2;
   const routingMode = ROUTING_MODES.EVENT;
+  const modality = classifyModality(eventType, payload);
 
   // Get all handlers for this event type
   const handlers = getHandlers(eventType);
@@ -399,7 +454,7 @@ async function processEventDirect(supabase, event, options = {}) {
     if (persist) {
       console.log(`[EventRouter] No handler for event type: ${eventType}`);
     }
-    return { success: true, status: 'no_handler', routingMode, attempts: 0 };
+    return { success: true, status: 'no_handler', routingMode, modality, attempts: 0 };
   }
 
   // --- Fire-and-forget mode (Vision events) ---
@@ -423,6 +478,7 @@ async function processEventDirect(supabase, event, options = {}) {
       success: allSucceeded,
       status: allSucceeded ? 'success' : 'partial_failure',
       routingMode,
+      modality,
       handlerResults,
     };
   }
@@ -434,7 +490,7 @@ async function processEventDirect(supabase, event, options = {}) {
   const alreadyProcessed = await isAlreadyProcessed(supabase, eventId);
   if (alreadyProcessed) {
     console.log(`[EventRouter] Duplicate event ${eventId} (${eventType}) - skipping`);
-    return { success: true, status: 'duplicate_event', routingMode, attempts: 0 };
+    return { success: true, status: 'duplicate_event', routingMode, modality, attempts: 0 };
   }
 
   // 2. Validate payload
@@ -457,7 +513,7 @@ async function processEventDirect(supabase, event, options = {}) {
       errorMessage: validation.reason,
     });
 
-    return { success: false, status: 'validation_error', routingMode, error: validation.reason };
+    return { success: false, status: 'validation_error', routingMode, modality, error: validation.reason };
   }
 
   // 3. Execute all handlers with retry
@@ -529,6 +585,7 @@ async function processEventDirect(supabase, event, options = {}) {
     success: allSucceeded,
     status: allSucceeded ? 'success' : 'partial_failure',
     routingMode,
+    modality,
     schemaVersion: EVENT_SCHEMA_VERSION,
     attempts: totalAttempts,
     handlerResults,


### PR DESCRIPTION
## Summary
- Add `EVENT_MODALITIES` enum (DIRECTIVE/INQUIRY/KNOWLEDGE/EVENT) orthogonal to existing routing modes
- Add `classifyModality()` function using governance types, command/directive prefixes, inquiry/knowledge suffix patterns
- Include modality in all dispatch responses (EVENT, ROUND, PRIORITY_QUEUE modes)
- 15 new tests for modality classification, response integration, and stateless handler registry isolation

Closes architecture gap A04 (modality_based_routing) and verifies A01 (stateless_shared_services).

#SD-MAN-INFRA-CORRECTIVE-ARCHITECTURE-GAP-022

## Test plan
- [x] 33 unit tests pass (18 existing + 15 new)
- [x] classifyModality covers all four modalities
- [x] Payload override honored, invalid values rejected
- [x] Modality present in all processEvent/dispatchByMode responses
- [x] createHandlerRegistry produces isolated instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)