### PR TITLE
fix: repair EVA intake AI classification pipeline

### DIFF
--- a/lib/integrations/intake-classifier.js
+++ b/lib/integrations/intake-classifier.js
@@ -54,6 +54,11 @@ export function buildClassificationPrompt(title, description, context = {}) {
 
   return `Classify this intake item into 3 dimensions: Application, Aspects, and Intent.
 
+Context: The Chairman is a solo entrepreneur building a venture validation platform with two tightly integrated products:
+- ehg_engineer: The backend engine — LEO Protocol (AI-orchestrated multi-agent workflow), EVA pipeline (25-stage venture lifecycle management), intake classification, database schema, CLI tooling, sub-agents, CI/CD, and all orchestration logic.
+- ehg_app: The unified web frontend — Chairman Glass Cockpit (daily briefing, decision queue, vision alignment), venture management UI, admin panel, analytics dashboards, Asset Factory, Content Forge, GTM dashboards, and all user-facing interfaces.
+Items were saved by the Chairman as reference material, ideas, or insights relevant to building these products. Videos about AI tools, engineering practices, product design, automation, or workflow optimization almost always relate to ehg_engineer or ehg_app. Only classify as "new_venture" if the item is clearly about starting a separate, unrelated business venture — NOT if it's about technology, patterns, or trends that could inform the existing platform.
+
 Title: ${title}
 Description: ${description || 'No description'}${contextSection}
 
@@ -122,12 +127,14 @@ export async function getAIRecommendation(title, description, context = {}) {
     const { getClassificationClient } = await import('../llm/client-factory.js');
     const client = await getClassificationClient();
     const prompt = buildClassificationPrompt(title, description, context);
-    const content = await client.complete(
+    const response = await client.complete(
       'You are a precise classification system for a strategic management platform. Respond with only valid JSON.',
       prompt,
-      { maxTokens: 150 }
+      { maxTokens: 1024 }
     );
-    return parseAIClassification(content);
+    // Adapters return { content: string, ... } — extract the text
+    const text = typeof response === 'string' ? response : response?.content;
+    return parseAIClassification(text);
   } catch {
     return null;
   }

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -387,15 +387,21 @@ export class GoogleAdapter {
           generationConfig.responseMimeType = 'application/json';
         }
 
-        // Thinking level support (Gemini 3.x only — 2.x models don't support thinkingConfig)
+        // Thinking level support
         const effortLevel = options.effortLevel || this.effortLevel;
         const isGemini3x = /^gemini-3/.test(model);
+        const isGemini2_5 = /^gemini-2\.5/.test(model);
         if (effortLevel && isGemini3x) {
           const family = model.includes('flash') ? 'flash' : 'pro';
           const levelMap = GEMINI_THINKING_LEVELS[family] || GEMINI_THINKING_LEVELS.pro;
           generationConfig.thinkingConfig = {
             thinkingLevel: levelMap[effortLevel] || 'low'
           };
+        } else if (isGemini2_5 && !effortLevel) {
+          // Gemini 2.5 has built-in thinking that shares the maxOutputTokens budget.
+          // Disable it for simple tasks (classification, fast) to prevent thinking
+          // from consuming 90%+ of the output token budget.
+          generationConfig.thinkingConfig = { thinkingBudget: 0 };
         }
 
         const response = await fetch(


### PR DESCRIPTION
## Summary
- Fixed LLM adapter response extraction in `intake-classifier.js` — was passing full `{content, provider, usage}` object to JSON parser instead of extracting `.content` string
- Increased `maxTokens` from 150 to 1024 to accommodate Gemini 2.5 Flash's shared thinking budget
- Added Chairman/platform context to classification prompt for accurate app routing (ehg_engineer vs ehg_app vs new_venture)
- Disabled Gemini 2.5 built-in thinking for simple tasks (`thinkingBudget: 0`) in `provider-adapters.js` to prevent thinking from consuming 90%+ of output token budget

## Test plan
- [x] Dry run: 10 YouTube items classified correctly (8 ehg_engineer, 2 ehg_app, 0 new_venture at 90% confidence)
- [x] AI method used (not keyword_fallback) for all 10 items
- [ ] Full batch classification of remaining 195 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)