### PR TITLE
feat: wire DFE escalation advisory gate into EXEC-TO-PLAN pipeline

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/dfe-escalation-gate.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/dfe-escalation-gate.js
@@ -1,0 +1,90 @@
+/**
+ * DFE Escalation Advisory Gate for EXEC-TO-PLAN
+ * Part of SD-MAN-GEN-CORRECTIVE-VISION-GAP-001
+ *
+ * Wires evaluateAndEscalate() into the handoff gate pipeline.
+ * Advisory (required: false) — never blocks handoffs, but routes
+ * ESCALATE decisions to chairman_decisions table for governance.
+ */
+
+import { evaluate } from '../../../../../../lib/governance/decision-filter-engine.js';
+import {
+  evaluateAndEscalate,
+  requiresEscalation,
+} from '../../../../../../lib/governance/chairman-escalation.js';
+
+/**
+ * Create the DFE_ESCALATION_GATE validator
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Object} Gate configuration
+ */
+export function createDFEEscalationGate(supabase) {
+  return {
+    name: 'DFE_ESCALATION_GATE',
+    validator: async (ctx) => {
+      console.log('\n🔍 DFE Escalation Gate (Advisory)');
+      console.log('-'.repeat(50));
+
+      try {
+        // Derive confidence from the gate results so far
+        const gateScore = ctx.gateResults?.normalizedScore ?? ctx.qualityScore ?? 85;
+        const confidence = gateScore / 100;
+
+        const { dfeResult, escalation } = await evaluateAndEscalate(
+          {
+            confidence,
+            gateType: 'PHASE_GATE',
+            sdId: ctx.sdUuid || ctx.sdId,
+            sdKey: ctx.sdKey || ctx.sdId,
+            context: { source: 'exec-to-plan-gate' },
+          },
+          evaluate,
+          supabase
+        );
+
+        if (requiresEscalation(dfeResult)) {
+          const escId = escalation?.id || 'pending';
+          console.log(`   ⚠️  DFE decision: ESCALATE (confidence ${confidence.toFixed(2)})`);
+          console.log(`   📋 Chairman escalation created: ${escId}`);
+
+          return {
+            passed: true, // Advisory — never blocks
+            score: 80,
+            max_score: 100,
+            issues: [],
+            warnings: [
+              `DFE escalated to chairman (confidence ${confidence.toFixed(2)}, id: ${escId})`,
+            ],
+            gate_status: 'ADVISORY_ESCALATION',
+            dfe_decision: dfeResult.decision,
+            escalation_id: escId,
+          };
+        }
+
+        console.log(`   ✅ DFE decision: ${dfeResult.decision} (confidence ${confidence.toFixed(2)})`);
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: [],
+          gate_status: 'PASS',
+          dfe_decision: dfeResult.decision,
+        };
+      } catch (error) {
+        // Advisory gate — errors should not block handoffs
+        console.log(`   ℹ️  DFE escalation check skipped: ${error.message}`);
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: [`DFE escalation gate skipped: ${error.message}`],
+          gate_status: 'SKIPPED',
+        };
+      }
+    },
+    required: false, // Advisory — never blocks handoffs
+  };
+}

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/index.js
@@ -21,3 +21,4 @@ export { createIntegrationTestRequirementGate } from './integration-test-require
 export { createIntegrationContractGate } from './integration-contract-gate.js';
 export { createStoryAutoValidationGate } from './story-auto-validation.js';
 export { createE2ETestMappingGate } from './e2e-test-mapping.js';
+export { createDFEEscalationGate } from './dfe-escalation-gate.js';

--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -25,7 +25,8 @@ import {
   createIntegrationTestRequirementGate,
   createIntegrationContractGate,
   createStoryAutoValidationGate,
-  createE2ETestMappingGate
+  createE2ETestMappingGate,
+  createDFEEscalationGate
 } from './gates/index.js';
 
 // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
@@ -158,6 +159,10 @@ export class ExecToPlanExecutor extends BaseExecutor {
     // E2E test mapping (SD-LEO-FIX-STORIES-SUB-AGENT-001)
     // Maps E2E test files to user stories for coverage tracking
     gates.push(createE2ETestMappingGate(this.supabase));
+
+    // DFE Escalation advisory gate (SD-MAN-GEN-CORRECTIVE-VISION-GAP-001)
+    // Routes ESCALATE decisions to chairman_decisions for governance
+    gates.push(createDFEEscalationGate(this.supabase));
 
     return gates;
   }

--- a/tests/unit/governance/dfe-escalation-gate.test.js
+++ b/tests/unit/governance/dfe-escalation-gate.test.js
@@ -1,0 +1,173 @@
+/**
+ * DFE Escalation Gate Integration Tests
+ * Part of SD-MAN-GEN-CORRECTIVE-VISION-GAP-001
+ *
+ * Verifies the full escalation pipeline:
+ * gate validator → DFE evaluate → chairman escalation routing
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createDFEEscalationGate } from '../../../scripts/modules/handoff/executors/exec-to-plan/gates/dfe-escalation-gate.js';
+
+function createMockSupabase(insertResult = {}) {
+  return {
+    from: vi.fn().mockReturnValue({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: 'esc-123', decision_type: 'dfe_escalation', status: 'pending', blocking: false, ...insertResult },
+            error: null,
+          }),
+        }),
+      }),
+    }),
+  };
+}
+
+describe('DFE Escalation Gate', () => {
+  let mockSupabase;
+
+  beforeEach(() => {
+    mockSupabase = createMockSupabase();
+  });
+
+  it('returns passed=true when DFE decides GO (high confidence)', async () => {
+    const gate = createDFEEscalationGate(mockSupabase);
+    const ctx = {
+      sdId: 'SD-TEST-001',
+      sdKey: 'SD-TEST-001',
+      qualityScore: 90, // 0.90 confidence → above PHASE_GATE goThreshold of 0.80
+    };
+
+    const result = await gate.validator(ctx);
+
+    expect(result.passed).toBe(true);
+    expect(result.score).toBe(100);
+    expect(result.dfe_decision).toBe('GO');
+    expect(result.issues).toHaveLength(0);
+    expect(result.warnings).toHaveLength(0);
+    // No supabase insert should happen for GO decisions
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('returns passed=true with warning when DFE decides ESCALATE (medium confidence)', async () => {
+    const gate = createDFEEscalationGate(mockSupabase);
+    const ctx = {
+      sdId: 'SD-TEST-002',
+      sdKey: 'SD-TEST-002',
+      sdUuid: 'uuid-test-002',
+      qualityScore: 60, // 0.60 confidence → between escalate (0.4) and go (0.80) for PHASE_GATE
+    };
+
+    const result = await gate.validator(ctx);
+
+    expect(result.passed).toBe(true); // Advisory — never blocks
+    expect(result.score).toBe(80);
+    expect(result.dfe_decision).toBe('ESCALATE');
+    expect(result.gate_status).toBe('ADVISORY_ESCALATION');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('DFE escalated to chairman');
+    expect(result.escalation_id).toBe('esc-123');
+    // Supabase should have been called to insert escalation
+    expect(mockSupabase.from).toHaveBeenCalledWith('chairman_decisions');
+  });
+
+  it('returns passed=true with warning when DFE decides BLOCK (low confidence, non-critical)', async () => {
+    const gate = createDFEEscalationGate(mockSupabase);
+    const ctx = {
+      sdId: 'SD-TEST-003',
+      sdKey: 'SD-TEST-003',
+      qualityScore: 30, // 0.30 confidence → below escalate (0.4) for PHASE_GATE, but non-critical → ESCALATE
+    };
+
+    const result = await gate.validator(ctx);
+
+    expect(result.passed).toBe(true); // Advisory — never blocks
+    expect(result.dfe_decision).toBe('ESCALATE'); // Non-critical context → ESCALATE not BLOCK
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('returns passed=true when supabase insert fails (graceful degradation)', async () => {
+    const failingSupabase = {
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'Connection refused' },
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const gate = createDFEEscalationGate(failingSupabase);
+    const ctx = {
+      sdId: 'SD-TEST-004',
+      qualityScore: 60, // Would trigger ESCALATE
+    };
+
+    const result = await gate.validator(ctx);
+
+    expect(result.passed).toBe(true); // Advisory — errors don't block
+    expect(result.gate_status).toBe('SKIPPED');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('DFE escalation gate skipped');
+  });
+
+  it('uses gateResults.normalizedScore when available', async () => {
+    const gate = createDFEEscalationGate(mockSupabase);
+    const ctx = {
+      sdId: 'SD-TEST-005',
+      gateResults: { normalizedScore: 95 }, // High score → GO
+    };
+
+    const result = await gate.validator(ctx);
+
+    expect(result.passed).toBe(true);
+    expect(result.dfe_decision).toBe('GO');
+  });
+
+  it('defaults to 85 confidence when no score context is available', async () => {
+    const gate = createDFEEscalationGate(mockSupabase);
+    const ctx = { sdId: 'SD-TEST-006' }; // No score data
+
+    const result = await gate.validator(ctx);
+
+    expect(result.passed).toBe(true);
+    expect(result.dfe_decision).toBe('GO'); // 0.85 >= 0.80 goThreshold for PHASE_GATE
+  });
+
+  it('gate is marked as not required (advisory)', () => {
+    const gate = createDFEEscalationGate(mockSupabase);
+    expect(gate.required).toBe(false);
+    expect(gate.name).toBe('DFE_ESCALATION_GATE');
+  });
+
+  it('verifies chairman_decisions insert payload structure', async () => {
+    const gate = createDFEEscalationGate(mockSupabase);
+    const ctx = {
+      sdId: 'SD-TEST-007',
+      sdKey: 'SD-TEST-007',
+      sdUuid: 'uuid-007',
+      qualityScore: 55, // ESCALATE range
+    };
+
+    await gate.validator(ctx);
+
+    // Verify the insert was called with correct structure
+    const fromCall = mockSupabase.from;
+    expect(fromCall).toHaveBeenCalledWith('chairman_decisions');
+
+    const insertCall = fromCall.mock.results[0].value.insert;
+    const insertPayload = insertCall.mock.calls[0][0];
+
+    expect(insertPayload).toHaveProperty('decision_type', 'dfe_escalation');
+    expect(insertPayload).toHaveProperty('status', 'pending');
+    expect(insertPayload).toHaveProperty('blocking', false);
+    expect(insertPayload.context).toHaveProperty('gate_type', 'PHASE_GATE');
+    expect(insertPayload.context).toHaveProperty('sd_id', 'uuid-007');
+    expect(insertPayload.context).toHaveProperty('sd_key', 'SD-TEST-007');
+    expect(insertPayload.context).toHaveProperty('source', 'decision-filter-engine');
+  });
+});

--- a/tests/unit/governance/guardrail-registry-smoke.test.js
+++ b/tests/unit/governance/guardrail-registry-smoke.test.js
@@ -1,0 +1,209 @@
+/**
+ * Guardrail Registry Smoke Tests
+ * Part of SD-MAN-GEN-CORRECTIVE-VISION-GAP-001
+ *
+ * Validates that guardrail-registry.js is functional:
+ * list() returns expected guardrails, check() produces correct
+ * violation structure, register() adds custom guardrails.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { list, check, register, reset, MODES } from '../../../lib/governance/guardrail-registry.js';
+
+describe('Guardrail Registry Smoke Tests', () => {
+  beforeEach(() => {
+    reset(); // Restore defaults before each test
+  });
+
+  describe('list()', () => {
+    it('returns at least 9 default guardrails', () => {
+      const guardrails = list();
+      expect(guardrails.length).toBeGreaterThanOrEqual(9);
+    });
+
+    it('each guardrail has id, name, mode, description', () => {
+      const guardrails = list();
+      for (const g of guardrails) {
+        expect(g).toHaveProperty('id');
+        expect(g).toHaveProperty('name');
+        expect(g).toHaveProperty('mode');
+        expect(g).toHaveProperty('description');
+        expect(typeof g.id).toBe('string');
+        expect(typeof g.name).toBe('string');
+        expect(['blocking', 'advisory']).toContain(g.mode);
+        expect(typeof g.description).toBe('string');
+      }
+    });
+
+    it('includes expected guardrail IDs', () => {
+      const ids = list().map(g => g.id);
+      expect(ids).toContain('GR-VISION-ALIGNMENT');
+      expect(ids).toContain('GR-SCOPE-BOUNDARY');
+      expect(ids).toContain('GR-GOVERNANCE-CASCADE');
+      expect(ids).toContain('GR-RISK-ASSESSMENT');
+      expect(ids).toContain('GR-CORRECTIVE-EXEMPT');
+      expect(ids).toContain('GR-BULK-SD-BLOCK');
+      expect(ids).toContain('GR-ORCHESTRATOR-ARCH-PLAN');
+      expect(ids).toContain('GR-BRAINSTORM-INTENT');
+      expect(ids).toContain('GR-OKR-HARD-STOP');
+    });
+  });
+
+  describe('check()', () => {
+    it('returns {passed, violations, warnings} structure', () => {
+      const result = check({});
+      expect(result).toHaveProperty('passed');
+      expect(result).toHaveProperty('violations');
+      expect(result).toHaveProperty('warnings');
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.violations)).toBe(true);
+      expect(Array.isArray(result.warnings)).toBe(true);
+    });
+
+    it('GR-VISION-ALIGNMENT triggers on visionScore < 30', () => {
+      const result = check({ visionScore: 10 });
+      expect(result.passed).toBe(false);
+      const violation = result.violations.find(v => v.guardrail === 'GR-VISION-ALIGNMENT');
+      expect(violation).toBeDefined();
+      expect(violation.severity).toBe('critical');
+      expect(violation.mode).toBe('blocking');
+    });
+
+    it('GR-VISION-ALIGNMENT passes on visionScore >= 30', () => {
+      const result = check({ visionScore: 50, strategic_objectives: ['OKR-1'] });
+      const violation = result.violations.find(v => v.guardrail === 'GR-VISION-ALIGNMENT');
+      expect(violation).toBeUndefined();
+    });
+
+    it('GR-GOVERNANCE-CASCADE triggers on missing strategic_objectives and parent_sd_id', () => {
+      const result = check({ strategic_objectives: [], parent_sd_id: null });
+      const violation = result.violations.find(v => v.guardrail === 'GR-GOVERNANCE-CASCADE');
+      expect(violation).toBeDefined();
+      expect(violation.severity).toBe('high');
+    });
+
+    it('GR-GOVERNANCE-CASCADE passes with parent_sd_id', () => {
+      const result = check({ parent_sd_id: 'some-parent' });
+      const violation = result.violations.find(v => v.guardrail === 'GR-GOVERNANCE-CASCADE');
+      expect(violation).toBeUndefined();
+    });
+
+    it('GR-CORRECTIVE-EXEMPT exempts corrective SDs', () => {
+      const result = check({
+        visionScore: 10, // Would normally trigger GR-VISION-ALIGNMENT
+        metadata: { source: 'corrective_sd_generator' },
+      });
+      // Corrective exempt guardrail should mark as exempt, not violated
+      const exempt = result.violations.find(v => v.guardrail === 'GR-CORRECTIVE-EXEMPT');
+      expect(exempt).toBeUndefined(); // Exempt means no violation entry
+    });
+
+    it('GR-RISK-ASSESSMENT generates advisory warning for high priority without risks', () => {
+      const result = check({
+        priority: 'high',
+        risks: [],
+        strategic_objectives: ['OKR-1'],
+      });
+      const warning = result.warnings.find(w => w.guardrail === 'GR-RISK-ASSESSMENT');
+      expect(warning).toBeDefined();
+      expect(warning.mode).toBe('advisory');
+    });
+
+    it('GR-OKR-HARD-STOP blocks late-cycle SD creation without chairman override', () => {
+      const result = check({ okrCycleDay: 30, strategic_objectives: ['OKR-1'] });
+      const violation = result.violations.find(v => v.guardrail === 'GR-OKR-HARD-STOP');
+      expect(violation).toBeDefined();
+      expect(violation.severity).toBe('critical');
+    });
+
+    it('GR-OKR-HARD-STOP allows late-cycle with chairman override', () => {
+      const result = check({
+        okrCycleDay: 30,
+        chairmanOverride: true,
+        strategic_objectives: ['OKR-1'],
+      });
+      const violation = result.violations.find(v => v.guardrail === 'GR-OKR-HARD-STOP');
+      expect(violation).toBeUndefined();
+    });
+
+    it('violations have correct entry structure', () => {
+      const result = check({ visionScore: 5 });
+      expect(result.violations.length).toBeGreaterThan(0);
+      const v = result.violations[0];
+      expect(v).toHaveProperty('guardrail');
+      expect(v).toHaveProperty('name');
+      expect(v).toHaveProperty('mode');
+      expect(v).toHaveProperty('severity');
+      expect(v).toHaveProperty('message');
+    });
+  });
+
+  describe('register()', () => {
+    it('adds a custom guardrail that appears in list()', () => {
+      const before = list().length;
+
+      register({
+        id: 'GR-CUSTOM-TEST',
+        name: 'Custom Test Guardrail',
+        mode: MODES.ADVISORY,
+        description: 'Test guardrail for smoke testing',
+        check: () => ({ violated: false }),
+      });
+
+      const after = list();
+      expect(after.length).toBe(before + 1);
+      const custom = after.find(g => g.id === 'GR-CUSTOM-TEST');
+      expect(custom).toBeDefined();
+      expect(custom.name).toBe('Custom Test Guardrail');
+    });
+
+    it('replaces an existing guardrail by id', () => {
+      const before = list().length;
+
+      register({
+        id: 'GR-VISION-ALIGNMENT',
+        name: 'Replaced Vision Alignment',
+        mode: MODES.ADVISORY, // Changed from blocking
+        description: 'Replaced for testing',
+        check: () => ({ violated: false }),
+      });
+
+      const after = list();
+      expect(after.length).toBe(before); // Same count, replaced in-place
+      const replaced = after.find(g => g.id === 'GR-VISION-ALIGNMENT');
+      expect(replaced.name).toBe('Replaced Vision Alignment');
+      expect(replaced.mode).toBe('advisory');
+    });
+
+    it('throws on missing id or check function', () => {
+      expect(() => register({ name: 'No ID' })).toThrow('Guardrail must have id and check function');
+      expect(() => register({ id: 'GR-NO-CHECK' })).toThrow('Guardrail must have id and check function');
+    });
+  });
+
+  describe('reset()', () => {
+    it('restores defaults after custom registration', () => {
+      register({
+        id: 'GR-TEMP',
+        name: 'Temp',
+        mode: MODES.ADVISORY,
+        description: 'Temp',
+        check: () => ({ violated: false }),
+      });
+
+      const withCustom = list().length;
+      reset();
+      const afterReset = list().length;
+
+      expect(afterReset).toBeLessThan(withCustom);
+      expect(list().find(g => g.id === 'GR-TEMP')).toBeUndefined();
+    });
+  });
+
+  describe('MODES constant', () => {
+    it('exports BLOCKING and ADVISORY modes', () => {
+      expect(MODES.BLOCKING).toBe('blocking');
+      expect(MODES.ADVISORY).toBe('advisory');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add DFE escalation advisory gate that routes ESCALATE decisions to chairman_decisions table for governance oversight
- Wire gate into EXEC-TO-PLAN pipeline (gates/index.js + executor index.js)
- Add 8 integration tests covering GO/ESCALATE/BLOCK decisions, graceful degradation, and payload verification
- Add 18 guardrail registry smoke tests validating governance foundation (list, check, register, reset, MODES)

## Test plan
- [x] All 26 tests pass (`npx vitest run tests/unit/governance/`)
- [x] Gate is advisory (required: false) — never blocks handoffs
- [x] Graceful degradation on supabase failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)