### PR TITLE
chore: add brainstorm and planning docs for venture artifact pipeline

### DIFF
--- a/brainstorm/2026-03-06-venture-artifact-generation-system.md
+++ b/brainstorm/2026-03-06-venture-artifact-generation-system.md
@@ -1,0 +1,112 @@
+# Brainstorm: Venture Artifact Generation System
+
+## Metadata
+- **Date**: 2026-03-06
+- **Domain**: Architecture
+- **Phase**: Execute
+- **Mode**: Conversational
+- **Outcome Classification**: Needs Triage
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: NichePulse (7ff47c57-c4cc-4990-8be3-e1567ff1953d)
+
+---
+
+## Problem Statement
+
+The EHG venture lifecycle has 25 stages, each requiring specific artifacts (market_analysis, pricing_model, etc.) to advance. The auto-advance consumer (`useStageAutoAdvance`) polls for these artifacts and advances stages automatically — but **no code in the web UI creates these artifacts**. Ventures get stuck at their current stage indefinitely because nothing generates the required outputs.
+
+The user's investigation revealed this is NOT a greenfield problem: a complete CLI-based pipeline already exists (25 stage templates, StageExecutionWorker class, stage-zero queue processor) built by orchestrator SD `SD-LEO-ORCH-EVA-STAGE-PIPELINE-001` with 11 child SDs (all marked COMPLETED). However, the Stage Execution Worker is **not running** — it's not registered in `config/workers.json` and has no entry point script.
+
+## Discovery Summary
+
+### What Works (End-to-End Verified)
+1. **UI → Stage Zero**: "Find Me Opportunities" button → DiscoveryModeDialog (4 strategies: Trend Scanner, Democratization Finder, Capability Overhang, Nursery Re-eval) → `stage_zero_requests` table
+2. **Stage Zero Processing**: `stage-zero-queue-processor.js` polls every 30s, claims requests atomically, 5-min timeout
+3. **Venture Creation**: Stage Zero Orchestrator creates venture with `current_lifecycle_stage = 1`, persists to `ventures` table
+4. **Auto-Advance Consumer**: `useStageAutoAdvance` hook polls `venture_artifacts` every 5s, detects required artifacts, auto-advances non-gate stages; gate stages wait for chairman approval via `useGateApproval`
+5. **Gate Decision System**: `get_gate_decision_status` SECURITY DEFINER RPC, `usePendingGateDecision` for approve/reject mutations
+
+### What's Broken
+1. **Stage Execution Worker NOT RUNNING**: Class exists at `lib/eva/stage-execution-worker.js` but:
+   - Not registered in `config/workers.json`
+   - No entry point script
+   - Not started by LEO stack
+   - Ventures stuck at stage 1 indefinitely
+2. **Database Schema Mismatch**: Three different tables used by different components:
+   - `ventures` (used by stage-zero, web UI)
+   - `eva_ventures` (used by stage-execution-worker)
+   - `workflow_executions` (used by eva-workers)
+3. **Stages 17-25 are Simulations**: LLM imagines dev/QA/launch results rather than tracking real work. Infrastructure exists (lifecycle-sd-bridge.js, sd-completed.js) but analysis steps bypass it.
+
+### Existing Infrastructure (from CLI)
+- **25 stage templates** (`lib/eva/stage-templates/stage-XX.js`): 80-230 lines each, full JSON schemas, cross-stage contracts, validation
+- **StageExecutionWorker class**: Polling, gate handling, retry logic, operating mode boundaries (EVALUATION 1-5, STRATEGY 6-12, PLANNING 13-16, BUILD 17-21, LAUNCH 22-25)
+- **Chairman gates**: BLOCKING [3, 10, 22, 24], ADVISORY [5, 23]
+- **LLM Client Factory**: Gemini adapter with retry logic, token budgets per stage
+- **Stage Zero Orchestrator**: Venture creation, artifact persistence, chairman review
+
+### Key Prior Work
+- **Brainstorm**: `brainstorm/2026-03-04-eva-stage-execution-worker.md` — comprehensive analysis of the pipeline problem, led to orchestrator SD
+- **Orchestrator**: `SD-LEO-ORCH-EVA-STAGE-PIPELINE-001` with 11 children (A-K), all marked COMPLETED
+- **Documentation**: `docs/guides/workflow/25-stage-venture-lifecycle-overview.md`, `docs/guides/workflow/cli-venture-lifecycle/00-overview.md`
+
+## Analysis
+
+### Arguments For (Wiring Existing Infrastructure)
+- **90% of the code already exists** — 25 stage templates, StageExecutionWorker class, stage-zero pipeline, auto-advance consumer hooks all implemented
+- **Low effort, high impact** — registering the worker in `workers.json` and fixing DB schema alignment could unblock the entire 25-stage pipeline
+- **11 child SDs already "completed"** — the orchestrator delivered the components; only integration testing and runtime activation remain
+- **Auto-advance consumer already works** — `useStageAutoAdvance` polls artifacts and advances stages; it just needs artifacts to be created
+
+### Arguments Against
+- **"Completed" SDs may be hollow** — 11 children marked complete but the worker isn't running, suggesting validation gaps in the orchestrator
+- **Database schema mismatch is non-trivial** — three different tables (`ventures`, `eva_ventures`, `workflow_executions`) means wiring requires schema reconciliation, not just config changes
+- **Stages 17-25 are simulations** — LLM imagines dev/QA/launch results rather than tracking real work; shipping this as-is could mislead users about venture readiness
+- **No integration tests exist** — end-to-end flow from stage zero through all 25 stages has never been tested
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**:
+  1. Polling race condition: auto-advance consumer fires before artifact content is fully persisted (5s poll vs async DB write)
+  2. No failure propagation strategy — if stage 4 artifact generation fails, nothing prevents repeated retries consuming Gemini tokens
+  3. Duplicate `integration_plan` mapping (stages 15 and 19) is a symptom of deeper schema inconsistency
+- **Assumptions at Risk**:
+  1. Gemini API latency assumed fast enough for synchronous stage completion — later stages with 375K token budgets may take minutes
+  2. Context windows at later stages (stage 16+) may exceed Gemini's limits when cross-stage contracts pull from 15+ prior artifacts
+  3. `useEnsureArtifact` hooks are completely untested in production
+- **Worst Case**: Silent corruption cascade — malformed stage 3 artifact passes validation, propagates through cross-stage contracts, produces plausible-looking but wrong analysis through stages 4-10, only caught at kill gate 13 (if at all)
+
+### Visionary
+- **Opportunities**:
+  1. Artifact chain as an epistemic graph — each stage's output is a node, cross-stage contracts are edges, enabling "trace this conclusion back to its evidence" UI
+  2. Kill gate predictive triage — pre-score ventures at stage 2 using lightweight signals (market size, competition density) to predict gate 3 outcome, saving full pipeline execution for high-probability ventures
+  3. Tier-aware artifact compression as a competitive moat — tier 1 ventures get 10-stage summaries, tier 3 get full 25-stage deep analysis, creating a natural "upgrade path" for promising ideas
+- **Synergies**: Chairman UI rebuild, FK registry work, auto-advance consumer are all ready to consume pipeline output
+- **Upside Scenario**: Full automation from "Find opportunity" click to stage 10+ in under 20 minutes, with Chairman reviewing kill gates asynchronously
+
+### Pragmatist
+- **Feasibility**: 5/10 (wiring is moderate complexity due to schema mismatch)
+- **Resource Requirements**: 3-4 weeks, Gemini API credits (~$5-15/venture for full pipeline), content schema audit
+- **Constraints**:
+  1. Must audit existing `venture_artifacts` content before building on it (duplicate `integration_plan` bug)
+  2. Stage templates expect `eva_ventures` table but web UI uses `ventures` table — schema bridge needed
+  3. Auto-advance race condition: worker creates artifact → consumer detects → advances → worker picks up next stage (timing must be coordinated)
+- **Recommended Path**: Fix duplicates in STAGE_ARTIFACT_MAP → align DB schemas → register worker in workers.json → test single venture end-to-end → scale
+
+### Synthesis
+- **Consensus Points**: All three perspectives agree the infrastructure exists but isn't integrated. The schema mismatch is the critical blocker, not missing code.
+- **Tension Points**: Visionary sees opportunity to build epistemic graph features; Pragmatist says "just wire it up first"; Challenger warns the wiring may expose deeper issues.
+- **Composite Risk**: Medium — infrastructure exists but integration testing is zero, and "completed" SDs that didn't actually deliver raise process concerns.
+
+## Open Questions
+1. Should we run `/heal sd` on `SD-LEO-ORCH-EVA-STAGE-PIPELINE-001` to verify the 11 child SDs actually delivered?
+2. Can the `stage-execution-worker.js` be pointed at the `ventures` table instead of `eva_ventures`, or do we need a schema bridge?
+3. Should stages 17-25 (simulations) be clearly labeled as "AI Projections" in the UI to set expectations?
+4. What's the Gemini token budget per venture, and what's the cost at scale (100 ventures)?
+
+## Suggested Next Steps
+1. **Run `/heal sd --sd-id SD-LEO-ORCH-EVA-STAGE-PIPELINE-001`** — verify the 11 child SDs actually delivered what they promised
+2. **Audit the schema mismatch** — determine if `ventures` ↔ `eva_ventures` can be unified or needs a bridge table
+3. **Create a targeted wiring SD** — register worker, fix schema alignment, add entry point script, test with NichePulse
+4. **Do NOT brainstorm a new system** — the system exists; the problem is integration, not design

--- a/docs/plans/venture-artifact-pipeline-wiring-architecture.md
+++ b/docs/plans/venture-artifact-pipeline-wiring-architecture.md
@@ -1,0 +1,113 @@
+# Architecture Plan: Venture Artifact Pipeline Wiring
+
+## Stack & Repository Decisions
+
+- **Backend (EHG_Engineer)**: Node.js worker process, existing LLM Client Factory with Gemini adapter
+- **Frontend (ehg)**: No changes needed — auto-advance hooks already consume `venture_artifacts`
+- **Database**: Supabase PostgreSQL — schema reconciliation between `ventures` and `eva_ventures`
+- **AI Engine**: Google Gemini API via existing `lib/llm/client-factory.js` adapter
+
+## Legacy Deprecation Plan
+
+- **`eva_ventures` table**: Either drop (if worker can be pointed at `ventures`) or create a view that maps `ventures` → `eva_ventures` schema
+- **`workflow_executions` table**: Used by disabled `eva-workers` — leave as-is, do not integrate
+- **`lib/eva/workers/index.js`**: Disabled alternative worker system — leave disabled, use `stage-execution-worker.js` instead
+
+## Route & Component Structure
+
+No new routes or components. Existing architecture:
+
+**Backend Modules (EHG_Engineer):**
+- `lib/eva/stage-execution-worker.js` — Main worker class (EXISTS, needs activation)
+- `lib/eva/stage-templates/stage-XX.js` — 25 stage templates (EXIST)
+- `scripts/stage-zero-queue-processor.js` — Stage zero handler (RUNNING)
+- `config/workers.json` — Worker registry (NEEDS UPDATE)
+
+**Frontend Hooks (ehg):**
+- `src/hooks/useStageAutoAdvance.ts` — Auto-advance consumer (WORKING)
+- `src/hooks/useVentureWorkflow.ts` — Stage work queries (WORKING)
+- `src/hooks/useGateApproval.ts` — Gate approval polling (WORKING)
+- `src/hooks/usePendingGateDecision.ts` — Gate decision mutations (WORKING)
+
+## Data Layer
+
+### Schema Reconciliation
+
+**Problem**: `stage-execution-worker.js` imports from modules that query `eva_ventures`. The web UI and stage-zero processor use `ventures`.
+
+**Approach**: Modify the worker's data access layer to read from `ventures` table instead of `eva_ventures`. Key column mapping:
+- `eva_ventures.venture_id` → `ventures.id`
+- `eva_ventures.current_stage` → `ventures.current_lifecycle_stage`
+- `eva_ventures.status` → `ventures.status`
+- `eva_ventures.tier` → `ventures.tier`
+
+**Artifacts**: Worker writes to `venture_artifacts` table (same table the frontend reads from). Schema:
+- `venture_id` (FK to ventures.id)
+- `lifecycle_stage` (integer)
+- `artifact_type` (matches STAGE_ARTIFACT_MAP)
+- `content` (JSONB — schema defined by stage template)
+- `is_current` (boolean — only latest version matters)
+
+### RLS Considerations
+- Worker runs server-side with service role key — no RLS concerns for writes
+- Frontend reads `venture_artifacts` via authenticated client — existing RLS policies apply
+
+## API Surface
+
+No new RPCs needed. Existing RPCs used:
+- `bootstrap_venture_workflow` — creates stage work rows (already called by frontend)
+- `advance_venture_stage` — advances stage (called by auto-advance hook)
+- `get_gate_decision_status` — checks gate approval (called by useGateApproval)
+- `approve_chairman_decision` / `reject_chairman_decision` — gate actions (called by usePendingGateDecision)
+
+**Worker → Database**: Direct Supabase client queries (not RPCs) for:
+- Reading ventures needing processing
+- Writing artifacts
+- Creating chairman decisions at gate stages
+- Updating venture stage state
+
+## Implementation Phases
+
+### Phase 1: Worker Activation (1-2 days)
+1. Audit `stage-execution-worker.js` imports to identify all `eva_ventures` references
+2. Create adapter layer or modify queries to read from `ventures` table
+3. Add worker to `config/workers.json` with appropriate settings
+4. Create entry point script (`scripts/start-stage-worker.js`) or integrate into LEO stack
+5. Test: Start worker, verify it picks up NichePulse at current stage
+
+### Phase 2: End-to-End Integration Test (1-2 days)
+1. Create test venture via "Find Me Opportunities" UI flow
+2. Verify stage-zero processor creates venture at stage 1
+3. Verify worker picks up venture, executes stage 1 template, creates artifact
+4. Verify auto-advance consumer detects artifact and advances to stage 2
+5. Continue through stages 1-3 (first kill gate)
+6. Verify gate pause — worker stops, Chairman UI shows pending decision
+7. Approve gate, verify pipeline resumes
+
+### Phase 3: STAGE_ARTIFACT_MAP Fix (0.5 day)
+1. Fix duplicate `integration_plan` mapping (stages 15 and 19)
+2. Verify all 25 stage mappings match stage template output types
+3. Update `useVentureArtifacts.ts` if needed
+
+### Phase 4: Observability (1-2 days)
+1. Add worker health check endpoint
+2. Log pipeline progress to `workflow_executions` or new tracking table
+3. Surface pipeline status in venture detail page (optional)
+
+## Testing Strategy
+
+- **Unit**: Verify stage template schemas match `venture_artifacts` content expectations
+- **Integration**: End-to-end test with a real venture (NichePulse or new test venture)
+- **Gate Testing**: Verify all 7 gate stages (3, 5, 10, 13, 16, 22, 23) correctly pause and resume
+- **Failure Testing**: Kill Gemini API mid-pipeline, verify retry logic and state consistency
+- **Race Condition**: Verify auto-advance doesn't fire before artifact is fully persisted (5s poll interval should provide sufficient margin)
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|------|-----------|
+| Schema mismatch deeper than expected | Start with read-only audit of worker imports before any code changes |
+| Gemini API rate limits at scale | Existing LLM Client Factory has retry logic; add per-venture rate limiting if needed |
+| Auto-advance race condition | Worker writes artifact → waits 2s → updates stage status; consumer polls every 5s |
+| "Completed" child SDs didn't deliver | Run `/heal sd` on orchestrator to verify; treat as sunk cost if hollow |
+| Stages 17-25 produce misleading output | Label as "AI Projections" in artifact metadata; defer to Phase 4 |

--- a/docs/plans/venture-artifact-pipeline-wiring-vision.md
+++ b/docs/plans/venture-artifact-pipeline-wiring-vision.md
@@ -1,0 +1,86 @@
+# Vision: Venture Artifact Pipeline Wiring
+
+## Executive Summary
+
+The EHG venture lifecycle requires AI-generated artifacts at each of its 25 stages to advance ventures automatically through the pipeline. A complete CLI-based artifact generation system already exists — 25 stage templates, a StageExecutionWorker class, and a stage-zero queue processor — built by orchestrator SD `SD-LEO-ORCH-EVA-STAGE-PIPELINE-001` with 11 child SDs.
+
+However, the Stage Execution Worker is not running. It's not registered in `config/workers.json`, has no entry point script, and is not started by the LEO stack. Additionally, a database schema mismatch exists between the `ventures` table (used by the web UI and stage-zero processor) and the `eva_ventures` table (expected by the stage execution worker). This vision addresses wiring the existing infrastructure into a functioning end-to-end pipeline.
+
+The goal is NOT to build new artifact generation capabilities — those exist. The goal is to connect the existing components so that a venture created via "Find Me Opportunities" automatically progresses through stages 1-25 (pausing at chairman gates) without manual intervention.
+
+## Problem Statement
+
+Ventures created through the Chairman UI's "Find Me Opportunities" flow get stuck at stage 1 indefinitely. The stage-zero queue processor successfully creates the venture and bootstraps stage work, but no process picks up the venture to execute stages 1 through 25. The auto-advance consumer (`useStageAutoAdvance`) on the frontend correctly polls for artifacts and advances stages — but no artifacts are ever created because the producer (Stage Execution Worker) isn't running.
+
+This affects all ventures in the system. NichePulse (currently at stage 7) was manually advanced through stages. No venture has ever completed the automated pipeline end-to-end.
+
+## Personas
+
+**Chairman (Rick)**: Primary decision-maker who reviews kill/promotion gates. Wants ventures to progress automatically between gates, surfacing only decision points that require human judgment. Currently has to manually advance stages, defeating the purpose of the 25-stage automation.
+
+**EVA (AI Orchestrator)**: The automated system executing stage templates, generating artifacts via Gemini API, and validating cross-stage contracts. Currently exists as code but never runs — needs activation and schema alignment.
+
+**Venture (Entity)**: A business opportunity progressing through the lifecycle. Currently stuck at whatever stage it was manually set to. Needs continuous automated evaluation from stage 1 through stage 25 (or kill gate termination).
+
+## Information Architecture
+
+**Data Flow**: `stage_zero_requests` → Stage Zero Processor → `ventures` table → Stage Execution Worker → `venture_artifacts` → Auto-Advance Consumer → stage progression → Chairman Gate (if applicable) → next stage
+
+**Current Break Point**: Between `ventures` table creation (stage-zero output) and Stage Execution Worker pickup. The worker expects `eva_ventures` but ventures live in `ventures`.
+
+**Key Tables**:
+- `ventures` — source of truth for venture state (used by web UI, stage-zero)
+- `venture_stage_work` — tracks per-stage status (bootstrapped by RPC)
+- `venture_artifacts` — stores generated artifacts (consumed by auto-advance)
+- `chairman_decisions` — gate decisions (created at gate entry, approved/rejected by Chairman)
+- `eva_ventures` — parallel venture table used by CLI pipeline (SCHEMA MISMATCH)
+- `workflow_executions` — execution tracking (used by disabled eva-workers)
+
+**Routes**: No new routes needed. Existing venture detail page already has auto-advance wired.
+
+## Key Decision Points
+
+1. **Schema Reconciliation Strategy**: Unify `ventures` and `eva_ventures` into one table, OR create a bridge/view that lets the worker read from `ventures`
+2. **Worker Activation Method**: Register in `workers.json` for LEO stack management, OR create standalone entry point
+3. **Simulation Stage Handling (17-25)**: Label as "AI Projections" in UI, OR defer activation to a later phase
+4. **Failure Recovery**: What happens when Gemini API fails mid-pipeline — retry from failed stage, or require manual intervention
+
+## Integration Patterns
+
+- **Stage Execution Worker → ventures table**: Worker polls for ventures with `current_lifecycle_stage` needing processing (currently polls `eva_ventures` — needs redirect)
+- **Worker → Gemini API**: Via LLM Client Factory with existing retry logic and token budgets per stage
+- **Worker → venture_artifacts**: Inserts generated artifacts, triggering auto-advance consumer detection
+- **Worker → chairman_decisions**: At gate stages, creates pending decision and waits for Chairman approval before advancing
+- **config/workers.json → LEO stack**: Worker registry controls which processes the stack manages (start/stop/restart)
+
+## Evolution Plan
+
+**Phase 1 (Wiring)**: Register worker, fix schema alignment, test with NichePulse. Target: ventures auto-advance through non-gate stages.
+
+**Phase 2 (Gate Integration)**: Verify chairman gate flow works end-to-end — worker pauses, decision surfaces in Chairman UI, approval triggers auto-advance.
+
+**Phase 3 (Observability)**: Add pipeline status to venture detail page — show which stage is executing, estimated completion, error states.
+
+**Phase 4 (Simulation Handling)**: Address stages 17-25 — either label as projections or build real integrations for build/test/launch tracking.
+
+## Out of Scope
+
+- Building new stage templates (all 25 exist)
+- Changing the auto-advance consumer logic (already working)
+- Modifying the Chairman gate decision UI (already working)
+- Real build/test/launch tracking for stages 17-25 (simulation is acceptable for now)
+- Multi-tenant or multi-user concerns (single Chairman model)
+
+## UI/UX Wireframes
+
+N/A — no new UI components needed. The existing venture detail page with auto-advance badges and chairman gate buttons already handles the display. The only visible change will be that ventures actually progress through stages automatically.
+
+## Success Criteria
+
+1. A venture created via "Find Me Opportunities" automatically progresses from stage 1 through stage 3 (first kill gate) without manual intervention
+2. Stage Execution Worker is registered in `config/workers.json` and starts/stops with LEO stack
+3. Generated artifacts appear in `venture_artifacts` table with correct `venture_id`, `lifecycle_stage`, and `artifact_type`
+4. Auto-advance consumer detects artifacts and advances stages within 10 seconds of artifact creation
+5. Chairman gate stages (3, 5, 10, 13, 16, 22, 23, 24) pause pipeline execution until Chairman approves
+6. NichePulse can be run through the full tier-1 pipeline (stages 1-10) as integration test
+7. No schema migration required — worker reads from `ventures` table (or view) instead of `eva_ventures`


### PR DESCRIPTION
## Summary
- Brainstorm session output for Venture Artifact Generation System
- Vision document registered in EVA (VISION-VENTURE-ARTIFACT-PIPELINE-L2-001)
- Architecture plan registered in EVA (ARCH-VENTURE-ARTIFACT-PIPELINE-001)

## Test plan
- [x] Documents written and saved
- [x] Registered in EVA for HEAL tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)