### PR TITLE
feat(eva): redesign Identity Phase stages 10-12 with persona-first flow

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -153,35 +153,59 @@ const STAGE_CONTRACTS = new Map([
   }],
 
   [10, {
-    consumes: [],
+    consumes: [
+      { stage: 1, fields: {
+        description: { type: 'string' },
+        valueProp: { type: 'string' },
+        targetMarket: { type: 'string' },
+      }},
+    ],
     produces: {
-      candidates: { type: 'array', minItems: 5 },
+      customerPersonas: { type: 'array', minItems: 3 },
       brandGenome: { type: 'object' },
+      candidates: { type: 'array', minItems: 5 },
     },
   }],
 
   [11, {
-    consumes: [],
+    consumes: [
+      { stage: 1, fields: {
+        description: { type: 'string' },
+        targetMarket: { type: 'string' },
+      }},
+      { stage: 10, fields: {
+        customerPersonas: { type: 'array', minItems: 3 },
+        brandGenome: { type: 'object' },
+      }},
+    ],
     produces: {
-      tiers: { type: 'array', minItems: 3 },
-      channels: { type: 'array', minItems: 8 },
+      candidates: { type: 'array', minItems: 5 },
+      visualIdentity: { type: 'object' },
+      scoringCriteria: { type: 'array', minItems: 1 },
     },
   }],
 
   [12, {
     consumes: [
+      { stage: 1, fields: {
+        description: { type: 'string' },
+        targetMarket: { type: 'string' },
+      }},
       { stage: 10, fields: {
-        candidates: { type: 'array', minItems: 5 },
+        customerPersonas: { type: 'array', minItems: 3 },
+        brandGenome: { type: 'object' },
       }},
       { stage: 11, fields: {
-        tiers: { type: 'array', minItems: 3 },
-        channels: { type: 'array', minItems: 8 },
+        candidates: { type: 'array', minItems: 5 },
       }},
     ],
     produces: {
-      sales_model: { type: 'string' },
+      marketTiers: { type: 'array', minItems: 3 },
+      channels: { type: 'array', minItems: 8 },
+      salesModel: { type: 'string' },
       deal_stages: { type: 'array', minItems: 3 },
       funnel_stages: { type: 'array', minItems: 4 },
+      customer_journey: { type: 'array', minItems: 5 },
       reality_gate: { type: 'object' },
     },
   }],

--- a/lib/eva/contracts/stage-contracts.yaml
+++ b/lib/eva/contracts/stage-contracts.yaml
@@ -174,12 +174,14 @@ stages:
       valuationEstimate: { type: object, required: false }
 
   10:
-    name: "Brand Identity"
+    name: "Customer & Brand Foundation"
     consumes:
       - stage: 1
         fields:
           description: { type: string }
           valueProp: { type: string }
+          targetMarket: { type: string }
+          problemStatement: { type: string }
       - stage: 3
         fields:
           overallScore: { type: integer, required: false }
@@ -190,11 +192,12 @@ stages:
         fields:
           customerSegments: { type: object, required: false }
     produces:
-      candidates: { type: array, minItems: 5 }
+      customerPersonas: { type: array, minItems: 3 }
       brandGenome: { type: object }
+      candidates: { type: array, minItems: 5 }
 
   11:
-    name: "Marketing Strategy"
+    name: "Naming & Visual Identity"
     consumes:
       - stage: 1
         fields:
@@ -205,34 +208,42 @@ stages:
           unitEconomics: { type: object, required: false }
       - stage: 10
         fields:
-          candidates: { type: array }
+          customerPersonas: { type: array, minItems: 3 }
+          brandGenome: { type: object }
     produces:
-      tiers: { type: array, minItems: 3 }
-      channels: { type: array, minItems: 8 }
+      candidates: { type: array, minItems: 5 }
+      visualIdentity: { type: object }
+      scoringCriteria: { type: array, minItems: 1 }
 
   12:
-    name: "Sales Framework"
+    name: "GTM & Sales Strategy"
     consumes:
       - stage: 1
         fields:
           description: { type: string }
+          targetMarket: { type: string }
       - stage: 5
         fields:
           unitEconomics: { type: object, required: false }
       - stage: 7
         fields:
-          tiers: { type: array, required: false }
+          pricing_model: { type: string, required: false }
+          arpa: { type: number, required: false }
       - stage: 10
         fields:
-          candidates: { type: array, minItems: 5 }
+          customerPersonas: { type: array, minItems: 3 }
+          brandGenome: { type: object }
       - stage: 11
         fields:
-          tiers: { type: array, minItems: 3 }
-          channels: { type: array, minItems: 8 }
+          candidates: { type: array, minItems: 5 }
+          decision: { type: object, required: false }
     produces:
-      sales_model: { type: string }
+      marketTiers: { type: array, minItems: 3 }
+      channels: { type: array, minItems: 8 }
+      salesModel: { type: string }
       deal_stages: { type: array, minItems: 3 }
       funnel_stages: { type: array, minItems: 4 }
+      customer_journey: { type: array, minItems: 5 }
       reality_gate: { type: object }
 
   13:

--- a/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
@@ -1,0 +1,330 @@
+/**
+ * Stage 10 Analysis Step - Customer & Brand Foundation
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-A
+ *
+ * Generates customer personas FIRST from upstream research data,
+ * then derives brand genome grounded in persona insights.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-10-customer-brand
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+
+// Duplicated from stage-10.js to avoid circular dependency
+const MIN_PERSONAS = 3;
+const MIN_CANDIDATES = 5;
+const MIN_CRITERIA = 3;
+const NAMING_STRATEGIES = ['descriptive', 'abstract', 'acronym', 'founder', 'metaphorical'];
+const AVAILABILITY_STATUSES = ['pending', 'available', 'taken', 'unknown'];
+
+const SYSTEM_PROMPT = `You are EVA's Customer & Brand Foundation Engine. Generate customer personas FIRST, then derive a brand genome grounded in those personas.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "customerPersonas": [
+    {
+      "name": "Persona name (e.g., 'Tech-Savvy Startup Founder')",
+      "demographics": {
+        "ageRange": "25-40",
+        "role": "Founder/CEO",
+        "companySize": "1-50 employees",
+        "industry": "Technology",
+        "income": "Mid-to-high",
+        "location": "Urban"
+      },
+      "goals": ["Primary goal 1", "Primary goal 2"],
+      "painPoints": ["Pain point 1", "Pain point 2"],
+      "behaviors": ["Behavior 1", "Behavior 2"],
+      "motivations": ["Motivation 1", "Motivation 2"]
+    }
+  ],
+  "brandGenome": {
+    "archetype": "Brand archetype (Hero, Explorer, Creator, etc.)",
+    "values": ["Core value 1", "Core value 2", "Core value 3"],
+    "tone": "Brand tone description grounded in persona preferences",
+    "audience": "Primary audience description derived from personas",
+    "differentiators": ["Differentiator 1", "Differentiator 2"],
+    "customerAlignment": [
+      {
+        "trait": "Brand trait or value",
+        "personaName": "Persona this trait serves",
+        "personaInsight": "How this trait addresses the persona's needs/goals"
+      }
+    ]
+  },
+  "brandPersonality": {
+    "vision": "Company vision statement",
+    "mission": "Company mission statement",
+    "brandVoice": "Detailed brand voice guidelines"
+  },
+  "namingStrategy": "descriptive|abstract|acronym|founder|metaphorical",
+  "scoringCriteria": [
+    { "name": "Criterion name", "weight": 25 }
+  ],
+  "candidates": [
+    {
+      "name": "Brand name candidate",
+      "rationale": "Why this name fits the brand and resonates with personas",
+      "scores": { "Criterion name": 85 }
+    }
+  ],
+  "decision": {
+    "selectedName": "Top-scoring candidate name",
+    "workingTitle": true,
+    "rationale": "Why this name is recommended",
+    "availabilityChecks": { "domain": "pending", "trademark": "pending", "social": "pending" }
+  }
+}
+
+Rules:
+- Generate at least ${MIN_PERSONAS} customer personas with demographics, goals, painPoints
+- Personas must be derived from upstream research data (stages 1, 3, 5, 8)
+- Brand genome MUST include customerAlignment linking each brand trait to persona insights
+- Each customerAlignment entry must reference a specific persona by name
+- Generate at least ${MIN_CANDIDATES} naming candidates
+- Generate at least ${MIN_CRITERIA} scoring criteria, weights MUST sum to exactly 100
+- Each candidate MUST have a score (0-100) for every criterion
+- brandPersonality vision/mission must be specific to this venture
+- namingStrategy: choose approach that fits both brand and customer personas
+- decision.selectedName must match one of the candidate names`;
+
+/**
+ * Generate customer personas and brand foundation from upstream stage data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea (required)
+ * @param {Object} [params.stage3Data] - Stage 3 hybrid scoring
+ * @param {Object} [params.stage5Data] - Stage 5 financial model
+ * @param {Object} [params.stage8Data] - Stage 8 BMC
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Customer & brand foundation analysis
+ */
+export async function analyzeStage10({ stage1Data, stage3Data, stage5Data, stage8Data, ventureName, logger = console }) {
+  const startTime = Date.now();
+  logger.log('[Stage10] Starting customer & brand foundation analysis', { ventureName });
+  if (!stage1Data?.description) {
+    throw new Error('Stage 10 customer & brand requires Stage 1 data with description');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  const scoringContext = stage3Data?.overallScore
+    ? `Viability Score: ${stage3Data.overallScore}/100`
+    : '';
+
+  const financialContext = stage5Data
+    ? `Financial: Initial Investment $${stage5Data.initialInvestment || 'N/A'}, Year 1 Revenue $${stage5Data.year1?.revenue || 'N/A'}`
+    : '';
+
+  const bmcContext = stage8Data
+    ? `BMC Customer Segments: ${sanitizeForPrompt(JSON.stringify(stage8Data.customerSegments?.items || stage8Data.customerSegments || 'N/A').substring(0, 300))}
+BMC Value Proposition: ${stage8Data.valuePropositions?.items?.[0] || 'N/A'}`
+    : '';
+
+  const userPrompt = `Generate customer personas and brand foundation for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${sanitizeForPrompt(stage1Data.description)}
+Target Market: ${sanitizeForPrompt(stage1Data.targetMarket || 'N/A')}
+Problem: ${sanitizeForPrompt(stage1Data.problemStatement || 'N/A')}
+Value Proposition: ${sanitizeForPrompt(stage1Data.valueProp || 'N/A')}
+${scoringContext}
+${financialContext}
+${bmcContext}
+
+IMPORTANT: Generate customer personas FIRST based on the research data above, then derive the brand genome to serve those personas.
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  const usage = extractUsage(response);
+  const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
+
+  let llmFallbackCount = 0;
+
+  // --- Normalize customer personas ---
+  let customerPersonas = Array.isArray(parsed.customerPersonas) ? parsed.customerPersonas : [];
+  if (customerPersonas.length < MIN_PERSONAS) llmFallbackCount++;
+  while (customerPersonas.length < MIN_PERSONAS) {
+    customerPersonas.push({
+      name: `Persona ${customerPersonas.length + 1}`,
+      demographics: { role: 'General user', industry: 'Various' },
+      goals: ['Solve the core problem'],
+      painPoints: ['Current solutions are inadequate'],
+      behaviors: [],
+      motivations: [],
+    });
+  }
+  customerPersonas = customerPersonas.map((p, i) => ({
+    name: String(p.name || `Persona ${i + 1}`).substring(0, 200),
+    demographics: p.demographics && typeof p.demographics === 'object' ? p.demographics : { role: 'General user' },
+    goals: Array.isArray(p.goals) && p.goals.length > 0
+      ? p.goals.map(g => String(g).substring(0, 300))
+      : ['Solve the core problem'],
+    painPoints: Array.isArray(p.painPoints) && p.painPoints.length > 0
+      ? p.painPoints.map(pp => String(pp).substring(0, 300))
+      : ['Current solutions are inadequate'],
+    behaviors: Array.isArray(p.behaviors) ? p.behaviors.map(b => String(b).substring(0, 300)) : [],
+    motivations: Array.isArray(p.motivations) ? p.motivations.map(m => String(m).substring(0, 300)) : [],
+  }));
+
+  // --- Normalize brand genome with customerAlignment ---
+  if (!parsed.brandGenome || typeof parsed.brandGenome !== 'object') llmFallbackCount++;
+  const rawBg = parsed.brandGenome || {};
+  const brandGenome = {
+    archetype: String(rawBg.archetype || 'Creator').substring(0, 200),
+    values: Array.isArray(rawBg.values) && rawBg.values.length > 0
+      ? rawBg.values.map(v => String(v).substring(0, 200))
+      : ['Innovation'],
+    tone: String(rawBg.tone || 'Professional').substring(0, 200),
+    audience: String(rawBg.audience || stage1Data.targetMarket || 'General').substring(0, 200),
+    differentiators: Array.isArray(rawBg.differentiators) && rawBg.differentiators.length > 0
+      ? rawBg.differentiators.map(d => String(d).substring(0, 200))
+      : ['Unique approach'],
+    customerAlignment: [],
+  };
+
+  // Normalize customerAlignment — each brand trait linked to a persona
+  let rawAlignment = Array.isArray(rawBg.customerAlignment) ? rawBg.customerAlignment : [];
+  if (rawAlignment.length === 0) {
+    llmFallbackCount++;
+    // Auto-generate alignment from brand values and first persona
+    rawAlignment = brandGenome.values.map(v => ({
+      trait: v,
+      personaName: customerPersonas[0]?.name || 'Primary User',
+      personaInsight: `This value addresses the needs of ${customerPersonas[0]?.name || 'the primary user'}`,
+    }));
+  }
+  brandGenome.customerAlignment = rawAlignment.map(ca => ({
+    trait: String(ca.trait || 'Brand trait').substring(0, 200),
+    personaName: String(ca.personaName || customerPersonas[0]?.name || 'Primary User').substring(0, 200),
+    personaInsight: String(ca.personaInsight || 'Addresses persona needs').substring(0, 500),
+  }));
+
+  // --- Normalize scoring criteria ---
+  let scoringCriteria = Array.isArray(parsed.scoringCriteria)
+    ? parsed.scoringCriteria.filter(c => c?.name && typeof c?.weight === 'number')
+    : [];
+  if (scoringCriteria.length < MIN_CRITERIA) {
+    llmFallbackCount++;
+    scoringCriteria = [
+      { name: 'Memorability', weight: 25 },
+      { name: 'Relevance', weight: 25 },
+      { name: 'Persona Resonance', weight: 25 },
+      { name: 'Uniqueness', weight: 25 },
+    ];
+  }
+
+  // Ensure weights sum to 100
+  const weightSum = scoringCriteria.reduce((sum, c) => sum + c.weight, 0);
+  if (Math.abs(weightSum - 100) > 0.001) {
+    const factor = 100 / weightSum;
+    scoringCriteria = scoringCriteria.map(c => ({
+      name: String(c.name).substring(0, 200),
+      weight: Math.round(c.weight * factor * 100) / 100,
+    }));
+    const newSum = scoringCriteria.reduce((sum, c) => sum + c.weight, 0);
+    if (Math.abs(newSum - 100) > 0.001) {
+      scoringCriteria[0].weight += 100 - newSum;
+      scoringCriteria[0].weight = Math.round(scoringCriteria[0].weight * 100) / 100;
+    }
+  } else {
+    scoringCriteria = scoringCriteria.map(c => ({
+      name: String(c.name).substring(0, 200),
+      weight: c.weight,
+    }));
+  }
+
+  // --- Normalize candidates ---
+  if (!Array.isArray(parsed.candidates) || parsed.candidates.length === 0) {
+    throw new Error('Stage 10: LLM returned no naming candidates');
+  }
+  const candidates = parsed.candidates.map((c, i) => {
+    const scores = {};
+    for (const criterion of scoringCriteria) {
+      const raw = c.scores?.[criterion.name];
+      scores[criterion.name] = typeof raw === 'number' ? Math.min(100, Math.max(0, Math.round(raw))) : 50;
+    }
+    return {
+      name: String(c.name || `Candidate ${i + 1}`).substring(0, 200),
+      rationale: String(c.rationale || 'Generated candidate').substring(0, 500),
+      scores,
+    };
+  });
+
+  // --- Normalize brand personality ---
+  if (!parsed.brandPersonality) llmFallbackCount++;
+  const rawBp = parsed.brandPersonality || parsed.narrativeExtension || {};
+  const brandPersonality = {
+    vision: String(rawBp.vision || '').substring(0, 500) || null,
+    mission: String(rawBp.mission || '').substring(0, 500) || null,
+    brandVoice: String(rawBp.brandVoice || '').substring(0, 500) || null,
+  };
+
+  // --- Normalize naming strategy ---
+  if (!NAMING_STRATEGIES.includes(parsed.namingStrategy)) llmFallbackCount++;
+  const namingStrategy = NAMING_STRATEGIES.includes(parsed.namingStrategy)
+    ? parsed.namingStrategy
+    : 'descriptive';
+
+  // --- Normalize decision ---
+  const dec = parsed.decision || {};
+  const topCandidate = candidates.length > 0
+    ? [...candidates].sort((a, b) => {
+        const scoreA = scoringCriteria.reduce((sum, cr) => sum + (a.scores[cr.name] || 0) * cr.weight / 100, 0);
+        const scoreB = scoringCriteria.reduce((sum, cr) => sum + (b.scores[cr.name] || 0) * cr.weight / 100, 0);
+        return scoreB - scoreA;
+      })[0]
+    : null;
+  const selectedName = dec.selectedName && candidates.some(c => c.name === dec.selectedName)
+    ? dec.selectedName
+    : topCandidate?.name || '';
+  const ac = dec.availabilityChecks || {};
+  const decision = {
+    selectedName,
+    workingTitle: dec.workingTitle !== false,
+    rationale: String(dec.rationale || 'Top-scoring candidate based on weighted criteria').substring(0, 500),
+    availabilityChecks: {
+      domain: AVAILABILITY_STATUSES.includes(ac.domain) ? ac.domain : 'pending',
+      trademark: AVAILABILITY_STATUSES.includes(ac.trademark) ? ac.trademark : 'pending',
+      social: AVAILABILITY_STATUSES.includes(ac.social) ? ac.social : 'pending',
+    },
+  };
+
+  // --- Source provenance ---
+  const sourceProvenance = {
+    stage1: !!stage1Data,
+    stage3: !!stage3Data,
+    stage5: !!stage5Data,
+    stage8: !!stage8Data,
+    upstreamCount: [stage1Data, stage3Data, stage5Data, stage8Data].filter(Boolean).length,
+  };
+
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage10] LLM fallback fields detected', { llmFallbackCount });
+  }
+
+  logger.log('[Stage10] Analysis complete', { duration: Date.now() - startTime, personaCount: customerPersonas.length });
+  return {
+    customerPersonas,
+    brandGenome,
+    brandPersonality,
+    namingStrategy,
+    scoringCriteria,
+    candidates,
+    decision,
+    totalPersonas: customerPersonas.length,
+    totalCandidates: candidates.length,
+    totalCriteria: scoringCriteria.length,
+    personaCoverageScore: null, // computed by template.computeDerived
+    sourceProvenance,
+    fourBuckets, usage, llmFallbackCount,
+  };
+}
+
+export { MIN_PERSONAS, MIN_CANDIDATES, MIN_CRITERIA, NAMING_STRATEGIES };

--- a/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
@@ -1,0 +1,355 @@
+/**
+ * Stage 11 Analysis Step - Naming & Visual Identity
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-A
+ *
+ * Consumes Stage 10 customer personas and brand genome to evaluate
+ * naming candidates against personas and produce visual identity guidelines.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-11-visual-identity
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+import { runTournament } from '../../crews/tournament-orchestrator.js';
+import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+
+// Duplicated from stage-11.js to avoid circular dependency
+const MIN_CANDIDATES = 5;
+const MIN_CRITERIA = 3;
+const NAMING_STRATEGIES = ['descriptive', 'abstract', 'acronym', 'founder', 'metaphorical'];
+const AVAILABILITY_STATUSES = ['pending', 'available', 'taken', 'unknown'];
+
+const SYSTEM_PROMPT = `You are EVA's Naming & Visual Identity Engine. Evaluate naming candidates against customer personas and produce visual identity guidelines.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "namingStrategy": {
+    "approach": "descriptive|abstract|acronym|founder|metaphorical",
+    "rationale": "Why this naming approach fits the brand and personas"
+  },
+  "scoringCriteria": [
+    { "name": "Criterion name", "weight": 25 }
+  ],
+  "candidates": [
+    {
+      "name": "Brand name candidate",
+      "rationale": "Why this name fits brand and resonates with personas",
+      "scores": { "Criterion name": 85 },
+      "personaFit": [
+        {
+          "personaName": "Persona name from Stage 10",
+          "fitScore": 85,
+          "reasoning": "How this name resonates with this persona"
+        }
+      ]
+    }
+  ],
+  "visualIdentity": {
+    "colorPalette": [
+      {
+        "name": "Primary",
+        "hex": "#2563EB",
+        "usage": "Primary brand color, CTAs, key UI elements",
+        "personaAlignment": "Appeals to professional/tech audience"
+      }
+    ],
+    "typography": {
+      "heading": "Font family for headings",
+      "body": "Font family for body text",
+      "rationale": "Why these fonts fit the brand personality"
+    },
+    "imageryGuidance": "Guidelines for visual imagery style, photography direction, illustration style"
+  },
+  "brandExpression": {
+    "tagline": "Brand tagline",
+    "elevator_pitch": "30-second elevator pitch",
+    "messaging_pillars": ["Pillar 1", "Pillar 2", "Pillar 3"]
+  },
+  "decision": {
+    "selectedName": "Top-scoring candidate name",
+    "workingTitle": true,
+    "rationale": "Why this name is recommended",
+    "availabilityChecks": { "domain": "pending", "trademark": "pending", "social": "pending" }
+  }
+}
+
+Rules:
+- Generate at least ${MIN_CANDIDATES} naming candidates
+- Each candidate MUST have personaFit scores referencing Stage 10 personas by name
+- Generate at least ${MIN_CRITERIA} scoring criteria, weights MUST sum to exactly 100
+- Include "Persona Resonance" as one scoring criterion
+- Visual identity must include colorPalette (>=3 colors), typography, and imageryGuidance
+- Color palette entries must include hex value, usage description, and persona alignment
+- Typography must include heading and body font recommendations
+- Brand expression includes tagline, elevator pitch, and messaging pillars
+- Names should be evaluated against both brand genome AND customer personas
+- Tournament-mode scoring preserved for naming candidates`;
+
+/**
+ * Generate naming evaluation and visual identity from Stage 10 data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea (required)
+ * @param {Object} [params.stage5Data] - Stage 5 financial model
+ * @param {Object} params.stage10Data - Stage 10 customer & brand (required)
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} Naming & visual identity analysis
+ */
+export async function analyzeStage11({ stage1Data, stage5Data, stage10Data, ventureName, logger = console }) {
+  const startTime = Date.now();
+  logger.log('[Stage11] Starting naming & visual identity analysis', { ventureName });
+
+  if (!stage1Data?.description) {
+    throw new Error('Stage 11 requires Stage 1 data with description');
+  }
+  if (!stage10Data?.customerPersonas || !stage10Data?.brandGenome) {
+    throw new Error('Stage 11 requires Stage 10 data with customerPersonas and brandGenome');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  // Build persona context from Stage 10
+  const personaContext = stage10Data.customerPersonas
+    .map(p => `- ${p.name}: Goals: ${(p.goals || []).join(', ')}. Pain points: ${(p.painPoints || []).join(', ')}`)
+    .join('\n');
+
+  const brandContext = `Brand Archetype: ${stage10Data.brandGenome.archetype}
+Brand Values: ${(stage10Data.brandGenome.values || []).join(', ')}
+Brand Tone: ${stage10Data.brandGenome.tone}
+Target Audience: ${stage10Data.brandGenome.audience}
+Differentiators: ${(stage10Data.brandGenome.differentiators || []).join(', ')}`;
+
+  const financialContext = stage5Data
+    ? `Financial: Initial Investment $${stage5Data.initialInvestment || 'N/A'}`
+    : '';
+
+  // Include Stage 10 naming candidates if available for refinement
+  const existingCandidates = stage10Data.candidates
+    ? `\nExisting naming candidates from Stage 10 (refine or replace):\n${stage10Data.candidates.map(c => `- ${c.name}: ${c.rationale}`).join('\n')}`
+    : '';
+
+  const userPrompt = `Evaluate naming candidates against customer personas and create visual identity for this venture.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${sanitizeForPrompt(stage1Data.description)}
+Target Market: ${sanitizeForPrompt(stage1Data.targetMarket || 'N/A')}
+
+Customer Personas (from Stage 10):
+${personaContext}
+
+${brandContext}
+${financialContext}
+${existingCandidates}
+
+IMPORTANT: Each naming candidate MUST include personaFit scores for each Stage 10 persona.
+
+Output ONLY valid JSON.`;
+
+  // Tournament mode support
+  const tournamentEnabled = process.env.CREW_TOURNAMENT_ENABLED === 'true';
+  let parsed, fourBuckets, tournamentMeta = null, usage = null;
+
+  if (tournamentEnabled) {
+    logger.log('[Stage11] Tournament mode enabled');
+    const { result, tournament } = await runTournament({
+      systemPrompt: SYSTEM_PROMPT,
+      userPrompt,
+      context: { description: stage1Data.description, targetMarket: stage1Data.targetMarket },
+      options: { logger },
+    });
+    tournamentMeta = tournament;
+
+    if (result) {
+      parsed = result;
+      fourBuckets = result.fourBuckets || parseFourBuckets(result, { logger });
+    } else {
+      logger.log('[Stage11] Tournament fallback — using single generation');
+      const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+      usage = extractUsage(response);
+      parsed = parseJSON(response);
+      fourBuckets = parseFourBuckets(parsed, { logger });
+    }
+  } else {
+    const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+    usage = extractUsage(response);
+    parsed = parseJSON(response);
+    fourBuckets = parseFourBuckets(parsed, { logger });
+  }
+
+  let llmFallbackCount = 0;
+  const personaNames = stage10Data.customerPersonas.map(p => p.name);
+
+  // --- Normalize naming strategy ---
+  const rawNs = parsed.namingStrategy || {};
+  const namingStrategy = {
+    approach: NAMING_STRATEGIES.includes(rawNs.approach) ? rawNs.approach : 'descriptive',
+    rationale: String(rawNs.rationale || 'Selected based on brand and persona analysis').substring(0, 500),
+  };
+
+  // --- Normalize scoring criteria ---
+  let scoringCriteria = Array.isArray(parsed.scoringCriteria)
+    ? parsed.scoringCriteria.filter(c => c?.name && typeof c?.weight === 'number')
+    : [];
+  if (scoringCriteria.length < MIN_CRITERIA) {
+    llmFallbackCount++;
+    scoringCriteria = [
+      { name: 'Memorability', weight: 25 },
+      { name: 'Relevance', weight: 25 },
+      { name: 'Persona Resonance', weight: 25 },
+      { name: 'Uniqueness', weight: 25 },
+    ];
+  }
+  // Ensure "Persona Resonance" is a criterion
+  if (!scoringCriteria.some(c => c.name.toLowerCase().includes('persona'))) {
+    scoringCriteria.push({ name: 'Persona Resonance', weight: 0 });
+  }
+
+  // Normalize weights to sum to 100
+  const weightSum = scoringCriteria.reduce((sum, c) => sum + c.weight, 0);
+  if (Math.abs(weightSum - 100) > 0.001) {
+    const factor = 100 / weightSum;
+    scoringCriteria = scoringCriteria.map(c => ({
+      name: String(c.name).substring(0, 200),
+      weight: Math.round(c.weight * factor * 100) / 100,
+    }));
+    const newSum = scoringCriteria.reduce((sum, c) => sum + c.weight, 0);
+    if (Math.abs(newSum - 100) > 0.001) {
+      scoringCriteria[0].weight += 100 - newSum;
+      scoringCriteria[0].weight = Math.round(scoringCriteria[0].weight * 100) / 100;
+    }
+  } else {
+    scoringCriteria = scoringCriteria.map(c => ({
+      name: String(c.name).substring(0, 200),
+      weight: c.weight,
+    }));
+  }
+
+  // --- Normalize candidates with personaFit ---
+  if (!Array.isArray(parsed.candidates) || parsed.candidates.length === 0) {
+    throw new Error('Stage 11: LLM returned no naming candidates');
+  }
+
+  const candidates = parsed.candidates.map((c, i) => {
+    const scores = {};
+    for (const criterion of scoringCriteria) {
+      const raw = c.scores?.[criterion.name];
+      scores[criterion.name] = typeof raw === 'number' ? Math.min(100, Math.max(0, Math.round(raw))) : 50;
+    }
+
+    // Normalize personaFit — ensure each Stage 10 persona is referenced
+    let personaFit = Array.isArray(c.personaFit) ? c.personaFit : [];
+    if (personaFit.length === 0) llmFallbackCount++;
+
+    // Ensure all personas from Stage 10 are represented
+    for (const pName of personaNames) {
+      if (!personaFit.some(pf => pf.personaName === pName)) {
+        personaFit.push({
+          personaName: pName,
+          fitScore: 50,
+          reasoning: 'Default fit assessment',
+        });
+      }
+    }
+
+    personaFit = personaFit.map(pf => ({
+      personaName: String(pf.personaName || 'Unknown').substring(0, 200),
+      fitScore: typeof pf.fitScore === 'number' ? Math.min(100, Math.max(0, Math.round(pf.fitScore))) : 50,
+      reasoning: String(pf.reasoning || 'No reasoning provided').substring(0, 500),
+    }));
+
+    return {
+      name: String(c.name || `Candidate ${i + 1}`).substring(0, 200),
+      rationale: String(c.rationale || 'Generated candidate').substring(0, 500),
+      scores,
+      personaFit,
+    };
+  });
+
+  // --- Normalize visual identity ---
+  if (!parsed.visualIdentity || typeof parsed.visualIdentity !== 'object') llmFallbackCount++;
+  const rawVi = parsed.visualIdentity || {};
+
+  let colorPalette = Array.isArray(rawVi.colorPalette) ? rawVi.colorPalette : [];
+  if (colorPalette.length === 0) {
+    llmFallbackCount++;
+    colorPalette = [
+      { name: 'Primary', hex: '#2563EB', usage: 'Primary brand color', personaAlignment: 'Professional appeal' },
+      { name: 'Secondary', hex: '#10B981', usage: 'Accent and success states', personaAlignment: 'Trust and growth' },
+      { name: 'Neutral', hex: '#6B7280', usage: 'Text and backgrounds', personaAlignment: 'Clean, readable' },
+    ];
+  }
+  colorPalette = colorPalette.map(c => ({
+    name: String(c.name || 'Color').substring(0, 100),
+    hex: String(c.hex || '#000000').substring(0, 7),
+    usage: String(c.usage || '').substring(0, 300),
+    personaAlignment: String(c.personaAlignment || '').substring(0, 300),
+  }));
+
+  const typography = rawVi.typography && typeof rawVi.typography === 'object'
+    ? {
+        heading: String(rawVi.typography.heading || 'Inter').substring(0, 100),
+        body: String(rawVi.typography.body || 'Inter').substring(0, 100),
+        rationale: String(rawVi.typography.rationale || '').substring(0, 300),
+      }
+    : { heading: 'Inter', body: 'Inter', rationale: 'Clean, modern sans-serif' };
+
+  const imageryGuidance = String(rawVi.imageryGuidance || 'Professional, modern imagery aligned with brand values').substring(0, 1000);
+
+  const visualIdentity = { colorPalette, typography, imageryGuidance };
+
+  // --- Normalize brand expression ---
+  const rawBe = parsed.brandExpression || {};
+  const brandExpression = {
+    tagline: String(rawBe.tagline || '').substring(0, 200) || null,
+    elevator_pitch: String(rawBe.elevator_pitch || '').substring(0, 500) || null,
+    messaging_pillars: Array.isArray(rawBe.messaging_pillars)
+      ? rawBe.messaging_pillars.map(p => String(p).substring(0, 200))
+      : [],
+  };
+
+  // --- Normalize decision ---
+  const dec = parsed.decision || {};
+  const topCandidate = candidates.length > 0
+    ? [...candidates].sort((a, b) => {
+        const scoreA = scoringCriteria.reduce((sum, cr) => sum + (a.scores[cr.name] || 0) * cr.weight / 100, 0);
+        const scoreB = scoringCriteria.reduce((sum, cr) => sum + (b.scores[cr.name] || 0) * cr.weight / 100, 0);
+        return scoreB - scoreA;
+      })[0]
+    : null;
+  const selectedName = dec.selectedName && candidates.some(c => c.name === dec.selectedName)
+    ? dec.selectedName
+    : topCandidate?.name || '';
+  const ac = dec.availabilityChecks || {};
+  const decision = {
+    selectedName,
+    workingTitle: dec.workingTitle !== false,
+    rationale: String(dec.rationale || 'Top-scoring candidate based on weighted criteria and persona fit').substring(0, 500),
+    availabilityChecks: {
+      domain: AVAILABILITY_STATUSES.includes(ac.domain) ? ac.domain : 'pending',
+      trademark: AVAILABILITY_STATUSES.includes(ac.trademark) ? ac.trademark : 'pending',
+      social: AVAILABILITY_STATUSES.includes(ac.social) ? ac.social : 'pending',
+    },
+  };
+
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage11] LLM fallback fields detected', { llmFallbackCount });
+  }
+
+  logger.log('[Stage11] Analysis complete', { duration: Date.now() - startTime, candidateCount: candidates.length });
+  return {
+    namingStrategy,
+    scoringCriteria,
+    candidates,
+    visualIdentity,
+    brandExpression,
+    decision,
+    totalCandidates: candidates.length,
+    totalCriteria: scoringCriteria.length,
+    fourBuckets, usage, llmFallbackCount,
+    ...(tournamentMeta ? { tournament: tournamentMeta } : {}),
+  };
+}
+
+export { MIN_CANDIDATES, MIN_CRITERIA, NAMING_STRATEGIES };

--- a/lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales.js
@@ -1,0 +1,384 @@
+/**
+ * Stage 12 Analysis Step - GTM & Sales Strategy
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-A
+ *
+ * Combined go-to-market and sales strategy generation.
+ * Consumes Stage 10 personas/brand and Stage 11 naming/visual identity
+ * to produce market tiers, channels, sales model, funnel, and journey.
+ *
+ * @module lib/eva/stage-templates/analysis-steps/stage-12-gtm-sales
+ */
+
+import { getLLMClient } from '../../../llm/index.js';
+import { parseJSON, extractUsage } from '../../utils/parse-json.js';
+import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
+import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+import { isSearchEnabled, searchBatch, formatResultsForPrompt } from '../../utils/web-search.js';
+// evaluateRealityGate is a hoisted function declaration, safe for circular dependency import.
+// stage-12.js imports analyzeStage12 from this file; this file imports evaluateRealityGate back.
+import { evaluateRealityGate } from '../stage-12.js';
+import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+
+// Duplicated from stage-12.js to avoid circular dependency at module-level evaluation.
+const SALES_MODELS = ['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel'];
+const CHANNEL_TYPES = ['paid', 'organic', 'earned', 'owned'];
+const REQUIRED_TIERS = 3;
+const REQUIRED_CHANNELS = 8;
+const MIN_DEAL_STAGES = 3;
+const MIN_FUNNEL_STAGES = 4;
+const MIN_JOURNEY_STEPS = 5;
+
+const SYSTEM_PROMPT = `You are EVA's GTM & Sales Strategy Engine. Generate a complete go-to-market and sales strategy for a venture, grounded in its customer personas and brand identity.
+
+You MUST output valid JSON with exactly this structure:
+{
+  "marketTiers": [
+    {
+      "name": "Tier name",
+      "description": "Market tier description",
+      "persona": "Primary persona this tier targets (from Stage 10)",
+      "painPoints": ["Pain point 1", "Pain point 2"],
+      "tam": 1000000,
+      "sam": 500000,
+      "som": 50000
+    }
+  ],
+  "channels": [
+    {
+      "name": "Channel name",
+      "channelType": "paid|organic|earned|owned",
+      "primaryTier": "Tier name this channel targets",
+      "monthly_budget": 5000,
+      "expected_cac": 50,
+      "primary_kpi": "Key performance indicator"
+    }
+  ],
+  "salesModel": "self-serve|inside-sales|enterprise|hybrid|marketplace|channel",
+  "sales_cycle_days": 30,
+  "deal_stages": [
+    {
+      "name": "Stage name",
+      "description": "Stage description",
+      "avg_duration_days": 7,
+      "mappedFunnelStage": "Matching funnel stage name"
+    }
+  ],
+  "funnel_stages": [
+    {
+      "name": "Funnel stage name",
+      "metric": "Conversion metric name",
+      "target_value": 10000,
+      "conversionRateEstimate": 0.25
+    }
+  ],
+  "customer_journey": [
+    {
+      "step": "Journey step description",
+      "funnel_stage": "Matching funnel stage",
+      "touchpoint": "Channel or interaction point"
+    }
+  ]
+}
+
+Rules:
+- Generate EXACTLY ${REQUIRED_TIERS} market tiers (Tier 1 = most accessible, Tier 3 = aspirational)
+- Generate EXACTLY ${REQUIRED_CHANNELS} acquisition channels
+- Each tier needs name, description, persona (reference Stage 10 personas by name), painPoints, TAM/SAM/SOM
+- Each channel needs name, channelType (paid|organic|earned|owned), primaryTier, monthly_budget (>= 0), expected_cac (>= 0), primary_kpi
+- salesModel must be one of: self-serve, inside-sales, enterprise, hybrid, marketplace, channel
+- sales_cycle_days must be >= 1
+- Generate at least ${MIN_DEAL_STAGES} deal stages with mappedFunnelStage references
+- Generate at least ${MIN_FUNNEL_STAGES} funnel stages with metrics, target values, and conversionRateEstimate (0-1)
+- Generate at least ${MIN_JOURNEY_STEPS} customer journey steps mapped to funnel stages
+- Use upstream persona data and brand identity to inform tier definitions
+- Align channels to tiers — each channel should target a specific tier
+- Sales model should match the venture's pricing and target audience`;
+
+/**
+ * Generate combined GTM & sales strategy from upstream stage data.
+ *
+ * @param {Object} params
+ * @param {Object} params.stage1Data - Stage 1 Draft Idea (required)
+ * @param {Object} [params.stage5Data] - Stage 5 financial model
+ * @param {Object} [params.stage7Data] - Stage 7 pricing strategy
+ * @param {Object} params.stage10Data - Stage 10 customer & brand (required)
+ * @param {Object} [params.stage11Data] - Stage 11 naming & visual identity
+ * @param {string} [params.ventureName]
+ * @returns {Promise<Object>} GTM & sales strategy
+ */
+export async function analyzeStage12({ stage1Data, stage5Data, stage7Data, stage10Data, stage11Data, ventureName, logger = console }) {
+  const startTime = Date.now();
+  logger.log('[Stage12] Starting GTM & sales strategy analysis', { ventureName });
+
+  if (!stage1Data?.description) {
+    throw new Error('Stage 12 requires Stage 1 data with description');
+  }
+  if (!stage10Data?.customerPersonas) {
+    throw new Error('Stage 12 requires Stage 10 data with customerPersonas');
+  }
+
+  const client = getLLMClient({ purpose: 'content-generation' });
+
+  // Build persona context from Stage 10
+  const personaContext = stage10Data.customerPersonas
+    .map(p => `- ${p.name}: Goals: ${(p.goals || []).join(', ')}. Pain points: ${(p.painPoints || []).join(', ')}`)
+    .join('\n');
+
+  const brandContext = stage10Data.brandGenome
+    ? `Brand: ${stage10Data.brandGenome.archetype} archetype, targeting ${stage10Data.brandGenome.audience}\nDifferentiators: ${(stage10Data.brandGenome.differentiators || []).join(', ')}`
+    : '';
+
+  const namingContext = stage11Data?.decision?.selectedName
+    ? `Selected Name: ${stage11Data.decision.selectedName}`
+    : '';
+
+  const financialContext = stage5Data
+    ? `Financial: Initial Investment $${stage5Data.initialInvestment || 'N/A'}, Year 1 Revenue $${stage5Data.year1?.revenue || 'N/A'}`
+    : '';
+
+  const pricingContext = stage7Data
+    ? `Pricing: ${stage7Data.pricing_model || 'N/A'}, ARPA $${stage7Data.arpa || 'N/A'}`
+    : '';
+
+  // Web-grounded search for GTM intelligence
+  let webContext = '';
+  if (isSearchEnabled()) {
+    const queries = [
+      `${sanitizeForPrompt(stage1Data.targetMarket || ventureName)} go to market strategy channels ${new Date().getFullYear()}`,
+      `${sanitizeForPrompt(stage1Data.targetMarket || 'SaaS')} customer acquisition channels CAC benchmarks`,
+      `${sanitizeForPrompt(stage1Data.description?.substring(0, 80))} sales model strategy`,
+    ];
+    logger.log('[Stage12] Running web search', { queryCount: queries.length });
+    const webResults = await searchBatch(queries, { logger });
+    webContext = formatResultsForPrompt(webResults, 'GTM & Sales Intelligence Research');
+  }
+
+  const userPrompt = `Generate a GTM & sales strategy for this venture, grounded in the customer personas.
+
+Venture: ${ventureName || 'Unnamed'}
+Description: ${sanitizeForPrompt(stage1Data.description)}
+Target Market: ${sanitizeForPrompt(stage1Data.targetMarket || 'N/A')}
+Problem: ${sanitizeForPrompt(stage1Data.problemStatement || 'N/A')}
+
+Customer Personas (from Stage 10):
+${personaContext}
+
+${brandContext}
+${namingContext}
+${financialContext}
+${pricingContext}
+${webContext}
+
+IMPORTANT: Market tiers MUST reference Stage 10 personas by name. Channels should target specific tiers.
+
+Output ONLY valid JSON.`;
+
+  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  const usage = extractUsage(response);
+  const parsed = parseJSON(response);
+  const fourBuckets = parseFourBuckets(parsed, { logger });
+
+  let llmFallbackCount = 0;
+
+  // --- Normalize market tiers (exactly 3) ---
+  let marketTiers = Array.isArray(parsed.marketTiers) ? parsed.marketTiers : [];
+  if (marketTiers.length < REQUIRED_TIERS) llmFallbackCount++;
+  while (marketTiers.length < REQUIRED_TIERS) {
+    marketTiers.push({
+      name: `Tier ${marketTiers.length + 1}`,
+      description: 'TBD',
+      tam: 0, sam: 0, som: 0,
+    });
+  }
+  marketTiers = marketTiers.slice(0, REQUIRED_TIERS).map((t, i) => ({
+    name: String(t.name || `Tier ${i + 1}`).substring(0, 200),
+    description: String(t.description || 'TBD').substring(0, 500),
+    persona: String(t.persona || '').substring(0, 500) || null,
+    painPoints: Array.isArray(t.painPoints) && t.painPoints.length > 0
+      ? t.painPoints.map(p => String(p).substring(0, 300))
+      : [],
+    tam: typeof t.tam === 'number' && t.tam >= 0 ? t.tam : 0,
+    sam: typeof t.sam === 'number' && t.sam >= 0 ? t.sam : 0,
+    som: typeof t.som === 'number' && t.som >= 0 ? t.som : 0,
+  }));
+  const tierNames = marketTiers.map(t => t.name);
+
+  // --- Normalize channels (exactly 8) ---
+  let channels = Array.isArray(parsed.channels) ? parsed.channels : [];
+  if (channels.length < REQUIRED_CHANNELS) llmFallbackCount++;
+  const defaultChannelNames = [
+    'Organic Search', 'Paid Search', 'Social Media', 'Content Marketing',
+    'Email Marketing', 'Partnerships', 'Events', 'Direct Sales',
+  ];
+  while (channels.length < REQUIRED_CHANNELS) {
+    channels.push({
+      name: defaultChannelNames[channels.length] || `Channel ${channels.length + 1}`,
+      monthly_budget: 0,
+      expected_cac: 0,
+      primary_kpi: 'TBD',
+    });
+  }
+  channels = channels.slice(0, REQUIRED_CHANNELS).map((ch, i) => {
+    const primaryTier = tierNames.includes(ch.primaryTier)
+      ? ch.primaryTier
+      : tierNames[0] || 'Tier 1';
+    return {
+      name: String(ch.name || defaultChannelNames[i] || `Channel ${i + 1}`).substring(0, 200),
+      channelType: CHANNEL_TYPES.includes(ch.channelType) ? ch.channelType : 'organic',
+      primaryTier,
+      monthly_budget: typeof ch.monthly_budget === 'number' && ch.monthly_budget >= 0 ? ch.monthly_budget : 0,
+      expected_cac: typeof ch.expected_cac === 'number' && ch.expected_cac >= 0 ? ch.expected_cac : 0,
+      primary_kpi: String(ch.primary_kpi || 'TBD').substring(0, 200),
+    };
+  });
+
+  // --- Normalize sales model ---
+  if (!SALES_MODELS.includes(parsed.salesModel)) llmFallbackCount++;
+  const salesModel = SALES_MODELS.includes(parsed.salesModel)
+    ? parsed.salesModel
+    : 'hybrid';
+
+  // --- Normalize sales cycle days ---
+  if (typeof parsed.sales_cycle_days !== 'number' || parsed.sales_cycle_days < 1) llmFallbackCount++;
+  const sales_cycle_days = typeof parsed.sales_cycle_days === 'number' && parsed.sales_cycle_days >= 1
+    ? Math.round(parsed.sales_cycle_days)
+    : 30;
+
+  // --- Normalize deal stages (min 3) ---
+  let deal_stages = Array.isArray(parsed.deal_stages) ? parsed.deal_stages : [];
+  if (deal_stages.length < MIN_DEAL_STAGES) {
+    llmFallbackCount++;
+    const defaults = [
+      { name: 'Qualification', description: 'Initial lead qualification', avg_duration_days: 3 },
+      { name: 'Discovery', description: 'Needs assessment and demo', avg_duration_days: 7 },
+      { name: 'Proposal', description: 'Solution proposal and pricing', avg_duration_days: 5 },
+      { name: 'Negotiation', description: 'Terms negotiation and close', avg_duration_days: 7 },
+    ];
+    while (deal_stages.length < MIN_DEAL_STAGES) {
+      deal_stages.push(defaults[deal_stages.length] || { name: `Stage ${deal_stages.length + 1}`, description: 'TBD', avg_duration_days: 5 });
+    }
+  }
+  deal_stages = deal_stages.map((ds, i) => ({
+    name: String(ds.name || `Stage ${i + 1}`).substring(0, 200),
+    description: String(ds.description || 'TBD').substring(0, 500),
+    avg_duration_days: typeof ds.avg_duration_days === 'number' && ds.avg_duration_days >= 0 ? ds.avg_duration_days : 5,
+    mappedFunnelStage: String(ds.mappedFunnelStage || '').substring(0, 200) || null,
+  }));
+
+  // --- Normalize funnel stages (min 4) ---
+  let funnel_stages = Array.isArray(parsed.funnel_stages) ? parsed.funnel_stages : [];
+  if (funnel_stages.length < MIN_FUNNEL_STAGES) {
+    llmFallbackCount++;
+    const defaults = [
+      { name: 'Awareness', metric: 'Website visitors', target_value: 10000 },
+      { name: 'Interest', metric: 'Signup rate', target_value: 500 },
+      { name: 'Consideration', metric: 'Trial starts', target_value: 100 },
+      { name: 'Purchase', metric: 'Paid conversions', target_value: 20 },
+    ];
+    while (funnel_stages.length < MIN_FUNNEL_STAGES) {
+      funnel_stages.push(defaults[funnel_stages.length] || { name: `Stage ${funnel_stages.length + 1}`, metric: 'TBD', target_value: 0 });
+    }
+  }
+  funnel_stages = funnel_stages.map((fs, i) => ({
+    name: String(fs.name || `Stage ${i + 1}`).substring(0, 200),
+    metric: String(fs.metric || 'TBD').substring(0, 200),
+    target_value: typeof fs.target_value === 'number' && fs.target_value >= 0 ? fs.target_value : 0,
+    conversionRateEstimate: typeof fs.conversionRateEstimate === 'number' && fs.conversionRateEstimate >= 0 && fs.conversionRateEstimate <= 1
+      ? Math.round(fs.conversionRateEstimate * 10000) / 10000
+      : null,
+  }));
+
+  // --- Normalize customer journey (min 5) ---
+  let customer_journey = Array.isArray(parsed.customer_journey) ? parsed.customer_journey : [];
+  if (customer_journey.length < MIN_JOURNEY_STEPS) {
+    llmFallbackCount++;
+    const defaults = [
+      { step: 'Discovers product via search/social', funnel_stage: 'Awareness', touchpoint: 'Website' },
+      { step: 'Reads content and explores features', funnel_stage: 'Interest', touchpoint: 'Blog/Landing page' },
+      { step: 'Signs up for free trial', funnel_stage: 'Consideration', touchpoint: 'Sign-up form' },
+      { step: 'Engages with product features', funnel_stage: 'Consideration', touchpoint: 'Product' },
+      { step: 'Converts to paid plan', funnel_stage: 'Purchase', touchpoint: 'Checkout' },
+    ];
+    while (customer_journey.length < MIN_JOURNEY_STEPS) {
+      customer_journey.push(defaults[customer_journey.length] || { step: `Step ${customer_journey.length + 1}`, funnel_stage: 'TBD', touchpoint: 'TBD' });
+    }
+  }
+  customer_journey = customer_journey.map(cj => ({
+    step: String(cj.step || 'TBD').substring(0, 300),
+    funnel_stage: String(cj.funnel_stage || 'TBD').substring(0, 200),
+    touchpoint: String(cj.touchpoint || 'TBD').substring(0, 200),
+  }));
+
+  // --- Back-link deal stages to valid funnel stage names ---
+  const funnelNames = funnel_stages.map(fs => fs.name);
+  deal_stages = deal_stages.map(ds => ({
+    ...ds,
+    mappedFunnelStage: ds.mappedFunnelStage && funnelNames.includes(ds.mappedFunnelStage)
+      ? ds.mappedFunnelStage
+      : funnelNames[0] || null,
+  }));
+
+  // --- Compute derived metrics ---
+  const total_monthly_budget = channels.reduce((sum, ch) => sum + ch.monthly_budget, 0);
+  const cacValues = channels.filter(ch => ch.expected_cac > 0);
+  const avg_cac = cacValues.length > 0
+    ? Math.round(cacValues.reduce((sum, ch) => sum + ch.expected_cac, 0) / cacValues.length * 100) / 100
+    : 0;
+
+  // Economy check: pipeline metrics for Reality Gate
+  const totalPipelineValue = funnel_stages.reduce((sum, fs) => sum + fs.target_value, 0);
+  const avgConversionRate = (() => {
+    const rates = funnel_stages.filter(fs => fs.conversionRateEstimate !== null);
+    return rates.length > 0
+      ? Math.round(rates.reduce((sum, fs) => sum + fs.conversionRateEstimate, 0) / rates.length * 10000) / 10000
+      : null;
+  })();
+
+  const economyCheck = {
+    totalPipelineValue,
+    avgConversionRate,
+    pricingAvailable: !!stage7Data,
+  };
+
+  // --- Evaluate Phase 3→4 Reality Gate (local gate) ---
+  const reality_gate = evaluateRealityGate({
+    stage10: stage10Data,
+    stage11: stage11Data,
+    stage12: {
+      marketTiers,
+      channels,
+      deal_stages,
+      funnel_stages,
+      customer_journey,
+      economyCheck,
+    },
+  });
+
+  if (llmFallbackCount > 0) {
+    logger.warn('[Stage12] LLM fallback fields detected', { llmFallbackCount });
+  }
+
+  logger.log('[Stage12] Analysis complete', {
+    duration: Date.now() - startTime,
+    tierCount: marketTiers.length,
+    channelCount: channels.length,
+    realityGatePass: reality_gate.pass,
+  });
+
+  return {
+    marketTiers,
+    channels,
+    salesModel,
+    sales_cycle_days,
+    deal_stages,
+    funnel_stages,
+    customer_journey,
+    economyCheck,
+    reality_gate,
+    total_monthly_budget,
+    avg_cac,
+    fourBuckets, usage, llmFallbackCount,
+  };
+}
+
+export { SALES_MODELS, CHANNEL_TYPES, REQUIRED_TIERS, REQUIRED_CHANNELS, MIN_DEAL_STAGES, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS };

--- a/lib/eva/stage-templates/stage-10.js
+++ b/lib/eva/stage-templates/stage-10.js
@@ -1,30 +1,45 @@
 /**
- * Stage 10 Template - Naming / Brand
+ * Stage 10 Template - Customer & Brand Foundation
  * Phase: THE IDENTITY (Stages 10-12)
- * Part of SD-LEO-FEAT-TMPL-IDENTITY-001
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-A
  *
- * Brand genome inputs and naming candidates with weighted scoring.
- * Weights must sum to exactly 100. Minimum 5 candidates required.
+ * Customer personas FIRST, then brand genome grounded in persona insights.
+ * Minimum 3 personas required. Brand genome includes customerAlignment.
+ * Chairman governance gate preserved as blocking gate.
  *
  * @module lib/eva/stage-templates/stage-10
  */
 
-import { validateString, validateNumber, validateArray, validateInteger, validateEnum, collectErrors } from './validation.js';
+import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage10 } from './analysis-steps/stage-10-naming-brand.js';
+import { analyzeStage10 } from './analysis-steps/stage-10-customer-brand.js';
 import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
+const MIN_PERSONAS = 3;
 const MIN_CANDIDATES = 5;
 const WEIGHT_SUM = 100;
 const BRAND_GENOME_KEYS = ['archetype', 'values', 'tone', 'audience', 'differentiators'];
 const NAMING_STRATEGIES = ['descriptive', 'abstract', 'acronym', 'founder', 'metaphorical'];
+const ARCHETYPES = ['Hero', 'Explorer', 'Creator', 'Sage', 'Innocent', 'Outlaw', 'Magician', 'Ruler', 'Caregiver', 'Everyman', 'Jester', 'Lover'];
 
 const TEMPLATE = {
   id: 'stage-10',
-  slug: 'naming-brand',
-  title: 'Naming/Brand',
-  version: '2.0.0',
+  slug: 'customer-brand-foundation',
+  title: 'Customer & Brand Foundation',
+  version: '3.0.0',
   schema: {
+    customerPersonas: {
+      type: 'array',
+      minItems: MIN_PERSONAS,
+      items: {
+        name: { type: 'string', required: true },
+        demographics: { type: 'object', required: true },
+        goals: { type: 'array', minItems: 1 },
+        painPoints: { type: 'array', minItems: 1 },
+        behaviors: { type: 'array' },
+        motivations: { type: 'array' },
+      },
+    },
     brandGenome: {
       type: 'object',
       required: true,
@@ -34,6 +49,15 @@ const TEMPLATE = {
         tone: { type: 'string', required: true },
         audience: { type: 'string', required: true },
         differentiators: { type: 'array', minItems: 1 },
+        customerAlignment: { type: 'array', minItems: 1 },
+      },
+    },
+    brandPersonality: {
+      type: 'object',
+      fields: {
+        vision: { type: 'string' },
+        mission: { type: 'string' },
+        brandVoice: { type: 'string' },
       },
     },
     scoringCriteria: {
@@ -51,19 +75,9 @@ const TEMPLATE = {
         name: { type: 'string', required: true },
         rationale: { type: 'string', required: true },
         scores: { type: 'object', required: true },
-        weighted_score: { type: 'number', derived: true },
-      },
-    },
-    narrativeExtension: {
-      type: 'object',
-      fields: {
-        vision: { type: 'string' },
-        mission: { type: 'string' },
-        brandVoice: { type: 'string' },
       },
     },
     namingStrategy: { type: 'enum', values: NAMING_STRATEGIES },
-    // Chairman governance gate (SD-EVA-FIX-CHAIRMAN-GATES-001)
     chairmanGate: {
       type: 'object',
       fields: {
@@ -73,33 +87,57 @@ const TEMPLATE = {
       },
     },
     // Derived
+    personaCoverageScore: { type: 'number', derived: true },
     ranked_candidates: { type: 'array', derived: true },
     decision: { type: 'object', derived: true },
+    sourceProvenance: { type: 'object', derived: true },
   },
   defaultData: {
+    customerPersonas: [],
     brandGenome: {
       archetype: null,
       values: [],
       tone: null,
       audience: null,
       differentiators: [],
+      customerAlignment: [],
     },
+    brandPersonality: { vision: null, mission: null, brandVoice: null },
     scoringCriteria: [],
     candidates: [],
-    narrativeExtension: { vision: null, mission: null, brandVoice: null },
     namingStrategy: null,
     ranked_candidates: [],
     decision: null,
     chairmanGate: { status: 'pending', rationale: null, decision_id: null },
+    personaCoverageScore: null,
+    sourceProvenance: null,
   },
 
-  /**
-   * Validate stage input data.
-   * @param {Object} data
-   * @returns {{ valid: boolean, errors: string[] }}
-   */
   validate(data, { logger = console } = {}) {
     const errors = [];
+
+    // Customer personas (min 3)
+    const personasCheck = validateArray(data?.customerPersonas, 'customerPersonas', MIN_PERSONAS);
+    if (!personasCheck.valid) {
+      errors.push(personasCheck.error);
+    } else {
+      for (let i = 0; i < data.customerPersonas.length; i++) {
+        const p = data.customerPersonas[i];
+        const prefix = `customerPersonas[${i}]`;
+        const results = [
+          validateString(p?.name, `${prefix}.name`, 1),
+        ];
+        errors.push(...collectErrors(results));
+
+        if (!p?.demographics || typeof p.demographics !== 'object') {
+          errors.push(`${prefix}.demographics is required and must be an object`);
+        }
+        const goalsCheck = validateArray(p?.goals, `${prefix}.goals`, 1);
+        if (!goalsCheck.valid) errors.push(goalsCheck.error);
+        const painCheck = validateArray(p?.painPoints, `${prefix}.painPoints`, 1);
+        if (!painCheck.valid) errors.push(painCheck.error);
+      }
+    }
 
     // Brand genome
     const bg = data?.brandGenome;
@@ -113,6 +151,19 @@ const TEMPLATE = {
         } else {
           const strCheck = validateString(bg[key], `brandGenome.${key}`, 1);
           if (!strCheck.valid) errors.push(strCheck.error);
+        }
+      }
+      // customerAlignment: each trait must link to persona insight
+      const caCheck = validateArray(bg.customerAlignment, 'brandGenome.customerAlignment', 1);
+      if (!caCheck.valid) {
+        errors.push(caCheck.error);
+      } else {
+        for (let i = 0; i < bg.customerAlignment.length; i++) {
+          const ca = bg.customerAlignment[i];
+          const prefix = `brandGenome.customerAlignment[${i}]`;
+          if (!ca?.trait) errors.push(`${prefix}.trait is required`);
+          if (!ca?.personaInsight) errors.push(`${prefix}.personaInsight is required`);
+          if (!ca?.personaName) errors.push(`${prefix}.personaName is required`);
         }
       }
     }
@@ -154,34 +205,24 @@ const TEMPLATE = {
           validateString(c?.rationale, `${prefix}.rationale`, 1),
         ];
         errors.push(...collectErrors(results));
-
         if (!c?.scores || typeof c.scores !== 'object') {
           errors.push(`${prefix}.scores is required and must be an object`);
-        } else if (data?.scoringCriteria) {
-          for (let j = 0; j < data.scoringCriteria.length; j++) {
-            const criterion = data.scoringCriteria[j];
-            if (criterion?.name) {
-              const scoreVal = c.scores[criterion.name];
-              const scoreCheck = validateInteger(scoreVal, `${prefix}.scores.${criterion.name}`, 0, 100);
-              if (!scoreCheck.valid) errors.push(scoreCheck.error);
-            }
-          }
         }
       }
     }
 
-    // Narrative extension (G10-1)
-    const ne = data?.narrativeExtension;
-    if (ne && typeof ne === 'object') {
+    // Brand personality (optional fields)
+    const bp = data?.brandPersonality;
+    if (bp && typeof bp === 'object') {
       for (const field of ['vision', 'mission', 'brandVoice']) {
-        if (ne[field] !== null && ne[field] !== undefined) {
-          const neCheck = validateString(ne[field], `narrativeExtension.${field}`, 1);
-          if (!neCheck.valid) errors.push(neCheck.error);
+        if (bp[field] !== null && bp[field] !== undefined) {
+          const bpCheck = validateString(bp[field], `brandPersonality.${field}`, 1);
+          if (!bpCheck.valid) errors.push(bpCheck.error);
         }
       }
     }
 
-    // Naming strategy enum (G10-2)
+    // Naming strategy enum
     if (data?.namingStrategy !== null && data?.namingStrategy !== undefined) {
       const nsCheck = validateEnum(data.namingStrategy, 'namingStrategy', NAMING_STRATEGIES);
       if (!nsCheck.valid) errors.push(nsCheck.error);
@@ -199,13 +240,22 @@ const TEMPLATE = {
     return { valid: errors.length === 0, errors };
   },
 
-  /**
-   * Compute derived fields: weighted scores and ranking.
-   * @param {Object} data - Validated input data
-   * @returns {Object} Data with weighted scores and ranked candidates
-   */
   computeDerived(data, { logger: _logger = console } = {}) {
-    // Dead code: all derivations handled by analysisStep.
+    // Compute persona coverage score
+    if (Array.isArray(data?.customerPersonas) && data.customerPersonas.length > 0) {
+      const fieldsPerPersona = ['name', 'demographics', 'goals', 'painPoints'];
+      let totalFields = 0;
+      let populatedFields = 0;
+      for (const p of data.customerPersonas) {
+        for (const f of fieldsPerPersona) {
+          totalFields++;
+          if (p[f] && (typeof p[f] !== 'object' || (Array.isArray(p[f]) ? p[f].length > 0 : Object.keys(p[f]).length > 0))) {
+            populatedFields++;
+          }
+        }
+      }
+      data.personaCoverageScore = totalFields > 0 ? Math.round((populatedFields / totalFields) * 100) : 0;
+    }
     return { ...data };
   },
 };
@@ -218,7 +268,7 @@ TEMPLATE.onBeforeAnalysis = async function onBeforeAnalysis(supabase, ventureId)
   const { id, isNew } = await createOrReusePendingDecision({
     ventureId,
     stageNumber: 10,
-    summary: 'Chairman brand approval required for Stage 10 (Naming/Brand)',
+    summary: 'Chairman brand approval required for Stage 10 (Customer & Brand Foundation)',
     supabase,
   });
   return { chairmanDecisionId: id, isNew };
@@ -228,5 +278,5 @@ TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage10;
 ensureOutputSchema(TEMPLATE);
 
-export { MIN_CANDIDATES, WEIGHT_SUM, BRAND_GENOME_KEYS, NAMING_STRATEGIES };
+export { MIN_PERSONAS, MIN_CANDIDATES, WEIGHT_SUM, BRAND_GENOME_KEYS, NAMING_STRATEGIES, ARCHETYPES };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-11.js
+++ b/lib/eva/stage-templates/stage-11.js
@@ -1,172 +1,165 @@
 /**
- * Stage 11 Template - GTM (Go-To-Market)
+ * Stage 11 Template - Naming & Visual Identity
  * Phase: THE IDENTITY (Stages 10-12)
- * Part of SD-LEO-FEAT-TMPL-IDENTITY-001
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-A
  *
- * Exactly 3 target-market tiers and exactly 8 acquisition channels.
- * Each channel requires budget and CAC fields.
- * Launch timeline with milestones.
+ * Evaluates naming candidates against Stage 10 customer personas.
+ * Produces visual identity guidelines (colorPalette, typography, imageryGuidance).
+ * Minimum 5 naming candidates with personaFit scores.
+ * No chairman gate at Stage 11 (gate is at 12).
  *
  * @module lib/eva/stage-templates/stage-11
  */
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage11 } from './analysis-steps/stage-11-gtm.js';
+import { analyzeStage11 } from './analysis-steps/stage-11-visual-identity.js';
 
-const REQUIRED_TIERS = 3;
-const REQUIRED_CHANNELS = 8;
-const CHANNEL_TYPES = ['paid', 'organic', 'earned', 'owned'];
-
-const CHANNEL_NAMES = [
-  'Organic Search',
-  'Paid Search',
-  'Social Media',
-  'Content Marketing',
-  'Email Marketing',
-  'Partnerships',
-  'Events',
-  'Direct Sales',
-  'Referrals',
-  'PR/Media',
-  'Influencer Marketing',
-  'Community',
-];
+const MIN_CANDIDATES = 5;
+const WEIGHT_SUM = 100;
+const NAMING_STRATEGIES = ['descriptive', 'abstract', 'acronym', 'founder', 'metaphorical'];
 
 const TEMPLATE = {
   id: 'stage-11',
-  slug: 'gtm',
-  title: 'GTM Strategy',
-  version: '2.0.0',
+  slug: 'naming-visual-identity',
+  title: 'Naming & Visual Identity',
+  version: '3.0.0',
   schema: {
-    tiers: {
-      type: 'array',
-      exactItems: REQUIRED_TIERS,
-      items: {
-        name: { type: 'string', required: true },
-        description: { type: 'string', required: true },
-        persona: { type: 'string' },
-        painPoints: { type: 'array' },
-        tam: { type: 'number', min: 0 },
-        sam: { type: 'number', min: 0 },
-        som: { type: 'number', min: 0 },
+    namingStrategy: {
+      type: 'object',
+      required: true,
+      fields: {
+        approach: { type: 'enum', values: NAMING_STRATEGIES },
+        rationale: { type: 'string' },
       },
     },
-    channels: {
-      type: 'array',
-      exactItems: REQUIRED_CHANNELS,
-      items: {
-        name: { type: 'string', required: true },
-        channelType: { type: 'enum', values: CHANNEL_TYPES },
-        primaryTier: { type: 'string' },
-        monthly_budget: { type: 'number', min: 0, required: true },
-        expected_cac: { type: 'number', min: 0, required: true },
-        target_cac: { type: 'number', min: 0 },
-        primary_kpi: { type: 'string', required: true },
-      },
-    },
-    launch_timeline: {
+    scoringCriteria: {
       type: 'array',
       minItems: 1,
       items: {
-        milestone: { type: 'string', required: true },
-        date: { type: 'string', required: true },
-        owner: { type: 'string' },
+        name: { type: 'string', required: true },
+        weight: { type: 'number', min: 0, max: 100, required: true },
+      },
+    },
+    candidates: {
+      type: 'array',
+      minItems: MIN_CANDIDATES,
+      items: {
+        name: { type: 'string', required: true },
+        rationale: { type: 'string', required: true },
+        scores: { type: 'object', required: true },
+        personaFit: { type: 'array', required: true },
+      },
+    },
+    visualIdentity: {
+      type: 'object',
+      required: true,
+      fields: {
+        colorPalette: { type: 'array', minItems: 1 },
+        typography: { type: 'object' },
+        imageryGuidance: { type: 'string', required: true },
+      },
+    },
+    brandExpression: {
+      type: 'object',
+      fields: {
+        tagline: { type: 'string' },
+        elevator_pitch: { type: 'string' },
+        messaging_pillars: { type: 'array' },
       },
     },
     // Derived
-    total_monthly_budget: { type: 'number', derived: true },
-    avg_cac: { type: 'number', derived: true },
+    ranked_candidates: { type: 'array', derived: true },
+    decision: { type: 'object', derived: true },
   },
   defaultData: {
-    tiers: [],
-    channels: [],
-    launch_timeline: [],
-    total_monthly_budget: null,
-    avg_cac: null,
+    namingStrategy: { approach: null, rationale: null },
+    scoringCriteria: [],
+    candidates: [],
+    visualIdentity: {
+      colorPalette: [],
+      typography: null,
+      imageryGuidance: null,
+    },
+    brandExpression: { tagline: null, elevator_pitch: null, messaging_pillars: [] },
+    ranked_candidates: [],
+    decision: null,
   },
 
-  /**
-   * Validate stage input data.
-   * @param {Object} data
-   * @returns {{ valid: boolean, errors: string[] }}
-   */
   validate(data, { logger = console } = {}) {
     const errors = [];
 
-    // Tiers: exactly 3
-    if (!Array.isArray(data?.tiers)) {
-      errors.push('tiers must be an array');
-    } else if (data.tiers.length !== REQUIRED_TIERS) {
-      errors.push(`tiers must have exactly ${REQUIRED_TIERS} items (got ${data.tiers.length})`);
+    // Naming strategy
+    const ns = data?.namingStrategy;
+    if (!ns || typeof ns !== 'object') {
+      errors.push('namingStrategy is required and must be an object');
     } else {
-      for (let i = 0; i < data.tiers.length; i++) {
-        const t = data.tiers[i];
-        const prefix = `tiers[${i}]`;
-        const results = [
-          validateString(t?.name, `${prefix}.name`, 1),
-          validateString(t?.description, `${prefix}.description`, 1),
-        ];
-        errors.push(...collectErrors(results));
-
-        // G11-1: persona validation
-        if (t?.persona !== null && t?.persona !== undefined) {
-          const personaCheck = validateString(t.persona, `${prefix}.persona`, 1);
-          if (!personaCheck.valid) errors.push(personaCheck.error);
-        }
-
-        // G11-2: painPoints validation
-        if (t?.painPoints !== undefined) {
-          const ppCheck = validateArray(t.painPoints, `${prefix}.painPoints`, 1);
-          if (!ppCheck.valid) errors.push(ppCheck.error);
-        }
+      if (ns.approach !== null && ns.approach !== undefined) {
+        const nsCheck = validateEnum(ns.approach, 'namingStrategy.approach', NAMING_STRATEGIES);
+        if (!nsCheck.valid) errors.push(nsCheck.error);
       }
     }
 
-    // Channels: exactly 8
-    if (!Array.isArray(data?.channels)) {
-      errors.push('channels must be an array');
-    } else if (data.channels.length !== REQUIRED_CHANNELS) {
-      errors.push(`channels must have exactly ${REQUIRED_CHANNELS} items (got ${data.channels.length})`);
+    // Scoring criteria
+    const criteriaCheck = validateArray(data?.scoringCriteria, 'scoringCriteria', 1);
+    if (!criteriaCheck.valid) {
+      errors.push(criteriaCheck.error);
     } else {
-      for (let i = 0; i < data.channels.length; i++) {
-        const ch = data.channels[i];
-        const prefix = `channels[${i}]`;
+      let weightSum = 0;
+      for (let i = 0; i < data.scoringCriteria.length; i++) {
+        const c = data.scoringCriteria[i];
+        const prefix = `scoringCriteria[${i}]`;
         const results = [
-          validateString(ch?.name, `${prefix}.name`, 1),
-          validateNumber(ch?.monthly_budget, `${prefix}.monthly_budget`, 0),
-          validateNumber(ch?.expected_cac, `${prefix}.expected_cac`, 0),
-          validateString(ch?.primary_kpi, `${prefix}.primary_kpi`, 1),
+          validateString(c?.name, `${prefix}.name`, 1),
+          validateNumber(c?.weight, `${prefix}.weight`, 0),
         ];
         errors.push(...collectErrors(results));
-
-        // G11-3: channelType enum validation
-        if (ch?.channelType !== null && ch?.channelType !== undefined) {
-          const ctCheck = validateEnum(ch.channelType, `${prefix}.channelType`, CHANNEL_TYPES);
-          if (!ctCheck.valid) errors.push(ctCheck.error);
+        if (typeof c?.weight === 'number') {
+          if (c.weight > 100) errors.push(`${prefix}.weight must be <= 100 (got ${c.weight})`);
+          weightSum += c.weight;
         }
-
-        // G11-4: primaryTier validation
-        if (ch?.primaryTier !== null && ch?.primaryTier !== undefined) {
-          const ptCheck = validateString(ch.primaryTier, `${prefix}.primaryTier`, 1);
-          if (!ptCheck.valid) errors.push(ptCheck.error);
-        }
+      }
+      if (Math.abs(weightSum - WEIGHT_SUM) > 0.001) {
+        errors.push(`Scoring criteria weights must sum to ${WEIGHT_SUM} (got ${weightSum})`);
       }
     }
 
-    // Launch timeline
-    const timelineCheck = validateArray(data?.launch_timeline, 'launch_timeline', 1);
-    if (!timelineCheck.valid) {
-      errors.push(timelineCheck.error);
+    // Candidates with personaFit
+    const candidatesCheck = validateArray(data?.candidates, 'candidates', MIN_CANDIDATES);
+    if (!candidatesCheck.valid) {
+      errors.push(candidatesCheck.error);
     } else {
-      for (let i = 0; i < data.launch_timeline.length; i++) {
-        const m = data.launch_timeline[i];
-        const prefix = `launch_timeline[${i}]`;
+      for (let i = 0; i < data.candidates.length; i++) {
+        const c = data.candidates[i];
+        const prefix = `candidates[${i}]`;
         const results = [
-          validateString(m?.milestone, `${prefix}.milestone`, 1),
-          validateString(m?.date, `${prefix}.date`, 1),
+          validateString(c?.name, `${prefix}.name`, 1),
+          validateString(c?.rationale, `${prefix}.rationale`, 1),
         ];
         errors.push(...collectErrors(results));
+
+        if (!c?.scores || typeof c.scores !== 'object') {
+          errors.push(`${prefix}.scores is required and must be an object`);
+        }
+        // personaFit: array of persona-specific scores
+        const pfCheck = validateArray(c?.personaFit, `${prefix}.personaFit`, 1);
+        if (!pfCheck.valid) errors.push(pfCheck.error);
+      }
+    }
+
+    // Visual identity
+    const vi = data?.visualIdentity;
+    if (!vi || typeof vi !== 'object') {
+      errors.push('visualIdentity is required and must be an object');
+    } else {
+      const cpCheck = validateArray(vi.colorPalette, 'visualIdentity.colorPalette', 1);
+      if (!cpCheck.valid) errors.push(cpCheck.error);
+
+      const igCheck = validateString(vi.imageryGuidance, 'visualIdentity.imageryGuidance', 1);
+      if (!igCheck.valid) errors.push(igCheck.error);
+
+      if (!vi.typography || typeof vi.typography !== 'object') {
+        errors.push('visualIdentity.typography is required and must be an object');
       }
     }
 
@@ -174,13 +167,7 @@ const TEMPLATE = {
     return { valid: errors.length === 0, errors };
   },
 
-  /**
-   * Compute derived fields: total budget and average CAC.
-   * @param {Object} data - Validated input data
-   * @returns {Object} Data with derived metrics
-   */
   computeDerived(data, { logger: _logger = console } = {}) {
-    // Dead code: all derivations handled by analysisStep.
     return { ...data };
   },
 };
@@ -189,5 +176,5 @@ TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage11;
 ensureOutputSchema(TEMPLATE);
 
-export { REQUIRED_TIERS, REQUIRED_CHANNELS, CHANNEL_NAMES, CHANNEL_TYPES };
+export { MIN_CANDIDATES, WEIGHT_SUM, NAMING_STRATEGIES };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-12.js
+++ b/lib/eva/stage-templates/stage-12.js
@@ -1,46 +1,71 @@
 /**
- * Stage 12 Template - Sales Logic
+ * Stage 12 Template - GTM & Sales Strategy
  * Phase: THE IDENTITY (Stages 10-12)
- * Part of SD-LEO-FEAT-TMPL-IDENTITY-001
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-A
  *
- * Sales process definition with funnel stages, metrics,
- * customer journey mapping, and Phase 3→4 Reality Gate.
+ * Combined go-to-market and sales strategy in one stage.
+ * Produces market tiers, channels, sales model, funnel, journey.
+ * Phase 3→4 Reality Gate preserved as dual-gate pattern.
  *
  * DUAL-GATE DESIGN (G12-6):
  * This stage participates in two separate gates for the 12→13 boundary:
  *   1. LOCAL gate (this file, evaluateRealityGate): Validates data completeness
- *      across Stages 10-12 (naming candidates, tiers, channels, funnel, journey).
+ *      across Stages 10-12 (personas, brand, naming, tiers, channels, funnel, journey).
  *   2. SYSTEM gate (reality-gates.js, BOUNDARY_CONFIG '12->13'): Validates
- *      artifact existence in venture_artifacts table (business_model_canvas,
- *      technical_architecture, project_plan).
+ *      artifact existence in venture_artifacts table.
  * Both gates must pass for a venture to transition from IDENTITY to BLUEPRINT.
- *
- * Local gate pass requires:
- *   - Stage 10: >= 5 scored naming candidates
- *   - Stage 11: exactly 3 tiers and 8 channels
- *   - Stage 12: >= 4 funnel stages with metrics, >= 5 journey steps
  *
  * @module lib/eva/stage-templates/stage-12
  */
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { REQUIRED_TIERS, REQUIRED_CHANNELS } from './stage-11.js';
-import { MIN_CANDIDATES } from './stage-10.js';
-import { analyzeStage12 } from './analysis-steps/stage-12-sales-logic.js';
+import { analyzeStage12 } from './analysis-steps/stage-12-gtm-sales.js';
+import { MIN_PERSONAS } from './stage-10.js';
 
 const SALES_MODELS = ['self-serve', 'inside-sales', 'enterprise', 'hybrid', 'marketplace', 'channel'];
+const CHANNEL_TYPES = ['paid', 'organic', 'earned', 'owned'];
+const REQUIRED_TIERS = 3;
+const REQUIRED_CHANNELS = 8;
+const MIN_DEAL_STAGES = 3;
 const MIN_FUNNEL_STAGES = 4;
 const MIN_JOURNEY_STEPS = 5;
-const MIN_DEAL_STAGES = 3;
+const MIN_CANDIDATES = 5;
 
 const TEMPLATE = {
   id: 'stage-12',
-  slug: 'sales-logic',
-  title: 'Sales Identity',
-  version: '2.0.0',
+  slug: 'gtm-sales-strategy',
+  title: 'GTM & Sales Strategy',
+  version: '3.0.0',
   schema: {
-    sales_model: { type: 'enum', values: SALES_MODELS, required: true },
+    // GTM section
+    marketTiers: {
+      type: 'array',
+      exactItems: REQUIRED_TIERS,
+      items: {
+        name: { type: 'string', required: true },
+        description: { type: 'string', required: true },
+        persona: { type: 'string' },
+        painPoints: { type: 'array' },
+        tam: { type: 'number', min: 0 },
+        sam: { type: 'number', min: 0 },
+        som: { type: 'number', min: 0 },
+      },
+    },
+    channels: {
+      type: 'array',
+      exactItems: REQUIRED_CHANNELS,
+      items: {
+        name: { type: 'string', required: true },
+        channelType: { type: 'enum', values: CHANNEL_TYPES },
+        primaryTier: { type: 'string' },
+        monthly_budget: { type: 'number', min: 0, required: true },
+        expected_cac: { type: 'number', min: 0, required: true },
+        primary_kpi: { type: 'string', required: true },
+      },
+    },
+    // Sales section
+    salesModel: { type: 'enum', values: SALES_MODELS, required: true },
     sales_cycle_days: { type: 'number', min: 1, required: true },
     deal_stages: {
       type: 'array',
@@ -73,36 +98,79 @@ const TEMPLATE = {
     },
     // Derived
     economyCheck: { type: 'object', derived: true },
-    reality_gate: {
-      type: 'object',
-      derived: true,
-    },
+    reality_gate: { type: 'object', derived: true },
+    total_monthly_budget: { type: 'number', derived: true },
+    avg_cac: { type: 'number', derived: true },
   },
   defaultData: {
-    sales_model: null,
+    marketTiers: [],
+    channels: [],
+    salesModel: null,
     sales_cycle_days: null,
     deal_stages: [],
     funnel_stages: [],
     customer_journey: [],
     economyCheck: null,
     reality_gate: null,
+    total_monthly_budget: null,
+    avg_cac: null,
   },
 
-  /**
-   * Validate stage input data.
-   * @param {Object} data
-   * @returns {{ valid: boolean, errors: string[] }}
-   */
   validate(data, { logger = console } = {}) {
     const errors = [];
 
-    const modelCheck = validateEnum(data?.sales_model, 'sales_model', SALES_MODELS);
+    // --- GTM section ---
+
+    // Market tiers: exactly 3
+    if (!Array.isArray(data?.marketTiers)) {
+      errors.push('marketTiers must be an array');
+    } else if (data.marketTiers.length !== REQUIRED_TIERS) {
+      errors.push(`marketTiers must have exactly ${REQUIRED_TIERS} items (got ${data.marketTiers.length})`);
+    } else {
+      for (let i = 0; i < data.marketTiers.length; i++) {
+        const t = data.marketTiers[i];
+        const prefix = `marketTiers[${i}]`;
+        const results = [
+          validateString(t?.name, `${prefix}.name`, 1),
+          validateString(t?.description, `${prefix}.description`, 1),
+        ];
+        errors.push(...collectErrors(results));
+      }
+    }
+
+    // Channels: exactly 8
+    if (!Array.isArray(data?.channels)) {
+      errors.push('channels must be an array');
+    } else if (data.channels.length !== REQUIRED_CHANNELS) {
+      errors.push(`channels must have exactly ${REQUIRED_CHANNELS} items (got ${data.channels.length})`);
+    } else {
+      for (let i = 0; i < data.channels.length; i++) {
+        const ch = data.channels[i];
+        const prefix = `channels[${i}]`;
+        const results = [
+          validateString(ch?.name, `${prefix}.name`, 1),
+          validateNumber(ch?.monthly_budget, `${prefix}.monthly_budget`, 0),
+          validateNumber(ch?.expected_cac, `${prefix}.expected_cac`, 0),
+          validateString(ch?.primary_kpi, `${prefix}.primary_kpi`, 1),
+        ];
+        errors.push(...collectErrors(results));
+
+        if (ch?.channelType !== null && ch?.channelType !== undefined) {
+          const ctCheck = validateEnum(ch.channelType, `${prefix}.channelType`, CHANNEL_TYPES);
+          if (!ctCheck.valid) errors.push(ctCheck.error);
+        }
+      }
+    }
+
+    // --- Sales section ---
+
+    const modelCheck = validateEnum(data?.salesModel, 'salesModel', SALES_MODELS);
     if (!modelCheck.valid) errors.push(modelCheck.error);
 
     const cycleCheck = validateNumber(data?.sales_cycle_days, 'sales_cycle_days', 1);
     if (!cycleCheck.valid) errors.push(cycleCheck.error);
 
-    // Deal stages
+    // Deal stages (min 3)
     const dealCheck = validateArray(data?.deal_stages, 'deal_stages', MIN_DEAL_STAGES);
     if (!dealCheck.valid) {
       errors.push(dealCheck.error);
@@ -115,16 +183,10 @@ const TEMPLATE = {
           validateString(ds?.description, `${prefix}.description`, 1),
         ];
         errors.push(...collectErrors(results));
-
-        // G12-2: mappedFunnelStage validation
-        if (ds?.mappedFunnelStage !== null && ds?.mappedFunnelStage !== undefined) {
-          const mfsCheck = validateString(ds.mappedFunnelStage, `${prefix}.mappedFunnelStage`, 1);
-          if (!mfsCheck.valid) errors.push(mfsCheck.error);
-        }
       }
     }
 
-    // Funnel stages
+    // Funnel stages (min 4)
     const funnelCheck = validateArray(data?.funnel_stages, 'funnel_stages', MIN_FUNNEL_STAGES);
     if (!funnelCheck.valid) {
       errors.push(funnelCheck.error);
@@ -139,7 +201,6 @@ const TEMPLATE = {
         ];
         errors.push(...collectErrors(results));
 
-        // G12-3: conversionRateEstimate validation (0-1 ratio range)
         if (fs?.conversionRateEstimate !== null && fs?.conversionRateEstimate !== undefined) {
           const crCheck = validateNumber(fs.conversionRateEstimate, `${prefix}.conversionRateEstimate`, 0);
           if (!crCheck.valid) {
@@ -151,7 +212,7 @@ const TEMPLATE = {
       }
     }
 
-    // Customer journey
+    // Customer journey (min 5)
     const journeyCheck = validateArray(data?.customer_journey, 'customer_journey', MIN_JOURNEY_STEPS);
     if (!journeyCheck.valid) {
       errors.push(journeyCheck.error);
@@ -172,14 +233,7 @@ const TEMPLATE = {
     return { valid: errors.length === 0, errors };
   },
 
-  /**
-   * Compute derived fields: reality gate evaluation.
-   * @param {Object} data - Validated input data
-   * @param {Object} [prerequisites] - Optional: { stage10, stage11 }
-   * @returns {Object} Data with reality_gate
-   */
   computeDerived(data, _prerequisites, { logger: _logger = console } = {}) {
-    // Dead code: all derivations handled by analysisStep.
     return { ...data };
   },
 };
@@ -187,10 +241,10 @@ const TEMPLATE = {
 /**
  * Pure function: evaluate Phase 3→4 Reality Gate.
  *
- * Pass requires:
- *   - Stage 10: >= 5 scored naming candidates
- *   - Stage 11: exactly 3 tiers and 8 channels
- *   - Stage 12: >= 4 funnel stages with metrics, >= 5 journey steps
+ * Checks data completeness across Stages 10, 11, 12:
+ *   - Stage 10: >= 3 customer personas, brand genome with customerAlignment
+ *   - Stage 11: >= 5 naming candidates with personaFit scores
+ *   - Stage 12: 3 tiers, 8 channels, >= 3 deal stages, >= 4 funnel stages, >= 5 journey steps
  *
  * @param {{ stage10: Object, stage11: Object, stage12: Object }} prerequisites
  * @returns {{ pass: boolean, rationale: string, blockers: string[], required_next_actions: string[] }}
@@ -199,56 +253,75 @@ export function evaluateRealityGate({ stage10, stage11, stage12 }) {
   const blockers = [];
   const required_next_actions = [];
 
-  // Stage 10: >= 5 scored candidates
-  const candidatesCount = stage10?.candidates?.length || 0;
+  // Stage 10: customer personas (>= 3)
+  const personaCount = stage10?.customerPersonas?.length || 0;
+  if (personaCount < MIN_PERSONAS) {
+    blockers.push(`Insufficient customer personas: ${personaCount} < ${MIN_PERSONAS} required`);
+    required_next_actions.push(`Add ${MIN_PERSONAS - personaCount} more customer personas`);
+  }
+
+  // Stage 10: brand genome with customerAlignment
+  const alignmentCount = stage10?.brandGenome?.customerAlignment?.length || 0;
+  if (alignmentCount === 0) {
+    blockers.push('Brand genome missing customerAlignment — brand traits not linked to persona insights');
+    required_next_actions.push('Add customerAlignment entries linking brand traits to persona insights');
+  }
+
+  // Stage 11: naming candidates with personaFit (>= 5)
+  const candidatesCount = stage11?.candidates?.length || 0;
   if (candidatesCount < MIN_CANDIDATES) {
     blockers.push(`Insufficient naming candidates: ${candidatesCount} < ${MIN_CANDIDATES} required`);
-    required_next_actions.push(`Add ${MIN_CANDIDATES - candidatesCount} more naming candidates with scores`);
+    required_next_actions.push(`Add ${MIN_CANDIDATES - candidatesCount} more naming candidates with persona fit scores`);
   }
 
-  // Check that candidates have scores
-  const scoredCount = stage10?.candidates?.filter(c => c.weighted_score !== undefined && c.weighted_score !== null).length || 0;
-  if (scoredCount < MIN_CANDIDATES && candidatesCount >= MIN_CANDIDATES) {
-    blockers.push(`Only ${scoredCount} of ${candidatesCount} candidates have scores computed`);
-    required_next_actions.push('Ensure all naming candidates have scoring criteria applied');
+  // Stage 11: candidates must have personaFit scores
+  const candidatesWithFit = stage11?.candidates?.filter(c => Array.isArray(c.personaFit) && c.personaFit.length > 0).length || 0;
+  if (candidatesWithFit < candidatesCount && candidatesCount >= MIN_CANDIDATES) {
+    blockers.push(`${candidatesCount - candidatesWithFit} candidate(s) missing personaFit scores`);
+    required_next_actions.push('Ensure all naming candidates have personaFit scores');
   }
 
-  // Stage 11: exactly 3 tiers
-  const tiersCount = stage11?.tiers?.length || 0;
+  // Stage 12: market tiers (exactly 3)
+  const tiersCount = stage12?.marketTiers?.length || 0;
   if (tiersCount !== REQUIRED_TIERS) {
-    blockers.push(`GTM requires exactly ${REQUIRED_TIERS} tiers (got ${tiersCount})`);
+    blockers.push(`GTM requires exactly ${REQUIRED_TIERS} market tiers (got ${tiersCount})`);
     required_next_actions.push(`Define exactly ${REQUIRED_TIERS} target market tiers`);
   }
 
-  // Stage 11: exactly 8 channels
-  const channelsCount = stage11?.channels?.length || 0;
+  // Stage 12: channels (exactly 8)
+  const channelsCount = stage12?.channels?.length || 0;
   if (channelsCount !== REQUIRED_CHANNELS) {
     blockers.push(`GTM requires exactly ${REQUIRED_CHANNELS} channels (got ${channelsCount})`);
-    required_next_actions.push(`Define exactly ${REQUIRED_CHANNELS} acquisition channels with budget and CAC`);
+    required_next_actions.push(`Define exactly ${REQUIRED_CHANNELS} acquisition channels`);
   }
 
-  // Stage 12: >= 4 funnel stages
+  // Stage 12: deal stages (>= 3)
+  const dealCount = stage12?.deal_stages?.length || 0;
+  if (dealCount < MIN_DEAL_STAGES) {
+    blockers.push(`Insufficient deal stages: ${dealCount} < ${MIN_DEAL_STAGES} required`);
+    required_next_actions.push(`Add ${MIN_DEAL_STAGES - dealCount} more deal stages`);
+  }
+
+  // Stage 12: funnel stages (>= 4) with metrics
   const funnelCount = stage12?.funnel_stages?.length || 0;
   if (funnelCount < MIN_FUNNEL_STAGES) {
     blockers.push(`Insufficient funnel stages: ${funnelCount} < ${MIN_FUNNEL_STAGES} required`);
     required_next_actions.push(`Add ${MIN_FUNNEL_STAGES - funnelCount} more funnel stages with metrics`);
   }
-
-  // Stage 12: funnel stages must have metrics
   const funnelWithMetrics = stage12?.funnel_stages?.filter(fs => fs.metric && fs.target_value !== undefined).length || 0;
   if (funnelWithMetrics < funnelCount && funnelCount >= MIN_FUNNEL_STAGES) {
     blockers.push(`${funnelCount - funnelWithMetrics} funnel stage(s) missing metric or target value`);
     required_next_actions.push('Ensure all funnel stages have a named metric and target value');
   }
 
-  // Stage 12: >= 5 journey steps
+  // Stage 12: journey steps (>= 5)
   const journeyCount = stage12?.customer_journey?.length || 0;
   if (journeyCount < MIN_JOURNEY_STEPS) {
     blockers.push(`Insufficient customer journey steps: ${journeyCount} < ${MIN_JOURNEY_STEPS} required`);
-    required_next_actions.push(`Add ${MIN_JOURNEY_STEPS - journeyCount} more customer journey steps mapped to funnel stages`);
+    required_next_actions.push(`Add ${MIN_JOURNEY_STEPS - journeyCount} more customer journey steps`);
   }
 
-  // G12-4: Economy check validation
+  // Economy check validation
   const econ = stage12?.economyCheck;
   if (econ) {
     if (typeof econ.totalPipelineValue === 'number' && econ.totalPipelineValue <= 0) {
@@ -263,7 +336,7 @@ export function evaluateRealityGate({ stage10, stage11, stage12 }) {
 
   const pass = blockers.length === 0;
   const rationale = pass
-    ? 'All Phase 3 prerequisites met. Identity, GTM, and sales logic are complete.'
+    ? 'All Phase 3 prerequisites met. Customer foundation, naming/identity, GTM, and sales logic are complete.'
     : `Phase 3 is incomplete: ${blockers.length} blocker(s) found.`;
 
   return { pass, rationale, blockers, required_next_actions };
@@ -273,5 +346,5 @@ TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage12;
 ensureOutputSchema(TEMPLATE);
 
-export { SALES_MODELS, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS, MIN_DEAL_STAGES };
+export { SALES_MODELS, CHANNEL_TYPES, REQUIRED_TIERS, REQUIRED_CHANNELS, MIN_DEAL_STAGES, MIN_FUNNEL_STAGES, MIN_JOURNEY_STEPS, MIN_CANDIDATES };
 export default TEMPLATE;

--- a/scripts/test-stages-10-12-e2e.js
+++ b/scripts/test-stages-10-12-e2e.js
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+/**
+ * E2E Smoke Test — Stages 10-12 (Identity Phase Resequence)
+ * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-A
+ *
+ * Tests:
+ *  1. Template loading (schema, validate, computeDerived, outputSchema)
+ *  2. Validation with good/bad data
+ *  3. Contract compliance (consumes/produces match templates)
+ *  4. Cross-stage data flow (Stage 10 output → Stage 11 input → Stage 12 input)
+ *  5. Reality gate (pass and fail scenarios)
+ *  6. Analysis step imports (modules load without error)
+ */
+
+import stage10Template, { MIN_PERSONAS, MIN_CANDIDATES as S10_MIN_CANDIDATES, BRAND_GENOME_KEYS } from '../lib/eva/stage-templates/stage-10.js';
+import stage11Template, { MIN_CANDIDATES as S11_MIN_CANDIDATES } from '../lib/eva/stage-templates/stage-11.js';
+import stage12Template, {
+  evaluateRealityGate,
+  SALES_MODELS,
+  REQUIRED_TIERS,
+  REQUIRED_CHANNELS,
+  MIN_DEAL_STAGES,
+  MIN_FUNNEL_STAGES,
+  MIN_JOURNEY_STEPS,
+} from '../lib/eva/stage-templates/stage-12.js';
+import { getContract } from '../lib/eva/contracts/stage-contracts.js';
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function assert(condition, label) {
+  if (condition) {
+    passed++;
+    console.log('  PASS ' + label);
+  } else {
+    failed++;
+    failures.push(label);
+    console.log('  FAIL ' + label);
+  }
+}
+
+// ─── Test Data Fixtures ───────────────────────────────────────────────
+
+function makePersonas(count) {
+  return Array.from({ length: count }, (_, i) => ({
+    name: 'Persona ' + (i + 1),
+    role: 'User Role ' + (i + 1),
+    demographics: { ageRange: '25-35', income: '$60k-$90k' },
+    goals: ['Goal A', 'Goal B'],
+    painPoints: ['Pain A', 'Pain B'],
+    behaviors: ['Behavior A'],
+    motivations: ['Motivation A'],
+  }));
+}
+
+function makeBrandGenome() {
+  // BRAND_GENOME_KEYS = ['archetype','values','tone','audience','differentiators']
+  const genome = {};
+  for (const key of BRAND_GENOME_KEYS) {
+    genome[key] = 'Sample value for ' + key;
+  }
+  genome.customerAlignment = [
+    { trait: 'Innovation', personaInsight: 'Seeks novelty', personaName: 'Persona 1' },
+    { trait: 'Trust', personaInsight: 'Values reliability', personaName: 'Persona 2' },
+  ];
+  return genome;
+}
+
+function makeStage10GoodData() {
+  return {
+    customerPersonas: makePersonas(3),
+    brandGenome: makeBrandGenome(),
+    brandPersonality: { tone: 'Professional', voice: 'Authoritative' },
+    namingStrategy: 'descriptive',
+    scoringCriteria: [
+      { name: 'Market Fit', weight: 40, description: 'How well it fits the market' },
+      { name: 'Brand Alignment', weight: 30, description: 'Aligns with brand values' },
+      { name: 'Persona Resonance', weight: 30, description: 'Resonates with personas' },
+    ],
+    candidates: Array.from({ length: 5 }, (_, i) => ({
+      name: 'Candidate ' + (i + 1),
+      rationale: 'Strong fit because of reason ' + (i + 1),
+      scores: { 'Market Fit': 8, 'Brand Alignment': 7, 'Persona Resonance': 9 },
+    })),
+    chairmanGate: { status: 'approved', rationale: 'Strong brand foundation' },
+  };
+}
+
+function makeStage11GoodData() {
+  return {
+    namingStrategy: { approach: 'descriptive', rationale: 'Clear communication of value' },
+    scoringCriteria: [
+      { name: 'Persona Resonance', weight: 50 },
+      { name: 'Memorability', weight: 50 },
+    ],
+    candidates: Array.from({ length: 5 }, (_, i) => ({
+      name: 'BrandName' + (i + 1),
+      rationale: 'Reason ' + (i + 1),
+      scores: { 'Persona Resonance': 8, 'Memorability': 7 },
+      personaFit: [
+        { personaName: 'Persona 1', fitScore: 8, rationale: 'Great fit' },
+        { personaName: 'Persona 2', fitScore: 7, rationale: 'Good fit' },
+        { personaName: 'Persona 3', fitScore: 9, rationale: 'Excellent fit' },
+      ],
+    })),
+    visualIdentity: {
+      colorPalette: [
+        { name: 'Primary', hex: '#1a1a2e' },
+        { name: 'Secondary', hex: '#16213e' },
+        { name: 'Accent', hex: '#0f3460' },
+      ],
+      typography: { headingFont: 'Inter', bodyFont: 'Open Sans' },
+      imageryGuidance: 'Professional, clean photography with blue tones',
+    },
+    brandExpression: { tagline: 'Innovation simplified', elevator_pitch: 'We simplify innovation', messaging_pillars: ['Trust', 'Speed'] },
+  };
+}
+
+function makeStage12GoodData() {
+  return {
+    marketTiers: Array.from({ length: 3 }, (_, i) => ({
+      name: 'Tier ' + (i + 1),
+      description: 'Market tier description ' + (i + 1),
+      persona: 'Persona ' + (i + 1),
+      tam: 1000000 * (3 - i),
+      sam: 500000 * (3 - i),
+      som: 100000 * (3 - i),
+    })),
+    channels: Array.from({ length: 8 }, (_, i) => ({
+      name: 'Channel ' + (i + 1),
+      channelType: ['paid', 'organic', 'earned', 'owned'][i % 4],
+      primaryTier: 'Tier ' + ((i % 3) + 1),
+      monthly_budget: 5000 + i * 1000,
+      expected_cac: 50 + i * 10,
+      primary_kpi: 'KPI ' + (i + 1),
+    })),
+    salesModel: 'hybrid',
+    sales_cycle_days: 45,
+    deal_stages: Array.from({ length: 3 }, (_, i) => ({
+      name: 'Stage ' + (i + 1),
+      description: 'Deal stage description ' + (i + 1),
+      avg_duration_days: 10 + i * 5,
+      mappedFunnelStage: 'Funnel ' + (i + 1),
+    })),
+    funnel_stages: Array.from({ length: 4 }, (_, i) => ({
+      name: 'Funnel ' + (i + 1),
+      metric: 'Metric ' + (i + 1),
+      target_value: 1000 * (4 - i),
+      conversionRateEstimate: 0.25 - i * 0.05,
+    })),
+    customer_journey: Array.from({ length: 5 }, (_, i) => ({
+      step: 'Step ' + (i + 1),
+      funnel_stage: 'Funnel ' + ((i % 4) + 1),
+      touchpoint: 'Touchpoint ' + (i + 1),
+    })),
+  };
+}
+
+// ─── Test 1: Template Loading ────────────────────────────────────────
+
+console.log('\n=== Test 1: Template Loading ===');
+
+assert(stage10Template.id === 'stage-10', 'Stage 10 template id');
+assert(stage10Template.title === 'Customer & Brand Foundation', 'Stage 10 template title');
+assert(typeof stage10Template.validate === 'function', 'Stage 10 has validate()');
+assert(typeof stage10Template.computeDerived === 'function', 'Stage 10 has computeDerived()');
+assert(Array.isArray(stage10Template.outputSchema), 'Stage 10 has outputSchema');
+assert(typeof stage10Template.analysisStep === 'function', 'Stage 10 has analysisStep');
+
+assert(stage11Template.id === 'stage-11', 'Stage 11 template id');
+assert(stage11Template.title === 'Naming & Visual Identity', 'Stage 11 template title');
+assert(typeof stage11Template.validate === 'function', 'Stage 11 has validate()');
+assert(Array.isArray(stage11Template.outputSchema), 'Stage 11 has outputSchema');
+assert(typeof stage11Template.analysisStep === 'function', 'Stage 11 has analysisStep');
+
+assert(stage12Template.id === 'stage-12', 'Stage 12 template id');
+assert(stage12Template.title === 'GTM & Sales Strategy', 'Stage 12 template title');
+assert(typeof stage12Template.validate === 'function', 'Stage 12 has validate()');
+assert(Array.isArray(stage12Template.outputSchema), 'Stage 12 has outputSchema');
+assert(typeof stage12Template.analysisStep === 'function', 'Stage 12 has analysisStep');
+
+// ─── Test 2: Validation — Good Data ──────────────────────────────────
+
+console.log('\n=== Test 2: Validation — Good Data ===');
+
+const s10Result = stage10Template.validate(makeStage10GoodData(), { logger: { warn() {} } });
+assert(s10Result.valid === true, 'Stage 10 good data validates');
+assert(s10Result.errors.length === 0, 'Stage 10 good data has 0 errors');
+
+const s11Result = stage11Template.validate(makeStage11GoodData(), { logger: { warn() {} } });
+assert(s11Result.valid === true, 'Stage 11 good data validates');
+assert(s11Result.errors.length === 0, 'Stage 11 good data has 0 errors');
+
+const s12Result = stage12Template.validate(makeStage12GoodData(), { logger: { warn() {} } });
+assert(s12Result.valid === true, 'Stage 12 good data validates');
+assert(s12Result.errors.length === 0, 'Stage 12 good data has 0 errors');
+
+// ─── Test 3: Validation — Bad Data ───────────────────────────────────
+
+console.log('\n=== Test 3: Validation — Bad Data ===');
+
+const s10Bad = stage10Template.validate({}, { logger: { warn() {} } });
+assert(s10Bad.valid === false, 'Stage 10 empty data fails validation');
+assert(s10Bad.errors.length >= 3, 'Stage 10 empty data has 3+ errors');
+
+const s11Bad = stage11Template.validate({}, { logger: { warn() {} } });
+assert(s11Bad.valid === false, 'Stage 11 empty data fails validation');
+assert(s11Bad.errors.length >= 3, 'Stage 11 empty data has 3+ errors');
+
+const s12Bad = stage12Template.validate({}, { logger: { warn() {} } });
+assert(s12Bad.valid === false, 'Stage 12 empty data fails validation');
+assert(s12Bad.errors.length >= 3, 'Stage 12 empty data has 3+ errors');
+
+// Specific bad data: wrong salesModel enum
+const s12WrongEnum = stage12Template.validate(
+  { ...makeStage12GoodData(), salesModel: 'telemarketing' },
+  { logger: { warn() {} } }
+);
+assert(s12WrongEnum.valid === false, 'Stage 12 rejects invalid salesModel enum');
+
+// Specific bad data: too few market tiers
+const s12FewTiers = stage12Template.validate(
+  { ...makeStage12GoodData(), marketTiers: [{ name: 'One', description: 'Only one' }] },
+  { logger: { warn() {} } }
+);
+assert(s12FewTiers.valid === false, 'Stage 12 rejects fewer than 3 market tiers');
+
+// ─── Test 4: Contract Compliance ─────────────────────────────────────
+
+console.log('\n=== Test 4: Contract Compliance ===');
+
+const c10 = getContract(10);
+assert(c10 !== undefined, 'Contract exists for stage 10');
+// produces is a keyed object: { fieldName: { type, minItems, ... } }
+const c10ProduceKeys = Object.keys(c10.produces);
+assert(c10ProduceKeys.includes('customerPersonas'), 'Stage 10 contract produces customerPersonas');
+assert(c10ProduceKeys.includes('brandGenome'), 'Stage 10 contract produces brandGenome');
+assert(c10ProduceKeys.includes('candidates'), 'Stage 10 contract produces candidates');
+
+const c11 = getContract(11);
+assert(c11 !== undefined, 'Contract exists for stage 11');
+assert(c11.consumes.some(c => c.stage === 10), 'Stage 11 consumes from stage 10');
+const c11ProduceKeys = Object.keys(c11.produces);
+assert(c11ProduceKeys.includes('candidates'), 'Stage 11 contract produces candidates');
+assert(c11ProduceKeys.includes('visualIdentity'), 'Stage 11 contract produces visualIdentity');
+
+const c12 = getContract(12);
+assert(c12 !== undefined, 'Contract exists for stage 12');
+assert(c12.consumes.some(c => c.stage === 10), 'Stage 12 consumes from stage 10');
+assert(c12.consumes.some(c => c.stage === 11), 'Stage 12 consumes from stage 11');
+const c12ProduceKeys = Object.keys(c12.produces);
+assert(c12ProduceKeys.includes('marketTiers'), 'Stage 12 contract produces marketTiers');
+assert(c12ProduceKeys.includes('channels'), 'Stage 12 contract produces channels');
+assert(c12ProduceKeys.includes('salesModel'), 'Stage 12 contract produces salesModel');
+assert(c12ProduceKeys.includes('reality_gate'), 'Stage 12 contract produces reality_gate');
+
+// Verify Stage 10 output schema fields match contract produces
+const s10OutputFields = stage10Template.outputSchema.map(o => o.field);
+for (const prodKey of c10ProduceKeys) {
+  assert(s10OutputFields.includes(prodKey), 'Stage 10 outputSchema includes contract field: ' + prodKey);
+}
+
+// ─── Test 5: Cross-Stage Data Flow ───────────────────────────────────
+
+console.log('\n=== Test 5: Cross-Stage Data Flow ===');
+
+// Stage 10 output feeds Stage 11 consumes
+const s10Output = makeStage10GoodData();
+const c11Consumes10 = c11.consumes.find(c => c.stage === 10);
+if (c11Consumes10) {
+  // fields is a keyed object: { fieldName: { type, ... } }
+  for (const fieldName of Object.keys(c11Consumes10.fields)) {
+    assert(s10Output[fieldName] !== undefined, 'Stage 10 output provides ' + fieldName + ' for Stage 11');
+  }
+}
+
+// Stage 11 output feeds Stage 12 consumes
+const s11Output = makeStage11GoodData();
+const c12Consumes11 = c12.consumes.find(c => c.stage === 11);
+if (c12Consumes11) {
+  for (const fieldName of Object.keys(c12Consumes11.fields)) {
+    assert(s11Output[fieldName] !== undefined, 'Stage 11 output provides ' + fieldName + ' for Stage 12');
+  }
+}
+
+// ─── Test 6: Reality Gate — Pass ──────────────────────────────────────
+
+console.log('\n=== Test 6: Reality Gate ===');
+
+const gatePass = evaluateRealityGate({
+  stage10: makeStage10GoodData(),
+  stage11: makeStage11GoodData(),
+  stage12: makeStage12GoodData(),
+});
+assert(gatePass.pass === true, 'Reality gate passes with complete data');
+assert(gatePass.blockers.length === 0, 'Reality gate has 0 blockers when passing');
+assert(typeof gatePass.rationale === 'string', 'Reality gate returns rationale');
+
+// Reality gate — fail: missing personas
+const gateFail1 = evaluateRealityGate({
+  stage10: { customerPersonas: [], brandGenome: {} },
+  stage11: { candidates: [] },
+  stage12: { marketTiers: [], channels: [], deal_stages: [], funnel_stages: [], customer_journey: [] },
+});
+assert(gateFail1.pass === false, 'Reality gate fails with empty data');
+assert(gateFail1.blockers.length >= 5, 'Reality gate reports 5+ blockers with empty data');
+
+// Reality gate — fail: candidates missing personaFit
+const gateFail2 = evaluateRealityGate({
+  stage10: makeStage10GoodData(),
+  stage11: {
+    candidates: Array.from({ length: 5 }, (_, i) => ({ name: 'C' + i })), // No personaFit
+  },
+  stage12: makeStage12GoodData(),
+});
+assert(gateFail2.pass === false, 'Reality gate fails when candidates lack personaFit');
+assert(gateFail2.blockers.some(b => b.includes('personaFit')), 'Reality gate reports personaFit blocker');
+
+// ─── Test 7: Constants Consistency ───────────────────────────────────
+
+console.log('\n=== Test 7: Constants Consistency ===');
+
+assert(MIN_PERSONAS === 3, 'MIN_PERSONAS is 3');
+assert(S10_MIN_CANDIDATES === 5, 'Stage 10 MIN_CANDIDATES is 5');
+assert(S11_MIN_CANDIDATES === 5, 'Stage 11 MIN_CANDIDATES is 5');
+assert(REQUIRED_TIERS === 3, 'REQUIRED_TIERS is 3');
+assert(REQUIRED_CHANNELS === 8, 'REQUIRED_CHANNELS is 8');
+assert(MIN_DEAL_STAGES === 3, 'MIN_DEAL_STAGES is 3');
+assert(MIN_FUNNEL_STAGES === 4, 'MIN_FUNNEL_STAGES is 4');
+assert(MIN_JOURNEY_STEPS === 5, 'MIN_JOURNEY_STEPS is 5');
+assert(SALES_MODELS.includes('hybrid'), 'SALES_MODELS includes hybrid');
+assert(SALES_MODELS.includes('self-serve'), 'SALES_MODELS includes self-serve');
+
+// ─── Test 8: Downstream Contracts (Stage 13) ─────────────────────────
+
+console.log('\n=== Test 8: Downstream Contract Check ===');
+
+const c13 = getContract(13);
+if (c13) {
+  // Stage 13 (Product Roadmap) should not consume from old stage 10/11/12 fields that no longer exist
+  const c13ConsumeStages = c13.consumes.map(c => c.stage);
+  assert(typeof c13 === 'object', 'Contract exists for stage 13');
+  console.log('  INFO Stage 13 consumes from stages: ' + JSON.stringify(c13ConsumeStages));
+} else {
+  console.log('  SKIP Stage 13 contract not found (may not be updated yet)');
+}
+
+// ─── Summary ─────────────────────────────────────────────────────────
+
+console.log('\n===================================');
+console.log('  RESULTS: ' + passed + ' passed, ' + failed + ' failed');
+console.log('===================================');
+
+if (failures.length > 0) {
+  console.log('\nFailures:');
+  for (const f of failures) {
+    console.log('  - ' + f);
+  }
+  process.exit(1);
+}
+
+console.log('\nAll tests passed!');
+process.exit(0);


### PR DESCRIPTION
## Summary
- Redesign stages 10-12 as part of EVA 25-stage pipeline overhaul
- Stage 10 (Customer & Brand Foundation): customerPersonas first, then brandGenome grounded in persona insights
- Stage 11 (Naming & Visual Identity): naming candidates scored against Stage 10 personas with visual identity system
- Stage 12 (GTM & Sales Strategy): combined GTM + sales with Phase 3→4 reality gate
- 3 analysis steps, updated contracts (YAML + JS), 69 tests passing

## Test plan
- [x] 69 unit tests passing across stage 10, 11, 12, and index test files
- [x] Stage contract validation and dependency graph verified
- [x] Import chain verified clean
- [x] Edge cases handled with safe defaults

SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)