### PR TITLE
feat: add exit business readiness score computation and API

### DIFF
--- a/database/migrations/20260316_exit_business_readiness.sql
+++ b/database/migrations/20260316_exit_business_readiness.sql
@@ -1,0 +1,92 @@
+-- Migration: Add business readiness metrics to venture_exit_readiness
+-- SD: SD-LEO-INFRA-EXIT-BUSINESS-READINESS-001
+-- Date: 2026-03-16
+-- Description: Adds 10 columns for ARR tracking, customer counts, growth rates,
+--              market multiples, and readiness scoring with chairman escalation.
+-- Safety: Table has 0 rows, all changes are additive (ADD COLUMN).
+
+BEGIN;
+
+-- 1. Target Annual Recurring Revenue
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS target_arr NUMERIC;
+
+COMMENT ON COLUMN venture_exit_readiness.target_arr
+  IS 'Target Annual Recurring Revenue in USD';
+
+-- 2. Actual ARR
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS actual_arr NUMERIC;
+
+COMMENT ON COLUMN venture_exit_readiness.actual_arr
+  IS 'Actual Annual Recurring Revenue in USD';
+
+-- 3. Target customer count
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS target_customer_count INTEGER;
+
+COMMENT ON COLUMN venture_exit_readiness.target_customer_count
+  IS 'Target number of customers for exit readiness';
+
+-- 4. Actual customer count
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS actual_customer_count INTEGER;
+
+COMMENT ON COLUMN venture_exit_readiness.actual_customer_count
+  IS 'Current actual number of customers';
+
+-- 5. Target growth rate (decimal, e.g., 0.20 for 20%)
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS growth_rate_target NUMERIC;
+
+COMMENT ON COLUMN venture_exit_readiness.growth_rate_target
+  IS 'Target growth rate as decimal (e.g., 0.20 = 20%)';
+
+-- 6. Actual growth rate
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS growth_rate_actual NUMERIC;
+
+COMMENT ON COLUMN venture_exit_readiness.growth_rate_actual
+  IS 'Actual growth rate as decimal (e.g., 0.15 = 15%)';
+
+-- 7. Current market multiple for the sector
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS market_multiple_current NUMERIC;
+
+COMMENT ON COLUMN venture_exit_readiness.market_multiple_current
+  IS 'Current market revenue multiple for the venture sector';
+
+-- 8. Computed readiness score (0-100)
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS readiness_score NUMERIC DEFAULT 0;
+
+COMMENT ON COLUMN venture_exit_readiness.readiness_score
+  IS 'Computed business readiness score (0-100)';
+
+-- 9. Per-venture threshold for chairman escalation
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS readiness_threshold NUMERIC DEFAULT 70;
+
+COMMENT ON COLUMN venture_exit_readiness.readiness_threshold
+  IS 'Score threshold that triggers chairman review escalation';
+
+-- 10. Chairman review trigger flag
+ALTER TABLE venture_exit_readiness
+  ADD COLUMN IF NOT EXISTS chairman_review_triggered BOOLEAN DEFAULT false;
+
+COMMENT ON COLUMN venture_exit_readiness.chairman_review_triggered
+  IS 'Set true when readiness_score exceeds threshold for 2+ consecutive periods';
+
+COMMIT;
+
+-- Rollback SQL (manual use only):
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS target_arr;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS actual_arr;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS target_customer_count;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS actual_customer_count;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS growth_rate_target;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS growth_rate_actual;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS market_multiple_current;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS readiness_score;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS readiness_threshold;
+-- ALTER TABLE venture_exit_readiness DROP COLUMN IF EXISTS chairman_review_triggered;

--- a/server/routes/eva-exit.js
+++ b/server/routes/eva-exit.js
@@ -469,4 +469,90 @@ router.get('/:ventureId/data-room/completeness', asyncHandler(async (req, res) =
   });
 }));
 
+// ── Business Readiness ─────────────────────────────────────────
+// SD: SD-LEO-INFRA-EXIT-BUSINESS-READINESS-001
+
+/**
+ * Compute readiness score from business metrics (0-100).
+ * Weighted average: ARR ratio (40%), customer ratio (30%), growth ratio (30%).
+ */
+function computeReadinessScore({ target_arr, actual_arr, target_customer_count, actual_customer_count, growth_rate_target, growth_rate_actual }) {
+  const ratios = [];
+  if (target_arr > 0 && actual_arr != null) ratios.push({ weight: 0.4, value: Math.min(actual_arr / target_arr, 1.5) });
+  if (target_customer_count > 0 && actual_customer_count != null) ratios.push({ weight: 0.3, value: Math.min(actual_customer_count / target_customer_count, 1.5) });
+  if (growth_rate_target > 0 && growth_rate_actual != null) ratios.push({ weight: 0.3, value: Math.min(growth_rate_actual / growth_rate_target, 1.5) });
+
+  if (ratios.length === 0) return 0;
+
+  const totalWeight = ratios.reduce((s, r) => s + r.weight, 0);
+  const weighted = ratios.reduce((s, r) => s + r.value * r.weight, 0) / totalWeight;
+  return Math.round(Math.min(100, weighted * 100));
+}
+
+/**
+ * GET /api/eva/exit/readiness/:ventureId
+ * Get business readiness metrics for a venture.
+ */
+router.get('/readiness/:ventureId', asyncHandler(async (req, res) => {
+  const { data, error } = await dbLoader.supabase
+    .from('venture_exit_readiness')
+    .select('*')
+    .eq('venture_id', req.params.ventureId)
+    .single();
+
+  if (error) return res.status(404).json({ error: 'No readiness record found' });
+  res.json(data);
+}));
+
+/**
+ * PATCH /api/eva/exit/readiness/:ventureId
+ * Update business readiness metrics. Auto-computes readiness_score and chairman escalation.
+ */
+router.patch('/readiness/:ventureId', asyncHandler(async (req, res) => {
+  const ventureId = req.params.ventureId;
+  const { target_arr, actual_arr, target_customer_count, actual_customer_count, growth_rate_target, growth_rate_actual, market_multiple_current, readiness_threshold } = req.body;
+
+  // Get current record for escalation check
+  const { data: current } = await dbLoader.supabase
+    .from('venture_exit_readiness')
+    .select('readiness_score, readiness_threshold, chairman_review_triggered')
+    .eq('venture_id', ventureId)
+    .single();
+
+  const updates = {};
+  if (target_arr !== undefined) updates.target_arr = target_arr;
+  if (actual_arr !== undefined) updates.actual_arr = actual_arr;
+  if (target_customer_count !== undefined) updates.target_customer_count = target_customer_count;
+  if (actual_customer_count !== undefined) updates.actual_customer_count = actual_customer_count;
+  if (growth_rate_target !== undefined) updates.growth_rate_target = growth_rate_target;
+  if (growth_rate_actual !== undefined) updates.growth_rate_actual = growth_rate_actual;
+  if (market_multiple_current !== undefined) updates.market_multiple_current = market_multiple_current;
+  if (readiness_threshold !== undefined) updates.readiness_threshold = readiness_threshold;
+
+  // Merge with existing values for score computation
+  const merged = { ...current, ...updates };
+  const score = computeReadinessScore(merged);
+  updates.readiness_score = score;
+
+  // Chairman escalation: trigger if score > threshold for 2+ consecutive periods
+  const threshold = merged.readiness_threshold || 70;
+  const previousAbove = current?.readiness_score > threshold;
+  const currentAbove = score > threshold;
+  if (previousAbove && currentAbove && !current?.chairman_review_triggered) {
+    updates.chairman_review_triggered = true;
+  }
+
+  updates.updated_at = new Date().toISOString();
+
+  const { data, error } = await dbLoader.supabase
+    .from('venture_exit_readiness')
+    .update(updates)
+    .eq('venture_id', ventureId)
+    .select()
+    .single();
+
+  if (error) return res.status(500).json({ error: error.message });
+  res.json(data);
+}));
+
 export default router;


### PR DESCRIPTION
## Summary
- ALTER `venture_exit_readiness`: add 10 business readiness columns (target/actual ARR, customer counts, growth rates, market multiples, readiness_score, chairman_review_triggered)
- Add `computeReadinessScore`: weighted formula (ARR 40%, customers 30%, growth 30%)
- Add GET/PATCH `/api/eva/exit/readiness/:ventureId` API routes
- Chairman escalation: auto-triggers when score > threshold for 2+ consecutive periods

## Test plan
- [x] 15 smoke tests pass
- [x] ESLint clean
- [x] Migration verified on live database

SD: SD-LEO-INFRA-EXIT-BUSINESS-READINESS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)