### PR TITLE
feat: R&D proposals in Friday meeting + Research Lab page

### DIFF
--- a/lib/skunkworks/friday-rd-section.js
+++ b/lib/skunkworks/friday-rd-section.js
@@ -1,0 +1,152 @@
+/**
+ * Friday Meeting R&D Proposals Section
+ * Gathers and renders R&D proposals for the Friday meeting.
+ *
+ * SD: SD-AUTONOMOUS-SKUNKWORKS-RD-DEPARTMENT-ORCH-001-B
+ */
+
+/**
+ * Gather pending R&D proposals from rd_proposals table.
+ * @param {Object} deps - { supabase, logger }
+ * @returns {Promise<{proposals: Array, grouped: Object}>}
+ */
+export async function gatherRdProposals(deps) {
+  const { supabase, logger = console } = deps;
+
+  const { data: proposals, error } = await supabase
+    .from('rd_proposals')
+    .select('id, title, hypothesis, priority_score, signal_source, evidence, expected_impact, batch_run_id, created_at')
+    .eq('status', 'pending_review')
+    .order('priority_score', { ascending: false })
+    .limit(15);
+
+  if (error) {
+    logger.warn(`  [rd-proposals] Query failed: ${error.message}`);
+    return { proposals: [], grouped: {} };
+  }
+
+  const grouped = {};
+  for (const p of proposals || []) {
+    const source = p.signal_source || 'composite';
+    if (!grouped[source]) grouped[source] = [];
+    grouped[source].push(p);
+  }
+
+  return { proposals: proposals || [], grouped };
+}
+
+/**
+ * Render R&D proposals section for the Friday meeting output.
+ * @param {Object} data - { proposals, grouped }
+ * @returns {string}
+ */
+export function renderRdProposals(data) {
+  const lines = [];
+  lines.push('');
+  lines.push('  SECTION 5: R&D PROPOSALS');
+  lines.push('  ' + '─'.repeat(45));
+
+  if (data.proposals.length === 0) {
+    lines.push('  No pending R&D proposals.');
+    lines.push('  The skunkworks batch runs every Monday.');
+    return lines.join('\n');
+  }
+
+  lines.push(`  ${data.proposals.length} pending proposal(s) across ${Object.keys(data.grouped).length} signal source(s):`);
+  lines.push('');
+
+  for (const [source, proposals] of Object.entries(data.grouped)) {
+    lines.push(`  [${source.toUpperCase()}]`);
+    for (const p of proposals) {
+      lines.push(`    - ${p.title} (priority: ${p.priority_score})`);
+      if (p.hypothesis) {
+        lines.push(`      Hypothesis: ${p.hypothesis}`);
+      }
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build combined decision payload for AskUserQuestion.
+ * Merges consultant findings and R&D proposals into a single decision flow.
+ *
+ * @param {Array} findings - Consultant findings
+ * @param {Array} proposals - R&D proposals
+ * @returns {Object|null} AskUserQuestion payload
+ */
+export function buildCombinedDecisionPayload(findings, proposals) {
+  const questions = [];
+  let idx = 0;
+  const total = findings.length + proposals.length;
+
+  for (const f of findings) {
+    idx++;
+    questions.push({
+      question: `[FINDING] ${f.title}\n${f.description}\nDomain: ${f.analysis_domain || 'unknown'} | Priority: ${f.priority_score} | Action: ${f.action_type}`,
+      header: `Item ${idx}/${total} — Consultant Finding`,
+      multiSelect: false,
+      itemType: 'finding',
+      itemId: f.id,
+      options: [
+        { label: 'Accept', description: 'Act on this finding — EVA will create SD or take recommended action' },
+        { label: 'Dismiss', description: 'This finding is not actionable — suppress similar future recommendations' },
+        { label: 'Defer', description: 'Review again next week — keep as pending' },
+      ],
+    });
+  }
+
+  for (const p of proposals) {
+    idx++;
+    questions.push({
+      question: `[R&D PROPOSAL] ${p.title}\nHypothesis: ${p.hypothesis || 'N/A'}\nSignal: ${p.signal_source || 'composite'} | Priority: ${p.priority_score}`,
+      header: `Item ${idx}/${total} — R&D Proposal`,
+      multiSelect: false,
+      itemType: 'rd_proposal',
+      itemId: p.id,
+      options: [
+        { label: 'Approve', description: 'Accept this R&D proposal for investigation' },
+        { label: 'Dismiss', description: 'Reject this proposal — not worth investigating' },
+        { label: 'Defer', description: 'Review again next week — keep as pending' },
+      ],
+    });
+  }
+
+  return questions.length > 0 ? { questions } : null;
+}
+
+/**
+ * Process a chairman decision on an R&D proposal.
+ * @param {Object} deps - { supabase, logger }
+ * @param {string} proposalId
+ * @param {string} decision - 'Approve' | 'Dismiss' | 'Defer'
+ * @param {string} [notes]
+ * @returns {Promise<string>} 'accepted' | 'dismissed' | 'deferred'
+ */
+export async function processRdProposalDecision(deps, proposalId, decision, notes) {
+  const { supabase, logger = console } = deps;
+  const now = new Date().toISOString();
+  const statusMap = { Approve: 'accepted', Dismiss: 'dismissed' };
+  const newStatus = statusMap[decision];
+
+  if (newStatus) {
+    const update = {
+      status: newStatus,
+      decided_at: now,
+      decided_by: 'chairman',
+      reviewed_at: now,
+    };
+    if (notes) update.decision_notes = notes;
+
+    const { error } = await supabase
+      .from('rd_proposals')
+      .update(update)
+      .eq('id', proposalId);
+    if (error) logger.warn(`   Failed to update R&D proposal: ${error.message}`);
+    return newStatus === 'accepted' ? 'accepted' : 'dismissed';
+  }
+  // Defer — leave as pending_review
+  return 'deferred';
+}

--- a/scripts/eva/friday-meeting.mjs
+++ b/scripts/eva/friday-meeting.mjs
@@ -1,18 +1,21 @@
 /**
- * Friday Meeting Interactive Format - Structured 5-Section Agenda
+ * Friday Meeting Interactive Format - Structured 6-Section Agenda
  *
  * Presents a structured Friday meeting to the chairman:
  * 1. Performance Review — baseline vs actual, OKR progress
  * 2. Capability Report — capabilities delivered this week
  * 3. Consultant Findings — high-confidence recommendations by domain
  * 4. Intake Review — pending intake items
- * 5. Decisions — interactive accept/dismiss via AskUserQuestion
+ * 5. R&D Proposals — skunkworks batch proposals for chairman review
+ * 6. Decisions — interactive accept/dismiss via AskUserQuestion
  *
  * SD-MAN-ORCH-FRIDAY-EVA-AUTONOMOUS-001-B
+ * SD-AUTONOMOUS-SKUNKWORKS-RD-DEPARTMENT-ORCH-001-B
  */
 
 import { createClient } from '@supabase/supabase-js';
 import { getLLMClient } from '../../lib/llm/client-factory.js';
+import { gatherRdProposals as _gatherRdProposals, renderRdProposals as _renderRdProposals, buildCombinedDecisionPayload as _buildCombinedDecisionPayload, processRdProposalDecision as _processRdProposalDecision } from '../../lib/skunkworks/friday-rd-section.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -224,7 +227,17 @@ function renderIntakeReview(data) {
   return lines.join('\n');
 }
 
-// ─── Section 5: Decisions ────────────────────────────────────
+// ─── Section 5: R&D Proposals (delegated to lib/skunkworks/friday-rd-section.js)
+
+function gatherRdProposals() {
+  return _gatherRdProposals({ supabase, logger });
+}
+
+function renderRdProposals(data) {
+  return _renderRdProposals(data);
+}
+
+// ─── Section 6: Decisions ────────────────────────────────────
 
 function buildDecisionPayload(findings) {
   if (findings.length === 0) return null;
@@ -241,6 +254,10 @@ function buildDecisionPayload(findings) {
       ],
     })),
   };
+}
+
+function buildCombinedDecisionPayload(findings, proposals) {
+  return _buildCombinedDecisionPayload(findings, proposals);
 }
 
 async function processDecision(finding, decision) {
@@ -263,6 +280,10 @@ async function processDecision(finding, decision) {
   }
   // Defer — leave as pending
   return 'deferred';
+}
+
+function processRdProposalDecision(proposalId, decision, notes) {
+  return _processRdProposalDecision({ supabase, logger }, proposalId, decision, notes);
 }
 
 // ─── Persistence: Fleet Rollup ───────────────────────────────
@@ -413,24 +434,27 @@ export async function fridayMeetingHandler(options = {}) {
   logger.log('═'.repeat(55));
 
   // Gather all data in parallel
-  const [perfData, capData, consultData, intakeData] = await Promise.all([
+  const [perfData, capData, consultData, intakeData, rdData] = await Promise.all([
     gatherPerformanceReview(),
     gatherCapabilityReport(),
     gatherConsultantFindings(),
     gatherIntakeReview(),
+    gatherRdProposals(),
   ]);
 
-  // Render sections 1-4
+  // Render sections 1-5
   logger.log(renderPerformanceReview(perfData));
   logger.log(renderCapabilityReport(capData));
   logger.log(renderConsultantFindings(consultData));
   logger.log(renderIntakeReview(intakeData));
+  logger.log(renderRdProposals(rdData));
 
-  // Section 5: Decisions
+  // Section 6: Decisions
   logger.log('');
-  logger.log('  SECTION 5: DECISIONS');
+  logger.log('  SECTION 6: DECISIONS');
   logger.log('  ' + '─'.repeat(45));
 
+  const totalDecisionItems = consultData.findings.length + rdData.proposals.length;
   const results = {
     meeting_date: new Date().toISOString(),
     sections: {
@@ -438,25 +462,28 @@ export async function fridayMeetingHandler(options = {}) {
       capability: { completedSDs: capData.completedSDs.length },
       consultant: { totalFindings: consultData.findings.length, domains: Object.keys(consultData.grouped).length },
       intake: { pendingItems: intakeData.pending.length },
+      rd_proposals: { pendingProposals: rdData.proposals.length, sources: Object.keys(rdData.grouped).length },
     },
-    decisions: { accepted: 0, dismissed: 0, deferred: 0, total: consultData.findings.length },
+    decisions: { accepted: 0, dismissed: 0, deferred: 0, total: totalDecisionItems },
   };
 
-  if (consultData.findings.length === 0) {
-    logger.log('  No findings require decisions this week.');
+  if (totalDecisionItems === 0) {
+    logger.log('  No findings or proposals require decisions this week.');
   } else {
-    logger.log(`  ${consultData.findings.length} finding(s) require your decision.`);
+    logger.log(`  ${totalDecisionItems} item(s) require your decision:`);
+    if (consultData.findings.length > 0) logger.log(`    - ${consultData.findings.length} consultant finding(s)`);
+    if (rdData.proposals.length > 0) logger.log(`    - ${rdData.proposals.length} R&D proposal(s)`);
     logger.log('');
 
-    // Build the AskUserQuestion payload for interactive mode
-    const payload = buildDecisionPayload(consultData.findings);
+    // Build combined AskUserQuestion payload
+    const payload = buildCombinedDecisionPayload(consultData.findings, rdData.proposals);
 
     if (options.interactive !== false && payload) {
       // Output the payload for Claude Code to pick up
       logger.log('FRIDAY_MEETING_DECISIONS_PAYLOAD=' + JSON.stringify(payload));
       logger.log('');
       logger.log('  Awaiting chairman decisions via AskUserQuestion...');
-      logger.log('  (If running non-interactively, all findings will be deferred)');
+      logger.log('  (If running non-interactively, all items will be deferred)');
     }
   }
 
@@ -501,8 +528,13 @@ export async function fridayMeetingHandler(options = {}) {
 export async function processMeetingDecisions(decisions, { chairmanNotes = null } = {}) {
   const summary = { accepted: 0, dismissed: 0, deferred: 0 };
 
-  for (const { findingId, decision } of decisions) {
-    const result = await processDecision({ id: findingId }, decision);
+  for (const { findingId, decision, itemType, notes } of decisions) {
+    let result;
+    if (itemType === 'rd_proposal') {
+      result = await processRdProposalDecision(findingId, decision, notes);
+    } else {
+      result = await processDecision({ id: findingId }, decision);
+    }
     summary[result]++;
   }
 

--- a/tests/unit/eva/friday-rd-proposals.test.js
+++ b/tests/unit/eva/friday-rd-proposals.test.js
@@ -1,0 +1,254 @@
+/**
+ * Tests for Friday Meeting R&D Proposals integration
+ * Tests gatherRdProposals, renderRdProposals, buildCombinedDecisionPayload,
+ * and processRdProposalDecision from lib/skunkworks/friday-rd-section.js
+ *
+ * SD: SD-AUTONOMOUS-SKUNKWORKS-RD-DEPARTMENT-ORCH-001-B
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  gatherRdProposals,
+  renderRdProposals,
+  buildCombinedDecisionPayload,
+  processRdProposalDecision,
+} from '../../../lib/skunkworks/friday-rd-section.js';
+
+function mockSupabase(data, error = null) {
+  return {
+    from: vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          order: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue({ data, error }),
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    }),
+  };
+}
+
+const logger = { log: vi.fn(), warn: vi.fn() };
+
+describe('gatherRdProposals', () => {
+  it('returns proposals grouped by signal_source', async () => {
+    const proposals = [
+      { id: '1', title: 'P1', signal_source: 'calibration', priority_score: 80 },
+      { id: '2', title: 'P2', signal_source: 'calibration', priority_score: 60 },
+      { id: '3', title: 'P3', signal_source: 'venture_portfolio', priority_score: 70 },
+    ];
+    const supabase = mockSupabase(proposals);
+
+    const result = await gatherRdProposals({ supabase, logger });
+
+    expect(result.proposals).toHaveLength(3);
+    expect(result.grouped.calibration).toHaveLength(2);
+    expect(result.grouped.venture_portfolio).toHaveLength(1);
+  });
+
+  it('returns empty on query error', async () => {
+    const supabase = mockSupabase(null, { message: 'connection failed' });
+
+    const result = await gatherRdProposals({ supabase, logger });
+
+    expect(result.proposals).toHaveLength(0);
+    expect(result.grouped).toEqual({});
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('connection failed'));
+  });
+
+  it('returns empty when no proposals exist', async () => {
+    const supabase = mockSupabase([]);
+
+    const result = await gatherRdProposals({ supabase, logger });
+
+    expect(result.proposals).toHaveLength(0);
+  });
+
+  it('defaults null signal_source to composite', async () => {
+    const proposals = [{ id: '1', title: 'P1', signal_source: null, priority_score: 50 }];
+    const supabase = mockSupabase(proposals);
+
+    const result = await gatherRdProposals({ supabase, logger });
+
+    expect(result.grouped.composite).toHaveLength(1);
+  });
+
+  it('queries only pending_review status', async () => {
+    const supabase = mockSupabase([]);
+
+    await gatherRdProposals({ supabase, logger });
+
+    expect(supabase.from).toHaveBeenCalledWith('rd_proposals');
+    const chain = supabase.from.mock.results[0].value;
+    expect(chain.select).toHaveBeenCalled();
+    const selectChain = chain.select.mock.results[0].value;
+    expect(selectChain.eq).toHaveBeenCalledWith('status', 'pending_review');
+  });
+});
+
+describe('renderRdProposals', () => {
+  it('shows empty state when no proposals', () => {
+    const output = renderRdProposals({ proposals: [], grouped: {} });
+
+    expect(output).toContain('SECTION 5: R&D PROPOSALS');
+    expect(output).toContain('No pending R&D proposals');
+    expect(output).toContain('skunkworks batch runs every Monday');
+  });
+
+  it('renders proposals grouped by signal source', () => {
+    const data = {
+      proposals: [
+        { id: '1', title: 'Calibrate X', priority_score: 85, hypothesis: 'Recalibrating X improves accuracy', signal_source: 'calibration' },
+        { id: '2', title: 'Fix health Y', priority_score: 70, hypothesis: null, signal_source: 'codebase_health' },
+      ],
+      grouped: {
+        calibration: [{ id: '1', title: 'Calibrate X', priority_score: 85, hypothesis: 'Recalibrating X improves accuracy' }],
+        codebase_health: [{ id: '2', title: 'Fix health Y', priority_score: 70, hypothesis: null }],
+      },
+    };
+
+    const output = renderRdProposals(data);
+
+    expect(output).toContain('2 pending proposal(s) across 2 signal source(s)');
+    expect(output).toContain('[CALIBRATION]');
+    expect(output).toContain('Calibrate X (priority: 85)');
+    expect(output).toContain('Hypothesis: Recalibrating X improves accuracy');
+    expect(output).toContain('[CODEBASE_HEALTH]');
+    expect(output).toContain('Fix health Y (priority: 70)');
+    // No hypothesis line for null hypothesis
+    expect(output).not.toContain('Hypothesis: null');
+  });
+});
+
+describe('buildCombinedDecisionPayload', () => {
+  it('returns null when no items', () => {
+    expect(buildCombinedDecisionPayload([], [])).toBeNull();
+  });
+
+  it('builds findings with Accept/Dismiss/Defer options', () => {
+    const findings = [
+      { id: 'f1', title: 'Finding 1', description: 'Desc', analysis_domain: 'gate', priority_score: 0.8, action_type: 'review' },
+    ];
+    const payload = buildCombinedDecisionPayload(findings, []);
+
+    expect(payload.questions).toHaveLength(1);
+    expect(payload.questions[0].itemType).toBe('finding');
+    expect(payload.questions[0].itemId).toBe('f1');
+    expect(payload.questions[0].options.map(o => o.label)).toEqual(['Accept', 'Dismiss', 'Defer']);
+  });
+
+  it('builds proposals with Approve/Dismiss/Defer options', () => {
+    const proposals = [
+      { id: 'p1', title: 'Proposal 1', hypothesis: 'H1', signal_source: 'calibration', priority_score: 90 },
+    ];
+    const payload = buildCombinedDecisionPayload([], proposals);
+
+    expect(payload.questions).toHaveLength(1);
+    expect(payload.questions[0].itemType).toBe('rd_proposal');
+    expect(payload.questions[0].itemId).toBe('p1');
+    expect(payload.questions[0].options.map(o => o.label)).toEqual(['Approve', 'Dismiss', 'Defer']);
+  });
+
+  it('combines findings and proposals with correct numbering', () => {
+    const findings = [{ id: 'f1', title: 'F1', description: 'D', analysis_domain: 'x', priority_score: 1, action_type: 'y' }];
+    const proposals = [{ id: 'p1', title: 'P1', hypothesis: 'H', signal_source: 'z', priority_score: 2 }];
+
+    const payload = buildCombinedDecisionPayload(findings, proposals);
+
+    expect(payload.questions).toHaveLength(2);
+    expect(payload.questions[0].header).toContain('Item 1/2');
+    expect(payload.questions[0].header).toContain('Consultant Finding');
+    expect(payload.questions[1].header).toContain('Item 2/2');
+    expect(payload.questions[1].header).toContain('R&D Proposal');
+  });
+
+  it('handles null hypothesis in proposals', () => {
+    const proposals = [{ id: 'p1', title: 'P1', hypothesis: null, signal_source: 'x', priority_score: 1 }];
+    const payload = buildCombinedDecisionPayload([], proposals);
+
+    expect(payload.questions[0].question).toContain('Hypothesis: N/A');
+  });
+});
+
+describe('processRdProposalDecision', () => {
+  it('updates status to accepted on Approve', async () => {
+    const updateMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const supabase = { from: vi.fn().mockReturnValue({ update: updateMock }) };
+
+    const result = await processRdProposalDecision({ supabase, logger }, 'p1', 'Approve');
+
+    expect(result).toBe('accepted');
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'accepted',
+      decided_by: 'chairman',
+    }));
+  });
+
+  it('updates status to dismissed on Dismiss', async () => {
+    const updateMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const supabase = { from: vi.fn().mockReturnValue({ update: updateMock }) };
+
+    const result = await processRdProposalDecision({ supabase, logger }, 'p1', 'Dismiss');
+
+    expect(result).toBe('dismissed');
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'dismissed',
+    }));
+  });
+
+  it('returns deferred without DB update on Defer', async () => {
+    const updateMock = vi.fn();
+    const supabase = { from: vi.fn().mockReturnValue({ update: updateMock }) };
+
+    const result = await processRdProposalDecision({ supabase, logger }, 'p1', 'Defer');
+
+    expect(result).toBe('deferred');
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it('includes decision_notes when provided', async () => {
+    const updateMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const supabase = { from: vi.fn().mockReturnValue({ update: updateMock }) };
+
+    await processRdProposalDecision({ supabase, logger }, 'p1', 'Approve', 'Looks promising');
+
+    expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({
+      decision_notes: 'Looks promising',
+    }));
+  });
+
+  it('sets reviewed_at and decided_at timestamps', async () => {
+    const updateMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    });
+    const supabase = { from: vi.fn().mockReturnValue({ update: updateMock }) };
+
+    await processRdProposalDecision({ supabase, logger }, 'p1', 'Approve');
+
+    const updateArg = updateMock.mock.calls[0][0];
+    expect(updateArg.reviewed_at).toBeDefined();
+    expect(updateArg.decided_at).toBeDefined();
+    expect(new Date(updateArg.reviewed_at).toISOString()).toBe(updateArg.reviewed_at);
+  });
+
+  it('warns on DB update error', async () => {
+    const updateMock = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ error: { message: 'connection lost' } }),
+    });
+    const supabase = { from: vi.fn().mockReturnValue({ update: updateMock }) };
+
+    const result = await processRdProposalDecision({ supabase, logger }, 'p1', 'Approve');
+
+    expect(result).toBe('accepted');
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('connection lost'));
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `lib/skunkworks/friday-rd-section.js` with dependency-injected functions for R&D proposal gathering, rendering, combined decision payloads, and decision processing
- Integrate R&D proposals as Section 5 in the Friday meeting (6-section agenda)
- 18 unit tests covering all extracted functions

## SD
SD-AUTONOMOUS-SKUNKWORKS-RD-DEPARTMENT-ORCH-001-B (Phase 2: EVA Friday Integration & R&D Dashboard)

## Test plan
- [x] 18/18 unit tests passing (`tests/unit/eva/friday-rd-proposals.test.js`)
- [ ] Manual: Run Friday meeting and verify Section 5 renders proposals
- [ ] Manual: Verify combined decision flow handles both findings and R&D proposals

🤖 Generated with [Claude Code](https://claude.com/claude-code)