### PR TITLE
feat: auto-generate phase SDs with coverage tracking

### DIFF
--- a/scripts/create-orchestrator-from-plan.js
+++ b/scripts/create-orchestrator-from-plan.js
@@ -114,7 +114,7 @@ async function main() {
   if (archKey) {
     const { data, error } = await supabase
       .from('eva_architecture_plans')
-      .select('plan_key, content, extracted_dimensions')
+      .select('plan_key, content, sections, extracted_dimensions')
       .eq('plan_key', archKey)
       .single();
 
@@ -123,8 +123,16 @@ async function main() {
       process.exit(1);
     }
     archPlan = data;
-    phases = parsePhases(data.content);
-    console.log(`   📋 Found ${phases.length} implementation phase(s) in architecture plan`);
+    // Prefer structured phases from JSONB sections (used by phase coverage gate)
+    // Fall back to markdown parsing for legacy plans without structured sections
+    const structuredPhases = data.sections?.implementation_phases;
+    if (structuredPhases && Array.isArray(structuredPhases) && structuredPhases.length > 0) {
+      phases = structuredPhases;
+      console.log(`   📋 Found ${phases.length} structured phase(s) in sections.implementation_phases`);
+    } else {
+      phases = parsePhases(data.content);
+      console.log(`   📋 Found ${phases.length} phase(s) parsed from architecture plan content`);
+    }
   }
 
   // Load vision document
@@ -228,11 +236,28 @@ async function main() {
     const dimensionMap = mapDimensionsToPhases(allDimensions, phases);
 
     for (const phase of phases) {
+      // FR-002: Skip phases that already have an existing SD
+      if (phase.covered_by_sd_key) {
+        const { data: existingSd } = await supabase
+          .from('strategic_directives_v2')
+          .select('sd_key, status')
+          .eq('sd_key', phase.covered_by_sd_key)
+          .single();
+
+        if (existingSd) {
+          console.log(`   ⏭️  Skip Phase ${phase.number}: ${phase.title} — covered by ${existingSd.sd_key} (${existingSd.status})`);
+          continue;
+        }
+        console.log(`   ⚠️  Phase ${phase.number}: covered_by_sd_key=${phase.covered_by_sd_key} not found — creating new SD`);
+      }
+
       const childId = randomUUID();
       const suffix = `-${String.fromCharCode(64 + phase.number)}`; // -A, -B, -C...
       const childKey = `${orchestratorKey}${suffix}`;
+      // FR-004: Handle separate_orchestrator phases (no parent, orchestrator type)
+      const isSeparateOrchestrator = phase.child_designation === 'separate_orchestrator';
       const typeResult = inferSDType(phase.title, phase.description || '', phase.content || '');
-      const childType = typeof typeResult === 'string' ? typeResult : (typeResult?.sdType || 'feature');
+      const childType = isSeparateOrchestrator ? 'orchestrator' : (typeof typeResult === 'string' ? typeResult : (typeResult?.sdType || 'feature'));
 
       // Inherit strategic fields from orchestrator
       const inherited = inheritStrategicFields(orchestratorSD, {
@@ -261,7 +286,7 @@ async function main() {
         status: 'draft',
         current_phase: 'LEAD_APPROVAL',
         priority: orchestratorSD.priority,
-        parent_sd_id: orchestratorId,
+        parent_sd_id: isSeparateOrchestrator ? null : orchestratorId,
         scope: phase.content?.trim().slice(0, 2000) || phase.description || '',
         rationale: `Phase ${phase.number} of ${title}`,
         success_metrics: phaseMetrics.length > 0 ? phaseMetrics : inherited.success_metrics || [],
@@ -296,7 +321,25 @@ async function main() {
         if (childError) {
           console.error(`   ❌ Error creating child ${childKey}: ${childError.message}`);
         } else {
-          console.log(`   ✅ Child ${childKey}: ${phase.title} (type: ${childType})`);
+          console.log(`   ✅ Child ${childKey}: ${phase.title} (type: ${childType}${isSeparateOrchestrator ? ', separate orchestrator' : ''})`);
+
+          // FR-001: Update covered_by_sd_key in architecture plan sections
+          if (archKey && archPlan?.sections?.implementation_phases) {
+            try {
+              const updatedPhases = [...archPlan.sections.implementation_phases];
+              const phaseIdx = updatedPhases.findIndex(p => p.number === phase.number);
+              if (phaseIdx !== -1) {
+                updatedPhases[phaseIdx] = { ...updatedPhases[phaseIdx], covered_by_sd_key: childKey };
+                archPlan.sections = { ...archPlan.sections, implementation_phases: updatedPhases };
+                await supabase
+                  .from('eva_architecture_plans')
+                  .update({ sections: archPlan.sections })
+                  .eq('plan_key', archKey);
+              }
+            } catch (linkErr) {
+              console.warn(`   ⚠️  Failed to link Phase ${phase.number} → ${childKey}: ${linkErr.message}`);
+            }
+          }
         }
       }
     }

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -1690,21 +1690,27 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const archKeyIdx = args.indexOf('--arch-key');
       const archKey = archKeyIdx !== -1 ? args[archKeyIdx + 1] : null;
 
-      // Advisory: suggest orchestrator creation when both vision and arch keys provided
+      // FR-003: Auto-route to orchestrator creator when arch key has phases
       if (visionKey && archKey) {
         try {
           const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
           const { data: archPlan } = await sb
             .from('eva_architecture_plans')
-            .select('content')
+            .select('content, sections')
             .eq('plan_key', archKey)
             .single();
-          if (archPlan?.content && /^##?\s*(Phase|Implementation Phase|Step)\s+\d/im.test(archPlan.content)) {
-            console.log('\n💡 Advisory: Architecture plan has implementation phases.');
-            console.log('   Consider using the orchestrator creator for multi-phase work:');
-            console.log(`   node scripts/create-orchestrator-from-plan.js --vision-key ${visionKey} --arch-key ${archKey} --title "${title}" --auto-children\n`);
+          const hasStructuredPhases = archPlan?.sections?.implementation_phases?.length > 0;
+          const hasContentPhases = archPlan?.content && /^##?\s*(Phase|Implementation Phase|Step)\s+\d/im.test(archPlan.content);
+          if (hasStructuredPhases || hasContentPhases) {
+            console.log('\n🔄 Auto-routing to orchestrator creator (architecture plan has phases)...');
+            const { execSync } = await import('child_process');
+            const cmd = `node scripts/create-orchestrator-from-plan.js --vision-key ${visionKey} --arch-key ${archKey} --title "${title}" --auto-children`;
+            execSync(cmd, { stdio: 'inherit', cwd: process.cwd() });
+            process.exit(0);
           }
-        } catch { /* Advisory only — continue regardless */ }
+        } catch (routeErr) {
+          console.warn(`\n⚠️  Auto-routing failed, continuing with single SD creation: ${routeErr.message}`);
+        }
 
         // Advisory: warn about uncovered architecture phases (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
         try {


### PR DESCRIPTION
## Summary
- Extends `create-orchestrator-from-plan.js` to auto-update `covered_by_sd_key` in architecture plan sections after creating each child SD
- Adds skip logic for phases that already have existing SDs (idempotent re-runs)
- Auto-routes `leo-create-sd.js` to orchestrator creator when architecture plan has implementation phases
- Handles `separate_orchestrator` phases with null parent and orchestrator SD type
- Prefers structured JSONB `sections.implementation_phases` over markdown parsing

## Test plan
- [ ] Run `create-orchestrator-from-plan.js --dry-run` with an architecture plan that has structured phases
- [ ] Verify `covered_by_sd_key` is updated in `eva_architecture_plans.sections` after child creation
- [ ] Verify existing SDs are skipped on re-run
- [ ] Verify `leo-create-sd.js --arch-key` auto-routes to orchestrator creator

🤖 Generated with [Claude Code](https://claude.com/claude-code)