### PR TITLE
feat(A01): Cache TTL management across module caches

### DIFF
--- a/lib/agents/auto-selector.js
+++ b/lib/agents/auto-selector.js
@@ -9,6 +9,7 @@ import IntelligentMultiSelector from './intelligent-multi-selector.js';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { TTLMap } from '../utils/ttl-map.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -18,7 +19,7 @@ class IntelligentAutoSelector {
     this.contextMonitor = new ContextMonitor(openaiApiKey, projectRoot);
     this.multiSelector = new IntelligentMultiSelector(openaiApiKey, projectRoot);
     this.projectRoot = projectRoot;
-    this.userPatterns = new Map();
+    this.userPatterns = new TTLMap({ defaultTTLMs: 60 * 60 * 1000, maxEntries: 200 }); // 60 min TTL
     this.feedbackHistory = [];
     
     // Auto-selection configuration
@@ -33,8 +34,8 @@ class IntelligentAutoSelector {
       coordination_timeout: 5000    // Max time for agent coordination
     };
 
-    // Agent execution modules (would be loaded dynamically)
-    this.agentModules = new Map();
+    // Agent execution modules (TTL-managed)
+    this.agentModules = new TTLMap({ defaultTTLMs: 2 * 60 * 60 * 1000, maxEntries: 50 }); // 2h TTL
     this.loadAgentModules();
   }
 

--- a/lib/agents/context-monitor.js
+++ b/lib/agents/context-monitor.js
@@ -8,13 +8,14 @@ import { getLLMClient } from '../llm/client-factory.js';
 import fs from 'fs/promises';
 import path from 'path';
 import { execSync } from 'child_process';
+import { TTLMap } from '../utils/ttl-map.js';
 
 class ContextMonitor {
   constructor(openaiApiKey, projectRoot = process.cwd()) {
     this.openai = getLLMClient({ purpose: 'validation' });
     this.projectRoot = projectRoot;
-    this.contextCache = new Map();
-    this.userPatterns = new Map();
+    this.contextCache = new TTLMap({ defaultTTLMs: 5 * 60 * 1000, maxEntries: 500 }); // 5 min TTL
+    this.userPatterns = new TTLMap({ defaultTTLMs: 60 * 60 * 1000, maxEntries: 200 }); // 60 min TTL
     
     // Configuration with sensible defaults
     this.config = {

--- a/lib/agents/learning-database.js
+++ b/lib/agents/learning-database.js
@@ -8,6 +8,7 @@ import fsModule from 'fs';
 const fs = fsModule.promises;
 import path from 'path';
 import EventEmitter from 'events';
+import { TTLMap } from '../utils/ttl-map.js';
 
 class LearningDatabase extends EventEmitter {
   constructor() {
@@ -16,12 +17,13 @@ class LearningDatabase extends EventEmitter {
     // SD-SEC-ERROR-HANDLING-001: Track interval references for cleanup
     this._intervals = [];
 
-    // Pattern recognition data
+    // Pattern recognition data (TTL-managed, 60 min default)
+    const patternTTL = 60 * 60 * 1000;
     this.patterns = {
-      falsePositives: new Map(),    // Patterns that are usually false positives
-      truePositives: new Map(),     // Patterns that are usually real issues
-      fixPatterns: new Map(),       // Successful fix patterns
-      correlations: new Map()       // Issue correlations
+      falsePositives: new TTLMap({ defaultTTLMs: patternTTL, maxEntries: 500 }),
+      truePositives: new TTLMap({ defaultTTLMs: patternTTL, maxEntries: 500 }),
+      fixPatterns: new TTLMap({ defaultTTLMs: patternTTL, maxEntries: 500 }),
+      correlations: new TTLMap({ defaultTTLMs: patternTTL, maxEntries: 500 })
     };
     
     // Historical metrics
@@ -31,7 +33,7 @@ class LearningDatabase extends EventEmitter {
       confirmedIssues: 0,
       falsePositiveRate: 0,
       averageFixTime: 0,
-      commonIssues: new Map()
+      commonIssues: new TTLMap({ defaultTTLMs: 2 * 60 * 60 * 1000, maxEntries: 200 }) // 2h TTL
     };
     
     // Learning models

--- a/lib/agents/performance-optimizer.js
+++ b/lib/agents/performance-optimizer.js
@@ -4,6 +4,8 @@
  * Ensures the invisible sub-agent system operates at maximum efficiency
  */
 
+import { TTLMap } from '../utils/ttl-map.js';
+
 
 
 class PerformanceOptimizer {
@@ -32,8 +34,12 @@ class PerformanceOptimizer {
       ...config
     };
     
-    // Initialize caching systems
-    this.memoryCache = new Map();
+    // Initialize caching systems (TTL-managed, bounded)
+    this.memoryCache = new TTLMap({
+      defaultTTLMs: this.config.cache_ttl,
+      maxEntries: this.config.memory_cache_size,
+      sweepIntervalMs: 5 * 60 * 1000, // sweep every 5 min
+    });
     this.cacheStats = {
       hits: 0,
       misses: 0,
@@ -118,17 +124,12 @@ class PerformanceOptimizer {
     const startTime = Date.now();
     
     try {
-      // Try memory cache first (fastest)
-      if (this.memoryCache.has(key)) {
-        const cached = this.memoryCache.get(key);
-        if (Date.now() - cached.timestamp < this.config.cache_ttl) {
-          this.cacheStats.hits++;
-          this.recordOperationTime('cache_get_memory', Date.now() - startTime);
-          return cached.value;
-        } else {
-          // Expired, remove from memory cache
-          this.memoryCache.delete(key);
-        }
+      // Try memory cache first (fastest) — TTLMap handles expiry
+      const cached = this.memoryCache.get(key);
+      if (cached !== undefined) {
+        this.cacheStats.hits++;
+        this.recordOperationTime('cache_get_memory', Date.now() - startTime);
+        return cached;
       }
       
       // Try Redis cache (if available)
@@ -187,20 +188,14 @@ class PerformanceOptimizer {
   }
 
   /**
-   * Set item in memory cache with LRU eviction
+   * Set item in memory cache — TTLMap handles eviction and TTL
    */
   setMemoryCache(key, value) {
-    // LRU eviction if at capacity
-    if (this.memoryCache.size >= this.config.memory_cache_size) {
-      const firstKey = this.memoryCache.keys().next().value;
-      this.memoryCache.delete(firstKey);
+    const sizeBefore = this.memoryCache.size;
+    this.memoryCache.set(key, value);
+    if (this.memoryCache.size <= sizeBefore && sizeBefore >= this.config.memory_cache_size) {
       this.cacheStats.evictions++;
     }
-    
-    this.memoryCache.set(key, {
-      value,
-      timestamp: Date.now()
-    });
   }
 
   /**

--- a/lib/eva/eva-master-scheduler.js
+++ b/lib/eva/eva-master-scheduler.js
@@ -18,6 +18,7 @@ import { runOkrMonthlySnapshot } from './jobs/okr-monthly-handler.js';
 import { runOkrMonthlyGeneration } from './jobs/okr-monthly-generator.js';
 import { runOkrMidMonthReview } from './jobs/okr-mid-month-review.js';
 import { archiveStaleOkrs } from './jobs/okr-archive-stale.js';
+import { TTLMap } from '../utils/ttl-map.js';
 
 // ── Constants ────────────────────────────────────────────────
 
@@ -78,8 +79,8 @@ export class EvaMasterScheduler {
     // Periodic vision scoring configuration (US-001)
     this.visionScoringIntervalMs = cfg.visionScoringIntervalMs || DEFAULT_VISION_SCORING_INTERVAL_MS;
 
-    // Round registry (FR-1, FR-3, FR-4)
-    this._roundRegistry = new Map();
+    // Round registry — bounded to prevent unbounded growth (FR-1, FR-3, FR-4)
+    this._roundRegistry = new TTLMap({ defaultTTLMs: 24 * 60 * 60 * 1000, maxEntries: 500 }); // 24h TTL, max 500
     this._lastRoundRun = new Map();
     this._totalRoundExecutions = 0;
     this._totalRoundErrors = 0;
@@ -94,8 +95,8 @@ export class EvaMasterScheduler {
     this._metricsWriteFailures = 0;
     this._lastVisionScoringAt = null;
 
-    // Job Registry (US-002: pluggable periodic tasks)
-    this._jobRegistry = new Map();
+    // Job Registry — bounded (US-002: pluggable periodic tasks)
+    this._jobRegistry = new TTLMap({ defaultTTLMs: 24 * 60 * 60 * 1000, maxEntries: 1000 }); // 24h TTL, max 1000
     this._jobLastRunAt = new Map();
 
     // Register built-in jobs

--- a/lib/eva/hub-health-monitor.js
+++ b/lib/eva/hub-health-monitor.js
@@ -18,6 +18,7 @@ export const HEALTH_STATUS = Object.freeze({
 
 const DEFAULT_CHECK_INTERVAL_MS = 30_000; // 30 seconds
 const CONSECUTIVE_FAILURES_THRESHOLD = 3;
+const DEFAULT_STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes — remove services with no heartbeat
 
 // In-memory health state
 let _serviceHealth = new Map();
@@ -161,7 +162,7 @@ export function getSystemHealth() {
  * @param {Object} [options.logger] - Logger instance
  */
 export function startMonitoring(registry, supabase, options = {}) {
-  const { intervalMs = DEFAULT_CHECK_INTERVAL_MS, logger = console } = options;
+  const { intervalMs = DEFAULT_CHECK_INTERVAL_MS, staleThresholdMs = DEFAULT_STALE_THRESHOLD_MS, logger = console } = options;
 
   stopMonitoring();
 
@@ -169,10 +170,15 @@ export function startMonitoring(registry, supabase, options = {}) {
   checkAllServices(registry, supabase, { logger });
 
   _checkInterval = setInterval(() => {
+    // Sweep stale entries before running new checks
+    const stale = sweepStaleServices(staleThresholdMs);
+    if (stale.length > 0) {
+      logger.info(`[HealthMonitor] Swept ${stale.length} stale service(s): ${stale.join(', ')}`);
+    }
     checkAllServices(registry, supabase, { logger });
   }, intervalMs);
 
-  logger.info(`[HealthMonitor] Started monitoring (interval: ${intervalMs}ms)`);
+  logger.info(`[HealthMonitor] Started monitoring (interval: ${intervalMs}ms, staleThreshold: ${staleThresholdMs}ms)`);
 }
 
 /**
@@ -183,6 +189,28 @@ export function stopMonitoring() {
     clearInterval(_checkInterval);
     _checkInterval = null;
   }
+}
+
+/**
+ * Remove stale service entries that haven't been checked within the threshold.
+ *
+ * @param {number} [thresholdMs] - Inactivity threshold (default: 10 minutes)
+ * @returns {string[]} Names of removed stale services
+ */
+export function sweepStaleServices(thresholdMs = DEFAULT_STALE_THRESHOLD_MS) {
+  const now = Date.now();
+  const removed = [];
+
+  for (const [name, entry] of _serviceHealth) {
+    if (!entry.lastChecked) continue;
+    const age = now - new Date(entry.lastChecked).getTime();
+    if (age > thresholdMs) {
+      _serviceHealth.delete(name);
+      removed.push(name);
+    }
+  }
+
+  return removed;
 }
 
 /**

--- a/lib/utils/ttl-map.js
+++ b/lib/utils/ttl-map.js
@@ -1,0 +1,168 @@
+/**
+ * TTLMap — Map wrapper with automatic entry expiration and bounded size.
+ *
+ * SD: SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-A
+ *
+ * Extends the native Map interface with:
+ * - Per-entry TTL (time-to-live) with lazy expiration on access
+ * - Optional periodic sweep to remove expired entries in bulk
+ * - Bounded size with FIFO eviction when maxEntries is exceeded
+ *
+ * @module lib/utils/ttl-map
+ */
+
+export class TTLMap {
+  /**
+   * @param {Object} [options]
+   * @param {number} [options.defaultTTLMs=1800000] - Default TTL in ms (30 min)
+   * @param {number} [options.maxEntries=Infinity] - Max entries before FIFO eviction
+   * @param {number} [options.sweepIntervalMs=0] - Periodic sweep interval (0 = disabled)
+   */
+  constructor(options = {}) {
+    this.defaultTTLMs = options.defaultTTLMs ?? 30 * 60 * 1000; // 30 min
+    this.maxEntries = options.maxEntries ?? Infinity;
+    this._store = new Map(); // key → { value, expiresAt }
+    this._sweepTimer = null;
+
+    if (options.sweepIntervalMs && options.sweepIntervalMs > 0) {
+      this._sweepTimer = setInterval(() => this.sweep(), options.sweepIntervalMs);
+      if (this._sweepTimer.unref) this._sweepTimer.unref();
+    }
+  }
+
+  /**
+   * Get a value. Returns undefined if expired or missing.
+   */
+  get(key) {
+    const entry = this._store.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this._store.delete(key);
+      return undefined;
+    }
+    return entry.value;
+  }
+
+  /**
+   * Set a value with optional per-entry TTL.
+   * @param {*} key
+   * @param {*} value
+   * @param {number} [ttlMs] - Override default TTL for this entry
+   */
+  set(key, value, ttlMs) {
+    const ttl = ttlMs ?? this.defaultTTLMs;
+    this._store.set(key, { value, expiresAt: Date.now() + ttl });
+    this._evictIfNeeded();
+    return this;
+  }
+
+  /**
+   * Check if key exists and is not expired.
+   */
+  has(key) {
+    const entry = this._store.get(key);
+    if (!entry) return false;
+    if (Date.now() > entry.expiresAt) {
+      this._store.delete(key);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Delete a key.
+   */
+  delete(key) {
+    return this._store.delete(key);
+  }
+
+  /**
+   * Clear all entries.
+   */
+  clear() {
+    this._store.clear();
+  }
+
+  /**
+   * Number of entries (including potentially expired ones not yet swept).
+   */
+  get size() {
+    return this._store.size;
+  }
+
+  /**
+   * Remove all expired entries in bulk.
+   * @returns {number} Number of entries removed
+   */
+  sweep() {
+    const now = Date.now();
+    let removed = 0;
+    for (const [key, entry] of this._store) {
+      if (now > entry.expiresAt) {
+        this._store.delete(key);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /**
+   * Iterate over non-expired entries.
+   */
+  *entries() {
+    const now = Date.now();
+    for (const [key, entry] of this._store) {
+      if (now <= entry.expiresAt) {
+        yield [key, entry.value];
+      }
+    }
+  }
+
+  /**
+   * Iterate over non-expired keys.
+   */
+  *keys() {
+    for (const [key] of this.entries()) {
+      yield key;
+    }
+  }
+
+  /**
+   * Iterate over non-expired values.
+   */
+  *values() {
+    for (const [, value] of this.entries()) {
+      yield value;
+    }
+  }
+
+  /**
+   * forEach over non-expired entries.
+   */
+  forEach(callback, thisArg) {
+    for (const [key, value] of this.entries()) {
+      callback.call(thisArg, value, key, this);
+    }
+  }
+
+  /**
+   * Stop the periodic sweep timer.
+   */
+  destroy() {
+    if (this._sweepTimer) {
+      clearInterval(this._sweepTimer);
+      this._sweepTimer = null;
+    }
+    this._store.clear();
+  }
+
+  /** @private Evict oldest entries if over maxEntries */
+  _evictIfNeeded() {
+    while (this._store.size > this.maxEntries) {
+      const oldestKey = this._store.keys().next().value;
+      this._store.delete(oldestKey);
+    }
+  }
+}
+
+export default TTLMap;


### PR DESCRIPTION
## Summary
- Add `TTLMap` utility class with per-entry TTL, periodic sweep, and bounded size (FIFO eviction)
- Replace bare `Map` caches in 5 agent/scheduler modules with `TTLMap` instances
- Add `sweepStaleServices()` to hub-health-monitor for inactive service cleanup

## Details
Addresses **A01 (Scalable Module Architecture)** dimension gaps:
- Module-level caches without TTL → now all have configurable TTL + max size
- No module health monitoring → hub-health-monitor now sweeps stale services

**Files changed (7):**
| File | Change |
|------|--------|
| `lib/utils/ttl-map.js` | New TTLMap utility class |
| `lib/agents/performance-optimizer.js` | Replace memoryCache with TTLMap |
| `lib/agents/context-monitor.js` | Replace contextCache + userPatterns with TTLMap |
| `lib/agents/auto-selector.js` | Replace userPatterns + agentModules with TTLMap |
| `lib/agents/learning-database.js` | Replace 5 pattern caches with TTLMap |
| `lib/eva/eva-master-scheduler.js` | Replace round/job registries with TTLMap |
| `lib/eva/hub-health-monitor.js` | Add stale service sweep |

## Test plan
- [x] All modified modules load without import errors
- [x] TTLMap unit verification (set/get/expiry/eviction)
- [x] Pre-existing circular dep in eva-master-scheduler confirmed unrelated
- [ ] Integration: verify caches expire correctly under normal operation

SD: SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)