### PR TITLE
docs: align stages_v2.yaml with corrected stage names 7-10

### DIFF
--- a/docs/guides/workflow/stages_v2.yaml
+++ b/docs/guides/workflow/stages_v2.yaml
@@ -344,7 +344,7 @@ stages:
 
   - id: 7
     title: "Revenue Architecture"
-    design_spec_title: "Pricing Strategy"
+    design_spec_title: "Revenue Architecture"
     description: "Pricing model development, tier structure, and value-based pricing analysis."
     phase_number: 2
     phase_name: "THE ENGINE"
@@ -368,6 +368,7 @@ stages:
 
   - id: 8
     title: "Business Model Canvas"
+    design_spec_title: "Business Model Canvas"
     description: "Complete business model documentation using BMC framework."
     phase_number: 2
     phase_name: "THE ENGINE"
@@ -391,7 +392,7 @@ stages:
 
   - id: 9
     title: "Exit Strategy"
-    design_spec_title: "Exit-Oriented Design"
+    design_spec_title: "Exit Strategy"
     description: "Strategic exit planning, valuation targets, and acquisition-friendly architecture."
     phase_number: 2
     phase_name: "THE ENGINE"
@@ -418,7 +419,7 @@ stages:
   # ============================================================================
   - id: 10
     title: "Customer & Brand Foundation"
-    design_spec_title: "Strategic Naming"
+    design_spec_title: "Customer & Brand Foundation"
     description: "Customer personas, brand genome grounded in persona insights, naming, and Chairman governance gate."
     phase_number: 3
     phase_name: "THE IDENTITY"


### PR DESCRIPTION
## Summary
- Update `design_spec_title` values in `stages_v2.yaml` for stages 7-10 to match corrected `venture-workflow.ts` names
- Add missing `design_spec_title` for stage 8 (Business Model Canvas)

## Changes
| Stage | Old design_spec_title | New design_spec_title |
|-------|----------------------|----------------------|
| 7 | Pricing Strategy | Revenue Architecture |
| 8 | (missing) | Business Model Canvas |
| 9 | Exit-Oriented Design | Exit Strategy |
| 10 | Strategic Naming | Customer & Brand Foundation |

## Test plan
- [x] YAML valid (no syntax errors)
- [x] design_spec_title values match venture-workflow.ts stageName values

Companion to rickfelix/ehg#245
SD: SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)