### PR TITLE
chore: update context window from 200K to 1M tokens

### DIFF
--- a/.claude/protocol-config.md
+++ b/.claude/protocol-config.md
@@ -79,9 +79,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 ## Context Management
 
 ### Token Budget
-- Total Available: 200,000 tokens
-- Standard Context: 200K (standard pricing)
-- Extended Context: 1M tokens (premium pricing via `[1m]` suffix)
+- Total Available: 1,000,000 tokens
+- Standard Context: 1M (all models)
 - Current Estimated Usage: ~131K tokens
 
 ### Memory Strategy

--- a/.claude/statusline-context-tracker.ps1
+++ b/.claude/statusline-context-tracker.ps1
@@ -30,11 +30,11 @@ $LogDir = "C:\Users\rickf\Projects\_EHG\EHG_Engineer\.claude\logs"
 $StateFile = "$LogDir\.context-state.json"
 
 # Thresholds
-$ContextWindow = 200000
+$ContextWindow = 1000000
 $AutocompactPct = 80          # Compaction triggers at this % of context window
-$WarningThreshold = 60
-$CriticalThreshold = 80
-$EmergencyThreshold = 95
+$WarningThreshold = 80
+$CriticalThreshold = 93
+$EmergencyThreshold = 97
 
 # Ensure log directory exists
 if (-not (Test-Path $LogDir)) {
@@ -71,7 +71,7 @@ $modelShort = switch -Regex ($model) {
 $contextSize = if ($data.context_window.context_window_size) {
     [int]$data.context_window.context_window_size
 } else {
-    200000
+    1000000
 }
 
 # Extract current usage

--- a/.claude/statusline-context-tracker.sh
+++ b/.claude/statusline-context-tracker.sh
@@ -16,7 +16,7 @@
 # Context Calculation (v2.0 - Jan 2026):
 #   - Claude Code reserves ~45K tokens as buffer for auto-compact process
 #   - Auto-compact triggers at 80% of raw context (per v2.0.64+)
-#   - This script shows % of USABLE context (200K - 45K = 155K)
+#   - This script shows % of USABLE context (1M - 45K = 955K)
 #   - When display shows 100%, auto-compact is imminent
 #   - Raw % is logged for debugging but not displayed
 #
@@ -41,17 +41,17 @@ STATE_FILE="${LOG_DIR}/.context-state.json"
 MAX_LOG_SIZE=5242880  # 5MB rotation threshold
 
 # Thresholds (based on Claude Code v2.0.64+ behavior)
-# Auto-compact triggers at 80% of context window (160K for 200K window)
+# Auto-compact triggers at 80% of context window (800K for 1M window)
 # Claude reserves ~40-45K tokens as buffer for compaction process
-CONTEXT_WINDOW=200000
+CONTEXT_WINDOW=1000000
 AUTOCOMPACT_BUFFER=45000  # Reserved by Claude Code for compaction
 AUTOCOMPACT_TRIGGER=80    # % at which auto-compact triggers (v2.0.64+)
 
 # Display thresholds based on USABLE context (after buffer)
-# Usable = CONTEXT_WINDOW - AUTOCOMPACT_BUFFER = ~155K
-WARNING_THRESHOLD=60   # 60% of usable = ~93K (safe zone ending)
-CRITICAL_THRESHOLD=80  # 80% of usable = ~124K (compact soon)
-EMERGENCY_THRESHOLD=95 # 95% of usable = ~147K (auto-compact imminent)
+# Usable = CONTEXT_WINDOW - AUTOCOMPACT_BUFFER = ~955K
+WARNING_THRESHOLD=80   # 80% of usable = ~764K (safe zone ending)
+CRITICAL_THRESHOLD=93  # 93% of usable = ~888K (compact soon)
+EMERGENCY_THRESHOLD=97 # 97% of usable = ~926K (auto-compact imminent)
 
 # Ensure log directory exists
 mkdir -p "$LOG_DIR"
@@ -83,10 +83,10 @@ MODEL=$(echo "$INPUT" | jq -r '.model.display_name // "Unknown"')
 MODEL_ID=$(echo "$INPUT" | jq -r '.model.id // "unknown"')
 
 # Extract context window size (may vary by model)
-CONTEXT_SIZE=$(echo "$INPUT" | jq -r '.context_window.context_window_size // 200000')
+CONTEXT_SIZE=$(echo "$INPUT" | jq -r '.context_window.context_window_size // 1000000')
 # Validate CONTEXT_SIZE is a positive number
 if ! [[ "$CONTEXT_SIZE" =~ ^[0-9]+$ ]] || [ "$CONTEXT_SIZE" -eq 0 ]; then
-    CONTEXT_SIZE=200000
+    CONTEXT_SIZE=1000000
 fi
 
 # Extract current_usage (the accurate, server-authoritative data)

--- a/.claude/statusline.cjs
+++ b/.claude/statusline.cjs
@@ -26,9 +26,9 @@ const { execSync } = require('child_process');
 const LOG_DIR = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.claude/logs';
 const STATE_FILE = path.join(LOG_DIR, '.context-state.json');
 const AUTOCOMPACT_PCT = 80;
-const WARNING_THRESHOLD = 60;
-const CRITICAL_THRESHOLD = 90;
-const EMERGENCY_THRESHOLD = 95;
+const WARNING_THRESHOLD = 80;
+const CRITICAL_THRESHOLD = 93;
+const EMERGENCY_THRESHOLD = 97;
 
 // ANSI escape codes
 const ESC = '\x1b';
@@ -66,7 +66,7 @@ if (!data) {
 
 // Extract fields
 const model = (data.model && data.model.display_name) || 'Unknown';
-const contextSize = (data.context_window && data.context_window.context_window_size) || 200000;
+const contextSize = (data.context_window && data.context_window.context_window_size) || 1000000;
 const currentUsage = (data.context_window && data.context_window.current_usage) || {};
 const inputTokens = currentUsage.input_tokens || 0;
 const outputTokens = currentUsage.output_tokens || 0;

--- a/lib/context/context-monitor.js
+++ b/lib/context/context-monitor.js
@@ -37,9 +37,9 @@ class ContextMonitor {
     }
 
     // Thresholds (tokens)
-    this.WARNING_THRESHOLD = 150000;    // 75% of 200K
-    this.CRITICAL_THRESHOLD = 170000;   // 85% of 200K
-    this.EMERGENCY_THRESHOLD = 190000;  // 95% of 200K
+    this.WARNING_THRESHOLD = 800000;    // 80% of 1M
+    this.CRITICAL_THRESHOLD = 930000;   // 93% of 1M
+    this.EMERGENCY_THRESHOLD = 970000;  // 97% of 1M
 
     // Base context (from CLAUDE.md imports)
     this.BASE_CONTEXT_TOKENS = 56000;
@@ -123,7 +123,7 @@ class ContextMonitor {
     const conversationTokens = this.estimateTokens(conversationContent);
     const totalEstimated = this.BASE_CONTEXT_TOKENS + conversationTokens;
 
-    const percentUsed = (totalEstimated / 200000) * 100;
+    const percentUsed = (totalEstimated / 1000000) * 100;
 
     let status, recommendation;
 
@@ -147,7 +147,7 @@ class ContextMonitor {
       conversationTokens,
       baseContextTokens: this.BASE_CONTEXT_TOKENS,
       percentUsed: percentUsed.toFixed(1),
-      tokensRemaining: 200000 - totalEstimated,
+      tokensRemaining: 1000000 - totalEstimated,
       recommendation,
       method: this.useAccurateCount ? 'tiktoken' : 'estimated'
     };

--- a/scripts/context-monitor.js
+++ b/scripts/context-monitor.js
@@ -17,11 +17,11 @@ const __dirname = dirname(__filename);
 class ContextMonitor {
   constructor() {
     this.config = {
-      totalTokens: 200000,
+      totalTokens: 1000000,
       safetyMargin: 20000,
-      usableTokens: 180000,
-      warningThreshold: 0.7,  // 70%
-      criticalThreshold: 0.9, // 90%
+      usableTokens: 980000,
+      warningThreshold: 0.85,  // 85%
+      criticalThreshold: 0.95, // 95%
       
       allocation: {
         systemPrompt: 5000,

--- a/templates/claude-md/CLAUDE.md
+++ b/templates/claude-md/CLAUDE.md
@@ -66,9 +66,9 @@ Automatic triggers:
 
 ## Token Budget Allocation
 ```yaml
-total_available: 200000
+total_available: 1000000
 safety_margin: 20000
-usable_context: 180000
+usable_context: 980000
 
 allocation:
   system_prompt: 5000


### PR DESCRIPTION
## Summary
- Updated all context window defaults from 200,000 to 1,000,000 tokens across statusline scripts, context monitors, protocol config, and CLAUDE.md template
- Raised alert thresholds to avoid premature warnings with the 5x larger window: WARNING 60%→80%, CRITICAL 80-90%→93%, EMERGENCY 95%→97%
- Updated 7 files: statusline.cjs, statusline-context-tracker.sh/.ps1, context-monitor.js (lib + scripts), protocol-config.md, CLAUDE.md template

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Verify statusline displays correctly with new fallback values
- [ ] Verify context monitor thresholds fire at appropriate levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)