### PR TITLE
fix: relax DELIVERABLES_COMPLETENESS gate for infrastructure SDs and exclude generated files from git check

### DIFF
--- a/lib/sub-agents/github.js
+++ b/lib/sub-agents/github.js
@@ -455,11 +455,22 @@ async function checkBranchLifecycle(repoPath) {
     lifecycle.current_branch.name = currentBranch.trim();
 
     // Check for uncommitted changes
+    // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-055: Exclude regenerated protocol/session files
+    const GENERATED_FILE_PATTERNS = [
+      /^CLAUDE.*\.md$/,
+      /^\.claude\//,
+      /^claude-generation-manifest\.json$/,
+      /^scripts\/section-file-mapping.*\.json$/
+    ];
+    const isGeneratedFile = (filePath) => GENERATED_FILE_PATTERNS.some(p => p.test(filePath));
+
     const { stdout: statusOutput } = await execAsync(`cd "${repoPath}" && git status --porcelain`);
     if (statusOutput.trim()) {
       const lines = statusOutput.trim().split('\n');
       lines.forEach(line => {
         const status = line.substring(0, 2);
+        const filePath = line.substring(3).trim();
+        if (isGeneratedFile(filePath)) return;
         if (status[0] === 'M' || status[0] === 'A' || status[0] === 'D') {
           lifecycle.uncommitted_changes.staged_count++;
         }

--- a/scripts/modules/handoff/validation/semantic-gate-utils.js
+++ b/scripts/modules/handoff/validation/semantic-gate-utils.js
@@ -15,7 +15,7 @@
  */
 export const SEMANTIC_GATE_APPLICABILITY = {
   SCOPE_AUDIT:                    { feature: 'REQ', bugfix: 'REQ', infrastructure: 'OPT', documentation: 'SKIP', security: 'REQ', refactor: 'OPT', orchestrator: 'SKIP', database: 'REQ', enhancement: 'OPT' },
-  DELIVERABLES_COMPLETENESS:      { feature: 'REQ', bugfix: 'REQ', infrastructure: 'REQ', documentation: 'SKIP', security: 'REQ', refactor: 'REQ', orchestrator: 'SKIP', database: 'REQ', enhancement: 'REQ' },
+  DELIVERABLES_COMPLETENESS:      { feature: 'REQ', bugfix: 'REQ', infrastructure: 'OPT', documentation: 'SKIP', security: 'REQ', refactor: 'REQ', orchestrator: 'SKIP', database: 'REQ', enhancement: 'REQ' },
   CHILD_SCOPE_COVERAGE:           { feature: 'SKIP', bugfix: 'SKIP', infrastructure: 'SKIP', documentation: 'SKIP', security: 'SKIP', refactor: 'SKIP', orchestrator: 'REQ', database: 'SKIP', enhancement: 'SKIP' },
   VISION_DIMENSION_COMPLETENESS:  { feature: 'REQ', bugfix: 'OPT', infrastructure: 'OPT', documentation: 'SKIP', security: 'REQ', refactor: 'SKIP', orchestrator: 'SKIP', database: 'REQ', enhancement: 'REQ' },
   SMOKE_TEST_VALIDATION:          { feature: 'REQ', bugfix: 'REQ', infrastructure: 'OPT', documentation: 'SKIP', security: 'REQ', refactor: 'SKIP', orchestrator: 'SKIP', database: 'OPT', enhancement: 'OPT' },


### PR DESCRIPTION
## Summary
- Change DELIVERABLES_COMPLETENESS gate from REQ to OPT for infrastructure SDs — they rarely populate sd_scope_deliverables, causing guaranteed 33/100 failures (PAT-AUTO-d1b66fd4)
- Add exclusion patterns for regenerated protocol/session files (CLAUDE*.md, .claude/*, claude-generation-manifest.json) in GITHUB sub-agent git status check — these are always modified during sessions and trigger false positive CRITICAL findings (SAL-GITHUB-ISS)
- Non-infrastructure SD types retain REQ enforcement

## Test plan
- [x] 115 semantic validation gate unit tests pass
- [x] 15 smoke tests pass
- [x] Verified infrastructure type now gets OPT level
- [x] Verified feature/bugfix/security types retain REQ level

SD: SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-055

🤖 Generated with [Claude Code](https://claude.com/claude-code)