### PR TITLE
feat: SRIP quality scoring service and naming generator

### DIFF
--- a/lib/eva/services/index.js
+++ b/lib/eva/services/index.js
@@ -82,3 +82,14 @@ export {
 } from './srip-interview-engine.js';
 
 export { buildSynthesisPrompt } from './srip-prompt-builder.js';
+
+// SRIP Quality Check services (SD-LEO-INFRA-SRIP-QUALITY-SCORING-001)
+export {
+  createQualityCheck,
+  getQualityCheck,
+  listQualityChecks,
+  getLatestQualityCheck,
+  checkPassed,
+  gatePromptActivation,
+  QUALITY_DOMAINS,
+} from './srip-quality-check.js';

--- a/lib/eva/services/srip-quality-check.js
+++ b/lib/eva/services/srip-quality-check.js
@@ -1,0 +1,195 @@
+/**
+ * SRIP Quality Check Service
+ * SD: SD-LEO-INFRA-SRIP-QUALITY-SCORING-001
+ *
+ * CRUD operations for the srip_quality_checks table.
+ * Provides 6-domain fidelity scoring for site replications.
+ *
+ * Quality domains: layout, visual_composition, design_system,
+ * interaction, technical, accessibility
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+}
+
+export const QUALITY_DOMAINS = [
+  'layout',
+  'visual_composition',
+  'design_system',
+  'interaction',
+  'technical',
+  'accessibility',
+];
+
+/**
+ * Create a new quality check record.
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture UUID
+ * @param {string} params.synthesisPromptId - FK to srip_synthesis_prompts
+ * @param {Object} params.domainScores - JSONB with per-domain scores {layout: 85, ...}
+ * @param {number} params.overallScore - Weighted average 0-100
+ * @param {Object} [params.gaps] - JSONB gap analysis per domain
+ * @param {number} [params.passThreshold] - Threshold for pass/fail (default 70)
+ * @param {string} [params.createdBy] - Creator identifier
+ * @returns {Promise<Object>} Created record
+ */
+export async function createQualityCheck({
+  ventureId,
+  synthesisPromptId,
+  domainScores,
+  overallScore,
+  gaps = null,
+  passThreshold = 70,
+  createdBy = 'srip-service',
+}) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('srip_quality_checks')
+    .insert({
+      venture_id: ventureId,
+      synthesis_prompt_id: synthesisPromptId,
+      domain_scores: domainScores,
+      overall_score: overallScore,
+      gaps,
+      pass_threshold: passThreshold,
+      created_by: createdBy,
+    })
+    .select()
+    .single();
+
+  if (error) throw new Error(`createQualityCheck failed: ${error.message}`);
+  return data;
+}
+
+/**
+ * Get a quality check by ID.
+ * @param {string} id - Record UUID
+ * @returns {Promise<Object|null>}
+ */
+export async function getQualityCheck(id) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('srip_quality_checks')
+    .select('*')
+    .eq('id', id)
+    .single();
+
+  if (error) return null;
+  return data;
+}
+
+/**
+ * List quality checks for a venture.
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} [options]
+ * @param {string} [options.synthesisPromptId] - Filter by prompt
+ * @param {number} [options.limit] - Max results
+ * @returns {Promise<Array>}
+ */
+export async function listQualityChecks(ventureId, { synthesisPromptId, limit = 50 } = {}) {
+  const supabase = getSupabase();
+  let query = supabase
+    .from('srip_quality_checks')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (synthesisPromptId) query = query.eq('synthesis_prompt_id', synthesisPromptId);
+
+  const { data, error } = await query;
+  if (error) throw new Error(`listQualityChecks failed: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Get the latest quality check for a synthesis prompt.
+ * @param {string} synthesisPromptId - Synthesis prompt UUID
+ * @returns {Promise<Object|null>}
+ */
+export async function getLatestQualityCheck(synthesisPromptId) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('srip_quality_checks')
+    .select('*')
+    .eq('synthesis_prompt_id', synthesisPromptId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error) return null;
+  return data;
+}
+
+/**
+ * Check if a quality check passes the threshold.
+ * Uses the `passed` generated column from the database.
+ * @param {string} qualityCheckId - Quality check UUID
+ * @returns {Promise<boolean>}
+ */
+export async function checkPassed(qualityCheckId) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('srip_quality_checks')
+    .select('passed, overall_score, pass_threshold')
+    .eq('id', qualityCheckId)
+    .single();
+
+  if (error) return false;
+  return data.passed;
+}
+
+/**
+ * Gate synthesis prompt activation based on quality check.
+ * If the latest quality check passes, activate the prompt.
+ * @param {string} ventureId - Venture UUID
+ * @param {string} synthesisPromptId - Prompt to potentially activate
+ * @returns {Promise<{activated: boolean, score: number, threshold: number}>}
+ */
+export async function gatePromptActivation(ventureId, synthesisPromptId) {
+  const qualityCheck = await getLatestQualityCheck(synthesisPromptId);
+
+  if (!qualityCheck) {
+    return { activated: false, score: 0, threshold: 70, reason: 'No quality check found' };
+  }
+
+  if (qualityCheck.passed) {
+    // Activate the prompt via the synthesis service
+    const supabase = getSupabase();
+    await supabase
+      .from('srip_synthesis_prompts')
+      .update({ status: 'active' })
+      .eq('id', synthesisPromptId)
+      .eq('venture_id', ventureId);
+
+    // Supersede other active prompts
+    await supabase
+      .from('srip_synthesis_prompts')
+      .update({ status: 'superseded' })
+      .eq('venture_id', ventureId)
+      .eq('status', 'active')
+      .neq('id', synthesisPromptId);
+
+    return {
+      activated: true,
+      score: qualityCheck.overall_score,
+      threshold: qualityCheck.pass_threshold,
+    };
+  }
+
+  return {
+    activated: false,
+    score: qualityCheck.overall_score,
+    threshold: qualityCheck.pass_threshold,
+    reason: `Score ${qualityCheck.overall_score} below threshold ${qualityCheck.pass_threshold}`,
+  };
+}

--- a/scripts/eva/srip/naming-generator.mjs
+++ b/scripts/eva/srip/naming-generator.mjs
@@ -1,0 +1,153 @@
+/**
+ * SRIP Naming Generator Module
+ * SD: SD-LEO-INFRA-SRIP-QUALITY-SCORING-001
+ *
+ * Generates session-based brand name candidates from site DNA
+ * and brand interview data. Domain availability is set to 'unknown'
+ * per architecture phasing (WHOIS integration deferred to SD-C).
+ *
+ * Input: siteDnaId + brandInterviewId + ventureId
+ * Output: Array of naming candidates with domain_status='unknown'
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { getValidationClient } from '../../../lib/llm/client-factory.js';
+
+dotenv.config();
+
+const DEFAULT_CANDIDATE_COUNT = 8;
+
+/**
+ * Generate naming candidates from DNA + interview data.
+ * @param {Object} params
+ * @param {string} params.ventureId - Venture UUID
+ * @param {string} params.siteDnaId - Site DNA record UUID
+ * @param {string} params.brandInterviewId - Brand interview UUID
+ * @param {number} [params.count] - Number of candidates (default 8)
+ * @returns {Promise<Array<Object>>} Array of naming candidates
+ */
+export async function generateNamingCandidates({
+  ventureId,
+  siteDnaId,
+  brandInterviewId,
+  count = DEFAULT_CANDIDATE_COUNT,
+}) {
+  const supabase = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  // Fetch DNA and interview data
+  const [dnaResult, interviewResult] = await Promise.all([
+    supabase.from('srip_site_dna').select('dna_json').eq('id', siteDnaId).single(),
+    supabase.from('srip_brand_interviews').select('answers').eq('id', brandInterviewId).single(),
+  ]);
+
+  if (dnaResult.error) throw new Error(`DNA fetch failed: ${dnaResult.error.message}`);
+  if (interviewResult.error) throw new Error(`Interview fetch failed: ${interviewResult.error.message}`);
+
+  const dnaJson = dnaResult.data.dna_json || {};
+  const answers = interviewResult.data.answers || {};
+
+  // Extract naming signals from DNA + interview
+  const brandName = answers.brand_name || '';
+  const tagline = answers.tagline || '';
+  const tone = answers.tone_of_voice || '';
+  const audience = answers.target_audience || '';
+  const positioning = answers.competitive_positioning || '';
+
+  // Design tokens from DNA
+  const designTokens = dnaJson.design_tokens || {};
+  const techStack = dnaJson.tech_stack || {};
+
+  // Build LLM prompt for naming generation
+  const client = getValidationClient();
+  const systemPrompt = `You are a brand naming expert. Generate ${count} creative brand name candidates based on the brand context provided. Each name should be:
+- Memorable and unique
+- Relevant to the brand's positioning
+- Domain-friendly (could work as a .com)
+- Appropriate for the target audience and tone
+
+Return ONLY valid JSON array of objects with: name, rationale, style (e.g., "abstract", "descriptive", "compound", "acronym")`;
+
+  const userPrompt = `Brand Context:
+- Current Name: ${brandName}
+- Tagline: ${tagline}
+- Tone: ${tone}
+- Target Audience: ${audience}
+- Positioning: ${positioning}
+
+Design Style: ${designTokens.colors?.primary || 'modern'} palette, ${answers.typography_preference || 'clean'} typography
+Industry Signals: ${techStack.detected || 'web application'}
+
+Generate ${count} naming candidates as JSON array.`;
+
+  try {
+    const response = await client.messages.create({
+      model: 'claude-haiku-4-5-20251001',
+      max_tokens: 1024,
+      messages: [
+        { role: 'user', content: userPrompt },
+      ],
+      system: systemPrompt,
+    });
+
+    const responseText = response.content[0]?.text || '[]';
+    // Extract JSON from response
+    const jsonMatch = responseText.match(/\[[\s\S]*\]/);
+    const candidates = jsonMatch ? JSON.parse(jsonMatch[0]) : [];
+
+    // Add domain_status = 'unknown' per architecture phasing
+    return candidates.map((candidate, index) => ({
+      ...candidate,
+      index: index + 1,
+      venture_id: ventureId,
+      domain_status: 'unknown', // WHOIS deferred to SD-C
+      domain_checked_at: null,
+      generated_from: {
+        site_dna_id: siteDnaId,
+        brand_interview_id: brandInterviewId,
+      },
+    }));
+  } catch (error) {
+    console.error(`Naming generation LLM error: ${error.message}`);
+    // Fallback: generate basic candidates from brand keywords
+    return generateFallbackCandidates(answers, count, ventureId, siteDnaId, brandInterviewId);
+  }
+}
+
+/**
+ * Fallback naming generator when LLM is unavailable.
+ * Creates candidates from brand keywords without LLM.
+ */
+function generateFallbackCandidates(answers, count, ventureId, siteDnaId, brandInterviewId) {
+  const brandName = answers.brand_name || 'Brand';
+  const words = (answers.tagline || '').split(/\s+/).filter(w => w.length > 3);
+  const candidates = [];
+
+  const suffixes = ['io', 'ly', 'fy', 'hub', 'lab', 'app', 'base'];
+  const prefixes = ['go', 'my', 'the', 'get', 'try'];
+
+  for (let i = 0; i < count && i < suffixes.length + prefixes.length; i++) {
+    const word = words[i % Math.max(words.length, 1)] || brandName.toLowerCase();
+    const name = i < suffixes.length
+      ? `${word}${suffixes[i]}`
+      : `${prefixes[i - suffixes.length]}${brandName.toLowerCase()}`;
+
+    candidates.push({
+      name,
+      rationale: `Generated from brand keywords (fallback)`,
+      style: 'compound',
+      index: i + 1,
+      venture_id: ventureId,
+      domain_status: 'unknown',
+      domain_checked_at: null,
+      generated_from: { site_dna_id: siteDnaId, brand_interview_id: brandInterviewId },
+    });
+  }
+
+  return candidates;
+}
+
+export { DEFAULT_CANDIDATE_COUNT };

--- a/tests/unit/srip/srip-quality-naming.test.js
+++ b/tests/unit/srip/srip-quality-naming.test.js
@@ -1,0 +1,97 @@
+/**
+ * SRIP Quality Check & Naming Generator Tests
+ * SD: SD-LEO-INFRA-SRIP-QUALITY-SCORING-001
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      neq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+  })),
+}));
+
+vi.mock('dotenv', () => ({ default: { config: vi.fn() }, config: vi.fn() }));
+
+describe('SRIP Quality Check Service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+  });
+
+  it('exports QUALITY_DOMAINS constant with 6 domains', async () => {
+    const { QUALITY_DOMAINS } = await import('../../../lib/eva/services/srip-quality-check.js');
+    expect(QUALITY_DOMAINS).toHaveLength(6);
+    expect(QUALITY_DOMAINS).toContain('layout');
+    expect(QUALITY_DOMAINS).toContain('visual_composition');
+    expect(QUALITY_DOMAINS).toContain('design_system');
+    expect(QUALITY_DOMAINS).toContain('interaction');
+    expect(QUALITY_DOMAINS).toContain('technical');
+    expect(QUALITY_DOMAINS).toContain('accessibility');
+  });
+
+  it('exports createQualityCheck function', async () => {
+    const { createQualityCheck } = await import('../../../lib/eva/services/srip-quality-check.js');
+    expect(typeof createQualityCheck).toBe('function');
+  });
+
+  it('exports getQualityCheck function', async () => {
+    const { getQualityCheck } = await import('../../../lib/eva/services/srip-quality-check.js');
+    expect(typeof getQualityCheck).toBe('function');
+  });
+
+  it('exports listQualityChecks function', async () => {
+    const { listQualityChecks } = await import('../../../lib/eva/services/srip-quality-check.js');
+    expect(typeof listQualityChecks).toBe('function');
+  });
+
+  it('exports getLatestQualityCheck function', async () => {
+    const { getLatestQualityCheck } = await import('../../../lib/eva/services/srip-quality-check.js');
+    expect(typeof getLatestQualityCheck).toBe('function');
+  });
+
+  it('exports checkPassed function', async () => {
+    const { checkPassed } = await import('../../../lib/eva/services/srip-quality-check.js');
+    expect(typeof checkPassed).toBe('function');
+  });
+
+  it('exports gatePromptActivation function', async () => {
+    const { gatePromptActivation } = await import('../../../lib/eva/services/srip-quality-check.js');
+    expect(typeof gatePromptActivation).toBe('function');
+  });
+});
+
+describe('SRIP Naming Generator', () => {
+  it('exports generateNamingCandidates function', async () => {
+    const { generateNamingCandidates } = await import('../../../scripts/eva/srip/naming-generator.mjs');
+    expect(typeof generateNamingCandidates).toBe('function');
+  });
+
+  it('exports DEFAULT_CANDIDATE_COUNT constant', async () => {
+    const { DEFAULT_CANDIDATE_COUNT } = await import('../../../scripts/eva/srip/naming-generator.mjs');
+    expect(DEFAULT_CANDIDATE_COUNT).toBe(8);
+  });
+});
+
+describe('Barrel Export includes quality check', () => {
+  it('re-exports quality check functions from index', async () => {
+    const services = await import('../../../lib/eva/services/index.js');
+    expect(typeof services.createQualityCheck).toBe('function');
+    expect(typeof services.getQualityCheck).toBe('function');
+    expect(typeof services.listQualityChecks).toBe('function');
+    expect(typeof services.getLatestQualityCheck).toBe('function');
+    expect(typeof services.checkPassed).toBe('function');
+    expect(typeof services.gatePromptActivation).toBe('function');
+    expect(services.QUALITY_DOMAINS).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds quality check CRUD service for srip_quality_checks table (6-domain fidelity scoring)
- Adds naming generator with session-based candidates and LLM fallback
- Updates barrel export with quality check functions
- Domain availability deferred per architecture phasing (set to 'unknown')

## Test plan
- [x] 10 unit tests passing (quality service + naming generator + barrel exports)
- [ ] Manual verification with quality check creation

SD: SD-LEO-INFRA-SRIP-QUALITY-SCORING-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)