### PR TITLE
fix: increase Stage Zero LLM token budgets for Gemini 2.5 thinking overhead

### DIFF
--- a/lib/eva/stage-zero/modeling.js
+++ b/lib/eva/stage-zero/modeling.js
@@ -90,7 +90,8 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 2000, timeout: 120000 });
+    // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);
     if (jsonMatch) {

--- a/lib/eva/stage-zero/paths/competitor-teardown.js
+++ b/lib/eva/stage-zero/paths/competitor-teardown.js
@@ -166,7 +166,8 @@ Return a JSON object with these fields:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 2000, timeout: 120000 });
+    // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);
     if (jsonMatch) {
@@ -226,7 +227,8 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 2000, timeout: 120000 });
+    // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);
     if (jsonMatch) {
@@ -278,7 +280,8 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);
     if (jsonMatch) {

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -356,7 +356,8 @@ Return a JSON array (only include ventures worth reviving, up to ${candidateCoun
 If no ventures are worth reviving, return an empty array: []`;
 
   try {
-    const text = await client.complete('', prompt, { max_tokens: 2000, timeout: 120000 });
+    // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
+    const text = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const content = typeof text === 'string' ? text : (text?.content || text?.choices?.[0]?.message?.content || '');
     const jsonMatch = content.match(/\[[\s\S]*\]/);
     if (jsonMatch) {
@@ -367,7 +368,7 @@ If no ventures are worth reviving, return an empty array: []`;
         automation_feasibility: c.automation_feasibility || c.new_score || 5,
       }));
     }
-    logger.warn('   Warning: Could not parse nursery re-evaluation response');
+    logger.warn(`   Warning: Could not parse nursery re-evaluation response (${content.length} chars)`);
     return [];
   } catch (err) {
     logger.warn(`   Warning: Nursery re-evaluation failed: ${err.message}`);
@@ -380,14 +381,22 @@ If no ventures are worth reviving, return an empty array: []`;
  */
 async function callLLMForCandidates(client, prompt, { logger = console, strategyName = 'unknown' } = {}) {
   try {
-    const raw = await client.complete('', prompt, { max_tokens: 3000, timeout: 120000 });
+    // 8192 minimum: Gemini 2.5 Pro uses ~3000 thinking tokens from the output budget
+    const raw = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const text = typeof raw === 'string' ? raw : (raw?.content || raw?.choices?.[0]?.message?.content || '');
+
+    if (!text || text.length < 10) {
+      const usage = raw?.usage || {};
+      logger.warn(`   Warning: ${strategyName} returned empty/truncated response (${text.length} chars). Usage: ${JSON.stringify(usage)}`);
+      return [];
+    }
+
     const jsonMatch = text.match(/\[[\s\S]*\]/);
     if (jsonMatch) {
       const parsed = JSON.parse(jsonMatch[0]);
       return parsed.map(c => ({ ...c, source: strategyName }));
     }
-    logger.warn(`   Warning: Could not parse ${strategyName} response`);
+    logger.warn(`   Warning: Could not parse ${strategyName} response (${text.length} chars, no JSON array found)`);
     return [];
   } catch (err) {
     logger.warn(`   Warning: ${strategyName} analysis failed: ${err.message}`);

--- a/lib/eva/stage-zero/synthesis/archetypes.js
+++ b/lib/eva/stage-zero/synthesis/archetypes.js
@@ -82,7 +82,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/attention-capital.js
+++ b/lib/eva/stage-zero/synthesis/attention-capital.js
@@ -111,7 +111,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/build-cost-estimation.js
+++ b/lib/eva/stage-zero/synthesis/build-cost-estimation.js
@@ -76,7 +76,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/cross-reference.js
+++ b/lib/eva/stage-zero/synthesis/cross-reference.js
@@ -237,7 +237,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/design-evaluation.js
+++ b/lib/eva/stage-zero/synthesis/design-evaluation.js
@@ -77,7 +77,7 @@ composite_score = weighted average of 6 dimensions * 10 (equal weights). Round t
 recommendation: design_led (composite >= 70), design_standard (40-69), design_minimal (< 40).`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/moat-architecture.js
+++ b/lib/eva/stage-zero/synthesis/moat-architecture.js
@@ -70,7 +70,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/narrative-risk.js
+++ b/lib/eva/stage-zero/synthesis/narrative-risk.js
@@ -103,7 +103,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/portfolio-evaluation.js
+++ b/lib/eva/stage-zero/synthesis/portfolio-evaluation.js
@@ -155,7 +155,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/problem-reframing.js
+++ b/lib/eva/stage-zero/synthesis/problem-reframing.js
@@ -82,7 +82,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 2000, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/tech-trajectory.js
+++ b/lib/eva/stage-zero/synthesis/tech-trajectory.js
@@ -124,7 +124,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 2000, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/time-horizon.js
+++ b/lib/eva/stage-zero/synthesis/time-horizon.js
@@ -64,7 +64,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);

--- a/lib/eva/stage-zero/synthesis/virality.js
+++ b/lib/eva/stage-zero/synthesis/virality.js
@@ -81,7 +81,7 @@ Return JSON:
 }`;
 
   try {
-    const response = await client.complete('', prompt, { max_tokens: 1500, timeout: 120000 });
+    const response = await client.complete('', prompt, { max_tokens: 8192, timeout: 120000 });
     const usage = extractUsage(response);
     const text = typeof response === 'string' ? response : (response?.content || '');
     const jsonMatch = text.match(/\{[\s\S]*\}/);


### PR DESCRIPTION
## Summary
- Gemini 2.5 Pro consumes ~3000 tokens from the shared `maxOutputTokens` budget for internal "thinking", leaving zero tokens for actual response content
- Root cause confirmed via RCA sub-agent with empirical Gemini API testing: `finishReason=MAX_TOKENS` with 2997/3000 tokens on thinking
- Increased `max_tokens` from 2000-3000 to 8192 across all 15 Stage Zero LLM call sites (discovery, competitor teardown, modeling, 12 synthesis components)
- Added truncation detection with usage metadata logging in `discovery-mode.js`

## Test plan
- [x] Full 25-stage E2E test (stages 0-25) passed with zero failures for "NicheSignal AI" venture
- [x] All 26 artifacts verified present and current
- [x] Gemini 429 rate limit handled by adapter retry logic (expected behavior)
- [x] grep confirms zero remaining low-budget values across Stage Zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)