### PR TITLE
feat: specialist_registry table + DB-backed specialist persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ docs/plans/*-vision.md
 docs/plans/*-architecture.md
 
 # Brainstorm documents are DB-only — content stored in brainstorm_sessions.content column
-brainstorm/
+/brainstorm/
 
 # Auto-generated database optimization files
 database-optimization.sql

--- a/lib/brainstorm/board-judiciary-bridge.js
+++ b/lib/brainstorm/board-judiciary-bridge.js
@@ -171,6 +171,18 @@ export async function recordJudiciaryVerdict({
 }
 
 /**
+ * Update a debate session's round number.
+ * @param {string} debateSessionId
+ * @param {number} roundNumber
+ */
+export async function updateDebateRound(debateSessionId, roundNumber) {
+  await supabase
+    .from('debate_sessions')
+    .update({ round_number: roundNumber })
+    .eq('id', debateSessionId);
+}
+
+/**
  * Fetch all arguments for a debate session, organized by round.
  * @param {string} debateSessionId
  * @returns {Promise<{round1: Array, round2: Array, specialists: Array}>}

--- a/lib/brainstorm/deliberation-engine.js
+++ b/lib/brainstorm/deliberation-engine.js
@@ -16,7 +16,8 @@ import {
   createBoardDebateSession,
   recordBoardArgument,
   recordJudiciaryVerdict,
-  extractConstitutionalCitations
+  extractConstitutionalCitations,
+  updateDebateRound
 } from './board-judiciary-bridge.js';
 
 const DEFAULT_QUORUM = 4;
@@ -131,11 +132,11 @@ export async function executeDeliberation({
 
   if (expertiseGaps.length > 0) {
     for (const gap of expertiseGaps.slice(0, 3)) { // Max 3 specialists
-      let specialist = findSpecialist(gap);
+      let specialist = await findSpecialist(gap);
 
       if (!specialist) {
         specialist = generateSpecialistIdentity(gap, topic);
-        registerSpecialist(specialist);
+        await registerSpecialist(specialist);
       }
 
       const testimony = await invokeAgent(
@@ -311,13 +312,6 @@ Produce your judiciary verdict. Include:
     escalationRequired,
     citations: citationsWithScores
   };
-}
-
-async function updateDebateRound(debateSessionId, roundNumber) {
-  await supabase
-    .from('debate_sessions')
-    .update({ round_number: roundNumber })
-    .eq('id', debateSessionId);
 }
 
 // Re-export for convenience

--- a/lib/brainstorm/specialist-registry.js
+++ b/lib/brainstorm/specialist-registry.js
@@ -4,38 +4,72 @@
  * Manages reusable specialist agent identities across brainstorm sessions.
  * Specialists are spawned when board members flag expertise gaps.
  * Registry enables continuity — specialists build expertise over time.
+ * Backed by the specialist_registry table for cross-session persistence.
  */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
 const SIMILARITY_THRESHOLD = 0.7;
 
-// In-process registry (v1). Future: persist to database.
+// In-session cache — avoids repeated DB queries within a single deliberation
 const registry = new Map();
 
+// All-rows DB cache to avoid repeated full-table fetches within a session
+let dbRowsCache = null;
+let dbRowsCacheTime = 0;
+const DB_CACHE_TTL_MS = 30_000;
+
+const SPECIALIST_ROLE_INSTRUCTIONS = `Your role:
+- Provide deep, specific expertise that the board's permanent seats cannot
+- Reference concrete examples, patterns, and technical details from your domain
+- Your testimony will be recorded in debate_arguments and used by board members in their rebuttals
+- Be direct and actionable — the board needs expert input, not general advice
+
+Produce your testimony as a focused expert analysis. Include specific recommendations.`;
+
 /**
- * Register a specialist identity.
+ * Register a specialist identity (in-session cache + database).
  * @param {object} specialist - { topicDomain, capabilityProfile, identity, agentCode }
  */
-export function registerSpecialist(specialist) {
+export async function registerSpecialist(specialist) {
   const key = normalizeKey(specialist.topicDomain);
   const existing = registry.get(key) || [];
-  existing.push({
+  const entry = {
     ...specialist,
     registeredAt: new Date().toISOString(),
     usageCount: 0
-  });
+  };
+  existing.push(entry);
   registry.set(key, existing);
+
+  // Persist to database for cross-session reuse
+  const role = specialist.agentCode.toLowerCase();
+  const { error } = await supabase.from('specialist_registry').upsert({
+    name: specialist.agentCode,
+    role,
+    expertise: specialist.capabilityProfile,
+    context: specialist.identity,
+    metadata: { source: 'brainstorm-deliberation', topicDomain: specialist.topicDomain }
+  }, { onConflict: 'role' });
+  if (error) console.log(`specialist_registry upsert error: ${error.message}`);
+  else dbRowsCache = null; // invalidate so next findSpecialist sees the new entry
 }
 
 /**
  * Find a matching specialist for a given domain.
- * Returns the best match if similarity >= threshold, null otherwise.
+ * Checks in-session cache first, then falls back to the database.
  * @param {string} topicDomain - The domain to search for
- * @returns {object|null} Matching specialist or null
+ * @returns {Promise<object|null>} Matching specialist or null
  */
-export function findSpecialist(topicDomain) {
+export async function findSpecialist(topicDomain) {
   const searchKey = normalizeKey(topicDomain);
   const searchWords = searchKey.split('-').filter(Boolean);
 
+  // 1. Check in-session cache
   let bestMatch = null;
   let bestScore = 0;
 
@@ -45,16 +79,50 @@ export function findSpecialist(topicDomain) {
 
     if (score >= SIMILARITY_THRESHOLD && score > bestScore) {
       bestScore = score;
-      // Return the most-used specialist for this domain
       bestMatch = specialists.sort((a, b) => (b.usageCount || 0) - (a.usageCount || 0))[0];
     }
   }
 
   if (bestMatch) {
     bestMatch.usageCount = (bestMatch.usageCount || 0) + 1;
+    return bestMatch;
   }
 
-  return bestMatch;
+  // 2. Fall back to database (use query coverage — asymmetric match)
+  const rows = await getCachedRows();
+  if (!rows.length) return null;
+
+  for (const row of rows) {
+    const candidateWords = new Set(
+      normalizeKey(`${row.name} ${row.expertise}`).split('-').filter(Boolean)
+    );
+    // Query coverage: what fraction of search words appear in the candidate
+    const matched = searchWords.filter(w => candidateWords.has(w)).length;
+    const score = matched / searchWords.length;
+
+    if (score >= SIMILARITY_THRESHOLD && score > bestScore) {
+      bestScore = score;
+      bestMatch = row;
+    }
+  }
+
+  if (!bestMatch) return null;
+
+  // Convert DB row to specialist identity format
+  const specialist = {
+    topicDomain: bestMatch.metadata?.topicDomain || bestMatch.role,
+    capabilityProfile: bestMatch.expertise,
+    agentCode: bestMatch.name,
+    identity: bestMatch.context || buildIdentityFromRow(bestMatch),
+    usageCount: 0,
+    source: 'database'
+  };
+
+  // Cache for remainder of session
+  const cacheKey = normalizeKey(specialist.topicDomain);
+  registry.set(cacheKey, [specialist]);
+
+  return specialist;
 }
 
 /**
@@ -75,13 +143,7 @@ export function generateSpecialistIdentity(gapDescription, topicContext) {
 
 Context: The board is deliberating on "${topicContext}" and identified a gap in their collective expertise regarding ${gapDescription}.
 
-Your role:
-- Provide deep, specific expertise that the board's permanent seats cannot
-- Reference concrete examples, patterns, and technical details from your domain
-- Your testimony will be recorded in debate_arguments and used by board members in their rebuttals
-- Be direct and actionable — the board needs expert input, not general advice
-
-Produce your testimony as a focused expert analysis. Include specific recommendations.`
+${SPECIALIST_ROLE_INSTRUCTIONS}`
   };
 }
 
@@ -108,6 +170,27 @@ export function parseExpertiseGaps(seatOutputs) {
   }
 
   return gaps;
+}
+
+async function getCachedRows() {
+  if (dbRowsCache && Date.now() - dbRowsCacheTime < DB_CACHE_TTL_MS) {
+    return dbRowsCache;
+  }
+  const { data, error } = await supabase
+    .from('specialist_registry')
+    .select('name, role, expertise, context, metadata');
+  if (error || !data?.length) return [];
+  dbRowsCache = data;
+  dbRowsCacheTime = Date.now();
+  return data;
+}
+
+function buildIdentityFromRow(row) {
+  return `You are a specialist agent summoned by the Board of Directors to provide expert testimony.
+
+Your expertise: ${row.expertise}
+
+${SPECIALIST_ROLE_INSTRUCTIONS}`;
 }
 
 function normalizeKey(domain) {
@@ -141,4 +224,5 @@ export function getRegistrySize() {
 
 export function clearRegistry() {
   registry.clear();
+  dbRowsCache = null;
 }

--- a/scripts/migrations/create-specialist-registry.js
+++ b/scripts/migrations/create-specialist-registry.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Migration: Create specialist_registry table
+ *
+ * Required by: lib/proving-companion/specialist-persister.js
+ * Purpose: Stores Board of Directors specialist entries (one per assessed venture stage)
+ *          with upsert-on-conflict(role) semantics.
+ *
+ * Idempotent — safe to re-run (uses IF NOT EXISTS / IF EXISTS guards).
+ */
+
+import pg from 'pg';
+import dotenv from 'dotenv';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+dotenv.config({ path: join(__dirname, '../..', '.env') });
+
+const { Client } = pg;
+
+const MIGRATION_SQL = `
+CREATE TABLE IF NOT EXISTS specialist_registry (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name          TEXT NOT NULL,
+  role          TEXT NOT NULL UNIQUE,
+  expertise     TEXT NOT NULL,
+  context       TEXT CHECK (char_length(context) <= 8000),
+  metadata      JSONB NOT NULL DEFAULT '{}',
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE specialist_registry IS 'Board of Directors specialist registry — one entry per assessed venture stage, upserted by proving companion';
+COMMENT ON COLUMN specialist_registry.role IS 'Unique specialist role identifier (e.g. venture-stage-5), used as upsert conflict target';
+COMMENT ON COLUMN specialist_registry.context IS 'Stage assessment context (capped at 8000 chars / ~2000 tokens)';
+COMMENT ON COLUMN specialist_registry.metadata IS 'Flexible metadata: source_venture_id, stage_number, created_by';
+
+CREATE OR REPLACE FUNCTION set_specialist_registry_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_specialist_registry_updated_at ON specialist_registry;
+CREATE TRIGGER trg_specialist_registry_updated_at
+  BEFORE UPDATE ON specialist_registry
+  FOR EACH ROW
+  EXECUTE FUNCTION set_specialist_registry_updated_at();
+
+ALTER TABLE specialist_registry ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE tablename = 'specialist_registry'
+      AND policyname = 'service_role_full_access_specialist_registry'
+  ) THEN
+    CREATE POLICY service_role_full_access_specialist_registry
+      ON specialist_registry
+      FOR ALL
+      TO service_role
+      USING (true)
+      WITH CHECK (true);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_specialist_registry_role ON specialist_registry (role);
+CREATE INDEX IF NOT EXISTS idx_specialist_registry_metadata ON specialist_registry USING GIN (metadata);
+`;
+
+async function runMigration() {
+  console.log('\\n=== Migration: create specialist_registry ===\\n');
+
+  const connectionString = process.env.SUPABASE_POOLER_URL;
+  if (!connectionString) {
+    console.error('SUPABASE_POOLER_URL not set in .env');
+    process.exit(1);
+  }
+
+  const client = new Client({
+    connectionString,
+    ssl: { rejectUnauthorized: false },
+    connectionTimeoutMillis: 15000,
+  });
+
+  try {
+    await client.connect();
+    const verifyResult = await client.query('SELECT current_database(), current_user');
+    console.log(`Connected to: ${verifyResult.rows[0].current_database} as ${verifyResult.rows[0].current_user}`);
+
+    const statements = splitStatements(MIGRATION_SQL);
+    console.log(`Executing ${statements.length} statements...\\n`);
+
+    let success = 0;
+    let skipped = 0;
+
+    for (let i = 0; i < statements.length; i++) {
+      const stmt = statements[i];
+      const preview = stmt.replace(/\\s+/g, ' ').substring(0, 90);
+      try {
+        await client.query(stmt);
+        console.log(`  [${i + 1}/${statements.length}] OK: ${preview}...`);
+        success++;
+      } catch (err) {
+        if (err.message.includes('already exists') || err.message.includes('already enabled')) {
+          console.log(`  [${i + 1}/${statements.length}] SKIP (already exists): ${preview}...`);
+          skipped++;
+        } else {
+          console.error(`  [${i + 1}/${statements.length}] ERROR: ${err.message}`);
+          throw err;
+        }
+      }
+    }
+
+    console.log(`\\n--- Summary: ${success} succeeded, ${skipped} skipped ---\\n`);
+    console.log('Migration completed successfully.\\n');
+
+  } catch (err) {
+    console.error('\\nMigration FAILED:', err.message);
+    process.exit(1);
+  } finally {
+    await client.end();
+  }
+}
+
+function splitStatements(sql) {
+  const statements = [];
+  let current = '';
+  let inDollarQuote = false;
+
+  for (let i = 0; i < sql.length; i++) {
+    if (sql[i] === '$' && sql[i + 1] === '$') {
+      inDollarQuote = !inDollarQuote;
+      current += '$$';
+      i++;
+    } else if (sql[i] === ';' && !inDollarQuote) {
+      const trimmed = current.trim();
+      if (trimmed.length > 0 && !isCommentOnly(trimmed)) {
+        statements.push(trimmed);
+      }
+      current = '';
+    } else {
+      current += sql[i];
+    }
+  }
+
+  const trimmed = current.trim();
+  if (trimmed.length > 0 && !isCommentOnly(trimmed)) {
+    statements.push(trimmed);
+  }
+
+  return statements;
+}
+
+function isCommentOnly(sql) {
+  const lines = sql.split('\\n').filter(l => l.trim().length > 0);
+  return lines.every(l => l.trim().startsWith('--'));
+}
+
+runMigration();


### PR DESCRIPTION
## Summary
- Create `specialist_registry` table (UUID PK, unique `role` for upsert, JSONB metadata, RLS, GIN index, updated_at trigger) with idempotent migration script
- Wire `lib/brainstorm/specialist-registry.js` to read/write from DB — `findSpecialist()` checks in-session cache then falls back to DB with query-coverage similarity; `registerSpecialist()` persists to both cache and DB
- Fix pre-existing runtime crash: `updateDebateRound()` in `deliberation-engine.js` referenced undefined `supabase` — moved to `board-judiciary-bridge.js` where the client lives
- Fix `.gitignore`: anchor `brainstorm/` to root (`/brainstorm/`) so it doesn't block `lib/brainstorm/` code files
- Extract shared `SPECIALIST_ROLE_INSTRUCTIONS` constant to deduplicate prompt text
- Verified: 17 Synapse AI stage specialists persisted end-to-end via `persist-specialists` command

## Test plan
- [x] `persist-specialists` command persists 17/17 specialists
- [x] `findSpecialist()` returns DB matches with query-coverage similarity
- [x] Cache hit on repeated lookups (no redundant DB queries)
- [x] `registerSpecialist()` round-trips through DB
- [x] No false positives for unrelated domains
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)