### PR TITLE
fix: claim-guard UUID compatibility for marker-based identity

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -75,11 +75,12 @@ export function isSameConversation(tidA, tidB) {
   const isWinCC = (tid) => /^win-cc-\d+/.test(tid || '');
   if ((isUUID(tidA) && isWinCC(tidB)) || (isUUID(tidB) && isWinCC(tidA))) return 'ambiguous';
 
-  // Two different UUID-format terminal_ids on the same machine: ambiguous.
-  // With 3+ concurrent conversations sharing the same SSE port, marker file
-  // cleanup can delete a conversation's identity, causing non-deterministic
-  // PID resolution to assign different UUIDs to the same conversation.
-  if (isUUID(tidA) && isUUID(tidB)) return 'ambiguous';
+  // Two UUID-format terminal_ids: compare literally.
+  // Post PR #2231, getTerminalId() resolves via SSE port marker match,
+  // producing stable UUIDs. Two different UUIDs = different conversations.
+  // (Previously returned 'ambiguous' due to marker cleanup instability,
+  // but SSE port matching eliminated that failure mode.)
+  if (isUUID(tidA) && isUUID(tidB)) return false;
 
   // Parse win-cc-{port}[-{pid}] format
   const parseWinCC = (tid) => {

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -106,8 +106,9 @@ async function splitCollidingSessions(supabase, collisions, actions, warnings) {
       collision.markers.map(m => m.pid).join(', ') + ' — keeper PID=' + keeper.pid);
 
     for (const extra of extras) {
-      const newTerminalId = 'win-' + extra.pid;
-      const newSessionId = 'session_' + randomUUID().substring(0, 8) + '_' + newTerminalId + '_' + extra.pid;
+      // Use marker-based UUID if available, fall back to PID-based format
+      const newTerminalId = extra.session_id || ('win-' + extra.pid);
+      const newSessionId = 'session_' + randomUUID().substring(0, 8) + '_' + extra.pid;
 
       // Check if a session with this terminal_id already exists (idempotent)
       const { data: existing } = await supabase


### PR DESCRIPTION
## Summary
- `isSameConversation()`: Two different UUIDs now return `false` instead of `ambiguous`. SSE port marker matching (PR #2231) produces stable UUIDs, eliminating the old ambiguity workaround.
- `stale-session-sweep.cjs`: Identity splits use marker-based session UUID for terminal_id instead of hardcoded `win-{pid}` format.
- 2 files, +9/-7 lines.

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Coordinator audit identified these as the specific conflicts

SD: SD-LEO-FIX-CLAIM-GUARD-UUID-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)