### PR TITLE
fix: orchestrator child claim verification gate

### DIFF
--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -1253,10 +1253,14 @@ With the preflight:
 
 When starting work on an orchestrator SD:
 1. **Run preflight automatically** - `node scripts/orchestrator-preflight.js SD-XXX-001`
-2. **Display the requirements** - Let the user see child workflow requirements
-3. **Proceed with full workflow** - No confirmation needed; full LEAD→PLAN→EXEC for each child is the ONLY correct path
+2. **Display the requirements** - Let the user see child workflow requirements and claim status
+3. **Identify the target child** - Pick the first unclaimed, non-completed child from preflight output
+4. **Claim the child explicitly** - Run `npm run sd:start <CHILD-SD-ID>` to formally claim it. **Do NOT skip this step.** The parent's `sd:start` auto-routing does NOT substitute for an explicit child claim.
+5. **Proceed with full workflow** - Full LEAD→PLAN→EXEC for the claimed child
 
-**There is no question about how to proceed.** Children are independent SDs requiring full workflow. The preflight is for visibility, not approval.
+**CRITICAL**: `sd:start` on the parent may auto-route to a child's worktree. Treat this as a recommendation, NOT a commitment. Always verify the child is unclaimed before starting work. If `sd:start` output shows `WORKTREE_CWD` for a child you did not explicitly claim, **STOP and run `sd:start` on the child first.**
+
+Children are independent SDs requiring full workflow. The preflight is for visibility, not approval.
 
 ### Child SD Pre-Work Validation (MANDATORY)
 

--- a/scripts/orchestrator-preflight.js
+++ b/scripts/orchestrator-preflight.js
@@ -456,15 +456,26 @@ async function printPreflightReport(sd, children, detection, validation) {
   console.log('CHILD WORKFLOW REQUIREMENTS (per SD type):');
   console.log('─'.repeat(60));
 
+  // Query active session claims for child claim status
+  const { data: activeClaims } = await supabase
+    .from('claude_sessions')
+    .select('session_id, sd_id')
+    .not('sd_id', 'is', null)
+    .in('status', ['active', 'busy', 'idle']);
+  const claimMap = new Map((activeClaims || []).map(c => [c.sd_id, c.session_id]));
+
   for (const child of children) {
     const profile = getProfile(child.sd_type);
     const handoffs = await getHandoffCount(child.sd_key || child.id);
     const prdExists = await hasPRD(child.sd_key || child.id);
+    const claimedBy = claimMap.get(child.sd_key) || claimMap.get(child.id);
+    const claimStatus = claimedBy ? `⚠️  CLAIMED (${claimedBy.substring(0, 20)})` : '🟢 unclaimed';
 
     console.log('');
     console.log(`${child.sd_key || child.id} (${child.sd_type || 'feature'})`);
     console.log(`  Title: ${child.title.substring(0, 50)}${child.title.length > 50 ? '...' : ''}`);
     console.log(`  Status: ${formatStatus(child.status)}`);
+    console.log(`  Claim: ${claimStatus}`);
     console.log(`  PRD: ${profile.prd_required ? (prdExists ? '✅ exists' : '❌ REQUIRED') : '⏭️ skip'}`);
     console.log(`  E2E: ${profile.e2e_required ? 'required' : 'skip'}`);
     console.log(`  Handoffs: ${handoffs}/${profile.min_handoffs} min`);


### PR DESCRIPTION
## Summary
- Add claim status per child to `orchestrator-preflight.js` output (queries `claude_sessions`)
- Update `leo.md` orchestrator workflow: explicit "run `sd:start` on child" step
- Warn that parent auto-routing to child worktree is a recommendation, not a commitment

## Root Cause (RCA)
`sd:start` on parent orchestrator auto-routes to child worktree, creating an implicit claim with no defense-in-depth verification. `orchestrator-preflight.js` had zero claim awareness.

## Test plan
- [x] `orchestrator-preflight.js` shows claim status per child
- [x] `leo.md` includes explicit child claim step in orchestrator workflow
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)