### PR TITLE
feat: branding service end-to-end for ClarityStats

### DIFF
--- a/lib/services/branding-service.js
+++ b/lib/services/branding-service.js
@@ -1,189 +1,305 @@
 /**
- * Branding Service — EHG Venture Factory
+ * Branding Service — First EHG Venture Factory Shared Service
  * SD: SD-LEO-ORCH-EHG-VENTURE-FACTORY-001-D
  *
- * Generates confidence-scored brand artifacts for ventures.
- * Routes artifacts through the Decision Filter Engine:
- *   - >0.85 confidence → auto-PR (auto-apply to venture repo)
- *   - 0.5-0.85 → review-flagged PR (Chairman reviews)
- *   - <0.5 → draft-only (stored but not applied)
+ * Generates confidence-scored brand identity artifacts (logo spec, color palette)
+ * for ventures. Integrates with service_tasks queue and service_telemetry.
  */
 
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import { reportTelemetry } from './telemetry.js';
+import { createClient } from '@supabase/supabase-js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const BRANDING_SCHEMA = JSON.parse(
-  readFileSync(join(__dirname, 'schemas', 'branding-artifact.json'), 'utf8')
-);
+const SERVICE_KEY = 'branding';
 
-// Decision Filter Engine thresholds
-const DFE_THRESHOLDS = {
-  AUTO_APPROVE: 0.85,   // Auto-PR to venture repo
-  REVIEW_FLAG: 0.50,    // Chairman review required
-  // Below 0.50 = draft-only
+const CONFIDENCE_THRESHOLDS = {
+  auto: 0.85,   // Auto-approve above this
+  review: 0.5,  // Needs human review
+  draft: 0.0,   // Draft quality, not actionable
 };
 
-/**
- * Generate branding artifacts for a venture.
- * @param {object} supabase - Supabase client
- * @param {object} params - Task input parameters
- * @param {string} params.venture_id - UUID of the target venture
- * @param {string} params.brand_name - Venture brand name
- * @param {string} [params.industry] - Industry context for generation
- * @param {string} [params.target_audience] - Target audience description
- * @param {string[]} [params.competitor_brands] - Competitor brand names
- * @returns {Promise<{artifact: object, confidence_score: number, routing: string}>}
- */
-export async function generateBrandArtifact(supabase, params) {
-  const { venture_id, brand_name, industry, target_audience, competitor_brands } = params;
+const REQUIRED_INPUT_FIELDS = ['venture_name', 'industry'];
+const OPTIONAL_INPUT_FIELDS = ['target_audience', 'brand_values', 'color_preferences', 'style'];
 
-  // Generate brand artifacts with confidence scoring
-  const artifact = buildBrandArtifact(brand_name, industry, target_audience);
-  const confidence = computeConfidence(artifact, params);
-  const routing = classifyRouting(confidence);
-
-  // Store telemetry
-  await reportTelemetry(supabase, {
-    service_key: 'branding',
-    venture_id,
-    event_type: 'artifact_generated',
-    confidence_score: confidence,
-    routing_decision: routing,
-    metadata: {
-      brand_name,
-      industry: industry || null,
-      artifact_fields: Object.keys(artifact).length,
-    },
-  });
-
-  return { artifact, confidence_score: confidence, routing };
-}
-
-/**
- * Build brand artifact from input parameters.
- * Uses deterministic generation based on brand name characteristics.
- */
-function buildBrandArtifact(brandName, industry, targetAudience) {
-  const nameHash = simpleHash(brandName);
-
-  // Color palette derived from brand name characteristics
-  const palette = generateColorPalette(nameHash, industry);
-
-  // Typography based on industry context
-  const typography = selectTypography(industry);
-
-  // Brand voice based on audience and industry
-  const voice = determineBrandVoice(industry, targetAudience);
-
-  // Logo specification
-  const logoSpec = generateLogoSpec(brandName, industry);
-
-  return {
-    venture_id: null, // Set by caller
-    brand_name: brandName,
-    tagline: generateTagline(brandName, industry),
-    color_palette: palette,
-    typography,
-    brand_voice: voice,
-    logo_spec: logoSpec,
-  };
-}
-
-/**
- * Compute confidence score for generated artifacts.
- * Higher confidence when more input context is provided.
- */
-function computeConfidence(artifact, params) {
-  let score = 0.6; // Base confidence
-
-  // More context = higher confidence
-  if (params.industry) score += 0.1;
-  if (params.target_audience) score += 0.1;
-  if (params.competitor_brands?.length > 0) score += 0.05;
-
-  // Artifact completeness
-  if (artifact.tagline) score += 0.05;
-  if (artifact.logo_spec) score += 0.05;
-  if (artifact.brand_voice?.personality_traits?.length >= 3) score += 0.05;
-
-  return Math.min(1.0, Math.round(score * 100) / 100);
-}
-
-/**
- * Classify routing decision based on confidence score.
- * @returns {'auto_approve' | 'review_flagged' | 'draft_only'}
- */
-function classifyRouting(confidence) {
-  if (confidence >= DFE_THRESHOLDS.AUTO_APPROVE) return 'auto_approve';
-  if (confidence >= DFE_THRESHOLDS.REVIEW_FLAG) return 'review_flagged';
-  return 'draft_only';
-}
-
-// --- Internal generation helpers ---
-
-function simpleHash(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+export class BrandingService {
+  constructor(options = {}) {
+    this.supabase = options.supabaseClient || createClient(
+      process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SERVICE_ROLE_KEY
+    );
+    this.serviceId = options.serviceId || null;
   }
-  return Math.abs(hash);
+
+  /**
+   * Resolve the branding service ID from ehg_services registry.
+   */
+  async resolveServiceId() {
+    if (this.serviceId) return this.serviceId;
+
+    const { data, error } = await this.supabase
+      .from('ehg_services')
+      .select('id')
+      .eq('service_key', SERVICE_KEY)
+      .eq('status', 'active')
+      .single();
+
+    if (error || !data) {
+      throw new Error(`Branding service not found in registry: ${error?.message || 'no data'}`);
+    }
+
+    this.serviceId = data.id;
+    return this.serviceId;
+  }
+
+  /**
+   * Generate brand identity artifacts from venture context.
+   *
+   * @param {object} input - Venture branding input
+   * @param {string} input.venture_name - Name of the venture
+   * @param {string} input.industry - Industry/sector
+   * @param {string} [input.target_audience] - Target audience description
+   * @param {string[]} [input.brand_values] - Core brand values
+   * @param {string[]} [input.color_preferences] - Preferred colors
+   * @param {string} [input.style] - Brand style (modern, classic, playful, etc.)
+   * @returns {{ artifacts: object, confidence: number }}
+   */
+  generateBrandArtifacts(input) {
+    const confidence = this.computeConfidence(input);
+
+    const logoSpec = {
+      concept: `${input.venture_name} brand mark`,
+      style: input.style || 'modern',
+      typography: {
+        primary: this.selectTypography(input.industry, input.style),
+        weight: 'bold',
+      },
+      icon_suggestion: this.suggestIcon(input.industry),
+      layout: 'horizontal',
+    };
+
+    const colorPalette = this.generateColorPalette(input);
+
+    const artifacts = {
+      brand_name: input.venture_name,
+      confidence,
+      artifacts: {
+        logo_spec: logoSpec,
+        color_palette: colorPalette,
+        typography: {
+          heading: logoSpec.typography.primary,
+          body: this.selectBodyFont(input.style),
+        },
+        brand_guidelines: this.generateGuidelines(input, logoSpec, colorPalette),
+      },
+    };
+
+    return { artifacts, confidence };
+  }
+
+  /**
+   * Compute confidence score (0-1) based on input completeness and quality.
+   */
+  computeConfidence(input) {
+    let score = 0;
+    const weights = {
+      venture_name: 0.2,
+      industry: 0.2,
+      target_audience: 0.15,
+      brand_values: 0.15,
+      color_preferences: 0.15,
+      style: 0.15,
+    };
+
+    for (const [field, weight] of Object.entries(weights)) {
+      const value = input[field];
+      if (value !== undefined && value !== null && value !== '') {
+        if (Array.isArray(value) && value.length > 0) {
+          score += weight;
+        } else if (typeof value === 'string' && value.trim().length > 0) {
+          score += weight;
+        }
+      }
+    }
+
+    return Math.round(score * 100) / 100;
+  }
+
+  /**
+   * Create a pending task in service_tasks queue.
+   *
+   * @param {string} ventureId - UUID of the venture
+   * @param {object} input - Branding input parameters
+   * @param {object} [options] - Additional options
+   * @param {number} [options.priority=5] - Task priority (lower = higher)
+   * @returns {Promise<{ taskId: string, confidence: number, artifacts: object }>}
+   */
+  async createTask(ventureId, input, options = {}) {
+    const serviceId = await this.resolveServiceId();
+    const { artifacts, confidence } = this.generateBrandArtifacts(input);
+
+    const { data, error } = await this.supabase
+      .from('service_tasks')
+      .insert({
+        venture_id: ventureId,
+        service_id: serviceId,
+        task_type: 'brand_generation',
+        status: 'pending',
+        priority: options.priority || 5,
+        artifacts,
+        confidence_score: confidence,
+        input_params: input,
+        metadata: {
+          confidence_thresholds: CONFIDENCE_THRESHOLDS,
+          confidence_tier: confidence >= CONFIDENCE_THRESHOLDS.auto ? 'auto'
+            : confidence >= CONFIDENCE_THRESHOLDS.review ? 'review' : 'draft',
+        },
+      })
+      .select('id')
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to create branding task: ${error.message}`);
+    }
+
+    return { taskId: data.id, confidence, artifacts };
+  }
+
+  /**
+   * Report task outcomes to service_telemetry.
+   *
+   * @param {object} params
+   * @param {string} params.taskId - UUID of the completed service_task
+   * @param {string} params.ventureId - UUID of the venture
+   * @param {object} params.outcomes - Structured outcome metrics
+   * @param {string} [params.prUrl] - PR URL if applicable
+   * @param {string} [params.prStatus] - PR status
+   * @param {string} [params.agentVersion] - Venture agent version
+   */
+  async reportTelemetry({ taskId, ventureId, outcomes, prUrl, prStatus, agentVersion }) {
+    const serviceId = await this.resolveServiceId();
+
+    const { error } = await this.supabase
+      .from('service_telemetry')
+      .insert({
+        task_id: taskId,
+        venture_id: ventureId,
+        service_id: serviceId,
+        pr_url: prUrl || null,
+        pr_status: prStatus || null,
+        outcomes: outcomes || {},
+        venture_agent_version: agentVersion || '1.0.0',
+      });
+
+    if (error) {
+      throw new Error(`Failed to report telemetry: ${error.message}`);
+    }
+
+    return { success: true };
+  }
+
+  /**
+   * Complete a task: update status, record completion, and report telemetry.
+   *
+   * @param {string} taskId - UUID of the task to complete
+   * @param {object} outcomes - Outcome data
+   */
+  async completeTask(taskId, outcomes = {}) {
+    const { data: task, error: fetchError } = await this.supabase
+      .from('service_tasks')
+      .select('venture_id, service_id, artifacts, confidence_score')
+      .eq('id', taskId)
+      .single();
+
+    if (fetchError || !task) {
+      throw new Error(`Task not found: ${fetchError?.message || 'no data'}`);
+    }
+
+    const { error: updateError } = await this.supabase
+      .from('service_tasks')
+      .update({
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+      })
+      .eq('id', taskId);
+
+    if (updateError) {
+      throw new Error(`Failed to complete task: ${updateError.message}`);
+    }
+
+    await this.reportTelemetry({
+      taskId,
+      ventureId: task.venture_id,
+      outcomes: {
+        ...outcomes,
+        confidence_score: task.confidence_score,
+        artifacts_generated: true,
+      },
+    });
+
+    return { success: true };
+  }
+
+  // --- Private helpers ---
+
+  selectTypography(industry, style) {
+    const fonts = {
+      technology: { modern: 'Inter', classic: 'Georgia', playful: 'Poppins' },
+      finance: { modern: 'Roboto', classic: 'Merriweather', playful: 'Nunito' },
+      health: { modern: 'Open Sans', classic: 'Lora', playful: 'Quicksand' },
+      default: { modern: 'Inter', classic: 'Georgia', playful: 'Poppins' },
+    };
+    const group = fonts[industry?.toLowerCase()] || fonts.default;
+    return group[style?.toLowerCase()] || group.modern;
+  }
+
+  selectBodyFont(style) {
+    const bodyFonts = { modern: 'Inter', classic: 'Source Serif Pro', playful: 'Nunito' };
+    return bodyFonts[style?.toLowerCase()] || bodyFonts.modern;
+  }
+
+  suggestIcon(industry) {
+    const icons = {
+      technology: 'circuit-board',
+      finance: 'bar-chart',
+      health: 'heart-pulse',
+      education: 'graduation-cap',
+      analytics: 'line-chart',
+    };
+    return icons[industry?.toLowerCase()] || 'star';
+  }
+
+  generateColorPalette(input) {
+    if (input.color_preferences && input.color_preferences.length > 0) {
+      return input.color_preferences.slice(0, 5);
+    }
+
+    const palettes = {
+      technology: ['#2563EB', '#3B82F6', '#60A5FA', '#1E293B', '#F8FAFC'],
+      finance: ['#059669', '#10B981', '#34D399', '#1F2937', '#F9FAFB'],
+      health: ['#DC2626', '#EF4444', '#FCA5A5', '#1E293B', '#FFFFFF'],
+      analytics: ['#7C3AED', '#8B5CF6', '#A78BFA', '#1E293B', '#F5F3FF'],
+      default: ['#3B82F6', '#6366F1', '#8B5CF6', '#1E293B', '#F8FAFC'],
+    };
+
+    return palettes[input.industry?.toLowerCase()] || palettes.default;
+  }
+
+  generateGuidelines(input, logoSpec, colorPalette) {
+    return [
+      `Brand: ${input.venture_name}`,
+      `Industry: ${input.industry || 'General'}`,
+      `Style: ${input.style || 'Modern'}`,
+      `Primary Font: ${logoSpec.typography.primary}`,
+      `Primary Color: ${colorPalette[0]}`,
+      `Use the logo mark at minimum 32px height.`,
+      `Maintain clear space equal to the height of the logo icon around the mark.`,
+    ].join('\n');
+  }
 }
 
-function generateColorPalette(hash, industry) {
-  const palettes = {
-    technology: { primary: '#2563EB', secondary: '#1E40AF', accent: '#3B82F6', background: '#F8FAFC', text: '#0F172A' },
-    finance: { primary: '#047857', secondary: '#065F46', accent: '#10B981', background: '#F0FDF4', text: '#064E3B' },
-    health: { primary: '#0891B2', secondary: '#0E7490', accent: '#22D3EE', background: '#ECFEFF', text: '#164E63' },
-    education: { primary: '#7C3AED', secondary: '#6D28D9', accent: '#A78BFA', background: '#F5F3FF', text: '#4C1D95' },
-    default: { primary: '#0F766E', secondary: '#115E59', accent: '#14B8A6', background: '#F0FDFA', text: '#134E4A' },
-  };
-  return palettes[industry] || palettes.default;
+/**
+ * Create a BrandingService with default configuration.
+ */
+export function createBrandingService(options = {}) {
+  return new BrandingService(options);
 }
 
-function selectTypography(industry) {
-  const styles = {
-    technology: { heading_font: 'Inter', body_font: 'Inter', mono_font: 'JetBrains Mono', base_size_px: 16 },
-    finance: { heading_font: 'Merriweather', body_font: 'Source Sans 3', mono_font: 'Fira Code', base_size_px: 16 },
-    health: { heading_font: 'Nunito', body_font: 'Open Sans', mono_font: 'IBM Plex Mono', base_size_px: 16 },
-    education: { heading_font: 'Poppins', body_font: 'Lato', mono_font: 'Source Code Pro', base_size_px: 16 },
-    default: { heading_font: 'Inter', body_font: 'Inter', base_size_px: 16 },
-  };
-  return styles[industry] || styles.default;
-}
-
-function determineBrandVoice(industry, targetAudience) {
-  const voices = {
-    technology: { tone: 'professional', personality_traits: ['innovative', 'precise', 'forward-thinking'], writing_style: 'concise' },
-    finance: { tone: 'authoritative', personality_traits: ['trustworthy', 'reliable', 'analytical'], writing_style: 'formal' },
-    health: { tone: 'warm', personality_traits: ['caring', 'knowledgeable', 'supportive'], writing_style: 'conversational' },
-    education: { tone: 'friendly', personality_traits: ['encouraging', 'clear', 'curious'], writing_style: 'conversational' },
-    default: { tone: 'professional', personality_traits: ['reliable', 'clear'], writing_style: 'concise' },
-  };
-  return voices[industry] || voices.default;
-}
-
-function generateLogoSpec(brandName, industry) {
-  const firstChar = brandName.charAt(0).toUpperCase();
-  const isShortName = brandName.length <= 8;
-  return {
-    style: isShortName ? 'wordmark' : 'combination',
-    shape: 'rounded',
-    description: `${isShortName ? 'Wordmark' : 'Combination mark'} featuring "${firstChar}" with ${industry || 'modern'} design sensibility`,
-  };
-}
-
-function generateTagline(brandName, industry) {
-  const taglines = {
-    technology: `${brandName} — Engineering the future`,
-    finance: `${brandName} — Your financial compass`,
-    health: `${brandName} — Wellness, redefined`,
-    education: `${brandName} — Learn without limits`,
-    default: `${brandName} — Built for what matters`,
-  };
-  return taglines[industry] || taglines.default;
-}
-
-export { DFE_THRESHOLDS, BRANDING_SCHEMA, classifyRouting, computeConfidence };
+export default BrandingService;

--- a/lib/services/branding-service.test.js
+++ b/lib/services/branding-service.test.js
@@ -1,0 +1,273 @@
+/**
+ * Tests for Branding Service
+ * SD: SD-LEO-ORCH-EHG-VENTURE-FACTORY-001-D
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BrandingService } from './branding-service.js';
+
+function createMockSupabase(overrides = {}) {
+  const chainable = {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    ...overrides,
+  };
+  const fromFn = vi.fn().mockReturnValue(chainable);
+  return { from: fromFn, _chainable: chainable };
+}
+
+const MOCK_VENTURE_ID = '72efb937-981c-495c-b12c-1f006aee50d0';
+const MOCK_SERVICE_ID = '37914cf7-3bd0-4eca-b8ff-c8d94daf1d77';
+
+const FULL_INPUT = {
+  venture_name: 'ClarityStats',
+  industry: 'analytics',
+  target_audience: 'Data-driven decision makers',
+  brand_values: ['clarity', 'precision', 'trust'],
+  color_preferences: ['#7C3AED', '#4F46E5'],
+  style: 'modern',
+};
+
+const MINIMAL_INPUT = {
+  venture_name: 'ClarityStats',
+  industry: 'analytics',
+};
+
+describe('BrandingService', () => {
+  let service;
+  let mockSupabase;
+
+  beforeEach(() => {
+    mockSupabase = createMockSupabase();
+    service = new BrandingService({
+      supabaseClient: mockSupabase,
+      serviceId: MOCK_SERVICE_ID,
+    });
+  });
+
+  describe('generateBrandArtifacts', () => {
+    it('generates artifacts with full input', () => {
+      const { artifacts, confidence } = service.generateBrandArtifacts(FULL_INPUT);
+
+      expect(artifacts.brand_name).toBe('ClarityStats');
+      expect(artifacts.confidence).toBeGreaterThan(0.8);
+      expect(artifacts.artifacts.logo_spec).toBeDefined();
+      expect(artifacts.artifacts.color_palette).toBeDefined();
+      expect(artifacts.artifacts.typography).toBeDefined();
+      expect(artifacts.artifacts.brand_guidelines).toBeDefined();
+      expect(confidence).toBeGreaterThan(0.8);
+    });
+
+    it('generates artifacts with minimal input', () => {
+      const { artifacts, confidence } = service.generateBrandArtifacts(MINIMAL_INPUT);
+
+      expect(artifacts.brand_name).toBe('ClarityStats');
+      expect(confidence).toBeLessThanOrEqual(0.5);
+      expect(artifacts.artifacts.logo_spec).toBeDefined();
+      expect(artifacts.artifacts.color_palette).toHaveLength(5);
+    });
+
+    it('uses color_preferences when provided', () => {
+      const { artifacts } = service.generateBrandArtifacts(FULL_INPUT);
+      expect(artifacts.artifacts.color_palette).toEqual(['#7C3AED', '#4F46E5']);
+    });
+
+    it('falls back to industry palette without preferences', () => {
+      const { artifacts } = service.generateBrandArtifacts(MINIMAL_INPUT);
+      expect(artifacts.artifacts.color_palette).toHaveLength(5);
+      expect(artifacts.artifacts.color_palette[0]).toBe('#7C3AED'); // analytics palette
+    });
+
+    it('includes logo spec with typography and icon', () => {
+      const { artifacts } = service.generateBrandArtifacts(FULL_INPUT);
+      const logo = artifacts.artifacts.logo_spec;
+
+      expect(logo.concept).toContain('ClarityStats');
+      expect(logo.style).toBe('modern');
+      expect(logo.typography.primary).toBeDefined();
+      expect(logo.icon_suggestion).toBe('line-chart');
+    });
+
+    it('generates brand guidelines string', () => {
+      const { artifacts } = service.generateBrandArtifacts(FULL_INPUT);
+      const guidelines = artifacts.artifacts.brand_guidelines;
+
+      expect(guidelines).toContain('ClarityStats');
+      expect(guidelines).toContain('analytics');
+    });
+  });
+
+  describe('computeConfidence', () => {
+    it('returns 1.0 for complete input', () => {
+      const score = service.computeConfidence(FULL_INPUT);
+      expect(score).toBe(1);
+    });
+
+    it('returns 0.4 for minimal input (name + industry)', () => {
+      const score = service.computeConfidence(MINIMAL_INPUT);
+      expect(score).toBe(0.4);
+    });
+
+    it('returns 0 for empty input', () => {
+      const score = service.computeConfidence({});
+      expect(score).toBe(0);
+    });
+
+    it('handles empty arrays as missing', () => {
+      const score = service.computeConfidence({
+        venture_name: 'Test',
+        industry: 'tech',
+        brand_values: [],
+      });
+      expect(score).toBe(0.4);
+    });
+
+    it('handles empty strings as missing', () => {
+      const score = service.computeConfidence({
+        venture_name: 'Test',
+        industry: '',
+      });
+      expect(score).toBe(0.2);
+    });
+  });
+
+  describe('resolveServiceId', () => {
+    it('returns cached service ID if set', async () => {
+      const id = await service.resolveServiceId();
+      expect(id).toBe(MOCK_SERVICE_ID);
+      expect(mockSupabase.from).not.toHaveBeenCalled();
+    });
+
+    it('queries database when no cached ID', async () => {
+      const svc = new BrandingService({ supabaseClient: mockSupabase });
+      mockSupabase._chainable.single.mockResolvedValue({
+        data: { id: MOCK_SERVICE_ID },
+        error: null,
+      });
+
+      const id = await svc.resolveServiceId();
+      expect(id).toBe(MOCK_SERVICE_ID);
+      expect(mockSupabase.from).toHaveBeenCalledWith('ehg_services');
+    });
+
+    it('throws if service not found', async () => {
+      const svc = new BrandingService({ supabaseClient: mockSupabase });
+      mockSupabase._chainable.single.mockResolvedValue({
+        data: null,
+        error: { message: 'not found' },
+      });
+
+      await expect(svc.resolveServiceId()).rejects.toThrow('Branding service not found');
+    });
+  });
+
+  describe('createTask', () => {
+    it('creates a pending task with artifacts and confidence', async () => {
+      mockSupabase._chainable.single.mockResolvedValue({
+        data: { id: 'task-uuid-001' },
+        error: null,
+      });
+
+      const result = await service.createTask(MOCK_VENTURE_ID, FULL_INPUT);
+
+      expect(result.taskId).toBe('task-uuid-001');
+      expect(result.confidence).toBeGreaterThan(0.8);
+      expect(result.artifacts).toBeDefined();
+      expect(result.artifacts.brand_name).toBe('ClarityStats');
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('service_tasks');
+      const insertCall = mockSupabase._chainable.insert.mock.calls[0][0];
+      expect(insertCall.venture_id).toBe(MOCK_VENTURE_ID);
+      expect(insertCall.service_id).toBe(MOCK_SERVICE_ID);
+      expect(insertCall.task_type).toBe('brand_generation');
+      expect(insertCall.status).toBe('pending');
+      expect(insertCall.confidence_score).toBeGreaterThan(0.8);
+    });
+
+    it('throws on insert error', async () => {
+      mockSupabase._chainable.single.mockResolvedValue({
+        data: null,
+        error: { message: 'FK violation' },
+      });
+
+      await expect(service.createTask(MOCK_VENTURE_ID, FULL_INPUT))
+        .rejects.toThrow('Failed to create branding task');
+    });
+
+    it('applies custom priority', async () => {
+      mockSupabase._chainable.single.mockResolvedValue({
+        data: { id: 'task-002' },
+        error: null,
+      });
+
+      await service.createTask(MOCK_VENTURE_ID, FULL_INPUT, { priority: 1 });
+
+      const insertCall = mockSupabase._chainable.insert.mock.calls[0][0];
+      expect(insertCall.priority).toBe(1);
+    });
+  });
+
+  describe('reportTelemetry', () => {
+    it('inserts telemetry record', async () => {
+      mockSupabase._chainable.insert.mockReturnValue({
+        error: null,
+      });
+
+      const result = await service.reportTelemetry({
+        taskId: 'task-001',
+        ventureId: MOCK_VENTURE_ID,
+        outcomes: { confidence_score: 0.92, artifacts_generated: true },
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockSupabase.from).toHaveBeenCalledWith('service_telemetry');
+    });
+  });
+
+  describe('completeTask', () => {
+    it('updates task status and reports telemetry', async () => {
+      // Mock task fetch
+      const fetchChainable = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({
+          data: {
+            venture_id: MOCK_VENTURE_ID,
+            service_id: MOCK_SERVICE_ID,
+            artifacts: { brand_name: 'ClarityStats' },
+            confidence_score: 0.92,
+          },
+          error: null,
+        }),
+      };
+
+      // Mock task update
+      const updateChainable = {
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnValue({ error: null }),
+      };
+
+      // Mock telemetry insert
+      const telemetryChainable = {
+        insert: vi.fn().mockReturnValue({ error: null }),
+      };
+
+      let callCount = 0;
+      mockSupabase.from = vi.fn().mockImplementation((table) => {
+        if (table === 'service_telemetry') return telemetryChainable;
+        callCount++;
+        if (callCount === 1) return fetchChainable; // First service_tasks call = fetch
+        return updateChainable; // Second = update
+      });
+
+      const result = await service.completeTask('task-001', { user_accepted: true });
+
+      expect(result.success).toBe(true);
+      expect(mockSupabase.from).toHaveBeenCalledWith('service_tasks');
+      expect(mockSupabase.from).toHaveBeenCalledWith('service_telemetry');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `BrandingService` class with confidence-scored brand artifact generation (logo spec, color palette, typography, guidelines)
- Integrates with `service_tasks` queue and `service_telemetry` for full E2E flow
- 19 vitest unit tests covering generateBrandArtifacts, computeConfidence, resolveServiceId, createTask, reportTelemetry, completeTask

## Test plan
- [x] 19 unit tests pass (vitest)
- [x] Integration test verified against live DB (task creation, completion, telemetry)
- [x] Confidence scoring: auto (≥0.85), review (0.5-0.85), draft (<0.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)