### PR TITLE
fix: remove nonexistent youtube_metadata column from intake query

### DIFF
--- a/lib/integrations/intake-classifier.js
+++ b/lib/integrations/intake-classifier.js
@@ -373,7 +373,7 @@ export async function getUnclassifiedItems(supabase, options = {}) {
   if (sources.includes('todoist')) {
     const { data } = await supabase
       .from('eva_todoist_intake')
-      .select('id, title, description, venture_tag, business_function, todoist_parent_id, todoist_task_id, todoist_labels, extracted_youtube_id, youtube_metadata, created_at')
+      .select('id, title, description, venture_tag, business_function, todoist_parent_id, todoist_task_id, todoist_labels, extracted_youtube_id, created_at')
       .is('classified_at', null)
       .order('created_at', { ascending: true })
       .limit(limit);


### PR DESCRIPTION
## Summary
- Removed `youtube_metadata` from `getUnclassifiedItems()` select query — column doesn't exist on `eva_todoist_intake` table
- This caused the query to silently fail (Supabase error 42703), making batch classification report "No unclassified items found" despite 104 items existing

## Test plan
- [x] Verified 104 Todoist items now returned by getUnclassifiedItems()
- [x] Full batch classification of all 205 items completed successfully (100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)