### PR TITLE
fix: add git freshness check to prevent stale-codebase heal scoring

### DIFF
--- a/scripts/eva/git-freshness.js
+++ b/scripts/eva/git-freshness.js
@@ -1,0 +1,155 @@
+/**
+ * git-freshness.js — Git State Verification for Heal Scoring
+ *
+ * Ensures the local codebase is up-to-date with remote before scoring.
+ * Prevents stale-codebase scoring that produces misleading results.
+ *
+ * Root cause: After worktree PRs merge to main on GitHub, the local
+ * main branch stays behind. Scoring agents evaluate stale code and
+ * report no improvement despite completed SDs.
+ *
+ * Three safeguards:
+ *   1. ensureFresh() — fetch + auto-pull if behind remote
+ *   2. getGitMeta()  — capture commit SHA + branch for score audit trail
+ *   3. warnIfWorktree() — detect worktree scoring (may miss main-branch code)
+ */
+
+import { execSync } from 'child_process';
+
+/**
+ * Ensure the local branch is up-to-date with its remote tracking branch.
+ * If behind, auto-pulls. Returns a status object for logging.
+ *
+ * @param {object} opts
+ * @param {string} opts.cwd - Working directory (default: process.cwd())
+ * @param {boolean} opts.autoPull - Auto-pull if behind (default: true)
+ * @param {string} opts.remote - Remote name (default: 'origin')
+ * @returns {{ fresh: boolean, branch: string, behind: number, ahead: number, pulled: boolean, sha: string }}
+ */
+export function ensureFresh(opts = {}) {
+  const cwd = opts.cwd || process.cwd();
+  const autoPull = opts.autoPull !== false;
+  const remote = opts.remote || 'origin';
+
+  const result = {
+    fresh: true,
+    branch: '',
+    behind: 0,
+    ahead: 0,
+    pulled: false,
+    sha: '',
+    error: null,
+  };
+
+  try {
+    // Get current branch
+    result.branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd, encoding: 'utf8' }).trim();
+
+    // Fetch remote (quiet, no output)
+    try {
+      execSync(`git fetch ${remote} ${result.branch} --quiet`, { cwd, encoding: 'utf8', stdio: 'pipe' });
+    } catch {
+      // Fetch may fail if no tracking branch — that's OK
+    }
+
+    // Get current SHA
+    result.sha = execSync('git rev-parse HEAD', { cwd, encoding: 'utf8' }).trim();
+
+    // Check if tracking branch exists
+    let trackingRef;
+    try {
+      trackingRef = execSync(`git rev-parse ${remote}/${result.branch}`, { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+    } catch {
+      // No tracking branch — can't compare, assume fresh
+      return result;
+    }
+
+    // Count behind/ahead
+    const counts = execSync(
+      `git rev-list --left-right --count ${result.branch}...${remote}/${result.branch}`,
+      { cwd, encoding: 'utf8', stdio: 'pipe' }
+    ).trim();
+
+    const [ahead, behind] = counts.split(/\s+/).map(Number);
+    result.ahead = ahead || 0;
+    result.behind = behind || 0;
+    result.fresh = result.behind === 0;
+
+    // Auto-pull if behind
+    if (result.behind > 0 && autoPull) {
+      console.log(`\n⚠️  Local ${result.branch} is ${result.behind} commit(s) behind ${remote}/${result.branch}`);
+      console.log('   Auto-pulling to ensure scoring uses latest code...');
+
+      try {
+        execSync(`git pull ${remote} ${result.branch}`, { cwd, encoding: 'utf8', stdio: 'pipe' });
+        result.pulled = true;
+        result.sha = execSync('git rev-parse HEAD', { cwd, encoding: 'utf8' }).trim();
+        result.fresh = true;
+        result.behind = 0;
+        console.log(`   ✅ Pulled successfully. Now at ${result.sha.substring(0, 10)}`);
+      } catch (pullErr) {
+        result.error = `Auto-pull failed: ${pullErr.message}`;
+        console.error(`   ❌ Auto-pull failed: ${pullErr.message}`);
+        console.error('   ⚠️  Scoring will proceed against STALE local code.');
+        console.error(`   Fix: manually run 'git pull ${remote} ${result.branch}' and retry.`);
+      }
+    } else if (result.behind > 0) {
+      result.error = `Local branch is ${result.behind} commit(s) behind remote`;
+      console.warn(`\n⚠️  Local ${result.branch} is ${result.behind} commit(s) behind ${remote}/${result.branch}`);
+      console.warn('   Scoring may produce stale results. Run \'git pull\' first.');
+    }
+  } catch (err) {
+    result.error = err.message;
+    // Non-fatal: if git commands fail, scoring still proceeds
+  }
+
+  return result;
+}
+
+/**
+ * Get git metadata for embedding in score records.
+ * Provides audit trail of what code was actually scored.
+ *
+ * @param {string} cwd - Working directory
+ * @returns {{ sha: string, branch: string, shortSha: string, isWorktree: boolean, worktreePath: string|null }}
+ */
+export function getGitMeta(cwd) {
+  const meta = {
+    sha: '',
+    branch: '',
+    shortSha: '',
+    isWorktree: false,
+    worktreePath: null,
+  };
+
+  try {
+    meta.sha = execSync('git rev-parse HEAD', { cwd: cwd || process.cwd(), encoding: 'utf8', stdio: 'pipe' }).trim();
+    meta.shortSha = meta.sha.substring(0, 10);
+    meta.branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: cwd || process.cwd(), encoding: 'utf8', stdio: 'pipe' }).trim();
+
+    // Detect worktree
+    const gitDir = execSync('git rev-parse --git-dir', { cwd: cwd || process.cwd(), encoding: 'utf8', stdio: 'pipe' }).trim();
+    meta.isWorktree = gitDir.includes('.worktrees') || gitDir.includes('worktrees');
+    if (meta.isWorktree) {
+      meta.worktreePath = cwd || process.cwd();
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  return meta;
+}
+
+/**
+ * Emit a warning if scoring is happening inside a worktree.
+ * Worktree scoring may miss code that only exists on main.
+ *
+ * @param {object} gitMeta - Output from getGitMeta()
+ */
+export function warnIfWorktree(gitMeta) {
+  if (gitMeta.isWorktree) {
+    console.warn(`\n⚠️  WORKTREE DETECTED: Scoring from worktree branch '${gitMeta.branch}'`);
+    console.warn('   Worktree may not include all merged changes from main.');
+    console.warn('   For accurate portfolio-level scoring, run from main branch.');
+  }
+}

--- a/tests/unit/eva/git-freshness.test.js
+++ b/tests/unit/eva/git-freshness.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execSync } from 'child_process';
+
+// Mock child_process before importing the module
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+const { ensureFresh, getGitMeta, warnIfWorktree } = await import('../../../scripts/eva/git-freshness.js');
+
+describe('git-freshness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('ensureFresh', () => {
+    it('returns fresh when local matches remote', () => {
+      execSync
+        .mockReturnValueOnce('main\n') // branch
+        .mockReturnValueOnce('') // fetch
+        .mockReturnValueOnce('abc123def456\n') // HEAD sha
+        .mockReturnValueOnce('abc123def456\n') // remote ref
+        .mockReturnValueOnce('0\t0\n'); // rev-list counts
+
+      const result = ensureFresh();
+      expect(result.fresh).toBe(true);
+      expect(result.behind).toBe(0);
+      expect(result.pulled).toBe(false);
+      expect(result.branch).toBe('main');
+    });
+
+    it('detects behind and auto-pulls', () => {
+      execSync
+        .mockReturnValueOnce('main\n') // branch
+        .mockReturnValueOnce('') // fetch
+        .mockReturnValueOnce('old123\n') // HEAD sha
+        .mockReturnValueOnce('new456\n') // remote ref
+        .mockReturnValueOnce('0\t3\n') // 3 behind
+        .mockReturnValueOnce('') // pull
+        .mockReturnValueOnce('new456\n'); // new HEAD sha
+
+      const result = ensureFresh();
+      expect(result.pulled).toBe(true);
+      expect(result.fresh).toBe(true);
+      expect(result.behind).toBe(0);
+      expect(result.sha).toBe('new456');
+    });
+
+    it('reports stale when auto-pull fails', () => {
+      execSync
+        .mockReturnValueOnce('main\n') // branch
+        .mockReturnValueOnce('') // fetch
+        .mockReturnValueOnce('old123\n') // HEAD sha
+        .mockReturnValueOnce('new456\n') // remote ref
+        .mockReturnValueOnce('0\t2\n') // 2 behind
+        .mockImplementationOnce(() => { throw new Error('merge conflict'); }); // pull fails
+
+      const result = ensureFresh();
+      expect(result.pulled).toBe(false);
+      expect(result.fresh).toBe(false);
+      expect(result.error).toContain('Auto-pull failed');
+    });
+
+    it('skips pull when autoPull is false', () => {
+      execSync
+        .mockReturnValueOnce('main\n')
+        .mockReturnValueOnce('')
+        .mockReturnValueOnce('old123\n')
+        .mockReturnValueOnce('new456\n')
+        .mockReturnValueOnce('0\t5\n');
+
+      const result = ensureFresh({ autoPull: false });
+      expect(result.fresh).toBe(false);
+      expect(result.behind).toBe(5);
+      expect(result.pulled).toBe(false);
+    });
+
+    it('handles no tracking branch gracefully', () => {
+      execSync
+        .mockReturnValueOnce('feature-branch\n')
+        .mockImplementationOnce(() => { throw new Error('fetch failed'); }) // fetch
+        .mockReturnValueOnce('abc123\n') // HEAD sha
+        .mockImplementationOnce(() => { throw new Error('no ref'); }); // remote ref
+
+      const result = ensureFresh();
+      expect(result.fresh).toBe(true); // assumes fresh when can't compare
+      expect(result.branch).toBe('feature-branch');
+    });
+
+    it('handles total git failure gracefully', () => {
+      execSync.mockImplementation(() => { throw new Error('not a git repo'); });
+
+      const result = ensureFresh();
+      expect(result.error).toBeDefined();
+      // Non-fatal — scoring still proceeds
+    });
+  });
+
+  describe('getGitMeta', () => {
+    it('returns sha, branch, and shortSha', () => {
+      execSync
+        .mockReturnValueOnce('abc123def4567890\n') // HEAD
+        .mockReturnValueOnce('main\n') // branch
+        .mockReturnValueOnce('.git\n'); // git-dir
+
+      const meta = getGitMeta();
+      expect(meta.sha).toBe('abc123def4567890');
+      expect(meta.shortSha).toBe('abc123def4');
+      expect(meta.branch).toBe('main');
+      expect(meta.isWorktree).toBe(false);
+    });
+
+    it('detects worktree from git-dir path', () => {
+      execSync
+        .mockReturnValueOnce('abc123\n')
+        .mockReturnValueOnce('feat/branch\n')
+        .mockReturnValueOnce('/repo/.worktrees/feat-branch/.git\n');
+
+      const meta = getGitMeta();
+      expect(meta.isWorktree).toBe(true);
+    });
+
+    it('handles git failure gracefully', () => {
+      execSync.mockImplementation(() => { throw new Error('not a git repo'); });
+
+      const meta = getGitMeta();
+      expect(meta.sha).toBe('');
+      expect(meta.branch).toBe('');
+    });
+  });
+
+  describe('warnIfWorktree', () => {
+    it('warns when in a worktree', () => {
+      warnIfWorktree({ isWorktree: true, branch: 'feat/test' });
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('WORKTREE DETECTED')
+      );
+    });
+
+    it('does not warn when not in worktree', () => {
+      warnIfWorktree({ isWorktree: false, branch: 'main' });
+      expect(console.warn).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds pre-scoring git freshness verification to vision heal and SD heal workflows
- Auto-pulls latest remote changes before scoring to prevent evaluating stale code
- Records git commit SHA in score metadata for audit trail
- Detects and warns when scoring from a worktree (may miss main-branch code)

**Root cause**: After worktree PRs merge to main on GitHub, the local main branch stays behind. Vision heal scoring agents evaluate stale code and report no improvement despite completed SDs.

## Files
- `scripts/eva/git-freshness.js` — NEW shared utility (`ensureFresh()`, `getGitMeta()`, `warnIfWorktree()`)
- `scripts/eva/vision-heal.js` — freshness check before scoring, git SHA in persisted scores
- `scripts/eva/heal-command.mjs` — freshness check before SD heal scoring, git SHA in persisted scores
- `tests/unit/eva/git-freshness.test.js` — 11 tests covering all paths

## Test plan
- [x] 11 unit tests pass for git-freshness module
- [x] All 62 EVA-related tests pass with zero regressions
- [x] Smoke tests pass (15/15)
- [ ] Verify auto-pull triggers on next vision heal run when behind remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)