### PR TITLE
feat: add Friday operations scorecard and quarterly assessments

### DIFF
--- a/database/migrations/ops_friday_scorecard_tables.sql
+++ b/database/migrations/ops_friday_scorecard_tables.sql
@@ -1,0 +1,108 @@
+-- =============================================================================
+-- Migration: ops_friday_scorecard_tables.sql
+-- SD: SD-LEO-INFRA-OPERATIONS-FRIDAY-SCORECARD-001
+-- Date: 2026-03-16
+--
+-- Tables: ops_friday_scorecards, ops_quarterly_assessments
+-- RLS Pattern: JWT venture_id claim-based
+-- =============================================================================
+
+BEGIN;
+
+-- ============================================================
+-- 1. ops_friday_scorecards — weekly scorecard snapshots
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ops_friday_scorecards (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id),
+  week_date DATE NOT NULL,
+  revenue_status TEXT CHECK (revenue_status IN ('green', 'yellow', 'red', 'grey')),
+  customer_status TEXT CHECK (customer_status IN ('green', 'yellow', 'red', 'grey')),
+  product_status TEXT CHECK (product_status IN ('green', 'yellow', 'red', 'grey')),
+  agent_status TEXT CHECK (agent_status IN ('green', 'yellow', 'red', 'grey')),
+  cost_status TEXT CHECK (cost_status IN ('green', 'yellow', 'red', 'grey')),
+  overall_status TEXT NOT NULL CHECK (overall_status IN ('green', 'yellow', 'red', 'grey')),
+  alert_count INTEGER DEFAULT 0,
+  decision_items JSONB DEFAULT '[]'::jsonb,
+  computed_at TIMESTAMPTZ DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(venture_id, week_date)
+);
+
+COMMENT ON TABLE ops_friday_scorecards IS 'Weekly operations scorecard snapshots for Friday meeting with Eva';
+COMMENT ON COLUMN ops_friday_scorecards.overall_status IS 'Worst status across all domains';
+COMMENT ON COLUMN ops_friday_scorecards.decision_items IS 'Array of items requiring chairman decision';
+
+ALTER TABLE ops_friday_scorecards ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "ops_friday_scorecards_service_role" ON ops_friday_scorecards
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "ops_friday_scorecards_venture_select" ON ops_friday_scorecards
+  FOR SELECT TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "ops_friday_scorecards_venture_insert" ON ops_friday_scorecards
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "ops_friday_scorecards_venture_update" ON ops_friday_scorecards
+  FOR UPDATE TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid)
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+-- ============================================================
+-- 2. ops_quarterly_assessments — deep assessment scheduling
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ops_quarterly_assessments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id),
+  assessment_type TEXT NOT NULL CHECK (assessment_type IN ('risk_recalibration', 'exit_readiness', 'competitive_landscape', 'financial_health')),
+  quarter TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'in_progress', 'completed', 'skipped')),
+  scheduled_date DATE,
+  completed_date DATE,
+  findings JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(venture_id, assessment_type, quarter)
+);
+
+COMMENT ON TABLE ops_quarterly_assessments IS 'Quarterly deep assessments surfaced through Friday meeting';
+
+ALTER TABLE ops_quarterly_assessments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "ops_quarterly_assessments_service_role" ON ops_quarterly_assessments
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "ops_quarterly_assessments_venture_select" ON ops_quarterly_assessments
+  FOR SELECT TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "ops_quarterly_assessments_venture_insert" ON ops_quarterly_assessments
+  FOR INSERT TO authenticated
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+CREATE POLICY "ops_quarterly_assessments_venture_update" ON ops_quarterly_assessments
+  FOR UPDATE TO authenticated
+  USING (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid)
+  WITH CHECK (venture_id = (auth.jwt()->'app_metadata'->>'venture_id')::uuid);
+
+-- ============================================================
+-- 3. Indexes
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_ops_friday_scorecards_venture_week
+  ON ops_friday_scorecards (venture_id, week_date DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ops_quarterly_assessments_venture_quarter
+  ON ops_quarterly_assessments (venture_id, quarter DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ops_quarterly_assessments_status
+  ON ops_quarterly_assessments (status)
+  WHERE status IN ('scheduled', 'in_progress');
+
+COMMIT;

--- a/lib/eva/services/friday-scorecard.js
+++ b/lib/eva/services/friday-scorecard.js
@@ -1,0 +1,243 @@
+/**
+ * Friday Operations Scorecard Service
+ * SD: SD-LEO-INFRA-OPERATIONS-FRIDAY-SCORECARD-001
+ *
+ * Aggregates all ops domain signals into a unified per-venture scorecard
+ * for the weekly Friday meeting with Eva.
+ *
+ * Exports:
+ *   generateScorecard()    — compute + store weekly scorecard
+ *   scheduleAssessments()  — create quarterly deep assessment records
+ *   getAgendaItems()       — prioritized Friday meeting agenda
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+}
+
+const ASSESSMENT_TYPES = [
+  'risk_recalibration',
+  'exit_readiness',
+  'competitive_landscape',
+  'financial_health',
+];
+
+const STATUS_PRIORITY = { emergency: 0, critical: 1, red: 2, yellow: 3, warning: 4, green: 5, grey: 6 };
+
+/**
+ * Compute the worst status from a list of statuses.
+ */
+function worstStatus(statuses) {
+  if (!statuses || statuses.length === 0) return 'grey';
+  return statuses.reduce((worst, s) => {
+    const wp = STATUS_PRIORITY[worst] ?? 6;
+    const sp = STATUS_PRIORITY[s] ?? 6;
+    return sp < wp ? s : worst;
+  }, 'grey');
+}
+
+/**
+ * Map alert severities to scorecard status colors.
+ */
+function alertsToStatus(alerts) {
+  if (!alerts || alerts.length === 0) return 'green';
+  const severities = alerts.map(a => a.severity);
+  if (severities.includes('emergency') || severities.includes('critical')) return 'red';
+  if (severities.includes('warning')) return 'yellow';
+  return 'green';
+}
+
+/**
+ * Generate a unified Friday scorecard for a venture.
+ */
+export async function generateScorecard({ ventureId, weekDate, supabase }) {
+  if (!supabase) supabase = getSupabase();
+  const week = weekDate || getWeekDate();
+
+  // Fetch open alerts from all health domains
+  const { data: healthAlerts } = await supabase
+    .from('ops_health_alerts')
+    .select('layer, severity')
+    .eq('venture_id', ventureId)
+    .in('status', ['open', 'acknowledged']);
+
+  const { data: revenueAlerts } = await supabase
+    .from('ops_revenue_alerts')
+    .select('severity')
+    .eq('venture_id', ventureId)
+    .in('status', ['open', 'acknowledged']);
+
+  const productAlerts = (healthAlerts || []).filter(a => a.layer === 'product');
+  const agentAlerts = (healthAlerts || []).filter(a => a.layer === 'agent');
+
+  // Compute per-domain status
+  const revenueStatus = alertsToStatus(revenueAlerts);
+  const productStatus = alertsToStatus(productAlerts);
+  const agentStatus = alertsToStatus(agentAlerts);
+
+  // Customer and cost status: check if tables have data, otherwise grey
+  const customerStatus = await getCustomerStatus(ventureId, supabase);
+  const costStatus = 'grey'; // Cost governance SD not yet implemented
+
+  const allStatuses = [revenueStatus, customerStatus, productStatus, agentStatus, costStatus];
+  const overallStatus = worstStatus(allStatuses);
+  const alertCount = (healthAlerts || []).length + (revenueAlerts || []).length;
+
+  const scorecard = {
+    venture_id: ventureId,
+    week_date: week,
+    revenue_status: revenueStatus,
+    customer_status: customerStatus,
+    product_status: productStatus,
+    agent_status: agentStatus,
+    cost_status: costStatus,
+    overall_status: overallStatus,
+    alert_count: alertCount,
+    decision_items: [],
+  };
+
+  // Store scorecard
+  const { data, error } = await supabase
+    .from('ops_friday_scorecards')
+    .upsert(
+      { ...scorecard, computed_at: new Date().toISOString() },
+      { onConflict: 'venture_id,week_date' }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    console.error(`generateScorecard failed: ${error.message}`);
+    return scorecard;
+  }
+  return data || scorecard;
+}
+
+/**
+ * Check customer health status from ops_customer_health_scores.
+ */
+async function getCustomerStatus(ventureId, supabase) {
+  const { data, error } = await supabase
+    .from('ops_customer_health_scores')
+    .select('health_score')
+    .eq('venture_id', ventureId)
+    .order('scored_at', { ascending: false })
+    .limit(5);
+
+  if (error || !data || data.length === 0) return 'grey';
+
+  const avgScore = data.reduce((sum, d) => sum + (d.health_score || 0), 0) / data.length;
+  if (avgScore < 40) return 'red';
+  if (avgScore < 70) return 'yellow';
+  return 'green';
+}
+
+/**
+ * Schedule quarterly deep assessments for a venture.
+ */
+export async function scheduleAssessments({ ventureId, quarter, supabase }) {
+  if (!supabase) supabase = getSupabase();
+
+  const assessments = ASSESSMENT_TYPES.map(type => ({
+    venture_id: ventureId,
+    assessment_type: type,
+    quarter,
+    status: 'scheduled',
+    scheduled_date: getQuarterEndDate(quarter),
+  }));
+
+  const { data, error } = await supabase
+    .from('ops_quarterly_assessments')
+    .upsert(assessments, { onConflict: 'venture_id,assessment_type,quarter' })
+    .select();
+
+  if (error) {
+    console.error(`scheduleAssessments failed: ${error.message}`);
+    return [];
+  }
+  return data || [];
+}
+
+/**
+ * Get prioritized agenda items for Friday meeting.
+ */
+export async function getAgendaItems({ ventureId, supabase } = {}) {
+  if (!supabase) supabase = getSupabase();
+  const items = [];
+
+  // 1. Emergency and critical alerts
+  let alertQuery = supabase
+    .from('ops_health_alerts')
+    .select('id, venture_id, layer, metric_type, severity, actual_value, threshold_value, created_at')
+    .in('status', ['open', 'acknowledged'])
+    .in('severity', ['emergency', 'critical'])
+    .order('created_at', { ascending: false });
+
+  if (ventureId) alertQuery = alertQuery.eq('venture_id', ventureId);
+
+  const { data: alerts } = await alertQuery;
+  for (const alert of (alerts || [])) {
+    items.push({
+      type: 'alert',
+      priority: alert.severity === 'emergency' ? 0 : 1,
+      venture_id: alert.venture_id,
+      title: `${alert.severity.toUpperCase()}: ${alert.layer} ${alert.metric_type}`,
+      detail: `Actual: ${alert.actual_value}, Threshold: ${alert.threshold_value}`,
+      created_at: alert.created_at,
+    });
+  }
+
+  // 2. Overdue assessments
+  const today = new Date().toISOString().split('T')[0];
+  let assessQuery = supabase
+    .from('ops_quarterly_assessments')
+    .select('id, venture_id, assessment_type, quarter, scheduled_date')
+    .eq('status', 'scheduled')
+    .lte('scheduled_date', today);
+
+  if (ventureId) assessQuery = assessQuery.eq('venture_id', ventureId);
+
+  const { data: overdue } = await assessQuery;
+  for (const assessment of (overdue || [])) {
+    items.push({
+      type: 'overdue_assessment',
+      priority: 2,
+      venture_id: assessment.venture_id,
+      title: `OVERDUE: ${assessment.assessment_type.replace(/_/g, ' ')} (${assessment.quarter})`,
+      detail: `Scheduled: ${assessment.scheduled_date}`,
+      created_at: assessment.scheduled_date,
+    });
+  }
+
+  // Sort by priority (lower = more urgent)
+  items.sort((a, b) => a.priority - b.priority);
+  return items;
+}
+
+/**
+ * Get the ISO week date (Monday of current week).
+ */
+function getWeekDate(date) {
+  const d = date ? new Date(date) : new Date();
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  const monday = new Date(d.setDate(diff));
+  return monday.toISOString().split('T')[0];
+}
+
+/**
+ * Get the end date of a quarter string (e.g., "2026-Q2" → "2026-06-30").
+ */
+function getQuarterEndDate(quarter) {
+  const [year, q] = quarter.split('-Q');
+  const quarterEnds = { '1': '03-31', '2': '06-30', '3': '09-30', '4': '12-31' };
+  return `${year}-${quarterEnds[q] || '12-31'}`;
+}

--- a/tests/unit/ops/friday-scorecard.test.js
+++ b/tests/unit/ops/friday-scorecard.test.js
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  generateScorecard,
+  scheduleAssessments,
+  getAgendaItems,
+} from '../../../lib/eva/services/friday-scorecard.js';
+
+const VENTURE_ID = '00000000-0000-0000-0000-000000000001';
+const WEEK = '2026-03-16';
+
+function mockSupabase(tableData = {}) {
+  const chainMethods = (resolvedValue) => {
+    const chain = {};
+    const methods = ['select', 'eq', 'gte', 'lte', 'in', 'order', 'limit', 'single', 'upsert'];
+    for (const m of methods) {
+      chain[m] = vi.fn().mockReturnValue(chain);
+    }
+    chain.single = vi.fn().mockResolvedValue(resolvedValue);
+    chain.then = (resolve) => resolve(resolvedValue);
+    return chain;
+  };
+
+  return {
+    from: vi.fn((table) => {
+      const data = tableData[table];
+      if (data !== undefined) {
+        return chainMethods({ data, error: null });
+      }
+      return chainMethods({ data: null, error: null });
+    }),
+  };
+}
+
+describe('generateScorecard', () => {
+  it('returns all-green scorecard when no alerts exist', async () => {
+    const sb = mockSupabase({
+      ops_health_alerts: [],
+      ops_revenue_alerts: [],
+      ops_customer_health_scores: [],
+      ops_friday_scorecards: null,
+    });
+    const result = await generateScorecard({ ventureId: VENTURE_ID, weekDate: WEEK, supabase: sb });
+
+    expect(result.revenue_status).toBe('green');
+    expect(result.product_status).toBe('green');
+    expect(result.agent_status).toBe('green');
+    expect(result.customer_status).toBe('grey'); // No data
+    expect(result.cost_status).toBe('grey'); // Not implemented
+    expect(result.overall_status).toBe('green'); // green is worst active status; grey = unavailable
+    expect(result.alert_count).toBe(0);
+  });
+
+  it('returns red overall when critical health alert exists', async () => {
+    const sb = mockSupabase({
+      ops_health_alerts: [{ layer: 'product', severity: 'critical' }],
+      ops_revenue_alerts: [],
+      ops_customer_health_scores: [],
+      ops_friday_scorecards: null,
+    });
+    const result = await generateScorecard({ ventureId: VENTURE_ID, weekDate: WEEK, supabase: sb });
+
+    expect(result.product_status).toBe('red');
+    expect(result.overall_status).toBe('red');
+  });
+
+  it('returns yellow when only warning alerts exist', async () => {
+    const sb = mockSupabase({
+      ops_health_alerts: [{ layer: 'agent', severity: 'warning' }],
+      ops_revenue_alerts: [{ severity: 'warning' }],
+      ops_customer_health_scores: [{ health_score: 80 }],
+      ops_friday_scorecards: null,
+    });
+    const result = await generateScorecard({ ventureId: VENTURE_ID, weekDate: WEEK, supabase: sb });
+
+    expect(result.agent_status).toBe('yellow');
+    expect(result.revenue_status).toBe('yellow');
+    expect(result.customer_status).toBe('green'); // 80 > 70
+  });
+
+  it('counts alerts from both health and revenue domains', async () => {
+    const sb = mockSupabase({
+      ops_health_alerts: [
+        { layer: 'product', severity: 'warning' },
+        { layer: 'agent', severity: 'critical' },
+      ],
+      ops_revenue_alerts: [{ severity: 'warning' }],
+      ops_customer_health_scores: [],
+      ops_friday_scorecards: null,
+    });
+    const result = await generateScorecard({ ventureId: VENTURE_ID, weekDate: WEEK, supabase: sb });
+
+    expect(result.alert_count).toBe(3);
+  });
+
+  it('shows red customer status when health scores are low', async () => {
+    const sb = mockSupabase({
+      ops_health_alerts: [],
+      ops_revenue_alerts: [],
+      ops_customer_health_scores: [
+        { health_score: 30 },
+        { health_score: 35 },
+      ],
+      ops_friday_scorecards: null,
+    });
+    const result = await generateScorecard({ ventureId: VENTURE_ID, weekDate: WEEK, supabase: sb });
+
+    expect(result.customer_status).toBe('red'); // avg 32.5 < 40
+  });
+});
+
+describe('scheduleAssessments', () => {
+  it('creates 4 assessment types for a quarter', async () => {
+    const inserted = [];
+    const sb = {
+      from: vi.fn(() => ({
+        upsert: vi.fn((data) => {
+          inserted.push(...data);
+          return {
+            select: vi.fn().mockResolvedValue({ data, error: null }),
+          };
+        }),
+      })),
+    };
+
+    const result = await scheduleAssessments({ ventureId: VENTURE_ID, quarter: '2026-Q2', supabase: sb });
+
+    expect(inserted).toHaveLength(4);
+    const types = inserted.map(a => a.assessment_type).sort();
+    expect(types).toEqual([
+      'competitive_landscape',
+      'exit_readiness',
+      'financial_health',
+      'risk_recalibration',
+    ]);
+    expect(inserted[0].status).toBe('scheduled');
+    expect(inserted[0].quarter).toBe('2026-Q2');
+  });
+});
+
+describe('getAgendaItems', () => {
+  it('returns empty array when no alerts or overdue assessments', async () => {
+    const sb = mockSupabase({
+      ops_health_alerts: [],
+      ops_quarterly_assessments: [],
+    });
+    const result = await getAgendaItems({ ventureId: VENTURE_ID, supabase: sb });
+    expect(result).toEqual([]);
+  });
+
+  it('prioritizes emergency alerts over critical', async () => {
+    const sb = mockSupabase({
+      ops_health_alerts: [
+        { id: '1', venture_id: VENTURE_ID, layer: 'product', metric_type: 'uptime', severity: 'critical', actual_value: 98.5, threshold_value: 99.0, created_at: '2026-03-16' },
+        { id: '2', venture_id: VENTURE_ID, layer: 'product', metric_type: 'uptime', severity: 'emergency', actual_value: 95.0, threshold_value: 99.0, created_at: '2026-03-16' },
+      ],
+      ops_quarterly_assessments: [],
+    });
+    const result = await getAgendaItems({ ventureId: VENTURE_ID, supabase: sb });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].priority).toBe(0); // emergency first
+    expect(result[1].priority).toBe(1); // critical second
+  });
+
+  it('includes overdue assessments after alerts', async () => {
+    const sb = mockSupabase({
+      ops_health_alerts: [
+        { id: '1', venture_id: VENTURE_ID, layer: 'agent', metric_type: 'quota', severity: 'critical', actual_value: 96, threshold_value: 95, created_at: '2026-03-16' },
+      ],
+      ops_quarterly_assessments: [
+        { id: '2', venture_id: VENTURE_ID, assessment_type: 'risk_recalibration', quarter: '2026-Q1', scheduled_date: '2026-03-01' },
+      ],
+    });
+    const result = await getAgendaItems({ ventureId: VENTURE_ID, supabase: sb });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe('alert');
+    expect(result[1].type).toBe('overdue_assessment');
+  });
+});


### PR DESCRIPTION
## Summary
- Create `ops_friday_scorecards` table for weekly per-venture green/yellow/red status snapshots
- Create `ops_quarterly_assessments` table for deep assessment scheduling (risk, exit, competitive, financial)
- Build `friday-scorecard.js` service with generateScorecard, scheduleAssessments, getAgendaItems
- 9 unit tests covering scorecard computation, assessment scheduling, and agenda prioritization
- RLS policies on both tables with venture-scoped JWT access
- Completes the Operations Mode vision (SD 6 of 6, VISION-OPS-MODE-L2-001)

## Test plan
- [x] 9 unit tests pass (vitest)
- [x] Scorecard aggregation from all ops domains tested
- [x] Quarterly assessment scheduling tested (4 types per quarter)
- [x] Agenda item prioritization tested (emergency > critical > overdue)
- [x] Empty/grey data handling tested
- [x] Migration executed successfully on Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)