### PR TITLE
feat: wire Stage 10-11 brand output to structured tables

### DIFF
--- a/database/migrations/srip_rls_tightening.sql
+++ b/database/migrations/srip_rls_tightening.sql
@@ -1,0 +1,138 @@
+-- =============================================================================
+-- Migration: srip_rls_tightening.sql
+-- Purpose: Tighten RLS on SRIP tables from USING(true) to venture-scoped
+-- SD: SD-LEO-INFRA-WIRE-STAGE-BRAND-001
+-- Date: 2026-03-16
+--
+-- Replaces permissive USING(true) policies on 4 SRIP tables with
+-- venture-scoped policies: authenticated users can only access data
+-- for ventures they created. Service role retains full access.
+--
+-- Tables affected:
+--   - srip_site_dna
+--   - srip_brand_interviews
+--   - srip_synthesis_prompts
+--   - srip_quality_checks
+--
+-- Rollback:
+--   Re-run the original 20260314_srip_artifact_tables.sql RLS section
+-- =============================================================================
+
+-- ============================================================
+-- 1. srip_site_dna — drop permissive, add venture-scoped
+-- ============================================================
+
+DROP POLICY IF EXISTS srip_site_dna_select_policy ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_insert_policy ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_update_policy ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_delete_policy ON srip_site_dna;
+
+CREATE POLICY srip_site_dna_select_owner ON srip_site_dna
+  FOR SELECT TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_site_dna_insert_owner ON srip_site_dna
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_site_dna_update_owner ON srip_site_dna
+  FOR UPDATE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_site_dna_delete_owner ON srip_site_dna
+  FOR DELETE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_site_dna_service_all ON srip_site_dna
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+
+-- ============================================================
+-- 2. srip_brand_interviews — drop permissive, add venture-scoped
+-- ============================================================
+
+DROP POLICY IF EXISTS srip_brand_interviews_select_policy ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_insert_policy ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_update_policy ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_delete_policy ON srip_brand_interviews;
+
+CREATE POLICY srip_brand_interviews_select_owner ON srip_brand_interviews
+  FOR SELECT TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_brand_interviews_insert_owner ON srip_brand_interviews
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_brand_interviews_update_owner ON srip_brand_interviews
+  FOR UPDATE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_brand_interviews_delete_owner ON srip_brand_interviews
+  FOR DELETE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_brand_interviews_service_all ON srip_brand_interviews
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+
+-- ============================================================
+-- 3. srip_synthesis_prompts — drop permissive, add venture-scoped
+-- ============================================================
+
+DROP POLICY IF EXISTS srip_synthesis_prompts_select_policy ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_insert_policy ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_update_policy ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_delete_policy ON srip_synthesis_prompts;
+
+CREATE POLICY srip_synthesis_prompts_select_owner ON srip_synthesis_prompts
+  FOR SELECT TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_synthesis_prompts_insert_owner ON srip_synthesis_prompts
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_synthesis_prompts_update_owner ON srip_synthesis_prompts
+  FOR UPDATE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_synthesis_prompts_delete_owner ON srip_synthesis_prompts
+  FOR DELETE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_synthesis_prompts_service_all ON srip_synthesis_prompts
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+
+-- ============================================================
+-- 4. srip_quality_checks — drop permissive, add venture-scoped
+-- ============================================================
+
+DROP POLICY IF EXISTS srip_quality_checks_select_policy ON srip_quality_checks;
+DROP POLICY IF EXISTS srip_quality_checks_insert_policy ON srip_quality_checks;
+DROP POLICY IF EXISTS srip_quality_checks_update_policy ON srip_quality_checks;
+DROP POLICY IF EXISTS srip_quality_checks_delete_policy ON srip_quality_checks;
+
+CREATE POLICY srip_quality_checks_select_owner ON srip_quality_checks
+  FOR SELECT TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_quality_checks_insert_owner ON srip_quality_checks
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_quality_checks_update_owner ON srip_quality_checks
+  FOR UPDATE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_quality_checks_delete_owner ON srip_quality_checks
+  FOR DELETE TO authenticated
+  USING (venture_id IN (SELECT id FROM ventures WHERE created_by = auth.uid()));
+
+CREATE POLICY srip_quality_checks_service_all ON srip_quality_checks
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);

--- a/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
@@ -103,7 +103,7 @@ Rules:
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Customer & brand foundation analysis
  */
-export async function analyzeStage10({ stage1Data, stage3Data, stage5Data, stage8Data, ventureName, logger = console }) {
+export async function analyzeStage10({ stage1Data, stage3Data, stage5Data, stage8Data, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage10] Starting customer & brand foundation analysis', { ventureName });
   if (!stage1Data?.description) {
@@ -309,6 +309,11 @@ Output ONLY valid JSON.`;
     logger.warn('[Stage10] LLM fallback fields detected', { llmFallbackCount });
   }
 
+  // --- DB Write-Through: Personas, Brand Genome, Venture Artifacts ---
+  if (supabase && ventureId) {
+    await writeStage10Artifacts({ supabase, ventureId, customerPersonas, brandGenome, stage1Data, logger });
+  }
+
   logger.log('[Stage10] Analysis complete', { duration: Date.now() - startTime, personaCount: customerPersonas.length });
   return {
     customerPersonas,
@@ -325,6 +330,106 @@ Output ONLY valid JSON.`;
     sourceProvenance,
     fourBuckets, usage, llmFallbackCount,
   };
+}
+
+/**
+ * Write Stage 10 outputs to customer_personas, venture_persona_mapping,
+ * brand_genome_submissions, and venture_artifacts.
+ * All DB writes are non-fatal — errors are logged and swallowed.
+ */
+async function writeStage10Artifacts({ supabase, ventureId, customerPersonas, brandGenome, stage1Data, logger }) {
+  // Derive industry from stage1Data or first persona demographics
+  const ventureIndustry = stage1Data?.targetMarket || customerPersonas[0]?.demographics?.industry || null;
+
+  // 1. Upsert customer personas and create venture_persona_mapping
+  for (let idx = 0; idx < customerPersonas.length; idx++) {
+    const persona = customerPersonas[idx];
+    try {
+      const { data: personaRow, error: personaErr } = await supabase
+        .from('customer_personas')
+        .upsert({
+          name: persona.name,
+          demographics: persona.demographics,
+          goals: persona.goals,
+          pain_points: persona.painPoints,
+          psychographics: { behaviors: persona.behaviors, motivations: persona.motivations },
+          industry: ventureIndustry,
+          source_venture_id: ventureId,
+        }, { onConflict: 'idx_customer_personas_canonical' })
+        .select('id')
+        .single();
+
+      if (personaErr) {
+        logger.warn('[Stage10] Persona upsert failed', { name: persona.name, error: personaErr.message });
+        continue;
+      }
+
+      // Create venture_persona_mapping with role encoded in notes and relevance_score
+      const role = idx === 0 ? 'primary' : idx === 1 ? 'secondary' : 'tertiary';
+      const relevanceScore = idx === 0 ? 1.0 : idx === 1 ? 0.75 : 0.5;
+      const { error: mappingErr } = await supabase
+        .from('venture_persona_mapping')
+        .upsert({
+          venture_id: ventureId,
+          persona_id: personaRow.id,
+          relevance_score: relevanceScore,
+          notes: JSON.stringify({ role, source_stage: 10, generated_at: new Date().toISOString() }),
+        }, { onConflict: 'venture_persona_mapping_venture_id_persona_id_key' })
+        .select('id');
+
+      if (mappingErr) {
+        logger.warn('[Stage10] Persona mapping upsert failed', { personaId: personaRow.id, error: mappingErr.message });
+      }
+    } catch (err) {
+      logger.warn('[Stage10] Persona write-through error', { name: persona.name, error: err.message });
+    }
+  }
+
+  // 2. Create brand genome via service
+  try {
+    const { createBrandGenome } = await import('../../services/brand-genome.js');
+    const genomeResult = await createBrandGenome(supabase, {
+      venture_id: ventureId,
+      created_by: 'eva-stage-10',
+      brand_data: {
+        archetype: brandGenome.archetype,
+        values: brandGenome.values,
+        tone: brandGenome.tone,
+        audience: brandGenome.audience,
+        differentiators: brandGenome.differentiators,
+        customerAlignment: brandGenome.customerAlignment,
+      },
+    });
+    logger.log('[Stage10] Brand genome created', { id: genomeResult?.id });
+
+    // Write venture_artifacts ref for brand genome
+    try {
+      await supabase.from('venture_artifacts').insert({
+        venture_id: ventureId,
+        lifecycle_stage: 10,
+        artifact_type: 'brand_guidelines',
+        title: 'Brand Genome (Stage 10)',
+        metadata: { brand_genome_id: genomeResult?.id, source: 'stage-10-analysis' },
+      });
+    } catch (artifactErr) {
+      logger.warn('[Stage10] Brand genome artifact ref failed', { error: artifactErr.message });
+    }
+  } catch (err) {
+    logger.warn('[Stage10] Brand genome creation failed', { error: err.message });
+  }
+
+  // 3. Write venture_artifacts ref for persona catalog
+  try {
+    await supabase.from('venture_artifacts').insert({
+      venture_id: ventureId,
+      lifecycle_stage: 10,
+      artifact_type: 'brand_guidelines',
+      title: 'Customer Personas (Stage 10)',
+      metadata: { persona_count: customerPersonas.length, source: 'stage-10-analysis' },
+    });
+  } catch (err) {
+    logger.warn('[Stage10] Persona artifact ref failed', { error: err.message });
+  }
 }
 
 export { MIN_PERSONAS, MIN_CANDIDATES, MIN_CRITERIA, NAMING_STRATEGIES };

--- a/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
@@ -97,7 +97,7 @@ Rules:
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Naming & visual identity analysis
  */
-export async function analyzeStage11({ stage1Data, stage5Data, stage10Data, ventureName, logger = console }) {
+export async function analyzeStage11({ stage1Data, stage5Data, stage10Data, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage11] Starting naming & visual identity analysis', { ventureName });
 
@@ -337,6 +337,11 @@ Output ONLY valid JSON.`;
     logger.warn('[Stage11] LLM fallback fields detected', { llmFallbackCount });
   }
 
+  // --- DB Write-Through: Naming Suggestions + Venture Artifacts ---
+  if (supabase && ventureId) {
+    await writeStage11Artifacts({ supabase, ventureId, candidates, logger });
+  }
+
   logger.log('[Stage11] Analysis complete', { duration: Date.now() - startTime, candidateCount: candidates.length });
   return {
     namingStrategy,
@@ -350,6 +355,66 @@ Output ONLY valid JSON.`;
     fourBuckets, usage, llmFallbackCount,
     ...(tournamentMeta ? { tournament: tournamentMeta } : {}),
   };
+}
+
+/**
+ * Write Stage 11 naming candidates to naming_suggestions and venture_artifacts.
+ * All DB writes are non-fatal — errors are logged and swallowed.
+ */
+async function writeStage11Artifacts({ supabase, ventureId, candidates, logger }) {
+  // Generate a session UUID per Stage 11 run
+  const generationSessionId = crypto.randomUUID();
+
+  for (const candidate of candidates) {
+    try {
+      // Compute brand_fit_score from personaFit average if available
+      const personaFitAvg = Array.isArray(candidate.personaFit) && candidate.personaFit.length > 0
+        ? Math.round(candidate.personaFit.reduce((sum, pf) => sum + (pf.fitScore || 0), 0) / candidate.personaFit.length)
+        : null;
+
+      // Map pronounceability from scoring criteria if present
+      const pronounceabilityScore = candidate.scores?.['Pronounceability'] ?? candidate.scores?.['Memorability'] ?? null;
+      const uniquenessScore = candidate.scores?.['Uniqueness'] ?? null;
+
+      const { error: insertErr } = await supabase.from('naming_suggestions').insert({
+        venture_id: ventureId,
+        generation_session_id: generationSessionId,
+        name: candidate.name,
+        rationale: candidate.rationale,
+        brand_fit_score: personaFitAvg,
+        pronounceability_score: pronounceabilityScore,
+        uniqueness_score: uniquenessScore,
+        domain_com_status: 'unknown',
+        domain_io_status: 'unknown',
+        domain_ai_status: 'unknown',
+      });
+
+      if (insertErr) {
+        logger.warn('[Stage11] Naming suggestion insert failed', { name: candidate.name, error: insertErr.message });
+      }
+    } catch (err) {
+      logger.warn('[Stage11] Naming suggestion write error', { name: candidate.name, error: err.message });
+    }
+  }
+
+  // Write venture_artifacts ref for naming session
+  try {
+    await supabase.from('venture_artifacts').insert({
+      venture_id: ventureId,
+      lifecycle_stage: 11,
+      artifact_type: 'brand_name',
+      title: 'Naming Candidates (Stage 11)',
+      metadata: {
+        generation_session_id: generationSessionId,
+        candidate_count: candidates.length,
+        source: 'stage-11-analysis',
+      },
+    });
+  } catch (err) {
+    logger.warn('[Stage11] Naming artifact ref failed', { error: err.message });
+  }
+
+  logger.log('[Stage11] Wrote naming suggestions', { sessionId: generationSessionId, count: candidates.length });
 }
 
 export { MIN_CANDIDATES, MIN_CRITERIA, NAMING_STRATEGIES };

--- a/tests/unit/eva/brand-stage-wiring.test.js
+++ b/tests/unit/eva/brand-stage-wiring.test.js
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for Stage 10/11 Brand Wiring
+ * SD: SD-LEO-INFRA-WIRE-STAGE-BRAND-001
+ *
+ * Tests:
+ * - Persona role assignment logic (first=primary, rest=secondary/tertiary)
+ * - Naming score mapping from candidate scores and personaFit
+ *
+ * @module tests/unit/eva/brand-stage-wiring.test
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the LLM client and brand-genome service
+vi.mock('../../../lib/llm/index.js', () => ({
+  getLLMClient: vi.fn(() => ({
+    complete: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../lib/eva/services/brand-genome.js', () => ({
+  createBrandGenome: vi.fn().mockResolvedValue({ id: 'bg-mock-id' }),
+}));
+
+import { analyzeStage10 } from '../../../lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js';
+import { getLLMClient } from '../../../lib/llm/index.js';
+
+/**
+ * Helper: create well-formed Stage 10 LLM response.
+ */
+function createStage10Response(overrides = {}) {
+  return JSON.stringify({
+    customerPersonas: [
+      {
+        name: 'Enterprise CTO',
+        demographics: { role: 'CTO', industry: 'Technology', ageRange: '35-50' },
+        goals: ['Reduce infra costs', 'Improve reliability'],
+        painPoints: ['Vendor lock-in', 'Scaling complexity'],
+        behaviors: ['Evaluates new tools quarterly'],
+        motivations: ['Team productivity'],
+      },
+      {
+        name: 'Startup Founder',
+        demographics: { role: 'CEO', industry: 'Technology', ageRange: '25-35' },
+        goals: ['Ship fast', 'Find PMF'],
+        painPoints: ['Limited budget'],
+        behaviors: ['Early adopter'],
+        motivations: ['Growth'],
+      },
+      {
+        name: 'DevOps Lead',
+        demographics: { role: 'DevOps', industry: 'Technology', ageRange: '28-40' },
+        goals: ['Automate everything'],
+        painPoints: ['Alert fatigue'],
+        behaviors: ['CLI-first'],
+        motivations: ['Efficiency'],
+      },
+    ],
+    brandGenome: {
+      archetype: 'Creator',
+      values: ['Reliability', 'Speed'],
+      tone: 'Confident and technical',
+      audience: 'Engineering teams',
+      differentiators: ['AI-native'],
+      customerAlignment: [
+        { trait: 'Reliability', personaName: 'Enterprise CTO', personaInsight: 'CTOs need uptime' },
+      ],
+    },
+    brandPersonality: {
+      vision: 'Make infrastructure invisible',
+      mission: 'We automate the boring parts',
+      brandVoice: 'Technical but human',
+    },
+    namingStrategy: 'abstract',
+    scoringCriteria: [
+      { name: 'Memorability', weight: 25 },
+      { name: 'Relevance', weight: 25 },
+      { name: 'Uniqueness', weight: 25 },
+      { name: 'Persona Resonance', weight: 25 },
+    ],
+    candidates: [
+      { name: 'Stratum', rationale: 'Layers of infrastructure', scores: { Memorability: 90, Relevance: 85, Uniqueness: 80, 'Persona Resonance': 88 } },
+      { name: 'Nimbus', rationale: 'Cloud metaphor', scores: { Memorability: 75, Relevance: 70, Uniqueness: 65, 'Persona Resonance': 72 } },
+      { name: 'Forge', rationale: 'Building tools', scores: { Memorability: 80, Relevance: 78, Uniqueness: 60, 'Persona Resonance': 76 } },
+      { name: 'Axiom', rationale: 'Foundational truth', scores: { Memorability: 85, Relevance: 82, Uniqueness: 90, 'Persona Resonance': 80 } },
+      { name: 'Lattice', rationale: 'Interconnected', scores: { Memorability: 70, Relevance: 75, Uniqueness: 72, 'Persona Resonance': 68 } },
+    ],
+    decision: {
+      selectedName: 'Stratum',
+      workingTitle: true,
+      rationale: 'Top scorer overall',
+      availabilityChecks: { domain: 'pending', trademark: 'pending', social: 'pending' },
+    },
+    ...overrides,
+  });
+}
+
+describe('Stage 10 Brand Wiring — Persona Role Assignment', () => {
+  let mockSupabase;
+  let personaUpsertCalls;
+  let mappingUpsertCalls;
+  let artifactInsertCalls;
+
+  beforeEach(() => {
+    personaUpsertCalls = [];
+    mappingUpsertCalls = [];
+    artifactInsertCalls = [];
+
+    // Build a chainable mock for supabase
+    const mockChain = (calls) => {
+      const chain = {};
+      chain.upsert = (...args) => { calls.push(args[0]); return chain; };
+      chain.insert = (...args) => { calls.push(args[0]); return chain; };
+      chain.select = () => chain;
+      chain.single = () => Promise.resolve({ data: { id: `mock-${Math.random().toString(36).slice(2, 8)}` }, error: null });
+      return chain;
+    };
+
+    mockSupabase = {
+      from: vi.fn((table) => {
+        if (table === 'customer_personas') return mockChain(personaUpsertCalls);
+        if (table === 'venture_persona_mapping') return mockChain(mappingUpsertCalls);
+        if (table === 'venture_artifacts') return mockChain(artifactInsertCalls);
+        return mockChain([]);
+      }),
+    };
+
+    const mockComplete = vi.fn().mockResolvedValue(createStage10Response());
+    getLLMClient.mockReturnValue({ complete: mockComplete });
+  });
+
+  it('assigns primary role to first persona, secondary to second, tertiary to rest', async () => {
+    const result = await analyzeStage10({
+      stage1Data: { description: 'Cloud infra platform', targetMarket: 'Engineering teams' },
+      ventureName: 'TestVenture',
+      ventureId: 'venture-uuid-123',
+      supabase: mockSupabase,
+      logger: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    // Verify 3 personas created
+    expect(result.customerPersonas).toHaveLength(3);
+
+    // Verify persona mapping calls happened (3 personas = 3 mapping calls)
+    expect(mappingUpsertCalls).toHaveLength(3);
+
+    // Check role assignment via notes and relevance_score
+    const roles = mappingUpsertCalls.map(call => JSON.parse(call.notes).role);
+    expect(roles[0]).toBe('primary');
+    expect(roles[1]).toBe('secondary');
+    expect(roles[2]).toBe('tertiary');
+
+    // Check relevance scores
+    const scores = mappingUpsertCalls.map(call => call.relevance_score);
+    expect(scores[0]).toBe(1.0);
+    expect(scores[1]).toBe(0.75);
+    expect(scores[2]).toBe(0.5);
+  });
+
+  it('writes brand genome artifact ref', async () => {
+    await analyzeStage10({
+      stage1Data: { description: 'Cloud infra platform', targetMarket: 'Engineering teams' },
+      ventureName: 'TestVenture',
+      ventureId: 'venture-uuid-123',
+      supabase: mockSupabase,
+      logger: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    // Should have 2 artifact inserts: brand genome + persona catalog
+    expect(artifactInsertCalls).toHaveLength(2);
+
+    const brandArtifact = artifactInsertCalls.find(a => a.title === 'Brand Genome (Stage 10)');
+    expect(brandArtifact).toBeDefined();
+    expect(brandArtifact.lifecycle_stage).toBe(10);
+    expect(brandArtifact.artifact_type).toBe('brand_guidelines');
+  });
+
+  it('skips DB writes when supabase is not provided', async () => {
+    const result = await analyzeStage10({
+      stage1Data: { description: 'Cloud infra platform', targetMarket: 'Engineering teams' },
+      ventureName: 'TestVenture',
+      logger: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    // Should still return valid analysis
+    expect(result.customerPersonas).toHaveLength(3);
+    expect(result.brandGenome.archetype).toBe('Creator');
+
+    // No DB calls made
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+});
+
+describe('Stage 11 Brand Wiring — Naming Score Mapping', () => {
+  it('maps persona fit average to brand_fit_score', () => {
+    // Test the score mapping logic directly
+    const candidate = {
+      name: 'TestName',
+      rationale: 'Test rationale',
+      scores: { Memorability: 90, Uniqueness: 85 },
+      personaFit: [
+        { personaName: 'CTO', fitScore: 80, reasoning: 'Good fit' },
+        { personaName: 'Founder', fitScore: 70, reasoning: 'Decent fit' },
+        { personaName: 'DevOps', fitScore: 90, reasoning: 'Great fit' },
+      ],
+    };
+
+    // brand_fit_score = average of personaFit fitScores
+    const personaFitAvg = Array.isArray(candidate.personaFit) && candidate.personaFit.length > 0
+      ? Math.round(candidate.personaFit.reduce((sum, pf) => sum + (pf.fitScore || 0), 0) / candidate.personaFit.length)
+      : null;
+
+    expect(personaFitAvg).toBe(80); // (80+70+90)/3 = 80
+
+    // pronounceability_score falls back to Memorability when Pronounceability absent
+    const pronounceabilityScore = candidate.scores?.['Pronounceability'] ?? candidate.scores?.['Memorability'] ?? null;
+    expect(pronounceabilityScore).toBe(90);
+
+    // uniqueness_score maps directly
+    const uniquenessScore = candidate.scores?.['Uniqueness'] ?? null;
+    expect(uniquenessScore).toBe(85);
+  });
+
+  it('returns null brand_fit_score when no personaFit data', () => {
+    const candidate = {
+      name: 'TestName',
+      scores: { Memorability: 90, Uniqueness: 85 },
+      personaFit: [],
+    };
+
+    const personaFitAvg = Array.isArray(candidate.personaFit) && candidate.personaFit.length > 0
+      ? Math.round(candidate.personaFit.reduce((sum, pf) => sum + (pf.fitScore || 0), 0) / candidate.personaFit.length)
+      : null;
+
+    expect(personaFitAvg).toBeNull();
+  });
+
+  it('maps domain statuses to unknown', () => {
+    // Verify the domain status values match naming_suggestions CHECK constraints
+    const validStatuses = ['available', 'taken', 'error', 'unknown'];
+    const defaultStatus = 'unknown';
+    expect(validStatuses).toContain(defaultStatus);
+  });
+});


### PR DESCRIPTION
## Summary
- Wire Stage 10 to customer_personas (cross-venture dedup), brand_genome_submissions, venture_persona_mapping
- Wire Stage 11 to naming_suggestions with evaluation scores
- Tighten RLS on 4 SRIP tables from USING(true) to venture-scoped
- 6 unit tests, migration validated by database agent

## Test plan
- [x] 6/6 unit tests passing
- [x] RLS migration executed and verified (20 policies across 4 tables)

SD: SD-LEO-INFRA-WIRE-STAGE-BRAND-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)