### PR TITLE
fix: treat cancelled children as terminal in orchestrator gate

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
@@ -140,8 +140,9 @@ async function checkParentOrchestrator(supabase, sdUuid, _ctx) {
   if (!childError && childSDs && childSDs.length > 0) {
     console.log(`   ℹ️  Parent SD detected with ${childSDs.length} children`);
 
-    const completedChildren = childSDs.filter(c => c.status === 'completed');
-    const incompleteChildren = childSDs.filter(c => c.status !== 'completed');
+    const terminalStatuses = ['completed', 'cancelled'];
+    const completedChildren = childSDs.filter(c => terminalStatuses.includes(c.status));
+    const incompleteChildren = childSDs.filter(c => !terminalStatuses.includes(c.status));
 
     console.log(`   ✅ Completed: ${completedChildren.length}/${childSDs.length}`);
 


### PR DESCRIPTION
## Summary
- Fixed `PREREQUISITE_HANDOFF_CHECK` gate to recognize `cancelled` as a terminal child status alongside `completed`
- Parent orchestrator SDs are no longer blocked when a child is legitimately cancelled (e.g., scope moved to another repo)
- Also fixed DB function `get_progress_breakdown()` (both TEXT and UUID overloads) to count cancelled children in progress calculation

## Context
- Part of SD-LEO-INFRA-UNIFIED-STRATEGIC-INTELLIGENCE-001 completion
- Child D was cancelled because its frontend scope belonged in the ehg app repo, not EHG_Engineer
- The parent orchestrator was blocked at 80% progress because the gate and DB function only counted `completed` children

## Test plan
- [x] Verified all 4 children show as terminal (3 completed + 1 cancelled → all resolved)
- [x] Verified parent orchestrator reached 100% progress and `completed` status
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)