### PR TITLE
refactor: eliminate hard-coded venture references — registry-driven multi-venture pattern

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -21,6 +21,8 @@ import {
   generateChildKey,
   normalizeVenturePrefix,
 } from '../../scripts/modules/sd-key-generator.js';
+// SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven target_application
+import { getCurrentVenture } from '../venture-resolver.js';
 
 // Type mapping from Stage 18 types to database sd_type
 const TYPE_MAP = {
@@ -102,7 +104,7 @@ export async function convertSprintToSDs(params, deps = {}) {
       priority: 'medium',
       category: 'Feature',
       current_phase: 'LEAD',
-      target_application: 'EHG_Engineer',
+      target_application: getCurrentVenture(),
       created_by: 'lifecycle-sd-bridge',
       success_criteria: payloads.map(p => p.title),
       success_metrics: [
@@ -156,7 +158,7 @@ export async function convertSprintToSDs(params, deps = {}) {
         priority: payload.priority || 'medium',
         category: dbType.charAt(0).toUpperCase() + dbType.slice(1),
         current_phase: 'LEAD',
-        target_application: payload.target_application || 'EHG_Engineer',
+        target_application: payload.target_application || getCurrentVenture(),
         created_by: 'lifecycle-sd-bridge',
         parent_sd_id: orchestratorId,
         success_criteria: [payload.success_criteria],
@@ -312,7 +314,7 @@ export async function convertExpansionToSD(params, deps = {}) {
       priority: 'medium',
       category: dbType.charAt(0).toUpperCase() + dbType.slice(1),
       current_phase: 'LEAD',
-      target_application: 'EHG_Engineer',
+      target_application: getCurrentVenture(),
       created_by: 'lifecycle-sd-bridge-expand',
       success_criteria: [`Deliver: ${expansionTitle}`],
       success_metrics: [

--- a/lib/feedback-capture.js
+++ b/lib/feedback-capture.js
@@ -20,6 +20,8 @@ import { processQuality, PROCESSING_STATUS } from './quality/feedback-quality-pr
 // SD-EHG-ORCH-INTELLIGENCE-INTEGRATION-001-E: Vision dimension classification
 import { classifyFeedback } from './eva/feedback-dimension-classifier.js';
 import { publishVisionEvent, VISION_EVENTS } from './eva/event-bus/vision-events.js';
+// SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven source_application
+import { getCurrentVenture } from './venture-resolver.js';
 
 // Cache for deduplication
 const errorCache = new Map();
@@ -121,7 +123,7 @@ export async function captureError(error, options = {}, supabase) {
       error_type: error.name || 'Error',
       severity: options.severity || 'medium',
       source_type: options.source_type || 'error_capture',
-      source_application: 'EHG_Engineer'
+      source_application: getCurrentVenture()
     };
 
     // SD-QUALITY-TRIAGE-001: Check ignore patterns before proceeding
@@ -183,7 +185,7 @@ export async function captureError(error, options = {}, supabase) {
       status: qualityResult?.status === PROCESSING_STATUS.QUARANTINED ? 'quarantined' : 'new',
       source_type: options.source_type || 'error_capture',
       source_url: options.context || process.cwd(),
-      source_application: 'EHG_Engineer',
+      source_application: getCurrentVenture(),
       error_hash: hash,
       error_type: error.name || 'Error',
       occurrence_count: 1,

--- a/lib/gap-detection/creators/corrective-sd-creator.js
+++ b/lib/gap-detection/creators/corrective-sd-creator.js
@@ -7,6 +7,8 @@
  */
 
 import { createSupabaseServiceClient } from '../../../scripts/lib/supabase-connection.js';
+// SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven target_application
+import { getCurrentVenture } from '../../venture-resolver.js';
 
 function getSupabase() {
   return createSupabaseServiceClient();
@@ -81,7 +83,7 @@ export async function createCorrectiveSDs(gaps, parentSdKey, options = {}) {
           original_severity: gap.severity,
           confidence: gap.confidence
         }),
-        target_application: 'EHG_Engineer'
+        target_application: getCurrentVenture()
       }).select('sd_key');
 
       if (error) {

--- a/lib/rca/rca-orchestrator.js
+++ b/lib/rca/rca-orchestrator.js
@@ -16,6 +16,8 @@
 import dotenv from 'dotenv';
 import { checkRateLimit, CLASSIFICATIONS } from './trigger-sdk.js';
 import { normalizeSDId } from '../../scripts/modules/sd-id-normalizer.js';
+// SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven target_application
+import { getCurrentVenture } from '../venture-resolver.js';
 
 dotenv.config();
 
@@ -382,7 +384,7 @@ async function maybeCreateFixSD(supabase, rcrId, triggerEvent, log) {
         linked_rcr_id: rcrId,
         linked_fingerprint: triggerEvent.fingerprint
       }),
-      target_application: 'EHG_Engineer'
+      target_application: getCurrentVenture()
     })
     .select('id')
     .single();

--- a/lib/sub-agents/database/migration-handler.js
+++ b/lib/sub-agents/database/migration-handler.js
@@ -63,7 +63,7 @@ export async function findPendingMigrations(sdId = null, migrationPath = null) {
     : [
         'database/migrations/*.sql',
         'supabase/migrations/*.sql',
-        'supabase/ehg_engineer/migrations/*.sql'
+        'supabase/migrations/*.sql'
       ];
 
   const pendingMigrations = [];

--- a/lib/sub-agents/github.js
+++ b/lib/sub-agents/github.js
@@ -62,13 +62,10 @@ export async function execute(sdId, subAgent, options = {}) {
 
   // Determine repo path based on target application or options
   // SD-VISION-V2-009 FIX: GITHUB sub-agent must run gh commands from correct repo directory
-  let repoPath = options.repo_path || process.cwd();
+  // SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Use venture-resolver instead of hard-coded paths
+  const { getVenturePath } = await import('../../lib/venture-resolver.js');
   const targetApp = sdData?.target_application?.toLowerCase();
-  if (targetApp === 'ehg') {
-    repoPath = path.resolve(__dirname, '../../../../ehg');
-  } else if (targetApp === 'ehg_engineer') {
-    repoPath = path.resolve(__dirname, '../../..');
-  }
+  let repoPath = options.repo_path || (targetApp ? getVenturePath(targetApp) : process.cwd());
 
   if (relaxedCiSdTypes.includes(sdCategory)) {
     console.log(`\n🗄️  SD Type Detection: ${sdCategory.toUpperCase()}`);

--- a/lib/uat/result-recorder.js
+++ b/lib/uat/result-recorder.js
@@ -24,6 +24,8 @@ import {
   recordPatternOccurrence
 } from './issue-pattern-matcher.js';
 import { GRADE } from '../standards/grade-scale.js';
+// SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven source_application
+import { getCurrentVenture } from '../venture-resolver.js';
 
 let supabase = null;
 
@@ -302,7 +304,7 @@ async function recordDefect(testRunId, scenario, details) {
       priority_reasoning: priorityResult.reasoning,
       status: 'new',  // Valid status per schema
       source_type: 'uat_failure',
-      source_application: 'EHG_Engineer',
+      source_application: getCurrentVenture(),
       metadata: {
         test_run_id: testRunId,
         scenario_id: scenario.id,

--- a/lib/venture-resolver.js
+++ b/lib/venture-resolver.js
@@ -1,0 +1,191 @@
+/**
+ * Venture Resolver — Registry-driven venture path and config resolution
+ *
+ * Reads from applications/registry.json to resolve venture paths dynamically
+ * instead of hard-coding 'ehg', 'EHG_Engineer', or absolute Windows paths.
+ *
+ * Created by: SD-LEO-REFAC-ELIMINATE-HARD-CODED-001
+ *
+ * @module lib/venture-resolver
+ */
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// EHG_Engineer root (this repo)
+const ENGINEER_ROOT = path.resolve(__dirname, '..');
+
+// Registry path
+const REGISTRY_PATH = path.resolve(ENGINEER_ROOT, 'applications/registry.json');
+
+// Cached registry (loaded once per process)
+let _registryCache = null;
+
+/**
+ * Load the application registry, with caching.
+ * @returns {Object} The parsed registry object
+ */
+function loadRegistry() {
+  if (_registryCache) return _registryCache;
+
+  try {
+    const content = readFileSync(REGISTRY_PATH, 'utf8');
+    _registryCache = JSON.parse(content);
+    return _registryCache;
+  } catch {
+    // Fallback: minimal registry for EHG_Engineer itself
+    _registryCache = {
+      applications: {
+        APP_SELF: {
+          id: 'APP_SELF',
+          name: 'EHG_Engineer',
+          local_path: ENGINEER_ROOT,
+          status: 'active'
+        }
+      }
+    };
+    return _registryCache;
+  }
+}
+
+/**
+ * Resolve the local filesystem path for a venture/application by name.
+ * Handles case-insensitive matching (e.g., 'EHG', 'ehg', 'EHG_Engineer').
+ *
+ * @param {string} targetApp - Application name (e.g., 'EHG', 'EHG_Engineer', 'ehg')
+ * @returns {string} Absolute local path to the venture repository
+ */
+export function getVenturePath(targetApp) {
+  if (!targetApp) return ENGINEER_ROOT;
+
+  const registry = loadRegistry();
+  const apps = registry.applications || {};
+  const needle = targetApp.toLowerCase();
+
+  // Search by name (case-insensitive)
+  for (const app of Object.values(apps)) {
+    if (app.name?.toLowerCase() === needle && app.local_path) {
+      return path.resolve(app.local_path);
+    }
+  }
+
+  // Special case: 'ehg_engineer' maps to this repo
+  if (needle === 'ehg_engineer') {
+    return ENGINEER_ROOT;
+  }
+
+  // Auto-discover: assume sibling directory of EHG_Engineer parent
+  const baseDir = path.resolve(ENGINEER_ROOT, '..');
+  return path.resolve(baseDir, targetApp);
+}
+
+/**
+ * Get the full configuration for a venture from the registry.
+ *
+ * @param {string} targetApp - Application name
+ * @returns {Object|null} Registry entry for the venture, or null
+ */
+export function getVentureConfig(targetApp) {
+  if (!targetApp) return null;
+
+  const registry = loadRegistry();
+  const apps = registry.applications || {};
+  const needle = targetApp.toLowerCase();
+
+  for (const app of Object.values(apps)) {
+    if (app.name?.toLowerCase() === needle) {
+      return { ...app, local_path: app.local_path ? path.resolve(app.local_path) : null };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * List all active ventures from the registry.
+ *
+ * @returns {Array<Object>} Array of active venture configurations
+ */
+export function listVentures() {
+  const registry = loadRegistry();
+  const apps = registry.applications || {};
+
+  return Object.values(apps)
+    .filter(app => app.status === 'active')
+    .map(app => ({
+      ...app,
+      local_path: app.local_path ? path.resolve(app.local_path) : null
+    }));
+}
+
+/**
+ * Get the GitHub repo identifier (e.g., 'rickfelix/ehg') for a venture.
+ *
+ * @param {string} targetApp - Application name
+ * @returns {string} GitHub repo identifier, or fallback
+ */
+export function getGitHubRepo(targetApp) {
+  const config = getVentureConfig(targetApp);
+  if (config?.github_repo) {
+    return config.github_repo.replace(/\.git$/, '');
+  }
+
+  // Fallback: assume rickfelix/<name>
+  return `rickfelix/${targetApp || 'EHG_Engineer'}`;
+}
+
+/**
+ * Resolve the source_application value for the current repo context.
+ * Uses process.cwd() to detect which venture we're running from.
+ *
+ * @returns {string} The venture name for the current working directory
+ */
+export function getCurrentVenture() {
+  const cwd = process.cwd().replace(/\\/g, '/').toLowerCase();
+  const registry = loadRegistry();
+  const apps = registry.applications || {};
+
+  // Sort by local_path length descending so more specific paths match first
+  // (e.g., 'EHG_Engineer' before 'ehg' since 'ehg' is a substring)
+  const sortedApps = Object.values(apps)
+    .filter(app => app.local_path)
+    .sort((a, b) => (b.local_path?.length || 0) - (a.local_path?.length || 0));
+
+  for (const app of sortedApps) {
+    const appPath = app.local_path.replace(/\\/g, '/').toLowerCase();
+    // Use trailing separator to prevent 'ehg' matching 'ehg_engineer'
+    if (cwd === appPath || cwd.startsWith(appPath + '/')) {
+      return app.name;
+    }
+  }
+
+  // Check if cwd is a worktree or subdirectory of EHG_Engineer
+  const engineerRoot = ENGINEER_ROOT.replace(/\\/g, '/').toLowerCase();
+  if (cwd.startsWith(engineerRoot) || cwd.includes('ehg_engineer')) {
+    return 'EHG_Engineer';
+  }
+
+  // Default: EHG_Engineer (we're running from this repo)
+  return 'EHG_Engineer';
+}
+
+/**
+ * Clear the registry cache (useful for tests).
+ */
+export function clearRegistryCache() {
+  _registryCache = null;
+}
+
+export default {
+  getVenturePath,
+  getVentureConfig,
+  listVentures,
+  getGitHubRepo,
+  getCurrentVenture,
+  clearRegistryCache,
+  ENGINEER_ROOT
+};

--- a/scripts/auto-learning-capture.js
+++ b/scripts/auto-learning-capture.js
@@ -21,6 +21,7 @@ import { execFileSync } from 'child_process';
 import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { getGitHubRepo } from '../lib/venture-resolver.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -457,7 +458,8 @@ async function captureLearningSFromMerge(prNumber) {
   const captureData = {
     prNumber,
     prTitle: pr.title,
-    prUrl: `https://github.com/${process.env.GITHUB_REPO || 'rickfelix/ehg-engineer'}/pull/${prNumber}`,
+    // SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Use venture-resolver for GitHub repo
+    prUrl: `https://github.com/${process.env.GITHUB_REPO || getGitHubRepo('EHG_Engineer')}/pull/${prNumber}`,
     workType: mapWorkTypeToCategory(workType),
     learningWorthyCategories,
     learnings,

--- a/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/retrospective.js
@@ -411,7 +411,7 @@ export async function createExecToPlanRetrospective(supabase, sdId, sd, handoffR
       trigger_event: 'HANDOFF_COMPLETION',
       status: 'PUBLISHED',
       performance_impact: 'Standard',
-      target_application: 'EHG_Engineer',
+      target_application: sd.target_application || 'EHG_Engineer',
       learning_category: 'IMPLEMENTATION_REVIEW',
       related_files: [],
       related_commits: [],

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/target-application.js
@@ -126,23 +126,25 @@ export async function validateTargetApplication(sd, supabase) {
   }
 
   if (!currentTarget && !inferredTarget) {
-    // No target and couldn't infer - default to EHG with warning
-    console.log('\n   ⚠️  Could not determine target_application, defaulting to EHG');
+    // SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Use venture-resolver for default
+    const { getCurrentVenture } = await import('../../../../../../lib/venture-resolver.js');
+    const defaultTarget = getCurrentVenture();
+    console.log(`\n   ⚠️  Could not determine target_application, defaulting to ${defaultTarget}`);
 
     const { error } = await supabase
       .from('strategic_directives_v2')
-      .update({ target_application: 'EHG' })
+      .update({ target_application: defaultTarget })
       .eq('id', sd.id);
 
     if (!error) {
-      console.log('   ✅ Default target_application set to: EHG');
+      console.log(`   ✅ Default target_application set to: ${defaultTarget}`);
     }
 
     return {
       pass: true,
       score: 70,
       issues: [],
-      warnings: ['target_application defaulted to EHG - verify this is correct']
+      warnings: [`target_application defaulted to ${defaultTarget} - verify this is correct`]
     };
   }
 

--- a/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/retrospective.js
@@ -320,7 +320,7 @@ export async function createHandoffRetrospective(sdId, sd, handoffResult, retros
       trigger_event: 'HANDOFF_COMPLETION',
       status: 'PUBLISHED',
       performance_impact: 'Standard',
-      target_application: 'EHG_Engineer',
+      target_application: sd.target_application || 'EHG_Engineer',
       learning_category: 'PROCESS_IMPROVEMENT',
       related_files: [],
       related_commits: [],

--- a/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/retrospective.js
@@ -231,7 +231,7 @@ export async function createHandoffRetrospective(supabase, sdId, sd, handoffResu
       trigger_event: 'HANDOFF_COMPLETION',
       status: 'PUBLISHED',
       performance_impact: 'Standard',
-      target_application: 'EHG_Engineer',
+      target_application: sd.target_application || 'EHG_Engineer',
       learning_category: 'PROCESS_IMPROVEMENT',
       related_files: [],
       related_commits: [],

--- a/scripts/modules/handoff/orchestrator-completion-guardian.js
+++ b/scripts/modules/handoff/orchestrator-completion-guardian.js
@@ -521,7 +521,7 @@ export class OrchestratorCompletionGuardian {
         quality_score: 80,
         generated_by: 'SUB_AGENT',
         trigger_event: 'Orchestrator auto-completion',
-        target_application: 'EHG_Engineer',
+        target_application: this.parentData?.target_application || 'EHG_Engineer',
         learning_category: 'PROCESS_IMPROVEMENT',
         affected_components: this.childData.map(c => c.id)
       });

--- a/scripts/modules/handoff/retrospective-enricher.js
+++ b/scripts/modules/handoff/retrospective-enricher.js
@@ -18,6 +18,8 @@
 
 import { safeTruncate } from '../../../lib/utils/safe-truncate.js';
 import { execSync } from 'child_process';
+// SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven venture paths
+import { getVenturePath } from '../../../lib/venture-resolver.js';
 import { RetrospectiveQualityRubric } from '../rubrics/retrospective-quality-rubric.js';
 
 /**
@@ -612,9 +614,8 @@ export async function enrichRetrospectivePreGate(supabase, sdId, sd) {
  */
 function getGitChangedFiles(targetApp) {
   try {
-    const repoPath = targetApp === 'EHG'
-      ? 'C:/Users/rickf/Projects/_EHG/ehg'
-      : 'C:/Users/rickf/Projects/_EHG/EHG_Engineer';
+    // SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Use venture-resolver instead of absolute paths
+    const repoPath = getVenturePath(targetApp);
     const output = execSync('git diff --name-only HEAD~5 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null', {
       cwd: repoPath,
       encoding: 'utf8',

--- a/tests/unit/venture-resolver.test.js
+++ b/tests/unit/venture-resolver.test.js
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for lib/venture-resolver.js
+ * SD-LEO-REFAC-ELIMINATE-HARD-CODED-001
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getVenturePath,
+  getVentureConfig,
+  listVentures,
+  getGitHubRepo,
+  getCurrentVenture,
+  clearRegistryCache,
+  ENGINEER_ROOT
+} from '../../lib/venture-resolver.js';
+import path from 'path';
+
+describe('venture-resolver', () => {
+  beforeEach(() => {
+    clearRegistryCache();
+  });
+
+  describe('getVenturePath', () => {
+    it('resolves ehg to its registry path', () => {
+      const result = getVenturePath('ehg');
+      expect(result).toContain('ehg');
+      expect(path.isAbsolute(result)).toBe(true);
+    });
+
+    it('resolves EHG case-insensitively', () => {
+      const lower = getVenturePath('ehg');
+      const upper = getVenturePath('EHG');
+      // Both should resolve to same path
+      expect(lower.toLowerCase()).toBe(upper.toLowerCase());
+    });
+
+    it('resolves EHG_Engineer to this repo root', () => {
+      const result = getVenturePath('EHG_Engineer');
+      expect(result).toContain('EHG_Engineer');
+    });
+
+    it('returns an absolute path for null/undefined input', () => {
+      const nullPath = getVenturePath(null);
+      const undefPath = getVenturePath(undefined);
+      expect(path.isAbsolute(nullPath)).toBe(true);
+      expect(path.isAbsolute(undefPath)).toBe(true);
+      expect(nullPath).toContain('EHG_Engineer');
+    });
+
+    it('auto-discovers unknown ventures as sibling directories', () => {
+      const result = getVenturePath('some-new-venture');
+      expect(result).toContain('some-new-venture');
+      expect(path.isAbsolute(result)).toBe(true);
+    });
+  });
+
+  describe('getVentureConfig', () => {
+    it('returns config for known ventures', () => {
+      const config = getVentureConfig('ehg');
+      expect(config).not.toBeNull();
+      expect(config.name).toBe('ehg');
+      expect(config.github_repo).toContain('rickfelix');
+    });
+
+    it('returns null for unknown ventures', () => {
+      const config = getVentureConfig('nonexistent-venture');
+      expect(config).toBeNull();
+    });
+
+    it('returns null for null input', () => {
+      expect(getVentureConfig(null)).toBeNull();
+    });
+  });
+
+  describe('listVentures', () => {
+    it('returns active ventures from registry', () => {
+      const ventures = listVentures();
+      expect(ventures.length).toBeGreaterThan(0);
+      expect(ventures.every(v => v.status === 'active')).toBe(true);
+    });
+
+    it('includes ehg in the list', () => {
+      const ventures = listVentures();
+      const names = ventures.map(v => v.name);
+      expect(names).toContain('ehg');
+    });
+  });
+
+  describe('getGitHubRepo', () => {
+    it('returns GitHub repo for known ventures', () => {
+      const repo = getGitHubRepo('ehg');
+      expect(repo).toBe('rickfelix/ehg');
+    });
+
+    it('strips .git suffix', () => {
+      const repo = getGitHubRepo('ehg');
+      expect(repo).not.toContain('.git');
+    });
+
+    it('generates fallback for unknown ventures', () => {
+      const repo = getGitHubRepo('my-venture');
+      expect(repo).toBe('rickfelix/my-venture');
+    });
+  });
+
+  describe('getCurrentVenture', () => {
+    it('returns a string', () => {
+      const venture = getCurrentVenture();
+      expect(typeof venture).toBe('string');
+      expect(venture.length).toBeGreaterThan(0);
+    });
+
+    it('does not match ehg when running from EHG_Engineer', () => {
+      // When running from EHG_Engineer worktree, should not return 'ehg'
+      const venture = getCurrentVenture();
+      // The test runs from EHG_Engineer context
+      if (process.cwd().toLowerCase().includes('ehg_engineer')) {
+        expect(venture).toBe('EHG_Engineer');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Create `lib/venture-resolver.js` module that reads `applications/registry.json` to dynamically resolve venture paths, configs, and GitHub repos
- Replace 15 hard-coded `'EHG_Engineer'`, `'ehg'`, and absolute Windows path references across 14 files
- Fix bug in `auto-learning-capture.js` where GitHub repo was incorrectly hard-coded as `'rickfelix/ehg-engineer'` (wrong name)
- Replace absolute Windows paths in `retrospective-enricher.js` and `github.js` with registry lookups
- Replace `source_application` and `target_application` literals in 10 modules with `getCurrentVenture()` or `sd.target_application` fallbacks
- Add 15 unit tests for venture-resolver module (all passing)

## Test plan
- [x] `venture-resolver.test.js` — 15/15 unit tests passing
- [x] `retrospective-enricher.test.js` — passes (was failing before fix)
- [x] Full test suite — no new regressions (137 failures all pre-existing on main)
- [ ] Verify handoff flow works with registry-driven paths

SD: SD-LEO-REFAC-ELIMINATE-HARD-CODED-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)