### PR TITLE
fix: three critical venture workflow fixes

### DIFF
--- a/database/migrations/20260316_approve_rpc_unblock_orchestrator.sql
+++ b/database/migrations/20260316_approve_rpc_unblock_orchestrator.sql
@@ -1,0 +1,61 @@
+-- Migration: Update approve_chairman_decision RPC to unblock orchestrator
+-- After recording the approval, set the venture's orchestrator_state to 'idle'
+-- so the stage-execution-worker picks it back up automatically.
+--
+-- Rollback: Re-run the original migration at:
+--   ehg/supabase/migrations/20260302_001_create_approve_chairman_decision.sql
+
+CREATE OR REPLACE FUNCTION approve_chairman_decision(
+  p_decision_id UUID,
+  p_rationale TEXT DEFAULT NULL,
+  p_decided_by TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_decision RECORD;
+BEGIN
+  -- Lock the row
+  SELECT * INTO v_decision
+  FROM chairman_decisions
+  WHERE id = p_decision_id AND status = 'pending'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Decision not found or already resolved'
+    );
+  END IF;
+
+  -- Update decision with stage-aware decision value
+  UPDATE chairman_decisions SET
+    decision = CASE
+      WHEN lifecycle_stage = 0 THEN 'proceed'
+      WHEN lifecycle_stage = 10 THEN 'approve'
+      WHEN lifecycle_stage = 22 THEN 'release'
+      WHEN lifecycle_stage = 25 THEN 'continue'
+      ELSE 'go'
+    END,
+    status = 'approved',
+    rationale = COALESCE(p_rationale, 'Approved by Chairman'),
+    decided_by = COALESCE(p_decided_by, auth.uid()::text),
+    blocking = false,
+    updated_at = now()
+  WHERE id = p_decision_id;
+
+  -- Unblock the orchestrator so the worker picks the venture back up
+  UPDATE ventures
+  SET orchestrator_state = 'idle',
+      updated_at = now()
+  WHERE id = v_decision.venture_id
+    AND orchestrator_state = 'blocked';
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'decision_id', p_decision_id,
+    'venture_id', v_decision.venture_id,
+    'lifecycle_stage', v_decision.lifecycle_stage,
+    'new_status', 'approved'
+  );
+END;
+$$;

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -517,6 +517,16 @@ export class StageExecutionWorker {
           this._logger.warn(`[Worker] venture_stage_work sync failed (non-fatal): ${err.message}`);
         }
 
+        // Advisory gates: create chairman_decisions row but don't block pipeline.
+        // This lets the UI show the decision for review even though the worker continues.
+        if (CHAIRMAN_GATES.ADVISORY.has(currentStage)) {
+          this._logger.log(`[Worker] Advisory chairman gate at stage ${currentStage} — creating decision row`);
+          await this._handleChairmanGate(ventureId, currentStage).catch(err => {
+            this._logger.warn(`[Worker] Advisory gate decision creation failed (non-fatal): ${err.message}`);
+          });
+          // Don't block — continue processing
+        }
+
         // Check chairman gate AFTER stage execution so validation data
         // is available for the user to review before approving/rejecting.
         if (CHAIRMAN_GATES.BLOCKING.has(currentStage)) {


### PR DESCRIPTION
## Summary
Three root cause fixes for the venture workflow issues discovered during /prove live testing:

1. **Bootstrap all 25 stages** — Migration applied + backfill. All existing ventures now have 25 venture_stage_work rows. New ventures will too.
2. **Approve RPC unblocks orchestrator** — `approve_chairman_decision` now sets `orchestrator_state='idle'` so the worker resumes after chairman approval.
3. **Advisory gates create decision rows** — Worker now calls `_handleChairmanGate` for advisory gates (5, 23) without blocking the pipeline.

## What these fix
- No more blank screens on stages 11-25 (rows exist now)
- No more manual orchestrator unblocking after gate approval
- Stage 5 and 23 will show approve/reject buttons without manual intervention
- Worker resumes automatically after chairman decisions

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Bootstrap backfill verified: all 3 ventures have 25 rows
- [x] Approve RPC function updated in database
- [ ] End-to-end: create venture, process through Stage 3 gate, approve, verify worker resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)