### PR TITLE
feat: wire Stage 6 risk output to recalibration forms

### DIFF
--- a/lib/eva/services/risk-forecaster.js
+++ b/lib/eva/services/risk-forecaster.js
@@ -22,23 +22,34 @@ const MODEL_VERSION = '1.0';
  * @returns {Array} Generated forecast rows
  */
 export async function generateForecast(ventureId) {
-  const { data: assessments, error } = await supabase
-    .from('risk_assessments')
-    .select('id, risk_category, risk_score, assessment_date, factors')
+  const { data: forms, error } = await supabase
+    .from('risk_recalibration_forms')
+    .select('id, gate_number, assessment_date, market_risk_current, product_risk_current, technical_risk_current, legal_risk_current, financial_risk_current, operational_risk_current, new_risks')
     .eq('venture_id', ventureId)
     .order('assessment_date', { ascending: true });
 
-  if (error) throw new Error(`Risk assessment query failed: ${error.message}`);
-  if (!assessments || assessments.length < MIN_ASSESSMENTS) {
+  if (error) throw new Error(`Risk recalibration query failed: ${error.message}`);
+  if (!forms || forms.length < MIN_ASSESSMENTS) {
     return [];
   }
 
-  // Group by risk_category
+  // Convert per-category columns to assessment-like records
+  const levelToScore = (level) => ({ CRITICAL: 90, HIGH: 60, MEDIUM: 30, LOW: 10, 'N/A': 0 }[level] || 0);
+  const categoryColumns = ['market', 'product', 'technical', 'legal', 'financial', 'operational'];
   const byCategory = {};
-  for (const a of assessments) {
-    const cat = a.risk_category || 'general';
-    if (!byCategory[cat]) byCategory[cat] = [];
-    byCategory[cat].push(a);
+  for (const form of forms) {
+    for (const cat of categoryColumns) {
+      const level = form[`${cat}_risk_current`];
+      if (!level || level === 'N/A') continue;
+      if (!byCategory[cat]) byCategory[cat] = [];
+      byCategory[cat].push({
+        id: form.id,
+        risk_category: cat,
+        risk_score: levelToScore(level),
+        assessment_date: form.assessment_date,
+        factors: (form.new_risks || []).filter(r => r.category?.toLowerCase().startsWith(cat)).map(r => r.description),
+      });
+    }
   }
 
   const forecasts = [];

--- a/lib/eva/stage-templates/analysis-steps/stage-06-risk-matrix.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-06-risk-matrix.js
@@ -15,7 +15,7 @@ import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { RISK_CATEGORIES } from '../stage-06.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
 
-const MIN_RISKS = 8;
+const MIN_RISKS = 10;
 const MIN_CATEGORIES = 3;
 
 const SYSTEM_PROMPT = `You are EVA's Risk Assessment Engine. Generate a structured risk register for a venture based on analysis from Stages 1-5.
@@ -62,7 +62,7 @@ Rules:
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Risk register with aggregate metrics
  */
-export async function analyzeStage06({ stage1Data, stage3Data, stage4Data, stage5Data, ventureName, logger = console }) {
+export async function analyzeStage06({ stage1Data, stage3Data, stage4Data, stage5Data, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage06] Starting analysis', { ventureName });
   if (!stage1Data?.description) {
@@ -172,6 +172,58 @@ Output ONLY valid JSON.`;
     risksByCategory[r.category] = (risksByCategory[r.category] || 0) + 1;
   }
 
+  // Persist risks to risk_recalibration_forms (dual-write: advisory_data preserved by engine)
+  let riskFormId = null;
+  if (supabase && ventureId) {
+    try {
+      const scoreToLevel = (score) => score >= 75 ? 'CRITICAL' : score >= 40 ? 'HIGH' : score >= 15 ? 'MEDIUM' : 'LOW';
+      const categoryMap = {
+        'Market': 'market', 'Product': 'product', 'Technical': 'technical',
+        'Legal/Compliance': 'legal', 'Financial': 'financial', 'Operational': 'operational'
+      };
+
+      const formRow = {
+        venture_id: ventureId,
+        gate_number: 6,
+        risk_context: 'evaluation',
+        from_phase: 'EXEC',
+        to_phase: 'EXEC',
+        assessment_date: new Date().toISOString(),
+        assessor_type: 'LEO',
+        risk_trajectory: normalized_risk_score > 5 ? 'DEGRADING' : normalized_risk_score > 2 ? 'STABLE' : 'IMPROVING',
+        blocking_risks: risks.some(r => r.score >= 75),
+        chairman_review_required: risks.some(r => r.score >= 75) || risks.filter(r => r.score >= 40).length >= 2,
+        go_decision: risks.some(r => r.score >= 75) ? 'CONDITIONAL' : 'GO',
+        new_risks: risks.map(r => ({ category: r.category, level: scoreToLevel(r.score), description: r.description, mitigations: [r.mitigation] })),
+      };
+
+      for (const [stageCategory, colPrefix] of Object.entries(categoryMap)) {
+        const catRisks = risks.filter(r => r.category === stageCategory);
+        const highestScore = catRisks.length > 0 ? Math.max(...catRisks.map(r => r.score)) : 0;
+        formRow[`${colPrefix}_risk_current`] = catRisks.length > 0 ? scoreToLevel(highestScore) : 'LOW';
+        formRow[`${colPrefix}_risk_previous`] = 'N/A';
+        formRow[`${colPrefix}_risk_delta`] = 'NEW';
+        formRow[`${colPrefix}_risk_justification`] = catRisks.map(r => r.description).join('; ').substring(0, 500) || null;
+        formRow[`${colPrefix}_risk_mitigations`] = catRisks.map(r => ({ risk_id: r.id, mitigation: r.mitigation }));
+      }
+
+      const { data: formData, error: formError } = await supabase
+        .from('risk_recalibration_forms')
+        .upsert(formRow, { onConflict: 'venture_id,gate_number' })
+        .select('id')
+        .single();
+
+      if (formError) {
+        logger.warn('[Stage06] risk_recalibration_forms upsert failed (non-blocking):', formError.message);
+      } else {
+        riskFormId = formData.id;
+        logger.log('[Stage06] Risk form persisted to risk_recalibration_forms:', { id: riskFormId });
+      }
+    } catch (err) {
+      logger.warn('[Stage06] risk form persistence failed (non-blocking):', err.message);
+    }
+  }
+
   logger.log('[Stage06] Analysis complete', { duration: Date.now() - startTime });
   return {
     risks,
@@ -182,7 +234,7 @@ Output ONLY valid JSON.`;
     risksByCategory,
     totalRisks: risks.length,
     categoryCoverage: Object.keys(risksByCategory).length,
-    fourBuckets, usage, llmFallbackCount,
+    fourBuckets, usage, llmFallbackCount, riskFormId,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add risk category mapper and form writer to `analyzeStage06` (dual-write pattern)
- Map 3-factor scores (severity x probability x impact) to risk levels per 6 categories
- Upsert `risk_recalibration_forms` with all category columns populated
- Rewire `risk_forecaster.js` from legacy `risk_assessments` to `risk_recalibration_forms`
- Fix MIN_RISKS from 8 to 10 (matching Stage 9 reality gate requirement)

## Test plan
- [x] 15 smoke tests pass
- [x] ESLint clean
- [x] Changes are additive (dual-write preserves advisory_data)

SD: SD-LEO-INFRA-WIRE-STAGE-RISK-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)