### PR TITLE
fix: auto-slug regex preserves word boundaries from special chars

### DIFF
--- a/scripts/eva/markdown-to-sections-parser.mjs
+++ b/scripts/eva/markdown-to-sections-parser.mjs
@@ -90,7 +90,7 @@ export function parseMarkdownToSections(content, headingToKeyMap) {
       // If still no match, use a slug of the heading
       if (!currentKey) {
         currentKey = heading
-          .replace(/[^a-z0-9\s]/g, '')
+          .replace(/[^a-z0-9\s]/g, ' ')
           .replace(/\s+/g, '_')
           .substring(0, 50);
       }


### PR DESCRIPTION
## Summary
- Fix Level 3 auto-slug fallback regex in `markdown-to-sections-parser.mjs`
- Change `replace(/[^a-z0-9\s]/g, '')` → `replace(/[^a-z0-9\s]/g, ' ')` 
- Special chars now become word boundaries instead of being stripped
- Fixes: "UI/UX Wireframes" → `ui_ux_wireframes` (was `uiux_wireframes`)
- Resolves silent vision quality trigger failures (0/10 sections matched)

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Verify vision documents with special-char headings now match standard keys

SD: SD-VISION-SECTIONS-JSONB-FORMAT-ORCH-001-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)