### PR TITLE
fix: EVA Friday meeting data population and process.argv guard

### DIFF
--- a/scripts/eva/brainstorm-to-vision.mjs
+++ b/scripts/eva/brainstorm-to-vision.mjs
@@ -249,10 +249,10 @@ async function main() {
 }
 
 // Windows-compatible ESM entry point
-if (
+if (process.argv[1] && (
   import.meta.url === `file://${process.argv[1]}` ||
   import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`
-) {
+)) {
   main().catch(err => { console.error('Fatal:', err.message); process.exit(1); });
 }
 

--- a/scripts/eva/consultant-analysis-round.mjs
+++ b/scripts/eva/consultant-analysis-round.mjs
@@ -400,6 +400,8 @@ export async function consultantAnalysisHandler(options = {}) {
         action_type: 'review',
         status: 'pending',
         application_domain: finding.domain,
+        analysis_domain: finding.domain,
+        confidence_tier: finding.tier,
         detected_by: 'consultant-analysis-round.mjs',
       }, { onConflict: 'recommendation_date,title' });
 
@@ -437,8 +439,8 @@ export function registerConsultantAnalysisRound(scheduler) {
 }
 
 // Manual trigger support
-if (import.meta.url === `file://${process.argv[1]}` ||
-    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`) {
+if (process.argv[1] && (import.meta.url === `file://${process.argv[1]}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`)) {
   console.log('[consultant-analysis] Manual trigger starting...');
   consultantAnalysisHandler().then(result => {
     console.log('[consultant-analysis] Result:', JSON.stringify(result, null, 2));

--- a/scripts/eva/dashboard-command.mjs
+++ b/scripts/eva/dashboard-command.mjs
@@ -160,8 +160,8 @@ async function main() {
 }
 
 // ESM entry point (Windows-compatible)
-if (import.meta.url === `file://${process.argv[1]}` ||
-    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`) {
+if (process.argv[1] && (import.meta.url === `file://${process.argv[1]}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`)) {
   main();
 }
 

--- a/scripts/eva/doc-health-audit.mjs
+++ b/scripts/eva/doc-health-audit.mjs
@@ -692,8 +692,8 @@ async function main() {
 }
 
 // ESM entry point (handles Windows path differences)
-const isMainModule = import.meta.url === `file://${process.argv[1]}` ||
-  import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+const isMainModule = process.argv[1] && (import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`);
 
 if (isMainModule) {
   main();

--- a/scripts/eva/friday-meeting.mjs
+++ b/scripts/eva/friday-meeting.mjs
@@ -574,8 +574,8 @@ export function registerFridayMeetingRound(scheduler) {
 }
 
 // CLI entry point
-const isDirectRun = import.meta.url === `file://${process.argv[1]}`
-  || import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+const isDirectRun = process.argv[1] && (import.meta.url === `file://${process.argv[1]}`
+  || import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`);
 
 if (isDirectRun) {
   fridayMeetingHandler({ interactive: true })

--- a/scripts/eva/intake-enricher.js
+++ b/scripts/eva/intake-enricher.js
@@ -347,8 +347,8 @@ export async function enrichItems(options = {}) {
 }
 
 // CLI entry point
-if (import.meta.url === `file://${process.argv[1]}` ||
-    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`) {
+if (process.argv[1] && (import.meta.url === `file://${process.argv[1]}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`)) {
   const verbose = process.argv.includes('--verbose') || process.argv.includes('-v');
   const dryRun = process.argv.includes('--dry-run');
   const limitIdx = process.argv.indexOf('--limit');

--- a/scripts/eva/process-gap-reporter.mjs
+++ b/scripts/eva/process-gap-reporter.mjs
@@ -249,8 +249,8 @@ export async function syncProcessGaps(supabase, options = {}) {
 }
 
 // CLI entry point
-const isMain = import.meta.url === `file://${process.argv[1]}` ||
-               import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+const isMain = process.argv[1] && (import.meta.url === `file://${process.argv[1]}` ||
+               import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`);
 
 if (isMain) {
   const args = process.argv.slice(2);

--- a/scripts/eva/seed-l1-vision.js
+++ b/scripts/eva/seed-l1-vision.js
@@ -261,10 +261,10 @@ export async function main() {
 }
 
 // Windows-compatible ESM entry point
-if (
+if (process.argv[1] && (
   import.meta.url === `file://${process.argv[1]}` ||
   import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`
-) {
+)) {
   main().catch((err) => {
     console.error('Fatal error:', err.message);
     process.exit(1);

--- a/scripts/eva/vision-to-patterns.js
+++ b/scripts/eva/vision-to-patterns.js
@@ -285,8 +285,8 @@ export async function syncVisionScoresToPatterns(supabase, options = {}) {
 // CLI entry point
 // ============================================================================
 
-const isMainModule = import.meta.url === `file://${process.argv[1]}` ||
-                     import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+const isMainModule = process.argv[1] && (import.meta.url === `file://${process.argv[1]}` ||
+                     import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`);
 
 if (isMainModule) {
   const args = process.argv.slice(2);
@@ -299,14 +299,14 @@ if (isMainModule) {
     process.env.SUPABASE_SERVICE_ROLE_KEY
   );
 
-  console.log(`\n🔄 Vision-to-Patterns Sync`);
+  console.log('\n🔄 Vision-to-Patterns Sync');
   console.log(`   Lookback: ${lookbackDays} days`);
   console.log(`   Dry Run:  ${dryRun}`);
   console.log('');
 
   syncVisionScoresToPatterns(supabase, { dryRun, lookbackDays })
     .then(({ synced, skipped, errors }) => {
-      console.log(`\n✅ Sync complete`);
+      console.log('\n✅ Sync complete');
       console.log(`   Synced:  ${synced} dimension patterns`);
       console.log(`   Skipped: ${skipped} high-scoring dimensions`);
       console.log(`   Errors:  ${errors}`);


### PR DESCRIPTION
## Summary
- Fixed consultant-analysis-round.mjs not writing `confidence_tier` or `analysis_domain` columns during upsert, causing Friday meeting Section 3 to always show "No high-confidence findings"
- Added `process.argv[1]` null guard to 9 EVA scripts that crashed when dynamically imported via `node -e "import(...)"`

## Files changed (9)
- `scripts/eva/consultant-analysis-round.mjs` — add `confidence_tier` and `analysis_domain` to upsert + argv guard
- `scripts/eva/friday-meeting.mjs` — argv guard
- `scripts/eva/brainstorm-to-vision.mjs` — argv guard
- `scripts/eva/dashboard-command.mjs` — argv guard
- `scripts/eva/doc-health-audit.mjs` — argv guard
- `scripts/eva/intake-enricher.js` — argv guard
- `scripts/eva/process-gap-reporter.mjs` — argv guard
- `scripts/eva/seed-l1-vision.js` — argv guard
- `scripts/eva/vision-to-patterns.js` — argv guard

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Management review round runs and populates data
- [x] Consultant analysis round inserts 9 findings with correct `confidence_tier=high` and `analysis_domain`
- [x] Friday meeting Section 1 shows performance review data
- [x] Friday meeting Section 3 shows 9 high-confidence findings across 2 domains
- [x] Dynamic import no longer crashes EVA scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)