### PR TITLE
fix: resolve ESM and auth state issues in browser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,4 @@ playground.config.js
 # Claude Code temp files (Windows migration artifacts)
 tmpclaude-*-cwd
 nul
+tests/e2e/ehg-app/.auth/

--- a/tests/e2e/ehg-app/admin-directives.spec.ts
+++ b/tests/e2e/ehg-app/admin-directives.spec.ts
@@ -5,9 +5,12 @@
  * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
  */
 import { test, expect } from '@playwright/test';
-import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 
-const authFile = path.join(__dirname, '.auth', 'user.json');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const authFile = join(__dirname, '.auth', 'user.json');
 
 test.describe('Admin SD Management', () => {
   test.use({ storageState: authFile });

--- a/tests/e2e/ehg-app/auth.setup.spec.ts
+++ b/tests/e2e/ehg-app/auth.setup.spec.ts
@@ -5,9 +5,14 @@
  * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
  */
 import { test as setup, expect } from '@playwright/test';
-import path from 'path';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+dotenv.config({ path: '.env.test' });
 
-const authFile = path.join(__dirname, '.auth', 'user.json');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const authFile = join(__dirname, '.auth', 'user.json');
 
 setup('authenticate', async ({ page }) => {
   // Check if app is running

--- a/tests/e2e/ehg-app/chairman-dashboard.spec.ts
+++ b/tests/e2e/ehg-app/chairman-dashboard.spec.ts
@@ -5,9 +5,12 @@
  * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
  */
 import { test, expect } from '@playwright/test';
-import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 
-const authFile = path.join(__dirname, '.auth', 'user.json');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const authFile = join(__dirname, '.auth', 'user.json');
 
 test.describe('Chairman Dashboard', () => {
   // Use saved auth state

--- a/tests/e2e/ehg-app/login.spec.ts
+++ b/tests/e2e/ehg-app/login.spec.ts
@@ -5,6 +5,8 @@
  * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
  */
 import { test, expect } from '@playwright/test';
+import dotenv from 'dotenv';
+dotenv.config({ path: '.env.test' });
 
 test.describe('Login Flow', () => {
   test.beforeEach(async ({ page }) => {

--- a/tests/e2e/ehg-app/ventures.spec.ts
+++ b/tests/e2e/ehg-app/ventures.spec.ts
@@ -5,9 +5,12 @@
  * SD-LEO-TESTING-STRATEGY-REDESIGN-ORCH-001-C
  */
 import { test, expect } from '@playwright/test';
-import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 
-const authFile = path.join(__dirname, '.auth', 'user.json');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const authFile = join(__dirname, '.auth', 'user.json');
 
 test.describe('Venture Management', () => {
   test.use({ storageState: authFile });


### PR DESCRIPTION
## Summary
- Fix ESM `__dirname` compatibility using `fileURLToPath`/`dirname`
- Add `.env.test` credential loading for auth setup and login tests
- Add `.auth/` to `.gitignore` to prevent JWT token leaks
- All 20 browser tests now pass against live EHG app

## Test plan
- [x] 20/20 tests passing on Chromium against live app

🤖 Generated with [Claude Code](https://claude.com/claude-code)