### PR TITLE
fix: correct broken doc links and repo cleanup

### DIFF
--- a/.claude/auto-proceed-state.json
+++ b/.claude/auto-proceed-state.json
@@ -1,13 +1,13 @@
 {
   "isActive": true,
   "wasInterrupted": false,
-  "currentSd": "SD-MAN-INFRA-VISION-HEAL-PLATFORM-001-15",
+  "currentSd": "SD-MAN-ORCH-VISION-HEAL-SCORE-93-002-04-B",
   "currentPhase": "EXEC",
-  "currentTask": "Implementing V1-Growth: Venture Growth Automation Enhancement",
+  "currentTask": "Implementing Data Contracts, CLI Authority & Compute Posture Enhancement",
   "lastInterruptedAt": null,
   "lastResumedAt": null,
   "resumeCount": 0,
   "version": "1.0.0",
-  "clearedAt": "2026-02-22T16:30:58.391Z",
-  "lastUpdatedAt": "2026-02-27T20:34:31.562Z"
+  "clearedAt": "2026-03-01T03:36:25.685Z",
+  "lastUpdatedAt": "2026-03-01T06:52:01.977Z"
 }

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -686,7 +686,7 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 **Branch Strategy**: `eng/` prefix for EHG_Engineer, standard prefixes for EHG app features
 **Size**: <100 lines ideal, <200 max
 
-**Full Guidelines**: See `docs/03_protocols_and_standards/leo_git_commit_guidelines_v4.2.0.md`
+**Full Guidelines**: See `docs/03_protocols_and_standards/leo-git-commit-guidelines-v4.2.0.md`
 
 ## PR Size Guidelines
 
@@ -813,7 +813,7 @@ const solution = await kb.getSolution('PAT-003');
 | Production gen (Stage 17) | `ehg/scripts/genesis/production-generator.js` |
 
 ### Full Documentation
-- Implementation guide: `docs/architecture/GENESIS_IMPLEMENTATION_GUIDE.md`
+- Implementation guide: `docs/architecture/genesis-implementation-guide.md`
 - Quick reference: `docs/reference/genesis-codebase-guide.md`
 
 ## Parent-Child SD Hierarchy

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -445,7 +445,7 @@ All commands and sub-agents must run inline/foreground to maintain workflow cont
 
 **Available since**: Claude Code v2.1.4
 
-**Pattern Reference**: See `docs/patterns/PAT-AUTO-PROCEED-001.md` for full analysis of the background task enforcement gap.
+**Pattern Reference**: See `docs/patterns/pat-auto-proceed-001.md` for full analysis of the background task enforcement gap.
 
 ### Pause Points (When ON)
 

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1432,7 +1432,7 @@ Before LEAD approval, you MUST:
 | UI Components | `docs/vision/specs/03-ui-components.md` | React components, layouts |
 | EVA Orchestration | `docs/vision/specs/04-eva-orchestration.md` | EVA modes, token budgets |
 | Agent Hierarchy | `docs/vision/specs/06-hierarchical-agent-architecture.md` | LTREE, CEOs, VPs |
-| Glass Cockpit | `VISION_V2_GLASS_COCKPIT.md` | Design philosophy |
+| Glass Cockpit | `vision-v2-glass-cockpit.md` | Design philosophy |
 
 ### LEAD Approval Gate for Vision V2 SDs
 

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1778,7 +1778,7 @@ Add this to PRD's `technical_context`:
 
 This PRD implements requirements from:
 - **Primary Spec**: [spec-name.md](path/to/spec) - Sections X, Y, Z
-- **Design Philosophy**: [VISION_V2_GLASS_COCKPIT.md](VISION_V2_GLASS_COCKPIT.md)
+- **Design Philosophy**: [vision-v2-glass-cockpit.md](vision-v2-glass-cockpit.md)
 
 Key spec requirements addressed:
 1. [Requirement from spec Section X]

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ EHG_Engineer/
 ## Important Files
 
 - [Windows Setup Guide](docs/guides/windows-setup-guide.md) - Windows development without WSL
-- [IMPORTANT_DATABASE_DISTINCTION.md](docs/operations/IMPORTANT_DATABASE_DISTINCTION.md) - Critical info about database separation
-- [PROJECT_REGISTRATION_GUIDE.md](docs/guides/PROJECT_REGISTRATION_GUIDE.md) - How to add new projects
-- [SIMPLE_PROJECT_SETUP.md](docs/guides/SIMPLE_PROJECT_SETUP.md) - Simplified setup instructions
+- [important-database-distinction.md](docs/operations/important-database-distinction.md) - Critical info about database separation
+- [project-registration-guide.md](docs/guides/project-registration-guide.md) - How to add new projects
+- [simple-project-setup.md](docs/guides/simple-project-setup.md) - Simplified setup instructions
 - `.env.project-template` - Template for new projects
 
 ## Support


### PR DESCRIPTION
## Summary
- Fixed broken doc references in CLAUDE_CORE.md, CLAUDE_LEAD.md, CLAUDE_PLAN.md, CLAUDE_CORE_DIGEST.md, and README.md where filenames were renamed to kebab-case but references still used UPPERCASE paths
- Updated auto-proceed session state

## Repo Cleanup (not in diff)
Performed comprehensive repo hygiene across both EHG_Engineer and EHG:
- Deleted 266 untracked temp files (.claude/tmp-*, scripts/temp/*, brainstorm session files)
- Deleted 57 merged local branches (EHG_Engineer) + 4 merged (EHG)
- Deleted 25 squash-merged branches with remote cleanup (EHG_Engineer) + 9 (EHG)
- Pruned stale remote-tracking refs in both repos
- Kept 2 branches with OPEN PRs (#1513, #1612)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Doc links verified as kebab-case matches actual filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)