### PR TITLE
feat: six coordinator improvements for fleet reliability

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -537,8 +537,9 @@ async function printPredictions(d) {
     }
   }
 
-  // 3. Heartbeat aging — workers approaching stale threshold
+  // 3. Heartbeat aging — workers approaching stale threshold (FIX #5: with coordination messages)
   const STALE_WARNING = STALE_THRESHOLD * 0.6; // 60% of 5min = 3min
+  const agingWorkers = [];
   for (const s of d.activeSessions) {
     if (s.heartbeat_age_seconds >= STALE_WARNING) {
       const remaining = Math.round(STALE_THRESHOLD - s.heartbeat_age_seconds);
@@ -548,7 +549,34 @@ async function printPredictions(d) {
         label: 'AGING',
         msg: s.tty + ' on ' + shortSd + ' — heartbeat aging (' + s.heartbeat_age_human + '), stale in ~' + remaining + 's'
       });
+      agingWorkers.push(s);
     }
+  }
+
+  // Send STALE_WARNING coordination messages for aging workers
+  for (const s of agingWorkers) {
+    // Check if we already sent a stale warning recently (avoid spam)
+    const { data: existingWarn } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('target_session', s.session_id)
+      .eq('message_type', 'STALE_WARNING')
+      .is('acknowledged_at', null)
+      .limit(1);
+
+    if (existingWarn && existingWarn.length > 0) continue;
+
+    await supabase
+      .from('session_coordination')
+      .insert({
+        target_session: s.session_id,
+        target_sd: s.sd_id,
+        message_type: 'STALE_WARNING',
+        subject: 'Heartbeat aging on ' + s.sd_id.split('-').pop() + ' — approaching stale threshold',
+        body: 'Your session on ' + s.sd_id + ' has not heartbeated in ' + s.heartbeat_age_human + '. If you are still working, send a heartbeat. If stuck, consider releasing the claim.',
+        payload: { session_id: s.session_id, heartbeat_age: s.heartbeat_age_seconds, stale_threshold: STALE_THRESHOLD },
+        sender_type: 'dashboard'
+      }).then(() => {}).catch(() => {}); // Non-blocking
   }
 
   // Print

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -163,30 +163,66 @@ async function main() {
   const claimedKeys = new Set((claimedSdStatus || []).map(sd => sd.sd_key));
   const { data: allPendingApproval } = await supabase
     .from('strategic_directives_v2')
-    .select('sd_key, status, current_phase, progress_percentage')
+    .select('sd_key, status, current_phase, progress_percentage, completion_date')
     .eq('status', 'pending_approval');
 
   const activeClaimSdIds = new Set(classified.filter(s => s.status === 'ACTIVE').map(s => s.sd_id));
   const stuckApproval = (allPendingApproval || []).filter(sd => !activeClaimSdIds.has(sd.sd_key));
 
   for (const sd of stuckApproval) {
-    const { error } = await supabase
-      .from('strategic_directives_v2')
-      .update({
-        status: 'draft',
-        current_phase: 'LEAD',
-        progress_percentage: 0,
-        claiming_session_id: null,
-        is_working_on: false
-      })
-      .eq('sd_key', sd.sd_key);
+    // FIX #1: STUCK_100 — if at 100% with completion_date, mark completed instead of resetting
+    if (sd.progress_percentage >= 100 && sd.completion_date) {
+      const { error } = await supabase
+        .from('strategic_directives_v2')
+        .update({
+          status: 'completed',
+          claiming_session_id: null,
+          is_working_on: false
+        })
+        .eq('sd_key', sd.sd_key)
+        .select();
 
-    if (!error) {
-      actions.push('QA: reset ' + sd.sd_key + ' from pending_approval → draft/LEAD/0% (no session working on it)');
+      if (!error) {
+        actions.push('QA: completed ' + sd.sd_key + ' — was stuck at 100%/pending_approval with completion_date');
+      }
+    } else {
+      const { error } = await supabase
+        .from('strategic_directives_v2')
+        .update({
+          status: 'draft',
+          current_phase: 'LEAD',
+          progress_percentage: 0,
+          claiming_session_id: null,
+          is_working_on: false
+        })
+        .eq('sd_key', sd.sd_key);
+
+      if (!error) {
+        actions.push('QA: reset ' + sd.sd_key + ' from pending_approval → draft/LEAD/0% (no session working on it)');
+      }
     }
   }
 
-  // 3e. QA — detect bare-shell SDs (title == description, no real scope)
+  // FIX #2: Proactively clear stale claiming_session_id on completed SDs to prevent churn
+  const { data: completedWithClaims } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, claiming_session_id, is_working_on')
+    .eq('status', 'completed')
+    .not('claiming_session_id', 'is', null);
+
+  for (const sd of (completedWithClaims || [])) {
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      .update({ claiming_session_id: null, is_working_on: false })
+      .eq('sd_key', sd.sd_key)
+      .select();
+
+    if (!error) {
+      actions.push('QA: cleared stale claiming_session_id on completed ' + sd.sd_key);
+    }
+  }
+
+  // 3e. QA — detect and auto-enrich bare-shell SDs (FIX #6)
   const { data: pendingSDs } = await supabase
     .from('strategic_directives_v2')
     .select('sd_key, title, description, scope')
@@ -197,8 +233,57 @@ async function main() {
     return !sd.description || sd.description === sd.title || (sd.description.length < 100 && sd.scope === sd.title);
   });
   if (bareShellSDs.length > 0) {
+    const fs = require('fs');
+    const path = require('path');
+    const repoRoot = path.resolve(__dirname, '..');
+    const searchDirs = ['docs/audits', 'docs/plans', 'brainstorm'].map(d => path.join(repoRoot, d));
+
     for (const sd of bareShellSDs) {
-      warnings.push('BARE_SHELL: ' + sd.sd_key + ' has no real description — workers will waste cycles');
+      // Try to find matching content in docs/audits, docs/plans, brainstorm
+      const keywords = sd.title.toLowerCase().split(/[\s\-_]+/).filter(w => w.length > 3);
+      let bestMatch = null;
+      let bestScore = 0;
+
+      for (const dir of searchDirs) {
+        if (!fs.existsSync(dir)) continue;
+        const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
+        for (const file of files) {
+          const nameLower = file.toLowerCase();
+          const score = keywords.filter(kw => nameLower.includes(kw)).length;
+          if (score > bestScore) {
+            bestScore = score;
+            bestMatch = path.join(dir, file);
+          }
+        }
+      }
+
+      if (bestMatch && bestScore >= 2) {
+        // Read up to 2000 chars from the matching file for description enrichment
+        const content = fs.readFileSync(bestMatch, 'utf8').substring(0, 2000);
+        // Extract first paragraph or summary section
+        const lines = content.split('\n').filter(l => l.trim() && !l.startsWith('#'));
+        const summary = lines.slice(0, 10).join('\n').substring(0, 500);
+
+        if (summary.length > 50) {
+          const { error } = await supabase
+            .from('strategic_directives_v2')
+            .update({
+              description: sd.title + '\n\n' + summary + '\n\n[Auto-enriched by sweep from ' + path.basename(bestMatch) + ']'
+            })
+            .eq('sd_key', sd.sd_key)
+            .select();
+
+          if (!error) {
+            actions.push('ENRICH: ' + sd.sd_key + ' — description populated from ' + path.basename(bestMatch));
+          } else {
+            warnings.push('BARE_SHELL: ' + sd.sd_key + ' — enrichment failed: ' + error.message);
+          }
+        } else {
+          warnings.push('BARE_SHELL: ' + sd.sd_key + ' — found ' + path.basename(bestMatch) + ' but content too short');
+        }
+      } else {
+        warnings.push('BARE_SHELL: ' + sd.sd_key + ' has no real description — no matching docs found');
+      }
     }
   }
 
@@ -302,6 +387,35 @@ async function main() {
 
   // Clean up expired messages first
   try { await supabase.rpc('cleanup_expired_coordination'); } catch { /* ignore */ }
+
+  // FIX #3: Clean up coordination messages targeting dead/stale sessions
+  // These accumulate because target sessions exit without reading them
+  const allSessionIds = new Set(classified.map(s => s.session_id));
+  const { data: unreadMsgs } = await supabase
+    .from('session_coordination')
+    .select('id, target_session')
+    .is('acknowledged_at', null)
+    .is('read_at', null);
+
+  const deadMsgIds = (unreadMsgs || [])
+    .filter(m => !allSessionIds.has(m.target_session))
+    .map(m => m.id);
+
+  // Also include messages targeting sessions classified as DEAD or stale
+  const deadOrStaleIds = new Set(classified.filter(s => s.status !== 'ACTIVE').map(s => s.session_id));
+  const staleMsgIds = (unreadMsgs || [])
+    .filter(m => deadOrStaleIds.has(m.target_session))
+    .map(m => m.id);
+
+  const allDeadMsgIds = [...new Set([...deadMsgIds, ...staleMsgIds])];
+  if (allDeadMsgIds.length > 0) {
+    // Delete in batches of 50
+    for (let i = 0; i < allDeadMsgIds.length; i += 50) {
+      const batch = allDeadMsgIds.slice(i, i + 50);
+      await supabase.from('session_coordination').delete().in('id', batch);
+    }
+    actions.push('CLEANUP: deleted ' + allDeadMsgIds.length + ' unread coordination messages targeting dead/gone sessions');
+  }
 
   for (const s of activeSessions) {
     // Check if we already have an unacknowledged message for this session
@@ -431,12 +545,16 @@ async function main() {
   }
 
   // QA summary
-  const qaIssues = workingOnCompleted.length + orphanedClaims.length + stuckApproval.length;
+  const stuckCompleted = stuckApproval.filter(sd => sd.progress_percentage >= 100 && sd.completion_date);
+  const stuckReset = stuckApproval.filter(sd => !(sd.progress_percentage >= 100 && sd.completion_date));
+  const qaIssues = workingOnCompleted.length + orphanedClaims.length + stuckApproval.length + (completedWithClaims || []).length;
   if (qaIssues > 0) {
     console.log('QA FIXES (' + qaIssues + '):');
     if (workingOnCompleted.length > 0) console.log('  Released ' + workingOnCompleted.length + ' session(s) working on completed SDs');
     if (orphanedClaims.length > 0) console.log('  Released ' + orphanedClaims.length + ' session(s) with orphaned claims');
-    if (stuckApproval.length > 0) console.log('  Reset ' + stuckApproval.length + ' SD(s) from pending_approval → draft (no session working on them)');
+    if (stuckCompleted.length > 0) console.log('  Completed ' + stuckCompleted.length + ' SD(s) stuck at 100%/pending_approval');
+    if (stuckReset.length > 0) console.log('  Reset ' + stuckReset.length + ' SD(s) from pending_approval → draft (no session working on them)');
+    if ((completedWithClaims || []).length > 0) console.log('  Cleared ' + (completedWithClaims || []).length + ' stale claiming_session_id on completed SDs');
     console.log('');
   }
 


### PR DESCRIPTION
## Summary
- **STUCK_100 auto-fix**: SDs at 100%/pending_approval with completion_date are auto-completed (not reset to draft), breaking the churn loop where workers re-claim completed SDs
- **Churn prevention**: Proactively clears `claiming_session_id` on all completed SDs every sweep cycle — prevents workers from seeing completed SDs as claimable
- **Dead message cleanup**: Deletes unread coordination messages targeting sessions that no longer exist, reducing message noise from 20+ down to only active targets
- **Bare shell enrichment**: Searches `docs/audits/`, `docs/plans/`, `brainstorm/` for matching content and auto-populates empty SD descriptions so workers don't waste cycles on LEAD setup
- **Aging predictions with action**: Sends `STALE_WARNING` coordination messages to workers approaching the stale threshold (60% of 5min), not just displaying warnings
- **Automated cron loops**: Sweep runs every 5min, dashboard every 5min offset — both via CronCreate (session-scoped)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Sweep first-run: cleared 318 stale claiming_session_id, enriched 1 bare shell SD, deleted 81 dead messages
- [x] Dashboard: predictions section sends STALE_WARNING messages, all sections render correctly
- [x] Cron jobs created for both sweep and dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)