### PR TITLE
docs: add 4 new PLAN-TO-LEAD gate keys to validation gate registry

### DIFF
--- a/docs/reference/validation-gate-registry.md
+++ b/docs/reference/validation-gate-registry.md
@@ -107,6 +107,10 @@ ORDER BY disabled_gates DESC;
 | `GATE_INFRASTRUCTURE_CONSUMER_CHECK` | Infrastructure consumer check |
 | `GATE_INTEGRATION_SECTION_VALIDATION` | PRD integration section |
 | `GATE_DELIVERABLES_PLANNING` | Deliverables planning check |
+| `ACCEPTANCE_CRITERIA_VALIDATION` | Validates user stories have acceptance criteria + validation evidence (BLOCKING) |
+| `SUCCESS_METRICS_ACHIEVEMENT` | Validates SD success metrics have actual values recorded and targets met (BLOCKING) |
+| `VISION_COMPLETION_SCORE` | Re-scores SD against vision dimensions at completion, detects regression (advisory) |
+| `ARCHITECTURE_PLAN_VALIDATION` | Validates architecture plan dimension coverage in SD implementation (advisory) |
 
 ## Monitoring
 


### PR DESCRIPTION
## Summary

- Adds 4 new gate keys to `docs/reference/validation-gate-registry.md` Known Gate Keys table, introduced by SD-LEO-COMPLETION-GATES-001:
  - `ACCEPTANCE_CRITERIA_VALIDATION` — validates user stories have acceptance criteria + validation evidence (BLOCKING)
  - `SUCCESS_METRICS_ACHIEVEMENT` — validates actual values recorded and targets met (BLOCKING)
  - `VISION_COMPLETION_SCORE` — re-scores SD against vision dimensions at completion, detects regression (advisory)
  - `ARCHITECTURE_PLAN_VALIDATION` — validates architecture plan dimension coverage (advisory)

Note: `docs/leo/handoffs/handoff-system-guide.md` was edited locally (gate list updated to 16-gate sequence) but DOCMON blocks direct edits to handoff docs — those must be updated via database (`leo_protocol_sections`).

## Test plan

- [x] DOCMON pre-push validation passed
- [x] Smoke tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)