### PR TITLE
feat: cascade enforcement, emit defaults, event bus persistence

### DIFF
--- a/lib/eva/event-bus/index.js
+++ b/lib/eva/event-bus/index.js
@@ -9,7 +9,7 @@
 
 import { registerHandler, getHandler, getHandlers, listRegisteredTypes, getHandlerCount, clearHandlers, getRegistryCounts } from './handler-registry.js';
 import { processEvent, replayDLQEntry } from './event-router.js';
-import { registerDefaultSchemas, clearSchemas, listSchemas, getSchemaCount } from './event-schema-registry.js';
+import { registerDefaultSchemas, clearSchemas, listSchemas, getSchemaCount, initPersistence } from './event-schema-registry.js';
 import { handleStageCompleted } from './handlers/stage-completed.js';
 import { handleDecisionSubmitted } from './handlers/decision-submitted.js';
 import { handleGateEvaluated } from './handlers/gate-evaluated.js';
@@ -137,7 +137,8 @@ export async function initializeEventBus(supabase) {
     singleton: true,
   });
 
-  // --- Schema Registry: register default schemas for all event types ---
+  // --- Schema Registry: initialize persistence + register default schemas ---
+  initPersistence(supabase);
   registerDefaultSchemas();
 
   // --- Vision handlers (multi-subscriber, fire-and-forget) ---

--- a/lib/eva/shared-services.js
+++ b/lib/eva/shared-services.js
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 /**
  * Shared Services Abstraction: Common Service Interface
  * SD-EVA-FEAT-SHARED-SERVICES-001
@@ -115,6 +117,9 @@ export async function emit(supabase, eventType, payload, serviceName = 'unknown'
     .insert({
       event_type: eventType,
       payload: { ...payload, _service: serviceName },
+      trigger_source: payload?.trigger_source || 'manual',
+      correlation_id: payload?.correlation_id || crypto.randomUUID(),
+      status: payload?.status || 'succeeded',
       created_at: new Date().toISOString(),
     })
     .select('id, event_type, created_at')


### PR DESCRIPTION
## Summary
- Make cascade-alignment-gate blocking when alignment score < 70% threshold (V09 strategic_governance_cascade)
- Add trigger_source, correlation_id, status defaults to shared-services emit() preventing NOT NULL violations (A05 event_bus_integration)
- Wire initPersistence(supabase) before registerDefaultSchemas() in event bus initialization (A05 event_bus_integration)

SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-011

## Test plan
- [x] Event schema registry tests pass (17 tests)
- [x] Guardrail registry tests pass (34 tests)
- [x] Shared services tests pass
- [x] Event bus persistence tests pass
- [x] Smoke tests pass (15 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)