### PR TITLE
fix: add fix SD type to retrospective auto-pass and prevent duplicate rows

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
@@ -437,17 +437,36 @@ export async function createExecToPlanRetrospective(supabase, sdId, sd, handoffR
       }
     };
 
-    // Insert retrospective
-    const { data, error } = await supabase
+    // SD-LEARN-FIX-ADDRESS-PAT-AUTO-050: Upsert to prevent duplicate rows on retry
+    const { data: existing } = await supabase
       .from('retrospectives')
-      .insert(retrospective)
-      .select();
+      .select('id')
+      .eq('sd_id', retrospective.sd_id)
+      .eq('retrospective_type', 'EXEC_TO_PLAN')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    let data, error;
+    if (existing) {
+      ({ data, error } = await supabase
+        .from('retrospectives')
+        .update(retrospective)
+        .eq('id', existing.id)
+        .select());
+    } else {
+      ({ data, error } = await supabase
+        .from('retrospectives')
+        .insert(retrospective)
+        .select());
+    }
 
     if (error) {
       console.log(`\n   ⚠️  Could not save retrospective: ${error.message}`);
       console.log('   Retrospective data will not be persisted');
     } else {
-      console.log(`\n   ✅ EXEC phase retrospective created (ID: ${data[0].id})`);
+      const verb = existing ? 'updated (avoided duplicate)' : 'created';
+      console.log(`\n   ✅ EXEC phase retrospective ${verb} (ID: ${data[0].id})`);
       console.log(`   Quality Score: ${qualityScore}% | Issues Captured: ${sdIssues.length}`);
     }
 

--- a/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
@@ -334,17 +334,36 @@ export async function createHandoffRetrospective(sdId, sd, handoffResult, retros
       } : null
     };
 
-    // Insert retrospective
-    const { data, error } = await supabase
+    // SD-LEARN-FIX-ADDRESS-PAT-AUTO-050: Upsert to prevent duplicate rows on retry
+    const { data: existing } = await supabase
       .from('retrospectives')
-      .insert(retrospective)
-      .select();
+      .select('id')
+      .eq('sd_id', retrospective.sd_id)
+      .eq('retrospective_type', retrospectiveType)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    let data, error;
+    if (existing) {
+      ({ data, error } = await supabase
+        .from('retrospectives')
+        .update(retrospective)
+        .eq('id', existing.id)
+        .select());
+    } else {
+      ({ data, error } = await supabase
+        .from('retrospectives')
+        .insert(retrospective)
+        .select());
+    }
 
     if (error) {
       console.log(`\n   ⚠️  Could not save retrospective: ${error.message}`);
       console.log('   Retrospective data will not be persisted');
     } else {
-      console.log(`\n   ✅ Handoff retrospective created (ID: ${data[0].id})`);
+      const verb = existing ? 'updated (avoided duplicate)' : 'created';
+      console.log(`\n   ✅ Handoff retrospective ${verb} (ID: ${data[0].id})`);
       console.log(`   Quality Score: ${qualityScore}% | Team Satisfaction: ${Math.round(avgRating * 2)}/10`);
     }
 

--- a/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
@@ -245,17 +245,38 @@ export async function createHandoffRetrospective(supabase, sdId, sd, handoffResu
       } : null
     };
 
-    // Insert retrospective
-    const { data, error } = await supabase
+    // SD-LEARN-FIX-ADDRESS-PAT-AUTO-050: Upsert to prevent duplicate rows on retry
+    // Each failed handoff attempt previously created a NEW row with boilerplate content.
+    // The gate reads the NEWEST row, so duplicates override enriched content.
+    const { data: existing } = await supabase
       .from('retrospectives')
-      .insert(retrospective)
-      .select();
+      .select('id')
+      .eq('sd_id', retrospective.sd_id)
+      .eq('retrospective_type', retrospectiveType)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    let data, error;
+    if (existing) {
+      ({ data, error } = await supabase
+        .from('retrospectives')
+        .update(retrospective)
+        .eq('id', existing.id)
+        .select());
+    } else {
+      ({ data, error } = await supabase
+        .from('retrospectives')
+        .insert(retrospective)
+        .select());
+    }
 
     if (error) {
       console.log(`\n   ⚠️  Could not save retrospective: ${error.message}`);
       console.log('   Retrospective data will not be persisted');
     } else {
-      console.log(`\n   ✅ Handoff retrospective created (ID: ${data[0].id})`);
+      const verb = existing ? 'updated (avoided duplicate)' : 'created';
+      console.log(`\n   ✅ Handoff retrospective ${verb} (ID: ${data[0].id})`);
       console.log(`   Quality Score: ${qualityScore}% | Team Satisfaction: ${Math.round(avgRating * 2)}/10`);
     }
 

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
@@ -180,9 +180,10 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
     };
   }
 
-  // BUGFIX FAST-PATH
-  if ((sdType === 'bugfix' || sdType === 'bug_fix') && retrospective) {
-    console.log('   🔧 BUGFIX AUTO-PASS: Bugfix SD with retrospective exists');
+  // BUGFIX / FIX FAST-PATH
+  // SD-LEARN-FIX-ADDRESS-PAT-AUTO-050: Added 'fix' type (PAT-AUTO-1cae3b92)
+  if ((sdType === 'bugfix' || sdType === 'bug_fix' || sdType === 'fix') && retrospective) {
+    console.log(`   🔧 FIX AUTO-PASS: ${sdType} SD with retrospective exists`);
     console.log(`      Retrospective quality_score: ${retrospective.quality_score || 0}/100`);
 
     return {
@@ -190,7 +191,7 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
       score: Math.max(retrospective.quality_score || 50, 50),
       max_score: 100,
       issues: [],
-      warnings: ['Bugfix auto-pass: Simple fix validated via git commit evidence'],
+      warnings: [`${sdType} auto-pass: Simple fix validated via git commit evidence`],
       details: {
         bugfix_auto_pass: true,
         sd_type: sdType,
@@ -277,7 +278,7 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
 async function determineThreshold(sd, allChildrenComplete) {
   const isInfrastructure = isInfrastructureSDSync(sd);
   const sdType = sd?.sd_type || sd?.category || 'feature';
-  const isBugfix = sdType === 'bugfix' || sdType === 'bug_fix';
+  const isBugfix = sdType === 'bugfix' || sdType === 'bug_fix' || sdType === 'fix';
 
   let threshold;
   if (allChildrenComplete) {


### PR DESCRIPTION
## Summary
- Add `fix` SD type alongside `bugfix`/`bug_fix` in RETROSPECTIVE_QUALITY_GATE auto-pass path and threshold determination
- Change `.insert()` to upsert pattern in all 3 retrospective creator files to prevent duplicate boilerplate rows from overriding enriched content on handoff retries
- Resolves PAT-AUTO-1cae3b92 (RETROSPECTIVE_QUALITY_GATE failure for fix-type SDs)

## Test plan
- [x] Verified `fix` type triggers auto-pass in `checkAutoPassConditions()`
- [x] Verified `fix` type gets 50% threshold in `determineThreshold()`
- [x] Verified upsert pattern checks for existing retrospective before insert
- [x] All 3 retrospective creators (plan-to-exec, exec-to-plan, lead-to-plan) updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)