### PR TITLE
feat: timeline governance, milestones, and heal-before-complete gate

### DIFF
--- a/database/migrations/20260301_sd_milestones.sql
+++ b/database/migrations/20260301_sd_milestones.sql
@@ -1,0 +1,176 @@
+-- Migration: SD Milestones Table with Auto-Populating Triggers
+-- SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-007-03 (FR-002)
+-- Purpose: Automatically records milestone events for each SD lifecycle via triggers
+
+-- Step 1: Create the sd_milestones table
+CREATE TABLE IF NOT EXISTS sd_milestones (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  sd_id UUID NOT NULL,
+  milestone_type TEXT NOT NULL,
+  milestone_name TEXT NOT NULL,
+  achieved_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  metadata JSONB DEFAULT '{}'::jsonb,
+
+  -- Prevent duplicate milestones for same SD + type
+  UNIQUE(sd_id, milestone_type)
+);
+
+-- Step 2: Add CHECK constraint for known milestone types
+ALTER TABLE sd_milestones
+  ADD CONSTRAINT chk_milestone_type CHECK (
+    milestone_type IN (
+      'sd_created',
+      'lead_approved',
+      'prd_created',
+      'plan_approved',
+      'exec_started',
+      'exec_completed',
+      'pr_merged',
+      'sd_completed',
+      'sd_deferred',
+      'sd_cancelled'
+    )
+  );
+
+-- Step 3: Indexes for query patterns
+CREATE INDEX IF NOT EXISTS idx_sd_milestones_sd_id
+  ON sd_milestones (sd_id);
+
+CREATE INDEX IF NOT EXISTS idx_sd_milestones_achieved
+  ON sd_milestones (achieved_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_sd_milestones_type
+  ON sd_milestones (milestone_type);
+
+-- Step 4: Trigger function for sd_phase_handoffs INSERT
+-- Maps handoff types to milestone types
+CREATE OR REPLACE FUNCTION trg_fn_sd_milestone_on_handoff()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_milestone_type TEXT;
+  v_milestone_name TEXT;
+BEGIN
+  -- Map handoff_type to milestone
+  CASE NEW.handoff_type
+    WHEN 'LEAD-to-PLAN' THEN
+      v_milestone_type := 'lead_approved';
+      v_milestone_name := 'LEAD approved - transitioned to PLAN';
+    WHEN 'PLAN-to-EXEC' THEN
+      v_milestone_type := 'exec_started';
+      v_milestone_name := 'EXEC phase started';
+    WHEN 'EXEC-to-PLAN' THEN
+      v_milestone_type := 'exec_completed';
+      v_milestone_name := 'EXEC phase completed - returned to PLAN';
+    WHEN 'PLAN-to-LEAD' THEN
+      v_milestone_type := 'plan_approved';
+      v_milestone_name := 'PLAN approved - submitted for LEAD final review';
+    ELSE
+      -- Unknown handoff type - skip
+      RETURN NEW;
+  END CASE;
+
+  -- UPSERT: ON CONFLICT DO NOTHING prevents duplicates from retries
+  INSERT INTO sd_milestones (sd_id, milestone_type, milestone_name, metadata)
+  VALUES (
+    NEW.sd_id::UUID,
+    v_milestone_type,
+    v_milestone_name,
+    jsonb_build_object(
+      'handoff_id', NEW.id::TEXT,
+      'handoff_type', NEW.handoff_type,
+      'handoff_status', NEW.status,
+      'from_phase', NEW.from_phase,
+      'to_phase', NEW.to_phase
+    )
+  )
+  ON CONFLICT (sd_id, milestone_type) DO UPDATE
+    SET achieved_at = NOW(),
+        metadata = sd_milestones.metadata || jsonb_build_object(
+          'updated_from_handoff', NEW.id::TEXT,
+          'updated_at', NOW()::TEXT
+        );
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  -- Non-fatal: log but don't block handoff creation
+  RAISE WARNING 'sd_milestone trigger failed: %', SQLERRM;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 5: Trigger function for strategic_directives_v2 status changes
+CREATE OR REPLACE FUNCTION trg_fn_sd_milestone_on_status_change()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_milestone_type TEXT;
+  v_milestone_name TEXT;
+BEGIN
+  -- Only fire on status changes
+  IF OLD.status = NEW.status THEN
+    RETURN NEW;
+  END IF;
+
+  -- Map status transitions to milestones
+  CASE NEW.status
+    WHEN 'completed' THEN
+      v_milestone_type := 'sd_completed';
+      v_milestone_name := 'SD completed';
+    WHEN 'deferred' THEN
+      v_milestone_type := 'sd_deferred';
+      v_milestone_name := 'SD deferred';
+    WHEN 'cancelled' THEN
+      v_milestone_type := 'sd_cancelled';
+      v_milestone_name := 'SD cancelled';
+    ELSE
+      -- Other status changes don't create milestones
+      RETURN NEW;
+  END CASE;
+
+  INSERT INTO sd_milestones (sd_id, milestone_type, milestone_name, metadata)
+  VALUES (
+    NEW.id::UUID,
+    v_milestone_type,
+    v_milestone_name,
+    jsonb_build_object(
+      'old_status', OLD.status,
+      'new_status', NEW.status,
+      'sd_key', COALESCE(NEW.sd_key, 'unknown')
+    )
+  )
+  ON CONFLICT (sd_id, milestone_type) DO UPDATE
+    SET achieved_at = NOW(),
+        metadata = sd_milestones.metadata || jsonb_build_object(
+          'updated_status', NEW.status,
+          'updated_at', NOW()::TEXT
+        );
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  -- Non-fatal: log but don't block SD status changes
+  RAISE WARNING 'sd_milestone status trigger failed: %', SQLERRM;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 6: Create triggers (independent of trg_capability_lifecycle)
+CREATE TRIGGER trg_sd_milestone_on_handoff
+  AFTER INSERT ON sd_phase_handoffs
+  FOR EACH ROW
+  EXECUTE FUNCTION trg_fn_sd_milestone_on_handoff();
+
+CREATE TRIGGER trg_sd_milestone_on_status_change
+  AFTER UPDATE OF status ON strategic_directives_v2
+  FOR EACH ROW
+  EXECUTE FUNCTION trg_fn_sd_milestone_on_status_change();
+
+-- Step 7: Backfill existing completed SDs with sd_completed milestone
+INSERT INTO sd_milestones (sd_id, milestone_type, milestone_name, achieved_at, metadata)
+SELECT
+  id::UUID,
+  'sd_completed',
+  'SD completed (backfill)',
+  COALESCE(updated_at, created_at, NOW()),
+  jsonb_build_object('backfill', true, 'sd_key', COALESCE(sd_key, 'unknown'))
+FROM strategic_directives_v2
+WHERE status = 'completed'
+ON CONFLICT (sd_id, milestone_type) DO NOTHING;

--- a/scripts/modules/governance/timeline-violation-handler.js
+++ b/scripts/modules/governance/timeline-violation-handler.js
@@ -1,0 +1,173 @@
+/**
+ * Timeline Violation Handler
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-007-03 (FR-003)
+ *
+ * When the Day-28 blocking gate fires during sd-start.js, this module:
+ * 1. Creates an escalation record in eva_orchestration_events
+ * 2. Bumps SD priority to 'critical' if currently lower
+ * 3. Returns a structured error for the caller
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const DEFAULT_AGE_THRESHOLD_DAYS = 28;
+
+/**
+ * Load the SD age block threshold from leo_config.
+ * @param {Object} supabase
+ * @returns {Promise<number>}
+ */
+export async function loadAgeThreshold(supabase) {
+  try {
+    const { data } = await supabase
+      .from('leo_config')
+      .select('value')
+      .eq('key', 'sd_age_block_days')
+      .single();
+
+    if (data?.value != null) {
+      const parsed = parseInt(data.value, 10);
+      if (!isNaN(parsed) && parsed > 0) return parsed;
+    }
+  } catch {
+    // Fall through to default
+  }
+  return DEFAULT_AGE_THRESHOLD_DAYS;
+}
+
+/**
+ * Check if an SD exceeds the age threshold.
+ *
+ * @param {Object} options
+ * @param {Object} options.supabase - Supabase client
+ * @param {string} options.sdKey - SD key (e.g., SD-XXX-001)
+ * @param {string} options.sdUuid - SD UUID
+ * @param {string} options.createdAt - SD created_at timestamp
+ * @param {number} [options.thresholdDays] - Override threshold (default: from leo_config or 28)
+ * @returns {Promise<{blocked: boolean, ageDays: number, threshold: number}>}
+ */
+export async function checkSDAge({ supabase, sdKey, sdUuid, createdAt, thresholdDays = null }) {
+  const threshold = thresholdDays ?? await loadAgeThreshold(supabase);
+  const created = new Date(createdAt);
+  const now = new Date();
+  const ageDays = Math.floor((now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24));
+
+  return {
+    blocked: ageDays > threshold,
+    ageDays,
+    threshold,
+  };
+}
+
+/**
+ * Handle a timeline violation: create escalation event and bump priority.
+ *
+ * @param {Object} options
+ * @param {Object} options.supabase - Supabase client
+ * @param {string} options.sdKey - SD key
+ * @param {string} options.sdUuid - SD UUID
+ * @param {number} options.ageDays - SD age in days
+ * @param {number} options.threshold - Threshold that was exceeded
+ * @param {string} options.currentPriority - Current SD priority
+ * @param {boolean} [options.isOverride=false] - Whether --force was used
+ * @returns {Promise<{escalationEventId: string|null, priorityBumped: boolean, error: string|null}>}
+ */
+export async function handleTimelineViolation({
+  supabase,
+  sdKey,
+  sdUuid,
+  ageDays,
+  threshold,
+  currentPriority,
+  isOverride = false,
+}) {
+  let escalationEventId = null;
+  let priorityBumped = false;
+
+  // 1. Create escalation event in eva_orchestration_events
+  try {
+    const eventData = {
+      sd_key: sdKey,
+      sd_id: sdUuid,
+      age_days: ageDays,
+      threshold,
+      violation_type: 'sd_age_exceeded',
+      recommended_actions: [
+        'Complete the SD immediately if work is near-done',
+        'Defer the SD to next cycle if blocked',
+        'Cancel the SD if it is no longer relevant',
+        'Escalate to chairman for review',
+      ],
+      override_used: isOverride,
+    };
+
+    const { data, error } = await supabase
+      .from('eva_orchestration_events')
+      .insert({
+        event_type: isOverride ? 'chairman_override' : 'escalation',
+        event_source: 'timeline_violation_handler',
+        event_data: eventData,
+        chairman_flagged: true,
+      })
+      .select('event_id')
+      .single();
+
+    if (error) {
+      console.warn(`[timeline-violation] Failed to persist escalation event: ${error.message}`);
+    } else {
+      escalationEventId = data.event_id;
+    }
+  } catch (err) {
+    console.warn(`[timeline-violation] Event creation error: ${err.message}`);
+  }
+
+  // 2. Bump SD priority to 'critical' if currently lower (and not an override)
+  if (!isOverride && currentPriority !== 'critical') {
+    try {
+      const { error: updateErr } = await supabase
+        .from('strategic_directives_v2')
+        .update({ priority: 'critical' })
+        .eq('id', sdUuid);
+
+      if (updateErr) {
+        console.warn(`[timeline-violation] Priority bump failed: ${updateErr.message}`);
+      } else {
+        priorityBumped = true;
+      }
+    } catch (err) {
+      console.warn(`[timeline-violation] Priority bump error: ${err.message}`);
+    }
+  }
+
+  return { escalationEventId, priorityBumped, error: null };
+}
+
+/**
+ * Build the structured error message for the blocked SD.
+ *
+ * @param {Object} options
+ * @param {string} options.sdKey
+ * @param {number} options.ageDays
+ * @param {number} options.threshold
+ * @returns {string}
+ */
+export function formatBlockMessage({ sdKey, ageDays, threshold }) {
+  return [
+    '',
+    `  ❌ SD AGE BLOCK: ${sdKey}`,
+    `  ${'═'.repeat(50)}`,
+    `  Age:       ${ageDays} days`,
+    `  Threshold: ${threshold} days`,
+    `  Status:    BLOCKED — SD exceeds maximum age`,
+    '',
+    '  Recommended Actions:',
+    '    1. Complete the SD if work is near-done',
+    '    2. Defer to next cycle if blocked on dependencies',
+    '    3. Cancel if no longer relevant',
+    '    4. Use --force flag for chairman override',
+    '',
+    `  Override: npm run sd:start ${sdKey} -- --force`,
+    `  ${'═'.repeat(50)}`,
+    '',
+  ].join('\n');
+}

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
@@ -1,0 +1,208 @@
+/**
+ * Heal-Before-Complete Gate for PLAN-TO-LEAD
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-007-03 (FR-004)
+ *
+ * Checks that the SD has a recent heal score meeting the threshold
+ * before allowing final approval. Prevents premature SD completion
+ * by catching gaps while context is fresh.
+ *
+ * - SD heal: BLOCKING — score must be >= threshold (default 80)
+ * - Vision heal: ADVISORY — logged but does not block
+ */
+
+const DEFAULT_HEAL_THRESHOLD = 80;
+
+/**
+ * Load the heal gate threshold from leo_config.
+ * @param {Object} supabase
+ * @returns {Promise<number>}
+ */
+async function loadHealThreshold(supabase) {
+  try {
+    const { data } = await supabase
+      .from('leo_config')
+      .select('value')
+      .eq('key', 'heal_gate_threshold')
+      .single();
+
+    if (data?.value != null) {
+      const parsed = parseInt(data.value, 10);
+      if (!isNaN(parsed) && parsed > 0 && parsed <= 100) return parsed;
+    }
+  } catch {
+    // Fall through to default
+  }
+  return DEFAULT_HEAL_THRESHOLD;
+}
+
+/**
+ * Create the HEAL_BEFORE_COMPLETE gate validator.
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Object} Gate configuration
+ */
+export function createHealBeforeCompleteGate(supabase) {
+  return {
+    name: 'HEAL_BEFORE_COMPLETE',
+    validator: async (ctx) => {
+      console.log('\n🩺 HEAL GATE: SD Heal Score Verification');
+      console.log('-'.repeat(50));
+
+      const sdKey = ctx.sd?.sd_key || ctx.sdId;
+      const sdUuid = ctx.sd?.id || ctx.sdId;
+
+      // Parent orchestrators skip heal gate — children are individually healed
+      const { data: childSDs } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sdUuid);
+
+      if (childSDs && childSDs.length > 0) {
+        console.log(`   ℹ️  Orchestrator SD with ${childSDs.length} children — skipping heal gate`);
+        console.log('   ✅ Children are individually healed during their own PLAN-TO-LEAD');
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: ['Orchestrator SD — heal gate deferred to children'],
+          details: { is_orchestrator: true, child_count: childSDs.length }
+        };
+      }
+
+      const threshold = await loadHealThreshold(supabase);
+
+      // Query most recent SD heal score from eva_vision_scores
+      const { data: healScores, error: healError } = await supabase
+        .from('eva_vision_scores')
+        .select('id, sd_id, total_score, threshold_action, rubric_snapshot, created_at')
+        .eq('sd_id', sdKey)
+        .order('created_at', { ascending: false })
+        .limit(1);
+
+      if (healError) {
+        console.log(`   ⚠️  Database error querying heal scores: ${healError.message}`);
+        return {
+          passed: false,
+          score: 0,
+          max_score: 100,
+          issues: [`Database error: ${healError.message}`],
+          warnings: [],
+          remediation: 'Check database connectivity and retry'
+        };
+      }
+
+      // No heal score found — require running /heal sd first
+      if (!healScores || healScores.length === 0) {
+        console.log(`   ❌ No heal score found for ${sdKey}`);
+        console.log('');
+        console.log('   The heal-before-complete gate requires an SD heal score');
+        console.log('   before final approval. This catches gaps while context is fresh.');
+        console.log('');
+        console.log(`   Run: /heal sd --sd-id ${sdKey}`);
+        console.log('   Then retry PLAN-TO-LEAD.');
+
+        return {
+          passed: false,
+          score: 0,
+          max_score: 100,
+          issues: [`No heal score found for ${sdKey} — run /heal sd --sd-id ${sdKey} before PLAN-TO-LEAD`],
+          warnings: [],
+          remediation: `/heal sd --sd-id ${sdKey}`
+        };
+      }
+
+      const latestScore = healScores[0];
+      const sdHealScore = latestScore.total_score;
+      const scoreAge = Math.round((Date.now() - new Date(latestScore.created_at).getTime()) / (1000 * 60));
+      const isSDHeal = latestScore.rubric_snapshot?.mode === 'sd-heal';
+
+      console.log(`   SD Heal Score: ${sdHealScore}/100 (threshold: ${threshold})`);
+      console.log(`   Score Age: ${scoreAge} min`);
+      console.log(`   Score ID: ${latestScore.id}`);
+      if (!isSDHeal) {
+        console.log(`   ⚠️  Score mode: ${latestScore.rubric_snapshot?.mode || 'unknown'} (expected: sd-heal)`);
+      }
+
+      // Check vision heal score (advisory — non-blocking)
+      let visionAdvisory = null;
+      try {
+        const { data: visionScores } = await supabase
+          .from('eva_vision_scores')
+          .select('id, total_score, created_at')
+          .is('sd_id', null)
+          .order('created_at', { ascending: false })
+          .limit(1);
+
+        if (visionScores && visionScores.length > 0) {
+          visionAdvisory = {
+            score: visionScores[0].total_score,
+            age_minutes: Math.round((Date.now() - new Date(visionScores[0].created_at).getTime()) / (1000 * 60))
+          };
+          console.log(`   Vision Heal (advisory): ${visionAdvisory.score}/100 (${visionAdvisory.age_minutes} min ago)`);
+        } else {
+          console.log('   Vision Heal (advisory): No recent score — consider running /heal vision');
+        }
+      } catch {
+        console.log('   Vision Heal (advisory): Query failed (non-blocking)');
+      }
+
+      // SD heal score below threshold — NEEDS_ITERATION
+      if (sdHealScore < threshold) {
+        const gaps = latestScore.rubric_snapshot?.gaps || [];
+        console.log('');
+        console.log(`   ❌ NEEDS_ITERATION: SD heal score ${sdHealScore} < ${threshold} threshold`);
+        if (gaps.length > 0) {
+          console.log('   Gaps to address:');
+          gaps.forEach((gap, i) => {
+            console.log(`     ${i + 1}. ${gap}`);
+          });
+        }
+        console.log('');
+        console.log('   Fix the gaps within this SD, re-ship, then re-run:');
+        console.log(`   /heal sd --sd-id ${sdKey}`);
+
+        return {
+          passed: false,
+          score: Math.round((sdHealScore / threshold) * 100),
+          max_score: 100,
+          issues: [
+            `SD heal score ${sdHealScore}/100 below threshold ${threshold} — NEEDS_ITERATION`,
+            ...gaps.map(g => `Gap: ${g}`)
+          ],
+          warnings: visionAdvisory ? [`Vision heal advisory: ${visionAdvisory.score}/100`] : [],
+          remediation: `Fix identified gaps, re-ship, run /heal sd --sd-id ${sdKey}, then retry PLAN-TO-LEAD`,
+          details: {
+            sd_heal_score: sdHealScore,
+            threshold,
+            score_id: latestScore.id,
+            score_age_minutes: scoreAge,
+            gaps,
+            vision_advisory: visionAdvisory
+          }
+        };
+      }
+
+      // SD heal score meets threshold — PASS
+      console.log(`   ✅ SD heal score ${sdHealScore} >= ${threshold} threshold — PASS`);
+
+      return {
+        passed: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings: visionAdvisory
+          ? [`Vision heal advisory: ${visionAdvisory.score}/100`]
+          : ['No vision heal score available — consider running /heal vision'],
+        details: {
+          sd_heal_score: sdHealScore,
+          threshold,
+          score_id: latestScore.id,
+          score_age_minutes: scoreAge,
+          vision_advisory: visionAdvisory
+        }
+      };
+    },
+    required: true
+  };
+}

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
@@ -12,3 +12,4 @@ export { createGitCommitEnforcementGate } from './git-commit-enforcement.js';
 export { createTraceabilityGate, createWorkflowROIGate, requiresTraceabilityGates } from './traceability-gates.js';
 export { createUserStoryExistenceGate } from './user-story-existence.js';
 export { createDocumentationLinkValidationGate } from './documentation-link-validation.js';
+export { createHealBeforeCompleteGate } from './heal-before-complete.js';

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -29,7 +29,8 @@ import {
   createTraceabilityGate,
   createWorkflowROIGate,
   createUserStoryExistenceGate,
-  createDocumentationLinkValidationGate
+  createDocumentationLinkValidationGate,
+  createHealBeforeCompleteGate
 } from './gates/index.js';
 // Note: requiresTraceabilityGates is re-exported via 'export * from ./gates/index.js'
 
@@ -117,6 +118,10 @@ export class PlanToLeadExecutor extends BaseExecutor {
 
     // Prerequisite handoff check
     gates.push(createPrerequisiteCheckGate(this.supabase));
+
+    // Heal-before-complete gate (SD-MAN-GEN-CORRECTIVE-VISION-GAP-007-03 FR-004)
+    // SD heal score must meet threshold before final approval
+    gates.push(createHealBeforeCompleteGate(this.supabase));
 
     // Sub-agent orchestration
     gates.push(createSubAgentOrchestrationGate(this.supabase));


### PR DESCRIPTION
## Summary
- **FR-001**: Blocking Day-28 age gate in `sd-start.js` — blocks overdue SDs with structured error, chairman `--force` override
- **FR-002**: `sd_milestones` table with auto-populating triggers on `sd_phase_handoffs` INSERT and `strategic_directives_v2` status changes
- **FR-003**: Timeline violation auto-escalation — creates `eva_orchestration_events` escalation record and bumps SD priority to critical
- **FR-004**: Heal-before-complete gate in PLAN-TO-LEAD — requires SD heal score >= 80 before final approval (vision heal advisory/non-blocking)

SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-007-03 (V10 Timeline & Milestone Governance)

## Test plan
- [ ] SD younger than 28 days starts normally via sd-start.js
- [ ] SD older than 28 days is blocked with structured error (exit code 1)
- [ ] `--force` flag overrides age block and logs to eva_orchestration_events
- [ ] sd_milestones table created with correct schema and triggers
- [ ] Handoff INSERT auto-creates milestone records
- [ ] SD status change to completed auto-creates milestone
- [ ] Timeline violation creates escalation with chairman_flagged=true
- [ ] PLAN-TO-LEAD gate blocks when no heal score exists
- [ ] PLAN-TO-LEAD gate blocks when heal score < 80
- [ ] PLAN-TO-LEAD gate passes when heal score >= 80
- [ ] Orchestrator SDs skip heal gate (children individually healed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)