### PR TITLE
feat: add background worker framework for operations dashboard

### DIFF
--- a/lib/eva/workers/base-worker.js
+++ b/lib/eva/workers/base-worker.js
@@ -1,0 +1,115 @@
+/**
+ * BaseWorker — Abstract base class for background workers.
+ * Provides lifecycle management, error handling, health checks, and logging.
+ *
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ */
+
+export class BaseWorker {
+  /**
+   * @param {string} name - Human-readable worker name
+   * @param {object} opts
+   * @param {number} [opts.intervalMs=60000] - Run interval in milliseconds
+   * @param {number} [opts.maxRetries=3] - Max consecutive failures before circuit-break
+   * @param {import('@supabase/supabase-js').SupabaseClient} [opts.supabase] - Supabase client
+   */
+  constructor(name, opts = {}) {
+    this.name = name;
+    this.intervalMs = opts.intervalMs ?? 60_000;
+    this.maxRetries = opts.maxRetries ?? 3;
+    this.supabase = opts.supabase ?? null;
+
+    this._timer = null;
+    this._running = false;
+    this._consecutiveFailures = 0;
+    this._lastRun = null;
+    this._lastError = null;
+    this._totalRuns = 0;
+    this._totalErrors = 0;
+  }
+
+  /** Override in subclass: the actual work to perform each tick */
+  async execute() {
+    throw new Error(`${this.name}: execute() not implemented`);
+  }
+
+  /** Start the worker on its interval */
+  start() {
+    if (this._running) return;
+    this._running = true;
+    this._log('started', { intervalMs: this.intervalMs });
+
+    // Run immediately, then on interval
+    this._tick();
+    this._timer = setInterval(() => this._tick(), this.intervalMs);
+  }
+
+  /** Stop the worker */
+  stop() {
+    if (!this._running) return;
+    this._running = false;
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+    this._log('stopped');
+  }
+
+  /** Health check — returns worker status */
+  health() {
+    return {
+      name: this.name,
+      running: this._running,
+      lastRun: this._lastRun,
+      lastError: this._lastError?.message ?? null,
+      consecutiveFailures: this._consecutiveFailures,
+      totalRuns: this._totalRuns,
+      totalErrors: this._totalErrors,
+      circuitBroken: this._consecutiveFailures >= this.maxRetries,
+    };
+  }
+
+  /** Internal: run one tick with error handling and circuit breaking */
+  async _tick() {
+    if (this._consecutiveFailures >= this.maxRetries) {
+      this._log('circuit-broken', {
+        failures: this._consecutiveFailures,
+        lastError: this._lastError?.message,
+      });
+      return;
+    }
+
+    try {
+      this._totalRuns++;
+      await this.execute();
+      this._lastRun = new Date();
+      this._consecutiveFailures = 0;
+    } catch (err) {
+      this._totalErrors++;
+      this._consecutiveFailures++;
+      this._lastError = err;
+      this._log('error', {
+        message: err.message,
+        consecutiveFailures: this._consecutiveFailures,
+      });
+    }
+  }
+
+  /** Reset circuit breaker to allow retries */
+  resetCircuitBreaker() {
+    this._consecutiveFailures = 0;
+    this._lastError = null;
+    this._log('circuit-reset');
+  }
+
+  _log(event, data = {}) {
+    const entry = {
+      worker: this.name,
+      event,
+      timestamp: new Date().toISOString(),
+      ...data,
+    };
+    // eslint-disable-next-line no-console
+    console.log(`[worker:${this.name}]`, JSON.stringify(entry));
+  }
+}

--- a/lib/eva/workers/health-monitor-worker.js
+++ b/lib/eva/workers/health-monitor-worker.js
@@ -1,0 +1,79 @@
+/**
+ * HealthMonitorWorker — Monitors venture workflow health.
+ * Detects stale executions, failing stages, and blocked ventures.
+ * Logs alerts for the workflow alerts hook to pick up.
+ *
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ */
+
+import { BaseWorker } from './base-worker.js';
+
+/** A workflow is stale if no update in this many hours */
+const STALE_THRESHOLD_HOURS = 24;
+
+export class HealthMonitorWorker extends BaseWorker {
+  constructor(opts = {}) {
+    super('health-monitor', { intervalMs: 300_000, ...opts }); // every 5 min
+  }
+
+  async execute() {
+    if (!this.supabase) return;
+
+    const staleThreshold = new Date(
+      Date.now() - STALE_THRESHOLD_HOURS * 3_600_000,
+    ).toISOString();
+
+    // 1. Detect stale in-progress workflow executions
+    const { data: stale } = await this.supabase
+      .from('workflow_executions')
+      .select('id, venture_id, current_lifecycle_stage, updated_at')
+      .eq('status', 'in_progress')
+      .lt('updated_at', staleThreshold);
+
+    if (stale?.length) {
+      this._log('stale-detected', {
+        count: stale.length,
+        ventureIds: stale.map((s) => s.venture_id),
+      });
+    }
+
+    // 2. Detect repeated failures on same stage (3+ failures)
+    const { data: failedExecs } = await this.supabase
+      .from('stage_executions')
+      .select('execution_id, stage_number')
+      .eq('status', 'failed');
+
+    if (failedExecs?.length) {
+      const failureCounts = new Map();
+      for (const f of failedExecs) {
+        const key = `${f.execution_id}:${f.stage_number}`;
+        failureCounts.set(key, (failureCounts.get(key) || 0) + 1);
+      }
+      const repeatedFailures = [...failureCounts.entries()].filter(
+        ([, count]) => count >= 3,
+      );
+      if (repeatedFailures.length) {
+        this._log('repeated-failures', {
+          count: repeatedFailures.length,
+          stages: repeatedFailures.map(([key]) => key),
+        });
+      }
+    }
+
+    // 3. Count active vs total ventures
+    const { count: activeCount } = await this.supabase
+      .from('workflow_executions')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'in_progress');
+
+    const { count: totalCount } = await this.supabase
+      .from('workflow_executions')
+      .select('id', { count: 'exact', head: true });
+
+    this._log('health-summary', {
+      activeWorkflows: activeCount ?? 0,
+      totalWorkflows: totalCount ?? 0,
+      staleWorkflows: stale?.length ?? 0,
+    });
+  }
+}

--- a/lib/eva/workers/index.js
+++ b/lib/eva/workers/index.js
@@ -1,0 +1,48 @@
+/**
+ * Worker entry point — Registers and starts all background workers.
+ *
+ * Usage:
+ *   node lib/eva/workers/index.js
+ *   node lib/eva/workers/index.js --health   (print health and exit)
+ *
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { WorkerScheduler } from './worker-scheduler.js';
+import { StageAdvanceWorker } from './stage-advance-worker.js';
+import { HealthMonitorWorker } from './health-monitor-worker.js';
+import { MetricsCollectorWorker } from './metrics-collector-worker.js';
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('[workers] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+const scheduler = new WorkerScheduler();
+
+// Register workers
+scheduler.register(new StageAdvanceWorker({ supabase }));
+scheduler.register(new HealthMonitorWorker({ supabase }));
+scheduler.register(new MetricsCollectorWorker({ supabase }));
+
+// CLI
+const args = process.argv.slice(2);
+
+if (args.includes('--health')) {
+  // Print health and exit
+  console.log(JSON.stringify(scheduler.healthCheck(), null, 2));
+  process.exit(0);
+}
+
+// Start all workers
+scheduler.installShutdownHandlers();
+scheduler.startAll();
+
+console.log(`[workers] Running ${scheduler.list().length} worker(s): ${scheduler.list().join(', ')}`);
+console.log('[workers] Press Ctrl+C to stop');

--- a/lib/eva/workers/metrics-collector-worker.js
+++ b/lib/eva/workers/metrics-collector-worker.js
@@ -1,0 +1,70 @@
+/**
+ * MetricsCollectorWorker — Collects and aggregates performance metrics
+ * from stage executions for the dashboard.
+ *
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ */
+
+import { BaseWorker } from './base-worker.js';
+
+export class MetricsCollectorWorker extends BaseWorker {
+  constructor(opts = {}) {
+    super('metrics-collector', { intervalMs: 60_000, ...opts }); // every 1 min
+  }
+
+  async execute() {
+    if (!this.supabase) return;
+
+    const now = new Date();
+    const todayStart = new Date(now);
+    todayStart.setHours(0, 0, 0, 0);
+
+    // Collect today's stage execution stats
+    const { data: todayExecs } = await this.supabase
+      .from('stage_executions')
+      .select('status, duration_minutes, stage_number')
+      .gte('updated_at', todayStart.toISOString());
+
+    if (!todayExecs?.length) {
+      this._log('no-data');
+      return;
+    }
+
+    const completed = todayExecs.filter((e) => e.status === 'completed');
+    const failed = todayExecs.filter((e) => e.status === 'failed');
+    const inProgress = todayExecs.filter(
+      (e) => e.status === 'in_progress' || e.status === 'running',
+    );
+
+    // Stage velocity: average duration per stage number
+    const velocity = {};
+    const counts = {};
+    for (const exec of completed) {
+      if (exec.duration_minutes) {
+        velocity[exec.stage_number] =
+          (velocity[exec.stage_number] || 0) + exec.duration_minutes;
+        counts[exec.stage_number] = (counts[exec.stage_number] || 0) + 1;
+      }
+    }
+    for (const stage of Object.keys(velocity)) {
+      velocity[stage] = Math.round(velocity[stage] / (counts[stage] || 1));
+    }
+
+    // Throughput
+    const throughput = completed.length;
+    const errorRate =
+      completed.length + failed.length > 0
+        ? failed.length / (completed.length + failed.length)
+        : 0;
+
+    this._log('metrics', {
+      date: todayStart.toISOString().slice(0, 10),
+      completed: completed.length,
+      failed: failed.length,
+      inProgress: inProgress.length,
+      throughput,
+      errorRate: Math.round(errorRate * 100),
+      stageVelocity: velocity,
+    });
+  }
+}

--- a/lib/eva/workers/stage-advance-worker.js
+++ b/lib/eva/workers/stage-advance-worker.js
@@ -1,0 +1,80 @@
+/**
+ * StageAdvanceWorker — Checks for ventures ready to auto-advance
+ * through their stage pipeline (stages 1-25). Only advances past
+ * non-gate stages; kill/promotion gates require chairman approval.
+ *
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ */
+
+import { BaseWorker } from './base-worker.js';
+
+/** Gate stages that require chairman decision — never auto-advance past these */
+const GATE_STAGES = new Set([3, 5, 13, 16, 17, 22, 23]);
+
+export class StageAdvanceWorker extends BaseWorker {
+  constructor(opts = {}) {
+    super('stage-advance', { intervalMs: 120_000, ...opts });
+  }
+
+  async execute() {
+    if (!this.supabase) return;
+
+    // Find workflow executions that are in_progress
+    const { data: readyExecs, error } = await this.supabase
+      .from('workflow_executions')
+      .select('id, venture_id, current_lifecycle_stage')
+      .eq('status', 'in_progress');
+
+    if (error) throw error;
+    if (!readyExecs?.length) return;
+
+    for (const exec of readyExecs) {
+      const nextStage = exec.current_lifecycle_stage + 1;
+
+      // Don't auto-advance past gates or beyond stage 25
+      if (GATE_STAGES.has(nextStage) || nextStage > 25) continue;
+
+      // Check if current stage execution is completed
+      const { data: currentStageExec } = await this.supabase
+        .from('stage_executions')
+        .select('status')
+        .eq('execution_id', exec.id)
+        .eq('stage_number', exec.current_lifecycle_stage)
+        .eq('status', 'completed')
+        .limit(1);
+
+      if (!currentStageExec?.length) continue;
+
+      // Check no stage execution already exists for next stage
+      const { data: existing } = await this.supabase
+        .from('stage_executions')
+        .select('id')
+        .eq('execution_id', exec.id)
+        .eq('stage_number', nextStage)
+        .limit(1);
+
+      if (existing?.length) continue;
+
+      this._log('advancing', {
+        ventureId: exec.venture_id,
+        from: exec.current_lifecycle_stage,
+        to: nextStage,
+      });
+
+      // Update workflow execution stage
+      await this.supabase
+        .from('workflow_executions')
+        .update({
+          current_lifecycle_stage: nextStage,
+          current_stage_started_at: new Date().toISOString(),
+        })
+        .eq('id', exec.id);
+
+      // Update venture's current_lifecycle_stage
+      await this.supabase
+        .from('ventures')
+        .update({ current_lifecycle_stage: nextStage })
+        .eq('id', exec.venture_id);
+    }
+  }
+}

--- a/lib/eva/workers/worker-scheduler.js
+++ b/lib/eva/workers/worker-scheduler.js
@@ -1,0 +1,83 @@
+/**
+ * WorkerScheduler — Manages lifecycle of multiple background workers.
+ * Provides start-all, stop-all, health dashboard, and graceful shutdown.
+ *
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ */
+
+import { BaseWorker } from './base-worker.js';
+
+export class WorkerScheduler {
+  constructor() {
+    /** @type {Map<string, BaseWorker>} */
+    this._workers = new Map();
+    this._shutdownHandlers = [];
+  }
+
+  /**
+   * Register a worker instance.
+   * @param {BaseWorker} worker
+   */
+  register(worker) {
+    if (this._workers.has(worker.name)) {
+      throw new Error(`Worker "${worker.name}" already registered`);
+    }
+    this._workers.set(worker.name, worker);
+  }
+
+  /** Start all registered workers */
+  startAll() {
+    for (const worker of this._workers.values()) {
+      worker.start();
+    }
+    console.log(`[scheduler] Started ${this._workers.size} worker(s)`);
+  }
+
+  /** Stop all registered workers */
+  stopAll() {
+    for (const worker of this._workers.values()) {
+      worker.stop();
+    }
+    console.log(`[scheduler] Stopped ${this._workers.size} worker(s)`);
+  }
+
+  /** Get health status for all workers */
+  healthCheck() {
+    const results = {};
+    for (const [name, worker] of this._workers) {
+      results[name] = worker.health();
+    }
+    return results;
+  }
+
+  /** Get a single worker by name */
+  get(name) {
+    return this._workers.get(name) ?? null;
+  }
+
+  /** List registered worker names */
+  list() {
+    return [...this._workers.keys()];
+  }
+
+  /**
+   * Install graceful shutdown handlers (SIGINT, SIGTERM).
+   * Call once after registering all workers.
+   */
+  installShutdownHandlers() {
+    const handler = () => {
+      console.log('[scheduler] Shutdown signal received');
+      this.stopAll();
+      for (const fn of this._shutdownHandlers) fn();
+      process.exit(0);
+    };
+
+    process.on('SIGINT', handler);
+    process.on('SIGTERM', handler);
+  }
+
+  /** Register an additional cleanup function for shutdown */
+  onShutdown(fn) {
+    this._shutdownHandlers.push(fn);
+  }
+}


### PR DESCRIPTION
## Summary
- Created `lib/eva/workers/` with reusable background worker framework
- **BaseWorker**: abstract base with lifecycle management, circuit breaker (3 consecutive failures), health checks
- **WorkerScheduler**: manages multiple workers with start-all/stop-all/health/graceful shutdown
- **StageAdvanceWorker**: auto-advances ventures past non-gate stages (skips kill/promotion gates at 3, 5, 13, 16, 17, 22, 23)
- **HealthMonitorWorker**: detects stale workflows (24h+ idle) and repeated stage failures (3+)
- **MetricsCollectorWorker**: aggregates daily stage execution throughput, error rate, stage velocity
- CLI entry point: `node lib/eva/workers/index.js` (or `--health` for status)

## Test plan
- [ ] `node -e "import('./lib/eva/workers/base-worker.js').then(m => console.log(new m.BaseWorker('t').health()))"` — verify import
- [ ] `node lib/eva/workers/index.js --health` — verify scheduler health output
- [ ] Verify StageAdvanceWorker skips gate stages (3, 5, 13, 16, 17, 22, 23)

SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I

🤖 Generated with [Claude Code](https://claude.com/claude-code)