### PR TITLE
feat: inter-item guided loop for distill brainstorm pipeline

### DIFF
--- a/.claude/commands/distill.md
+++ b/.claude/commands/distill.md
@@ -586,7 +586,27 @@ For each item in the **selected** brainstorm queue (cherry-picked subset), proce
 
 4. Update queue display: `[DONE] "Item title..." → SD_KEY (VISION-KEY, ARCH-KEY)` or `[NEEDS_TRIAGE] "Item title..."`
 
-5. **Continue to next item** in queue automatically.
+5. **Inter-item decision point** (SD-DISTILLTOBRAINSTORM-ORCH-001-C):
+
+   If there are remaining items in the selected queue, present AskUserQuestion:
+
+   ```
+   question: "Item N of M complete. SD_KEY created. What next?"
+   header: "Brainstorm Loop — N/M"
+   options:
+     - label: "Process next item"
+       description: "Continue to: 'NEXT_ITEM_TITLE'"
+     - label: "Defer remaining items"
+       description: "Send N remaining items to waves without brainstorm"
+     - label: "Done for now"
+       description: "Save progress — resume later with /distill"
+   ```
+
+   - **Process next item**: Continue loop to the next selected item
+   - **Defer remaining**: Set `item_disposition = 'deferred'` for all remaining items, skip to summary
+   - **Done for now**: Save loop state (step 6) and exit — state file enables resume next session
+
+   If this is the LAST item (no more remaining), skip AskUserQuestion and go directly to summary.
 
 6. **After each item completes**, update loop state:
    ```bash

--- a/lib/integrations/refine-promote.js
+++ b/lib/integrations/refine-promote.js
@@ -2,6 +2,10 @@
  * Refine: Research SD Promotion Engine
  * SD: SD-LEO-INFRA-ADD-DISTILL-REFINE-001
  *
+ * DEPRECATED (SD-DISTILLTOBRAINSTORM-ORCH-001-C): Items with brainstorm_session_id
+ * already have full SDs created via the brainstorm auto-chain. This Research SD
+ * path only runs for non-brainstormed items that went through the refine pipeline.
+ *
  * Promotes high-scoring wave items into Research SDs.
  * Research SDs follow a lightweight workflow — they're meant for
  * investigation/exploration before deciding whether to build.


### PR DESCRIPTION
## Summary
- **distill.md**: Add AskUserQuestion between brainstorm items — chairman sees progress (N/M), can continue, defer remaining, or stop
- **refine-promote.js**: Add deprecation header — brainstorm auto-chain supersedes Research SD path

## Test plan
- [ ] Run /distill with 2+ items with chairman notes
- [ ] Verify AskUserQuestion appears between items with progress counter
- [ ] Select "Done for now" — verify state saved for resume
- [ ] Resume /distill — verify remaining items shown

SD: SD-DISTILLTOBRAINSTORM-CONTINUOUS-GUIDED-PIPELINE-ORCH-001-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)