### PR TITLE
feat: add persistent EVA Updates for Friday meeting data

### DIFF
--- a/database/migrations/20260313_eva_updates_table.sql
+++ b/database/migrations/20260313_eva_updates_table.sql
@@ -1,0 +1,50 @@
+-- Migration: Create eva_updates table
+-- Purpose: Store EVA weekly meeting updates with sections, coordinator data, decisions, and chairman notes
+-- Date: 2026-03-13
+-- Rollback: DROP TABLE IF EXISTS eva_updates CASCADE;
+
+CREATE TABLE IF NOT EXISTS eva_updates (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  meeting_date DATE NOT NULL UNIQUE,
+  sections JSONB DEFAULT '{}',
+  coordinator JSONB DEFAULT '{}',
+  decisions JSONB DEFAULT '{}',
+  chairman_notes TEXT,
+  digest TEXT,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+COMMENT ON TABLE eva_updates IS 'Stores EVA weekly meeting updates including section reports, coordinator status, decisions, and chairman notes';
+COMMENT ON COLUMN eva_updates.meeting_date IS 'Date of the EVA meeting (unique per day)';
+COMMENT ON COLUMN eva_updates.sections IS 'JSONB object containing section-level reports and status';
+COMMENT ON COLUMN eva_updates.coordinator IS 'JSONB object containing coordinator metrics and status';
+COMMENT ON COLUMN eva_updates.decisions IS 'JSONB object containing decisions made during the meeting';
+COMMENT ON COLUMN eva_updates.chairman_notes IS 'Free-text chairman observations and notes';
+COMMENT ON COLUMN eva_updates.digest IS 'Condensed summary of the meeting for quick reference';
+COMMENT ON COLUMN eva_updates.completed_at IS 'Timestamp when the meeting update was finalized';
+
+-- Index for historical queries (descending date for recent-first access)
+CREATE INDEX IF NOT EXISTS idx_eva_updates_meeting_date ON eva_updates (meeting_date DESC);
+
+-- Row Level Security
+ALTER TABLE eva_updates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access" ON eva_updates
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Updated_at trigger function
+CREATE OR REPLACE FUNCTION update_eva_updates_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_eva_updates_updated_at
+  BEFORE UPDATE ON eva_updates
+  FOR EACH ROW
+  EXECUTE FUNCTION update_eva_updates_updated_at();

--- a/scripts/eva/friday-meeting.mjs
+++ b/scripts/eva/friday-meeting.mjs
@@ -264,6 +264,70 @@ async function processDecision(finding, decision) {
   return 'deferred';
 }
 
+// ─── Persistence: Fleet Rollup ───────────────────────────────
+
+async function getFleetRollup() {
+  try {
+    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const [completedRes, activeRes, pendingRes, blockedRes] = await Promise.all([
+      supabase.from('strategic_directives_v2')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'completed')
+        .gte('completion_date', oneWeekAgo),
+      supabase.from('strategic_directives_v2')
+        .select('id', { count: 'exact', head: true })
+        .eq('is_working_on', true),
+      supabase.from('strategic_directives_v2')
+        .select('id', { count: 'exact', head: true })
+        .in('status', ['draft', 'ready', 'in_progress'])
+        .eq('is_working_on', false),
+      supabase.from('strategic_directives_v2')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'blocked'),
+    ]);
+
+    return {
+      fleet_velocity: completedRes.count || 0,
+      active_claims: activeRes.count || 0,
+      pending_sds: pendingRes.count || 0,
+      blocked_sds: blockedRes.count || 0,
+      captured_at: new Date().toISOString(),
+    };
+  } catch (err) {
+    logger.warn(`  Fleet rollup failed (non-blocking): ${err.message}`);
+    return {};
+  }
+}
+
+// ─── Persistence: Meeting Log ────────────────────────────────
+
+async function persistMeetingLog(results, coordinator = {}) {
+  try {
+    const meetingDate = new Date().toISOString().slice(0, 10);
+
+    const { error } = await supabase
+      .from('eva_updates')
+      .upsert({
+        meeting_date: meetingDate,
+        sections: results.sections || {},
+        coordinator,
+        decisions: results.decisions || {},
+        completed_at: new Date().toISOString(),
+      }, { onConflict: 'meeting_date' });
+
+    if (error) {
+      logger.warn(`  Meeting persist failed (non-blocking): ${error.message}`);
+      return false;
+    }
+    logger.log('  ✓ Meeting data persisted to eva_updates');
+    return true;
+  } catch (err) {
+    logger.warn(`  Meeting persist error (non-blocking): ${err.message}`);
+    return false;
+  }
+}
+
 // ─── Main Handler ────────────────────────────────────────────
 
 /**
@@ -327,6 +391,10 @@ export async function fridayMeetingHandler(options = {}) {
     }
   }
 
+  // Persist meeting data (non-blocking)
+  const coordinator = await getFleetRollup();
+  await persistMeetingLog(results, coordinator);
+
   logger.log('');
   logger.log('═'.repeat(55));
   logger.log('   Meeting data gathered. Decisions pending.');
@@ -356,6 +424,17 @@ export async function processMeetingDecisions(decisions) {
   logger.log(`  Dismissed: ${summary.dismissed}`);
   logger.log(`  Deferred:  ${summary.deferred}`);
   logger.log('  ' + '─'.repeat(45) + '\n');
+
+  // Update persisted record with decision outcomes
+  const meetingDate = new Date().toISOString().slice(0, 10);
+  await supabase
+    .from('eva_updates')
+    .update({ decisions: summary })
+    .eq('meeting_date', meetingDate)
+    .then(({ error }) => {
+      if (error) logger.warn(`  Decision persist failed: ${error.message}`);
+      else logger.log('  ✓ Decisions updated in eva_updates');
+    });
 
   return summary;
 }

--- a/scripts/lib/health-urgency.js
+++ b/scripts/lib/health-urgency.js
@@ -1,0 +1,191 @@
+/**
+ * Health Urgency Bridge
+ * SD: SD-LEO-INFRA-PRIORITY-SCORER-HEALTH-001
+ *
+ * Bridges codebase_health_snapshots DB data to the healthData format
+ * consumed by calculateHealthUrgency() in priority-scorer.js.
+ *
+ * Also provides:
+ * - isHealthDerivedSD() for health SD detection
+ * - checkHealthFreshness() for sd:next advisory
+ * - loadHealthUrgencyForSD() for batch loading in sd-next queue
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+/**
+ * Get a Supabase client (reuses process-level singleton pattern)
+ */
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  );
+}
+
+/**
+ * Build healthData object from latest codebase_health_snapshots.
+ * This object is passed to calculateHealthUrgency() in priority-scorer.js.
+ *
+ * @param {Object} [supabase] - Supabase client (optional, creates one if not provided)
+ * @returns {Promise<Object|null>} healthData or null if no snapshots exist
+ */
+export async function buildHealthDataFromSnapshots(supabase) {
+  const sb = supabase || getSupabase();
+
+  // Get latest snapshot per dimension
+  const { data: snapshots } = await sb
+    .from('codebase_health_snapshots')
+    .select('dimension, score, finding_count, findings, scanned_at')
+    .order('scanned_at', { ascending: false })
+    .limit(20);
+
+  if (!snapshots || snapshots.length === 0) return null;
+
+  // Deduplicate: keep latest per dimension
+  const latest = new Map();
+  for (const snap of snapshots) {
+    if (!latest.has(snap.dimension)) {
+      latest.set(snap.dimension, snap);
+    }
+  }
+
+  // Aggregate severity distribution across all dimensions
+  const severity_distribution = { critical: 0, high: 0, medium: 0, info: 0 };
+  let totalFindings = 0;
+  let lowestScore = 100;
+  let oldestScanMs = Date.now();
+
+  for (const [, snap] of latest) {
+    totalFindings += snap.finding_count || 0;
+    if (snap.score < lowestScore) lowestScore = snap.score;
+    const scanTime = new Date(snap.scanned_at).getTime();
+    if (scanTime < oldestScanMs) oldestScanMs = scanTime;
+
+    // Count severities from findings array
+    if (Array.isArray(snap.findings)) {
+      for (const f of snap.findings) {
+        const sev = (f.severity || 'info').toLowerCase();
+        if (sev === 'critical') severity_distribution.critical++;
+        else if (sev === 'high' || sev === 'warning') severity_distribution.high++;
+        else if (sev === 'medium') severity_distribution.medium++;
+        else severity_distribution.info++;
+      }
+    }
+  }
+
+  const oldestFindingDays = (Date.now() - oldestScanMs) / (1000 * 60 * 60 * 24);
+
+  return {
+    finding_count: totalFindings,
+    severity_distribution,
+    oldest_finding_days: Math.round(oldestFindingDays * 10) / 10,
+    dimension_score: lowestScore
+  };
+}
+
+/**
+ * Load health urgency max_points config from DB.
+ * Falls back to default 20 if no config row exists.
+ *
+ * @param {Object} [supabase] - Supabase client
+ * @returns {Promise<Object>} Config object with max_points
+ */
+export async function loadHealthUrgencyConfig(supabase) {
+  const sb = supabase || getSupabase();
+  try {
+    const { data } = await sb
+      .from('codebase_health_config')
+      .select('metadata')
+      .eq('dimension', 'health_urgency')
+      .single();
+
+    if (data?.metadata) {
+      return {
+        max_points: data.metadata.health_urgency_max_points || 20,
+        enabled: data.metadata.health_urgency_enabled !== false
+      };
+    }
+  } catch {
+    // Config row doesn't exist — use defaults
+  }
+  return { max_points: 20, enabled: true };
+}
+
+/**
+ * Check if an SD is health-derived (originated from codebase health system).
+ *
+ * @param {Object} sd - Strategic Directive object
+ * @returns {boolean} True if SD was generated from health findings
+ */
+export function isHealthDerivedSD(sd) {
+  if (sd.metadata?.origin === 'codebase_health') return true;
+  if (sd.metadata?.source === 'health_scan') return true;
+
+  if (Array.isArray(sd.delivers_capabilities)) {
+    for (const cap of sd.delivers_capabilities) {
+      if (typeof cap === 'object' && cap.capability_key?.includes('health')) return true;
+    }
+  }
+
+  const title = (sd.title || '').toLowerCase();
+  if (title.includes('health') && (title.includes('degradation') || title.includes('finding'))) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Check health snapshot freshness for sd:next advisory.
+ *
+ * @param {Object} [supabase] - Supabase client
+ * @returns {Promise<{ stale: boolean, message: string, lastScan: string|null, hoursOld: number|null }>}
+ */
+export async function checkHealthFreshness(supabase) {
+  const sb = supabase || getSupabase();
+
+  const { data: latest } = await sb
+    .from('codebase_health_snapshots')
+    .select('scanned_at')
+    .order('scanned_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (!latest) {
+    return {
+      stale: true,
+      message: 'No health snapshots found. Run: npm run health:scan',
+      lastScan: null,
+      hoursOld: null
+    };
+  }
+
+  const hoursOld = (Date.now() - new Date(latest.scanned_at).getTime()) / (1000 * 60 * 60);
+
+  if (hoursOld > 24) {
+    return {
+      stale: true,
+      message: `Health snapshots are ${Math.round(hoursOld)}h old. Run: npm run health:scan`,
+      lastScan: latest.scanned_at,
+      hoursOld: Math.round(hoursOld)
+    };
+  }
+
+  return {
+    stale: false,
+    message: `Last health scan: ${Math.round(hoursOld)}h ago`,
+    lastScan: latest.scanned_at,
+    hoursOld: Math.round(hoursOld)
+  };
+}
+
+export default {
+  buildHealthDataFromSnapshots,
+  loadHealthUrgencyConfig,
+  isHealthDerivedSD,
+  checkHealthFreshness
+};

--- a/scripts/modules/sd-next/display/health-freshness.js
+++ b/scripts/modules/sd-next/display/health-freshness.js
@@ -1,0 +1,25 @@
+/**
+ * Health Freshness Advisory Display
+ * SD: SD-LEO-INFRA-PRIORITY-SCORER-HEALTH-001 (FR-5)
+ *
+ * Shows a non-blocking advisory when health snapshots are stale (>24h old).
+ */
+
+import { colors } from '../colors.js';
+
+/**
+ * Display health snapshot freshness advisory.
+ *
+ * @param {{ stale: boolean, message: string, lastScan: string|null, hoursOld: number|null }} freshness
+ */
+export function displayHealthFreshness(freshness) {
+  if (!freshness) return;
+
+  if (freshness.stale) {
+    console.log(`\n${colors.yellow}${colors.bold}HEALTH ADVISORY${colors.reset}`);
+    console.log(`${colors.yellow}   ⚠️  ${freshness.message}${colors.reset}`);
+    if (freshness.lastScan) {
+      console.log(`${colors.dim}   Last scan: ${new Date(freshness.lastScan).toLocaleString()}${colors.reset}`);
+    }
+  }
+}

--- a/scripts/modules/sd-next/display/index.js
+++ b/scripts/modules/sd-next/display/index.js
@@ -28,3 +28,4 @@ export { displayTelemetryFindings } from './telemetry-findings.js';
 export { displayVisionPortfolioHeader, formatVisionBadge } from './vision-scorecard.js';
 export { displayQuickFixes } from './quick-fixes.js';
 export { displayRoadmapAwareness } from './roadmap-awareness.js';
+export { displayHealthFreshness } from './health-freshness.js';

--- a/tests/unit/lib/health-urgency.test.js
+++ b/tests/unit/lib/health-urgency.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { calculateHealthUrgency, calculatePriorityScore, WEIGHTS } from '../../../scripts/lib/priority-scorer.js';
+
+describe('Health Urgency Scoring (priority-scorer)', () => {
+  it('should return 0 when no health data provided', () => {
+    expect(calculateHealthUrgency()).toBe(0);
+    expect(calculateHealthUrgency({})).toBe(0);
+    expect(calculateHealthUrgency({ finding_count: 0 })).toBe(0);
+  });
+
+  it('should score critical findings higher than warnings', () => {
+    const criticalData = {
+      finding_count: 5,
+      severity_distribution: { critical: 5, high: 0, medium: 0, info: 0 },
+      oldest_finding_days: 0,
+      dimension_score: 50
+    };
+    const warningData = {
+      finding_count: 5,
+      severity_distribution: { critical: 0, high: 5, medium: 0, info: 0 },
+      oldest_finding_days: 0,
+      dimension_score: 50
+    };
+
+    const criticalScore = calculateHealthUrgency(criticalData);
+    const warningScore = calculateHealthUrgency(warningData);
+
+    expect(criticalScore).toBeGreaterThan(warningScore);
+    expect(criticalScore).toBeGreaterThan(0);
+    expect(warningScore).toBeGreaterThan(0);
+  });
+
+  it('should increase urgency with finding age (staleness)', () => {
+    const freshData = {
+      finding_count: 3,
+      severity_distribution: { critical: 1, high: 1, medium: 1, info: 0 },
+      oldest_finding_days: 1,
+      dimension_score: 60
+    };
+    const staleData = {
+      ...freshData,
+      oldest_finding_days: 10
+    };
+
+    const freshScore = calculateHealthUrgency(freshData);
+    const staleScore = calculateHealthUrgency(staleData);
+
+    expect(staleScore).toBeGreaterThan(freshScore);
+  });
+
+  it('should cap at max_points', () => {
+    const extremeData = {
+      finding_count: 100,
+      severity_distribution: { critical: 50, high: 30, medium: 15, info: 5 },
+      oldest_finding_days: 30,
+      dimension_score: 10
+    };
+
+    const score = calculateHealthUrgency(extremeData);
+    expect(score).toBeLessThanOrEqual(WEIGHTS.healthUrgency.defaultWeight);
+  });
+
+  it('should respect custom max_points config', () => {
+    const data = {
+      finding_count: 10,
+      severity_distribution: { critical: 5, high: 3, medium: 2, info: 0 },
+      oldest_finding_days: 5,
+      dimension_score: 30
+    };
+
+    const score10 = calculateHealthUrgency(data, { max_points: 10 });
+    const score30 = calculateHealthUrgency(data, { max_points: 30 });
+
+    expect(score10).toBeLessThanOrEqual(10);
+    expect(score30).toBeLessThanOrEqual(30);
+  });
+
+  it('should return 0 when finding_count is 0 even with low dimension score', () => {
+    const healthyData = {
+      finding_count: 0,
+      severity_distribution: { critical: 0, high: 0, medium: 0, info: 0 },
+      oldest_finding_days: 0,
+      dimension_score: 100
+    };
+
+    expect(calculateHealthUrgency(healthyData)).toBe(0);
+  });
+});
+
+describe('Health Urgency in Priority Scorer Integration', () => {
+  it('should include healthUrgency in breakdown', () => {
+    const sd = { priority: 'medium', sd_type: 'infrastructure' };
+    const result = calculatePriorityScore(sd, [], {}, { healthUrgency: 15 });
+
+    expect(result.healthUrgency).toBe(15);
+    expect(result.details.healthUrgency).toContain('15.0 pts');
+    expect(result.total).toBeGreaterThan(0);
+  });
+
+  it('should cap healthUrgency at max points', () => {
+    const sd = { priority: 'medium', sd_type: 'feature' };
+    const result = calculatePriorityScore(sd, [], {}, { healthUrgency: 100 });
+
+    expect(result.healthUrgency).toBe(WEIGHTS.maxPoints.healthUrgency);
+  });
+
+  it('should show none when no health urgency provided', () => {
+    const sd = { priority: 'high', sd_type: 'feature' };
+    const result = calculatePriorityScore(sd, [], {}, {});
+
+    expect(result.healthUrgency).toBe(0);
+    expect(result.details.healthUrgency).toBe('none');
+  });
+
+  it('should add health urgency to total score', () => {
+    const sd = { priority: 'medium', sd_type: 'infrastructure' };
+    const withoutHealth = calculatePriorityScore(sd, [], {}, {});
+    const withHealth = calculatePriorityScore(sd, [], {}, { healthUrgency: 15 });
+
+    expect(withHealth.total).toBe(withoutHealth.total + 15);
+  });
+});
+
+describe('isHealthDerivedSD', () => {
+  let isHealthDerivedSD;
+
+  beforeAll(async () => {
+    const mod = await import('../../../scripts/lib/health-urgency.js');
+    isHealthDerivedSD = mod.isHealthDerivedSD;
+  });
+
+  it('should detect health origin in metadata', () => {
+    expect(isHealthDerivedSD({ metadata: { origin: 'codebase_health' } })).toBe(true);
+    expect(isHealthDerivedSD({ metadata: { source: 'health_scan' } })).toBe(true);
+  });
+
+  it('should detect health capabilities', () => {
+    const sd = {
+      delivers_capabilities: [
+        { capability_type: 'quality_gate', capability_key: 'health-scanner', name: 'Health Scanner' }
+      ]
+    };
+    expect(isHealthDerivedSD(sd)).toBe(true);
+  });
+
+  it('should detect health title keywords', () => {
+    expect(isHealthDerivedSD({ title: 'Health degradation: complexity at 40/100' })).toBe(true);
+    expect(isHealthDerivedSD({ title: 'Implement new feature' })).toBe(false);
+  });
+
+  it('should return false for non-health SDs', () => {
+    expect(isHealthDerivedSD({ title: 'Add login button', metadata: {} })).toBe(false);
+    expect(isHealthDerivedSD({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Create `eva_updates` table with JSONB columns for forward-compatible meeting storage
- Add `persistMeetingLog()` and `getFleetRollup()` to `friday-meeting.mjs`
- Each Friday meeting now auto-persists 5-section data + coordinator fleet rollup
- Uses `ON CONFLICT (meeting_date) DO UPDATE` for idempotent re-runs

## Test plan
- [x] Smoke test: table upsert verified (insert + idempotent re-upsert = same row)
- [x] RLS enabled with service role policy
- [x] Index on meeting_date DESC for historical queries
- [x] Coordinator rollup failure is non-blocking (graceful degradation)
- [ ] Run Friday meeting end-to-end to verify persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)