### PR TITLE
feat: add pipeline data aggregation API for EVA stages 10-12

### DIFF
--- a/lib/eva/pipeline-data/index.js
+++ b/lib/eva/pipeline-data/index.js
@@ -1,0 +1,259 @@
+/**
+ * Pipeline Data Aggregation Module — Stages 10-12 Data for GUI
+ *
+ * SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-K
+ *
+ * Aggregates stage data from venture_stage_work, venture_artifacts,
+ * and brand_genome_submissions for frontend dashboard consumption.
+ *
+ * @module lib/eva/pipeline-data
+ */
+
+/**
+ * Get customer intelligence data (Stage 10).
+ * Returns customer personas and brand genome summary.
+ *
+ * @param {string} ventureId - UUID of the venture
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object>} Customer intelligence data
+ */
+export async function getCustomerIntelligence(ventureId, deps = {}) {
+  const { supabase } = deps;
+  if (!supabase) return { ventureId, status: 'no-client' };
+
+  // Get stage 10 artifacts (customer personas, brand genome)
+  const { data: artifacts } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_type, content, quality_score, created_at')
+    .eq('venture_id', ventureId)
+    .in('artifact_type', ['customer_persona', 'brand_genome', 'positioning_statement'])
+    .order('created_at', { ascending: false });
+
+  // Get brand genome submission
+  const { data: brandGenome } = await supabase
+    .from('brand_genome_submissions')
+    .select('brand_data, completeness_score, submission_status, created_at')
+    .eq('venture_id', ventureId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  // Get stage work status
+  const { data: stageWork } = await supabase
+    .from('venture_stage_work')
+    .select('stage_status, health_score, updated_at')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', 10)
+    .maybeSingle();
+
+  const personas = (artifacts || []).filter(a => a.artifact_type === 'customer_persona');
+  const positioning = (artifacts || []).find(a => a.artifact_type === 'positioning_statement');
+
+  return {
+    ventureId,
+    stage: 10,
+    label: 'Customer & Brand Foundation',
+    status: stageWork?.stage_status || 'not_started',
+    healthScore: stageWork?.health_score || null,
+    personas: personas.map(p => ({
+      content: p.content,
+      qualityScore: p.quality_score,
+      createdAt: p.created_at,
+    })),
+    brandGenome: brandGenome ? {
+      data: brandGenome.brand_data,
+      completeness: brandGenome.completeness_score,
+      status: brandGenome.submission_status,
+      updatedAt: brandGenome.created_at,
+    } : null,
+    positioning: positioning ? {
+      content: positioning.content,
+      qualityScore: positioning.quality_score,
+    } : null,
+    updatedAt: stageWork?.updated_at || null,
+  };
+}
+
+/**
+ * Get brand genome and visual identity data (Stage 11).
+ * Returns naming candidates, visual identity, and brand expression.
+ *
+ * @param {string} ventureId - UUID of the venture
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object>} Brand genome data
+ */
+export async function getBrandGenomeData(ventureId, deps = {}) {
+  const { supabase } = deps;
+  if (!supabase) return { ventureId, status: 'no-client' };
+
+  const { data: artifacts } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_type, content, quality_score, created_at')
+    .eq('venture_id', ventureId)
+    .in('artifact_type', ['naming_candidate', 'visual_identity', 'brand_expression'])
+    .order('created_at', { ascending: false });
+
+  const { data: stageWork } = await supabase
+    .from('venture_stage_work')
+    .select('stage_status, health_score, updated_at')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', 11)
+    .maybeSingle();
+
+  const namingCandidates = (artifacts || []).filter(a => a.artifact_type === 'naming_candidate');
+  const visualIdentity = (artifacts || []).find(a => a.artifact_type === 'visual_identity');
+  const brandExpression = (artifacts || []).find(a => a.artifact_type === 'brand_expression');
+
+  return {
+    ventureId,
+    stage: 11,
+    label: 'Naming & Visual Identity',
+    status: stageWork?.stage_status || 'not_started',
+    healthScore: stageWork?.health_score || null,
+    namingCandidates: namingCandidates.map(n => ({
+      content: n.content,
+      qualityScore: n.quality_score,
+      createdAt: n.created_at,
+    })),
+    visualIdentity: visualIdentity ? {
+      content: visualIdentity.content,
+      qualityScore: visualIdentity.quality_score,
+    } : null,
+    brandExpression: brandExpression ? {
+      content: brandExpression.content,
+      qualityScore: brandExpression.quality_score,
+    } : null,
+    updatedAt: stageWork?.updated_at || null,
+  };
+}
+
+/**
+ * Get GTM strategy data (Stage 12).
+ * Returns market tiers, channels, sales model, and customer journey.
+ *
+ * @param {string} ventureId - UUID of the venture
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object>} GTM strategy data
+ */
+export async function getGtmStrategy(ventureId, deps = {}) {
+  const { supabase } = deps;
+  if (!supabase) return { ventureId, status: 'no-client' };
+
+  const { data: artifacts } = await supabase
+    .from('venture_artifacts')
+    .select('artifact_type, content, quality_score, created_at')
+    .eq('venture_id', ventureId)
+    .in('artifact_type', ['market_tier', 'channel_strategy', 'sales_playbook', 'customer_journey'])
+    .order('created_at', { ascending: false });
+
+  const { data: stageWork } = await supabase
+    .from('venture_stage_work')
+    .select('stage_status, health_score, updated_at')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', 12)
+    .maybeSingle();
+
+  const marketTiers = (artifacts || []).filter(a => a.artifact_type === 'market_tier');
+  const channels = (artifacts || []).filter(a => a.artifact_type === 'channel_strategy');
+  const salesPlaybook = (artifacts || []).find(a => a.artifact_type === 'sales_playbook');
+  const customerJourney = (artifacts || []).find(a => a.artifact_type === 'customer_journey');
+
+  return {
+    ventureId,
+    stage: 12,
+    label: 'GTM & Sales Strategy',
+    status: stageWork?.stage_status || 'not_started',
+    healthScore: stageWork?.health_score || null,
+    marketTiers: marketTiers.map(t => ({
+      content: t.content,
+      qualityScore: t.quality_score,
+    })),
+    channels: channels.map(c => ({
+      content: c.content,
+      qualityScore: c.quality_score,
+    })),
+    salesPlaybook: salesPlaybook ? {
+      content: salesPlaybook.content,
+      qualityScore: salesPlaybook.quality_score,
+    } : null,
+    customerJourney: customerJourney ? {
+      content: customerJourney.content,
+      qualityScore: customerJourney.quality_score,
+    } : null,
+    updatedAt: stageWork?.updated_at || null,
+  };
+}
+
+/**
+ * Get pipeline summary for stages 10-12.
+ * Returns aggregated completion status and health scores.
+ *
+ * @param {string} ventureId - UUID of the venture
+ * @param {Object} deps
+ * @param {Object} deps.supabase - Supabase client
+ * @returns {Promise<Object>} Pipeline summary
+ */
+export async function getPipelineSummary(ventureId, deps = {}) {
+  const { supabase } = deps;
+  if (!supabase) return { ventureId, stages: {} };
+
+  const { data: stageWork } = await supabase
+    .from('venture_stage_work')
+    .select('lifecycle_stage, stage_status, health_score, updated_at')
+    .eq('venture_id', ventureId)
+    .gte('lifecycle_stage', 10)
+    .lte('lifecycle_stage', 12)
+    .order('lifecycle_stage', { ascending: true });
+
+  const stages = {};
+  for (const stage of (stageWork || [])) {
+    stages[`stage_${stage.lifecycle_stage}`] = {
+      stage: stage.lifecycle_stage,
+      label: STAGE_LABELS[stage.lifecycle_stage],
+      status: stage.stage_status,
+      healthScore: stage.health_score,
+      updatedAt: stage.updated_at,
+    };
+  }
+
+  // Fill missing stages
+  for (let i = 10; i <= 12; i++) {
+    if (!stages[`stage_${i}`]) {
+      stages[`stage_${i}`] = {
+        stage: i,
+        label: STAGE_LABELS[i],
+        status: 'not_started',
+        healthScore: null,
+        updatedAt: null,
+      };
+    }
+  }
+
+  const completedCount = Object.values(stages).filter(s => s.status === 'completed').length;
+
+  return {
+    ventureId,
+    stages,
+    completion: {
+      total: 3,
+      completed: completedCount,
+      percentage: Math.round((completedCount / 3) * 100),
+    },
+    overallHealth: computeOverallHealth(Object.values(stages)),
+  };
+}
+
+const STAGE_LABELS = {
+  10: 'Customer & Brand Foundation',
+  11: 'Naming & Visual Identity',
+  12: 'GTM & Sales Strategy',
+};
+
+function computeOverallHealth(stages) {
+  const scores = stages.map(s => s.healthScore).filter(s => s != null);
+  if (scores.length === 0) return null;
+  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+}

--- a/server/index.js
+++ b/server/index.js
@@ -52,6 +52,7 @@ import v2ApiRoutes from './routes/v2-apis.js';
 import chairmanRoutes from './routes/chairman.js';
 import evaOperationsRoutes from './routes/eva-operations.js';
 import evaLaunchRoutes from './routes/eva-launch.js';
+import evaPipelineRoutes from './routes/eva-pipeline.js';
 import { createChairmanScopeGuard } from '../lib/middleware/chairman-scope-guard.js';
 
 // Import Story API
@@ -146,6 +147,7 @@ app.use('/api/v2', optionalAuth, v2ApiRoutes);
 app.use('/api/chairman', optionalAuth, createChairmanScopeGuard({ blocking: true }), chairmanRoutes);
 app.use('/api/eva/operations', optionalAuth, evaOperationsRoutes);
 app.use('/api/eva/launch', optionalAuth, evaLaunchRoutes);
+app.use('/api/eva/pipeline', optionalAuth, evaPipelineRoutes);
 // Dashboard routes: read-only, optional auth
 app.use('/api', optionalAuth, dashboardRoutes);
 

--- a/server/routes/eva-pipeline.js
+++ b/server/routes/eva-pipeline.js
@@ -1,0 +1,75 @@
+/**
+ * EVA Pipeline Data API Routes
+ *
+ * SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-K
+ *
+ * Exposes stage 10-12 data aggregation endpoints for GUI dashboards.
+ *
+ * @module server/routes/eva-pipeline
+ */
+
+import { Router } from 'express';
+
+const router = Router();
+
+/**
+ * GET /api/eva/pipeline/:ventureId/customer-intelligence
+ * Returns Stage 10 customer personas and brand genome data.
+ */
+router.get('/:ventureId/customer-intelligence', async (req, res) => {
+  try {
+    const { getCustomerIntelligence } = await import('../../lib/eva/pipeline-data/index.js');
+    const supabase = req.app.locals.supabase || req.supabase;
+    const data = await getCustomerIntelligence(req.params.ventureId, { supabase });
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to get customer intelligence', message: err.message });
+  }
+});
+
+/**
+ * GET /api/eva/pipeline/:ventureId/brand-genome
+ * Returns Stage 11 visual identity and naming data.
+ */
+router.get('/:ventureId/brand-genome', async (req, res) => {
+  try {
+    const { getBrandGenomeData } = await import('../../lib/eva/pipeline-data/index.js');
+    const supabase = req.app.locals.supabase || req.supabase;
+    const data = await getBrandGenomeData(req.params.ventureId, { supabase });
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to get brand genome data', message: err.message });
+  }
+});
+
+/**
+ * GET /api/eva/pipeline/:ventureId/gtm-strategy
+ * Returns Stage 12 market tiers, channels, and sales model.
+ */
+router.get('/:ventureId/gtm-strategy', async (req, res) => {
+  try {
+    const { getGtmStrategy } = await import('../../lib/eva/pipeline-data/index.js');
+    const supabase = req.app.locals.supabase || req.supabase;
+    const data = await getGtmStrategy(req.params.ventureId, { supabase });
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to get GTM strategy', message: err.message });
+  }
+});
+
+/**
+ * GET /api/eva/pipeline/:ventureId/summary
+ * Returns aggregated pipeline summary for stages 10-12.
+ */
+router.get('/:ventureId/summary', async (req, res) => {
+  try {
+    const { getPipelineSummary } = await import('../../lib/eva/pipeline-data/index.js');
+    const supabase = req.app.locals.supabase || req.supabase;
+    const data = await getPipelineSummary(req.params.ventureId, { supabase });
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to get pipeline summary', message: err.message });
+  }
+});
+
+export default router;

--- a/tests/eva/pipeline-data.test.js
+++ b/tests/eva/pipeline-data.test.js
@@ -1,0 +1,161 @@
+/**
+ * Tests for Pipeline Data Aggregation Module (Stages 10-12)
+ * SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-K
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getCustomerIntelligence,
+  getBrandGenomeData,
+  getGtmStrategy,
+  getPipelineSummary,
+} from '../../lib/eva/pipeline-data/index.js';
+
+// Mock supabase client helper
+function mockSupabase(tables = {}) {
+  return {
+    from(table) {
+      const tableData = tables[table] || [];
+      const chain = {
+        _filters: [],
+        select() { return chain; },
+        eq() { return chain; },
+        in() { return chain; },
+        gte() { return chain; },
+        lte() { return chain; },
+        order() { return chain; },
+        limit() { return chain; },
+        maybeSingle() {
+          return Promise.resolve({ data: Array.isArray(tableData) ? tableData[0] || null : tableData, error: null });
+        },
+        then(resolve) {
+          return Promise.resolve({ data: tableData, error: null }).then(resolve);
+        },
+      };
+      // Make chain thenable for direct await
+      chain[Symbol.for('nodejs.util.inspect.custom')] = () => '[MockChain]';
+      return chain;
+    },
+  };
+}
+
+describe('getCustomerIntelligence (Stage 10)', () => {
+  it('returns no-client when supabase is missing', async () => {
+    const result = await getCustomerIntelligence('v1');
+    expect(result).toEqual({ ventureId: 'v1', status: 'no-client' });
+  });
+
+  it('returns structured stage 10 data', async () => {
+    const supabase = mockSupabase({
+      venture_artifacts: [
+        { artifact_type: 'customer_persona', content: { name: 'Persona A' }, quality_score: 85, created_at: '2026-01-01' },
+        { artifact_type: 'positioning_statement', content: { statement: 'We are...' }, quality_score: 90, created_at: '2026-01-02' },
+      ],
+      brand_genome_submissions: { brand_data: { tone: 'bold' }, completeness_score: 75, submission_status: 'draft', created_at: '2026-01-01' },
+      venture_stage_work: { stage_status: 'in_progress', health_score: 80, updated_at: '2026-01-03' },
+    });
+
+    const result = await getCustomerIntelligence('v1', { supabase });
+    expect(result.ventureId).toBe('v1');
+    expect(result.stage).toBe(10);
+    expect(result.label).toBe('Customer & Brand Foundation');
+    expect(result.status).toBe('in_progress');
+    expect(result.healthScore).toBe(80);
+  });
+
+  it('handles empty artifacts gracefully', async () => {
+    const supabase = mockSupabase({
+      venture_artifacts: [],
+      brand_genome_submissions: null,
+      venture_stage_work: null,
+    });
+
+    const result = await getCustomerIntelligence('v1', { supabase });
+    expect(result.personas).toEqual([]);
+    expect(result.brandGenome).toBeNull();
+    expect(result.positioning).toBeNull();
+    expect(result.status).toBe('not_started');
+  });
+});
+
+describe('getBrandGenomeData (Stage 11)', () => {
+  it('returns no-client when supabase is missing', async () => {
+    const result = await getBrandGenomeData('v1');
+    expect(result).toEqual({ ventureId: 'v1', status: 'no-client' });
+  });
+
+  it('returns structured stage 11 data', async () => {
+    const supabase = mockSupabase({
+      venture_artifacts: [
+        { artifact_type: 'naming_candidate', content: { name: 'BrandX' }, quality_score: 88, created_at: '2026-01-01' },
+      ],
+      venture_stage_work: { stage_status: 'completed', health_score: 95, updated_at: '2026-01-05' },
+    });
+
+    const result = await getBrandGenomeData('v1', { supabase });
+    expect(result.stage).toBe(11);
+    expect(result.label).toBe('Naming & Visual Identity');
+    expect(result.status).toBe('completed');
+    expect(result.namingCandidates).toHaveLength(1);
+  });
+});
+
+describe('getGtmStrategy (Stage 12)', () => {
+  it('returns no-client when supabase is missing', async () => {
+    const result = await getGtmStrategy('v1');
+    expect(result).toEqual({ ventureId: 'v1', status: 'no-client' });
+  });
+
+  it('returns structured stage 12 data', async () => {
+    const supabase = mockSupabase({
+      venture_artifacts: [
+        { artifact_type: 'market_tier', content: { tier: 'enterprise' }, quality_score: 82, created_at: '2026-01-01' },
+        { artifact_type: 'channel_strategy', content: { channel: 'direct' }, quality_score: 78, created_at: '2026-01-02' },
+      ],
+      venture_stage_work: { stage_status: 'in_progress', health_score: 70, updated_at: '2026-01-04' },
+    });
+
+    const result = await getGtmStrategy('v1', { supabase });
+    expect(result.stage).toBe(12);
+    expect(result.label).toBe('GTM & Sales Strategy');
+    expect(result.marketTiers).toHaveLength(1);
+    expect(result.channels).toHaveLength(1);
+  });
+});
+
+describe('getPipelineSummary', () => {
+  it('returns empty stages when supabase is missing', async () => {
+    const result = await getPipelineSummary('v1');
+    expect(result).toEqual({ ventureId: 'v1', stages: {} });
+  });
+
+  it('fills missing stages with not_started', async () => {
+    const supabase = mockSupabase({
+      venture_stage_work: [
+        { lifecycle_stage: 10, stage_status: 'completed', health_score: 90, updated_at: '2026-01-01' },
+      ],
+    });
+
+    const result = await getPipelineSummary('v1', { supabase });
+    expect(result.stages.stage_10.status).toBe('completed');
+    expect(result.stages.stage_11.status).toBe('not_started');
+    expect(result.stages.stage_12.status).toBe('not_started');
+    expect(result.completion.completed).toBe(1);
+    expect(result.completion.percentage).toBe(33);
+  });
+
+  it('computes overall health from available scores', async () => {
+    const supabase = mockSupabase({
+      venture_stage_work: [
+        { lifecycle_stage: 10, stage_status: 'completed', health_score: 80, updated_at: '2026-01-01' },
+        { lifecycle_stage: 11, stage_status: 'completed', health_score: 90, updated_at: '2026-01-02' },
+        { lifecycle_stage: 12, stage_status: 'completed', health_score: 100, updated_at: '2026-01-03' },
+      ],
+    });
+
+    const result = await getPipelineSummary('v1', { supabase });
+    expect(result.completion.completed).toBe(3);
+    expect(result.completion.percentage).toBe(100);
+    expect(result.overallHealth).toBe(90);
+  });
+});


### PR DESCRIPTION
## Summary
- Added `lib/eva/pipeline-data/index.js` with 4 data aggregation functions for stages 10-12
- Added `server/routes/eva-pipeline.js` with REST endpoints: customer-intelligence, brand-genome, gtm-strategy, summary
- Registered route in `server/index.js` at `/api/eva/pipeline`
- 10 vitest tests covering all functions and edge cases

SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-K (Pipeline-to-GUI Wiring)
Parent: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001 (Child 11/11 - FINAL)

## Test plan
- [x] 10/10 vitest tests passing
- [x] No-client fallback returns structured response
- [x] Empty data handled gracefully
- [x] Health score computation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)