### PR TITLE
fix: await venture_stage_work sync in stage execution worker

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -509,9 +509,13 @@ export class StageExecutionWorker {
         // Write-through to venture_stage_work so the UI can display results.
         // processStage() writes to venture_artifacts but not venture_stage_work,
         // while the frontend reads advisory_data from venture_stage_work.
-        this._syncStageWork(ventureId, currentStage, result).catch(err => {
+        // MUST await — fire-and-forget caused stage_status to stay 'in_progress'
+        // for completed stages, breaking frontend currentStage detection.
+        try {
+          await this._syncStageWork(ventureId, currentStage, result);
+        } catch (err) {
           this._logger.warn(`[Worker] venture_stage_work sync failed (non-fatal): ${err.message}`);
-        });
+        }
 
         // Check chairman gate AFTER stage execution so validation data
         // is available for the user to review before approving/rejecting.


### PR DESCRIPTION
## Summary
- Change `_syncStageWork` from fire-and-forget to awaited
- Ensures `stage_status` is written to DB before worker advances to next stage
- Root cause of kill gate buttons not appearing: Stage 1 stayed `in_progress` after completion, causing frontend to pick wrong `currentStage`

## Root cause chain
1. Worker calls `_syncStageWork()` without `await` (fire-and-forget)
2. DB update for Stage 1 `stage_status: completed` may not finish before worker starts Stage 2
3. Frontend `useVentureWorkflow` does `.find(s => s.stage_status === 'in_progress')` → picks Stage 1 (stale) instead of Stage 3
4. `currentStage = 1` → not a gate → gate buttons never render

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Start a new venture, verify Stage 1 shows `completed` in venture_stage_work after worker processes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)