### PR TITLE
feat: add growth_strategy column migration for portfolio balance

### DIFF
--- a/database/migrations/20260314_add_growth_strategy_to_ventures.sql
+++ b/database/migrations/20260314_add_growth_strategy_to_ventures.sql
@@ -1,0 +1,24 @@
+-- Migration: Add growth_strategy column to ventures table
+-- SD: SD-LEO-FEAT-PORTFOLIO-BALANCE-SYSTEM-001
+-- Purpose: Enable portfolio-level strategy classification (Cash Engine, Capability Builder, Moonshot)
+
+-- Step 1: Create enum type
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'growth_strategy_type') THEN
+    CREATE TYPE growth_strategy_type AS ENUM ('cash_engine', 'capability_builder', 'moonshot');
+  END IF;
+END$$;
+
+-- Step 2: Add column (nullable - backward compatible)
+ALTER TABLE ventures
+  ADD COLUMN IF NOT EXISTS growth_strategy growth_strategy_type;
+
+-- Step 3: Index for portfolio balance queries
+CREATE INDEX IF NOT EXISTS idx_ventures_growth_strategy
+  ON ventures (growth_strategy)
+  WHERE status = 'active' AND deleted_at IS NULL;
+
+-- Step 4: Column documentation
+COMMENT ON COLUMN ventures.growth_strategy IS
+  'Portfolio growth strategy classification: cash_engine (proven revenue), capability_builder (reusable tech/business capabilities), moonshot (high risk/high ceiling)';


### PR DESCRIPTION
## Summary
- Adds `growth_strategy_type` enum (`cash_engine`, `capability_builder`, `moonshot`) to Supabase
- Adds `growth_strategy` column to `ventures` table (nullable, backward compatible)
- Creates partial index on `growth_strategy` for active ventures
- Migration already applied to production database

## SD
SD-LEO-FEAT-PORTFOLIO-BALANCE-SYSTEM-001

## Test plan
- [x] Migration applied successfully to Supabase
- [x] Column queryable via `SELECT growth_strategy FROM ventures`
- [x] Enum type created with correct values
- [x] Index created for active venture queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)