### PR TITLE
feat(eva): redesign launch phase stages 23-25

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -329,35 +329,43 @@ const STAGE_CONTRACTS = new Map([
       }},
     ],
     produces: {
-      go_decision: { type: 'string' },
-      launch_tasks: { type: 'array', minItems: 1 },
-      decision: { type: 'string' },
+      marketing_items: { type: 'array', minItems: 3 },
+      sd_bridge_payloads: { type: 'array' },
+      marketing_strategy_summary: { type: 'string', minLength: 10 },
     },
   }],
 
   [24, {
-    consumes: [],
+    consumes: [
+      { stage: 22, fields: {
+        promotion_gate: { type: 'object' },
+        releaseDecision: { type: 'object', required: false },
+      }},
+      { stage: 23, fields: {
+        marketing_items: { type: 'array' },
+        marketing_readiness_pct: { type: 'number', required: false },
+      }},
+    ],
     produces: {
-      aarrr: { type: 'object' },
-      learnings: { type: 'array' },
-      launchOutcome: { type: 'object' },
+      readiness_checklist: { type: 'object' },
+      go_no_go_decision: { type: 'string' },
+      readiness_score: { type: 'number' },
     },
   }],
 
   [25, {
     consumes: [
-      { stage: 1, fields: {
-        description: { type: 'string' },
-        problemStatement: { type: 'string' },
-      }},
       { stage: 24, fields: {
-        launchOutcome: { type: 'object' },
+        chairmanGate: { type: 'object' },
+        go_no_go_decision: { type: 'string' },
+        readiness_score: { type: 'number' },
       }},
     ],
     produces: {
-      review_summary: { type: 'string', minLength: 20 },
-      ventureDecision: { type: 'object' },
-      drift_detected: { type: 'object' },
+      distribution_channels: { type: 'array', minItems: 1 },
+      operations_handoff: { type: 'object' },
+      launch_summary: { type: 'string', minLength: 10 },
+      pipeline_terminus: { type: 'boolean' },
     },
   }],
 ]);
@@ -504,9 +512,9 @@ export const CROSS_STAGE_DEPS = {
 
   // Phase 6: LAUNCH & LEARN (Stages 22-25)
   22: [17, 18, 19, 20, 21],  // Release readiness: full build phase
-  23: [1, 22],               // Post-launch ops: idea + release readiness
-  24: [5, 23],               // Metrics & learning: economics + post-launch
-  25: [1, 5, 13, 16, 23, 24], // Portfolio review: idea + economics + roadmap + financials + ops + metrics
+  23: [1, 22],               // Marketing preparation: idea + release readiness
+  24: [22, 23],              // Launch readiness (chairman gate): release + marketing
+  25: [24],                  // Launch execution (pipeline terminus): chairman approval
 };
 
 /**

--- a/lib/eva/stage-templates/analysis-steps/index.js
+++ b/lib/eva/stage-templates/analysis-steps/index.js
@@ -42,9 +42,9 @@ export { analyzeStage21 } from './stage-21-build-review.js';
 export { analyzeStage22 } from './stage-22-release-readiness.js';
 
 // LAUNCH & LEARN (Stages 23-25)
-export { analyzeStage23 } from './stage-23-launch-execution.js';
-export { analyzeStage24 } from './stage-24-metrics-learning.js';
-export { analyzeStage25 } from './stage-25-venture-review.js';
+export { analyzeStage23 } from './stage-23-marketing-prep.js';
+export { analyzeStage24 } from './stage-24-launch-readiness.js';
+export { analyzeStage25 } from './stage-25-launch-execution.js';
 
 /**
  * Get the analysis step function for a given stage number (1-25).
@@ -75,9 +75,9 @@ export async function getAnalysisStep(stageNumber) {
     20: () => import('./stage-20-quality-assurance.js').then(m => m.analyzeStage20),
     21: () => import('./stage-21-build-review.js').then(m => m.analyzeStage21),
     22: () => import('./stage-22-release-readiness.js').then(m => m.analyzeStage22),
-    23: () => import('./stage-23-launch-execution.js').then(m => m.analyzeStage23),
-    24: () => import('./stage-24-metrics-learning.js').then(m => m.analyzeStage24),
-    25: () => import('./stage-25-venture-review.js').then(m => m.analyzeStage25),
+    23: () => import('./stage-23-marketing-prep.js').then(m => m.analyzeStage23),
+    24: () => import('./stage-24-launch-readiness.js').then(m => m.analyzeStage24),
+    25: () => import('./stage-25-launch-execution.js').then(m => m.analyzeStage25),
   };
   const loader = loaders[stageNumber];
   return loader ? loader() : null;

--- a/lib/eva/stage-templates/analysis-steps/stage-23-marketing-prep.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-marketing-prep.js
@@ -1,0 +1,198 @@
+/**
+ * Stage 23 Analysis Step - Marketing Preparation
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
+ *
+ * Consumes Stage 22 release readiness data, generates marketing item
+ * payloads via LLM, and creates real marketing SDs via lifecycle-sd-bridge.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-23-marketing-prep
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+import { checkReleaseReadiness } from '../stage-23.js';
+
+// Duplicated from stage-23.js to avoid circular dependency at module-level eval
+const MARKETING_ITEM_TYPES = [
+  'landing_page', 'social_media_campaign', 'press_release',
+  'email_campaign', 'content_blog', 'video_promo', 'ad_creative',
+  'product_demo', 'case_study', 'launch_announcement',
+];
+const MARKETING_PRIORITIES = ['critical', 'high', 'medium', 'low'];
+
+const SYSTEM_PROMPT = `You are EVA's Marketing Preparation Analyst. Given a venture that has passed release readiness (Stage 22), generate marketing material items and SD payloads for content creation.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "marketing_strategy_summary": "2-4 sentence summary of the marketing strategy for this venture launch",
+  "target_audience": "Primary target audience description",
+  "marketing_items": [
+    {
+      "title": "Marketing item title (e.g., 'Product Landing Page')",
+      "description": "What this marketing item should contain and accomplish",
+      "type": "landing_page|social_media_campaign|press_release|email_campaign|content_blog|video_promo|ad_creative|product_demo|case_study|launch_announcement",
+      "priority": "critical|high|medium|low"
+    }
+  ],
+  "sd_bridge_payloads": [
+    {
+      "title": "SD title for this marketing item",
+      "type": "feature",
+      "description": "SD description with implementation details",
+      "scope": "Files and components involved",
+      "rationale": "Why this marketing item is needed for launch"
+    }
+  ]
+}
+
+Rules:
+- At least 3 marketing items required, covering at least 3 different types
+- Each marketing item must have a corresponding sd_bridge_payload
+- sd_bridge_payloads use type "feature" for content creation SDs
+- marketing_strategy_summary must be at least 10 characters
+- Prioritize items based on launch readiness: landing_page and launch_announcement are typically critical
+- If venture has specific product features, tailor marketing items to highlight them
+- Include at least one high-priority item for each of: awareness (press/social), conversion (landing page/demo), retention (email/content)`;
+
+/**
+ * Generate marketing preparation items from Stage 22 release readiness data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage22Data - Release readiness (releaseDecision, releaseItems, etc.)
+ * @param {Object} [params.stage01Data] - Venture hydration (for product context)
+ * @param {Object} [params.stage10Data] - Naming/branding data
+ * @param {Object} [params.stage11Data] - GTM strategy data
+ * @param {string} [params.ventureName]
+ * @param {Object} [params.logger]
+ * @returns {Promise<Object>} Marketing items with SD bridge payloads
+ */
+export async function analyzeStage23({ stage22Data, stage01Data, stage10Data, stage11Data, ventureName, logger = console }) {
+  const startTime = Date.now();
+  logger.log('[Stage23] Starting marketing preparation analysis', { ventureName });
+
+  // Check Stage 22 prerequisite
+  const readiness = checkReleaseReadiness({ stage22Data });
+  if (!readiness.ready) {
+    const errorMsg = `Stage 22 release readiness required: ${readiness.reasons.join('; ')}`;
+    logger.warn(`[Stage23] ${errorMsg}`);
+    throw new Error(errorMsg);
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  // Build context from upstream stages
+  const releaseContext = stage22Data.releaseDecision
+    ? `Release: ${stage22Data.releaseDecision.decision} — ${stage22Data.releaseDecision.rationale || 'No rationale'}`
+    : '';
+
+  const itemsContext = Array.isArray(stage22Data.release_items)
+    ? `Release items: ${stage22Data.release_items.map(ri => `${ri.name} (${ri.category || ri.status})`).join(', ')}`
+    : '';
+
+  const brandContext = stage10Data?.ventureName
+    ? `Brand: ${stage10Data.ventureName}. Tagline: ${stage10Data.tagline || 'N/A'}`
+    : '';
+
+  const gtmContext = stage11Data?.channels
+    ? `GTM channels: ${JSON.stringify(stage11Data.channels).substring(0, 300)}`
+    : '';
+
+  const ventureContext = stage01Data?.problem_statement
+    ? `Problem: ${stage01Data.problem_statement}. Solution: ${stage01Data.solution_overview || 'N/A'}`
+    : '';
+
+  const userPrompt = `Generate marketing preparation items for this venture's launch.
+
+Venture: ${ventureName || 'Unnamed'}
+${releaseContext}
+${itemsContext}
+${brandContext}
+${gtmContext}
+${ventureContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  const usage = extractUsage(response);
+  const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
+
+  // Normalize marketing_strategy_summary
+  const marketing_strategy_summary = String(parsed.marketing_strategy_summary || 'Marketing strategy pending generation.').substring(0, 1000);
+
+  // Normalize target_audience
+  const target_audience = String(parsed.target_audience || 'Target audience pending identification.').substring(0, 500);
+
+  // Normalize marketing items
+  let marketing_items = Array.isArray(parsed.marketing_items)
+    ? parsed.marketing_items.filter(item => item?.title && item?.description)
+    : [];
+
+  if (marketing_items.length < 3) {
+    marketing_items = [
+      { title: 'Product Landing Page', description: 'Main landing page for product launch', type: 'landing_page', priority: 'critical' },
+      { title: 'Launch Announcement', description: 'Official launch announcement for distribution', type: 'launch_announcement', priority: 'critical' },
+      { title: 'Social Media Campaign', description: 'Multi-platform social media launch campaign', type: 'social_media_campaign', priority: 'high' },
+    ];
+  } else {
+    marketing_items = marketing_items.map(item => ({
+      title: String(item.title).substring(0, 200),
+      description: String(item.description).substring(0, 500),
+      type: MARKETING_ITEM_TYPES.includes(item.type) ? item.type : 'content_blog',
+      priority: MARKETING_PRIORITIES.includes(item.priority) ? item.priority : 'medium',
+    }));
+  }
+
+  // Normalize SD bridge payloads
+  let sd_bridge_payloads = Array.isArray(parsed.sd_bridge_payloads)
+    ? parsed.sd_bridge_payloads.filter(p => p?.title)
+    : [];
+
+  // If no payloads but items exist, generate payloads from items
+  if (sd_bridge_payloads.length === 0 && marketing_items.length > 0) {
+    sd_bridge_payloads = marketing_items.map(item => ({
+      title: `Create: ${item.title}`,
+      type: 'feature',
+      description: item.description,
+      scope: `Marketing content creation: ${item.type}`,
+      rationale: `Required for launch: ${item.title}`,
+    }));
+  } else {
+    sd_bridge_payloads = sd_bridge_payloads.map(p => ({
+      title: String(p.title).substring(0, 200),
+      type: String(p.type || 'feature'),
+      description: String(p.description || '').substring(0, 500),
+      scope: String(p.scope || '').substring(0, 300),
+      rationale: String(p.rationale || '').substring(0, 300),
+    }));
+  }
+
+  // Compute derived fields
+  const total_marketing_items = marketing_items.length;
+  const sds_created_count = 0; // Will be updated after lifecycle-sd-bridge creates SDs
+  const marketing_readiness_pct = 0; // Will be updated as marketing SDs are completed
+
+  const latencyMs = Date.now() - startTime;
+  logger.log(`[Stage23] Marketing preparation complete`, {
+    itemCount: total_marketing_items,
+    payloadCount: sd_bridge_payloads.length,
+    latencyMs,
+  });
+
+  return {
+    marketing_items,
+    sd_bridge_payloads,
+    marketing_sds: [], // Populated by lifecycle-sd-bridge integration
+    marketing_strategy_summary,
+    target_audience,
+    marketing_readiness_pct,
+    total_marketing_items,
+    sds_created_count,
+    ...(fourBuckets || {}),
+    _usage: usage,
+    _latencyMs: latencyMs,
+  };
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-24-launch-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-launch-readiness.js
@@ -1,0 +1,205 @@
+/**
+ * Stage 24 Analysis Step - Launch Readiness (Chairman Gate)
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
+ *
+ * Queries Stage 22 and Stage 23 artifacts for real readiness data.
+ * Computes weighted readiness score from checklist items.
+ * Produces go/no-go recommendation for chairman gate.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-24-launch-readiness
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+import { computeReadinessScore } from '../stage-24.js';
+
+// Duplicated from stage-24.js to avoid circular dependency
+const GO_NO_GO_DECISIONS = ['go', 'no_go', 'conditional_go'];
+const CHECKLIST_ITEM_STATUSES = ['pass', 'fail', 'pending', 'waived'];
+const READINESS_CHECKLIST_KEYS = [
+  'release_confirmed',
+  'marketing_complete',
+  'monitoring_ready',
+  'rollback_plan_exists',
+];
+
+const SYSTEM_PROMPT = `You are EVA's Launch Readiness Analyst. Evaluate the venture's readiness to launch based on Stage 22 (release) and Stage 23 (marketing) data.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "readiness_checklist": {
+    "release_confirmed": {
+      "status": "pass|fail|pending|waived",
+      "evidence": "Evidence from Stage 22 release decision",
+      "verified_at": "ISO timestamp"
+    },
+    "marketing_complete": {
+      "status": "pass|fail|pending|waived",
+      "evidence": "Evidence from Stage 23 marketing SDs status",
+      "verified_at": "ISO timestamp"
+    },
+    "monitoring_ready": {
+      "status": "pass|fail|pending|waived",
+      "evidence": "Evidence of monitoring infrastructure readiness",
+      "verified_at": "ISO timestamp"
+    },
+    "rollback_plan_exists": {
+      "status": "pass|fail|pending|waived",
+      "evidence": "Evidence of rollback plan documentation",
+      "verified_at": "ISO timestamp"
+    }
+  },
+  "go_no_go_decision": "go|no_go|conditional_go",
+  "decision_rationale": "2-3 sentence rationale for the go/no-go recommendation",
+  "incident_response_plan": "Description of incident response procedures (at least 10 chars)",
+  "monitoring_setup": "Description of monitoring infrastructure (at least 10 chars)",
+  "rollback_plan": "Description of rollback procedures (at least 10 chars)",
+  "launch_risks": [
+    {
+      "risk": "Description of launch risk",
+      "severity": "critical|high|medium|low",
+      "mitigation": "How the risk will be mitigated"
+    }
+  ]
+}
+
+Rules:
+- release_confirmed: "pass" if Stage 22 releaseDecision.decision is "release" or "approved"
+- marketing_complete: "pass" if Stage 23 has marketing_readiness_pct >= 80 or marketing_items exist
+- monitoring_ready: "pass" if monitoring infrastructure is described
+- rollback_plan_exists: "pass" if rollback procedures are documented
+- go_no_go_decision: "go" only if all critical checklist items pass, "conditional_go" if non-critical items pending, "no_go" if critical items fail
+- At least 1 launch risk required
+- incident_response_plan, monitoring_setup, rollback_plan must each be at least 10 characters`;
+
+/**
+ * Generate launch readiness assessment from Stage 22 and Stage 23 data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage22Data - Release readiness data
+ * @param {Object} params.stage23Data - Marketing preparation data
+ * @param {Object} [params.stage01Data] - Venture hydration data
+ * @param {string} [params.ventureName]
+ * @param {Object} [params.logger]
+ * @returns {Promise<Object>} Launch readiness with checklist, score, and recommendation
+ */
+export async function analyzeStage24({ stage22Data, stage23Data, ventureName, logger = console }) {
+  const startTime = Date.now();
+  logger.log('[Stage24] Starting launch readiness analysis', { ventureName });
+
+  if (!stage22Data) {
+    throw new Error('Stage 24 launch readiness requires Stage 22 (release readiness) data');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  // Build context from upstream stages
+  const releaseContext = stage22Data.releaseDecision
+    ? `Release decision: ${stage22Data.releaseDecision.decision} — ${stage22Data.releaseDecision.rationale || 'N/A'}`
+    : 'Release decision: not available';
+
+  const promotionContext = stage22Data.promotion_gate
+    ? `Promotion gate: ${stage22Data.promotion_gate.pass ? 'PASS' : 'FAIL'} (blockers: ${(stage22Data.promotion_gate.blockers || []).length})`
+    : 'Promotion gate: not available';
+
+  const releaseItems = Array.isArray(stage22Data.release_items)
+    ? `Release items: ${stage22Data.release_items.length} items (${stage22Data.release_items.filter(i => i.status === 'approved').length} approved)`
+    : '';
+
+  const marketingContext = stage23Data
+    ? `Marketing: ${stage23Data.total_marketing_items || 0} items, readiness ${stage23Data.marketing_readiness_pct || 0}%, strategy: ${(stage23Data.marketing_strategy_summary || 'N/A').substring(0, 200)}`
+    : 'Marketing data: not available';
+
+  const retroContext = stage22Data.sprintRetrospective
+    ? `Sprint retrospective: ${(stage22Data.sprintRetrospective.wentWell || []).slice(0, 2).join('; ')}`
+    : '';
+
+  const userPrompt = `Evaluate launch readiness for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+${releaseContext}
+${promotionContext}
+${releaseItems}
+${marketingContext}
+${retroContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  const usage = extractUsage(response);
+  const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
+
+  // Normalize readiness checklist
+  const readiness_checklist = {};
+  for (const key of READINESS_CHECKLIST_KEYS) {
+    const item = parsed.readiness_checklist?.[key];
+    readiness_checklist[key] = {
+      status: CHECKLIST_ITEM_STATUSES.includes(item?.status) ? item.status : 'pending',
+      evidence: String(item?.evidence || 'Evidence pending').substring(0, 500),
+      verified_at: item?.verified_at || new Date().toISOString(),
+    };
+  }
+
+  // Normalize go/no-go decision
+  const go_no_go_decision = GO_NO_GO_DECISIONS.includes(parsed.go_no_go_decision)
+    ? parsed.go_no_go_decision
+    : 'no_go';
+
+  // Normalize rationale
+  const decision_rationale = String(parsed.decision_rationale || 'Readiness assessment pending.').substring(0, 1000);
+
+  // Normalize operational plans
+  const incident_response_plan = String(parsed.incident_response_plan || 'Incident response plan pending creation.').substring(0, 2000);
+  const monitoring_setup = String(parsed.monitoring_setup || 'Monitoring infrastructure setup pending.').substring(0, 2000);
+  const rollback_plan = String(parsed.rollback_plan || 'Rollback procedures pending documentation.').substring(0, 2000);
+
+  // Normalize launch risks
+  let launch_risks = Array.isArray(parsed.launch_risks)
+    ? parsed.launch_risks.filter(r => r?.risk && r?.mitigation)
+    : [];
+
+  if (launch_risks.length === 0) {
+    launch_risks = [{
+      risk: 'Unidentified launch risks',
+      severity: 'medium',
+      mitigation: 'Conduct thorough pre-launch review',
+    }];
+  } else {
+    launch_risks = launch_risks.map(r => ({
+      risk: String(r.risk).substring(0, 300),
+      severity: ['critical', 'high', 'medium', 'low'].includes(r.severity) ? r.severity : 'medium',
+      mitigation: String(r.mitigation).substring(0, 300),
+    }));
+  }
+
+  // Compute derived readiness score
+  const { readiness_score, all_checks_pass, blocking_items } = computeReadinessScore({ readiness_checklist });
+
+  const latencyMs = Date.now() - startTime;
+  logger.log(`[Stage24] Launch readiness analysis complete`, {
+    readiness_score,
+    go_no_go_decision,
+    blocking_items: blocking_items.length,
+    latencyMs,
+  });
+
+  return {
+    readiness_checklist,
+    go_no_go_decision,
+    decision_rationale,
+    incident_response_plan,
+    monitoring_setup,
+    rollback_plan,
+    launch_risks,
+    readiness_score,
+    all_checks_pass,
+    blocking_items,
+    ...(fourBuckets || {}),
+    _usage: usage,
+    _latencyMs: latencyMs,
+  };
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-25-launch-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-25-launch-execution.js
@@ -1,0 +1,239 @@
+/**
+ * Stage 25 Analysis Step - Launch Execution (Pipeline Terminus)
+ * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
+ *
+ * Verifies Stage 24 chairman approval, activates distribution channels,
+ * generates operations handoff, and marks pipeline terminus.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-25-launch-execution
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+import { verifyLaunchAuthorization } from '../stage-25.js';
+
+// Duplicated from stage-25.js to avoid circular dependency
+const CHANNEL_STATUSES = ['inactive', 'activating', 'active', 'failed', 'paused'];
+const ESCALATION_LEVELS = ['L1', 'L2', 'L3'];
+
+const SYSTEM_PROMPT = `You are EVA's Launch Execution Analyst. Given a venture that has been approved for launch (Stage 24 chairman gate passed), generate the go-live execution plan with distribution channels and operations handoff.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "launch_summary": "3-5 sentence summary of the launch execution including key milestones and outcomes",
+  "go_live_timestamp": "ISO 8601 timestamp for go-live (planned or actual)",
+  "distribution_channels": [
+    {
+      "name": "Channel name (e.g., 'App Store', 'Web', 'Social Media')",
+      "type": "app_store|web|social|email|partner|marketplace|direct",
+      "status": "inactive|activating|active|failed|paused",
+      "activation_date": "ISO date when channel was/will be activated",
+      "metrics_endpoint": "URL or identifier for channel metrics"
+    }
+  ],
+  "operations_handoff": {
+    "monitoring": {
+      "dashboards": [
+        { "name": "Dashboard name", "url": "Dashboard URL", "owner": "Team/person responsible" }
+      ],
+      "alerts": [
+        { "name": "Alert name", "condition": "When this triggers", "severity": "critical|warning|info", "notify": "Channel/team to notify" }
+      ],
+      "health_check_url": "URL for health check endpoint"
+    },
+    "escalation": {
+      "contacts": [
+        { "level": "L1|L2|L3", "team": "Team name", "channel": "Contact method", "response_time": "Expected response time" }
+      ],
+      "runbook_url": "URL to operations runbook",
+      "sla_targets": {
+        "uptime": "99.9%",
+        "response_time_p95": "200ms",
+        "incident_resolution": "4 hours"
+      }
+    },
+    "maintenance": {
+      "schedule": "Maintenance window schedule (e.g., 'Sundays 2-4 AM UTC')",
+      "backup_strategy": "Backup approach and frequency",
+      "update_policy": "How updates/patches are deployed"
+    }
+  }
+}
+
+Rules:
+- At least 1 distribution channel required
+- operations_handoff.monitoring must have at least 1 dashboard and 1 alert
+- operations_handoff.escalation must have at least 1 contact at L1
+- launch_summary must be at least 10 characters
+- All channels should have realistic activation dates
+- SLA targets should be reasonable for the venture type`;
+
+/**
+ * Generate launch execution plan from Stage 24 approval data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage24Data - Launch readiness (chairman gate, readiness checklist)
+ * @param {Object} [params.stage22Data] - Release readiness data
+ * @param {Object} [params.stage23Data] - Marketing preparation data
+ * @param {Object} [params.stage01Data] - Venture hydration data
+ * @param {string} [params.ventureName]
+ * @param {Object} [params.logger]
+ * @returns {Promise<Object>} Launch execution with distribution channels and operations handoff
+ */
+export async function analyzeStage25({ stage24Data, stage22Data, stage23Data, ventureName, logger = console }) {
+  const startTime = Date.now();
+  logger.log('[Stage25] Starting launch execution analysis', { ventureName });
+
+  // Verify Stage 24 chairman approval
+  const auth = verifyLaunchAuthorization({ stage24Data });
+  if (!auth.authorized) {
+    const errorMsg = `Launch not authorized: ${auth.reasons.join('; ')}`;
+    logger.warn(`[Stage25] ${errorMsg}`);
+    throw new Error(errorMsg);
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  // Build context from upstream stages
+  const readinessContext = stage24Data.readiness_score != null
+    ? `Readiness score: ${stage24Data.readiness_score}/100. Decision: ${stage24Data.go_no_go_decision}`
+    : '';
+
+  const checklistContext = stage24Data.readiness_checklist
+    ? `Checklist: ${Object.entries(stage24Data.readiness_checklist).map(([k, v]) => `${k}=${v.status}`).join(', ')}`
+    : '';
+
+  const irpContext = stage24Data.incident_response_plan
+    ? `Incident response: ${stage24Data.incident_response_plan.substring(0, 200)}`
+    : '';
+
+  const monitorContext = stage24Data.monitoring_setup
+    ? `Monitoring: ${stage24Data.monitoring_setup.substring(0, 200)}`
+    : '';
+
+  const rollbackContext = stage24Data.rollback_plan
+    ? `Rollback: ${stage24Data.rollback_plan.substring(0, 200)}`
+    : '';
+
+  const releaseContext = stage22Data?.releaseDecision
+    ? `Release: ${stage22Data.releaseDecision.decision}. Items: ${(stage22Data.release_items || []).length}`
+    : '';
+
+  const marketingContext = stage23Data
+    ? `Marketing: ${stage23Data.total_marketing_items || 0} items prepared`
+    : '';
+
+  const userPrompt = `Generate launch execution plan for this venture that has been approved for launch.
+
+Venture: ${ventureName || 'Unnamed'}
+${readinessContext}
+${checklistContext}
+${irpContext}
+${monitorContext}
+${rollbackContext}
+${releaseContext}
+${marketingContext}
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  const usage = extractUsage(response);
+  const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
+
+  // Normalize launch summary
+  const launch_summary = String(parsed.launch_summary || 'Launch execution in progress.').substring(0, 2000);
+
+  // Normalize go-live timestamp
+  const go_live_timestamp = parsed.go_live_timestamp || new Date().toISOString();
+
+  // Normalize distribution channels
+  let distribution_channels = Array.isArray(parsed.distribution_channels)
+    ? parsed.distribution_channels.filter(ch => ch?.name && ch?.type)
+    : [];
+
+  if (distribution_channels.length === 0) {
+    distribution_channels = [{
+      name: 'Web Application',
+      type: 'web',
+      status: 'activating',
+      activation_date: new Date().toISOString(),
+      metrics_endpoint: null,
+    }];
+  } else {
+    distribution_channels = distribution_channels.map(ch => ({
+      name: String(ch.name).substring(0, 200),
+      type: String(ch.type).substring(0, 50),
+      status: CHANNEL_STATUSES.includes(ch.status) ? ch.status : 'inactive',
+      activation_date: ch.activation_date || null,
+      metrics_endpoint: ch.metrics_endpoint ? String(ch.metrics_endpoint).substring(0, 500) : null,
+    }));
+  }
+
+  // Normalize operations handoff
+  const ops = parsed.operations_handoff || {};
+  const operations_handoff = {
+    monitoring: {
+      dashboards: Array.isArray(ops.monitoring?.dashboards) ? ops.monitoring.dashboards.slice(0, 10).map(d => ({
+        name: String(d?.name || 'Dashboard').substring(0, 100),
+        url: String(d?.url || '').substring(0, 500),
+        owner: String(d?.owner || 'Operations').substring(0, 100),
+      })) : [{ name: 'Operations Dashboard', url: '', owner: 'Operations' }],
+      alerts: Array.isArray(ops.monitoring?.alerts) ? ops.monitoring.alerts.slice(0, 20).map(a => ({
+        name: String(a?.name || 'Alert').substring(0, 100),
+        condition: String(a?.condition || '').substring(0, 300),
+        severity: ['critical', 'warning', 'info'].includes(a?.severity) ? a.severity : 'warning',
+        notify: String(a?.notify || 'ops-team').substring(0, 100),
+      })) : [{ name: 'Health Check Alert', condition: 'Service unavailable', severity: 'critical', notify: 'ops-team' }],
+      health_check_url: String(ops.monitoring?.health_check_url || '').substring(0, 500) || null,
+    },
+    escalation: {
+      contacts: Array.isArray(ops.escalation?.contacts) ? ops.escalation.contacts.slice(0, 10).map(c => ({
+        level: ESCALATION_LEVELS.includes(c?.level) ? c.level : 'L1',
+        team: String(c?.team || 'Support').substring(0, 100),
+        channel: String(c?.channel || 'email').substring(0, 100),
+        response_time: String(c?.response_time || '1 hour').substring(0, 100),
+      })) : [{ level: 'L1', team: 'Support', channel: 'email', response_time: '1 hour' }],
+      runbook_url: String(ops.escalation?.runbook_url || '').substring(0, 500) || null,
+      sla_targets: ops.escalation?.sla_targets && typeof ops.escalation.sla_targets === 'object'
+        ? Object.fromEntries(Object.entries(ops.escalation.sla_targets).slice(0, 10).map(([k, v]) => [k, String(v).substring(0, 100)]))
+        : { uptime: '99.9%', response_time_p95: '500ms' },
+    },
+    maintenance: {
+      schedule: String(ops.maintenance?.schedule || 'To be determined').substring(0, 300),
+      backup_strategy: String(ops.maintenance?.backup_strategy || 'Daily automated backups').substring(0, 300),
+      update_policy: String(ops.maintenance?.update_policy || 'Rolling updates with zero downtime').substring(0, 300),
+    },
+  };
+
+  // Compute derived fields
+  const channels_active_count = distribution_channels.filter(ch => ch.status === 'active').length;
+  const channels_total_count = distribution_channels.length;
+  const pipeline_terminus = true;
+  const pipeline_mode = 'operations';
+
+  const latencyMs = Date.now() - startTime;
+  logger.log(`[Stage25] Launch execution analysis complete`, {
+    channels: channels_total_count,
+    active: channels_active_count,
+    pipeline_terminus,
+    latencyMs,
+  });
+
+  return {
+    launch_summary,
+    go_live_timestamp,
+    distribution_channels,
+    operations_handoff,
+    pipeline_terminus,
+    pipeline_mode,
+    channels_active_count,
+    channels_total_count,
+    ...(fourBuckets || {}),
+    _usage: usage,
+    _latencyMs: latencyMs,
+  };
+}

--- a/lib/eva/stage-templates/index.js
+++ b/lib/eva/stage-templates/index.js
@@ -42,9 +42,9 @@ export { default as stage21 } from './stage-21.js';
 export { default as stage22, evaluatePromotionGate as evaluatePhase5PromotionGate } from './stage-22.js';
 
 // Phase 6: LAUNCH & LEARN (Stages 23-25)
-export { default as stage23, evaluateKillGate as evaluateStage23KillGate } from './stage-23.js';
-export { default as stage24 } from './stage-24.js';
-export { default as stage25, detectDrift } from './stage-25.js';
+export { default as stage23, checkReleaseReadiness } from './stage-23.js';
+export { default as stage24, computeReadinessScore } from './stage-24.js';
+export { default as stage25, verifyLaunchAuthorization } from './stage-25.js';
 
 import stage01 from './stage-01.js';
 import stage02 from './stage-02.js';

--- a/lib/eva/stage-templates/stage-23.js
+++ b/lib/eva/stage-templates/stage-23.js
@@ -1,120 +1,109 @@
 /**
- * Stage 23 Template - Launch Execution
+ * Stage 23 Template - Marketing Preparation
  * Phase: LAUNCH & LEARN (Stages 23-25)
- * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
- * Launch execution with Go/No-Go kill gate.
- * Kill gate requires:
- *   - go_decision set to "go"
- *   - incident_response_plan present
- *   - monitoring_setup present
- *   - rollback_plan present
+ * Creates marketing material SDs via lifecycle-sd-bridge
+ * when a venture reaches launch phase (Stage 22 release confirmed).
+ *
+ * Replaces the former Launch Execution template (moved to Stage 25).
  *
  * @module lib/eva/stage-templates/stage-23
  */
 
-import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
+import { validateString, validateArray, validateNumber, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage23 } from './analysis-steps/stage-23-launch-execution.js';
+import { analyzeStage23 } from './analysis-steps/stage-23-marketing-prep.js';
 
-const GO_DECISIONS = ['go', 'no-go', 'conditional_go'];
-const LAUNCH_TYPES = ['soft_launch', 'beta', 'general_availability'];
-const MIN_LAUNCH_TASKS = 1;
+const MARKETING_ITEM_TYPES = [
+  'landing_page', 'social_media_campaign', 'press_release',
+  'email_campaign', 'content_blog', 'video_promo', 'ad_creative',
+  'product_demo', 'case_study', 'launch_announcement',
+];
+
+const MARKETING_PRIORITIES = ['critical', 'high', 'medium', 'low'];
+const MIN_MARKETING_ITEMS = 3;
 
 const TEMPLATE = {
   id: 'stage-23',
-  slug: 'launch-execution',
-  title: 'Launch Execution',
-  version: '1.0.0',
+  slug: 'marketing-preparation',
+  title: 'Marketing Preparation',
+  version: '2.0.0',
   schema: {
-    go_decision: { type: 'enum', values: GO_DECISIONS, required: true },
-    launchType: { type: 'enum', values: LAUNCH_TYPES },
-    incident_response_plan: { type: 'string', minLength: 10, required: true },
-    monitoring_setup: { type: 'string', minLength: 10, required: true },
-    rollback_plan: { type: 'string', minLength: 10, required: true },
-    launch_tasks: {
+    marketing_items: {
       type: 'array',
-      minItems: MIN_LAUNCH_TASKS,
+      minItems: MIN_MARKETING_ITEMS,
+      required: true,
       items: {
-        name: { type: 'string', required: true },
+        title: { type: 'string', required: true },
+        description: { type: 'string', required: true },
+        type: { type: 'enum', values: MARKETING_ITEM_TYPES, required: true },
+        priority: { type: 'enum', values: MARKETING_PRIORITIES, required: true },
+      },
+    },
+    sd_bridge_payloads: {
+      type: 'array',
+      items: {
+        title: { type: 'string', required: true },
+        type: { type: 'string', required: true },
+        description: { type: 'string' },
+        scope: { type: 'string' },
+      },
+    },
+    marketing_sds: {
+      type: 'array',
+      items: {
+        sd_key: { type: 'string', required: true },
+        title: { type: 'string', required: true },
+        type: { type: 'string', required: true },
         status: { type: 'string', required: true },
-        owner: { type: 'string' },
       },
     },
-    launch_date: { type: 'string', required: true },
-    planned_launch_date: { type: 'string' },
-    actual_launch_date: { type: 'string' },
-    successCriteria: {
-      type: 'array',
-      items: {
-        metric: { type: 'string', required: true },
-        target: { type: 'string', required: true },
-        measurementWindow: { type: 'string' },
-        priority: { type: 'enum', values: ['primary', 'secondary'] },
-      },
-    },
-    rollbackTriggers: {
-      type: 'array',
-      items: {
-        trigger: { type: 'string', required: true },
-        threshold: { type: 'string', required: true },
-        action: { type: 'string', required: true },
-      },
-    },
+    marketing_strategy_summary: { type: 'string', minLength: 10 },
+    target_audience: { type: 'string', minLength: 5 },
     // Derived
-    decision: { type: 'enum', values: ['pass', 'kill'], derived: true },
-    blockProgression: { type: 'boolean', derived: true },
-    reasons: { type: 'array', derived: true },
+    marketing_readiness_pct: { type: 'number', derived: true },
+    total_marketing_items: { type: 'number', derived: true },
+    sds_created_count: { type: 'number', derived: true },
   },
   defaultData: {
-    go_decision: null,
-    launchType: null,
-    incident_response_plan: null,
-    monitoring_setup: null,
-    rollback_plan: null,
-    launch_tasks: [],
-    launch_date: null,
-    planned_launch_date: null,
-    actual_launch_date: null,
-    successCriteria: [],
-    rollbackTriggers: [],
-    decision: null,
-    blockProgression: false,
-    reasons: [],
+    marketing_items: [],
+    sd_bridge_payloads: [],
+    marketing_sds: [],
+    marketing_strategy_summary: null,
+    target_audience: null,
+    marketing_readiness_pct: 0,
+    total_marketing_items: 0,
+    sds_created_count: 0,
   },
 
   validate(data, { logger = console } = {}) {
     const errors = [];
 
-    const goCheck = validateEnum(data?.go_decision, 'go_decision', GO_DECISIONS);
-    if (!goCheck.valid) errors.push(goCheck.error);
-
-    const irpCheck = validateString(data?.incident_response_plan, 'incident_response_plan', 10);
-    if (!irpCheck.valid) errors.push(irpCheck.error);
-
-    const monCheck = validateString(data?.monitoring_setup, 'monitoring_setup', 10);
-    if (!monCheck.valid) errors.push(monCheck.error);
-
-    const rollbackCheck = validateString(data?.rollback_plan, 'rollback_plan', 10);
-    if (!rollbackCheck.valid) errors.push(rollbackCheck.error);
-
-    const tasksCheck = validateArray(data?.launch_tasks, 'launch_tasks', MIN_LAUNCH_TASKS);
-    if (!tasksCheck.valid) {
-      errors.push(tasksCheck.error);
+    const itemsCheck = validateArray(data?.marketing_items, 'marketing_items', MIN_MARKETING_ITEMS);
+    if (!itemsCheck.valid) {
+      errors.push(itemsCheck.error);
     } else {
-      for (let i = 0; i < data.launch_tasks.length; i++) {
-        const t = data.launch_tasks[i];
-        const prefix = `launch_tasks[${i}]`;
+      for (let i = 0; i < data.marketing_items.length; i++) {
+        const item = data.marketing_items[i];
+        const prefix = `marketing_items[${i}]`;
         const results = [
-          validateString(t?.name, `${prefix}.name`, 1),
-          validateString(t?.status, `${prefix}.status`, 1),
+          validateString(item?.title, `${prefix}.title`, 1),
+          validateString(item?.description, `${prefix}.description`, 1),
         ];
         errors.push(...collectErrors(results));
+
+        if (item?.type && !MARKETING_ITEM_TYPES.includes(item.type)) {
+          errors.push(`${prefix}.type must be one of [${MARKETING_ITEM_TYPES.join(', ')}] (got '${item.type}')`);
+        }
+        if (item?.priority && !MARKETING_PRIORITIES.includes(item.priority)) {
+          errors.push(`${prefix}.priority must be one of [${MARKETING_PRIORITIES.join(', ')}] (got '${item.priority}')`);
+        }
       }
     }
 
-    const dateCheck = validateString(data?.launch_date, 'launch_date', 1);
-    if (!dateCheck.valid) errors.push(dateCheck.error);
+    const summaryCheck = validateString(data?.marketing_strategy_summary, 'marketing_strategy_summary', 10);
+    if (!summaryCheck.valid) errors.push(summaryCheck.error);
 
     if (errors.length > 0) { logger.warn('[Stage23] Validation failed', { errorCount: errors.length, errors }); }
     return { valid: errors.length === 0, errors };
@@ -127,71 +116,40 @@ const TEMPLATE = {
 };
 
 /**
- * Pure function: evaluate Go/No-Go kill gate for Stage 23.
+ * Pure function: check Stage 22 release readiness prerequisite.
  *
- * @param {{ go_decision: string, incident_response_plan: string, monitoring_setup: string, rollback_plan: string, stage22Data?: Object }} params
- * @returns {{ decision: 'pass'|'kill', blockProgression: boolean, reasons: Object[] }}
+ * @param {{ stage22Data?: Object }} params
+ * @returns {{ ready: boolean, reasons: string[] }}
  */
-export function evaluateKillGate({ go_decision, incident_response_plan, monitoring_setup, rollback_plan, stage22Data }) {
+export function checkReleaseReadiness({ stage22Data }) {
   const reasons = [];
 
-  // Launch CC-3: Stage 22 release readiness must be confirmed before launch
-  if (stage22Data && !stage22Data.promotion_gate?.pass) {
-    const blockerCount = stage22Data.promotion_gate?.blockers?.length || 0;
-    reasons.push({
-      type: 'stage22_not_complete',
-      message: `Stage 22 release readiness not confirmed${blockerCount > 0 ? ` (${blockerCount} blocker(s))` : ''}`,
-    });
+  if (!stage22Data) {
+    reasons.push('Stage 22 release readiness data not available');
+    return { ready: false, reasons };
   }
 
-  // Launch CC-4: Stage 22 releaseDecision must approve before launch
-  if (stage22Data && stage22Data.releaseDecision) {
+  // Check promotion gate
+  if (!stage22Data.promotion_gate?.pass) {
+    reasons.push('Stage 22 promotion gate has not passed');
+  }
+
+  // Check release decision
+  if (stage22Data.releaseDecision) {
     const rd = stage22Data.releaseDecision;
-    if (rd.decision !== 'approve' && rd.decision !== 'approved') {
-      reasons.push({
-        type: 'release_not_approved',
-        message: `Stage 22 release decision: ${rd.decision}${rd.rationale ? ` — ${rd.rationale}` : ''}`,
-      });
+    if (rd.decision !== 'release' && rd.decision !== 'approved') {
+      reasons.push(`Stage 22 release decision is '${rd.decision}', not 'release'`);
     }
+  } else {
+    reasons.push('Stage 22 release decision not found');
   }
 
-  if (go_decision !== 'go' && go_decision !== 'conditional_go') {
-    reasons.push({
-      type: 'no_go_decision',
-      message: go_decision === 'no-go'
-        ? 'Launch decision is no-go'
-        : 'Go/no-go decision not set',
-    });
-  }
-
-  if (go_decision === 'go' || go_decision === 'conditional_go') {
-    if (!incident_response_plan || incident_response_plan.trim().length < 10) {
-      reasons.push({
-        type: 'missing_incident_response',
-        message: 'Incident response plan is required for GO decision',
-      });
-    }
-    if (!monitoring_setup || monitoring_setup.trim().length < 10) {
-      reasons.push({
-        type: 'missing_monitoring',
-        message: 'Monitoring setup is required for GO decision',
-      });
-    }
-    if (!rollback_plan || rollback_plan.trim().length < 10) {
-      reasons.push({
-        type: 'missing_rollback',
-        message: 'Rollback plan is required for GO decision',
-      });
-    }
-  }
-
-  const decision = reasons.length > 0 ? 'kill' : 'pass';
-  return { decision, blockProgression: decision === 'kill', reasons };
+  return { ready: reasons.length === 0, reasons };
 }
 
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage23;
 ensureOutputSchema(TEMPLATE);
 
-export { GO_DECISIONS, LAUNCH_TYPES, MIN_LAUNCH_TASKS };
+export { MARKETING_ITEM_TYPES, MARKETING_PRIORITIES, MIN_MARKETING_ITEMS };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-24.js
+++ b/lib/eva/stage-templates/stage-24.js
@@ -1,136 +1,139 @@
 /**
- * Stage 24 Template - Metrics & Learning
+ * Stage 24 Template - Launch Readiness
  * Phase: LAUNCH & LEARN (Stages 23-25)
- * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
- * AARRR framework metrics (Acquisition, Activation, Retention,
- * Revenue, Referral) with trend windows and funnel definitions.
+ * Chairman go/no-go launch decision gate with real upstream readiness data.
+ * Readiness checklist: release_confirmed, marketing_complete,
+ * monitoring_ready, rollback_plan_exists.
+ *
+ * Replaces the former Metrics & Learning template (AARRR framework
+ * becomes a continuous operations service, not a pipeline stage).
  *
  * @module lib/eva/stage-templates/stage-24
  */
 
-import { validateString, validateNumber, validateArray, collectErrors } from './validation.js';
+import { validateString, validateNumber, validateEnum, validateArray, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage24 } from './analysis-steps/stage-24-metrics-learning.js';
+import { analyzeStage24 } from './analysis-steps/stage-24-launch-readiness.js';
+import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
-const AARRR_CATEGORIES = ['acquisition', 'activation', 'retention', 'revenue', 'referral'];
-const TREND_DIRECTIONS = ['up', 'down', 'flat'];
-const IMPACT_LEVELS = ['high', 'medium', 'low'];
-const OUTCOME_ASSESSMENTS = ['success', 'partial', 'failure', 'indeterminate'];
-const MIN_METRICS_PER_CATEGORY = 1;
-const MIN_FUNNELS = 1;
+const GO_NO_GO_DECISIONS = ['go', 'no_go', 'conditional_go'];
+const CHECKLIST_ITEM_STATUSES = ['pass', 'fail', 'pending', 'waived'];
+
+const READINESS_CHECKLIST_KEYS = [
+  'release_confirmed',
+  'marketing_complete',
+  'monitoring_ready',
+  'rollback_plan_exists',
+];
+
+// Weights for readiness score computation
+const CHECKLIST_WEIGHTS = {
+  release_confirmed: 0.35,
+  marketing_complete: 0.25,
+  monitoring_ready: 0.20,
+  rollback_plan_exists: 0.20,
+};
 
 const TEMPLATE = {
   id: 'stage-24',
-  slug: 'metrics-learning',
-  title: 'Metrics & Learning',
-  version: '1.0.0',
+  slug: 'launch-readiness',
+  title: 'Launch Readiness',
+  version: '2.0.0',
   schema: {
-    aarrr: {
+    readiness_checklist: {
       type: 'object',
       required: true,
-      properties: Object.fromEntries(AARRR_CATEGORIES.map(cat => [cat, {
-        type: 'array',
-        minItems: MIN_METRICS_PER_CATEGORY,
-        items: {
-          name: { type: 'string', required: true },
-          value: { type: 'number', required: true },
-          target: { type: 'number', required: true },
-          previousValue: { type: 'number' },
-          trendDirection: { type: 'enum', values: TREND_DIRECTIONS },
-          trend_window_days: { type: 'number', min: 1 },
-          criterionRef: { type: 'string' },
+      properties: Object.fromEntries(READINESS_CHECKLIST_KEYS.map(key => [key, {
+        type: 'object',
+        fields: {
+          status: { type: 'enum', values: CHECKLIST_ITEM_STATUSES, required: true },
+          evidence: { type: 'string', required: true },
+          verified_at: { type: 'string' },
         },
       }])),
     },
-    funnels: {
+    go_no_go_decision: { type: 'enum', values: GO_NO_GO_DECISIONS },
+    decision_rationale: { type: 'string', minLength: 10 },
+    incident_response_plan: { type: 'string', minLength: 10, required: true },
+    monitoring_setup: { type: 'string', minLength: 10, required: true },
+    rollback_plan: { type: 'string', minLength: 10, required: true },
+    launch_risks: {
       type: 'array',
-      minItems: MIN_FUNNELS,
       items: {
-        name: { type: 'string', required: true },
-        steps: { type: 'array', minItems: 2 },
+        risk: { type: 'string', required: true },
+        severity: { type: 'enum', values: ['critical', 'high', 'medium', 'low'] },
+        mitigation: { type: 'string', required: true },
       },
     },
-    learnings: {
-      type: 'array',
-      items: {
-        insight: { type: 'string', required: true },
-        action: { type: 'string', required: true },
-        category: { type: 'string' },
-        impactLevel: { type: 'enum', values: IMPACT_LEVELS },
+    // Chairman governance gate
+    chairmanGate: {
+      type: 'object',
+      fields: {
+        status: { type: 'string' },
+        rationale: { type: 'string' },
+        decision_id: { type: 'string' },
       },
     },
     // Derived
-    total_metrics: { type: 'number', derived: true },
-    categories_complete: { type: 'boolean', derived: true },
-    funnel_count: { type: 'number', derived: true },
-    metrics_on_target: { type: 'number', derived: true },
-    metrics_below_target: { type: 'number', derived: true },
-    launchOutcome: { type: 'object', derived: true },
+    readiness_score: { type: 'number', derived: true },
+    all_checks_pass: { type: 'boolean', derived: true },
+    blocking_items: { type: 'array', derived: true },
   },
   defaultData: {
-    aarrr: {},
-    funnels: [],
-    learnings: [],
-    total_metrics: 0,
-    categories_complete: false,
-    funnel_count: 0,
-    metrics_on_target: 0,
-    metrics_below_target: 0,
-    launchOutcome: null,
+    readiness_checklist: Object.fromEntries(
+      READINESS_CHECKLIST_KEYS.map(key => [key, { status: 'pending', evidence: null, verified_at: null }])
+    ),
+    go_no_go_decision: null,
+    decision_rationale: null,
+    incident_response_plan: null,
+    monitoring_setup: null,
+    rollback_plan: null,
+    launch_risks: [],
+    chairmanGate: { status: 'pending', rationale: null, decision_id: null },
+    readiness_score: 0,
+    all_checks_pass: false,
+    blocking_items: [],
   },
 
   validate(data, { logger = console } = {}) {
     const errors = [];
 
-    if (!data?.aarrr || typeof data.aarrr !== 'object') {
-      errors.push('aarrr is required and must be an object');
-      return { valid: false, errors };
-    }
-
-    for (const cat of AARRR_CATEGORIES) {
-      const metrics = data.aarrr[cat];
-      const arrCheck = validateArray(metrics, `aarrr.${cat}`, MIN_METRICS_PER_CATEGORY);
-      if (!arrCheck.valid) {
-        errors.push(arrCheck.error);
-        continue;
-      }
-      for (let i = 0; i < metrics.length; i++) {
-        const m = metrics[i];
-        const prefix = `aarrr.${cat}[${i}]`;
-        const results = [
-          validateString(m?.name, `${prefix}.name`, 1),
-          validateNumber(m?.value, `${prefix}.value`, 0),
-          validateNumber(m?.target, `${prefix}.target`, 0),
-        ];
-        errors.push(...collectErrors(results));
-      }
-    }
-
-    const funnelCheck = validateArray(data?.funnels, 'funnels', MIN_FUNNELS);
-    if (!funnelCheck.valid) {
-      errors.push(funnelCheck.error);
+    // Validate readiness checklist
+    if (!data?.readiness_checklist || typeof data.readiness_checklist !== 'object') {
+      errors.push('readiness_checklist is required and must be an object');
     } else {
-      for (let i = 0; i < data.funnels.length; i++) {
-        const f = data.funnels[i];
-        const prefix = `funnels[${i}]`;
-        const nameCheck = validateString(f?.name, `${prefix}.name`, 1);
-        if (!nameCheck.valid) errors.push(nameCheck.error);
-        const stepsCheck = validateArray(f?.steps, `${prefix}.steps`, 2);
-        if (!stepsCheck.valid) errors.push(stepsCheck.error);
+      for (const key of READINESS_CHECKLIST_KEYS) {
+        const item = data.readiness_checklist[key];
+        if (!item) {
+          errors.push(`readiness_checklist.${key} is required`);
+          continue;
+        }
+        if (!CHECKLIST_ITEM_STATUSES.includes(item.status)) {
+          errors.push(`readiness_checklist.${key}.status must be one of [${CHECKLIST_ITEM_STATUSES.join(', ')}]`);
+        }
+        const evidenceCheck = validateString(item?.evidence, `readiness_checklist.${key}.evidence`, 1);
+        if (!evidenceCheck.valid) errors.push(evidenceCheck.error);
       }
     }
 
-    if (data?.learnings && Array.isArray(data.learnings)) {
-      for (let i = 0; i < data.learnings.length; i++) {
-        const l = data.learnings[i];
-        const prefix = `learnings[${i}]`;
-        const results = [
-          validateString(l?.insight, `${prefix}.insight`, 1),
-          validateString(l?.action, `${prefix}.action`, 1),
-        ];
-        errors.push(...collectErrors(results));
-      }
+    // Validate operational readiness items
+    const irpCheck = validateString(data?.incident_response_plan, 'incident_response_plan', 10);
+    if (!irpCheck.valid) errors.push(irpCheck.error);
+
+    const monCheck = validateString(data?.monitoring_setup, 'monitoring_setup', 10);
+    if (!monCheck.valid) errors.push(monCheck.error);
+
+    const rollbackCheck = validateString(data?.rollback_plan, 'rollback_plan', 10);
+    if (!rollbackCheck.valid) errors.push(rollbackCheck.error);
+
+    // Chairman governance gate check
+    const gateStatus = data?.chairmanGate?.status;
+    if (gateStatus === 'rejected') {
+      errors.push(`Chairman gate rejected: ${data.chairmanGate.rationale || 'No rationale provided'}`);
+    } else if (gateStatus !== 'approved') {
+      errors.push('Chairman launch readiness gate is pending — awaiting chairman decision');
     }
 
     if (errors.length > 0) { logger.warn('[Stage24] Validation failed', { errorCount: errors.length, errors }); }
@@ -143,9 +146,61 @@ const TEMPLATE = {
   },
 };
 
+/**
+ * Pure function: compute readiness score from checklist items.
+ *
+ * @param {{ readiness_checklist: Object }} params
+ * @returns {{ readiness_score: number, all_checks_pass: boolean, blocking_items: string[] }}
+ */
+export function computeReadinessScore({ readiness_checklist }) {
+  if (!readiness_checklist || typeof readiness_checklist !== 'object') {
+    return { readiness_score: 0, all_checks_pass: false, blocking_items: READINESS_CHECKLIST_KEYS.slice() };
+  }
+
+  let weightedScore = 0;
+  const blocking_items = [];
+
+  for (const key of READINESS_CHECKLIST_KEYS) {
+    const item = readiness_checklist[key];
+    const weight = CHECKLIST_WEIGHTS[key] || 0;
+
+    if (item?.status === 'pass') {
+      weightedScore += weight * 100;
+    } else if (item?.status === 'waived') {
+      weightedScore += weight * 50; // Waived counts as partial
+    } else {
+      blocking_items.push(key);
+    }
+  }
+
+  const readiness_score = Math.round(weightedScore);
+  const all_checks_pass = blocking_items.length === 0;
+
+  return { readiness_score, all_checks_pass, blocking_items };
+}
+
+/**
+ * Pre-analysis hook: create or reuse a PENDING chairman decision.
+ * Blocks launch until chairman reviews readiness and approves.
+ */
+TEMPLATE.onBeforeAnalysis = async function onBeforeAnalysis(supabase, ventureId) {
+  const { id, isNew } = await createOrReusePendingDecision({
+    ventureId,
+    stageNumber: 24,
+    summary: 'Chairman launch readiness go/no-go decision required for Stage 24',
+    supabase,
+  });
+  return { chairmanDecisionId: id, isNew };
+};
+
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage24;
 ensureOutputSchema(TEMPLATE);
 
-export { AARRR_CATEGORIES, TREND_DIRECTIONS, IMPACT_LEVELS, OUTCOME_ASSESSMENTS, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS };
+export {
+  GO_NO_GO_DECISIONS,
+  CHECKLIST_ITEM_STATUSES,
+  READINESS_CHECKLIST_KEYS,
+  CHECKLIST_WEIGHTS,
+};
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -1,201 +1,141 @@
 /**
- * Stage 25 Template - Venture Review
+ * Stage 25 Template - Launch Execution
  * Phase: LAUNCH & LEARN (Stages 23-25)
- * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
- * Final venture review with 5-category initiatives,
- * drift detection against Stage 1 vision/constraints,
- * and drift justification requirement.
+ * Pipeline terminus: execute go-live, activate distribution channels,
+ * and hand off to operations. Sets ventures.pipeline_mode to 'operations'.
+ *
+ * Replaces the former Venture Review template (drift detection and
+ * venture health assessment become continuous operations services).
  *
  * @module lib/eva/stage-templates/stage-25
  */
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage25 } from './analysis-steps/stage-25-venture-review.js';
-import { extractTemplate } from '../template-extractor.js';
-import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
+import { analyzeStage25 } from './analysis-steps/stage-25-launch-execution.js';
 
-const REVIEW_CATEGORIES = ['product', 'market', 'technical', 'financial', 'team'];
-const INITIATIVE_STATUSES = ['planned', 'in_progress', 'completed', 'abandoned', 'deferred'];
-const VENTURE_DECISIONS = ['continue', 'pivot', 'expand', 'sunset', 'exit'];
-const CONFIDENCE_LEVELS = ['high', 'medium', 'low'];
-const NEXT_STEP_PRIORITIES = ['critical', 'high', 'medium', 'low'];
-const SEMANTIC_DRIFT_LEVELS = ['aligned', 'moderate_drift', 'major_drift'];
-const HEALTH_BANDS = ['critical', 'fragile', 'viable', 'strong'];
-const MIN_INITIATIVES_PER_CATEGORY = 1;
+const CHANNEL_STATUSES = ['inactive', 'activating', 'active', 'failed', 'paused'];
+const PIPELINE_MODES = ['discovery', 'build', 'launch', 'operations'];
+const ESCALATION_LEVELS = ['L1', 'L2', 'L3'];
+const MIN_DISTRIBUTION_CHANNELS = 1;
 
 const TEMPLATE = {
   id: 'stage-25',
-  slug: 'venture-review',
-  title: 'Venture Review',
-  version: '1.0.0',
+  slug: 'launch-execution',
+  title: 'Launch Execution',
+  version: '2.0.0',
   schema: {
-    review_summary: { type: 'string', minLength: 20, required: true },
-    initiatives: {
+    distribution_channels: {
+      type: 'array',
+      minItems: MIN_DISTRIBUTION_CHANNELS,
+      required: true,
+      items: {
+        name: { type: 'string', required: true },
+        type: { type: 'string', required: true },
+        status: { type: 'enum', values: CHANNEL_STATUSES, required: true },
+        activation_date: { type: 'string' },
+        metrics_endpoint: { type: 'string' },
+      },
+    },
+    operations_handoff: {
       type: 'object',
       required: true,
-      properties: Object.fromEntries(REVIEW_CATEGORIES.map(cat => [cat, {
-        type: 'array',
-        minItems: MIN_INITIATIVES_PER_CATEGORY,
-        items: {
-          title: { type: 'string', required: true },
-          status: { type: 'enum', values: INITIATIVE_STATUSES, required: true },
-          outcome: { type: 'string', required: true },
-        },
-      }])),
-    },
-    current_vision: { type: 'string', minLength: 10, required: true },
-    drift_justification: { type: 'string' },
-    next_steps: {
-      type: 'array',
-      minItems: 1,
-      items: {
-        action: { type: 'string', required: true },
-        owner: { type: 'string', required: true },
-        timeline: { type: 'string', required: true },
-        priority: { type: 'enum', values: NEXT_STEP_PRIORITIES },
-        category: { type: 'string' },
-      },
-    },
-    // Chairman governance gate (SD-EVA-FIX-CHAIRMAN-GATES-001)
-    chairmanGate: {
-      type: 'object',
       fields: {
-        status: { type: 'string' },
-        rationale: { type: 'string' },
-        decision_id: { type: 'string' },
-      },
-    },
-    financialComparison: {
-      type: 'object',
-      fields: {
-        projectedRevenue: { type: 'string' },
-        actualRevenue: { type: 'string' },
-        projectedCosts: { type: 'string' },
-        actualCosts: { type: 'string' },
-        revenueVariancePct: { type: 'number' },
-        financialTrajectory: { type: 'enum', values: ['above_plan', 'on_plan', 'below_plan', 'critical'] },
-        variance: { type: 'string' },
-        assessment: { type: 'string' },
-      },
-    },
-    ventureHealth: {
-      type: 'object',
-      fields: {
-        overallRating: { type: 'enum', values: HEALTH_BANDS },
-        dimensions: {
+        monitoring: {
           type: 'object',
-          properties: Object.fromEntries(REVIEW_CATEGORIES.map(cat => [cat, {
-            type: 'object',
-            fields: {
-              score: { type: 'number', min: 0, max: 100 },
-              rationale: { type: 'string' },
-            },
-          }])),
+          fields: {
+            dashboards: { type: 'array' },
+            alerts: { type: 'array' },
+            health_check_url: { type: 'string' },
+          },
+        },
+        escalation: {
+          type: 'object',
+          fields: {
+            contacts: { type: 'array' },
+            runbook_url: { type: 'string' },
+            sla_targets: { type: 'object' },
+          },
+        },
+        maintenance: {
+          type: 'object',
+          fields: {
+            schedule: { type: 'string' },
+            backup_strategy: { type: 'string' },
+            update_policy: { type: 'string' },
+          },
         },
       },
     },
-    // Expansion analysis (populated when ventureDecision is 'expand')
-    expansionAnalysis: {
-      type: 'object',
-      fields: {
-        vectors: { type: 'object' },
-        readinessScore: { type: 'number', min: 0, max: 100 },
-      },
-    },
-    expansionReadinessScore: { type: 'number', min: 0, max: 100 },
+    launch_summary: { type: 'string', minLength: 10, required: true },
+    go_live_timestamp: { type: 'string' },
     // Derived
-    total_initiatives: { type: 'number', derived: true },
-    all_categories_reviewed: { type: 'boolean', derived: true },
-    drift_detected: { type: 'boolean', derived: true },
-    drift_check: { type: 'object', derived: true },
-    ventureDecision: { type: 'object', derived: true },
+    pipeline_terminus: { type: 'boolean', derived: true },
+    pipeline_mode: { type: 'enum', values: PIPELINE_MODES, derived: true },
+    channels_active_count: { type: 'number', derived: true },
+    channels_total_count: { type: 'number', derived: true },
   },
   defaultData: {
-    review_summary: null,
-    initiatives: {},
-    current_vision: null,
-    drift_justification: null,
-    next_steps: [],
-    financialComparison: { projectedRevenue: null, actualRevenue: null, projectedCosts: null, actualCosts: null, revenueVariancePct: null, financialTrajectory: null, variance: null, assessment: null },
-    ventureHealth: { overallRating: null, dimensions: {} },
-    expansionAnalysis: null,
-    expansionReadinessScore: null,
-    chairmanGate: { status: 'pending', rationale: null, decision_id: null },
-    total_initiatives: 0,
-    all_categories_reviewed: false,
-    drift_detected: false,
-    drift_check: null,
-    ventureDecision: null,
+    distribution_channels: [],
+    operations_handoff: {
+      monitoring: { dashboards: [], alerts: [], health_check_url: null },
+      escalation: { contacts: [], runbook_url: null, sla_targets: {} },
+      maintenance: { schedule: null, backup_strategy: null, update_policy: null },
+    },
+    launch_summary: null,
+    go_live_timestamp: null,
+    pipeline_terminus: false,
+    pipeline_mode: 'launch',
+    channels_active_count: 0,
+    channels_total_count: 0,
   },
 
   validate(data, { logger = console } = {}) {
     const errors = [];
 
-    const summaryCheck = validateString(data?.review_summary, 'review_summary', 20);
-    if (!summaryCheck.valid) errors.push(summaryCheck.error);
-
-    if (!data?.initiatives || typeof data.initiatives !== 'object') {
-      errors.push('initiatives is required and must be an object');
+    // Validate distribution channels
+    const channelsCheck = validateArray(data?.distribution_channels, 'distribution_channels', MIN_DISTRIBUTION_CHANNELS);
+    if (!channelsCheck.valid) {
+      errors.push(channelsCheck.error);
     } else {
-      for (const cat of REVIEW_CATEGORIES) {
-        const items = data.initiatives[cat];
-        const arrCheck = validateArray(items, `initiatives.${cat}`, MIN_INITIATIVES_PER_CATEGORY);
-        if (!arrCheck.valid) {
-          errors.push(arrCheck.error);
-          continue;
-        }
-        for (let i = 0; i < items.length; i++) {
-          const item = items[i];
-          const prefix = `initiatives.${cat}[${i}]`;
-          const results = [
-            validateString(item?.title, `${prefix}.title`, 1),
-            validateEnum(item?.status, `${prefix}.status`, INITIATIVE_STATUSES),
-            validateString(item?.outcome, `${prefix}.outcome`, 1),
-          ];
-          errors.push(...collectErrors(results));
-        }
-      }
-    }
-
-    const visionCheck = validateString(data?.current_vision, 'current_vision', 10);
-    if (!visionCheck.valid) errors.push(visionCheck.error);
-
-    const stepsCheck = validateArray(data?.next_steps, 'next_steps', 1);
-    if (!stepsCheck.valid) {
-      errors.push(stepsCheck.error);
-    } else {
-      for (let i = 0; i < data.next_steps.length; i++) {
-        const ns = data.next_steps[i];
-        const prefix = `next_steps[${i}]`;
+      for (let i = 0; i < data.distribution_channels.length; i++) {
+        const ch = data.distribution_channels[i];
+        const prefix = `distribution_channels[${i}]`;
         const results = [
-          validateString(ns?.action, `${prefix}.action`, 1),
-          validateString(ns?.owner, `${prefix}.owner`, 1),
-          validateString(ns?.timeline, `${prefix}.timeline`, 1),
+          validateString(ch?.name, `${prefix}.name`, 1),
+          validateString(ch?.type, `${prefix}.type`, 1),
         ];
         errors.push(...collectErrors(results));
+
+        if (ch?.status && !CHANNEL_STATUSES.includes(ch.status)) {
+          errors.push(`${prefix}.status must be one of [${CHANNEL_STATUSES.join(', ')}] (got '${ch.status}')`);
+        }
       }
     }
 
-    // Chairman governance gate check
-    const gateStatus = data?.chairmanGate?.status;
-    if (gateStatus === 'rejected') {
-      errors.push(`Chairman gate rejected: ${data.chairmanGate.rationale || 'No rationale provided'}`);
-    } else if (gateStatus !== 'approved') {
-      errors.push('Chairman venture review gate is pending — awaiting chairman decision');
+    // Validate operations handoff
+    if (!data?.operations_handoff || typeof data.operations_handoff !== 'object') {
+      errors.push('operations_handoff is required and must be an object');
+    } else {
+      const handoff = data.operations_handoff;
+      if (!handoff.monitoring || typeof handoff.monitoring !== 'object') {
+        errors.push('operations_handoff.monitoring is required');
+      }
+      if (!handoff.escalation || typeof handoff.escalation !== 'object') {
+        errors.push('operations_handoff.escalation is required');
+      }
     }
+
+    // Validate launch summary
+    const summaryCheck = validateString(data?.launch_summary, 'launch_summary', 10);
+    if (!summaryCheck.valid) errors.push(summaryCheck.error);
 
     if (errors.length > 0) { logger.warn('[Stage25] Validation failed', { errorCount: errors.length, errors }); }
     return { valid: errors.length === 0, errors };
   },
 
-  /**
-   * Compute derived fields including drift detection.
-   * @param {Object} data - Validated input data
-   * @param {Object} [prerequisites] - Optional: { stage01 } for drift detection
-   * @returns {Object} Data with derived fields
-   */
   computeDerived(data, _prerequisites, { logger: _logger = console } = {}) {
     // Dead code: all derivations handled by analysisStep.
     return { ...data };
@@ -203,78 +143,37 @@ const TEMPLATE = {
 };
 
 /**
- * Pure function: detect drift between original and current vision.
- * Drift is detected when current_vision differs significantly from original.
+ * Pure function: verify Stage 24 chairman gate approval before launch.
  *
- * @param {{ original_vision: string|null, current_vision: string }} params
- * @returns {{ drift_detected: boolean, rationale: string, original_vision: string|null, current_vision: string }}
+ * @param {{ stage24Data?: Object }} params
+ * @returns {{ authorized: boolean, reasons: string[] }}
  */
-export function detectDrift({ original_vision, current_vision }) {
-  if (!original_vision) {
-    return {
-      drift_detected: false,
-      rationale: 'No original vision available for comparison',
-      original_vision,
-      current_vision,
-    };
+export function verifyLaunchAuthorization({ stage24Data }) {
+  const reasons = [];
+
+  if (!stage24Data) {
+    reasons.push('Stage 24 launch readiness data not available');
+    return { authorized: false, reasons };
   }
 
-  // Simple drift detection: check if visions share significant overlap
-  const originalWords = new Set(original_vision.toLowerCase().split(/\s+/).filter(w => w.length > 3));
-  const currentWords = new Set(current_vision.toLowerCase().split(/\s+/).filter(w => w.length > 3));
-
-  let overlap = 0;
-  for (const word of originalWords) {
-    if (currentWords.has(word)) overlap++;
+  // Check chairman gate
+  const gateStatus = stage24Data.chairmanGate?.status;
+  if (gateStatus !== 'approved') {
+    reasons.push(`Stage 24 chairman gate status is '${gateStatus || 'unknown'}', not 'approved'`);
   }
 
-  const overlapRatio = originalWords.size > 0 ? overlap / originalWords.size : 1;
-  const drift_detected = overlapRatio < 0.3;
+  // Check go/no-go decision
+  const decision = stage24Data.go_no_go_decision;
+  if (decision !== 'go' && decision !== 'conditional_go') {
+    reasons.push(`Stage 24 go/no-go decision is '${decision || 'not set'}', expected 'go' or 'conditional_go'`);
+  }
 
-  const rationale = drift_detected
-    ? `Significant drift detected: only ${Math.round(overlapRatio * 100)}% overlap with original vision`
-    : `Vision aligned: ${Math.round(overlapRatio * 100)}% overlap with original vision`;
-
-  return { drift_detected, rationale, original_vision, current_vision };
+  return { authorized: reasons.length === 0, reasons };
 }
-
-/**
- * Pre-analysis hook: create or reuse a PENDING chairman decision.
- * Blocks venture progression until chairman reviews venture and approves continued investment.
- */
-TEMPLATE.onBeforeAnalysis = async function onBeforeAnalysis(supabase, ventureId) {
-  const { id, isNew } = await createOrReusePendingDecision({
-    ventureId,
-    stageNumber: 25,
-    summary: 'Chairman venture review approval required for Stage 25',
-    supabase,
-  });
-  return { chairmanDecisionId: id, isNew };
-};
 
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage25;
 ensureOutputSchema(TEMPLATE);
 
-/**
- * Post-completion hook: Extract a reusable template after Stage 25 finishes.
- * SD-EVA-FEAT-VENTURE-TEMPLATES-001 (FR-8)
- *
- * Called after the chairman makes a Stage 25 decision. Runs async
- * (off the critical path) to avoid blocking the review flow.
- *
- * @param {import('@supabase/supabase-js').SupabaseClient} supabase
- * @param {string} ventureId
- * @returns {Promise<{id: string, template_name: string, template_version: number}|null>}
- */
-TEMPLATE.onComplete = async function onComplete(supabase, ventureId) {
-  try {
-    return await extractTemplate(supabase, ventureId);
-  } catch (err) {
-    console.warn(`Template extraction failed for venture ${ventureId}: ${err.message}`);
-    return null;
-  }
-};
-
-export { REVIEW_CATEGORIES, INITIATIVE_STATUSES, VENTURE_DECISIONS, CONFIDENCE_LEVELS, NEXT_STEP_PRIORITIES, SEMANTIC_DRIFT_LEVELS, HEALTH_BANDS, MIN_INITIATIVES_PER_CATEGORY };
+export { CHANNEL_STATUSES, PIPELINE_MODES, ESCALATION_LEVELS, MIN_DISTRIBUTION_CHANNELS };
 export default TEMPLATE;

--- a/tests/unit/eva/stage-templates/index.test.js
+++ b/tests/unit/eva/stage-templates/index.test.js
@@ -2,7 +2,8 @@
  * Unit tests for stage templates index/registry
  * Part of SD-LEO-FEAT-TMPL-TRUTH-001, SD-LEO-FEAT-TMPL-ENGINE-001,
  *   SD-LEO-FEAT-TMPL-IDENTITY-001, SD-LEO-FEAT-TMPL-BLUEPRINT-001,
- *   SD-LEO-FEAT-TMPL-BUILD-001, SD-LEO-FEAT-TMPL-LAUNCH-001
+ *   SD-LEO-FEAT-TMPL-BUILD-001, SD-LEO-FEAT-TMPL-LAUNCH-001,
+ *   SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
  * Test Scenario TS-5: Registry returns correct templates (stages 1-25)
  *
@@ -39,12 +40,12 @@ import {
   evaluateStage03KillGate,
   evaluateStage05KillGate,
   evaluateStage13KillGate,
-  evaluateStage23KillGate,
+  checkReleaseReadiness,
   evaluatePhase2RealityGate,
   evaluatePhase3RealityGate,
   evaluatePhase4PromotionGate,
   evaluatePhase5PromotionGate,
-  detectDrift,
+  verifyLaunchAuthorization,
   getTemplate,
   getAllTemplates,
 } from '../../../../lib/eva/stage-templates/index.js';
@@ -222,9 +223,9 @@ describe('index.js - Stage templates registry', () => {
       expect(stage25).toBeDefined();
     });
 
-    it('should export Phase 6 gate and drift detection functions', () => {
-      expect(typeof evaluateStage23KillGate).toBe('function');
-      expect(typeof detectDrift).toBe('function');
+    it('should export Phase 6 gate functions', () => {
+      expect(typeof checkReleaseReadiness).toBe('function');
+      expect(typeof verifyLaunchAuthorization).toBe('function');
     });
 
     it('should have correct Phase 6 template IDs', () => {
@@ -234,15 +235,15 @@ describe('index.js - Stage templates registry', () => {
     });
 
     it('should have correct Phase 6 template slugs', () => {
-      expect(stage23.slug).toBe('launch-execution');
-      expect(stage24.slug).toBe('metrics-learning');
-      expect(stage25.slug).toBe('venture-review');
+      expect(stage23.slug).toBe('marketing-preparation');
+      expect(stage24.slug).toBe('launch-readiness');
+      expect(stage25.slug).toBe('launch-execution');
     });
 
     it('should have correct Phase 6 template titles', () => {
-      expect(stage23.title).toBe('Launch Execution');
-      expect(stage24.title).toBe('Metrics & Learning');
-      expect(stage25.title).toBe('Venture Review');
+      expect(stage23.title).toBe('Marketing Preparation');
+      expect(stage24.title).toBe('Launch Readiness');
+      expect(stage25.title).toBe('Launch Execution');
     });
   });
 
@@ -325,21 +326,21 @@ describe('index.js - Stage templates registry', () => {
       const template = getTemplate(23);
       expect(template).toBe(stage23);
       expect(template.id).toBe('stage-23');
-      expect(template.slug).toBe('launch-execution');
+      expect(template.slug).toBe('marketing-preparation');
     });
 
     it('should return stage24 for stageNumber 24', () => {
       const template = getTemplate(24);
       expect(template).toBe(stage24);
       expect(template.id).toBe('stage-24');
-      expect(template.slug).toBe('metrics-learning');
+      expect(template.slug).toBe('launch-readiness');
     });
 
     it('should return stage25 for stageNumber 25', () => {
       const template = getTemplate(25);
       expect(template).toBe(stage25);
       expect(template.id).toBe('stage-25');
-      expect(template.slug).toBe('venture-review');
+      expect(template.slug).toBe('launch-execution');
     });
 
     it('should return null for invalid stage numbers', () => {
@@ -454,23 +455,38 @@ describe('index.js - Stage templates registry', () => {
       expect(result.blockers).toEqual([]);
     });
 
-    it('evaluateStage23KillGate should work correctly', () => {
-      const result = evaluateStage23KillGate({
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
+    it('checkReleaseReadiness should work correctly', () => {
+      const result = checkReleaseReadiness({
+        stage22Data: {
+          promotion_gate: { pass: true, blockers: [] },
+          releaseDecision: { decision: 'release' },
+        },
       });
-      expect(result.decision).toBe('pass');
-      expect(result.blockProgression).toBe(false);
+      expect(result.ready).toBe(true);
+      expect(result.reasons).toEqual([]);
     });
 
-    it('detectDrift should work correctly', () => {
-      const result = detectDrift({
-        original_vision: 'Building revolutionary platform technology solutions',
-        current_vision: 'Building revolutionary platform technology solutions',
+    it('checkReleaseReadiness should detect missing stage22Data', () => {
+      const result = checkReleaseReadiness({ stage22Data: undefined });
+      expect(result.ready).toBe(false);
+      expect(result.reasons.length).toBeGreaterThan(0);
+    });
+
+    it('verifyLaunchAuthorization should work correctly', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'approved' },
+          go_no_go_decision: 'go',
+        },
       });
-      expect(result.drift_detected).toBe(false);
+      expect(result.authorized).toBe(true);
+      expect(result.reasons).toEqual([]);
+    });
+
+    it('verifyLaunchAuthorization should detect missing stage24Data', () => {
+      const result = verifyLaunchAuthorization({ stage24Data: undefined });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons.length).toBeGreaterThan(0);
     });
   });
 
@@ -608,14 +624,14 @@ describe('index.js - Stage templates registry', () => {
   describe('Round-trip determinism for stages 23-25', () => {
     it('should produce deterministic output for stage 23', () => {
       const input = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [
-          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
+        marketing_items: [
+          { title: 'Landing Page', description: 'Main page', type: 'landing_page', priority: 'critical' },
+          { title: 'Press Release', description: 'Launch PR', type: 'press_release', priority: 'high' },
+          { title: 'Email', description: 'Launch email', type: 'email_campaign', priority: 'medium' },
         ],
-        launch_date: '2026-03-01',
+        marketing_strategy_summary: 'Comprehensive marketing strategy for launch',
+        sd_bridge_payloads: [],
+        marketing_sds: [],
       };
       const result1 = stage23.computeDerived(input);
       const result2 = stage23.computeDerived(input);
@@ -624,19 +640,16 @@ describe('index.js - Stage templates registry', () => {
 
     it('should produce deterministic output for stage 24', () => {
       const input = {
-        aarrr: {
-          acquisition: [{ name: 'Signups', value: 100, target: 150 }],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        readiness_checklist: {
+          release_confirmed: { status: 'pass', evidence: 'Verified' },
+          marketing_complete: { status: 'pass', evidence: 'Ready' },
+          monitoring_ready: { status: 'pass', evidence: 'Configured' },
+          rollback_plan_exists: { status: 'pass', evidence: 'Approved' },
         },
-        funnels: [
-          { name: 'Signup funnel', steps: ['Landing', 'Signup', 'Activation'] },
-        ],
-        learnings: [
-          { insight: 'Users drop off at step 2', action: 'Simplify onboarding' },
-        ],
+        incident_response_plan: 'Full incident response plan details here',
+        monitoring_setup: 'Full monitoring setup details here',
+        rollback_plan: 'Full rollback plan details here',
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
       const result1 = stage24.computeDerived(input);
       const result2 = stage24.computeDerived(input);
@@ -645,18 +658,15 @@ describe('index.js - Stage templates registry', () => {
 
     it('should produce deterministic output for stage 25', () => {
       const input = {
-        review_summary: 'Comprehensive review of all venture aspects',
-        initiatives: {
-          product: [{ title: 'MVP Launch', status: 'complete', outcome: 'Success' }],
-          market: [{ title: 'Market Analysis', status: 'complete', outcome: 'Success' }],
-          technical: [{ title: 'Infrastructure', status: 'complete', outcome: 'Success' }],
-          financial: [{ title: 'Funding Round', status: 'complete', outcome: 'Success' }],
-          team: [{ title: 'Team Expansion', status: 'complete', outcome: 'Success' }],
-        },
-        current_vision: 'Building revolutionary platform technology solutions',
-        next_steps: [
-          { action: 'Launch next phase', owner: 'CEO', timeline: 'Q1 2026' },
+        distribution_channels: [
+          { name: 'Web App', type: 'web', status: 'active' },
         ],
+        operations_handoff: {
+          monitoring: { dashboards: ['main'], alerts: ['cpu'] },
+          escalation: { contacts: ['ops@example.com'] },
+        },
+        launch_summary: 'Comprehensive launch execution summary',
+        go_live_timestamp: '2026-03-01T00:00:00Z',
       };
       const result1 = stage25.computeDerived(input);
       const result2 = stage25.computeDerived(input);

--- a/tests/unit/eva/stage-templates/stage-23.test.js
+++ b/tests/unit/eva/stage-templates/stage-23.test.js
@@ -1,637 +1,402 @@
 /**
- * Unit tests for Stage 23 - Launch Execution template
- * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ * Unit tests for Stage 23 - Marketing Preparation template
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
- * Test Scenario: Stage 23 validation enforces Go/No-Go kill gate with
- * incident response, monitoring, and rollback plan requirements.
+ * Test Scenario: Stage 23 validation enforces marketing item requirements,
+ * marketing strategy summary, and release readiness checks against Stage 22.
  *
  * @module tests/unit/eva/stage-templates/stage-23.test
  */
 
 import { describe, it, expect } from 'vitest';
-import stage23, { evaluateKillGate, GO_DECISIONS, LAUNCH_TYPES, MIN_LAUNCH_TASKS } from '../../../../lib/eva/stage-templates/stage-23.js';
+import stage23, {
+  checkReleaseReadiness,
+  MARKETING_ITEM_TYPES,
+  MARKETING_PRIORITIES,
+  MIN_MARKETING_ITEMS,
+} from '../../../../lib/eva/stage-templates/stage-23.js';
 
-describe('stage-23.js - Launch Execution template', () => {
-  describe('Template metadata', () => {
-    it('should have correct template structure', () => {
+describe('stage-23.js - Marketing Preparation template', () => {
+  describe('Template contract', () => {
+    it('should export TEMPLATE with required properties', () => {
+      expect(stage23).toBeDefined();
+      expect(stage23.id).toBeDefined();
+      expect(stage23.slug).toBeDefined();
+      expect(stage23.title).toBeDefined();
+      expect(stage23.version).toBeDefined();
+    });
+
+    it('should have correct id, slug, title, version', () => {
       expect(stage23.id).toBe('stage-23');
-      expect(stage23.slug).toBe('launch-execution');
-      expect(stage23.title).toBe('Launch Execution');
-      expect(stage23.version).toBe('1.0.0');
+      expect(stage23.slug).toBe('marketing-preparation');
+      expect(stage23.title).toBe('Marketing Preparation');
+      expect(stage23.version).toBe('2.0.0');
     });
 
-    it('should have schema definition', () => {
+    it('should have schema, defaultData, validate, computeDerived', () => {
       expect(stage23.schema).toBeDefined();
-      expect(stage23.schema.go_decision).toBeDefined();
-      expect(stage23.schema.incident_response_plan).toBeDefined();
-      expect(stage23.schema.monitoring_setup).toBeDefined();
-      expect(stage23.schema.rollback_plan).toBeDefined();
-      expect(stage23.schema.launch_tasks).toBeDefined();
-      expect(stage23.schema.launch_date).toBeDefined();
-      expect(stage23.schema.decision).toBeDefined();
-      expect(stage23.schema.blockProgression).toBeDefined();
-      expect(stage23.schema.reasons).toBeDefined();
-    });
-
-    it('should have defaultData', () => {
-      expect(stage23.defaultData).toEqual({
-        go_decision: null,
-        launchType: null,
-        incident_response_plan: null,
-        monitoring_setup: null,
-        rollback_plan: null,
-        launch_tasks: [],
-        launch_date: null,
-        planned_launch_date: null,
-        actual_launch_date: null,
-        successCriteria: [],
-        rollbackTriggers: [],
-        decision: null,
-        blockProgression: false,
-        reasons: [],
-      });
-    });
-
-    it('should have validate function', () => {
+      expect(stage23.defaultData).toBeDefined();
       expect(typeof stage23.validate).toBe('function');
-    });
-
-    it('should have computeDerived function', () => {
       expect(typeof stage23.computeDerived).toBe('function');
     });
 
+    it('should have analysisStep function', () => {
+      expect(typeof stage23.analysisStep).toBe('function');
+    });
+
+    it('should have outputSchema from extractOutputSchema', () => {
+      expect(stage23.outputSchema).toBeDefined();
+    });
+
+    it('should have schema with expected fields', () => {
+      expect(stage23.schema.marketing_items).toBeDefined();
+      expect(stage23.schema.sd_bridge_payloads).toBeDefined();
+      expect(stage23.schema.marketing_sds).toBeDefined();
+      expect(stage23.schema.marketing_strategy_summary).toBeDefined();
+      expect(stage23.schema.target_audience).toBeDefined();
+      expect(stage23.schema.marketing_readiness_pct).toBeDefined();
+      expect(stage23.schema.total_marketing_items).toBeDefined();
+      expect(stage23.schema.sds_created_count).toBeDefined();
+    });
+
+    it('should have correct defaultData', () => {
+      expect(stage23.defaultData).toEqual({
+        marketing_items: [],
+        sd_bridge_payloads: [],
+        marketing_sds: [],
+        marketing_strategy_summary: null,
+        target_audience: null,
+        marketing_readiness_pct: 0,
+        total_marketing_items: 0,
+        sds_created_count: 0,
+      });
+    });
+
     it('should export constants', () => {
-      expect(GO_DECISIONS).toEqual(['go', 'no-go', 'conditional_go']);
-      expect(LAUNCH_TYPES).toEqual(['soft_launch', 'beta', 'general_availability']);
-      expect(MIN_LAUNCH_TASKS).toBe(1);
+      expect(Array.isArray(MARKETING_ITEM_TYPES)).toBe(true);
+      expect(MARKETING_ITEM_TYPES).toContain('landing_page');
+      expect(MARKETING_ITEM_TYPES).toContain('social_media_campaign');
+      expect(MARKETING_ITEM_TYPES).toContain('press_release');
+      expect(MARKETING_ITEM_TYPES).toContain('email_campaign');
+      expect(MARKETING_ITEM_TYPES).toContain('launch_announcement');
+      expect(MARKETING_ITEM_TYPES).toHaveLength(10);
+
+      expect(MARKETING_PRIORITIES).toEqual(['critical', 'high', 'medium', 'low']);
+      expect(MIN_MARKETING_ITEMS).toBe(3);
     });
 
-    it('should export evaluateKillGate function', () => {
-      expect(typeof evaluateKillGate).toBe('function');
+    it('should export checkReleaseReadiness function', () => {
+      expect(typeof checkReleaseReadiness).toBe('function');
     });
   });
 
-  describe('validate() - Go/No-Go decision', () => {
-    it('should pass for valid go decision', () => {
+  describe('validate() - Marketing items', () => {
+    const validBase = {
+      marketing_strategy_summary: 'Comprehensive marketing strategy for launch',
+    };
+
+    it('should pass for well-formed data with 3+ marketing items', () => {
       const validData = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [
-          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
+        ...validBase,
+        marketing_items: [
+          { title: 'Landing Page', description: 'Main product landing page', type: 'landing_page', priority: 'critical' },
+          { title: 'Press Release', description: 'Launch press release', type: 'press_release', priority: 'high' },
+          { title: 'Email Blast', description: 'Launch email campaign', type: 'email_campaign', priority: 'medium' },
         ],
-        launch_date: '2026-03-01',
       };
-      const result = stage23.validate(validData);
+      const result = stage23.validate(validData, { logger: { warn: () => {} } });
       expect(result.valid).toBe(true);
       expect(result.errors).toEqual([]);
     });
 
-    it('should pass for valid no-go decision', () => {
-      const validData = {
-        go_decision: 'no-go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [
-          { name: 'Deploy to production', status: 'blocked' },
-        ],
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(validData);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toEqual([]);
-    });
-
-    it('should fail for missing go_decision', () => {
+    it('should fail for fewer than 3 marketing items', () => {
       const invalidData = {
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('go_decision'))).toBe(true);
-    });
-
-    it('should fail for invalid go_decision value', () => {
-      const invalidData = {
-        go_decision: 'maybe',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('go_decision'))).toBe(true);
-    });
-  });
-
-  describe('validate() - Required plans', () => {
-    const validTasks = [{ name: 'Deploy to production', status: 'ready' }];
-
-    it('should fail for missing incident_response_plan', () => {
-      const invalidData = {
-        go_decision: 'go',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: validTasks,
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('incident_response_plan'))).toBe(true);
-    });
-
-    it('should fail for incident_response_plan < 10 characters', () => {
-      const invalidData = {
-        go_decision: 'go',
-        incident_response_plan: 'Short',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: validTasks,
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('incident_response_plan'))).toBe(true);
-    });
-
-    it('should fail for missing monitoring_setup', () => {
-      const invalidData = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: validTasks,
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('monitoring_setup'))).toBe(true);
-    });
-
-    it('should fail for monitoring_setup < 10 characters', () => {
-      const invalidData = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Short',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: validTasks,
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('monitoring_setup'))).toBe(true);
-    });
-
-    it('should fail for missing rollback_plan', () => {
-      const invalidData = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        launch_tasks: validTasks,
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('rollback_plan'))).toBe(true);
-    });
-
-    it('should fail for rollback_plan < 10 characters', () => {
-      const invalidData = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Short',
-        launch_tasks: validTasks,
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('rollback_plan'))).toBe(true);
-    });
-  });
-
-  describe('validate() - Launch tasks', () => {
-    const validPlans = {
-      go_decision: 'go',
-      incident_response_plan: 'Incident response plan details',
-      monitoring_setup: 'Monitoring setup details',
-      rollback_plan: 'Rollback plan details',
-      launch_date: '2026-03-01',
-    };
-
-    it('should fail for missing launch_tasks', () => {
-      const invalidData = { ...validPlans };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('launch_tasks'))).toBe(true);
-    });
-
-    it('should fail for empty launch_tasks array', () => {
-      const invalidData = {
-        ...validPlans,
-        launch_tasks: [],
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('launch_tasks') && e.includes('at least 1'))).toBe(true);
-    });
-
-    it('should fail for launch task missing name', () => {
-      const invalidData = {
-        ...validPlans,
-        launch_tasks: [{ status: 'ready' }],
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('launch_tasks[0].name'))).toBe(true);
-    });
-
-    it('should fail for launch task missing status', () => {
-      const invalidData = {
-        ...validPlans,
-        launch_tasks: [{ name: 'Deploy to production' }],
-      };
-      const result = stage23.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('launch_tasks[0].status'))).toBe(true);
-    });
-
-    it('should pass with optional owner field', () => {
-      const validData = {
-        ...validPlans,
-        launch_tasks: [
-          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
+        ...validBase,
+        marketing_items: [
+          { title: 'Landing Page', description: 'Main product landing page', type: 'landing_page', priority: 'critical' },
+          { title: 'Press Release', description: 'Launch press release', type: 'press_release', priority: 'high' },
         ],
       };
-      const result = stage23.validate(validData);
-      expect(result.valid).toBe(true);
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_items') && e.includes('at least 3'))).toBe(true);
     });
 
-    it('should validate multiple launch tasks', () => {
-      const validData = {
-        ...validPlans,
-        launch_tasks: [
-          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
-          { name: 'Update DNS', status: 'pending', owner: 'SRE' },
-          { name: 'Notify customers', status: 'ready', owner: 'Marketing' },
+    it('should fail for empty marketing items array', () => {
+      const invalidData = {
+        ...validBase,
+        marketing_items: [],
+      };
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_items'))).toBe(true);
+    });
+
+    it('should fail for missing marketing_items', () => {
+      const invalidData = {
+        ...validBase,
+      };
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_items'))).toBe(true);
+    });
+
+    it('should fail for marketing item missing title', () => {
+      const invalidData = {
+        ...validBase,
+        marketing_items: [
+          { description: 'Main product landing page', type: 'landing_page', priority: 'critical' },
+          { title: 'Press Release', description: 'Launch press release', type: 'press_release', priority: 'high' },
+          { title: 'Email Blast', description: 'Launch email campaign', type: 'email_campaign', priority: 'medium' },
         ],
       };
-      const result = stage23.validate(validData);
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe('validate() - Launch date', () => {
-    const validData = {
-      go_decision: 'go',
-      incident_response_plan: 'Incident response plan details',
-      monitoring_setup: 'Monitoring setup details',
-      rollback_plan: 'Rollback plan details',
-      launch_tasks: [{ name: 'Deploy', status: 'ready' }],
-    };
-
-    it('should fail for missing launch_date', () => {
-      const invalidData = { ...validData };
-      const result = stage23.validate(invalidData);
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('launch_date'))).toBe(true);
+      expect(result.errors.some(e => e.includes('marketing_items[0].title'))).toBe(true);
     });
 
-    it('should fail for empty launch_date', () => {
+    it('should fail for marketing item missing description', () => {
       const invalidData = {
-        ...validData,
-        launch_date: '',
+        ...validBase,
+        marketing_items: [
+          { title: 'Landing Page', type: 'landing_page', priority: 'critical' },
+          { title: 'Press Release', description: 'Launch press release', type: 'press_release', priority: 'high' },
+          { title: 'Email Blast', description: 'Launch email campaign', type: 'email_campaign', priority: 'medium' },
+        ],
       };
-      const result = stage23.validate(invalidData);
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('launch_date'))).toBe(true);
+      expect(result.errors.some(e => e.includes('marketing_items[0].description'))).toBe(true);
     });
 
-    it('should pass for valid launch_date', () => {
-      const validDataWithDate = {
-        ...validData,
-        launch_date: '2026-03-01',
+    it('should fail for marketing item with invalid type', () => {
+      const invalidData = {
+        ...validBase,
+        marketing_items: [
+          { title: 'Landing Page', description: 'Main page', type: 'invalid_type', priority: 'critical' },
+          { title: 'Press Release', description: 'Launch press release', type: 'press_release', priority: 'high' },
+          { title: 'Email Blast', description: 'Launch email campaign', type: 'email_campaign', priority: 'medium' },
+        ],
       };
-      const result = stage23.validate(validDataWithDate);
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_items[0].type'))).toBe(true);
+    });
+
+    it('should fail for marketing item with invalid priority', () => {
+      const invalidData = {
+        ...validBase,
+        marketing_items: [
+          { title: 'Landing Page', description: 'Main page', type: 'landing_page', priority: 'urgent' },
+          { title: 'Press Release', description: 'Launch press release', type: 'press_release', priority: 'high' },
+          { title: 'Email Blast', description: 'Launch email campaign', type: 'email_campaign', priority: 'medium' },
+        ],
+      };
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_items[0].priority'))).toBe(true);
+    });
+
+    it('should validate multiple items and collect all errors', () => {
+      const invalidData = {
+        ...validBase,
+        marketing_items: [
+          { title: 'Landing Page', description: 'Main page', type: 'landing_page', priority: 'critical' },
+          { description: 'Missing title', type: 'press_release', priority: 'high' },
+          { title: 'Email Blast', type: 'email_campaign', priority: 'medium' },
+        ],
+      };
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_items[1].title'))).toBe(true);
+      expect(result.errors.some(e => e.includes('marketing_items[2].description'))).toBe(true);
+    });
+  });
+
+  describe('validate() - Marketing strategy summary', () => {
+    const validItems = [
+      { title: 'Landing Page', description: 'Main product landing page', type: 'landing_page', priority: 'critical' },
+      { title: 'Press Release', description: 'Launch press release', type: 'press_release', priority: 'high' },
+      { title: 'Email Blast', description: 'Launch email campaign', type: 'email_campaign', priority: 'medium' },
+    ];
+
+    it('should fail for missing marketing_strategy_summary', () => {
+      const invalidData = {
+        marketing_items: validItems,
+      };
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_strategy_summary'))).toBe(true);
+    });
+
+    it('should fail for marketing_strategy_summary shorter than 10 characters', () => {
+      const invalidData = {
+        marketing_items: validItems,
+        marketing_strategy_summary: 'Short',
+      };
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_strategy_summary'))).toBe(true);
+    });
+
+    it('should pass for marketing_strategy_summary with 10+ characters', () => {
+      const validData = {
+        marketing_items: validItems,
+        marketing_strategy_summary: 'Comprehensive marketing strategy for product launch',
+      };
+      const result = stage23.validate(validData, { logger: { warn: () => {} } });
       expect(result.valid).toBe(true);
     });
   });
 
-  describe('evaluateKillGate() - Pure function', () => {
-    it('should pass for go decision with all required plans', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
+  describe('computeDerived()', () => {
+    it('should spread input data to output', () => {
+      const data = {
+        marketing_items: [
+          { title: 'Landing Page', description: 'Main page', type: 'landing_page', priority: 'critical' },
+        ],
+        marketing_strategy_summary: 'Strategy summary text here',
+      };
+      const result = stage23.computeDerived(data);
+      expect(result.marketing_items).toEqual(data.marketing_items);
+      expect(result.marketing_strategy_summary).toBe(data.marketing_strategy_summary);
+    });
+  });
+
+  describe('checkReleaseReadiness() - Pure function', () => {
+    it('should return ready when stage22 promotion gate passes and release decision is release', () => {
+      const result = checkReleaseReadiness({
+        stage22Data: {
+          promotion_gate: { pass: true, blockers: [] },
+          releaseDecision: { decision: 'release' },
+        },
       });
-      expect(result.decision).toBe('pass');
-      expect(result.blockProgression).toBe(false);
+      expect(result.ready).toBe(true);
       expect(result.reasons).toEqual([]);
     });
 
-    it('should kill for no-go decision', () => {
-      const result = evaluateKillGate({
-        go_decision: 'no-go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('no_go_decision');
-      expect(result.reasons[0].message).toContain('no-go');
-    });
-
-    it('should kill for null go_decision', () => {
-      const result = evaluateKillGate({
-        go_decision: null,
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('no_go_decision');
-      expect(result.reasons[0].message).toContain('not set');
-    });
-
-    it('should kill for go decision missing incident_response_plan', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: null,
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('missing_incident_response');
-      expect(result.reasons[0].message).toContain('Incident response plan');
-    });
-
-    it('should kill for go decision with short incident_response_plan', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: 'Short',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('missing_incident_response');
-    });
-
-    it('should kill for go decision missing monitoring_setup', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: null,
-        rollback_plan: 'Rollback plan details',
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('missing_monitoring');
-      expect(result.reasons[0].message).toContain('Monitoring setup');
-    });
-
-    it('should kill for go decision missing rollback_plan', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: null,
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('missing_rollback');
-      expect(result.reasons[0].message).toContain('Rollback plan');
-    });
-
-    it('should collect multiple blockers for go decision', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: null,
-        monitoring_setup: 'Short',
-        rollback_plan: null,
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(3);
-      expect(result.reasons.some(r => r.type === 'missing_incident_response')).toBe(true);
-      expect(result.reasons.some(r => r.type === 'missing_monitoring')).toBe(true);
-      expect(result.reasons.some(r => r.type === 'missing_rollback')).toBe(true);
-    });
-
-    it('should not check plans for no-go decision', () => {
-      const result = evaluateKillGate({
-        go_decision: 'no-go',
-        incident_response_plan: null,
-        monitoring_setup: null,
-        rollback_plan: null,
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons).toHaveLength(1);
-      expect(result.reasons[0].type).toBe('no_go_decision');
-    });
-
-    it('should kill when stage22 promotion gate has not passed (Launch CC-3)', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
+    it('should return ready when release decision is approved', () => {
+      const result = checkReleaseReadiness({
         stage22Data: {
-          promotion_gate: { pass: false, blockers: ['Test coverage below 80%', 'Integration failing'] },
+          promotion_gate: { pass: true, blockers: [] },
+          releaseDecision: { decision: 'approved' },
         },
       });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      const s22Reason = result.reasons.find(r => r.type === 'stage22_not_complete');
-      expect(s22Reason).toBeDefined();
-      expect(s22Reason.message).toContain('2 blocker(s)');
-    });
-
-    it('should pass when stage22 promotion gate has passed', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        stage22Data: {
-          promotion_gate: { pass: true, blockers: [], warnings: [] },
-        },
-      });
-      expect(result.decision).toBe('pass');
-      expect(result.blockProgression).toBe(false);
-    });
-
-    it('should not check stage22 when stage22Data is not provided', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-      });
-      expect(result.decision).toBe('pass');
-      expect(result.reasons.some(r => r.type === 'stage22_not_complete')).toBe(false);
-    });
-  });
-
-  describe('computeDerived() - Kill gate integration', () => {
-    it('should include kill gate evaluation in derived fields', () => {
-      const data = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.computeDerived(data);
-      expect(result.decision).toBe('pass');
-      expect(result.blockProgression).toBe(false);
+      expect(result.ready).toBe(true);
       expect(result.reasons).toEqual([]);
     });
 
-    it('should block progression for no-go decision', () => {
-      const data = {
-        go_decision: 'no-go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [{ name: 'Deploy', status: 'blocked' }],
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.computeDerived(data);
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
+    it('should return not ready when stage22Data is not provided', () => {
+      const result = checkReleaseReadiness({ stage22Data: undefined });
+      expect(result.ready).toBe(false);
       expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0]).toContain('not available');
     });
 
-    it('should block progression for missing plans', () => {
-      const data = {
-        go_decision: 'go',
-        incident_response_plan: null,
-        monitoring_setup: null,
-        rollback_plan: null,
-        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.computeDerived(data);
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
+    it('should return not ready when promotion gate has not passed', () => {
+      const result = checkReleaseReadiness({
+        stage22Data: {
+          promotion_gate: { pass: false, blockers: ['Test coverage below 80%'] },
+          releaseDecision: { decision: 'release' },
+        },
+      });
+      expect(result.ready).toBe(false);
+      expect(result.reasons.some(r => r.includes('promotion gate'))).toBe(true);
+    });
+
+    it('should return not ready when release decision is not release or approved', () => {
+      const result = checkReleaseReadiness({
+        stage22Data: {
+          promotion_gate: { pass: true, blockers: [] },
+          releaseDecision: { decision: 'hold' },
+        },
+      });
+      expect(result.ready).toBe(false);
+      expect(result.reasons.some(r => r.includes('release decision'))).toBe(true);
+    });
+
+    it('should return not ready when releaseDecision is missing', () => {
+      const result = checkReleaseReadiness({
+        stage22Data: {
+          promotion_gate: { pass: true, blockers: [] },
+        },
+      });
+      expect(result.ready).toBe(false);
+      expect(result.reasons.some(r => r.includes('release decision not found'))).toBe(true);
+    });
+
+    it('should collect multiple reasons when both gate and decision fail', () => {
+      const result = checkReleaseReadiness({
+        stage22Data: {
+          promotion_gate: { pass: false, blockers: ['Not ready'] },
+          releaseDecision: { decision: 'hold' },
+        },
+      });
+      expect(result.ready).toBe(false);
+      expect(result.reasons).toHaveLength(2);
+      expect(result.reasons.some(r => r.includes('promotion gate'))).toBe(true);
+      expect(result.reasons.some(r => r.includes('release decision'))).toBe(true);
+    });
+
+    it('should handle null stage22Data', () => {
+      const result = checkReleaseReadiness({ stage22Data: null });
+      expect(result.ready).toBe(false);
       expect(result.reasons.length).toBeGreaterThan(0);
-    });
-
-    it('should pass prerequisites stage22Data to kill gate', () => {
-      const data = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
-        launch_date: '2026-03-01',
-      };
-      const prerequisites = {
-        stage22: { promotion_gate: { pass: false, blockers: ['Not ready'] } },
-      };
-      const result = stage23.computeDerived(data, prerequisites);
-      expect(result.decision).toBe('kill');
-      expect(result.reasons.some(r => r.type === 'stage22_not_complete')).toBe(true);
-    });
-
-    it('should preserve original data fields', () => {
-      const data = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [{ name: 'Deploy', status: 'ready' }],
-        launch_date: '2026-03-01',
-      };
-      const result = stage23.computeDerived(data);
-      expect(result.go_decision).toBe('go');
-      expect(result.incident_response_plan).toBe('Incident response plan details');
-      expect(result.monitoring_setup).toBe('Monitoring setup details');
-      expect(result.rollback_plan).toBe('Rollback plan details');
-      expect(result.launch_tasks).toEqual(data.launch_tasks);
-      expect(result.launch_date).toBe('2026-03-01');
     });
   });
 
   describe('Edge cases', () => {
     it('should handle null data in validate', () => {
-      const result = stage23.validate(null);
+      const result = stage23.validate(null, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
     it('should handle undefined data in validate', () => {
-      const result = stage23.validate(undefined);
+      const result = stage23.validate(undefined, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it('should handle whitespace-only strings in kill gate', () => {
-      const result = evaluateKillGate({
-        go_decision: 'go',
-        incident_response_plan: '          ',
-        monitoring_setup: '          ',
-        rollback_plan: '          ',
-      });
-      expect(result.decision).toBe('kill');
-      expect(result.blockProgression).toBe(true);
-      expect(result.reasons.length).toBe(3);
+    it('should handle non-array marketing_items', () => {
+      const invalidData = {
+        marketing_items: 'not an array',
+        marketing_strategy_summary: 'Valid strategy summary text',
+      };
+      const result = stage23.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('marketing_items'))).toBe(true);
     });
   });
 
   describe('Integration: validate + computeDerived workflow', () => {
     it('should work together for valid data', () => {
       const data = {
-        go_decision: 'go',
-        incident_response_plan: 'Incident response plan details',
-        monitoring_setup: 'Monitoring setup details',
-        rollback_plan: 'Rollback plan details',
-        launch_tasks: [
-          { name: 'Deploy to production', status: 'ready', owner: 'DevOps' },
-          { name: 'Update DNS', status: 'ready', owner: 'SRE' },
+        marketing_items: [
+          { title: 'Landing Page', description: 'Main product landing page', type: 'landing_page', priority: 'critical' },
+          { title: 'Press Release', description: 'Launch press release', type: 'press_release', priority: 'high' },
+          { title: 'Email Blast', description: 'Launch email campaign', type: 'email_campaign', priority: 'medium' },
         ],
-        launch_date: '2026-03-01',
+        marketing_strategy_summary: 'Comprehensive marketing strategy for product launch',
+        sd_bridge_payloads: [],
+        marketing_sds: [],
       };
-      const validation = stage23.validate(data);
+      const validation = stage23.validate(data, { logger: { warn: () => {} } });
       expect(validation.valid).toBe(true);
 
       const computed = stage23.computeDerived(data);
-      expect(computed.decision).toBe('pass');
-      expect(computed.blockProgression).toBe(false);
+      expect(computed.marketing_items).toEqual(data.marketing_items);
+      expect(computed.marketing_strategy_summary).toBe(data.marketing_strategy_summary);
     });
 
     it('should not require validation before computeDerived (decoupled)', () => {
       const data = {
-        go_decision: 'invalid',
-        incident_response_plan: 'Short',
-        monitoring_setup: null,
-        rollback_plan: null,
-        launch_tasks: [],
-        launch_date: '',
+        marketing_items: [],
+        marketing_strategy_summary: 'Short',
       };
+      // computeDerived should not throw even with invalid data
       const computed = stage23.computeDerived(data);
-      expect(computed.decision).toBe('kill');
-      expect(computed.blockProgression).toBe(true);
+      expect(computed.marketing_items).toEqual([]);
     });
   });
 });

--- a/tests/unit/eva/stage-templates/stage-24.test.js
+++ b/tests/unit/eva/stage-templates/stage-24.test.js
@@ -1,604 +1,493 @@
 /**
- * Unit tests for Stage 24 - Metrics & Learning template
- * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ * Unit tests for Stage 24 - Launch Readiness template
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
- * Test Scenario: Stage 24 validation enforces AARRR framework metrics
- * (Acquisition, Activation, Retention, Revenue, Referral) with funnels
- * and optional learnings.
+ * Test Scenario: Stage 24 validation enforces a readiness checklist with
+ * weighted scoring, operational readiness plans, and chairman governance gate.
  *
  * @module tests/unit/eva/stage-templates/stage-24.test
  */
 
 import { describe, it, expect } from 'vitest';
-import stage24, { AARRR_CATEGORIES, MIN_METRICS_PER_CATEGORY, MIN_FUNNELS } from '../../../../lib/eva/stage-templates/stage-24.js';
+import stage24, {
+  computeReadinessScore,
+  GO_NO_GO_DECISIONS,
+  CHECKLIST_ITEM_STATUSES,
+  READINESS_CHECKLIST_KEYS,
+  CHECKLIST_WEIGHTS,
+} from '../../../../lib/eva/stage-templates/stage-24.js';
 
-describe('stage-24.js - Metrics & Learning template', () => {
-  describe('Template metadata', () => {
-    it('should have correct template structure', () => {
+describe('stage-24.js - Launch Readiness template', () => {
+  describe('Template contract', () => {
+    it('should export TEMPLATE with required properties', () => {
+      expect(stage24).toBeDefined();
+      expect(stage24.id).toBeDefined();
+      expect(stage24.slug).toBeDefined();
+      expect(stage24.title).toBeDefined();
+      expect(stage24.version).toBeDefined();
+    });
+
+    it('should have correct id, slug, title, version', () => {
       expect(stage24.id).toBe('stage-24');
-      expect(stage24.slug).toBe('metrics-learning');
-      expect(stage24.title).toBe('Metrics & Learning');
-      expect(stage24.version).toBe('1.0.0');
+      expect(stage24.slug).toBe('launch-readiness');
+      expect(stage24.title).toBe('Launch Readiness');
+      expect(stage24.version).toBe('2.0.0');
     });
 
-    it('should have schema definition', () => {
+    it('should have schema, defaultData, validate, computeDerived', () => {
       expect(stage24.schema).toBeDefined();
-      expect(stage24.schema.aarrr).toBeDefined();
-      expect(stage24.schema.funnels).toBeDefined();
-      expect(stage24.schema.learnings).toBeDefined();
-      expect(stage24.schema.total_metrics).toBeDefined();
-      expect(stage24.schema.categories_complete).toBeDefined();
-      expect(stage24.schema.funnel_count).toBeDefined();
-      expect(stage24.schema.metrics_on_target).toBeDefined();
-      expect(stage24.schema.metrics_below_target).toBeDefined();
-    });
-
-    it('should have defaultData', () => {
-      expect(stage24.defaultData).toEqual({
-        aarrr: {},
-        funnels: [],
-        learnings: [],
-        total_metrics: 0,
-        categories_complete: false,
-        funnel_count: 0,
-        metrics_on_target: 0,
-        metrics_below_target: 0,
-        launchOutcome: null,
-      });
-    });
-
-    it('should have validate function', () => {
+      expect(stage24.defaultData).toBeDefined();
       expect(typeof stage24.validate).toBe('function');
-    });
-
-    it('should have computeDerived function', () => {
       expect(typeof stage24.computeDerived).toBe('function');
     });
 
+    it('should have analysisStep function', () => {
+      expect(typeof stage24.analysisStep).toBe('function');
+    });
+
+    it('should have outputSchema from extractOutputSchema', () => {
+      expect(stage24.outputSchema).toBeDefined();
+    });
+
+    it('should have onBeforeAnalysis hook', () => {
+      expect(typeof stage24.onBeforeAnalysis).toBe('function');
+    });
+
+    it('should have schema with expected fields', () => {
+      expect(stage24.schema.readiness_checklist).toBeDefined();
+      expect(stage24.schema.go_no_go_decision).toBeDefined();
+      expect(stage24.schema.decision_rationale).toBeDefined();
+      expect(stage24.schema.incident_response_plan).toBeDefined();
+      expect(stage24.schema.monitoring_setup).toBeDefined();
+      expect(stage24.schema.rollback_plan).toBeDefined();
+      expect(stage24.schema.launch_risks).toBeDefined();
+      expect(stage24.schema.chairmanGate).toBeDefined();
+      expect(stage24.schema.readiness_score).toBeDefined();
+      expect(stage24.schema.all_checks_pass).toBeDefined();
+      expect(stage24.schema.blocking_items).toBeDefined();
+    });
+
+    it('should have correct defaultData', () => {
+      expect(stage24.defaultData.go_no_go_decision).toBeNull();
+      expect(stage24.defaultData.decision_rationale).toBeNull();
+      expect(stage24.defaultData.incident_response_plan).toBeNull();
+      expect(stage24.defaultData.monitoring_setup).toBeNull();
+      expect(stage24.defaultData.rollback_plan).toBeNull();
+      expect(stage24.defaultData.launch_risks).toEqual([]);
+      expect(stage24.defaultData.chairmanGate).toEqual({
+        status: 'pending', rationale: null, decision_id: null,
+      });
+      expect(stage24.defaultData.readiness_score).toBe(0);
+      expect(stage24.defaultData.all_checks_pass).toBe(false);
+      expect(stage24.defaultData.blocking_items).toEqual([]);
+    });
+
+    it('should have readiness_checklist default with pending status for all keys', () => {
+      const checklist = stage24.defaultData.readiness_checklist;
+      for (const key of READINESS_CHECKLIST_KEYS) {
+        expect(checklist[key]).toEqual({ status: 'pending', evidence: null, verified_at: null });
+      }
+    });
+
     it('should export constants', () => {
-      expect(AARRR_CATEGORIES).toEqual(['acquisition', 'activation', 'retention', 'revenue', 'referral']);
-      expect(MIN_METRICS_PER_CATEGORY).toBe(1);
-      expect(MIN_FUNNELS).toBe(1);
+      expect(GO_NO_GO_DECISIONS).toEqual(['go', 'no_go', 'conditional_go']);
+      expect(CHECKLIST_ITEM_STATUSES).toEqual(['pass', 'fail', 'pending', 'waived']);
+      expect(READINESS_CHECKLIST_KEYS).toEqual([
+        'release_confirmed', 'marketing_complete', 'monitoring_ready', 'rollback_plan_exists',
+      ]);
+      expect(CHECKLIST_WEIGHTS).toEqual({
+        release_confirmed: 0.35,
+        marketing_complete: 0.25,
+        monitoring_ready: 0.20,
+        rollback_plan_exists: 0.20,
+      });
+    });
+
+    it('should export computeReadinessScore function', () => {
+      expect(typeof computeReadinessScore).toBe('function');
     });
   });
 
-  describe('validate() - AARRR object structure', () => {
-    it('should fail for missing aarrr object', () => {
-      const invalidData = {
-        funnels: [{ name: 'Funnel 1', steps: ['Step 1', 'Step 2'] }],
-      };
-      const result = stage24.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('aarrr'))).toBe(true);
+  describe('validate() - Readiness checklist', () => {
+    const makeValidData = (overrides = {}) => ({
+      readiness_checklist: {
+        release_confirmed: { status: 'pass', evidence: 'Release build verified' },
+        marketing_complete: { status: 'pass', evidence: 'Marketing materials ready' },
+        monitoring_ready: { status: 'pass', evidence: 'Dashboards configured' },
+        rollback_plan_exists: { status: 'pass', evidence: 'Rollback playbook approved' },
+      },
+      incident_response_plan: 'Full incident response plan details here',
+      monitoring_setup: 'Full monitoring setup details here',
+      rollback_plan: 'Full rollback plan details here',
+      chairmanGate: { status: 'approved', rationale: null, decision_id: null },
+      ...overrides,
     });
 
-    it('should fail for non-object aarrr', () => {
-      const invalidData = {
-        aarrr: 'not an object',
-        funnels: [{ name: 'Funnel 1', steps: ['Step 1', 'Step 2'] }],
-      };
-      const result = stage24.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('aarrr'))).toBe(true);
-    });
-  });
-
-  describe('validate() - AARRR categories', () => {
-    it('should pass for valid AARRR metrics across all categories', () => {
-      const validData = {
-        aarrr: {
-          acquisition: [{ name: 'Signups', value: 100, target: 150 }],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Signup funnel', steps: ['Landing', 'Signup'] }],
-      };
-      const result = stage24.validate(validData);
+    it('should pass for valid data with all checks passing', () => {
+      const result = stage24.validate(makeValidData(), { logger: { warn: () => {} } });
       expect(result.valid).toBe(true);
       expect(result.errors).toEqual([]);
     });
 
-    it('should fail for missing acquisition category', () => {
-      const invalidData = {
-        aarrr: {
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.validate(invalidData);
+    it('should fail for missing readiness_checklist', () => {
+      const data = makeValidData();
+      delete data.readiness_checklist;
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('aarrr.acquisition'))).toBe(true);
+      expect(result.errors.some(e => e.includes('readiness_checklist'))).toBe(true);
     });
 
-    it('should fail for empty acquisition array', () => {
-      const invalidData = {
-        aarrr: {
-          acquisition: [],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.validate(invalidData);
+    it('should fail for non-object readiness_checklist', () => {
+      const data = makeValidData({ readiness_checklist: 'not an object' });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('aarrr.acquisition') && e.includes('at least 1'))).toBe(true);
+      expect(result.errors.some(e => e.includes('readiness_checklist'))).toBe(true);
     });
 
-    it('should fail for metric missing name', () => {
-      const invalidData = {
-        aarrr: {
-          acquisition: [{ value: 100, target: 150 }],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.validate(invalidData);
+    it('should fail for missing checklist key', () => {
+      const data = makeValidData();
+      delete data.readiness_checklist.release_confirmed;
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('aarrr.acquisition[0].name'))).toBe(true);
+      expect(result.errors.some(e => e.includes('readiness_checklist.release_confirmed'))).toBe(true);
     });
 
-    it('should fail for metric missing value', () => {
-      const invalidData = {
-        aarrr: {
-          acquisition: [{ name: 'Signups', target: 150 }],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.validate(invalidData);
+    it('should fail for checklist item with invalid status', () => {
+      const data = makeValidData();
+      data.readiness_checklist.release_confirmed.status = 'invalid';
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('aarrr.acquisition[0].value'))).toBe(true);
+      expect(result.errors.some(e => e.includes('readiness_checklist.release_confirmed.status'))).toBe(true);
     });
 
-    it('should fail for metric missing target', () => {
-      const invalidData = {
-        aarrr: {
-          acquisition: [{ name: 'Signups', value: 100 }],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.validate(invalidData);
+    it('should fail for checklist item with missing evidence', () => {
+      const data = makeValidData();
+      data.readiness_checklist.marketing_complete.evidence = null;
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('aarrr.acquisition[0].target'))).toBe(true);
+      expect(result.errors.some(e => e.includes('readiness_checklist.marketing_complete.evidence'))).toBe(true);
     });
 
-    it('should allow multiple metrics per category', () => {
-      const validData = {
-        aarrr: {
-          acquisition: [
-            { name: 'Signups', value: 100, target: 150 },
-            { name: 'Traffic', value: 1000, target: 1200 },
-          ],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.validate(validData);
+    it('should accept waived status as valid', () => {
+      const data = makeValidData();
+      data.readiness_checklist.monitoring_ready = { status: 'waived', evidence: 'Deferred to post-launch' };
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(true);
     });
 
-    it('should pass with optional trend_window_days', () => {
-      const validData = {
-        aarrr: {
-          acquisition: [{ name: 'Signups', value: 100, target: 150, trend_window_days: 30 }],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.validate(validData);
+    it('should accept pending status as valid (status-wise)', () => {
+      const data = makeValidData();
+      data.readiness_checklist.rollback_plan_exists = { status: 'pending', evidence: 'In progress' };
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      // pending is a valid status per CHECKLIST_ITEM_STATUSES
       expect(result.valid).toBe(true);
     });
   });
 
-  describe('validate() - Funnels', () => {
-    const validAARRR = {
-      acquisition: [{ name: 'Signups', value: 100, target: 150 }],
-      activation: [{ name: 'First Action', value: 80, target: 90 }],
-      retention: [{ name: '30-day retention', value: 70, target: 75 }],
-      revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-      referral: [{ name: 'Referral rate', value: 5, target: 10 }],
-    };
-
-    it('should fail for missing funnels', () => {
-      const invalidData = {
-        aarrr: validAARRR,
-      };
-      const result = stage24.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('funnels'))).toBe(true);
-    });
-
-    it('should fail for empty funnels array', () => {
-      const invalidData = {
-        aarrr: validAARRR,
-        funnels: [],
-      };
-      const result = stage24.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('funnels') && e.includes('at least 1'))).toBe(true);
-    });
-
-    it('should fail for funnel missing name', () => {
-      const invalidData = {
-        aarrr: validAARRR,
-        funnels: [{ steps: ['Step 1', 'Step 2'] }],
-      };
-      const result = stage24.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('funnels[0].name'))).toBe(true);
-    });
-
-    it('should fail for funnel missing steps', () => {
-      const invalidData = {
-        aarrr: validAARRR,
-        funnels: [{ name: 'Signup funnel' }],
-      };
-      const result = stage24.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('funnels[0].steps'))).toBe(true);
-    });
-
-    it('should fail for funnel with < 2 steps', () => {
-      const invalidData = {
-        aarrr: validAARRR,
-        funnels: [{ name: 'Signup funnel', steps: ['Landing'] }],
-      };
-      const result = stage24.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('funnels[0].steps') && e.includes('at least 2'))).toBe(true);
-    });
-
-    it('should pass for valid funnel with 2 steps', () => {
-      const validData = {
-        aarrr: validAARRR,
-        funnels: [{ name: 'Signup funnel', steps: ['Landing', 'Signup'] }],
-      };
-      const result = stage24.validate(validData);
-      expect(result.valid).toBe(true);
-    });
-
-    it('should pass for multiple funnels', () => {
-      const validData = {
-        aarrr: validAARRR,
-        funnels: [
-          { name: 'Signup funnel', steps: ['Landing', 'Signup', 'Activation'] },
-          { name: 'Purchase funnel', steps: ['Browse', 'Cart', 'Checkout', 'Purchase'] },
-        ],
-      };
-      const result = stage24.validate(validData);
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe('validate() - Learnings (optional)', () => {
-    const validData = {
-      aarrr: {
-        acquisition: [{ name: 'Signups', value: 100, target: 150 }],
-        activation: [{ name: 'First Action', value: 80, target: 90 }],
-        retention: [{ name: '30-day retention', value: 70, target: 75 }],
-        revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-        referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+  describe('validate() - Operational readiness plans', () => {
+    const makeValidData = (overrides = {}) => ({
+      readiness_checklist: {
+        release_confirmed: { status: 'pass', evidence: 'Release build verified' },
+        marketing_complete: { status: 'pass', evidence: 'Marketing materials ready' },
+        monitoring_ready: { status: 'pass', evidence: 'Dashboards configured' },
+        rollback_plan_exists: { status: 'pass', evidence: 'Rollback playbook approved' },
       },
-      funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-    };
-
-    it('should pass without learnings (optional)', () => {
-      const result = stage24.validate(validData);
-      expect(result.valid).toBe(true);
+      incident_response_plan: 'Full incident response plan details here',
+      monitoring_setup: 'Full monitoring setup details here',
+      rollback_plan: 'Full rollback plan details here',
+      chairmanGate: { status: 'approved', rationale: null, decision_id: null },
+      ...overrides,
     });
 
-    it('should pass with empty learnings array', () => {
-      const dataWithLearnings = {
-        ...validData,
-        learnings: [],
-      };
-      const result = stage24.validate(dataWithLearnings);
-      expect(result.valid).toBe(true);
-    });
-
-    it('should pass with valid learnings', () => {
-      const dataWithLearnings = {
-        ...validData,
-        learnings: [
-          { insight: 'Users drop off at step 2', action: 'Simplify onboarding', category: 'activation' },
-        ],
-      };
-      const result = stage24.validate(dataWithLearnings);
-      expect(result.valid).toBe(true);
-    });
-
-    it('should fail for learning missing insight', () => {
-      const invalidData = {
-        ...validData,
-        learnings: [{ action: 'Simplify onboarding' }],
-      };
-      const result = stage24.validate(invalidData);
+    it('should fail for missing incident_response_plan', () => {
+      const data = makeValidData({ incident_response_plan: null });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('learnings[0].insight'))).toBe(true);
+      expect(result.errors.some(e => e.includes('incident_response_plan'))).toBe(true);
     });
 
-    it('should fail for learning missing action', () => {
-      const invalidData = {
-        ...validData,
-        learnings: [{ insight: 'Users drop off at step 2' }],
-      };
-      const result = stage24.validate(invalidData);
+    it('should fail for incident_response_plan < 10 characters', () => {
+      const data = makeValidData({ incident_response_plan: 'Short' });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('learnings[0].action'))).toBe(true);
+      expect(result.errors.some(e => e.includes('incident_response_plan'))).toBe(true);
     });
 
-    it('should pass with optional category field', () => {
-      const dataWithLearnings = {
-        ...validData,
-        learnings: [
-          { insight: 'Users drop off at step 2', action: 'Simplify onboarding', category: 'activation' },
-        ],
-      };
-      const result = stage24.validate(dataWithLearnings);
+    it('should fail for missing monitoring_setup', () => {
+      const data = makeValidData({ monitoring_setup: null });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('monitoring_setup'))).toBe(true);
+    });
+
+    it('should fail for monitoring_setup < 10 characters', () => {
+      const data = makeValidData({ monitoring_setup: 'Short' });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('monitoring_setup'))).toBe(true);
+    });
+
+    it('should fail for missing rollback_plan', () => {
+      const data = makeValidData({ rollback_plan: null });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('rollback_plan'))).toBe(true);
+    });
+
+    it('should fail for rollback_plan < 10 characters', () => {
+      const data = makeValidData({ rollback_plan: 'Short' });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('rollback_plan'))).toBe(true);
+    });
+  });
+
+  describe('validate() - Chairman governance gate', () => {
+    const makeValidData = (overrides = {}) => ({
+      readiness_checklist: {
+        release_confirmed: { status: 'pass', evidence: 'Release build verified' },
+        marketing_complete: { status: 'pass', evidence: 'Marketing materials ready' },
+        monitoring_ready: { status: 'pass', evidence: 'Dashboards configured' },
+        rollback_plan_exists: { status: 'pass', evidence: 'Rollback playbook approved' },
+      },
+      incident_response_plan: 'Full incident response plan details here',
+      monitoring_setup: 'Full monitoring setup details here',
+      rollback_plan: 'Full rollback plan details here',
+      ...overrides,
+    });
+
+    it('should pass when chairman gate is approved', () => {
+      const data = makeValidData({ chairmanGate: { status: 'approved', rationale: null, decision_id: null } });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
       expect(result.valid).toBe(true);
     });
-  });
 
-  describe('computeDerived() - Metric counts', () => {
-    it('should calculate total_metrics correctly', () => {
-      const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 100, target: 150 }, { name: 'M2', value: 200, target: 250 }],
-          activation: [{ name: 'M3', value: 80, target: 90 }],
-          retention: [{ name: 'M4', value: 70, target: 75 }],
-          revenue: [{ name: 'M5', value: 10000, target: 12000 }],
-          referral: [{ name: 'M6', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.total_metrics).toBe(6);
+    it('should fail when chairman gate is pending', () => {
+      const data = makeValidData({ chairmanGate: { status: 'pending', rationale: null, decision_id: null } });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Chairman') && e.includes('pending'))).toBe(true);
     });
 
-    it('should set categories_complete to true when all categories have metrics', () => {
-      const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 100, target: 150 }],
-          activation: [{ name: 'M2', value: 80, target: 90 }],
-          retention: [{ name: 'M3', value: 70, target: 75 }],
-          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
-          referral: [{ name: 'M5', value: 5, target: 10 }],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.categories_complete).toBe(true);
+    it('should fail when chairman gate is rejected', () => {
+      const data = makeValidData({
+        chairmanGate: { status: 'rejected', rationale: 'Not ready for launch', decision_id: null },
+      });
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Chairman') && e.includes('rejected'))).toBe(true);
     });
 
-    it('should set categories_complete to false when missing categories', () => {
-      const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 100, target: 150 }],
-          activation: [{ name: 'M2', value: 80, target: 90 }],
-          retention: [],
-          revenue: [],
-          referral: [],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.categories_complete).toBe(false);
-    });
-
-    it('should calculate funnel_count correctly', () => {
-      const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 100, target: 150 }],
-          activation: [{ name: 'M2', value: 80, target: 90 }],
-          retention: [{ name: 'M3', value: 70, target: 75 }],
-          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
-          referral: [{ name: 'M5', value: 5, target: 10 }],
-        },
-        funnels: [
-          { name: 'F1', steps: ['A', 'B'] },
-          { name: 'F2', steps: ['C', 'D'] },
-          { name: 'F3', steps: ['E', 'F'] },
-        ],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.funnel_count).toBe(3);
+    it('should fail when chairmanGate is not provided', () => {
+      const data = makeValidData();
+      // No chairmanGate means status is undefined, which is not 'approved'
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('Chairman') || e.includes('chairman'))).toBe(true);
     });
   });
 
-  describe('computeDerived() - Target tracking', () => {
-    it('should calculate metrics_on_target correctly', () => {
-      const data = {
-        aarrr: {
-          acquisition: [
-            { name: 'M1', value: 150, target: 150 }, // on target
-            { name: 'M2', value: 200, target: 150 }, // above target
-          ],
-          activation: [{ name: 'M3', value: 80, target: 90 }], // below
-          retention: [{ name: 'M4', value: 75, target: 75 }], // on target
-          revenue: [{ name: 'M5', value: 10000, target: 12000 }], // below
-          referral: [{ name: 'M6', value: 15, target: 10 }], // above
+  describe('computeReadinessScore() - Pure function', () => {
+    it('should return 100 when all items pass', () => {
+      const result = computeReadinessScore({
+        readiness_checklist: {
+          release_confirmed: { status: 'pass' },
+          marketing_complete: { status: 'pass' },
+          monitoring_ready: { status: 'pass' },
+          rollback_plan_exists: { status: 'pass' },
         },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.metrics_on_target).toBe(4); // M1, M2, M4, M6
+      });
+      expect(result.readiness_score).toBe(100);
+      expect(result.all_checks_pass).toBe(true);
+      expect(result.blocking_items).toEqual([]);
     });
 
-    it('should calculate metrics_below_target correctly', () => {
-      const data = {
-        aarrr: {
-          acquisition: [
-            { name: 'M1', value: 150, target: 150 }, // on target
-            { name: 'M2', value: 200, target: 150 }, // above target
-          ],
-          activation: [{ name: 'M3', value: 80, target: 90 }], // below
-          retention: [{ name: 'M4', value: 75, target: 75 }], // on target
-          revenue: [{ name: 'M5', value: 10000, target: 12000 }], // below
-          referral: [{ name: 'M6', value: 15, target: 10 }], // above
+    it('should return 0 when all items are pending', () => {
+      const result = computeReadinessScore({
+        readiness_checklist: {
+          release_confirmed: { status: 'pending' },
+          marketing_complete: { status: 'pending' },
+          monitoring_ready: { status: 'pending' },
+          rollback_plan_exists: { status: 'pending' },
         },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.metrics_below_target).toBe(2); // M3, M5
+      });
+      expect(result.readiness_score).toBe(0);
+      expect(result.all_checks_pass).toBe(false);
+      expect(result.blocking_items).toHaveLength(4);
     });
 
-    it('should handle all metrics on target', () => {
-      const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 150, target: 150 }],
-          activation: [{ name: 'M2', value: 90, target: 90 }],
-          retention: [{ name: 'M3', value: 75, target: 75 }],
-          revenue: [{ name: 'M4', value: 12000, target: 12000 }],
-          referral: [{ name: 'M5', value: 10, target: 10 }],
+    it('should return 0 when all items fail', () => {
+      const result = computeReadinessScore({
+        readiness_checklist: {
+          release_confirmed: { status: 'fail' },
+          marketing_complete: { status: 'fail' },
+          monitoring_ready: { status: 'fail' },
+          rollback_plan_exists: { status: 'fail' },
         },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.metrics_on_target).toBe(5);
-      expect(result.metrics_below_target).toBe(0);
+      });
+      expect(result.readiness_score).toBe(0);
+      expect(result.all_checks_pass).toBe(false);
+      expect(result.blocking_items).toHaveLength(4);
     });
 
-    it('should handle all metrics below target', () => {
-      const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 100, target: 150 }],
-          activation: [{ name: 'M2', value: 80, target: 90 }],
-          retention: [{ name: 'M3', value: 70, target: 75 }],
-          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
-          referral: [{ name: 'M5', value: 5, target: 10 }],
+    it('should give waived items 50% weight', () => {
+      const result = computeReadinessScore({
+        readiness_checklist: {
+          release_confirmed: { status: 'waived' },
+          marketing_complete: { status: 'waived' },
+          monitoring_ready: { status: 'waived' },
+          rollback_plan_exists: { status: 'waived' },
         },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.metrics_on_target).toBe(0);
-      expect(result.metrics_below_target).toBe(5);
+      });
+      // All waived: 0.35*50 + 0.25*50 + 0.20*50 + 0.20*50 = 50
+      expect(result.readiness_score).toBe(50);
+      expect(result.all_checks_pass).toBe(true);
+      expect(result.blocking_items).toEqual([]);
+    });
+
+    it('should apply correct weights per checklist key', () => {
+      // Only release_confirmed passes (weight 0.35), rest fail
+      const result = computeReadinessScore({
+        readiness_checklist: {
+          release_confirmed: { status: 'pass' },
+          marketing_complete: { status: 'fail' },
+          monitoring_ready: { status: 'fail' },
+          rollback_plan_exists: { status: 'fail' },
+        },
+      });
+      // 0.35 * 100 = 35
+      expect(result.readiness_score).toBe(35);
+      expect(result.all_checks_pass).toBe(false);
+      expect(result.blocking_items).toEqual(['marketing_complete', 'monitoring_ready', 'rollback_plan_exists']);
+    });
+
+    it('should handle mixed pass and waived statuses', () => {
+      const result = computeReadinessScore({
+        readiness_checklist: {
+          release_confirmed: { status: 'pass' },      // 0.35 * 100 = 35
+          marketing_complete: { status: 'waived' },    // 0.25 * 50  = 12.5
+          monitoring_ready: { status: 'pass' },        // 0.20 * 100 = 20
+          rollback_plan_exists: { status: 'pending' }, // 0.20 * 0   = 0
+        },
+      });
+      // 35 + 12.5 + 20 + 0 = 67.5 -> rounded to 68
+      expect(result.readiness_score).toBe(68);
+      expect(result.all_checks_pass).toBe(false);
+      expect(result.blocking_items).toEqual(['rollback_plan_exists']);
+    });
+
+    it('should handle null readiness_checklist', () => {
+      const result = computeReadinessScore({ readiness_checklist: null });
+      expect(result.readiness_score).toBe(0);
+      expect(result.all_checks_pass).toBe(false);
+      expect(result.blocking_items).toEqual(READINESS_CHECKLIST_KEYS.slice());
+    });
+
+    it('should handle undefined readiness_checklist', () => {
+      const result = computeReadinessScore({ readiness_checklist: undefined });
+      expect(result.readiness_score).toBe(0);
+      expect(result.all_checks_pass).toBe(false);
+      expect(result.blocking_items).toHaveLength(4);
+    });
+
+    it('should handle missing keys in checklist', () => {
+      const result = computeReadinessScore({
+        readiness_checklist: {
+          release_confirmed: { status: 'pass' },
+          // Other keys missing
+        },
+      });
+      expect(result.readiness_score).toBe(35); // Only release_confirmed passes
+      expect(result.all_checks_pass).toBe(false);
+      expect(result.blocking_items).toContain('marketing_complete');
+      expect(result.blocking_items).toContain('monitoring_ready');
+      expect(result.blocking_items).toContain('rollback_plan_exists');
     });
   });
 
-  describe('computeDerived() - Data preservation', () => {
-    it('should preserve original data fields', () => {
+  describe('computeDerived()', () => {
+    it('should spread input data to output', () => {
       const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 100, target: 150 }],
-          activation: [{ name: 'M2', value: 80, target: 90 }],
-          retention: [{ name: 'M3', value: 70, target: 75 }],
-          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
-          referral: [{ name: 'M5', value: 5, target: 10 }],
+        readiness_checklist: {
+          release_confirmed: { status: 'pass', evidence: 'Verified' },
+          marketing_complete: { status: 'pass', evidence: 'Ready' },
+          monitoring_ready: { status: 'pass', evidence: 'Configured' },
+          rollback_plan_exists: { status: 'pass', evidence: 'Approved' },
         },
-        funnels: [{ name: 'Funnel', steps: ['A', 'B', 'C'] }],
-        learnings: [{ insight: 'Test insight', action: 'Test action' }],
+        incident_response_plan: 'Incident response plan',
+        monitoring_setup: 'Monitoring setup',
+        rollback_plan: 'Rollback plan',
       };
       const result = stage24.computeDerived(data);
-      expect(result.aarrr).toEqual(data.aarrr);
-      expect(result.funnels).toEqual(data.funnels);
-      expect(result.learnings).toEqual(data.learnings);
+      expect(result.readiness_checklist).toEqual(data.readiness_checklist);
+      expect(result.incident_response_plan).toBe(data.incident_response_plan);
     });
   });
 
   describe('Edge cases', () => {
     it('should handle null data in validate', () => {
-      const result = stage24.validate(null);
+      const result = stage24.validate(null, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
     it('should handle undefined data in validate', () => {
-      const result = stage24.validate(undefined);
+      const result = stage24.validate(undefined, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it('should handle empty aarrr object in computeDerived', () => {
+    it('should handle whitespace-only plan strings', () => {
       const data = {
-        aarrr: {},
-        funnels: [{ name: 'Funnel', steps: ['A', 'B'] }],
-      };
-      const result = stage24.computeDerived(data);
-      expect(result.total_metrics).toBe(0);
-      expect(result.categories_complete).toBe(false);
-    });
-
-    it('should handle empty funnels array in computeDerived', () => {
-      const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 100, target: 150 }],
-          activation: [{ name: 'M2', value: 80, target: 90 }],
-          retention: [{ name: 'M3', value: 70, target: 75 }],
-          revenue: [{ name: 'M4', value: 10000, target: 12000 }],
-          referral: [{ name: 'M5', value: 5, target: 10 }],
+        readiness_checklist: {
+          release_confirmed: { status: 'pass', evidence: 'Verified' },
+          marketing_complete: { status: 'pass', evidence: 'Ready' },
+          monitoring_ready: { status: 'pass', evidence: 'Configured' },
+          rollback_plan_exists: { status: 'pass', evidence: 'Approved' },
         },
-        funnels: [],
+        incident_response_plan: '          ',
+        monitoring_setup: '          ',
+        rollback_plan: '          ',
+        chairmanGate: { status: 'approved' },
       };
-      const result = stage24.computeDerived(data);
-      expect(result.funnel_count).toBe(0);
+      const result = stage24.validate(data, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      // Whitespace-only strings should fail minimum length checks
+      expect(result.errors.length).toBeGreaterThanOrEqual(3);
     });
   });
 
   describe('Integration: validate + computeDerived workflow', () => {
     it('should work together for valid data', () => {
       const data = {
-        aarrr: {
-          acquisition: [{ name: 'Signups', value: 100, target: 150 }],
-          activation: [{ name: 'First Action', value: 80, target: 90 }],
-          retention: [{ name: '30-day retention', value: 70, target: 75 }],
-          revenue: [{ name: 'MRR', value: 10000, target: 12000 }],
-          referral: [{ name: 'Referral rate', value: 5, target: 10 }],
+        readiness_checklist: {
+          release_confirmed: { status: 'pass', evidence: 'Release build verified' },
+          marketing_complete: { status: 'pass', evidence: 'Marketing materials ready' },
+          monitoring_ready: { status: 'pass', evidence: 'Dashboards configured' },
+          rollback_plan_exists: { status: 'pass', evidence: 'Rollback playbook approved' },
         },
-        funnels: [
-          { name: 'Signup funnel', steps: ['Landing', 'Signup', 'Activation'] },
-          { name: 'Purchase funnel', steps: ['Browse', 'Cart', 'Purchase'] },
-        ],
-        learnings: [
-          { insight: 'Users drop off at step 2', action: 'Simplify onboarding', category: 'activation' },
-        ],
+        incident_response_plan: 'Full incident response plan with escalation matrix',
+        monitoring_setup: 'Full monitoring setup with dashboards and alerts',
+        rollback_plan: 'Full rollback plan with versioned deployment strategy',
+        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
+        go_no_go_decision: 'go',
       };
-      const validation = stage24.validate(data);
+      const validation = stage24.validate(data, { logger: { warn: () => {} } });
       expect(validation.valid).toBe(true);
 
       const computed = stage24.computeDerived(data);
-      expect(computed.total_metrics).toBe(5);
-      expect(computed.categories_complete).toBe(true);
-      expect(computed.funnel_count).toBe(2);
-      expect(computed.metrics_below_target).toBe(5);
+      expect(computed.readiness_checklist).toEqual(data.readiness_checklist);
     });
 
     it('should not require validation before computeDerived (decoupled)', () => {
       const data = {
-        aarrr: {
-          acquisition: [{ name: 'M1', value: 100, target: 150 }],
-          activation: [],
-          retention: [],
-          revenue: [],
-          referral: [],
-        },
-        funnels: [{ name: 'Funnel', steps: ['A'] }], // Invalid: < 2 steps
+        readiness_checklist: {},
+        incident_response_plan: 'Short',
+        monitoring_setup: null,
+        rollback_plan: null,
       };
       const computed = stage24.computeDerived(data);
-      expect(computed.total_metrics).toBe(1);
-      expect(computed.categories_complete).toBe(false);
+      expect(computed.readiness_checklist).toEqual({});
     });
   });
 });

--- a/tests/unit/eva/stage-templates/stage-25.test.js
+++ b/tests/unit/eva/stage-templates/stage-25.test.js
@@ -1,772 +1,544 @@
 /**
- * Unit tests for Stage 25 - Venture Review template
- * Part of SD-LEO-FEAT-TMPL-LAUNCH-001
+ * Unit tests for Stage 25 - Launch Execution template
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
- * Test Scenario: Stage 25 validation enforces 5-category initiative review
- * (product, market, technical, financial, team) with drift detection against
- * Stage 1 vision/constraints.
+ * Test Scenario: Stage 25 validation enforces distribution channel requirements,
+ * operations handoff structure, launch summary, and chairman gate authorization
+ * from Stage 24.
  *
  * @module tests/unit/eva/stage-templates/stage-25.test
  */
 
 import { describe, it, expect } from 'vitest';
-import stage25, { detectDrift, REVIEW_CATEGORIES, MIN_INITIATIVES_PER_CATEGORY } from '../../../../lib/eva/stage-templates/stage-25.js';
+import stage25, {
+  verifyLaunchAuthorization,
+  CHANNEL_STATUSES,
+  PIPELINE_MODES,
+  ESCALATION_LEVELS,
+  MIN_DISTRIBUTION_CHANNELS,
+} from '../../../../lib/eva/stage-templates/stage-25.js';
 
-describe('stage-25.js - Venture Review template', () => {
-  describe('Template metadata', () => {
-    it('should have correct template structure', () => {
+describe('stage-25.js - Launch Execution template', () => {
+  describe('Template contract', () => {
+    it('should export TEMPLATE with required properties', () => {
+      expect(stage25).toBeDefined();
+      expect(stage25.id).toBeDefined();
+      expect(stage25.slug).toBeDefined();
+      expect(stage25.title).toBeDefined();
+      expect(stage25.version).toBeDefined();
+    });
+
+    it('should have correct id, slug, title, version', () => {
       expect(stage25.id).toBe('stage-25');
-      expect(stage25.slug).toBe('venture-review');
-      expect(stage25.title).toBe('Venture Review');
-      expect(stage25.version).toBe('1.0.0');
+      expect(stage25.slug).toBe('launch-execution');
+      expect(stage25.title).toBe('Launch Execution');
+      expect(stage25.version).toBe('2.0.0');
     });
 
-    it('should have schema definition', () => {
+    it('should have schema, defaultData, validate, computeDerived', () => {
       expect(stage25.schema).toBeDefined();
-      expect(stage25.schema.review_summary).toBeDefined();
-      expect(stage25.schema.initiatives).toBeDefined();
-      expect(stage25.schema.current_vision).toBeDefined();
-      expect(stage25.schema.drift_justification).toBeDefined();
-      expect(stage25.schema.next_steps).toBeDefined();
-      expect(stage25.schema.total_initiatives).toBeDefined();
-      expect(stage25.schema.all_categories_reviewed).toBeDefined();
-      expect(stage25.schema.drift_detected).toBeDefined();
-      expect(stage25.schema.drift_check).toBeDefined();
-    });
-
-    it('should have defaultData', () => {
-      expect(stage25.defaultData).toEqual({
-        review_summary: null,
-        initiatives: {},
-        current_vision: null,
-        drift_justification: null,
-        next_steps: [],
-        financialComparison: { projectedRevenue: null, actualRevenue: null, projectedCosts: null, actualCosts: null, revenueVariancePct: null, financialTrajectory: null, variance: null, assessment: null },
-        ventureHealth: { overallRating: null, dimensions: {} },
-        chairmanGate: { status: 'pending', rationale: null, decision_id: null },
-        total_initiatives: 0,
-        all_categories_reviewed: false,
-        drift_detected: false,
-        drift_check: null,
-        ventureDecision: null,
-      });
-    });
-
-    it('should have validate function', () => {
+      expect(stage25.defaultData).toBeDefined();
       expect(typeof stage25.validate).toBe('function');
-    });
-
-    it('should have computeDerived function', () => {
       expect(typeof stage25.computeDerived).toBe('function');
     });
 
+    it('should have analysisStep function', () => {
+      expect(typeof stage25.analysisStep).toBe('function');
+    });
+
+    it('should have outputSchema from extractOutputSchema', () => {
+      expect(stage25.outputSchema).toBeDefined();
+    });
+
+    it('should have schema with expected fields', () => {
+      expect(stage25.schema.distribution_channels).toBeDefined();
+      expect(stage25.schema.operations_handoff).toBeDefined();
+      expect(stage25.schema.launch_summary).toBeDefined();
+      expect(stage25.schema.go_live_timestamp).toBeDefined();
+      expect(stage25.schema.pipeline_terminus).toBeDefined();
+      expect(stage25.schema.pipeline_mode).toBeDefined();
+      expect(stage25.schema.channels_active_count).toBeDefined();
+      expect(stage25.schema.channels_total_count).toBeDefined();
+    });
+
+    it('should have correct defaultData', () => {
+      expect(stage25.defaultData).toEqual({
+        distribution_channels: [],
+        operations_handoff: {
+          monitoring: { dashboards: [], alerts: [], health_check_url: null },
+          escalation: { contacts: [], runbook_url: null, sla_targets: {} },
+          maintenance: { schedule: null, backup_strategy: null, update_policy: null },
+        },
+        launch_summary: null,
+        go_live_timestamp: null,
+        pipeline_terminus: false,
+        pipeline_mode: 'launch',
+        channels_active_count: 0,
+        channels_total_count: 0,
+      });
+    });
+
     it('should export constants', () => {
-      expect(REVIEW_CATEGORIES).toEqual(['product', 'market', 'technical', 'financial', 'team']);
-      expect(MIN_INITIATIVES_PER_CATEGORY).toBe(1);
+      expect(CHANNEL_STATUSES).toEqual(['inactive', 'activating', 'active', 'failed', 'paused']);
+      expect(PIPELINE_MODES).toEqual(['discovery', 'build', 'launch', 'operations']);
+      expect(ESCALATION_LEVELS).toEqual(['L1', 'L2', 'L3']);
+      expect(MIN_DISTRIBUTION_CHANNELS).toBe(1);
     });
 
-    it('should export detectDrift function', () => {
-      expect(typeof detectDrift).toBe('function');
-    });
-  });
-
-  describe('validate() - Review summary', () => {
-    it('should fail for missing review_summary', () => {
-      const invalidData = {
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('review_summary'))).toBe(true);
-    });
-
-    it('should fail for review_summary < 20 characters', () => {
-      const invalidData = {
-        review_summary: 'Short summary',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('review_summary'))).toBe(true);
-    });
-
-    it('should pass for valid review_summary', () => {
-      const validData = {
-        review_summary: 'Comprehensive review of all venture aspects completed successfully',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
-      };
-      const result = stage25.validate(validData);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toEqual([]);
+    it('should export verifyLaunchAuthorization function', () => {
+      expect(typeof verifyLaunchAuthorization).toBe('function');
     });
   });
 
-  describe('validate() - Initiatives object structure', () => {
-    it('should fail for missing initiatives object', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('initiatives'))).toBe(true);
-    });
-
-    it('should fail for non-object initiatives', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: 'not an object',
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('initiatives'))).toBe(true);
-    });
-  });
-
-  describe('validate() - Initiative categories', () => {
-    it('should pass for valid initiatives across all categories', () => {
-      const validData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'MVP Launch', status: 'completed', outcome: 'Successfully launched' }],
-          market: [{ title: 'Market Analysis', status: 'completed', outcome: 'Positive feedback' }],
-          technical: [{ title: 'Infrastructure Setup', status: 'completed', outcome: 'Stable platform' }],
-          financial: [{ title: 'Funding Round', status: 'completed', outcome: 'Fully funded' }],
-          team: [{ title: 'Team Expansion', status: 'completed', outcome: 'Key hires made' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
-      };
-      const result = stage25.validate(validData);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toEqual([]);
-    });
-
-    it('should fail for missing product category', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('initiatives.product'))).toBe(true);
-    });
-
-    it('should fail for empty product array', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('initiatives.product') && e.includes('at least 1'))).toBe(true);
-    });
-
-    it('should fail for initiative missing title', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('initiatives.product[0].title'))).toBe(true);
-    });
-
-    it('should fail for initiative missing status', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('initiatives.product[0].status'))).toBe(true);
-    });
-
-    it('should fail for initiative missing outcome', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('initiatives.product[0].outcome'))).toBe(true);
-    });
-
-    it('should allow multiple initiatives per category', () => {
-      const validData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [
-            { title: 'MVP Launch', status: 'completed', outcome: 'Success' },
-            { title: 'Feature A', status: 'completed', outcome: 'Success' },
-          ],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
-      };
-      const result = stage25.validate(validData);
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe('validate() - Current vision', () => {
-    const validInitiatives = {
-      product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-      market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-      technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-      financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-      team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-    };
-
-    it('should fail for missing current_vision', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: validInitiatives,
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('current_vision'))).toBe(true);
-    });
-
-    it('should fail for current_vision < 10 characters', () => {
-      const invalidData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: validInitiatives,
-        current_vision: 'Short',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('current_vision'))).toBe(true);
-    });
-
-    it('should pass for valid current_vision', () => {
-      const validData = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: validInitiatives,
-        current_vision: 'Current vision statement for the venture',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
-      };
-      const result = stage25.validate(validData);
-      expect(result.valid).toBe(true);
-    });
-  });
-
-  describe('validate() - Next steps', () => {
-    const validData = {
-      review_summary: 'Comprehensive review summary here',
-      initiatives: {
-        product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-        market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-        technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-        team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
+  describe('validate() - Distribution channels', () => {
+    const validBase = {
+      operations_handoff: {
+        monitoring: { dashboards: [], alerts: [] },
+        escalation: { contacts: [], runbook_url: null },
       },
-      current_vision: 'Current vision statement',
+      launch_summary: 'Comprehensive launch summary for the venture go-live',
     };
 
-    it('should fail for missing next_steps', () => {
-      const invalidData = { ...validData };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('next_steps'))).toBe(true);
-    });
-
-    it('should fail for empty next_steps array', () => {
-      const invalidData = {
-        ...validData,
-        next_steps: [],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('next_steps') && e.includes('at least 1'))).toBe(true);
-    });
-
-    it('should fail for next step missing action', () => {
-      const invalidData = {
-        ...validData,
-        next_steps: [{ owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('next_steps[0].action'))).toBe(true);
-    });
-
-    it('should fail for next step missing owner', () => {
-      const invalidData = {
-        ...validData,
-        next_steps: [{ action: 'Action 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('next_steps[0].owner'))).toBe(true);
-    });
-
-    it('should fail for next step missing timeline', () => {
-      const invalidData = {
-        ...validData,
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1' }],
-      };
-      const result = stage25.validate(invalidData);
-      expect(result.valid).toBe(false);
-      expect(result.errors.some(e => e.includes('next_steps[0].timeline'))).toBe(true);
-    });
-
-    it('should pass for valid next steps', () => {
-      const validDataWithSteps = {
-        ...validData,
-        next_steps: [
-          { action: 'Launch next phase', owner: 'CEO', timeline: 'Q1 2026' },
-          { action: 'Expand team', owner: 'HR', timeline: 'Q2 2026' },
+    it('should pass for valid data with 1+ distribution channels', () => {
+      const validData = {
+        ...validBase,
+        distribution_channels: [
+          { name: 'Web App', type: 'web', status: 'active' },
         ],
-        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
       };
-      const result = stage25.validate(validDataWithSteps);
+      const result = stage25.validate(validData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual([]);
+    });
+
+    it('should pass for multiple distribution channels', () => {
+      const validData = {
+        ...validBase,
+        distribution_channels: [
+          { name: 'Web App', type: 'web', status: 'active' },
+          { name: 'Mobile App', type: 'mobile', status: 'activating' },
+          { name: 'API Gateway', type: 'api', status: 'inactive' },
+        ],
+      };
+      const result = stage25.validate(validData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(true);
+    });
+
+    it('should fail for missing distribution_channels', () => {
+      const invalidData = { ...validBase };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('distribution_channels'))).toBe(true);
+    });
+
+    it('should fail for empty distribution_channels array', () => {
+      const invalidData = {
+        ...validBase,
+        distribution_channels: [],
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('distribution_channels') && e.includes('at least 1'))).toBe(true);
+    });
+
+    it('should fail for channel missing name', () => {
+      const invalidData = {
+        ...validBase,
+        distribution_channels: [
+          { type: 'web', status: 'active' },
+        ],
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('distribution_channels[0].name'))).toBe(true);
+    });
+
+    it('should fail for channel missing type', () => {
+      const invalidData = {
+        ...validBase,
+        distribution_channels: [
+          { name: 'Web App', status: 'active' },
+        ],
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('distribution_channels[0].type'))).toBe(true);
+    });
+
+    it('should fail for channel with invalid status', () => {
+      const invalidData = {
+        ...validBase,
+        distribution_channels: [
+          { name: 'Web App', type: 'web', status: 'invalid_status' },
+        ],
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('distribution_channels[0].status'))).toBe(true);
+    });
+
+    it('should accept all valid CHANNEL_STATUSES', () => {
+      for (const status of CHANNEL_STATUSES) {
+        const validData = {
+          ...validBase,
+          distribution_channels: [
+            { name: 'Web App', type: 'web', status },
+          ],
+        };
+        const result = stage25.validate(validData, { logger: { warn: () => {} } });
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    it('should validate multiple channels and collect errors', () => {
+      const invalidData = {
+        ...validBase,
+        distribution_channels: [
+          { name: 'Web App', type: 'web', status: 'active' },
+          { type: 'mobile', status: 'active' }, // missing name
+          { name: 'API Gateway', status: 'active' }, // missing type
+        ],
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('distribution_channels[1].name'))).toBe(true);
+      expect(result.errors.some(e => e.includes('distribution_channels[2].type'))).toBe(true);
+    });
+  });
+
+  describe('validate() - Operations handoff', () => {
+    const validChannels = [{ name: 'Web App', type: 'web', status: 'active' }];
+    const validSummary = 'Comprehensive launch summary for the venture';
+
+    it('should fail for missing operations_handoff', () => {
+      const invalidData = {
+        distribution_channels: validChannels,
+        launch_summary: validSummary,
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('operations_handoff'))).toBe(true);
+    });
+
+    it('should fail for non-object operations_handoff', () => {
+      const invalidData = {
+        distribution_channels: validChannels,
+        operations_handoff: 'not an object',
+        launch_summary: validSummary,
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('operations_handoff'))).toBe(true);
+    });
+
+    it('should fail for missing monitoring in operations_handoff', () => {
+      const invalidData = {
+        distribution_channels: validChannels,
+        operations_handoff: {
+          escalation: { contacts: [] },
+        },
+        launch_summary: validSummary,
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('operations_handoff.monitoring'))).toBe(true);
+    });
+
+    it('should fail for missing escalation in operations_handoff', () => {
+      const invalidData = {
+        distribution_channels: validChannels,
+        operations_handoff: {
+          monitoring: { dashboards: [] },
+        },
+        launch_summary: validSummary,
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('operations_handoff.escalation'))).toBe(true);
+    });
+
+    it('should pass with valid monitoring and escalation', () => {
+      const validData = {
+        distribution_channels: validChannels,
+        operations_handoff: {
+          monitoring: { dashboards: ['main-dashboard'], alerts: ['cpu-alert'] },
+          escalation: { contacts: ['on-call@example.com'], runbook_url: 'https://runbook.example.com' },
+        },
+        launch_summary: validSummary,
+      };
+      const result = stage25.validate(validData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(true);
+    });
+
+    it('should pass with maintenance included (optional)', () => {
+      const validData = {
+        distribution_channels: validChannels,
+        operations_handoff: {
+          monitoring: { dashboards: [], alerts: [] },
+          escalation: { contacts: [] },
+          maintenance: { schedule: 'weekly', backup_strategy: 'daily snapshots', update_policy: 'rolling' },
+        },
+        launch_summary: validSummary,
+      };
+      const result = stage25.validate(validData, { logger: { warn: () => {} } });
       expect(result.valid).toBe(true);
     });
   });
 
-  describe('detectDrift() - Pure function', () => {
-    it('should detect no drift for null original_vision', () => {
-      const result = detectDrift({
-        original_vision: null,
-        current_vision: 'Current vision statement',
-      });
-      expect(result.drift_detected).toBe(false);
-      expect(result.rationale).toContain('No original vision');
-      expect(result.original_vision).toBeNull();
-      expect(result.current_vision).toBe('Current vision statement');
+  describe('validate() - Launch summary', () => {
+    const validBase = {
+      distribution_channels: [{ name: 'Web App', type: 'web', status: 'active' }],
+      operations_handoff: {
+        monitoring: { dashboards: [] },
+        escalation: { contacts: [] },
+      },
+    };
+
+    it('should fail for missing launch_summary', () => {
+      const invalidData = { ...validBase };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_summary'))).toBe(true);
     });
 
-    it('should detect no drift for identical visions', () => {
-      const vision = 'Building revolutionary platform technology solutions';
-      const result = detectDrift({
-        original_vision: vision,
-        current_vision: vision,
-      });
-      expect(result.drift_detected).toBe(false);
-      expect(result.rationale).toContain('100% overlap');
+    it('should fail for launch_summary < 10 characters', () => {
+      const invalidData = {
+        ...validBase,
+        launch_summary: 'Short',
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_summary'))).toBe(true);
     });
 
-    it('should detect no drift for high overlap (>30%)', () => {
-      const result = detectDrift({
-        original_vision: 'Building revolutionary platform technology solutions marketplace',
-        current_vision: 'Building innovative platform technology solutions ecosystem',
-      });
-      expect(result.drift_detected).toBe(false);
-      expect(result.rationale).toContain('overlap');
+    it('should fail for empty launch_summary', () => {
+      const invalidData = {
+        ...validBase,
+        launch_summary: '',
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_summary'))).toBe(true);
     });
 
-    it('should detect drift for low overlap (<30%)', () => {
-      const result = detectDrift({
-        original_vision: 'Building revolutionary platform technology solutions marketplace',
-        current_vision: 'Creating artisanal handmade crafts store',
-      });
-      expect(result.drift_detected).toBe(true);
-      expect(result.rationale).toContain('Significant drift');
-      expect(result.rationale).toContain('overlap');
-    });
-
-    it('should filter out short words (<=3 chars) in overlap calculation', () => {
-      const result = detectDrift({
-        original_vision: 'A big red car and the sun',
-        current_vision: 'The big sun',
-      });
-      // Only words >3 chars: original = [], current = []
-      // Should detect drift due to no meaningful overlap
-      expect(result.drift_detected).toBe(false); // No words >3 chars, so 100% overlap of empty sets
-    });
-
-    it('should be case-insensitive', () => {
-      const result = detectDrift({
-        original_vision: 'Building Revolutionary Platform Technology',
-        current_vision: 'building revolutionary platform technology',
-      });
-      expect(result.drift_detected).toBe(false);
-      expect(result.rationale).toContain('100% overlap');
-    });
-
-    it('should handle whitespace and punctuation', () => {
-      const result = detectDrift({
-        original_vision: 'Building  revolutionary   platform!',
-        current_vision: 'Building revolutionary platform.',
-      });
-      expect(result.drift_detected).toBe(false);
+    it('should pass for valid launch_summary', () => {
+      const validData = {
+        ...validBase,
+        launch_summary: 'Comprehensive launch execution summary with all details',
+      };
+      const result = stage25.validate(validData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(true);
     });
   });
 
-  describe('computeDerived() - Initiative counts', () => {
-    it('should calculate total_initiatives correctly', () => {
-      const data = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }, { title: 'P2', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }, { title: 'F2', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
+  describe('verifyLaunchAuthorization() - Pure function', () => {
+    it('should return authorized when chairman gate is approved and decision is go', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'approved' },
+          go_no_go_decision: 'go',
         },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.computeDerived(data);
-      expect(result.total_initiatives).toBe(7);
+      });
+      expect(result.authorized).toBe(true);
+      expect(result.reasons).toEqual([]);
     });
 
-    it('should set all_categories_reviewed to true when all categories present', () => {
-      const data = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
+    it('should return authorized when decision is conditional_go', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'approved' },
+          go_no_go_decision: 'conditional_go',
         },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.computeDerived(data);
-      expect(result.all_categories_reviewed).toBe(true);
+      });
+      expect(result.authorized).toBe(true);
+      expect(result.reasons).toEqual([]);
     });
 
-    it('should set all_categories_reviewed to false when missing categories', () => {
-      const data = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [],
-          financial: [],
-          team: [],
+    it('should return not authorized when stage24Data is not provided', () => {
+      const result = verifyLaunchAuthorization({ stage24Data: undefined });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons).toHaveLength(1);
+      expect(result.reasons[0]).toContain('not available');
+    });
+
+    it('should return not authorized when stage24Data is null', () => {
+      const result = verifyLaunchAuthorization({ stage24Data: null });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons.length).toBeGreaterThan(0);
+    });
+
+    it('should return not authorized when chairman gate is not approved', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'pending' },
+          go_no_go_decision: 'go',
         },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.computeDerived(data);
-      expect(result.all_categories_reviewed).toBe(false);
+      });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons.some(r => r.includes('chairman gate'))).toBe(true);
+    });
+
+    it('should return not authorized when chairman gate is rejected', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'rejected' },
+          go_no_go_decision: 'go',
+        },
+      });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons.some(r => r.includes('chairman gate'))).toBe(true);
+    });
+
+    it('should return not authorized when decision is no_go', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'approved' },
+          go_no_go_decision: 'no_go',
+        },
+      });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons.some(r => r.includes('go/no-go decision'))).toBe(true);
+    });
+
+    it('should return not authorized when decision is not set', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'approved' },
+          go_no_go_decision: null,
+        },
+      });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons.some(r => r.includes('go/no-go decision'))).toBe(true);
+    });
+
+    it('should collect multiple reasons when both gate and decision fail', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'pending' },
+          go_no_go_decision: 'no_go',
+        },
+      });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons).toHaveLength(2);
+      expect(result.reasons.some(r => r.includes('chairman gate'))).toBe(true);
+      expect(result.reasons.some(r => r.includes('go/no-go decision'))).toBe(true);
+    });
+
+    it('should handle missing chairmanGate in stage24Data', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          go_no_go_decision: 'go',
+        },
+      });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons.some(r => r.includes('chairman gate'))).toBe(true);
+    });
+
+    it('should handle missing go_no_go_decision in stage24Data', () => {
+      const result = verifyLaunchAuthorization({
+        stage24Data: {
+          chairmanGate: { status: 'approved' },
+        },
+      });
+      expect(result.authorized).toBe(false);
+      expect(result.reasons.some(r => r.includes('go/no-go decision'))).toBe(true);
     });
   });
 
-  describe('computeDerived() - Drift detection integration', () => {
-    it('should include drift check when prerequisites.stage01 provided', () => {
+  describe('computeDerived()', () => {
+    it('should spread input data to output', () => {
       const data = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
+        distribution_channels: [
+          { name: 'Web App', type: 'web', status: 'active' },
+        ],
+        operations_handoff: {
+          monitoring: { dashboards: ['main'] },
+          escalation: { contacts: ['ops@example.com'] },
         },
-        current_vision: 'Building revolutionary platform technology solutions',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const prerequisites = {
-        stage01: {
-          venture_name: 'Platform Builder',
-          elevator_pitch: 'Building revolutionary platform technology solutions',
-        },
-      };
-      const result = stage25.computeDerived(data, prerequisites);
-      expect(result.drift_check).toBeDefined();
-      expect(result.drift_check.drift_detected).toBe(false);
-      expect(result.drift_detected).toBe(false);
-    });
-
-    it('should detect drift when vision changed significantly', () => {
-      const data = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Creating artisanal handmade crafts marketplace',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const prerequisites = {
-        stage01: {
-          venture_name: 'Platform Builder',
-          elevator_pitch: 'Building revolutionary platform technology solutions',
-        },
-      };
-      const result = stage25.computeDerived(data, prerequisites);
-      expect(result.drift_check).toBeDefined();
-      expect(result.drift_check.drift_detected).toBe(true);
-      expect(result.drift_detected).toBe(true);
-    });
-
-    it('should skip drift check when prerequisites not provided', () => {
-      const data = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+        launch_summary: 'Launch summary text',
+        go_live_timestamp: '2026-03-01T00:00:00Z',
       };
       const result = stage25.computeDerived(data);
-      expect(result.drift_check).toBeDefined();
-      expect(result.drift_check.drift_detected).toBe(false);
-      expect(result.drift_check.rationale).toContain('Stage 1 data not provided');
-    });
-
-    it('should preserve original data fields', () => {
-      const data = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-          financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-          team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-        },
-        current_vision: 'Current vision statement',
-        drift_justification: 'Justification text',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-      };
-      const result = stage25.computeDerived(data);
-      expect(result.review_summary).toBe(data.review_summary);
-      expect(result.initiatives).toEqual(data.initiatives);
-      expect(result.current_vision).toBe(data.current_vision);
-      expect(result.drift_justification).toBe(data.drift_justification);
-      expect(result.next_steps).toEqual(data.next_steps);
+      expect(result.distribution_channels).toEqual(data.distribution_channels);
+      expect(result.operations_handoff).toEqual(data.operations_handoff);
+      expect(result.launch_summary).toBe(data.launch_summary);
+      expect(result.go_live_timestamp).toBe(data.go_live_timestamp);
     });
   });
 
   describe('Edge cases', () => {
     it('should handle null data in validate', () => {
-      const result = stage25.validate(null);
+      const result = stage25.validate(null, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
     it('should handle undefined data in validate', () => {
-      const result = stage25.validate(undefined);
+      const result = stage25.validate(undefined, { logger: { warn: () => {} } });
       expect(result.valid).toBe(false);
       expect(result.errors.length).toBeGreaterThan(0);
     });
 
-    it('should handle empty initiatives object in computeDerived', () => {
-      const data = {
-        review_summary: 'Comprehensive review summary here',
-        initiatives: {},
-        current_vision: 'Current vision statement',
-        next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
+    it('should handle non-array distribution_channels', () => {
+      const invalidData = {
+        distribution_channels: 'not an array',
+        operations_handoff: {
+          monitoring: { dashboards: [] },
+          escalation: { contacts: [] },
+        },
+        launch_summary: 'Valid launch summary text',
       };
-      const result = stage25.computeDerived(data);
-      expect(result.total_initiatives).toBe(0);
-      expect(result.all_categories_reviewed).toBe(false);
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('distribution_channels'))).toBe(true);
+    });
+
+    it('should handle whitespace-only launch_summary', () => {
+      const invalidData = {
+        distribution_channels: [{ name: 'Web', type: 'web', status: 'active' }],
+        operations_handoff: {
+          monitoring: { dashboards: [] },
+          escalation: { contacts: [] },
+        },
+        launch_summary: '          ',
+      };
+      const result = stage25.validate(invalidData, { logger: { warn: () => {} } });
+      expect(result.valid).toBe(false);
+      expect(result.errors.some(e => e.includes('launch_summary'))).toBe(true);
     });
   });
 
   describe('Integration: validate + computeDerived workflow', () => {
     it('should work together for valid data', () => {
       const data = {
-        review_summary: 'Comprehensive review of all venture aspects completed successfully',
-        initiatives: {
-          product: [{ title: 'MVP Launch', status: 'completed', outcome: 'Successfully launched' }],
-          market: [{ title: 'Market Analysis', status: 'completed', outcome: 'Positive feedback' }],
-          technical: [{ title: 'Infrastructure Setup', status: 'completed', outcome: 'Stable platform' }],
-          financial: [{ title: 'Funding Round', status: 'completed', outcome: 'Fully funded' }],
-          team: [{ title: 'Team Expansion', status: 'completed', outcome: 'Key hires made' }],
-        },
-        current_vision: 'Building revolutionary platform technology solutions',
-        drift_justification: 'No drift detected, vision remains consistent',
-        next_steps: [
-          { action: 'Launch next phase', owner: 'CEO', timeline: 'Q1 2026' },
+        distribution_channels: [
+          { name: 'Web App', type: 'web', status: 'active' },
+          { name: 'Mobile App', type: 'mobile', status: 'activating' },
         ],
-        chairmanGate: { status: 'approved', rationale: null, decision_id: null },
+        operations_handoff: {
+          monitoring: { dashboards: ['main-dashboard'], alerts: ['cpu-alert'], health_check_url: 'https://health.example.com' },
+          escalation: { contacts: ['ops@example.com'], runbook_url: 'https://runbook.example.com', sla_targets: { p1: '15m' } },
+          maintenance: { schedule: 'weekly', backup_strategy: 'daily', update_policy: 'rolling' },
+        },
+        launch_summary: 'Comprehensive launch execution summary with distribution channels active',
+        go_live_timestamp: '2026-03-01T00:00:00Z',
       };
-      const validation = stage25.validate(data);
+      const validation = stage25.validate(data, { logger: { warn: () => {} } });
       expect(validation.valid).toBe(true);
 
       const computed = stage25.computeDerived(data);
-      expect(computed.total_initiatives).toBe(5);
-      expect(computed.all_categories_reviewed).toBe(true);
+      expect(computed.distribution_channels).toEqual(data.distribution_channels);
+      expect(computed.operations_handoff).toEqual(data.operations_handoff);
     });
 
     it('should not require validation before computeDerived (decoupled)', () => {
       const data = {
-        review_summary: 'Short', // Invalid: < 20 chars
-        initiatives: {
-          product: [{ title: 'P1' }], // Invalid: missing status and outcome
-          market: [],
-          technical: [],
-          financial: [],
-          team: [],
-        },
-        current_vision: 'CV',
-        next_steps: [],
+        distribution_channels: [],
+        operations_handoff: {},
+        launch_summary: 'Short',
       };
       const computed = stage25.computeDerived(data);
-      expect(computed.total_initiatives).toBe(1);
-      expect(computed.all_categories_reviewed).toBe(false);
-    });
-  });
-
-  describe('computeDerived() - Venture decision classification', () => {
-    const fullInitiatives = {
-      product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-      market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-      technical: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-      financial: [{ title: 'F1', status: 'completed', outcome: 'Success' }],
-      team: [{ title: 'T1', status: 'completed', outcome: 'Success' }],
-    };
-
-    const baseData = {
-      review_summary: 'Comprehensive review summary here',
-      initiatives: fullInitiatives,
-      current_vision: 'Building revolutionary platform technology solutions',
-      next_steps: [{ action: 'Action 1', owner: 'Owner 1', timeline: 'Q1 2026' }],
-    };
-
-    it('should return ventureDecision.decision="continue" when no drift and all categories reviewed', () => {
-      const prerequisites = {
-        stage01: {
-          venture_name: 'Platform Builder',
-          elevator_pitch: 'Building revolutionary platform technology solutions',
-        },
-      };
-      const result = stage25.computeDerived(baseData, prerequisites);
-      expect(result.ventureDecision).toBeDefined();
-      expect(result.ventureDecision.decision).toBe('continue');
-      expect(result.ventureDecision.confidence).toBe('high');
-    });
-
-    it('should return ventureDecision.decision="pivot" when drift_detected=true', () => {
-      const data = {
-        ...baseData,
-        current_vision: 'Creating artisanal handmade crafts marketplace',
-      };
-      const prerequisites = {
-        stage01: {
-          venture_name: 'Platform Builder',
-          elevator_pitch: 'Building revolutionary platform technology solutions',
-        },
-      };
-      const result = stage25.computeDerived(data, prerequisites);
-      expect(result.ventureDecision.decision).toBe('pivot');
-      expect(result.ventureDecision.rationale).toContain('Drift detected');
-      expect(result.ventureDecision.rationale).toContain('pivot');
-    });
-
-    it('should return ventureDecision.confidence="low" when not all categories reviewed', () => {
-      const data = {
-        ...baseData,
-        initiatives: {
-          product: [{ title: 'P1', status: 'completed', outcome: 'Success' }],
-          market: [{ title: 'M1', status: 'completed', outcome: 'Success' }],
-          technical: [],
-          financial: [],
-          team: [],
-        },
-      };
-      const result = stage25.computeDerived(data);
-      expect(result.ventureDecision.confidence).toBe('low');
-    });
-
-    it('should set drift_check with semanticDrift field in computeDerived output', () => {
-      const prerequisites = {
-        stage01: {
-          venture_name: 'Platform Builder',
-          elevator_pitch: 'Building revolutionary platform technology solutions',
-        },
-      };
-      const result = stage25.computeDerived(baseData, prerequisites);
-      expect(result.drift_check).toBeDefined();
-      expect(result.drift_check).toHaveProperty('semanticDrift');
-      expect(result.drift_check.semanticDrift).toBe('aligned');
-
-      // With drift
-      const driftData = {
-        ...baseData,
-        current_vision: 'Creating artisanal handmade crafts marketplace',
-      };
-      const driftResult = stage25.computeDerived(driftData, prerequisites);
-      expect(driftResult.drift_check.semanticDrift).toMatch(/moderate_drift|major_drift/);
+      expect(computed.distribution_channels).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Redesign Marketing Preparation (stage 23), Launch Readiness (stage 24), and Launch Execution (stage 25) templates for EVA pipeline v2 contract system
- Add 3 new LLM-based analysis step modules for marketing prep, launch readiness scoring, and go-live execution
- Update stage contracts with proper dependency graph and inter-stage data flow
- Chairman gate integration in stage 24 (launch readiness) and stage 25 (go/no-go authorization)
- 250 tests across 7 files, all passing

## Test plan
- [x] 250 unit tests passing across stage-23, stage-24, stage-25, and index test files
- [x] Stage contract validation and dependency graph verified
- [x] Import chain verified clean — all templates load and register
- [x] Edge cases handled with safe defaults and normalization

SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)