### PR TITLE
fix: harden Stage 19 with outputSchema, field casing, stale ref cleanup

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js
@@ -14,6 +14,9 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
+// NOTE: These constants intentionally duplicated from stage-19.js
+// to avoid circular dependency — stage-19.js imports analyzeStage19 from this file,
+// and SYSTEM_PROMPT uses these constants at module-level evaluation.
 const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
 const ISSUE_SEVERITIES = ['critical', 'high', 'medium', 'low'];
 const ISSUE_STATUSES = ['open', 'investigating', 'resolved', 'deferred'];
@@ -70,12 +73,12 @@ export async function analyzeStage19({ stage18Data, stage17Data, ventureName, lo
 
   const client = getLLMClient({ purpose: 'content-generation' });
 
-  const sprintContext = stage18Data.sprintGoal
-    ? `Sprint Goal: ${stage18Data.sprintGoal}`
+  const sprintContext = stage18Data.sprint_goal
+    ? `Sprint Goal: ${stage18Data.sprint_goal}`
     : '';
 
-  const itemsContext = stage18Data.sprintItems
-    ? `Sprint Items (${stage18Data.sprintItems.length}): ${JSON.stringify(stage18Data.sprintItems.map(i => ({ title: i.title, type: i.type, loc: i.estimatedLoc })))}`
+  const itemsContext = stage18Data.items
+    ? `Sprint Items (${stage18Data.items.length}): ${JSON.stringify(stage18Data.items.map(i => ({ title: i.title, type: i.type, story_points: i.story_points })))}`
     : '';
 
   const readinessContext = stage17Data?.buildReadiness
@@ -101,19 +104,22 @@ Output ONLY valid JSON.`;
     ? parsed.tasks.filter(t => t?.name)
     : [];
 
-  if (tasks.length === 0 && stage18Data.sprintItems?.length > 0) {
-    tasks = stage18Data.sprintItems.map(item => ({
+  const sprintItems = stage18Data.items || [];
+  if (tasks.length === 0 && sprintItems.length > 0) {
+    tasks = sprintItems.map(item => ({
       name: item.title,
       description: item.description || '',
       assignee: 'Unassigned',
       status: 'pending',
+      sprint_item_ref: item.title,
     }));
   } else {
-    tasks = tasks.map(t => ({
+    tasks = tasks.map((t, idx) => ({
       name: String(t.name).substring(0, 200),
       description: String(t.description || '').substring(0, 500),
       assignee: String(t.assignee || 'Unassigned').substring(0, 200),
       status: TASK_STATUSES.includes(t.status) ? t.status : 'pending',
+      sprint_item_ref: sprintItems[idx]?.title || String(t.name).substring(0, 200),
     }));
   }
 
@@ -146,15 +152,45 @@ Output ONLY valid JSON.`;
     rationale: String(sc.rationale || `Sprint ${decision}: ${doneTasks}/${tasks.length} tasks done`).substring(0, 500),
   };
 
+  // Compute derived fields (these live in computeDerived but that path is dead code when analysisStep exists)
+  const total_tasks = tasks.length;
+  const completed_tasks = doneTasks;
+  const blocked_tasks = blockedTasks;
+  const completion_pct = total_tasks > 0
+    ? Math.round((completed_tasks / total_tasks) * 10000) / 100
+    : 0;
+
+  const tasks_by_status = {};
+  for (const status of TASK_STATUSES) {
+    tasks_by_status[status] = tasks.filter(t => t.status === status).length;
+  }
+
+  // Track LLM fallback fields
+  let llmFallbackCount = 0;
+  if (!Array.isArray(parsed.tasks) || parsed.tasks.length === 0) llmFallbackCount++;
+  for (const t of parsed.tasks || []) {
+    if (!TASK_STATUSES.includes(t?.status)) llmFallbackCount++;
+  }
+  for (const i of parsed.issues || []) {
+    if (!ISSUE_SEVERITIES.includes(i?.severity)) llmFallbackCount++;
+    if (!ISSUE_STATUSES.includes(i?.status)) llmFallbackCount++;
+  }
+  if (!COMPLETION_DECISIONS.includes(sc.decision)) llmFallbackCount++;
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage19] LLM fallback fields detected', { llmFallbackCount });
+  }
+
   logger.log('[Stage19] Analysis complete', { duration: Date.now() - startTime });
   return {
     tasks,
     issues,
     sprintCompletion,
-    totalTasks: tasks.length,
-    completedTasks: doneTasks,
-    blockedTasks,
-    openIssues: issues.filter(i => i.status === 'open').length,
+    total_tasks,
+    completed_tasks,
+    blocked_tasks,
+    completion_pct,
+    tasks_by_status,
+    llmFallbackCount,
     fourBuckets, usage,
   };
 }

--- a/lib/eva/stage-templates/stage-19.js
+++ b/lib/eva/stage-templates/stage-19.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage19 } from './analysis-steps/stage-19-build-execution.js';
 
 const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
@@ -142,7 +143,9 @@ const TEMPLATE = {
   },
 };
 
+TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage19;
+ensureOutputSchema(TEMPLATE);
 
 export { TASK_STATUSES, ISSUE_SEVERITIES, ISSUE_STATUSES, SPRINT_COMPLETION_DECISIONS, MIN_TASKS };
 export default TEMPLATE;

--- a/scripts/test-stage19-e2e.js
+++ b/scripts/test-stage19-e2e.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Stage 19 E2E Test — Build Execution
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ *
+ * Tests: template structure, validation, computeDerived,
+ * execution flow, audit flags.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log(`  ✅ ${msg}`); } else { fail++; console.error(`  ❌ FAIL: ${msg}`); } }
+
+// ── Load template ──
+const mod = await import(`file:///${ROOT}/lib/eva/stage-templates/stage-19.js`.replace(/\\/g, '/'));
+const TEMPLATE = mod.default;
+const { TASK_STATUSES, ISSUE_SEVERITIES, ISSUE_STATUSES, SPRINT_COMPLETION_DECISIONS, MIN_TASKS } = mod;
+const silent = { warn: () => {}, log: () => {}, error: () => {} };
+
+console.log('\n=== 1. Template structure ===');
+assert(TEMPLATE.id === 'stage-19', 'id = stage-19');
+assert(TEMPLATE.slug === 'build-execution', 'slug = build-execution');
+assert(TEMPLATE.version === '2.0.0', 'version = 2.0.0');
+assert(TEMPLATE.schema.tasks?.type === 'array', 'tasks is array');
+assert(TEMPLATE.schema.tasks?.minItems === MIN_TASKS, `tasks minItems = ${MIN_TASKS}`);
+assert(TEMPLATE.schema.issues?.type === 'array', 'issues is array');
+assert(TEMPLATE.schema.total_tasks?.derived === true, 'total_tasks is derived');
+assert(TEMPLATE.schema.completed_tasks?.derived === true, 'completed_tasks is derived');
+assert(TEMPLATE.schema.blocked_tasks?.derived === true, 'blocked_tasks is derived');
+assert(TEMPLATE.schema.completion_pct?.derived === true, 'completion_pct is derived');
+assert(TEMPLATE.schema.tasks_by_status?.derived === true, 'tasks_by_status is derived');
+assert(TEMPLATE.schema.sprintCompletion?.derived === true, 'sprintCompletion is derived');
+assert(typeof TEMPLATE.validate === 'function', 'has validate()');
+assert(typeof TEMPLATE.computeDerived === 'function', 'has computeDerived()');
+assert(typeof TEMPLATE.analysisStep === 'function', 'has analysisStep()');
+assert(TASK_STATUSES.length === 4, 'TASK_STATUSES has 4 entries');
+assert(ISSUE_SEVERITIES.length === 4, 'ISSUE_SEVERITIES has 4 entries');
+assert(ISSUE_STATUSES.length === 4, 'ISSUE_STATUSES has 4 entries');
+assert(SPRINT_COMPLETION_DECISIONS.length === 3, 'SPRINT_COMPLETION_DECISIONS has 3 entries');
+assert(MIN_TASKS === 1, 'MIN_TASKS = 1');
+
+// OutputSchema
+assert(TEMPLATE.outputSchema && typeof TEMPLATE.outputSchema === 'object', 'has outputSchema (AUDIT)');
+
+console.log('\n=== 2. Validation — good data ===');
+const goodTask = {
+  name: 'Build Auth Module',
+  status: 'in_progress',
+  assignee: 'Dev-1',
+  sprint_item_ref: 'Sprint 1 Item 1',
+};
+const goodData = {
+  tasks: [goodTask],
+  issues: [
+    { description: 'Token expiry edge case', severity: 'medium', status: 'open' },
+  ],
+};
+const goodResult = TEMPLATE.validate(goodData, { logger: silent });
+assert(goodResult.valid === true, 'good data passes validation');
+assert(goodResult.errors.length === 0, 'no errors');
+
+console.log('\n=== 3. Validation — bad data ===');
+assert(TEMPLATE.validate({}, { logger: silent }).valid === false, 'empty data fails');
+
+// Invalid task status
+const badStatus = { tasks: [{ ...goodTask, status: 'INVALID' }] };
+assert(TEMPLATE.validate(badStatus, { logger: silent }).valid === false, 'invalid task status fails');
+
+// Missing task name
+const noName = { tasks: [{ ...goodTask, name: '' }] };
+assert(TEMPLATE.validate(noName, { logger: silent }).valid === false, 'empty task name fails');
+
+// Invalid issue severity
+const badSev = { tasks: [goodTask], issues: [{ description: 'Bug', severity: 'INVALID', status: 'open' }] };
+assert(TEMPLATE.validate(badSev, { logger: silent }).valid === false, 'invalid issue severity fails');
+
+// Invalid issue status
+const badIssueStatus = { tasks: [goodTask], issues: [{ description: 'Bug', severity: 'high', status: 'INVALID' }] };
+assert(TEMPLATE.validate(badIssueStatus, { logger: silent }).valid === false, 'invalid issue status fails');
+
+// Missing issue description
+const noIssueDesc = { tasks: [goodTask], issues: [{ description: '', severity: 'high', status: 'open' }] };
+assert(TEMPLATE.validate(noIssueDesc, { logger: silent }).valid === false, 'empty issue description fails');
+
+console.log('\n=== 4. computeDerived ===');
+const derivedInput = {
+  tasks: [
+    { name: 'Task A', status: 'done' },
+    { name: 'Task B', status: 'in_progress' },
+    { name: 'Task C', status: 'blocked' },
+    { name: 'Task D', status: 'pending' },
+  ],
+  issues: [
+    { description: 'Critical bug', severity: 'critical', status: 'open' },
+  ],
+};
+const derived = TEMPLATE.computeDerived(derivedInput, { logger: silent });
+assert(derived.total_tasks === 4, 'total_tasks = 4');
+assert(derived.completed_tasks === 1, 'completed_tasks = 1');
+assert(derived.blocked_tasks === 1, 'blocked_tasks = 1');
+assert(derived.completion_pct === 25, 'completion_pct = 25');
+assert(derived.tasks_by_status.done === 1, 'tasks_by_status.done = 1');
+assert(derived.tasks_by_status.blocked === 1, 'tasks_by_status.blocked = 1');
+assert(derived.sprintCompletion.decision === 'blocked', 'sprint blocked (critical issues + blocked tasks)');
+assert(derived.sprintCompletion.readyForQa === false, 'not ready for QA when blocked');
+
+// Complete scenario
+const completeInput = {
+  tasks: [
+    { name: 'Task A', status: 'done' },
+    { name: 'Task B', status: 'done' },
+  ],
+  issues: [],
+};
+const completeDerived = TEMPLATE.computeDerived(completeInput, { logger: silent });
+assert(completeDerived.completion_pct === 100, 'completion_pct = 100');
+assert(completeDerived.sprintCompletion.decision === 'complete', 'sprint complete when all done');
+assert(completeDerived.sprintCompletion.readyForQa === true, 'ready for QA when complete');
+
+console.log('\n=== 5. fetchUpstreamArtifacts mock ===');
+const engineSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-execution-engine.js'), 'utf8');
+assert(engineSrc.includes('lifecycle_stage'), 'engine queries lifecycle_stage');
+
+console.log('\n=== 6. Execution flow ===');
+assert(engineSrc.includes('hasAnalysisStep'), 'engine uses hasAnalysisStep flag');
+const hasElseComputeDerived = /else\s+if\s*\(\s*typeof\s+template\.computeDerived/.test(engineSrc);
+assert(hasElseComputeDerived, 'engine has else-if for computeDerived (dead code when analysisStep exists)');
+
+console.log('\n=== 7. Audit flags ===');
+const analysisSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/analysis-steps/stage-19-build-execution.js'), 'utf8');
+const templateSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/stage-19.js'), 'utf8');
+
+// 7a: outputSchema
+assert(templateSrc.includes('extractOutputSchema'), 'template calls extractOutputSchema (AUDIT)');
+assert(templateSrc.includes('ensureOutputSchema'), 'template calls ensureOutputSchema (AUDIT)');
+
+// 7b: DRY exception documented
+assert(analysisSrc.includes('circular dependency'), 'DRY exception documented (AUDIT)');
+
+// 7c: LLM fallback detection
+assert(analysisSrc.includes('llmFallbackCount'), 'analysis step tracks llmFallbackCount (AUDIT)');
+
+// 7d: Field casing — analysis output must use snake_case matching template schema
+assert(analysisSrc.includes('total_tasks'), 'analysis uses total_tasks (snake_case, AUDIT)');
+assert(analysisSrc.includes('completed_tasks'), 'analysis uses completed_tasks (snake_case, AUDIT)');
+assert(analysisSrc.includes('blocked_tasks'), 'analysis uses blocked_tasks (snake_case, AUDIT)');
+assert(analysisSrc.includes('completion_pct'), 'analysis computes completion_pct (AUDIT)');
+assert(analysisSrc.includes('tasks_by_status'), 'analysis computes tasks_by_status (AUDIT)');
+
+// 7e: Stale Stage 18 field refs (after Stage 18 fix, fields are snake_case)
+assert(!analysisSrc.includes('stage18Data.sprintGoal'), 'no stale sprintGoal ref (AUDIT)');
+assert(!analysisSrc.includes('stage18Data.sprintItems'), 'no stale sprintItems ref (AUDIT)');
+assert(analysisSrc.includes('sprint_goal') || analysisSrc.includes('stage18Data.sprint_goal'), 'uses sprint_goal (AUDIT)');
+
+// 7f: Tasks include sprint_item_ref mapping
+assert(analysisSrc.includes('sprint_item_ref'), 'tasks include sprint_item_ref (AUDIT)');
+
+// 7g: logger passed to parseFourBuckets
+assert(analysisSrc.includes('parseFourBuckets(parsed, { logger }'), 'logger passed to parseFourBuckets');
+
+console.log('\n=== 8. Error cases ===');
+assert(TEMPLATE.validate(null, { logger: silent }).valid === false, 'null data fails');
+assert(TEMPLATE.validate('string', { logger: silent }).valid === false, 'string data fails');
+
+console.log(`\n${'='.repeat(50)}`);
+console.log(`Results: ${pass} passed, ${fail} failed out of ${pass + fail}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add `extractOutputSchema`/`ensureOutputSchema` to Stage 19 template (systemic pattern)
- Fix stale Stage 18 refs: `sprintGoal`→`sprint_goal`, `sprintItems`→`items`, `estimatedLoc`→`story_points`
- Fix field casing in analysis step output: `totalTasks`→`total_tasks`, `completedTasks`→`completed_tasks`, `blockedTasks`→`blocked_tasks`
- Add missing derived fields computed in analysis step: `completion_pct`, `tasks_by_status`
- Add `sprint_item_ref` mapping to tasks (template schema field was unpopulated)
- Document DRY exception for circular dependency constants
- Add `llmFallbackCount` tracking for LLM output validation
- Add E2E test script (59 tests, all passing)

## Test plan
- [x] `node scripts/test-stage19-e2e.js` — 59/59 passing
- [x] Smoke tests passing (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)