### PR TITLE
feat: add AI wave clustering engine and CLI roadmap tooling

### DIFF
--- a/lib/integrations/wave-clusterer.js
+++ b/lib/integrations/wave-clusterer.js
@@ -1,0 +1,133 @@
+/**
+ * Wave Clusterer — AI-powered grouping of backlog items into roadmap waves
+ * SD: SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-C
+ *
+ * Groups classified intake/backlog items into 2-4 waves based on:
+ *   - Semantic similarity (AI) or keyword category (fallback)
+ *   - Priority ordering within waves
+ *   - Dependency relationships
+ *
+ * Pattern: AI classification with keyword fallback (intake-classifier.js)
+ */
+
+import { getClassificationClient } from '../llm/client-factory.js';
+import { WAVE_STATUSES } from './roadmap-taxonomy.js';
+
+const CLUSTER_CONFIG = {
+  MIN_WAVES: 2,
+  MAX_WAVES: 4,
+  MIN_ITEMS_PER_WAVE: 1,
+  AI_TIMEOUT_MS: 30000,
+};
+
+/**
+ * Build the LLM prompt to cluster items into waves.
+ * @param {Array<{id: string, title: string, description?: string, priority?: string, category?: string}>} items
+ * @returns {string}
+ */
+export function buildClusteringPrompt(items) {
+  const itemList = items.map((item, i) =>
+    `  ${i + 1}. [${item.priority || 'medium'}] ${item.title}${item.category ? ` (${item.category})` : ''}`
+  ).join('\n');
+
+  return `Group these ${items.length} backlog items into ${CLUSTER_CONFIG.MIN_WAVES}-${CLUSTER_CONFIG.MAX_WAVES} execution waves.
+
+Items:
+${itemList}
+
+Grouping criteria:
+- Wave 1 = highest priority / foundational items
+- Later waves = dependent or lower priority items
+- Group thematically similar items together
+- Each wave needs a descriptive title
+
+Respond with ONLY valid JSON (no markdown):
+{"waves": [{"title": "<wave title>", "description": "<1 sentence>", "item_indices": [1, 2]}]}`;
+}
+
+/**
+ * Parse AI clustering response into wave assignments.
+ * @param {string} response - Raw LLM text
+ * @param {number} itemCount - Total items for validation
+ * @returns {{ waves: Array<{title: string, description: string, item_indices: number[]}> } | null}
+ */
+export function parseClusteringResponse(response, itemCount) {
+  try {
+    const cleaned = response.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+    const parsed = JSON.parse(cleaned);
+    if (!parsed.waves || !Array.isArray(parsed.waves)) return null;
+
+    // Validate indices are in range
+    const allIndices = parsed.waves.flatMap(w => w.item_indices);
+    if (allIndices.some(i => i < 1 || i > itemCount)) return null;
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Keyword-based fallback clustering by priority + category.
+ * @param {Array<{id: string, title: string, priority?: string, category?: string}>} items
+ * @returns {{ waves: Array<{title: string, description: string, item_indices: number[]}> }}
+ */
+export function keywordCluster(items) {
+  const priorityOrder = { critical: 0, high: 1, medium: 2, low: 3 };
+  const sorted = items.map((item, i) => ({ ...item, originalIndex: i + 1 }))
+    .sort((a, b) => (priorityOrder[a.priority] ?? 2) - (priorityOrder[b.priority] ?? 2));
+
+  const waveSize = Math.ceil(sorted.length / CLUSTER_CONFIG.MAX_WAVES);
+  const waves = [];
+
+  for (let i = 0; i < sorted.length; i += waveSize) {
+    const chunk = sorted.slice(i, i + waveSize);
+    const waveNum = waves.length + 1;
+    waves.push({
+      title: `Wave ${waveNum}: ${waveNum === 1 ? 'Foundation' : waveNum === 2 ? 'Core Features' : 'Enhancements'}`,
+      description: `${chunk.length} items grouped by priority`,
+      item_indices: chunk.map(c => c.originalIndex),
+    });
+  }
+
+  return { waves };
+}
+
+/**
+ * Cluster backlog items into waves using AI with keyword fallback.
+ * @param {Array<{id: string, title: string, description?: string, priority?: string, category?: string}>} items
+ * @returns {Promise<{ waves: Array<{title: string, description: string, item_indices: number[]}>, method: 'ai' | 'keyword' }>}
+ */
+export async function clusterItems(items) {
+  if (!items || items.length === 0) {
+    throw new Error('No items to cluster');
+  }
+
+  if (items.length < CLUSTER_CONFIG.MIN_WAVES) {
+    return {
+      waves: [{ title: 'Wave 1: All Items', description: 'Single wave for small backlog', item_indices: items.map((_, i) => i + 1) }],
+      method: 'keyword',
+    };
+  }
+
+  // Try AI clustering
+  try {
+    const client = getClassificationClient();
+    const prompt = buildClusteringPrompt(items);
+    const response = await Promise.race([
+      client.generate(prompt),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('AI timeout')), CLUSTER_CONFIG.AI_TIMEOUT_MS)),
+    ]);
+
+    const parsed = parseClusteringResponse(response, items.length);
+    if (parsed && parsed.waves.length >= CLUSTER_CONFIG.MIN_WAVES) {
+      return { ...parsed, method: 'ai' };
+    }
+  } catch {
+    // Fall through to keyword clustering
+  }
+
+  return { ...keywordCluster(items), method: 'keyword' };
+}
+
+export { CLUSTER_CONFIG };

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * roadmap-generate.js — Generate a roadmap from SD backlog items
+ * SD: SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-C
+ *
+ * Reads from sd_backlog_map, clusters items into waves via wave-clusterer,
+ * and persists results to strategic_roadmaps + roadmap_waves + roadmap_wave_items.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { clusterItems } from '../lib/integrations/wave-clusterer.js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+async function fetchBacklogItems(visionKey) {
+  const query = supabase
+    .from('sd_backlog_map')
+    .select('id, backlog_title, item_description, priority, category, source_type, source_id')
+    .order('priority', { ascending: true });
+
+  if (visionKey) {
+    query.eq('vision_key', visionKey);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Failed to fetch backlog: ${error.message}`);
+  return data || [];
+}
+
+async function createRoadmap(title, visionKey) {
+  const { data, error } = await supabase
+    .from('strategic_roadmaps')
+    .insert({
+      title,
+      vision_key: visionKey || null,
+      status: 'draft',
+      created_by: 'leo-roadmap-generate',
+    })
+    .select('id')
+    .single();
+
+  if (error) throw new Error(`Failed to create roadmap: ${error.message}`);
+  return data.id;
+}
+
+async function createWaves(roadmapId, waves, items) {
+  const results = [];
+
+  for (let i = 0; i < waves.length; i++) {
+    const wave = waves[i];
+    const { data: waveRow, error: waveErr } = await supabase
+      .from('roadmap_waves')
+      .insert({
+        roadmap_id: roadmapId,
+        sequence_rank: i,
+        title: wave.title,
+        description: wave.description,
+        status: 'proposed',
+        confidence_score: 0,
+        created_by: 'leo-roadmap-generate',
+      })
+      .select('id')
+      .single();
+
+    if (waveErr) throw new Error(`Failed to create wave ${i}: ${waveErr.message}`);
+
+    // Insert wave items
+    const waveItems = wave.item_indices
+      .map(idx => items[idx - 1])
+      .filter(Boolean)
+      .map((item, rank) => ({
+        wave_id: waveRow.id,
+        source_type: item.source_type || 'todoist',
+        source_id: item.id,
+        title: item.backlog_title || item.title,
+        priority_rank: rank,
+      }));
+
+    if (waveItems.length > 0) {
+      const { error: itemErr } = await supabase
+        .from('roadmap_wave_items')
+        .insert(waveItems);
+      if (itemErr) console.warn(`  Warning: Could not insert items for wave ${i}: ${itemErr.message}`);
+    }
+
+    results.push({ waveId: waveRow.id, title: wave.title, itemCount: waveItems.length });
+  }
+
+  return results;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const titleFlag = args.indexOf('--title');
+  const visionFlag = args.indexOf('--vision-key');
+  const dryRun = args.includes('--dry-run');
+
+  const title = titleFlag >= 0 ? args[titleFlag + 1] : 'Auto-Generated Roadmap';
+  const visionKey = visionFlag >= 0 ? args[visionFlag + 1] : null;
+
+  console.log('Roadmap Generator');
+  console.log('═'.repeat(50));
+
+  // Fetch backlog items
+  const items = await fetchBacklogItems(visionKey);
+  console.log(`  Backlog items found: ${items.length}`);
+
+  if (items.length === 0) {
+    console.log('  No backlog items found. Populate sd_backlog_map first.');
+    process.exit(0);
+  }
+
+  // Cluster into waves
+  const clusterInput = items.map(item => ({
+    id: item.id,
+    title: item.backlog_title || '',
+    description: item.item_description || '',
+    priority: item.priority || 'medium',
+    category: item.category || '',
+  }));
+
+  const result = await clusterItems(clusterInput);
+  console.log(`  Clustering method: ${result.method}`);
+  console.log(`  Waves proposed: ${result.waves.length}`);
+
+  result.waves.forEach((wave, i) => {
+    console.log(`    Wave ${i + 1}: ${wave.title} (${wave.item_indices.length} items)`);
+  });
+
+  if (dryRun) {
+    console.log('\n  [DRY RUN] No changes written to database.');
+    return;
+  }
+
+  // Persist to database
+  const roadmapId = await createRoadmap(title, visionKey);
+  console.log(`\n  Roadmap created: ${roadmapId}`);
+
+  const waveResults = await createWaves(roadmapId, result.waves, items);
+  waveResults.forEach(w => {
+    console.log(`  Wave: ${w.title} → ${w.itemCount} items`);
+  });
+
+  console.log('\n  Done. Run `node scripts/roadmap-status.js` to view.');
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/roadmap-promote.js
+++ b/scripts/roadmap-promote.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * roadmap-promote.js — Promote wave items to Strategic Directives (stub)
+ * SD: SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-C
+ *
+ * Stub implementation for child -D (Wave-to-SD Promotion and Baseline Integration).
+ * Validates arguments and shows what would be promoted without creating SDs.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+async function main() {
+  const args = process.argv.slice(2);
+  const waveIdFlag = args.indexOf('--wave-id');
+  const waveId = waveIdFlag >= 0 ? args[waveIdFlag + 1] : null;
+
+  if (!waveId) {
+    console.log('Usage: node scripts/roadmap-promote.js --wave-id <uuid>');
+    console.log('\nPromotes all unassigned items in a wave to Strategic Directives.');
+    console.log('Note: Full implementation in child SD -D.');
+    process.exit(0);
+  }
+
+  // Fetch wave and its items
+  const { data: wave, error: wErr } = await supabase
+    .from('roadmap_waves')
+    .select('id, title, status')
+    .eq('id', waveId)
+    .single();
+
+  if (wErr || !wave) {
+    console.error(`Wave not found: ${waveId}`);
+    process.exit(1);
+  }
+
+  const { data: items, error: iErr } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, title, source_type, promoted_to_sd_key')
+    .eq('wave_id', waveId)
+    .order('priority_rank', { ascending: true });
+
+  if (iErr) { console.error('Error:', iErr.message); process.exit(1); }
+
+  const unpromoted = (items || []).filter(i => !i.promoted_to_sd_key);
+  const promoted = (items || []).filter(i => i.promoted_to_sd_key);
+
+  console.log(`Wave: ${wave.title} [${wave.status}]`);
+  console.log('═'.repeat(50));
+  console.log(`  Total items: ${(items || []).length}`);
+  console.log(`  Already promoted: ${promoted.length}`);
+  console.log(`  Ready to promote: ${unpromoted.length}`);
+
+  if (unpromoted.length > 0) {
+    console.log('\n  Items ready for promotion:');
+    unpromoted.forEach((item, i) => {
+      console.log(`    ${i + 1}. ${item.title || '(untitled)'} [${item.source_type}]`);
+    });
+  }
+
+  console.log('\n  [STUB] Full promotion logic will be implemented in child SD -D.');
+  console.log('  This will create SDs via leo-create-sd.js and update promoted_to_sd_key.');
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/roadmap-status.js
+++ b/scripts/roadmap-status.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * roadmap-status.js — Display roadmap wave status
+ * SD: SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-C
+ *
+ * Shows all roadmaps with their waves, item counts, and progress.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { WAVE_STATUS_LABELS } from '../lib/integrations/roadmap-taxonomy.js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+async function main() {
+  const args = process.argv.slice(2);
+  const roadmapIdFlag = args.indexOf('--roadmap-id');
+  const roadmapId = roadmapIdFlag >= 0 ? args[roadmapIdFlag + 1] : null;
+
+  // Fetch roadmaps
+  const roadmapQuery = supabase
+    .from('strategic_roadmaps')
+    .select('id, title, status, current_baseline_version, created_at')
+    .order('created_at', { ascending: false });
+
+  if (roadmapId) roadmapQuery.eq('id', roadmapId);
+
+  const { data: roadmaps, error: rmErr } = await roadmapQuery;
+  if (rmErr) { console.error('Error fetching roadmaps:', rmErr.message); process.exit(1); }
+
+  if (!roadmaps || roadmaps.length === 0) {
+    console.log('No roadmaps found. Run `node scripts/roadmap-generate.js` to create one.');
+    return;
+  }
+
+  console.log('Roadmap Status');
+  console.log('═'.repeat(60));
+
+  for (const rm of roadmaps) {
+    console.log(`\n  ${rm.title} [${rm.status.toUpperCase()}]`);
+    console.log(`  ID: ${rm.id}`);
+    console.log(`  Baseline: v${rm.current_baseline_version}`);
+    console.log(`  Created: ${new Date(rm.created_at).toLocaleDateString()}`);
+
+    // Fetch waves
+    const { data: waves, error: wErr } = await supabase
+      .from('roadmap_waves')
+      .select('id, sequence_rank, title, status, progress_pct, confidence_score')
+      .eq('roadmap_id', rm.id)
+      .order('sequence_rank', { ascending: true });
+
+    if (wErr) { console.warn(`  Warning: Could not fetch waves: ${wErr.message}`); continue; }
+
+    if (!waves || waves.length === 0) {
+      console.log('  No waves defined.');
+      continue;
+    }
+
+    console.log(`  Waves: ${waves.length}`);
+    console.log('  ' + '─'.repeat(56));
+
+    for (const wave of waves) {
+      // Count items per wave
+      const { count } = await supabase
+        .from('roadmap_wave_items')
+        .select('id', { count: 'exact', head: true })
+        .eq('wave_id', wave.id);
+
+      const promoted = await supabase
+        .from('roadmap_wave_items')
+        .select('id', { count: 'exact', head: true })
+        .eq('wave_id', wave.id)
+        .not('promoted_to_sd_key', 'is', null);
+
+      const statusLabel = WAVE_STATUS_LABELS[wave.status] || wave.status;
+      const progress = Number(wave.progress_pct || 0).toFixed(0);
+      const conf = Number(wave.confidence_score || 0).toFixed(2);
+
+      console.log(`    [${wave.sequence_rank}] ${wave.title}`);
+      console.log(`        Status: ${statusLabel} | Progress: ${progress}% | Confidence: ${conf}`);
+      console.log(`        Items: ${count || 0} | Promoted: ${promoted.count || 0}`);
+    }
+  }
+
+  console.log('\n' + '═'.repeat(60));
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Added `lib/integrations/wave-clusterer.js` — AI-powered clustering engine that groups backlog items into 2-4 execution waves using semantic similarity with keyword-based fallback
- Added `scripts/roadmap-generate.js` — CLI to generate roadmaps from SD backlog items, clustering into waves and persisting to database
- Added `scripts/roadmap-status.js` — CLI to display roadmap wave status with item counts and progress
- Added `scripts/roadmap-promote.js` — Stub for wave-to-SD promotion (full implementation in child -D)

## Test plan
- [ ] Verify `roadmap-generate.js --dry-run` clusters backlog items without database writes
- [ ] Verify `roadmap-status.js` displays roadmap waves with correct labels
- [ ] Verify `roadmap-promote.js --wave-id <uuid>` shows unpromoted items
- [ ] Verify wave-clusterer falls back to keyword clustering when AI unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)