### PR TITLE
fix: pattern-maintenance grep output parsing bug

### DIFF
--- a/.github/workflows/pattern-maintenance-weekly.yml
+++ b/.github/workflows/pattern-maintenance-weekly.yml
@@ -64,8 +64,10 @@ jobs:
           npm run pattern:stale:dry 2>&1 | tee stale-output.txt
 
           # Check for patterns needing attention
-          DECREASING=$(grep -c "MARK AS DECREASING" stale-output.txt || echo "0")
-          OBSOLETE=$(grep -c "MARK AS OBSOLETE" stale-output.txt || echo "0")
+          DECREASING=$(grep -c "MARK AS DECREASING" stale-output.txt || true)
+          DECREASING=${DECREASING:-0}
+          OBSOLETE=$(grep -c "MARK AS OBSOLETE" stale-output.txt || true)
+          OBSOLETE=${OBSOLETE:-0}
 
           echo "decreasing_count=$DECREASING" >> $GITHUB_OUTPUT
           echo "obsolete_count=$OBSOLETE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Fixes `grep -c` output parsing: when no matches found, grep exits 1 causing `|| echo "0"` to append a second `0`, producing `0\n0` which fails bash integer comparison
- Uses `|| true` instead, with `${VAR:-0}` default

## Test plan
- [x] Script itself now runs successfully (491 patterns analyzed)
- [ ] Workflow should pass after this fix — the only remaining failure was this bash bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)