### PR TITLE
fix: blueprint-browse uses opportunity_blueprints instead of stale venture_blueprints

### DIFF
--- a/lib/eva/stage-zero/paths/blueprint-browse.js
+++ b/lib/eva/stage-zero/paths/blueprint-browse.js
@@ -1,14 +1,14 @@
 /**
  * Path 2: Blueprint Browse
  *
- * Browse categorized venture blueprint templates,
- * select a template, and customize parameters.
+ * Browse categorized opportunity blueprints,
+ * select a blueprint, and customize parameters.
  *
  * Flow:
- * 1. Load blueprints from venture_blueprints table
+ * 1. Load blueprints from opportunity_blueprints table
  * 2. Group by category for browsing
  * 3. Select blueprint (by ID or category filter)
- * 4. Apply customizations to template parameters
+ * 4. Apply customizations to blueprint parameters
  * 5. Return PathOutput with blueprint-derived venture brief
  *
  * Part of SD-LEO-ORCH-STAGE-INTELLIGENT-VENTURE-001-D
@@ -48,7 +48,7 @@ export async function executeBlueprintBrowse({ blueprintId, category, customizat
   logger.log(`   Found ${blueprints.length} blueprint(s) across ${Object.keys(grouped).length} category/categories`);
 
   for (const [cat, items] of Object.entries(grouped)) {
-    logger.log(`   [${cat}] ${items.length} template(s)`);
+    logger.log(`   [${cat}] ${items.length} blueprint(s)`);
   }
 
   // Step 3: Select blueprint
@@ -58,22 +58,23 @@ export async function executeBlueprintBrowse({ blueprintId, category, customizat
     if (!selected) {
       throw new Error(`Blueprint not found: ${blueprintId}`);
     }
-    logger.log(`   Selected: ${selected.name} (${selected.category})`);
+    logger.log(`   Selected: ${selected.title} (${selected.category})`);
   } else if (category) {
     const filtered = grouped[category];
     if (!filtered || filtered.length === 0) {
       throw new Error(`No blueprints in category: ${category}. Available: ${Object.keys(grouped).join(', ')}`);
     }
     selected = filtered[0];
-    logger.log(`   Auto-selected from ${category}: ${selected.name}`);
+    logger.log(`   Auto-selected from ${category}: ${selected.title}`);
   } else {
     // Non-interactive: pick first blueprint
     selected = blueprints[0];
-    logger.log(`   Auto-selected: ${selected.name} (${selected.category})`);
+    logger.log(`   Auto-selected: ${selected.title} (${selected.category})`);
   }
 
-  // Step 4: Apply customizations
-  const template = applyCustomizations(selected.template_data || {}, customizations);
+  // Step 4: Build template data from individual blueprint columns
+  const templateData = buildTemplateData(selected);
+  const template = applyCustomizations(templateData, customizations);
 
   if (Object.keys(customizations).length > 0) {
     logger.log(`   Applied ${Object.keys(customizations).length} customization(s)`);
@@ -89,13 +90,13 @@ export async function executeBlueprintBrowse({ blueprintId, category, customizat
       categories_available: Object.keys(grouped),
     },
     blueprint_id: selected.id,
-    suggested_name: template.name || selected.name,
+    suggested_name: template.name || selected.title,
     suggested_problem: template.problem_statement || '',
-    suggested_solution: template.solution || '',
+    suggested_solution: template.solution_concept || '',
     target_market: template.target_market || '',
     metadata: {
       path: 'blueprint_browse',
-      blueprint_name: selected.name,
+      blueprint_name: selected.title,
       blueprint_category: selected.category,
       total_blueprints: blueprints.length,
       categories_browsed: Object.keys(grouped),
@@ -114,8 +115,8 @@ export async function executeBlueprintBrowse({ blueprintId, category, customizat
  */
 async function loadBlueprints(supabase, { category } = {}) {
   let query = supabase
-    .from('venture_blueprints')
-    .select('id, name, category, description, template_data, is_active')
+    .from('opportunity_blueprints')
+    .select('id, title, category, summary, problem_statement, solution_concept, target_market, differentiation, competitive_gaps, customer_evidence, opportunity_score, metadata, enhanced_data, confidence_score, is_active')
     .eq('is_active', true)
     .order('category', { ascending: true });
 
@@ -149,10 +150,33 @@ export function groupByCategory(blueprints) {
 }
 
 /**
- * Apply customizations over template defaults.
- * Customizations override template_data values at the top level.
+ * Build a template data object from individual opportunity_blueprints columns.
+ * This consolidates the spread-out columns into a single object for downstream use.
  *
- * @param {Object} template - Original template_data from blueprint
+ * @param {Object} blueprint - Row from opportunity_blueprints
+ * @returns {Object} Consolidated template data
+ */
+function buildTemplateData(blueprint) {
+  return {
+    name: blueprint.title,
+    problem_statement: blueprint.problem_statement || '',
+    solution_concept: blueprint.solution_concept || '',
+    target_market: blueprint.target_market || '',
+    differentiation: blueprint.differentiation || '',
+    competitive_gaps: blueprint.competitive_gaps || '',
+    customer_evidence: blueprint.customer_evidence || '',
+    opportunity_score: blueprint.opportunity_score,
+    confidence_score: blueprint.confidence_score,
+    ...(blueprint.metadata || {}),
+    ...(blueprint.enhanced_data || {}),
+  };
+}
+
+/**
+ * Apply customizations over template defaults.
+ * Customizations override template values at the top level.
+ *
+ * @param {Object} template - Consolidated template data from blueprint
  * @param {Object} customizations - User overrides
  * @returns {Object} Merged template
  */
@@ -180,6 +204,6 @@ export async function listBlueprintCategories(deps = {}) {
   return Object.entries(grouped).map(([category, items]) => ({
     category,
     count: items.length,
-    blueprints: items.map(b => ({ id: b.id, name: b.name })),
+    blueprints: items.map(b => ({ id: b.id, name: b.title })),
   }));
 }

--- a/test/unit/blueprint-browse.test.js
+++ b/test/unit/blueprint-browse.test.js
@@ -23,29 +23,38 @@ import {
 
 const DEFAULT_BLUEPRINTS = [
   {
-    id: 'bp-saas-1', name: 'SaaS Starter', category: 'software',
-    description: 'Standard SaaS venture template',
-    template_data: { name: 'SaaS Venture', problem_statement: 'Manual processes waste time', solution: 'Automated SaaS platform', target_market: 'SMBs', pricing_model: 'subscription' },
+    id: 'bp-saas-1', title: 'SaaS Starter', category: 'software',
+    summary: 'Standard SaaS venture template',
+    problem_statement: 'Manual processes waste time', solution_concept: 'Automated SaaS platform',
+    target_market: 'SMBs', differentiation: 'AI-powered', competitive_gaps: '',
+    customer_evidence: '', opportunity_score: 80, confidence_score: 0.85,
+    metadata: { pricing_model: 'subscription' }, enhanced_data: null,
     is_active: true,
   },
   {
-    id: 'bp-market-1', name: 'Marketplace Template', category: 'marketplace',
-    description: 'Two-sided marketplace template',
-    template_data: { name: 'AI Marketplace', problem_statement: 'Fragmented supply and demand', solution: 'AI-powered matching marketplace', target_market: 'Enterprises' },
+    id: 'bp-market-1', title: 'Marketplace Template', category: 'marketplace',
+    summary: 'Two-sided marketplace template',
+    problem_statement: 'Fragmented supply and demand', solution_concept: 'AI-powered matching marketplace',
+    target_market: 'Enterprises', differentiation: '', competitive_gaps: '',
+    customer_evidence: '', opportunity_score: 75, confidence_score: 0.8,
+    metadata: null, enhanced_data: null,
     is_active: true,
   },
   {
-    id: 'bp-saas-2', name: 'API-First SaaS', category: 'software',
-    description: 'API-first developer tools',
-    template_data: { name: 'DevTools API', problem_statement: 'Developers lack automation', solution: 'API-first developer platform', target_market: 'Developers' },
+    id: 'bp-saas-2', title: 'API-First SaaS', category: 'software',
+    summary: 'API-first developer tools',
+    problem_statement: 'Developers lack automation', solution_concept: 'API-first developer platform',
+    target_market: 'Developers', differentiation: '', competitive_gaps: '',
+    customer_evidence: '', opportunity_score: 70, confidence_score: 0.75,
+    metadata: null, enhanced_data: null,
     is_active: true,
   },
 ];
 
 function createMockSupabase(blueprints = DEFAULT_BLUEPRINTS, dbError = null) {
   // Build a chainable mock that handles:
-  // .from('venture_blueprints').select(...).eq('is_active', true).eq('category', X).order(...)
-  // .from('venture_blueprints').select(...).eq('is_active', true).order(...)
+  // .from('opportunity_blueprints').select(...).eq('is_active', true).eq('category', X).order(...)
+  // .from('opportunity_blueprints').select(...).eq('is_active', true).order(...)
   const buildChain = (data, error) => {
     const chain = {};
     chain.eq = vi.fn().mockImplementation((field, value) => {
@@ -89,7 +98,7 @@ describe('Blueprint Browse - executeBlueprintBrowse', () => {
 
     expect(result.origin_type).toBe('blueprint');
     expect(result.blueprint_id).toBe('bp-saas-1');
-    expect(result.suggested_name).toBe('SaaS Venture');
+    expect(result.suggested_name).toBe('SaaS Starter');
     expect(result.suggested_problem).toBe('Manual processes waste time');
   });
 
@@ -101,7 +110,7 @@ describe('Blueprint Browse - executeBlueprintBrowse', () => {
     );
 
     expect(result.blueprint_id).toBe('bp-market-1');
-    expect(result.suggested_name).toBe('AI Marketplace');
+    expect(result.suggested_name).toBe('Marketplace Template');
     expect(result.metadata.blueprint_category).toBe('marketplace');
   });
 
@@ -141,9 +150,13 @@ describe('Blueprint Browse - executeBlueprintBrowse', () => {
     expect(result.raw_material.categories_available).toContain('marketplace');
   });
 
-  test('handles blueprint with missing template_data', async () => {
+  test('handles blueprint with missing optional fields', async () => {
     const supabase = createMockSupabase([
-      { id: 'bp-empty', name: 'Empty Template', category: 'other', description: 'No data', template_data: null, is_active: true },
+      { id: 'bp-empty', title: 'Empty Template', category: 'other', summary: 'No data',
+        problem_statement: null, solution_concept: null, target_market: null,
+        differentiation: null, competitive_gaps: null, customer_evidence: null,
+        opportunity_score: null, confidence_score: null, metadata: null, enhanced_data: null,
+        is_active: true },
     ]);
 
     const result = await executeBlueprintBrowse({}, { supabase, logger: silentLogger });

--- a/test/unit/stage-zero.test.js
+++ b/test/unit/stage-zero.test.js
@@ -39,11 +39,15 @@ function createMockSupabase(overrides = {}) {
     };
 
     // Table-specific mocks
-    if (table === 'venture_blueprints') {
+    if (table === 'opportunity_blueprints') {
       chain.eq = vi.fn().mockReturnValue({
         order: vi.fn().mockResolvedValue({
           data: overrides.blueprints || [
-            { id: 'bp-1', name: 'SaaS Blueprint', category: 'software', description: 'Standard SaaS', template_data: { name: 'SaaS Venture', problem_statement: 'test problem', solution: 'test solution', target_market: 'SMBs' }, is_active: true },
+            { id: 'bp-1', title: 'SaaS Blueprint', category: 'software', summary: 'Standard SaaS',
+              problem_statement: 'test problem', solution_concept: 'test solution', target_market: 'SMBs',
+              differentiation: '', competitive_gaps: '', customer_evidence: '',
+              opportunity_score: 80, confidence_score: 0.85, metadata: null, enhanced_data: null,
+              is_active: true },
           ],
           error: null,
         }),


### PR DESCRIPTION
## Summary
- Fixed Stage 0 blueprint_browse path querying non-existent `venture_blueprints` table with wrong columns
- Changed to `opportunity_blueprints` table with correct columns (`title`, `summary`, `problem_statement`, `solution_concept`, etc.)
- Added `buildTemplateData()` helper to consolidate individual blueprint columns into a template object
- Updated all `selected.name` references to `selected.title`
- Updated unit tests to match new schema (19/19 pass, plus 28/30 in stage-zero tests — 2 pre-existing discovery mock failures)

## Test plan
- [x] Unit tests: `npx vitest run test/unit/blueprint-browse.test.js` — 19/19 pass
- [x] Unit tests: `npx vitest run test/unit/stage-zero.test.js` — 28/30 pass (2 pre-existing failures)
- [x] Smoke tests: 15/15 pass
- [x] E2E: Inserted real blueprint request, ran processor with `--once`, full pipeline completed: poll → claim → synthesis (13 components) → chairman review → venture created in 39s

🤖 Generated with [Claude Code](https://claude.com/claude-code)