### PR TITLE
fix: Stage 14-15 contract declarations and work_type config

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -237,7 +237,14 @@ const STAGE_CONTRACTS = new Map([
   }],
 
   [14, {
-    consumes: [],
+    consumes: [
+      { stage: 1, fields: {
+        description: { type: 'string' },
+      }},
+      { stage: 13, fields: {
+        milestones: { type: 'array' },
+      }},
+    ],
     produces: {
       architecture_summary: { type: 'string', minLength: 20 },
       layers: { type: 'object' },
@@ -246,7 +253,20 @@ const STAGE_CONTRACTS = new Map([
   }],
 
   [15, {
-    consumes: [],
+    consumes: [
+      { stage: 1, fields: {
+        description: { type: 'string' },
+      }},
+      { stage: 6, fields: {
+        risks: { type: 'array', required: false },
+      }},
+      { stage: 13, fields: {
+        milestones: { type: 'array' },
+      }},
+      { stage: 14, fields: {
+        layers: { type: 'object' },
+      }},
+    ],
     produces: {
       risks: { type: 'array', minItems: 1 },
       total_risks: { type: 'number' },


### PR DESCRIPTION
## Summary
- Fixed Stage 14 and 15 empty `consumes` arrays in `stage-contracts.js` to match YAML spec
- Stage 14 now declares consumes from stages 1 (description) and 13 (milestones)
- Stage 15 now declares consumes from stages 1, 6, 13, and 14 per YAML contract
- Updated `lifecycle_stage_config.work_type` from `sd_required` to `artifact_only` for stages 14 and 15 (DB change)

## Test plan
- [x] All 18 stage-contracts unit tests pass
- [x] All 5 gap-012 enforcement tests pass
- [x] 15 smoke tests pass
- [x] Verified JS contract matches YAML specification for stages 14 and 15

SD: SD-LEO-FIX-FIX-BLUEPRINT-STAGE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)