### PR TITLE
docs: add chairman venture table and EVA operations artifacts

### DIFF
--- a/brainstorm/2026-03-05-acquisition-readiness-gap-remediation.md
+++ b/brainstorm/2026-03-05-acquisition-readiness-gap-remediation.md
@@ -1,0 +1,106 @@
+# Brainstorm: Acquisition Readiness Gap Remediation
+
+## Metadata
+- **Date**: 2026-03-05
+- **Domain**: Architecture
+- **Phase**: Decide
+- **Mode**: Conversational
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: All active ventures (portfolio-level feature)
+- **Related Brainstorm**: "Venture Acquisition-Readiness Architecture" (2026-03-05) — the original brainstorm that produced the orchestrator SD
+
+---
+
+## Problem Statement
+
+The completed orchestrator SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001 (3 phases, 3 child SDs) delivered 90% of the specified scope. A gap analysis identified two concrete implementation gaps:
+
+1. **Route Registration Gap** — PRD FR-7 and FR-8 specified standalone routes for PortfolioExitReadiness (`/chairman/portfolio/exit-readiness`) and SeparationPlanView (`/chairman/ventures/:id/separation-plan`). Components exist and work but are only accessible as embedded tabs in VentureDetail.tsx — no standalone route pages were created.
+
+2. **Per-PR Separability Delta** — The original SD scope included CI integration for computing how each PR affects venture separability. This was intentionally deferred during implementation.
+
+## Discovery Summary
+
+### Current State
+- **PortfolioExitReadiness** (280 lines) — props-based portfolio dashboard. Exported from `chairman-v3/index.ts` but has no page integration or route.
+- **SeparationPlanView** (361 lines) — props-based per-venture view. Embedded as tab in `VentureDetail.tsx` (lines 236, 311) but no standalone route.
+- **Chairman V3** has 11 routes in `chairmanRoutesV3.tsx`, all lazy-loaded via `LazyRoute` + `ProtectedRouteWrapper` pattern.
+- **Separation rehearsal engine** exists at `lib/eva/exit/separation-rehearsal.js` (497 lines), scoring 5 dimensions with PASS_THRESHOLD=70.
+- **4 API endpoints** exist in `server/routes/eva-exit.js` for data fetching.
+
+### Decisions Made
+- **Route registration**: Option C — Keep tabs AND add standalone pages (both access patterns serve different mental models)
+- **Separability delta**: Option B — npm run script (not GitHub Action). Engine scores DB state, not code diff, so CI would show zero delta.
+- **Snapshot storage**: Option B — Database table (over filesystem JSON). Scored 8.10/10 in tradeoff matrix vs 5.85/10 for filesystem.
+
+## Analysis
+
+### Arguments For
+1. **PRD compliance** — FR-7 and FR-8 explicitly specify standalone routes
+2. **Deep-linkability** — standalone routes enable bookmarking/sharing for acquisition discussions
+3. **Separability trajectory** — delta snapshots over time become a differentiated M&A asset
+4. **Low effort, high option value** — ~1 week total for both gaps
+
+### Arguments Against
+1. **Dual-path data consistency risk** — two code paths fetching the same data can diverge
+2. **Manual delta script adoption** — without CI enforcement, may be unused when it matters
+3. **Maintenance surface expands** — 13 routes instead of 11, plus a new CLI tool
+
+### Tradeoff Matrix: Snapshot Storage
+
+| Dimension | Weight | Filesystem JSON | DB Table | Hybrid |
+|-----------|--------|----------------|----------|--------|
+| Complexity | 20% | 9/10 | 5/10 | 4/10 |
+| Maintainability | 25% | 7/10 | 8/10 | 5/10 |
+| Portability | 15% | 3/10 | 9/10 | 8/10 |
+| Auditability | 20% | 4/10 | 9/10 | 9/10 |
+| Future flexibility | 20% | 5/10 | 9/10 | 8/10 |
+
+**Winner: DB Table (8.10/10)** — filesystem scored < 3 on portability (critical weakness in acquisition context).
+
+Proposed table: `separability_snapshots` with columns `(id, venture_id, dimension_scores, overall_score, snapshot_type, triggered_by, created_at)`.
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**:
+  1. Dual data paths (tab wrapper vs page wrapper) will diverge unless tightly coupled via shared hooks
+  2. No deprecation plan for tab embeddings — maintenance surface doubles indefinitely
+  3. Delta script snapshots are ephemeral without a persistence layer
+- **Assumptions at Risk**:
+  1. DB state may not reflect actual separability (aspirational vs real coupling)
+  2. LazyRoute doesn't protect against data-fetching waterfalls in portfolio view
+  3. Manual process won't be followed under time pressure
+- **Worst Case**: Standalone page and tab show different scores during due diligence → trust-destroying inconsistency
+
+### Visionary
+- **Opportunities**:
+  1. Standalone pages become investor-facing surfaces with minimal permission layer
+  2. Delta snapshots as time-series produce separability trajectory charts
+  3. Props-based pattern enables PDF/export pipeline for board reporting
+- **Synergies**: Delta script plugs into existing rehearsal engine with zero duplication; lazy-loading pattern keeps new routes Tier 2 LOC
+- **Upside Scenario**: Acquirers receive defensible separability history tied to specific engineering decisions — commands a premium
+
+### Pragmatist
+- **Feasibility**: GAP 1 = 3/10, GAP 2 = 5/10
+- **Resource Requirements**: 1 developer, ~1 week, no external dependencies
+- **Constraints**: Snapshot storage decision is blocking for GAP 2; page wrappers need error boundaries
+- **Recommended Path**: GAP 1 first (2-3 hours, establishes data-fetching patterns), then GAP 2 (4-6 hours)
+
+### Synthesis
+- **Consensus Points**: Both gaps worth closing, GAP 1 is straightforward, snapshot storage is the critical decision for GAP 2
+- **Tension Points**: Dual-path consistency (Challenger) vs different mental models (Visionary) — resolved by shared data-fetching hook
+- **Composite Risk**: Low-Medium
+
+## Open Questions
+1. Should the delta script auto-trigger at SD completion (Visionary's suggestion) or remain manual-only?
+2. Should the portfolio exit readiness page aggregate all ventures or only active ones?
+3. What retention policy for separability snapshots? (Keep all vs rolling window)
+
+## Suggested Next Steps
+1. Create a corrective SD to address both gaps
+2. GAP 1 first: 2 page wrappers + route registration in chairmanRoutesV3.tsx
+3. GAP 2 second: `separability_snapshots` table + npm run script
+4. Shared data-fetching hook to mitigate Challenger's dual-path concern
+5. Future: wire delta into post-completion pipeline for automatic trajectory tracking

--- a/brainstorm/2026-03-05-chairman-venture-table-view.md
+++ b/brainstorm/2026-03-05-chairman-venture-table-view.md
@@ -1,0 +1,88 @@
+# Brainstorm: Chairman Venture Table View — Replace Swimlane with Portfolio Command Surface
+
+## Metadata
+- **Date**: 2026-03-05
+- **Domain**: Architecture
+- **Phase**: Explore
+- **Mode**: Conversational
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: All active ventures (cross-cutting UI change)
+
+---
+
+## Problem Statement
+The Chairman's primary venture view (`/chairman/ventures`) renders a 5-column swimlane (VentureLifecycleMap) where clicking a venture card opens a Sheet side panel with only 4 data fields (stage, AI score, status, validation score). There is no way to navigate to the full venture detail page (`/chairman/ventures/:id`), which has 8 tabs including the 25-stage workflow and exit readiness. No sorting or filtering exists. The Chairman cannot effectively manage a portfolio from this view.
+
+## Discovery Summary
+
+### Current State
+- `VentureLifecycleMap` renders 5 columns (being restructured to 6 by active SD)
+- `VentureDetailDrawer` (Sheet) shows: Stage, AI Score, Status, Validation Score + bar chart
+- No "View Details" button in the drawer — full detail page is unreachable
+- No sort, filter, or search capabilities
+- Full `VentureDetail` page exists at `/chairman/ventures/:id` with 8 tabs: Overview, Workflow, Research, Brand Variants, Financial, Team, Timeline, Exit
+- 3 of 8 tabs are placeholder stubs (Financial, Team, Timeline)
+
+### User Requirements
+- Replace swimlane entirely with a table/list view
+- Remove the side panel — clicking rows navigates to full detail page
+- Follow the Operations page pattern (`/chairman/operations`)
+- Include exit-readiness elements (pipeline mode, asset count, exit model)
+- Account for active 6-phase restructuring (5→6 columns, LAUNCH_LEARN→THE_LAUNCH, kill gates [3,5,13,23])
+
+### Reference Implementation
+- `OperationsDashboard` at `/chairman/operations` has the desired pattern:
+  - Summary cards at top (Total, Active, Avg Progress, Efficiency)
+  - Scrollable table with columns: Venture, Status, Stage, Progress, Health %, Last Activity
+  - Clickable rows navigate to detail page
+  - Real-time updates via WebSocket
+
+## Analysis
+
+### Arguments For
+- Gives Chairman direct access to venture detail pages (currently impossible from swimlane)
+- Adds sort/filter capability that doesn't exist today
+- Follows a proven pattern already in the codebase (Operations)
+- ~200 LOC — small, low-risk change
+- Makes the UI immune to future phase restructurings (phase is a badge, not a column position)
+- Removes ~70 lines of dead-end drawer code
+- Enables future portfolio-level triage ("show me all ventures in exit_prep sorted by asset count")
+
+### Arguments Against
+- Loses the spatial lifecycle clustering view (mitigated by phase-distribution summary chips)
+- Exit-readiness columns won't have data for most ventures yet (mitigated by deferring to Step 2)
+- VentureDetail page has 3 stub tabs (mitigated by hiding/de-emphasizing)
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: Schema drift between arch docs and actual DB; swimlane encodes spatial lifecycle info that tables destroy; detail page has 3 stub tabs
+- **Assumptions at Risk**: Operations pattern may not work for heterogeneous data; 6-phase restructuring is in-flight; exit-readiness data doesn't exist yet for most ventures
+- **Worst Case**: Spatial overview lost, empty exit columns undermine confidence, stub tabs exposed as primary landing
+
+### Visionary
+- **Opportunities**: Unified portfolio command surface (composable table reused across views); exit-readiness as first-class sort/filter dimension; kill-gate radar (computed "next kill gate" column)
+- **Synergies**: Table is immune to phase restructuring; exit-readiness backend already built; removes Sheet drawer code (~70 lines)
+- **Upside Scenario**: Table becomes central portfolio management surface, composable pattern propagates to LP Dashboard / Board View
+
+### Pragmatist
+- **Feasibility**: 3/10 difficulty — proven reference impl in codebase
+- **Resource Requirements**: ~200 LOC net change, 1 component + 1 hook, single SD child
+- **Constraints**: Exit-readiness data is per-venture API (N+1 queries), readiness_score not in DB yet, 6-phase restructuring should land first
+- **Recommended Path**: Step 1 — table with core columns (Name, Status, Phase, Stage, AI Score, Last Activity). Step 2 — add exit-readiness columns after bulk endpoint exists.
+
+### Synthesis
+- **Consensus**: Operations pattern is proven, Sheet should go, ~200 LOC, defer exit columns
+- **Tension**: Spatial awareness vs flat table (resolved: phase-distribution summary above table)
+- **Composite Risk**: Low
+
+## Open Questions
+- Should stub tabs (Financial, Team, Timeline) be hidden entirely or shown as "coming soon"?
+- Should a compact phase-distribution summary (venture count chips per phase) sit above the table?
+- When exit-readiness bulk endpoint lands, what column set is ideal?
+
+## Suggested Next Steps
+1. Generate Vision + Architecture Plan → Register in EVA
+2. Create SD for Step 1 (table view with core columns)
+3. After Venture Architecture ORCH-001 completes → create follow-up SD for exit-readiness columns

--- a/brainstorm/2026-03-05-venture-acquisition-readiness-architecture.md
+++ b/brainstorm/2026-03-05-venture-acquisition-readiness-architecture.md
@@ -1,0 +1,130 @@
+# Brainstorm: Venture Acquisition-Readiness Architecture
+
+## Metadata
+- **Date**: 2026-03-05
+- **Domain**: Architecture
+- **Phase**: Explore
+- **Mode**: Conversational
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: Synthify Studios, NicheSignal AI, CreatorFlow AI, NicheBrief AI
+
+---
+
+## Problem Statement
+
+EHG is a venture factory that evaluates, builds, launches, and operates ventures through a 25-stage pipeline. The end goal is to sell ventures via acquisition — but the current architecture has no concept of exit readiness. Ventures enter Operations mode (post-Stage 25) and can only be "parked" or "killed." There is no pipeline mode, scoring system, asset registry, or data room capability to support the business's core monetization event: selling ventures to buyers.
+
+The recent pipeline redesign (SD-LEO-ORCH-EVA-STAGE-PIPELINE-001, completed 2026-03-04) introduced 4 operating modes (Evaluation, Build, Launch, Operations) but treated Operations as the terminal state. The gap between "venture is operating" and "venture is sold" is entirely unaddressed in the architecture.
+
+## Discovery Summary
+
+### Exit Model
+- **Varies per venture** — not a single model. Must support:
+  - Full acquisition (code + data + customers + brand)
+  - Licensing / white-label (buyer licenses tech/brand, EHG retains IP)
+  - Revenue share / partial sale (buyer purchases revenue stake)
+- Acqui-hire explicitly excluded
+- Exit model is mutable — may shift as venture matures and acquirer pool becomes clearer
+
+### Timing
+- **Acquisition-readiness assessment starts at Stage 0** — baked into the earliest evaluation so ventures are designed for exit from birth
+- This doesn't mean the exit model is known at Stage 0 — it means the criteria for separability, data portability, and asset tracking are evaluated continuously
+
+### Infrastructure Strategy
+- **Shared infrastructure with documented separation plan** — ventures share EHG's Supabase instance, Express server, and worker scheduler during Build/Launch/Operations, but each venture has a documented path to standalone operation
+- Balance between cost efficiency (shared infra) and exit readiness (separation plan)
+
+### Score Impact
+- **Informational only** — the acquirability score does not auto-influence pipeline decisions. The Chairman decides manually. However, team analysis identified this as a risk — there should be at least a soft-gate that flags score degradation.
+
+## Analysis
+
+### Arguments For
+1. **Exit is EHG's business model** — The pipeline must produce sellable ventures. Currently it produces operating ventures with no exit readiness.
+2. **Cost of retrofitting is exponential** — Every month without separation boundaries makes eventual separation harder. Starting at Stage 0 is cheaper.
+3. **Competitive differentiation** — 30-day M&A readiness commands premium valuations. This is a structural advantage.
+4. **Builds on recent work** — Pipeline redesign just shipped. Infrastructure is fresh and well-understood.
+
+### Arguments Against
+1. **Only 4 real ventures** — Risk of over-engineering for hypothetical scale.
+2. **Pipeline redesign fatigue** — Modifying stage templates again immediately could introduce regressions.
+3. **Legal precedes technical** — Entity structure, IP assignment agreements are prerequisites the system can track but not create.
+
+## Architecture: Tradeoff Matrix
+
+### Option A: Minimal — Add pipeline_mode + asset registry only
+
+| Dimension | Weight | Score | Notes |
+|-----------|--------|-------|-------|
+| Complexity | 20% | 8 | Low complexity — additive schema changes |
+| Maintainability | 25% | 7 | Simple to maintain, but incomplete |
+| Performance | 20% | 9 | No runtime overhead |
+| Migration effort | 15% | 9 | ALTER TABLE + new tables only |
+| Future flexibility | 20% | 4 | No scoring, no dry-runs, no data room |
+| **Weighted** | | **7.15** | |
+
+### Option B: Full Exit Pipeline — modes + registry + scoring + dry-runs + data room
+
+| Dimension | Weight | Score | Notes |
+|-----------|--------|-------|-------|
+| Complexity | 20% | 4 | Significant: new workers, stage modifications, export system |
+| Maintainability | 25% | 6 | More surface area but well-structured if following existing patterns |
+| Performance | 20% | 7 | New workers add scheduler load but within existing capacity |
+| Migration effort | 15% | 5 | Schema changes + stage template mods + new operations workers |
+| Future flexibility | 20% | 9 | Complete exit readiness, live data rooms, separation rehearsals |
+| **Weighted** | | **6.30** | |
+
+### Option C: Phased — Registry + scoring first, exit pipeline + dry-runs later
+
+| Dimension | Weight | Score | Notes |
+|-----------|--------|-------|-------|
+| Complexity | 20% | 6 | Moderate: additive first, modifications second |
+| Maintainability | 25% | 8 | Clean phase boundaries |
+| Performance | 20% | 8 | Gradual scheduler load increase |
+| Migration effort | 15% | 7 | Spread across phases |
+| Future flexibility | 20% | 8 | Full capability eventually, lower initial risk |
+| **Weighted** | | **7.50** | **RECOMMENDED** |
+
+**Recommendation**: Option C (Phased) scores highest. It avoids the pipeline redesign fatigue risk by deferring stage template modifications while still delivering the foundational asset registry and scoring immediately.
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: Separation plans are theoretical without rehearsals; asset registry needs provenance/legal chain not just inventory; informational-only score has no correction pressure
+- **Assumptions at Risk**: Exit model is unknowable at Stage 0 (treat as mutable); data export ≠ data handoff (need validated migration artifacts); 4 ventures have heterogeneous separation complexity
+- **Worst Case**: Due diligence reveals shared infra entanglement that requires 6-8 weeks to resolve in a 30-45 day window. Deal collapses or reprices. All separability scores become suspect.
+
+### Visionary
+- **Opportunities**: Separability score as CI-level signal (per-PR delta); data room as live event-sourced product (not point-in-time doc); licensing relationships as proof-of-separability that generate revenue
+- **Synergies**: Acquirability criteria dual-purpose existing gate questions; operations dashboard naturally surfaces separability metrics; EHG's process IP (the factory methodology) is itself licensable
+- **Upside Scenario**: EHG closes acquisitions in 30 days vs. industry 60-180. Acquirers pay 6-10x multiples. The methodology becomes EHG's most valuable export.
+
+### Pragmatist
+- **Feasibility**: 7/10
+- **Resource Requirements**: Schema design, new operations workers, stage template criteria additions. Stripe + AARRR (already identified gaps) feed directly into financial diligence.
+- **Constraints**: Pipeline just redesigned (avoid destabilizing); small venture sample (avoid over-fitting); legal entity structure is offline business decision
+- **Recommended Path**: Start with Asset Registry + `exit_prep` mode (additive), then scoring worker, then stage template mods last
+
+### Synthesis
+- **Consensus**: Asset registry is essential (all 3); separation must be validated not just documented; exit model is mutable
+- **Tension**: Challenger wants provenance + legal rigor; Visionary wants event-sourcing + CI integration; both valid but different phases
+- **Composite Risk**: Medium — feasible but untested separation plans are the critical risk
+
+## Out of Scope
+1. Legal entity creation (LLC per venture, IP assignment agreements) — the system tracks these but does not create them
+2. Acquirer discovery / M&A matchmaking — this is a business development function, not a pipeline function
+3. Post-acquisition integration support — once the venture leaves EHG, the pipeline's job is done
+4. Pricing / valuation models — the system provides data for valuation but does not compute a price
+
+## Open Questions
+1. Should the asset registry track historical provenance (event-sourced) or current state only? (Visionary recommends event-sourced; Pragmatist says current state first, add history later)
+2. What constitutes a "separation rehearsal" in practice? A Docker compose that spins up the venture isolated? A migration script that exports and reimports into a fresh Supabase project?
+3. How do we handle ventures where the "product" is an AI model trained on shared EHG data? Is the model itself an asset, or only the fine-tuning?
+4. Should the operations dashboard show acquirability metrics alongside health metrics, or in a separate Chairman view?
+
+## Suggested Next Steps
+1. Create Vision document (`docs/plans/venture-exit-readiness-vision.md`)
+2. Create Architecture plan (`docs/plans/venture-exit-readiness-architecture.md`)
+3. Register both in EVA for HEAL scoring
+4. Create orchestrator SD with phased children (Phase 1: registry + mode, Phase 2: scoring + workers, Phase 3: stage templates + dry-runs)

--- a/docs/04_features/eva-post-pipeline-operations.md
+++ b/docs/04_features/eva-post-pipeline-operations.md
@@ -1,0 +1,326 @@
+---
+Category: Feature
+Status: Draft
+Version: 1.0.0
+Author: LEO Orchestrator
+Last Updated: 2026-03-05
+Tags: eva, operations, venture-lifecycle, background-workers
+---
+
+# Feature: EVA Post-Pipeline Operations Mode
+
+## Metadata
+- **Category**: Feature
+- **Status**: Draft
+- **Version**: 1.0.0
+- **Author**: LEO Orchestrator
+- **Last Updated**: 2026-03-05
+- **Tags**: eva, operations, venture-lifecycle, background-workers
+
+## Overview
+
+Post-Pipeline Operations Mode is the phase of the EVA venture lifecycle that begins after a venture completes the 25-stage evaluation-build-launch pipeline. Once a venture is live, it moves from gate-driven progression to continuous automated monitoring. Six background workers run on scheduled cadences to keep venture health data current, classify incoming feedback, track financial status, and surface enhancement signals.
+
+This document is written for developers building features against the Operations Mode API and for product stakeholders understanding what the system does for live ventures.
+
+For operator-level runbook content (worker infrastructure, known gaps, startup sequence), see the [Operations Mode Runbook](../06_deployment/eva-operations-mode.md).
+
+---
+
+## Table of Contents
+
+- [Feature Overview](#feature-overview)
+- [Activation](#activation)
+- [Continuous Services](#continuous-services)
+- [API Reference](#api-reference)
+- [Frontend Dashboard](#frontend-dashboard)
+- [Related Documentation](#related-documentation)
+
+---
+
+## Feature Overview
+
+When a venture completes Stage 25 (Launch Execution), the EVA pipeline hands off responsibility to the Operations Mode subsystem. From this point forward the venture is "live" — it has cleared every evaluation gate, been built, and been launched. The pipeline's job is done.
+
+Operations Mode provides:
+
+1. **Automated health monitoring** — the system continuously checks registered services for the venture and reports overall health.
+2. **Financial contract verification** — an hourly check confirms the venture has a valid financial contract on record.
+3. **Feedback classification** — incoming feedback items are automatically tagged with dimension codes so the product team can triage by category.
+4. **Metrics collection** — pipeline throughput metrics are gathered every six hours and persisted for reporting.
+5. **Enhancement detection** — daily scan of retrospectives surfaces improvement signals and queues them for the LEO protocol backlog.
+6. **Operations snapshot** — an hourly status snapshot aggregates all subsystems into a single record for dashboard consumption.
+
+A venture stays in Operations Mode indefinitely. Operators can manually set `pipeline_mode = 'parked'` to suspend workers for a venture or `pipeline_mode = 'killed'` to terminate it permanently.
+
+---
+
+## Implementation Status at a Glance
+
+This section provides a clear picture of what works today, what partially works, and what still needs to be built.
+
+### What Works Today
+
+| Component | Details |
+|-----------|---------|
+| **Health Scoring** (`ops_health_score`) | Fully functional. Sweeps stale services, computes aggregate health status, runs hourly. |
+| **Operations Snapshot** (`ops_status_snapshot`) | Fully functional. Aggregates all subsystems into a persisted snapshot, runs hourly. Gracefully handles individual subsystem failures. |
+| **Worker Infrastructure** | `BaseWorker`, `WorkerScheduler`, circuit breaker (trips after 3 failures), graceful shutdown — all operational. |
+| **Master Scheduler Integration** | `registerOperationsHandlers()` correctly wires all 6 handlers into the scheduler domain registry. |
+| **REST API** | `GET /api/eva/operations/status` and `GET /api/eva/operations/workers` — mounted and returning data. |
+| **Pipeline Mode Column** | `ventures.pipeline_mode` CHECK constraint enforced (`evaluation`, `build`, `launch`, `operations`, `parked`, `killed`). |
+
+### What Partially Works
+
+| Component | What Works | What's Missing |
+|-----------|-----------|----------------|
+| **Feedback Classifier** (`ops_feedback_classify`) | Keyword classifier module exists and assigns dimension codes. | `feedback_items` table has no migration — worker will circuit-break if table doesn't exist. |
+| **Metrics Collector** (`ops_metrics_collect`) | Collects pipeline throughput (active ventures, stage completions). | Does not collect AARRR business metrics (Acquisition, Activation, Retention, Revenue, Referral). |
+| **Enhancement Detector** (`ops_enhancement_detect`) | Signal detection from retrospectives works. | `captureSignals()` called with `{ supabase }` but function expects `{ sessionId, sdId }` — signals detected but not persisted. No auto-creation of SDs from signals. |
+| **Financial Sync** (`ops_financial_sync`) | Checks whether `venture_financial_contract` record exists. | No Stripe or payment provider integration. No revenue/subscription/billing data pulled. |
+
+### What Still Needs to Be Built
+
+| Component | Description | Tracked By |
+|-----------|-------------|------------|
+| **Customer Service Agent** | Planned as a continuous service for retention monitoring and customer success outreach. Zero implementation — no handler, no module, no DB schema. | Not yet tracked as an SD |
+| **Operations Dashboard UI** | Chairman pages for monitoring ventures in operations mode. Routes: `/chairman/operations`, `/chairman/operations/:ventureId`. Backend APIs are ready. | SD-LEO-FEAT-EVA-OPERATIONS-DASHBOARD-001 (planning) |
+| **Pipeline-to-GUI Wiring** | Stage visualization including Stage 25 terminus handoff. Backend data layer exists. | SD-LEO-FEAT-EVA-PIPELINE-GUI-001 (planning) |
+| **Stripe Integration** | Connect Financial Sync worker to Stripe for MRR/ARR/CAC/LTV tracking. | Not yet tracked as an SD |
+| **AARRR Metrics Framework** | Per-venture business metrics (Acquisition, Activation, Retention, Revenue, Referral) from external analytics. | Not yet tracked as an SD |
+| **`feedback_items` Migration** | Database migration to create the `feedback_items` table and unblock the feedback classifier. | Not yet tracked as an SD |
+| **`captureSignals` Fix** | Fix parameter mismatch so enhancement signals are persisted to Supabase, not just detected in-memory. | Not yet tracked as an SD |
+
+---
+
+## Activation
+
+### Trigger
+
+Operations Mode activates when Stage 25's completion handler writes `pipeline_mode = 'operations'` to the `ventures` table. This happens automatically; no manual step is required.
+
+### Pipeline Mode Values
+
+The `pipeline_mode` column on the `ventures` table tracks which phase owns the venture:
+
+| Value | Meaning |
+|---|---|
+| `evaluation` | Stages 0–17 — idea screening and evaluation |
+| `build` | Stages 18–22 — product development |
+| `launch` | Stages 23–25 — marketing, readiness, and go-live |
+| `operations` | Post-pipeline — continuous automated services active |
+| `parked` | Suspended — workers paused, venture on hold |
+| `killed` | Terminated — venture archived, no further processing |
+
+### What Changes at Activation
+
+Before Stage 25 completes, the venture is governed by stage gate logic (pass/fail gates, stage templates, analysis steps). After activation:
+
+- Stage gate execution stops for this venture.
+- The Master Scheduler begins including the venture in the worker processing scope (`status IN ('active', 'in_progress')` queries).
+- The venture appears in the Operations dashboard (when SD-LEO-FEAT-EVA-OPERATIONS-DASHBOARD-001 is implemented).
+
+---
+
+## Continuous Services
+
+Each worker runs independently on its own cadence. A worker failure (up to 3 consecutive) trips its circuit breaker; the worker resumes on the next successful run or after a manual `resetCircuitBreaker()` call.
+
+### Financial Sync (Hourly)
+
+**Handler**: `ops_financial_sync`
+
+Queries `eva_ventures` for active and in-progress ventures and calls `getContract()` from `lib/eva/contracts/financial-contract.js` for each. Confirms a `venture_financial_contract` record exists.
+
+What this means for your venture: the system will alert (via logs) if a financial contract record is missing. It does not currently verify contract terms, check payment processor status, or connect to Stripe.
+
+**Current status**: stub implementation — contract existence check only.
+
+### Feedback Classification (Every 10 minutes)
+
+**Handler**: `ops_feedback_classify`
+
+Fetches up to 20 `feedback_items` rows where `dimension_code IS NULL` and calls `classifyFeedback()` to assign each item a dimension code. The classifier assigns a category (e.g., UX, performance, reliability) so product teams can filter and prioritize feedback.
+
+What this means for your venture: unclassified feedback submitted after the venture goes live is automatically categorized. Manual triage of raw feedback entries should decrease significantly once the classifier is running.
+
+**Current status**: partial — classifier module exists; `feedback_items` table migration not confirmed.
+
+### Metrics Collection (Every 6 hours)
+
+**Handler**: `ops_metrics_collect`
+
+Records pipeline throughput metrics: count of active ventures and count of stage gate passes in the prior 6-hour window. Persisted to `eva_scheduler_metrics` as `metric_type = 'ops_pipeline_throughput'`.
+
+What this means for your venture: provides data for platform-level health dashboards. Per-venture AARRR business metrics (Acquisition, Activation, Retention, Revenue, Referral) are not yet collected.
+
+**Current status**: partial — pipeline throughput only, no AARRR metrics.
+
+### Health Scoring (Hourly)
+
+**Handler**: `ops_health_score`
+
+Calls `sweepStaleServices()` to remove expired service registrations, then `getSystemHealth()` to compute an overall health status across all registered services. Returns service count and a `healthy`/`unhealthy` status.
+
+What this means for your venture: if services associated with the venture (e.g., integrations, background processors) go stale, they are swept and the health status reflects the current live service count. This is the most reliable of the six workers.
+
+**Current status**: functional.
+
+### Enhancement Detection (Daily)
+
+**Handler**: `ops_enhancement_detect`
+
+Scans retrospectives created in the prior 24 hours. For each retrospective, concatenates `what_went_well`, `what_needs_improvement`, and `key_learnings` and passes the text to `captureSignals()`. Detected signals are queued for the LEO protocol improvement backlog.
+
+What this means for your venture: learnings captured in retrospectives during the venture's build and launch phases feed back into the broader LEO system, improving future evaluations and processes.
+
+**Current status**: partial — signal capture may fail due to a parameter mismatch in `captureSignals()`.
+
+### Operations Snapshot (Hourly)
+
+**Handler**: `ops_status_snapshot`
+
+Calls `getOperationsStatus()` which fans out to all six subsystems in parallel using `Promise.allSettled()`. The result is persisted to `eva_scheduler_metrics` as `metric_type = 'ops_status_snapshot'`. Individual subsystem failures do not fail the snapshot — they appear as `{ status: 'error' }` entries.
+
+What this means for your venture: the operations dashboard can show a point-in-time status history without querying all subsystems on every page load. The snapshot is the data source for trend views.
+
+**Current status**: functional.
+
+---
+
+## API Reference
+
+Two REST endpoints are available for querying operations status programmatically. The base path is `/api/eva/operations`.
+
+### GET /api/eva/operations/status
+
+Returns the current aggregated status of all six operations subsystems. Use this endpoint to build dashboards, health monitors, or alerts.
+
+**Authentication**: inherits the application's standard authentication middleware.
+
+**Example request**:
+```
+GET /api/eva/operations/status
+```
+
+**Example response**:
+```json
+{
+  "timestamp": "2026-03-05T14:00:00.000Z",
+  "subsystems": {
+    "health": {
+      "subsystem": "health-monitor",
+      "status": "healthy",
+      "serviceCount": 4,
+      "lastCheck": "2026-03-05T13:59:45.000Z"
+    },
+    "metrics": {
+      "subsystem": "metrics-collector",
+      "status": "active",
+      "recentMetrics": 5,
+      "lastCollected": "2026-03-05T12:01:00.000Z"
+    },
+    "feedback": {
+      "subsystem": "feedback-classifier",
+      "status": "active",
+      "last24hItems": 12
+    },
+    "enhancements": {
+      "subsystem": "enhancement-detector",
+      "status": "active",
+      "pendingEnhancements": 3
+    },
+    "financial": {
+      "subsystem": "financial-sync",
+      "status": "active",
+      "lastSync": "2026-03-05T13:00:00.000Z"
+    },
+    "scheduler": {
+      "subsystem": "scheduler",
+      "status": "active",
+      "instanceId": "scheduler-001",
+      "lastHeartbeat": "2026-03-05T13:59:50.000Z",
+      "pendingJobs": 0
+    }
+  },
+  "overall": "healthy"
+}
+```
+
+The `overall` field summarizes all subsystems:
+- `"healthy"` — every subsystem is `active` or `healthy`
+- `"degraded"` — at least one subsystem is `error` or `unhealthy`
+- `"unknown"` — mixed or unrecognized statuses
+
+Individual subsystem errors appear inline as:
+```json
+{ "subsystem": "metrics-collector", "status": "error", "error": "relation does not exist" }
+```
+
+### GET /api/eva/operations/workers
+
+Returns the static cadence configuration for all registered workers. Does not hit the database. Useful for building worker status UIs or verifying scheduler configuration.
+
+**Example request**:
+```
+GET /api/eva/operations/workers
+```
+
+**Example response**:
+```json
+{
+  "workers": {
+    "ops_financial_sync": "hourly",
+    "ops_feedback_classify": "frequent",
+    "ops_metrics_collect": "six_hourly",
+    "ops_health_score": "hourly",
+    "ops_enhancement_detect": "daily",
+    "ops_status_snapshot": "hourly"
+  }
+}
+```
+
+### Querying Operations Status in React
+
+Example using `@tanstack/react-query`:
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+
+function useOperationsStatus() {
+  return useQuery({
+    queryKey: ['eva', 'operations', 'status'],
+    queryFn: async () => {
+      const res = await fetch('/api/eva/operations/status');
+      if (!res.ok) throw new Error('Failed to fetch operations status');
+      return res.json();
+    },
+    refetchInterval: 60_000, // refresh every minute
+  });
+}
+```
+
+---
+
+## Frontend Dashboard
+
+The Operations dashboard is planned under **SD-LEO-FEAT-EVA-OPERATIONS-DASHBOARD-001**. When implemented it will provide:
+
+- **Overview page** (`/chairman/operations`) — list of all ventures in operations mode with overall health badges, last-seen timestamps for each worker, and a count of pending feedback items.
+- **Venture detail page** (`/chairman/operations/:ventureId`) — per-venture breakdown of each worker's last run, subsystem health, pending enhancements, and financial contract status.
+- **Real-time updates** — Supabase Realtime subscriptions on `eva_scheduler_metrics` to push worker run results without manual refresh.
+
+The dashboard consumes `GET /api/eva/operations/status` for the health panel and `GET /api/eva/operations/workers` for the cadence reference panel.
+
+A companion pipeline visualization GUI (**SD-LEO-FEAT-EVA-PIPELINE-GUI-001**) will show the Stage 25 terminus handoff that triggers operations mode activation, giving operators a visual record of when a venture transitioned from the pipeline.
+
+---
+
+## Related Documentation
+
+- [EVA Operations Mode — Operational Runbook](../06_deployment/eva-operations-mode.md)
+- [EVA Pipeline Redesign Architecture](../plans/eva-pipeline-redesign-architecture.md)
+
+---
+
+*Feature Documentation Version: 1.0.0 | Last Updated: 2026-03-05 | Source SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I*

--- a/docs/06_deployment/eva-operations-mode.md
+++ b/docs/06_deployment/eva-operations-mode.md
@@ -1,0 +1,341 @@
+---
+Category: Deployment
+Status: Draft
+Version: 1.0.0
+Author: LEO Orchestrator
+Last Updated: 2026-03-05
+Tags: eva, operations, background-workers, post-pipeline
+---
+
+# EVA Operations Mode — Operational Runbook
+
+## Metadata
+- **Category**: Deployment
+- **Status**: Draft
+- **Version**: 1.0.0
+- **Author**: LEO Orchestrator
+- **Last Updated**: 2026-03-05
+- **Tags**: eva, operations, background-workers, post-pipeline
+
+## Overview
+
+Operations Mode is the post-pipeline phase of the EVA venture lifecycle. It activates automatically when a venture completes Stage 25 (Launch Execution), the terminus of the 25-stage evaluation-build-launch pipeline. At that point the venture's `pipeline_mode` column transitions from `'launch'` to `'operations'` and six background workers take over ongoing venture management.
+
+Operations Mode replaces the staged gate-driven evaluation model with a continuous, cadence-driven service layer. Workers run on fixed schedules managed by the EVA Master Scheduler. Unlike pipeline stages, there is no exit gate — a venture stays in Operations Mode until it is explicitly parked (`'parked'`) or killed (`'killed'`).
+
+**Source SD**: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+**Key modules**: `lib/eva/operations/`, `lib/eva/workers/`, `server/routes/eva-operations.js`
+
+---
+
+## Current Implementation Status
+
+### Operational (Production-Ready)
+
+- **Health Scorer** (`ops_health_score`) — sweeps stale services, reports aggregate health. Hourly cadence.
+- **Operations Snapshot** (`ops_status_snapshot`) — persists full subsystem status to `eva_scheduler_metrics`. Hourly cadence.
+- **Worker Infrastructure** — `BaseWorker` lifecycle, `WorkerScheduler` registry, circuit breaker, graceful shutdown all functional.
+- **Master Scheduler Integration** — all 6 handlers registered via `registerOperationsHandlers()`.
+- **REST API** — both endpoints (`/status`, `/workers`) mounted and returning data.
+
+### Partially Implemented (Needs Fixes Before Reliable)
+
+| Worker | What Works | Blocker |
+|--------|-----------|---------|
+| `ops_feedback_classify` | Classifier logic assigns dimension codes | `feedback_items` table migration missing — circuit-breaks if absent |
+| `ops_metrics_collect` | Pipeline throughput collection | No AARRR business metrics; infrastructure metrics only |
+| `ops_enhancement_detect` | Signal pattern detection | `captureSignals()` param mismatch — signals not persisted |
+| `ops_financial_sync` | Contract existence check | No Stripe/payment provider integration |
+
+### Not Yet Built
+
+| Component | Description |
+|-----------|-------------|
+| Customer Service Agent | Continuous retention monitoring/outreach — no code exists |
+| Operations Dashboard UI | Chairman pages at `/chairman/operations` — tracked by SD-LEO-FEAT-EVA-OPERATIONS-DASHBOARD-001 |
+| Pipeline-to-GUI Wiring | Stage visualization UI — tracked by SD-LEO-FEAT-EVA-PIPELINE-GUI-001 |
+| Stripe Integration | MRR/ARR/CAC/LTV sync for Financial Sync worker |
+| AARRR Metrics | Per-venture Acquisition/Activation/Retention/Revenue/Referral collection |
+
+---
+
+## Pipeline Mode Lifecycle
+
+The `pipeline_mode` column on the `ventures` table controls which phase of the EVA system is responsible for a venture. Valid values and their transitions are:
+
+| Value | Phase | Entered when |
+|---|---|---|
+| `evaluation` | Stages 0–17 (Evaluation) | Venture is created and enters Stage 0 |
+| `build` | Stages 18–22 (Build) | Venture passes Stage 17 promotion gate |
+| `launch` | Stages 23–25 (Launch) | Venture passes Stage 22 release gate |
+| `operations` | Post-pipeline Operations | Stage 25 (Launch Execution) completes |
+| `parked` | Suspended | Manual operator action |
+| `killed` | Terminated | Manual operator action or kill-gate failure |
+
+**Transition rule**: only Stage 25's completion handler writes `pipeline_mode = 'operations'`. No other path should set this value directly.
+
+**Parked vs. killed**:
+- `parked` — workers stop running for this venture; the venture can be un-parked.
+- `killed` — terminal state; venture is archived and workers will not process it.
+
+---
+
+## Background Workers
+
+Six workers are registered with the EVA Master Scheduler via `registerOperationsHandlers()` in `lib/eva/operations/domain-handler.js`. Each is a domain handler (a plain async function) registered against a named key in the scheduler's domain registry, not a subclass of `BaseWorker`.
+
+| Worker key | Cadence | What it does | Implementation status |
+|---|---|---|---|
+| `ops_financial_sync` | Hourly | Queries active/in-progress ventures and verifies each has a financial contract via `getContract()`. Logs contract presence; does **not** sync to Stripe or any payment provider. | **STUB** — contract existence check only. No Stripe integration. |
+| `ops_feedback_classify` | Every 10 min (frequent) | Fetches unclassified rows from `feedback_items` (where `dimension_code IS NULL`, up to 20 per run) and calls `classifyFeedback()` to assign a dimension code. | **PARTIAL** — classifier logic exists but `feedback_items` table has no confirmed migration. May fail if table is absent. |
+| `ops_metrics_collect` | Every 6 hours | Counts active ventures and stages completed in the prior 6 h window from `eva_stage_gate_results`, then inserts a `'ops_pipeline_throughput'` snapshot into `eva_scheduler_metrics`. Collects pipeline throughput only — not AARRR metrics. | **PARTIAL** — cadence mismatch: domain handler registers as `'six_hourly'` but the scheduler maps this interval inconsistently with other hourly workers. No AARRR (Acquisition, Activation, Retention, Revenue, Referral) metrics collected. |
+| `ops_health_score` | Hourly | Calls `sweepStaleServices()` then `getSystemHealth()` from `hub-health-monitor.js`. Returns service count and overall health status. | **FUNCTIONAL** — health monitor is implemented and operational. |
+| `ops_enhancement_detect` | Daily | Fetches retrospectives from the last 24 h and calls `captureSignals()` for each. Detected signals are enhancement candidates for the LEO backlog. | **PARTIAL** — `captureSignals()` is called with only `(text, { supabase })` but its signature may require additional params (param mismatch risk). |
+| `ops_status_snapshot` | Hourly | Calls `getOperationsStatus()` (aggregates all subsystems) and persists the result to `eva_scheduler_metrics` as `'ops_status_snapshot'`. | **FUNCTIONAL** — depends on subsystem health; degrades gracefully if subsystems are unavailable. |
+
+> Note: A seventh conceptual service — Customer Success Agent — was identified during architecture planning but **has no implementation**. It is not registered as a handler and does not run.
+
+### Cadence Reference
+
+Cadences are declared in the exported `OPERATIONS_CADENCES` constant in `domain-handler.js`:
+
+```js
+export const OPERATIONS_CADENCES = {
+  ops_financial_sync:     'hourly',
+  ops_feedback_classify:  'frequent',   // ~10 min
+  ops_metrics_collect:    'six_hourly',
+  ops_health_score:       'hourly',
+  ops_enhancement_detect: 'daily',
+  ops_status_snapshot:    'hourly',
+};
+```
+
+---
+
+## Worker Infrastructure
+
+### BaseWorker (`lib/eva/workers/base-worker.js`)
+
+All scheduled background work in EVA uses `BaseWorker` as the abstract base class. Domain handlers registered via `registerOperationsHandlers()` are wrapped by the scheduler; the `BaseWorker` class provides the lifecycle layer that any direct subclass would inherit.
+
+Key properties and behavior:
+
+| Property | Default | Description |
+|---|---|---|
+| `intervalMs` | 60 000 ms | How often `execute()` is called |
+| `maxRetries` | 3 | Consecutive failures before circuit-breaker trips |
+| `_consecutiveFailures` | 0 | Resets to 0 on any success |
+| `_totalRuns` | 0 | Monotonic counter of all executions |
+| `_totalErrors` | 0 | Monotonic counter of all errors |
+
+**Start behavior**: `start()` calls `_tick()` immediately on startup, then sets an interval. Workers do not wait one full interval before the first run.
+
+**Circuit breaker**: when `_consecutiveFailures >= maxRetries`, `_tick()` logs a `'circuit-broken'` event and skips execution. Call `resetCircuitBreaker()` to resume. The circuit breaker is per-instance and does not persist across process restarts.
+
+**Health check**: `health()` returns:
+
+```js
+{
+  name: string,
+  running: boolean,
+  lastRun: Date | null,
+  lastError: string | null,
+  consecutiveFailures: number,
+  totalRuns: number,
+  totalErrors: number,
+  circuitBroken: boolean,
+}
+```
+
+### WorkerScheduler (`lib/eva/workers/worker-scheduler.js`)
+
+`WorkerScheduler` is a registry and lifecycle manager for `BaseWorker` instances.
+
+**Key methods**:
+
+| Method | Description |
+|---|---|
+| `register(worker)` | Add a worker. Throws if a worker with the same name is already registered. |
+| `startAll()` | Call `start()` on every registered worker. |
+| `stopAll()` | Call `stop()` on every registered worker. |
+| `healthCheck()` | Return a map of `workerName → health()` for all workers. |
+| `get(name)` | Retrieve a single worker by name (returns `null` if not found). |
+| `list()` | Return an array of registered worker names. |
+| `installShutdownHandlers()` | Register `SIGINT`/`SIGTERM` handlers that call `stopAll()` and run any `onShutdown()` callbacks. Call once after registering all workers. |
+| `onShutdown(fn)` | Register an additional cleanup callback invoked during graceful shutdown. |
+
+---
+
+## Master Scheduler Integration
+
+Operations handlers are registered with the EVA Master Scheduler via `registerOperationsHandlers(domainRegistry)` exported from `lib/eva/operations/domain-handler.js`.
+
+The function accepts the scheduler's `domainRegistry` (a `ServiceRegistry` instance) and calls `domainRegistry.register(key, handler)` for each of the six workers. The scheduler is responsible for invoking each handler at the declared cadence with a `params` object containing at minimum `{ supabase, logger }`.
+
+**Startup sequence** (expected):
+
+1. Server process starts.
+2. Supabase client is initialized and attached to `app.locals.supabase`.
+3. `WorkerScheduler` is instantiated.
+4. `registerOperationsHandlers(scheduler.domainRegistry)` is called.
+5. `scheduler.startAll()` is called.
+6. `scheduler.installShutdownHandlers()` is called.
+
+**Important**: `registerOperationsHandlers` uses dynamic `import()` inside each handler to load subsystem modules lazily. This avoids circular dependency issues at startup but means the first invocation of each handler carries a module-load overhead.
+
+---
+
+## API Endpoints
+
+The Operations REST API is mounted under `/api/eva/operations` via `server/routes/eva-operations.js`. The router must be wired into the Express application with `app.use('/api/eva/operations', evaOperationsRouter)`.
+
+### GET /api/eva/operations/status
+
+Returns aggregated status from all EVA operations subsystems. Calls `getOperationsStatus()` from `lib/eva/operations/index.js`, which fans out to six subsystem queries using `Promise.allSettled()`. Individual subsystem failures do not cause a 500 response — they surface as `{ status: 'error', error: '<message>' }` entries within the response.
+
+**Response shape**:
+
+```json
+{
+  "timestamp": "2026-03-05T14:00:00.000Z",
+  "subsystems": {
+    "health": {
+      "subsystem": "health-monitor",
+      "status": "healthy",
+      "serviceCount": 4,
+      "lastCheck": "2026-03-05T13:59:45.000Z"
+    },
+    "metrics": {
+      "subsystem": "metrics-collector",
+      "status": "active",
+      "recentMetrics": 5,
+      "lastCollected": "2026-03-05T12:01:00.000Z"
+    },
+    "feedback": {
+      "subsystem": "feedback-classifier",
+      "status": "active",
+      "last24hItems": 12
+    },
+    "enhancements": {
+      "subsystem": "enhancement-detector",
+      "status": "active",
+      "pendingEnhancements": 3
+    },
+    "financial": {
+      "subsystem": "financial-sync",
+      "status": "active",
+      "lastSync": "2026-03-05T13:00:00.000Z"
+    },
+    "scheduler": {
+      "subsystem": "scheduler",
+      "status": "active",
+      "instanceId": "scheduler-001",
+      "lastHeartbeat": "2026-03-05T13:59:50.000Z",
+      "pendingJobs": 0
+    }
+  },
+  "overall": "healthy"
+}
+```
+
+**`overall` values**:
+- `"healthy"` — all subsystems report `active` or `healthy`
+- `"degraded"` — at least one subsystem reports `error` or `unhealthy`
+- `"unknown"` — mixed/unrecognized statuses
+
+**Error response (500)**:
+```json
+{ "error": "Failed to get operations status", "message": "<detail>" }
+```
+
+---
+
+### GET /api/eva/operations/workers
+
+Returns the static cadence configuration for all registered workers. This endpoint reads directly from the `OPERATIONS_CADENCES` export in `domain-handler.js` and does not hit the database.
+
+**Response shape**:
+
+```json
+{
+  "workers": {
+    "ops_financial_sync": "hourly",
+    "ops_feedback_classify": "frequent",
+    "ops_metrics_collect": "six_hourly",
+    "ops_health_score": "hourly",
+    "ops_enhancement_detect": "daily",
+    "ops_status_snapshot": "hourly"
+  }
+}
+```
+
+**Error response (500)**:
+```json
+{ "error": "Failed to get worker config", "message": "<detail>" }
+```
+
+---
+
+## Known Gaps and Recommended Actions
+
+The following gaps were identified during the SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I audit (2026-03-05). Each gap requires a follow-on SD or targeted fix before Operations Mode can be considered production-ready.
+
+For the full "what exists vs. what's planned" breakdown, see the [Implementation Status section in the feature doc](../04_features/eva-post-pipeline-operations.md#implementation-status-at-a-glance).
+
+### Gap 1 — Customer Service Agent is Missing
+
+The architecture identified a Customer Success Agent as a continuous service for ventures in operations mode. No implementation exists. The handler key `ops_cs_agent` is not registered, and there is no corresponding module in `lib/eva/`.
+
+**Impact**: Ventures in operations mode receive no automated customer success outreach or retention monitoring.
+**Recommended action**: Create a new SD to implement the CS Agent worker, including DB schema for customer interaction tracking and the `ops_cs_agent` domain handler.
+
+### Gap 2 — `feedback_items` Table Has No Confirmed Migration
+
+The `ops_feedback_classify` worker queries `feedback_items` with `.from('feedback_items')`. There is no migration file in the repo confirming this table exists in the production schema. If the table is absent, the worker will error on every run, triggering its circuit breaker after 3 consecutive failures.
+
+**Impact**: Feedback classification silently stops after 3 failures at startup.
+**Recommended action**: Quick fix — create migration `database/migrations/YYYYMMDD_feedback_items.sql` with the required schema (at minimum: `id`, `venture_id`, `content`, `dimension_code`, `created_at`).
+
+### Gap 3 — `captureSignals` Parameter Mismatch
+
+The `ops_enhancement_detect` handler calls `captureSignals(text, { supabase })`. The `captureSignals` function in `lib/retrospective-signals/index.js` expects `{ sessionId, sdId }`. The `supabase` parameter is silently ignored, so signals are detected in-memory but never persisted.
+
+**Impact**: Enhancement signals from retrospectives are not captured, starving the LEO enhancement backlog.
+**Recommended action**: Quick fix — update the call in `lib/eva/operations/domain-handler.js` to pass the correct parameters, or update `captureSignals` to accept and use the `supabase` client for persistence.
+
+### Gap 4 — No AARRR Metrics Collected
+
+The `ops_metrics_collect` worker collects pipeline throughput (active venture count, stage completions per 6 h window). It does not collect any AARRR-framework metrics (Acquisition, Activation, Retention, Revenue, Referral) that would provide meaningful business health signals for ventures in live operation.
+
+**Impact**: Operations dashboard has no customer-facing health data; metrics stored are infrastructure-level only.
+**Recommended action**: Create a new SD to define the AARRR metrics schema, integrate with product analytics sources, and extend `ops_metrics_collect` or add a dedicated AARRR handler.
+
+### Gap 5 — No Stripe Integration in Financial Sync
+
+The `ops_financial_sync` worker verifies that a `venture_financial_contract` record exists for each venture. It does not connect to Stripe or any payment processor. Revenue data, subscription status, and billing health are not checked.
+
+**Impact**: Financial health monitoring is a contract-existence check only. Revenue anomalies are undetectable.
+**Recommended action**: Create a new SD to integrate Stripe webhooks and API polling into the financial sync worker. Requires Stripe API key configuration and a `venture_financial_metrics` table for MRR/ARR/CAC/LTV tracking.
+
+---
+
+## Follow-on SDs
+
+The following SDs extend or build on Operations Mode:
+
+- **SD-LEO-FEAT-EVA-OPERATIONS-DASHBOARD-001** — Frontend operations dashboard. Provides a Chairman UI for monitoring ventures in operations mode. Consumes `GET /api/eva/operations/status` and worker health data. Routes: `/chairman/operations` and `/chairman/operations/:ventureId`.
+
+- **SD-LEO-FEAT-EVA-PIPELINE-GUI-001** — Pipeline visualization GUI. Provides stage-by-stage progress visualization for ventures moving through Evaluation → Build → Launch → Operations. Includes the Stage 25 terminus handoff visualization.
+
+---
+
+## Related Documentation
+
+- [EVA Post-Pipeline Operations — Feature Documentation](../04_features/eva-post-pipeline-operations.md)
+- [EVA Pipeline Redesign Architecture](../plans/eva-pipeline-redesign-architecture.md)
+- [Infrastructure Hardening Runbook](./infrastructure-hardening-runbook.md)
+- [Deployment Operations](./deployment_ops.md)
+
+---
+
+*Runbook Version: 1.0.0 | Last Updated: 2026-03-05 | Source SD: SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I*

--- a/docs/plans/archived/sd-leo-feat-chairman-venture-table-001-plan.md
+++ b/docs/plans/archived/sd-leo-feat-chairman-venture-table-001-plan.md
@@ -1,0 +1,188 @@
+<!-- Archived from: docs/plans/chairman-venture-table-view-architecture.md -->
+<!-- SD Key: SD-LEO-FEAT-CHAIRMAN-VENTURE-TABLE-001 -->
+<!-- Archived at: 2026-03-05T14:56:54.656Z -->
+
+# Architecture Plan: Chairman Venture Table View
+
+## Stack & Repository Decisions
+
+**Repository**: `rickfelix/ehg` (frontend app)
+**Stack**: React + TypeScript + Shadcn UI + Tailwind CSS + @tanstack/react-query
+**Pattern Reference**: `src/components/chairman-v3/operations/OperationsDashboard.tsx`
+
+No new dependencies. All UI components (Table, Badge, Card) already in Shadcn. No backend changes for Phase 1.
+
+## Legacy Deprecation Plan
+
+### Components to Remove
+| Component | Location | Lines | Replacement |
+|-----------|----------|-------|-------------|
+| VentureLifecycleMap | `src/components/chairman-v3/VentureLifecycleMap.tsx` | ~263 | VentureTable (new) |
+| VentureDetailDrawer | Inline in VentureLifecycleMap (lines 123-186) | ~63 | Removed (row click navigates) |
+| SwimlaneColumnView | Inline in VentureLifecycleMap (lines 82-121) | ~40 | Removed |
+
+### Hook to Refactor
+| Hook | Location | Change |
+|------|----------|--------|
+| useVentureLifecycle | `src/hooks/useVentureLifecycle.ts` | Remove swimlane grouping, add sort/filter state, flatten to array |
+
+### Files Untouched
+- `src/pages/chairman-v3/VentureLifecyclePage.tsx` — wrapper, just imports (may update import name)
+- `src/pages/chairman-v3/VentureDetailPage.tsx` — detail page, no changes
+- `src/pages/VentureDetail.tsx` — 8-tab detail, no changes
+- All route definitions — routes unchanged
+
+## Route & Component Structure
+
+### Component Tree
+```
+VentureLifecyclePage (page wrapper)
+  └── VentureTable (new component, replaces VentureLifecycleMap)
+        ├── Summary Cards (Total, Active, Avg AI Score, Near Gate)
+        ├── PhaseDistribution (venture count chips per phase)
+        └── Table
+              ├── TableHeader (sortable column headers)
+              └── TableBody
+                    └── TableRow (clickable → navigate to /chairman/ventures/:id)
+                          ├── Name cell
+                          ├── Status badge
+                          ├── Phase badge (from venture-workflow.ts)
+                          ├── Stage (N/25)
+                          ├── AI Score (colored)
+                          ├── Next Gate (computed from VENTURE_STAGES)
+                          └── Last Activity (timeAgo)
+```
+
+### New Files
+| File | Purpose | Est. Lines |
+|------|---------|-----------|
+| `src/components/chairman-v3/ventures/VentureTable.tsx` | Main table component | ~120 |
+| `src/components/chairman-v3/ventures/PhaseDistribution.tsx` | Phase count chips | ~30 |
+| `src/components/chairman-v3/ventures/index.ts` | Barrel export | ~3 |
+
+### Modified Files
+| File | Change | Est. Delta |
+|------|--------|-----------|
+| `src/hooks/useVentureLifecycle.ts` | Remove swimlane grouping, add sort state | ~-20, +30 |
+| `src/pages/chairman-v3/VentureLifecyclePage.tsx` | Update import to VentureTable | ~2 lines |
+
+### Deleted Files
+| File | Reason |
+|------|--------|
+| `src/components/chairman-v3/VentureLifecycleMap.tsx` | Replaced by VentureTable |
+
+## Data Layer
+
+### Supabase Query (existing, refactored)
+The current `useVentureLifecycle` hook queries:
+```sql
+SELECT id, name, status, current_lifecycle_stage, ai_score, validation_score,
+       risk_score, updated_at, pipeline_mode
+FROM ventures
+WHERE status = 'active'
+ORDER BY current_lifecycle_stage ASC
+```
+
+**Refactored hook** removes the swimlane column grouping and returns a flat array with computed fields:
+```typescript
+interface VentureTableRow {
+  id: string;
+  name: string;
+  status: string;
+  stage: number;           // current_lifecycle_stage
+  phase: string;           // computed from VENTURE_STAGES config
+  aiScore: number;
+  nextGate: {              // computed from VENTURE_STAGES
+    type: 'kill' | 'promotion';
+    stageNumber: number;
+    distance: number;      // stages until gate
+  } | null;
+  lastActivity: string;    // updated_at as timeAgo
+  pipelineMode: string;    // for Phase 2
+}
+```
+
+### Phase Distribution Query
+Derived client-side from the ventures array — no additional DB query:
+```typescript
+const phaseCounts = ventures.reduce((acc, v) => {
+  const stage = VENTURE_STAGES.find(s => s.stageNumber === v.stage);
+  const phase = stage?.chunk ?? 'unknown';
+  acc[phase] = (acc[phase] || 0) + 1;
+  return acc;
+}, {});
+```
+
+### Next Gate Computation
+Derived client-side from `VENTURE_STAGES` config:
+```typescript
+function getNextGate(currentStage: number): NextGate | null {
+  const gates = VENTURE_STAGES.filter(s => s.gateType !== 'none' && s.stageNumber > currentStage);
+  if (gates.length === 0) return null;
+  const next = gates[0];
+  return { type: next.gateType, stageNumber: next.stageNumber, distance: next.stageNumber - currentStage };
+}
+```
+
+### RLS
+No changes — existing RLS policies on `ventures` table apply.
+
+## API Surface
+No new API endpoints for Phase 1. All data comes from existing Supabase queries.
+
+**Phase 2 dependency**: `GET /api/eva/exit/portfolio` (bulk exit summary) from Venture Architecture ORCH-001.
+
+## Implementation Phases
+
+### Phase 1: Core Table View (This SD — ~200 LOC)
+1. Create `VentureTable.tsx` — Shadcn Table with 7 columns, summary cards, phase chips
+2. Create `PhaseDistribution.tsx` — compact phase count badges
+3. Refactor `useVentureLifecycle.ts` — flatten data, add sort state, compute next-gate
+4. Update `VentureLifecyclePage.tsx` — swap import
+5. Delete `VentureLifecycleMap.tsx`
+6. Test: ventures render in table, rows navigate to detail, sort works, phase chips accurate
+
+### Phase 2: Exit-Readiness Columns (Follow-up SD)
+- Blocked on: bulk exit summary endpoint from ORCH-001
+- Add 3 columns: Pipeline Mode badge, Asset Count, Exit Model
+- Add filter: dropdown by pipeline mode
+- ~80 LOC additional
+
+### Phase 3: Advanced Features (Future)
+- Column show/hide preferences
+- Saved filter presets
+- Export to CSV/PDF
+- Inline quick actions
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+- `getNextGate()` — correct gate computation for each stage
+- Phase distribution — correct counts for sample venture arrays
+- Sort comparator — ascending/descending for each sortable column
+
+### Component Tests (Vitest + React Testing Library)
+- VentureTable renders correct number of rows
+- Clicking a row calls `navigate` with correct venture ID
+- Summary cards show correct totals
+- Phase distribution chips show correct counts
+- Sort toggles update column order
+
+### E2E Tests (Playwright)
+- Navigate to `/chairman/ventures` → table renders with venture rows
+- Click a venture row → navigates to `/chairman/ventures/:id`
+- Click column header → rows re-sort
+- Phase chips reflect correct venture distribution
+
+### Visual Regression
+- Screenshot comparison of table view vs Operations page (pattern consistency)
+
+## Risk Mitigation
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| 6-phase restructuring lands after this SD | Low | Table uses `VENTURE_STAGES` config — phase is computed from stage number, not hardcoded. Restructuring changes config, table adapts automatically. |
+| Empty exit-readiness columns if Phase 2 ships before data exists | Medium | Defer exit columns to Phase 2. Only add when bulk endpoint AND venture data exist. |
+| VentureDetail page stub tabs exposed as primary landing | Low | Separate concern — can hide stubs in a follow-up. Table navigates to existing page as-is. |
+| Spatial lifecycle awareness lost | Low | PhaseDistribution chips above table preserve at-a-glance clustering signal. |
+| N+1 queries for exit data in Phase 2 | Medium | Accept for small portfolio (7 ventures). Add bulk endpoint before scaling. |

--- a/docs/plans/archived/sd-leo-feat-eva-operations-dashboard-001-plan.md
+++ b/docs/plans/archived/sd-leo-feat-eva-operations-dashboard-001-plan.md
@@ -1,0 +1,41 @@
+<!-- Archived from: .claude/plans/eva-operations-dashboard-ui.md -->
+<!-- SD Key: SD-LEO-FEAT-EVA-OPERATIONS-DASHBOARD-001 -->
+<!-- Archived at: 2026-03-05T11:05:48.467Z -->
+
+# EVA Operations Dashboard UI — Complete Missing Frontend Pages
+
+## Problem Statement
+SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I (Operations Dashboard and Background Workers) was marked completed but only the backend workers, APIs, and Supabase hooks were implemented. The frontend Operations Dashboard pages were never built.
+
+## Scope
+Build the missing Operations Dashboard UI in the `ehg` frontend app to consume the existing backend APIs at `/api/eva/operations/*`.
+
+### Components to Build
+1. **VentureOperationsPage.tsx** — Live ventures overview table (`/chairman/operations`)
+2. **VentureOperationsDetailPage.tsx** — Per-venture detail with tabs (`/chairman/operations/:ventureId`)
+3. **RevenueTab.tsx** — MRR, CAC/LTV, churn metrics display
+4. **CustomerServiceTab.tsx** — Ticket management, SLA tracking
+5. **FeedbackTab.tsx** — Wraps Universal Inbox for venture feedback
+6. **MetricsTab.tsx** — AARRR funnel visualization
+7. **HealthTab.tsx** — Health score breakdown per venture
+
+### Hooks & Routes
+- Add route `/chairman/operations` → VentureOperationsPage
+- Add route `/chairman/operations/:ventureId` → VentureOperationsDetailPage
+- Create `useVentureOperations.ts` hook consuming existing APIs
+- Wire into `chairmanRoutesV3.tsx`
+
+### Existing Backend (Already Implemented)
+- `lib/eva/workers/` — 5 worker modules (base, health-monitor, metrics-collector, stage-advance, scheduler)
+- `lib/eva/operations/` — domain-handler.js, index.js
+- `server/routes/eva-operations.js` — API endpoints
+- `src/hooks/useLiveWorkflowProgress.ts` — already updated with real Supabase queries
+
+## Type
+feature
+
+## Target Repository
+ehg (frontend)
+
+## Dependencies
+None — backend APIs already exist from Child I

--- a/docs/plans/archived/sd-leo-feat-eva-pipeline-gui-001-plan.md
+++ b/docs/plans/archived/sd-leo-feat-eva-pipeline-gui-001-plan.md
@@ -1,0 +1,39 @@
+<!-- Archived from: .claude/plans/eva-pipeline-gui-wiring.md -->
+<!-- SD Key: SD-LEO-FEAT-EVA-PIPELINE-GUI-001 -->
+<!-- Archived at: 2026-03-05T11:06:55.502Z -->
+
+# EVA Pipeline-to-GUI Data Wiring — Stage 10-12 and Capability Registry
+
+## Problem Statement
+SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-K (Pipeline-to-GUI Wiring) was marked completed but only the backend pipeline data aggregation APIs were built. No frontend components were created or wired to consume the data.
+
+## Scope
+Wire the existing backend pipeline APIs at `/api/eva/pipeline/*` into the `ehg` frontend app. Create the Capability Registry page and integrate stage 10-12 data into existing Chairman UI.
+
+### Components to Build or Wire
+1. **Stage 10 — Customer Intelligence** — Wire `/api/eva/pipeline/:ventureId/customer-intelligence` data into existing Chairman venture detail views
+2. **Stage 11 — Brand Genome** — Wire `/api/eva/pipeline/:ventureId/brand-genome` data into Brand Genome Wizard component
+3. **Stage 12 — GTM Strategy** — Wire `/api/eva/pipeline/:ventureId/gtm-strategy` data into GTM Dashboard views
+4. **CapabilityRegistryPage.tsx** — New page showing cross-venture capability graph and Capability Contribution Scores (CCS) from Child E
+5. **PipelineSummaryCard.tsx** — Aggregated pipeline summary widget using `/api/eva/pipeline/:ventureId/summary`
+
+### Hooks & Routes
+- Create `usePipelineData.ts` hook consuming pipeline APIs
+- Create `useCapabilityRegistry.ts` hook for CCS data
+- Add route `/chairman/capabilities` → CapabilityRegistryPage
+- Wire pipeline summary into venture detail pages
+
+### Existing Backend (Already Implemented)
+- `lib/eva/pipeline-data/index.js` — 259 lines, 4 endpoints
+- `server/routes/eva-pipeline.js` — 75 lines
+- Capability Contribution Score module from Child E
+- Financial consistency contract from Child F
+
+## Type
+feature
+
+## Target Repository
+ehg (frontend)
+
+## Dependencies
+None — all backend APIs already exist from Children E, F, K

--- a/docs/plans/chairman-venture-table-view-architecture.md
+++ b/docs/plans/chairman-venture-table-view-architecture.md
@@ -1,0 +1,184 @@
+# Architecture Plan: Chairman Venture Table View
+
+## Stack & Repository Decisions
+
+**Repository**: `rickfelix/ehg` (frontend app)
+**Stack**: React + TypeScript + Shadcn UI + Tailwind CSS + @tanstack/react-query
+**Pattern Reference**: `src/components/chairman-v3/operations/OperationsDashboard.tsx`
+
+No new dependencies. All UI components (Table, Badge, Card) already in Shadcn. No backend changes for Phase 1.
+
+## Legacy Deprecation Plan
+
+### Components to Remove
+| Component | Location | Lines | Replacement |
+|-----------|----------|-------|-------------|
+| VentureLifecycleMap | `src/components/chairman-v3/VentureLifecycleMap.tsx` | ~263 | VentureTable (new) |
+| VentureDetailDrawer | Inline in VentureLifecycleMap (lines 123-186) | ~63 | Removed (row click navigates) |
+| SwimlaneColumnView | Inline in VentureLifecycleMap (lines 82-121) | ~40 | Removed |
+
+### Hook to Refactor
+| Hook | Location | Change |
+|------|----------|--------|
+| useVentureLifecycle | `src/hooks/useVentureLifecycle.ts` | Remove swimlane grouping, add sort/filter state, flatten to array |
+
+### Files Untouched
+- `src/pages/chairman-v3/VentureLifecyclePage.tsx` — wrapper, just imports (may update import name)
+- `src/pages/chairman-v3/VentureDetailPage.tsx` — detail page, no changes
+- `src/pages/VentureDetail.tsx` — 8-tab detail, no changes
+- All route definitions — routes unchanged
+
+## Route & Component Structure
+
+### Component Tree
+```
+VentureLifecyclePage (page wrapper)
+  └── VentureTable (new component, replaces VentureLifecycleMap)
+        ├── Summary Cards (Total, Active, Avg AI Score, Near Gate)
+        ├── PhaseDistribution (venture count chips per phase)
+        └── Table
+              ├── TableHeader (sortable column headers)
+              └── TableBody
+                    └── TableRow (clickable → navigate to /chairman/ventures/:id)
+                          ├── Name cell
+                          ├── Status badge
+                          ├── Phase badge (from venture-workflow.ts)
+                          ├── Stage (N/25)
+                          ├── AI Score (colored)
+                          ├── Next Gate (computed from VENTURE_STAGES)
+                          └── Last Activity (timeAgo)
+```
+
+### New Files
+| File | Purpose | Est. Lines |
+|------|---------|-----------|
+| `src/components/chairman-v3/ventures/VentureTable.tsx` | Main table component | ~120 |
+| `src/components/chairman-v3/ventures/PhaseDistribution.tsx` | Phase count chips | ~30 |
+| `src/components/chairman-v3/ventures/index.ts` | Barrel export | ~3 |
+
+### Modified Files
+| File | Change | Est. Delta |
+|------|--------|-----------|
+| `src/hooks/useVentureLifecycle.ts` | Remove swimlane grouping, add sort state | ~-20, +30 |
+| `src/pages/chairman-v3/VentureLifecyclePage.tsx` | Update import to VentureTable | ~2 lines |
+
+### Deleted Files
+| File | Reason |
+|------|--------|
+| `src/components/chairman-v3/VentureLifecycleMap.tsx` | Replaced by VentureTable |
+
+## Data Layer
+
+### Supabase Query (existing, refactored)
+The current `useVentureLifecycle` hook queries:
+```sql
+SELECT id, name, status, current_lifecycle_stage, ai_score, validation_score,
+       risk_score, updated_at, pipeline_mode
+FROM ventures
+WHERE status = 'active'
+ORDER BY current_lifecycle_stage ASC
+```
+
+**Refactored hook** removes the swimlane column grouping and returns a flat array with computed fields:
+```typescript
+interface VentureTableRow {
+  id: string;
+  name: string;
+  status: string;
+  stage: number;           // current_lifecycle_stage
+  phase: string;           // computed from VENTURE_STAGES config
+  aiScore: number;
+  nextGate: {              // computed from VENTURE_STAGES
+    type: 'kill' | 'promotion';
+    stageNumber: number;
+    distance: number;      // stages until gate
+  } | null;
+  lastActivity: string;    // updated_at as timeAgo
+  pipelineMode: string;    // for Phase 2
+}
+```
+
+### Phase Distribution Query
+Derived client-side from the ventures array — no additional DB query:
+```typescript
+const phaseCounts = ventures.reduce((acc, v) => {
+  const stage = VENTURE_STAGES.find(s => s.stageNumber === v.stage);
+  const phase = stage?.chunk ?? 'unknown';
+  acc[phase] = (acc[phase] || 0) + 1;
+  return acc;
+}, {});
+```
+
+### Next Gate Computation
+Derived client-side from `VENTURE_STAGES` config:
+```typescript
+function getNextGate(currentStage: number): NextGate | null {
+  const gates = VENTURE_STAGES.filter(s => s.gateType !== 'none' && s.stageNumber > currentStage);
+  if (gates.length === 0) return null;
+  const next = gates[0];
+  return { type: next.gateType, stageNumber: next.stageNumber, distance: next.stageNumber - currentStage };
+}
+```
+
+### RLS
+No changes — existing RLS policies on `ventures` table apply.
+
+## API Surface
+No new API endpoints for Phase 1. All data comes from existing Supabase queries.
+
+**Phase 2 dependency**: `GET /api/eva/exit/portfolio` (bulk exit summary) from Venture Architecture ORCH-001.
+
+## Implementation Phases
+
+### Phase 1: Core Table View (This SD — ~200 LOC)
+1. Create `VentureTable.tsx` — Shadcn Table with 7 columns, summary cards, phase chips
+2. Create `PhaseDistribution.tsx` — compact phase count badges
+3. Refactor `useVentureLifecycle.ts` — flatten data, add sort state, compute next-gate
+4. Update `VentureLifecyclePage.tsx` — swap import
+5. Delete `VentureLifecycleMap.tsx`
+6. Test: ventures render in table, rows navigate to detail, sort works, phase chips accurate
+
+### Phase 2: Exit-Readiness Columns (Follow-up SD)
+- Blocked on: bulk exit summary endpoint from ORCH-001
+- Add 3 columns: Pipeline Mode badge, Asset Count, Exit Model
+- Add filter: dropdown by pipeline mode
+- ~80 LOC additional
+
+### Phase 3: Advanced Features (Future)
+- Column show/hide preferences
+- Saved filter presets
+- Export to CSV/PDF
+- Inline quick actions
+
+## Testing Strategy
+
+### Unit Tests (Vitest)
+- `getNextGate()` — correct gate computation for each stage
+- Phase distribution — correct counts for sample venture arrays
+- Sort comparator — ascending/descending for each sortable column
+
+### Component Tests (Vitest + React Testing Library)
+- VentureTable renders correct number of rows
+- Clicking a row calls `navigate` with correct venture ID
+- Summary cards show correct totals
+- Phase distribution chips show correct counts
+- Sort toggles update column order
+
+### E2E Tests (Playwright)
+- Navigate to `/chairman/ventures` → table renders with venture rows
+- Click a venture row → navigates to `/chairman/ventures/:id`
+- Click column header → rows re-sort
+- Phase chips reflect correct venture distribution
+
+### Visual Regression
+- Screenshot comparison of table view vs Operations page (pattern consistency)
+
+## Risk Mitigation
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| 6-phase restructuring lands after this SD | Low | Table uses `VENTURE_STAGES` config — phase is computed from stage number, not hardcoded. Restructuring changes config, table adapts automatically. |
+| Empty exit-readiness columns if Phase 2 ships before data exists | Medium | Defer exit columns to Phase 2. Only add when bulk endpoint AND venture data exist. |
+| VentureDetail page stub tabs exposed as primary landing | Low | Separate concern — can hide stubs in a follow-up. Table navigates to existing page as-is. |
+| Spatial lifecycle awareness lost | Low | PhaseDistribution chips above table preserve at-a-glance clustering signal. |
+| N+1 queries for exit data in Phase 2 | Medium | Accept for small portfolio (7 ventures). Add bulk endpoint before scaling. |

--- a/docs/plans/chairman-venture-table-view-vision.md
+++ b/docs/plans/chairman-venture-table-view-vision.md
@@ -1,0 +1,157 @@
+# Vision: Chairman Venture Table View — Portfolio Command Surface
+
+## Executive Summary
+The Chairman's primary venture view (`/chairman/ventures`) currently renders a swimlane/kanban layout that prevents the user from navigating to individual venture detail pages, sorting or filtering ventures, or seeing any exit-readiness information at the portfolio level. This vision replaces the swimlane with a table-based portfolio command surface — following the proven OperationsDashboard pattern already in the codebase — that gives the Chairman direct access to venture details, dynamic sort/filter capabilities, and (in a second phase) exit-readiness columns for portfolio-level triage.
+
+This is a cross-cutting UI change affecting all 7 active ventures. It addresses the primary UX gap identified during UAT testing of the 25-stage venture workflow: the Chairman cannot reach the full venture detail page from the ventures list.
+
+## Problem Statement
+The current `VentureLifecycleMap` component renders ventures as cards in 5 (soon 6) swimlane columns grouped by lifecycle phase. Clicking a card opens a `Sheet` side panel showing only 4 data fields (stage, AI score, status, validation score) with no navigation to the full detail page. The full `VentureDetail` page at `/chairman/ventures/:id` — with 8 tabs including the 25-stage workflow viewer and exit readiness tab — is completely unreachable from the Chairman's ventures view. There is no sorting, filtering, or search capability. The Chairman cannot manage a portfolio from this view.
+
+**Who is affected**: The Chairman persona — the primary user of the `/chairman/*` routes, responsible for venture lifecycle oversight, kill-gate decisions, and exit-readiness assessment.
+
+**Current impact**: Every venture interaction requires either manual URL entry or navigating through the legacy `/ventures` route, bypassing the Chairman Shell entirely.
+
+## Personas
+
+### The Chairman (Primary)
+- **Goals**: Portfolio oversight, kill-gate decisions, exit-readiness monitoring, venture triage
+- **Mindset**: Executive — wants at-a-glance status then drill-down into specifics
+- **Key Activities**: Review venture progress across lifecycle phases, identify ventures approaching kill gates, assess exit readiness across the portfolio, make go/no-go decisions on individual ventures
+- **Pain Points**: Cannot navigate to venture details from the main ventures view; no way to sort/prioritize ventures; no portfolio-level exit-readiness visibility
+
+### The Builder (Secondary)
+- **Goals**: Understand which ventures need technical attention
+- **Mindset**: Tactical — wants to know what's blocked and what's next
+- **Key Activities**: Check venture health scores, identify stalled ventures, review stage progress
+- **Pain Points**: The Builder routes (`/builder/*`) don't have a ventures view — they may use the Chairman ventures page for reference
+
+## Information Architecture
+
+### Routes (Unchanged)
+| Route | Component | Purpose |
+|-------|-----------|---------|
+| `/chairman/ventures` | VentureLifecyclePage | **NEW: Table view** (replaces swimlane) |
+| `/chairman/ventures/:id` | VentureDetailPage | Existing 8-tab detail (unchanged) |
+| `/chairman/operations` | VentureOperationsPage | Reference implementation for table pattern |
+
+### Data Sources
+| Hook/API | Data | Used By |
+|----------|------|---------|
+| `useVentureLifecycle()` | Ventures + lifecycle stage grouping | Table (refactored to flatten) |
+| `useLiveWorkflowProgress()` | Stage execution progress + performance | Optional: progress column |
+| `useExitSummary()` | Pipeline mode, asset count, exit profile | Phase 2: exit-readiness columns |
+| `venture-workflow.ts` | Stage metadata, phase names, gate types | Phase badge + kill-gate column |
+
+### Navigation Flow
+```
+/chairman/ventures (Table)
+  → Click row → /chairman/ventures/:id (8-tab Detail)
+    → Workflow tab → 25-stage viewer (Timeline/Kanban/List sub-views)
+    → Exit tab → Exit readiness (pipeline mode, assets, exit profile)
+    → Overview tab → Metrics, scores, quick actions
+```
+
+## Key Decision Points
+
+1. **Phase-distribution summary**: Include a compact row of chips above the table showing venture count per phase (e.g., "The Truth: 2 | The Engine: 1 | The Build: 4"). This preserves the spatial clustering signal from the swimlane without the swimlane's limitations.
+
+2. **Exit-readiness column timing**: Defer exit-readiness columns (Pipeline Mode, Asset Count, Exit Model) to a follow-up SD after the Venture Architecture ORCH-001 completes and bulk query support exists. Ship Phase 1 with core columns only.
+
+3. **Stub tab handling**: Hide or de-emphasize the 3 placeholder tabs (Financial, Team, Timeline) on the VentureDetail page to avoid exposing unfinished UI as the primary landing page.
+
+4. **Kill-gate proximity**: Include a "Next Gate" computed column showing distance to the nearest kill gate (e.g., "Kill @ Stage 5 (2 away)") — surfaces decision points proactively.
+
+## Integration Patterns
+
+### With Existing Chairman Shell (V3)
+- The table view renders inside the `ChairmanShell` grid layout (same as current swimlane)
+- No changes to the shell, sidebar, topbar, or attention-queue areas
+- `VentureLifecyclePage.tsx` wrapper is unchanged (6 lines)
+
+### With Operations Dashboard
+- Reuse the same Shadcn Table component pattern
+- Reuse status badge color mapping, timeAgo utility, summary card layout
+- Same click-to-navigate pattern: `navigate(/chairman/ventures/${id})`
+
+### With Exit-Readiness System (Phase 2)
+- When `GET /api/eva/exit/portfolio` endpoint lands, add exit columns
+- `useExitSummary()` already returns the required data shape
+- `PIPELINE_MODE_COLORS` from ExitReadinessTab.tsx provides badge styling
+
+### With 6-Phase Restructuring
+- Table consumes phase from `getStageByNumber()` in venture-workflow.ts
+- Phase is a computed badge, not a spatial column — immune to future restructuring
+- Kill gates [3, 5, 13, 23] are sourced from the VENTURE_STAGES config
+
+## Evolution Plan
+
+### Phase 1: Core Table View (This SD)
+- Replace VentureLifecycleMap with VentureTable component
+- Remove VentureDetailDrawer (Sheet side panel)
+- Columns: Name, Status, Phase, Stage, AI Score, Next Gate, Last Activity
+- Summary cards: Total Ventures, Active, Avg AI Score, Approaching Kill Gate
+- Sort on Name, Stage, AI Score columns
+- Phase-distribution chips above table
+- Clickable rows navigate to `/chairman/ventures/:id`
+- ~200 LOC
+
+### Phase 2: Exit-Readiness Columns (Follow-up SD)
+- Add columns: Pipeline Mode, Asset Count, Exit Model
+- Requires bulk exit summary endpoint from Venture Architecture ORCH-001
+- Filter by pipeline mode (building/operations/exit_prep/divesting)
+- Sort by asset count, readiness indicators
+
+### Phase 3: Advanced Portfolio Features (Future)
+- Column customization (show/hide columns)
+- Saved filter presets
+- CSV/PDF export for LP reporting
+- Inline quick actions (advance stage, trigger review)
+
+## Out of Scope
+- Changing the VentureDetail page tabs or content (separate concern)
+- Implementing the 3 stub tabs (Financial, Team, Timeline)
+- Backend API changes (Phase 1 uses existing data)
+- Exit-readiness bulk endpoint (built by Venture Architecture ORCH-001)
+- Mobile/responsive optimization (desktop-first, Chairman persona)
+
+## UI/UX Wireframes
+
+### Phase 1: Table View
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Venture Portfolio                                    [+ New Venture]│
+├─────────────────────────────────────────────────────────────────────┤
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐           │
+│  │ Total: 7 │  │ Active: 5│  │ Avg AI:72│  │ Near Gate│           │
+│  │ ventures │  │          │  │          │  │    2     │           │
+│  └──────────┘  └──────────┘  └──────────┘  └──────────┘           │
+├─────────────────────────────────────────────────────────────────────┤
+│  Phase: [Truth:2] [Engine:1] [Identity:0] [Blueprint:1] [Build:2] │
+│         [Launch:1]                                                  │
+├─────────────────────────────────────────────────────────────────────┤
+│  Name          │ Status │ Phase      │ Stage │ AI  │ Next Gate     │
+│  ──────────────┼────────┼────────────┼───────┼─────┼───────────────│
+│  CreatorFlow   │ active │ The Engine │  7/25 │  82 │ Kill @ 13 (6) │
+│  NicheSignal   │ active │ The Truth  │  4/25 │  75 │ Kill @ 5  (1) │
+│  Synthify      │ active │ The Build  │ 18/25 │  88 │ Kill @ 23 (5) │
+│  NicheBrief    │ active │ The Truth  │  2/25 │  68 │ Kill @ 3  (1) │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Phase 2: With Exit-Readiness Columns
+```
+│  ... │ Pipeline  │ Assets │ Exit Model      │
+│  ... │ building  │   --   │ --              │
+│  ... │ operations│   12   │ Full Acquisition│
+│  ... │ exit_prep │    8   │ Licensing       │
+```
+
+## Success Criteria
+1. Chairman can navigate from ventures list to any venture detail page in 1 click
+2. Chairman can sort ventures by name, stage, AI score, and phase
+3. Phase-distribution summary shows venture counts per lifecycle phase
+4. Kill-gate proximity is visible for every venture without clicking into details
+5. No regression in existing VentureDetail page functionality
+6. Side panel (Sheet drawer) is fully removed
+7. Table follows the same visual pattern as the Operations Dashboard

--- a/tests/e2e/api/eva-operations.spec.ts
+++ b/tests/e2e/api/eva-operations.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * EVA Operations API E2E Tests
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ *
+ * Tests the EVA Operations REST API endpoints:
+ *   GET /api/eva/operations/status
+ *   GET /api/eva/operations/workers
+ *
+ * Requires a running server — do NOT run in unit/integration CI.
+ * Start the server first: npm run dev (or npm start)
+ */
+
+import { test, expect } from '@playwright/test';
+
+const API_BASE = process.env.API_BASE_URL || 'http://localhost:3000';
+
+test.describe('EVA Operations API E2E', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  // ── GET /api/eva/operations/status ──────────────────────────────────────────
+
+  test('GET /api/eva/operations/status — returns 200 with expected shape', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/status`);
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    // Top-level fields
+    expect(data).toHaveProperty('timestamp');
+    expect(data).toHaveProperty('overall');
+    expect(data).toHaveProperty('subsystems');
+
+    // Timestamp is ISO-8601
+    expect(new Date(data.timestamp).getTime()).not.toBeNaN();
+
+    // overall is one of the known status values
+    expect(['healthy', 'degraded', 'unknown']).toContain(data.overall);
+  });
+
+  test('GET /api/eva/operations/status — subsystems has all 6 expected keys', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/status`);
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    const { subsystems } = data;
+
+    expect(subsystems).toHaveProperty('health');
+    expect(subsystems).toHaveProperty('metrics');
+    expect(subsystems).toHaveProperty('feedback');
+    expect(subsystems).toHaveProperty('enhancements');
+    expect(subsystems).toHaveProperty('financial');
+    expect(subsystems).toHaveProperty('scheduler');
+  });
+
+  test('GET /api/eva/operations/status — each subsystem has a status field', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/status`);
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    for (const [key, sub] of Object.entries(data.subsystems as Record<string, { status: string }>)) {
+      expect(sub, `subsystem "${key}" missing status field`).toHaveProperty('status');
+      expect(typeof sub.status).toBe('string');
+    }
+  });
+
+  test('GET /api/eva/operations/status — health subsystem has serviceCount', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/status`);
+
+    expect(response.status()).toBe(200);
+
+    const { subsystems } = await response.json();
+    expect(subsystems.health).toHaveProperty('serviceCount');
+    expect(typeof subsystems.health.serviceCount).toBe('number');
+  });
+
+  test('GET /api/eva/operations/status — metrics subsystem has recentMetrics', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/status`);
+
+    expect(response.status()).toBe(200);
+
+    const { subsystems } = await response.json();
+    // recentMetrics present when supabase is connected; otherwise status='no-client'
+    if (subsystems.metrics.status !== 'no-client') {
+      expect(subsystems.metrics).toHaveProperty('recentMetrics');
+    }
+  });
+
+  test('GET /api/eva/operations/status — scheduler subsystem has pendingJobs', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/status`);
+
+    expect(response.status()).toBe(200);
+
+    const { subsystems } = await response.json();
+    if (subsystems.scheduler.status !== 'no-client') {
+      expect(subsystems.scheduler).toHaveProperty('pendingJobs');
+      expect(typeof subsystems.scheduler.pendingJobs).toBe('number');
+    }
+  });
+
+  // ── GET /api/eva/operations/workers ────────────────────────────────────────
+
+  test('GET /api/eva/operations/workers — returns 200 with cadence config', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/workers`);
+
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+    expect(data).toHaveProperty('workers');
+  });
+
+  test('GET /api/eva/operations/workers — cadence config has all 6 worker keys', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/workers`);
+
+    expect(response.status()).toBe(200);
+
+    const { workers } = await response.json();
+
+    expect(workers).toHaveProperty('ops_financial_sync', 'hourly');
+    expect(workers).toHaveProperty('ops_feedback_classify', 'frequent');
+    expect(workers).toHaveProperty('ops_metrics_collect', 'six_hourly');
+    expect(workers).toHaveProperty('ops_health_score', 'hourly');
+    expect(workers).toHaveProperty('ops_enhancement_detect', 'daily');
+    expect(workers).toHaveProperty('ops_status_snapshot', 'hourly');
+  });
+
+  test('GET /api/eva/operations/workers — all cadence values are strings', async ({ request }) => {
+    const response = await request.get(`${API_BASE}/api/eva/operations/workers`);
+
+    expect(response.status()).toBe(200);
+
+    const { workers } = await response.json();
+
+    for (const [key, cadence] of Object.entries(workers as Record<string, unknown>)) {
+      expect(typeof cadence, `cadence for "${key}" should be a string`).toBe('string');
+    }
+  });
+});

--- a/tests/integration/eva/operations-workers.integration.test.js
+++ b/tests/integration/eva/operations-workers.integration.test.js
@@ -1,0 +1,495 @@
+/**
+ * Integration Tests — EVA Operations Workers
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ *
+ * Tests the actual domain handler registration and handler invocation
+ * with a stateful mock Supabase client, without hitting the real DB
+ * or making any external LLM/Stripe calls.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── Module mocks (must be hoisted before imports) ───────────────────────────
+
+// Mock financial contract module — used inside ops_financial_sync handler
+vi.mock('../../../lib/eva/contracts/financial-contract.js', () => ({
+  validateConsistency: vi.fn().mockResolvedValue({ valid: true }),
+  getContract: vi.fn().mockResolvedValue({ id: 'fc-001', venture_id: 'v-001' }),
+}));
+
+// Mock feedback classifier — used inside ops_feedback_classify handler
+vi.mock('../../../lib/eva/feedback-dimension-classifier.js', () => ({
+  classifyFeedback: vi.fn().mockResolvedValue({
+    dimensionCode: 'DIM-PRODUCT',
+    confidence: 0.92,
+  }),
+}));
+
+// Mock hub-health-monitor — used inside ops_health_score handler and index.js
+vi.mock('../../../lib/eva/hub-health-monitor.js', () => ({
+  getSystemHealth: vi.fn().mockReturnValue({
+    status: 'healthy',
+    overall: 'healthy',
+    services: [{ name: 'test-svc', status: 'healthy' }],
+    healthy: 1,
+    degraded: 0,
+    unhealthy: 0,
+    lastCheck: new Date().toISOString(),
+  }),
+  sweepStaleServices: vi.fn().mockReturnValue([]),
+  checkServiceHealth: vi.fn(),
+  checkAllServices: vi.fn(),
+  clearHealthState: vi.fn(),
+  HEALTH_STATUS: {
+    HEALTHY: 'healthy',
+    DEGRADED: 'degraded',
+    UNHEALTHY: 'unhealthy',
+    UNKNOWN: 'unknown',
+  },
+}));
+
+// Mock retrospective signals — used inside ops_enhancement_detect handler
+vi.mock('../../../lib/retrospective-signals/index.js', () => ({
+  captureSignals: vi.fn().mockResolvedValue([
+    { signal: 'improve-docs', source: 'retro-001' },
+  ]),
+}));
+
+// ─── Stateful Mock Supabase ────────────────────────────────────────────────────
+
+/**
+ * Creates a stateful mock Supabase that returns predictable data for each table
+ * while recording all insert/update calls for assertion.
+ */
+function createStatefulMockSupabase(overrides = {}) {
+  const state = {
+    inserts: [],
+    updates: [],
+  };
+
+  const tableData = {
+    eva_ventures: [
+      { id: 'v-001', status: 'active' },
+      { id: 'v-002', status: 'in_progress' },
+    ],
+    feedback_items: [
+      { id: 'fi-001', title: 'Improve onboarding', description: 'UX feels clunky', dimension_code: null },
+      { id: 'fi-002', title: 'Add export feature', description: 'CSV export needed', dimension_code: null },
+    ],
+    eva_stage_gate_results: [],
+    eva_scheduler_metrics: [],
+    eva_scheduler_heartbeat: [
+      { instance_id: 'sched-1', last_heartbeat: new Date().toISOString(), status: 'active' },
+    ],
+    eva_scheduler_queue: [],
+    retrospectives: [
+      {
+        id: 'retro-001',
+        what_went_well: 'Good team communication and fast iteration',
+        what_needs_improvement: 'Documentation was lacking and onboarding is slow',
+        key_learnings: 'Need better runbooks for new engineers',
+      },
+    ],
+    venture_financial_contract: [
+      { venture_id: 'v-001', updated_at: new Date().toISOString() },
+    ],
+    protocol_improvement_queue: [
+      { id: 'piq-001', status: 'pending' },
+    ],
+    ...overrides,
+  };
+
+  function makeChain(tableName) {
+    let _resolvedValue = { data: tableData[tableName] || [], error: null, count: (tableData[tableName] || []).length };
+
+    const chain = {
+      select: vi.fn().mockImplementation((fields, opts) => {
+        // head: true with count means return count only
+        if (opts?.head && opts?.count === 'exact') {
+          _resolvedValue = {
+            data: null,
+            error: null,
+            count: (tableData[tableName] || []).length,
+          };
+        }
+        return chain;
+      }),
+      insert: vi.fn().mockImplementation((row) => {
+        state.inserts.push({ table: tableName, row });
+        _resolvedValue = { data: row, error: null };
+        return chain;
+      }),
+      update: vi.fn().mockImplementation((updates) => {
+        state.updates.push({ table: tableName, updates });
+        _resolvedValue = { data: null, error: null };
+        return chain;
+      }),
+      eq: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => Promise.resolve(_resolvedValue)),
+      single: vi.fn().mockImplementation(() =>
+        Promise.resolve({ data: (tableData[tableName] || [])[0] || null, error: null })
+      ),
+      // Make the chain itself thenable so `await supabase.from(t).select(...).insert(...)` works
+      then: vi.fn().mockImplementation((resolve) => resolve(_resolvedValue)),
+    };
+    return chain;
+  }
+
+  const supabase = {
+    _state: state,
+    from: vi.fn((tableName) => makeChain(tableName)),
+  };
+
+  return supabase;
+}
+
+const silentLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+};
+
+// ─── registerOperationsHandlers ───────────────────────────────────────────────
+
+describe('registerOperationsHandlers', () => {
+  it('registers exactly 6 handlers in the domain registry', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+
+    const registered = {};
+    const mockRegistry = {
+      register: vi.fn((name, handler) => {
+        registered[name] = handler;
+      }),
+    };
+
+    registerOperationsHandlers(mockRegistry);
+
+    expect(mockRegistry.register).toHaveBeenCalledTimes(6);
+    expect(registered).toHaveProperty('ops_financial_sync');
+    expect(registered).toHaveProperty('ops_feedback_classify');
+    expect(registered).toHaveProperty('ops_metrics_collect');
+    expect(registered).toHaveProperty('ops_health_score');
+    expect(registered).toHaveProperty('ops_enhancement_detect');
+    expect(registered).toHaveProperty('ops_status_snapshot');
+  }, 120000);
+});
+
+// ─── Handler invocation tests ─────────────────────────────────────────────────
+
+describe('ops_financial_sync handler', () => {
+  it('returns checked count and timestamp', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    const result = await handlers.ops_financial_sync({ supabase, logger: silentLogger });
+
+    expect(result).toHaveProperty('checked');
+    expect(result).toHaveProperty('timestamp');
+    expect(typeof result.checked).toBe('number');
+    expect(typeof result.timestamp).toBe('string');
+  }, 120000);
+
+  it('queries active/in_progress ventures', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    await handlers.ops_financial_sync({ supabase, logger: silentLogger });
+
+    expect(supabase.from).toHaveBeenCalledWith('eva_ventures');
+  }, 120000);
+});
+
+describe('ops_feedback_classify handler', () => {
+  it('returns classified count, total count, and timestamp', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    const result = await handlers.ops_feedback_classify({ supabase, logger: silentLogger });
+
+    expect(result).toHaveProperty('classified');
+    expect(result).toHaveProperty('total');
+    expect(result).toHaveProperty('timestamp');
+    expect(typeof result.classified).toBe('number');
+    expect(typeof result.total).toBe('number');
+  }, 120000);
+
+  it('queries feedback_items for unclassified entries', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    await handlers.ops_feedback_classify({ supabase, logger: silentLogger });
+
+    expect(supabase.from).toHaveBeenCalledWith('feedback_items');
+  }, 120000);
+});
+
+describe('ops_metrics_collect handler', () => {
+  it('returns a snapshot with metric_type ops_pipeline_throughput', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    const result = await handlers.ops_metrics_collect({ supabase, logger: silentLogger });
+
+    expect(result).toHaveProperty('metric_type', 'ops_pipeline_throughput');
+    expect(result).toHaveProperty('metric_value');
+    expect(result).toHaveProperty('created_at');
+  }, 120000);
+
+  it('queries eva_ventures and eva_stage_gate_results', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    await handlers.ops_metrics_collect({ supabase, logger: silentLogger });
+
+    const calledTables = supabase.from.mock.calls.map(([t]) => t);
+    expect(calledTables).toContain('eva_ventures');
+    expect(calledTables).toContain('eva_stage_gate_results');
+  }, 120000);
+
+  it('inserts snapshot into eva_scheduler_metrics', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    await handlers.ops_metrics_collect({ supabase, logger: silentLogger });
+
+    const calledTables = supabase.from.mock.calls.map(([t]) => t);
+    expect(calledTables).toContain('eva_scheduler_metrics');
+  }, 120000);
+});
+
+describe('ops_health_score handler', () => {
+  it('calls sweepStaleServices and getSystemHealth', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const { sweepStaleServices, getSystemHealth } = await import(
+      '../../../lib/eva/hub-health-monitor.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    await handlers.ops_health_score({ supabase, logger: silentLogger });
+
+    expect(sweepStaleServices).toHaveBeenCalled();
+    expect(getSystemHealth).toHaveBeenCalled();
+  }, 120000);
+
+  it('returns health object with timestamp', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    const result = await handlers.ops_health_score({ supabase, logger: silentLogger });
+
+    expect(result).toHaveProperty('timestamp');
+    expect(result).toHaveProperty('status', 'healthy');
+  }, 120000);
+});
+
+describe('ops_enhancement_detect handler', () => {
+  it('returns scanned count, detected count, and timestamp', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    const result = await handlers.ops_enhancement_detect({ supabase, logger: silentLogger });
+
+    expect(result).toHaveProperty('scanned');
+    expect(result).toHaveProperty('detected');
+    expect(result).toHaveProperty('timestamp');
+    expect(typeof result.scanned).toBe('number');
+    expect(typeof result.detected).toBe('number');
+  }, 120000);
+
+  it('queries retrospectives table', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    await handlers.ops_enhancement_detect({ supabase, logger: silentLogger });
+
+    expect(supabase.from).toHaveBeenCalledWith('retrospectives');
+  }, 120000);
+});
+
+describe('ops_status_snapshot handler', () => {
+  it('returns a status snapshot with overall field', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    const result = await handlers.ops_status_snapshot({ supabase, logger: silentLogger });
+
+    expect(result).toHaveProperty('overall');
+    expect(result).toHaveProperty('timestamp');
+    expect(result).toHaveProperty('subsystems');
+  }, 120000);
+
+  it('inserts snapshot into eva_scheduler_metrics', async () => {
+    const { registerOperationsHandlers } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const handlers = {};
+    registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
+
+    await handlers.ops_status_snapshot({ supabase, logger: silentLogger });
+
+    const calledTables = supabase.from.mock.calls.map(([t]) => t);
+    expect(calledTables).toContain('eva_scheduler_metrics');
+  }, 120000);
+});
+
+// ─── getOperationsStatus ──────────────────────────────────────────────────────
+
+describe('getOperationsStatus', () => {
+  it('returns correct structure with all 6 subsystem keys', async () => {
+    const { getOperationsStatus } = await import(
+      '../../../lib/eva/operations/index.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const status = await getOperationsStatus({ supabase, logger: silentLogger });
+
+    expect(status).toHaveProperty('timestamp');
+    expect(status).toHaveProperty('overall');
+    expect(status).toHaveProperty('subsystems');
+
+    const { subsystems } = status;
+    expect(subsystems).toHaveProperty('health');
+    expect(subsystems).toHaveProperty('metrics');
+    expect(subsystems).toHaveProperty('feedback');
+    expect(subsystems).toHaveProperty('enhancements');
+    expect(subsystems).toHaveProperty('financial');
+    expect(subsystems).toHaveProperty('scheduler');
+  }, 120000);
+
+  it('each subsystem has a status field', async () => {
+    const { getOperationsStatus } = await import(
+      '../../../lib/eva/operations/index.js'
+    );
+    const supabase = createStatefulMockSupabase();
+
+    const status = await getOperationsStatus({ supabase, logger: silentLogger });
+
+    for (const [key, sub] of Object.entries(status.subsystems)) {
+      expect(sub, `subsystem "${key}" missing status field`).toHaveProperty('status');
+    }
+  }, 120000);
+
+  it('returns no-client status for db-dependent subsystems when supabase is absent', async () => {
+    const { getOperationsStatus } = await import(
+      '../../../lib/eva/operations/index.js'
+    );
+
+    const status = await getOperationsStatus({ logger: silentLogger });
+
+    expect(status.subsystems.metrics.status).toBe('no-client');
+    expect(status.subsystems.feedback.status).toBe('no-client');
+    expect(status.subsystems.financial.status).toBe('no-client');
+    expect(status.subsystems.enhancements.status).toBe('no-client');
+    expect(status.subsystems.scheduler.status).toBe('no-client');
+  }, 120000);
+
+  it('derives overall as unknown when subsystems have mixed non-active statuses', async () => {
+    const { getOperationsStatus } = await import(
+      '../../../lib/eva/operations/index.js'
+    );
+    // No supabase → db subsystems return 'no-client'
+    const status = await getOperationsStatus({ logger: silentLogger });
+
+    // With no-client status for most subsystems, overall should be 'unknown'
+    expect(['unknown', 'degraded']).toContain(status.overall);
+  }, 120000);
+
+  it('does not throw when a subsystem throws internally', async () => {
+    const { getOperationsStatus } = await import(
+      '../../../lib/eva/operations/index.js'
+    );
+    const supabase = {
+      from: vi.fn(() => {
+        throw new Error('DB exploded');
+      }),
+    };
+
+    await expect(getOperationsStatus({ supabase, logger: silentLogger })).resolves.toBeDefined();
+  }, 120000);
+});
+
+// ─── OPERATIONS_CADENCES export ───────────────────────────────────────────────
+
+describe('OPERATIONS_CADENCES', () => {
+  it('exports cadence config for all 6 operations workers', async () => {
+    const { OPERATIONS_CADENCES } = await import(
+      '../../../lib/eva/operations/domain-handler.js'
+    );
+
+    expect(OPERATIONS_CADENCES).toHaveProperty('ops_financial_sync', 'hourly');
+    expect(OPERATIONS_CADENCES).toHaveProperty('ops_feedback_classify', 'frequent');
+    expect(OPERATIONS_CADENCES).toHaveProperty('ops_metrics_collect', 'six_hourly');
+    expect(OPERATIONS_CADENCES).toHaveProperty('ops_health_score', 'hourly');
+    expect(OPERATIONS_CADENCES).toHaveProperty('ops_enhancement_detect', 'daily');
+    expect(OPERATIONS_CADENCES).toHaveProperty('ops_status_snapshot', 'hourly');
+  }, 120000);
+});

--- a/tests/unit/eva/workers/worker-scheduler.test.js
+++ b/tests/unit/eva/workers/worker-scheduler.test.js
@@ -1,0 +1,428 @@
+/**
+ * Unit Tests for WorkerScheduler and BaseWorker
+ * SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-I
+ *
+ * Tests lifecycle management, interval firing, health reporting,
+ * and circuit breaker logic for background workers.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WorkerScheduler } from '../../../../lib/eva/workers/worker-scheduler.js';
+import { BaseWorker } from '../../../../lib/eva/workers/base-worker.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Concrete test worker that records each execute() call.
+ */
+class TestWorker extends BaseWorker {
+  constructor(name, opts = {}) {
+    super(name, opts);
+    this.executeCalls = 0;
+    this.executeImpl = opts.executeImpl ?? (() => Promise.resolve());
+  }
+
+  async execute() {
+    this.executeCalls++;
+    return this.executeImpl();
+  }
+}
+
+// ─── BaseWorker Tests ─────────────────────────────────────────────────────────
+
+describe('BaseWorker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('constructor', () => {
+    it('sets default options correctly', () => {
+      const worker = new TestWorker('my-worker');
+
+      expect(worker.name).toBe('my-worker');
+      expect(worker.intervalMs).toBe(60_000);
+      expect(worker.maxRetries).toBe(3);
+      expect(worker.supabase).toBeNull();
+    });
+
+    it('accepts custom options', () => {
+      const mockSupabase = {};
+      const worker = new TestWorker('custom', {
+        intervalMs: 5000,
+        maxRetries: 5,
+        supabase: mockSupabase,
+      });
+
+      expect(worker.intervalMs).toBe(5000);
+      expect(worker.maxRetries).toBe(5);
+      expect(worker.supabase).toBe(mockSupabase);
+    });
+
+    it('initialises internal counters to zero', () => {
+      const worker = new TestWorker('init-worker');
+      const h = worker.health();
+
+      expect(h.running).toBe(false);
+      expect(h.totalRuns).toBe(0);
+      expect(h.totalErrors).toBe(0);
+      expect(h.consecutiveFailures).toBe(0);
+      expect(h.circuitBroken).toBe(false);
+      expect(h.lastRun).toBeNull();
+      expect(h.lastError).toBeNull();
+    });
+  });
+
+  describe('start / stop lifecycle', () => {
+    it('start() sets running to true', () => {
+      const worker = new TestWorker('lifecycle', { intervalMs: 1000 });
+      worker.start();
+      expect(worker.health().running).toBe(true);
+      worker.stop();
+    });
+
+    it('stop() sets running to false and clears timer', () => {
+      const worker = new TestWorker('stop-test', { intervalMs: 1000 });
+      worker.start();
+      worker.stop();
+      expect(worker.health().running).toBe(false);
+      expect(worker._timer).toBeNull();
+    });
+
+    it('start() is idempotent — calling twice does not double-start', () => {
+      const worker = new TestWorker('idempotent', { intervalMs: 10000 });
+      worker.start();
+      const firstTimer = worker._timer;
+      worker.start(); // second call — should be a no-op
+      expect(worker._timer).toBe(firstTimer);
+      worker.stop();
+    });
+
+    it('stop() is idempotent — calling twice does not throw', () => {
+      const worker = new TestWorker('stop-twice', { intervalMs: 10000 });
+      worker.start();
+      worker.stop();
+      expect(() => worker.stop()).not.toThrow();
+    });
+  });
+
+  describe('execute() fires on interval', () => {
+    it('fires execute() immediately on start', async () => {
+      const worker = new TestWorker('fire-on-start', { intervalMs: 10000 });
+      worker.start();
+
+      // Flush the immediate _tick() (it's async — advance by 0ms to drain microtasks)
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(worker.executeCalls).toBeGreaterThanOrEqual(1);
+      worker.stop();
+    });
+
+    it('fires execute() again after one interval elapses', async () => {
+      const worker = new TestWorker('interval-fire', { intervalMs: 5000 });
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0); // initial tick
+
+      await vi.advanceTimersByTimeAsync(5000); // interval tick
+
+      expect(worker.executeCalls).toBeGreaterThanOrEqual(2);
+      worker.stop();
+    });
+
+    it('tracks totalRuns correctly after multiple intervals', async () => {
+      const worker = new TestWorker('run-count', { intervalMs: 1000 });
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0); // immediate tick
+
+      await vi.advanceTimersByTimeAsync(3000);
+
+      // 1 immediate + 3 intervals = 4 runs
+      expect(worker.health().totalRuns).toBe(4);
+      worker.stop();
+    });
+
+    it('stops firing after stop() is called', async () => {
+      const worker = new TestWorker('stop-fire', { intervalMs: 1000 });
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      worker.stop();
+
+      const callsAfterStop = worker.executeCalls;
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(worker.executeCalls).toBe(callsAfterStop);
+    });
+  });
+
+  describe('health() reporting', () => {
+    it('returns correct shape after a successful run', async () => {
+      const worker = new TestWorker('health-ok', { intervalMs: 10000 });
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      worker.stop();
+
+      const h = worker.health();
+      expect(h.name).toBe('health-ok');
+      expect(h.running).toBe(false);
+      expect(h.totalRuns).toBeGreaterThanOrEqual(1);
+      expect(h.totalErrors).toBe(0);
+      expect(h.consecutiveFailures).toBe(0);
+      expect(h.circuitBroken).toBe(false);
+      expect(h.lastRun).toBeInstanceOf(Date);
+    });
+
+    it('records lastError on failure', async () => {
+      const worker = new TestWorker('health-fail', {
+        intervalMs: 10000,
+        executeImpl: () => Promise.reject(new Error('boom')),
+      });
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+      worker.stop();
+
+      expect(worker.health().lastError).toBe('boom');
+    });
+  });
+
+  describe('circuit breaker', () => {
+    it('trips after maxRetries consecutive failures', async () => {
+      let calls = 0;
+      const worker = new TestWorker('circuit-trip', {
+        intervalMs: 1000,
+        maxRetries: 3,
+        executeImpl: () => {
+          calls++;
+          return Promise.reject(new Error('fail'));
+        },
+      });
+      worker.start();
+
+      // Tick 3 times to trip the breaker (1 immediate + 2 intervals)
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(worker.health().circuitBroken).toBe(true);
+      expect(worker.health().consecutiveFailures).toBe(3);
+
+      // Advance more intervals — execute() should NOT be called again
+      const callsWhenBroken = calls;
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(calls).toBe(callsWhenBroken);
+
+      worker.stop();
+    });
+
+    it('resetCircuitBreaker() clears consecutive failures', async () => {
+      const worker = new TestWorker('circuit-reset', {
+        intervalMs: 10000,
+        maxRetries: 1,
+        executeImpl: () => Promise.reject(new Error('err')),
+      });
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(worker.health().circuitBroken).toBe(true);
+
+      worker.resetCircuitBreaker();
+      expect(worker.health().circuitBroken).toBe(false);
+      expect(worker.health().consecutiveFailures).toBe(0);
+      expect(worker.health().lastError).toBeNull();
+
+      worker.stop();
+    });
+
+    it('resets consecutive failures after a success', async () => {
+      let callCount = 0;
+      const worker = new TestWorker('circuit-recover', {
+        intervalMs: 1000,
+        maxRetries: 5,
+        executeImpl: () => {
+          callCount++;
+          if (callCount <= 2) return Promise.reject(new Error('transient'));
+          return Promise.resolve();
+        },
+      });
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0); // fail 1
+
+      await vi.advanceTimersByTimeAsync(1000); // fail 2
+
+      expect(worker.health().consecutiveFailures).toBe(2);
+
+      await vi.advanceTimersByTimeAsync(1000); // success
+
+      expect(worker.health().consecutiveFailures).toBe(0);
+      expect(worker.health().circuitBroken).toBe(false);
+
+      worker.stop();
+    });
+
+    it('increments totalErrors without tripping when below maxRetries', async () => {
+      let fail = true;
+      const worker = new TestWorker('partial-fail', {
+        intervalMs: 1000,
+        maxRetries: 5,
+        executeImpl: () => {
+          if (fail) {
+            fail = false;
+            return Promise.reject(new Error('once'));
+          }
+          return Promise.resolve();
+        },
+      });
+      worker.start();
+      await vi.advanceTimersByTimeAsync(0); // fail
+      await vi.advanceTimersByTimeAsync(1000); // success
+
+      const h = worker.health();
+      expect(h.totalErrors).toBe(1);
+      expect(h.circuitBroken).toBe(false);
+
+      worker.stop();
+    });
+  });
+
+  describe('execute() not implemented in base class', () => {
+    it('throws when execute() not overridden', async () => {
+      // Use the raw BaseWorker directly — do NOT call start() so we control timing
+      const base = new BaseWorker('raw');
+      await expect(base.execute()).rejects.toThrow('raw: execute() not implemented');
+    });
+  });
+});
+
+// ─── WorkerScheduler Tests ────────────────────────────────────────────────────
+
+describe('WorkerScheduler', () => {
+  let scheduler;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    scheduler = new WorkerScheduler();
+  });
+
+  afterEach(() => {
+    // Clean up any running workers
+    scheduler.stopAll();
+    vi.useRealTimers();
+  });
+
+  describe('register()', () => {
+    it('registers a worker and makes it retrievable', () => {
+      const worker = new TestWorker('reg-worker', { intervalMs: 60000 });
+      scheduler.register(worker);
+
+      expect(scheduler.get('reg-worker')).toBe(worker);
+    });
+
+    it('throws when registering a worker with a duplicate name', () => {
+      const w1 = new TestWorker('dup', { intervalMs: 60000 });
+      const w2 = new TestWorker('dup', { intervalMs: 60000 });
+      scheduler.register(w1);
+
+      expect(() => scheduler.register(w2)).toThrow('Worker "dup" already registered');
+    });
+  });
+
+  describe('get()', () => {
+    it('returns null for an unknown worker name', () => {
+      expect(scheduler.get('nonexistent')).toBeNull();
+    });
+
+    it('returns the correct worker instance', () => {
+      const w = new TestWorker('get-me', { intervalMs: 60000 });
+      scheduler.register(w);
+      expect(scheduler.get('get-me')).toBe(w);
+    });
+  });
+
+  describe('list()', () => {
+    it('returns empty array when no workers registered', () => {
+      expect(scheduler.list()).toEqual([]);
+    });
+
+    it('returns names of all registered workers', () => {
+      scheduler.register(new TestWorker('alpha', { intervalMs: 60000 }));
+      scheduler.register(new TestWorker('beta', { intervalMs: 60000 }));
+
+      const names = scheduler.list();
+      expect(names).toContain('alpha');
+      expect(names).toContain('beta');
+      expect(names).toHaveLength(2);
+    });
+  });
+
+  describe('startAll()', () => {
+    it('starts all registered workers', () => {
+      const w1 = new TestWorker('start-a', { intervalMs: 60000 });
+      const w2 = new TestWorker('start-b', { intervalMs: 60000 });
+      scheduler.register(w1);
+      scheduler.register(w2);
+
+      scheduler.startAll();
+
+      expect(w1.health().running).toBe(true);
+      expect(w2.health().running).toBe(true);
+    });
+
+    it('is safe to call when no workers are registered', () => {
+      expect(() => scheduler.startAll()).not.toThrow();
+    });
+  });
+
+  describe('stopAll()', () => {
+    it('stops all running workers', () => {
+      const w1 = new TestWorker('stop-a', { intervalMs: 60000 });
+      const w2 = new TestWorker('stop-b', { intervalMs: 60000 });
+      scheduler.register(w1);
+      scheduler.register(w2);
+
+      scheduler.startAll();
+      scheduler.stopAll();
+
+      expect(w1.health().running).toBe(false);
+      expect(w2.health().running).toBe(false);
+    });
+
+    it('is safe to call when no workers are registered', () => {
+      expect(() => scheduler.stopAll()).not.toThrow();
+    });
+  });
+
+  describe('healthCheck()', () => {
+    it('returns an object keyed by worker name', () => {
+      scheduler.register(new TestWorker('hc-a', { intervalMs: 60000 }));
+      scheduler.register(new TestWorker('hc-b', { intervalMs: 60000 }));
+
+      const report = scheduler.healthCheck();
+
+      expect(report).toHaveProperty('hc-a');
+      expect(report).toHaveProperty('hc-b');
+    });
+
+    it('includes running status for each worker', () => {
+      const w = new TestWorker('hc-running', { intervalMs: 60000 });
+      scheduler.register(w);
+      scheduler.startAll();
+
+      const report = scheduler.healthCheck();
+      expect(report['hc-running'].running).toBe(true);
+    });
+
+    it('returns empty object when no workers registered', () => {
+      expect(scheduler.healthCheck()).toEqual({});
+    });
+  });
+
+  describe('onShutdown()', () => {
+    it('registers a cleanup callback', () => {
+      const cleanup = vi.fn();
+      scheduler.onShutdown(cleanup);
+      expect(scheduler._shutdownHandlers).toContain(cleanup);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add brainstorm documents for chairman venture table view and acquisition readiness
- Add vision and architecture plans for chairman venture table (EVA-registered)
- Archive SD plan documents for completed SDs
- Add EVA post-pipeline operations feature docs and deployment guide
- Add EVA operations test suite (unit, integration, E2E)

## Test plan
- [x] All pre-commit checks pass (smoke tests 15/15)
- [x] No secrets detected
- [x] Documentation-only change with test artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)