### PR TITLE
refactor: align EVA contract schemas with actual stage outputs

### DIFF
--- a/lib/eva/contracts/stage-contracts.yaml
+++ b/lib/eva/contracts/stage-contracts.yaml
@@ -30,6 +30,7 @@ stages:
           valueProp: { type: string }
           targetMarket: { type: string }
           archetype: { type: string }
+          keyAssumptions: { type: array, required: false }
     produces:
       compositeScore: { type: integer, min: 0, max: 100 }
 
@@ -40,6 +41,7 @@ stages:
         fields:
           archetype: { type: string }
           problemStatement: { type: string }
+          keyAssumptions: { type: array, required: false }
       - stage: 2
         fields:
           compositeScore: { type: integer }
@@ -71,6 +73,7 @@ stages:
     produces:
       unitEconomics: { type: object }
       decision: { type: string }
+      roiBands: { type: object, required: false }
 
   6:
     name: "Risk Assessment"
@@ -122,6 +125,7 @@ stages:
       exit_thesis: { type: string, minLength: 20 }
       exit_paths: { type: array, minItems: 1 }
       reality_gate: { type: object }
+      valuationEstimate: { type: object, required: false }
 
   10:
     name: "Brand Identity"

--- a/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js
@@ -177,6 +177,8 @@ Output ONLY valid JSON.`;
   const EVIDENCE_MAP = {
     'market-strategist': 'market',
     'customer-advocate': 'customer',
+    'growth-hacker': 'growth',
+    'revenue-analyst': 'revenue',
     'moat-architect': 'competitive',
     'ops-realist': 'execution',
     'product-designer': 'design',

--- a/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js
@@ -224,19 +224,19 @@ Output ONLY valid JSON.`;
 
   // Running cash balance
   let runningBalance = initial_capital;
-  const cashBalanceEnd = revenue_projections.map(rp => {
+  const cash_balance_end = revenue_projections.map(rp => {
     runningBalance += (rp.revenue - rp.costs);
     return { month: rp.month, balance: Math.round(runningBalance * 100) / 100 };
   });
 
   // Viability warnings
-  const viabilityWarnings = [];
+  const viability_warnings = [];
   let consecutiveLoss = 0;
   for (const rp of revenue_projections) {
     if (rp.costs > rp.revenue) {
       consecutiveLoss++;
       if (consecutiveLoss >= 3) {
-        viabilityWarnings.push(`Costs exceed revenue for ${consecutiveLoss} consecutive months (month ${rp.month - consecutiveLoss + 1} to ${rp.month})`);
+        viability_warnings.push(`Costs exceed revenue for ${consecutiveLoss} consecutive months (month ${rp.month - consecutiveLoss + 1} to ${rp.month})`);
         break;
       }
     } else {
@@ -244,14 +244,14 @@ Output ONLY valid JSON.`;
     }
   }
   if (runway_months !== Infinity && runway_months < 6) {
-    viabilityWarnings.push(`Short runway: ${runway_months} months (recommended: >= 6)`);
+    viability_warnings.push(`Short runway: ${runway_months} months (recommended: >= 6)`);
   }
   if (break_even_month === null && revenue_projections.length > 0) {
-    viabilityWarnings.push(`No break-even within ${revenue_projections.length}-month projection period`);
+    viability_warnings.push(`No break-even within ${revenue_projections.length}-month projection period`);
   }
-  const negativeMonth = cashBalanceEnd.find(cb => cb.balance < 0);
+  const negativeMonth = cash_balance_end.find(cb => cb.balance < 0);
   if (negativeMonth) {
-    viabilityWarnings.push(`Cash balance goes negative in month ${negativeMonth.month}`);
+    viability_warnings.push(`Cash balance goes negative in month ${negativeMonth.month}`);
   }
 
   // Evaluate Phase 4→5 Promotion Gate
@@ -274,8 +274,8 @@ Output ONLY valid JSON.`;
     burn_rate,
     break_even_month,
     pnl,
-    cashBalanceEnd,
-    viabilityWarnings,
+    cash_balance_end,
+    viability_warnings,
     promotion_gate,
     llmFallbackCount,
     fourBuckets, usage,

--- a/lib/eva/stage-templates/stage-02.js
+++ b/lib/eva/stage-templates/stage-02.js
@@ -52,6 +52,8 @@ const TEMPLATE = {
       properties: {
         market: { type: 'string', required: true },
         customer: { type: 'string', required: true },
+        growth: { type: 'string', required: true },
+        revenue: { type: 'string', required: true },
         competitive: { type: 'string', required: true },
         execution: { type: 'string', required: true },
         design: { type: 'string', required: true },
@@ -72,7 +74,7 @@ const TEMPLATE = {
   defaultData: {
     analysis: { strategic: '', technical: '', tactical: '' },
     metrics: Object.fromEntries(METRIC_NAMES.map(m => [m, null])),
-    evidence: { market: '', customer: '', competitive: '', execution: '', design: '' },
+    evidence: { market: '', customer: '', growth: '', revenue: '', competitive: '', execution: '', design: '' },
     compositeScore: null,
     provenance: {},
   },
@@ -93,6 +95,7 @@ const TEMPLATE = {
         valueProp: { type: 'string', minLength: 20 },
         targetMarket: { type: 'string', minLength: 10 },
         archetype: { type: 'string' },
+        keyAssumptions: { type: 'array', required: false },
       };
       const crossCheck = validateCrossStageContract(prerequisites.stage01, contract, 'stage-01');
       errors.push(...crossCheck.errors);
@@ -122,7 +125,7 @@ const TEMPLATE = {
     if (!data?.evidence || typeof data.evidence !== 'object') {
       errors.push('evidence is required and must be an object');
     } else {
-      for (const domain of ['market', 'customer', 'competitive', 'execution', 'design']) {
+      for (const domain of ['market', 'customer', 'growth', 'revenue', 'competitive', 'execution', 'design']) {
         const r = validateString(data.evidence[domain], `evidence.${domain}`, 1);
         if (!r.valid) errors.push(r.error);
       }

--- a/lib/eva/stage-templates/stage-05.js
+++ b/lib/eva/stage-templates/stage-05.js
@@ -88,6 +88,15 @@ const TEMPLATE = {
     netProfitY3: { type: 'number', derived: true },
     breakEvenMonth: { type: 'number', nullable: true, derived: true },
     roi3y: { type: 'number', derived: true },
+    roiBands: {
+      type: 'object',
+      derived: true,
+      properties: {
+        pessimistic: { type: 'number' },
+        base: { type: 'number' },
+        optimistic: { type: 'number' },
+      },
+    },
     decision: { type: 'enum', values: ['pass', 'conditional_pass', 'kill'], derived: true },
     blockProgression: { type: 'boolean', derived: true },
     reasons: { type: 'array', derived: true },
@@ -109,6 +118,7 @@ const TEMPLATE = {
     netProfitY3: null,
     breakEvenMonth: null,
     roi3y: null,
+    roiBands: null,
     decision: null,
     blockProgression: false,
     reasons: [],

--- a/lib/eva/stage-templates/stage-09.js
+++ b/lib/eva/stage-templates/stage-09.js
@@ -56,6 +56,17 @@ const TEMPLATE = {
         success_criteria: { type: 'string', required: true },
       },
     },
+    // Derived: valuation estimate
+    valuationEstimate: {
+      type: 'object',
+      derived: true,
+      properties: {
+        method: { type: 'string' },
+        revenueBase: { type: 'number' },
+        multipliers: { type: 'object' },
+        estimatedRange: { type: 'object' },
+      },
+    },
     // Derived: reality gate payload
     reality_gate: {
       type: 'object',
@@ -74,6 +85,7 @@ const TEMPLATE = {
     exit_paths: [],
     target_acquirers: [],
     milestones: [],
+    valuationEstimate: null,
     reality_gate: null,
   },
 

--- a/lib/eva/stage-templates/stage-16.js
+++ b/lib/eva/stage-templates/stage-16.js
@@ -66,8 +66,8 @@ const TEMPLATE = {
     total_projected_revenue: { type: 'number', derived: true },
     total_projected_costs: { type: 'number', derived: true },
     pnl: { type: 'object', derived: true },
-    cashBalanceEnd: { type: 'array', derived: true },
-    viabilityWarnings: { type: 'array', derived: true },
+    cash_balance_end: { type: 'array', derived: true },
+    viability_warnings: { type: 'array', derived: true },
     promotion_gate: { type: 'object', derived: true },
   },
   defaultData: {
@@ -81,8 +81,8 @@ const TEMPLATE = {
     total_projected_revenue: 0,
     total_projected_costs: 0,
     pnl: null,
-    cashBalanceEnd: [],
-    viabilityWarnings: [],
+    cash_balance_end: [],
+    viability_warnings: [],
     promotion_gate: null,
   },
 

--- a/tests/unit/eva/stage-templates/stage-16.test.js
+++ b/tests/unit/eva/stage-templates/stage-16.test.js
@@ -39,8 +39,8 @@ describe('stage-16.js - Financial Projections template', () => {
         total_projected_revenue: 0,
         total_projected_costs: 0,
         pnl: null,
-        cashBalanceEnd: [],
-        viabilityWarnings: [],
+        cash_balance_end: [],
+        viability_warnings: [],
         promotion_gate: null,
       });
     });


### PR DESCRIPTION
## Summary
- **FR1**: Add `keyAssumptions` to Stage 2/3 consumes, `roiBands` to Stage 5 produces, `valuationEstimate` to Stage 9 produces in `stage-contracts.yaml`
- **FR2**: Add `keyAssumptions` to Stage 2 cross-stage contract validation
- **FR3**: Map `growth-hacker` and `revenue-analyst` personas in EVIDENCE_MAP, add `growth`/`revenue` evidence domains to Stage 2 schema and validation
- **FR4**: Add `roiBands` derived field to Stage 5 schema and defaultData
- **FR5**: Add `valuationEstimate` derived field to Stage 9 schema and defaultData
- **FR6**: Rename `cashBalanceEnd`/`viabilityWarnings` to snake_case in Stage 16 schema, defaultData, and analysis step

SD: SD-LEO-REFAC-EVA-CONTRACT-SCHEMA-001

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Stage 16 unit tests: 32 pass (12 pre-existing failures from SD-B dead code cleanup)
- [x] Stage 5 unit tests: 26 pass (11 pre-existing failures from SD-B dead code cleanup)
- [x] Pre-commit hooks all green (ESLint, secret scan, LOC check, Gate 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)