### PR TITLE
feat: SLA-urgency sorting, computed priority scores, escalation threshold (GAP-014)

### DIFF
--- a/database/migrations/20260301_gap014_chairman_routing_polish.sql
+++ b/database/migrations/20260301_gap014_chairman_routing_polish.sql
@@ -1,0 +1,181 @@
+-- Migration: Chairman Gatekeeping & Work Routing Polish
+-- SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-014
+-- Purpose: SLA-urgency sort, computed priority scores, blocking column formalization
+--
+-- Changes:
+--   1. v_chairman_pending_decisions: SLA-remaining sort (A07)
+--   2. select_schedulable_ventures: computed priority_score (A04)
+--   3. chairman_decisions.blocking: explicit column with DEFAULT false (A07)
+
+-- ============================================================
+-- Change 1: Formalize blocking column on chairman_decisions
+-- ============================================================
+-- The column is already used by chairman-sla-enforcer.js and
+-- dfe-gate-escalation-router.js but was never explicitly added
+-- via migration. This makes it explicit and idempotent.
+
+ALTER TABLE chairman_decisions
+  ADD COLUMN IF NOT EXISTS blocking BOOLEAN DEFAULT false;
+
+-- decision_type is referenced by chairman-sla-enforcer.js but was never
+-- explicitly added via migration. This makes it explicit.
+ALTER TABLE chairman_decisions
+  ADD COLUMN IF NOT EXISTS decision_type TEXT;
+
+COMMENT ON COLUMN chairman_decisions.blocking IS
+  'When true, this decision blocks downstream SD progression. '
+  'Set by chairman-sla-enforcer.js when SLA is violated with blockOnViolation=true. '
+  'Read by enforceDecisionSLAs() to skip further escalation on already-blocking decisions. '
+  'SD-MAN-GEN-CORRECTIVE-VISION-GAP-014';
+
+-- Index for blocking queries (SLA enforcer filters on pending + blocking)
+CREATE INDEX IF NOT EXISTS idx_chairman_decisions_blocking
+  ON chairman_decisions (blocking)
+  WHERE status = 'pending';
+
+-- ============================================================
+-- Change 2: v_chairman_pending_decisions with SLA-remaining sort
+-- ============================================================
+-- Replaces created_at DESC sort with SLA-remaining ascending.
+-- Uses decision_type to look up SLA hours, then computes deadline
+-- and remaining time. Most urgent decisions sort first.
+
+-- DROP existing view first because column order/names change
+DROP VIEW IF EXISTS v_chairman_pending_decisions;
+
+CREATE OR REPLACE VIEW v_chairman_pending_decisions AS
+WITH sla_config AS (
+  -- SLA hours per decision_type (mirrors DEFAULT_SLA_MATRIX in chairman-sla-enforcer.js)
+  SELECT * FROM (VALUES
+    ('gate_decision',        4),
+    ('guardrail_override',   8),
+    ('cascade_override',     8),
+    ('advisory',            24),
+    ('override',            12),
+    ('budget_review',        2),
+    ('stakeholder_response', 2)
+  ) AS t(decision_type, sla_hours)
+)
+SELECT
+  cd.id,
+  cd.venture_id,
+  v.name AS venture_name,
+  cd.lifecycle_stage,
+  lsc.stage_name,
+  cd.health_score,
+  cd.recommendation,
+  cd.decision,
+  cd.status,
+  cd.summary,
+  cd.brief_data,
+  cd.override_reason,
+  cd.risks_acknowledged,
+  cd.quick_fixes_applied,
+  cd.created_at,
+  cd.updated_at,
+  cd.decided_by,
+  cd.rationale,
+  cd.blocking,
+  -- SLA deadline: created_at + SLA hours (default 24h if type unknown)
+  cd.created_at + make_interval(hours => COALESCE(sc.sla_hours, 24)) AS sla_deadline_at,
+  -- SLA remaining in seconds (negative = overdue)
+  EXTRACT(EPOCH FROM (
+    cd.created_at + make_interval(hours => COALESCE(sc.sla_hours, 24)) - NOW()
+  )) AS sla_remaining_seconds,
+  -- Stale-context indicator
+  CASE
+    WHEN v.updated_at > cd.created_at THEN true
+    ELSE false
+  END AS is_stale_context,
+  v.updated_at AS venture_updated_at
+FROM chairman_decisions cd
+JOIN ventures v ON v.id = cd.venture_id
+LEFT JOIN lifecycle_stage_config lsc ON lsc.stage_number = cd.lifecycle_stage
+LEFT JOIN sla_config sc ON sc.decision_type = cd.decision_type
+ORDER BY
+  -- Pending decisions first
+  CASE cd.status WHEN 'pending' THEN 0 ELSE 1 END,
+  -- Then by SLA remaining ascending (most urgent / overdue first)
+  EXTRACT(EPOCH FROM (
+    cd.created_at + make_interval(hours => COALESCE(sc.sla_hours, 24)) - NOW()
+  )) ASC NULLS LAST;
+
+
+-- ============================================================
+-- Change 3: select_schedulable_ventures with computed priority_score
+-- ============================================================
+-- Replaces placeholder 0::NUMERIC with a weighted formula:
+--   priority_score = (0.4 * blocking_age_factor) + (0.3 * health_factor) + (0.3 * fifo_factor)
+--
+-- blocking_age_factor: normalized 0-100, higher = older blocking decision
+-- health_factor: inverse of health_score (lower health = higher priority)
+-- fifo_factor: normalized 0-100 based on queue position age
+
+CREATE OR REPLACE FUNCTION select_schedulable_ventures(p_batch_size INTEGER DEFAULT 20)
+RETURNS TABLE (
+  queue_id UUID,
+  venture_id UUID,
+  blocking_decision_age_seconds NUMERIC,
+  priority_score NUMERIC,
+  fifo_key TIMESTAMPTZ,
+  max_stages_per_cycle INTEGER
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH lockable AS (
+    SELECT
+      q.id AS queue_id,
+      q.venture_id,
+      q.blocking_decision_age_seconds,
+      q.fifo_key,
+      q.max_stages_per_cycle,
+      v.orchestrator_state,
+      v.health_status
+    FROM eva_scheduler_queue q
+    JOIN eva_ventures v ON v.id = q.venture_id
+    WHERE q.status = 'pending'
+      AND v.orchestrator_state NOT IN ('blocked', 'failed')
+    ORDER BY q.blocking_decision_age_seconds DESC NULLS LAST,
+             q.fifo_key ASC
+    LIMIT p_batch_size
+    FOR UPDATE OF q SKIP LOCKED
+  ),
+  scored AS (
+    SELECT
+      l.*,
+      -- Blocking age factor (0-100): older blocking = higher score
+      -- Normalize: cap at 86400 seconds (24h), scale to 0-100
+      LEAST(COALESCE(l.blocking_decision_age_seconds, 0) / 864.0, 100) AS blocking_age_factor,
+      -- Health factor (0-100): lower health = higher priority
+      -- health_status is text (healthy/warning/critical); map to numeric score
+      (100.0 - CASE l.health_status
+        WHEN 'healthy' THEN 80
+        WHEN 'warning' THEN 50
+        WHEN 'critical' THEN 20
+        ELSE 50
+      END) AS health_factor,
+      -- FIFO factor (0-100): older queue entry = higher priority
+      -- Normalize based on age in seconds, cap at 3600 (1 hour)
+      LEAST(EXTRACT(EPOCH FROM (NOW() - l.fifo_key)) / 36.0, 100) AS fifo_factor
+    FROM lockable l
+  )
+  SELECT
+    s.queue_id,
+    s.venture_id,
+    s.blocking_decision_age_seconds,
+    -- Weighted composite: blocking_age(40%) + health(30%) + fifo(30%)
+    ROUND((0.4 * s.blocking_age_factor) + (0.3 * s.health_factor) + (0.3 * s.fifo_factor), 2) AS priority_score,
+    s.fifo_key,
+    s.max_stages_per_cycle
+  FROM scored s
+  -- Exclude ventures with pending chairman decisions
+  WHERE NOT EXISTS (
+    SELECT 1 FROM eva_decisions d
+    WHERE d.eva_venture_id = s.venture_id
+      AND d.status = 'pending'
+  )
+  ORDER BY
+    -- Primary: computed priority score descending (highest priority first)
+    ROUND((0.4 * s.blocking_age_factor) + (0.3 * s.health_factor) + (0.3 * s.fifo_factor), 2) DESC;
+END;
+$$ LANGUAGE plpgsql;

--- a/lib/eva/event-bus/event-router.js
+++ b/lib/eva/event-bus/event-router.js
@@ -307,6 +307,122 @@ async function executeWithRetry(handler, payload, context, retryOpts) {
 }
 
 /**
+ * Default threshold (ms) for escalating PRIORITY_QUEUE items to EVENT channel.
+ * Items queued longer than this are re-routed for broader processing.
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-014 (A04)
+ */
+export const ESCALATION_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Check PRIORITY_QUEUE items for age-based escalation to EVENT channel.
+ * Items older than the threshold are re-routed from PRIORITY_QUEUE to EVENT
+ * processing for broader handler coverage.
+ *
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-014 (A04: event_rounds_priority_queue_work_routing)
+ *
+ * @param {object} supabase - Supabase client
+ * @param {object} [options]
+ * @param {number} [options.thresholdMs] - Escalation threshold in ms (default 30 min)
+ * @param {number} [options.limit] - Max items to escalate per run (default 50)
+ * @param {object} [options.logger] - Logger instance
+ * @returns {Promise<{ checked: number, escalated: number, errors: string[] }>}
+ */
+export async function checkEscalationThreshold(supabase, options = {}) {
+  const {
+    thresholdMs = ESCALATION_THRESHOLD_MS,
+    limit = 50,
+    logger = console,
+  } = options;
+
+  const result = { checked: 0, escalated: 0, errors: [] };
+
+  if (!supabase) {
+    result.errors.push('No supabase client');
+    return result;
+  }
+
+  // Find PRIORITY_QUEUE items older than threshold
+  const thresholdDate = new Date(Date.now() - thresholdMs).toISOString();
+
+  const { data: staleItems, error } = await supabase
+    .from('sub_agent_queue')
+    .select('id, task_type, payload, metadata, created_at')
+    .eq('status', 'pending')
+    .eq('priority', 'urgent')
+    .lt('created_at', thresholdDate)
+    .order('created_at', { ascending: true })
+    .limit(limit);
+
+  if (error) {
+    result.errors.push(`Query failed: ${error.message}`);
+    return result;
+  }
+
+  if (!staleItems || staleItems.length === 0) {
+    return result;
+  }
+
+  result.checked = staleItems.length;
+
+  for (const item of staleItems) {
+    try {
+      // Re-dispatch as EVENT mode by constructing a synthetic event
+      const syntheticEvent = {
+        id: `escalated-${item.id}`,
+        event_type: item.task_type,
+        event_data: {
+          ...(item.payload || {}),
+          _escalation_source: 'priority_queue_age_threshold',
+          _original_queue_id: item.id,
+          _queue_age_ms: Date.now() - new Date(item.created_at).getTime(),
+        },
+        eva_venture_id: item.metadata?.venture_id || item.payload?.ventureId || null,
+      };
+
+      // Process via EVENT mode directly
+      const processResult = await processEventDirect(supabase, syntheticEvent, { persist: true });
+
+      if (processResult.success) {
+        // Mark original queue item as escalated
+        await supabase
+          .from('sub_agent_queue')
+          .update({
+            status: 'completed',
+            metadata: {
+              ...(item.metadata || {}),
+              escalated_to_event: true,
+              escalated_at: new Date().toISOString(),
+            },
+          })
+          .eq('id', item.id);
+
+        // Record escalation in event ledger
+        await recordLedgerEntry(supabase, {
+          eventId: syntheticEvent.id,
+          eventType: item.task_type,
+          handlerName: 'escalation-threshold',
+          status: 'success',
+          attempts: 1,
+          metadata: {
+            source: 'escalation_threshold',
+            original_queue_id: item.id,
+            queue_age_ms: Date.now() - new Date(item.created_at).getTime(),
+            threshold_ms: thresholdMs,
+          },
+        });
+
+        result.escalated++;
+        logger.log(`[EventRouter] Escalated PRIORITY_QUEUE → EVENT: ${item.task_type} (queue id ${item.id}, age ${Math.round((Date.now() - new Date(item.created_at).getTime()) / 60000)}min)`);
+      }
+    } catch (err) {
+      result.errors.push(`Escalation failed for ${item.id}: ${err.message}`);
+    }
+  }
+
+  return result;
+}
+
+/**
  * Enqueue an event into sub_agent_queue with urgent priority and preemption.
  * Used by PRIORITY_QUEUE routing mode for governance signals.
  * @param {object} supabase

--- a/tests/unit/gap-014/escalation-threshold.test.js
+++ b/tests/unit/gap-014/escalation-threshold.test.js
@@ -1,0 +1,92 @@
+/**
+ * Tests for checkEscalationThreshold — PRIORITY_QUEUE age-based escalation to EVENT
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-014 (A04: event_rounds_priority_queue_work_routing)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { checkEscalationThreshold, ESCALATION_THRESHOLD_MS } from '../../../lib/eva/event-bus/event-router.js';
+
+const silentLogger = { warn() {}, info() {}, error() {}, debug() {}, log() {} };
+
+function createMockSupabase(staleItems = [], errors = {}) {
+  const updates = [];
+  const inserts = [];
+
+  return {
+    _updates: updates,
+    _inserts: inserts,
+    from(table) {
+      return {
+        select(cols) {
+          return {
+            eq(col, val) { return this; },
+            lt(col, val) { return this; },
+            order(col, opts) { return this; },
+            limit(n) {
+              if (errors.query) return Promise.resolve({ data: null, error: { message: errors.query } });
+              return Promise.resolve({ data: staleItems, error: null });
+            },
+            single() { return Promise.resolve({ data: null, error: null }); },
+          };
+        },
+        update(payload) {
+          updates.push({ table, payload });
+          return {
+            eq(col, val) {
+              return Promise.resolve({ error: null });
+            },
+          };
+        },
+        insert(payload) {
+          inserts.push({ table, payload });
+          return {
+            select() {
+              return {
+                single() {
+                  return Promise.resolve({ data: { id: 'mock-queue-id' }, error: null });
+                },
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('checkEscalationThreshold (GAP-014)', () => {
+  it('exports ESCALATION_THRESHOLD_MS as 30 minutes', () => {
+    expect(ESCALATION_THRESHOLD_MS).toBe(30 * 60 * 1000);
+  });
+
+  it('returns zero counts when no stale items found', async () => {
+    const supabase = createMockSupabase([]);
+    const result = await checkEscalationThreshold(supabase, { logger: silentLogger });
+    expect(result.checked).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns error when no supabase client provided', async () => {
+    const result = await checkEscalationThreshold(null, { logger: silentLogger });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/No supabase client/);
+  });
+
+  it('returns error on query failure', async () => {
+    const supabase = createMockSupabase([], { query: 'connection refused' });
+    const result = await checkEscalationThreshold(supabase, { logger: silentLogger });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/Query failed/);
+  });
+
+  it('accepts configurable threshold', async () => {
+    const supabase = createMockSupabase([]);
+    const result = await checkEscalationThreshold(supabase, {
+      thresholdMs: 60 * 60 * 1000, // 1 hour
+      logger: silentLogger,
+    });
+    expect(result.checked).toBe(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/tests/unit/gap-014/event-router-exports.test.js
+++ b/tests/unit/gap-014/event-router-exports.test.js
@@ -1,0 +1,44 @@
+/**
+ * Tests for event-router.js exports added by GAP-014
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-014 (A04)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  checkEscalationThreshold,
+  ESCALATION_THRESHOLD_MS,
+  classifyRoutingMode,
+  ROUTING_MODES,
+} from '../../../lib/eva/event-bus/event-router.js';
+
+describe('event-router GAP-014 exports', () => {
+  it('exports checkEscalationThreshold as a function', () => {
+    expect(typeof checkEscalationThreshold).toBe('function');
+  });
+
+  it('exports ESCALATION_THRESHOLD_MS as a number', () => {
+    expect(typeof ESCALATION_THRESHOLD_MS).toBe('number');
+    expect(ESCALATION_THRESHOLD_MS).toBeGreaterThan(0);
+  });
+
+  it('classifyRoutingMode routes governance events to PRIORITY_QUEUE', () => {
+    expect(classifyRoutingMode('guardrail.violated', {})).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(classifyRoutingMode('chairman.decision_required', {})).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(classifyRoutingMode('gate.blocked', {})).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+  });
+
+  it('classifyRoutingMode routes critical payload to PRIORITY_QUEUE', () => {
+    expect(classifyRoutingMode('custom.event', { priority: 'critical' })).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+    expect(classifyRoutingMode('custom.event', { urgent: true })).toBe(ROUTING_MODES.PRIORITY_QUEUE);
+  });
+
+  it('classifyRoutingMode routes standard events to EVENT', () => {
+    expect(classifyRoutingMode('stage.completed', {})).toBe(ROUTING_MODES.EVENT);
+    expect(classifyRoutingMode('decision.submitted', {})).toBe(ROUTING_MODES.EVENT);
+  });
+
+  it('classifyRoutingMode routes round events to ROUND', () => {
+    expect(classifyRoutingMode('round.daily', {})).toBe(ROUTING_MODES.ROUND);
+    expect(classifyRoutingMode('cadence.weekly', {})).toBe(ROUTING_MODES.ROUND);
+  });
+});

--- a/tests/unit/gap-014/migration-validation.test.js
+++ b/tests/unit/gap-014/migration-validation.test.js
@@ -1,0 +1,84 @@
+/**
+ * Tests for GAP-014 SQL migration content validation
+ * SD-MAN-GEN-CORRECTIVE-VISION-GAP-014
+ *
+ * Validates the migration SQL contains the expected changes:
+ *   1. blocking column ADD COLUMN IF NOT EXISTS
+ *   2. v_chairman_pending_decisions with SLA sort
+ *   3. select_schedulable_ventures with computed priority_score
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const migrationPath = path.resolve('database/migrations/20260301_gap014_chairman_routing_polish.sql');
+const sql = fs.readFileSync(migrationPath, 'utf8');
+
+describe('GAP-014 migration SQL validation', () => {
+  // Change 1: blocking column
+  it('adds blocking column with DEFAULT false', () => {
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS blocking BOOLEAN DEFAULT false/i);
+  });
+
+  it('adds COMMENT on blocking column', () => {
+    expect(sql).toMatch(/COMMENT ON COLUMN chairman_decisions\.blocking/i);
+  });
+
+  it('adds index on blocking column', () => {
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS.*idx_chairman_decisions_blocking/i);
+  });
+
+  // Change 2: v_chairman_pending_decisions SLA sort
+  it('creates view v_chairman_pending_decisions', () => {
+    expect(sql).toMatch(/CREATE OR REPLACE VIEW v_chairman_pending_decisions/i);
+  });
+
+  it('includes sla_deadline_at column', () => {
+    expect(sql).toMatch(/sla_deadline_at/i);
+  });
+
+  it('includes sla_remaining_seconds column', () => {
+    expect(sql).toMatch(/sla_remaining_seconds/i);
+  });
+
+  it('sorts by SLA remaining ascending', () => {
+    expect(sql).toMatch(/ASC NULLS LAST/i);
+  });
+
+  it('includes SLA config values matching chairman-sla-enforcer.js', () => {
+    // gate_decision: 4h, budget_review: 2h, advisory: 24h
+    expect(sql).toMatch(/gate_decision.*4/i);
+    expect(sql).toMatch(/budget_review.*2/i);
+    expect(sql).toMatch(/advisory.*24/i);
+  });
+
+  it('includes blocking column in view output', () => {
+    expect(sql).toMatch(/cd\.blocking/i);
+  });
+
+  // Change 3: select_schedulable_ventures computed priority
+  it('creates function select_schedulable_ventures', () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION select_schedulable_ventures/i);
+  });
+
+  it('does NOT use placeholder 0::NUMERIC', () => {
+    // The view should NOT have the old placeholder
+    const functionSection = sql.substring(sql.indexOf('CREATE OR REPLACE FUNCTION select_schedulable_ventures'));
+    expect(functionSection).not.toMatch(/0::NUMERIC AS priority_score.*placeholder/i);
+  });
+
+  it('uses weighted formula for priority_score', () => {
+    expect(sql).toMatch(/0\.4\s*\*\s*s\.blocking_age_factor/i);
+    expect(sql).toMatch(/0\.3\s*\*\s*s\.health_factor/i);
+    expect(sql).toMatch(/0\.3\s*\*\s*s\.fifo_factor/i);
+  });
+
+  it('includes health_status in lockable CTE', () => {
+    expect(sql).toMatch(/v\.health_status/i);
+  });
+
+  it('orders by priority_score descending', () => {
+    expect(sql).toMatch(/ORDER BY.*priority_score.*DESC/is);
+  });
+});


### PR DESCRIPTION
## Summary
- **v_chairman_pending_decisions** now sorts by SLA-remaining ascending (most urgent/overdue decisions first) with configurable SLA hours per decision_type
- **select_schedulable_ventures** replaces placeholder `0::NUMERIC` with weighted composite priority formula: blocking_age (40%) + health (30%) + FIFO (30%)
- **checkEscalationThreshold()** added to event-router.js for automatic PRIORITY_QUEUE → EVENT escalation when items exceed configurable age threshold (default 30min)
- **blocking/decision_type columns** formalized on chairman_decisions with index and documentation comments
- Migration applied to Supabase, 25 unit tests validate all changes

## Test plan
- [x] 14 migration SQL validation tests pass (migration-validation.test.js)
- [x] 5 escalation threshold tests pass (escalation-threshold.test.js)
- [x] 6 event-router export tests pass (event-router-exports.test.js)
- [x] Migration applied to Supabase and verified (view, function, columns, index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)