### PR TITLE
fix: use section-specific thresholds in Gate 2 validators

### DIFF
--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
@@ -23,7 +23,9 @@ export function registerGate2Validators(registry) {
     // Normalize section score (max 25) to 0-100 scale
     const rawScore = sectionA.score ?? scoreFromGateScores ?? 0;
     const finalScore = Math.round((rawScore / 25) * 100);
-    const passed = result?.passed ?? (finalScore >= 70);
+    // SD-LEARN-FIX-ADDRESS-PAT-AUTO-057: Use section-specific threshold,
+    // not overall result.passed which inherits cross-section failures
+    const passed = finalScore >= 70;
 
     return {
       passed,
@@ -54,7 +56,8 @@ export function registerGate2Validators(registry) {
     // Normalize section score (max 35) to 0-100 scale
     const rawScore = sectionB.score ?? scoreFromGateScores ?? 0;
     const finalScore = Math.round((rawScore / 35) * 100);
-    const passed = result?.passed ?? (finalScore >= 50); // Lower threshold for DB
+    // SD-LEARN-FIX-ADDRESS-PAT-AUTO-057: Use section-specific threshold
+    const passed = finalScore >= 50; // Lower threshold for DB
 
     return {
       passed,
@@ -85,7 +88,8 @@ export function registerGate2Validators(registry) {
     // Normalize section score (max 25) to 0-100 scale
     const rawScore = sectionC.score ?? scoreFromGateScores ?? 0;
     const finalScore = Math.round((rawScore / 25) * 100);
-    const passed = result?.passed ?? (finalScore >= 70);
+    // SD-LEARN-FIX-ADDRESS-PAT-AUTO-057: Use section-specific threshold
+    const passed = finalScore >= 70;
 
     return {
       passed,
@@ -116,7 +120,8 @@ export function registerGate2Validators(registry) {
     // Normalize section score (max 25) to 0-100 scale
     const rawScore = sectionD.score ?? scoreFromGateScores ?? 0;
     const finalScore = Math.round((rawScore / 25) * 100);
-    const passed = result?.passed ?? (finalScore >= 70);
+    // SD-LEARN-FIX-ADDRESS-PAT-AUTO-057: Use section-specific threshold
+    const passed = finalScore >= 70;
 
     return {
       passed,


### PR DESCRIPTION
## Summary
- Gate 2 section validators (A-D) were inheriting the overall `result.passed` value, causing cross-section failure propagation
- When any section failed, all sections reported as failed regardless of their individual scores
- Fixed by replacing `result?.passed ?? (finalScore >= N)` with direct `finalScore >= N` in all 4 section validators

## Root Cause
Pattern PAT-AUTO-953af5e1 ("Gate 2A:uiComponentsImplemented failed: score 80/100") was caused by section validators using `result.passed` from the overall Gate 2 result. This boolean reflects the aggregate pass/fail across ALL sections, so a failure in section B would cascade to sections A, C, and D.

## Changes
- `gate-2-implementation-fidelity.js`: 4 lines changed across sections A, B, C, D
- Each section now evaluates its own score against its own threshold independently

## Test plan
- [x] Verified each section uses `finalScore >= threshold` instead of `result?.passed`
- [x] Section A threshold: 70, Section B: 50, Section C: 70, Section D: 70
- [x] Pattern PAT-AUTO-953af5e1 resolved in database

🤖 Generated with [Claude Code](https://claude.com/claude-code)