### PR TITLE
feat: Connect brainstorm sessions to strategic roadmap (#SD-MAN-INFRA-STRATEGIC-ROADMAP-PROCESS-001)

### DIFF
--- a/database/migrations/20260314_roadmap_brainstorm_source_type.sql
+++ b/database/migrations/20260314_roadmap_brainstorm_source_type.sql
@@ -1,0 +1,10 @@
+-- SD: SD-MAN-INFRA-STRATEGIC-ROADMAP-PROCESS-001
+-- Add 'brainstorm' to roadmap_wave_items.source_type CHECK constraint
+-- Enables auto-creating roadmap items from brainstorm sessions
+
+-- Drop existing constraint
+ALTER TABLE roadmap_wave_items DROP CONSTRAINT IF EXISTS roadmap_wave_items_source_type_check;
+
+-- Re-create with 'brainstorm' included
+ALTER TABLE roadmap_wave_items ADD CONSTRAINT roadmap_wave_items_source_type_check
+  CHECK (source_type IN ('todoist', 'youtube', 'brainstorm'));

--- a/lib/integrations/roadmap-manager.js
+++ b/lib/integrations/roadmap-manager.js
@@ -197,6 +197,65 @@ export async function approveSequence(supabase, roadmapId, rationale) {
 }
 
 /**
+ * Create a roadmap wave item from a brainstorm session.
+ * SD: SD-MAN-INFRA-STRATEGIC-ROADMAP-PROCESS-001
+ * Idempotent via source_id — re-processing same brainstorm is a no-op.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {object} opts
+ * @param {string} opts.brainstormSessionId - UUID of brainstorm_sessions record
+ * @param {string} opts.waveId - UUID of roadmap_waves record to add item to
+ * @param {string} [opts.title] - Optional title override
+ * @returns {Promise<{created: boolean, itemId: string|null, reason: string}>}
+ */
+export async function createWaveItemFromBrainstorm(supabase, { brainstormSessionId, waveId, title }) {
+  // Load brainstorm session
+  const { data: bs, error: bsErr } = await supabase
+    .from('brainstorm_sessions')
+    .select('id, topic, metadata')
+    .eq('id', brainstormSessionId)
+    .single();
+
+  if (bsErr || !bs) return { created: false, itemId: null, reason: 'Brainstorm session not found' };
+
+  // Only process brainstorms with both vision and arch docs
+  const visionKey = bs.metadata?.vision_key;
+  const archKey = bs.metadata?.arch_key;
+  if (!visionKey || !archKey) {
+    return { created: false, itemId: null, reason: 'Missing vision_key or arch_key — skipping' };
+  }
+
+  // Idempotency: check if already exists
+  const { data: existing } = await supabase
+    .from('roadmap_wave_items')
+    .select('id')
+    .eq('wave_id', waveId)
+    .eq('source_type', 'brainstorm')
+    .eq('source_id', brainstormSessionId)
+    .limit(1);
+
+  if (existing?.length > 0) {
+    return { created: false, itemId: existing[0].id, reason: 'Already exists (idempotent)' };
+  }
+
+  // Insert wave item
+  const { data: item, error: insertErr } = await supabase
+    .from('roadmap_wave_items')
+    .insert({
+      wave_id: waveId,
+      source_type: 'brainstorm',
+      source_id: brainstormSessionId,
+      title: title || bs.topic || 'Untitled brainstorm',
+      metadata: { vision_key: visionKey, arch_key: archKey, brainstorm_topic: bs.topic },
+    })
+    .select('id')
+    .single();
+
+  if (insertErr) return { created: false, itemId: null, reason: `Insert failed: ${insertErr.message}` };
+  return { created: true, itemId: item.id, reason: 'Created from brainstorm' };
+}
+
+/**
  * Promote unpromoted wave items to Strategic Directives.
  * Creates one SD per item, updates promoted_to_sd_key, transitions wave to active.
  *
@@ -215,7 +274,7 @@ export async function promoteWaveToSDs(supabase, waveId) {
 
   const { data: items, error: iErr } = await supabase
     .from('roadmap_wave_items')
-    .select('id, title, source_type, source_id, promoted_to_sd_key, priority_rank')
+    .select('id, title, source_type, source_id, promoted_to_sd_key, priority_rank, metadata')
     .eq('wave_id', waveId)
     .order('priority_rank', { ascending: true });
 
@@ -270,6 +329,9 @@ export async function promoteWaveToSDs(supabase, waveId) {
           risk_flags: brainstormResults.risk_flags,
         };
       }
+      // SD-MAN-INFRA-STRATEGIC-ROADMAP-PROCESS-001: Pass vision/arch keys from brainstorm metadata
+      if (item.metadata?.vision_key) sdMetadata.vision_key = item.metadata.vision_key;
+      if (item.metadata?.arch_key) sdMetadata.arch_key = item.metadata.arch_key;
 
       const { data: sd, error: sdErr } = await supabase
         .from('strategic_directives_v2')


### PR DESCRIPTION
## Summary
- Add `createWaveItemFromBrainstorm()` to roadmap-manager.js for auto-creating roadmap items from chairman-approved brainstorms
- Idempotent via `source_id` check — re-processing same brainstorm is a no-op
- Promote flow now passes `vision_key` and `arch_key` from brainstorm metadata to created SDs
- Migration adds `brainstorm` to `roadmap_wave_items.source_type` CHECK constraint

## Test plan
- [ ] Call `createWaveItemFromBrainstorm()` with valid brainstorm (vision+arch) -> verify item created
- [ ] Call again with same brainstorm -> verify idempotent (no duplicate)
- [ ] Call with brainstorm missing vision_key -> verify skipped
- [ ] Promote brainstorm wave item -> verify SD has vision_key and arch_key in metadata
- [ ] Existing todoist/youtube items unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)