### PR TITLE
feat: SRIP database schema and EVA module CLI

### DIFF
--- a/database/migrations/20260314_srip_artifact_tables.sql
+++ b/database/migrations/20260314_srip_artifact_tables.sql
@@ -1,0 +1,268 @@
+-- =============================================================================
+-- Migration: 20260314_srip_artifact_tables.sql
+-- Purpose: Create SRIP (Site Replication Intelligence Protocol) artifact tables
+-- SD: SD-MAN-ORCH-SRIP-CLONER-INTEGRATION-001
+-- Author: database-agent
+-- Date: 2026-03-14
+--
+-- Tables created:
+--   1. srip_site_dna          - Extracted design patterns from reference URLs
+--   2. srip_brand_interviews  - Brand interview answers per venture
+--   3. srip_synthesis_prompts - Generated one-shot replication prompts
+--   4. srip_quality_checks    - Multi-domain fidelity scores
+--
+-- Dependencies:
+--   - ventures(id) must exist (created in 20251130_ehg_app_schema_migration.sql)
+--   - public.update_updated_at_column() must exist (created in 20251201_fix_ehg_consolidation_p0.sql)
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS srip_quality_checks CASCADE;
+--   DROP TABLE IF EXISTS srip_synthesis_prompts CASCADE;
+--   DROP TABLE IF EXISTS srip_brand_interviews CASCADE;
+--   DROP TABLE IF EXISTS srip_site_dna CASCADE;
+-- =============================================================================
+
+-- =============================================================================
+-- TABLE 1: srip_site_dna
+-- Stores extracted design patterns (DNA) from reference URLs.
+-- The dna_json column contains design tokens, layout structure, component
+-- inventory, and other visual/structural patterns extracted from the reference.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS srip_site_dna (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID REFERENCES ventures(id) ON DELETE CASCADE,
+  reference_url TEXT NOT NULL,
+  screenshot_path TEXT,
+  dna_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+  extraction_steps JSONB DEFAULT '[]'::jsonb,
+  quality_score NUMERIC(5,2),
+  status VARCHAR(20) DEFAULT 'draft' CHECK (status IN ('draft', 'processing', 'completed', 'failed')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  created_by VARCHAR(100)
+);
+
+COMMENT ON TABLE srip_site_dna IS 'SRIP: Stores extracted design DNA (tokens, layout, components) from reference site URLs for venture site replication.';
+COMMENT ON COLUMN srip_site_dna.dna_json IS 'JSONB containing design tokens, layout structure, component inventory, typography, color palette, and spacing extracted from the reference URL.';
+COMMENT ON COLUMN srip_site_dna.extraction_steps IS 'JSONB array tracking which extraction steps have completed (e.g., screenshot, DOM analysis, style extraction).';
+COMMENT ON COLUMN srip_site_dna.quality_score IS 'Quality score (0-100) indicating confidence in the extraction completeness and accuracy.';
+COMMENT ON COLUMN srip_site_dna.screenshot_path IS 'Optional path to a manual screenshot fallback when automated capture is unavailable.';
+
+
+-- =============================================================================
+-- TABLE 2: srip_brand_interviews
+-- Stores brand interview answers per venture, linking to the site DNA that
+-- may have pre-populated some answers automatically.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS srip_brand_interviews (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID REFERENCES ventures(id) ON DELETE CASCADE,
+  site_dna_id UUID REFERENCES srip_site_dna(id) ON DELETE SET NULL,
+  answers JSONB NOT NULL DEFAULT '{}'::jsonb,
+  pre_populated_count INT DEFAULT 0,
+  manual_input_count INT DEFAULT 0,
+  status VARCHAR(20) DEFAULT 'draft' CHECK (status IN ('draft', 'in_progress', 'completed')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  created_by VARCHAR(100)
+);
+
+COMMENT ON TABLE srip_brand_interviews IS 'SRIP: Stores 12-question brand interview answers per venture. Some answers may be auto-populated from site DNA extraction.';
+COMMENT ON COLUMN srip_brand_interviews.answers IS 'JSONB containing the 12 brand interview question-answer pairs (e.g., brand personality, target audience, tone of voice).';
+COMMENT ON COLUMN srip_brand_interviews.pre_populated_count IS 'Number of interview questions that were automatically filled from site DNA analysis.';
+COMMENT ON COLUMN srip_brand_interviews.manual_input_count IS 'Number of interview questions that required manual user input.';
+
+
+-- =============================================================================
+-- TABLE 3: srip_synthesis_prompts
+-- Stores generated one-shot replication prompts that combine site DNA and
+-- brand interview data into actionable prompts for site generation.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS srip_synthesis_prompts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID REFERENCES ventures(id) ON DELETE CASCADE,
+  site_dna_id UUID REFERENCES srip_site_dna(id) ON DELETE SET NULL,
+  brand_interview_id UUID REFERENCES srip_brand_interviews(id) ON DELETE SET NULL,
+  prompt_text TEXT NOT NULL,
+  fidelity_target NUMERIC(5,2) DEFAULT 80.00,
+  version INT DEFAULT 1,
+  token_count INT,
+  status VARCHAR(20) DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'superseded')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by VARCHAR(100)
+);
+
+COMMENT ON TABLE srip_synthesis_prompts IS 'SRIP: Stores generated one-shot replication prompts that synthesize site DNA and brand interview data into actionable site generation instructions.';
+COMMENT ON COLUMN srip_synthesis_prompts.prompt_text IS 'The full synthesized prompt text combining design DNA and brand context for one-shot site replication.';
+COMMENT ON COLUMN srip_synthesis_prompts.fidelity_target IS 'Target fidelity score (0-100) that the generated site should achieve against the reference.';
+COMMENT ON COLUMN srip_synthesis_prompts.version IS 'Version number for prompt iterations. New versions supersede previous ones.';
+COMMENT ON COLUMN srip_synthesis_prompts.token_count IS 'Estimated token length of the prompt for LLM context budget planning.';
+
+
+-- =============================================================================
+-- TABLE 4: srip_quality_checks
+-- Stores multi-domain fidelity scores comparing generated output against
+-- the reference site across 6 quality domains.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS srip_quality_checks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID REFERENCES ventures(id) ON DELETE CASCADE,
+  synthesis_prompt_id UUID REFERENCES srip_synthesis_prompts(id) ON DELETE SET NULL,
+  domain_scores JSONB NOT NULL DEFAULT '{}'::jsonb,
+  overall_score NUMERIC(5,2),
+  gaps JSONB DEFAULT '[]'::jsonb,
+  pass_threshold NUMERIC(5,2) DEFAULT 80.00,
+  passed BOOLEAN GENERATED ALWAYS AS (overall_score >= pass_threshold) STORED,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by VARCHAR(100)
+);
+
+COMMENT ON TABLE srip_quality_checks IS 'SRIP: Stores multi-domain fidelity scores comparing generated site output against the reference across 6 domains: layout, visual_composition, design_system, interaction, technical, accessibility.';
+COMMENT ON COLUMN srip_quality_checks.domain_scores IS 'JSONB containing scores for each quality domain: layout, visual_composition, design_system, interaction, technical, accessibility.';
+COMMENT ON COLUMN srip_quality_checks.overall_score IS 'Weighted overall fidelity score (0-100) aggregated from domain scores.';
+COMMENT ON COLUMN srip_quality_checks.gaps IS 'JSONB array of actionable improvement items identified during quality assessment.';
+COMMENT ON COLUMN srip_quality_checks.pass_threshold IS 'Minimum overall score required to pass quality check (default 80.00).';
+COMMENT ON COLUMN srip_quality_checks.passed IS 'Generated column: true when overall_score >= pass_threshold.';
+
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+
+-- Venture lookups (all tables)
+CREATE INDEX IF NOT EXISTS idx_srip_site_dna_venture_id ON srip_site_dna(venture_id);
+CREATE INDEX IF NOT EXISTS idx_srip_brand_interviews_venture_id ON srip_brand_interviews(venture_id);
+CREATE INDEX IF NOT EXISTS idx_srip_synthesis_prompts_venture_id ON srip_synthesis_prompts(venture_id);
+CREATE INDEX IF NOT EXISTS idx_srip_quality_checks_venture_id ON srip_quality_checks(venture_id);
+
+-- Status filtering
+CREATE INDEX IF NOT EXISTS idx_srip_site_dna_status ON srip_site_dna(status);
+CREATE INDEX IF NOT EXISTS idx_srip_synthesis_prompts_status ON srip_synthesis_prompts(status);
+
+-- GIN indexes for JSONB query support
+CREATE INDEX IF NOT EXISTS idx_srip_site_dna_dna_json ON srip_site_dna USING GIN (dna_json);
+CREATE INDEX IF NOT EXISTS idx_srip_quality_checks_domain_scores ON srip_quality_checks USING GIN (domain_scores);
+
+
+-- =============================================================================
+-- UPDATED_AT TRIGGERS
+-- Uses shared public.update_updated_at_column() function
+-- (created in 20251201_fix_ehg_consolidation_p0.sql)
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS update_srip_site_dna_updated_at ON srip_site_dna;
+CREATE TRIGGER update_srip_site_dna_updated_at
+  BEFORE UPDATE ON srip_site_dna
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+DROP TRIGGER IF EXISTS update_srip_brand_interviews_updated_at ON srip_brand_interviews;
+CREATE TRIGGER update_srip_brand_interviews_updated_at
+  BEFORE UPDATE ON srip_brand_interviews
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+
+-- =============================================================================
+-- ROW LEVEL SECURITY
+-- Enables RLS on all SRIP tables with permissive policies for service_role access.
+-- Uses idempotent DO block pattern to avoid policy-already-exists errors.
+-- =============================================================================
+
+ALTER TABLE srip_site_dna ENABLE ROW LEVEL SECURITY;
+ALTER TABLE srip_brand_interviews ENABLE ROW LEVEL SECURITY;
+ALTER TABLE srip_synthesis_prompts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE srip_quality_checks ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  -- srip_site_dna policies
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_site_dna' AND policyname = 'srip_site_dna_select_policy'
+  ) THEN
+    CREATE POLICY srip_site_dna_select_policy ON srip_site_dna FOR SELECT USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_site_dna' AND policyname = 'srip_site_dna_insert_policy'
+  ) THEN
+    CREATE POLICY srip_site_dna_insert_policy ON srip_site_dna FOR INSERT WITH CHECK (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_site_dna' AND policyname = 'srip_site_dna_update_policy'
+  ) THEN
+    CREATE POLICY srip_site_dna_update_policy ON srip_site_dna FOR UPDATE USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_site_dna' AND policyname = 'srip_site_dna_delete_policy'
+  ) THEN
+    CREATE POLICY srip_site_dna_delete_policy ON srip_site_dna FOR DELETE USING (true);
+  END IF;
+
+  -- srip_brand_interviews policies
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_brand_interviews' AND policyname = 'srip_brand_interviews_select_policy'
+  ) THEN
+    CREATE POLICY srip_brand_interviews_select_policy ON srip_brand_interviews FOR SELECT USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_brand_interviews' AND policyname = 'srip_brand_interviews_insert_policy'
+  ) THEN
+    CREATE POLICY srip_brand_interviews_insert_policy ON srip_brand_interviews FOR INSERT WITH CHECK (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_brand_interviews' AND policyname = 'srip_brand_interviews_update_policy'
+  ) THEN
+    CREATE POLICY srip_brand_interviews_update_policy ON srip_brand_interviews FOR UPDATE USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_brand_interviews' AND policyname = 'srip_brand_interviews_delete_policy'
+  ) THEN
+    CREATE POLICY srip_brand_interviews_delete_policy ON srip_brand_interviews FOR DELETE USING (true);
+  END IF;
+
+  -- srip_synthesis_prompts policies
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_synthesis_prompts' AND policyname = 'srip_synthesis_prompts_select_policy'
+  ) THEN
+    CREATE POLICY srip_synthesis_prompts_select_policy ON srip_synthesis_prompts FOR SELECT USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_synthesis_prompts' AND policyname = 'srip_synthesis_prompts_insert_policy'
+  ) THEN
+    CREATE POLICY srip_synthesis_prompts_insert_policy ON srip_synthesis_prompts FOR INSERT WITH CHECK (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_synthesis_prompts' AND policyname = 'srip_synthesis_prompts_update_policy'
+  ) THEN
+    CREATE POLICY srip_synthesis_prompts_update_policy ON srip_synthesis_prompts FOR UPDATE USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_synthesis_prompts' AND policyname = 'srip_synthesis_prompts_delete_policy'
+  ) THEN
+    CREATE POLICY srip_synthesis_prompts_delete_policy ON srip_synthesis_prompts FOR DELETE USING (true);
+  END IF;
+
+  -- srip_quality_checks policies
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_quality_checks' AND policyname = 'srip_quality_checks_select_policy'
+  ) THEN
+    CREATE POLICY srip_quality_checks_select_policy ON srip_quality_checks FOR SELECT USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_quality_checks' AND policyname = 'srip_quality_checks_insert_policy'
+  ) THEN
+    CREATE POLICY srip_quality_checks_insert_policy ON srip_quality_checks FOR INSERT WITH CHECK (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_quality_checks' AND policyname = 'srip_quality_checks_update_policy'
+  ) THEN
+    CREATE POLICY srip_quality_checks_update_policy ON srip_quality_checks FOR UPDATE USING (true);
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'srip_quality_checks' AND policyname = 'srip_quality_checks_delete_policy'
+  ) THEN
+    CREATE POLICY srip_quality_checks_delete_policy ON srip_quality_checks FOR DELETE USING (true);
+  END IF;
+END $$;

--- a/scripts/eva/srip-command.mjs
+++ b/scripts/eva/srip-command.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * EVA SRIP Command - Site Replication Intelligence Protocol
+ * SD: SD-MAN-ORCH-SRIP-CLONER-INTEGRATION-001-A
+ *
+ * CLI entry point for the SRIP pipeline modules.
+ * Follows EVA module patterns (vision-command.mjs, archplan-command.mjs).
+ *
+ * Subcommands:
+ *   audit     --url <url> [--screenshot <path>] [--venture-id <id>]
+ *             Run Forensic Audit on a reference site, extract Site DNA
+ *
+ *   interview --site-dna-id <id> [--venture-id <id>]
+ *             Run Brand Interview (pre-populates from venture data)
+ *
+ *   synthesize --site-dna-id <id> --brand-interview-id <id>
+ *              Generate one-shot replication prompt from DNA + brand
+ *
+ *   check     --synthesis-prompt-id <id>
+ *             Run Quality Check against built output
+ *
+ *   list      [--venture-id <id>] [--type <site_dna|interviews|prompts|checks>]
+ *             List SRIP artifacts
+ *
+ * Usage:
+ *   node scripts/eva/srip-command.mjs audit --url https://example.com --venture-id <uuid>
+ *   node scripts/eva/srip-command.mjs interview --site-dna-id <uuid>
+ *   node scripts/eva/srip-command.mjs list --venture-id <uuid>
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// ============================================================================
+// Argument parsing
+// ============================================================================
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const subcommand = args[0];
+  const opts = {};
+  for (let i = 1; i < args.length; i++) {
+    if (args[i].startsWith('--')) {
+      const key = args[i].slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+      opts[key] = args[i + 1] && !args[i + 1].startsWith('--') ? args[++i] : true;
+    }
+  }
+  return { subcommand, opts };
+}
+
+// ============================================================================
+// Supabase client
+// ============================================================================
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+}
+
+// ============================================================================
+// Subcommand: list
+// ============================================================================
+
+async function handleList(opts) {
+  const supabase = getSupabase();
+  const ventureId = opts.ventureId;
+  const type = opts.type || 'all';
+
+  const tables = {
+    site_dna: 'srip_site_dna',
+    interviews: 'srip_brand_interviews',
+    prompts: 'srip_synthesis_prompts',
+    checks: 'srip_quality_checks',
+  };
+
+  const tablesToQuery = type === 'all' ? Object.entries(tables) : [[type, tables[type]]];
+
+  for (const [label, table] of tablesToQuery) {
+    if (!table) {
+      console.error(`Unknown type: ${type}. Valid: site_dna, interviews, prompts, checks`);
+      continue;
+    }
+
+    const cols = table === 'srip_quality_checks' ? 'id, venture_id, overall_score, created_at' : 'id, venture_id, status, created_at';
+    let query = supabase.from(table).select(cols).order('created_at', { ascending: false }).limit(10);
+    if (ventureId) query = query.eq('venture_id', ventureId);
+
+    const { data, error } = await query;
+    if (error) {
+      console.error(`Error querying ${table}:`, error.message);
+      continue;
+    }
+
+    console.log(`\n=== ${label.toUpperCase()} (${data?.length || 0} records) ===`);
+    if (data && data.length > 0) {
+      for (const row of data) {
+        const statusOrScore = row.status || (row.overall_score !== undefined ? `score: ${row.overall_score}` : 'N/A');
+        console.log(`  ${row.id} | venture: ${row.venture_id || 'N/A'} | ${statusOrScore} | ${new Date(row.created_at).toLocaleDateString()}`);
+      }
+    } else {
+      console.log('  (no records)');
+    }
+  }
+}
+
+// ============================================================================
+// Subcommand: audit (placeholder - implemented in Child B)
+// ============================================================================
+
+async function handleAudit(opts) {
+  if (!opts.url) {
+    console.error('Error: --url is required for audit subcommand');
+    process.exit(1);
+  }
+  console.log(`\n🔍 SRIP Forensic Audit`);
+  console.log(`   URL: ${opts.url}`);
+  console.log(`   Screenshot: ${opts.screenshot || 'none (URL-only mode)'}`);
+  console.log(`   Venture: ${opts.ventureId || 'not specified'}`);
+  console.log(`\n   ⚠️  Forensic Audit module not yet implemented.`);
+  console.log(`   This will be implemented in SD-MAN-ORCH-SRIP-CLONER-INTEGRATION-001-B.`);
+}
+
+// ============================================================================
+// Subcommand: interview (placeholder - implemented in Child C)
+// ============================================================================
+
+async function handleInterview(opts) {
+  if (!opts.siteDnaId) {
+    console.error('Error: --site-dna-id is required for interview subcommand');
+    process.exit(1);
+  }
+  console.log(`\n📝 SRIP Brand Interview`);
+  console.log(`   Site DNA: ${opts.siteDnaId}`);
+  console.log(`   Venture: ${opts.ventureId || 'auto-detect from site_dna'}`);
+  console.log(`\n   ⚠️  Brand Interview module not yet implemented.`);
+  console.log(`   This will be implemented in SD-MAN-ORCH-SRIP-CLONER-INTEGRATION-001-C.`);
+}
+
+// ============================================================================
+// Subcommand: synthesize (placeholder - implemented in Child C)
+// ============================================================================
+
+async function handleSynthesize(opts) {
+  if (!opts.siteDnaId || !opts.brandInterviewId) {
+    console.error('Error: --site-dna-id and --brand-interview-id are required');
+    process.exit(1);
+  }
+  console.log(`\n🔄 SRIP Synthesis`);
+  console.log(`   Site DNA: ${opts.siteDnaId}`);
+  console.log(`   Brand Interview: ${opts.brandInterviewId}`);
+  console.log(`\n   ⚠️  Synthesis module not yet implemented.`);
+  console.log(`   This will be implemented in SD-MAN-ORCH-SRIP-CLONER-INTEGRATION-001-C.`);
+}
+
+// ============================================================================
+// Subcommand: check (placeholder - implemented in Child D)
+// ============================================================================
+
+async function handleCheck(opts) {
+  if (!opts.synthesisPromptId) {
+    console.error('Error: --synthesis-prompt-id is required for check subcommand');
+    process.exit(1);
+  }
+  console.log(`\n✅ SRIP Quality Check`);
+  console.log(`   Synthesis Prompt: ${opts.synthesisPromptId}`);
+  console.log(`\n   ⚠️  Quality Check module not yet implemented.`);
+  console.log(`   This will be implemented in SD-MAN-ORCH-SRIP-CLONER-INTEGRATION-001-D.`);
+}
+
+// ============================================================================
+// Help
+// ============================================================================
+
+function showHelp() {
+  console.log(`
+SRIP - Site Replication Intelligence Protocol
+
+Usage: node scripts/eva/srip-command.mjs <subcommand> [options]
+
+Subcommands:
+  audit       Run Forensic Audit on a reference site
+              --url <url>              Reference site URL (required)
+              --screenshot <path>      Manual screenshot path (optional)
+              --venture-id <id>        Link to venture (optional)
+
+  interview   Run Brand Interview
+              --site-dna-id <id>       Site DNA to interview against (required)
+              --venture-id <id>        Venture for data pre-population
+
+  synthesize  Generate replication prompt
+              --site-dna-id <id>       Site DNA source (required)
+              --brand-interview-id <id> Brand data source (required)
+
+  check       Run Quality Check
+              --synthesis-prompt-id <id> Prompt to validate (required)
+
+  list        List SRIP artifacts
+              --venture-id <id>        Filter by venture (optional)
+              --type <type>            Filter: site_dna|interviews|prompts|checks
+
+Examples:
+  node scripts/eva/srip-command.mjs audit --url https://stripe.com
+  node scripts/eva/srip-command.mjs list --venture-id abc123
+  node scripts/eva/srip-command.mjs list --type site_dna
+`);
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+async function main() {
+  const { subcommand, opts } = parseArgs(process.argv);
+
+  if (!subcommand || subcommand === 'help' || subcommand === '--help' || opts.help) {
+    showHelp();
+    return;
+  }
+
+  switch (subcommand) {
+    case 'audit':
+      await handleAudit(opts);
+      break;
+    case 'interview':
+      await handleInterview(opts);
+      break;
+    case 'synthesize':
+      await handleSynthesize(opts);
+      break;
+    case 'check':
+      await handleCheck(opts);
+      break;
+    case 'list':
+      await handleList(opts);
+      break;
+    default:
+      console.error(`Unknown subcommand: ${subcommand}`);
+      showHelp();
+      process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('SRIP command error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Create 4 Supabase tables for SRIP artifact storage (srip_site_dna, srip_brand_interviews, srip_synthesis_prompts, srip_quality_checks)
- Add EVA module CLI entry point (srip-command.mjs) with 5 subcommands
- Migration includes FK constraints, RLS policies, indexes, and updated_at triggers

## Test plan
- [x] Migration applied successfully to Supabase
- [x] All 4 tables verified via `information_schema.tables`
- [x] CLI `--help` shows all subcommands
- [x] CLI `list` queries all 4 tables without errors
- [x] Placeholder subcommands (audit, interview, synthesize, check) respond with expected messages

SD: SD-MAN-ORCH-SRIP-CLONER-INTEGRATION-001-A
Parent: SD-MAN-ORCH-SRIP-CLONER-INTEGRATION-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)