### PR TITLE
feat(A03): StageRegistry for extensible stage framework

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -444,4 +444,22 @@ export function validatePostStage(stageNumber, stageOutput, { logger = console, 
   };
 }
 
+/**
+ * Cross-stage dependency map for execution engine.
+ * Defines which upstream stages are required for each stage's analysisStep.
+ * Moved from stage-execution-engine.js for centralization.
+ * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D
+ */
+export const CROSS_STAGE_DEPS = {
+  1: [0],              // Stage 1 needs Stage 0 synthesis
+  3: [1, 2],           // Kill gate: needs idea + validation
+  5: [1, 3, 4],        // Kill gate: needs idea + market + competitor
+  8: [1, 2, 3, 4, 5, 6, 7], // BMC: synthesizes all prior
+  9: [1, 5, 8],        // Reality gate: needs idea + financial + BMC
+  13: [1, 5, 9, 10, 11, 12], // Kill gate: needs full identity
+  16: [1, 5, 7, 13, 14, 15], // P&L: needs pricing + planning
+  22: [17, 18, 19, 20, 21],  // UAT: needs full build
+  25: [22, 23, 24],    // Ops review: needs launch data
+};
+
 export { STAGE_CONTRACTS };

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -10,6 +10,8 @@ import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { stageRegistry } from './stage-registry.js';
+import { CROSS_STAGE_DEPS } from './contracts/stage-contracts.js';
 
 dotenv.config();
 
@@ -17,21 +19,46 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const STAGE_TEMPLATES_DIR = join(__dirname, 'stage-templates');
 
 /**
+ * Ensure the StageRegistry is initialized with built-in stages.
+ * Safe to call multiple times — idempotent.
+ */
+let _registryInitialized = false;
+async function ensureRegistryInitialized() {
+  if (_registryInitialized) return;
+  if (!stageRegistry._initialized) {
+    await stageRegistry.registerBuiltinStages();
+  }
+  _registryInitialized = true;
+}
+
+/**
  * Load a stage template module by stage number.
+ * Uses StageRegistry for lookup with file-based fallback.
  * @param {number} stageNumber - Stage number (1-25)
  * @returns {Promise<Object>} Stage template with validate, computeDerived, analysisStep
  */
 export async function loadStageTemplate(stageNumber) {
+  await ensureRegistryInitialized();
+
+  // Try registry first
+  const template = stageRegistry.get(stageNumber);
+  if (template) {
+    return template;
+  }
+
+  // Direct file fallback (for stages not yet registered)
   const paddedNum = String(stageNumber).padStart(2, '0');
   const templatePath = join(STAGE_TEMPLATES_DIR, `stage-${paddedNum}.js`);
 
   try {
     const module = await import(`file://${templatePath.replace(/\\/g, '/')}`);
-    const template = module.TEMPLATE || module.default;
-    if (!template) {
+    const loaded = module.TEMPLATE || module.default;
+    if (!loaded) {
       throw new Error(`Stage ${stageNumber} template has no TEMPLATE export`);
     }
-    return template;
+    // Register for future lookups
+    stageRegistry.register(stageNumber, loaded, { source: 'file' });
+    return loaded;
   } catch (err) {
     if (err.code === 'ERR_MODULE_NOT_FOUND') {
       throw new Error(`Stage ${stageNumber} template not found at ${templatePath}`);
@@ -184,20 +211,7 @@ export async function executeStage(options = {}) {
   const template = await loadStageTemplate(stageNumber);
   logger.log(`   Loaded stage ${stageNumber} template: ${template.title || template.id}`);
 
-  // 2. Determine required upstream stages from cross-stage dependency map
-  // Mirrors contract-validator.js CROSS_STAGE_DEPS + sequential fallback
-  const CROSS_STAGE_DEPS = {
-    1: [0],              // Stage 1 needs Stage 0 synthesis
-    3: [1, 2],           // Kill gate: needs idea + validation
-    5: [1, 3, 4],        // Kill gate: needs idea + market + competitor
-    8: [1, 2, 3, 4, 5, 6, 7], // BMC: synthesizes all prior
-    9: [1, 5, 8],        // Reality gate: needs idea + financial + BMC
-    13: [1, 5, 9, 10, 11, 12], // Kill gate: needs full identity
-    16: [1, 5, 7, 13, 14, 15], // P&L: needs pricing + planning
-    22: [17, 18, 19, 20, 21],  // UAT: needs full build
-    25: [22, 23, 24],    // Ops review: needs launch data
-  };
-
+  // 2. Determine required upstream stages from centralized cross-stage dependency map
   let requiredStages = CROSS_STAGE_DEPS[stageNumber] || [];
   if (requiredStages.length === 0 && stageNumber > 1) {
     requiredStages = [stageNumber - 1]; // Default: previous stage

--- a/lib/eva/stage-registry.js
+++ b/lib/eva/stage-registry.js
@@ -1,0 +1,244 @@
+/**
+ * StageRegistry - Registry-based stage template discovery
+ * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D: A03 Stage Framework Extensibility
+ *
+ * Follows the ValidatorRegistry pattern (register/get/has/getStats).
+ * Provides unified lookup for stage templates with:
+ * - File-based registration for built-in stages (1-25)
+ * - Database-driven configuration via lifecycle_stage_config
+ * - 5-minute TTL cache for DB-loaded configs
+ * - Graceful fallback to file-based templates when DB unavailable
+ *
+ * @module lib/eva/stage-registry
+ * @version 1.0.0
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+dotenv.config();
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const STAGE_TEMPLATES_DIR = join(__dirname, 'stage-templates');
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class StageRegistry {
+  constructor() {
+    /** @type {Map<number, {template: Object, source: 'file'|'db', version: string, registeredAt: number}>} */
+    this.stages = new Map();
+
+    /** @type {Map<number, {template: Object, cachedAt: number}>} */
+    this.dbCache = new Map();
+
+    this.stats = {
+      cacheHits: 0,
+      cacheMisses: 0,
+      dbErrors: 0,
+    };
+
+    this._initialized = false;
+  }
+
+  /**
+   * Register a stage template.
+   * @param {number} stageNumber - Stage number (1-25)
+   * @param {Object} template - Stage template object
+   * @param {{ source?: 'file'|'db', version?: string }} [options]
+   */
+  register(stageNumber, template, options = {}) {
+    const { source = 'file', version = '1.0.0' } = options;
+    this.stages.set(stageNumber, {
+      template,
+      source,
+      version,
+      registeredAt: Date.now(),
+    });
+  }
+
+  /**
+   * Get a stage template by number.
+   * Checks: DB cache (with TTL) → file-based registry → null.
+   * @param {number} stageNumber
+   * @returns {Object|null} Stage template or null
+   */
+  get(stageNumber) {
+    // Check DB cache first (overrides file-based)
+    const cached = this.dbCache.get(stageNumber);
+    if (cached && (Date.now() - cached.cachedAt) < CACHE_TTL_MS) {
+      this.stats.cacheHits++;
+      return cached.template;
+    }
+
+    // Fall back to file-based registry
+    const entry = this.stages.get(stageNumber);
+    if (entry) {
+      return entry.template;
+    }
+
+    return null;
+  }
+
+  /**
+   * Check if a stage is registered.
+   * @param {number} stageNumber
+   * @returns {boolean}
+   */
+  has(stageNumber) {
+    // Check DB cache (within TTL)
+    const cached = this.dbCache.get(stageNumber);
+    if (cached && (Date.now() - cached.cachedAt) < CACHE_TTL_MS) {
+      return true;
+    }
+    return this.stages.has(stageNumber);
+  }
+
+  /**
+   * Get registry statistics.
+   * @returns {{ total: number, fromFile: number, fromDB: number, cacheHits: number, cacheMisses: number }}
+   */
+  getStats() {
+    let fromFile = 0;
+    let fromDB = 0;
+    for (const entry of this.stages.values()) {
+      if (entry.source === 'file') fromFile++;
+      else if (entry.source === 'db') fromDB++;
+    }
+    // Count valid DB cache entries
+    for (const [, cached] of this.dbCache) {
+      if ((Date.now() - cached.cachedAt) < CACHE_TTL_MS) {
+        fromDB++;
+      }
+    }
+    return {
+      total: this.stages.size + this.dbCache.size,
+      fromFile,
+      fromDB,
+      cacheHits: this.stats.cacheHits,
+      cacheMisses: this.stats.cacheMisses,
+    };
+  }
+
+  /**
+   * Register all built-in stage templates (1-25) from file system.
+   * @returns {Promise<number>} Number of stages registered
+   */
+  async registerBuiltinStages() {
+    let count = 0;
+    for (let i = 1; i <= 25; i++) {
+      const paddedNum = String(i).padStart(2, '0');
+      const templatePath = join(STAGE_TEMPLATES_DIR, `stage-${paddedNum}.js`);
+      try {
+        const module = await import(`file://${templatePath.replace(/\\/g, '/')}`);
+        const template = module.TEMPLATE || module.default;
+        if (template) {
+          const version = template.version || '1.0.0';
+          this.register(i, template, { source: 'file', version });
+          count++;
+        }
+      } catch (err) {
+        // Stage file doesn't exist — skip silently
+        if (err.code !== 'ERR_MODULE_NOT_FOUND') {
+          console.warn(`StageRegistry: Failed to load stage ${i}: ${err.message}`);
+        }
+      }
+    }
+    this._initialized = true;
+    return count;
+  }
+
+  /**
+   * Load stage configurations from lifecycle_stage_config DB table.
+   * DB entries are cached with 5-minute TTL.
+   * @param {Object} [supabaseClient] - Optional Supabase client override
+   * @returns {Promise<number>} Number of stages loaded from DB
+   */
+  async loadFromDB(supabaseClient) {
+    try {
+      const supabase = supabaseClient || createClient(
+        process.env.SUPABASE_URL,
+        process.env.SUPABASE_SERVICE_ROLE_KEY
+      );
+
+      const { data, error } = await supabase
+        .from('lifecycle_stage_config')
+        .select('stage_number, stage_name, phase_name, metadata, description')
+        .order('stage_number');
+
+      if (error) {
+        this.stats.dbErrors++;
+        console.warn(`StageRegistry: DB load failed: ${error.message}`);
+        return 0;
+      }
+
+      let loaded = 0;
+      const now = Date.now();
+      for (const row of data || []) {
+        // Build a template-compatible config from DB row
+        const dbConfig = {
+          id: `stage-${String(row.stage_number).padStart(2, '0')}`,
+          title: row.stage_name,
+          phase: row.phase_name,
+          description: row.description || '',
+          version: row.metadata?.version || '1.0.0',
+          _source: 'db',
+          _dbMetadata: row.metadata,
+        };
+
+        // Merge DB config with file-based template if available
+        const fileEntry = this.stages.get(row.stage_number);
+        if (fileEntry) {
+          // DB augments file-based template with metadata
+          const merged = {
+            ...fileEntry.template,
+            title: dbConfig.title || fileEntry.template.title,
+            phase: dbConfig.phase || fileEntry.template.phase,
+            description: dbConfig.description || fileEntry.template.description,
+            version: dbConfig.version,
+            _dbMetadata: dbConfig._dbMetadata,
+          };
+          this.dbCache.set(row.stage_number, { template: merged, cachedAt: now });
+        } else {
+          // Pure DB-only stage (no file template)
+          this.dbCache.set(row.stage_number, { template: dbConfig, cachedAt: now });
+        }
+        loaded++;
+      }
+      this.stats.cacheMisses++;
+      return loaded;
+    } catch (err) {
+      this.stats.dbErrors++;
+      console.warn(`StageRegistry: DB load error: ${err.message}`);
+      return 0;
+    }
+  }
+
+  /**
+   * Invalidate DB cache, forcing next get() to use file-based templates
+   * until loadFromDB() is called again.
+   */
+  refreshCache() {
+    this.dbCache.clear();
+    this.stats.cacheHits = 0;
+    this.stats.cacheMisses = 0;
+  }
+
+  /**
+   * Get all registered stage numbers.
+   * @returns {number[]}
+   */
+  getRegisteredStages() {
+    const stages = new Set([...this.stages.keys()]);
+    for (const [num, cached] of this.dbCache) {
+      if ((Date.now() - cached.cachedAt) < CACHE_TTL_MS) {
+        stages.add(num);
+      }
+    }
+    return Array.from(stages).sort((a, b) => a - b);
+  }
+}
+
+// Singleton instance
+export const stageRegistry = new StageRegistry();
+export default stageRegistry;

--- a/lib/eva/stage-templates/index.js
+++ b/lib/eva/stage-templates/index.js
@@ -72,21 +72,33 @@ import stage23 from './stage-23.js';
 import stage24 from './stage-24.js';
 import stage25 from './stage-25.js';
 
+import { stageRegistry } from '../stage-registry.js';
+
+// Auto-register built-in stages into the registry
+const BUILTIN_TEMPLATES = {
+  1: stage01, 2: stage02, 3: stage03, 4: stage04, 5: stage05,
+  6: stage06, 7: stage07, 8: stage08, 9: stage09,
+  10: stage10, 11: stage11, 12: stage12,
+  13: stage13, 14: stage14, 15: stage15, 16: stage16,
+  17: stage17, 18: stage18, 19: stage19, 20: stage20, 21: stage21, 22: stage22,
+  23: stage23, 24: stage24, 25: stage25,
+};
+
+// Register all built-in templates synchronously (they're already imported)
+for (const [num, template] of Object.entries(BUILTIN_TEMPLATES)) {
+  if (!stageRegistry.has(Number(num))) {
+    stageRegistry.register(Number(num), template, { source: 'file', version: template.version || '1.0.0' });
+  }
+}
+
 /**
  * Get a stage template by stage number (1-25).
+ * Delegates to StageRegistry for unified lookup.
  * @param {number} stageNumber
  * @returns {Object|null} Stage template or null if not found
  */
 export function getTemplate(stageNumber) {
-  const templates = {
-    1: stage01, 2: stage02, 3: stage03, 4: stage04, 5: stage05,
-    6: stage06, 7: stage07, 8: stage08, 9: stage09,
-    10: stage10, 11: stage11, 12: stage12,
-    13: stage13, 14: stage14, 15: stage15, 16: stage16,
-    17: stage17, 18: stage18, 19: stage19, 20: stage20, 21: stage21, 22: stage22,
-    23: stage23, 24: stage24, 25: stage25,
-  };
-  return templates[stageNumber] || null;
+  return stageRegistry.get(stageNumber) || BUILTIN_TEMPLATES[stageNumber] || null;
 }
 
 /**

--- a/test/unit/stage-registry.test.js
+++ b/test/unit/stage-registry.test.js
@@ -1,0 +1,233 @@
+/**
+ * StageRegistry Unit Tests
+ * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D
+ *
+ * Tests for the registry-based stage template discovery system.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { StageRegistry } from '../../lib/eva/stage-registry.js';
+
+describe('StageRegistry', () => {
+  let registry;
+
+  beforeEach(() => {
+    registry = new StageRegistry();
+  });
+
+  describe('register/get/has', () => {
+    it('should register and retrieve a stage template', () => {
+      const template = { id: 'stage-01', title: 'Test Stage', validate: () => ({ valid: true }) };
+      registry.register(1, template);
+
+      expect(registry.has(1)).toBe(true);
+      expect(registry.get(1)).toBe(template);
+    });
+
+    it('should return null for unregistered stage', () => {
+      expect(registry.has(99)).toBe(false);
+      expect(registry.get(99)).toBeNull();
+    });
+
+    it('should allow overwriting a registered stage', () => {
+      const template1 = { id: 'v1', title: 'Version 1' };
+      const template2 = { id: 'v2', title: 'Version 2' };
+
+      registry.register(1, template1);
+      registry.register(1, template2);
+
+      expect(registry.get(1)).toBe(template2);
+    });
+
+    it('should store source and version metadata', () => {
+      const template = { id: 'stage-05', title: 'Test' };
+      registry.register(5, template, { source: 'db', version: '2.1.0' });
+
+      const entry = registry.stages.get(5);
+      expect(entry.source).toBe('db');
+      expect(entry.version).toBe('2.1.0');
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return correct stats for empty registry', () => {
+      const stats = registry.getStats();
+      expect(stats.total).toBe(0);
+      expect(stats.fromFile).toBe(0);
+      expect(stats.fromDB).toBe(0);
+      expect(stats.cacheHits).toBe(0);
+      expect(stats.cacheMisses).toBe(0);
+    });
+
+    it('should count file-based registrations', () => {
+      registry.register(1, { id: '01' }, { source: 'file' });
+      registry.register(2, { id: '02' }, { source: 'file' });
+      registry.register(3, { id: '03' }, { source: 'db' });
+
+      const stats = registry.getStats();
+      expect(stats.fromFile).toBe(2);
+    });
+
+    it('should track cache hits', () => {
+      registry.register(1, { id: '01' });
+      registry.get(1); // File hit, not cache hit
+
+      // Simulate DB cache entry
+      registry.dbCache.set(2, { template: { id: '02' }, cachedAt: Date.now() });
+      registry.get(2); // Cache hit
+
+      const stats = registry.getStats();
+      expect(stats.cacheHits).toBe(1);
+    });
+  });
+
+  describe('DB cache with TTL', () => {
+    it('should return DB-cached template within TTL', () => {
+      const template = { id: 'db-stage', title: 'From DB' };
+      registry.dbCache.set(10, { template, cachedAt: Date.now() });
+
+      expect(registry.get(10)).toBe(template);
+      expect(registry.has(10)).toBe(true);
+    });
+
+    it('should ignore expired DB cache entries', () => {
+      const template = { id: 'expired', title: 'Old' };
+      // Set cachedAt to 6 minutes ago (past 5-min TTL)
+      registry.dbCache.set(10, { template, cachedAt: Date.now() - 6 * 60 * 1000 });
+
+      // No file-based fallback registered
+      expect(registry.get(10)).toBeNull();
+      expect(registry.has(10)).toBe(false);
+    });
+
+    it('should fall back to file-based template when DB cache expired', () => {
+      const fileTemplate = { id: 'file-stage', title: 'From File' };
+      const dbTemplate = { id: 'db-stage', title: 'From DB' };
+
+      registry.register(10, fileTemplate, { source: 'file' });
+      // Expired DB cache
+      registry.dbCache.set(10, { template: dbTemplate, cachedAt: Date.now() - 6 * 60 * 1000 });
+
+      expect(registry.get(10)).toBe(fileTemplate);
+    });
+
+    it('should prefer DB cache over file-based when cache is fresh', () => {
+      const fileTemplate = { id: 'file-stage', title: 'From File' };
+      const dbTemplate = { id: 'db-stage', title: 'From DB' };
+
+      registry.register(10, fileTemplate, { source: 'file' });
+      registry.dbCache.set(10, { template: dbTemplate, cachedAt: Date.now() });
+
+      expect(registry.get(10)).toBe(dbTemplate);
+    });
+  });
+
+  describe('refreshCache', () => {
+    it('should clear DB cache', () => {
+      registry.dbCache.set(1, { template: { id: '01' }, cachedAt: Date.now() });
+      registry.dbCache.set(2, { template: { id: '02' }, cachedAt: Date.now() });
+      registry.stats.cacheHits = 10;
+
+      registry.refreshCache();
+
+      expect(registry.dbCache.size).toBe(0);
+      expect(registry.stats.cacheHits).toBe(0);
+    });
+
+    it('should not clear file-based registrations', () => {
+      registry.register(1, { id: '01' }, { source: 'file' });
+      registry.refreshCache();
+
+      expect(registry.has(1)).toBe(true);
+      expect(registry.get(1).id).toBe('01');
+    });
+  });
+
+  describe('getRegisteredStages', () => {
+    it('should return sorted stage numbers', () => {
+      registry.register(5, { id: '05' });
+      registry.register(1, { id: '01' });
+      registry.register(25, { id: '25' });
+
+      expect(registry.getRegisteredStages()).toEqual([1, 5, 25]);
+    });
+
+    it('should include DB-cached stages within TTL', () => {
+      registry.register(1, { id: '01' });
+      registry.dbCache.set(10, { template: { id: '10' }, cachedAt: Date.now() });
+
+      const stages = registry.getRegisteredStages();
+      expect(stages).toContain(1);
+      expect(stages).toContain(10);
+    });
+  });
+
+  describe('registerBuiltinStages', () => {
+    it('should register stages from file system', async () => {
+      const count = await registry.registerBuiltinStages();
+
+      expect(count).toBeGreaterThanOrEqual(25);
+      expect(registry.has(1)).toBe(true);
+      expect(registry.has(25)).toBe(true);
+      expect(registry._initialized).toBe(true);
+
+      const stats = registry.getStats();
+      expect(stats.fromFile).toBeGreaterThanOrEqual(25);
+    });
+  });
+
+  describe('loadFromDB', () => {
+    it('should handle DB errors gracefully', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            order: () => Promise.resolve({ data: null, error: { message: 'Connection refused' } }),
+          }),
+        }),
+      };
+
+      const loaded = await registry.loadFromDB(mockSupabase);
+      expect(loaded).toBe(0);
+      expect(registry.stats.dbErrors).toBe(1);
+    });
+
+    it('should cache DB-loaded configs', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            order: () => Promise.resolve({
+              data: [
+                { stage_number: 1, stage_name: 'DB Stage 1', phase_name: 'Phase 1', metadata: { version: '2.0.0' }, description: 'From DB' },
+              ],
+              error: null,
+            }),
+          }),
+        }),
+      };
+
+      // Register file-based first
+      registry.register(1, { id: 'stage-01', title: 'File Stage 1' }, { source: 'file' });
+
+      const loaded = await registry.loadFromDB(mockSupabase);
+      expect(loaded).toBe(1);
+
+      // DB cache should override
+      const template = registry.get(1);
+      expect(template.title).toBe('DB Stage 1');
+      expect(template.version).toBe('2.0.0');
+    });
+
+    it('should handle empty DB result', async () => {
+      const mockSupabase = {
+        from: () => ({
+          select: () => ({
+            order: () => Promise.resolve({ data: [], error: null }),
+          }),
+        }),
+      };
+
+      const loaded = await registry.loadFromDB(mockSupabase);
+      expect(loaded).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Introduces `StageRegistry` class (`lib/eva/stage-registry.js`) following the ValidatorRegistry pattern with register/get/has/getStats API
- Decouples stage execution from hardcoded template require() paths — registry provides unified lookup with file-based + DB-cached templates
- Adds 5-minute TTL cache for DB-loaded stage configurations via `lifecycle_stage_config` table
- Centralizes `CROSS_STAGE_DEPS` map in `stage-contracts.js` (moved from execution engine)
- Refactors `stage-execution-engine.js` and `stage-templates/index.js` to use registry

## Test plan
- [x] 19 StageRegistry unit tests pass (register, get, has, TTL cache, DB loading, stats)
- [x] 18 existing stage-contracts tests pass (backward compatibility)
- [x] Smoke test: execution engine loads stage 1 through registry, 25 stages registered
- [x] getTemplate/getAllTemplates backward compatibility verified

## SD Reference
SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D (A03: Extensible Stage Framework, target ≥78 from 70)

🤖 Generated with [Claude Code](https://claude.com/claude-code)