### PR TITLE
feat: Eliminate Research SD middleman for brainstorm items (#SD-DISTILLTOBRAINSTORM-ORCH-001-B)

### DIFF
--- a/database/migrations/20260314_distill_wave_item_disposition.sql
+++ b/database/migrations/20260314_distill_wave_item_disposition.sql
@@ -1,0 +1,10 @@
+-- SD: SD-DISTILLTOBRAINSTORM-CONTINUOUS-GUIDED-PIPELINE-ORCH-001-B
+-- Add item_disposition and brainstorm_session_id to roadmap_wave_items
+
+ALTER TABLE roadmap_wave_items
+  ADD COLUMN IF NOT EXISTS item_disposition TEXT DEFAULT 'pending'
+    CHECK (item_disposition IN ('pending', 'selected', 'deferred', 'brainstormed', 'promoted', 'dropped')),
+  ADD COLUMN IF NOT EXISTS brainstorm_session_id UUID REFERENCES brainstorm_sessions(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN roadmap_wave_items.item_disposition IS 'Flow state: pending→selected→brainstormed→promoted (or deferred/dropped at any point)';
+COMMENT ON COLUMN roadmap_wave_items.brainstorm_session_id IS 'FK to brainstorm_sessions when item has been brainstormed. Null = not yet brainstormed.';

--- a/lib/integrations/refine-promote.js
+++ b/lib/integrations/refine-promote.js
@@ -173,7 +173,16 @@ export async function promote(scoredItems, originalItems, options = {}) {
   let counter = 1;
 
   for (const group of groups) {
-    const result = await createResearchSD(group, counter++, {
+    // SD-DISTILLTOBRAINSTORM-ORCH-001-B: Skip Research SD for items with brainstorm
+    // Items that went through brainstorm-to-SD path already have SDs
+    const nonBrainstormed = group.items.filter(i => !i.brainstorm_session_id);
+    if (nonBrainstormed.length === 0) {
+      console.log(`  ⏭️  Skipping ${group.application}: all ${group.items.length} items already brainstormed`);
+      continue;
+    }
+    const filteredGroup = { ...group, items: nonBrainstormed };
+
+    const result = await createResearchSD(filteredGroup, counter++, {
       supabase,
       dryRun: options.dryRun,
     });

--- a/scripts/roadmap-status.js
+++ b/scripts/roadmap-status.js
@@ -77,13 +77,25 @@ async function main() {
         .eq('wave_id', wave.id)
         .not('promoted_to_sd_key', 'is', null);
 
+      // SD-DISTILLTOBRAINSTORM-ORCH-001-B: Disposition breakdown
+      const { data: dispositionData } = await supabase
+        .from('roadmap_wave_items')
+        .select('item_disposition')
+        .eq('wave_id', wave.id);
+      const dispositions = {};
+      for (const row of (dispositionData || [])) {
+        const d = row.item_disposition || 'pending';
+        dispositions[d] = (dispositions[d] || 0) + 1;
+      }
+      const dispStr = Object.entries(dispositions).map(([k, v]) => `${k}:${v}`).join(' ');
+
       const statusLabel = WAVE_STATUS_LABELS[wave.status] || wave.status;
       const progress = Number(wave.progress_pct || 0).toFixed(0);
       const conf = Number(wave.confidence_score || 0).toFixed(2);
 
       console.log(`    [${wave.sequence_rank}] ${wave.title}`);
       console.log(`        Status: ${statusLabel} | Progress: ${progress}% | Confidence: ${conf}`);
-      console.log(`        Items: ${count || 0} | Promoted: ${promoted.count || 0}`);
+      console.log(`        Items: ${count || 0} | Promoted: ${promoted.count || 0}${dispStr ? ' | ' + dispStr : ''}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Migration: add `item_disposition` enum and `brainstorm_session_id` FK to `roadmap_wave_items`
- `refine-promote.js`: skip Research SD creation for items with `brainstorm_session_id`
- `roadmap-status.js`: show disposition breakdown per wave (pending:N selected:N etc.)

## Test plan
- [ ] Migration adds two columns with correct constraints
- [ ] Item with brainstorm_session_id -> Research SD NOT created
- [ ] Item without brainstorm_session_id -> Research SD created (legacy path)
- [ ] roadmap-status.js shows disposition counts per wave

🤖 Generated with [Claude Code](https://claude.com/claude-code)