### PR TITLE
fix: enforce DB-only policy for vision/arch documents in brainstorm skill

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -757,7 +757,7 @@ This step creates formal planning documents and registers them in EVA's tracking
 
 ### 9.5A: Auto-Generate Vision Document
 
-**AUTOMATED**: Synthesize a vision document from brainstorm content. Write to `docs/plans/<topic-slug>-vision.md`.
+**AUTOMATED**: Synthesize a vision document from brainstorm content. Generate the content in-memory — do NOT write to the filesystem. The content will be passed directly to EVA registration via `--content` flag.
 
 Use the brainstorm discovery answers, team perspectives (Challenger, Visionary, Pragmatist), and evaluation results to generate **all** of the following sections. Every section is **required** — EVA registration will fail if any are missing.
 
@@ -799,7 +799,7 @@ Use the brainstorm discovery answers, team perspectives (Challenger, Visionary, 
 [Include ONLY if Step 8.7 produced flagged items. List each flagged category with the specific concern and recommended mitigation. Omit this section entirely if all items were accepted as-is.]
 ```
 
-**After writing the file**, verify it exists and has all 10 required sections before proceeding to 9.5B.
+**After generating the content in-memory**, verify it has all 10 required sections before proceeding to 9.5B. Do NOT write this content to the filesystem — it will be passed directly to the registration command.
 
 ### 9.5B: Register Vision in EVA (with Key Capture)
 
@@ -809,10 +809,12 @@ Run the vision command with dimensions derived from the vision doc's success cri
 node scripts/eva/vision-command.mjs upsert \
   --vision-key VISION-<TOPIC-KEY>-L2-001 \
   --level L2 \
-  --source docs/plans/<topic-slug>-vision.md \
+  --content '<VISION_CONTENT_FROM_STEP_9.5A>' \
   --brainstorm-id <SESSION_ID> \
   --dimensions '<JSON_ARRAY>'
 ```
+
+**IMPORTANT**: Use `--content` to pass the in-memory vision content directly. Do NOT use `--source` with a file path — that would create a markdown file, violating the DB-only policy.
 
 **Dimension derivation** (no LLM needed):
 - Extract 6-10 dimensions from the vision doc's success criteria and key sections
@@ -828,12 +830,12 @@ node scripts/eva/vision-command.mjs upsert \
 3. **If the command fails** (non-zero exit code or error in output):
    - Report the specific error to the user (e.g., "Missing required section: Problem Statement")
    - **HALT** — do NOT proceed to Step 9.5C
-   - Suggest fixing the vision document and retrying: "Fix the issue in docs/plans/<slug>-vision.md, then re-run Step 9.5B"
+   - Suggest fixing the in-memory vision content and retrying Step 9.5B
 4. **If the command succeeds**, confirm: `✅ Vision registered: VISION-<KEY> (L2, N dimensions)`
 
 ### 9.5C: Auto-Generate Architecture Plan
 
-**AUTOMATED**: Synthesize an architecture plan from brainstorm content. Write to `docs/plans/<topic-slug>-architecture.md`.
+**AUTOMATED**: Synthesize an architecture plan from brainstorm content. Generate the content in-memory — do NOT write to the filesystem. The content will be passed directly to EVA registration via `--content` flag.
 
 Use the Pragmatist's feasibility analysis, the Challenger's risk assessment, and the brainstorm's technical discussion to generate **all** of the following sections. Every section is **required**.
 
@@ -895,7 +897,7 @@ Architecture plans MUST reference specific details from the brainstorm conversat
 
 **If Chairman Review flags exist** (from Step 8.7): Include a `## Chairman Review Flags` section listing each flagged item and how the architecture addresses or mitigates the concern.
 
-**After writing the file**, verify it exists and has all 8 required sections (plus Chairman Review Flags if applicable) before proceeding to the quality gate.
+**After generating the content in-memory**, verify it has all 8 required sections (plus Chairman Review Flags if applicable) before proceeding to the quality gate. Do NOT write this content to the filesystem.
 
 ### 9.5C-GATE: Architecture Plan Quality Gate (BLOCKING)
 
@@ -913,7 +915,7 @@ Architecture plans MUST reference specific details from the brainstorm conversat
 
 **Scoring Procedure:**
 
-1. Read the architecture plan file (`docs/plans/<topic-slug>-architecture.md`)
+1. Review the in-memory architecture plan content
 2. For each dimension, assign a score 0-100 based on the criteria above
 3. Compute weighted total: `total = (completeness * 0.25) + (depth * 0.20) + (deferral * 0.20) + (phasing * 0.15) + (chairman * 0.20)`
 4. Record the scores in the brainstorm session context for metadata capture at Step 11
@@ -936,9 +938,11 @@ Architecture plans MUST reference specific details from the brainstorm conversat
 node scripts/eva/archplan-command.mjs upsert \
   --plan-key ARCH-<TOPIC-KEY>-001 \
   --vision-key VISION-<TOPIC-KEY>-L2-001 \
-  --source docs/plans/<topic-slug>-architecture.md \
+  --content '<ARCHITECTURE_CONTENT_FROM_STEP_9.5C>' \
   --dimensions '<JSON_ARRAY>'
 ```
+
+**IMPORTANT**: Use `--content` to pass the in-memory architecture content directly. Do NOT use `--source` with a file path — that would require creating a markdown file, violating the DB-only policy. The `--sections` flag is also available as an alternative for structured JSON input.
 
 Architecture dimensions focus on structural/implementation aspects (6-8 dimensions).
 Weights should sum to ~1.0 — verify before passing (warn if outside 0.9-1.1).

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ applications/*/.env.encrypted
 applications/*/.env.decrypted
 applications/*/.leo-sync/supabase/.temp/
 
+# Vision/Architecture documents are DB-only — never commit markdown versions
+docs/plans/*-vision.md
+docs/plans/*-architecture.md
+
 # Auto-generated database optimization files
 database-optimization.sql
 migrations/*_optimize_database.sql

--- a/scripts/eva/archplan-command.mjs
+++ b/scripts/eva/archplan-command.mjs
@@ -14,7 +14,9 @@
  *   extract  --source <path>              Extract dimensions (includes ADR/capability context)
  *   upsert   --plan-key <key>             Upsert architecture plan after chairman approval
  *            --vision-key <key>           Link to parent vision document
- *            --source <path>
+ *            --source <path>              Read content from file
+ *            [--content <text>]           Inline content (DB-only workflow)
+ *            [--sections <json>]          Structured sections JSON (DB-only workflow, mirrors vision-command)
  *            [--dimensions <json>]
  *            [--brainstorm-id <uuid>]
  *   addendum --plan-key <key>             Append addendum section to existing plan
@@ -34,6 +36,8 @@ import { fileURLToPath } from 'url';
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import { getValidationClient } from '../../lib/llm/client-factory.js';
+import { getSectionSchema, validateSections } from './document-section-registry.mjs';
+import { renderSectionsToMarkdown } from './sections-to-markdown-renderer.mjs';
 
 dotenv.config();
 
@@ -201,20 +205,46 @@ async function cmdExtract({ source, content: contentArg }) {
   console.log(JSON.stringify(dimensions, null, 2));
 }
 
-async function cmdUpsert({ planKey, visionKey, source, dimensions: dimensionsJson, brainstormId, content: contentArg }) {
+async function cmdUpsert({ planKey, visionKey, source, dimensions: dimensionsJson, brainstormId, content: contentArg, sections: sectionsJson }) {
   if (!planKey) { console.error('--plan-key is required'); process.exit(1); }
   if (!visionKey) { console.error('--vision-key is required (link to parent vision document)'); process.exit(1); }
-  if (!source && !contentArg) { console.error('--source or --content is required'); process.exit(1); }
+  if (!source && !contentArg && !sectionsJson) { console.error('--source, --content, or --sections is required'); process.exit(1); }
 
-  let content;
-  if (contentArg) {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  let content = '';
+
+  // Sections-first path: --sections flag provides structured sections directly (DB-only workflow)
+  if (sectionsJson) {
+    let parsedSections;
+    try {
+      parsedSections = JSON.parse(sectionsJson);
+    } catch (e) {
+      console.error('Invalid --sections JSON:', e.message);
+      process.exit(1);
+    }
+
+    // Validate against schema
+    const validation = await validateSections(parsedSections, 'architecture', { supabase });
+    if (!validation.valid) {
+      console.error('Section validation errors:');
+      validation.errors.forEach(e => console.error(`  - ${e}`));
+      process.exit(1);
+    }
+    if (validation.warnings.length > 0) {
+      validation.warnings.forEach(w => console.warn(`  ⚠️  ${w}`));
+    }
+
+    // Render content from sections
+    const schema = await getSectionSchema('architecture', { supabase });
+    content = renderSectionsToMarkdown(parsedSections, planKey, schema);
+  } else if (contentArg) {
     content = contentArg;
   } else {
     const fullPath = resolve(REPO_ROOT, source);
     if (!existsSync(fullPath)) { console.error(`File not found: ${fullPath}`); process.exit(1); }
     content = readFileSync(fullPath, 'utf8');
   }
-  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
   // Resolve vision_id from vision_key
   const { data: visionDoc, error: visionErr } = await supabase


### PR DESCRIPTION
## Summary
- Add `--sections` flag to `archplan-command.mjs` mirroring `vision-command.mjs` capability for file-free architecture plan registration
- Rewrite brainstorm skill Steps 9.5A-D to use `--content` flag instead of writing markdown files to `docs/plans/`
- Delete 50 orphaned vision/arch markdown files from `docs/plans/`
- Add `.gitignore` rules to block future `*-vision.md` and `*-architecture.md` files in `docs/plans/`

**Root cause** (from RCA): Brainstorm skill instructions were never updated after DB-only policy was established. Memory feedback files are advisory and get overridden by explicit skill instructions.

SD: SD-MAN-INFRA-FIX-BRAINSTORM-SKILL-001

## Test plan
- [x] `.gitignore` blocks `docs/plans/test-vision.md` (verified via `git check-ignore`)
- [x] Zero orphaned `*-vision.md` / `*-architecture.md` files remain in `docs/plans/`
- [x] `archplan-command.mjs` has `--sections` support (4 code references)
- [x] `brainstorm.md` no longer instructs writing to `docs/plans/` (0 matches)
- [x] Smoke tests pass (15/15)
- [x] LOC: +52 -14 (66 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)