### PR TITLE
feat(A03): add StageRegistry for DB-driven stage configuration

### DIFF
--- a/lib/eva/stage-registry/core.js
+++ b/lib/eva/stage-registry/core.js
@@ -1,0 +1,148 @@
+/**
+ * StageRegistry Core Class
+ * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D
+ *
+ * Registry-based stage discovery mirroring ValidatorRegistry pattern.
+ * Maps stage numbers to configuration objects loaded from DB or file templates.
+ */
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class StageRegistry {
+  constructor() {
+    /** @type {Map<number, object>} stageNumber → config */
+    this.stages = new Map();
+
+    /** @type {Map<number, object>} stageNumber → file-based fallback */
+    this.fallbackStages = new Map();
+
+    /** @type {number|null} */
+    this._cacheLoadedAt = null;
+
+    /** @type {string} */
+    this._source = 'empty';
+  }
+
+  /**
+   * Register a stage configuration
+   * @param {number} stageNumber
+   * @param {object} config - Stage configuration object
+   */
+  register(stageNumber, config) {
+    if (typeof stageNumber !== 'number' || stageNumber < 0) {
+      throw new Error(`Stage number must be a non-negative number, got: ${stageNumber}`);
+    }
+    this.stages.set(stageNumber, { ...config, _registeredAt: Date.now() });
+  }
+
+  /**
+   * Get stage configuration by number
+   * @param {number} stageNumber
+   * @returns {object|null}
+   */
+  get(stageNumber) {
+    const stage = this.stages.get(stageNumber);
+    if (stage) return stage;
+
+    // Check fallback
+    const fallback = this.fallbackStages.get(stageNumber);
+    if (fallback) return fallback;
+
+    return null;
+  }
+
+  /**
+   * Check if a stage exists in the registry
+   * @param {number} stageNumber
+   * @returns {boolean}
+   */
+  has(stageNumber) {
+    return this.stages.has(stageNumber) || this.fallbackStages.has(stageNumber);
+  }
+
+  /**
+   * Get all registered stage numbers
+   * @returns {number[]}
+   */
+  getRegisteredStages() {
+    return Array.from(this.stages.keys()).sort((a, b) => a - b);
+  }
+
+  /**
+   * Get stages for a specific phase
+   * @param {number} phaseNumber
+   * @returns {object[]} Array of stage configs in that phase
+   */
+  getStagesForPhase(phaseNumber) {
+    const result = [];
+    for (const [num, config] of this.stages) {
+      if (config.phase_number === phaseNumber) {
+        result.push({ stageNumber: num, ...config });
+      }
+    }
+    return result.sort((a, b) => a.stageNumber - b.stageNumber);
+  }
+
+  /**
+   * Register a fallback stage from file-based templates
+   * @param {number} stageNumber
+   * @param {object} template
+   */
+  registerFallback(stageNumber, template) {
+    this.fallbackStages.set(stageNumber, { ...template, _source: 'file-fallback' });
+  }
+
+  /**
+   * Check if cache is still valid
+   * @returns {boolean}
+   */
+  isCacheValid() {
+    if (!this._cacheLoadedAt) return false;
+    return (Date.now() - this._cacheLoadedAt) < CACHE_TTL_MS;
+  }
+
+  /**
+   * Mark cache as loaded
+   */
+  markCacheLoaded() {
+    this._cacheLoadedAt = Date.now();
+    this._source = 'database';
+  }
+
+  /**
+   * Invalidate cache
+   */
+  invalidateCache() {
+    this._cacheLoadedAt = null;
+  }
+
+  /**
+   * Get registration statistics
+   * @returns {object}
+   */
+  getStats() {
+    const stats = {
+      totalRegistered: this.stages.size,
+      totalFallbacks: this.fallbackStages.size,
+      source: this._source,
+      cacheValid: this.isCacheValid(),
+      byPhase: {},
+    };
+
+    for (const [, config] of this.stages) {
+      const phase = config.phase_number || 'unknown';
+      stats.byPhase[phase] = (stats.byPhase[phase] || 0) + 1;
+    }
+
+    return stats;
+  }
+
+  /**
+   * Clear all registered stages
+   */
+  clear() {
+    this.stages.clear();
+    this._cacheLoadedAt = null;
+    this._source = 'empty';
+  }
+}

--- a/lib/eva/stage-registry/index.js
+++ b/lib/eva/stage-registry/index.js
@@ -1,0 +1,147 @@
+/**
+ * StageRegistry Factory & Singleton
+ * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D
+ *
+ * Creates and configures a StageRegistry instance.
+ * Supports loading from database (lifecycle_stage_config) with
+ * graceful fallback to file-based stage templates.
+ */
+
+import { StageRegistry } from './core.js';
+
+/**
+ * Load stage configurations from lifecycle_stage_config table
+ * @param {StageRegistry} registry
+ * @param {object} supabase - Supabase client
+ * @returns {Promise<{loaded: number, error: string|null}>}
+ */
+export async function loadFromDatabase(registry, supabase) {
+  if (!supabase) {
+    return { loaded: 0, error: 'No supabase client provided' };
+  }
+
+  if (registry.isCacheValid()) {
+    return { loaded: registry.stages.size, error: null, cached: true };
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('lifecycle_stage_config')
+      .select('stage_number, stage_name, description, phase_number, phase_name, work_type, sd_required, advisory_enabled, depends_on, required_artifacts, metadata')
+      .order('stage_number', { ascending: true });
+
+    if (error) {
+      console.warn(`[StageRegistry] DB load failed: ${error.message}`);
+      return { loaded: 0, error: error.message };
+    }
+
+    if (!data || data.length === 0) {
+      return { loaded: 0, error: 'No stage configs found in database' };
+    }
+
+    // Clear existing DB-loaded stages (keep fallbacks)
+    registry.clear();
+
+    for (const row of data) {
+      registry.register(row.stage_number, {
+        stage_name: row.stage_name,
+        description: row.description,
+        phase_number: row.phase_number,
+        phase_name: row.phase_name,
+        work_type: row.work_type,
+        sd_required: row.sd_required,
+        advisory_enabled: row.advisory_enabled,
+        depends_on: row.depends_on || [],
+        required_artifacts: row.required_artifacts || [],
+        metadata: row.metadata || {},
+      });
+    }
+
+    registry.markCacheLoaded();
+    return { loaded: data.length, error: null };
+  } catch (err) {
+    console.warn(`[StageRegistry] DB load exception: ${err.message}`);
+    return { loaded: 0, error: err.message };
+  }
+}
+
+/**
+ * Load fallback stages from file-based templates
+ * @param {StageRegistry} registry
+ * @returns {Promise<number>} Number of fallbacks loaded
+ */
+export async function loadFallbackTemplates(registry) {
+  try {
+    const { getAllTemplates } = await import('../stage-templates/index.js');
+    const templates = getAllTemplates();
+
+    let count = 0;
+    for (const template of templates) {
+      if (template && template.id) {
+        const num = parseInt(template.id.replace('stage-', ''), 10);
+        if (!isNaN(num)) {
+          registry.registerFallback(num, {
+            stage_name: template.title || template.slug || `Stage ${num}`,
+            description: template.description || '',
+            version: template.version || '1.0.0',
+            _template: template,
+          });
+          count++;
+        }
+      }
+    }
+    return count;
+  } catch (err) {
+    console.warn(`[StageRegistry] Fallback load failed: ${err.message}`);
+    return 0;
+  }
+}
+
+/**
+ * Create a fully configured StageRegistry
+ * @param {object} [options]
+ * @param {object} [options.supabase] - Supabase client for DB loading
+ * @param {boolean} [options.loadFallbacks=true] - Whether to load file fallbacks
+ * @returns {Promise<StageRegistry>}
+ */
+export async function createStageRegistry(options = {}) {
+  const registry = new StageRegistry();
+
+  // Load file-based fallbacks first (fast, always available)
+  if (options.loadFallbacks !== false) {
+    await loadFallbackTemplates(registry);
+  }
+
+  // Try loading from database (overrides fallbacks)
+  if (options.supabase) {
+    await loadFromDatabase(registry, options.supabase);
+  }
+
+  return registry;
+}
+
+// Singleton instance (lazy initialization)
+let _instance = null;
+
+/**
+ * Get the singleton StageRegistry instance
+ * @returns {StageRegistry}
+ */
+export function getStageRegistry() {
+  if (!_instance) {
+    _instance = new StageRegistry();
+  }
+  return _instance;
+}
+
+/**
+ * Initialize the singleton with database and fallbacks
+ * @param {object} supabase
+ * @returns {Promise<StageRegistry>}
+ */
+export async function initStageRegistry(supabase) {
+  _instance = await createStageRegistry({ supabase, loadFallbacks: true });
+  return _instance;
+}
+
+export { StageRegistry } from './core.js';

--- a/tests/unit/eva/stage-registry.test.js
+++ b/tests/unit/eva/stage-registry.test.js
@@ -1,0 +1,202 @@
+/**
+ * Tests for StageRegistry — A03 Stage Framework Extensibility
+ * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StageRegistry } from '../../../lib/eva/stage-registry/core.js';
+import {
+  loadFromDatabase,
+  loadFallbackTemplates,
+  createStageRegistry,
+  getStageRegistry,
+} from '../../../lib/eva/stage-registry/index.js';
+
+describe('StageRegistry Core', () => {
+  let registry;
+
+  beforeEach(() => {
+    registry = new StageRegistry();
+  });
+
+  it('registers and retrieves stage config', () => {
+    registry.register(1, { stage_name: 'Draft Idea', phase_number: 1 });
+    const config = registry.get(1);
+    expect(config).toBeTruthy();
+    expect(config.stage_name).toBe('Draft Idea');
+  });
+
+  it('returns null for unregistered stage', () => {
+    expect(registry.get(99)).toBeNull();
+  });
+
+  it('has() checks existence', () => {
+    registry.register(1, { stage_name: 'Draft Idea' });
+    expect(registry.has(1)).toBe(true);
+    expect(registry.has(99)).toBe(false);
+  });
+
+  it('throws on invalid stage number', () => {
+    expect(() => registry.register(-1, {})).toThrow();
+    expect(() => registry.register('abc', {})).toThrow();
+  });
+
+  it('getRegisteredStages returns sorted numbers', () => {
+    registry.register(5, { stage_name: 'S5' });
+    registry.register(1, { stage_name: 'S1' });
+    registry.register(3, { stage_name: 'S3' });
+    expect(registry.getRegisteredStages()).toEqual([1, 3, 5]);
+  });
+
+  it('getStagesForPhase returns correct subset', () => {
+    registry.register(1, { stage_name: 'S1', phase_number: 1 });
+    registry.register(2, { stage_name: 'S2', phase_number: 1 });
+    registry.register(3, { stage_name: 'S3', phase_number: 2 });
+    const phase1 = registry.getStagesForPhase(1);
+    expect(phase1).toHaveLength(2);
+    expect(phase1[0].stage_name).toBe('S1');
+  });
+
+  it('getStats returns registration info', () => {
+    registry.register(1, { stage_name: 'S1', phase_number: 1 });
+    registry.register(2, { stage_name: 'S2', phase_number: 1 });
+    const stats = registry.getStats();
+    expect(stats.totalRegistered).toBe(2);
+    expect(stats.byPhase[1]).toBe(2);
+  });
+
+  it('fallback stages are returned when primary not found', () => {
+    registry.registerFallback(1, { stage_name: 'Fallback' });
+    expect(registry.get(1).stage_name).toBe('Fallback');
+    expect(registry.has(1)).toBe(true);
+  });
+
+  it('primary stages take precedence over fallbacks', () => {
+    registry.registerFallback(1, { stage_name: 'Fallback' });
+    registry.register(1, { stage_name: 'Primary' });
+    expect(registry.get(1).stage_name).toBe('Primary');
+  });
+
+  it('cache validity tracking works', () => {
+    expect(registry.isCacheValid()).toBe(false);
+    registry.markCacheLoaded();
+    expect(registry.isCacheValid()).toBe(true);
+    registry.invalidateCache();
+    expect(registry.isCacheValid()).toBe(false);
+  });
+
+  it('clear removes all stages and resets cache', () => {
+    registry.register(1, { stage_name: 'S1' });
+    registry.markCacheLoaded();
+    registry.clear();
+    expect(registry.stages.size).toBe(0);
+    expect(registry.isCacheValid()).toBe(false);
+  });
+});
+
+describe('StageRegistry — loadFromDatabase', () => {
+  it('loads stages from lifecycle_stage_config', async () => {
+    const registry = new StageRegistry();
+    const mockData = [
+      { stage_number: 1, stage_name: 'Draft Idea', phase_number: 1, phase_name: 'THE TRUTH', work_type: 'artifact_only', sd_required: false, advisory_enabled: false, depends_on: [], required_artifacts: ['idea_brief'], metadata: {}, description: '' },
+      { stage_number: 2, stage_name: 'Chairman Review', phase_number: 1, phase_name: 'THE TRUTH', work_type: 'decision_gate', sd_required: false, advisory_enabled: false, depends_on: [1], required_artifacts: [], metadata: {}, description: '' },
+    ];
+
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: mockData, error: null }),
+      })),
+    };
+
+    const result = await loadFromDatabase(registry, supabase);
+    expect(result.loaded).toBe(2);
+    expect(result.error).toBeNull();
+    expect(registry.has(1)).toBe(true);
+    expect(registry.has(2)).toBe(true);
+    expect(registry.isCacheValid()).toBe(true);
+  });
+
+  it('returns cached data within TTL', async () => {
+    const registry = new StageRegistry();
+    registry.register(1, { stage_name: 'Cached' });
+    registry.markCacheLoaded();
+
+    const result = await loadFromDatabase(registry, {});
+    expect(result.cached).toBe(true);
+    expect(result.loaded).toBe(1);
+  });
+
+  it('handles DB errors gracefully', async () => {
+    const registry = new StageRegistry();
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: null, error: { message: 'connection failed' } }),
+      })),
+    };
+
+    const result = await loadFromDatabase(registry, supabase);
+    expect(result.loaded).toBe(0);
+    expect(result.error).toContain('connection failed');
+  });
+
+  it('handles exceptions gracefully', async () => {
+    const registry = new StageRegistry();
+    const supabase = {
+      from: vi.fn(() => { throw new Error('DB down'); }),
+    };
+
+    const result = await loadFromDatabase(registry, supabase);
+    expect(result.loaded).toBe(0);
+    expect(result.error).toContain('DB down');
+  });
+
+  it('returns error when no supabase client', async () => {
+    const registry = new StageRegistry();
+    const result = await loadFromDatabase(registry, null);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+describe('StageRegistry — createStageRegistry', () => {
+  it('creates registry with DB data', async () => {
+    const mockData = Array.from({ length: 5 }, (_, i) => ({
+      stage_number: i + 1,
+      stage_name: `Stage ${i + 1}`,
+      phase_number: 1,
+      phase_name: 'TEST',
+      work_type: 'artifact_only',
+      sd_required: false,
+      advisory_enabled: false,
+      depends_on: [],
+      required_artifacts: [],
+      metadata: {},
+      description: '',
+    }));
+
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({ data: mockData, error: null }),
+      })),
+    };
+
+    const registry = await createStageRegistry({ supabase, loadFallbacks: false });
+    expect(registry.stages.size).toBe(5);
+    expect(registry.isCacheValid()).toBe(true);
+  });
+
+  it('creates registry without DB (fallback only)', async () => {
+    const registry = await createStageRegistry({ loadFallbacks: false });
+    expect(registry.stages.size).toBe(0);
+  });
+});
+
+describe('StageRegistry — getStageRegistry singleton', () => {
+  it('returns same instance', () => {
+    const a = getStageRegistry();
+    const b = getStageRegistry();
+    expect(a).toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `StageRegistry` class in `lib/eva/stage-registry/` mirroring the `ValidatorRegistry` pattern
- Supports loading stage configs from `lifecycle_stage_config` DB table with 5-min TTL cache
- Graceful fallback to file-based stage templates when DB unavailable
- 19 unit tests covering core registry, DB loading, fallback, cache, and singleton behavior

## SD Context
- **SD**: SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D (Child D of Theme B)
- **Dimension**: A03 — Stage Framework Extensibility
- **PRD**: Stage Registry & DB-Driven Stage Configuration

## Test plan
- [x] 19 unit tests passing (vitest)
- [x] StageRegistry register/get/has/getStagesForPhase methods validated
- [x] DB loading with mock Supabase client tested
- [x] Cache TTL and invalidation tested
- [x] Fallback precedence (primary > fallback) tested
- [x] Error handling for DB failures and missing client tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)