### PR TITLE
fix: harden Stage 22 with outputSchema, field casing, stale refs, promotion gate rescue

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js
@@ -13,9 +13,15 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+// evaluatePromotionGate is a function declaration (hoisted), safe from TDZ in circular import
+import { evaluatePromotionGate } from '../stage-22.js';
 
+// NOTE: These constants intentionally duplicated from stage-22.js
+// to avoid circular dependency — stage-22.js imports analyzeStage22 from this file,
+// and SYSTEM_PROMPT uses these constants at module-level evaluation.
 const RELEASE_DECISIONS = ['release', 'hold', 'cancel'];
 const RELEASE_CATEGORIES = ['feature', 'bugfix', 'infrastructure', 'documentation', 'security', 'performance', 'configuration'];
+const APPROVAL_STATUSES = ['pending', 'approved', 'rejected'];
 
 const SYSTEM_PROMPT = `You are EVA's Release Readiness Analyst. Synthesize the entire BUILD LOOP (Stages 17-21) into a release decision, sprint retrospective, and sprint summary.
 
@@ -80,19 +86,19 @@ export async function analyzeStage22({ stage17Data, stage18Data, stage19Data, st
   const client = getLLMClient({ purpose: 'content-generation' });
 
   const qaContext = stage20Data.qualityDecision
-    ? `QA: ${stage20Data.qualityDecision.decision} (${stage20Data.overallPassRate}% pass, ${stage20Data.coveragePct}% coverage)`
+    ? `QA: ${stage20Data.qualityDecision.decision} (${stage20Data.overall_pass_rate}% pass, ${stage20Data.coverage_pct}% coverage)`
     : '';
 
   const reviewContext = stage21Data.reviewDecision
-    ? `Review: ${stage21Data.reviewDecision.decision} (${stage21Data.passingIntegrations}/${stage21Data.totalIntegrations} integrations)`
+    ? `Review: ${stage21Data.reviewDecision.decision} (${stage21Data.passing_integrations}/${stage21Data.total_integrations} integrations)`
     : '';
 
-  const sprintContext = stage18Data?.sprintGoal
-    ? `Sprint Goal: ${stage18Data.sprintGoal}, Items: ${stage18Data.totalItems || 0}`
+  const sprintContext = stage18Data?.sprint_goal
+    ? `Sprint Goal: ${stage18Data.sprint_goal}, Items: ${stage18Data.total_items || 0}`
     : '';
 
   const executionContext = stage19Data
-    ? `Execution: ${stage19Data.completedTasks}/${stage19Data.totalTasks} tasks, ${stage19Data.openIssues} open issues`
+    ? `Execution: ${stage19Data.completed_tasks}/${stage19Data.total_tasks} tasks, ${stage19Data.issues?.length || 0} open issues`
     : '';
 
   const readinessContext = stage17Data?.buildReadiness
@@ -180,27 +186,67 @@ Output ONLY valid JSON.`;
       : ['Review sprint metrics in next planning'],
   };
 
-  // Normalize sprint summary
+  // Normalize sprint summary (use snake_case upstream refs from fixed stages 18-21)
   const ss = parsed.sprintSummary || {};
   const sprintSummary = {
-    sprintGoal: String(ss.sprintGoal || stage18Data?.sprintGoal || 'Sprint goal').substring(0, 300),
-    itemsPlanned: typeof ss.itemsPlanned === 'number' ? ss.itemsPlanned : (stage18Data?.totalItems || 0),
-    itemsCompleted: typeof ss.itemsCompleted === 'number' ? ss.itemsCompleted : (stage19Data?.completedTasks || 0),
-    qualityAssessment: String(ss.qualityAssessment || `${stage20Data.overallPassRate || 0}% pass rate`).substring(0, 300),
-    integrationStatus: String(ss.integrationStatus || `${stage21Data.passingIntegrations || 0}/${stage21Data.totalIntegrations || 0} passing`).substring(0, 300),
+    sprintGoal: String(ss.sprintGoal || stage18Data?.sprint_goal || 'Sprint goal').substring(0, 300),
+    itemsPlanned: typeof ss.itemsPlanned === 'number' ? ss.itemsPlanned : (stage18Data?.total_items || 0),
+    itemsCompleted: typeof ss.itemsCompleted === 'number' ? ss.itemsCompleted : (stage19Data?.completed_tasks || 0),
+    qualityAssessment: String(ss.qualityAssessment || `${stage20Data.overall_pass_rate || 0}% pass rate`).substring(0, 300),
+    integrationStatus: String(ss.integrationStatus || `${stage21Data.passing_integrations || 0}/${stage21Data.total_integrations || 0} passing`).substring(0, 300),
   };
+
+  // Transform to template schema field names (snake_case)
+  const release_items = releaseItems.map(ri => ({
+    name: ri.name,
+    category: ri.category,
+    status: ri.status,
+    approver: ri.approver,
+  }));
+  const release_notes = releaseNotes;
+  const target_date = targetDate;
+  const total_items = release_items.length;
+  const approved_items = release_items.filter(ri => ri.status === 'approved').length;
+  const all_approved = total_items > 0 && release_items.every(ri => ri.status === 'approved');
+
+  // Evaluate Phase 5→6 Promotion Gate (rescued from dead computeDerived)
+  const stage22Output = { release_items, releaseDecision, all_approved };
+  const promotion_gate = evaluatePromotionGate({
+    stage17: stage17Data,
+    stage18: stage18Data,
+    stage19: stage19Data,
+    stage20: stage20Data,
+    stage21: stage21Data,
+    stage22: stage22Output,
+  });
+
+  // Track LLM fallback fields
+  let llmFallbackCount = 0;
+  if (!Array.isArray(parsed.releaseItems) || parsed.releaseItems.length === 0) llmFallbackCount++;
+  for (const ri of parsed.releaseItems || []) {
+    if (!RELEASE_CATEGORIES.includes(ri?.category)) llmFallbackCount++;
+    if (!APPROVAL_STATUSES.includes(ri?.status)) llmFallbackCount++;
+  }
+  if (!RELEASE_DECISIONS.includes(rd.decision)) llmFallbackCount++;
+  if (!parsed.releaseNotes || parsed.releaseNotes.length < 10) llmFallbackCount++;
+  if (!parsed.targetDate || !/^\d{4}-\d{2}-\d{2}$/.test(parsed.targetDate)) llmFallbackCount++;
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage22] LLM fallback fields detected', { llmFallbackCount });
+  }
 
   logger.log('[Stage22] Analysis complete', { duration: Date.now() - startTime });
   return {
-    releaseItems,
-    releaseNotes,
-    targetDate,
+    release_items,
+    release_notes,
+    target_date,
     releaseDecision,
     sprintRetrospective,
     sprintSummary,
-    totalItems: releaseItems.length,
-    approvedItems: releaseItems.filter(ri => ri.status === 'approved').length,
-    allApproved: releaseItems.every(ri => ri.status === 'approved'),
+    total_items,
+    approved_items,
+    all_approved,
+    promotion_gate,
+    llmFallbackCount,
     fourBuckets, usage,
   };
 }

--- a/lib/eva/stage-templates/stage-22.js
+++ b/lib/eva/stage-templates/stage-22.js
@@ -20,6 +20,7 @@
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage22 } from './analysis-steps/stage-22-release-readiness.js';
 import { CHECKLIST_CATEGORIES } from './stage-17.js';
 import { MIN_COVERAGE_PCT } from './stage-20.js';
@@ -135,7 +136,7 @@ const TEMPLATE = {
     return { valid: errors.length === 0, errors };
   },
 
-  computeDerived(data, prerequisites, { logger = console } = {}) {
+  computeDerived(data, prerequisites, { logger: _logger = console } = {}) {
     const total_items = data.release_items.length;
     const approved_items = data.release_items.filter(ri => ri.status === 'approved').length;
     const all_approved = total_items > 0 && approved_items === total_items;
@@ -312,7 +313,9 @@ TEMPLATE.onBeforeAnalysis = async function onBeforeAnalysis(supabase, ventureId)
   return { chairmanDecisionId: id, isNew };
 };
 
+TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage22;
+ensureOutputSchema(TEMPLATE);
 
 export { APPROVAL_STATUSES, RELEASE_CATEGORIES, RELEASE_DECISIONS, MIN_RELEASE_ITEMS, MIN_READINESS_PCT, MIN_BUILD_COMPLETION_PCT };
 export default TEMPLATE;

--- a/scripts/test-stage22-e2e.js
+++ b/scripts/test-stage22-e2e.js
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+/**
+ * Stage 22 E2E Test — Release Readiness
+ * Phase: THE BUILD LOOP (Stages 17-22)
+ *
+ * Tests: template structure, validation, computeDerived,
+ * execution flow, audit flags, promotion gate.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log(`  ✅ ${msg}`); } else { fail++; console.error(`  ❌ FAIL: ${msg}`); } }
+
+// ── Load template ──
+const mod = await import(`file:///${ROOT}/lib/eva/stage-templates/stage-22.js`.replace(/\\/g, '/'));
+const TEMPLATE = mod.default;
+const { APPROVAL_STATUSES, RELEASE_CATEGORIES, RELEASE_DECISIONS, MIN_RELEASE_ITEMS, MIN_READINESS_PCT, MIN_BUILD_COMPLETION_PCT, evaluatePromotionGate } = mod;
+const silent = { warn: () => {}, log: () => {}, error: () => {} };
+
+console.log('\n=== 1. Template structure ===');
+assert(TEMPLATE.id === 'stage-22', 'id = stage-22');
+assert(TEMPLATE.slug === 'release-readiness', 'slug = release-readiness');
+assert(TEMPLATE.version === '2.0.0', 'version = 2.0.0');
+assert(TEMPLATE.schema.release_items?.type === 'array', 'release_items is array');
+assert(TEMPLATE.schema.release_items?.minItems === MIN_RELEASE_ITEMS, `release_items minItems = ${MIN_RELEASE_ITEMS}`);
+assert(TEMPLATE.schema.release_notes?.required === true, 'release_notes required');
+assert(TEMPLATE.schema.target_date?.required === true, 'target_date required');
+assert(TEMPLATE.schema.total_items?.derived === true, 'total_items is derived');
+assert(TEMPLATE.schema.approved_items?.derived === true, 'approved_items is derived');
+assert(TEMPLATE.schema.all_approved?.derived === true, 'all_approved is derived');
+assert(TEMPLATE.schema.releaseDecision?.derived === true, 'releaseDecision is derived');
+assert(TEMPLATE.schema.promotion_gate?.derived === true, 'promotion_gate is derived');
+assert(typeof TEMPLATE.validate === 'function', 'has validate()');
+assert(typeof TEMPLATE.computeDerived === 'function', 'has computeDerived()');
+assert(typeof TEMPLATE.analysisStep === 'function', 'has analysisStep()');
+assert(typeof TEMPLATE.onBeforeAnalysis === 'function', 'has onBeforeAnalysis()');
+assert(APPROVAL_STATUSES.length === 3, 'APPROVAL_STATUSES has 3 entries');
+assert(RELEASE_CATEGORIES.length === 7, 'RELEASE_CATEGORIES has 7 entries');
+assert(RELEASE_DECISIONS.length === 3, 'RELEASE_DECISIONS has 3 entries');
+assert(MIN_RELEASE_ITEMS === 1, 'MIN_RELEASE_ITEMS = 1');
+assert(typeof evaluatePromotionGate === 'function', 'evaluatePromotionGate is exported');
+
+// OutputSchema
+assert(TEMPLATE.outputSchema && typeof TEMPLATE.outputSchema === 'object', 'has outputSchema (AUDIT)');
+
+console.log('\n=== 2. Validation — good data ===');
+const goodItem = {
+  name: 'Auth Module v2',
+  category: 'feature',
+  status: 'approved',
+  approver: 'Product Owner',
+};
+const goodData = {
+  release_items: [goodItem],
+  release_notes: 'Release includes auth module v2 with OAuth support.',
+  target_date: '2026-03-15',
+  chairmanGate: { status: 'approved', rationale: 'Release approved', decision_id: 'dec-001' },
+};
+const goodResult = TEMPLATE.validate(goodData, { logger: silent });
+assert(goodResult.valid === true, 'good data passes validation');
+assert(goodResult.errors.length === 0, 'no errors');
+
+console.log('\n=== 3. Validation — bad data ===');
+assert(TEMPLATE.validate({}, { logger: silent }).valid === false, 'empty data fails');
+
+// Missing release_notes
+const noNotes = { ...goodData, release_notes: '' };
+assert(TEMPLATE.validate(noNotes, { logger: silent }).valid === false, 'empty release_notes fails');
+
+// Missing target_date
+const noDate = { ...goodData, target_date: '' };
+assert(TEMPLATE.validate(noDate, { logger: silent }).valid === false, 'empty target_date fails');
+
+// Invalid category
+const badCat = { ...goodData, release_items: [{ ...goodItem, category: 'INVALID' }] };
+assert(TEMPLATE.validate(badCat, { logger: silent }).valid === false, 'invalid category fails');
+
+// Invalid status
+const badStatus = { ...goodData, release_items: [{ ...goodItem, status: 'INVALID' }] };
+assert(TEMPLATE.validate(badStatus, { logger: silent }).valid === false, 'invalid item status fails');
+
+// Chairman gate pending
+const pendingGate = { ...goodData, chairmanGate: { status: 'pending' } };
+assert(TEMPLATE.validate(pendingGate, { logger: silent }).valid === false, 'pending chairman gate fails');
+
+// Chairman gate rejected
+const rejectedGate = { ...goodData, chairmanGate: { status: 'rejected', rationale: 'Not ready' } };
+assert(TEMPLATE.validate(rejectedGate, { logger: silent }).valid === false, 'rejected chairman gate fails');
+
+console.log('\n=== 4. computeDerived ===');
+const derivedInput = {
+  release_items: [
+    { name: 'Auth', category: 'feature', status: 'approved', approver: 'PO' },
+    { name: 'Bugfix', category: 'bugfix', status: 'pending', approver: 'QA' },
+    { name: 'Docs', category: 'documentation', status: 'approved', approver: 'TW' },
+  ],
+  release_notes: 'Sprint 1 release',
+  target_date: '2026-03-15',
+};
+const derived = TEMPLATE.computeDerived(derivedInput, null, { logger: silent });
+assert(derived.total_items === 3, 'total_items = 3');
+assert(derived.approved_items === 2, 'approved_items = 2');
+assert(derived.all_approved === false, 'not all_approved');
+assert(derived.releaseDecision.decision === 'hold', 'hold (some approved)');
+assert(derived.promotion_gate.pass === false, 'promotion_gate fails without prerequisites');
+
+// All approved
+const allApprovedInput = {
+  release_items: [
+    { name: 'Auth', category: 'feature', status: 'approved', approver: 'PO' },
+    { name: 'Docs', category: 'documentation', status: 'approved', approver: 'TW' },
+  ],
+  release_notes: 'Sprint 1 release',
+  target_date: '2026-03-15',
+};
+const allApprovedDerived = TEMPLATE.computeDerived(allApprovedInput, null, { logger: silent });
+assert(allApprovedDerived.all_approved === true, 'all_approved when all approved');
+assert(allApprovedDerived.releaseDecision.decision === 'release', 'release when all approved');
+
+console.log('\n=== 5. Promotion Gate ===');
+// All passing prerequisites
+const fullPrereqs = {
+  stage17: { buildReadiness: { decision: 'go', rationale: 'Ready' } },
+  stage18: { items: [{ title: 'Item 1' }] },
+  stage19: { sprintCompletion: { decision: 'complete', rationale: 'Done' } },
+  stage20: { qualityDecision: { decision: 'pass', rationale: 'All tests pass' } },
+  stage21: { reviewDecision: { decision: 'approve', rationale: 'All passing' } },
+  stage22: { releaseDecision: { decision: 'release' }, release_items: [{ status: 'approved' }] },
+};
+const gatePass = evaluatePromotionGate(fullPrereqs);
+assert(gatePass.pass === true, 'promotion gate passes with all good prereqs');
+assert(gatePass.blockers.length === 0, 'no blockers');
+
+// Failing prerequisites — QA fail
+const failPrereqs = {
+  ...fullPrereqs,
+  stage20: { qualityDecision: { decision: 'fail', rationale: 'Tests failing' } },
+};
+const gateFail = evaluatePromotionGate(failPrereqs);
+assert(gateFail.pass === false, 'promotion gate fails with QA failure');
+assert(gateFail.blockers.some(b => b.includes('Quality gate')), 'QA blocker present');
+
+// Warnings — conditional review
+const warnPrereqs = {
+  ...fullPrereqs,
+  stage21: { reviewDecision: { decision: 'conditional', rationale: 'Minor issues' } },
+};
+const gateWarn = evaluatePromotionGate(warnPrereqs);
+assert(gateWarn.pass === true, 'promotion gate passes with warnings');
+assert(gateWarn.warnings.length > 0, 'has warnings for conditional review');
+
+console.log('\n=== 6. fetchUpstreamArtifacts mock ===');
+const engineSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-execution-engine.js'), 'utf8');
+assert(engineSrc.includes('lifecycle_stage'), 'engine queries lifecycle_stage');
+
+console.log('\n=== 7. Execution flow ===');
+assert(engineSrc.includes('hasAnalysisStep'), 'engine uses hasAnalysisStep flag');
+const hasElseComputeDerived = /else\s+if\s*\(\s*typeof\s+template\.computeDerived/.test(engineSrc);
+assert(hasElseComputeDerived, 'engine has else-if for computeDerived (dead code when analysisStep exists)');
+
+console.log('\n=== 8. Audit flags ===');
+const analysisSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js'), 'utf8');
+const templateSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/stage-22.js'), 'utf8');
+
+// 8a: outputSchema
+assert(templateSrc.includes('extractOutputSchema'), 'template calls extractOutputSchema (AUDIT)');
+assert(templateSrc.includes('ensureOutputSchema'), 'template calls ensureOutputSchema (AUDIT)');
+
+// 8b: DRY exception documented
+assert(analysisSrc.includes('circular dependency'), 'DRY exception documented (AUDIT)');
+
+// 8c: LLM fallback detection
+assert(analysisSrc.includes('llmFallbackCount'), 'analysis step tracks llmFallbackCount (AUDIT)');
+
+// 8d: Field casing — analysis output must use snake_case matching template schema
+assert(analysisSrc.includes('release_items'), 'analysis uses release_items (snake_case, AUDIT)');
+assert(analysisSrc.includes('release_notes'), 'analysis uses release_notes (snake_case, AUDIT)');
+assert(analysisSrc.includes('target_date'), 'analysis uses target_date (snake_case, AUDIT)');
+assert(analysisSrc.includes('total_items'), 'analysis uses total_items (snake_case, AUDIT)');
+assert(analysisSrc.includes('approved_items'), 'analysis uses approved_items (snake_case, AUDIT)');
+assert(analysisSrc.includes('all_approved'), 'analysis uses all_approved (snake_case, AUDIT)');
+
+// 8e: Stale Stage 20 field refs (after Stage 20 fix, fields are snake_case)
+assert(!analysisSrc.includes('stage20Data.overallPassRate'), 'no stale overallPassRate ref (AUDIT)');
+assert(!analysisSrc.includes('stage20Data.coveragePct'), 'no stale coveragePct ref (AUDIT)');
+
+// 8f: Stale Stage 21 field refs (after Stage 21 fix, fields are snake_case)
+assert(!analysisSrc.includes('stage21Data.passingIntegrations'), 'no stale passingIntegrations ref (AUDIT)');
+assert(!analysisSrc.includes('stage21Data.totalIntegrations'), 'no stale totalIntegrations ref (AUDIT)');
+
+// 8g: Stale Stage 18 field refs (after Stage 18 fix, fields are snake_case)
+assert(!analysisSrc.includes('stage18Data.sprintGoal'), 'no stale sprintGoal ref (AUDIT)');
+assert(!analysisSrc.includes('stage18Data.totalItems'), 'no stale totalItems ref (AUDIT)');
+
+// 8h: Stale Stage 19 field refs (after Stage 19 fix, fields are snake_case)
+assert(!analysisSrc.includes('stage19Data.completedTasks'), 'no stale completedTasks ref (AUDIT)');
+assert(!analysisSrc.includes('stage19Data.totalTasks'), 'no stale totalTasks ref (AUDIT)');
+assert(!analysisSrc.includes('stage19Data.openIssues'), 'no stale openIssues ref (AUDIT)');
+
+// 8i: Promotion gate imported and called from analysis step
+assert(analysisSrc.includes('evaluatePromotionGate'), 'analysis step imports evaluatePromotionGate (AUDIT)');
+assert(analysisSrc.includes('promotion_gate'), 'analysis step returns promotion_gate (AUDIT)');
+
+// 8j: logger passed to parseFourBuckets
+assert(analysisSrc.includes('parseFourBuckets(parsed, { logger }'), 'logger passed to parseFourBuckets');
+
+console.log('\n=== 9. Error cases ===');
+assert(TEMPLATE.validate(null, { logger: silent }).valid === false, 'null data fails');
+assert(TEMPLATE.validate('string', { logger: silent }).valid === false, 'string data fails');
+
+console.log(`\n${'='.repeat(50)}`);
+console.log(`Results: ${pass} passed, ${fail} failed out of ${pass + fail}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Added `extractOutputSchema`/`ensureOutputSchema` to Stage 22 template (AUDIT compliance)
- Fixed stale field refs from Stages 18-21: `sprintGoal`→`sprint_goal`, `totalItems`→`total_items`, `completedTasks`→`completed_tasks`, `totalTasks`→`total_tasks`, `openIssues`→`issues?.length`, `overallPassRate`→`overall_pass_rate`, `coveragePct`→`coverage_pct`, `passingIntegrations`→`passing_integrations`, `totalIntegrations`→`total_integrations`
- Transformed output fields to snake_case: `releaseItems`→`release_items`, `releaseNotes`→`release_notes`, `targetDate`→`target_date`, etc.
- Rescued `evaluatePromotionGate` from dead `computeDerived` into analysis step (circular import safe — function declarations are hoisted)
- Added DRY exception comment, `llmFallbackCount` tracking, ESLint fix
- Created E2E test (`scripts/test-stage22-e2e.js`, 71 tests all passing)

## Test plan
- [x] `node --experimental-vm-modules scripts/test-stage22-e2e.js` — 71/71 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)