### PR TITLE
feat: add plugin pipeline to Friday meeting + fix issue_patterns RLS

### DIFF
--- a/database/migrations/fix-issue-patterns-service-role-rls.sql
+++ b/database/migrations/fix-issue-patterns-service-role-rls.sql
@@ -1,0 +1,32 @@
+-- Migration: fix-issue-patterns-service-role-rls.sql
+-- Date: 2026-03-16
+-- Description: Add missing RLS policy for service_role on issue_patterns table
+--
+-- Problem: Scripts using SUPABASE_SERVICE_ROLE_KEY to query issue_patterns
+--   received "Invalid API key" errors because no RLS policy existed for the
+--   service_role role. Only authenticated and public role policies existed.
+--
+-- Fix: Grant service_role full access (SELECT, INSERT, UPDATE, DELETE) via
+--   a permissive ALL policy with no row-level restrictions.
+--
+-- Applied to: dedlbzhpgkmetvhbkyzq (consolidated database)
+-- Applied on: 2026-03-16
+--
+-- Idempotent: No (will error if policy already exists)
+-- Pre-check: SELECT policyname FROM pg_policies WHERE tablename = 'issue_patterns' AND roles::text LIKE '%service_role%';
+
+CREATE POLICY "Allow service_role full access to issue_patterns"
+  ON public.issue_patterns
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Verification query:
+-- SELECT policyname, permissive, roles, cmd
+-- FROM pg_policies
+-- WHERE tablename = 'issue_patterns'
+-- ORDER BY policyname;
+
+-- Rollback:
+-- DROP POLICY "Allow service_role full access to issue_patterns" ON public.issue_patterns;

--- a/scripts/eva/friday-meeting.mjs
+++ b/scripts/eva/friday-meeting.mjs
@@ -291,6 +291,57 @@ function renderFleetTelemetry(data) {
   return lines.join('\n');
 }
 
+// ─── Section 5c: Plugin Pipeline ─────────────────────────────
+
+async function gatherPluginDiscoveries() {
+  try {
+    const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const { data, error } = await supabase
+      .from('anthropic_plugin_registry')
+      .select('plugin_name, source_repo, status, fitness_score, last_scanned_at, created_at')
+      .gte('last_scanned_at', oneWeekAgo)
+      .order('status')
+      .order('fitness_score', { ascending: false, nullsFirst: false });
+
+    if (error || !data) return null;
+    if (data.length === 0) return null;
+
+    const byStatus = {};
+    for (const p of data) {
+      const s = p.status || 'discovered';
+      if (!byStatus[s]) byStatus[s] = [];
+      byStatus[s].push(p);
+    }
+
+    return { plugins: data, byStatus, total: data.length };
+  } catch {
+    return null;
+  }
+}
+
+function renderPluginDiscoveries(data) {
+  if (!data) return '';
+
+  const lines = ['', '  SECTION 5c: ANTHROPIC PLUGIN PIPELINE', '  ' + '─'.repeat(40)];
+  lines.push(`  Plugins scanned this week: ${data.total}`);
+  lines.push('');
+
+  const statusIcons = { discovered: 'NEW', adapted: 'LIVE', evaluating: 'EVAL', rejected: 'SKIP', outdated: 'OLD' };
+
+  for (const [status, plugins] of Object.entries(data.byStatus)) {
+    const icon = statusIcons[status] || status.toUpperCase();
+    lines.push(`  [${icon}]`);
+    for (const p of plugins) {
+      const repo = (p.source_repo || '').split('/').pop();
+      const score = p.fitness_score != null ? ` (fitness: ${p.fitness_score})` : '';
+      lines.push(`    - ${p.plugin_name} (${repo})${score}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
 // ─── Section 6: Decisions ────────────────────────────────────
 
 function buildDecisionPayload(findings) {
@@ -488,13 +539,14 @@ export async function fridayMeetingHandler(options = {}) {
   logger.log('═'.repeat(55));
 
   // Gather all data in parallel
-  const [perfData, capData, consultData, intakeData, rdData, fleetData] = await Promise.all([
+  const [perfData, capData, consultData, intakeData, rdData, fleetData, pluginData] = await Promise.all([
     gatherPerformanceReview(),
     gatherCapabilityReport(),
     gatherConsultantFindings(),
     gatherIntakeReview(),
     gatherRdProposals(),
     gatherFleetTelemetry(),
+    gatherPluginDiscoveries(),
   ]);
 
   // Render sections 1-5b
@@ -504,6 +556,7 @@ export async function fridayMeetingHandler(options = {}) {
   logger.log(renderIntakeReview(intakeData));
   logger.log(renderRdProposals(rdData));
   logger.log(renderFleetTelemetry(fleetData));
+  logger.log(renderPluginDiscoveries(pluginData));
 
   // Section 6: Decisions
   logger.log('');
@@ -519,6 +572,7 @@ export async function fridayMeetingHandler(options = {}) {
       consultant: { totalFindings: consultData.findings.length, domains: Object.keys(consultData.grouped).length },
       intake: { pendingItems: intakeData.pending.length },
       rd_proposals: { pendingProposals: rdData.proposals.length, sources: Object.keys(rdData.grouped).length },
+      plugin_pipeline: { scannedThisWeek: pluginData?.total || 0 },
     },
     decisions: { accepted: 0, dismissed: 0, deferred: 0, total: totalDecisionItems },
   };


### PR DESCRIPTION
## Summary
- Adds **Section 5c: Anthropic Plugin Pipeline** to the Friday meeting with Eva — queries `anthropic_plugin_registry` for plugins scanned in the past week, grouped by status with fitness scores
- Adds missing `service_role` RLS policy on `issue_patterns` table — fixes the "Invalid API key" error that's been failing `pattern-maintenance-weekly` workflow (already applied to prod DB)

## Test plan
- [ ] Run `/friday` and verify plugin pipeline section appears (or shows nothing if no scans this week)
- [x] Triggered `pattern-maintenance-weekly` workflow to verify RLS fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)