### PR TITLE
feat: YouTube digest channel config CLI

### DIFF
--- a/lib/integrations/youtube/__tests__/video-metadata.test.js
+++ b/lib/integrations/youtube/__tests__/video-metadata.test.js
@@ -1,30 +1,31 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-vi.mock('googleapis', () => ({
-  google: {
-    youtube: vi.fn()
-  }
-}));
-
-vi.mock('../oauth-manager.js', () => ({
-  getAuthenticatedClient: vi.fn()
-}));
-
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fetchVideoMetadata } from '../video-metadata.js';
-import { google } from 'googleapis';
-import { getAuthenticatedClient } from '../oauth-manager.js';
 
 describe('fetchVideoMetadata', () => {
-  let mockYouTubeClient;
+  const originalEnv = process.env.YOUTUBE_API_KEY;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockYouTubeClient = {
-      videos: { list: vi.fn() }
-    };
-    google.youtube.mockReturnValue(mockYouTubeClient);
-    getAuthenticatedClient.mockResolvedValue({});
+    process.env.YOUTUBE_API_KEY = 'test-api-key';
+    vi.stubGlobal('fetch', vi.fn());
   });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.YOUTUBE_API_KEY = originalEnv;
+    } else {
+      delete process.env.YOUTUBE_API_KEY;
+    }
+    vi.unstubAllGlobals();
+  });
+
+  function mockFetchResponse(data, ok = true, status = 200) {
+    fetch.mockResolvedValue({
+      ok,
+      status,
+      json: () => Promise.resolve(data),
+    });
+  }
 
   it('returns null for empty videoId', async () => {
     expect(await fetchVideoMetadata(null)).toBeNull();
@@ -37,20 +38,24 @@ describe('fetchVideoMetadata', () => {
     expect(await fetchVideoMetadata('toolongvideoidentifier')).toBeNull();
   });
 
+  it('returns null when YOUTUBE_API_KEY not set', async () => {
+    delete process.env.YOUTUBE_API_KEY;
+    expect(await fetchVideoMetadata('dQw4w9WgXcQ')).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('fetches metadata for valid video ID', async () => {
-    mockYouTubeClient.videos.list.mockResolvedValue({
-      data: {
-        items: [{
-          snippet: {
-            title: 'Test Video Title',
-            description: 'A test description',
-            channelTitle: 'Test Channel',
-            tags: ['tag1', 'tag2'],
-            publishedAt: '2026-01-15T10:00:00Z'
-          },
-          contentDetails: { duration: 'PT1H23M45S' }
-        }]
-      }
+    mockFetchResponse({
+      items: [{
+        snippet: {
+          title: 'Test Video Title',
+          description: 'A test description',
+          channelTitle: 'Test Channel',
+          tags: ['tag1', 'tag2'],
+          publishedAt: '2026-01-15T10:00:00Z'
+        },
+        contentDetails: { duration: 'PT1H23M45S' }
+      }]
     });
 
     const result = await fetchVideoMetadata('dQw4w9WgXcQ');
@@ -64,30 +69,34 @@ describe('fetchVideoMetadata', () => {
       publishedAt: '2026-01-15T10:00:00Z'
     });
 
-    expect(mockYouTubeClient.videos.list).toHaveBeenCalledWith({
-      part: ['snippet', 'contentDetails'],
-      id: ['dQw4w9WgXcQ']
-    });
+    expect(fetch).toHaveBeenCalledOnce();
+    expect(fetch.mock.calls[0][0]).toContain('dQw4w9WgXcQ');
+    expect(fetch.mock.calls[0][0]).toContain('test-api-key');
   });
 
   it('returns null when video not found', async () => {
-    mockYouTubeClient.videos.list.mockResolvedValue({ data: { items: [] } });
+    mockFetchResponse({ items: [] });
+    expect(await fetchVideoMetadata('dQw4w9WgXcQ')).toBeNull();
+  });
+
+  it('returns null when items array is missing', async () => {
+    mockFetchResponse({});
     expect(await fetchVideoMetadata('dQw4w9WgXcQ')).toBeNull();
   });
 
   it('returns null on API error (fail-open)', async () => {
-    mockYouTubeClient.videos.list.mockRejectedValue(new Error('Quota exceeded'));
+    mockFetchResponse({}, false, 403);
     expect(await fetchVideoMetadata('dQw4w9WgXcQ')).toBeNull();
   });
 
-  it('returns null on OAuth error (fail-open)', async () => {
-    getAuthenticatedClient.mockRejectedValue(new Error('No stored tokens'));
+  it('returns null on network error (fail-open)', async () => {
+    fetch.mockRejectedValue(new Error('Network error'));
     expect(await fetchVideoMetadata('dQw4w9WgXcQ')).toBeNull();
   });
 
   it('handles missing snippet fields gracefully', async () => {
-    mockYouTubeClient.videos.list.mockResolvedValue({
-      data: { items: [{ snippet: { title: 'Minimal' }, contentDetails: {} }] }
+    mockFetchResponse({
+      items: [{ snippet: { title: 'Minimal' }, contentDetails: {} }]
     });
 
     const result = await fetchVideoMetadata('dQw4w9WgXcQ');
@@ -110,8 +119,8 @@ describe('fetchVideoMetadata', () => {
     ];
 
     for (const { duration, expected } of cases) {
-      mockYouTubeClient.videos.list.mockResolvedValue({
-        data: { items: [{ snippet: { title: 'Test' }, contentDetails: { duration } }] }
+      mockFetchResponse({
+        items: [{ snippet: { title: 'Test' }, contentDetails: { duration } }]
       });
       const result = await fetchVideoMetadata('dQw4w9WgXcQ');
       expect(result.durationSeconds).toBe(expected);

--- a/scripts/eva/youtube-config.js
+++ b/scripts/eva/youtube-config.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * EVA YouTube Channel Configuration Manager
+ * SD: SD-LEO-FEAT-EVA-DAILY-YOUTUBE-001
+ *
+ * Manage YouTube channels for the subscription digest pipeline.
+ *
+ * Usage:
+ *   node scripts/eva/youtube-config.js list
+ *   node scripts/eva/youtube-config.js add --id <channel_id> --name <name> [--threshold N]
+ *   node scripts/eva/youtube-config.js remove --id <channel_id>
+ *   node scripts/eva/youtube-config.js seed
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const SEED_CHANNELS = [
+  { channel_id: 'UCbfYPyITQ-7l4upoX8nvctg', channel_name: 'Two Minute Papers' },
+  { channel_id: 'UCsBjURrPoezykLs9EqgamOA', channel_name: 'Fireship' },
+  { channel_id: 'UCcefcZRL2oaA_uBNeo5UOWg', channel_name: 'Y Combinator' },
+  { channel_id: 'UCNJ1Ymd5yFuUPtn21xtRbbw', channel_name: 'AI Explained' },
+  { channel_id: 'UCJIfeSCssxSC_Dhc5s7woww', channel_name: 'Matt Wolfe' },
+  { channel_id: 'UCLXo7UDZvByw2ixzpQCufnA', channel_name: 'Vox' },
+  { channel_id: 'UCnUYZLuoy1rq1aVMwx4piYg', channel_name: 'Jeff Su' }
+];
+
+async function listChannels() {
+  const { data, error } = await supabase
+    .from('eva_youtube_config')
+    .select('channel_id, channel_name, active, score_threshold, max_recommendations')
+    .order('channel_name');
+
+  if (error) { console.error('Error:', error.message); return; }
+  if (!data?.length) { console.log('No channels configured. Run: node scripts/eva/youtube-config.js seed'); return; }
+
+  console.log(`\n📺 Configured Channels (${data.length}):\n`);
+  for (const ch of data) {
+    const status = ch.active ? '✅' : '❌';
+    console.log(`  ${status} ${ch.channel_name} (${ch.channel_id}) threshold=${ch.score_threshold}`);
+  }
+}
+
+async function addChannel(channelId, channelName, threshold = 70) {
+  const { error } = await supabase
+    .from('eva_youtube_config')
+    .upsert({
+      channel_id: channelId,
+      channel_name: channelName,
+      active: true,
+      score_threshold: threshold,
+      max_recommendations: 15
+    }, { onConflict: 'channel_id' });
+
+  if (error) { console.error('Error:', error.message); return; }
+  console.log(`✅ Added: ${channelName} (${channelId})`);
+}
+
+async function removeChannel(channelId) {
+  const { error } = await supabase
+    .from('eva_youtube_config')
+    .update({ active: false })
+    .eq('channel_id', channelId);
+
+  if (error) { console.error('Error:', error.message); return; }
+  console.log(`❌ Deactivated channel: ${channelId}`);
+}
+
+async function seedChannels() {
+  console.log(`\n🌱 Seeding ${SEED_CHANNELS.length} default channels...\n`);
+
+  for (const ch of SEED_CHANNELS) {
+    await addChannel(ch.channel_id, ch.channel_name);
+  }
+
+  console.log('\n✅ Seed complete. Run "node scripts/eva/youtube-config.js list" to verify.');
+}
+
+// Parse CLI
+const [command, ...rest] = process.argv.slice(2);
+const getFlag = (flag) => { const i = rest.indexOf(flag); return i >= 0 ? rest[i + 1] : undefined; };
+
+switch (command) {
+  case 'list': await listChannels(); break;
+  case 'add': {
+    const id = getFlag('--id');
+    const name = getFlag('--name');
+    const threshold = parseInt(getFlag('--threshold') || '70', 10);
+    if (!id || !name) { console.error('Usage: add --id <channel_id> --name <name> [--threshold N]'); break; }
+    await addChannel(id, name, threshold);
+    break;
+  }
+  case 'remove': {
+    const id = getFlag('--id');
+    if (!id) { console.error('Usage: remove --id <channel_id>'); break; }
+    await removeChannel(id);
+    break;
+  }
+  case 'seed': await seedChannels(); break;
+  default:
+    console.log('Usage: node scripts/eva/youtube-config.js <list|add|remove|seed>');
+}


### PR DESCRIPTION
## Summary
- Add `scripts/eva/youtube-config.js` CLI for managing YouTube channel subscriptions (list, add, remove, seed commands)
- Update `video-metadata.test.js` to use fetch-based mocking instead of googleapis, aligning with RSS-hybrid zero-quota approach

## Context
Part of SD-LEO-FEAT-EVA-DAILY-YOUTUBE-001 (EVA Daily YouTube Subscription Digest). Core pipeline was shipped in PRs #2128 and #2129. This PR adds the channel config management tool and updates tests.

## Test plan
- [x] All 29 YouTube digest tests pass (scanner: 7, scorer: 7, todoist: 5, video-metadata: 10)
- [x] Smoke tests pass (15/15)
- [x] Pipeline dry-run verified with 59 configured channels
- [x] Config CLI verified: list, seed commands work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)