### PR TITLE
feat: extend exit tables for unified lifecycle and wire Stage 9

### DIFF
--- a/database/migrations/extend_exit_tables.sql
+++ b/database/migrations/extend_exit_tables.sql
@@ -1,0 +1,62 @@
+-- ============================================================================
+-- Migration: Extend Exit Tables for Stage 9 Wiring
+-- SD: SD-LEO-INFRA-EXTEND-EXIT-TABLES-001 (SD-A)
+-- Date: 2026-03-15
+-- Description:
+--   1. ALTER venture_exit_profiles: add exit_context, review_period
+--   2. Create composite unique index on (venture_id, exit_context)
+--   3. Tighten RLS on venture_exit_profiles to owner-scoped
+-- ============================================================================
+
+-- Step 1: Add columns to venture_exit_profiles
+ALTER TABLE venture_exit_profiles
+  ADD COLUMN IF NOT EXISTS exit_context TEXT DEFAULT 'planning'
+    CHECK (exit_context IN ('planning', 'readiness_assessment')),
+  ADD COLUMN IF NOT EXISTS review_period TEXT;
+
+COMMENT ON COLUMN venture_exit_profiles.exit_context IS 'Context in which the exit profile was created: planning (Stage 9) or readiness_assessment (later stages)';
+COMMENT ON COLUMN venture_exit_profiles.review_period IS 'Review period label, e.g. Q1-2026, for tracking when the profile was assessed';
+
+-- Step 2: Replace the existing current-profile index with a composite context-aware unique index
+-- The old index enforced one current profile per venture; the new one enforces
+-- one current profile per (venture, exit_context) pair, excluding superseded rows.
+DROP INDEX IF EXISTS idx_exit_profiles_current;
+
+CREATE UNIQUE INDEX idx_exit_profiles_current_context
+  ON venture_exit_profiles (venture_id, exit_context)
+  WHERE is_current = true;
+
+-- Step 3: Tighten RLS — replace overly permissive authenticated policies with owner-scoped
+-- Drop the old permissive policies
+DROP POLICY IF EXISTS exit_profiles_select_authenticated ON venture_exit_profiles;
+DROP POLICY IF EXISTS exit_profiles_insert_authenticated ON venture_exit_profiles;
+DROP POLICY IF EXISTS exit_profiles_update_authenticated ON venture_exit_profiles;
+
+-- Create owner-scoped policies: authenticated users can only access their own venture data
+CREATE POLICY exit_profiles_select_owner ON venture_exit_profiles
+  FOR SELECT TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY exit_profiles_insert_owner ON venture_exit_profiles
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY exit_profiles_update_owner ON venture_exit_profiles
+  FOR UPDATE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+-- Service role policy is preserved from the original migration (exit_profiles_service_role)
+
+-- ============================================================================
+-- ROLLBACK (if needed):
+-- DROP POLICY IF EXISTS exit_profiles_update_owner ON venture_exit_profiles;
+-- DROP POLICY IF EXISTS exit_profiles_insert_owner ON venture_exit_profiles;
+-- DROP POLICY IF EXISTS exit_profiles_select_owner ON venture_exit_profiles;
+-- CREATE POLICY exit_profiles_select_authenticated ON venture_exit_profiles FOR SELECT TO authenticated USING (true);
+-- CREATE POLICY exit_profiles_insert_authenticated ON venture_exit_profiles FOR INSERT TO authenticated WITH CHECK (true);
+-- CREATE POLICY exit_profiles_update_authenticated ON venture_exit_profiles FOR UPDATE TO authenticated USING (true);
+-- DROP INDEX IF EXISTS idx_exit_profiles_current_context;
+-- CREATE UNIQUE INDEX idx_exit_profiles_current ON venture_exit_profiles(venture_id, is_current) WHERE is_current = true;
+-- ALTER TABLE venture_exit_profiles DROP COLUMN IF EXISTS review_period;
+-- ALTER TABLE venture_exit_profiles DROP COLUMN IF EXISTS exit_context;
+-- ============================================================================

--- a/tests/unit/eva/exit-table-wiring.test.js
+++ b/tests/unit/eva/exit-table-wiring.test.js
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for Exit Table Wiring (SD-LEO-INFRA-EXTEND-EXIT-TABLES-001, SD-A)
+ *
+ * Tests:
+ * 1. EXIT_MODEL_MAP mapping logic — all 5 Stage 9 exit types map to valid table exit_model values
+ * 2. Stage 13 property name fix — exit_paths is used (not strategies)
+ *
+ * @module tests/unit/eva/exit-table-wiring
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EXIT_TYPES, EXIT_MODEL_MAP } from '../../../lib/eva/stage-templates/analysis-steps/stage-09-exit-strategy.js';
+
+// Valid exit_model values from the venture_exit_profiles CHECK constraint
+const VALID_EXIT_MODELS = ['full_acquisition', 'licensing', 'revenue_share', 'acqui_hire', 'asset_sale', 'merger'];
+
+describe('EXIT_MODEL_MAP', () => {
+  it('maps all 5 EXIT_TYPES to valid exit_model values', () => {
+    for (const exitType of EXIT_TYPES) {
+      const mapped = EXIT_MODEL_MAP[exitType];
+      expect(mapped, `EXIT_MODEL_MAP['${exitType}'] should be defined`).toBeDefined();
+      expect(VALID_EXIT_MODELS, `EXIT_MODEL_MAP['${exitType}'] = '${mapped}' should be in VALID_EXIT_MODELS`).toContain(mapped);
+    }
+  });
+
+  it('maps acquisition to full_acquisition', () => {
+    expect(EXIT_MODEL_MAP['acquisition']).toBe('full_acquisition');
+  });
+
+  it('maps ipo to full_acquisition', () => {
+    expect(EXIT_MODEL_MAP['ipo']).toBe('full_acquisition');
+  });
+
+  it('maps merger to merger', () => {
+    expect(EXIT_MODEL_MAP['merger']).toBe('merger');
+  });
+
+  it('maps mbo to full_acquisition', () => {
+    expect(EXIT_MODEL_MAP['mbo']).toBe('full_acquisition');
+  });
+
+  it('maps liquidation to asset_sale', () => {
+    expect(EXIT_MODEL_MAP['liquidation']).toBe('asset_sale');
+  });
+
+  it('returns undefined for unknown exit types (graceful degradation)', () => {
+    expect(EXIT_MODEL_MAP['unknown_type']).toBeUndefined();
+    expect(EXIT_MODEL_MAP['']).toBeUndefined();
+    expect(EXIT_MODEL_MAP[null]).toBeUndefined();
+  });
+
+  it('has exactly 5 entries matching EXIT_TYPES', () => {
+    expect(Object.keys(EXIT_MODEL_MAP)).toHaveLength(EXIT_TYPES.length);
+    for (const key of Object.keys(EXIT_MODEL_MAP)) {
+      expect(EXIT_TYPES).toContain(key);
+    }
+  });
+});
+
+describe('Stage 13 exit_paths property name fix', () => {
+  it('reads exit_paths (not strategies) from stage9Data', async () => {
+    // Dynamically import the module to read its source and verify
+    // the property name used for stage 9 data consumption
+    const modulePath = '../../../lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js';
+    const moduleSource = await import('node:fs').then(fs =>
+      fs.readFileSync(
+        new URL(modulePath, import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1'),
+        'utf-8'
+      )
+    );
+
+    // The old (broken) code used stage9Data?.strategies
+    expect(moduleSource).not.toContain('stage9Data?.strategies');
+    expect(moduleSource).not.toContain("stage9Data?.strategies");
+
+    // The fixed code uses stage9Data?.exit_paths
+    expect(moduleSource).toContain('stage9Data?.exit_paths');
+  });
+
+  it('includes exit model in LLM prompt context when exit_paths present', async () => {
+    const modulePath = '../../../lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js';
+    const moduleSource = await import('node:fs').then(fs =>
+      fs.readFileSync(
+        new URL(modulePath, import.meta.url).pathname.replace(/^\/([A-Z]:)/, '$1'),
+        'utf-8'
+      )
+    );
+
+    // The prompt context should reference exit_model
+    expect(moduleSource).toContain('exit model');
+    // The prompt should reference the primary exit path type
+    expect(moduleSource).toContain('exit_paths[0]?.type');
+  });
+});


### PR DESCRIPTION
## Summary
- Add exit_context TEXT and review_period columns to venture_exit_profiles
- Create composite unique index for context-based partitioning
- Tighten RLS to owner-scoped policies (security hardening)
- Migration executed: columns, index, and RLS verified in database
- 10 unit tests for exit model mapping logic

## Test plan
- [x] 10/10 unit tests passing (exit-table-wiring.test.js)
- [x] Migration validated by database agent
- [x] Existing exit profile data preserved

SD: SD-LEO-INFRA-EXTEND-EXIT-TABLES-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)