### PR TITLE
fix: auto-persist evidence scores in heal loop

### DIFF
--- a/scripts/eva/heal-command.mjs
+++ b/scripts/eva/heal-command.mjs
@@ -47,7 +47,7 @@ function cmdVision(args) {
     const evidenceScript = join(__dirname, 'vision-evidence-scorer.js');
     const passthrough = args.slice(1).filter(a => a !== 'score');
     try {
-      execFileSync('node', [evidenceScript, ...passthrough], { stdio: 'inherit' });
+      execFileSync('node', [evidenceScript, '--persist', ...passthrough], { stdio: 'inherit' });
     } catch (err) {
       process.exit(err.status || 1);
     }


### PR DESCRIPTION
## Summary
- Add `--persist` flag to evidence scorer invocation in `heal-command.mjs`
- Without this, the heal loop's `vision score` route never emits `HEAL_STATUS` signals, breaking auto-chain to corrective SD generation

## Test plan
- [ ] Run `node scripts/eva/heal-command.mjs vision score` and verify it persists to `eva_vision_scores` with `scored_by: 'evidence-scorer'`
- [ ] Verify `HEAL_STATUS=PASS` or `HEAL_STATUS=NEEDS_CORRECTION` is emitted in output
- [ ] Run with `--llm` flag to verify LLM fallback path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)