### PR TITLE
fix: multi-repo Gate 2 validation via registry-based repo discovery

### DIFF
--- a/applications/registry.json
+++ b/applications/registry.json
@@ -13,7 +13,8 @@
       "status": "active",
       "environment": "development",
       "registered_at": "2025-08-30T15:20:08.903Z",
-      "note": "CONSOLIDATED: Now uses same DB as EHG_Engineer (SD-ARCH-EHG-006)"
+      "note": "CONSOLIDATED: Now uses same DB as EHG_Engineer (SD-ARCH-EHG-006)",
+      "local_path": "C:/Users/rickf/Projects/_EHG/ehg"
     },
     "APP002": {
       "id": "APP002",
@@ -26,7 +27,8 @@
       "status": "active",
       "environment": "development",
       "registered_at": "2025-08-30T16:06:36.693Z",
-      "registered_by": "ENV_REGISTRATION"
+      "registered_by": "ENV_REGISTRATION",
+      "local_path": "C:/Users/rickf/Projects/_EHG/test-leo-project"
     }
   },
   "metadata": {

--- a/scripts/modules/implementation-fidelity/preflight/index.js
+++ b/scripts/modules/implementation-fidelity/preflight/index.js
@@ -7,7 +7,7 @@
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { getSDSearchTerms, gitLogForSD, detectImplementationRepo, EHG_ENGINEER_ROOT, EHG_ROOT } from '../utils/index.js';
+import { getSDSearchTerms, gitLogForSD, detectImplementationRepos, EHG_ENGINEER_ROOT, EHG_ROOT } from '../utils/index.js';
 
 const execAsync = promisify(exec);
 
@@ -98,16 +98,25 @@ async function checkAmbiguityResolution(sd_id, validation, supabase) {
 
   try {
     const searchTerms = await getSDSearchTerms(sd_id, supabase);
-    const implementationRepo = await detectImplementationRepo(sd_id, supabase);
-    const gitLog = await gitLogForSD(
-      `git -C "${implementationRepo}" log --all --grep="\${TERM}" --format="%H" -n 1`,
-      searchTerms,
-      { timeout: 10000 }
-    );
-    const commitHash = gitLog.trim().split('\n')[0];
+    const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+    let combinedDiff = '';
+    for (const repo of implementationRepos) {
+      try {
+        const gitLog = await gitLogForSD(
+          `git -C "${repo}" log --all --grep="\${TERM}" --format="%H" -n 1`,
+          searchTerms,
+          { timeout: 10000 }
+        );
+        const hash = gitLog.trim().split('\n')[0];
+        if (hash) {
+          const { stdout: d } = await execAsync(`git -C "${repo}" show ${hash}`);
+          combinedDiff += d;
+        }
+      } catch (_) { /* skip repos without matching commits */ }
+    }
 
-    if (commitHash) {
-      const { stdout: diff } = await execAsync(`git -C "${implementationRepo}" show ${commitHash}`);
+    if (combinedDiff) {
+      const diff = combinedDiff;
 
       const ambiguityPatterns = [
         /TODO:.*\?/gi,
@@ -212,16 +221,25 @@ async function checkStubbedCode(sd_id, validation, supabase) {
 
   try {
     const searchTerms = await getSDSearchTerms(sd_id, supabase);
-    const implementationRepo = await detectImplementationRepo(sd_id, supabase);
-    const gitLog = await gitLogForSD(
-      `git -C "${implementationRepo}" log --all --grep="\${TERM}" --format="%H" -n 1`,
-      searchTerms,
-      { timeout: 10000 }
-    );
-    const commitHash = gitLog.trim().split('\n')[0];
+    const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+    let combinedDiff = '';
+    for (const repo of implementationRepos) {
+      try {
+        const gitLog = await gitLogForSD(
+          `git -C "${repo}" log --all --grep="\${TERM}" --format="%H" -n 1`,
+          searchTerms,
+          { timeout: 10000 }
+        );
+        const hash = gitLog.trim().split('\n')[0];
+        if (hash) {
+          const { stdout: d } = await execAsync(`git -C "${repo}" show ${hash}`);
+          combinedDiff += d;
+        }
+      } catch (_) { /* skip repos without matching commits */ }
+    }
 
-    if (commitHash) {
-      const { stdout: diff } = await execAsync(`git -C "${implementationRepo}" show ${commitHash}`);
+    if (combinedDiff) {
+      const diff = combinedDiff;
 
       const stubbedCodePatterns = [
         /throw new Error\(['"]not implemented/gi,

--- a/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
+++ b/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
@@ -3,7 +3,7 @@
  * Part of SD-LEO-REFACTOR-IMPL-FIDELITY-001
  */
 
-import { getSDSearchTerms, gitLogForSD, detectImplementationRepo } from '../utils/index.js';
+import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../utils/index.js';
 
 /**
  * Validate Data Flow Alignment
@@ -143,12 +143,16 @@ export async function validateDataFlowAlignment(sd_id, designAnalysis, databaseA
   let gitDiff = '';
   try {
     const searchTerms = await getSDSearchTerms(sd_id, supabase);
-    const implementationRepo = await detectImplementationRepo(sd_id, supabase);
-    gitDiff = await gitLogForSD(
-      `git -C "${implementationRepo}" log --all --grep="\${TERM}" --pretty=format:"" --patch`,
-      searchTerms,
-      { timeout: 15000 }
-    );
+    const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+    for (const repo of implementationRepos) {
+      try {
+        gitDiff += await gitLogForSD(
+          `git -C "${repo}" log --all --grep="\${TERM}" --pretty=format:"" --patch`,
+          searchTerms,
+          { timeout: 15000 }
+        );
+      } catch (_) { /* skip repos without matching commits */ }
+    }
   } catch (_e) {
     gitDiff = '';
   }

--- a/scripts/modules/implementation-fidelity/sections/database-fidelity.js
+++ b/scripts/modules/implementation-fidelity/sections/database-fidelity.js
@@ -8,7 +8,7 @@
 import { existsSync } from 'fs';
 import { readdir, readFile } from 'fs/promises';
 import path from 'path';
-import { getSDSearchTerms, gitLogForSD, detectImplementationRepo } from '../utils/index.js';
+import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../utils/index.js';
 
 /**
  * Validate Database Implementation Fidelity
@@ -56,24 +56,30 @@ export async function validateDatabaseFidelity(sd_id, databaseAnalysis, validati
     console.log('   ✅ B1 exempt for this SD type - full credit (25/25)');
   } else {
     try {
-      const implementationRepo = await detectImplementationRepo(sd_id, supabase);
-      console.log(`   📂 Searching for migrations in: ${implementationRepo}`);
+      const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+      console.log(`   📂 Searching for migrations in: ${implementationRepos.join(', ')}`);
 
       const migrationDirs = ['database/migrations', 'supabase/migrations', 'migrations'];
       let migrationFiles = [];
+      let primaryMigrationRepo = null;
       // Search by both UUID and sd_key for migration file matching
       const searchTerms = await getSDSearchTerms(sd_id, supabase);
       const searchLower = searchTerms.map(t => t.replace('SD-', '').toLowerCase());
 
-      for (const dir of migrationDirs) {
-        const fullPath = path.join(implementationRepo, dir);
-        if (existsSync(fullPath)) {
-          const files = await readdir(fullPath);
-          const sdMigrations = files.filter(f => {
-            const fileLower = f.toLowerCase();
-            return searchLower.some(term => fileLower.includes(term));
-          });
-          migrationFiles.push(...sdMigrations.map(f => ({ dir, file: f })));
+      for (const repo of implementationRepos) {
+        for (const dir of migrationDirs) {
+          const fullPath = path.join(repo, dir);
+          if (existsSync(fullPath)) {
+            const files = await readdir(fullPath);
+            const sdMigrations = files.filter(f => {
+              const fileLower = f.toLowerCase();
+              return searchLower.some(term => fileLower.includes(term));
+            });
+            if (sdMigrations.length > 0 && !primaryMigrationRepo) {
+              primaryMigrationRepo = repo;
+            }
+            migrationFiles.push(...sdMigrations.map(f => ({ dir, file: f })));
+          }
         }
       }
 
@@ -81,7 +87,7 @@ export async function validateDatabaseFidelity(sd_id, databaseAnalysis, validati
         sectionScore += 5;
         sectionDetails.migration_files = migrationFiles.map(m => `${m.dir}/${m.file}`);
         sectionDetails.migration_count = migrationFiles.length;
-        sectionDetails.implementation_repo = implementationRepo;
+        sectionDetails.implementation_repo = primaryMigrationRepo || implementationRepos[0];
         console.log(`   ✅ Found ${migrationFiles.length} migration file(s) (5/25)`);
 
         // B1.2: Verify migrations were executed (20 points - CRITICAL)
@@ -111,12 +117,17 @@ export async function validateDatabaseFidelity(sd_id, databaseAnalysis, validati
   } else {
     try {
       const searchTerms = await getSDSearchTerms(sd_id, supabase);
-      const implementationRepo = await detectImplementationRepo(sd_id, supabase);
-      const gitDiff = await gitLogForSD(
-        `git -C "${implementationRepo}" log --all --grep="\${TERM}" --pretty=format:"" --patch`,
-        searchTerms,
-        { timeout: 15000 }
-      );
+      const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+      let gitDiff = '';
+      for (const repo of implementationRepos) {
+        try {
+          gitDiff += await gitLogForSD(
+            `git -C "${repo}" log --all --grep="\${TERM}" --pretty=format:"" --patch`,
+            searchTerms,
+            { timeout: 15000 }
+          );
+        } catch (_) { /* skip repos without matching commits */ }
+      }
 
       const hasRLS = gitDiff.includes('CREATE POLICY') ||
                      gitDiff.includes('ALTER POLICY') ||

--- a/scripts/modules/implementation-fidelity/sections/design-fidelity.js
+++ b/scripts/modules/implementation-fidelity/sections/design-fidelity.js
@@ -5,7 +5,7 @@
  * Phase-aware weighting: Reduced from 25 to make room for critical database checks
  */
 
-import { getSDSearchTerms, gitLogForSD, detectImplementationRepo } from '../utils/index.js';
+import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../utils/index.js';
 
 /**
  * Validate Design Implementation Fidelity
@@ -146,13 +146,18 @@ export async function validateDesignFidelity(sd_id, designAnalysis, validation, 
   console.log('\n   [A1] UI Components Implementation...');
 
   try {
-    const implementationRepo = await detectImplementationRepo(sd_id, supabase);
+    const implementationRepos = await detectImplementationRepos(sd_id, supabase);
     const searchTerms = await getSDSearchTerms(sd_id, supabase);
-    const gitLog = await gitLogForSD(
-      `git -C "${implementationRepo}" log --all --grep="\${TERM}" --name-only --pretty=format:""`,
-      searchTerms,
-      { timeout: 10000 }
-    );
+    let gitLog = '';
+    for (const repo of implementationRepos) {
+      try {
+        gitLog += await gitLogForSD(
+          `git -C "${repo}" log --all --grep="\${TERM}" --name-only --pretty=format:""`,
+          searchTerms,
+          { timeout: 10000 }
+        );
+      } catch (_) { /* skip repos without matching commits */ }
+    }
 
     const componentFiles = gitLog.split('\n')
       .filter(f => f.match(/\.(tsx?|jsx?)$/) && (f.includes('component') || f.includes('Component') || f.includes('src/')))
@@ -211,12 +216,17 @@ export async function validateDesignFidelity(sd_id, designAnalysis, validation, 
 
   try {
     const searchTerms = await getSDSearchTerms(sd_id, supabase);
-    const implementationRepo = await detectImplementationRepo(sd_id, supabase);
-    const gitDiff = await gitLogForSD(
-      `git -C "${implementationRepo}" log --all --grep="\${TERM}" --pretty=format:"" --patch`,
-      searchTerms,
-      { timeout: 15000 }
-    );
+    const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+    let gitDiff = '';
+    for (const repo of implementationRepos) {
+      try {
+        gitDiff += await gitLogForSD(
+          `git -C "${repo}" log --all --grep="\${TERM}" --pretty=format:"" --patch`,
+          searchTerms,
+          { timeout: 15000 }
+        );
+      } catch (_) { /* skip repos without matching commits */ }
+    }
 
     const hasCRUD = gitDiff.toLowerCase().includes('create') ||
                     gitDiff.toLowerCase().includes('update') ||

--- a/scripts/modules/implementation-fidelity/sections/enhanced-testing.js
+++ b/scripts/modules/implementation-fidelity/sections/enhanced-testing.js
@@ -8,7 +8,7 @@
 import { existsSync } from 'fs';
 import { readdir } from 'fs/promises';
 import path from 'path';
-import { getSDSearchTerms, gitLogForSD, detectImplementationRepo } from '../utils/index.js';
+import { getSDSearchTerms, gitLogForSD, detectImplementationRepos } from '../utils/index.js';
 
 /**
  * Validate Enhanced Testing
@@ -29,7 +29,7 @@ export async function validateEnhancedTesting(sd_id, designAnalysis, databaseAna
   console.log('\n   [D1] E2E Test Coverage & Execution (CRITICAL)...');
 
   try {
-    const implementationRepo = await detectImplementationRepo(sd_id, supabase);
+    const implementationRepos = await detectImplementationRepos(sd_id, supabase);
 
     const testDirs = [
       'tests/e2e',
@@ -40,20 +40,22 @@ export async function validateEnhancedTesting(sd_id, designAnalysis, databaseAna
     ];
 
     let testFiles = [];
-    for (const dir of testDirs) {
-      const fullPath = path.join(implementationRepo, dir);
-      if (existsSync(fullPath)) {
-        const files = await readdir(fullPath, { recursive: true });
-        const sdTests = files.filter(f =>
-          typeof f === 'string' &&
-          (f.includes(sd_id.toLowerCase()) ||
-           f.includes(sd_id.replace('SD-', '').toLowerCase()) ||
-           f.endsWith('.test.ts') ||
-           f.endsWith('.test.js') ||
-           f.endsWith('.spec.ts') ||
-           f.endsWith('.spec.js'))
-        );
-        testFiles.push(...sdTests.map(f => path.join(dir, f)));
+    for (const repo of implementationRepos) {
+      for (const dir of testDirs) {
+        const fullPath = path.join(repo, dir);
+        if (existsSync(fullPath)) {
+          const files = await readdir(fullPath, { recursive: true });
+          const sdTests = files.filter(f =>
+            typeof f === 'string' &&
+            (f.includes(sd_id.toLowerCase()) ||
+             f.includes(sd_id.replace('SD-', '').toLowerCase()) ||
+             f.endsWith('.test.ts') ||
+             f.endsWith('.test.js') ||
+             f.endsWith('.spec.ts') ||
+             f.endsWith('.spec.js'))
+          );
+          testFiles.push(...sdTests.map(f => path.join(dir, f)));
+        }
       }
     }
 
@@ -139,12 +141,17 @@ export async function validateEnhancedTesting(sd_id, designAnalysis, databaseAna
   } else {
     try {
       const searchTerms = await getSDSearchTerms(sd_id, supabase);
-      const implementationRepo = await detectImplementationRepo(sd_id, supabase);
-      const gitLog = await gitLogForSD(
-        `git -C "${implementationRepo}" log --all --grep="\${TERM}" --name-only --pretty=format:""`,
-        searchTerms,
-        { timeout: 10000 }
-      );
+      const implementationRepos = await detectImplementationRepos(sd_id, supabase);
+      let gitLog = '';
+      for (const repo of implementationRepos) {
+        try {
+          gitLog += await gitLogForSD(
+            `git -C "${repo}" log --all --grep="\${TERM}" --name-only --pretty=format:""`,
+            searchTerms,
+            { timeout: 10000 }
+          );
+        } catch (_) { /* skip repos without matching commits */ }
+      }
 
       const hasMigrationTests = gitLog.includes('migration') && gitLog.includes('test');
 

--- a/scripts/modules/implementation-fidelity/utils/index.js
+++ b/scripts/modules/implementation-fidelity/utils/index.js
@@ -11,6 +11,8 @@ export {
 
 export {
   detectImplementationRepo,
+  detectImplementationRepos,
+  resolveReposForSD,
   EHG_ENGINEER_ROOT,
   EHG_ROOT
 } from './repo-detection.js';

--- a/scripts/modules/implementation-fidelity/utils/repo-detection.js
+++ b/scripts/modules/implementation-fidelity/utils/repo-detection.js
@@ -1,12 +1,14 @@
 /**
  * Repository Detection for Implementation Fidelity Validation
  * Part of SD-LEO-REFACTOR-IMPL-FIDELITY-001
+ * Refactored: SD-LEARN-FIX-ADDRESS-PAT-AUTO-052 (multi-repo support via registry)
  */
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { readFile } from 'fs/promises';
 import { getSDSearchTerms } from './git-helpers.js';
 
 const execAsync = promisify(exec);
@@ -19,67 +21,151 @@ export const EHG_ENGINEER_ROOT = path.resolve(__dirname, '../../../..');
 export const EHG_ROOT = path.resolve(__dirname, '../../../../../ehg');
 
 /**
- * Detect which repository contains the implementation for this SD
- * Returns the root path of the implementation repository
- *
- * Strategy:
- * 1. Check if SD has commits in EHG (application repo)
- * 2. If not found, default to EHG_Engineer (governance repo)
+ * Resolve repos for an SD using application registry + target_application field.
+ * Falls back to hardcoded paths if registry is missing.
  *
  * @param {string} sd_id - Strategic Directive ID
  * @param {Object} supabase - Supabase client
- * @returns {Promise<string>} - Root path of implementation repository
+ * @returns {Promise<string[]>} - Array of repo root paths to search
  */
-export async function detectImplementationRepo(sd_id, supabase) {
-  // SD-VENTURE-STAGE0-UI-001: Also search by sd_key (SD-XXX-001 format)
-  // SD-LEO-GEN-RENAME-COLUMNS-SELF-001-D1: Renamed legacy_id to sd_key (column dropped 2026-01-24)
+export async function resolveReposForSD(sd_id, supabase) {
+  // 1. Check if SD has a target_application
+  let targetApp = null;
+  try {
+    const { data } = await supabase
+      .from('strategic_directives_v2')
+      .select('target_application')
+      .or(`sd_key.eq.${sd_id},id.eq.${sd_id}`)
+      .limit(1)
+      .single();
+    targetApp = data?.target_application;
+  } catch (_) {
+    // Ignore - will fallback to all repos
+  }
+
+  // 2. Load registry
+  let registry = null;
+  try {
+    const registryPath = path.resolve(EHG_ENGINEER_ROOT, 'applications/registry.json');
+    const content = await readFile(registryPath, 'utf8');
+    registry = JSON.parse(content);
+  } catch (_) {
+    // Registry missing — fallback to hardcoded paths
+    console.log('   ⚠️  Registry not found, falling back to hardcoded repo paths');
+    return [EHG_ROOT, EHG_ENGINEER_ROOT];
+  }
+
+  const apps = registry.applications || {};
+  const activeApps = Object.values(apps).filter(a => a.status === 'active');
+
+  // 3. If target_application set, return only that app's path
+  if (targetApp) {
+    const match = activeApps.find(a => a.name === targetApp || a.id === targetApp);
+    if (match && match.local_path) {
+      const resolved = path.resolve(match.local_path);
+      console.log(`   📋 Registry resolved ${targetApp} → ${resolved}`);
+      return [resolved];
+    }
+    // target_application set but no local_path — try auto-discovery
+    if (match) {
+      const discovered = path.resolve(EHG_ENGINEER_ROOT, '..', match.name);
+      console.log(`   📋 Auto-discovered ${targetApp} → ${discovered}`);
+      return [discovered];
+    }
+  }
+
+  // 4. No target_application — return all active repos with local_path
+  const paths = [];
+  for (const app of activeApps) {
+    if (app.local_path) {
+      paths.push(path.resolve(app.local_path));
+    } else {
+      // Auto-discover by scanning parent directory for matching repo name
+      paths.push(path.resolve(EHG_ENGINEER_ROOT, '..', app.name));
+    }
+  }
+
+  // Always include EHG_ENGINEER_ROOT if not already present
+  const engineerNorm = EHG_ENGINEER_ROOT.replace(/\\/g, '/');
+  if (!paths.some(p => p.replace(/\\/g, '/') === engineerNorm)) {
+    paths.push(EHG_ENGINEER_ROOT);
+  }
+
+  return paths;
+}
+
+/**
+ * Detect ALL repositories containing implementation for this SD.
+ * Returns an array of repo root paths where SD artifacts were found.
+ *
+ * @param {string} sd_id - Strategic Directive ID
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<string[]>} - Array of repo root paths with SD artifacts
+ */
+export async function detectImplementationRepos(sd_id, supabase) {
   const searchTerms = await getSDSearchTerms(sd_id, supabase);
 
-  // PAT-WORKTREE-LIFECYCLE-001: If running inside a worktree for this SD, prefer cwd.
-  // When __dirname is inside .worktrees/, relative paths resolve to sibling worktrees
-  // instead of actual repos, causing false matches (e.g., .worktrees/ehg instead of ehg).
+  // PAT-WORKTREE-LIFECYCLE-001: If running inside a worktree for this SD, include cwd first
   const cwd = process.cwd();
   const cwdNorm = cwd.replace(/\\/g, '/');
+  const foundRepos = [];
+
   if (cwdNorm.includes('.worktrees/')) {
     const sdKey = searchTerms.find(t => t.startsWith('SD-'));
     if (sdKey && cwdNorm.includes(sdKey)) {
       console.log(`   📋 Worktree detected for ${sdKey}, using cwd: ${cwd}`);
-      return cwd;
+      foundRepos.push(cwd);
     }
   }
 
-  const repos = [
-    EHG_ROOT,           // Application repo (priority)
-    EHG_ENGINEER_ROOT   // Governance repo (fallback)
-  ];
+  // Get candidate repos from registry
+  const candidateRepos = await resolveReposForSD(sd_id, supabase);
 
   if (searchTerms.length > 1) {
     console.log(`   📋 Also searching for sd_key: ${searchTerms[1]}`);
   }
 
-  for (const repo of repos) {
+  // Check each candidate repo for SD commits
+  for (const repo of candidateRepos) {
+    // Skip if already added (worktree)
+    const repoNorm = repo.replace(/\\/g, '/');
+    if (foundRepos.some(r => r.replace(/\\/g, '/') === repoNorm)) continue;
+
     for (const term of searchTerms) {
       try {
-        // Check if this repo has commits for this SD
-        // Windows fix: Shell fallbacks like `|| echo ""` and `|| true` don't work
-        // correctly with Node's exec on Windows (cmd.exe vs bash semantics).
-        // Instead, run git directly and rely on the catch block for errors.
         const { stdout } = await execAsync(
           `git -C "${repo}" log --all --grep="${term}" --format="%H" -n 1`,
           { timeout: 10000 }
         );
         if (stdout.trim()) {
           console.log(`   💡 Implementation detected in: ${repo} (matched: ${term})`);
-          return repo;
+          foundRepos.push(repo);
+          break; // Found in this repo, move to next repo
         }
       } catch (_error) {
-        // Repo might not exist or not accessible, continue to next
         continue;
       }
     }
   }
 
-  // Default to current working directory if no commits found
-  console.log(`   ⚠️  No SD commits found in known repos, using current directory: ${cwd}`);
-  return cwd;
+  // If nothing found, default to cwd
+  if (foundRepos.length === 0) {
+    console.log(`   ⚠️  No SD commits found in known repos, using current directory: ${cwd}`);
+    foundRepos.push(cwd);
+  }
+
+  return foundRepos;
+}
+
+/**
+ * Backward-compatible alias: returns the first (primary) repo.
+ * Existing callers using detectImplementationRepo() continue to work.
+ *
+ * @param {string} sd_id - Strategic Directive ID
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<string>} - Root path of primary implementation repository
+ */
+export async function detectImplementationRepo(sd_id, supabase) {
+  const repos = await detectImplementationRepos(sd_id, supabase);
+  return repos[0];
 }


### PR DESCRIPTION
## Summary
- Replace single-repo `detectImplementationRepo()` with multi-repo `detectImplementationRepos()` using `applications/registry.json` for scalable repo resolution
- Update all 9 call sites across 5 Gate 2 validator files (design-fidelity, database-fidelity, data-flow-alignment, enhanced-testing, preflight) to iterate over full repo array
- Add `resolveReposForSD()` that resolves repos from registry via `target_application` lookup — adding new apps requires zero code changes

## Test plan
- [x] All 8 modified files pass syntax validation
- [x] EXEC-TO-PLAN handoff passed at 92%
- [x] PLAN-TO-LEAD handoff passed at 94%
- [x] SD heal score: 95/100
- [x] Smoke tests pass (15/15)

SD: SD-LEARN-FIX-ADDRESS-PAT-AUTO-052
Pattern: PAT-AUTO-2ede55b1

🤖 Generated with [Claude Code](https://claude.com/claude-code)