### PR TITLE
fix: remove Method 3 marker file fallback from terminal identity

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -23,7 +23,7 @@
  */
 
 import { execSync } from 'child_process';
-import { readFileSync, readdirSync, statSync } from 'fs';
+import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import crypto from 'crypto';
@@ -116,25 +116,10 @@ function findClaudeCodePid() {
     console.log('[terminal-identity] Process scan found no matching process');
   }
 
-  // Method 3: Fallback — read newest PID marker file from SessionStart hook.
-  // SD-MAN-GEN-DESC-FES-INHERITS-001 (FR-2): When tree walk and process scan
-  // both fail, read the most recent pid-*.json marker and verify PID liveness.
-  try {
-    const markerDir = resolve(__dirname, '../.claude/session-identity');
-    const markers = readdirSync(markerDir)
-      .filter(f => /^pid-\d+\.json$/.test(f))
-      .map(f => ({ name: f, mtime: statSync(resolve(markerDir, f)).mtimeMs }))
-      .sort((a, b) => b.mtime - a.mtime);
-    for (const m of markers) {
-      const pid = m.name.match(/^pid-(\d+)\.json$/)[1];
-      try { process.kill(Number(pid), 0); } catch { continue; }
-      console.log(`[terminal-identity] Marker file resolved Claude Code PID: ${pid}`);
-      _cachedCCPid = pid;
-      return _cachedCCPid;
-    }
-  } catch {
-    // Marker directory missing or unreadable — fall through
-  }
+  // Method 3 REMOVED (SD-LEO-FIX-DETERMINISTIC-FLEET-SESSION-001):
+  // Marker file fallback picked the newest alive PID — the same file for all
+  // sessions on the same machine — causing terminal_id collisions. Removed so
+  // sessions fall through to unique-per-process identifiers (win-pid-N).
 
   // Negative cache: remember that lookup failed so we don't retry expensive scans
   _cachedCCPid = null;


### PR DESCRIPTION
## Summary
- Remove broken Method 3 (marker file fallback) from `findClaudeCodePid()` in `lib/terminal-identity.js`
- Method 3 picked the newest alive PID marker — same file for all sessions — causing `terminal_id` collisions
- Sessions now fall through to unique `win-pid-N` identifiers instead of sharing wrong identity
- Removes unused `readdirSync`/`statSync` imports

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Verify multiple Claude Code sessions get unique `terminal_id` values
- [ ] Verify `claude_sessions` has no duplicate `terminal_id` entries

SD: SD-LEO-FIX-DETERMINISTIC-FLEET-SESSION-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)