### PR TITLE
fix: reduce SD age gate threshold from 28 to 21 days

### DIFF
--- a/scripts/modules/governance/timeline-violation-handler.js
+++ b/scripts/modules/governance/timeline-violation-handler.js
@@ -10,7 +10,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-const DEFAULT_AGE_THRESHOLD_DAYS = 28;
+const DEFAULT_AGE_THRESHOLD_DAYS = 21;
 
 /**
  * Load the SD age block threshold from leo_config.
@@ -158,7 +158,7 @@ export function formatBlockMessage({ sdKey, ageDays, threshold }) {
     `  ${'═'.repeat(50)}`,
     `  Age:       ${ageDays} days`,
     `  Threshold: ${threshold} days`,
-    `  Status:    BLOCKED — SD exceeds maximum age`,
+    '  Status:    BLOCKED — SD exceeds maximum age',
     '',
     '  Recommended Actions:',
     '    1. Complete the SD if work is near-done',


### PR DESCRIPTION
## Summary
- Reduces the default SD age gate blocking threshold from 28 days to 21 days
- Tighter governance window forces earlier decisions on stale SDs (complete, defer, or cancel)
- Configurable via `leo_config.sd_age_block_days` — this only changes the fallback default

## Test plan
- [x] Smoke tests pass
- [ ] Verify SDs older than 21 days are blocked by `sd:start`
- [ ] Verify `--force` override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)