### PR TITLE
feat: Five-Point Brief validation for sub-agent prompts

### DIFF
--- a/lib/sub-agent-executor/executor.js
+++ b/lib/sub-agent-executor/executor.js
@@ -23,6 +23,7 @@ import {
   createArtifact
 } from '../artifact-tools.js';
 import { validateSubAgentOutput, HallucinationLevel } from '../validation/hallucination-check.js';
+import { validateBrief, buildRcaBriefTemplate, buildBriefTemplate } from './prompt-brief-validator.js';
 
 /**
  * Execute a sub-agent with standardized lifecycle
@@ -77,6 +78,32 @@ export async function executeSubAgent(code, sdId, options = {}) {
     }
     console.log(`   Recommended model: ${recommendedModel}`);
 
+    // Step 0c: Validate prompt against Five-Point Brief (advisory mode)
+    // SD-LEO-INFRA-SUB-AGENT-EXECUTION-001-A (FR-001, FR-002, FR-003)
+    const promptText = options.objective || options.prompt || '';
+    const briefResult = validateBrief(promptText);
+    if (!briefResult.valid) {
+      console.log(`   [Brief] Advisory: missing fields: ${briefResult.missing.join(', ')} (score: ${(briefResult.score * 100).toFixed(0)}%)`);
+      // FR-003: RCA-specific template pre-fill
+      if (code === 'RCA' && options.errorContext) {
+        const rcaBrief = buildRcaBriefTemplate(options.errorContext);
+        options._injectedBrief = rcaBrief;
+        console.log('   [Brief] RCA template injected from error context');
+      } else if (briefResult.missing.length > 0) {
+        // FR-002: Generic template injection with SD context
+        const briefTemplate = buildBriefTemplate({
+          sdKey: sdKey,
+          phase: normalizedPhase,
+          targetFiles: options.targetFiles || [],
+          missingFields: briefResult.missing,
+        });
+        options._injectedBrief = briefTemplate;
+        console.log(`   [Brief] Template injected for ${briefResult.missing.length} missing field(s)`);
+      }
+    } else {
+      console.log('   [Brief] All Five-Point Brief fields present (100%)');
+    }
+
     // Step 1: Load instructions from database (with Agent Experience Factory composition)
     const compositionContext = {
       sessionId: options.sessionId || `session-${Date.now()}`,
@@ -84,6 +111,11 @@ export async function executeSubAgent(code, sdId, options = {}) {
       maxPromptTokens: options.maxPromptTokens || 600
     };
     const subAgent = await loadSubAgentInstructions(code, compositionContext);
+
+    // Step 1b: Inject brief template into formatted instructions if available
+    if (options._injectedBrief && subAgent.injectBrief) {
+      subAgent.formatted = subAgent.injectBrief(options._injectedBrief);
+    }
 
     // Attach routing metadata for downstream use
     subAgent.routing = {

--- a/lib/sub-agent-executor/instruction-loader.js
+++ b/lib/sub-agent-executor/instruction-loader.js
@@ -59,7 +59,13 @@ export async function loadSubAgentInstructions(code, compositionContext = {}) {
     ...subAgent,
     relevantPatterns,
     compositionResult,
-    formatted
+    formatted,
+    // SD-LEO-INFRA-SUB-AGENT-EXECUTION-001-A (FR-002): Attach brief injection hook
+    injectBrief(briefTemplate) {
+      return briefTemplate
+        ? `${formatted}\n${briefTemplate}\n`
+        : formatted;
+    },
   };
 }
 

--- a/lib/sub-agent-executor/prompt-brief-validator.js
+++ b/lib/sub-agent-executor/prompt-brief-validator.js
@@ -1,0 +1,114 @@
+/**
+ * Prompt Brief Validator
+ * Validates sub-agent prompts contain Five-Point Brief fields.
+ * Advisory mode only — warns but does not block execution.
+ *
+ * SD-LEO-INFRA-SUB-AGENT-EXECUTION-001-A (FR-001, FR-003)
+ */
+
+const BRIEF_FIELDS = [
+  { key: 'symptom', patterns: [/symptom/i, /what\s+is\s+happening/i, /observed\s+behavior/i] },
+  { key: 'location', patterns: [/location/i, /file[s]?\s*[:/]/i, /endpoint/i, /table/i] },
+  { key: 'frequency', patterns: [/frequency/i, /pattern/i, /timing/i, /how\s+often/i, /always|intermittent|once/i] },
+  { key: 'prior_attempts', patterns: [/prior\s+attempts?/i, /already\s+tried/i, /previous(ly)?\s+(tried|attempted)/i] },
+  { key: 'desired_outcome', patterns: [/desired\s+outcome/i, /success\s+criteria/i, /expected\s+(result|behavior|outcome)/i] },
+];
+
+/**
+ * Validate a prompt for Five-Point Brief fields.
+ * Returns { valid, missing, present, score }.
+ *
+ * @param {string} prompt - The sub-agent prompt text
+ * @returns {{ valid: boolean, missing: string[], present: string[], score: number }}
+ */
+export function validateBrief(prompt) {
+  if (!prompt || typeof prompt !== 'string') {
+    return { valid: false, missing: BRIEF_FIELDS.map(f => f.key), present: [], score: 0 };
+  }
+
+  const present = [];
+  const missing = [];
+
+  for (const field of BRIEF_FIELDS) {
+    const found = field.patterns.some(p => p.test(prompt));
+    if (found) {
+      present.push(field.key);
+    } else {
+      missing.push(field.key);
+    }
+  }
+
+  const score = present.length / BRIEF_FIELDS.length;
+  return { valid: missing.length === 0, missing, present, score };
+}
+
+/**
+ * Build an RCA-specific brief template pre-filled from error context.
+ * FR-003: Pre-fills Symptom, Location, Prior attempts from available data.
+ *
+ * @param {Object} errorContext
+ * @param {string} [errorContext.errorMessage] - The error/failure message
+ * @param {string} [errorContext.filePath] - File where error occurred
+ * @param {number} [errorContext.retryCount] - Number of retries attempted
+ * @param {string} [errorContext.sdId] - Strategic Directive ID
+ * @returns {string} Pre-filled brief template section
+ */
+export function buildRcaBriefTemplate(errorContext = {}) {
+  const symptom = errorContext.errorMessage || '<describe what IS happening>';
+  const location = errorContext.filePath || '<file/endpoint/table>';
+  const retries = errorContext.retryCount ?? 0;
+  const priorAttempts = retries > 0
+    ? `Retried ${retries} time(s) without resolution`
+    : '<what you already tried>';
+
+  return [
+    '--- Five-Point Brief (RCA) ---',
+    `Symptom: ${symptom}`,
+    `Location: ${location}`,
+    'Frequency: Observed during current execution',
+    `Prior attempts: ${priorAttempts}`,
+    'Desired outcome: Root cause identified with corrective action',
+    '--- End Brief ---',
+  ].join('\n');
+}
+
+/**
+ * Build a generic brief template enriched with SD/PRD context.
+ * FR-002: Auto-fills available fields from resolved SD data.
+ *
+ * @param {Object} sdContext
+ * @param {string} [sdContext.sdKey] - SD key
+ * @param {string} [sdContext.phase] - Current phase
+ * @param {string[]} [sdContext.targetFiles] - Target files from PRD
+ * @param {string[]} [sdContext.missingFields] - Which brief fields are missing
+ * @returns {string} Brief template section to inject
+ */
+export function buildBriefTemplate(sdContext = {}) {
+  const lines = ['--- Five-Point Brief ---'];
+
+  const defaults = {
+    symptom: '<describe what IS happening>',
+    location: sdContext.targetFiles?.length
+      ? `Files: ${sdContext.targetFiles.slice(0, 3).join(', ')}`
+      : '<file/endpoint/table>',
+    frequency: '<pattern/timing>',
+    prior_attempts: '<what you already tried>',
+    desired_outcome: '<clear success criteria>',
+  };
+
+  const missing = sdContext.missingFields || Object.keys(defaults);
+
+  for (const field of BRIEF_FIELDS) {
+    if (missing.includes(field.key)) {
+      const label = field.key.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+      lines.push(`${label}: ${defaults[field.key]}`);
+    }
+  }
+
+  if (sdContext.sdKey) {
+    lines.push(`Context: SD ${sdContext.sdKey}${sdContext.phase ? ` (${sdContext.phase} phase)` : ''}`);
+  }
+
+  lines.push('--- End Brief ---');
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Adds advisory-mode Five-Point Brief validation to sub-agent executor (FR-001)
- Auto-injects brief templates with SD context when fields are missing (FR-002)
- RCA-specific template pre-fills Symptom/Location/Prior attempts from error context (FR-003)

## Changes
- **New**: `lib/sub-agent-executor/prompt-brief-validator.js` — validateBrief(), buildRcaBriefTemplate(), buildBriefTemplate()
- **Modified**: `lib/sub-agent-executor/executor.js` — Step 0c validation hook between SD resolution and instruction loading
- **Modified**: `lib/sub-agent-executor/instruction-loader.js` — injectBrief() method for template composition

## Test plan
- [x] 5 smoke tests pass (empty, full, partial, RCA template, generic template)
- [x] 15 existing smoke tests pass
- [x] Import resolution verified
- [ ] Integration test: invoke sub-agent without brief fields → advisory warning logged
- [ ] Integration test: RCA sub-agent with errorContext → template pre-filled

SD-LEO-INFRA-SUB-AGENT-EXECUTION-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)