### PR TITLE
fix: add reference section to EXEC file mapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,4 +119,4 @@ Escalate to full files (e.g. `CLAUDE_CORE.md`) only when digest is insufficient.
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-03-06 12:32:00 AM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-03-06 12:46:45 AM | Protocol: LEO 4.3.3 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-03-06 12:32:00 AM
+**Generated**: 2026-03-06 12:46:45 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-06T05:32:00.251Z -->
-<!-- git_commit: ae0692a1 -->
+<!-- generated_at: 2026-03-06T05:46:45.147Z -->
+<!-- git_commit: c10c6aa5 -->
 <!-- db_snapshot_hash: 68c699fe5480c33a -->
 <!-- file_content_hash: pending -->
 
@@ -261,5 +261,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-03-06 12:32:00 AM*
+*DIGEST generated: 2026-03-06 12:46:45 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-06T05:32:00.251Z -->
-<!-- git_commit: ae0692a1 -->
+<!-- generated_at: 2026-03-06T05:46:45.147Z -->
+<!-- git_commit: c10c6aa5 -->
 <!-- db_snapshot_hash: 68c699fe5480c33a -->
 <!-- file_content_hash: pending -->
 
@@ -152,5 +152,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-03-06 12:32:00 AM*
+*DIGEST generated: 2026-03-06 12:46:45 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-03-06 12:32:00 AM
+**Generated**: 2026-03-06 12:46:45 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing
 
@@ -471,6 +471,48 @@ Skills provide patterns, templates, and examples. Apply them to your specific im
 Skills are for **creative guidance** (how to build).
 Sub-agents are for **validation** (did you build it right).
 Use skills during EXEC, save sub-agents for PLAN_VERIFY.
+
+## Validation Rules (SD-LEARN-008)
+
+## PLAN-TO-EXEC Validation Gates
+
+### GATE_PRD_EXISTS
+**Purpose**: Block EXEC phase if no PRD exists for the SD
+
+**Trigger**: PLAN-TO-EXEC handoff
+**Behavior**:
+- Checks product_requirements_v2 table for matching sd_id
+- PRD status must be 'approved', 'ready_for_exec', or 'in_progress'
+- Blocks handoff with clear remediation steps if missing
+
+**Remediation**:
+```bash
+node scripts/create-prd-template.js <SD-ID>
+# Then approve the PRD and retry handoff
+```
+
+### Schema Keyword Detection for DATABASE Sub-Agent
+**Purpose**: Auto-invoke DATABASE sub-agent for SDs with schema-related content
+
+**Trigger**: PLAN_PRD phase sub-agent orchestration
+**Keywords Detected**:
+- schema, migration, table, column, constraint, index
+- foreign key, rls, row level security, trigger, function
+- alter table, create table, drop table, database
+
+**Behavior**:
+- Scans SD title, description, scope, and rationale
+- If schema keywords detected, DATABASE sub-agent is added to execution list
+- Works even if SD type is not 'database'
+
+**Example**:
+```
+SD Type: feature
+Title: "Add user preferences table"
+→ Schema keyword 'table' detected
+→ DATABASE sub-agent auto-invoked
+```
+
 
 ## Multi-Instance Coordination (MANDATORY)
 
@@ -1047,6 +1089,56 @@ gh pr create --title "feat(SD-XXX): title" --body "## Summary..."  --base main
 gh pr merge --auto --squash --delete-branch
 # Claude immediately continues to next SD
 ```
+
+## /batch Command Reference
+
+The /batch command provides unified batch operations across the SD fleet.
+
+### Usage
+```
+node scripts/batch-dispatcher.mjs <operation> [--apply] [flags]
+node scripts/batch-dispatcher.mjs --list
+```
+
+### Available Operations
+
+| Operation | Description | Key Flags |
+|-----------|-------------|-----------|
+| accept-handoffs | Accept valid pending handoffs | --type (lead-to-plan, plan-to-exec, etc.) |
+| rescore | Rescore vision scores by type | --type (manual, round1, round2) |
+| complete-children | Complete children of orchestrator SD | --parent <SD-KEY> |
+| update-refs | Find and update SD key references | --from <OLD-KEY> --to <NEW-KEY> |
+| test-sds | Verify smoke tests across SDs | --status (completed, in_progress) |
+| simplify-all | Codebase-wide simplification sweep | --path <root> |
+
+### Common Flags
+- **--apply**: Execute writes (default is dry-run preview)
+- **--concurrency N**: Process N items in parallel (default: 1, serial)
+- **--list**: Show all available operations
+
+### Examples
+```bash
+# Preview pending handoffs
+node scripts/batch-dispatcher.mjs accept-handoffs
+
+# Accept handoffs with concurrency
+node scripts/batch-dispatcher.mjs accept-handoffs --apply --concurrency 3
+
+# Preview SD reference updates
+node scripts/batch-dispatcher.mjs update-refs --from SD-OLD-001 --to SD-NEW-001
+
+# Check smoke tests across completed SDs
+node scripts/batch-dispatcher.mjs test-sds --status completed
+
+# Preview codebase simplifications
+node scripts/batch-dispatcher.mjs simplify-all
+```
+
+### Safety
+- All operations default to **dry-run** (preview only)
+- Use **--apply** to execute actual writes
+- Write verification (read-back) validates all mutations
+- All executions logged to batch_operation_log table
 
 ## E2E Testing: Dev Mode vs Preview Mode
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-06T05:32:00.251Z -->
-<!-- git_commit: ae0692a1 -->
+<!-- generated_at: 2026-03-06T05:46:45.147Z -->
+<!-- git_commit: c10c6aa5 -->
 <!-- db_snapshot_hash: 68c699fe5480c33a -->
 <!-- file_content_hash: pending -->
 
@@ -221,5 +221,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-03-06 12:32:00 AM*
+*DIGEST generated: 2026-03-06 12:46:45 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-03-06 12:32:00 AM
+**Generated**: 2026-03-06 12:46:45 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-06T05:32:00.251Z -->
-<!-- git_commit: ae0692a1 -->
+<!-- generated_at: 2026-03-06T05:46:45.147Z -->
+<!-- git_commit: c10c6aa5 -->
 <!-- db_snapshot_hash: 68c699fe5480c33a -->
 <!-- file_content_hash: pending -->
 
@@ -126,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-06 12:32:00 AM*
+*DIGEST generated: 2026-03-06 12:46:45 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-03-06 12:32:00 AM
+**Generated**: 2026-03-06 12:46:45 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-06T05:32:00.251Z -->
-<!-- git_commit: ae0692a1 -->
+<!-- generated_at: 2026-03-06T05:46:45.147Z -->
+<!-- git_commit: c10c6aa5 -->
 <!-- db_snapshot_hash: 68c699fe5480c33a -->
 <!-- file_content_hash: pending -->
 
@@ -124,5 +124,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-06 12:32:00 AM*
+*DIGEST generated: 2026-03-06 12:46:45 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,76 +1,76 @@
 {
-  "generated_at": "2026-03-06T05:32:00.251Z",
-  "git_commit": "ae0692a1",
+  "generated_at": "2026-03-06T05:46:45.147Z",
+  "git_commit": "c10c6aa5",
   "db_snapshot_hash": "68c699fe5480c33a",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 5789,
       "estimated_tokens": 1448,
-      "content_hash": "cb5c72b737a9e7a8",
+      "content_hash": "91f0a94b17e5ae58",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 48691,
       "estimated_tokens": 12173,
-      "content_hash": "82fbf958f309ce38",
+      "content_hash": "15ef1775c38b227c",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 53232,
       "estimated_tokens": 13308,
-      "content_hash": "289aae2b79e6c2ba",
+      "content_hash": "19fce1caa94641c5",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 78416,
       "estimated_tokens": 19604,
-      "content_hash": "7838caff9ded3e7d",
+      "content_hash": "95174b787538a690",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 62840,
-      "estimated_tokens": 15710,
-      "content_hash": "bdf5e6cd0718f316",
+      "chars": 65789,
+      "estimated_tokens": 16448,
+      "content_hash": "7d65acc3353fd3f0",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 6681,
       "estimated_tokens": 1671,
-      "content_hash": "5383ff871f195a9f",
+      "content_hash": "66649070df3a7bbe",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 10175,
       "estimated_tokens": 2544,
-      "content_hash": "f5d826bac9e3ac6f",
+      "content_hash": "ddacc6a4bffd3537",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 4802,
       "estimated_tokens": 1201,
-      "content_hash": "ee0ebd9589896dbb",
+      "content_hash": "821f80f7ec335ef5",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 5032,
       "estimated_tokens": 1258,
-      "content_hash": "6e019761da5bc708",
+      "content_hash": "81f00ca28829a99d",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 9486,
       "estimated_tokens": 2372,
-      "content_hash": "67ef9881c0aed71c",
+      "content_hash": "127a3fe6740a9cd3",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     }
   }

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -131,7 +131,8 @@
       "migration_script_pattern",
       "test_coverage_quality_gate",
       "integration_test_requirement_gate",
-      "governance_kr_progress_exec"
+      "governance_kr_progress_exec",
+      "reference"
     ],
     "_removed_sections_note": "mandatory_phase_transitions_exec (duplicate of CORE mandatory_phase_transitions), migration_execution_delegation (duplicate of CORE migration_execution_protocol), workflow (was listed twice — removed duplicate). RCA mandate removed from generator — already in router."
   },


### PR DESCRIPTION
## Summary
- Add `reference` section type to CLAUDE_EXEC.md mapping in section-file-mapping.json
- The `/batch Command Reference` section (type: reference) was in the database but not rendering in CLAUDE_EXEC.md

## Test plan
- [x] `grep batch CLAUDE_EXEC.md` now returns 10 matches
- [x] Smoke tests pass (15/15)

SD: SD-LEO-SIMPLIFY-ENFORCEMENT-AND-ORCH-001-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)