### PR TITLE
feat: doc-audit v2 — auto-fix, trend, prioritization, dedup

### DIFF
--- a/scripts/eva/doc-health-audit.mjs
+++ b/scripts/eva/doc-health-audit.mjs
@@ -5,13 +5,15 @@
  * Mirrors the /heal pattern: score → persist → generate corrective SDs → re-score until grade A.
  *
  * Subcommands:
- *   score    — Scan filesystem, compute 10-dimension scores, print report
+ *   run      — Full pipeline: score → persist → generate (DEFAULT, no-arg behavior)
+ *   score    — Scan filesystem, compute 13-dimension scores, print report
  *   persist  — Write score JSON to eva_vision_scores (mode: 'doc-audit')
  *   generate — Query latest doc-audit score, create corrective SDs for failing dimensions
  *   status   — Query latest doc-audit score from DB, print summary
  *
  * Usage:
- *   node scripts/eva/doc-health-audit.mjs score [--json] [--verbose]
+ *   node scripts/eva/doc-health-audit.mjs [run] [--verbose] [--structural-only] [--no-auto-fix]
+ *   node scripts/eva/doc-health-audit.mjs score [--json] [--verbose] [--structural-only]
  *   node scripts/eva/doc-health-audit.mjs persist '<json>'
  *   node scripts/eva/doc-health-audit.mjs persist --file <path>
  *   node scripts/eva/doc-health-audit.mjs generate [<score-id>]
@@ -25,9 +27,11 @@ import { dirname, join } from 'path';
 import { readFileSync } from 'fs';
 
 import { scanDocs } from '../modules/doc-audit/scanner.js';
-import { scoreAllDimensions } from '../modules/doc-audit/scorer.js';
+import { scoreAllDimensions, scoreAllDimensionsAsync, enrichGapsWithImpact } from '../modules/doc-audit/scorer.js';
 import { GRADE_THRESHOLDS, classifyScore } from '../modules/doc-audit/rubric.js';
-import { printReport, printSignals, printStatus, toJSON } from '../modules/doc-audit/reporter.js';
+import { printReport, printSignals, printStatus, printTrend, printAutoFixSummary, toJSON } from '../modules/doc-audit/reporter.js';
+import { autoFixAll } from '../modules/doc-audit/auto-fixer.js';
+import { generateSDKey } from '../modules/sd-key-generator.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(__dirname, '../..');
@@ -48,6 +52,7 @@ function getSupabase() {
 async function cmdScore(args) {
   const jsonMode = args.includes('--json');
   const verbose = args.includes('--verbose');
+  const structuralOnly = args.includes('--structural-only');
 
   const log = jsonMode ? process.stderr.write.bind(process.stderr) : (m) => console.log(m);
   log('\n  Scanning documentation files...\n');
@@ -59,8 +64,32 @@ async function cmdScore(args) {
 
   log(`  Found ${stats.fileCount} files in ${stats.dirCount} directories.\n\n`);
 
-  const scoreResult = scoreAllDimensions(scanResult, ROOT_DIR);
+  let scoreResult;
+  let mode = 'structural';
+
+  if (structuralOnly) {
+    scoreResult = scoreAllDimensions(scanResult, ROOT_DIR);
+  } else {
+    // Try full scoring with coverage dimensions
+    let supabase = null;
+    try {
+      supabase = getSupabase();
+    } catch {
+      // Supabase unavailable — fall back to structural-only
+    }
+
+    if (supabase) {
+      mode = 'full';
+      log('  Querying database for coverage dimensions (D11-D13)...\n');
+      scoreResult = await scoreAllDimensionsAsync(scanResult, ROOT_DIR, supabase);
+    } else {
+      log('  Supabase unavailable — scoring structural dimensions only (D01-D10).\n');
+      scoreResult = scoreAllDimensions(scanResult, ROOT_DIR);
+    }
+  }
+
   const jsonOutput = toJSON(scoreResult, stats);
+  jsonOutput.mode_used = mode;
 
   if (jsonMode) {
     console.log(JSON.stringify(jsonOutput, null, 2));
@@ -92,22 +121,33 @@ async function cmdScore(args) {
 
 // ─── PERSIST subcommand ─────────────────────────────────────────────────────
 
-async function cmdPersist(args) {
+/**
+ * Persist score data to database.
+ * @param {string[]|object} argsOrData - CLI args array OR score data object (for internal chaining)
+ * @returns {Promise<string>} The inserted score ID
+ */
+async function cmdPersist(argsOrData) {
   let scoreData;
 
-  // Parse input: --file <path> or inline JSON
-  const fileIdx = args.indexOf('--file');
-  if (fileIdx !== -1 && args[fileIdx + 1]) {
-    const filePath = args[fileIdx + 1];
-    scoreData = JSON.parse(readFileSync(filePath, 'utf-8'));
+  if (argsOrData && typeof argsOrData === 'object' && !Array.isArray(argsOrData)) {
+    // Direct object passed from cmdRun pipeline
+    scoreData = argsOrData;
   } else {
-    // Find first arg that looks like JSON
-    const jsonArg = args.find(a => a.startsWith('{'));
-    if (jsonArg) {
-      scoreData = JSON.parse(jsonArg);
+    const args = argsOrData || [];
+    // Parse input: --file <path> or inline JSON
+    const fileIdx = args.indexOf('--file');
+    if (fileIdx !== -1 && args[fileIdx + 1]) {
+      const filePath = args[fileIdx + 1];
+      scoreData = JSON.parse(readFileSync(filePath, 'utf-8'));
     } else {
-      console.error('Usage: doc-health-audit.mjs persist --file <path> | persist \'<json>\'');
-      process.exit(1);
+      // Find first arg that looks like JSON
+      const jsonArg = args.find(a => a.startsWith('{'));
+      if (jsonArg) {
+        scoreData = JSON.parse(jsonArg);
+      } else {
+        console.error('Usage: doc-health-audit.mjs persist --file <path> | persist \'<json>\'');
+        process.exit(1);
+      }
     }
   }
 
@@ -167,9 +207,72 @@ async function cmdPersist(args) {
   return inserted.id;
 }
 
+// ─── Helpers: Trend + Dedup ──────────────────────────────────────────────────
+
+/**
+ * Fetch the most recent previous doc-audit score for trend comparison.
+ * @returns {{ data: object|null, roundNumber: number }}
+ */
+async function fetchPreviousScore(supabase) {
+  try {
+    const { data: previous } = await supabase
+      .from('eva_vision_scores')
+      .select('total_score, dimension_scores, scored_at')
+      .filter('rubric_snapshot->>mode', 'eq', 'doc-audit')
+      .order('scored_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    const { count } = await supabase
+      .from('eva_vision_scores')
+      .select('id', { count: 'exact', head: true })
+      .filter('rubric_snapshot->>mode', 'eq', 'doc-audit');
+
+    return { data: previous, roundNumber: (count || 0) + 1 };
+  } catch {
+    return { data: null, roundNumber: 1 };
+  }
+}
+
+/**
+ * Check for existing active corrective SDs covering the same dimensions.
+ * Returns the set of dimension IDs already covered and the existing SD keys.
+ */
+async function checkExistingCorrectives(supabase, failingDimIds) {
+  try {
+    const { data: existingSDs, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, metadata, status')
+      .filter('metadata->>source', 'eq', 'doc-health-audit')
+      .not('status', 'in', '("completed","cancelled","rejected")');
+
+    if (error || !existingSDs) {
+      console.log('  Warning: Could not check for existing corrective SDs. Proceeding with creation.');
+      return { coveredDims: new Set(), existingKeys: [] };
+    }
+
+    const coveredDims = new Set();
+    const existingKeys = [];
+
+    for (const sd of existingSDs) {
+      const sdDims = sd.metadata?.dimensions || [];
+      const overlap = sdDims.filter(d => failingDimIds.includes(d));
+      if (overlap.length > 0) {
+        for (const d of overlap) coveredDims.add(d);
+        existingKeys.push({ sdKey: sd.sd_key || sd.id, dims: overlap });
+      }
+    }
+
+    return { coveredDims, existingKeys };
+  } catch {
+    console.log('  Warning: Dedup check failed. Proceeding with creation.');
+    return { coveredDims: new Set(), existingKeys: [] };
+  }
+}
+
 // ─── GENERATE subcommand ────────────────────────────────────────────────────
 
-async function cmdGenerate(args) {
+async function cmdGenerate(args, opts = {}) {
   const supabase = getSupabase();
 
   let scoreId = args[0];
@@ -222,9 +325,11 @@ async function cmdGenerate(args) {
   // Group failing dimensions by tier
   const dims = score.dimension_scores;
   const tiers = { escalation: [], gap_closure: [], minor: [] };
+  const failingDimIds = [];
 
   for (const [id, dim] of Object.entries(dims)) {
     if (dim.score >= GRADE_THRESHOLDS.ACCEPT) continue;
+    failingDimIds.push(id);
 
     if (dim.score < GRADE_THRESHOLDS.GAP_CLOSURE) {
       tiers.escalation.push({ id, ...dim });
@@ -235,37 +340,95 @@ async function cmdGenerate(args) {
     }
   }
 
+  // ── Dedup: Check for existing corrective SDs ──
+  const { coveredDims, existingKeys } = await checkExistingCorrectives(supabase, failingDimIds);
+
+  if (existingKeys.length > 0) {
+    console.log('  Existing corrective SDs detected:');
+    for (const { sdKey, dims: covDims } of existingKeys) {
+      console.log(`    ${sdKey} already covers ${covDims.join(', ')} — skipping`);
+    }
+  }
+
+  if (coveredDims.size === failingDimIds.length && failingDimIds.length > 0) {
+    console.log('\n  All failing dimensions covered by existing corrective SDs. No new SDs needed.');
+
+    // Back-link current score to existing SDs
+    for (const { sdKey } of existingKeys) {
+      await backLinkScoreToSD(supabase, sdKey, scoreId);
+    }
+
+    console.log('  DOC_AUDIT_STATUS=NEEDS_CORRECTION');
+    return;
+  }
+
+  // ── Build prioritized gap description ──
+  const { scanResult: scanData } = opts;
+  let prioritizedGapText = '';
+  if (scanData) {
+    const enriched = enrichGapsWithImpact(
+      { dimensions: Object.entries(dims).map(([id, d]) => ({ id, ...d })) },
+      scanData.files, ROOT_DIR,
+    );
+
+    // Flatten all gaps across failing dimensions, sort by impact, take top 50
+    const allGaps = [];
+    for (const dim of enriched.dimensions) {
+      if (dim.score >= GRADE_THRESHOLDS.ACCEPT) continue;
+      for (const eg of (dim.enrichedGaps || [])) {
+        allGaps.push({ dimId: dim.id, ...eg });
+      }
+    }
+    allGaps.sort((a, b) => b.impactScore - a.impactScore);
+    const top50 = allGaps.slice(0, 50);
+
+    if (top50.length > 0) {
+      prioritizedGapText = '\n\nPrioritized gaps (by impact score):\n' +
+        top50.map((g, i) => `${i + 1}. [${g.dimId}] (impact ${g.impactScore}) ${g.text}`).join('\n');
+    }
+  }
+
   const createdSDs = [];
 
-  // Create one SD per non-empty tier
+  // Create one SD per non-empty tier (skip dimensions already covered)
   for (const [tier, dimensions] of Object.entries(tiers)) {
-    if (dimensions.length === 0) continue;
+    // Filter out already-covered dimensions
+    const uncovered = dimensions.filter(d => !coveredDims.has(d.id));
+    if (uncovered.length === 0) continue;
 
-    const dimNames = dimensions.map(d => d.name || d.id).join(', ');
-    const dimIds = dimensions.map(d => d.id);
-    const lowestScore = Math.min(...dimensions.map(d => d.score));
+    const dimNames = uncovered.map(d => d.name || d.id).join(', ');
+    const dimIds = uncovered.map(d => d.id);
+    const lowestScore = Math.min(...uncovered.map(d => d.score));
     const priority = tier === 'escalation' ? 'critical' : tier === 'gap_closure' ? 'high' : 'medium';
-    const sdType = tier === 'minor' ? 'enhancement' : 'corrective';
+    const sdType = 'documentation';
 
-    // Build success criteria
-    const successCriteria = dimensions.map(d =>
+    const successCriteria = uncovered.map(d =>
       `Re-run /doc-audit shows ${d.id} (${d.name}) >= ${GRADE_THRESHOLDS.ACCEPT}`
     );
 
-    // Build title
-    const title = dimensions.length === 1
-      ? `Documentation Audit: Fix ${dimensions[0].name} (score ${dimensions[0].score}/100)`
-      : `Documentation Audit: Fix ${dimensions.length} dimensions (${tier}, lowest ${lowestScore}/100)`;
+    const title = uncovered.length === 1
+      ? `Documentation Audit: Fix ${uncovered[0].name} (score ${uncovered[0].score}/100)`
+      : `Documentation Audit: Fix ${uncovered.length} dimensions (${tier}, lowest ${lowestScore}/100)`;
 
-    // Dynamically import createSD
+    const sdKey = await generateSDKey({
+      source: 'MANUAL',
+      type: 'documentation',
+      title,
+      skipLeadValidation: true,
+    });
+
     const { createSD } = await import('../leo-create-sd.js');
 
+    const description = `Corrective SD generated by doc-health-audit. Addresses failing dimensions: ${dimNames}.${prioritizedGapText}`;
+
     const result = await createSD({
+      sdKey,
       title,
       type: sdType,
       category: 'documentation',
       priority,
-      description: `Corrective SD generated by doc-health-audit. Addresses failing dimensions: ${dimNames}.`,
+      rationale: `Doc-audit scored ${lowestScore}/100 on ${dimNames}. ${tier === 'escalation' ? 'Critical remediation needed.' : tier === 'gap_closure' ? 'Gap closure needed to reach Grade A.' : 'Minor improvements to reach Grade A.'}`,
+      description,
       success_criteria: successCriteria,
       metadata: {
         source: 'doc-health-audit',
@@ -292,10 +455,182 @@ async function cmdGenerate(args) {
 
     console.log(`\n  ${createdSDs.length} corrective SD(s) created and linked to score ${scoreId}.`);
   } else {
-    console.log('\n  No corrective SDs created (all dimensions above threshold or no gaps detected).');
+    console.log('\n  No corrective SDs created (all dimensions above threshold or already covered).');
   }
 
   console.log('  DOC_AUDIT_STATUS=NEEDS_CORRECTION');
+}
+
+/**
+ * Back-link a score ID to an existing SD's metadata.linked_score_ids.
+ */
+async function backLinkScoreToSD(supabase, sdKey, scoreId) {
+  try {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('id, metadata')
+      .eq('sd_key', sdKey)
+      .single();
+
+    if (sd) {
+      const linked = sd.metadata?.linked_score_ids || [];
+      if (!linked.includes(scoreId)) {
+        linked.push(scoreId);
+        await supabase
+          .from('strategic_directives_v2')
+          .update({ metadata: { ...sd.metadata, linked_score_ids: linked } })
+          .eq('id', sd.id);
+      }
+    }
+  } catch {
+    // Non-critical — don't fail the pipeline
+  }
+}
+
+// ─── RUN subcommand (full 5-step pipeline) ───────────────────────────────────
+
+/**
+ * Full audit pipeline: score → auto-fix → re-score → persist → generate.
+ * This is the default no-arg behavior and the primary entry point.
+ */
+async function cmdRun(args) {
+  const verbose = args.includes('--verbose');
+  const structuralOnly = args.includes('--structural-only');
+  const noAutoFix = args.includes('--no-auto-fix');
+
+  console.log('\n  ╔═══════════════════════════════════════════════════════════╗');
+  console.log('  ║  DOC-AUDIT: Full Pipeline (score → fix → re-score → persist → generate) ║');
+  console.log('  ╚═══════════════════════════════════════════════════════════╝\n');
+
+  let supabase = null;
+  if (!structuralOnly) {
+    try {
+      supabase = getSupabase();
+    } catch {
+      // Supabase unavailable
+    }
+  }
+
+  // Helper: run scoring
+  async function runScoring(scan) {
+    const stats = { fileCount: scan.files.length, dirCount: scan.directories.length };
+    let result;
+    if (supabase && !structuralOnly) {
+      result = await scoreAllDimensionsAsync(scan, ROOT_DIR, supabase);
+    } else {
+      result = scoreAllDimensions(scan, ROOT_DIR);
+    }
+    return { scoreResult: result, stats };
+  }
+
+  function printGaps(scoreResult) {
+    if (!verbose) return;
+    console.log('\n  GAPS BY DIMENSION:');
+    for (const dim of scoreResult.dimensions) {
+      if (dim.gaps.length > 0) {
+        console.log(`\n  ${dim.id}: ${dim.name} (${dim.gaps.length} gaps)`);
+        for (const gap of dim.gaps.slice(0, 10)) {
+          console.log(`    - ${gap}`);
+        }
+        if (dim.gaps.length > 10) {
+          console.log(`    ... and ${dim.gaps.length - 10} more`);
+        }
+      }
+    }
+    console.log('');
+  }
+
+  // ── [1/5] SCORE ──
+  console.log('  [1/5] Scoring documentation...\n');
+  let scanResult = scanDocs(ROOT_DIR);
+  console.log(`  Found ${scanResult.files.length} files in ${scanResult.directories.length} directories.\n`);
+
+  if (supabase && !structuralOnly) {
+    console.log('  Querying database for coverage dimensions (D11-D13)...\n');
+  }
+
+  let { scoreResult, stats } = await runScoring(scanResult);
+  printReport(scoreResult, stats);
+  printGaps(scoreResult);
+
+  // ── [2/5] AUTO-FIX ──
+  let fixResult = null;
+  if (!noAutoFix && scoreResult.totalScore < GRADE_THRESHOLDS.ACCEPT) {
+    console.log('\n  [2/5] Auto-fixing trivial issues (D02, D06, D07)...\n');
+    fixResult = autoFixAll(scanResult, ROOT_DIR, scoreResult);
+    printAutoFixSummary(fixResult);
+
+    // ── [3/5] RE-SCORE ──
+    if (fixResult.fixed.length > 0) {
+      console.log('\n  [3/5] Re-scoring after auto-fix...\n');
+      scanResult = scanDocs(ROOT_DIR);
+      ({ scoreResult, stats } = await runScoring(scanResult));
+      printReport(scoreResult, stats);
+      printGaps(scoreResult);
+    } else {
+      console.log('\n  [3/5] No fixes applied — skipping re-score.\n');
+    }
+  } else if (noAutoFix) {
+    console.log('\n  [2/5] Auto-fix skipped (--no-auto-fix).');
+    console.log('  [3/5] Re-score skipped.\n');
+  } else {
+    console.log('\n  [2/5] Grade A — auto-fix not needed.');
+    console.log('  [3/5] Re-score skipped.\n');
+  }
+
+  const jsonOutput = toJSON(scoreResult, stats);
+
+  // ── Check: Grade A? ──
+  if (scoreResult.totalScore >= GRADE_THRESHOLDS.ACCEPT) {
+    console.log(`\n  Grade A achieved (${scoreResult.totalScore}/100). No corrective action needed.\n`);
+    console.log('  DOC_AUDIT_STATUS=PASS');
+    console.log('═'.repeat(59));
+    return;
+  }
+
+  // ── TREND DISPLAY ──
+  if (supabase) {
+    const { data: previous, roundNumber } = await fetchPreviousScore(supabase);
+    printTrend(scoreResult, previous, roundNumber);
+  }
+
+  // ── [4/5] PERSIST ──
+  if (!supabase) {
+    console.log('\n  Supabase unavailable — cannot persist or generate corrective SDs.');
+    console.log('  Run individual subcommands when database is available:');
+    console.log('    node scripts/eva/doc-health-audit.mjs score --json > score.json');
+    console.log('    node scripts/eva/doc-health-audit.mjs persist --file score.json');
+    console.log('    node scripts/eva/doc-health-audit.mjs generate');
+    printSignals(scoreResult.totalScore, null);
+    return;
+  }
+
+  console.log('\n  [4/5] Persisting score to database...\n');
+  const scoreId = await cmdPersist(jsonOutput);
+
+  // ── [5/5] GENERATE (with dedup + prioritization) ──
+  console.log('\n  [5/5] Generating corrective SDs for failing dimensions...\n');
+  await cmdGenerate([scoreId], { scanResult });
+
+  // ── Final signals ──
+  console.log('');
+  console.log('═'.repeat(59));
+  console.log('  DOC-AUDIT PIPELINE COMPLETE');
+  console.log('═'.repeat(59));
+  console.log(`  Score: ${scoreResult.totalScore}/100 (Grade ${jsonOutput.grade})`);
+  console.log(`  Score ID: ${scoreId}`);
+  if (fixResult && fixResult.fixed.length > 0) {
+    console.log(`  Auto-fixed: ${fixResult.fixed.length} issues`);
+  }
+  console.log('');
+  console.log('  Corrective SDs have been created and queued.');
+  console.log('  After they are executed, re-run to verify improvement:');
+  console.log('    node scripts/eva/doc-health-audit.mjs run');
+  console.log('');
+  console.log('  DOC_AUDIT_STATUS=NEEDS_CORRECTION');
+  console.log(`  DOC_AUDIT_SCORE_ID=${scoreId}`);
+  console.log('  DOC_AUDIT_NEXT_CMD=node scripts/eva/doc-health-audit.mjs run');
+  console.log('═'.repeat(59));
 }
 
 // ─── STATUS subcommand ──────────────────────────────────────────────────────
@@ -318,11 +653,18 @@ async function cmdStatus() {
 
 async function main() {
   const args = process.argv.slice(2);
-  const subcommand = args[0] || 'score';
-  const subArgs = args.slice(1);
+  const subcommand = args[0] || 'run';
+  // If first arg is a flag (starts with --), treat as 'run' with flags
+  const isFlag = subcommand.startsWith('--');
+  const actualCommand = isFlag ? 'run' : subcommand;
+  const subArgs = isFlag ? args : args.slice(1);
 
   try {
-    switch (subcommand) {
+    switch (actualCommand) {
+      case 'run':
+      case 'audit':
+        await cmdRun(subArgs);
+        break;
       case 'score':
         await cmdScore(subArgs);
         break;
@@ -338,8 +680,8 @@ async function main() {
         await cmdStatus();
         break;
       default:
-        console.error(`Unknown subcommand: ${subcommand}`);
-        console.error('Usage: doc-health-audit.mjs [score|persist|generate|status] [options]');
+        console.error(`Unknown subcommand: ${actualCommand}`);
+        console.error('Usage: doc-health-audit.mjs [run|score|persist|generate|status] [options]');
         process.exit(1);
     }
   } catch (err) {
@@ -357,4 +699,4 @@ if (isMainModule) {
   main();
 }
 
-export { cmdScore, cmdPersist, cmdGenerate, cmdStatus };
+export { cmdRun, cmdScore, cmdPersist, cmdGenerate, cmdStatus };

--- a/scripts/modules/doc-audit/auto-fixer.js
+++ b/scripts/modules/doc-audit/auto-fixer.js
@@ -1,0 +1,357 @@
+/**
+ * Doc-Audit Auto-Fixer — Automatically fixes trivially correctable documentation gaps
+ *
+ * Fixes three dimension categories:
+ *   D02: Missing YAML front-matter → inject stub metadata
+ *   D06: Missing README.md index   → create directory listing README
+ *   D07: Missing TOC in long docs  → insert generated TOC after title
+ *
+ * Safety guarantees:
+ *   - Never overwrites existing front-matter, README, or TOC
+ *   - Only operates on gaps detected by the scorer
+ *   - All changes are additive (prepend/insert/create), never destructive
+ *
+ * Used by:
+ *   scripts/eva/doc-health-audit.mjs  (cmdRun step 2)
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { join, extname, basename } from 'path';
+
+// ─── Category inference from directory path ─────────────────────────────────
+
+const CATEGORY_MAP = {
+  '01_architecture': 'architecture',
+  '02_api': 'api',
+  '03_protocols_and_standards': 'protocol',
+  '04_features': 'feature',
+  '05_testing': 'testing',
+  '06_deployment': 'deployment',
+  'guides': 'guide',
+  'reference': 'reference',
+  'database': 'database',
+  'leo': 'protocol',
+  'plans': 'architecture',
+};
+
+function inferCategory(relPath) {
+  const parts = relPath.replace(/\\/g, '/').split('/');
+  // Check docs/XXX segment
+  if (parts[0] === 'docs' && parts.length > 1) {
+    const subdir = parts[1];
+    if (CATEGORY_MAP[subdir]) return CATEGORY_MAP[subdir];
+  }
+  return 'general';
+}
+
+const TODAY = new Date().toISOString().slice(0, 10);
+
+// ─── Main entry point ────────────────────────────────────────────────────────
+
+/**
+ * Auto-fix trivial documentation gaps (D02, D06, D07).
+ * @param {{ files: object[], directories: object[] }} scanResult
+ * @param {string} rootDir
+ * @param {{ dimensions: object[] }} scoreResult
+ * @returns {{ fixed: Array<{dimension: string, file: string, action: string}>, skipped: string[] }}
+ */
+export function autoFixAll(scanResult, rootDir, scoreResult) {
+  const fixed = [];
+  const skipped = [];
+
+  const d02 = scoreResult.dimensions.find(d => d.id === 'D02');
+  const d06 = scoreResult.dimensions.find(d => d.id === 'D06');
+  const d07 = scoreResult.dimensions.find(d => d.id === 'D07');
+
+  // Build date index from scan data (already enriched with git dates)
+  const dateIndex = new Map();
+  for (const f of scanResult.files) {
+    const normalized = f.relPath.replace(/\\/g, '/');
+    if (f.gitLastModified) {
+      dateIndex.set(normalized, f.gitLastModified.toISOString().slice(0, 10));
+    }
+  }
+
+  if (d02 && d02.gaps.length > 0) {
+    const result = fixD02Metadata(scanResult.files, d02.gaps, rootDir, dateIndex);
+    fixed.push(...result.fixed);
+    skipped.push(...result.skipped);
+  }
+
+  if (d06 && d06.gaps.length > 0) {
+    const result = fixD06IndexCoverage(scanResult.directories, d06.gaps, rootDir);
+    fixed.push(...result.fixed);
+    skipped.push(...result.skipped);
+  }
+
+  if (d07 && d07.gaps.length > 0) {
+    const result = fixD07Toc(scanResult.files, d07.gaps, rootDir);
+    fixed.push(...result.fixed);
+    skipped.push(...result.skipped);
+  }
+
+  return { fixed, skipped };
+}
+
+// ─── D02: Inject front-matter ────────────────────────────────────────────────
+
+function fixD02Metadata(files, gaps, rootDir, dateIndex) {
+  const fixed = [];
+  const skipped = [];
+
+  // Only auto-fix files that are missing front-matter entirely
+  const missingFMGaps = gaps.filter(g => g.includes('missing YAML front-matter entirely'));
+
+  for (const gap of missingFMGaps) {
+    // Parse: "relPath — missing YAML front-matter entirely"
+    const match = gap.match(/^(.+?)\s+—\s+missing YAML front-matter entirely/);
+    if (!match) {
+      skipped.push(`D02: Could not parse gap: ${gap}`);
+      continue;
+    }
+
+    const relPath = match[1].trim();
+    const fullPath = join(rootDir, relPath);
+
+    if (!existsSync(fullPath)) {
+      skipped.push(`D02: File not found: ${relPath}`);
+      continue;
+    }
+
+    let content;
+    try {
+      content = readFileSync(fullPath, 'utf-8');
+    } catch {
+      skipped.push(`D02: Could not read: ${relPath}`);
+      continue;
+    }
+
+    // Safety: double-check no existing front-matter
+    if (content.startsWith('---')) {
+      skipped.push(`D02: Already has front-matter: ${relPath}`);
+      continue;
+    }
+
+    const category = inferCategory(relPath);
+    const normalizedRel = relPath.replace(/\\/g, '/');
+    const lastUpdated = dateIndex.get(normalizedRel) || TODAY;
+
+    const frontMatter = [
+      '---',
+      `category: ${category}`,
+      'status: draft',
+      'version: 1.0.0',
+      'author: auto-fixer',
+      `last_updated: ${lastUpdated}`,
+      `tags: [${category}, auto-generated]`,
+      '---',
+      '',
+    ].join('\n');
+
+    writeFileSync(fullPath, frontMatter + content, 'utf-8');
+    fixed.push({ dimension: 'D02', file: relPath, action: 'Injected YAML front-matter' });
+  }
+
+  return { fixed, skipped };
+}
+
+// ─── D06: Create stub README.md ──────────────────────────────────────────────
+
+function fixD06IndexCoverage(directories, gaps, rootDir) {
+  const fixed = [];
+  const skipped = [];
+
+  for (const gap of gaps) {
+    // Parse: "relPath/ — missing README.md index"
+    const match = gap.match(/^(.+?)\/?\s+—\s+missing README\.md index/);
+    if (!match) {
+      skipped.push(`D06: Could not parse gap: ${gap}`);
+      continue;
+    }
+
+    const relPath = match[1].trim();
+    const dirPath = join(rootDir, relPath);
+    const readmePath = join(dirPath, 'README.md');
+
+    // Safety: never overwrite existing README
+    if (existsSync(readmePath)) {
+      skipped.push(`D06: README already exists: ${relPath}/README.md`);
+      continue;
+    }
+
+    if (!existsSync(dirPath)) {
+      skipped.push(`D06: Directory not found: ${relPath}`);
+      continue;
+    }
+
+    // List .md files in the directory
+    let entries;
+    try {
+      entries = readdirSync(dirPath, { withFileTypes: true });
+    } catch {
+      skipped.push(`D06: Could not read directory: ${relPath}`);
+      continue;
+    }
+
+    const mdFiles = entries
+      .filter(e => e.isFile() && extname(e.name) === '.md' && e.name !== 'README.md')
+      .map(e => e.name)
+      .sort();
+
+    const subdirs = entries
+      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+      .map(e => e.name)
+      .sort();
+
+    // Build title from directory name
+    const dirName = basename(relPath)
+      .replace(/^\d+[-_]/, '') // strip leading numbers
+      .replace(/[-_]/g, ' ')
+      .replace(/\b\w/g, c => c.toUpperCase());
+
+    const lines = [
+      `# ${dirName}`,
+      '',
+    ];
+
+    if (mdFiles.length > 0) {
+      lines.push('## Documents', '');
+      for (const f of mdFiles) {
+        const label = f.replace(/\.md$/, '').replace(/[-_]/g, ' ');
+        lines.push(`- [${label}](./${f})`);
+      }
+      lines.push('');
+    }
+
+    if (subdirs.length > 0) {
+      lines.push('## Subdirectories', '');
+      for (const d of subdirs) {
+        lines.push(`- [${d}](./${d}/)`);
+      }
+      lines.push('');
+    }
+
+    if (mdFiles.length === 0 && subdirs.length === 0) {
+      lines.push('*No documents yet.*', '');
+    }
+
+    writeFileSync(readmePath, lines.join('\n'), 'utf-8');
+    fixed.push({ dimension: 'D06', file: `${relPath}/README.md`, action: 'Created stub README' });
+  }
+
+  return { fixed, skipped };
+}
+
+// ─── D07: Generate and insert TOC ────────────────────────────────────────────
+
+function fixD07Toc(files, gaps, rootDir) {
+  const fixed = [];
+  const skipped = [];
+
+  // Only fix "N lines but no TOC" gaps (not "missing # title heading")
+  const tocGaps = gaps.filter(g => g.includes('lines but no TOC'));
+
+  for (const gap of tocGaps) {
+    // Parse: "relPath — 250 lines but no TOC"
+    const match = gap.match(/^(.+?)\s+—\s+\d+ lines but no TOC/);
+    if (!match) {
+      skipped.push(`D07: Could not parse gap: ${gap}`);
+      continue;
+    }
+
+    const relPath = match[1].trim();
+    const fullPath = join(rootDir, relPath);
+
+    if (!existsSync(fullPath)) {
+      skipped.push(`D07: File not found: ${relPath}`);
+      continue;
+    }
+
+    let content;
+    try {
+      content = readFileSync(fullPath, 'utf-8');
+    } catch {
+      skipped.push(`D07: Could not read: ${relPath}`);
+      continue;
+    }
+
+    // Safety: check for existing TOC
+    if (/^\s*[-*]\s+\[.*\]\(#/m.test(content)) {
+      skipped.push(`D07: Already has TOC: ${relPath}`);
+      continue;
+    }
+
+    // Extract ## and ### headings for TOC
+    const lines = content.split('\n');
+    const headings = [];
+    for (const line of lines) {
+      const h2 = line.match(/^##\s+(.+)/);
+      if (h2) {
+        headings.push({ level: 2, text: h2[1].trim() });
+        continue;
+      }
+      const h3 = line.match(/^###\s+(.+)/);
+      if (h3) {
+        headings.push({ level: 3, text: h3[1].trim() });
+      }
+    }
+
+    if (headings.length < 2) {
+      skipped.push(`D07: Too few headings for TOC (${headings.length}): ${relPath}`);
+      continue;
+    }
+
+    // Build TOC
+    const tocLines = ['## Table of Contents', ''];
+    for (const h of headings) {
+      // Skip the TOC heading itself if somehow present
+      if (h.text === 'Table of Contents') continue;
+
+      const anchor = h.text
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/\s+/g, '-');
+      const indent = h.level === 3 ? '  ' : '';
+      tocLines.push(`${indent}- [${h.text}](#${anchor})`);
+    }
+    tocLines.push('');
+
+    // Find insertion point: after front-matter + first # title line + blank line
+    let insertIdx = 0;
+
+    // Skip front-matter
+    if (lines[0] === '---') {
+      for (let i = 1; i < lines.length; i++) {
+        if (lines[i] === '---') {
+          insertIdx = i + 1;
+          break;
+        }
+      }
+    }
+
+    // Skip blank lines after front-matter
+    while (insertIdx < lines.length && lines[insertIdx].trim() === '') {
+      insertIdx++;
+    }
+
+    // Skip first # title heading
+    if (insertIdx < lines.length && /^#\s+/.test(lines[insertIdx])) {
+      insertIdx++;
+    }
+
+    // Skip blank line after title
+    while (insertIdx < lines.length && lines[insertIdx].trim() === '') {
+      insertIdx++;
+    }
+
+    // Insert TOC
+    const before = lines.slice(0, insertIdx);
+    const after = lines.slice(insertIdx);
+    const newContent = [...before, '', ...tocLines, ...after].join('\n');
+
+    writeFileSync(fullPath, newContent, 'utf-8');
+    fixed.push({ dimension: 'D07', file: relPath, action: `Inserted TOC (${headings.length} headings)` });
+  }
+
+  return { fixed, skipped };
+}


### PR DESCRIPTION
## Summary

- **Auto-fixer**: New module that automatically fixes D02 (missing YAML front-matter), D06 (missing README.md index), D07 (missing TOC in long docs). Score jumped 63→93 in testing.
- **Trend tracking**: Shows per-dimension deltas vs previous score with round numbering for heal loop visibility
- **Smart gap prioritization**: Scores gaps 0-100 (inbound links + critical directory + recency). Top 50 gaps included in corrective SD descriptions
- **SD deduplication**: Checks for existing active corrective SDs before creating new ones, preventing duplicate SDs across runs
- **5-step pipeline**: `score → auto-fix → re-score → persist → generate` (was 3-step). New `--no-auto-fix` flag to skip auto-fix

## Test plan
- [x] `run --structural-only` — full 5-step pipeline with auto-fix
- [x] `run --no-auto-fix` — skips steps 2/3, verifies trend + persist + dedup + generate
- [x] `run` with Supabase — end-to-end: trend shows deltas, dedup prevents duplicate SDs
- [x] `score --structural-only` — unchanged score-only path still works
- [x] Auto-fix safety: never overwrites existing front-matter, README, or TOC
- [x] All 15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)