### PR TITLE
fix: Stage 13 contract declaration and exit_paths reference

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -214,7 +214,21 @@ const STAGE_CONTRACTS = new Map([
   }],
 
   [13, {
-    consumes: [],
+    consumes: [
+      { stage: 1, fields: {
+        description: { type: 'string' },
+        valueProp: { type: 'string' },
+      }},
+      { stage: 5, fields: {
+        unitEconomics: { type: 'object', required: false },
+      }},
+      { stage: 8, fields: {
+        customerSegments: { type: 'object', required: false },
+      }},
+      { stage: 9, fields: {
+        exit_thesis: { type: 'string', required: false },
+      }},
+    ],
     produces: {
       vision_statement: { type: 'string', minLength: 20 },
       milestones: { type: 'array', minItems: 3 },

--- a/lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-13-product-roadmap.js
@@ -87,8 +87,8 @@ export async function analyzeStage13({ stage1Data, stage5Data, stage8Data, stage
     ? `BMC: ${Object.keys(stage8Data).filter(k => stage8Data[k]?.items?.length > 0).length}/9 blocks populated`
     : '';
 
-  const exitContext = stage9Data?.strategies
-    ? `Exit Strategies: ${stage9Data.strategies.length} defined`
+  const exitContext = stage9Data?.exit_paths
+    ? `Exit Strategies: ${stage9Data.exit_paths.length} defined`
     : '';
 
   const userPrompt = `Generate a product roadmap for this venture.


### PR DESCRIPTION
## Summary
- Fix Stage 13 contract: add consumes for stages 1, 5, 8, 9 (was empty `[]`) matching YAML spec
- Fix Stage 13 property reference: `stage9Data.strategies` → `stage9Data.exit_paths`
  (Stage 9 produces `exit_paths`, so exit context was always empty in roadmap generation)

## Test plan
- [x] 18 stage-contracts unit tests pass
- [x] 5 gap-012 enforcement tests pass
- [x] 15 smoke tests pass

SD: SD-LEO-FIX-FIX-STAGE-CONTRACT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)