### PR TITLE
feat: add experiment-driven burst scheduling and auto-iteration loop

### DIFF
--- a/lib/eva/experiments/auto-iteration.js
+++ b/lib/eva/experiments/auto-iteration.js
@@ -1,0 +1,230 @@
+/**
+ * Auto-Iteration Loop
+ *
+ * Connects prompt promotion to experiment creation and pipeline burst triggering.
+ * When a prompt is promoted, automatically:
+ * 1. Creates a successor experiment with the winning prompt as champion
+ * 2. Generates a new challenger via MetaOptimizer
+ * 3. Triggers a pipeline burst via DemandEstimator
+ *
+ * Part of SD-AUTOMATED-PIPELINE-RUNNER-FOR-ORCH-001-C
+ */
+
+import { EventEmitter } from 'events';
+import { generateNextChallenger } from './meta-optimizer.js';
+import { evaluatePromotion } from './prompt-promotion.js';
+
+const DEFAULT_CONFIG = {
+  maxIterations: 10,          // Safety limit on auto-iteration count
+  cooldownMs: 30_000,         // Minimum time between iterations
+  autoStart: false,           // Whether to start iteration on construction
+};
+
+export class AutoIterationLoop extends EventEmitter {
+  /**
+   * @param {Object} [config]
+   * @param {number} [config.maxIterations=10] - Max auto-iterations before pause
+   * @param {number} [config.cooldownMs=30000] - Cooldown between iterations
+   * @param {Object} deps
+   * @param {Object} deps.supabase - Supabase client
+   * @param {Object} [deps.demandEstimator] - DemandEstimator instance
+   * @param {Object} [deps.logger] - Logger instance
+   */
+  constructor(config = {}, deps = {}) {
+    super();
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.supabase = deps.supabase;
+    this.demandEstimator = deps.demandEstimator || null;
+    this.logger = deps.logger || console;
+
+    this._iterationCount = 0;
+    this._lastIterationAt = 0;
+    this._running = false;
+  }
+
+  /**
+   * Process a completed experiment — evaluate for promotion, and if promoted,
+   * create successor experiment and trigger burst.
+   *
+   * @param {Object} params
+   * @param {string} params.experimentId - Completed experiment ID
+   * @param {Object} params.analysis - Output from analyzeExperiment()
+   * @param {Object} params.experiment - Experiment record with variants
+   * @returns {Promise<Object>} Iteration result
+   */
+  async processCompletion(params) {
+    const { experimentId, analysis, experiment } = params;
+
+    // Step 1: Evaluate for promotion
+    const promotionResult = await evaluatePromotion(
+      { supabase: this.supabase, logger: this.logger },
+      { experimentId, analysis, experiment }
+    );
+
+    if (!promotionResult.promoted) {
+      this.logger.log(
+        `[AutoIteration] Experiment ${experimentId} not promoted: ${promotionResult.reason}`
+      );
+      this.emit('no-promotion', { experimentId, reason: promotionResult.reason });
+      return { iterated: false, reason: promotionResult.reason };
+    }
+
+    // Step 2: Check safety limits
+    if (this._iterationCount >= this.config.maxIterations) {
+      this.logger.warn(
+        `[AutoIteration] Max iterations reached (${this.config.maxIterations}) — pausing`
+      );
+      this.emit('max-iterations', { count: this._iterationCount });
+      return { iterated: false, reason: 'max_iterations_reached' };
+    }
+
+    const now = Date.now();
+    if (now - this._lastIterationAt < this.config.cooldownMs) {
+      this.logger.warn('[AutoIteration] Cooldown active — skipping iteration');
+      return { iterated: false, reason: 'cooldown_active' };
+    }
+
+    // Step 3: Create successor experiment
+    const successor = await this._createSuccessorExperiment({
+      promotionResult,
+      previousExperiment: experiment,
+      previousExperimentId: experimentId,
+      analysis,
+    });
+
+    if (!successor) {
+      return { iterated: false, reason: 'successor_creation_failed' };
+    }
+
+    // Step 4: Trigger pipeline burst via DemandEstimator
+    if (this.demandEstimator) {
+      this.demandEstimator.emit('burst-needed', {
+        experimentId: successor.id,
+        experimentName: successor.name,
+        sampleCount: 0,
+        target: this.demandEstimator.config?.minSamplesPerExperiment || 20,
+        deficit: this.demandEstimator.config?.minSamplesPerExperiment || 20,
+        burstBatchSize: this.demandEstimator.config?.burstBatchSize || 12,
+        source: 'auto-iteration',
+      });
+    }
+
+    this._iterationCount++;
+    this._lastIterationAt = now;
+
+    this.logger.log(
+      `[AutoIteration] Iteration ${this._iterationCount}: ` +
+      `promoted ${promotionResult.promptName} → experiment ${successor.id}`
+    );
+
+    this.emit('iteration-complete', {
+      iteration: this._iterationCount,
+      promotedPrompt: promotionResult.promptName,
+      successorExperimentId: successor.id,
+      successorExperimentName: successor.name,
+    });
+
+    return {
+      iterated: true,
+      iteration: this._iterationCount,
+      promotion: promotionResult,
+      successorExperiment: successor,
+    };
+  }
+
+  /**
+   * Reset the iteration counter (e.g., on daily reset or manual intervention).
+   */
+  resetCounter() {
+    this._iterationCount = 0;
+    this._lastIterationAt = 0;
+    this.logger.log('[AutoIteration] Counter reset');
+  }
+
+  /**
+   * Get current auto-iteration status.
+   */
+  status() {
+    return {
+      iterationCount: this._iterationCount,
+      maxIterations: this.config.maxIterations,
+      lastIterationAt: this._lastIterationAt
+        ? new Date(this._lastIterationAt).toISOString()
+        : null,
+      cooldownMs: this.config.cooldownMs,
+    };
+  }
+
+  // --- Internal ---
+
+  async _createSuccessorExperiment(params) {
+    const { promotionResult, previousExperiment, previousExperimentId, analysis } = params;
+    const winnerPromptName = promotionResult.promptName;
+
+    try {
+      // Generate next challenger via MetaOptimizer
+      const winnerVariant = analysis.per_variant?.[promotionResult.winner];
+      const challenger = await generateNextChallenger(
+        { supabase: this.supabase, logger: this.logger },
+        {
+          championPromptName: winnerPromptName,
+          previousExperimentId,
+          winnerPosterior: winnerVariant?.posterior,
+        }
+      );
+
+      // Compute successor version
+      const prevVersion = previousExperiment?.config?.version || 1;
+      const successorName = `${previousExperiment?.name || 'experiment'}_v${prevVersion + 1}`;
+
+      // Create the successor experiment
+      const { data: newExp, error } = await this.supabase
+        .from('experiments')
+        .insert({
+          name: successorName,
+          status: 'active',
+          variants: [
+            {
+              key: 'champion',
+              prompt_name: winnerPromptName,
+              description: `Promoted winner from experiment ${previousExperimentId}`,
+            },
+            {
+              key: 'challenger',
+              prompt_name: challenger.prompt_name,
+              description: challenger.hypothesis,
+            },
+          ],
+          config: {
+            version: prevVersion + 1,
+            predecessor_experiment_id: previousExperimentId,
+            promoted_from: {
+              experiment_id: previousExperimentId,
+              winner_variant: promotionResult.winner,
+              confidence: promotionResult.confidence,
+            },
+            auto_iteration: true,
+            challenger_perturbation: challenger.perturbation_used,
+          },
+        })
+        .select('id, name')
+        .single();
+
+      if (error) {
+        this.logger.error(`[AutoIteration] Failed to create successor: ${error.message}`);
+        this.emit('error', { phase: 'create-successor', error: error.message });
+        return null;
+      }
+
+      this.logger.log(
+        `[AutoIteration] Created successor experiment: ${newExp.name} (${newExp.id})`
+      );
+
+      return newExp;
+    } catch (err) {
+      this.logger.error(`[AutoIteration] Successor creation error: ${err.message}`);
+      this.emit('error', { phase: 'create-successor', error: err.message });
+      return null;
+    }
+  }
+}

--- a/lib/eva/pipeline-runner/demand-estimator.js
+++ b/lib/eva/pipeline-runner/demand-estimator.js
@@ -1,0 +1,183 @@
+/**
+ * Demand Estimator
+ *
+ * Monitors experiment sample counts in experiment_assignments and emits
+ * burst signals when samples fall below a configurable threshold.
+ * Enables demand-driven venture generation for the pipeline.
+ *
+ * Part of SD-AUTOMATED-PIPELINE-RUNNER-FOR-ORCH-001-C
+ */
+
+import { EventEmitter } from 'events';
+
+const DEFAULT_CONFIG = {
+  pollIntervalMs: 60_000,         // Check every 60 seconds
+  minSamplesPerExperiment: 20,    // Trigger burst when below this
+  burstBatchSize: 12,             // Batch size during burst
+  maxConcurrentBursts: 3,         // Max experiments triggering bursts simultaneously
+};
+
+export class DemandEstimator extends EventEmitter {
+  /**
+   * @param {Object} [config]
+   * @param {number} [config.pollIntervalMs=60000] - Polling interval
+   * @param {number} [config.minSamplesPerExperiment=20] - Sample threshold for burst
+   * @param {number} [config.burstBatchSize=12] - Batch size during burst
+   * @param {number} [config.maxConcurrentBursts=3] - Max concurrent burst experiments
+   * @param {Object} [deps]
+   * @param {Object} [deps.supabase] - Supabase client
+   * @param {Object} [deps.logger] - Logger instance
+   */
+  constructor(config = {}, deps = {}) {
+    super();
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.supabase = deps.supabase;
+    this.logger = deps.logger || console;
+    this._timer = null;
+    this._running = false;
+    this._activeBursts = new Map(); // experimentId -> { target, current }
+  }
+
+  /**
+   * Start polling for experiment demand.
+   */
+  start() {
+    if (this._running) return;
+    this._running = true;
+    this.logger.log(`[DemandEstimator] Started — poll every ${this.config.pollIntervalMs}ms`);
+    this._poll();
+    this._timer = setInterval(() => this._poll(), this.config.pollIntervalMs);
+  }
+
+  /**
+   * Stop polling.
+   */
+  stop() {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+    this._running = false;
+    this.logger.log('[DemandEstimator] Stopped');
+  }
+
+  /**
+   * Check demand for a single experiment (useful for manual triggering).
+   * @param {string} experimentId
+   * @returns {Promise<Object>} { experimentId, sampleCount, target, needsBurst }
+   */
+  async checkExperiment(experimentId) {
+    const sampleCount = await this._countSamples(experimentId);
+    const target = this.config.minSamplesPerExperiment;
+    return {
+      experimentId,
+      sampleCount,
+      target,
+      needsBurst: sampleCount < target,
+      deficit: Math.max(0, target - sampleCount),
+    };
+  }
+
+  /**
+   * Get current burst status.
+   * @returns {Object}
+   */
+  status() {
+    return {
+      running: this._running,
+      activeBursts: this._activeBursts.size,
+      burstDetails: Object.fromEntries(this._activeBursts),
+      config: this.config,
+    };
+  }
+
+  // --- Internal ---
+
+  async _poll() {
+    if (!this.supabase) return;
+
+    try {
+      const activeExperiments = await this._getActiveExperiments();
+
+      if (activeExperiments.length === 0) {
+        // Clear any stale bursts
+        if (this._activeBursts.size > 0) {
+          this._activeBursts.clear();
+          this.emit('burst-end', { reason: 'no_active_experiments' });
+        }
+        return;
+      }
+
+      for (const exp of activeExperiments) {
+        if (this._activeBursts.size >= this.config.maxConcurrentBursts) break;
+
+        const sampleCount = await this._countSamples(exp.id);
+        const target = this.config.minSamplesPerExperiment;
+
+        if (sampleCount < target) {
+          const deficit = target - sampleCount;
+
+          if (!this._activeBursts.has(exp.id)) {
+            this._activeBursts.set(exp.id, { target, current: sampleCount, deficit });
+            this.logger.log(
+              `[DemandEstimator] Burst triggered for experiment ${exp.id}: ` +
+              `${sampleCount}/${target} samples (deficit: ${deficit})`
+            );
+            this.emit('burst-needed', {
+              experimentId: exp.id,
+              experimentName: exp.name,
+              sampleCount,
+              target,
+              deficit,
+              burstBatchSize: this.config.burstBatchSize,
+            });
+          }
+        } else {
+          // Demand satisfied — end burst for this experiment
+          if (this._activeBursts.has(exp.id)) {
+            this._activeBursts.delete(exp.id);
+            this.logger.log(
+              `[DemandEstimator] Demand satisfied for experiment ${exp.id}: ${sampleCount}/${target}`
+            );
+            this.emit('burst-satisfied', { experimentId: exp.id, sampleCount });
+          }
+        }
+      }
+
+      // Check if all bursts are satisfied
+      if (this._activeBursts.size === 0) {
+        this.emit('all-satisfied');
+      }
+    } catch (err) {
+      this.logger.warn(`[DemandEstimator] Poll error: ${err.message}`);
+    }
+  }
+
+  async _getActiveExperiments() {
+    const { data, error } = await this.supabase
+      .from('experiments')
+      .select('id, name, status')
+      .eq('status', 'active');
+
+    if (error) {
+      this.logger.warn(`[DemandEstimator] Failed to query experiments: ${error.message}`);
+      return [];
+    }
+
+    return data || [];
+  }
+
+  async _countSamples(experimentId) {
+    const { count, error } = await this.supabase
+      .from('experiment_assignments')
+      .select('*', { count: 'exact', head: true })
+      .eq('experiment_id', experimentId);
+
+    if (error) {
+      this.logger.warn(`[DemandEstimator] Failed to count samples: ${error.message}`);
+      return 0;
+    }
+
+    return count || 0;
+  }
+}

--- a/lib/eva/pipeline-runner/index.js
+++ b/lib/eva/pipeline-runner/index.js
@@ -12,6 +12,7 @@ import { PipelineScheduler } from './pipeline-scheduler.js';
 import { CircuitBreaker } from './circuit-breaker.js';
 import { DiversityValidator } from './diversity-validator.js';
 import { DeadLetterQueue } from './dead-letter-queue.js';
+import { DemandEstimator } from './demand-estimator.js';
 
 /**
  * Create and configure a pipeline runner instance.
@@ -58,11 +59,18 @@ export function createPipelineRunner(config = {}, deps = {}) {
     baseDelayMs: config.baseDelayMs,
   }, { logger });
 
+  const demandEstimator = new DemandEstimator({
+    pollIntervalMs: config.demandPollIntervalMs,
+    minSamplesPerExperiment: config.minSamplesPerExperiment,
+    burstBatchSize: config.burstBatchSize,
+  }, { supabase: deps.supabase, logger });
+
   const scheduler = new PipelineScheduler(
     {
       intervalMs: config.intervalMs,
       batchSize: config.batchSize,
       maxDailyVentures: config.maxDailyVentures,
+      burstBatchSize: config.burstBatchSize,
     },
     {
       factory,
@@ -70,6 +78,7 @@ export function createPipelineRunner(config = {}, deps = {}) {
       circuitBreaker,
       diversityValidator,
       deadLetterQueue,
+      demandEstimator,
       logger,
     }
   );
@@ -81,15 +90,18 @@ export function createPipelineRunner(config = {}, deps = {}) {
     executor,
     diversityValidator,
     deadLetterQueue,
+    demandEstimator,
 
     /** Start scheduled batch execution. */
     start() {
       scheduler.start();
+      demandEstimator.start();
     },
 
     /** Stop scheduled execution. */
     stop() {
       scheduler.stop();
+      demandEstimator.stop();
     },
 
     /**
@@ -113,3 +125,4 @@ export { PipelineScheduler } from './pipeline-scheduler.js';
 export { CircuitBreaker } from './circuit-breaker.js';
 export { DiversityValidator } from './diversity-validator.js';
 export { DeadLetterQueue } from './dead-letter-queue.js';
+export { DemandEstimator } from './demand-estimator.js';

--- a/lib/eva/pipeline-runner/pipeline-scheduler.js
+++ b/lib/eva/pipeline-runner/pipeline-scheduler.js
@@ -3,15 +3,20 @@
  *
  * Cron-driven batch orchestration for synthetic venture generation.
  * Coordinates SyntheticVentureFactory, PipelineExecutor, CircuitBreaker,
- * DiversityValidator, and DeadLetterQueue.
+ * DiversityValidator, DeadLetterQueue, and DemandEstimator.
  *
- * Part of SD-AUTOMATED-PIPELINE-RUNNER-FOR-ORCH-001-A/B
+ * Supports hybrid scheduling: baseline mode (48/day) with burst mode (up to 144/day)
+ * triggered by DemandEstimator demand signals.
+ *
+ * Part of SD-AUTOMATED-PIPELINE-RUNNER-FOR-ORCH-001-A/B/C
  */
 
 const DEFAULT_CONFIG = {
   intervalMs: 30 * 60 * 1000, // 30 minutes
   batchSize: 4,
   maxDailyVentures: 144,
+  burstBatchSize: 12,         // Batch size during burst mode
+  baselineDailyTarget: 48,    // Baseline target (12 batches × 4)
 };
 
 export class PipelineScheduler {
@@ -33,10 +38,13 @@ export class PipelineScheduler {
     this.circuitBreaker = deps.circuitBreaker;
     this.diversityValidator = deps.diversityValidator || null;
     this.deadLetterQueue = deps.deadLetterQueue || null;
+    this.demandEstimator = deps.demandEstimator || null;
     this.logger = deps.logger || console;
 
     this._timer = null;
     this._running = false;
+    this._burstMode = false;
+    this._burstExperimentId = null;
     this._dailyCount = 0;
     this._dailyResetAt = this._nextMidnight();
     this._metrics = {
@@ -46,7 +54,16 @@ export class PipelineScheduler {
       totalFailures: 0,
       lastBatchAt: null,
       avgBatchDurationMs: 0,
+      burstBatches: 0,
+      baselineBatches: 0,
     };
+
+    // Wire up DemandEstimator events
+    if (this.demandEstimator) {
+      this.demandEstimator.on('burst-needed', (event) => this._onBurstNeeded(event));
+      this.demandEstimator.on('burst-satisfied', (event) => this._onBurstSatisfied(event));
+      this.demandEstimator.on('all-satisfied', () => this._onAllSatisfied());
+    }
   }
 
   /**
@@ -95,15 +112,45 @@ export class PipelineScheduler {
   /**
    * Get current scheduler status and metrics.
    */
+  /**
+   * Activate burst mode for a specific experiment.
+   * @param {string} experimentId
+   * @param {number} [batchSize] - Override burst batch size
+   */
+  activateBurst(experimentId, batchSize) {
+    this._burstMode = true;
+    this._burstExperimentId = experimentId;
+    if (batchSize) this.config.burstBatchSize = batchSize;
+    this.logger.log(
+      `[PipelineScheduler] BURST MODE activated for experiment ${experimentId} ` +
+      `(batchSize=${this.config.burstBatchSize})`
+    );
+  }
+
+  /**
+   * Deactivate burst mode, return to baseline scheduling.
+   */
+  deactivateBurst() {
+    const wasActive = this._burstMode;
+    this._burstMode = false;
+    this._burstExperimentId = null;
+    if (wasActive) {
+      this.logger.log('[PipelineScheduler] BURST MODE deactivated — returning to baseline');
+    }
+  }
+
   status() {
     this._maybeResetDaily();
     return {
       running: this._running,
+      burstMode: this._burstMode,
+      burstExperimentId: this._burstExperimentId,
       config: this.config,
       dailyCount: this._dailyCount,
       dailyRemaining: Math.max(0, this.config.maxDailyVentures - this._dailyCount),
       circuitBreaker: this.circuitBreaker?.status() || null,
       deadLetterQueue: this.deadLetterQueue?.summary() || null,
+      demandEstimator: this.demandEstimator?.status() || null,
       metrics: { ...this._metrics },
     };
   }
@@ -136,15 +183,25 @@ export class PipelineScheduler {
       }
     }
 
-    await this._executeBatch(this.config.batchSize);
+    // Use burst batch size if burst mode is active
+    const batchSize = this._burstMode
+      ? this.config.burstBatchSize
+      : this.config.batchSize;
+
+    await this._executeBatch(batchSize, {
+      experimentId: this._burstExperimentId,
+    });
   }
 
   async _executeBatch(batchSize, options = {}) {
     const batchStart = Date.now();
-    this.logger.log(`[PipelineScheduler] Starting batch of ${batchSize} ventures...`);
+    const mode = this._burstMode ? 'BURST' : 'BASELINE';
+    this.logger.log(`[PipelineScheduler] Starting ${mode} batch of ${batchSize} ventures...`);
 
-    // Generate ventures
-    const { ventures, metadata } = this.factory.createBatch(batchSize);
+    // Generate ventures, passing experimentId for tagging
+    const { ventures, metadata } = this.factory.createBatch(batchSize, {
+      experimentId: options.experimentId,
+    });
 
     // Run DiversityValidator if available (enhanced validation beyond factory's built-in check)
     let diversityResult = null;
@@ -226,8 +283,13 @@ export class PipelineScheduler {
     this._metrics.avgBatchDurationMs = Math.round(
       ((this._metrics.avgBatchDurationMs * (this._metrics.totalBatches - 1)) + batchDuration) / this._metrics.totalBatches
     );
+    if (this._burstMode) {
+      this._metrics.burstBatches++;
+    } else {
+      this._metrics.baselineBatches++;
+    }
 
-    this.logger.log(`[PipelineScheduler] Batch complete: ${successes}/${results.length} succeeded in ${batchDuration}ms`);
+    this.logger.log(`[PipelineScheduler] ${mode} batch complete: ${successes}/${results.length} succeeded in ${batchDuration}ms`);
 
     return {
       batchSize: results.length,
@@ -239,7 +301,25 @@ export class PipelineScheduler {
       diversity: metadata,
       diversityValidation: diversityResult,
       deadLetterDepth: this.deadLetterQueue?.depth() || 0,
+      mode,
+      experimentId: options.experimentId || null,
     };
+  }
+
+  // --- DemandEstimator Event Handlers ---
+
+  _onBurstNeeded(event) {
+    this.activateBurst(event.experimentId, event.burstBatchSize);
+  }
+
+  _onBurstSatisfied(event) {
+    if (this._burstExperimentId === event.experimentId) {
+      this.deactivateBurst();
+    }
+  }
+
+  _onAllSatisfied() {
+    this.deactivateBurst();
   }
 
   _maybeResetDaily() {

--- a/lib/eva/pipeline-runner/synthetic-venture-factory.js
+++ b/lib/eva/pipeline-runner/synthetic-venture-factory.js
@@ -117,6 +117,7 @@ export class SyntheticVentureFactory {
    * @param {number} [options.seed] - Seed for reproducible generation
    * @param {string} [options.batchId] - Custom batch identifier
    * @param {string[]} [options.archetypeFilter] - Restrict to specific archetypes
+   * @param {string} [options.experimentId] - Tag ventures for a specific experiment
    * @returns {{ ventures: Object[], metadata: Object }}
    */
   createBatch(batchSize = 4, options = {}) {
@@ -134,6 +135,9 @@ export class SyntheticVentureFactory {
     for (let i = 0; i < batchSize; i++) {
       const archetype = archetypeAssignments[i];
       const venture = this._generateVenture(archetype, seed + i, rand, batchId, i);
+      if (options.experimentId) {
+        venture.synthetic_metadata.experiment_id = options.experimentId;
+      }
       ventures.push(venture);
     }
 
@@ -147,6 +151,7 @@ export class SyntheticVentureFactory {
         batchId,
         seed,
         batchSize,
+        experimentId: options.experimentId || null,
         archetypeDistribution: this._countArchetypes(archetypeKeys),
         shannonEntropy: entropy,
         normalizedEntropy: normEntropy,

--- a/tests/unit/eva/experiments/auto-iteration.test.js
+++ b/tests/unit/eva/experiments/auto-iteration.test.js
@@ -1,0 +1,260 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AutoIterationLoop } from '../../../../lib/eva/experiments/auto-iteration.js';
+
+// Mock the imports
+vi.mock('../../../../lib/eva/experiments/meta-optimizer.js', () => ({
+  generateNextChallenger: vi.fn().mockResolvedValue({
+    prompt_name: 'test_prompt_challenger_123',
+    prompt_content: 'modified prompt content',
+    hypothesis: 'rephrase perturbation should improve scores',
+    perturbation_used: 'rephrase',
+  }),
+}));
+
+vi.mock('../../../../lib/eva/experiments/prompt-promotion.js', () => ({
+  evaluatePromotion: vi.fn(),
+}));
+
+import { evaluatePromotion } from '../../../../lib/eva/experiments/prompt-promotion.js';
+
+describe('AutoIterationLoop', () => {
+  let loop;
+  let mockSupabase;
+  let mockDemandEstimator;
+  let mockLogger;
+
+  const mockAnalysis = {
+    status: 'conclusive',
+    total_samples: 30,
+    stopping: { winner: 'champion' },
+    per_variant: {
+      champion: { mean_score: 0.85, posterior: { alpha: 25, beta: 5 } },
+      challenger: { mean_score: 0.70, posterior: { alpha: 20, beta: 10 } },
+    },
+    comparisons: [{ variantA: 'champion', probABetterThanB: 0.95 }],
+  };
+
+  const mockExperiment = {
+    id: 'exp-1',
+    name: 'test_experiment',
+    variants: [
+      { key: 'champion', prompt_name: 'stage_zero_synthesis_v1' },
+      { key: 'challenger', prompt_name: 'stage_zero_synthesis_v1_challenger_old' },
+    ],
+    config: { version: 1 },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    mockDemandEstimator = {
+      emit: vi.fn(),
+      config: { minSamplesPerExperiment: 20, burstBatchSize: 12 },
+    };
+    mockSupabase = {
+      from: vi.fn().mockReturnValue({
+        insert: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { id: 'exp-2', name: 'test_experiment_v2' },
+              error: null,
+            }),
+          }),
+        }),
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({
+              data: { content: 'champion prompt text', prompt_text: 'champion prompt text', metadata: {} },
+              error: null,
+            }),
+            order: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        }),
+      }),
+    };
+  });
+
+  describe('processCompletion', () => {
+    it('should skip iteration when not promoted', async () => {
+      evaluatePromotion.mockResolvedValue({
+        promoted: false,
+        reason: 'experiment_not_conclusive',
+      });
+
+      loop = new AutoIterationLoop({}, {
+        supabase: mockSupabase,
+        demandEstimator: mockDemandEstimator,
+        logger: mockLogger,
+      });
+
+      const result = await loop.processCompletion({
+        experimentId: 'exp-1',
+        analysis: mockAnalysis,
+        experiment: mockExperiment,
+      });
+
+      expect(result.iterated).toBe(false);
+      expect(result.reason).toBe('experiment_not_conclusive');
+    });
+
+    it('should create successor experiment on promotion', async () => {
+      evaluatePromotion.mockResolvedValue({
+        promoted: true,
+        winner: 'champion',
+        promptName: 'stage_zero_synthesis_v1',
+        confidence: 0.95,
+      });
+
+      loop = new AutoIterationLoop({}, {
+        supabase: mockSupabase,
+        demandEstimator: mockDemandEstimator,
+        logger: mockLogger,
+      });
+
+      const result = await loop.processCompletion({
+        experimentId: 'exp-1',
+        analysis: mockAnalysis,
+        experiment: mockExperiment,
+      });
+
+      expect(result.iterated).toBe(true);
+      expect(result.iteration).toBe(1);
+      expect(result.successorExperiment.id).toBe('exp-2');
+    });
+
+    it('should trigger pipeline burst via DemandEstimator', async () => {
+      evaluatePromotion.mockResolvedValue({
+        promoted: true,
+        winner: 'champion',
+        promptName: 'stage_zero_synthesis_v1',
+        confidence: 0.95,
+      });
+
+      loop = new AutoIterationLoop({}, {
+        supabase: mockSupabase,
+        demandEstimator: mockDemandEstimator,
+        logger: mockLogger,
+      });
+
+      await loop.processCompletion({
+        experimentId: 'exp-1',
+        analysis: mockAnalysis,
+        experiment: mockExperiment,
+      });
+
+      expect(mockDemandEstimator.emit).toHaveBeenCalledWith(
+        'burst-needed',
+        expect.objectContaining({
+          experimentId: 'exp-2',
+          source: 'auto-iteration',
+        })
+      );
+    });
+
+    it('should respect max iterations safety limit', async () => {
+      evaluatePromotion.mockResolvedValue({
+        promoted: true,
+        winner: 'champion',
+        promptName: 'stage_zero_synthesis_v1',
+        confidence: 0.95,
+      });
+
+      loop = new AutoIterationLoop({ maxIterations: 1 }, {
+        supabase: mockSupabase,
+        demandEstimator: mockDemandEstimator,
+        logger: mockLogger,
+      });
+
+      // First iteration succeeds
+      await loop.processCompletion({
+        experimentId: 'exp-1',
+        analysis: mockAnalysis,
+        experiment: mockExperiment,
+      });
+
+      // Second iteration blocked by max limit
+      const result = await loop.processCompletion({
+        experimentId: 'exp-2',
+        analysis: mockAnalysis,
+        experiment: mockExperiment,
+      });
+
+      expect(result.iterated).toBe(false);
+      expect(result.reason).toBe('max_iterations_reached');
+    });
+
+    it('should respect cooldown between iterations', async () => {
+      evaluatePromotion.mockResolvedValue({
+        promoted: true,
+        winner: 'champion',
+        promptName: 'stage_zero_synthesis_v1',
+        confidence: 0.95,
+      });
+
+      loop = new AutoIterationLoop(
+        { maxIterations: 10, cooldownMs: 60_000 },
+        {
+          supabase: mockSupabase,
+          demandEstimator: mockDemandEstimator,
+          logger: mockLogger,
+        }
+      );
+
+      await loop.processCompletion({
+        experimentId: 'exp-1',
+        analysis: mockAnalysis,
+        experiment: mockExperiment,
+      });
+
+      // Immediate second attempt — should be blocked by cooldown
+      const result = await loop.processCompletion({
+        experimentId: 'exp-2',
+        analysis: mockAnalysis,
+        experiment: mockExperiment,
+      });
+
+      expect(result.iterated).toBe(false);
+      expect(result.reason).toBe('cooldown_active');
+    });
+  });
+
+  describe('resetCounter', () => {
+    it('should reset iteration count', async () => {
+      evaluatePromotion.mockResolvedValue({
+        promoted: true,
+        winner: 'champion',
+        promptName: 'stage_zero_synthesis_v1',
+        confidence: 0.95,
+      });
+
+      loop = new AutoIterationLoop({ maxIterations: 1, cooldownMs: 0 }, {
+        supabase: mockSupabase,
+        demandEstimator: mockDemandEstimator,
+        logger: mockLogger,
+      });
+
+      await loop.processCompletion({
+        experimentId: 'exp-1',
+        analysis: mockAnalysis,
+        experiment: mockExperiment,
+      });
+
+      loop.resetCounter();
+
+      const status = loop.status();
+      expect(status.iterationCount).toBe(0);
+    });
+  });
+
+  describe('status', () => {
+    it('should return current iteration status', () => {
+      loop = new AutoIterationLoop({ maxIterations: 5 }, { logger: mockLogger });
+      const status = loop.status();
+      expect(status.iterationCount).toBe(0);
+      expect(status.maxIterations).toBe(5);
+      expect(status.lastIterationAt).toBeNull();
+    });
+  });
+});

--- a/tests/unit/eva/pipeline-runner/burst-mode.test.js
+++ b/tests/unit/eva/pipeline-runner/burst-mode.test.js
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PipelineScheduler } from '../../../../lib/eva/pipeline-runner/pipeline-scheduler.js';
+
+describe('PipelineScheduler Burst Mode', () => {
+  let scheduler;
+  let mockFactory;
+  let mockExecutor;
+  let mockCircuitBreaker;
+  let mockLogger;
+
+  beforeEach(() => {
+    mockLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    mockFactory = {
+      createBatch: vi.fn().mockReturnValue({
+        ventures: [
+          { name: 'V1', archetype: 'democratizer' },
+          { name: 'V2', archetype: 'automator' },
+        ],
+        metadata: {
+          batchId: 'BATCH-1',
+          normalizedEntropy: 1.0,
+          diversityPass: true,
+          experimentId: null,
+        },
+      }),
+    };
+    mockExecutor = {
+      execute: vi.fn().mockResolvedValue({ success: true }),
+      supabase: {},
+    };
+    mockCircuitBreaker = {
+      isOpen: vi.fn().mockReturnValue(false),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
+      status: vi.fn().mockReturnValue({ state: 'closed' }),
+      checkOrganicPriority: vi.fn().mockResolvedValue(false),
+    };
+  });
+
+  describe('activateBurst / deactivateBurst', () => {
+    it('should track burst mode state', () => {
+      scheduler = new PipelineScheduler(
+        { batchSize: 4, burstBatchSize: 12 },
+        { factory: mockFactory, executor: mockExecutor, circuitBreaker: mockCircuitBreaker, logger: mockLogger }
+      );
+
+      expect(scheduler.status().burstMode).toBe(false);
+
+      scheduler.activateBurst('exp-1');
+      expect(scheduler.status().burstMode).toBe(true);
+      expect(scheduler.status().burstExperimentId).toBe('exp-1');
+
+      scheduler.deactivateBurst();
+      expect(scheduler.status().burstMode).toBe(false);
+      expect(scheduler.status().burstExperimentId).toBeNull();
+    });
+  });
+
+  describe('burst batch size', () => {
+    it('should use burst batch size during burst mode', async () => {
+      scheduler = new PipelineScheduler(
+        { batchSize: 4, burstBatchSize: 12 },
+        { factory: mockFactory, executor: mockExecutor, circuitBreaker: mockCircuitBreaker, logger: mockLogger }
+      );
+
+      scheduler.activateBurst('exp-1', 12);
+      await scheduler.runBatch({ batchSize: 12 });
+
+      expect(mockFactory.createBatch).toHaveBeenCalledWith(12, expect.objectContaining({}));
+    });
+  });
+
+  describe('experimentId pass-through', () => {
+    it('should pass experimentId to createBatch during burst', async () => {
+      scheduler = new PipelineScheduler(
+        { batchSize: 4 },
+        { factory: mockFactory, executor: mockExecutor, circuitBreaker: mockCircuitBreaker, logger: mockLogger }
+      );
+
+      await scheduler.runBatch({ experimentId: 'exp-1' });
+
+      expect(mockFactory.createBatch).toHaveBeenCalledWith(
+        4,
+        expect.objectContaining({ experimentId: 'exp-1' })
+      );
+    });
+  });
+
+  describe('metrics tracking', () => {
+    it('should track burst vs baseline batches', async () => {
+      scheduler = new PipelineScheduler(
+        { batchSize: 4, burstBatchSize: 12 },
+        { factory: mockFactory, executor: mockExecutor, circuitBreaker: mockCircuitBreaker, logger: mockLogger }
+      );
+
+      // Baseline batch
+      await scheduler.runBatch();
+      expect(scheduler.status().metrics.baselineBatches).toBe(1);
+      expect(scheduler.status().metrics.burstBatches).toBe(0);
+
+      // Burst batch
+      scheduler.activateBurst('exp-1');
+      await scheduler.runBatch({ batchSize: 12 });
+      expect(scheduler.status().metrics.burstBatches).toBe(1);
+      expect(scheduler.status().metrics.baselineBatches).toBe(1);
+    });
+  });
+
+  describe('DemandEstimator integration', () => {
+    it('should activate burst on burst-needed event', () => {
+      const { DemandEstimator } = require('../../../../lib/eva/pipeline-runner/demand-estimator.js');
+      const demandEstimator = new DemandEstimator({}, { logger: mockLogger });
+
+      scheduler = new PipelineScheduler(
+        { batchSize: 4, burstBatchSize: 12 },
+        {
+          factory: mockFactory,
+          executor: mockExecutor,
+          circuitBreaker: mockCircuitBreaker,
+          demandEstimator,
+          logger: mockLogger,
+        }
+      );
+
+      expect(scheduler.status().burstMode).toBe(false);
+
+      demandEstimator.emit('burst-needed', {
+        experimentId: 'exp-1',
+        burstBatchSize: 12,
+      });
+
+      expect(scheduler.status().burstMode).toBe(true);
+      expect(scheduler.status().burstExperimentId).toBe('exp-1');
+    });
+
+    it('should deactivate burst on burst-satisfied event', () => {
+      const { DemandEstimator } = require('../../../../lib/eva/pipeline-runner/demand-estimator.js');
+      const demandEstimator = new DemandEstimator({}, { logger: mockLogger });
+
+      scheduler = new PipelineScheduler(
+        { batchSize: 4 },
+        {
+          factory: mockFactory,
+          executor: mockExecutor,
+          circuitBreaker: mockCircuitBreaker,
+          demandEstimator,
+          logger: mockLogger,
+        }
+      );
+
+      demandEstimator.emit('burst-needed', { experimentId: 'exp-1', burstBatchSize: 12 });
+      expect(scheduler.status().burstMode).toBe(true);
+
+      demandEstimator.emit('burst-satisfied', { experimentId: 'exp-1' });
+      expect(scheduler.status().burstMode).toBe(false);
+    });
+  });
+
+  describe('organic priority during burst', () => {
+    it('should skip batch when organic queue is busy during burst', async () => {
+      mockCircuitBreaker.checkOrganicPriority.mockResolvedValue(true);
+
+      scheduler = new PipelineScheduler(
+        { batchSize: 4 },
+        { factory: mockFactory, executor: mockExecutor, circuitBreaker: mockCircuitBreaker, logger: mockLogger }
+      );
+
+      scheduler.activateBurst('exp-1');
+      // _tick checks organic priority
+      await scheduler._tick();
+
+      expect(mockFactory.createBatch).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Organic queue depth exceeded')
+      );
+    });
+  });
+});

--- a/tests/unit/eva/pipeline-runner/demand-estimator.test.js
+++ b/tests/unit/eva/pipeline-runner/demand-estimator.test.js
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { DemandEstimator } from '../../../../lib/eva/pipeline-runner/demand-estimator.js';
+
+describe('DemandEstimator', () => {
+  let estimator;
+  let mockSupabase;
+  let mockLogger;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    mockSupabase = {
+      from: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    };
+  });
+
+  afterEach(() => {
+    if (estimator) estimator.stop();
+    vi.useRealTimers();
+  });
+
+  describe('constructor', () => {
+    it('should use default config values', () => {
+      estimator = new DemandEstimator({}, { logger: mockLogger });
+      expect(estimator.config.pollIntervalMs).toBe(60_000);
+      expect(estimator.config.minSamplesPerExperiment).toBe(20);
+      expect(estimator.config.burstBatchSize).toBe(12);
+    });
+
+    it('should accept custom config', () => {
+      estimator = new DemandEstimator({
+        pollIntervalMs: 5000,
+        minSamplesPerExperiment: 10,
+      }, { logger: mockLogger });
+      expect(estimator.config.pollIntervalMs).toBe(5000);
+      expect(estimator.config.minSamplesPerExperiment).toBe(10);
+    });
+  });
+
+  describe('checkExperiment', () => {
+    it('should detect when experiment needs burst', async () => {
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ count: 5, error: null }),
+          }),
+        }),
+      };
+      estimator = new DemandEstimator(
+        { minSamplesPerExperiment: 20 },
+        { supabase, logger: mockLogger }
+      );
+
+      const result = await estimator.checkExperiment('exp-1');
+      expect(result.needsBurst).toBe(true);
+      expect(result.deficit).toBe(15);
+      expect(result.sampleCount).toBe(5);
+    });
+
+    it('should not need burst when samples are sufficient', async () => {
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ count: 25, error: null }),
+          }),
+        }),
+      };
+      estimator = new DemandEstimator(
+        { minSamplesPerExperiment: 20 },
+        { supabase, logger: mockLogger }
+      );
+
+      const result = await estimator.checkExperiment('exp-1');
+      expect(result.needsBurst).toBe(false);
+      expect(result.deficit).toBe(0);
+    });
+  });
+
+  describe('polling', () => {
+    it('should emit burst-needed when experiment has insufficient samples', async () => {
+      // Mock getActiveExperiments
+      const fromMock = vi.fn();
+      mockSupabase.from = fromMock;
+
+      // First call: experiments query
+      fromMock.mockImplementation((table) => {
+        if (table === 'experiments') {
+          return {
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({
+                data: [{ id: 'exp-1', name: 'Test Exp', status: 'active' }],
+                error: null,
+              }),
+            }),
+          };
+        }
+        // experiment_assignments count query
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ count: 3, error: null }),
+          }),
+        };
+      });
+
+      estimator = new DemandEstimator(
+        { minSamplesPerExperiment: 20, pollIntervalMs: 1000 },
+        { supabase: mockSupabase, logger: mockLogger }
+      );
+
+      const burstPromise = new Promise(resolve => {
+        estimator.on('burst-needed', resolve);
+      });
+
+      estimator.start();
+      await vi.advanceTimersByTimeAsync(100);
+
+      const event = await burstPromise;
+      expect(event.experimentId).toBe('exp-1');
+      expect(event.deficit).toBe(17);
+    });
+
+    it('should not emit when no active experiments', async () => {
+      mockSupabase.from = vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+        }),
+      });
+
+      estimator = new DemandEstimator(
+        { pollIntervalMs: 1000 },
+        { supabase: mockSupabase, logger: mockLogger }
+      );
+
+      const burstFn = vi.fn();
+      estimator.on('burst-needed', burstFn);
+
+      estimator.start();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(burstFn).not.toHaveBeenCalled();
+    });
+
+    it('should not poll without supabase', async () => {
+      estimator = new DemandEstimator(
+        { pollIntervalMs: 1000 },
+        { logger: mockLogger }
+      );
+
+      const burstFn = vi.fn();
+      estimator.on('burst-needed', burstFn);
+
+      estimator.start();
+      await vi.advanceTimersByTimeAsync(2000);
+
+      expect(burstFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('status', () => {
+    it('should return current status', () => {
+      estimator = new DemandEstimator({}, { logger: mockLogger });
+      const status = estimator.status();
+      expect(status.running).toBe(false);
+      expect(status.activeBursts).toBe(0);
+    });
+  });
+
+  describe('start/stop', () => {
+    it('should set running state', () => {
+      estimator = new DemandEstimator({}, { logger: mockLogger });
+      expect(estimator.status().running).toBe(false);
+      estimator.start();
+      expect(estimator.status().running).toBe(true);
+      estimator.stop();
+      expect(estimator.status().running).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add DemandEstimator module for experiment sample monitoring and burst triggers
- Add AutoIterationLoop connecting prompt promotion to successor experiments
- Enhance PipelineScheduler with hybrid baseline/burst scheduling
- Wire experimentId through SyntheticVentureFactory
- 94 tests passing across 9 files

Part of SD-AUTOMATED-PIPELINE-RUNNER-FOR-ORCH-001 (Child C)

## Test plan
- [x] 94 tests pass (DemandEstimator, burst mode, auto-iteration, full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)