### PR TITLE
feat: add architecture phase coverage gate for LEAD-TO-PLAN

### DIFF
--- a/scripts/backfill-architecture-sections.js
+++ b/scripts/backfill-architecture-sections.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/**
+ * Backfill Architecture Plan Sections
+ * Part of SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001
+ *
+ * One-time idempotent script: reads existing architecture plans with NULL sections,
+ * extracts phases from content using parsePhases(), and populates the sections column.
+ * Skips plans that already have non-null sections.
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { parsePhases } from './create-orchestrator-from-plan.js';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function main() {
+  console.log('🔄 Backfilling architecture plan sections...\n');
+
+  const { data: plans, error } = await supabase
+    .from('eva_architecture_plans')
+    .select('id, plan_key, content, sections')
+    .is('sections', null)
+    .not('content', 'is', null);
+
+  if (error) {
+    console.error('❌ Query failed:', error.message);
+    process.exit(1);
+  }
+
+  console.log(`   Found ${plans.length} plan(s) with NULL sections\n`);
+
+  let updated = 0;
+  let skipped = 0;
+
+  for (const plan of plans) {
+    const phases = parsePhases(plan.content);
+
+    if (phases.length === 0) {
+      console.log(`   ⏭️  ${plan.plan_key}: No phases found — skipping`);
+      skipped++;
+      continue;
+    }
+
+    const sections = {
+      implementation_phases: phases.map(p => ({
+        number: p.number,
+        title: p.title,
+        description: p.description || '',
+        child_designation: 'child',
+        covered_by_sd_key: null,
+        deliverables: [],
+        estimate_loc: null
+      })),
+      extracted_at: new Date().toISOString(),
+      extraction_source: 'backfill'
+    };
+
+    const { error: updateError } = await supabase
+      .from('eva_architecture_plans')
+      .update({ sections })
+      .eq('id', plan.id);
+
+    if (updateError) {
+      console.log(`   ❌ ${plan.plan_key}: Update failed — ${updateError.message}`);
+    } else {
+      console.log(`   ✅ ${plan.plan_key}: ${phases.length} phase(s) extracted`);
+      updated++;
+    }
+  }
+
+  console.log(`\n📊 Backfill complete: ${updated} updated, ${skipped} skipped (no phases)`);
+}
+
+main().catch(err => { console.error('Fatal:', err.message); process.exit(1); });

--- a/scripts/eva/archplan-command.mjs
+++ b/scripts/eva/archplan-command.mjs
@@ -249,6 +249,32 @@ async function cmdUpsert({ planKey, visionKey, source, dimensions: dimensionsJso
 
   const version = existing ? existing.version + 1 : 1;
 
+  // Extract structured sections from content (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
+  let sections = null;
+  try {
+    const { parsePhases } = await import('../create-orchestrator-from-plan.js');
+    const phases = parsePhases(content);
+    if (phases.length > 0) {
+      sections = {
+        implementation_phases: phases.map(p => ({
+          number: p.number,
+          title: p.title,
+          description: p.description || '',
+          child_designation: 'child',
+          covered_by_sd_key: null,
+          deliverables: [],
+          estimate_loc: null
+        })),
+        extracted_at: new Date().toISOString(),
+        extraction_source: 'content_parse'
+      };
+      console.log(`\n   📋 Extracted ${phases.length} implementation phase(s) into sections`);
+    }
+  } catch (e) {
+    // Non-blocking: sections population is best-effort
+    console.warn(`   ⚠️  Could not extract sections: ${e.message}`);
+  }
+
   const record = {
     plan_key: planKey,
     vision_id: visionDoc.id,
@@ -260,6 +286,7 @@ async function cmdUpsert({ planKey, visionKey, source, dimensions: dimensionsJso
     created_by: 'eva-archplan-command',
     source_file_path: source,
     ...(brainstormId ? { source_brainstorm_id: brainstormId } : {}),
+    ...(sections ? { sections } : {}),
   };
 
   const { data, error } = await supabase

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1705,6 +1705,28 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
             console.log(`   node scripts/create-orchestrator-from-plan.js --vision-key ${visionKey} --arch-key ${archKey} --title "${title}" --auto-children\n`);
           }
         } catch { /* Advisory only — continue regardless */ }
+
+        // Advisory: warn about uncovered architecture phases (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
+        try {
+          const sb2 = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+          const { data: archPlanSections } = await sb2
+            .from('eva_architecture_plans')
+            .select('sections')
+            .eq('plan_key', archKey)
+            .single();
+          const phases = archPlanSections?.sections?.implementation_phases;
+          if (phases && Array.isArray(phases)) {
+            const uncovered = phases.filter(p => !p.covered_by_sd_key);
+            if (uncovered.length > 0) {
+              console.log(`\n⚠️  Architecture Phase Coverage Warning:`);
+              console.log(`   ${uncovered.length}/${phases.length} phase(s) have no assigned SD:`);
+              for (const p of uncovered) {
+                console.log(`   ❌ Phase ${p.number}: ${p.title}`);
+              }
+              console.log(`   Assign SDs before LEAD-TO-PLAN to pass the phase coverage gate.\n`);
+            }
+          }
+        } catch { /* Advisory only — continue regardless */ }
       }
 
       const sdKey = await generateSDKey({ source, type, title, venturePrefix });

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
@@ -62,3 +62,6 @@ export {
 export { createScopeReductionVerificationGate } from './scope-reduction-verification.js';
 export { createSdTypeCompatibilityGate } from './sd-type-compatibility.js';
 export { createOverlappingScopeDetectionGate } from './overlapping-scope-detection.js';
+
+// Architecture Phase Coverage Gate (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
+export { createPhaseCoverageGate } from './phase-coverage.js';

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js
@@ -1,0 +1,131 @@
+/**
+ * ARCHITECTURE_PHASE_COVERAGE Semantic Gate
+ * Part of SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001
+ *
+ * Validates that every implementation phase in an architecture plan
+ * has a corresponding SD before LEAD-TO-PLAN passes.
+ *
+ * Phase: LEAD-TO-PLAN (blocking)
+ */
+
+import {
+  validatePhaseCoverage,
+  formatCoverageReport
+} from '../../../validation/phase-coverage-validator.js';
+
+import {
+  buildSemanticResult,
+  buildSkipResult
+} from '../../../validation/semantic-gate-utils.js';
+
+const GATE_NAME = 'ARCHITECTURE_PHASE_COVERAGE';
+
+export function createPhaseCoverageGate(supabase) {
+  return {
+    name: GATE_NAME,
+    validator: async (ctx) => {
+      console.log('\n🏗️  GATE: Architecture Phase Coverage');
+      console.log('-'.repeat(50));
+
+      const sdId = ctx.sd?.id || ctx.sdId;
+      const archKey = ctx.sd?.metadata?.arch_key || ctx.sd?.metadata?.architecture_plan_key;
+
+      if (!archKey) {
+        console.log('   ℹ️  No architecture plan linked — gate not applicable');
+        return buildSkipResult(GATE_NAME, 'no_arch_key');
+      }
+
+      if (!supabase || !sdId) {
+        return buildSemanticResult({
+          passed: true, score: 50, confidence: 0.3,
+          warnings: ['Cannot verify phase coverage — missing context']
+        });
+      }
+
+      try {
+        // Get architecture plan with sections
+        const { data: plan, error: planError } = await supabase
+          .from('eva_architecture_plans')
+          .select('sections')
+          .eq('plan_key', archKey)
+          .single();
+
+        if (planError || !plan) {
+          console.log(`   ⚠️  Architecture plan '${archKey}' not found`);
+          return buildSemanticResult({
+            passed: true, score: 50, confidence: 0.3,
+            warnings: [`Architecture plan '${archKey}' not found in database`]
+          });
+        }
+
+        const phases = plan.sections?.implementation_phases;
+        if (!phases || !Array.isArray(phases) || phases.length === 0) {
+          console.log('   ℹ️  No structured phases in sections — gate not applicable');
+          return buildSemanticResult({
+            passed: true, score: 100, confidence: 0.5,
+            warnings: ['Architecture plan has no structured phases in sections column']
+          });
+        }
+
+        // Get all SDs linked to this architecture plan
+        const { data: sds, error: sdsError } = await supabase
+          .from('strategic_directives_v2')
+          .select('sd_key, title, status, parent_sd_id')
+          .or(`metadata->>arch_key.eq.${archKey},metadata->>architecture_plan_key.eq.${archKey}`);
+
+        if (sdsError) {
+          console.log(`   ⚠️  Error querying linked SDs: ${sdsError.message}`);
+          return buildSemanticResult({
+            passed: true, score: 50, confidence: 0.3,
+            warnings: [`Error querying linked SDs: ${sdsError.message}`]
+          });
+        }
+
+        const report = validatePhaseCoverage(phases, sds || []);
+        console.log(formatCoverageReport(report));
+
+        if (!report.passed) {
+          const missingTitles = report.uncovered.map(u => u.phase.title).join(', ');
+          return buildSemanticResult({
+            passed: false,
+            score: Math.round(report.coveragePercent),
+            confidence: 1,
+            issues: [`Architecture phase coverage incomplete: ${report.coveredCount}/${report.totalPhases} phases covered. Missing: ${missingTitles}`],
+            details: {
+              archKey,
+              totalPhases: report.totalPhases,
+              coveredCount: report.coveredCount,
+              coveragePercent: report.coveragePercent,
+              uncoveredPhases: report.uncovered.map(u => ({
+                number: u.phase.number,
+                title: u.phase.title,
+                designation: u.phase.child_designation
+              }))
+            },
+            remediation: `Create SDs for uncovered phases: ${missingTitles}. Then link them via metadata.arch_key = '${archKey}'.`
+          });
+        }
+
+        return buildSemanticResult({
+          passed: true,
+          score: 100,
+          confidence: 1,
+          details: {
+            archKey,
+            totalPhases: report.totalPhases,
+            coveredCount: report.coveredCount,
+            coveragePercent: report.coveragePercent
+          }
+        });
+      } catch (err) {
+        console.log(`   ⚠️  Error: ${err.message}`);
+        return buildSemanticResult({
+          passed: true, score: 50, confidence: 0.3,
+          warnings: [`Phase coverage verification error: ${err.message}`]
+        });
+      }
+    },
+    required: true,
+    weight: 0.8
+  };
+}

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -22,7 +22,9 @@ import {
   // Semantic Validation Gates (SD-LEO-FEAT-SEMANTIC-VALIDATION-GATES-002)
   createScopeReductionVerificationGate,
   createSdTypeCompatibilityGate,
-  createOverlappingScopeDetectionGate
+  createOverlappingScopeDetectionGate,
+  // Architecture Phase Coverage Gate (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
+  createPhaseCoverageGate
 } from './gates/index.js';
 
 // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
@@ -120,6 +122,10 @@ export class LeadToPlanExecutor extends BaseExecutor {
     gates.push(createScopeReductionVerificationGate(this.supabase));
     gates.push(createSdTypeCompatibilityGate(this.supabase));
     gates.push(createOverlappingScopeDetectionGate(this.supabase));
+
+    // Architecture Phase Coverage Gate (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
+    // Blocks when an architecture plan has uncovered phases
+    gates.push(createPhaseCoverageGate(this.supabase));
 
     return gates;
   }

--- a/scripts/modules/handoff/validation/phase-coverage-validator.js
+++ b/scripts/modules/handoff/validation/phase-coverage-validator.js
@@ -1,0 +1,85 @@
+/**
+ * Phase Coverage Validator
+ * Part of SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001
+ *
+ * Pure validation logic: takes structured phases (from eva_architecture_plans.sections)
+ * and list of SDs (from strategic_directives_v2), returns coverage report.
+ * No side effects, no database calls.
+ */
+
+/**
+ * Validates that all architecture phases are covered by SDs.
+ * @param {Object[]} phases - From eva_architecture_plans.sections.implementation_phases
+ * @param {Object[]} sds - From strategic_directives_v2 (linked SDs)
+ * @returns {Object} Coverage report
+ */
+export function validatePhaseCoverage(phases, sds) {
+  if (!phases || !Array.isArray(phases) || phases.length === 0) {
+    return { covered: [], uncovered: [], coveragePercent: 100, totalPhases: 0, coveredCount: 0, passed: true };
+  }
+
+  const sdKeys = new Set((sds || []).map(sd => sd.sd_key));
+  const covered = [];
+  const uncovered = [];
+
+  for (const phase of phases) {
+    const assignedSd = phase.covered_by_sd_key;
+    if (assignedSd && sdKeys.has(assignedSd)) {
+      const sd = sds.find(s => s.sd_key === assignedSd);
+      covered.push({ phase, sd_key: assignedSd, sd_title: sd?.title || assignedSd });
+    } else if (assignedSd) {
+      // covered_by_sd_key is set but the SD doesn't exist in the linked SDs list
+      // Still count as covered if the key is populated (SD may exist outside this arch plan)
+      covered.push({ phase, sd_key: assignedSd, sd_title: assignedSd });
+    } else {
+      uncovered.push({ phase });
+    }
+  }
+
+  const totalPhases = phases.length;
+  const coveredCount = covered.length;
+  const coveragePercent = totalPhases > 0 ? Math.round((coveredCount / totalPhases) * 1000) / 10 : 100;
+
+  return {
+    covered,
+    uncovered,
+    coveragePercent,
+    totalPhases,
+    coveredCount,
+    passed: coveredCount === totalPhases
+  };
+}
+
+/**
+ * Formats coverage report for terminal display.
+ * @param {Object} report - From validatePhaseCoverage()
+ * @returns {string} Formatted output
+ */
+export function formatCoverageReport(report) {
+  const lines = [];
+
+  if (report.totalPhases === 0) {
+    lines.push('   ℹ️  No implementation phases defined — gate not applicable');
+    return lines.join('\n');
+  }
+
+  lines.push('   📋 Architecture Phase Coverage:');
+
+  for (const { phase, sd_key, sd_title } of report.covered) {
+    const designation = phase.child_designation === 'separate_orchestrator' ? ' (separate orchestrator)' : '';
+    lines.push(`   ✅ Phase ${phase.number}: ${phase.title} → ${sd_key}${designation}`);
+  }
+
+  for (const { phase } of report.uncovered) {
+    const designation = phase.child_designation === 'separate_orchestrator'
+      ? ' (separate orchestrator — create SD)'
+      : ' (child — create SD)';
+    lines.push(`   ❌ Phase ${phase.number}: ${phase.title} → NO SD ASSIGNED${designation}`);
+  }
+
+  lines.push('');
+  const status = report.passed ? 'PASS' : 'BLOCKING';
+  lines.push(`   Coverage: ${report.coveredCount}/${report.totalPhases} (${report.coveragePercent}%) — ${status}`);
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- Adds `ARCHITECTURE_PHASE_COVERAGE` blocking gate to LEAD-TO-PLAN handoff
- Validates all implementation phases in architecture plans have corresponding SDs before work begins
- Prevents silently dropped deliverables (root cause: Strategic Roadmap Phase 3 UI tab was never assigned an SD)
- Auto-populates `eva_architecture_plans.sections` column during `archplan-command.mjs` upsert
- Includes one-time backfill script for existing plans (5 plans populated)
- Advisory warning at SD creation when uncovered phases detected

## Test plan
- [x] Unit tests: `validatePhaseCoverage()` passes all 3 cases (no phases, all covered, uncovered)
- [x] Gate imports and initializes correctly
- [x] Backfill script ran successfully (5/6 plans populated)
- [ ] Integration: LEAD-TO-PLAN handoff with linked arch plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)