### PR TITLE
feat: stage execution worker resilience & smart recovery

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -30,6 +30,8 @@ import {
 } from './chairman-decision-watcher.js';
 import { emit } from './shared-services.js';
 
+import { hostname } from 'os';
+
 // ── Constants ───────────────────────────────────────────────
 
 const MAX_STAGE = 25;
@@ -37,6 +39,7 @@ const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_MAX_RETRIES = 2;
 const DEFAULT_RETRY_DELAY_MS = 5_000;
 const DEFAULT_GATE_TIMEOUT_MS = 0; // 0 = wait indefinitely
+const DEFAULT_STALE_LOCK_THRESHOLD_MS = 300_000; // 5 minutes
 
 /**
  * Chairman gate stages where pipeline pauses for human decision.
@@ -99,6 +102,10 @@ export class StageExecutionWorker {
     this._chairmanId = options.chairmanId || null;
     this._dryRun = options.dryRun || false;
     this._waitForReview = options.waitForReview || false;
+    this._staleLockThresholdMs = options.staleLockThresholdMs ?? DEFAULT_STALE_LOCK_THRESHOLD_MS;
+
+    /** @type {string} Unique worker identity for heartbeats and lock ownership */
+    this._workerId = `sew-${hostname()}-${process.pid}`;
 
     /** @type {Map<string, AbortController>} Active ventures → abort controllers */
     this._activeVentures = new Map();
@@ -126,7 +133,12 @@ export class StageExecutionWorker {
     }
 
     this._running = true;
-    this._logger.log(`[Worker] Started (poll every ${this._pollIntervalMs}ms, dryRun=${this._dryRun})`);
+    this._logger.log(`[Worker] Started (poll every ${this._pollIntervalMs}ms, dryRun=${this._dryRun}, id=${this._workerId})`);
+
+    // Register heartbeat
+    this._upsertHeartbeat('online').catch(err =>
+      this._logger.warn(`[Worker] Initial heartbeat failed: ${err.message}`)
+    );
 
     // Run immediately, then on interval
     this._tick();
@@ -152,6 +164,11 @@ export class StageExecutionWorker {
       controller.abort();
     }
     this._activeVentures.clear();
+
+    // Mark heartbeat as stopped
+    this._upsertHeartbeat('stopped').catch(err =>
+      this._logger.warn(`[Worker] Stop heartbeat failed: ${err.message}`)
+    );
 
     this._logger.log('[Worker] Stopped');
   }
@@ -245,6 +262,12 @@ export class StageExecutionWorker {
 
     this._processing = true;
     try {
+      // Heartbeat + stale lock cleanup before polling
+      await this._upsertHeartbeat('online').catch(err =>
+        this._logger.warn(`[Worker] Heartbeat failed: ${err.message}`)
+      );
+      await this._releaseStaleLocks();
+
       const ventures = await this._pollForWork();
       if (ventures.length === 0) return;
 
@@ -578,6 +601,94 @@ export class StageExecutionWorker {
       this._logger.error(`[Worker] Chairman gate error at stage ${stageNumber}: ${err.message}`);
       return { blocked: true, killed: false, approved: false };
     }
+  }
+
+  /**
+   * Release stale processing locks on ventures that have been locked
+   * longer than the threshold. Resets them to idle so they can be
+   * picked up on the next poll cycle.
+   *
+   * FR-001: Stale Lock Auto-Release
+   */
+  async _releaseStaleLocks() {
+    try {
+      const cutoff = new Date(Date.now() - this._staleLockThresholdMs).toISOString();
+
+      const { data: stale, error } = await this._supabase
+        .from('ventures')
+        .select('id, name, orchestrator_lock_acquired_at')
+        .eq('orchestrator_state', ORCHESTRATOR_STATES.PROCESSING)
+        .lt('orchestrator_lock_acquired_at', cutoff);
+
+      if (error) {
+        this._logger.warn(`[Worker] Stale lock query failed: ${error.message}`);
+        return;
+      }
+
+      if (!stale || stale.length === 0) return;
+
+      for (const venture of stale) {
+        const lockAge = Date.now() - new Date(venture.orchestrator_lock_acquired_at).getTime();
+        this._logger.warn(
+          `[Worker] Releasing stale lock on ${venture.name || venture.id} ` +
+          `(locked ${Math.round(lockAge / 1000)}s ago, threshold ${this._staleLockThresholdMs / 1000}s)`
+        );
+
+        const { error: resetError } = await this._supabase
+          .from('ventures')
+          .update({
+            orchestrator_state: ORCHESTRATOR_STATES.IDLE,
+            orchestrator_lock_id: null,
+            orchestrator_lock_acquired_at: null,
+          })
+          .eq('id', venture.id)
+          .eq('orchestrator_state', ORCHESTRATOR_STATES.PROCESSING);
+
+        if (resetError) {
+          this._logger.error(`[Worker] Failed to release stale lock on ${venture.id}: ${resetError.message}`);
+        } else {
+          await emit(this._supabase, 'stale_lock_released', {
+            ventureId: venture.id,
+            ventureName: venture.name,
+            lockAge,
+            releasedBy: this._workerId,
+          }, 'stage-execution-worker').catch(() => {});
+        }
+      }
+    } catch (err) {
+      this._logger.error(`[Worker] Stale lock sweep error: ${err.message}`);
+    }
+  }
+
+  /**
+   * Upsert worker heartbeat to worker_heartbeats table.
+   *
+   * FR-002: Health Heartbeat
+   *
+   * @param {'online'|'stopped'|'crashed'} status
+   */
+  async _upsertHeartbeat(status) {
+    const { error } = await this._supabase
+      .from('worker_heartbeats')
+      .upsert(
+        {
+          worker_id: this._workerId,
+          worker_type: 'stage-execution-worker',
+          last_heartbeat_at: new Date().toISOString(),
+          status,
+          pid: process.pid,
+          hostname: hostname(),
+          metadata: {
+            activeVentures: this._activeVentures.size,
+            pollIntervalMs: this._pollIntervalMs,
+            uptime: process.uptime(),
+          },
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'worker_id' }
+      );
+
+    if (error) throw new Error(error.message);
   }
 
   /**

--- a/scripts/start-stage-worker.js
+++ b/scripts/start-stage-worker.js
@@ -1,23 +1,32 @@
 #!/usr/bin/env node
 
 /**
- * Stage Execution Worker — Entry Point
+ * Stage Execution Worker — Supervisor Entry Point
  *
- * Starts the StageExecutionWorker that polls eva_ventures for active ventures,
- * executes stage templates via Gemini, and creates venture_artifacts.
- * Pauses at chairman gate stages for human decisions.
+ * FR-004: Process supervisor with auto-restart and circuit breaker.
+ *
+ * In supervisor mode (default), forks the worker as a child process and
+ * restarts it on crash with exponential backoff. A circuit breaker trips
+ * if MAX_RESTARTS occur within the WINDOW — the supervisor then waits for
+ * the cooldown period before resetting the counter.
+ *
+ * In direct mode (--direct), runs the worker in-process (for --once, testing).
  *
  * Usage:
- *   node scripts/start-stage-worker.js           # Continuous polling (30s default)
- *   node scripts/start-stage-worker.js --once     # Single poll cycle then exit
+ *   node scripts/start-stage-worker.js           # Supervisor mode (auto-restart)
+ *   node scripts/start-stage-worker.js --once     # Single poll, no supervisor
  *   node scripts/start-stage-worker.js --dry-run  # Skip persistence
+ *   node scripts/start-stage-worker.js --direct   # In-process, no supervisor
  *
  * Environment:
  *   SUPABASE_URL / NEXT_PUBLIC_SUPABASE_URL
  *   SUPABASE_SERVICE_ROLE_KEY
  *   STAGE_WORKER_POLL_INTERVAL_MS  (default: 30000)
+ *   STAGE_WORKER_MAX_RESTARTS      (default: 5)
+ *   STAGE_WORKER_RESTART_WINDOW_MS (default: 600000 = 10 min)
+ *   STAGE_WORKER_COOLDOWN_MS       (default: 60000 = 1 min)
  *
- * SD: SD-MAN-GEN-CORRECTIVE-VISION-GAP-017
+ * SD: SD-LEO-INFRA-STAGE-EXECUTION-WORKER-001
  */
 
 import dotenv from 'dotenv';
@@ -25,11 +34,23 @@ dotenv.config();
 
 import { createClient } from '@supabase/supabase-js';
 import { writeFileSync, unlinkSync } from 'fs';
-import { resolve } from 'path';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { fork } from 'child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const PID_FILE = resolve(process.cwd(), 'stage-execution-worker.pid');
 const ONCE_MODE = process.argv.includes('--once');
 const DRY_RUN = process.argv.includes('--dry-run');
+const DIRECT_MODE = process.argv.includes('--direct');
+
+// Circuit breaker settings
+const MAX_RESTARTS = parseInt(process.env.STAGE_WORKER_MAX_RESTARTS || '5', 10);
+const RESTART_WINDOW_MS = parseInt(process.env.STAGE_WORKER_RESTART_WINDOW_MS || '600000', 10);
+const COOLDOWN_MS = parseInt(process.env.STAGE_WORKER_COOLDOWN_MS || '60000', 10);
+const BASE_RESTART_DELAY_MS = 1000;
 
 // ── Supabase Client ───────────────────────────────────────────────
 
@@ -37,20 +58,18 @@ const supabaseUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE
 const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 if (!supabaseUrl || !supabaseKey) {
-  console.error('[stage-worker] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  console.error('[supervisor] Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
   process.exit(1);
 }
 
-const supabase = createClient(supabaseUrl, supabaseKey);
-
 // ── PID File ──────────────────────────────────────────────────────
 
-function writePid() {
+function writePid(pid) {
   try {
-    writeFileSync(PID_FILE, String(process.pid));
-    console.log(`[stage-worker] PID ${process.pid} written to ${PID_FILE}`);
+    writeFileSync(PID_FILE, String(pid));
+    console.log(`[supervisor] PID ${pid} written to ${PID_FILE}`);
   } catch (err) {
-    console.warn(`[stage-worker] Could not write PID file: ${err.message}`);
+    console.warn(`[supervisor] Could not write PID file: ${err.message}`);
   }
 }
 
@@ -58,36 +77,147 @@ function removePid() {
   try {
     unlinkSync(PID_FILE);
   } catch {
-    // File may not exist — that's fine
+    // File may not exist
   }
 }
 
-// ── Graceful Shutdown ─────────────────────────────────────────────
+// ── Heartbeat Helpers ─────────────────────────────────────────────
 
-let worker = null;
-
-async function shutdown(signal) {
-  console.log(`\n[stage-worker] Received ${signal}, shutting down...`);
-  if (worker) {
-    worker.stop();
-  }
-  removePid();
-  // Give in-flight operations a moment to finish
-  setTimeout(() => process.exit(0), 2000);
+async function markHeartbeat(supabase, workerId, status) {
+  const { hostname } = await import('os');
+  await supabase
+    .from('worker_heartbeats')
+    .upsert(
+      {
+        worker_id: workerId,
+        worker_type: 'stage-execution-worker',
+        last_heartbeat_at: new Date().toISOString(),
+        status,
+        pid: process.pid,
+        hostname: hostname(),
+        metadata: { role: 'supervisor' },
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'worker_id' }
+    )
+    .then(({ error }) => {
+      if (error) console.warn(`[supervisor] Heartbeat upsert failed: ${error.message}`);
+    });
 }
 
-process.on('SIGINT', () => shutdown('SIGINT'));
-process.on('SIGTERM', () => shutdown('SIGTERM'));
+// ── Supervisor Mode ───────────────────────────────────────────────
 
-// ── Main ──────────────────────────────────────────────────────────
+function runSupervisor() {
+  const restartTimestamps = [];
+  let child = null;
+  let shuttingDown = false;
+  let restartTimer = null;
 
-async function main() {
-  // Dynamic import for ESM module
+  const workerScript = resolve(__dirname, 'start-stage-worker.js');
+
+  function spawnChild() {
+    const args = ['--direct'];
+    if (DRY_RUN) args.push('--dry-run');
+
+    child = fork(workerScript, args, {
+      stdio: ['pipe', 'inherit', 'inherit', 'ipc'],
+      env: { ...process.env },
+    });
+
+    writePid(child.pid);
+    console.log(`[supervisor] Spawned worker child PID=${child.pid}`);
+
+    child.on('exit', (code, signal) => {
+      if (shuttingDown) return;
+
+      console.warn(`[supervisor] Worker exited (code=${code}, signal=${signal})`);
+
+      // Record crash timestamp
+      restartTimestamps.push(Date.now());
+
+      // Prune timestamps outside the window
+      const windowStart = Date.now() - RESTART_WINDOW_MS;
+      while (restartTimestamps.length > 0 && restartTimestamps[0] < windowStart) {
+        restartTimestamps.shift();
+      }
+
+      // Circuit breaker check
+      if (restartTimestamps.length >= MAX_RESTARTS) {
+        console.error(
+          `[supervisor] Circuit breaker tripped: ${restartTimestamps.length} restarts ` +
+          `in ${RESTART_WINDOW_MS / 1000}s window. Cooling down for ${COOLDOWN_MS / 1000}s...`
+        );
+
+        // Mark crashed heartbeat
+        const supabase = createClient(supabaseUrl, supabaseKey);
+        markHeartbeat(supabase, `sew-supervisor-${process.pid}`, 'crashed');
+
+        restartTimer = setTimeout(() => {
+          console.log('[supervisor] Cooldown complete, resetting circuit breaker');
+          restartTimestamps.length = 0;
+          spawnChild();
+        }, COOLDOWN_MS);
+        return;
+      }
+
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s (capped)
+      const attempt = restartTimestamps.length;
+      const delay = Math.min(BASE_RESTART_DELAY_MS * Math.pow(2, attempt - 1), 30_000);
+      console.log(`[supervisor] Restarting in ${delay}ms (attempt ${attempt}/${MAX_RESTARTS})...`);
+
+      restartTimer = setTimeout(spawnChild, delay);
+    });
+
+    child.on('error', (err) => {
+      console.error(`[supervisor] Worker spawn error: ${err.message}`);
+    });
+  }
+
+  // Graceful shutdown
+  function shutdown(signal) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`\n[supervisor] Received ${signal}, shutting down...`);
+
+    if (restartTimer) clearTimeout(restartTimer);
+
+    if (child && !child.killed) {
+      child.kill('SIGTERM');
+      // Force kill after 5s
+      setTimeout(() => {
+        if (child && !child.killed) {
+          console.warn('[supervisor] Force killing worker');
+          child.kill('SIGKILL');
+        }
+        removePid();
+        process.exit(0);
+      }, 5000);
+    } else {
+      removePid();
+      process.exit(0);
+    }
+  }
+
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+  console.log('[supervisor] Starting Stage Execution Worker (supervisor mode)');
+  console.log(`[supervisor]   Max restarts: ${MAX_RESTARTS} per ${RESTART_WINDOW_MS / 1000}s`);
+  console.log(`[supervisor]   Cooldown: ${COOLDOWN_MS / 1000}s`);
+  console.log(`[supervisor]   Dry run: ${DRY_RUN}`);
+
+  spawnChild();
+}
+
+// ── Direct Mode (in-process) ──────────────────────────────────────
+
+async function runDirect() {
+  const supabase = createClient(supabaseUrl, supabaseKey);
   const { StageExecutionWorker } = await import('../lib/eva/stage-execution-worker.js');
 
   const pollIntervalMs = parseInt(process.env.STAGE_WORKER_POLL_INTERVAL_MS || '30000', 10);
 
-  worker = new StageExecutionWorker({
+  const worker = new StageExecutionWorker({
     supabase,
     pollIntervalMs,
     dryRun: DRY_RUN,
@@ -102,23 +232,29 @@ async function main() {
     },
   });
 
-  writePid();
+  writePid(process.pid);
 
-  console.log('[stage-worker] Starting Stage Execution Worker');
+  // Graceful shutdown
+  function shutdown(signal) {
+    console.log(`\n[stage-worker] Received ${signal}, shutting down...`);
+    worker.stop();
+    removePid();
+    setTimeout(() => process.exit(0), 2000);
+  }
+
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+  console.log('[stage-worker] Starting Stage Execution Worker (direct mode)');
   console.log(`[stage-worker]   Poll interval: ${pollIntervalMs}ms`);
   console.log(`[stage-worker]   Dry run: ${DRY_RUN}`);
   console.log(`[stage-worker]   Once mode: ${ONCE_MODE}`);
 
   if (ONCE_MODE) {
-    // Single poll cycle: call the internal poll method if available,
-    // otherwise start and stop after one interval
-    if (typeof worker._poll === 'function') {
-      await worker._poll();
-    } else {
-      worker.start();
-      await new Promise(resolve => setTimeout(resolve, pollIntervalMs + 5000));
-      worker.stop();
-    }
+    worker.start();
+    // Wait for one full tick cycle to complete
+    await new Promise(resolve => setTimeout(resolve, pollIntervalMs + 5000));
+    worker.stop();
     removePid();
     console.log('[stage-worker] Single pass complete, exiting.');
     process.exit(0);
@@ -128,8 +264,14 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error('[stage-worker] Fatal error:', err);
-  removePid();
-  process.exit(1);
-});
+// ── Entry Point ───────────────────────────────────────────────────
+
+if (ONCE_MODE || DIRECT_MODE) {
+  runDirect().catch(err => {
+    console.error('[stage-worker] Fatal error:', err);
+    removePid();
+    process.exit(1);
+  });
+} else {
+  runSupervisor();
+}

--- a/supabase/migrations/20260307_worker_heartbeats.sql
+++ b/supabase/migrations/20260307_worker_heartbeats.sql
@@ -1,0 +1,31 @@
+-- Worker Heartbeats Table
+-- SD-LEO-INFRA-STAGE-EXECUTION-WORKER-001 (FR-002)
+-- Tracks liveness of background workers (stage-execution-worker, etc.)
+
+CREATE TABLE IF NOT EXISTS worker_heartbeats (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  worker_id TEXT NOT NULL,
+  worker_type TEXT NOT NULL DEFAULT 'stage-execution-worker',
+  last_heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  status TEXT NOT NULL DEFAULT 'online' CHECK (status IN ('online', 'stopped', 'crashed')),
+  pid INTEGER,
+  hostname TEXT,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT worker_heartbeats_worker_id_unique UNIQUE (worker_id)
+);
+
+-- Index for efficient status queries
+CREATE INDEX IF NOT EXISTS idx_worker_heartbeats_type_status
+  ON worker_heartbeats (worker_type, status);
+
+-- Enable RLS
+ALTER TABLE worker_heartbeats ENABLE ROW LEVEL SECURITY;
+
+-- Service role has full access
+CREATE POLICY "service_role_full_access" ON worker_heartbeats
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');

--- a/tests/unit/eva/stage-execution-worker-resilience.test.js
+++ b/tests/unit/eva/stage-execution-worker-resilience.test.js
@@ -1,0 +1,256 @@
+/**
+ * Tests for StageExecutionWorker Resilience Features
+ * SD-LEO-INFRA-STAGE-EXECUTION-WORKER-001
+ *
+ * FR-001: Stale Lock Auto-Release
+ * FR-002: Health Heartbeat
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StageExecutionWorker, CHAIRMAN_GATES, getOperatingMode } from '../../../lib/eva/stage-execution-worker.js';
+
+// Mock dependencies
+vi.mock('../../../lib/eva/eva-orchestrator.js', () => ({
+  processStage: vi.fn(),
+}));
+
+vi.mock('../../../lib/eva/orchestrator-state-machine.js', () => ({
+  acquireProcessingLock: vi.fn().mockResolvedValue({ acquired: false }),
+  releaseProcessingLock: vi.fn().mockResolvedValue({}),
+  markCompleted: vi.fn().mockResolvedValue({}),
+  ORCHESTRATOR_STATES: {
+    IDLE: 'idle',
+    PROCESSING: 'processing',
+    BLOCKED: 'blocked',
+    FAILED: 'failed',
+    COMPLETED: 'completed',
+    KILLED_AT_REALITY_GATE: 'killed_at_reality_gate',
+  },
+}));
+
+vi.mock('../../../lib/eva/chairman-decision-watcher.js', () => ({
+  createOrReusePendingDecision: vi.fn(),
+  waitForDecision: vi.fn(),
+}));
+
+vi.mock('../../../lib/eva/shared-services.js', () => ({
+  emit: vi.fn().mockResolvedValue(undefined),
+}));
+
+function createMockSupabase() {
+  const results = { data: null, error: null };
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(results),
+    upsert: vi.fn().mockResolvedValue(results),
+    update: vi.fn().mockReturnThis(),
+  };
+
+  return {
+    from: vi.fn().mockReturnValue(chain),
+    _chain: chain,
+    _results: results,
+  };
+}
+
+function createMockLogger() {
+  return {
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+}
+
+describe('StageExecutionWorker Resilience (FR-001/FR-002)', () => {
+  let supabase;
+  let logger;
+  let worker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    supabase = createMockSupabase();
+    logger = createMockLogger();
+  });
+
+  afterEach(() => {
+    if (worker) worker.stop();
+    vi.useRealTimers();
+  });
+
+  describe('constructor - new fields', () => {
+    it('generates a unique workerId', () => {
+      worker = new StageExecutionWorker({ supabase, logger });
+      expect(worker._workerId).toMatch(/^sew-/);
+      expect(worker._workerId).toContain(String(process.pid));
+    });
+
+    it('sets default stale lock threshold', () => {
+      worker = new StageExecutionWorker({ supabase, logger });
+      expect(worker._staleLockThresholdMs).toBe(300_000);
+    });
+
+    it('accepts custom stale lock threshold', () => {
+      worker = new StageExecutionWorker({ supabase, logger, staleLockThresholdMs: 60_000 });
+      expect(worker._staleLockThresholdMs).toBe(60_000);
+    });
+  });
+
+  describe('FR-001: Stale Lock Auto-Release', () => {
+    it('releases locks older than threshold', async () => {
+      worker = new StageExecutionWorker({ supabase, logger, staleLockThresholdMs: 300_000 });
+
+      const staleLockTime = new Date(Date.now() - 400_000).toISOString(); // 400s ago
+      const staleVentures = [
+        { id: 'v1', name: 'Stale Venture', orchestrator_lock_acquired_at: staleLockTime },
+      ];
+
+      // First call to from('ventures').select().eq().lt() returns stale ventures
+      const selectChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        lt: vi.fn().mockResolvedValue({ data: staleVentures, error: null }),
+      };
+
+      // Second call for update
+      const updateChain = {
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+      };
+      // Make the final .eq() resolve
+      updateChain.eq.mockReturnValueOnce(updateChain).mockResolvedValueOnce({ error: null });
+
+      let callCount = 0;
+      supabase.from.mockImplementation((table) => {
+        if (table === 'ventures') {
+          callCount++;
+          if (callCount === 1) return selectChain;
+          return updateChain;
+        }
+        // heartbeat or events table
+        return supabase._chain;
+      });
+
+      await worker._releaseStaleLocks();
+
+      expect(supabase.from).toHaveBeenCalledWith('ventures');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Releasing stale lock on Stale Venture')
+      );
+    });
+
+    it('does nothing when no stale locks found', async () => {
+      worker = new StageExecutionWorker({ supabase, logger });
+
+      const selectChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        lt: vi.fn().mockResolvedValue({ data: [], error: null }),
+      };
+
+      supabase.from.mockReturnValue(selectChain);
+
+      await worker._releaseStaleLocks();
+
+      // Should only query, not update
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('handles query errors gracefully', async () => {
+      worker = new StageExecutionWorker({ supabase, logger });
+
+      const selectChain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        lt: vi.fn().mockResolvedValue({ data: null, error: { message: 'DB down' } }),
+      };
+
+      supabase.from.mockReturnValue(selectChain);
+
+      await worker._releaseStaleLocks(); // Should not throw
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Stale lock query failed')
+      );
+    });
+  });
+
+  describe('FR-002: Health Heartbeat', () => {
+    it('upserts heartbeat with correct fields', async () => {
+      worker = new StageExecutionWorker({ supabase, logger });
+
+      await worker._upsertHeartbeat('online');
+
+      expect(supabase.from).toHaveBeenCalledWith('worker_heartbeats');
+      expect(supabase._chain.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          worker_id: worker._workerId,
+          worker_type: 'stage-execution-worker',
+          status: 'online',
+          pid: process.pid,
+        }),
+        { onConflict: 'worker_id' }
+      );
+    });
+
+    it('throws on upsert error', async () => {
+      worker = new StageExecutionWorker({ supabase, logger });
+
+      supabase._chain.upsert.mockResolvedValueOnce({ error: { message: 'Constraint violation' } });
+
+      await expect(worker._upsertHeartbeat('online')).rejects.toThrow('Constraint violation');
+    });
+
+    it('sends online heartbeat on start()', () => {
+      worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 60000 });
+      worker.start();
+
+      expect(supabase.from).toHaveBeenCalledWith('worker_heartbeats');
+    });
+
+    it('sends stopped heartbeat on stop()', () => {
+      worker = new StageExecutionWorker({ supabase, logger, pollIntervalMs: 60000 });
+      worker._running = true;
+      worker.stop();
+
+      // Check that upsert was called with status 'stopped'
+      const upsertCalls = supabase._chain.upsert.mock.calls;
+      const stoppedCall = upsertCalls.find(
+        ([payload]) => payload.status === 'stopped'
+      );
+      expect(stoppedCall).toBeTruthy();
+    });
+  });
+
+  describe('getStatus()', () => {
+    it('returns worker status including workerId', () => {
+      worker = new StageExecutionWorker({ supabase, logger });
+      const status = worker.getStatus();
+
+      expect(status.running).toBe(false);
+      expect(status.processing).toBe(false);
+      expect(status.activeVentures).toBe(0);
+      expect(status.ventureIds).toEqual([]);
+    });
+  });
+
+  describe('getOperatingMode()', () => {
+    it('maps stages to correct modes', () => {
+      expect(getOperatingMode(1)).toBe('EVALUATION');
+      expect(getOperatingMode(5)).toBe('EVALUATION');
+      expect(getOperatingMode(6)).toBe('STRATEGY');
+      expect(getOperatingMode(12)).toBe('STRATEGY');
+      expect(getOperatingMode(13)).toBe('PLANNING');
+      expect(getOperatingMode(16)).toBe('PLANNING');
+      expect(getOperatingMode(17)).toBe('BUILD');
+      expect(getOperatingMode(21)).toBe('BUILD');
+      expect(getOperatingMode(22)).toBe('LAUNCH');
+      expect(getOperatingMode(25)).toBe('LAUNCH');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

SD-LEO-INFRA-STAGE-EXECUTION-WORKER-001

- **FR-001**: Stale lock auto-release — detects ventures stuck in `processing` state longer than 5 min, resets to `idle` on each tick cycle
- **FR-002**: Health heartbeat — new `worker_heartbeats` table + upsert on start/tick/stop tracking PID, hostname, status, and uptime
- **FR-004**: Process supervisor — `start-stage-worker.js` refactored to fork worker as child process with exponential backoff restart and circuit breaker (5 crashes in 10 min → 60s cooldown)
- 12 new unit tests covering all resilience features

## Test plan

- [x] `node --check` passes on both modified files
- [x] 12/12 new resilience tests pass (`vitest run`)
- [x] Heal score: 97/100
- [x] LEAD-FINAL-APPROVAL: 96%

🤖 Generated with [Claude Code](https://claude.com/claude-code)