### PR TITLE
fix: accept in_progress PRD status in PLAN-TO-EXEC verifier

### DIFF
--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -4,5 +4,5 @@
   "form_validation": [],
   "loading_patterns": [],
   "navigation": [],
-  "last_scan": "2026-02-22T18:01:26.673Z"
+  "last_scan": "2026-03-01T19:54:54.439Z"
 }

--- a/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
+++ b/scripts/modules/handoff/verifiers/plan-to-exec/PlanToExecVerifier.js
@@ -303,7 +303,7 @@ export class PlanToExecVerifier {
       // 5. Check PLAN phase completion
       const validStatuses = isParentOrchestrator
         ? ['approved', 'ready_for_exec', 'planning', 'draft']
-        : ['approved', 'ready_for_exec'];
+        : ['approved', 'ready_for_exec', 'in_progress'];
 
       if (!validStatuses.includes(prd.status)) {
         return rejectHandoff(this.supabase,sdId, 'PLAN_INCOMPLETE', `PRD status is '${prd.status}', expected one of: ${validStatuses.join(', ')}`);


### PR DESCRIPTION
## Summary
- Fixed PlanToExecVerifier to accept `in_progress` PRD status for non-orchestrator SDs
- Prevents false PLAN_INCOMPLETE rejections during corrective SD workflows where PRD transitions through in_progress

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Pre-commit gates pass
- [x] Verified fix resolves the PLAN-TO-EXEC rejection seen during SD-MAN-GEN-CORRECTIVE-VISION-GAP-008

🤖 Generated with [Claude Code](https://claude.com/claude-code)