### PR TITLE
feat: 6-level hierarchy traversal and governance policies (V09)

### DIFF
--- a/scripts/governance-policies-seed.js
+++ b/scripts/governance-policies-seed.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+/**
+ * Seed Governance Policies (V09 FR-004)
+ *
+ * Seeds the governance_policies table with organizational hierarchy constraints
+ * that enforce depth limits, cross-boundary rules, and approval escalation thresholds.
+ *
+ * Usage:
+ *   node scripts/seed-governance-policies.js           # Preview (dry-run)
+ *   node scripts/seed-governance-policies.js --execute  # Insert into database
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const GOVERNANCE_POLICIES = [
+  {
+    policy_key: 'GOV-DEPTH-LIMIT',
+    title: 'Maximum Hierarchy Depth Limit',
+    description: 'Prevents SD hierarchies from exceeding 6 levels deep. Deeper nesting indicates decomposition issues.',
+    policy_type: 'hierarchy_constraint',
+    enforcement_level: 'blocking',
+    rule: {
+      type: 'max_depth',
+      max_depth: 6,
+      applies_to: 'all_sd_types',
+      action_on_violation: 'block_creation'
+    },
+    is_active: true
+  },
+  {
+    policy_key: 'GOV-CROSS-BOUNDARY',
+    title: 'Cross-Hierarchy Dependency Boundary',
+    description: 'Dependencies crossing hierarchy boundaries (different parent chains) require explicit approval. Prevents invisible coupling.',
+    policy_type: 'dependency_constraint',
+    enforcement_level: 'warning',
+    rule: {
+      type: 'cross_boundary_dependency',
+      require_same_ancestor: false,
+      max_cross_boundary_depth: 3,
+      action_on_violation: 'warn_and_log'
+    },
+    is_active: true
+  },
+  {
+    policy_key: 'GOV-APPROVAL-ESCALATION',
+    title: 'Approval Escalation for Deep Changes',
+    description: 'Changes at depth >= 4 require parent orchestrator acknowledgment before LEAD-FINAL-APPROVAL.',
+    policy_type: 'approval_constraint',
+    enforcement_level: 'advisory',
+    rule: {
+      type: 'escalation_threshold',
+      depth_threshold: 4,
+      escalation_target: 'parent_orchestrator',
+      action_on_violation: 'log_advisory'
+    },
+    is_active: true
+  },
+  {
+    policy_key: 'GOV-CHILD-CAP',
+    title: 'Maximum Children Per Orchestrator',
+    description: 'Limits orchestrator fan-out to 15 direct children. Wider trees should decompose into sub-orchestrators.',
+    policy_type: 'hierarchy_constraint',
+    enforcement_level: 'warning',
+    rule: {
+      type: 'max_children',
+      max_children: 15,
+      applies_to: 'orchestrator',
+      action_on_violation: 'warn_and_log'
+    },
+    is_active: true
+  },
+  {
+    policy_key: 'GOV-ORPHAN-PREVENTION',
+    title: 'Orphaned SD Prevention',
+    description: 'Active SDs whose parent is cancelled or completed must be reviewed. Prevents orphaned work items.',
+    policy_type: 'lifecycle_constraint',
+    enforcement_level: 'blocking',
+    rule: {
+      type: 'parent_lifecycle_check',
+      trigger_on: ['parent_cancelled', 'parent_completed'],
+      child_statuses_affected: ['draft', 'active', 'in_progress'],
+      action_on_violation: 'block_and_notify'
+    },
+    is_active: true
+  }
+];
+
+async function seedPolicies(execute = false) {
+  console.log('\n📋 Governance Policies Seed Script (V09 FR-004)');
+  console.log('═'.repeat(55));
+
+  if (!execute) {
+    console.log('  Mode: DRY-RUN (use --execute to insert)\n');
+  } else {
+    console.log('  Mode: EXECUTE\n');
+  }
+
+  // Check if table exists by querying it
+  const { data: existing, error: checkError } = await supabase
+    .from('governance_policies')
+    .select('policy_key')
+    .limit(100);
+
+  if (checkError) {
+    // Table might not exist — create it first
+    console.log(`  ⚠️  governance_policies table not found (${checkError.message})`);
+    console.log('  The table will be created when V09 migration runs.');
+    console.log('\n  Policies to seed:');
+    for (const policy of GOVERNANCE_POLICIES) {
+      console.log(`    - ${policy.policy_key}: ${policy.title} [${policy.enforcement_level}]`);
+    }
+    console.log(`\n  Total: ${GOVERNANCE_POLICIES.length} policies`);
+    console.log('═'.repeat(55) + '\n');
+    return;
+  }
+
+  const existingKeys = new Set((existing || []).map(p => p.policy_key));
+
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const policy of GOVERNANCE_POLICIES) {
+    if (existingKeys.has(policy.policy_key)) {
+      console.log(`  ⏭️  ${policy.policy_key} — already exists`);
+      skipped++;
+      continue;
+    }
+
+    if (execute) {
+      const { error: insertError } = await supabase
+        .from('governance_policies')
+        .insert({
+          ...policy,
+          rule: policy.rule,
+          created_at: new Date().toISOString()
+        });
+
+      if (insertError) {
+        console.log(`  ❌ ${policy.policy_key} — ${insertError.message}`);
+      } else {
+        console.log(`  ✅ ${policy.policy_key} — inserted [${policy.enforcement_level}]`);
+        inserted++;
+      }
+    } else {
+      console.log(`  📝 ${policy.policy_key}: ${policy.title} [${policy.enforcement_level}]`);
+      console.log(`     ${policy.description.substring(0, 80)}`);
+    }
+  }
+
+  console.log(`\n  Summary: ${inserted} inserted, ${skipped} skipped, ${GOVERNANCE_POLICIES.length} total`);
+  console.log('═'.repeat(55) + '\n');
+}
+
+const execute = process.argv.includes('--execute');
+seedPolicies(execute).catch(err => {
+  console.error(`Error: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/lib/governance-policy-checker.js
+++ b/scripts/lib/governance-policy-checker.js
@@ -1,0 +1,253 @@
+/**
+ * Governance Policy Checker (V09 FR-005)
+ *
+ * Evaluates SDs against governance_policies rules.
+ * Called from blocker-resolution.js to add policy-based blocking signals.
+ *
+ * Usage:
+ *   import { checkGovernancePolicies } from './lib/governance-policy-checker.js';
+ *   const result = await checkGovernancePolicies(supabase, sdId, { ancestorChain });
+ */
+
+import { getAncestorChain, MAX_HIERARCHY_DEPTH } from './sd-hierarchy-mapper.js';
+
+/**
+ * Check an SD against all active governance policies.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdId - The sd_key or UUID of the SD to check
+ * @param {Object} [context] - Optional context to avoid redundant queries
+ * @param {Array} [context.ancestorChain] - Pre-fetched ancestor chain
+ * @param {Object} [context.sd] - Pre-fetched SD record
+ * @param {Array} [context.children] - Pre-fetched children (for orchestrators)
+ * @returns {Promise<Object>} { violations: Array, blockers: Array, warnings: Array, advisories: Array }
+ */
+export async function checkGovernancePolicies(supabase, sdId, context = {}) {
+  const violations = [];
+
+  // Load policies
+  const { data: policies, error: policyError } = await supabase
+    .from('governance_policies')
+    .select('*')
+    .eq('is_active', true);
+
+  if (policyError || !policies || policies.length === 0) {
+    // Table doesn't exist or no policies — pass through (fail-open)
+    return { violations: [], blockers: [], warnings: [], advisories: [] };
+  }
+
+  // Load SD if not provided
+  const sd = context.sd || await fetchSD(supabase, sdId);
+  if (!sd) {
+    return { violations: [], blockers: [], warnings: [], advisories: [] };
+  }
+
+  // Load ancestor chain if not provided
+  const ancestorChain = context.ancestorChain || await safeGetAncestorChain(sd.sd_key || sd.id);
+
+  // Evaluate each policy
+  for (const policy of policies) {
+    const violation = await evaluatePolicy(supabase, policy, sd, ancestorChain, context);
+    if (violation) {
+      violations.push(violation);
+    }
+  }
+
+  return {
+    violations,
+    blockers: violations.filter(v => v.enforcement_level === 'blocking'),
+    warnings: violations.filter(v => v.enforcement_level === 'warning'),
+    advisories: violations.filter(v => v.enforcement_level === 'advisory')
+  };
+}
+
+/**
+ * Evaluate a single policy against an SD.
+ */
+async function evaluatePolicy(supabase, policy, sd, ancestorChain, context) {
+  const rule = policy.rule;
+  if (!rule || !rule.type) return null;
+
+  switch (rule.type) {
+    case 'max_depth':
+      return checkMaxDepth(policy, sd, ancestorChain, rule);
+
+    case 'cross_boundary_dependency':
+      return await checkCrossBoundary(supabase, policy, sd, ancestorChain, rule);
+
+    case 'escalation_threshold':
+      return checkEscalationThreshold(policy, sd, ancestorChain, rule);
+
+    case 'max_children':
+      return await checkMaxChildren(supabase, policy, sd, context, rule);
+
+    case 'parent_lifecycle_check':
+      return checkParentLifecycle(policy, sd, ancestorChain, rule);
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * GOV-DEPTH-LIMIT: Check if SD exceeds max hierarchy depth.
+ */
+function checkMaxDepth(policy, sd, ancestorChain, rule) {
+  const depth = ancestorChain.length + 1; // +1 for the SD itself
+  if (depth > rule.max_depth) {
+    return {
+      policy_key: policy.policy_key,
+      title: policy.title,
+      enforcement_level: policy.enforcement_level,
+      message: `SD is at depth ${depth}, exceeding limit of ${rule.max_depth}`,
+      sd_key: sd.sd_key || sd.id,
+      details: { depth, max_depth: rule.max_depth }
+    };
+  }
+  return null;
+}
+
+/**
+ * GOV-CROSS-BOUNDARY: Check dependencies crossing hierarchy boundaries.
+ */
+async function checkCrossBoundary(supabase, policy, sd, ancestorChain, rule) {
+  // Only relevant if SD has dependencies
+  if (!sd.dependencies) return null;
+
+  let deps;
+  try {
+    deps = typeof sd.dependencies === 'string' ? JSON.parse(sd.dependencies) : sd.dependencies;
+  } catch { return null; }
+
+  if (!Array.isArray(deps) || deps.length === 0) return null;
+
+  const ancestorIds = new Set(ancestorChain.map(a => a.id));
+  if (sd.parent_sd_id) ancestorIds.add(sd.parent_sd_id);
+
+  for (const dep of deps) {
+    const depKey = typeof dep === 'string' ? dep.match(/^(SD-[A-Z0-9-]+)/)?.[1] : dep?.sd_id;
+    if (!depKey) continue;
+
+    // Fetch dependency's ancestor chain
+    const depAncestors = await safeGetAncestorChain(depKey);
+    const depAncestorIds = new Set(depAncestors.map(a => a.id));
+
+    // Check if they share a common ancestor
+    const hasCommonAncestor = [...ancestorIds].some(id => depAncestorIds.has(id));
+
+    if (!hasCommonAncestor && depAncestors.length > 0) {
+      return {
+        policy_key: policy.policy_key,
+        title: policy.title,
+        enforcement_level: policy.enforcement_level,
+        message: `Dependency on ${depKey} crosses hierarchy boundary (no common ancestor)`,
+        sd_key: sd.sd_key || sd.id,
+        details: { dependency: depKey, cross_boundary: true }
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * GOV-APPROVAL-ESCALATION: Check if deep SDs need escalation.
+ */
+function checkEscalationThreshold(policy, sd, ancestorChain, rule) {
+  const depth = ancestorChain.length + 1;
+  if (depth >= rule.depth_threshold && sd.current_phase === 'EXEC') {
+    return {
+      policy_key: policy.policy_key,
+      title: policy.title,
+      enforcement_level: policy.enforcement_level,
+      message: `SD at depth ${depth} (>= ${rule.depth_threshold}) — parent orchestrator acknowledgment recommended`,
+      sd_key: sd.sd_key || sd.id,
+      details: { depth, threshold: rule.depth_threshold, escalation_target: rule.escalation_target }
+    };
+  }
+  return null;
+}
+
+/**
+ * GOV-CHILD-CAP: Check if orchestrator has too many children.
+ */
+async function checkMaxChildren(supabase, policy, sd, context, rule) {
+  // Only applies to orchestrators
+  if (sd.sd_type !== 'orchestrator' && !sd.relationship_type?.includes('orchestrator')) return null;
+
+  const children = context.children || await fetchChildren(supabase, sd.id);
+  if (children.length > rule.max_children) {
+    return {
+      policy_key: policy.policy_key,
+      title: policy.title,
+      enforcement_level: policy.enforcement_level,
+      message: `Orchestrator has ${children.length} children, exceeding limit of ${rule.max_children}`,
+      sd_key: sd.sd_key || sd.id,
+      details: { child_count: children.length, max_children: rule.max_children }
+    };
+  }
+  return null;
+}
+
+/**
+ * GOV-ORPHAN-PREVENTION: Check if parent is cancelled/completed while child is active.
+ */
+function checkParentLifecycle(policy, sd, ancestorChain, rule) {
+  if (!sd.parent_sd_id || ancestorChain.length === 0) return null;
+
+  const affectedStatuses = rule.child_statuses_affected || ['draft', 'active', 'in_progress'];
+  if (!affectedStatuses.includes(sd.status)) return null;
+
+  // Check immediate parent (depth 0 in ancestor chain)
+  const parent = ancestorChain[0];
+  if (!parent) return null;
+
+  const triggerStatuses = rule.trigger_on || ['parent_cancelled', 'parent_completed'];
+  const parentTriggered =
+    (triggerStatuses.includes('parent_cancelled') && parent.status === 'cancelled') ||
+    (triggerStatuses.includes('parent_completed') && parent.status === 'completed');
+
+  if (parentTriggered) {
+    return {
+      policy_key: policy.policy_key,
+      title: policy.title,
+      enforcement_level: policy.enforcement_level,
+      message: `Parent ${parent.sd_key} is ${parent.status} but child is still ${sd.status}`,
+      sd_key: sd.sd_key || sd.id,
+      details: { parent_sd_key: parent.sd_key, parent_status: parent.status, child_status: sd.status }
+    };
+  }
+  return null;
+}
+
+// Helper: fetch SD record
+async function fetchSD(supabase, sdId) {
+  const { data } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, status, current_phase, parent_sd_id, sd_type, relationship_type, dependencies')
+    .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
+    .eq('is_active', true)
+    .single();
+  return data;
+}
+
+// Helper: fetch children
+async function fetchChildren(supabase, parentId) {
+  const { data } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, status')
+    .eq('parent_sd_id', parentId)
+    .eq('is_active', true);
+  return data || [];
+}
+
+// Helper: safe ancestor chain fetch (non-throwing)
+async function safeGetAncestorChain(sdId) {
+  try {
+    return await getAncestorChain(sdId, MAX_HIERARCHY_DEPTH);
+  } catch {
+    return [];
+  }
+}
+
+export default { checkGovernancePolicies };

--- a/scripts/modules/sd-next/dependency-resolver.js
+++ b/scripts/modules/sd-next/dependency-resolver.js
@@ -203,7 +203,7 @@ export function scanMetadataForMisplacedDependencies(metadata) {
  * @returns {Promise<Object>} Trace result with paths, workable SDs, and diagnostics
  */
 export async function traceDependencyChain(supabase, sdKey, options = {}) {
-  const { maxDepth = 3, maxResults = 5 } = options;
+  const { maxDepth = 6, maxResults = 5 } = options; // Raised from 3 to support 6-level deep hierarchies (V09)
   const visited = new Set();
   const workableSDs = [];
   const tracedPaths = [];


### PR DESCRIPTION
## Summary
- Raise hierarchy depth limits from 2-3 to 6 across blocker-resolution and dependency-resolver
- Add `getAncestorChain()` to sd-hierarchy-mapper with cycle detection and circuit breakers
- Wire deep hierarchy tree display into orchestrator-preflight (up to 6 levels)
- Add ancestor-level blocking validation in child-sd-preflight
- Create governance-policy-checker with 5 policy types (depth limit, cross-boundary, escalation, child cap, orphan prevention)
- Integrate governance policy violations into blocker detection as Signal 4

## Test plan
- [ ] Verify `getAncestorChain()` traverses 6+ level hierarchies without infinite loops
- [ ] Verify orchestrator-preflight displays deep tree with depth indicators
- [ ] Verify child-sd-preflight blocks when ancestor is cancelled/blocked
- [ ] Verify governance-policy-checker returns violations for depth > 6
- [ ] Verify blocker-resolution logs governance warnings without breaking existing flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)