### PR TITLE
fix: defer vision scoring to fire-and-forget in SD creation

### DIFF
--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1317,10 +1317,12 @@ async function createSD(options) {
   }
 
   // Vision pre-screen at SD conception (SD-LEO-INFRA-VISION-SD-CONCEPTION-GATE-001)
-  await scoreSDAtConception(data.sd_key, title, description, supabase, {
+  // Fire-and-forget: vision scoring is advisory and should not block SD creation.
+  // Blocking here caused duplicate SDs when the script timed out after DB insert.
+  scoreSDAtConception(data.sd_key, title, description, supabase, {
     visionKey: metadata?.vision_key,
     archKey: metadata?.arch_key
-  });
+  }).catch(err => console.log(`\n   ⚠️  Vision pre-screen failed (non-blocking): ${err.message}`));
 
   // OKR Auto-Mapping at SD creation (SD-MAN-FEAT-CORRECTIVE-VISION-GAP-070)
   // Automatically link new SDs to the most relevant active OKR objective


### PR DESCRIPTION
## Summary
- Changed `scoreSDAtConception()` from `await` to fire-and-forget in `leo-create-sd.js`
- Vision scoring has a 15s timeout + LLM calls that blocked the script return after the DB insert was already committed
- When the overall script timed out (30s default), re-running created duplicate SDs because the first insert had already succeeded
- Vision scoring is advisory — it writes to `eva_vision_scores` but does not affect the SD record itself

## Test plan
- [x] All 7 existing vision prescreen tests pass
- [x] `scoreSDAtConception` still runs and logs results, just doesn't block script completion

QF-20260308-552

🤖 Generated with [Claude Code](https://claude.com/claude-code)