### PR TITLE
feat: add Capability Contribution Score (CCS) module

### DIFF
--- a/database/migrations/20260304_venture_capability_scores.sql
+++ b/database/migrations/20260304_venture_capability_scores.sql
@@ -1,0 +1,89 @@
+-- =============================================================================
+-- Migration: Venture Capability Scores
+-- SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E
+-- Date: 2026-03-04
+-- Description: Creates venture_capability_scores table for the Capability
+--   Contribution Score (CCS) system. Stores per-stage dimension scores with
+--   rationale and cumulative aggregation. Supports cross-venture comparison.
+--
+-- Pre-requisites:
+--   - ventures table exists with id UUID PK
+--   - venture_artifacts table exists with id UUID PK
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS venture_capability_scores;
+-- =============================================================================
+
+-- Phase 1: Create table
+CREATE TABLE IF NOT EXISTS venture_capability_scores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id) ON DELETE CASCADE,
+  stage_number INTEGER NOT NULL CHECK (stage_number BETWEEN 0 AND 25),
+  dimension TEXT NOT NULL CHECK (dimension IN (
+    'technical_depth',
+    'market_validation',
+    'financial_rigor',
+    'operational_readiness',
+    'strategic_alignment'
+  )),
+  score NUMERIC(5,2) CHECK (score >= 0 AND score <= 100),
+  rationale TEXT CHECK (char_length(rationale) <= 200),
+  cumulative_score NUMERIC(5,2) CHECK (cumulative_score >= 0 AND cumulative_score <= 100),
+  artifact_id UUID REFERENCES venture_artifacts(id) ON DELETE SET NULL,
+  scored_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Phase 2: Unique constraint for idempotent upserts
+-- Re-scoring the same venture/stage/dimension replaces the previous score
+ALTER TABLE venture_capability_scores
+  DROP CONSTRAINT IF EXISTS uq_venture_stage_dimension;
+ALTER TABLE venture_capability_scores
+  ADD CONSTRAINT uq_venture_stage_dimension
+  UNIQUE (venture_id, stage_number, dimension);
+
+-- Phase 3: Indexes for query patterns
+CREATE INDEX IF NOT EXISTS idx_vcs_venture_dimension
+  ON venture_capability_scores (venture_id, dimension);
+
+CREATE INDEX IF NOT EXISTS idx_vcs_venture_stage
+  ON venture_capability_scores (venture_id, stage_number);
+
+CREATE INDEX IF NOT EXISTS idx_vcs_scored_at
+  ON venture_capability_scores (scored_at DESC);
+
+-- Phase 4: Enable RLS
+ALTER TABLE venture_capability_scores ENABLE ROW LEVEL SECURITY;
+
+-- Phase 5: RLS policies (matching venture_artifacts access pattern)
+DROP POLICY IF EXISTS vcs_select_policy ON venture_capability_scores;
+CREATE POLICY vcs_select_policy ON venture_capability_scores
+  FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS vcs_insert_policy ON venture_capability_scores;
+CREATE POLICY vcs_insert_policy ON venture_capability_scores
+  FOR INSERT WITH CHECK (true);
+
+DROP POLICY IF EXISTS vcs_update_policy ON venture_capability_scores;
+CREATE POLICY vcs_update_policy ON venture_capability_scores
+  FOR UPDATE USING (true);
+
+-- Phase 6: Updated_at trigger
+CREATE OR REPLACE FUNCTION fn_update_vcs_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_vcs_updated_at ON venture_capability_scores;
+CREATE TRIGGER trg_vcs_updated_at
+  BEFORE UPDATE ON venture_capability_scores
+  FOR EACH ROW
+  EXECUTE FUNCTION fn_update_vcs_updated_at();
+
+-- Phase 7: Comment
+COMMENT ON TABLE venture_capability_scores IS
+  'Per-stage capability dimension scores for the CCS system. Each stage contributes weighted scores across 5 dimensions: technical_depth, market_validation, financial_rigor, operational_readiness, strategic_alignment.';

--- a/lib/eva/capability-score/__tests__/capability-score.test.js
+++ b/lib/eva/capability-score/__tests__/capability-score.test.js
@@ -1,0 +1,531 @@
+/**
+ * Unit Tests — Capability Contribution Score (CCS)
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E
+ *
+ * Covers: stage-capability-weights, score-stage, cumulative-profile, compare-ventures
+ */
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+
+// ─── stage-capability-weights ───────────────────────────────────────
+
+import {
+  DIMENSIONS,
+  STAGE_DIMENSION_WEIGHTS,
+  DIMENSION_RUBRICS,
+  DIMENSION_OVERALL_WEIGHTS,
+} from '../stage-capability-weights.js';
+
+describe('stage-capability-weights', () => {
+  test('exports 5 dimensions', () => {
+    expect(DIMENSIONS).toHaveLength(5);
+    expect(DIMENSIONS).toContain('technical_depth');
+    expect(DIMENSIONS).toContain('market_validation');
+    expect(DIMENSIONS).toContain('financial_rigor');
+    expect(DIMENSIONS).toContain('operational_readiness');
+    expect(DIMENSIONS).toContain('strategic_alignment');
+  });
+
+  test('covers all 25 stages', () => {
+    for (let s = 1; s <= 25; s++) {
+      expect(STAGE_DIMENSION_WEIGHTS[s]).toBeDefined();
+    }
+  });
+
+  test('each stage weight sums to 1.0', () => {
+    for (let s = 1; s <= 25; s++) {
+      const sum = Object.values(STAGE_DIMENSION_WEIGHTS[s]).reduce((a, b) => a + b, 0);
+      expect(Math.abs(sum - 1.0)).toBeLessThan(0.001);
+    }
+  });
+
+  test('each stage has all 5 dimensions', () => {
+    for (let s = 1; s <= 25; s++) {
+      for (const dim of DIMENSIONS) {
+        expect(STAGE_DIMENSION_WEIGHTS[s][dim]).toBeDefined();
+      }
+    }
+  });
+
+  test('overall weights sum to 1.0', () => {
+    const sum = Object.values(DIMENSION_OVERALL_WEIGHTS).reduce((a, b) => a + b, 0);
+    expect(Math.abs(sum - 1.0)).toBeLessThan(0.001);
+  });
+
+  test('rubrics exist for all dimensions', () => {
+    for (const dim of DIMENSIONS) {
+      expect(DIMENSION_RUBRICS[dim]).toBeDefined();
+      expect(typeof DIMENSION_RUBRICS[dim]).toBe('string');
+      expect(DIMENSION_RUBRICS[dim].length).toBeGreaterThan(50);
+    }
+  });
+
+  test('stage 1 emphasizes strategic_alignment and market_validation', () => {
+    const s1 = STAGE_DIMENSION_WEIGHTS[1];
+    expect(s1.strategic_alignment).toBeGreaterThanOrEqual(0.30);
+    expect(s1.market_validation).toBeGreaterThanOrEqual(0.30);
+  });
+
+  test('stage 18 emphasizes technical_depth', () => {
+    const s18 = STAGE_DIMENSION_WEIGHTS[18];
+    expect(s18.technical_depth).toBeGreaterThanOrEqual(0.35);
+  });
+});
+
+// ─── score-stage ────────────────────────────────────────────────────
+
+import { computeCapabilityScore } from '../score-stage.js';
+
+function mockLLMClient(response) {
+  return {
+    complete: vi.fn().mockResolvedValue(response),
+  };
+}
+
+function mockSupabase(upsertResult = { error: null }) {
+  return {
+    from: vi.fn().mockReturnValue({
+      upsert: vi.fn().mockResolvedValue(upsertResult),
+    }),
+  };
+}
+
+const MOCK_SCORES_RESPONSE = JSON.stringify({
+  scores: {
+    technical_depth: { score: 72, rationale: 'Good architecture choices' },
+    market_validation: { score: 65, rationale: 'Reasonable market evidence' },
+    financial_rigor: { score: 58, rationale: 'Basic financial model' },
+    operational_readiness: { score: 45, rationale: 'Minimal ops planning' },
+    strategic_alignment: { score: 80, rationale: 'Strong vision alignment' },
+  },
+});
+
+describe('computeCapabilityScore', () => {
+  const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+  test('returns null for null/undefined artifact', async () => {
+    const result = await computeCapabilityScore(1, null, { logger: silentLogger });
+    expect(result).toBeNull();
+  });
+
+  test('returns null for non-object artifact', async () => {
+    const result = await computeCapabilityScore(1, 'string', { logger: silentLogger });
+    expect(result).toBeNull();
+  });
+
+  test('returns null for unknown stage (no weight config)', async () => {
+    const result = await computeCapabilityScore(99, { data: 'test' }, { logger: silentLogger });
+    expect(result).toBeNull();
+  });
+
+  test('scores artifact with mock LLM and returns all 5 dimensions', async () => {
+    const llmClient = mockLLMClient(MOCK_SCORES_RESPONSE);
+    const result = await computeCapabilityScore(1, { description: 'Test venture idea' }, {
+      ventureId: 'v-001',
+      artifactId: 'a-001',
+      llmClient,
+      logger: silentLogger,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result.stageNumber).toBe(1);
+    expect(result.ventureId).toBe('v-001');
+    expect(result.scores.technical_depth.score).toBe(72);
+    expect(result.scores.market_validation.score).toBe(65);
+    expect(result.scores.financial_rigor.score).toBe(58);
+    expect(result.scores.operational_readiness.score).toBe(45);
+    expect(result.scores.strategic_alignment.score).toBe(80);
+    expect(result.scoredAt).toBeDefined();
+  });
+
+  test('clamps scores to 0-100 range', async () => {
+    const response = JSON.stringify({
+      scores: {
+        technical_depth: { score: 150, rationale: 'Over max' },
+        market_validation: { score: -10, rationale: 'Under min' },
+        financial_rigor: { score: 50, rationale: 'Normal' },
+        operational_readiness: { score: 100, rationale: 'Max' },
+        strategic_alignment: { score: 0, rationale: 'Min' },
+      },
+    });
+    const result = await computeCapabilityScore(1, { data: 'test' }, {
+      ventureId: 'v-001',
+      llmClient: mockLLMClient(response),
+      logger: silentLogger,
+    });
+
+    expect(result.scores.technical_depth.score).toBe(100);
+    expect(result.scores.market_validation.score).toBe(0);
+    expect(result.scores.financial_rigor.score).toBe(50);
+  });
+
+  test('handles missing dimension in LLM response gracefully', async () => {
+    const response = JSON.stringify({
+      scores: {
+        technical_depth: { score: 70, rationale: 'ok' },
+        // Missing other dimensions
+      },
+    });
+    const result = await computeCapabilityScore(1, { data: 'test' }, {
+      ventureId: 'v-001',
+      llmClient: mockLLMClient(response),
+      logger: silentLogger,
+    });
+
+    expect(result.scores.technical_depth.score).toBe(70);
+    expect(result.scores.market_validation.score).toBeNull();
+  });
+
+  test('persists scores via UPSERT when supabase provided', async () => {
+    const supabase = mockSupabase();
+    const result = await computeCapabilityScore(1, { data: 'test' }, {
+      ventureId: 'v-001',
+      artifactId: 'a-001',
+      supabase,
+      llmClient: mockLLMClient(MOCK_SCORES_RESPONSE),
+      logger: silentLogger,
+    });
+
+    expect(result).not.toBeNull();
+    expect(supabase.from).toHaveBeenCalledWith('venture_capability_scores');
+  });
+
+  test('returns null when LLM throws (non-blocking)', async () => {
+    const failingClient = {
+      complete: vi.fn().mockRejectedValue(new Error('LLM unavailable')),
+    };
+    const result = await computeCapabilityScore(1, { data: 'test' }, {
+      ventureId: 'v-001',
+      llmClient: failingClient,
+      logger: silentLogger,
+    });
+
+    expect(result).toBeNull();
+    expect(silentLogger.warn).toHaveBeenCalled();
+  });
+
+  test('returns null when LLM response has no scores object', async () => {
+    const result = await computeCapabilityScore(1, { data: 'test' }, {
+      ventureId: 'v-001',
+      llmClient: mockLLMClient(JSON.stringify({ invalid: true })),
+      logger: silentLogger,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test('truncates rationale to 200 characters', async () => {
+    const longRationale = 'A'.repeat(300);
+    const response = JSON.stringify({
+      scores: {
+        technical_depth: { score: 70, rationale: longRationale },
+        market_validation: { score: 60, rationale: 'ok' },
+        financial_rigor: { score: 50, rationale: 'ok' },
+        operational_readiness: { score: 40, rationale: 'ok' },
+        strategic_alignment: { score: 80, rationale: 'ok' },
+      },
+    });
+    const result = await computeCapabilityScore(1, { data: 'test' }, {
+      ventureId: 'v-001',
+      llmClient: mockLLMClient(response),
+      logger: silentLogger,
+    });
+
+    expect(result.scores.technical_depth.rationale.length).toBeLessThanOrEqual(200);
+  });
+});
+
+// ─── cumulative-profile ─────────────────────────────────────────────
+
+import { getCumulativeProfile, getGateContext } from '../cumulative-profile.js';
+
+function mockSupabaseQuery(data, error = null) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockReturnValue({
+            lte: vi.fn().mockResolvedValue({ data, error }),
+            then: (fn) => fn({ data, error }),
+          }),
+          lte: vi.fn().mockReturnValue({
+            then: (fn) => fn({ data, error }),
+          }),
+          then: (fn) => fn({ data, error }),
+        }),
+        lte: vi.fn().mockReturnValue({
+          then: (fn) => fn({ data, error }),
+        }),
+        then: (fn) => fn({ data, error }),
+      }),
+    }),
+  };
+}
+
+describe('getCumulativeProfile', () => {
+  const silentLogger = { log: vi.fn(), warn: vi.fn() };
+
+  test('returns empty profile when no scores exist', async () => {
+    // Build a properly chained mock for: .from().select().eq().order()
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({
+              lte: vi.fn().mockResolvedValue({ data: [], error: null }),
+              then: (fn) => Promise.resolve(fn({ data: [], error: null })),
+            }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await getCumulativeProfile('v-001', { supabase });
+
+    expect(result.ventureId).toBe('v-001');
+    expect(result.overall).toBeNull();
+    expect(result.stagesScored).toBe(0);
+    expect(result.gaps).toEqual([]);
+  });
+
+  test('computes weighted cumulative from scored data', async () => {
+    const data = [
+      { stage_number: 1, dimension: 'technical_depth', score: 70, rationale: 'ok', scored_at: '2026-01-01' },
+      { stage_number: 1, dimension: 'market_validation', score: 80, rationale: 'ok', scored_at: '2026-01-01' },
+      { stage_number: 1, dimension: 'financial_rigor', score: 40, rationale: 'ok', scored_at: '2026-01-01' },
+      { stage_number: 1, dimension: 'operational_readiness', score: 50, rationale: 'ok', scored_at: '2026-01-01' },
+      { stage_number: 1, dimension: 'strategic_alignment', score: 90, rationale: 'ok', scored_at: '2026-01-01' },
+    ];
+
+    const orderMock = vi.fn().mockResolvedValue({ data, error: null });
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: orderMock,
+          }),
+        }),
+      }),
+    };
+
+    const result = await getCumulativeProfile('v-001', { supabase });
+
+    expect(result.ventureId).toBe('v-001');
+    expect(result.stagesScored).toBe(1);
+    expect(result.overall).not.toBeNull();
+    expect(result.overall).toBeGreaterThan(0);
+    // financial_rigor at 40 should be a gap (< 40 threshold)
+    // Actually 40 is not < 40, it's equal, so no gap
+    expect(result.dimensions.technical_depth.cumulative).toBe(70);
+    expect(result.dimensions.market_validation.cumulative).toBe(80);
+  });
+
+  test('detects capability gaps below 40', async () => {
+    const data = [
+      { stage_number: 1, dimension: 'technical_depth', score: 30, rationale: 'weak', scored_at: '2026-01-01' },
+      { stage_number: 1, dimension: 'market_validation', score: 80, rationale: 'ok', scored_at: '2026-01-01' },
+      { stage_number: 1, dimension: 'financial_rigor', score: 20, rationale: 'missing', scored_at: '2026-01-01' },
+      { stage_number: 1, dimension: 'operational_readiness', score: 60, rationale: 'ok', scored_at: '2026-01-01' },
+      { stage_number: 1, dimension: 'strategic_alignment', score: 75, rationale: 'ok', scored_at: '2026-01-01' },
+    ];
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data, error: null }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await getCumulativeProfile('v-001', { supabase });
+
+    expect(result.gaps).toHaveLength(2);
+    expect(result.gaps.map(g => g.dimension)).toContain('technical_depth');
+    expect(result.gaps.map(g => g.dimension)).toContain('financial_rigor');
+  });
+
+  test('computes trend from 2+ scores in same dimension', async () => {
+    const data = [
+      { stage_number: 1, dimension: 'technical_depth', score: 50, rationale: 'ok', scored_at: '2026-01-01' },
+      { stage_number: 2, dimension: 'technical_depth', score: 70, rationale: 'better', scored_at: '2026-01-02' },
+    ];
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data, error: null }),
+          }),
+        }),
+      }),
+    };
+
+    const result = await getCumulativeProfile('v-001', { supabase });
+
+    expect(result.dimensions.technical_depth.trend).toBe('improving');
+  });
+
+  test('throws on query error', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB error' } }),
+          }),
+        }),
+      }),
+    };
+
+    await expect(getCumulativeProfile('v-001', { supabase }))
+      .rejects.toThrow('Failed to fetch capability scores');
+  });
+});
+
+// ─── compare-ventures ───────────────────────────────────────────────
+
+import { compareVentures } from '../compare-ventures.js';
+
+describe('compareVentures', () => {
+  test('returns empty when no data', async () => {
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          then: (fn) => Promise.resolve(fn({ data: [], error: null })),
+        }),
+      }),
+    };
+
+    const result = await compareVentures({ supabase });
+
+    expect(result.ventures).toEqual([]);
+    expect(result.sortBy).toBe('overall');
+  });
+
+  test('ranks ventures by overall score descending', async () => {
+    const data = [
+      { venture_id: 'v-1', stage_number: 1, dimension: 'technical_depth', score: 90 },
+      { venture_id: 'v-1', stage_number: 1, dimension: 'market_validation', score: 85 },
+      { venture_id: 'v-1', stage_number: 1, dimension: 'financial_rigor', score: 80 },
+      { venture_id: 'v-1', stage_number: 1, dimension: 'operational_readiness', score: 75 },
+      { venture_id: 'v-1', stage_number: 1, dimension: 'strategic_alignment', score: 70 },
+      { venture_id: 'v-2', stage_number: 1, dimension: 'technical_depth', score: 40 },
+      { venture_id: 'v-2', stage_number: 1, dimension: 'market_validation', score: 35 },
+      { venture_id: 'v-2', stage_number: 1, dimension: 'financial_rigor', score: 30 },
+      { venture_id: 'v-2', stage_number: 1, dimension: 'operational_readiness', score: 25 },
+      { venture_id: 'v-2', stage_number: 1, dimension: 'strategic_alignment', score: 20 },
+    ];
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockResolvedValue({ data, error: null }),
+      }),
+    };
+
+    const result = await compareVentures({ supabase });
+
+    expect(result.ventures).toHaveLength(2);
+    expect(result.ventures[0].ventureId).toBe('v-1');
+    expect(result.ventures[1].ventureId).toBe('v-2');
+    expect(result.ventures[0].rank).toBe(1);
+    expect(result.ventures[1].rank).toBe(2);
+    expect(result.ventures[0].overall).toBeGreaterThan(result.ventures[1].overall);
+  });
+
+  test('sorts by specific dimension', async () => {
+    const data = [
+      { venture_id: 'v-1', stage_number: 1, dimension: 'technical_depth', score: 40 },
+      { venture_id: 'v-1', stage_number: 1, dimension: 'market_validation', score: 90 },
+      { venture_id: 'v-2', stage_number: 1, dimension: 'technical_depth', score: 80 },
+      { venture_id: 'v-2', stage_number: 1, dimension: 'market_validation', score: 50 },
+    ];
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockResolvedValue({ data, error: null }),
+      }),
+    };
+
+    const result = await compareVentures({ supabase, sortBy: 'technical_depth' });
+
+    expect(result.ventures[0].ventureId).toBe('v-2'); // TD=80 > TD=40
+    expect(result.sortBy).toBe('technical_depth');
+  });
+
+  test('rejects invalid sortBy dimension', async () => {
+    const supabase = { from: vi.fn() };
+    await expect(compareVentures({ supabase, sortBy: 'invalid_dim' }))
+      .rejects.toThrow('Invalid sortBy');
+  });
+
+  test('applies limit', async () => {
+    const data = [];
+    for (let i = 0; i < 10; i++) {
+      for (const dim of DIMENSIONS) {
+        data.push({ venture_id: `v-${i}`, stage_number: 1, dimension: dim, score: 50 + i });
+      }
+    }
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockResolvedValue({ data, error: null }),
+      }),
+    };
+
+    const result = await compareVentures({ supabase, limit: 3 });
+
+    expect(result.ventures).toHaveLength(3);
+    expect(result.totalVentures).toBe(10);
+  });
+
+  test('applies stage range filters', async () => {
+    const data = [
+      { venture_id: 'v-1', stage_number: 3, dimension: 'technical_depth', score: 70 },
+    ];
+
+    const gteMock = vi.fn().mockReturnThis();
+    const lteMock = vi.fn().mockResolvedValue({ data, error: null });
+
+    const supabase = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          gte: gteMock,
+          lte: lteMock,
+        }),
+      }),
+    };
+
+    // When stageMin is provided, gte is called
+    const selectReturnValue = {
+      gte: vi.fn().mockReturnValue({
+        lte: vi.fn().mockResolvedValue({ data, error: null }),
+      }),
+    };
+    const supabase2 = {
+      from: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue(selectReturnValue),
+      }),
+    };
+
+    const result = await compareVentures({ supabase: supabase2, stageMin: 2, stageMax: 5 });
+
+    expect(selectReturnValue.gte).toHaveBeenCalledWith('stage_number', 2);
+  });
+});
+
+// ─── barrel export ──────────────────────────────────────────────────
+
+describe('index barrel export', () => {
+  test('re-exports all public APIs', async () => {
+    const barrel = await import('../index.js');
+
+    expect(barrel.computeCapabilityScore).toBeDefined();
+    expect(barrel.getCumulativeProfile).toBeDefined();
+    expect(barrel.getGateContext).toBeDefined();
+    expect(barrel.compareVentures).toBeDefined();
+    expect(barrel.DIMENSIONS).toBeDefined();
+    expect(barrel.STAGE_DIMENSION_WEIGHTS).toBeDefined();
+    expect(barrel.DIMENSION_RUBRICS).toBeDefined();
+    expect(barrel.DIMENSION_OVERALL_WEIGHTS).toBeDefined();
+  });
+});

--- a/lib/eva/capability-score/__tests__/ccs-integration.test.js
+++ b/lib/eva/capability-score/__tests__/ccs-integration.test.js
@@ -1,0 +1,59 @@
+/**
+ * Integration Tests — CCS hook in stage-execution-engine
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E
+ *
+ * Verifies CCS is invoked as a non-blocking post-analysis hook
+ * and that stage execution still works if CCS module is unavailable.
+ */
+import { describe, test, expect, vi } from 'vitest';
+import { validateOutput } from '../../stage-execution-engine.js';
+
+describe('validateOutput (stage-execution-engine)', () => {
+  test('returns valid:true when template has no validate function', () => {
+    const result = validateOutput({ some: 'data' }, {});
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('returns validation result from template.validate()', () => {
+    const template = {
+      validate: vi.fn().mockReturnValue({ valid: true, errors: [] }),
+    };
+    const result = validateOutput({ some: 'data' }, template);
+    expect(result.valid).toBe(true);
+    expect(template.validate).toHaveBeenCalled();
+  });
+
+  test('catches validation errors and returns valid:false', () => {
+    const template = {
+      validate: vi.fn().mockImplementation(() => { throw new Error('boom'); }),
+    };
+    const result = validateOutput({ some: 'data' }, template);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain('boom');
+  });
+});
+
+describe('CCS hook backward compatibility', () => {
+  test('dynamic import of score-stage.js resolves', async () => {
+    const mod = await import('../score-stage.js');
+    expect(typeof mod.computeCapabilityScore).toBe('function');
+  });
+
+  test('CCS failure does not throw (non-blocking pattern)', async () => {
+    const { computeCapabilityScore } = await import('../score-stage.js');
+
+    // Simulate LLM failure — should return null, not throw
+    const failClient = {
+      complete: vi.fn().mockRejectedValue(new Error('LLM down')),
+    };
+
+    const result = await computeCapabilityScore(1, { data: 'test' }, {
+      ventureId: 'v-001',
+      llmClient: failClient,
+      logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    expect(result).toBeNull(); // Non-blocking: null, not thrown
+  });
+});

--- a/lib/eva/capability-score/compare-ventures.js
+++ b/lib/eva/capability-score/compare-ventures.js
@@ -1,0 +1,135 @@
+/**
+ * Capability Contribution Score — Cross-Venture Comparison
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E: FR-005
+ *
+ * Compares capability profiles across multiple ventures.
+ * Returns ranked list by overall CCS or specific dimension.
+ * Supports filtering by stage range and sorting by any dimension.
+ */
+
+import {
+  DIMENSIONS,
+  DIMENSION_OVERALL_WEIGHTS,
+} from './stage-capability-weights.js';
+
+/**
+ * Compare ventures by their capability profiles.
+ *
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @param {string} [deps.sortBy='overall'] - 'overall' or a dimension name
+ * @param {number} [deps.stageMin] - Minimum stage number (inclusive)
+ * @param {number} [deps.stageMax] - Maximum stage number (inclusive)
+ * @param {string[]} [deps.ventureIds] - Specific venture IDs to compare (omit for all)
+ * @param {number} [deps.limit=50] - Max ventures to return
+ * @returns {Promise<Object>} Ranked comparison result
+ */
+export async function compareVentures(deps = {}) {
+  const {
+    supabase,
+    sortBy = 'overall',
+    stageMin,
+    stageMax,
+    ventureIds,
+    limit = 50,
+  } = deps;
+
+  // Validate sortBy
+  if (sortBy !== 'overall' && !DIMENSIONS.includes(sortBy)) {
+    throw new Error(`Invalid sortBy: ${sortBy}. Must be 'overall' or one of: ${DIMENSIONS.join(', ')}`);
+  }
+
+  // Build query
+  let query = supabase
+    .from('venture_capability_scores')
+    .select('venture_id, stage_number, dimension, score');
+
+  if (stageMin !== undefined) {
+    query = query.gte('stage_number', stageMin);
+  }
+  if (stageMax !== undefined) {
+    query = query.lte('stage_number', stageMax);
+  }
+  if (ventureIds && ventureIds.length > 0) {
+    query = query.in('venture_id', ventureIds);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Failed to fetch capability scores: ${error.message}`);
+  }
+
+  if (!data || data.length === 0) {
+    return { ventures: [], sortBy, stageRange: { min: stageMin, max: stageMax } };
+  }
+
+  // Group by venture_id
+  const ventureMap = {};
+  for (const row of data) {
+    if (!ventureMap[row.venture_id]) {
+      ventureMap[row.venture_id] = { scores: {}, stages: new Set() };
+    }
+    ventureMap[row.venture_id].stages.add(row.stage_number);
+
+    if (!ventureMap[row.venture_id].scores[row.dimension]) {
+      ventureMap[row.venture_id].scores[row.dimension] = [];
+    }
+    ventureMap[row.venture_id].scores[row.dimension].push(parseFloat(row.score));
+  }
+
+  // Compute averages per venture
+  const ventures = Object.entries(ventureMap).map(([ventureId, { scores, stages }]) => {
+    const dimensionAverages = {};
+    for (const dim of DIMENSIONS) {
+      const dimScores = scores[dim] || [];
+      dimensionAverages[dim] = dimScores.length > 0
+        ? Math.round((dimScores.reduce((a, b) => a + b, 0) / dimScores.length) * 100) / 100
+        : null;
+    }
+
+    // Overall CCS
+    let overallSum = 0;
+    let overallWeight = 0;
+    for (const dim of DIMENSIONS) {
+      if (dimensionAverages[dim] !== null) {
+        overallSum += dimensionAverages[dim] * DIMENSION_OVERALL_WEIGHTS[dim];
+        overallWeight += DIMENSION_OVERALL_WEIGHTS[dim];
+      }
+    }
+    const overall = overallWeight > 0
+      ? Math.round((overallSum / overallWeight) * 100) / 100
+      : null;
+
+    return {
+      ventureId,
+      overall,
+      dimensions: dimensionAverages,
+      stagesScored: stages.size,
+      maxStage: Math.max(...stages),
+    };
+  });
+
+  // Sort
+  ventures.sort((a, b) => {
+    const aVal = sortBy === 'overall' ? a.overall : a.dimensions[sortBy];
+    const bVal = sortBy === 'overall' ? b.overall : b.dimensions[sortBy];
+    if (aVal === null && bVal === null) return 0;
+    if (aVal === null) return 1;
+    if (bVal === null) return -1;
+    return bVal - aVal; // Descending
+  });
+
+  // Apply limit
+  const limited = ventures.slice(0, limit);
+
+  // Add rank
+  limited.forEach((v, i) => { v.rank = i + 1; });
+
+  return {
+    ventures: limited,
+    sortBy,
+    stageRange: { min: stageMin, max: stageMax },
+    totalVentures: ventures.length,
+  };
+}

--- a/lib/eva/capability-score/cumulative-profile.js
+++ b/lib/eva/capability-score/cumulative-profile.js
@@ -1,0 +1,238 @@
+/**
+ * Capability Contribution Score — Cumulative Profile Aggregation
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E: FR-003, FR-004
+ *
+ * Computes a running cumulative capability profile for a venture by
+ * aggregating scores across all completed stages.
+ *
+ * Cumulative score per dimension = weighted average of all stage scores.
+ * Overall CCS = weighted sum of dimension cumulative scores using DIMENSION_OVERALL_WEIGHTS.
+ */
+
+import {
+  DIMENSIONS,
+  STAGE_DIMENSION_WEIGHTS,
+  DIMENSION_OVERALL_WEIGHTS,
+} from './stage-capability-weights.js';
+
+/**
+ * Get the cumulative capability profile for a venture.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @param {number} [deps.upToStage] - Only include scores up to this stage (inclusive)
+ * @returns {Promise<Object>} Cumulative profile with dimensions, overall, trend
+ */
+export async function getCumulativeProfile(ventureId, deps = {}) {
+  const { supabase, upToStage } = deps;
+
+  let query = supabase
+    .from('venture_capability_scores')
+    .select('stage_number, dimension, score, rationale, scored_at')
+    .eq('venture_id', ventureId)
+    .order('stage_number', { ascending: true });
+
+  if (upToStage !== undefined) {
+    query = query.lte('stage_number', upToStage);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Failed to fetch capability scores: ${error.message}`);
+  }
+
+  if (!data || data.length === 0) {
+    return {
+      ventureId,
+      dimensions: {},
+      overall: null,
+      stagesScored: 0,
+      trend: {},
+      gaps: [],
+    };
+  }
+
+  // Group by dimension
+  const byDimension = {};
+  for (const dim of DIMENSIONS) {
+    byDimension[dim] = [];
+  }
+
+  for (const row of data) {
+    if (byDimension[row.dimension]) {
+      byDimension[row.dimension].push({
+        stage: row.stage_number,
+        score: parseFloat(row.score),
+        rationale: row.rationale,
+      });
+    }
+  }
+
+  // Compute weighted average per dimension
+  const dimensions = {};
+  for (const dim of DIMENSIONS) {
+    const entries = byDimension[dim];
+    if (entries.length === 0) {
+      dimensions[dim] = { cumulative: null, stageCount: 0, latest: null, trend: 'stable' };
+      continue;
+    }
+
+    // Weighted average: each stage's score is weighted by the stage's dimension weight
+    let weightedSum = 0;
+    let totalWeight = 0;
+    for (const entry of entries) {
+      const stageWeights = STAGE_DIMENSION_WEIGHTS[entry.stage];
+      const weight = stageWeights?.[dim] || 0;
+      weightedSum += entry.score * weight;
+      totalWeight += weight;
+    }
+
+    const cumulative = totalWeight > 0
+      ? Math.round((weightedSum / totalWeight) * 100) / 100
+      : null;
+
+    // Trend: compare last 2 scores
+    const trend = computeTrend(entries);
+    const latest = entries[entries.length - 1];
+
+    dimensions[dim] = {
+      cumulative,
+      stageCount: entries.length,
+      latest: latest?.score ?? null,
+      latestStage: latest?.stage ?? null,
+      trend,
+    };
+  }
+
+  // Overall CCS
+  let overallSum = 0;
+  let overallWeight = 0;
+  for (const dim of DIMENSIONS) {
+    if (dimensions[dim].cumulative !== null) {
+      overallSum += dimensions[dim].cumulative * DIMENSION_OVERALL_WEIGHTS[dim];
+      overallWeight += DIMENSION_OVERALL_WEIGHTS[dim];
+    }
+  }
+  const overall = overallWeight > 0
+    ? Math.round((overallSum / overallWeight) * 100) / 100
+    : null;
+
+  // Capability gaps (dimensions below 40)
+  const gaps = DIMENSIONS
+    .filter(dim => dimensions[dim].cumulative !== null && dimensions[dim].cumulative < 40)
+    .map(dim => ({
+      dimension: dim,
+      score: dimensions[dim].cumulative,
+      trend: dimensions[dim].trend,
+    }));
+
+  // Count unique stages scored
+  const stagesScored = new Set(data.map(r => r.stage_number)).size;
+
+  return {
+    ventureId,
+    dimensions,
+    overall,
+    stagesScored,
+    trend: computeOverallTrend(dimensions),
+    gaps,
+  };
+}
+
+/**
+ * Build gate context summary for chairman gate decisions.
+ * Includes dimension breakdown, trend arrows, gap warnings, and cohort comparison.
+ *
+ * @param {string} ventureId
+ * @param {Object} deps
+ * @param {Object} deps.supabase
+ * @param {number} deps.gateStage - The gate stage number
+ * @returns {Promise<Object>} Gate context with CCS summary
+ */
+export async function getGateContext(ventureId, deps = {}) {
+  const { supabase, gateStage } = deps;
+
+  const profile = await getCumulativeProfile(ventureId, { supabase, upToStage: gateStage });
+
+  // Get cohort average if 3+ ventures have scores
+  let cohortComparison = null;
+  try {
+    const { data: cohortData } = await supabase
+      .from('venture_capability_scores')
+      .select('venture_id, dimension, score')
+      .lte('stage_number', gateStage);
+
+    if (cohortData && cohortData.length > 0) {
+      const ventureIds = new Set(cohortData.map(r => r.venture_id));
+      if (ventureIds.size >= 3) {
+        const cohortAvg = {};
+        for (const dim of DIMENSIONS) {
+          const dimScores = cohortData.filter(r => r.dimension === dim);
+          if (dimScores.length > 0) {
+            cohortAvg[dim] = Math.round(
+              dimScores.reduce((sum, r) => sum + parseFloat(r.score), 0) / dimScores.length * 100
+            ) / 100;
+          }
+        }
+        cohortComparison = {
+          venturesInCohort: ventureIds.size,
+          averages: cohortAvg,
+        };
+      }
+    }
+  } catch {
+    // Non-blocking
+  }
+
+  const trendArrow = (trend) => {
+    if (trend === 'improving') return '\u2191'; // ↑
+    if (trend === 'declining') return '\u2193'; // ↓
+    return '\u2192'; // →
+  };
+
+  return {
+    ventureId,
+    gateStage,
+    overall: profile.overall,
+    dimensions: Object.fromEntries(
+      DIMENSIONS.map(dim => [dim, {
+        score: profile.dimensions[dim]?.cumulative,
+        trend: profile.dimensions[dim]?.trend,
+        arrow: trendArrow(profile.dimensions[dim]?.trend),
+        isGap: profile.dimensions[dim]?.cumulative !== null && profile.dimensions[dim]?.cumulative < 40,
+      }])
+    ),
+    gaps: profile.gaps,
+    stagesScored: profile.stagesScored,
+    cohortComparison,
+  };
+}
+
+/**
+ * Compute trend direction from a list of scored entries.
+ */
+function computeTrend(entries) {
+  if (entries.length < 2) return 'stable';
+  const recent = entries.slice(-2);
+  const diff = recent[1].score - recent[0].score;
+  if (diff > 5) return 'improving';
+  if (diff < -5) return 'declining';
+  return 'stable';
+}
+
+/**
+ * Compute overall trend from dimension trends.
+ */
+function computeOverallTrend(dimensions) {
+  let improving = 0;
+  let declining = 0;
+  for (const dim of DIMENSIONS) {
+    if (dimensions[dim]?.trend === 'improving') improving++;
+    if (dimensions[dim]?.trend === 'declining') declining++;
+  }
+  if (improving > declining + 1) return 'improving';
+  if (declining > improving + 1) return 'declining';
+  return 'stable';
+}

--- a/lib/eva/capability-score/index.js
+++ b/lib/eva/capability-score/index.js
@@ -1,0 +1,16 @@
+/**
+ * Capability Contribution Score — Public API
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E
+ *
+ * Barrel export for the CCS module.
+ */
+
+export { computeCapabilityScore } from './score-stage.js';
+export { getCumulativeProfile, getGateContext } from './cumulative-profile.js';
+export { compareVentures } from './compare-ventures.js';
+export {
+  DIMENSIONS,
+  STAGE_DIMENSION_WEIGHTS,
+  DIMENSION_RUBRICS,
+  DIMENSION_OVERALL_WEIGHTS,
+} from './stage-capability-weights.js';

--- a/lib/eva/capability-score/score-stage.js
+++ b/lib/eva/capability-score/score-stage.js
@@ -1,0 +1,182 @@
+/**
+ * Capability Contribution Score — Per-Stage Scoring Engine
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E: FR-002, TR-003
+ *
+ * Computes a 5-dimension capability score for a stage artifact using an LLM.
+ * Called as a post-analysis hook in executeStage() after validateOutput() succeeds.
+ *
+ * Design:
+ *   - Uses getValidationClient() (smaller/faster model) for scoring
+ *   - 30s timeout — non-blocking (failure does not block stage progression)
+ *   - Idempotent: re-running replaces previous scores via UPSERT
+ *   - Dependency injection for LLM client and Supabase (testable with mocks)
+ */
+
+import { getValidationClient } from '../../llm/client-factory.js';
+import { parseJSON, extractUsage } from '../utils/parse-json.js';
+import {
+  DIMENSIONS,
+  STAGE_DIMENSION_WEIGHTS,
+  DIMENSION_RUBRICS,
+} from './stage-capability-weights.js';
+
+const SCORING_TIMEOUT_MS = 30_000;
+
+/**
+ * Compute capability scores for a stage artifact.
+ *
+ * @param {number} stageNumber - Stage number (1-25)
+ * @param {Object} artifact - Stage output artifact data
+ * @param {Object} deps - Injected dependencies
+ * @param {string} deps.ventureId - Venture UUID
+ * @param {string} [deps.artifactId] - Artifact UUID (for FK reference)
+ * @param {Object} [deps.supabase] - Supabase client (required for persistence)
+ * @param {Object} [deps.llmClient] - LLM client override (for testing)
+ * @param {Object} [deps.logger] - Logger override
+ * @returns {Promise<Object|null>} Scoring result or null on failure
+ */
+export async function computeCapabilityScore(stageNumber, artifact, deps = {}) {
+  const {
+    ventureId,
+    artifactId = null,
+    supabase,
+    llmClient,
+    logger = console,
+  } = deps;
+
+  if (!artifact || typeof artifact !== 'object') {
+    logger.warn('   CCS: No artifact to score');
+    return null;
+  }
+
+  const stageWeights = STAGE_DIMENSION_WEIGHTS[stageNumber];
+  if (!stageWeights) {
+    logger.warn(`   CCS: No weight config for stage ${stageNumber}`);
+    return null;
+  }
+
+  const client = llmClient || getValidationClient();
+
+  // Build scoring prompt
+  const artifactSummary = JSON.stringify(artifact).substring(0, 3000);
+  const dimensionInstructions = DIMENSIONS.map(dim => {
+    const weight = stageWeights[dim];
+    return `- **${dim}** (weight: ${weight}): ${DIMENSION_RUBRICS[dim]}`;
+  }).join('\n');
+
+  const prompt = `You are an EHG venture capability evaluator. Score this Stage ${stageNumber} artifact across 5 capability dimensions.
+
+STAGE ARTIFACT (truncated):
+${artifactSummary}
+
+SCORING DIMENSIONS (each 0-100):
+${dimensionInstructions}
+
+INSTRUCTIONS:
+- Score each dimension 0-100 based on the artifact content
+- Provide a brief rationale for each score (max 200 characters)
+- Be calibrated: 50 = adequate, 70 = good, 90+ = exceptional
+- If the artifact has minimal content for a dimension, score lower but don't score 0 unless truly absent
+
+Respond with ONLY valid JSON in this exact format:
+{
+  "scores": {
+    "technical_depth": { "score": <0-100>, "rationale": "<max 200 chars>" },
+    "market_validation": { "score": <0-100>, "rationale": "<max 200 chars>" },
+    "financial_rigor": { "score": <0-100>, "rationale": "<max 200 chars>" },
+    "operational_readiness": { "score": <0-100>, "rationale": "<max 200 chars>" },
+    "strategic_alignment": { "score": <0-100>, "rationale": "<max 200 chars>" }
+  }
+}`;
+
+  // Execute with timeout
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SCORING_TIMEOUT_MS);
+
+  try {
+    const response = await client.complete(prompt, {
+      maxTokens: 1024,
+      temperature: 0.2,
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeout);
+
+    const parsed = parseJSON(response);
+    const usage = extractUsage(response);
+
+    if (!parsed?.scores) {
+      logger.warn('   CCS: LLM response missing scores object');
+      return null;
+    }
+
+    // Validate and normalize scores
+    const scores = {};
+    for (const dim of DIMENSIONS) {
+      const entry = parsed.scores[dim];
+      if (!entry || typeof entry.score !== 'number') {
+        logger.warn(`   CCS: Missing or invalid score for ${dim}`);
+        scores[dim] = { score: null, rationale: null };
+        continue;
+      }
+      scores[dim] = {
+        score: Math.max(0, Math.min(100, Math.round(entry.score * 100) / 100)),
+        rationale: String(entry.rationale || '').substring(0, 200),
+      };
+    }
+
+    // Persist to database if supabase is available
+    if (supabase && ventureId) {
+      await persistScores(supabase, ventureId, stageNumber, scores, artifactId, logger);
+    }
+
+    logger.log(`   CCS: Stage ${stageNumber} scored — ${DIMENSIONS.map(d => `${d.substring(0, 2).toUpperCase()}:${scores[d]?.score ?? '?'}`).join(' ')}`);
+
+    return {
+      stageNumber,
+      ventureId,
+      scores,
+      usage,
+      scoredAt: new Date().toISOString(),
+    };
+  } catch (err) {
+    clearTimeout(timeout);
+    if (err.name === 'AbortError') {
+      logger.warn(`   CCS: Scoring timed out after ${SCORING_TIMEOUT_MS}ms for stage ${stageNumber}`);
+    } else {
+      logger.warn(`   CCS: Scoring failed for stage ${stageNumber}: ${err.message}`);
+    }
+    return null;
+  }
+}
+
+/**
+ * Persist dimension scores to venture_capability_scores via UPSERT.
+ * Idempotent — re-scoring replaces previous scores.
+ */
+async function persistScores(supabase, ventureId, stageNumber, scores, artifactId, logger) {
+  const rows = DIMENSIONS
+    .filter(dim => scores[dim]?.score !== null && scores[dim]?.score !== undefined)
+    .map(dim => ({
+      venture_id: ventureId,
+      stage_number: stageNumber,
+      dimension: dim,
+      score: scores[dim].score,
+      rationale: scores[dim].rationale,
+      artifact_id: artifactId,
+      scored_at: new Date().toISOString(),
+    }));
+
+  if (rows.length === 0) return;
+
+  const { error } = await supabase
+    .from('venture_capability_scores')
+    .upsert(rows, {
+      onConflict: 'venture_id,stage_number,dimension',
+      ignoreDuplicates: false,
+    });
+
+  if (error) {
+    logger.warn(`   CCS: Failed to persist scores: ${error.message}`);
+  }
+}

--- a/lib/eva/capability-score/stage-capability-weights.js
+++ b/lib/eva/capability-score/stage-capability-weights.js
@@ -1,0 +1,156 @@
+/**
+ * Capability Contribution Score — Stage-to-Dimension Weight Configuration
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E: TR-002
+ *
+ * Centralized configuration for:
+ *   - STAGE_DIMENSION_WEIGHTS: which dimensions each stage contributes to and how much
+ *   - DIMENSION_RUBRICS: scoring rubric descriptions for LLM evaluation
+ *   - DIMENSION_OVERALL_WEIGHTS: how dimensions combine into overall CCS
+ *
+ * All weights are validated at import time.
+ */
+
+export const DIMENSIONS = [
+  'technical_depth',
+  'market_validation',
+  'financial_rigor',
+  'operational_readiness',
+  'strategic_alignment',
+];
+
+/**
+ * Per-stage dimension weights.
+ * Key = stage number (1-25), Value = Map of dimension → weight (0.0-1.0).
+ * Weights per stage should sum to 1.0.
+ * null dimensions are omitted (not measured at that stage).
+ *
+ * Stage groupings:
+ *   1-5:   THE TRUTH (heavy on market validation + strategic alignment)
+ *   6-10:  THE ENGINE (financial rigor + operational readiness emerge)
+ *   11-12: THE IDENTITY (strategic alignment + market validation)
+ *   13-16: THE BLUEPRINT (technical depth + operational readiness)
+ *   17-20: THE BUILD (technical depth dominant)
+ *   21-25: LAUNCH & LEARN (operational readiness + all dimensions)
+ */
+export const STAGE_DIMENSION_WEIGHTS = {
+  // THE TRUTH
+  1:  { technical_depth: 0.10, market_validation: 0.35, financial_rigor: 0.05, operational_readiness: 0.10, strategic_alignment: 0.40 },
+  2:  { technical_depth: 0.15, market_validation: 0.30, financial_rigor: 0.10, operational_readiness: 0.10, strategic_alignment: 0.35 },
+  3:  { technical_depth: 0.15, market_validation: 0.30, financial_rigor: 0.15, operational_readiness: 0.10, strategic_alignment: 0.30 },
+  4:  { technical_depth: 0.20, market_validation: 0.25, financial_rigor: 0.15, operational_readiness: 0.15, strategic_alignment: 0.25 },
+  5:  { technical_depth: 0.20, market_validation: 0.25, financial_rigor: 0.20, operational_readiness: 0.15, strategic_alignment: 0.20 },
+
+  // THE ENGINE
+  6:  { technical_depth: 0.15, market_validation: 0.20, financial_rigor: 0.30, operational_readiness: 0.15, strategic_alignment: 0.20 },
+  7:  { technical_depth: 0.15, market_validation: 0.20, financial_rigor: 0.30, operational_readiness: 0.20, strategic_alignment: 0.15 },
+  8:  { technical_depth: 0.20, market_validation: 0.15, financial_rigor: 0.25, operational_readiness: 0.25, strategic_alignment: 0.15 },
+  9:  { technical_depth: 0.20, market_validation: 0.15, financial_rigor: 0.25, operational_readiness: 0.25, strategic_alignment: 0.15 },
+  10: { technical_depth: 0.25, market_validation: 0.15, financial_rigor: 0.20, operational_readiness: 0.25, strategic_alignment: 0.15 },
+
+  // THE IDENTITY
+  11: { technical_depth: 0.10, market_validation: 0.30, financial_rigor: 0.10, operational_readiness: 0.15, strategic_alignment: 0.35 },
+  12: { technical_depth: 0.10, market_validation: 0.30, financial_rigor: 0.10, operational_readiness: 0.15, strategic_alignment: 0.35 },
+
+  // THE BLUEPRINT
+  13: { technical_depth: 0.35, market_validation: 0.10, financial_rigor: 0.15, operational_readiness: 0.25, strategic_alignment: 0.15 },
+  14: { technical_depth: 0.35, market_validation: 0.10, financial_rigor: 0.15, operational_readiness: 0.25, strategic_alignment: 0.15 },
+  15: { technical_depth: 0.30, market_validation: 0.10, financial_rigor: 0.20, operational_readiness: 0.25, strategic_alignment: 0.15 },
+  16: { technical_depth: 0.30, market_validation: 0.10, financial_rigor: 0.20, operational_readiness: 0.25, strategic_alignment: 0.15 },
+
+  // THE BUILD
+  17: { technical_depth: 0.35, market_validation: 0.10, financial_rigor: 0.15, operational_readiness: 0.25, strategic_alignment: 0.15 },
+  18: { technical_depth: 0.40, market_validation: 0.05, financial_rigor: 0.15, operational_readiness: 0.30, strategic_alignment: 0.10 },
+  19: { technical_depth: 0.40, market_validation: 0.05, financial_rigor: 0.15, operational_readiness: 0.30, strategic_alignment: 0.10 },
+  20: { technical_depth: 0.35, market_validation: 0.10, financial_rigor: 0.15, operational_readiness: 0.25, strategic_alignment: 0.15 },
+
+  // LAUNCH & LEARN
+  21: { technical_depth: 0.20, market_validation: 0.20, financial_rigor: 0.20, operational_readiness: 0.25, strategic_alignment: 0.15 },
+  22: { technical_depth: 0.20, market_validation: 0.20, financial_rigor: 0.20, operational_readiness: 0.25, strategic_alignment: 0.15 },
+  23: { technical_depth: 0.15, market_validation: 0.25, financial_rigor: 0.20, operational_readiness: 0.20, strategic_alignment: 0.20 },
+  24: { technical_depth: 0.15, market_validation: 0.25, financial_rigor: 0.20, operational_readiness: 0.20, strategic_alignment: 0.20 },
+  25: { technical_depth: 0.20, market_validation: 0.20, financial_rigor: 0.20, operational_readiness: 0.20, strategic_alignment: 0.20 },
+};
+
+/**
+ * Dimension rubrics for LLM scoring.
+ * These are included in the scoring prompt so the LLM knows what to evaluate.
+ */
+export const DIMENSION_RUBRICS = {
+  technical_depth:
+    'Evaluate the technical sophistication, architecture quality, and engineering rigor demonstrated in this stage output. Consider: solution complexity vs simplicity, technology choices, scalability considerations, technical feasibility, and innovation level. Score 0 = no technical substance, 100 = exceptional technical depth.',
+
+  market_validation:
+    'Evaluate the strength of market evidence, customer understanding, and demand validation in this stage output. Consider: target market clarity, user pain point identification, competitive positioning, evidence of market demand, and go-to-market feasibility. Score 0 = no market evidence, 100 = compelling market validation.',
+
+  financial_rigor:
+    'Evaluate the financial analysis quality, unit economics clarity, and business model viability in this stage output. Consider: revenue model clarity, cost structure understanding, pricing strategy, financial projections realism, and path to profitability. Score 0 = no financial analysis, 100 = rigorous financial modeling.',
+
+  operational_readiness:
+    'Evaluate the operational preparedness, execution capability, and implementation feasibility in this stage output. Consider: team capability signals, resource planning, timeline realism, risk mitigation strategies, and operational infrastructure. Score 0 = no operational planning, 100 = fully operational-ready.',
+
+  strategic_alignment:
+    'Evaluate how well this stage output aligns with the venture\'s strategic vision, mission coherence, and long-term positioning. Consider: vision clarity, mission alignment, strategic differentiation, ecosystem fit, and long-term defensibility. Score 0 = no strategic coherence, 100 = exceptional strategic alignment.',
+};
+
+/**
+ * Overall dimension weights for computing a single CCS number.
+ * These determine how much each dimension contributes to the cumulative score.
+ * Must sum to 1.0.
+ */
+export const DIMENSION_OVERALL_WEIGHTS = {
+  technical_depth: 0.25,
+  market_validation: 0.20,
+  financial_rigor: 0.20,
+  operational_readiness: 0.15,
+  strategic_alignment: 0.20,
+};
+
+// =============================
+// Import-time validation
+// =============================
+
+function validateWeights() {
+  const errors = [];
+
+  // Validate DIMENSION_OVERALL_WEIGHTS sum to 1.0
+  const overallSum = Object.values(DIMENSION_OVERALL_WEIGHTS).reduce((a, b) => a + b, 0);
+  if (Math.abs(overallSum - 1.0) > 0.001) {
+    errors.push(`DIMENSION_OVERALL_WEIGHTS sum to ${overallSum}, expected 1.0`);
+  }
+
+  // Validate each stage's dimension weights sum to 1.0
+  for (const [stage, weights] of Object.entries(STAGE_DIMENSION_WEIGHTS)) {
+    const stageSum = Object.values(weights).reduce((a, b) => a + b, 0);
+    if (Math.abs(stageSum - 1.0) > 0.001) {
+      errors.push(`Stage ${stage} weights sum to ${stageSum}, expected 1.0`);
+    }
+    // Validate all dimensions are present
+    for (const dim of DIMENSIONS) {
+      if (weights[dim] === undefined) {
+        errors.push(`Stage ${stage} missing dimension: ${dim}`);
+      }
+    }
+    // Validate weight range
+    for (const [dim, weight] of Object.entries(weights)) {
+      if (weight < 0 || weight > 1) {
+        errors.push(`Stage ${stage} dimension ${dim} weight ${weight} out of range [0, 1]`);
+      }
+    }
+  }
+
+  // Validate all dimensions have rubrics
+  for (const dim of DIMENSIONS) {
+    if (!DIMENSION_RUBRICS[dim]) {
+      errors.push(`Missing rubric for dimension: ${dim}`);
+    }
+    if (!DIMENSION_OVERALL_WEIGHTS[dim] && DIMENSION_OVERALL_WEIGHTS[dim] !== 0) {
+      errors.push(`Missing overall weight for dimension: ${dim}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Capability weight validation failed:\n  ${errors.join('\n  ')}`);
+  }
+}
+
+validateWeights();

--- a/lib/eva/stage-execution-engine.js
+++ b/lib/eva/stage-execution-engine.js
@@ -335,6 +335,24 @@ export async function executeStage(options = {}) {
     logger.log(`   Artifact persisted: ${artifactId}`);
   }
 
+  // 6.5. Capability Contribution Score — non-blocking post-analysis hook
+  // SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E: Compute CCS after artifact persistence
+  let capabilityScore = null;
+  if (!dryRun && validation.valid && artifactId) {
+    try {
+      const { computeCapabilityScore } = await import('./capability-score/score-stage.js');
+      capabilityScore = await computeCapabilityScore(stageNumber, output, {
+        ventureId,
+        artifactId,
+        supabase,
+        logger,
+      });
+    } catch (ccsErr) {
+      // Non-blocking: artifact already persisted, CCS is additive
+      logger.warn(`   CCS: Module unavailable or failed: ${ccsErr.message}`);
+    }
+  }
+
   // 7. SD-MAN-GEN-CORRECTIVE-VISION-GAP-013 (A04): Require artifact output for non-dry-run
   if (!dryRun && !artifactId) {
     const reason = !validation.valid
@@ -358,5 +376,6 @@ export async function executeStage(options = {}) {
     persisted: !dryRun && validation.valid,
     artifactRequired: !dryRun,
     artifactMissing: !dryRun && !artifactId,
+    capabilityScore,
   };
 }


### PR DESCRIPTION
## Summary
- Add `venture_capability_scores` table migration with UPSERT-based idempotent scoring
- Implement 5-dimension CCS scoring engine (`score-stage.js`) using LLM evaluation with 30s timeout
- Add `stage-capability-weights.js` with per-stage dimension weights for all 25 stages (import-time validated)
- Add `cumulative-profile.js` for weighted aggregation, trend detection, gap analysis, and chairman gate context
- Add `compare-ventures.js` for cross-venture ranking by overall or per-dimension scores
- Integrate CCS as non-blocking post-analysis hook in `stage-execution-engine.js` (step 6.5)
- Add 35 unit/integration tests covering all modules

## Test plan
- [x] 30 unit tests for weights, scoring, cumulative profile, comparison, barrel export
- [x] 5 integration tests for validateOutput, dynamic import, non-blocking failure
- [x] All 35 tests pass in 261ms

SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-E

🤖 Generated with [Claude Code](https://claude.com/claude-code)