### PR TITLE
fix: auto-reactivate cancelled SDs in LEAD-TO-PLAN gate

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/transition-readiness.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/transition-readiness.js
@@ -44,10 +44,28 @@ export async function validateTransitionReadiness(sd, supabase) {
 
   // Check 2: SD status allows LEAD→PLAN transition
   // SD-LEARN-FIX-ADDRESS-PAT-AUTO-019: Added 'DRAFT' - the standard starting state for LEAD-TO-PLAN
-  const validStatuses = ['ACTIVE', 'APPROVED', 'PLANNING', 'READY', 'LEAD_APPROVED', 'DRAFT', null, undefined];
-  const blockingStatuses = ['COMPLETED', 'CANCELLED', 'ARCHIVED', 'ON_HOLD'];
+  const validStatuses = ['ACTIVE', 'APPROVED', 'PLANNING', 'READY', 'LEAD_APPROVED', 'DRAFT', 'IN_PROGRESS', null, undefined];
+  const blockingStatuses = ['COMPLETED', 'ARCHIVED', 'ON_HOLD'];
+  // SD-LEARN-FIX-ADDRESS-PAT-AUTO-055: Cancelled SDs are auto-reactivated instead of blocked.
+  // Attempting LEAD-TO-PLAN on a cancelled SD signals clear intent to work on it.
+  const autoReactivateStatuses = ['CANCELLED'];
 
-  if (blockingStatuses.includes(sd.status?.toUpperCase())) {
+  if (autoReactivateStatuses.includes(sd.status?.toUpperCase())) {
+    // Auto-reactivate: set status back to draft so the workflow can proceed
+    try {
+      await supabase
+        .from('strategic_directives_v2')
+        .update({ status: 'draft', is_active: true })
+        .eq('id', sd.id);
+      warnings.push(`SD status was '${sd.status}' — auto-reactivated to 'draft' (LEAD-TO-PLAN intent detected)`);
+      console.log(`   ⚠️  Auto-reactivated: ${sd.status} → draft (LEAD-TO-PLAN intent)`);
+      score -= 5;
+    } catch (reactivateError) {
+      issues.push(`SD status '${sd.status}' does not allow handoff and auto-reactivation failed: ${reactivateError.message}`);
+      console.log(`   ❌ Blocking status: ${sd.status} (auto-reactivation failed)`);
+      score -= 30;
+    }
+  } else if (blockingStatuses.includes(sd.status?.toUpperCase())) {
     issues.push(`SD status '${sd.status}' does not allow handoff - must be active/approved`);
     console.log(`   ❌ Blocking status: ${sd.status}`);
     score -= 30;


### PR DESCRIPTION
## Summary
- Fixes PAT-AUTO-d5fbfe82: GATE_SD_TRANSITION_READINESS blocked cancelled SDs with -30 deduction
- Cancelled SDs now auto-reactivated to 'draft' with -5 warning when LEAD-TO-PLAN is attempted
- Added 'IN_PROGRESS' to validStatuses to eliminate unnecessary "unusual status" warnings

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Pre-commit hooks pass
- [ ] Verify cancelled SD auto-reactivation on next /learn-created SD

SD: SD-LEARN-FIX-ADDRESS-PAT-AUTO-055

🤖 Generated with [Claude Code](https://claude.com/claude-code)