### PR TITLE
feat: intent-guided Gemini video analysis + chairman notes

### DIFF
--- a/.claude/commands/distill.md
+++ b/.claude/commands/distill.md
@@ -275,13 +275,20 @@ If `REVIEW_COUNT=0`, skip to Phase 3 — no items need review.
 
 For each item in the review JSON (or batched in groups of up to 4 — AskUserQuestion supports 1-4 questions per call):
 
-Each item has: `itemId`, `markdown` (formatted description), `options` (intent choices with AI recommendation first), `title`.
+Each item has: `itemId`, `markdown` (formatted description), `options` (intent choices with AI recommendation first), `title`, `captureIntent`.
+
+**Build the question text** for each item:
+1. Start with the item's `markdown` field (title, source, application, aspects, enrichment summary, confidence, description)
+2. **If the item has a YouTube video**: Add a clickable link line: `**Watch:** https://www.youtube.com/watch?v=VIDEO_ID` — detect this by checking if `enrichment_summary` contains "Video:" or "YouTube video:" or if the title contains a youtu.be/youtube.com URL
+3. **If enrichment contains "AI Analysis:"**: Show the Gemini video summary prominently — this is the actual content analysis of the video
 
 Present using AskUserQuestion:
-- `question`: Use the item's `markdown` field — it contains title, source, application, aspects, enrichment summary, confidence, and description
+- `question`: The built question text with clickable YouTube URL
 - `header`: "Review"
 - `options`: Use the item's `options` array (Build/Research/Reference/Improve with AI recommendation marked)
 - `multiSelect`: false
+
+**IMPORTANT**: Use the `annotations` parameter on the AskUserQuestion call to enable the chairman to add notes. The user can attach free-text notes to any selection. After the user responds, check `annotations` for any notes they provided.
 
 **Batching strategy** (for efficiency when many items):
 - If ≤ 4 items: present all in a single AskUserQuestion call (one question per item)
@@ -293,7 +300,7 @@ Present using AskUserQuestion:
 
 **Step 2c: Store decisions**
 
-For each item the chairman reviewed, store the decision. The `chairman_intent` column has a check constraint allowing only: `idea`, `insight`, `reference`, `question`, `value`. So we store the chairman's action-intent choice by mapping it BACK to capture-intent for storage:
+For each item the chairman reviewed, store the decision AND any notes. The `chairman_intent` column has a check constraint allowing only: `idea`, `insight`, `reference`, `question`, `value`. So we store the chairman's action-intent choice by mapping it BACK to capture-intent for storage:
 
 | Chairman chose | Store as `chairman_intent` |
 |---------------|---------------------------|
@@ -301,6 +308,8 @@ For each item the chairman reviewed, store the decision. The `chairman_intent` c
 | Improve | `insight` |
 | Reference | `reference` |
 | Research | `question` |
+
+Check `annotations` from the AskUserQuestion response for any notes the chairman provided. Store notes in `chairman_notes` column.
 
 For each reviewed item, run:
 
@@ -311,6 +320,7 @@ const { createClient } = require('@supabase/supabase-js');
 const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 sb.from('eva_todoist_intake').update({
   chairman_intent: 'INTENT_VALUE',
+  chairman_notes: 'NOTES_OR_NULL',
   chairman_reviewed_at: new Date().toISOString()
 }).eq('id', 'ITEM_UUID').then(({error}) => {
   if (error) console.error('Error:', error.message);
@@ -322,6 +332,50 @@ sb.from('eva_todoist_intake').update({
 Replace `INTENT_VALUE` with the mapped capture-intent value and `ITEM_UUID` with the item ID.
 
 You can batch multiple updates into a single script for efficiency.
+
+**Step 2d: Gemini video analysis for YouTube items (post-review)**
+
+After storing all chairman decisions, check if any reviewed items are YouTube videos where the chairman provided notes. For these items, run Gemini video analysis with the chairman's intent as context.
+
+Identify YouTube items: items where `enrichment_summary` starts with `"Video:"` or contains `"YouTube video:"`.
+
+For each YouTube item with chairman notes, run:
+
+```bash
+node -e "
+import dotenv from 'dotenv';
+dotenv.config();
+import { analyzeVideoContent } from './lib/integrations/youtube/video-metadata.js';
+
+const result = await analyzeVideoContent('VIDEO_ID', {
+  verbose: true,
+  chairmanIntent: 'CHAIRMAN_NOTES_HERE',
+  metadata: { title: 'VIDEO_TITLE', channelName: 'CHANNEL', durationSeconds: DURATION }
+});
+if (result) console.log('ANALYSIS:' + result);
+else console.log('ANALYSIS_FAILED');
+"
+```
+
+Use `timeout: 120000` (videos can take time).
+
+If analysis succeeds, update the item's `enrichment_summary` to append the analysis:
+
+```bash
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+sb.from('eva_todoist_intake').update({
+  enrichment_summary: 'EXISTING_SUMMARY | Chairman Analysis: GEMINI_RESULT'
+}).eq('id', 'ITEM_UUID').then(({error}) => {
+  if (error) console.error('Error:', error.message);
+  else console.log('OK');
+});
+"
+```
+
+Present the Gemini analysis to the chairman as a summary after all items are processed.
 
 **Phase 3: Waves + Archive + Status (automated)**
 

--- a/lib/integrations/youtube/video-metadata.js
+++ b/lib/integrations/youtube/video-metadata.js
@@ -84,4 +84,93 @@ export async function fetchVideoMetadata(videoId, options = {}) {
   }
 }
 
-export default { fetchVideoMetadata };
+/**
+ * Analyze YouTube video content using Gemini's native video understanding.
+ * Sends the YouTube URL directly to Gemini — no download needed.
+ *
+ * Called AFTER chairman review so the chairman's intent guides the analysis.
+ * Fail-open: returns null on any error.
+ *
+ * @param {string} videoId - 11-character YouTube video ID
+ * @param {Object} [options]
+ * @param {boolean} [options.verbose=false]
+ * @param {string} [options.chairmanIntent] - Chairman's notes/intent to guide analysis
+ * @param {Object} [options.metadata] - Pre-fetched metadata to include in prompt
+ * @returns {Promise<string|null>} Content summary or null
+ */
+export async function analyzeVideoContent(videoId, options = {}) {
+  if (!videoId || videoId.length !== 11) return null;
+
+  const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) {
+    if (options.verbose) console.log('    Gemini: No API key for video analysis');
+    return null;
+  }
+
+  const youtubeUrl = `https://www.youtube.com/watch?v=${videoId}`;
+  const model = 'gemini-2.5-pro';
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+
+  const metaContext = options.metadata
+    ? `\nVideo title: "${options.metadata.title}"\nChannel: ${options.metadata.channelName}\nDuration: ${Math.round(options.metadata.durationSeconds / 60)} minutes`
+    : '';
+
+  const intentContext = options.chairmanIntent
+    ? `\n\nThe chairman's intent for this video: "${options.chairmanIntent}"\nFocus your analysis on what's relevant to this intent.`
+    : '';
+
+  const prompt = options.chairmanIntent
+    ? `Analyze this YouTube video based on the chairman's stated intent. Provide 3-5 sentences explaining what's in the video that's relevant to their goals, specific techniques or insights they should know about, and actionable takeaways.${metaContext}${intentContext}`
+    : `Summarize this YouTube video in 3-4 sentences for a strategic business evaluation. Focus on: what it teaches, key techniques or insights, and why it might be valuable for a software company building AI-powered tools.${metaContext}`;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 60_000);
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{
+          parts: [
+            { text: prompt },
+            {
+              fileData: {
+                mimeType: 'video/*',
+                fileUri: youtubeUrl,
+              },
+            },
+          ],
+        }],
+        generationConfig: {
+          maxOutputTokens: 2048,
+          temperature: 0.3,
+        },
+      }),
+    });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => '');
+      if (options.verbose) console.log(`    Gemini video analysis error: ${response.status} ${errBody.substring(0, 200)}`);
+      return null;
+    }
+
+    const data = await response.json();
+    const summary = data.candidates?.[0]?.content?.parts?.[0]?.text || null;
+
+    if (options.verbose && summary) {
+      console.log(`    Gemini video summary: ${summary.substring(0, 100)}...`);
+    }
+
+    return summary;
+  } catch (err) {
+    if (options.verbose) {
+      console.log(`    Gemini video analysis failed: ${err.message}`);
+    }
+    return null;
+  }
+}
+
+export default { fetchVideoMetadata, analyzeVideoContent };

--- a/scripts/eva/intake-enricher.js
+++ b/scripts/eva/intake-enricher.js
@@ -19,19 +19,35 @@ dotenv.config();
 import { createClient } from '@supabase/supabase-js';
 import { extractYouTubeVideoId, extractYouTubeUrl, extractYouTubePlaylistId } from '../../lib/integrations/url-extractor.js';
 
-// Lazy imports — video-metadata.js pulls in googleapis which may have module issues
+// Lazy imports for YouTube metadata + video analysis
 let _fetchVideoMetadata = null;
+let _analyzeVideoContent = null;
+
 async function lazyFetchVideoMetadata(videoId, options) {
   if (!_fetchVideoMetadata) {
     try {
       const mod = await import('../../lib/integrations/youtube/video-metadata.js');
       _fetchVideoMetadata = mod.fetchVideoMetadata;
+      _analyzeVideoContent = mod.analyzeVideoContent;
     } catch (err) {
       console.error(`    video-metadata.js import failed: ${err.message}`);
       return null;
     }
   }
   return _fetchVideoMetadata(videoId, options);
+}
+
+async function lazyAnalyzeVideoContent(videoId, options) {
+  if (!_analyzeVideoContent) {
+    try {
+      const mod = await import('../../lib/integrations/youtube/video-metadata.js');
+      _analyzeVideoContent = mod.analyzeVideoContent;
+    } catch (err) {
+      if (options?.verbose) console.log(`    video analysis import failed: ${err.message}`);
+      return null;
+    }
+  }
+  return _analyzeVideoContent(videoId, options);
 }
 
 let _checkDuplicate = null;
@@ -239,6 +255,9 @@ export async function enrichItems(options = {}) {
         } else {
           enrichmentSummary = `YouTube video: ${videoId} (metadata unavailable)`;
         }
+
+        // Note: Gemini video analysis runs AFTER chairman review (in /distill skill)
+        // so the chairman's intent can guide what Gemini focuses on
 
         // Cross-link with eva_youtube_intake
         if (!item.youtube_intake_id) {


### PR DESCRIPTION
## Summary

- **Gemini video analysis**: `analyzeVideoContent()` sends YouTube URL to Gemini 2.5 Pro with chairman's stated intent as context, producing targeted analysis (e.g., "I want to learn the UI cloning technique" → analysis focused on that technique)
- **Chairman notes**: `/distill` skill now captures notes via AskUserQuestion annotations, stores in `chairman_notes` column
- **Clickable YouTube URLs**: Review questions include `**Watch:** https://youtube.com/watch?v=...` so chairman can watch before deciding
- **Post-review analysis**: Gemini runs AFTER chairman review (Step 2d), using their notes to guide focus — not blind analysis during enrichment

### Flow
1. Enricher fetches YouTube metadata (title, channel, duration)
2. Chairman sees item with clickable link, picks intent, adds notes
3. Gemini analyzes video guided by chairman's notes
4. Analysis stored in `enrichment_summary`

## Test plan
- [x] `analyzeVideoContent()` with intent: 1195-char analysis focused on chairman's stated goal
- [x] Without intent: generic 3-4 sentence summary
- [x] Fail-open: returns null on error, never blocks pipeline
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)