### PR TITLE
feat: add JSON-based worker registry for LEO stack

### DIFF
--- a/config/workers.json
+++ b/config/workers.json
@@ -1,0 +1,49 @@
+{
+  "version": "1.0.0",
+  "workers": [
+    {
+      "name": "stage-zero-processor",
+      "display_name": "Stage Zero Queue Processor",
+      "command": "node scripts/stage-zero-queue-processor.js",
+      "cwd": ".",
+      "health_check": { "type": "pid" },
+      "pid_file": "stage-zero.pid",
+      "log_prefix": "stage-zero",
+      "enabled": true,
+      "description": "Polls stage_zero_requests table every 30s for chairman discovery/teardown requests"
+    },
+    {
+      "name": "eva-workers",
+      "display_name": "EVA Workers",
+      "command": "node lib/eva/workers/index.js",
+      "cwd": ".",
+      "health_check": { "type": "pid" },
+      "pid_file": "eva-workers.pid",
+      "log_prefix": "eva-workers",
+      "enabled": false,
+      "description": "StageAdvance (120s), HealthMonitor (60s), MetricsCollector (60s)"
+    },
+    {
+      "name": "subagent-worker",
+      "display_name": "Sub-Agent Worker",
+      "command": "node scripts/subagent-worker.js",
+      "cwd": ".",
+      "health_check": { "type": "pid" },
+      "pid_file": "subagent-worker.pid",
+      "log_prefix": "subagent-worker",
+      "enabled": false,
+      "description": "Polls sub_agent_queue table for queued sub-agent activations"
+    },
+    {
+      "name": "eva-master-scheduler",
+      "display_name": "EVA Master Scheduler",
+      "command": "node lib/eva/eva-master-scheduler.js",
+      "cwd": ".",
+      "health_check": { "type": "pid" },
+      "pid_file": "eva-master-scheduler.pid",
+      "log_prefix": "eva-scheduler",
+      "enabled": false,
+      "description": "Priority-based venture processing from eva_scheduler_queue"
+    }
+  ]
+}

--- a/docs/reference/worker-registry-guide.md
+++ b/docs/reference/worker-registry-guide.md
@@ -1,0 +1,134 @@
+# Worker Registry Guide
+
+## Overview
+
+The LEO Stack uses a JSON-based worker registry (`config/workers.json`) as the single source of truth for all background workers. Both the PowerShell (`.ps1`) and Bash (`.sh`) stack scripts read this file, so adding a new worker requires zero script changes — just add a JSON entry.
+
+## Registry Schema
+
+Each worker entry in `config/workers.json`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Unique identifier (used internally) |
+| `display_name` | string | Human-readable name shown in status output |
+| `command` | string | Shell command to start the worker |
+| `cwd` | string | Working directory (`.` = `EHG_Engineer` root) |
+| `health_check` | object | Health check config (`{ "type": "pid" }`) |
+| `pid_file` | string | PID filename (stored in `.pids/`) |
+| `log_prefix` | string | Log filename prefix (stored in `.logs/`) |
+| `enabled` | boolean | Whether the worker starts with the stack |
+| `description` | string | What the worker does |
+
+## Adding a New Worker
+
+1. Edit `config/workers.json`
+2. Add a new entry to the `workers` array:
+
+```json
+{
+  "name": "my-worker",
+  "display_name": "My Worker",
+  "command": "node scripts/my-worker.js",
+  "cwd": ".",
+  "health_check": { "type": "pid" },
+  "pid_file": "my-worker.pid",
+  "log_prefix": "my-worker",
+  "enabled": true,
+  "description": "Does something useful"
+}
+```
+
+3. Restart the stack: `node scripts/cross-platform-run.js leo-stack restart`
+
+No script modifications needed.
+
+## Enabling / Disabling Workers
+
+Set `"enabled": true` or `"enabled": false` in the worker entry. Disabled workers:
+- Show as `[--] Worker Name: Disabled` in status output
+- Are NOT started during `start` or `restart`
+- Are still listed in the registry for documentation
+
+## Integration with LEO Stack
+
+### Start
+Workers start after the App server during `leo-stack start` / `restart`. Each enabled worker:
+1. Checks if already running via PID file (idempotent)
+2. Spawns as a background process
+3. Writes PID to `.pids/<pid_file>`
+4. Logs output to `.logs/<log_prefix>-<timestamp>.log`
+5. Validates the process is still alive after 2 seconds
+
+### Stop
+Workers stop before the App server during `leo-stack stop`. Each worker:
+1. Reads PID from `.pids/<pid_file>`
+2. Sends SIGTERM (or Stop-Process on Windows)
+3. Waits up to 5 seconds for graceful shutdown
+4. Force kills if still running
+5. Removes PID file
+
+### Status
+`leo-stack status` shows workers in a separate section:
+
+```
+[STATUS] Server Status:
+==================================
+[OK] EHG_Engineer (3000) : Running (PID: 12345, Port: 3000)
+[OK] EHG App (8080)      : Running (PID: 12346, Port: 8080)
+
+Workers:
+   [OK] Stage Zero Queue Processor: Running (PID: 12347)
+   [--] EVA Workers: Disabled
+   [--] Sub-Agent Worker: Disabled
+   [--] EVA Master Scheduler: Disabled
+==================================
+```
+
+### Commands
+
+| Command | Effect on Workers |
+|---------|-------------------|
+| `start` | Starts enabled workers after servers |
+| `stop` | Stops all workers before servers |
+| `restart` | Stops then starts all workers |
+| `status` | Shows worker status (Running/Dead/Disabled) |
+| `start-worker` | Starts only workers (not servers) |
+| `emergency` | Force-kills all node processes including workers |
+
+## Troubleshooting
+
+### Stale PID Files
+If a worker crashed without cleanup, its PID file may reference a dead process. The stack detects this — on next `start`, it removes the stale PID file and starts a fresh process.
+
+### Startup Failures
+Check the worker log at `.logs/<log_prefix>-<timestamp>.log`. Common issues:
+- Missing environment variables (ensure `.env` is configured)
+- Database connection errors (check Supabase credentials)
+- Port conflicts (if the worker binds to a port)
+
+### Log Locations
+All worker logs are in `.logs/`:
+- `stage-zero-<timestamp>.log` — Stage Zero Queue Processor
+- `eva-workers-<timestamp>.log` — EVA Workers
+- `subagent-worker-<timestamp>.log` — Sub-Agent Worker
+- `eva-scheduler-<timestamp>.log` — EVA Master Scheduler
+
+## Architecture: Stage Zero Queue Processor
+
+```
+UI (Chairman)
+    |
+    v
+stage_zero_requests table (Supabase)
+    |  status: pending
+    v
+Stage Zero Queue Processor (polls every 30s)
+    |  status: in_progress
+    |  runs discovery/teardown logic
+    v
+Results written back to table
+    |  status: completed / failed
+    v
+UI polls for status changes
+```

--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -23,7 +23,7 @@
 
 param(
     [Parameter(Position=0)]
-    [ValidateSet("start", "stop", "restart", "status", "clean", "emergency", "start-engineer", "start-app", "help")]
+    [ValidateSet("start", "stop", "restart", "status", "clean", "emergency", "start-engineer", "start-app", "start-worker", "help")]
     [string]$Command = "help",
 
     [Alias("f")]
@@ -43,6 +43,9 @@ if (-not (Test-Path $PidDir)) { New-Item -ItemType Directory -Path $PidDir -Forc
 
 $EngineerPidFile = Join-Path $PidDir "engineer.pid"
 $AppPidFile = Join-Path $PidDir "app.pid"
+
+# Worker Registry
+$WorkerRegistryFile = Join-Path $EngineerDir "config\workers.json"
 
 # Log directory
 $LogDir = Join-Path $EngineerDir ".logs"
@@ -200,6 +203,79 @@ function Start-App {
     }
 }
 
+# Function to read worker registry
+function Get-WorkerRegistry {
+    if (-not (Test-Path $WorkerRegistryFile)) {
+        Write-Log "WARN" "[WARN] Worker registry not found: $WorkerRegistryFile" "Yellow"
+        return @()
+    }
+    $registry = Get-Content $WorkerRegistryFile -Raw | ConvertFrom-Json
+    return $registry.workers
+}
+
+# Function to start all enabled workers from registry
+function Start-Workers {
+    $workers = Get-WorkerRegistry
+    if ($workers.Count -eq 0) { return }
+
+    Write-Log "INFO" "[WORKERS] Starting enabled workers..." "Blue"
+
+    foreach ($worker in $workers) {
+        if (-not $worker.enabled) { continue }
+
+        $pidFile = Join-Path $PidDir $worker.pid_file
+
+        # Check if already running
+        if (Test-Path $pidFile) {
+            $existingPid = Get-Content $pidFile -ErrorAction SilentlyContinue
+            $existingProc = Get-Process -Id $existingPid -ErrorAction SilentlyContinue
+            if ($existingProc) {
+                Write-Log "WARN" "[WARN] $($worker.display_name) already running (PID: $existingPid)" "Yellow"
+                continue
+            }
+            Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+        }
+
+        $workerCwd = if ($worker.cwd -eq ".") { $EngineerDir } else { $worker.cwd }
+        $workerLog = Join-Path $LogDir "$($worker.log_prefix)-$(Get-Date -Format 'yyyyMMdd-HHmmss').log"
+
+        $process = Start-Process -FilePath "cmd" -ArgumentList "/c", "$($worker.command) > `"$workerLog`" 2>&1" `
+            -WorkingDirectory $workerCwd -WindowStyle Hidden -PassThru
+
+        $process.Id | Out-File -FilePath $pidFile -Encoding ASCII
+
+        Start-Sleep -Seconds 2
+
+        if (-not $process.HasExited) {
+            Write-Log "INFO" "[OK] $($worker.display_name) started (PID: $($process.Id))" "Green"
+            Write-Log "INFO" "   * Log: $workerLog" "White"
+        } else {
+            Write-Log "ERROR" "[ERROR] $($worker.display_name) failed to start! Check log: $workerLog" "Red"
+            if (Test-Path $workerLog) {
+                $logContent = Get-Content $workerLog -Tail 5 -ErrorAction SilentlyContinue
+                if ($logContent) {
+                    foreach ($line in $logContent) {
+                        Write-Log "ERROR" "   > $line" "Red"
+                    }
+                }
+            }
+        }
+    }
+}
+
+# Function to stop all workers from registry
+function Stop-Workers {
+    $workers = Get-WorkerRegistry
+    if ($workers.Count -eq 0) { return }
+
+    Write-Log "INFO" "[WORKERS] Stopping workers..." "Yellow"
+
+    foreach ($worker in $workers) {
+        $pidFile = Join-Path $PidDir $worker.pid_file
+        Stop-Server -PidFile $pidFile -Name $worker.display_name
+    }
+}
+
 # Function to stop a server by PID file
 function Stop-Server {
     param(
@@ -242,6 +318,8 @@ function Stop-Server {
 function Stop-AllServers {
     Write-Log "INFO" "[STOP] Stopping all servers..." "Red"
     Write-Host "=================================="
+
+    Stop-Workers
 
     Stop-Server -PidFile $AppPidFile -Name "EHG App"
     Start-Sleep -Seconds 1
@@ -294,6 +372,31 @@ function Show-Status {
     Check-ServerStatus -PidFile $EngineerPidFile -Port 3000 -Name "EHG_Engineer (3000)"
     Check-ServerStatus -PidFile $AppPidFile -Port 8080 -Name "EHG App (8080)"
 
+    # Worker status
+    $workers = Get-WorkerRegistry
+    if ($workers.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Workers:" -ForegroundColor Cyan
+        foreach ($worker in $workers) {
+            if (-not $worker.enabled) {
+                Write-Log "INFO" "   [--] $($worker.display_name): Disabled" "DarkGray"
+                continue
+            }
+            $pidFile = Join-Path $PidDir $worker.pid_file
+            if (Test-Path $pidFile) {
+                $pidValue = Get-Content $pidFile -ErrorAction SilentlyContinue
+                $proc = Get-Process -Id $pidValue -ErrorAction SilentlyContinue
+                if ($proc) {
+                    Write-Log "INFO" "   [OK] $($worker.display_name): Running (PID: $pidValue)" "Green"
+                } else {
+                    Write-Log "INFO" "   [!!] $($worker.display_name): Dead (stale PID: $pidValue)" "Red"
+                }
+            } else {
+                Write-Log "INFO" "   [--] $($worker.display_name): Not running" "Red"
+            }
+        }
+    }
+
     Write-Host "=================================="
 
     # Show memory
@@ -329,6 +432,8 @@ function Start-AllServers {
         Write-Log "ERROR" "Failed to start EHG App" "Red"
         return
     }
+
+    Start-Workers
 
     Write-Host "=================================="
     Write-Log "INFO" "[DONE] LEO Stack startup complete!" "Green"
@@ -394,6 +499,13 @@ function Invoke-EmergencyCleanup {
     # Clean PID files
     Remove-Item $EngineerPidFile, $AppPidFile -Force -ErrorAction SilentlyContinue
 
+    # Clean worker PID files
+    $workers = Get-WorkerRegistry
+    foreach ($worker in $workers) {
+        $pidFile = Join-Path $PidDir $worker.pid_file
+        Remove-Item $pidFile -Force -ErrorAction SilentlyContinue
+    }
+
     # Verify ports are clear
     foreach ($port in @(3000, 8080)) {
         if (Test-PortInUse -Port $port) {
@@ -429,10 +541,15 @@ function Show-Help {
     Write-Host "  emergency        - FORCE kill all node processes" -ForegroundColor White
     Write-Host "  start-engineer   - Start only EHG_Engineer (3000)" -ForegroundColor White
     Write-Host "  start-app        - Start only EHG App (8080)" -ForegroundColor White
+    Write-Host "  start-worker     - Start all enabled workers from config/workers.json" -ForegroundColor White
     Write-Host ""
     Write-Host "Servers:" -ForegroundColor Yellow
     Write-Host "  Port 3000 - EHG_Engineer (LEO Protocol Framework, Backend API)" -ForegroundColor White
     Write-Host "  Port 8080 - EHG App (Frontend UI with Vite)" -ForegroundColor White
+    Write-Host ""
+    Write-Host "Worker Registry:" -ForegroundColor Yellow
+    Write-Host "  Workers are defined in config/workers.json. Set `"enabled`": true to auto-start" -ForegroundColor White
+    Write-Host "  with the stack. See docs/reference/worker-registry-guide.md for details." -ForegroundColor White
     Write-Host ""
     Write-Host "Examples:" -ForegroundColor Yellow
     Write-Host "  .\scripts\leo-stack.ps1 start" -ForegroundColor Gray
@@ -454,6 +571,7 @@ switch ($Command) {
     "emergency" { Invoke-EmergencyCleanup }
     "start-engineer" { Start-Engineer }
     "start-app" { Start-App }
+    "start-worker" { Start-Workers }
     "help" { Show-Help }
     default { Show-Help }
 }

--- a/scripts/leo-stack.sh
+++ b/scripts/leo-stack.sh
@@ -39,6 +39,9 @@ mkdir -p "$PID_DIR"
 ENGINEER_PID="$PID_DIR/engineer.pid"
 APP_PID="$PID_DIR/app.pid"
 
+# Worker Registry
+WORKER_REGISTRY="$ENGINEER_DIR/config/workers.json"
+
 # Log directory
 LOG_DIR="$ENGINEER_DIR/.logs"
 mkdir -p "$LOG_DIR"
@@ -188,10 +191,116 @@ stop_server() {
     fi
 }
 
+# Function to get worker list from registry (outputs JSON lines via node)
+get_workers() {
+    if [ ! -f "$WORKER_REGISTRY" ]; then
+        return
+    fi
+    node -e "
+        const r = require('$WORKER_REGISTRY');
+        r.workers.forEach(w => console.log(JSON.stringify(w)));
+    "
+}
+
+# Function to start all enabled workers from registry
+start_workers() {
+    if [ ! -f "$WORKER_REGISTRY" ]; then return; fi
+
+    log "INFO" "${BLUE}[WORKERS] Starting enabled workers...${NC}"
+
+    get_workers | while IFS= read -r worker_json; do
+        local enabled=$(node -e "console.log(JSON.parse(process.argv[1]).enabled)" "$worker_json")
+        if [ "$enabled" != "true" ]; then continue; fi
+
+        local name=$(node -e "console.log(JSON.parse(process.argv[1]).display_name)" "$worker_json")
+        local command=$(node -e "console.log(JSON.parse(process.argv[1]).command)" "$worker_json")
+        local cwd_val=$(node -e "console.log(JSON.parse(process.argv[1]).cwd)" "$worker_json")
+        local pid_file_name=$(node -e "console.log(JSON.parse(process.argv[1]).pid_file)" "$worker_json")
+        local log_prefix=$(node -e "console.log(JSON.parse(process.argv[1]).log_prefix)" "$worker_json")
+
+        local pid_file="$PID_DIR/$pid_file_name"
+        local worker_cwd="$ENGINEER_DIR"
+        if [ "$cwd_val" != "." ]; then worker_cwd="$cwd_val"; fi
+
+        # Check if already running
+        if [ -f "$pid_file" ]; then
+            local existing_pid=$(cat "$pid_file")
+            if ps -p $existing_pid > /dev/null 2>&1; then
+                log "WARN" "${YELLOW}[WARN] $name already running (PID: $existing_pid)${NC}"
+                continue
+            fi
+            rm -f "$pid_file"
+        fi
+
+        local worker_log="$LOG_DIR/${log_prefix}-$(date +%Y%m%d-%H%M%S).log"
+
+        cd "$worker_cwd"
+        eval "$command" >> "$worker_log" 2>&1 &
+        local pid=$!
+        echo $pid > "$pid_file"
+        cd "$ENGINEER_DIR"
+
+        sleep 2
+        if ps -p $pid > /dev/null 2>&1; then
+            log "INFO" "${GREEN}[OK] $name started (PID: $pid)${NC}"
+            log "INFO" "   * Log: $worker_log"
+        else
+            log "ERROR" "${RED}[ERROR] $name failed to start! Check log: $worker_log${NC}"
+        fi
+    done
+}
+
+# Function to stop all workers from registry
+stop_workers() {
+    if [ ! -f "$WORKER_REGISTRY" ]; then return; fi
+
+    log "INFO" "${YELLOW}[WORKERS] Stopping workers...${NC}"
+
+    get_workers | while IFS= read -r worker_json; do
+        local name=$(node -e "console.log(JSON.parse(process.argv[1]).display_name)" "$worker_json")
+        local pid_file_name=$(node -e "console.log(JSON.parse(process.argv[1]).pid_file)" "$worker_json")
+        local pid_file="$PID_DIR/$pid_file_name"
+        stop_server "$pid_file" "$name"
+    done
+}
+
+# Function to show worker status from registry
+show_worker_status() {
+    if [ ! -f "$WORKER_REGISTRY" ]; then return; fi
+
+    echo ""
+    echo -e "${BLUE}Workers:${NC}"
+
+    get_workers | while IFS= read -r worker_json; do
+        local name=$(node -e "console.log(JSON.parse(process.argv[1]).display_name)" "$worker_json")
+        local enabled=$(node -e "console.log(JSON.parse(process.argv[1]).enabled)" "$worker_json")
+        local pid_file_name=$(node -e "console.log(JSON.parse(process.argv[1]).pid_file)" "$worker_json")
+        local pid_file="$PID_DIR/$pid_file_name"
+
+        if [ "$enabled" != "true" ]; then
+            log "INFO" "   ${NC}[--] $name: Disabled"
+            continue
+        fi
+
+        if [ -f "$pid_file" ]; then
+            local pid_val=$(cat "$pid_file")
+            if ps -p $pid_val > /dev/null 2>&1; then
+                log "INFO" "   ${GREEN}[OK] $name: Running (PID: $pid_val)${NC}"
+            else
+                log "INFO" "   ${RED}[!!] $name: Dead (stale PID: $pid_val)${NC}"
+            fi
+        else
+            log "INFO" "   ${RED}[--] $name: Not running${NC}"
+        fi
+    done
+}
+
 # Function to stop all servers
 stop_all() {
     log "INFO" "${RED}[STOP] Stopping all servers...${NC}"
     echo "=================================="
+
+    stop_workers
 
     stop_server "$APP_PID" "EHG App"
     sleep 1
@@ -237,6 +346,9 @@ status() {
 
     check_status "$ENGINEER_PID" 3000 "EHG_Engineer (3000)"
     check_status "$APP_PID" 8080 "EHG App (8080)"
+
+    show_worker_status
+
     echo "=================================="
 
     # Show memory if available
@@ -269,6 +381,8 @@ start_all() {
     sleep $STARTUP_DELAY
 
     start_app || { log "ERROR" "${RED}Failed to start EHG App${NC}"; return 1; }
+
+    start_workers
 
     echo "=================================="
     log "INFO" "${GREEN}[DONE] LEO Stack startup complete!${NC}"
@@ -354,6 +468,9 @@ case "${1:-}" in
     start-app)
         start_app
         ;;
+    start-worker)
+        start_workers
+        ;;
     *)
         echo "LEO Stack Management Script - Cross-Platform Version"
         echo "====================================================="
@@ -374,10 +491,15 @@ case "${1:-}" in
         echo "Advanced Commands:"
         echo "  start-engineer   - Start only EHG_Engineer (3000)"
         echo "  start-app        - Start only EHG App (8080)"
+        echo "  start-worker     - Start all enabled workers from config/workers.json"
         echo ""
         echo "Servers:"
         echo "  Port 3000 - EHG_Engineer (LEO Protocol Framework, Backend API)"
         echo "  Port 8080 - EHG App (Frontend UI with Vite)"
+        echo ""
+        echo "Worker Registry:"
+        echo "  Workers are defined in config/workers.json. Set \"enabled\": true to auto-start"
+        echo "  with the stack. See docs/reference/worker-registry-guide.md for details."
         echo ""
         echo "NOTE: On Windows, use 'node scripts/cross-platform-run.js leo-stack'"
         echo "      which automatically uses the PowerShell version (leo-stack.ps1)"


### PR DESCRIPTION
## Summary
- Add `config/workers.json` as single source of truth for background workers (Stage Zero Processor, EVA Workers, Sub-Agent Worker, EVA Master Scheduler)
- Replace hardcoded `Start-StageZeroProcessor` in `leo-stack.ps1` with registry-driven `Get-WorkerRegistry`, `Start-Workers`, `Stop-Workers` functions
- Mirror registry support in `leo-stack.sh` for Linux/macOS parity
- Only Stage Zero Processor is enabled by default; others registered but disabled
- Workers integrate with start/stop/restart/status/emergency lifecycle — adding a new worker requires only a JSON entry
- Add `start-worker` command and worker status section to both scripts
- Add `docs/reference/worker-registry-guide.md` with schema reference, troubleshooting, and architecture diagram

## Test plan
- [x] PS1 syntax validation passes
- [x] Bash syntax validation passes (`bash -n`)
- [x] JSON validation passes
- [x] `leo-stack.ps1 help` shows worker registry section
- [x] `leo-stack.ps1 status` shows worker status (Running/Not running/Disabled)
- [ ] `leo-stack restart` starts Stage Zero Processor alongside Engineer and App
- [ ] `leo-stack stop` cleanly stops workers before servers
- [ ] Idempotent: re-running `start` skips already-running workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)