### PR TITLE
feat: database-first vision/architecture document sections

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-MAN-INFRA-VENTURE-DATA-LIFECYCLE-001",
-  "expectedBranch": "feat/SD-MAN-INFRA-VENTURE-DATA-LIFECYCLE-001",
-  "createdAt": "2026-03-05T21:10:11.279Z",
+  "sdKey": "SD-LEO-INFRA-DATABASE-FIRST-VISION-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-DATABASE-FIRST-VISION-001",
+  "createdAt": "2026-03-06T22:15:07.977Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/database/migrations/20260306_document_section_schemas.sql
+++ b/database/migrations/20260306_document_section_schemas.sql
@@ -1,0 +1,91 @@
+-- Document Section Schemas
+-- SD-LEO-INFRA-DATABASE-FIRST-VISION-001
+--
+-- Registry of required/optional sections per document type.
+-- Drives validation and rendering for vision and architecture_plan documents.
+--
+-- NOTE: This migration was already applied to production on 2026-03-06.
+-- This file is kept for reference and future environment setup.
+
+-- ═══════════════════════════════════════════════════════════════
+-- 1. Create document_section_schemas table
+-- ═══════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS document_section_schemas (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_type TEXT NOT NULL CHECK (document_type IN ('vision', 'architecture_plan')),
+  domain TEXT, -- optional domain-specific override (NULL = universal)
+  section_key TEXT NOT NULL,
+  section_name TEXT NOT NULL,
+  description TEXT,
+  section_order INTEGER NOT NULL,
+  is_required BOOLEAN NOT NULL DEFAULT true,
+  min_content_length INTEGER DEFAULT 0,
+  json_schema JSONB, -- optional JSON schema for structured sections
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (document_type, domain, section_key)
+);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 2. Seed vision sections (10 required sections)
+-- ═══════════════════════════════════════════════════════════════
+
+INSERT INTO document_section_schemas (document_type, section_key, section_name, description, section_order, is_required, min_content_length)
+VALUES
+  ('vision', 'executive_summary',       'Executive Summary',       'High-level synthesis of the vision core thesis', 1, true, 100),
+  ('vision', 'problem_statement',       'Problem Statement',       'What problem this addresses, who is affected, current impact', 2, true, 100),
+  ('vision', 'personas',                'Personas',                'For each persona: name, goals, mindset, key activities', 3, true, 50),
+  ('vision', 'information_architecture','Information Architecture','Views, routes, data sources, navigation structure', 4, true, 50),
+  ('vision', 'key_decision_points',     'Key Decision Points',     'Critical decision/intervention points', 5, true, 50),
+  ('vision', 'integration_patterns',    'Integration Patterns',    'How this connects to existing systems', 6, true, 50),
+  ('vision', 'evolution_plan',          'Evolution Plan',          'Phasing strategy: what ships first, what comes later', 7, true, 50),
+  ('vision', 'out_of_scope',           'Out of Scope',            'Explicit boundaries — what this is NOT', 8, true, 30),
+  ('vision', 'ui_ux_wireframes',       'UI/UX Wireframes',        'ASCII mockups for key views or N/A for backend', 9, true, 20),
+  ('vision', 'success_criteria',       'Success Criteria',        'Measurable outcomes', 10, true, 50)
+ON CONFLICT (document_type, domain, section_key) DO NOTHING;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 3. Seed architecture_plan sections (8 required sections)
+-- ═══════════════════════════════════════════════════════════════
+
+INSERT INTO document_section_schemas (document_type, section_key, section_name, description, section_order, is_required, min_content_length)
+VALUES
+  ('architecture_plan', 'stack_and_repository',        'Stack & Repository Decisions',  'Technology choices, repo structure', 1, true, 50),
+  ('architecture_plan', 'legacy_deprecation',          'Legacy Deprecation Plan',       'What existing systems this replaces/modifies', 2, true, 30),
+  ('architecture_plan', 'route_and_component_structure','Route & Component Structure',  'Routes, components, module organization', 3, true, 50),
+  ('architecture_plan', 'data_layer',                  'Data Layer',                    'Supabase tables, queries, mutations, RLS', 4, true, 50),
+  ('architecture_plan', 'api_surface',                 'API Surface',                   'RPC functions, REST endpoints, governance', 5, true, 30),
+  ('architecture_plan', 'implementation_phases',       'Implementation Phases',         'Phase 1/2/3 with deliverables', 6, true, 50),
+  ('architecture_plan', 'testing_strategy',            'Testing Strategy',              'Unit, integration, E2E approach', 7, true, 30),
+  ('architecture_plan', 'risk_mitigation',             'Risk Mitigation',               'Technical risks with mitigation strategies', 8, true, 30)
+ON CONFLICT (document_type, domain, section_key) DO NOTHING;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 4. Add sections JSONB columns to existing tables
+-- ═══════════════════════════════════════════════════════════════
+
+ALTER TABLE eva_vision_documents
+  ADD COLUMN IF NOT EXISTS sections JSONB DEFAULT '{}'::jsonb;
+
+ALTER TABLE eva_architecture_plans
+  ADD COLUMN IF NOT EXISTS sections JSONB DEFAULT '{}'::jsonb;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 5. Add updated_at trigger
+-- ═══════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION update_document_section_schemas_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_document_section_schemas_updated_at ON document_section_schemas;
+CREATE TRIGGER set_document_section_schemas_updated_at
+  BEFORE UPDATE ON document_section_schemas
+  FOR EACH ROW
+  EXECUTE FUNCTION update_document_section_schemas_timestamp();

--- a/scripts/eva/document-section-registry.mjs
+++ b/scripts/eva/document-section-registry.mjs
@@ -1,0 +1,122 @@
+/**
+ * Document Section Registry
+ * SD-LEO-INFRA-DATABASE-FIRST-VISION-001
+ *
+ * Queries document_section_schemas for section definitions.
+ * Provides validation and key-mapping utilities for vision
+ * and architecture_plan document types.
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+
+let _supabase = null;
+function getSupabase() {
+  if (!_supabase) {
+    _supabase = createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+  }
+  return _supabase;
+}
+
+/**
+ * Get section schema definitions for a document type.
+ *
+ * @param {string} documentType - 'vision' or 'architecture_plan'
+ * @param {Object} [options]
+ * @param {Object} [options.supabase] - Supabase client override
+ * @param {boolean} [options.activeOnly=true] - Only return active sections
+ * @returns {Promise<Array>} Ordered array of section schema objects
+ */
+export async function getSectionSchema(documentType, options = {}) {
+  const { supabase: sbOverride, activeOnly = true } = options;
+  const supabase = sbOverride || getSupabase();
+
+  let query = supabase
+    .from('document_section_schemas')
+    .select('*')
+    .eq('document_type', documentType)
+    .order('section_order', { ascending: true });
+
+  if (activeOnly) {
+    query = query.eq('is_active', true);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to load section schema for ${documentType}: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Validate a sections object against the schema for a document type.
+ *
+ * @param {Object} sections - Object with section_key → content pairs
+ * @param {string} documentType - 'vision' or 'architecture_plan'
+ * @param {Object} [options]
+ * @param {Object} [options.supabase] - Supabase client override
+ * @returns {Promise<{valid: boolean, errors: string[], warnings: string[]}>}
+ */
+export async function validateSections(sections, documentType, options = {}) {
+  const schema = await getSectionSchema(documentType, options);
+  const errors = [];
+  const warnings = [];
+
+  for (const def of schema) {
+    const content = sections[def.section_key];
+
+    if (def.is_required && (!content || content.trim().length === 0)) {
+      errors.push(`Missing required section: ${def.section_name} (${def.section_key})`);
+      continue;
+    }
+
+    if (content && def.min_content_length && content.trim().length < def.min_content_length) {
+      warnings.push(
+        `Section "${def.section_name}" is short (${content.trim().length} chars, minimum ${def.min_content_length})`
+      );
+    }
+  }
+
+  // Check for unknown sections
+  const knownKeys = new Set(schema.map(s => s.section_key));
+  for (const key of Object.keys(sections)) {
+    if (!knownKeys.has(key)) {
+      warnings.push(`Unknown section key: ${key} (not in schema for ${documentType})`);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Build a mapping from section heading names to section keys.
+ * Used by the markdown parser to map "## Executive Summary" → "executive_summary".
+ *
+ * @param {string} documentType - 'vision' or 'architecture_plan'
+ * @param {Object} [options]
+ * @param {Object} [options.supabase] - Supabase client override
+ * @returns {Promise<Map<string, string>>} Map of lowercase heading → section_key
+ */
+export async function buildSectionKeyMapping(documentType, options = {}) {
+  const schema = await getSectionSchema(documentType, options);
+  const mapping = new Map();
+
+  for (const def of schema) {
+    // Map exact name (lowercase)
+    mapping.set(def.section_name.toLowerCase(), def.section_key);
+
+    // Map key with spaces (e.g., "executive summary" → "executive_summary")
+    mapping.set(def.section_key.replace(/_/g, ' '), def.section_key);
+
+    // Map key as-is
+    mapping.set(def.section_key, def.section_key);
+  }
+
+  return mapping;
+}

--- a/scripts/eva/markdown-to-sections-parser.mjs
+++ b/scripts/eva/markdown-to-sections-parser.mjs
@@ -1,0 +1,111 @@
+/**
+ * Markdown-to-Sections Parser
+ * SD-LEO-INFRA-DATABASE-FIRST-VISION-001
+ *
+ * Parses markdown content into structured sections using H2 headings
+ * as section boundaries. Maps headings to section keys using the
+ * document_section_schemas registry.
+ */
+
+/**
+ * Build a default heading-to-key mapping for common headings.
+ * Used when no database mapping is available (offline/fallback).
+ *
+ * @returns {Map<string, string>}
+ */
+export function buildDefaultMapping() {
+  const entries = [
+    // Vision sections
+    ['executive summary', 'executive_summary'],
+    ['problem statement', 'problem_statement'],
+    ['personas', 'personas'],
+    ['information architecture', 'information_architecture'],
+    ['key decision points', 'key_decision_points'],
+    ['integration patterns', 'integration_patterns'],
+    ['evolution plan', 'evolution_plan'],
+    ['out of scope', 'out_of_scope'],
+    ['ui/ux wireframes', 'ui_ux_wireframes'],
+    ['ui ux wireframes', 'ui_ux_wireframes'],
+    ['wireframes', 'ui_ux_wireframes'],
+    ['success criteria', 'success_criteria'],
+    // Architecture plan sections
+    ['stack & repository decisions', 'stack_and_repository'],
+    ['stack and repository decisions', 'stack_and_repository'],
+    ['stack & repository', 'stack_and_repository'],
+    ['legacy deprecation plan', 'legacy_deprecation'],
+    ['legacy deprecation', 'legacy_deprecation'],
+    ['route & component structure', 'route_and_component_structure'],
+    ['route and component structure', 'route_and_component_structure'],
+    ['data layer', 'data_layer'],
+    ['api surface', 'api_surface'],
+    ['implementation phases', 'implementation_phases'],
+    ['testing strategy', 'testing_strategy'],
+    ['risk mitigation', 'risk_mitigation'],
+  ];
+  return new Map(entries);
+}
+
+/**
+ * Parse markdown content into sections keyed by section_key.
+ *
+ * @param {string} content - Raw markdown content (may contain CRLF)
+ * @param {Map<string, string>} [headingToKeyMap] - Optional heading→key mapping
+ * @returns {Object} sections - { section_key: content_string, ... }
+ */
+export function parseMarkdownToSections(content, headingToKeyMap) {
+  const mapping = headingToKeyMap || buildDefaultMapping();
+
+  // Normalize CRLF to LF (Supabase stores CRLF on Windows)
+  const normalized = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  const lines = normalized.split('\n');
+  const sections = {};
+  let currentKey = null;
+  let currentLines = [];
+
+  for (const line of lines) {
+    // Match H2 headings: "## Heading Text"
+    const h2Match = line.match(/^##\s+(.+)$/);
+
+    if (h2Match) {
+      // Save previous section
+      if (currentKey) {
+        sections[currentKey] = currentLines.join('\n').trim();
+      }
+
+      // Resolve new section key
+      const heading = h2Match[1].trim().toLowerCase();
+      currentKey = mapping.get(heading) || null;
+
+      // If no mapping found, try fuzzy match (strip common prefixes/suffixes)
+      if (!currentKey) {
+        for (const [mapHeading, mapKey] of mapping.entries()) {
+          if (heading.includes(mapHeading) || mapHeading.includes(heading)) {
+            currentKey = mapKey;
+            break;
+          }
+        }
+      }
+
+      // If still no match, use a slug of the heading
+      if (!currentKey) {
+        currentKey = heading
+          .replace(/[^a-z0-9\s]/g, '')
+          .replace(/\s+/g, '_')
+          .substring(0, 50);
+      }
+
+      currentLines = [];
+    } else if (currentKey !== null) {
+      currentLines.push(line);
+    }
+    // Lines before any H2 heading are skipped (title, metadata, etc.)
+  }
+
+  // Save last section
+  if (currentKey) {
+    sections[currentKey] = currentLines.join('\n').trim();
+  }
+
+  return sections;
+}

--- a/scripts/eva/migrate-content-to-sections.mjs
+++ b/scripts/eva/migrate-content-to-sections.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * Migrate existing vision/architecture documents' content → sections JSONB.
+ * SD-LEO-INFRA-DATABASE-FIRST-VISION-001
+ *
+ * Usage:
+ *   node scripts/eva/migrate-content-to-sections.mjs [--dry-run]
+ *
+ * Reads the `content` column, parses into sections using the markdown parser,
+ * and writes the parsed sections to the `sections` JSONB column.
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+import { parseMarkdownToSections, buildDefaultMapping } from './markdown-to-sections-parser.mjs';
+import { buildSectionKeyMapping } from './document-section-registry.mjs';
+
+const dryRun = process.argv.includes('--dry-run');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function migrateTable(tableName, documentType, keyColumn) {
+  console.log(`\n--- ${tableName} (${documentType}) ---`);
+
+  // Build mapping from DB schema
+  let mapping;
+  try {
+    mapping = await buildSectionKeyMapping(documentType, { supabase });
+  } catch {
+    console.log('  Falling back to default mapping');
+    mapping = buildDefaultMapping();
+  }
+
+  const { data: rows, error } = await supabase
+    .from(tableName)
+    .select(`${keyColumn}, content, sections`);
+
+  if (error) {
+    console.error(`  Error loading ${tableName}: ${error.message}`);
+    return { success: 0, failed: 0 };
+  }
+
+  let success = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    const key = row[keyColumn];
+
+    // Skip if sections already populated
+    if (row.sections && Object.keys(row.sections).length > 0) {
+      console.log(`  ${key}: already has sections, skipping`);
+      success++;
+      continue;
+    }
+
+    if (!row.content || row.content.trim().length < 100) {
+      console.log(`  ${key}: content too short (${row.content?.length || 0} chars), skipping`);
+      failed++;
+      continue;
+    }
+
+    const sections = parseMarkdownToSections(row.content, mapping);
+    const sectionCount = Object.keys(sections).length;
+
+    if (sectionCount === 0) {
+      console.log(`  ${key}: no sections parsed, skipping`);
+      failed++;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(`  ${key}: would write ${sectionCount} sections`);
+      success++;
+      continue;
+    }
+
+    const { error: updateErr } = await supabase
+      .from(tableName)
+      .update({ sections })
+      .eq(keyColumn, key);
+
+    if (updateErr) {
+      console.log(`  ${key}: update failed - ${updateErr.message}`);
+      failed++;
+    } else {
+      console.log(`  ${key}: wrote ${sectionCount} sections`);
+      success++;
+    }
+  }
+
+  console.log(`  Result: ${success} success, ${failed} failed`);
+  return { success, failed };
+}
+
+console.log(`Migration mode: ${dryRun ? 'DRY RUN' : 'LIVE'}`);
+
+const visionResult = await migrateTable('eva_vision_documents', 'vision', 'vision_key');
+const archResult = await migrateTable('eva_architecture_plans', 'architecture_plan', 'plan_key');
+
+console.log('\n--- Summary ---');
+console.log(`Vision:  ${visionResult.success} success, ${visionResult.failed} failed`);
+console.log(`Arch:    ${archResult.success} success, ${archResult.failed} failed`);
+console.log(`Total:   ${visionResult.success + archResult.success} success, ${visionResult.failed + archResult.failed} failed`);

--- a/scripts/eva/sections-to-markdown-renderer.mjs
+++ b/scripts/eva/sections-to-markdown-renderer.mjs
@@ -1,0 +1,73 @@
+/**
+ * Sections-to-Markdown Renderer
+ * SD-LEO-INFRA-DATABASE-FIRST-VISION-001
+ *
+ * Renders structured sections back to markdown format.
+ * Provides summary utilities for CLI display.
+ */
+
+/**
+ * Render sections object to markdown string.
+ * Uses provided schema order, or falls back to key order.
+ *
+ * @param {Object} sections - { section_key: content_string, ... }
+ * @param {string} title - Document title for H1 heading
+ * @param {Array} [schema] - Optional ordered schema array from getSectionSchema
+ * @returns {string} Rendered markdown
+ */
+export function renderSectionsToMarkdown(sections, title, schema) {
+  const parts = [];
+
+  if (title) {
+    parts.push(`# ${title}\n`);
+  }
+
+  if (schema && schema.length > 0) {
+    // Render in schema order
+    for (const def of schema) {
+      const content = sections[def.section_key];
+      if (content) {
+        parts.push(`## ${def.section_name}\n\n${content}\n`);
+      }
+    }
+
+    // Render any extra sections not in schema
+    const schemaKeys = new Set(schema.map(s => s.section_key));
+    for (const [key, content] of Object.entries(sections)) {
+      if (!schemaKeys.has(key) && content) {
+        const heading = key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+        parts.push(`## ${heading}\n\n${content}\n`);
+      }
+    }
+  } else {
+    // No schema — render in insertion order
+    for (const [key, content] of Object.entries(sections)) {
+      if (content) {
+        const heading = key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+        parts.push(`## ${heading}\n\n${content}\n`);
+      }
+    }
+  }
+
+  return parts.join('\n');
+}
+
+/**
+ * Generate a compact summary of sections for CLI display.
+ *
+ * @param {Object} sections - { section_key: content_string, ... }
+ * @returns {string} Summary string like "8 sections (2.4 KB)"
+ */
+export function renderSectionsSummary(sections) {
+  if (!sections || typeof sections !== 'object') return 'no sections';
+
+  const keys = Object.keys(sections);
+  const totalSize = Object.values(sections)
+    .reduce((sum, v) => sum + (typeof v === 'string' ? v.length : 0), 0);
+
+  const sizeStr = totalSize >= 1024
+    ? `${(totalSize / 1024).toFixed(1)} KB`
+    : `${totalSize} B`;
+
+  return `${keys.length} sections (${sizeStr})`;
+}

--- a/scripts/eva/vision-command.mjs
+++ b/scripts/eva/vision-command.mjs
@@ -34,6 +34,9 @@ import { fileURLToPath } from 'url';
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import { getValidationClient } from '../../lib/llm/client-factory.js';
+import { parseMarkdownToSections, buildDefaultMapping } from './markdown-to-sections-parser.mjs';
+import { buildSectionKeyMapping, getSectionSchema, validateSections } from './document-section-registry.mjs';
+import { renderSectionsToMarkdown, renderSectionsSummary } from './sections-to-markdown-renderer.mjs';
 
 dotenv.config();
 
@@ -135,15 +138,62 @@ async function cmdExtract({ source }) {
   console.log(JSON.stringify(dimensions, null, 2));
 }
 
-async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dimensionsJson, brainstormId }) {
+async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dimensionsJson, brainstormId, sections: sectionsJson }) {
   if (!visionKey) { console.error('--vision-key is required'); process.exit(1); }
   if (!level || !['L1', 'L2'].includes(level)) { console.error('--level must be L1 or L2'); process.exit(1); }
-  if (!source) { console.error('--source is required'); process.exit(1); }
+  if (!source && !sectionsJson) { console.error('--source or --sections is required'); process.exit(1); }
 
-  const fullPath = resolve(REPO_ROOT, source);
-  if (!existsSync(fullPath)) { console.error(`File not found: ${fullPath}`); process.exit(1); }
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
-  const content = readFileSync(fullPath, 'utf8');
+  let content = '';
+  let sections = null;
+
+  // Sections-first path: --sections flag provides structured sections directly
+  if (sectionsJson) {
+    try {
+      sections = JSON.parse(sectionsJson);
+    } catch (e) {
+      console.error('Invalid --sections JSON:', e.message);
+      process.exit(1);
+    }
+
+    // Validate against schema
+    const validation = await validateSections(sections, 'vision', { supabase });
+    if (!validation.valid) {
+      console.error('Section validation errors:');
+      validation.errors.forEach(e => console.error(`  - ${e}`));
+      process.exit(1);
+    }
+    if (validation.warnings.length > 0) {
+      validation.warnings.forEach(w => console.warn(`  ⚠️  ${w}`));
+    }
+
+    // Render content from sections
+    const schema = await getSectionSchema('vision', { supabase });
+    content = renderSectionsToMarkdown(sections, visionKey, schema);
+  }
+
+  // Source file path: backward-compatible (auto-parse sections from markdown)
+  if (source) {
+    const fullPath = resolve(REPO_ROOT, source);
+    if (!existsSync(fullPath)) { console.error(`File not found: ${fullPath}`); process.exit(1); }
+    content = readFileSync(fullPath, 'utf8');
+
+    // Auto-parse sections from source markdown if not provided
+    if (!sections) {
+      let mapping;
+      try {
+        mapping = await buildSectionKeyMapping('vision', { supabase });
+      } catch {
+        mapping = buildDefaultMapping();
+      }
+      sections = parseMarkdownToSections(content, mapping);
+      const sectionCount = Object.keys(sections).length;
+      if (sectionCount > 0) {
+        console.log(`   Auto-parsed ${sectionCount} sections from source file`);
+      }
+    }
+  }
 
   let dimensions = null;
   if (dimensionsJson) {
@@ -157,8 +207,6 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
     console.error('\n🤖 No pre-extracted dimensions provided — extracting now...');
     dimensions = await extractDimensions(content);
   }
-
-  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
   if (dimensions) {
     const weightSum = dimensions.reduce((sum, d) => sum + (d.weight || 0), 0);
@@ -183,10 +231,11 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
     extracted_dimensions: dimensions,
     version,
     status: 'active',
-    chairman_approved: true, // approval already happened in skill before calling upsert
-    source_file_path: source,
+    chairman_approved: true,
+    source_file_path: source || null,
     created_by: 'eva-vision-command',
     addendums: existing?.addendums || [],
+    ...(sections && Object.keys(sections).length > 0 ? { sections } : {}),
     ...(ventureId ? { venture_id: ventureId } : {}),
     ...(brainstormId ? { source_brainstorm_id: brainstormId } : {}),
   };
@@ -206,6 +255,7 @@ async function cmdUpsert({ visionKey, level, source, ventureId, dimensions: dime
   console.log(`   Version: ${data.version}`);
   console.log(`   Status:  ${data.status}`);
   if (dimensions) console.log(`   Dimensions: ${dimensions.length} extracted`);
+  if (sections) console.log(`   Sections: ${renderSectionsSummary(sections)}`);
 }
 
 async function cmdAddendum({ visionKey, section, brainstormId }) {
@@ -276,17 +326,68 @@ async function cmdList() {
   const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
   const { data, error } = await supabase
     .from('eva_vision_documents')
-    .select('id, vision_key, level, version, status, chairman_approved, created_at')
+    .select('id, vision_key, level, version, status, chairman_approved, sections, created_at')
     .order('created_at', { ascending: false });
 
   if (error) { console.error('❌ List failed:', error.message); process.exit(1); }
   if (!data?.length) { console.log('No vision documents found.'); return; }
 
   console.log('\n📋 EVA Vision Documents:\n');
-  console.log('  ' + 'Key'.padEnd(28) + 'Level'.padEnd(6) + 'Ver'.padEnd(5) + 'Status'.padEnd(12) + 'Approved');
-  console.log('  ' + '-'.repeat(65));
+  console.log('  ' + 'Key'.padEnd(35) + 'Level'.padEnd(6) + 'Ver'.padEnd(5) + 'Status'.padEnd(10) + 'Sections');
+  console.log('  ' + '-'.repeat(75));
   for (const d of data) {
-    console.log('  ' + d.vision_key.padEnd(28) + d.level.padEnd(6) + String(d.version).padEnd(5) + d.status.padEnd(12) + (d.chairman_approved ? '✅' : '⏳'));
+    const sectionsInfo = renderSectionsSummary(d.sections);
+    console.log('  ' + d.vision_key.padEnd(35) + d.level.padEnd(6) + String(d.version).padEnd(5) + d.status.padEnd(10) + sectionsInfo);
+  }
+}
+
+async function cmdView({ visionKey, section: sectionKey, format }) {
+  if (!visionKey) { console.error('--vision-key is required'); process.exit(1); }
+
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data, error } = await supabase
+    .from('eva_vision_documents')
+    .select('vision_key, level, version, status, content, sections')
+    .eq('vision_key', visionKey)
+    .single();
+
+  if (error) { console.error(`❌ Not found: ${visionKey}`); process.exit(1); }
+
+  // JSON format output
+  if (format === 'json') {
+    console.log(JSON.stringify({
+      vision_key: data.vision_key,
+      level: data.level,
+      version: data.version,
+      status: data.status,
+      sections: data.sections || {},
+      sections_summary: renderSectionsSummary(data.sections),
+    }, null, 2));
+    return;
+  }
+
+  // View specific section
+  if (sectionKey) {
+    const content = data.sections?.[sectionKey];
+    if (!content) {
+      const available = data.sections ? Object.keys(data.sections).join(', ') : 'none';
+      console.error(`Section "${sectionKey}" not found. Available: ${available}`);
+      process.exit(1);
+    }
+    console.log(`\n## ${sectionKey}\n`);
+    console.log(content);
+    return;
+  }
+
+  // Full document view
+  console.log(`\n📄 ${data.vision_key} (${data.level}, v${data.version}, ${data.status})\n`);
+  if (data.sections && Object.keys(data.sections).length > 0) {
+    const schema = await getSectionSchema('vision', { supabase });
+    console.log(renderSectionsToMarkdown(data.sections, data.vision_key, schema));
+  } else if (data.content) {
+    console.log(data.content);
+  } else {
+    console.log('(no content)');
   }
 }
 
@@ -301,8 +402,9 @@ switch (subcommand) {
   case 'upsert':   await cmdUpsert(opts); break;
   case 'addendum': await cmdAddendum(opts); break;
   case 'list':     await cmdList(); break;
+  case 'view':     await cmdView(opts); break;
   default:
     console.error(`Unknown subcommand: ${subcommand}`);
-    console.error('Valid subcommands: extract, upsert, addendum, list');
+    console.error('Valid subcommands: extract, upsert, addendum, list, view');
     process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Add `document_section_schemas` registry table with 18 section definitions (10 vision, 8 architecture)
- Add `sections` JSONB column to `eva_vision_documents` and `eva_architecture_plans`
- Create parser, renderer, registry, and migration modules for structured document sections
- Refactor `vision-command.mjs` to support `--sections` flag for structured output

## Test plan
- [x] Migration applied to production database
- [x] 18 section schemas seeded (verified)
- [x] 3+ vision documents already migrated to sections format
- [x] CLI commands functional (vision:list, vision:view, archplan:list, archplan:view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)