### PR TITLE
feat: add 5-10X value multiplier methodology

### DIFF
--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -17,6 +17,7 @@
 
 import { evaluateDecision } from '../../../eva/decision-filter-engine.js';
 import { ChairmanPreferenceStore } from '../../../eva/chairman-preference-store.js';
+import { CompetitiveBaselineService } from '../../../discovery/competitive-baseline-service.js';
 import { randomUUID } from 'crypto';
 
 // ── Gate Configuration ──────────────────────────────────────────────
@@ -26,6 +27,12 @@ import { randomUUID } from 'crypto';
  * if Filter Engine thresholds fail.
  */
 const KILL_GATE_STAGES = new Set([3, 5, 13, 23]);
+
+/**
+ * Advisory gate stages: non-blocking value multiplier assessments
+ * at stage 5 (post-discovery) and stage 13 (pre-scale).
+ */
+const ADVISORY_GATE_STAGES = new Set([5, 13]);
 
 /**
  * Promotion gate stages: checkpoints where ventures need
@@ -100,7 +107,20 @@ export async function validateStageGate(supabase, ventureId, fromStage, toStage,
 
   // Check kill gates (FR-1)
   if (KILL_GATE_STAGES.has(toStage)) {
-    return evaluateKillGate(supabase, ventureId, fromStage, toStage, options);
+    const killResult = await evaluateKillGate(supabase, ventureId, fromStage, toStage, options);
+
+    // Run advisory value multiplier assessment at stages 5 and 13 (non-blocking)
+    if (ADVISORY_GATE_STAGES.has(toStage)) {
+      try {
+        const advisory = await evaluateAdvisoryValueMultiplierGate(supabase, ventureId, toStage, options);
+        killResult.advisory = advisory;
+      } catch (err) {
+        logger.warn(`   Advisory gate error at stage ${toStage} (non-blocking): ${err.message}`);
+        killResult.advisory = { passed: true, error: err.message };
+      }
+    }
+
+    return killResult;
   }
 
   // Check promotion gates (FR-2)
@@ -422,6 +442,69 @@ function buildSummary(gateType, stage, status, evaluatedThresholds) {
   return summary;
 }
 
+// ── Advisory Value Multiplier Gate ───────────────────────────────────
+
+/**
+ * Evaluate advisory value multiplier gate (non-blocking).
+ *
+ * Always returns passed: true. Logs assessment to venture_artifacts
+ * as value_multiplier_assessment type.
+ *
+ * Stage 5 requires at least ASSUMPTION-level evidence.
+ * Stage 13 requires FACT-level evidence.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} ventureId - Venture ID
+ * @param {number} toStage - Target stage (5 or 13)
+ * @param {Object} options - Gate options
+ * @returns {Promise<Object>} Advisory result (always passed: true)
+ */
+async function evaluateAdvisoryValueMultiplierGate(supabase, ventureId, toStage, options = {}) {
+  const logger = options.logger || console;
+  logger.log(`   Evaluating Advisory Value Multiplier Gate for stage ${toStage}`);
+
+  const service = new CompetitiveBaselineService(supabase);
+
+  try {
+    const assessment = await service.computeMultiplierAssessment(ventureId, options.stageOutput || {});
+
+    // Evidence quality check
+    const requiredEpistemic = toStage >= 13 ? 'FACT' : 'ASSUMPTION';
+    const epistemicOrder = ['UNKNOWN', 'SIMULATION', 'ASSUMPTION', 'FACT'];
+    const actualLevel = epistemicOrder.indexOf(assessment.epistemic);
+    const requiredLevel = epistemicOrder.indexOf(requiredEpistemic);
+    const meetsEvidenceBar = actualLevel >= requiredLevel;
+
+    const advisoryResult = {
+      passed: true, // Advisory gates are always non-blocking
+      gate_name: `ADVISORY_VALUE_MULTIPLIER_STAGE_${toStage}`,
+      assessment,
+      meets_evidence_bar: meetsEvidenceBar,
+      required_epistemic: requiredEpistemic,
+      recommendation: meetsEvidenceBar
+        ? `Value multiplier ${assessment.lower}x-${assessment.upper}x (confidence: ${assessment.confidence})`
+        : `Evidence quality ${assessment.epistemic} below required ${requiredEpistemic}. Consider gathering more data.`,
+    };
+
+    // Log to venture_artifacts for tracking
+    await supabase.from('venture_artifacts').insert({
+      venture_id: ventureId,
+      lifecycle_stage: toStage,
+      artifact_type: 'value_multiplier_assessment',
+      artifact_data: advisoryResult,
+      is_current: true,
+    }).then(({ error }) => {
+      if (error) logger.warn(`   Failed to log advisory artifact: ${error.message}`);
+    });
+
+    return advisoryResult;
+  } catch (err) {
+    // Fail open - advisory gates never block
+    logger.warn(`   Advisory value multiplier gate error (non-blocking): ${err.message}`);
+    return { passed: true, error: err.message };
+  }
+}
+
 // ── Existing Gates (Preserved - FR-4) ───────────────────────────────
 
 /**
@@ -687,6 +770,7 @@ async function validateDeploymentHealthGate(supabase, ventureId) {
 export {
   KILL_GATE_STAGES,
   PROMOTION_GATE_STAGES,
+  ADVISORY_GATE_STAGES,
   GATE_TYPE,
   GATE_STATUS,
   FILTER_PREFERENCE_KEYS,
@@ -696,6 +780,7 @@ export {
 export const _internal = {
   evaluateKillGate,
   evaluatePromotionGate,
+  evaluateAdvisoryValueMultiplierGate,
   resolveGateContext,
   buildSummary,
   validateFinancialViabilityGate,

--- a/lib/discovery/competitive-baseline-service.js
+++ b/lib/discovery/competitive-baseline-service.js
@@ -1,0 +1,211 @@
+/**
+ * Competitive Baseline Service
+ * SD: SD-LEO-INFRA-10X-VALUE-MULTIPLIER-001
+ *
+ * CRUD service for per-venture competitor data stored in
+ * the `competitive_baselines` table. Provides multiplier
+ * assessment computation with epistemic classification.
+ */
+
+const EPISTEMIC_TAGS = ['FACT', 'ASSUMPTION', 'SIMULATION', 'UNKNOWN'];
+const BASELINE_TYPES = ['COMPETITOR', 'STATUS_QUO'];
+
+const STATUS_QUO_DEFAULTS = {
+  competitor_name: 'STATUS_QUO',
+  baseline_type: 'STATUS_QUO',
+  pricing_data: { model: 'manual_process', cost_per_unit: 0 },
+  feature_coverage: { automation: 0, analytics: 0, integration: 0 },
+  performance_metrics: { speed: 'manual', accuracy: 'variable', uptime: null },
+  epistemic_tag: 'ASSUMPTION',
+};
+
+class CompetitiveBaselineService {
+  constructor(supabase) {
+    this.supabase = supabase;
+  }
+
+  /**
+   * Create a new competitive baseline entry.
+   * @param {Object} baseline
+   * @returns {Promise<Object>} Created baseline
+   */
+  async create(baseline) {
+    const { data, error } = await this.supabase
+      .from('competitive_baselines')
+      .insert({
+        venture_id: baseline.venture_id,
+        competitor_name: baseline.competitor_name,
+        baseline_type: baseline.baseline_type || 'COMPETITOR',
+        pricing_data: baseline.pricing_data || {},
+        feature_coverage: baseline.feature_coverage || {},
+        performance_metrics: baseline.performance_metrics || {},
+        epistemic_tag: baseline.epistemic_tag || 'UNKNOWN',
+      })
+      .select()
+      .single();
+
+    if (error) throw new Error(`Failed to create baseline: ${error.message}`);
+    return data;
+  }
+
+  /**
+   * Get all baselines for a venture.
+   * @param {string} ventureId
+   * @returns {Promise<Array>} Baselines
+   */
+  async getByVentureId(ventureId) {
+    const { data, error } = await this.supabase
+      .from('competitive_baselines')
+      .select('*')
+      .eq('venture_id', ventureId)
+      .order('created_at', { ascending: true });
+
+    if (error) throw new Error(`Failed to query baselines: ${error.message}`);
+    return data || [];
+  }
+
+  /**
+   * Update an existing baseline.
+   * @param {string} id
+   * @param {Object} updates
+   * @returns {Promise<Object>} Updated baseline
+   */
+  async update(id, updates) {
+    const { data, error } = await this.supabase
+      .from('competitive_baselines')
+      .update({
+        ...updates,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) throw new Error(`Failed to update baseline: ${error.message}`);
+    return data;
+  }
+
+  /**
+   * Ensure at least one baseline exists for a venture.
+   * If none exist, auto-creates a STATUS_QUO baseline.
+   * @param {string} ventureId
+   * @returns {Promise<Array>} All baselines for the venture
+   */
+  async ensureBaselines(ventureId) {
+    const existing = await this.getByVentureId(ventureId);
+
+    if (existing.length === 0) {
+      const sqBaseline = await this.create({
+        venture_id: ventureId,
+        ...STATUS_QUO_DEFAULTS,
+      });
+      return [sqBaseline];
+    }
+
+    return existing;
+  }
+
+  /**
+   * Compute a value multiplier assessment for a venture.
+   *
+   * Returns confidence-bounded intervals. STATUS_QUO-only
+   * ventures get 1.5x wider intervals to reflect uncertainty.
+   *
+   * @param {string} ventureId
+   * @param {Object} ventureData - Optional venture context
+   * @returns {Promise<Object>} Assessment with { lower, upper, confidence, epistemic, baselines_used, has_real_competitors, sub_scores }
+   */
+  async computeMultiplierAssessment(ventureId, ventureData = {}) {
+    const baselines = await this.ensureBaselines(ventureId);
+    const hasRealCompetitors = baselines.some(b => b.baseline_type === 'COMPETITOR');
+
+    // Classify overall epistemic quality
+    const epistemicCounts = {};
+    for (const b of baselines) {
+      const tag = b.epistemic_tag || 'UNKNOWN';
+      epistemicCounts[tag] = (epistemicCounts[tag] || 0) + 1;
+    }
+    const dominantEpistemic = Object.entries(epistemicCounts)
+      .sort((a, b) => b[1] - a[1])[0][0];
+
+    // Sub-scores
+    const pricingScore = this._scorePricing(baselines, ventureData);
+    const featureScore = this._scoreFeatures(baselines, ventureData);
+    const performanceScore = this._scorePerformance(baselines, ventureData);
+
+    const avgScore = (pricingScore + featureScore + performanceScore) / 3;
+
+    // Confidence based on epistemic quality and data completeness
+    let confidence = 0.5;
+    if (dominantEpistemic === 'FACT') confidence = 0.85;
+    else if (dominantEpistemic === 'ASSUMPTION') confidence = 0.6;
+    else if (dominantEpistemic === 'SIMULATION') confidence = 0.45;
+    else confidence = 0.3;
+
+    // Adjust confidence by baseline count
+    if (baselines.length >= 3) confidence = Math.min(1.0, confidence + 0.1);
+
+    // Compute interval
+    const baseMultiplier = 1 + (avgScore / 100) * 9; // Maps 0-100 → 1x-10x
+    const intervalWidth = hasRealCompetitors ? 0.3 : 0.45; // STATUS_QUO gets 1.5x wider
+    const lower = Math.max(1.0, Math.round((baseMultiplier * (1 - intervalWidth)) * 100) / 100);
+    const upper = Math.round((baseMultiplier * (1 + intervalWidth)) * 100) / 100;
+
+    return {
+      lower,
+      upper,
+      confidence: Math.round(confidence * 100) / 100,
+      epistemic: dominantEpistemic,
+      baselines_used: baselines.length,
+      has_real_competitors: hasRealCompetitors,
+      sub_scores: {
+        pricing: pricingScore,
+        feature: featureScore,
+        performance: performanceScore,
+      },
+    };
+  }
+
+  _scorePricing(baselines, ventureData) {
+    if (!ventureData.pricing) return 50;
+    const competitors = baselines.filter(b => b.pricing_data?.cost_per_unit > 0);
+    if (competitors.length === 0) return 50;
+
+    const avgCompetitorCost = competitors.reduce((s, b) => s + b.pricing_data.cost_per_unit, 0) / competitors.length;
+    const ventureCost = ventureData.pricing.cost_per_unit || avgCompetitorCost;
+
+    if (ventureCost === 0 || avgCompetitorCost === 0) return 50;
+    const ratio = avgCompetitorCost / ventureCost;
+    return Math.min(100, Math.max(0, Math.round(ratio * 25)));
+  }
+
+  _scoreFeatures(baselines, ventureData) {
+    if (!ventureData.features) return 50;
+    const competitors = baselines.filter(b => b.feature_coverage && Object.keys(b.feature_coverage).length > 0);
+    if (competitors.length === 0) return 50;
+
+    let totalCoverage = 0;
+    for (const b of competitors) {
+      const values = Object.values(b.feature_coverage).filter(v => typeof v === 'number');
+      if (values.length > 0) {
+        totalCoverage += values.reduce((s, v) => s + v, 0) / values.length;
+      }
+    }
+    const avgCompCoverage = totalCoverage / competitors.length;
+
+    // Higher score when competitors have LOW coverage (more room for us)
+    return Math.min(100, Math.max(0, Math.round((1 - avgCompCoverage) * 100)));
+  }
+
+  _scorePerformance(baselines, ventureData) {
+    if (!ventureData.performance) return 50;
+    // Simple heuristic: if we have performance data and competitors don't, advantage
+    const competitorsWithPerf = baselines.filter(
+      b => b.performance_metrics && b.performance_metrics.speed && b.performance_metrics.speed !== 'manual'
+    );
+    if (competitorsWithPerf.length === 0) return 70; // No automated competitors = advantage
+    return 50; // Neutral if competitors also have performance data
+  }
+}
+
+export { CompetitiveBaselineService, EPISTEMIC_TAGS, BASELINE_TYPES, STATUS_QUO_DEFAULTS };

--- a/lib/discovery/opportunity-scorer.js
+++ b/lib/discovery/opportunity-scorer.js
@@ -27,14 +27,25 @@ const CONFIDENCE_THRESHOLDS = {
   // Below 70 = auto-rejected
 };
 
-// Scoring weights
-const SCORING_WEIGHTS = {
+// Legacy scoring weights (original 6 dimensions, preserved for backward compatibility)
+const LEGACY_SCORING_WEIGHTS = {
   market_opportunity: 0.25,
   competitive_advantage: 0.20,
   feasibility: 0.15,
   evidence_strength: 0.20,
   time_to_value: 0.10,
   risk_adjusted: 0.10
+};
+
+// Scoring weights (7 dimensions including value_multiplier)
+const SCORING_WEIGHTS = {
+  market_opportunity: 0.20,
+  competitive_advantage: 0.15,
+  feasibility: 0.15,
+  evidence_strength: 0.15,
+  time_to_value: 0.10,
+  risk_adjusted: 0.10,
+  value_multiplier: 0.15
 };
 
 class OpportunityScorer {
@@ -72,16 +83,33 @@ class OpportunityScorer {
     const evidenceScore = this.calculateEvidenceScore(opportunity);
     const timeScore = this.calculateTimeScore(opportunity);
     const riskScore = this.calculateRiskScore(opportunity);
+    const valueMultiplierScore = this.calculateValueMultiplierScore(opportunity);
+
+    // Select weights based on config
+    const weights = this.config.useLegacyWeights ? LEGACY_SCORING_WEIGHTS : SCORING_WEIGHTS;
 
     // Calculate weighted overall score
-    const overallScore = Math.round(
-      marketScore * SCORING_WEIGHTS.market_opportunity +
-      competitiveScore * SCORING_WEIGHTS.competitive_advantage +
-      feasibilityScore * SCORING_WEIGHTS.feasibility +
-      evidenceScore * SCORING_WEIGHTS.evidence_strength +
-      timeScore * SCORING_WEIGHTS.time_to_value +
-      riskScore * SCORING_WEIGHTS.risk_adjusted
-    );
+    let overallScore;
+    if (this.config.useLegacyWeights) {
+      overallScore = Math.round(
+        marketScore * weights.market_opportunity +
+        competitiveScore * weights.competitive_advantage +
+        feasibilityScore * weights.feasibility +
+        evidenceScore * weights.evidence_strength +
+        timeScore * weights.time_to_value +
+        riskScore * weights.risk_adjusted
+      );
+    } else {
+      overallScore = Math.round(
+        marketScore * weights.market_opportunity +
+        competitiveScore * weights.competitive_advantage +
+        feasibilityScore * weights.feasibility +
+        evidenceScore * weights.evidence_strength +
+        timeScore * weights.time_to_value +
+        riskScore * weights.risk_adjusted +
+        valueMultiplierScore * weights.value_multiplier
+      );
+    }
 
     // Determine box classification
     const classification = this.classifyOpportunity(opportunity, overallScore);
@@ -89,17 +117,23 @@ class OpportunityScorer {
     // Determine approval status
     const approvalStatus = this.determineApprovalStatus(overallScore);
 
+    const scores = {
+      market_opportunity: marketScore,
+      competitive_advantage: competitiveScore,
+      feasibility: feasibilityScore,
+      evidence_strength: evidenceScore,
+      time_to_value: timeScore,
+      risk_adjusted: riskScore,
+      overall: overallScore
+    };
+
+    if (!this.config.useLegacyWeights) {
+      scores.value_multiplier = valueMultiplierScore;
+    }
+
     return {
       ...opportunity,
-      scores: {
-        market_opportunity: marketScore,
-        competitive_advantage: competitiveScore,
-        feasibility: feasibilityScore,
-        evidence_strength: evidenceScore,
-        time_to_value: timeScore,
-        risk_adjusted: riskScore,
-        overall: overallScore
-      },
+      scores,
       classification,
       approval_status: approvalStatus,
       confidence_score: overallScore
@@ -213,6 +247,50 @@ class OpportunityScorer {
     }
 
     return 60; // Default
+  }
+
+  /**
+   * Calculate value multiplier score (0-100)
+   * Assesses how much value this opportunity delivers relative to competitive baselines.
+   * Returns 50 (neutral) when no data is available for backward compatibility.
+   */
+  calculateValueMultiplierScore(opportunity) {
+    let score = 50; // Neutral baseline when no data available
+
+    // Sub-score 1: Gap superiority (how much better than competitors)
+    if (opportunity.gap_analysis?.superiority_factor) {
+      const superiority = opportunity.gap_analysis.superiority_factor;
+      if (superiority >= 5) score += 25;
+      else if (superiority >= 3) score += 15;
+      else if (superiority >= 1.5) score += 5;
+    }
+
+    // Sub-score 2: Competitive baseline evidence quality
+    if (opportunity.competitive_baselines?.length > 0) {
+      const baselines = opportunity.competitive_baselines;
+      const factCount = baselines.filter(b => b.epistemic_tag === 'FACT').length;
+      const ratio = factCount / baselines.length;
+      if (ratio >= 0.7) score += 15;
+      else if (ratio >= 0.3) score += 8;
+    }
+
+    // Sub-score 3: Direct value multiplier data
+    if (opportunity.value_multiplier_estimate) {
+      const mult = opportunity.value_multiplier_estimate;
+      if (mult >= 10) score += 10;
+      else if (mult >= 5) score += 7;
+      else if (mult >= 2) score += 3;
+    }
+
+    // Sub-score 4: Moat/defensibility signals
+    if (opportunity.moat_indicators) {
+      const moat = opportunity.moat_indicators;
+      if (moat.network_effects) score += 5;
+      if (moat.switching_costs) score += 5;
+      if (moat.data_advantage) score += 5;
+    }
+
+    return Math.min(100, Math.max(0, score));
   }
 
   /**
@@ -391,4 +469,4 @@ class OpportunityScorer {
 }
 
 export default OpportunityScorer;
-export { BOX_THRESHOLDS, CONFIDENCE_THRESHOLDS, SCORING_WEIGHTS };
+export { BOX_THRESHOLDS, CONFIDENCE_THRESHOLDS, SCORING_WEIGHTS, LEGACY_SCORING_WEIGHTS };

--- a/lib/eva/cross-venture-learning.js
+++ b/lib/eva/cross-venture-learning.js
@@ -324,10 +324,11 @@ async function analyzeCrossVenturePatterns(supabase, options = {}) {
   }
 
   // Step 3: Run analyses in parallel for efficiency
-  const [killStageFrequency, failedAssumptions, successPatterns] = await Promise.all([
+  const [killStageFrequency, failedAssumptions, successPatterns, multiplierCalibration] = await Promise.all([
     analyzeKillStageFrequency(supabase, ventureIds),
     analyzeFailedAssumptions(supabase, ventureIds),
     analyzeSuccessPatterns(supabase, ventureIds, ventures),
+    analyzeMultiplierCalibration(supabase, ventureIds, ventures),
   ]);
 
   // Step 4: Build report
@@ -336,6 +337,7 @@ async function analyzeCrossVenturePatterns(supabase, options = {}) {
     killStageFrequency,
     failedAssumptions,
     successPatterns,
+    multiplierCalibration,
     metadata: {
       generatedAt: new Date().toISOString(),
       ventureCount: ventures.length,
@@ -346,6 +348,97 @@ async function analyzeCrossVenturePatterns(supabase, options = {}) {
         dateTo: options.dateTo || null,
       },
     },
+  };
+}
+
+/**
+ * Analyze value multiplier calibration across completed ventures.
+ * Compares stage-5 value_multiplier_assessment artifacts vs stage-13+
+ * outcomes for completed ventures.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string[]} ventureIds
+ * @param {Array<{id: string, current_lifecycle_stage: number, status: string}>} ventures
+ * @returns {Promise<Object>} Calibration analysis
+ */
+async function analyzeMultiplierCalibration(supabase, ventureIds, ventures) {
+  // Only analyze ventures that have reached stage 13+
+  const completedVentures = ventures.filter(v => v.current_lifecycle_stage >= 13);
+
+  if (completedVentures.length < MIN_VENTURES) {
+    return {
+      status: 'insufficient_data',
+      sample_size: completedVentures.length,
+      minimum_required: MIN_VENTURES,
+    };
+  }
+
+  const completedIds = completedVentures.map(v => v.id);
+
+  // Fetch stage-5 and stage-13 value_multiplier_assessment artifacts
+  const { data: artifacts, error } = await supabase
+    .from('venture_artifacts')
+    .select('venture_id, lifecycle_stage, artifact_data')
+    .in('venture_id', completedIds)
+    .eq('artifact_type', 'value_multiplier_assessment')
+    .in('lifecycle_stage', [5, 13])
+    .eq('is_current', true);
+
+  if (error) {
+    return { status: 'error', message: error.message };
+  }
+
+  if (!artifacts || artifacts.length === 0) {
+    return { status: 'no_assessments', sample_size: 0 };
+  }
+
+  // Group by venture, match stage-5 estimate vs stage-13 outcome
+  const ventureAssessments = {};
+  for (const a of artifacts) {
+    if (!ventureAssessments[a.venture_id]) {
+      ventureAssessments[a.venture_id] = {};
+    }
+    ventureAssessments[a.venture_id][`stage_${a.lifecycle_stage}`] = a.artifact_data;
+  }
+
+  const calibrationPoints = [];
+  for (const [ventureId, stages] of Object.entries(ventureAssessments)) {
+    const stage5 = stages.stage_5;
+    const stage13 = stages.stage_13;
+
+    if (stage5?.assessment && stage13?.assessment) {
+      const estimated = (stage5.assessment.lower + stage5.assessment.upper) / 2;
+      const actual = (stage13.assessment.lower + stage13.assessment.upper) / 2;
+      const bias = round2(estimated - actual);
+
+      calibrationPoints.push({
+        venture_id: ventureId,
+        estimated,
+        actual,
+        bias,
+        stage5_confidence: stage5.assessment.confidence,
+        stage13_confidence: stage13.assessment.confidence,
+      });
+    }
+  }
+
+  if (calibrationPoints.length === 0) {
+    return { status: 'no_paired_data', sample_size: 0 };
+  }
+
+  const avgBias = round2(calibrationPoints.reduce((s, p) => s + p.bias, 0) / calibrationPoints.length);
+
+  return {
+    status: 'complete',
+    sample_size: calibrationPoints.length,
+    avg_bias: avgBias,
+    bias_direction: avgBias > 0.5 ? 'optimistic' : avgBias < -0.5 ? 'pessimistic' : 'well_calibrated',
+    calibration_points: calibrationPoints,
+    recommendation: avgBias > 0.5
+      ? 'Stage-5 estimates tend to be optimistic. Consider applying a discount factor.'
+      : avgBias < -0.5
+        ? 'Stage-5 estimates tend to be pessimistic. Opportunities may be undervalued.'
+        : 'Estimation accuracy is within acceptable bounds.',
   };
 }
 
@@ -604,6 +697,7 @@ export {
   analyzeKillStageFrequency,
   analyzeFailedAssumptions,
   analyzeSuccessPatterns,
+  analyzeMultiplierCalibration,
   analyzeAssumptionCalibration,
   searchSimilar,
   MODULE_VERSION,

--- a/supabase/migrations/20260309_competitive_baselines.sql
+++ b/supabase/migrations/20260309_competitive_baselines.sql
@@ -1,0 +1,27 @@
+-- Migration: Create competitive_baselines table
+-- SD: SD-LEO-INFRA-10X-VALUE-MULTIPLIER-001
+-- Purpose: Store per-venture competitor data with epistemic classification
+
+CREATE TABLE IF NOT EXISTS competitive_baselines (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id) ON DELETE CASCADE,
+  competitor_name TEXT NOT NULL,
+  baseline_type TEXT NOT NULL DEFAULT 'COMPETITOR' CHECK (baseline_type IN ('COMPETITOR', 'STATUS_QUO')),
+  pricing_data JSONB DEFAULT '{}'::jsonb,
+  feature_coverage JSONB DEFAULT '{}'::jsonb,
+  performance_metrics JSONB DEFAULT '{}'::jsonb,
+  epistemic_tag TEXT NOT NULL DEFAULT 'UNKNOWN' CHECK (epistemic_tag IN ('FACT', 'ASSUMPTION', 'SIMULATION', 'UNKNOWN')),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_competitive_baselines_venture_id ON competitive_baselines(venture_id);
+
+ALTER TABLE competitive_baselines ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on competitive_baselines"
+  ON competitive_baselines
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- Extended OpportunityScorer from 6 to 7 weighted scoring dimensions with `value_multiplier` (0.15 weight)
- Added `CompetitiveBaselineService` for per-venture competitor data with epistemic classification (FACT/ASSUMPTION/SIMULATION/UNKNOWN)
- Added advisory value multiplier stage gates at stages 5 (post-discovery) and 13 (pre-scale) — non-blocking, logged to venture_artifacts
- Added cross-venture multiplier calibration comparing stage-5 estimates vs stage-13+ outcomes
- Added `competitive_baselines` table migration with RLS and service role policy

## Test plan
- [x] Cross-venture-learning tests: 33/33 passing
- [x] Smoke tests: 15/15 passing
- [x] Backward compatibility: `useLegacyWeights` config preserves original 6-dimension scoring
- [x] Advisory gates fail-open: system errors never block venture progression

SD: SD-LEO-INFRA-10X-VALUE-MULTIPLIER-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)