### PR TITLE
feat: add planning_traceability dimension to SD HEAL scoring

### DIFF
--- a/scripts/eva/heal-command.mjs
+++ b/scripts/eva/heal-command.mjs
@@ -140,7 +140,7 @@ async function cmdSDQuery(opts) {
 
   let query = supabase
     .from('strategic_directives_v2')
-    .select('sd_key, title, key_changes, success_criteria, success_metrics, strategic_objectives, smoke_test_steps, delivers_capabilities, completion_date, status');
+    .select('sd_key, title, key_changes, success_criteria, success_metrics, strategic_objectives, smoke_test_steps, delivers_capabilities, completion_date, status, metadata');
 
   // SD-LEO-INFRA-ALIGN-HEAL-GATE-001 (FR-4): --in-progress includes non-completed SDs
   if (opts.inProgress) {
@@ -190,6 +190,25 @@ async function cmdSDQuery(opts) {
     console.log(`    Completed: ${sd.completion_date || 'unknown'}`);
   }
 
+  // Load architecture plan deliverables for SDs that have arch_key in metadata
+  const archDeliverablesBySD = {};
+  for (const sd of sds) {
+    const archKey = sd.metadata?.arch_key;
+    if (archKey) {
+      const { data: archPlan } = await supabase
+        .from('eva_architecture_plans')
+        .select('extracted_dimensions')
+        .eq('plan_key', archKey)
+        .single();
+      if (archPlan?.extracted_dimensions?.length > 0) {
+        archDeliverablesBySD[sd.sd_key] = archPlan.extracted_dimensions.map(d => ({
+          name: d.key || d.name,
+          description: d.description || '',
+        }));
+      }
+    }
+  }
+
   // Build inline scoring context
   const scoringContext = {
     mode: 'SD_HEAL_SCORE',
@@ -216,6 +235,10 @@ async function cmdSDQuery(opts) {
       '  - smoke_tests_pass (0-100): Would the smoke_test_steps pass if executed?',
       '    NOTE: If smoke_test_steps is empty/null/[], score 100 with reasoning "N/A: no smoke test steps defined".',
       '  - capabilities_present (0-100): Are delivers_capabilities actually functional?',
+      '  - planning_traceability (0-100, OPTIONAL): Were architecture plan deliverables actually implemented?',
+      '    NOTE: Only include this dimension if the SD has an arch_key in metadata AND architecture_deliverables are provided below.',
+      '    If no architecture plan is linked, OMIT this dimension entirely (do not score it).',
+      '    Score = (deliverables_found / total_deliverables * 100). Search codebase for each deliverable by keyword.',
       '',
       'Include the classification in each dimension\'s reasoning field (e.g., "DESCOPED: zero callers in codebase").',
       'The gaps array should ONLY contain items classified as MISSING — not DESCOPED, RELOCATED, or SUPERSEDED.',
@@ -223,19 +246,27 @@ async function cmdSDQuery(opts) {
       'After scoring, write JSON to a file and run:',
       '  node scripts/eva/heal-command.mjs sd persist --file <path-to-json>',
     ].join('\n'),
-    sds: sds.map(sd => ({
-      sd_key: sd.sd_key,
-      title: sd.title,
-      completion_date: sd.completion_date,
-      promises: {
-        key_changes: sd.key_changes,
-        success_criteria: sd.success_criteria,
-        success_metrics: sd.success_metrics,
-        strategic_objectives: sd.strategic_objectives,
-        smoke_test_steps: sd.smoke_test_steps,
-        delivers_capabilities: sd.delivers_capabilities,
-      },
-    })),
+    sds: sds.map(sd => {
+      const sdData = {
+        sd_key: sd.sd_key,
+        title: sd.title,
+        completion_date: sd.completion_date,
+        promises: {
+          key_changes: sd.key_changes,
+          success_criteria: sd.success_criteria,
+          success_metrics: sd.success_metrics,
+          strategic_objectives: sd.strategic_objectives,
+          smoke_test_steps: sd.smoke_test_steps,
+          delivers_capabilities: sd.delivers_capabilities,
+        },
+      };
+      // Include architecture deliverables when SD has linked architecture plan
+      if (archDeliverablesBySD[sd.sd_key]) {
+        sdData.architecture_deliverables = archDeliverablesBySD[sd.sd_key];
+        sdData.has_architecture_plan = true;
+      }
+      return sdData;
+    }),
     responseFormat: {
       sd_scores: [
         {
@@ -246,6 +277,8 @@ async function cmdSDQuery(opts) {
             { id: 'success_metrics_achieved', score: 0, reasoning: '...' },
             { id: 'smoke_tests_pass', score: 0, reasoning: '...' },
             { id: 'capabilities_present', score: 0, reasoning: '...' },
+            // Include planning_traceability ONLY when SD has architecture_deliverables
+            // { id: 'planning_traceability', score: 0, reasoning: 'N of M deliverables found...', gaps: ['missing deliverable names'] },
           ],
           item_classifications: [
             { item: 'exampleFunction', classification: 'DESCOPED|MISSING|RELOCATED|SUPERSEDED', evidence: 'brief evidence' },
@@ -393,6 +426,11 @@ async function cmdSDPersist(scoreJson, filePath, { inProgress = false } = {}) {
     'smoke_tests_pass',
     'capabilities_present',
   ];
+  // KNOWN_DIMENSIONS includes optional dimensions that are accepted but not required
+  const KNOWN_DIMENSIONS = [
+    ...REQUIRED_DIMENSIONS,
+    'planning_traceability',
+  ];
   const MIN_RATIONALE_LENGTH = 20;
 
   const validationErrors = [];
@@ -411,14 +449,14 @@ async function cmdSDPersist(scoreJson, filePath, { inProgress = false } = {}) {
       });
     }
 
-    // Check for unknown dimension keys
-    const unknown = dimIds.filter(d => !REQUIRED_DIMENSIONS.includes(d));
+    // Check for unknown dimension keys (accepts both required and optional known dimensions)
+    const unknown = dimIds.filter(d => !KNOWN_DIMENSIONS.includes(d));
     if (unknown.length > 0) {
       validationErrors.push({
         sdKey: sdScore.sd_key,
         rule: 'UNKNOWN_DIMENSIONS',
         details: `Unknown dimension keys: ${unknown.join(', ')}`,
-        fix: 'Use only: ' + REQUIRED_DIMENSIONS.join(', '),
+        fix: 'Use only: ' + KNOWN_DIMENSIONS.join(', '),
       });
     }
 

--- a/tests/unit/eva/heal-planning-traceability.test.js
+++ b/tests/unit/eva/heal-planning-traceability.test.js
@@ -1,0 +1,225 @@
+/**
+ * heal-planning-traceability.test.js
+ *
+ * Tests for the planning_traceability dimension added to SD HEAL scoring.
+ * Validates dimension acceptance, backward compatibility, and architecture
+ * deliverable loading logic.
+ *
+ * SD: SD-LEO-FEAT-ADD-PLANNING-DOCUMENT-001
+ */
+import { describe, it, expect } from 'vitest';
+
+// ─── Dimension Validation Constants (mirrored from heal-command.mjs) ───
+
+const REQUIRED_DIMENSIONS = [
+  'key_changes_delivered',
+  'success_criteria_met',
+  'success_metrics_achieved',
+  'smoke_tests_pass',
+  'capabilities_present',
+];
+
+const KNOWN_DIMENSIONS = [
+  ...REQUIRED_DIMENSIONS,
+  'planning_traceability',
+];
+
+// ─── Validation Logic (extracted from heal-command.mjs cmdSDPersist) ───
+
+function validateSDScores(sdScores) {
+  const MIN_RATIONALE_LENGTH = 20;
+  const validationErrors = [];
+
+  for (const sdScore of sdScores) {
+    const dims = sdScore.dimensions || [];
+    const dimIds = dims.map(d => d.id);
+
+    const missing = REQUIRED_DIMENSIONS.filter(r => !dimIds.includes(r));
+    if (missing.length > 0) {
+      validationErrors.push({
+        sdKey: sdScore.sd_key,
+        rule: 'MISSING_DIMENSIONS',
+        details: `Missing ${missing.length} of 5 required dimensions: ${missing.join(', ')}`,
+      });
+    }
+
+    const unknown = dimIds.filter(d => !KNOWN_DIMENSIONS.includes(d));
+    if (unknown.length > 0) {
+      validationErrors.push({
+        sdKey: sdScore.sd_key,
+        rule: 'UNKNOWN_DIMENSIONS',
+        details: `Unknown dimension keys: ${unknown.join(', ')}`,
+      });
+    }
+
+    for (const dim of dims) {
+      const reasoning = (dim.reasoning || '').trim();
+      if (reasoning.length < MIN_RATIONALE_LENGTH) {
+        validationErrors.push({
+          sdKey: sdScore.sd_key,
+          rule: 'INSUFFICIENT_RATIONALE',
+          details: `Dimension '${dim.id}' has rationale of ${reasoning.length} chars`,
+        });
+      }
+    }
+  }
+
+  return validationErrors;
+}
+
+// ─── Helper: build a valid 5-dimension score ───
+
+function make5DimScore(sdKey = 'SD-TEST-001', score = 85) {
+  return {
+    sd_key: sdKey,
+    dimensions: REQUIRED_DIMENSIONS.map(id => ({
+      id,
+      score,
+      reasoning: `Verified ${id} — all items present in codebase.`,
+    })),
+    total_score: score,
+    gaps: [],
+    summary: 'All promises delivered.',
+  };
+}
+
+// ─── Helper: build a 6-dimension score (with planning_traceability) ───
+
+function make6DimScore(sdKey = 'SD-TEST-001', score = 85, planScore = 80) {
+  const base = make5DimScore(sdKey, score);
+  base.dimensions.push({
+    id: 'planning_traceability',
+    score: planScore,
+    reasoning: `4 of 5 architecture deliverables found in codebase. Missing: state-machine-module.`,
+    gaps: ['state-machine-module'],
+  });
+  return base;
+}
+
+// ─── Tests ───
+
+describe('KNOWN_DIMENSIONS', () => {
+  it('includes all 5 required dimensions', () => {
+    for (const dim of REQUIRED_DIMENSIONS) {
+      expect(KNOWN_DIMENSIONS).toContain(dim);
+    }
+  });
+
+  it('includes planning_traceability as 6th dimension', () => {
+    expect(KNOWN_DIMENSIONS).toContain('planning_traceability');
+    expect(KNOWN_DIMENSIONS).toHaveLength(6);
+  });
+});
+
+describe('Validation: 5-dimension scores (backward compatibility)', () => {
+  it('accepts valid 5-dimension scores with zero errors', () => {
+    const errors = validateSDScores([make5DimScore()]);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects scores missing required dimensions', () => {
+    const score = make5DimScore();
+    score.dimensions = score.dimensions.filter(d => d.id !== 'smoke_tests_pass');
+    const errors = validateSDScores([score]);
+    expect(errors.some(e => e.rule === 'MISSING_DIMENSIONS')).toBe(true);
+  });
+});
+
+describe('Validation: 6-dimension scores (planning_traceability)', () => {
+  it('accepts scores with planning_traceability — no UNKNOWN_DIMENSIONS error', () => {
+    const errors = validateSDScores([make6DimScore()]);
+    const unknownErrors = errors.filter(e => e.rule === 'UNKNOWN_DIMENSIONS');
+    expect(unknownErrors).toHaveLength(0);
+  });
+
+  it('still validates rationale length for planning_traceability', () => {
+    const score = make6DimScore();
+    score.dimensions.find(d => d.id === 'planning_traceability').reasoning = 'short';
+    const errors = validateSDScores([score]);
+    expect(errors.some(e => e.rule === 'INSUFFICIENT_RATIONALE' && e.details.includes('planning_traceability'))).toBe(true);
+  });
+});
+
+describe('Validation: truly unknown dimensions rejected', () => {
+  it('rejects scores with invented dimension keys', () => {
+    const score = make5DimScore();
+    score.dimensions.push({
+      id: 'totally_bogus_dimension',
+      score: 50,
+      reasoning: 'This dimension does not exist in the schema.',
+    });
+    const errors = validateSDScores([score]);
+    expect(errors.some(e => e.rule === 'UNKNOWN_DIMENSIONS' && e.details.includes('totally_bogus_dimension'))).toBe(true);
+  });
+});
+
+describe('Architecture deliverable loading', () => {
+  it('extracts deliverable names from extracted_dimensions', () => {
+    const extractedDimensions = [
+      { key: 'economic-lens-engine', name: 'Economic Lens Engine', description: 'Six-axis analysis', weight: 15 },
+      { key: 'kill-gate-integration', name: 'Kill Gate', description: 'Stage gate survival', weight: 10 },
+    ];
+    const deliverables = extractedDimensions.map(d => ({
+      name: d.key || d.name,
+      description: d.description || '',
+    }));
+    expect(deliverables).toHaveLength(2);
+    expect(deliverables[0].name).toBe('economic-lens-engine');
+    expect(deliverables[1].name).toBe('kill-gate-integration');
+  });
+
+  it('uses name as fallback when key is not present', () => {
+    const extractedDimensions = [
+      { name: 'Fallback Name', description: 'No key field' },
+    ];
+    const deliverables = extractedDimensions.map(d => ({
+      name: d.key || d.name,
+      description: d.description || '',
+    }));
+    expect(deliverables[0].name).toBe('Fallback Name');
+  });
+
+  it('skips loading when SD has no arch_key in metadata', () => {
+    const sd = { sd_key: 'SD-TEST-001', metadata: {} };
+    const archKey = sd.metadata?.arch_key;
+    expect(archKey).toBeUndefined();
+  });
+
+  it('skips loading when SD has null metadata', () => {
+    const sd = { sd_key: 'SD-TEST-001', metadata: null };
+    const archKey = sd.metadata?.arch_key;
+    expect(archKey).toBeUndefined();
+  });
+
+  it('extracts arch_key when present in metadata', () => {
+    const sd = { sd_key: 'SD-TEST-001', metadata: { arch_key: 'ARCH-EHG-L1-001' } };
+    const archKey = sd.metadata?.arch_key;
+    expect(archKey).toBe('ARCH-EHG-L1-001');
+  });
+});
+
+describe('Score calculation for planning_traceability', () => {
+  it('scores 100 when all deliverables found', () => {
+    const found = 5, total = 5;
+    const score = Math.round((found / total) * 100);
+    expect(score).toBe(100);
+  });
+
+  it('scores 60 when 3 of 5 deliverables found', () => {
+    const found = 3, total = 5;
+    const score = Math.round((found / total) * 100);
+    expect(score).toBe(60);
+  });
+
+  it('scores 0 when no deliverables found', () => {
+    const found = 0, total = 5;
+    const score = Math.round((found / total) * 100);
+    expect(score).toBe(0);
+  });
+
+  it('handles empty deliverable list gracefully (0/0 = 100 by convention)', () => {
+    const total = 0;
+    const score = total === 0 ? 100 : 0;
+    expect(score).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary
- Add optional 6th dimension (`planning_traceability`) to SD HEAL scoring system
- When an SD has `arch_key` in metadata, loads architecture plan deliverables from `eva_architecture_plans` and includes them in scoring context
- Creates `KNOWN_DIMENSIONS` array (required + optional) for backward-compatible validation
- SDs without architecture plans skip the dimension entirely — no false failures
- Existing 5-dimension scores remain fully valid (backward compatible)

## Changes
- `scripts/eva/heal-command.mjs`: Add `metadata` to SD query, load arch deliverables, extend scoring prompt, update validation to accept `planning_traceability`
- `tests/unit/eva/heal-planning-traceability.test.js`: 16 unit tests covering validation, backward compat, deliverable extraction, and score calculation

## Test plan
- [x] 16 unit tests pass (validation, backward compat, dimension acceptance, score calculation)
- [x] Existing 5-dimension scores accepted without errors
- [x] `planning_traceability` accepted as known dimension (not rejected as unknown)
- [x] Truly unknown dimensions still rejected
- [x] Architecture deliverable extraction handles missing/null metadata gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)