### PR TITLE
fix: Stage 17 audit — checklist transform, derived fields, stale ref cleanup

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-17-build-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-build-readiness.js
@@ -14,9 +14,13 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
+// NOTE: These constants intentionally duplicated from stage-17.js
+// to avoid circular dependency — stage-17.js imports analyzeStage17 from this file,
+// and SYSTEM_PROMPT uses these constants at module-level evaluation.
 const READINESS_DECISIONS = ['go', 'conditional_go', 'no_go'];
 const PRIORITY_LEVELS = ['critical', 'high', 'medium', 'low'];
 const SEVERITY_LEVELS = ['critical', 'high', 'medium', 'low'];
+const CHECKLIST_CATEGORIES = ['architecture', 'team_readiness', 'tooling', 'environment', 'dependencies'];
 const MIN_READINESS_ITEMS = 3;
 const MIN_CATEGORIES = 3;
 
@@ -80,16 +84,16 @@ export async function analyzeStage17({ stage13Data, stage14Data, stage15Data, st
     ? `Milestones: ${JSON.stringify(stage13Data.milestones.slice(0, 5))}`
     : `Roadmap: ${JSON.stringify(stage13Data).substring(0, 500)}`;
 
-  const archContext = stage14Data
-    ? `Architecture: ${stage14Data.systemType || 'N/A'}, Components: ${stage14Data.components?.length || 0}`
+  const archContext = stage14Data?.layers
+    ? `Architecture: ${stage14Data.total_components || 'N/A'} components across ${stage14Data.layer_count || 5} layers (${Object.keys(stage14Data.layers).join(', ')})`
     : '';
 
-  const resourceContext = stage15Data
-    ? `Team: ${stage15Data.teamSize || 'N/A'} members, Budget: $${stage15Data.totalBudget || 'N/A'}`
+  const riskContext = stage15Data?.risks
+    ? `Risks: ${stage15Data.total_risks || stage15Data.risks.length} identified (${stage15Data.severity_breakdown?.critical || 0} critical, ${stage15Data.severity_breakdown?.high || 0} high)`
     : '';
 
   const financialContext = stage16Data
-    ? `Runway: ${stage16Data.runwayMonths || 'N/A'} months`
+    ? `Runway: ${stage16Data.runway_months || 'N/A'} months, Burn: $${stage16Data.burn_rate || 'N/A'}/mo`
     : '';
 
   const userPrompt = `Assess build readiness for this venture.
@@ -97,7 +101,7 @@ export async function analyzeStage17({ stage13Data, stage14Data, stage15Data, st
 Venture: ${ventureName || 'Unnamed'}
 ${roadmapContext}
 ${archContext}
-${resourceContext}
+${riskContext}
 ${financialContext}
 
 Output ONLY valid JSON.`;
@@ -128,36 +132,97 @@ Output ONLY valid JSON.`;
     }));
   }
 
-  // Normalize blockers
+  // Normalize blockers (template expects mitigation, not just owner)
   const blockers = Array.isArray(parsed.blockers)
     ? parsed.blockers.filter(b => b?.description).map(b => ({
         description: String(b.description).substring(0, 500),
-        owner: String(b.owner || 'Unassigned').substring(0, 200),
         severity: SEVERITY_LEVELS.includes(b.severity) ? b.severity : 'medium',
+        mitigation: String(b.mitigation || b.owner || 'TBD').substring(0, 500),
       }))
     : [];
 
+  // Track LLM fallback fields
+  let llmFallbackCount = 0;
+  if (!Array.isArray(parsed.readinessItems) || parsed.readinessItems.length < MIN_READINESS_ITEMS) llmFallbackCount++;
+  for (const item of parsed.readinessItems || []) {
+    if (!['complete', 'in_progress', 'not_started', 'blocked'].includes(item?.status)) llmFallbackCount++;
+    if (!CHECKLIST_CATEGORIES.includes(item?.category)) llmFallbackCount++;
+  }
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage17] LLM fallback fields detected', { llmFallbackCount });
+  }
+
+  // Transform flat readinessItems into checklist object grouped by category
+  const checklist = {};
+  for (const cat of CHECKLIST_CATEGORIES) {
+    checklist[cat] = readinessItems
+      .filter(item => item.category === cat)
+      .map(item => ({
+        name: item.name,
+        status: item.status,
+        owner: item.owner || '',
+        notes: item.description || '',
+      }));
+    // Ensure at least 1 item per category
+    if (checklist[cat].length === 0) {
+      checklist[cat] = [{ name: `${cat} assessment`, status: 'not_started', owner: '', notes: '' }];
+    }
+  }
+
+  // Compute derived fields (these live in computeDerived but that path is dead code when analysisStep exists)
+  let total_items = 0;
+  let completed_items = 0;
+  let categoriesPresent = 0;
+  for (const cat of CHECKLIST_CATEGORIES) {
+    const items = checklist[cat] || [];
+    if (items.length > 0) categoriesPresent++;
+    total_items += items.length;
+    completed_items += items.filter(item => item.status === 'complete').length;
+  }
+  const readiness_pct = total_items > 0
+    ? Math.round((completed_items / total_items) * 10000) / 100
+    : 0;
+  const all_categories_present = categoriesPresent === CHECKLIST_CATEGORIES.length;
+  const blocker_count = blockers.length;
+
   // Normalize buildReadiness decision
   const br = parsed.buildReadiness || {};
-  const decision = READINESS_DECISIONS.includes(br.decision) ? br.decision : (blockers.length > 0 ? 'no_go' : 'go');
+  const hasCriticalBlockers = blockers.some(b => b.severity === 'critical');
+  let decision;
+  if (READINESS_DECISIONS.includes(br.decision)) {
+    decision = br.decision;
+  } else if (hasCriticalBlockers) {
+    decision = 'no_go';
+  } else if (blocker_count > 0 || readiness_pct < 100) {
+    decision = 'conditional_go';
+  } else {
+    decision = 'go';
+  }
   const conditions = decision === 'conditional_go' && Array.isArray(br.conditions)
     ? br.conditions.map(c => String(c).substring(0, 300))
     : [];
 
   const buildReadiness = {
     decision,
-    rationale: String(br.rationale || `Build readiness: ${decision}`).substring(0, 500),
+    rationale: String(br.rationale || (decision === 'go'
+      ? 'All checklist items complete, no blockers'
+      : decision === 'no_go'
+        ? `Critical blockers present (${blocker_count} blocker(s))`
+        : `Readiness at ${readiness_pct}% with ${blocker_count} non-critical blocker(s)`)).substring(0, 500),
     conditions,
   };
 
   logger.log('[Stage17] Analysis complete', { duration: Date.now() - startTime });
   return {
-    readinessItems,
+    checklist,
     blockers,
+    total_items,
+    completed_items,
+    readiness_pct,
+    all_categories_present,
+    blocker_count,
     buildReadiness,
-    totalItems: readinessItems.length,
-    completedItems: readinessItems.filter(i => i.status === 'complete').length,
-    blockerCount: blockers.length,
+    llmFallbackCount,
     fourBuckets, usage,
   };
 }

--- a/lib/eva/stage-templates/stage-17.js
+++ b/lib/eva/stage-templates/stage-17.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage17 } from './analysis-steps/stage-17-build-readiness.js';
 
 const CHECKLIST_CATEGORIES = [
@@ -164,7 +165,9 @@ const TEMPLATE = {
   },
 };
 
+TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage17;
+ensureOutputSchema(TEMPLATE);
 
 export { CHECKLIST_CATEGORIES, ITEM_STATUSES, SEVERITY_LEVELS, BUILD_READINESS_DECISIONS, MIN_ITEMS_PER_CATEGORY };
 export default TEMPLATE;

--- a/scripts/test-stage17-e2e.js
+++ b/scripts/test-stage17-e2e.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Stage 17 E2E Test — Pre-Build Checklist
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ *
+ * Tests: template structure, validation, computeDerived,
+ * execution flow, audit flags.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log(`  ✅ ${msg}`); } else { fail++; console.error(`  ❌ FAIL: ${msg}`); } }
+
+// ── Load template ──
+const mod = await import(`file:///${ROOT}/lib/eva/stage-templates/stage-17.js`.replace(/\\/g, '/'));
+const TEMPLATE = mod.default;
+const { CHECKLIST_CATEGORIES, ITEM_STATUSES, SEVERITY_LEVELS, BUILD_READINESS_DECISIONS, MIN_ITEMS_PER_CATEGORY } = mod;
+const silent = { warn: () => {}, log: () => {}, error: () => {} };
+
+console.log('\n=== 1. Template structure ===');
+assert(TEMPLATE.id === 'stage-17', 'id = stage-17');
+assert(TEMPLATE.slug === 'pre-build-checklist', 'slug = pre-build-checklist');
+assert(TEMPLATE.version === '2.0.0', 'version = 2.0.0');
+assert(TEMPLATE.schema.checklist?.required === true, 'checklist required');
+assert(TEMPLATE.schema.total_items?.derived === true, 'total_items is derived');
+assert(TEMPLATE.schema.readiness_pct?.derived === true, 'readiness_pct is derived');
+assert(TEMPLATE.schema.buildReadiness?.derived === true, 'buildReadiness is derived');
+assert(typeof TEMPLATE.validate === 'function', 'has validate()');
+assert(typeof TEMPLATE.computeDerived === 'function', 'has computeDerived()');
+assert(typeof TEMPLATE.analysisStep === 'function', 'has analysisStep()');
+assert(CHECKLIST_CATEGORIES.length === 5, 'CHECKLIST_CATEGORIES has 5 entries');
+assert(ITEM_STATUSES.length === 4, 'ITEM_STATUSES has 4 entries');
+assert(SEVERITY_LEVELS.length === 4, 'SEVERITY_LEVELS has 4 entries');
+assert(BUILD_READINESS_DECISIONS.length === 3, 'BUILD_READINESS_DECISIONS has 3 entries');
+
+// OutputSchema
+assert(TEMPLATE.outputSchema && typeof TEMPLATE.outputSchema === 'object', 'has outputSchema (AUDIT)');
+
+console.log('\n=== 2. Validation — good data ===');
+const goodItem = (name, status = 'complete') => ({ name, status, owner: 'Engineer', notes: '' });
+const goodData = {
+  checklist: {
+    architecture: [goodItem('Arch Design')],
+    team_readiness: [goodItem('Team Hired')],
+    tooling: [goodItem('CI/CD Setup')],
+    environment: [goodItem('Dev Env')],
+    dependencies: [goodItem('Deps Audited')],
+  },
+  blockers: [],
+};
+const goodResult = TEMPLATE.validate(goodData, { logger: silent });
+assert(goodResult.valid === true, 'good data passes validation');
+assert(goodResult.errors.length === 0, 'no errors');
+
+console.log('\n=== 3. Validation — bad data ===');
+assert(TEMPLATE.validate({}, { logger: silent }).valid === false, 'empty data fails');
+
+// Missing category
+const missingCat = { checklist: { architecture: [goodItem('A')] }, blockers: [] };
+assert(TEMPLATE.validate(missingCat, { logger: silent }).valid === false, 'missing categories fails');
+
+// Invalid status
+const badStatus = {
+  checklist: Object.fromEntries(CHECKLIST_CATEGORIES.map(c => [c, [{ name: 'X', status: 'INVALID' }]])),
+};
+assert(TEMPLATE.validate(badStatus, { logger: silent }).valid === false, 'invalid item status fails');
+
+// Bad blocker severity
+const badBlocker = {
+  ...goodData,
+  blockers: [{ description: 'Block', severity: 'INVALID', mitigation: 'Fix' }],
+};
+assert(TEMPLATE.validate(badBlocker, { logger: silent }).valid === false, 'bad blocker severity fails');
+
+console.log('\n=== 4. fetchUpstreamArtifacts mock ===');
+const engineSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-execution-engine.js'), 'utf8');
+assert(engineSrc.includes('lifecycle_stage'), 'engine queries lifecycle_stage');
+
+console.log('\n=== 5. Execution flow ===');
+assert(engineSrc.includes('hasAnalysisStep'), 'engine uses hasAnalysisStep flag');
+const hasElseComputeDerived = /else\s+if\s*\(\s*typeof\s+template\.computeDerived/.test(engineSrc);
+assert(hasElseComputeDerived, 'engine has else-if for computeDerived (dead code when analysisStep exists)');
+
+console.log('\n=== 6. Audit flags ===');
+const analysisSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/analysis-steps/stage-17-build-readiness.js'), 'utf8');
+const templateSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/stage-17.js'), 'utf8');
+
+// 6a: outputSchema
+assert(templateSrc.includes('extractOutputSchema'), 'template calls extractOutputSchema (AUDIT)');
+assert(templateSrc.includes('ensureOutputSchema'), 'template calls ensureOutputSchema (AUDIT)');
+
+// 6b: DRY exception documented
+assert(analysisSrc.includes('circular dependency'), 'DRY exception documented (AUDIT)');
+
+// 6c: LLM fallback detection
+assert(analysisSrc.includes('llmFallbackCount'), 'analysis step tracks llmFallbackCount (AUDIT)');
+
+// 6d: Field casing — analysis output must use snake_case matching template schema
+assert(analysisSrc.includes('total_items'), 'analysis uses total_items (snake_case, AUDIT)');
+assert(analysisSrc.includes('completed_items'), 'analysis uses completed_items (snake_case, AUDIT)');
+assert(analysisSrc.includes('blocker_count'), 'analysis uses blocker_count (snake_case, AUDIT)');
+assert(analysisSrc.includes('readiness_pct'), 'analysis computes readiness_pct (AUDIT)');
+assert(analysisSrc.includes('all_categories_present'), 'analysis computes all_categories_present (AUDIT)');
+
+// 6e: Analysis step outputs checklist object (not flat readinessItems)
+assert(analysisSrc.includes('checklist:') || analysisSrc.includes('checklist,'), 'analysis outputs checklist object (AUDIT)');
+
+// 6f: Stale upstream field refs — should use correct field names
+assert(!analysisSrc.includes('systemType'), 'no stale systemType reference (AUDIT)');
+assert(!analysisSrc.includes('teamSize'), 'no stale teamSize reference (AUDIT)');
+assert(!analysisSrc.includes('totalBudget'), 'no stale totalBudget reference (AUDIT)');
+assert(!analysisSrc.includes('runwayMonths'), 'no stale runwayMonths reference (AUDIT)');
+
+// 6g: Blockers include mitigation field
+assert(analysisSrc.includes('mitigation'), 'blockers include mitigation field (AUDIT)');
+
+// 6h: logger passed to parseFourBuckets
+assert(analysisSrc.includes('parseFourBuckets(parsed, { logger }'), 'logger passed to parseFourBuckets');
+
+console.log('\n=== 7. Error cases ===');
+assert(TEMPLATE.validate(null, { logger: silent }).valid === false, 'null data fails');
+assert(TEMPLATE.validate('string', { logger: silent }).valid === false, 'string data fails');
+
+console.log(`\n${'='.repeat(50)}`);
+console.log(`Results: ${pass} passed, ${fail} failed out of ${pass + fail}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add `extractOutputSchema`/`ensureOutputSchema` to Stage 17 template
- Transform flat `readinessItems` array into `checklist` object grouped by category (matching template schema)
- Compute all derived fields in analysis step: total_items, completed_items, readiness_pct, all_categories_present, blocker_count, buildReadiness
- Fix field casing: `totalItems`→`total_items`, `completedItems`→`completed_items`, `blockerCount`→`blocker_count`
- Fix stale upstream refs: `systemType`, `teamSize`, `totalBudget`, `runwayMonths` → correct Stage 14/15/16 field names
- Add `mitigation` field to blockers (template requires it, analysis step was missing it)
- Add `llmFallbackCount` tracking, document DRY exception
- Add E2E test (42 tests, all passing)

## Test plan
- [x] `node scripts/test-stage17-e2e.js` — 42/42 passing
- [x] Smoke tests passing
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)