### PR TITLE
docs: add EVA intake redesign and strategic roadmap artifact brainstorm/vision/architecture docs

### DIFF
--- a/brainstorm/2026-03-08-5-10x-value-methodology.md
+++ b/brainstorm/2026-03-08-5-10x-value-methodology.md
@@ -1,0 +1,116 @@
+# Brainstorm: 5-10X Value vs Competition Methodology
+
+## Metadata
+- **Date**: 2026-03-08
+- **Domain**: Integration
+- **Phase**: MVP (formalizing value multiplier assessment into existing opportunity/portfolio pipeline)
+- **Mode**: Conversational (autonomous — chairman asleep, EVA proceeding)
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: EHG_Engineer (opportunity scoring, portfolio optimization, stage gates)
+- **Source**: Chairman final cut — item retained from SD-RESEARCH-VENTURE_ECONOMICS-20260309-003
+
+---
+
+## Problem Statement
+EHG's venture factory evaluates opportunities across 6 weighted dimensions (market opportunity, competitive advantage, feasibility, evidence strength, time-to-value, risk-adjusted) and classifies them into Green/Yellow/Red execution boxes. Stage gates enforce kill decisions at stages 3, 5, 13, and 23. Portfolio optimization balances resource allocation. But nowhere in this pipeline does the system formally quantify *how much more value* an EHG venture delivers compared to the competition. The "5-10X" claim — that EHG ventures should deliver 5-10X the value of incumbent solutions — exists as a strategic narrative but not as a measurable, enforceable dimension. Ventures pass scoring gates without proving they deliver disproportionate value. The gap-analyzer identifies competitive gaps but doesn't translate those gaps into a value multiplier. Financial contracts track unit economics but don't anchor them against competitor baselines.
+
+## Discovery Summary
+
+### Existing Infrastructure (Key Finding)
+The Pragmatist's exploration revealed substantial existing infrastructure that the value methodology can extend:
+
+**Opportunity Scoring Pipeline:**
+- **Gap Analyzer** (`lib/discovery/gap-analyzer.js`, 343 LOC): 6 dimensions (features, pricing, segments, experience, integrations, quality) with epistemic classification (FACT/ASSUMPTION/SIMULATION/UNKNOWN). Calculates gap scores with impact/timing bonuses and difficulty penalties.
+- **Opportunity Scorer** (`lib/discovery/opportunity-scorer.js`, 394 LOC): 6 weighted dimensions — market_opportunity (0.25), competitive_advantage (0.20), feasibility (0.15), evidence_strength (0.20), time_to_value (0.10), risk_adjusted (0.10). Three-box classification (Green/Yellow/Red). Auto-approval at 85%+ confidence.
+
+**Venture Lifecycle Infrastructure:**
+- **Moat Architecture** (`lib/eva/stage-zero/synthesis/moat-architecture.js`, 109 LOC): 7 moat types — data_moat, automation_speed, vertical_expertise, network_effects, switching_costs, design_moat, agent_consumability. Outputs primary/secondary moats with compounding trajectory and vulnerability analysis.
+- **Stage Gates** (`lib/agents/modules/venture-state-machine/stage-gates.js`, 704 LOC): Kill gates at stages 3, 5, 13, 23. Promotion gates at 16, 17, 22. Artifact-based gates for financial viability (5→6), UAT signoff (21→22), deployment health (22→23).
+- **Financial Contract** (`lib/eva/contracts/financial-contract.js`, 276 LOC): Tracks capital_required, cac_estimate, ltv_estimate, unit_economics, pricing_model. Consistency thresholds: WARN at >20% deviation, BLOCK at >50%.
+
+**Portfolio Intelligence:**
+- **Cross-Venture Learning** (`lib/eva/cross-venture-learning.js`, 612 LOC): Kill-stage frequency analysis, failed assumption patterns, success patterns. Hybrid semantic+keyword search across ventures. Assumption calibration analysis.
+- **Portfolio Optimizer** (`lib/eva/portfolio-optimizer.js`, 524 LOC): 5 signal weights (urgency 0.30, roi 0.25, financial 0.20, market 0.15, health 0.10). Contention detection/resolution, provider boost for platform ventures, portfolio balance enforcement (40% cap).
+
+**Existing Value References (unstructured):**
+- "10x cheaper than" narrative in seed models (pricing anchoring)
+- "10x cost reduction" in bull case scenarios
+- "5.76x performance advantages" in AI agent orchestration
+- Sensitivity multiplier (1x-10x) in listening radar
+- These references are narrative, not structural — no formal scoring dimension
+
+### What Must Be Built
+- **Value multiplier scoring dimension** in OpportunityScorer (7th dimension)
+- **Competitive value comparator service** anchoring EHG venture value against competitor baselines
+- **5-10X gate** in stage-gates.js (enforce at key stages: post-discovery, pre-build, pre-launch)
+- **Value decay monitoring** detecting when competitive advantage erodes over time
+- **Portfolio value dashboard** surfacing value multiplier across all active ventures
+
+## Analysis
+
+### Arguments For
+- Extensive infrastructure already exists — gap analysis, opportunity scoring, moat architecture, stage gates all built and production-ready
+- Missing piece is surgical: add value_multiplier as 7th dimension in OpportunityScorer and wire it to stage gates
+- Forces disciplined thinking about competitive differentiation early in venture lifecycle
+- Portfolio-level visibility into which ventures deliver disproportionate value vs which are incrementally better
+- Financial contract infrastructure already tracks unit economics — anchoring against competitors is a natural extension
+- Cross-venture learning can identify which value multiplier strategies actually worked (calibration feedback loop)
+
+### Arguments Against
+- **"5-10X" is unmeasurable before building**: Value is emergent — you can't score what doesn't exist yet. Multiplier frameworks create false precision around inherently uncertain predictions
+- **Survivorship bias in the 10X narrative**: Successful companies are described as "10X" retroactively. Using this as a forward-looking gate kills ideas that don't "look 10X" on paper but become 10X through iteration
+- **The denominator problem**: Competitor value delivery is unknowable with precision. You're dividing by an estimate, multiplying the uncertainty
+- **Selection bias toward hype over substance**: Framework rewards ventures that claim large multipliers (AI-powered, platform effects) over boring-but-profitable businesses (better execution, niche focus)
+- **Framework could kill promising ideas**: Ventures in their infancy often look "1.5X better" — the 10X emerges after product-market fit through compounding effects. Early-stage gates would kill them
+- **Opportunity cost of measurement**: Time spent estimating value multipliers is time not spent building. For a venture factory, velocity matters more than precision
+
+## Integration: Data Quality/Coverage Analysis
+
+| Dimension | Score |
+|-----------|-------|
+| Data Quality | 7/10 (Strong quantitative infrastructure: 6-dim gap scoring, 6-dim opportunity scoring, financial contracts with deviation thresholds) |
+| Coverage | 6/10 (Good scoring pipeline but no competitive baseline anchoring, no value multiplier dimension) |
+| Edge Cases | 4 identified |
+
+**Edge Cases**:
+1. **No competitor data available** (Common) — New market categories where there are no direct competitors. Value multiplier against what baseline? Need fallback to "improvement over status quo" scoring.
+2. **Value multiplier varies by segment** (Moderate) — A venture might be 10X for SMBs but 1.5X for enterprise. Which segment's multiplier is the score?
+3. **Temporal value decay** (Common) — Competitors copy features, AI commoditizes capabilities. A 10X advantage at launch becomes 2X within 18 months. Snapshot scoring misses the trajectory.
+4. **Intangible value components** (Moderate) — Design quality, brand trust, community — real value that resists quantification. Framework might systematically undervalue these.
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: (1) "5-10X" is unmeasurable before building — value is emergent from customer interaction, not predictable from spreadsheets; framework creates false precision around inherently uncertain predictions (2) Survivorship bias — successful companies are described as "10X" retroactively, using this forward-looking kills ideas that iterate into greatness (3) The denominator problem — competitor value is unknowable with precision, dividing by an estimate multiplies uncertainty (4) Selection bias toward hype — rewards AI/platform narrative over boring-but-profitable execution plays
+- **Assumptions at Risk**: (1) "Value is measurable pre-build" — only post-launch customer behavior reveals true value (2) "10X ventures are identifiable early" — research shows most successful products pivoted from their original thesis (3) "Quantifying value prevents bad bets" — it filters for confidence, not for insight (4) "Competitors' value delivery is knowable" — public data captures features, not the full user experience
+- **Worst Case**: Framework kills 3 promising ideas that "only" look 2X. One of those would have iterated into a market leader. Meanwhile, the venture that scored 12X on paper fails because its multiplier was based on AI hype assumptions. The framework creates a false sense of rigor while actually reducing the portfolio's optionality. Engineering time building the measurement system would have been better spent building products.
+
+### Visionary
+- **Opportunities**: (1) value_multiplier as 7th dimension in OpportunityScorer — surgical addition to existing weighted scoring (2) Unfair advantage as computable property: moat_score × market_gap × execution_feasibility → value multiplier estimate with confidence intervals (3) Continuous value erosion monitoring — detect when competitive advantage decays, trigger strategic responses before it's too late (4) Integration with brainstorm pipeline — 10X assessment before full team analysis saves resources on incremental ideas (5) Design quality as measurable component of value multiplier — connects to design-as-competitive-advantage initiative (6) Portfolio value heat map for chairman — color-coded view of which ventures justify continued investment
+- **Synergies**: Gap Analyzer (competitive gaps → value multiplier inputs), Moat Architecture (moat strength feeds multiplier durability), Financial Contract (unit economics anchor the economic multiplier), Cross-Venture Learning (calibrate multiplier estimates against actual outcomes), Portfolio Optimizer (value multiplier as additional signal weight), Stage Gates (5-10X gate at critical lifecycle points)
+- **Upside Scenario**: Within 6 months — every venture has a quantified value multiplier with confidence intervals, updated monthly. Portfolio optimizer uses value multiplier as highest-weight signal. Two ventures redirected from "2X incrementalism" to genuine 10X opportunities. Chairman dashboard shows portfolio value heat map. Cross-venture learning calibrates estimates against outcomes, improving prediction accuracy over time. Investor narrative: "We don't build products — we build 10X value multipliers, and we can prove it."
+
+### Pragmatist
+- **Feasibility**: 7/10 — Strong existing foundation (OpportunityScorer dimensions, gap analysis, moat architecture, stage gates). Missing piece is the value_multiplier dimension and competitive baseline service. Moderate complexity but high infrastructure reuse.
+- **Resource Requirements**: 4-phase implementation over ~8 weeks. Phase 1 (value dimension): 2 weeks. Phase 2 (competitive baselines): 2 weeks. Phase 3 (stage gate integration): 2 weeks. Phase 4 (dashboard + monitoring): 2 weeks.
+- **Constraints**: (1) Competitive baseline data quality varies wildly — some markets have public pricing/feature data, others don't; (2) Value multiplier confidence degrades rapidly for pre-revenue ventures; (3) OpportunityScorer weights must be rebalanced when adding 7th dimension; (4) Stage gate integration requires careful threshold tuning to avoid killing viable ventures
+- **Recommended Path**: Start with value_multiplier as a scoring dimension (Phase 1) — it's additive and non-breaking. Then build competitive baselines (Phase 2). Only after calibrating against real outcomes should you wire it into kill gates (Phase 3). Dashboard last (Phase 4). Use as lens first, gate later.
+
+### Synthesis
+- **Consensus Points**: (1) Existing infrastructure is strong — 2,962 LOC across 7 files provides a solid foundation (all 3 agree); (2) value_multiplier should be a scoring dimension, not just a narrative (Pragmatist + Visionary); (3) Must start as a lens/measurement before becoming a gate (Challenger + Pragmatist agree — avoid premature kill decisions)
+- **Tension Points**: (1) Challenger argues value is emergent and unmeasurable pre-build vs Visionary sees it as computable from existing signals; (2) Challenger warns about selection bias for hype vs Visionary sees this as addressable via evidence_strength weight; (3) Pragmatist recommends phased approach (dimension → baseline → gate → dashboard) vs Visionary wants full integration immediately
+- **Composite Risk**: Medium — strong existing foundation reduces technical risk, but the methodological risk (can you meaningfully estimate value multipliers?) is the strategic wildcard. Pragmatist's phased approach mitigates this by treating early phases as hypothesis validation.
+
+## Open Questions
+- Should value multiplier be a kill gate or an advisory signal? (Consensus: start as advisory, graduate to gate after calibration)
+- How do you handle ventures in new categories with no direct competitors? (Proposed: "improvement over status quo" fallback)
+- What confidence threshold is required before value multiplier affects portfolio allocation?
+- Should the multiplier be a point estimate or a range (e.g., 3-7X) with confidence intervals?
+- How often should value multiplier be recalculated as the competitive landscape shifts?
+
+## Suggested Next Steps
+1. Create SD(s) from this brainstorm with vision-key and arch-key linkage
+2. Architecture suggests a single SD — adding value_multiplier dimension is additive to existing infrastructure, not a new system
+3. Phase the implementation: scoring dimension first (non-breaking), competitive baselines second, gate integration third (after calibration data exists)
+4. Connect to cross-venture learning for outcome calibration (did estimated multipliers match reality?)

--- a/brainstorm/2026-03-08-autonomous-consultant-agent.md
+++ b/brainstorm/2026-03-08-autonomous-consultant-agent.md
@@ -1,0 +1,98 @@
+# Brainstorm: Autonomous Consultant Agent
+
+## Metadata
+- **Date**: 2026-03-08
+- **Domain**: Integration
+- **Phase**: MVP (extending existing pipeline with pattern detection + recommendation)
+- **Mode**: Conversational (autonomous — chairman asleep, EVA proceeding)
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: EHG_Engineer (EVA pipeline infrastructure)
+- **Source**: Chairman final cut — item retained from SD-RESEARCH-EVA_PIPELINE-20260309-005
+
+---
+
+## Problem Statement
+The chairman captures 400+ strategic ideas across Todoist, YouTube, conversations, and reading, but synthesis happens manually during brainstorm sessions. This creates delayed action on time-sensitive opportunities and missed cross-domain connections. The volume far exceeds human synthesis capacity. EVA currently acts as a reactive assistant — the consultant agent transforms it into a proactive strategic advisor.
+
+## Discovery Summary
+
+### Existing Infrastructure (Key Finding)
+The Pragmatist agent's codebase exploration revealed that significant infrastructure already exists:
+- **Fully reusable**: `todoist-sync.js`, `playlist-sync.js`, `eva-sync-state` circuit breaker, `intake-classifier.js` (3D taxonomy: App + Aspects + Intent), `wave-clusterer.js`, `client-factory.js` (LLM routing with Haiku/Sonnet tiers)
+- **Partially reusable**: `deeper-analysis-router.js` (routing patterns), `post-processor.js` (archival lifecycle)
+- **Must be built**: Pattern detector (temporal clustering), trend correlator (cross-source matching), recommendation engine (confidence-scored output), chairman digest, data freshness monitoring
+
+### Processing Pipeline Design
+Sync → Classify → Pattern Detection → Trend Correlation → Recommendation Generation → Chairman Digest
+
+### Data Sources
+- Todoist API (task lists, projects) — structured, actionable items
+- YouTube API (watch history, playlists) — noisy, ambiguous content
+- `roadmap_wave_items` (historical ideas)
+- `strategic_directives_v2` (active work context)
+
+### Key Insight: Validate Before Building
+The Pragmatist recommended a Phase 0 validation approach: create a simple trend snapshot table that materializes aggregate statistics (items per app/aspect/intent, velocity changes) WITHOUT LLM involvement. Run manually for 2 weeks. If the snapshots don't surface non-obvious patterns, the full LLM-powered pipeline won't help either.
+
+## Analysis
+
+### Arguments For
+- **Closes the synthesis gap**: 400+ ideas can't be manually connected — automation is the only scalable approach
+- **Leverages existing infrastructure**: 80%+ of the sync/classify pipeline is already built and production-ready
+- **Low marginal cost**: ~$1-2/day LLM cost using existing Haiku/Sonnet routing via `client-factory.js`
+- **Compound value**: Every feedback interaction makes the system more accurate — competitive moat grows over time
+- **Enables temporal intelligence**: Time-series of chairman attention reveals patterns invisible in snapshot brainstorm sessions
+
+### Arguments Against
+- **YouTube API risk**: Google has been progressively restricting YouTube Data API access to personal activity data. Building a core dependency on this is a vendor risk.
+- **Classification heterogeneity**: Todoist tasks and YouTube videos have wildly different signal-to-noise ratios. Haiku-level classification may struggle with this.
+- **Foundation dependency**: The EVA intake redesign (3D taxonomy) is designed but not yet in production. This agent builds on that unreleased foundation.
+- **Feedback loop chicken-and-egg**: Without the feedback loop, recommendations can't improve. But the feedback loop requires the chairman to engage. Early recommendations may be mediocre, risking disengagement before the system proves itself.
+
+## Integration: Data Quality/Coverage Analysis
+
+| Dimension | Score |
+|-----------|-------|
+| Data Quality | 7/10 (Todoist high, YouTube medium — heterogeneous) |
+| Coverage | 6/10 (two sources cover ~70% of chairman's idea capture) |
+| Edge Cases | 4 identified |
+
+**Edge Cases**:
+1. **YouTube API deprecation** (Rare but high-impact) — graceful degradation to Todoist-only mode with explicit confidence reduction
+2. **Todoist bulk import** (Common) — chairman sometimes imports 50+ items at once, creating spike patterns that aren't real trends
+3. **Cross-source duplicates** (Common) — same idea captured in both Todoist and YouTube should count as 1 signal, not 2
+4. **Stale sync** (Rare) — sync fails silently; system generates recommendations on outdated data
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: (1) No mechanism to detect stale data — system will present degraded analysis with same confidence as fresh; (2) 400+ items are not uniform across sources — classification collapse risk from heterogeneity; (3) No feedback loop means system can't learn what matters vs. noise
+- **Assumptions at Risk**: (1) $1/day LLM cost assumes stable volumes, but cross-referencing grows non-linearly as corpus grows; (2) EVA intake redesign isn't in production yet — building second floor on blueprint first floor; (3) YouTube watch history API may be further restricted by Google
+- **Worst Case**: System ships, runs 3-4 weeks, YouTube sync breaks silently. System continues on Todoist-only but still presents "cross-source trend analysis." Chairman gets generic, repetitive digests. LLM costs creep up. `eva_consultant_recommendations` becomes another data graveyard. Net result: more noise, not less.
+
+### Visionary
+- **Opportunities**: (1) Cross-domain pattern arbitrage — extract alpha from data the chairman already possesses but can't manually cross-reference at scale; (2) Temporal intelligence — time-series of strategic attention reveals what topics the chairman gravitates toward before consciously deciding to act; (3) Recommendation feedback loop becomes a competitive moat — personalized strategic model no off-the-shelf AI can replicate
+- **Synergies**: EVA intake redesign (classification backbone), roadmap wave system (automatic priority reality check), LEO Protocol (high-confidence recommendations auto-generate draft SDs), Todoist bidirectional sync (EVA→Todoist action items)
+- **Upside Scenario**: Within 6 months, the daily digest replaces 2 hours of manual review. The agent surfaces a non-obvious cross-domain connection leading to a strategic decision the chairman wouldn't have reached independently. EVA transitions from productivity tool to intellectual partner.
+
+### Pragmatist
+- **Feasibility**: 5/10 — existing infrastructure makes Phase 0-1 straightforward, but the leap from classification to pattern detection/recommendation is qualitatively different
+- **Resource Requirements**: 3-5 SDs (6-10 days), ~$0.50-1.50/day LLM, 1-2 new DB tables, no cron infrastructure needed for validation phase
+- **Constraints**: (1) No persistent scheduler exists — manual invocation sufficient for validation; (2) Pattern detection quality will be mediocre at 400 items — early iterations should present clusters/frequencies, not bold recommendations; (3) LLM cost drift is the real risk — batch aggressively following `wave-clusterer.js` pattern
+- **Recommended Path**: Start with trend snapshot table + batch aggregation script (no LLM). Run manually 2 weeks. If snapshots prove useful, proceed to LLM-powered recommendation engine. Do not build the cron runner in Phase 0.
+
+### Synthesis
+- **Consensus Points**: (1) Existing infrastructure makes this feasible (all 3 agree); (2) Feedback loop is critical (Challenger + Visionary agree it's the key differentiator); (3) Start small and validate (Challenger + Pragmatist agree on validation-first approach)
+- **Tension Points**: (1) Visionary sees compound value over 6 months vs Challenger's concern about 3-4 week degradation window; (2) Pragmatist recommends no-LLM Phase 0 vs Visionary's emphasis on LLM-powered cross-domain pattern arbitrage
+- **Composite Risk**: Medium — strong existing infrastructure mitigates implementation risk, but data quality and feedback loop risks require active management
+
+## Open Questions
+- Should Phase 0 snapshots include YouTube data, or Todoist-only to avoid the API risk?
+- What is the minimum feedback engagement rate needed to make the learning loop viable?
+- Should recommendations link to specific wave items, or present higher-level thematic summaries?
+
+## Suggested Next Steps
+1. Create SD(s) from this brainstorm with vision-key and arch-key linkage
+2. The 4-phase architecture (Phase 0 → 3) may warrant an orchestrator SD with children
+3. Phase 0 can begin immediately on existing raw data without waiting for EVA intake redesign

--- a/brainstorm/2026-03-08-competitor-monitoring-countermeasures.md
+++ b/brainstorm/2026-03-08-competitor-monitoring-countermeasures.md
@@ -1,0 +1,99 @@
+# Brainstorm: Continuous Competitor Monitoring + Countermeasures
+
+## Metadata
+- **Date**: 2026-03-08
+- **Domain**: Integration
+- **Phase**: MVP (extending existing competitor intelligence with continuous monitoring)
+- **Mode**: Conversational (autonomous — chairman asleep, EVA proceeding)
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: EHG_Engineer (competitive intelligence infrastructure)
+- **Source**: Chairman final cut — item retained from SD-RESEARCH-COMPETITIVE_INTEL-20260309-006
+
+---
+
+## Problem Statement
+EHG operates a venture factory with multiple products in competitive markets, but competitor analysis is ad-hoc — performed manually during brainstorm sessions. For a multi-venture operation, the surface area of competitors to monitor scales multiplicatively, making manual tracking unsustainable. Time-sensitive competitive signals (pricing changes, feature launches) are perishable and lose strategic value when discovered weeks later.
+
+## Discovery Summary
+
+### Existing Infrastructure (Key Finding)
+The Pragmatist's codebase exploration revealed significant existing infrastructure:
+- **`lib/discovery/opportunity-discovery-service.js`** — Full orchestrator: scan → analyze → score → blueprint → synthesis
+- **`lib/research/competitor-intelligence.js`** — Competitor URL analysis (axios-based)
+- **`lib/discovery/gap-analyzer.js`** — 6-dimension gap analysis
+- **`competitors` table** — Already exists, linked to ventures via `venture_id`
+- **`app_rankings` table** — Already exists with indices for apple_appstore, google_play, product_hunt
+- **`opportunity_scans` table** — Scan tracking with status lifecycle
+- **Prior brainstorm** — `brainstorm/2026-02-21-ranking-data-pipeline-sources-poc-integration.md` has detailed implementation plan (~395 LOC, validated, marked "Ready for SD")
+- **Dependencies present**: `axios`, `puppeteer`, `playwright` all in `package.json`
+
+### What Must Be Built
+- Ranking data pollers (Apple RSS, Google Play, Product Hunt)
+- Change detection engine (temporal diff of snapshots)
+- Significance scoring (what changes matter vs noise)
+- Countermeasure routing (competitor change → venture-specific recommendation)
+- Source health monitoring
+
+## Analysis
+
+### Arguments For
+- Existing infrastructure reduces implementation effort by ~60% — tables, scoring, analysis all exist
+- Multi-venture competitive graph is a proprietary asset no single-product company can replicate
+- Prior brainstorm provides detailed, validated implementation plan ready for SD creation
+- Low ongoing cost (~$5/month LLM, free-tier APIs)
+- Cross-venture pattern library creates compound value over time
+
+### Arguments Against
+- Legal/ethical risk from automated scraping — each source has distinct ToS implications
+- Signal-to-noise ratio at scale (multiple ventures × multiple competitors × multiple sources) may be catastrophic without heavy curation
+- Counter-intelligence risk: automated scraping patterns can reveal strategic interests to competitors
+- Continuous monitoring may be overkill — most ventures need periodic deep analysis at key decision points, not real-time alerts
+- Countermeasure quality depends on deep product-market understanding that pattern detection may lack
+
+## Integration: Data Quality/Coverage Analysis
+
+| Dimension | Score |
+|-----------|-------|
+| Data Quality | 6/10 (Tier 1 sources stable; Tier 2-3 fragile) |
+| Coverage | 5/10 (3 sources cover app rankings well; missing pricing, features, marketing) |
+| Edge Cases | 4 identified |
+
+**Edge Cases**:
+1. **Google Play HTML changes** (Common, every 2-4 months) — scraper breaks, returns stale/wrong data
+2. **G2/Capterra Cloudflare blocking** (Common) — anti-bot measures make scraping unreliable. Deferred.
+3. **Bulk ranking fluctuations** (Common) — app store algorithms cause temporary ranking changes that aren't meaningful competitive signals
+4. **Competitor website redesigns** (Moderate) — page structure changes break any URL-based analysis
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: (1) Legal exposure from automated scraping is jurisdiction-dependent and non-trivial — LinkedIn and Meta have sued scrapers successfully; (2) Signal-to-noise ratio will be catastrophic at scale without heavy curation and months of labeled training data; (3) No consideration of counter-intelligence — scraping reveals strategic interest areas
+- **Assumptions at Risk**: (1) Competitor data is machine-readable and stable — in reality, competitors redesign pages, A/B test pricing, use client-side rendering; (2) Continuous monitoring adds more value than periodic manual analysis — most ventures need deep dives at decision points, not continuous alerts; (3) EVA can meaningfully act on competitor signals — contextualizing competitive moves requires deep product-market understanding
+- **Worst Case**: Fragile scraping pipelines consume engineering cycles to maintain, generate low-quality alerts nobody trusts, and a significant competitor move gets buried in noise. Leadership reverts to ad-hoc analysis with a maintenance burden.
+
+### Visionary
+- **Opportunities**: (1) Cross-venture competitive graph as proprietary asset — patterns from one market inform strategy in adjacent markets; (2) Event-driven countermeasure triggers with real-time response windows — transform monitoring from reporting into operational reflex; (3) Multi-source triangulation — correlate job postings + patent filings + pricing changes for high-confidence intelligence
+- **Synergies**: EVA recommendation engine (market-aware strategic advisor), SD/PRD pipeline (auto-generate draft SDs from countermeasures), cross-venture pattern library (reusable strategic playbooks)
+- **Upside Scenario**: Competitive intelligence platform becomes a core reason ventures want to be part of EHG portfolio. Competitive response time drops from weeks to hours. Pattern library enables pre-emptive positioning.
+
+### Pragmatist
+- **Feasibility**: 6/10 — internal pipeline is largely built; external data ingestion carries all the integration risk
+- **Resource Requirements**: 3-4 weeks to continuous monitoring, 6-8 weeks to countermeasures (including data accumulation). ~$5/month ongoing.
+- **Constraints**: (1) Web scraping is inherently fragile — defer G2/Capterra; (2) No cron/scheduler infrastructure exists; (3) Countermeasure layer (delta detection + routing) is highest-value, highest-complexity new work requiring temporal data that doesn't exist yet
+- **Recommended Path**: Build ranking pollers first (Phase 1), let data accumulate 2-3 weeks, then build countermeasure engine. Prior brainstorm at `2026-02-21-ranking-data-pipeline-sources-poc-integration.md` has exact implementation plan ready for SD creation.
+
+### Synthesis
+- **Consensus Points**: (1) Existing infrastructure significantly reduces new work (all 3 agree); (2) Start with reliable data sources only — Apple RSS, Product Hunt, Google Play (Challenger + Pragmatist); (3) Validate before heavy automation investment (Challenger + Pragmatist)
+- **Tension Points**: (1) Visionary sees real-time event-driven architecture vs Pragmatist recommends batch; (2) Challenger questions whether continuous monitoring adds value over periodic analysis
+- **Composite Risk**: Medium — strong existing infrastructure, but data source fragility and signal-to-noise ratio require careful management
+
+## Open Questions
+- Should Phase 0 manual experiment be required, or can we skip to polling given existing infrastructure?
+- What significance thresholds should be used for ranking changes? (5+ positions? 10+?)
+- Should countermeasures be fully automated (auto-generate draft SDs) or require human review?
+
+## Suggested Next Steps
+1. Create SD(s) from this brainstorm with vision-key and arch-key linkage
+2. Architecture suggests 3 implementation phases (pollers → pipeline → countermeasures) — could be orchestrator with children
+3. Phase 1 can build on validated prior brainstorm implementation plan

--- a/brainstorm/2026-03-08-design-as-competitive-advantage.md
+++ b/brainstorm/2026-03-08-design-as-competitive-advantage.md
@@ -1,0 +1,114 @@
+# Brainstorm: Design as Competitive Advantage
+
+## Metadata
+- **Date**: 2026-03-08
+- **Domain**: Integration
+- **Phase**: MVP (systematizing existing design infrastructure into venture-wide competitive advantage)
+- **Mode**: Conversational (autonomous — chairman asleep, EVA proceeding)
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: EHG_Engineer (LEO Protocol design gates), EHG (Chairman UI, component library)
+- **Source**: Chairman final cut — item retained from SD-RESEARCH-DESIGN_QUALITY-20260309-010
+
+---
+
+## Problem Statement
+EHG launches ventures into competitive markets where design quality increasingly separates winners from losers. Currently, design quality across EHG ventures is ad-hoc — the Chairman V3 UI has strong design infrastructure (86 TSX components, Shadcn UI, design tokens, accessibility testing), but this quality doesn't systematically transfer to new ventures. The design-agent runs accessibility audits but doesn't enforce broader design quality. There is no cross-venture component sharing, no design quality metrics, and no measurement of whether design investment translates to business outcomes.
+
+## Discovery Summary
+
+### Existing Infrastructure (Key Finding)
+The Pragmatist's exploration revealed substantial existing design infrastructure:
+
+**Design System Foundation:**
+- **Design tokens**: `ehg-design-tokens.json` — 3-tier hierarchy (Brand → Semantic → Component), light/dark mode, validation scripts
+- **60 Shadcn UI components** in `src/components/ui/` with comprehensive coverage (buttons, forms, modals, tables, navigation, charts)
+- **Tailwind configuration**: 200+ design tokens (colors, typography, spacing, animations, shadows)
+- **Dark mode**: Class-based strategy with full coverage
+
+**Design Quality Infrastructure:**
+- **Design sub-agent** (v4.2.0): WCAG 2.1 AA, responsive validation, design system compliance, persona-driven validation
+- **Accessibility testing**: 7 a11y test files, axe-core integration (Playwright + React), eslint-plugin-jsx-a11y
+- **Design-Database gates**: 100-point scoring system with adaptive weighting
+- **Golden Nugget Validator**: Enforces persona-driven design, glanceability (<2s comprehension), cognitive load management
+- **Component audit tools**: `component-integration-audit.js`, `component-complexity-analysis.js`, `god-components.js`
+
+**Documentation:**
+- `docs/04_features/design_system.md` — Enhanced PRD with 3-tier component architecture
+- `docs/guides/design-ui-ux-workflow.md` — UI/UX collaboration playbook
+- `docs/leo/sub-agents/design-sub-agent-guide.md` — Module map, validation checklists
+
+### What Must Be Built
+- Cross-venture component sharing (monorepo or npm packages)
+- Design quality metrics dashboard (consistency, accessibility, reuse ratio)
+- Venture-specific brand token customization layer
+- Design review expanded to ALL feature SDs (not just subset)
+- Accessibility testing in CI/CD (not just manual)
+- Cross-venture design pattern library with provenance tracking
+- Storybook or equivalent for interactive component documentation
+
+## Analysis
+
+### Arguments For
+- Exceptional existing infrastructure — design tokens, design-agent, accessibility testing, quality gates all built and working
+- Venture factory model uniquely positioned for compound design intelligence — cross-venture learning impossible for single-product companies
+- AI-assisted design review changes economics — total coverage (every PR, every commit) at near-zero marginal cost
+- Design quality measurably impacts user perception — aesthetic-usability effect well-documented in research
+- Missing pieces are organizational/systemic, not technical — primarily needs systematization, not new invention
+
+### Arguments Against
+- **Market dependency**: Design quality matters in consumer/prosumer markets but may be irrelevant in enterprise B2B, internal tools, or developer tools
+- **Speed vs quality tension**: Venture factories optimize for speed-to-market; design excellence requires iteration and refinement — fundamental tension
+- **Can't systematize taste**: Automated checks enforce the floor (accessibility, consistency) but not the ceiling (products that feel exceptional)
+- **Who designs?**: Infrastructure without a designer is a kitchen without a chef — AI generates competent but generic UI, not differentiated experiences
+- **Content type explosion risk**: Shared design system can constrain ventures instead of enabling them if governance is too rigid
+- **All ventures look the same**: Design consistency can become homogeneity — every product looks like "an EHG template" instead of the best product for its market
+
+## Integration: Data Quality/Coverage Analysis
+
+| Dimension | Score |
+|-----------|-------|
+| Data Quality | 8/10 (Strong existing metrics from design-agent, axe-core, component audit tools) |
+| Coverage | 6/10 (Good for EHG app; no cross-venture infrastructure) |
+| Edge Cases | 4 identified |
+
+**Edge Cases**:
+1. **Venture-specific brand override conflicts** (Common) — Ventures need distinct visual identities but shared components. Token override system must handle inheritance without breaking consistency.
+2. **Design system governance deadlock** (Moderate) — When a venture needs a component variant the system doesn't support, who decides whether to add it to shared vs local?
+3. **AI design review false positives** (Common) — Automated checks may flag valid design decisions as violations, creating noise and reviewer fatigue.
+4. **Cross-repo component versioning** (Moderate) — When shared components update, ventures must migrate — version compatibility across multiple consumers.
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: (1) "Build it and they will come" — no evidence that all EHG venture markets reward design quality; enterprise B2B and developer tools may not benefit; (2) Venture factory speed-to-market fundamentally conflicts with design excellence; cannot have both without explicit stage-gating; (3) Automated review catches violations, not absence of vision — green checkmarks do not equal great design; (4) Critical unanswered question: "Who is the designer?" — AI generates generic, humans are expensive, chairman doesn't scale
+- **Assumptions at Risk**: (1) "Design creates disproportionate value" — only in design-sensitive markets, which EHG may or may not be targeting; (2) "Shared design system saves time" — or it constrains each venture's unique market positioning; (3) "Compound design intelligence" — operationally vague; linear gains from shared components masquerading as exponential claims; (4) "Automated review = quality assurance" — it's baseline hygiene, not design excellence
+- **Worst Case**: Design system becomes bottleneck — ventures can't ship until they comply. Compliance bar is high enough to slow validation but not high enough to differentiate. All ventures look the same. Design infrastructure rots as ventures fork and work around it. Opportunity cost: engineering time diverted from features customers actually use.
+
+### Visionary
+- **Opportunities**: (1) Design intelligence layer as portfolio-level capital asset — every venture inherits accumulated design knowledge on day one; (2) AI-assisted design review transforms economics — total coverage at near-zero marginal cost, design regressions caught before merge; (3) Cross-venture design insights compound — patterns discovered in one venture improve all others; (4) New venture time-to-design-excellence collapses from months to weeks; (5) Long-term: design system itself becomes a product (Design-as-a-Service for portfolio companies)
+- **Synergies**: LEO Protocol (design as first-class quality dimension in SD workflow), EVA Chat Canvas (canvas artifacts as design system showcase and testbed), competitive intelligence (design benchmarking and gap identification), component quality scoring (feeds into retrospective learnings), design decisions captured through EVA intake classification
+- **Upside Scenario**: Within 12 months — new ventures launch with design quality score >85, design regression caught pre-merge like test regression, at least one venture wins customers specifically because of design quality. Design quality per dollar invested is 3-5X due to shared infrastructure.
+
+### Pragmatist
+- **Feasibility**: 7.8/10 — Exceptional existing foundation (design-agent, tokens, a11y, gates). Missing pieces are organizational: cross-venture sharing, metrics, enforcement expansion.
+- **Resource Requirements**: 6-8 months phased approach. Phase 1 (metrics): 3 weeks. Phase 2 (review expansion): 3 weeks. Phase 3 (shared library): 6 weeks. Phase 4 (venture tokens): 4 weeks. Phase 5 (pattern library): 4 weeks. Phase 6 (CI/CD a11y): 2 weeks.
+- **Constraints**: (1) No monorepo structure for cross-venture component sharing; (2) No Storybook or design documentation tool; (3) Design-agent only auto-invokes for feature SDs (not all types); (4) Accessibility testing not in CI/CD pipeline
+- **Recommended Path**: Start with measurement (Phase 1), then expand enforcement (Phase 2), then build shared library (Phase 3). Don't build infrastructure before proving measurement works.
+
+### Synthesis
+- **Consensus Points**: (1) Existing infrastructure is strong — substantial foundation already built (all 3 agree); (2) Cross-venture sharing is the critical gap (Pragmatist + Visionary); (3) Must distinguish between design hygiene (automatable) and design excellence (requires judgment) (Challenger + Pragmatist agree)
+- **Tension Points**: (1) Challenger questions whether design is a real differentiator in all EHG markets vs Visionary sees portfolio-level compound advantage; (2) Challenger asks "who designs?" vs Visionary sees AI economics transforming the equation; (3) Pragmatist recommends measurement-first vs Visionary wants to build the intelligence layer
+- **Composite Risk**: Medium-Low — strong existing foundation reduces technical risk, but product-market fit (do EHG's markets reward design?) is the strategic wildcard
+
+## Open Questions
+- Should design quality investment be stage-gated? (validation-stage ventures get minimal design; growth-stage get full investment)
+- Who is the "designer" for each venture? AI-generated baseline + chairman taste-check? Contracted per venture?
+- Should the design system be opt-in per venture or mandatory?
+- How do we measure whether design quality actually drives business outcomes (conversion, retention, NPS)?
+
+## Suggested Next Steps
+1. Create SD(s) from this brainstorm with vision-key and arch-key linkage
+2. Architecture suggests 3 main phases — could be single SD with phased implementation or orchestrator
+3. Consider starting with metrics/measurement phase to validate the hypothesis before infrastructure investment
+4. Cross-repo coordination required (EHG frontend + EHG_Engineer backend)

--- a/brainstorm/2026-03-08-eva-chat-route-dynamic-canvas.md
+++ b/brainstorm/2026-03-08-eva-chat-route-dynamic-canvas.md
@@ -1,0 +1,115 @@
+# Brainstorm: EVA Chat Route with Dynamic Canvas
+
+## Metadata
+- **Date**: 2026-03-08
+- **Domain**: Integration
+- **Phase**: MVP (extending existing EVA infrastructure with dedicated conversational interface)
+- **Mode**: Conversational (autonomous — chairman asleep, EVA proceeding)
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: EHG_Engineer (backend EVA pipeline), EHG (Chairman UI frontend)
+- **Source**: Chairman final cut — merged from SD-RESEARCH-CHAIRMAN_UI-20260309-008 (GUI communication with EVA + dynamic canvas alongside chat)
+
+---
+
+## Problem Statement
+The chairman interacts with EVA (the AI strategic advisor) through dashboard-surfaced recommendations and a floating chat card. This limits strategic dialogue to either passive consumption (dashboards) or constrained conversation (small floating card). There is no dedicated workspace where the chairman can engage in extended strategic dialogue with EVA while seeing rich, structured analysis rendered alongside the conversation. The current floating chat cannot display charts, tables, decision matrices, or other structured artifacts that strategic decision-making requires.
+
+## Discovery Summary
+
+### Existing Infrastructure (Key Finding)
+The Pragmatist's codebase exploration revealed significant existing infrastructure across both repositories:
+
+**Frontend (EHG/ehg — Chairman V3):**
+- **`EVAChatInterface.tsx`** (614 LOC) — Fully functional chat UI with message rendering, voice input, tab system
+- **`EVAConversationService`** (386 LOC) — Manages conversations, messages, action items
+- **`EVAContext`** (296 LOC) — React Context for EVA state management
+- **`ChartRenderer.tsx`** (330 LOC) — Recharts wrapper supporting bar/line/pie/area charts
+- **`react-resizable-panels@2.1.9`** — Already in dependencies for split-panel layouts
+- **`react-markdown@9.1.0`** — Available for rich text rendering
+- **`@tanstack/react-query@5.83.0`** — Mature data fetching patterns throughout
+- **`recharts@2.15.4`** — Full chart library already integrated
+- **86 TSX components** in Chairman V3, 13 existing routes
+- Route pattern: `ProtectedRoute → ChairmanShell → LazyRoute → Page`
+
+**Backend (EHG_Engineer):**
+- **`client-factory.js`** — LLM routing infrastructure (Haiku/Sonnet tiers)
+- **EVA intake pipeline** — `eva-intake-pipeline.js`, `eva-intake-classify.js`, sync services
+- **`AIServiceManager`** — Wraps Claude/OpenAI with retry logic, timeouts, streaming support
+- **`voice_conversations` table** — Supabase migration for conversation storage (partially reusable)
+
+### What Must Be Built
+- EVA Chat route page with split-panel layout (chat + canvas)
+- Canvas content type system (5-7 initial types: decision matrix, comparison table, chart, OKR breakdown, timeline, text/markdown, risk heatmap)
+- Response parser/validator (EVA JSON output → canvas render)
+- Backend conversation API (save/retrieve EVA conversations)
+- Database migration for `eva_chat_conversations` table
+- Streaming integration (Challenger flagged polling as insufficient for chat UX)
+
+## Analysis
+
+### Arguments For
+- Existing infrastructure reduces implementation effort by ~70% — chat UI, charts, layouts, data fetching all exist
+- Transforms EVA from passive advisor (dashboard push) to interactive partner (conversational pull)
+- Compound queries become possible — multi-dimensional strategic questions answered in seconds instead of 20-minute dashboard navigation
+- Decision journaling with structured artifacts creates traceable strategic rationale
+- No new dependencies required — recharts, react-resizable-panels, react-markdown all in place
+- Canvas as action surface enables brainstorm→SD creation within conversation
+
+### Arguments Against
+- **Product-market risk**: No validated demand — does the chairman actually prefer conversational interaction for strategic decisions, or does he prefer structured dashboards?
+- **LLM output reliability**: EVA must produce consistent structured JSON for canvas content types — inconsistent output breaks the experience
+- **Streaming is non-negotiable**: Modern chat UX expects streaming; polling creates 5-15 second dead zones that feel broken
+- **Canvas is a rendering framework**: Each content type is effectively a mini-application with its own state, error handling, and lifecycle — not just a component
+- **EVAChatInterface coupling**: The existing 614 LOC component was built as a floating card, not a route-level panel — extraction is closer to a rewrite
+- **Content type explosion**: The chairman will request types beyond the initial 5-7; without a registry pattern, each addition is 2-3 days of work
+
+## Integration: Data Quality/Coverage Analysis
+
+| Dimension | Score |
+|-----------|-------|
+| Data Quality | 8/10 (High — all data from Supabase/EVA pipeline, well-structured) |
+| Coverage | 7/10 (Good — existing EVA context + venture metrics; gaps in real-time competitor data) |
+| Edge Cases | 5 identified |
+
+**Edge Cases**:
+1. **Malformed LLM JSON** (Common) — EVA produces canvas content that passes schema validation but renders nonsensically (0 data points, mismatched columns). Requires validation+repair layer.
+2. **Content type not supported** (Common during rollout) — Chairman asks for visualization EVA cannot produce. Graceful fallback to markdown/text rendering.
+3. **Long conversation performance** (Moderate) — 100+ message threads with many canvas renders cause React re-render cascading. Memoization and lazy-loading required.
+4. **Stale data rendering** (Moderate) — Canvas shows metrics that are hours/days old. Freshness indicators needed on all canvas artifacts.
+5. **Concurrent conversation sessions** (Rare) — Chairman opens EVA chat on desktop and mobile simultaneously. Conversation sync via Supabase Realtime.
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: (1) "Build it and they will come" trap — no validated demand for conversational strategic interface; chairman may prefer structured dashboards for decision-making; (2) Canvas is a rendering framework, not a feature — each content type is a mini-application with its own state/error handling; (3) EVAChatInterface extraction from floating card is closer to a rewrite than refactoring due to layout/context coupling; (4) Conversation persistence and shareability not addressed — without them, canvas becomes transient artifact generator
+- **Assumptions at Risk**: (1) EVA can reliably produce structured JSON — LLMs produce malformed/hallucinated output more than teams expect; (2) Polling is sufficient — modern chat UX demands streaming, launching without it feels broken by comparison; (3) 5-7 content types cover use cases — content type requests follow a power law, architecture must handle growth; (4) Existing EVAChatInterface can be extracted — 614 LOC built for floating card context has different layout/lifecycle assumptions
+- **Worst Case**: Feature ships, chairman tries real strategic queries. EVA produces inconsistent JSON, canvas crashes or shows raw data. Polling delay makes it feel sluggish. Chairman uses it twice, returns to dashboards. Feature becomes most expensive per usage minute — ongoing maintenance for content types nobody uses. Engineering time diverted from high-impact dashboard improvements.
+
+### Visionary
+- **Opportunities**: (1) Paradigm shift from "navigating information" to "conversing with it" — compound queries collapse 20-minute dashboard workflows to 90 seconds; (2) Decision journaling — every canvas render is a decision artifact with timestamped rationale, creates traceable strategic history; (3) In-chat brainstorming — brainstorm→SD pipeline happens inside conversation with canvas providing structured scaffolding; (4) Venture factory differentiator — no competitor has conversational strategic AI + structured canvas
+- **Synergies**: EVA recommendation engine (push→pull complete loop), brainstorm pipeline (conversational brainstorming), LEO Protocol/SD creation (natural language front end for SD initiation), competitor monitoring (canvas visualizes competitive intelligence), Todoist/YouTube intake (visual classification review through canvas)
+- **Upside Scenario**: Within 6 months, the EVA chat route becomes the chairman's primary work surface. Morning briefings take 3 minutes instead of 15. Brainstorm-to-SD conversion drops from days to minutes. 40% of SDs initiated through conversational EVA. Decision documentation goes from 20% to 100% with full conversational context.
+
+### Pragmatist
+- **Feasibility**: 8.5/10 — Both codebases have mature infrastructure; existing EVA patterns, conversation management, chart rendering, and layout systems all in place. Main work is integration.
+- **Resource Requirements**: 950-1,550 LOC (excluding tests), ~7-9 days. No new dependencies needed. Phase 1 (infra): 2-3 days, Phase 2 (canvas): 2-3 days, Phase 3 (streaming+polish): 2-3 days.
+- **Constraints**: (1) Streaming vs polling decision must be made early — architectural impact; (2) EVAChatInterface extraction is really a rewrite; (3) Content type registry pattern needed from day 1 to prevent maintenance explosion; (4) Database migration needed for eva_chat_conversations table
+- **Recommended Path**: Phase 1 (route + layout + basic API), Phase 2 (canvas content types with registry pattern), Phase 3 (streaming + error handling + polish). Start with 5 core content types, make the registry extensible.
+
+### Synthesis
+- **Consensus Points**: (1) Existing infrastructure is strong — 70%+ reusable (all 3 agree); (2) Content type architecture must be extensible from day 1 (Challenger + Pragmatist); (3) This is technically feasible with known patterns (all 3 agree)
+- **Tension Points**: (1) Challenger questions whether demand exists vs Visionary sees paradigm shift; (2) Pragmatist says polling-first vs Challenger insists streaming is non-negotiable for chat UX; (3) Visionary envisions persistent workspaces vs Challenger warns about scope creep
+- **Composite Risk**: Medium — strong technical foundation, but product-market fit risk (conversational vs dashboard preference) requires validation. LLM output reliability is the technical wildcard.
+
+## Open Questions
+- Should a Phase 0 prototype be required to validate the chairman prefers conversational EVA over dashboard-surfaced recommendations?
+- Streaming vs polling: commit to streaming from day 1 (adds 3-4 days but prevents rewrite), or ship polling MVP first?
+- Should canvas artifacts be persistent (saved alongside conversation) or ephemeral (rendered on demand)?
+- How should the canvas handle EVA hallucinations or incorrect structured data?
+
+## Suggested Next Steps
+1. Create SD(s) from this brainstorm with vision-key and arch-key linkage
+2. Architecture suggests 3 implementation phases — could be orchestrator with children
+3. Cross-repo coordination required (EHG frontend + EHG_Engineer backend)
+4. Consider Phase 0 prototype (2-day spike) to validate chairman preference before full build

--- a/brainstorm/2026-03-08-genesis-venture-factory-offering.md
+++ b/brainstorm/2026-03-08-genesis-venture-factory-offering.md
@@ -1,0 +1,121 @@
+# Brainstorm: Genesis — Public Venture Factory Offering
+
+## Metadata
+- **Date**: 2026-03-08
+- **Domain**: Product
+- **Phase**: MVP (productizing EHG's venture factory methodology as a standalone offering)
+- **Mode**: Conversational (autonomous — chairman asleep, EVA proceeding)
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: EHG_Engineer (LEO Protocol, EVA, stage gates), EHG (Chairman UI, design system)
+- **Source**: Chairman final cut — item retained from SD-RESEARCH-VENTURE_FACTORY-20260309-012
+
+---
+
+## Problem Statement
+EHG has built a comprehensive venture factory infrastructure: a 25-stage venture lifecycle engine, AI-powered strategic advisory (EVA), automated stage gates with kill/promotion decisions, opportunity scoring across 6 dimensions, moat architecture assessment, cross-venture learning, portfolio optimization, and a simulation chamber (Genesis/Aries). This infrastructure represents 221K+ LOC in the EVA subsystem alone, with 34K+ LOC of directly reusable core components. But this investment is locked inside EHG as an internal operating system. The question is whether EHG should productize this methodology — offering "Genesis" as a platform that helps others build venture factories using the EHG playbook — transforming EHG from a portfolio company into a platform company.
+
+## Discovery Summary
+
+### Existing Infrastructure (Key Finding)
+The Pragmatist's exploration revealed massive existing infrastructure — far more than expected:
+
+**Core Venture Lifecycle Engine (34,130 LOC, production-ready):**
+- **Venture State Machine** (`lib/agents/modules/venture-state-machine/`, 1,301 LOC): Full lifecycle engine with stage transitions, validation, and state management
+- **EVA Stage Templates** (`lib/eva/stage-templates/`, 68 files, 14,690 LOC): Stages 1-25 fully templated with automation, requirements, gates, outputs, and validation per stage
+- **EVA Stage-Zero Synthesis** (`lib/eva/stage-zero/`, 41 files, 7,597 LOC): 16 archetype profiles for venture typing, automatic path routing (Blueprint Browse, Competitor Teardown, Discovery Mode)
+- **Genesis Simulation** (`lib/genesis/` + `scripts/genesis/`, 20 files, 8,151 LOC): Spawn ventures in sandboxed "Aries" environment, pattern-based code generation, GitHub repo + Vercel deployment, pre-production quality gates
+- **Venture CEO Factory** (`lib/agents/venture-ceo-factory.js`, 474 LOC): Auto-create 19-agent hierarchy (1 CEO + 4 VPs + 14 Crews)
+- **Discovery Service** (`lib/discovery/`, 1,917 LOC): Gap analysis (6 dims), opportunity scoring (6 weighted dims), Green/Yellow/Red classification
+
+**Supporting Intelligence Layer (4,830 LOC):**
+- **EVA Orchestrators** (2,159 LOC): Multi-venture coordination, event-driven architecture
+- **Cross-Venture Learning** (871 LOC): Pattern recognition, assumption calibration, success/failure analysis
+- **Historical Pattern Matching** (~800 LOC): Decision support from past ventures
+- **Capability Graphs** (~600 LOC): Competency tracking across agents
+- **Event Bus & Handlers** (~400 LOC): Async event processing
+
+**Database Schema**: 60+ tables covering venture lifecycle, strategic directives, financial contracts, retrospectives, issue patterns
+
+**Overall**: ~88% reusability rating across core components. 221K LOC total in /lib/ (874 files).
+
+### What Must Be Built (for productization)
+- **Multi-tenancy layer** (~30-40% new code): RLS policies, schema partitioning, billing keys, customer isolation
+- **Customer auth & onboarding** (~15-20%): Signup flow, multi-user RBAC, API keys, OAuth
+- **Billing infrastructure** (~10-15%): Usage metering, pricing tier enforcement, Stripe integration
+- **API documentation & SDKs** (~10-15%): OpenAPI spec, REST wrapper, webhook system
+- **White-labeling** (~5-8%): Custom domains, branding, CSS theming
+- **Compliance** (~5-10%): GDPR, data retention, customer data deletion
+- **Customer support** (~5-10%): Support ticketing, knowledge base, training materials
+
+## Analysis
+
+### Arguments For
+- 80-85% of the technical product already built — remaining 15-20% is infrastructure plumbing (multi-tenancy, auth, billing)
+- 25-stage venture lifecycle validated in production is genuinely novel — no competitor has this depth
+- Platform company multiples (10-20x revenue) vs portfolio company multiples (3-5x)
+- Data network effects: more ventures → smarter system → better predictions → more ventures
+- Revenue diversification: SaaS subscriptions cover operating costs while equity positions become pure upside
+- Genesis simulation chamber ("try before you commit") is a differentiator no accelerator offers
+- EHG's AI CEO agents managing VPs + crews is architecturally novel
+
+### Arguments Against
+- **Methodology may not be separable from the operator**: EHG's success may depend on the chairman's judgment, not the tooling. Selling a fighter jet without the pilot.
+- **Survivorship bias in track record**: How many EHG ventures have actually launched, scaled, and exited? Selling an unfinished experiment as a product is a credibility risk.
+- **Market may not exist at the right price point**: Venture studios number in hundreds, not thousands. Enterprise buyers expect white-glove service. Individuals expect free.
+- **IP exposure risk**: Every Genesis customer becomes a potential competitor. Publishing the playbook gives away the advantage.
+- **Resource conflict**: Teaching mode vs building mode compete for leadership attention. Every support ticket for Genesis is time not spent on EHG ventures.
+- **AI-assisted venture building is a moving target**: Foundation model capabilities change quarterly. Today's differentiator is tomorrow's commodity.
+- **Open-source alternatives will undercut**: Methodology layer is not defensible IP. Free blog posts, YouTube tutorials, and templates cover 80% of value.
+
+## Integration: Data Quality/Coverage Analysis
+
+| Dimension | Score |
+|-----------|-------|
+| Data Quality | 8/10 (Comprehensive infrastructure, production-proven, well-documented) |
+| Coverage | 7/10 (Strong core engine but no multi-tenancy, billing, or external-facing layers) |
+| Edge Cases | 5 identified |
+
+**Edge Cases**:
+1. **Customer ventures competing with EHG ventures** (High) — Genesis users may build in markets EHG is targeting. No conflict resolution mechanism exists.
+2. **Cross-venture learning privacy** (High) — Should learnings from Customer A's ventures improve Customer B's experience? Aggregate vs private patterns.
+3. **Vercel deployment per customer** (Moderate) — Currently hardcoded to EHG's Vercel team. Per-customer deployment accounts add complexity and cost.
+4. **Chairman approval gates without a chairman** (Moderate) — Stages 3, 5, 13, 23 require "chairman" decisions. External users need role-mapped decision authority.
+5. **Agent token budgets at scale** (Moderate) — CEO agents allocated 50K tokens per venture. Multi-customer scale could explode LLM costs.
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: (1) Methodology may not be separable from the operator — value is the pilot, not the fighter jet (2) Survivorship bias — EHG's track record is an ongoing experiment, not a validated methodology (3) Market may not exist at the right price point — venture studios are hundreds, not thousands (4) AI-assisted venture building is a moving target — today's differentiator is 18-month commodity (5) Teaching mode vs building mode is a resource conflict — leadership attention is zero-sum (6) Open-source alternatives will undercut — methodology is not defensible IP
+- **Assumptions at Risk**: (1) "Our methodology is transferable without us" — may require EHG-level AI literacy, technical skill, and strategic judgment (2) "People will pay meaningful revenue" — venture studio audience is small, enterprise expects white-glove, individuals expect free (3) "Exposing our methodology does not create competitors" — every customer becomes a potential competitor (4) "We can support external users without degrading internal velocity" — external users generate support burden (5) "The venture factory model is the future" — venture studios have existed 20+ years without becoming dominant
+- **Worst Case**: Genesis generates modest revenue (enough to survive, not enough to matter) while draining leadership attention from core ventures. Becomes politically difficult to kill because it was a strategic initiative. EHG's greatest asset — focused execution — gets diluted. Slow resource drain with no clear kill signal.
+
+### Visionary
+- **Opportunities**: (1) Platform flywheel — transform from portfolio company (3-5x multiple) to platform company (10-20x multiple) (2) Data network effects — 200+ external ventures generate structured data, creating asymmetric prediction advantage (3) Revenue diversification — SaaS subscriptions cover operating costs, equity positions become pure upside (4) Talent/deal flow magnet — founders on Genesis become natural investment targets, engineers become familiar with stack (5) Methodology lock-in through tooling — software-embedded methodology stickier than books/blogs (6) Open-core model — free methodology framework, premium AI insights and cross-venture benchmarking
+- **Synergies**: LEO Protocol (generalizable orchestration engine), EVA (strategic advisor as a service), Design System (shared UI accelerator for Genesis ventures), Stage Gates (validation-as-a-service), Cross-Venture Intelligence (aggregate benchmarking), Competitive Intelligence Pipeline (shared market signal feed)
+- **Upside Scenario**: 12-18 months — 200+ ventures on platform, first Genesis-built venture raises Series A, ARR $800K-1.2M. Genesis becomes "Y Combinator meets Replit for venture building." Data flywheel creates prediction capability no competitor can replicate. EHG holds equity in 30-50 Genesis ventures. "Genesis-built" becomes a quality signal.
+
+### Pragmatist
+- **Feasibility**: 7.5/10 — Productizable with significant engineering lift on multi-tenancy and customer-facing layers. 88% of core components reusable. Missing pieces are infrastructure plumbing, not product innovation.
+- **Resource Requirements**: 2-3 senior backend engineers, 12-16 weeks MVP. Phase 1 (weeks 1-6): Multi-tenant schema, auth, core workflow. Phase 2 (weeks 7-12): Full stage gates, billing, support. Phase 3 (months 5+): Cross-venture learning, white-labeling, enterprise. Estimated $50-100K cloud infrastructure costs.
+- **Constraints**: (1) Supabase single-tenant design requires schema refactor (2) Chairman-only gate decisions need role mapping (3) Vercel deployment hardcoded to EHG (4) Agent token budgets need per-customer metering (5) Cross-venture learning data trained on EHG ventures (biased)
+- **Recommended Path**: Validate demand before building — interview 20 potential customers. Start with content (thought leadership), measure inbound interest. If interest validates, ring-fence investment with hard kill metric (10 paying customers in 6 months). Consider licensing to established venture studios as lower-lift alternative to self-serve SaaS.
+
+### Synthesis
+- **Consensus Points**: (1) The technical foundation is exceptional — 80-85% of core product exists (all 3 agree); (2) Multi-tenancy and customer-facing layers are the primary technical gap (Pragmatist + Visionary); (3) Demand validation must happen before significant investment (Challenger + Pragmatist agree)
+- **Tension Points**: (1) Challenger sees existential risks (IP exposure, resource drain, market uncertainty) vs Visionary sees category-defining opportunity; (2) Challenger argues methodology requires the operator vs Visionary argues tooling embeds methodology; (3) Pragmatist recommends content-first validation vs Visionary wants to capture first-mover advantage with product
+- **Composite Risk**: Medium-High — strong technical foundation reduces build risk, but market risk (do enough buyers exist at viable price points?) and strategic risk (resource conflict, IP exposure) are significant. Demand validation before investment is critical.
+
+## Open Questions
+- Should Genesis target enterprise venture studios (high touch, high revenue, small market) or individual founders (low touch, low revenue, large market)?
+- What is the kill metric? (Proposed: 10 paying customers in 6 months or redirect effort)
+- How do we handle ventures built on Genesis that compete with EHG ventures?
+- Should cross-venture learning be shared across all Genesis customers or siloed per customer?
+- Is licensing to existing venture studios a better initial strategy than self-serve SaaS?
+- What equity stake (if any) should Genesis take in ventures built on the platform?
+
+## Suggested Next Steps
+1. Create SD(s) from this brainstorm with vision-key and arch-key linkage
+2. Architecture suggests an orchestrator with phased children — Phase 1 (demand validation + multi-tenancy), Phase 2 (product + billing), Phase 3 (growth + enterprise)
+3. Critical: Phase 1 must include demand validation (customer interviews) before heavy engineering investment
+4. Consider starting with thought leadership content to measure market interest before product build

--- a/brainstorm/2026-03-08-pre-development-artifact-checklist.md
+++ b/brainstorm/2026-03-08-pre-development-artifact-checklist.md
@@ -1,0 +1,123 @@
+# Brainstorm: Pre-Development Artifact Checklist & Quality Gates
+
+## Metadata
+- **Date**: 2026-03-08
+- **Domain**: protocol
+- **Phase**: mvp (formalizing artifact prerequisites before EXEC phase)
+- **Mode**: Conversational (autonomous — chairman asleep, EVA proceeding)
+- **Outcome Classification**: Ready for SD
+- **Team Analysis**: Yes (3/3 perspectives)
+- **Related Ventures**: EHG_Engineer (LEO Protocol gate infrastructure)
+- **Source**: Chairman final cut — item retained from SD-RESEARCH-LIFECYCLE_GATES-20260309-013
+
+---
+
+## Problem Statement
+EHG's LEO Protocol has a sophisticated gate system — 40+ gates across 4 phase transitions, type-aware scoring, progressive preflight, and 3-tier auto-heal. But the gates are scattered across 5 executor directories with no unified "readiness dashboard" that tells you whether all prerequisite artifacts are complete before an SD enters EXEC (implementation). The infrastructure exists to enforce artifact requirements; it just needs orchestration at a higher level. Specifically: brainstorm docs, vision docs, architecture plans, PRDs, and EVA registrations are sometimes created and sometimes skipped depending on the developer's diligence, not on systematic enforcement. The recently merged SD-type-aware gates (PR #1890) and progressive preflight provide the foundation — the question is whether to add a unified pre-EXEC artifact checklist on top of this foundation.
+
+## Discovery Summary
+
+### Existing Infrastructure (Key Finding)
+The Pragmatist's exploration revealed that 90% of the infrastructure already exists:
+
+**Gate Infrastructure (Comprehensive):**
+- **BaseExecutor** (`scripts/modules/handoff/executors/BaseExecutor.js`, 1,021 LOC): Template method pattern orchestrating all phase transitions
+- **ValidationOrchestrator** (`scripts/modules/handoff/validation/ValidationOrchestrator.js`, 949 LOC): Gate execution coordinator with retry logic
+- **Phase-specific gate directories**: LEAD-TO-PLAN (8 gates), PLAN-TO-EXEC (16+ gates), EXEC-TO-PLAN (21+ gates), PLAN-TO-LEAD (16+ gates)
+- **Database-driven rules**: `leo_validation_rules` table enables dynamic gate policy override
+- **SD Type Awareness**: Different blocking/advisory behavior per SD type (feature, infrastructure, fix, etc.)
+
+**Already Validated at PLAN-TO-EXEC:**
+- PRD exists and status = 'approved' (GATE_PRD_EXISTS)
+- Architecture verification (GATE_ARCHITECTURE_VERIFICATION)
+- Exploration audit (≥5 files documented — currently advisory only)
+- Planning completeness with 3-ring model (GATE_PLANNING_COMPLETENESS)
+- Vision dimension completeness (GATE_VISION_DIMENSION_COMPLETENESS)
+- Architecture requirement trace (GATE_ARCHITECTURE_REQUIREMENT_TRACE)
+
+**Gaps Identified:**
+1. **No centralized artifact checklist UI** — gates are scattered, no single readiness summary
+2. **EVA registration not enforced** — vision scores checked but brainstorm/vision/architecture document presence not required
+3. **PRD exec_checklist not validated at PLAN-TO-EXEC** — only checked at EXEC-TO-PLAN (after implementation)
+4. **Exploration audit is advisory-only** — warns but doesn't block
+5. **No phase coverage gate in PLAN-TO-EXEC** — phase-coverage-validator.js exists but isn't wired in
+6. **No orchestrator coherence check at PLAN-TO-EXEC** — only validated in LEAD phase
+
+### What Must Be Built
+- **Unified PRE-EXEC-READINESS gate** (~100-150 LOC): Aggregate artifact checks into single gate with missing-artifacts summary
+- **EVA artifact registration gate** (~80-120 LOC): Validate vision + architecture docs exist in EVA
+- **PRD exec_checklist validation** (~40-60 LOC): Check exec_checklist exists at PLAN-TO-EXEC
+- **Elevate exploration audit to blocking** (~20 LOC): Feature/infrastructure/database types require 5+ files
+- **Orchestrator coherence gate** (~100-150 LOC): Child dependencies validated at PLAN-TO-EXEC
+
+## Analysis
+
+### Arguments For
+- 90% of infrastructure already exists — this is configuration, not construction
+- The recently shipped type-aware gates and progressive preflight provide the perfect foundation
+- Artifacts created to pass gates become AI training data — improving LEO's future performance
+- Chairman gets predictability: work is legible before code is written
+- Rework caught at artifact stage costs 10-100x less than rework caught in production
+- Cross-venture learning can correlate artifact quality with implementation outcomes
+- Genesis customers benefit from the same artifact pipeline (scaling readiness)
+
+### Arguments Against
+- **Gate count is already high** (8+ validation checkpoints in the pipeline) — adding more risks gate fatigue
+- **Small work items suffer disproportionately** — a 15-line config fix doesn't need a brainstorm doc
+- **Artifact existence ≠ artifact utility** — developers create boilerplate to pass gates (compliance theater)
+- **EVA registration as gate is premature** — EVA intake redesign itself is still in design phase
+- **Automation creates workaround incentives** — people who skip artifacts are the same people who'll find bypasses
+- **No evidence from retrospectives** that missing artifacts caused implementation failures
+- **The type-aware gates just shipped** (PR #1890) — evaluate their impact before adding another layer
+- **Staleness risk** — artifacts written weeks before implementation may create false confidence
+
+## Integration: Data Quality/Coverage Analysis
+
+| Dimension | Score |
+|-----------|-------|
+| Data Quality | 9/10 (Comprehensive gate infrastructure, 40+ gates, database-driven rules, type-aware scoring) |
+| Coverage | 7/10 (Strong validation but no unified pre-EXEC readiness check, EVA registration optional) |
+| Edge Cases | 4 identified |
+
+**Edge Cases**:
+1. **Quick-fix and bugfix SDs** (Common) — Should not require brainstorm/vision/architecture docs. Type-awareness must exempt Tier 1/2 work items.
+2. **Retrospective auto-generation quality** (Known) — Auto-generated artifacts always fail quality gates (MEMORY.md documented pattern). Same risk for auto-generated brainstorm/vision docs.
+3. **Stale artifacts** (Moderate) — Architecture doc written 3 weeks before implementation may no longer reflect current codebase. No recency enforcement mechanism.
+4. **EVA intake redesign dependency** (Moderate) — Making EVA registration a gate couples development lifecycle to a system still under construction.
+
+## Team Perspectives
+
+### Challenger
+- **Blind Spots**: (1) Problem may be misdiagnosed — existing gates should already catch missing artifacts; if they don't, the issue is enforcement not coverage (2) Small work items suffer disproportionately — 15-line fixes don't need full artifact chains (3) EVA registration as gate is premature — coupling to a system under construction (4) Artifact existence ≠ artifact utility — compliance theater risk (5) Gate count already high — 8+ checkpoints, adding more risks fatigue
+- **Assumptions at Risk**: (1) "More validation = better outcomes" — inverted U-curve in process research (2) "All SD types need same artifacts" — type-aware gates just shipped, evaluate first (3) "Automation prevents skipping" — emergency bypass and workaround culture (4) "Missing artifacts cause failures" — may be poor scoping, changing requirements instead (5) "Checklist will be maintained" — process debt accumulates faster than code debt
+- **Worst Case**: Compliance theater — developers create minimum-viable artifacts to pass gates (2-sentence brainstorms, restated titles as visions). Gate pass rates look great (95%). Development velocity drops 15-20%. Quality doesn't measurably improve. System becomes a ratchet — gates only get added, never removed.
+
+### Visionary
+- **Opportunities**: (1) Quality compounding — each SD builds on validated foundations, exponential improvement (2) Institutional knowledge as living asset — every decision becomes searchable (3) AI performance flywheel — well-structured artifacts are training data that makes LEO smarter (4) Predictability for chairman — work is legible before code is written (5) Rework elimination at source — 10-100x cheaper to catch at requirements vs production (6) Team scaling readiness — artifact chain IS the onboarding for new contributors (7) Audit trail for enterprise trust
+- **Synergies**: LEO Phase Transitions (natural enforcement point), EVA Registration Pipeline (mandatory not optional), Heal Command (verify against full artifact chain not just PRD), Learn Command (correlate artifact quality with outcomes), SD Type-Aware Gates (type-specific artifact requirements), Progressive Preflight (artifact completeness as fast-fail), Brainstorm Pipeline (formalize informal intake-to-SD chain)
+- **Upside Scenario**: 6-12 months — artifact coverage 95%+, rework rate drops from ~25% to ~8%, LEO auto-generates draft artifacts with 70% acceptance rate by month 9, estimation accuracy within 20%, Genesis ships artifact pipeline as customer-facing feature.
+
+### Pragmatist
+- **Feasibility**: 8/10 — Gate infrastructure is mature, modular, extensible. 40+ gates already implemented. Database-driven rules allow dynamic configuration. Missing pieces are ~400-500 LOC across 5 small additions.
+- **Resource Requirements**: 1-2 SDs, estimated 2-3 weeks total. Unified PRE-EXEC-READINESS gate (150 LOC), EVA registration gate (120 LOC), PRD exec_checklist validation (60 LOC), exploration audit elevation (20 LOC), orchestrator coherence gate (150 LOC).
+- **Constraints**: (1) Must be type-aware — no artifact burden on Tier 1/2 work (2) EVA registration gate should be advisory until EVA intake redesign is built (3) Quality checks needed alongside existence checks (4) Must not slow down quick fixes
+- **Recommended Path**: Start with the unified PRE-EXEC-READINESS gate — it's the most impactful single addition. Make it type-aware from day 1. EVA registration starts advisory, graduates to blocking after EVA intake redesign ships. Evaluate impact of type-aware gates (PR #1890) before adding blocking artifact gates.
+
+### Synthesis
+- **Consensus Points**: (1) Infrastructure is 90% built — this is small incremental work (all 3 agree); (2) Must be type-aware — no artifact burden on small fixes (Challenger + Pragmatist); (3) Artifact quality matters more than artifact existence (Challenger + Visionary agree)
+- **Tension Points**: (1) Challenger warns about gate fatigue and compliance theater vs Visionary sees quality compounding and AI training data; (2) Challenger recommends waiting for type-aware gate data vs Pragmatist wants to build now; (3) Challenger prefers soft warnings vs Pragmatist recommends blocking gates with type-awareness
+- **Composite Risk**: Low — the work is small (~500 LOC), highly incremental, and builds on mature infrastructure. The strategic risk is compliance theater (artifacts created to pass gates without providing value), mitigated by quality checks and type-awareness.
+
+## Open Questions
+- Should the artifact checklist be blocking or advisory for the first 30 days? (Proposed: advisory first, blocking after calibration)
+- Which artifacts are required for which SD types? (Proposed: feature/infrastructure require all 5; fix/bugfix require only PRD; documentation requires nothing)
+- Should artifact recency be enforced? (e.g., architecture doc must be <30 days old)
+- How do we measure whether artifact gates actually reduce rework? (Proposed: learn command correlation analysis)
+- Should EVA registration be required before or after the EVA intake redesign ships?
+
+## Suggested Next Steps
+1. Create a single SD from this brainstorm — the work is ~500 LOC across 5 small gate additions
+2. Start with unified PRE-EXEC-READINESS gate as the primary deliverable
+3. Make type-aware from day 1 — no artifact burden on quick fixes
+4. EVA registration starts advisory, graduates to blocking post-EVA-intake-redesign
+5. Include quality checks (not just existence checks) for brainstorm and vision artifacts

--- a/docs/plans/5-10x-value-methodology-architecture.md
+++ b/docs/plans/5-10x-value-methodology-architecture.md
@@ -1,0 +1,82 @@
+# Architecture Plan: 5-10X Value vs Competition Methodology
+
+## Stack & Repository Decisions
+- **Repositories**: EHG_Engineer (backend — scoring pipeline, stage gates, portfolio optimizer)
+- **Runtime**: Node.js (existing LEO Protocol infrastructure)
+- **LLM**: Claude Sonnet for competitive baseline analysis and value multiplier estimation. Uses existing `client-factory.js` for LLM routing.
+- **Database**: Supabase (PostgreSQL) — extends existing schema
+- **Existing Infrastructure (Fully Reusable)**: OpportunityScorer (394 LOC, 6 weighted dimensions), GapAnalyzer (343 LOC, 6 gap dimensions), moat-architecture.js (109 LOC, 7 moat types), stage-gates.js (704 LOC, kill/promotion gates), financial-contract.js (276 LOC, unit economics), cross-venture-learning.js (612 LOC, pattern extraction), portfolio-optimizer.js (524 LOC, resource allocation)
+- **New Dependencies**: None required
+
+## Legacy Deprecation Plan
+N/A — additive infrastructure. The existing OpportunityScorer gains a 7th dimension; existing 6 dimensions and their weights are rebalanced but not removed. Stage gates gain an advisory check; existing kill/promotion gates unchanged. Portfolio optimizer gains an additional signal; existing 5 signals unchanged.
+
+## Route & Component Structure
+
+### EHG_Engineer (Backend)
+- `lib/discovery/opportunity-scorer.js` — **Modified**: Add `value_multiplier` as 7th scoring dimension. Rebalance weights. Add `calculateValueMultiplier()` method.
+- `lib/discovery/value-multiplier-calculator.js` — **New**: Calculates value multiplier from gap scores, financial contract data, moat output. Produces multiplier range with confidence interval.
+- `lib/discovery/competitive-baseline-service.js` — **New**: Manages competitive baseline data per venture. CRUD operations on `competitive_baselines` table. Integrates with gap analyzer outputs.
+- `lib/agents/modules/venture-state-machine/stage-gates.js` — **Modified**: Add advisory value multiplier gate at stages 5 and 13. Non-blocking (advisory only) until calibration data supports kill gate.
+- `lib/eva/portfolio-optimizer.js` — **Modified**: Add `value_multiplier` as 6th signal weight. Rebalance existing 5 weights.
+- `lib/eva/cross-venture-learning.js` — **Modified**: Add `analyzeValueMultiplierCalibration()` for historical accuracy tracking.
+- `scripts/eva/value-multiplier-dashboard.mjs` — **New**: Generates portfolio value multiplier report for chairman.
+
+## Data Layer
+
+### New Tables
+- `competitive_baselines` — Per-venture competitive baseline data
+  - `id` (uuid), `venture_id` (fk → ventures), `competitor_name` (text)
+  - `pricing_data` (jsonb — plans, tiers, per-seat costs), `feature_coverage` (jsonb — feature list with scores)
+  - `performance_metrics` (jsonb — speed, reliability, uptime), `user_satisfaction` (jsonb — NPS, reviews, ratings)
+  - `data_quality` (text — FACT, ASSUMPTION, SIMULATION, UNKNOWN per four-bucket model)
+  - `source` (text — where data came from), `collected_at` (timestamptz)
+  - `created_at` (timestamptz), `updated_at` (timestamptz)
+
+- `value_multiplier_scores` — Per-venture value multiplier time-series
+  - `id` (uuid), `venture_id` (fk → ventures), `scored_at` (timestamptz)
+  - `overall_multiplier` (numeric — composite score, e.g., 7.3)
+  - `multiplier_low` (numeric — confidence interval low bound, e.g., 5.0)
+  - `multiplier_high` (numeric — confidence interval high bound, e.g., 9.5)
+  - `confidence_level` (text — FACT, ASSUMPTION, SIMULATION, UNKNOWN)
+  - `sub_scores` (jsonb — { price_performance: 8.2, capability_breadth: 6.5, time_to_value: 9.0, ux_quality: 7.0, integration_depth: 5.5 })
+  - `competitor_baseline_ids` (uuid[] — references to competitive_baselines used)
+  - `scoring_context` (jsonb — gap scores, financial data, moat data used in calculation)
+  - `created_at` (timestamptz)
+
+### Existing Tables Used
+- `ventures` — Venture context for scoring
+- `venture_financial_contract` — Unit economics data for price-performance sub-score
+- `competitors` — Existing competitor tracking (if populated)
+- `opportunity_scans` — Gap analyzer outputs
+
+### RLS
+- Service role for backend scoring pipeline
+- Authenticated read for dashboard access (chairman view)
+
+## API Surface
+- No new REST endpoints needed (internal pipeline)
+- RPC: `get_value_multiplier_history(venture_id, since_date)` — time-series for dashboard
+- RPC: `get_portfolio_value_summary()` — all ventures' latest multiplier scores
+- The existing stage gate system handles gate integration internally
+
+## Implementation Phases
+- **Phase 1** (2 weeks): Value Multiplier Dimension — Create `value_multiplier_scores` table. Build `value-multiplier-calculator.js` composing multiplier from gap scores + financial contract + moat output. Integrate as 7th dimension in OpportunityScorer with rebalanced weights: market_opportunity 0.20, competitive_advantage 0.15, feasibility 0.15, evidence_strength 0.15, time_to_value 0.10, risk_adjusted 0.10, value_multiplier 0.15. Dashboard widget showing multiplier per venture.
+- **Phase 2** (2 weeks): Competitive Baselines — Create `competitive_baselines` table. Build `competitive-baseline-service.js` for CRUD and gap analyzer integration. Epistemic quality tags (FACT/ASSUMPTION/SIMULATION/UNKNOWN) per data point. LLM-assisted baseline extraction from existing competitor analysis artifacts.
+- **Phase 3** (2 weeks): Stage Gate Integration — Add advisory value multiplier gate at stages 5 (post-discovery) and 13 (pre-scale). Non-blocking — produces advisory output, does not prevent stage advancement. Multiplier trajectory tracking via time-series in `value_multiplier_scores`. Decay detection: alert when multiplier drops >20% quarter-over-quarter. Cross-venture learning calibration: `analyzeValueMultiplierCalibration()` in cross-venture-learning.js.
+- **Phase 4** (2 weeks): Portfolio Intelligence — Add `value_multiplier` as signal weight (0.15) in portfolio-optimizer.js. Rebalance existing weights: urgency 0.25, roi 0.20, financial 0.15, market 0.15, health 0.10, value_multiplier 0.15. Portfolio value heat map generation (`value-multiplier-dashboard.mjs`). Calibration report (estimated vs actual multiplier for completed ventures).
+
+## Testing Strategy
+- Unit tests for value multiplier calculator (known gap scores + financial data → expected multiplier range)
+- Unit tests for confidence interval calculation (FACT data → narrow intervals, ASSUMPTION → wider)
+- Integration tests for OpportunityScorer with 7th dimension (existing 6-dimension tests still pass)
+- Integration tests for stage gate advisory check (venture at stage 5 → advisory output without blocking)
+- Calibration tests: synthetic historical data → calibration report accuracy
+- Edge case tests: no competitor data → status quo fallback, multi-segment ventures → weighted composite
+
+## Risk Mitigation
+- **False precision**: Confidence intervals required on all multiplier scores. UNKNOWN epistemic level when data is insufficient. Chairman sees ranges, not single numbers. Advisory-only gates until calibration proves predictive power.
+- **Weight rebalancing destabilization**: Existing OpportunityScorer tests must continue to pass. Rebalanced weights maintain same ordering on test portfolio (no rank inversions for well-scored ventures). Feature flag to toggle 7th dimension during rollout.
+- **Competitive data staleness**: `collected_at` timestamp on all baselines. Auto-warning when baseline data > 90 days old. Confidence level degrades over time (FACT → ASSUMPTION after 6 months without refresh).
+- **Kill gate misuse**: Advisory-only for minimum 12 months. Explicit "lens not gate" labeling. Kill gate requires chairman opt-in per venture, not automatic enforcement.
+- **Denominator estimation error**: The value multiplier is "EHG value / competitor value" where competitor value is estimated. Error propagation tracked via confidence intervals. Cross-venture learning calibrates estimation accuracy. Portfolio decisions use the conservative (low) end of the interval.

--- a/docs/plans/5-10x-value-methodology-vision.md
+++ b/docs/plans/5-10x-value-methodology-vision.md
@@ -1,0 +1,68 @@
+# Vision: 5-10X Value vs Competition Methodology
+
+## Executive Summary
+EHG's venture factory evaluates opportunities through gap analysis, opportunity scoring, moat architecture, and stage gates — but none of these systems formally quantify how much more value an EHG venture delivers compared to competition. The "5-10X better" claim exists as aspiration, not measurement. This vision transforms value multiplier assessment from a narrative concept into a measurable, trackable, and eventually enforceable dimension across the venture lifecycle. It integrates surgically into the existing 6-dimension OpportunityScorer as a 7th dimension, anchors against competitive baselines, and feeds into the portfolio optimizer — giving the chairman a quantified answer to "which of our ventures are truly 10X better?"
+
+The strategic bet: in a market flooded with AI-powered startups claiming disruption, the ability to *prove* disproportionate value delivery — with data, not narrative — becomes the differentiator for fundraising, resource allocation, and kill/promote decisions.
+
+## Problem Statement
+EHG evaluates ventures through a sophisticated pipeline: gap analysis (6 dimensions), opportunity scoring (6 weighted dimensions), moat architecture (7 moat types), and stage gates (kill at 3/5/13/23, promotion at 16/17/22). Financial contracts track unit economics with consistency thresholds. But the pipeline has a structural blind spot: it measures *opportunity quality* and *execution feasibility* without measuring *value superiority*. A venture can score well on market opportunity and competitive advantage without proving it delivers 5-10X the value of incumbents. The gap analyzer identifies where competitors fall short, but doesn't translate those gaps into a multiplier. The opportunity scorer rewards competitive advantage (0.20 weight) but doesn't anchor it against a competitor baseline. The result: ventures advance through gates based on potential, not on demonstrated value superiority.
+
+## Personas
+- **Chairman (Rick)**: Makes portfolio-level allocation decisions. Needs a quantified answer to "which ventures deliver disproportionate value?" to justify continued investment and kill incremental bets. Values the 10X narrative but wants it backed by data.
+- **EVA (AI Strategic Advisor)**: Runs the scoring pipeline. Needs a value multiplier dimension that integrates with existing OpportunityScorer and can be computed from available data (gap analysis outputs, financial contract data, moat scores). Must handle uncertainty gracefully.
+- **Venture Development Teams (LEO/Claude)**: Consume value multiplier assessments. Need clear criteria for what "5-10X" means in their specific market context so they can design toward it, not just pass a score.
+- **Investors/Board (Future)**: Portfolio value multiplier data becomes a fundraising asset — "our average venture delivers 7.3X the value of incumbent solutions, calibrated against actual outcomes."
+
+## Information Architecture
+- **Value Multiplier Dimension**: 7th scoring dimension in OpportunityScorer — weighted alongside market_opportunity, competitive_advantage, feasibility, evidence_strength, time_to_value, risk_adjusted. Composed of sub-scores: price-performance ratio, capability breadth, time-to-value compression, user experience quality, integration depth.
+- **Competitive Baseline Registry**: Per-venture competitive baseline data — pricing, features, performance, user satisfaction. Sources: public data, competitor analysis artifacts, gap analyzer outputs. Stored as structured data with epistemic tags (FACT/ASSUMPTION/SIMULATION per gap analyzer's four-bucket model).
+- **Value Multiplier Trajectory**: Time-series tracking of value multiplier — captures decay as competitors copy, and growth as EHG ventures compound advantages. Integrated with moat architecture durability assessment.
+- **Portfolio Value Dashboard**: Chairman-level view showing value multiplier heat map across all active ventures, with confidence intervals and trajectory arrows (improving/stable/declining).
+- **Existing Infrastructure Extended**: Gap Analyzer (competitive gap → value multiplier input), OpportunityScorer (new dimension), Moat Architecture (moat durability → multiplier sustainability), Stage Gates (value gate at key lifecycle points), Financial Contract (unit economics → economic multiplier), Cross-Venture Learning (outcome calibration).
+
+## Key Decision Points
+- **Lens Before Gate**: Value multiplier starts as a measurement dimension, not a kill gate. It becomes a gate only after calibration data proves it predicts venture success. This resolves the Challenger's concern about killing promising ideas with premature quantification.
+- **Confidence Intervals, Not Point Estimates**: Value multiplier expressed as a range (e.g., 3-7X) with explicit confidence level. This addresses the denominator problem — competitor value is estimated, so the multiplier inherits that uncertainty. Chairman sees ranges, not false precision.
+- **Composed from Existing Signals**: Value multiplier is calculated from data already in the pipeline — gap scores, financial contract data, moat architecture output — not from new external data collection. This makes Phase 1 achievable in 2 weeks.
+- **Segment-Aware Multiplier**: When a venture targets multiple segments, the value multiplier is calculated per-segment with a weighted composite. This prevents the "10X for SMBs but 1.5X for enterprise" averaging problem.
+- **Temporal Decay Tracking**: Value multiplier is not a one-time score but a tracked metric that updates as competitive landscape shifts. Integrated with moat durability assessment. Declining multiplier triggers strategic review.
+- **Status Quo Fallback for New Categories**: When no direct competitors exist, value multiplier anchors against "status quo" (current manual process, existing tools, doing nothing). This handles the greenfield edge case.
+
+## Integration Patterns
+- **OpportunityScorer**: Value multiplier added as 7th dimension. Existing 6 weights rebalanced: market_opportunity 0.20, competitive_advantage 0.15, feasibility 0.15, evidence_strength 0.15, time_to_value 0.10, risk_adjusted 0.10, value_multiplier 0.15. Auto-approval thresholds unchanged.
+- **Gap Analyzer**: Gap scores per dimension feed directly into value multiplier sub-scores. Features gap → capability breadth multiplier. Pricing gap → price-performance multiplier. Experience gap → UX multiplier.
+- **Moat Architecture**: Moat durability score modulates the value multiplier trajectory — strong moats sustain high multipliers, weak moats predict decay. Agent consumability moat type feeds into the integration depth sub-score.
+- **Stage Gates**: New advisory gate at stage 5 (post-discovery) — value multiplier must be estimated with at least ASSUMPTION-level confidence. Advisory at stage 13 (pre-scale) — multiplier must be validated with at least partial FACT evidence. Kill gate consideration at stage 23 (pre-exit) only after 12 months of calibration data.
+- **Financial Contract**: Unit economics comparison — LTV/CAC ratio relative to competitor baseline. Price-performance ratio derived from pricing_model and competitor pricing data.
+- **Cross-Venture Learning**: Historical multiplier estimates calibrated against actual outcomes. Portfolio-level calibration analysis: "We estimated 8X, reality was 4X — systematic overestimation in AI ventures." Feeds back into confidence interval estimation.
+- **Portfolio Optimizer**: Value multiplier becomes an additional signal weight (proposed 0.15). Ventures with declining multipliers flagged for resource reallocation or strategic pivot.
+- **Brainstorm Pipeline**: Value multiplier pre-assessment during brainstorm phase — quick estimate before full team analysis. Ideas below 2X threshold can be deprioritized earlier, saving team analysis resources.
+
+## Evolution Plan
+- **Phase 1** (2 weeks): Value Multiplier Dimension — Add value_multiplier as 7th dimension in OpportunityScorer. Calculate from existing signals (gap scores, financial contract data, moat output). Rebalance weights. Dashboard widget showing multiplier per venture.
+- **Phase 2** (2 weeks): Competitive Baselines — Create competitive_baselines table storing per-venture competitor data (pricing, features, performance). Integration with gap analyzer outputs. Epistemic tags on each data point.
+- **Phase 3** (2 weeks): Stage Gate Integration — Advisory value multiplier gate at stages 5 and 13. Multiplier trajectory tracking (value_multiplier_history table). Decay detection with alerts. Cross-venture learning calibration.
+- **Phase 4** (2 weeks): Portfolio Intelligence — Portfolio value heat map in chairman dashboard. Multiplier trend charts (line over time per venture). Calibration report (estimated vs actual). Kill gate consideration after 12 months calibration.
+
+## Out of Scope
+- External competitive intelligence data feeds (scraping, paid APIs) — use existing manual + gap analyzer data
+- Customer-validated value measurement (NPS, willingness-to-pay studies) — future evolution requiring per-venture user analytics
+- Value multiplier as a marketing/sales tool (investor decks, pitch materials) — future, after internal calibration proves accuracy
+- Replacing the chairman's judgment on venture value — multiplier is a signal, not a verdict
+- Real-time competitor monitoring integration — handled separately by competitor monitoring initiative
+- Value pricing strategy automation — multiplier informs pricing but doesn't set prices
+
+## UI/UX Wireframes
+N/A — primarily infrastructure. Value multiplier surfaces through existing Chairman V3 dashboard widgets and portfolio optimizer output. New widget: value multiplier heat map (color-coded matrix: ventures × time, color = multiplier level, arrows = trajectory).
+
+## Success Criteria
+- Value multiplier calculated for 100% of active ventures (Phase 1)
+- Competitive baselines established for top 3 competitors per venture (Phase 2)
+- Value multiplier expressed with confidence intervals (not point estimates) for all ventures
+- Advisory gate at stages 5 and 13 operational (Phase 3)
+- Cross-venture learning calibrates estimates against 10+ completed venture outcomes (Phase 3)
+- Portfolio optimizer incorporates value multiplier as signal weight (Phase 4)
+- Chairman dashboard shows portfolio value heat map with trajectory indicators (Phase 4)
+- Calibration report shows <30% estimation error after 6 months of data collection
+- No viable venture killed by value multiplier assessment (tracked as false-negative rate)

--- a/docs/plans/autonomous-consultant-agent-architecture.md
+++ b/docs/plans/autonomous-consultant-agent-architecture.md
@@ -1,0 +1,74 @@
+# Architecture Plan: Autonomous Consultant Agent
+
+## Stack & Repository Decisions
+- **Repository**: EHG_Engineer (backend pipeline)
+- **Runtime**: Node.js scripts invoked manually or triggered by EVA intake pipeline (scheduler decision deferred until pipeline is validated)
+- **LLM**: Claude Haiku for classification/pattern detection, Claude Sonnet for recommendation synthesis. Uses existing `client-factory.js` for LLM routing with tier-based model selection.
+- **Database**: Supabase (PostgreSQL) — extends existing schema
+- **Existing Infrastructure (Fully Reusable)**: `todoist-sync.js`, `playlist-sync.js`, `eva-sync-state` circuit breaker, `intake-classifier.js` (3D taxonomy: App + Aspects + Intent), `wave-clusterer.js` (grouping logic), `client-factory.js` (LLM routing)
+- **Partially Reusable**: `deeper-analysis-router.js` (routing patterns), `post-processor.js` (archival lifecycle pattern)
+
+## Legacy Deprecation Plan
+N/A — greenfield capability. Extends existing EVA intake pipeline without replacing any current functionality.
+
+## Route & Component Structure
+- `scripts/eva/eva-trend-snapshot.mjs` — Phase 0 validation script: batch aggregation of classified items (no LLM needed)
+- `scripts/eva/consultant-agent.mjs` — Main orchestrator (sync → detect → recommend)
+- `lib/integrations/trend-detector.js` — Pattern detection across recent wave items with data freshness tracking
+- `lib/integrations/recommendation-engine.js` — Generates actionable recommendations from detected patterns; batch processing to control LLM costs
+- `lib/integrations/data-freshness-monitor.js` — Tracks last-sync timestamps per source, flags degraded confidence when sources go stale (>72 hours)
+- `scripts/eva/consultant-digest.mjs` — Formats and delivers chairman digest with freshness indicators
+
+## Data Layer
+### New Tables
+- `eva_consultant_snapshots` — Phase 0 trend snapshots (no LLM needed)
+  - `id` (uuid), `snapshot_date` (date), `source_counts` (jsonb — items per source)
+  - `top_aspects_by_app` (jsonb), `top_intents` (jsonb), `new_item_velocity` (jsonb — items/week vs prior 4-week avg)
+  - `raw_cluster_data` (jsonb — aggregate statistics for manual review)
+
+- `eva_consultant_recommendations` — Stores generated recommendations with confidence scores
+  - `id` (uuid), `title`, `description`, `confidence_score` (0-100), `urgency` (low/medium/high)
+  - `source_items` (jsonb — references to wave items, todoist tasks, etc.)
+  - `recommendation_type` (trend, opportunity, risk, connection)
+  - `status` (pending, accepted, dismissed, expired)
+  - `chairman_response` (jsonb — action taken, feedback, usefulness_rating 1-5)
+  - `data_freshness` (jsonb — per-source staleness at time of generation)
+
+- `eva_source_health` — Data freshness tracking per source
+  - `id` (uuid), `source_name` (text), `last_sync_at` (timestamptz), `last_item_count` (int)
+  - `status` (healthy/degraded/stale), `degraded_since` (timestamptz)
+
+### Existing Tables Used
+- `roadmap_wave_items` — Source data for pattern detection
+- `eva_todoist_intake` — Classified items from Todoist sync
+- `eva_youtube_intake` — Classified items from YouTube sync
+- `strategic_directives_v2` — Active work context for relevance scoring
+
+### RLS
+- Service role only (backend pipeline) — no user-facing RLS needed
+
+## API Surface
+- No REST endpoints needed (internal pipeline)
+- RPC: `get_recent_recommendations(limit, status)` — for chairman view integration
+- RPC: `respond_to_recommendation(id, response)` — chairman accept/dismiss
+
+## Implementation Phases
+- **Phase 0** (1-2 days): Validation — `eva_consultant_snapshots` table + `eva-trend-snapshot.mjs` script. Aggregate classified item statistics without LLM. Run manually for 2 weeks to validate hypothesis before investing in LLM-powered generation. Also create `eva_source_health` table for data freshness tracking.
+- **Phase 1** (2-3 days): Trend detector — LLM-assisted pattern detection across recent classified items with data freshness monitoring. Batch processing pattern (one big prompt per run, parse one JSON response) following `wave-clusterer.js` template to control costs.
+- **Phase 2** (2-3 days): Recommendation engine — generate actionable recommendations from detected trends with confidence scores, chairman feedback loop (accept/dismiss/rate), and degraded-confidence flagging for stale sources.
+- **Phase 3** (1-2 days): Chairman digest — formatted output for chairman view consumption with source freshness indicators. Auto-SD generation for high-confidence recommendations.
+
+## Testing Strategy
+- Unit tests for trend detection algorithms (pattern matching, clustering)
+- Integration tests for recommendation pipeline (mock data → recommendations)
+- Manual validation: chairman reviews first batch of recommendations for quality calibration
+
+## Risk Mitigation
+- **Recommendation fatigue**: Start with max 3 recommendations per digest cycle; quality over quantity
+- **False patterns**: Require minimum 3 corroborating signals before surfacing a trend. At 400 items across mixed topics, many "trends" will be noise — the confidence threshold must be high initially.
+- **LLM cost drift**: Use Haiku for classification, Sonnet only for final synthesis. Batch aggressively — follow the `wave-clusterer.js` pattern of "build one big prompt, parse one JSON response" rather than per-item Sonnet calls. Estimated <$1.50/day; monitor monthly.
+- **Stale recommendations**: Auto-expire after 14 days if not acted on
+- **Data source degradation**: YouTube Data API has been progressively restricted by Google (watch history scope limitations). The system must gracefully degrade when a source becomes unavailable — continue operating on remaining sources with explicit confidence adjustments, never present single-source analysis as "cross-source."
+- **Source heterogeneity**: Todoist tasks are structured/actionable; YouTube content is noisy/ambiguous. Weight sources differently in pattern detection. Don't treat a YouTube video about a topic the same as a Todoist task to investigate that topic.
+- **Foundation dependency**: The EVA intake redesign (3D classification) must be production-ready before Phase 1. Phase 0 (snapshots) can run on existing raw data.
+- **No feedback = no learning**: Without the chairman feedback loop (Phase 2), the system cannot improve. Phase 2 must ship before the digest becomes a routine notification.

--- a/docs/plans/autonomous-consultant-agent-vision.md
+++ b/docs/plans/autonomous-consultant-agent-vision.md
@@ -1,0 +1,63 @@
+# Vision: Autonomous Consultant Agent
+
+## Executive Summary
+The Autonomous Consultant Agent transforms EVA from a reactive assistant into a proactive strategic advisor. By continuously monitoring industry trends, competitor moves, and the chairman's curated content feeds (Todoist tasks, YouTube research), EVA autonomously surfaces actionable insights before they're needed — like a top-tier management consultant who never sleeps.
+
+This capability addresses the core problem of information overload: the chairman captures dozens of ideas, articles, and research leads daily, but synthesis and strategic connection-making happens manually. The consultant agent closes that gap by autonomously processing inputs, identifying patterns, and presenting synthesized recommendations.
+
+## Problem Statement
+The chairman captures strategic ideas across multiple channels (Todoist, YouTube, conversations, reading) but lacks an autonomous system that connects dots across these inputs. Currently, insights are processed manually during brainstorm sessions, leading to delayed action on time-sensitive opportunities and missed connections between seemingly unrelated ideas. The volume of captured ideas (400+ in recent waves) far exceeds human synthesis capacity.
+
+## Personas
+- **Chairman (Rick)**: Captures ideas rapidly across channels. Needs synthesis, not more raw data. Values concise, actionable recommendations. Time-constrained — needs the agent to do the heavy lifting.
+- **EVA (AI Advisor)**: Acts as the autonomous consultant. Monitors feeds, identifies patterns, generates recommendations. Must earn trust through accuracy and relevance over time.
+
+## Information Architecture
+- **Data Sources**: Todoist API (task lists, projects), YouTube API (watch history, playlists), roadmap_wave_items (historical ideas), strategic_directives_v2 (active work)
+- **Processing Pipeline**: Sync → Classify → Pattern Detection → Trend Correlation → Recommendation Generation
+- **Output Routes**: Chairman digest (daily/weekly), priority alerts (time-sensitive), trend reports (monthly)
+- **Storage**: Recommendations stored in dedicated table with confidence scores, source links, and action status
+
+## Key Decision Points
+- **Autonomy Level**: How much should the agent act without confirmation? Start conservative (recommend only) and graduate to auto-action based on confidence thresholds.
+- **Signal vs Noise**: What filtering mechanisms prevent recommendation fatigue? Quality scoring with adjustable thresholds. Require minimum 3 corroborating signals before surfacing a trend.
+- **Feed Priority**: When multiple trends compete for attention, how does the agent prioritize? Composite scoring based on strategic alignment, time-sensitivity, and opportunity size.
+- **Data Freshness Monitoring**: How does the system detect degraded input quality? Each data source must report last-sync timestamps. If any source goes stale (>72 hours without new data), recommendations from that source are flagged as "degraded confidence" and the chairman is informed. The system must never present stale analysis with high confidence.
+- **Feedback Loop**: How does the recommendation engine learn? The chairman's accept/dismiss actions feed back into the scoring model. Without explicit feedback, the system cannot distinguish signal from noise. This is critical to avoid the system becoming another notification to ignore.
+- **Source Heterogeneity**: Todoist tasks are structured and actionable; YouTube content is noisy and ambiguous. The pattern detector must weight sources differently and handle varying signal-to-noise ratios per source type.
+
+## Integration Patterns
+- Extends existing EVA intake pipeline (Todoist sync, YouTube sync already built)
+- Leverages existing classification taxonomy (App + Aspects + Intent from EVA intake redesign)
+- Feeds into existing roadmap wave system for items that graduate from recommendations to action items
+- Connects to chairman view for presentation layer
+- **Bidirectional Todoist sync**: Currently ideas flow Todoist→EVA only. The consultant agent enables EVA→Todoist: creating follow-up tasks, flagging stale ideas for review, and injecting synthesized action items back into the chairman's daily workflow
+- **LEO Protocol integration**: High-confidence recommendations can auto-generate draft SDs via `leo-create-sd.js`, closing the loop from observation to actionable work item
+- **Roadmap reality check**: Detects misalignment between `roadmap_wave_items` priorities and where the chairman's actual attention flows (measured by idea volume and recency per domain)
+
+## Evolution Plan
+- **Phase 0 (Validation)**: Trend snapshot table + batch aggregation script — materialize classified item statistics (items per app/aspect/intent/week, velocity changes) without LLM. Run manually for 2 weeks to validate whether automated synthesis surfaces non-obvious patterns. Cheapest possible hypothesis test before investing in LLM-powered generation.
+- **Phase 1**: Trend detection from existing feeds (Todoist + YouTube) — LLM-assisted pattern matching across recent inputs with data freshness tracking per source
+- **Phase 2**: Proactive recommendations with confidence scoring and chairman feedback loop — "Based on 3 recent signals, consider X" with accept/dismiss actions that train the model
+- **Phase 3**: Autonomous action (create draft SDs, schedule research, flag competitors) with human-in-the-loop approval. Bidirectional Todoist sync (EVA→Todoist action items).
+
+## Out of Scope
+- Building a new data ingestion pipeline (uses existing sync infrastructure: `todoist-sync.js`, `playlist-sync.js`, `intake-classifier.js`)
+- Real-time monitoring (batch processing on configurable schedule is sufficient)
+- External data sources beyond Todoist and YouTube (can be added later)
+- Full agent autonomy without human approval gates
+- Building a persistent scheduler/cron infrastructure (manual invocation sufficient for validation; scheduler decision deferred until pipeline is proven)
+- Replacing or modifying the existing EVA intake redesign 3D classification taxonomy
+
+## UI/UX Wireframes
+N/A — this is primarily a backend/pipeline capability. Output surfaces through existing chairman view routes.
+
+## Success Criteria
+- Agent processes new inputs within 24 hours of capture
+- Recommendations have >60% chairman acceptance rate (measured by explicit accept/dismiss feedback)
+- Reduces time from idea capture to strategic decision by 50%
+- Identifies cross-domain connections that chairman confirms as valuable
+- Zero false-positive alerts that waste chairman attention
+- Data freshness: system detects and reports stale sources within 24 hours of last sync failure
+- LLM cost stays under $2/day via aggressive batching (Haiku for classification, Sonnet only for final synthesis)
+- Phase 0 validation: trend snapshots surface at least 1 non-obvious pattern within 2 weeks of manual operation

--- a/docs/plans/competitor-monitoring-countermeasures-architecture.md
+++ b/docs/plans/competitor-monitoring-countermeasures-architecture.md
@@ -1,0 +1,72 @@
+# Architecture Plan: Continuous Competitor Monitoring + Countermeasures
+
+## Stack & Repository Decisions
+- **Repository**: EHG_Engineer (backend pipeline)
+- **Runtime**: Node.js scripts, periodic batch execution (daily or weekly)
+- **LLM**: Claude Haiku for change classification, Claude Sonnet for countermeasure synthesis. Uses existing `client-factory.js` for LLM routing.
+- **Database**: Supabase (PostgreSQL) — extends existing schema
+- **Existing Infrastructure (Fully Reusable)**: `lib/discovery/opportunity-discovery-service.js` (scan→analyze→score→blueprint), `lib/research/competitor-intelligence.js` (competitor URL analysis via axios), `lib/discovery/gap-analyzer.js` (6-dimension gap analysis), `competitors` table (venture-linked), `app_rankings` table (apple/gplay/producthunt sources), `opportunity_scans` table
+- **Existing Dependencies**: `axios`, `puppeteer`, `playwright` (all in `package.json`)
+- **New Dependencies**: `google-play-scraper` npm package
+- **Prior Design Work**: `brainstorm/2026-02-21-ranking-data-pipeline-sources-poc-integration.md` (detailed implementation plan, ~395 LOC, validated)
+
+## Legacy Deprecation Plan
+N/A — extends existing competitive intelligence infrastructure. The current `competitor-intelligence.js` remains as the analysis engine; this adds data polling and change detection layers.
+
+## Route & Component Structure
+- `scripts/eva/ranking-poller-apple.mjs` — Apple App Store RSS feed poller
+- `scripts/eva/ranking-poller-gplay.mjs` — Google Play scraper using `google-play-scraper` npm
+- `scripts/eva/ranking-poller-producthunt.mjs` — Product Hunt GraphQL API poller
+- `scripts/eva/competitor-change-detector.mjs` — Temporal diff engine: compares current vs previous `app_rankings` snapshots
+- `lib/discovery/countermeasure-engine.js` — Maps significant competitor changes to actionable countermeasure recommendations
+- `lib/integrations/competitor-source-health.js` — Tracks poller health and data freshness per source
+
+## Data Layer
+### New Tables
+- `competitor_events` — Detected changes with significance scores
+  - `id` (uuid), `competitor_id` (fk → competitors), `venture_id` (fk → ventures)
+  - `event_type` (ranking_change, pricing_change, feature_launch, market_entry)
+  - `significance_score` (0-100), `raw_data` (jsonb — before/after snapshots)
+  - `countermeasure_status` (pending, generated, accepted, dismissed)
+  - `detected_at` (timestamptz), `source` (text)
+
+- `competitor_source_health` — Poller health tracking
+  - `id` (uuid), `source_name` (text), `last_poll_at` (timestamptz)
+  - `last_success` (bool), `consecutive_failures` (int), `status` (healthy/degraded/stale)
+
+### Existing Tables Used
+- `competitors` — Competitor profiles linked to ventures via `venture_id`
+- `app_rankings` — Historical ranking data (already has apple/gplay/producthunt sources with indices)
+- `opportunity_scans` — Scan tracking with status lifecycle
+- `ventures` — Venture context for routing countermeasures
+
+### RLS
+- Service role only (backend pipeline) — no user-facing RLS needed
+
+## API Surface
+- No REST endpoints needed (internal pipeline)
+- RPC: `get_competitor_events(venture_id, since_date)` — for chairman view integration
+- RPC: `get_ranking_trends(competitor_id, period)` — temporal ranking analysis
+- The existing `opportunity-discovery-service.js` orchestrator handles the internal API
+
+## Implementation Phases
+- **Phase 0** (4 weeks, manual): Manual competitive brief — 2 hours/week monitoring top 3 competitors for most mature venture. Validates whether competitive intelligence drives strategic decisions before automating.
+- **Phase 1** (1 week): Ranking data pollers — Apple RSS + Google Play + Product Hunt → `app_rankings` table. Enhance `discovery-mode.js` and `competitor-teardown.js` to consume ranking data (~30 LOC modifications each per prior brainstorm analysis).
+- **Phase 2** (1-2 weeks): Pipeline orchestrator + scheduling — connect pollers → trend scanner → auto-teardown → synthesis. Choose cron mechanism (GitHub Actions recommended for zero-infrastructure cost).
+- **Phase 3** (2-3 weeks, after 2-3 weeks of data accumulation): Countermeasure engine — temporal comparison of `app_rankings` snapshots, change significance scoring, routing logic via `competitors.venture_id`, integration with EVA recommendation engine.
+
+## Testing Strategy
+- Unit tests for each poller (mock API responses)
+- Integration tests for change detection (known before/after snapshots → expected events)
+- Poller health monitoring: automated alerts when consecutive_failures > 3
+- Manual validation: chairman reviews first batch of competitor events for significance calibration
+- Legal review: verify all data sources comply with terms of service
+
+## Risk Mitigation
+- **Scraping fragility**: Tier data sources by reliability. Apple RSS (stable) and Product Hunt (GraphQL API) first. Google Play scraper breaks every 2-4 months — budget for maintenance. Defer G2/Capterra entirely (Cloudflare protection makes them unreliable).
+- **Signal-to-noise**: Aggressive significance thresholds — only surface ranking drops >5 positions, pricing changes >10%, or new features in core product areas. Start conservative, loosen based on chairman feedback.
+- **Legal exposure**: Use only public APIs and RSS feeds. No scraping behind authentication. No ToS violations. Standard user agents and rate limiting.
+- **Counter-intelligence**: Distribute polling timing (not all at midnight), use standard user agents, rotate request patterns. Don't reveal strategic interest areas through scraping patterns.
+- **Cost control**: Haiku for change classification, Sonnet only for countermeasure synthesis. Estimated <$5/month LLM cost. Batch processing to minimize API calls.
+- **No data = bad countermeasures**: The countermeasure engine (Phase 3) must wait until 2-3 weeks of `app_rankings` data accumulates. Temporal comparison requires history.
+- **Validation-first**: Phase 0 manual experiment must produce at least 1 strategic decision before proceeding to automation. If manual review isn't useful, automation won't be either.

--- a/docs/plans/competitor-monitoring-countermeasures-vision.md
+++ b/docs/plans/competitor-monitoring-countermeasures-vision.md
@@ -1,0 +1,63 @@
+# Vision: Continuous Competitor Monitoring + Countermeasures
+
+## Executive Summary
+EHG operates a venture factory model where competitive intelligence is critical across multiple simultaneous ventures. Currently, competitor analysis happens ad-hoc during brainstorm sessions or when threats surface organically. This system transforms competitive intelligence from a reactive, manual process into an automated, continuous pipeline that detects competitor moves and generates countermeasure recommendations — giving EHG asymmetric response times measured in hours, not weeks.
+
+The unique strategic advantage is EHG's multi-venture structure: a competitive intelligence system spanning multiple ventures builds a cross-venture competitive graph that no single-product company can replicate. Patterns observed in one market inform strategy in adjacent markets.
+
+## Problem Statement
+EHG launches ventures into competitive markets but lacks continuous visibility into competitor moves. Competitor analysis is performed manually during brainstorm sessions, leading to delayed awareness of pricing changes, feature launches, and market shifts. For a venture factory managing multiple products, the surface area of competitors to monitor scales multiplicatively — manual tracking becomes impossible. Time-sensitive competitive signals (pricing changes, key hire announcements, feature launches) are perishable and lose value when discovered weeks later.
+
+## Personas
+- **Chairman (Rick)**: Needs synthesized competitive intelligence across all ventures. Values actionable countermeasure recommendations over raw data. Makes strategic decisions (pricing, positioning, feature priority) based on competitive context.
+- **EVA (AI Advisor)**: Acts as the competitive intelligence analyst. Continuously ingests competitor signals, detects significant changes, triangulates across sources for confidence, and generates countermeasure recommendations.
+- **Venture Teams**: Consume venture-specific competitive insights. Need to know when a direct competitor makes a move that affects their product positioning.
+
+## Information Architecture
+- **Data Sources (Tiered by Reliability)**:
+  - Tier 1 (Stable APIs): Apple RSS feeds (app store rankings), Product Hunt GraphQL API
+  - Tier 2 (Moderate fragility): Google Play scraper (`google-play-scraper` npm), social media APIs
+  - Tier 3 (Fragile/Deferred): G2, Capterra (Cloudflare protection, CAPTCHAs — defer to later phase)
+- **Existing Infrastructure**: `competitors` table (venture-linked), `app_rankings` table (apple/gplay/producthunt sources), `opportunity_scans` table, `opportunity-discovery-service.js`, `competitor-intelligence.js`, `gap-analyzer.js`
+- **Processing Pipeline**: Poll sources → Detect changes (temporal diff) → Score significance → Triangulate across sources → Generate countermeasures → Route to ventures/EVA
+- **Storage**: Rankings history in `app_rankings`, change events in new `competitor_events` table, countermeasures in EVA recommendation pipeline
+
+## Key Decision Points
+- **Scraping Legality**: Each data source carries distinct legal risk. Use only public APIs and RSS feeds in initial phases. Avoid scraping behind authentication or Terms of Service violations. No scraping of competitor websites that prohibit automated access.
+- **Signal-to-Noise Ratio**: With multiple ventures tracking 5-10 competitors each across 3+ sources, the signal volume will be high. Significance scoring must be aggressive — only surface changes that meet a meaningful threshold (e.g., ranking drop of 5+ positions, pricing change of >10%, new feature in core product area).
+- **Counter-Intelligence**: Automated scraping leaves fingerprints (IP patterns, timing). Use standard user agents, rate limiting, and distributed timing to avoid revealing strategic interest areas to competitors.
+- **Continuous vs Periodic**: Start with periodic batch runs (daily/weekly), not real-time streaming. Real-time adds infrastructure complexity without proportional value at current scale.
+- **Validate Before Automating**: Run a 4-week manual competitive brief experiment before building automation — if a 2-hour/week manual review doesn't drive strategic decisions, automation won't either.
+
+## Integration Patterns
+- **EVA Recommendation Engine**: Competitor signals become a new input dimension for EVA's pattern detection, enabling market-aware strategic recommendations
+- **SD/PRD Pipeline**: High-confidence countermeasures can auto-generate draft Strategic Directives via `leo-create-sd.js`
+- **Existing Discovery Pipeline**: Extends `opportunity-discovery-service.js` (scan → analyze → score → blueprint) with temporal change detection
+- **Cross-Venture Pattern Library**: Competitive patterns (e.g., "competitor drops pricing >20% → churn increases in 60 days") become reusable strategic playbooks across ventures
+- **Prior Brainstorm**: Builds on validated implementation plan from `brainstorm/2026-02-21-ranking-data-pipeline-sources-poc-integration.md`
+
+## Evolution Plan
+- **Phase 0 (Validation)**: 4-week manual experiment — one person, 2 hours/week, monitoring top 3 competitors for most mature venture. If the brief drives strategic decisions, proceed to automation.
+- **Phase 1 (Ranking Pollers)**: Apple RSS + Google Play + Product Hunt pollers → `app_rankings` table. Enhance `discovery-mode.js` and `competitor-teardown.js` to consume ranking data.
+- **Phase 2 (Pipeline + Scheduling)**: Orchestrator connecting pollers → trend scanner → auto-teardown → synthesis. Choose cron mechanism (GitHub Actions or `node-cron`).
+- **Phase 3 (Countermeasures)**: Delta detection (temporal diff of `app_rankings` snapshots), change significance scoring, countermeasure routing logic mapping competitor changes to ventures via `competitors.venture_id`, EVA integration.
+
+## Out of Scope
+- Scraping behind authentication or Terms of Service violations
+- G2/Capterra integration (Cloudflare-protected — deferred to later phase)
+- Real-time streaming architecture (batch is sufficient at current scale)
+- Hiring/talent monitoring of competitors
+- Direct competitive response automation (human-in-the-loop required for all countermeasures)
+- Building new scraping infrastructure from scratch (leverages existing `axios`, `puppeteer`, `playwright` in `package.json`)
+
+## UI/UX Wireframes
+N/A — this is primarily a backend/pipeline capability. Competitive insights surface through EVA's recommendation engine and the chairman view.
+
+## Success Criteria
+- Ranking data polled and stored for all tracked competitors with <24 hour latency
+- Significant competitor changes (pricing, features, rankings) detected within 24 hours
+- Countermeasure recommendations have >50% chairman acceptance rate
+- Cross-venture competitive patterns identified that inform strategy in at least 2 ventures
+- Zero legal/ethical issues from data collection methods
+- Manual competitive brief validates the concept before automation investment
+- LLM cost for competitive analysis stays under $5/month

--- a/docs/plans/design-as-competitive-advantage-architecture.md
+++ b/docs/plans/design-as-competitive-advantage-architecture.md
@@ -1,0 +1,94 @@
+# Architecture Plan: Design as Competitive Advantage
+
+## Stack & Repository Decisions
+- **Repositories**: EHG (frontend — shared component library source), EHG_Engineer (LEO Protocol design gates, metrics pipeline)
+- **Component Library**: `@ehg/components` npm workspace package (extracted from EHG's `src/components/ui/`)
+- **Token System**: `@ehg/tokens` npm workspace package (built from `ehg-design-tokens.json`)
+- **Design Documentation**: Storybook 8.x (new dependency for interactive component explorer)
+- **Quality Scoring**: Existing design-agent (v4.2.0) + new metrics aggregation layer
+- **Database**: Supabase (PostgreSQL) — extends existing schema
+- **Existing Infrastructure (Fully Reusable)**: Design-agent v4.2.0 (WCAG audits, responsive validation), design tokens (3-tier hierarchy), 60 Shadcn components, axe-core (Playwright + React), eslint-plugin-jsx-a11y, Golden Nugget Validator, component audit scripts, design-database gates
+- **New Dependencies**: `storybook@8.x` (documentation), `chromatic` or Playwright visual regression (testing)
+
+## Legacy Deprecation Plan
+N/A — additive infrastructure. Existing design-agent, components, and gates remain in place. The shared library is extracted from existing code, not replacing it. The EHG app becomes a consumer of its own published components.
+
+## Route & Component Structure
+
+### EHG_Engineer (Backend/Infrastructure)
+- `lib/integrations/design-quality-scorer.js` — Aggregates design quality metrics across ventures (accessibility, token compliance, reuse ratio)
+- `lib/integrations/design-metrics-collector.js` — Collects and stores per-venture design health data
+- `scripts/eva/design-health-dashboard.mjs` — Generates venture design health report
+- `scripts/design/component-reuse-analyzer.js` — Analyzes component usage across ventures
+- `scripts/design/design-token-compliance-checker.js` — Validates venture token usage against shared system
+
+### EHG (Frontend — Shared Library)
+- `packages/components/` — `@ehg/components` workspace package
+  - `src/` — Generalized versions of current `src/components/ui/` components
+  - `stories/` — Storybook stories for each component
+  - `package.json` — Publishable package with semver
+- `packages/tokens/` — `@ehg/tokens` workspace package
+  - `src/tokens.json` — Base design tokens (brand + semantic tiers)
+  - `src/themes/` — Per-venture theme overrides
+  - `build.js` — Generates CSS variables, Tailwind config, TypeScript constants
+- `.storybook/` — Storybook configuration at workspace root
+
+## Data Layer
+
+### New Tables
+- `venture_design_health` — Per-venture design quality metrics
+  - `id` (uuid), `venture_id` (fk → ventures), `measured_at` (timestamptz)
+  - `accessibility_score` (int 0-100), `token_compliance_score` (int 0-100)
+  - `component_reuse_ratio` (numeric), `consistency_score` (int 0-100)
+  - `design_debt_count` (int), `details` (jsonb — per-category breakdowns)
+
+- `design_patterns` — Cross-venture design pattern library
+  - `id` (uuid), `pattern_name` (text), `category` (text — navigation, form, data-display, feedback, layout)
+  - `description` (text), `usage_examples` (jsonb — code snippets, screenshots)
+  - `provenance` (jsonb — which venture discovered it, evidence of effectiveness)
+  - `components_used` (text[] — references to @ehg/components)
+  - `status` (active, deprecated), `created_at` (timestamptz)
+
+- `venture_design_customizations` — Per-venture brand token overrides
+  - `id` (uuid), `venture_id` (fk → ventures)
+  - `brand_tokens` (jsonb — color overrides, typography, spacing)
+  - `theme_config` (jsonb — light/dark mode customizations)
+  - `created_at` (timestamptz), `updated_at` (timestamptz)
+
+### Existing Tables Used
+- `ventures` — Venture context for design health scoring
+- `strategic_directives_v2` — SD type and status for design gate enforcement
+- `sd_phase_handoffs` — Handoff data for design quality gate results
+- `ehg_component_patterns` — Existing component usage tracking
+
+### RLS
+- Service role for backend metrics collection
+- Authenticated read for dashboard access (chairman view)
+
+## API Surface
+- No new REST endpoints needed (internal pipeline)
+- RPC: `get_venture_design_health(venture_id, since_date)` — for dashboard integration
+- RPC: `get_design_patterns(category, search_term)` — pattern library search
+- The existing design-agent gates handle SD workflow integration
+
+## Implementation Phases
+- **Phase 1** (3 weeks): Metrics — Create `venture_design_health` table. Build design-quality-scorer.js aggregating existing axe-core results, token usage, and component audit data. Dashboard script for chairman view. Establish baseline measurements.
+- **Phase 2** (3 weeks): Review Expansion — Expand `requiresDesignDatabaseGatesSync()` to all feature SDs. Add accessibility testing to CI/CD pipeline (pre-merge hook). Add design quality acceptance criteria to PRD creation template. Pre-commit design linting for token compliance.
+- **Phase 3** (6 weeks): Shared Library — Set up npm workspaces in EHG repo. Extract and generalize 30 most-used components into `@ehg/components`. Create `@ehg/tokens` package with build pipeline. Add Storybook with stories for all published components. Visual regression testing baseline.
+- **Phase 4** (4 weeks): Venture Customization — Create `venture_design_customizations` table. Token override system (venture tokens inherit from base, override specific values). Token build script generates venture-specific CSS variables. Documentation for venture design onboarding.
+- **Phase 5** (4 weeks): Pattern Library — Create `design_patterns` table. Extract 20-30 patterns from existing components with usage examples and decision rationale. Build searchable UI in chairman view. Provenance tracking (which venture, what evidence).
+
+## Testing Strategy
+- Unit tests for design quality scorer (known component data → expected scores)
+- Integration tests for token compliance checker (valid/invalid token usage → correct flags)
+- Visual regression tests for shared components (Storybook + Playwright screenshots)
+- Accessibility regression tests in CI/CD (axe-core on component Storybook stories)
+- Cross-venture component compatibility tests (shared components render correctly with venture-specific tokens)
+
+## Risk Mitigation
+- **Speed-vs-quality tension**: Design quality tiers by venture stage. Validation-stage ventures: accessibility baseline only (axe-core passes). Growth-stage: full design system compliance. Gates scale with venture maturity.
+- **Homogeneity (all ventures look the same)**: Layered token system — immutable foundation (spacing, type scale) + fully customizable surface (colors, brand). Ventures own their visual identity. Component variants supported without forking.
+- **Shared library governance**: Clear ownership model. Shared library changes require backward compatibility or semver major bump. Ventures can pin versions. Quarterly maintenance review.
+- **AI can't replace design taste**: Explicitly scope automation to "design hygiene" (floor). Design excellence (ceiling) requires chairman or human judgment. Gates are labeled "baseline quality" not "design approved."
+- **Market relevance**: Design investment is optional per venture. Portfolio strategy determines which ventures are in design-sensitive markets. Infrastructure supports all ventures; enforcement intensity varies.
+- **Storybook maintenance burden**: Stories auto-generated from component props. Visual regression catches drift. Maintenance is incremental, not a separate workstream.

--- a/docs/plans/design-as-competitive-advantage-vision.md
+++ b/docs/plans/design-as-competitive-advantage-vision.md
@@ -1,0 +1,64 @@
+# Vision: Design as Competitive Advantage
+
+## Executive Summary
+EHG's venture factory launches products into competitive markets where design quality increasingly determines user preference and retention. Currently, design quality is strong but siloed — the Chairman V3 UI has 86+ components, design tokens, accessibility testing, and a design sub-agent, but this infrastructure doesn't systematically transfer to new ventures. This vision transforms design from an ad-hoc per-venture effort into a portfolio-level strategic asset: a Design Intelligence Layer that compounds across ventures, ensuring every EHG product launches with design quality that took competitors years to achieve.
+
+The strategic bet: in a world where AI commoditizes code generation, design quality and design intelligence become the durable differentiators. EHG's venture factory model generates the diversity of design contexts that trains this intelligence — a compounding advantage no single-product company can replicate.
+
+## Problem Statement
+EHG has invested significantly in design infrastructure for the Chairman V3 UI — 60 Shadcn components, 3-tier design tokens, accessibility testing (axe-core), a design sub-agent (v4.2.0), and quality gates. But this investment is locked in a single application. New ventures start from scratch, encountering the same design decisions and making the same mistakes. There is no systematic measurement of design quality, no cross-venture component sharing, and no mechanism to translate design decisions in one venture into institutional knowledge. The design-agent validates accessibility but doesn't enforce broader design quality across all SD types.
+
+## Personas
+- **Chairman (Rick)**: Portfolio-level view. Cares about consistent design quality across all ventures. Values design as a differentiator but cannot personally review every screen in every venture.
+- **EVA (AI Advisor)**: Can assess design quality at scale — component compliance, token usage, accessibility scores — and surface insights across the portfolio.
+- **Venture Development Teams (LEO/Claude)**: Consume the shared design system. Need components that are high-quality, well-documented, and easy to customize for their venture's brand identity.
+- **End Users (per venture)**: Experience the result. Design quality affects perception of product quality, trust, and willingness to pay.
+
+## Information Architecture
+- **Design Token Registry**: Supabase-backed registry of design tokens organized in 3-tier hierarchy (Brand → Semantic → Component). Each venture inherits base tokens and can override for brand customization. Version-controlled with change tracking.
+- **Component Quality Index**: Every shared component scored on accessibility (axe-core), performance (bundle size, render time), design coherence (token compliance), and usage health (adoption across ventures).
+- **Design Decision Log**: Captures *why* design decisions were made — which pattern was chosen, what alternatives were considered, what evidence informed the choice. Feeds into the cross-venture pattern library.
+- **Venture Design Health Dashboard**: Aggregated view across all ventures — consistency scores, accessibility compliance, component reuse ratios, design debt tracking.
+- **Existing Foundation**: Design tokens (`ehg-design-tokens.json`), 60 Shadcn components, design-agent (v4.2.0), accessibility testing (7 test files), Golden Nugget Validator, component audit tools.
+
+## Key Decision Points
+- **Design Quality Tiers by Venture Stage**: Validation-stage ventures get minimal design requirements (accessibility baseline only). Growth-stage ventures get full design system integration. This resolves the speed-vs-quality tension — design investment scales with venture maturity, not applied uniformly.
+- **Shared System Architecture**: Layered design system — immutable foundation (spacing, type scale, accessibility utilities) that every venture uses, with fully customizable surface layer (colors, brand tokens, component variants). Ventures own their visual identity while inheriting structural quality.
+- **Design Hygiene vs Design Excellence**: Automated review (axe-core, token compliance, component usage) handles the floor. Human/AI judgment handles the ceiling. The two are never conflated — "passing gates" means baseline quality, not great design.
+- **Cross-Venture Sharing Mechanism**: npm workspace-based shared packages (`@ehg/components`, `@ehg/tokens`) published from a monorepo structure. Components have semver versioning, ventures can pin versions.
+- **Design Review Scope**: Expand design-agent auto-invocation to ALL feature SDs (not just subset). Add design quality metrics to retrospective data.
+
+## Integration Patterns
+- **LEO Protocol**: Design becomes a first-class quality dimension in the SD workflow. LEAD phase assesses design implications, PLAN phase includes design acceptance criteria in PRDs, EXEC phase runs design quality gates on every PR, retrospectives capture design learnings.
+- **EVA Chat Canvas**: Canvas artifacts serve as both a product feature and a design system testbed. Components used in the canvas are shared library components, providing continuous validation.
+- **Competitive Intelligence**: Design benchmarking integrated into competitor monitoring — systematically track competitors' accessibility scores, design consistency, performance metrics. Surface design gaps as strategic opportunities.
+- **EVA Intake**: Design complexity becomes a classification dimension in the intake taxonomy. New ideas are assessed for their design system compatibility.
+- **Existing Design-Agent**: Extended from accessibility auditing to broader design quality scoring — token compliance, component usage validation, responsive design verification.
+
+## Evolution Plan
+- **Phase 1** (3 weeks): Metrics and Measurement — Design quality scorecard (consistency %, accessibility %, reuse ratio, component adoption rate). Dashboard showing design metrics across ventures. Baseline data collection.
+- **Phase 2** (3 weeks): Systematize Design Review — Expand design-agent to all feature SDs. Add design quality acceptance criteria to PRD process. Pre-commit design linting for token compliance. Accessibility testing in CI/CD.
+- **Phase 3** (6 weeks): Shared Component Library — npm workspace structure (`@ehg/components`, `@ehg/tokens`). Extract and generalize Chairman V3's best components. Storybook for interactive documentation. Visual regression testing.
+- **Phase 4** (4 weeks): Venture Brand Customization — Token override system for per-venture branding. Database table for venture design customizations. Token build script generates venture-specific CSS variables. Onboarding documentation.
+- **Phase 5** (4 weeks): Cross-Venture Pattern Library — Extract 20-30 high-value patterns with usage examples and decision rationale. Searchable pattern explorer. Decision journal tracking pattern provenance across ventures.
+
+## Out of Scope
+- Design-as-a-Service product for external companies (future evolution, post-maturity)
+- AI-generated complete page layouts (future — current AI produces competent but generic UI)
+- Design A/B testing infrastructure (future — requires user analytics pipeline per venture)
+- Mobile-specific design system (desktop-first, mobile adaptations later)
+- Replacing the chairman's taste-level design judgment with automation (human ceiling, automated floor)
+- Hiring full-time designers per venture (contradicts venture factory cost structure)
+
+## UI/UX Wireframes
+N/A — this is primarily infrastructure and process. Design quality surfaces through improved output of every venture's UI, not through a dedicated interface (except the metrics dashboard, which follows existing Chairman V3 patterns).
+
+## Success Criteria
+- Design quality score reaches 85%+ across all active ventures (baseline TBD in Phase 1)
+- WCAG AA accessibility compliance reaches 95%+ (currently ~85% in EHG app)
+- Component reuse ratio reaches 60%+ across ventures (currently ~40%, single-venture only)
+- New venture time-to-design-baseline drops 50% (measured from first commit to passing design gates)
+- Design-agent review coverage: 100% of feature SDs (currently subset)
+- Accessibility testing runs in CI/CD on every PR (currently manual)
+- At least 20 cross-venture design patterns documented with provenance and evidence
+- Design review time per SD drops 30% via automated gates

--- a/docs/plans/eva-chat-route-dynamic-canvas-architecture.md
+++ b/docs/plans/eva-chat-route-dynamic-canvas-architecture.md
@@ -1,0 +1,135 @@
+# Architecture Plan: EVA Chat Route with Dynamic Canvas
+
+## Stack & Repository Decisions
+- **Repositories**: EHG (frontend — React/Vite/Shadcn UI) and EHG_Engineer (backend — Node.js/Supabase)
+- **Frontend**: React + TypeScript + Vite + Shadcn UI + Tailwind CSS
+- **Chart Library**: Recharts (already in EHG at `recharts@2.15.4`)
+- **Layout**: `react-resizable-panels@2.1.9` (already in EHG dependencies)
+- **Markdown**: `react-markdown@9.1.0` (already in EHG dependencies)
+- **Data Fetching**: `@tanstack/react-query@5.83.0` (already in EHG dependencies)
+- **LLM**: Claude Sonnet for strategic analysis, Claude Haiku for content type classification. Uses existing `client-factory.js` for LLM routing.
+- **Database**: Supabase (PostgreSQL) — extends existing schema
+- **Streaming**: Server-Sent Events (SSE) for text streaming; canvas artifacts render on completion
+- **Existing Infrastructure (Fully Reusable)**: `EVAChatInterface.tsx` (614 LOC — UI patterns), `EVAConversationService` (386 LOC — conversation management), `EVAContext` (296 LOC — state management), `ChartRenderer.tsx` (330 LOC — Recharts wrapper), `AIServiceManager` (retry/timeout/streaming), `client-factory.js` (LLM routing)
+- **New Dependencies**: None required
+
+## Legacy Deprecation Plan
+N/A — additive feature. The existing floating EVAChatInterface continues to function. The new route-level chat is a separate component that shares service-layer code (EVAConversationService, EVAContext) but has its own UI optimized for full-page layout.
+
+## Route & Component Structure
+
+### Frontend (EHG repo)
+- `src/pages/chairman/EVAChatPage.tsx` — Route page with ResizablePanelGroup layout
+- `src/components/eva-chat/EVAChatPanel.tsx` — Full-page chat panel (rewrite of floating card patterns for route context)
+- `src/components/eva-chat/EVACanvasPanel.tsx` — Canvas container managing content type rendering
+- `src/components/eva-chat/canvas/CanvasContentRegistry.ts` — Content type registry (schema, renderer, validator per type)
+- `src/components/eva-chat/canvas/renderers/DecisionMatrixRenderer.tsx` — Weighted option comparison
+- `src/components/eva-chat/canvas/renderers/ComparisonTableRenderer.tsx` — Side-by-side comparison
+- `src/components/eva-chat/canvas/renderers/ChartCanvasRenderer.tsx` — Wrapper around existing ChartRenderer
+- `src/components/eva-chat/canvas/renderers/OKRBreakdownRenderer.tsx` — Objectives/key results display
+- `src/components/eva-chat/canvas/renderers/TimelineRenderer.tsx` — Chronological events/milestones
+- `src/components/eva-chat/canvas/renderers/TextRenderer.tsx` — Rich markdown via react-markdown
+- `src/components/eva-chat/canvas/CanvasResponseParser.ts` — Parse + validate EVA structured output
+- `src/hooks/useEVAChatStream.ts` — SSE streaming hook for EVA responses
+- `src/hooks/useCanvasState.ts` — Canvas content state management
+- Route registration in `src/routes/chairmanRoutesV3.tsx` — `/chairman/eva-chat`
+
+### Backend (EHG_Engineer repo)
+- `lib/integrations/eva-chat-service.js` — EVA conversation orchestration (prompt construction, context injection, response parsing)
+- `lib/integrations/eva-canvas-prompt.js` — System prompt templates for canvas-aware EVA responses
+- `scripts/eva/eva-chat-api.mjs` — REST/RPC endpoints for conversation CRUD
+
+## Data Layer
+
+### New Tables
+- `eva_chat_conversations` — Conversation threads
+  - `id` (uuid), `user_id` (fk → auth.users), `title` (text — auto-generated from first message)
+  - `status` (active, archived), `metadata` (jsonb — tags, venture context)
+  - `created_at` (timestamptz), `updated_at` (timestamptz)
+
+- `eva_chat_messages` — Individual messages within conversations
+  - `id` (uuid), `conversation_id` (fk → eva_chat_conversations)
+  - `role` (user, assistant, system), `content` (text — raw message text)
+  - `canvas_content` (jsonb — structured canvas artifact, null if text-only)
+  - `canvas_content_type` (text — registry key, null if text-only)
+  - `token_count` (int), `model_used` (text)
+  - `created_at` (timestamptz)
+
+- `eva_canvas_artifacts` — Persistent canvas state snapshots
+  - `id` (uuid), `message_id` (fk → eva_chat_messages)
+  - `content_type` (text — registry key), `content_data` (jsonb — full artifact data)
+  - `title` (text — human-readable label), `pinned` (bool — chairman can pin important artifacts)
+  - `created_at` (timestamptz)
+
+### Existing Tables Used
+- `auth.users` — User identity for conversation ownership
+- `voice_conversations` — Reference pattern for conversation schema (not directly used)
+
+### RLS
+- Row-level security on all new tables: users can only access their own conversations
+- Service role for backend conversation creation (EVA response insertion)
+- `eva_chat_conversations`: `auth.uid() = user_id` for SELECT/INSERT/UPDATE
+- `eva_chat_messages`: `auth.uid() = (SELECT user_id FROM eva_chat_conversations WHERE id = conversation_id)` for SELECT
+- `eva_canvas_artifacts`: Inherits message-level access
+
+## API Surface
+
+### Supabase RPC
+- `create_eva_conversation(p_title, p_metadata)` → returns conversation_id
+- `get_eva_conversations(p_limit, p_offset)` → paginated conversation list
+- `get_conversation_messages(p_conversation_id)` → full message thread with canvas artifacts
+
+### REST Endpoints (EHG_Engineer)
+- `POST /api/eva-chat/message` — Send message, receive streaming EVA response
+  - Request: `{ conversation_id, content, context: { venture_id?, topic? } }`
+  - Response: SSE stream — text chunks, then final canvas artifact JSON
+- `POST /api/eva-chat/conversations` — Create new conversation
+- `GET /api/eva-chat/conversations/:id` — Retrieve conversation with messages
+
+### Canvas Content Type Schema
+```typescript
+interface CanvasContent {
+  type: string;  // Registry key
+  title: string; // Display label
+  data: unknown; // Type-specific payload
+}
+
+// Example: Decision Matrix
+interface DecisionMatrixData {
+  options: string[];
+  criteria: { name: string; weight: number }[];
+  scores: number[][];  // [option_index][criteria_index]
+  recommendation?: string;
+}
+
+// Example: Comparison Table
+interface ComparisonTableData {
+  columns: { key: string; label: string }[];
+  rows: Record<string, string | number>[];
+  highlights?: { row: number; column: string; type: 'positive' | 'negative' | 'neutral' }[];
+}
+```
+
+## Implementation Phases
+
+- **Phase 0** (2 days): Prototype — Extract EVAChatInterface patterns to a route-level page. Mock 2-3 canvas content types with hardcoded data. Chairman uses prototype to validate preference for conversational interface vs dashboards.
+- **Phase 1** (2-3 days): Infrastructure — `/chairman/eva-chat` route with ResizablePanelGroup layout. EVAChatPanel (rewritten for route context). Database migration for `eva_chat_conversations` and `eva_chat_messages`. Backend conversation API (create, retrieve, list). Basic message send/receive via REST.
+- **Phase 2** (2-3 days): Canvas Rendering — CanvasContentRegistry with 5 initial types (decision matrix, comparison table, chart, OKR breakdown, timeline, text). CanvasResponseParser with JSON Schema validation per type. Graceful fallback rendering for malformed output. EVA system prompt templates for structured output.
+- **Phase 3** (2-3 days): Streaming + Polish — SSE streaming for text responses (useEVAChatStream hook). Canvas artifact rendering on response completion. Conversation persistence with canvas state. Error handling and loading states. `eva_canvas_artifacts` table for pinning important artifacts.
+
+## Testing Strategy
+- Unit tests for CanvasResponseParser (malformed JSON → graceful fallback)
+- Unit tests for each canvas content type renderer (valid data → correct render)
+- Integration tests for conversation API (create → message → retrieve round-trip)
+- E2E test for chat route (send message → receive response → canvas renders)
+- LLM output validation tests (sample EVA outputs → expected content type parsing)
+- Performance tests: conversation thread with 100+ messages, 20+ canvas artifacts
+
+## Risk Mitigation
+- **LLM output inconsistency**: Validation+repair layer between EVA output and canvas renderer. JSON Schema validation per content type. Fallback to text/markdown rendering — canvas never crashes. Budget 150-250 LOC for this layer.
+- **EVAChatInterface coupling to floating card**: Treat extraction as a rewrite. Build EVAChatPanel as a new component sharing service-layer code (hooks, EVAConversationService) but with route-optimized UI. Keep floating card functional — do not try to make one component serve two contexts.
+- **Content type explosion**: Registry pattern from day 1. Each type is a self-registering module (schema + renderer + validator). New types added by dropping a file, not modifying a switch statement. Target: <100 LOC per new content type.
+- **Streaming complexity**: Hybrid approach — stream text response token-by-token via SSE, render canvas artifacts as complete units when response finishes. This avoids incremental chart rendering (which requires all data points) while maintaining responsive chat UX.
+- **Cross-repo coordination**: Clear API contract. Frontend consumes REST/RPC endpoints; backend provides them. Independent deployability. API versioning from day 1.
+- **Product-market fit risk**: Phase 0 prototype validates chairman preference before committing to full build. If prototype shows low engagement, redirect effort toward AI-enhanced dashboards instead.
+- **Performance**: React.memo on canvas renderers, lazy-load canvas artifacts beyond viewport, virtualized message list for long conversations. Supabase Realtime for conversation sync if needed.

--- a/docs/plans/eva-chat-route-dynamic-canvas-vision.md
+++ b/docs/plans/eva-chat-route-dynamic-canvas-vision.md
@@ -1,0 +1,107 @@
+# Vision: EVA Chat Route with Dynamic Canvas
+
+## Executive Summary
+EHG's Chairman UI currently surfaces EVA's strategic intelligence through static dashboards and a constrained floating chat card. This vision transforms the chairman's interaction with EVA from passive information consumption to active conversational strategy — a dedicated chat route where the chairman engages in extended strategic dialogue with EVA while a dynamic canvas renders rich, structured analysis (charts, tables, decision matrices, timelines) alongside the conversation. The canvas is not just a display surface but an action surface where strategic artifacts become the starting point for decisions, brainstorms, and SD creation.
+
+The strategic bet: conversational AI + structured visual output creates a fundamentally different way to operate a venture factory — one where strategic thinking is externalized, structured, and traceable.
+
+## Problem Statement
+The chairman manages a portfolio of ventures through the Chairman V3 UI. Strategic analysis currently requires navigating multiple dashboards, mentally cross-referencing data, and synthesizing insights manually. EVA surfaces recommendations through push-based dashboard widgets, but there is no way to engage EVA in extended dialogue — asking follow-up questions, requesting alternative analyses, or drilling into specific dimensions. The existing floating chat card (EVAChatInterface.tsx, 614 LOC) is limited by its card-size viewport and cannot render structured visual artifacts. Strategic decisions that require comparing options, visualizing trends, or evaluating tradeoffs lack a natural workspace.
+
+## Personas
+- **Chairman (Rick)**: Primary user. Makes portfolio-level strategic decisions. Needs a workspace where he can think out loud, ask EVA compound questions ("Which ventures have declining MRR but improving engagement, and how does that compare to competitors?"), and see structured analysis rendered instantly. Values traceability — wants to look back at why decisions were made.
+- **EVA (AI Strategic Advisor)**: The conversational partner. Needs a richer output surface than text to communicate structured analysis. Currently constrained to text responses in a floating card; the canvas gives EVA a medium for charts, tables, matrices, and interactive artifacts.
+- **Venture Leads (Future)**: Secondary users who may eventually participate in canvas-enabled strategy sessions. Not in MVP scope.
+
+## Information Architecture
+- **Conversation Thread**: Left panel — message history with the chairman's queries and EVA's responses. Supports text, markdown, code blocks, and embedded references to canvas artifacts.
+- **Dynamic Canvas**: Right panel — renders structured content extracted from EVA's responses. Content types form a registry pattern where each type (chart, table, decision matrix, timeline, etc.) is a self-registering module with its own schema, renderer, and validator.
+- **Content Type System**: 5-7 initial types:
+  - `decision-matrix` — weighted comparison of strategic options
+  - `comparison-table` — side-by-side venture/competitor/feature comparison
+  - `chart` — bar, line, area, pie via existing ChartRenderer (Recharts)
+  - `okr-breakdown` — objectives, key results, metrics with progress indicators
+  - `timeline` — chronological events, milestones, projections
+  - `text` — rich markdown content for narrative analysis
+  - `risk-heatmap` — probability × impact grid (stretch goal)
+- **Conversation Persistence**: Conversations and their canvas artifacts stored in Supabase for retrieval and review. Each conversation has a thread of messages and associated canvas states.
+- **Existing Infrastructure Leveraged**: EVAChatInterface (chat UI patterns), EVAConversationService (conversation management), ChartRenderer (visualization), react-resizable-panels (layout), react-markdown (text rendering), @tanstack/react-query (data fetching)
+
+## Key Decision Points
+- **Streaming vs Polling**: The chat UX must feel responsive. Modern AI chat interfaces stream responses token-by-token. Polling creates 5-15 second dead zones that erode trust. Decision: commit to streaming from Phase 1 for the text response; canvas artifacts render as complete units when the response finishes.
+- **Canvas Persistence**: Canvas artifacts are persistent — stored alongside the conversation in Supabase. This enables decision journaling (traceable strategic rationale) and prevents the "transient artifact generator" anti-pattern where valuable analysis disappears after the session.
+- **Content Type Extensibility**: Use a registry pattern from day 1. New content types are added by registering a schema, renderer, and validator — not by modifying a switch statement. This prevents maintenance explosion as the chairman requests types beyond the initial 5-7.
+- **LLM Output Validation**: EVA's structured JSON output goes through a validation+repair layer before canvas rendering. Malformed output degrades gracefully to text/markdown — the canvas never crashes. Schema validation per content type with fallback rendering.
+- **Cross-Repository Architecture**: The chat route lives in EHG (frontend), while conversation APIs and EVA orchestration live in EHG_Engineer (backend). Clear API contract between the two repos via Supabase RPC and REST endpoints.
+- **Demand Validation**: A lightweight Phase 0 prototype (2-day spike with mocked canvas content) validates that the chairman prefers conversational EVA over dashboard-surfaced recommendations before committing to the full build.
+
+## Integration Patterns
+- **EVA Recommendation Engine**: Transforms from push-only (dashboard surfacing) to push+pull (conversational queries + proactive recommendations in context). The chat route gives the recommendation engine a conversational delivery channel.
+- **Brainstorm Pipeline**: Brainstorms can happen inside the EVA chat — the chairman describes an idea, EVA renders a structured brainstorm scaffold on the canvas (problem statement, competitive context, effort estimate), and the conversation refines it toward SD creation.
+- **LEO Protocol / SD Creation**: The canvas serves as a natural-language front end for SD initiation. The chairman describes what they want built, EVA renders a draft SD structure on the canvas, and once approved, calls `leo-create-sd.js` with the agreed parameters.
+- **Competitor Monitoring**: Canvas renders competitive intelligence — feature comparison matrices, market share trends, positioning maps — pulling from the competitor monitoring pipeline's data.
+- **Todoist/YouTube Intake**: Canvas displays classified intake items visually, enabling the chairman to review, reclassify, or promote items to brainstorms through conversation.
+- **Existing EVA Infrastructure**: Extends `EVAChatInterface.tsx` (UI patterns), `EVAConversationService` (conversation management), `client-factory.js` (LLM routing). Does not replace any existing functionality.
+
+## Evolution Plan
+- **Phase 0** (2 days): Prototype/Spike — Mocked canvas content with the existing EVAChatInterface extracted to a route. Validates chairman preference for conversational interface before full investment.
+- **Phase 1** (2-3 days): Infrastructure — EVA Chat route (`/chairman/eva-chat`), split-panel layout using react-resizable-panels, basic conversation API (save/retrieve), database migration for `eva_chat_conversations`.
+- **Phase 2** (2-3 days): Canvas Rendering — Content type registry pattern, 5 initial content types (decision matrix, comparison table, chart, OKR breakdown, timeline, text), EVA response parser/validator, graceful fallback rendering.
+- **Phase 3** (2-3 days): Streaming + Polish — Streaming text responses via SSE, canvas artifact rendering on response completion, conversation persistence with canvas state, error handling, loading states.
+- **Future**: Persistent canvas workspaces (named strategic environments), canvas as action surface (approve/reject/create from canvas), multi-stakeholder collaborative canvas, multi-modal input (screenshots, voice, PDFs).
+
+## Out of Scope
+- Collaborative multi-user canvas (future evolution)
+- Voice-to-canvas pipeline (future — extends existing voice transcription)
+- Canvas export to PDF/presentation format (future)
+- Real-time canvas collaboration via WebSocket (future)
+- Replacing existing Chairman V3 dashboards (canvas is additive, not replacement)
+- Mobile-optimized canvas layout (desktop-first)
+- Custom canvas widget builder (content types are developer-defined)
+
+## UI/UX Wireframes
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Chairman V3 Shell (Navigation Bar)                                 │
+├─────────────────────────────────┬───────────────────────────────────┤
+│                                 │                                   │
+│  EVA Chat Thread                │  Dynamic Canvas                   │
+│  ─────────────────              │  ─────────────────                │
+│                                 │                                   │
+│  [Rick]: Which ventures have    │  ┌─────────────────────────────┐  │
+│  declining MRR but improving    │  │  Venture Comparison Table   │  │
+│  engagement?                    │  │                             │  │
+│                                 │  │  Venture  MRR   Engagement  │  │
+│  [EVA]: Based on the last 90   │  │  ─────── ───── ──────────── │  │
+│  days, here's the analysis...  │  │  App A   ↓12%  ↑ 23%       │  │
+│                                 │  │  App B   ↓ 5%  ↑ 45%       │  │
+│  📊 Canvas: Venture Comparison │  │  App C   ↑ 8%  ↑  3%       │  │
+│                                 │  └─────────────────────────────┘  │
+│  [Rick]: Now overlay competitor │                                   │
+│  data for App B                 │  ┌─────────────────────────────┐  │
+│                                 │  │  📈 Engagement Trend Chart  │  │
+│  [EVA]: Here's App B vs its    │  │  (Recharts line chart)      │  │
+│  top 3 competitors...          │  │                             │  │
+│                                 │  │  ~~~~~/                     │  │
+│  📊 Canvas: Competitive        │  │  ~~~~~/                     │  │
+│  Analysis                       │  │  ─── App B  ─── Comp 1     │  │
+│                                 │  └─────────────────────────────┘  │
+│                                 │                                   │
+│  ┌──────────────────────┐      │                                   │
+│  │ Type a message...    │      │                                   │
+│  └──────────────────────┘      │                                   │
+├─────────────────────────────────┴───────────────────────────────────┤
+│  ◀─── Drag to resize panels ───▶                                   │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Success Criteria
+- EVA Chat route accessible at `/chairman/eva-chat` with split-panel layout
+- Canvas renders 5+ content types correctly from EVA structured output
+- Conversation persistence — chairman can return and review prior strategic dialogues
+- Streaming text responses with <2 second time-to-first-token
+- LLM output validation layer prevents canvas crashes — graceful fallback to text for malformed output
+- Canvas content types extensible via registry pattern — adding a new type requires <100 LOC
+- Phase 0 prototype validates chairman preference for conversational interface
+- Cross-repo coordination: frontend (EHG) and backend (EHG_Engineer) deploy independently
+- No degradation of existing Chairman V3 dashboard performance

--- a/docs/plans/genesis-venture-factory-offering-architecture.md
+++ b/docs/plans/genesis-venture-factory-offering-architecture.md
@@ -1,0 +1,150 @@
+# Architecture Plan: Genesis — Public Venture Factory Offering
+
+## Stack & Repository Decisions
+- **Repositories**: New `genesis` repository (standalone SaaS product), with shared libraries extracted from EHG_Engineer
+- **Frontend**: React + TypeScript + Vite + Tailwind CSS (EHG stack for consistency)
+- **Backend**: Node.js + Supabase (PostgreSQL) — mirrors EHG_Engineer patterns
+- **Auth**: Supabase Auth with multi-tenant RBAC
+- **Billing**: Stripe (subscriptions + usage metering)
+- **Deployment**: Vercel (frontend) + Supabase (backend/database)
+- **LLM**: Claude Sonnet for EVA advisory, Claude Haiku for classification tasks. Uses client-factory.js pattern for LLM routing with per-customer token metering.
+- **Existing Infrastructure (Extracted from EHG_Engineer)**: Venture State Machine (1,301 LOC), Stage Templates (14,690 LOC — stages 1-25), Stage-Zero Synthesis (7,597 LOC), Genesis Simulation (8,151 LOC), CEO Factory (474 LOC), Discovery Service (1,917 LOC), Cross-Venture Learning (871 LOC), Portfolio Optimizer (524 LOC)
+- **New Dependencies**: `@stripe/stripe-js` (billing), `@supabase/auth-helpers-react` (multi-tenant auth)
+
+## Legacy Deprecation Plan
+N/A — Genesis is a new standalone product. EHG_Engineer's internal infrastructure remains unchanged. Shared libraries are extracted as read-only copies, not moved. EHG_Engineer continues to evolve independently; Genesis periodically syncs upstream improvements.
+
+## Route & Component Structure
+
+### Genesis Repository (New)
+- `packages/core/` — Extracted venture lifecycle engine (state machine, stage templates, gates)
+- `packages/eva-advisory/` — EVA strategic advisor API (chat, classification, assumption testing)
+- `packages/simulation/` — Genesis simulation chamber (Aries sandbox)
+- `packages/intelligence/` — Cross-venture learning and aggregate analytics
+- `apps/web/` — Customer-facing SaaS dashboard (React + Vite)
+  - `src/pages/Dashboard.tsx` — Portfolio overview with venture cards
+  - `src/pages/VentureDetail.tsx` — Single venture lifecycle view
+  - `src/pages/GateDecision.tsx` — Kill/promote gate decision interface
+  - `src/pages/EVAChat.tsx` — EVA advisory chat interface
+  - `src/pages/Settings.tsx` — Account, billing, team management
+  - `src/pages/Onboarding.tsx` — New customer onboarding flow
+- `apps/api/` — REST API server (Node.js + Express)
+  - `routes/ventures.js` — Venture CRUD, stage advancement
+  - `routes/gates.js` — Gate evaluation, decision recording
+  - `routes/eva.js` — EVA advisory chat endpoint (streaming)
+  - `routes/billing.js` — Stripe webhook handlers, usage reporting
+  - `middleware/tenant.js` — Multi-tenant context injection
+  - `middleware/metering.js` — Usage metering for billing
+
+### EHG_Engineer (Source — no modifications)
+- Existing infrastructure serves as source for extraction
+- No changes to EHG_Engineer codebase required
+
+## Data Layer
+
+### New Tables (Genesis Database — separate Supabase project)
+- `organizations` — Customer organizations (multi-tenant root)
+  - `id` (uuid), `name` (text), `slug` (text, unique)
+  - `plan` (text — free, pro, enterprise), `stripe_customer_id` (text)
+  - `settings` (jsonb — gate thresholds, custom stages, branding)
+  - `created_at` (timestamptz), `updated_at` (timestamptz)
+
+- `org_members` — Organization membership with roles
+  - `id` (uuid), `org_id` (fk → organizations), `user_id` (fk → auth.users)
+  - `role` (text — owner, admin, member, viewer)
+  - `invited_at` (timestamptz), `accepted_at` (timestamptz)
+
+- `genesis_ventures` — Per-organization ventures
+  - `id` (uuid), `org_id` (fk → organizations)
+  - `name` (text), `description` (text), `venture_type` (text — saas, marketplace, api, content)
+  - `current_stage` (int 1-25), `stage_history` (jsonb — transitions with timestamps)
+  - `health_score` (numeric 0-10), `health_details` (jsonb)
+  - `simulation_id` (uuid, nullable — if spawned via Aries)
+  - `status` (active, paused, killed, graduated), `kill_reason` (text, nullable)
+  - `metadata` (jsonb), `created_at` (timestamptz), `updated_at` (timestamptz)
+
+- `genesis_gate_decisions` — Gate evaluation results
+  - `id` (uuid), `venture_id` (fk → genesis_ventures)
+  - `stage` (int), `gate_type` (text — kill, promotion, artifact)
+  - `decision` (text — pass, fail, chairman_review)
+  - `criteria_scores` (jsonb — per-criterion scores and evidence)
+  - `decided_by` (fk → auth.users), `rationale` (text)
+  - `created_at` (timestamptz)
+
+- `genesis_eva_conversations` — EVA advisory chat threads
+  - `id` (uuid), `venture_id` (fk → genesis_ventures)
+  - `messages` (jsonb[] — role, content, canvas artifacts)
+  - `token_count` (int), `model_used` (text)
+  - `created_at` (timestamptz), `updated_at` (timestamptz)
+
+- `genesis_venture_artifacts` — Per-venture documents and outputs
+  - `id` (uuid), `venture_id` (fk → genesis_ventures)
+  - `artifact_type` (text — prd, bmc, financial_model, pitch_deck, market_research)
+  - `stage_produced` (int), `content` (jsonb)
+  - `status` (draft, review, approved), `version` (int)
+  - `created_at` (timestamptz)
+
+- `genesis_aggregate_patterns` — Cross-venture anonymized patterns
+  - `id` (uuid), `pattern_type` (text — failure_mode, success_factor, pivot_pattern)
+  - `description` (text), `frequency` (int — how many ventures exhibit)
+  - `stage_range` (int[] — which stages it typically appears)
+  - `venture_types` (text[] — which venture types affected)
+  - `recommendation` (text), `confidence` (numeric 0-1)
+  - `created_at` (timestamptz), `updated_at` (timestamptz)
+
+- `genesis_usage_events` — Billing usage metering
+  - `id` (uuid), `org_id` (fk → organizations)
+  - `event_type` (text — venture_created, gate_evaluated, eva_query, simulation_run)
+  - `quantity` (int), `metadata` (jsonb)
+  - `created_at` (timestamptz)
+
+### RLS
+- All tables enforce `org_id` isolation: users can only access their organization's data
+- `organizations`: Only members can read; only owners can update
+- `genesis_ventures`: Members of the venture's org can read; admin+ can write
+- `genesis_aggregate_patterns`: Readable by all authenticated users (the shared intelligence layer)
+- `genesis_usage_events`: Only service role can write; org owners can read their own
+
+## API Surface
+
+### REST Endpoints
+- `POST /api/ventures` — Create new venture in org
+- `GET /api/ventures` — List org's ventures with health scores
+- `POST /api/ventures/:id/advance` — Advance venture to next stage (triggers gate evaluation)
+- `POST /api/ventures/:id/gate-decision` — Record kill/promote decision
+- `POST /api/eva/chat` — EVA advisory chat (SSE streaming response)
+- `POST /api/simulation/spawn` — Create Aries sandbox for a venture
+- `GET /api/intelligence/patterns` — Cross-venture aggregate patterns
+- `GET /api/intelligence/benchmarks` — Venture health benchmarking vs cohort
+- `POST /api/billing/webhook` — Stripe webhook handler
+- `GET /api/billing/usage` — Current period usage summary
+
+### Supabase RPC
+- `get_org_portfolio_health(org_id)` — Aggregate health across ventures
+- `get_stage_completion_rates(venture_type)` — Cross-platform stage analytics
+- `get_similar_ventures(venture_id)` — Find ventures with similar profiles
+
+## Implementation Phases
+- **Phase 0** (4 weeks): Demand Validation — No code. Content marketing (blog posts about EHG methodology, case studies). 20+ customer discovery interviews. Landing page with waitlist. Success metric: 50+ qualified signups, clear willingness-to-pay signal from ≥5 prospects.
+- **Phase 1** (6 weeks): MVP — New Genesis repository. Multi-tenant Supabase schema (organizations, org_members, genesis_ventures, genesis_gate_decisions). Customer auth via Supabase Auth. Core 10-stage workflow extracted from EHG stage templates. Basic EVA advisory chat. Free trial + $299/month pro tier via Stripe. Private beta with 5-10 founding customers.
+- **Phase 2** (6 weeks): Product Completeness — Stages 11-25 with full gate engine. Genesis simulation chamber (Aries sandbox per customer). Usage metering and billing enforcement. Venture health dashboards. Support ticketing integration. Public launch.
+- **Phase 3** (8 weeks): Intelligence Layer — Cross-venture aggregate patterns (genesis_aggregate_patterns). Benchmarking API. Enterprise tier with white-labeling, SSO, and data isolation. Accelerator partnership tier. $999+/month pricing.
+- **Phase 4** (ongoing): Growth — Open-core community tier. API/SDK for custom integrations. Template marketplace. Equity track option. International expansion.
+
+## Testing Strategy
+- Unit tests for multi-tenant data isolation (org A cannot access org B's ventures)
+- Unit tests for stage gate evaluation (known inputs → expected gate decisions)
+- Integration tests for venture lifecycle (create → advance through stages → gate decisions → completion)
+- Integration tests for Stripe billing (subscription creation, usage metering, tier enforcement)
+- E2E tests for customer onboarding flow (signup → create org → create first venture → advance to stage 2)
+- Security tests for RLS policies (verify cross-tenant data isolation at database level)
+- Load tests for EVA advisory (concurrent chat sessions across multiple orgs)
+
+## Risk Mitigation
+- **Market risk (no demand)**: Phase 0 demand validation before any engineering. Hard kill metric (50+ signups, 5+ WTP signals). If Phase 0 fails, total investment is 4 weeks of content + interviews — minimal sunk cost.
+- **Multi-tenancy data leakage**: RLS at database level (not application level). Integration tests verify cross-tenant isolation. Security audit before public launch. Bug bounty program for enterprise tier.
+- **LLM cost explosion**: Per-customer token metering. Tier-based token budgets (free: 50K/month, pro: 500K/month, enterprise: custom). Usage alerts at 80% and 100% of budget. Haiku for classification (cheap), Sonnet for advisory (metered).
+- **Resource drain on EHG**: Genesis team capped at 3 FTE. Support SLA limited to business hours. Self-serve documentation required before public launch. If support burden exceeds capacity, raise prices before adding headcount.
+- **IP exposure**: Methodology is public (content marketing moat). Software is proprietary (product moat). Cross-venture intelligence is defensible (data moat). Competitors can read about the methodology but cannot replicate 200+ ventures worth of pattern data.
+- **Competing with customers**: Terms of Service include non-compete clause for direct EHG venture categories. Genesis does not provide venture ideas or market intelligence about EHG's active markets.
+- **Vercel deployment per customer**: Sandbox environments use Genesis Vercel team (metered). Production deployments require customer's own Vercel account. Clear separation of infrastructure costs.

--- a/docs/plans/genesis-venture-factory-offering-vision.md
+++ b/docs/plans/genesis-venture-factory-offering-vision.md
@@ -1,0 +1,99 @@
+# Vision: Genesis — Public Venture Factory Offering
+
+## Executive Summary
+EHG has built a venture factory operating system: 25-stage lifecycle engine, AI strategic advisor (EVA), automated stage gates, opportunity scoring, moat architecture, simulation chamber, and cross-venture learning — totaling 221K+ LOC of production infrastructure. This vision transforms EHG from a company that builds ventures into the company that built the platform on which ventures get built. Genesis is the productization of EHG's venture factory methodology as a standalone SaaS platform, enabling others to run AI-augmented venture factories using EHG's battle-tested playbook.
+
+The strategic bet: in a world where AI commoditizes code generation, the meta-skill of *systematically building ventures* becomes the durable advantage. EHG's venture factory methodology — validated through production use and encoded in software — is more valuable as a platform than as an internal tool. Genesis captures this value through a hybrid model: SaaS subscriptions for operating costs, equity optionality in Genesis-built ventures for upside, and data network effects that compound with every venture on the platform.
+
+## Problem Statement
+EHG's venture factory infrastructure is locked inside a single organization. The 25-stage lifecycle, EVA advisory, kill gates, simulation chamber, and cross-venture learning were built to serve EHG's internal portfolio — but their value is not EHG-specific. Any team building multiple ventures would benefit from structured stage gates, AI-powered assumption testing, and cross-portfolio intelligence. Meanwhile, the market for venture building support is fragmented: accelerators offer networks and capital but not persistent tooling, productivity tools offer task management but not venture methodology, and AI startup generators produce ideas but not systematic execution. No one owns the operating system layer between "I have an idea" and "I have a validated, funded, launched product." Genesis fills that gap.
+
+## Personas
+- **Venture Studio Operators**: Run small studios (2-10 active ventures). Need structured methodology beyond spreadsheets. Value stage gates, portfolio health views, and cross-venture learning. Willing to pay $500-1000/month per studio.
+- **Corporate Innovation Teams**: Large companies running internal ventures. Need accountability frameworks, kill criteria, and executive dashboards. Enterprise pricing ($2000+/month). Value white-labeling and data privacy.
+- **Serial Entrepreneurs**: Building 2nd or 3rd venture. Want an AI co-founder that provides strategic challenge, not just code generation. Value EVA advisory, assumption testing, and market intelligence. $100-300/month.
+- **Accelerator Programs**: Running cohort-based programs. Need per-venture tracking, milestone gates, and cohort analytics. Value aggregate reporting for LPs. Partnership/licensing model.
+- **Chairman (Rick)**: Genesis venture owner. Needs Genesis to cover its own operating costs via SaaS revenue while generating equity optionality. Values the data network effect for improving EHG's own venture factory.
+
+## Information Architecture
+- **Venture Dashboard**: Per-customer portfolio view showing all active ventures, their current stage (1-25), health indicators, and upcoming gate decisions. Mirrors EHG's Chairman view but multi-tenant.
+- **Stage Gate Engine**: Customer-configurable validation gates with kill/promote/review decisions. Default configuration mirrors EHG's production gates (stages 3, 5, 13, 23 kill; 16, 17, 22 promotion). Customers can customize thresholds and add custom gates.
+- **EVA Advisory Interface**: Chat-based strategic advisor for each venture. Uses Genesis-specific prompts trained on cross-venture patterns. Provides assumption challenges, competitive analysis, and strategic recommendations.
+- **Simulation Chamber (Aries)**: "Try before you commit" environment where Genesis users can spawn a venture in a sandbox, run initial validation, and decide whether to promote to production. Reduces waste by catching non-viable ideas before significant investment.
+- **Cross-Venture Intelligence**: Aggregate (anonymized) insights across all Genesis ventures — stage completion rates, common failure modes, successful pivot patterns, market signal correlations. Premium feature for paid tiers.
+- **Template Library**: Curated collection of EHG's stage templates, artifact formats, and validation checklists. Customizable per venture type (SaaS, marketplace, API, content, hardware).
+- **Existing Infrastructure Leveraged**: Venture State Machine, Stage Templates (stages 1-25), Stage-Zero synthesis, Genesis simulation, CEO Factory, Discovery Service, Cross-Venture Learning, Portfolio Optimizer.
+
+## Key Decision Points
+- **Demand Validation First**: Before any engineering investment beyond Phase 1 MVP, validate demand through 20+ customer interviews and content-based interest measurement. Hard kill metric: 10 paying customers within 6 months of launch or redirect effort.
+- **Enterprise-First or Community-First**: Two viable go-to-market strategies. Enterprise-first (venture studios, corporate innovation) offers higher revenue per customer but smaller TAM. Community-first (individual founders, open-core model) offers larger TAM but lower willingness to pay. Decision: start enterprise-first (higher signal per customer), add community tier after product-market fit.
+- **Equity Model**: Genesis can take equity in ventures built on the platform (like YC) or be pure SaaS (like Notion). Hybrid recommended: pure SaaS by default, optional equity track for ventures that want Genesis resources (advisory, capital, network) in exchange for 1-2% equity.
+- **IP Protection**: Productizing the methodology means exposing it. Mitigation: the methodology is the "what" (public — content marketing), the software is the "how" (proprietary — product moat), and the data is the "why it works" (defensible — network effects). Competitors can read about the methodology but cannot replicate the accumulated cross-venture intelligence.
+- **Data Sharing Model**: Cross-venture learning data is either shared (all customers benefit from aggregate intelligence) or siloed (each customer only learns from their own ventures). Decision: shared by default (this IS the network effect), with enterprise tier offering private-only mode.
+- **Build vs License**: Genesis as self-serve SaaS vs licensing to established venture studios. Phase 1 explores both — SaaS for validation, licensing conversations for enterprise revenue.
+
+## Integration Patterns
+- **LEO Protocol → Genesis Orchestration SDK**: Strip EHG-specific implementation, expose configurable LEAD-PLAN-EXEC framework. Customers configure their own phase definitions, gate criteria, and handoff requirements. LEO becomes the engine, Genesis is the car.
+- **EVA → Strategic Advisor API**: EVA's intake, classification, and advisory capabilities exposed as API endpoints. Per-customer context window (venture portfolio, market data, historical decisions). Premium tier feature with per-query token metering.
+- **Design System → Venture UI Starter Kit**: EHG's Shadcn component library and design tokens offered as optional starter kit for Genesis-built ventures. "Powered by Genesis" visual identity. Ventures can override with custom branding.
+- **Stage Gates → Validation-as-a-Service**: Gate definitions, scoring rubrics, and decision frameworks as configurable templates. Customers can use EHG defaults or customize. Gate results feed into venture health dashboards.
+- **Cross-Venture Learning → Aggregate Intelligence**: Pattern recognition across all Genesis ventures (anonymized). Premium feature: "Ventures in your category typically stall at Stage 7 because of pricing model uncertainty. Here are the 3 most common pivots."
+- **Competitive Intelligence → Market Signal Feed**: EHG's competitive intelligence pipeline (market scanning, signal detection) exposed to Genesis users as shared intelligence layer. Aggregated across all ventures on the platform.
+
+## Evolution Plan
+- **Phase 0** (4 weeks): Demand Validation — Content marketing (blog posts, case studies about EHG methodology). 20+ customer interviews. Landing page with waitlist. Measure inbound interest. Kill metric: 50+ qualified waitlist signups.
+- **Phase 1** (6 weeks): MVP — Multi-tenant schema + RLS. Customer auth + API keys. Core 10-stage workflow (stages 1-10 with gates). Basic EVA advisory. Free trial + $299/month pro tier. Private beta for 5-10 founding customers.
+- **Phase 2** (6 weeks): Product Completeness — Stages 11-25 with full gates. Genesis simulation chamber. Billing and usage metering. Support infrastructure. Venture health dashboards. Public launch target: 50+ customers.
+- **Phase 3** (8 weeks): Intelligence Layer — Cross-venture learning (aggregate patterns). Advanced analytics and benchmarking. Enterprise tier ($999+/month) for corporate innovation teams. White-labeling for accelerator partnerships.
+- **Phase 4** (ongoing): Growth & Network Effects — Open-core community tier. API/SDK for custom integrations. Marketplace for venture templates. Equity track for select ventures. International expansion.
+
+## Out of Scope
+- Building ventures for Genesis customers (Genesis provides methodology, not execution)
+- Replacing human judgment in venture decisions (AI advises, humans decide)
+- Competing with accelerators for capital allocation (Genesis is tooling, not funding)
+- Mobile application (desktop-first, responsive web)
+- Real-time collaboration features (async-first, real-time collaboration in future phases)
+- Hardware venture support (software/SaaS ventures initially)
+
+## UI/UX Wireframes
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Genesis Dashboard — [Customer Name] Studio                        │
+├────────────────────────────────────────────────────────────────────┤
+│                                                                    │
+│  Portfolio Overview                                                │
+│  ─────────────────                                                 │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐             │
+│  │ Venture A │ │ Venture B │ │ Venture C │ │  + New   │             │
+│  │ Stage 12  │ │ Stage 5   │ │ Stage 2   │ │ Venture  │             │
+│  │ ████████░ │ │ ████░░░░░ │ │ █░░░░░░░░ │ │          │             │
+│  │ Health: ✅│ │ Health: ⚠️│ │ Health: ✅│ │          │             │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘             │
+│                                                                    │
+│  Upcoming Decisions                         Intelligence Feed      │
+│  ────────────────                           ─────────────────      │
+│  🔴 Venture B: Kill Gate (Stage 5)          📊 Ventures in your   │
+│     3 criteria failing                       category: 34% stall  │
+│     [Review] [Decide]                        at Stage 5 pricing.  │
+│                                              Consider: flat-rate   │
+│  🟢 Venture A: Promotion Gate (Stage 13)     vs usage-based.      │
+│     All criteria passing                                           │
+│     [Approve] [Review]                      📈 Your portfolio      │
+│                                              health: 7.2/10        │
+│  EVA Advisory                               (above 6.8 avg)       │
+│  ────────────                                                      │
+│  💬 "Venture B's pricing model shows                               │
+│  signs of the 'free tier trap' pattern                             │
+│  we've seen in 23% of SaaS ventures..."                           │
+│                                                                    │
+│  [Ask EVA a question...]                                           │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+## Success Criteria
+- **Demand Validation (Phase 0)**: 50+ qualified waitlist signups, 20+ customer interviews completed, clear willingness-to-pay signal from ≥5 potential customers
+- **MVP (Phase 1)**: 5-10 founding customers active, ≥3 ventures created per customer, NPS ≥40 from founding customers
+- **Product-Market Fit (Phase 2)**: 50+ paying customers, $15K+ MRR, <10% monthly churn, ≥1 customer success story (venture reaching Stage 10+)
+- **Intelligence Layer (Phase 3)**: Cross-venture benchmarking active, ≥1 enterprise customer ($999+/month), 200+ ventures generating learning data
+- **Kill Metric**: If <10 paying customers within 6 months of Phase 1 launch, redirect engineering effort back to core EHG ventures
+- **Resource Guardrail**: Genesis team never exceeds 3 FTE; if support burden requires >3 FTE, either raise prices or reduce scope

--- a/docs/plans/pre-development-artifact-checklist-architecture.md
+++ b/docs/plans/pre-development-artifact-checklist-architecture.md
@@ -1,0 +1,65 @@
+# Architecture Plan: Pre-Development Artifact Checklist & Quality Gates
+
+## Stack & Repository Decisions
+- **Repositories**: EHG_Engineer (LEO Protocol gate infrastructure)
+- **Runtime**: Node.js (existing gate system)
+- **Database**: Supabase (PostgreSQL) — extends existing `leo_validation_rules` table
+- **Existing Infrastructure (Fully Reusable)**: BaseExecutor (1,021 LOC), ValidationOrchestrator (949 LOC), PLAN-TO-EXEC gates (16+ existing), SD Type Validation (`lib/utils/sd-type-validation.js`), Progressive Preflight (`scripts/phase-preflight.js`, 782 LOC), database-driven `leo_validation_rules`
+- **New Dependencies**: None required
+
+## Legacy Deprecation Plan
+N/A — additive gates within existing infrastructure. All existing PLAN-TO-EXEC gates continue to function unchanged. New gates are registered alongside existing ones using the same ValidationOrchestrator pattern.
+
+## Route & Component Structure
+
+### EHG_Engineer (Backend)
+- `scripts/modules/handoff/executors/plan-to-exec/gates/pre-exec-readiness.js` — **New** (150 LOC): Unified artifact readiness gate. Aggregates brainstorm, vision, architecture, PRD, and EVA registration checks. Type-aware requirements matrix. Returns structured readiness report.
+- `scripts/modules/handoff/executors/plan-to-exec/gates/eva-registration-gate.js` — **New** (120 LOC): Validates EVA vision and architecture documents exist and are registered. Advisory mode initially. Checks `eva_vision_documents` and `eva_architecture_plans` tables.
+- `scripts/modules/handoff/executors/plan-to-exec/gates/exec-checklist-gate.js` — **New** (60 LOC): Validates PRD `exec_checklist` exists and has ≥1 item before EXEC phase (currently only checked post-EXEC).
+- `scripts/modules/handoff/executors/plan-to-exec/gates/exploration-audit-enforcement.js` — **Modified** (20 LOC): Elevate existing exploration audit from advisory to blocking for feature/infrastructure/database SD types.
+- `scripts/modules/handoff/executors/plan-to-exec/gates/orchestrator-coherence.js` — **New** (150 LOC): For parent SDs, validate all children have completed LEAD. For child SDs, validate parent is in EXEC. Moves logic from phase-preflight.js into formal gate.
+- `scripts/modules/handoff/executors/plan-to-exec/gates/index.js` — **Modified**: Register new gates in the gate array.
+- `lib/utils/artifact-requirements.js` — **New** (80 LOC): Type-aware artifact requirements matrix. Exports `getRequiredArtifacts(sdType)` returning which artifacts are required/optional/exempt per SD type.
+
+## Data Layer
+
+### New Tables
+None — uses existing tables. Gate results stored in existing `sd_phase_handoffs` JSONB `gate_results` field.
+
+### Existing Tables Used
+- `strategic_directives_v2` — SD metadata, type, parent_sd_id
+- `product_requirements_v2` — PRD existence, status, exec_checklist
+- `eva_vision_documents` — Vision document registration
+- `eva_architecture_plans` — Architecture plan registration
+- `brainstorm_sessions` — Brainstorm document existence (via document_path or created_sd_id)
+- `leo_validation_rules` — Dynamic gate configuration (advisory vs blocking per type)
+- `sd_phase_handoffs` — Gate results storage
+
+### RLS
+No changes — uses existing service role access for gate validation.
+
+## API Surface
+No new endpoints — gates are internal to the handoff system. Results surface through:
+- `npm run sd:next` — artifact readiness badges per SD
+- `node scripts/handoff.js execute PLAN-TO-EXEC <SD-ID>` — gate pass/fail with readiness report
+- `node scripts/phase-preflight.js PLAN-TO-EXEC <SD-ID>` — fast-fail preflight output
+
+## Implementation Phases
+- **Phase 1** (2 weeks): Core Gates — Create `pre-exec-readiness.js` unified gate (~150 LOC). Create `artifact-requirements.js` type-aware matrix (~80 LOC). Register in `plan-to-exec/gates/index.js`. Configure as advisory in `leo_validation_rules`. Add artifact readiness badges to `sd:next` output.
+- **Phase 2** (1 week): Quality Elevation — Promote readiness gate to blocking for feature/infrastructure. Create `eva-registration-gate.js` (~120 LOC, advisory). Create `exec-checklist-gate.js` (~60 LOC). Elevate exploration audit to blocking (~20 LOC change). Add artifact quality scoring (brainstorm has team analysis, vision has dimensions, architecture has phases).
+- **Phase 3** (1 week): Orchestrator and Calibration — Create `orchestrator-coherence.js` (~150 LOC). Wire in phase-coverage-validator. Add Learn command correlation analysis for artifact quality vs implementation outcomes. Collect 30-day calibration data.
+
+## Testing Strategy
+- Unit tests for `artifact-requirements.js` (each SD type → expected required/optional/exempt artifacts)
+- Unit tests for `pre-exec-readiness.js` (SD with all artifacts → pass, SD missing required artifact → fail with report)
+- Unit tests for type-awareness (quick-fix SD → all artifacts exempt, feature SD → all required)
+- Integration tests for PLAN-TO-EXEC handoff with new gates (existing gates still pass, new gates evaluate correctly)
+- Edge case tests: orchestrator SD with incomplete children → coherence gate fails, documentation SD → no artifact requirements
+- Regression tests: all existing PLAN-TO-EXEC tests continue to pass (no existing gate behavior changed)
+
+## Risk Mitigation
+- **Gate fatigue**: Advisory-first for 30 days. Type-aware from day 1 (no burden on small fixes). Quick-fix/bugfix exempt. Monitor velocity metrics during advisory period — if measurable slowdown, recalibrate.
+- **Compliance theater**: Quality checks, not just existence checks. Brainstorm must have ≥3 team perspectives. Vision must have ≥5 scored dimensions. Architecture must have ≥2 implementation phases. PRD must have populated exec_checklist. Minimum content thresholds prevent boilerplate from passing.
+- **EVA coupling risk**: EVA registration gate starts advisory. Does not block PLAN-TO-EXEC until EVA intake redesign is production-ready. Gate configuration stored in `leo_validation_rules` — can be promoted to blocking via database update without code change.
+- **Breaking existing workflow**: All new gates use the same ValidationOrchestrator pattern as existing gates. BaseExecutor template method ensures consistent execution. New gates are additive — existing gate behavior unchanged. Feature flag via `leo_validation_rules` advisory/blocking mode.
+- **Stale artifact risk**: Deferred to Phase 2. If retrospective data shows stale artifacts correlate with rework, add recency check. Evidence-based, not speculative.

--- a/docs/plans/pre-development-artifact-checklist-vision.md
+++ b/docs/plans/pre-development-artifact-checklist-vision.md
@@ -1,0 +1,61 @@
+# Vision: Pre-Development Artifact Checklist & Quality Gates
+
+## Executive Summary
+EHG's LEO Protocol enforces 40+ gates across 4 phase transitions, but these gates are scattered across executor directories with no unified "readiness report" before implementation begins. The result: some SDs enter EXEC phase with complete artifact chains (brainstorm → vision → architecture → PRD → EVA registration), while others skip steps depending on developer diligence rather than systematic enforcement. This vision adds a unified Pre-EXEC Readiness Gate that aggregates artifact completeness into a single type-aware check — ensuring every SD has the prerequisite thinking done before code is written, without burdening small fixes with unnecessary ceremony.
+
+The strategic bet: well-structured artifacts are not just quality gates — they are the training data that makes LEO smarter over time. Every validated artifact chain teaches the system what good pre-development thinking looks like. The artifact gate is both a quality floor and an AI performance flywheel.
+
+## Problem Statement
+The LEO Protocol's gate system is comprehensive but fragmented. PLAN-TO-EXEC validates PRD existence, architecture verification, vision dimensions, and planning completeness — but these are separate gates with no unified "are we ready?" summary. Additionally, several artifact types are checked downstream (EVA registration at vision-dimension-completeness, PRD exec_checklist at EXEC-TO-PLAN) rather than upstream (before implementation starts). The recently shipped SD-type-aware gates (PR #1890) and progressive preflight provide the right foundation for type-specific artifact requirements — but the artifact requirements themselves haven't been formalized. The gap isn't infrastructure; it's orchestration.
+
+## Personas
+- **LEO (AI Orchestrator)**: Runs the LEAD→PLAN→EXEC pipeline. Needs clear signal on whether an SD is ready for EXEC or needs more pre-work. Currently has to evaluate 16+ individual gates at PLAN-TO-EXEC without a summary view.
+- **Chairman (Rick)**: Wants predictability. Needs confidence that when an SD enters implementation, the thinking has been done. Values the artifact chain as a decision audit trail — why did we build this, what alternatives were considered, what does success look like.
+- **EVA (AI Strategic Advisor)**: Produces vision and architecture artifacts. Needs its outputs to be systematically consumed (registered, scored, traced) rather than optionally referenced.
+- **Future Contributors**: Need the artifact chain as onboarding material. A complete brainstorm → vision → architecture → PRD chain tells a contributor everything they need to know about a feature's history and rationale.
+
+## Information Architecture
+- **Pre-EXEC Readiness Report**: Single aggregated view showing artifact completeness per SD. Lists: brainstorm (exists/missing), vision (registered/scored/missing), architecture (registered/traced/missing), PRD (exists/approved/has-exec-checklist), EVA registration (complete/partial/missing). Color-coded: green (all present), yellow (optional missing), red (required missing).
+- **Type-Aware Artifact Requirements**: Matrix of SD types × artifact requirements. Feature/infrastructure require all 5 artifacts. Fix/bugfix require only PRD. Documentation/enhancement require only PRD and exploration audit. Quick-fixes exempt from all artifact gates.
+- **Artifact Quality Scoring**: Beyond existence checks — brainstorm must have team analysis section, vision must have ≥5 dimensions scored, architecture must have implementation phases, PRD must have user stories linked to requirements. Quality thresholds prevent boilerplate artifacts from passing.
+- **Existing Infrastructure Extended**: BaseExecutor (gate template), ValidationOrchestrator (gate runner), SD Type Validation (type-aware rules), Progressive Preflight (fast-fail), Database-driven leo_validation_rules (dynamic configuration).
+
+## Key Decision Points
+- **Advisory First, Blocking Later**: Pre-EXEC Readiness Gate starts as advisory for 30 days to gather baseline data on current artifact coverage. After calibration, graduates to blocking for feature/infrastructure SDs. This addresses the Challenger's concern about adding blocking gates without evidence.
+- **Type-Aware from Day 1**: No artifact burden on quick fixes, bugfixes, or documentation SDs. The type-aware gate system (PR #1890) already provides the foundation. Artifact requirements scale with SD complexity, not applied uniformly.
+- **Quality Checks, Not Just Existence Checks**: The retrospective quality gate pattern (MEMORY.md) shows that existence alone doesn't ensure value. Brainstorm docs must contain team analysis. Vision docs must have scored dimensions. Architecture docs must have implementation phases. PRDs must have exec_checklist populated.
+- **EVA Registration Advisory Until Intake Redesign Ships**: EVA registration check starts advisory because the EVA intake redesign is still being built. Graduates to blocking once EVA intake is production-ready. This avoids coupling to a system under construction.
+- **Recency Not Enforced Initially**: Artifact staleness is a real risk but adds complexity. Defer recency checks to Phase 2 after measuring whether stale artifacts actually cause problems (evidence-based gating).
+
+## Integration Patterns
+- **PLAN-TO-EXEC Gate**: The primary enforcement point. Pre-EXEC Readiness Gate runs as part of the existing PLAN-TO-EXEC handoff, alongside the 16+ existing gates. Uses the same BaseExecutor template and ValidationOrchestrator infrastructure.
+- **Progressive Preflight**: Artifact completeness as a fast-fail preflight check. Before full PLAN-TO-EXEC evaluation, preflight verifies required artifacts exist. Saves token budget on full gate evaluation when prerequisites are clearly missing.
+- **Learn Command**: After 50+ SDs pass through artifact gates, learn can correlate artifact quality with implementation outcomes. "SDs with comprehensive architecture docs had 40% fewer mid-implementation changes." Evidence feeds back into gate calibration.
+- **Heal Command**: Extended to verify implementation against the full artifact chain, not just the PRD. Architecture promises, vision commitments, and success criteria from brainstorm docs all become verifiable against the actual codebase.
+- **sd:next Display**: Queue display shows artifact readiness status per SD. "SD-X: 4/5 artifacts ready (missing: architecture doc)" helps the chairman and LEO prioritize pre-work before implementation.
+
+## Evolution Plan
+- **Phase 1** (2 weeks): Unified Pre-EXEC Readiness Gate — Single gate aggregating artifact checks. Type-aware requirements matrix. Advisory mode for 30 days. Integrated into PLAN-TO-EXEC handoff. Dashboard output in sd:next.
+- **Phase 2** (1 week): Quality Elevation — Promote readiness gate to blocking for feature/infrastructure SDs. Add artifact quality scoring (not just existence). EVA registration gate (advisory). Exploration audit elevated to blocking.
+- **Phase 3** (1 week): Orchestrator Coherence — PLAN-TO-EXEC orchestrator coherence validation. PRD exec_checklist validation. Phase coverage validator wired in. Learn command correlation analysis.
+
+## Out of Scope
+- Auto-generating artifacts (future — LEO drafts artifacts based on brainstorm input)
+- Artifact versioning and change tracking (future — diff between vision v1 and v2)
+- Artifact recency enforcement (deferred to Phase 2 pending evidence)
+- Cross-SD artifact dependency resolution (future — SD-Y depends on SD-X's architecture)
+- External reviewer workflow (future — human review of artifact quality)
+- Genesis customer-facing artifact pipeline (handled by Genesis SD)
+
+## UI/UX Wireframes
+N/A — this surfaces through existing interfaces: sd:next queue display (artifact readiness badges), handoff system output (gate pass/fail with missing artifacts), and progressive preflight output (fast-fail on missing prerequisites).
+
+## Success Criteria
+- Unified Pre-EXEC Readiness Gate operational for all SD types
+- Type-aware artifact requirements: feature/infrastructure require 5 artifacts, fix/bugfix require 1, quick-fix exempt
+- Zero blocking-gate false positives on Tier 1/2 work items (quick fixes pass without ceremony)
+- Artifact quality checks prevent boilerplate from passing (brainstorm has team analysis, vision has scored dimensions)
+- After 30-day advisory period: baseline data on current artifact coverage collected
+- After blocking promotion: <10% of feature/infrastructure SDs fail readiness gate (indicating upstream pipeline produces artifacts consistently)
+- Learn command correlation: measurable relationship between artifact quality and implementation outcomes (positive or null — data decides)
+- No measurable velocity decrease for Tier 1/2 work items (quick fixes unaffected)


### PR DESCRIPTION
## Summary
- 7 brainstorm documents from chairman's final cut research items, each with full 3-agent team analysis (Challenger/Visionary/Pragmatist)
- 7 vision documents with executive summaries, personas, information architecture, key decisions, evolution plans, and success criteria
- 7 architecture plans with stack decisions, route/component structures, data layer designs, API surfaces, implementation phases, testing strategies, and risk mitigation
- Items: Autonomous Consultant Agent, Continuous Competitor Monitoring, EVA Chat Route & Dynamic Canvas, Design as Competitive Advantage, 5-10X Value Multiplier Methodology, Genesis Venture Factory Offering, Pre-Development Artifact Checklist & Quality Gates
- All items registered in EVA (vision + architecture) with brainstorm session records and SDs created in database

## Test plan
- [x] All files are markdown documentation — no runtime behavior changes
- [x] Smoke tests pass (15/15)
- [x] DOCMON compliance check passed (passive voice warnings only, non-blocking)
- [x] EVA registrations verified in database
- [x] SDs created and linked to brainstorm sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)