### PR TITLE
docs: Chairman Dashboard V2 design prototype + vision/architecture specs

### DIFF
--- a/chairman-dashboard-v2-design.html
+++ b/chairman-dashboard-v2-design.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>EHG Chairman Dashboard V2 - Design Prototype</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<script>
+tailwind.config={darkMode:'class',theme:{extend:{fontFamily:{sans:['Inter','system-ui','sans-serif'],mono:['JetBrains Mono','monospace']}}}}
+</script>
+<style>
+:root{--glass-bg:rgba(255,255,255,0.04);--glass-border:rgba(255,255,255,0.07);--glow-primary:rgba(99,102,241,0.12);--glow-success:rgba(34,197,94,0.12);--glow-warn:rgba(234,179,8,0.12);--glow-danger:rgba(239,68,68,0.12)}
+.light{--glass-bg:rgba(0,0,0,0.02);--glass-border:rgba(0,0,0,0.06);--glow-primary:rgba(99,102,241,0.06);--glow-success:rgba(34,197,94,0.06);--glow-warn:rgba(234,179,8,0.06);--glow-danger:rgba(239,68,68,0.06)}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:'Inter',system-ui,sans-serif;overflow:hidden}
+.font-mono{font-family:'JetBrains Mono',monospace}
+.glass{background:var(--glass-bg);border:1px solid var(--glass-border);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px)}
+.glow-p{box-shadow:0 0 24px var(--glow-primary),inset 0 1px 0 rgba(255,255,255,0.04)}
+.glow-s{box-shadow:0 0 24px var(--glow-success)}
+.glow-w{box-shadow:0 0 24px var(--glow-warn)}
+.glow-d{box-shadow:0 0 24px var(--glow-danger)}
+.mesh{background:radial-gradient(ellipse at 15% 50%,rgba(99,102,241,0.07) 0%,transparent 50%),radial-gradient(ellipse at 85% 15%,rgba(34,197,94,0.04) 0%,transparent 50%),radial-gradient(ellipse at 50% 85%,rgba(234,179,8,0.03) 0%,transparent 50%)}
+.light .mesh{background:radial-gradient(ellipse at 15% 50%,rgba(99,102,241,0.03) 0%,transparent 50%),radial-gradient(ellipse at 85% 15%,rgba(34,197,94,0.02) 0%,transparent 50%)}
+.grain{position:relative}.grain::after{content:'';position:absolute;inset:0;opacity:0.025;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");pointer-events:none;border-radius:inherit}
+.sb::-webkit-scrollbar{width:5px}.sb::-webkit-scrollbar-track{background:transparent}.sb::-webkit-scrollbar-thumb{background:rgba(255,255,255,0.08);border-radius:3px}
+.light .sb::-webkit-scrollbar-thumb{background:rgba(0,0,0,0.1)}
+.ch:hover{transform:translateY(-1px);box-shadow:0 4px 24px rgba(0,0,0,0.2)}.light .ch:hover{box-shadow:0 4px 24px rgba(0,0,0,0.06)}
+.ch{transition:all 0.15s ease}
+.view{display:none}.view.active{display:block;animation:fadeUp 0.25s ease-out}
+@keyframes fadeUp{0%{opacity:0;transform:translateY(6px)}100%{opacity:1;transform:translateY(0)}}
+@keyframes pulse-slow{0%,100%{opacity:1}50%{opacity:0.6}}
+.pulse-slow{animation:pulse-slow 2.5s ease-in-out infinite}
+.nav-btn{color:#6b7280;transition:all 0.15s ease}
+.nav-btn:hover{background:rgba(255,255,255,0.04);color:#d1d5db}
+.nav-btn.act{background:rgba(99,102,241,0.1);color:#a5b4fc;font-weight:500}
+.light .nav-btn{color:#6b7280}.light .nav-btn:hover{background:rgba(0,0,0,0.04);color:#374151}
+.light .nav-btn.act{background:rgba(99,102,241,0.08);color:#4f46e5}
+.stage-dot{transition:all 0.15s ease;cursor:pointer}.stage-dot:hover{transform:scale(1.3)}
+.exp-content{max-height:0;overflow:hidden;transition:max-height 0.3s ease,opacity 0.2s ease;opacity:0}
+.exp-content.open{max-height:600px;opacity:1}
+.detail-panel{position:fixed;top:0;right:0;bottom:0;width:min(480px,90vw);transform:translateX(100%);transition:transform 0.3s ease;z-index:50}
+.detail-panel.open{transform:translateX(0)}
+.detail-overlay{position:fixed;inset:0;background:rgba(0,0,0,0.5);opacity:0;transition:opacity 0.3s ease;pointer-events:none;z-index:45}
+.detail-overlay.open{opacity:1;pointer-events:auto}
+@media(max-width:768px){.sidebar-area{display:none!important}.mob-tabs{display:flex!important}.main-scroll{padding-bottom:5rem!important}}
+@media(min-width:769px){.mob-tabs{display:none!important}}
+</style>
+</head>
+<body class="bg-[#0a0e17] text-gray-200 h-screen overflow-hidden">
+<div id="app" class="flex h-screen">
+
+<!-- SIDEBAR -->
+<aside class="sidebar-area w-[232px] h-screen flex flex-col border-r border-white/[0.06] bg-[#0c1019] flex-shrink-0 z-20">
+  <div class="h-14 flex items-center px-4 border-b border-white/[0.06] flex-shrink-0 gap-2.5">
+    <div class="w-7 h-7 rounded-lg bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center shadow-lg shadow-indigo-500/20">
+      <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+    </div>
+    <span class="text-sm font-bold tracking-tight">EHG</span>
+    <span class="text-[9px] font-mono text-gray-600 bg-white/[0.04] px-1.5 py-0.5 rounded">v2</span>
+  </div>
+  <div class="flex-1 overflow-y-auto py-4 px-2.5 space-y-5 sb">
+    <div>
+      <div class="px-2 mb-2 flex items-center gap-2"><span class="text-[9px] font-semibold uppercase tracking-[0.15em] text-gray-600">Chairman</span><div class="flex-1 h-px bg-white/[0.04]"></div></div>
+      <nav class="space-y-0.5" id="nav-chairman">
+        <button onclick="go('briefing')" data-v="briefing" class="nav-btn act w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-lg text-[13px]">
+          <svg class="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
+          Briefing</button>
+        <button onclick="go('decisions')" data-v="decisions" class="nav-btn w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-lg text-[13px]">
+          <svg class="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+          Decisions<span class="ml-auto text-[9px] font-semibold bg-red-500/15 text-red-400 w-5 h-5 rounded-full flex items-center justify-center">3</span></button>
+        <button onclick="go('ventures')" data-v="ventures" class="nav-btn w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-lg text-[13px]">
+          <svg class="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
+          Ventures</button>
+        <button onclick="go('vision')" data-v="vision" class="nav-btn w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-lg text-[13px]">
+          <svg class="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
+          Vision</button>
+        <button onclick="go('prefs')" data-v="prefs" class="nav-btn w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-lg text-[13px]">
+          <svg class="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><circle cx="12" cy="12" r="3"/></svg>
+          Preferences</button>
+      </nav>
+    </div>
+    <div>
+      <div class="px-2 mb-2 flex items-center gap-2"><span class="text-[9px] font-semibold uppercase tracking-[0.15em] text-gray-600">Builder</span><div class="flex-1 h-px bg-white/[0.04]"></div></div>
+      <nav class="space-y-0.5" id="nav-builder">
+        <button onclick="go('active')" data-v="active" class="nav-btn w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-lg text-[13px]">
+          <svg class="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
+          Active SDs<span class="ml-auto text-[9px] font-semibold bg-green-500/15 text-green-400 w-5 h-5 rounded-full flex items-center justify-center">4</span></button>
+        <button onclick="go('queue')" data-v="queue" class="nav-btn w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-lg text-[13px]">
+          <svg class="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M4 6h16M4 10h16M4 14h16M4 18h16"/></svg>
+          Build Queue</button>
+        <button onclick="go('inbox')" data-v="inbox" class="nav-btn w-full flex items-center gap-2.5 px-2.5 py-[7px] rounded-lg text-[13px]">
+          <svg class="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/></svg>
+          Inbox<span class="ml-auto text-[9px] font-semibold bg-indigo-500/15 text-indigo-400 w-5 h-5 rounded-full flex items-center justify-center">2</span></button>
+      </nav>
+    </div>
+  </div>
+  <div class="p-3 border-t border-white/[0.06] flex-shrink-0">
+    <div class="flex items-center gap-2.5 px-1.5">
+      <div class="w-8 h-8 rounded-full bg-gradient-to-br from-amber-400 to-orange-500 flex items-center justify-center text-[11px] font-bold text-white shadow-lg shadow-amber-500/20">RF</div>
+      <div class="flex-1 min-w-0"><p class="text-xs font-medium truncate">Rick Felix</p><p class="text-[10px] text-gray-600 truncate">Chairman & Builder</p></div>
+    </div>
+  </div>
+</aside>
+
+<!-- MAIN -->
+<div class="flex-1 flex flex-col min-w-0 h-screen">
+  <!-- TOPBAR -->
+  <header class="h-14 flex items-center justify-between px-4 md:px-6 border-b border-white/[0.06] bg-[#0a0e17]/80 backdrop-blur-xl flex-shrink-0 z-10">
+    <div class="flex items-center gap-3">
+      <button class="md:hidden p-1.5 rounded-lg hover:bg-white/5" onclick="document.querySelector('.sidebar-area').classList.toggle('hidden')">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 12h16M4 18h16"/></svg>
+      </button>
+      <h1 id="ptitle" class="text-sm font-semibold">Daily Briefing</h1>
+      <span class="text-[11px] text-gray-600 hidden md:inline font-mono">Mar 2, 2026</span>
+    </div>
+    <div class="flex items-center gap-1.5">
+      <button id="persona-btn" onclick="togglePersona()" class="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px] font-medium border transition-all" style="border-color:rgba(251,191,36,0.25);background:rgba(251,191,36,0.04)">
+        <span id="p-icon" class="text-amber-400">&#9818;</span>
+        <span id="p-label">Chairman</span>
+      </button>
+      <button onclick="toggleTheme()" class="p-2 rounded-lg hover:bg-white/5 transition-colors" title="Toggle theme">
+        <svg id="t-dark" class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+        <svg id="t-light" class="w-4 h-4 text-amber-400 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+      </button>
+      <div class="relative">
+        <button class="p-2 rounded-lg hover:bg-white/5 transition-colors"><svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg></button>
+        <span class="absolute top-1.5 right-1.5 w-2 h-2 bg-red-500 rounded-full"></span>
+      </div>
+    </div>
+  </header>
+
+  <!-- SCROLLABLE CONTENT -->
+  <main class="flex-1 overflow-y-auto main-scroll sb mesh grain">
+
+<!-- ========== VIEW: BRIEFING ========== -->
+<div id="v-briefing" class="view active p-4 md:p-6 space-y-4">
+  <div class="glass rounded-2xl p-5 glow-p">
+    <div class="flex flex-col sm:flex-row items-start justify-between gap-3">
+      <div>
+        <p class="text-[10px] text-indigo-400/70 font-semibold uppercase tracking-[0.15em] mb-1">Good Morning</p>
+        <h2 class="text-xl font-bold text-white">Welcome back, Rick</h2>
+        <p class="text-[13px] text-gray-400 mt-1.5 max-w-lg leading-relaxed">3 gate decisions need your attention today. Portfolio health is <span class="text-green-400 font-medium">strong at 82%</span>. VentureForge passed Stage 10 overnight.</p>
+      </div>
+      <button class="flex items-center gap-2 px-3 py-2 rounded-xl bg-indigo-500/10 border border-indigo-500/20 text-indigo-300 text-[11px] font-medium hover:bg-indigo-500/15 transition-colors shrink-0">
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z"/></svg>
+        Ask EVA
+      </button>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 lg:grid-cols-4 gap-3">
+    <div class="glass rounded-xl p-4 ch cursor-pointer" onclick="go('ventures')">
+      <div class="flex items-center justify-between mb-2"><span class="text-[9px] font-semibold uppercase tracking-[0.12em] text-gray-500">Active Ventures</span>
+        <svg class="w-4 h-4 text-indigo-400/60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16"/></svg></div>
+      <p class="text-2xl font-bold text-white">7</p>
+      <div class="flex items-center gap-1 mt-1"><svg class="w-3 h-3 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg><span class="text-[10px] text-green-400 font-medium">+2 this month</span></div>
+    </div>
+    <div class="glass rounded-xl p-4 ch cursor-pointer glow-d" onclick="go('decisions')">
+      <div class="flex items-center justify-between mb-2"><span class="text-[9px] font-semibold uppercase tracking-[0.12em] text-gray-500">Pending Decisions</span>
+        <svg class="w-4 h-4 text-red-400/60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg></div>
+      <p class="text-2xl font-bold text-white">3</p>
+      <div class="flex items-center gap-1.5 mt-1"><span class="w-1.5 h-1.5 rounded-full bg-red-500 pulse-slow"></span><span class="text-[10px] text-red-400 font-medium">1 critical</span></div>
+    </div>
+    <div class="glass rounded-xl p-4 ch">
+      <div class="flex items-center justify-between mb-2"><span class="text-[9px] font-semibold uppercase tracking-[0.12em] text-gray-500">Portfolio Health</span>
+        <svg class="w-4 h-4 text-green-400/60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"/></svg></div>
+      <p class="text-2xl font-bold text-white">82%</p>
+      <div class="w-full h-1.5 bg-white/[0.04] rounded-full mt-2 overflow-hidden"><div class="h-full bg-gradient-to-r from-green-500 to-emerald-400 rounded-full" style="width:82%"></div></div>
+    </div>
+    <div class="glass rounded-xl p-4 ch cursor-pointer" onclick="go('vision')">
+      <div class="flex items-center justify-between mb-2"><span class="text-[9px] font-semibold uppercase tracking-[0.12em] text-gray-500">Vision Alignment</span>
+        <svg class="w-4 h-4 text-purple-400/60" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg></div>
+      <p class="text-2xl font-bold text-white">76%</p>
+      <div class="flex items-center gap-1 mt-1"><span class="text-[10px] text-amber-400 font-medium">~ Stable</span></div>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+    <div class="glass rounded-2xl overflow-hidden">
+      <div class="flex items-center justify-between px-5 pt-4 pb-2"><h3 class="text-[13px] font-semibold flex items-center gap-2"><svg class="w-4 h-4 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>Awaiting Decision</h3><button onclick="go('decisions')" class="text-[10px] text-indigo-400 font-medium hover:text-indigo-300">View all &rarr;</button></div>
+      <div class="px-3 pb-3 space-y-1">
+        <button onclick="go('detail')" class="w-full text-left p-3 rounded-xl hover:bg-white/[0.03] transition-all border-l-[3px] border-red-500 group">
+          <div class="flex items-center gap-2 mb-1"><span class="text-[8px] font-bold uppercase tracking-wider bg-red-500/15 text-red-400 px-1.5 py-0.5 rounded">Critical</span><span class="text-[12px] font-medium text-white">Kill Gate: NeuralPay Stage 22</span></div>
+          <p class="text-[11px] text-gray-500 line-clamp-1">Health at 42%. Revenue validation failed. Recommend park or pivot.</p>
+        </button>
+        <button class="w-full text-left p-3 rounded-xl hover:bg-white/[0.03] transition-all border-l-[3px] border-amber-500 group">
+          <div class="flex items-center gap-2 mb-1"><span class="text-[8px] font-bold uppercase tracking-wider bg-amber-500/15 text-amber-400 px-1.5 py-0.5 rounded">High</span><span class="text-[12px] font-medium text-white">Stage 0: DataWeave Routing</span></div>
+          <p class="text-[11px] text-gray-500 line-clamp-1">Portfolio synergy 74%. Constraint check: 4/5 passed. Horizon: 18mo.</p>
+        </button>
+        <button class="w-full text-left p-3 rounded-xl hover:bg-white/[0.03] transition-all border-l-[3px] border-blue-500 group">
+          <div class="flex items-center gap-2 mb-1"><span class="text-[8px] font-bold uppercase tracking-wider bg-blue-500/15 text-blue-400 px-1.5 py-0.5 rounded">Normal</span><span class="text-[12px] font-medium text-white">Stage 10: VentureForge Brand</span></div>
+          <p class="text-[11px] text-gray-500 line-clamp-1">3 naming candidates scored. Top pick: VentureForge (87/100).</p>
+        </button>
+      </div>
+    </div>
+    <div class="glass rounded-2xl overflow-hidden">
+      <div class="flex items-center justify-between px-5 pt-4 pb-2"><h3 class="text-[13px] font-semibold flex items-center gap-2"><svg class="w-4 h-4 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"/></svg>Portfolio Pulse</h3><button onclick="go('ventures')" class="text-[10px] text-indigo-400 font-medium hover:text-indigo-300">View all &rarr;</button></div>
+      <div class="px-5 pb-4 space-y-0">
+        <div class="flex items-center justify-between py-2.5 border-b border-white/[0.04]"><div class="flex items-center gap-3"><div class="w-2 h-2 rounded-full bg-green-500"></div><div><p class="text-[12px] font-medium text-white">VentureForge</p><p class="text-[10px] text-gray-600">Stage 10 &middot; Identity</p></div></div><div class="text-right"><p class="text-[12px] font-semibold text-green-400">91</p></div></div>
+        <div class="flex items-center justify-between py-2.5 border-b border-white/[0.04]"><div class="flex items-center gap-3"><div class="w-2 h-2 rounded-full bg-green-500"></div><div><p class="text-[12px] font-medium text-white">CodeLens AI</p><p class="text-[10px] text-gray-600">Stage 18 &middot; Build</p></div></div><div class="text-right"><p class="text-[12px] font-semibold text-green-400">85</p></div></div>
+        <div class="flex items-center justify-between py-2.5 border-b border-white/[0.04]"><div class="flex items-center gap-3"><div class="w-2 h-2 rounded-full bg-amber-500"></div><div><p class="text-[12px] font-medium text-white">SynthWave Audio</p><p class="text-[10px] text-gray-600">Stage 7 &middot; Engine</p></div></div><div class="text-right"><p class="text-[12px] font-semibold text-amber-400">67</p></div></div>
+        <div class="flex items-center justify-between py-2.5 border-b border-white/[0.04]"><div class="flex items-center gap-3"><div class="w-2 h-2 rounded-full bg-red-500"></div><div><p class="text-[12px] font-medium text-white">NeuralPay</p><p class="text-[10px] text-gray-600">Stage 22 &middot; Launch</p></div></div><div class="text-right"><p class="text-[12px] font-semibold text-red-400">42</p></div></div>
+        <div class="flex items-center justify-between py-2.5"><div class="flex items-center gap-3"><div class="w-2 h-2 rounded-full bg-green-500"></div><div><p class="text-[12px] font-medium text-white">PromptStack</p><p class="text-[10px] text-gray-600">Stage 3 &middot; Truth</p></div></div><div class="text-right"><p class="text-[12px] font-semibold text-green-400">88</p></div></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="glass rounded-xl p-4">
+    <div class="flex items-center justify-between mb-2"><span class="text-[9px] font-semibold uppercase tracking-[0.12em] text-gray-500">Monthly Token Budget</span><span class="text-[11px] text-gray-400 font-mono">142K / 200K</span></div>
+    <div class="w-full h-[6px] bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-gradient-to-r from-indigo-500 to-purple-500 rounded-full" style="width:71%"></div></div>
+    <p class="text-[10px] text-gray-600 mt-1.5">58K tokens remaining &middot; Projected: 189K by month end</p>
+  </div>
+</div>
+
+<!-- ========== VIEW: DECISIONS ========== -->
+<div id="v-decisions" class="view p-4 md:p-6 space-y-4">
+  <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+    <h2 class="text-base font-semibold flex items-center gap-2 flex-wrap">
+      <svg class="w-5 h-5 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+      Decision Gates<span class="text-[10px] font-medium bg-white/5 text-gray-400 px-2 py-0.5 rounded-full">3</span><span class="text-[10px] font-medium bg-red-500/15 text-red-400 px-2 py-0.5 rounded-full pulse-slow">1 Critical</span>
+    </h2>
+    <div class="flex gap-1 flex-wrap">
+      <button class="px-3 py-1.5 rounded-lg text-[11px] font-medium bg-indigo-500/15 text-indigo-300 border border-indigo-500/20">All</button>
+      <button class="px-3 py-1.5 rounded-lg text-[11px] font-medium text-gray-500 hover:bg-white/[0.03] border border-transparent">Investment</button>
+      <button class="px-3 py-1.5 rounded-lg text-[11px] font-medium text-gray-500 hover:bg-white/[0.03] border border-transparent">Graduation</button>
+      <button class="px-3 py-1.5 rounded-lg text-[11px] font-medium text-gray-500 hover:bg-white/[0.03] border border-transparent">Kill Gate</button>
+    </div>
+  </div>
+  <div class="space-y-2">
+    <button onclick="go('detail')" class="w-full text-left glass rounded-xl p-4 ch border-l-4 border-red-500 glow-d group">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 mb-1"><svg class="w-4 h-4 text-red-400 pulse-slow" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg><h4 class="text-sm font-semibold text-white">Kill Gate: NeuralPay Release Readiness</h4></div>
+          <div class="flex items-center gap-2 text-[11px] text-gray-500 flex-wrap"><span>NeuralPay</span><span class="text-gray-700">&bull;</span><span>Stage 22</span><span class="text-gray-700">&bull;</span><span class="text-red-400 font-medium">Overdue 2d</span></div>
+          <p class="text-[12px] text-gray-400 mt-2 line-clamp-2">Health at 42%. Revenue validation failed. Three sprints missed. EVA: Park and reallocate to CodeLens AI.</p>
+        </div>
+        <div class="flex items-center gap-2 shrink-0 flex-wrap justify-end">
+          <span class="text-[8px] font-bold uppercase tracking-wider bg-red-500/15 text-red-400 px-2 py-1 rounded-lg">Kill Gate</span>
+          <span class="text-[8px] font-bold uppercase tracking-wider bg-red-500 text-white px-2 py-1 rounded-lg">Critical</span>
+          <svg class="w-4 h-4 text-gray-700 group-hover:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7"/></svg>
+        </div>
+      </div>
+    </button>
+    <button class="w-full text-left glass rounded-xl p-4 ch border-l-4 border-amber-500 group">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex-1"><div class="flex items-center gap-2 mb-1"><svg class="w-4 h-4 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg><h4 class="text-sm font-semibold text-white">Stage 0: DataWeave Venture Routing</h4></div>
+          <div class="flex items-center gap-2 text-[11px] text-gray-500"><span>DataWeave</span><span class="text-gray-700">&bull;</span><span>Stage 0</span><span class="text-gray-700">&bull;</span><span>Due in 3d</span></div>
+          <p class="text-[12px] text-gray-400 mt-2">AI data pipeline venture. Synergy: 74%. Constraints: 4/5. Horizon: 18mo.</p>
+        </div>
+        <div class="flex items-center gap-2 shrink-0"><span class="text-[8px] font-bold uppercase bg-blue-500/15 text-blue-400 px-2 py-1 rounded-lg">Investment</span><span class="text-[8px] font-bold uppercase bg-amber-500 text-white px-2 py-1 rounded-lg">High</span></div>
+      </div>
+    </button>
+    <button class="w-full text-left glass rounded-xl p-4 ch group">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex-1"><div class="flex items-center gap-2 mb-1"><h4 class="text-sm font-semibold text-white">Stage 10: VentureForge Brand Approval</h4></div>
+          <div class="flex items-center gap-2 text-[11px] text-gray-500"><span>VentureForge</span><span class="text-gray-700">&bull;</span><span>Stage 10</span><span class="text-gray-700">&bull;</span><span>Due in 7d</span></div>
+          <p class="text-[12px] text-gray-400 mt-2">Brand naming finalized. 3 candidates. Top: VentureForge (87/100). Visual identity ready.</p>
+        </div>
+        <div class="flex items-center gap-2 shrink-0"><span class="text-[8px] font-bold uppercase bg-green-500/15 text-green-400 px-2 py-1 rounded-lg">Graduation</span><span class="text-[8px] font-bold uppercase bg-blue-500 text-white px-2 py-1 rounded-lg">Normal</span></div>
+      </div>
+    </button>
+  </div>
+</div>
+
+<!-- ========== VIEW: DECISION DETAIL ========== -->
+<div id="v-detail" class="view p-4 md:p-6 space-y-4">
+  <button onclick="go('decisions')" class="flex items-center gap-1.5 text-[12px] text-gray-400 hover:text-gray-300 transition-colors mb-1">
+    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7"/></svg>
+    Back to Decisions
+  </button>
+  <div class="glass rounded-2xl p-5 glow-d border-l-4 border-red-500">
+    <div class="flex items-start justify-between gap-4 mb-4">
+      <div>
+        <div class="flex items-center gap-2 mb-2"><span class="text-[8px] font-bold uppercase bg-red-500/15 text-red-400 px-2 py-1 rounded-lg">Kill Gate</span><span class="text-[8px] font-bold uppercase bg-red-500 text-white px-2 py-1 rounded-lg">Critical</span><span class="text-[10px] text-red-400">Overdue 2d</span></div>
+        <h2 class="text-lg font-bold text-white">Kill Gate: NeuralPay Release Readiness</h2>
+        <p class="text-[12px] text-gray-400 mt-1">NeuralPay &middot; Stage 22 &middot; Launch & Learn phase</p>
+      </div>
+    </div>
+    <p class="text-[13px] text-gray-300 leading-relaxed">NeuralPay has failed to meet revenue validation targets for three consecutive sprints. The health score has dropped from 78 to 42 over the past 6 weeks. The EVA system recommends parking this venture and reallocating engineering resources to CodeLens AI, which is performing above targets.</p>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div class="glass rounded-xl p-4">
+      <h3 class="text-[12px] font-semibold mb-3 flex items-center gap-2"><svg class="w-4 h-4 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>Health Metrics</h3>
+      <div class="space-y-3">
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Overall Health</span><span class="text-red-400 font-semibold">42%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-red-500 rounded-full" style="width:42%"></div></div></div>
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Revenue Validation</span><span class="text-red-400 font-semibold">28%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-red-500 rounded-full" style="width:28%"></div></div></div>
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Technical Readiness</span><span class="text-amber-400 font-semibold">65%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-amber-500 rounded-full" style="width:65%"></div></div></div>
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Market Fit</span><span class="text-red-400 font-semibold">35%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-red-500 rounded-full" style="width:35%"></div></div></div>
+      </div>
+    </div>
+    <div class="glass rounded-xl p-4">
+      <h3 class="text-[12px] font-semibold mb-3 flex items-center gap-2"><svg class="w-4 h-4 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>Risk Factors</h3>
+      <div class="space-y-2.5">
+        <div class="flex items-start gap-2.5 p-2.5 rounded-lg bg-red-500/[0.06] border border-red-500/10"><span class="w-1.5 h-1.5 rounded-full bg-red-500 mt-1.5 shrink-0"></span><div><p class="text-[11px] font-medium text-red-300">Revenue below threshold</p><p class="text-[10px] text-gray-500">3 consecutive sprints missed revenue targets by 40%+</p></div></div>
+        <div class="flex items-start gap-2.5 p-2.5 rounded-lg bg-red-500/[0.06] border border-red-500/10"><span class="w-1.5 h-1.5 rounded-full bg-red-500 mt-1.5 shrink-0"></span><div><p class="text-[11px] font-medium text-red-300">Market fit unvalidated</p><p class="text-[10px] text-gray-500">Customer interviews show 2/10 willingness to pay</p></div></div>
+        <div class="flex items-start gap-2.5 p-2.5 rounded-lg bg-amber-500/[0.06] border border-amber-500/10"><span class="w-1.5 h-1.5 rounded-full bg-amber-500 mt-1.5 shrink-0"></span><div><p class="text-[11px] font-medium text-amber-300">Resource opportunity cost</p><p class="text-[10px] text-gray-500">Engineering time could accelerate CodeLens AI launch</p></div></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="glass rounded-xl p-4">
+    <h3 class="text-[12px] font-semibold mb-3">EVA Recommendation</h3>
+    <div class="p-3 rounded-lg bg-indigo-500/[0.06] border border-indigo-500/10">
+      <p class="text-[12px] text-indigo-200 leading-relaxed"><strong>Park NeuralPay</strong> and reallocate 80% of engineering capacity to CodeLens AI (Stage 18, health 85%). NeuralPay can be revisited in Q3 2026 if market conditions change. Estimated portfolio health improvement: +8 points.</p>
+    </div>
+  </div>
+
+  <div class="flex flex-col sm:flex-row gap-2">
+    <button class="flex-1 px-4 py-2.5 rounded-xl bg-red-500/15 border border-red-500/20 text-red-300 text-[12px] font-semibold hover:bg-red-500/25 transition-colors">Kill Venture</button>
+    <button class="flex-1 px-4 py-2.5 rounded-xl bg-amber-500/15 border border-amber-500/20 text-amber-300 text-[12px] font-semibold hover:bg-amber-500/25 transition-colors">Park Venture</button>
+    <button class="flex-1 px-4 py-2.5 rounded-xl bg-green-500/15 border border-green-500/20 text-green-300 text-[12px] font-semibold hover:bg-green-500/25 transition-colors">Continue (Override)</button>
+    <button class="px-4 py-2.5 rounded-xl bg-indigo-500/15 border border-indigo-500/20 text-indigo-300 text-[12px] font-semibold hover:bg-indigo-500/25 transition-colors flex items-center gap-2">
+      <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+      Open in Claude Code
+    </button>
+  </div>
+</div>
+
+<!-- ========== VIEW: VENTURES ========== -->
+<div id="v-ventures" class="view p-4 md:p-6 space-y-5">
+  <h2 class="text-base font-semibold flex items-center gap-2">
+    <svg class="w-5 h-5 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16"/></svg>
+    Venture Lifecycle Map
+  </h2>
+  <!-- 25-Stage Pipeline -->
+  <div class="glass rounded-2xl p-5 overflow-x-auto">
+    <div class="flex gap-3 min-w-[800px]">
+      <div class="flex-1 min-w-[120px]">
+        <div class="flex items-center gap-1.5 mb-2"><div class="w-2 h-2 rounded-full bg-purple-500"></div><span class="text-[9px] font-bold uppercase tracking-wider text-purple-400">Truth (0-3)</span></div>
+        <div class="space-y-1.5 p-2 rounded-lg border border-dashed border-purple-500/20 min-h-[80px] bg-purple-500/[0.02]">
+          <div class="p-2 rounded-md bg-white/[0.03] border border-white/[0.05] hover:bg-white/[0.06] transition-colors cursor-pointer" onclick="go('venturedetail')"><p class="text-[11px] font-medium text-white">PromptStack</p><div class="flex items-center justify-between mt-1"><span class="text-[9px] text-gray-500">Stage 3</span><div class="flex items-center gap-1"><div class="w-1.5 h-1.5 rounded-full bg-green-500"></div><span class="text-[9px] font-semibold text-green-400">88</span></div></div></div>
+          <div class="p-2 rounded-md bg-white/[0.03] border border-white/[0.05] hover:bg-white/[0.06] transition-colors cursor-pointer"><p class="text-[11px] font-medium text-white">DataWeave</p><div class="flex items-center justify-between mt-1"><span class="text-[9px] text-gray-500">Stage 0</span><div class="flex items-center gap-1"><div class="w-1.5 h-1.5 rounded-full bg-gray-500"></div><span class="text-[9px] text-gray-400">--</span></div></div></div>
+        </div>
+        <div class="text-center mt-1.5"><span class="text-[9px] text-gray-600 bg-white/[0.03] px-2 py-0.5 rounded-full">2 ventures</span></div>
+      </div>
+      <div class="flex-1 min-w-[120px]">
+        <div class="flex items-center gap-1.5 mb-2"><div class="w-2 h-2 rounded-full bg-blue-500"></div><span class="text-[9px] font-bold uppercase tracking-wider text-blue-400">Engine (4-9)</span></div>
+        <div class="space-y-1.5 p-2 rounded-lg border border-dashed border-blue-500/20 min-h-[80px] bg-blue-500/[0.02]">
+          <div class="p-2 rounded-md bg-white/[0.03] border border-white/[0.05] hover:bg-white/[0.06] transition-colors cursor-pointer"><p class="text-[11px] font-medium text-white">SynthWave Audio</p><div class="flex items-center justify-between mt-1"><span class="text-[9px] text-gray-500">Stage 7</span><div class="flex items-center gap-1"><div class="w-1.5 h-1.5 rounded-full bg-amber-500"></div><span class="text-[9px] font-semibold text-amber-400">67</span></div></div></div>
+          <div class="p-2 rounded-md bg-white/[0.03] border border-white/[0.05] hover:bg-white/[0.06] transition-colors cursor-pointer"><p class="text-[11px] font-medium text-white">AgentMesh</p><div class="flex items-center justify-between mt-1"><span class="text-[9px] text-gray-500">Stage 5</span><div class="flex items-center gap-1"><div class="w-1.5 h-1.5 rounded-full bg-green-500"></div><span class="text-[9px] font-semibold text-green-400">79</span></div></div></div>
+        </div>
+        <div class="text-center mt-1.5"><span class="text-[9px] text-gray-600 bg-white/[0.03] px-2 py-0.5 rounded-full">2 ventures</span></div>
+      </div>
+      <div class="flex-1 min-w-[120px]">
+        <div class="flex items-center gap-1.5 mb-2"><div class="w-2 h-2 rounded-full bg-teal-500"></div><span class="text-[9px] font-bold uppercase tracking-wider text-teal-400">Identity (10-12)</span><span class="text-[8px] font-bold bg-red-500/15 text-red-400 px-1.5 py-0.5 rounded">Gate 10</span></div>
+        <div class="space-y-1.5 p-2 rounded-lg border border-dashed border-teal-500/20 min-h-[80px] bg-teal-500/[0.02]">
+          <div class="p-2 rounded-md bg-white/[0.03] border border-white/[0.05] hover:bg-white/[0.06] transition-colors cursor-pointer" onclick="go('venturedetail')"><p class="text-[11px] font-medium text-white">VentureForge</p><div class="flex items-center justify-between mt-1"><span class="text-[9px] text-gray-500">Stage 10</span><div class="flex items-center gap-1"><div class="w-1.5 h-1.5 rounded-full bg-green-500"></div><span class="text-[9px] font-semibold text-green-400">91</span></div></div></div>
+        </div>
+        <div class="text-center mt-1.5"><span class="text-[9px] text-gray-600 bg-white/[0.03] px-2 py-0.5 rounded-full">1 venture</span></div>
+      </div>
+      <div class="flex-1 min-w-[120px]">
+        <div class="flex items-center gap-1.5 mb-2"><div class="w-2 h-2 rounded-full bg-orange-500"></div><span class="text-[9px] font-bold uppercase tracking-wider text-orange-400">Blueprint (13-15)</span></div>
+        <div class="p-2 rounded-lg border border-dashed border-orange-500/20 min-h-[80px] bg-orange-500/[0.02] flex items-center justify-center"><p class="text-[10px] text-gray-600 italic">No ventures</p></div>
+        <div class="text-center mt-1.5"><span class="text-[9px] text-gray-600 bg-white/[0.03] px-2 py-0.5 rounded-full">0 ventures</span></div>
+      </div>
+      <div class="flex-1 min-w-[120px]">
+        <div class="flex items-center gap-1.5 mb-2"><div class="w-2 h-2 rounded-full bg-pink-500"></div><span class="text-[9px] font-bold uppercase tracking-wider text-pink-400">Build (16-20)</span></div>
+        <div class="space-y-1.5 p-2 rounded-lg border border-dashed border-pink-500/20 min-h-[80px] bg-pink-500/[0.02]">
+          <div class="p-2 rounded-md bg-white/[0.03] border border-white/[0.05] hover:bg-white/[0.06] transition-colors cursor-pointer"><p class="text-[11px] font-medium text-white">CodeLens AI</p><div class="flex items-center justify-between mt-1"><span class="text-[9px] text-gray-500">Stage 18</span><div class="flex items-center gap-1"><div class="w-1.5 h-1.5 rounded-full bg-green-500"></div><span class="text-[9px] font-semibold text-green-400">85</span></div></div></div>
+        </div>
+        <div class="text-center mt-1.5"><span class="text-[9px] text-gray-600 bg-white/[0.03] px-2 py-0.5 rounded-full">1 venture</span></div>
+      </div>
+      <div class="flex-1 min-w-[120px]">
+        <div class="flex items-center gap-1.5 mb-2"><div class="w-2 h-2 rounded-full bg-emerald-500"></div><span class="text-[9px] font-bold uppercase tracking-wider text-emerald-400">Launch (21-25)</span><span class="text-[8px] font-bold bg-red-500/15 text-red-400 px-1.5 py-0.5 rounded">Gate 22</span></div>
+        <div class="space-y-1.5 p-2 rounded-lg border border-dashed border-emerald-500/20 min-h-[80px] bg-emerald-500/[0.02]">
+          <div class="p-2 rounded-md bg-white/[0.03] border border-red-500/20 hover:bg-white/[0.06] transition-colors cursor-pointer"><p class="text-[11px] font-medium text-white">NeuralPay</p><div class="flex items-center justify-between mt-1"><span class="text-[9px] text-gray-500">Stage 22</span><div class="flex items-center gap-1"><div class="w-1.5 h-1.5 rounded-full bg-red-500"></div><span class="text-[9px] font-semibold text-red-400">42</span></div></div></div>
+          <div class="p-2 rounded-md bg-white/[0.03] border border-white/[0.05] hover:bg-white/[0.06] transition-colors cursor-pointer"><p class="text-[11px] font-medium text-white">IntelliRoute</p><div class="flex items-center justify-between mt-1"><span class="text-[9px] text-gray-500">Stage 24</span><div class="flex items-center gap-1"><div class="w-1.5 h-1.5 rounded-full bg-green-500"></div><span class="text-[9px] font-semibold text-green-400">83</span></div></div></div>
+        </div>
+        <div class="text-center mt-1.5"><span class="text-[9px] text-gray-600 bg-white/[0.03] px-2 py-0.5 rounded-full">2 ventures</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ========== VIEW: VENTURE DETAIL ========== -->
+<div id="v-venturedetail" class="view p-4 md:p-6 space-y-4">
+  <button onclick="go('ventures')" class="flex items-center gap-1.5 text-[12px] text-gray-400 hover:text-gray-300 mb-1"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7"/></svg>Back to Ventures</button>
+  <div class="glass rounded-2xl p-5 glow-s">
+    <div class="flex items-start justify-between gap-4">
+      <div><h2 class="text-lg font-bold text-white">VentureForge</h2><p class="text-[12px] text-gray-400 mt-1">AI-powered venture creation platform &middot; Identity phase</p></div>
+      <div class="text-right"><p class="text-3xl font-bold text-green-400">91</p><p class="text-[10px] text-gray-500 uppercase tracking-wider">Health</p></div>
+    </div>
+  </div>
+  <!-- Stage Timeline -->
+  <div class="glass rounded-xl p-4">
+    <h3 class="text-[12px] font-semibold mb-3">Journey Progress</h3>
+    <div class="flex items-center gap-0.5 flex-wrap">
+      <div class="flex items-center gap-1 mr-2"><span class="text-[9px] text-purple-400 font-medium w-10">Truth</span></div>
+      <div class="w-5 h-5 rounded-full bg-purple-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">1</div><div class="w-3 h-0.5 bg-purple-500"></div>
+      <div class="w-5 h-5 rounded-full bg-purple-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">2</div><div class="w-3 h-0.5 bg-purple-500"></div>
+      <div class="w-5 h-5 rounded-full bg-purple-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">3</div><div class="w-5 h-0.5 bg-white/[0.06]"></div>
+      <div class="flex items-center gap-1 mr-2"><span class="text-[9px] text-blue-400 font-medium">Engine</span></div>
+      <div class="w-5 h-5 rounded-full bg-blue-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">4</div><div class="w-3 h-0.5 bg-blue-500"></div>
+      <div class="w-5 h-5 rounded-full bg-blue-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">5</div><div class="w-3 h-0.5 bg-blue-500"></div>
+      <div class="w-5 h-5 rounded-full bg-blue-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">6</div><div class="w-3 h-0.5 bg-blue-500"></div>
+      <div class="w-5 h-5 rounded-full bg-blue-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">7</div><div class="w-3 h-0.5 bg-blue-500"></div>
+      <div class="w-5 h-5 rounded-full bg-blue-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">8</div><div class="w-3 h-0.5 bg-blue-500"></div>
+      <div class="w-5 h-5 rounded-full bg-blue-500 text-white flex items-center justify-center text-[8px] font-bold stage-dot">9</div><div class="w-5 h-0.5 bg-white/[0.06]"></div>
+      <div class="flex items-center gap-1 mr-2"><span class="text-[9px] text-teal-400 font-medium">ID</span></div>
+      <div class="w-5 h-5 rounded-full bg-teal-500 text-white flex items-center justify-center text-[8px] font-bold ring-2 ring-teal-400 ring-offset-2 ring-offset-[#0a0e17] stage-dot">10</div><div class="w-3 h-0.5 bg-white/[0.06]"></div>
+      <div class="w-5 h-5 rounded-full bg-teal-900/50 text-teal-500/50 flex items-center justify-center text-[8px] stage-dot">11</div><div class="w-3 h-0.5 bg-white/[0.04]"></div>
+      <div class="w-5 h-5 rounded-full bg-teal-900/50 text-teal-500/50 flex items-center justify-center text-[8px] stage-dot">12</div>
+    </div>
+    <div class="mt-3 px-2 py-1.5 rounded-lg bg-teal-500/[0.06] inline-block"><span class="text-[11px] text-teal-300 font-medium">Currently in: THE IDENTITY &middot; Stage 10 of 25 (40%)</span></div>
+  </div>
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+    <div class="glass rounded-xl p-3"><p class="text-[9px] text-gray-500 uppercase tracking-wider mb-1">AI Score</p><p class="text-lg font-bold text-green-400">91</p></div>
+    <div class="glass rounded-xl p-3"><p class="text-[9px] text-gray-500 uppercase tracking-wider mb-1">Validation</p><p class="text-lg font-bold text-green-400">87</p></div>
+    <div class="glass rounded-xl p-3"><p class="text-[9px] text-gray-500 uppercase tracking-wider mb-1">Status</p><p class="text-lg font-bold text-white capitalize">active</p></div>
+    <div class="glass rounded-xl p-3"><p class="text-[9px] text-gray-500 uppercase tracking-wider mb-1">Time in Stage</p><p class="text-lg font-bold text-white">4d</p></div>
+  </div>
+</div>
+
+<!-- ========== VIEW: VISION ========== -->
+<div id="v-vision" class="view p-4 md:p-6 space-y-4">
+  <div class="flex items-center justify-between"><div><h2 class="text-base font-semibold">Vision & Alignment</h2><p class="text-[12px] text-gray-500 mt-0.5">Portfolio alignment against EHG-2028 vision</p></div>
+    <button class="px-3 py-1.5 rounded-lg text-[11px] font-medium bg-white/[0.04] border border-white/[0.06] text-gray-400 hover:bg-white/[0.06] transition-colors flex items-center gap-1.5"><svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>Refresh</button>
+  </div>
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <!-- Score Ring -->
+    <div class="glass rounded-2xl p-5 flex flex-col items-center glow-p">
+      <div class="relative w-32 h-32">
+        <svg class="w-full h-full -rotate-90" viewBox="0 0 120 120">
+          <circle cx="60" cy="60" r="52" fill="none" stroke="rgba(255,255,255,0.04)" stroke-width="8"/>
+          <circle cx="60" cy="60" r="52" fill="none" stroke="url(#vgrad)" stroke-width="8" stroke-linecap="round" stroke-dasharray="326.7" stroke-dashoffset="78.4" class="score-ring"/>
+          <defs><linearGradient id="vgrad" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#818cf8"/><stop offset="100%" stop-color="#6366f1"/></linearGradient></defs>
+        </svg>
+        <div class="absolute inset-0 flex flex-col items-center justify-center"><p class="text-3xl font-bold text-white">76</p><p class="text-[9px] text-gray-500 uppercase tracking-wider">Score</p></div>
+      </div>
+      <p class="text-[12px] text-gray-400 mt-2">Portfolio Vision Score</p>
+    </div>
+    <!-- Dimensions -->
+    <div class="glass rounded-2xl p-4">
+      <h3 class="text-[12px] font-semibold mb-3">Dimension Breakdown</h3>
+      <div class="space-y-2.5">
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Innovation</span><span class="text-green-400 font-medium">84%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-green-500 rounded-full" style="width:84%"></div></div></div>
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Market Reach</span><span class="text-amber-400 font-medium">71%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-amber-500 rounded-full" style="width:71%"></div></div></div>
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Sustainability</span><span class="text-green-400 font-medium">82%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-green-500 rounded-full" style="width:82%"></div></div></div>
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Revenue Potential</span><span class="text-red-400 font-medium">58%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-red-500 rounded-full" style="width:58%"></div></div></div>
+        <div><div class="flex justify-between text-[11px] mb-1"><span class="text-gray-400">Tech Moat</span><span class="text-green-400 font-medium">79%</span></div><div class="h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-green-500 rounded-full" style="width:79%"></div></div></div>
+      </div>
+    </div>
+    <!-- Trend -->
+    <div class="glass rounded-2xl p-4">
+      <h3 class="text-[12px] font-semibold mb-3">Score Trend (6mo)</h3>
+      <div class="flex items-end gap-2 h-32">
+        <div class="flex-1 flex flex-col items-center gap-1"><div class="w-full bg-indigo-500/60 rounded-t" style="height:58%"></div><span class="text-[8px] text-gray-600">Oct</span></div>
+        <div class="flex-1 flex flex-col items-center gap-1"><div class="w-full bg-indigo-500/60 rounded-t" style="height:62%"></div><span class="text-[8px] text-gray-600">Nov</span></div>
+        <div class="flex-1 flex flex-col items-center gap-1"><div class="w-full bg-indigo-500/70 rounded-t" style="height:68%"></div><span class="text-[8px] text-gray-600">Dec</span></div>
+        <div class="flex-1 flex flex-col items-center gap-1"><div class="w-full bg-indigo-500/80 rounded-t" style="height:72%"></div><span class="text-[8px] text-gray-600">Jan</span></div>
+        <div class="flex-1 flex flex-col items-center gap-1"><div class="w-full bg-indigo-500/90 rounded-t" style="height:74%"></div><span class="text-[8px] text-gray-600">Feb</span></div>
+        <div class="flex-1 flex flex-col items-center gap-1"><div class="w-full bg-indigo-500 rounded-t" style="height:76%"></div><span class="text-[8px] text-gray-400 font-medium">Mar</span></div>
+      </div>
+    </div>
+  </div>
+  <!-- Corrective SDs -->
+  <div class="glass rounded-xl p-4">
+    <h3 class="text-[12px] font-semibold mb-3">Active Corrective SDs</h3>
+    <div class="overflow-x-auto"><table class="w-full text-[11px]"><thead><tr class="text-gray-500 border-b border-white/[0.06]"><th class="text-left py-2 px-2 font-medium">SD Key</th><th class="text-left py-2 px-2 font-medium">Title</th><th class="text-left py-2 px-2 font-medium">Dimension</th><th class="text-left py-2 px-2 font-medium">Status</th></tr></thead>
+    <tbody>
+      <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]"><td class="py-2 px-2 font-mono text-indigo-400">SD-CORR-REV-001</td><td class="py-2 px-2 text-white">Revenue model diversification</td><td class="py-2 px-2"><span class="px-1.5 py-0.5 rounded bg-red-500/10 text-red-400">Revenue</span></td><td class="py-2 px-2"><span class="px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400">In Progress</span></td></tr>
+      <tr class="border-b border-white/[0.03] hover:bg-white/[0.02]"><td class="py-2 px-2 font-mono text-indigo-400">SD-CORR-MKT-002</td><td class="py-2 px-2 text-white">Market expansion strategy</td><td class="py-2 px-2"><span class="px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400">Market</span></td><td class="py-2 px-2"><span class="px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-400">Planning</span></td></tr>
+    </tbody></table></div>
+  </div>
+</div>
+
+<!-- ========== VIEW: PREFERENCES ========== -->
+<div id="v-prefs" class="view p-4 md:p-6 space-y-4">
+  <h2 class="text-base font-semibold">Preferences</h2>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div class="glass rounded-xl p-4 space-y-4">
+      <h3 class="text-[12px] font-semibold flex items-center gap-2"><svg class="w-4 h-4 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>Risk Tolerance</h3>
+      <div class="space-y-3">
+        <div><label class="text-[11px] text-gray-400 block mb-1.5">Kill Gate Threshold</label><div class="flex items-center gap-3"><input type="range" min="20" max="60" value="40" class="flex-1 accent-indigo-500 h-1"><span class="text-[11px] font-mono text-white bg-white/[0.04] px-2 py-1 rounded">40%</span></div></div>
+        <div><label class="text-[11px] text-gray-400 block mb-1.5">Max Concurrent Ventures</label><div class="flex items-center gap-3"><input type="range" min="3" max="15" value="8" class="flex-1 accent-indigo-500 h-1"><span class="text-[11px] font-mono text-white bg-white/[0.04] px-2 py-1 rounded">8</span></div></div>
+      </div>
+    </div>
+    <div class="glass rounded-xl p-4 space-y-4">
+      <h3 class="text-[12px] font-semibold flex items-center gap-2"><svg class="w-4 h-4 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>Notifications</h3>
+      <div class="space-y-3">
+        <label class="flex items-center justify-between cursor-pointer"><span class="text-[11px] text-gray-300">Critical gate alerts</span><div class="w-9 h-5 bg-indigo-500 rounded-full relative"><div class="absolute w-4 h-4 bg-white rounded-full top-0.5 right-0.5 shadow-sm"></div></div></label>
+        <label class="flex items-center justify-between cursor-pointer"><span class="text-[11px] text-gray-300">Daily briefing email</span><div class="w-9 h-5 bg-indigo-500 rounded-full relative"><div class="absolute w-4 h-4 bg-white rounded-full top-0.5 right-0.5 shadow-sm"></div></div></label>
+        <label class="flex items-center justify-between cursor-pointer"><span class="text-[11px] text-gray-300">Health score drops</span><div class="w-9 h-5 bg-white/10 rounded-full relative"><div class="absolute w-4 h-4 bg-gray-400 rounded-full top-0.5 left-0.5 shadow-sm"></div></div></label>
+      </div>
+    </div>
+  </div>
+  <div class="glass rounded-xl p-4 space-y-3">
+    <h3 class="text-[12px] font-semibold">Budget Caps</h3>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <div><label class="text-[11px] text-gray-400 block mb-1">Monthly Token Budget</label><div class="flex items-center gap-2"><input type="text" value="200,000" class="bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-1.5 text-[12px] text-white w-full outline-none focus:border-indigo-500/50"><span class="text-[10px] text-gray-500 shrink-0">tokens</span></div></div>
+      <div><label class="text-[11px] text-gray-400 block mb-1">Max Per-Venture Spend</label><div class="flex items-center gap-2"><input type="text" value="50,000" class="bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-1.5 text-[12px] text-white w-full outline-none focus:border-indigo-500/50"><span class="text-[10px] text-gray-500 shrink-0">tokens</span></div></div>
+      <div><label class="text-[11px] text-gray-400 block mb-1">Alert Threshold</label><div class="flex items-center gap-2"><input type="text" value="80" class="bg-white/[0.04] border border-white/[0.06] rounded-lg px-3 py-1.5 text-[12px] text-white w-full outline-none focus:border-indigo-500/50"><span class="text-[10px] text-gray-500 shrink-0">%</span></div></div>
+    </div>
+  </div>
+</div>
+
+<!-- ========== VIEW: ACTIVE SDs ========== -->
+<div id="v-active" class="view p-4 md:p-6 space-y-4">
+  <h2 class="text-base font-semibold flex items-center gap-2">
+    <svg class="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
+    Active SDs<span class="text-[10px] font-medium bg-green-500/15 text-green-400 px-2 py-0.5 rounded-full">4</span>
+  </h2>
+  <div class="space-y-4">
+    <div><h3 class="text-[10px] font-semibold uppercase tracking-wider text-purple-400 mb-2">LEAD Phase (1)</h3>
+      <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1 min-w-0"><p class="text-[10px] font-mono text-gray-600">SD-LEO-ARCH-007</p><h4 class="text-[13px] font-medium text-white truncate">Chairman Dashboard V3 Architecture</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-purple-500 text-white px-2 py-0.5 rounded">LEAD</span><button class="p-1 rounded hover:bg-white/5" title="Open in Claude Code"><svg class="w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg></button></div></div><div class="flex items-center gap-2 mt-2"><div class="flex-1 h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-purple-500 rounded-full" style="width:15%"></div></div><span class="text-[10px] text-gray-500 font-mono w-8 text-right">15%</span></div></div>
+    </div>
+    <div><h3 class="text-[10px] font-semibold uppercase tracking-wider text-blue-400 mb-2">PLAN Phase (1)</h3>
+      <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1 min-w-0"><p class="text-[10px] font-mono text-gray-600">SD-CORR-MKT-002</p><h4 class="text-[13px] font-medium text-white truncate">Market Expansion Strategy</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-blue-500 text-white px-2 py-0.5 rounded">PLAN</span><button class="p-1 rounded hover:bg-white/5"><svg class="w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg></button></div></div><div class="flex items-center gap-2 mt-2"><div class="flex-1 h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-blue-500 rounded-full" style="width:45%"></div></div><span class="text-[10px] text-gray-500 font-mono w-8 text-right">45%</span></div></div>
+    </div>
+    <div><h3 class="text-[10px] font-semibold uppercase tracking-wider text-green-400 mb-2">EXEC Phase (2)</h3>
+      <div class="space-y-2">
+        <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1 min-w-0"><p class="text-[10px] font-mono text-gray-600">SD-CORR-REV-001</p><h4 class="text-[13px] font-medium text-white truncate">Revenue Model Diversification</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-green-500 text-white px-2 py-0.5 rounded">EXEC</span><button class="p-1 rounded hover:bg-white/5"><svg class="w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg></button></div></div><div class="flex items-center gap-2 mt-2"><div class="flex-1 h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-green-500 rounded-full" style="width:72%"></div></div><span class="text-[10px] text-gray-500 font-mono w-8 text-right">72%</span></div></div>
+        <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1 min-w-0"><p class="text-[10px] font-mono text-gray-600">SD-INFRA-DB-004</p><h4 class="text-[13px] font-medium text-white truncate">Database Migration Pipeline</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-green-500 text-white px-2 py-0.5 rounded">EXEC</span><button class="p-1 rounded hover:bg-white/5"><svg class="w-3.5 h-3.5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg></button></div></div><div class="flex items-center gap-2 mt-2"><div class="flex-1 h-1.5 bg-white/[0.04] rounded-full overflow-hidden"><div class="h-full bg-green-500 rounded-full" style="width:38%"></div></div><span class="text-[10px] text-gray-500 font-mono w-8 text-right">38%</span></div></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ========== VIEW: BUILD QUEUE ========== -->
+<div id="v-queue" class="view p-4 md:p-6 space-y-4">
+  <div class="flex items-center justify-between">
+    <h2 class="text-base font-semibold flex items-center gap-2"><svg class="w-5 h-5 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 10h16M4 14h16M4 18h16"/></svg>Build Queue<span class="text-[10px] font-medium bg-white/5 text-gray-400 px-2 py-0.5 rounded-full">6</span></h2>
+    <div class="flex gap-1">
+      <button class="px-2.5 py-1 rounded-lg text-[10px] font-medium bg-indigo-500/15 text-indigo-300 border border-indigo-500/20">All</button>
+      <button class="px-2.5 py-1 rounded-lg text-[10px] font-medium text-gray-500 hover:bg-white/[0.03]">P0-P1</button>
+      <button class="px-2.5 py-1 rounded-lg text-[10px] font-medium text-gray-500 hover:bg-white/[0.03]">P2-P3</button>
+    </div>
+  </div>
+  <div class="space-y-2">
+    <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1"><p class="text-[10px] font-mono text-gray-600">SD-FEAT-AUTH-009</p><h4 class="text-[13px] font-medium text-white">Multi-tenant Auth System</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-red-500 text-white px-2 py-0.5 rounded">P0</span><span class="text-[9px] bg-white/5 text-gray-400 px-1.5 py-0.5 rounded">feature</span></div></div></div>
+    <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1"><p class="text-[10px] font-mono text-gray-600">SD-INFRA-PERF-003</p><h4 class="text-[13px] font-medium text-white">API Response Time Optimization</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-red-500 text-white px-2 py-0.5 rounded">P1</span><span class="text-[9px] bg-white/5 text-gray-400 px-1.5 py-0.5 rounded">infra</span></div></div></div>
+    <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1"><p class="text-[10px] font-mono text-gray-600">SD-FEAT-DASH-012</p><h4 class="text-[13px] font-medium text-white">Real-time Venture Health Streaming</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-orange-500 text-white px-2 py-0.5 rounded">P2</span><span class="text-[9px] bg-white/5 text-gray-400 px-1.5 py-0.5 rounded">feature</span></div></div></div>
+    <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1"><p class="text-[10px] font-mono text-gray-600">SD-QUAL-TEST-005</p><h4 class="text-[13px] font-medium text-white">E2E Test Coverage for Gate Flows</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-orange-500 text-white px-2 py-0.5 rounded">P3</span><span class="text-[9px] bg-white/5 text-gray-400 px-1.5 py-0.5 rounded">quality</span></div></div></div>
+    <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1"><p class="text-[10px] font-mono text-gray-600">SD-FEAT-NOTIF-008</p><h4 class="text-[13px] font-medium text-white">Push Notification Infrastructure</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-gray-500 text-white px-2 py-0.5 rounded">P4</span><span class="text-[9px] bg-white/5 text-gray-400 px-1.5 py-0.5 rounded">feature</span></div></div></div>
+    <div class="glass rounded-xl p-3.5 ch"><div class="flex items-start justify-between gap-2"><div class="flex-1"><p class="text-[10px] font-mono text-gray-600">SD-INFRA-LOG-006</p><h4 class="text-[13px] font-medium text-white">Structured Logging & Observability</h4></div><div class="flex items-center gap-1.5"><span class="text-[9px] font-bold bg-gray-500 text-white px-2 py-0.5 rounded">P5</span><span class="text-[9px] bg-white/5 text-gray-400 px-1.5 py-0.5 rounded">infra</span></div></div></div>
+  </div>
+</div>
+
+<!-- ========== VIEW: INBOX ========== -->
+<div id="v-inbox" class="view p-4 md:p-6 space-y-4">
+  <div class="flex items-center justify-between">
+    <h2 class="text-base font-semibold flex items-center gap-2"><svg class="w-5 h-5 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/></svg>Brainstorm Inbox<span class="text-[10px] font-medium bg-indigo-500/15 text-indigo-400 px-2 py-0.5 rounded-full">2 new</span></h2>
+    <button class="px-3 py-1.5 rounded-lg text-[11px] font-medium bg-indigo-500/15 border border-indigo-500/20 text-indigo-300 hover:bg-indigo-500/25 transition-colors">+ New Idea</button>
+  </div>
+  <div class="space-y-2">
+    <div class="glass rounded-xl p-4 ch border-l-[3px] border-indigo-500">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex-1">
+          <div class="flex items-center gap-2 mb-1"><span class="text-[8px] font-bold uppercase bg-indigo-500/15 text-indigo-400 px-1.5 py-0.5 rounded">New</span><h4 class="text-[13px] font-medium text-white">AI-Powered Competitor Intelligence Tool</h4></div>
+          <p class="text-[11px] text-gray-400 mt-1">Automated competitive landscape monitoring using LLMs to parse SEC filings, press releases, and product launches. Could integrate with existing EHG portfolio analysis.</p>
+          <div class="flex items-center gap-3 mt-2"><span class="text-[10px] text-gray-600">2h ago</span><span class="text-[10px] text-gray-600">&bull;</span><span class="text-[10px] text-gray-500">via brainstorm CLI</span></div>
+        </div>
+        <div class="flex gap-1 shrink-0">
+          <button class="p-1.5 rounded-lg hover:bg-green-500/10 text-gray-500 hover:text-green-400 transition-colors" title="Promote to SD"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg></button>
+          <button class="p-1.5 rounded-lg hover:bg-red-500/10 text-gray-500 hover:text-red-400 transition-colors" title="Dismiss"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 18L18 6M6 6l12 12"/></svg></button>
+        </div>
+      </div>
+    </div>
+    <div class="glass rounded-xl p-4 ch border-l-[3px] border-indigo-500">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex-1">
+          <div class="flex items-center gap-2 mb-1"><span class="text-[8px] font-bold uppercase bg-indigo-500/15 text-indigo-400 px-1.5 py-0.5 rounded">New</span><h4 class="text-[13px] font-medium text-white">Voice-First Venture Management Interface</h4></div>
+          <p class="text-[11px] text-gray-400 mt-1">Natural language interface for EVA interactions. Chairman could review decisions, approve gates, and check portfolio health via voice commands during commute.</p>
+          <div class="flex items-center gap-3 mt-2"><span class="text-[10px] text-gray-600">1d ago</span><span class="text-[10px] text-gray-600">&bull;</span><span class="text-[10px] text-gray-500">via web capture</span></div>
+        </div>
+        <div class="flex gap-1 shrink-0">
+          <button class="p-1.5 rounded-lg hover:bg-green-500/10 text-gray-500 hover:text-green-400 transition-colors"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg></button>
+          <button class="p-1.5 rounded-lg hover:bg-red-500/10 text-gray-500 hover:text-red-400 transition-colors"><svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 18L18 6M6 6l12 12"/></svg></button>
+        </div>
+      </div>
+    </div>
+    <div class="glass rounded-xl p-4 ch opacity-60">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex-1">
+          <h4 class="text-[13px] font-medium text-white">Automated PR Review Bot for EHG Repos</h4>
+          <p class="text-[11px] text-gray-400 mt-1">LLM-powered code review that checks against LEO protocol compliance, component sizing, and accessibility standards.</p>
+          <div class="flex items-center gap-3 mt-2"><span class="text-[10px] text-gray-600">3d ago</span><span class="text-[10px] text-green-500">Promoted to SD-FEAT-REVIEW-010</span></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+  </main>
+</div>
+
+<!-- MOBILE TAB BAR -->
+<div class="mob-tabs hidden fixed bottom-0 left-0 right-0 h-16 bg-[#0c1019]/95 backdrop-blur-xl border-t border-white/[0.06] items-center justify-around px-2 z-30">
+  <button onclick="go('briefing')" class="mob-tab flex flex-col items-center gap-0.5 py-1 px-2 rounded-lg" data-v="briefing">
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
+    <span class="text-[9px]">Briefing</span></button>
+  <button onclick="go('decisions')" class="mob-tab flex flex-col items-center gap-0.5 py-1 px-2 rounded-lg" data-v="decisions">
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+    <span class="text-[9px]">Decisions</span></button>
+  <button onclick="go('ventures')" class="mob-tab flex flex-col items-center gap-0.5 py-1 px-2 rounded-lg" data-v="ventures">
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16"/></svg>
+    <span class="text-[9px]">Ventures</span></button>
+  <button onclick="go('vision')" class="mob-tab flex flex-col items-center gap-0.5 py-1 px-2 rounded-lg" data-v="vision">
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>
+    <span class="text-[9px]">Vision</span></button>
+  <button onclick="go('active')" class="mob-tab flex flex-col items-center gap-0.5 py-1 px-2 rounded-lg" data-v="active">
+    <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
+    <span class="text-[9px]">Build</span></button>
+</div>
+
+</div>
+
+<script>
+const titles={briefing:'Daily Briefing',decisions:'Decision Gates',detail:'Decision Detail',ventures:'Venture Lifecycle',venturedetail:'Venture Detail',vision:'Vision & Alignment',prefs:'Preferences',active:'Active SDs',queue:'Build Queue',inbox:'Brainstorm Inbox'};
+let currentView='briefing';
+let isDark=true;
+let isChairman=true;
+
+function go(v){
+  document.querySelectorAll('.view').forEach(el=>el.classList.remove('active'));
+  const target=document.getElementById('v-'+v);
+  if(target){target.classList.add('active');currentView=v;}
+  document.getElementById('ptitle').textContent=titles[v]||v;
+  document.querySelectorAll('.nav-btn').forEach(b=>{b.classList.remove('act');if(b.dataset.v===v)b.classList.add('act');});
+  document.querySelectorAll('.mob-tab').forEach(b=>{
+    b.style.color=b.dataset.v===v?'#a5b4fc':'#6b7280';
+  });
+}
+
+function toggleTheme(){
+  isDark=!isDark;
+  const html=document.documentElement;
+  if(isDark){html.classList.add('dark');html.classList.remove('light');document.body.style.background='#0a0e17';document.body.style.color='#e5e7eb';document.getElementById('t-dark').classList.remove('hidden');document.getElementById('t-light').classList.add('hidden');}
+  else{html.classList.remove('dark');html.classList.add('light');document.body.style.background='#f8fafc';document.body.style.color='#1e293b';document.getElementById('t-dark').classList.add('hidden');document.getElementById('t-light').classList.remove('hidden');}
+  // Update sidebar/topbar backgrounds
+  const sidebar=document.querySelector('.sidebar-area');
+  const topbar=document.querySelector('header');
+  if(sidebar)sidebar.style.background=isDark?'#0c1019':'#ffffff';
+  if(topbar)topbar.style.background=isDark?'rgba(10,14,23,0.8)':'rgba(248,250,252,0.8)';
+  document.querySelectorAll('.glass').forEach(el=>{
+    if(!isDark){el.style.background='rgba(255,255,255,0.7)';el.style.borderColor='rgba(0,0,0,0.06)';}
+    else{el.style.background='';el.style.borderColor='';}
+  });
+}
+
+function togglePersona(){
+  isChairman=!isChairman;
+  const btn=document.getElementById('persona-btn');
+  const icon=document.getElementById('p-icon');
+  const label=document.getElementById('p-label');
+  if(isChairman){icon.textContent='\u265A';icon.style.color='#fbbf24';label.textContent='Chairman';btn.style.borderColor='rgba(251,191,36,0.25)';btn.style.background='rgba(251,191,36,0.04)';}
+  else{icon.textContent='\u2692';icon.style.color='#60a5fa';label.textContent='Builder';btn.style.borderColor='rgba(96,165,250,0.25)';btn.style.background='rgba(96,165,250,0.04)';}
+}
+
+// Init mobile tabs
+document.querySelectorAll('.mob-tab').forEach(b=>{
+  b.style.color=b.dataset.v==='briefing'?'#a5b4fc':'#6b7280';
+});
+</script>
+</body>
+</html>

--- a/docs/plans/chairman-web-ui-architecture-v2.md
+++ b/docs/plans/chairman-web-ui-architecture-v2.md
@@ -1,0 +1,1648 @@
+# Chairman Web UI — Architecture Plan v2
+
+## Metadata
+
+- **Version**: 2.0.0
+- **Date**: 2026-03-02
+- **Status**: Draft
+- **Supersedes**: `docs/plans/chairman-web-ui-architecture.md` (v1.0.0)
+- **Companion**: `docs/plans/chairman-web-ui-vision-v2.md`
+
+---
+
+## Table of Contents
+
+- [1. Overview](#1-overview)
+- [2. Repository & Stack](#2-repository--stack)
+- [3. Route Structure](#3-route-structure)
+- [4. ChairmanShell Layout](#4-chairmanshell-layout)
+- [5. Component Architecture](#5-component-architecture)
+- [6. Data Layer](#6-data-layer)
+- [7. Governance API Surface](#7-governance-api-surface)
+- [8. Zod Response Validation](#8-zod-response-validation)
+- [9. Zustand Client State](#9-zustand-client-state)
+- [10. Progressive Disclosure Architecture](#10-progressive-disclosure-architecture)
+- [11. Gate-Specific Renderers](#11-gate-specific-renderers)
+- [12. Claude Code Integration](#12-claude-code-integration)
+- [13. Notification System](#13-notification-system)
+- [14. Mobile & PWA](#14-mobile--pwa)
+- [15. Legacy Deprecation](#15-legacy-deprecation)
+- [16. Implementation Phases](#16-implementation-phases)
+- [17. Testing Strategy](#17-testing-strategy)
+- [18. Risk Mitigation](#18-risk-mitigation)
+
+---
+
+## 1. Overview
+
+This document defines the technical architecture for the Chairman Web UI rebuild. It is the engineering companion to the vision document (v2) and provides actionable specifications for components, data flow, API contracts, and implementation phasing.
+
+**Architecture principles**:
+1. **Single shell** — one `ChairmanShell` layout replaces the double-layer `AuthenticatedLayout > ChairmanLayoutV3` nesting
+2. **Route-based personas** — `/chairman/*` and `/builder/*` share the shell but show different sidebar sections
+3. **RPC-first governance** — decision mutations go through Supabase RPC functions, not direct table writes
+4. **Validate at the boundary** — Zod schemas on every Supabase response, graceful fallback on failure
+5. **Clean up as we go** — no separate legacy cleanup phase; each SD removes what it replaces
+
+---
+
+## 2. Repository & Stack
+
+### 2.1 Repo: `rickfelix/ehg`
+
+Local path: `C:\Users\rickf\Projects\_EHG\ehg`
+
+All work happens in the existing EHG app. No new repositories. Feature branches per SD, PRs to `main`.
+
+### 2.2 Tech Stack
+
+| Layer | Technology | Version | Notes |
+|-------|-----------|---------|-------|
+| Framework | React | ^18.3.1 | Existing |
+| Build | Vite | Existing | Existing |
+| Language | TypeScript | Existing | Strict mode |
+| UI Components | Shadcn UI | Existing | Card, Table, Badge, Button, Sheet, Tabs, ScrollArea |
+| Styling | Tailwind CSS | Existing | Responsive utilities, `cn()` from lib/utils |
+| Icons | Lucide React | Existing | Consistent icon set |
+| Data | @supabase/supabase-js | ^2.56.0 | Hosted instance: `dedlbzhpgkmetvhbkyzq.supabase.co` |
+| Auth | Supabase Auth | Existing | `ProtectedRoute` + `ProtectedRouteWrapper` |
+| State (server) | @tanstack/react-query | ^5.83.0 | v5 object syntax required |
+| State (client) | zustand | ^5.0.8 | New `chairman-ui` store (see Section 9) |
+| Routing | react-router-dom | ^6.30.1 | Existing |
+| Charts | Recharts | ^2.15.4 | HEAL trends, health visualizations |
+| Animation | framer-motion | ^11.18.2 | Subtle view transitions only |
+| Validation | zod | ^3.25.76 | RPC response validation (see Section 8) |
+| Toasts | sonner | ^1.7.4 | **Only toast system** for v3 — see Section 2.3 |
+| Theme | Custom ThemeProvider | Existing | `src/components/theme/ThemeProvider.tsx` |
+| Hosting | Vercel | Existing | HTTPS, edge CDN |
+
+### 2.3 Toast System: Sonner Only
+
+Two toast systems exist in the app. Chairman v3 standardizes on **sonner**:
+
+| System | Package | v3 Usage |
+|--------|---------|----------|
+| sonner | `sonner ^1.7.4` | **Use exclusively** — `toast.success()`, `toast.error()`, `toast.info()` |
+| Radix toast | `@radix-ui/react-toast` | **Do NOT import** in any v3 component |
+
+Sonner is already themed via `src/components/ui/sonner.tsx`. The `next-themes` import in that file should be swapped to the custom ThemeProvider during cleanup.
+
+### 2.4 React Query v5 Conventions
+
+All v3 hooks must use the v5 object syntax:
+
+```tsx
+// CORRECT (v5)
+const { data, isLoading } = useQuery({
+  queryKey: ['chairman', 'decisions', 'pending'],
+  queryFn: async () => { ... },
+  staleTime: 60_000,
+});
+
+// WRONG (v4 shorthand)
+const { data } = useQuery(['decisions'], fetchDecisions);
+```
+
+**Query key conventions**:
+- Prefix: `['chairman', ...]` or `['builder', ...]`
+- Include filter params: `['chairman', 'decisions', { status: 'pending', gateType }]`
+- Mutations use `useMutation` with `onSuccess` invalidation of related keys
+
+### 2.5 Animation Rules (Framer Motion)
+
+| Transition | Animation | Duration |
+|------------|-----------|----------|
+| View mount | Fade in + slide up 8px | 200ms |
+| Decision card enter | Stagger children 50ms | 150ms each |
+| Persona toggle | Crossfade sidebar items | 250ms |
+| Toast | Slide in from right (handled by sonner) | 200ms |
+| Modal/Sheet | Scale from 0.95 + fade | 200ms |
+
+**Rule**: No animation > 300ms. No spring physics. This is a governance tool.
+
+---
+
+## 3. Route Structure
+
+### 3.1 Route Groups
+
+```
+/chairman                    → Daily Briefing (landing)
+/chairman/decisions          → Decision Queue (blocking gates)
+/chairman/decisions/:id      → Decision Detail (full context)
+/chairman/ventures           → Venture Lifecycle Map
+/chairman/ventures/:id       → Venture Detail (25-stage view)
+/chairman/vision             → Vision & Alignment (HEAL scores)
+/chairman/preferences        → Chairman Preferences
+
+/builder                     → Builder Dashboard (Active SDs)
+/builder/queue               → Build Queue (SD pipeline)
+/builder/inbox               → Brainstorm Inbox
+```
+
+**Total**: 7 chairman routes + 3 builder routes = 10 routes (down from 19+)
+
+### 3.2 Route File
+
+New file: `src/routes/chairmanRoutesV3.tsx`
+
+Coexists with `chairmanRoutes.tsx` during transition. Once stable, the old file is deleted and the new file is renamed.
+
+```tsx
+// src/routes/chairmanRoutesV3.tsx
+import { Route } from 'react-router-dom';
+import { ProtectedRouteWrapper } from '@/components/auth/ProtectedRouteWrapper';
+import { LazyRoute } from '@/components/routing/LazyRoute';
+import { RouteErrorBoundary } from '@/components/errors/RouteErrorBoundary';
+import ChairmanShell from '@/components/chairman-v3/ChairmanShell';
+
+// All routes wrapped in: ProtectedRoute > ChairmanShell
+// NO exceptions — every v3 route uses ChairmanShell
+
+export const chairmanRoutesV3 = (
+  <Route element={<ChairmanShell />}>
+    {/* Chairman persona */}
+    <Route path="/chairman" element={
+      <ProtectedRouteWrapper loadingMessage="Loading briefing...">
+        <LazyRoute component={() => import('@/components/chairman-v3/DailyBriefing')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    <Route path="/chairman/decisions" element={
+      <ProtectedRouteWrapper loadingMessage="Loading decisions...">
+        <LazyRoute component={() => import('@/components/chairman-v3/DecisionQueue')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    <Route path="/chairman/decisions/:id" element={
+      <ProtectedRouteWrapper loadingMessage="Loading decision...">
+        <LazyRoute component={() => import('@/components/chairman-v3/DecisionDetail')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    <Route path="/chairman/ventures" element={
+      <ProtectedRouteWrapper loadingMessage="Loading ventures...">
+        <LazyRoute component={() => import('@/components/chairman-v3/VentureLifecycle')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    <Route path="/chairman/ventures/:id" element={
+      <ProtectedRouteWrapper loadingMessage="Loading venture...">
+        <LazyRoute component={() => import('@/components/chairman-v3/VentureDetail')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    <Route path="/chairman/vision" element={
+      <ProtectedRouteWrapper loadingMessage="Loading vision...">
+        <LazyRoute component={() => import('@/components/chairman-v3/VisionAlignment')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    <Route path="/chairman/preferences" element={
+      <ProtectedRouteWrapper loadingMessage="Loading preferences...">
+        <LazyRoute component={() => import('@/components/chairman-v3/Preferences')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    {/* Builder persona */}
+    <Route path="/builder" element={
+      <ProtectedRouteWrapper loadingMessage="Loading builder...">
+        <LazyRoute component={() => import('@/components/chairman-v3/builder/BuilderDashboard')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    <Route path="/builder/queue" element={
+      <ProtectedRouteWrapper loadingMessage="Loading queue...">
+        <LazyRoute component={() => import('@/components/chairman-v3/builder/BuildQueue')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    <Route path="/builder/inbox" element={
+      <ProtectedRouteWrapper loadingMessage="Loading inbox...">
+        <LazyRoute component={() => import('@/components/chairman-v3/builder/BrainstormInbox')} />
+      </ProtectedRouteWrapper>
+    } errorElement={<RouteErrorBoundary />} />
+
+    {/* Redirects from legacy routes */}
+    <Route path="/chairman/overview" element={<Navigate to="/chairman" replace />} />
+    <Route path="/chairman/settings" element={<Navigate to="/chairman/preferences" replace />} />
+    <Route path="/chairman/gates" element={<Navigate to="/chairman/decisions" replace />} />
+    <Route path="/chairman/escalations/:id" element={<Navigate to="/chairman/decisions" replace />} />
+    <Route path="/chairman/governance" element={<Navigate to="/chairman" replace />} />
+    <Route path="/chairman/lifecycle" element={<Navigate to="/chairman/ventures" replace />} />
+    <Route path="/chairman/portfolio" element={<Navigate to="/chairman/ventures" replace />} />
+    <Route path="/chairman/*" element={<Navigate to="/chairman" replace />} />
+  </Route>
+);
+```
+
+---
+
+## 4. ChairmanShell Layout
+
+### 4.1 Component: `ChairmanShell.tsx`
+
+Replaces both `AuthenticatedLayout` and `ChairmanLayoutV3` for all chairman/builder routes.
+
+```tsx
+interface ChairmanShellProps {
+  children?: React.ReactNode; // or uses <Outlet />
+}
+```
+
+**Structure**:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  TopNav: ◆ EHG    [Chairman ▼] [Builder]               ⚙ Prefs  👤  │
+├────────────┬─────────────────────────────────────────────────────────┤
+│  Sidebar   │  <Outlet />                                             │
+│  (w-56)    │  (main content area)                                    │
+│            │                                                         │
+│  CHAIRMAN  │                                                         │
+│  ────────  │                                                         │
+│  Briefing  │                                                         │
+│  Decisions │                                                         │
+│  Ventures  │                                                         │
+│  Vision    │                                                         │
+│  Prefs     │                                                         │
+│            │                                                         │
+│  BUILDER   │                                                         │
+│  ────────  │                                                         │
+│  Active    │                                                         │
+│  Queue     │                                                         │
+│  Inbox     │                                                         │
+│            │                                                         │
+│ ────────── │                                                         │
+│ Alerts 🔴3 │                                                         │
+└────────────┴─────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Desktop Behavior
+
+- **Sidebar width**: `w-56` (224px) expanded, `w-14` (56px) collapsed (icon-only)
+- **Auto-collapse**: Below 1200px viewport width
+- **Persona toggle**: Top nav buttons. Clicking "Chairman" or "Builder" scrolls sidebar to that section and navigates to persona landing page (`/chairman` or `/builder`)
+- **Active route**: Highlighted with accent background + left border indicator
+- **Alert badge**: Sidebar bottom item, red dot with unread count. Clicking opens alert panel (Sheet from right)
+- **No header chrome beyond top nav**: No breadcrumbs, no search bar, no company selector in the shell. Those belong to other app sections.
+
+### 4.3 Mobile Behavior (< 768px)
+
+- **Sidebar hidden**: Replaced by bottom tab bar
+- **Top nav simplified**: Logo + settings gear + user avatar only
+- **Bottom tab bar**: Fixed, `h-14`
+  - Chairman: Briefing, Decisions, Ventures, Vision, [overflow: Prefs + persona switch]
+  - Builder: Active, Queue, Inbox, [overflow: persona switch]
+- **Full width content**: No sidebar consuming space
+
+### 4.4 What ChairmanShell Does NOT Include
+
+- `ModernNavigationSidebar` (the 50+ route sidebar) — not rendered
+- `HeaderSearch`, `BreadcrumbNavigation`, `CompanySelector` — not rendered
+- `FloatingEVAAssistant`, `FeedbackWidget`, `FeatureSearch` — not rendered
+- `AttentionQueueSidebar` — replaced by the alert badge + panel
+- `MobileTabBar` (existing) — replaced by new bottom tab bar component
+
+The ChairmanShell is an entirely new layout. It does NOT wrap `AuthenticatedLayout`.
+
+---
+
+## 5. Component Architecture
+
+### 5.1 Directory Structure
+
+```
+src/components/chairman-v3/
+  ChairmanShell.tsx            # Layout: top nav + sidebar + bottom tabs + <Outlet />
+  DailyBriefing.tsx            # /chairman — morning summary
+  DecisionQueue.tsx            # /chairman/decisions — pending gate list
+  DecisionDetail.tsx           # /chairman/decisions/:id — full context
+  VentureLifecycle.tsx         # /chairman/ventures — all ventures pipeline
+  VentureDetail.tsx            # /chairman/ventures/:id — single 25-stage view
+  VisionAlignment.tsx          # /chairman/vision — HEAL scores + drift
+  Preferences.tsx              # /chairman/preferences — settings editor
+
+  builder/
+    BuilderDashboard.tsx       # /builder — active SDs
+    BuildQueue.tsx             # /builder/queue — SD pipeline
+    BrainstormInbox.tsx        # /builder/inbox — idea capture + history
+
+  gates/
+    GateRendererStage0.tsx     # Venture routing context
+    GateRendererStage10.tsx    # Brand approval context
+    GateRendererStage22.tsx    # Release readiness context
+    GateRendererStage25.tsx    # Portfolio review context
+    GateRendererKillGate.tsx   # Kill gate context (stages 3, 5, 13, 23)
+    GateRenderer.tsx           # Router component: picks renderer by gate type
+
+  shared/
+    ClaudeCodeLink.tsx         # "Open in Claude Code" — context assembly + clipboard
+    DecisionActions.tsx        # Approve/Reject/Park button group with confirmation
+    HealthScore.tsx            # Color-coded 0-100 score display
+    StageIndicator.tsx         # Small stage badge (number + status color)
+    StagePipeline.tsx          # Horizontal 25-stage pipeline visualization
+    AlertPanel.tsx             # Right-side sheet for notification list
+    MetricCard.tsx             # Dashboard metric card (count + label + trend)
+    PersonaToggle.tsx          # Chairman/Builder switch buttons
+    BottomTabBar.tsx           # Mobile bottom navigation
+    StaleDataIndicator.tsx     # "Last updated: 3m ago [Refresh]"
+
+  index.ts                     # Barrel exports
+```
+
+### 5.2 Key Shared Components
+
+#### ClaudeCodeLink
+
+```tsx
+interface ClaudeCodeLinkProps {
+  ventureId: string;
+  ventureName: string;
+  gateType?: string;
+  stage?: number;
+  summary: string;
+  dataSnapshot: Record<string, unknown>;
+  suggestedAction?: string;
+}
+```
+
+Behavior:
+1. Formats data into markdown context block (see vision v2 Section 7.3)
+2. `navigator.clipboard.writeText(formatted)`
+3. `toast.success("Copied to clipboard — paste into Claude Code")`
+
+#### DecisionActions
+
+```tsx
+interface DecisionActionsProps {
+  decisionId: string;
+  gateType: 'stage0' | 'stage10' | 'stage22' | 'stage25' | 'kill_gate';
+  onApprove: (notes?: string) => void;
+  onReject: (reason: string) => void;
+  onPark: (notes?: string) => void;
+  isActing: boolean;
+}
+```
+
+- Stage 0: [Approve] [Park as Blocked] [Park as Nursery]
+- Stage 10: [Approve Top] [Select Different] [Reject]
+- Stage 22: [Approve Release] [Reject] [Hold]
+- Stage 25: [Continue] [Pivot] [Expand] [Sunset] [Exit]
+- Kill Gate: [Continue] [Kill] [Park]
+
+Reject and multi-option actions open a rationale input (Sheet or Dialog).
+
+#### StagePipeline
+
+```tsx
+interface StagePipelineProps {
+  currentStage: number;
+  stages: Array<{
+    number: number;
+    status: 'completed' | 'in_progress' | 'not_started' | 'blocked';
+    healthScore?: number;
+  }>;
+  onStageClick?: (stageNumber: number) => void;
+}
+```
+
+Horizontal scrollable pipeline. 6 phase groups with labels. Color-coded dots per stage. Click to navigate to venture detail at that stage.
+
+### 5.3 Error Boundary Strategy
+
+Reuse the existing app error boundary hierarchy:
+
+| Boundary | Usage in v3 |
+|----------|-------------|
+| `GlobalErrorBoundary` | Already wraps entire app — no change |
+| `RouteErrorBoundary` | Wrap each v3 route via `errorElement` prop |
+| `ComponentErrorBoundary` | Wrap data-dependent sections (HEAL chart, venture list, decision cards) |
+| `ProtectedRouteWrapper` | Provides Suspense + loading message per route |
+| `LazyRoute` | Code-splitting for all v3 views |
+
+---
+
+## 6. Data Layer
+
+### 6.1 Hook Directory
+
+```
+src/hooks/chairman-v3/
+  useChairmanBriefing.ts       # /chairman — pending count + ventures + HEAL + recent SDs
+  useDecisionQueue.ts          # /chairman/decisions — pending gates with filtering
+  useDecisionDetail.ts         # /chairman/decisions/:id — single decision + artifacts
+  useVentureLifecycle.ts       # /chairman/ventures — all ventures with stage info
+  useVentureDetail.ts          # /chairman/ventures/:id — single venture deep view
+  useVisionScores.ts           # /chairman/vision — HEAL history + dimensions
+  useChairmanPreferences.ts    # /chairman/preferences — preferences CRUD
+  useBuilderDashboard.ts       # /builder — active SDs + recent completions
+  useBuildQueue.ts             # /builder/queue — SD pipeline
+  useBrainstormInbox.ts        # /builder/inbox — brainstorm sessions
+  useAlerts.ts                 # Cross-cutting — notification state
+```
+
+### 6.2 Supabase Queries by View
+
+#### Daily Briefing (`/chairman`)
+
+```tsx
+// useChairmanBriefing.ts
+// Combines 4 parallel queries
+
+// 1. Pending decisions count
+const pendingCount = supabase
+  .from('v_chairman_pending_decisions')
+  .select('id', { count: 'exact', head: true });
+
+// 2. Active ventures with current stage
+const ventures = supabase
+  .from('ventures')
+  .select('id, name, current_lifecycle_stage, status, health_score, health_status')
+  .eq('status', 'active')
+  .order('name');
+
+// 3. Latest HEAL score
+const healScore = supabase
+  .from('eva_vision_scores')
+  .select('id, total_score, dimension_scores, threshold_action, scored_at')
+  .order('scored_at', { ascending: false })
+  .limit(1)
+  .single();
+
+// 4. Recent SD completions (last 7 days)
+const recentSDs = supabase
+  .from('strategic_directives_v2')
+  .select('sd_key, title, status, completion_date')
+  .eq('status', 'completed')
+  .gte('completion_date', sevenDaysAgo)
+  .order('completion_date', { ascending: false })
+  .limit(10);
+```
+
+**Stale time**: 5 min. **Refetch interval**: 5 min.
+
+#### Decision Queue (`/chairman/decisions`)
+
+```tsx
+// useDecisionQueue.ts
+// Query the unified view with optional filters
+
+const decisions = supabase
+  .from('v_chairman_pending_decisions')
+  .select('*')
+  .order('sla_remaining_seconds', { ascending: true }) // Most urgent first
+  .limit(50);
+
+// Client-side filter by priority and gate type
+// (simpler than multiple query paths)
+```
+
+**Stale time**: 30s. **Refetch interval**: 60s. **Realtime**: Subscribe to `chairman_decisions` INSERT events.
+
+**View columns available** (`v_chairman_pending_decisions`):
+- `id`, `venture_id`, `venture_name`, `lifecycle_stage`, `stage_name`
+- `health_score`, `recommendation`, `decision`, `status`
+- `summary`, `brief_data`, `override_reason`, `risks_acknowledged`
+- `created_at`, `updated_at`, `decided_by`, `rationale`, `blocking`
+- `sla_deadline_at`, `sla_remaining_seconds`, `is_stale_context`, `venture_updated_at`
+- `decision_type` (gate_decision, guardrail_override, cascade_override, advisory, etc.)
+
+#### Decision Detail (`/chairman/decisions/:id`)
+
+```tsx
+// useDecisionDetail.ts
+
+// 1. Decision with full brief_data
+const decision = supabase
+  .from('chairman_decisions')
+  .select('*')
+  .eq('id', decisionId)
+  .single();
+
+// 2. Venture context
+const venture = supabase
+  .from('ventures')
+  .select(`
+    id, name, current_lifecycle_stage, problem_statement,
+    solution_approach, moat_strategy, portfolio_synergy_score,
+    health_score, health_status, brand_variants
+  `)
+  .eq('id', ventureId)
+  .single();
+
+// 3. Stage configuration for gate context
+const stageConfig = supabase
+  .from('lifecycle_stage_config')
+  .select('*')
+  .eq('stage_number', lifecycleStage)
+  .single();
+```
+
+**Stale time**: 30s. No auto-refetch (user is actively reviewing).
+
+#### Venture Lifecycle (`/chairman/ventures`)
+
+```tsx
+// useVentureLifecycle.ts
+
+const ventures = supabase
+  .from('ventures')
+  .select(`
+    id, name, current_lifecycle_stage, status,
+    health_score, health_status, created_at
+  `)
+  .eq('status', 'active')
+  .order('name');
+
+// For each venture, get pending decisions count
+const pendingDecisions = supabase
+  .from('chairman_decisions')
+  .select('venture_id', { count: 'exact' })
+  .eq('status', 'pending')
+  .in('venture_id', ventureIds);
+```
+
+**Stale time**: 2 min. **Refetch interval**: 5 min.
+
+#### Venture Detail (`/chairman/ventures/:id`)
+
+```tsx
+// useVentureDetail.ts
+
+// 1. Full venture record
+const venture = supabase
+  .from('ventures')
+  .select('*')
+  .eq('id', ventureId)
+  .single();
+
+// 2. Stage transition history
+const transitions = supabase
+  .from('venture_stage_transitions')
+  .select('*')
+  .eq('venture_id', ventureId)
+  .order('created_at', { ascending: true });
+
+// 3. Past decisions for this venture
+const decisions = supabase
+  .from('chairman_decisions')
+  .select('*')
+  .eq('venture_id', ventureId)
+  .order('created_at', { ascending: false })
+  .limit(20);
+```
+
+#### Vision & Alignment (`/chairman/vision`)
+
+```tsx
+// useVisionScores.ts
+
+// 1. HEAL score history (last 30 entries)
+const scores = supabase
+  .from('eva_vision_scores')
+  .select('id, total_score, dimension_scores, threshold_action, scored_at')
+  .order('scored_at', { ascending: false })
+  .limit(30);
+
+// 2. Active vision document
+const visionDoc = supabase
+  .from('eva_vision_documents')
+  .select('id, vision_key, level, status, extracted_dimensions, version')
+  .eq('status', 'active')
+  .eq('level', 'L1')
+  .single();
+
+// 3. Corrective SDs (open)
+const correctiveSDs = supabase
+  .from('strategic_directives_v2')
+  .select('sd_key, title, status, priority')
+  .like('sd_key', 'SD-MAN-FEAT-CORRECTIVE%')
+  .neq('status', 'completed')
+  .order('created_at', { ascending: false });
+```
+
+**Stale time**: 5 min. **Refetch interval**: 10 min.
+
+#### Preferences (`/chairman/preferences`)
+
+```tsx
+// useChairmanPreferences.ts
+
+// 1. Chairman settings (resolved with inheritance)
+const settings = supabase.rpc('get_chairman_settings', {
+  p_company_id: companyId,
+  p_venture_id: null, // global
+});
+
+// 2. Chairman preferences (key-value pairs)
+const preferences = supabase
+  .from('chairman_preferences')
+  .select('*')
+  .order('preference_key');
+
+// 3. Venture-specific overrides
+const overrides = supabase
+  .from('chairman_preferences')
+  .select('*, ventures!inner(name)')
+  .not('venture_id', 'is', null)
+  .order('preference_key');
+```
+
+**Stale time**: 10 min. Manual refresh only.
+
+#### Builder Dashboard (`/builder`)
+
+```tsx
+// useBuilderDashboard.ts
+
+// 1. Active SDs
+const activeSDs = supabase
+  .from('strategic_directives_v2')
+  .select('sd_key, title, status, priority, sd_type, parent_sd_id')
+  .in('status', ['in_progress', 'ready', 'planning'])
+  .order('priority', { ascending: false });
+
+// 2. Recent completions (last 7 days)
+const completedSDs = supabase
+  .from('strategic_directives_v2')
+  .select('sd_key, title, completion_date')
+  .eq('status', 'completed')
+  .gte('completion_date', sevenDaysAgo)
+  .order('completion_date', { ascending: false })
+  .limit(10);
+```
+
+#### Build Queue (`/builder/queue`)
+
+```tsx
+// useBuildQueue.ts
+// Visual mirror of `npm run sd:next` — read-only
+
+const queue = supabase
+  .from('strategic_directives_v2')
+  .select(`
+    sd_key, title, status, priority, sd_type,
+    parent_sd_id, track, created_at
+  `)
+  .in('status', ['draft', 'ready', 'planning', 'in_progress'])
+  .order('priority', { ascending: false })
+  .order('created_at', { ascending: true })
+  .limit(50);
+```
+
+#### Brainstorm Inbox (`/builder/inbox`)
+
+```tsx
+// useBrainstormInbox.ts
+
+const sessions = supabase
+  .from('brainstorm_sessions')
+  .select(`
+    id, domain, topic, mode, stage, outcome_type,
+    session_quality_score, crystallization_score,
+    created_sd_id, created_at
+  `)
+  .order('created_at', { ascending: false })
+  .limit(30);
+```
+
+### 6.3 Mutations
+
+| Action | Hook | RPC / Table | Operation |
+|--------|------|-------------|-----------|
+| Approve gate | `useDecisionQueue` | `approve_chairman_decision` RPC | See Section 7 |
+| Reject gate | `useDecisionQueue` | `reject_chairman_decision` RPC | See Section 7 |
+| Park venture | `useDecisionQueue` | `park_venture_decision` RPC | See Section 7 |
+| Update preference | `useChairmanPreferences` | `chairman_preferences` | UPSERT |
+| Update setting | `useChairmanPreferences` | `chairman_settings` | UPDATE |
+
+All mutations use optimistic updates:
+1. Cancel in-flight queries
+2. Set optimistic data (remove from list / update status)
+3. On error: rollback to previous data
+4. On settle: invalidate related query keys
+
+### 6.4 Realtime Subscriptions
+
+```tsx
+// In useDecisionQueue.ts — subscribe to new decisions
+supabase
+  .channel('chairman-decisions-v3')
+  .on('postgres_changes', {
+    event: 'INSERT',
+    schema: 'public',
+    table: 'chairman_decisions',
+    filter: 'status=eq.pending'
+  }, () => {
+    queryClient.invalidateQueries({ queryKey: ['chairman', 'decisions'] });
+  })
+  .subscribe();
+```
+
+| Subscription | Table | Event | Invalidates |
+|-------------|-------|-------|-------------|
+| New decisions | `chairman_decisions` | INSERT (status=pending) | `['chairman', 'decisions']`, `['chairman', 'briefing']` |
+| Decision resolved | `chairman_decisions` | UPDATE | `['chairman', 'decisions']`, `['chairman', 'briefing']` |
+| Venture stage change | `venture_stage_transitions` | INSERT | `['chairman', 'ventures']`, `['chairman', 'briefing']` |
+
+---
+
+## 7. Governance API Surface
+
+### 7.1 New RPC Functions
+
+The existing `chairman_decisions` table uses direct `UPDATE` statements for approve/reject/park. This works but lacks:
+- Audit trail generation
+- Side-effect execution (e.g., unblocking downstream SDs)
+- Input validation
+- Consistent return format
+
+New RPC functions encapsulate governance actions:
+
+#### `approve_chairman_decision`
+
+```sql
+CREATE OR REPLACE FUNCTION approve_chairman_decision(
+  p_decision_id UUID,
+  p_rationale TEXT DEFAULT NULL,
+  p_decided_by TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_decision RECORD;
+  v_result JSONB;
+BEGIN
+  -- Lock the row
+  SELECT * INTO v_decision
+  FROM chairman_decisions
+  WHERE id = p_decision_id AND status = 'pending'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Decision not found or already resolved'
+    );
+  END IF;
+
+  -- Update decision
+  UPDATE chairman_decisions SET
+    decision = CASE
+      WHEN lifecycle_stage = 0 THEN 'proceed'
+      WHEN lifecycle_stage = 10 THEN 'approve'
+      WHEN lifecycle_stage = 22 THEN 'release'
+      WHEN lifecycle_stage = 25 THEN 'continue'
+      ELSE 'go'
+    END,
+    status = 'approved',
+    rationale = COALESCE(p_rationale, 'Approved by Chairman'),
+    decided_by = COALESCE(p_decided_by, auth.uid()::text),
+    blocking = false,
+    updated_at = now()
+  WHERE id = p_decision_id;
+
+  -- Return result
+  RETURN jsonb_build_object(
+    'success', true,
+    'decision_id', p_decision_id,
+    'venture_id', v_decision.venture_id,
+    'lifecycle_stage', v_decision.lifecycle_stage,
+    'new_status', 'approved'
+  );
+END;
+$$;
+```
+
+#### `reject_chairman_decision`
+
+```sql
+CREATE OR REPLACE FUNCTION reject_chairman_decision(
+  p_decision_id UUID,
+  p_rationale TEXT,
+  p_decided_by TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_decision RECORD;
+BEGIN
+  SELECT * INTO v_decision
+  FROM chairman_decisions
+  WHERE id = p_decision_id AND status = 'pending'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Decision not found or already resolved'
+    );
+  END IF;
+
+  UPDATE chairman_decisions SET
+    decision = CASE
+      WHEN decision_type = 'gate_decision' AND lifecycle_stage IN (3, 5, 13, 23) THEN 'kill'
+      ELSE 'no_go'
+    END,
+    status = 'rejected',
+    rationale = p_rationale,
+    decided_by = COALESCE(p_decided_by, auth.uid()::text),
+    blocking = false,
+    updated_at = now()
+  WHERE id = p_decision_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'decision_id', p_decision_id,
+    'venture_id', v_decision.venture_id,
+    'lifecycle_stage', v_decision.lifecycle_stage,
+    'new_status', 'rejected'
+  );
+END;
+$$;
+```
+
+#### `park_venture_decision`
+
+```sql
+CREATE OR REPLACE FUNCTION park_venture_decision(
+  p_decision_id UUID,
+  p_park_type TEXT,  -- 'blocked' (30d review) | 'nursery' (90d review)
+  p_reason TEXT,
+  p_decided_by TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_decision RECORD;
+BEGIN
+  SELECT * INTO v_decision
+  FROM chairman_decisions
+  WHERE id = p_decision_id AND status = 'pending'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Decision not found or already resolved'
+    );
+  END IF;
+
+  UPDATE chairman_decisions SET
+    decision = 'pause',
+    status = 'approved', -- parked is a type of resolution
+    rationale = p_reason,
+    decided_by = COALESCE(p_decided_by, auth.uid()::text),
+    blocking = false,
+    updated_at = now()
+  WHERE id = p_decision_id;
+
+  -- Update venture status based on park type
+  IF p_park_type = 'blocked' THEN
+    UPDATE ventures SET status = 'paused', updated_at = now()
+    WHERE id = v_decision.venture_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'decision_id', p_decision_id,
+    'venture_id', v_decision.venture_id,
+    'park_type', p_park_type,
+    'review_date', CASE
+      WHEN p_park_type = 'blocked' THEN (now() + interval '30 days')::date
+      WHEN p_park_type = 'nursery' THEN (now() + interval '90 days')::date
+    END
+  );
+END;
+$$;
+```
+
+### 7.2 RLS Policy Requirements
+
+All v3 routes need authenticated read access. Decision mutations go through `SECURITY DEFINER` RPC functions (bypass RLS).
+
+| Table | Existing RLS? | v3 Need | Action |
+|-------|:---:|---------|--------|
+| `chairman_decisions` | Yes (`fn_is_chairman()`) | Read + RPC write | Verify SELECT policy works with Supabase auth |
+| `chairman_preferences` | Yes (`fn_is_chairman()`) | Full CRUD | No change needed |
+| `chairman_settings` | Yes | Read + update | No change needed |
+| `ventures` | Yes | Read | No change needed |
+| `venture_stage_transitions` | Check | Read | Verify SELECT policy exists |
+| `eva_vision_scores` | Check | Read | Verify SELECT policy exists |
+| `eva_vision_documents` | Check | Read | Verify SELECT policy exists |
+| `lifecycle_stage_config` | Check | Read | Likely public read — verify |
+| `strategic_directives_v2` | Check | Read | Verify SELECT for builder views |
+| `brainstorm_sessions` | Check | Read | Verify SELECT policy exists |
+
+**Action item**: Run RLS audit query before Phase 1 implementation begins.
+
+---
+
+## 8. Zod Response Validation
+
+### 8.1 Schema Location
+
+New directory: `src/lib/schemas/chairman-v3/`
+
+### 8.2 Schemas
+
+```tsx
+// src/lib/schemas/chairman-v3/decisions.ts
+import { z } from 'zod';
+
+export const PendingDecisionSchema = z.object({
+  id: z.string().uuid(),
+  venture_id: z.string().uuid().nullable(),
+  venture_name: z.string().nullable(),
+  lifecycle_stage: z.number().int().min(0).max(25).nullable(),
+  stage_name: z.string().nullable(),
+  health_score: z.string().nullable(),
+  recommendation: z.string().nullable(),
+  decision: z.string().nullable(),
+  decision_type: z.string().nullable(),
+  status: z.string().nullable(),
+  summary: z.string().nullable(),
+  brief_data: z.record(z.unknown()).nullable(),
+  risks_acknowledged: z.unknown().nullable(),
+  created_at: z.string(),
+  sla_deadline_at: z.string().nullable(),
+  sla_remaining_seconds: z.number().nullable(),
+  blocking: z.boolean(),
+});
+
+export const DecisionListSchema = z.array(PendingDecisionSchema);
+
+export const RpcResultSchema = z.object({
+  success: z.boolean(),
+  decision_id: z.string().uuid().optional(),
+  venture_id: z.string().uuid().optional(),
+  error: z.string().optional(),
+});
+```
+
+```tsx
+// src/lib/schemas/chairman-v3/ventures.ts
+import { z } from 'zod';
+
+export const VentureSummarySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  current_lifecycle_stage: z.number().int().min(1).max(25).nullable(),
+  status: z.string(),
+  health_score: z.number().nullable(),
+  health_status: z.string().nullable(),
+});
+
+export const VentureListSchema = z.array(VentureSummarySchema);
+```
+
+```tsx
+// src/lib/schemas/chairman-v3/vision.ts
+import { z } from 'zod';
+
+export const VisionScoreSchema = z.object({
+  id: z.string().uuid(),
+  total_score: z.number().int().min(0).max(100),
+  dimension_scores: z.array(z.object({
+    dimension: z.string(),
+    score: z.number(),
+    weight: z.number(),
+    reasoning: z.string().optional(),
+  })),
+  threshold_action: z.enum(['accept', 'minor_sd', 'gap_closure_sd', 'escalate']),
+  scored_at: z.string(),
+});
+
+export const VisionScoreListSchema = z.array(VisionScoreSchema);
+```
+
+### 8.3 Usage Pattern
+
+```tsx
+// In hooks — validate then fallback
+const result = DecisionListSchema.safeParse(data);
+if (!result.success) {
+  console.error('[useDecisionQueue] Schema validation failed:', result.error);
+  // Return data anyway — log the drift, don't crash
+  return data as PendingDecision[];
+}
+return result.data;
+```
+
+---
+
+## 9. Zustand Client State
+
+### 9.1 Store: `chairman-ui`
+
+```tsx
+// src/stores/chairman-ui.ts
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface ChairmanUIStore {
+  // Persona
+  activePersona: 'chairman' | 'builder';
+  setPersona: (persona: 'chairman' | 'builder') => void;
+  togglePersona: () => void;
+
+  // Sidebar
+  sidebarCollapsed: boolean;
+  setSidebarCollapsed: (collapsed: boolean) => void;
+  toggleSidebar: () => void;
+
+  // Alerts
+  alertsPanelOpen: boolean;
+  setAlertsPanelOpen: (open: boolean) => void;
+  unreadAlertCount: number;
+  setUnreadAlertCount: (count: number) => void;
+}
+
+export const useChairmanUI = create<ChairmanUIStore>()(
+  persist(
+    (set) => ({
+      activePersona: 'chairman',
+      setPersona: (persona) => set({ activePersona: persona }),
+      togglePersona: () => set((s) => ({
+        activePersona: s.activePersona === 'chairman' ? 'builder' : 'chairman',
+      })),
+
+      sidebarCollapsed: false,
+      setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
+      toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
+
+      alertsPanelOpen: false,
+      setAlertsPanelOpen: (open) => set({ alertsPanelOpen: open }),
+      unreadAlertCount: 0,
+      setUnreadAlertCount: (count) => set({ unreadAlertCount: count }),
+    }),
+    {
+      name: 'ehg-chairman-ui',
+      partialize: (state) => ({
+        activePersona: state.activePersona,
+        sidebarCollapsed: state.sidebarCollapsed,
+      }),
+    }
+  )
+);
+```
+
+**Persisted**: `activePersona`, `sidebarCollapsed` survive page reload.
+**Not persisted**: `alertsPanelOpen`, `unreadAlertCount` (transient UI state).
+
+---
+
+## 10. Progressive Disclosure Architecture
+
+### 10.1 Three Layers
+
+| Layer | Where | Component | Data |
+|-------|-------|-----------|------|
+| **L0: Summary** | Decision Queue list | `DecisionQueue.tsx` card items | View row: title, priority, summary, SLA countdown |
+| **L1: Context** | Expanded card OR slide-over Sheet | `GateRenderer.tsx` inside Sheet | View row + `brief_data` JSONB + stage config |
+| **L2: Full Detail** | Decision Detail page | `DecisionDetail.tsx` | Full decision record + venture record + stage transitions + artifacts |
+
+### 10.2 "Tell Me More" Flow
+
+1. **L0 → L1**: User clicks "Tell me more" on a decision card. A `Sheet` slides in from the right with gate-specific context (see Section 11). Quick actions available at L1.
+2. **L1 → L2**: User clicks "View Full Detail" inside the Sheet. Navigation to `/chairman/decisions/:id`. Full artifact access, audit trail, Claude Code handoff.
+
+### 10.3 Data Loading Strategy
+
+- **L0**: Loaded with the decision queue query (already in cache)
+- **L1**: `brief_data` column from the same query row (no additional fetch if present). If `brief_data` is null, fetch from `chairman_decisions` by ID.
+- **L2**: Dedicated `useDecisionDetail` hook. Only fires when user navigates to detail page.
+
+---
+
+## 11. Gate-Specific Renderers
+
+### 11.1 Router Component
+
+```tsx
+// src/components/chairman-v3/gates/GateRenderer.tsx
+
+interface GateRendererProps {
+  decision: PendingDecision;
+  venture?: VentureRecord;
+  stageConfig?: StageConfigRecord;
+}
+
+export function GateRenderer({ decision, venture, stageConfig }: GateRendererProps) {
+  const stage = decision.lifecycle_stage;
+
+  if (stage === 0) return <GateRendererStage0 {...props} />;
+  if (stage === 10) return <GateRendererStage10 {...props} />;
+  if (stage === 22) return <GateRendererStage22 {...props} />;
+  if (stage === 25) return <GateRendererStage25 {...props} />;
+  if ([3, 5, 13, 23].includes(stage)) return <GateRendererKillGate {...props} />;
+
+  // Fallback: generic gate context
+  return <GateRendererGeneric {...props} />;
+}
+```
+
+### 11.2 Renderer Specifications
+
+#### Stage 0: Venture Routing
+
+Context sections:
+1. **Problem & Solution**: `venture.problem_statement`, `venture.solution_approach`
+2. **Market & Archetype**: From `brief_data` or venture metadata
+3. **Portfolio Synergy**: `venture.portfolio_synergy_score` (0-1 displayed as 0-100)
+4. **Chairman Constraints**: 10 strategic filters from `brief_data.constraint_scores` — pass/fail badges
+5. **Time Horizon**: `venture.time_horizon_classification`
+
+Actions: [Approve → Stage 1] [Park as Blocked (30d)] [Park as Nursery (90d)]
+
+#### Stage 10: Brand Approval
+
+Context sections:
+1. **Brand Genome**: Archetype, values, tone from `venture.brand_variants` or `brief_data`
+2. **Naming Candidates**: 5+ candidates with per-criterion weighted scores (horizontal bar chart via Recharts)
+3. **Narrative Extension**: Vision, mission, brand voice excerpts
+4. **Naming Strategy**: Type classification
+
+Actions: [Approve Top Candidate] [Select Different (dropdown)] [Reject with Rationale]
+
+#### Stage 22: Release Readiness
+
+Context sections:
+1. **Release Items**: Feature/bugfix/infra list with status badges
+2. **Release Notes**: Preview (rendered markdown)
+3. **Build Quality**: Checks from stages 17-21 (pass/fail list)
+4. **Target Date**: Sprint retrospective summary
+
+Actions: [Approve Release] [Reject with Rationale] [Hold]
+
+#### Stage 25: Portfolio Review
+
+Context sections:
+1. **Review Summary**: Initiative outcomes by category
+2. **Vision Drift**: Current vs original comparison from `brief_data`
+3. **Financial Comparison**: Projected vs actual (if available)
+4. **Health Dimensions**: 5-dimension radar chart or score cards (0-100 each)
+5. **Proposed Next Steps**: From `recommendation`
+
+Actions: [Continue] [Pivot] [Expand] [Sunset] [Exit] — each opens rationale input
+
+#### Kill Gates (3, 5, 13, 23)
+
+Context sections:
+1. **Health Score vs Threshold**: `health_score` compared to stage threshold (from `lifecycle_stage_config`)
+2. **Stage Artifacts Summary**: Brief list of what was produced
+3. **Risk Factors**: `risks_acknowledged` array rendered as badges
+4. **EVA Recommendation**: `recommendation` field
+
+Actions: [Continue (Override)] [Kill (Terminate)] [Park (Pause for Review)]
+
+---
+
+## 12. Claude Code Integration
+
+### 12.1 ClaudeCodeLink Component
+
+```tsx
+// src/components/chairman-v3/shared/ClaudeCodeLink.tsx
+
+function assembleContext(props: ClaudeCodeLinkProps): string {
+  return `## Chairman Decision Context
+
+**Venture**: ${props.ventureName} (ID: ${props.ventureId})
+**Gate**: Stage ${props.stage} — ${props.gateType}
+**Summary**: ${props.summary}
+
+### Data Snapshot
+${formatDataSnapshot(props.dataSnapshot)}
+
+### Suggested Action
+${props.suggestedAction || 'Review and take appropriate action.'}
+`;
+}
+
+export function ClaudeCodeLink(props: ClaudeCodeLinkProps) {
+  const handleCopy = async () => {
+    const context = assembleContext(props);
+    await navigator.clipboard.writeText(context);
+    toast.success('Copied to clipboard — paste into Claude Code');
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={handleCopy}>
+      <Terminal className="h-4 w-4 mr-2" />
+      Open in Claude Code
+    </Button>
+  );
+}
+```
+
+### 12.2 Placement
+
+- Decision cards (L0): Small icon button
+- Decision Sheet (L1): Full button with label
+- Decision Detail (L2): Prominent button with context preview
+- Venture Detail: Button for "Investigate in Claude Code"
+
+---
+
+## 13. Notification System
+
+### 13.1 Alert Sources
+
+| Source | Priority | Detection |
+|--------|----------|-----------|
+| New blocking decision | Critical | Realtime subscription on `chairman_decisions` INSERT |
+| SLA approaching (< 2h) | Warning | Computed from `sla_remaining_seconds` in view |
+| HEAL score drop | Warning | Compare latest vs previous in `eva_vision_scores` |
+| Auto-approve countdown (< 4h) | Info | Computed from `sla_deadline_at` |
+| Stage progression | Info | Realtime subscription on `venture_stage_transitions` INSERT |
+| SD completion | Info | Poll `strategic_directives_v2` status changes |
+
+### 13.2 Delivery Channels
+
+| Channel | Implementation | Component |
+|---------|---------------|-----------|
+| **Dashboard badge** | `useChairmanUI.unreadAlertCount` → red dot on sidebar "Alerts" | `ChairmanShell.tsx` sidebar |
+| **Browser tab title** | `useEffect` sets `document.title` = `(${count}) Chairman — EHG` | `ChairmanShell.tsx` |
+| **sonner toast** | `toast.warning()` for critical alerts while app is open | `useAlerts.ts` |
+| **Email digest** | Supabase Edge Function + Resend API, scheduled daily | Separate SD |
+| **Push notification** | Web Push API via service worker | PWA SD |
+
+### 13.3 Alert State Hook
+
+```tsx
+// src/hooks/chairman-v3/useAlerts.ts
+
+interface Alert {
+  id: string;
+  type: 'decision' | 'sla' | 'heal' | 'stage' | 'sd';
+  priority: 'critical' | 'warning' | 'info';
+  title: string;
+  message: string;
+  link?: string;
+  read: boolean;
+  createdAt: string;
+}
+
+// Derives alerts from existing query caches
+// No separate table — computed from decision + venture + vision data
+```
+
+---
+
+## 14. Mobile & PWA
+
+### 14.1 Responsive Breakpoints
+
+| Breakpoint | Layout |
+|-----------|--------|
+| `< 768px` (mobile) | Bottom tab bar, full-width content, stacked cards |
+| `768px - 1199px` (tablet) | Collapsed sidebar (icon-only), content fills remaining space |
+| `>= 1200px` (desktop) | Expanded sidebar + content |
+
+### 14.2 Mobile-Specific Adaptations
+
+| Component | Desktop | Mobile |
+|-----------|---------|--------|
+| Sidebar | Left sidebar, expandable | Bottom tab bar, 5 items |
+| Decision cards | Horizontal layout with side context | Stacked vertical |
+| Stage pipeline | Horizontal scroll | Horizontal scroll with larger touch targets |
+| Decision actions | Inline buttons | Full-width sticky footer buttons |
+| Sheets | Right-side slide-over | Full-screen bottom sheet |
+| Tables | Standard table | Card list layout |
+
+### 14.3 PWA Architecture
+
+#### manifest.json
+
+```json
+{
+  "name": "EHG Chairman",
+  "short_name": "Chairman",
+  "description": "EHG Venture Factory governance dashboard",
+  "start_url": "/chairman",
+  "display": "standalone",
+  "orientation": "any",
+  "theme_color": "#1a1a2e",
+  "background_color": "#16213e",
+  "icons": [
+    { "src": "/icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icons/icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "/icons/icon-maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}
+```
+
+#### Service Worker Strategy
+
+Use `vite-plugin-pwa` for Vite integration:
+
+```tsx
+// vite.config.ts addition
+import { VitePWA } from 'vite-plugin-pwa';
+
+VitePWA({
+  registerType: 'autoUpdate',
+  workbox: {
+    globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+    runtimeCaching: [
+      {
+        // Cache Supabase API responses for offline briefing
+        urlPattern: /^https:\/\/dedlbzhpgkmetvhbkyzq\.supabase\.co\/rest\/v1\/.*/,
+        handler: 'StaleWhileRevalidate',
+        options: {
+          cacheName: 'supabase-api',
+          expiration: { maxEntries: 50, maxAgeSeconds: 3600 },
+        },
+      },
+    ],
+  },
+})
+```
+
+**Caching strategy**:
+- **App shell**: Precache (HTML, JS, CSS, fonts)
+- **Supabase API**: StaleWhileRevalidate (show cached data, refresh in background)
+- **Images/icons**: Cache-first with 7-day expiry
+
+#### Web Push Notifications
+
+1. **Edge Function**: Triggered by Supabase webhook on `chairman_decisions` INSERT where `status = 'pending'`
+2. **Subscription**: Stored in `chairman_push_subscriptions` table (new)
+3. **Push payload**: `{ title, body, tag, data: { url } }`
+4. **Service worker handler**: `self.addEventListener('notificationclick', ...)` — opens `/chairman/decisions`
+5. **Quiet hours**: Edge function checks `chairman_preferences` before sending
+
+#### Install Prompt
+
+Custom install banner shown after 3+ visits (tracked in localStorage). Uses `beforeinstallprompt` event.
+
+---
+
+## 15. Legacy Deprecation
+
+### 15.1 Strategy: Clean Up As We Go
+
+Each implementation SD that creates a new component also:
+1. Updates the route file to use the new component
+2. Adds redirects from superseded routes
+3. Deletes the superseded component file
+4. Removes unused imports
+
+### 15.2 Supersession Map
+
+| Old Route | Old Component | New Route | New Component | Cleanup SD |
+|-----------|--------------|-----------|---------------|------------|
+| `/chairman` | BriefingDashboard | `/chairman` | DailyBriefing | Chairman Views SD |
+| `/chairman/overview` | ChairmanOverview | `/chairman` (redirect) | — | Chairman Views SD |
+| `/chairman/decisions` | DecisionGateQueue | `/chairman/decisions` | DecisionQueue | Decision System SD |
+| `/chairman/portfolio` | VenturesPage | `/chairman/ventures` | VentureLifecycle | Chairman Views SD |
+| `/chairman/settings` | ChairmanSettingsPage | `/chairman/preferences` | Preferences | Chairman Views SD |
+| `/chairman/escalations/:id` | ChairmanEscalationPage | `/chairman/decisions` (redirect) | — | Decision System SD |
+| `/chairman/analytics` | DecisionAnalyticsDashboard | — (removed) | — | Decision System SD |
+| `/chairman/risk-review` | ChairmanRiskReviewPage | `/chairman/ventures` (redirect) | — | Chairman Views SD |
+| `/chairman/vision` | VisionDashboard | `/chairman/vision` | VisionAlignment | Chairman Views SD |
+| `/chairman/governance` | GovernanceOverview | `/chairman` (redirect) | — | Chairman Views SD |
+| `/chairman/lifecycle` | VentureLifecycleMap | `/chairman/ventures` (redirect) | — | Chairman Views SD |
+| `/chairman/builder` | BuilderViews | `/builder` | BuilderDashboard | Builder Views SD |
+| `/chairman/queue` | BuilderViews | `/builder/queue` | BuildQueue | Builder Views SD |
+| `/chairman/health` | HealthHeatmapPanel | — (removed, merged into briefing) | — | Foundation SD |
+| `/chairman/events` | EventFeedPanel | — (removed, merged into alerts) | — | Foundation SD |
+
+### 15.3 Layout Transition
+
+1. **Phase 1**: New `ChairmanShell` created. New route file (`chairmanRoutesV3.tsx`) registers v3 routes alongside old routes.
+2. **Phase 2**: Old route file (`chairmanRoutes.tsx`) entries are replaced one-by-one as new components are built. Each replacement is a PR.
+3. **Phase 3**: Old route file deleted. `ChairmanLayoutV3.tsx`, `AttentionQueueSidebar.tsx`, old `MobileTabBar.tsx` deleted. `AuthenticatedLayout` no longer wraps chairman/builder routes.
+
+### 15.4 Existing Components to Preserve/Adapt
+
+| Component | Location | Action |
+|-----------|----------|--------|
+| `EVAGreeting.tsx` | chairman-v3/ | Reuse in DailyBriefing |
+| `QuickStatCard.tsx` | chairman-v3/ | Adapt as MetricCard |
+| `StageTimeline.tsx` | chairman-v3/ | Adapt as StagePipeline |
+| `TokenBudgetBar.tsx` | chairman-v3/ | Reuse in Preferences if relevant |
+| `VisionScoreCard.tsx` | chairman-v3/VisionDashboard/ | Reuse in VisionAlignment |
+| `VisionTrendChart.tsx` | chairman-v3/VisionDashboard/ | Reuse in VisionAlignment |
+| `DimensionBreakdownPanel.tsx` | chairman-v3/VisionDashboard/ | Reuse in VisionAlignment |
+| `CorrectiveSDsTable.tsx` | chairman-v3/VisionDashboard/ | Reuse in VisionAlignment |
+| `PersonaToggle.tsx` | chairman-v3/ | Reuse in ChairmanShell top nav |
+| `OfflineIndicator.tsx` | chairman-v3/ | Reuse in ChairmanShell |
+
+### 15.5 Existing Hooks Replacement
+
+| Old Hook | New Hook | Action |
+|----------|----------|--------|
+| `useChairmanDashboardData.ts` | `useChairmanBriefing.ts` | Replace (different data shape) |
+| `useChairmanData.ts` | Split across v3 hooks | Deprecate when all consumers migrated |
+| `useChairmanConfig.ts` | `useChairmanPreferences.ts` | Evaluate reuse — may carry over |
+| `useChairmanOverviewData.ts` | `useChairmanBriefing.ts` | Replace |
+| `useDecisionGateQueue.ts` | `useDecisionQueue.ts` (v3) | Carry forward core logic, new return shape |
+| `useDecisionQueue.ts` | `useDecisionQueue.ts` (v3) | Merge useful patterns |
+| `useVisionDashboardData.ts` | `useVisionScores.ts` | Replace (streamlined query) |
+| `useGovernanceData.ts` | Merged into briefing | Deprecate |
+| `useBuilderViews.ts` | `useBuilderDashboard.ts` | Replace |
+| `useVentureLifecycle.ts` | `useVentureLifecycle.ts` (v3) | Evaluate — may be reusable as-is |
+| `useVentureData.ts` | `useVentureDetail.ts` | Replace (different shape) |
+
+---
+
+## 16. Implementation Phases
+
+### Phase Map to Orchestrator SDs
+
+| Phase | Orchestrator SD | Children | Scope |
+|-------|----------------|----------|-------|
+| **1: Foundation** | Orch-1 | Shell, Routes, Store, Sonner, Zod | ChairmanShell layout, route registration, Zustand store, Zod schemas, sonner standardization |
+| **2: Decision System** | Orch-2 | Queue, Detail, Gate Renderers, RPC, ClaudeCodeLink | Decision queue, detail page, 5 gate renderers, progressive disclosure, RPC functions, Claude Code handoff |
+| **3: Chairman Views** | Orch-3 | Briefing, Ventures, Vision, Preferences | Daily briefing, venture lifecycle/detail, vision alignment, preferences editor |
+| **4: Builder Views** | Orch-4 | Dashboard, Queue, Inbox | Builder dashboard, build queue, brainstorm inbox |
+| **5: Notifications & PWA** | Orch-5 | Alerts, Email, PWA, Push | Alert system, tab title badges, email digest edge function, manifest, service worker, web push |
+
+### Phase 1: Foundation
+
+| Child SD | Scope | Dependencies |
+|----------|-------|-------------|
+| Shell & Layout | `ChairmanShell.tsx`, `BottomTabBar.tsx`, `PersonaToggle.tsx` (new), sidebar items | None |
+| Route Registration | `chairmanRoutesV3.tsx`, redirect map, lazy loading setup | Shell |
+| Zustand Store | `chairman-ui.ts` store with persona, sidebar, alerts state | None |
+| Sonner Standardization | Verify sonner theming, fix `next-themes` import in `sonner.tsx` | None |
+| Zod Schemas | `src/lib/schemas/chairman-v3/` with decision, venture, vision schemas | None |
+| RLS Audit | Verify all required table SELECT policies work with Supabase auth | None |
+
+### Phase 2: Decision System
+
+| Child SD | Scope | Dependencies |
+|----------|-------|-------------|
+| Decision Queue View | `DecisionQueue.tsx`, `useDecisionQueue.ts` (v3), queue list with filtering | Foundation complete |
+| Decision Detail Page | `DecisionDetail.tsx`, `useDecisionDetail.ts`, full context view | Decision Queue |
+| Gate Renderers | `GateRenderer.tsx` + 5 specific renderers (Stage 0, 10, 22, 25, Kill) | Decision Queue |
+| RPC Functions | 3 Supabase migrations: `approve_chairman_decision`, `reject_chairman_decision`, `park_venture_decision` | None (DB-only) |
+| Decision Actions | `DecisionActions.tsx` with gate-type-specific buttons + rationale input | RPC Functions |
+| Progressive Disclosure | Sheet-based L1 view, "Tell me more" flow, L0→L1→L2 navigation | Gate Renderers + Decision Detail |
+| Claude Code Link | `ClaudeCodeLink.tsx` component, context assembly per gate type | Decision Detail |
+
+### Phase 3: Chairman Views
+
+| Child SD | Scope | Dependencies |
+|----------|-------|-------------|
+| Daily Briefing | `DailyBriefing.tsx`, `useChairmanBriefing.ts`, 4 metric cards, decision preview, portfolio pulse, HEAL preview | Foundation + Decision Queue (for decision preview) |
+| Venture Lifecycle | `VentureLifecycle.tsx`, `useVentureLifecycle.ts`, pipeline view per venture | Foundation |
+| Venture Detail | `VentureDetail.tsx`, `useVentureDetail.ts`, 25-stage timeline, transition history, past decisions | Venture Lifecycle |
+| Vision Alignment | `VisionAlignment.tsx`, `useVisionScores.ts`, HEAL trend chart, dimension breakdown, corrective SDs | Foundation |
+| Preferences | `Preferences.tsx`, `useChairmanPreferences.ts`, settings editor, venture overrides, notification config | Foundation |
+
+### Phase 4: Builder Views
+
+| Child SD | Scope | Dependencies |
+|----------|-------|-------------|
+| Builder Dashboard | `BuilderDashboard.tsx`, `useBuilderDashboard.ts`, active SDs + recent completions | Foundation |
+| Build Queue | `BuildQueue.tsx`, `useBuildQueue.ts`, prioritized SD pipeline | Foundation |
+| Brainstorm Inbox | `BrainstormInbox.tsx`, `useBrainstormInbox.ts`, session list + capture form | Foundation |
+
+### Phase 5: Notifications & PWA
+
+| Child SD | Scope | Dependencies |
+|----------|-------|-------------|
+| Alert System | `useAlerts.ts`, `AlertPanel.tsx`, sidebar badge, tab title update | Foundation + any view that generates alerts |
+| Email Digest | Supabase Edge Function + Resend integration, preference-driven scheduling | Preferences (for config) |
+| PWA Shell | `manifest.json`, icons, `vite-plugin-pwa` config, service worker caching | Foundation |
+| Push Notifications | Web Push subscription, Edge Function webhook trigger, quiet hours | PWA Shell + Preferences |
+
+---
+
+## 17. Testing Strategy
+
+| Level | Approach | Scope |
+|-------|----------|-------|
+| **Schema** | Zod `.safeParse()` logs on every Supabase response | All hooks |
+| **Component** | Vitest + React Testing Library | Each view component, gate renderers |
+| **Hook** | Vitest with MSW (Mock Service Worker) for Supabase mocking | Each data hook |
+| **Integration** | Manual testing with real Supabase data | All decision flows (approve/reject/park per gate type) |
+| **E2E** | Manual walkthrough of full decision lifecycle | Stage 0 → approve → verify venture proceeds |
+| **Mobile** | Chrome DevTools responsive mode + real device | All views at 375px, 768px, 1200px |
+| **Accessibility** | Keyboard navigation, focus management, ARIA labels | Shell, decision actions, forms |
+| **PWA** | Lighthouse PWA audit | Install, offline, push |
+
+---
+
+## 18. Risk Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| RLS policies block reads | Medium | High | Run audit query before Phase 1. Test with auth token in Supabase dashboard. |
+| `v_chairman_pending_decisions` view schema changes | Low | Medium | Zod validation catches drift. View is defined in migrations we control. |
+| Double-layout during transition confuses users | Medium | Low | v3 routes are new paths (`/builder/*`). Old routes redirect. No ambiguity period. |
+| `brief_data` JSONB is empty for most decisions | High | Medium | Gate renderers gracefully handle null brief_data — show available fields, hide empty sections. |
+| PWA service worker caching stale data | Medium | Medium | StaleWhileRevalidate strategy. Clear cache on app update. Version cache names. |
+| Sonner + next-themes conflict | Low | Low | Fix during Foundation SD. Swap import in sonner.tsx. |
+| Large decision queue (50+ items) | Low | Medium | Pagination or virtual scrolling. Initial limit of 50 is sufficient for current scale. |
+| Claude Code deep-link API changes | Low | Low | Clipboard-first approach. Deep-link is additive future enhancement. |
+| Multiple sessions causing claim conflicts during SD work | Medium | Low | Standard LEO claim system handles this. Each SD is independent. |
+
+---
+
+## Appendix A: Database Quick Reference
+
+### Key Tables
+
+| Table | Primary Use | Key Columns |
+|-------|-----------|-------------|
+| `chairman_decisions` | Gate decisions | `id`, `venture_id`, `lifecycle_stage`, `decision`, `status`, `decision_type`, `blocking`, `brief_data`, `summary`, `rationale` |
+| `chairman_preferences` | Key-value prefs | `chairman_id`, `venture_id`, `preference_key`, `preference_value`, `value_type` |
+| `chairman_settings` | Numeric settings | `company_id`, `venture_id`, `risk_tolerance`, `kill_gate_mode`, `exploit_ratio` |
+| `ventures` | Core ventures | `id`, `name`, `current_lifecycle_stage`, `status`, `health_score`, `problem_statement`, `brand_variants` |
+| `eva_vision_scores` | HEAL scores | `vision_id`, `total_score`, `dimension_scores`, `threshold_action` |
+| `eva_vision_documents` | Vision docs | `vision_key`, `level`, `content`, `extracted_dimensions`, `status` |
+| `lifecycle_stage_config` | Stage definitions | `stage_number`, `stage_name`, `phase_name`, `work_type`, `advisory_enabled` |
+| `venture_stage_transitions` | Stage audit trail | `venture_id`, `from_stage`, `to_stage`, `transition_type`, `handoff_data` |
+| `brainstorm_sessions` | Idea inbox | `domain`, `topic`, `outcome_type`, `session_quality_score`, `created_sd_id` |
+| `strategic_directives_v2` | SD pipeline | `sd_key`, `title`, `status`, `priority`, `sd_type`, `track` |
+
+### Key Views
+
+| View | Purpose |
+|------|---------|
+| `v_chairman_pending_decisions` | SLA-sorted pending decisions with venture context, used by decision queue |
+| `v_chairman_settings_resolved` | Settings with company → venture inheritance resolved |
+
+### Key RPC Functions
+
+| Function | Purpose |
+|----------|---------|
+| `fn_is_chairman()` | Auth check — returns boolean |
+| `get_chairman_settings(company_id, venture_id)` | Resolved settings with inheritance |
+| `approve_chairman_decision(id, rationale)` | **New** — approve with audit trail |
+| `reject_chairman_decision(id, rationale)` | **New** — reject with audit trail |
+| `park_venture_decision(id, park_type, reason)` | **New** — park (blocked/nursery) |
+
+---
+
+## Appendix B: File Impact Summary
+
+### New Files (created by this rebuild)
+
+| File | Phase |
+|------|-------|
+| `src/components/chairman-v3/ChairmanShell.tsx` | 1 |
+| `src/components/chairman-v3/shared/BottomTabBar.tsx` | 1 |
+| `src/components/chairman-v3/shared/MetricCard.tsx` | 1 |
+| `src/components/chairman-v3/shared/StagePipeline.tsx` | 1 |
+| `src/components/chairman-v3/shared/StaleDataIndicator.tsx` | 1 |
+| `src/components/chairman-v3/shared/AlertPanel.tsx` | 5 |
+| `src/routes/chairmanRoutesV3.tsx` | 1 |
+| `src/stores/chairman-ui.ts` | 1 |
+| `src/lib/schemas/chairman-v3/decisions.ts` | 1 |
+| `src/lib/schemas/chairman-v3/ventures.ts` | 1 |
+| `src/lib/schemas/chairman-v3/vision.ts` | 1 |
+| `src/components/chairman-v3/DecisionQueue.tsx` | 2 |
+| `src/components/chairman-v3/DecisionDetail.tsx` | 2 |
+| `src/components/chairman-v3/gates/GateRenderer.tsx` | 2 |
+| `src/components/chairman-v3/gates/GateRendererStage0.tsx` | 2 |
+| `src/components/chairman-v3/gates/GateRendererStage10.tsx` | 2 |
+| `src/components/chairman-v3/gates/GateRendererStage22.tsx` | 2 |
+| `src/components/chairman-v3/gates/GateRendererStage25.tsx` | 2 |
+| `src/components/chairman-v3/gates/GateRendererKillGate.tsx` | 2 |
+| `src/components/chairman-v3/DailyBriefing.tsx` | 3 |
+| `src/components/chairman-v3/VentureLifecycle.tsx` | 3 |
+| `src/components/chairman-v3/VentureDetail.tsx` | 3 |
+| `src/components/chairman-v3/VisionAlignment.tsx` | 3 |
+| `src/components/chairman-v3/Preferences.tsx` | 3 |
+| `src/components/chairman-v3/builder/BuilderDashboard.tsx` | 4 |
+| `src/components/chairman-v3/builder/BuildQueue.tsx` | 4 |
+| `src/components/chairman-v3/builder/BrainstormInbox.tsx` | 4 |
+| `src/hooks/chairman-v3/useChairmanBriefing.ts` | 3 |
+| `src/hooks/chairman-v3/useDecisionQueue.ts` | 2 |
+| `src/hooks/chairman-v3/useDecisionDetail.ts` | 2 |
+| `src/hooks/chairman-v3/useVentureLifecycle.ts` | 3 |
+| `src/hooks/chairman-v3/useVentureDetail.ts` | 3 |
+| `src/hooks/chairman-v3/useVisionScores.ts` | 3 |
+| `src/hooks/chairman-v3/useChairmanPreferences.ts` | 3 |
+| `src/hooks/chairman-v3/useBuilderDashboard.ts` | 4 |
+| `src/hooks/chairman-v3/useBuildQueue.ts` | 4 |
+| `src/hooks/chairman-v3/useBrainstormInbox.ts` | 4 |
+| `src/hooks/chairman-v3/useAlerts.ts` | 5 |
+| `public/manifest.json` | 5 |
+| `public/sw.js` (generated by vite-plugin-pwa) | 5 |
+| Supabase migration: `approve_chairman_decision` | 2 |
+| Supabase migration: `reject_chairman_decision` | 2 |
+| Supabase migration: `park_venture_decision` | 2 |
+
+### Files to Delete (after replacement)
+
+| File | When |
+|------|------|
+| `src/routes/chairmanRoutes.tsx` | After all routes migrated |
+| `src/components/chairman-v3/ChairmanLayoutV3.tsx` | After ChairmanShell is stable |
+| `src/components/chairman-v3/AttentionQueueSidebar.tsx` | After AlertPanel replaces it |
+| `src/components/chairman-v3/MobileTabBar.tsx` (old) | After BottomTabBar replaces it |
+| `src/components/chairman-v3/ChairmanOverview.tsx` | After DailyBriefing replaces it |
+| `src/components/chairman-v3/BriefingDashboard.tsx` | After DailyBriefing replaces it |
+| `src/components/chairman-v3/DecisionGateQueue.tsx` | After DecisionQueue replaces it |
+| `src/components/chairman-v3/DecisionGateDetailSheet.tsx` | After DecisionDetail replaces it |
+| `src/components/chairman-v3/DecisionGateActions.tsx` | After DecisionActions replaces it |
+| `src/components/chairman-v3/DecisionStack.tsx` | After DecisionQueue replaces it |
+| `src/components/chairman-v3/BuilderViews.tsx` | After builder/ directory replaces it |
+| `src/hooks/useChairmanDashboardData.ts` | After useChairmanBriefing replaces it |
+| `src/hooks/useChairmanOverviewData.ts` | After useChairmanBriefing replaces it |
+| `src/hooks/useDecisionGateQueue.ts` | After v3 useDecisionQueue replaces it |
+| `src/hooks/useDecisionQueue.ts` | After v3 useDecisionQueue replaces it |

--- a/docs/plans/chairman-web-ui-vision-v2.md
+++ b/docs/plans/chairman-web-ui-vision-v2.md
@@ -1,0 +1,573 @@
+# Chairman Web UI — Vision Document v2
+
+## Metadata
+
+- **Version**: 2.0.0
+- **Date**: 2026-03-02
+- **Status**: Draft
+- **Supersedes**: `docs/plans/chairman-web-ui-vision.md` (v1.0.0)
+- **Origin**: Comprehensive UI/UX assessment + cross-reference against v1 vision, architecture plan, and Glass Cockpit OS vision
+- **Companion**: `docs/plans/chairman-web-ui-architecture-v2.md`
+
+---
+
+## 1. Executive Summary
+
+Rebuild the EHG chairman experience as a focused governance and portfolio management interface. This is not a refactor — it is a clean rebuild that replaces the existing double-layer navigation and 50+ route sidebar with the single-shell layout originally planned but never implemented.
+
+The UI serves two personas (same person, different cognitive modes), integrates with Claude Code for complex actions, and evolves from responsive web app (Phase C) to installable PWA with push notifications (Phase D).
+
+**Key changes from v1**:
+- Confirmed scope includes ALL builder views (Active SDs, Build Queue, Brainstorm Inbox)
+- Full PWA implementation in scope (not deferred to Phase D)
+- All 4 gate types get gate-specific context rendering
+- RPC governance functions replace direct table writes
+- 3-layer progressive disclosure on decisions
+- Legacy cleanup happens as-we-go, not as a separate phase
+
+---
+
+## 2. Problem Statement
+
+### What exists today (assessed 2026-03-02)
+
+The EHG app has 69+ completed chairman-related SDs that collectively built:
+- **Two navigation layers**: `AuthenticatedLayout` (ModernNavigationSidebar with 50+ database-driven routes, header with search/breadcrumbs/company selector) wrapping `ChairmanLayoutV3` (9 tab items, AttentionQueueSidebar, MobileTabBar)
+- **~350-570px of horizontal sidebar space** consumed before content starts
+- **~112px of vertical chrome** from two stacked headers
+- **Three search entry points** (sidebar search, header search, Cmd+K modal)
+- **Mobile/desktop tab mismatch** — 5 desktop tabs unreachable on mobile, 2 mobile tabs don't exist on desktop
+- **4 routes skip the layout wrapper** — losing tab navigation context
+- **Generic decision cards** with no gate-specific context
+- **Broken data pipeline** — `venture_stages` table missing, `get_daily_briefing` RPC returns wrong shape, decision records have null context fields
+
+### Root cause
+
+Feature accretion across 69+ SDs without a unified information architecture pass. Each SD added navigation elements, routes, and components independently.
+
+### What we're building instead
+
+A clean rebuild following the Telegram-inspired information architecture from v1, with a single `ChairmanShell` layout containing 8 navigation items (5 chairman + 3 builder), gate-specific decision rendering, progressive disclosure, and Claude Code handoff integration.
+
+---
+
+## 3. Personas
+
+### 3.1 Chairman (Governance Mode)
+
+**Goal**: Make informed decisions that keep ventures aligned with strategic vision.
+
+**Mindset**: Executive review. Wants synthesized information, not raw data. Comfortable with approve/reject/park decisions when given sufficient context. Reviews in batches, not real-time.
+
+**Key activities**:
+- Daily briefing review (portfolio pulse, aggregate health)
+- Blocking gate decisions (approve/reject ventures at stages 0, 10, 22, 25)
+- Vision alignment monitoring (HEAL scores, drift detection)
+- Venture lifecycle overview (25-stage pipeline view per venture)
+- Preference management (risk tolerance, budget caps, notification settings)
+
+**Decision frequency**: ~1-4 blocking decisions per week across all ventures. Batched daily review.
+
+### 3.2 Solo Entrepreneur (Builder Mode)
+
+**Goal**: Execute efficiently across the venture portfolio using LEO protocol.
+
+**Mindset**: Operational. Wants to know what's next, what's blocked, and what just completed. Uses CLI as primary tool but needs a visual overview of the build pipeline.
+
+**Key activities**:
+- Active SD tracking (current phase, progress, blockers)
+- SD queue monitoring (what's ready, what's blocked, what's in progress)
+- Brainstorm capture and review (ideas inbox)
+
+**Primary tool**: CLI (`npm run sd:next`, Claude Code). The web UI is supplementary for the builder — a monitoring surface, not an execution surface.
+
+### 3.3 Persona Switching
+
+Both personas are the same person. The UI uses **route-based context**:
+
+- `/chairman/*` routes → chairman governance mode (calm, information-dense, decision-oriented)
+- `/builder/*` routes → builder operational mode (active, queue-focused, progress-oriented)
+- Persona toggle in the top nav switches sidebar sections and navigates to the persona's landing page
+- Persona preference persisted to localStorage via Zustand store
+
+---
+
+## 4. Information Architecture
+
+### 4.1 Chairman Views
+
+| View | Route | Type | Purpose |
+|------|-------|------|---------|
+| **Daily Briefing** | `/chairman` | Read | Morning summary: greeting, 4 metric cards, decision preview, portfolio pulse, HEAL alignment |
+| **Decisions** | `/chairman/decisions` | Read/Write | Blocking gate queue with gate-specific context. Approve/reject/park. |
+| **Decision Detail** | `/chairman/decisions/:id` | Read/Write | Full context for one gate decision. Progressive disclosure. Claude Code handoff. |
+| **Venture Lifecycle** | `/chairman/ventures` | Read | 25-stage pipeline view per venture. Gate status. Health scores. |
+| **Venture Detail** | `/chairman/ventures/:id` | Read | Single venture deep view. 25-stage horizontal timeline. Artifacts. |
+| **Vision & Alignment** | `/chairman/vision` | Read | HEAL scores, drift detection, corrective SD alerts |
+| **Preferences** | `/chairman/preferences` | Read/Write | Risk tolerance, budget caps, notification settings, venture overrides |
+
+### 4.2 Builder Views
+
+| View | Route | Type | Purpose |
+|------|-------|------|---------|
+| **Active SDs** | `/builder` | Read | In-progress SD details, phase, progress, blockers |
+| **Build Queue** | `/builder/queue` | Read | Prioritized SD pipeline (visual mirror of `npm run sd:next`) |
+| **Brainstorm Inbox** | `/builder/inbox` | Read/Write | Brainstorm capture, past brainstorm viewer |
+
+### 4.3 Shared
+
+| View | Route | Type | Purpose |
+|------|-------|------|---------|
+| **Alerts** | (badge + toast) | Read | Proactive notifications for both personas |
+
+---
+
+## 5. Chairman Decision Points
+
+The UI's highest-value feature is the **Decision Queue** — the points where the EVA pipeline blocks for human judgment.
+
+### 5.1 Stage 0: Venture Routing Decision
+
+**Trigger**: New venture synthesized from ideation pipeline
+**Context shown**:
+- Venture name, problem statement, solution hypothesis
+- Target market, archetype, moat strategy
+- Portfolio synergy score (0-100), time horizon
+- Chairman constraint scores (10 strategic filters) — pass/fail per constraint
+
+**Actions**: Approve (→ Stage 1) | Park as Blocked (30d review) | Park as Nursery (90d review)
+**Auto-resolve**: N/A
+
+### 5.2 Stage 10: Brand Approval Gate
+
+**Trigger**: Brand naming analysis complete with 5+ candidates
+**Context shown**:
+- Brand genome (archetype, values, tone)
+- 5+ naming candidates with per-criterion weighted scores (bar chart)
+- Narrative extension (vision, mission, brand voice)
+- Naming strategy type
+
+**Actions**: Approve top candidate | Select different candidate (override) | Reject with rationale
+**Auto-resolve**: 24h → auto-approve with flag
+
+### 5.3 Stage 22: Release Readiness Gate
+
+**Trigger**: Build loop complete, release package assembled
+**Context shown**:
+- Release items (features/bugfixes/infra) with status
+- Release notes preview
+- Target date, sprint retrospective summary
+- Build quality checks from stages 17-21
+
+**Actions**: Approve release | Reject with rationale | Hold
+**Auto-resolve**: 24h → auto-approve with flag
+
+### 5.4 Stage 25: Venture Portfolio Review
+
+**Trigger**: Post-launch data collected, venture review complete
+**Context shown**:
+- Review summary with initiative outcomes by category
+- Current vs original vision comparison, drift analysis
+- Financial comparison (projected vs actual)
+- Venture health scores (5 dimensions, 0-100 each)
+- Proposed next steps
+
+**Actions**: Continue | Pivot | Expand | Sunset | Exit — each with rationale
+**Auto-resolve**: 24h → auto-approve with flag
+
+### 5.5 Kill Gates (Stage 3, 5, 13, 23)
+
+**Trigger**: Stage completion with failing health metrics
+**Context shown**:
+- Health score vs threshold
+- Stage artifacts summary
+- Risk factors
+- Recommendation from EVA
+
+**Actions**: Continue (override) | Kill (terminate venture) | Park (pause for review)
+**Auto-resolve**: N/A — kill gates require explicit human decision
+
+---
+
+## 6. Progressive Disclosure
+
+Every decision uses a 3-layer disclosure pattern to manage cognitive load:
+
+### Layer 0: EVA Summary (Default — Decision Queue list)
+
+Compact card showing:
+- Gate type badge + venture name
+- 1-2 sentence synthesized summary
+- Priority indicator (critical/high/normal/low)
+- Auto-approve countdown (if applicable)
+- Quick actions: [Approve] [Reject] [Tell me more →]
+
+### Layer 1: Decision Context (Expanded card or slide-over panel)
+
+Gate-specific context rendering (see Section 5 for each gate type):
+- Evidence and reasoning
+- Scores, charts, pass/fail indicators
+- Risk factors and recommendation
+- [Approve] [Reject with rationale] [Park] [Open in Claude Code]
+
+### Layer 2: Full Detail (Decision Detail page — `/chairman/decisions/:id`)
+
+Complete artifact access:
+- All stage artifacts for the venture
+- Raw data tables, full audit trail
+- Token usage, agent logs (builder-level detail)
+- Claude Code context assembly for complex actions
+
+---
+
+## 7. Claude Code Integration
+
+### 7.1 Pattern: Dashboard Reads, Claude Code Writes
+
+The UI is primarily a **read surface** for governance context. When the chairman needs to take action beyond approve/reject (e.g., issue a protocol directive, investigate a drift, create a corrective SD), the UI hands off to Claude Code.
+
+### 7.2 ClaudeCodeLink Component
+
+Every decision card and venture detail view includes an "Open in Claude Code" action that:
+
+1. Assembles structured context (venture ID, stage, relevant data summary, suggested action)
+2. Formats as a markdown prompt block
+3. Copies to clipboard with a "Copied!" toast confirmation
+4. The chairman pastes into Claude Code web/desktop to execute the decision
+
+### 7.3 Context Assembly Format
+
+```markdown
+## Chairman Decision Context
+
+**Venture**: {name} (ID: {id})
+**Gate**: Stage {n} — {gate_type}
+**Summary**: {1-2 sentence summary}
+
+### Data Snapshot
+{gate-specific data formatted as markdown}
+
+### Suggested Action
+{recommended next step for Claude Code}
+```
+
+---
+
+## 8. Shell Layout
+
+### 8.1 Desktop
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│  ◆ EHG    [Chairman ▼]  [Builder]                     ⚙ Prefs   👤  │
+├────────────┬─────────────────────────────────────────────────────────┤
+│            │                                                         │
+│  CHAIRMAN  │              Main Content Area                          │
+│  ────────  │              (route-dependent)                          │
+│  Briefing  │                                                         │
+│  Decisions │                                                         │
+│  Ventures  │                                                         │
+│  Vision    │                                                         │
+│  Prefs     │                                                         │
+│            │                                                         │
+│  BUILDER   │                                                         │
+│  ────────  │                                                         │
+│  Active    │                                                         │
+│  Queue     │                                                         │
+│  Inbox     │                                                         │
+│            │                                                         │
+│ ────────── │                                                         │
+│ [Alerts 🔴3]│                                                        │
+└────────────┴─────────────────────────────────────────────────────────┘
+```
+
+**Behavior**:
+- Clicking [Chairman] or [Builder] in top nav scrolls sidebar to that section + navigates to persona landing page
+- Active route highlighted in sidebar
+- Alert badge at sidebar bottom shows unread count
+- Sidebar collapses to icon-only on narrow desktops (< 1200px)
+
+### 8.2 Mobile
+
+```
+┌────────────────────────────┐
+│  ◆ EHG              ⚙  👤 │
+├────────────────────────────┤
+│                            │
+│                            │
+│     Main Content Area      │
+│     (full width)           │
+│                            │
+│                            │
+│                            │
+│                            │
+│                            │
+├────────────────────────────┤
+│ Brief │ Dec │ Vent │ Vis │⋯│  ← Bottom tab bar
+└────────────────────────────┘
+```
+
+**Behavior**:
+- Bottom tabs show current persona's views (swipe or tap ⋯ for overflow/persona switch)
+- Chairman: Brief, Dec, Vent, Vis, ⋯(Prefs + persona switch)
+- Builder: Active, Queue, Inbox, ⋯(persona switch)
+- Same items as desktop sidebar — full parity
+
+---
+
+## 9. UI/UX Wireframes
+
+### 9.1 Daily Briefing (`/chairman`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Good morning, Chairman.                     Mar 2, 2026   ☀️   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐   │
+│  │ PENDING  │  │ ACTIVE   │  │  HEAL    │  │ COMPLETED    │   │
+│  │ DECISIONS│  │ VENTURES │  │  SCORE   │  │ THIS WEEK    │   │
+│  │    2     │  │    1     │  │   78%    │  │     3 SDs    │   │
+│  └──────────┘  └──────────┘  └──────────┘  └──────────────┘   │
+│                                                                 │
+│  DECISION QUEUE (2 pending)                      View All →     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  🔴 Kill Gate — Stage 3           NicheBrief AI         │   │
+│  │     Health: 61/100 (below threshold)                     │   │
+│  │     Waiting since: 2h ago            [Review →]          │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  PORTFOLIO PULSE                                                │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  NicheBrief AI    ███░░░░░░░░░░░░  Stage 3/25  Active   │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  VISION ALIGNMENT                                               │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  HEAL Score: 78% ████████████████░░░░  (↑ 3% this week)│   │
+│  │  0 drift alerts · 0 corrective SDs        [Details →]   │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.2 Decision Queue (`/chairman/decisions`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Decisions                                    1 pending · 0 held│
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌─ BLOCKING ───────────────────────────────────────────────┐  │
+│  │                                                           │  │
+│  │  ┌─────────────────────────────────────────────────────┐ │  │
+│  │  │ 🔴 KILL GATE · Stage 3                              │ │  │
+│  │  │ NicheBrief AI                                       │ │  │
+│  │  │                                                     │ │  │
+│  │  │ Health: 61/100 · Below 70 threshold                 │ │  │
+│  │  │ Risk: Market validation incomplete                  │ │  │
+│  │  │ Recommendation: Continue with monitoring            │ │  │
+│  │  │                                                     │ │  │
+│  │  │  [✓ Continue]  [✗ Kill]  [Park]  [Tell me more →]  │ │  │
+│  │  │                                                     │ │  │
+│  │  └─────────────────────────────────────────────────────┘ │  │
+│  │                                                           │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌─ RECENT (last 7 days) ───────────────────────────────────┐  │
+│  │  (no recent decisions)                                    │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.3 Venture Lifecycle (`/chairman/ventures`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Venture Lifecycle                              1 active · 0 🌱  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ┌─ NicheBrief AI ──────────────────────── Stage 3/25 ──────┐  │
+│  │                                                           │  │
+│  │  THE TRUTH    THE ENGINE   IDENTITY   BLUEPRINT  BUILD  L │  │
+│  │  ●─●─●─◐──── ○─○─○─○──── ○─○─○───── ○─○─○───── ○──── ○ │  │
+│  │  0 1 2 [3]   4 5 6 7     8 9 10      11-13      14-22 23│  │
+│  │          ▲                                                │  │
+│  │   🔴 BLOCKING — Kill Gate (Health: 61/100)                │  │
+│  │                                                           │  │
+│  │  Health: 61/100   HEAL: Aligned   [View Detail →]         │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  Legend: ● Complete  ◐ In Progress  ○ Future  [N] Current Stage │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.4 Builder Dashboard (`/builder`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Builder                                     0 active · 0 ready │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ACTIVE SDs                                                     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  No active SDs. Check the Build Queue for ready work.   │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  READY QUEUE (next 3)                        View Full Queue →  │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  (populated from strategic_directives_v2 pipeline)      │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  RECENT COMPLETIONS                                             │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  (last 7 days of completed SDs with PR links)           │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 9.5 Preferences (`/chairman/preferences`)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Chairman Preferences                                           │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  RISK & BUDGET                                                  │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Max Drawdown Tolerance     [====●=======] 35%          │   │
+│  │  Monthly Budget Cap         [$____500____] USD          │   │
+│  │  Tech Stack Directive       [React + Supabase    ▼]     │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  NOTIFICATIONS                                                  │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  Email                      [chairman@ehg.com      ]    │   │
+│  │  Daily Digest               [●  ON  ○ OFF]              │   │
+│  │  Digest Time                [08:00 ▼]  Timezone [EST ▼] │   │
+│  │  Quiet Hours                [22:00] to [07:00]          │   │
+│  │  Push Notifications         [●  ON  ○ OFF]              │   │
+│  │  Alert Threshold            [Critical + Warning  ▼]     │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  VENTURE-SPECIFIC OVERRIDES                                     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │  NicheBrief AI     Max drawdown: 25%        [Edit] [✕]  │   │
+│  │  [+ Add Venture Override]                                │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│                                           [Save Changes]        │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 10. Data Freshness Strategy
+
+| Tier | Refresh Model | Staleness Tolerance | Views |
+|------|--------------|---------------------|-------|
+| **Live** | Supabase Realtime subscription | 0s | Decision Queue (new decisions arriving) |
+| **Near-live** | Poll every 60s while tab active | 1 min | Active SDs (phase transitions), Alerts |
+| **Session** | Fetch on view mount, cache for session | 5-15 min | Daily Briefing, Venture Lifecycle, Vision & Alignment |
+| **Manual** | Fetch on explicit refresh or navigation | Unlimited | Build Queue, Preferences |
+
+### Stale Data Indicator
+
+When data is older than its staleness tolerance:
+```
+Last updated: 3 min ago  [↻ Refresh]
+```
+No aggressive warnings — the chairman knows this is a daily review tool.
+
+---
+
+## 11. Notification & Alert Delivery
+
+### Delivery Channels
+
+| Channel | Events | Implementation |
+|---------|--------|----------------|
+| **Dashboard badge** | All alerts | Red dot on sidebar Alerts item, count badge |
+| **Browser tab title** | Pending decisions | `(3) Chairman — EHG` in tab title |
+| **Email digest** | Blocking decisions only | Daily email at configured time via Supabase Edge Function + Resend |
+| **Push notification** | Blocking decisions, critical HEAL drops | Web Push API via service worker |
+| **App badge** | Unread count | Navigator Badge API (where supported) |
+
+### Alert Priority Levels
+
+| Priority | Trigger | Behavior |
+|----------|---------|----------|
+| **Critical** | New blocking gate decision | Push + email + badge |
+| **Warning** | HEAL score < threshold, auto-approve < 4h | Push + badge |
+| **Info** | Stage progression, SD completion | Badge only |
+
+### Chairman Preferences Integration
+
+The Preferences view controls:
+- Email digest time (default: 08:00 local) and on/off toggle
+- Push notification opt-in
+- Alert priority threshold (Critical only, or Critical + Warning)
+- Quiet hours
+
+---
+
+## 12. PWA Capabilities
+
+### Manifest
+
+```json
+{
+  "name": "EHG Chairman",
+  "short_name": "Chairman",
+  "start_url": "/chairman",
+  "display": "standalone",
+  "theme_color": "#1a1a2e",
+  "background_color": "#16213e"
+}
+```
+
+### Service Worker
+
+- Cache briefing data for offline reading
+- Background sync for decision actions taken offline
+- Install prompt after 3+ visits
+
+### Push Notifications
+
+- Supabase Edge Function triggers on new `chairman_decisions` rows with `status = 'pending'`
+- Web Push API via service worker subscription
+- Respects quiet hours and alert threshold from chairman_preferences
+
+---
+
+## 13. What This UI Is NOT
+
+1. **Not an execution surface for LEO** — no SD creation, no phase handoffs, no code review. That's CLI + Claude Code.
+2. **Not a replacement for `npm run sd:next`** — the builder queue is a visual mirror, not a replacement.
+3. **Not a real-time monitoring dashboard** — batched daily review, not live streaming.
+4. **Not multi-user** — single chairman, single builder, same person. No RBAC.
+5. **Not the existing app sidebar** — ChairmanShell replaces ModernNavigationSidebar for chairman/builder routes. The 50+ route sidebar is for other app sections only.
+
+---
+
+## 14. Success Criteria
+
+1. **Daily habit formation**: Chairman opens the briefing view at least 5 of 7 days per week after 2 weeks
+2. **Decision queue clearance**: All blocking gate decisions resolved through the UI (not CLI or auto-approve)
+3. **Context sufficiency**: Chairman can make gate decisions without needing CLI for additional context
+4. **Mobile usable**: All views render and function correctly on mobile browser and as installed PWA
+5. **Sub-second loads**: Dashboard views load in < 1s with cached Supabase queries
+6. **Progressive disclosure works**: Chairman uses "Tell me more" on at least 50% of non-trivial decisions
+
+---
+
+## 15. Related Documents
+
+- **Architecture plan**: `docs/plans/chairman-web-ui-architecture-v2.md`
+- **Superseded vision**: `docs/plans/chairman-web-ui-vision.md` (v1)
+- **Glass Cockpit OS**: `docs/reference/vision/00-vision-v2-chairman-os.md`
+- **EVA Lifecycle Vision**: `docs/plans/eva-venture-lifecycle-vision.md`


### PR DESCRIPTION
## Summary
- **Design prototype** (`chairman-dashboard-v2-design.html`) — standalone interactive HTML with all 10 views (7 chairman + 3 builder), dark/light theme toggle, persona switching, glass morphism design system, and responsive mobile layout
- **Vision v2** (`docs/plans/chairman-web-ui-vision-v2.md`) — complete product vision defining personas, information architecture, progressive disclosure, gate-specific rendering, and PWA capabilities
- **Architecture v2** (`docs/plans/chairman-web-ui-architecture-v2.md`) — technical specification covering component architecture, data layer, governance API surface, Zod validation, Zustand state, and implementation phases

## Test plan
- [ ] Open `chairman-dashboard-v2-design.html` in browser and verify all 10 views render
- [ ] Toggle dark/light mode
- [ ] Toggle Chairman/Builder persona
- [ ] Test responsive behavior at mobile breakpoints
- [ ] Review vision doc for completeness against existing codebase
- [ ] Review architecture doc for alignment with current tech stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)