### PR TITLE
feat: improve user stories gate error messaging and JSONB migration

### DIFF
--- a/scripts/migrate-jsonb-stories.js
+++ b/scripts/migrate-jsonb-stories.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Migrate JSONB-embedded user stories to user_stories table
+ * SD: SD-PRD-USER-STORIES-TABLE-ORCH-001
+ *
+ * Extracts stories from product_requirements_v2 JSONB fields
+ * (content.user_stories, metadata.user_stories) and inserts
+ * them into the user_stories table.
+ *
+ * Usage:
+ *   node scripts/migrate-jsonb-stories.js --dry-run   # Preview only
+ *   node scripts/migrate-jsonb-stories.js              # Execute
+ */
+
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
+
+dotenv.config();
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const dryRun = process.argv.includes('--dry-run');
+
+function makeStoryKey(sdId, index) {
+  const prefix = (sdId || 'MIG').replace(/[^A-Z0-9]/gi, '').substring(0, 6).toUpperCase();
+  return `${prefix}:US-${String(index + 1).padStart(3, '0')}`;
+}
+
+async function main() {
+  console.log(`\nMigrate JSONB Stories → user_stories table`);
+  console.log(`Mode: ${dryRun ? 'DRY-RUN (no changes)' : 'EXECUTE'}\n`);
+
+  // Find PRDs with JSONB-embedded stories
+  const { data: prds, error } = await supabase
+    .from('product_requirements_v2')
+    .select('id, directive_id, title, content, metadata');
+
+  if (error) { console.error('Query error:', error.message); return; }
+
+  let totalFound = 0;
+  let totalMigrated = 0;
+  let totalSkipped = 0;
+
+  for (const prd of prds || []) {
+    const jsonbStories = prd.content?.user_stories || prd.metadata?.user_stories || prd.content?.stories || [];
+    if (!Array.isArray(jsonbStories) || jsonbStories.length === 0) continue;
+
+    // Check if stories already exist in table for this PRD
+    const { data: existing } = await supabase
+      .from('user_stories')
+      .select('id')
+      .eq('prd_id', prd.id)
+      .limit(1);
+
+    if (existing?.length > 0) {
+      console.log(`  SKIP ${prd.title} — stories already in table`);
+      totalSkipped += jsonbStories.length;
+      continue;
+    }
+
+    console.log(`  ${prd.title}: ${jsonbStories.length} stories`);
+    totalFound += jsonbStories.length;
+
+    if (dryRun) continue;
+
+    // Transform and insert
+    const rows = jsonbStories.map((s, i) => ({
+      id: randomUUID(),
+      story_key: s.story_key || makeStoryKey(prd.directive_id, i),
+      prd_id: prd.id,
+      sd_id: prd.directive_id,
+      title: s.title || `Story ${i + 1}`,
+      user_role: s.user_role || 'System user',
+      user_want: s.user_want || s.description || 'to be defined',
+      user_benefit: s.user_benefit || s.benefit || 'Improves system functionality',
+      story_points: s.story_points || 3,
+      priority: s.priority === 'must_have' ? 'critical' : (s.priority || 'critical'),
+      status: 'ready',
+      acceptance_criteria: Array.isArray(s.acceptance_criteria) ? s.acceptance_criteria : [],
+      implementation_context: s.implementation_context || s.description || 'Implementation details from JSONB migration',
+      given_when_then: Array.isArray(s.given_when_then) ? s.given_when_then : [],
+      testing_scenarios: Array.isArray(s.testing_scenarios) ? s.testing_scenarios : [],
+      created_by: 'JSONB_MIGRATION'
+    }));
+
+    const { error: insertErr } = await supabase.from('user_stories').upsert(rows, { onConflict: 'story_key' });
+
+    if (insertErr) {
+      console.log(`    ERROR: ${insertErr.message}`);
+    } else {
+      totalMigrated += rows.length;
+      console.log(`    Migrated ${rows.length} stories`);
+    }
+  }
+
+  console.log(`\nSummary:`);
+  console.log(`  Found in JSONB: ${totalFound}`);
+  console.log(`  Already in table: ${totalSkipped}`);
+  console.log(`  Migrated: ${dryRun ? '(dry-run)' : totalMigrated}`);
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-1-plan-to-exec.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-1-plan-to-exec.js
@@ -42,6 +42,23 @@ export function registerGate1Validators(registry) {
     }
 
     if (stories.length === 0) {
+      // SD-PRD-USER-STORIES-TABLE-ORCH-001: Distinguish missing vs misplaced stories
+      const jsonbLocations = [];
+      if (prd?.content?.user_stories?.length > 0) jsonbLocations.push('prd.content.user_stories');
+      if (prd?.metadata?.user_stories?.length > 0) jsonbLocations.push('prd.metadata.user_stories');
+      if (prd?.content?.stories?.length > 0) jsonbLocations.push('prd.content.stories');
+
+      if (jsonbLocations.length > 0) {
+        return {
+          passed: false, score: 0, max_score: 100,
+          issues: [
+            `User stories found in PRD JSONB (${jsonbLocations.join(', ')}) but NOT in user_stories table.`,
+            'REMEDIATION: Run autoTriggerStories() or use add-prd-to-database.js (canonical path) to populate user_stories table.',
+            'Stories must be in the user_stories table with prd_id and sd_id foreign keys.'
+          ]
+        };
+      }
+
       return { passed: false, score: 0, max_score: 100, issues: ['No user stories found in PRD or user_stories table'] };
     }
 


### PR DESCRIPTION
## Summary
- Update PLAN-TO-EXEC gate to distinguish between missing user stories and stories embedded in PRD JSONB (with clear remediation: use add-prd-to-database.js)
- Add `migrate-jsonb-stories.js` script to extract JSONB-embedded stories into `user_stories` table (idempotent, --dry-run support)
- Add protocol section documenting two-step PRD+stories requirement

SD: SD-PRD-USER-STORIES-TABLE-ORCH-001

## Test plan
- [x] `npm run test:smoke` — 15 tests pass
- [x] Gate error distinguishes missing vs JSONB-embedded stories
- [x] Protocol section added to leo_protocol_sections for CLAUDE_PLAN.md
- [x] Gate requirements templates seeded (from previous SD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)