### PR TITLE
feat(eva): launch workflow API endpoints for stages 23-25

### DIFF
--- a/lib/eva/launch-workflow/index.js
+++ b/lib/eva/launch-workflow/index.js
@@ -1,0 +1,178 @@
+/**
+ * Launch Workflow Module — API for EVA Launch Stages (23-25)
+ *
+ * SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-J
+ *
+ * Provides launch readiness status, go/no-go checklist, and stage
+ * progression timeline for ventures in the launch phase.
+ *
+ * @module lib/eva/launch-workflow
+ */
+
+/**
+ * Get launch readiness status for a venture.
+ * Aggregates stage 23-25 data including current stage, readiness flags,
+ * and launch phase progress.
+ *
+ * @param {string} ventureId - UUID of the venture
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object>} Launch status
+ */
+export async function getLaunchStatus(ventureId, deps = {}) {
+  const { supabase } = deps;
+  if (!supabase) return { ventureId, status: 'no-client' };
+
+  const { data: venture, error } = await supabase
+    .from('eva_ventures')
+    .select('id, name, status, current_stage, created_at, updated_at')
+    .eq('id', ventureId)
+    .maybeSingle();
+
+  if (error || !venture) {
+    return { ventureId, status: 'not-found', error: error?.message };
+  }
+
+  const currentStage = venture.current_stage || 0;
+  const inLaunchPhase = currentStage >= 23;
+
+  // Get latest gate results for launch stages
+  const { data: gateResults } = await supabase
+    .from('eva_stage_gate_results')
+    .select('stage_number, passed, gate_type, reasoning, created_at')
+    .eq('venture_id', ventureId)
+    .gte('stage_number', 22)
+    .order('stage_number', { ascending: true });
+
+  const launchGates = (gateResults || []).reduce((acc, g) => {
+    acc[`stage_${g.stage_number}`] = {
+      passed: g.passed,
+      gateType: g.gate_type,
+      reasoning: g.reasoning,
+      evaluatedAt: g.created_at,
+    };
+    return acc;
+  }, {});
+
+  return {
+    ventureId,
+    ventureName: venture.name,
+    status: venture.status,
+    currentStage,
+    inLaunchPhase,
+    launchReadiness: {
+      stage22Gate: launchGates.stage_22 || null,
+      stage24Gate: launchGates.stage_24 || null,
+      allGatesPassed: !!(launchGates.stage_22?.passed && launchGates.stage_24?.passed),
+    },
+    updatedAt: venture.updated_at,
+  };
+}
+
+/**
+ * Get go/no-go checklist for a venture's launch decision.
+ * Derives checklist items from chairman gate results at blocking stages.
+ *
+ * @param {string} ventureId - UUID of the venture
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object>} Checklist with items and overall readiness
+ */
+export async function getChecklist(ventureId, deps = {}) {
+  const { supabase } = deps;
+  if (!supabase) return { ventureId, items: [], ready: false };
+
+  // Chairman blocking gates for launch: 22 and 24
+  // Advisory gates: 23
+  const { data: gates } = await supabase
+    .from('eva_stage_gate_results')
+    .select('stage_number, passed, gate_type, reasoning, score, created_at')
+    .eq('venture_id', ventureId)
+    .gte('stage_number', 20)
+    .order('stage_number', { ascending: true });
+
+  const items = (gates || []).map((g) => ({
+    stage: g.stage_number,
+    label: STAGE_LABELS[g.stage_number] || `Stage ${g.stage_number}`,
+    type: BLOCKING_GATES.includes(g.stage_number) ? 'blocking' : 'advisory',
+    passed: g.passed,
+    score: g.score,
+    reasoning: g.reasoning,
+    evaluatedAt: g.created_at,
+  }));
+
+  const blockingItems = items.filter((i) => i.type === 'blocking');
+  const ready = blockingItems.length > 0 && blockingItems.every((i) => i.passed);
+
+  return { ventureId, items, ready, evaluatedCount: items.length };
+}
+
+/**
+ * Get stage progression timeline for a venture.
+ * Returns chronologically ordered stage completion events.
+ *
+ * @param {string} ventureId - UUID of the venture
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object>} Timeline with stage events
+ */
+export async function getTimeline(ventureId, deps = {}) {
+  const { supabase } = deps;
+  if (!supabase) return { ventureId, events: [] };
+
+  const { data: gates } = await supabase
+    .from('eva_stage_gate_results')
+    .select('stage_number, passed, gate_type, score, created_at')
+    .eq('venture_id', ventureId)
+    .order('created_at', { ascending: true });
+
+  const events = (gates || []).map((g) => ({
+    stage: g.stage_number,
+    label: STAGE_LABELS[g.stage_number] || `Stage ${g.stage_number}`,
+    passed: g.passed,
+    score: g.score,
+    timestamp: g.created_at,
+    phase: getPhaseForStage(g.stage_number),
+  }));
+
+  const { data: venture } = await supabase
+    .from('eva_ventures')
+    .select('current_stage, created_at')
+    .eq('id', ventureId)
+    .maybeSingle();
+
+  return {
+    ventureId,
+    currentStage: venture?.current_stage || 0,
+    startedAt: venture?.created_at || null,
+    events,
+    stageCount: events.length,
+  };
+}
+
+// Stage label reference
+const STAGE_LABELS = {
+  1: 'Idea Intake', 2: 'Market Sizing', 3: 'Problem Validation',
+  4: 'Competitive Landscape', 5: 'Business Model Canvas', 6: 'Technical Feasibility',
+  7: 'Financial Projections', 8: 'Risk Assessment', 9: 'Go-to-Market Strategy',
+  10: 'Investment Readiness', 11: 'Brand & Messaging', 12: 'Product Architecture',
+  13: 'MVP Definition', 14: 'Development Roadmap', 15: 'Resource Planning',
+  16: 'Quality Assurance Plan', 17: 'Security Review', 18: 'Compliance Check',
+  19: 'Partnership Strategy', 20: 'Customer Acquisition Plan',
+  21: 'Operational Readiness', 22: 'Pre-Launch Review',
+  23: 'Launch Execution', 24: 'Metrics & Learning', 25: 'Venture Review',
+};
+
+// Chairman blocking gates
+const BLOCKING_GATES = [3, 10, 22, 24];
+
+/**
+ * Get the operating phase for a given stage number.
+ */
+function getPhaseForStage(stageNumber) {
+  if (stageNumber <= 2) return 'EVALUATION';
+  if (stageNumber <= 5) return 'STRATEGY';
+  if (stageNumber <= 10) return 'PLANNING';
+  if (stageNumber <= 22) return 'BUILD';
+  return 'LAUNCH';
+}

--- a/server/index.js
+++ b/server/index.js
@@ -51,6 +51,7 @@ import venturesRoutes from './routes/ventures.js';
 import v2ApiRoutes from './routes/v2-apis.js';
 import chairmanRoutes from './routes/chairman.js';
 import evaOperationsRoutes from './routes/eva-operations.js';
+import evaLaunchRoutes from './routes/eva-launch.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 
 // Import Story API
@@ -144,6 +145,7 @@ app.use('/api/competitor-analysis', optionalAuth, venturesRoutes);
 app.use('/api/v2', optionalAuth, v2ApiRoutes);
 app.use('/api/chairman', optionalAuth, createChairmanScopeGuard({ blocking: true }), chairmanRoutes);
 app.use('/api/eva/operations', optionalAuth, evaOperationsRoutes);
+app.use('/api/eva/launch', optionalAuth, evaLaunchRoutes);
 // Dashboard routes: read-only, optional auth
 app.use('/api', optionalAuth, dashboardRoutes);
 

--- a/server/routes/eva-launch.js
+++ b/server/routes/eva-launch.js
@@ -1,0 +1,60 @@
+/**
+ * EVA Launch Workflow API Routes
+ *
+ * SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-J
+ *
+ * Exposes launch readiness, checklist, and timeline endpoints.
+ *
+ * @module server/routes/eva-launch
+ */
+
+import { Router } from 'express';
+
+const router = Router();
+
+/**
+ * GET /api/eva/launch/:ventureId/status
+ * Returns launch readiness status for a venture.
+ */
+router.get('/:ventureId/status', async (req, res) => {
+  try {
+    const { getLaunchStatus } = await import('../../lib/eva/launch-workflow/index.js');
+    const supabase = req.app.locals.supabase || req.supabase;
+    const status = await getLaunchStatus(req.params.ventureId, { supabase });
+    res.json(status);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to get launch status', message: err.message });
+  }
+});
+
+/**
+ * GET /api/eva/launch/:ventureId/checklist
+ * Returns go/no-go checklist derived from chairman gate results.
+ */
+router.get('/:ventureId/checklist', async (req, res) => {
+  try {
+    const { getChecklist } = await import('../../lib/eva/launch-workflow/index.js');
+    const supabase = req.app.locals.supabase || req.supabase;
+    const checklist = await getChecklist(req.params.ventureId, { supabase });
+    res.json(checklist);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to get checklist', message: err.message });
+  }
+});
+
+/**
+ * GET /api/eva/launch/:ventureId/timeline
+ * Returns stage progression timeline for a venture.
+ */
+router.get('/:ventureId/timeline', async (req, res) => {
+  try {
+    const { getTimeline } = await import('../../lib/eva/launch-workflow/index.js');
+    const supabase = req.app.locals.supabase || req.supabase;
+    const timeline = await getTimeline(req.params.ventureId, { supabase });
+    res.json(timeline);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to get timeline', message: err.message });
+  }
+});
+
+export default router;

--- a/tests/eva/launch-workflow.test.js
+++ b/tests/eva/launch-workflow.test.js
@@ -1,0 +1,153 @@
+/**
+ * Launch Workflow Module Tests
+ *
+ * SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-J
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { getLaunchStatus, getChecklist, getTimeline } from '../../lib/eva/launch-workflow/index.js';
+
+// Helper to create a mock supabase client
+function createMockSupabase(responses = {}) {
+  const chainable = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(responses.venture || { data: null, error: null }),
+  };
+
+  // For queries that end with maybeSingle vs those that don't
+  let callCount = 0;
+  const from = vi.fn().mockImplementation((table) => {
+    if (table === 'eva_ventures') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue(
+              responses.venture || { data: null, error: null }
+            ),
+            gte: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue(
+                responses.gates || { data: [], error: null }
+              ),
+            }),
+          }),
+        }),
+      };
+    }
+    if (table === 'eva_stage_gate_results') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            gte: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue(
+                responses.gates || { data: [], error: null }
+              ),
+            }),
+            order: vi.fn().mockResolvedValue(
+              responses.gates || { data: [], error: null }
+            ),
+          }),
+        }),
+      };
+    }
+    return chainable;
+  });
+
+  return { from };
+}
+
+describe('Launch Workflow Module', () => {
+  describe('getLaunchStatus', () => {
+    it('returns no-client when supabase is missing', async () => {
+      const result = await getLaunchStatus('test-id');
+      expect(result).toEqual({ ventureId: 'test-id', status: 'no-client' });
+    });
+
+    it('returns not-found when venture does not exist', async () => {
+      const supabase = createMockSupabase({
+        venture: { data: null, error: null },
+      });
+      const result = await getLaunchStatus('missing-id', { supabase });
+      expect(result.status).toBe('not-found');
+    });
+
+    it('returns launch status for a venture in launch phase', async () => {
+      const supabase = createMockSupabase({
+        venture: {
+          data: {
+            id: 'v1', name: 'Test Venture', status: 'active',
+            current_stage: 23, created_at: '2026-01-01', updated_at: '2026-03-01',
+          },
+          error: null,
+        },
+        gates: {
+          data: [
+            { stage_number: 22, passed: true, gate_type: 'chairman', reasoning: 'Good', created_at: '2026-02-01' },
+            { stage_number: 24, passed: false, gate_type: 'chairman', reasoning: 'Needs work', created_at: '2026-03-01' },
+          ],
+          error: null,
+        },
+      });
+
+      const result = await getLaunchStatus('v1', { supabase });
+      expect(result.inLaunchPhase).toBe(true);
+      expect(result.ventureName).toBe('Test Venture');
+      expect(result.currentStage).toBe(23);
+    });
+  });
+
+  describe('getChecklist', () => {
+    it('returns empty checklist without supabase', async () => {
+      const result = await getChecklist('test-id');
+      expect(result).toEqual({ ventureId: 'test-id', items: [], ready: false });
+    });
+
+    it('returns checklist items from gate results', async () => {
+      const supabase = createMockSupabase({
+        gates: {
+          data: [
+            { stage_number: 22, passed: true, gate_type: 'chairman', reasoning: 'OK', score: 90, created_at: '2026-02-01' },
+            { stage_number: 23, passed: true, gate_type: 'advisory', reasoning: 'Good', score: 85, created_at: '2026-02-15' },
+          ],
+          error: null,
+        },
+      });
+
+      const result = await getChecklist('v1', { supabase });
+      expect(result.evaluatedCount).toBe(2);
+      expect(result.items.length).toBe(2);
+    });
+  });
+
+  describe('getTimeline', () => {
+    it('returns empty timeline without supabase', async () => {
+      const result = await getTimeline('test-id');
+      expect(result).toEqual({ ventureId: 'test-id', events: [] });
+    });
+
+    it('maps phase correctly for stage numbers', async () => {
+      const supabase = createMockSupabase({
+        venture: {
+          data: { current_stage: 5, created_at: '2026-01-01' },
+          error: null,
+        },
+        gates: {
+          data: [
+            { stage_number: 1, passed: true, gate_type: 'auto', score: 80, created_at: '2026-01-05' },
+            { stage_number: 5, passed: true, gate_type: 'auto', score: 75, created_at: '2026-01-20' },
+            { stage_number: 23, passed: false, gate_type: 'chairman', score: 50, created_at: '2026-02-01' },
+          ],
+          error: null,
+        },
+      });
+
+      const result = await getTimeline('v1', { supabase });
+      expect(result.stageCount).toBe(3);
+      expect(result.events[0].phase).toBe('EVALUATION');
+      expect(result.events[1].phase).toBe('STRATEGY');
+      expect(result.events[2].phase).toBe('LAUNCH');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add launch readiness status API (`/api/eva/launch/:ventureId/status`)
- Add go/no-go checklist API (`/api/eva/launch/:ventureId/checklist`)
- Add stage progression timeline API (`/api/eva/launch/:ventureId/timeline`)
- 7 unit tests passing

SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-J (child of EVA 25-Stage Pipeline Redesign orchestrator)

## Test plan
- [x] 7/7 vitest tests pass
- [x] All 3 endpoints return properly structured JSON
- [x] Route registered in server/index.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)