### PR TITLE
test: add unit tests for YouTube digest modules

### DIFF
--- a/lib/eva/__tests__/youtube-relevance-scorer.test.js
+++ b/lib/eva/__tests__/youtube-relevance-scorer.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { scoreVideoRelevance, scoreVideoBatch } from '../youtube-relevance-scorer.js';
+
+// Mock the client-factory module
+vi.mock('../../llm/client-factory.js', () => ({
+  getLLMClient: vi.fn()
+}));
+
+import { getLLMClient } from '../../llm/client-factory.js';
+
+describe('youtube-relevance-scorer', () => {
+  const mockVideo = {
+    title: 'Building AI Agents with LangChain',
+    channel_name: 'Tech Channel',
+    video_id: 'abc123'
+  };
+
+  const mockInterests = [
+    { name: 'AI Automation', keywords: ['ai', 'agents', 'llm', 'automation'] },
+    { name: 'SaaS', keywords: ['saas', 'subscription', 'b2b'] }
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scores a relevant video with high score', async () => {
+    const mockClient = {
+      complete: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          score: 85,
+          venture_tags: ['AI Automation'],
+          reasoning: 'Directly about AI agent development'
+        })
+      })
+    };
+    getLLMClient.mockReturnValue(mockClient);
+
+    const result = await scoreVideoRelevance(mockVideo, mockInterests);
+
+    expect(result.score).toBe(85);
+    expect(result.venture_tags).toEqual(['AI Automation']);
+    expect(result.reasoning).toBe('Directly about AI agent development');
+    expect(mockClient.complete).toHaveBeenCalledOnce();
+  });
+
+  it('clamps score to 0-100 range', async () => {
+    const mockClient = {
+      complete: vi.fn().mockResolvedValue({
+        content: JSON.stringify({ score: 150, venture_tags: [], reasoning: 'test' })
+      })
+    };
+    getLLMClient.mockReturnValue(mockClient);
+
+    const result = await scoreVideoRelevance(mockVideo, mockInterests);
+    expect(result.score).toBe(100);
+  });
+
+  it('returns score 0 on LLM failure', async () => {
+    const mockClient = {
+      complete: vi.fn().mockRejectedValue(new Error('LLM timeout'))
+    };
+    getLLMClient.mockReturnValue(mockClient);
+
+    const result = await scoreVideoRelevance(mockVideo, mockInterests);
+
+    expect(result.score).toBe(0);
+    expect(result.venture_tags).toEqual([]);
+    expect(result.reasoning).toContain('Scoring failed');
+  });
+
+  it('handles non-JSON LLM response', async () => {
+    const mockClient = {
+      complete: vi.fn().mockResolvedValue({
+        content: 'Sorry, I cannot process this request.'
+      })
+    };
+    getLLMClient.mockReturnValue(mockClient);
+
+    const result = await scoreVideoRelevance(mockVideo, mockInterests);
+
+    expect(result.score).toBe(0);
+    expect(result.reasoning).toContain('Scoring failed');
+  });
+
+  it('handles missing venture_tags in response', async () => {
+    const mockClient = {
+      complete: vi.fn().mockResolvedValue({
+        content: JSON.stringify({ score: 60, reasoning: 'Tangentially related' })
+      })
+    };
+    getLLMClient.mockReturnValue(mockClient);
+
+    const result = await scoreVideoRelevance(mockVideo, mockInterests);
+
+    expect(result.score).toBe(60);
+    expect(result.venture_tags).toEqual([]);
+  });
+
+  describe('scoreVideoBatch', () => {
+    it('scores multiple videos sequentially', async () => {
+      let callCount = 0;
+      const mockClient = {
+        complete: vi.fn().mockImplementation(() => {
+          callCount++;
+          return Promise.resolve({
+            content: JSON.stringify({
+              score: callCount * 30,
+              venture_tags: ['AI Automation'],
+              reasoning: `Video ${callCount}`
+            })
+          });
+        })
+      };
+      getLLMClient.mockReturnValue(mockClient);
+
+      const videos = [
+        { ...mockVideo, video_id: 'v1' },
+        { ...mockVideo, video_id: 'v2', title: 'Cooking Show' }
+      ];
+
+      const scores = await scoreVideoBatch(videos, mockInterests);
+
+      expect(scores.size).toBe(2);
+      expect(scores.get('v1').score).toBe(30);
+      expect(scores.get('v2').score).toBe(60);
+    });
+
+    it('handles empty video list', async () => {
+      const scores = await scoreVideoBatch([], mockInterests);
+      expect(scores.size).toBe(0);
+    });
+  });
+});

--- a/lib/integrations/todoist/__tests__/digest-task-creator.test.js
+++ b/lib/integrations/todoist/__tests__/digest-task-creator.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createDigestTasks } from '../digest-task-creator.js';
+
+let mockApiInstance;
+
+vi.mock('@doist/todoist-api-typescript', () => ({
+  TodoistApi: vi.fn(function () { return mockApiInstance; })
+}));
+
+describe('digest-task-creator', () => {
+  const mockDigest = {
+    date: '2026-03-14',
+    videos: [
+      {
+        title: 'AI Agents Deep Dive',
+        channel_name: 'Tech Channel',
+        video_url: 'https://www.youtube.com/watch?v=abc123',
+        relevance_score: 85,
+        venture_tags: ['AI Automation']
+      },
+      {
+        title: 'SaaS Metrics 2026',
+        channel_name: 'Business Channel',
+        video_url: 'https://www.youtube.com/watch?v=def456',
+        relevance_score: 72,
+        venture_tags: ['SaaS']
+      }
+    ]
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.TODOIST_API_TOKEN = 'test-token';
+  });
+
+  it('returns null IDs in dry-run mode', async () => {
+    const result = await createDigestTasks(mockDigest, { dryRun: true });
+
+    expect(result.parentTaskId).toBeNull();
+    expect(result.childTaskIds).toEqual([]);
+  });
+
+  it('creates parent and child tasks in production mode', async () => {
+    mockApiInstance = {
+      getProjects: vi.fn().mockResolvedValue([
+        { id: 'proj1', name: 'EVA' }
+      ]),
+      addTask: vi.fn()
+        .mockResolvedValueOnce({ id: 'parent1' })
+        .mockResolvedValueOnce({ id: 'child1' })
+        .mockResolvedValueOnce({ id: 'child2' })
+    };
+
+    const result = await createDigestTasks(mockDigest, { dryRun: false });
+
+    expect(result.parentTaskId).toBe('parent1');
+    expect(result.childTaskIds).toEqual(['child1', 'child2']);
+
+    // Verify parent task creation
+    expect(mockApiInstance.addTask).toHaveBeenCalledTimes(3);
+    const parentCall = mockApiInstance.addTask.mock.calls[0][0];
+    expect(parentCall.content).toContain('EVA-AUTO');
+    expect(parentCall.content).toContain('2026-03-14');
+    expect(parentCall.projectId).toBe('proj1');
+
+    // Verify child tasks have parentId
+    const childCall = mockApiInstance.addTask.mock.calls[1][0];
+    expect(childCall.parentId).toBe('parent1');
+    expect(childCall.content).toContain('EVA-AUTO');
+  });
+
+  it('throws when project not found', async () => {
+    mockApiInstance = {
+      getProjects: vi.fn().mockResolvedValue([
+        { id: 'proj1', name: 'Other' }
+      ])
+    };
+
+    await expect(createDigestTasks(mockDigest, { dryRun: false }))
+      .rejects.toThrow('Todoist project "EVA" not found');
+  });
+
+  it('throws when no API token', async () => {
+    delete process.env.TODOIST_API_TOKEN;
+
+    await expect(createDigestTasks(mockDigest, { dryRun: false }))
+      .rejects.toThrow('TODOIST_API_TOKEN required');
+  });
+
+  it('uses custom project name', async () => {
+    mockApiInstance = {
+      getProjects: vi.fn().mockResolvedValue([
+        { id: 'proj2', name: 'Custom' }
+      ]),
+      addTask: vi.fn().mockResolvedValue({ id: 'task1' })
+    };
+
+    await createDigestTasks(mockDigest, { dryRun: false, projectName: 'Custom' });
+
+    const parentCall = mockApiInstance.addTask.mock.calls[0][0];
+    expect(parentCall.projectId).toBe('proj2');
+  });
+});


### PR DESCRIPTION
## Summary
- Add 7 unit tests for `youtube-relevance-scorer.js` (LLM scoring happy path, clamping, error handling, non-JSON response, missing fields, batch scoring, empty batch)
- Add 5 unit tests for `digest-task-creator.js` (dry-run mode, production task creation, project not found, missing token, custom project name)
- All 19 tests pass (including 7 existing scanner tests)

SD: SD-LEO-FEAT-EVA-DAILY-YOUTUBE-001

## Test plan
- [x] `npx vitest run lib/eva/__tests__/youtube-relevance-scorer.test.js` — 7 tests pass
- [x] `npx vitest run lib/integrations/todoist/__tests__/digest-task-creator.test.js` — 5 tests pass
- [x] `npx vitest run lib/integrations/youtube/__tests__/subscription-scanner.test.js` — 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)