### PR TITLE
feat: operations mode transition engine and worker bug fixes

### DIFF
--- a/lib/eva/operations/domain-handler.js
+++ b/lib/eva/operations/domain-handler.js
@@ -46,6 +46,17 @@ export function registerOperationsHandlers(domainRegistry) {
     const { classifyFeedback } = await import('../feedback-dimension-classifier.js');
     const { supabase, logger = console } = params;
 
+    // Verify feedback_items table exists before querying (migration safety)
+    const { error: probeError } = await supabase
+      .from('feedback_items')
+      .select('id', { count: 'exact', head: true })
+      .limit(0);
+
+    if (probeError) {
+      logger.warn(`[ops_feedback_classify] feedback_items table not available: ${probeError.message}`);
+      return { classified: 0, total: 0, skipped: true, reason: probeError.message, timestamp: new Date().toISOString() };
+    }
+
     const { data: unclassified } = await supabase
       .from('feedback_items')
       .select('id, title, description')
@@ -70,8 +81,9 @@ export function registerOperationsHandlers(domainRegistry) {
 
   domainRegistry.register('ops_metrics_collect', async (params) => {
     const { supabase, logger = console } = params;
+    const sixHoursAgo = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString();
 
-    // Collect pipeline throughput metrics
+    // Pipeline throughput metrics
     const { count: activeVentures } = await supabase
       .from('eva_ventures')
       .select('id', { count: 'exact', head: true })
@@ -81,17 +93,32 @@ export function registerOperationsHandlers(domainRegistry) {
       .from('eva_stage_gate_results')
       .select('id', { count: 'exact', head: true })
       .eq('passed', true)
-      .gte('created_at', new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString());
+      .gte('created_at', sixHoursAgo);
+
+    // AARRR business metrics from venture_financial_contract
+    const { data: contracts } = await supabase
+      .from('venture_financial_contract')
+      .select('venture_id, cac_estimate, ltv_estimate, pricing_model, revenue_projection')
+      .limit(50);
+
+    const aarrr = {
+      acquisition: { ventures_with_cac: (contracts || []).filter(c => c.cac_estimate).length },
+      revenue: { ventures_with_ltv: (contracts || []).filter(c => c.ltv_estimate).length },
+      total_contracts: (contracts || []).length,
+    };
 
     const snapshot = {
-      metric_type: 'ops_pipeline_throughput',
-      metric_value: JSON.stringify({ activeVentures, completedStages6h: completedStages }),
+      metric_type: 'ops_metrics_combined',
+      metric_value: JSON.stringify({
+        pipeline: { activeVentures, completedStages6h: completedStages },
+        aarrr,
+      }),
       created_at: new Date().toISOString(),
     };
 
     await supabase.from('eva_scheduler_metrics').insert(snapshot);
 
-    logger.info(`[ops_metrics_collect] Active: ${activeVentures}, Stages (6h): ${completedStages}`);
+    logger.info(`[ops_metrics_collect] Active: ${activeVentures}, Stages (6h): ${completedStages}, Contracts: ${aarrr.total_contracts}`);
     return snapshot;
   });
 
@@ -123,8 +150,8 @@ export function registerOperationsHandlers(domainRegistry) {
         .filter(Boolean)
         .join(' ');
       if (text.length > 20) {
-        const signals = await captureSignals(text, { supabase });
-        if (signals?.length > 0) detected += signals.length;
+        const result = await captureSignals(text, { sessionId: 'ops_enhancement_detect', sdId: retro.id });
+        if (result?.count > 0) detected += result.count;
       }
     }
 

--- a/lib/eva/operations/mode-transition-engine.js
+++ b/lib/eva/operations/mode-transition-engine.js
@@ -1,0 +1,157 @@
+/**
+ * Operations Mode Transition Engine.
+ * Evaluates venture metrics against configurable thresholds to determine
+ * when ventures should change lifecycle modes. All transitions require
+ * chairman approval via pending_ceo_handoffs.
+ *
+ * @module lib/eva/operations/mode-transition-engine
+ */
+
+/**
+ * Threshold configs for each transition path.
+ * Values based on brainstorm/2026-03-15-operations-mode-design.md
+ */
+export const TRANSITION_THRESHOLDS = {
+  'operations→growth': {
+    mom_growth_pct: 20,        // MoM growth >20%
+    min_months_growth: 3,      // Sustained for 3+ months
+    min_customers: 100,
+    max_churn_pct: 5,
+  },
+  'growth→scaling': {
+    min_arr: 100000,           // ARR >$100K
+    min_ltv_cac_ratio: 3.0,    // LTV:CAC >3.0
+    min_months_sustained: 6,
+  },
+  'scaling→exit_prep': {
+    min_exit_readiness_score: 70,
+    min_quarters_above: 2,
+  },
+  'exit_prep→divesting': {
+    chairman_approval_required: true,  // Chairman approves buyer/deal
+  },
+  'divesting→sold': {
+    transaction_complete: true,
+  },
+  'any→parked': {
+    chairman_decision: true,
+  },
+  'any→killed': {
+    chairman_decision: true,
+  },
+};
+
+/**
+ * Evaluate whether a venture qualifies for a mode transition.
+ *
+ * @param {string} currentMode - Current venture mode
+ * @param {object} metrics - Venture metrics snapshot
+ * @param {number} [metrics.mom_growth_pct] - Month-over-month growth %
+ * @param {number} [metrics.consecutive_growth_months] - Months of sustained growth
+ * @param {number} [metrics.customer_count] - Active customers
+ * @param {number} [metrics.churn_pct] - Monthly churn %
+ * @param {number} [metrics.arr] - Annual Recurring Revenue
+ * @param {number} [metrics.ltv_cac_ratio] - LTV to CAC ratio
+ * @param {number} [metrics.exit_readiness_score] - Exit readiness score (0-100)
+ * @param {number} [metrics.quarters_above_exit_threshold] - Quarters with exit score ≥70
+ * @returns {{ eligible: boolean, targetMode: string|null, reasons: string[] }}
+ */
+export function evaluateTransition(currentMode, metrics) {
+  const transitions = getTransitionsFrom(currentMode);
+
+  for (const { path, target, thresholds } of transitions) {
+    const reasons = [];
+    let eligible = true;
+
+    if (thresholds.chairman_decision || thresholds.chairman_approval_required || thresholds.transaction_complete) {
+      // These are chairman-only transitions, not metric-driven
+      continue;
+    }
+
+    if (thresholds.mom_growth_pct !== undefined) {
+      if ((metrics.mom_growth_pct || 0) > thresholds.mom_growth_pct) {
+        reasons.push(`MoM growth ${metrics.mom_growth_pct}% > ${thresholds.mom_growth_pct}%`);
+      } else { eligible = false; }
+    }
+    if (thresholds.min_months_growth !== undefined) {
+      if ((metrics.consecutive_growth_months || 0) >= thresholds.min_months_growth) {
+        reasons.push(`${metrics.consecutive_growth_months} months sustained growth`);
+      } else { eligible = false; }
+    }
+    if (thresholds.min_customers !== undefined) {
+      if ((metrics.customer_count || 0) >= thresholds.min_customers) {
+        reasons.push(`${metrics.customer_count} customers`);
+      } else { eligible = false; }
+    }
+    if (thresholds.max_churn_pct !== undefined) {
+      if ((metrics.churn_pct || 100) <= thresholds.max_churn_pct) {
+        reasons.push(`Churn ${metrics.churn_pct}% ≤ ${thresholds.max_churn_pct}%`);
+      } else { eligible = false; }
+    }
+    if (thresholds.min_arr !== undefined) {
+      if ((metrics.arr || 0) >= thresholds.min_arr) {
+        reasons.push(`ARR $${metrics.arr} ≥ $${thresholds.min_arr}`);
+      } else { eligible = false; }
+    }
+    if (thresholds.min_ltv_cac_ratio !== undefined) {
+      if ((metrics.ltv_cac_ratio || 0) >= thresholds.min_ltv_cac_ratio) {
+        reasons.push(`LTV:CAC ${metrics.ltv_cac_ratio} ≥ ${thresholds.min_ltv_cac_ratio}`);
+      } else { eligible = false; }
+    }
+    if (thresholds.min_exit_readiness_score !== undefined) {
+      if ((metrics.exit_readiness_score || 0) >= thresholds.min_exit_readiness_score) {
+        reasons.push(`Exit readiness ${metrics.exit_readiness_score} ≥ ${thresholds.min_exit_readiness_score}`);
+      } else { eligible = false; }
+    }
+    if (thresholds.min_quarters_above !== undefined) {
+      if ((metrics.quarters_above_exit_threshold || 0) >= thresholds.min_quarters_above) {
+        reasons.push(`${metrics.quarters_above_exit_threshold} quarters above threshold`);
+      } else { eligible = false; }
+    }
+
+    if (eligible && reasons.length > 0) {
+      return { eligible: true, targetMode: target, reasons };
+    }
+  }
+
+  return { eligible: false, targetMode: null, reasons: [] };
+}
+
+/**
+ * Submit a mode transition for chairman approval.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {string} fromMode - Current mode
+ * @param {string} toMode - Target mode
+ * @param {string[]} reasons - Evaluation reasons
+ * @returns {Promise<{id: string, status: string}>}
+ */
+export async function submitTransitionForApproval(supabase, ventureId, fromMode, toMode, reasons) {
+  const { data, error } = await supabase
+    .from('pending_ceo_handoffs')
+    .insert({
+      venture_id: ventureId,
+      from_stage: `mode:${fromMode}`,
+      to_stage: `mode:${toMode}`,
+      handoff_data: { type: 'mode_transition', from: fromMode, to: toMode, reasons, evaluated_at: new Date().toISOString() },
+      status: 'pending',
+      proposed_at: new Date().toISOString(),
+    })
+    .select('id, status')
+    .single();
+
+  if (error) throw new Error(`Failed to submit transition: ${error.message}`);
+  return data;
+}
+
+function getTransitionsFrom(mode) {
+  const results = [];
+  for (const [path, thresholds] of Object.entries(TRANSITION_THRESHOLDS)) {
+    const [from, target] = path.split('→');
+    if (from === mode || from === 'any') {
+      results.push({ path, target, thresholds });
+    }
+  }
+  return results;
+}

--- a/tests/unit/eva/mode-transition-engine.test.js
+++ b/tests/unit/eva/mode-transition-engine.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateTransition, TRANSITION_THRESHOLDS } from '../../../lib/eva/operations/mode-transition-engine.js';
+
+describe('ModeTransitionEngine', () => {
+  describe('TRANSITION_THRESHOLDS', () => {
+    it('defines 7 transition paths', () => {
+      expect(Object.keys(TRANSITION_THRESHOLDS)).toHaveLength(7);
+    });
+  });
+
+  describe('operations → growth', () => {
+    it('qualifies when all thresholds met', () => {
+      const result = evaluateTransition('operations', {
+        mom_growth_pct: 25,
+        consecutive_growth_months: 4,
+        customer_count: 150,
+        churn_pct: 3,
+      });
+      expect(result.eligible).toBe(true);
+      expect(result.targetMode).toBe('growth');
+      expect(result.reasons.length).toBeGreaterThan(0);
+    });
+
+    it('rejects when growth insufficient', () => {
+      const result = evaluateTransition('operations', {
+        mom_growth_pct: 10, // below 20%
+        consecutive_growth_months: 4,
+        customer_count: 150,
+        churn_pct: 3,
+      });
+      expect(result.eligible).toBe(false);
+    });
+
+    it('rejects when churn too high', () => {
+      const result = evaluateTransition('operations', {
+        mom_growth_pct: 25,
+        consecutive_growth_months: 4,
+        customer_count: 150,
+        churn_pct: 8, // above 5%
+      });
+      expect(result.eligible).toBe(false);
+    });
+
+    it('rejects when customers insufficient', () => {
+      const result = evaluateTransition('operations', {
+        mom_growth_pct: 25,
+        consecutive_growth_months: 4,
+        customer_count: 50, // below 100
+        churn_pct: 3,
+      });
+      expect(result.eligible).toBe(false);
+    });
+  });
+
+  describe('growth → scaling', () => {
+    it('qualifies when ARR, LTV:CAC, and duration met', () => {
+      const result = evaluateTransition('growth', {
+        arr: 120000,
+        ltv_cac_ratio: 3.5,
+        min_months_sustained: 7,
+      });
+      expect(result.eligible).toBe(true);
+      expect(result.targetMode).toBe('scaling');
+    });
+
+    it('rejects when ARR too low', () => {
+      const result = evaluateTransition('growth', {
+        arr: 50000,
+        ltv_cac_ratio: 3.5,
+      });
+      expect(result.eligible).toBe(false);
+    });
+  });
+
+  describe('scaling → exit_prep', () => {
+    it('qualifies when exit readiness sustained', () => {
+      const result = evaluateTransition('scaling', {
+        exit_readiness_score: 75,
+        quarters_above_exit_threshold: 3,
+      });
+      expect(result.eligible).toBe(true);
+      expect(result.targetMode).toBe('exit_prep');
+    });
+
+    it('rejects when score below threshold', () => {
+      const result = evaluateTransition('scaling', {
+        exit_readiness_score: 60,
+        quarters_above_exit_threshold: 3,
+      });
+      expect(result.eligible).toBe(false);
+    });
+  });
+
+  describe('chairman-only transitions', () => {
+    it('does not auto-qualify exit_prep→divesting', () => {
+      const result = evaluateTransition('exit_prep', {});
+      expect(result.eligible).toBe(false);
+    });
+
+    it('does not auto-qualify any→parked', () => {
+      const result = evaluateTransition('operations', {});
+      expect(result.eligible).toBe(false);
+    });
+  });
+
+  describe('no valid transition', () => {
+    it('returns not eligible for unknown mode', () => {
+      const result = evaluateTransition('sold', {});
+      expect(result.eligible).toBe(false);
+      expect(result.targetMode).toBeNull();
+    });
+
+    it('handles missing metrics gracefully', () => {
+      const result = evaluateTransition('operations', {});
+      expect(result.eligible).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add mode transition evaluation engine (`lib/eva/operations/mode-transition-engine.js`) with 7 configurable transition paths
- Fix feedback_items worker migration mismatch (probe table before querying)
- Fix AARRR metrics column references (use `venture_financial_contract` table)
- Fix captureSignals parameter handling and metrics collection
- All transitions require chairman approval via `pending_ceo_handoffs`

## Test plan
- [x] 13 unit tests passing for mode-transition-engine
- [ ] Verify feedback_items worker handles missing table gracefully
- [ ] Verify metrics collection uses correct column names

🤖 Generated with [Claude Code](https://claude.com/claude-code)