### PR TITLE
feat: add portfolio exit readiness API and separability delta tracking

### DIFF
--- a/database/migrations/20260305_venture_separability_snapshots.sql
+++ b/database/migrations/20260305_venture_separability_snapshots.sql
@@ -1,0 +1,46 @@
+-- Migration: venture_separability_snapshots
+-- SD: SD-LEO-FEAT-ACQUISITION-READINESS-GAP-001 (ARG04:US-004)
+--
+-- Stores point-in-time separability score snapshots for tracking
+-- how venture separability changes over time. Designed for
+-- acquisition due diligence (defensible history of engineering decisions).
+
+CREATE TABLE IF NOT EXISTS venture_separability_snapshots (
+  id            uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  venture_id    uuid NOT NULL REFERENCES ventures(id) ON DELETE CASCADE,
+  dimension_scores jsonb NOT NULL DEFAULT '{}',
+  overall_score numeric(5,2) NOT NULL,
+  snapshot_type varchar(20) NOT NULL DEFAULT 'manual'
+    CHECK (snapshot_type IN ('manual', 'scheduled', 'post_sd')),
+  triggered_by  text,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for time-series queries per venture
+CREATE INDEX idx_separability_snapshots_venture_time
+  ON venture_separability_snapshots(venture_id, created_at DESC);
+
+-- RLS: only venture owners can see their snapshots
+ALTER TABLE venture_separability_snapshots ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Venture separability snapshots viewable by venture owner"
+  ON venture_separability_snapshots FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM ventures v
+      WHERE v.id = venture_separability_snapshots.venture_id
+        AND v.created_by = auth.uid()
+    )
+  );
+
+CREATE POLICY "Venture separability snapshots insertable by venture owner"
+  ON venture_separability_snapshots FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM ventures v
+      WHERE v.id = venture_separability_snapshots.venture_id
+        AND v.created_by = auth.uid()
+    )
+  );

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "llm:canary:rollback": "node scripts/llm-canary-control.js rollback",
     "llm:canary:quality": "node scripts/llm-canary-control.js quality",
     "llm:canary:history": "node scripts/llm-canary-control.js history",
+    "separability:delta": "node scripts/separability-delta.js",
     "eva:run": "node scripts/eva-run.js",
     "eva:stage": "node scripts/eva/run-stage.js",
     "eva:heal": "node scripts/eva/vision-heal.js",

--- a/scripts/separability-delta.js
+++ b/scripts/separability-delta.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * separability-delta.js — Capture and compare venture separability snapshots.
+ *
+ * SD: SD-LEO-FEAT-ACQUISITION-READINESS-GAP-001 (ARG04:US-004)
+ *
+ * Usage:
+ *   npm run separability:delta -- --venture-id=<uuid>
+ *   npm run separability:delta -- --venture-id=<uuid> --type=post_sd --triggered-by="SD-XXX-001"
+ *
+ * Uses the existing separation-rehearsal.js engine (no duplication).
+ * Stores snapshots in venture_separability_snapshots table.
+ * On subsequent runs, shows delta comparison against previous snapshot.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { rehearseSeparation, DIMENSIONS, PASS_THRESHOLD } from '../lib/eva/exit/separation-rehearsal.js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+function parseArgs() {
+  const args = {};
+  for (const arg of process.argv.slice(2)) {
+    const [key, ...rest] = arg.replace(/^--/, '').split('=');
+    args[key.replace(/-/g, '_')] = rest.join('=') || true;
+  }
+  return args;
+}
+
+function formatDelta(current, previous) {
+  if (previous === null || previous === undefined) return '';
+  const diff = current - previous;
+  if (diff === 0) return ' (=)';
+  const sign = diff > 0 ? '+' : '';
+  return ` (${sign}${diff.toFixed(1)})`;
+}
+
+function scoreBar(score) {
+  const filled = Math.round(score / 5);
+  const empty = 20 - filled;
+  return '█'.repeat(filled) + '░'.repeat(empty);
+}
+
+async function main() {
+  const args = parseArgs();
+
+  if (!args.venture_id) {
+    console.error('Usage: npm run separability:delta -- --venture-id=<uuid>');
+    process.exit(1);
+  }
+
+  const ventureId = args.venture_id;
+  const snapshotType = args.type || 'manual';
+  const triggeredBy = args.triggered_by || null;
+
+  // Verify venture exists
+  const { data: venture, error: ventureError } = await supabase
+    .from('ventures')
+    .select('id, name')
+    .eq('id', ventureId)
+    .single();
+
+  if (ventureError || !venture) {
+    console.error(`Venture not found: ${ventureId}`);
+    process.exit(1);
+  }
+
+  console.log(`\n══════════════════════════════════════════════════════`);
+  console.log(`  SEPARABILITY DELTA: ${venture.name}`);
+  console.log(`══════════════════════════════════════════════════════\n`);
+
+  // Run rehearsal to get current scores
+  console.log('  Running separation rehearsal (dry_run)...\n');
+  const result = await rehearseSeparation(ventureId, 'dry_run', supabase);
+
+  // Build dimension scores object
+  const dimensionScores = {};
+  for (const dr of result.dimension_results) {
+    dimensionScores[dr.dimension] = dr.score;
+  }
+
+  // Fetch previous snapshot for comparison
+  const { data: prevSnapshot } = await supabase
+    .from('venture_separability_snapshots')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  const prevScores = prevSnapshot?.dimension_scores || {};
+  const prevOverall = prevSnapshot?.overall_score ?? null;
+
+  // Display current scores with delta
+  console.log('  Dimension Scores:');
+  console.log('  ─────────────────────────────────────────────────');
+  for (const dim of DIMENSIONS) {
+    const score = dimensionScores[dim] ?? 0;
+    const prev = prevScores[dim] ?? null;
+    const delta = formatDelta(score, prev);
+    const bar = scoreBar(score);
+    const label = dim.padEnd(14);
+    console.log(`  ${label} ${bar} ${score.toFixed(1)}%${delta}`);
+  }
+  console.log('  ─────────────────────────────────────────────────');
+  const overallDelta = formatDelta(result.overall_score, prevOverall);
+  const passLabel = result.overall_score >= PASS_THRESHOLD ? '✅ PASS' : '❌ BELOW THRESHOLD';
+  console.log(`  OVERALL        ${scoreBar(result.overall_score)} ${result.overall_score.toFixed(1)}%${overallDelta}  ${passLabel}`);
+  console.log(`  Threshold: ${PASS_THRESHOLD}%`);
+
+  if (prevSnapshot) {
+    const prevDate = new Date(prevSnapshot.created_at).toLocaleDateString();
+    console.log(`\n  Previous snapshot: ${prevDate} (${prevSnapshot.snapshot_type})`);
+  } else {
+    console.log('\n  No previous snapshot — this is the first capture.');
+  }
+
+  // Store new snapshot
+  const { data: newSnapshot, error: insertError } = await supabase
+    .from('venture_separability_snapshots')
+    .insert({
+      venture_id: ventureId,
+      dimension_scores: dimensionScores,
+      overall_score: result.overall_score,
+      snapshot_type: snapshotType,
+      triggered_by: triggeredBy,
+    })
+    .select('id, created_at')
+    .single();
+
+  if (insertError) {
+    console.error(`\n  ❌ Failed to store snapshot: ${insertError.message}`);
+    process.exit(1);
+  }
+
+  console.log(`\n  ✅ Snapshot saved: ${newSnapshot.id}`);
+  console.log(`     Created: ${new Date(newSnapshot.created_at).toISOString()}`);
+
+  if (result.warnings.length > 0) {
+    console.log(`\n  ⚠️  Warnings:`);
+    for (const w of result.warnings) {
+      console.log(`     - ${w}`);
+    }
+  }
+
+  console.log(`\n══════════════════════════════════════════════════════\n`);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});

--- a/server/routes/eva-exit.js
+++ b/server/routes/eva-exit.js
@@ -240,6 +240,94 @@ router.get('/summary', asyncHandler(async (req, res) => {
   });
 }));
 
+// ── Portfolio Exit Readiness ────────────────────────────────────
+// SD: SD-LEO-FEAT-ACQUISITION-READINESS-GAP-001 (ARG05:US-005)
+
+/**
+ * GET /api/eva/exit/portfolio-readiness
+ * Aggregated exit readiness across all ventures owned by the user.
+ * Returns venture array with separability scores, data room completion, and rehearsal dates.
+ */
+router.get('/portfolio-readiness', asyncHandler(async (req, res) => {
+  // Get all ventures
+  const { data: ventures, error: ventureError } = await dbLoader.supabase
+    .from('ventures')
+    .select('id, name, pipeline_mode')
+    .order('name');
+
+  if (ventureError) return res.status(500).json({ error: ventureError.message });
+  if (!ventures || ventures.length === 0) return res.json([]);
+
+  const ventureIds = ventures.map(v => v.id);
+
+  // Parallel fetch: exit profiles, latest scores, asset counts, data room completeness
+  const [profilesResult, scoresResult, assetsResult, dataRoomResult] = await Promise.all([
+    dbLoader.supabase
+      .from('venture_exit_profiles')
+      .select('venture_id, exit_model, readiness_assessment, updated_at')
+      .in('venture_id', ventureIds)
+      .eq('is_current', true),
+    dbLoader.supabase
+      .from('venture_separability_scores')
+      .select('venture_id, overall_score, scored_at')
+      .in('venture_id', ventureIds)
+      .order('scored_at', { ascending: false }),
+    dbLoader.supabase
+      .from('venture_asset_registry')
+      .select('venture_id')
+      .in('venture_id', ventureIds),
+    dbLoader.supabase
+      .from('venture_data_room_artifacts')
+      .select('venture_id, is_current')
+      .in('venture_id', ventureIds)
+      .eq('is_current', true),
+  ]);
+
+  // Index profiles by venture_id
+  const profileMap = {};
+  for (const p of profilesResult.data || []) {
+    profileMap[p.venture_id] = p;
+  }
+
+  // Index latest score per venture (first match per venture since ordered desc)
+  const scoreMap = {};
+  for (const s of scoresResult.data || []) {
+    if (!scoreMap[s.venture_id]) scoreMap[s.venture_id] = s;
+  }
+
+  // Count assets per venture
+  const assetCountMap = {};
+  for (const a of assetsResult.data || []) {
+    assetCountMap[a.venture_id] = (assetCountMap[a.venture_id] || 0) + 1;
+  }
+
+  // Count data room artifacts per venture (approximation for data_room_pct)
+  const dataRoomCountMap = {};
+  for (const d of dataRoomResult.data || []) {
+    dataRoomCountMap[d.venture_id] = (dataRoomCountMap[d.venture_id] || 0) + 1;
+  }
+
+  // Assemble response
+  const result = ventures.map(v => {
+    const profile = profileMap[v.id];
+    const score = scoreMap[v.id];
+    const rehearsal = profile?.readiness_assessment;
+
+    return {
+      id: v.id,
+      name: v.name,
+      pipeline_mode: v.pipeline_mode || null,
+      exit_model: profile?.exit_model || null,
+      separability_score: score?.overall_score ?? null,
+      data_room_pct: dataRoomCountMap[v.id] ? Math.min(Math.round((dataRoomCountMap[v.id] / 8) * 100), 100) : null,
+      last_rehearsal: rehearsal ? profile.updated_at : null,
+      asset_count: assetCountMap[v.id] || 0,
+    };
+  });
+
+  res.json(result);
+}));
+
 // ── Separability Scores (Phase 2) ──────────────────────────────
 // SD: SD-VENTURE-ACQUISITIONREADINESS-ARCHITECTURE-ORCH-001-B
 


### PR DESCRIPTION
## Summary
- Add `GET /api/eva/exit/portfolio-readiness` endpoint aggregating exit readiness across all ventures (separability scores, data room completion, rehearsal dates, asset counts)
- Add `venture_separability_snapshots` table with RLS for point-in-time separability score tracking
- Add `npm run separability:delta` CLI script using existing separation-rehearsal engine for snapshot capture and delta comparison

**SD**: SD-LEO-FEAT-ACQUISITION-READINESS-GAP-001

## Test plan
- [ ] Verify portfolio-readiness endpoint returns correct venture aggregation
- [ ] Verify separability delta script captures and compares snapshots
- [ ] Verify RLS policies on venture_separability_snapshots table

🤖 Generated with [Claude Code](https://claude.com/claude-code)