### PR TITLE
fix: SD-type-aware TRANSLATION_FIDELITY threshold

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js
@@ -19,7 +19,24 @@ import {
 } from '../../../validation/semantic-gate-utils.js';
 
 const GATE_NAME = 'TRANSLATION_FIDELITY';
-const PASSING_SCORE = 70;
+
+// SD-type-aware thresholds (SD-LEARN-FIX-ADDRESS-PAT-AUTO-068)
+// Infrastructure/fix/documentation SDs have lower fidelity requirements
+// because architecture plans are less common and translations are simpler.
+const PASSING_SCORES = {
+  feature: 70,
+  enhancement: 70,
+  orchestrator: 70,
+  infrastructure: 60,
+  fix: 60,
+  documentation: 60,
+  refactor: 65,
+};
+const DEFAULT_PASSING_SCORE = 70;
+
+function getPassingScore(sdType) {
+  return PASSING_SCORES[sdType] || DEFAULT_PASSING_SCORE;
+}
 
 export function createTranslationFidelityGate(supabase) {
   return {
@@ -87,9 +104,11 @@ export function createTranslationFidelityGate(supabase) {
         const gapCount = result.gaps?.length || 0;
         const criticalGaps = result.gaps?.filter(g => g.severity === 'critical') || [];
         const score = result.score ?? 0;
-        const passed = score >= PASSING_SCORE && criticalGaps.length === 0;
+        const sdType = sd?.sd_type || 'feature';
+        const passingScore = getPassingScore(sdType);
+        const passed = score >= passingScore && criticalGaps.length === 0;
 
-        console.log(`   Score: ${score}/100 | Gaps: ${gapCount} (${criticalGaps.length} critical)`);
+        console.log(`   Score: ${score}/100 | Threshold: ${passingScore} (${sdType}) | Gaps: ${gapCount} (${criticalGaps.length} critical)`);
 
         if (gapCount > 0) {
           console.log('   Gaps found:');
@@ -102,7 +121,7 @@ export function createTranslationFidelityGate(supabase) {
         if (passed) {
           console.log(`   ✅ Translation fidelity PASSED (${score}/100)`);
         } else {
-          console.log(`   ❌ Translation fidelity FAILED (${score}/100, need ${PASSING_SCORE})`);
+          console.log(`   ❌ Translation fidelity FAILED (${score}/100, need ${passingScore} for ${sdType})`);
         }
 
         return buildSemanticResult({
@@ -110,7 +129,7 @@ export function createTranslationFidelityGate(supabase) {
           score,
           confidence: 1.0,
           issues: passed ? [] : [
-            `Translation fidelity score ${score}/100 below threshold ${PASSING_SCORE}`,
+            `Translation fidelity score ${score}/100 below threshold ${passingScore} (${sdType})`,
             ...criticalGaps.map(g => `Critical gap: ${g.item}`)
           ],
           warnings: result.gaps


### PR DESCRIPTION
## Summary
- Makes TRANSLATION_FIDELITY gate threshold SD-type-aware (infrastructure=60, feature=70)
- Eliminates PAT-AUTO-93d98468 false failures where infrastructure SDs scored 65/100 but were blocked
- Gate console output now shows threshold value and SD type for debugging

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Infrastructure SDs scoring 60-69 will now pass (was failing)
- [x] Feature SDs still require 70+ (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)