### PR TITLE
fix: normalize success metrics and bypass smoke test gate for SD-LEARN SDs

### DIFF
--- a/scripts/modules/child-sd-template.js
+++ b/scripts/modules/child-sd-template.js
@@ -139,10 +139,10 @@ export function inheritStrategicFields(parentSD, childContext = {}) {
   // Reason: Parent metrics like "all children complete" don't apply to individual children
   // Each child has unique deliverables that require specific, measurable targets
   inherited.success_metrics = [
-    { metric: `${phaseTitle} implementation complete`, target: '100%', measurement: 'Deliverables checklist' },
-    { metric: 'Quality gate pass rate', target: '≥85%', measurement: 'Handoff validation score' },
-    { metric: 'Test coverage for new code', target: '≥80%', measurement: 'Jest/Playwright coverage' },
-    { metric: 'Regressions introduced', target: '0', measurement: 'CI test results' }
+    { metric: `${phaseTitle} implementation complete`, target: '100%', actual: null, measurement: 'Deliverables checklist' },
+    { metric: 'Quality gate pass rate', target: '≥85%', actual: null, measurement: 'Handoff validation score' },
+    { metric: 'Test coverage for new code', target: '≥80%', actual: null, measurement: 'Jest/Playwright coverage' },
+    { metric: 'Regressions introduced', target: '0', actual: null, measurement: 'CI test results' }
   ];
 
   // Inherit key_principles - contextualize for phase

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/smoke-test-evidence.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/smoke-test-evidence.js
@@ -34,8 +34,15 @@ const SMOKE_TEST_EVIDENCE_PATTERNS = [
 
 /**
  * Detect if an SD is pipeline/integration work based on title, key, and tags.
+ * Excludes /learn SDs (SD-LEARN-*) that merely reference pipeline patterns
+ * in their description but are process-improvement SDs, not pipeline implementations.
  */
 function isPipelineSD(sd) {
+  const sdKey = (sd.sd_key || '').toUpperCase();
+
+  // /learn SDs address process patterns, not pipeline implementation
+  if (sdKey.startsWith('SD-LEARN-')) return false;
+
   const searchText = [
     sd.sd_key || '',
     sd.title || '',

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-achievement.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-achievement.js
@@ -120,10 +120,10 @@ export function createSuccessMetricsAchievementGate(supabase) {
         };
       }
 
-      const metrics = sdRecord?.success_metrics;
+      const rawMetrics = sdRecord?.success_metrics;
 
       // No metrics defined — pass with warning (some SDs may legitimately lack them)
-      if (!metrics || !Array.isArray(metrics) || metrics.length === 0) {
+      if (!rawMetrics || !Array.isArray(rawMetrics) || rawMetrics.length === 0) {
         console.log('   ⚠️  No success metrics defined on this SD');
         return {
           passed: true, score: 100, max_score: 100,
@@ -132,6 +132,14 @@ export function createSuccessMetricsAchievementGate(supabase) {
           details: { metrics_count: 0 }
         };
       }
+
+      // Normalize metrics: plain strings → objects with {name, target, actual}
+      const metrics = rawMetrics.map(m => {
+        if (typeof m === 'string') {
+          return { name: m, target: 'N/A', actual: null };
+        }
+        return m;
+      });
 
       console.log(`   Found ${metrics.length} success metric(s)\n`);
 


### PR DESCRIPTION
## Summary
- **SUCCESS_METRICS_ACHIEVEMENT gate**: Normalizes plain string metrics to `{name, target, actual}` objects before scoring (fixes PAT-AUTO-41b51e4d)
- **SMOKE_TEST_EVIDENCE gate**: Bypasses SDs with `SD-LEARN-` prefix to prevent false positives on process-improvement SDs (fixes PAT-AUTO-77fe50e3)
- **Child SD template**: Includes `actual: null` in all 4 inherited success metrics

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint auto-fix clean
- [x] No secret detection violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)