### PR TITLE
fix: raise CLAIM_REMINDER grace period from 60s to 5min

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -396,8 +396,8 @@ async function main() {
   const claimIntegrityIssues = [];
 
   for (const s of aliveIdle) {
-    // Only nudge if idle for >60s (give time for normal claim flow after session start)
-    if (s.heartbeat_age_seconds < 60) continue;
+    // Only nudge if idle for >5min (give time for post-completion transitions: /learn, protocol reads, context compaction)
+    if (s.heartbeat_age_seconds < 300) continue;
 
     // Check if we already sent a CLAIM_REMINDER recently (avoid spam)
     const { data: existingReminder } = await supabase


### PR DESCRIPTION
## Summary
- Raises the CLAIM_REMINDER grace period from 60s to 300s (5min)
- Sessions between SDs (running /learn, protocol reads, context compaction) were getting unnecessary nudges
- Reduces coordination message noise while still catching genuinely idle sessions

## Test plan
- [x] Sweep still sends CLAIM_REMINDER to sessions idle >5min
- [x] Sessions in post-completion transitions (<5min) are no longer nudged

🤖 Generated with [Claude Code](https://claude.com/claude-code)