### PR TITLE
feat: Heartbeat Intelligence Protocol (#SD-MAN-INFRA-WORKER-WORKTREE-SELF-001)

### DIFF
--- a/database/migrations/20260314_heartbeat_intelligence.sql
+++ b/database/migrations/20260314_heartbeat_intelligence.sql
@@ -1,0 +1,31 @@
+-- Heartbeat Intelligence Protocol
+-- SD: SD-MAN-INFRA-WORKER-WORKTREE-SELF-001
+-- Adds 3 telemetry columns to claude_sessions for fleet coordinator intelligence
+
+-- 1. Add columns
+ALTER TABLE claude_sessions
+  ADD COLUMN IF NOT EXISTS has_uncommitted_changes boolean DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS handoff_fail_count integer DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS current_phase text DEFAULT NULL;
+
+COMMENT ON COLUMN claude_sessions.has_uncommitted_changes IS 'True if worker has uncommitted git changes. NULL = unknown (pre-upgrade session). Used as release guard.';
+COMMENT ON COLUMN claude_sessions.handoff_fail_count IS 'Count of failed handoff attempts on current SD. Reset on SD change or success. >3 triggers WORKER_STRUGGLING.';
+COMMENT ON COLUMN claude_sessions.current_phase IS 'Normalized phase: LEAD, PLAN, or EXEC. Derived from strategic_directives_v2.current_phase. NULL if no SD claimed.';
+
+-- 2. Fleet telemetry weekly aggregate view
+CREATE OR REPLACE VIEW fleet_telemetry_weekly AS
+SELECT
+  date_trunc('week', cs.heartbeat_at) AS week_start,
+  COUNT(DISTINCT cs.session_id) AS total_sessions,
+  COUNT(DISTINCT cs.session_id) FILTER (WHERE cs.has_uncommitted_changes = true) AS wip_sessions,
+  COUNT(DISTINCT cs.session_id) FILTER (WHERE cs.handoff_fail_count > 3) AS struggling_sessions,
+  ROUND(AVG(cs.handoff_fail_count)::numeric, 1) AS avg_fail_count,
+  SUM(EXTRACT(EPOCH FROM (COALESCE(cs.released_at, NOW()) - cs.created_at)) / 3600)::numeric(10,1) AS total_session_hours,
+  COUNT(DISTINCT cs.current_branch) FILTER (WHERE cs.current_branch IS NOT NULL AND cs.current_branch != 'main') AS unique_branches
+FROM claude_sessions cs
+WHERE cs.heartbeat_at >= NOW() - INTERVAL '90 days'
+GROUP BY date_trunc('week', cs.heartbeat_at)
+HAVING SUM(EXTRACT(EPOCH FROM (COALESCE(cs.released_at, NOW()) - cs.created_at)) / 3600) >= 10
+ORDER BY week_start DESC;
+
+COMMENT ON VIEW fleet_telemetry_weekly IS 'Weekly aggregate of fleet telemetry for EVA Friday reporting. Only includes weeks with >=10 heartbeat-hours.';

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -440,8 +440,9 @@ export async function getOrCreateSession() {
 export async function updateHeartbeat(sessionId) {
   const now = new Date().toISOString();
 
-  // Detect current git branch for multi-session safety tracking
+  // Detect current git branch and uncommitted changes for fleet telemetry
   let currentBranch = null;
+  let hasUncommittedChanges = null;
   try {
     const { execSync } = await import('child_process');
     currentBranch = execSync('git rev-parse --abbrev-ref HEAD', {
@@ -449,8 +450,44 @@ export async function updateHeartbeat(sessionId) {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe']
     }).trim();
+    // Check for uncommitted changes (cached with heartbeat cycle as implicit TTL)
+    const gitStatus = execSync('git status --porcelain', {
+      timeout: 3000,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    hasUncommittedChanges = gitStatus.length > 0;
   } catch {
-    // Git not available or not in a repo - branch stays null
+    // Git not available or not in a repo - values stay null
+  }
+
+  // Normalize current phase from SD (LEAD_APPROVAL -> LEAD, PLAN_PRD -> PLAN, etc.)
+  const PHASE_MAP = {
+    'LEAD': 'LEAD', 'LEAD_APPROVAL': 'LEAD', 'LEAD_COMPLETE': 'LEAD',
+    'LEAD_FINAL': 'LEAD', 'LEAD_FINAL_APPROVAL': 'LEAD',
+    'PLAN_PRD': 'PLAN', 'PLAN_VERIFICATION': 'PLAN',
+    'EXEC': 'EXEC', 'EXEC_COMPLETE': 'EXEC',
+    'COMPLETED': null, 'CANCELLED': null
+  };
+  let currentPhase = null;
+  try {
+    const { data: sessionData } = await supabase
+      .from('claude_sessions')
+      .select('sd_id')
+      .eq('session_id', sessionId)
+      .single();
+    if (sessionData?.sd_id) {
+      const { data: sdData } = await supabase
+        .from('strategic_directives_v2')
+        .select('current_phase')
+        .eq('sd_key', sessionData.sd_id)
+        .single();
+      if (sdData?.current_phase) {
+        currentPhase = PHASE_MAP[sdData.current_phase] ?? null;
+      }
+    }
+  } catch {
+    // Phase detection is non-critical
   }
 
   // Update local file
@@ -481,11 +518,24 @@ export async function updateHeartbeat(sessionId) {
     if (fallbackError) {
       const updateFields = { heartbeat_at: now, updated_at: now };
       if (currentBranch) updateFields.current_branch = currentBranch;
+      if (hasUncommittedChanges !== null) updateFields.has_uncommitted_changes = hasUncommittedChanges;
+      if (currentPhase !== undefined) updateFields.current_phase = currentPhase;
       await supabase
         .from('claude_sessions')
         .update(updateFields)
         .eq('session_id', sessionId);
     }
+  }
+
+  // Update enriched telemetry fields (separate from heartbeat RPC for backward compat)
+  const telemetryFields = {};
+  if (hasUncommittedChanges !== null) telemetryFields.has_uncommitted_changes = hasUncommittedChanges;
+  if (currentPhase !== undefined) telemetryFields.current_phase = currentPhase;
+  if (Object.keys(telemetryFields).length > 0) {
+    await supabase
+      .from('claude_sessions')
+      .update(telemetryFields)
+      .eq('session_id', sessionId);
   }
 
   // Recover released sessions: if a session is still sending heartbeats,
@@ -498,7 +548,7 @@ export async function updateHeartbeat(sessionId) {
     .eq('session_id', sessionId)
     .eq('status', 'released');
 
-  return { success: true, heartbeat_at: now, current_branch: currentBranch };
+  return { success: true, heartbeat_at: now, current_branch: currentBranch, has_uncommitted_changes: hasUncommittedChanges, current_phase: currentPhase };
 }
 
 /**

--- a/scripts/eva/friday-meeting.mjs
+++ b/scripts/eva/friday-meeting.mjs
@@ -237,6 +237,60 @@ function renderRdProposals(data) {
   return _renderRdProposals(data);
 }
 
+// ─── Section 5b: Fleet Telemetry (SD-MAN-INFRA-WORKER-WORKTREE-SELF-001) ───
+
+async function gatherFleetTelemetry() {
+  try {
+    const { data, error } = await supabase
+      .from('fleet_telemetry_weekly')
+      .select('*')
+      .order('week_start', { ascending: false })
+      .limit(4);
+
+    if (error || !data?.length) return null;
+
+    // Also get current active session count
+    const { data: activeSessions } = await supabase
+      .from('claude_sessions')
+      .select('session_id, handoff_fail_count, has_uncommitted_changes, current_phase')
+      .eq('status', 'active');
+
+    return {
+      weeks: data,
+      currentActive: activeSessions?.length || 0,
+      currentStrugglingCount: (activeSessions || []).filter(s => (s.handoff_fail_count || 0) > 3).length,
+      currentWipCount: (activeSessions || []).filter(s => s.has_uncommitted_changes === true).length
+    };
+  } catch {
+    return null;
+  }
+}
+
+function renderFleetTelemetry(data) {
+  if (!data) return '';
+
+  const lines = ['', '  SECTION 5b: FLEET TELEMETRY', '  ' + '─'.repeat(40)];
+
+  // Current fleet snapshot
+  lines.push(`  Active Sessions:     ${data.currentActive}`);
+  lines.push(`  With WIP (uncommitted): ${data.currentWipCount}`);
+  lines.push(`  Struggling (>3 fails): ${data.currentStrugglingCount}`);
+  lines.push('');
+
+  // Weekly trend (last 4 weeks)
+  if (data.weeks.length > 0) {
+    lines.push('  Weekly Trend:');
+    lines.push('  ' + 'Week'.padEnd(14) + 'Sessions'.padEnd(10) + 'WIP'.padEnd(6) + 'Struggling'.padEnd(12) + 'Hours');
+    lines.push('  ' + '─'.repeat(48));
+    for (const w of data.weeks) {
+      const weekLabel = new Date(w.week_start).toISOString().slice(0, 10);
+      lines.push('  ' + weekLabel.padEnd(14) + String(w.total_sessions).padEnd(10) + String(w.wip_sessions).padEnd(6) + String(w.struggling_sessions).padEnd(12) + String(w.total_session_hours));
+    }
+  }
+
+  return lines.join('\n');
+}
+
 // ─── Section 6: Decisions ────────────────────────────────────
 
 function buildDecisionPayload(findings) {
@@ -434,20 +488,22 @@ export async function fridayMeetingHandler(options = {}) {
   logger.log('═'.repeat(55));
 
   // Gather all data in parallel
-  const [perfData, capData, consultData, intakeData, rdData] = await Promise.all([
+  const [perfData, capData, consultData, intakeData, rdData, fleetData] = await Promise.all([
     gatherPerformanceReview(),
     gatherCapabilityReport(),
     gatherConsultantFindings(),
     gatherIntakeReview(),
     gatherRdProposals(),
+    gatherFleetTelemetry(),
   ]);
 
-  // Render sections 1-5
+  // Render sections 1-5b
   logger.log(renderPerformanceReview(perfData));
   logger.log(renderCapabilityReport(capData));
   logger.log(renderConsultantFindings(consultData));
   logger.log(renderIntakeReview(intakeData));
   logger.log(renderRdProposals(rdData));
+  logger.log(renderFleetTelemetry(fleetData));
 
   // Section 6: Decisions
   logger.log('');

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -127,14 +127,17 @@ function printWorkers(d) {
   if (d.activeSessions.length === 0) {
     console.log('  (no active workers)');
   } else {
-    console.log('  ' + pad('Terminal', 12) + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 14) + 'Heartbeat');
-    console.log('  ' + '─'.repeat(68));
+    console.log('  ' + pad('Terminal', 12) + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + 'Heartbeat');
+    console.log('  ' + '─'.repeat(72));
     for (const s of d.activeSessions) {
       const child = d.children.find(c => c.sd_key === s.sd_id);
       const pct = child ? child.progress_percentage : 0;
-      const phase = child ? child.current_phase : '?';
+      const phase = s.current_phase || (child ? child.current_phase : '?');
       const shortSd = s.sd_id.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
-      console.log('  ' + pad(s.tty, 12) + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 14) + s.heartbeat_age_human);
+      const fails = s.handoff_fail_count != null ? String(s.handoff_fail_count) : '-';
+      const wip = s.has_uncommitted_changes === true ? 'Y' : s.has_uncommitted_changes === false ? 'N' : '-';
+      const struggleTag = (s.handoff_fail_count || 0) > 3 ? ' [STRUGGLING]' : '';
+      console.log('  ' + pad(s.tty, 12) + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + s.heartbeat_age_human + struggleTag);
     }
   }
 

--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -182,6 +182,17 @@ export class HandoffRecorder {
 
       console.log(`📝 Success recorded: ${executionId}`);
 
+      // SD-MAN-INFRA-WORKER-WORKTREE-SELF-001: Reset handoff_fail_count on success
+      try {
+        await this.supabase
+          .from('claude_sessions')
+          .update({ handoff_fail_count: 0 })
+          .eq('sd_id', sdId)
+          .eq('status', 'active');
+      } catch (resetErr) {
+        console.warn(`   [handoff-fail-count] Reset non-blocking: ${resetErr.message}`);
+      }
+
       // SD-MAN-FEAT-CORRECTIVE-VISION-GAP-072 US-001: Governance audit trail
       // Log every handoff execution (success) to validation_audit_log for compliance review
       await this._logGovernanceAudit(handoffType, sdUuid, {
@@ -295,6 +306,25 @@ export class HandoffRecorder {
       }
 
       console.log(`📝 Failure recorded: ${executionId}`);
+
+      // SD-MAN-INFRA-WORKER-WORKTREE-SELF-001: Increment handoff_fail_count for fleet telemetry
+      try {
+        const { data: sessions } = await this.supabase
+          .from('claude_sessions')
+          .select('session_id, handoff_fail_count')
+          .eq('sd_id', sdId)
+          .eq('status', 'active');
+        if (sessions?.length > 0) {
+          for (const s of sessions) {
+            await this.supabase
+              .from('claude_sessions')
+              .update({ handoff_fail_count: (s.handoff_fail_count || 0) + 1 })
+              .eq('session_id', s.session_id);
+          }
+        }
+      } catch (failCountErr) {
+        console.warn(`   [handoff-fail-count] Non-blocking: ${failCountErr.message}`);
+      }
 
       // SD-MAN-FEAT-CORRECTIVE-VISION-GAP-072 US-001: Governance audit trail
       // Log every handoff execution (failure) to validation_audit_log for compliance review

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -466,9 +466,16 @@ async function main() {
     }
   }
 
-  // 4. Auto-release dead sessions
+  // 4. Auto-release dead sessions (with WIP guard)
   const dead = classified.filter(s => s.status === 'DEAD');
   for (const s of dead) {
+    // SD-MAN-INFRA-WORKER-WORKTREE-SELF-001: WIP release guard
+    // Sessions with uncommitted changes are protected from automatic release
+    if (s.has_uncommitted_changes === true) {
+      warnings.push('WIP_GUARD: ' + s.session_id + ' has uncommitted changes — NOT releasing (SD: ' + s.sd_id + ')');
+      continue;
+    }
+
     const { error } = await supabase
       .from('claude_sessions')
       .update({
@@ -484,6 +491,27 @@ async function main() {
     } else {
       actions.push('RELEASED ' + s.session_id + ' — PID ' + s.pid + ' dead — freed ' + s.sd_id);
     }
+  }
+
+  // 4a. Worktree conflict detection (SD-MAN-INFRA-WORKER-WORKTREE-SELF-001)
+  // Detect multiple active sessions on the same feature branch (excludes main/QF)
+  const branchSessions = new Map();
+  for (const s of classified.filter(c => c.status === 'ACTIVE' && c.current_branch && c.current_branch !== 'main')) {
+    if (!branchSessions.has(s.current_branch)) branchSessions.set(s.current_branch, []);
+    branchSessions.get(s.current_branch).push(s);
+  }
+  for (const [branch, sessions] of branchSessions) {
+    if (sessions.length > 1) {
+      const ids = sessions.map(s => s.session_id).join(', ');
+      warnings.push('WORKTREE_CONFLICT: branch ' + branch + ' claimed by ' + sessions.length + ' sessions: ' + ids);
+    }
+  }
+
+  // 4b. Struggling worker detection (SD-MAN-INFRA-WORKER-WORKTREE-SELF-001)
+  // Flag workers with repeated handoff failures
+  for (const s of classified.filter(c => c.status === 'ACTIVE' && (c.handoff_fail_count || 0) > 3)) {
+    const tier = s.handoff_fail_count >= 7 ? 'REASSIGN' : s.handoff_fail_count >= 5 ? 'RCA' : 'WARN';
+    warnings.push('WORKER_STRUGGLING: ' + s.session_id + ' has ' + s.handoff_fail_count + ' handoff failures (tier: ' + tier + ', SD: ' + s.sd_id + ')');
   }
 
   // 5. Resolve conflicts — keep freshest, release ALL others (including active)


### PR DESCRIPTION
## Summary
- Add 3 telemetry columns to `claude_sessions`: `has_uncommitted_changes`, `handoff_fail_count`, `current_phase`
- Enrich heartbeat in `session-manager.mjs` with git WIP detection and phase normalization
- Add WIP release guard, worktree conflict detection, and struggling worker flags to sweep
- Display Phase, Fails, WIP columns in fleet dashboard WORKERS table
- Add Fleet Telemetry section to EVA Friday meeting report
- Create `fleet_telemetry_weekly` aggregate view for reporting

## Test plan
- [ ] Verify migration adds 3 columns to claude_sessions
- [ ] Verify heartbeat reports has_uncommitted_changes correctly
- [ ] Verify phase normalization (LEAD_APPROVAL -> LEAD, etc.)
- [ ] Verify handoff_fail_count increments on failure, resets on success
- [ ] Verify WIP sessions protected from sweep release
- [ ] Verify WORKTREE_CONFLICT detected for duplicate branches (main excluded)
- [ ] Verify WORKER_STRUGGLING flag at >3 failures
- [ ] Verify fleet dashboard shows new columns
- [ ] Verify Friday meeting includes Fleet Telemetry section

🤖 Generated with [Claude Code](https://claude.com/claude-code)