### PR TITLE
feat: add blueprint quality scoring persistence layer

### DIFF
--- a/lib/eva/blueprint-scoring/index.js
+++ b/lib/eva/blueprint-scoring/index.js
@@ -9,3 +9,4 @@ export { scoreArtifact } from './quality-scorer.js';
 export { checkConsistency } from './consistency-checker.js';
 export { calculateReadiness } from './readiness-calculator.js';
 export { evaluateGate } from './gate-engine.js';
+export { scoreAndPersist, getLatestReadiness, getLatestAssessment, listAssessments, seedDefaultRubrics } from './persistence.js';

--- a/lib/eva/blueprint-scoring/persistence.js
+++ b/lib/eva/blueprint-scoring/persistence.js
@@ -1,0 +1,235 @@
+/**
+ * Blueprint Quality Scoring — Database Persistence Layer.
+ * Stores and retrieves quality assessments from blueprint_quality_assessments.
+ * Seeds default rubrics into blueprint_templates.quality_rubric.
+ *
+ * @module lib/eva/blueprint-scoring/persistence
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { ARTIFACT_TYPES, RUBRIC_DEFINITIONS } from './rubric-definitions.js';
+import { scoreArtifact } from './quality-scorer.js';
+import { checkConsistency } from './consistency-checker.js';
+import { calculateReadiness } from './readiness-calculator.js';
+import { evaluateGate } from './gate-engine.js';
+
+dotenv.config();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+}
+
+/**
+ * Score all artifacts for a venture and store results in blueprint_quality_assessments.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Record<string, object>} artifacts - Artifact content keyed by type
+ * @param {Object} [options]
+ * @param {string} [options.assessorModel] - Model identifier
+ * @returns {Promise<{assessments: Array, readiness: Object, gate: Object}>}
+ */
+export async function scoreAndPersist(ventureId, artifacts, options = {}) {
+  const { assessorModel = 'blueprint-quality-scorer' } = options;
+  const supabase = getSupabase();
+
+  // 1. Score each artifact
+  const artifactScores = [];
+  const assessments = [];
+
+  for (const type of ARTIFACT_TYPES) {
+    const content = artifacts[type];
+    if (!content) continue;
+
+    const result = scoreArtifact(type, content);
+    artifactScores.push({ artifactType: type, total: result.total });
+
+    const gateDecision = result.total >= 70 ? 'pass' : result.total >= 50 ? 'retry' : 'fail';
+
+    const { data, error } = await supabase
+      .from('blueprint_quality_assessments')
+      .insert({
+        venture_id: ventureId,
+        artifact_type: type,
+        assessment_scores: Object.fromEntries(result.dimensions.map((d) => [d.name, d.score])),
+        overall_score: result.total,
+        gate_decision: gateDecision,
+        assessor_model: assessorModel,
+        metadata: { rubric_version: result.rubricVersion },
+      })
+      .select()
+      .single();
+
+    if (error) throw new Error(`Assessment insert failed for ${type}: ${error.message}`);
+    assessments.push(data);
+  }
+
+  // 2. Consistency check
+  const consistencyResult = checkConsistency(artifacts);
+
+  // 3. Readiness score
+  const readiness = calculateReadiness(artifactScores, consistencyResult);
+
+  // 4. Gate decision
+  const gate = evaluateGate(readiness, artifactScores.map((s) => {
+    const result = scoreArtifact(s.artifactType, artifacts[s.artifactType]);
+    return { artifactType: s.artifactType, dimensions: result.dimensions };
+  }));
+
+  // 5. Store aggregate readiness assessment
+  const { data: readinessRecord, error: readinessError } = await supabase
+    .from('blueprint_quality_assessments')
+    .insert({
+      venture_id: ventureId,
+      artifact_type: '_readiness_aggregate',
+      assessment_scores: readiness.artifactSubscores,
+      overall_score: readiness.readinessScore,
+      gate_decision: gate.decision,
+      assessor_model: assessorModel,
+      metadata: {
+        consistency_penalty: readiness.consistencyPenalty,
+        missing_artifacts: readiness.missingArtifacts,
+        remediation_count: gate.remediationItems.length,
+        breakdown: readiness.breakdown,
+      },
+      notes: gate.remediationItems.length > 0
+        ? `${gate.remediationItems.length} remediation items`
+        : 'All artifacts meet quality thresholds',
+    })
+    .select()
+    .single();
+
+  if (readinessError) throw new Error(`Readiness insert failed: ${readinessError.message}`);
+
+  return {
+    assessments,
+    readiness: { ...readiness, id: readinessRecord.id },
+    gate,
+  };
+}
+
+/**
+ * Get latest readiness assessment for a venture.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @returns {Promise<Object|null>}
+ */
+export async function getLatestReadiness(ventureId) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('blueprint_quality_assessments')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', '_readiness_aggregate')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error) return null;
+  return data;
+}
+
+/**
+ * Get latest assessment for a specific artifact type.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {string} artifactType - Artifact type
+ * @returns {Promise<Object|null>}
+ */
+export async function getLatestAssessment(ventureId, artifactType) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('blueprint_quality_assessments')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .eq('artifact_type', artifactType)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  if (error) return null;
+  return data;
+}
+
+/**
+ * List all assessments for a venture.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} [options]
+ * @param {number} [options.limit] - Max results (default 50)
+ * @returns {Promise<Array>}
+ */
+export async function listAssessments(ventureId, { limit = 50 } = {}) {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('blueprint_quality_assessments')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) throw new Error(`listAssessments failed: ${error.message}`);
+  return data || [];
+}
+
+/**
+ * Seed default rubrics into blueprint_templates for any artifact types
+ * with empty or missing quality_rubric.
+ *
+ * @returns {Promise<{seeded: number, skipped: number}>}
+ */
+export async function seedDefaultRubrics() {
+  const supabase = getSupabase();
+  let seeded = 0;
+  let skipped = 0;
+
+  for (const [artifactType, rubric] of Object.entries(RUBRIC_DEFINITIONS)) {
+    const rubricData = {
+      dimensions: rubric.dimensions.map((d) => ({
+        name: d.name,
+        weight: d.weight,
+        criteria: d.criteria,
+        scoring_levels: d.scoring_levels,
+      })),
+      min_pass_score: rubric.min_pass_score,
+      version: rubric.version,
+    };
+
+    const { data: existing } = await supabase
+      .from('blueprint_templates')
+      .select('id, quality_rubric')
+      .eq('artifact_type', artifactType)
+      .eq('is_active', true)
+      .limit(1)
+      .single();
+
+    if (existing && (!existing.quality_rubric || !existing.quality_rubric.dimensions)) {
+      const { error } = await supabase
+        .from('blueprint_templates')
+        .update({ quality_rubric: rubricData })
+        .eq('id', existing.id);
+      if (!error) seeded++;
+      else skipped++;
+    } else if (!existing) {
+      const { error } = await supabase
+        .from('blueprint_templates')
+        .insert({
+          artifact_type: artifactType,
+          archetype: 'default',
+          template_content: {},
+          quality_rubric: rubricData,
+          version: 1,
+          created_by: 'blueprint-quality-scorer',
+        });
+      if (!error) seeded++;
+      else skipped++;
+    } else {
+      skipped++;
+    }
+  }
+
+  return { seeded, skipped };
+}

--- a/tests/unit/eva/blueprint-scoring.test.js
+++ b/tests/unit/eva/blueprint-scoring.test.js
@@ -4,6 +4,7 @@ import { scoreArtifact } from '../../../lib/eva/blueprint-scoring/quality-scorer
 import { checkConsistency } from '../../../lib/eva/blueprint-scoring/consistency-checker.js';
 import { calculateReadiness } from '../../../lib/eva/blueprint-scoring/readiness-calculator.js';
 import { evaluateGate } from '../../../lib/eva/blueprint-scoring/gate-engine.js';
+import { scoreAndPersist, seedDefaultRubrics, getLatestReadiness, getLatestAssessment, listAssessments } from '../../../lib/eva/blueprint-scoring/persistence.js';
 
 // --- Rubric Definitions ---
 
@@ -199,5 +200,103 @@ describe('QualityGateDecisionEngine', () => {
     const result = evaluateGate(readiness, details);
     expect(result.remediationItems.some((r) => r.dimension === 'entity_coverage')).toBe(true);
     expect(result.remediationItems.some((r) => r.dimension === 'relationship_clarity')).toBe(false);
+  });
+});
+
+// --- Persistence Module (Exports Check) ---
+
+describe('PersistenceModule', () => {
+  it('exports scoreAndPersist function', () => {
+    expect(typeof scoreAndPersist).toBe('function');
+  });
+
+  it('exports seedDefaultRubrics function', () => {
+    expect(typeof seedDefaultRubrics).toBe('function');
+  });
+
+  it('exports getLatestReadiness function', () => {
+    expect(typeof getLatestReadiness).toBe('function');
+  });
+
+  it('exports getLatestAssessment function', () => {
+    expect(typeof getLatestAssessment).toBe('function');
+  });
+
+  it('exports listAssessments function', () => {
+    expect(typeof listAssessments).toBe('function');
+  });
+});
+
+// --- End-to-End Scoring Flow (Pure Logic) ---
+
+describe('End-to-End Scoring Flow', () => {
+  it('scores a complete blueprint through all stages', () => {
+    const artifacts = {
+      data_model: {
+        entities: [
+          { name: 'User', attributes: [{ name: 'id' }, { name: 'email' }, { name: 'name' }] },
+          { name: 'Order', attributes: [{ name: 'id' }, { name: 'total' }, { name: 'status' }] },
+        ],
+        relationships: [{ from: 'User', to: 'Order', type: '1:N' }],
+        normalization: { level: '3NF' },
+        naming: { convention: 'snake_case' },
+      },
+      erd_diagram: { entities: ['User', 'Order'], diagram: 'erDiagram...' },
+      api_contract: { endpoints: ['users', 'orders'], schemas: { User: {}, Order: {} } },
+      user_story_pack: { stories: ['create user', 'place order'], epics: [{ name: 'Core' }] },
+      technical_architecture: { layers: ['presentation', 'api', 'data'], components: ['auth'] },
+      schema_spec: { tables: { users: {}, orders: {} }, types: {} },
+      risk_register: { risks: [{ name: 'Scale' }, { name: 'Security' }], mitigations: {} },
+      financial_projection: { revenue: {}, costs: {}, metrics: { ltv: 500, cac: 100 } },
+      launch_readiness: { screens: ['users', 'orders'], checklist: [], dimensions: {} },
+      sprint_plan: { sprints: [{ stories: ['create user', 'place order'] }] },
+      promotion_gate: { criteria: {}, decision: 'promote', evidence: {} },
+    };
+
+    // Score each artifact
+    const scores = [];
+    for (const [type, content] of Object.entries(artifacts)) {
+      if (ARTIFACT_TYPES.includes(type)) {
+        const result = scoreArtifact(type, content);
+        scores.push({ artifactType: type, total: result.total });
+        expect(result.total).toBeGreaterThan(0);
+      }
+    }
+
+    // Consistency check
+    const consistency = checkConsistency(artifacts);
+    expect(consistency.checkedPairs).toBe(3);
+
+    // Readiness calculation
+    const readiness = calculateReadiness(scores, consistency);
+    expect(readiness.readinessScore).toBeGreaterThan(0);
+    expect(readiness.missingArtifacts).toHaveLength(0);
+    expect(readiness.breakdown.presentCount).toBe(11);
+
+    // Gate decision
+    const gate = evaluateGate(readiness);
+    expect(['pass', 'retry', 'fail']).toContain(gate.decision);
+    expect(gate.score).toBe(readiness.readinessScore);
+  });
+
+  it('handles partial blueprint with missing artifacts', () => {
+    const artifacts = {
+      data_model: { entities: [{ name: 'User' }] },
+      api_contract: { endpoints: ['users'] },
+    };
+
+    const scores = Object.entries(artifacts)
+      .filter(([type]) => ARTIFACT_TYPES.includes(type))
+      .map(([type, content]) => ({ artifactType: type, total: scoreArtifact(type, content).total }));
+
+    const consistency = checkConsistency(artifacts);
+    const readiness = calculateReadiness(scores, consistency);
+
+    expect(readiness.missingArtifacts.length).toBeGreaterThan(0);
+    expect(readiness.readinessScore).toBeLessThan(50);
+
+    const gate = evaluateGate(readiness);
+    expect(gate.decision).toBe('fail');
+    expect(gate.remediationItems.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- Adds database persistence module for blueprint quality assessments (scoreAndPersist, getLatestReadiness, listAssessments)
- Adds 7 additional tests for persistence exports and end-to-end scoring flow
- Re-exports persistence functions from index.js

## Test plan
- [x] All 27 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)