### PR TITLE
fix: Stage 18 audit — SD bridge activation, field transform, stale refs

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js
@@ -14,6 +14,9 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
+// NOTE: These constants intentionally duplicated from stage-18.js
+// to avoid circular dependency — stage-18.js imports analyzeStage18 from this file,
+// and SYSTEM_PROMPT uses these constants at module-level evaluation.
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];
 const ARCHITECTURE_LAYERS = ['frontend', 'backend', 'database', 'infrastructure', 'integration', 'security'];
@@ -75,8 +78,8 @@ export async function analyzeStage18({ stage17Data, stage13Data, stage14Data, ve
     ? `Roadmap milestones: ${JSON.stringify(stage13Data.milestones.slice(0, 3).map(m => m.name || m.title || m))}`
     : '';
 
-  const archContext = stage14Data
-    ? `Architecture layers: ${stage14Data.components?.map(c => c.name || c).join(', ') || 'N/A'}`
+  const archContext = stage14Data?.layers
+    ? `Architecture: ${stage14Data.total_components || 'N/A'} components across ${stage14Data.layer_count || 5} layers (${Object.keys(stage14Data.layers).join(', ')})`
     : '';
 
   const userPrompt = `Generate a sprint plan for this venture.
@@ -129,12 +132,61 @@ Output ONLY valid JSON.`;
     }));
   }
 
+  // Track LLM fallback fields
+  let llmFallbackCount = 0;
+  if (!parsed.sprintGoal || String(parsed.sprintGoal).length < 10) llmFallbackCount++;
+  if (!Array.isArray(parsed.sprintItems) || parsed.sprintItems.length < MIN_SPRINT_ITEMS) llmFallbackCount++;
+  for (const item of parsed.sprintItems || []) {
+    if (!SD_TYPES.includes(item?.type)) llmFallbackCount++;
+    if (!PRIORITY_VALUES.includes(item?.priority)) llmFallbackCount++;
+  }
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage18] LLM fallback fields detected', { llmFallbackCount });
+  }
+
+  // Transform sprint items to match template schema
+  const items = sprintItems.map(item => ({
+    title: item.title,
+    description: item.description,
+    priority: item.priority,
+    type: item.type,
+    scope: String(item.architectureLayer || 'general').substring(0, 200),
+    success_criteria: String(item.acceptanceCriteria || 'Item completed').substring(0, 500),
+    dependencies: [],
+    risks: [],
+    target_application: 'ehg',
+    story_points: typeof item.estimatedLoc === 'number' ? Math.ceil(item.estimatedLoc / 50) : 3,
+    architectureLayer: item.architectureLayer,
+    milestoneRef: item.milestoneRef,
+  }));
+
+  // Compute derived fields (these live in computeDerived but that path is dead code when analysisStep exists)
+  const total_items = items.length;
+  const total_story_points = items.reduce((sum, item) => sum + (item.story_points || 0), 0);
+
+  // Generate SD bridge payloads
+  const sd_bridge_payloads = items.map(item => ({
+    title: item.title,
+    description: item.description,
+    priority: item.priority,
+    type: item.type,
+    scope: item.scope,
+    success_criteria: item.success_criteria,
+    dependencies: item.dependencies,
+    risks: item.risks,
+    target_application: item.target_application,
+  }));
+
   logger.log('[Stage18] Analysis complete', { duration: Date.now() - startTime });
   return {
-    sprintGoal,
-    sprintItems,
-    totalItems: sprintItems.length,
-    totalEstimatedLoc: sprintItems.reduce((sum, i) => sum + i.estimatedLoc, 0),
+    sprint_name: `Sprint ${new Date().toISOString().slice(0, 10)}`,
+    sprint_duration_days: 14,
+    sprint_goal: sprintGoal,
+    items,
+    total_items,
+    total_story_points,
+    sd_bridge_payloads,
+    llmFallbackCount,
     fourBuckets, usage,
   };
 }

--- a/lib/eva/stage-templates/stage-18.js
+++ b/lib/eva/stage-templates/stage-18.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
+import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage18 } from './analysis-steps/stage-18-sprint-planning.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
@@ -139,7 +140,9 @@ const TEMPLATE = {
   },
 };
 
+TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage18;
+ensureOutputSchema(TEMPLATE);
 
 export { PRIORITY_VALUES, SD_TYPES, MIN_SPRINT_ITEMS, SD_BRIDGE_REQUIRED_FIELDS, MIN_SPRINT_DURATION_DAYS, MAX_SPRINT_DURATION_DAYS };
 export default TEMPLATE;

--- a/scripts/test-stage18-e2e.js
+++ b/scripts/test-stage18-e2e.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * Stage 18 E2E Test — Sprint Planning
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ *
+ * Tests: template structure, validation, computeDerived,
+ * execution flow, audit flags.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log(`  ✅ ${msg}`); } else { fail++; console.error(`  ❌ FAIL: ${msg}`); } }
+
+// ── Load template ──
+const mod = await import(`file:///${ROOT}/lib/eva/stage-templates/stage-18.js`.replace(/\\/g, '/'));
+const TEMPLATE = mod.default;
+const { PRIORITY_VALUES, SD_TYPES, MIN_SPRINT_ITEMS, SD_BRIDGE_REQUIRED_FIELDS } = mod;
+const silent = { warn: () => {}, log: () => {}, error: () => {} };
+
+console.log('\n=== 1. Template structure ===');
+assert(TEMPLATE.id === 'stage-18', 'id = stage-18');
+assert(TEMPLATE.slug === 'sprint-planning', 'slug = sprint-planning');
+assert(TEMPLATE.version === '2.0.0', 'version = 2.0.0');
+assert(TEMPLATE.schema.sprint_name?.required === true, 'sprint_name required');
+assert(TEMPLATE.schema.sprint_duration_days?.required === true, 'sprint_duration_days required');
+assert(TEMPLATE.schema.sprint_goal?.required === true, 'sprint_goal required');
+assert(TEMPLATE.schema.items?.minItems === MIN_SPRINT_ITEMS, `items minItems = ${MIN_SPRINT_ITEMS}`);
+assert(TEMPLATE.schema.total_items?.derived === true, 'total_items is derived');
+assert(TEMPLATE.schema.sd_bridge_payloads?.derived === true, 'sd_bridge_payloads is derived');
+assert(typeof TEMPLATE.validate === 'function', 'has validate()');
+assert(typeof TEMPLATE.computeDerived === 'function', 'has computeDerived()');
+assert(typeof TEMPLATE.analysisStep === 'function', 'has analysisStep()');
+assert(PRIORITY_VALUES.length === 4, 'PRIORITY_VALUES has 4 entries');
+assert(SD_TYPES.length === 5, 'SD_TYPES has 5 entries');
+assert(SD_BRIDGE_REQUIRED_FIELDS.length === 9, 'SD_BRIDGE_REQUIRED_FIELDS has 9 entries');
+
+// OutputSchema
+assert(TEMPLATE.outputSchema && typeof TEMPLATE.outputSchema === 'object', 'has outputSchema (AUDIT)');
+
+console.log('\n=== 2. Validation — good data ===');
+const goodItem = {
+  title: 'Build Auth Module',
+  description: 'Implement JWT authentication',
+  priority: 'high',
+  type: 'feature',
+  scope: 'Backend authentication layer',
+  success_criteria: 'Users can login/register',
+  dependencies: [],
+  risks: ['Token expiry handling'],
+  target_application: 'ehg',
+  story_points: 5,
+  architectureLayer: 'backend',
+  milestoneRef: 'MVP',
+};
+const goodData = {
+  sprint_name: 'Sprint 1',
+  sprint_duration_days: 14,
+  sprint_goal: 'Complete core authentication and user management',
+  items: [goodItem],
+};
+const goodResult = TEMPLATE.validate(goodData, { logger: silent });
+assert(goodResult.valid === true, 'good data passes validation');
+assert(goodResult.errors.length === 0, 'no errors');
+
+console.log('\n=== 3. Validation — bad data ===');
+assert(TEMPLATE.validate({}, { logger: silent }).valid === false, 'empty data fails');
+
+// Too long sprint
+const longSprint = { ...goodData, sprint_duration_days: 60 };
+assert(TEMPLATE.validate(longSprint, { logger: silent }).valid === false, 'too long sprint fails');
+
+// Short goal
+const shortGoal = { ...goodData, sprint_goal: 'Short' };
+assert(TEMPLATE.validate(shortGoal, { logger: silent }).valid === false, 'short goal fails');
+
+// Invalid priority
+const badPri = { ...goodData, items: [{ ...goodItem, priority: 'INVALID' }] };
+assert(TEMPLATE.validate(badPri, { logger: silent }).valid === false, 'invalid priority fails');
+
+// Invalid type
+const badType = { ...goodData, items: [{ ...goodItem, type: 'INVALID' }] };
+assert(TEMPLATE.validate(badType, { logger: silent }).valid === false, 'invalid type fails');
+
+// Missing scope
+const noScope = { ...goodData, items: [{ ...goodItem, scope: '' }] };
+assert(TEMPLATE.validate(noScope, { logger: silent }).valid === false, 'empty scope fails');
+
+console.log('\n=== 4. fetchUpstreamArtifacts mock ===');
+const engineSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-execution-engine.js'), 'utf8');
+assert(engineSrc.includes('lifecycle_stage'), 'engine queries lifecycle_stage');
+
+console.log('\n=== 5. Execution flow ===');
+assert(engineSrc.includes('hasAnalysisStep'), 'engine uses hasAnalysisStep flag');
+const hasElseComputeDerived = /else\s+if\s*\(\s*typeof\s+template\.computeDerived/.test(engineSrc);
+assert(hasElseComputeDerived, 'engine has else-if for computeDerived (dead code when analysisStep exists)');
+
+console.log('\n=== 6. Audit flags ===');
+const analysisSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/analysis-steps/stage-18-sprint-planning.js'), 'utf8');
+const templateSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/stage-18.js'), 'utf8');
+
+// 6a: outputSchema
+assert(templateSrc.includes('extractOutputSchema'), 'template calls extractOutputSchema (AUDIT)');
+assert(templateSrc.includes('ensureOutputSchema'), 'template calls ensureOutputSchema (AUDIT)');
+
+// 6b: DRY exception documented
+assert(analysisSrc.includes('circular dependency'), 'DRY exception documented (AUDIT)');
+
+// 6c: LLM fallback detection
+assert(analysisSrc.includes('llmFallbackCount'), 'analysis step tracks llmFallbackCount (AUDIT)');
+
+// 6d: Field casing — analysis output must use snake_case matching template schema
+assert(analysisSrc.includes('sprint_name'), 'analysis uses sprint_name (AUDIT)');
+assert(analysisSrc.includes('sprint_goal'), 'analysis uses sprint_goal (AUDIT)');
+assert(analysisSrc.includes('sprint_duration_days'), 'analysis uses sprint_duration_days (AUDIT)');
+assert(analysisSrc.includes('total_items'), 'analysis uses total_items (snake_case, AUDIT)');
+assert(analysisSrc.includes('total_story_points'), 'analysis uses total_story_points (AUDIT)');
+assert(analysisSrc.includes('sd_bridge_payloads'), 'analysis generates sd_bridge_payloads (AUDIT)');
+
+// 6e: Items have template-required fields
+assert(analysisSrc.includes('target_application'), 'items include target_application (AUDIT)');
+assert(analysisSrc.includes('success_criteria'), 'items include success_criteria (AUDIT)');
+
+// 6f: Stale upstream field refs
+assert(!analysisSrc.includes('stage14Data.components'), 'no stale stage14 components reference (AUDIT)');
+
+// 6g: logger passed to parseFourBuckets
+assert(analysisSrc.includes('parseFourBuckets(parsed, { logger }'), 'logger passed to parseFourBuckets');
+
+console.log('\n=== 7. Error cases ===');
+assert(TEMPLATE.validate(null, { logger: silent }).valid === false, 'null data fails');
+assert(TEMPLATE.validate('string', { logger: silent }).valid === false, 'string data fails');
+
+console.log(`\n${'='.repeat(50)}`);
+console.log(`Results: ${pass} passed, ${fail} failed out of ${pass + fail}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add `extractOutputSchema`/`ensureOutputSchema` to Stage 18 template
- Transform LLM `sprintItems` to template schema `items` with all required fields (scope, success_criteria, target_application, story_points, dependencies, risks)
- Compute all derived fields in analysis step: total_items, total_story_points, sd_bridge_payloads (were dead code in computeDerived)
- Fix stale Stage 14 ref: `components`→`layers` with `total_components`/`layer_count`
- Add sprint_name, sprint_duration_days, sprint_goal to output
- Add `llmFallbackCount` tracking, document DRY exception
- Add E2E test (43 tests, all passing)

## Test plan
- [x] `node scripts/test-stage18-e2e.js` — 43/43 passing
- [x] Smoke tests passing
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)