### PR TITLE
feat: wave brainstorm generation and enhanced SD promotion

### DIFF
--- a/lib/integrations/roadmap-manager.js
+++ b/lib/integrations/roadmap-manager.js
@@ -9,6 +9,34 @@
 import { validateTransition } from './roadmap-taxonomy.js';
 
 /**
+ * Load enrichment data (enrichment_summary, chairman_intent, chairman_notes)
+ * from the intake source table for a wave item.
+ */
+async function loadItemEnrichment(supabase, item) {
+  const fields = 'title, description, target_application, target_aspects, chairman_intent, chairman_notes, enrichment_summary, classification_confidence';
+
+  if (item.source_type === 'todoist' || item.source_type === 'classified') {
+    const { data } = await supabase
+      .from('eva_intake_classified')
+      .select(fields)
+      .eq('id', item.source_id)
+      .single();
+    return data || {};
+  }
+
+  if (item.source_type === 'youtube') {
+    const { data } = await supabase
+      .from('eva_youtube_intake')
+      .select(fields)
+      .eq('id', item.source_id)
+      .single();
+    return data || {};
+  }
+
+  return {};
+}
+
+/**
  * Get the most recent active roadmap.
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  * @returns {Promise<Object|null>}
@@ -179,7 +207,7 @@ export async function approveSequence(supabase, roadmapId, rationale) {
 export async function promoteWaveToSDs(supabase, waveId) {
   const { data: wave, error: wErr } = await supabase
     .from('roadmap_waves')
-    .select('id, title, status, roadmap_id')
+    .select('id, title, status, roadmap_id, metadata')
     .eq('id', waveId)
     .single();
 
@@ -187,7 +215,7 @@ export async function promoteWaveToSDs(supabase, waveId) {
 
   const { data: items, error: iErr } = await supabase
     .from('roadmap_wave_items')
-    .select('id, title, source_type, promoted_to_sd_key, priority_rank')
+    .select('id, title, source_type, source_id, promoted_to_sd_key, priority_rank')
     .eq('wave_id', waveId)
     .order('priority_rank', { ascending: true });
 
@@ -197,10 +225,50 @@ export async function promoteWaveToSDs(supabase, waveId) {
   const created = [];
   const errors = [];
 
+  // Extract brainstorm context from wave metadata (if available)
+  const brainstormResults = wave.metadata?.brainstorm_results || null;
+
   for (const item of unpromoted) {
     try {
-      const sdTitle = `[Wave: ${wave.title}] ${item.title || 'Untitled item'}`;
+      // Load enrichment data from intake source
+      const enrichment = await loadItemEnrichment(supabase, item);
+
+      const sdTitle = `[Wave: ${wave.title}] ${enrichment.title || item.title || 'Untitled item'}`;
       const sdKey = `SD-WAVE-${waveId.substring(0, 8).toUpperCase()}-${String(created.length + 1).padStart(3, '0')}`;
+
+      // Build enriched description
+      const descParts = [`Promoted from roadmap wave "${wave.title}" (source: ${item.source_type})`];
+      if (enrichment.enrichment_summary) {
+        descParts.push(`\n\n## Enrichment Context\n${enrichment.enrichment_summary}`);
+      }
+      if (enrichment.chairman_intent) {
+        descParts.push(`\n**Chairman Intent:** ${enrichment.chairman_intent}`);
+      }
+      if (enrichment.chairman_notes) {
+        descParts.push(`**Chairman Notes:** ${enrichment.chairman_notes}`);
+      }
+      // Attach item-specific brainstorm recommendation
+      if (brainstormResults) {
+        const itemIdx = unpromoted.indexOf(item) + 1;
+        const rec = (brainstormResults.item_recommendations || []).find(r => r.item_index === itemIdx);
+        if (rec) {
+          descParts.push(`\n## Wave Brainstorm Assessment\n**Wave Theme:** ${brainstormResults.wave_theme || 'N/A'}`);
+          descParts.push(`**Priority:** ${rec.priority}`);
+          descParts.push(`**Recommendation:** ${rec.recommendation}`);
+        }
+      }
+
+      // Build SD metadata with enrichment + brainstorm context
+      const sdMetadata = {};
+      if (enrichment.enrichment_summary) sdMetadata.enrichment_summary = enrichment.enrichment_summary;
+      if (enrichment.chairman_intent) sdMetadata.chairman_intent = enrichment.chairman_intent;
+      if (enrichment.chairman_notes) sdMetadata.chairman_notes = enrichment.chairman_notes;
+      if (brainstormResults) {
+        sdMetadata.wave_brainstorm_context = {
+          wave_theme: brainstormResults.wave_theme,
+          wave_assessment: brainstormResults.wave_assessment,
+        };
+      }
 
       const { data: sd, error: sdErr } = await supabase
         .from('strategic_directives_v2')
@@ -209,8 +277,10 @@ export async function promoteWaveToSDs(supabase, waveId) {
           title: sdTitle.substring(0, 200),
           status: 'draft',
           sd_type: 'feature',
-          description: `Promoted from roadmap wave "${wave.title}" (source: ${item.source_type})`,
-          scope: `Wave item: ${item.title}`,
+          description: descParts.join('\n'),
+          scope: `Wave item: ${enrichment.title || item.title}`,
+          target_application: enrichment.target_application || undefined,
+          metadata: Object.keys(sdMetadata).length > 0 ? sdMetadata : undefined,
           success_metrics: [
             { metric: 'Implementation completeness', target: '100%', actual: null },
           ],

--- a/scripts/eva/wave-brainstorm.js
+++ b/scripts/eva/wave-brainstorm.js
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+/**
+ * wave-brainstorm.js — LLM-powered strategic brainstorm per roadmap wave
+ * SD: SD-DISTILL-PIPELINE-CHAIRMAN-REVIEW-ORCH-001-D
+ *
+ * Generates strategic recommendations for a wave's items as a cohesive unit.
+ * Stores results in roadmap_waves.metadata JSONB.
+ *
+ * Usage:
+ *   node scripts/eva/wave-brainstorm.js --wave-id <uuid>
+ *   node scripts/eva/wave-brainstorm.js --wave-id <uuid> --dry-run
+ *   node scripts/eva/wave-brainstorm.js --wave-id <uuid> --review
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { createLLMClient } from '../../lib/llm/client-factory.js';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+);
+
+/**
+ * Load wave items with enrichment data from intake tables.
+ */
+async function loadWaveItems(waveId) {
+  const { data: wave, error: wErr } = await supabase
+    .from('roadmap_waves')
+    .select('id, title, description, status, metadata, roadmap_id, sequence_rank')
+    .eq('id', waveId)
+    .single();
+
+  if (wErr || !wave) throw new Error(`Wave not found: ${waveId}`);
+
+  const { data: waveItems, error: iErr } = await supabase
+    .from('roadmap_wave_items')
+    .select('id, title, source_type, source_id, priority_rank, promoted_to_sd_key')
+    .eq('wave_id', waveId)
+    .order('priority_rank', { ascending: true });
+
+  if (iErr) throw new Error(`Failed to load wave items: ${iErr.message}`);
+  if (!waveItems || waveItems.length === 0) return { wave, items: [] };
+
+  // Enrich items with intake classification data
+  const enrichedItems = [];
+  for (const item of waveItems) {
+    let enrichment = {};
+    if (item.source_type === 'todoist' || item.source_type === 'classified') {
+      const { data } = await supabase
+        .from('eva_intake_classified')
+        .select('title, description, target_application, target_aspects, chairman_intent, chairman_notes, enrichment_summary, classification_confidence')
+        .eq('id', item.source_id)
+        .single();
+      if (data) enrichment = data;
+    } else if (item.source_type === 'youtube') {
+      const { data } = await supabase
+        .from('eva_youtube_intake')
+        .select('title, description, target_application, target_aspects, chairman_intent, chairman_notes, enrichment_summary')
+        .eq('id', item.source_id)
+        .single();
+      if (data) enrichment = data;
+    }
+
+    enrichedItems.push({
+      ...item,
+      enrichment_title: enrichment.title || item.title,
+      description: enrichment.description || '',
+      target_application: enrichment.target_application || 'unknown',
+      target_aspects: enrichment.target_aspects || [],
+      chairman_intent: enrichment.chairman_intent || null,
+      chairman_notes: enrichment.chairman_notes || null,
+      enrichment_summary: enrichment.enrichment_summary || null,
+      classification_confidence: enrichment.classification_confidence || null,
+    });
+  }
+
+  return { wave, items: enrichedItems };
+}
+
+/**
+ * Generate brainstorm via LLM.
+ */
+async function generateBrainstorm(wave, items) {
+  const itemDescriptions = items.map((item, i) => {
+    const parts = [
+      `${i + 1}. "${item.enrichment_title || item.title}"`,
+      `   App: ${item.target_application}`,
+      `   Intent: ${item.chairman_intent || 'unset'}`,
+    ];
+    if (item.enrichment_summary) parts.push(`   Summary: ${item.enrichment_summary}`);
+    if (item.chairman_notes) parts.push(`   Chairman Notes: ${item.chairman_notes}`);
+    if (Array.isArray(item.target_aspects) && item.target_aspects.length > 0) {
+      parts.push(`   Aspects: ${item.target_aspects.join(', ')}`);
+    }
+    return parts.join('\n');
+  }).join('\n\n');
+
+  const prompt = `You are a strategic technology advisor. Analyze this roadmap wave and provide strategic recommendations.
+
+Wave: "${wave.title}"
+Description: ${wave.description || 'No description'}
+Items (${items.length}):
+
+${itemDescriptions}
+
+Provide a JSON response with this structure:
+{
+  "wave_theme": "One sentence describing the unifying theme of this wave",
+  "wave_assessment": "2-3 sentence strategic assessment of this wave's value and risk",
+  "item_recommendations": [
+    {
+      "item_index": 1,
+      "priority": "high|medium|low",
+      "recommendation": "Brief strategic recommendation for this item",
+      "dependencies": ["item indices this depends on"]
+    }
+  ],
+  "dependency_suggestions": [
+    "Cross-item dependency or ordering suggestion"
+  ],
+  "risk_flags": [
+    "Strategic risk or concern about this wave"
+  ]
+}
+
+IMPORTANT: Return ONLY valid JSON, no markdown fences.`;
+
+  const client = await createLLMClient('planning');
+  const response = await client.chat(prompt);
+  const text = typeof response === 'string' ? response : response.content || response.text || '';
+
+  // Parse JSON, handling potential markdown fences
+  const cleaned = text.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+  return JSON.parse(cleaned);
+}
+
+/**
+ * Persist brainstorm results to wave metadata.
+ */
+async function persistBrainstorm(waveId, brainstorm, existingMetadata) {
+  const merged = {
+    ...(existingMetadata || {}),
+    brainstorm_at: new Date().toISOString(),
+    brainstorm_results: brainstorm,
+    model_used: 'planning-tier',
+  };
+
+  const { error } = await supabase
+    .from('roadmap_waves')
+    .update({ metadata: merged })
+    .eq('id', waveId);
+
+  if (error) throw new Error(`Failed to persist brainstorm: ${error.message}`);
+}
+
+/**
+ * Display brainstorm results for chairman review.
+ */
+function displayBrainstorm(brainstorm, items) {
+  console.log('\n  Wave Theme:', brainstorm.wave_theme);
+  console.log('  Assessment:', brainstorm.wave_assessment);
+  console.log('\n  Item Recommendations:');
+
+  for (const rec of brainstorm.item_recommendations || []) {
+    const item = items[rec.item_index - 1];
+    const title = item ? (item.enrichment_title || item.title || '(untitled)') : `Item ${rec.item_index}`;
+    const priorityIcon = rec.priority === 'high' ? '🔴' : rec.priority === 'medium' ? '🟡' : '🟢';
+    console.log(`    ${priorityIcon} [${rec.priority.toUpperCase()}] ${title}`);
+    console.log(`       ${rec.recommendation}`);
+    if (rec.dependencies && rec.dependencies.length > 0) {
+      console.log(`       Depends on: items ${rec.dependencies.join(', ')}`);
+    }
+  }
+
+  if (brainstorm.dependency_suggestions && brainstorm.dependency_suggestions.length > 0) {
+    console.log('\n  Dependency Suggestions:');
+    brainstorm.dependency_suggestions.forEach(s => console.log(`    - ${s}`));
+  }
+
+  if (brainstorm.risk_flags && brainstorm.risk_flags.length > 0) {
+    console.log('\n  Risk Flags:');
+    brainstorm.risk_flags.forEach(r => console.log(`    ⚠ ${r}`));
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const waveIdFlag = args.indexOf('--wave-id');
+  const waveId = waveIdFlag >= 0 ? args[waveIdFlag + 1] : null;
+  const dryRun = args.includes('--dry-run');
+  const review = args.includes('--review');
+
+  if (!waveId) {
+    console.log('Usage:');
+    console.log('  node scripts/eva/wave-brainstorm.js --wave-id <uuid>');
+    console.log('  node scripts/eva/wave-brainstorm.js --wave-id <uuid> --dry-run');
+    console.log('  node scripts/eva/wave-brainstorm.js --wave-id <uuid> --review');
+    process.exit(0);
+  }
+
+  console.log('\nWave Brainstorm Generator');
+  console.log('═'.repeat(50));
+
+  // Load wave + items with enrichment
+  const { wave, items } = await loadWaveItems(waveId);
+  console.log(`  Wave: ${wave.title} [${wave.status}]`);
+  console.log(`  Items: ${items.length}`);
+
+  if (items.length === 0) {
+    console.log('\n  No items in wave. Nothing to brainstorm.');
+    process.exit(0);
+  }
+
+  // Show item summary
+  const byApp = {};
+  const byIntent = {};
+  for (const item of items) {
+    byApp[item.target_application] = (byApp[item.target_application] || 0) + 1;
+    byIntent[item.chairman_intent || 'unset'] = (byIntent[item.chairman_intent || 'unset'] || 0) + 1;
+  }
+  console.log(`  By app: ${Object.entries(byApp).map(([k, v]) => `${k}(${v})`).join(', ')}`);
+  console.log(`  By intent: ${Object.entries(byIntent).map(([k, v]) => `${k}(${v})`).join(', ')}`);
+
+  // Generate brainstorm
+  console.log('\n  Generating brainstorm...');
+  const brainstorm = await generateBrainstorm(wave, items);
+  console.log('  Brainstorm generated.');
+
+  // Display results
+  displayBrainstorm(brainstorm, items);
+
+  if (review) {
+    console.log('\n  Chairman Review Mode');
+    console.log('  Review the recommendations above.');
+    console.log('  To persist, re-run without --review flag (or remove --dry-run).');
+  }
+
+  if (dryRun) {
+    console.log('\n  [DRY RUN] No changes written to database.');
+    return;
+  }
+
+  // Persist
+  await persistBrainstorm(wave.id, brainstorm, wave.metadata);
+  console.log('\n  Brainstorm results saved to wave metadata.');
+  console.log('═'.repeat(50));
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/tests/unit/eva/wave-brainstorm.test.js
+++ b/tests/unit/eva/wave-brainstorm.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+
+// Test the enrichment attachment logic used in promoteWaveToSDs
+// (inline replica since the actual function requires supabase)
+
+function buildEnrichedDescription(waveTitle, sourceType, enrichment, brainstormResults, itemIndex) {
+  const descParts = [`Promoted from roadmap wave "${waveTitle}" (source: ${sourceType})`];
+  if (enrichment.enrichment_summary) {
+    descParts.push(`\n\n## Enrichment Context\n${enrichment.enrichment_summary}`);
+  }
+  if (enrichment.chairman_intent) {
+    descParts.push(`\n**Chairman Intent:** ${enrichment.chairman_intent}`);
+  }
+  if (enrichment.chairman_notes) {
+    descParts.push(`**Chairman Notes:** ${enrichment.chairman_notes}`);
+  }
+  if (brainstormResults) {
+    const rec = (brainstormResults.item_recommendations || []).find(r => r.item_index === itemIndex);
+    if (rec) {
+      descParts.push(`\n## Wave Brainstorm Assessment\n**Wave Theme:** ${brainstormResults.wave_theme || 'N/A'}`);
+      descParts.push(`**Priority:** ${rec.priority}`);
+      descParts.push(`**Recommendation:** ${rec.recommendation}`);
+    }
+  }
+  return descParts.join('\n');
+}
+
+function buildSDMetadata(enrichment, brainstormResults) {
+  const sdMetadata = {};
+  if (enrichment.enrichment_summary) sdMetadata.enrichment_summary = enrichment.enrichment_summary;
+  if (enrichment.chairman_intent) sdMetadata.chairman_intent = enrichment.chairman_intent;
+  if (enrichment.chairman_notes) sdMetadata.chairman_notes = enrichment.chairman_notes;
+  if (brainstormResults) {
+    sdMetadata.wave_brainstorm_context = {
+      wave_theme: brainstormResults.wave_theme,
+      wave_assessment: brainstormResults.wave_assessment,
+    };
+  }
+  return sdMetadata;
+}
+
+describe('wave brainstorm and enhanced promotion', () => {
+  describe('buildEnrichedDescription', () => {
+    it('includes base promotion info without enrichment', () => {
+      const result = buildEnrichedDescription('Wave 1', 'todoist', {}, null, 1);
+      expect(result).toContain('Promoted from roadmap wave "Wave 1"');
+      expect(result).toContain('source: todoist');
+      expect(result).not.toContain('Enrichment Context');
+    });
+
+    it('includes enrichment summary when present', () => {
+      const enrichment = { enrichment_summary: 'A helpful AI summary of the item' };
+      const result = buildEnrichedDescription('Wave 1', 'todoist', enrichment, null, 1);
+      expect(result).toContain('## Enrichment Context');
+      expect(result).toContain('A helpful AI summary of the item');
+    });
+
+    it('includes chairman intent and notes', () => {
+      const enrichment = {
+        chairman_intent: 'Build',
+        chairman_notes: 'Priority for Q2',
+      };
+      const result = buildEnrichedDescription('Wave 1', 'classified', enrichment, null, 1);
+      expect(result).toContain('**Chairman Intent:** Build');
+      expect(result).toContain('**Chairman Notes:** Priority for Q2');
+    });
+
+    it('includes brainstorm recommendation for matching item', () => {
+      const brainstorm = {
+        wave_theme: 'Infrastructure automation',
+        wave_assessment: 'High value wave',
+        item_recommendations: [
+          { item_index: 1, priority: 'high', recommendation: 'Implement first due to dependencies' },
+          { item_index: 2, priority: 'low', recommendation: 'Can wait' },
+        ],
+      };
+      const result = buildEnrichedDescription('Wave 1', 'todoist', {}, brainstorm, 1);
+      expect(result).toContain('## Wave Brainstorm Assessment');
+      expect(result).toContain('**Wave Theme:** Infrastructure automation');
+      expect(result).toContain('**Priority:** high');
+      expect(result).toContain('Implement first due to dependencies');
+    });
+
+    it('omits brainstorm section when no matching recommendation', () => {
+      const brainstorm = {
+        wave_theme: 'Theme',
+        item_recommendations: [{ item_index: 5, priority: 'low', recommendation: 'Unrelated' }],
+      };
+      const result = buildEnrichedDescription('Wave 1', 'todoist', {}, brainstorm, 1);
+      expect(result).not.toContain('Wave Brainstorm Assessment');
+    });
+
+    it('combines all sections: enrichment + chairman + brainstorm', () => {
+      const enrichment = {
+        enrichment_summary: 'Summary text',
+        chairman_intent: 'Research',
+        chairman_notes: 'Needs investigation',
+      };
+      const brainstorm = {
+        wave_theme: 'Research wave',
+        item_recommendations: [
+          { item_index: 1, priority: 'medium', recommendation: 'Start with literature review' },
+        ],
+      };
+      const result = buildEnrichedDescription('Research Wave', 'youtube', enrichment, brainstorm, 1);
+      expect(result).toContain('Enrichment Context');
+      expect(result).toContain('Chairman Intent');
+      expect(result).toContain('Chairman Notes');
+      expect(result).toContain('Wave Brainstorm Assessment');
+    });
+  });
+
+  describe('buildSDMetadata', () => {
+    it('returns empty object when no enrichment or brainstorm', () => {
+      const result = buildSDMetadata({}, null);
+      expect(Object.keys(result)).toHaveLength(0);
+    });
+
+    it('includes enrichment fields when present', () => {
+      const result = buildSDMetadata({
+        enrichment_summary: 'Summary',
+        chairman_intent: 'Build',
+        chairman_notes: 'Notes',
+      }, null);
+      expect(result.enrichment_summary).toBe('Summary');
+      expect(result.chairman_intent).toBe('Build');
+      expect(result.chairman_notes).toBe('Notes');
+      expect(result.wave_brainstorm_context).toBeUndefined();
+    });
+
+    it('includes brainstorm context when present', () => {
+      const brainstorm = {
+        wave_theme: 'Automation',
+        wave_assessment: 'High priority',
+        item_recommendations: [],
+      };
+      const result = buildSDMetadata({}, brainstorm);
+      expect(result.wave_brainstorm_context).toEqual({
+        wave_theme: 'Automation',
+        wave_assessment: 'High priority',
+      });
+    });
+
+    it('includes both enrichment and brainstorm', () => {
+      const result = buildSDMetadata(
+        { enrichment_summary: 'Sum', chairman_intent: 'Build' },
+        { wave_theme: 'Theme', wave_assessment: 'Assessment' }
+      );
+      expect(result.enrichment_summary).toBe('Sum');
+      expect(result.chairman_intent).toBe('Build');
+      expect(result.wave_brainstorm_context.wave_theme).toBe('Theme');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `scripts/eva/wave-brainstorm.js` — LLM-powered strategic brainstorm per roadmap wave with item-level recommendations, risk flags, and dependency suggestions
- Enhance `lib/integrations/roadmap-manager.js` `promoteWaveToSDs()` to load enrichment data (enrichment_summary, chairman_intent, chairman_notes) and brainstorm context, attaching both to promoted SD descriptions and metadata
- Add 10 unit tests for enriched description building and SD metadata construction

## Test plan
- [x] 10 wave brainstorm tests pass
- [x] 5 wave locking tests pass
- [x] 21 chairman intake review tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)