### PR TITLE
fix: worktree claim guard and compaction heartbeat extension

### DIFF
--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -7,6 +7,8 @@
  * 2. Tool policy profile validation - LOG-ONLY (stdout warning, exit 0)
  * 3. Sub-agent routing advisory - SOFT HINT (stdout, exit 0)
  *
+ * 4. Worktree claim guard (PAT-CLMMULTI-001) - HARD BLOCK (exit 2)
+ *
  * Hook API:
  *   Input:  CLAUDE_TOOL_INPUT (JSON), CLAUDE_TOOL_NAME (string)
  *   Output: exit(0) = allow, exit(2) = block (stderr = rejection message)
@@ -15,6 +17,10 @@
 
 const TOOL_NAME = process.env.CLAUDE_TOOL_NAME || '';
 const TOOL_INPUT_RAW = process.env.CLAUDE_TOOL_INPUT || '';
+
+// --- WORKTREE CLAIM GUARD (PAT-CLMMULTI-001) ---
+// Regex to detect paths inside .worktrees/<SD-KEY>/
+const WORKTREE_PATH_RE = /[/\\]\.worktrees[/\\]([^/\\]+)/;
 
 // --- TOOL POLICY PROFILES (from lib/tool-policy.js) ---
 // Inline copy for CJS hook compatibility (lib/tool-policy.js is ESM).
@@ -58,6 +64,40 @@ function main() {
         'Run this command in the foreground. Background tasks break the autonomous chain of thought.\n'
       );
       process.exit(2); // Hard block
+    }
+  }
+
+  // --- ENFORCEMENT 4: Worktree Claim Guard (PAT-CLMMULTI-001) ---
+  // Blocks Edit/Write to worktree files when this session is working on a
+  // DIFFERENT SD. Prevents cross-worktree edits from parallel sessions.
+  // Uses local state file (no DB call) for speed. Fail-open on errors.
+  if (TOOL_NAME === 'Edit' || TOOL_NAME === 'Write') {
+    const filePath = input.file_path || '';
+    const match = filePath.match(WORKTREE_PATH_RE);
+    if (match) {
+      const worktreeSdKey = match[1];
+      try {
+        const fs = require('fs');
+        const path = require('path');
+        const stateFile = path.resolve(__dirname, '../../.claude/unified-session-state.json');
+        if (fs.existsSync(stateFile)) {
+          const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
+          const claimedSd = state.sd?.id;
+          if (claimedSd && claimedSd !== worktreeSdKey) {
+            process.stderr.write(
+              `CLAIM GUARD (PAT-CLMMULTI-001): Edit/Write blocked.\n` +
+              `  Target worktree: ${worktreeSdKey}\n` +
+              `  Your claimed SD: ${claimedSd}\n` +
+              `  You are editing files for a different SD than you have claimed.\n` +
+              `  Switch to the correct worktree or release your claim.\n`
+            );
+            process.exit(2);
+          }
+        }
+        // No state file = no claim info = fail-open
+      } catch {
+        // Fail-open: file read errors don't block edits
+      }
     }
   }
 

--- a/scripts/hooks/precompact-unified.js
+++ b/scripts/hooks/precompact-unified.js
@@ -35,11 +35,51 @@ function findCurrentSessionId() {
   return null;
 }
 
+/**
+ * Extend heartbeat TTL to prevent claim staleness during compaction.
+ * PAT-CLMCOMPACT-01: Compaction can take 30-60s; without extending,
+ * the claim may go stale and be released by another session.
+ */
+async function extendHeartbeat(sessionId) {
+  if (!sessionId) return;
+  try {
+    // Load env if not already set (parent process usually provides these)
+    if (!process.env.SUPABASE_URL) {
+      const envPath = path.resolve(new URL('.', import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1'), '../../.env');
+      const dotenv = await import('dotenv');
+      dotenv.config({ path: envPath });
+    }
+    const { createClient } = await import('@supabase/supabase-js');
+    const supabase = createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+    const { error } = await supabase
+      .from('claude_sessions')
+      .update({ heartbeat_at: new Date().toISOString() })
+      .eq('session_id', sessionId)
+      .in('status', ['active', 'idle']);
+    if (error) {
+      console.log(`[PRECOMPACT] Heartbeat extension failed: ${error.message}`);
+    } else {
+      console.log(`[PRECOMPACT] Heartbeat extended for session ${sessionId.substring(0, 24)}...`);
+    }
+  } catch (err) {
+    console.log(`[PRECOMPACT] Heartbeat extension error: ${err.message}`);
+  }
+}
+
 async function main() {
   const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const manager = new UnifiedStateManager(projectDir);
 
   try {
+    // PAT-CLMCOMPACT-01: Extend heartbeat BEFORE saving state
+    const sessionId = findCurrentSessionId();
+    if (sessionId) {
+      await extendHeartbeat(sessionId);
+    }
+
     // Save comprehensive state (getSDState now queries database)
     const state = await manager.saveState('precompact', {
       highlights: ['Pre-compaction state captured'],
@@ -47,13 +87,10 @@ async function main() {
     });
 
     // SD-LEO-INFRA-COMPACTION-CLAIM-001: Persist session_id for re-claim
-    if (state.sd?.id) {
-      const sessionId = findCurrentSessionId();
-      if (sessionId) {
-        state.sd.previousSessionId = sessionId;
-        state.sd.claimPreservedAt = new Date().toISOString();
-        manager.saveStateSync(state);
-      }
+    if (state.sd?.id && sessionId) {
+      state.sd.previousSessionId = sessionId;
+      state.sd.claimPreservedAt = new Date().toISOString();
+      manager.saveStateSync(state);
     }
 
     // Output formatted state for Claude to see


### PR DESCRIPTION
## Summary
- Add PreToolUse claim guard (PAT-CLMMULTI-001) in `pre-tool-enforce.cjs` that blocks Edit/Write to worktree files when session has a different SD claim. Uses local state file for speed, fail-open on errors.
- Add `extendHeartbeat()` in `precompact-unified.js` to update `heartbeat_at` before state save, preventing claim staleness during compaction window (PAT-CLMCOMPACT-01).

## Test plan
- [x] Claim guard regex correctly parses `.worktrees/` paths and extracts SD key
- [x] Claim guard blocks Edit/Write when session SD differs from worktree SD
- [x] Claim guard allows Edit/Write for non-worktree paths unconditionally
- [x] Claim guard fails open on file read errors
- [x] Heartbeat extension updates `claude_sessions.heartbeat_at` before state save
- [x] Heartbeat extension handles missing session gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)