### PR TITLE
fix: null safety in chairman-report posterior access

### DIFF
--- a/lib/eva/experiments/chairman-report.js
+++ b/lib/eva/experiments/chairman-report.js
@@ -87,11 +87,13 @@ function buildExecutiveSummary(analysis, experimentName) {
 function buildVariantPerformance(analysis) {
   const variants = [];
   for (const [key, data] of Object.entries(analysis.per_variant || {})) {
+    const posterior = data.posterior || { alpha: 0, beta: 0 };
+    const posteriorSum = posterior.alpha + posterior.beta;
     variants.push({
       name: key,
       samples: data.count,
-      mean_score: round2(data.mean_score),
-      success_rate: round2(data.posterior.alpha / (data.posterior.alpha + data.posterior.beta) * 100),
+      mean_score: round2(data.mean_score ?? 0),
+      success_rate: round2(posteriorSum > 0 ? (posterior.alpha / posteriorSum) * 100 : 0),
       credible_interval: data.credible_interval
         ? {
             lower: round4(data.credible_interval.lower),
@@ -270,9 +272,11 @@ function buildGateSurvivalSection(analysis, gateSurvivalData) {
   // Overall survival rates from posteriors
   const overallSurvival = {};
   for (const [key, data] of Object.entries(analysis.per_variant || {})) {
+    const posterior = data.posterior || { alpha: 0, beta: 0 };
+    const posteriorSum = posterior.alpha + posterior.beta;
     overallSurvival[key] = {
       samples: data.count,
-      survival_rate: round2(data.posterior.alpha / (data.posterior.alpha + data.posterior.beta) * 100),
+      survival_rate: round2(posteriorSum > 0 ? (posterior.alpha / posteriorSum) * 100 : 0),
     };
   }
 
@@ -319,7 +323,7 @@ function formatReport(sections) {
   lines.push('');
 
   for (const section of sections) {
-    lines.push(`── ${section.title} ${'─'.repeat(Math.max(0, 50 - section.title.length))}`)
+    lines.push(`── ${section.title} ${'─'.repeat(Math.max(0, 50 - section.title.length))}`);
     lines.push('');
     lines.push(formatContent(section.content, 3));
     lines.push('');
@@ -356,5 +360,5 @@ function formatContent(obj, indent = 0) {
   return lines.join('\n');
 }
 
-function round2(n) { return Math.round(n * 100) / 100; }
-function round4(n) { return Math.round(n * 10000) / 10000; }
+function round2(n) { return Number.isFinite(n) ? Math.round(n * 100) / 100 : 0; }
+function round4(n) { return Number.isFinite(n) ? Math.round(n * 10000) / 10000 : 0; }


### PR DESCRIPTION
## Summary
- Guard `data.posterior` access with fallback to `{alpha: 0, beta: 0}` preventing TypeError when posterior is undefined
- Add divide-by-zero protection when `posteriorSum` is 0
- Make `round2`/`round4` return `0` for non-finite inputs (NaN, undefined) instead of propagating NaN
- Fix missing semicolon in `formatReport`

## Test plan
- [x] All 14 existing chairman-report tests pass
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)