### PR TITLE
fix: correct lifecycle phase boundaries and rename Phase 6

### DIFF
--- a/database/migrations/20260305_fix_lifecycle_phase_boundaries.sql
+++ b/database/migrations/20260305_fix_lifecycle_phase_boundaries.sql
@@ -1,0 +1,33 @@
+-- Fix Phase 5/6 boundaries and rename Phase 6
+-- Phase 5 expanded: [17-20] → [17-22]
+-- Phase 6 renamed: "LAUNCH & LEARN" → "THE LAUNCH", condensed: [21-25] → [23-25]
+
+-- 1. Fix lifecycle_phases table
+UPDATE lifecycle_phases
+SET stages = ARRAY[17,18,19,20,21,22]
+WHERE phase_number = 5;
+
+UPDATE lifecycle_phases
+SET phase_name = 'THE LAUNCH',
+    description = 'Launch preparation, execution, and go-live',
+    stages = ARRAY[23,24,25]
+WHERE phase_number = 6;
+
+-- 2. Fix lifecycle_stage_config table (stages 21-22 → Phase 5)
+UPDATE lifecycle_stage_config
+SET phase_number = 5, phase_name = 'THE BUILD LOOP'
+WHERE stage_number IN (21, 22);
+
+UPDATE lifecycle_stage_config
+SET phase_name = 'THE LAUNCH'
+WHERE stage_number IN (23, 24, 25);
+
+-- 3. Update venture_token_ledger CHECK constraint
+ALTER TABLE venture_token_ledger
+  DROP CONSTRAINT IF EXISTS venture_token_ledger_phase_check;
+ALTER TABLE venture_token_ledger
+  ADD CONSTRAINT venture_token_ledger_phase_check
+  CHECK (phase IN ('THE_TRUTH', 'THE_ENGINE', 'THE_IDENTITY', 'THE_BLUEPRINT', 'THE_BUILD_LOOP', 'THE_LAUNCH'));
+
+-- 4. Migrate existing data
+UPDATE venture_token_ledger SET phase = 'THE_LAUNCH' WHERE phase = 'LAUNCH_LEARN';

--- a/docs/guides/workflow/stages/stage-21-qa-and-uat.md
+++ b/docs/guides/workflow/stages/stage-21-qa-and-uat.md
@@ -129,7 +129,7 @@ No specific exit gates defined.
 ## Related Documentation
 
 - [stages_v2.yaml](../stages_v2.yaml#L919) - Stage 21 definition
-- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-6-launch-learn) - Phase context
+- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-5-the-build-loop) - Phase context
 - [Stage 20: Security & Performance](stage-20-security-and-performance.md) - Previous stage
 - [Stage 22: Deployment & Infrastructure](stage-22-deployment-and-infrastructure.md) - Next stage
 

--- a/docs/guides/workflow/stages/stage-22-deployment-and-infrastructure.md
+++ b/docs/guides/workflow/stages/stage-22-deployment-and-infrastructure.md
@@ -126,7 +126,7 @@ No specific exit gates defined.
 ## Related Documentation
 
 - [stages_v2.yaml](../stages_v2.yaml#L959) - Stage 22 definition
-- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-6-launch-learn) - Phase context
+- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-5-the-build-loop) - Phase context
 - [Stage 21: QA & UAT](stage-21-qa-and-uat.md) - Previous stage
 - [Stage 23: Production Launch](stage-23-production-launch.md) - Next stage
 

--- a/docs/guides/workflow/stages/stage-23-production-launch.md
+++ b/docs/guides/workflow/stages/stage-23-production-launch.md
@@ -126,7 +126,7 @@ No specific exit gates defined.
 ## Related Documentation
 
 - [stages_v2.yaml](../stages_v2.yaml#L999) - Stage 23 definition
-- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-6-launch-learn) - Phase context
+- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-6-the-launch) - Phase context
 - [Stage 22: Deployment & Infrastructure](stage-22-deployment-and-infrastructure.md) - Previous stage
 - [Stage 24: Analytics & Feedback](stage-24-analytics-and-feedback.md) - Next stage
 

--- a/docs/guides/workflow/stages/stage-24-analytics-and-feedback.md
+++ b/docs/guides/workflow/stages/stage-24-analytics-and-feedback.md
@@ -125,7 +125,7 @@ No specific exit gates defined.
 ## Related Documentation
 
 - [stages_v2.yaml](../stages_v2.yaml#L1039) - Stage 24 definition
-- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-6-launch-learn) - Phase context
+- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-6-the-launch) - Phase context
 - [Stage 23: Production Launch](stage-23-production-launch.md) - Previous stage
 - [Stage 25: Optimization & Scale](stage-25-optimization-and-scale.md) - Next stage
 

--- a/docs/guides/workflow/stages/stage-25-optimization-and-scale.md
+++ b/docs/guides/workflow/stages/stage-25-optimization-and-scale.md
@@ -131,7 +131,7 @@ No specific exit gates defined.
 ## Related Documentation
 
 - [stages_v2.yaml](../stages_v2.yaml#L1079) - Stage 25 definition
-- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-6-launch-learn) - Phase context
+- [25-Stage Overview](../25-stage-venture-lifecycle-overview.md#phase-6-the-launch) - Phase context
 - [Stage 24: Analytics & Feedback](stage-24-analytics-and-feedback.md) - Previous stage
 
 

--- a/docs/guides/workflow/stages_v2.yaml
+++ b/docs/guides/workflow/stages_v2.yaml
@@ -14,7 +14,7 @@
 #
 # Phase structure changes from design spec to implementation:
 #   - Phase 5 (THE BUILD LOOP): expanded from [17-20] to [17-22]
-#   - Phase 6 (LAUNCH & LEARN): condensed from [21-25] to [23-25]
+#   - Phase 6 (THE LAUNCH): condensed from [21-25] to [23-25]
 # ============================================================================
 
 version: "2.0"
@@ -54,7 +54,7 @@ golden_nuggets:
           THE_IDENTITY: 0.10   # 10% (Stages 10-12)
           THE_BLUEPRINT: 0.20  # 20% (Stages 13-16)
           THE_BUILD_LOOP: 0.20 # 20% (Stages 17-20)
-          LAUNCH_LEARN: 0.10   # 10% (Stages 21-25)
+          THE_LAUNCH: 0.10     # 10% (Stages 23-25)
       deep_due_diligence:
         total_tokens: 1500000  # 1M-2M midpoint
         use_case: "High-stakes, complex markets"
@@ -121,8 +121,8 @@ phases:
     description: "Implementation and development cycle"
     stages: [17, 18, 19, 20, 21, 22]
   - id: 6
-    name: "LAUNCH & LEARN"
-    description: "Deployment, analytics, and optimization"
+    name: "THE LAUNCH"
+    description: "Launch preparation, execution, and go-live"
     stages: [23, 24, 25]
 
 stages:
@@ -802,14 +802,14 @@ stages:
       - Monitoring coverage
 
   # ============================================================================
-  # PHASE 6: LAUNCH & LEARN (Stages 23-25)
+  # PHASE 6: THE LAUNCH (Stages 23-25)
   # ============================================================================
   - id: 23
     title: "Marketing Preparation"
     design_spec_title: "Production Launch"
     description: "Pre-launch marketing preparation including asset creation, channel readiness, and go-live checklist."
     phase_number: 6
-    phase_name: "LAUNCH & LEARN"
+    phase_name: "THE LAUNCH"
     work_type: decision_gate
     sd_required: false
     advisory_enabled: false
@@ -837,7 +837,7 @@ stages:
     design_spec_title: "Analytics & Feedback"
     description: "Launch readiness scoring, distribution channel activation checklist, and launch authorization gate."
     phase_number: 6
-    phase_name: "LAUNCH & LEARN"
+    phase_name: "THE LAUNCH"
     work_type: artifact_only
     sd_required: false
     advisory_enabled: false
@@ -866,7 +866,7 @@ stages:
     design_spec_title: "Optimization & Scale"
     description: "Go-live execution, distribution channel activation, operations handoff. Sets pipeline_mode to 'operations'."
     phase_number: 6
-    phase_name: "LAUNCH & LEARN"
+    phase_name: "THE LAUNCH"
     work_type: sd_required
     sd_required: true
     sd_suffix: "OPTIMIZE"

--- a/lib/eva/stage-templates/stage-23.js
+++ b/lib/eva/stage-templates/stage-23.js
@@ -1,6 +1,6 @@
 /**
  * Stage 23 Template - Marketing Preparation
- * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Phase: THE LAUNCH (Stages 23-25)
  * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
  * Creates marketing material SDs via lifecycle-sd-bridge

--- a/lib/eva/stage-templates/stage-24.js
+++ b/lib/eva/stage-templates/stage-24.js
@@ -1,6 +1,6 @@
 /**
  * Stage 24 Template - Launch Readiness
- * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Phase: THE LAUNCH (Stages 23-25)
  * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
  * Chairman go/no-go launch decision gate with real upstream readiness data.

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -1,6 +1,6 @@
 /**
  * Stage 25 Template - Launch Execution
- * Phase: LAUNCH & LEARN (Stages 23-25)
+ * Phase: THE LAUNCH (Stages 23-25)
  * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-B
  *
  * Pipeline terminus: execute go-live, activate distribution channels,


### PR DESCRIPTION
## Summary
- Rename "LAUNCH & LEARN" to "THE LAUNCH" in stage templates (23-25) and `stages_v2.yaml`
- Fix phase context links: stages 21-22 now reference Phase 5 (THE BUILD LOOP), stages 23-25 reference Phase 6 (THE LAUNCH)
- Add database migration to update `lifecycle_phases`, `lifecycle_stage_config`, and `venture_token_ledger`

Companion PR: rickfelix/ehg#220 (frontend comment fixes)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] DOCMON validation passes
- [ ] Run migration against Supabase: `database/migrations/20260305_fix_lifecycle_phase_boundaries.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)