### PR TITLE
fix: raise statusline critical threshold from 80% to 90%

### DIFF
--- a/.claude/statusline.cjs
+++ b/.claude/statusline.cjs
@@ -27,7 +27,7 @@ const LOG_DIR = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.claude/logs';
 const STATE_FILE = path.join(LOG_DIR, '.context-state.json');
 const AUTOCOMPACT_PCT = 80;
 const WARNING_THRESHOLD = 60;
-const CRITICAL_THRESHOLD = 80;
+const CRITICAL_THRESHOLD = 90;
 const EMERGENCY_THRESHOLD = 95;
 
 // ANSI escape codes


### PR DESCRIPTION
## Summary
- Raised the CRITICAL_THRESHOLD from 80% to 90% in the statusline context bar
- Progress bar now stays hidden until 90% usage, reducing noise during normal operation
- Yellow (CRITICAL) shows 90-94%, red (EMERGENCY) at 95%+

## Test plan
- [x] Verify statusline renders correctly below 90% (no bar shown)
- [ ] Verify yellow bar appears at 90-94%
- [ ] Verify red bar appears at 95%+

🤖 Generated with [Claude Code](https://claude.com/claude-code)