### PR TITLE
feat: add SD quality gate to LEAD-TO-PLAN handoff pipeline

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
@@ -65,3 +65,6 @@ export { createOverlappingScopeDetectionGate } from './overlapping-scope-detecti
 
 // Architecture Phase Coverage Gate (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
 export { createPhaseCoverageGate } from './phase-coverage.js';
+
+// SD Quality Gate (SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001-A)
+export { validateSdQuality, createSdQualityGate } from './sd-quality-gate.js';

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/sd-quality-gate.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/sd-quality-gate.js
@@ -1,0 +1,310 @@
+/**
+ * SD Quality Gate for LEAD-TO-PLAN
+ * SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001-A
+ *
+ * BLOCKING gate that validates SD field completeness, content quality,
+ * and structural correctness before proceeding to PLAN phase.
+ *
+ * Ensures SDs entering PLAN have sufficient substance for meaningful PRD creation.
+ */
+
+/**
+ * Per-sd_type threshold configuration.
+ * Defines how many of the 8 JSONB fields must be populated per SD type.
+ */
+const SD_TYPE_THRESHOLDS = {
+  feature:        { requiredFields: 8, minDescriptionWords: 100, passingScore: 70 },
+  security:       { requiredFields: 8, minDescriptionWords: 100, passingScore: 70 },
+  infrastructure: { requiredFields: 6, minDescriptionWords: 50,  passingScore: 65 },
+  enhancement:    { requiredFields: 6, minDescriptionWords: 50,  passingScore: 65 },
+  refactor:       { requiredFields: 5, minDescriptionWords: 50,  passingScore: 60 },
+  fix:            { requiredFields: 4, minDescriptionWords: 50,  passingScore: 60 },
+  documentation:  { requiredFields: 3, minDescriptionWords: 30,  passingScore: 55 },
+};
+
+const DEFAULT_THRESHOLD = { requiredFields: 5, minDescriptionWords: 50, passingScore: 65 };
+
+/**
+ * The 8 JSONB array fields checked for completeness.
+ */
+const JSONB_FIELDS = [
+  'strategic_objectives',
+  'dependencies',
+  'implementation_guidelines',
+  'success_criteria',
+  'success_metrics',
+  'key_changes',
+  'key_principles',
+  'risks',
+];
+
+/**
+ * Structural validation rules for specific JSONB fields.
+ * Entries should be objects with these keys, not plain strings.
+ */
+const STRUCTURAL_RULES = {
+  success_criteria: { expectedKeys: ['criterion', 'measure'], label: '{criterion, measure}' },
+  key_changes:      { expectedKeys: ['change', 'impact'],     label: '{change, impact}' },
+};
+
+/**
+ * Check if a JSONB field is populated (non-null, non-empty array).
+ */
+function isPopulated(value) {
+  return Array.isArray(value) && value.length > 0;
+}
+
+/**
+ * Count words in a string.
+ */
+function wordCount(text) {
+  if (!text || typeof text !== 'string') return 0;
+  return text.trim().split(/\s+/).filter(Boolean).length;
+}
+
+/**
+ * Validate field completeness across the 8 JSONB arrays.
+ */
+function checkFieldCompleteness(sd, threshold) {
+  const issues = [];
+  const warnings = [];
+  let populatedCount = 0;
+  const missingFields = [];
+
+  for (const field of JSONB_FIELDS) {
+    const value = sd[field];
+    if (isPopulated(value)) {
+      populatedCount++;
+    } else {
+      const issueType = value === null || value === undefined ? 'missing' : 'empty';
+      missingFields.push({ field, type: issueType });
+    }
+  }
+
+  // Only flag missing fields as issues if total populated is below threshold
+  if (populatedCount < threshold.requiredFields) {
+    for (const { field, type } of missingFields) {
+      issues.push({
+        field,
+        type,
+        message: `${field} is ${type} (${type === 'missing' ? 'null' : 'empty array'})`,
+      });
+    }
+  } else if (missingFields.length > 0) {
+    // Enough fields populated but some still missing — warn only
+    for (const { field, type } of missingFields) {
+      warnings.push({
+        field,
+        type,
+        message: `${field} is ${type} — not required for ${sd.sd_type || 'this'} SD type but recommended`,
+      });
+    }
+  }
+
+  // Score: proportion of populated fields relative to requirement
+  const completenessScore = Math.round((populatedCount / threshold.requiredFields) * 40);
+  const cappedScore = Math.min(completenessScore, 40); // max 40 points from completeness
+
+  return { populatedCount, issues, warnings, score: cappedScore };
+}
+
+/**
+ * Validate content quality: description depth and scope boundaries.
+ */
+function checkContentQuality(sd, threshold) {
+  const issues = [];
+  const warnings = [];
+  let score = 0;
+
+  // Description word count
+  const descWords = wordCount(sd.description);
+  if (descWords < threshold.minDescriptionWords) {
+    issues.push({
+      field: 'description',
+      type: 'too_short',
+      message: `description is ${descWords} words (minimum ${threshold.minDescriptionWords} for ${sd.sd_type || 'unknown'} SDs)`,
+    });
+  } else {
+    score += 20;
+  }
+
+  // Scope field check for boundary markers
+  const scope = sd.scope || '';
+  const scopeWords = wordCount(scope);
+  if (scopeWords > 0) {
+    const hasInScope = /in[- ]?scope/i.test(scope);
+    const hasOutOfScope = /out[- ]?of[- ]?scope/i.test(scope) || /exclud/i.test(scope) || /not included/i.test(scope);
+    if (hasInScope || hasOutOfScope) {
+      score += 10;
+    } else if (scopeWords >= 20) {
+      score += 5; // Has substance but no explicit boundaries
+      warnings.push({
+        field: 'scope',
+        type: 'no_boundaries',
+        message: 'scope field lacks explicit in-scope/out-of-scope boundaries',
+      });
+    }
+  } else {
+    warnings.push({
+      field: 'scope',
+      type: 'empty',
+      message: 'scope field is empty - consider defining boundaries',
+    });
+  }
+
+  return { issues, warnings, score: Math.min(score, 30) }; // max 30 points from content
+}
+
+/**
+ * Validate structural quality of JSONB entries.
+ * Checks that entries use proper object structure rather than plain strings.
+ */
+function checkStructuralQuality(sd) {
+  const issues = [];
+  const warnings = [];
+  let score = 30; // Start with full structural score, deduct for issues
+
+  for (const [field, rule] of Object.entries(STRUCTURAL_RULES)) {
+    const value = sd[field];
+    if (!isPopulated(value)) continue;
+
+    let stringOnlyCount = 0;
+    let wellStructuredCount = 0;
+
+    for (const entry of value) {
+      if (typeof entry === 'string') {
+        stringOnlyCount++;
+      } else if (typeof entry === 'object' && entry !== null) {
+        const hasExpectedKeys = rule.expectedKeys.some(key => key in entry);
+        if (hasExpectedKeys) {
+          wellStructuredCount++;
+        } else {
+          stringOnlyCount++; // Object but missing expected keys
+        }
+      }
+    }
+
+    if (stringOnlyCount > 0) {
+      const deduction = Math.min(15, stringOnlyCount * 5);
+      score -= deduction;
+      warnings.push({
+        field,
+        type: 'wrong_structure',
+        message: `${field}: ${stringOnlyCount}/${value.length} entries are plain strings instead of ${rule.label} objects`,
+        example: `Expected format: ${JSON.stringify(Object.fromEntries(rule.expectedKeys.map(k => [k, '...'])))}`,
+      });
+    }
+  }
+
+  return { issues, warnings, score: Math.max(score, 0) }; // max 30 points from structure
+}
+
+/**
+ * Build an actionable remediation report from collected issues and warnings.
+ */
+function buildRemediationReport(issues, warnings) {
+  const lines = [];
+
+  if (issues.length > 0) {
+    lines.push('ISSUES (must fix):');
+    for (const issue of issues) {
+      lines.push(`  - [${issue.type}] ${issue.field}: ${issue.message}`);
+      if (issue.example) {
+        lines.push(`    Example: ${issue.example}`);
+      }
+    }
+  }
+
+  if (warnings.length > 0) {
+    lines.push('WARNINGS (recommended):');
+    for (const warning of warnings) {
+      lines.push(`  - [${warning.type}] ${warning.field}: ${warning.message}`);
+      if (warning.example) {
+        lines.push(`    Example: ${warning.example}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Validate SD quality for LEAD-TO-PLAN handoff.
+ *
+ * Checks:
+ * 1. Field completeness (8 JSONB arrays) - 40 points
+ * 2. Content quality (description depth, scope) - 30 points
+ * 3. Structural quality (object shape) - 30 points
+ *
+ * @param {Object} sd - Strategic Directive record
+ * @returns {Object} Validation result {pass, score, max_score, issues, warnings}
+ */
+export async function validateSdQuality(sd) {
+  const sdType = sd.sd_type || 'feature';
+  const threshold = SD_TYPE_THRESHOLDS[sdType] || DEFAULT_THRESHOLD;
+
+  console.log(`   SD type: ${sdType} (requires ${threshold.requiredFields}/8 fields, ${threshold.minDescriptionWords}+ word description)`);
+
+  // Run all three checks
+  const completeness = checkFieldCompleteness(sd, threshold);
+  const content = checkContentQuality(sd, threshold);
+  const structure = checkStructuralQuality(sd);
+
+  // Combine results
+  const allIssues = [...completeness.issues, ...content.issues, ...structure.issues];
+  const allWarnings = [...completeness.warnings, ...content.warnings, ...structure.warnings];
+  const totalScore = completeness.score + content.score + structure.score;
+
+  // Log results
+  console.log(`   Field completeness: ${completeness.populatedCount}/${JSONB_FIELDS.length} populated (${completeness.score}/40 pts)`);
+  console.log(`   Content quality: ${content.score}/30 pts`);
+  console.log(`   Structural quality: ${structure.score}/30 pts`);
+  console.log(`   Total: ${totalScore}/100`);
+
+  if (allIssues.length > 0) {
+    console.log(`\n   ❌ ${allIssues.length} blocking issue(s):`);
+    for (const issue of allIssues) {
+      console.log(`      - ${issue.field}: ${issue.message}`);
+    }
+  }
+
+  if (allWarnings.length > 0) {
+    console.log(`   ⚠️  ${allWarnings.length} warning(s):`);
+    for (const warning of allWarnings) {
+      console.log(`      - ${warning.field}: ${warning.message}`);
+    }
+  }
+
+  const pass = totalScore >= threshold.passingScore && allIssues.length === 0;
+
+  if (!pass && (allIssues.length > 0 || allWarnings.length > 0)) {
+    console.log(`\n   Remediation Report:`);
+    console.log(buildRemediationReport(allIssues, allWarnings));
+  }
+
+  return {
+    pass,
+    score: totalScore,
+    max_score: 100,
+    issues: allIssues.map(i => i.message),
+    warnings: allWarnings.map(w => w.message),
+  };
+}
+
+/**
+ * Create the SD quality gate for LEAD-TO-PLAN pipeline.
+ *
+ * @returns {Object} Gate configuration
+ */
+export function createSdQualityGate() {
+  return {
+    name: 'GATE_SD_QUALITY',
+    validator: async (ctx) => {
+      console.log('\n📊 GATE: SD Quality Validation');
+      console.log('-'.repeat(50));
+      return validateSdQuality(ctx.sd);
+    },
+    required: true, // BLOCKING gate
+    remediation: 'Enrich the SD with populated JSONB fields (strategic_objectives, dependencies, success_criteria, key_changes, risks), a detailed description meeting the word count minimum for this SD type, and proper object structures ({criterion, measure} for success_criteria, {change, impact} for key_changes).',
+  };
+}

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -24,7 +24,9 @@ import {
   createSdTypeCompatibilityGate,
   createOverlappingScopeDetectionGate,
   // Architecture Phase Coverage Gate (SD-LEO-INFRA-ARCHITECTURE-PHASE-COVERAGE-001)
-  createPhaseCoverageGate
+  createPhaseCoverageGate,
+  // SD Quality Gate (SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001-A)
+  createSdQualityGate
 } from './gates/index.js';
 
 // Protocol File Read Gate (SD-LEO-INFRA-ENFORCE-PROTOCOL-FILE-001)
@@ -96,6 +98,10 @@ export class LeadToPlanExecutor extends BaseExecutor {
     // Placeholder Content Detection Gate (SD-LEO-INFRA-PROTOCOL-FILE-STATE-001)
     // Warning-only: detects default template text from leo-create-sd.js
     gates.push(createPlaceholderContentGate());
+
+    // SD Quality Gate (SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001-A)
+    // BLOCKING: validates field completeness, content depth, structural correctness
+    gates.push(createSdQualityGate());
 
     // LEO v4.4.1: Proactive Branch Creation Gate (DISABLED)
     // See: ./gates/branch-preparation.js for code preserved for reference


### PR DESCRIPTION
## Summary
- New blocking gate (`GATE_SD_QUALITY`) added to LEAD-TO-PLAN pipeline as gate #9 of 17
- Validates SD field completeness across 8 JSONB arrays (strategic_objectives, dependencies, implementation_guidelines, success_criteria, success_metrics, key_changes, key_principles, risks)
- Content quality check: description word count minimum per sd_type, scope boundary detection
- Structural quality check: validates {criterion, measure} and {change, impact} object shapes
- Per-sd_type configurable thresholds: feature=8 fields, infrastructure=6, fix=4, documentation=3
- Actionable remediation reports with field name, issue type, and example formats

## Test plan
- [x] Gate module loads and exports correctly
- [x] Well-populated infrastructure SD passes with score 100/100
- [x] Sparse feature SD (3/8 fields) fails with score 40/100
- [x] Fix SD with 4 fields passes completeness check (meets threshold)
- [x] Gate registered in executor (gate #9, BLOCKING)
- [x] All 17 gates load without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)