### PR TITLE
feat: orchestrator scope governance — backward reconciliation and cancellation audit

### DIFF
--- a/database/migrations/20260313_scope_governance.sql
+++ b/database/migrations/20260313_scope_governance.sql
@@ -1,0 +1,39 @@
+-- Migration: Orchestrator Scope Governance (Phase 1)
+-- SD: SD-LEO-INFRA-ORCHESTRATOR-SCOPE-GOVERNANCE-001
+-- Adds cancellation audit trail columns, scope_authority, and cancellation trigger
+
+-- 1. Add cancellation audit trail columns
+ALTER TABLE strategic_directives_v2
+  ADD COLUMN IF NOT EXISTS cancellation_reason TEXT,
+  ADD COLUMN IF NOT EXISTS cancelled_by TEXT;
+
+COMMENT ON COLUMN strategic_directives_v2.cancellation_reason IS 'Required reason when SD is cancelled — enforced by trigger';
+COMMENT ON COLUMN strategic_directives_v2.cancelled_by IS 'Who cancelled the SD (chairman, lead, system, session_id)';
+
+-- 2. Add scope_authority column
+ALTER TABLE strategic_directives_v2
+  ADD COLUMN IF NOT EXISTS scope_authority TEXT;
+
+COMMENT ON COLUMN strategic_directives_v2.scope_authority IS 'Who authorized the current scope (chairman, lead, system)';
+
+-- 3. Create trigger to enforce cancellation_reason on cancel
+CREATE OR REPLACE FUNCTION trg_require_cancellation_reason()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only fire when status transitions TO 'cancelled'
+  IF NEW.status = 'cancelled' AND (OLD.status IS NULL OR OLD.status != 'cancelled') THEN
+    IF NEW.cancellation_reason IS NULL OR TRIM(NEW.cancellation_reason) = '' THEN
+      RAISE EXCEPTION 'cancellation_reason is required when setting status to cancelled (SD: %)', NEW.sd_key;
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop if exists to allow re-runs
+DROP TRIGGER IF EXISTS trg_require_cancellation_reason ON strategic_directives_v2;
+
+CREATE TRIGGER trg_require_cancellation_reason
+  BEFORE UPDATE ON strategic_directives_v2
+  FOR EACH ROW
+  EXECUTE FUNCTION trg_require_cancellation_reason();

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/phase-coverage.js
@@ -10,7 +10,8 @@
 
 import {
   validatePhaseCoverage,
-  formatCoverageReport
+  formatCoverageReport,
+  detectOrphanChildren
 } from '../../../validation/phase-coverage-validator.js';
 
 import {
@@ -111,6 +112,20 @@ export function createPhaseCoverageGate(supabase) {
         const report = validatePhaseCoverage(phases, allSds);
         console.log(formatCoverageReport(report));
 
+        // Backward reconciliation: detect orphan children referencing non-existent phases
+        // SD-LEO-INFRA-ORCHESTRATOR-SCOPE-GOVERNANCE-001 (FR-003)
+        const childSds = allSds.filter(sd => sd.parent_sd_id);
+        const orphanReport = detectOrphanChildren(phases, childSds);
+        const warnings = [];
+
+        if (orphanReport.orphans.length > 0) {
+          console.log(`\n   ⚠️  Backward Reconciliation: ${orphanReport.orphans.length} orphan child(ren) detected`);
+          for (const orphan of orphanReport.orphans) {
+            console.log(`   🔸 ${orphan.sd_key}: ${orphan.reason}`);
+            warnings.push(`Orphan child ${orphan.sd_key}: ${orphan.reason}`);
+          }
+        }
+
         if (!report.passed) {
           const missingTitles = report.uncovered.map(u => u.phase.title).join(', ');
           return buildSemanticResult({
@@ -118,6 +133,7 @@ export function createPhaseCoverageGate(supabase) {
             score: Math.round(report.coveragePercent),
             confidence: 1,
             issues: [`Architecture phase coverage incomplete: ${report.coveredCount}/${report.totalPhases} phases covered. Missing: ${missingTitles}`],
+            warnings,
             details: {
               archKey,
               totalPhases: report.totalPhases,
@@ -127,7 +143,8 @@ export function createPhaseCoverageGate(supabase) {
                 number: u.phase.number,
                 title: u.phase.title,
                 designation: u.phase.child_designation
-              }))
+              })),
+              orphanChildren: orphanReport.orphans
             },
             remediation: `Create SDs for uncovered phases: ${missingTitles}. Then link them via metadata.arch_key = '${archKey}'.`
           });
@@ -135,13 +152,15 @@ export function createPhaseCoverageGate(supabase) {
 
         return buildSemanticResult({
           passed: true,
-          score: 100,
+          score: orphanReport.orphans.length > 0 ? 80 : 100,
           confidence: 1,
+          warnings,
           details: {
             archKey,
             totalPhases: report.totalPhases,
             coveredCount: report.coveredCount,
-            coveragePercent: report.coveragePercent
+            coveragePercent: report.coveragePercent,
+            orphanChildren: orphanReport.orphans
           }
         });
       } catch (err) {

--- a/scripts/modules/handoff/validation/phase-coverage-validator.js
+++ b/scripts/modules/handoff/validation/phase-coverage-validator.js
@@ -135,6 +135,62 @@ function wordOverlapScore(wordsA, wordsB) {
 }
 
 /**
+ * Backward reconciliation: detect child SDs that claim to implement a phase
+ * not present in the architecture plan. These are "orphan" children created
+ * from phantom phases (e.g., phases that were removed after plan amendment).
+ *
+ * SD-LEO-INFRA-ORCHESTRATOR-SCOPE-GOVERNANCE-001 (FR-003)
+ *
+ * @param {Object[]} phases - From eva_architecture_plans.sections.implementation_phases
+ * @param {Object[]} childSds - Child SDs of the orchestrator
+ * @returns {Object} Reconciliation report with orphans array
+ */
+export function detectOrphanChildren(phases, childSds) {
+  if (!childSds || childSds.length === 0) {
+    return { orphans: [], checkedCount: 0 };
+  }
+
+  const phaseNumbers = new Set((phases || []).map(p => p.number));
+  const phaseTitles = new Set((phases || []).map(p => normalizeForMatch(p.title).join(' ')));
+  const orphans = [];
+
+  for (const sd of childSds) {
+    // Extract phase reference from SD title or metadata
+    const phaseMatch = sd.title?.match(/Phase\s+(\d+)/i);
+    if (phaseMatch) {
+      const refNum = parseInt(phaseMatch[1], 10);
+      if (!phaseNumbers.has(refNum)) {
+        orphans.push({
+          sd_key: sd.sd_key,
+          title: sd.title,
+          status: sd.status,
+          referenced_phase: refNum,
+          reason: `References Phase ${refNum} which does not exist in the architecture plan`
+        });
+        continue;
+      }
+    }
+
+    // Check letter-suffix children (e.g., SD-XXX-001-C for Phase 3)
+    const letterMatch = sd.sd_key?.match(/-([A-Z])$/);
+    if (letterMatch) {
+      const letterIndex = letterMatch[1].charCodeAt(0) - 64; // A=1, B=2, etc.
+      if (letterIndex > 0 && !phaseNumbers.has(letterIndex) && phases && phases.length > 0) {
+        orphans.push({
+          sd_key: sd.sd_key,
+          title: sd.title,
+          status: sd.status,
+          referenced_phase: letterIndex,
+          reason: `Suffix -${letterMatch[1]} implies Phase ${letterIndex} which does not exist in the architecture plan`
+        });
+      }
+    }
+  }
+
+  return { orphans, checkedCount: childSds.length };
+}
+
+/**
  * Formats coverage report for terminal display.
  * @param {Object} report - From validatePhaseCoverage()
  * @returns {string} Formatted output

--- a/tests/unit/scope-governance.test.js
+++ b/tests/unit/scope-governance.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validatePhaseCoverage,
+  detectOrphanChildren,
+  formatCoverageReport
+} from '../../scripts/modules/handoff/validation/phase-coverage-validator.js';
+
+describe('Orchestrator Scope Governance', () => {
+  describe('detectOrphanChildren', () => {
+    const phases = [
+      { number: 1, title: 'Database Migration', child_designation: 'A' },
+      { number: 2, title: 'API Implementation', child_designation: 'B' },
+      { number: 3, title: 'Frontend Integration', child_designation: 'C' }
+    ];
+
+    it('returns empty orphans when no children exist', () => {
+      const result = detectOrphanChildren(phases, []);
+      expect(result.orphans).toEqual([]);
+      expect(result.checkedCount).toBe(0);
+    });
+
+    it('returns empty orphans when all children reference valid phases', () => {
+      const children = [
+        { sd_key: 'SD-TEST-001-A', title: 'Phase 1: Database Migration', status: 'draft', parent_sd_id: 'uuid-1' },
+        { sd_key: 'SD-TEST-001-B', title: 'Phase 2: API Implementation', status: 'draft', parent_sd_id: 'uuid-1' }
+      ];
+      const result = detectOrphanChildren(phases, children);
+      expect(result.orphans).toEqual([]);
+      expect(result.checkedCount).toBe(2);
+    });
+
+    it('detects orphan child referencing non-existent phase number', () => {
+      const children = [
+        { sd_key: 'SD-TEST-001-A', title: 'Phase 1: Database Migration', status: 'draft', parent_sd_id: 'uuid-1' },
+        { sd_key: 'SD-TEST-001-D', title: 'Phase 5: Monitoring Setup', status: 'draft', parent_sd_id: 'uuid-1' }
+      ];
+      const result = detectOrphanChildren(phases, children);
+      expect(result.orphans).toHaveLength(1);
+      expect(result.orphans[0].sd_key).toBe('SD-TEST-001-D');
+      expect(result.orphans[0].referenced_phase).toBe(5);
+      expect(result.orphans[0].reason).toContain('Phase 5');
+      expect(result.orphans[0].reason).toContain('does not exist');
+    });
+
+    it('detects orphan by letter suffix when phase count exceeded', () => {
+      const twoPhases = [
+        { number: 1, title: 'Phase One' },
+        { number: 2, title: 'Phase Two' }
+      ];
+      const children = [
+        { sd_key: 'SD-TEST-001-C', title: 'Some work', status: 'draft', parent_sd_id: 'uuid-1' }
+      ];
+      const result = detectOrphanChildren(twoPhases, children);
+      expect(result.orphans).toHaveLength(1);
+      expect(result.orphans[0].sd_key).toBe('SD-TEST-001-C');
+      expect(result.orphans[0].reason).toContain('-C');
+    });
+
+    it('handles null phases gracefully', () => {
+      const children = [
+        { sd_key: 'SD-TEST-001-A', title: 'Phase 1: Work', status: 'draft', parent_sd_id: 'uuid-1' }
+      ];
+      const result = detectOrphanChildren(null, children);
+      // With no phases, Phase 1 reference is technically orphan
+      expect(result.checkedCount).toBe(1);
+    });
+
+    it('handles null children gracefully', () => {
+      const result = detectOrphanChildren(phases, null);
+      expect(result.orphans).toEqual([]);
+      expect(result.checkedCount).toBe(0);
+    });
+  });
+
+  describe('validatePhaseCoverage (existing + backward compat)', () => {
+    it('reports 100% coverage when all phases have SDs', () => {
+      const phases = [
+        { number: 1, title: 'Phase One', covered_by_sd_key: 'SD-A' },
+        { number: 2, title: 'Phase Two', covered_by_sd_key: 'SD-B' }
+      ];
+      const sds = [
+        { sd_key: 'SD-A', title: 'A', status: 'draft' },
+        { sd_key: 'SD-B', title: 'B', status: 'draft' }
+      ];
+      const result = validatePhaseCoverage(phases, sds);
+      expect(result.passed).toBe(true);
+      expect(result.coveragePercent).toBe(100);
+    });
+
+    it('reports uncovered phases', () => {
+      const phases = [
+        { number: 1, title: 'Phase One', covered_by_sd_key: 'SD-A' },
+        { number: 2, title: 'Phase Two' }
+      ];
+      const sds = [{ sd_key: 'SD-A', title: 'A', status: 'draft' }];
+      const result = validatePhaseCoverage(phases, sds);
+      expect(result.passed).toBe(false);
+      expect(result.uncovered).toHaveLength(1);
+      expect(result.uncovered[0].phase.title).toBe('Phase Two');
+    });
+
+    it('handles empty phases', () => {
+      const result = validatePhaseCoverage([], []);
+      expect(result.passed).toBe(true);
+      expect(result.totalPhases).toBe(0);
+    });
+  });
+
+  describe('formatCoverageReport', () => {
+    it('formats report with covered and uncovered phases', () => {
+      const report = {
+        covered: [{ phase: { number: 1, title: 'DB Migration' }, sd_key: 'SD-A', sd_title: 'SD A' }],
+        uncovered: [{ phase: { number: 2, title: 'API Work', child_designation: 'B' } }],
+        coveragePercent: 50,
+        totalPhases: 2,
+        coveredCount: 1,
+        passed: false
+      };
+      const output = formatCoverageReport(report);
+      expect(output).toContain('DB Migration');
+      expect(output).toContain('SD-A');
+      expect(output).toContain('API Work');
+      expect(output).toContain('BLOCKING');
+    });
+
+    it('formats empty phases report', () => {
+      const report = { covered: [], uncovered: [], coveragePercent: 100, totalPhases: 0, coveredCount: 0, passed: true };
+      const output = formatCoverageReport(report);
+      expect(output).toContain('not applicable');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `cancellation_reason`, `cancelled_by`, `scope_authority` columns to `strategic_directives_v2`
- Add DB trigger enforcing `cancellation_reason` when status transitions to `cancelled`
- Add `detectOrphanChildren()` backward reconciliation to phase-coverage validator
- Integrate orphan detection into LEAD-TO-PLAN phase-coverage gate (warnings + score reduction)
- 11 unit tests covering orphan detection, phase coverage, and report formatting

## Test plan
- [x] Unit tests pass (11/11) — `vitest tests/unit/scope-governance.test.js`
- [x] DB migration deployed and verified
- [x] PLAN-TO-LEAD handoff passes at 92%
- [x] LEAD-FINAL-APPROVAL passes at 95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)