### PR TITLE
feat: wave-to-SD promotion and baseline integration

### DIFF
--- a/lib/integrations/roadmap-manager.js
+++ b/lib/integrations/roadmap-manager.js
@@ -1,0 +1,252 @@
+/**
+ * Roadmap Manager Module
+ * Stateful operations for strategic roadmap lifecycle:
+ * approve, promote, baseline, query.
+ *
+ * SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-D (FR-002, FR-003)
+ */
+
+import { validateTransition } from './roadmap-taxonomy.js';
+
+/**
+ * Get the most recent active roadmap.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @returns {Promise<Object|null>}
+ */
+export async function getActiveRoadmap(supabase) {
+  const { data, error } = await supabase
+    .from('strategic_roadmaps')
+    .select('id, title, status, vision_key, current_baseline_version, created_at')
+    .eq('status', 'active')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error && error.code !== 'PGRST116') {
+    throw new Error(`Failed to get active roadmap: ${error.message}`);
+  }
+  return data || null;
+}
+
+/**
+ * Get stats for a roadmap: wave count, item counts, promotion progress.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} roadmapId
+ * @returns {Promise<Object>}
+ */
+export async function getRoadmapStats(supabase, roadmapId) {
+  const { data: waves, error: wErr } = await supabase
+    .from('roadmap_waves')
+    .select('id, title, status')
+    .eq('roadmap_id', roadmapId);
+
+  if (wErr) throw new Error(`Failed to get waves: ${wErr.message}`);
+
+  const waveIds = (waves || []).map(w => w.id);
+  let totalItems = 0;
+  let promotedItems = 0;
+
+  if (waveIds.length > 0) {
+    const { data: items, error: iErr } = await supabase
+      .from('roadmap_wave_items')
+      .select('id, promoted_to_sd_key')
+      .in('wave_id', waveIds);
+
+    if (iErr) throw new Error(`Failed to get items: ${iErr.message}`);
+    totalItems = (items || []).length;
+    promotedItems = (items || []).filter(i => i.promoted_to_sd_key).length;
+  }
+
+  return {
+    wave_count: (waves || []).length,
+    total_items: totalItems,
+    promoted_items: promotedItems,
+    completion_pct: totalItems > 0 ? Math.round((promotedItems / totalItems) * 100) : 0,
+  };
+}
+
+/**
+ * Get baseline snapshot history for a roadmap.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} roadmapId
+ * @returns {Promise<Array>}
+ */
+export async function getBaselineHistory(supabase, roadmapId) {
+  const { data, error } = await supabase
+    .from('roadmap_baseline_snapshots')
+    .select('id, version, wave_sequence, change_rationale, approved_by, created_at')
+    .eq('roadmap_id', roadmapId)
+    .order('version', { ascending: false });
+
+  if (error) throw new Error(`Failed to get baseline history: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Approve a wave sequence: transitions waves from proposed→approved,
+ * creates a baseline snapshot, and increments the roadmap version.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} roadmapId
+ * @param {string} rationale - Change rationale from Chairman
+ * @returns {Promise<{version: number, snapshotId: string}>}
+ */
+export async function approveSequence(supabase, roadmapId, rationale) {
+  // Fetch roadmap
+  const { data: roadmap, error: rErr } = await supabase
+    .from('strategic_roadmaps')
+    .select('id, current_baseline_version')
+    .eq('id', roadmapId)
+    .single();
+
+  if (rErr || !roadmap) throw new Error(`Roadmap not found: ${roadmapId}`);
+
+  // Fetch all waves with items for snapshot
+  const { data: waves, error: wErr } = await supabase
+    .from('roadmap_waves')
+    .select('id, title, status, sequence_rank, confidence_score')
+    .eq('roadmap_id', roadmapId)
+    .order('sequence_rank', { ascending: true });
+
+  if (wErr) throw new Error(`Failed to get waves: ${wErr.message}`);
+
+  // Build wave sequence snapshot (include items per wave)
+  const waveSequence = [];
+  for (const wave of (waves || [])) {
+    const { data: items } = await supabase
+      .from('roadmap_wave_items')
+      .select('id, title, source_type, promoted_to_sd_key, priority_rank')
+      .eq('wave_id', wave.id)
+      .order('priority_rank', { ascending: true });
+
+    waveSequence.push({
+      wave_id: wave.id,
+      title: wave.title,
+      status: wave.status,
+      sequence_rank: wave.sequence_rank,
+      items: items || [],
+    });
+  }
+
+  // Increment version
+  const newVersion = (roadmap.current_baseline_version || 0) + 1;
+
+  // Create baseline snapshot
+  const { data: snapshot, error: sErr } = await supabase
+    .from('roadmap_baseline_snapshots')
+    .insert({
+      roadmap_id: roadmapId,
+      version: newVersion,
+      wave_sequence: waveSequence,
+      change_rationale: rationale,
+      approved_by: 'chairman',
+    })
+    .select('id')
+    .single();
+
+  if (sErr) throw new Error(`Failed to create snapshot: ${sErr.message}`);
+
+  // Update roadmap version
+  await supabase
+    .from('strategic_roadmaps')
+    .update({ current_baseline_version: newVersion, status: 'active' })
+    .eq('id', roadmapId);
+
+  // Transition proposed waves to approved
+  for (const wave of (waves || [])) {
+    if (wave.status === 'proposed') {
+      const check = validateTransition('proposed', 'approved');
+      if (check.valid) {
+        await supabase
+          .from('roadmap_waves')
+          .update({ status: 'approved' })
+          .eq('id', wave.id);
+      }
+    }
+  }
+
+  return { version: newVersion, snapshotId: snapshot.id };
+}
+
+/**
+ * Promote unpromoted wave items to Strategic Directives.
+ * Creates one SD per item, updates promoted_to_sd_key, transitions wave to active.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} waveId
+ * @returns {Promise<{created: string[], skipped: number, errors: string[]}>}
+ */
+export async function promoteWaveToSDs(supabase, waveId) {
+  const { data: wave, error: wErr } = await supabase
+    .from('roadmap_waves')
+    .select('id, title, status, roadmap_id')
+    .eq('id', waveId)
+    .single();
+
+  if (wErr || !wave) throw new Error(`Wave not found: ${waveId}`);
+
+  const { data: items, error: iErr } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, title, source_type, promoted_to_sd_key, priority_rank')
+    .eq('wave_id', waveId)
+    .order('priority_rank', { ascending: true });
+
+  if (iErr) throw new Error(`Failed to get items: ${iErr.message}`);
+
+  const unpromoted = (items || []).filter(i => !i.promoted_to_sd_key);
+  const created = [];
+  const errors = [];
+
+  for (const item of unpromoted) {
+    try {
+      const sdTitle = `[Wave: ${wave.title}] ${item.title || 'Untitled item'}`;
+      const sdKey = `SD-WAVE-${waveId.substring(0, 8).toUpperCase()}-${String(created.length + 1).padStart(3, '0')}`;
+
+      const { data: sd, error: sdErr } = await supabase
+        .from('strategic_directives_v2')
+        .insert({
+          sd_key: sdKey,
+          title: sdTitle.substring(0, 200),
+          status: 'draft',
+          sd_type: 'feature',
+          description: `Promoted from roadmap wave "${wave.title}" (source: ${item.source_type})`,
+          scope: `Wave item: ${item.title}`,
+          success_metrics: [
+            { metric: 'Implementation completeness', target: '100%', actual: null },
+          ],
+        })
+        .select('sd_key')
+        .single();
+
+      if (sdErr) throw sdErr;
+
+      // Update tracking
+      await supabase
+        .from('roadmap_wave_items')
+        .update({ promoted_to_sd_key: sd.sd_key })
+        .eq('id', item.id);
+
+      created.push(sd.sd_key);
+    } catch (err) {
+      errors.push(`${item.title}: ${err.message}`);
+    }
+  }
+
+  // Transition wave to active on first promotion
+  if (created.length > 0 && (wave.status === 'approved' || wave.status === 'proposed')) {
+    const targetStatus = wave.status === 'proposed' ? 'approved' : 'active';
+    const check = validateTransition(wave.status, targetStatus);
+    if (check.valid) {
+      await supabase
+        .from('roadmap_waves')
+        .update({ status: targetStatus })
+        .eq('id', waveId);
+    }
+  }
+
+  return {
+    created,
+    skipped: (items || []).length - unpromoted.length,
+    errors,
+  };
+}

--- a/scripts/roadmap-promote.js
+++ b/scripts/roadmap-promote.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 /**
- * roadmap-promote.js — Promote wave items to Strategic Directives (stub)
- * SD: SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-C
+ * roadmap-promote.js — Promote wave items to Strategic Directives
+ * SD: SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-D
  *
- * Stub implementation for child -D (Wave-to-SD Promotion and Baseline Integration).
- * Validates arguments and shows what would be promoted without creating SDs.
+ * Creates SDs for unpromoted wave items, updates tracking fields,
+ * and transitions wave status. Also supports --approve for baseline snapshots.
  */
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import { promoteWaveToSDs, approveSequence, getRoadmapStats } from '../lib/integrations/roadmap-manager.js';
 
 dotenv.config();
 
@@ -21,15 +22,27 @@ async function main() {
   const args = process.argv.slice(2);
   const waveIdFlag = args.indexOf('--wave-id');
   const waveId = waveIdFlag >= 0 ? args[waveIdFlag + 1] : null;
+  const approveFlag = args.includes('--approve');
+  const roadmapIdFlag = args.indexOf('--roadmap-id');
+  const roadmapId = roadmapIdFlag >= 0 ? args[roadmapIdFlag + 1] : null;
+  const rationaleFlag = args.indexOf('--rationale');
+  const rationale = rationaleFlag >= 0 ? args[rationaleFlag + 1] : 'Approved via CLI';
+  const dryRun = args.includes('--dry-run');
+
+  if (approveFlag && roadmapId) {
+    return handleApprove(roadmapId, rationale);
+  }
 
   if (!waveId) {
-    console.log('Usage: node scripts/roadmap-promote.js --wave-id <uuid>');
-    console.log('\nPromotes all unassigned items in a wave to Strategic Directives.');
-    console.log('Note: Full implementation in child SD -D.');
+    console.log('Usage:');
+    console.log('  node scripts/roadmap-promote.js --wave-id <uuid>              Promote wave items to SDs');
+    console.log('  node scripts/roadmap-promote.js --wave-id <uuid> --dry-run    Preview without creating');
+    console.log('  node scripts/roadmap-promote.js --approve --roadmap-id <uuid> Approve wave sequence');
+    console.log('    --rationale "reason"                                        (optional rationale)');
     process.exit(0);
   }
 
-  // Fetch wave and its items
+  // Fetch wave and items for preview
   const { data: wave, error: wErr } = await supabase
     .from('roadmap_waves')
     .select('id, title, status')
@@ -52,21 +65,66 @@ async function main() {
   const unpromoted = (items || []).filter(i => !i.promoted_to_sd_key);
   const promoted = (items || []).filter(i => i.promoted_to_sd_key);
 
-  console.log(`Wave: ${wave.title} [${wave.status}]`);
-  console.log('═'.repeat(50));
+  console.log(`\nWave: ${wave.title} [${wave.status}]`);
+  console.log('═'.repeat(60));
   console.log(`  Total items: ${(items || []).length}`);
   console.log(`  Already promoted: ${promoted.length}`);
   console.log(`  Ready to promote: ${unpromoted.length}`);
 
-  if (unpromoted.length > 0) {
-    console.log('\n  Items ready for promotion:');
-    unpromoted.forEach((item, i) => {
-      console.log(`    ${i + 1}. ${item.title || '(untitled)'} [${item.source_type}]`);
+  if (promoted.length > 0) {
+    console.log('\n  Already promoted:');
+    promoted.forEach((item, i) => {
+      console.log(`    ✓ ${item.title || '(untitled)'} → ${item.promoted_to_sd_key}`);
     });
   }
 
-  console.log('\n  [STUB] Full promotion logic will be implemented in child SD -D.');
-  console.log('  This will create SDs via leo-create-sd.js and update promoted_to_sd_key.');
+  if (unpromoted.length === 0) {
+    console.log('\n  All items already promoted. Nothing to do.');
+    process.exit(0);
+  }
+
+  console.log('\n  Items to promote:');
+  unpromoted.forEach((item, i) => {
+    console.log(`    ${i + 1}. ${item.title || '(untitled)'} [${item.source_type}]`);
+  });
+
+  if (dryRun) {
+    console.log('\n  [DRY RUN] No SDs created. Remove --dry-run to execute.');
+    process.exit(0);
+  }
+
+  // Execute promotion
+  console.log('\n  Promoting...');
+  const result = await promoteWaveToSDs(supabase, waveId);
+
+  console.log('\n  Results:');
+  console.log(`    Created: ${result.created.length} SDs`);
+  result.created.forEach(key => console.log(`      → ${key}`));
+  if (result.skipped > 0) {
+    console.log(`    Skipped: ${result.skipped} (already promoted)`);
+  }
+  if (result.errors.length > 0) {
+    console.log(`    Errors: ${result.errors.length}`);
+    result.errors.forEach(e => console.log(`      ✗ ${e}`));
+  }
+  console.log('═'.repeat(60));
+}
+
+async function handleApprove(roadmapId, rationale) {
+  console.log(`\nApproving wave sequence for roadmap: ${roadmapId}`);
+  console.log('═'.repeat(60));
+
+  const result = await approveSequence(supabase, roadmapId, rationale);
+
+  console.log(`  ✓ Baseline snapshot created (version ${result.version})`);
+  console.log(`  ✓ Snapshot ID: ${result.snapshotId}`);
+  console.log(`  ✓ Rationale: ${rationale}`);
+
+  const stats = await getRoadmapStats(supabase, roadmapId);
+  console.log('\n  Roadmap stats:');
+  console.log(`    Waves: ${stats.wave_count}`);
+  console.log(`    Items: ${stats.total_items} (${stats.promoted_items} promoted, ${stats.completion_pct}%)`);
+  console.log('═'.repeat(60));
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- Implements full wave-to-SD promotion logic in `roadmap-promote.js` (replaces stub)
- Creates `roadmap-manager.js` with approveSequence(), promoteWaveToSDs(), getActiveRoadmap(), getRoadmapStats(), getBaselineHistory()
- Baseline snapshots capture complete wave sequence JSONB with version tracking

## Changes
- **New**: `lib/integrations/roadmap-manager.js` — stateful roadmap lifecycle operations
- **Modified**: `scripts/roadmap-promote.js` — full promotion + approval CLI with --dry-run support

## Test plan
- [x] All 15 smoke tests pass
- [x] Import resolution verified for all 5 exports
- [x] CLI help output works correctly
- [ ] Integration: promote wave with items → SDs created
- [ ] Integration: approve sequence → baseline snapshot created

SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-D

🤖 Generated with [Claude Code](https://claude.com/claude-code)