### PR TITLE
fix: sweep release uses 'released' status to avoid unique constraint

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -114,17 +114,26 @@ async function main() {
   });
 
   for (const s of workingOnCompleted) {
+    // Use 'released' not 'idle' — stale sessions can't become 'idle' due to
+    // idx_claude_sessions_unique_terminal_active (one active/idle per terminal).
+    // Using 'idle' silently fails when another session on the same terminal exists.
+    const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
     const { error } = await supabase
       .from('claude_sessions')
       .update({
         sd_id: null,
-        status: 'idle',
+        status: targetStatus,
         released_at: now.toISOString(),
         released_reason: 'SWEEP_SD_ALREADY_COMPLETED'
       })
       .eq('session_id', s.session_id);
 
     if (!error) {
+      // Also clear claiming_session_id on the SD to break the churn loop
+      await supabase
+        .from('strategic_directives_v2')
+        .update({ claiming_session_id: null, is_working_on: false })
+        .eq('sd_key', s.sd_id);
       actions.push('QA: released ' + s.session_id + ' (' + s.tty + ') — ' + s.sd_id + ' already completed');
     }
   }
@@ -132,11 +141,12 @@ async function main() {
   // 3c. QA — detect sessions claiming SDs that don't exist
   const orphanedClaims = classified.filter(s => !sdStatusMap[s.sd_id]);
   for (const s of orphanedClaims) {
+    const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
     const { error } = await supabase
       .from('claude_sessions')
       .update({
         sd_id: null,
-        status: 'idle',
+        status: targetStatus,
         released_at: now.toISOString(),
         released_reason: 'SWEEP_ORPHANED_CLAIM'
       })
@@ -199,7 +209,7 @@ async function main() {
       .from('claude_sessions')
       .update({
         sd_id: null,
-        status: 'idle',
+        status: 'released',
         released_at: now.toISOString(),
         released_reason: 'SWEEP_PID_DEAD'
       })
@@ -222,11 +232,12 @@ async function main() {
       // Skip if already released in step 4
       if (dead.find(d => d.session_id === evict.session_id)) continue;
 
+      const targetStatus = evict.status === 'ACTIVE' ? 'idle' : 'released';
       const { error } = await supabase
         .from('claude_sessions')
         .update({
           sd_id: null,
-          status: 'idle',
+          status: targetStatus,
           released_at: now.toISOString(),
           released_reason: 'SWEEP_CONFLICT_RESOLUTION'
         })


### PR DESCRIPTION
## Summary
- Root cause fix for the Child A churn loop: stale session sweep was setting `status='idle'` when releasing sessions, but `idx_claude_sessions_unique_terminal_active` blocks this when another active/idle session exists on the same terminal
- Supabase client silently swallows 409 Conflict errors without `.select()`, so sweep logged success while updates were no-ops
- Changed all 4 release paths (completed-SD, orphaned, dead, conflict) to use `status='released'` for non-ACTIVE sessions
- Also clears `claiming_session_id` on the SD when releasing completed-SD claims

## Test plan
- [x] Manually verified the constraint error via `.select()` chain
- [x] Applied fix, ran sweep — Child A churn loop broken
- [x] Dashboard confirmed: QA issues 4→1, fleet DEGRADED→HEALTHY
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)