### PR TITLE
fix: harden Stage Zero with SQL injection fix, dedup, and timeout budget

### DIFF
--- a/lib/eva/stage-zero/paths/competitor-teardown.js
+++ b/lib/eva/stage-zero/paths/competitor-teardown.js
@@ -96,12 +96,32 @@ async function analyzeCompetitor(url, deps = {}) {
   let marketPositionBlock = '';
   if (supabase) {
     try {
-      const { data: rankings } = await supabase
-        .from('app_rankings')
-        .select('chart_position, source, rating, review_count, installs_range, category')
-        .or(`app_url.eq.${url},website_url.eq.${url}`)
-        .order('scraped_at', { ascending: false })
-        .limit(5);
+      // Validate URL format to prevent filter injection via crafted strings
+      let sanitizedUrl;
+      try {
+        sanitizedUrl = new URL(url).href;
+      } catch {
+        sanitizedUrl = null;
+      }
+
+      const rankings = [];
+      if (sanitizedUrl) {
+        // Use separate .eq() calls instead of .or() string interpolation to avoid injection
+        const [byApp, byWeb] = await Promise.all([
+          supabase.from('app_rankings')
+            .select('chart_position, source, rating, review_count, installs_range, category')
+            .eq('app_url', sanitizedUrl)
+            .order('scraped_at', { ascending: false })
+            .limit(5),
+          supabase.from('app_rankings')
+            .select('chart_position, source, rating, review_count, installs_range, category')
+            .eq('website_url', sanitizedUrl)
+            .order('scraped_at', { ascending: false })
+            .limit(5),
+        ]);
+        if (byApp.data) rankings.push(...byApp.data);
+        if (byWeb.data) rankings.push(...byWeb.data.filter(r => !rankings.some(e => e.chart_position === r.chart_position && e.source === r.source)));
+      }
 
       if (rankings && rankings.length > 0) {
         const lines = rankings.map(r =>

--- a/lib/eva/stage-zero/stage-zero-orchestrator.js
+++ b/lib/eva/stage-zero/stage-zero-orchestrator.js
@@ -38,6 +38,16 @@ export async function executeStageZero(params, deps = {}) {
   const { path, pathParams = {}, options = {} } = params;
   const { supabase, logger = console, synthesize } = deps;
   const startTime = Date.now();
+  const deadline = options.deadline || null;
+
+  // Helper: check remaining time budget before expensive steps
+  const checkBudget = (stepName, minMs = 30000) => {
+    if (!deadline) return;
+    const remaining = deadline - Date.now();
+    if (remaining < minMs) {
+      throw new Error(`Insufficient time for ${stepName}: ${Math.round(remaining / 1000)}s remaining, need ${Math.round(minMs / 1000)}s`);
+    }
+  };
 
   if (!supabase) {
     throw new Error('supabase client is required');
@@ -55,6 +65,7 @@ export async function executeStageZero(params, deps = {}) {
   logger.log(`   Path: ${getPathLabel(path)}`);
   logger.log('   ' + '─'.repeat(50));
 
+  checkBudget('path execution', 60000);
   const pathOutput = await routePath(path, pathParams, enrichedDeps);
 
   if (!pathOutput) {
@@ -71,6 +82,7 @@ export async function executeStageZero(params, deps = {}) {
   let synthesisResult;
   const synthesizeFn = synthesize || runSynthesis;
   if (!options.skipSynthesis) {
+    checkBudget('synthesis', 45000);
     logger.log('\n   Running synthesis...');
     synthesisResult = await synthesizeFn(pathOutput, enrichedDeps);
   } else {
@@ -80,6 +92,7 @@ export async function executeStageZero(params, deps = {}) {
   // Step 2b: Run horizontal forecast (financial projections)
   if (!options.skipSynthesis) {
     try {
+      checkBudget('forecast', 30000);
       logger.log('\n   Generating financial forecast...');
       const forecast = await generateForecast(synthesisResult, enrichedDeps);
       const score = calculateVentureScore(forecast);
@@ -95,6 +108,7 @@ export async function executeStageZero(params, deps = {}) {
   }
 
   // Step 3: Chairman review
+  checkBudget('chairman review', 30000);
   logger.log('\n   Entering chairman review...');
   const reviewResult = await conductChairmanReview(synthesisResult, enrichedDeps);
 

--- a/scripts/stage-zero-queue-processor.js
+++ b/scripts/stage-zero-queue-processor.js
@@ -58,7 +58,7 @@ const log = {
 
 // ── Stale Claim Recovery ───────────────────────────────────────────
 
-async function releaseStaleCliams(supabase) {
+async function releaseStaleClaims(supabase) {
   const staleThreshold = new Date(Date.now() - STALE_CLAIM_MIN * 60 * 1000).toISOString();
 
   const { data, error } = await supabase
@@ -184,10 +184,46 @@ function withTimeout(promise, ms) {
   ]);
 }
 
+// ── Deduplication ─────────────────────────────────────────────────
+
+async function checkForDuplicate(supabase, request) {
+  const path = request.metadata?.path || 'blueprint_browse';
+
+  // Only dedup blueprint_browse with an explicit blueprint_id
+  if (path !== 'blueprint_browse' || !request.blueprint_id) return null;
+
+  const since = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1 hour lookback
+
+  const { data, error } = await supabase
+    .from('stage_zero_requests')
+    .select('id, result')
+    .eq('status', 'completed')
+    .eq('blueprint_id', request.blueprint_id)
+    .gt('completed_at', since)
+    .neq('id', request.id)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data?.result) return null;
+  return data;
+}
+
 // ── Process a Single Request ───────────────────────────────────────
 
 async function processRequest(supabase, request) {
   log.info(`Processing request ${request.id} | path=${request.metadata?.path || 'blueprint_browse'} | priority=${request.priority}`);
+
+  // Check for duplicate completed request before doing expensive work
+  const duplicate = await checkForDuplicate(supabase, request);
+  if (duplicate) {
+    log.info(`Dedup hit: request ${request.id} matches completed ${duplicate.id}, copying result`);
+    await updateStatus(supabase, request.id, {
+      status: 'completed',
+      result: duplicate.result,
+      completed_at: new Date().toISOString(),
+    });
+    return true;
+  }
 
   // Mark as in_progress
   await updateStatus(supabase, request.id, {
@@ -197,9 +233,10 @@ async function processRequest(supabase, request) {
 
   try {
     const params = mapRequestToParams(request);
+    const deadline = Date.now() + EXECUTION_TIMEOUT_MS;
 
     const result = await withTimeout(
-      executeStageZero(params, { supabase, logger: log }),
+      executeStageZero({ ...params, options: { ...params.options, deadline } }, { supabase, logger: log }),
       EXECUTION_TIMEOUT_MS
     );
 
@@ -232,7 +269,7 @@ let running = true;
 
 async function pollOnce(supabase) {
   // Release stale claims first
-  await releaseStaleCliams(supabase);
+  await releaseStaleClaims(supabase);
 
   // Fetch next pending
   const request = await fetchNextPending(supabase);
@@ -302,4 +339,4 @@ if (isMainModule) {
   });
 }
 
-export { pollOnce, processRequest, mapRequestToParams, releaseStaleCliams };
+export { pollOnce, processRequest, mapRequestToParams, releaseStaleClaims };


### PR DESCRIPTION
## Summary
- **SQL injection fix**: Replace `.or()` string interpolation with URL validation + separate `.eq()` queries in competitor-teardown ranking lookup to prevent Supabase filter injection
- **Request deduplication**: Identical blueprint_browse requests completed within 1 hour are resolved from cache, avoiding redundant LLM calls
- **Timeout budget**: Pass execution deadline through orchestrator with `checkBudget()` guards before synthesis, forecast, and chairman review to fail early when time is insufficient
- **Typo fix**: `releaseStaleCliams` → `releaseStaleClaims`

## Test plan
- [x] Unit tests: 47/49 pass (2 pre-existing discovery mode failures)
- [x] Smoke tests: 15/15 pass
- [ ] E2E: Queue processor processes blueprint_browse request end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)