### PR TITLE
fix(security): harden API middleware — auth, CORS, rate limits, headers

### DIFF
--- a/scripts/claude-middleware-service.js
+++ b/scripts/claude-middleware-service.js
@@ -10,6 +10,8 @@ import express from 'express';
 import http from 'http';
 import { WebSocketServer } from 'ws';
 import cors from 'cors';
+import helmet from 'helmet';
+import rateLimit from 'express-rate-limit';
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'url';
 import path from 'path';
@@ -37,8 +39,19 @@ const app = express();
 const server = http.createServer(app);
 const wss = new WebSocketServer({ server });
 
-// Middleware
-app.use(cors());
+// Security middleware
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || 'http://localhost:3000,http://localhost:5173').split(',');
+app.use(helmet());
+app.use(cors({
+  origin: allowedOrigins,
+  methods: ['GET', 'POST'],
+  allowedHeaders: ['Content-Type', 'Authorization']
+}));
+app.use(rateLimit({
+  windowMs: 60 * 1000,
+  max: 100,
+  message: { error: 'Rate limit exceeded. Try again later.' }
+}));
 app.use(express.json({ limit: '10mb' }));
 
 // Initialize the invisible sub-agent system

--- a/src/api/stories/index.js
+++ b/src/api/stories/index.js
@@ -196,6 +196,6 @@ export async function verifyStories(req, res) {
 // Apply rate limiting
 export default {
   generateStories: [limiter, generateStories],
-  listStories,
+  listStories: [limiter, listStories],
   verifyStories: [limiter, verifyStories]
 };

--- a/src/services/refresh-api.js
+++ b/src/services/refresh-api.js
@@ -8,6 +8,26 @@
 import path from 'path';
 import { getProcessManager } from './CodebaseSearchService.js';
 
+/**
+ * Middleware: Require API key for admin endpoints.
+ * Set ADMIN_API_KEY env var; requests must send Authorization: Bearer <key>.
+ */
+function requireAdminAuth(req, res, next) {
+  const adminKey = process.env.ADMIN_API_KEY;
+  if (!adminKey) {
+    // If no key configured, reject all admin requests in production
+    if (process.env.NODE_ENV === 'production') {
+      return res.status(503).json({ error: 'Admin API not configured' });
+    }
+    return next(); // Allow in development when unconfigured
+  }
+  const auth = req.headers.authorization;
+  if (!auth || auth !== `Bearer ${adminKey}`) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  next();
+}
+
 class RefreshAPI {
   constructor(server, dbLoader) {
     this.server = server;
@@ -16,111 +36,91 @@ class RefreshAPI {
   }
 
   setupRoutes(app) {
-    // System status endpoint
+    // System status endpoint — sanitized (no PID, memory, or Node version)
     app.get('/api/system-status', (req, res) => {
       res.json({
         startTime: this.serverStartTime.toISOString(),
         uptime: Date.now() - this.serverStartTime.getTime(),
-        pid: process.pid,
-        memory: process.memoryUsage(),
-        version: process.version,
         status: 'running'
       });
     });
 
     // Health check endpoint
     app.get('/api/health', (req, res) => {
-      res.json({ 
-        status: 'ok', 
+      res.json({
+        status: 'ok',
         timestamp: new Date().toISOString(),
         database: this.dbLoader?.isConnected || false
       });
     });
 
-    // Database refresh endpoint
-    app.post('/api/refresh', async (req, res) => {
+    // Database refresh endpoint — requires admin auth
+    app.post('/api/refresh', requireAdminAuth, async (req, res) => {
       try {
         const { type } = req.body;
-        
+
         console.log(`🔄 Refresh request: ${type}`);
-        
+
         if (type === 'database') {
-          // Force reload data from database
           await this.refreshDatabase();
-          res.json({ 
-            success: true, 
+          res.json({
+            success: true,
             type: 'database',
             message: 'Database refreshed successfully',
             timestamp: new Date().toISOString()
           });
         } else {
-          res.status(400).json({ 
-            error: 'Invalid refresh type. Use "database"' 
+          res.status(400).json({
+            error: 'Invalid refresh type. Use "database"'
           });
         }
       } catch (error) {
-        console.error('❌ Refresh failed:', error.message);
-        res.status(500).json({ 
-          error: error.message,
-          type: 'refresh_error'
-        });
+        console.error('Refresh failed:', error.message);
+        res.status(500).json({ error: 'Refresh failed' });
       }
     });
 
-    // Server restart endpoint
-    app.post('/api/restart', async (req, res) => {
+    // Server restart endpoint — requires admin auth
+    app.post('/api/restart', requireAdminAuth, async (req, res) => {
       try {
         console.log('🔄 Server restart requested via API');
-        
-        // Send response before restarting
-        res.json({ 
-          success: true, 
+
+        res.json({
+          success: true,
           message: 'Server restart initiated',
-          timestamp: new Date().toISOString(),
-          expectedDowntime: '10-15 seconds'
+          timestamp: new Date().toISOString()
         });
 
-        // Give response time to send
         setTimeout(() => {
           this.restartServer();
         }, 1000);
 
       } catch (error) {
-        console.error('❌ Restart failed:', error.message);
-        res.status(500).json({ 
-          error: error.message,
-          type: 'restart_error'
-        });
+        console.error('Restart failed:', error.message);
+        res.status(500).json({ error: 'Restart failed' });
       }
     });
 
-    // Force refresh endpoint (database + restart)
-    app.post('/api/force-refresh', async (req, res) => {
+    // Force refresh endpoint (database + restart) — requires admin auth
+    app.post('/api/force-refresh', requireAdminAuth, async (req, res) => {
       try {
         console.log('🔄 Force refresh requested (database + restart)');
-        
-        // First refresh database
+
         await this.refreshDatabase();
-        
-        // Send response before restarting
-        res.json({ 
-          success: true, 
+
+        res.json({
+          success: true,
           message: 'Database refreshed, server restart initiated',
-          timestamp: new Date().toISOString(),
-          expectedDowntime: '10-15 seconds'
+          timestamp: new Date().toISOString()
         });
 
-        // Give response time to send, then restart
         setTimeout(() => {
           this.restartServer();
         }, 1000);
 
       } catch (error) {
-        console.error('❌ Force refresh failed:', error.message);
-        res.status(500).json({ 
-          error: error.message,
-          type: 'force_refresh_error'
-        });
+        console.error('Force refresh failed:', error.message);
+        res.status(500).json({ error: 'Force refresh failed' });
       }
     });
   }


### PR DESCRIPTION
## Summary
- **SD**: SD-MAN-FIX-API-MIDDLEWARE-SECURITY-001
- Hardens API and middleware security across 3 files
- All security packages were already installed (`helmet`, `cors`, `express-rate-limit`) but unused/misconfigured

## Changes

### `scripts/claude-middleware-service.js`
- **helmet.js**: Added security headers (X-Content-Type-Options, X-Frame-Options, HSTS, etc.)
- **CORS**: Restricted from wildcard `*` to `ALLOWED_ORIGINS` env var
- **Rate limiting**: Added 100 req/min limit on all endpoints

### `src/services/refresh-api.js` (P0 Critical)
- **Admin auth**: Added `requireAdminAuth` middleware to `/api/refresh`, `/api/restart`, `/api/force-refresh`
  - Uses `ADMIN_API_KEY` env var with Bearer token
  - Blocks all admin requests in production if key unconfigured
  - Allows unauthenticated in dev when key not set
- **Info disclosure fix**: Removed `pid`, `memory`, `version` from `/api/system-status`
- **Error sanitization**: Internal `error.message` no longer leaked to clients

### `src/api/stories/index.js`
- **Rate limiting**: Applied existing limiter to previously unprotected `listStories` endpoint

## Deployment action needed
After merge, set these env vars:
- `ALLOWED_ORIGINS` — comma-separated list of allowed CORS origins
- `ADMIN_API_KEY` — secret key for admin API endpoints

## Test plan
- [x] All 15 smoke tests pass
- [x] ESLint clean
- [x] DOCMON compliance passes
- [ ] Manual: verify `curl -X POST /api/restart` returns 401 without auth header
- [ ] Manual: verify CORS rejects cross-origin from unlisted domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)