### PR TITLE
feat: remove legacy Research SD path from distill pipeline

### DIFF
--- a/.claude/commands/distill.md
+++ b/.claude/commands/distill.md
@@ -18,7 +18,7 @@ Parse `$ARGUMENTS` for flags:
 - `refine --dry-run` → Preview refinement without DB writes
 - `refine --roadmap-id <id>` → Refine a specific roadmap
 - `refine --wave-id <id>` → Refine a specific wave only
-- `refine --skip-promote` → Run steps 1-3 only (no Research SD creation)
+- `refine --skip-promote` → Run steps 1-3 only (skip promotion analysis)
 - `approve --roadmap-id <id>` → Chairman approves wave sequence
 - `promote --wave-id <id>` → Promote approved wave items to SDs
 
@@ -194,7 +194,7 @@ This loads the inline scoring results, persists scores to DB, then runs Step 4 (
 - Duplicate groups found (Phase B, semantic)
 - Reconciliation results — novel vs already-done items (Phase D, semantic)
 - Scoring distribution — promote / review / defer (Phase F, semantic)
-- Research SDs created if promotion ran (Phase G)
+- Brainstorm promotion analysis if ran (Phase G)
 
 If this was a live run, show:
 ```

--- a/lib/integrations/refine-promote.js
+++ b/lib/integrations/refine-promote.js
@@ -1,29 +1,14 @@
 /**
- * Refine: Research SD Promotion Engine
+ * Refine: Promotion Analysis Engine
  * SD: SD-LEO-INFRA-ADD-DISTILL-REFINE-001
  *
- * DEPRECATED (SD-DISTILLTOBRAINSTORM-ORCH-001-C): Items with brainstorm_session_id
- * already have full SDs created via the brainstorm auto-chain. This Research SD
- * path only runs for non-brainstormed items that went through the refine pipeline.
- *
- * Promotes high-scoring wave items into Research SDs.
- * Research SDs follow a lightweight workflow — they're meant for
- * investigation/exploration before deciding whether to build.
- *
- * This module:
- *   1. Identifies items recommended for promotion (composite >= 70)
- *   2. Groups them by theme/application into Research SD batches
- *   3. Creates draft SDs with sd_type='documentation' (lightweight workflow)
- *   4. Links wave items back via promoted_to_sd_key
+ * SD-DISTILLTOBRAINSTORM-ORCH-001-C: Legacy Research SD creation removed.
+ * All items now go through the brainstorm auto-chain (vision → arch → SD).
+ * This module retains only the scoring/grouping logic used by /distill refine.
  */
 
-import { createClient } from '@supabase/supabase-js';
-import dotenv from 'dotenv';
-
-dotenv.config();
-
 /**
- * Group scored items by target application for SD creation.
+ * Group scored items by target application for analysis.
  * @param {Array<{item_index: number, composite: number, recommendation: string}>} scoredItems
  * @param {Array} originalItems - Items with metadata
  * @returns {Array<{application: string, items: Array}>}
@@ -48,149 +33,40 @@ export function groupForPromotion(scoredItems, originalItems) {
 }
 
 /**
- * Generate a Research SD title from a group of items.
- * @param {string} application
- * @param {Array} items
- * @returns {string}
- */
-function generateSDTitle(application, items) {
-  const appLabels = {
-    ehg_engineer: 'EHG Engineer',
-    ehg_app: 'EHG App',
-    new_venture: 'New Ventures',
-  };
-  const label = appLabels[application] || application;
-
-  if (items.length === 1) {
-    return `Research: ${(items[0].title || 'Untitled').slice(0, 80)}`;
-  }
-
-  // Extract common theme from item titles
-  const intents = [...new Set(items.map(i => i.chairman_intent).filter(Boolean))];
-  const intentLabel = intents.length === 1 ? intents[0] : 'mixed';
-
-  return `Research: ${label} ${intentLabel} items (${items.length} topics)`;
-}
-
-/**
- * Generate a unique SD key for a research SD.
- * @param {string} application
- * @param {number} counter
- * @returns {string}
- */
-function generateSDKey(application, counter) {
-  const appCode = {
-    ehg_engineer: 'ENG',
-    ehg_app: 'APP',
-    new_venture: 'VENT',
-  };
-  const code = appCode[application] || 'RES';
-  const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
-  return `SD-RESEARCH-${code}-${date}-${String(counter).padStart(3, '0')}`;
-}
-
-/**
- * Create a Research SD in the database and link wave items.
- * @param {Object} group - { application, items }
- * @param {number} counter - Unique counter for SD key
- * @param {Object} options
- * @param {import('@supabase/supabase-js').SupabaseClient} options.supabase
- * @param {boolean} [options.dryRun]
- * @returns {Promise<{sd_key: string, title: string, item_count: number}>}
- */
-async function createResearchSD(group, counter, options) {
-  const { supabase, dryRun } = options;
-  const sdKey = generateSDKey(group.application, counter);
-  const title = generateSDTitle(group.application, group.items);
-
-  const sdData = {
-    id: sdKey,
-    sd_key: sdKey,
-    title,
-    description: `Research SD auto-promoted from /distill refine. ${group.items.length} items from ${group.application} scored >= 70 by multi-persona evaluation.`,
-    sd_type: 'documentation',
-    category: 'research',
-    status: 'draft',
-    current_phase: 'LEAD',
-    priority: 'medium',
-    target_application: group.application === 'ehg_app' ? 'EHG' : 'EHG_Engineer',
-    strategic_objectives: group.items.map(i => (i.title || '').slice(0, 200)),
-    key_changes: group.items.map(i => ({
-      description: (i.title || '').slice(0, 200),
-      type: 'research',
-    })),
-    success_criteria: [
-      'Research findings documented',
-      'Build/no-build decision made for each item',
-      'Follow-up SDs created for approved items',
-    ],
-    metadata: {
-      source: 'distill-refine',
-      refine_date: new Date().toISOString(),
-      avg_composite: Math.round(group.items.reduce((sum, i) => sum + i.composite, 0) / group.items.length),
-    },
-  };
-
-  if (dryRun) {
-    return { sd_key: sdKey, title, item_count: group.items.length };
-  }
-
-  const { error: sdErr } = await supabase
-    .from('strategic_directives_v2')
-    .insert(sdData);
-
-  if (sdErr) {
-    console.warn(`  Warning: Could not create research SD ${sdKey}: ${sdErr.message}`);
-    return { sd_key: null, title, item_count: group.items.length, error: sdErr.message };
-  }
-
-  // Link wave items back to the created SD
-  for (const item of group.items) {
-    if (item.wave_item_id) {
-      await supabase
-        .from('roadmap_wave_items')
-        .update({ promoted_to_sd_key: sdKey })
-        .eq('id', item.wave_item_id);
-    }
-  }
-
-  return { sd_key: sdKey, title, item_count: group.items.length };
-}
-
-/**
- * Promote scored items into Research SDs.
+ * Process scored items — all promotion now happens via brainstorm auto-chain.
+ *
+ * Items with brainstorm_session_id already have full SDs created via the
+ * brainstorm-to-SD path (vision → arch → SD). This function logs which items
+ * were promoted via brainstorm and which were skipped by scoring.
+ *
  * @param {Array} scoredItems - Output from refine-score
  * @param {Array} originalItems - Original wave items
  * @param {Object} [options]
- * @param {import('@supabase/supabase-js').SupabaseClient} [options.supabase]
- * @param {boolean} [options.dryRun]
- * @returns {Promise<{ promoted: Array<{sd_key: string, title: string, item_count: number}>, skipped: number }>}
+ * @returns {Promise<{ promoted: Array<{application: string, item_count: number}>, skipped: number }>}
  */
 export async function promote(scoredItems, originalItems, options = {}) {
-  const supabase = options.supabase || createClient(
-    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  );
-
   const groups = groupForPromotion(scoredItems, originalItems);
   const promoted = [];
-  let counter = 1;
 
   for (const group of groups) {
-    // SD-DISTILLTOBRAINSTORM-ORCH-001-B: Skip Research SD for items with brainstorm
-    // Items that went through brainstorm-to-SD path already have SDs
-    const nonBrainstormed = group.items.filter(i => !i.brainstorm_session_id);
-    if (nonBrainstormed.length === 0) {
-      console.log(`  ⏭️  Skipping ${group.application}: all ${group.items.length} items already brainstormed`);
-      continue;
-    }
-    const filteredGroup = { ...group, items: nonBrainstormed };
+    const brainstormed = group.items.filter(i => i.brainstorm_session_id);
+    const notBrainstormed = group.items.filter(i => !i.brainstorm_session_id);
 
-    const result = await createResearchSD(filteredGroup, counter++, {
-      supabase,
-      dryRun: options.dryRun,
+    if (brainstormed.length > 0) {
+      console.log(`  ✅ ${group.application}: ${brainstormed.length} item(s) already have SDs via brainstorm`);
+    }
+
+    if (notBrainstormed.length > 0) {
+      console.log(`  ⚠️  ${group.application}: ${notBrainstormed.length} item(s) scored for promotion but lack brainstorm session`);
+      console.log(`     These items should be processed via /distill brainstorm loop`);
+    }
+
+    promoted.push({
+      application: group.application,
+      item_count: group.items.length,
+      brainstormed: brainstormed.length,
+      pending: notBrainstormed.length,
     });
-    promoted.push(result);
   }
 
   const skipped = scoredItems.filter(s => s.recommendation !== 'promote').length;

--- a/scripts/eva-intake-refine.js
+++ b/scripts/eva-intake-refine.js
@@ -296,10 +296,12 @@ async function runScoring(waves) {
 }
 
 /**
- * Step 4: Research SD Promotion
+ * Step 4: Brainstorm Promotion Analysis
+ * SD-DISTILLTOBRAINSTORM-ORCH-001-C: Research SDs no longer created.
+ * All items go through brainstorm auto-chain (vision → arch → SD).
  */
 async function runPromotion(waves, scoringResults) {
-  header(4, 'Research SD Promotion');
+  header(4, 'Brainstorm Promotion Analysis');
 
   if (skipPromote) {
     console.log('  [SKIPPED] --skip-promote flag set');
@@ -328,29 +330,14 @@ async function runPromotion(waves, scoringResults) {
   }
 
   if (groups.length === 0) {
-    console.log('  No items scored high enough for auto-promotion.');
+    console.log('  No items scored high enough for promotion.');
     return { promoted: [], skipped: allScoredItems.length };
   }
 
-  if (dryRun) {
-    console.log('\n  [DRY RUN] Would create Research SDs:');
-    for (const g of groups) {
-      console.log(`    SD-RESEARCH-${g.application}: ${g.items.length} items`);
-    }
-    return { promoted: groups.map(g => ({ sd_key: '(dry-run)', title: `Research: ${g.application}`, item_count: g.items.length })), skipped: 0 };
-  }
-
-  const result = await promote(allScoredItems, allOriginalItems, {
-    supabase,
-    dryRun,
-  });
+  const result = await promote(allScoredItems, allOriginalItems);
 
   for (const p of result.promoted) {
-    if (p.sd_key) {
-      console.log(`  Created: ${p.sd_key} — "${p.title}" (${p.item_count} items)`);
-    } else {
-      console.log(`  Failed: "${p.title}" — ${p.error}`);
-    }
+    console.log(`  ${p.application}: ${p.brainstormed} brainstormed, ${p.pending} pending brainstorm`);
   }
 
   return result;
@@ -623,8 +610,8 @@ async function main() {
     console.log(`  Scoring: avg composite ${avg}/100`);
   }
   if (promotionResults) {
-    console.log(`  Promoted: ${promotionResults.promoted.length} Research SD(s) created`);
-    console.log(`  Skipped: ${promotionResults.skipped} items below threshold`);
+    console.log(`  Brainstorm groups: ${promotionResults.promoted.length}`);
+    console.log(`  Below threshold: ${promotionResults.skipped} items`);
   }
 
   console.log('');


### PR DESCRIPTION
## Summary
- Remove `createResearchSD`, `generateSDKey`, `generateSDTitle` functions from `refine-promote.js`
- All distill items now go through brainstorm auto-chain (vision → arch → SD) exclusively
- `promote()` function now reports brainstorm status per group instead of creating Research SDs
- Update `eva-intake-refine.js` caller to match new return shape
- Update `distill.md` skill references from "Research SD" to "brainstorm promotion analysis"

## Test plan
- [x] `refine-promote.js` loads and exports correctly
- [x] `eva-intake-refine.js` parses without errors
- [ ] Run `/distill refine` on wave with brainstormed items — verify no Research SDs created
- [ ] Run `/distill refine` on wave with non-brainstormed items — verify warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)