### PR TITLE
feat: resolve auto-proceed/context-compact nudge conflict

### DIFF
--- a/.claude/agents/rca-agent.partial
+++ b/.claude/agents/rca-agent.partial
@@ -394,6 +394,26 @@ Issue Detected -> 5-Whys Analysis -> Root Cause Identified
 
 ---
 
+## SD Creation from CAPA Recommendations (NC-002 Compliance)
+
+When RCA analysis determines that corrective or preventive action requires creating a Strategic Directive:
+
+**MANDATORY: Use `node scripts/leo-create-sd.js` per NC-002.**
+
+NEVER recommend or execute direct database inserts into `strategic_directives_v2`. The `leo-create-sd.js` pipeline performs 23 governance validations including blocking guardrail checks, vision scoring, OKR mapping, and audit trail tracking. Direct inserts bypass all of these.
+
+**CAPA template when recommending SD creation:**
+```
+### Corrective Action: Create SD
+- **Create via**: `node scripts/leo-create-sd.js --title "..." --type "infrastructure|feature|fix"`
+- **Justification**: [Why this requires formal SD vs quick fix]
+- **NC-002**: SD creation MUST use leo-create-sd.js — never direct DB insert
+```
+
+Similarly, PRD creation MUST use `node scripts/add-prd-to-database.js`, not direct inserts.
+
+---
+
 ## Invocation Commands
 
 ### Direct Execution

--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -570,8 +570,8 @@ node scripts/modules/sd-key-generator.js LEO <type> "<title>"
 
   **MANDATORY**: Before running `--from-plan`, you MUST read protocol files:
   ```
-  Read tool: CLAUDE_CORE_DIGEST.md    (SD types, validation requirements, sub-agent triggers)
-  Read tool: CLAUDE_LEAD_DIGEST.md    (SD creation process, field requirements, handoff gates)
+  Read tool: CLAUDE_CORE.md    (SD types, validation requirements, sub-agent triggers)
+  Read tool: CLAUDE_LEAD.md    (SD creation process, field requirements, handoff gates)
   ```
 
   Then run the creation script:
@@ -619,11 +619,11 @@ Resume work on the current working SD.
 
 2. **If SD found (is_working_on = true and progress < 100):**
    - Display the SD info from the script output
-   - **ALWAYS read `CLAUDE_CORE_DIGEST.md` first** (sub-agent prompt quality standard, SD type requirements)
+   - **ALWAYS read `CLAUDE_CORE.md` first** (sub-agent prompt quality standard, SD type requirements)
    - Then read the phase-specific context file based on `current_phase`:
-     - LEAD phases (LEAD_APPROVAL, LEAD_FINAL_APPROVAL) → Read `CLAUDE_LEAD_DIGEST.md`
-     - PLAN phases (PLAN_*, PRD_*) → Read `CLAUDE_PLAN_DIGEST.md`
-     - EXEC phases (EXEC_*, IMPLEMENTATION_*) → Read `CLAUDE_EXEC_DIGEST.md`
+     - LEAD phases (LEAD_APPROVAL, LEAD_FINAL_APPROVAL) → Read `CLAUDE_LEAD.md`
+     - PLAN phases (PLAN_*, PRD_*) → Read `CLAUDE_PLAN.md`
+     - EXEC phases (EXEC_*, IMPLEMENTATION_*) → Read `CLAUDE_EXEC.md`
    - Load BOTH context files using the Read tool
    - Show recommended next action based on phase:
      - LEAD phases: "Continue LEAD approval workflow"
@@ -959,25 +959,25 @@ This is the RECOMMENDED way to begin work on an SD. It combines claiming + conte
 
 5. **MANDATORY: Read protocol files based on phase:**
 
-   **Step 1: ALWAYS read CLAUDE_CORE_DIGEST.md first (contains sub-agent prompt quality standard, SD type requirements, gate thresholds):**
+   **Step 1: ALWAYS read CLAUDE_CORE.md first (contains sub-agent prompt quality standard, SD type requirements, gate thresholds):**
    ```
-   Read tool: CLAUDE_CORE_DIGEST.md
+   Read tool: CLAUDE_CORE.md
    ```
 
    **Step 2: Read phase-specific digest file:**
 
    | Phase | Files to Read (use Read tool) |
    |-------|-------------------------------|
-   | LEAD | `CLAUDE_LEAD_DIGEST.md` |
-   | PLAN | `CLAUDE_PLAN_DIGEST.md` |
-   | EXEC | `CLAUDE_EXEC_DIGEST.md` |
+   | LEAD | `CLAUDE_LEAD.md` |
+   | PLAN | `CLAUDE_PLAN.md` |
+   | EXEC | `CLAUDE_EXEC.md` |
 
    **Execute BOTH file reads immediately** - do not just mention them, actually use the Read tool:
    ```
-   Read tool: CLAUDE_CORE_DIGEST.md   (ALWAYS - contains Five-Point Brief, model routing, SD types)
-   Read tool: CLAUDE_LEAD_DIGEST.md   (if phase is LEAD)
-   Read tool: CLAUDE_PLAN_DIGEST.md   (if phase is PLAN)
-   Read tool: CLAUDE_EXEC_DIGEST.md   (if phase is EXEC)
+   Read tool: CLAUDE_CORE.md   (ALWAYS - contains Five-Point Brief, model routing, SD types)
+   Read tool: CLAUDE_LEAD.md   (if phase is LEAD)
+   Read tool: CLAUDE_PLAN.md   (if phase is PLAN)
+   Read tool: CLAUDE_EXEC.md   (if phase is EXEC)
    ```
 
 6. **Check for orchestrator/child status:**
@@ -1276,10 +1276,10 @@ node scripts/child-sd-preflight.js SD-XXX-001
 
 **CRITICAL**: Before starting work on ANY SD (new, existing, or child), you MUST load the required context files in this order:
 
-#### Step 1: ALWAYS Read CLAUDE.md and CLAUDE_CORE_DIGEST.md First
+#### Step 1: ALWAYS Read CLAUDE.md and CLAUDE_CORE.md First
 ```
 Read tool: CLAUDE.md
-Read tool: CLAUDE_CORE_DIGEST.md
+Read tool: CLAUDE_CORE.md
 ```
 
 **CLAUDE.md provides**:
@@ -1288,7 +1288,7 @@ Read tool: CLAUDE_CORE_DIGEST.md
 - AUTO-PROCEED mode configuration
 - Session initialization guidance
 
-**CLAUDE_CORE_DIGEST.md provides**:
+**CLAUDE_CORE.md provides**:
 - SD type definitions and workflow requirements
 - PRD requirements, handoff counts, gate thresholds
 - Sub-agent configuration and model routing
@@ -1301,9 +1301,9 @@ Based on the SD's `current_phase`, load the appropriate digest file:
 
 | Phase | File to Load |
 |-------|--------------|
-| LEAD_APPROVAL, LEAD_FINAL_APPROVAL | CLAUDE_LEAD_DIGEST.md |
-| PLAN_*, PRD_* | CLAUDE_PLAN_DIGEST.md |
-| EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC_DIGEST.md |
+| LEAD_APPROVAL, LEAD_FINAL_APPROVAL | CLAUDE_LEAD.md |
+| PLAN_*, PRD_* | CLAUDE_PLAN.md |
+| EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
 
 #### Why This Matters
 Without loading CLAUDE.md and CLAUDE_CORE.md:
@@ -1360,7 +1360,7 @@ Child SDs with incomplete dependencies show as BLOCKED.
    - Skill intent detection patterns
    - AUTO-PROCEED mode behavior
 
-2. **CLAUDE_CORE_DIGEST.md** - Core protocol guidance, SD types, workflow requirements
+2. **CLAUDE_CORE.md** - Core protocol guidance, SD types, workflow requirements
    - Contains SD type definitions and their mandatory requirements
    - Specifies PRD requirements, handoff counts, and gate thresholds per SD type
    - Defines the LEAD→PLAN→EXEC workflow phases
@@ -1375,7 +1375,7 @@ Child SDs with incomplete dependencies show as BLOCKED.
 #### SD Creation Checklist
 Before creating any SD, ensure you:
 - [ ] Read CLAUDE.md for sub-agent trigger keywords
-- [ ] Read CLAUDE_CORE_DIGEST.md for SD type requirements
+- [ ] Read CLAUDE_CORE.md for SD type requirements
 - [ ] Read field reference for required fields and formats
 - [ ] Use proper ID format: `SD-{CATEGORY}-{NUMBER}` (e.g., SD-FEATURE-001)
 - [ ] Set appropriate `sd_type` based on scope and requirements

--- a/database/migrations/20260314_artifact_creation_source_advisory.sql
+++ b/database/migrations/20260314_artifact_creation_source_advisory.sql
@@ -1,0 +1,285 @@
+-- Migration: Advisory triggers for artifact creation source validation
+-- Purpose: Log warnings to audit_log when PRDs, Vision Docs, or Architecture Plans
+--          are created without proper provenance (extends NC-002 pattern from SD trigger)
+-- Advisory only: NEVER blocks INSERT, only logs for observability
+--
+-- Reference: 20260314_sd_creation_source_advisory.sql (same pattern)
+--
+-- Rollback:
+--   DROP TRIGGER IF EXISTS trg_prd_creation_source_advisory ON product_requirements_v2;
+--   DROP FUNCTION IF EXISTS check_prd_creation_source();
+--   DROP TRIGGER IF EXISTS trg_vision_creation_source_advisory ON eva_vision_documents;
+--   DROP FUNCTION IF EXISTS check_vision_creation_source();
+--   DROP TRIGGER IF EXISTS trg_arch_creation_source_advisory ON eva_architecture_plans;
+--   DROP FUNCTION IF EXISTS check_arch_creation_source();
+
+-- ============================================================================
+-- 1. PRD Creation Source Advisory (product_requirements_v2)
+-- ============================================================================
+-- Schema notes:
+--   - Has metadata JSONB column -> check metadata->>'created_via'
+--   - Has created_by VARCHAR column (fallback context)
+--   - Has directive_id VARCHAR (SD reference, logged for traceability)
+
+CREATE OR REPLACE FUNCTION check_prd_creation_source()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_created_via TEXT;
+  v_valid_sources TEXT[] := ARRAY[
+    'add-prd-to-database',
+    'unified-handoff-system',
+    'ADMIN_OVERRIDE'
+  ];
+  v_entity_id TEXT;
+  v_audit_log_exists BOOLEAN;
+BEGIN
+  -- Extract created_via from metadata JSONB (safely handle NULL metadata)
+  v_created_via := COALESCE(NEW.metadata->>'created_via', 'MISSING');
+  v_entity_id := COALESCE(NEW.id::text, 'UNKNOWN');
+
+  -- Only fire advisory logic if source is missing or not in valid list
+  IF v_created_via = 'MISSING' OR NOT (v_created_via = ANY(v_valid_sources)) THEN
+
+    -- Check if audit_log table exists (defensive: avoid breaking if table is dropped)
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'audit_log'
+    ) INTO v_audit_log_exists;
+
+    IF v_audit_log_exists THEN
+      -- Log advisory warning to audit_log
+      INSERT INTO audit_log (
+        event_type,
+        entity_type,
+        entity_id,
+        new_value,
+        metadata,
+        severity,
+        created_by
+      ) VALUES (
+        'prd_creation_source_missing',
+        'product_requirement',
+        v_entity_id,
+        jsonb_build_object(
+          'prd_id', v_entity_id,
+          'directive_id', COALESCE(NEW.directive_id, 'UNKNOWN'),
+          'created_via', v_created_via,
+          'created_by', COALESCE(NEW.created_by, 'UNKNOWN'),
+          'metadata_snapshot', NEW.metadata
+        ),
+        jsonb_build_object(
+          'nc_code', 'NC-002',
+          'description', 'PRD created without valid provenance. Expected creation via add-prd-to-database.js or other approved pipeline.',
+          'valid_sources', to_jsonb(v_valid_sources),
+          'detected_source', v_created_via,
+          'trigger', 'trg_prd_creation_source_advisory'
+        ),
+        'warning',
+        'trg_prd_creation_source_advisory'
+      );
+    ELSE
+      -- Fallback: use RAISE NOTICE if audit_log does not exist
+      RAISE NOTICE '[NC-002 ADVISORY] PRD "%" created with unrecognized source: "%". Expected one of: add-prd-to-database, unified-handoff-system, ADMIN_OVERRIDE',
+        v_entity_id, v_created_via;
+    END IF;
+
+  END IF;
+
+  -- ALWAYS return NEW: this trigger must NEVER block an insert
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION check_prd_creation_source() IS
+  'Advisory trigger function for NC-002: logs warning when PRD is created without valid provenance (metadata->created_via). Never blocks inserts.';
+
+DROP TRIGGER IF EXISTS trg_prd_creation_source_advisory ON product_requirements_v2;
+
+CREATE TRIGGER trg_prd_creation_source_advisory
+  AFTER INSERT ON product_requirements_v2
+  FOR EACH ROW
+  EXECUTE FUNCTION check_prd_creation_source();
+
+COMMENT ON TRIGGER trg_prd_creation_source_advisory ON product_requirements_v2 IS
+  'NC-002 Advisory: Logs warning to audit_log when PRD is created without valid created_via metadata. Does NOT block inserts.';
+
+
+-- ============================================================================
+-- 2. Vision Document Creation Source Advisory (eva_vision_documents)
+-- ============================================================================
+-- Schema notes:
+--   - NO metadata JSONB column -> check created_by TEXT column instead
+--   - Has vision_key VARCHAR (human-readable key)
+--   - created_by stores the pipeline name (e.g., 'brainstorm-to-vision')
+
+CREATE OR REPLACE FUNCTION check_vision_creation_source()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_created_by TEXT;
+  v_valid_sources TEXT[] := ARRAY[
+    'brainstorm-to-vision',
+    'seed-l1-vision',
+    'vision-scorer',
+    'ADMIN_OVERRIDE'
+  ];
+  v_entity_id TEXT;
+  v_audit_log_exists BOOLEAN;
+BEGIN
+  -- Extract created_by (the provenance indicator for this table)
+  v_created_by := COALESCE(NEW.created_by, 'MISSING');
+  v_entity_id := COALESCE(NEW.vision_key, NEW.id::text, 'UNKNOWN');
+
+  -- Only fire advisory logic if source is missing or not in valid list
+  IF v_created_by = 'MISSING' OR NOT (v_created_by = ANY(v_valid_sources)) THEN
+
+    -- Check if audit_log table exists (defensive: avoid breaking if table is dropped)
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'audit_log'
+    ) INTO v_audit_log_exists;
+
+    IF v_audit_log_exists THEN
+      -- Log advisory warning to audit_log
+      INSERT INTO audit_log (
+        event_type,
+        entity_type,
+        entity_id,
+        new_value,
+        metadata,
+        severity,
+        created_by
+      ) VALUES (
+        'vision_creation_source_missing',
+        'vision_document',
+        v_entity_id,
+        jsonb_build_object(
+          'vision_key', COALESCE(NEW.vision_key, 'UNKNOWN'),
+          'created_by', v_created_by,
+          'level', COALESCE(NEW.level, 'UNKNOWN'),
+          'status', COALESCE(NEW.status, 'UNKNOWN')
+        ),
+        jsonb_build_object(
+          'nc_code', 'NC-002',
+          'description', 'Vision document created without valid provenance. Expected creation via brainstorm-to-vision, seed-l1-vision, or other approved pipeline.',
+          'valid_sources', to_jsonb(v_valid_sources),
+          'detected_source', v_created_by,
+          'trigger', 'trg_vision_creation_source_advisory'
+        ),
+        'warning',
+        'trg_vision_creation_source_advisory'
+      );
+    ELSE
+      -- Fallback: use RAISE NOTICE if audit_log does not exist
+      RAISE NOTICE '[NC-002 ADVISORY] Vision document "%" created with unrecognized source: "%". Expected one of: brainstorm-to-vision, seed-l1-vision, vision-scorer, ADMIN_OVERRIDE',
+        v_entity_id, v_created_by;
+    END IF;
+
+  END IF;
+
+  -- ALWAYS return NEW: this trigger must NEVER block an insert
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION check_vision_creation_source() IS
+  'Advisory trigger function for NC-002: logs warning when vision document is created without valid provenance (created_by). Never blocks inserts.';
+
+DROP TRIGGER IF EXISTS trg_vision_creation_source_advisory ON eva_vision_documents;
+
+CREATE TRIGGER trg_vision_creation_source_advisory
+  AFTER INSERT ON eva_vision_documents
+  FOR EACH ROW
+  EXECUTE FUNCTION check_vision_creation_source();
+
+COMMENT ON TRIGGER trg_vision_creation_source_advisory ON eva_vision_documents IS
+  'NC-002 Advisory: Logs warning to audit_log when vision document is created without valid created_by provenance. Does NOT block inserts.';
+
+
+-- ============================================================================
+-- 3. Architecture Plan Creation Source Advisory (eva_architecture_plans)
+-- ============================================================================
+-- Schema notes:
+--   - NO metadata JSONB column -> check created_by TEXT column instead
+--   - Has plan_key VARCHAR (human-readable key)
+--   - created_by stores the pipeline name (e.g., 'vision-to-architecture')
+
+CREATE OR REPLACE FUNCTION check_arch_creation_source()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_created_by TEXT;
+  v_valid_sources TEXT[] := ARRAY[
+    'brainstorm-to-vision',
+    'vision-to-architecture',
+    'ADMIN_OVERRIDE'
+  ];
+  v_entity_id TEXT;
+  v_audit_log_exists BOOLEAN;
+BEGIN
+  -- Extract created_by (the provenance indicator for this table)
+  v_created_by := COALESCE(NEW.created_by, 'MISSING');
+  v_entity_id := COALESCE(NEW.plan_key, NEW.id::text, 'UNKNOWN');
+
+  -- Only fire advisory logic if source is missing or not in valid list
+  IF v_created_by = 'MISSING' OR NOT (v_created_by = ANY(v_valid_sources)) THEN
+
+    -- Check if audit_log table exists (defensive: avoid breaking if table is dropped)
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'audit_log'
+    ) INTO v_audit_log_exists;
+
+    IF v_audit_log_exists THEN
+      -- Log advisory warning to audit_log
+      INSERT INTO audit_log (
+        event_type,
+        entity_type,
+        entity_id,
+        new_value,
+        metadata,
+        severity,
+        created_by
+      ) VALUES (
+        'arch_creation_source_missing',
+        'architecture_plan',
+        v_entity_id,
+        jsonb_build_object(
+          'plan_key', COALESCE(NEW.plan_key, 'UNKNOWN'),
+          'created_by', v_created_by,
+          'vision_id', COALESCE(NEW.vision_id::text, 'UNKNOWN'),
+          'status', COALESCE(NEW.status, 'UNKNOWN')
+        ),
+        jsonb_build_object(
+          'nc_code', 'NC-002',
+          'description', 'Architecture plan created without valid provenance. Expected creation via vision-to-architecture or other approved pipeline.',
+          'valid_sources', to_jsonb(v_valid_sources),
+          'detected_source', v_created_by,
+          'trigger', 'trg_arch_creation_source_advisory'
+        ),
+        'warning',
+        'trg_arch_creation_source_advisory'
+      );
+    ELSE
+      -- Fallback: use RAISE NOTICE if audit_log does not exist
+      RAISE NOTICE '[NC-002 ADVISORY] Architecture plan "%" created with unrecognized source: "%". Expected one of: brainstorm-to-vision, vision-to-architecture, ADMIN_OVERRIDE',
+        v_entity_id, v_created_by;
+    END IF;
+
+  END IF;
+
+  -- ALWAYS return NEW: this trigger must NEVER block an insert
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION check_arch_creation_source() IS
+  'Advisory trigger function for NC-002: logs warning when architecture plan is created without valid provenance (created_by). Never blocks inserts.';
+
+DROP TRIGGER IF EXISTS trg_arch_creation_source_advisory ON eva_architecture_plans;
+
+CREATE TRIGGER trg_arch_creation_source_advisory
+  AFTER INSERT ON eva_architecture_plans
+  FOR EACH ROW
+  EXECUTE FUNCTION check_arch_creation_source();
+
+COMMENT ON TRIGGER trg_arch_creation_source_advisory ON eva_architecture_plans IS
+  'NC-002 Advisory: Logs warning to audit_log when architecture plan is created without valid created_by provenance. Does NOT block inserts.';

--- a/database/migrations/20260314_sd_creation_source_advisory.sql
+++ b/database/migrations/20260314_sd_creation_source_advisory.sql
@@ -1,0 +1,102 @@
+-- Migration: Advisory trigger for SD creation source validation
+-- Purpose: Log a warning to audit_log when an SD is created without proper provenance
+-- Context: RCA finding NC-002 - SDs created via direct DB insert bypass leo-create-sd.js governance
+-- Advisory only: NEVER blocks INSERT, only logs for observability
+--
+-- Valid creation sources:
+--   - 'leo-create-sd'              (standard governance pipeline)
+--   - 'unified-handoff-system'     (phase handoff child creation)
+--   - 'orchestrator-child-auto'    (orchestrator auto-child creation)
+--   - 'ADMIN_OVERRIDE'             (explicit admin bypass)
+--
+-- Rollback:
+--   DROP TRIGGER IF EXISTS trg_sd_creation_source_advisory ON strategic_directives_v2;
+--   DROP FUNCTION IF EXISTS check_sd_creation_source();
+
+-- Step 1: Create the advisory trigger function
+CREATE OR REPLACE FUNCTION check_sd_creation_source()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_created_via TEXT;
+  v_valid_sources TEXT[] := ARRAY[
+    'leo-create-sd',
+    'unified-handoff-system',
+    'orchestrator-child-auto',
+    'ADMIN_OVERRIDE'
+  ];
+  v_sd_key TEXT;
+  v_audit_log_exists BOOLEAN;
+BEGIN
+  -- Extract created_via from metadata JSONB (safely handle NULL metadata)
+  v_created_via := COALESCE(NEW.metadata->>'created_via', 'MISSING');
+  v_sd_key := COALESCE(NEW.sd_key, NEW.id, 'UNKNOWN');
+
+  -- Only fire advisory logic if source is missing or not in valid list
+  IF v_created_via = 'MISSING' OR NOT (v_created_via = ANY(v_valid_sources)) THEN
+
+    -- Check if audit_log table exists (defensive: avoid breaking if table is dropped)
+    SELECT EXISTS (
+      SELECT 1 FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'audit_log'
+    ) INTO v_audit_log_exists;
+
+    IF v_audit_log_exists THEN
+      -- Log advisory warning to audit_log
+      INSERT INTO audit_log (
+        event_type,
+        entity_type,
+        entity_id,
+        new_value,
+        metadata,
+        severity,
+        created_by
+      ) VALUES (
+        'sd_creation_source_missing',
+        'strategic_directive',
+        v_sd_key,
+        jsonb_build_object(
+          'sd_key', v_sd_key,
+          'created_via', v_created_via,
+          'metadata_snapshot', NEW.metadata
+        ),
+        jsonb_build_object(
+          'nc_code', 'NC-002',
+          'description', 'SD created without valid provenance. Expected creation via leo-create-sd.js or other approved pipeline.',
+          'valid_sources', to_jsonb(v_valid_sources),
+          'detected_source', v_created_via,
+          'trigger', 'trg_sd_creation_source_advisory'
+        ),
+        'warning',
+        'trg_sd_creation_source_advisory'
+      );
+    ELSE
+      -- Fallback: use RAISE NOTICE if audit_log does not exist
+      RAISE NOTICE '[NC-002 ADVISORY] SD "%" created with unrecognized source: "%". Expected one of: leo-create-sd, unified-handoff-system, orchestrator-child-auto, ADMIN_OVERRIDE',
+        v_sd_key, v_created_via;
+    END IF;
+
+  END IF;
+
+  -- ALWAYS return NEW: this trigger must NEVER block an insert
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Step 2: Add comment documenting the function
+COMMENT ON FUNCTION check_sd_creation_source() IS
+  'Advisory trigger function for NC-002: logs warning when SD is created without valid provenance (created_via metadata). Never blocks inserts.';
+
+-- Step 3: Create the trigger (AFTER INSERT - advisory, does not modify the row)
+-- Using AFTER INSERT because this is observational/logging only.
+-- AFTER triggers cannot block the INSERT and run after the row is committed,
+-- which is the correct semantic for advisory logging.
+DROP TRIGGER IF EXISTS trg_sd_creation_source_advisory ON strategic_directives_v2;
+
+CREATE TRIGGER trg_sd_creation_source_advisory
+  AFTER INSERT ON strategic_directives_v2
+  FOR EACH ROW
+  EXECUTE FUNCTION check_sd_creation_source();
+
+-- Step 4: Add comment documenting the trigger
+COMMENT ON TRIGGER trg_sd_creation_source_advisory ON strategic_directives_v2 IS
+  'NC-002 Advisory: Logs warning to audit_log when SD is created without valid created_via metadata. Does NOT block inserts.';

--- a/lib/tasks/templates/tracks/fast/lead.json
+++ b/lib/tasks/templates/tracks/fast/lead.json
@@ -7,7 +7,7 @@
       "id_template": "{{SD_ID}}-LEAD-INIT",
       "subject": "LEAD Phase Initialized: {{SD_TITLE}}",
       "activeForm": "Initializing LEAD phase",
-      "description": "Load CLAUDE_LEAD_DIGEST.md identity and SD context.",
+      "description": "Load CLAUDE_LEAD.md identity and SD context.",
       "blockedBy": [],
       "metadata": {
         "category": "init",

--- a/lib/tasks/templates/tracks/full/lead.json
+++ b/lib/tasks/templates/tracks/full/lead.json
@@ -7,7 +7,7 @@
       "id_template": "{{SD_ID}}-LEAD-INIT",
       "subject": "LEAD Phase Initialized: {{SD_TITLE}}",
       "activeForm": "Initializing LEAD phase",
-      "description": "Load CLAUDE_LEAD_DIGEST.md identity and SD context for strategic review.",
+      "description": "Load CLAUDE_LEAD.md identity and SD context for strategic review.",
       "blockedBy": [],
       "metadata": {
         "category": "init",

--- a/lib/tasks/templates/tracks/standard/lead.json
+++ b/lib/tasks/templates/tracks/standard/lead.json
@@ -7,7 +7,7 @@
       "id_template": "{{SD_ID}}-LEAD-INIT",
       "subject": "LEAD Phase Initialized: {{SD_TITLE}}",
       "activeForm": "Initializing LEAD phase",
-      "description": "Load CLAUDE_LEAD_DIGEST.md identity and SD context.",
+      "description": "Load CLAUDE_LEAD.md identity and SD context.",
       "blockedBy": [],
       "metadata": {
         "category": "init",

--- a/scripts/child-sd-preflight.js
+++ b/scripts/child-sd-preflight.js
@@ -300,8 +300,8 @@ class ChildSDPreflightValidator {
       console.log(`${colors.dim}   Ready to work on ${displayId}.${colors.reset}`);
       console.log(`\n${colors.yellow}${colors.bold}⚠️  CONTEXT LOADING REMINDER:${colors.reset}`);
       console.log(`${colors.yellow}   Before starting work, you MUST read:${colors.reset}`);
-      console.log(`${colors.yellow}   1. CLAUDE_CORE_DIGEST.md (SD type requirements, gates, thresholds)${colors.reset}`);
-      console.log(`${colors.yellow}   2. Phase-specific digest file (CLAUDE_LEAD_DIGEST.md, CLAUDE_PLAN_DIGEST.md, or CLAUDE_EXEC_DIGEST.md)${colors.reset}`);
+      console.log(`${colors.yellow}   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)${colors.reset}`);
+      console.log(`${colors.yellow}   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)${colors.reset}`);
       console.log(`\n${colors.cyan}${'═'.repeat(59)}${colors.reset}\n`);
       return { status: 'PASS', reason: 'No dependencies', parent: this.parent, sd: this.sd };
     }
@@ -399,8 +399,8 @@ class ChildSDPreflightValidator {
     console.log(`${colors.green}   All dependencies satisfied. Ready to work on ${displayId}.${colors.reset}`);
     console.log(`\n${colors.yellow}${colors.bold}⚠️  CONTEXT LOADING REMINDER:${colors.reset}`);
     console.log(`${colors.yellow}   Before starting work, you MUST read:${colors.reset}`);
-    console.log(`${colors.yellow}   1. CLAUDE_CORE_DIGEST.md (SD type requirements, gates, thresholds)${colors.reset}`);
-    console.log(`${colors.yellow}   2. Phase-specific digest file (CLAUDE_LEAD_DIGEST.md, CLAUDE_PLAN_DIGEST.md, or CLAUDE_EXEC_DIGEST.md)${colors.reset}`);
+    console.log(`${colors.yellow}   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)${colors.reset}`);
+    console.log(`${colors.yellow}   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)${colors.reset}`);
     console.log(`\n${colors.cyan}${'═'.repeat(59)}${colors.reset}\n`);
 
     return {

--- a/scripts/generate-session-prologue.js
+++ b/scripts/generate-session-prologue.js
@@ -57,7 +57,7 @@ async function generateSessionPrologue() {
 1. Run \`npm run sd:next\` to see the SD queue
 2. If SD marked "CONTINUE" → Resume that SD
 3. If no active SD → Pick highest-ranked READY SD
-4. Load CLAUDE_LEAD_DIGEST.md for approval workflow
+4. Load CLAUDE_LEAD.md for approval workflow
 
 ---
 *Remind Claude: Follow database-first, keep PRs small, use sub-agents, create handoffs*`;

--- a/scripts/hooks/context-compact-nudge.js
+++ b/scripts/hooks/context-compact-nudge.js
@@ -218,7 +218,20 @@ function main() {
       const age = formatDuration(sessionAgeMinutes);
       const source = TIME_ONLY ? 'AUTO-PROCEED' : 'interactive';
 
-      if (level === 'CRITICAL') {
+      // Check if AUTO-PROCEED is active — downgrade CRITICAL to ADVISORY
+      // to avoid interrupting autonomous execution (SD-LEO-INFRA-AUTO-PROCEED-CONTEXT-001)
+      let isAutoProceed = false;
+      try {
+        const apStatePath = path.join(process.cwd(), '.claude', 'auto-proceed-state.json');
+        if (fs.existsSync(apStatePath)) {
+          const apState = JSON.parse(fs.readFileSync(apStatePath, 'utf8'));
+          isAutoProceed = apState.isActive === true;
+        }
+      } catch { /* fail-safe: default to non-auto-proceed (show CRITICAL) */ }
+
+      if (level === 'CRITICAL' && isAutoProceed) {
+        console.log(`[context-compact-nudge] ADVISORY (AUTO-PROCEED active): Session running ${age}. Context compaction recommended at next SD boundary.`);
+      } else if (level === 'CRITICAL') {
         console.log(`[context-compact-nudge] CRITICAL (${source}): Session running ${age}. Run /context-compact NOW to prevent API serialization errors.`);
       } else {
         console.log(`[context-compact-nudge] WARNING (${source}): Session running ${age}. Consider running /context-compact to reduce context size.`);

--- a/scripts/hooks/load-phase-context.cjs
+++ b/scripts/hooks/load-phase-context.cjs
@@ -171,12 +171,8 @@ function main() {
   const contextDocPath = getContextDocPath(toPhase);
 
   if (contextDocPath && fs.existsSync(contextDocPath)) {
-    const digestDoc = PHASE_DIGEST_DOCS[toPhase];
     console.log(`[load-phase-context] Context document: ${PHASE_CONTEXT_DOCS[toPhase]} (full)`);
     console.log(`[load-phase-context] INSTRUCTION: Read ${contextDocPath} for phase-specific guidance`);
-    if (digestDoc) {
-      console.log(`[load-phase-context] COMPACT FALLBACK: Use ${digestDoc} if context is constrained`);
-    }
   } else {
     console.warn(`[load-phase-context] Context document not found for phase: ${toPhase}`);
   }

--- a/scripts/modules/handoff/gates/core-protocol-gate.js
+++ b/scripts/modules/handoff/gates/core-protocol-gate.js
@@ -105,9 +105,8 @@ const CORE_PROTOCOL_REQUIREMENTS_DIGEST = {
  * @returns {Object} Requirements by trigger type
  */
 function getCoreProtocolRequirements() {
-  return getProtocolMode() === 'full'
-    ? CORE_PROTOCOL_REQUIREMENTS_FULL
-    : CORE_PROTOCOL_REQUIREMENTS_DIGEST;
+  // Always use FULL files — 1M context window makes digest mode unnecessary
+  return CORE_PROTOCOL_REQUIREMENTS_FULL;
 }
 
 // Legacy export for backward compatibility
@@ -136,9 +135,8 @@ const PHASE_PROTOCOL_FILES_DIGEST = {
  * @returns {Object} Phase to file mapping
  */
 function getPhaseProtocolFiles() {
-  return getProtocolMode() === 'full'
-    ? PHASE_PROTOCOL_FILES_FULL
-    : PHASE_PROTOCOL_FILES_DIGEST;
+  // Always use FULL files — 1M context window makes digest mode unnecessary
+  return PHASE_PROTOCOL_FILES_FULL;
 }
 
 // Legacy export
@@ -169,9 +167,8 @@ const HANDOFF_PHASE_FILES_DIGEST = {
  * @returns {Object} Handoff to file mapping
  */
 function getHandoffPhaseFiles() {
-  return getProtocolMode() === 'full'
-    ? HANDOFF_PHASE_FILES_FULL
-    : HANDOFF_PHASE_FILES_DIGEST;
+  // Always use FULL files — 1M context window makes digest mode unnecessary
+  return HANDOFF_PHASE_FILES_FULL;
 }
 
 // Legacy export

--- a/scripts/modules/handoff/gates/protocol-file-read-gate.js
+++ b/scripts/modules/handoff/gates/protocol-file-read-gate.js
@@ -65,9 +65,8 @@ const HANDOFF_FILE_REQUIREMENTS_DIGEST = {
  * @returns {Object} Requirements map
  */
 function getHandoffFileRequirements() {
-  return getProtocolMode() === 'full'
-    ? HANDOFF_FILE_REQUIREMENTS_FULL
-    : HANDOFF_FILE_REQUIREMENTS_DIGEST;
+  // Always use FULL files — 1M context window makes digest mode unnecessary
+  return HANDOFF_FILE_REQUIREMENTS_FULL;
 }
 
 // Legacy export for backward compatibility
@@ -433,7 +432,7 @@ export async function validateProtocolFileRead(handoffType, ctx = {}) {
     if (fullFileExists) {
       console.log(`   ⚠️  DIGEST file ${requiredFile} not found, but FULL file ${fullFileEquivalent} exists`);
       console.log('   ✅ CROSS-MODE FALLBACK: FULL file present - allowing handoff');
-      console.log(`   💡 Regenerate DIGEST files: node scripts/generate-claude-md-from-db.js`);
+      console.log('   💡 Regenerate DIGEST files: node scripts/generate-claude-md-from-db.js');
 
       markProtocolFileRead(requiredFile);
 

--- a/scripts/modules/sd-key-generator.js
+++ b/scripts/modules/sd-key-generator.js
@@ -52,7 +52,7 @@ function readSessionState() {
  */
 function isLeadFileRead() {
   const state = readSessionState();
-  return state.protocolFilesRead?.includes('CLAUDE_LEAD.md') || state.protocolFilesRead?.includes('CLAUDE_LEAD_DIGEST.md') || false;
+  return state.protocolFilesRead?.includes('CLAUDE_LEAD.md') || state.protocolFilesRead?.includes('CLAUDE_LEAD.md') || false;
 }
 
 /**
@@ -61,7 +61,7 @@ function isLeadFileRead() {
  */
 function isCoreFileRead() {
   const state = readSessionState();
-  return state.protocolFilesRead?.includes('CLAUDE_CORE.md') || state.protocolFilesRead?.includes('CLAUDE_CORE_DIGEST.md') || false;
+  return state.protocolFilesRead?.includes('CLAUDE_CORE.md') || state.protocolFilesRead?.includes('CLAUDE_CORE.md') || false;
 }
 
 /**
@@ -142,10 +142,10 @@ export function validateCoreFileRead() {
 │   • Required validation patterns                                           │
 │                                                                             │
 │ ACTION REQUIRED:                                                           │
-│   1. Read CLAUDE_CORE_DIGEST.md completely (no limit parameter)            │
+│   1. Read CLAUDE_CORE.md completely (no limit parameter)            │
 │   2. Then retry SD key generation                                          │
 │                                                                             │
-│ HINT: Use Read tool with file_path="CLAUDE_CORE_DIGEST.md" (no limit)      │
+│ HINT: Use Read tool with file_path="CLAUDE_CORE.md" (no limit)      │
 └─────────────────────────────────────────────────────────────────────────────┘
 `
     };
@@ -171,10 +171,10 @@ export function validateCoreFileRead() {
 │   • Protocol phase validation rules                                        │
 │                                                                             │
 │ ACTION REQUIRED:                                                           │
-│   1. Re-read CLAUDE_CORE_DIGEST.md completely (WITHOUT limit parameter)    │
+│   1. Re-read CLAUDE_CORE.md completely (WITHOUT limit parameter)    │
 │   2. Then retry SD key generation                                          │
 │                                                                             │
-│ HINT: Use Read tool with file_path="CLAUDE_CORE_DIGEST.md" (no limit)      │
+│ HINT: Use Read tool with file_path="CLAUDE_CORE.md" (no limit)      │
 └─────────────────────────────────────────────────────────────────────────────┘
 `
     };
@@ -223,10 +223,10 @@ export function validateLeadFileRead() {
 │   • Handoff chain requirements                                             │
 │                                                                             │
 │ ACTION REQUIRED:                                                           │
-│   1. Read CLAUDE_LEAD_DIGEST.md completely (no limit parameter)            │
+│   1. Read CLAUDE_LEAD.md completely (no limit parameter)            │
 │   2. Then retry SD key generation                                          │
 │                                                                             │
-│ HINT: Use Read tool with file_path="CLAUDE_LEAD_DIGEST.md" (no limit)      │
+│ HINT: Use Read tool with file_path="CLAUDE_LEAD.md" (no limit)      │
 └─────────────────────────────────────────────────────────────────────────────┘
 `
     };
@@ -253,10 +253,10 @@ export function validateLeadFileRead() {
 │   • Lines 825-1030: PRD Enrichment and Evaluation Checklist                │
 │                                                                             │
 │ ACTION REQUIRED:                                                           │
-│   1. Re-read CLAUDE_LEAD_DIGEST.md completely (WITHOUT limit parameter)    │
+│   1. Re-read CLAUDE_LEAD.md completely (WITHOUT limit parameter)    │
 │   2. Then retry SD key generation                                          │
 │                                                                             │
-│ HINT: Use Read tool with file_path="CLAUDE_LEAD_DIGEST.md" (no limit)      │
+│ HINT: Use Read tool with file_path="CLAUDE_LEAD.md" (no limit)      │
 └─────────────────────────────────────────────────────────────────────────────┘
 `
     };

--- a/templates/session-prologue.md
+++ b/templates/session-prologue.md
@@ -30,7 +30,7 @@
 1. Run `npm run sd:next` to see the SD queue
 2. If SD marked "CONTINUE" → Resume that SD
 3. If no active SD → Pick highest-ranked READY SD
-4. Load CLAUDE_LEAD_DIGEST.md for approval workflow
+4. Load CLAUDE_LEAD.md for approval workflow
 
 ---
 *Remind Claude: Follow database-first, keep PRs small, use sub-agents, create handoffs*


### PR DESCRIPTION
## Summary
- Make context-compact-nudge hook auto-proceed-aware (ADVISORY vs CRITICAL when AUTO-PROCEED active)
- Add Directive Priority Hierarchy to protocol (Safety > AUTO-PROCEED > Gates > Advisory)
- Switch all protocol file references from DIGEST to full versions (1M context window)
- Add NC-002 advisory triggers for SD/PRD/vision/arch creation source validation
- Add NC-002 awareness to RCA sub-agent prompt

## Test plan
- [ ] Verify hook outputs ADVISORY when auto-proceed state file shows isActive=true
- [ ] Verify hook outputs CRITICAL when auto-proceed is OFF (unchanged behavior)
- [ ] Verify CLAUDE.md regeneration includes new priority hierarchy section
- [ ] Verify advisory triggers log to audit_log on direct DB inserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)