### PR TITLE
feat: pre-seed board deliberations with specialist roster

### DIFF
--- a/lib/brainstorm/deliberation-engine.js
+++ b/lib/brainstorm/deliberation-engine.js
@@ -11,7 +11,7 @@
  */
 import { BOARD_SEATS } from './board-seats/index.js';
 import { loadSeatMemory } from './institutional-memory.js';
-import { parseExpertiseGaps, findSpecialist, generateSpecialistIdentity, registerSpecialist } from './specialist-registry.js';
+import { parseExpertiseGaps, findSpecialist, findRelevantSpecialists, generateSpecialistIdentity, registerSpecialist } from './specialist-registry.js';
 import {
   createBoardDebateSession,
   recordBoardArgument,
@@ -66,12 +66,23 @@ export async function executeDeliberation({
   const memories = await Promise.all(memoryPromises);
   const memoryMap = Object.fromEntries(memories.map(m => [m.code, m.memory]));
 
+  // 2.5. Pre-seed: query DB for specialists relevant to this topic
+  const preSeeded = await findRelevantSpecialists(topic, keywords);
+  let preSeededRoster = '';
+  if (preSeeded.length > 0) {
+    const roster = preSeeded.map(s =>
+      `- ${s.name} (${s.role}): ${s.expertise}`
+    ).join('\n');
+    preSeededRoster = `AVAILABLE SPECIALIST EXPERTISE (from prior proving runs):\n${roster}\n\nThese specialists can be summoned for testimony. When flagging EXPERTISE_GAP, check whether an existing specialist already covers the gap before requesting a new one.\n`;
+  }
+  result.preSeededSpecialists = preSeeded;
+
   // 3. Round 1: All seats in parallel
   const round1Promises = BOARD_SEATS.map(async seat => {
     const seatStart = Date.now();
     const prompt = seat.systemPrompt({
       memoryContext: memoryMap[seat.code] || '',
-      specialistTestimony: ''
+      specialistTestimony: preSeededRoster
     });
 
     const position = await invokeAgent(

--- a/lib/brainstorm/specialist-registry.js
+++ b/lib/brainstorm/specialist-registry.js
@@ -23,6 +23,20 @@ let dbRowsCache = null;
 let dbRowsCacheTime = 0;
 const DB_CACHE_TTL_MS = 30_000;
 
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'can', 'shall', 'must', 'need', 'to', 'of',
+  'in', 'for', 'on', 'with', 'at', 'by', 'from', 'as', 'into', 'about',
+  'than', 'after', 'before', 'between', 'through', 'during', 'above',
+  'and', 'but', 'or', 'nor', 'not', 'so', 'yet', 'both', 'either',
+  'if', 'then', 'else', 'when', 'where', 'how', 'what', 'which', 'who',
+  'that', 'this', 'these', 'those', 'it', 'its', 'we', 'our', 'they',
+  'them', 'their', 'he', 'she', 'his', 'her', 'i', 'my', 'me', 'you',
+  'your', 'up', 'out', 'no', 'yes', 'all', 'any', 'each', 'every',
+  'some', 'such', 'only', 'also', 'just', 'more', 'most', 'very'
+]);
+
 const SPECIALIST_ROLE_INSTRUCTIONS = `Your role:
 - Provide deep, specific expertise that the board's permanent seats cannot
 - Reference concrete examples, patterns, and technical details from your domain
@@ -123,6 +137,50 @@ export async function findSpecialist(topicDomain) {
   registry.set(cacheKey, [specialist]);
 
   return specialist;
+}
+
+/**
+ * Find all specialists relevant to a topic. Uses a lower threshold than
+ * findSpecialist() to cast a wider net for pre-seeding deliberations.
+ * @param {string} topic - The deliberation topic
+ * @param {string[]} keywords - Additional topic keywords
+ * @param {number} maxResults - Maximum specialists to return (default: 5)
+ * @returns {Promise<object[]>} Relevant specialists sorted by score descending
+ */
+export async function findRelevantSpecialists(topic, keywords = [], maxResults = 5) {
+  const PRE_SEED_THRESHOLD = 0.3;
+  const rows = await getCachedRows();
+  if (!rows.length) return [];
+
+  // Build search words from topic + keywords, filtering stop words
+  const topicWords = normalizeKey(topic).split('-').filter(Boolean);
+  const kwWords = keywords.flatMap(k => normalizeKey(k).split('-').filter(Boolean));
+  const searchWords = [...new Set([...topicWords, ...kwWords])].filter(w => !STOP_WORDS.has(w) && w.length > 1);
+  if (!searchWords.length) return [];
+
+  const scored = [];
+  for (const row of rows) {
+    const candidateWords = new Set(
+      normalizeKey(`${row.name} ${row.expertise} ${row.context || ''}`).split('-').filter(Boolean)
+    );
+    const matched = searchWords.filter(w => candidateWords.has(w)).length;
+    const score = matched / searchWords.length;
+
+    if (score >= PRE_SEED_THRESHOLD) {
+      scored.push({
+        name: row.name,
+        role: row.role,
+        expertise: row.expertise,
+        context: row.context,
+        metadata: row.metadata,
+        relevanceScore: score
+      });
+    }
+  }
+
+  return scored
+    .sort((a, b) => b.relevanceScore - a.relevanceScore)
+    .slice(0, maxResults);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `findRelevantSpecialists(topic, keywords)` to query DB for topic-relevant specialists at deliberation start (lower 0.3 threshold, stop-word filtering, max 5 results)
- Inject "AVAILABLE SPECIALIST EXPERTISE" roster into Round 1 board seat prompts so all 6 seats know what domain expertise exists before producing positions
- Add operations specialist placeholder (stages 25+) for future proving runs
- Stop-word list prevents natural-language topics from diluting query-coverage scores

## Test plan
- [x] Venture assessment topic matches 5 stage specialists
- [x] Unrelated topic ("CSS login redesign") matches 0 specialists
- [x] Operations topic matches placeholder at 0.83 relevance
- [x] Roster format renders correctly for board seat injection
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)