### PR TITLE
feat: activate stage execution worker and wire venture pipeline

### DIFF
--- a/config/workers.json
+++ b/config/workers.json
@@ -13,6 +13,17 @@
       "description": "Polls stage_zero_requests table every 30s for chairman discovery/teardown requests"
     },
     {
+      "name": "stage-execution-worker",
+      "display_name": "Stage Execution Worker",
+      "command": "node scripts/start-stage-worker.js",
+      "cwd": ".",
+      "health_check": { "type": "pid" },
+      "pid_file": "stage-execution-worker.pid",
+      "log_prefix": "stage-worker",
+      "enabled": true,
+      "description": "Polls eva_ventures for active ventures, executes stage templates via Gemini, creates artifacts. Pauses at gate stages for chairman decisions."
+    },
+    {
       "name": "eva-workers",
       "display_name": "EVA Workers",
       "command": "node lib/eva/workers/index.js",

--- a/scripts/start-stage-worker.js
+++ b/scripts/start-stage-worker.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+/**
+ * Stage Execution Worker — Entry Point
+ *
+ * Starts the StageExecutionWorker that polls eva_ventures for active ventures,
+ * executes stage templates via Gemini, and creates venture_artifacts.
+ * Pauses at chairman gate stages for human decisions.
+ *
+ * Usage:
+ *   node scripts/start-stage-worker.js           # Continuous polling (30s default)
+ *   node scripts/start-stage-worker.js --once     # Single poll cycle then exit
+ *   node scripts/start-stage-worker.js --dry-run  # Skip persistence
+ *
+ * Environment:
+ *   SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *   STAGE_WORKER_POLL_INTERVAL_MS  (default: 30000)
+ *
+ * SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-017
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { createClient } from '@supabase/supabase-js';
+import { writeFileSync, unlinkSync } from 'fs';
+import { resolve } from 'path';
+
+const PID_FILE = resolve(process.cwd(), 'stage-execution-worker.pid');
+const ONCE_MODE = process.argv.includes('--once');
+const DRY_RUN = process.argv.includes('--dry-run');
+
+// ── Supabase Client ───────────────────────────────────────────────
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !supabaseKey) {
+  console.error('[stage-worker] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseKey);
+
+// ── PID File ──────────────────────────────────────────────────────
+
+function writePid() {
+  try {
+    writeFileSync(PID_FILE, String(process.pid));
+    console.log(`[stage-worker] PID ${process.pid} written to ${PID_FILE}`);
+  } catch (err) {
+    console.warn(`[stage-worker] Could not write PID file: ${err.message}`);
+  }
+}
+
+function removePid() {
+  try {
+    unlinkSync(PID_FILE);
+  } catch {
+    // File may not exist — that's fine
+  }
+}
+
+// ── Graceful Shutdown ─────────────────────────────────────────────
+
+let worker = null;
+
+async function shutdown(signal) {
+  console.log(`\n[stage-worker] Received ${signal}, shutting down...`);
+  if (worker) {
+    worker.stop();
+  }
+  removePid();
+  // Give in-flight operations a moment to finish
+  setTimeout(() => process.exit(0), 2000);
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+// ── Main ──────────────────────────────────────────────────────────
+
+async function main() {
+  // Dynamic import for ESM module
+  const { StageExecutionWorker } = await import('../lib/eva/stage-execution-worker.js');
+
+  const pollIntervalMs = parseInt(process.env.STAGE_WORKER_POLL_INTERVAL_MS || '30000', 10);
+
+  worker = new StageExecutionWorker({
+    supabase,
+    pollIntervalMs,
+    dryRun: DRY_RUN,
+    logger: {
+      info: (...args) => console.log('[stage-worker]', ...args),
+      warn: (...args) => console.warn('[stage-worker]', ...args),
+      error: (...args) => console.error('[stage-worker]', ...args),
+      debug: (...args) => {
+        if (process.env.DEBUG) console.debug('[stage-worker]', ...args);
+      },
+    },
+  });
+
+  writePid();
+
+  console.log(`[stage-worker] Starting Stage Execution Worker`);
+  console.log(`[stage-worker]   Poll interval: ${pollIntervalMs}ms`);
+  console.log(`[stage-worker]   Dry run: ${DRY_RUN}`);
+  console.log(`[stage-worker]   Once mode: ${ONCE_MODE}`);
+
+  if (ONCE_MODE) {
+    // Single poll cycle: call the internal poll method if available,
+    // otherwise start and stop after one interval
+    if (typeof worker._poll === 'function') {
+      await worker._poll();
+    } else {
+      worker.start();
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs + 5000));
+      worker.stop();
+    }
+    removePid();
+    console.log('[stage-worker] Single pass complete, exiting.');
+    process.exit(0);
+  } else {
+    worker.start();
+    console.log('[stage-worker] Worker running. Press Ctrl+C to stop.');
+  }
+}
+
+main().catch(err => {
+  console.error('[stage-worker] Fatal error:', err);
+  removePid();
+  process.exit(1);
+});

--- a/supabase/migrations/20260307_activate_stage_execution_worker.sql
+++ b/supabase/migrations/20260307_activate_stage_execution_worker.sql
@@ -1,0 +1,172 @@
+-- ============================================================================
+-- Activate Stage Execution Worker: Schema Alignment
+-- ============================================================================
+-- SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-017
+-- Purpose: Fix the eva_ventures schema gap so the Stage Execution Worker
+--          can discover and process ventures. Three changes:
+--   1. Add current_lifecycle_stage column to eva_ventures
+--   2. AFTER INSERT trigger on ventures → auto-create eva_ventures row
+--   3. AFTER UPDATE trigger on ventures → sync current_lifecycle_stage
+--   4. Backfill existing ventures into eva_ventures
+--
+-- Zero changes to stage-execution-worker.js (584 lines) — triggers make
+-- existing queries work.
+-- ============================================================================
+
+-- ============================================================================
+-- STEP 1: Add current_lifecycle_stage column to eva_ventures
+-- ============================================================================
+ALTER TABLE eva_ventures
+  ADD COLUMN IF NOT EXISTS current_lifecycle_stage INTEGER DEFAULT 1
+  CHECK (current_lifecycle_stage BETWEEN 1 AND 25);
+
+-- Partial index for the worker's polling query:
+-- SELECT * FROM eva_ventures WHERE status='active' AND orchestrator_state='idle'
+CREATE INDEX IF NOT EXISTS idx_eva_ventures_worker_poll
+  ON eva_ventures (current_lifecycle_stage)
+  WHERE status = 'active' AND orchestrator_state = 'idle';
+
+-- ============================================================================
+-- STEP 2: AFTER INSERT trigger — auto-create eva_ventures row
+-- ============================================================================
+CREATE OR REPLACE FUNCTION sync_ventures_to_eva_ventures_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO eva_ventures (
+    venture_id,
+    name,
+    status,
+    current_lifecycle_stage,
+    orchestrator_state,
+    created_at,
+    updated_at
+  ) VALUES (
+    NEW.id,
+    COALESCE(NEW.name, 'Unnamed Venture'),
+    COALESCE(NEW.status, 'active'),
+    COALESCE(NEW.current_lifecycle_stage, 1),
+    'idle',
+    NOW(),
+    NOW()
+  )
+  ON CONFLICT (venture_id) DO UPDATE SET
+    name = EXCLUDED.name,
+    status = EXCLUDED.status,
+    current_lifecycle_stage = EXCLUDED.current_lifecycle_stage,
+    updated_at = NOW();
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ventures_insert_sync_eva ON ventures;
+CREATE TRIGGER trg_ventures_insert_sync_eva
+  AFTER INSERT ON ventures
+  FOR EACH ROW
+  EXECUTE FUNCTION sync_ventures_to_eva_ventures_insert();
+
+-- ============================================================================
+-- STEP 3: AFTER UPDATE trigger — sync current_lifecycle_stage
+-- ============================================================================
+CREATE OR REPLACE FUNCTION sync_ventures_to_eva_ventures_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Only fire when current_lifecycle_stage actually changes
+  IF OLD.current_lifecycle_stage IS DISTINCT FROM NEW.current_lifecycle_stage THEN
+    UPDATE eva_ventures
+      SET current_lifecycle_stage = NEW.current_lifecycle_stage,
+          updated_at = NOW()
+      WHERE venture_id = NEW.id;
+  END IF;
+
+  -- Also sync status changes
+  IF OLD.status IS DISTINCT FROM NEW.status THEN
+    UPDATE eva_ventures
+      SET status = NEW.status,
+          updated_at = NOW()
+      WHERE venture_id = NEW.id;
+  END IF;
+
+  -- Also sync name changes
+  IF OLD.name IS DISTINCT FROM NEW.name THEN
+    UPDATE eva_ventures
+      SET name = NEW.name,
+          updated_at = NOW()
+      WHERE venture_id = NEW.id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ventures_update_sync_eva ON ventures;
+CREATE TRIGGER trg_ventures_update_sync_eva
+  AFTER UPDATE ON ventures
+  FOR EACH ROW
+  EXECUTE FUNCTION sync_ventures_to_eva_ventures_update();
+
+-- ============================================================================
+-- STEP 4: Backfill — create eva_ventures rows for all existing ventures
+-- ============================================================================
+INSERT INTO eva_ventures (
+  venture_id,
+  name,
+  status,
+  current_lifecycle_stage,
+  orchestrator_state,
+  created_at,
+  updated_at
+)
+SELECT
+  v.id,
+  COALESCE(v.name, 'Unnamed Venture'),
+  COALESCE(v.status, 'active'),
+  COALESCE(v.current_lifecycle_stage, 1),
+  'idle',
+  NOW(),
+  NOW()
+FROM ventures v
+WHERE NOT EXISTS (
+  SELECT 1 FROM eva_ventures ev WHERE ev.venture_id = v.id
+)
+ON CONFLICT (venture_id) DO UPDATE SET
+  current_lifecycle_stage = EXCLUDED.current_lifecycle_stage,
+  status = EXCLUDED.status,
+  name = EXCLUDED.name,
+  updated_at = NOW();
+
+-- Also update existing eva_ventures rows that are missing current_lifecycle_stage
+UPDATE eva_ventures ev
+SET current_lifecycle_stage = v.current_lifecycle_stage,
+    updated_at = NOW()
+FROM ventures v
+WHERE ev.venture_id = v.id
+  AND (ev.current_lifecycle_stage IS NULL OR ev.current_lifecycle_stage != v.current_lifecycle_stage);
+
+-- ============================================================================
+-- SUMMARY
+-- ============================================================================
+DO $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_count FROM eva_ventures;
+  RAISE NOTICE '';
+  RAISE NOTICE '============================================';
+  RAISE NOTICE 'Stage Execution Worker Activation - Complete';
+  RAISE NOTICE '============================================';
+  RAISE NOTICE 'Added: current_lifecycle_stage column to eva_ventures';
+  RAISE NOTICE 'Added: idx_eva_ventures_worker_poll partial index';
+  RAISE NOTICE 'Added: trg_ventures_insert_sync_eva trigger';
+  RAISE NOTICE 'Added: trg_ventures_update_sync_eva trigger';
+  RAISE NOTICE 'Backfilled: % eva_ventures rows', v_count;
+  RAISE NOTICE '';
+END $$;


### PR DESCRIPTION
## Summary
- Added `current_lifecycle_stage` column to `eva_ventures` with CHECK constraint (1-25) and partial index for worker polling
- Created AFTER INSERT/UPDATE triggers on `ventures` table to auto-sync rows into `eva_ventures`
- Registered `stage-execution-worker` in `config/workers.json` (enabled)
- Created `scripts/start-stage-worker.js` entry point with PID management, graceful shutdown, and `--once`/`--dry-run` flags
- Backfill migration for existing ventures (NichePulse at stage 7, Test Venture at stage 1)

SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-017

## Test plan
- [x] Migration applied to live Supabase — verified 2 eva_ventures rows with correct stages
- [x] Triggers verified: INSERT and UPDATE sync working
- [x] Worker entry point loads StageExecutionWorker class via dynamic import
- [ ] Run `node scripts/start-stage-worker.js --once --dry-run` to verify single poll cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)