### PR TITLE
feat: inject capability context into Stage 0 discovery scanners

### DIFF
--- a/lib/capabilities/index.js
+++ b/lib/capabilities/index.js
@@ -29,6 +29,11 @@ export {
   formatPlane1Score,
 } from './plane1-scoring.js';
 
+// Scanner context injection
+export {
+  getCapabilityContextBlock,
+} from './scanner-context.js';
+
 // Reuse tracking
 export {
   REUSE_CONFIG,

--- a/lib/capabilities/scanner-context.js
+++ b/lib/capabilities/scanner-context.js
@@ -1,0 +1,147 @@
+/**
+ * Scanner Context Module
+ * SD: SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B
+ *
+ * Queries v_capability_ledger and formats capability data as concise context
+ * blocks for injection into Stage 0 discovery scanner LLM prompts.
+ *
+ * Each scanner type gets a differently formatted block optimized for its
+ * analysis approach. All blocks are capped at 2000 characters.
+ */
+
+const MAX_CONTEXT_CHARS = 2000;
+const MAX_CAPABILITIES = 20;
+
+/**
+ * Get a formatted capability context block for a specific scanner type.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} scannerType - One of: trend_scanner, democratization_finder, capability_overhang, nursery_reeval
+ * @returns {Promise<string>} Formatted markdown context block, or empty string if no data
+ */
+export async function getCapabilityContextBlock(supabase, scannerType) {
+  if (!supabase) return '';
+
+  try {
+    const { data: capabilities, error } = await supabase
+      .from('v_capability_ledger')
+      .select('capability_name, capability_type, plane1_score, maturity_score, reuse_count, sd_key, scored_at')
+      .order('plane1_score', { ascending: false })
+      .limit(MAX_CAPABILITIES);
+
+    if (error) {
+      console.warn(`[scanner-context] Query error: ${error.message}`);
+      return '';
+    }
+
+    if (!capabilities || capabilities.length === 0) {
+      return '';
+    }
+
+    const formatters = {
+      trend_scanner: formatForTrendScanner,
+      democratization_finder: formatForDemocratization,
+      capability_overhang: formatForOverhang,
+      nursery_reeval: formatForNurseryReeval,
+    };
+
+    const formatter = formatters[scannerType] || formatForOverhang;
+    const block = formatter(capabilities);
+
+    // Hard cap enforcement
+    if (block.length > MAX_CONTEXT_CHARS) {
+      return block.substring(0, MAX_CONTEXT_CHARS - 3) + '...';
+    }
+
+    return block;
+  } catch (err) {
+    console.warn(`[scanner-context] Error: ${err.message}`);
+    return '';
+  }
+}
+
+/**
+ * Trend Scanner: Group capabilities by category to identify where EHG
+ * has existing strengths that align with market trends.
+ */
+function formatForTrendScanner(capabilities) {
+  const byType = {};
+  for (const cap of capabilities) {
+    const type = cap.capability_type || 'other';
+    if (!byType[type]) byType[type] = [];
+    byType[type].push(cap);
+  }
+
+  let block = '## EHG Internal Capabilities (by category)\n';
+  block += 'When suggesting ventures, consider how these existing capabilities provide a head start:\n\n';
+
+  for (const [type, caps] of Object.entries(byType)) {
+    block += `**${type}**: ${caps.map(c => c.capability_name).join(', ')}\n`;
+  }
+
+  return block;
+}
+
+/**
+ * Democratization Finder: Highlight capabilities with high reuse potential
+ * that could be used to democratize premium services.
+ */
+function formatForDemocratization(capabilities) {
+  // Sort by reuse_count to highlight most reusable capabilities
+  const sorted = [...capabilities].sort((a, b) => (b.reuse_count || 0) - (a.reuse_count || 0));
+
+  let block = '## EHG Reusable Capabilities\n';
+  block += 'These internal capabilities can power democratized versions of premium services:\n\n';
+
+  for (const cap of sorted.slice(0, 15)) {
+    const reuse = cap.reuse_count ? ` (reused ${cap.reuse_count}x)` : '';
+    block += `- **${cap.capability_name}** [${cap.capability_type}]${reuse}\n`;
+  }
+
+  return block;
+}
+
+/**
+ * Capability Overhang: Full detail including plane1_score and maturity
+ * to enable true overhang gap analysis against market opportunities.
+ */
+function formatForOverhang(capabilities) {
+  let block = '## EHG Capability Ledger (Internal Strengths)\n';
+  block += 'Use this real data to identify ventures where EHG has an existing capability advantage:\n\n';
+  block += '| Capability | Type | Score | Maturity | Reuse |\n';
+  block += '|---|---|---|---|---|\n';
+
+  for (const cap of capabilities) {
+    const score = cap.plane1_score != null ? cap.plane1_score.toFixed(1) : 'N/A';
+    const maturity = cap.maturity_score != null ? cap.maturity_score : 'N/A';
+    const reuse = cap.reuse_count || 0;
+    block += `| ${cap.capability_name} | ${cap.capability_type} | ${score} | ${maturity} | ${reuse}x |\n`;
+  }
+
+  block += '\nLook for gaps between these capabilities and market opportunities not yet productized.\n';
+
+  return block;
+}
+
+/**
+ * Nursery Re-eval: Focus on recently added capabilities that may
+ * unblock previously parked ventures.
+ */
+function formatForNurseryReeval(capabilities) {
+  // Sort by scored_at (most recent first) to highlight new capabilities
+  const sorted = [...capabilities].sort((a, b) => {
+    const dateA = a.scored_at ? new Date(a.scored_at).getTime() : 0;
+    const dateB = b.scored_at ? new Date(b.scored_at).getTime() : 0;
+    return dateB - dateA;
+  });
+
+  let block = '## Recently Added EHG Capabilities\n';
+  block += 'Consider whether these new/updated capabilities unblock any parked ventures:\n\n';
+
+  for (const cap of sorted.slice(0, 15)) {
+    const date = cap.scored_at ? new Date(cap.scored_at).toISOString().split('T')[0] : 'unknown';
+    block += `- **${cap.capability_name}** [${cap.capability_type}] — added ${date}\n`;
+  }
+
+  return block;
+}

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -17,6 +17,7 @@
 
 import { createPathOutput } from '../interfaces.js';
 import { getValidationClient } from '../../../llm/client-factory.js';
+import { getCapabilityContextBlock } from '../../../capabilities/scanner-context.js';
 
 const VALID_STRATEGIES = ['trend_scanner', 'democratization_finder', 'capability_overhang', 'nursery_reeval'];
 
@@ -160,10 +161,13 @@ async function runTrendScanner({ constraints, candidateCount, strategyConfig }, 
     }
   }
 
+  // SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B: Inject capability context
+  const capabilityBlock = await getCapabilityContextBlock(supabase, 'trend_scanner');
+
   const prompt = `You are an AI venture scout for EHG, a fully automated holding group.
 
 EHG's advantage: Everything is AI-operated. No human employees. Lower costs, faster iteration, 24/7 operation.
-${contextBlock}${rankingBlock}
+${contextBlock}${rankingBlock}${capabilityBlock ? `\n${capabilityBlock}\n` : ''}
 STRATEGY: Trend Scanner
 ${strategyConfig.description || 'Scan for trending products, emerging markets, and undermarketed opportunities.'}
 ${constraintText}
@@ -196,7 +200,7 @@ Return a JSON array:
  * that can be made accessible through automation.
  */
 async function runDemocratizationFinder({ constraints, candidateCount, strategyConfig }, deps = {}) {
-  const { logger = console, llmClient, strategicContext } = deps;
+  const { supabase, logger = console, llmClient, strategicContext } = deps;
   const client = llmClient || getValidationClient();
 
   const constraintText = Object.keys(constraints).length > 0
@@ -207,10 +211,13 @@ async function runDemocratizationFinder({ constraints, candidateCount, strategyC
     ? `\n${strategicContext.formattedPromptBlock}\n`
     : '';
 
+  // SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B: Inject capability context
+  const capabilityBlock = await getCapabilityContextBlock(supabase, 'democratization_finder');
+
   const prompt = `You are an AI venture scout for EHG, a fully automated holding group.
 
 EHG's advantage: Everything is AI-operated. Dramatically lower costs enable democratizing premium services.
-${contextBlock}
+${contextBlock}${capabilityBlock ? `\n${capabilityBlock}\n` : ''}
 STRATEGY: Democratization Finder
 ${strategyConfig.description || 'Find premium services only available to the wealthy that can be made accessible through automation.'}
 ${constraintText}
@@ -245,7 +252,7 @@ Return a JSON array:
  * that have not been productized.
  */
 async function runCapabilityOverhang({ constraints, candidateCount, strategyConfig }, deps = {}) {
-  const { logger = console, llmClient, strategicContext } = deps;
+  const { supabase, logger = console, llmClient, strategicContext } = deps;
   const client = llmClient || getValidationClient();
 
   const constraintText = Object.keys(constraints).length > 0
@@ -256,10 +263,13 @@ async function runCapabilityOverhang({ constraints, candidateCount, strategyConf
     ? `\n${strategicContext.formattedPromptBlock}\n`
     : '';
 
+  // SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B: Inject real capability data
+  const capabilityBlock = await getCapabilityContextBlock(supabase, 'capability_overhang');
+
   const prompt = `You are an AI venture scout for EHG, a fully automated holding group.
 
 EHG's advantage: Deep AI expertise and automated operations. Can productize AI capabilities faster than incumbents.
-${contextBlock}
+${contextBlock}${capabilityBlock ? `\n${capabilityBlock}\n` : ''}
 STRATEGY: Capability Overhang Exploit
 ${strategyConfig.description || 'Find gaps between what AI can do and what products currently offer.'}
 ${constraintText}
@@ -295,6 +305,9 @@ async function runNurseryReeval({ constraints, candidateCount }, deps = {}) {
   const { supabase, logger = console, llmClient } = deps;
   const client = llmClient || getValidationClient();
 
+  // SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B: Inject capability context
+  const capabilityBlock = await getCapabilityContextBlock(supabase, 'nursery_reeval');
+
   // Load parked ventures from nursery
   const { data: nurseryItems, error } = await supabase
     .from('venture_nursery')
@@ -329,7 +342,7 @@ These ventures were previously parked in EHG's Venture Nursery. Conditions may h
 - Market shifts
 - Portfolio gaps emerged
 - Technology costs decreased
-
+${capabilityBlock ? `\n${capabilityBlock}\n` : ''}
 Parked ventures:
 ${itemSummaries}
 ${constraintText}

--- a/tests/unit/scanner-context.test.js
+++ b/tests/unit/scanner-context.test.js
@@ -1,0 +1,131 @@
+/**
+ * Tests for lib/capabilities/scanner-context.js
+ * SD: SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { getCapabilityContextBlock } from '../../lib/capabilities/scanner-context.js';
+
+function mockSupabase(data = [], error = null) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        order: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue({ data, error }),
+        }),
+      }),
+    }),
+  };
+}
+
+const SAMPLE_CAPABILITIES = [
+  { capability_name: 'AI Image Classification', capability_type: 'ai_automation', plane1_score: 18.5, maturity_score: 4, reuse_count: 3, sd_key: 'SD-IMG-001', scored_at: '2026-03-01T00:00:00Z' },
+  { capability_name: 'Natural Language Processing', capability_type: 'ai_automation', plane1_score: 16.2, maturity_score: 3, reuse_count: 5, sd_key: 'SD-NLP-001', scored_at: '2026-03-02T00:00:00Z' },
+  { capability_name: 'Supabase Integration', capability_type: 'infrastructure', plane1_score: 14.0, maturity_score: 5, reuse_count: 10, sd_key: 'SD-INFRA-001', scored_at: '2026-02-15T00:00:00Z' },
+  { capability_name: 'Payment Processing', capability_type: 'integration', plane1_score: 12.0, maturity_score: 3, reuse_count: 2, sd_key: 'SD-PAY-001', scored_at: '2026-02-20T00:00:00Z' },
+  { capability_name: 'Automated Reporting', capability_type: 'application', plane1_score: 10.5, maturity_score: 2, reuse_count: 1, sd_key: 'SD-RPT-001', scored_at: '2026-03-03T00:00:00Z' },
+];
+
+describe('getCapabilityContextBlock', () => {
+  it('returns empty string when supabase is null', async () => {
+    const result = await getCapabilityContextBlock(null, 'trend_scanner');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string when no capabilities exist', async () => {
+    const supabase = mockSupabase([]);
+    const result = await getCapabilityContextBlock(supabase, 'trend_scanner');
+    expect(result).toBe('');
+  });
+
+  it('returns empty string on query error', async () => {
+    const supabase = mockSupabase(null, { message: 'connection failed' });
+    const result = await getCapabilityContextBlock(supabase, 'trend_scanner');
+    expect(result).toBe('');
+  });
+
+  it('formats trend_scanner with category grouping', async () => {
+    const supabase = mockSupabase(SAMPLE_CAPABILITIES);
+    const result = await getCapabilityContextBlock(supabase, 'trend_scanner');
+
+    expect(result).toContain('EHG Internal Capabilities');
+    expect(result).toContain('ai_automation');
+    expect(result).toContain('AI Image Classification');
+    expect(result).toContain('infrastructure');
+  });
+
+  it('formats democratization_finder with reuse focus', async () => {
+    const supabase = mockSupabase(SAMPLE_CAPABILITIES);
+    const result = await getCapabilityContextBlock(supabase, 'democratization_finder');
+
+    expect(result).toContain('Reusable Capabilities');
+    expect(result).toContain('reused');
+  });
+
+  it('formats capability_overhang with full detail table', async () => {
+    const supabase = mockSupabase(SAMPLE_CAPABILITIES);
+    const result = await getCapabilityContextBlock(supabase, 'capability_overhang');
+
+    expect(result).toContain('Capability Ledger');
+    expect(result).toContain('Score');
+    expect(result).toContain('Maturity');
+    expect(result).toContain('18.5');
+    expect(result).toContain('AI Image Classification');
+  });
+
+  it('formats nursery_reeval with recent capabilities', async () => {
+    const supabase = mockSupabase(SAMPLE_CAPABILITIES);
+    const result = await getCapabilityContextBlock(supabase, 'nursery_reeval');
+
+    expect(result).toContain('Recently Added');
+    expect(result).toContain('added');
+    // Most recent should be first (2026-03-03)
+    const reportIdx = result.indexOf('Automated Reporting');
+    const nlpIdx = result.indexOf('Natural Language Processing');
+    expect(reportIdx).toBeLessThan(nlpIdx);
+  });
+
+  it('enforces 2000 character cap', async () => {
+    // Create a large capability set
+    const largeSet = Array.from({ length: 20 }, (_, i) => ({
+      capability_name: `Very Long Capability Name That Takes Up Space Number ${i + 1} With Extra Description`,
+      capability_type: 'ai_automation',
+      plane1_score: 20 - i,
+      maturity_score: 5,
+      reuse_count: i,
+      sd_key: `SD-LONG-${i}`,
+      scored_at: '2026-03-01T00:00:00Z',
+    }));
+
+    const supabase = mockSupabase(largeSet);
+    const result = await getCapabilityContextBlock(supabase, 'capability_overhang');
+
+    expect(result.length).toBeLessThanOrEqual(2000);
+  });
+
+  it('uses overhang format as default for unknown scanner type', async () => {
+    const supabase = mockSupabase(SAMPLE_CAPABILITIES);
+    const result = await getCapabilityContextBlock(supabase, 'unknown_scanner');
+
+    expect(result).toContain('Capability Ledger');
+  });
+
+  it('produces different output for different scanner types', async () => {
+    const supabase = mockSupabase(SAMPLE_CAPABILITIES);
+
+    const trend = await getCapabilityContextBlock(supabase, 'trend_scanner');
+    const demo = await getCapabilityContextBlock(supabase, 'democratization_finder');
+    const overhang = await getCapabilityContextBlock(supabase, 'capability_overhang');
+    const nursery = await getCapabilityContextBlock(supabase, 'nursery_reeval');
+
+    // All should be non-empty
+    expect(trend.length).toBeGreaterThan(0);
+    expect(demo.length).toBeGreaterThan(0);
+    expect(overhang.length).toBeGreaterThan(0);
+    expect(nursery.length).toBeGreaterThan(0);
+
+    // All should be different
+    expect(trend).not.toBe(demo);
+    expect(demo).not.toBe(overhang);
+    expect(overhang).not.toBe(nursery);
+  });
+});


### PR DESCRIPTION
## Summary
- Create `lib/capabilities/scanner-context.js` module that queries `v_capability_ledger` and formats capability data for scanner LLM prompts
- Integrate capability context injection into all 4 Stage 0 scanners (Trend, Democratization, Capability Overhang, Nursery Re-eval)
- Each scanner gets type-specific formatting: category-grouped (trend), reuse-focused (democratization), full detail table (overhang), recency-sorted (nursery)
- Hard cap at 2000 characters, top 20 by plane1_score
- Graceful degradation: empty string on no data or query errors

SD: SD-CAPABILITYAWARE-SCANNERS-AND-ANTHROPIC-ORCH-001-B

## Test plan
- [x] 10 unit tests passing for scanner-context module
- [x] Smoke tests passing (15/15)
- [x] ESLint passing
- [x] DOCMON compliance passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)