### PR TITLE
fix: enforce DB-only storage for brainstorm content

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -1,6 +1,6 @@
 # /brainstorm - EHG-Aware Strategic Brainstorming
 
-Universal thinking tool with domain-specific question banks, multi-venture awareness, and self-improving retrospective. Produces a document in `brainstorm/`.
+Universal thinking tool with domain-specific question banks, multi-venture awareness, and self-improving retrospective. Stores content in the `brainstorm_sessions.content` database column (DB-only — no filesystem markdown files).
 
 **Arguments**: `$ARGUMENTS`
 
@@ -707,19 +707,17 @@ No AskUserQuestion needed — proceed directly to Step 9.5 after Step 9.
 
 ---
 
-## Step 9: Generate and Save Document
+## Step 9: Generate and Save to Database
 
-### File Naming
+### DB-Only Storage (MANDATORY)
 
-Generate a slug from the topic (lowercase, hyphens, no special chars, max 50 chars).
+**Do NOT write a markdown file to the filesystem.** Brainstorm content is stored in the `brainstorm_sessions.content` column.
 
-**File path**: `brainstorm/YYYY-MM-DD-<topic-slug>.md`
-
-Example: `brainstorm/2026-02-10-improve-handoff-gate-scoring.md`
+Build the brainstorm document **in-memory** using the template below. You will pass this content to the database insert at the end of this step.
 
 ### Document Template
 
-Write the document using the Write tool with this structure:
+Build the following markdown content in-memory (do NOT use the Write tool):
 
 ```markdown
 # Brainstorm: [Topic Title]
@@ -846,12 +844,9 @@ Write the document using the Write tool with this structure:
 - [Actionable next steps based on the brainstorm and outcome classification]
 ```
 
-### After Saving
+### After Building Content
 
-Confirm the file was saved:
-```
-Brainstorm saved to: brainstorm/YYYY-MM-DD-<topic-slug>.md
-```
+The in-memory markdown content will be stored in the database in the session recording step below. Do NOT write it to the filesystem.
 
 ---
 
@@ -1182,7 +1177,10 @@ supabase.from('brainstorm_sessions')
 
 ## Step 10: Session Retrospective
 
-After saving the document, record the session for self-improvement:
+Record the session with the in-memory brainstorm content stored in the `content` column:
+
+**IMPORTANT**: Pass the brainstorm markdown content (built in-memory above) as the `content` field value.
+Do NOT set `document_path` — that field is deprecated. All brainstorm content goes in the `content` column.
 
 ```bash
 node -e "
@@ -1200,7 +1198,7 @@ supabase.from('brainstorm_sessions').insert({
   session_quality_score: <0-100>,
   crystallization_score: <0.0-1.0 or null>,
   retrospective_status: 'pending',
-  document_path: '<file_path>',
+  content: \`<BRAINSTORM_MARKDOWN_CONTENT>\`,
   metadata: {
     questions_asked: <count>,
     questions_skipped: <count>,
@@ -1217,6 +1215,10 @@ supabase.from('brainstorm_sessions').insert({
 "
 ```
 
+**Note**: The `<BRAINSTORM_MARKDOWN_CONTENT>` placeholder must be replaced with the actual in-memory markdown content from the template above. Use backtick template literal for multi-line content. Escape any backticks in the content with `\\\``.
+
+**NEVER write brainstorm content to `brainstorm/*.md` files.** The PreToolUse hook will block it, and it violates the DB-only policy.
+
 **Session quality score** (0-100): Rate based on:
 - Did the user engage with all required questions? (+20 per question answered)
 - Was the evaluation framework used? (+20)
@@ -1230,7 +1232,7 @@ Cap at 100. This score feeds into the self-improvement loop.
 
 ## Step 11: Command Ecosystem Integration
 
-After the document is saved and session recorded, suggest next steps based on the outcome classification:
+After the session is recorded in the database, suggest next steps based on the outcome classification:
 
 ### 11.0: Distill Pipeline Auto-Chain (SD-DISTILLTOBRAINSTORM-ORCH-001-A)
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ applications/*/.leo-sync/supabase/.temp/
 docs/plans/*-vision.md
 docs/plans/*-architecture.md
 
+# Brainstorm documents are DB-only — content stored in brainstorm_sessions.content column
+brainstorm/
+
 # Auto-generated database optimization files
 database-optimization.sql
 migrations/*_optimize_database.sql

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -359,6 +359,9 @@ if [ ! -z "$STAGED_MD_FILES" ]; then
   # SD-LEO-STREAMS-001: Added docs/reference/ exclusion for schema documentation
   HANDOFF_FILES=$(echo "$STAGED_MD_FILES" | grep -i 'handoff' | grep -v 'retrospectives/' | grep -v 'docs/vision/' | grep -v 'docs/plans/' | grep -v 'docs/specs/' | grep -v 'docs/reference/' | grep -v '\.claude/commands/' || true)
 
+  # Check for brainstorm markdown files (DB-only: content belongs in brainstorm_sessions.content)
+  BRAINSTORM_FILES=$(echo "$STAGED_MD_FILES" | grep -E '^brainstorm/' || true)
+
   VIOLATIONS=""
 
   if [ ! -z "$SD_FILES" ]; then
@@ -371,6 +374,10 @@ if [ ! -z "$STAGED_MD_FILES" ]; then
 
   if [ ! -z "$HANDOFF_FILES" ]; then
     VIOLATIONS="${VIOLATIONS}Handoff markdown files:\n$(echo "$HANDOFF_FILES" | sed 's/^/  - /')\n\n"
+  fi
+
+  if [ ! -z "$BRAINSTORM_FILES" ]; then
+    VIOLATIONS="${VIOLATIONS}Brainstorm markdown files:\n$(echo "$BRAINSTORM_FILES" | sed 's/^/  - /')\n\n"
   fi
 
   if [ ! -z "$VIOLATIONS" ]; then
@@ -398,6 +405,13 @@ if [ ! -z "$STAGED_MD_FILES" ]; then
     if [ ! -z "$HANDOFF_FILES" ]; then
       echo "   Handoffs → Use database:"
       echo "   Run: node scripts/unified-handoff-system.js"
+      echo ""
+    fi
+
+    if [ ! -z "$BRAINSTORM_FILES" ]; then
+      echo "   Brainstorms → Use database:"
+      echo "   Store content in brainstorm_sessions.content column."
+      echo "   Run: node scripts/brainstorm-backfill-content.mjs  (to migrate existing files)"
       echo ""
     fi
 

--- a/lib/integrations/brainstorm-retrospective.js
+++ b/lib/integrations/brainstorm-retrospective.js
@@ -40,7 +40,8 @@ function getSupabase() {
  * @param {string} [session.outcomeType] - Outcome classification
  * @param {number} [session.qualityScore] - 0-100 session quality
  * @param {number} [session.crystallizationScore] - 0.0-1.0
- * @param {string} [session.documentPath] - Path to saved document
+ * @param {string} [session.content] - Brainstorm markdown content (DB-only, replaces documentPath)
+ * @param {string} [session.documentPath] - DEPRECATED: Path to saved document (use content instead)
  * @param {Object} [session.metadata] - Additional metadata
  * @returns {Promise<Object>} Created session record
  */
@@ -60,6 +61,7 @@ export async function recordSession(session) {
       session_quality_score: session.qualityScore || null,
       crystallization_score: session.crystallizationScore || null,
       retrospective_status: 'pending',
+      content: session.content || null,
       document_path: session.documentPath || null,
       metadata: session.metadata || {},
     })

--- a/scripts/brainstorm-backfill-content.mjs
+++ b/scripts/brainstorm-backfill-content.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Brainstorm Content Backfill Script
+ *
+ * Migrates brainstorm content from filesystem markdown files to the
+ * brainstorm_sessions.content database column.
+ *
+ * Finds all sessions with document_path set but content NULL,
+ * reads the file, and updates the content column.
+ *
+ * Usage:
+ *   node scripts/brainstorm-backfill-content.mjs              # Execute backfill
+ *   node scripts/brainstorm-backfill-content.mjs --dry-run    # Preview without changes
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env' });
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main() {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  console.log('\n═══════════════════════════════════════════════════════');
+  console.log(' BRAINSTORM CONTENT BACKFILL');
+  if (DRY_RUN) console.log(' MODE: DRY RUN (no DB changes)');
+  console.log('═══════════════════════════════════════════════════════\n');
+
+  // Find sessions with document_path but no content
+  const { data: sessions, error } = await supabase
+    .from('brainstorm_sessions')
+    .select('id, topic, document_path, created_at')
+    .not('document_path', 'is', null)
+    .is('content', null)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    console.error('Query failed:', error.message);
+    process.exit(1);
+  }
+
+  console.log(`Found ${sessions?.length || 0} sessions with document_path but no content\n`);
+
+  if (!sessions?.length) {
+    console.log('Nothing to backfill.');
+    return;
+  }
+
+  let migrated = 0;
+  let failed = 0;
+  let fileNotFound = 0;
+
+  for (const session of sessions) {
+    const label = session.topic?.slice(0, 60) || session.id;
+    const filePath = resolve(process.cwd(), session.document_path);
+
+    let content;
+    try {
+      content = readFileSync(filePath, 'utf8');
+    } catch {
+      console.log(`  SKIP  ${label}`);
+      console.log(`        File not found: ${session.document_path}`);
+      fileNotFound++;
+      continue;
+    }
+
+    if (content.length < 10) {
+      console.log(`  SKIP  ${label} (empty file: ${content.length} chars)`);
+      fileNotFound++;
+      continue;
+    }
+
+    if (DRY_RUN) {
+      console.log(`  [DRY] ${label} (${content.length} chars)`);
+      migrated++;
+      continue;
+    }
+
+    const { error: updErr } = await supabase
+      .from('brainstorm_sessions')
+      .update({ content })
+      .eq('id', session.id);
+
+    if (updErr) {
+      console.log(`  FAIL  ${label}: ${updErr.message}`);
+      failed++;
+    } else {
+      console.log(`  OK    ${label} (${content.length} chars)`);
+      migrated++;
+    }
+  }
+
+  console.log('\n═══════════════════════════════════════════════════════');
+  console.log(` BACKFILL COMPLETE`);
+  console.log(`   Migrated:       ${migrated}`);
+  console.log(`   File not found: ${fileNotFound}`);
+  console.log(`   Failed:         ${failed}`);
+  console.log(`   Total:          ${sessions.length}`);
+  console.log('═══════════════════════════════════════════════════════\n');
+}
+
+// Windows-compatible ESM entry point
+if (process.argv[1] && (
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`
+)) {
+  main().catch(err => { console.error('Fatal:', err.message); process.exit(1); });
+}
+
+export { main };

--- a/scripts/eva/brainstorm-to-vision.mjs
+++ b/scripts/eva/brainstorm-to-vision.mjs
@@ -91,7 +91,7 @@ async function main() {
   // Find unlinked brainstorm sessions with vision-relevant outcomes
   let query = supabase
     .from('brainstorm_sessions')
-    .select('id, topic, outcome_type, metadata, document_path, new_capability_candidates, created_at')
+    .select('id, topic, outcome_type, metadata, content, document_path, new_capability_candidates, created_at')
     .in('outcome_type', VISION_RELEVANT_OUTCOMES)
     .order('created_at', { ascending: true });
 
@@ -139,15 +139,18 @@ async function main() {
     console.log(`\n─── Processing: ${label}`);
     console.log(`    Outcome: ${session.outcome_type} | Created: ${session.created_at}`);
 
-    // Build content from session data: prefer document_path, fallback to metadata+topic
+    // Build content from session data: prefer DB content column, fallback to document_path, then metadata
     let content = '';
-    if (session.document_path) {
+    if (session.content) {
+      content = session.content;
+      console.log(`    📄 Loaded from DB content column (${content.length} chars)`);
+    } else if (session.document_path) {
       try {
         const { readFileSync } = await import('fs');
         const { resolve } = await import('path');
         const docPath = resolve(process.cwd(), session.document_path);
         content = readFileSync(docPath, 'utf8');
-        console.log(`    📄 Loaded document: ${session.document_path} (${content.length} chars)`);
+        console.log(`    📄 Loaded from document_path: ${session.document_path} (${content.length} chars)`);
       } catch {
         console.log(`    ⚠️  Document not found: ${session.document_path}, using metadata`);
       }

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -126,16 +126,16 @@ function main() {
       }
     }
 
-    // Block new file creation in brainstorm/
+    // Block ALL markdown writes to brainstorm/ (new or existing)
+    // Brainstorm content belongs in brainstorm_sessions.content column, not on disk.
     if (/brainstorm\/[^/]+\.md$/.test(filePath)) {
-      if (!fs.existsSync(input.file_path)) {
-        process.stderr.write(
-          'DB-ONLY ENFORCEMENT: Blocked new markdown file in brainstorm/.\n' +
-          'Brainstorm content must be stored in brainstorm_sessions.content column.\n' +
-          'Store via Supabase upsert to brainstorm_sessions table.\n'
-        );
-        process.exit(2);
-      }
+      process.stderr.write(
+        'DB-ONLY ENFORCEMENT: Blocked markdown write to brainstorm/.\n' +
+        'Brainstorm content must be stored in brainstorm_sessions.content column.\n' +
+        'Build content in-memory and pass it to the DB insert in Step 9.\n' +
+        'Do NOT use the Write tool for brainstorm documents.\n'
+      );
+      process.exit(2);
     }
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `/brainstorm` command wrote markdown files to `brainstorm/` and never populated the `brainstorm_sessions.content` DB column (added March 13 but command was never updated)
- **Impact**: 242 DB sessions, only 4 had content populated; 137 markdown files accumulating on disk

### Corrective
- Updated `/brainstorm` command Step 9 — builds content in-memory, stores in DB `content` column, no filesystem writes
- Backfill script (`brainstorm-backfill-content.mjs`) migrated 104 sessions from file → DB content column
- Updated `brainstorm-to-vision.mjs` to prefer DB `content` column over filesystem `document_path`
- Updated `brainstorm-retrospective.js` library to accept `content` parameter

### Preventive
- Pre-commit DOCMON guard now blocks `brainstorm/*.md` files from being committed
- PreToolUse hook blocks ALL writes to `brainstorm/` (previously only blocked new files, allowing overwrites)
- Added `brainstorm/` to `.gitignore`

## Test plan
- [x] Backfill dry-run verified 104 sessions readable, 16 files missing (unrecoverable)
- [x] Backfill executed successfully — DB now has 108 sessions with content (4 original + 104 migrated)
- [x] Smoke tests pass (15/15)
- [x] Pre-commit hooks pass (DOCMON, secrets, linting, Gate 0)
- [ ] Next `/brainstorm` invocation should store content in DB, not write file

🤖 Generated with [Claude Code](https://claude.com/claude-code)