### PR TITLE
fix: Stage 12 audit — reality gate, stale fields, outputSchema, LLM fallback

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js
@@ -12,7 +12,13 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+// evaluateRealityGate is a hoisted function declaration, safe for circular dependency import.
+// stage-12.js imports analyzeStage12 from this file; this file imports evaluateRealityGate back.
+import { evaluateRealityGate } from '../stage-12.js';
 
+// NOTE: VALID_SALES_MODELS, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS, MIN_DEAL_STAGES intentionally
+// duplicated from stage-12.js to avoid circular dependency — stage-12.js imports analyzeStage12
+// from this file, and SYSTEM_PROMPT uses these constants at module-level evaluation.
 const VALID_SALES_MODELS = ['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel'];
 const MIN_FUNNEL_STAGES = 4;
 const MIN_JOURNEY_STEPS = 5;
@@ -95,7 +101,7 @@ export async function analyzeStage12({ stage1Data, stage5Data, stage7Data, stage
     : '';
 
   const pricingContext = stage7Data
-    ? `Pricing: ${stage7Data.pricingModel || 'N/A'}, ARPA $${stage7Data.unitEconomics?.arpa || 'N/A'}`
+    ? `Pricing: ${stage7Data.pricing_model || 'N/A'}, ARPA $${stage7Data.arpa || 'N/A'}`
     : '';
 
   const userPrompt = `Generate a sales process definition for this venture.
@@ -205,7 +211,31 @@ Output ONLY valid JSON.`;
       : null;
   })();
 
-  logger.log('[Stage12] Analysis complete', { duration: Date.now() - startTime });
+  // Track LLM fallback fields
+  let llmFallbackCount = 0;
+  if (!Array.isArray(parsed.deal_stages) || parsed.deal_stages.length < MIN_DEAL_STAGES) llmFallbackCount++;
+  if (!Array.isArray(parsed.funnel_stages) || parsed.funnel_stages.length < MIN_FUNNEL_STAGES) llmFallbackCount++;
+  if (!Array.isArray(parsed.customer_journey) || parsed.customer_journey.length < MIN_JOURNEY_STEPS) llmFallbackCount++;
+  if (!VALID_SALES_MODELS.includes(parsed.sales_model)) llmFallbackCount++;
+  if (typeof parsed.sales_cycle_days !== 'number' || parsed.sales_cycle_days < 1) llmFallbackCount++;
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage12] LLM fallback fields detected', { llmFallbackCount });
+  }
+
+  const economyCheck = {
+    totalPipelineValue,
+    avgConversionRate,
+    pricingAvailable: !!stage7Data,
+  };
+
+  // Evaluate Phase 3→4 Reality Gate (local gate)
+  const reality_gate = evaluateRealityGate({
+    stage10: stage10Data,
+    stage11: stage11Data,
+    stage12: { funnel_stages: funnelStages, customer_journey: customerJourney, economyCheck },
+  });
+
+  logger.log('[Stage12] Analysis complete', { duration: Date.now() - startTime, realityGatePass: reality_gate.pass });
   return {
     sales_model,
     sales_cycle_days,
@@ -215,11 +245,9 @@ Output ONLY valid JSON.`;
     totalDealStages: dealStages.length,
     totalFunnelStages: funnelStages.length,
     totalJourneySteps: customerJourney.length,
-    economyCheck: {
-      totalPipelineValue,
-      avgConversionRate,
-      pricingAvailable: !!stage7Data,
-    },
+    economyCheck,
+    reality_gate,
+    llmFallbackCount,
     fourBuckets, usage,
   };
 }

--- a/lib/eva/stage-templates/stage-12.js
+++ b/lib/eva/stage-templates/stage-12.js
@@ -24,6 +24,7 @@
  */
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
+import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { REQUIRED_TIERS, REQUIRED_CHANNELS } from './stage-11.js';
 import { MIN_CANDIDATES } from './stage-10.js';
 import { analyzeStage12 } from './analysis-steps/stage-12-sales-logic.js';
@@ -285,7 +286,9 @@ export function evaluateRealityGate({ stage10, stage11, stage12 }) {
   return { pass, rationale, blockers, required_next_actions };
 }
 
+TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage12;
+ensureOutputSchema(TEMPLATE);
 
 export { SALES_MODELS, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS, MIN_DEAL_STAGES };
 export default TEMPLATE;

--- a/scripts/test-stage12-e2e.js
+++ b/scripts/test-stage12-e2e.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Stage 12 E2E Test — Sales Logic
+ * Phase: THE IDENTITY (Stages 10-12)
+ *
+ * Tests: template structure, validation, evaluateRealityGate,
+ * computeDerived, cross-stage contracts, execution flow, audit flags.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log(`  ✅ ${msg}`); } else { fail++; console.error(`  ❌ FAIL: ${msg}`); } }
+
+// ── Load template ──
+const mod = await import(`file:///${ROOT}/lib/eva/stage-templates/stage-12.js`.replace(/\\/g, '/'));
+const TEMPLATE = mod.default;
+const { evaluateRealityGate } = mod;
+const { SALES_MODELS, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS, MIN_DEAL_STAGES } = mod;
+const silent = { warn: () => {}, log: () => {}, error: () => {} };
+
+console.log('\n=== 1. Template structure ===');
+assert(TEMPLATE.id === 'stage-12', 'id = stage-12');
+assert(TEMPLATE.slug === 'sales-logic', 'slug = sales-logic');
+assert(TEMPLATE.version === '2.0.0', 'version = 2.0.0');
+assert(TEMPLATE.schema.sales_model, 'schema has sales_model');
+assert(TEMPLATE.schema.sales_cycle_days, 'schema has sales_cycle_days');
+assert(TEMPLATE.schema.deal_stages?.minItems === MIN_DEAL_STAGES, `deal_stages minItems = ${MIN_DEAL_STAGES}`);
+assert(TEMPLATE.schema.funnel_stages?.minItems === MIN_FUNNEL_STAGES, `funnel_stages minItems = ${MIN_FUNNEL_STAGES}`);
+assert(TEMPLATE.schema.customer_journey?.minItems === MIN_JOURNEY_STEPS, `customer_journey minItems = ${MIN_JOURNEY_STEPS}`);
+assert(TEMPLATE.schema.economyCheck?.derived === true, 'economyCheck is derived');
+assert(TEMPLATE.schema.reality_gate?.derived === true, 'reality_gate is derived');
+assert(typeof TEMPLATE.validate === 'function', 'has validate()');
+assert(typeof TEMPLATE.computeDerived === 'function', 'has computeDerived()');
+assert(typeof TEMPLATE.analysisStep === 'function', 'has analysisStep()');
+assert(typeof evaluateRealityGate === 'function', 'evaluateRealityGate is exported');
+assert(SALES_MODELS.length >= 4, 'SALES_MODELS has >= 4 entries');
+
+// OutputSchema
+assert(TEMPLATE.outputSchema && typeof TEMPLATE.outputSchema === 'object', 'has outputSchema (AUDIT)');
+
+console.log('\n=== 2. Validation — good data ===');
+const goodData = {
+  sales_model: 'hybrid',
+  sales_cycle_days: 30,
+  deal_stages: Array.from({ length: 3 }, (_, i) => ({
+    name: `Stage ${i}`, description: `Desc ${i}`, avg_duration_days: 5, mappedFunnelStage: `Funnel ${i}`,
+  })),
+  funnel_stages: Array.from({ length: 4 }, (_, i) => ({
+    name: `Funnel ${i}`, metric: `Metric ${i}`, target_value: 1000 * (i + 1), conversionRateEstimate: 0.25,
+  })),
+  customer_journey: Array.from({ length: 5 }, (_, i) => ({
+    step: `Step ${i}`, funnel_stage: `Funnel ${i % 4}`, touchpoint: `Touch ${i}`,
+  })),
+};
+const goodResult = TEMPLATE.validate(goodData, { logger: silent });
+assert(goodResult.valid === true, 'good data passes validation');
+assert(goodResult.errors.length === 0, 'no errors');
+
+console.log('\n=== 3. Validation — bad data ===');
+const badResult = TEMPLATE.validate({}, { logger: silent });
+assert(badResult.valid === false, 'empty data fails');
+
+// Invalid sales model
+const badModel = { ...goodData, sales_model: 'INVALID' };
+assert(TEMPLATE.validate(badModel, { logger: silent }).valid === false, 'invalid sales_model fails');
+
+// Too few deal stages
+const fewDeals = { ...goodData, deal_stages: goodData.deal_stages.slice(0, 1) };
+assert(TEMPLATE.validate(fewDeals, { logger: silent }).valid === false, `< ${MIN_DEAL_STAGES} deal stages fails`);
+
+// Too few funnel stages
+const fewFunnel = { ...goodData, funnel_stages: goodData.funnel_stages.slice(0, 1) };
+assert(TEMPLATE.validate(fewFunnel, { logger: silent }).valid === false, `< ${MIN_FUNNEL_STAGES} funnel stages fails`);
+
+// Too few journey steps
+const fewJourney = { ...goodData, customer_journey: goodData.customer_journey.slice(0, 2) };
+assert(TEMPLATE.validate(fewJourney, { logger: silent }).valid === false, `< ${MIN_JOURNEY_STEPS} journey steps fails`);
+
+// Conversion rate > 1
+const badConv = {
+  ...goodData,
+  funnel_stages: goodData.funnel_stages.map((fs, i) => i === 0 ? { ...fs, conversionRateEstimate: 1.5 } : fs),
+};
+assert(TEMPLATE.validate(badConv, { logger: silent }).valid === false, 'conversionRateEstimate > 1 fails');
+
+console.log('\n=== 4. evaluateRealityGate ===');
+const stage10Pass = {
+  candidates: Array.from({ length: 5 }, (_, i) => ({ name: `B${i}`, weighted_score: 70 })),
+};
+const stage11Pass = {
+  tiers: Array.from({ length: 3 }, (_, i) => ({ name: `T${i}` })),
+  channels: Array.from({ length: 8 }, (_, i) => ({ name: `C${i}` })),
+};
+const stage12Pass = {
+  funnel_stages: Array.from({ length: 4 }, (_, i) => ({ name: `F${i}`, metric: `M${i}`, target_value: 1000 })),
+  customer_journey: Array.from({ length: 5 }, (_, i) => ({ step: `S${i}` })),
+  economyCheck: { totalPipelineValue: 4000, avgConversionRate: 0.25 },
+};
+const gatePass = evaluateRealityGate({ stage10: stage10Pass, stage11: stage11Pass, stage12: stage12Pass });
+assert(gatePass.pass === true, 'reality gate passes with good data');
+assert(gatePass.blockers.length === 0, 'no blockers');
+
+// Fail: too few candidates
+const gateFewCands = evaluateRealityGate({
+  stage10: { candidates: [{ name: 'A', weighted_score: 70 }] },
+  stage11: stage11Pass, stage12: stage12Pass,
+});
+assert(gateFewCands.pass === false, 'fails with < 5 candidates');
+assert(gateFewCands.blockers.some(b => b.includes('candidates')), 'blocker mentions candidates');
+
+// Fail: wrong tier count
+const gateBadTiers = evaluateRealityGate({
+  stage10: stage10Pass,
+  stage11: { tiers: [{ name: 'T1' }], channels: stage11Pass.channels },
+  stage12: stage12Pass,
+});
+assert(gateBadTiers.pass === false, 'fails with != 3 tiers');
+
+// Fail: too few funnel stages
+const gateFewFunnel = evaluateRealityGate({
+  stage10: stage10Pass, stage11: stage11Pass,
+  stage12: { ...stage12Pass, funnel_stages: [{ name: 'F1', metric: 'M', target_value: 100 }] },
+});
+assert(gateFewFunnel.pass === false, 'fails with < 4 funnel stages');
+
+console.log('\n=== 5. fetchUpstreamArtifacts mock ===');
+const engineSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-execution-engine.js'), 'utf8');
+assert(engineSrc.includes('lifecycle_stage'), 'engine queries lifecycle_stage');
+
+console.log('\n=== 6. Execution flow ===');
+assert(engineSrc.includes('hasAnalysisStep'), 'engine uses hasAnalysisStep flag');
+const hasElseComputeDerived = /else\s+if\s*\(\s*typeof\s+template\.computeDerived/.test(engineSrc);
+assert(hasElseComputeDerived, 'engine has else-if for computeDerived (dead code when analysisStep exists)');
+
+console.log('\n=== 7. Audit flags ===');
+const analysisSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/analysis-steps/stage-12-sales-logic.js'), 'utf8');
+const templateSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/stage-12.js'), 'utf8');
+
+// 7a: outputSchema
+assert(templateSrc.includes('extractOutputSchema'), 'template calls extractOutputSchema (AUDIT)');
+assert(templateSrc.includes('ensureOutputSchema'), 'template calls ensureOutputSchema (AUDIT)');
+
+// 7b: DRY exception documented
+assert(analysisSrc.includes('circular dependency'), 'DRY exception documented (AUDIT)');
+
+// 7c: LLM fallback detection
+assert(analysisSrc.includes('llmFallbackCount'), 'analysis step tracks llmFallbackCount (AUDIT)');
+
+// 7d: Stale Stage 7 field names — should use pricing_model and arpa (not pricingModel/unitEconomics.arpa)
+assert(!analysisSrc.includes('pricingModel'), 'no stale pricingModel reference (AUDIT)');
+assert(!analysisSrc.includes('unitEconomics'), 'no stale unitEconomics reference (AUDIT)');
+
+// 7e: Reality gate called from analysis step
+assert(analysisSrc.includes('evaluateRealityGate'), 'analysis step calls evaluateRealityGate (AUDIT)');
+
+// 7f: logger passed to parseFourBuckets
+assert(analysisSrc.includes('parseFourBuckets(parsed, { logger }'), 'logger passed to parseFourBuckets');
+
+console.log('\n=== 8. Error cases ===');
+// Zero sales cycle days
+const zeroCycle = { ...goodData, sales_cycle_days: 0 };
+assert(TEMPLATE.validate(zeroCycle, { logger: silent }).valid === false, 'sales_cycle_days = 0 fails');
+
+// Missing touchpoint
+const noTouch = {
+  ...goodData,
+  customer_journey: goodData.customer_journey.map((cj, i) => i === 0 ? { ...cj, touchpoint: null } : cj),
+};
+assert(TEMPLATE.validate(noTouch, { logger: silent }).valid === false, 'null touchpoint fails');
+
+console.log(`\n${'='.repeat(50)}`);
+console.log(`Results: ${pass} passed, ${fail} failed out of ${pass + fail}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add `extractOutputSchema`/`ensureOutputSchema` to Stage 12 template
- Import and call `evaluateRealityGate` from analysis step (was dead code trapped in `computeDerived`)
- Fix stale Stage 7 field names: `pricingModel`→`pricing_model`, `unitEconomics.arpa`→`arpa`
- Add `llmFallbackCount` tracking for LLM output quality monitoring
- Document DRY exception for circular dependency constants
- ESLint fix: unused `logger`→`_logger` in computeDerived
- Add E2E test (43 tests, all passing)

## Test plan
- [x] `node scripts/test-stage12-e2e.js` — 43 passed, 0 failed
- [x] Pre-commit smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)