### PR TITLE
feat: blocking chairman scope guard, event schema seeder (V08/A05)

### DIFF
--- a/lib/middleware/chairman-scope-guard.js
+++ b/lib/middleware/chairman-scope-guard.js
@@ -1,0 +1,49 @@
+/**
+ * Chairman Scope Guard — Express middleware
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-011 (V08: chairman_dashboard_scope)
+ *
+ * Wraps auditDashboardRoutes() as blocking Express middleware.
+ * Prohibited routes (data-entry, editing, creation) are rejected with 403.
+ * Allowed governance routes pass through. Unknown routes pass with a warning log.
+ *
+ * @module lib/middleware/chairman-scope-guard
+ */
+
+import { auditDashboardRoutes } from '../eva/chairman-dashboard-scope.js';
+
+/**
+ * Create chairman scope guard middleware.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.blocking=true] - If true, return 403 for prohibited routes. If false, advisory-only (log).
+ * @returns {Function} Express middleware
+ */
+export function createChairmanScopeGuard(options = {}) {
+  const { blocking = true } = options;
+
+  return (req, res, next) => {
+    const routePath = '/chairman' + req.path;
+    const audit = auditDashboardRoutes([routePath]);
+
+    if (!audit.passed) {
+      console.warn(`[ChairmanScopeGuard] SCOPE VIOLATION: ${audit.summary} — ${req.method} ${req.originalUrl}`);
+
+      if (blocking) {
+        return res.status(403).json({
+          error: 'Scope violation',
+          message: audit.summary,
+          code: 'CHAIRMAN_SCOPE_VIOLATION',
+          prohibited: audit.prohibited,
+        });
+      }
+    }
+
+    if (audit.unknown.length > 0) {
+      console.warn(`[ChairmanScopeGuard] Unclassified route: ${routePath}`);
+    }
+
+    next();
+  };
+}
+
+export default createChairmanScopeGuard;

--- a/scripts/eva-seed-event-schemas.js
+++ b/scripts/eva-seed-event-schemas.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+/**
+ * Seed eva_event_schemas with core event types used across EVA services.
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-011 (A05: event_bus_integration)
+ *
+ * Populates the schema registry so event types are formally documented.
+ * Uses upsert (ON CONFLICT DO UPDATE) to be idempotent.
+ *
+ * Usage: node scripts/seed-event-schemas.js
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const CORE_EVENT_SCHEMAS = [
+  {
+    event_type: 'evaluation_started',
+    version: '1.0.0',
+    schema_definition: {
+      description: 'Fired when an EVA evaluation begins (expand/spinoff)',
+      fields: {
+        venture_id: { type: 'uuid', required: true },
+        evaluation_type: { type: 'string', required: true, enum: ['expand', 'spinoff'] },
+        stage_number: { type: 'integer', required: false },
+      },
+      source_modules: ['lib/eva/expand-spinoff-evaluator.js'],
+    },
+  },
+  {
+    event_type: 'evaluation_completed',
+    version: '1.0.0',
+    schema_definition: {
+      description: 'Fired when an EVA evaluation completes with results',
+      fields: {
+        venture_id: { type: 'uuid', required: true },
+        evaluation_type: { type: 'string', required: true },
+        result: { type: 'object', required: true },
+        duration_ms: { type: 'integer', required: false },
+      },
+      source_modules: ['lib/eva/expand-spinoff-evaluator.js'],
+    },
+  },
+  {
+    event_type: 'dependency_blocked',
+    version: '1.0.0',
+    schema_definition: {
+      description: 'Fired when an SD dependency check finds a blocker',
+      fields: {
+        sd_id: { type: 'uuid', required: true },
+        blocked_by: { type: 'uuid', required: true },
+        reason: { type: 'string', required: true },
+      },
+      source_modules: ['lib/eva/eva-orchestrator.js'],
+    },
+  },
+  {
+    event_type: 'dependency_check_passed',
+    version: '1.0.0',
+    schema_definition: {
+      description: 'Fired when all SD dependencies are satisfied',
+      fields: {
+        sd_id: { type: 'uuid', required: true },
+        dependencies_checked: { type: 'integer', required: true },
+      },
+      source_modules: ['lib/eva/eva-orchestrator.js'],
+    },
+  },
+  {
+    event_type: 'optimization_started',
+    version: '1.0.0',
+    schema_definition: {
+      description: 'Fired when portfolio optimization begins',
+      fields: {
+        portfolio_size: { type: 'integer', required: true },
+        strategy: { type: 'string', required: false },
+      },
+      source_modules: ['lib/eva/portfolio-optimizer.js'],
+    },
+  },
+  {
+    event_type: 'contention_detected',
+    version: '1.0.0',
+    schema_definition: {
+      description: 'Fired when resource contention is detected during optimization',
+      fields: {
+        resource: { type: 'string', required: true },
+        competing_sds: { type: 'array', required: true },
+        severity: { type: 'string', required: true, enum: ['low', 'medium', 'high'] },
+      },
+      source_modules: ['lib/eva/portfolio-optimizer.js'],
+    },
+  },
+  {
+    event_type: 'optimization_completed',
+    version: '1.0.0',
+    schema_definition: {
+      description: 'Fired when portfolio optimization completes',
+      fields: {
+        portfolio_size: { type: 'integer', required: true },
+        optimizations_applied: { type: 'integer', required: true },
+        duration_ms: { type: 'integer', required: false },
+      },
+      source_modules: ['lib/eva/portfolio-optimizer.js'],
+    },
+  },
+  {
+    event_type: 'cascade_alignment_check',
+    version: '1.0.0',
+    schema_definition: {
+      description: 'Fired during cascade alignment validation at handoff boundaries',
+      fields: {
+        sd_id: { type: 'uuid', required: true },
+        parent_sd_id: { type: 'uuid', required: true },
+        score: { type: 'integer', required: true },
+        aligned: { type: 'boolean', required: true },
+      },
+      source_modules: ['scripts/modules/governance/cascade-validator.js'],
+    },
+  },
+];
+
+async function main() {
+  console.log('Seeding eva_event_schemas with core event types...\n');
+
+  let inserted = 0;
+  let updated = 0;
+  let errors = 0;
+
+  for (const schema of CORE_EVENT_SCHEMAS) {
+    const { data, error } = await supabase
+      .from('eva_event_schemas')
+      .upsert(schema, { onConflict: 'event_type,version' })
+      .select('id, event_type');
+
+    if (error) {
+      console.log(`  ✗ ${schema.event_type}: ${error.message}`);
+      errors++;
+    } else {
+      console.log(`  ✓ ${schema.event_type} v${schema.version}`);
+      inserted++;
+    }
+  }
+
+  console.log(`\nDone: ${inserted} schemas seeded, ${errors} errors`);
+
+  // Verify
+  const { data: count } = await supabase
+    .from('eva_event_schemas')
+    .select('id', { count: 'exact', head: true });
+
+  const { count: totalCount } = await supabase
+    .from('eva_event_schemas')
+    .select('*', { count: 'exact', head: true });
+
+  console.log(`Total schemas in table: ${totalCount}`);
+
+  if (errors > 0) process.exit(1);
+}
+
+main().catch(err => {
+  console.error('Seed failed:', err.message);
+  process.exit(1);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -50,6 +50,7 @@ import testingCampaignRoutes from './routes/testing-campaign.js';
 import venturesRoutes from './routes/ventures.js';
 import v2ApiRoutes from './routes/v2-apis.js';
 import chairmanRoutes from './routes/chairman.js';
+import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 
 // Import Story API
 import * as storiesAPI from '../src/api/stories.js';
@@ -140,7 +141,7 @@ app.use('/api/testing/campaign', requireAuth, testingCampaignRoutes);
 app.use('/api/ventures', optionalAuth, venturesRoutes);
 app.use('/api/competitor-analysis', optionalAuth, venturesRoutes);
 app.use('/api/v2', optionalAuth, v2ApiRoutes);
-app.use('/api/chairman', optionalAuth, chairmanRoutes);
+app.use('/api/chairman', optionalAuth, createChairmanScopeGuard({ blocking: true }), chairmanRoutes);
 // Dashboard routes: read-only, optional auth
 app.use('/api', optionalAuth, dashboardRoutes);
 

--- a/tests/unit/middleware/chairman-scope-guard.test.js
+++ b/tests/unit/middleware/chairman-scope-guard.test.js
@@ -1,0 +1,91 @@
+/**
+ * Tests for Chairman Scope Guard middleware
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-011 (V08: chairman_dashboard_scope)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createChairmanScopeGuard } from '../../../lib/middleware/chairman-scope-guard.js';
+
+function createMockReqRes(path, method = 'GET') {
+  const req = { path, method, originalUrl: `/api/chairman${path}` };
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  };
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('Chairman Scope Guard — Blocking Mode', () => {
+  const guard = createChairmanScopeGuard({ blocking: true });
+
+  it('allows governance routes through', () => {
+    const { req, res, next } = createMockReqRes('/decisions');
+    guard(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows portfolio routes', () => {
+    const { req, res, next } = createMockReqRes('/portfolio/health');
+    guard(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('blocks prohibited create routes with 403', () => {
+    const { req, res, next } = createMockReqRes('/ventures/new');
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'CHAIRMAN_SCOPE_VIOLATION' })
+    );
+  });
+
+  it('blocks prohibited edit routes with 403', () => {
+    const { req, res, next } = createMockReqRes('/sd/123/edit');
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows unknown routes through (not prohibited)', () => {
+    const { req, res, next } = createMockReqRes('/some-custom-route');
+    guard(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('allows escalation routes', () => {
+    const { req, res, next } = createMockReqRes('/escalations/pending');
+    guard(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('allows stakeholder-response routes (V02)', () => {
+    const { req, res, next } = createMockReqRes('/stakeholder-response/abc');
+    guard(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('Chairman Scope Guard — Advisory Mode', () => {
+  const guard = createChairmanScopeGuard({ blocking: false });
+
+  it('lets prohibited routes through with warning (advisory)', () => {
+    const { req, res, next } = createMockReqRes('/ventures/new');
+    guard(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe('Chairman Scope Guard — Default Options', () => {
+  const guard = createChairmanScopeGuard();
+
+  it('defaults to blocking mode', () => {
+    const { req, res, next } = createMockReqRes('/sd/456/edit');
+    guard(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});


### PR DESCRIPTION
## Summary
- **SD-MAN-GEN-CORRECTIVE-VISION-GAP-011**: Corrective SD for vision dimensions V08 (chairman_dashboard_scope) and A05 (event_bus_integration)
- Created `lib/middleware/chairman-scope-guard.js` — Express middleware wrapping `auditDashboardRoutes()` with blocking mode (403 for prohibited routes)
- Wired blocking scope guard on `/api/chairman` routes in `server/index.js` (replaces advisory-only inline check)
- Created `scripts/eva-seed-event-schemas.js` to populate `eva_event_schemas` with 8 core event types (evaluation_started, evaluation_completed, dependency_blocked, dependency_check_passed, optimization_started, contention_detected, optimization_completed, cascade_alignment_check)
- Added 9 unit tests for scope guard covering blocking mode, advisory mode, and default options

## Test plan
- [x] 9/9 chairman-scope-guard tests pass
- [x] 53/53 existing governance tests pass (no regressions)
- [x] 15/15 smoke tests pass
- [x] Event schemas seeded successfully (8 schemas, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)