### PR TITLE
fix: harden Stage 20 with outputSchema, field casing, stale ref cleanup

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js
@@ -14,6 +14,9 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
+// NOTE: These constants intentionally duplicated from stage-20.js
+// to avoid circular dependency — stage-20.js imports analyzeStage20 from this file,
+// and SYSTEM_PROMPT uses these constants at module-level evaluation.
 const QUALITY_DECISIONS = ['pass', 'conditional_pass', 'fail'];
 const TEST_SUITE_TYPES = ['unit', 'integration', 'e2e'];
 const DEFECT_SEVERITIES = ['critical', 'high', 'medium', 'low'];
@@ -77,15 +80,15 @@ export async function analyzeStage20({ stage19Data, stage18Data, ventureName, lo
   const client = getLLMClient({ purpose: 'content-generation' });
 
   const tasksContext = stage19Data.tasks
-    ? `Tasks (${stage19Data.totalTasks}): ${stage19Data.completedTasks} done, ${stage19Data.blockedTasks} blocked`
+    ? `Tasks (${stage19Data.total_tasks}): ${stage19Data.completed_tasks} done, ${stage19Data.blocked_tasks} blocked`
     : '';
 
   const issuesContext = stage19Data.issues?.length > 0
     ? `Known issues: ${stage19Data.issues.map(i => `${i.severity}: ${i.description}`).join('; ')}`
     : '';
 
-  const sprintContext = stage18Data?.sprintGoal
-    ? `Sprint goal: ${stage18Data.sprintGoal}`
+  const sprintContext = stage18Data?.sprint_goal
+    ? `Sprint goal: ${stage18Data.sprint_goal}`
     : '';
 
   const userPrompt = `Generate a QA assessment for this venture's build sprint.
@@ -174,17 +177,58 @@ Output ONLY valid JSON.`;
     rationale: String(qd.rationale || `Quality: ${overallPassRate}% pass rate, ${weightedCoverage}% coverage`).substring(0, 500),
   };
 
+  // Transform to template schema field names (snake_case)
+  const test_suites = testSuites.map(ts => ({
+    name: ts.name,
+    type: ts.type,
+    total_tests: ts.totalTests,
+    passing_tests: ts.passingTests,
+    coverage_pct: ts.coveragePct,
+  }));
+
+  const known_defects = knownDefects.map(d => ({
+    description: d.description,
+    severity: d.severity,
+    status: d.status,
+  }));
+
+  // Compute derived fields (these live in computeDerived but that path is dead code when analysisStep exists)
+  const total_tests = totalTests;
+  const total_passing = totalPassing;
+  const overall_pass_rate = overallPassRate;
+  const coverage_pct = weightedCoverage;
+  const critical_failures = totalFailures;
+  const quality_gate_passed = overall_pass_rate === 100 && coverage_pct >= MIN_COVERAGE_PCT;
+
+  // Track LLM fallback fields
+  let llmFallbackCount = 0;
+  if (!Array.isArray(parsed.testSuites) || parsed.testSuites.length === 0) llmFallbackCount++;
+  for (const ts of parsed.testSuites || []) {
+    if (!TEST_SUITE_TYPES.includes(ts?.type)) llmFallbackCount++;
+    if (typeof ts?.totalTests !== 'number') llmFallbackCount++;
+  }
+  for (const d of parsed.knownDefects || []) {
+    if (!DEFECT_SEVERITIES.includes(d?.severity)) llmFallbackCount++;
+    if (!DEFECT_STATUSES.includes(d?.status)) llmFallbackCount++;
+  }
+  if (!QUALITY_DECISIONS.includes(qd.decision)) llmFallbackCount++;
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage20] LLM fallback fields detected', { llmFallbackCount });
+  }
+
   logger.log('[Stage20] Analysis complete', { duration: Date.now() - startTime });
   return {
-    testSuites,
-    knownDefects,
+    test_suites,
+    known_defects,
     qualityDecision,
-    overallPassRate,
-    coveragePct: weightedCoverage,
-    totalTests,
+    overall_pass_rate,
+    coverage_pct,
+    critical_failures,
     totalFailures,
-    totalDefects: knownDefects.length,
-    openDefects: knownDefects.filter(d => d.status === 'open').length,
+    total_tests,
+    total_passing,
+    quality_gate_passed,
+    llmFallbackCount,
     fourBuckets, usage,
   };
 }

--- a/lib/eva/stage-templates/stage-20.js
+++ b/lib/eva/stage-templates/stage-20.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
+import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage20 } from './analysis-steps/stage-20-quality-assurance.js';
 
 const DEFECT_SEVERITIES = ['critical', 'high', 'medium', 'low'];
@@ -161,7 +162,9 @@ const TEMPLATE = {
   },
 };
 
+TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage20;
+ensureOutputSchema(TEMPLATE);
 
 export { DEFECT_SEVERITIES, DEFECT_STATUSES, MIN_TEST_SUITES, MIN_COVERAGE_PCT, TEST_SUITE_TYPES, QUALITY_DECISIONS };
 export default TEMPLATE;

--- a/scripts/test-stage20-e2e.js
+++ b/scripts/test-stage20-e2e.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Stage 20 E2E Test — Quality Assurance
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ *
+ * Tests: template structure, validation, computeDerived,
+ * execution flow, audit flags.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log(`  ✅ ${msg}`); } else { fail++; console.error(`  ❌ FAIL: ${msg}`); } }
+
+// ── Load template ──
+const mod = await import(`file:///${ROOT}/lib/eva/stage-templates/stage-20.js`.replace(/\\/g, '/'));
+const TEMPLATE = mod.default;
+const { DEFECT_SEVERITIES, DEFECT_STATUSES, MIN_TEST_SUITES, MIN_COVERAGE_PCT, TEST_SUITE_TYPES, QUALITY_DECISIONS } = mod;
+const silent = { warn: () => {}, log: () => {}, error: () => {} };
+
+console.log('\n=== 1. Template structure ===');
+assert(TEMPLATE.id === 'stage-20', 'id = stage-20');
+assert(TEMPLATE.slug === 'quality-assurance', 'slug = quality-assurance');
+assert(TEMPLATE.version === '2.0.0', 'version = 2.0.0');
+assert(TEMPLATE.schema.test_suites?.type === 'array', 'test_suites is array');
+assert(TEMPLATE.schema.test_suites?.minItems === MIN_TEST_SUITES, `test_suites minItems = ${MIN_TEST_SUITES}`);
+assert(TEMPLATE.schema.known_defects?.type === 'array', 'known_defects is array');
+assert(TEMPLATE.schema.overall_pass_rate?.derived === true, 'overall_pass_rate is derived');
+assert(TEMPLATE.schema.coverage_pct?.derived === true, 'coverage_pct is derived');
+assert(TEMPLATE.schema.total_tests?.derived === true, 'total_tests is derived');
+assert(TEMPLATE.schema.total_passing?.derived === true, 'total_passing is derived');
+assert(TEMPLATE.schema.quality_gate_passed?.derived === true, 'quality_gate_passed is derived');
+assert(TEMPLATE.schema.qualityDecision?.derived === true, 'qualityDecision is derived');
+assert(typeof TEMPLATE.validate === 'function', 'has validate()');
+assert(typeof TEMPLATE.computeDerived === 'function', 'has computeDerived()');
+assert(typeof TEMPLATE.analysisStep === 'function', 'has analysisStep()');
+assert(DEFECT_SEVERITIES.length === 4, 'DEFECT_SEVERITIES has 4 entries');
+assert(DEFECT_STATUSES.length === 5, 'DEFECT_STATUSES has 5 entries');
+assert(TEST_SUITE_TYPES.length === 3, 'TEST_SUITE_TYPES has 3 entries');
+assert(QUALITY_DECISIONS.length === 3, 'QUALITY_DECISIONS has 3 entries');
+assert(MIN_TEST_SUITES === 1, 'MIN_TEST_SUITES = 1');
+assert(MIN_COVERAGE_PCT === 60, 'MIN_COVERAGE_PCT = 60');
+
+// OutputSchema
+assert(TEMPLATE.outputSchema && typeof TEMPLATE.outputSchema === 'object', 'has outputSchema (AUDIT)');
+
+console.log('\n=== 2. Validation — good data ===');
+const goodSuite = {
+  name: 'Auth Unit Tests',
+  type: 'unit',
+  total_tests: 50,
+  passing_tests: 48,
+  coverage_pct: 85,
+};
+const goodData = {
+  test_suites: [goodSuite],
+  known_defects: [
+    { description: 'Token refresh race condition', severity: 'medium', status: 'open' },
+  ],
+};
+const goodResult = TEMPLATE.validate(goodData, { logger: silent });
+assert(goodResult.valid === true, 'good data passes validation');
+assert(goodResult.errors.length === 0, 'no errors');
+
+console.log('\n=== 3. Validation — bad data ===');
+assert(TEMPLATE.validate({}, { logger: silent }).valid === false, 'empty data fails');
+
+// Invalid suite type
+const badType = { test_suites: [{ ...goodSuite, type: 'INVALID' }] };
+assert(TEMPLATE.validate(badType, { logger: silent }).valid === false, 'invalid suite type fails');
+
+// Missing suite name
+const noName = { test_suites: [{ ...goodSuite, name: '' }] };
+assert(TEMPLATE.validate(noName, { logger: silent }).valid === false, 'empty suite name fails');
+
+// passing > total
+const overPass = { test_suites: [{ ...goodSuite, passing_tests: 100, total_tests: 50 }] };
+assert(TEMPLATE.validate(overPass, { logger: silent }).valid === false, 'passing > total fails');
+
+// Invalid defect severity
+const badSev = { test_suites: [goodSuite], known_defects: [{ description: 'Bug', severity: 'INVALID', status: 'open' }] };
+assert(TEMPLATE.validate(badSev, { logger: silent }).valid === false, 'invalid defect severity fails');
+
+// Invalid defect status
+const badDefStatus = { test_suites: [goodSuite], known_defects: [{ description: 'Bug', severity: 'high', status: 'INVALID' }] };
+assert(TEMPLATE.validate(badDefStatus, { logger: silent }).valid === false, 'invalid defect status fails');
+
+console.log('\n=== 4. computeDerived ===');
+const derivedInput = {
+  test_suites: [
+    { name: 'Unit', type: 'unit', total_tests: 100, passing_tests: 95, coverage_pct: 80 },
+    { name: 'E2E', type: 'e2e', total_tests: 20, passing_tests: 18, coverage_pct: 60 },
+  ],
+  known_defects: [],
+};
+const derived = TEMPLATE.computeDerived(derivedInput, { logger: silent });
+assert(derived.total_tests === 120, 'total_tests = 120');
+assert(derived.total_passing === 113, 'total_passing = 113');
+assert(derived.overall_pass_rate === 94.17, 'overall_pass_rate = 94.17');
+assert(derived.coverage_pct === 70, 'coverage_pct = 70 (avg)');
+assert(derived.quality_gate_passed === false, 'quality_gate not passed (not 100% pass rate)');
+assert(derived.qualityDecision.decision === 'conditional_pass', 'conditional_pass (high pass rate, ok coverage)');
+
+// Perfect pass
+const perfectInput = {
+  test_suites: [
+    { name: 'Unit', type: 'unit', total_tests: 100, passing_tests: 100, coverage_pct: 90 },
+  ],
+  known_defects: [],
+};
+const perfectDerived = TEMPLATE.computeDerived(perfectInput, { logger: silent });
+assert(perfectDerived.quality_gate_passed === true, 'quality_gate passed (100% pass, 90% coverage)');
+assert(perfectDerived.qualityDecision.decision === 'pass', 'decision = pass');
+
+console.log('\n=== 5. fetchUpstreamArtifacts mock ===');
+const engineSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-execution-engine.js'), 'utf8');
+assert(engineSrc.includes('lifecycle_stage'), 'engine queries lifecycle_stage');
+
+console.log('\n=== 6. Execution flow ===');
+assert(engineSrc.includes('hasAnalysisStep'), 'engine uses hasAnalysisStep flag');
+const hasElseComputeDerived = /else\s+if\s*\(\s*typeof\s+template\.computeDerived/.test(engineSrc);
+assert(hasElseComputeDerived, 'engine has else-if for computeDerived (dead code when analysisStep exists)');
+
+console.log('\n=== 7. Audit flags ===');
+const analysisSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/analysis-steps/stage-20-quality-assurance.js'), 'utf8');
+const templateSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/stage-20.js'), 'utf8');
+
+// 7a: outputSchema
+assert(templateSrc.includes('extractOutputSchema'), 'template calls extractOutputSchema (AUDIT)');
+assert(templateSrc.includes('ensureOutputSchema'), 'template calls ensureOutputSchema (AUDIT)');
+
+// 7b: DRY exception documented
+assert(analysisSrc.includes('circular dependency'), 'DRY exception documented (AUDIT)');
+
+// 7c: LLM fallback detection
+assert(analysisSrc.includes('llmFallbackCount'), 'analysis step tracks llmFallbackCount (AUDIT)');
+
+// 7d: Field casing — analysis output must use snake_case matching template schema
+assert(analysisSrc.includes('test_suites'), 'analysis uses test_suites (snake_case, AUDIT)');
+assert(analysisSrc.includes('known_defects'), 'analysis uses known_defects (snake_case, AUDIT)');
+assert(analysisSrc.includes('overall_pass_rate'), 'analysis uses overall_pass_rate (snake_case, AUDIT)');
+assert(analysisSrc.includes('total_tests'), 'analysis uses total_tests (snake_case, AUDIT)');
+assert(analysisSrc.includes('total_passing'), 'analysis uses total_passing (snake_case, AUDIT)');
+assert(analysisSrc.includes('quality_gate_passed'), 'analysis computes quality_gate_passed (AUDIT)');
+
+// 7e: Stale Stage 19 field refs (after Stage 19 fix, fields are snake_case)
+assert(!analysisSrc.includes('stage19Data.totalTasks'), 'no stale totalTasks ref (AUDIT)');
+assert(!analysisSrc.includes('stage19Data.completedTasks'), 'no stale completedTasks ref (AUDIT)');
+assert(!analysisSrc.includes('stage19Data.blockedTasks'), 'no stale blockedTasks ref (AUDIT)');
+
+// 7f: Stale Stage 18 field refs
+assert(!analysisSrc.includes('stage18Data.sprintGoal'), 'no stale sprintGoal ref (AUDIT)');
+
+// 7g: logger passed to parseFourBuckets
+assert(analysisSrc.includes('parseFourBuckets(parsed, { logger }'), 'logger passed to parseFourBuckets');
+
+console.log('\n=== 8. Error cases ===');
+assert(TEMPLATE.validate(null, { logger: silent }).valid === false, 'null data fails');
+assert(TEMPLATE.validate('string', { logger: silent }).valid === false, 'string data fails');
+
+console.log(`\n${'='.repeat(50)}`);
+console.log(`Results: ${pass} passed, ${fail} failed out of ${pass + fail}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add `extractOutputSchema`/`ensureOutputSchema` to Stage 20 template
- Fix stale Stage 19 refs: `totalTasks`→`total_tasks`, `completedTasks`→`completed_tasks`, `blockedTasks`→`blocked_tasks`
- Fix stale Stage 18 ref: `sprintGoal`→`sprint_goal`
- Transform analysis step output to snake_case: `testSuites`→`test_suites`, `knownDefects`→`known_defects`
- Add missing derived fields: `total_passing`, `critical_failures`, `quality_gate_passed`
- Document DRY exception, add `llmFallbackCount` tracking
- Add E2E test (58 tests, all passing)

## Test plan
- [x] `node scripts/test-stage20-e2e.js` — 58/58 passing
- [x] Smoke tests passing (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)