### PR TITLE
fix: align guardrail metadata key checks with canonical arch_key

### DIFF
--- a/lib/governance/guardrail-registry.js
+++ b/lib/governance/guardrail-registry.js
@@ -132,7 +132,8 @@ const DEFAULT_GUARDRAILS = [
     check: (sdData) => {
       const sessionSdCount = sdData.sessionSdCount || 0;
       const hasOrchestratorPlan = sdData.metadata?.orchestrator_plan_ref
-        || sdData.metadata?.architecture_plan_ref;
+        || sdData.metadata?.architecture_plan_ref
+        || sdData.metadata?.arch_key;
 
       if (sessionSdCount >= 4 && !hasOrchestratorPlan) {
         return {
@@ -153,7 +154,8 @@ const DEFAULT_GUARDRAILS = [
       const childrenCount = sdData.childrenCount || 0;
       const isOrchestrator = childrenCount >= 3 || sdData.sd_type === 'orchestrator';
       const hasArchPlan = sdData.metadata?.architecture_plan_ref
-        || sdData.metadata?.arch_plan_key;
+        || sdData.metadata?.arch_plan_key
+        || sdData.metadata?.arch_key;
 
       if (isOrchestrator && !hasArchPlan) {
         return {


### PR DESCRIPTION
## Summary
- **GR-ORCHESTRATOR-ARCH-PLAN** and **GR-BULK-SD-BLOCK** guardrails checked for `architecture_plan_ref` and `arch_plan_key` — metadata keys that no script in the codebase ever writes
- The canonical key used by 10+ scripts (`leo-create-sd`, `create-orchestrator-from-plan`, `vision-scorer`, etc.) is `arch_key`
- Added `arch_key` to the OR checks in both guardrails so orchestrator SD creation via standard CLI works when `--arch-key` is provided

## Root Cause
RCA: PAT-METADATA-KEY-MISMATCH-001 — Guardrail was authored independently from SD creation scripts, and the author assumed key names instead of checking the existing codebase convention. No shared constants module exists for metadata field names.

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Verify `node scripts/leo-create-sd.js MANUAL orchestrator "Test" --arch-key ARCH-KEY` no longer blocked by guardrail
- [ ] Existing guardrail behavior preserved (still blocks when no arch key provided)

🤖 Generated with [Claude Code](https://claude.com/claude-code)