### PR TITLE
feat: brainstorm-to-SD pipeline enforcement gate

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -857,6 +857,22 @@ supabase.from('brainstorm_sessions')
 
 ---
 
+## Step 9.6: Outcome Auto-Upgrade (SD-LEO-INFRA-BRAINSTORM-SD-PIPELINE-001)
+
+**After Step 9.5E validates both vision_key and plan_key exist**, check if the outcome_type should be upgraded:
+
+- If `outcome_type` is **"Needs Triage"** AND both vision_key and plan_key are captured:
+  - Auto-upgrade `outcome_type` to **"Ready for SD"**
+  - Set `outcome_auto_classified` to `true` in the brainstorm session record
+  - Log: `"Step 9.6: Auto-upgraded outcome from 'needs_triage' to 'ready_for_sd' — vision+arch artifacts exist"`
+  - **Rationale**: If the brainstorm produced complete vision and architecture documents, the outcome is substantive enough for SD creation regardless of the LLM classification.
+
+- If `outcome_type` is **"Potential Conflict"**: Do NOT auto-upgrade. Conflicts require human review even when artifacts exist.
+
+- All other outcome types: No change needed.
+
+---
+
 ## Step 10: Session Retrospective
 
 After saving the document, record the session for self-improvement:
@@ -941,7 +957,32 @@ This path should NOT occur under normal operation — Step 9.5 is mandatory for 
 If it does occur (e.g., EVA registration failed), prompt the user to fix the registration issue before creating SDs.
 Do NOT offer a "Create SD without vision/arch" option — that is an anti-pattern.
 
-**If outcome is "Needs Triage" or "Potential Conflict":**
+**If outcome is "Needs Triage" or "Potential Conflict" WITH vision/arch keys registered (Step 9.5E completed):**
+
+Step 9.6 may have auto-upgraded "Needs Triage" to "Ready for SD" — but if the outcome remains
+"Needs Triage" (e.g., Step 9.6 was skipped) or is "Potential Conflict" (never auto-upgraded),
+AND vision_key + plan_key exist from Step 9.5E, offer SD creation alongside triage options:
+
+```
+question: "This outcome has vision and architecture documents registered. What would you like to do?"
+header: "Next Steps"
+options:
+  - label: "Create SDs (Recommended)"
+    description: "Vision+arch artifacts exist — create Strategic Directives from this brainstorm"
+  - label: "Triangulate"
+    description: "Get external AI opinions on the unresolved questions"
+  - label: "Brainstorm again"
+    description: "Run another brainstorm with more specific scope"
+  - label: "Capture pattern"
+    description: "Record insights as learnings via /learn"
+  - label: "Done for now"
+    description: "End brainstorming session"
+```
+
+When "Create SDs (Recommended)" is selected, follow the same auto-chaining as "Ready for SD":
+invoke /eva review with the registered keys, then invoke /leo create with vision/arch traceability.
+
+**If outcome is "Needs Triage" or "Potential Conflict" WITHOUT vision/arch keys:**
 ```
 question: "This needs further analysis. What would you like to do?"
 header: "Next Steps"

--- a/scripts/detect-orphan-visions.js
+++ b/scripts/detect-orphan-visions.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * FR-004: Detect Orphan Visions
+ * SD-LEO-INFRA-BRAINSTORM-SD-PIPELINE-001
+ *
+ * Queries v_orphan_visions to surface vision/architecture documents
+ * created from brainstorms that never produced an SD.
+ *
+ * Usage:
+ *   node scripts/detect-orphan-visions.js [--json] [--min-age-days N]
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { parseArgs } from 'node:util';
+
+const { values: args } = parseArgs({
+  options: {
+    json: { type: 'boolean', default: false },
+    'min-age-days': { type: 'string', default: '0' },
+  },
+});
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const minAgeDays = parseInt(args['min-age-days'], 10) || 0;
+
+const { data, error } = await supabase
+  .from('v_orphan_visions')
+  .select('*')
+  .gte('age_days', minAgeDays)
+  .order('brainstorm_created_at', { ascending: false });
+
+if (error) {
+  console.error('Error querying v_orphan_visions:', error.message);
+  process.exit(1);
+}
+
+if (args.json) {
+  console.log(JSON.stringify(data, null, 2));
+  process.exit(0);
+}
+
+if (!data.length) {
+  console.log('No orphan visions found.');
+  process.exit(0);
+}
+
+console.log(`\nOrphan Visions (${data.length} found):\n`);
+console.log('%-20s %-20s %-15s %-6s %s', 'Vision Key', 'Arch Key', 'Outcome', 'Days', 'Topic');
+console.log('-'.repeat(90));
+
+for (const row of data) {
+  console.log(
+    '%-20s %-20s %-15s %-6d %s',
+    row.vision_key || '(none)',
+    row.plan_key || '(none)',
+    row.outcome_type || '?',
+    row.age_days,
+    (row.brainstorm_topic || '').substring(0, 40)
+  );
+}
+
+console.log('\nTo create SDs from these, run: /leo create --vision-key <KEY> --arch-key <KEY>');

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1295,6 +1295,26 @@ async function createSD(options) {
     });
   } catch { /* CLI tracking is fire-and-forget */ }
 
+  // FR-005 (SD-LEO-INFRA-BRAINSTORM-SD-PIPELINE-001): Backfill brainstorm_sessions.created_sd_id
+  // When an SD is created with a vision_key from a brainstorm, link it back to the originating session
+  if (metadata?.vision_key) {
+    try {
+      const { data: visionDoc } = await supabase
+        .from('eva_vision_documents')
+        .select('source_brainstorm_id')
+        .eq('vision_key', metadata.vision_key)
+        .single();
+
+      if (visionDoc?.source_brainstorm_id) {
+        await supabase
+          .from('brainstorm_sessions')
+          .update({ created_sd_id: data.sd_key })
+          .eq('id', visionDoc.source_brainstorm_id)
+          .is('created_sd_id', null); // Only backfill if not already linked
+      }
+    } catch { /* Non-fatal: brainstorm backfill should not block SD creation */ }
+  }
+
   // Vision pre-screen at SD conception (SD-LEO-INFRA-VISION-SD-CONCEPTION-GATE-001)
   await scoreSDAtConception(data.sd_key, title, description, supabase, {
     visionKey: metadata?.vision_key,

--- a/supabase/migrations/20260307_v_orphan_visions.sql
+++ b/supabase/migrations/20260307_v_orphan_visions.sql
@@ -1,0 +1,31 @@
+-- FR-003: v_orphan_visions view
+-- SD-LEO-INFRA-BRAINSTORM-SD-PIPELINE-001
+--
+-- Surfaces vision/architecture documents created from brainstorms
+-- that never resulted in an SD (brainstorm_sessions.created_sd_id IS NULL).
+
+CREATE OR REPLACE VIEW v_orphan_visions AS
+SELECT
+  v.id              AS vision_id,
+  v.vision_key,
+  a.id              AS arch_id,
+  a.plan_key,
+  bs.id             AS brainstorm_id,
+  bs.topic          AS brainstorm_topic,
+  bs.domain         AS brainstorm_domain,
+  bs.outcome_type,
+  bs.created_sd_id,
+  bs.created_at     AS brainstorm_created_at,
+  v.created_at      AS vision_created_at,
+  EXTRACT(DAY FROM NOW() - bs.created_at)::int AS age_days
+FROM eva_vision_documents v
+JOIN brainstorm_sessions bs
+  ON bs.id = v.source_brainstorm_id
+LEFT JOIN eva_architecture_plans a
+  ON a.source_brainstorm_id = bs.id
+WHERE bs.created_sd_id IS NULL
+ORDER BY bs.created_at DESC;
+
+COMMENT ON VIEW v_orphan_visions IS
+  'Vision/architecture docs from brainstorms that never produced an SD. '
+  'Used by scripts/detect-orphan-visions.js to surface stale brainstorm artifacts.';


### PR DESCRIPTION
## Summary
- **Step 9.6 auto-upgrade**: When vision+arch artifacts exist, auto-upgrades `needs_triage` outcome to `ready_for_sd`
- **Step 11 branching fix**: Offers SD creation for Needs Triage/Potential Conflict outcomes when vision+arch keys are registered
- **v_orphan_visions SQL view**: Surfaces vision docs from brainstorms that never produced an SD
- **detect-orphan-visions.js CLI**: Queries orphan view with `--json` and `--min-age-days` filters
- **FR-005 backfill**: `leo-create-sd.js` links `brainstorm_sessions.created_sd_id` when SD created with vision_key

SD-LEO-INFRA-BRAINSTORM-SD-PIPELINE-001

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Pre-commit hooks pass (secret scan, ESLint, DOCMON)
- [x] Heal score: 85/100
- [ ] Deploy migration to verify v_orphan_visions view

🤖 Generated with [Claude Code](https://claude.com/claude-code)