### PR TITLE
fix: update E2E stage runner and docs after orchestrator pipeline changes

### DIFF
--- a/docs/eva/e2e-stage-test-report.md
+++ b/docs/eva/e2e-stage-test-report.md
@@ -1,14 +1,14 @@
 ---
 category: general
-status: draft
-version: 1.0.0
+status: approved
+version: 2.0.0
 author: auto-fixer
-last_updated: 2026-02-28
-tags: [general, auto-generated]
+last_updated: 2026-03-05
+tags: [eva, testing, e2e, stage-templates, regression]
 ---
 # EVA E2E Stage Test Report
 
-**Date**: 2026-02-15
+**Date**: 2026-03-05
 **Harness**: `scripts/e2e-stage-runner.mjs`
 **Result**: 25/25 stages PASS, 0 findings
 
@@ -25,8 +25,9 @@ For each of the 25 stages, the harness validates:
 ### Gate Validation
 | Gate Type | Stages | Tests | Result |
 |-----------|--------|-------|--------|
-| Kill Gate (pass path) | 3, 5, 13, 23 | Valid data yields `pass` | PASS |
-| Kill Gate (kill path) | 3, 5, 13, 23 | Empty/bad data yields `kill` | PASS |
+| Kill Gate (pass path) | 3, 5, 13 | Valid data yields `pass` | PASS |
+| Kill Gate (kill path) | 3, 5, 13 | Empty/bad data yields `kill` | PASS |
+| Release Readiness (Stage 23) | 23 | `checkReleaseReadiness()` pass/fail | PASS |
 | Reality Gate (Stage 12) | 12 | Local gate with prerequisites | PASS |
 | Promotion Gate (Stage 16) | 16 | Phase 4->5 with stages 13-16 | PASS |
 | Promotion Gate (Stage 22) | 22 | Phase 5->6 with stages 17-22 | PASS |
@@ -45,7 +46,26 @@ For each of the 25 stages, the harness validates:
 
 ## Issues Fixed During Testing
 
-During development of the test harness, 5 test data generators needed corrections to match actual stage schemas:
+### v2.0.0 — Orchestrator Pipeline Changes (2026-03-05)
+
+After SD-LEO-ORCH-EVA-STAGE-PIPELINE-001 (11 children, A-K) restructured the 25-stage pipeline, 8 test data generators needed updates to match the new template schemas:
+
+| Stage | Issue | Fix |
+|-------|-------|-----|
+| 02 | Missing `designQuality` metric (7th metric added by orchestrator) | Added `designQuality: 68` to metrics and `growth`, `revenue`, `design` evidence fields |
+| 03 | Missing `designQuality` in root-level data and kill gate test cases | Added `designQuality: 68` to genStage03 and all 3 kill gate test scenarios |
+| 10 | Complete schema rewrite: now Customer & Brand Foundation with personas, brandGenome, customerAlignment, chairmanGate | Full rewrite: 3 customerPersonas with demographics/goals/painPoints, brandGenome with customerAlignment array, chairmanGate status='approved' |
+| 11 | Complete schema rewrite: now Naming & Visual Identity with namingStrategy object, candidates with personaFit, visualIdentity | Full rewrite: namingStrategy as `{approach, rationale}`, 5 candidates with personaFit arrays, visualIdentity with colorPalette/typography/imageryGuidance |
+| 12 | Complete schema rewrite: now GTM & Sales Strategy with marketTiers (3), channels (8), salesModel (camelCase) | Full rewrite: exactly 3 marketTiers, 8 channels with budget/cac/kpi, salesModel enum, kept deal_stages/funnel_stages/customer_journey |
+| 23 | Complete schema rewrite: now Marketing Preparation with marketing_items, no longer a kill gate | Full rewrite: marketing_items using MARKETING_ITEM_TYPES enum, marketing_strategy_summary, target_audience. Gate test changed from kill gate to `checkReleaseReadiness()` |
+| 24 | Complete schema rewrite: now Launch Readiness with readiness_checklist, chairmanGate, computeDerived takes 3 args | Full rewrite: readiness_checklist (4 keys), incident_response_plan, monitoring_setup, rollback_plan, chairmanGate. Added to STAGES_WITH_EXTRA_COMPUTE |
+| 25 | Complete schema rewrite: now Launch Execution with distribution_channels, operations_handoff | Full rewrite: distribution_channels with CHANNEL_STATUSES, operations_handoff with monitoring/escalation/maintenance, launch_summary |
+
+**Note**: All issues were in test data generators, not in the stage templates themselves. The templates were updated correctly by the orchestrator children.
+
+### v1.0.0 — Initial Harness (2026-02-15)
+
+During initial development, 5 test data generators needed corrections:
 
 | Stage | Issue | Fix |
 |-------|-------|-----|
@@ -54,8 +74,6 @@ During development of the test harness, 5 test data generators needed correction
 | 06 | Missing `id`, `severity` (int), `owner`, `review_date`; strings too short | Added all required fields, used integer severity 1-5 |
 | 12 | Missing `sales_model`, `deal_stages[]`; `funnel_stages` and `customer_journey` had wrong sub-fields | Added `sales_model` enum, `deal_stages[]`, fixed `metric`/`target_value`/`funnel_stage`/`touchpoint` |
 | 13 | Used `target_date` (wrong); missing `phases[]`; `timeline_months` is derived not input | Changed to `date` with parseable dates, added `phases[]`, removed `timeline_months` |
-
-**Note**: All issues were in test data generators, not in the stage templates themselves. The templates are correct.
 
 ## Deferred Items
 

--- a/docs/guides/testing/eva-stage-regression-guide.md
+++ b/docs/guides/testing/eva-stage-regression-guide.md
@@ -1,9 +1,9 @@
 ---
 category: guide
 status: approved
-version: 1.0.0
+version: 1.1.0
 author: DOCMON Sub-Agent
-last_updated: 2026-03-04
+last_updated: 2026-03-05
 tags: [eva, testing, regression, e2e, stage-templates]
 ---
 
@@ -13,9 +13,9 @@ tags: [eva, testing, regression, e2e, stage-templates]
 
 - **Category**: Guide
 - **Status**: Approved
-- **Version**: 1.0.0
+- **Version**: 1.1.0
 - **Author**: DOCMON Sub-Agent
-- **Last Updated**: 2026-03-04
+- **Last Updated**: 2026-03-05
 - **Tags**: [eva, testing, regression, e2e, stage-templates]
 
 ## Overview
@@ -52,14 +52,14 @@ Two layers, complementary purposes:
 4. `computeDerived()` executes and returns correct shape
 5. Every schema key exists in `defaultData`
 
-Plus 4 gate suites: kill gates (Stages 3, 5, 13, 23), reality gates (Stage 9, 12), promotion gates (Stages 16, 22), decision filter engine.
+Plus gate suites: kill gates (Stages 3, 5, 13), release readiness (Stage 23), reality gates (Stage 9, 12), promotion gates (Stages 16, 22), decision filter engine.
 
 **Unit Tests** — deeper per-stage assertions in `tests/unit/eva/stage-templates/`:
 - Enum constraints, string minLength, integer ranges, array minItems
 - Derived field correctness, weighted scoring, decision logic
 - Cross-stage contract matching (Stage N output → Stage N+1 `consume`)
 - Constants (MIN_CANDIDATES, WEIGHT_SUM, APPROVAL_STATUSES, etc.)
-- Chairman gate enforcement (Stages 10, 22, 25)
+- Chairman gate enforcement (Stages 10, 22, 24)
 
 ---
 
@@ -147,7 +147,8 @@ Phase 1: THE TRUTH (Stages 1-5)
   ...
 
 Gate Tests
-  ✓ Kill gates (Stages 3, 5, 13, 23)
+  ✓ Kill gates (Stages 3, 5, 13)
+  ✓ Release readiness (Stage 23)
   ✓ Reality gates
   ✓ Decision filter engine
   ✓ Reality gate module boundaries
@@ -241,7 +242,7 @@ For the deferred items, see `brainstorm/2026-03-04-systemic-audit-findings-remed
 
 ## Related Documentation
 
-- **Test report** (last clean run, 2026-02-15): [`docs/eva/e2e-stage-test-report.md`](../../eva/e2e-stage-test-report.md)
+- **Test report** (last clean run, 2026-03-05): [`docs/eva/e2e-stage-test-report.md`](../../eva/e2e-stage-test-report.md)
 - **Full testing guide** (orchestrator, integration, UAT): [`docs/guides/workflow/cli-venture-lifecycle/guides/testing-guide.md`](../workflow/cli-venture-lifecycle/guides/testing-guide.md)
 - **Audit findings and remediation**: [`brainstorm/2026-03-04-systemic-audit-findings-remediation.md`](../../../brainstorm/2026-03-04-systemic-audit-findings-remediation.md)
 - **Stage lifecycle overview**: [`docs/guides/workflow/25-stage-venture-lifecycle-overview.md`](../workflow/25-stage-venture-lifecycle-overview.md)
@@ -253,4 +254,5 @@ For the deferred items, see `brainstorm/2026-03-04-systemic-audit-findings-remed
 ---
 
 *Version History*
+- **v1.1.0** (2026-03-05): Updated gate references after orchestrator SD-LEO-ORCH-EVA-STAGE-PIPELINE-001. Stage 23 is now release readiness (not kill gate). Stage 24 added as chairman gate. Test report link updated.
 - **v1.0.0** (2026-03-04): Initial runbook. Captures regression suite built during March 2026 systemic audit (PRs #1747–#1773).

--- a/scripts/e2e-stage-runner.mjs
+++ b/scripts/e2e-stage-runner.mjs
@@ -44,12 +44,16 @@ function genStage02() {
     metrics: {
       marketFit: 75, customerNeed: 80, momentum: 65,
       revenuePotential: 70, competitiveBarrier: 60, executionFeasibility: 72,
+      designQuality: 68,
     },
     evidence: {
       market: 'TAM analysis shows $50B global artisan goods market growing at 8% CAGR',
       customer: '200 artisan interviews confirm logistics as top pain point',
+      growth: 'Artisan economy growing at 8% CAGR with increasing online adoption',
+      revenue: 'Transaction-based revenue model with 15% take rate validated by comparable marketplaces',
       competitive: 'No AI-powered artisan marketplace exists; closest is Etsy (manual matching)',
       execution: 'Team has relevant marketplace and AI experience from prior ventures',
+      design: 'UX research confirms mobile-first approach resonates with artisan seller demographic',
     },
     suggestions: [
       { type: 'immediate', text: 'Validate pricing with 50 target artisan users in pilot region' },
@@ -62,6 +66,7 @@ function genStage03() {
   return {
     marketFit: 75, customerNeed: 80, momentum: 65,
     revenuePotential: 70, competitiveBarrier: 60, executionFeasibility: 72,
+    designQuality: 68,
     competitorEntities: [
       { name: 'CompetitorA', positioning: 'Market leader', threat_level: 'H' },
       { name: 'CompetitorB', positioning: 'Niche player', threat_level: 'M' },
@@ -191,6 +196,15 @@ function genStage09() {
 }
 
 function genStage10() {
+  const personaNames = ['Small Artisan Producer', 'Boutique Gallery Owner', 'Craft-Conscious Consumer'];
+  const customerPersonas = personaNames.map((name, i) => ({
+    name,
+    demographics: { age: '25-45', location: `Region ${i + 1}`, income: 'Middle' },
+    goals: [`Expand market reach ${i + 1}`, `Increase revenue ${i + 1}`],
+    painPoints: [`High logistics cost ${i + 1}`, `Limited online presence ${i + 1}`],
+    behaviors: [`Social media active ${i + 1}`],
+    motivations: [`Financial growth ${i + 1}`],
+  }));
   const criteria = [
     { name: 'memorability', weight: 25 },
     { name: 'relevance', weight: 25 },
@@ -201,37 +215,71 @@ function genStage10() {
   const candidates = [];
   for (let i = 0; i < 5; i++) {
     const scores = {};
-    for (const c of criteria) {
-      scores[c.name] = 60 + Math.floor(Math.random() * 30);
-    }
-    candidates.push({
-      name: `BrandName${i + 1}`,
-      rationale: `Rationale for candidate ${i + 1}`,
-      scores,
-    });
+    for (const c of criteria) scores[c.name] = 60 + (i * 5 + 10);
+    candidates.push({ name: `BrandName${i + 1}`, rationale: `Rationale for candidate ${i + 1}`, scores });
   }
   return {
+    customerPersonas,
     brandGenome: {
-      archetype: 'marketplace',
+      archetype: 'Explorer',
       values: ['trust', 'craft'],
       tone: 'Warm and professional',
       audience: 'Small artisan businesses',
       differentiators: ['AI logistics', 'Global reach'],
+      customerAlignment: [
+        { trait: 'trust', personaInsight: 'Artisans value reliable partnerships', personaName: personaNames[0] },
+        { trait: 'craft', personaInsight: 'Gallery owners seek authentic brands', personaName: personaNames[1] },
+      ],
     },
+    brandPersonality: { vision: 'Empower artisans globally', mission: 'Connect craft to commerce', brandVoice: 'Warm, authentic, empowering' },
     scoringCriteria: criteria,
     candidates,
-    narrativeExtension: { vision: 'Empower artisans globally', mission: 'Connect craft to commerce', brandVoice: 'Warm, authentic, empowering' },
     namingStrategy: 'descriptive',
     chairmanGate: { status: 'approved', rationale: 'Brand direction approved', decision_id: 'test-decision-10' },
   };
 }
 
 function genStage11() {
+  const criteria = [
+    { name: 'memorability', weight: 25 },
+    { name: 'relevance', weight: 25 },
+    { name: 'uniqueness', weight: 20 },
+    { name: 'pronounceability', weight: 15 },
+    { name: 'availability', weight: 15 },
+  ];
+  const candidates = [];
+  for (let i = 0; i < 5; i++) {
+    const scores = {};
+    for (const c of criteria) scores[c.name] = 60 + (i * 5 + 10);
+    candidates.push({
+      name: `CandidateName${i + 1}`,
+      rationale: `Naming rationale for candidate ${i + 1}`,
+      scores,
+      personaFit: [
+        { personaName: 'Small Artisan Producer', fitScore: 70 + i },
+        { personaName: 'Boutique Gallery Owner', fitScore: 65 + i },
+      ],
+    });
+  }
+  return {
+    namingStrategy: { approach: 'descriptive', rationale: 'Descriptive names best convey artisan marketplace value' },
+    scoringCriteria: criteria,
+    candidates,
+    visualIdentity: {
+      colorPalette: [{ name: 'Primary', hex: '#2D5016' }, { name: 'Secondary', hex: '#F5E6D3' }],
+      typography: { heading: 'Playfair Display', body: 'Inter', monospace: 'Fira Code' },
+      imageryGuidance: 'Use warm, natural photography showcasing artisan craftsmanship and authentic materials',
+    },
+    brandExpression: { tagline: 'Craft meets commerce', elevator_pitch: 'AI marketplace for artisans', messaging_pillars: ['Authenticity', 'Global reach'] },
+  };
+}
+
+function genStage12() {
   const tiers = [];
   for (let i = 0; i < 3; i++) {
     tiers.push({
       name: `Tier ${i + 1}`,
-      description: `Target market tier ${i + 1} description`,
+      description: `Target market tier ${i + 1} description with sufficient detail`,
       persona: `Persona ${i + 1}`,
       painPoints: [`Pain ${i + 1}a`, `Pain ${i + 1}b`],
       tam: 1000000 * (i + 1),
@@ -239,9 +287,9 @@ function genStage11() {
       som: 100000 * (i + 1),
     });
   }
-  const channels = [];
   const channelNames = ['Organic Search', 'Paid Search', 'Social Media', 'Content Marketing', 'Email Marketing', 'Partnerships', 'Events', 'Direct Sales'];
   const channelTypes = ['organic', 'paid', 'organic', 'owned', 'owned', 'earned', 'earned', 'paid'];
+  const channels = [];
   for (let i = 0; i < 8; i++) {
     channels.push({
       name: channelNames[i],
@@ -249,23 +297,13 @@ function genStage11() {
       primaryTier: `Tier ${(i % 3) + 1}`,
       monthly_budget: 1000 * (i + 1),
       expected_cac: 20 + i * 5,
-      target_cac: 15 + i * 3,
       primary_kpi: `KPI for ${channelNames[i]}`,
     });
   }
   return {
-    tiers,
+    marketTiers: tiers,
     channels,
-    launch_timeline: [
-      { milestone: 'Soft launch', date: '2026-Q2', owner: 'Marketing' },
-      { milestone: 'Full launch', date: '2026-Q3', owner: 'Marketing' },
-    ],
-  };
-}
-
-function genStage12() {
-  return {
-    sales_model: 'hybrid',
+    salesModel: 'hybrid',
     sales_cycle_days: 30,
     deal_stages: [
       { name: 'Prospecting', description: 'Identify and qualify potential customers' },
@@ -466,85 +504,57 @@ function genStage22() {
 
 function genStage23() {
   return {
-    go_decision: 'go',
-    launchType: 'soft_launch',
-    incident_response_plan: 'On-call rotation with 15-minute response SLA. Escalation path: Dev → SRE → CTO.',
-    monitoring_setup: 'Datadog APM with custom dashboards for key metrics: latency, error rate, throughput.',
-    rollback_plan: 'Blue-green deployment with instant rollback capability. Database migrations are backward compatible.',
-    launch_tasks: [
-      { name: 'Deploy to production', status: 'complete', owner: 'DevOps' },
-      { name: 'Enable feature flags', status: 'complete', owner: 'Dev Lead' },
+    marketing_items: [
+      { title: 'Press Release', description: 'Announce marketplace launch to artisan media outlets', type: 'press_release', priority: 'critical' },
+      { title: 'Social Campaign', description: 'Instagram and Pinterest campaign targeting craft communities', type: 'social_media_campaign', priority: 'high' },
+      { title: 'Email Blast', description: 'Launch announcement to waitlist subscribers', type: 'email_campaign', priority: 'high' },
     ],
-    launch_date: '2026-06-15',
-    planned_launch_date: '2026-06-15',
-    actual_launch_date: '2026-06-15',
-    successCriteria: [
-      { metric: 'DAU', target: '500', measurementWindow: '30 days', priority: 'primary' },
-      { metric: 'Error Rate', target: '<1%', measurementWindow: '7 days', priority: 'primary' },
-    ],
-    rollbackTriggers: [
-      { trigger: 'Error rate spike', threshold: '>5% for 10 minutes', action: 'Auto-rollback' },
-    ],
+    marketing_strategy_summary: 'Multi-channel launch campaign targeting artisan communities through content marketing, social media, and direct outreach to established craft networks.',
+    target_audience: 'Small artisan producers and craft-conscious consumers aged 25-45',
   };
 }
 
 function genStage24() {
-  const aarrr = {};
-  for (const cat of ['acquisition', 'activation', 'retention', 'revenue', 'referral']) {
-    aarrr[cat] = [
-      { name: `${cat} metric 1`, value: 100, target: 120, previousValue: 80, trendDirection: 'up', trend_window_days: 30 },
-      { name: `${cat} metric 2`, value: 50, target: 60, previousValue: 45, trendDirection: 'up', trend_window_days: 30 },
-    ];
-  }
   return {
-    aarrr,
-    funnels: [
-      {
-        name: 'User Acquisition Funnel',
-        steps: [
-          { name: 'Visit', count: 10000 },
-          { name: 'Signup', count: 500 },
-          { name: 'Activation', count: 250 },
-        ],
-      },
-    ],
-    learnings: [
-      { insight: 'Organic search drives highest quality traffic', action: 'Double SEO investment', category: 'acquisition', impactLevel: 'high' },
-    ],
+    readiness_checklist: {
+      release_confirmed: { status: 'pass', evidence: 'Release candidate RC-1.0.0 tested and confirmed', verified_at: '2026-06-10T10:00:00Z' },
+      marketing_complete: { status: 'pass', evidence: 'All marketing materials approved and scheduled', verified_at: '2026-06-11T14:00:00Z' },
+      monitoring_ready: { status: 'pass', evidence: 'Datadog dashboards and alerts configured', verified_at: '2026-06-12T09:00:00Z' },
+      rollback_plan_exists: { status: 'pass', evidence: 'Blue-green rollback tested in staging', verified_at: '2026-06-12T11:00:00Z' },
+    },
+    incident_response_plan: 'On-call rotation with 15-minute response SLA. Escalation path: Dev → SRE → CTO. Runbook at /docs/runbook.',
+    monitoring_setup: 'Datadog APM with custom dashboards for key metrics: latency, error rate, throughput, and user engagement.',
+    rollback_plan: 'Blue-green deployment with instant rollback capability. Database migrations are backward compatible. Tested in staging.',
+    chairmanGate: { status: 'approved', rationale: 'Launch readiness confirmed', decision_id: 'test-decision-24' },
   };
 }
 
 function genStage25() {
-  const initiatives = {};
-  for (const cat of ['product', 'market', 'technical', 'financial', 'team']) {
-    initiatives[cat] = [
-      { title: `${cat} initiative 1`, status: 'completed', outcome: `${cat} outcome achieved` },
-    ];
-  }
   return {
-    review_summary: 'Comprehensive venture review after MVP launch phase showing strong product-market fit signals',
-    initiatives,
-    current_vision: 'AI-powered artisan marketplace connecting global buyers with local craft',
-    drift_justification: null,
-    next_steps: [
-      { action: 'Scale marketing spend', owner: 'CMO', timeline: 'Q3 2026', priority: 'high' },
-      { action: 'Hire additional engineers', owner: 'CTO', timeline: 'Q3 2026', priority: 'medium' },
+    distribution_channels: [
+      { name: 'Web App', type: 'direct', status: 'active', activation_date: '2026-06-15', metrics_endpoint: '/api/metrics/web' },
+      { name: 'Mobile App (iOS)', type: 'app_store', status: 'activating', activation_date: '2026-07-01' },
+      { name: 'Partner API', type: 'api', status: 'inactive' },
     ],
-    chairmanGate: { status: 'approved', rationale: 'Venture review approved', decision_id: 'test-decision-25' },
-    financialComparison: {
-      projectedRevenue: '$500K', actualRevenue: '$480K', projectedCosts: '$300K', actualCosts: '$310K',
-      revenueVariancePct: -4, financialTrajectory: 'on_plan', variance: 'Minor', assessment: 'Within acceptable range',
-    },
-    ventureHealth: {
-      overallRating: 'viable',
-      dimensions: {
-        product: { score: 75, rationale: 'Strong MVP' },
-        market: { score: 70, rationale: 'Growing demand' },
-        technical: { score: 80, rationale: 'Solid architecture' },
-        financial: { score: 65, rationale: 'Runway adequate' },
-        team: { score: 72, rationale: 'Core team in place' },
+    operations_handoff: {
+      monitoring: {
+        dashboards: ['Main KPI Dashboard', 'Error Rate Dashboard'],
+        alerts: ['Error spike > 5%', 'Latency > 2s p95'],
+        health_check_url: 'https://api.artisanmarket.com/health',
+      },
+      escalation: {
+        contacts: ['oncall@artisanmarket.com', '+1-555-DEVOPS'],
+        runbook_url: 'https://docs.internal/runbook',
+        sla_targets: { p1: '15min', p2: '1hr', p3: '24hr' },
+      },
+      maintenance: {
+        schedule: 'Weekly Tuesday 2AM UTC maintenance window',
+        backup_strategy: 'Daily automated backups with 30-day retention',
+        update_policy: 'Semantic versioning with staged rollout',
       },
     },
+    launch_summary: 'Artisan marketplace launched with web app as primary channel. iOS app in activation phase. Partner API planned for Q3 2026.',
+    go_live_timestamp: '2026-06-15T00:00:00Z',
   };
 }
 
@@ -561,7 +571,7 @@ const TEST_DATA_GENERATORS = {
 const STAGES_WITH_PREREQUISITES_VALIDATE = new Set([2, 3, 4, 5, 6, 7, 8, 9]);
 
 // Stages that accept an extra arg to computeDerived()
-const STAGES_WITH_EXTRA_COMPUTE = new Set([1, 9, 12, 15, 16, 22, 23, 25]);
+const STAGES_WITH_EXTRA_COMPUTE = new Set([1, 9, 12, 15, 16, 22, 23, 24, 25]);
 
 // ───────────────────────────────────────────────────────────────────
 // Core test runner
@@ -718,13 +728,13 @@ async function testKillGates() {
   try {
     const { evaluateKillGate } = await import('../lib/eva/stage-templates/stage-03.js');
     // PASS case
-    const passResult = evaluateKillGate({ overallScore: 75, metrics: { marketFit: 75, customerNeed: 80, momentum: 65, revenuePotential: 70, competitiveBarrier: 60, executionFeasibility: 72 } });
+    const passResult = evaluateKillGate({ overallScore: 75, metrics: { marketFit: 75, customerNeed: 80, momentum: 65, revenuePotential: 70, competitiveBarrier: 60, executionFeasibility: 72, designQuality: 68 } });
     if (passResult.decision !== 'pass') findings.push({ severity: 'high', check: 'gate_stage03', message: `Expected pass, got ${passResult.decision}` });
     // KILL case
-    const killResult = evaluateKillGate({ overallScore: 40, metrics: { marketFit: 30, customerNeed: 80, momentum: 65, revenuePotential: 70, competitiveBarrier: 60, executionFeasibility: 72 } });
+    const killResult = evaluateKillGate({ overallScore: 40, metrics: { marketFit: 30, customerNeed: 80, momentum: 65, revenuePotential: 70, competitiveBarrier: 60, executionFeasibility: 72, designQuality: 40 } });
     if (killResult.decision !== 'kill') findings.push({ severity: 'high', check: 'gate_stage03', message: `Expected kill, got ${killResult.decision}` });
     // REVISE case
-    const reviseResult = evaluateKillGate({ overallScore: 60, metrics: { marketFit: 55, customerNeed: 65, momentum: 55, revenuePotential: 60, competitiveBarrier: 55, executionFeasibility: 70 } });
+    const reviseResult = evaluateKillGate({ overallScore: 60, metrics: { marketFit: 55, customerNeed: 65, momentum: 55, revenuePotential: 60, competitiveBarrier: 55, executionFeasibility: 70, designQuality: 55 } });
     if (reviseResult.decision !== 'revise') findings.push({ severity: 'high', check: 'gate_stage03', message: `Expected revise, got ${reviseResult.decision}` });
   } catch (err) {
     findings.push({ severity: 'critical', check: 'gate_stage03', message: `Stage 3 kill gate threw: ${err.message}` });
@@ -758,22 +768,26 @@ async function testKillGates() {
     findings.push({ severity: 'critical', check: 'gate_stage13', message: `Stage 13 kill gate threw: ${err.message}` });
   }
 
-  // Stage 23 kill gate
+  // Stage 23 release readiness check
   try {
-    const stage23 = getTemplate(23);
-    const data = genStage23();
-    const derived = stage23.computeDerived(data, null, { logger: silentLogger });
-    if (derived.decision === 'kill') {
-      findings.push({ severity: 'medium', check: 'gate_stage23', message: `Valid go data triggered kill: ${derived.reasons?.map(r => r.message).join('; ')}` });
+    const { checkReleaseReadiness } = await import('../lib/eva/stage-templates/stage-23.js');
+    // PASS case: stage 22 has promotion_gate.pass and releaseDecision
+    const passResult = checkReleaseReadiness({
+      stage22Data: {
+        promotion_gate: { pass: true },
+        releaseDecision: { decision: 'release', rationale: 'All approved' },
+      },
+    });
+    if (!passResult.ready) {
+      findings.push({ severity: 'high', check: 'gate_stage23', message: `Expected ready, got not ready: ${passResult.reasons?.join('; ')}` });
     }
-    // Test no-go kill
-    const noGoData = { ...data, go_decision: 'no-go' };
-    const noGoDerived = stage23.computeDerived(noGoData, null, { logger: silentLogger });
-    if (noGoDerived.decision !== 'kill') {
-      findings.push({ severity: 'high', check: 'gate_stage23', message: `no-go should trigger kill, got ${noGoDerived.decision}` });
+    // FAIL case: no stage 22 data
+    const failResult = checkReleaseReadiness({ stage22Data: null });
+    if (failResult.ready) {
+      findings.push({ severity: 'high', check: 'gate_stage23', message: 'Expected not ready without stage 22 data, got ready' });
     }
   } catch (err) {
-    findings.push({ severity: 'critical', check: 'gate_stage23', message: `Stage 23 kill gate threw: ${err.message}` });
+    findings.push({ severity: 'critical', check: 'gate_stage23', message: `Stage 23 release readiness threw: ${err.message}` });
   }
 
   return findings;


### PR DESCRIPTION
## Summary
- Updated 8 test data generators in `scripts/e2e-stage-runner.mjs` to match new stage template schemas from SD-LEO-ORCH-EVA-STAGE-PIPELINE-001 (11 children, A-K)
- Stages 10-12: Identity Phase resequence (Customer & Brand Foundation, Naming & Visual Identity, GTM & Sales Strategy)
- Stages 23-25: Launch Phase redesign (Marketing Preparation, Launch Readiness, Launch Execution)
- Stages 2-3: Added `designQuality` metric (7th metric)
- Stage 23 gate test changed from kill gate to `checkReleaseReadiness()`
- Stage 24 added to `STAGES_WITH_EXTRA_COMPUTE` set
- Updated `docs/eva/e2e-stage-test-report.md` to v2.0.0 with full orchestrator change log
- Updated `docs/guides/testing/eva-stage-regression-guide.md` v1.1.0 with corrected gate references

## Test plan
- [x] `node scripts/e2e-stage-runner.mjs` — 25/25 stages PASS, 0 findings
- [x] All gate tests pass (kill gates 3/5/13, release readiness 23, reality gates, promotion gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)