### PR TITLE
feat: incremental roadmap with baseline control

### DIFF
--- a/lib/integrations/wave-clusterer.js
+++ b/lib/integrations/wave-clusterer.js
@@ -8,6 +8,10 @@
  *   - Semantic similarity (AI) or keyword category (fallback)
  *   - Priority ordering within waves
  *
+ * Supports two modes:
+ *   - Full clustering: Groups all classified items into new waves (first run / draft roadmap)
+ *   - Incremental assignment: Assigns only new items to existing baselined waves
+ *
  * Architecture ref: docs/plans/strategic-roadmap-artifact-architecture.md
  */
 
@@ -72,6 +76,182 @@ export async function loadClassifiedIntakeItems(supabase, options = {}) {
   }
 
   return items.slice(0, limit);
+}
+
+/**
+ * Load classified intake items that are NOT yet assigned to any roadmap wave.
+ * Used for incremental mode — only returns items that need wave assignment.
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} [options]
+ * @param {string} [options.application] - Filter by target_application
+ * @param {number} [options.limit] - Max items to return (default: 500)
+ * @returns {Promise<Array>}
+ */
+export async function loadNewIntakeItems(supabase, options = {}) {
+  // Get all source_ids already assigned to a wave
+  const { data: assigned } = await supabase
+    .from('roadmap_wave_items')
+    .select('source_id');
+
+  const assignedIds = new Set((assigned || []).map(r => r.source_id));
+
+  // Load all classified items, then filter out already-assigned ones
+  const allItems = await loadClassifiedIntakeItems(supabase, options);
+  return allItems.filter(item => !assignedIds.has(item.id));
+}
+
+/**
+ * Build the LLM prompt to assign new items into existing waves.
+ * @param {Array} items - New items to assign
+ * @param {Array<{title: string, description: string, sample_titles: string[]}>} existingWaves
+ * @returns {string}
+ */
+export function buildAssignmentPrompt(items, existingWaves) {
+  const waveList = existingWaves.map((w, i) =>
+    `  ${i + 1}. "${w.title}" — ${w.description}${w.sample_titles.length > 0 ? '\n     Examples: ' + w.sample_titles.slice(0, 5).join(', ') : ''}`
+  ).join('\n');
+
+  const itemList = items.map((item, i) =>
+    `  ${i + 1}. [${item.target_application}] [${item.chairman_intent}] ${(item.title || '').slice(0, 100)} (aspects: ${(item.target_aspects || []).join(', ')})`
+  ).join('\n');
+
+  return `You are assigning new intake items to existing roadmap waves.
+
+The roadmap has been baselined with these approved waves:
+${waveList}
+
+Assign each of these ${items.length} new items to the BEST matching existing wave.
+If an item clearly does not fit ANY existing wave, assign it to wave 0 (unmatched).
+
+New items:
+${itemList}
+
+Respond with ONLY valid JSON (no markdown, no explanation):
+{"assignments": [{"item_index": 1, "wave_index": 2}, {"item_index": 2, "wave_index": 1}]}
+
+Rules:
+- item_index is 1-based (matching the item list above)
+- wave_index is 1-based (matching the wave list above), or 0 for unmatched
+- Every item must appear exactly once
+- Prefer matching by application and thematic similarity
+- Only use wave 0 if the item truly doesn't fit any wave`;
+}
+
+/**
+ * Parse AI assignment response.
+ * @param {string} response - Raw LLM text
+ * @param {number} itemCount
+ * @param {number} waveCount
+ * @returns {{ assignments: Array<{item_index: number, wave_index: number}> } | null}
+ */
+export function parseAssignmentResponse(response, itemCount, waveCount) {
+  try {
+    const cleaned = response.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+    const parsed = JSON.parse(cleaned);
+    if (!parsed.assignments || !Array.isArray(parsed.assignments)) return null;
+
+    // Validate indices
+    for (const a of parsed.assignments) {
+      if (a.item_index < 1 || a.item_index > itemCount) return null;
+      if (a.wave_index < 0 || a.wave_index > waveCount) return null;
+    }
+
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Keyword-based fallback for assigning items to existing waves.
+ * Matches by application name in wave title.
+ * @param {Array} items
+ * @param {Array<{title: string}>} existingWaves
+ * @returns {{ assignments: Array<{item_index: number, wave_index: number}> }}
+ */
+export function keywordAssign(items, existingWaves) {
+  const assignments = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const app = item.target_application || '';
+
+    // Try to match by application keyword in wave title
+    let bestWave = 0;
+    for (let w = 0; w < existingWaves.length; w++) {
+      const title = existingWaves[w].title.toLowerCase();
+      if (app === 'ehg_engineer' && (title.includes('engineer') || title.includes('protocol') || title.includes('foundational'))) {
+        bestWave = w + 1;
+        break;
+      }
+      if (app === 'ehg_app' && (title.includes('chairman') || title.includes('ui') || title.includes('oversight'))) {
+        bestWave = w + 1;
+        break;
+      }
+      if (app === 'new_venture' && (title.includes('venture') || title.includes('product') || title.includes('exploration'))) {
+        bestWave = w + 1;
+        break;
+      }
+    }
+
+    // Fallback: assign to the largest wave (most general)
+    if (bestWave === 0 && existingWaves.length > 0) {
+      bestWave = 1;
+    }
+
+    assignments.push({ item_index: i + 1, wave_index: bestWave });
+  }
+
+  return { assignments };
+}
+
+/**
+ * Assign new items to existing baselined waves using AI with keyword fallback.
+ * @param {Array} items - New items to assign
+ * @param {Array<{id: string, title: string, description: string, sample_titles: string[]}>} existingWaves - Current wave info
+ * @returns {Promise<{ assignments: Array<{item_index: number, wave_index: number}>, unmatched: number[], method: 'ai' | 'keyword' }>}
+ */
+export async function assignToExistingWaves(items, existingWaves) {
+  if (!items || items.length === 0) {
+    return { assignments: [], unmatched: [], method: 'keyword' };
+  }
+
+  // Try AI assignment
+  try {
+    const client = await getClassificationClient();
+    const prompt = buildAssignmentPrompt(items, existingWaves);
+    let timeoutId;
+    const response = await Promise.race([
+      client.complete(
+        'You are a strategic planning system. Assign items to existing waves. Respond with only valid JSON.',
+        prompt,
+        { maxTokens: 4096 }
+      ),
+      new Promise((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('AI timeout')), CLUSTER_CONFIG.AI_TIMEOUT_MS);
+        if (timeoutId.unref) timeoutId.unref();
+      }),
+    ]);
+    clearTimeout(timeoutId);
+
+    const text = typeof response === 'string' ? response : response?.content;
+    const parsed = parseAssignmentResponse(text, items.length, existingWaves.length);
+    if (parsed) {
+      const unmatched = parsed.assignments
+        .filter(a => a.wave_index === 0)
+        .map(a => a.item_index);
+      return { ...parsed, unmatched, method: 'ai' };
+    }
+  } catch (err) {
+    console.warn(`  AI assignment failed: ${err.message}. Using keyword fallback.`);
+  }
+
+  // Keyword fallback
+  const result = keywordAssign(items, existingWaves);
+  const unmatched = result.assignments
+    .filter(a => a.wave_index === 0)
+    .map(a => a.item_index);
+  return { ...result, unmatched, method: 'keyword' };
 }
 
 /**

--- a/scripts/eva-intake-archive.js
+++ b/scripts/eva-intake-archive.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * EVA Intake Archive — Move processed items to their archive destinations
+ * EVA Intake Archive — Archive processed items at their source
  *
- * Todoist: Moves classified tasks from EVA/EVA Next Steps → "Processed" project
- * YouTube: Moves classified videos from "For Processing" → "Processed" playlist
+ * Todoist: Complete (check off) classified tasks via Sync API
+ * YouTube: Remove from "For Processing" + add to "Processed" playlist
  *
  * Only archives items that have been classified (classified_at IS NOT NULL)
  * and not yet processed (processed_at IS NULL).
@@ -19,7 +19,7 @@ async function main() {
 
   console.log('');
   console.log('  Archive summary:');
-  console.log(`    Todoist: ${result.todoist.processed} moved to Processed project`);
+  console.log(`    Todoist: ${result.todoist.processed} completed (checked off)`);
   console.log(`    YouTube: ${result.youtube.processed} moved to Processed playlist`);
 
   if (result.totalErrors > 0) {

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -1,23 +1,30 @@
 #!/usr/bin/env node
 /**
- * roadmap-generate.js — Generate a roadmap from classified intake items
+ * roadmap-generate.js — Generate or incrementally update a roadmap from classified intake items
  *
- * Reads classified items directly from eva_todoist_intake and eva_youtube_intake,
- * clusters them into waves via wave-clusterer, and persists results to
- * strategic_roadmaps + roadmap_waves + roadmap_wave_items.
+ * Two modes:
+ *   1. Full (no baselined roadmap): Cluster all classified items into new waves
+ *   2. Incremental (baselined roadmap exists): Assign only NEW items to existing waves
  *
- * Architecture ref: docs/plans/strategic-roadmap-artifact-architecture.md
+ * The baseline acts as a control mechanism — once approved, items are locked.
+ * New weekly distills only add to existing waves, never re-cluster.
  *
  * Usage:
- *   node scripts/roadmap-generate.js                              # Generate from all classified items
+ *   node scripts/roadmap-generate.js                              # Auto-detect mode
  *   node scripts/roadmap-generate.js --title "Q2 Roadmap"         # Custom roadmap title
  *   node scripts/roadmap-generate.js --app ehg_engineer            # Filter by application
  *   node scripts/roadmap-generate.js --dry-run                     # Preview without writing to DB
+ *   node scripts/roadmap-generate.js --full                        # Force full clustering (ignore baseline)
  */
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
-import { clusterItems, loadClassifiedIntakeItems } from '../lib/integrations/wave-clusterer.js';
+import {
+  clusterItems,
+  loadClassifiedIntakeItems,
+  loadNewIntakeItems,
+  assignToExistingWaves,
+} from '../lib/integrations/wave-clusterer.js';
 
 dotenv.config();
 
@@ -25,6 +32,56 @@ const supabase = createClient(
   process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
   process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 );
+
+/**
+ * Find the active baselined roadmap (status='active', baseline_version > 0).
+ * Returns null if no baselined roadmap exists.
+ */
+async function getBaselinedRoadmap() {
+  const { data, error } = await supabase
+    .from('strategic_roadmaps')
+    .select('id, title, status, current_baseline_version')
+    .eq('status', 'active')
+    .gt('current_baseline_version', 0)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  if (error || !data || data.length === 0) return null;
+  return data[0];
+}
+
+/**
+ * Load existing waves with sample item titles for context.
+ */
+async function loadExistingWaves(roadmapId) {
+  const { data: waves, error } = await supabase
+    .from('roadmap_waves')
+    .select('id, title, description, sequence_rank')
+    .eq('roadmap_id', roadmapId)
+    .order('sequence_rank', { ascending: true });
+
+  if (error || !waves) return [];
+
+  // Fetch a few sample titles per wave for AI context
+  const result = [];
+  for (const wave of waves) {
+    const { data: items } = await supabase
+      .from('roadmap_wave_items')
+      .select('title')
+      .eq('wave_id', wave.id)
+      .limit(5);
+
+    result.push({
+      id: wave.id,
+      title: wave.title,
+      description: wave.description || '',
+      sequence_rank: wave.sequence_rank,
+      sample_titles: (items || []).map(i => i.title).filter(Boolean),
+    });
+  }
+
+  return result;
+}
 
 async function createRoadmap(title) {
   const { data, error } = await supabase
@@ -85,17 +142,108 @@ async function createWaves(roadmapId, waves, items) {
   return results;
 }
 
-async function main() {
-  const args = process.argv.slice(2);
-  const titleFlag = args.indexOf('--title');
-  const appFlag = args.indexOf('--app');
-  const dryRun = args.includes('--dry-run');
+/**
+ * Incremental mode: assign new items to existing baselined waves.
+ */
+async function runIncremental(roadmap, options) {
+  const { application, dryRun } = options;
 
-  const title = titleFlag >= 0 ? args[titleFlag + 1] : 'EVA Intake Roadmap';
-  const application = appFlag >= 0 ? args[appFlag + 1] : undefined;
+  console.log(`  Mode: INCREMENTAL (baseline v${roadmap.current_baseline_version})`);
+  console.log(`  Roadmap: ${roadmap.title} [${roadmap.id.substring(0, 8)}]`);
 
-  console.log('Roadmap Generator');
-  console.log('═'.repeat(50));
+  // Load only items not yet assigned to any wave
+  const newItems = await loadNewIntakeItems(supabase, { application, limit: 500 });
+  console.log(`  New items (not in any wave): ${newItems.length}`);
+
+  if (newItems.length === 0) {
+    console.log('  No new items to assign. Roadmap is up to date.');
+    return;
+  }
+
+  // Show distribution of new items
+  const byApp = {};
+  const byIntent = {};
+  for (const item of newItems) {
+    byApp[item.target_application] = (byApp[item.target_application] || 0) + 1;
+    byIntent[item.chairman_intent] = (byIntent[item.chairman_intent] || 0) + 1;
+  }
+  console.log('  By application:', Object.entries(byApp).map(([k, v]) => `${k}(${v})`).join(', '));
+  console.log('  By intent:', Object.entries(byIntent).map(([k, v]) => `${k}(${v})`).join(', '));
+
+  // Load existing waves for assignment context
+  const existingWaves = await loadExistingWaves(roadmap.id);
+  console.log(`  Existing waves: ${existingWaves.length}`);
+  existingWaves.forEach(w => console.log(`    [${w.sequence_rank}] ${w.title}`));
+
+  // AI assigns new items to existing waves
+  console.log('\n  Assigning new items to existing waves...');
+  const result = await assignToExistingWaves(newItems, existingWaves);
+  console.log(`  Method: ${result.method}`);
+
+  // Summarize assignments per wave
+  const waveCounts = {};
+  for (const a of result.assignments) {
+    const waveTitle = a.wave_index > 0 ? existingWaves[a.wave_index - 1].title : 'UNMATCHED';
+    waveCounts[waveTitle] = (waveCounts[waveTitle] || 0) + 1;
+  }
+
+  console.log('\n  Assignment summary:');
+  for (const [title, count] of Object.entries(waveCounts)) {
+    console.log(`    ${title}: +${count} items`);
+  }
+
+  if (result.unmatched.length > 0) {
+    console.log(`\n  Unmatched items (${result.unmatched.length}):`);
+    result.unmatched.forEach(idx => {
+      const item = newItems[idx - 1];
+      if (item) console.log(`    - [${item.target_application}] ${(item.title || '').slice(0, 70)}`);
+    });
+    console.log('  These items need manual wave assignment or a roadmap restructure.');
+  }
+
+  if (dryRun) {
+    console.log('\n  [DRY RUN] No changes written to database.');
+    return;
+  }
+
+  // Persist: insert new wave items into existing waves
+  let inserted = 0;
+  for (const a of result.assignments) {
+    if (a.wave_index === 0) continue; // Skip unmatched
+
+    const item = newItems[a.item_index - 1];
+    const wave = existingWaves[a.wave_index - 1];
+    if (!item || !wave) continue;
+
+    const { error } = await supabase
+      .from('roadmap_wave_items')
+      .insert({
+        wave_id: wave.id,
+        source_type: item.source_type,
+        source_id: item.id,
+      });
+
+    if (error) {
+      console.warn(`  Warning: Could not insert item ${item.id} into wave ${wave.title}: ${error.message}`);
+    } else {
+      inserted++;
+    }
+  }
+
+  console.log(`\n  Inserted ${inserted} items into existing waves.`);
+  if (result.unmatched.length > 0) {
+    console.log(`  ${result.unmatched.length} unmatched items not inserted.`);
+  }
+  console.log('  Done. Review with: node scripts/roadmap-status.js');
+}
+
+/**
+ * Full mode: cluster all items into new waves (original behavior).
+ */
+async function runFull(options) {
+  const { title, application, dryRun } = options;
+
+  console.log('  Mode: FULL CLUSTERING');
 
   // Load classified intake items directly from intake tables
   const items = await loadClassifiedIntakeItems(supabase, { application, limit: 500 });
@@ -157,6 +305,31 @@ async function main() {
 
   console.log('\n  Done. Review waves with: node scripts/roadmap-status.js');
   console.log(`  Approve waves with:      node scripts/roadmap-promote.js --approve --roadmap-id ${roadmapId}`);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const titleFlag = args.indexOf('--title');
+  const appFlag = args.indexOf('--app');
+  const dryRun = args.includes('--dry-run');
+  const forceFull = args.includes('--full');
+
+  const title = titleFlag >= 0 ? args[titleFlag + 1] : 'EVA Intake Roadmap';
+  const application = appFlag >= 0 ? args[appFlag + 1] : undefined;
+
+  console.log('Roadmap Generator');
+  console.log('═'.repeat(50));
+
+  // Auto-detect mode: if a baselined roadmap exists, use incremental
+  if (!forceFull) {
+    const baselinedRoadmap = await getBaselinedRoadmap();
+    if (baselinedRoadmap) {
+      await runIncremental(baselinedRoadmap, { application, dryRun });
+      return;
+    }
+  }
+
+  await runFull({ title, application, dryRun });
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- Roadmap generator auto-detects baselined roadmaps and switches to incremental mode
- New weekly items are AI-assigned to existing waves instead of creating duplicate roadmaps
- Baseline acts as a control mechanism — items are locked once approved
- Added `--full` flag to force re-clustering when needed
- Fixed archive summary text (now says "completed" instead of "moved to Processed project")

## Changes
- `lib/integrations/wave-clusterer.js` — `loadNewIntakeItems()`, `assignToExistingWaves()`, assignment prompt/parser, keyword fallback
- `scripts/roadmap-generate.js` — incremental vs full mode auto-detection, `--full` flag
- `scripts/eva-intake-archive.js` — corrected summary text

## Test plan
- [x] Full mode works when no baseline exists (dry-run verified)
- [x] Incremental mode activates when baselined roadmap detected
- [x] 23 new items correctly assigned to existing waves via AI
- [x] Idempotent — re-running shows "0 new items"
- [x] `--full` flag bypasses baseline and forces re-cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)