### PR TITLE
feat: user story requirements template and pipeline fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "git:recover": "node scripts/git-commit-recovery.js",
     "lead:dossier": "node scripts/lead-dossier.js",
     "doc:audit": "node scripts/eva/doc-health-audit.mjs",
+    "story:template": "node scripts/story-requirements-template.js",
     "sd:next": "node scripts/sd-next.js",
     "sd:start": "node scripts/sd-start.js",
     "debug:tid": "node scripts/one-time/debug-terminal-identity.mjs",

--- a/scripts/__tests__/story-requirements-template.test.js
+++ b/scripts/__tests__/story-requirements-template.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { execSync } from 'child_process';
+import path from 'path';
+
+describe('story-requirements-template', () => {
+  const scriptPath = path.resolve('scripts/story-requirements-template.js');
+
+  it('outputs structural requirements section', () => {
+    const output = execSync(`node ${scriptPath}`, { encoding: 'utf8', timeout: 15000 });
+    expect(output).toContain('STRUCTURAL REQUIREMENTS');
+    expect(output).toContain('implementation_context');
+    expect(output).toContain('given_when_then');
+    expect(output).toContain('testing_scenarios');
+    expect(output).toContain('architecture_references');
+  });
+
+  it('outputs semantic quality criteria', () => {
+    const output = execSync(`node ${scriptPath}`, { encoding: 'utf8', timeout: 15000 });
+    expect(output).toContain('SEMANTIC QUALITY CRITERIA');
+    expect(output).toContain('Acceptance Criteria Clarity');
+    expect(output).toContain('50%');
+    expect(output).toContain('Benefit Articulation');
+  });
+
+  it('outputs SD type thresholds', () => {
+    const output = execSync(`node ${scriptPath}`, { encoding: 'utf8', timeout: 15000 });
+    expect(output).toContain('SD TYPE THRESHOLDS');
+    expect(output).toContain('infrastructure');
+    expect(output).toContain('feature');
+    expect(output).toContain('security');
+  });
+
+  it('outputs example story', () => {
+    const output = execSync(`node ${scriptPath}`, { encoding: 'utf8', timeout: 15000 });
+    expect(output).toContain('EXAMPLE STORY');
+    expect(output).toContain('user_role');
+    expect(output).toContain('user_benefit');
+  });
+
+  it('outputs validator source files', () => {
+    const output = execSync(`node ${scriptPath}`, { encoding: 'utf8', timeout: 15000 });
+    expect(output).toContain('VALIDATOR SOURCE');
+    expect(output).toContain('user-story-quality-rubric.js');
+  });
+
+  it('shows default threshold without SD-KEY', () => {
+    const output = execSync(`node ${scriptPath}`, { encoding: 'utf8', timeout: 15000 });
+    expect(output).toContain('Default Threshold: 70%');
+  });
+});

--- a/scripts/gate-requirements-seeder.js
+++ b/scripts/gate-requirements-seeder.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+/**
+ * Seed gate_requirements_templates for user story quality validators
+ * SD: SD-LEO-INFRA-USER-STORY-REQUIREMENTS-001
+ *
+ * Idempotent: uses upsert on (gate_type, template_name) unique constraint.
+ *
+ * Usage:
+ *   node scripts/seed-gate-requirements.js
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const templates = [
+  {
+    gate_type: 'userStoryQualityValidation',
+    template_name: 'structural_requirements',
+    is_default: true,
+    requirements_template: {
+      dimension: 'structural',
+      description: 'Database column constraints that must be satisfied for INSERT to succeed',
+      requirements: [
+        { field: 'implementation_context', type: 'text', constraint: 'NOT NULL', min_chars: 20, description: 'Technical approach and file locations' },
+        { field: 'given_when_then', type: 'JSONB array', constraint: 'recommended', min_items: 1, format: '[{given, when, then_clause}]' },
+        { field: 'testing_scenarios', type: 'JSONB array', constraint: 'recommended', min_items: 1, format: '["Run X and verify Y"]' },
+        { field: 'architecture_references', type: 'JSONB array', constraint: 'optional', format: '["Phase 1: Component"]' },
+        { field: 'acceptance_criteria', type: 'JSONB array', constraint: 'min 2 items', description: 'Specific, measurable pass/fail assertions' },
+        { field: 'user_benefit', type: 'text', constraint: 'recommended 400+ chars', description: 'User-centric value proposition' }
+      ]
+    },
+    verification_criteria: {
+      blocking: ['implementation_context NOT NULL'],
+      recommended: ['given_when_then has ≥1 item', 'testing_scenarios has ≥1 item', 'acceptance_criteria has ≥2 items', 'user_benefit ≥400 characters']
+    }
+  },
+  {
+    gate_type: 'userStoryQualityValidation',
+    template_name: 'semantic_quality_rubric',
+    is_default: false,
+    requirements_template: {
+      dimension: 'semantic',
+      description: 'AI-scored quality criteria with weighted dimensions',
+      scoring_scale: '0-10 per criterion, weighted to 0-100 total',
+      criteria: [
+        { name: 'acceptance_criteria_clarity_testability', weight: 50, description: 'Specificity, testability, pass/fail clarity of acceptance criteria', scoring: { low: '0-3: boilerplate, untestable', mid: '4-6: some specific but vague', high: '7-8: mostly testable', excellent: '9-10: fully testable with clear pass/fail' } },
+        { name: 'story_independence_implementability', weight: 30, description: 'Self-containment, INVEST principles', scoring: { low: '0-3: dependent, unclear', mid: '4-6: partial independence', high: '7-8: mostly independent', excellent: '9-10: fully self-contained' } },
+        { name: 'benefit_articulation', weight: 15, description: 'User value proposition clarity and specificity', scoring: { low: '0-3: generic (improve system)', mid: '4-6: some specificity', high: '7-8: clear user value', excellent: '9-10: quantified, persona-specific' } },
+        { name: 'given_when_then_format', weight: 5, description: 'BDD scenario completeness', scoring: { low: '0-3: no scenarios', mid: '4-6: partial', high: '7-8: complete', excellent: '9-10: comprehensive edge cases' } }
+      ]
+    },
+    verification_criteria: {
+      method: 'LLM rubric evaluation',
+      fallback: 'heuristic scoring when LLM unavailable',
+      source_files: ['scripts/modules/rubrics/user-story-quality-rubric.js', 'scripts/modules/user-story-quality-validation.js']
+    }
+  },
+  {
+    gate_type: 'userStoryQualityValidation',
+    template_name: 'sd_type_thresholds',
+    is_default: false,
+    requirements_template: {
+      dimension: 'contextual',
+      description: 'Pass thresholds vary by SD type',
+      thresholds: {
+        documentation: 50, infrastructure: 50, quality: 50,
+        tooling: 55, devops: 55, feature: 55, enhancement: 55, bugfix: 55, fix: 55,
+        database: 68, security: 68,
+        default: 70
+      },
+      special_rules: [
+        { sd_types: ['feature', 'bugfix', 'security'], rule: 'Must include ≥1 human-verifiable acceptance criterion' },
+        { sd_types: ['infrastructure', 'documentation'], rule: 'Technical-only criteria acceptable; "developer" or "system" as user role OK' },
+        { sd_types: ['security'], rule: 'Require threat modeling in acceptance criteria' }
+      ]
+    },
+    verification_criteria: {
+      source_file: 'scripts/modules/handoff/verifiers/plan-to-exec/story-quality.js',
+      lookup_method: 'SD type from strategic_directives_v2.sd_type'
+    }
+  }
+];
+
+async function main() {
+  console.log('Seeding gate_requirements_templates for userStoryQualityValidation...\n');
+
+  for (const tmpl of templates) {
+    const { error } = await supabase
+      .from('gate_requirements_templates')
+      .upsert(tmpl, { onConflict: 'gate_type,template_name' });
+
+    if (error) {
+      console.error(`  ❌ ${tmpl.template_name}: ${error.message}`);
+    } else {
+      console.log(`  ✅ ${tmpl.template_name} (${tmpl.requirements_template.dimension})`);
+    }
+  }
+
+  console.log('\nDone. Query with:');
+  console.log("  SELECT * FROM gate_requirements_templates WHERE gate_type = 'userStoryQualityValidation';");
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/modules/auto-trigger-stories.mjs
+++ b/scripts/modules/auto-trigger-stories.mjs
@@ -776,6 +776,9 @@ export async function autoTriggerStories(supabase, sdId, prdId, options = {}) {
           implementation_context: typeof story.implementation_context === 'object'
             ? JSON.stringify(story.implementation_context)
             : story.implementation_context,
+          given_when_then: Array.isArray(story.given_when_then) ? story.given_when_then : [],
+          testing_scenarios: Array.isArray(story.testing_scenarios) ? story.testing_scenarios : [],
+          architecture_references: Array.isArray(story.architecture_references) ? story.architecture_references : [],
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
         }));
@@ -991,6 +994,9 @@ async function generateUserStoriesFromPRD(supabase, prd, sdId, prdId, personaCon
       status: 'ready',
       acceptance_criteria: transformedCriteria, // Now SD-type-aware
       implementation_context: fr.description || fr.requirement || 'Implementation details to be defined during EXEC phase',
+      given_when_then: [],
+      testing_scenarios: [],
+      architecture_references: [],
       technical_notes: fr.rationale || '',
       created_by: 'PRODUCT_REQUIREMENTS_EXPERT',
       // E2E Test Path (v1.3.0): Auto-populated based on SD type

--- a/scripts/story-requirements-template.js
+++ b/scripts/story-requirements-template.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/**
+ * User Story Requirements Template
+ * SD: SD-LEO-INFRA-USER-STORY-REQUIREMENTS-001
+ *
+ * Outputs all user story quality gate requirements so sessions can write
+ * gate-passing stories on the first attempt.
+ *
+ * Usage:
+ *   npm run story:template              # Show all requirements
+ *   npm run story:template SD-XXX-001   # Show with SD-type-specific thresholds
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+
+const SD_TYPE_THRESHOLDS = {
+  documentation: 50, docs: 50,
+  infrastructure: 50, infra: 50,
+  quality: 50, qa: 50, testing: 50, e2e: 50,
+  tooling: 55, devops: 55,
+  feature: 55, enhancement: 55,
+  bugfix: 55, bug_fix: 55, fix: 55,
+  database: 68, security: 68,
+  default: 70
+};
+
+const RUBRIC_WEIGHTS = {
+  acceptance_criteria_clarity_testability: { weight: 50, label: 'Acceptance Criteria Clarity & Testability' },
+  story_independence_implementability: { weight: 30, label: 'Story Independence & Implementability' },
+  benefit_articulation: { weight: 15, label: 'Benefit Articulation' },
+  given_when_then_format: { weight: 5, label: 'Given-When-Then Format' }
+};
+
+async function getSDType(sdKey) {
+  if (!sdKey) return null;
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data } = await supabase.from('strategic_directives_v2')
+    .select('sd_type').eq('sd_key', sdKey).single();
+  return data?.sd_type || null;
+}
+
+function getThreshold(sdType) {
+  if (!sdType) return SD_TYPE_THRESHOLDS.default;
+  return SD_TYPE_THRESHOLDS[sdType.toLowerCase()] || SD_TYPE_THRESHOLDS.default;
+}
+
+async function main() {
+  const sdKey = process.argv[2];
+  const sdType = sdKey ? await getSDType(sdKey) : null;
+  const threshold = getThreshold(sdType);
+
+  console.log(`
+════════════════════════════════════════════════════════════
+  USER STORY QUALITY REQUIREMENTS
+════════════════════════════════════════════════════════════`);
+
+  if (sdKey) {
+    console.log(`  SD: ${sdKey}`);
+    console.log(`  Type: ${sdType || 'unknown'}`);
+    console.log(`  Pass Threshold: ${threshold}%`);
+  } else {
+    console.log(`  Default Threshold: ${threshold}% (pass --sd-key for type-specific)`);
+  }
+
+  console.log(`
+── STRUCTURAL REQUIREMENTS (NOT NULL) ─────────────────────
+
+  These columns must have values or INSERT will fail:
+
+  ✦ implementation_context  (text, NOT NULL)
+    What: Technical approach and file locations for the story
+    Min: 20+ characters recommended
+    Example: "Modify lib/auth/session.js to add token rotation.
+              Use existing refreshToken() method as base."
+
+  ✦ given_when_then  (JSONB array)
+    What: Structured BDD scenarios
+    Format: [{given: "...", when: "...", then_clause: "..."}]
+    Min: 1 scenario per story, 3+ recommended
+
+  ✦ testing_scenarios  (JSONB array of strings)
+    What: Concrete test cases
+    Format: ["Run X and verify Y", "Submit form with Z..."]
+    Min: 1 scenario, 3+ recommended
+
+  ✦ architecture_references  (JSONB array)
+    What: References to architecture plan phases/components
+    Format: ["Phase 1: Component Name", "API endpoint: /foo"]
+    Note: Populate when architecture plan exists for the SD
+
+── SEMANTIC QUALITY CRITERIA (AI-SCORED) ──────────────────
+
+  Stories are scored 0-100 by an LLM rubric with these weights:
+`);
+
+  for (const [key, info] of Object.entries(RUBRIC_WEIGHTS)) {
+    console.log(`  ${info.label} (${info.weight}%)`);
+  }
+
+  console.log(`
+  Scoring scale per criterion (0-10):
+    0-3: No criteria, boilerplate, or untestable
+    4-6: Some specific elements but vague or missing testability
+    7-8: Most elements specific, testable, and verifiable
+    9-10: Excellent — fully testable with clear pass/fail
+
+── ACCEPTANCE CRITERIA RULES (50% weight) ─────────────────
+
+  ✦ Must be specific, measurable, pass/fail assertions
+    BAD:  "System works correctly"
+    GOOD: "GIVEN user submits form WHEN email is invalid
+           THEN error message 'Invalid email format' appears"
+
+  ✦ For feature/bugfix SDs: ≥1 criterion must be human-verifiable
+    BAD:  "Data saved to database correctly" (all technical)
+    GOOD: "User sees success message after clicking Submit"
+
+  ✦ For infrastructure/docs SDs: Technical-only criteria OK
+    OK:   "Deploy time < 30s" or "Query returns < 100ms"
+
+  ✦ Minimum: 2 acceptance criteria per story
+
+── BENEFIT ARTICULATION RULES (15% weight) ────────────────
+
+  ✦ Must be specific, user-centric, and 400+ characters recommended
+    BAD:  "Improves the system" (generic, <50 chars)
+    GOOD: "Reduces chairman daily triage time from 30-60 minutes
+           of manual YouTube scanning to <60 seconds of digest
+           review, with >70% relevance precision validated by
+           chairman feedback over a 30-day supervised period"
+
+  ✦ For infrastructure SDs: Technical benefits acceptable
+    OK:   "Eliminates 2-3 failed handoff cycles per SD, saving
+           30-90 minutes of rework each time"
+
+── GIVEN-WHEN-THEN RULES (5% weight) ─────────────────────
+
+  ✦ Structured as JSONB array of objects
+  ✦ Each object: {given, when, then_clause}
+  ✦ Map 1:1 with acceptance criteria where possible
+
+── SD TYPE THRESHOLDS ─────────────────────────────────────
+`);
+
+  const types = Object.entries(SD_TYPE_THRESHOLDS)
+    .filter(([k]) => !['default', 'docs', 'infra', 'qa', 'e2e', 'bug_fix'].includes(k));
+
+  for (const [type, thresh] of types) {
+    const marker = sdType && type === sdType.toLowerCase() ? ' ◄ THIS SD' : '';
+    console.log(`  ${type.padEnd(18)} ${thresh}%${marker}`);
+  }
+
+  console.log(`
+── EXAMPLE STORY (Scoring 80%+) ───────────────────────────
+
+  title: "View Story Requirements Before Writing"
+  user_role: "LEO Protocol session (Claude Code agent)"
+  user_want: "run npm run story:template to see all quality
+              requirements before writing stories"
+  user_benefit: "First-attempt PLAN-TO-EXEC handoff pass rate
+                 increases from ~30% to >80% by eliminating
+                 discovery-through-failure loops, saving
+                 30-90 minutes of rework per SD"
+  acceptance_criteria:
+    - "GIVEN template command exists WHEN running
+       npm run story:template THEN output displays all
+       structural constraints (NOT NULL columns, min chars)"
+    - "GIVEN command is run THEN semantic quality criteria
+       listed with minimum score expectations"
+  given_when_then:
+    - {given: "template command exists",
+       when: "running npm run story:template",
+       then_clause: "output displays all structural constraints"}
+  testing_scenarios:
+    - "Run npm run story:template with no args, verify output"
+    - "Run npm run story:template SD-XXX, verify thresholds"
+  implementation_context: "Create scripts/story-requirements-
+    template.js. Read curated requirements from hardcoded
+    summary. Accept optional SD-KEY argument."
+
+── VALIDATOR SOURCE ───────────────────────────────────────
+
+  Gate:   userStoryQualityValidation (PLAN-TO-EXEC)
+  Rubric: scripts/modules/rubrics/user-story-quality-rubric.js
+  Verifier: scripts/modules/handoff/verifiers/plan-to-exec/story-quality.js
+  Validator: scripts/modules/user-story-quality-validation.js
+
+════════════════════════════════════════════════════════════`);
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `npm run story:template [SD-KEY]` command that outputs all user story quality gate requirements (structural, semantic, contextual) before writing stories
- Fix pipeline data-mapping bug in `auto-trigger-stories.mjs` that dropped `given_when_then`, `testing_scenarios`, and `architecture_references` columns during INSERT
- Add `gate-requirements-seeder.js` to populate `gate_requirements_templates` with machine-readable requirements for `userStoryQualityValidation`
- 6 unit tests for template command output

SD: SD-LEO-INFRA-USER-STORY-REQUIREMENTS-001

## Test plan
- [x] `npx vitest run scripts/__tests__/story-requirements-template.test.js` — 6 tests pass
- [x] `npm run test:smoke` — 15 tests pass
- [x] `node scripts/gate-requirements-seeder.js` — 3 templates seeded successfully
- [x] `npm run story:template SD-LEO-INFRA-USER-STORY-REQUIREMENTS-001` — outputs complete requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)