### PR TITLE
feat: brainstorm_sessions content column migration

### DIFF
--- a/database/migrations/20260313_brainstorm_content_column.sql
+++ b/database/migrations/20260313_brainstorm_content_column.sql
@@ -1,0 +1,13 @@
+-- Migration: Add content column to brainstorm_sessions
+-- Purpose: Store brainstorm markdown content directly in the database
+--          instead of relying on filesystem files (DB-only pattern)
+-- Date: 2026-03-13
+-- Idempotent: Yes (IF NOT EXISTS guard)
+
+ALTER TABLE brainstorm_sessions
+  ADD COLUMN IF NOT EXISTS content TEXT;
+
+COMMENT ON COLUMN brainstorm_sessions.content IS 'Brainstorm markdown content stored directly in DB (replaces filesystem storage)';
+
+-- Rollback:
+-- ALTER TABLE brainstorm_sessions DROP COLUMN IF EXISTS content;


### PR DESCRIPTION
## Summary
- Adds migration file documenting the `content TEXT` column on `brainstorm_sessions` table
- Column already applied to production DB; this migration file is for documentation/reproducibility
- Part of SD-LEO-INFRA-ONLY-ENFORCEMENT-STRATEGIC-002 (DB-Only Enforcement for Strategic Artifacts)

## Test plan
- [x] Column verified present in production DB
- [x] Migration uses `IF NOT EXISTS` guard for idempotency
- [x] 7/7 DB-only enforcement unit tests passing
- [x] 15/15 smoke tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)