### PR TITLE
feat: handoff precheck discoverability and LLM gate skipping

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -229,6 +229,7 @@ export class HandoffOrchestrator {
         sdId,
         sd,
         options,
+        precheckMode: true,
         supabase: this.supabase
       });
 

--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -305,5 +305,11 @@ export async function displayExecutionResult(result, handoffType, sdId) {
         console.log(`   ${line}`);
       });
     }
+    // Auto-suggest precheck command for batch gate evaluation
+    if (handoffType && sdId) {
+      console.log('');
+      console.log('   💡 TIP: Run precheck to see ALL gate failures at once:');
+      console.log(`      node scripts/handoff.js precheck ${handoffType} ${sdId}`);
+    }
   }
 }

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/scope-reduction-verification.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/scope-reduction-verification.js
@@ -431,6 +431,7 @@ export function createScopeReductionVerificationGate(supabase) {
       }
     },
     required: true,
-    weight: 0.6
+    weight: 0.6,
+    llmPowered: true
   };
 }

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/translation-fidelity.js
@@ -157,7 +157,8 @@ export function createTranslationFidelityGate(supabase) {
       }
     },
     required: true,
-    weight: 0.9
+    weight: 0.9,
+    llmPowered: true
   };
 }
 

--- a/scripts/modules/handoff/executors/plan-to-exec/gates/translation-fidelity.js
+++ b/scripts/modules/handoff/executors/plan-to-exec/gates/translation-fidelity.js
@@ -136,6 +136,7 @@ export function createTranslationFidelityGate(supabase) {
       }
     },
     required: true,
-    weight: 0.9
+    weight: 0.9,
+    llmPowered: true
   };
 }

--- a/scripts/modules/handoff/validation/ValidationOrchestrator.js
+++ b/scripts/modules/handoff/validation/ValidationOrchestrator.js
@@ -887,6 +887,17 @@ export class ValidationOrchestrator {
         continue;
       }
 
+      // Skip LLM-powered gates in precheck mode for fast advisory checks
+      if (context.precheckMode && gate.llmPowered) {
+        console.log(`⏭️  Skipping ${gate.name} (LLM gate — evaluated during execute)`);
+        const skipResult = { passed: true, score: 0, maxScore: 0, issues: [], warnings: [`Skipped in precheck mode (LLM gate)`] };
+        results.gateResults[gate.name] = skipResult;
+        results.warnings.push(`${gate.name}: Skipped in precheck mode (LLM gate — run execute for full evaluation)`);
+        if (!results.skippedGates) results.skippedGates = [];
+        results.skippedGates.push(gate.name);
+        continue;
+      }
+
       const gateResult = await this.validateGate(gate.name, gate.validator, context);
       results.gateResults[gate.name] = gateResult;
 


### PR DESCRIPTION
## Summary
- Auto-suggest precheck command when execute handoff fails (eliminates 7+ retry loops)
- Skip LLM-powered gates (TRANSLATION_FIDELITY, SCOPE_REDUCTION) in precheck mode for <5s advisory checks
- Tag LLM-powered gates with `llmPowered: true` metadata
- Protocol sections added to `leo_protocol_sections` for CLAUDE_PLAN.md and CLAUDE_EXEC.md

## Test plan
- [x] Precheck correctly skips LLM gates (verified: "Skipping SCOPE_REDUCTION_VERIFICATION (LLM gate)")
- [x] Failed execute output includes precheck suggestion tip
- [x] Normal execute behavior unchanged (gates still run fully)
- [x] 81/90 handoff tests pass (9 pre-existing failures in dual-generation.test.js, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)