### PR TITLE
feat: add real browser tests for critical EHG app user journeys

### DIFF
--- a/tests/e2e/ehg-app/admin-directives.spec.ts
+++ b/tests/e2e/ehg-app/admin-directives.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * Admin SD Management browser test — EHG App
+ * Verifies real browser access to SD (strategic directives) management page.
+ *
+ * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const authFile = path.join(__dirname, '.auth', 'user.json');
+
+test.describe('Admin SD Management', () => {
+  test.use({ storageState: authFile });
+
+  test.beforeEach(async ({ page }) => {
+    try {
+      const response = await page.goto('/admin/directives', { timeout: 15000 });
+      if (!response || response.status() >= 500) {
+        test.skip(true, 'EHG app not available');
+      }
+    } catch {
+      test.skip(true, 'EHG app not reachable');
+    }
+  });
+
+  test('SD management page loads', async ({ page }) => {
+    await expect(page).toHaveURL(/\/admin\/directives/);
+    // Page should have loaded with some content
+    await expect(page.locator('main, [role="main"], .main-content')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('SD list displays directive items', async ({ page }) => {
+    // Look for SD items in a table, list, or card layout
+    const sdItems = page.locator('tr, [data-testid*="directive"], [class*="directive"], [class*="card"]');
+    // Should have at least one SD displayed (we know SDs exist in the database)
+    await expect(sdItems.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('clicking an SD shows detail view', async ({ page }) => {
+    // Find a clickable SD item
+    const sdLink = page.locator('a[href*="/admin/directives/"], tr[data-clickable], [class*="card"] a').first();
+    if (await sdLink.count() > 0) {
+      await sdLink.click();
+      // Should navigate to a detail view or open a panel
+      await page.waitForTimeout(2000);
+      // Detail view should show SD information
+      const detailContent = page.locator('[class*="detail"], [class*="panel"], [role="dialog"], main');
+      await expect(detailContent.first()).toBeVisible();
+    }
+  });
+});

--- a/tests/e2e/ehg-app/auth.setup.spec.ts
+++ b/tests/e2e/ehg-app/auth.setup.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Auth setup for EHG App browser tests.
+ * Logs in and saves storage state for reuse by other tests.
+ *
+ * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
+ */
+import { test as setup, expect } from '@playwright/test';
+import path from 'path';
+
+const authFile = path.join(__dirname, '.auth', 'user.json');
+
+setup('authenticate', async ({ page }) => {
+  // Check if app is running
+  try {
+    const response = await page.goto('/login', { timeout: 10000 });
+    if (!response || response.status() >= 500) {
+      setup.skip(true, 'EHG app not running at ' + (process.env.BASE_URL || 'http://localhost:8080'));
+      return;
+    }
+  } catch {
+    setup.skip(true, 'EHG app not reachable — skipping browser tests');
+    return;
+  }
+
+  // Fill login form
+  const email = process.env.TEST_USER_EMAIL || 'admin@ehg.com';
+  const password = process.env.TEST_USER_PASSWORD || 'test-password';
+
+  await page.getByLabel(/email/i).fill(email);
+  await page.getByLabel(/password/i).fill(password);
+  await page.getByRole('button', { name: /sign in/i }).click();
+
+  // Wait for redirect to chairman dashboard
+  await page.waitForURL(/\/(chairman|admin|ventures)/, { timeout: 15000 });
+
+  // Save storage state
+  await page.context().storageState({ path: authFile });
+});

--- a/tests/e2e/ehg-app/chairman-dashboard.spec.ts
+++ b/tests/e2e/ehg-app/chairman-dashboard.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Chairman Dashboard browser test — EHG App
+ * Verifies real browser access to chairman daily briefing page.
+ *
+ * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const authFile = path.join(__dirname, '.auth', 'user.json');
+
+test.describe('Chairman Dashboard', () => {
+  // Use saved auth state
+  test.use({ storageState: authFile });
+
+  test.beforeEach(async ({ page }) => {
+    try {
+      const response = await page.goto('/chairman', { timeout: 15000 });
+      if (!response || response.status() >= 500) {
+        test.skip(true, 'EHG app not available');
+      }
+    } catch {
+      test.skip(true, 'EHG app not reachable');
+    }
+  });
+
+  test('chairman dashboard loads and shows daily briefing', async ({ page }) => {
+    // Should be on the chairman page (daily briefing is default)
+    await expect(page).toHaveURL(/\/chairman/);
+
+    // Main layout should be visible
+    await expect(page.locator('main, [role="main"], .main-content')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('chairman sidebar navigation is visible', async ({ page }) => {
+    // Sidebar should contain navigation links
+    const sidebar = page.locator('nav, aside, [role="navigation"]');
+    await expect(sidebar.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('can navigate to decisions page', async ({ page }) => {
+    // Look for decisions link in navigation
+    const decisionsLink = page.getByRole('link', { name: /decision/i });
+    if (await decisionsLink.count() > 0) {
+      await decisionsLink.first().click();
+      await page.waitForURL(/\/chairman\/decisions|\/decisions/, { timeout: 10000 });
+    }
+  });
+
+  test('can navigate to ventures page', async ({ page }) => {
+    const venturesLink = page.getByRole('link', { name: /venture/i });
+    if (await venturesLink.count() > 0) {
+      await venturesLink.first().click();
+      await page.waitForURL(/\/ventures|\/chairman\/ventures/, { timeout: 10000 });
+    }
+  });
+});

--- a/tests/e2e/ehg-app/login.spec.ts
+++ b/tests/e2e/ehg-app/login.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Login flow browser test — EHG App
+ * Verifies real browser login: navigate to /login, enter credentials, verify redirect.
+ *
+ * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Login Flow', () => {
+  test.beforeEach(async ({ page }) => {
+    try {
+      await page.goto('/login', { timeout: 10000 });
+    } catch {
+      test.skip(true, 'EHG app not reachable');
+    }
+  });
+
+  test('login page renders with email and password fields', async ({ page }) => {
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+  });
+
+  test('successful login redirects to chairman dashboard', async ({ page }) => {
+    const email = process.env.TEST_USER_EMAIL || 'admin@ehg.com';
+    const password = process.env.TEST_USER_PASSWORD || 'test-password';
+
+    await page.getByLabel(/email/i).fill(email);
+    await page.getByLabel(/password/i).fill(password);
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    await page.waitForURL(/\/(chairman|admin)/, { timeout: 15000 });
+    await expect(page).toHaveURL(/\/(chairman|admin)/);
+  });
+
+  test('login page shows error for invalid credentials', async ({ page }) => {
+    await page.getByLabel(/email/i).fill('invalid@example.com');
+    await page.getByLabel(/password/i).fill('wrongpassword');
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    // Should show error message, not redirect
+    await page.waitForTimeout(3000);
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('unauthenticated access to /chairman redirects to /login', async ({ page }) => {
+    // Clear any stored auth
+    await page.context().clearCookies();
+    await page.goto('/chairman');
+    await page.waitForURL(/\/login/, { timeout: 10000 });
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/tests/e2e/ehg-app/public-pages.spec.ts
+++ b/tests/e2e/ehg-app/public-pages.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Public pages browser test — EHG App
+ * Verifies public-facing pages load without authentication.
+ *
+ * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Public Pages', () => {
+  test.beforeEach(async ({ page }) => {
+    try {
+      const response = await page.goto('/', { timeout: 10000 });
+      if (!response || response.status() >= 500) {
+        test.skip(true, 'EHG app not available');
+      }
+    } catch {
+      test.skip(true, 'EHG app not reachable');
+    }
+  });
+
+  test('home page loads and renders content', async ({ page }) => {
+    await expect(page).toHaveURL(/\//);
+    // Page should have some visible content
+    await expect(page.locator('body')).toBeVisible();
+    // Should have navigation
+    const nav = page.locator('nav, header, [role="banner"]');
+    await expect(nav.first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('about page loads', async ({ page }) => {
+    await page.goto('/about');
+    await expect(page).toHaveURL(/\/about/);
+    await expect(page.locator('main, [role="main"], article')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('ventures public page loads', async ({ page }) => {
+    await page.goto('/ventures');
+    // Might redirect to auth or show public venture list
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('login page loads from navigation', async ({ page }) => {
+    // Find and click login link
+    const loginLink = page.getByRole('link', { name: /log.?in|sign.?in/i });
+    if (await loginLink.count() > 0) {
+      await loginLink.first().click();
+      await page.waitForURL(/\/login/, { timeout: 5000 });
+      await expect(page.getByLabel(/email/i)).toBeVisible();
+    } else {
+      // Navigate directly
+      await page.goto('/login');
+      await expect(page.getByLabel(/email/i)).toBeVisible();
+    }
+  });
+
+  test('no console errors on home page', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(2000);
+
+    // Filter out known benign errors (e.g., favicon, third-party)
+    const realErrors = consoleErrors.filter(
+      (e) => !e.includes('favicon') && !e.includes('404') && !e.includes('net::ERR')
+    );
+    expect(realErrors).toHaveLength(0);
+  });
+});

--- a/tests/e2e/ehg-app/ventures.spec.ts
+++ b/tests/e2e/ehg-app/ventures.spec.ts
@@ -1,0 +1,46 @@
+/**
+ * Ventures browser test — EHG App
+ * Verifies real browser access to venture management pages.
+ *
+ * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
+ */
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const authFile = path.join(__dirname, '.auth', 'user.json');
+
+test.describe('Venture Management', () => {
+  test.use({ storageState: authFile });
+
+  test.beforeEach(async ({ page }) => {
+    try {
+      const response = await page.goto('/ventures', { timeout: 15000 });
+      if (!response || response.status() >= 500) {
+        test.skip(true, 'EHG app not available');
+      }
+    } catch {
+      test.skip(true, 'EHG app not reachable');
+    }
+  });
+
+  test('ventures page loads and shows venture list', async ({ page }) => {
+    await expect(page).toHaveURL(/\/ventures/);
+    await expect(page.locator('main, [role="main"]')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('venture cards or list items are displayed', async ({ page }) => {
+    // Ventures should be displayed as cards or list items
+    const ventureItems = page.locator('[class*="venture"], [class*="card"], [data-testid*="venture"], table tbody tr');
+    await expect(ventureItems.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('clicking a venture navigates to detail page', async ({ page }) => {
+    const ventureLink = page.locator('a[href*="/ventures/"]').first();
+    if (await ventureLink.count() > 0) {
+      await ventureLink.click();
+      await page.waitForURL(/\/ventures\/[^/]+/, { timeout: 10000 });
+      // Detail page should show venture content
+      await expect(page.locator('main, [role="main"]')).toBeVisible();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- 6 Playwright test files covering critical EHG app user journeys with real browser interaction
- Login flow, chairman dashboard, SD management, ventures, and public pages
- Auth state caching via Playwright storage state fixture
- Graceful skip when EHG app is not running

## Test plan
- [ ] Start EHG app (`npm run dev` in ehg repo) and run `npx playwright test tests/e2e/ehg-app/`
- [ ] Verify tests skip gracefully when app is not running
- [ ] Verify auth fixture caches login state across tests

SD: SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
Parent: SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)