### PR TITLE
feat: add /distill command with archive step

### DIFF
--- a/.claude/commands/distill.md
+++ b/.claude/commands/distill.md
@@ -1,0 +1,141 @@
+# Distill Command
+
+Refine raw ideas from all sources into strategic roadmap waves.
+
+Runs the full EVA intake pipeline: **Sync → Classify → AI Wave Clustering → Archive → Roadmap Status**
+
+## Arguments
+
+Parse `$ARGUMENTS` for flags:
+- No args → Full pipeline
+- `--dry-run` → Preview only, no DB writes
+- `--skip-sync` → Skip Todoist/YouTube sync, start at classify
+- `--from-step N` → Start from step N (1-4)
+- `--app <app>` → Filter clustering by application (ehg_engineer, ehg_app, new_venture)
+- `--skip-archive` → Skip moving items to Processed (Todoist project / YouTube playlist)
+- `status` → Show current roadmap status only
+- `approve --roadmap-id <id>` → Chairman approves wave sequence
+- `promote --wave-id <id>` → Promote approved wave items to SDs
+
+## Instructions
+
+### If argument is "status":
+
+```bash
+node scripts/roadmap-status.js
+```
+
+Display the output showing all roadmaps with their waves, item counts, and progress.
+
+---
+
+### If argument starts with "approve":
+
+Extract `--roadmap-id` from arguments:
+
+```bash
+node scripts/roadmap-promote.js --approve --roadmap-id <id>
+```
+
+If `--roadmap-id` is missing, show usage:
+```
+Usage: /distill approve --roadmap-id <uuid>
+       /distill approve --roadmap-id <uuid> --rationale "reason"
+```
+
+---
+
+### If argument starts with "promote":
+
+Extract `--wave-id` from arguments:
+
+```bash
+node scripts/roadmap-promote.js --wave-id <id>
+```
+
+Add `--dry-run` if the user included it. If `--wave-id` is missing, show usage:
+```
+Usage: /distill promote --wave-id <uuid>
+       /distill promote --wave-id <uuid> --dry-run
+```
+
+---
+
+### If no subcommand (default — run pipeline):
+
+**Step 1: Build the command**
+
+Start with the base command and append flags from arguments:
+
+```bash
+node scripts/eva-intake-pipeline.js [flags]
+```
+
+Pass through any flags the user provided (`--dry-run`, `--skip-sync`, `--from-step N`, `--app <app>`).
+
+**Step 2: Execute the pipeline**
+
+```bash
+node scripts/eva-intake-pipeline.js $FLAGS
+```
+
+Use `timeout: 600000` (10 minutes) — the AI classification and clustering steps can take time with 200+ items.
+
+**Step 3: Present results**
+
+After the pipeline completes, summarize:
+- How many items were synced (if sync ran)
+- Classification coverage (should be 100% if all items classified)
+- Number of waves proposed and their themes
+- Whether results were persisted (live run) or previewed (dry run)
+
+**Step 4: Next steps**
+
+If this was a live run (not dry-run), show:
+```
+Chairman Review (next steps):
+  /distill status                              View roadmap waves
+  /distill approve --roadmap-id <id>           Approve wave sequence
+  /distill promote --wave-id <id>              Promote wave to SDs
+```
+
+If this was a dry run, suggest:
+```
+Looks good? Run without --dry-run to persist:
+  /distill
+  /distill --skip-sync    (if items already synced)
+```
+
+---
+
+## Pipeline Steps Reference
+
+| Step | What it does | Script |
+|------|-------------|--------|
+| 1. Sync | Pull new items from Todoist + YouTube | `eva-idea-sync.js` |
+| 2. Classify | AI classification using 3D taxonomy (App + Aspects + Intent) | `eva-intake-classify.js` |
+| 3. Cluster | AI groups classified items into 2-6 execution waves | `roadmap-generate.js` |
+| 4. Archive | Move classified items to Processed (Todoist project + YouTube playlist) | `eva-intake-archive.js` |
+| 5. Status | Display roadmap with wave breakdown | `roadmap-status.js` |
+
+## Examples
+
+```
+/distill                          # Full pipeline (sync + classify + cluster + status)
+/distill --dry-run                # Preview without writing to DB
+/distill --skip-sync              # Skip sync, classify + cluster existing items
+/distill --app ehg_engineer       # Only cluster items for EHG Engineer
+/distill status                   # View current roadmap waves
+/distill approve --roadmap-id abc # Chairman approves wave sequence
+/distill promote --wave-id xyz    # Promote approved wave to SDs
+```
+
+## Command Ecosystem
+
+| Before this | After this |
+|-------------|------------|
+| Todoist/YouTube capture | `/distill` processes raw ideas |
+| `/distill` completes | `/distill status` to review waves |
+| Chairman reviews waves | `/distill approve` to lock sequence |
+| Waves approved | `/distill promote` to create SDs |
+| SDs created | `/leo next` to begin work |

--- a/lib/integrations/post-processor.js
+++ b/lib/integrations/post-processor.js
@@ -59,12 +59,23 @@ async function postProcessTodoist(options = {}) {
 
   const api = new TodoistApi(token);
 
-  // Get evaluated items not yet processed
-  const { data: items } = await supabase
+  // Get items ready for archival:
+  // - Legacy evaluation flow: status in approved/rejected/needs_revision
+  // - New distill flow: classified (classified_at set) and still pending
+  const { data: legacyItems } = await supabase
     .from('eva_todoist_intake')
     .select('id, todoist_task_id, status')
     .in('status', ['approved', 'rejected', 'needs_revision'])
     .is('processed_at', null);
+
+  const { data: classifiedItems } = await supabase
+    .from('eva_todoist_intake')
+    .select('id, todoist_task_id, status')
+    .eq('status', 'pending')
+    .not('classified_at', 'is', null)
+    .is('processed_at', null);
+
+  const items = [...(legacyItems || []), ...(classifiedItems || [])];
 
   if (!items || items.length === 0) {
     if (options.verbose) console.log('  Todoist: No items to post-process');
@@ -98,9 +109,21 @@ async function postProcessTodoist(options = {}) {
         console.log(`    Processed: ${item.todoist_task_id} → ${label}`);
       }
     } catch (err) {
-      results.errors.push({ id: item.id, error: err.message });
-      if (options.verbose) {
-        console.error(`    Error processing ${item.todoist_task_id}: ${err.message}`);
+      // 403/404 = task completed/deleted in Todoist — mark processed anyway
+      if (err.message?.includes('403') || err.message?.includes('404')) {
+        await supabase
+          .from('eva_todoist_intake')
+          .update({ status: 'processed', processed_at: new Date().toISOString() })
+          .eq('id', item.id);
+        results.processed++;
+        if (options.verbose) {
+          console.log(`    Archived (source unavailable): ${item.todoist_task_id}`);
+        }
+      } else {
+        results.errors.push({ id: item.id, error: err.message });
+        if (options.verbose) {
+          console.error(`    Error processing ${item.todoist_task_id}: ${err.message}`);
+        }
       }
     }
   }
@@ -163,12 +186,23 @@ async function postProcessYouTube(options = {}) {
     return results;
   }
 
-  // Get evaluated items not yet processed
-  const { data: items } = await supabase
+  // Get items ready for archival:
+  // - Legacy evaluation flow: status in approved/rejected/needs_revision
+  // - New distill flow: classified (classified_at set) and still pending
+  const { data: legacyItems } = await supabase
     .from('eva_youtube_intake')
     .select('id, youtube_video_id, youtube_playlist_item_id, status')
     .in('status', ['approved', 'rejected', 'needs_revision'])
     .is('processed_at', null);
+
+  const { data: classifiedItems } = await supabase
+    .from('eva_youtube_intake')
+    .select('id, youtube_video_id, youtube_playlist_item_id, status')
+    .eq('status', 'pending')
+    .not('classified_at', 'is', null)
+    .is('processed_at', null);
+
+  const items = [...(legacyItems || []), ...(classifiedItems || [])];
 
   if (!items || items.length === 0) {
     if (options.verbose) console.log('  YouTube: No items to post-process');

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "eva:ideas:auth:youtube": "node scripts/eva-youtube-auth.js",
     "eva:intake:classify": "node scripts/eva-intake-classify.js",
     "eva:intake:pipeline": "node scripts/eva-intake-pipeline.js",
+    "eva:distill": "node scripts/eva-intake-pipeline.js",
     "roadmap:generate": "node scripts/roadmap-generate.js",
     "roadmap:status": "node scripts/roadmap-status.js",
     "roadmap:approve": "node scripts/roadmap-promote.js --approve",

--- a/scripts/eva-intake-archive.js
+++ b/scripts/eva-intake-archive.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * EVA Intake Archive — Move processed items to their archive destinations
+ *
+ * Todoist: Moves classified tasks from EVA/EVA Next Steps → "Processed" project
+ * YouTube: Moves classified videos from "For Processing" → "Processed" playlist
+ *
+ * Only archives items that have been classified (classified_at IS NOT NULL)
+ * and not yet processed (processed_at IS NULL).
+ */
+
+import dotenv from 'dotenv';
+dotenv.config();
+
+async function main() {
+  const { postProcessAll } = await import('../lib/integrations/post-processor.js');
+
+  const result = await postProcessAll({ verbose: true });
+
+  console.log('');
+  console.log('  Archive summary:');
+  console.log(`    Todoist: ${result.todoist.processed} moved to Processed project`);
+  console.log(`    YouTube: ${result.youtube.processed} moved to Processed playlist`);
+
+  if (result.totalErrors > 0) {
+    console.log(`    Errors: ${result.totalErrors}`);
+    for (const e of [...result.todoist.errors, ...result.youtube.errors]) {
+      console.log(`      - ${e.id}: ${e.error}`);
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('Archive error:', err.message);
+  process.exit(1);
+});

--- a/scripts/eva-intake-pipeline.js
+++ b/scripts/eva-intake-pipeline.js
@@ -11,9 +11,10 @@
  * Usage:
  *   npm run eva:intake:pipeline                    # Full pipeline
  *   npm run eva:intake:pipeline -- --dry-run       # Preview only, no DB writes
- *   npm run eva:intake:pipeline -- --from-step N   # Start from step N (1-4)
+ *   npm run eva:intake:pipeline -- --from-step N   # Start from step N (1-5)
  *   npm run eva:intake:pipeline -- --skip-sync     # Skip sync, start at classify
  *   npm run eva:intake:pipeline -- --app <app>     # Filter clustering by application
+ *   npm run eva:intake:pipeline -- --skip-archive  # Skip archiving processed items
  *
  * Post-pipeline (separate Chairman actions):
  *   npm run roadmap:approve -- --roadmap-id <id>   # Chairman reviews + approves waves
@@ -31,6 +32,7 @@ const root = join(__dirname, '..');
 const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
 const skipSync = args.includes('--skip-sync');
+const skipArchive = args.includes('--skip-archive');
 const fromStepIdx = args.indexOf('--from-step');
 const fromStep = fromStepIdx >= 0 ? parseInt(args[fromStepIdx + 1], 10) || 1 : 1;
 const appIdx = args.indexOf('--app');
@@ -57,7 +59,7 @@ function header(step, title) {
 console.log('');
 console.log('══════════════════════════════════════════════════════');
 console.log('  EVA INTAKE PIPELINE');
-console.log('  Sync → Classify → Propose Waves → Status');
+console.log('  Sync → Classify → Propose Waves → Archive → Status');
 console.log('══════════════════════════════════════════════════════');
 
 // ─── Step 1: Sync ───────────────────────────────────────────
@@ -111,12 +113,27 @@ if (fromStep <= 3) {
   console.log('\n── Step 3: Propose ── SKIPPED\n');
 }
 
-// ─── Step 4: Status ─────────────────────────────────────────
-if (fromStep <= 4) {
-  header(4, 'Roadmap status');
+// ─── Step 4: Archive ────────────────────────────────────────
+if (fromStep <= 4 && !skipArchive) {
+  header(4, 'Archive processed items');
+  if (dryRun) {
+    console.log('  [DRY RUN] Would move classified items to Processed (Todoist project + YouTube playlist)\n');
+  } else {
+    const ok = run('node scripts/eva-intake-archive.js');
+    if (!ok) {
+      console.error('  ⚠ Archive had errors. Items remain in source. Check output above.\n');
+    }
+  }
+} else {
+  console.log('\n── Step 4: Archive ── SKIPPED\n');
+}
+
+// ─── Step 5: Status ─────────────────────────────────────────
+if (fromStep <= 5) {
+  header(5, 'Roadmap status');
   run('node scripts/roadmap-status.js');
 } else {
-  console.log('\n── Step 4: Status ── SKIPPED\n');
+  console.log('\n── Step 5: Status ── SKIPPED\n');
 }
 
 // ─── Summary ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add archive step (Step 4) to EVA intake pipeline — moves classified items to "Processed" project (Todoist) and "Processed" playlist (YouTube)
- Update post-processor to handle both legacy evaluation flow and new distill flow items
- Add graceful 403/404 handling for Todoist tasks that were completed/deleted
- Add `/distill` slash command as branded one-word pipeline entry point
- Add `--skip-archive` flag and `eva:distill` npm script alias

## Test plan
- [x] Full pipeline run: 281 items classified, 256 archived (25 YouTube pending API quota reset)
- [x] Todoist: 154 items archived (101 moved + 52 source-unavailable + 1 already processed)
- [x] YouTube: 99 videos moved to Processed playlist
- [x] 403/404 graceful handling verified with 52 completed Todoist tasks
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)