### PR TITLE
fix: Stage Zero processor logger compatibility

### DIFF
--- a/scripts/stage-zero-queue-processor.js
+++ b/scripts/stage-zero-queue-processor.js
@@ -50,6 +50,7 @@ function createServiceClient() {
 // ── Logging ────────────────────────────────────────────────────────
 
 const log = {
+  log: (...args) => console.log(`[${new Date().toISOString()}] [SZ-PROC]`, ...args),
   info: (...args) => console.log(`[${new Date().toISOString()}] [SZ-PROC]`, ...args),
   warn: (...args) => console.warn(`[${new Date().toISOString()}] [SZ-PROC] WARN:`, ...args),
   error: (...args) => console.error(`[${new Date().toISOString()}] [SZ-PROC] ERROR:`, ...args),


### PR DESCRIPTION
## Summary
- Add `logger.log()` method to the Stage Zero queue processor's logger object
- The `executeStageZero()` internals (chairman-review.js, etc.) call `logger.log()` for formatting output, which was missing from the processor's logger

## Test plan
- [x] Processor starts and polls successfully
- [x] Status transitions verified: pending → claimed → in_progress → failed (with error details stored)
- [x] Failure is now in `executeStageZero()` internals (stale `venture_blueprints.template_data` column), not the processor

🤖 Generated with [Claude Code](https://claude.com/claude-code)