### PR TITLE
feat: venture tiering and exit readiness tooling (SD-001-G)

### DIFF
--- a/scripts/modules/venture-lifecycle/fk-registry.cjs
+++ b/scripts/modules/venture-lifecycle/fk-registry.cjs
@@ -106,6 +106,13 @@ const VENTURE_FK_REGISTRY = [
   { table: 'public_portfolio', column: 'venture_id', policy: 'CASCADE', category: 'other' },
   // stage_of_death_predictions — not in live DB (phantom migration artifact)
   { table: 'tool_usage_ledger', column: 'venture_id', policy: 'CASCADE', category: 'other' },
+
+  // ─── Venture Factory tables — CASCADE (SD-001-A + SD-001-G) ───
+  { table: 'service_tasks', column: 'venture_id', policy: 'CASCADE', category: 'venture_factory' },
+  { table: 'venture_service_bindings', column: 'venture_id', policy: 'CASCADE', category: 'venture_factory' },
+  { table: 'service_telemetry', column: 'venture_id', policy: 'CASCADE', category: 'venture_factory' },
+  { table: 'venture_exit_readiness', column: 'venture_id', policy: 'CASCADE', category: 'venture_factory' },
+  { table: 'venture_tiers', column: 'venture_id', policy: 'CASCADE', category: 'venture_factory' },
 ];
 
 // Self-referencing FK columns on ventures table that must be nulled before delete

--- a/supabase/functions/tier-evaluation/index.ts
+++ b/supabase/functions/tier-evaluation/index.ts
@@ -1,0 +1,232 @@
+// Tier Evaluation Edge Function
+// SD: SD-LEO-ORCH-EHG-VENTURE-FACTORY-001-G
+// Reads service_telemetry aggregates per venture, compares against
+// promotion criteria thresholds, and writes new venture_tiers evaluation record.
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+// Default promotion criteria thresholds per tier
+const DEFAULT_CRITERIA: Record<string, {
+  min_completed_tasks: number;
+  min_avg_confidence: number;
+  min_services_bound: number;
+  min_telemetry_reports: number;
+}> = {
+  seed: {
+    min_completed_tasks: 0,
+    min_avg_confidence: 0,
+    min_services_bound: 0,
+    min_telemetry_reports: 0,
+  },
+  growth: {
+    min_completed_tasks: 5,
+    min_avg_confidence: 0.6,
+    min_services_bound: 2,
+    min_telemetry_reports: 3,
+  },
+  scale: {
+    min_completed_tasks: 20,
+    min_avg_confidence: 0.75,
+    min_services_bound: 4,
+    min_telemetry_reports: 10,
+  },
+  exit: {
+    min_completed_tasks: 50,
+    min_avg_confidence: 0.85,
+    min_services_bound: 5,
+    min_telemetry_reports: 25,
+  },
+};
+
+const TIER_ORDER = ['seed', 'growth', 'scale', 'exit'];
+
+interface TelemetrySnapshot {
+  completed_tasks: number;
+  avg_confidence: number;
+  services_bound: number;
+  telemetry_reports: number;
+  evaluated_at: string;
+}
+
+serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: CORS_HEADERS });
+  }
+
+  if (req.method !== 'POST') {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed' }),
+      { status: 405, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        { status: 401, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const body = await req.json();
+    const { venture_id, custom_criteria } = body;
+
+    if (!venture_id) {
+      return new Response(
+        JSON.stringify({ error: 'venture_id is required' }),
+        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Use service_role client to read across tables
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    );
+
+    // Verify venture exists
+    const { data: venture, error: ventureError } = await supabase
+      .from('ventures')
+      .select('id, name')
+      .eq('id', venture_id)
+      .single();
+
+    if (ventureError || !venture) {
+      return new Response(
+        JSON.stringify({ error: 'Venture not found' }),
+        { status: 404, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Aggregate telemetry data
+    // 1. Count completed tasks
+    const { count: completedTasks } = await supabase
+      .from('service_tasks')
+      .select('*', { count: 'exact', head: true })
+      .eq('venture_id', venture_id)
+      .eq('status', 'completed');
+
+    // 2. Average confidence score from completed tasks
+    const { data: confidenceData } = await supabase
+      .from('service_tasks')
+      .select('confidence_score')
+      .eq('venture_id', venture_id)
+      .eq('status', 'completed')
+      .not('confidence_score', 'is', null);
+
+    const avgConfidence = confidenceData && confidenceData.length > 0
+      ? confidenceData.reduce((sum, t) => sum + (t.confidence_score ?? 0), 0) / confidenceData.length
+      : 0;
+
+    // 3. Count bound services
+    const { count: servicesBound } = await supabase
+      .from('venture_service_bindings')
+      .select('*', { count: 'exact', head: true })
+      .eq('venture_id', venture_id)
+      .eq('status', 'active');
+
+    // 4. Count telemetry reports
+    const { count: telemetryReports } = await supabase
+      .from('service_telemetry')
+      .select('*', { count: 'exact', head: true })
+      .eq('venture_id', venture_id);
+
+    const snapshot: TelemetrySnapshot = {
+      completed_tasks: completedTasks ?? 0,
+      avg_confidence: Math.round(avgConfidence * 100) / 100,
+      services_bound: servicesBound ?? 0,
+      telemetry_reports: telemetryReports ?? 0,
+      evaluated_at: new Date().toISOString(),
+    };
+
+    // Get current tier
+    const { data: currentTierData } = await supabase
+      .from('venture_tiers')
+      .select('tier_level')
+      .eq('venture_id', venture_id)
+      .eq('is_current', true)
+      .limit(1)
+      .single();
+
+    const currentTier = currentTierData?.tier_level ?? 'seed';
+    const currentTierIndex = TIER_ORDER.indexOf(currentTier);
+
+    // Evaluate next tier
+    const criteria = custom_criteria ?? DEFAULT_CRITERIA;
+    let recommendedTier = currentTier;
+    let promotionReason = 'No tier change — current metrics do not meet next tier thresholds';
+
+    // Check if venture qualifies for a higher tier
+    for (let i = currentTierIndex + 1; i < TIER_ORDER.length; i++) {
+      const nextTier = TIER_ORDER[i];
+      const thresholds = criteria[nextTier];
+      if (!thresholds) continue;
+
+      const meetsAll =
+        snapshot.completed_tasks >= thresholds.min_completed_tasks &&
+        snapshot.avg_confidence >= thresholds.min_avg_confidence &&
+        snapshot.services_bound >= thresholds.min_services_bound &&
+        snapshot.telemetry_reports >= thresholds.min_telemetry_reports;
+
+      if (meetsAll) {
+        recommendedTier = nextTier;
+        promotionReason = `Meets all ${nextTier} tier thresholds: tasks=${snapshot.completed_tasks}>=${thresholds.min_completed_tasks}, confidence=${snapshot.avg_confidence}>=${thresholds.min_avg_confidence}, services=${snapshot.services_bound}>=${thresholds.min_services_bound}, reports=${snapshot.telemetry_reports}>=${thresholds.min_telemetry_reports}`;
+      } else {
+        break; // Can't skip tiers
+      }
+    }
+
+    const tierChanged = recommendedTier !== currentTier;
+
+    // Write evaluation record (always, even if no change)
+    const { data: tierRecord, error: insertError } = await supabase
+      .from('venture_tiers')
+      .insert({
+        venture_id,
+        tier_level: recommendedTier,
+        promotion_criteria: criteria[recommendedTier] ?? {},
+        telemetry_snapshot: snapshot,
+        is_current: true,
+        promoted_from: tierChanged ? currentTier : null,
+        promotion_reason: promotionReason,
+        evaluated_by: 'tier-evaluation-edge-function',
+      })
+      .select('id, tier_level, is_current, promoted_from, promotion_reason')
+      .single();
+
+    if (insertError) {
+      return new Response(
+        JSON.stringify({ error: 'Failed to write tier evaluation', details: insertError.message }),
+        { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        evaluation: {
+          venture_id,
+          venture_name: venture.name,
+          previous_tier: currentTier,
+          recommended_tier: recommendedTier,
+          tier_changed: tierChanged,
+          promotion_reason: promotionReason,
+          telemetry_snapshot: snapshot,
+          tier_record: tierRecord,
+        },
+      }),
+      { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+    );
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: 'Internal server error' }),
+      { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/migrations/20260309_venture_tiers_and_exit_readiness.sql
+++ b/supabase/migrations/20260309_venture_tiers_and_exit_readiness.sql
@@ -1,0 +1,141 @@
+-- Venture Tiers and Exit Readiness Enhancement
+-- SD: SD-LEO-ORCH-EHG-VENTURE-FACTORY-001-G
+-- Creates: venture_tiers (NEW)
+-- Alters: venture_exit_readiness (ADD separation_test_results JSONB)
+-- Plus RLS policies, indexes, and historical tier trigger
+--
+-- IMPORTANT: venture_exit_readiness ALREADY EXISTS from SD-001-A foundation migration.
+-- This migration ALTERs it — does NOT create it.
+-- venture_tiers.tier_level is DISTINCT from ventures.tier (integer for stage caps).
+
+-- ============================================================
+-- 1. venture_tiers — Business Maturity Tiering
+-- ============================================================
+-- Tracks data-driven business maturity classification per venture.
+-- tier_level (seed/growth/scale/exit) is different from ventures.tier
+-- which is a simple integer controlling stage workflow caps.
+CREATE TABLE IF NOT EXISTS venture_tiers (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id        UUID NOT NULL REFERENCES ventures(id) ON DELETE CASCADE,
+  tier_level        TEXT NOT NULL
+                    CHECK (tier_level IN ('seed', 'growth', 'scale', 'exit')),
+  promotion_criteria JSONB DEFAULT '{}'::jsonb,
+  telemetry_snapshot JSONB DEFAULT '{}'::jsonb,
+  is_current        BOOLEAN NOT NULL DEFAULT true,
+  promoted_from     TEXT,
+  promotion_reason  TEXT,
+  evaluated_by      TEXT DEFAULT 'system',
+  created_at        TIMESTAMPTZ DEFAULT now(),
+  updated_at        TIMESTAMPTZ DEFAULT now()
+);
+
+COMMENT ON TABLE venture_tiers IS 'Business maturity tier tracking (seed/growth/scale/exit). Distinct from ventures.tier integer.';
+COMMENT ON COLUMN venture_tiers.tier_level IS 'Business maturity level: seed, growth, scale, exit';
+COMMENT ON COLUMN venture_tiers.promotion_criteria IS 'JSONB thresholds used to evaluate this tier promotion';
+COMMENT ON COLUMN venture_tiers.telemetry_snapshot IS 'JSONB snapshot of service_telemetry metrics at evaluation time';
+COMMENT ON COLUMN venture_tiers.is_current IS 'Only one record per venture should be is_current=true';
+COMMENT ON COLUMN venture_tiers.promoted_from IS 'Previous tier level before promotion';
+COMMENT ON COLUMN venture_tiers.evaluated_by IS 'Who/what triggered this evaluation (system, manual, edge-function)';
+
+-- ============================================================
+-- 2. Historical Tier Trigger
+-- ============================================================
+-- When a new tier record with is_current=true is inserted,
+-- mark all previous records for that venture as is_current=false.
+CREATE OR REPLACE FUNCTION mark_previous_tiers_historical()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.is_current = true THEN
+    UPDATE venture_tiers
+    SET is_current = false, updated_at = now()
+    WHERE venture_id = NEW.venture_id
+      AND id != NEW.id
+      AND is_current = true;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trigger_mark_previous_tiers_historical') THEN
+    CREATE TRIGGER trigger_mark_previous_tiers_historical
+      AFTER INSERT ON venture_tiers
+      FOR EACH ROW EXECUTE FUNCTION mark_previous_tiers_historical();
+  END IF;
+END
+$$;
+
+-- ============================================================
+-- 3. Indexes on venture_tiers
+-- ============================================================
+CREATE INDEX IF NOT EXISTS idx_venture_tiers_venture_id
+  ON venture_tiers (venture_id);
+
+CREATE INDEX IF NOT EXISTS idx_venture_tiers_current
+  ON venture_tiers (venture_id)
+  WHERE is_current = true;
+
+CREATE INDEX IF NOT EXISTS idx_venture_tiers_tier_level
+  ON venture_tiers (tier_level);
+
+CREATE INDEX IF NOT EXISTS idx_venture_tiers_promotion_criteria
+  ON venture_tiers USING GIN (promotion_criteria);
+
+-- ============================================================
+-- 4. RLS on venture_tiers
+-- ============================================================
+ALTER TABLE venture_tiers ENABLE ROW LEVEL SECURITY;
+
+-- Service role: full access (implicit via supabase service_role)
+-- Authenticated users: scoped to own ventures
+CREATE POLICY "venture_tiers_select_own" ON venture_tiers
+  FOR SELECT TO authenticated
+  USING (venture_id IN (
+    SELECT id FROM ventures WHERE created_by = auth.uid()
+  ));
+
+CREATE POLICY "venture_tiers_insert_own" ON venture_tiers
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id IN (
+    SELECT id FROM ventures WHERE created_by = auth.uid()
+  ));
+
+CREATE POLICY "venture_tiers_update_own" ON venture_tiers
+  FOR UPDATE TO authenticated
+  USING (venture_id IN (
+    SELECT id FROM ventures WHERE created_by = auth.uid()
+  ));
+
+-- ============================================================
+-- 5. ALTER venture_exit_readiness — Add separation_test_results
+-- ============================================================
+-- venture_exit_readiness already has separation_tested BOOLEAN.
+-- This adds structured JSONB results alongside it.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'venture_exit_readiness'
+      AND column_name = 'separation_test_results'
+  ) THEN
+    ALTER TABLE venture_exit_readiness
+      ADD COLUMN separation_test_results JSONB DEFAULT '{}'::jsonb;
+  END IF;
+END
+$$;
+
+COMMENT ON COLUMN venture_exit_readiness.separation_test_results IS 'Structured per-dimension pass/fail separation test results with blocking items';
+
+-- ============================================================
+-- 6. Updated_at trigger for venture_tiers
+-- ============================================================
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'set_updated_at_venture_tiers') THEN
+    CREATE TRIGGER set_updated_at_venture_tiers
+      BEFORE UPDATE ON venture_tiers
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END
+$$;


### PR DESCRIPTION
## Summary
- Create `venture_tiers` table with tier_level CHECK (seed/growth/scale/exit) and `mark_previous_tiers_historical` trigger
- ALTER `venture_exit_readiness` to add `separation_test_results` JSONB column
- Implement `tier-evaluation` Edge Function consuming `service_telemetry` for automated tier promotion
- Add RLS policies for venture-level tenant isolation and update FK registry with 5 entries

## Test plan
- [ ] Verify venture_tiers table exists with correct schema and constraints
- [ ] Verify historical trigger sets previous tiers to is_current=false on new insert
- [ ] Verify separation_test_results column on venture_exit_readiness
- [ ] Verify tier-evaluation Edge Function logic with service telemetry data
- [ ] Verify FK registry includes all 5 venture_factory entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)