### PR TITLE
fix: pass target_application through validation.details in Gate 2

### DIFF
--- a/scripts/modules/implementation-fidelity/index.js
+++ b/scripts/modules/implementation-fidelity/index.js
@@ -114,7 +114,7 @@ export async function validateGate2ExecToPlan(sd_id, supabase) {
     // Try direct ID lookup first (works for both UUID and SD-KEY format IDs)
     const result = await supabase
       .from('strategic_directives_v2')
-      .select('id, title, sd_type, scope, category, intensity_level')
+      .select('id, title, sd_type, scope, category, intensity_level, target_application')
       .eq('id', sd_id)
       .single();
 
@@ -126,8 +126,9 @@ export async function validateGate2ExecToPlan(sd_id, supabase) {
     const sdType = (sd?.sd_type || '').toLowerCase();
     const intensityLevel = (sd?.intensity_level || '').toLowerCase();
     validation.details.sd_type = sdType;
+    validation.details.target_application = sd?.target_application || '';
 
-    console.log(`   🔍 SD Type check: sd_type=${sdType}, intensity_level=${intensityLevel}`);
+    console.log(`   🔍 SD Type check: sd_type=${sdType}, intensity_level=${intensityLevel}, target=${sd?.target_application || 'unknown'}`);
 
     // Fetch Gate 2 exempt sections
     try {

--- a/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
+++ b/scripts/modules/implementation-fidelity/sections/data-flow-alignment.js
@@ -101,18 +101,8 @@ export async function validateDataFlowAlignment(sd_id, designAnalysis, databaseA
 
     // PAT-GATE2-BE-001: target_application-aware exemption for Section C
     // EHG_Engineer is a backend-only repo (CLI, scripts, tooling) - never has form/UI integration
-    // Mirrors the same exemption already applied in Section A (design-fidelity.js)
     if (!hasUIScope) {
-      let targetApp = null;
-      try {
-        const sdKey = sd_id;
-        const { data: fullSd } = await supabase
-          .from('strategic_directives_v2')
-          .select('target_application')
-          .or(`id.eq.${sdKey},sd_key.eq.${sdKey}`)
-          .single();
-        targetApp = fullSd?.target_application;
-      } catch { /* continue with other checks */ }
+      const targetApp = validation.details.target_application || null;
 
       if (targetApp === 'EHG_Engineer') {
         console.log('   ✅ EHG_Engineer target application (backend-only) - Section C not applicable (25/25)');

--- a/scripts/modules/implementation-fidelity/sections/design-fidelity.js
+++ b/scripts/modules/implementation-fidelity/sections/design-fidelity.js
@@ -104,16 +104,7 @@ export async function validateDesignFidelity(sd_id, designAnalysis, validation, 
     // PAT-GATE2-BE-001: target_application-aware exemption
     // EHG_Engineer is a backend-only repo (CLI, scripts, tooling) - never has UI components
     if (!hasUIScope) {
-      let targetApp = null;
-      try {
-        const sdKey = sd_id;
-        const { data: fullSd } = await supabase
-          .from('strategic_directives_v2')
-          .select('target_application')
-          .or(`id.eq.${sdKey},sd_key.eq.${sdKey}`)
-          .single();
-        targetApp = fullSd?.target_application;
-      } catch { /* continue with other checks */ }
+      const targetApp = validation.details.target_application || null;
 
       if (targetApp === 'EHG_Engineer') {
         console.log('   ✅ EHG_Engineer target application (backend-only) - Section A not applicable (25/25)');


### PR DESCRIPTION
## Summary
- Sections A and C were silently failing to fetch `target_application` via separate `.or()` queries, causing EHG_Engineer backend-only feature SDs to miss exemptions (~20 point loss)
- Now `index.js` fetches `target_application` once and passes it via `validation.details`, eliminating fragile re-queries
- Companion fix for PR #1836 (SD-type-aware section policy)

## Test plan
- [x] Syntax check passes
- [x] 16 policy unit tests pass
- [x] Smoke tests pass
- [ ] Retry EXEC-TO-PLAN handoff for SD-SITUATIONAL-MODELING-ENGINE-UNIFIED-ORCH-001-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)