### PR TITLE
feat: add D14 Content Accuracy dimension to doc-audit

### DIFF
--- a/scripts/modules/doc-audit/content-classifier.js
+++ b/scripts/modules/doc-audit/content-classifier.js
@@ -1,0 +1,325 @@
+/**
+ * D14 Content Accuracy — Deterministic document classifier.
+ *
+ * Classifications:
+ *   ACCURATE (100)      — Content matches codebase reality
+ *   UNVERIFIABLE (75)   — Insufficient code references to verify
+ *   DRIFTED (50)        — Some content doesn't match current state
+ *   STALE (25)          — Old content with unverified references
+ *   ASPIRATIONAL (0)    — Describes features that don't exist
+ *
+ * Uses 5 deterministic heuristics (no LLM):
+ *   1. Code artifact cross-reference
+ *   2. Stage number validation (>25 = invalid)
+ *   3. DOCMON template detection
+ *   4. TAM/market claim detection
+ *   5. Content-code ratio analysis
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, relative, extname } from 'path';
+
+const SOURCE_EXTENSIONS = new Set(['.js', '.ts', '.mjs', '.cjs', '.sql']);
+const SOURCE_DIRS = ['src', 'lib', 'scripts', 'database'];
+const MAX_STAGE = 25;
+
+// ── Code Artifact Index ─────────────────────────────────────────────
+
+/**
+ * Scan source files and build an index of exported artifacts.
+ * @param {string} rootDir - Project root directory
+ * @returns {Map<string, string>} Map of artifact name → source file relative path
+ */
+export function buildCodeArtifactIndex(rootDir) {
+  const index = new Map();
+  for (const dir of SOURCE_DIRS) {
+    const absDir = join(rootDir, dir);
+    if (existsSync(absDir)) walkDir(absDir, rootDir, index);
+  }
+  return index;
+}
+
+function walkDir(dir, rootDir, index) {
+  let entries;
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === '.temp') continue;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkDir(fullPath, rootDir, index);
+    } else if (SOURCE_EXTENSIONS.has(extname(entry.name))) {
+      extractSourceArtifacts(fullPath, rootDir, index);
+    }
+  }
+}
+
+function extractSourceArtifacts(filePath, rootDir, index) {
+  let content;
+  try { content = readFileSync(filePath, 'utf8'); } catch { return; }
+  const relPath = relative(rootDir, filePath).replace(/\\/g, '/');
+  const ext = extname(filePath);
+
+  const patterns = ext === '.sql'
+    ? [
+        /CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi,
+        /CREATE\s+(?:OR\s+REPLACE\s+)?(?:MATERIALIZED\s+)?VIEW\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi,
+        /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-zA-Z_][a-zA-Z0-9_]*)/gi,
+      ]
+    : [
+        /export\s+(?:async\s+)?function\s+([A-Za-z_$]\w*)/g,
+        /export\s+class\s+([A-Za-z_$]\w*)/g,
+        /export\s+(?:const|let|var)\s+([A-Za-z_$]\w*)/g,
+        /exports\.([A-Za-z_$]\w*)\s*=/g,
+        /(?:^|\n)\s*(?:async\s+)?function\s+([A-Za-z_$]\w*)/g,
+        /(?:^|\n)\s*class\s+([A-Za-z_$]\w*)/g,
+        /export\s+interface\s+([A-Za-z_$]\w*)/g,
+        /export\s+type\s+([A-Za-z_$]\w*)/g,
+      ];
+
+  for (const pattern of patterns) {
+    let match;
+    while ((match = pattern.exec(content)) !== null) {
+      if (match[1] && match[1].length > 1) index.set(match[1], relPath);
+    }
+  }
+}
+
+// ── Document Artifact Extraction ────────────────────────────────────
+
+const EXCLUDE_NAMES = new Set([
+  'README', 'TODO', 'FIXME', 'NOTE', 'WARNING', 'ERROR', 'INFO', 'DEBUG',
+  'JavaScript', 'TypeScript', 'PostgreSQL', 'Supabase', 'GitHub', 'GitLab',
+  'NodeJs', 'GraphQL', 'WebSocket', 'DevOps', 'SaaS', 'PaaS', 'IaaS',
+  'CloudFlare', 'MongoDB', 'Firebase', 'ReactJs', 'NextJs', 'VueJs',
+]);
+
+function extractDocArtifacts(content) {
+  const codeNames = new Set();
+  const fileRefs = new Set();
+
+  // 1. Backtick-quoted identifiers (high confidence)
+  const backtickPatterns = [
+    /`([A-Za-z_$]\w*)\(\)`/g,                     // `functionName()`
+    /`([A-Za-z_$]\w*)\(`/g,                        // `functionName(`
+    /`(fn_[a-z_]+)`/g,                             // `fn_snake_case`
+    /`([A-Z][a-z]+(?:[A-Z][a-z]*)+)`/g,            // `PascalCaseCompound` (2+ words)
+  ];
+  for (const p of backtickPatterns) {
+    let m; while ((m = p.exec(content)) !== null) codeNames.add(m[1]);
+  }
+
+  // 2. Code block analysis (interface/class declarations + type references)
+  const codeBlocks = content.match(/```[\s\S]*?```/g) || [];
+  for (const block of codeBlocks) {
+    const blockPatterns = [
+      /interface\s+([A-Z]\w+)/g,
+      /class\s+([A-Z]\w+)/g,
+      /:\s*([A-Z][a-z]+(?:[A-Z][a-z]*)+)(?:\s*[;,\[\]{}])/g,
+    ];
+    for (const p of blockPatterns) {
+      let m; while ((m = p.exec(block)) !== null) codeNames.add(m[1]);
+    }
+  }
+
+  // 3. Full file path references
+  const pathPatterns = [
+    /`((?:scripts|src|lib|database|docs)\/[\w/.+-]+\.(?:js|ts|mjs|cjs|tsx|jsx|sql|md))`/g,
+    /(?:^|\s)((?:scripts|src|lib|database)\/[\w/.+-]+\.(?:js|ts|mjs|cjs|sql))/gm,
+  ];
+  for (const p of pathPatterns) {
+    let m; while ((m = p.exec(content)) !== null) fileRefs.add(m[1]);
+  }
+
+  // 4. Standalone filenames in backticks (migration files, etc.)
+  const filenamePattern = /`([A-Za-z0-9_.-]+\.(?:js|ts|mjs|cjs|sql))`/g;
+  let m;
+  while ((m = filenamePattern.exec(content)) !== null) fileRefs.add(m[1]);
+
+  const filtered = [...codeNames].filter(n => !EXCLUDE_NAMES.has(n) && n.length > 2);
+  return { codeNames: filtered, fileRefs: [...fileRefs] };
+}
+
+// ── Heuristics ──────────────────────────────────────────────────────
+
+function checkStageReferences(content) {
+  const pattern = /\bStage\s+(\d+)\b/gi;
+  const invalid = [];
+  let m;
+  while ((m = pattern.exec(content)) !== null) {
+    const n = parseInt(m[1], 10);
+    if (n > MAX_STAGE) invalid.push({ stage: n, text: m[0] });
+  }
+  return invalid;
+}
+
+function detectDocmonTemplate(fileInfo, content) {
+  const markers = [];
+  if (fileInfo.metadata) {
+    const tags = Array.isArray(fileInfo.metadata.tags) ? fileInfo.metadata.tags : [];
+    if (tags.includes('auto-generated')) markers.push('tag: auto-generated');
+    if (fileInfo.metadata.author === 'DOCMON') markers.push('author: DOCMON');
+    if (fileInfo.metadata.author === 'auto-fixer') markers.push('author: auto-fixer');
+  }
+  if (/\*This enhanced PRD establishes .+ as the .+ foundation/i.test(content)) {
+    markers.push('DOCMON template boilerplate');
+  }
+  return markers;
+}
+
+function detectTAMClaims(content) {
+  const pattern = /\$[\d,.]+\s*[BMT](?:illion)?\b/gi;
+  const claims = [];
+  let m;
+  while ((m = pattern.exec(content)) !== null) claims.push(m[0]);
+  return claims;
+}
+
+/**
+ * Check if a standalone filename exists in common project directories.
+ */
+function resolveStandaloneFile(filename, rootDir) {
+  const searchDirs = ['database/migrations', 'scripts', 'src', 'lib', 'database'];
+  for (const dir of searchDirs) {
+    if (existsSync(join(rootDir, dir, filename))) return true;
+  }
+  return false;
+}
+
+// ── Classification ──────────────────────────────────────────────────
+
+/**
+ * Classify a single documentation file.
+ * @param {object} fileInfo - Scanner FileInfo object
+ * @param {Map} codeIndex - Code artifact index from buildCodeArtifactIndex
+ * @param {string} rootDir - Project root directory
+ * @returns {{ classification: string, score: number, evidence: string[] }}
+ */
+export function classifyDocument(fileInfo, codeIndex, rootDir) {
+  const fullPath = join(rootDir, fileInfo.relPath);
+  let content;
+  try { content = readFileSync(fullPath, 'utf8'); }
+  catch { return { classification: 'UNVERIFIABLE', score: 75, evidence: ['File not readable'] }; }
+
+  const evidence = [];
+  const { codeNames, fileRefs } = extractDocArtifacts(content);
+
+  // Cross-reference code names against index
+  const resolvedNames = codeNames.filter(n => codeIndex.has(n));
+  const unresolvedNames = codeNames.filter(n => !codeIndex.has(n));
+
+  // Cross-reference file paths against filesystem
+  const resolvedFiles = fileRefs.filter(f => {
+    if (f.includes('/')) return existsSync(join(rootDir, f));
+    return resolveStandaloneFile(f, rootDir);
+  });
+  const unresolvedFiles = fileRefs.filter(f => {
+    if (f.includes('/')) return !existsSync(join(rootDir, f));
+    return !resolveStandaloneFile(f, rootDir);
+  });
+
+  const totalRefs = codeNames.length + fileRefs.length;
+  const resolvedCount = resolvedNames.length + resolvedFiles.length;
+  const unresolvedCount = unresolvedNames.length + unresolvedFiles.length;
+  const unresolvedPct = totalRefs > 0 ? (unresolvedCount / totalRefs) * 100 : 0;
+
+  if (totalRefs > 0) {
+    evidence.push(`References: ${resolvedCount}/${totalRefs} resolved (${Math.round(unresolvedPct)}% unresolved)`);
+    if (unresolvedNames.length > 0) {
+      const sample = unresolvedNames.slice(0, 5).join(', ');
+      const more = unresolvedNames.length > 5 ? ` (+${unresolvedNames.length - 5} more)` : '';
+      evidence.push(`Unresolved code: ${sample}${more}`);
+    }
+    if (unresolvedFiles.length > 0) {
+      const sample = unresolvedFiles.slice(0, 3).join(', ');
+      const more = unresolvedFiles.length > 3 ? ` (+${unresolvedFiles.length - 3} more)` : '';
+      evidence.push(`Unresolved files: ${sample}${more}`);
+    }
+  }
+
+  const invalidStages = checkStageReferences(content);
+  if (invalidStages.length > 0) {
+    evidence.push(`Invalid stages: ${invalidStages.map(s => s.text).join(', ')}`);
+  }
+
+  const templateMarkers = detectDocmonTemplate(fileInfo, content);
+  if (templateMarkers.length > 0) {
+    evidence.push(`Template: ${templateMarkers.join(', ')}`);
+  }
+
+  const tamClaims = detectTAMClaims(content);
+  if (tamClaims.length > 0) {
+    evidence.push(`TAM claims: ${tamClaims.join(', ')}`);
+  }
+
+  const wordCount = content.split(/\s+/).length;
+
+  // ── Decision tree ──
+
+  // ASPIRATIONAL: majority of references unresolved
+  if (totalRefs > 0 && unresolvedPct > 50) {
+    return { classification: 'ASPIRATIONAL', score: 0, evidence };
+  }
+
+  // ASPIRATIONAL: invalid stages + notable unresolved
+  if (invalidStages.length > 0 && unresolvedPct > 20) {
+    return { classification: 'ASPIRATIONAL', score: 0, evidence };
+  }
+
+  // DRIFTED: some invalid stages or moderate unresolved
+  if (invalidStages.length > 0 || (totalRefs > 0 && unresolvedPct > 20)) {
+    return { classification: 'DRIFTED', score: 50, evidence };
+  }
+
+  // STALE: old file with some unresolved references
+  if (fileInfo.gitLastModified) {
+    const ageDays = (Date.now() - new Date(fileInfo.gitLastModified).getTime()) / 86400000;
+    if (ageDays > 180 && totalRefs > 0 && unresolvedPct > 10) {
+      evidence.push(`Last updated: ${Math.round(ageDays)} days ago`);
+      return { classification: 'STALE', score: 25, evidence };
+    }
+  }
+
+  // UNVERIFIABLE: heavy content but few verifiable references
+  if (wordCount > 500 && totalRefs > 0 && resolvedCount < 3) {
+    evidence.push(`${wordCount} words, only ${resolvedCount} verified reference(s)`);
+    return { classification: 'UNVERIFIABLE', score: 75, evidence };
+  }
+
+  // ACCURATE
+  if (totalRefs > 0) {
+    evidence.push(`${resolvedCount} reference(s) verified`);
+  } else {
+    evidence.push('No code references to verify');
+  }
+  return { classification: 'ACCURATE', score: 100, evidence };
+}
+
+// ── Batch Operations ────────────────────────────────────────────────
+
+/**
+ * Classify all documentation files from a scan result.
+ * @param {object} scanResult - Result from scanDocs()
+ * @param {Map} codeIndex - Code artifact index
+ * @param {string} rootDir - Project root directory
+ * @returns {Map<string, { classification: string, score: number, evidence: string[] }>}
+ */
+export function classifyAll(scanResult, codeIndex, rootDir) {
+  const results = new Map();
+  for (const fileInfo of scanResult.files) {
+    results.set(fileInfo.relPath, classifyDocument(fileInfo, codeIndex, rootDir));
+  }
+  return results;
+}
+
+/**
+ * Get classification distribution counts.
+ * @param {Map} classifications - Results from classifyAll()
+ * @returns {{ ACCURATE: number, DRIFTED: number, ASPIRATIONAL: number, STALE: number, UNVERIFIABLE: number }}
+ */
+export function getDistribution(classifications) {
+  const dist = { ACCURATE: 0, DRIFTED: 0, ASPIRATIONAL: 0, STALE: 0, UNVERIFIABLE: 0 };
+  for (const [, result] of classifications) {
+    dist[result.classification] = (dist[result.classification] || 0) + 1;
+  }
+  return dist;
+}

--- a/scripts/modules/doc-audit/coverage-scorer.js
+++ b/scripts/modules/doc-audit/coverage-scorer.js
@@ -1,0 +1,315 @@
+/**
+ * Doc-Audit Coverage Scorer — D11-D14 coverage dimensions
+ *
+ * D11-D13: Database-backed — query Supabase for vision docs, architecture
+ *          plans, and completed SDs, then match keywords against scanned docs.
+ * D14:     Filesystem-backed — classify doc content accuracy via code
+ *          artifact cross-referencing (no LLM, deterministic).
+ *
+ * Used by:
+ *   scripts/modules/doc-audit/scorer.js  (async scoring path)
+ */
+
+import { buildCodeArtifactIndex, classifyAll, getDistribution } from './content-classifier.js';
+
+// ─── Stop words for keyword extraction ───────────────────────────────────────
+
+const STOP_WORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'but', 'in', 'on', 'at', 'to', 'for',
+  'of', 'with', 'by', 'from', 'as', 'is', 'was', 'are', 'were', 'be',
+  'been', 'being', 'have', 'has', 'had', 'do', 'does', 'did', 'will',
+  'would', 'could', 'should', 'may', 'might', 'can', 'shall', 'must',
+  'not', 'no', 'nor', 'so', 'if', 'then', 'than', 'too', 'very',
+  'just', 'about', 'up', 'out', 'that', 'this', 'it', 'its',
+  'all', 'each', 'every', 'both', 'few', 'more', 'most', 'other',
+  'some', 'such', 'only', 'own', 'same', 'into', 'over', 'after',
+  'before', 'between', 'under', 'above', 'through', 'during', 'without',
+  'also', 'new', 'used', 'using', 'use', 'based', 'system', 'support',
+]);
+
+// ─── Keyword extraction ──────────────────────────────────────────────────────
+
+/**
+ * Extract meaningful keywords from text.
+ * Tokenizes, lowercases, removes stop words and short tokens.
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function extractKeywords(text) {
+  if (!text) return [];
+  return text
+    .toLowerCase()
+    .split(/[\s\-_/,.:;()\[\]{}|]+/)
+    .filter(t => t.length >= 3 && !STOP_WORDS.has(t));
+}
+
+// ─── Doc matching ────────────────────────────────────────────────────────────
+
+/**
+ * Search scanned files for keyword matches.
+ * @param {string[]} keywords - Keywords to search for
+ * @param {Array} files - Scanned file objects with headings + contentSnippet
+ * @param {number} threshold - Minimum keyword matches to count as covered (default 2)
+ * @returns {string[]} Matching file relPaths
+ */
+export function findMatchingDocs(keywords, files, threshold = 2) {
+  if (keywords.length === 0) return [];
+
+  const matches = [];
+  for (const file of files) {
+    // Build searchable text from headings + snippet + filename
+    const searchText = [
+      ...(file.headings || []),
+      file.contentSnippet || '',
+      file.name.replace(/\.md$/, '').replace(/[-_]/g, ' '),
+    ].join(' ').toLowerCase();
+
+    let hitCount = 0;
+    for (const kw of keywords) {
+      if (searchText.includes(kw)) hitCount++;
+    }
+
+    if (hitCount >= Math.min(threshold, keywords.length)) {
+      matches.push(file.relPath);
+    }
+  }
+  return matches;
+}
+
+// ─── D11: Vision Coverage (10%) ──────────────────────────────────────────────
+
+/**
+ * Score vision capability documentation coverage.
+ * @param {Array} files - Scanned doc files
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<{score: number, findings: string[], gaps: string[]}>}
+ */
+export async function scoreD11(files, supabase) {
+  const findings = [];
+  const gaps = [];
+
+  const { data: visions, error } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key, extracted_dimensions, status')
+    .eq('status', 'active');
+
+  if (error) {
+    return { score: 0, findings: [`Database error: ${error.message}`], gaps: [] };
+  }
+
+  if (!visions || visions.length === 0) {
+    return { score: 100, findings: ['No active vision documents found'], gaps: [] };
+  }
+
+  // Extract capabilities from extracted_dimensions JSONB
+  const capabilities = [];
+  for (const v of visions) {
+    const dims = v.extracted_dimensions;
+    if (!Array.isArray(dims)) continue;
+    for (const dim of dims) {
+      if (dim.name) {
+        capabilities.push({
+          name: dim.name,
+          description: dim.description || '',
+          visionKey: v.vision_key,
+        });
+      }
+    }
+  }
+
+  if (capabilities.length === 0) {
+    return { score: 100, findings: ['No capabilities extracted from vision documents'], gaps: [] };
+  }
+
+  let covered = 0;
+  for (const cap of capabilities) {
+    const keywords = extractKeywords(`${cap.name} ${cap.description}`);
+    const matches = findMatchingDocs(keywords, files);
+
+    if (matches.length > 0) {
+      covered++;
+    } else {
+      gaps.push(`${cap.visionKey}: "${cap.name}" — no documentation found`);
+    }
+  }
+
+  const score = Math.round((covered / capabilities.length) * 100);
+  findings.push(`${covered}/${capabilities.length} vision capabilities documented across ${visions.length} vision docs`);
+
+  return { score, findings, gaps };
+}
+
+// ─── D12: Architecture Coverage (8%) ─────────────────────────────────────────
+
+/**
+ * Score architecture component documentation coverage.
+ * @param {Array} files - Scanned doc files
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<{score: number, findings: string[], gaps: string[]}>}
+ */
+export async function scoreD12(files, supabase) {
+  const findings = [];
+  const gaps = [];
+
+  const { data: plans, error } = await supabase
+    .from('eva_architecture_plans')
+    .select('plan_key, extracted_dimensions, status')
+    .eq('status', 'active');
+
+  if (error) {
+    return { score: 0, findings: [`Database error: ${error.message}`], gaps: [] };
+  }
+
+  if (!plans || plans.length === 0) {
+    return { score: 100, findings: ['No active architecture plans found'], gaps: [] };
+  }
+
+  // Extract components from extracted_dimensions JSONB
+  const components = [];
+  for (const p of plans) {
+    const dims = p.extracted_dimensions;
+    if (!Array.isArray(dims)) continue;
+    for (const dim of dims) {
+      if (dim.name) {
+        components.push({
+          name: dim.name,
+          description: dim.description || '',
+          planKey: p.plan_key,
+        });
+      }
+    }
+  }
+
+  if (components.length === 0) {
+    return { score: 100, findings: ['No components extracted from architecture plans'], gaps: [] };
+  }
+
+  let covered = 0;
+  for (const comp of components) {
+    const keywords = extractKeywords(`${comp.name} ${comp.description}`);
+    const matches = findMatchingDocs(keywords, files);
+
+    if (matches.length > 0) {
+      covered++;
+    } else {
+      gaps.push(`${comp.planKey}: "${comp.name}" — no documentation found`);
+    }
+  }
+
+  const score = Math.round((covered / components.length) * 100);
+  findings.push(`${covered}/${components.length} architecture components documented across ${plans.length} plans`);
+
+  return { score, findings, gaps };
+}
+
+// ─── D13: SD Documentation Coverage (12%) ────────────────────────────────────
+
+/**
+ * Score completed SD documentation coverage.
+ * Only checks feature/api/infrastructure SDs completed in last 180 days.
+ * @param {Array} files - Scanned doc files
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<{score: number, findings: string[], gaps: string[]}>}
+ */
+export async function scoreD13(files, supabase) {
+  const findings = [];
+  const gaps = [];
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - 180);
+
+  const { data: sds, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, key_changes, delivers_capabilities, sd_type')
+    .eq('status', 'completed')
+    .in('sd_type', ['feature', 'api', 'infrastructure'])
+    .gte('completion_date', cutoffDate.toISOString());
+
+  if (error) {
+    return { score: 0, findings: [`Database error: ${error.message}`], gaps: [] };
+  }
+
+  if (!sds || sds.length === 0) {
+    return { score: 100, findings: ['No qualifying completed SDs in last 180 days'], gaps: [] };
+  }
+
+  let covered = 0;
+  for (const sd of sds) {
+    // Build keyword text from title + key_changes + delivers_capabilities
+    const parts = [sd.title || ''];
+    if (Array.isArray(sd.key_changes)) parts.push(...sd.key_changes);
+    else if (typeof sd.key_changes === 'string') parts.push(sd.key_changes);
+    if (Array.isArray(sd.delivers_capabilities)) parts.push(...sd.delivers_capabilities);
+    else if (typeof sd.delivers_capabilities === 'string') parts.push(sd.delivers_capabilities);
+
+    const keywords = extractKeywords(parts.join(' '));
+    const matches = findMatchingDocs(keywords, files);
+
+    if (matches.length > 0) {
+      covered++;
+    } else {
+      gaps.push(`${sd.sd_key}: "${sd.title}" (${sd.sd_type}) — no documentation found`);
+    }
+  }
+
+  const score = Math.round((covered / sds.length) * 100);
+  findings.push(`${covered}/${sds.length} qualifying SDs have documentation (${sds.length} ${['feature', 'api', 'infrastructure'].join('/')} SDs in last 180d)`);
+
+  return { score, findings, gaps };
+}
+
+// ─── D14: Content Accuracy (8%) ──────────────────────────────────────────────
+
+/**
+ * Score documentation content accuracy by classifying files against
+ * the actual codebase using deterministic heuristics (no LLM).
+ *
+ * Classification scores: ACCURATE=100, UNVERIFIABLE=75, DRIFTED=50,
+ *                        STALE=25, ASPIRATIONAL=0
+ *
+ * @param {{ files: object[] }} scanResult - Result from scanDocs()
+ * @param {string} rootDir - Project root directory
+ * @returns {Promise<{score: number, findings: string[], gaps: string[]}>}
+ */
+export async function scoreD14(scanResult, rootDir) {
+  const findings = [];
+  const gaps = [];
+
+  const codeIndex = buildCodeArtifactIndex(rootDir);
+  findings.push(`Code artifact index: ${codeIndex.size} artifacts indexed`);
+
+  const classifications = classifyAll(scanResult, codeIndex, rootDir);
+  const dist = getDistribution(classifications);
+  const total = classifications.size;
+
+  if (total === 0) {
+    return { score: 100, findings: ['No documentation files to classify'], gaps };
+  }
+
+  // Weighted average score
+  const SCORES = { ACCURATE: 100, UNVERIFIABLE: 75, DRIFTED: 50, STALE: 25, ASPIRATIONAL: 0 };
+  let weightedSum = 0;
+  for (const [, result] of classifications) {
+    weightedSum += SCORES[result.classification] ?? 75;
+  }
+  const score = Math.round(weightedSum / total);
+
+  // Distribution summary
+  findings.push(
+    `Classification: ${dist.ACCURATE} accurate, ${dist.UNVERIFIABLE} unverifiable, ` +
+    `${dist.DRIFTED} drifted, ${dist.STALE} stale, ${dist.ASPIRATIONAL} aspirational`
+  );
+
+  // Gaps: ASPIRATIONAL and DRIFTED files with evidence
+  for (const [relPath, result] of classifications) {
+    if (result.classification === 'ASPIRATIONAL') {
+      gaps.push(`${relPath} — ASPIRATIONAL: ${result.evidence.join('; ')}`);
+    } else if (result.classification === 'DRIFTED') {
+      gaps.push(`${relPath} — DRIFTED: ${result.evidence.join('; ')}`);
+    } else if (result.classification === 'STALE') {
+      gaps.push(`${relPath} — STALE: ${result.evidence.join('; ')}`);
+    }
+  }
+
+  return { score, findings, gaps };
+}

--- a/scripts/modules/doc-audit/scanner.js
+++ b/scripts/modules/doc-audit/scanner.js
@@ -157,6 +157,7 @@ function parseFile(fullPath, rootDir) {
       relPath, name, dir, lineCount: 0, hasMetadata: false,
       metadata: {}, links: [], hasTitle: false, hasToc: false,
       isProhibitedLocation: false, isNamingCompliant: true,
+      headings: [], contentSnippet: '',
     };
   }
 
@@ -175,6 +176,16 @@ function parseFile(fullPath, rootDir) {
   // Check for TOC (look for markdown links to anchors)
   const hasToc = lines.some(l => /^\s*[-*]\s+\[.*\]\(#/.test(l));
 
+  // Extract headings (h1-h3) for keyword matching in coverage scoring
+  const headings = lines
+    .filter(l => /^#{1,3}\s+\S/.test(l))
+    .map(l => l.replace(/^#+\s+/, '').trim());
+
+  // Content snippet (first 500 chars after front-matter) for keyword matching
+  const fmEnd = hasMetadata ? content.indexOf('---', 3) : -1;
+  const snippetStart = fmEnd >= 0 ? fmEnd + 3 : 0;
+  const contentSnippet = content.slice(snippetStart, snippetStart + 500).trim();
+
   // Check prohibited location
   const topDir = relPath.split(/[/\\]/)[0];
   const isProhibitedLocation = PROHIBITED_DIRS.includes(topDir) && name !== 'README.md';
@@ -185,6 +196,7 @@ function parseFile(fullPath, rootDir) {
   return {
     relPath, name, dir, lineCount, hasMetadata, metadata,
     links, hasTitle, hasToc, isProhibitedLocation, isNamingCompliant,
+    headings, contentSnippet,
     gitLastModified: null, // filled by enrichWithGitDates
   };
 }


### PR DESCRIPTION
## Summary
- Add D14 Content Accuracy dimension to the doc-audit scoring system (#SD-LEO-INFRA-DOCUMENTATION-CONTENT-VISION-002)
- Create `content-classifier.js` with 5 deterministic heuristics: code artifact cross-referencing, stage number validation, DOCMON template detection, TAM claim detection, and content-code ratio analysis
- Create `coverage-scorer.js` extracting D11-D14 database-backed scoring into dedicated module
- Expand rubric from 13 to 14 dimensions with proportional weight redistribution (D14 = 8%)
- Add headings and content snippet extraction to scanner for improved keyword matching
- Classification taxonomy: ACCURATE(100), UNVERIFIABLE(75), DRIFTED(50), STALE(25), ASPIRATIONAL(0)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Doc-audit score command runs successfully with D14 included
- [x] Content classifier correctly indexes code artifacts from src/, lib/, scripts/, database/
- [x] Classification decision tree produces expected results for known doc types
- [x] getDimensions('structural') correctly rescales D01-D10 weights to sum to 1.0
- [x] getDimensions('full') returns all 14 dimensions summing to 1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)