### PR TITLE
feat: Wire brainstorm auto-chain into distill pipeline (#SD-DISTILLTOBRAINSTORM-ORCH-001-A)

### DIFF
--- a/.claude/commands/distill.md
+++ b/.claude/commands/distill.md
@@ -450,8 +450,11 @@ For each item in the brainstorm queue, process one at a time:
    Focus the brainstorm on shaping the chairman's stated intent into an actionable plan.
    ```
 
-3. **After brainstorm completes**, link back and update queue:
+3. **After brainstorm completes**, auto-chain: vision → arch → SD → roadmap link
 
+   The brainstorm skill outputs a `brainstorm_session_id`. Use it to:
+
+   **3a. Link brainstorm to intake item:**
    ```bash
    node -e "
    require('dotenv').config();
@@ -466,7 +469,76 @@ For each item in the brainstorm queue, process one at a time:
    "
    ```
 
-4. Update queue display: `[DONE] "Item title..." → sd_created (VISION-KEY, ARCH-KEY)`
+   **3b. Check if brainstorm produced vision + arch docs:**
+   ```bash
+   node -e "
+   require('dotenv').config();
+   const { createClient } = require('@supabase/supabase-js');
+   const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+   sb.from('brainstorm_sessions').select('id, topic, metadata')
+     .eq('id', 'BRAINSTORM_SESSION_ID').single()
+     .then(({data}) => {
+       const vk = data?.metadata?.vision_key;
+       const ak = data?.metadata?.arch_key;
+       console.log('VISION_KEY=' + (vk || 'NONE'));
+       console.log('ARCH_KEY=' + (ak || 'NONE'));
+       console.log('CHAIN_READY=' + (vk && ak ? 'true' : 'false'));
+     });
+   "
+   ```
+
+   **3c. If CHAIN_READY=true, create SD from brainstorm:**
+   ```bash
+   node scripts/leo-create-sd.js --from-brainstorm BRAINSTORM_SESSION_ID --vision-key VISION_KEY --arch-key ARCH_KEY
+   ```
+   If `leo-create-sd.js` doesn't support `--from-brainstorm`, create the SD directly:
+   ```bash
+   node -e "
+   require('dotenv').config();
+   const { createClient } = require('@supabase/supabase-js');
+   const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+   // Use sd-key-generator for proper key
+   const { execSync } = require('child_process');
+   const keyResult = execSync('node scripts/modules/sd-key-generator.js LEO feature \"BRAINSTORM_TOPIC\"', {encoding:'utf8'}).trim();
+   const sdKey = keyResult.split('\\n').pop().trim();
+   sb.from('strategic_directives_v2').insert({
+     sd_key: sdKey,
+     title: 'BRAINSTORM_TOPIC',
+     status: 'draft',
+     sd_type: 'feature',
+     current_phase: 'LEAD',
+     description: 'Created from brainstorm session BRAINSTORM_SESSION_ID via distill pipeline.',
+     metadata: { vision_key: 'VISION_KEY', arch_key: 'ARCH_KEY', brainstorm_session_id: 'BRAINSTORM_SESSION_ID', source: 'distill-pipeline' }
+   }).select('sd_key').single().then(({data, error}) => {
+     if (error) console.error('SD creation failed:', error.message);
+     else console.log('SD_CREATED=' + data.sd_key);
+   });
+   "
+   ```
+
+   **3d. Link to roadmap wave item (if wave context exists):**
+   ```bash
+   node -e "
+   require('dotenv').config();
+   const { createClient } = require('@supabase/supabase-js');
+   const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+   // Update wave item with promoted_sd_key if this item came from a wave
+   sb.from('roadmap_wave_items')
+     .update({ promoted_to_sd_key: 'SD_KEY_CREATED' })
+     .eq('source_id', 'BRAINSTORM_SESSION_ID')
+     .eq('source_type', 'brainstorm')
+     .then(({error}) => {
+       if (error) console.warn('Wave link skipped:', error.message);
+       else console.log('Wave item linked to SD');
+     });
+   "
+   ```
+
+   **3e. If CHAIN_READY=false** (brainstorm didn't produce vision+arch):
+   - Log: `[NEEDS_TRIAGE] "Item title..." — brainstorm completed but no vision/arch produced`
+   - Item goes to waves for manual processing later
+
+4. Update queue display: `[DONE] "Item title..." → SD_KEY (VISION-KEY, ARCH-KEY)` or `[NEEDS_TRIAGE] "Item title..."`
 
 5. **Continue to next item** in queue automatically.
 


### PR DESCRIPTION
## Summary
- Add post-brainstorm auto-chain steps (3b-3e) to distill.md skill
- After brainstorm completes, check for vision+arch docs (CHAIN_READY)
- If ready: auto-create SD with vision/arch keys, link to roadmap wave item
- If not ready: mark NEEDS_TRIAGE for manual wave processing
- Both legacy Research SD and new brainstorm-to-SD paths coexist

## Test plan
- [ ] Run /distill with item that has chairman_notes -> brainstorm invoked
- [ ] After brainstorm with vision+arch -> SD auto-created with keys in metadata
- [ ] Wave item promoted_sd_key populated after SD creation
- [ ] Brainstorm without vision+arch -> NEEDS_TRIAGE logged
- [ ] Items without notes -> legacy Research SD path unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)