### PR TITLE
feat: sub-agent gate integration dedup (SD-LEO-INFRA-SUB-AGENT-EXECUTION-001-B)

### DIFF
--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -270,11 +270,44 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     created_at: new Date().toISOString()
   };
 
-  const { data, error } = await supabase
+  // SD-LEO-INFRA-SUB-AGENT-EXECUTION-001-B (TR-003): Dedup check
+  // Prevent duplicate records for same sd_id + sub_agent_code within 5 minutes
+  const DEDUP_WINDOW_MS = 5 * 60 * 1000;
+  const dedupCutoff = new Date(Date.now() - DEDUP_WINDOW_MS).toISOString();
+
+  const { data: existing } = await supabase
     .from('sub_agent_execution_results')
-    .insert(record)
-    .select()
-    .single();
+    .select('id')
+    .eq('sd_id', normalizedSdId)
+    .eq('sub_agent_code', code)
+    .gte('created_at', dedupCutoff)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  let data, error;
+
+  if (existing?.length > 0) {
+    // Update existing record instead of creating duplicate
+    console.log(`   Dedup: updating existing record ${existing[0].id} (within ${DEDUP_WINDOW_MS / 60000}min window)`);
+    const { created_at: _keep, ...updateFields } = record;
+    const updateResult = await supabase
+      .from('sub_agent_execution_results')
+      .update({ ...updateFields, updated_at: new Date().toISOString() })
+      .eq('id', existing[0].id)
+      .select()
+      .single();
+    data = updateResult.data;
+    error = updateResult.error;
+  } else {
+    // Normal insert — no recent duplicate
+    const insertResult = await supabase
+      .from('sub_agent_execution_results')
+      .insert(record)
+      .select()
+      .single();
+    data = insertResult.data;
+    error = insertResult.error;
+  }
 
   if (error) {
     // SD-VENTURE-STAGE0-UI-001: Treat timeout errors as warnings, not fatal


### PR DESCRIPTION
## Summary
- Adds dedup check to `storeSubAgentResults()` in `lib/sub-agent-executor/results-storage.js`
- Prevents duplicate records in `sub_agent_execution_results` when same sub-agent runs twice for same SD within 5-minute window
- Updates existing record instead of inserting duplicate (TR-003)

## Test plan
- [x] Module loads without syntax errors
- [x] Smoke tests pass (15/15)
- [x] Pre-commit hooks pass (lint, LOC check, Gate 0)
- [x] EXEC-TO-PLAN handoff approved (94% score)

🤖 Generated with [Claude Code](https://claude.com/claude-code)