### PR TITLE
feat: enforce guardrails, add analysis intelligence, migrate state to DB-first

### DIFF
--- a/lib/context/unified-state-manager.js
+++ b/lib/context/unified-state-manager.js
@@ -22,6 +22,9 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { execSync } from 'child_process';
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
 
 const STATE_FILE_NAME = 'unified-session-state.json';
 const STATE_DIR = '.claude';
@@ -50,6 +53,86 @@ function getSessionScopedStateFileName() {
     }
   } catch { /* fallback to legacy */ }
   return STATE_FILE_NAME; // Legacy fallback
+}
+
+// Database client (lazy init) for PAT-STATE-SYNC-001 dual-write
+let _supabase = null;
+function getSupabase() {
+  if (!_supabase && process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    _supabase = createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+  }
+  return _supabase;
+}
+
+/**
+ * Get session ID for DB sync (reuses the same logic as getSessionScopedStateFileName)
+ * @returns {string|null}
+ */
+function getSessionIdForSync() {
+  try {
+    const sessionDir = path.join(os.homedir(), '.claude-sessions');
+    if (!fs.existsSync(sessionDir)) return null;
+    const pid = process.ppid || process.pid;
+    const files = fs.readdirSync(sessionDir).filter(f => f.endsWith('.json'));
+    for (const file of files) {
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(sessionDir, file), 'utf8'));
+        if (data.pid === pid && data.session_id) return data.session_id;
+      } catch { /* skip */ }
+    }
+  } catch { /* fallback */ }
+  return null;
+}
+
+/**
+ * Sync session state to database (async, best-effort, fire-and-forget).
+ * PAT-STATE-SYNC-001: Writes a compact summary to claude_sessions.metadata.session_state.
+ * DB write failure does not block file write.
+ * @param {object} state - The full state object
+ */
+async function syncSessionStateToDb(state) {
+  const supabase = getSupabase();
+  if (!supabase) return;
+
+  const sessionId = getSessionIdForSync();
+  if (!sessionId) return;
+
+  try {
+    // Read existing metadata to merge
+    const { data: existing } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', sessionId)
+      .single();
+
+    const existingMetadata = existing?.metadata || {};
+
+    // Write compact summary (not the full state — keep metadata lean)
+    const updatedMetadata = {
+      ...existingMetadata,
+      session_state: {
+        sd_id: state.sd?.id || null,
+        sd_phase: state.sd?.phase || null,
+        sd_progress: state.sd?.progress ?? null,
+        git_branch: state.git?.branch || null,
+        pending_actions_count: state.summaries?.pendingActions?.length || 0,
+        decisions_count: state.decisions?.length || 0,
+        trigger: state.trigger,
+        timestamp: state.timestamp
+      }
+    };
+
+    await supabase
+      .from('claude_sessions')
+      .update({ metadata: updatedMetadata })
+      .eq('session_id', sessionId);
+  } catch (err) {
+    // Best-effort — never block file write
+    console.warn(`[UnifiedState] DB sync error: ${err.message}`);
+  }
 }
 
 // Token budget configuration (ReSum/RECOMP research)
@@ -679,6 +762,12 @@ class UnifiedStateManager {
     const tempFile = `${this.stateFile}.tmp`;
     fs.writeFileSync(tempFile, JSON.stringify(state, null, 2), 'utf8');
     fs.renameSync(tempFile, this.stateFile);
+
+    // PAT-STATE-SYNC-001: Dual-write to DB (async, fire-and-forget)
+    syncSessionStateToDb(state).catch(err => {
+      console.warn(`[UnifiedState] DB sync failed: ${err.message}`);
+    });
+
     return state;
   }
 

--- a/lib/governance/guardrail-registry.js
+++ b/lib/governance/guardrail-registry.js
@@ -168,8 +168,8 @@ const DEFAULT_GUARDRAILS = [
   {
     id: 'GR-BRAINSTORM-INTENT',
     name: 'Brainstorm Intent Documentation',
-    mode: MODES.ADVISORY,
-    description: 'SDs sourced from brainstorm sessions should reference the brainstorm session ID',
+    mode: MODES.BLOCKING,
+    description: 'SDs sourced from brainstorm sessions must reference the brainstorm session ID',
     check: (sdData) => {
       const isBrainstormSourced = sdData.metadata?.source === 'brainstorm'
         || sdData.metadata?.brainstorm_origin === true;

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1105,6 +1105,8 @@ async function createSD(options) {
   // Blocking guardrails can prevent SD creation. Advisory guardrails log warnings.
   try {
     const guardrailRegistry = await import('../lib/governance/guardrail-registry.js');
+    // Compute OKR cycle day (day of current month, 1-31)
+    const okrCycleDay = new Date().getDate();
     const guardrailInput = {
       sd_type: dbType,
       scope: description,
@@ -1113,6 +1115,7 @@ async function createSD(options) {
       strategic_objectives: finalStrategicObjectives,
       risks: [],
       metadata,
+      okrCycleDay,
     };
     const guardrailResult = guardrailRegistry.check(guardrailInput);
 

--- a/tests/unit/governance/guardrail-registry.test.js
+++ b/tests/unit/governance/guardrail-registry.test.js
@@ -272,14 +272,14 @@ describe('Guardrail Registry - GR-ORCHESTRATOR-ARCH-PLAN', () => {
 });
 
 describe('Guardrail Registry - GR-BRAINSTORM-INTENT', () => {
-  it('warns brainstorm-sourced SD without session ID', () => {
+  it('blocks brainstorm-sourced SD without session ID', () => {
     const result = check({
       metadata: { source: 'brainstorm' },
       strategic_objectives: ['OKR-1'],
     });
-    expect(result.passed).toBe(true); // advisory, not blocking
-    const warning = result.warnings.find((w) => w.guardrail === 'GR-BRAINSTORM-INTENT');
-    expect(warning).toBeDefined();
+    expect(result.passed).toBe(false); // blocking (upgraded from advisory)
+    const violation = result.violations.find((v) => v.guardrail === 'GR-BRAINSTORM-INTENT');
+    expect(violation).toBeDefined();
   });
 
   it('passes brainstorm SD with session ID', () => {
@@ -305,8 +305,8 @@ describe('Guardrail Registry - GR-BRAINSTORM-INTENT', () => {
       metadata: { brainstorm_origin: true },
       strategic_objectives: ['OKR-1'],
     });
-    const warning = result.warnings.find((w) => w.guardrail === 'GR-BRAINSTORM-INTENT');
-    expect(warning).toBeDefined();
+    const violation = result.violations.find((v) => v.guardrail === 'GR-BRAINSTORM-INTENT');
+    expect(violation).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- **GR-OKR-HARD-STOP enforcement**: Wire `okrCycleDay` into guardrailInput in `leo-create-sd.js` so OKR cycle boundary enforcement actually fires
- **GR-BRAINSTORM-INTENT upgrade**: Changed from advisory to blocking mode — SDs from brainstorms must reference their session ID
- **AnalysisStep intelligence**: Added `_synthesizeLeadAnalysis` (PLAN-TO-EXEC) and `_synthesizeExecAnalysis` (EXEC-TO-PLAN) for compounding intelligence across handoffs
- **DB-first continuation state**: Migrated `continuation-state.js` to PAT-STATE-SYNC-001 with `readStateFromDb()` (DB primary, file fallback) and dual-write `writeState()`
- **DB-first session state**: Added fire-and-forget DB sync to `unified-state-manager.js` `saveStateSync()`

SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-010 (Vision Gap — guardrail enforcement, analysis intelligence, DB source of truth)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Module imports verified (continuation-state, unified-state-manager, plan-to-exec all load cleanly)
- [x] Guardrail registry tests updated for BRAINSTORM-INTENT blocking mode
- [ ] Verify okrCycleDay appears in guardrailInput during SD creation
- [ ] Verify continuation-state DB read/write via readStateFromDb()

🤖 Generated with [Claude Code](https://claude.com/claude-code)