### PR TITLE
feat: Event Bus Integration Hardening (GAP-026)

### DIFF
--- a/lib/eva/event-bus/index.js
+++ b/lib/eva/event-bus/index.js
@@ -9,7 +9,8 @@
 
 import { registerHandler, getHandler, getHandlers, listRegisteredTypes, getHandlerCount, clearHandlers, getRegistryCounts } from './handler-registry.js';
 import { processEvent, replayDLQEntry } from './event-router.js';
-import { registerDefaultSchemas, clearSchemas, listSchemas, getSchemaCount, initPersistence } from './event-schema-registry.js';
+import { registerDefaultSchemas, clearSchemas, listSchemas, getSchemaCount, initPersistence, loadSchemasFromDB, syncSchemasToDB } from './event-schema-registry.js';
+import { registerHookObserver, getHookObserverCount, clearHookObservers } from './vision-events.js';
 import { handleStageCompleted } from './handlers/stage-completed.js';
 import { handleDecisionSubmitted } from './handlers/decision-submitted.js';
 import { handleGateEvaluated } from './handlers/gate-evaluated.js';
@@ -137,9 +138,15 @@ export async function initializeEventBus(supabase) {
     singleton: true,
   });
 
-  // --- Schema Registry: initialize persistence + register default schemas ---
+  // --- Schema Registry: DB load → defaults → sync (GAP-026: FR-001, FR-004) ---
   initPersistence(supabase);
+  const dbLoadResult = await loadSchemasFromDB(supabase);
+  const schemaSource = dbLoadResult.loaded > 0 ? 'database' : 'in-memory';
   registerDefaultSchemas();
+  // Write-behind: persist any new code-defined schemas to DB (fire-and-forget)
+  syncSchemasToDB(supabase).catch((err) => {
+    console.warn(`[EventBus] Schema sync failed: ${err.message}`);
+  });
 
   // --- Vision handlers (multi-subscriber, fire-and-forget) ---
   // Each registerVision*Handlers() function is internally idempotent.
@@ -151,10 +158,26 @@ export async function initializeEventBus(supabase) {
   registerLeoPatternResolvedHandlers();
   registerFeedbackQualityUpdatedHandlers();
 
+  // --- Default governance hook observer (GAP-026: FR-002) ---
+  // Bridge vision events into governance system for audit/observability.
+  // Only register if no observers are already registered (idempotent).
+  if (getHookObserverCount() === 0) {
+    registerHookObserver(function governanceObserver(eventType, payload) {
+      console.log(`[GovernanceHook] ${eventType} — sd: ${payload?.sdKey || payload?.scoreId || 'n/a'}`);
+    });
+  }
+
   _initialized = true;
 
   const types = listRegisteredTypes();
-  return { registered: true, handlerCount: getHandlerCount(), types, schemaCount: getSchemaCount() };
+  return {
+    registered: true,
+    handlerCount: getHandlerCount(),
+    types,
+    schemaCount: getSchemaCount(),
+    schemaSource,
+    hookObserverCount: getHookObserverCount(),
+  };
 }
 
 /**
@@ -180,6 +203,7 @@ export {
 // Schema registry
 export { registerDefaultSchemas, clearSchemas, listSchemas, getSchemaCount } from './event-schema-registry.js';
 export { registerSchema, validate as validateEventSchema, getSchema, hasSchema } from './event-schema-registry.js';
+export { loadSchemasFromDB, syncSchemasToDB } from './event-schema-registry.js';
 
 // Routing strategy
 export { loadRoutingStrategy, getRoutingClassifier, invalidateCache as invalidateRoutingCache } from './routing-strategy-loader.js';
@@ -191,6 +215,9 @@ export {
   clearVisionSubscribers,
   getSubscriberCount,
   VISION_EVENTS,
+  registerHookObserver,
+  getHookObserverCount,
+  clearHookObservers,
 } from './vision-events.js';
 
 // Vision handler registration (for callers that register outside initializeEventBus)


### PR DESCRIPTION
## Summary
- Add `loadSchemasFromDB()` call during event bus init to load persisted schemas from `eva_event_schemas` table at startup (FR-001)
- Register default governance hook observer for vision events audit/observability (FR-002)
- Add `syncSchemasToDB()` write-behind call after `registerDefaultSchemas()` to persist new schemas (FR-004)
- Enhance `eva-events-status.js` with `schema_source`, `hook_observer_count`, and `mandatory_emit_paths` fields (FR-005)
- Export `loadSchemasFromDB`, `syncSchemasToDB`, `registerHookObserver`, `getHookObserverCount`, `clearHookObservers` from event bus index

## Test plan
- [x] All 54 unit tests pass (event-bus-handlers, vision-event-bus, event-bus-a05-persistence)
- [x] Module exports verified (5 new exports present)
- [x] Backward compatible — existing callers unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)