### PR TITLE
feat: enforce /simplify as mandatory step in /ship pipeline

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -242,14 +242,16 @@ node scripts/ship-preflight.js --json
 
 ---
 
-### Step 0.6: Code Simplification (OPTIONAL)
+### Step 0.6: Code Simplification (MANDATORY)
 
-Before committing, consider running `/simplify` to clean up code without changing behavior.
+Before committing, run `/simplify` to clean up code without changing behavior. This step is **mandatory** to prevent technical debt accumulation.
 
-**When to run:**
-- Session had rapid iteration (multiple debug cycles)
-- Code works but feels "messy"
-- Pre-PR polish desired
+**Procedure:**
+1. Run `/simplify` to preview available simplifications
+2. Review changes (especially `logic` type rules)
+3. Run `/simplify --apply` if acceptable
+4. If no simplifications found, proceed to Step 0.9
+5. Proceed to Step 0.9
 
 **Quick check:**
 ```javascript
@@ -261,24 +263,21 @@ const engine = new SimplificationEngine(supabase);
 const files = engine.getSessionChangedFiles();
 
 if (files.length > 0) {
-  console.log(`📝 ${files.length} files changed - consider /simplify`);
+  console.log(`${files.length} files changed - running /simplify`);
   const results = await engine.simplify(files, { dryRun: true });
   if (results.totalChanges > 0) {
-    console.log(`   🔧 ${results.totalChanges} simplifications available`);
+    console.log(`   ${results.totalChanges} simplifications available`);
   }
 }
 ```
 
-**If changes found:**
-1. Run `/simplify` to preview
-2. Review changes (especially `logic` type rules)
-3. Run `/simplify --apply` if acceptable
-4. Proceed to Step 1
+**Escape hatch (`--skip-simplify`):**
 
-**Skip if:**
-- No simplifications found
-- Time-sensitive shipping
-- Changes are too risky (manual cleanup preferred)
+For time-sensitive shipping, use `--skip-simplify` to bypass this step. The bypass is logged:
+```
+[SIMPLIFY-SKIP] /simplify skipped via --skip-simplify flag. Reason: <provide reason>
+```
+Only use this escape hatch when shipping is genuinely time-sensitive. Habitual skipping defeats the purpose of enforcement.
 
 See `/simplify` command for full details.
 

--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -156,13 +156,19 @@ The engine uses confidence scores from database rules:
 
 ---
 
-## Integration with /ship
+## Integration with /ship (Mandatory Enforcement)
 
-The `/ship` command includes an optional Step 0.6 that suggests running `/simplify`:
+The `/ship` command enforces `/simplify` as a **mandatory** step (Step 0.6) before committing:
 
 ```
-/leo complete → /simplify (optional) → /ship → /learn
+/leo complete → /simplify (MANDATORY) → /ship → /learn
 ```
+
+**Enforcement behavior:**
+- `/ship` requires `/simplify` to be run before proceeding to commit
+- If no simplifications are found, `/simplify` completes instantly and `/ship` continues
+- Use `--skip-simplify` with `/ship` for time-sensitive shipping (bypass is logged)
+- When invoked directly (not via `/ship`), `/simplify` works unchanged
 
 See `/ship` command for the integrated workflow.
 

--- a/brainstorm/2026-03-05-simplify-batch-leo-protocol-integration.md
+++ b/brainstorm/2026-03-05-simplify-batch-leo-protocol-integration.md
@@ -1,0 +1,134 @@
+# Brainstorm: Integrating /simplify and /batch Commands into the LEO Protocol
+
+## Metadata
+- **Date**: 2026-03-05
+- **Domain**: Protocol
+- **Phase**: Discovery
+- **Mode**: Conversational
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: None (internal protocol improvement)
+
+---
+
+## Problem Statement
+
+The LEO protocol has a mature build cycle (LEAD→PLAN→EXEC), scoring (/heal), and learning (/learn), but lacks a formal **operational maintenance layer**. Two specific gaps:
+
+1. **/simplify** exists as a code cleanup command but is positioned as "optional Step 0.6" in /ship. Agents routinely skip it under AUTO-PROCEED. It's session-scoped only and never addresses legacy code debt.
+
+2. **/batch** doesn't exist as a command despite 10+ ad-hoc batch scripts sharing common patterns (query DB → iterate → process → report). These scripts handle handoff acceptance, child SD completion, vision rescoring, and more — but with no unified interface, no common dry-run semantics, and no DB logging of operations.
+
+## Discovery Summary
+
+### Current /simplify State
+- Full command definition at `.claude/commands/simplify.md`
+- Database-driven rules in `leo_simplification_rules` table
+- Session-scoped (files changed since origin/main)
+- Three confidence tiers: auto-apply (≥95%), suggest (≥80%), manual review (≥60%)
+- Integrated with /ship as optional Step 0.6
+- Plugin bridge supports Claude Opus reasoning when available
+
+### Current Batch Script Landscape
+| Script | Purpose |
+|--------|---------|
+| `batch-accept-all-valid-handoffs.mjs` | Accept all pending handoffs across types |
+| `batch-accept-pending-handoffs.mjs` | Accept LEAD→PLAN handoffs specifically |
+| `batch-complete-child-sds.js` | Force-complete children of an orchestrator |
+| `batch-rescore-manual-overrides.js` | Rescore manual vision overrides via Ollama |
+| `batch-rescore-round1-children.js` | Rescore Round 1 children |
+| `batch-rescore-round2-children.js` | Rescore Round 2 children |
+| `batch-update-handoff-table-refs.cjs` | Update handoff table references |
+| `batch-test-completed-sds.cjs` | Test completed SDs |
+| `batch-test-completed-sds-real.cjs` | Real batch testing with monitoring |
+| `generate-stage-dossiers-batch.js` | Batch generate stage dossiers |
+
+Common pattern: All use Supabase queries, iterate results, process each, report success/fail counts. Some support `--dry-run`.
+
+### Affected Workflows
+- **EXEC→Ship transition** (where /simplify lives today)
+- **Orchestrator management** (batch handoff acceptance)
+- **EVA scoring** (batch rescore)
+- **General codebase maintenance** (no protocol layer exists)
+
+## Analysis
+
+### Arguments For
+1. **LEO has no maintenance mode.** Build, score, learn — but no "operate on the fleet at scale." /batch fills this gap.
+2. **/simplify enforcement is nearly free.** The command exists, works, and just needs the "optional" escape hatch removed. Immediate code quality improvement.
+3. **The 165 broken ESM scripts** (documented in MEMORY.md) are a textbook /batch use case — controlled sweep with auditability vs. 165 individual PRs.
+4. **/batch amplifies /heal.** Instead of per-SD vision scoring, a single session could sweep the entire scored backlog.
+5. **Track-level operations.** The A/B/C track system produces SDs with shared patterns. /batch enables track-level transformations (e.g., PR #1818 injected capability context into all Stage 0 scanners — a /batch use case).
+
+### Arguments Against
+1. **Protocol surface area risk.** Adding operational tooling to the protocol layer adds failure modes to the most sensitive system component.
+2. **Thin wrapper illusion.** A unified /batch interface over heterogeneous scripts creates false safety — operators assume uniform error handling when each script has unique failure modes.
+3. **No gate metric for /simplify.** Making it mandatory without a measurable quality metric in gate validators means it's "theater" — adding latency with no signal.
+4. **Implicit serialization guard.** Ad-hoc manual scripts are safe because they run one at a time. Automation removes that guard.
+5. **Session-scope is a feature, not a bug.** Touching legacy code during a live EXEC phase causes gate drift and unexpected diffs.
+
+## Protocol: Friction/Value/Risk Analysis
+
+| Dimension | /simplify | /batch | Combined |
+|-----------|-----------|--------|----------|
+| Friction Reduction | 6/10 | 8/10 | **7/10** |
+| Value Addition | 5/10 | 9/10 | **7/10** |
+| Risk Profile | 2/10 | 6/10 | **4/10** |
+
+**Decision Rule**: Implement if (Friction + Value) > Risk * 2
+- /simplify: 11 > 4 → **Implement**
+- /batch: 17 > 12 → **Implement** (with caution)
+- Combined: 14 > 8 → **Implement**
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**:
+  1. Protocol-vs-tooling conflation — /simplify and /batch are operational conveniences, not protocol primitives. Grafting them into the protocol layer adds surface area to the most sensitive part of the system.
+  2. "No unified interface" diagnosis misidentifies the problem — it's a tooling gap, not a protocol gap. A thin wrapper over heterogeneous operations creates false safety.
+  3. Session-scope of /simplify may be intentional design, not a limitation — agents may correctly assess the risk.
+- **Assumptions at Risk**:
+  1. "Agents skip /simplify because it's optional" — the real reason may be that no gate checks for simplification quality. Without a metric, mandatory /simplify is theater.
+  2. "A /batch command would reduce ad-hoc sprawl" — the sprawl may be a symptom of bulk operations not being modeled as first-class SDs.
+  3. "Backward compatibility can be managed" — several scripts have implicit dependencies on execution order and Supabase row state.
+- **Worst Case**: /batch bulk-advances handoffs, silent Supabase schema errors cause writes to fail silently, 3 SDs enter zombie state (in-memory says "advanced" but DB disagrees), no recovery path exists, RCA agents investigate the wrong layer.
+
+### Visionary
+- **Opportunities**:
+  1. /batch transforms LEO from a build-only protocol into a **fleet management system** — ad-hoc scripts converge into reusable, auditable commands with operational memory.
+  2. /simplify as mandatory pre-commit check closes the loop between code quality intent and enforcement — quality gate with teeth, like /heal for vision scores.
+  3. Combined /batch + /heal gives LEO a **self-maintenance mode** — periodic protocol hygiene as a single command rather than manual multi-session effort.
+- **Synergies**:
+  - /batch amplifies /heal (sweep entire scored backlog in one session)
+  - /simplify reinforces PR size discipline (≤100 LOC advisory becomes structural)
+  - /batch connects to A/B/C track system (track-level transformations)
+  - /simplify + /batch solves the 165 broken ESM scripts (controlled sweep with auditability)
+- **Upside Scenario**: LEO becomes self-improving. /batch can be pointed at the protocol scripts themselves, applying /simplify to the orchestration layer, identifying patterns in failed gate runs, surfacing them to /learn. The protocol's own codebase becomes subject to the same quality discipline it enforces on application code.
+
+### Pragmatist
+- **Feasibility**: 4/10 overall (split: /simplify enforcement = 2/10 difficulty, /batch unification = 6/10 difficulty)
+- **Resource Requirements**:
+  - /simplify: 1 engineer, 2-4 hours. Update /ship protocol, add PreToolUse hook enforcement.
+  - /batch: 1 engineer, 3-5 days. Dispatcher script (~150-200 LOC), common argument parser, dry-run enforcement, documentation.
+- **Constraints**:
+  1. Audit all 10+ batch scripts for argument signatures, exit codes, and output formats before building dispatcher.
+  2. Mandatory dry-run mode — these scripts operate on the database. Misrouted commands can corrupt SD state.
+  3. Protocol adoption requires documentation in CLAUDE_EXEC_DIGEST.md — agents won't discover undocumented commands.
+- **Recommended Path**: /simplify enforcement first (days 1-2), then /batch dispatcher for top 3-4 scripts (days 3-7), then expand incrementally (week 2-3). Do not big-bang rewrite. Total: ~2 weeks for solid v1.
+
+### Synthesis
+- **Consensus Points**: Two-phase approach (simplify first, batch second). Dry-run is non-negotiable. Script audit is a prerequisite.
+- **Tension Points**: Protocol layer vs. tooling layer placement. Silent failure amplification vs. fleet maintenance power. Whether agents skip /simplify correctly or not.
+- **Composite Risk**: Medium
+
+## Open Questions
+1. Should /simplify have a gate metric (e.g., "simplification compliance score") to give enforcement teeth?
+2. Should /batch be a protocol phase or a separate tooling layer outside LEAD→PLAN→EXEC?
+3. Should bulk operations be modeled as SDs themselves (Challenger's alternative) rather than a new command?
+4. What is the right concurrency model for /batch? Serial-only (safe) or controlled parallelism (fast)?
+
+## Suggested Next Steps
+1. **SD-A (Quick Win)**: Enforce /simplify in /ship — remove "optional" qualifier, add hook enforcement. ~2-4 hours.
+2. **SD-B (Build)**: Create /batch command — audit existing scripts, build dispatcher with dry-run enforcement, route top 3-4 highest-frequency scripts first, expand incrementally. ~2 weeks.
+3. Consider: Add simplification quality metric to gate validators (addresses Challenger's "theater" concern).
+4. Consider: Model /batch operations as a "MAINTAIN" mode in LEO lifecycle documentation.

--- a/docs/plans/simplify-batch-leo-integration-architecture.md
+++ b/docs/plans/simplify-batch-leo-integration-architecture.md
@@ -1,0 +1,224 @@
+# Architecture Plan: /simplify and /batch Integration into LEO Protocol
+
+## Stack & Repository Decisions
+
+- **Repository**: EHG_Engineer (same repo — internal protocol tooling)
+- **Runtime**: Node.js (ESM) — consistent with existing scripts
+- **Database**: Supabase (existing) — new table `batch_operation_log` only
+- **No new dependencies** — uses existing Supabase client, dotenv, and simplification engine
+- **Command definition**: `.claude/commands/batch.md` (new) + update `.claude/commands/simplify.md` and `.claude/commands/ship.md`
+
+## Legacy Deprecation Plan
+
+### /simplify
+- No deprecation needed — the command already exists. Changes are behavioral (optional → enforced).
+
+### Batch Scripts
+- **NOT deprecated** — existing scripts remain as the underlying implementations
+- /batch dispatcher routes to them; they are not rewritten
+- Ad-hoc direct invocation remains possible but discouraged in documentation
+- Migration path: update script argument signatures to conform to standard interface where needed (minor refactoring)
+
+### Scripts to Route (in priority order)
+
+| Script | Operation Key | Estimated Refactor |
+|--------|--------------|-------------------|
+| `batch-accept-all-valid-handoffs.mjs` | `accept-handoffs` | Minimal — already has clean output |
+| `batch-accept-pending-handoffs.mjs` | `accept-handoffs --type lead-to-plan` | Minimal — subset of above |
+| `eva/batch-rescore-manual-overrides.js` | `rescore --type manual` | Minimal — already has --dry-run |
+| `eva/batch-rescore-round1-children.js` | `rescore --type round1` | Minimal — similar pattern |
+| `eva/batch-rescore-round2-children.js` | `rescore --type round2` | Minimal — similar pattern |
+| `batch-complete-child-sds.js` | `complete-children` | Moderate — hardcoded parent SD |
+| `batch-update-handoff-table-refs.cjs` | `update-refs` | Moderate — CJS needs ESM wrapper |
+| `batch-test-completed-sds.cjs` | `test-sds` | Moderate — CJS needs ESM wrapper |
+
+## Route & Component Structure
+
+### New Files
+```
+.claude/commands/batch.md              # /batch command definition (skill)
+scripts/batch-dispatcher.mjs           # Main dispatcher (~150-200 LOC)
+scripts/batch-operations/              # Operation registry
+  index.mjs                            # Operation manifest
+  accept-handoffs.mjs                  # Adapter for existing script
+  rescore.mjs                          # Adapter for existing scripts
+  complete-children.mjs                # Adapter for existing script
+database/migrations/YYYYMMDD_batch_operation_log.sql  # Audit table
+```
+
+### Modified Files
+```
+.claude/commands/ship.md               # Step 0.6: optional → enforced
+.claude/commands/simplify.md           # Add enforcement mode docs
+scripts/hooks/pre-tool-enforce.cjs     # Add /simplify gate before /ship
+```
+
+### Dispatcher Architecture
+```
+/batch <operation> [flags]
+    │
+    ├── Parse args (operation, --dry-run, --filter, --concurrency)
+    ├── Load operation from registry (scripts/batch-operations/index.mjs)
+    ├── Validate: require --dry-run on first invocation
+    ├── Execute operation
+    │   ├── Query phase: Supabase query for items
+    │   ├── Preview phase: Show item count + sample
+    │   ├── Process phase: Iterate with progress reporting
+    │   └── Verify phase: Read-back verification on writes
+    ├── Report: success/fail/skip counts
+    └── Log: Write to batch_operation_log
+```
+
+### Operation Interface Contract
+Each operation module must export:
+```javascript
+export default {
+  key: 'accept-handoffs',
+  description: 'Accept all valid pending handoffs',
+  supportsDryRun: true,
+  flags: [
+    { name: 'type', description: 'Handoff type filter', values: ['lead-to-plan', 'plan-to-exec', 'all'] }
+  ],
+  async execute(supabase, { dryRun, filter, concurrency }) {
+    // Returns: { total, processed, skipped, failed, details[] }
+  }
+};
+```
+
+## Data Layer
+
+### New Table: `batch_operation_log`
+```sql
+CREATE TABLE batch_operation_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  operation TEXT NOT NULL,
+  dry_run BOOLEAN NOT NULL DEFAULT true,
+  operator TEXT,                          -- session_id or 'manual'
+  total_items INTEGER NOT NULL DEFAULT 0,
+  processed INTEGER NOT NULL DEFAULT 0,
+  skipped INTEGER NOT NULL DEFAULT 0,
+  failed INTEGER NOT NULL DEFAULT 0,
+  details JSONB DEFAULT '[]'::jsonb,      -- per-item results
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ,
+  duration_ms INTEGER,
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for dashboard queries
+CREATE INDEX idx_batch_operation_log_operation ON batch_operation_log(operation);
+CREATE INDEX idx_batch_operation_log_created ON batch_operation_log(created_at DESC);
+
+-- RLS: service role only (operational commands)
+ALTER TABLE batch_operation_log ENABLE ROW LEVEL SECURITY;
+```
+
+### Existing Tables Used (Read/Write)
+- `sd_phase_handoffs` — handoff acceptance operations
+- `strategic_directives_v2` — SD completion operations
+- `eva_vision_scores` — rescore operations
+- `leo_simplification_rules` — /simplify rules (read-only)
+
+### Write Verification Pattern
+```javascript
+// After any batch write, verify with read-back
+async function verifiedWrite(supabase, table, id, updates) {
+  const { error: writeError } = await supabase.from(table).update(updates).eq('id', id);
+  if (writeError) return { success: false, error: writeError.message };
+
+  // Read-back verification
+  const { data, error: readError } = await supabase.from(table).select('*').eq('id', id).single();
+  if (readError || !data) return { success: false, error: 'Write verification failed' };
+
+  // Verify the update applied
+  for (const [key, value] of Object.entries(updates)) {
+    if (data[key] !== value) return { success: false, error: `Field ${key} not updated` };
+  }
+  return { success: true };
+}
+```
+
+## API Surface
+
+### CLI Interface
+```bash
+# /simplify enforcement (Phase 1)
+/simplify                      # Dry-run (unchanged)
+/simplify --apply              # Apply (unchanged)
+/ship                          # Now runs /simplify automatically before commit
+/ship --skip-simplify          # Escape hatch with logging
+
+# /batch command (Phase 2)
+/batch accept-handoffs                        # Dry-run preview
+/batch accept-handoffs --apply                # Execute
+/batch accept-handoffs --type lead-to-plan    # Filtered
+/batch rescore --type manual                  # Rescore manual overrides
+/batch rescore --type round1                  # Rescore round 1 children
+/batch complete-children --parent <sd-key>    # Complete children of orchestrator
+/batch test-sds                               # Test completed SDs
+/batch --list                                 # Show available operations
+```
+
+### RPC Functions
+No new RPC functions. Uses existing:
+- `accept_phase_handoff(handoff_id_param)` — for batch handoff acceptance
+- `release_sd(session_id, sd_id)` — for SD state management
+
+## Implementation Phases
+
+### Phase 1: /simplify Enforcement (SD-A) — ~30-50 LOC changed
+1. Update `.claude/commands/ship.md` — remove "optional" from Step 0.6, add `--skip-simplify` escape
+2. Update `scripts/hooks/pre-tool-enforce.cjs` — add simplify gate check
+3. Update `.claude/commands/simplify.md` — document enforcement mode
+4. Test: verify /ship blocks without /simplify, verify --skip-simplify logs bypass
+
+### Phase 2: /batch Dispatcher (SD-B) — ~400-500 LOC new
+1. Create `batch_operation_log` migration
+2. Build `scripts/batch-dispatcher.mjs` with operation registry pattern
+3. Create 3 operation adapters: accept-handoffs, rescore, complete-children
+4. Write `.claude/commands/batch.md` command definition
+5. Add write-verification pattern
+6. Test: dry-run all 3 operations, verify logging, verify no side effects
+
+### Phase 3: /batch Expansion (SD-C, future) — incremental
+1. Add remaining operations (update-refs, test-sds)
+2. Add `simplify-all` codebase-wide sweep operation
+3. Add concurrency control with configurable parallelism
+4. Update CLAUDE_EXEC_DIGEST.md with /batch documentation
+
+## Testing Strategy
+
+### /simplify Enforcement (Phase 1)
+- **Unit**: Hook correctly blocks /ship without prior /simplify run
+- **Unit**: `--skip-simplify` flag logs bypass and proceeds
+- **Integration**: Full /ship flow with /simplify enforcement end-to-end
+
+### /batch Dispatcher (Phase 2)
+- **Unit**: Dispatcher correctly routes to operation modules
+- **Unit**: `--dry-run` enforced on first invocation (no writes)
+- **Unit**: Write-verification catches silent Supabase failures
+- **Integration**: Each operation adapter produces correct results vs. direct script invocation
+- **Safety**: Verify batch_operation_log captures 100% of executions
+
+### Regression
+- Existing batch scripts continue to work when invoked directly
+- /simplify behavior unchanged when invoked directly (not via /ship)
+
+## Risk Mitigation
+
+### Silent Failure Amplification (Critical)
+- **Risk**: Supabase returns empty data on schema errors. Batch amplifies one silent failure into N failures.
+- **Mitigation**: Mandatory write-verification (read-back after write) on all batch operations. Fail-fast on first verification failure with partial results logged.
+
+### Race Conditions on Shared State (Medium)
+- **Risk**: Parallel batch operations writing to same Supabase tables (e.g., sd_phase_handoffs).
+- **Mitigation**: Serial execution only in Phase 1-2. Concurrency control deferred to Phase 3 with advisory locks.
+
+### Operator Confusion (Low)
+- **Risk**: Operators don't discover /batch or continue using ad-hoc scripts.
+- **Mitigation**: Document in CLAUDE_EXEC_DIGEST.md. Surface in sd:next output when batch-relevant conditions detected.
+
+### /simplify False Positives (Low)
+- **Risk**: /simplify suggests changes that break functionality, blocking /ship.
+- **Mitigation**: `--skip-simplify` escape hatch with mandatory logging. Only `cleanup` rules enforced by default; `logic` rules remain optional.

--- a/docs/plans/simplify-batch-leo-integration-vision.md
+++ b/docs/plans/simplify-batch-leo-integration-vision.md
@@ -1,0 +1,130 @@
+# Vision: /simplify and /batch Integration into LEO Protocol
+
+## Executive Summary
+
+The LEO protocol excels at building new things (LEAD→PLAN→EXEC) and scoring alignment (/heal), but lacks a formal operational maintenance layer. Two commands — /simplify (existing but underutilized) and /batch (nonexistent despite 10+ ad-hoc scripts) — represent the foundation of a "MAINTAIN" mode that transforms LEO from a build-only workflow into a fleet management system.
+
+/simplify enforcement closes the gap between code quality intent and actual enforcement. /batch unification replaces scattered one-off scripts with an auditable, dry-run-safe operational command that enables fleet-level maintenance sweeps.
+
+Together, these commands give LEO the self-maintenance capability it needs to prevent technical debt accumulation at scale.
+
+## Problem Statement
+
+**Who is affected**: LEO protocol operators (Claude Code agents and human engineers) running SDs through the LEAD→PLAN→EXEC pipeline.
+
+**What problem**: Two gaps exist:
+1. Code quality degrades because /simplify is optional (Step 0.6 in /ship) and routinely skipped under AUTO-PROCEED. Session-scoped only — legacy debt is never addressed.
+2. Bulk operations (handoff acceptance, SD completion, vision rescoring) are performed via 10+ ad-hoc scripts with no unified interface, no common dry-run semantics, and no operational logging. This creates inconsistent error handling, no auditability, and operator friction.
+
+**Current impact**: Technical debt accumulates silently. 165 scripts have the same broken ESM entry point pattern (documented in MEMORY.md). Batch operations require knowing which specific script to run, with what arguments, against which Supabase env vars.
+
+## Personas
+
+### Protocol Operator (Primary)
+- **Goals**: Ship clean code through the LEO pipeline efficiently; manage fleet of SDs at scale
+- **Mindset**: Values automation, trusts dry-run previews, wants single-command solutions
+- **Key activities**: Running SDs through phases, clearing handoff queues, rescoring vision after rule changes, maintaining codebase hygiene
+
+### Chairman (Secondary)
+- **Goals**: Visibility into operational health; confidence that the fleet is well-maintained
+- **Mindset**: Strategic oversight, wants dashboards not terminal commands
+- **Key activities**: Reviewing SD progress across tracks, approving batch operations on the fleet
+
+### Protocol Developer (Tertiary)
+- **Goals**: Extend LEO with new batch operations without reinventing the wheel
+- **Mindset**: DRY principles, wants a framework to plug new operations into
+- **Key activities**: Writing new batch scripts that conform to a standard interface
+
+## Information Architecture
+
+### /simplify Integration Points
+- `/ship` Step 0.6 → promoted from optional to enforced (with escape hatch for time-sensitive shipping)
+- PreToolUse hook enforcement via `scripts/hooks/pre-tool-enforce.cjs`
+- Gate metric: simplification compliance score in gate validator schema
+- Database: `leo_simplification_rules` table (existing)
+
+### /batch Command Structure
+```
+/batch <operation> [--dry-run] [--filter <criteria>] [--concurrency <n>]
+```
+
+Operations:
+- `accept-handoffs` — wraps batch-accept-all-valid-handoffs.mjs
+- `complete-children <parent-sd>` — wraps batch-complete-child-sds.js
+- `rescore [--type manual|round1|round2]` — wraps batch-rescore-*.js
+- `update-refs` — wraps batch-update-handoff-table-refs.cjs
+- `test-sds` — wraps batch-test-completed-sds.cjs
+- `simplify-all [--type cleanup|style|logic]` — codebase-wide /simplify sweep
+
+### Data Sources
+- `sd_phase_handoffs` — handoff state for batch acceptance
+- `strategic_directives_v2` — SD state for batch completion/testing
+- `eva_vision_scores` — vision scores for batch rescoring
+- `leo_simplification_rules` — simplification rule definitions
+- `batch_operation_log` (new) — audit trail for all /batch executions
+
+## Key Decision Points
+
+1. **Protocol layer vs. tooling layer**: Should /batch be a protocol phase (alongside LEAD/PLAN/EXEC) or a separate operational tooling layer? The Challenger perspective argues tooling layer to avoid adding failure modes to the sensitive protocol core.
+
+2. **Mandatory vs. enforced-with-escape**: /simplify enforcement needs an escape hatch for time-sensitive shipping. The question is whether the escape is a flag (`--skip-simplify`) or a gate override with logging.
+
+3. **Serial vs. parallel execution**: Batch operations currently run one-at-a-time (implicit serialization guard). Introducing parallelism requires solving race conditions on shared Supabase state (e.g., two scripts writing to `sd_phase_handoffs` concurrently).
+
+4. **Silent failure amplification**: Supabase returns empty data on schema errors without throwing. Batch operations amplify this — one silent failure becomes N silent failures. Mitigation: mandatory write-verification (read-back after write).
+
+## Integration Patterns
+
+### Existing System Connections
+- **/ship**: /simplify moves from optional Step 0.6 to enforced pre-commit gate
+- **/heal**: /batch can drive /heal across the entire scored backlog in one session
+- **/learn**: /batch completion triggers /learn for operational pattern capture
+- **PreToolUse hooks**: Enforce /simplify compliance before /ship proceeds
+- **A/B/C Track system**: /batch enables track-level transformations
+
+### New Integration Points
+- **`batch_operation_log` table**: Audit trail for all /batch executions (operation, timestamp, item count, success/fail, dry-run flag, operator)
+- **Chairman Dashboard**: Surface /batch operation history and /simplify compliance rates
+- **sd:next output**: Show /simplify compliance status per SD in queue display
+
+## Evolution Plan
+
+### Phase 1: /simplify Enforcement (SD-A)
+- Remove "optional" qualifier from /ship Step 0.6
+- Add PreToolUse hook enforcement
+- Add `--skip-simplify` escape with mandatory logging
+- LOC estimate: ~30-50 lines changed
+
+### Phase 2: /batch Command Foundation (SD-B)
+- Build dispatcher with dry-run enforcement (~150-200 LOC)
+- Route top 3-4 highest-frequency scripts (accept-handoffs, rescore, complete-children)
+- Create `batch_operation_log` table
+- Common argument parser and progress reporting
+- LOC estimate: ~300-400 lines new
+
+### Phase 3: /batch Expansion (SD-C, future)
+- Add remaining batch scripts to dispatcher
+- Add `simplify-all` operation for codebase-wide sweeps
+- Add concurrency control for safe parallel execution
+- Chairman Dashboard integration
+
+## Out of Scope
+
+- Rewriting the underlying batch scripts — /batch is a routing/dispatcher layer, not a rewrite
+- Automated scheduling of /batch operations (cron-style) — future enhancement
+- /simplify rule authoring UI — rules are managed directly in the database
+- Cross-repository /batch operations — scoped to EHG_Engineer only
+- Real-time /batch progress streaming to Chairman UI
+
+## UI/UX Wireframes
+
+N/A — /simplify and /batch are CLI commands, not UI components. Chairman Dashboard integration (Phase 3) would surface operation logs as a table view, but that is out of scope for initial phases.
+
+## Success Criteria
+
+1. **/simplify compliance rate reaches 80%+** of shipped SDs within 2 weeks of enforcement (measured via gate validator logs)
+2. **/batch dry-run mode** successfully previews all routed operations without DB mutations
+3. **Zero zombie SD states** caused by /batch operations (silent write failures caught by read-back verification)
+4. **Ad-hoc batch script usage drops 50%+** as operators adopt unified /batch interface
+5. **batch_operation_log** captures 100% of /batch executions with full audit trail
+6. **New batch operations** can be added by implementing a standard interface (< 1 hour to plug in a new operation)


### PR DESCRIPTION
## Summary
- Changed `/ship` Step 0.6 from OPTIONAL to MANDATORY — agents must run `/simplify` before committing
- Added `--skip-simplify` escape hatch with logged bypass for time-sensitive shipping
- Updated `/simplify` docs to reference its mandatory enforcement role in `/ship`
- Includes brainstorm, vision, and architecture plan documents for the `/simplify` and `/batch` integration orchestrator

## SD Reference
- Orchestrator: `SD-LEO-SIMPLIFY-ENFORCEMENT-AND-ORCH-001`
- Child SD-A: `SD-LEO-SIMPLIFY-ENFORCEMENT-AND-ORCH-001-A`

## Test plan
- [x] Verify `ship.md` Step 0.6 says MANDATORY
- [x] Verify `--skip-simplify` escape hatch is documented
- [x] Verify `simplify.md` references enforcement in `/ship`
- [x] Verify `/simplify` works unchanged when invoked directly
- [x] Pre-commit hooks pass (smoke tests, DOCMON, secret detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)