### PR TITLE
feat: branding service with confidence routing and telemetry

### DIFF
--- a/lib/services/branding-service.js
+++ b/lib/services/branding-service.js
@@ -1,0 +1,189 @@
+/**
+ * Branding Service — EHG Venture Factory
+ * SD: SD-LEO-ORCH-EHG-VENTURE-FACTORY-001-D
+ *
+ * Generates confidence-scored brand artifacts for ventures.
+ * Routes artifacts through the Decision Filter Engine:
+ *   - >0.85 confidence → auto-PR (auto-apply to venture repo)
+ *   - 0.5-0.85 → review-flagged PR (Chairman reviews)
+ *   - <0.5 → draft-only (stored but not applied)
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { reportTelemetry } from './telemetry.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BRANDING_SCHEMA = JSON.parse(
+  readFileSync(join(__dirname, 'schemas', 'branding-artifact.json'), 'utf8')
+);
+
+// Decision Filter Engine thresholds
+const DFE_THRESHOLDS = {
+  AUTO_APPROVE: 0.85,   // Auto-PR to venture repo
+  REVIEW_FLAG: 0.50,    // Chairman review required
+  // Below 0.50 = draft-only
+};
+
+/**
+ * Generate branding artifacts for a venture.
+ * @param {object} supabase - Supabase client
+ * @param {object} params - Task input parameters
+ * @param {string} params.venture_id - UUID of the target venture
+ * @param {string} params.brand_name - Venture brand name
+ * @param {string} [params.industry] - Industry context for generation
+ * @param {string} [params.target_audience] - Target audience description
+ * @param {string[]} [params.competitor_brands] - Competitor brand names
+ * @returns {Promise<{artifact: object, confidence_score: number, routing: string}>}
+ */
+export async function generateBrandArtifact(supabase, params) {
+  const { venture_id, brand_name, industry, target_audience, competitor_brands } = params;
+
+  // Generate brand artifacts with confidence scoring
+  const artifact = buildBrandArtifact(brand_name, industry, target_audience);
+  const confidence = computeConfidence(artifact, params);
+  const routing = classifyRouting(confidence);
+
+  // Store telemetry
+  await reportTelemetry(supabase, {
+    service_key: 'branding',
+    venture_id,
+    event_type: 'artifact_generated',
+    confidence_score: confidence,
+    routing_decision: routing,
+    metadata: {
+      brand_name,
+      industry: industry || null,
+      artifact_fields: Object.keys(artifact).length,
+    },
+  });
+
+  return { artifact, confidence_score: confidence, routing };
+}
+
+/**
+ * Build brand artifact from input parameters.
+ * Uses deterministic generation based on brand name characteristics.
+ */
+function buildBrandArtifact(brandName, industry, targetAudience) {
+  const nameHash = simpleHash(brandName);
+
+  // Color palette derived from brand name characteristics
+  const palette = generateColorPalette(nameHash, industry);
+
+  // Typography based on industry context
+  const typography = selectTypography(industry);
+
+  // Brand voice based on audience and industry
+  const voice = determineBrandVoice(industry, targetAudience);
+
+  // Logo specification
+  const logoSpec = generateLogoSpec(brandName, industry);
+
+  return {
+    venture_id: null, // Set by caller
+    brand_name: brandName,
+    tagline: generateTagline(brandName, industry),
+    color_palette: palette,
+    typography,
+    brand_voice: voice,
+    logo_spec: logoSpec,
+  };
+}
+
+/**
+ * Compute confidence score for generated artifacts.
+ * Higher confidence when more input context is provided.
+ */
+function computeConfidence(artifact, params) {
+  let score = 0.6; // Base confidence
+
+  // More context = higher confidence
+  if (params.industry) score += 0.1;
+  if (params.target_audience) score += 0.1;
+  if (params.competitor_brands?.length > 0) score += 0.05;
+
+  // Artifact completeness
+  if (artifact.tagline) score += 0.05;
+  if (artifact.logo_spec) score += 0.05;
+  if (artifact.brand_voice?.personality_traits?.length >= 3) score += 0.05;
+
+  return Math.min(1.0, Math.round(score * 100) / 100);
+}
+
+/**
+ * Classify routing decision based on confidence score.
+ * @returns {'auto_approve' | 'review_flagged' | 'draft_only'}
+ */
+function classifyRouting(confidence) {
+  if (confidence >= DFE_THRESHOLDS.AUTO_APPROVE) return 'auto_approve';
+  if (confidence >= DFE_THRESHOLDS.REVIEW_FLAG) return 'review_flagged';
+  return 'draft_only';
+}
+
+// --- Internal generation helpers ---
+
+function simpleHash(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function generateColorPalette(hash, industry) {
+  const palettes = {
+    technology: { primary: '#2563EB', secondary: '#1E40AF', accent: '#3B82F6', background: '#F8FAFC', text: '#0F172A' },
+    finance: { primary: '#047857', secondary: '#065F46', accent: '#10B981', background: '#F0FDF4', text: '#064E3B' },
+    health: { primary: '#0891B2', secondary: '#0E7490', accent: '#22D3EE', background: '#ECFEFF', text: '#164E63' },
+    education: { primary: '#7C3AED', secondary: '#6D28D9', accent: '#A78BFA', background: '#F5F3FF', text: '#4C1D95' },
+    default: { primary: '#0F766E', secondary: '#115E59', accent: '#14B8A6', background: '#F0FDFA', text: '#134E4A' },
+  };
+  return palettes[industry] || palettes.default;
+}
+
+function selectTypography(industry) {
+  const styles = {
+    technology: { heading_font: 'Inter', body_font: 'Inter', mono_font: 'JetBrains Mono', base_size_px: 16 },
+    finance: { heading_font: 'Merriweather', body_font: 'Source Sans 3', mono_font: 'Fira Code', base_size_px: 16 },
+    health: { heading_font: 'Nunito', body_font: 'Open Sans', mono_font: 'IBM Plex Mono', base_size_px: 16 },
+    education: { heading_font: 'Poppins', body_font: 'Lato', mono_font: 'Source Code Pro', base_size_px: 16 },
+    default: { heading_font: 'Inter', body_font: 'Inter', base_size_px: 16 },
+  };
+  return styles[industry] || styles.default;
+}
+
+function determineBrandVoice(industry, targetAudience) {
+  const voices = {
+    technology: { tone: 'professional', personality_traits: ['innovative', 'precise', 'forward-thinking'], writing_style: 'concise' },
+    finance: { tone: 'authoritative', personality_traits: ['trustworthy', 'reliable', 'analytical'], writing_style: 'formal' },
+    health: { tone: 'warm', personality_traits: ['caring', 'knowledgeable', 'supportive'], writing_style: 'conversational' },
+    education: { tone: 'friendly', personality_traits: ['encouraging', 'clear', 'curious'], writing_style: 'conversational' },
+    default: { tone: 'professional', personality_traits: ['reliable', 'clear'], writing_style: 'concise' },
+  };
+  return voices[industry] || voices.default;
+}
+
+function generateLogoSpec(brandName, industry) {
+  const firstChar = brandName.charAt(0).toUpperCase();
+  const isShortName = brandName.length <= 8;
+  return {
+    style: isShortName ? 'wordmark' : 'combination',
+    shape: 'rounded',
+    description: `${isShortName ? 'Wordmark' : 'Combination mark'} featuring "${firstChar}" with ${industry || 'modern'} design sensibility`,
+  };
+}
+
+function generateTagline(brandName, industry) {
+  const taglines = {
+    technology: `${brandName} — Engineering the future`,
+    finance: `${brandName} — Your financial compass`,
+    health: `${brandName} — Wellness, redefined`,
+    education: `${brandName} — Learn without limits`,
+    default: `${brandName} — Built for what matters`,
+  };
+  return taglines[industry] || taglines.default;
+}
+
+export { DFE_THRESHOLDS, BRANDING_SCHEMA, classifyRouting, computeConfidence };

--- a/lib/services/schemas/branding-artifact.json
+++ b/lib/services/schemas/branding-artifact.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Branding Artifact",
+  "description": "Output schema for the EHG Branding Service — confidence-scored brand identity artifacts",
+  "type": "object",
+  "required": ["venture_id", "brand_name", "color_palette", "typography", "brand_voice"],
+  "properties": {
+    "venture_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "UUID of the venture this branding is for"
+    },
+    "brand_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "description": "The venture's brand name"
+    },
+    "tagline": {
+      "type": "string",
+      "maxLength": 200,
+      "description": "Brand tagline or slogan"
+    },
+    "color_palette": {
+      "type": "object",
+      "required": ["primary", "secondary", "accent"],
+      "properties": {
+        "primary": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
+        "secondary": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
+        "accent": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
+        "background": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" },
+        "text": { "type": "string", "pattern": "^#[0-9a-fA-F]{6}$" }
+      },
+      "additionalProperties": false
+    },
+    "typography": {
+      "type": "object",
+      "required": ["heading_font", "body_font"],
+      "properties": {
+        "heading_font": { "type": "string" },
+        "body_font": { "type": "string" },
+        "mono_font": { "type": "string" },
+        "base_size_px": { "type": "integer", "minimum": 12, "maximum": 24, "default": 16 }
+      },
+      "additionalProperties": false
+    },
+    "brand_voice": {
+      "type": "object",
+      "required": ["tone", "personality_traits"],
+      "properties": {
+        "tone": {
+          "type": "string",
+          "enum": ["professional", "friendly", "authoritative", "playful", "technical", "warm"]
+        },
+        "personality_traits": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 2,
+          "maxItems": 5
+        },
+        "writing_style": {
+          "type": "string",
+          "enum": ["concise", "detailed", "conversational", "formal"]
+        }
+      },
+      "additionalProperties": false
+    },
+    "logo_spec": {
+      "type": "object",
+      "properties": {
+        "style": {
+          "type": "string",
+          "enum": ["wordmark", "lettermark", "icon", "combination", "emblem"]
+        },
+        "shape": {
+          "type": "string",
+          "enum": ["circle", "square", "rounded", "abstract", "geometric"]
+        },
+        "description": { "type": "string", "maxLength": 500 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/lib/services/telemetry.js
+++ b/lib/services/telemetry.js
@@ -1,0 +1,65 @@
+/**
+ * Service Telemetry — EHG Venture Factory
+ * SD: SD-LEO-ORCH-EHG-VENTURE-FACTORY-001-D
+ *
+ * Reports service outcomes to service_telemetry table for cross-venture intelligence.
+ */
+
+/**
+ * Report a telemetry event to the service_telemetry table.
+ * @param {object} supabase - Supabase client
+ * @param {object} event
+ * @param {string} event.service_key - Service identifier (e.g., 'branding')
+ * @param {string} event.venture_id - UUID of the venture
+ * @param {string} event.event_type - Type of event (e.g., 'artifact_generated', 'routing_decision')
+ * @param {number} [event.confidence_score] - Confidence score (0.0-1.0)
+ * @param {string} [event.routing_decision] - Routing outcome (auto_approve/review_flagged/draft_only)
+ * @param {object} [event.metadata] - Additional event data
+ */
+export async function reportTelemetry(supabase, event) {
+  const { service_key, venture_id, event_type, confidence_score, routing_decision, metadata } = event;
+
+  const { error } = await supabase
+    .from('service_telemetry')
+    .insert({
+      service_key,
+      venture_id,
+      event_type,
+      confidence_score: confidence_score ?? null,
+      routing_decision: routing_decision ?? null,
+      metadata: metadata ?? {},
+      created_at: new Date().toISOString(),
+    });
+
+  if (error) {
+    // Telemetry is non-blocking — log but don't throw
+    console.warn(`[telemetry] Failed to record event: ${error.message}`);
+  }
+}
+
+/**
+ * Query telemetry for a venture's service usage.
+ * @param {object} supabase - Supabase client
+ * @param {string} ventureId - UUID of the venture
+ * @param {object} [options]
+ * @param {string} [options.serviceKey] - Filter by service
+ * @param {number} [options.limit] - Max results (default 50)
+ */
+export async function getVentureTelemetry(supabase, ventureId, options = {}) {
+  const { serviceKey, limit = 50 } = options;
+
+  let query = supabase
+    .from('service_telemetry')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (serviceKey) {
+    query = query.eq('service_key', serviceKey);
+  }
+
+  const { data, error } = await query;
+  if (error) throw new Error(`Telemetry query failed: ${error.message}`);
+  return data || [];
+}

--- a/supabase/migrations/20260309_register_branding_service.sql
+++ b/supabase/migrations/20260309_register_branding_service.sql
@@ -1,0 +1,93 @@
+-- Venture Factory: Register Branding Service + Telemetry Table
+-- SD: SD-LEO-ORCH-EHG-VENTURE-FACTORY-001-D
+-- Idempotent: ON CONFLICT DO NOTHING / IF NOT EXISTS
+
+-- ============================================================
+-- 1. Register branding service in ehg_services
+-- ============================================================
+INSERT INTO ehg_services (service_key, display_name, description, artifact_schema, version, sla_tier)
+VALUES (
+  'branding',
+  'Branding Service',
+  'Generates confidence-scored brand identity artifacts (colors, typography, voice, logo spec) for ventures with Decision Filter Engine routing',
+  '{
+    "type": "object",
+    "required": ["venture_id", "brand_name", "color_palette", "typography", "brand_voice"],
+    "properties": {
+      "venture_id": {"type": "string", "format": "uuid"},
+      "brand_name": {"type": "string", "minLength": 1, "maxLength": 100},
+      "tagline": {"type": "string", "maxLength": 200},
+      "color_palette": {
+        "type": "object",
+        "required": ["primary", "secondary", "accent"],
+        "properties": {
+          "primary": {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"},
+          "secondary": {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"},
+          "accent": {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"}
+        }
+      },
+      "typography": {
+        "type": "object",
+        "required": ["heading_font", "body_font"],
+        "properties": {
+          "heading_font": {"type": "string"},
+          "body_font": {"type": "string"}
+        }
+      },
+      "brand_voice": {
+        "type": "object",
+        "required": ["tone", "personality_traits"],
+        "properties": {
+          "tone": {"type": "string", "enum": ["professional", "friendly", "authoritative", "playful", "technical", "warm"]},
+          "personality_traits": {"type": "array", "items": {"type": "string"}, "minItems": 2, "maxItems": 5}
+        }
+      }
+    }
+  }'::jsonb,
+  '1.0.0',
+  'standard'
+)
+ON CONFLICT (service_key) DO NOTHING;
+
+-- ============================================================
+-- 2. Create service_telemetry table for cross-venture intelligence
+-- ============================================================
+CREATE TABLE IF NOT EXISTS service_telemetry (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  service_key TEXT NOT NULL,
+  venture_id UUID NOT NULL,
+  event_type TEXT NOT NULL,
+  confidence_score NUMERIC(4,3),
+  routing_decision TEXT,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Add check constraint for routing_decision
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'service_telemetry_routing_check'
+  ) THEN
+    ALTER TABLE service_telemetry ADD CONSTRAINT service_telemetry_routing_check
+      CHECK (routing_decision IS NULL OR routing_decision IN ('auto_approve', 'review_flagged', 'draft_only'));
+  END IF;
+END $$;
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_service_telemetry_venture ON service_telemetry(venture_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_service_telemetry_service ON service_telemetry(service_key, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_service_telemetry_routing ON service_telemetry(routing_decision) WHERE routing_decision IS NOT NULL;
+
+-- ============================================================
+-- 3. Insert initial version record for branding service
+-- ============================================================
+INSERT INTO service_versions (service_id, version, artifact_schema, changelog)
+SELECT
+  id,
+  '1.0.0',
+  artifact_schema,
+  'Initial branding service: color palette, typography, brand voice, logo spec generation with Decision Filter Engine confidence routing'
+FROM ehg_services
+WHERE service_key = 'branding'
+ON CONFLICT (service_id, version) DO NOTHING;


### PR DESCRIPTION
## Summary
- Add `lib/services/branding-service.js`: generates confidence-scored brand identity artifacts (color palette, typography, brand voice, logo spec) with Decision Filter Engine routing (auto-approve >0.85, review 0.50-0.85, draft-only <0.50)
- Add `lib/services/schemas/branding-artifact.json`: JSON Schema contract for brand artifacts
- Add `lib/services/telemetry.js`: cross-venture intelligence reporting to `service_telemetry` table
- Add migration: registers branding service in `ehg_services`, creates `service_telemetry` table with routing constraints and performance indexes, inserts initial service version record

## Test plan
- [ ] Verify migration applies cleanly (`supabase db push`)
- [ ] Validate branding artifact generation with various industry inputs
- [ ] Confirm confidence routing thresholds produce correct routing decisions
- [ ] Verify telemetry events are recorded to service_telemetry table

🤖 Generated with [Claude Code](https://claude.com/claude-code)