### PR TITLE
fix: harden EVA pipeline with 4 systemic fixes from full 25-stage UAT

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -173,7 +173,22 @@ export async function createOrReusePendingDecision({
     throw new ServiceError('INVALID_ARGS', 'ventureId, stageNumber, and supabase are required', 'ChairmanDecisionWatcher');
   }
 
-  // Check for existing PENDING decision first
+  // Check for existing decision (approved takes priority, then pending)
+  const { data: existingApproved } = await supabase
+    .from('chairman_decisions')
+    .select('id, status')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', stageNumber)
+    .eq('status', 'approved')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (existingApproved) {
+    logger.log(`   Reusing existing APPROVED decision: ${existingApproved.id}`);
+    return { id: existingApproved.id, isNew: false };
+  }
+
   const { data: existing } = await supabase
     .from('chairman_decisions')
     .select('id')

--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -263,38 +263,54 @@ const STAGE_CONTRACTS = new Map([
   }],
 
   [20, {
-    consumes: [],
+    consumes: [
+      { stage: 18, fields: {
+        items: { type: 'array' },
+      }},
+      { stage: 19, fields: {
+        tasks: { type: 'array' },
+      }},
+    ],
     produces: {
       test_suites: { type: 'array', minItems: 1 },
       overall_pass_rate: { type: 'number' },
-      quality_gate_passed: { type: 'object' },
+      quality_gate_passed: { type: 'boolean' },
     },
   }],
 
   [21, {
-    consumes: [],
+    consumes: [
+      { stage: 19, fields: {
+        tasks: { type: 'array' },
+      }},
+      { stage: 20, fields: {
+        test_suites: { type: 'array' },
+      }},
+    ],
     produces: {
       integrations: { type: 'array', minItems: 1 },
       pass_rate: { type: 'number' },
-      all_passing: { type: 'object' },
+      all_passing: { type: 'boolean' },
     },
   }],
 
   [22, {
     consumes: [
       { stage: 17, fields: {
-        buildReadiness: { type: 'object' },
+        readiness_pct: { type: 'number' },
       }},
       { stage: 18, fields: {
         items: { type: 'array', minItems: 1 },
       }},
       { stage: 19, fields: {
-        sprintCompletion: { type: 'object' },
+        tasks: { type: 'array' },
       }},
       { stage: 20, fields: {
-        quality_gate_passed: { type: 'object' },
+        test_suites: { type: 'array' },
+        quality_gate_passed: { type: 'boolean', required: false },
       }},
       { stage: 21, fields: {
+        integrations: { type: 'array' },
         reviewDecision: { type: 'object', required: false },
       }},
     ],
@@ -455,15 +471,42 @@ export function validatePostStage(stageNumber, stageOutput, { logger = console, 
  * SD-MAN-ORCH-VISION-ARCHITECTURE-HARDENING-001-D
  */
 export const CROSS_STAGE_DEPS = {
-  1: [0],              // Stage 1 needs Stage 0 synthesis
-  3: [1, 2],           // Kill gate: needs idea + validation
-  5: [1, 3, 4],        // Kill gate: needs idea + market + competitor
-  8: [1, 2, 3, 4, 5, 6, 7], // BMC: synthesizes all prior
-  9: [1, 5, 8],        // Reality gate: needs idea + financial + BMC
-  13: [1, 5, 9, 10, 11, 12], // Kill gate: needs full identity
-  16: [1, 5, 7, 13, 14, 15], // P&L: needs pricing + planning
-  22: [17, 18, 19, 20, 21],  // UAT: needs full build
-  25: [22, 23, 24],    // Ops review: needs launch data
+  // Phase 1: THE TRUTH (Stages 1-5)
+  1: [0],                    // Hydration: Stage 0 synthesis
+  2: [1],                    // Multi-persona scoring: idea brief
+  3: [1, 2],                 // Kill gate: idea + persona scores
+  4: [1, 3],                 // Competitive intel: idea + kill gate entities
+  5: [1, 3, 4],              // Unit economics kill gate: idea + scores + competitors
+
+  // Phase 2: THE ENGINE (Stages 6-9)
+  6: [1, 3, 4, 5],           // Risk matrix: idea + scores + competitors + economics
+  7: [1, 4, 5, 6],           // Pricing strategy: idea + competitors + economics + risks
+  8: [1, 4, 5, 6, 7],        // BMC: idea + competitors + economics + risks + pricing
+  9: [1, 5, 6, 7, 8],        // Exit strategy (reality gate): idea + economics + risks + pricing + BMC
+
+  // Phase 3: THE IDENTITY (Stages 10-12)
+  10: [1, 3, 5, 8],          // Brand identity: idea + scores + economics + BMC
+  11: [1, 5, 10],            // Marketing/GTM: idea + economics + brand
+  12: [1, 5, 7, 10, 11],     // Sales framework: idea + economics + pricing + brand + GTM
+
+  // Phase 4: THE BLUEPRINT (Stages 13-16)
+  13: [1, 5, 8, 9],          // Product roadmap: idea + economics + BMC + exit
+  14: [1, 13],               // Technical architecture: idea + roadmap
+  15: [1, 6, 13, 14],        // Risk register: idea + risk matrix + roadmap + architecture
+  16: [1, 13, 14, 15],       // Financial projections (promotion gate): idea + roadmap + arch + risks
+
+  // Phase 5: THE BUILD (Stages 17-21)
+  17: [13, 14, 15, 16],      // Build readiness: roadmap + arch + risks + financials
+  18: [13, 14, 17],          // Sprint planning: roadmap + arch + readiness
+  19: [17, 18],              // Dev execution: readiness + sprint plan
+  20: [18, 19],              // QA & testing: sprint plan + dev output
+  21: [19, 20],              // Build review: dev output + QA results
+
+  // Phase 6: LAUNCH & LEARN (Stages 22-25)
+  22: [17, 18, 19, 20, 21],  // Release readiness: full build phase
+  23: [1, 22],               // Post-launch ops: idea + release readiness
+  24: [5, 23],               // Metrics & learning: economics + post-launch
+  25: [1, 5, 13, 16, 23, 24], // Portfolio review: idea + economics + roadmap + financials + ops + metrics
 };
 
 /**

--- a/lib/eva/contracts/stage-contracts.yaml
+++ b/lib/eva/contracts/stage-contracts.yaml
@@ -70,6 +70,13 @@ stages:
         fields:
           archetype: { type: string }
           targetMarket: { type: string }
+      - stage: 3
+        fields:
+          overallScore: { type: integer, required: false }
+          decision: { type: string, required: false }
+      - stage: 4
+        fields:
+          competitors: { type: array, required: false }
     produces:
       unitEconomics: { type: object }
       decision: { type: string }
@@ -78,6 +85,16 @@ stages:
   6:
     name: "Risk Assessment"
     consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+          targetMarket: { type: string }
+      - stage: 3
+        fields:
+          overallScore: { type: integer, required: false }
+      - stage: 4
+        fields:
+          competitors: { type: array, required: false }
       - stage: 5
         fields:
           unitEconomics: { type: object }
@@ -89,9 +106,19 @@ stages:
   7:
     name: "Pricing Strategy"
     consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+          targetMarket: { type: string }
+      - stage: 4
+        fields:
+          competitors: { type: array, required: false }
       - stage: 5
         fields:
           unitEconomics: { type: object }
+      - stage: 6
+        fields:
+          risks: { type: array }
     produces:
       pricing_model: { type: string }
       tiers: { type: array, minItems: 1 }
@@ -99,6 +126,19 @@ stages:
   8:
     name: "Business Model Canvas"
     consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+          valueProp: { type: string }
+      - stage: 4
+        fields:
+          competitors: { type: array, required: false }
+      - stage: 5
+        fields:
+          unitEconomics: { type: object }
+      - stage: 6
+        fields:
+          risks: { type: array }
       - stage: 7
         fields:
           pricing_model: { type: string }
@@ -111,6 +151,12 @@ stages:
   9:
     name: "Exit Strategy"
     consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+      - stage: 5
+        fields:
+          unitEconomics: { type: object }
       - stage: 6
         fields:
           risks: { type: array }
@@ -129,14 +175,37 @@ stages:
 
   10:
     name: "Brand Identity"
-    consumes: []
+    consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+          valueProp: { type: string }
+      - stage: 3
+        fields:
+          overallScore: { type: integer, required: false }
+      - stage: 5
+        fields:
+          unitEconomics: { type: object, required: false }
+      - stage: 8
+        fields:
+          customerSegments: { type: object, required: false }
     produces:
       candidates: { type: array, minItems: 5 }
       brandGenome: { type: object }
 
   11:
     name: "Marketing Strategy"
-    consumes: []
+    consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+          targetMarket: { type: string }
+      - stage: 5
+        fields:
+          unitEconomics: { type: object, required: false }
+      - stage: 10
+        fields:
+          candidates: { type: array }
     produces:
       tiers: { type: array, minItems: 3 }
       channels: { type: array, minItems: 8 }
@@ -144,6 +213,15 @@ stages:
   12:
     name: "Sales Framework"
     consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+      - stage: 5
+        fields:
+          unitEconomics: { type: object, required: false }
+      - stage: 7
+        fields:
+          tiers: { type: array, required: false }
       - stage: 10
         fields:
           candidates: { type: array, minItems: 5 }
@@ -159,7 +237,20 @@ stages:
 
   13:
     name: "Product Roadmap"
-    consumes: []
+    consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+          valueProp: { type: string }
+      - stage: 5
+        fields:
+          unitEconomics: { type: object, required: false }
+      - stage: 8
+        fields:
+          customerSegments: { type: object, required: false }
+      - stage: 9
+        fields:
+          exit_thesis: { type: string, required: false }
     produces:
       vision_statement: { type: string, minLength: 20 }
       milestones: { type: array, minItems: 3 }
@@ -167,7 +258,13 @@ stages:
 
   14:
     name: "Technical Architecture"
-    consumes: []
+    consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+      - stage: 13
+        fields:
+          milestones: { type: array }
     produces:
       architecture_summary: { type: string, minLength: 20 }
       layers: { type: object }
@@ -175,7 +272,19 @@ stages:
 
   15:
     name: "Risk Matrix"
-    consumes: []
+    consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+      - stage: 6
+        fields:
+          risks: { type: array, required: false }
+      - stage: 13
+        fields:
+          milestones: { type: array }
+      - stage: 14
+        fields:
+          layers: { type: object }
     produces:
       risks: { type: array, minItems: 1 }
       total_risks: { type: number }
@@ -183,6 +292,9 @@ stages:
   16:
     name: "Financial Projections"
     consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
       - stage: 13
         fields:
           milestones: { type: array, minItems: 3 }
@@ -199,7 +311,19 @@ stages:
 
   17:
     name: "Launch Readiness"
-    consumes: []
+    consumes:
+      - stage: 13
+        fields:
+          milestones: { type: array }
+      - stage: 14
+        fields:
+          layers: { type: object }
+      - stage: 15
+        fields:
+          risks: { type: array }
+      - stage: 16
+        fields:
+          runway_months: { type: number }
     produces:
       checklist: { type: object }
       readiness_pct: { type: number }
@@ -207,7 +331,16 @@ stages:
 
   18:
     name: "Sprint Planning"
-    consumes: []
+    consumes:
+      - stage: 13
+        fields:
+          milestones: { type: array }
+      - stage: 14
+        fields:
+          layers: { type: object }
+      - stage: 17
+        fields:
+          checklist: { type: object }
     produces:
       sprint_name: { type: string }
       items: { type: array, minItems: 1 }
@@ -216,6 +349,9 @@ stages:
   19:
     name: "Development Execution"
     consumes:
+      - stage: 17
+        fields:
+          buildReadiness: { type: object, required: false }
       - stage: 18
         fields:
           items: { type: array, minItems: 1 }
@@ -225,26 +361,50 @@ stages:
   20:
     name: "QA & Testing"
     consumes:
+      - stage: 18
+        fields:
+          items: { type: array }
       - stage: 19
         fields:
           tasks: { type: array }
     produces:
-      testResults: { type: object }
-      coverage: { type: number }
+      test_suites: { type: array, minItems: 1 }
+      quality_gate_passed: { type: boolean }
 
   21:
-    name: "Launch Prep"
-    consumes: []
+    name: "Build Review"
+    consumes:
+      - stage: 19
+        fields:
+          tasks: { type: array }
+      - stage: 20
+        fields:
+          test_suites: { type: array }
     produces:
-      deployment_plan: { type: string, minLength: 20 }
-      monitoring_setup: { type: string }
+      integrations: { type: array }
+      environment: { type: object }
+      reviewDecision: { type: object }
 
   22:
     name: "Go-Live"
     consumes:
+      - stage: 17
+        fields:
+          readiness_pct: { type: number }
+      - stage: 18
+        fields:
+          items: { type: array }
+      - stage: 19
+        fields:
+          tasks: { type: array }
+      - stage: 20
+        fields:
+          test_suites: { type: array }
+          quality_gate_passed: { type: boolean, required: false }
       - stage: 21
         fields:
-          deployment_plan: { type: string }
+          integrations: { type: array }
+          reviewDecision: { type: object, required: false }
     produces:
       launch_date: { type: string }
       launch_status: { type: string }
@@ -252,6 +412,9 @@ stages:
   23:
     name: "Post-Launch Ops"
     consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
       - stage: 22
         fields:
           launch_status: { type: string }
@@ -261,14 +424,38 @@ stages:
 
   24:
     name: "Growth Operations"
-    consumes: []
+    consumes:
+      - stage: 5
+        fields:
+          unitEconomics: { type: object }
+      - stage: 23
+        fields:
+          incident_response_plan: { type: string, required: false }
     produces:
       growth_metrics: { type: object }
       optimization_plan: { type: string }
 
   25:
     name: "Portfolio Review"
-    consumes: []
+    consumes:
+      - stage: 1
+        fields:
+          description: { type: string }
+      - stage: 5
+        fields:
+          unitEconomics: { type: object }
+      - stage: 13
+        fields:
+          milestones: { type: array }
+      - stage: 16
+        fields:
+          runway_months: { type: number }
+      - stage: 23
+        fields:
+          incident_response_plan: { type: string, required: false }
+      - stage: 24
+        fields:
+          growth_metrics: { type: object }
     produces:
       venture_decision: { type: string }
       portfolio_score: { type: number }

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { stageRegistry } from './stage-registry.js';
 import { CROSS_STAGE_DEPS, validatePreStage, CONTRACT_ENFORCEMENT } from './contracts/stage-contracts.js';
+import { waitForDecision } from './chairman-decision-watcher.js';
 
 dotenv.config();
 
@@ -270,6 +271,17 @@ export async function executeStage(options = {}) {
     };
   }
 
+  // 3.5. Call onBeforeAnalysis hook if defined (chairman gates, etc.)
+  let beforeAnalysisContext = {};
+  if (typeof template.onBeforeAnalysis === 'function') {
+    try {
+      beforeAnalysisContext = await template.onBeforeAnalysis(supabase, ventureId) || {};
+      logger.log(`   onBeforeAnalysis: ${JSON.stringify(beforeAnalysisContext).substring(0, 120)}`);
+    } catch (err) {
+      logger.warn(`   ⚠️ onBeforeAnalysis failed: ${err.message}`);
+    }
+  }
+
   // 4. Execute analysisStep
   let output;
   const hasAnalysisStep = typeof template.analysisStep === 'function';
@@ -278,6 +290,7 @@ export async function executeStage(options = {}) {
     try {
       output = await template.analysisStep({
         ...upstreamData,
+        ...beforeAnalysisContext,
         logger,
         ventureName: ventureId,
       });
@@ -288,6 +301,27 @@ export async function executeStage(options = {}) {
     output = template.computeDerived(template.defaultData || {}, upstreamData, { logger });
   } else {
     output = template.defaultData || {};
+  }
+
+  // 4.5. Resolve chairman gate if onBeforeAnalysis created a pending decision
+  if (beforeAnalysisContext.chairmanDecisionId && output) {
+    try {
+      const decisionResult = await waitForDecision({
+        decisionId: beforeAnalysisContext.chairmanDecisionId,
+        supabase,
+        logger,
+        timeoutMs: 5000, // Short timeout — decision should already exist
+      });
+      output.chairmanGate = {
+        status: decisionResult.status,
+        rationale: decisionResult.rationale,
+        decision_id: beforeAnalysisContext.chairmanDecisionId,
+      };
+      logger.log(`   Chairman gate resolved: ${decisionResult.status}`);
+    } catch (err) {
+      logger.warn(`   ⚠️ Chairman gate resolution failed: ${err.message}`);
+      output.chairmanGate = { status: 'pending', rationale: null, decision_id: beforeAnalysisContext.chairmanDecisionId };
+    }
   }
 
   // 5. Validate output

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -140,7 +140,7 @@ export class AnthropicAdapter {
         // Build request params
         const requestParams = {
           model,
-          max_tokens: options.maxTokens || options.max_tokens || 2000,
+          max_tokens: options.maxTokens || options.max_tokens || 8192,
           system: sanitizeUnicode(systemPrompt),
           messages: [{ role: 'user', content: sanitizeUnicode(userPrompt) }]
         };
@@ -263,7 +263,7 @@ export class OpenAIAdapter {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), options.timeout || PROVIDER_TIMEOUT_MS);
 
-        const maxTokens = options.maxTokens || options.max_tokens || 2000;
+        const maxTokens = options.maxTokens || options.max_tokens || 8192;
         const requestBody = {
             model,
             max_completion_tokens: maxTokens,
@@ -374,7 +374,7 @@ export class GoogleAdapter {
 
         // Build generationConfig
         const generationConfig = {
-          maxOutputTokens: options.maxTokens || options.max_tokens || 2000
+          maxOutputTokens: options.maxTokens || options.max_tokens || 8192
         };
 
         // Temperature support
@@ -542,7 +542,7 @@ export class OllamaAdapter {
           },
           body: JSON.stringify({
             model,
-            max_tokens: options.maxTokens || options.max_tokens || 2000,
+            max_tokens: options.maxTokens || options.max_tokens || 8192,
             temperature: options.temperature ?? 0.1,
             messages: [
               { role: 'system', content: sanitizeUnicode(systemPrompt) },

--- a/scripts/temp/run-stage.mjs
+++ b/scripts/temp/run-stage.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Execute a single EVA stage for a venture.
+ * Usage: node scripts/temp/run-stage.mjs <stageNumber>
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { executeStage } from '../../lib/eva/stage-execution-engine.js';
+
+const VENTURE_ID = 'd2195c98-b584-428b-9acc-e86dea125fa9';
+const stageNumber = parseInt(process.argv[2], 10);
+
+if (!stageNumber || stageNumber < 1 || stageNumber > 25) {
+  console.error('Usage: node scripts/temp/run-stage.mjs <stageNumber 1-25>');
+  process.exit(1);
+}
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function run() {
+  // Advance venture to this stage
+  const { error: advErr } = await supabase.from('ventures')
+    .update({ current_lifecycle_stage: stageNumber })
+    .eq('id', VENTURE_ID);
+  if (advErr) throw new Error(`Failed to advance venture: ${advErr.message}`);
+
+  console.log(`\n=== Executing Stage ${stageNumber} ===`);
+  const result = await executeStage({
+    stageNumber,
+    ventureId: VENTURE_ID,
+    dryRun: false,
+    supabase,
+  });
+
+  const output = result.output || {};
+  const SKIP_KEYS = ['sourceProvenance', 'fourBuckets'];
+  const keys = Object.keys(output).filter(k => !SKIP_KEYS.includes(k));
+
+  console.log(`Stage ${stageNumber}: SUCCESS`);
+  console.log(`  Output keys: ${keys.join(', ')}`);
+  if (output.decision) console.log(`  Decision: ${output.decision}`);
+  if (output.overallScore !== undefined) console.log(`  Overall Score: ${output.overallScore}`);
+  if (output.aggregate_risk_score !== undefined) console.log(`  Aggregate Risk Score: ${output.aggregate_risk_score}`);
+  if (output.readiness_pct !== undefined) console.log(`  Readiness %: ${output.readiness_pct}`);
+  if (output.runway_months !== undefined) console.log(`  Runway Months: ${output.runway_months}`);
+  if (output.total_story_points !== undefined) console.log(`  Story Points: ${output.total_story_points}`);
+  if (output.portfolio_score !== undefined) console.log(`  Portfolio Score: ${output.portfolio_score}`);
+  if (output.promotion_gate) console.log(`  Promotion Gate Pass: ${output.promotion_gate.pass}`);
+  if (output.reality_gate) console.log(`  Reality Gate Pass: ${output.reality_gate.pass}`);
+
+  return result;
+}
+
+run().catch(err => {
+  console.error(`\nStage ${stageNumber} FAILED:`, err.message);
+  if (err.stack) console.error(err.stack.substring(0, 500));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- **onBeforeAnalysis dead code**: 3 stages (10, 22, 25) defined chairman gate hooks that the execution engine never called. Added step 3.5 (hook invocation) and step 4.5 (chairman gate resolution) to `stage-execution-engine.js`
- **Chairman decision duplication**: `createOrReusePendingDecision` now checks for approved decisions first before creating pending ones
- **Contract type mismatches**: Fixed stages 20-22 JS contracts — wrong field names and types vs actual outputs (e.g. `quality_gate_passed` was `object`, actually `boolean`)
- **LLM max_tokens too low**: Default 2000→8192 across all 4 provider adapters to prevent truncated analysis
- **CROSS_STAGE_DEPS rewrite**: Complete dependency map for all 25 stages
- **YAML contract alignment**: Stages 20-22 field names and types corrected

## Test plan
- [x] Full 25-stage UAT: NicheBrief AI venture executed stages 0-25 with all artifacts persisted (26 artifacts verified)
- [x] Smoke tests pass (15/15)
- [x] Contract validation passes for all stages
- [x] Chairman gates resolve correctly for stages 10, 22, 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)