### PR TITLE
fix: consistent worktree tracking in claude_sessions

### DIFF
--- a/database/migrations/20260316_add_worktree_branch_to_sessions.sql
+++ b/database/migrations/20260316_add_worktree_branch_to_sessions.sql
@@ -1,0 +1,12 @@
+-- Migration: Add worktree_branch column to claude_sessions
+-- SD: SD-MAN-INFRA-FIX-WORKTREE-TRACKING-001
+-- Purpose: Enable coordinator to distinguish session branch from worktree branch
+--          for reliable worktree conflict detection across concurrent sessions.
+
+ALTER TABLE claude_sessions
+  ADD COLUMN IF NOT EXISTS worktree_branch TEXT;
+
+COMMENT ON COLUMN claude_sessions.worktree_branch IS
+  'Git branch checked out in the worktree (e.g. feat/SD-XXX-001). '
+  'Set by resolve-sd-workdir.js at claim time and concurrent-session-worktree hook. '
+  'Cleared by heartbeat when worktree_path directory no longer exists on disk.';

--- a/lib/session-manager.mjs
+++ b/lib/session-manager.mjs
@@ -531,6 +531,22 @@ export async function updateHeartbeat(sessionId) {
   const telemetryFields = {};
   if (hasUncommittedChanges !== null) telemetryFields.has_uncommitted_changes = hasUncommittedChanges;
   if (currentPhase !== undefined) telemetryFields.current_phase = currentPhase;
+
+  // Validate worktree_path still exists on disk — clear stale paths
+  try {
+    const { data: sessionRow } = await supabase
+      .from('claude_sessions')
+      .select('worktree_path')
+      .eq('session_id', sessionId)
+      .single();
+    if (sessionRow?.worktree_path && !fs.existsSync(sessionRow.worktree_path)) {
+      telemetryFields.worktree_path = null;
+      telemetryFields.worktree_branch = null;
+    }
+  } catch {
+    // Worktree validation is non-critical
+  }
+
   if (Object.keys(telemetryFields).length > 0) {
     await supabase
       .from('claude_sessions')

--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -548,6 +548,30 @@ async function main() {
       worktree_key: worktreeKey
     });
 
+    // Persist worktree info to claude_sessions so coordinator can track it
+    try {
+      const repoRoot = path.resolve(__dirname, '../..');
+      const worktreePath = path.join(repoRoot, '.worktrees', 'sd', worktreeKey);
+      if (mySessionId && fs.existsSync(worktreePath)) {
+        const { createClient } = require('@supabase/supabase-js');
+        const sbUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+        const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+        if (sbUrl && sbKey) {
+          const supabase = createClient(sbUrl, sbKey);
+          supabase
+            .from('claude_sessions')
+            .update({ worktree_path: worktreePath, worktree_branch: worktreeBranch })
+            .eq('session_id', mySessionId)
+            .then(({ error }) => {
+              if (error) logEvent('session.worktree.db_persist_failed', { error: error.message });
+              else logEvent('session.worktree.db_persisted', { worktree_path: worktreePath, worktree_branch: worktreeBranch });
+            });
+        }
+      }
+    } catch (dbErr) {
+      logEvent('session.worktree.db_persist_failed', { error: dbErr.message });
+    }
+
     console.log(`  Worktree created in ${durationMs}ms`);
     console.log(`  Key: ${worktreeKey}`);
     console.log('');

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -241,9 +241,9 @@ function ensureWorktreeEssentials(worktreePath, repoRoot) {
 }
 
 /**
- * Update claude_sessions.worktree_path for the active session
+ * Update claude_sessions.worktree_path and worktree_branch for the session
  */
-async function persistWorktreePath(sdKey, worktreePath) {
+async function persistWorktreePath(sdKey, worktreePath, worktreeBranch) {
   try {
     const { createClient } = await import('@supabase/supabase-js');
     const supabase = createClient(
@@ -251,11 +251,14 @@ async function persistWorktreePath(sdKey, worktreePath) {
       process.env.SUPABASE_SERVICE_ROLE_KEY
     );
 
+    const updateFields = { worktree_path: worktreePath };
+    if (worktreeBranch) updateFields.worktree_branch = worktreeBranch;
+
     const { error } = await supabase
       .from('claude_sessions')
-      .update({ worktree_path: worktreePath })
+      .update(updateFields)
       .eq('sd_id', sdKey)
-      .eq('status', 'active');
+      .in('status', ['active', 'idle']);
 
     if (error) {
       emitLog({ event: 'worktree.db_update_failed', sdKey, error: error.message, errorCode: 'DB_UPDATE_FAILED' });
@@ -313,7 +316,7 @@ async function resolve(sdKey, mode, repoRoot) {
     emitLog({ event: 'worktree.resolved', sdKey, source: 'scan', resolvedCwd: scanResult.path, outcome: 'success' });
 
     // Persist to DB for future lookups
-    await persistWorktreePath(sdKey, scanResult.path);
+    await persistWorktreePath(sdKey, scanResult.path, branch);
 
     ensureWorktreeEssentials(scanResult.path, repoRoot);
     return {
@@ -330,7 +333,7 @@ async function resolve(sdKey, mode, repoRoot) {
       emitLog({ event: 'worktree.resolved', sdKey, source: 'created', resolvedCwd: created.path, outcome: 'success' });
 
       // Persist to DB
-      await persistWorktreePath(sdKey, created.path);
+      await persistWorktreePath(sdKey, created.path, created.branch);
 
       return {
         sdKey, cwd: created.path, source: 'created', success: true,


### PR DESCRIPTION
## Summary
- Add `worktree_branch` column to `claude_sessions` for coordinator conflict detection
- Fix `concurrent-session-worktree.cjs` hook to persist `worktree_path` + `worktree_branch` to DB after auto-creation
- Extend heartbeat in `session-manager.mjs` to clear stale `worktree_path` when directory removed from disk
- Relax `persistWorktreePath()` status filter from `active`-only to `IN (active, idle)`

## Test plan
- [ ] Run `sd:start` on an SD — verify all 3 fields populated in `claude_sessions`
- [ ] Remove a worktree directory — verify next heartbeat clears `worktree_path` and `worktree_branch`
- [ ] Verify migration is idempotent (run twice without error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)