### PR TITLE
feat: add ASCII digit reference for /coordinator ETA display

### DIFF
--- a/.claude/commands/coordinator.md
+++ b/.claude/commands/coordinator.md
@@ -209,15 +209,48 @@ This banner signals the fleet has finished all work. Display it once per dashboa
 When the dashboard shows SDs still remaining in the queue (not yet complete), display this ETA block AFTER the dashboard output.
 
 ```
-        ___    ____  _  _     ____  __  __
-       / _ \  |___ \| || |   |  _ \|  \/  |
-      | (_) |   __) | || |_  | |_) | |\/| |
-       \__, |  / __/|__   _| |  __/| |  | |
-         /_/  |_____|  |_|   |_|   |_|  |_|
+       _  ___    _ _  _     ____  __  __
+      / |/ _ \  / | || |   |  _ \|  \/  |
+      | | | | |/ /| || |_  | |_) | |\/| |
+      | | |_| / / |__   _| |  __/| |  | |
+      |_|\___/_/     |_|   |_|   |_|  |_|
 
   █████████████████████████░░░░░░░░░░░░░  72%  ~1h 24m
   5 SDs left  |  3 workers  |  7.4/hr
 ```
+
+### ASCII Time Formatting Rules
+
+Render the estimated completion time using figlet-style block digits. Format: `H:MM AM/PM` or `HH:MM AM/PM`.
+
+**Digit reference** — use these exact patterns for each digit:
+```
+0:  ___      1:  _     2:  ____    3:  _____   4:  _  _
+   / _ \       / |       |___ \      |___ /      | || |
+  | | | |      | |         __) |      |_ \       | || |_
+  | |_| |      | |        / __/      ___) |      |__   _|
+   \___/       |_|       |_____|     |____/         |_|
+
+5:  ____    6:   __     7:  _____   8:  ___     9:  ___
+   | ___|      / /_       |___  |     ( _ )       / _ \
+   |___ \     | '_ \         / /      / _ \      | (_) |
+    ___) |    | (_) |       / /      | (_) |      \__, |
+   |____/     \___/        /_/       \___/          /_/
+```
+
+**Colon separator** — place between hour and minutes:
+```
+   _
+  (_)
+   _
+  (_)
+```
+
+**Rules:**
+- **Hour**: Use 1-2 digits (no leading zero). `9` not `09`. `10` is two digits.
+- **Minutes**: Always 2 digits with leading zero. `04` not `4`.
+- **AM/PM**: Render as standard text after the digit block, same style as the example.
+- Spacing: One space between each digit, colon is narrow (2 chars wide).
 
 ### Smart Estimation Process
 


### PR DESCRIPTION
## Summary
- Add exact figlet-style digit patterns (0-9) for consistent ASCII time rendering
- Hour: 1-2 digits (no leading zero), Minutes: always 2 digits with leading zero
- Add colon separator pattern and AM/PM formatting rules

## Test plan
- [ ] Verify ETA display renders correctly for single-digit hours (e.g., 9:04 PM)
- [ ] Verify ETA display renders correctly for double-digit hours (e.g., 10:14 PM)
- [ ] Verify minutes always show leading zero (e.g., :04 not :4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)