### PR TITLE
feat: add claim support for quick fixes (QF- prefix)

### DIFF
--- a/database/migrations/20260306_add_qf_claim_support.sql
+++ b/database/migrations/20260306_add_qf_claim_support.sql
@@ -1,0 +1,676 @@
+-- ============================================================================
+-- Migration: Add Quick Fix (QF) Claim Support
+-- Date: 2026-03-06
+-- Purpose: Extend claim infrastructure to support QF- prefixed IDs in
+--          claude_sessions.sd_id. Adds claiming_session_id to quick_fixes,
+--          branches RPC target-table updates on QF- prefix, and updates
+--          v_active_sessions to resolve QF titles.
+-- ============================================================================
+
+BEGIN;
+
+-- ============================================================================
+-- STEP 1: Add claiming_session_id column to quick_fixes
+-- ============================================================================
+
+ALTER TABLE quick_fixes ADD COLUMN IF NOT EXISTS claiming_session_id TEXT;
+
+-- ============================================================================
+-- STEP 2: Replace claim_sd() — branch target table update on QF- prefix
+-- Skip parent_sd_id lookup and conflict matrix check for QFs
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.claim_sd(
+  p_sd_id text,
+  p_session_id text,
+  p_track text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_existing_claim RECORD;
+  v_conflict RECORD;
+  v_parent_sd_id TEXT;
+  v_is_qf BOOLEAN := p_sd_id LIKE 'QF-%';
+BEGIN
+  -- TOCTOU FIX (US-007): Acquire advisory lock to serialize concurrent claims
+  PERFORM pg_advisory_xact_lock(hashtext(p_sd_id));
+
+  -- Check if SD/QF is already claimed by another active/idle session
+  SELECT cs.session_id, cs.sd_id
+  INTO v_existing_claim
+  FROM claude_sessions cs
+  WHERE cs.sd_id = p_sd_id
+    AND cs.session_id != p_session_id
+    AND cs.status IN ('active', 'idle')
+    AND EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 900
+  LIMIT 1
+  FOR UPDATE SKIP LOCKED;
+
+  IF v_existing_claim IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'already_claimed',
+      'message', format('SD %s is already claimed by session %s', p_sd_id, v_existing_claim.session_id),
+      'claimed_by', v_existing_claim.session_id
+    );
+  END IF;
+
+  -- QFs don't participate in sd_conflict_matrix or parent hierarchy
+  IF NOT v_is_qf THEN
+    -- Check for blocking conflicts with active SDs (reads from claude_sessions)
+    SELECT cm.*, cs_other.sd_id as active_sd, cs_other.session_id as active_session
+    INTO v_conflict
+    FROM sd_conflict_matrix cm
+    JOIN claude_sessions cs_other ON (
+      (cm.sd_id_a = p_sd_id AND cm.sd_id_b = cs_other.sd_id) OR
+      (cm.sd_id_b = p_sd_id AND cm.sd_id_a = cs_other.sd_id)
+    )
+    WHERE cm.conflict_severity = 'blocking'
+      AND cm.resolved_at IS NULL
+      AND cs_other.sd_id IS NOT NULL
+      AND cs_other.status IN ('active', 'idle')
+      AND EXTRACT(EPOCH FROM (NOW() - cs_other.heartbeat_at)) < 900
+      AND cs_other.session_id != p_session_id
+    LIMIT 1;
+
+    IF v_conflict IS NOT NULL THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'blocking_conflict',
+        'message', format('SD %s has blocking conflict with active SD %s', p_sd_id, v_conflict.active_sd),
+        'conflict_type', v_conflict.conflict_type,
+        'conflicting_sd', v_conflict.active_sd,
+        'conflicting_session', v_conflict.active_session
+      );
+    END IF;
+
+    -- Look up the parent SD of the SD being claimed (if it is a child)
+    SELECT parent_sd_id INTO v_parent_sd_id
+    FROM strategic_directives_v2
+    WHERE sd_key = p_sd_id;
+  END IF;
+
+  -- Release any existing claim for this session (switching SDs)
+  -- BUT preserve the parent orchestrator claim when claiming a child SD
+  UPDATE claude_sessions
+  SET sd_id = NULL,
+      track = NULL,
+      claimed_at = NULL,
+      released_at = NOW(),
+      released_reason = 'claim_switch',
+      status = 'idle'
+  WHERE session_id = p_session_id
+    AND sd_id IS NOT NULL
+    AND sd_id != p_sd_id
+    AND (v_parent_sd_id IS NULL OR sd_id != v_parent_sd_id);
+
+  -- Write the claim directly into claude_sessions
+  UPDATE claude_sessions
+  SET sd_id = p_sd_id,
+      track = p_track,
+      claimed_at = NOW(),
+      released_at = NULL,
+      released_reason = NULL,
+      heartbeat_at = NOW(),
+      status = 'active'
+  WHERE session_id = p_session_id;
+
+  -- Set claiming_session_id on the target table (SD or QF)
+  IF v_is_qf THEN
+    UPDATE quick_fixes
+    SET claiming_session_id = p_session_id,
+        status = 'in_progress'
+    WHERE id = p_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+    SET claiming_session_id = p_session_id,
+        active_session_id = p_session_id,
+        is_working_on = true
+    WHERE sd_key = p_sd_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'message', format('SD %s claimed successfully', p_sd_id),
+    'sd_id', p_sd_id,
+    'session_id', p_session_id,
+    'track', p_track,
+    'parent_preserved', v_parent_sd_id IS NOT NULL
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- STEP 3: Replace release_sd() — branch on QF- prefix
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS public.release_sd(text);
+DROP FUNCTION IF EXISTS public.release_sd(text, text);
+
+CREATE FUNCTION public.release_sd(
+  p_session_id text,
+  p_reason text DEFAULT 'manual'::text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_sd_id TEXT;
+BEGIN
+  -- Get current SD/QF from claude_sessions
+  SELECT sd_id INTO v_sd_id
+  FROM claude_sessions
+  WHERE session_id = p_session_id;
+
+  IF v_sd_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'message', 'No SD to release'
+    );
+  END IF;
+
+  -- Clear claim state on claude_sessions
+  UPDATE claude_sessions
+  SET sd_id = NULL,
+      track = NULL,
+      claimed_at = NULL,
+      released_at = NOW(),
+      released_reason = p_reason,
+      heartbeat_at = NOW(),
+      status = 'idle'
+  WHERE session_id = p_session_id;
+
+  -- Clear claiming state on the target table (SD or QF)
+  IF v_sd_id LIKE 'QF-%' THEN
+    UPDATE quick_fixes
+    SET claiming_session_id = NULL
+    WHERE id = v_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+    SET claiming_session_id = NULL,
+        active_session_id = NULL,
+        is_working_on = false
+    WHERE sd_key = v_sd_id
+      AND (active_session_id = p_session_id OR claiming_session_id = p_session_id);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'released_sd', v_sd_id,
+    'reason', p_reason,
+    'released_at', NOW()
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- STEP 4: Replace release_session() — branch on QF- prefix
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.release_session(p_session_id text, p_reason text DEFAULT 'graceful_exit'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_session RECORD;
+BEGIN
+  -- Get current session state
+  SELECT session_id, status, sd_id, released_at INTO v_session
+  FROM claude_sessions
+  WHERE session_id = p_session_id;
+
+  IF v_session IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'session_not_found',
+      'message', format('Session %s not found', p_session_id)
+    );
+  END IF;
+
+  -- Idempotent: if already released, return success with original timestamp
+  IF v_session.status = 'released' THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'already_released', true,
+      'session_id', p_session_id,
+      'released_at', v_session.released_at
+    );
+  END IF;
+
+  -- Release claim if session had one
+  IF v_session.sd_id IS NOT NULL THEN
+    IF v_session.sd_id LIKE 'QF-%' THEN
+      UPDATE quick_fixes
+      SET claiming_session_id = NULL
+      WHERE id = v_session.sd_id;
+    ELSE
+      UPDATE strategic_directives_v2
+      SET active_session_id = NULL, is_working_on = false
+      WHERE active_session_id = p_session_id;
+    END IF;
+  END IF;
+
+  -- Update session to released (sd_id cleared here)
+  UPDATE claude_sessions
+  SET status = 'released',
+      released_at = NOW(),
+      released_reason = p_reason,
+      sd_id = NULL,
+      track = NULL,
+      claimed_at = NULL,
+      updated_at = NOW()
+  WHERE session_id = p_session_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'released_at', NOW(),
+    'reason', p_reason,
+    'had_sd_claim', v_session.sd_id IS NOT NULL
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- STEP 5: Replace cleanup_stale_sessions() — add QF cleanup
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.cleanup_stale_sessions(p_stale_threshold_seconds integer DEFAULT 120, p_batch_size integer DEFAULT 100)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_stale_count INTEGER := 0;
+  v_released_count INTEGER := 0;
+BEGIN
+  -- Step 1: Mark active sessions as stale if heartbeat too old
+  WITH stale_sessions AS (
+    SELECT session_id
+    FROM claude_sessions
+    WHERE status IN ('active', 'idle')
+      AND heartbeat_at < NOW() - (p_stale_threshold_seconds || ' seconds')::INTERVAL
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  updated AS (
+    UPDATE claude_sessions cs
+    SET status = 'stale',
+        stale_at = NOW(),
+        stale_reason = 'HEARTBEAT_TIMEOUT',
+        updated_at = NOW()
+    FROM stale_sessions ss
+    WHERE cs.session_id = ss.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_stale_count FROM updated;
+
+  -- Step 2: Release stale sessions that have been stale for >30 seconds
+  WITH release_sessions AS (
+    SELECT session_id, sd_id
+    FROM claude_sessions
+    WHERE status = 'stale'
+      AND stale_at < NOW() - INTERVAL '30 seconds'
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  ),
+  released AS (
+    UPDATE claude_sessions cs
+    SET status = 'released',
+        released_at = NOW(),
+        released_reason = 'STALE_CLEANUP',
+        sd_id = NULL,
+        track = NULL,
+        claimed_at = NULL,
+        updated_at = NOW()
+    FROM release_sessions rs
+    WHERE cs.session_id = rs.session_id
+    RETURNING cs.session_id
+  )
+  SELECT COUNT(*) INTO v_released_count FROM released;
+
+  -- Clear is_working_on for released sessions on strategic_directives_v2
+  UPDATE strategic_directives_v2
+  SET active_session_id = NULL, is_working_on = false
+  WHERE active_session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  );
+
+  -- Clear claiming_session_id for released sessions on quick_fixes
+  UPDATE quick_fixes
+  SET claiming_session_id = NULL
+  WHERE claiming_session_id IN (
+    SELECT session_id FROM claude_sessions
+    WHERE status = 'released' AND released_reason = 'STALE_CLEANUP'
+    AND released_at > NOW() - INTERVAL '1 minute'
+  );
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'sessions_marked_stale', v_stale_count,
+    'sessions_released', v_released_count,
+    'stale_threshold_seconds', p_stale_threshold_seconds,
+    'batch_size', p_batch_size,
+    'executed_at', NOW()
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- STEP 6: Replace switch_sd_claim() — branch on QF- prefix for old/new
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.switch_sd_claim(p_session_id text, p_old_sd_id text, p_new_sd_id text, p_new_track text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE
+  v_session RECORD;
+  v_conflict RECORD;
+BEGIN
+  -- Validate session exists and owns the old claim
+  SELECT * INTO v_session
+  FROM claude_sessions
+  WHERE session_id = p_session_id
+    AND status = 'active'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Session not found or not active'
+    );
+  END IF;
+
+  -- Verify session currently holds the old SD/QF claim
+  IF v_session.sd_id IS DISTINCT FROM p_old_sd_id THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('Session does not hold claim on %s (current: %s)', p_old_sd_id, COALESCE(v_session.sd_id, 'none'))
+    );
+  END IF;
+
+  -- Check if new SD/QF is already claimed by another active/idle session
+  SELECT session_id, sd_id INTO v_conflict
+  FROM claude_sessions
+  WHERE sd_id = p_new_sd_id
+    AND status IN ('active', 'idle')
+    AND session_id != p_session_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', format('SD %s is already claimed by session %s', p_new_sd_id, v_conflict.session_id),
+      'conflict_session_id', v_conflict.session_id
+    );
+  END IF;
+
+  -- Clear old claim's working state (SD or QF)
+  IF p_old_sd_id LIKE 'QF-%' THEN
+    UPDATE quick_fixes
+    SET claiming_session_id = NULL
+    WHERE id = p_old_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+    SET active_session_id = NULL, is_working_on = false
+    WHERE sd_key = p_old_sd_id AND active_session_id = p_session_id;
+  END IF;
+
+  -- Atomic switch: update claim in claude_sessions
+  UPDATE claude_sessions
+  SET
+    sd_id = p_new_sd_id,
+    track = COALESCE(p_new_track, track),
+    claimed_at = NOW(),
+    heartbeat_at = NOW(),
+    updated_at = NOW()
+  WHERE session_id = p_session_id;
+
+  -- Set new claim's working state (SD or QF)
+  IF p_new_sd_id LIKE 'QF-%' THEN
+    UPDATE quick_fixes
+    SET claiming_session_id = p_session_id,
+        status = 'in_progress'
+    WHERE id = p_new_sd_id;
+  ELSE
+    UPDATE strategic_directives_v2
+    SET active_session_id = p_session_id,
+        claiming_session_id = p_session_id,
+        is_working_on = true
+    WHERE sd_key = p_new_sd_id;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'session_id', p_session_id,
+    'old_sd_id', p_old_sd_id,
+    'new_sd_id', p_new_sd_id,
+    'switched_at', NOW()::TEXT
+  );
+END;
+$function$;
+
+-- ============================================================================
+-- STEP 7: Replace create_or_replace_session() — branch on QF- prefix
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.create_or_replace_session(p_session_id text, p_machine_id text, p_terminal_id text, p_tty text, p_pid integer, p_hostname text, p_codebase text, p_metadata jsonb DEFAULT '{}'::jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_terminal_identity TEXT;
+  v_existing RECORD;
+  v_heartbeat_age NUMERIC;
+BEGIN
+  -- Compute terminal identity (matches the GENERATED ALWAYS column)
+  v_terminal_identity := COALESCE(p_machine_id, '') || ':' || COALESCE(p_terminal_id, p_tty, '');
+
+  -- Strategy: Try to insert first. If it succeeds, no conflict exists.
+  BEGIN
+    INSERT INTO claude_sessions (
+      session_id, machine_id, terminal_id, tty, pid, hostname, codebase,
+      status, heartbeat_at, metadata, created_at, updated_at
+    ) VALUES (
+      p_session_id, p_machine_id, p_terminal_id, p_tty, p_pid, p_hostname, p_codebase,
+      'idle', NOW(), p_metadata, NOW(), NOW()
+    )
+    ON CONFLICT (session_id) DO UPDATE SET
+      machine_id = EXCLUDED.machine_id,
+      terminal_id = EXCLUDED.terminal_id,
+      tty = EXCLUDED.tty,
+      pid = EXCLUDED.pid,
+      hostname = EXCLUDED.hostname,
+      heartbeat_at = NOW(),
+      metadata = EXCLUDED.metadata,
+      status = CASE
+        WHEN claude_sessions.status = 'released' THEN 'idle'
+        ELSE claude_sessions.status
+      END,
+      updated_at = NOW();
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'session_id', p_session_id,
+      'terminal_identity', v_terminal_identity,
+      'auto_released', false,
+      'created_at', NOW()
+    );
+
+  EXCEPTION
+    WHEN unique_violation THEN
+      NULL; -- Fall through to conflict resolution below
+  END;
+
+  -- Find the conflicting session
+  SELECT session_id, sd_id, status, heartbeat_at INTO v_existing
+  FROM claude_sessions
+  WHERE terminal_identity = v_terminal_identity
+    AND status IN ('active', 'idle')
+    AND session_id != p_session_id
+  LIMIT 1;
+
+  IF v_existing IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'session_id', p_session_id,
+      'terminal_identity', v_terminal_identity,
+      'error', 'terminal_conflict',
+      'message', format('Terminal %s had unique violation but no conflicting session found', v_terminal_identity)
+    );
+  END IF;
+
+  v_heartbeat_age := EXTRACT(EPOCH FROM (NOW() - v_existing.heartbeat_at));
+
+  IF v_heartbeat_age < 300 THEN
+    RETURN jsonb_build_object(
+      'success', true,
+      'session_id', p_session_id,
+      'terminal_identity', v_terminal_identity,
+      'auto_released', false,
+      'conflict', true,
+      'conflict_session_id', v_existing.session_id,
+      'conflict_sd_id', v_existing.sd_id,
+      'conflict_heartbeat_age_seconds', round(v_heartbeat_age)
+    );
+  END IF;
+
+  -- Stale heartbeat (>= 5 min) -- safe to auto-release and create new session
+  UPDATE claude_sessions
+  SET status = 'released',
+      released_at = NOW(),
+      released_reason = 'AUTO_REPLACED',
+      sd_id = NULL,
+      track = NULL,
+      claimed_at = NULL,
+      updated_at = NOW()
+  WHERE session_id = v_existing.session_id;
+
+  -- Release working state on target table if the stale session had a claim
+  IF v_existing.sd_id IS NOT NULL THEN
+    IF v_existing.sd_id LIKE 'QF-%' THEN
+      UPDATE quick_fixes
+      SET claiming_session_id = NULL
+      WHERE id = v_existing.sd_id;
+    ELSE
+      UPDATE strategic_directives_v2
+      SET active_session_id = NULL, is_working_on = false
+      WHERE active_session_id = v_existing.session_id;
+    END IF;
+  END IF;
+
+  RAISE NOTICE 'Auto-released stale session % (heartbeat %s ago) for terminal %',
+    v_existing.session_id, round(v_heartbeat_age), v_terminal_identity;
+
+  -- Now insert the new session
+  BEGIN
+    INSERT INTO claude_sessions (
+      session_id, machine_id, terminal_id, tty, pid, hostname, codebase,
+      status, heartbeat_at, metadata, created_at, updated_at
+    ) VALUES (
+      p_session_id, p_machine_id, p_terminal_id, p_tty, p_pid, p_hostname, p_codebase,
+      'idle', NOW(), p_metadata, NOW(), NOW()
+    )
+    ON CONFLICT (session_id) DO UPDATE SET
+      machine_id = EXCLUDED.machine_id,
+      terminal_id = EXCLUDED.terminal_id,
+      tty = EXCLUDED.tty,
+      pid = EXCLUDED.pid,
+      hostname = EXCLUDED.hostname,
+      heartbeat_at = NOW(),
+      metadata = EXCLUDED.metadata,
+      status = CASE
+        WHEN claude_sessions.status = 'released' THEN 'idle'
+        ELSE claude_sessions.status
+      END,
+      updated_at = NOW();
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'session_id', p_session_id,
+      'terminal_identity', v_terminal_identity,
+      'auto_released', true,
+      'previous_session_id', v_existing.session_id,
+      'created_at', NOW()
+    );
+
+  EXCEPTION
+    WHEN unique_violation THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'session_id', p_session_id,
+        'terminal_identity', v_terminal_identity,
+        'error', 'terminal_conflict',
+        'message', format('Terminal %s: race condition during stale session replacement', v_terminal_identity)
+      );
+  END;
+
+END;
+$function$;
+
+-- ============================================================================
+-- STEP 8: Rebuild v_active_sessions view — add QF title resolution
+-- ============================================================================
+
+DROP VIEW IF EXISTS v_active_sessions;
+
+CREATE VIEW v_active_sessions AS
+SELECT
+  cs.id,
+  cs.session_id,
+  cs.sd_id,
+  COALESCE(sd.title, qf.title) AS sd_title,
+  cs.track,
+  cs.tty,
+  cs.pid,
+  cs.hostname,
+  cs.codebase,
+  cs.current_branch,
+  cs.machine_id,
+  cs.terminal_id,
+  cs.terminal_identity,
+  cs.claimed_at,
+  cs.heartbeat_at,
+  cs.status,
+  cs.released_reason,
+  cs.released_at,
+  cs.stale_reason,
+  cs.stale_at,
+  cs.metadata,
+  cs.created_at,
+  EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) AS heartbeat_age_seconds,
+  (EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 60.0) AS heartbeat_age_minutes,
+  GREATEST(0, 300.0 - EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at))) AS seconds_until_stale,
+  CASE
+    WHEN cs.status = 'released' THEN 'released'
+    WHEN cs.status = 'stale' THEN 'stale'
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) > 300 THEN 'stale'
+    WHEN cs.sd_id IS NULL THEN 'idle'
+    ELSE 'active'
+  END AS computed_status,
+  CASE
+    WHEN cs.claimed_at IS NOT NULL
+      THEN EXTRACT(EPOCH FROM (NOW() - cs.claimed_at)) / 60.0
+    ELSE NULL
+  END AS claim_duration_minutes,
+  CASE
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 60
+      THEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at))::integer || 's ago'
+    WHEN EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) < 3600
+      THEN (EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 60.0)::integer || 'm ago'
+    ELSE (EXTRACT(EPOCH FROM (NOW() - cs.heartbeat_at)) / 3600.0)::integer || 'h ago'
+  END AS heartbeat_age_human
+FROM claude_sessions cs
+LEFT JOIN strategic_directives_v2 sd ON cs.sd_id = sd.sd_key
+LEFT JOIN quick_fixes qf ON cs.sd_id = qf.id
+WHERE cs.status <> 'released'
+ORDER BY cs.track, cs.claimed_at DESC;
+
+COMMIT;

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -367,14 +367,18 @@ export async function claimGuard(sdKey, sessionId) {
     };
   }
 
-  // Update claiming_session_id on the SD (new column from migration)
-  await supabase
-    .from('strategic_directives_v2')
-    .update({
-      claiming_session_id: sessionId,
-      is_working_on: true
-    })
-    .eq('sd_key', sdKey);
+  // Update claiming_session_id on the target table (SD or QF)
+  if (sdKey.startsWith('QF-')) {
+    await supabase
+      .from('quick_fixes')
+      .update({ claiming_session_id: sessionId, status: 'in_progress' })
+      .eq('id', sdKey);
+  } else {
+    await supabase
+      .from('strategic_directives_v2')
+      .update({ claiming_session_id: sessionId, is_working_on: true })
+      .eq('sd_key', sdKey);
+  }
 
   return {
     success: true,

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -261,6 +261,20 @@ export async function completeQuickFix(qfId, options = {}) {
     process.exit(1);
   }
 
+  // Release QF claim after successful completion
+  try {
+    const { default: sessionManager } = await import('../../../lib/session-manager.mjs');
+    const session = await sessionManager.getOrCreateSession();
+    if (session?.session_id) {
+      await supabase.rpc('release_sd', {
+        p_session_id: session.session_id,
+        p_reason: 'qf_completed'
+      });
+    }
+  } catch {
+    // Non-fatal — claim release is best-effort
+  }
+
   displayCompletionSummary(qf, actualLoc, commitSha, branchName, finalPrUrl, filesChanged);
 
   // Merge to Main

--- a/scripts/modules/sd-next/SDNextSelector.js
+++ b/scripts/modules/sd-next/SDNextSelector.js
@@ -30,7 +30,9 @@ import {
   loadSDHierarchy,
   loadOKRScorecard,
   loadVisionScores,
-  countActionableBaselineItems
+  countActionableBaselineItems,
+  loadOpenQuickFixes,
+  triageQuickFixes
 } from './data-loaders.js';
 import {
   displayOKRScorecard,
@@ -46,7 +48,8 @@ import {
   showExhaustedBaselineMessage,
   displayBlockedStateBanner,
   isOrchestratorBlocked,
-  displayTelemetryFindings
+  displayTelemetryFindings,
+  displayQuickFixes
 } from './display/index.js';
 import {
   detectAllBlockedState,
@@ -97,6 +100,8 @@ export class SDNextSelector {
     this.ventureContext = null; // Active venture context for SD filtering
     this.visionScores = new Map(); // Per-SD vision score aggregates (SD-MAN-INFRA-VISION-PORTFOLIO-SCORECARD-001)
     this.localSignals = new Map(); // Local filesystem signals (worktrees, auto-proceed-state) SD-LEO-INFRA-SESSION-COMPACTION-CLAIM-001
+    this.openQuickFixes = [];
+    this.qfTriageResults = new Map();
   }
 
   /**
@@ -149,6 +154,10 @@ export class SDNextSelector {
     this.conflicts = await loadConflicts(this.supabase);
     await this.loadActiveSessions();
     this.pendingProposals = await loadPendingProposals(this.supabase);
+    this.openQuickFixes = await loadOpenQuickFixes(this.supabase);
+    if (this.openQuickFixes.length > 0) {
+      this.qfTriageResults = await triageQuickFixes(this.openQuickFixes, this.supabase);
+    }
     this.loadMultiRepoStatus();
 
     // SD-LEO-INFRA-SESSION-COMPACTION-CLAIM-001: Detect local signals
@@ -175,6 +184,10 @@ export class SDNextSelector {
       await showFallbackQueue(this.supabase, {
         sessionContext: this.getSessionContext()
       });
+      const qfSummaryNoBaseline = displayQuickFixes(this.openQuickFixes, this.qfTriageResults, this.getSessionContext());
+      if (qfSummaryNoBaseline.topStartableQF) {
+        return { action: 'qf_start', sd_id: null, qf_id: qfSummaryNoBaseline.topStartableQF.id, reason: `${qfSummaryNoBaseline.totalCount} open quick fix(es) available` };
+      }
       return { action: 'none', sd_id: null, reason: 'No active baseline found' };
     }
 
@@ -188,14 +201,21 @@ export class SDNextSelector {
         skipBaselineWarning: true,
         sessionContext: this.getSessionContext()
       });
+      const qfSummaryExhausted = displayQuickFixes(this.openQuickFixes, this.qfTriageResults, this.getSessionContext());
+      if (qfSummaryExhausted.topStartableQF) {
+        return { action: 'qf_start', sd_id: null, qf_id: qfSummaryExhausted.topStartableQF.id, reason: `Baseline exhausted but ${qfSummaryExhausted.totalCount} open quick fix(es) available` };
+      }
       return { action: 'none', sd_id: null, reason: 'Baseline exhausted - all items completed' };
     }
 
     // Display tracks
     await this.displayTracks();
 
+    // Display open quick fixes with re-triage escalation warnings
+    const qfSummary = displayQuickFixes(this.openQuickFixes, this.qfTriageResults, this.getSessionContext());
+
     // Display recommendations and get structured action data
-    const recommendation = await displayRecommendations(this.supabase, this.baselineItems, this.conflicts, this.getSessionContext());
+    const recommendation = await displayRecommendations(this.supabase, this.baselineItems, this.conflicts, this.getSessionContext(), qfSummary);
 
     // Display proactive proposals (LEO v4.4)
     displayProposals(this.pendingProposals);

--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -317,6 +317,69 @@ export async function loadVisionScores(supabase) {
 }
 
 /**
+ * Load open quick fixes for display in the SD queue.
+ *
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<Array>} Array of quick fix objects
+ */
+export async function loadOpenQuickFixes(supabase) {
+  try {
+    const { data, error } = await supabase
+      .from('quick_fixes')
+      .select('id, title, type, severity, status, estimated_loc, description, created_at, target_application, claiming_session_id')
+      .in('status', ['open', 'in_progress'])
+      .order('created_at', { ascending: true })
+      .limit(50);
+
+    if (error) {
+      logQueryFailure('loadOpenQuickFixes', error, { table: 'quick_fixes' });
+      return [];
+    }
+
+    return data || [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Re-triage open quick fixes to detect tier drift (e.g., QFs that should be escalated to SDs).
+ * Uses the existing runTriageGate() with a non-interactive source so no gate prompt is shown.
+ *
+ * @param {Array} quickFixes - Array of quick fix objects from loadOpenQuickFixes
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<Map<string, import('../triage-gate.js').TriageResult>>}
+ */
+export async function triageQuickFixes(quickFixes, supabase) {
+  const results = new Map();
+  if (!quickFixes || quickFixes.length === 0) return results;
+
+  let runTriageGate;
+  try {
+    const mod = await import('../triage-gate.js');
+    runTriageGate = mod.runTriageGate;
+  } catch {
+    return results;
+  }
+
+  for (const qf of quickFixes) {
+    try {
+      const triageResult = await runTriageGate({
+        title: qf.title || '',
+        description: qf.description || '',
+        type: qf.type || 'bug',
+        source: 'sd-next-display',
+      }, supabase);
+      results.set(qf.id, triageResult);
+    } catch {
+      // Individual triage failure — skip, will fall back to stored tier
+    }
+  }
+
+  return results;
+}
+
+/**
  * Count how many baseline items have non-completed SDs
  *
  * @param {Object} supabase - Supabase client

--- a/scripts/modules/sd-next/display/index.js
+++ b/scripts/modules/sd-next/display/index.js
@@ -26,3 +26,4 @@ export {
 } from './blocked-state.js';
 export { displayTelemetryFindings } from './telemetry-findings.js';
 export { displayVisionPortfolioHeader, formatVisionBadge } from './vision-scorecard.js';
+export { displayQuickFixes } from './quick-fixes.js';

--- a/scripts/modules/sd-next/display/quick-fixes.js
+++ b/scripts/modules/sd-next/display/quick-fixes.js
@@ -1,0 +1,149 @@
+/**
+ * Quick Fixes Display for SD-Next
+ * Shows open quick fixes in the queue with re-triage escalation warnings
+ * and claim badges for multi-session awareness.
+ */
+
+import { colors } from '../colors.js';
+import { analyzeClaimRelationship } from '../claim-analysis.js';
+
+const MAX_DISPLAY = 10;
+
+const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
+
+/**
+ * Display open quick fixes section.
+ *
+ * @param {Array} quickFixes - Open quick fixes from loadOpenQuickFixes
+ * @param {Map} triageResults - Re-triage results from triageQuickFixes (qfId -> TriageResult)
+ * @param {Object} sessionContext - Session context for claim analysis
+ * @returns {{ escalationCount: number, totalCount: number, topQF: Object|null }}
+ */
+export function displayQuickFixes(quickFixes, triageResults = new Map(), sessionContext = {}) {
+  const summary = { escalationCount: 0, totalCount: 0, topQF: null };
+
+  if (!quickFixes || quickFixes.length === 0) return summary;
+
+  summary.totalCount = quickFixes.length;
+
+  const { claimedSDs = new Map(), currentSession = null, activeSessions = [] } = sessionContext;
+
+  // Classify each QF: escalation-flagged (tier 3 re-triage) vs normal, plus claim status
+  const classified = quickFixes.map(qf => {
+    const triage = triageResults.get(qf.id);
+    const escalate = triage && triage.tier === 3;
+    if (escalate) summary.escalationCount++;
+
+    // Claim analysis
+    let claimBadge = '';
+    let isClaimedByOther = false;
+
+    const claimingSessionId = qf.claiming_session_id || claimedSDs.get(qf.id);
+    if (claimingSessionId && currentSession) {
+      if (claimingSessionId === currentSession.session_id) {
+        claimBadge = `${colors.green}YOURS${colors.reset} `;
+      } else {
+        isClaimedByOther = true;
+        // Try richer analysis if we have session data
+        const claimingSession = activeSessions.find(s => s.session_id === claimingSessionId);
+        if (claimingSession) {
+          const analysis = analyzeClaimRelationship({
+            claimingSessionId,
+            claimingSession,
+            currentSession
+          });
+          if (analysis.relationship === 'same_conversation') {
+            claimBadge = `${colors.green}${analysis.displayLabel}${colors.reset} `;
+            isClaimedByOther = false;
+          } else {
+            claimBadge = analysis.relationship.startsWith('stale')
+              ? `${colors.yellow}${analysis.displayLabel}${colors.reset} `
+              : `${colors.yellow}CLAIMED${colors.reset} `;
+          }
+        } else {
+          claimBadge = `${colors.yellow}CLAIMED${colors.reset} `;
+        }
+      }
+    }
+
+    return { ...qf, _triage: triage, _escalate: escalate, _claimBadge: claimBadge, _isClaimedByOther: isClaimedByOther };
+  });
+
+  // Sort: escalation first, then severity, then age (oldest first — already sorted by created_at ASC from DB)
+  classified.sort((a, b) => {
+    if (a._escalate !== b._escalate) return a._escalate ? -1 : 1;
+    const sevA = SEVERITY_ORDER[a.severity] ?? 4;
+    const sevB = SEVERITY_ORDER[b.severity] ?? 4;
+    if (sevA !== sevB) return sevA - sevB;
+    return new Date(a.created_at) - new Date(b.created_at);
+  });
+
+  summary.topQF = classified[0] || null;
+  // Skip claimed-by-others QFs from topStartableQF selection
+  summary.topStartableQF = classified.find(qf => !qf._escalate && !qf._isClaimedByOther) || null;
+
+  // Display header
+  console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
+  console.log(`${colors.bold}${colors.yellow}OPEN QUICK FIXES (${summary.totalCount}):${colors.reset}\n`);
+
+  const displayed = classified.slice(0, MAX_DISPLAY);
+
+  for (const qf of displayed) {
+    const age = formatAge(qf.created_at);
+    const loc = qf.estimated_loc ? `~${qf.estimated_loc} LOC` : 'LOC unknown';
+    const target = qf.target_application || 'N/A';
+    const badge = qf._claimBadge;
+
+    if (qf._escalate) {
+      // Escalation row
+      const reason = qf._triage?.escalationReason || 'Re-triage returned Tier 3';
+      console.log(`  ${colors.red}${colors.bold}⚠ ESCALATE${colors.reset}  ${badge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
+      console.log(`       ${colors.dim}Re-triage: Tier 3 — ${reason}${colors.reset}`);
+      console.log(`       ${colors.dim}Action: /leo create --from-qf ${qf.id}${colors.reset}`);
+    } else {
+      // Normal row
+      const tier = qf._triage ? qf._triage.tier : inferTier(qf.estimated_loc);
+      const tierBadge = `[T${tier}]`;
+      const statusBadge = qf.status === 'in_progress' ? `${colors.cyan}WIP${colors.reset} ` : '';
+      console.log(`  ${colors.bold}${tierBadge}${colors.reset} ${badge}${statusBadge}${qf.id} - ${truncate(qf.title, 45)}  ${colors.dim}${qf.severity}  ${age}${colors.reset}`);
+      console.log(`       ${colors.dim}Est: ${loc} | Type: ${qf.type} | Target: ${target}${colors.reset}`);
+    }
+  }
+
+  if (summary.totalCount > MAX_DISPLAY) {
+    console.log(`\n  ${colors.dim}... and ${summary.totalCount - MAX_DISPLAY} more${colors.reset}`);
+  }
+
+  console.log(`\n  ${colors.dim}Manage: /leo QF-<ID>    Start: /leo QF-<ID>${colors.reset}`);
+
+  return summary;
+}
+
+/**
+ * Infer display tier from estimated LOC when triage result is unavailable.
+ */
+function inferTier(estimatedLoc) {
+  if (!estimatedLoc || estimatedLoc <= 30) return 1;
+  if (estimatedLoc <= 75) return 2;
+  return 3;
+}
+
+/**
+ * Format a human-readable age from a timestamp.
+ */
+function formatAge(createdAt) {
+  if (!createdAt) return '';
+  const diffMs = Date.now() - new Date(createdAt).getTime();
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  if (days === 0) return 'today';
+  if (days === 1) return '1d old';
+  return `${days}d old`;
+}
+
+/**
+ * Truncate a string to maxLen characters with ellipsis.
+ */
+function truncate(str, maxLen) {
+  if (!str) return '';
+  return str.length > maxLen ? str.substring(0, maxLen) + '...' : str;
+}

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -17,7 +17,7 @@ import { analyzeClaimRelationship } from '../claim-analysis.js';
  * @param {Array} conflicts - Active conflicts
  * @returns {{ action: string, sd_id: string|null, reason: string }} Recommended next action
  */
-export async function displayRecommendations(supabase, baselineItems, conflicts = [], sessionContext = {}) {
+export async function displayRecommendations(supabase, baselineItems, conflicts = [], sessionContext = {}, qfContext = {}) {
   console.log(`\n${colors.bold}───────────────────────────────────────────────────────────────────${colors.reset}`);
   console.log(`${colors.bold}${colors.green}RECOMMENDED ACTIONS:${colors.reset}\n`);
 
@@ -137,6 +137,11 @@ export async function displayRecommendations(supabase, baselineItems, conflicts 
     }
 
     return { action: 'start', sd_id: sdId, reason: `SD ${sdId} is next in queue (rank: ${sd.sequence_rank}, deps satisfied)` };
+  }
+  // QF fallback: if no SDs are actionable but quick fixes exist, suggest one
+  if (qfContext.totalCount > 0 && qfContext.topStartableQF) {
+    const qfId = qfContext.topStartableQF.id;
+    return { action: 'qf_start', sd_id: null, qf_id: qfId, reason: `No actionable SDs — ${qfContext.totalCount} open quick fix(es) available (top: ${qfId})` };
   }
   return { action: 'none', sd_id: null, reason: 'No actionable SDs found in queue' };
 }


### PR DESCRIPTION
## Summary
- Extends claim system (claim_sd, release_sd, and 4 other RPCs) to support `QF-` prefixed IDs
- Adds `claiming_session_id` column to `quick_fixes` table
- Updates `v_active_sessions` view to resolve QF titles via LEFT JOIN
- JS-side: claim-guard.mjs branches post-RPC, orchestrator releases on QF completion, sd:next shows claim badges on QFs

## Test plan
- [x] Migration applied: `claiming_session_id` column added
- [x] `claim_sd` RPC tested with QF- prefix — sets `claiming_session_id` and changes status to `in_progress`
- [x] `release_sd` RPC tested — clears `claiming_session_id`
- [x] `v_active_sessions` view resolves SD and QF titles correctly
- [x] End-to-end claim/release cycle verified on real QF record
- [x] 15/15 smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)