### PR TITLE
fix: reduce gate failure patterns (PAT-AUTO-bcc45c54, PAT-AUTO-30e58b88)

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -797,11 +797,23 @@ export function createPhaseCoverageExitGate(supabase) {
         const covered = [];
         const uncovered = [];
         const incomplete = [];
+        const deferred = [];
+
+        // PAT-AUTO-30e58b88: Detect phases explicitly marked as deferred/future.
+        // These should not block orchestrator completion.
+        const DEFERRED_PATTERN = /\b(deferred|future|planned|upcoming|tbd)\b/i;
 
         // The SD currently being approved should count as covered (avoid circular dependency)
         const currentSdKey = ctx.sd?.sd_key || ctx.sd?.id;
 
         for (const phase of phases) {
+          // Check if this phase is explicitly deferred/future before evaluating coverage
+          const phaseTitle = phase.title || '';
+          if (DEFERRED_PATTERN.test(phaseTitle)) {
+            deferred.push(phase);
+            continue;
+          }
+
           const assignedKey = phase.covered_by_sd_key;
           if (!assignedKey) {
             uncovered.push(phase);
@@ -851,11 +863,23 @@ export function createPhaseCoverageExitGate(supabase) {
         for (const phase of uncovered) {
           console.log(`   ❌ Phase ${phase.number}: ${phase.title} → NO SD ASSIGNED`);
         }
+        for (const phase of deferred) {
+          console.log(`   ⏭️  Phase ${phase.number}: ${phase.title} → DEFERRED (excluded from coverage)`);
+        }
 
-        const totalPhases = phases.length;
+        // PAT-AUTO-30e58b88: Only count active (non-deferred) phases for coverage
+        const activePhaseCount = phases.length - deferred.length;
         const coveredCount = covered.length;
-        const coveragePct = totalPhases > 0 ? Math.round((coveredCount / totalPhases) * 100) : 100;
-        console.log(`\n   Coverage: ${coveredCount}/${totalPhases} completed (${coveragePct}%)`);
+        const coveragePct = activePhaseCount > 0 ? Math.round((coveredCount / activePhaseCount) * 100) : 100;
+        console.log(`\n   Coverage: ${coveredCount}/${activePhaseCount} active phases completed (${coveragePct}%)`);
+        if (deferred.length > 0) {
+          console.log(`   ⏭️  ${deferred.length} phase(s) deferred (excluded): ${deferred.map(d => d.title).join(', ')}`);
+        }
+
+        const warnings = [];
+        if (deferred.length > 0) {
+          warnings.push(`${deferred.length} phase(s) deferred and excluded from coverage: ${deferred.map(d => d.title).join(', ')}`);
+        }
 
         if (incomplete.length > 0 || uncovered.length > 0) {
           const issues = [];
@@ -865,11 +889,11 @@ export function createPhaseCoverageExitGate(supabase) {
           if (uncovered.length > 0) {
             issues.push(`${uncovered.length} phase(s) have no SD assigned: ${uncovered.map(u => u.title).join(', ')}`);
           }
-          return { passed: false, score: coveragePct, max_score: 100, issues, warnings: [] };
+          return { passed: false, score: coveragePct, max_score: 100, issues, warnings, details: { deferred_phases: deferred.length } };
         }
 
-        console.log('   ✅ All architecture phases have completed SDs');
-        return { passed: true, score: 100, max_score: 100, issues: [], warnings: [] };
+        console.log('   ✅ All active architecture phases have completed SDs');
+        return { passed: true, score: 100, max_score: 100, issues: [], warnings, details: { deferred_phases: deferred.length } };
       } catch (err) {
         console.log(`   ⚠️  Error: ${err.message}`);
         return { passed: true, score: 50, max_score: 100, issues: [], warnings: [`Phase coverage exit error: ${err.message}`] };

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/sd-quality-gate.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/sd-quality-gate.js
@@ -277,6 +277,33 @@ export async function validateSdQuality(sd) {
 
   const pass = totalScore >= threshold.passingScore && allIssues.length === 0;
 
+  // PAT-AUTO-bcc45c54: Near-threshold diagnostics — show actionable guidance
+  // when score is within 10 points of passing to help orchestrators enrich SDs
+  const deficit = threshold.passingScore - totalScore;
+  if (deficit > 0 && deficit <= 10) {
+    console.log(`\n   📊 NEAR-THRESHOLD DIAGNOSTIC (${deficit} point(s) below passing score of ${threshold.passingScore}):`);
+    const improvements = [];
+    if (completeness.score < 40) {
+      const fieldDeficit = threshold.requiredFields - completeness.populatedCount;
+      if (fieldDeficit > 0) improvements.push(`Populate ${fieldDeficit} more JSONB field(s) for up to +${Math.min(fieldDeficit * 5, 40 - completeness.score)} completeness points`);
+    }
+    if (content.score < 30) {
+      const descWords = wordCount(sd.description);
+      if (descWords < threshold.minDescriptionWords) {
+        improvements.push(`Add ${threshold.minDescriptionWords - descWords} more words to description for up to +20 content points`);
+      }
+      if (content.score < 20) {
+        improvements.push(`Add scope with in-scope/out-of-scope boundaries for up to +10 content points`);
+      }
+    }
+    if (structure.score < 30) {
+      improvements.push(`Convert plain string entries in success_criteria/key_changes to structured objects for up to +${30 - structure.score} structure points`);
+    }
+    for (const imp of improvements) {
+      console.log(`      → ${imp}`);
+    }
+  }
+
   if (!pass && (allIssues.length > 0 || allWarnings.length > 0)) {
     console.log(`\n   Remediation Report:`);
     console.log(buildRemediationReport(allIssues, allWarnings));


### PR DESCRIPTION
## Summary
- **ARCHITECTURE_PHASE_COVERAGE_EXIT**: Skip phases marked as deferred/future/planned in architecture plans, reporting them as warnings instead of failures (fixes PAT-AUTO-30e58b88, 4 occurrences)
- **GATE_SD_QUALITY**: Add near-threshold diagnostics showing actionable improvement suggestions when score is within 10 points of passing (fixes PAT-AUTO-bcc45c54, 8 occurrences)

## Test plan
- [ ] Verify orchestrator with deferred architecture phases passes ARCHITECTURE_PHASE_COVERAGE_EXIT
- [ ] Verify non-deferred uncovered phases still fail the gate
- [ ] Verify near-threshold SD Quality diagnostics show improvement suggestions
- [ ] Verify existing passing SDs continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)