### PR TITLE
feat: add OKR-wave linkage and Chairman approval proposal workflow

### DIFF
--- a/lib/integrations/okr-wave-linker.js
+++ b/lib/integrations/okr-wave-linker.js
@@ -1,0 +1,216 @@
+/**
+ * OKR-Wave Linker Module
+ * SD: SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-E
+ *
+ * Manages bidirectional linkage between OKR objectives and roadmap wave items.
+ * Stores linkage in wave_items metadata JSONB column.
+ * Calculates alignment scores per wave and per roadmap.
+ */
+
+/**
+ * Link a wave item to an OKR objective.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} waveItemId - UUID of the wave item
+ * @param {string} okrId - Identifier for the OKR objective (e.g., "O-GOV-1" or "KR-GOV-1.1")
+ * @param {string} [rationale] - Why this item aligns with the OKR
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export async function linkOkrToWaveItem(supabase, waveItemId, okrId, rationale) {
+  const { data: item, error: fetchErr } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, metadata')
+    .eq('id', waveItemId)
+    .single();
+
+  if (fetchErr || !item) {
+    return { success: false, error: `Wave item not found: ${waveItemId}` };
+  }
+
+  const metadata = item.metadata || {};
+  const linkages = metadata.okr_linkages || [];
+
+  // Prevent duplicate linkage
+  if (linkages.some(l => l.okr_id === okrId)) {
+    return { success: false, error: `Already linked to ${okrId}` };
+  }
+
+  linkages.push({
+    okr_id: okrId,
+    rationale: rationale || null,
+    linked_at: new Date().toISOString(),
+  });
+
+  const { error: updateErr } = await supabase
+    .from('roadmap_wave_items')
+    .update({ metadata: { ...metadata, okr_linkages: linkages } })
+    .eq('id', waveItemId);
+
+  if (updateErr) {
+    return { success: false, error: updateErr.message };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Unlink a wave item from an OKR objective.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} waveItemId
+ * @param {string} okrId
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export async function unlinkOkrFromWaveItem(supabase, waveItemId, okrId) {
+  const { data: item, error: fetchErr } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, metadata')
+    .eq('id', waveItemId)
+    .single();
+
+  if (fetchErr || !item) {
+    return { success: false, error: `Wave item not found: ${waveItemId}` };
+  }
+
+  const metadata = item.metadata || {};
+  const linkages = metadata.okr_linkages || [];
+  const filtered = linkages.filter(l => l.okr_id !== okrId);
+
+  if (filtered.length === linkages.length) {
+    return { success: false, error: `Not linked to ${okrId}` };
+  }
+
+  const { error: updateErr } = await supabase
+    .from('roadmap_wave_items')
+    .update({ metadata: { ...metadata, okr_linkages: filtered } })
+    .eq('id', waveItemId);
+
+  if (updateErr) {
+    return { success: false, error: updateErr.message };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Calculate alignment scores for all waves in a roadmap.
+ * Alignment = items with OKR linkage / total items per wave.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} roadmapId
+ * @returns {Promise<{waves: Array<{wave_id: string, title: string, total_items: number, linked_items: number, alignment_pct: number, okr_ids: string[]}>, overall_alignment_pct: number}>}
+ */
+export async function calculateAlignment(supabase, roadmapId) {
+  const { data: waves, error: wErr } = await supabase
+    .from('roadmap_waves')
+    .select('id, title, sequence_rank')
+    .eq('roadmap_id', roadmapId)
+    .order('sequence_rank', { ascending: true });
+
+  if (wErr) throw new Error(`Failed to fetch waves: ${wErr.message}`);
+
+  let totalItems = 0;
+  let totalLinked = 0;
+  const waveResults = [];
+
+  for (const wave of (waves || [])) {
+    const { data: items } = await supabase
+      .from('roadmap_wave_items')
+      .select('id, title, metadata')
+      .eq('wave_id', wave.id);
+
+    const waveItems = items || [];
+    const linkedItems = waveItems.filter(i => {
+      const linkages = i.metadata?.okr_linkages || [];
+      return linkages.length > 0;
+    });
+
+    const allOkrIds = new Set();
+    linkedItems.forEach(i => {
+      (i.metadata?.okr_linkages || []).forEach(l => allOkrIds.add(l.okr_id));
+    });
+
+    totalItems += waveItems.length;
+    totalLinked += linkedItems.length;
+
+    waveResults.push({
+      wave_id: wave.id,
+      title: wave.title,
+      sequence_rank: wave.sequence_rank,
+      total_items: waveItems.length,
+      linked_items: linkedItems.length,
+      alignment_pct: waveItems.length > 0
+        ? Math.round((linkedItems.length / waveItems.length) * 100)
+        : 0,
+      okr_ids: [...allOkrIds],
+    });
+  }
+
+  return {
+    waves: waveResults,
+    overall_alignment_pct: totalItems > 0
+      ? Math.round((totalLinked / totalItems) * 100)
+      : 0,
+  };
+}
+
+/**
+ * Create a Chairman approval proposal for a roadmap's wave sequence.
+ * Inserts into chairman_decisions with roadmap context and OKR alignment data.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} roadmapId
+ * @param {object} [options]
+ * @param {string} [options.rationale] - Proposal rationale
+ * @returns {Promise<{decisionId: string, alignment: object}>}
+ */
+export async function createProposal(supabase, roadmapId, options = {}) {
+  // Fetch roadmap
+  const { data: roadmap, error: rErr } = await supabase
+    .from('strategic_roadmaps')
+    .select('id, title, status, current_baseline_version')
+    .eq('id', roadmapId)
+    .single();
+
+  if (rErr || !roadmap) {
+    throw new Error(`Roadmap not found: ${roadmapId}`);
+  }
+
+  // Calculate alignment
+  const alignment = await calculateAlignment(supabase, roadmapId);
+
+  // Build context for Chairman
+  const context = {
+    roadmap_id: roadmapId,
+    roadmap_title: roadmap.title,
+    current_baseline_version: roadmap.current_baseline_version || 0,
+    proposed_baseline_version: (roadmap.current_baseline_version || 0) + 1,
+    overall_alignment_pct: alignment.overall_alignment_pct,
+    wave_summary: alignment.waves.map(w => ({
+      title: w.title,
+      items: w.total_items,
+      okr_aligned: w.linked_items,
+      alignment_pct: w.alignment_pct,
+      okrs: w.okr_ids,
+    })),
+    proposal_rationale: options.rationale || 'Wave sequence ready for Chairman review',
+  };
+
+  // Insert chairman decision
+  const { data: decision, error: dErr } = await supabase
+    .from('chairman_decisions')
+    .insert({
+      decision_type: 'roadmap_approval',
+      status: 'pending',
+      blocking: true,
+      summary: `Roadmap approval: ${roadmap.title} (v${context.proposed_baseline_version})`,
+      rationale: options.rationale || null,
+      context,
+    })
+    .select('id')
+    .single();
+
+  if (dErr) {
+    throw new Error(`Failed to create proposal: ${dErr.message}`);
+  }
+
+  return { decisionId: decision.id, alignment };
+}

--- a/scripts/roadmap-okr-proposal.js
+++ b/scripts/roadmap-okr-proposal.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * roadmap-okr-proposal.js — OKR-wave linkage and Chairman approval CLI
+ * SD: SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001-E
+ *
+ * Subcommands:
+ *   link     --wave-item-id <uuid> --okr-id <id> [--rationale "reason"]
+ *   unlink   --wave-item-id <uuid> --okr-id <id>
+ *   status   --roadmap-id <uuid>
+ *   propose  --roadmap-id <uuid> [--rationale "reason"]
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import {
+  linkOkrToWaveItem,
+  unlinkOkrFromWaveItem,
+  calculateAlignment,
+  createProposal,
+} from '../lib/integrations/okr-wave-linker.js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+function parseArg(args, flag) {
+  const idx = args.indexOf(flag);
+  return idx >= 0 ? args[idx + 1] : null;
+}
+
+async function handleLink(args) {
+  const waveItemId = parseArg(args, '--wave-item-id');
+  const okrId = parseArg(args, '--okr-id');
+  const rationale = parseArg(args, '--rationale');
+
+  if (!waveItemId || !okrId) {
+    console.log('Usage: node scripts/roadmap-okr-proposal.js link --wave-item-id <uuid> --okr-id <id> [--rationale "reason"]');
+    process.exit(0);
+  }
+
+  const result = await linkOkrToWaveItem(supabase, waveItemId, okrId, rationale);
+
+  if (result.success) {
+    console.log('OKR-Wave Linkage');
+    console.log('═'.repeat(50));
+    console.log(`  ✓ Linked wave item to ${okrId}`);
+    if (rationale) console.log(`  Rationale: ${rationale}`);
+  } else {
+    console.error(`  ✗ ${result.error}`);
+    process.exit(1);
+  }
+}
+
+async function handleUnlink(args) {
+  const waveItemId = parseArg(args, '--wave-item-id');
+  const okrId = parseArg(args, '--okr-id');
+
+  if (!waveItemId || !okrId) {
+    console.log('Usage: node scripts/roadmap-okr-proposal.js unlink --wave-item-id <uuid> --okr-id <id>');
+    process.exit(0);
+  }
+
+  const result = await unlinkOkrFromWaveItem(supabase, waveItemId, okrId);
+
+  if (result.success) {
+    console.log('OKR-Wave Unlink');
+    console.log('═'.repeat(50));
+    console.log(`  ✓ Removed linkage to ${okrId}`);
+  } else {
+    console.error(`  ✗ ${result.error}`);
+    process.exit(1);
+  }
+}
+
+async function handleStatus(args) {
+  const roadmapId = parseArg(args, '--roadmap-id');
+
+  if (!roadmapId) {
+    console.log('Usage: node scripts/roadmap-okr-proposal.js status --roadmap-id <uuid>');
+    process.exit(0);
+  }
+
+  const { data: roadmap } = await supabase
+    .from('strategic_roadmaps')
+    .select('title, status')
+    .eq('id', roadmapId)
+    .single();
+
+  if (!roadmap) {
+    console.error(`Roadmap not found: ${roadmapId}`);
+    process.exit(1);
+  }
+
+  const alignment = await calculateAlignment(supabase, roadmapId);
+
+  console.log('OKR Alignment Status');
+  console.log('═'.repeat(60));
+  console.log(`  Roadmap: ${roadmap.title} [${roadmap.status}]`);
+  console.log(`  Overall Alignment: ${alignment.overall_alignment_pct}%`);
+  console.log('');
+
+  if (alignment.waves.length === 0) {
+    console.log('  No waves found.');
+    return;
+  }
+
+  console.log('  ' + '─'.repeat(56));
+  for (const wave of alignment.waves) {
+    const bar = alignment.overall_alignment_pct > 0
+      ? '█'.repeat(Math.round(wave.alignment_pct / 10)) + '░'.repeat(10 - Math.round(wave.alignment_pct / 10))
+      : '░'.repeat(10);
+
+    console.log(`  [${wave.sequence_rank}] ${wave.title}`);
+    console.log(`      Items: ${wave.total_items} | Linked: ${wave.linked_items} | ${bar} ${wave.alignment_pct}%`);
+    if (wave.okr_ids.length > 0) {
+      console.log(`      OKRs: ${wave.okr_ids.join(', ')}`);
+    }
+    console.log('');
+  }
+}
+
+async function handlePropose(args) {
+  const roadmapId = parseArg(args, '--roadmap-id');
+  const rationale = parseArg(args, '--rationale');
+
+  if (!roadmapId) {
+    console.log('Usage: node scripts/roadmap-okr-proposal.js propose --roadmap-id <uuid> [--rationale "reason"]');
+    process.exit(0);
+  }
+
+  console.log('Chairman Approval Proposal');
+  console.log('═'.repeat(60));
+
+  const { decisionId, alignment } = await createProposal(supabase, roadmapId, { rationale });
+
+  console.log(`  ✓ Proposal created`);
+  console.log(`  Decision ID: ${decisionId}`);
+  console.log(`  Overall OKR Alignment: ${alignment.overall_alignment_pct}%`);
+  console.log(`  Waves: ${alignment.waves.length}`);
+  if (rationale) console.log(`  Rationale: ${rationale}`);
+  console.log('');
+  console.log('  The Chairman will review this proposal in the decision queue.');
+  console.log('  Once approved, run `node scripts/roadmap-baseline.js create` to lock the baseline.');
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const subcommand = args[0];
+
+  if (!subcommand || !['link', 'unlink', 'status', 'propose'].includes(subcommand)) {
+    console.log('Usage: node scripts/roadmap-okr-proposal.js <link|unlink|status|propose> [options]');
+    console.log('');
+    console.log('Subcommands:');
+    console.log('  link     --wave-item-id <uuid> --okr-id <id> [--rationale "reason"]  Link item to OKR');
+    console.log('  unlink   --wave-item-id <uuid> --okr-id <id>                         Remove linkage');
+    console.log('  status   --roadmap-id <uuid>                                         Show alignment');
+    console.log('  propose  --roadmap-id <uuid> [--rationale "reason"]                  Submit for approval');
+    process.exit(0);
+  }
+
+  switch (subcommand) {
+    case 'link': await handleLink(args); break;
+    case 'unlink': await handleUnlink(args); break;
+    case 'status': await handleStatus(args); break;
+    case 'propose': await handlePropose(args); break;
+  }
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `lib/integrations/okr-wave-linker.js` — bidirectional OKR-wave linkage module with link/unlink/alignment calculation/proposal creation
- Add `scripts/roadmap-okr-proposal.js` — CLI with 4 subcommands: link, unlink, status, propose
- Alignment scoring calculates per-wave and overall percentage of items linked to OKR objectives
- Chairman approval proposals inserted into existing `chairman_decisions` table with `decision_type='roadmap_approval'`

Child -E of SD-LEO-FEAT-STRATEGIC-ROADMAP-ARTIFACT-001 (Strategic Roadmap Artifact orchestrator)

## Test plan
- [ ] Run `node scripts/roadmap-okr-proposal.js` to verify CLI help output
- [ ] Verify `linkOkrToWaveItem` prevents duplicate linkages
- [ ] Verify `calculateAlignment` handles empty waves correctly
- [ ] Verify `createProposal` inserts into chairman_decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)