### PR TITLE
docs: add venture exit readiness plans with completion status

### DIFF
--- a/docs/plans/venture-exit-readiness-architecture.md
+++ b/docs/plans/venture-exit-readiness-architecture.md
@@ -1,0 +1,350 @@
+# Architecture Plan: Venture Acquisition-Readiness
+
+## Stack & Repository Decisions
+
+- **Backend**: Express.js (existing server in `server/`) — new routes mounted under `/api/eva/exit/`
+- **Database**: Supabase (Postgres) — new tables with RLS policies following existing patterns
+- **Frontend**: React + TypeScript + Shadcn UI + Tailwind (in `rickfelix/ehg` repo) — new Chairman pages
+- **Workers**: EVA Master Scheduler domain handlers (following `registerOperationsHandlers()` pattern)
+- **Repository**: All backend/worker changes in `EHG_Engineer`. All frontend changes in `ehg` app repo.
+
+No new technology required. All components use existing stack and patterns.
+
+## Legacy Deprecation Plan
+
+No systems are deprecated. This is additive to the existing pipeline:
+
+- `ventures.pipeline_mode` CHECK constraint is extended (not replaced) with 3 new values
+- Existing operations workers continue unchanged — new exit-readiness workers are registered alongside them
+- Existing stage templates gain new soft criteria — no existing criteria are removed
+- Existing Chairman views remain — new exit views are added as tabs
+
+**Migration consideration**: The `pipeline_mode` CHECK constraint must be altered in a backward-compatible migration. Existing ventures keep their current mode values. No data migration required.
+
+## Route & Component Structure
+
+### API Routes (EHG_Engineer)
+
+```
+server/routes/eva-exit.js
+├── GET    /api/eva/exit/portfolio          → Portfolio exit readiness overview
+├── GET    /api/eva/exit/:ventureId/profile → Venture exit profile
+├── PUT    /api/eva/exit/:ventureId/profile → Update exit model/metadata
+├── POST   /api/eva/exit/:ventureId/enter   → Transition to exit_prep mode
+├── POST   /api/eva/exit/:ventureId/divest  → Transition to divesting mode
+├── POST   /api/eva/exit/:ventureId/sold    → Mark as sold (terminal)
+├── GET    /api/eva/exit/:ventureId/assets  → Asset registry for venture
+├── POST   /api/eva/exit/:ventureId/assets  → Register new asset
+├── PUT    /api/eva/exit/:ventureId/assets/:id → Update asset
+├── DELETE /api/eva/exit/:ventureId/assets/:id → Remove asset
+├── GET    /api/eva/exit/:ventureId/separability → Score history
+├── GET    /api/eva/exit/:ventureId/data-room   → Data room artifacts list
+├── POST   /api/eva/exit/:ventureId/data-room/generate → Trigger generation
+└── GET    /api/eva/exit/:ventureId/data-room/:artifactId → Download artifact
+```
+
+### Frontend Components (ehg repo)
+
+```
+src/components/chairman-v2/exit/
+├── PortfolioExitReadiness.tsx      → Portfolio overview table
+├── VentureExitDashboard.tsx        → Per-venture exit tab
+├── AssetRegistryPanel.tsx          → Asset CRUD with provenance
+├── SeparabilityScoreChart.tsx      → Time-series score visualization
+├── DataRoomPanel.tsx               → Data room status + download
+├── ExitModelSelector.tsx           → Exit model picker with descriptions
+└── SeparationPlanView.tsx          → Dependency map + dry-run results
+
+src/hooks/
+├── useExitProfile.ts               → React Query hook for exit profile
+├── useAssetRegistry.ts             → React Query hook for assets
+├── useSeparabilityHistory.ts        → React Query hook for score history
+└── useDataRoom.ts                   → React Query hook for data room
+```
+
+### Routes (ehg repo)
+
+```
+/chairman/portfolio/exit-readiness   → PortfolioExitReadiness
+/chairman/ventures/:id/exit          → VentureExitDashboard
+/chairman/ventures/:id/data-room     → DataRoomPanel (expanded)
+```
+
+## Data Layer
+
+### New Tables
+
+#### `venture_exit_profiles`
+```sql
+CREATE TABLE venture_exit_profiles (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id),
+  exit_model TEXT NOT NULL CHECK (exit_model IN ('full_acquisition', 'licensing', 'revenue_share', 'undetermined')),
+  exit_model_history JSONB DEFAULT '[]',  -- [{model, set_at, reason}]
+  target_buyer_type TEXT,                 -- 'strategic', 'financial', 'competitor', 'platform'
+  readiness_score NUMERIC(5,2) DEFAULT 0,
+  data_room_completeness NUMERIC(5,2) DEFAULT 0,
+  entered_exit_prep_at TIMESTAMPTZ,
+  entered_divesting_at TIMESTAMPTZ,
+  sold_at TIMESTAMPTZ,
+  sale_metadata JSONB,                    -- price, buyer, terms (post-sale record)
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(venture_id)
+);
+```
+
+#### `venture_asset_registry`
+```sql
+CREATE TABLE venture_asset_registry (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id),
+  asset_type TEXT NOT NULL CHECK (asset_type IN (
+    'code_repo', 'domain', 'customer_list', 'integration',
+    'brand_asset', 'api_key', 'database', 'ml_model',
+    'documentation', 'license', 'contract', 'other'
+  )),
+  name TEXT NOT NULL,
+  description TEXT,
+  location TEXT,                          -- URL, path, or identifier
+  owner_entity TEXT,                      -- legal entity that owns this asset
+  provenance JSONB DEFAULT '{}',          -- {created_by, created_at, license, ip_status, encumbrances}
+  dependencies JSONB DEFAULT '[]',        -- [{asset_id, dependency_type, separable}]
+  separable BOOLEAN DEFAULT true,         -- can this asset be extracted independently?
+  separation_notes TEXT,                  -- what's needed to separate
+  verified_at TIMESTAMPTZ,               -- last manual verification
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_asset_registry_venture ON venture_asset_registry(venture_id);
+CREATE INDEX idx_asset_registry_type ON venture_asset_registry(asset_type);
+```
+
+#### `venture_separability_scores`
+```sql
+CREATE TABLE venture_separability_scores (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id),
+  overall_score NUMERIC(5,2) NOT NULL,    -- 0-100
+  dimensions JSONB NOT NULL,              -- [{dimension, score, weight, details}]
+  shared_dependencies JSONB DEFAULT '[]', -- [{resource, type, severity, separable}]
+  computed_by TEXT DEFAULT 'ops_separability_score',
+  computation_metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_separability_venture_time ON venture_separability_scores(venture_id, created_at DESC);
+```
+
+#### `venture_data_room_artifacts`
+```sql
+CREATE TABLE venture_data_room_artifacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id),
+  artifact_type TEXT NOT NULL CHECK (artifact_type IN (
+    'financial_summary', 'customer_list', 'technical_architecture',
+    'dependency_map', 'integration_inventory', 'separation_plan',
+    'revenue_history', 'metric_dashboard', 'asset_inventory',
+    'legal_summary', 'custom'
+  )),
+  title TEXT NOT NULL,
+  content JSONB,                          -- structured content
+  file_path TEXT,                         -- generated file location
+  exit_model_applicable TEXT[],           -- which exit models need this artifact
+  status TEXT DEFAULT 'stale' CHECK (status IN ('current', 'stale', 'generating', 'error')),
+  last_generated_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ,                 -- when artifact becomes stale
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX idx_data_room_venture ON venture_data_room_artifacts(venture_id);
+```
+
+### Schema Modification
+
+```sql
+-- Extend pipeline_mode CHECK constraint
+ALTER TABLE ventures DROP CONSTRAINT IF EXISTS ventures_pipeline_mode_check;
+ALTER TABLE ventures ADD CONSTRAINT ventures_pipeline_mode_check
+  CHECK (pipeline_mode IN ('evaluation', 'build', 'launch', 'operations', 'exit_prep', 'divesting', 'sold', 'parked', 'killed'));
+```
+
+### RLS Policies
+
+All new tables follow the existing pattern: service role has full access, authenticated users have read access scoped to their ventures. Write access for asset registry and exit profiles is restricted to chairman role.
+
+### Key Queries
+
+```sql
+-- Portfolio exit readiness overview
+SELECT v.id, v.name, v.pipeline_mode,
+       ep.exit_model, ep.readiness_score, ep.data_room_completeness,
+       ss.overall_score as separability_score,
+       (SELECT COUNT(*) FROM venture_asset_registry ar WHERE ar.venture_id = v.id) as asset_count
+FROM ventures v
+LEFT JOIN venture_exit_profiles ep ON ep.venture_id = v.id
+LEFT JOIN LATERAL (
+  SELECT overall_score FROM venture_separability_scores
+  WHERE venture_id = v.id ORDER BY created_at DESC LIMIT 1
+) ss ON true
+WHERE v.status = 'active'
+ORDER BY ep.readiness_score DESC NULLS LAST;
+
+-- Separability score history for charts
+SELECT overall_score, dimensions, created_at
+FROM venture_separability_scores
+WHERE venture_id = $1
+ORDER BY created_at DESC
+LIMIT 90;  -- ~3 months of hourly data
+```
+
+## API Surface
+
+### RPC Functions
+
+```sql
+-- Transition venture to exit_prep mode (with validation)
+CREATE OR REPLACE FUNCTION enter_exit_prep(p_venture_id UUID)
+RETURNS JSONB AS $$
+DECLARE
+  v_current_mode TEXT;
+  v_has_profile BOOLEAN;
+BEGIN
+  SELECT pipeline_mode INTO v_current_mode FROM ventures WHERE id = p_venture_id;
+  IF v_current_mode != 'operations' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture must be in operations mode');
+  END IF;
+
+  SELECT EXISTS(SELECT 1 FROM venture_exit_profiles WHERE venture_id = p_venture_id) INTO v_has_profile;
+  IF NOT v_has_profile THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Exit profile required before entering exit prep');
+  END IF;
+
+  UPDATE ventures SET pipeline_mode = 'exit_prep' WHERE id = p_venture_id;
+  UPDATE venture_exit_profiles SET entered_exit_prep_at = NOW() WHERE venture_id = p_venture_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+```
+
+### REST Endpoints
+
+All endpoints under `/api/eva/exit/` follow existing Express middleware patterns:
+- `optionalAuth` middleware (same as operations routes)
+- Request validation via express-validator
+- Supabase client from `req.app.locals.supabase`
+- Standard error response format: `{ error: string, message: string }`
+
+## Implementation Phases
+
+### Phase 1: Foundation (Asset Registry + Exit Modes) — COMPLETED
+
+**Status**: Completed (SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001-A, PR #1794)
+
+**Scope**: Database schema, API routes, basic Chairman UI
+
+**Deliverables**:
+- Migration: extend `pipeline_mode` CHECK constraint
+- Migration: create `venture_exit_profiles` table
+- Migration: create `venture_asset_registry` table
+- API: `server/routes/eva-exit.js` with profile and asset CRUD
+- RPC: `enter_exit_prep()` function
+- Frontend: `VentureExitDashboard.tsx`, `AssetRegistryPanel.tsx`, `ExitModelSelector.tsx`
+- Frontend: Exit readiness tab on venture detail view
+
+**Dependencies**: None — fully additive to existing system
+
+### Phase 2: Scoring + Workers — COMPLETED
+
+**Status**: Completed (SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001-B, PR #1798)
+
+**Scope**: Separability scoring worker, data room framework, operations integration
+
+**Deliverables**:
+- Migration: create `venture_separability_scores` table
+- Migration: create `venture_data_room_artifacts` table
+- Worker: `ops_separability_score` domain handler (infrastructure dependency analysis)
+- Worker: `ops_data_room_refresh` domain handler (artifact generation)
+- Module: `lib/eva/exit/separability-scorer.js` (scoring engine)
+- Module: `lib/eva/exit/data-room-generator.js` (artifact templating)
+- API: separability history and data room endpoints
+- Frontend: `SeparabilityScoreChart.tsx`, `DataRoomPanel.tsx`
+
+**Dependencies**: Phase 1 (tables must exist for workers to write to)
+
+### Phase 3: Stage Integration + Validation — COMPLETED
+
+**Status**: Completed (SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001-C, Backend PR #1802, Frontend PR #219)
+
+**Scope**: Pipeline-wide acquirability criteria, separation rehearsal, dry-runs
+
+**Planned Deliverables** (all delivered):
+- Stage template modifications: acquirability criteria in stages 0, 18-22, 24
+- Module: `lib/eva/exit/separation-rehearsal.js` (standalone deployment validation)
+- Frontend: `SeparationPlanView.tsx`, `PortfolioExitReadiness.tsx`
+- Data room templates: per-exit-model artifact sets
+
+**Additional Deliverables** (implemented beyond plan):
+- Module: `lib/eva/exit/data-room-templates.js` — Template system for 6 exit models (full_acquisition, licensing, acqui_hire, revenue_share, merger, wind_down)
+- 7 acquirability analysis step files (`lib/eva/stage-templates/analysis-steps/stage-{00,18,19,20,21,22,24}-acquirability.js`)
+- `getAcquirabilityStep(stageNumber)` registry function in analysis steps index
+- Stage 24 acquirability review: weighted aggregation (stage0 30% + build delta 30% + separability 40%)
+- 4 Phase 3 API endpoints: POST rehearsal, GET rehearsal/latest, GET data-room/template, GET data-room/completeness
+- 115 unit tests across 3 test files (`separation-rehearsal.test.js`, `data-room-templates.test.js`, `stage-24-acquirability-review.test.js`)
+- Frontend: `PortfolioExitReadiness.tsx` (Chairman V3 portfolio dashboard), `SeparationPlanView.tsx` (venture detail separation view)
+
+**Deferred**:
+- Extended scoring: per-PR separability delta computation (CI integration) — deferred to future SD
+
+**Dependencies**: Phase 2 (scoring system must exist before adding criteria to stage gates)
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+- `tests/unit/eva/exit/separability-scorer.test.js` — scoring algorithm with mock dependency data
+- `tests/unit/eva/exit/data-room-generator.test.js` — artifact generation with mock venture data
+- `tests/unit/eva/exit/asset-registry.test.js` — provenance validation, dependency analysis
+
+### Integration Tests (Vitest)
+- `tests/integration/eva/exit-pipeline.integration.test.js` — full lifecycle: operations → exit_prep → divesting → sold with stateful mock Supabase
+- `tests/integration/eva/exit-workers.integration.test.js` — worker handler execution with mock infrastructure data
+
+### E2E Tests (Playwright)
+- `tests/e2e/api/eva-exit.spec.ts` — REST API endpoint validation
+- `tests/e2e/chairman/exit-readiness.spec.ts` — Chairman UI workflow (create profile, add assets, view scores)
+
+### Test Data
+- Seed fixtures for each exit model type
+- Mock infrastructure dependency scans with known separability scores
+- Mock data room templates for artifact generation testing
+
+## Risk Mitigation
+
+### Risk 1: Pipeline redesign fatigue
+The 25-stage pipeline was just redesigned (2026-03-04). Modifying stage templates again risks regressions.
+
+**Mitigation**: Phase 3 (stage template changes) is deferred. Phases 1 and 2 are fully additive — no existing code is modified. Phase 3 only proceeds after Phases 1-2 are stable and tested.
+
+### Risk 2: Separability score without validation
+A computed score that has never been tested against a real separation attempt creates false confidence (Challenger's key concern).
+
+**Mitigation**: Phase 2 includes scoring with explicit "unvalidated" status. Phase 3 adds separation rehearsals. Scores display a "last validated" timestamp — if never validated, the UI shows a warning badge. The score does not auto-influence decisions (informational only).
+
+### Risk 3: Small venture sample (N=4)
+Designing a generic exit architecture for 4 ventures risks over-fitting.
+
+**Mitigation**: The asset type and exit model enums are designed to be extensible. The scoring dimensions are configurable per venture (stored as JSONB, not fixed columns). The architecture favors flexibility over optimization for current ventures.
+
+### Risk 4: Legal entity structure is a prerequisite
+The asset registry tracks ownership, but the actual legal entity structure (LLCs per venture, IP assignments) is an offline business decision.
+
+**Mitigation**: The `owner_entity` field on assets accepts free-text. The system tracks what's recorded but does not validate legal entity existence. The data room generator flags assets with missing `owner_entity` as incomplete — surfacing the gap without blocking progress.
+
+### Risk 5: Shared Supabase instance complicates data export
+All ventures share a single Supabase project. Venture-scoped data export requires per-venture logical partitioning.
+
+**Mitigation**: All venture-scoped tables already have `venture_id` foreign keys. Data room generation uses filtered queries (`WHERE venture_id = $1`), not physical database separation. For full-acquisition exits requiring database transfer, Phase 3 includes a migration script that exports a venture's data into a standalone SQL dump with referential integrity preserved.

--- a/docs/plans/venture-exit-readiness-vision.md
+++ b/docs/plans/venture-exit-readiness-vision.md
@@ -1,0 +1,199 @@
+# Vision: Venture Acquisition-Readiness Architecture
+
+## Executive Summary
+
+EHG is a venture factory whose core business model is building and selling ventures. The 25-stage pipeline evaluates, builds, launches, and operates ventures — but the architecture stops at "operations." There is no concept of preparing a venture for sale, tracking its assets, scoring its separability from shared infrastructure, or generating the artifacts an acquirer needs for due diligence.
+
+This vision establishes acquisition-readiness as a first-class concern embedded throughout the venture lifecycle — from Stage 0 evaluation through Operations mode and into a new Exit Preparation phase. The system will track venture assets with provenance, compute separability scores continuously, maintain live data rooms, and support multiple exit models (full acquisition, licensing, revenue share) per venture.
+
+The goal is not just to make ventures sellable, but to make them sellable fast — compressing M&A timelines from the industry-standard 60-180 days to under 30 days by having every artifact an acquirer needs continuously maintained and validated.
+
+## Problem Statement
+
+EHG's pipeline produces ventures that can operate but cannot be sold without significant manual work. When an acquisition opportunity arises, the team must improvise: manually inventorying assets, untangling shared infrastructure, preparing financial documentation, and generating due diligence artifacts under time pressure. This ad hoc process is expensive, error-prone, and slow.
+
+The specific gaps are:
+- **No exit pipeline mode** — ventures can only be "parked" or "killed" after Operations. There is no recognized phase for exit preparation.
+- **No asset registry** — there is no programmatic record of what a venture consists of (code, domains, customers, integrations, brand assets) or who owns each asset.
+- **No separability assessment** — ventures share EHG infrastructure (Supabase, Express server, worker scheduler) with no continuous measurement of how cleanly they could be extracted.
+- **No financial data for valuation** — the Financial Sync worker checks contract existence but doesn't track MRR, ARR, churn, CAC, or LTV.
+- **No data room capability** — there is no system for generating the packaged documentation and data an acquirer's technical and legal teams need.
+
+These gaps affect all current ventures: Synthify Studios, NicheSignal AI, CreatorFlow AI, and NicheBrief AI — and will affect every future venture EHG creates.
+
+## Personas
+
+### The Chairman (Rick)
+- **Goals**: Maximize venture value at exit, maintain portfolio visibility, make informed park/kill/sell decisions
+- **Mindset**: Strategic, data-driven, wants to see acquirability alongside health metrics
+- **Key activities**: Reviews portfolio dashboard, assesses exit timing, engages with acquirers, approves exit preparation
+
+### The Acquirer's Technical Lead
+- **Goals**: Assess integration risk, validate data completeness, estimate separation cost
+- **Mindset**: Skeptical, detail-oriented, looking for hidden dependencies and technical debt
+- **Key activities**: Reviews data room, runs sandbox environments, evaluates infrastructure entanglement, produces technical due diligence report
+
+### The Acquirer's Business Analyst
+- **Goals**: Validate financial metrics, assess customer health, confirm unit economics
+- **Mindset**: Numbers-focused, wants auditable data with provenance
+- **Key activities**: Reviews revenue history, churn analysis, customer acquisition costs, growth trajectory
+
+### EVA (The Autonomous Pipeline)
+- **Goals**: Compute separability scores, maintain asset registry, generate data room artifacts, flag score degradation
+- **Mindset**: Continuous, automated, event-driven
+- **Key activities**: Runs scoring workers, updates asset ledger, produces export packages, alerts on regressions
+
+## Information Architecture
+
+### Views and Routes
+- `/chairman/portfolio/exit-readiness` — Portfolio-level acquirability overview (all ventures, scores, exit models)
+- `/chairman/ventures/:id/exit` — Per-venture exit dashboard (asset registry, separability score history, data room status)
+- `/chairman/ventures/:id/data-room` — Data room viewer (generated artifacts, completeness %)
+- `/chairman/ventures/:id/separation-plan` — Separation plan with dependency map and dry-run status
+
+### Data Sources
+- `venture_asset_registry` — Asset inventory with provenance
+- `venture_exit_profiles` — Per-venture exit model, target buyer type, readiness score
+- `venture_separability_scores` — Time-series separability assessments
+- `venture_data_room_artifacts` — Generated due diligence documents
+- Existing: `ventures.pipeline_mode` (extended with `exit_prep`, `divesting`, `sold`)
+- Existing: `venture_financial_contract`, `eva_scheduler_metrics`
+
+### Navigation
+- Exit readiness is a tab within the existing Chairman venture detail view
+- Portfolio-level view is accessible from the main Chairman dashboard
+- Data room is a sub-view of the exit dashboard
+
+## Key Decision Points
+
+### Decision 1: When to enter Exit Preparation
+- Trigger: Manual chairman action (not automated)
+- The acquirability score is informational — it informs the decision but doesn't make it
+- A soft-gate warns if separability score has degraded below threshold for 3+ months
+
+### Decision 2: Exit model selection per venture
+- Mutable attribute with version history (may change as acquirer pool becomes clearer)
+- Options: `full_acquisition`, `licensing`, `revenue_share`
+- Each model has different data room requirements and separation scope
+
+### Decision 3: Separation validation frequency
+- During Operations: quarterly dry-run assessment (lightweight — schema analysis + dependency scan)
+- During Exit Prep: full separation rehearsal (heavyweight — attempted standalone deployment)
+- Dry-run failures produce actionable work items, not blockers
+
+### Decision 4: Asset provenance depth
+- Phase 1: Current-state inventory (what assets exist, who owns them)
+- Phase 2: Event-sourced ledger (when each asset was added/modified, by whom, under what terms)
+- Phase 2 is required for licensing and revenue share models where IP chain matters
+
+## Integration Patterns
+
+### With Existing Pipeline (Stages 0-25)
+- Acquirability criteria added as evaluation dimensions in stage templates (not new gates — added to existing gate evaluations)
+- Stage 0: "Is this venture concept separable by design?"
+- Build stages (18-22): "Are shared infrastructure dependencies documented?"
+- Launch stage (24): "Is the asset registry complete for launch?"
+- These are soft criteria that contribute to scores, not hard blockers
+
+### With Operations Mode Workers
+- New `ops_separability_score` worker (hourly) — computes separability based on infrastructure dependency scan
+- Extended `ops_financial_sync` — when Stripe integration is built, feeds MRR/ARR into exit profile
+- Extended `ops_status_snapshot` — includes separability score in snapshot
+- New `ops_data_room_refresh` worker (daily) — regenerates stale data room artifacts
+
+### With EVA Master Scheduler
+- New domain handlers registered via `registerExitReadinessHandlers(domainRegistry)`
+- Follows the same pattern as `registerOperationsHandlers()` in `domain-handler.js`
+
+### With Chairman Dashboard
+- New views consume existing `/api/eva/operations/status` (extended) plus new `/api/eva/exit/*` endpoints
+- Real-time updates via Supabase Realtime on `venture_separability_scores` and `venture_data_room_artifacts`
+
+## Evolution Plan
+
+**All 3 phases completed** — Orchestrator SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001 (Children A, B, C). See `docs/plans/venture-exit-readiness-architecture.md` for detailed deliverables per phase.
+
+### Phase 1: Foundation (Asset Registry + Exit Modes) — COMPLETED
+- Add `exit_prep`, `divesting`, `sold` to `pipeline_mode` CHECK constraint
+- Create `venture_asset_registry` table with provenance fields
+- Create `venture_exit_profiles` table (exit model, target buyer type, readiness metadata)
+- API endpoints for CRUD operations on assets and exit profiles
+- Chairman UI: exit readiness tab on venture detail view
+
+### Phase 2: Scoring + Workers — COMPLETED
+- Create `venture_separability_scores` table (time-series)
+- Implement `ops_separability_score` worker (infrastructure dependency analysis)
+- Implement `ops_data_room_refresh` worker (artifact generation)
+- Extend existing operations workers with exit-relevant data
+- Chairman UI: separability score history chart, data room status
+
+### Phase 3: Stage Integration + Validation — COMPLETED
+- Add acquirability criteria to stage templates (0, 18-22, 24) — 7 analysis step files
+- Implement separation rehearsal capability (5-dimension engine with weighted scoring)
+- Data room templates for 6 exit models (full_acquisition, licensing, acqui_hire, revenue_share, merger, wind_down)
+- Chairman V3 UI: `PortfolioExitReadiness.tsx` (portfolio dashboard), `SeparationPlanView.tsx` (venture detail)
+- 115 unit tests, 4 Phase 3 API endpoints
+
+## Out of Scope
+
+- **Legal entity creation** — The system tracks which legal entity owns each asset but does not create LLCs, draft IP assignment agreements, or file paperwork.
+- **Acquirer discovery / matchmaking** — Finding buyers is a business development function. The system prepares ventures for sale; it does not find buyers.
+- **Post-acquisition integration support** — Once a venture is sold, the pipeline's job is done. Buyer integration is the buyer's responsibility.
+- **Pricing / valuation models** — The system provides data for valuation (financials, metrics, asset inventory) but does not compute a price or multiple.
+- **Acqui-hire support** — Originally excluded from scope but implemented in Phase 3 as one of 6 supported exit models (full_acquisition, licensing, acqui_hire, revenue_share, merger, wind_down).
+
+## UI/UX Wireframes
+
+### Portfolio Exit Readiness View
+```
+┌─────────────────────────────────────────────────────────┐
+│ Portfolio Exit Readiness                                │
+├──────────────┬──────────┬─────────┬─────────┬──────────┤
+│ Venture      │ Mode     │ Exit    │ Separ.  │ Data Rm  │
+│              │          │ Model   │ Score   │ Complete │
+├──────────────┼──────────┼─────────┼─────────┼──────────┤
+│ Synthify     │ ops      │ full    │ 72%     │ 45%      │
+│ NicheSignal  │ ops      │ license │ 84%     │ 68%      │
+│ CreatorFlow  │ exit_prep│ full    │ 91%     │ 92%      │
+│ NicheBrief   │ build    │ —       │ 31%     │ 12%      │
+└──────────────┴──────────┴─────────┴─────────┴──────────┘
+```
+
+### Venture Exit Dashboard
+```
+┌─────────────────────────────────────────────────────────┐
+│ CreatorFlow AI — Exit Preparation                       │
+├─────────────────────────────────────────────────────────┤
+│ Exit Model: Full Acquisition    Status: exit_prep       │
+│                                                         │
+│ ┌─ Separability Score ──────────────────────────────┐   │
+│ │  91% ████████████████████░░  (+3% from last month) │   │
+│ │  History: 78% → 82% → 88% → 91%                   │   │
+│ └────────────────────────────────────────────────────┘   │
+│                                                         │
+│ ┌─ Asset Registry (14 assets) ──────────────────────┐   │
+│ │  Code Repos: 2    Domains: 1    Integrations: 4   │   │
+│ │  Customers: 847   Brand Assets: 3   API Keys: 4   │   │
+│ │  ⚠ 1 asset missing provenance (domain ownership)  │   │
+│ └────────────────────────────────────────────────────┘   │
+│                                                         │
+│ ┌─ Data Room (92% complete) ────────────────────────┐   │
+│ │  ✓ Financial summary   ✓ Customer list            │   │
+│ │  ✓ Technical arch doc  ✓ Dependency map           │   │
+│ │  ✓ Integration inventory  ○ Separation rehearsal  │   │
+│ │  Last refreshed: 2h ago                           │   │
+│ └────────────────────────────────────────────────────┘   │
+│                                                         │
+│ [Enter Divestiture Mode]  [Generate Data Room Export]   │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Success Criteria
+
+1. **Every venture has an asset registry** within 30 days of entering Build phase (Stage 18)
+2. **Separability score is computed hourly** for all ventures in Operations or Exit Prep mode
+3. **Data room can be generated on demand** in under 5 minutes for any venture in Exit Prep mode
+4. **Exit preparation phase reduces M&A timeline** — target: 50% reduction from current ad hoc baseline
+5. **Zero "surprise" shared infrastructure dependencies** during due diligence — all dependencies surfaced by the separability scorer before buyer engagement
+6. **Acquirability criteria are evaluated** at every stage gate from Stage 0 onward (as soft criteria, not blockers)
+7. **Multiple exit models supported** per venture with model-specific data room templates


### PR DESCRIPTION
## Summary
- Adds architecture and vision plan documents for the Venture Acquisition-Readiness Architecture
- All 3 phases marked as COMPLETED with SD keys (A, B, C), PR numbers (#1794, #1798, #1802, #219)
- Documents actual deliverables including items beyond original plan (acqui-hire support, 6 exit models, 115 unit tests)
- Updates acqui-hire scope note (originally excluded, now implemented)

## Test plan
- [x] Documentation only — no code changes
- [x] Pre-commit hooks passed (smoke tests, DOCMON, secret scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)