### PR TITLE
feat: add LLM-driven guardrail intelligence analyzer (#SD-MAN-GEN-CORRECTIVE-VISION-GAP-002)

### DIFF
--- a/lib/governance/guardrail-intelligence-analyzer.js
+++ b/lib/governance/guardrail-intelligence-analyzer.js
@@ -1,0 +1,393 @@
+/**
+ * Guardrail Intelligence Analyzer (V03: analysisstep_active_intelligence)
+ *
+ * LLM-driven analysis layer on top of the deterministic guardrail registry.
+ * Takes guardrail check results + SD data and produces structured intelligence
+ * output: risk scores, pattern insights, and strategic recommendations.
+ *
+ * Addresses vision gaps:
+ * - V03: Moves beyond simple deterministic logic to LLM-driven analysis
+ *         producing structured output for the compounding intelligence chain
+ * - V07: Parallel analysis with configurable concurrency, no hard compute caps
+ *
+ * Results are persisted to `intelligence_analysis` table for chain consumption.
+ *
+ * @module guardrail-intelligence-analyzer
+ */
+
+import { evaluateCost, getComputePosture } from './compute-posture.js';
+
+/**
+ * Analysis prompt templates for each analysis dimension.
+ * Each produces a structured JSON response from the LLM.
+ */
+const ANALYSIS_PROMPTS = {
+  riskAssessment: (sdData, guardrailResults) => ({
+    role: 'system',
+    content: `You are a governance risk analyst. Analyze the following SD guardrail results and produce a structured risk assessment.
+
+SD Data:
+- Title: ${sdData.title || 'N/A'}
+- Type: ${sdData.sd_type || 'N/A'}
+- Priority: ${sdData.priority || 'N/A'}
+- Scope: ${sdData.scope || 'N/A'}
+
+Guardrail Results:
+- Passed: ${guardrailResults.passed}
+- Violations: ${JSON.stringify(guardrailResults.violations || [])}
+- Warnings: ${JSON.stringify(guardrailResults.warnings || [])}
+
+Respond with ONLY valid JSON matching this schema:
+{
+  "overall_risk": "low" | "medium" | "high" | "critical",
+  "risk_factors": [{ "factor": string, "severity": "low"|"medium"|"high"|"critical", "rationale": string }],
+  "mitigation_suggestions": [string]
+}`,
+  }),
+
+  patternAnalysis: (sdData, guardrailResults) => ({
+    role: 'system',
+    content: `You are a strategic pattern analyst. Analyze the SD and guardrail data for recurring patterns, strategic themes, and systemic issues.
+
+SD Data:
+- Title: ${sdData.title || 'N/A'}
+- Type: ${sdData.sd_type || 'N/A'}
+- Strategic Objectives: ${JSON.stringify(sdData.strategic_objectives || [])}
+
+Guardrail Results:
+- Violations: ${JSON.stringify(guardrailResults.violations || [])}
+- Warnings: ${JSON.stringify(guardrailResults.warnings || [])}
+
+Respond with ONLY valid JSON matching this schema:
+{
+  "patterns_detected": [{ "pattern": string, "frequency_signal": "new"|"recurring"|"systemic", "impact": string }],
+  "strategic_alignment_notes": string,
+  "cross_sd_implications": [string]
+}`,
+  }),
+
+  recommendations: (sdData, guardrailResults) => ({
+    role: 'system',
+    content: `You are a governance advisor. Based on the SD data and guardrail results, produce actionable recommendations.
+
+SD Data:
+- Title: ${sdData.title || 'N/A'}
+- Type: ${sdData.sd_type || 'N/A'}
+- Priority: ${sdData.priority || 'N/A'}
+
+Guardrail Results:
+- Passed: ${guardrailResults.passed}
+- Violations: ${JSON.stringify(guardrailResults.violations || [])}
+- Warnings: ${JSON.stringify(guardrailResults.warnings || [])}
+
+Respond with ONLY valid JSON matching this schema:
+{
+  "recommended_actions": [{ "action": string, "priority": "immediate"|"soon"|"backlog", "rationale": string }],
+  "governance_adjustments": [{ "guardrail_id": string, "suggestion": string }],
+  "escalation_needed": boolean,
+  "escalation_reason": string | null
+}`,
+  }),
+};
+
+/**
+ * Analyze guardrail results using LLM-driven intelligence.
+ *
+ * @param {Object} sdData - SD fields (title, sd_type, priority, scope, etc.)
+ * @param {Object} guardrailResults - Output from guardrail-registry check()
+ * @param {Object} options
+ * @param {Object} options.llmClient - LLM client with `analyze(prompt)` method
+ * @param {number} [options.concurrency=3] - Max parallel LLM calls
+ * @param {Object} [options.supabase] - Supabase client for persisting results
+ * @param {string} [options.sdKey] - SD key for DB persistence
+ * @param {string} [options.stageType='EXEC'] - Stage type for cost tracking
+ * @returns {Promise<IntelligenceAnalysis>}
+ *
+ * @typedef {Object} IntelligenceAnalysis
+ * @property {string|null} analysisId - UUID of persisted record (null if not persisted)
+ * @property {Object} riskAssessment - LLM risk analysis or fallback
+ * @property {Object} patternAnalysis - LLM pattern analysis or fallback
+ * @property {Object} recommendations - LLM recommendations or fallback
+ * @property {Object} cost - { totalCost, evaluation, posture }
+ * @property {Object} meta - { analyzedAt, dimensions, errors, partial }
+ */
+export async function analyzeGuardrailResults(sdData, guardrailResults, options = {}) {
+  const {
+    llmClient,
+    concurrency = 3,
+    supabase,
+    sdKey,
+    stageType = 'EXEC',
+  } = options;
+
+  const errors = [];
+  const startTime = Date.now();
+
+  // If no LLM client, return deterministic fallback
+  if (!llmClient || typeof llmClient.analyze !== 'function') {
+    const fallback = buildDeterministicFallback(sdData, guardrailResults);
+    fallback.meta.errors.push('No LLM client provided — using deterministic fallback');
+    return fallback;
+  }
+
+  // Build analysis tasks
+  const dimensions = ['riskAssessment', 'patternAnalysis', 'recommendations'];
+  const prompts = dimensions.map(dim => ({
+    dimension: dim,
+    prompt: ANALYSIS_PROMPTS[dim](sdData, guardrailResults),
+  }));
+
+  // Execute in parallel with configurable concurrency using batched Promise.allSettled
+  const results = {};
+  const batches = chunkArray(prompts, concurrency);
+  let totalCost = 0;
+
+  for (const batch of batches) {
+    const settled = await Promise.allSettled(
+      batch.map(async ({ dimension, prompt }) => {
+        const result = await llmClient.analyze(prompt);
+        return { dimension, result };
+      }),
+    );
+
+    for (const outcome of settled) {
+      if (outcome.status === 'fulfilled') {
+        const { dimension, result } = outcome.value;
+        results[dimension] = parseAnalysisResult(result, dimension);
+        totalCost += result?.cost ?? 0;
+      } else {
+        const idx = settled.indexOf(outcome);
+        const dim = batch[idx]?.dimension || 'unknown';
+        errors.push(`${dim}: ${outcome.reason?.message || 'Analysis failed'}`);
+        results[dim] = getFallbackForDimension(dim, sdData, guardrailResults);
+      }
+    }
+  }
+
+  // Cost tracking via compute-posture (V07: awareness-not-enforcement)
+  const posture = getComputePosture();
+  const costEvaluation = evaluateCost(totalCost, stageType, posture);
+
+  const analysis = {
+    analysisId: null,
+    riskAssessment: results.riskAssessment || getFallbackForDimension('riskAssessment', sdData, guardrailResults),
+    patternAnalysis: results.patternAnalysis || getFallbackForDimension('patternAnalysis', sdData, guardrailResults),
+    recommendations: results.recommendations || getFallbackForDimension('recommendations', sdData, guardrailResults),
+    cost: {
+      totalCost,
+      evaluation: costEvaluation,
+      posture: posture.policy,
+    },
+    meta: {
+      analyzedAt: new Date().toISOString(),
+      durationMs: Date.now() - startTime,
+      dimensions: dimensions.length,
+      errors,
+      partial: errors.length > 0,
+    },
+  };
+
+  // Persist to intelligence_analysis table if supabase provided
+  if (supabase && sdKey) {
+    try {
+      analysis.analysisId = await persistAnalysis(supabase, sdKey, analysis);
+    } catch (err) {
+      errors.push(`persist: ${err.message}`);
+    }
+  }
+
+  return analysis;
+}
+
+/**
+ * Build a deterministic fallback when no LLM is available.
+ * Derives insights from guardrail violations/warnings directly.
+ */
+export function buildDeterministicFallback(sdData, guardrailResults) {
+  const violations = guardrailResults.violations || [];
+  const warnings = guardrailResults.warnings || [];
+
+  const riskLevel = violations.some(v => v.severity === 'critical') ? 'critical'
+    : violations.length > 0 ? 'high'
+      : warnings.length > 2 ? 'medium'
+        : 'low';
+
+  return {
+    analysisId: null,
+    riskAssessment: {
+      overall_risk: riskLevel,
+      risk_factors: violations.map(v => ({
+        factor: v.guardrail,
+        severity: v.severity,
+        rationale: v.message,
+      })),
+      mitigation_suggestions: violations.map(v => `Address ${v.guardrail}: ${v.message}`),
+    },
+    patternAnalysis: {
+      patterns_detected: warnings.map(w => ({
+        pattern: w.guardrail,
+        frequency_signal: 'new',
+        impact: w.message,
+      })),
+      strategic_alignment_notes: guardrailResults.passed
+        ? 'All blocking guardrails passed'
+        : `${violations.length} blocking violation(s) detected`,
+      cross_sd_implications: [],
+    },
+    recommendations: {
+      recommended_actions: violations.map(v => ({
+        action: `Resolve ${v.name}`,
+        priority: v.severity === 'critical' ? 'immediate' : 'soon',
+        rationale: v.message,
+      })),
+      governance_adjustments: [],
+      escalation_needed: violations.some(v => v.severity === 'critical'),
+      escalation_reason: violations.find(v => v.severity === 'critical')?.message || null,
+    },
+    cost: {
+      totalCost: 0,
+      evaluation: { level: 'normal', cost: 0, threshold: {}, blocked: false },
+      posture: 'awareness-not-enforcement',
+    },
+    meta: {
+      analyzedAt: new Date().toISOString(),
+      durationMs: 0,
+      dimensions: 3,
+      errors: [],
+      partial: false,
+    },
+  };
+}
+
+/**
+ * Parse LLM result string/object into structured analysis.
+ *
+ * @param {Object|string} result - LLM response
+ * @param {string} dimension - Which analysis dimension
+ * @returns {Object} Parsed result
+ */
+function parseAnalysisResult(result, dimension) {
+  if (!result) return null;
+
+  // If result has a `content` field (common LLM response shape)
+  const raw = typeof result === 'string' ? result
+    : result.content || result.text || JSON.stringify(result);
+
+  try {
+    // Extract JSON from potential markdown code blocks
+    const jsonMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/) || [null, raw];
+    return JSON.parse(jsonMatch[1].trim());
+  } catch {
+    return getFallbackShape(dimension);
+  }
+}
+
+/**
+ * Get a safe fallback shape for a specific dimension.
+ */
+function getFallbackShape(dimension) {
+  const shapes = {
+    riskAssessment: {
+      overall_risk: 'medium',
+      risk_factors: [],
+      mitigation_suggestions: ['Unable to analyze — manual review recommended'],
+    },
+    patternAnalysis: {
+      patterns_detected: [],
+      strategic_alignment_notes: 'Analysis unavailable',
+      cross_sd_implications: [],
+    },
+    recommendations: {
+      recommended_actions: [],
+      governance_adjustments: [],
+      escalation_needed: false,
+      escalation_reason: null,
+    },
+  };
+  return shapes[dimension] || {};
+}
+
+/**
+ * Get fallback for a specific dimension using deterministic analysis.
+ */
+function getFallbackForDimension(dimension, sdData, guardrailResults) {
+  const fallback = buildDeterministicFallback(sdData, guardrailResults);
+  return fallback[dimension] || getFallbackShape(dimension);
+}
+
+/**
+ * Persist analysis results to intelligence_analysis table.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdKey - SD key for context
+ * @param {Object} analysis - Full analysis result
+ * @returns {Promise<string>} UUID of inserted record
+ */
+async function persistAnalysis(supabase, sdKey, analysis) {
+  const { data, error } = await supabase
+    .from('intelligence_analysis')
+    .insert({
+      agent_type: 'guardrail_intelligence',
+      status: 'COMPLETED',
+      results: {
+        sd_key: sdKey,
+        risk_assessment: analysis.riskAssessment,
+        pattern_analysis: analysis.patternAnalysis,
+        recommendations: analysis.recommendations,
+        cost: analysis.cost,
+        meta: analysis.meta,
+      },
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    throw new Error(`intelligence_analysis insert failed: ${error.message}`);
+  }
+
+  return data.id;
+}
+
+/**
+ * Split array into chunks for batched parallel execution.
+ *
+ * @param {Array} arr
+ * @param {number} size
+ * @returns {Array<Array>}
+ */
+function chunkArray(arr, size) {
+  const chunks = [];
+  for (let i = 0; i < arr.length; i += size) {
+    chunks.push(arr.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Retrieve past analyses for chain consumption (V03: compounding intelligence).
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {Object} [filters]
+ * @param {string} [filters.sdKey] - Filter by SD key
+ * @param {number} [filters.limit=10] - Max results
+ * @returns {Promise<Array>} Past analysis records
+ */
+export async function getAnalysisHistory(supabase, filters = {}) {
+  let query = supabase
+    .from('intelligence_analysis')
+    .select('id, agent_type, status, results, created_at')
+    .eq('agent_type', 'guardrail_intelligence')
+    .eq('status', 'COMPLETED');
+
+  if (filters.sdKey) {
+    query = query.contains('results', { sd_key: filters.sdKey });
+  }
+
+  query = query
+    .order('created_at', { ascending: false })
+    .limit(filters.limit || 10);
+
+  const { data, error } = await query;
+  if (error) return [];
+  return data || [];
+}

--- a/tests/unit/governance/guardrail-intelligence-analyzer.test.js
+++ b/tests/unit/governance/guardrail-intelligence-analyzer.test.js
@@ -1,0 +1,454 @@
+/**
+ * Tests for Guardrail Intelligence Analyzer
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-002
+ *
+ * Verifies LLM-driven analysis, parallel execution, deterministic fallback,
+ * cost tracking, and persistence to intelligence_analysis table.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  analyzeGuardrailResults,
+  buildDeterministicFallback,
+  getAnalysisHistory,
+} from '../../../lib/governance/guardrail-intelligence-analyzer.js';
+
+// --- Test fixtures ---
+
+const SAMPLE_SD = {
+  title: 'Implement user auth module',
+  sd_type: 'feature',
+  priority: 'high',
+  scope: 'Auth service with JWT tokens',
+  strategic_objectives: [{ id: 'OKR-1', name: 'Security' }],
+};
+
+const PASSING_GUARDRAILS = {
+  passed: true,
+  violations: [],
+  warnings: [],
+};
+
+const FAILING_GUARDRAILS = {
+  passed: false,
+  violations: [
+    {
+      guardrail: 'GR-VISION-ALIGNMENT',
+      name: 'Vision Alignment Minimum',
+      mode: 'blocking',
+      severity: 'critical',
+      message: 'Vision alignment score 20/100 is below minimum threshold (30).',
+    },
+    {
+      guardrail: 'GR-SCOPE-BOUNDARY',
+      name: 'Scope Boundary Enforcement',
+      mode: 'blocking',
+      severity: 'high',
+      message: 'Infrastructure SD includes frontend/UI scope.',
+    },
+  ],
+  warnings: [
+    {
+      guardrail: 'GR-RISK-ASSESSMENT',
+      name: 'Risk Assessment Required',
+      mode: 'advisory',
+      severity: 'medium',
+      message: 'High-priority SD has no risks identified.',
+    },
+  ],
+};
+
+/** Factory for mock LLM clients */
+function createMockLlmClient(responses = {}) {
+  const defaultResponses = {
+    riskAssessment: {
+      content: JSON.stringify({
+        overall_risk: 'high',
+        risk_factors: [{ factor: 'scope', severity: 'high', rationale: 'Broad scope' }],
+        mitigation_suggestions: ['Narrow scope to core auth'],
+      }),
+      cost: 5,
+    },
+    patternAnalysis: {
+      content: JSON.stringify({
+        patterns_detected: [{ pattern: 'scope-creep', frequency_signal: 'recurring', impact: 'Delays' }],
+        strategic_alignment_notes: 'Aligned with security OKR',
+        cross_sd_implications: ['May affect SD-AUTH-002'],
+      }),
+      cost: 5,
+    },
+    recommendations: {
+      content: JSON.stringify({
+        recommended_actions: [{ action: 'Split SD', priority: 'immediate', rationale: 'Too broad' }],
+        governance_adjustments: [],
+        escalation_needed: false,
+        escalation_reason: null,
+      }),
+      cost: 5,
+    },
+  };
+
+  const merged = { ...defaultResponses, ...responses };
+  let callIndex = 0;
+  const dimensions = ['riskAssessment', 'patternAnalysis', 'recommendations'];
+
+  return {
+    analyze: vi.fn(async () => {
+      const dim = dimensions[callIndex % dimensions.length];
+      callIndex++;
+      const resp = merged[dim];
+      if (resp instanceof Error) throw resp;
+      return resp;
+    }),
+    _callIndex: () => callIndex,
+  };
+}
+
+/** Factory for mock Supabase client */
+function createMockSupabase(insertResult = {}) {
+  const defaultResult = {
+    data: { id: 'analysis-uuid-001' },
+    error: null,
+    ...insertResult,
+  };
+
+  const chainable = {
+    insert: vi.fn().mockReturnThis(),
+    select: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(defaultResult),
+    eq: vi.fn().mockReturnThis(),
+    contains: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+  };
+
+  return {
+    from: vi.fn(() => chainable),
+    _chain: chainable,
+  };
+}
+
+// --- Tests ---
+
+describe('Guardrail Intelligence Analyzer - analyzeGuardrailResults', () => {
+  it('returns deterministic fallback when no LLM client provided', async () => {
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS);
+
+    expect(result.analysisId).toBeNull();
+    expect(result.riskAssessment).toBeDefined();
+    expect(result.patternAnalysis).toBeDefined();
+    expect(result.recommendations).toBeDefined();
+    expect(result.cost.totalCost).toBe(0);
+    expect(result.cost.posture).toBe('awareness-not-enforcement');
+    expect(result.meta.errors).toContain('No LLM client provided — using deterministic fallback');
+  });
+
+  it('returns deterministic fallback when llmClient lacks analyze method', async () => {
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, {
+      llmClient: { notAnalyze: () => {} },
+    });
+
+    expect(result.meta.errors).toContain('No LLM client provided — using deterministic fallback');
+    expect(result.cost.totalCost).toBe(0);
+  });
+
+  it('calls LLM for all 3 dimensions with valid client', async () => {
+    const llmClient = createMockLlmClient();
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, FAILING_GUARDRAILS, { llmClient });
+
+    expect(llmClient.analyze).toHaveBeenCalledTimes(3);
+    expect(result.riskAssessment.overall_risk).toBe('high');
+    expect(result.patternAnalysis.patterns_detected).toHaveLength(1);
+    expect(result.recommendations.recommended_actions).toHaveLength(1);
+    expect(result.meta.dimensions).toBe(3);
+    expect(result.meta.partial).toBe(false);
+  });
+
+  it('tracks cost from LLM responses', async () => {
+    const llmClient = createMockLlmClient();
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, { llmClient });
+
+    expect(result.cost.totalCost).toBe(15); // 5 per dimension * 3
+    expect(result.cost.evaluation).toBeDefined();
+    expect(result.cost.evaluation.level).toBe('normal'); // 15 < EXEC warn threshold (200)
+    expect(result.cost.posture).toBe('awareness-not-enforcement');
+  });
+
+  it('handles partial LLM failures gracefully', async () => {
+    const llmClient = createMockLlmClient({
+      patternAnalysis: new Error('LLM timeout'),
+    });
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, FAILING_GUARDRAILS, { llmClient });
+
+    expect(result.meta.partial).toBe(true);
+    expect(result.meta.errors.length).toBeGreaterThan(0);
+    // patternAnalysis should fall back to deterministic
+    expect(result.patternAnalysis).toBeDefined();
+    expect(result.patternAnalysis.patterns_detected).toBeDefined();
+    // Other dimensions should have LLM results
+    expect(result.riskAssessment.overall_risk).toBe('high');
+  });
+
+  it('respects concurrency setting', async () => {
+    let maxConcurrent = 0;
+    let currentConcurrent = 0;
+
+    const llmClient = {
+      analyze: vi.fn(async (prompt) => {
+        currentConcurrent++;
+        if (currentConcurrent > maxConcurrent) maxConcurrent = currentConcurrent;
+        await new Promise(r => setTimeout(r, 10));
+        currentConcurrent--;
+        return { content: JSON.stringify({ overall_risk: 'low', risk_factors: [], mitigation_suggestions: [] }), cost: 1 };
+      }),
+    };
+
+    // With concurrency=1, max should be 1
+    await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, {
+      llmClient,
+      concurrency: 1,
+    });
+
+    expect(maxConcurrent).toBe(1);
+  });
+
+  it('persists to intelligence_analysis table when supabase provided', async () => {
+    const llmClient = createMockLlmClient();
+    const supabase = createMockSupabase();
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, {
+      llmClient,
+      supabase,
+      sdKey: 'SD-TEST-001',
+    });
+
+    expect(result.analysisId).toBe('analysis-uuid-001');
+    expect(supabase.from).toHaveBeenCalledWith('intelligence_analysis');
+    expect(supabase._chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent_type: 'guardrail_intelligence',
+        status: 'COMPLETED',
+        results: expect.objectContaining({
+          sd_key: 'SD-TEST-001',
+        }),
+      }),
+    );
+  });
+
+  it('handles persistence failure gracefully', async () => {
+    const llmClient = createMockLlmClient();
+    const supabase = createMockSupabase({
+      data: null,
+      error: { message: 'Connection refused' },
+    });
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, {
+      llmClient,
+      supabase,
+      sdKey: 'SD-TEST-001',
+    });
+
+    expect(result.analysisId).toBeNull();
+    expect(result.meta.errors).toContainEqual(expect.stringContaining('persist'));
+  });
+
+  it('skips persistence when no supabase or sdKey', async () => {
+    const llmClient = createMockLlmClient();
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, { llmClient });
+
+    expect(result.analysisId).toBeNull();
+    expect(result.meta.errors).toHaveLength(0);
+  });
+
+  it('includes timing metadata', async () => {
+    const llmClient = createMockLlmClient();
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, { llmClient });
+
+    expect(result.meta.analyzedAt).toBeDefined();
+    expect(typeof result.meta.durationMs).toBe('number');
+    expect(result.meta.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('Guardrail Intelligence Analyzer - buildDeterministicFallback', () => {
+  it('returns critical risk for critical violations', () => {
+    const result = buildDeterministicFallback(SAMPLE_SD, FAILING_GUARDRAILS);
+
+    expect(result.riskAssessment.overall_risk).toBe('critical');
+    expect(result.riskAssessment.risk_factors).toHaveLength(2);
+    expect(result.recommendations.escalation_needed).toBe(true);
+  });
+
+  it('returns low risk when all guardrails pass', () => {
+    const result = buildDeterministicFallback(SAMPLE_SD, PASSING_GUARDRAILS);
+
+    expect(result.riskAssessment.overall_risk).toBe('low');
+    expect(result.riskAssessment.risk_factors).toHaveLength(0);
+    expect(result.recommendations.escalation_needed).toBe(false);
+    expect(result.patternAnalysis.strategic_alignment_notes).toContain('passed');
+  });
+
+  it('returns medium risk for multiple warnings without violations', () => {
+    const manyWarnings = {
+      passed: true,
+      violations: [],
+      warnings: [
+        { guardrail: 'GR-A', severity: 'low', message: 'a' },
+        { guardrail: 'GR-B', severity: 'low', message: 'b' },
+        { guardrail: 'GR-C', severity: 'low', message: 'c' },
+      ],
+    };
+
+    const result = buildDeterministicFallback(SAMPLE_SD, manyWarnings);
+
+    expect(result.riskAssessment.overall_risk).toBe('medium');
+  });
+
+  it('returns high risk for non-critical violations', () => {
+    const highViolation = {
+      passed: false,
+      violations: [{ guardrail: 'GR-X', severity: 'high', message: 'high issue' }],
+      warnings: [],
+    };
+
+    const result = buildDeterministicFallback(SAMPLE_SD, highViolation);
+
+    expect(result.riskAssessment.overall_risk).toBe('high');
+  });
+
+  it('maps violations to recommended actions with correct priority', () => {
+    const result = buildDeterministicFallback(SAMPLE_SD, FAILING_GUARDRAILS);
+
+    const actions = result.recommendations.recommended_actions;
+    expect(actions).toHaveLength(2);
+    expect(actions[0].priority).toBe('immediate'); // critical severity
+    expect(actions[1].priority).toBe('soon'); // high severity
+  });
+
+  it('maps warnings to detected patterns', () => {
+    const result = buildDeterministicFallback(SAMPLE_SD, FAILING_GUARDRAILS);
+
+    expect(result.patternAnalysis.patterns_detected).toHaveLength(1);
+    expect(result.patternAnalysis.patterns_detected[0].pattern).toBe('GR-RISK-ASSESSMENT');
+    expect(result.patternAnalysis.patterns_detected[0].frequency_signal).toBe('new');
+  });
+
+  it('has zero cost for deterministic fallback', () => {
+    const result = buildDeterministicFallback(SAMPLE_SD, PASSING_GUARDRAILS);
+
+    expect(result.cost.totalCost).toBe(0);
+    expect(result.cost.posture).toBe('awareness-not-enforcement');
+  });
+
+  it('returns complete structure with all required fields', () => {
+    const result = buildDeterministicFallback(SAMPLE_SD, PASSING_GUARDRAILS);
+
+    // Top-level
+    expect(result).toHaveProperty('analysisId');
+    expect(result).toHaveProperty('riskAssessment');
+    expect(result).toHaveProperty('patternAnalysis');
+    expect(result).toHaveProperty('recommendations');
+    expect(result).toHaveProperty('cost');
+    expect(result).toHaveProperty('meta');
+
+    // Risk assessment shape
+    expect(result.riskAssessment).toHaveProperty('overall_risk');
+    expect(result.riskAssessment).toHaveProperty('risk_factors');
+    expect(result.riskAssessment).toHaveProperty('mitigation_suggestions');
+
+    // Pattern analysis shape
+    expect(result.patternAnalysis).toHaveProperty('patterns_detected');
+    expect(result.patternAnalysis).toHaveProperty('strategic_alignment_notes');
+    expect(result.patternAnalysis).toHaveProperty('cross_sd_implications');
+
+    // Recommendations shape
+    expect(result.recommendations).toHaveProperty('recommended_actions');
+    expect(result.recommendations).toHaveProperty('governance_adjustments');
+    expect(result.recommendations).toHaveProperty('escalation_needed');
+    expect(result.recommendations).toHaveProperty('escalation_reason');
+  });
+});
+
+describe('Guardrail Intelligence Analyzer - getAnalysisHistory', () => {
+  it('queries intelligence_analysis table with correct filters', async () => {
+    const supabase = createMockSupabase();
+
+    await getAnalysisHistory(supabase, { sdKey: 'SD-TEST-001', limit: 5 });
+
+    expect(supabase.from).toHaveBeenCalledWith('intelligence_analysis');
+    expect(supabase._chain.eq).toHaveBeenCalledWith('agent_type', 'guardrail_intelligence');
+    expect(supabase._chain.eq).toHaveBeenCalledWith('status', 'COMPLETED');
+    expect(supabase._chain.contains).toHaveBeenCalledWith('results', { sd_key: 'SD-TEST-001' });
+  });
+
+  it('returns empty array on error', async () => {
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: null, error: { message: 'fail' } }),
+      })),
+    };
+
+    const result = await getAnalysisHistory(supabase);
+
+    expect(result).toEqual([]);
+  });
+
+  it('uses default limit of 10', async () => {
+    const supabase = createMockSupabase();
+
+    await getAnalysisHistory(supabase);
+
+    expect(supabase._chain.limit).toHaveBeenCalledWith(10);
+  });
+});
+
+describe('Guardrail Intelligence Analyzer - LLM Response Parsing', () => {
+  it('handles JSON in markdown code blocks', async () => {
+    const llmClient = {
+      analyze: vi.fn(async () => ({
+        content: '```json\n{"overall_risk":"low","risk_factors":[],"mitigation_suggestions":[]}\n```',
+        cost: 1,
+      })),
+    };
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, { llmClient });
+
+    expect(result.riskAssessment.overall_risk).toBe('low');
+  });
+
+  it('handles plain JSON response', async () => {
+    const llmClient = {
+      analyze: vi.fn(async () => ({
+        content: '{"overall_risk":"medium","risk_factors":[],"mitigation_suggestions":[]}',
+        cost: 1,
+      })),
+    };
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, { llmClient });
+
+    expect(result.riskAssessment.overall_risk).toBe('medium');
+  });
+
+  it('falls back on unparseable LLM response', async () => {
+    const llmClient = {
+      analyze: vi.fn(async () => ({
+        content: 'I cannot produce JSON right now, sorry!',
+        cost: 1,
+      })),
+    };
+
+    const result = await analyzeGuardrailResults(SAMPLE_SD, PASSING_GUARDRAILS, { llmClient });
+
+    // Should get fallback shapes, not crash
+    expect(result.riskAssessment).toBeDefined();
+    expect(result.riskAssessment.overall_risk).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `lib/governance/guardrail-intelligence-analyzer.js` — LLM-driven analysis layer on top of deterministic guardrail registry
- Addresses V03 (analysisstep_active_intelligence): produces structured intelligence output for compounding chain via `intelligence_analysis` table
- Addresses V07 (unlimited_compute_posture): parallel analysis with configurable concurrency, cost tracked via compute-posture.js
- Deterministic fallback when no LLM client available
- 24 passing unit tests

## Test plan
- [x] Unit tests: 24/24 passing (`npx vitest run tests/unit/governance/`)
- [x] LLM analysis with mock client
- [x] Parallel execution with concurrency control
- [x] Deterministic fallback path
- [x] Persistence to intelligence_analysis table
- [x] Graceful error handling (partial failures, unparseable responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)