### PR TITLE
feat: /prove interactive venture proving companion

### DIFF
--- a/.claude/skills/prove.md
+++ b/.claude/skills/prove.md
@@ -1,0 +1,320 @@
+# /prove — Interactive Venture Proving Companion
+
+**Trigger**: User types `/prove`
+
+## Instructions
+
+This skill wraps the venture proving companion (scripts/venture-proving-companion.js) in a guided, menu-driven CLI experience. ALL user interaction MUST use AskUserQuestion. NEVER auto-advance past a gate — the Chairman always decides.
+
+### Step 1: Detect Context
+
+Query for active proving runs and session state:
+
+```bash
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+(async () => {
+  // Check session metadata for sticky venture
+  const { data: sessions } = await supabase.from('claude_sessions')
+    .select('metadata')
+    .eq('status', 'active')
+    .order('heartbeat_at', { ascending: false })
+    .limit(1);
+  const stickyVenture = sessions?.[0]?.metadata?.proving_venture_id;
+
+  // Check for active proving runs (journal entries)
+  const { data: runs } = await supabase.rpc('get_proving_run_summary')
+    .catch(() => ({ data: null }));
+
+  // Fallback: query journal directly
+  if (!runs) {
+    const { data: journal } = await supabase.from('stage_proving_journal')
+      .select('venture_id, stage_number')
+      .order('created_at', { ascending: false })
+      .limit(100);
+
+    // Group by venture
+    const grouped = {};
+    for (const j of (journal || [])) {
+      grouped[j.venture_id] = grouped[j.venture_id] || [];
+      grouped[j.venture_id].push(j.stage_number);
+    }
+
+    const activeRuns = Object.entries(grouped).map(([vid, stages]) => ({
+      venture_id: vid,
+      stages_assessed: stages.length,
+      max_stage: Math.max(...stages)
+    }));
+
+    console.log('ACTIVE_RUNS=' + JSON.stringify(activeRuns));
+  } else {
+    console.log('ACTIVE_RUNS=' + JSON.stringify(runs));
+  }
+
+  console.log('STICKY_VENTURE=' + (stickyVenture || 'none'));
+
+  // Get ventures for selector
+  const { data: ventures } = await supabase.from('ventures')
+    .select('id, name, venture_name, current_lifecycle_stage')
+    .order('current_lifecycle_stage', { ascending: false })
+    .limit(10);
+  console.log('VENTURES=' + JSON.stringify(ventures));
+})();
+"
+```
+
+### Step 2: Show Main Menu
+
+**If an active run exists** (ACTIVE_RUNS has entries):
+
+Use AskUserQuestion:
+```javascript
+{
+  "questions": [{
+    "question": "You have an active proving run. What would you like to do?",
+    "header": "Venture Proving Companion",
+    "multiSelect": false,
+    "options": [
+      {"label": "Resume Run (Recommended)", "description": "<venture name> — <N>/25 stages assessed, next gate is <G>"},
+      {"label": "Review Pending Decisions", "description": "<M> stages assessed but awaiting your decision"},
+      {"label": "View Status", "description": "See full progress, gap breakdown, and decisions so far"},
+      {"label": "Start New Venture", "description": "Begin a proving run on a different venture"},
+      {"label": "Generate Report", "description": "Summary of what has been assessed so far"}
+    ]
+  }]
+}
+```
+
+**If no active run:**
+
+Use AskUserQuestion:
+```javascript
+{
+  "questions": [{
+    "question": "No active proving run. What would you like to do?",
+    "header": "Venture Proving Companion",
+    "multiSelect": false,
+    "options": [
+      {"label": "Start Proving Run (Recommended)", "description": "Pick a venture and begin the 25-stage assessment. First gate is at Stage 3."},
+      {"label": "View Past Runs", "description": "Browse completed proving run reports"}
+    ]
+  }]
+}
+```
+
+### Step 3: Venture Selector (if starting or switching)
+
+Use the `rankVentures()` function from `scripts/prove-helpers.cjs` to rank ventures.
+
+```bash
+node -e "
+require('dotenv').config();
+const { rankVentures } = require('./scripts/prove-helpers.cjs');
+// ... query ventures and journal data, then call rankVentures()
+"
+```
+
+Present ventures via AskUserQuestion:
+```javascript
+{
+  "questions": [{
+    "question": "Select a venture for the proving run:",
+    "header": "Venture Selector",
+    "multiSelect": false,
+    "options": [
+      // For each ranked venture:
+      {"label": "<venture name> (Recommended)", "description": "<rationale from rankVentures>"},
+      {"label": "<venture name>", "description": "<rationale>"}
+    ]
+  }]
+}
+```
+
+After selection, store in session metadata:
+```bash
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+supabase.from('claude_sessions')
+  .update({ metadata: { proving_venture_id: '<selected-venture-id>', proving_last_gate: 0 } })
+  .eq('status', 'active')
+  .order('heartbeat_at', { ascending: false })
+  .limit(1)
+  .then(() => console.log('Venture stored in session'));
+"
+```
+
+### Step 4: Gate Assessment
+
+Use `detectNextGate()` from `scripts/prove-helpers.cjs` to determine the next gate segment.
+
+```bash
+node -e "
+const { detectNextGate } = require('./scripts/prove-helpers.cjs');
+// ... query journal for this venture, call detectNextGate()
+"
+```
+
+Then run the assessment:
+```bash
+node scripts/venture-proving-companion.js assess <venture-id> --from <N> --to-gate <M>
+```
+
+Display the results as inline text (gap counts, severity, recommendation).
+
+### Step 5: Decision Prompt (ALWAYS — NEVER skip this)
+
+After EVERY gate assessment, present the decision prompt via AskUserQuestion:
+
+```javascript
+{
+  "questions": [
+    {
+      "question": "Gate <N> Assessment Complete. <gap_count> gaps found (<blocker_count> blockers). Recommendation: <RECOMMENDATION>. What is your decision?",
+      "header": "Gate <N> Decision",
+      "multiSelect": false,
+      "options": [
+        {"label": "Proceed", "description": "Record 'proceed' and continue to next gate segment. Gaps tracked but not blocking."},
+        {"label": "Fix First", "description": "Pause here. <complexity_assessment>. Will route to /brainstorm for complex gaps or quick-fix for simple ones."},
+        {"label": "Skip", "description": "Mark this gate as skipped. Move to next gate without recording gap resolution."},
+        {"label": "Defer", "description": "Park this venture. Return to main menu. You can resume later."}
+      ]
+    },
+    {
+      "question": "Any notes for this decision? (optional)",
+      "header": "Chairman Notes",
+      "multiSelect": false,
+      "options": [
+        {"label": "No notes", "description": "Just record the decision"},
+        {"label": "Add notes", "description": "I'll type my reasoning"}
+      ]
+    }
+  ]
+}
+```
+
+If "Add notes" selected, use AskUserQuestion with a free-text question to capture the note.
+
+### Step 6: Record Decision
+
+Write the chairman decision to the journal:
+
+```bash
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+supabase.from('stage_proving_journal')
+  .update({ chairman_decision: '<decision>', journal_notes: '<notes or null>' })
+  .eq('venture_id', '<venture-id>')
+  .gte('stage_number', <from>)
+  .lte('stage_number', <to-gate>)
+  .then(({error}) => console.log(error ? 'Error: ' + error.message : 'Decision recorded'));
+"
+```
+
+### Step 7: Handle Decision Outcome
+
+**If Proceed**: Go back to Step 4 for the next gate segment.
+
+**If Fix First**: Assess gap complexity using `assessGapComplexity()` from prove-helpers.cjs.
+
+- **Complex gaps**: Use AskUserQuestion:
+  ```javascript
+  {
+    "questions": [{
+      "question": "These gaps need architectural thinking. How would you like to remediate?",
+      "header": "Remediation",
+      "multiSelect": false,
+      "options": [
+        {"label": "Start Brainstorm (Recommended)", "description": "<N> blocker/major gaps. /brainstorm will generate vision + arch + SD with proper governance."},
+        {"label": "Create Quick-Fix", "description": "Skip governance for a fast inline fix (only if truly simple)"},
+        {"label": "Skip Remediation", "description": "Just record fix-first, handle it manually later"}
+      ]
+    }]
+  }
+  ```
+
+  If "Start Brainstorm" selected:
+  1. Build brainstorm context using `buildBrainstormContext()` from prove-helpers.cjs
+  2. Store proving return state in session metadata: `proving_return: true, proving_last_gate: <current_gate>`
+  3. Invoke the `brainstorm` skill using the Skill tool with the gap context as args
+  4. After brainstorm completes, offer: "Re-assess this gate?" or "Continue to next gate?"
+
+- **Simple gaps**: Offer inline quick-fix or skip.
+
+**If Skip**: Record skip, go to Step 4 for next gate.
+
+**If Defer**: Return to main menu (Step 2).
+
+### Step 8: Post-Completion
+
+When `detectNextGate()` returns `isComplete: true`:
+
+Use AskUserQuestion:
+```javascript
+{
+  "questions": [{
+    "question": "All 25 stages assessed! What would you like to do?",
+    "header": "Proving Run Complete",
+    "multiSelect": false,
+    "options": [
+      {"label": "Persist Specialists (Recommended)", "description": "Create 25 Board of Directors stage experts from this run. Improves future brainstorms."},
+      {"label": "Generate Report", "description": "Full proving run summary with gap breakdown, decision tally, and metrics."},
+      {"label": "Done", "description": "Return to main menu"}
+    ]
+  }]
+}
+```
+
+If "Persist Specialists":
+```bash
+node scripts/venture-proving-companion.js persist-specialists <venture-id>
+```
+
+If "Generate Report":
+```bash
+node scripts/venture-proving-companion.js report <venture-id>
+```
+
+### Brainstorm Return Detection
+
+At the START of /prove, check if returning from a brainstorm detour:
+
+```bash
+node -e "
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+(async () => {
+  const { data } = await supabase.from('claude_sessions')
+    .select('metadata').eq('status', 'active')
+    .order('heartbeat_at', { ascending: false }).limit(1).single();
+  if (data?.metadata?.proving_return) {
+    console.log('BRAINSTORM_RETURN=true');
+    console.log('RETURN_VENTURE=' + data.metadata.proving_venture_id);
+    console.log('RETURN_GATE=' + data.metadata.proving_last_gate);
+  }
+})();
+"
+```
+
+If `BRAINSTORM_RETURN=true`, skip main menu and show:
+```javascript
+{
+  "questions": [{
+    "question": "Welcome back from brainstorm. You were at Gate <N>. What next?",
+    "header": "Proving Run Resume",
+    "multiSelect": false,
+    "options": [
+      {"label": "Re-assess Gate (Recommended)", "description": "Run the assessment again to verify gaps were addressed"},
+      {"label": "Continue to Next Gate", "description": "Skip re-assessment and move forward"}
+    ]
+  }]
+}
+```
+
+Then clear the return flag in session metadata.

--- a/scripts/prove-helpers.cjs
+++ b/scripts/prove-helpers.cjs
@@ -1,0 +1,174 @@
+/**
+ * prove-helpers.cjs — Helper functions for /prove skill
+ * Gate detection, venture ranking, gap formatting, brainstorm context building
+ */
+
+const GATE_STAGES = [3, 5, 10, 22, 25];
+
+/**
+ * Detect the next gate segment to assess based on journal entries
+ * @param {object[]} journalEntries - existing journal entries for this venture
+ * @returns {{ from: number, toGate: number, isComplete: boolean }}
+ */
+function detectNextGate(journalEntries) {
+  if (!journalEntries || journalEntries.length === 0) {
+    return { from: 0, toGate: GATE_STAGES[0], isComplete: false };
+  }
+
+  const maxStage = Math.max(...journalEntries.map(e => e.stage_number));
+
+  // Find which gate we just completed
+  const completedGateIdx = GATE_STAGES.findIndex(g => g === maxStage);
+
+  if (completedGateIdx >= 0 && completedGateIdx < GATE_STAGES.length - 1) {
+    // Completed a gate, move to next segment
+    const nextFrom = maxStage + 1;
+    const nextGate = GATE_STAGES[completedGateIdx + 1];
+    return { from: nextFrom, toGate: nextGate, isComplete: false };
+  }
+
+  if (maxStage >= 25) {
+    return { from: 25, toGate: 25, isComplete: true };
+  }
+
+  // Mid-segment — find which gate segment we're in
+  const currentGate = GATE_STAGES.find(g => g > maxStage) || 25;
+  return { from: maxStage + 1, toGate: currentGate, isComplete: false };
+}
+
+/**
+ * Rank ventures by proving run readiness
+ * @param {object[]} ventures - from ventures table
+ * @param {object[]} journalGroups - journal entry counts per venture
+ * @returns {object[]} ranked ventures with rationale
+ */
+function rankVentures(ventures, journalGroups) {
+  const journalMap = {};
+  for (const g of (journalGroups || [])) {
+    journalMap[g.venture_id] = g.count;
+  }
+
+  return ventures
+    .map(v => {
+      const journalCount = journalMap[v.id] || 0;
+      const stage = v.current_lifecycle_stage || 0;
+      let state, rationale;
+
+      if (journalCount >= 26) {
+        state = 'complete';
+        rationale = 'Proving run complete — view report or re-run';
+      } else if (journalCount > 0) {
+        state = 'in_progress';
+        rationale = `${journalCount}/26 stages assessed — resume to continue`;
+      } else {
+        state = 'not_started';
+        rationale = stage >= 10
+          ? 'Most mature venture — best candidate for first run'
+          : stage >= 5
+            ? 'Mid-stage venture — good proving candidate'
+            : 'Early-stage — limited implementation to assess';
+      }
+
+      return {
+        id: v.id,
+        name: v.name || v.venture_name || `Venture ${v.id.slice(0, 8)}`,
+        lifecycle_stage: stage,
+        journal_count: journalCount,
+        state,
+        rationale,
+        score: (stage * 10) + (journalCount > 0 ? 500 : 0) // strongly prioritize in-progress
+      };
+    })
+    .sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Format gap analysis for display
+ * @param {object} gapAnalysis - from Gap Analyst
+ * @returns {string} formatted text
+ */
+function formatGapSummary(gapAnalysis) {
+  if (!gapAnalysis || !gapAnalysis.summary) return 'No gap data available.';
+
+  const s = gapAnalysis.summary;
+  const lines = [];
+
+  lines.push(`Gaps: ${s.total} total`);
+  if (s.by_severity.blocker > 0) lines.push(`  Blocker: ${s.by_severity.blocker}`);
+  if (s.by_severity.major > 0) lines.push(`  Major: ${s.by_severity.major}`);
+  if (s.by_severity.minor > 0) lines.push(`  Minor: ${s.by_severity.minor}`);
+  if (s.by_severity.cosmetic > 0) lines.push(`  Cosmetic: ${s.by_severity.cosmetic}`);
+
+  lines.push(`\nRecommendation: ${gapAnalysis.recommendation.toUpperCase()}`);
+  lines.push(gapAnalysis.recommendation_reason);
+
+  // Top blocker if any
+  const blocker = (gapAnalysis.gaps || []).find(g => g.severity === 'blocker');
+  if (blocker) {
+    lines.push(`\nTop blocker: ${blocker.description}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build brainstorm context from gap analysis for /brainstorm invocation
+ * @param {string} ventureName
+ * @param {number} gateStage
+ * @param {object} gapAnalysis
+ * @returns {string} brainstorm topic
+ */
+function buildBrainstormContext(ventureName, gateStage, gapAnalysis) {
+  const blockers = (gapAnalysis.gaps || []).filter(g => g.severity === 'blocker');
+  const majors = (gapAnalysis.gaps || []).filter(g => g.severity === 'major');
+  const criticalGaps = [...blockers, ...majors];
+
+  const lines = [
+    `Remediate proving run gaps for "${ventureName}" at Gate ${gateStage}`,
+    '',
+    `${criticalGaps.length} critical gaps found during venture proving run:`,
+  ];
+
+  for (const gap of criticalGaps.slice(0, 5)) {
+    lines.push(`- [${gap.severity}] Stage ${gap.stage_number}: ${gap.description}`);
+  }
+
+  lines.push('');
+  lines.push(`Recommendation: ${gapAnalysis.recommendation_reason}`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Determine if gaps are complex (need brainstorm) or simple (QF)
+ * @param {object} gapAnalysis
+ * @returns {{ isComplex: boolean, reason: string }}
+ */
+function assessGapComplexity(gapAnalysis) {
+  const blockers = (gapAnalysis.gaps || []).filter(g => g.severity === 'blocker').length;
+  const majors = (gapAnalysis.gaps || []).filter(g => g.severity === 'major').length;
+  const total = (gapAnalysis.gaps || []).length;
+
+  if (blockers > 0 || majors >= 3 || total >= 5) {
+    return {
+      isComplex: true,
+      reason: blockers > 0
+        ? `${blockers} blocker gap(s) require architectural thinking`
+        : `${majors} major gaps across multiple areas suggest systemic issue`
+    };
+  }
+
+  return {
+    isComplex: false,
+    reason: `${total} minor/cosmetic gap(s) — quick fix appropriate`
+  };
+}
+
+module.exports = {
+  GATE_STAGES,
+  detectNextGate,
+  rankVentures,
+  formatGapSummary,
+  buildBrainstormContext,
+  assessGapComplexity
+};

--- a/tests/unit/prove-helpers.test.js
+++ b/tests/unit/prove-helpers.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const {
+  detectNextGate,
+  rankVentures,
+  formatGapSummary,
+  buildBrainstormContext,
+  assessGapComplexity,
+  GATE_STAGES
+} = require('../../scripts/prove-helpers.cjs');
+
+describe('detectNextGate', () => {
+  it('returns gate 3 for empty journal', () => {
+    const result = detectNextGate([]);
+    expect(result).toEqual({ from: 0, toGate: 3, isComplete: false });
+  });
+
+  it('returns gate 3 for null journal', () => {
+    const result = detectNextGate(null);
+    expect(result).toEqual({ from: 0, toGate: 3, isComplete: false });
+  });
+
+  it('advances to gate 5 after completing gate 3', () => {
+    const journal = [
+      { stage_number: 0 }, { stage_number: 1 },
+      { stage_number: 2 }, { stage_number: 3 }
+    ];
+    const result = detectNextGate(journal);
+    expect(result).toEqual({ from: 4, toGate: 5, isComplete: false });
+  });
+
+  it('advances to gate 10 after completing gate 5', () => {
+    const journal = Array.from({ length: 6 }, (_, i) => ({ stage_number: i }));
+    const result = detectNextGate(journal);
+    expect(result).toEqual({ from: 6, toGate: 10, isComplete: false });
+  });
+
+  it('detects completion at stage 25', () => {
+    const journal = Array.from({ length: 26 }, (_, i) => ({ stage_number: i }));
+    const result = detectNextGate(journal);
+    expect(result.isComplete).toBe(true);
+  });
+
+  it('handles mid-segment correctly (stage 7 assessed)', () => {
+    const journal = Array.from({ length: 8 }, (_, i) => ({ stage_number: i }));
+    const result = detectNextGate(journal);
+    expect(result.from).toBe(8);
+    expect(result.toGate).toBe(10);
+  });
+});
+
+describe('rankVentures', () => {
+  it('ranks by lifecycle stage', () => {
+    const ventures = [
+      { id: 'a', name: 'Early', current_lifecycle_stage: 2 },
+      { id: 'b', name: 'Mature', current_lifecycle_stage: 15 },
+      { id: 'c', name: 'Mid', current_lifecycle_stage: 8 }
+    ];
+    const ranked = rankVentures(ventures, []);
+    expect(ranked[0].id).toBe('b');
+    expect(ranked[0].rationale).toContain('Most mature');
+  });
+
+  it('prioritizes in-progress runs', () => {
+    const ventures = [
+      { id: 'a', name: 'Mature', current_lifecycle_stage: 20 },
+      { id: 'b', name: 'InProgress', current_lifecycle_stage: 5 }
+    ];
+    const journalGroups = [{ venture_id: 'b', count: 10 }];
+    const ranked = rankVentures(ventures, journalGroups);
+    expect(ranked[0].id).toBe('b');
+    expect(ranked[0].state).toBe('in_progress');
+  });
+
+  it('marks complete runs', () => {
+    const ventures = [{ id: 'a', name: 'Done', current_lifecycle_stage: 25 }];
+    const journalGroups = [{ venture_id: 'a', count: 26 }];
+    const ranked = rankVentures(ventures, journalGroups);
+    expect(ranked[0].state).toBe('complete');
+  });
+});
+
+describe('formatGapSummary', () => {
+  it('formats gap analysis with severity counts', () => {
+    const analysis = {
+      summary: { total: 5, by_severity: { blocker: 1, major: 2, minor: 2, cosmetic: 0 } },
+      recommendation: 'fix_first',
+      recommendation_reason: '1 blocker must be resolved',
+      gaps: [{ severity: 'blocker', description: 'Missing create component' }]
+    };
+    const text = formatGapSummary(analysis);
+    expect(text).toContain('Gaps: 5 total');
+    expect(text).toContain('Blocker: 1');
+    expect(text).toContain('FIX_FIRST');
+    expect(text).toContain('Missing create component');
+  });
+
+  it('handles empty gap analysis', () => {
+    expect(formatGapSummary(null)).toBe('No gap data available.');
+    expect(formatGapSummary({})).toBe('No gap data available.');
+  });
+});
+
+describe('assessGapComplexity', () => {
+  it('returns complex for blockers', () => {
+    const analysis = { gaps: [{ severity: 'blocker' }] };
+    const result = assessGapComplexity(analysis);
+    expect(result.isComplex).toBe(true);
+    expect(result.reason).toContain('blocker');
+  });
+
+  it('returns complex for 3+ majors', () => {
+    const analysis = { gaps: [
+      { severity: 'major' }, { severity: 'major' }, { severity: 'major' }
+    ]};
+    const result = assessGapComplexity(analysis);
+    expect(result.isComplex).toBe(true);
+  });
+
+  it('returns simple for minor gaps only', () => {
+    const analysis = { gaps: [{ severity: 'minor' }, { severity: 'cosmetic' }] };
+    const result = assessGapComplexity(analysis);
+    expect(result.isComplex).toBe(false);
+    expect(result.reason).toContain('quick fix');
+  });
+});
+
+describe('buildBrainstormContext', () => {
+  it('builds context with blocker gaps', () => {
+    const analysis = {
+      gaps: [
+        { severity: 'blocker', stage_number: 2, description: 'Missing file X' },
+        { severity: 'major', stage_number: 3, description: 'No validation' }
+      ],
+      recommendation_reason: 'Blockers must be resolved'
+    };
+    const ctx = buildBrainstormContext('FinTech App', 3, analysis);
+    expect(ctx).toContain('FinTech App');
+    expect(ctx).toContain('Gate 3');
+    expect(ctx).toContain('Missing file X');
+    expect(ctx).toContain('No validation');
+  });
+});
+
+describe('GATE_STAGES', () => {
+  it('has correct gate stages', () => {
+    expect(GATE_STAGES).toEqual([3, 5, 10, 22, 25]);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `/prove` slash command skill for menu-driven venture proving companion
- All interaction via `AskUserQuestion` — pure CLI, no ASCII art menus
- Always pauses at every gate for deliberate chairman decisions
- Fix-first routes to `/brainstorm` for complex gaps with context pre-loading
- Session state preserves venture selection and brainstorm detour return
- `scripts/prove-helpers.cjs` with gate detection, venture ranking, gap formatting
- 16 unit tests passing

## Test plan
- [x] 16 unit tests for prove-helpers (gate detection, ranking, formatting, complexity)
- [ ] Manual: type `/prove` → verify main menu renders
- [ ] Manual: start proving run → verify gate assessment + decision flow
- [ ] Manual: fix-first → verify brainstorm bridge

SD-LEO-INFRA-INTERACTIVE-PROVE-SLASH-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)