### PR TITLE
feat: blueprint agent factory — 11 specialist agents and coordinator

### DIFF
--- a/lib/eva/blueprint-agents/api-contract.js
+++ b/lib/eva/blueprint-agents/api-contract.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: API Contract
+ *
+ * Defines API endpoint specifications from data model and technical architecture.
+ *
+ * @module lib/eva/blueprint-agents/api-contract
+ */
+
+export const artifactType = 'api_contract';
+
+export const description = 'API endpoint specifications and request/response contracts';
+
+export const dependencies = ['data_model', 'technical_architecture'];
+
+export const systemPrompt = `You are an API Contract Designer for venture blueprints. Given the data model and technical architecture, design the REST (or GraphQL) API surface that the frontend will consume.
+
+For each resource derived from the data model entities, define CRUD endpoints with: HTTP method, path (using RESTful conventions), request body schema, response schema, authentication requirement (public/authenticated/admin), and expected status codes. Group endpoints by resource.
+
+Include pagination strategy (cursor vs offset), filtering conventions, error response format, and rate limiting policy. If the architecture specifies GraphQL, produce query/mutation definitions instead of REST endpoints.
+
+Output a JSON object with keys: "base_url" (string), "auth_strategy" (string), "endpoints" (array of endpoint definitions grouped by resource), "conventions" (object with pagination, filtering, error_format), and "notes" (array of design decisions). Target 10-30 endpoints for a typical MVP.`;

--- a/lib/eva/blueprint-agents/data-model.js
+++ b/lib/eva/blueprint-agents/data-model.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: Data Model
+ *
+ * Designs entity relationships and data schema for a venture.
+ *
+ * @module lib/eva/blueprint-agents/data-model
+ */
+
+export const artifactType = 'data_model';
+
+export const description = 'Designs entity relationships and data schema for a venture';
+
+export const dependencies = [];
+
+export const systemPrompt = `You are a Data Modeling Specialist for early-stage venture blueprints. Your job is to design the core entity-relationship model that will underpin the venture's product.
+
+Given the venture brief (name, problem statement, target market, solution hypothesis), identify the 5-15 core entities, their attributes, and the relationships between them. Focus on the domain model, not infrastructure tables.
+
+For each entity, specify: name (PascalCase), key attributes with types (string, number, boolean, date, enum, json), primary key strategy (uuid vs serial), and nullable flags. For each relationship, specify: cardinality (1:1, 1:N, M:N), foreign key placement, and whether it is required or optional.
+
+Produce your output as a structured JSON object with keys "entities" (array of entity definitions) and "relationships" (array of relationship definitions). Include a "notes" field for any assumptions or trade-offs you made. Do not include auth/user tables unless they are central to the venture's domain.`;

--- a/lib/eva/blueprint-agents/erd-diagram.js
+++ b/lib/eva/blueprint-agents/erd-diagram.js
@@ -1,0 +1,19 @@
+/**
+ * Blueprint Agent: ERD Diagram
+ *
+ * Creates entity-relationship diagrams from the data model artifact.
+ *
+ * @module lib/eva/blueprint-agents/erd-diagram
+ */
+
+export const artifactType = 'erd_diagram';
+
+export const description = 'Creates ER diagrams from data model';
+
+export const dependencies = ['data_model'];
+
+export const systemPrompt = `You are an ERD Diagram Generator for venture blueprints. You receive a completed data model artifact containing entities, attributes, and relationships, and you produce a Mermaid erDiagram representation.
+
+Translate every entity into a Mermaid entity block with its attributes and types. Render all relationships using correct Mermaid cardinality notation (||--o{, }|--|{, etc.). Group related entities visually by adding comments as section dividers.
+
+Your output must be a JSON object with a "mermaid" key containing the complete Mermaid erDiagram source string, and a "summary" key with a one-paragraph plain-English description of the data architecture. Ensure the Mermaid syntax is valid and renderable without modification.`;

--- a/lib/eva/blueprint-agents/financial-projection.js
+++ b/lib/eva/blueprint-agents/financial-projection.js
@@ -1,0 +1,23 @@
+/**
+ * Blueprint Agent: Financial Projection
+ *
+ * Builds revenue model, cost structure, and runway analysis.
+ *
+ * @module lib/eva/blueprint-agents/financial-projection
+ */
+
+export const artifactType = 'financial_projection';
+
+export const description = 'Revenue model, cost structure, and runway analysis';
+
+export const dependencies = ['risk_register'];
+
+export const systemPrompt = `You are a Financial Modeling Specialist for venture blueprints. Given the venture brief and risk register, build a 12-month financial projection covering revenue, costs, and runway.
+
+Define the revenue model: pricing strategy (freemium, subscription, usage-based, marketplace commission), price points, and conversion assumptions. Project monthly recurring revenue (MRR) using a bottom-up model with user acquisition rate, conversion rate, and churn rate assumptions.
+
+Build the cost structure across: infrastructure (hosting, APIs, tools), people (team size ramp by month), marketing (CAC budget), and overhead. Calculate monthly burn rate and runway in months given an assumed starting capital.
+
+Identify the break-even point and the key unit economics (LTV, CAC, LTV:CAC ratio, payback period). Flag any financial risks that interact with entries from the risk register.
+
+Output a JSON object with keys: "revenue_model" (pricing, assumptions), "monthly_projections" (array of 12 month objects with revenue, costs, net), "unit_economics" (LTV, CAC, ratio, payback), "runway_months" (number), "break_even_month" (number or null), and "assumptions" (array of stated assumptions).`;

--- a/lib/eva/blueprint-agents/index.js
+++ b/lib/eva/blueprint-agents/index.js
@@ -1,0 +1,52 @@
+/**
+ * Blueprint Agent Registry
+ *
+ * Central registry mapping artifact types to their agent modules.
+ * Provides lookup and enumeration of all blueprint agents.
+ *
+ * @module lib/eva/blueprint-agents
+ */
+
+import * as dataModel from './data-model.js';
+import * as erdDiagram from './erd-diagram.js';
+import * as technicalArchitecture from './technical-architecture.js';
+import * as apiContract from './api-contract.js';
+import * as schemaSpec from './schema-spec.js';
+import * as userStoryPack from './user-story-pack.js';
+import * as riskRegister from './risk-register.js';
+import * as financialProjection from './financial-projection.js';
+import * as launchReadiness from './launch-readiness.js';
+import * as sprintPlan from './sprint-plan.js';
+import * as promotionGate from './promotion-gate.js';
+
+const agents = [
+  dataModel,
+  erdDiagram,
+  technicalArchitecture,
+  apiContract,
+  schemaSpec,
+  userStoryPack,
+  riskRegister,
+  financialProjection,
+  launchReadiness,
+  sprintPlan,
+  promotionGate,
+];
+
+/** @type {Map<string, {systemPrompt: string, artifactType: string, dependencies: string[], description: string}>} */
+export const agentRegistry = new Map(
+  agents.map((agent) => [agent.artifactType, agent])
+);
+
+/** All 11 artifact type strings in declaration order */
+export const ARTIFACT_TYPES = agents.map((a) => a.artifactType);
+
+/**
+ * Look up an agent module by artifact type.
+ *
+ * @param {string} artifactType - The artifact type key
+ * @returns {{systemPrompt: string, artifactType: string, dependencies: string[], description: string} | undefined}
+ */
+export function getAgent(artifactType) {
+  return agentRegistry.get(artifactType);
+}

--- a/lib/eva/blueprint-agents/launch-readiness.js
+++ b/lib/eva/blueprint-agents/launch-readiness.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: Launch Readiness
+ *
+ * Evaluates go/no-go readiness across all dimensions.
+ *
+ * @module lib/eva/blueprint-agents/launch-readiness
+ */
+
+export const artifactType = 'launch_readiness';
+
+export const description = 'Go/no-go launch readiness checklist and assessment';
+
+export const dependencies = ['technical_architecture', 'risk_register', 'financial_projection'];
+
+export const systemPrompt = `You are a Launch Readiness Evaluator for venture blueprints. Given the technical architecture, risk register, and financial projection, assess whether the venture is ready to begin execution and identify any blocking gaps.
+
+Evaluate readiness across six dimensions: product (MVP scope clarity, design readiness), technical (architecture validated, infra provisioned), market (target segment validated, go-to-market plan), financial (runway sufficient, unit economics viable), team (roles identified, critical hires planned), and legal (compliance requirements identified, IP strategy).
+
+For each dimension, assign a readiness score (0-100) and a status (green/yellow/red). List specific blocking items (red) that must be resolved before launch and advisory items (yellow) that should be addressed but are not blockers.
+
+Output a JSON object with keys: "dimensions" (array of dimension assessments with name, score, status, items), "overall_score" (weighted average 0-100), "go_no_go" (string: "GO", "CONDITIONAL_GO", or "NO_GO"), "blockers" (array of blocking items), and "recommended_actions" (prioritized array of next steps). A score below 60 should result in NO_GO.`;

--- a/lib/eva/blueprint-agents/promotion-gate.js
+++ b/lib/eva/blueprint-agents/promotion-gate.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: Promotion Gate
+ *
+ * Calculates blueprint readiness score and promotion decision.
+ *
+ * @module lib/eva/blueprint-agents/promotion-gate
+ */
+
+export const artifactType = 'promotion_gate';
+
+export const description = 'Blueprint readiness score and promotion decision';
+
+export const dependencies = ['launch_readiness', 'financial_projection'];
+
+export const systemPrompt = `You are a Blueprint Promotion Gate Evaluator. Given the launch readiness assessment and financial projection, determine whether the venture blueprint is complete and of sufficient quality to be promoted from the blueprint stage to active execution.
+
+Score the blueprint across four quality dimensions: completeness (are all required artifacts present and non-trivial), coherence (do artifacts reference each other consistently, no contradictions), viability (do financial projections show a plausible path to sustainability), and risk-awareness (are risks identified with actionable mitigations, not hand-waved).
+
+Each dimension is scored 0-100. The overall promotion score is a weighted average: completeness (30%), coherence (25%), viability (25%), risk-awareness (20%). A score of 70+ results in PROMOTE, 50-69 in REVISE (with specific feedback), below 50 in REJECT.
+
+Output a JSON object with keys: "dimensions" (object with completeness, coherence, viability, risk_awareness each having score and rationale), "overall_score" (number 0-100), "decision" (string: "PROMOTE", "REVISE", or "REJECT"), "feedback" (array of specific improvement items if not PROMOTE), and "chairman_summary" (2-3 sentence executive summary for the chairman's review).`;

--- a/lib/eva/blueprint-agents/risk-register.js
+++ b/lib/eva/blueprint-agents/risk-register.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: Risk Register
+ *
+ * Identifies risks and defines mitigation strategies.
+ *
+ * @module lib/eva/blueprint-agents/risk-register
+ */
+
+export const artifactType = 'risk_register';
+
+export const description = 'Risk identification and mitigation strategies';
+
+export const dependencies = ['technical_architecture'];
+
+export const systemPrompt = `You are a Risk Assessment Specialist for venture blueprints. Given the venture brief and technical architecture, identify the key risks that could prevent the venture from reaching product-market fit or sustaining operations.
+
+Categorize risks across five dimensions: market (demand, competition, timing), technical (scalability, integration, security), financial (runway, unit economics, funding), operational (team, legal, compliance), and execution (timeline, scope creep, dependencies). For each risk, assign likelihood (low/medium/high) and impact (low/medium/high).
+
+For every identified risk, define: a mitigation strategy (preventive action), a contingency plan (reactive action if risk materializes), an owner role (e.g., "CTO", "founder", "ops lead"), and a trigger condition that would activate the contingency.
+
+Output a JSON object with keys: "risks" (array of risk objects with category, description, likelihood, impact, mitigation, contingency, owner, trigger), "risk_score" (weighted aggregate 0-100), and "top_3_risks" (array of the three highest-priority risk descriptions). Aim for 10-20 risks total.`;

--- a/lib/eva/blueprint-agents/schema-spec.js
+++ b/lib/eva/blueprint-agents/schema-spec.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: Schema Spec
+ *
+ * Produces database schema DDL and TypeScript interface definitions.
+ *
+ * @module lib/eva/blueprint-agents/schema-spec
+ */
+
+export const artifactType = 'schema_spec';
+
+export const description = 'Database DDL schema and TypeScript interface definitions';
+
+export const dependencies = ['data_model', 'api_contract'];
+
+export const systemPrompt = `You are a Schema Specification Generator for venture blueprints. Given the data model and API contract, produce two outputs: database DDL (SQL) and TypeScript interface definitions.
+
+For the DDL, generate CREATE TABLE statements with proper column types, NOT NULL constraints, DEFAULT values, foreign key references with ON DELETE behavior, and indexes for frequently queried columns. Use PostgreSQL syntax. Include an initial migration file structure.
+
+For the TypeScript interfaces, generate one interface per entity matching the API response shapes (camelCase), plus request body types for create/update operations. Include enum types for any constrained fields. Add JSDoc comments referencing the corresponding database table.
+
+Output a JSON object with keys: "ddl" (string containing all SQL statements), "typescript" (string containing all interface definitions), "migrations" (array of migration file descriptors with name and purpose), and "notes" (array of schema decisions like index strategy or enum rationale).`;

--- a/lib/eva/blueprint-agents/sprint-plan.js
+++ b/lib/eva/blueprint-agents/sprint-plan.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: Sprint Plan
+ *
+ * Breaks user stories into time-boxed sprints with assignments.
+ *
+ * @module lib/eva/blueprint-agents/sprint-plan
+ */
+
+export const artifactType = 'sprint_plan';
+
+export const description = 'Sprint breakdown with story assignments and milestones';
+
+export const dependencies = ['user_story_pack', 'technical_architecture', 'launch_readiness'];
+
+export const systemPrompt = `You are a Sprint Planning Specialist for venture blueprints. Given the user story pack, technical architecture, and launch readiness assessment, organize the MVP stories into time-boxed sprints.
+
+Use 2-week sprint cycles. Sequence stories respecting technical dependencies (data layer before API, API before UI). Place foundational infrastructure and architecture setup in Sprint 0. Distribute story points evenly across sprints assuming a team velocity (state the assumed velocity).
+
+For each sprint, define: sprint number, goal (one sentence), stories included (by reference), total story points, key deliverable, and any risks or dependencies on external factors. Identify critical path stories that would delay subsequent sprints if slipped.
+
+Output a JSON object with keys: "sprint_duration_days" (number, typically 14), "assumed_velocity" (story points per sprint), "sprints" (array of sprint objects with number, goal, story_refs, points, deliverable, risks), "critical_path" (array of story references), "total_sprints" (number), and "estimated_completion_weeks" (number). Target 4-8 sprints for a typical MVP.`;

--- a/lib/eva/blueprint-agents/technical-architecture.js
+++ b/lib/eva/blueprint-agents/technical-architecture.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: Technical Architecture
+ *
+ * Designs system architecture layers, technology choices, and deployment topology.
+ *
+ * @module lib/eva/blueprint-agents/technical-architecture
+ */
+
+export const artifactType = 'technical_architecture';
+
+export const description = 'System architecture layers and technology stack decisions';
+
+export const dependencies = ['data_model'];
+
+export const systemPrompt = `You are a Technical Architecture Specialist for early-stage ventures. Given the venture brief and its data model, design a pragmatic system architecture optimized for speed-to-market and low operational cost.
+
+Define the architecture across four layers: presentation (frontend framework, SSR/SPA), application (API framework, auth strategy), data (database engine, caching, search), and infrastructure (hosting, CI/CD, observability). For each layer, recommend a specific technology with a one-sentence justification.
+
+Identify integration points (third-party APIs, payment processors, email/SMS) and note which are MVP-critical vs post-launch. Specify the deployment topology (monolith vs microservices, serverless vs containers) with rationale.
+
+Output a JSON object with keys: "layers" (object with presentation/application/data/infrastructure), "integrations" (array), "deployment" (object with topology, hosting, rationale), and "constraints" (array of technical constraints or assumptions). Keep recommendations concrete — name specific tools and frameworks, not categories.`;

--- a/lib/eva/blueprint-agents/user-story-pack.js
+++ b/lib/eva/blueprint-agents/user-story-pack.js
@@ -1,0 +1,21 @@
+/**
+ * Blueprint Agent: User Story Pack
+ *
+ * Generates epics and user stories with acceptance criteria.
+ *
+ * @module lib/eva/blueprint-agents/user-story-pack
+ */
+
+export const artifactType = 'user_story_pack';
+
+export const description = 'Epics and user stories with acceptance criteria';
+
+export const dependencies = [];
+
+export const systemPrompt = `You are a Product Requirements Specialist for venture blueprints. Given the venture brief (problem, solution, target market), produce a structured set of epics and user stories that define the MVP scope.
+
+Organize stories into 3-6 epics representing major feature areas. Each epic should have a name, description, and priority (P0-critical, P1-important, P2-nice-to-have). Under each epic, write 3-8 user stories in the format "As a [persona], I want to [action] so that [benefit]."
+
+For each story, include: acceptance criteria (3-5 testable conditions using Given/When/Then), story points estimate (1/2/3/5/8), and MVP flag (boolean). Ensure at least 60% of stories are flagged as MVP.
+
+Output a JSON object with keys: "epics" (array of epic objects, each containing "stories" array), "personas" (array of persona definitions referenced in stories), "mvp_story_count" (number), and "total_story_points" (number). Stories must be specific and testable, not vague feature descriptions.`;

--- a/lib/eva/blueprint-coordinator.js
+++ b/lib/eva/blueprint-coordinator.js
@@ -1,0 +1,100 @@
+/**
+ * Blueprint Coordinator
+ *
+ * Orchestrates blueprint agent execution in dependency order.
+ * No LLM calls — pure orchestration logic with topological sort.
+ *
+ * @module lib/eva/blueprint-coordinator
+ */
+
+import { agentRegistry, ARTIFACT_TYPES, getAgent } from './blueprint-agents/index.js';
+
+/**
+ * Topological sort of artifact types respecting agent dependencies.
+ * Uses Kahn's algorithm (BFS-based) for deterministic ordering.
+ *
+ * @returns {string[]} Artifact types in valid execution order
+ * @throws {Error} If a dependency cycle is detected
+ */
+export function resolveExecutionOrder() {
+  const inDegree = new Map();
+  const adjacency = new Map(); // dependency -> dependents
+
+  for (const type of ARTIFACT_TYPES) {
+    inDegree.set(type, 0);
+    adjacency.set(type, []);
+  }
+
+  for (const [type, agent] of agentRegistry) {
+    for (const dep of agent.dependencies) {
+      if (!agentRegistry.has(dep)) {
+        throw new Error(`Agent "${type}" depends on unknown artifact type "${dep}"`);
+      }
+      adjacency.get(dep).push(type);
+      inDegree.set(type, inDegree.get(type) + 1);
+    }
+  }
+
+  const queue = [];
+  for (const [type, degree] of inDegree) {
+    if (degree === 0) queue.push(type);
+  }
+
+  const sorted = [];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    sorted.push(current);
+    for (const dependent of adjacency.get(current)) {
+      const newDegree = inDegree.get(dependent) - 1;
+      inDegree.set(dependent, newDegree);
+      if (newDegree === 0) queue.push(dependent);
+    }
+  }
+
+  if (sorted.length !== ARTIFACT_TYPES.length) {
+    throw new Error('Dependency cycle detected in blueprint agents');
+  }
+
+  return sorted;
+}
+
+/**
+ * Orchestrate blueprint agent execution in dependency order.
+ *
+ * @param {Object} ventureData - Venture brief and context
+ * @param {Object} [options]
+ * @param {Function} [options.executeAgent] - async (agent, context) => result. If omitted, returns the execution plan.
+ * @returns {Promise<Map<string, any>>} Results keyed by artifact_type
+ */
+export async function orchestrate(ventureData, options = {}) {
+  const { executeAgent } = options;
+  const order = resolveExecutionOrder();
+  const results = new Map();
+
+  for (const artifactType of order) {
+    const agent = getAgent(artifactType);
+    const upstreamContext = {};
+    for (const dep of agent.dependencies) {
+      upstreamContext[dep] = results.get(dep);
+    }
+
+    const context = { ventureData, upstream: upstreamContext };
+
+    if (executeAgent) {
+      results.set(artifactType, await executeAgent(agent, context));
+    } else {
+      results.set(artifactType, { planned: true, dependencies: agent.dependencies });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Returns the agent registry for external inspection.
+ *
+ * @returns {Map<string, Object>}
+ */
+export function getAgentRegistry() {
+  return agentRegistry;
+}

--- a/tests/unit/eva/blueprint-agents.test.js
+++ b/tests/unit/eva/blueprint-agents.test.js
@@ -1,0 +1,205 @@
+/**
+ * Tests for Blueprint Agent Factory
+ *
+ * Validates registry completeness, agent module contracts,
+ * dependency integrity, and topological execution order.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  agentRegistry,
+  ARTIFACT_TYPES,
+  getAgent,
+} from '../../../lib/eva/blueprint-agents/index.js';
+import { resolveExecutionOrder, orchestrate } from '../../../lib/eva/blueprint-coordinator.js';
+
+// ── Registry completeness ────────────────────────────────────
+
+describe('Blueprint Agent Registry', () => {
+  const EXPECTED_TYPES = [
+    'data_model',
+    'erd_diagram',
+    'technical_architecture',
+    'api_contract',
+    'schema_spec',
+    'user_story_pack',
+    'risk_register',
+    'financial_projection',
+    'launch_readiness',
+    'sprint_plan',
+    'promotion_gate',
+  ];
+
+  it('exports all 11 artifact types', () => {
+    expect(ARTIFACT_TYPES).toHaveLength(11);
+    for (const type of EXPECTED_TYPES) {
+      expect(ARTIFACT_TYPES).toContain(type);
+    }
+  });
+
+  it('registry contains all 11 agents', () => {
+    expect(agentRegistry.size).toBe(11);
+    for (const type of EXPECTED_TYPES) {
+      expect(agentRegistry.has(type)).toBe(true);
+    }
+  });
+
+  it('getAgent returns the correct agent for each type', () => {
+    for (const type of EXPECTED_TYPES) {
+      const agent = getAgent(type);
+      expect(agent).toBeDefined();
+      expect(agent.artifactType).toBe(type);
+    }
+  });
+
+  it('getAgent returns undefined for unknown types', () => {
+    expect(getAgent('nonexistent_type')).toBeUndefined();
+  });
+});
+
+// ── Agent module contracts ───────────────────────────────────
+
+describe('Agent Module Contracts', () => {
+  for (const [type, agent] of agentRegistry) {
+    describe(`${type}`, () => {
+      it('exports artifactType as a string', () => {
+        expect(typeof agent.artifactType).toBe('string');
+        expect(agent.artifactType.length).toBeGreaterThan(0);
+      });
+
+      it('exports systemPrompt as a non-empty string', () => {
+        expect(typeof agent.systemPrompt).toBe('string');
+        expect(agent.systemPrompt.length).toBeGreaterThan(50);
+      });
+
+      it('exports dependencies as an array of strings', () => {
+        expect(Array.isArray(agent.dependencies)).toBe(true);
+        for (const dep of agent.dependencies) {
+          expect(typeof dep).toBe('string');
+        }
+      });
+
+      it('exports description as a string', () => {
+        expect(typeof agent.description).toBe('string');
+        expect(agent.description.length).toBeGreaterThan(0);
+      });
+    });
+  }
+});
+
+// ── Dependency integrity ─────────────────────────────────────
+
+describe('Dependency Integrity', () => {
+  it('every dependency references an existing artifact type', () => {
+    for (const [type, agent] of agentRegistry) {
+      for (const dep of agent.dependencies) {
+        expect(
+          agentRegistry.has(dep),
+          `Agent "${type}" depends on "${dep}" which does not exist in the registry`
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('no agent depends on itself', () => {
+    for (const [type, agent] of agentRegistry) {
+      expect(
+        agent.dependencies.includes(type),
+        `Agent "${type}" has a self-dependency`
+      ).toBe(false);
+    }
+  });
+});
+
+// ── Topological execution order ──────────────────────────────
+
+describe('resolveExecutionOrder', () => {
+  it('returns all 11 artifact types', () => {
+    const order = resolveExecutionOrder();
+    expect(order).toHaveLength(11);
+    expect(new Set(order).size).toBe(11);
+  });
+
+  it('places every agent after its dependencies', () => {
+    const order = resolveExecutionOrder();
+    const indexOf = new Map(order.map((type, i) => [type, i]));
+
+    for (const [type, agent] of agentRegistry) {
+      for (const dep of agent.dependencies) {
+        expect(
+          indexOf.get(dep),
+          `"${dep}" should appear before "${type}" in execution order`
+        ).toBeLessThan(indexOf.get(type));
+      }
+    }
+  });
+
+  it('places root agents (no dependencies) first', () => {
+    const order = resolveExecutionOrder();
+    const roots = ARTIFACT_TYPES.filter(
+      (t) => getAgent(t).dependencies.length === 0
+    );
+    // All roots should appear before any non-root
+    const firstNonRootIndex = order.findIndex(
+      (t) => getAgent(t).dependencies.length > 0
+    );
+    for (const root of roots) {
+      expect(order.indexOf(root)).toBeLessThan(firstNonRootIndex);
+    }
+  });
+});
+
+// ── Orchestrate (dry run) ────────────────────────────────────
+
+describe('orchestrate', () => {
+  it('returns a Map with all 11 artifact types when no executeAgent provided', async () => {
+    const results = await orchestrate({ name: 'Test Venture' });
+    expect(results.size).toBe(11);
+    for (const type of ARTIFACT_TYPES) {
+      expect(results.has(type)).toBe(true);
+      expect(results.get(type).planned).toBe(true);
+    }
+  });
+
+  it('calls executeAgent for each artifact in dependency order', async () => {
+    const callOrder = [];
+    const executeAgent = async (agent, context) => {
+      callOrder.push(agent.artifactType);
+      return { generated: true, type: agent.artifactType };
+    };
+
+    const results = await orchestrate({ name: 'Test' }, { executeAgent });
+
+    expect(callOrder).toHaveLength(11);
+    // Verify dependency ordering in call sequence
+    const indexOf = new Map(callOrder.map((type, i) => [type, i]));
+    for (const [type, agent] of agentRegistry) {
+      for (const dep of agent.dependencies) {
+        expect(indexOf.get(dep)).toBeLessThan(indexOf.get(type));
+      }
+    }
+  });
+
+  it('passes upstream results to dependent agents', async () => {
+    const receivedContexts = new Map();
+    const executeAgent = async (agent, context) => {
+      receivedContexts.set(agent.artifactType, context);
+      return { result: agent.artifactType };
+    };
+
+    await orchestrate({ name: 'Test' }, { executeAgent });
+
+    // erd_diagram depends on data_model — verify it received that upstream result
+    const erdContext = receivedContexts.get('erd_diagram');
+    expect(erdContext.upstream.data_model).toEqual({ result: 'data_model' });
+
+    // promotion_gate depends on launch_readiness and financial_projection
+    const gateContext = receivedContexts.get('promotion_gate');
+    expect(gateContext.upstream.launch_readiness).toEqual({ result: 'launch_readiness' });
+    expect(gateContext.upstream.financial_projection).toEqual({ result: 'financial_projection' });
+
+    // data_model has no dependencies — upstream should be empty
+    const dmContext = receivedContexts.get('data_model');
+    expect(Object.keys(dmContext.upstream)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Created 11 specialist agent modules in `lib/eva/blueprint-agents/` (one per artifact type)
- Each agent exports `systemPrompt`, `artifactType`, `dependencies`, and `description`
- Added agent registry (`index.js`) for dynamic loading by artifact type
- Created Blueprint Coordinator with topological sort execution ordering and upstream context passing
- 56 unit tests verify registry, contracts, dependency integrity, and orchestration

## Test plan
- [x] 56 unit tests pass (registry, agent contracts, deps, orchestration)
- [x] 15 smoke tests pass
- [x] All modules importable without errors
- [x] Topological sort produces valid execution order

SD: SD-LEO-INFRA-BLUEPRINT-AGENT-FACTORY-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)