### PR TITLE
feat: SRIP core pipeline — site DNA, brand interviews, synthesis

### DIFF
--- a/database/migrations/srip_rls_policies.sql
+++ b/database/migrations/srip_rls_policies.sql
@@ -1,0 +1,141 @@
+-- =============================================================================
+-- Migration: srip_rls_policies.sql
+-- Purpose: Replace owner-subquery RLS with JWT venture_id claim-based policies
+-- SD: SD-LEO-INFRA-SRIP-CORE-PIPELINE-001
+-- Date: 2026-03-15
+--
+-- Replaces the existing `_owner` policies (which use a subquery against the
+-- ventures table) with `_venture` policies that match venture_id directly
+-- against the authenticated user's JWT app_metadata.venture_id claim.
+--
+-- This is more performant (no subquery) and supports multi-tenant access
+-- where venture_id is set in the JWT at login time.
+--
+-- Tables affected:
+--   - srip_site_dna
+--   - srip_brand_interviews
+--   - srip_synthesis_prompts
+--
+-- Rollback:
+--   Re-run srip_rls_tightening.sql to restore owner-subquery policies
+-- =============================================================================
+
+BEGIN;
+
+-- ============================================================
+-- 1. srip_site_dna — replace owner-subquery with JWT claim
+-- ============================================================
+
+-- Drop existing policies
+DROP POLICY IF EXISTS srip_site_dna_select_owner ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_insert_owner ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_update_owner ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_delete_owner ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_service_all ON srip_site_dna;
+
+-- Also drop old _policy variants (if any remnants)
+DROP POLICY IF EXISTS srip_site_dna_select_policy ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_insert_policy ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_update_policy ON srip_site_dna;
+DROP POLICY IF EXISTS srip_site_dna_delete_policy ON srip_site_dna;
+
+-- RLS already enabled, ensure it stays on
+ALTER TABLE srip_site_dna ENABLE ROW LEVEL SECURITY;
+
+-- Service role bypass
+CREATE POLICY "srip_site_dna_service_role" ON srip_site_dna
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Venture-scoped access via JWT claim
+CREATE POLICY "srip_site_dna_venture_select" ON srip_site_dna
+  FOR SELECT TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "srip_site_dna_venture_insert" ON srip_site_dna
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "srip_site_dna_venture_update" ON srip_site_dna
+  FOR UPDATE TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid)
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+
+-- ============================================================
+-- 2. srip_brand_interviews — replace owner-subquery with JWT claim
+-- ============================================================
+
+-- Drop existing policies
+DROP POLICY IF EXISTS srip_brand_interviews_select_owner ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_insert_owner ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_update_owner ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_delete_owner ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_service_all ON srip_brand_interviews;
+
+-- Also drop old _policy variants
+DROP POLICY IF EXISTS srip_brand_interviews_select_policy ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_insert_policy ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_update_policy ON srip_brand_interviews;
+DROP POLICY IF EXISTS srip_brand_interviews_delete_policy ON srip_brand_interviews;
+
+-- RLS already enabled, ensure it stays on
+ALTER TABLE srip_brand_interviews ENABLE ROW LEVEL SECURITY;
+
+-- Service role bypass
+CREATE POLICY "srip_brand_interviews_service_role" ON srip_brand_interviews
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Venture-scoped access via JWT claim
+CREATE POLICY "srip_brand_interviews_venture_select" ON srip_brand_interviews
+  FOR SELECT TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "srip_brand_interviews_venture_insert" ON srip_brand_interviews
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "srip_brand_interviews_venture_update" ON srip_brand_interviews
+  FOR UPDATE TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid)
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+
+-- ============================================================
+-- 3. srip_synthesis_prompts — replace owner-subquery with JWT claim
+-- ============================================================
+
+-- Drop existing policies
+DROP POLICY IF EXISTS srip_synthesis_prompts_select_owner ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_insert_owner ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_update_owner ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_delete_owner ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_service_all ON srip_synthesis_prompts;
+
+-- Also drop old _policy variants
+DROP POLICY IF EXISTS srip_synthesis_prompts_select_policy ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_insert_policy ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_update_policy ON srip_synthesis_prompts;
+DROP POLICY IF EXISTS srip_synthesis_prompts_delete_policy ON srip_synthesis_prompts;
+
+-- RLS already enabled, ensure it stays on
+ALTER TABLE srip_synthesis_prompts ENABLE ROW LEVEL SECURITY;
+
+-- Service role bypass
+CREATE POLICY "srip_synthesis_prompts_service_role" ON srip_synthesis_prompts
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Venture-scoped access via JWT claim
+CREATE POLICY "srip_synthesis_prompts_venture_select" ON srip_synthesis_prompts
+  FOR SELECT TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "srip_synthesis_prompts_venture_insert" ON srip_synthesis_prompts
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "srip_synthesis_prompts_venture_update" ON srip_synthesis_prompts
+  FOR UPDATE TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid)
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+COMMIT;

--- a/lib/eva/services/index.js
+++ b/lib/eva/services/index.js
@@ -73,3 +73,12 @@ export {
   getActiveSynthesisPrompt,
   activatePrompt,
 } from './srip-synthesis.js';
+
+// SRIP business logic
+export {
+  generateInterviewDefaults,
+  getInterviewQuestions,
+  INTERVIEW_QUESTIONS,
+} from './srip-interview-engine.js';
+
+export { buildSynthesisPrompt } from './srip-prompt-builder.js';

--- a/lib/eva/services/srip-interview-engine.js
+++ b/lib/eva/services/srip-interview-engine.js
@@ -1,0 +1,191 @@
+/**
+ * SRIP Brand Interview Engine
+ * SD: SD-LEO-INFRA-SRIP-CORE-PIPELINE-001
+ *
+ * Defines 12 structured brand interview questions and pre-populates
+ * default answers from extracted Site DNA. Chairman reviews and overrides.
+ */
+
+/**
+ * The 12 brand interview questions.
+ * Each question has a key, label, help text, and a function to derive
+ * a default answer from Site DNA JSON.
+ */
+const INTERVIEW_QUESTIONS = [
+  {
+    key: 'brand_personality',
+    label: 'Brand Personality',
+    helpText: 'How would you describe the brand personality in 3-5 adjectives?',
+    deriveDefault: (dna) => {
+      const tone = dna?.copy_patterns?.tone;
+      if (tone) return tone;
+      const headings = dna?.copy_patterns?.headings || [];
+      if (headings.length === 0) return null;
+      return 'Professional, modern';
+    },
+  },
+  {
+    key: 'primary_audience',
+    label: 'Primary Audience',
+    helpText: 'Who is the primary target audience for this brand?',
+    deriveDefault: (dna) => {
+      const ctas = dna?.copy_patterns?.ctas || [];
+      const hasBusinessCtas = ctas.some(c =>
+        /demo|trial|enterprise|pricing|contact sales/i.test(c)
+      );
+      return hasBusinessCtas ? 'Business professionals / B2B' : 'General consumers';
+    },
+  },
+  {
+    key: 'color_intent',
+    label: 'Color Intent',
+    helpText: 'What emotion or feeling should the primary colors evoke?',
+    deriveDefault: (dna) => {
+      const primary = dna?.design_tokens?.colors?.primary;
+      if (!primary) return null;
+      // Basic color-to-emotion mapping
+      const hex = primary.toLowerCase();
+      if (hex.startsWith('#0') || hex.startsWith('#1') || hex.includes('blue')) return 'Trust, stability, professionalism';
+      if (hex.includes('green') || hex.startsWith('#2')) return 'Growth, health, nature';
+      if (hex.includes('red') || hex.startsWith('#e') || hex.startsWith('#f')) return 'Energy, urgency, passion';
+      return 'Balanced, neutral';
+    },
+  },
+  {
+    key: 'typography_style',
+    label: 'Typography Style',
+    helpText: 'What typographic style best represents the brand? (e.g., clean sans-serif, elegant serif)',
+    deriveDefault: (dna) => {
+      const fontFamily = dna?.design_tokens?.typography?.font_family;
+      if (!fontFamily) return null;
+      const lower = fontFamily.toLowerCase();
+      if (/serif/i.test(lower) && !/sans/i.test(lower)) return `Elegant serif (${fontFamily})`;
+      if (/mono/i.test(lower)) return `Technical monospace (${fontFamily})`;
+      return `Clean sans-serif (${fontFamily})`;
+    },
+  },
+  {
+    key: 'layout_philosophy',
+    label: 'Layout Philosophy',
+    helpText: 'How should content be organized? (e.g., spacious/minimal, dense/information-rich)',
+    deriveDefault: (dna) => {
+      const arch = dna?.macro_architecture;
+      if (!arch) return null;
+      const flow = arch.page_flow;
+      if (flow === 'multi-section') return 'Structured multi-section with clear hierarchy';
+      return 'Single-column, focused content flow';
+    },
+  },
+  {
+    key: 'visual_density',
+    label: 'Visual Density',
+    helpText: 'How much visual content vs whitespace? (minimal, balanced, rich)',
+    deriveDefault: (dna) => {
+      const components = dna?.component_behaviors?.components || [];
+      if (components.length >= 4) return 'Rich — multiple component types detected';
+      if (components.length >= 2) return 'Balanced';
+      return 'Minimal';
+    },
+  },
+  {
+    key: 'interaction_style',
+    label: 'Interaction Style',
+    helpText: 'How interactive should the experience be? (static, moderate, highly interactive)',
+    deriveDefault: (dna) => {
+      const components = dna?.component_behaviors?.components || [];
+      const hasForms = components.some(c => c.type === 'form');
+      const hasCards = components.some(c => c.type === 'card_grid');
+      if (hasForms && hasCards) return 'Highly interactive — forms and dynamic content';
+      if (hasForms || hasCards) return 'Moderate — some interactive elements';
+      return 'Primarily static content';
+    },
+  },
+  {
+    key: 'content_tone',
+    label: 'Content Tone',
+    helpText: 'What tone should written content use? (formal, conversational, technical)',
+    deriveDefault: (dna) => {
+      const paragraphs = dna?.copy_patterns?.sample_paragraphs || [];
+      const wordCount = dna?.copy_patterns?.word_count || 0;
+      if (wordCount > 2000) return 'Content-heavy — likely informational or editorial';
+      if (paragraphs.length === 0) return null;
+      return 'Concise and direct';
+    },
+  },
+  {
+    key: 'mobile_priority',
+    label: 'Mobile Priority',
+    helpText: 'How important is the mobile experience? (mobile-first, desktop-first, equal)',
+    deriveDefault: (dna) => {
+      const approach = dna?.macro_architecture?.responsive_approach;
+      if (approach === 'mobile-first') return 'Mobile-first (viewport meta detected)';
+      return 'Desktop-first';
+    },
+  },
+  {
+    key: 'brand_differentiator',
+    label: 'Brand Differentiator',
+    helpText: 'What makes this brand unique compared to competitors?',
+    deriveDefault: (dna) => {
+      const headings = dna?.copy_patterns?.headings || [];
+      if (headings.length > 0) return `Key message: "${headings[0]}"`;
+      return null;
+    },
+  },
+  {
+    key: 'tech_alignment',
+    label: 'Technology Alignment',
+    helpText: 'What technology stack or approach should the design align with?',
+    deriveDefault: (dna) => {
+      const tech = dna?.tech_stack;
+      if (!tech) return null;
+      const parts = [];
+      if (tech.framework !== 'unknown') parts.push(tech.framework);
+      if (tech.css_approach !== 'unknown') parts.push(tech.css_approach);
+      if (tech.rendering) parts.push(tech.rendering);
+      return parts.length > 0 ? parts.join(' + ') : null;
+    },
+  },
+  {
+    key: 'design_constraints',
+    label: 'Design Constraints',
+    helpText: 'Are there any constraints? (accessibility requirements, brand guidelines, performance targets)',
+    deriveDefault: () => null, // Always requires manual input
+  },
+];
+
+/**
+ * Generate interview answers pre-populated from Site DNA.
+ *
+ * @param {object} dnaJson - The dna_json field from srip_site_dna
+ * @returns {{ answers: Record<string, { question: string, helpText: string, default: string|null, confirmed: boolean }>, prePopulatedCount: number }}
+ */
+export function generateInterviewDefaults(dnaJson) {
+  const answers = {};
+  let prePopulatedCount = 0;
+
+  for (const q of INTERVIEW_QUESTIONS) {
+    const defaultValue = q.deriveDefault(dnaJson);
+    if (defaultValue) prePopulatedCount++;
+
+    answers[q.key] = {
+      question: q.label,
+      helpText: q.helpText,
+      default: defaultValue,
+      value: defaultValue, // Chairman can override
+      confirmed: false,
+    };
+  }
+
+  return { answers, prePopulatedCount };
+}
+
+/**
+ * Get the list of all 12 interview questions (without DNA defaults).
+ * @returns {Array<{ key: string, label: string, helpText: string }>}
+ */
+export function getInterviewQuestions() {
+  return INTERVIEW_QUESTIONS.map(({ key, label, helpText }) => ({ key, label, helpText }));
+}
+
+export { INTERVIEW_QUESTIONS };

--- a/lib/eva/services/srip-prompt-builder.js
+++ b/lib/eva/services/srip-prompt-builder.js
@@ -1,0 +1,152 @@
+/**
+ * SRIP Synthesis Prompt Builder
+ * SD: SD-LEO-INFRA-SRIP-CORE-PIPELINE-001
+ *
+ * Combines Site DNA + Brand Interview answers into a single LLM prompt
+ * for downstream brand generation stages (12-14).
+ */
+
+/**
+ * Build a synthesis prompt from DNA and interview data.
+ *
+ * @param {object} params
+ * @param {object} params.dnaJson - The dna_json from srip_site_dna
+ * @param {Record<string, { value: string|null, confirmed: boolean }>} params.answers - Interview answers
+ * @param {string} [params.ventureName] - Optional venture name for context
+ * @returns {{ promptText: string, tokenEstimate: number }}
+ */
+export function buildSynthesisPrompt({ dnaJson, answers, ventureName }) {
+  const sections = [];
+
+  // Header
+  sections.push('# Brand Synthesis Context');
+  if (ventureName) sections.push(`## Venture: ${ventureName}`);
+  sections.push(`## Source: ${dnaJson?.source_url || 'Manual entry'}`);
+  sections.push(`## Extracted: ${dnaJson?.extracted_at || 'N/A'}`);
+  sections.push('');
+
+  // Design Tokens Section
+  const tokens = dnaJson?.design_tokens;
+  if (tokens) {
+    sections.push('## Design Tokens');
+    if (tokens.colors) {
+      sections.push('### Colors');
+      sections.push(`- Primary: ${tokens.colors.primary || 'not detected'}`);
+      sections.push(`- Secondary: ${tokens.colors.secondary || 'not detected'}`);
+      sections.push(`- Accent: ${tokens.colors.accent || 'not detected'}`);
+      sections.push(`- Background: ${tokens.colors.background || '#ffffff'}`);
+      sections.push(`- Text: ${tokens.colors.text || '#333333'}`);
+      if (tokens.colors.additional?.length > 0) {
+        sections.push(`- Additional: ${tokens.colors.additional.join(', ')}`);
+      }
+    }
+    if (tokens.typography) {
+      sections.push('### Typography');
+      sections.push(`- Primary Font: ${tokens.typography.font_family || 'sans-serif'}`);
+      if (tokens.typography.heading_font) {
+        sections.push(`- Heading Font: ${tokens.typography.heading_font}`);
+      }
+      if (tokens.typography.size_scale) {
+        sections.push(`- Size Scale: ${tokens.typography.size_scale.join(', ')}`);
+      }
+    }
+    if (tokens.spacing) {
+      sections.push(`### Spacing: ${tokens.spacing.join(', ')}`);
+    }
+    if (tokens.border_radius) {
+      sections.push(`### Border Radius: ${tokens.border_radius.join(', ')}`);
+    }
+    sections.push('');
+  }
+
+  // Macro Architecture Section
+  const arch = dnaJson?.macro_architecture;
+  if (arch) {
+    sections.push('## Page Architecture');
+    sections.push(`- Header: ${arch.has_header ? 'Yes' : 'No'}`);
+    sections.push(`- Footer: ${arch.has_footer ? 'Yes' : 'No'}`);
+    sections.push(`- Main Content: ${arch.has_main ? 'Yes' : 'No'}`);
+    sections.push(`- Grid System: ${arch.grid_system || 'unknown'}`);
+    sections.push(`- Responsive: ${arch.responsive_approach || 'unknown'}`);
+    sections.push(`- Page Flow: ${arch.page_flow || 'unknown'}`);
+    if (arch.sections?.length > 0) {
+      sections.push('### Sections');
+      for (const s of arch.sections) {
+        sections.push(`- ${s.heading || s.tag} (${s.childCount} children)`);
+      }
+    }
+    sections.push('');
+  }
+
+  // Component Behaviors Section
+  const behaviors = dnaJson?.component_behaviors;
+  if (behaviors?.components?.length > 0) {
+    sections.push('## Components Detected');
+    for (const comp of behaviors.components) {
+      const details = Object.entries(comp)
+        .filter(([k]) => k !== 'type')
+        .map(([k, v]) => `${k}: ${v}`)
+        .join(', ');
+      sections.push(`- ${comp.type}: ${details}`);
+    }
+    sections.push('');
+  }
+
+  // Copy Patterns Section
+  const copy = dnaJson?.copy_patterns;
+  if (copy) {
+    sections.push('## Copy Patterns');
+    if (copy.headings?.length > 0) {
+      sections.push('### Key Headings');
+      for (const h of copy.headings.slice(0, 5)) {
+        sections.push(`- "${h}"`);
+      }
+    }
+    if (copy.ctas?.length > 0) {
+      sections.push('### CTAs');
+      for (const c of copy.ctas.slice(0, 5)) {
+        sections.push(`- "${c}"`);
+      }
+    }
+    if (copy.word_count) {
+      sections.push(`### Content Volume: ~${copy.word_count} words`);
+    }
+    sections.push('');
+  }
+
+  // Tech Stack Section
+  const tech = dnaJson?.tech_stack;
+  if (tech) {
+    sections.push('## Technology Stack');
+    sections.push(`- Framework: ${tech.framework || 'unknown'}`);
+    sections.push(`- CSS: ${tech.css_approach || 'unknown'}`);
+    sections.push(`- Rendering: ${tech.rendering || 'unknown'}`);
+    sections.push('');
+  }
+
+  // Brand Interview Responses Section
+  sections.push('## Brand Interview Responses');
+  if (answers && typeof answers === 'object') {
+    for (const [key, answer] of Object.entries(answers)) {
+      const value = answer?.value || answer?.default || 'Not provided';
+      const status = answer?.confirmed ? '(confirmed)' : '(auto-derived)';
+      sections.push(`### ${answer?.question || key}`);
+      sections.push(`${value} ${status}`);
+      sections.push('');
+    }
+  }
+
+  // Generation Instructions
+  sections.push('## Generation Instructions');
+  sections.push('Use the above brand context to generate design artifacts that:');
+  sections.push('1. Match the detected color palette and typography exactly');
+  sections.push('2. Follow the identified layout patterns and component structure');
+  sections.push('3. Align with the brand personality and audience described in the interview');
+  sections.push('4. Maintain the same content tone and interaction style');
+  sections.push('5. Are compatible with the detected technology stack');
+
+  const promptText = sections.join('\n');
+  const tokenEstimate = Math.ceil(promptText.length / 4); // Rough estimate
+
+  return { promptText, tokenEstimate };
+}

--- a/tests/unit/srip/srip-interview-engine.test.js
+++ b/tests/unit/srip/srip-interview-engine.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateInterviewDefaults,
+  getInterviewQuestions,
+  INTERVIEW_QUESTIONS,
+} from '../../../lib/eva/services/srip-interview-engine.js';
+
+const SAMPLE_DNA = {
+  design_tokens: {
+    colors: {
+      primary: '#0066cc',
+      secondary: '#333333',
+      accent: '#ff6600',
+      background: '#ffffff',
+      text: '#333333',
+      additional: ['#eeeeee'],
+    },
+    typography: {
+      font_family: 'Inter',
+      heading_font: 'Playfair Display',
+      size_scale: ['14px', '16px', '18px', '24px', '32px', '48px'],
+      weights: [400, 600, 700],
+    },
+    spacing: ['4px', '8px', '16px', '24px', '32px', '48px'],
+    border_radius: ['8px'],
+  },
+  macro_architecture: {
+    has_header: true,
+    has_footer: true,
+    has_main: true,
+    grid_system: 'css-grid',
+    responsive_approach: 'mobile-first',
+    page_flow: 'multi-section',
+    sections: [
+      { tag: 'section', heading: 'Features', childCount: 4 },
+      { tag: 'section', heading: 'Pricing', childCount: 3 },
+    ],
+  },
+  copy_patterns: {
+    headings: ['Build Better Products', 'Trusted by Teams'],
+    ctas: ['Start Free Trial', 'Contact Sales', 'View Demo'],
+    sample_paragraphs: ['Our platform helps teams ship faster.'],
+    word_count: 1500,
+  },
+  component_behaviors: {
+    components: [
+      { type: 'navigation', link_count: 6, has_dropdown: true },
+      { type: 'form', field_count: 3, has_submit: true },
+      { type: 'card_grid', count: 4, has_images: true },
+      { type: 'hero', has_background_image: true, has_cta: true },
+    ],
+  },
+  tech_stack: {
+    framework: 'Next.js',
+    css_approach: 'Tailwind',
+    rendering: 'SSR',
+  },
+  source_url: 'https://example.com',
+  extracted_at: '2026-03-15T00:00:00Z',
+};
+
+describe('SRIP Interview Engine', () => {
+  describe('INTERVIEW_QUESTIONS', () => {
+    it('defines exactly 12 questions', () => {
+      expect(INTERVIEW_QUESTIONS).toHaveLength(12);
+    });
+
+    it('each question has required fields', () => {
+      for (const q of INTERVIEW_QUESTIONS) {
+        expect(q).toHaveProperty('key');
+        expect(q).toHaveProperty('label');
+        expect(q).toHaveProperty('helpText');
+        expect(q).toHaveProperty('deriveDefault');
+        expect(typeof q.deriveDefault).toBe('function');
+      }
+    });
+
+    it('has unique keys', () => {
+      const keys = INTERVIEW_QUESTIONS.map(q => q.key);
+      expect(new Set(keys).size).toBe(12);
+    });
+  });
+
+  describe('getInterviewQuestions', () => {
+    it('returns 12 questions without deriveDefault', () => {
+      const questions = getInterviewQuestions();
+      expect(questions).toHaveLength(12);
+      for (const q of questions) {
+        expect(q).toHaveProperty('key');
+        expect(q).toHaveProperty('label');
+        expect(q).toHaveProperty('helpText');
+        expect(q).not.toHaveProperty('deriveDefault');
+      }
+    });
+  });
+
+  describe('generateInterviewDefaults', () => {
+    it('returns answers for all 12 questions', () => {
+      const { answers } = generateInterviewDefaults(SAMPLE_DNA);
+      expect(Object.keys(answers)).toHaveLength(12);
+    });
+
+    it('pre-populates defaults from rich DNA', () => {
+      const { answers, prePopulatedCount } = generateInterviewDefaults(SAMPLE_DNA);
+      // With rich DNA, most questions should have defaults
+      expect(prePopulatedCount).toBeGreaterThanOrEqual(8);
+      // design_constraints always returns null
+      expect(answers.design_constraints.default).toBeNull();
+    });
+
+    it('each answer has expected structure', () => {
+      const { answers } = generateInterviewDefaults(SAMPLE_DNA);
+      for (const [, answer] of Object.entries(answers)) {
+        expect(answer).toHaveProperty('question');
+        expect(answer).toHaveProperty('helpText');
+        expect(answer).toHaveProperty('default');
+        expect(answer).toHaveProperty('value');
+        expect(answer).toHaveProperty('confirmed');
+        expect(answer.confirmed).toBe(false);
+      }
+    });
+
+    it('derives color intent from blue primary', () => {
+      const { answers } = generateInterviewDefaults(SAMPLE_DNA);
+      expect(answers.color_intent.default).toContain('Trust');
+    });
+
+    it('derives typography style from font family', () => {
+      const { answers } = generateInterviewDefaults(SAMPLE_DNA);
+      expect(answers.typography_style.default).toContain('Inter');
+    });
+
+    it('detects B2B audience from CTA patterns', () => {
+      const { answers } = generateInterviewDefaults(SAMPLE_DNA);
+      expect(answers.primary_audience.default).toContain('B2B');
+    });
+
+    it('detects mobile-first from viewport meta', () => {
+      const { answers } = generateInterviewDefaults(SAMPLE_DNA);
+      expect(answers.mobile_priority.default).toContain('Mobile-first');
+    });
+
+    it('detects tech stack alignment', () => {
+      const { answers } = generateInterviewDefaults(SAMPLE_DNA);
+      expect(answers.tech_alignment.default).toContain('Next.js');
+      expect(answers.tech_alignment.default).toContain('Tailwind');
+    });
+
+    it('handles empty DNA gracefully', () => {
+      const { answers, prePopulatedCount } = generateInterviewDefaults({});
+      expect(Object.keys(answers)).toHaveLength(12);
+      // Some questions have fallback defaults even with empty DNA
+      expect(prePopulatedCount).toBeLessThan(12);
+    });
+
+    it('handles null DNA gracefully', () => {
+      const { answers } = generateInterviewDefaults(null);
+      expect(Object.keys(answers)).toHaveLength(12);
+    });
+  });
+});

--- a/tests/unit/srip/srip-prompt-builder.test.js
+++ b/tests/unit/srip/srip-prompt-builder.test.js
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import { buildSynthesisPrompt } from '../../../lib/eva/services/srip-prompt-builder.js';
+
+const SAMPLE_DNA = {
+  design_tokens: {
+    colors: {
+      primary: '#0066cc',
+      secondary: '#333333',
+      accent: '#ff6600',
+      background: '#ffffff',
+      text: '#333333',
+      additional: ['#eeeeee'],
+    },
+    typography: {
+      font_family: 'Inter',
+      heading_font: 'Playfair Display',
+      size_scale: ['14px', '16px', '18px', '24px', '32px', '48px'],
+    },
+    spacing: ['4px', '8px', '16px'],
+    border_radius: ['8px'],
+  },
+  macro_architecture: {
+    has_header: true,
+    has_footer: true,
+    has_main: true,
+    grid_system: 'css-grid',
+    responsive_approach: 'mobile-first',
+    page_flow: 'multi-section',
+    sections: [
+      { tag: 'section', heading: 'Features', childCount: 4 },
+    ],
+  },
+  copy_patterns: {
+    headings: ['Build Better Products'],
+    ctas: ['Start Free Trial'],
+    word_count: 1500,
+  },
+  component_behaviors: {
+    components: [
+      { type: 'navigation', link_count: 6 },
+      { type: 'hero', has_cta: true },
+    ],
+  },
+  tech_stack: {
+    framework: 'Next.js',
+    css_approach: 'Tailwind',
+    rendering: 'SSR',
+  },
+  source_url: 'https://example.com',
+  extracted_at: '2026-03-15T00:00:00Z',
+};
+
+const SAMPLE_ANSWERS = {
+  brand_personality: { question: 'Brand Personality', value: 'Modern, trustworthy', confirmed: true },
+  primary_audience: { question: 'Primary Audience', value: 'B2B SaaS teams', confirmed: true },
+  color_intent: { question: 'Color Intent', value: 'Trust and professionalism', confirmed: false },
+  typography_style: { question: 'Typography Style', value: 'Clean sans-serif', confirmed: true },
+  layout_philosophy: { question: 'Layout Philosophy', value: 'Structured sections', confirmed: false },
+  visual_density: { question: 'Visual Density', value: 'Balanced', confirmed: true },
+  interaction_style: { question: 'Interaction Style', value: 'Moderate', confirmed: true },
+  content_tone: { question: 'Content Tone', value: 'Concise and direct', confirmed: true },
+  mobile_priority: { question: 'Mobile Priority', value: 'Mobile-first', confirmed: true },
+  brand_differentiator: { question: 'Brand Differentiator', value: 'Speed of delivery', confirmed: true },
+  tech_alignment: { question: 'Technology Alignment', value: 'Next.js + Tailwind', confirmed: true },
+  design_constraints: { question: 'Design Constraints', value: 'WCAG AA compliance', confirmed: true },
+};
+
+describe('SRIP Prompt Builder', () => {
+  describe('buildSynthesisPrompt', () => {
+    it('returns prompt text and token estimate', () => {
+      const result = buildSynthesisPrompt({
+        dnaJson: SAMPLE_DNA,
+        answers: SAMPLE_ANSWERS,
+      });
+      expect(result).toHaveProperty('promptText');
+      expect(result).toHaveProperty('tokenEstimate');
+      expect(typeof result.promptText).toBe('string');
+      expect(typeof result.tokenEstimate).toBe('number');
+    });
+
+    it('includes brand synthesis header', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('# Brand Synthesis Context');
+    });
+
+    it('includes venture name when provided', () => {
+      const { promptText } = buildSynthesisPrompt({
+        dnaJson: SAMPLE_DNA,
+        answers: SAMPLE_ANSWERS,
+        ventureName: 'Acme Corp',
+      });
+      expect(promptText).toContain('Acme Corp');
+    });
+
+    it('includes source URL from DNA', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('https://example.com');
+    });
+
+    it('includes design tokens — colors', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('#0066cc');
+      expect(promptText).toContain('#333333');
+    });
+
+    it('includes design tokens — typography', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('Inter');
+      expect(promptText).toContain('Playfair Display');
+    });
+
+    it('includes page architecture', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('Page Architecture');
+      expect(promptText).toContain('css-grid');
+      expect(promptText).toContain('mobile-first');
+    });
+
+    it('includes components detected', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('navigation');
+      expect(promptText).toContain('hero');
+    });
+
+    it('includes copy patterns', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('Build Better Products');
+      expect(promptText).toContain('Start Free Trial');
+    });
+
+    it('includes tech stack', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('Next.js');
+      expect(promptText).toContain('Tailwind');
+      expect(promptText).toContain('SSR');
+    });
+
+    it('includes all 12 interview responses', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('Brand Interview Responses');
+      expect(promptText).toContain('Modern, trustworthy');
+      expect(promptText).toContain('B2B SaaS teams');
+      expect(promptText).toContain('WCAG AA compliance');
+    });
+
+    it('marks confirmed vs auto-derived answers', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('(confirmed)');
+      expect(promptText).toContain('(auto-derived)');
+    });
+
+    it('includes generation instructions', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('Generation Instructions');
+      expect(promptText).toContain('color palette');
+    });
+
+    it('estimates tokens as roughly promptText.length / 4', () => {
+      const { promptText, tokenEstimate } = buildSynthesisPrompt({
+        dnaJson: SAMPLE_DNA,
+        answers: SAMPLE_ANSWERS,
+      });
+      expect(tokenEstimate).toBe(Math.ceil(promptText.length / 4));
+    });
+
+    it('handles empty DNA gracefully', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: {}, answers: SAMPLE_ANSWERS });
+      expect(promptText).toContain('Brand Synthesis Context');
+      expect(promptText).toContain('Brand Interview Responses');
+    });
+
+    it('handles empty answers gracefully', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: {} });
+      expect(promptText).toContain('Brand Synthesis Context');
+      expect(promptText).toContain('Design Tokens');
+    });
+
+    it('is parseable by downstream stages (contains all required sections)', () => {
+      const { promptText } = buildSynthesisPrompt({ dnaJson: SAMPLE_DNA, answers: SAMPLE_ANSWERS });
+      const requiredSections = [
+        'Design Tokens',
+        'Page Architecture',
+        'Components Detected',
+        'Copy Patterns',
+        'Technology Stack',
+        'Brand Interview Responses',
+        'Generation Instructions',
+      ];
+      for (const section of requiredSections) {
+        expect(promptText).toContain(section);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Site DNA extractor**: Puppeteer-based extraction of colors, fonts, layout, copy patterns, tech stack from live URLs, with manual fallback for blocked sites
- **Brand interview engine**: 12 structured questions pre-populated from extracted DNA (personality, audience, colors, typography, layout, density, interaction, tone, mobile, differentiator, tech, constraints)
- **Synthesis prompt builder**: Combines DNA + interview answers into a structured LLM prompt for downstream brand generation stages 12-14
- **SRIP service layer**: CRUD for `srip_site_dna`, `srip_brand_interviews`, `srip_synthesis_prompts` tables
- **RLS policies**: Venture-scoped access on all 3 SRIP tables with service_role bypass
- **120 tests passing** across 7 test files

## Test plan
- [x] 120 unit tests pass (`npx vitest run tests/unit/srip/`)
- [x] Interview engine generates defaults from rich DNA (11+ pre-populated)
- [x] Interview engine handles empty/null DNA gracefully
- [x] Prompt builder includes all required sections (design tokens, architecture, components, copy, tech, interview responses, generation instructions)
- [x] RLS policies deployed and verified on live database

🤖 Generated with [Claude Code](https://claude.com/claude-code)