### PR TITLE
feat: wire Stage 5/7 financial models to structured storage

### DIFF
--- a/database/migrations/20260315_financial_schema_cleanup.sql
+++ b/database/migrations/20260315_financial_schema_cleanup.sql
@@ -1,0 +1,36 @@
+-- Migration: Financial Schema Cleanup for Stage 5/7 Integration
+-- SD: SD-LEO-INFRA-WIRE-STAGE-FINANCIAL-001
+-- Phase 2A: Wire Stage 5/7 Financial Models to Structured Storage
+-- Already executed against DB on 2026-03-15
+
+ALTER TABLE financial_models DROP CONSTRAINT IF EXISTS fk_company;
+ALTER TABLE financial_projections DROP CONSTRAINT IF EXISTS fk_model;
+ALTER TABLE financial_scenarios DROP CONSTRAINT IF EXISTS fk_scenario_model;
+
+ALTER TABLE modeling_requests DROP CONSTRAINT IF EXISTS modeling_requests_request_type_check;
+ALTER TABLE modeling_requests ADD CONSTRAINT modeling_requests_request_type_check
+  CHECK (request_type = ANY(ARRAY[
+    'time_horizon','build_cost','market_trend','portfolio_synergy',
+    'kill_gate_prediction','nursery_reeval','competitive_density',
+    'profitability_forecast','revenue_architecture'
+  ]));
+
+ALTER TABLE financial_models
+  ADD CONSTRAINT uq_financial_models_venture_template
+  UNIQUE (venture_id, template_type);
+
+DROP POLICY IF EXISTS modeling_requests_service_all ON modeling_requests;
+CREATE POLICY modeling_requests_select ON modeling_requests
+  FOR SELECT TO authenticated USING (
+    venture_id IN (SELECT v.id FROM ventures v JOIN user_company_access uca ON v.company_id = uca.company_id WHERE uca.user_id = auth.uid() AND uca.is_active = true)
+  );
+CREATE POLICY modeling_requests_insert ON modeling_requests
+  FOR INSERT TO authenticated WITH CHECK (
+    venture_id IN (SELECT v.id FROM ventures v JOIN user_company_access uca ON v.company_id = uca.company_id WHERE uca.user_id = auth.uid() AND uca.is_active = true)
+  );
+CREATE POLICY modeling_requests_update ON modeling_requests
+  FOR UPDATE TO authenticated USING (
+    venture_id IN (SELECT v.id FROM ventures v JOIN user_company_access uca ON v.company_id = uca.company_id WHERE uca.user_id = auth.uid() AND uca.is_active = true)
+  );
+CREATE POLICY modeling_requests_service ON modeling_requests
+  FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js
@@ -70,7 +70,7 @@ Rules:
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Financial model with kill gate evaluation
  */
-export async function analyzeStage05({ stage1Data, stage3Data, stage4Data, ventureName, ventureId, logger = console }) {
+export async function analyzeStage05({ stage1Data, stage3Data, stage4Data, ventureName, ventureId, supabase, logger = console }) {
   const _startTime = Date.now();
   logger.log('[Stage05] Starting analysis', { ventureName });
   if (!stage1Data?.description) {
@@ -199,6 +199,43 @@ Output ONLY valid JSON.`;
     }
   }
 
+  // Persist to financial_models table (dual-write: advisory_data preserved by engine)
+  let financialModelId = null;
+  if (supabase && ventureId) {
+    try {
+      const templateType = archetypeToTemplateType(stage1Data?.archetype);
+      const { data: fmData, error: fmError } = await supabase
+        .from('financial_models')
+        .upsert({
+          venture_id: ventureId,
+          template_type: templateType,
+          model_name: `Stage 5 Profitability Model - ${ventureName || 'Unknown'}`,
+          model_data: {
+            source_stage: 5,
+            initialInvestment: model.initialInvestment,
+            year1: model.year1, year2: model.year2, year3: model.year3,
+            unitEconomics: { cac, ltv, ltvCacRatio, paybackMonths, churnRate, grossMargin },
+            roiBands,
+            breakEvenMonth,
+            roi3y,
+            decision,
+            assumptions: Array.isArray(parsed.assumptions) ? parsed.assumptions : [],
+          },
+        }, { onConflict: 'venture_id,template_type' })
+        .select('id')
+        .single();
+
+      if (fmError) {
+        logger.warn('[Stage05] financial_models write failed (non-blocking):', fmError.message);
+      } else {
+        financialModelId = fmData.id;
+        logger.log('[Stage05] Financial model persisted to financial_models:', { id: financialModelId });
+      }
+    } catch (err) {
+      logger.warn('[Stage05] financial_models write failed (non-blocking):', err.message);
+    }
+  }
+
   return {
     ...model,
     grossProfitY1,
@@ -224,7 +261,23 @@ Output ONLY valid JSON.`;
     roiBands,
     assumptions: Array.isArray(parsed.assumptions) ? parsed.assumptions : [],
     fourBuckets, usage, llmFallbackCount,
+    financialModelId,
   };
+}
+
+function archetypeToTemplateType(archetype) {
+  const map = {
+    saas: 'saas',
+    marketplace: 'marketplace',
+    hardware: 'hardware',
+    services: 'services',
+    ecommerce: 'ecommerce',
+    subscription: 'subscription',
+    'e-commerce': 'ecommerce',
+    software: 'saas',
+    platform: 'marketplace',
+  };
+  return map[String(archetype || '').toLowerCase()] || 'custom';
 }
 
 function normalizeYear(year, logger, yearName) {

--- a/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-07-pricing-strategy.js
@@ -68,11 +68,32 @@ Rules:
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Pricing strategy with tiers and unit economics
  */
-export async function analyzeStage07({ stage1Data, stage4Data, stage5Data, stage6Data, ventureName, logger = console }) {
+export async function analyzeStage07({ stage1Data, stage4Data, stage5Data, stage6Data, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage07] Starting analysis', { ventureName });
   if (!stage1Data?.description) {
     throw new Error('Stage 07 pricing strategy requires Stage 1 data with description');
+  }
+
+  // Read Stage 5 financial model from structured storage (fallback to stage5Data)
+  let financialModelRecord = null;
+  let financialModelId = null;
+  if (supabase && ventureId) {
+    try {
+      const { data: fmData } = await supabase
+        .from('financial_models')
+        .select('id, model_data, template_type')
+        .eq('venture_id', ventureId)
+        .limit(1)
+        .maybeSingle();
+      if (fmData) {
+        financialModelRecord = fmData;
+        financialModelId = fmData.id;
+        logger.log('[Stage07] Read financial model from financial_models:', { id: financialModelId, template_type: fmData.template_type });
+      }
+    } catch (err) {
+      logger.warn('[Stage07] financial_models read failed (using stage5Data):', err.message);
+    }
   }
 
   const client = getLLMClient({ purpose: 'content-generation' });
@@ -177,6 +198,36 @@ Output ONLY valid JSON.`;
     logger.warn('[Stage07] LLM fallback fields detected', { llmFallbackCount });
   }
 
+  // Enrich financial_models with pricing data (dual-write: advisory_data preserved by engine)
+  if (supabase && financialModelId && financialModelRecord) {
+    try {
+      const enrichedModelData = {
+        ...financialModelRecord.model_data,
+        pricing: {
+          pricing_model,
+          tiers,
+          priceAnchor: {
+            competitorAvg: Math.max(0, Number(parsed.priceAnchor?.competitorAvg) || 0),
+            proposedPrice: Math.max(0, Number(parsed.priceAnchor?.proposedPrice) || tiers[0]?.price || 0),
+            positioning,
+          },
+          gross_margin_pct,
+          churn_rate_monthly,
+          cac,
+          arpa,
+        },
+        source_stage: 7,
+      };
+      await supabase
+        .from('financial_models')
+        .update({ model_data: enrichedModelData, model_name: `Financial Model - ${ventureName || 'Unknown'}` })
+        .eq('id', financialModelId);
+      logger.log('[Stage07] Financial model enriched with pricing data:', { id: financialModelId });
+    } catch (err) {
+      logger.warn('[Stage07] financial_models update failed (non-blocking):', err.message);
+    }
+  }
+
   logger.log('[Stage07] Analysis complete', { duration: Date.now() - startTime });
   return {
     pricing_model,
@@ -194,6 +245,7 @@ Output ONLY valid JSON.`;
     arpa,
     rationale: String(parsed.rationale || ''),
     fourBuckets, usage, llmFallbackCount,
+    financialModelId,
   };
 }
 


### PR DESCRIPTION
## Summary
- Stage 5 now upserts P&L model to `financial_models` table after analysis (dual-write with advisory_data preserved)
- Stage 7 reads Stage 5 model from `financial_models`, enriches with pricing data, falls back to advisory_data
- DDL cleanup: dropped duplicate FKs, added CHECK values for `profitability_forecast`/`revenue_architecture`, added UNIQUE constraint
- RLS fix: replaced `USING(true)` on `modeling_requests` with venture-scoped policies (CRITICAL security fix)
- Migration file: `database/migrations/20260315_financial_schema_cleanup.sql`

## Test plan
- [ ] Run Stage 5 on test venture, verify `financial_models` row created
- [ ] Run Stage 7 after Stage 5, verify enrichment with pricing data
- [ ] Verify advisory_data still populated (backward compatibility)
- [ ] Verify upsert idempotency (re-run doesn't duplicate)
- [ ] Verify RLS: authenticated user sees only own venture data

🤖 Generated with [Claude Code](https://claude.com/claude-code)