### PR TITLE
feat: rewrite gate validator to execute live Playwright tests

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/test-coverage-quality.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/test-coverage-quality.js
@@ -1,24 +1,26 @@
 /**
  * Test Coverage Quality Gate for EXEC-TO-PLAN
- * Part of SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-B
  *
- * Reads coverage/coverage-summary.json, computes coverage for CHANGED files only,
- * flags files with 0% coverage.
+ * REWRITTEN: SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-B
+ *
+ * Executes live Playwright tests via subprocess and maps results to gate scores.
+ * Replaces stale coverage-summary.json file reading with real test execution.
+ *
+ * Modes:
+ *   - LIVE (ENABLE_LIVE_TEST_EXECUTION=true): Spawns npx playwright test, parses JSON results
+ *   - ADVISORY (default): Returns advisory score without executing tests (gradual rollout)
  *
  * Thresholds:
  *   - 60% for feature/bugfix/security (BLOCKING)
  *   - 40% for infrastructure/refactor (ADVISORY/WARN)
  *
- * Fixes GAP-002 and GAP-004 from quality gate audit.
+ * Timeout: 60s default (configurable via PLAYWRIGHT_GATE_TIMEOUT_MS)
  */
 
-import { existsSync, readFileSync } from 'fs';
-import { resolve, relative } from 'path';
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
 
 /**
  * Detect code file changes in the current branch/working directory.
- * Reuses the same logic as mandatory-testing-validation.js detectCodeChanges().
  *
  * @returns {{ hasCodeFiles: boolean, codeFileCount: number, codeFiles: string[] }}
  */
@@ -56,32 +58,124 @@ function detectCodeChanges() {
 }
 
 /**
- * Resolve a coverage key path to a relative path for matching.
- * Coverage keys can be absolute paths (e.g., C:\Users\...\src\foo.js)
- * or relative paths. We normalize to forward-slash relative paths.
+ * Execute Playwright tests via subprocess and parse JSON reporter output.
  *
- * @param {string} coverageKey - Key from coverage-summary.json
- * @param {string} rootDir - Project root directory
- * @returns {string} Normalized relative path
+ * @param {number} timeoutMs - Timeout in milliseconds
+ * @returns {Promise<{success: boolean, results: Object|null, error: string|null}>}
  */
-function normalizeCoveragePath(coverageKey, rootDir) {
-  if (coverageKey === 'total') return 'total';
+function runPlaywrightTests(timeoutMs) {
+  return new Promise((resolve) => {
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
 
-  // Try to make it relative to root
-  let rel = coverageKey;
-  try {
-    rel = relative(rootDir, coverageKey);
-  } catch {
-    // If relative() fails, try string replacement
-    const normalizedRoot = rootDir.replace(/\\/g, '/');
-    const normalizedKey = coverageKey.replace(/\\/g, '/');
-    if (normalizedKey.startsWith(normalizedRoot)) {
-      rel = normalizedKey.slice(normalizedRoot.length).replace(/^\//, '');
+    const proc = spawn('npx', ['playwright', 'test', '--reporter=json'], {
+      shell: true,
+      timeout: timeoutMs,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        proc.kill('SIGTERM');
+        resolve({
+          success: false,
+          results: null,
+          error: `Timeout after ${timeoutMs}ms`
+        });
+      }
+    }, timeoutMs);
+
+    proc.stdout.on('data', (data) => { stdout += data.toString(); });
+    proc.stderr.on('data', (data) => { stderr += data.toString(); });
+
+    proc.on('error', (err) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve({
+          success: false,
+          results: null,
+          error: `Subprocess error: ${err.message}`
+        });
+      }
+    });
+
+    proc.on('close', (code) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+
+        try {
+          const results = JSON.parse(stdout);
+          resolve({
+            success: code === 0,
+            results,
+            error: code !== 0 ? `Exit code ${code}` : null
+          });
+        } catch (parseErr) {
+          resolve({
+            success: false,
+            results: null,
+            error: `Failed to parse JSON output: ${parseErr.message}. Stderr: ${stderr.slice(0, 200)}`
+          });
+        }
+      }
+    });
+  });
+}
+
+/**
+ * Parse Playwright JSON reporter output into structured results.
+ *
+ * @param {Object} jsonReport - Parsed Playwright JSON reporter output
+ * @returns {{ total: number, passed: number, failed: number, skipped: number, duration: number }}
+ */
+function parsePlaywrightResults(jsonReport) {
+  if (!jsonReport || !jsonReport.suites) {
+    return { total: 0, passed: 0, failed: 0, skipped: 0, duration: 0 };
+  }
+
+  let total = 0, passed = 0, failed = 0, skipped = 0;
+
+  function walkSuites(suites) {
+    for (const suite of suites) {
+      if (suite.specs) {
+        for (const spec of suite.specs) {
+          if (spec.tests) {
+            for (const test of spec.tests) {
+              total++;
+              const status = test.status || (test.results?.[0]?.status);
+              if (status === 'expected' || status === 'passed') passed++;
+              else if (status === 'skipped') skipped++;
+              else failed++;
+            }
+          }
+        }
+      }
+      if (suite.suites) walkSuites(suite.suites);
     }
   }
 
-  // Normalize to forward slashes
-  return rel.replace(/\\/g, '/');
+  walkSuites(jsonReport.suites);
+
+  const duration = jsonReport.stats?.duration || 0;
+
+  return { total, passed, failed, skipped, duration };
+}
+
+/**
+ * Map Playwright test results to a 0-100 gate score.
+ *
+ * @param {{ total: number, passed: number, failed: number, skipped: number }} results
+ * @returns {number} Score 0-100
+ */
+function mapToGateScore(results) {
+  if (results.total === 0) return 100; // No tests = pass (advisory)
+  const runnable = results.total - results.skipped;
+  if (runnable === 0) return 100; // All skipped = pass
+  return Math.round((results.passed / runnable) * 100);
 }
 
 /**
@@ -98,16 +192,18 @@ export function createTestCoverageQualityGate(_supabase) {
       console.log('-'.repeat(50));
 
       const sdType = ctx.sd?.sd_type || 'unknown';
-      console.log(`   📋 SD Type: ${sdType}${ctx.sd?.sd_type ? '' : ' (defaulted - sd_type not provided in context)'}`);
+      const liveExecution = process.env.ENABLE_LIVE_TEST_EXECUTION === 'true';
+      const timeoutMs = parseInt(process.env.PLAYWRIGHT_GATE_TIMEOUT_MS || '60000', 10);
 
-      // Determine thresholds and blocking behavior based on sd_type
-      // Only explicitly listed types use blocking mode; unknown/missing defaults to advisory
+      console.log(`   📋 SD Type: ${sdType}`);
+      console.log(`   📋 Mode: ${liveExecution ? 'LIVE (Playwright subprocess)' : 'ADVISORY (feature flag off)'}`);
+
       const BLOCKING_TYPES = ['feature', 'bugfix', 'security'];
       const isBlocking = BLOCKING_TYPES.includes(sdType);
       const threshold = isBlocking ? 60 : 40;
 
       console.log(`   📋 Threshold: ${threshold}%`);
-      console.log(`   📋 Mode: ${isBlocking ? 'BLOCKING' : 'ADVISORY'}`);
+      console.log(`   📋 Blocking: ${isBlocking ? 'YES' : 'NO (advisory)'}`);
 
       // 1. Detect changed code files
       const codeChanges = detectCodeChanges();
@@ -126,235 +222,147 @@ export function createTestCoverageQualityGate(_supabase) {
             blocking: false,
             threshold_used: threshold,
             sd_type: sdType,
+            mode: liveExecution ? 'live' : 'advisory',
             changed_files_count: 0,
-            evaluated_files_count: 0,
-            zero_coverage_files: [],
-            below_threshold_files: [],
             summary: 'No code files changed'
           }
         };
       }
 
-      // 2. Read coverage-summary.json
-      const rootDir = process.cwd();
-      const coveragePath = resolve(rootDir, 'coverage', 'coverage-summary.json');
-
-      if (!existsSync(coveragePath)) {
-        console.log(`   ⚠️  Coverage file not found: ${coveragePath}`);
-        console.log('   💡 Generate coverage: npx vitest run --coverage');
+      // 2. If feature flag is off, return advisory result
+      if (!liveExecution) {
+        console.log('   ⚠️  Live test execution disabled (ENABLE_LIVE_TEST_EXECUTION != true)');
+        console.log('   💡 Set ENABLE_LIVE_TEST_EXECUTION=true to enable live Playwright testing');
         return {
           passed: true,
           score: 70,
           max_score: 100,
           issues: [],
           warnings: [
-            'Coverage file not found: coverage/coverage-summary.json',
-            'Generate coverage by running: npx vitest run --coverage'
+            'Live test execution disabled. Set ENABLE_LIVE_TEST_EXECUTION=true to enable.',
+            `${codeChanges.codeFileCount} code files changed but not verified by live tests`
           ],
           details: {
-            status: 'WARN',
+            status: 'ADVISORY',
             blocking: false,
             threshold_used: threshold,
             sd_type: sdType,
+            mode: 'advisory',
             changed_files_count: codeChanges.codeFileCount,
-            evaluated_files_count: 0,
-            zero_coverage_files: [],
-            below_threshold_files: [],
-            summary: 'Coverage file missing at coverage/coverage-summary.json. Run: npx vitest run --coverage'
+            summary: 'Live test execution disabled - advisory mode'
           }
         };
       }
 
-      // 3. Parse coverage data
-      let coverageData;
-      try {
-        const raw = readFileSync(coveragePath, 'utf-8');
-        coverageData = JSON.parse(raw);
-      } catch (parseError) {
-        console.log(`   ⚠️  Failed to parse coverage-summary.json: ${parseError.message}`);
-        return {
-          passed: true,
-          score: 70,
-          max_score: 100,
-          issues: [],
-          warnings: [
-            `Failed to parse coverage/coverage-summary.json: ${parseError.message}`,
-            'Ensure coverage-summary.json is valid JSON'
-          ],
-          details: {
-            status: 'WARN',
-            blocking: false,
-            threshold_used: threshold,
-            sd_type: sdType,
-            changed_files_count: codeChanges.codeFileCount,
-            evaluated_files_count: 0,
-            zero_coverage_files: [],
-            below_threshold_files: [],
-            summary: `Parse error in coverage-summary.json: ${parseError.message}`
-          }
-        };
-      }
+      // 3. Execute Playwright tests
+      console.log(`   🔄 Executing: npx playwright test --reporter=json (timeout: ${timeoutMs}ms)`);
 
-      // 4. Build normalized coverage map
-      const coverageKeys = Object.keys(coverageData).filter(k => k !== 'total');
-      const coverageMap = new Map();
-      for (const key of coverageKeys) {
-        const normalized = normalizeCoveragePath(key, rootDir);
-        coverageMap.set(normalized, coverageData[key]);
-      }
+      const execution = await runPlaywrightTests(timeoutMs);
 
-      // 5. Match changed files to coverage entries
-      const zeroCoverageFiles = [];
-      const belowThresholdFiles = [];
-      let evaluatedCount = 0;
+      if (execution.error && !execution.results) {
+        console.log(`   ⚠️  Test execution failed: ${execution.error}`);
 
-      for (const changedFile of codeChanges.codeFiles) {
-        const normalizedChanged = changedFile.replace(/\\/g, '/');
-        const entry = coverageMap.get(normalizedChanged);
-
-        if (!entry) continue; // No coverage data for this file
-
-        evaluatedCount++;
-        const lines = entry.lines || entry.statements || {};
-        const total = lines.total || 0;
-        const covered = lines.covered || 0;
-
-        if (total === 0) continue; // No statements to cover
-
-        const percent = (covered / total) * 100;
-
-        if (covered === 0 && total > 0) {
-          zeroCoverageFiles.push({
-            file: normalizedChanged,
-            total_statements: total,
-            covered_statements: 0,
-            percent: 0
-          });
+        if (execution.error.startsWith('Timeout')) {
+          console.log(`   ❌ TIMEOUT: Tests did not complete within ${timeoutMs}ms`);
+          return {
+            passed: false,
+            score: 0,
+            max_score: 100,
+            issues: [`Test execution timed out after ${timeoutMs}ms`],
+            warnings: [],
+            details: {
+              status: 'FAIL',
+              blocking: isBlocking,
+              threshold_used: threshold,
+              sd_type: sdType,
+              mode: 'live',
+              changed_files_count: codeChanges.codeFileCount,
+              error: execution.error,
+              summary: `TIMEOUT: Tests exceeded ${timeoutMs}ms limit`
+            }
+          };
         }
 
-        if (percent < threshold) {
-          belowThresholdFiles.push({
-            file: normalizedChanged,
-            total_statements: total,
-            covered_statements: covered,
-            percent: Math.round(percent * 10) / 10
-          });
-        }
-      }
-
-      console.log(`   📊 Evaluated: ${evaluatedCount}/${codeChanges.codeFileCount} changed files`);
-      console.log(`   📊 Zero coverage: ${zeroCoverageFiles.length} files`);
-      console.log(`   📊 Below threshold: ${belowThresholdFiles.length} files`);
-
-      // 6. Handle no coverage matches
-      if (evaluatedCount === 0 && codeChanges.codeFileCount > 0) {
-        const sampleChanged = codeChanges.codeFiles.slice(0, 3);
-        console.log('   ⚠️  No changed files matched coverage entries');
-        console.log(`   💡 Sample changed files: ${sampleChanged.join(', ')}`);
-        console.log(`   💡 Coverage entries: ${coverageKeys.length} keys available`);
+        // Subprocess error (e.g., Playwright not installed)
+        console.log('   ⚠️  Falling back to advisory mode due to execution error');
         return {
           passed: true,
-          score: 70,
+          score: 50,
           max_score: 100,
           issues: [],
           warnings: [
-            `No changed files matched coverage entries (${codeChanges.codeFileCount} changed, ${coverageKeys.length} coverage keys)`,
-            `Sample changed: ${sampleChanged.join(', ')}`,
-            'Check path normalization between git diff output and coverage-summary.json keys'
+            `Test execution failed: ${execution.error}`,
+            'Falling back to advisory mode. Ensure Playwright is installed: npx playwright install'
           ],
           details: {
             status: 'WARN',
             blocking: false,
             threshold_used: threshold,
             sd_type: sdType,
+            mode: 'live_fallback',
             changed_files_count: codeChanges.codeFileCount,
-            evaluated_files_count: 0,
-            zero_coverage_files: [],
-            below_threshold_files: [],
-            summary: `Path mismatch: ${codeChanges.codeFileCount} changed files, ${coverageKeys.length} coverage keys, 0 matched`
+            error: execution.error,
+            summary: `Execution error: ${execution.error}`
           }
         };
       }
 
-      // 7. Determine result
-      const hasZeroCoverage = zeroCoverageFiles.length > 0;
-      const hasBelowThreshold = belowThresholdFiles.length > 0;
-      const failed = hasZeroCoverage || hasBelowThreshold;
+      // 4. Parse results
+      const results = parsePlaywrightResults(execution.results);
+      const score = mapToGateScore(results);
 
-      if (!failed) {
-        console.log('   ✅ All evaluated files meet coverage threshold');
-        return {
-          passed: true,
-          score: 100,
-          max_score: 100,
-          issues: [],
-          warnings: [],
-          details: {
-            status: 'PASS',
-            blocking: false,
-            threshold_used: threshold,
-            sd_type: sdType,
-            changed_files_count: codeChanges.codeFileCount,
-            evaluated_files_count: evaluatedCount,
-            zero_coverage_files: [],
-            below_threshold_files: [],
-            summary: `All ${evaluatedCount} evaluated files meet ${threshold}% threshold`
-          }
-        };
+      console.log(`   📊 Results: ${results.passed} passed, ${results.failed} failed, ${results.skipped} skipped (${results.total} total)`);
+      console.log(`   📊 Score: ${score}/100 (threshold: ${threshold}%)`);
+      if (results.duration) console.log(`   ⏱️  Duration: ${Math.round(results.duration / 1000)}s`);
+
+      // 5. Determine pass/fail
+      const passed = score >= threshold;
+      const issues = [];
+      const warnings = [];
+
+      if (!passed && isBlocking) {
+        issues.push(`Test score ${score}% below blocking threshold ${threshold}%: ${results.failed} test(s) failed`);
+      } else if (!passed && !isBlocking) {
+        warnings.push(`Test score ${score}% below advisory threshold ${threshold}%: ${results.failed} test(s) failed`);
       }
 
-      // Failed - build issues/warnings based on blocking mode
-      const messages = [];
-      if (hasZeroCoverage) {
-        messages.push(`${zeroCoverageFiles.length} file(s) with 0% coverage: ${zeroCoverageFiles.map(f => f.file).join(', ')}`);
-      }
-      if (hasBelowThreshold) {
-        messages.push(`${belowThresholdFiles.length} file(s) below ${threshold}% threshold: ${belowThresholdFiles.map(f => `${f.file} (${f.percent}%)`).join(', ')}`);
+      if (results.skipped > 0) {
+        warnings.push(`${results.skipped} test(s) skipped`);
       }
 
-      if (isBlocking) {
-        console.log('   ❌ BLOCKING: Coverage issues detected');
-        for (const msg of messages) console.log(`      • ${msg}`);
-        return {
-          passed: false,
-          score: 0,
-          max_score: 100,
-          issues: messages,
-          warnings: [],
-          details: {
-            status: 'FAIL',
-            blocking: true,
-            threshold_used: threshold,
-            sd_type: sdType,
-            changed_files_count: codeChanges.codeFileCount,
-            evaluated_files_count: evaluatedCount,
-            zero_coverage_files: zeroCoverageFiles,
-            below_threshold_files: belowThresholdFiles,
-            summary: `FAIL: ${messages.join('; ')}`
-          }
-        };
+      const status = passed ? 'PASS' : (isBlocking ? 'FAIL' : 'WARN');
+
+      if (passed) {
+        console.log(`   ✅ ${status}: Score ${score}% meets ${threshold}% threshold`);
+      } else if (isBlocking) {
+        console.log(`   ❌ ${status}: Score ${score}% below ${threshold}% threshold (BLOCKING)`);
       } else {
-        console.log('   ⚠️  ADVISORY: Coverage issues detected (non-blocking)');
-        for (const msg of messages) console.log(`      • ${msg}`);
-        return {
-          passed: true,
-          score: 60,
-          max_score: 100,
-          issues: [],
-          warnings: messages,
-          details: {
-            status: 'WARN',
-            blocking: false,
-            threshold_used: threshold,
-            sd_type: sdType,
-            changed_files_count: codeChanges.codeFileCount,
-            evaluated_files_count: evaluatedCount,
-            zero_coverage_files: zeroCoverageFiles,
-            below_threshold_files: belowThresholdFiles,
-            summary: `WARN: ${messages.join('; ')}`
-          }
-        };
+        console.log(`   ⚠️  ${status}: Score ${score}% below ${threshold}% threshold (advisory)`);
       }
+
+      return {
+        passed: isBlocking ? passed : true,
+        score,
+        max_score: 100,
+        issues,
+        warnings,
+        details: {
+          status,
+          blocking: isBlocking && !passed,
+          threshold_used: threshold,
+          sd_type: sdType,
+          mode: 'live',
+          changed_files_count: codeChanges.codeFileCount,
+          test_results: {
+            total: results.total,
+            passed: results.passed,
+            failed: results.failed,
+            skipped: results.skipped,
+            duration_ms: results.duration
+          },
+          summary: `${status}: ${results.passed}/${results.total} tests passed (${score}%, threshold ${threshold}%)`
+        }
+      };
     },
     required: true
   };

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/test-coverage-quality.test.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/test-coverage-quality.test.js
@@ -1,66 +1,119 @@
 /**
- * Unit tests for GATE_TEST_COVERAGE_QUALITY
- * Validates sd_type-aware scoring behavior.
+ * Unit tests for GATE_TEST_COVERAGE_QUALITY (Rewritten)
+ * Tests advisory mode, sd_type routing, and scoring logic.
  *
- * Part of SD-LEARN-FIX-ADDRESS-PAT-AUTO-016
+ * Part of SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-B
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createTestCoverageQualityGate } from './test-coverage-quality.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Mock child_process to control git diff output
+// Mock child_process to control git diff and prevent real subprocess execution
 vi.mock('child_process', () => ({
-  execSync: vi.fn(() => 'lib/some-file.js\nlib/other-file.js')
+  execSync: vi.fn(() => 'lib/some-file.js\nlib/other-file.js'),
+  spawn: vi.fn(() => {
+    // Return a mock proc that never resolves — live tests won't complete
+    // This is fine because we only test advisory mode through the validator
+    const noop = { on: vi.fn(), kill: vi.fn() };
+    return { stdout: noop, stderr: noop, on: vi.fn(), kill: vi.fn() };
+  })
 }));
 
-// Mock fs to control coverage file existence and content
-vi.mock('fs', () => ({
-  existsSync: vi.fn(() => false),
-  readFileSync: vi.fn(() => '{}')
-}));
-
-import { existsSync, readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { createTestCoverageQualityGate } from './test-coverage-quality.js';
 
 describe('GATE_TEST_COVERAGE_QUALITY', () => {
   let gate;
+  const originalEnv = { ...process.env };
 
   beforeEach(() => {
     vi.clearAllMocks();
     gate = createTestCoverageQualityGate(null);
+    delete process.env.ENABLE_LIVE_TEST_EXECUTION;
+    delete process.env.PLAYWRIGHT_GATE_TIMEOUT_MS;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
   });
 
   it('has correct gate name', () => {
     expect(gate.name).toBe('GATE_TEST_COVERAGE_QUALITY');
   });
 
+  it('is a required gate', () => {
+    expect(gate.required).toBe(true);
+  });
+
+  describe('advisory mode (feature flag off — default)', () => {
+    it('returns advisory result when ENABLE_LIVE_TEST_EXECUTION is not set', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(70);
+      expect(result.details.mode).toBe('advisory');
+      expect(result.details.status).toBe('ADVISORY');
+    });
+
+    it('returns advisory result for infrastructure SD', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'infrastructure' } });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(70);
+      expect(result.details.blocking).toBe(false);
+    });
+
+    it('warns about changed files not verified by live tests', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      expect(result.warnings.length).toBeGreaterThan(0);
+      expect(result.warnings.some(w => w.includes('Live test execution disabled'))).toBe(true);
+    });
+  });
+
+  describe('threshold routing by sd_type', () => {
+    it('uses 60% threshold for feature SDs', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      expect(result.details.threshold_used).toBe(60);
+    });
+
+    it('uses 60% threshold for bugfix SDs', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'bugfix' } });
+      expect(result.details.threshold_used).toBe(60);
+    });
+
+    it('uses 60% threshold for security SDs', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'security' } });
+      expect(result.details.threshold_used).toBe(60);
+    });
+
+    it('uses 40% threshold for infrastructure SDs', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'infrastructure' } });
+      expect(result.details.threshold_used).toBe(40);
+    });
+
+    it('uses 40% threshold for refactor SDs', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'refactor' } });
+      expect(result.details.threshold_used).toBe(40);
+    });
+  });
+
   describe('sd_type fallback behavior', () => {
     it('defaults to advisory mode when sd_type is null', async () => {
-      existsSync.mockReturnValue(false);
       const result = await gate.validator({ sd: { sd_type: null } });
-      // Missing coverage file for non-blocking type → score 70, not 0
       expect(result.passed).toBe(true);
-      expect(result.score).toBeGreaterThanOrEqual(70);
       expect(result.details.blocking).toBe(false);
     });
 
     it('defaults to advisory mode when sd_type is undefined', async () => {
-      existsSync.mockReturnValue(false);
       const result = await gate.validator({ sd: {} });
       expect(result.passed).toBe(true);
-      expect(result.score).toBeGreaterThanOrEqual(70);
       expect(result.details.blocking).toBe(false);
     });
 
     it('defaults to advisory mode when ctx.sd is undefined', async () => {
-      existsSync.mockReturnValue(false);
       const result = await gate.validator({});
       expect(result.passed).toBe(true);
-      expect(result.score).toBeGreaterThanOrEqual(70);
       expect(result.details.blocking).toBe(false);
     });
 
     it('defaults to advisory mode for unknown sd_type values', async () => {
-      existsSync.mockReturnValue(false);
       const result = await gate.validator({ sd: { sd_type: 'exotic' } });
       expect(result.passed).toBe(true);
       expect(result.details.blocking).toBe(false);
@@ -68,71 +121,66 @@ describe('GATE_TEST_COVERAGE_QUALITY', () => {
     });
   });
 
-  describe('infrastructure SD (advisory mode)', () => {
-    it('scores >= 70 when coverage file is missing', async () => {
-      existsSync.mockReturnValue(false);
-      const result = await gate.validator({ sd: { sd_type: 'infrastructure' } });
-      expect(result.passed).toBe(true);
-      expect(result.score).toBe(70);
-      expect(result.details.blocking).toBe(false);
-      expect(result.details.status).toBe('WARN');
-    });
-
-    it('uses 40% threshold', async () => {
-      existsSync.mockReturnValue(false);
-      const result = await gate.validator({ sd: { sd_type: 'infrastructure' } });
-      expect(result.details.threshold_used).toBe(40);
-    });
-  });
-
-  describe('feature SD (blocking mode)', () => {
-    it('uses blocking mode', async () => {
-      existsSync.mockReturnValue(false);
-      const result = await gate.validator({ sd: { sd_type: 'feature' } });
-      // Missing coverage for blocking type → still passes with warning (score 70)
-      // because no coverage file is a WARN, not a FAIL
-      expect(result.passed).toBe(true);
-      expect(result.details.threshold_used).toBe(60);
-    });
-
-    it('scores 0 when coverage fails for blocking type', async () => {
-      existsSync.mockReturnValue(true);
-      readFileSync.mockReturnValue(JSON.stringify({
-        total: { lines: { total: 100, covered: 0, pct: 0 } },
-        'lib/some-file.js': { lines: { total: 50, covered: 0, pct: 0 } }
-      }));
-      const result = await gate.validator({ sd: { sd_type: 'feature' } });
-      expect(result.passed).toBe(false);
-      expect(result.score).toBe(0);
-      expect(result.details.blocking).toBe(true);
-    });
-  });
-
-  describe('security SD (blocking mode)', () => {
-    it('uses blocking mode with 60% threshold', async () => {
-      existsSync.mockReturnValue(false);
-      const result = await gate.validator({ sd: { sd_type: 'security' } });
-      expect(result.details.threshold_used).toBe(60);
-    });
-  });
-
-  describe('refactor SD (advisory mode)', () => {
-    it('uses advisory mode with 40% threshold', async () => {
-      existsSync.mockReturnValue(false);
-      const result = await gate.validator({ sd: { sd_type: 'refactor' } });
-      expect(result.details.threshold_used).toBe(40);
-      expect(result.details.blocking).toBe(false);
-    });
-  });
-
   describe('no code changes', () => {
     it('returns score 100 when no code files changed', async () => {
-      const { execSync } = await import('child_process');
       execSync.mockReturnValue('');
       const result = await gate.validator({ sd: { sd_type: 'feature' } });
       expect(result.passed).toBe(true);
       expect(result.score).toBe(100);
       expect(result.details.status).toBe('PASS');
+      expect(result.details.changed_files_count).toBe(0);
+    });
+
+    it('returns score 100 for non-code files only', async () => {
+      execSync.mockReturnValue('README.md\ndocs/guide.md');
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(100);
+    });
+  });
+
+  describe('live mode detection', () => {
+    it('enters live mode when ENABLE_LIVE_TEST_EXECUTION=true', async () => {
+      process.env.ENABLE_LIVE_TEST_EXECUTION = 'true';
+      // Short timeout so test doesn't hang — spawn mock never resolves
+      process.env.PLAYWRIGHT_GATE_TIMEOUT_MS = '50';
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      // With our noop spawn mock, this will timeout and return FAIL or fallback
+      expect(result.details.mode).toMatch(/live/);
+    });
+
+    it('does not enter live mode when ENABLE_LIVE_TEST_EXECUTION=false', async () => {
+      process.env.ENABLE_LIVE_TEST_EXECUTION = 'false';
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      expect(result.details.mode).toBe('advisory');
+    });
+
+    it('does not enter live mode when ENABLE_LIVE_TEST_EXECUTION is unset', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      expect(result.details.mode).toBe('advisory');
+    });
+  });
+
+  describe('gate output contract', () => {
+    it('returns all required fields', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      expect(result).toHaveProperty('passed');
+      expect(result).toHaveProperty('score');
+      expect(result).toHaveProperty('max_score');
+      expect(result).toHaveProperty('issues');
+      expect(result).toHaveProperty('warnings');
+      expect(result).toHaveProperty('details');
+      expect(result.max_score).toBe(100);
+    });
+
+    it('details contain required fields', async () => {
+      const result = await gate.validator({ sd: { sd_type: 'feature' } });
+      expect(result.details).toHaveProperty('status');
+      expect(result.details).toHaveProperty('blocking');
+      expect(result.details).toHaveProperty('threshold_used');
+      expect(result.details).toHaveProperty('sd_type');
+      expect(result.details).toHaveProperty('mode');
+      expect(result.details).toHaveProperty('summary');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Rewrites EXEC-TO-PLAN gate validator (`test-coverage-quality.js`) to execute live Playwright tests via subprocess instead of reading stale `coverage-summary.json`
- Adds feature flag `ENABLE_LIVE_TEST_EXECUTION` (default false) for gradual rollout
- Configurable timeout (60s default), advisory fallback when disabled

## Test plan
- [x] 21 unit tests passing (advisory mode, threshold routing, sd_type fallback, output contract)
- [ ] Manual: set `ENABLE_LIVE_TEST_EXECUTION=true` and run handoff to verify live execution
- [ ] Verify zero references to `coverage-summary.json` in gate code

SD: SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-B
Parent: SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)