### PR TITLE
feat: add SD completion validation gates + orchestrator from vision/arch

### DIFF
--- a/scripts/create-orchestrator-from-plan.js
+++ b/scripts/create-orchestrator-from-plan.js
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+
+/**
+ * Orchestrator + Children Creator from Vision/Architecture Plans
+ *
+ * Creates an orchestrator SD with children derived from architecture plan
+ * implementation phases. Propagates vision_key and arch_key to all SDs,
+ * injects traceable success metrics, and scores at conception.
+ *
+ * Usage:
+ *   node scripts/create-orchestrator-from-plan.js \
+ *     --vision-key VISION-EHG-L2-001 \
+ *     --arch-key ARCH-EHG-001 \
+ *     --title "Orchestrator Title" \
+ *     [--auto-children]
+ *     [--dry-run]
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+import { inheritStrategicFields, inferSDType } from './modules/child-sd-template.js';
+import { generateTraceableMetrics, mapDimensionsToPhases } from './modules/vision-arch-traceability.js';
+import { scoreSDAtConception } from './leo-create-sd.js';
+
+dotenv.config();
+
+/**
+ * Parse architecture plan content for implementation phases.
+ */
+function parsePhases(content) {
+  if (!content) return [];
+
+  const lines = content.split('\n');
+  const phases = [];
+  let current = null;
+
+  for (const line of lines) {
+    const match = line.match(/^##?\s*(Phase|Implementation Phase|Step)\s+(\d+)[:\s-]*(.*)/i);
+    if (match) {
+      if (current) phases.push(current);
+      current = {
+        number: parseInt(match[2], 10),
+        title: match[3].trim() || `Phase ${match[2]}`,
+        description: '',
+        content: ''
+      };
+      continue;
+    }
+
+    if (current) {
+      current.content += line + '\n';
+      // First non-empty, non-header line becomes description
+      if (!current.description && line.trim() && !line.startsWith('#')) {
+        current.description = line.trim();
+      }
+    }
+  }
+
+  if (current) phases.push(current);
+  return phases;
+}
+
+/**
+ * Generate an SD key from title and type.
+ */
+function generateSDKey(title, suffix = '') {
+  const words = title.replace(/[^a-zA-Z0-9\s]/g, '').split(/\s+/).filter(Boolean);
+  const abbreviated = words.slice(0, 4).map(w => w.toUpperCase()).join('-');
+  return `SD-${abbreviated}${suffix}-001`;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  // Parse CLI args
+  const getArg = (flag) => {
+    const idx = args.indexOf(flag);
+    return idx !== -1 ? args[idx + 1] : null;
+  };
+
+  const visionKey = getArg('--vision-key');
+  const archKey = getArg('--arch-key');
+  const title = getArg('--title');
+  const autoChildren = args.includes('--auto-children');
+  const dryRun = args.includes('--dry-run');
+
+  if (!visionKey && !archKey) {
+    console.error('Error: At least one of --vision-key or --arch-key is required');
+    process.exit(1);
+  }
+  if (!title) {
+    console.error('Error: --title is required');
+    process.exit(1);
+  }
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  console.log('🏗️  Creating Orchestrator from Vision/Architecture Plan');
+  console.log('═'.repeat(60));
+  console.log(`   Title: ${title}`);
+  console.log(`   Vision Key: ${visionKey || 'N/A'}`);
+  console.log(`   Arch Key: ${archKey || 'N/A'}`);
+  console.log(`   Auto-Children: ${autoChildren}`);
+  console.log(`   Dry Run: ${dryRun}`);
+  console.log('');
+
+  // Load architecture plan for phase extraction
+  let phases = [];
+  let archPlan = null;
+  if (archKey) {
+    const { data, error } = await supabase
+      .from('eva_architecture_plans')
+      .select('plan_key, content, extracted_dimensions')
+      .eq('plan_key', archKey)
+      .single();
+
+    if (error || !data) {
+      console.error(`Error: Architecture plan '${archKey}' not found: ${error?.message || 'no record'}`);
+      process.exit(1);
+    }
+    archPlan = data;
+    phases = parsePhases(data.content);
+    console.log(`   📋 Found ${phases.length} implementation phase(s) in architecture plan`);
+  }
+
+  // Load vision document
+  let visionDoc = null;
+  if (visionKey) {
+    const { data, error } = await supabase
+      .from('eva_vision_documents')
+      .select('vision_key, extracted_dimensions')
+      .eq('vision_key', visionKey)
+      .single();
+
+    if (error || !data) {
+      console.warn(`   ⚠️  Vision document '${visionKey}' not found: ${error?.message || 'no record'}`);
+    } else {
+      visionDoc = data;
+      console.log(`   📄 Vision document loaded: ${visionDoc.extracted_dimensions?.length || 0} dimensions`);
+    }
+  }
+
+  // Generate traceable metrics
+  const { visionMetrics, archMetrics } = await generateTraceableMetrics(
+    supabase, visionKey, archKey
+  );
+  const allMetrics = [...visionMetrics, ...archMetrics];
+  console.log(`   📊 Generated ${allMetrics.length} traceable success metric(s)`);
+
+  // Create orchestrator SD
+  const orchestratorId = randomUUID();
+  const orchestratorKey = generateSDKey(title, '-ORCH');
+
+  const orchestratorSD = {
+    id: orchestratorId,
+    sd_key: orchestratorKey,
+    title,
+    description: `Orchestrator for ${title}. Created from vision/architecture plan.`,
+    sd_type: 'orchestrator',
+    category: 'feature',
+    status: 'draft',
+    current_phase: 'LEAD_APPROVAL',
+    priority: 'high',
+    scope: `Orchestrator coordinating ${phases.length} implementation phase(s)`,
+    rationale: `Auto-generated from vision (${visionKey || 'N/A'}) and architecture (${archKey || 'N/A'}) plans`,
+    success_metrics: allMetrics,
+    metadata: {
+      is_orchestrator: true,
+      vision_key: visionKey,
+      arch_key: archKey,
+      auto_generated: true,
+      child_count: phases.length
+    },
+    key_changes: JSON.stringify(phases.map(p => `Phase ${p.number}: ${p.title}`)),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString()
+  };
+
+  if (dryRun) {
+    console.log('\n📋 DRY RUN — Orchestrator SD:');
+    console.log(JSON.stringify(orchestratorSD, null, 2));
+  } else {
+    const { error: orchError } = await supabase
+      .from('strategic_directives_v2')
+      .insert(orchestratorSD);
+
+    if (orchError) {
+      console.error(`Error creating orchestrator: ${orchError.message}`);
+      process.exit(1);
+    }
+    console.log(`\n   ✅ Orchestrator created: ${orchestratorKey} (${orchestratorId})`);
+  }
+
+  // Create children from phases
+  if (phases.length > 0 && (autoChildren || !archPlan)) {
+    console.log(`\n📦 Creating ${phases.length} child SD(s)...`);
+    console.log('-'.repeat(40));
+
+    // Map dimensions to phases for targeted metrics
+    const allDimensions = [
+      ...(visionDoc?.extracted_dimensions || []),
+      ...(archPlan?.extracted_dimensions || [])
+    ];
+    const dimensionMap = mapDimensionsToPhases(allDimensions, phases);
+
+    for (const phase of phases) {
+      const childId = randomUUID();
+      const suffix = `-${String.fromCharCode(64 + phase.number)}`; // -A, -B, -C...
+      const childKey = `${orchestratorKey}${suffix}`;
+      const childType = inferSDType(phase.title, phase.description || '', phase.content || '');
+
+      // Inherit strategic fields from orchestrator
+      const inherited = inheritStrategicFields(orchestratorSD, {
+        phaseNumber: phase.number,
+        phaseTitle: phase.title,
+        phaseObjective: phase.description
+      });
+
+      // Build phase-specific metrics from dimension mapping
+      const phaseDims = dimensionMap.get(phases.indexOf(phase)) || [];
+      const phaseMetrics = phaseDims.map(dim => ({
+        metric: `${dim.name} implementation`,
+        target: '>=90%',
+        measurement: 'Dimension coverage',
+        source: `${archKey || visionKey}:${dim.name}`,
+        traceability: archKey ? 'arch_dimension' : 'vision_dimension'
+      }));
+
+      const childSD = {
+        id: childId,
+        sd_key: childKey,
+        title: `Phase ${phase.number}: ${phase.title}`,
+        description: phase.description || `Implementation phase ${phase.number}`,
+        sd_type: childType,
+        category: orchestratorSD.category,
+        status: 'draft',
+        current_phase: 'LEAD_APPROVAL',
+        priority: orchestratorSD.priority,
+        parent_sd_id: orchestratorId,
+        scope: phase.content?.trim().slice(0, 2000) || phase.description || '',
+        rationale: `Phase ${phase.number} of ${title}`,
+        success_metrics: phaseMetrics.length > 0 ? phaseMetrics : inherited.success_metrics || [],
+        key_principles: inherited.key_principles || [],
+        strategic_objectives: inherited.strategic_objectives || [],
+        success_criteria: inherited.success_criteria || [],
+        risks: inherited.risks || [],
+        metadata: {
+          vision_key: visionKey,
+          arch_key: archKey,
+          phase_number: phase.number,
+          parent_orchestrator: orchestratorKey,
+          auto_generated: true
+        },
+        key_changes: JSON.stringify([phase.title]),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
+      };
+
+      if (dryRun) {
+        console.log(`\n   📋 DRY RUN — Child ${childKey}:`);
+        console.log(`      Type: ${childType}, Metrics: ${phaseMetrics.length}`);
+      } else {
+        const { error: childError } = await supabase
+          .from('strategic_directives_v2')
+          .insert(childSD);
+
+        if (childError) {
+          console.error(`   ❌ Error creating child ${childKey}: ${childError.message}`);
+        } else {
+          console.log(`   ✅ Child ${childKey}: ${phase.title} (type: ${childType})`);
+        }
+      }
+    }
+  } else if (phases.length > 0) {
+    console.log(`\n   ℹ️  ${phases.length} phases found but --auto-children not specified`);
+    console.log('   Run with --auto-children to create child SDs automatically');
+  }
+
+  // Score orchestrator at conception
+  if (!dryRun) {
+    console.log('\n📊 Scoring orchestrator at conception...');
+    try {
+      await scoreSDAtConception(orchestratorKey, title, orchestratorSD.description, supabase, {
+        visionKey,
+        archKey
+      });
+      console.log('   ✅ Conception score recorded');
+    } catch (err) {
+      console.warn(`   ⚠️  Conception scoring failed (non-fatal): ${err.message}`);
+    }
+  }
+
+  console.log('\n' + '═'.repeat(60));
+  console.log('✅ Orchestrator creation complete');
+  console.log(`   Key: ${orchestratorKey}`);
+  console.log(`   Children: ${phases.length}`);
+  if (!dryRun) {
+    console.log(`\n   Next: node scripts/unified-handoff-system.js execute LEAD-TO-PLAN ${orchestratorKey}`);
+  }
+}
+
+// Only run CLI when invoked directly
+const _isMainModule = import.meta.url === `file://${process.argv[1]}` ||
+                      import.meta.url === `file:///${process.argv[1]?.replace(/\\/g, '/')}`;
+if (_isMainModule) {
+  main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+  });
+}
+
+export { parsePhases, generateSDKey };

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1609,6 +1609,23 @@ Note: SD keys starting with QF- will prompt to use create-quick-fix.js instead.
       const archKeyIdx = args.indexOf('--arch-key');
       const archKey = archKeyIdx !== -1 ? args[archKeyIdx + 1] : null;
 
+      // Advisory: suggest orchestrator creation when both vision and arch keys provided
+      if (visionKey && archKey) {
+        try {
+          const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+          const { data: archPlan } = await sb
+            .from('eva_architecture_plans')
+            .select('content')
+            .eq('plan_key', archKey)
+            .single();
+          if (archPlan?.content && /^##?\s*(Phase|Implementation Phase|Step)\s+\d/im.test(archPlan.content)) {
+            console.log('\n💡 Advisory: Architecture plan has implementation phases.');
+            console.log('   Consider using the orchestrator creator for multi-phase work:');
+            console.log(`   node scripts/create-orchestrator-from-plan.js --vision-key ${visionKey} --arch-key ${archKey} --title "${title}" --auto-children\n`);
+          }
+        } catch { /* Advisory only — continue regardless */ }
+      }
+
       const sdKey = await generateSDKey({ source, type, title, venturePrefix });
 
       await createSD({

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/acceptance-criteria-validation.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/acceptance-criteria-validation.js
@@ -1,0 +1,174 @@
+/**
+ * Acceptance Criteria Validation Gate for PLAN-TO-LEAD
+ *
+ * Validates that user stories have acceptance criteria defined AND that
+ * those criteria have been verified (via validation_status, story_test_mappings,
+ * or e2e_test_status). Prevents completion of SDs where acceptance criteria
+ * exist on paper but were never actually validated.
+ *
+ * BLOCKING gate — score >= 60 AND no story scores 0.
+ */
+
+export function createAcceptanceCriteriaValidationGate(supabase) {
+  return {
+    name: 'ACCEPTANCE_CRITERIA_VALIDATION',
+    validator: async (ctx) => {
+      console.log('\n✅ ACCEPTANCE CRITERIA VALIDATION GATE');
+      console.log('-'.repeat(50));
+
+      const sdUuid = ctx.sd?.id || ctx.sdId;
+      const _sdKey = ctx.sd?.sd_key || ctx.sdId;
+      const sdType = (ctx.sd?.sd_type || 'feature').toLowerCase();
+
+      // ORCHESTRATOR BYPASS
+      const { data: childSDs } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sdUuid);
+
+      if (childSDs && childSDs.length > 0) {
+        console.log(`   ℹ️  Parent orchestrator SD (${childSDs.length} children) — bypassing`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: ['Orchestrator SD — acceptance criteria deferred to children'],
+          details: { is_orchestrator: true, child_count: childSDs.length }
+        };
+      }
+
+      // SD TYPE CHECK — does this type require user stories?
+      const { data: profile } = await supabase
+        .from('sd_type_validation_profiles')
+        .select('requires_user_stories')
+        .eq('sd_type', sdType)
+        .single();
+
+      const storiesRequired = profile?.requires_user_stories ?? true;
+      if (!storiesRequired) {
+        console.log(`   ℹ️  SD type '${sdType}' does not require user stories — bypassing`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: [`SD type '${sdType}' does not require acceptance criteria`],
+          details: { sd_type: sdType, stories_required: false }
+        };
+      }
+
+      // Query user stories
+      const { data: stories, error: storyError } = await supabase
+        .from('user_stories')
+        .select('id, title, status, validation_status, acceptance_criteria, e2e_test_status, e2e_test_path')
+        .eq('sd_id', sdUuid);
+
+      if (storyError) {
+        console.log(`   ⚠️  User story query error: ${storyError.message}`);
+        return {
+          passed: false, score: 0, max_score: 100,
+          issues: [`Database error: ${storyError.message}`],
+          warnings: [], remediation: 'Check database connectivity and retry'
+        };
+      }
+
+      // No stories found — pass (USER_STORY_EXISTENCE_GATE handles that case)
+      if (!stories || stories.length === 0) {
+        console.log('   ℹ️  No user stories found — deferring to USER_STORY_EXISTENCE_GATE');
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: ['No user stories to validate acceptance criteria against'],
+          details: { story_count: 0 }
+        };
+      }
+
+      // Check for test mappings
+      const storyIds = stories.map(s => s.id);
+      const { data: testMappings } = await supabase
+        .from('story_test_mappings')
+        .select('story_id')
+        .in('story_id', storyIds);
+
+      const storiesWithTests = new Set((testMappings || []).map(m => m.story_id));
+
+      // Score each story
+      const storyScores = [];
+      for (const story of stories) {
+        const hasAcceptanceCriteria = story.acceptance_criteria &&
+          (Array.isArray(story.acceptance_criteria)
+            ? story.acceptance_criteria.length > 0
+            : typeof story.acceptance_criteria === 'string' && story.acceptance_criteria.trim().length > 0);
+
+        if (!hasAcceptanceCriteria) {
+          storyScores.push({ story, score: 0, reason: 'Missing acceptance criteria' });
+          continue;
+        }
+
+        const isValidated = story.validation_status === 'validated' ||
+                           story.status === 'completed';
+        const hasTestEvidence = storiesWithTests.has(story.id) ||
+                               (story.e2e_test_status && ['passing', 'created'].includes(story.e2e_test_status));
+
+        if (isValidated && hasTestEvidence) {
+          storyScores.push({ story, score: 100, reason: 'Validated with test evidence' });
+        } else if (isValidated) {
+          storyScores.push({ story, score: 70, reason: 'Validated but no test mapping' });
+        } else {
+          storyScores.push({ story, score: 50, reason: 'Has criteria but not validated' });
+        }
+      }
+
+      // Calculate overall score
+      const overallScore = Math.round(
+        storyScores.reduce((sum, s) => sum + s.score, 0) / storyScores.length
+      );
+      const hasZeroScore = storyScores.some(s => s.score === 0);
+      const passed = overallScore >= 60 && !hasZeroScore;
+
+      // Build issues and warnings
+      const issues = [];
+      const warnings = [];
+
+      for (const { story, score, reason } of storyScores) {
+        const label = `${story.title || story.id}: ${reason} (score: ${score})`;
+        if (score === 0) {
+          issues.push(label);
+          console.log(`   ❌ ${label}`);
+        } else if (score <= 70) {
+          warnings.push(label);
+          console.log(`   ⚠️  ${label}`);
+        } else {
+          console.log(`   ✅ ${label}`);
+        }
+      }
+
+      console.log(`\n   Overall Score: ${overallScore}/100 (threshold: 60, no zeros allowed)`);
+      console.log(`   ${passed ? '✅ PASSED' : '❌ FAILED'}`);
+
+      if (!passed) {
+        console.log('\n   REMEDIATION:');
+        if (hasZeroScore) {
+          console.log('   - Add acceptance_criteria to all user stories');
+        }
+        if (overallScore < 60) {
+          console.log('   - Validate stories and add test evidence');
+        }
+      }
+
+      return {
+        passed,
+        score: overallScore,
+        max_score: 100,
+        issues,
+        warnings,
+        ...((!passed) && {
+          remediation: 'Add acceptance criteria to all stories and validate them with test evidence'
+        }),
+        details: {
+          story_count: stories.length,
+          story_scores: storyScores.map(({ story, score, reason }) => ({
+            id: story.id, title: story.title, score, reason
+          })),
+          overall_score: overallScore,
+          has_zero_score: hasZeroScore
+        }
+      };
+    },
+    required: true
+  };
+}

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/architecture-plan-validation.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/architecture-plan-validation.js
@@ -1,0 +1,218 @@
+/**
+ * Architecture Plan Validation Gate for PLAN-TO-LEAD
+ *
+ * Validates that architecture plan dimensions have been addressed by the SD.
+ * Checks SD description, scope, key_changes, user stories, and vision scores
+ * for evidence of dimension coverage.
+ *
+ * ADVISORY gate — always passes, but reports uncovered dimensions as warnings.
+ */
+
+/**
+ * Check if text contains references to a dimension name.
+ * Uses word-boundary matching to avoid false positives.
+ */
+function textReferencesName(text, dimensionName) {
+  if (!text || !dimensionName) return false;
+  const normalizedText = text.toLowerCase();
+  const normalizedName = dimensionName.toLowerCase();
+
+  // Check exact match
+  if (normalizedText.includes(normalizedName)) return true;
+
+  // Check individual words (for multi-word dimensions like "data_pipeline")
+  const words = normalizedName.replace(/[_-]/g, ' ').split(/\s+/);
+  if (words.length > 1) {
+    return words.every(word => normalizedText.includes(word));
+  }
+
+  return false;
+}
+
+export function createArchitecturePlanValidationGate(supabase) {
+  return {
+    name: 'ARCHITECTURE_PLAN_VALIDATION',
+    validator: async (ctx) => {
+      console.log('\n🏗️  ARCHITECTURE PLAN VALIDATION GATE (Advisory)');
+      console.log('-'.repeat(50));
+
+      const sdUuid = ctx.sd?.id || ctx.sdId;
+      const sdKey = ctx.sd?.sd_key || ctx.sdId;
+
+      // ORCHESTRATOR BYPASS
+      const { data: childSDs } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sdUuid);
+
+      if (childSDs && childSDs.length > 0) {
+        console.log(`   ℹ️  Orchestrator SD (${childSDs.length} children) — bypassing`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: ['Orchestrator SD — architecture validation deferred to children'],
+          details: { is_orchestrator: true }
+        };
+      }
+
+      // Read metadata for arch_key
+      let metadata = ctx.sd?.metadata;
+      if (!metadata) {
+        const { data: sdRecord } = await supabase
+          .from('strategic_directives_v2')
+          .select('metadata')
+          .eq('id', sdUuid)
+          .single();
+        metadata = sdRecord?.metadata;
+      }
+
+      const archKey = metadata?.arch_key;
+      if (!archKey) {
+        console.log('   ⚠️  No arch_key in SD metadata — skipping architecture validation');
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [],
+          warnings: ['No arch_key in SD metadata — architecture plan validation skipped'],
+          details: { has_arch_key: false }
+        };
+      }
+
+      console.log(`   Architecture Key: ${archKey}`);
+
+      // Query architecture plan
+      const { data: archPlan, error: archError } = await supabase
+        .from('eva_architecture_plans')
+        .select('plan_key, extracted_dimensions, content')
+        .eq('plan_key', archKey)
+        .single();
+
+      if (archError || !archPlan) {
+        console.log(`   ⚠️  Architecture plan not found: ${archError?.message || 'no record'}`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [],
+          warnings: [`Architecture plan '${archKey}' not found in database`],
+          details: { arch_key: archKey, plan_found: false }
+        };
+      }
+
+      const dimensions = archPlan.extracted_dimensions;
+      if (!dimensions || !Array.isArray(dimensions) || dimensions.length === 0) {
+        console.log('   ⚠️  Architecture plan has no extracted dimensions');
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [],
+          warnings: ['Architecture plan has no extracted_dimensions to validate against'],
+          details: { arch_key: archKey, dimensions_count: 0 }
+        };
+      }
+
+      console.log(`   Found ${dimensions.length} architecture dimension(s)\n`);
+
+      // Gather SD text content for dimension matching
+      const sd = ctx.sd || {};
+      const sdText = [
+        sd.description || '',
+        sd.scope || '',
+        ...(Array.isArray(sd.key_changes) ? sd.key_changes : []),
+        sd.title || ''
+      ].join(' ');
+
+      // Fetch user stories for text matching
+      const { data: stories } = await supabase
+        .from('user_stories')
+        .select('title, acceptance_criteria')
+        .eq('sd_id', sdUuid);
+
+      const storyText = (stories || [])
+        .map(s => `${s.title || ''} ${JSON.stringify(s.acceptance_criteria || '')}`)
+        .join(' ');
+
+      // Fetch latest vision scores for dimension-level scores
+      const { data: visionScores } = await supabase
+        .from('eva_vision_scores')
+        .select('dimension_scores')
+        .eq('sd_id', sdKey)
+        .order('scored_at', { ascending: false })
+        .limit(1);
+
+      const dimensionScores = visionScores?.[0]?.dimension_scores || {};
+
+      // Evaluate each dimension
+      const results = [];
+      let totalWeightedScore = 0;
+      let totalWeight = 0;
+
+      for (const dim of dimensions) {
+        const name = dim.name || 'unnamed';
+        const weight = dim.weight || 1;
+        totalWeight += weight;
+
+        const inSD = textReferencesName(sdText, name);
+        const inStories = textReferencesName(storyText, name);
+
+        // Check vision score for this dimension
+        const dimScore = dimensionScores[name];
+        const hasVisionScore = dimScore != null && dimScore > 70;
+
+        const hasEvidence = inSD || inStories || hasVisionScore;
+        const evidenceSources = [];
+        if (inSD) evidenceSources.push('SD description/scope');
+        if (inStories) evidenceSources.push('user stories');
+        if (hasVisionScore) evidenceSources.push(`vision score: ${dimScore}`);
+
+        results.push({
+          name,
+          weight,
+          hasEvidence,
+          evidenceSources,
+          description: dim.description || '',
+          visionScore: dimScore
+        });
+
+        totalWeightedScore += hasEvidence ? weight : 0;
+
+        if (hasEvidence) {
+          console.log(`   ✅ ${name} (weight: ${weight}) — evidence: ${evidenceSources.join(', ')}`);
+        } else {
+          console.log(`   ⚠️  ${name} (weight: ${weight}) — no evidence found`);
+        }
+      }
+
+      const score = totalWeight > 0
+        ? Math.round((totalWeightedScore / totalWeight) * 100)
+        : 100;
+
+      const coveredCount = results.filter(r => r.hasEvidence).length;
+      const uncovered = results.filter(r => !r.hasEvidence);
+
+      console.log(`\n   Coverage: ${coveredCount}/${dimensions.length} dimensions (${score}%)`);
+
+      const warnings = uncovered.map(d =>
+        `Architecture dimension '${d.name}' (weight: ${d.weight}) has no evidence in SD scope, stories, or vision scores${d.description ? ` — expected: ${d.description}` : ''}`
+      );
+
+      if (warnings.length > 0) {
+        console.log(`   ⚠️  ${warnings.length} dimension(s) without evidence`);
+      } else {
+        console.log('   ✅ All architecture dimensions have evidence');
+      }
+
+      return {
+        passed: true, // Advisory — always passes
+        score,
+        max_score: 100,
+        issues: [],
+        warnings,
+        details: {
+          arch_key: archKey,
+          dimensions_total: dimensions.length,
+          dimensions_covered: coveredCount,
+          dimensions_uncovered: uncovered.length,
+          dimension_results: results,
+          weighted_score: score
+        }
+      };
+    },
+    required: true // Gate runs, but always passes (advisory)
+  };
+}

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
@@ -8,12 +8,12 @@
  * by catching gaps while context is fresh.
  *
  * - SD heal: BLOCKING — score must be >= threshold
- *   - Standard SDs: threshold from leo_config (default 80)
+ *   - Standard SDs: threshold from leo_config (default 93)
  *   - Corrective SDs: threshold from GRADE.A (93) via grade-scale.js
  * - Vision heal: ADVISORY — logged but does not block
  */
 
-const DEFAULT_HEAL_THRESHOLD = 80;
+const DEFAULT_HEAL_THRESHOLD = 93;
 const AUTO_HEAL_TIMEOUT_MS = 60_000; // 60 seconds
 
 /**

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
@@ -13,3 +13,7 @@ export { createTraceabilityGate, createWorkflowROIGate, requiresTraceabilityGate
 export { createUserStoryExistenceGate } from './user-story-existence.js';
 export { createDocumentationLinkValidationGate } from './documentation-link-validation.js';
 export { createHealBeforeCompleteGate } from './heal-before-complete.js';
+export { createAcceptanceCriteriaValidationGate } from './acceptance-criteria-validation.js';
+export { createSuccessMetricsAchievementGate } from './success-metrics-achievement.js';
+export { createVisionCompletionScoreGate } from './vision-completion-score.js';
+export { createArchitecturePlanValidationGate } from './architecture-plan-validation.js';

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-achievement.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-achievement.js
@@ -1,0 +1,214 @@
+/**
+ * Success Metrics Achievement Gate for PLAN-TO-LEAD
+ *
+ * Validates that SD success metrics have been measured (actual values populated)
+ * and that targets have been met. Prevents SDs from completing without
+ * demonstrating measurable outcomes.
+ *
+ * BLOCKING gate — score >= 70 AND no metric has empty actual value.
+ */
+
+/**
+ * Parse a numeric value from a metric string.
+ * Handles: "95%", ">=90%", "95", "3/5", "100ms"
+ * Returns null if not parseable.
+ */
+function parseMetricValue(value) {
+  if (value == null) return null;
+  const str = String(value).trim();
+  if (!str) return null;
+
+  // Handle percentage: "95%" or ">=90%"
+  const pctMatch = str.match(/([<>=]*)\s*([\d.]+)\s*%/);
+  if (pctMatch) return parseFloat(pctMatch[2]);
+
+  // Handle fraction: "3/5" → 60
+  const fracMatch = str.match(/^(\d+)\s*\/\s*(\d+)$/);
+  if (fracMatch) return (parseFloat(fracMatch[1]) / parseFloat(fracMatch[2])) * 100;
+
+  // Handle plain number
+  const num = parseFloat(str);
+  if (!isNaN(num)) return num;
+
+  return null;
+}
+
+/**
+ * Check if a comparison operator is met.
+ * Extracts operator from target string (>=, >, <=, <, or default >=).
+ */
+function meetsTarget(actual, target) {
+  if (actual == null || target == null) return null;
+
+  const actualNum = parseMetricValue(String(actual));
+  const targetStr = String(target).trim();
+
+  // Extract operator from target
+  const opMatch = targetStr.match(/^([<>=]+)/);
+  const operator = opMatch ? opMatch[1] : '>=';
+  const targetNum = parseMetricValue(targetStr);
+
+  if (actualNum == null || targetNum == null) return null;
+
+  switch (operator) {
+    case '>=': return actualNum >= targetNum;
+    case '>':  return actualNum > targetNum;
+    case '<=': return actualNum <= targetNum;
+    case '<':  return actualNum < targetNum;
+    case '=':
+    case '==': return actualNum === targetNum;
+    default:   return actualNum >= targetNum;
+  }
+}
+
+export function createSuccessMetricsAchievementGate(supabase) {
+  return {
+    name: 'SUCCESS_METRICS_ACHIEVEMENT',
+    validator: async (ctx) => {
+      console.log('\n📊 SUCCESS METRICS ACHIEVEMENT GATE');
+      console.log('-'.repeat(50));
+
+      const sdUuid = ctx.sd?.id || ctx.sdId;
+      const sdType = (ctx.sd?.sd_type || 'feature').toLowerCase();
+
+      // ORCHESTRATOR BYPASS
+      const { data: childSDs } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sdUuid);
+
+      if (childSDs && childSDs.length > 0) {
+        console.log(`   ℹ️  Parent orchestrator SD (${childSDs.length} children) — bypassing`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: ['Orchestrator SD — metrics deferred to children'],
+          details: { is_orchestrator: true, child_count: childSDs.length }
+        };
+      }
+
+      // SD TYPE CHECK — does this type require metrics?
+      const { data: profile } = await supabase
+        .from('sd_type_validation_profiles')
+        .select('requires_user_stories, description')
+        .eq('sd_type', sdType)
+        .single();
+
+      // Types without user stories typically don't have success metrics either
+      // (infrastructure, documentation, etc.)
+      if (profile && profile.requires_user_stories === false) {
+        console.log(`   ℹ️  SD type '${sdType}' does not require metrics — bypassing`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: [`SD type '${sdType}' does not require success metrics`],
+          details: { sd_type: sdType, metrics_required: false }
+        };
+      }
+
+      // Fetch SD success_metrics
+      const { data: sdRecord, error: sdError } = await supabase
+        .from('strategic_directives_v2')
+        .select('success_metrics')
+        .eq('id', sdUuid)
+        .single();
+
+      if (sdError) {
+        console.log(`   ⚠️  SD query error: ${sdError.message}`);
+        return {
+          passed: false, score: 0, max_score: 100,
+          issues: [`Database error: ${sdError.message}`],
+          warnings: [], remediation: 'Check database connectivity and retry'
+        };
+      }
+
+      const metrics = sdRecord?.success_metrics;
+
+      // No metrics defined — pass with warning (some SDs may legitimately lack them)
+      if (!metrics || !Array.isArray(metrics) || metrics.length === 0) {
+        console.log('   ⚠️  No success metrics defined on this SD');
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [],
+          warnings: ['No success metrics defined — consider adding measurable outcomes'],
+          details: { metrics_count: 0 }
+        };
+      }
+
+      console.log(`   Found ${metrics.length} success metric(s)\n`);
+
+      // Score each metric
+      const metricScores = [];
+      for (const metric of metrics) {
+        const name = metric.metric || metric.name || 'Unnamed metric';
+        const actual = metric.actual;
+        const target = metric.target;
+        const hasActual = actual != null && String(actual).trim() !== '';
+
+        if (!hasActual) {
+          metricScores.push({ name, score: 0, reason: 'No actual value recorded', target, actual });
+          console.log(`   ❌ ${name}: No actual value (target: ${target || 'N/A'})`);
+          continue;
+        }
+
+        const met = meetsTarget(actual, target);
+        if (met === true) {
+          metricScores.push({ name, score: 100, reason: 'Target met', target, actual });
+          console.log(`   ✅ ${name}: ${actual} meets target ${target}`);
+        } else if (met === false) {
+          metricScores.push({ name, score: 50, reason: 'Target not met', target, actual });
+          console.log(`   ⚠️  ${name}: ${actual} does NOT meet target ${target}`);
+        } else {
+          // Non-numeric comparison — actual exists but can't compare
+          metricScores.push({ name, score: 75, reason: 'Actual recorded (non-numeric)', target, actual });
+          console.log(`   ℹ️  ${name}: actual="${actual}" (non-numeric, target="${target || 'N/A'}")`);
+        }
+      }
+
+      // Calculate overall score
+      const overallScore = Math.round(
+        metricScores.reduce((sum, m) => sum + m.score, 0) / metricScores.length
+      );
+      const hasEmptyActual = metricScores.some(m => m.score === 0);
+      const passed = overallScore >= 70 && !hasEmptyActual;
+
+      const issues = metricScores
+        .filter(m => m.score === 0)
+        .map(m => `${m.name}: No actual value recorded (target: ${m.target || 'N/A'})`);
+
+      const warnings = metricScores
+        .filter(m => m.score > 0 && m.score <= 50)
+        .map(m => `${m.name}: ${m.actual} does not meet target ${m.target}`);
+
+      console.log(`\n   Overall Score: ${overallScore}/100 (threshold: 70, no empty actuals allowed)`);
+      console.log(`   ${passed ? '✅ PASSED' : '❌ FAILED'}`);
+
+      if (!passed) {
+        console.log('\n   REMEDIATION:');
+        if (hasEmptyActual) {
+          console.log('   - Record actual values for all success metrics');
+          console.log('   - Update: strategic_directives_v2.success_metrics[].actual');
+        }
+        if (overallScore < 70) {
+          console.log('   - Work toward meeting defined target values');
+        }
+      }
+
+      return {
+        passed,
+        score: overallScore,
+        max_score: 100,
+        issues,
+        warnings,
+        ...((!passed) && {
+          remediation: 'Record actual values for all success metrics and ensure targets are met'
+        }),
+        details: {
+          metrics_count: metrics.length,
+          metric_scores: metricScores,
+          overall_score: overallScore,
+          has_empty_actual: hasEmptyActual
+        }
+      };
+    },
+    required: true
+  };
+}

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/vision-completion-score.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/vision-completion-score.js
@@ -1,0 +1,176 @@
+/**
+ * Vision Completion Re-Score Gate for PLAN-TO-LEAD
+ *
+ * Re-scores the SD against vision/architecture dimensions at completion time
+ * and compares with the entry score. Detects vision regression — where an SD
+ * starts aligned but drifts during implementation.
+ *
+ * ADVISORY gate — always passes, but logs delta for visibility.
+ */
+
+const RESCORE_TIMEOUT_MS = 60_000;
+
+export function createVisionCompletionScoreGate(supabase) {
+  return {
+    name: 'VISION_COMPLETION_SCORE',
+    validator: async (ctx) => {
+      console.log('\n🔭 VISION COMPLETION RE-SCORE GATE (Advisory)');
+      console.log('-'.repeat(50));
+
+      const sdUuid = ctx.sd?.id || ctx.sdId;
+      const sdKey = ctx.sd?.sd_key || ctx.sdId;
+
+      // ORCHESTRATOR BYPASS
+      const { data: childSDs } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sdUuid);
+
+      if (childSDs && childSDs.length > 0) {
+        console.log(`   ℹ️  Orchestrator SD (${childSDs.length} children) — bypassing`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: ['Orchestrator SD — vision score deferred to children'],
+          details: { is_orchestrator: true }
+        };
+      }
+
+      // CORRECTIVE SD EXEMPTION
+      let metadata = ctx.sd?.metadata;
+      if (!metadata) {
+        const { data: sdRecord } = await supabase
+          .from('strategic_directives_v2')
+          .select('metadata')
+          .eq('id', sdUuid)
+          .single();
+        metadata = sdRecord?.metadata;
+      }
+
+      if (metadata?.vision_origin_score_id) {
+        console.log('   ℹ️  Corrective SD — vision re-score not applicable');
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: ['Corrective SD — skipping vision re-score'],
+          details: { is_corrective: true }
+        };
+      }
+
+      // Check for vision_key
+      const visionKey = metadata?.vision_key;
+      const archKey = metadata?.arch_key;
+
+      if (!visionKey) {
+        console.log('   ⚠️  No vision_key in SD metadata — skipping re-score');
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [],
+          warnings: ['No vision_key in SD metadata — cannot compare entry vs completion score'],
+          details: { has_vision_key: false }
+        };
+      }
+
+      console.log(`   Vision Key: ${visionKey}`);
+      if (archKey) console.log(`   Arch Key: ${archKey}`);
+
+      // Look up entry score (earliest score for this SD)
+      const { data: entryScores } = await supabase
+        .from('eva_vision_scores')
+        .select('id, total_score, dimension_scores, scored_at')
+        .eq('sd_id', sdKey)
+        .order('scored_at', { ascending: true })
+        .limit(1);
+
+      const entryScore = entryScores?.[0];
+      if (entryScore) {
+        console.log(`   Entry Score: ${entryScore.total_score}/100 (${new Date(entryScore.scored_at).toLocaleDateString()})`);
+      } else {
+        console.log('   ⚠️  No entry score found — will score for the first time');
+      }
+
+      // Re-score at completion
+      let completionScore = null;
+      try {
+        const { scoreSD } = await import('../../../../../../scripts/eva/vision-scorer.js');
+        const scorePromise = scoreSD({ sdKey, visionKey, archKey, supabase });
+        const timeoutPromise = new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('Vision re-score timed out')), RESCORE_TIMEOUT_MS)
+        );
+        await Promise.race([scorePromise, timeoutPromise]);
+
+        // Fetch the newly created score
+        const { data: newScores } = await supabase
+          .from('eva_vision_scores')
+          .select('id, total_score, dimension_scores, scored_at')
+          .eq('sd_id', sdKey)
+          .order('scored_at', { ascending: false })
+          .limit(1);
+
+        completionScore = newScores?.[0];
+      } catch (err) {
+        console.log(`   ⚠️  Vision re-score failed: ${err.message}`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [],
+          warnings: [`Vision re-score failed: ${err.message} — advisory only, not blocking`],
+          details: { rescore_error: err.message }
+        };
+      }
+
+      if (!completionScore) {
+        console.log('   ⚠️  Re-score ran but no score persisted');
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [],
+          warnings: ['Vision re-score did not produce a persisted score'],
+          details: { rescore_persisted: false }
+        };
+      }
+
+      console.log(`   Completion Score: ${completionScore.total_score}/100`);
+
+      // Compare entry vs completion
+      const warnings = [];
+      const delta = entryScore
+        ? completionScore.total_score - entryScore.total_score
+        : null;
+
+      if (delta !== null) {
+        console.log(`   Delta: ${delta >= 0 ? '+' : ''}${delta} points`);
+
+        if (delta >= 0) {
+          console.log('   ✅ Vision alignment maintained or improved');
+        } else if (delta > -5) {
+          console.log('   ℹ️  Minor vision score decrease (within tolerance)');
+        } else if (delta > -15) {
+          const msg = `Vision regression: score dropped ${Math.abs(delta)} points (${entryScore.total_score} → ${completionScore.total_score})`;
+          warnings.push(msg);
+          console.log(`   ⚠️  ${msg}`);
+        } else {
+          const msg = `Significant vision regression: score dropped ${Math.abs(delta)} points (${entryScore.total_score} → ${completionScore.total_score})`;
+          warnings.push(msg);
+          console.log(`   🚨 ${msg}`);
+        }
+      } else {
+        console.log('   ℹ️  No entry score to compare — baseline established');
+      }
+
+      return {
+        passed: true, // Advisory — always passes
+        score: completionScore.total_score,
+        max_score: 100,
+        issues: [],
+        warnings,
+        details: {
+          entry_score: entryScore?.total_score || null,
+          completion_score: completionScore.total_score,
+          delta,
+          entry_score_id: entryScore?.id || null,
+          completion_score_id: completionScore.id,
+          vision_key: visionKey,
+          arch_key: archKey
+        }
+      };
+    },
+    required: true // Gate runs, but always passes (advisory)
+  };
+}

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -30,7 +30,11 @@ import {
   createWorkflowROIGate,
   createUserStoryExistenceGate,
   createDocumentationLinkValidationGate,
-  createHealBeforeCompleteGate
+  createHealBeforeCompleteGate,
+  createAcceptanceCriteriaValidationGate,
+  createSuccessMetricsAchievementGate,
+  createVisionCompletionScoreGate,
+  createArchitecturePlanValidationGate
 } from './gates/index.js';
 // Note: requiresTraceabilityGates is re-exported via 'export * from ./gates/index.js'
 
@@ -120,8 +124,11 @@ export class PlanToLeadExecutor extends BaseExecutor {
     gates.push(createPrerequisiteCheckGate(this.supabase));
 
     // Heal-before-complete gate (SD-MAN-GEN-CORRECTIVE-VISION-GAP-007-03 FR-004)
-    // SD heal score must meet threshold before final approval
+    // SD heal score must meet threshold (93) before final approval
     gates.push(createHealBeforeCompleteGate(this.supabase));
+
+    // Vision completion re-score (advisory — detects vision regression)
+    gates.push(createVisionCompletionScoreGate(this.supabase));
 
     // Sub-agent orchestration
     gates.push(createSubAgentOrchestrationGate(this.supabase));
@@ -145,8 +152,17 @@ export class PlanToLeadExecutor extends BaseExecutor {
     // User story existence gate
     gates.push(createUserStoryExistenceGate(this.supabase));
 
+    // Acceptance criteria validation (blocking — every story must have criteria)
+    gates.push(createAcceptanceCriteriaValidationGate(this.supabase));
+
+    // Success metrics achievement (blocking — actuals must be recorded)
+    gates.push(createSuccessMetricsAchievementGate(this.supabase));
+
     // Documentation link validation gate (SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-D)
     gates.push(createDocumentationLinkValidationGate(this.supabase));
+
+    // Architecture plan validation (advisory — checks dimension coverage)
+    gates.push(createArchitecturePlanValidationGate(this.supabase));
 
     // DFE Escalation advisory gate (SD-MAN-GEN-CORRECTIVE-VISION-GAP-003)
     // Routes ESCALATE decisions to chairman_decisions for governance

--- a/scripts/modules/vision-arch-traceability.js
+++ b/scripts/modules/vision-arch-traceability.js
@@ -1,0 +1,109 @@
+/**
+ * Vision/Architecture Traceability Helper
+ *
+ * Generates traceable success metrics from vision documents and architecture
+ * plans. These metrics link SD success measurements back to their originating
+ * vision dimensions and architecture plan dimensions, enabling end-to-end
+ * traceability from strategic vision to implementation outcomes.
+ *
+ * Used by:
+ * - create-orchestrator-from-plan.js — inject into orchestrator + children
+ * - leo-create-sd.js — when --vision-key and --arch-key are provided
+ * - success-metrics-achievement.js — identify vision/arch-linked metrics
+ */
+
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/**
+ * Generate traceable success metrics from vision and architecture dimensions.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} visionKey - Vision document key (e.g., 'VISION-EHG-L2-001')
+ * @param {string} archKey - Architecture plan key (e.g., 'ARCH-EHG-001')
+ * @param {Object} [options] - Options
+ * @param {string} [options.targetTemplate] - Target value template (default: '>=90%')
+ * @returns {Promise<{visionMetrics: Array, archMetrics: Array}>}
+ */
+export async function generateTraceableMetrics(supabase, visionKey, archKey, options = {}) {
+  const { targetTemplate = '>=90%' } = options;
+  const visionMetrics = [];
+  const archMetrics = [];
+
+  // Load vision dimensions
+  if (visionKey) {
+    const { data: visionDoc } = await supabase
+      .from('eva_vision_documents')
+      .select('vision_key, extracted_dimensions')
+      .eq('vision_key', visionKey)
+      .single();
+
+    if (visionDoc?.extracted_dimensions && Array.isArray(visionDoc.extracted_dimensions)) {
+      for (const dim of visionDoc.extracted_dimensions) {
+        visionMetrics.push({
+          metric: `Vision: ${dim.name} alignment`,
+          target: targetTemplate,
+          measurement: 'EVA vision score dimension',
+          source: `${visionKey}:${dim.name}`,
+          traceability: 'vision_dimension'
+        });
+      }
+    }
+  }
+
+  // Load architecture dimensions
+  if (archKey) {
+    const { data: archPlan } = await supabase
+      .from('eva_architecture_plans')
+      .select('plan_key, extracted_dimensions')
+      .eq('plan_key', archKey)
+      .single();
+
+    if (archPlan?.extracted_dimensions && Array.isArray(archPlan.extracted_dimensions)) {
+      for (const dim of archPlan.extracted_dimensions) {
+        archMetrics.push({
+          metric: `Architecture: ${dim.name} implementation`,
+          target: targetTemplate,
+          measurement: 'Architecture dimension coverage',
+          source: `${archKey}:${dim.name}`,
+          traceability: 'arch_dimension'
+        });
+      }
+    }
+  }
+
+  return { visionMetrics, archMetrics };
+}
+
+/**
+ * Map architecture dimensions to implementation phases based on keyword matching.
+ *
+ * @param {Array} dimensions - Architecture dimensions array
+ * @param {Array} phases - Phase objects with {title, description, scope}
+ * @returns {Map<number, Array>} Map of phase index to relevant dimensions
+ */
+export function mapDimensionsToPhases(dimensions, phases) {
+  const phaseMap = new Map();
+
+  for (let i = 0; i < phases.length; i++) {
+    const phase = phases[i];
+    const phaseText = `${phase.title || ''} ${phase.description || ''} ${phase.scope || ''}`.toLowerCase();
+    const relevant = [];
+
+    for (const dim of dimensions) {
+      const dimName = (dim.name || '').toLowerCase().replace(/[_-]/g, ' ');
+      const dimWords = dimName.split(/\s+/);
+
+      // Check if any dimension word appears in phase text
+      const matches = dimWords.some(word => word.length > 3 && phaseText.includes(word));
+      if (matches) {
+        relevant.push(dim);
+      }
+    }
+
+    phaseMap.set(i, relevant);
+  }
+
+  return phaseMap;
+}


### PR DESCRIPTION
## Summary
- Raise heal score threshold from 80 to 93 for standard SDs (matching corrective SD grade)
- Add **ACCEPTANCE_CRITERIA_VALIDATION** gate (blocking) — validates stories have criteria AND validation evidence
- Add **SUCCESS_METRICS_ACHIEVEMENT** gate (blocking) — validates actual values recorded and targets met
- Add **VISION_COMPLETION_SCORE** gate (advisory) — re-scores SD against vision at completion, detects regression
- Add **ARCHITECTURE_PLAN_VALIDATION** gate (advisory) — validates architecture dimension coverage in SD scope/stories
- Add `create-orchestrator-from-plan.js` CLI for creating orchestrator + children from vision/arch plans
- Add `vision-arch-traceability.js` helper for generating traceable success metrics
- Add advisory in `leo-create-sd.js` suggesting orchestrator creator when both vision + arch keys provided

## Gate Sequence (PLAN-TO-LEAD, 16 total)
1. SD_START → 2. PROTOCOL_FILE_READ → 3. PREREQUISITE_CHECK → 4. HEAL_BEFORE_COMPLETE (93) → 5. **VISION_COMPLETION_SCORE** → 6. SUB_AGENT_ORCHESTRATION → 7. RETROSPECTIVE_QUALITY → 8. GIT_COMMIT_ENFORCEMENT → 9-10. TRACEABILITY/WORKFLOW_ROI → 11. USER_STORY_EXISTENCE → 12. **ACCEPTANCE_CRITERIA_VALIDATION** → 13. **SUCCESS_METRICS_ACHIEVEMENT** → 14. DOCUMENTATION_LINK_VALIDATION → 15. **ARCHITECTURE_PLAN_VALIDATION** → 16. DFE_ESCALATION

## Test plan
- [ ] Run PLAN-TO-LEAD handoff on test SD — confirm all 16 gates appear
- [ ] Verify heal gate requires 93 (not 80)
- [ ] Test acceptance criteria gate with stories missing criteria → should block
- [ ] Test success metrics gate with empty actuals → should block
- [ ] Test vision completion gate logs delta (advisory, non-blocking)
- [ ] Test architecture plan gate reports uncovered dimensions (advisory)
- [ ] Run `create-orchestrator-from-plan.js --dry-run` with test vision/arch keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)