### PR TITLE
feat: add post-meeting action executor and feedback recorder

### DIFF
--- a/lib/eva/consultant/action-executor.js
+++ b/lib/eva/consultant/action-executor.js
@@ -1,0 +1,195 @@
+/**
+ * Post-Meeting Action Executor for EVA Consultant System
+ *
+ * Converts chairman Friday meeting decisions into immediate system actions:
+ * - Accepted findings with action_type='create_sd' → new SD via leo-create-sd.js
+ * - Baseline updates → propagate to management_reviews
+ *
+ * Rate-limited to MAX_SDS_PER_MEETING to prevent queue flooding.
+ *
+ * Part of SD-MAN-ORCH-FRIDAY-EVA-AUTONOMOUS-001-C
+ */
+
+import { createSD } from '../../../scripts/leo-create-sd.js';
+import { generateSDKey, SD_SOURCES } from '../../../scripts/modules/sd-key-generator.js';
+import { recordDecision } from './feedback-recorder.js';
+
+const MAX_SDS_PER_MEETING = 5;
+
+/**
+ * Map recommendation fields to SD creation parameters.
+ *
+ * @param {object} recommendation - From eva_consultant_recommendations
+ * @returns {object} Parameters for createSD()
+ */
+function mapRecommendationToSD(recommendation) {
+  // Map recommendation_type → SD type
+  const typeMap = {
+    strategic: 'feature',
+    tactical: 'fix',
+    research: 'enhancement',
+    operational: 'infrastructure'
+  };
+  const sdType = typeMap[recommendation.recommendation_type] || 'feature';
+
+  return {
+    title: recommendation.title,
+    description: recommendation.description || recommendation.title,
+    type: sdType,
+    priority: recommendation.priority_score >= 0.7 ? 'high' : 'medium',
+    rationale: `Auto-created from EVA consultant finding (${recommendation.application_domain || 'general'})`,
+    metadata: {
+      source: 'eva_recommendation',
+      source_id: recommendation.id,
+      trend_id: recommendation.trend_id,
+      application_domain: recommendation.application_domain,
+      confidence_tier: recommendation.confidence_tier,
+      meeting_date: new Date().toISOString().split('T')[0]
+    }
+  };
+}
+
+/**
+ * Execute actions from accepted Friday meeting findings.
+ * Creates SDs for accepted findings where action_type='create_sd'.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {Array<{recommendationId: string, action: string, notes?: string}>} decisions
+ * @returns {Promise<{sdsCreated: Array, feedbackRecorded: number, errors: Array}>}
+ */
+async function executeDecisions(supabase, decisions) {
+  const results = {
+    sdsCreated: [],
+    feedbackRecorded: 0,
+    baselineUpdates: 0,
+    errors: []
+  };
+
+  let sdCount = 0;
+
+  for (const decision of decisions) {
+    // Record the feedback signal first
+    const feedbackResult = await recordDecision(supabase, decision);
+    if (feedbackResult.success) {
+      results.feedbackRecorded++;
+    } else {
+      results.errors.push({ phase: 'feedback', id: decision.recommendationId, error: feedbackResult.error });
+      continue;
+    }
+
+    // If accepted, check if we should create an SD
+    if (decision.action === 'accepted') {
+      // Fetch full recommendation to check action_type
+      const { data: rec, error: fetchError } = await supabase
+        .from('eva_consultant_recommendations')
+        .select('*')
+        .eq('id', decision.recommendationId)
+        .single();
+
+      if (fetchError || !rec) {
+        results.errors.push({ phase: 'fetch', id: decision.recommendationId, error: fetchError?.message || 'Not found' });
+        continue;
+      }
+
+      // Create SD if action_type warrants it and under rate limit
+      if (rec.action_type === 'create_sd' && sdCount < MAX_SDS_PER_MEETING) {
+        const sdResult = await createSDFromRecommendation(supabase, rec);
+        if (sdResult.success) {
+          results.sdsCreated.push(sdResult.sd);
+          sdCount++;
+        } else {
+          results.errors.push({ phase: 'sd_creation', id: rec.id, error: sdResult.error });
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Create a new SD from an accepted recommendation.
+ *
+ * @param {object} supabase
+ * @param {object} recommendation - Full recommendation record
+ * @returns {Promise<{success: boolean, sd?: object, error?: string}>}
+ */
+async function createSDFromRecommendation(supabase, recommendation) {
+  try {
+    const sdParams = mapRecommendationToSD(recommendation);
+
+    // Generate the SD key
+    const sdKey = generateSDKey({
+      source: SD_SOURCES.EVA || 'EVA',
+      type: sdParams.type,
+      title: sdParams.title
+    });
+
+    const sd = await createSD({
+      sdKey,
+      ...sdParams
+    });
+
+    if (!sd || !sd.sd_key) {
+      return { success: false, error: 'createSD returned no result' };
+    }
+
+    return { success: true, sd: { sd_key: sd.sd_key, title: sd.title, id: sd.id } };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}
+
+/**
+ * Update baseline version in management_reviews when chairman approves.
+ *
+ * @param {object} supabase
+ * @param {object} params
+ * @param {string} params.baselineFrom - Previous baseline version
+ * @param {string} params.baselineTo - New baseline version
+ * @param {string} [params.reason] - Reason for baseline change
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+async function updateBaseline(supabase, { baselineFrom, baselineTo, reason }) {
+  // Get the most recent management review
+  const { data: review, error: fetchError } = await supabase
+    .from('management_reviews')
+    .select('id, baseline_version_from, baseline_version_to')
+    .order('review_date', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (fetchError || !review) {
+    return { success: false, error: `No management review found: ${fetchError?.message || 'empty'}` };
+  }
+
+  const before = {
+    baseline_version_from: review.baseline_version_from,
+    baseline_version_to: review.baseline_version_to
+  };
+
+  const { error: updateError } = await supabase
+    .from('management_reviews')
+    .update({
+      baseline_version_from: baselineFrom,
+      baseline_version_to: baselineTo
+    })
+    .eq('id', review.id);
+
+  if (updateError) {
+    return { success: false, error: `Baseline update failed: ${updateError.message}` };
+  }
+
+  // Log audit trail
+  console.log(`[action-executor] Baseline updated: ${JSON.stringify(before)} → ${JSON.stringify({ baselineFrom, baselineTo })} (${reason || 'chairman approval'})`);
+
+  return { success: true };
+}
+
+export {
+  MAX_SDS_PER_MEETING,
+  mapRecommendationToSD,
+  executeDecisions,
+  createSDFromRecommendation,
+  updateBaseline
+};

--- a/lib/eva/consultant/feedback-recorder.js
+++ b/lib/eva/consultant/feedback-recorder.js
@@ -1,0 +1,219 @@
+/**
+ * Feedback Recorder for EVA Consultant System
+ *
+ * Records chairman accept/dismiss/defer decisions on Friday meeting findings.
+ * Applies confidence weighting:
+ * - Dismissed patterns: 4-week half-life decay (minimum floor: 0.1)
+ * - Accepted patterns: dampened boost (0.25 factor, cap: 2.0)
+ * - Domain-level weights propagate to related findings
+ *
+ * Part of SD-MAN-ORCH-FRIDAY-EVA-AUTONOMOUS-001-C
+ */
+
+const HALF_LIFE_WEEKS = 4;
+const CONFIDENCE_FLOOR = 0.1;
+const BOOST_FACTOR = 0.25;
+const BOOST_CAP = 2.0;
+const SECONDARY_BOOST = 0.1;
+const BASELINE_WEIGHT = 1.0;
+
+/**
+ * Compute decay multiplier for a dismissed pattern.
+ * Formula: 0.5^(weeks/HALF_LIFE_WEEKS)
+ * Applied once at dismissal time (representing one "week" of negative signal).
+ *
+ * @param {number} currentWeight - Current feedback_weight
+ * @returns {number} New weight (never below CONFIDENCE_FLOOR)
+ */
+function computeDecay(currentWeight) {
+  // Each dismissal applies one half-life period worth of decay
+  const decayed = currentWeight * Math.pow(0.5, 1 / HALF_LIFE_WEEKS);
+  return Math.max(CONFIDENCE_FLOOR, Math.round(decayed * 1000) / 1000);
+}
+
+/**
+ * Compute boost for an accepted pattern.
+ * Formula: weight *= (1 + BOOST_FACTOR), capped at BOOST_CAP
+ *
+ * @param {number} currentWeight - Current feedback_weight
+ * @returns {number} New weight (capped at BOOST_CAP)
+ */
+function computeBoost(currentWeight) {
+  const boosted = currentWeight * (1 + BOOST_FACTOR);
+  return Math.min(BOOST_CAP, Math.round(boosted * 1000) / 1000);
+}
+
+/**
+ * Record a single chairman decision on a recommendation.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {object} params
+ * @param {string} params.recommendationId - UUID of the recommendation
+ * @param {string} params.action - 'accepted' | 'dismissed' | 'deferred'
+ * @param {string} [params.notes] - Chairman reasoning/notes
+ * @returns {Promise<{success: boolean, recommendation?: object, error?: string}>}
+ */
+async function recordDecision(supabase, { recommendationId, action, notes }) {
+  const validActions = ['accepted', 'dismissed', 'deferred'];
+  if (!validActions.includes(action)) {
+    return { success: false, error: `Invalid action: ${action}. Must be one of: ${validActions.join(', ')}` };
+  }
+
+  // Map 'dismissed' to DB status 'rejected' (DB constraint only allows pending/accepted/deferred/rejected)
+  const dbStatus = action === 'dismissed' ? 'rejected' : action;
+
+  // Update the recommendation record
+  const { data: rec, error: updateError } = await supabase
+    .from('eva_consultant_recommendations')
+    .update({
+      status: dbStatus,
+      chairman_feedback: notes || action,
+      feedback_at: new Date().toISOString()
+    })
+    .eq('id', recommendationId)
+    .select('id, trend_id, application_domain, title')
+    .single();
+
+  if (updateError) {
+    return { success: false, error: `Failed to update recommendation: ${updateError.message}` };
+  }
+
+  // Apply confidence weighting to the trend if it exists
+  if (rec.trend_id) {
+    const weightResult = await adjustTrendWeight(supabase, rec.trend_id, action);
+    if (!weightResult.success) {
+      console.warn(`  Warning: Trend weight adjustment failed: ${weightResult.error}`);
+    }
+  }
+
+  // Apply domain-level secondary boost for accepted findings
+  if (action === 'accepted' && rec.application_domain) {
+    await applyDomainSecondaryBoost(supabase, rec.application_domain, recommendationId);
+  }
+
+  return { success: true, recommendation: rec };
+}
+
+/**
+ * Adjust the feedback_weight on an eva_consultant_trends record.
+ *
+ * @param {object} supabase
+ * @param {string} trendId - UUID of the trend
+ * @param {string} action - 'accepted' | 'dismissed' | 'deferred'
+ * @returns {Promise<{success: boolean, oldWeight?: number, newWeight?: number, error?: string}>}
+ */
+async function adjustTrendWeight(supabase, trendId, action) {
+  if (action === 'deferred') {
+    return { success: true, oldWeight: null, newWeight: null }; // No weight change for deferred
+  }
+
+  const { data: trend, error: fetchError } = await supabase
+    .from('eva_consultant_trends')
+    .select('id, feedback_weight')
+    .eq('id', trendId)
+    .single();
+
+  if (fetchError || !trend) {
+    return { success: false, error: `Trend not found: ${trendId}` };
+  }
+
+  const oldWeight = trend.feedback_weight ?? BASELINE_WEIGHT;
+  let newWeight;
+
+  if (action === 'accepted') {
+    newWeight = computeBoost(oldWeight);
+  } else if (action === 'dismissed') {
+    newWeight = computeDecay(oldWeight);
+  } else {
+    return { success: true, oldWeight, newWeight: oldWeight };
+  }
+
+  const { error: updateError } = await supabase
+    .from('eva_consultant_trends')
+    .update({ feedback_weight: newWeight })
+    .eq('id', trendId);
+
+  if (updateError) {
+    return { success: false, error: `Weight update failed: ${updateError.message}` };
+  }
+
+  return { success: true, oldWeight, newWeight };
+}
+
+/**
+ * Apply a secondary confidence boost to related findings in the same domain.
+ * Only affects pending recommendations (not yet decided).
+ *
+ * @param {object} supabase
+ * @param {string} domain - application_domain value
+ * @param {string} excludeId - Recommendation to exclude (the one being accepted)
+ */
+async function applyDomainSecondaryBoost(supabase, domain, excludeId) {
+  // Find pending recommendations in same domain with trend_ids
+  const { data: relatedRecs } = await supabase
+    .from('eva_consultant_recommendations')
+    .select('id, trend_id')
+    .eq('application_domain', domain)
+    .eq('status', 'pending')
+    .neq('id', excludeId)
+    .not('trend_id', 'is', null);
+
+  if (!relatedRecs || relatedRecs.length === 0) return;
+
+  // Apply secondary boost to each related trend
+  const trendIds = [...new Set(relatedRecs.map(r => r.trend_id))];
+  for (const trendId of trendIds) {
+    const { data: trend } = await supabase
+      .from('eva_consultant_trends')
+      .select('id, feedback_weight')
+      .eq('id', trendId)
+      .single();
+
+    if (trend) {
+      const currentWeight = trend.feedback_weight ?? BASELINE_WEIGHT;
+      const boosted = Math.min(BOOST_CAP, Math.round((currentWeight + SECONDARY_BOOST) * 1000) / 1000);
+      await supabase
+        .from('eva_consultant_trends')
+        .update({ feedback_weight: boosted })
+        .eq('id', trendId);
+    }
+  }
+}
+
+/**
+ * Record multiple decisions in batch (for Friday meeting flow).
+ *
+ * @param {object} supabase
+ * @param {Array<{recommendationId: string, action: string, notes?: string}>} decisions
+ * @returns {Promise<{processed: number, successes: number, failures: Array}>}
+ */
+async function recordBatch(supabase, decisions) {
+  const results = { processed: 0, successes: 0, failures: [] };
+
+  for (const decision of decisions) {
+    results.processed++;
+    const result = await recordDecision(supabase, decision);
+    if (result.success) {
+      results.successes++;
+    } else {
+      results.failures.push({ id: decision.recommendationId, error: result.error });
+    }
+  }
+
+  return results;
+}
+
+export {
+  HALF_LIFE_WEEKS,
+  CONFIDENCE_FLOOR,
+  BOOST_FACTOR,
+  BOOST_CAP,
+  SECONDARY_BOOST,
+  BASELINE_WEIGHT,
+  computeDecay,
+  computeBoost,
+  recordDecision,
+  adjustTrendWeight,
+  applyDomainSecondaryBoost,
+  recordBatch
+};

--- a/tests/unit/action-executor.test.js
+++ b/tests/unit/action-executor.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { mapRecommendationToSD, MAX_SDS_PER_MEETING } from '../../lib/eva/consultant/action-executor.js';
+
+describe('action-executor', () => {
+  describe('mapRecommendationToSD', () => {
+    it('maps strategic recommendation to feature SD', () => {
+      const rec = {
+        id: 'rec-001',
+        title: 'Improve gate calibration system',
+        description: 'Gate pass rates suggest calibration drift',
+        recommendation_type: 'strategic',
+        priority_score: 0.85,
+        application_domain: 'gate_calibration',
+        trend_id: 'trend-001',
+        confidence_tier: 'high'
+      };
+
+      const result = mapRecommendationToSD(rec);
+      expect(result.type).toBe('feature');
+      expect(result.title).toBe('Improve gate calibration system');
+      expect(result.priority).toBe('high');
+      expect(result.metadata.source).toBe('eva_recommendation');
+      expect(result.metadata.source_id).toBe('rec-001');
+      expect(result.metadata.application_domain).toBe('gate_calibration');
+    });
+
+    it('maps tactical recommendation to fix SD', () => {
+      const rec = {
+        id: 'rec-002',
+        title: 'Fix recurring test failure pattern',
+        recommendation_type: 'tactical',
+        priority_score: 0.5,
+        application_domain: 'retrospective_mining'
+      };
+
+      const result = mapRecommendationToSD(rec);
+      expect(result.type).toBe('fix');
+      expect(result.priority).toBe('medium');
+    });
+
+    it('maps operational recommendation to infrastructure SD', () => {
+      const rec = {
+        id: 'rec-003',
+        title: 'Optimize pipeline scheduling',
+        recommendation_type: 'operational',
+        priority_score: 0.6
+      };
+
+      const result = mapRecommendationToSD(rec);
+      expect(result.type).toBe('infrastructure');
+    });
+
+    it('maps research recommendation to enhancement SD', () => {
+      const rec = {
+        id: 'rec-004',
+        title: 'Investigate cross-venture patterns',
+        recommendation_type: 'research',
+        priority_score: 0.4
+      };
+
+      const result = mapRecommendationToSD(rec);
+      expect(result.type).toBe('enhancement');
+      expect(result.priority).toBe('medium');
+    });
+
+    it('includes meeting date in metadata', () => {
+      const rec = {
+        id: 'rec-005',
+        title: 'Test',
+        recommendation_type: 'tactical',
+        priority_score: 0.5
+      };
+
+      const result = mapRecommendationToSD(rec);
+      expect(result.metadata.meeting_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('MAX_SDS_PER_MEETING is 5', () => {
+      expect(MAX_SDS_PER_MEETING).toBe(5);
+    });
+  });
+});

--- a/tests/unit/feedback-recorder.test.js
+++ b/tests/unit/feedback-recorder.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeDecay,
+  computeBoost,
+  HALF_LIFE_WEEKS,
+  CONFIDENCE_FLOOR,
+  BOOST_FACTOR,
+  BOOST_CAP,
+  BASELINE_WEIGHT
+} from '../../lib/eva/consultant/feedback-recorder.js';
+
+describe('feedback-recorder', () => {
+  describe('computeDecay', () => {
+    it('reduces weight from baseline', () => {
+      const result = computeDecay(BASELINE_WEIGHT);
+      expect(result).toBeLessThan(BASELINE_WEIGHT);
+      expect(result).toBeGreaterThan(CONFIDENCE_FLOOR);
+    });
+
+    it('applies 4-week half-life formula', () => {
+      // After 4 dismissals (one per week), weight should be approximately halved
+      let weight = BASELINE_WEIGHT;
+      for (let i = 0; i < HALF_LIFE_WEEKS; i++) {
+        weight = computeDecay(weight);
+      }
+      // Should be close to 0.5 (half of baseline)
+      expect(weight).toBeCloseTo(0.5, 1);
+    });
+
+    it('never goes below CONFIDENCE_FLOOR', () => {
+      let weight = BASELINE_WEIGHT;
+      // Apply decay 100 times
+      for (let i = 0; i < 100; i++) {
+        weight = computeDecay(weight);
+      }
+      expect(weight).toBeGreaterThanOrEqual(CONFIDENCE_FLOOR);
+    });
+
+    it('floors at exactly 0.1 for very small weights', () => {
+      const result = computeDecay(0.05);
+      expect(result).toBe(CONFIDENCE_FLOOR);
+    });
+  });
+
+  describe('computeBoost', () => {
+    it('increases weight from baseline', () => {
+      const result = computeBoost(BASELINE_WEIGHT);
+      expect(result).toBeGreaterThan(BASELINE_WEIGHT);
+    });
+
+    it('applies 0.25 boost factor', () => {
+      const result = computeBoost(BASELINE_WEIGHT);
+      expect(result).toBe(1.25);
+    });
+
+    it('caps at BOOST_CAP', () => {
+      const result = computeBoost(1.9);
+      expect(result).toBeLessThanOrEqual(BOOST_CAP);
+    });
+
+    it('never exceeds 2.0', () => {
+      let weight = BASELINE_WEIGHT;
+      for (let i = 0; i < 50; i++) {
+        weight = computeBoost(weight);
+      }
+      expect(weight).toBeLessThanOrEqual(BOOST_CAP);
+    });
+  });
+
+  describe('decay and boost interaction', () => {
+    it('boost followed by decay moves back toward baseline', () => {
+      const boosted = computeBoost(BASELINE_WEIGHT);
+      const decayed = computeDecay(boosted);
+      // Should be less than boosted but more than a raw decay from baseline
+      expect(decayed).toBeLessThan(boosted);
+      expect(decayed).toBeGreaterThan(CONFIDENCE_FLOOR);
+    });
+
+    it('multiple decays followed by boost partially recovers', () => {
+      let weight = BASELINE_WEIGHT;
+      // 3 dismissals
+      for (let i = 0; i < 3; i++) {
+        weight = computeDecay(weight);
+      }
+      const afterDecay = weight;
+      // 1 acceptance
+      weight = computeBoost(weight);
+      expect(weight).toBeGreaterThan(afterDecay);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `lib/eva/consultant/action-executor.js` — converts accepted Friday meeting findings into SDs via `leo-create-sd.js` with rate limiting (max 5 per meeting)
- New `lib/eva/consultant/feedback-recorder.js` — records chairman accept/dismiss/defer decisions with confidence weighting (4-week half-life decay for dismissed, 0.25 boost for accepted, min floor 0.1)
- 16 unit tests covering decay math, boost caps, floor enforcement, and recommendation-to-SD field mapping

## Test plan
- [x] Unit tests pass: `npx vitest run tests/unit/feedback-recorder.test.js tests/unit/action-executor.test.js` (16/16)
- [x] Decay never breaches 0.1 floor (100 iteration test)
- [x] Boost caps at 2.0 (50 iteration test)
- [x] All recommendation types map correctly to SD types

🤖 Generated with [Claude Code](https://claude.com/claude-code)