### PR TITLE
fix: wire enrichment step into EVA intake pipeline

### DIFF
--- a/scripts/eva-intake-pipeline.js
+++ b/scripts/eva-intake-pipeline.js
@@ -99,6 +99,18 @@ if (fromStep <= 2) {
   console.log('\n── Step 2: Classify ── SKIPPED\n');
 }
 
+// ─── Step 2.5: Enrich ──────────────────────────────────────
+if (fromStep <= 2) {
+  header('2.5', 'Enrich classified items');
+  const enrichFlags = dryRun ? ' --dry-run' : '';
+  const ok = run(`node scripts/eva/intake-enricher.js${enrichFlags}`);
+  if (!ok) {
+    console.error('  ⚠ Enrichment had errors. Check output above.\n');
+  }
+} else {
+  console.log('\n── Step 2.5: Enrich ── SKIPPED\n');
+}
+
 // ─── Step 3: Chairman Review ─────────────────────────────────
 if (fromStep <= 3 && !skipReview) {
   header(3, 'Chairman intake review');


### PR DESCRIPTION
## Summary

- The intake enricher existed as a standalone script but was never called from the pipeline orchestrator
- Items went Classify → Chairman Review, but review filters on `enrichment_status='enriched'`, silently skipping unenriched items
- Adds Step 2.5 (Enrich) between Classify and Chairman Review
- Third missing integration found via RCA (after import bug and chairman review)

## Test plan
- [x] Pipeline run with 3 re-imported items: all enriched → reviewed → wave-assigned
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)