### PR TITLE
fix: apply XSS sanitization middleware to all API write routes

### DIFF
--- a/pages/api/aegis/validate.ts
+++ b/pages/api/aegis/validate.ts
@@ -15,6 +15,7 @@
 import { NextApiResponse } from 'next';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
 import { withPermission } from '../../../lib/middleware/rbac';
+import { withSanitization } from '../../../lib/middleware/sanitize';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -243,6 +244,7 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication and authorization middleware
+// SECURITY: Wrap handler with authentication, authorization, and XSS sanitization middleware
 // SD-SEC-AUTHORIZATION-RBAC-001: Requires compliance:write permission
-export default withAuth(withPermission('compliance:write')(handler));
+// SD-MANUAL-INFRA-XSS-SANITIZE-001: withSanitization strips HTML/scripts from request bodies
+export default withAuth(withSanitization(withPermission('compliance:write')(handler)));

--- a/pages/api/competitor-analysis.ts
+++ b/pages/api/competitor-analysis.ts
@@ -18,6 +18,7 @@ import { NextApiResponse } from 'next';
 import { z } from 'zod';
 import { withAuth, AuthenticatedRequest } from '../../lib/middleware/api-auth';
 import { withPermission } from '../../lib/middleware/rbac';
+import { withSanitization } from '../../lib/middleware/sanitize';
 
 // Request body validation schema
 const AnalyzeCompetitorSchema = z.object({
@@ -151,6 +152,7 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication and authorization middleware
+// SECURITY: Wrap handler with authentication, authorization, and XSS sanitization middleware
 // SD-SEC-AUTHORIZATION-RBAC-001: Requires ventures:create permission
-export default withAuth(withPermission('ventures:create')(handler));
+// SD-MANUAL-INFRA-XSS-SANITIZE-001: withSanitization strips HTML/scripts from request bodies
+export default withAuth(withSanitization(withPermission('ventures:create')(handler)));

--- a/pages/api/compliance/events.ts
+++ b/pages/api/compliance/events.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../lib/validation/leo-schemas';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
 import { getUserRole, hasPermission } from '../../../lib/middleware/rbac';
+import { withSanitization } from '../../../lib/middleware/sanitize';
 
 async function handler(
   req: AuthenticatedRequest,
@@ -180,6 +181,7 @@ async function handlePatch(req: AuthenticatedRequest, res: NextApiResponse) {
   }
 }
 
-// SECURITY: Wrap handler with authentication middleware
+// SECURITY: Wrap handler with authentication and XSS sanitization middleware
 // SD-SEC-AUTHORIZATION-RBAC-001: RBAC checks inside handler (method-specific)
-export default withAuth(handler);
+// SD-MANUAL-INFRA-XSS-SANITIZE-001: withSanitization strips HTML/scripts from request bodies
+export default withAuth(withSanitization(handler));

--- a/pages/api/leo/sub-agent-reports.ts
+++ b/pages/api/leo/sub-agent-reports.ts
@@ -16,6 +16,7 @@ import { NextApiResponse } from 'next';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { withAuth, AuthenticatedRequest } from '../../../lib/middleware/api-auth';
 import { withPermission } from '../../../lib/middleware/rbac';
+import { withSanitization } from '../../../lib/middleware/sanitize';
 import {
   SubAgentReportBody,
   SubAgentReportResponse,
@@ -295,6 +296,7 @@ async function handler(
   }
 }
 
-// SECURITY: Wrap handler with authentication and authorization middleware
+// SECURITY: Wrap handler with authentication, authorization, and XSS sanitization middleware
 // SD-SEC-AUTHORIZATION-RBAC-001: Requires leo:write permission
-export default withAuth(withPermission('leo:write')(handler));
+// SD-MANUAL-INFRA-XSS-SANITIZE-001: withSanitization strips HTML/scripts from request bodies
+export default withAuth(withSanitization(withPermission('leo:write')(handler)));


### PR DESCRIPTION
## Summary
- Adds `withSanitization` middleware to 4 remaining POST/PUT/PATCH API routes that were unprotected
- Routes protected: `aegis/validate`, `competitor-analysis`, `leo/sub-agent-reports`, `compliance/events`
- All 6 write routes now have defense-in-depth XSS sanitization at the API boundary
- Part of SD-MANUAL-INFRA-XSS-SANITIZE-001 (XSS Input Sanitization and Defense-in-Depth)

## Test plan
- [x] Unit tests pass (21/21 in sanitize.test.js)
- [x] Smoke tests pass (15/15)
- [x] No regressions in existing API behavior (middleware is transparent for clean input)
- [ ] E2E XSS injection tests validate sanitization across all routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)