### PR TITLE
feat: wire Stage Execution Worker to ventures table (schema alignment)

### DIFF
--- a/lib/eva/orchestrator-state-machine.js
+++ b/lib/eva/orchestrator-state-machine.js
@@ -105,7 +105,7 @@ export async function acquireProcessingLock(supabase, ventureId, options = {}) {
   try {
     // Atomic conditional update: only succeed if current state is idle
     const { data, error } = await supabase
-      .from('eva_ventures')
+      .from('ventures')
       .update({
         orchestrator_state: ORCHESTRATOR_STATES.PROCESSING,
         orchestrator_lock_id: lockId,
@@ -119,7 +119,7 @@ export async function acquireProcessingLock(supabase, ventureId, options = {}) {
     if (error || !data) {
       // Check current state for diagnostics
       const { data: current } = await supabase
-        .from('eva_ventures')
+        .from('ventures')
         .select('orchestrator_state')
         .eq('id', ventureId)
         .single();
@@ -172,7 +172,7 @@ export async function releaseProcessingLock(supabase, ventureId, options = {}) {
 
   try {
     let query = supabase
-      .from('eva_ventures')
+      .from('ventures')
       .update({
         orchestrator_state: targetState,
         orchestrator_lock_id: null,
@@ -217,7 +217,7 @@ export async function getOrchestratorState(supabase, ventureId) {
 
   try {
     const { data, error } = await supabase
-      .from('eva_ventures')
+      .from('ventures')
       .select('orchestrator_state, orchestrator_lock_id, orchestrator_lock_acquired_at')
       .eq('id', ventureId)
       .single();
@@ -256,7 +256,7 @@ export async function markCompleted(supabase, ventureId, options = {}) {
 
   try {
     let query = supabase
-      .from('eva_ventures')
+      .from('ventures')
       .update({
         orchestrator_state: ORCHESTRATOR_STATES.COMPLETED,
         orchestrator_lock_id: null,

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -7,7 +7,7 @@
  * through stages 1-25, pausing at chairman gates and blocking boundaries.
  *
  * Key responsibilities:
- *   - Poll eva_ventures for ventures needing stage advancement
+ *   - Poll ventures table for ventures needing stage advancement
  *   - Acquire/release orchestrator processing locks (concurrency safety)
  *   - Handle chairman gate blocking (stages 3, 5, 10, 22, 24)
  *   - Enforce operating mode boundaries (EVALUATION → STRATEGY → PLANNING → BUILD → LAUNCH)
@@ -174,7 +174,7 @@ export class StageExecutionWorker {
     try {
       // Mark venture as killed in DB
       const { error } = await this._supabase
-        .from('eva_ventures')
+        .from('ventures')
         .update({
           status: 'killed',
           orchestrator_state: ORCHESTRATOR_STATES.KILLED_AT_REALITY_GATE,
@@ -257,7 +257,7 @@ export class StageExecutionWorker {
   }
 
   /**
-   * Query eva_ventures for ventures ready for stage advancement.
+   * Query ventures table for ventures ready for stage advancement.
    *
    * Ready means: status=active, orchestrator_state=idle, current_lifecycle_stage < 25.
    *
@@ -266,7 +266,7 @@ export class StageExecutionWorker {
   async _pollForWork() {
     try {
       const { data, error } = await this._supabase
-        .from('eva_ventures')
+        .from('ventures')
         .select('id, name, current_lifecycle_stage')
         .eq('status', 'active')
         .eq('orchestrator_state', ORCHESTRATOR_STATES.IDLE)
@@ -320,8 +320,8 @@ export class StageExecutionWorker {
     try {
       // 3. Get current stage
       const { data: venture, error: fetchError } = await this._supabase
-        .from('eva_ventures')
-        .select('current_lifecycle_stage, name, venture_id')
+        .from('ventures')
+        .select('current_lifecycle_stage, name')
         .eq('id', ventureId)
         .single();
 
@@ -371,8 +371,7 @@ export class StageExecutionWorker {
         }
 
         // Execute the stage with retries
-        // processStage expects ventures.id (queries ventures table), not eva_ventures.id
-        const result = await this._executeWithRetry(venture.venture_id || ventureId, currentStage);
+        const result = await this._executeWithRetry(ventureId, currentStage);
         lastResult = result;
 
         if (!result || result.status === 'failed') {
@@ -502,7 +501,7 @@ export class StageExecutionWorker {
     try {
       // Fetch brief data for the decision
       const { data: venture } = await this._supabase
-        .from('eva_ventures')
+        .from('ventures')
         .select('name, metadata')
         .eq('id', ventureId)
         .single();

--- a/supabase/migrations/20260307_add_orchestrator_columns_to_ventures.sql
+++ b/supabase/migrations/20260307_add_orchestrator_columns_to_ventures.sql
@@ -1,0 +1,27 @@
+-- Migration: Add orchestrator state columns to ventures table
+-- SD: SD-LEO-INFRA-VENTURE-ARTIFACT-PIPELINE-001
+--
+-- The Stage Execution Worker needs orchestrator_state, orchestrator_lock_id,
+-- and orchestrator_lock_acquired_at to manage processing locks. These columns
+-- existed on eva_ventures but not on ventures (the table the UI uses).
+-- This migration adds them so the worker can poll ventures directly.
+
+ALTER TABLE ventures
+  ADD COLUMN IF NOT EXISTS orchestrator_state TEXT DEFAULT 'idle',
+  ADD COLUMN IF NOT EXISTS orchestrator_lock_id UUID,
+  ADD COLUMN IF NOT EXISTS orchestrator_lock_acquired_at TIMESTAMPTZ;
+
+-- Sync existing eva_ventures orchestrator state to ventures (if any)
+UPDATE ventures v
+SET
+  orchestrator_state = ev.orchestrator_state,
+  orchestrator_lock_id = ev.orchestrator_lock_id,
+  orchestrator_lock_acquired_at = ev.orchestrator_lock_acquired_at
+FROM eva_ventures ev
+WHERE v.id = ev.venture_id
+  AND ev.orchestrator_state IS NOT NULL;
+
+-- Add index for worker polling query performance
+CREATE INDEX IF NOT EXISTS idx_ventures_orchestrator_polling
+  ON ventures (status, orchestrator_state, current_lifecycle_stage)
+  WHERE status = 'active' AND orchestrator_state = 'idle';


### PR DESCRIPTION
## Summary
- Replace all `eva_ventures` references with `ventures` table in stage-execution-worker.js (4 refs) and orchestrator-state-machine.js (5 refs)
- Remove `venture_id` indirection — worker now uses ventures.id directly
- Add migration: `orchestrator_state`, `orchestrator_lock_id`, `orchestrator_lock_acquired_at` columns on ventures table
- Fixes schema mismatch where UI creates ventures in `ventures` but worker polled empty `eva_ventures`

## SD
SD-LEO-INFRA-VENTURE-ARTIFACT-PIPELINE-001

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Zero `eva_ventures` references in worker code path (grep verified)
- [x] Module imports cleanly
- [x] Migration executed on database (orchestrator columns present on ventures)
- [ ] Live worker polling test (requires Gemini API — deferred to post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)