### PR TITLE
fix: auto-slug regex and vision quality trigger diagnostics

### DIFF
--- a/database/migrations/20260315_vision_quality_trigger_diagnostics.sql
+++ b/database/migrations/20260315_vision_quality_trigger_diagnostics.sql
@@ -1,0 +1,87 @@
+-- SD-VISION-SECTIONS-JSONB-FORMAT-ORCH-001-B: Add diagnostic key output to vision quality trigger
+-- Shows which section keys were found vs expected when validation fails
+
+CREATE OR REPLACE FUNCTION trg_eva_vision_quality_check()
+RETURNS TRIGGER AS $$
+DECLARE
+  issues JSONB := '[]'::jsonb;
+  passed BOOLEAN := TRUE;
+  content_len INTEGER;
+  standard_count INTEGER := 0;
+  empty_section_count INTEGER := 0;
+  section_key TEXT;
+  section_value TEXT;
+  should_recalculate BOOLEAN := FALSE;
+  v_standard_keys TEXT[] := ARRAY[
+    'executive_summary', 'problem_statement', 'success_criteria',
+    'personas', 'out_of_scope', 'evolution_plan',
+    'ui_ux_wireframes', 'technical_approach', 'success_metrics',
+    'competitive_landscape'
+  ];
+  v_found_keys TEXT[] := '{}';
+  v_actual_keys TEXT[];
+BEGIN
+  -- Skip if quality_checked is already set (avoid infinite loop)
+  IF TG_OP = 'UPDATE' AND OLD.quality_checked IS NOT NULL AND NEW.sections IS NOT DISTINCT FROM OLD.sections THEN
+    RETURN NEW;
+  END IF;
+
+  -- Check 1: Content length >= 500 chars
+  content_len := length(COALESCE(NEW.content, ''));
+  IF content_len < 500 THEN
+    passed := FALSE;
+    issues := issues || jsonb_build_object(
+      'check', 'content_length',
+      'message', format('Content is %s chars (minimum 500). Vision docs require substantive narrative.', content_len)
+    );
+  END IF;
+
+  -- Check 2: Standard sections >= 8 of 10
+  IF NEW.sections IS NOT NULL AND jsonb_typeof(NEW.sections) = 'object' THEN
+    -- Collect actual keys for diagnostics
+    SELECT array_agg(k) INTO v_actual_keys FROM jsonb_object_keys(NEW.sections) AS k;
+
+    FOREACH section_key IN ARRAY v_standard_keys LOOP
+      IF NEW.sections ? section_key THEN
+        standard_count := standard_count + 1;
+        v_found_keys := array_append(v_found_keys, section_key);
+        -- Check 3: No empty sections (each >= 50 chars)
+        IF length(COALESCE(NEW.sections->>section_key, '')) < 50 THEN
+          empty_section_count := empty_section_count + 1;
+        END IF;
+      END IF;
+    END LOOP;
+
+    IF standard_count < 8 THEN
+      passed := FALSE;
+      issues := issues || jsonb_build_object(
+        'check', 'section_coverage',
+        'message', format('Only %s of 10 standard sections present (minimum 8).', standard_count),
+        'found_keys', to_jsonb(v_found_keys),
+        'actual_keys', to_jsonb(COALESCE(v_actual_keys, '{}'::TEXT[])),
+        'expected_keys', to_jsonb(v_standard_keys)
+      );
+    END IF;
+
+    IF empty_section_count > 0 THEN
+      passed := FALSE;
+      issues := issues || jsonb_build_object(
+        'check', 'section_content',
+        'message', format('%s section(s) have less than 50 chars.', empty_section_count)
+      );
+    END IF;
+  ELSE
+    passed := FALSE;
+    issues := issues || jsonb_build_object(
+      'check', 'sections_missing',
+      'message', 'Sections JSONB is NULL. Vision docs require structured sections.'
+    );
+  END IF;
+
+  NEW.quality_checked := passed;
+  NEW.quality_issues := issues;
+  NEW.quality_checked_at := NOW();
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/scripts/eva/__tests__/markdown-to-sections-parser.test.js
+++ b/scripts/eva/__tests__/markdown-to-sections-parser.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { parseMarkdownToSections } from '../markdown-to-sections-parser.mjs';
+
+describe('markdown-to-sections-parser auto-slug', () => {
+  it('converts UI/UX Wireframes to ui_ux_wireframes (not uiux_wireframes)', () => {
+    const md = `# Vision
+## UI/UX Wireframes
+Some wireframe content here that is relevant.
+`;
+    const sections = parseMarkdownToSections(md);
+    const keys = Object.keys(sections);
+    expect(keys).toContain('ui_ux_wireframes');
+    expect(keys).not.toContain('uiux_wireframes');
+  });
+
+  it('converts R&D Strategy to r_d_strategy', () => {
+    const md = `# Vision
+## R&D Strategy
+Research and development approach.
+`;
+    const sections = parseMarkdownToSections(md);
+    const keys = Object.keys(sections);
+    expect(keys).toContain('r_d_strategy');
+  });
+
+  it('handles standard headings via mapping', () => {
+    const md = `# Vision
+## Executive Summary
+This is the executive summary content.
+## Problem Statement
+This is the problem statement content.
+`;
+    const sections = parseMarkdownToSections(md);
+    expect(sections).toHaveProperty('executive_summary');
+    expect(sections).toHaveProperty('problem_statement');
+  });
+
+  it('trims leading/trailing underscores from slugs', () => {
+    const md = `# Vision
+## --Special Heading--
+Content here.
+`;
+    const sections = parseMarkdownToSections(md);
+    const keys = Object.keys(sections);
+    // Should not start or end with underscore
+    for (const key of keys) {
+      if (key === 'vision') continue;
+      expect(key).not.toMatch(/^_|_$/);
+    }
+  });
+});

--- a/scripts/eva/markdown-to-sections-parser.mjs
+++ b/scripts/eva/markdown-to-sections-parser.mjs
@@ -88,10 +88,13 @@ export function parseMarkdownToSections(content, headingToKeyMap) {
       }
 
       // If still no match, use a slug of the heading
+      // SD-VISION-SECTIONS-JSONB-FORMAT-ORCH-001-B: Replace special chars with space (not empty)
+      // so "UI/UX Wireframes" → "ui ux wireframes" → "ui_ux_wireframes" (not "uiux_wireframes")
       if (!currentKey) {
         currentKey = heading
-          .replace(/[^a-z0-9\s]/g, '')
+          .replace(/[^a-z0-9\s]/g, ' ')
           .replace(/\s+/g, '_')
+          .replace(/^_|_$/g, '')
           .substring(0, 50);
       }
 


### PR DESCRIPTION
## Summary
- Fix auto-slug regex in `markdown-to-sections-parser.mjs` to convert special characters to word boundaries instead of stripping them (`UI/UX Wireframes` -> `ui_ux_wireframes` not `uiux_wireframes`)
- Add diagnostic output to vision quality trigger showing `found_keys`, `actual_keys`, `expected_keys` when section coverage fails
- 4 unit tests for parser slug generation

SD: SD-VISION-SECTIONS-JSONB-FORMAT-ORCH-001-B

## Test plan
- [x] `npx vitest run scripts/eva/__tests__/markdown-to-sections-parser.test.js` — 4 tests pass
- [x] `npm run test:smoke` — 15 tests pass
- [x] Migration executed on Supabase — trigger function updated with diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)