### PR TITLE
feat: add PromptLoader service and prompt migration CLI

### DIFF
--- a/lib/eva/prompt-loader.js
+++ b/lib/eva/prompt-loader.js
@@ -1,0 +1,103 @@
+/**
+ * PromptLoader — Versioned prompt loading from leo_prompts table
+ *
+ * Queries the leo_prompts table for active prompts by name,
+ * falls back to null when no database entry exists (caller provides fallback).
+ * Caches results in memory with a configurable TTL.
+ *
+ * Part of SD-STAGE-ZERO-EXPERIMENTATION-FRAMEWORK-ORCH-001-B
+ *
+ * @module lib/eva/prompt-loader
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** @type {Map<string, { value: string, expiry: number }>} */
+const cache = new Map();
+
+/** @type {import('@supabase/supabase-js').SupabaseClient | null} */
+let supabaseClient = null;
+
+/**
+ * Get or create the Supabase client.
+ * Uses service role key for prompt reads (RLS allows anon read of active prompts,
+ * but service role is more reliable for server-side usage).
+ * @returns {import('@supabase/supabase-js').SupabaseClient | null}
+ */
+function getClient() {
+  if (supabaseClient) return supabaseClient;
+
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !key) return null;
+
+  try {
+    supabaseClient = createClient(url, key);
+    return supabaseClient;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load an active prompt by name from leo_prompts.
+ *
+ * Returns the prompt_text of the highest-version active prompt matching the name,
+ * or null if not found or on any error. Never throws.
+ *
+ * @param {string} name - Prompt name (e.g., 'stage-00-acquirability')
+ * @returns {Promise<string | null>} prompt_text or null
+ */
+export async function getPrompt(name) {
+  // Check cache first
+  const cached = cache.get(name);
+  if (cached && Date.now() < cached.expiry) {
+    return cached.value;
+  }
+
+  try {
+    const client = getClient();
+    if (!client) return null;
+
+    const { data, error } = await client
+      .from('leo_prompts')
+      .select('prompt_text')
+      .eq('name', name)
+      .eq('status', 'active')
+      .order('version', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (error || !data) return null;
+
+    // Cache the result
+    cache.set(name, {
+      value: data.prompt_text,
+      expiry: Date.now() + CACHE_TTL_MS,
+    });
+
+    return data.prompt_text;
+  } catch {
+    // Graceful fallback — never throw
+    return null;
+  }
+}
+
+/**
+ * Clear all cached prompts.
+ * Useful for testing and manual cache invalidation.
+ */
+export function clearCache() {
+  cache.clear();
+}
+
+/**
+ * Get the current cache size (for diagnostics).
+ * @returns {number}
+ */
+export function getCacheSize() {
+  return cache.size;
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-00-acquirability.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-00-acquirability.js
@@ -15,6 +15,7 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+import { getPrompt } from '../../prompt-loader.js';
 
 const SYSTEM_PROMPT = `You are EVA's Acquirability Assessment Engine. Evaluate the acquirability potential of a venture idea at conception. Your goal is to surface exit-readiness signals early so the venture can be architected for acquirability from day one.
 
@@ -85,7 +86,10 @@ This is a Stage 0 (inception) evaluation — the venture does not yet have finan
 
 Output ONLY valid JSON.`;
 
-  const response = await client.complete(SYSTEM_PROMPT + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
+  const dbPrompt = await getPrompt('stage-00-acquirability');
+  const systemPrompt = dbPrompt || SYSTEM_PROMPT;
+
+  const response = await client.complete(systemPrompt + getFourBucketsPrompt(), userPrompt, { timeout: 120000 });
   const usage = extractUsage(response);
   const parsed = parseJSON(response);
   const fourBuckets = parseFourBuckets(parsed, { logger });

--- a/scripts/migrate-prompts.js
+++ b/scripts/migrate-prompts.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Prompt Migration CLI — Seeds hardcoded prompts into leo_prompts table
+ *
+ * Reads SYSTEM_PROMPT constants from EVA source files, computes SHA-256 checksum,
+ * and inserts into leo_prompts with status='active', version=1.
+ *
+ * Usage:
+ *   node scripts/migrate-prompts.js           # Insert prompts
+ *   node scripts/migrate-prompts.js --dry-run  # List without inserting
+ *
+ * Idempotent: skips prompts whose checksum already exists.
+ *
+ * Part of SD-STAGE-ZERO-EXPERIMENTATION-FRAMEWORK-ORCH-001-B
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const dryRun = process.argv.includes('--dry-run');
+
+// System UUID for created_by (migration tool identity)
+const MIGRATION_TOOL_UUID = '00000000-0000-0000-0000-000000000001';
+
+/**
+ * Prompt source definitions.
+ * Each entry maps a prompt name to the source file and extraction method.
+ */
+const PROMPT_SOURCES = [
+  {
+    name: 'stage-00-acquirability',
+    file: 'lib/eva/stage-templates/analysis-steps/stage-00-acquirability.js',
+    extract: 'const_system_prompt',
+  },
+];
+
+/**
+ * Extract a SYSTEM_PROMPT constant from a JS source file.
+ * Handles backtick template literals and regular string literals.
+ *
+ * @param {string} filePath - Absolute path to the source file
+ * @returns {string | null} The extracted prompt text, or null if not found
+ */
+function extractSystemPrompt(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+
+  // Match: const SYSTEM_PROMPT = `...`;
+  const backtickMatch = content.match(/const\s+SYSTEM_PROMPT\s*=\s*`([\s\S]*?)`;/);
+  if (backtickMatch) return backtickMatch[1];
+
+  // Match: const SYSTEM_PROMPT = "..."; or '...';
+  const stringMatch = content.match(/const\s+SYSTEM_PROMPT\s*=\s*(['"])([\s\S]*?)\1;/);
+  if (stringMatch) return stringMatch[2];
+
+  return null;
+}
+
+/**
+ * Compute SHA-256 hex digest of a string.
+ * @param {string} text
+ * @returns {string}
+ */
+function computeChecksum(text) {
+  return createHash('sha256').update(text, 'utf-8').digest('hex');
+}
+
+async function main() {
+  console.log(dryRun ? '🔍 DRY RUN — no inserts will be made\n' : '🚀 Migrating prompts to leo_prompts\n');
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  let inserted = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const source of PROMPT_SOURCES) {
+    const filePath = resolve(ROOT, source.file);
+    let promptText;
+
+    try {
+      if (source.extract === 'const_system_prompt') {
+        promptText = extractSystemPrompt(filePath);
+      }
+    } catch (err) {
+      console.error(`  ❌ ${source.name}: Failed to read file — ${err.message}`);
+      failed++;
+      continue;
+    }
+
+    if (!promptText) {
+      console.error(`  ❌ ${source.name}: Could not extract prompt from ${source.file}`);
+      failed++;
+      continue;
+    }
+
+    const checksum = computeChecksum(promptText);
+    console.log(`  📝 ${source.name}`);
+    console.log(`     File: ${source.file}`);
+    console.log(`     Length: ${promptText.length} chars`);
+    console.log(`     Checksum: ${checksum.slice(0, 16)}...`);
+
+    if (dryRun) {
+      console.log(`     [DRY RUN] Would insert with version=1, status=active\n`);
+      inserted++;
+      continue;
+    }
+
+    // Check if checksum already exists (idempotency)
+    const { data: existing } = await supabase
+      .from('leo_prompts')
+      .select('id, name, version')
+      .eq('checksum', checksum)
+      .limit(1);
+
+    if (existing && existing.length > 0) {
+      console.log(`     ⏭️  Skipped — checksum already exists (${existing[0].name} v${existing[0].version})\n`);
+      skipped++;
+      continue;
+    }
+
+    // Also check if name+version exists (different content)
+    const { data: nameExists } = await supabase
+      .from('leo_prompts')
+      .select('id, version')
+      .eq('name', source.name)
+      .order('version', { ascending: false })
+      .limit(1);
+
+    const version = (nameExists && nameExists.length > 0) ? nameExists[0].version + 1 : 1;
+
+    const { error } = await supabase
+      .from('leo_prompts')
+      .insert({
+        name: source.name,
+        version,
+        status: 'active',
+        prompt_text: promptText,
+        checksum,
+        created_by: MIGRATION_TOOL_UUID,
+        metadata: {
+          source_file: source.file,
+          migrated_at: new Date().toISOString(),
+          migrated_by: 'scripts/migrate-prompts.js',
+        },
+      });
+
+    if (error) {
+      console.error(`     ❌ Insert failed: ${error.message}\n`);
+      failed++;
+    } else {
+      console.log(`     ✅ Inserted as v${version}\n`);
+      inserted++;
+    }
+  }
+
+  console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+  console.log(`  Inserted: ${inserted}`);
+  console.log(`  Skipped:  ${skipped}`);
+  console.log(`  Failed:   ${failed}`);
+  console.log(`  Total:    ${PROMPT_SOURCES.length}`);
+  if (dryRun) console.log('\n  ℹ️  Re-run without --dry-run to insert');
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Create `lib/eva/prompt-loader.js` — queries `leo_prompts` table for active versioned prompts by name, caches with 5-min TTL, graceful null fallback
- Create `scripts/migrate-prompts.js` — extracts `SYSTEM_PROMPT` constants from source files, computes SHA-256 checksum, inserts into `leo_prompts` (idempotent)
- Wire PromptLoader into `stage-00-acquirability.js` with fallback to hardcoded `SYSTEM_PROMPT`

## Test plan
- [x] PromptLoader returns active prompt from `leo_prompts`
- [x] PromptLoader returns null for missing prompts
- [x] PromptLoader caching works (5-min TTL)
- [x] migrate-prompts.js --dry-run lists prompts without inserting
- [x] migrate-prompts.js inserts prompt with correct checksum
- [x] Second run is idempotent (skips existing checksums)

SD: SD-STAGE-ZERO-EXPERIMENTATION-FRAMEWORK-ORCH-001-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)