### PR TITLE
fix: harden Stage 24 with outputSchema, field casing, funnels, and llmFallbackCount

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js
@@ -15,6 +15,8 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 
+// NOTE: These constants intentionally duplicated from stage-24.js
+// to avoid circular dependency (template imports analysis step at module-level eval).
 const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', 'referral'];
 const TREND_DIRECTIONS = ['up', 'flat', 'down'];
 const OUTCOME_ASSESSMENTS = ['success', 'partial', 'failure', 'indeterminate'];
@@ -23,6 +25,7 @@ const EXPERIMENT_STATUSES = ['running', 'concluded', 'cancelled'];
 const EXPERIMENT_OUTCOMES = ['positive', 'negative', 'inconclusive'];
 const COHORT_PERIODS = ['day_1', 'day_7', 'day_14', 'day_30', 'day_60', 'day_90'];
 const ENGAGEMENT_LEVELS = ['highly_engaged', 'engaged', 'casual', 'at_risk', 'churned'];
+const MIN_FUNNELS = 1;
 
 const SYSTEM_PROMPT = `You are EVA's Metrics & Learning Analyst. Evaluate launch success criteria against AARRR metrics and produce a launch scorecard.
 
@@ -346,6 +349,24 @@ Output ONLY valid JSON.`;
     }
   }
 
+  // Synthesize funnels from AARRR categories (template requires minItems: 1)
+  let funnels = Array.isArray(parsed.funnels) && parsed.funnels.length > 0
+    ? parsed.funnels.filter(f => f?.name).map(f => ({
+        name: String(f.name).substring(0, 200),
+        steps: Array.isArray(f.steps) ? f.steps : [],
+      }))
+    : [];
+
+  if (funnels.length < MIN_FUNNELS) {
+    funnels = [{
+      name: 'AARRR Conversion Funnel',
+      steps: AARRR_CATEGORIES.map(cat => ({
+        stage: cat,
+        count: aarrr[cat].reduce((sum, m) => sum + m.value, 0),
+      })),
+    }];
+  }
+
   // Compute growth experiment derived metrics
   const concludedExperiments = growthExperiments.filter(e => e.status === 'concluded');
   const positiveExperiments = concludedExperiments.filter(e => e.outcome === 'positive');
@@ -356,19 +377,39 @@ Output ONLY valid JSON.`;
     : 0;
   const highChurnCohorts = retentionCohorts.filter(c => c.churnRisk === 'high').length;
 
+  // Field casing: template schema uses snake_case
+  const total_metrics = totalMetrics;
+  const metrics_on_target = metricsOnTarget;
+  const metrics_below_target = metricsBelowTarget;
+  const categories_complete = categoriesComplete === AARRR_CATEGORIES.length;
+  const funnel_count = funnels.length;
+
+  // Track LLM fallback count
+  let llmFallbackCount = 0;
+  if (!Array.isArray(parsed.aarrr?.acquisition) || parsed.aarrr.acquisition.length === 0) llmFallbackCount++;
+  if (!Array.isArray(parsed.learnings) || parsed.learnings.length === 0) llmFallbackCount++;
+  if (!parsed.launchOutcome?.assessment || !OUTCOME_ASSESSMENTS.includes(parsed.launchOutcome.assessment)) llmFallbackCount++;
+  if (!Array.isArray(parsed.growthExperiments) || parsed.growthExperiments.length === 0) llmFallbackCount++;
+  if (!Array.isArray(parsed.retentionCohorts) || parsed.retentionCohorts.length === 0) llmFallbackCount++;
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage24] LLM fallback triggered', { llmFallbackCount });
+  }
+
   logger.log('[Stage24] Analysis complete', { duration: Date.now() - startTime });
   return {
     aarrr,
+    funnels,
     criteriaEvaluation,
     learnings,
     launchOutcome,
     growthExperiments,
     retentionCohorts,
     engagementScoring,
-    totalMetrics,
-    metricsOnTarget,
-    metricsBelowTarget,
-    categoriesComplete: categoriesComplete === AARRR_CATEGORIES.length,
+    total_metrics,
+    metrics_on_target,
+    metrics_below_target,
+    categories_complete,
+    funnel_count,
     totalLearnings: learnings.length,
     highImpactLearnings: learnings.filter(l => l.impactLevel === 'high').length,
     totalExperiments: growthExperiments.length,
@@ -380,7 +421,7 @@ Output ONLY valid JSON.`;
     avgDay30Retention,
     highChurnCohorts,
     engagementScore: engagementScoring.overallScore,
-    fourBuckets, usage,
+    llmFallbackCount, fourBuckets, usage,
   };
 }
 

--- a/lib/eva/stage-templates/stage-24.js
+++ b/lib/eva/stage-templates/stage-24.js
@@ -10,6 +10,7 @@
  */
 
 import { validateString, validateNumber, validateArray, collectErrors } from './validation.js';
+import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage24 } from './analysis-steps/stage-24-metrics-learning.js';
 
 const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', 'referral'];
@@ -136,7 +137,7 @@ const TEMPLATE = {
     return { valid: errors.length === 0, errors };
   },
 
-  computeDerived(data, { logger = console } = {}) {
+  computeDerived(data, _prerequisites, { logger: _logger = console } = {}) {
     let total_metrics = 0;
     let metrics_on_target = 0;
     let metrics_below_target = 0;
@@ -186,7 +187,9 @@ const TEMPLATE = {
   },
 };
 
+TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage24;
+ensureOutputSchema(TEMPLATE);
 
 export { AARRR_CATEGORIES, TREND_DIRECTIONS, IMPACT_LEVELS, OUTCOME_ASSESSMENTS, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS };
 export default TEMPLATE;

--- a/scripts/test-stage24-e2e.js
+++ b/scripts/test-stage24-e2e.js
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Stage 24 E2E Test — Metrics & Learning
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ *
+ * Tests: template structure, validation, computeDerived,
+ * execution flow, audit flags.
+ */
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const ROOT = resolve(import.meta.dirname, '..');
+let pass = 0, fail = 0;
+function assert(cond, msg) { if (cond) { pass++; console.log(`  ✅ ${msg}`); } else { fail++; console.error(`  ❌ FAIL: ${msg}`); } }
+
+// ── Load template ──
+const mod = await import(`file:///${ROOT}/lib/eva/stage-templates/stage-24.js`.replace(/\\/g, '/'));
+const TEMPLATE = mod.default;
+const { AARRR_CATEGORIES, TREND_DIRECTIONS, IMPACT_LEVELS, OUTCOME_ASSESSMENTS, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS } = mod;
+const silent = { warn: () => {}, log: () => {}, error: () => {} };
+
+console.log('\n=== 1. Template structure ===');
+assert(TEMPLATE.id === 'stage-24', 'id = stage-24');
+assert(TEMPLATE.slug === 'metrics-learning', 'slug = metrics-learning');
+assert(TEMPLATE.version === '1.0.0', 'version = 1.0.0');
+assert(TEMPLATE.schema.aarrr?.required === true, 'aarrr required');
+assert(TEMPLATE.schema.aarrr?.type === 'object', 'aarrr is object');
+assert(TEMPLATE.schema.funnels?.type === 'array', 'funnels is array');
+assert(TEMPLATE.schema.funnels?.minItems === MIN_FUNNELS, `funnels minItems = ${MIN_FUNNELS}`);
+assert(TEMPLATE.schema.total_metrics?.derived === true, 'total_metrics is derived');
+assert(TEMPLATE.schema.categories_complete?.derived === true, 'categories_complete is derived');
+assert(TEMPLATE.schema.funnel_count?.derived === true, 'funnel_count is derived');
+assert(TEMPLATE.schema.metrics_on_target?.derived === true, 'metrics_on_target is derived');
+assert(TEMPLATE.schema.metrics_below_target?.derived === true, 'metrics_below_target is derived');
+assert(TEMPLATE.schema.launchOutcome?.derived === true, 'launchOutcome is derived');
+assert(typeof TEMPLATE.validate === 'function', 'has validate()');
+assert(typeof TEMPLATE.computeDerived === 'function', 'has computeDerived()');
+assert(typeof TEMPLATE.analysisStep === 'function', 'has analysisStep()');
+assert(AARRR_CATEGORIES.length === 5, 'AARRR_CATEGORIES has 5 entries');
+assert(TREND_DIRECTIONS.length === 3, 'TREND_DIRECTIONS has 3 entries');
+assert(IMPACT_LEVELS.length === 3, 'IMPACT_LEVELS has 3 entries');
+assert(OUTCOME_ASSESSMENTS.length === 4, 'OUTCOME_ASSESSMENTS has 4 entries');
+assert(MIN_METRICS_PER_CATEGORY === 1, 'MIN_METRICS_PER_CATEGORY = 1');
+assert(MIN_FUNNELS === 1, 'MIN_FUNNELS = 1');
+
+// OutputSchema
+assert(TEMPLATE.outputSchema && typeof TEMPLATE.outputSchema === 'object', 'has outputSchema (AUDIT)');
+
+console.log('\n=== 2. Validation — good data ===');
+const goodMetric = { name: 'Users', value: 100, target: 200, trendDirection: 'up' };
+const goodData = {
+  aarrr: {
+    acquisition: [{ name: 'New signups', value: 500, target: 400, trendDirection: 'up' }],
+    activation: [{ name: 'Onboarding complete', value: 80, target: 90, trendDirection: 'up' }],
+    retention: [{ name: 'Day-30 retention', value: 35, target: 40, trendDirection: 'flat' }],
+    revenue: [{ name: 'MRR', value: 5000, target: 3000, trendDirection: 'up' }],
+    referral: [{ name: 'Referral rate', value: 8, target: 10, trendDirection: 'up' }],
+  },
+  funnels: [{ name: 'Signup funnel', steps: [{ stage: 'visit', count: 1000 }, { stage: 'signup', count: 500 }] }],
+  learnings: [{ insight: 'Users prefer dark mode', action: 'Implement dark mode toggle', impactLevel: 'medium' }],
+};
+const goodResult = TEMPLATE.validate(goodData, { logger: silent });
+assert(goodResult.valid === true, 'good data passes validation');
+assert(goodResult.errors.length === 0, 'no errors');
+
+console.log('\n=== 3. Validation — bad data ===');
+assert(TEMPLATE.validate({}, { logger: silent }).valid === false, 'empty data fails');
+
+// Missing aarrr
+assert(TEMPLATE.validate({ funnels: [{ name: 'f', steps: ['a', 'b'] }] }, { logger: silent }).valid === false, 'missing aarrr fails');
+
+// Empty AARRR category
+const emptyAcq = { ...goodData, aarrr: { ...goodData.aarrr, acquisition: [] } };
+assert(TEMPLATE.validate(emptyAcq, { logger: silent }).valid === false, 'empty acquisition category fails');
+
+// Invalid metric (missing name)
+const badMetric = { ...goodData, aarrr: { ...goodData.aarrr, acquisition: [{ value: 10, target: 20 }] } };
+assert(TEMPLATE.validate(badMetric, { logger: silent }).valid === false, 'metric without name fails');
+
+// Empty funnels
+const noFunnels = { ...goodData, funnels: [] };
+assert(TEMPLATE.validate(noFunnels, { logger: silent }).valid === false, 'empty funnels fails');
+
+// Funnel missing steps
+const badFunnel = { ...goodData, funnels: [{ name: 'f', steps: [{ a: 1 }] }] };
+assert(TEMPLATE.validate(badFunnel, { logger: silent }).valid === false, 'funnel with <2 steps fails');
+
+// Learning missing insight
+const badLearning = { ...goodData, learnings: [{ action: 'Do something' }] };
+assert(TEMPLATE.validate(badLearning, { logger: silent }).valid === false, 'learning without insight fails');
+
+console.log('\n=== 4. computeDerived ===');
+const derived = TEMPLATE.computeDerived(goodData, null, { logger: silent });
+assert(derived.total_metrics === 5, 'total_metrics = 5');
+assert(derived.categories_complete === true, 'all categories complete');
+assert(derived.funnel_count === 1, 'funnel_count = 1');
+assert(derived.metrics_on_target === 2, 'metrics_on_target = 2 (signups, MRR)');
+assert(derived.metrics_below_target === 3, 'metrics_below_target = 3');
+assert(derived.launchOutcome.assessment === 'failure', 'assessment = failure (40% criteria met)');
+assert(typeof derived.launchOutcome.criteriaMetRate === 'number', 'criteriaMetRate is number');
+
+// All metrics on target
+const allOnTarget = {
+  aarrr: Object.fromEntries(AARRR_CATEGORIES.map(c => [c, [{ name: c, value: 100, target: 50 }]])),
+  funnels: [{ name: 'f', steps: ['a', 'b'] }],
+  learnings: [],
+};
+const allOnDerived = TEMPLATE.computeDerived(allOnTarget, null, { logger: silent });
+assert(allOnDerived.metrics_on_target === 5, 'all on target');
+assert(allOnDerived.launchOutcome.assessment === 'success', '100% → success');
+
+// No metrics (indeterminate)
+const emptyAarrr = {
+  aarrr: Object.fromEntries(AARRR_CATEGORIES.map(c => [c, []])),
+  funnels: [],
+};
+const emptyDerived = TEMPLATE.computeDerived(emptyAarrr, null, { logger: silent });
+assert(emptyDerived.total_metrics === 0, 'no metrics');
+assert(emptyDerived.launchOutcome.assessment === 'indeterminate', '0 metrics → indeterminate');
+
+console.log('\n=== 5. fetchUpstreamArtifacts mock ===');
+const engineSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-execution-engine.js'), 'utf8');
+assert(engineSrc.includes('lifecycle_stage'), 'engine queries lifecycle_stage');
+
+console.log('\n=== 6. Execution flow ===');
+assert(engineSrc.includes('hasAnalysisStep'), 'engine uses hasAnalysisStep flag');
+const hasElseComputeDerived = /else\s+if\s*\(\s*typeof\s+template\.computeDerived/.test(engineSrc);
+assert(hasElseComputeDerived, 'engine has else-if for computeDerived (dead code when analysisStep exists)');
+
+console.log('\n=== 7. Audit flags ===');
+const analysisSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/analysis-steps/stage-24-metrics-learning.js'), 'utf8');
+const templateSrc = readFileSync(resolve(ROOT, 'lib/eva/stage-templates/stage-24.js'), 'utf8');
+
+// 7a: outputSchema
+assert(templateSrc.includes('extractOutputSchema'), 'template calls extractOutputSchema (AUDIT)');
+assert(templateSrc.includes('ensureOutputSchema'), 'template calls ensureOutputSchema (AUDIT)');
+
+// 7b: DRY exception documented
+assert(analysisSrc.includes('circular dependency'), 'DRY exception documented (AUDIT)');
+
+// 7c: LLM fallback detection
+assert(analysisSrc.includes('llmFallbackCount'), 'analysis step tracks llmFallbackCount (AUDIT)');
+
+// 7d: Field casing — analysis output uses snake_case for template schema
+assert(analysisSrc.includes('total_metrics'), 'analysis uses total_metrics (snake_case, AUDIT)');
+assert(analysisSrc.includes('metrics_on_target'), 'analysis uses metrics_on_target (snake_case, AUDIT)');
+assert(analysisSrc.includes('metrics_below_target'), 'analysis uses metrics_below_target (snake_case, AUDIT)');
+assert(analysisSrc.includes('categories_complete'), 'analysis uses categories_complete (snake_case, AUDIT)');
+assert(analysisSrc.includes('funnel_count'), 'analysis uses funnel_count (snake_case, AUDIT)');
+
+// 7e: Analysis step produces funnels (template requires minItems: 1)
+assert(analysisSrc.includes('funnels'), 'analysis step produces funnels (AUDIT)');
+assert(analysisSrc.includes('AARRR Conversion Funnel'), 'analysis step has default funnel fallback (AUDIT)');
+
+// 7f: logger passed to parseFourBuckets
+assert(analysisSrc.includes('parseFourBuckets(parsed, { logger }'), 'logger passed to parseFourBuckets');
+
+console.log('\n=== 8. Error cases ===');
+assert(TEMPLATE.validate(null, { logger: silent }).valid === false, 'null data fails');
+assert(TEMPLATE.validate('string', { logger: silent }).valid === false, 'string data fails');
+
+console.log(`\n${'='.repeat(50)}`);
+console.log(`Results: ${pass} passed, ${fail} failed out of ${pass + fail}`);
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Add extractOutputSchema/ensureOutputSchema to Stage 24 template
- Fix field casing: totalMetrics→total_metrics, metricsOnTarget→metrics_on_target, metricsBelowTarget→metrics_below_target
- Add missing funnel_count derived field and funnels generation (template requires minItems:1 but LLM prompt never produced them)
- Add llmFallbackCount tracking for LLM output quality detection
- Document DRY exception for circular dependency constants
- Fix ESLint: unused logger→_logger in computeDerived
- Add E2E test (60 tests, all passing)

## Test plan
- [x] E2E test: 60/60 passing
- [x] Smoke tests: 15/15 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)