### PR TITLE
feat: skip Research SD creation for brainstorm-path items

### DIFF
--- a/lib/integrations/roadmap-manager.js
+++ b/lib/integrations/roadmap-manager.js
@@ -274,13 +274,24 @@ export async function promoteWaveToSDs(supabase, waveId) {
 
   const { data: items, error: iErr } = await supabase
     .from('roadmap_wave_items')
-    .select('id, title, source_type, source_id, promoted_to_sd_key, priority_rank, metadata')
+    .select('id, title, source_type, source_id, promoted_to_sd_key, priority_rank, metadata, brainstorm_session_id, item_disposition')
     .eq('wave_id', waveId)
     .order('priority_rank', { ascending: true });
 
   if (iErr) throw new Error(`Failed to get items: ${iErr.message}`);
 
-  const unpromoted = (items || []).filter(i => !i.promoted_to_sd_key);
+  // Skip items that already have an SD (promoted_to_sd_key) OR were brainstormed
+  // (brainstorm_session_id exists — SD was created via brainstorm auto-chain)
+  const unpromoted = (items || []).filter(i => {
+    if (i.promoted_to_sd_key) return false; // already promoted
+    if (i.brainstorm_session_id) return false; // SD created via brainstorm path
+    if (i.item_disposition === 'dropped' || i.item_disposition === 'deferred') return false;
+    return true;
+  });
+  const brainstormed = (items || []).filter(i => i.brainstorm_session_id && !i.promoted_to_sd_key);
+  if (brainstormed.length > 0) {
+    console.log(`  ℹ️  ${brainstormed.length} item(s) skipped — already processed via brainstorm path`);
+  }
   const created = [];
   const errors = [];
 


### PR DESCRIPTION
## Summary
- `roadmap-manager.js`: `promoteWaveToSDs` now skips items with `brainstorm_session_id` (SD already created via brainstorm auto-chain), items with `dropped`/`deferred` disposition
- Logs count of brainstorm-path items skipped during promotion
- DB migration for `item_disposition` and `brainstorm_session_id` columns already applied

## Test plan
- [ ] Promote a wave with brainstormed items — verify they are skipped
- [ ] Promote a wave with non-brainstormed items — verify SDs still created
- [ ] Verify dropped/deferred items skipped during promotion

SD: SD-DISTILLTOBRAINSTORM-CONTINUOUS-GUIDED-PIPELINE-ORCH-001-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)