### PR TITLE
feat: add STUCK_APPROVAL QA check to fleet coordinator

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -105,7 +105,6 @@ async function loadData() {
 }
 
 // ── Section: Workers ──
-
 function printWorkers(d) {
   const now = new Date();
   console.log('');
@@ -162,7 +161,6 @@ function printOrchestrator(d) {
 }
 
 // ── Section: Available ──
-
 function printAvailable(d) {
   const total = d.unclaimedChildren.length + d.unclaimedStandalone.length;
   console.log('AVAILABLE FOR CLAIM (' + total + ')');
@@ -195,7 +193,6 @@ function printAvailable(d) {
 }
 
 // ── Section: Coordination ──
-
 function printCoordination(d) {
   console.log('COORDINATION MESSAGES');
   console.log('─'.repeat(72));
@@ -223,7 +220,6 @@ function printCoordination(d) {
 }
 
 // ── Section: Health ──
-
 function printHealth(d) {
   const health = d.activeSessions.length >= 3 ? 'HEALTHY' : d.activeSessions.length >= 1 ? 'DEGRADED' : 'DOWN';
   const icon = health === 'HEALTHY' ? '[OK]' : health === 'DEGRADED' ? '[!!]' : '[XX]';
@@ -239,7 +235,6 @@ function printHealth(d) {
 }
 
 // ── Section: QA ──
-
 function printQA(d) {
   const now = Date.now();
   const issues = [];
@@ -309,6 +304,18 @@ function printQA(d) {
     });
   });
 
+  // QA 6: SDs stuck in pending_approval with no active claiming session
+  const pendingApproval = Object.values(d.sdStatusMap).filter(sd => sd.status === 'pending_approval');
+  const activeClaimSdIds = new Set(recentRaw.map(s => s.sd_id).filter(Boolean));
+  pendingApproval.filter(sd => !activeClaimSdIds.has(sd.sd_key)).forEach(sd => {
+    const shortSd = sd.sd_key.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+    issues.push({
+      severity: 'HIGH',
+      check: 'STUCK_APPROVAL',
+      msg: shortSd + ' stuck in pending_approval — no session working on it (sweep will auto-reset to draft)'
+    });
+  });
+
   // Print
   const icon = issues.length === 0 ? '[PASS]' : '[' + issues.length + ' ISSUES]';
   console.log('QA CHECKS ' + icon);
@@ -327,13 +334,10 @@ function printQA(d) {
 }
 
 // ── Section: Forecast ──
-
 async function printForecast(d) {
   const now = new Date();
   console.log('FORECAST');
   console.log('─'.repeat(72));
-
-  // ── Orchestrator Forecast ──
   const orchCompleted = d.children.filter(c => c.status === 'completed' && c.completion_date);
   const orchRemaining = d.children.filter(c => c.status !== 'completed');
 
@@ -383,9 +387,7 @@ async function printForecast(d) {
   }
 
   console.log('');
-
-  // ── Full Queue Forecast ──
-  // Get ALL pending SDs across the entire queue (not just orchestrator)
+  // Full Queue Forecast — all pending SDs across the entire queue
   const { data: allPending } = await supabase
     .from('strategic_directives_v2')
     .select('sd_key, title, status, priority, current_phase, progress_percentage, dependencies')

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -147,6 +147,35 @@ async function main() {
     }
   }
 
+  // 3d. QA — detect SDs stuck in pending_approval with no claiming session
+  const pendingApproval = (claimedSdStatus || []).filter(sd => sd.status === 'pending_approval');
+  // Also check standalone SDs not already in claimedSdStatus
+  const claimedKeys = new Set((claimedSdStatus || []).map(sd => sd.sd_key));
+  const { data: allPendingApproval } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, status, current_phase, progress_percentage')
+    .eq('status', 'pending_approval');
+
+  const activeClaimSdIds = new Set(classified.filter(s => s.status === 'ACTIVE').map(s => s.sd_id));
+  const stuckApproval = (allPendingApproval || []).filter(sd => !activeClaimSdIds.has(sd.sd_key));
+
+  for (const sd of stuckApproval) {
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      .update({
+        status: 'draft',
+        current_phase: 'LEAD',
+        progress_percentage: 0,
+        claiming_session_id: null,
+        is_working_on: false
+      })
+      .eq('sd_key', sd.sd_key);
+
+    if (!error) {
+      actions.push('QA: reset ' + sd.sd_key + ' from pending_approval → draft/LEAD/0% (no session working on it)');
+    }
+  }
+
   // 4. Auto-release dead sessions
   const dead = classified.filter(s => s.status === 'DEAD');
   for (const s of dead) {
@@ -375,11 +404,12 @@ async function main() {
   }
 
   // QA summary
-  const qaIssues = workingOnCompleted.length + orphanedClaims.length;
+  const qaIssues = workingOnCompleted.length + orphanedClaims.length + stuckApproval.length;
   if (qaIssues > 0) {
     console.log('QA FIXES (' + qaIssues + '):');
     if (workingOnCompleted.length > 0) console.log('  Released ' + workingOnCompleted.length + ' session(s) working on completed SDs');
     if (orphanedClaims.length > 0) console.log('  Released ' + orphanedClaims.length + ' session(s) with orphaned claims');
+    if (stuckApproval.length > 0) console.log('  Reset ' + stuckApproval.length + ' SD(s) from pending_approval → draft (no session working on them)');
     console.log('');
   }
 


### PR DESCRIPTION
## Summary
- Adds QA check #6 (STUCK_APPROVAL) to `fleet-dashboard.cjs` — detects SDs in `pending_approval` with no active claiming session, flags as HIGH severity
- Adds auto-remediation to `stale-session-sweep.cjs` — resets stuck SDs to `draft/LEAD/0%` so workers can pick them up
- Updates QA summary counters in sweep output to include stuck approval fixes

## Test plan
- [x] Dashboard QA section runs cleanly (`node scripts/fleet-dashboard.cjs qa`)
- [x] Sweep detects and auto-fixes stuck `pending_approval` SDs
- [x] Verified live: sweep caught and reset `SD-LEO-FEAT-VISION-PAGE-CAPABILITY-001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)