### PR TITLE
fix: autonomy model query, tracer FK resolution, synthesis null safety

### DIFF
--- a/lib/eva/autonomy-model.js
+++ b/lib/eva/autonomy-model.js
@@ -48,8 +48,8 @@ export async function checkAutonomy(ventureId, gateType, { supabase }) {
   const { data, error } = await supabase
     .from('eva_ventures')
     .select('autonomy_level')
-    .eq('id', ventureId)
-    .single();
+    .eq('venture_id', ventureId)
+    .maybeSingle();
 
   if (error || !data) {
     log.warn('Could not fetch autonomy level, defaulting to L0', { ventureId, error: error?.message });

--- a/lib/eva/observability.js
+++ b/lib/eva/observability.js
@@ -144,13 +144,19 @@ export class OrchestratorTracer {
 
     const trace = this.getTrace();
 
+    // Resolve eva_ventures.id from ventures.id (FK target)
+    const evaVentureId = await this._resolveEvaVentureId(supabase, trace.ventureId);
+    if (!evaVentureId) {
+      return { persisted: false, error: 'No eva_ventures row for this venture — trace skipped' };
+    }
+
     try {
       const { data, error } = await supabase
         .from('eva_trace_log')
         .insert({
           trace_id: trace.traceId,
           parent_trace_id: trace.parentTraceId,
-          venture_id: trace.ventureId,
+          venture_id: evaVentureId,
           spans: trace.spans,
           events: trace.events,
           total_duration_ms: trace.totalDurationMs,
@@ -186,11 +192,17 @@ export class OrchestratorTracer {
       return { persisted: false, count: 0, error: !supabase ? 'No database client' : 'No events' };
     }
 
+    // Resolve eva_ventures.id from ventures.id (FK target)
+    const evaVentureId = await this._resolveEvaVentureId(supabase, this.ventureId);
+    if (!evaVentureId) {
+      return { persisted: false, count: 0, error: 'No eva_ventures row for this venture — events skipped' };
+    }
+
     try {
       const rows = this.events.map(e => ({
         event_type: e.eventType,
         trace_id: e.traceId,
-        eva_venture_id: e.ventureId,
+        eva_venture_id: evaVentureId,
         event_data: e.payload,
         event_source: 'eva_orchestrator',
       }));
@@ -207,6 +219,27 @@ export class OrchestratorTracer {
       this.logger.warn(`[Tracer] Event persist error: ${err.message}`);
       return { persisted: false, count: 0, error: err.message };
     }
+  }
+  /**
+   * Resolve eva_ventures.id from ventures.id. Returns null if no row exists.
+   * Caches the result for the lifetime of this tracer instance.
+   *
+   * @param {Object} supabase
+   * @param {string} ventureId - ventures.id
+   * @returns {Promise<string|null>}
+   */
+  async _resolveEvaVentureId(supabase, ventureId) {
+    if (!ventureId) return null;
+    if (this._evaVentureIdCache !== undefined) return this._evaVentureIdCache;
+
+    const { data } = await supabase
+      .from('eva_ventures')
+      .select('id')
+      .eq('venture_id', ventureId)
+      .maybeSingle();
+
+    this._evaVentureIdCache = data?.id || null;
+    return this._evaVentureIdCache;
   }
 }
 

--- a/lib/eva/stage-zero/synthesis/index.js
+++ b/lib/eva/stage-zero/synthesis/index.js
@@ -189,6 +189,7 @@ export async function runSynthesis(pathOutput, deps = {}) {
 
   // Aggregate token usage from all components
   const componentUsages = [crossRef, portfolio, reframing, moat, timeHorizon, archetype, buildCost, virality, design, narrativeRisk, techTrajectory, attentionCapital, mentalModelAnalysis]
+    .filter(c => c != null)
     .map(c => c.usage)
     .filter(Boolean);
   const usage = componentUsages.length > 0 ? {
@@ -196,14 +197,14 @@ export async function runSynthesis(pathOutput, deps = {}) {
     outputTokens: componentUsages.reduce((sum, u) => sum + (u.outputTokens || 0), 0),
   } : null;
 
-  logger.log(`   Synthesis complete: cross-ref=${crossRef.relevance_score || 0}, portfolio=${portfolio.composite_score || 0}, reframings=${(reframing.reframings || []).length}, moat=${moat.moat_score || 0}, constraints=${constraints.verdict || 'unknown'}, horizon=${timeHorizon.position || 'unknown'}, archetype=${archetype.primary_archetype || 'unknown'}, cost=${buildCost.complexity || 'unknown'}, virality=${virality.virality_score || 0}, design=${design.composite_score || 0}, narrative_risk=${narrativeRisk.nr_score || 0} (${narrativeRisk.nr_band || 'unknown'}), tech_trajectory=${techTrajectory.trajectory_score || 0} (${techTrajectory.competitive_timing?.signal || 'unknown'}), attention_capital=${attentionCapital.ac_score || 0} (${attentionCapital.ac_band || 'unknown'})`);
+  logger.log(`   Synthesis complete: cross-ref=${crossRef?.relevance_score || 0}, portfolio=${portfolio?.composite_score || 0}, reframings=${(reframing?.reframings || []).length}, moat=${moat?.moat_score || 0}, constraints=${constraints?.verdict || 'unknown'}, horizon=${timeHorizon?.position || 'unknown'}, archetype=${archetype?.primary_archetype || 'unknown'}, cost=${buildCost?.complexity || 'unknown'}, virality=${virality?.virality_score || 0}, design=${design?.composite_score || 0}, narrative_risk=${narrativeRisk?.nr_score || 0} (${narrativeRisk?.nr_band || 'unknown'}), tech_trajectory=${techTrajectory?.trajectory_score || 0} (${techTrajectory?.competitive_timing?.signal || 'unknown'}), attention_capital=${attentionCapital?.ac_score || 0} (${attentionCapital?.ac_band || 'unknown'})`);
 
   // Build enriched brief
-  const recommendedProblem = reframing.recommended_framing?.framing || pathOutput.suggested_problem;
+  const recommendedProblem = reframing?.recommended_framing?.framing || pathOutput.suggested_problem;
 
   // Determine maturity based on constraint verdict and time horizon
-  const maturity = constraints.verdict === 'fail' ? 'blocked'
-    : timeHorizon.position === 'park_and_build_later' ? 'nursery'
+  const maturity = constraints?.verdict === 'fail' ? 'blocked'
+    : timeHorizon?.position === 'park_and_build_later' ? 'nursery'
     : 'ready';
 
   return {


### PR DESCRIPTION
## Summary
- **Autonomy model**: Fixed query to use `venture_id` column (not `id`) and `maybeSingle()` instead of `single()` — eliminates "Cannot coerce the result to a single JSON object" errors that caused all ventures to default to L0 autonomy
- **Tracer/observability**: Added `_resolveEvaVentureId()` to map `ventures.id` → `eva_ventures.id` before persisting to `eva_trace_log` and `eva_events` — gracefully skips when no `eva_ventures` row exists
- **Synthesis engine**: Added null-safety for component usage aggregation — prevents crash when any synthesis component returns null

## Test plan
- [x] BrandForge AI: Full 25-stage pipeline UAT with L2 autonomy — zero autonomy errors, zero tracer FK errors
- [x] ClarityStats: Full 25-stage pipeline completed (prior run confirmed tracer fix)
- [x] Smoke tests: 15/15 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)