### PR TITLE
fix: add traffic-light gate threshold system (QF-20260306-633)

### DIFF
--- a/scripts/modules/adaptive-threshold-calculator.js
+++ b/scripts/modules/adaptive-threshold-calculator.js
@@ -25,6 +25,14 @@ const BASE_THRESHOLDS = {
 /**
  * Special case minimum thresholds (cannot go below these)
  */
+/**
+ * Yellow band width for near-miss tolerance (GREEN/YELLOW/RED zones)
+ */
+export const YELLOW_BAND_WIDTH = 5;
+
+/**
+ * Special case minimum thresholds (cannot go below these)
+ */
 const SPECIAL_MINIMUMS = {
   PRODUCTION: 90,
   SECURITY: 95,
@@ -180,8 +188,12 @@ export function calculateAdaptiveThreshold(options) {
   // Step 6: Cap at 100% (no artificial cap at 95%, can require 100%)
   const finalThreshold = Math.min(100, thresholdWithSpecialCases);
 
+  const yellowThreshold = Math.max(0, finalThreshold - YELLOW_BAND_WIDTH);
+
   return {
     finalThreshold,
+    yellowThreshold,
+    yellowBandWidth: YELLOW_BAND_WIDTH,
     breakdown: {
       baseThreshold,
       performanceMod,
@@ -196,6 +208,7 @@ export function calculateAdaptiveThreshold(options) {
       performanceMod,
       maturityMod,
       finalThreshold,
+      yellowThreshold,
       gateNumber
     })
   };
@@ -208,7 +221,7 @@ export function calculateAdaptiveThreshold(options) {
  * @returns {string} Reasoning text
  */
 function generateReasoningText(params) {
-  const { sd, baseThreshold, performanceMod, maturityMod, finalThreshold, gateNumber } = params;
+  const { sd, baseThreshold, performanceMod, maturityMod, finalThreshold, yellowThreshold, gateNumber } = params;
 
   const parts = [];
 
@@ -244,6 +257,8 @@ function generateReasoningText(params) {
     parts.push('100% required for emergency hotfix');
   }
 
+  parts.push(`yellow band ${yellowThreshold}-${finalThreshold - 1}%`);
+
   return `Gate ${gateNumber} threshold: ${parts.join(', ')}. Final: ${finalThreshold}%`;
 }
 
@@ -255,20 +270,37 @@ function generateReasoningText(params) {
  * @returns {Object} Pass/fail result with details
  */
 export function checkGatePassed(score, thresholdResult) {
-  const { finalThreshold, reasoning } = thresholdResult;
-  const passed = score >= finalThreshold;
+  const { finalThreshold, yellowThreshold, reasoning } = thresholdResult;
   const margin = score - finalThreshold;
+
+  let zone, passed;
+  if (score >= finalThreshold) {
+    zone = 'GREEN';
+    passed = true;
+  } else if (yellowThreshold !== undefined && score >= yellowThreshold) {
+    zone = 'YELLOW';
+    passed = true;  // Auto-pass with advisory warnings
+  } else {
+    zone = 'RED';
+    passed = false;
+  }
+
+  const messages = {
+    GREEN: `Gate passed: ${score}/${finalThreshold} (margin: +${margin.toFixed(1)}% | GREEN)`,
+    YELLOW: `Gate near-miss passed: ${score}/${finalThreshold} (shortfall: ${Math.abs(margin).toFixed(1)}% within ${YELLOW_BAND_WIDTH}pt tolerance | YELLOW)`,
+    RED: `Gate failed: ${score}/${finalThreshold} (shortfall: ${Math.abs(margin).toFixed(1)}% exceeds ${YELLOW_BAND_WIDTH}pt tolerance | RED)`
+  };
 
   return {
     passed,
+    zone,
     score,
     threshold: finalThreshold,
+    yellowThreshold: yellowThreshold ?? finalThreshold - YELLOW_BAND_WIDTH,
     margin,
     reasoning,
-    status: passed ? 'PASS' : 'FAIL',
-    message: passed
-      ? `Gate passed: ${score}/${finalThreshold} (margin: +${margin.toFixed(1)}%)`
-      : `Gate failed: ${score}/${finalThreshold} (shortfall: ${margin.toFixed(1)}%)`
+    status: zone,
+    message: messages[zone]
   };
 }
 

--- a/scripts/modules/design-database-gates-validation.js
+++ b/scripts/modules/design-database-gates-validation.js
@@ -11,7 +11,7 @@
  * v1.1.0: Added AI-powered SD type classification to replace keyword matching
  */
 
-import { calculateAdaptiveThreshold } from './adaptive-threshold-calculator.js';
+import { calculateAdaptiveThreshold, checkGatePassed, YELLOW_BAND_WIDTH } from './adaptive-threshold-calculator.js';
 import { getPatternStats } from './pattern-tracking.js';
 // Import centralized SD type checking (replaces local shouldValidateDesignDatabase)
 import { requiresDesignDatabaseGates, requiresDesignDatabaseGatesSync, validateStreamCompletion } from './sd-type-checker.js';
@@ -546,12 +546,17 @@ export async function validateGate1PlanToExec(sd_id, supabase) {
     console.log(`\nAdaptive Threshold: ${requiredThreshold.toFixed(1)}%`);
     console.log(`Reasoning: ${thresholdResult.reasoning}`);
 
-    if (validation.score >= requiredThreshold) {
-      validation.passed = true;
-      console.log(`✅ GATE 1: PASSED (${validation.score} ≥ ${requiredThreshold.toFixed(1)} points)`);
+    const gateResult = checkGatePassed(validation.score, thresholdResult);
+    validation.passed = gateResult.passed;
+    validation.zone = gateResult.zone;
+
+    if (gateResult.zone === 'GREEN') {
+      console.log(`✅ GATE 1: PASSED (${validation.score} >= ${requiredThreshold.toFixed(1)} | GREEN)`);
+    } else if (gateResult.zone === 'YELLOW') {
+      console.log(`🟡 GATE 1: PASSED (${validation.score} >= ${gateResult.yellowThreshold} | YELLOW — within ${YELLOW_BAND_WIDTH}pt tolerance of ${requiredThreshold.toFixed(1)})`);
+      validation.warnings.push(`Score ${validation.score} is in YELLOW zone (${gateResult.yellowThreshold}-${requiredThreshold.toFixed(0)}). Passed with advisory.`);
     } else {
-      validation.passed = false;
-      console.log(`❌ GATE 1: FAILED (${validation.score} < ${requiredThreshold.toFixed(1)} points)`);
+      console.log(`🔴 GATE 1: FAILED (${validation.score} < ${gateResult.yellowThreshold} | RED)`);
     }
 
     if (validation.issues.length > 0) {

--- a/scripts/modules/implementation-fidelity/index.js
+++ b/scripts/modules/implementation-fidelity/index.js
@@ -9,7 +9,7 @@
  * Refactored from 1,559 LOC monolithic file into focused modules.
  */
 
-import { calculateAdaptiveThreshold } from '../adaptive-threshold-calculator.js';
+import { calculateAdaptiveThreshold, checkGatePassed, YELLOW_BAND_WIDTH } from '../adaptive-threshold-calculator.js';
 import { getPatternStats } from '../pattern-tracking.js';
 import {
   shouldSkipCodeValidation,
@@ -262,12 +262,17 @@ export async function validateGate2ExecToPlan(sd_id, supabase) {
     console.log(`\nAdaptive Threshold: ${requiredThreshold.toFixed(1)}%`);
     console.log(`Reasoning: ${thresholdResult.reasoning}`);
 
-    if (validation.score >= requiredThreshold) {
-      validation.passed = true;
-      console.log(`✅ GATE 2: PASSED (${validation.score} ≥ ${requiredThreshold.toFixed(1)} points)`);
+    const gateResult = checkGatePassed(validation.score, thresholdResult);
+    validation.passed = gateResult.passed;
+    validation.zone = gateResult.zone;
+
+    if (gateResult.zone === 'GREEN') {
+      console.log(`✅ GATE 2: PASSED (${validation.score} >= ${requiredThreshold.toFixed(1)} | GREEN)`);
+    } else if (gateResult.zone === 'YELLOW') {
+      console.log(`🟡 GATE 2: PASSED (${validation.score} >= ${gateResult.yellowThreshold} | YELLOW — within ${YELLOW_BAND_WIDTH}pt tolerance of ${requiredThreshold.toFixed(1)})`);
+      validation.warnings.push(`Score ${validation.score} is in YELLOW zone (${gateResult.yellowThreshold}-${requiredThreshold.toFixed(0)}). Passed with advisory.`);
     } else {
-      validation.passed = false;
-      console.log(`❌ GATE 2: FAILED (${validation.score} < ${requiredThreshold.toFixed(1)} points)`);
+      console.log(`🔴 GATE 2: FAILED (${validation.score} < ${gateResult.yellowThreshold} | RED)`);
     }
 
     if (validation.issues.length > 0) {

--- a/scripts/modules/traceability-validation/index.js
+++ b/scripts/modules/traceability-validation/index.js
@@ -12,7 +12,7 @@
  * Part of: SD-DESIGN-DATABASE-VALIDATION-001
  */
 
-import { calculateAdaptiveThreshold } from '../adaptive-threshold-calculator.js';
+import { calculateAdaptiveThreshold, checkGatePassed, YELLOW_BAND_WIDTH } from '../adaptive-threshold-calculator.js';
 import { getPatternStats } from '../pattern-tracking.js';
 import { resolveSDContext } from './utils.js';
 import { runPreflightChecks } from './preflight/index.js';
@@ -192,12 +192,17 @@ export async function validateGate3PlanToLead(sd_id, supabase, gate2Results = nu
     console.log(`\nAdaptive Threshold: ${requiredThreshold.toFixed(1)}%`);
     console.log(`Reasoning: ${thresholdResult.reasoning}`);
 
-    if (validation.score >= requiredThreshold) {
-      validation.passed = true;
-      console.log(`OK GATE 3: PASSED (${validation.score} >= ${requiredThreshold.toFixed(1)} points)`);
+    const gateResult = checkGatePassed(validation.score, thresholdResult);
+    validation.passed = gateResult.passed;
+    validation.zone = gateResult.zone;
+
+    if (gateResult.zone === 'GREEN') {
+      console.log(`OK GATE 3: PASSED (${validation.score} >= ${requiredThreshold.toFixed(1)} | GREEN)`);
+    } else if (gateResult.zone === 'YELLOW') {
+      console.log(`YELLOW GATE 3: PASSED (${validation.score} >= ${gateResult.yellowThreshold} | YELLOW — within ${YELLOW_BAND_WIDTH}pt tolerance of ${requiredThreshold.toFixed(1)})`);
+      validation.warnings.push(`Score ${validation.score} is in YELLOW zone (${gateResult.yellowThreshold}-${requiredThreshold.toFixed(0)}). Passed with advisory.`);
     } else {
-      validation.passed = false;
-      console.log(`FAIL GATE 3: FAILED (${validation.score} < ${requiredThreshold.toFixed(1)} points)`);
+      console.log(`FAIL GATE 3: FAILED (${validation.score} < ${gateResult.yellowThreshold} | RED)`);
     }
 
     if (validation.issues.length > 0) {

--- a/scripts/modules/workflow-roi-validation.js
+++ b/scripts/modules/workflow-roi-validation.js
@@ -11,7 +11,7 @@
 
 import { exec } from 'child_process';
 import { promisify } from 'util';
-import { calculateAdaptiveThreshold } from './adaptive-threshold-calculator.js';
+import { calculateAdaptiveThreshold, checkGatePassed, YELLOW_BAND_WIDTH } from './adaptive-threshold-calculator.js';
 import { getPatternStats } from './pattern-tracking.js';
 
 const execAsync = promisify(exec);
@@ -336,13 +336,19 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
     console.log(`\nAdaptive Threshold: ${requiredThreshold.toFixed(1)}%`);
     console.log(`Reasoning: ${thresholdResult.reasoning}`);
 
-    if (validation.score >= requiredThreshold) {
-      validation.passed = true;
-      console.log(`✅ GATE 4: PASSED (${validation.score} ≥ ${requiredThreshold.toFixed(1)} points)`);
+    const gateResult = checkGatePassed(validation.score, thresholdResult);
+    validation.passed = gateResult.passed;
+    validation.zone = gateResult.zone;
+
+    if (gateResult.zone === 'GREEN') {
+      console.log(`✅ GATE 4: PASSED (${validation.score} >= ${requiredThreshold.toFixed(1)} | GREEN)`);
+      console.log('\n🎉 ALL VALIDATION GATES COMPLETE - SD READY FOR FINAL APPROVAL');
+    } else if (gateResult.zone === 'YELLOW') {
+      console.log(`🟡 GATE 4: PASSED (${validation.score} >= ${gateResult.yellowThreshold} | YELLOW — within ${YELLOW_BAND_WIDTH}pt tolerance of ${requiredThreshold.toFixed(1)})`);
+      validation.warnings.push(`Score ${validation.score} is in YELLOW zone (${gateResult.yellowThreshold}-${requiredThreshold.toFixed(0)}). Passed with advisory.`);
       console.log('\n🎉 ALL VALIDATION GATES COMPLETE - SD READY FOR FINAL APPROVAL');
     } else {
-      validation.passed = false;
-      console.log(`❌ GATE 4: FAILED (${validation.score} < ${requiredThreshold.toFixed(1)} points)`);
+      console.log(`🔴 GATE 4: FAILED (${validation.score} < ${gateResult.yellowThreshold} | RED)`);
     }
 
     if (validation.issues.length > 0) {


### PR DESCRIPTION
## Summary
- Introduces GREEN/YELLOW/RED zone system for validation gate thresholds
- Scores within 5 points of threshold auto-pass with advisory warnings (YELLOW zone) instead of hard-failing
- Eliminates false negatives for frontend-only SDs where N/A backend checks cause near-miss scores (e.g., 82 vs 85)

## Changes
- `adaptive-threshold-calculator.js`: Added `YELLOW_BAND_WIDTH=5`, `yellowThreshold` in return value, zone-aware `checkGatePassed()`
- 4 gate validators (Gates 1-4): Replace inline `score >= threshold` with `checkGatePassed()` for zone-aware pass/fail

## Test plan
- [x] Unit test: 8 zone boundary cases all pass (GREEN/YELLOW/RED at thresholds 85 and 95)
- [ ] Integration: EXEC-TO-PLAN handoff with score 82/85 should show YELLOW PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)