### PR TITLE
fix: protocol documentation accuracy fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ EHG_SUPABASE_ANON_KEY=your-ehg-anon-key
 EHG_SUPABASE_SERVICE_ROLE_KEY=your-ehg-service-role-key
 
 # Project Configuration
-LEO_PROTOCOL_VERSION=3.1.5.9
+LEO_PROTOCOL_VERSION=4.3.3
 PROJECT_NAME=EHG_Engineer
 
 # ==============================================================================

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 
 ## Essential Commands
 - **Pick Work**: `npm run sd:next`
-- **Phase Handoff**: `node scripts/unified-handoff-system.js execute <PHASE> <SD-ID>`
+- **Phase Handoff**: `node scripts/handoff.js execute <PHASE> <SD-ID>`
 - **Create SD**: `node scripts/leo-create-sd.js`
 - **Create PRD**: `node scripts/add-prd-to-database.js`
 - **LEO Stack**: `node scripts/cross-platform-run.js leo-stack restart|status|stop`
@@ -119,4 +119,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-03-14 8:36:22 AM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-03-17 10:23:33 AM | Protocol: LEO 4.3.3 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-03-14 8:36:22 AM
+**Generated**: 2026-03-17 10:23:33 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions
 
@@ -11,8 +11,6 @@
 ---
 
 ## Migration Execution Protocol
-
-## ⚠️ CRITICAL: Migration Execution Protocol
 
 **CRITICAL**: When you need to execute a migration, INVOKE the DATABASE sub-agent rather than writing execution scripts yourself.
 
@@ -36,14 +34,14 @@ Task tool with subagent_type="database-agent":
 ### System Overview
 | Component | Port | Path | Role |
 |-----------|------|------|------|
-| **EHG** (Frontend) | 8080 | `/mnt/c/_EHG/EHG/` | All UI (user + admin at /admin/*) |
-| **EHG_Engineer** (Backend) | 3000 | `/mnt/c/_EHG/EHG_Engineer/` | REST API + LEO scripts |
+| **EHG** (Frontend) | 8080 | `C:/Users/rickf/Projects/_EHG/ehg/` | All UI (user + admin at /admin/*) |
+| **EHG_Engineer** (Backend) | 3000 | `C:/Users/rickf/Projects/_EHG/EHG_Engineer/` | REST API + LEO scripts |
 
 **Database**: dedlbzhpgkmetvhbkyzq (Supabase) - CONSOLIDATED
 
 ### CRITICAL: During EXEC Phase
 1. Read PRD from EHG_Engineer database
-2. Navigate to `/mnt/c/_EHG/EHG/` for ALL frontend work
+2. Navigate to `C:/Users/rickf/Projects/_EHG/ehg/` for ALL frontend work
 3. Admin features: `/src/components/admin/` or `/src/pages/admin/`
 4. User features: `/src/components/` or `/src/pages/`
 5. Push to EHG repo: `rickfelix/ehg.git`
@@ -181,48 +179,6 @@ npm run handoff:compliance SD-ID
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
-## 🤖 Built-in Agent Integration
-
-## Built-in Agent Integration
-
-### Three-Layer Agent Architecture
-
-LEO Protocol uses three complementary agent layers:
-
-| Layer | Source | Agents | Purpose |
-|-------|--------|--------|---------|
-| **Built-in** | Claude Code | `Explore`, `Plan` | Fast discovery & multi-perspective planning |
-| **Sub-Agents** | `.claude/agents/` | DATABASE, TESTING, VALIDATION, etc. | Formal validation & gate enforcement |
-| **Skills** | `~/.claude/skills/` | 54 skills | Creative guidance & patterns |
-
-### Integration Principle
-
-> **Explore** for discovery → **Sub-agents** for validation → **Skills** for implementation patterns
-
-Built-in agents run FIRST (fast, parallel exploration), then sub-agents run for formal validation (database-driven, deterministic).
-
-### When to Use Each Layer
-
-| Task | Use | Example |
-|------|-----|---------|
-| "Does this already exist?" | Explore agent | `Task(subagent_type="Explore", prompt="Search for existing auth implementations")` |
-| "What patterns do we use?" | Explore agent | `Task(subagent_type="Explore", prompt="Find component patterns in src/")` |
-| "Is this schema valid?" | Sub-agent | `node lib/sub-agent-executor.js DATABASE <SD-ID>` |
-| "How should I build this?" | Skills | `skill: "schema-design"` or `skill: "e2e-patterns"` |
-| "What are the trade-offs?" | Plan agent | Launch 2-3 Plan agents with different perspectives |
-
-### Parallel Execution
-
-Built-in agents support parallel execution. Launch multiple Explore agents in a single message:
-
-```
-Task(subagent_type="Explore", prompt="Search for existing implementations")
-Task(subagent_type="Explore", prompt="Find related patterns")
-Task(subagent_type="Explore", prompt="Identify affected areas")
-```
-
-This is faster than sequential exploration and provides comprehensive coverage.
-
 ## Claude Code Plan Mode Integration
 
 **Status**: ACTIVE | **Version**: 1.0.0
@@ -265,6 +221,48 @@ Claude Code's Plan Mode integrates with LEO Protocol to provide:
 
 ### Module Location
 `scripts/modules/plan-mode/` - LEOPlanModeOrchestrator.js, phase-permissions.js
+
+## 🤖 Built-in Agent Integration
+
+## Built-in Agent Integration
+
+### Three-Layer Agent Architecture
+
+LEO Protocol uses three complementary agent layers:
+
+| Layer | Source | Agents | Purpose |
+|-------|--------|--------|---------|
+| **Built-in** | Claude Code | `Explore`, `Plan` | Fast discovery & multi-perspective planning |
+| **Sub-Agents** | `.claude/agents/` | DATABASE, TESTING, VALIDATION, etc. | Formal validation & gate enforcement |
+| **Skills** | `~/.claude/skills/` | 54 skills | Creative guidance & patterns |
+
+### Integration Principle
+
+> **Explore** for discovery → **Sub-agents** for validation → **Skills** for implementation patterns
+
+Built-in agents run FIRST (fast, parallel exploration), then sub-agents run for formal validation (database-driven, deterministic).
+
+### When to Use Each Layer
+
+| Task | Use | Example |
+|------|-----|---------|
+| "Does this already exist?" | Explore agent | `Task(subagent_type="Explore", prompt="Search for existing auth implementations")` |
+| "What patterns do we use?" | Explore agent | `Task(subagent_type="Explore", prompt="Find component patterns in src/")` |
+| "Is this schema valid?" | Sub-agent | `node lib/sub-agent-executor.js DATABASE <SD-ID>` |
+| "How should I build this?" | Skills | `skill: "schema-design"` or `skill: "e2e-patterns"` |
+| "What are the trade-offs?" | Plan agent | Launch 2-3 Plan agents with different perspectives |
+
+### Parallel Execution
+
+Built-in agents support parallel execution. Launch multiple Explore agents in a single message:
+
+```
+Task(subagent_type="Explore", prompt="Search for existing implementations")
+Task(subagent_type="Explore", prompt="Find related patterns")
+Task(subagent_type="Explore", prompt="Identify affected areas")
+```
+
+This is faster than sequential exploration and provides comprehensive coverage.
 
 ## Sub-Agent Model Routing
 
@@ -339,6 +337,39 @@ The pre-push hook automatically:
 2. Verifies completion status in database
 3. Blocks if not ready for merge
 
+## 🖥️ UI Parity Requirement (MANDATORY)
+
+**Every backend data contract field MUST have a corresponding UI representation.**
+
+### Principle
+If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
+
+### Requirements
+
+1. **Data Contract Coverage**
+   - Every field in `stageX_data` wrappers must map to a UI component
+   - Score displays must show actual numeric values, not just pass/fail
+   - Confidence levels must be visible with appropriate visual indicators
+
+2. **Human Inspectability**
+   - Stage outputs must be viewable in human-readable format
+   - Key findings, red flags, and recommendations must be displayed
+   - Source citations must be accessible
+
+3. **No Hidden Logic**
+   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
+   - Threshold comparisons must be visible
+   - Stage weights must be displayed in aggregation views
+
+### Verification Checklist
+Before marking any stage/feature as complete:
+- [ ] All output fields have UI representation
+- [ ] Scores are displayed numerically
+- [ ] Key findings are visible to users
+- [ ] Recommendations are actionable in the UI
+
+**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
+
 ## Execution Philosophy
 
 ### Quality-First (PARAMOUNT)
@@ -375,39 +406,6 @@ The pre-push hook automatically:
 - Skip LEAD approval for child SDs
 - Skip PRD creation for child SDs
 - Mark parent complete before all children complete in database
-
-## 🖥️ UI Parity Requirement (MANDATORY)
-
-**Every backend data contract field MUST have a corresponding UI representation.**
-
-### Principle
-If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
-
-### Requirements
-
-1. **Data Contract Coverage**
-   - Every field in `stageX_data` wrappers must map to a UI component
-   - Score displays must show actual numeric values, not just pass/fail
-   - Confidence levels must be visible with appropriate visual indicators
-
-2. **Human Inspectability**
-   - Stage outputs must be viewable in human-readable format
-   - Key findings, red flags, and recommendations must be displayed
-   - Source citations must be accessible
-
-3. **No Hidden Logic**
-   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
-   - Threshold comparisons must be visible
-   - Stage weights must be displayed in aggregation views
-
-### Verification Checklist
-Before marking any stage/feature as complete:
-- [ ] All output fields have UI representation
-- [ ] Scores are displayed numerically
-- [ ] Key findings are visible to users
-- [ ] Recommendations are actionable in the UI
-
-**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## Sub-Agent Routing Reference
 
@@ -492,6 +490,38 @@ To request an exception to this block:
 
 **No exceptions without explicit LEAD approval.**
 
+## Child SD Pre-Work Validation (MANDATORY)
+
+**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
+
+### Validation Command
+```bash
+node scripts/child-sd-preflight.js SD-XXX-001
+```
+
+### What It Checks
+1. **Is Child SD**: Verifies the SD has a parent_sd_id
+2. **Dependency Chain**: For each dependency SD:
+   - Status must be `completed`
+   - Progress must be `100%`
+   - Required handoffs must be present
+3. **Parent Context**: Loads parent orchestrator for reference
+
+### Results
+**PASS** - Ready to work if:
+- SD is standalone (not a child), OR
+- No dependencies, OR
+- All dependencies complete with required handoffs
+
+**BLOCKED** - Cannot proceed if:
+- One or more dependency SDs incomplete
+- Missing required handoffs on dependencies
+- Action: Complete blocking dependency first
+
+### Integration
+- `npm run sd:next` shows dependency status in queue
+- Child SDs with incomplete dependencies show as BLOCKED
+
 ## Global Negative Constraints
 
 These anti-patterns apply across ALL phases. Violating them leads to failed handoffs and rework.
@@ -524,38 +554,6 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 - `node scripts/handoff.js execute ...`
 - `node scripts/add-prd-to-database.js ...`
 - `node scripts/phase-preflight.js ...`
-
-## Child SD Pre-Work Validation (MANDATORY)
-
-**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
-
-### Validation Command
-```bash
-node scripts/child-sd-preflight.js SD-XXX-001
-```
-
-### What It Checks
-1. **Is Child SD**: Verifies the SD has a parent_sd_id
-2. **Dependency Chain**: For each dependency SD:
-   - Status must be `completed`
-   - Progress must be `100%`
-   - Required handoffs must be present
-3. **Parent Context**: Loads parent orchestrator for reference
-
-### Results
-**PASS** - Ready to work if:
-- SD is standalone (not a child), OR
-- No dependencies, OR
-- All dependencies complete with required handoffs
-
-**BLOCKED** - Cannot proceed if:
-- One or more dependency SDs incomplete
-- Missing required handoffs on dependencies
-- Action: Complete blocking dependency first
-
-### Integration
-- `npm run sd:next` shows dependency status in queue
-- Child SDs with incomplete dependencies show as BLOCKED
 
 ## 🔄 Git Commit Guidelines
 
@@ -1137,60 +1135,60 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 **From Published Retrospectives** - Apply these learnings proactively.
 
-### 1. SD Completion Retrospective: Centralized Claim Guard Eliminates 7 Multi-Session Collision Vectors [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/13/2026 | **Score**: 100
+### 1. LEAD_TO_PLAN Handoff Retrospective: Crew Tournament Pattern for Stage 11 GTM [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
 
 **Key Improvements**:
-- The 7 separate claim paths existed because each was added incrementally without recognizing the cros...
-- ESM/CJS compatibility required a wrapper file (claim-guard.cjs) which adds one more file to maintain...
+- {"area":"PRD quality validation failed 4 times during planning (scores: 46, 0, 51, 49/100) - the LEA...
+- {"area":"Goal summary validation scored 0/100 on first attempt - the summary lacked measurable objec...
 
 **Action Items**:
-- [ ] Create integration test that spawns 2 concurrent claim attempts on the same SD t...
-- [ ] Add cross-cutting concern detection to LEAD phase checklist: when approving an S...
+- [ ] During LEAD approval for AI-related SDs, require explicit cost impact analysis (...
+- [ ] Add measurable success criteria to LEAD approval template: target quality improv...
 
-### 2. Fix Unicode Surrogate Pair Splitting in Handoff Output - Retrospective [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/12/2026 | **Score**: 100
+### 2. SD Completion Retrospective: Autonomy Model L0-L4 Full Implementation [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
 
 **Key Improvements**:
-- [PAT-AUTO-45e4dfb7] Gate 1:userStoryQualityValidation failed: score 209/300
-- [PAT-AUTO-d2c1c285] Gate PREREQUISITE_HANDOFF_CHECK failed: score 841/1000
+- First EXEC-TO-PLAN handoff rejected (score 0) because sd_type="feature" requires 85% gate score but ...
+- PLAN-TO-LEAD retrospective rejected for learning_specificity (3/10) -- initial retrospective contain...
 
 **Action Items**:
-- [ ] No immediate actions required - continue standard workflow
-- [ ] Re-run blocking sub-agents for SD-LEO-FIX-FIX-UNICODE-SURROGATE-001 until PASS v...
+- [ ] Add sd_type "backend" or "infrastructure" that does not include UI gates in scor...
+- [ ] Document integration_operationalization required keys (consumers, dependencies, ...
 
-### 3. Replace External API PRD Generation With Inline Claude Code - Retrospective [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/13/2026 | **Score**: 100
+### 3. SD Completion Retrospective: Assumptions vs Reality End-to-End Loop (assumption-reality-tracker.js) [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
 
 **Key Improvements**:
-- [PAT-AUTO-c205e83a] Gate 2D:testingSubAgentVerified failed: score 0/100
-- [PAT-AUTO-0bd90c7f] Gate GATE2_IMPLEMENTATION_FIDELITY failed: score 68/100
+- PLAN-TO-EXEC handoff rejected 10 times before passing due to missing user stories and insufficient t...
+- deriveStatus() initially returned active instead of partially_validated, violating PRD FR-3 -- root ...
 
 **Action Items**:
-- [ ] No immediate actions required - continue standard workflow
-- [ ] Re-run blocking sub-agents for SD-LEO-FIX-REPLACE-EXTERNAL-API-001 until PASS ve...
+- [ ] Add observability/metrics for fire-and-forget Supabase writes in assumption-real...
+- [ ] Create integration test for full pipeline: collectRealityMeasurements -> buildCa...
 
-### 4. Terminal Identity Process Chain Hardening - Retrospective [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/13/2026 | **Score**: 100
+### 4. SD Completion Retrospective: Four Buckets Epistemic Classification Across 25 EVA Analysis Steps [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
 
 **Key Improvements**:
-- [PAT-AUTO-b28c8662] Gate GATE_PROTOCOL_FILE_READ failed: score 0/100
-- SD-LEO-FIX-TERMINAL-IDENTITY-001 proceeded without PRD - scope defined informally
+- PLAN-TO-EXEC handoff required 5 attempts because PRD separate columns (system_architecture, implemen...
+- Stage-02 (multi-persona) had fourBuckets variable scoped inside a for loop - required hoisting varia...
 
 **Action Items**:
-- [ ] No immediate actions required - continue standard workflow
-- [ ] Create PRD for SD-LEO-FIX-TERMINAL-IDENTITY-001 in product_requirements_v2 table
+- [ ] Create smoke test that runs one stage analysis end-to-end and verifies epistemic...
+- [ ] Monitor LLM token usage increase from appended Four Buckets prompt (~150 tokens ...
 
-### 5. LEAD_TO_PLAN Handoff Retrospective: Distill CLAUDE*.md Files for Maximum Token Reduction [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/13/2026 | **Score**: 100
+### 5. PLAN_TO_EXEC Handoff Retrospective: Crew Tournament Pattern for Stage 11 GTM [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
 
 **Key Improvements**:
-- [PAT-AUTO-c205e83a] Gate 2D:testingSubAgentVerified failed: score 0/100
-- [PAT-AUTO-0bd90c7f] Gate GATE2_IMPLEMENTATION_FIDELITY failed: score 68/100
+- {"area":"PRD quality gate failed first attempt at 44/100 due to missing system_architecture section,...
+- {"area":"Exploration audit gate scored 0/100 because the format used files_examined instead of the r...
 
 **Action Items**:
-- [ ] Monitor digest token budget utilization over next 5 SDs — current 83% (20,814/25...
-- [ ] Add regression test to verify CLAUDE.md stays under 15K chars after regeneration...
+- [ ] Create a pre-submission checklist for PRD quality gates that includes: system_ar...
+- [ ] Add timeout configuration testing to tournament orchestrator acceptance criteria...
 
 
 *Lessons auto-generated from `retrospectives` table. Query for full details.*
@@ -1200,7 +1198,7 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 | Agent | Code | Responsibilities | % Split |
 |-------|------|------------------|----------|
-| Implementation Agent | EXEC | Implementation based on PRD. **CRITICAL: Implementations happen in /mnt/c/_EHG/e... | I:30 = 30% |
+| Implementation Agent | EXEC | Implementation based on PRD. **CRITICAL: Implementations happen in C:/Users/rick... | I:30 = 30% |
 | Strategic Leadership Agent | LEAD | Strategic planning, business objectives, final approval. **SIMPLICITY FIRST (PRE... | P:20 A:15 = 35% |
 | Technical Planning Agent | PLAN | Technical design, PRD creation with comprehensive test plans, pre-automation val... | P:20 V:15 = 35% |
 
@@ -1256,7 +1254,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-03-14*
+*Generated from database: 2026-03-17*
 *Protocol Version: 4.3.3*
 *Includes: Proposals (0) + Hot Patterns (0) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-14T12:36:22.370Z -->
-<!-- git_commit: 05ee2881 -->
-<!-- db_snapshot_hash: cf3e5ecf7c7ae5c7 -->
+<!-- generated_at: 2026-03-17T14:23:33.230Z -->
+<!-- git_commit: 0be59f24 -->
+<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
@@ -261,5 +261,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-03-14 8:36:22 AM*
+*DIGEST generated: 2026-03-17 10:23:33 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-14T12:36:22.370Z -->
-<!-- git_commit: 05ee2881 -->
-<!-- db_snapshot_hash: cf3e5ecf7c7ae5c7 -->
+<!-- generated_at: 2026-03-17T14:23:33.230Z -->
+<!-- git_commit: 0be59f24 -->
+<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
@@ -152,5 +152,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-03-14 8:36:22 AM*
+*DIGEST generated: 2026-03-17 10:23:33 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-03-14 8:36:22 AM
+**Generated**: 2026-03-17 10:23:33 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing
 
@@ -85,12 +85,12 @@ Before writing ANY code, EXEC MUST:
    - Document: "Integration context reviewed: [X consumers, Y dependencies, Z metrics]"
 
 1. **APPLICATION CHECK** ⚠️ CRITICAL
-   - **ALL UI changes** (user AND admin) go to `/mnt/c/_EHG/EHG/`
-   - **User features**: `/mnt/c/_EHG/EHG/src/components/` and `/src/pages/`
-   - **Admin features**: `/mnt/c/_EHG/EHG/src/components/admin/` and `/src/pages/admin/`
-   - **Stage components**: `/mnt/c/_EHG/EHG/src/components/stages/admin/`
-   - **Backend API only**: `/mnt/c/_EHG/EHG_Engineer/` (routes, scripts, no UI)
-   - Verify: `cd /mnt/c/_EHG/EHG && pwd`
+   - **ALL UI changes** (user AND admin) go to `C:/Users/rickf/Projects/_EHG/ehg/`
+   - **User features**: `C:/Users/rickf/Projects/_EHG/ehg/src/components/` and `/src/pages/`
+   - **Admin features**: `C:/Users/rickf/Projects/_EHG/ehg/src/components/admin/` and `/src/pages/admin/`
+   - **Stage components**: `C:/Users/rickf/Projects/_EHG/ehg/src/components/stages/admin/`
+   - **Backend API only**: `C:/Users/rickf/Projects/_EHG/EHG_Engineer/` (routes, scripts, no UI)
+   - Verify: `cd C:/Users/rickf/Projects/_EHG/ehg && pwd`
    - Check GitHub: `git remote -v` should show `rickfelix/ehg.git` for frontend
 
 2. **URL Verification** ✅
@@ -173,70 +173,6 @@ npm run sd:status SD-XXX-001
 See: `docs/03_protocols_and_standards/gate0-workflow-entry-enforcement.md` for complete documentation.
 
 **If SD is in draft**: STOP. Do not implement. Run LEAD-TO-PLAN handoff first.
-
-
-## Branch Creation (Automated at LEAD-TO-PLAN)
-
-## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
-
-### Automatic Branch Creation
-
-As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
-
-1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
-2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
-3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
-4. Database is updated with branch name for tracking
-
-### Manual Branch Creation (If Needed)
-
-If branch creation fails or you need to create one manually:
-
-```bash
-# Create branch for an SD (looks up title from database)
-npm run sd:branch SD-XXX-001
-
-# Create with auto-stash (non-interactive)
-npm run sd:branch:auto SD-XXX-001
-
-# Check if branch exists
-npm run sd:branch:check SD-XXX-001
-
-# Full command with options
-node scripts/create-sd-branch.js SD-XXX-001 --app EHG --auto-stash
-```
-
-### Branch Naming Convention
-
-| SD Type | Branch Prefix | Example |
-|---------|---------------|---------|
-| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
-| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
-| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
-| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
-| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
-
-### Branch Hygiene Rules
-
-From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
-- **≤7 days stale** at PLAN-TO-EXEC handoff
-- **One SD per branch** (no mixing work)
-- **Merge main at phase transitions**
-
-### When Branch is Created
-
-```
-LEAD Phase                    PLAN Phase                   EXEC Phase
-    |                              |                            |
-    |   LEAD-TO-PLAN handoff       |                            |
-    |---[Branch Created Here]----->|                            |
-    |                              |   PRD Creation             |
-    |                              |   Sub-agent validation     |
-    |                              |                            |
-    |                              |   PLAN-TO-EXEC handoff     |
-    |                              |---[Branch Validated]------>|
-    |                              |                            |
-```
 
 
 ## ❌ Anti-Patterns from Retrospectives (EXEC Phase)
@@ -326,6 +262,70 @@ If `research_confidence_score = 0.00`, you skipped this step.
 | Simulate sub-agents | 15% quality loss | Execute actual tools |
 
 **Pattern References**: PAT-RECURSION-001 through PAT-RECURSION-005
+
+## Branch Creation (Automated at LEAD-TO-PLAN)
+
+## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
+
+### Automatic Branch Creation
+
+As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
+
+1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
+2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
+3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
+4. Database is updated with branch name for tracking
+
+### Manual Branch Creation (If Needed)
+
+If branch creation fails or you need to create one manually:
+
+```bash
+# Create branch for an SD (looks up title from database)
+npm run sd:branch SD-XXX-001
+
+# Create with auto-stash (non-interactive)
+npm run sd:branch:auto SD-XXX-001
+
+# Check if branch exists
+npm run sd:branch:check SD-XXX-001
+
+# Full command with options
+node scripts/create-sd-branch.js SD-XXX-001 --app EHG --auto-stash
+```
+
+### Branch Naming Convention
+
+| SD Type | Branch Prefix | Example |
+|---------|---------------|---------|
+| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
+| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
+| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
+| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
+| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
+
+### Branch Hygiene Rules
+
+From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
+- **≤7 days stale** at PLAN-TO-EXEC handoff
+- **One SD per branch** (no mixing work)
+- **Merge main at phase transitions**
+
+### When Branch is Created
+
+```
+LEAD Phase                    PLAN Phase                   EXEC Phase
+    |                              |                            |
+    |   LEAD-TO-PLAN handoff       |                            |
+    |---[Branch Created Here]----->|                            |
+    |                              |   PRD Creation             |
+    |                              |   Sub-agent validation     |
+    |                              |                            |
+    |                              |   PLAN-TO-EXEC handoff     |
+    |                              |---[Branch Validated]------>|
+    |                              |                            |
+```
+
 
 ## EXEC Phase Negative Constraints
 
@@ -551,12 +551,12 @@ When multiple Claude Code instances may run concurrently on different SDs:
 
 #### Before Starting EXEC Phase:
 ```bash
-# 1. Create isolated worktree (NOT shared /mnt/c/_EHG/ehg)
-cd /mnt/c/_EHG/ehg
-git worktree add /mnt/c/_EHG/ehg-worktrees/${SD_ID} -b feat/${SD_ID}-branch
+# 1. Create isolated worktree (NOT shared C:/Users/rickf/Projects/_EHG/ehg)
+cd C:/Users/rickf/Projects/_EHG/ehg
+git worktree add C:/Users/rickf/Projects/_EHG/ehg/.worktrees/${SD_ID} -b feat/${SD_ID}-branch
 
 # 2. Work ONLY in worktree directory
-cd /mnt/c/_EHG/ehg-worktrees/${SD_ID}
+cd C:/Users/rickf/Projects/_EHG/ehg/.worktrees/${SD_ID}
 
 # 3. All git operations happen here
 git add . && git commit -m "feat(${SD_ID}): description"
@@ -566,8 +566,8 @@ git push origin feat/${SD_ID}-branch
 #### After PR Merged:
 ```bash
 # Cleanup worktree
-cd /mnt/c/_EHG/ehg
-git worktree remove /mnt/c/_EHG/ehg-worktrees/${SD_ID}
+cd C:/Users/rickf/Projects/_EHG/ehg
+git worktree remove C:/Users/rickf/Projects/_EHG/ehg/.worktrees/${SD_ID}
 ```
 
 ### Forbidden Operations (Multi-Instance)
@@ -576,7 +576,7 @@ git worktree remove /mnt/c/_EHG/ehg-worktrees/${SD_ID}
 |-----------|---------------|-------------|
 | `git stash pop` across SDs | Mixes changes between instances | Use worktrees |
 | `git checkout` to different SD branch | Switches shared directory | Use worktrees |
-| Working in `/mnt/c/_EHG/ehg` during parallel execution | Shared state conflicts | Use worktree path |
+| Working in `C:/Users/rickf/Projects/_EHG/ehg` during parallel execution | Shared state conflicts | Use worktree path |
 | Branch switching mid-operation | Interrupts other instance | Complete or stash first |
 
 ### Quick Reference
@@ -808,7 +808,7 @@ Before creating EXEC→PLAN handoff, EXEC MUST run:
 
 #### 1. Unit Tests (Business Logic Validation)
 ```bash
-cd /mnt/c/_EHG/ehg
+cd C:/Users/rickf/Projects/_EHG/ehg
 npm run test:unit
 ```
 - **What it validates**: Service layer, business logic, data transformations
@@ -818,7 +818,7 @@ npm run test:unit
 
 #### 2. E2E Tests (UI/Integration Validation)
 ```bash
-cd /mnt/c/_EHG/ehg
+cd C:/Users/rickf/Projects/_EHG/ehg
 npm run test:e2e
 ```
 - **What it validates**: User flows, component rendering, integration
@@ -912,6 +912,86 @@ UI Parity Status:
 - Gate 2.5 Status: PASS/FAIL
 ```
 
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
+
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
+
+**Every completed Strategic Directive and Quick-Fix MUST end with:**
+
+1. **Commit** - All changes committed with proper message format
+2. **Push** - Branch pushed to remote
+3. **Merge to Main** - Feature branch merged into main
+
+### For Quick-Fixes
+
+The `complete-quick-fix.js` script handles this automatically:
+
+```bash
+node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
+```
+
+The script will:
+1. Verify tests pass and UAT completed
+2. Commit and push changes
+3. **Prompt to merge PR to main** (or local merge if no PR)
+4. Delete the feature branch
+
+### For Strategic Directives
+
+After LEAD approval, execute the following:
+
+```bash
+# 1. Ensure all changes committed
+git add .
+git commit -m "feat(SD-YYYY-XXX): [description]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# 2. Push to remote
+git push origin feature/SD-YYYY-XXX
+
+# 3. Create PR if not exists
+gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
+
+# 4. Merge PR (preferred method)
+gh pr merge --merge --delete-branch
+
+# OR local merge fallback
+git checkout main
+git pull origin main
+git merge --no-ff feature/SD-YYYY-XXX
+git push origin main
+git branch -d feature/SD-YYYY-XXX
+git push origin --delete feature/SD-YYYY-XXX
+```
+
+### Merge Checklist
+
+Before merging, verify:
+- [ ] All tests passing (unit + E2E)
+- [ ] CI/CD pipeline green
+- [ ] Code review completed (if required)
+- [ ] No merge conflicts
+- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
+
+### Anti-Patterns
+
+❌ **NEVER** leave feature branches unmerged after completion
+❌ **NEVER** skip the push step
+❌ **NEVER** merge without verifying tests pass
+❌ **NEVER** force push to main
+
+### Verification
+
+After merge, confirm:
+```bash
+git checkout main
+git pull origin main
+git log --oneline -5  # Should show your merge commit
+```
+
 ## 🌿 Branch Hygiene Gate (MANDATORY)
 
 ## Branch Hygiene Gate (MANDATORY)
@@ -1001,86 +1081,6 @@ When starting implementation:
 3. If multiple SDs detected → split branches
 4. If >100 files changed → assess scope creep
 5. Document branch health in handoff notes
-
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
-
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
-
-**Every completed Strategic Directive and Quick-Fix MUST end with:**
-
-1. **Commit** - All changes committed with proper message format
-2. **Push** - Branch pushed to remote
-3. **Merge to Main** - Feature branch merged into main
-
-### For Quick-Fixes
-
-The `complete-quick-fix.js` script handles this automatically:
-
-```bash
-node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
-```
-
-The script will:
-1. Verify tests pass and UAT completed
-2. Commit and push changes
-3. **Prompt to merge PR to main** (or local merge if no PR)
-4. Delete the feature branch
-
-### For Strategic Directives
-
-After LEAD approval, execute the following:
-
-```bash
-# 1. Ensure all changes committed
-git add .
-git commit -m "feat(SD-YYYY-XXX): [description]
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
-
-# 2. Push to remote
-git push origin feature/SD-YYYY-XXX
-
-# 3. Create PR if not exists
-gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
-
-# 4. Merge PR (preferred method)
-gh pr merge --merge --delete-branch
-
-# OR local merge fallback
-git checkout main
-git pull origin main
-git merge --no-ff feature/SD-YYYY-XXX
-git push origin main
-git branch -d feature/SD-YYYY-XXX
-git push origin --delete feature/SD-YYYY-XXX
-```
-
-### Merge Checklist
-
-Before merging, verify:
-- [ ] All tests passing (unit + E2E)
-- [ ] CI/CD pipeline green
-- [ ] Code review completed (if required)
-- [ ] No merge conflicts
-- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
-
-### Anti-Patterns
-
-❌ **NEVER** leave feature branches unmerged after completion
-❌ **NEVER** skip the push step
-❌ **NEVER** merge without verifying tests pass
-❌ **NEVER** force push to main
-
-### Verification
-
-After merge, confirm:
-```bash
-git checkout main
-git pull origin main
-git log --oneline -5  # Should show your merge commit
-```
 
 ## Auto-Merge Workflow for SD Completion
 
@@ -1852,16 +1852,16 @@ Generates modular CLAUDE files (CLAUDE.md, CLAUDE_CORE.md, CLAUDE_LEAD.md, CLAUD
 
 ### Handoff Scripts
 
-#### unified-handoff-system.js
+#### handoff.js
 Unified LEO Protocol handoff execution system. Handles all handoff types with database-driven templates and validation.
 
-**Usage**: `node scripts/unified-handoff-system.js <command> [TYPE] [SD-ID] [PRD-ID]`
+**Usage**: `node scripts/handoff.js <command> [TYPE] [SD-ID] [PRD-ID]`
 
 **Examples**:
-- `node scripts/unified-handoff-system.js execute LEAD-TO-PLAN SD-IDEATION-STAGE1-001`
-- `node scripts/unified-handoff-system.js execute PLAN-TO-EXEC SD-IDEATION-STAGE1-001 PRD-IDEATION-001`
-- `node scripts/unified-handoff-system.js list SD-IDEATION-STAGE1-001`
-- `node scripts/unified-handoff-system.js stats`
+- `node scripts/handoff.js execute LEAD-TO-PLAN SD-IDEATION-STAGE1-001`
+- `node scripts/handoff.js execute PLAN-TO-EXEC SD-IDEATION-STAGE1-001 PRD-IDEATION-001`
+- `node scripts/handoff.js list SD-IDEATION-STAGE1-001`
+- `node scripts/handoff.js stats`
 
 **Common Errors**:
 - Pattern: `--type.*not recognized` -> Fix: Use positional: execute TYPE SD-ID, not --type TYPE
@@ -1905,6 +1905,22 @@ Inserts a new LEO protocol version and copies sections from previous version.
 
 ### Validation Scripts
 
+#### verify-handoff-lead-to-plan.js
+Verifies LEAD to PLAN handoff requirements are met before allowing transition.
+
+**Usage**: `node scripts/verify-handoff-lead-to-plan.js <SD-ID>`
+
+**Examples**:
+- `node scripts/verify-handoff-lead-to-plan.js SD-IDEATION-STAGE1-001`
+
+#### verify-handoff-plan-to-exec.js
+Verifies PLAN to EXEC handoff requirements including PRD completeness and sub-agent validations.
+
+**Usage**: `node scripts/verify-handoff-plan-to-exec.js <SD-ID> [PRD-ID]`
+
+**Examples**:
+- `node scripts/verify-handoff-plan-to-exec.js SD-IDEATION-STAGE1-001`
+
 #### check-leo-version.js
 Verifies version consistency between CLAUDE*.md files and database. Use --fix to auto-regenerate.
 
@@ -1917,26 +1933,10 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 **Common Errors**:
 - Pattern: `No active protocol found` -> Fix: Ensure leo_protocols has exactly one active record
 
-#### verify-handoff-plan-to-exec.js
-Verifies PLAN to EXEC handoff requirements including PRD completeness and sub-agent validations.
-
-**Usage**: `node scripts/verify-handoff-plan-to-exec.js <SD-ID> [PRD-ID]`
-
-**Examples**:
-- `node scripts/verify-handoff-plan-to-exec.js SD-IDEATION-STAGE1-001`
-
-#### verify-handoff-lead-to-plan.js
-Verifies LEAD to PLAN handoff requirements are met before allowing transition.
-
-**Usage**: `node scripts/verify-handoff-lead-to-plan.js <SD-ID>`
-
-**Examples**:
-- `node scripts/verify-handoff-lead-to-plan.js SD-IDEATION-STAGE1-001`
-
 
 
 ---
 
-*Generated from database: 2026-03-14*
+*Generated from database: 2026-03-17*
 *Protocol Version: 4.3.3*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-14T12:36:22.370Z -->
-<!-- git_commit: 05ee2881 -->
-<!-- db_snapshot_hash: cf3e5ecf7c7ae5c7 -->
+<!-- generated_at: 2026-03-17T14:23:33.230Z -->
+<!-- git_commit: 0be59f24 -->
+<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
@@ -47,12 +47,12 @@ Before writing ANY code, EXEC MUST:
    - Document: "Integration context reviewed: [X consumers, Y dependencies, Z metrics]"
 
 1. **APPLICATION CHECK** ⚠️ CRITICAL
-   - **ALL UI changes** (user AND admin) go to `/mnt/c/_EHG/EHG/`
-   - **User features**: `/mnt/c/_EHG/EHG/src/components/` and `/src/pages/`
-   - **Admin features**: `/mnt/c/_EHG/EHG/src/components/admin/` and `/src/pages/admin/`
-   - **Stage components**: `/mnt/c/_EHG/EHG/src/components/stages/admin/`
-   - **Backend API only**: `/mnt/c/_EHG/EHG_Engineer/` (routes, scripts, no UI)
-   - Verify: `cd /mnt/c/_EHG/EHG && pwd`
+   - **ALL UI changes** (user AND admin) go to `C:/Users/rickf/Projects/_EHG/ehg/`
+   - **User features**: `C:/Users/rickf/Projects/_EHG/ehg/src/components/` and `/src/pages/`
+   - **Admin features**: `C:/Users/rickf/Projects/_EHG/ehg/src/components/admin/` and `/src/pages/admin/`
+   - **Stage components**: `C:/Users/rickf/Projects/_EHG/ehg/src/components/stages/admin/`
+   - **Backend API only**: `C:/Users/rickf/Projects/_EHG/EHG_Engineer/` (routes, scripts, no UI)
+   - Verify: `cd C:/Users/rickf/Projects/_EHG/ehg && pwd`
    - Check GitHub: `git remote -v` should show `rickfelix/ehg.git` for frontend
 
 2. **URL Verification** ✅
@@ -63,10 +63,7 @@ Before writing ANY code, EXEC MUST:
 
 3. **Component Identification** 🎯
    - Identify the exact file path of the target component
-   - Confirm component exists at specified location
-   - Document: "Target component: [full/path/to/component.tsx]"
-
-4. **Application C
+   - Confirm component exists at 
 
 *...truncated. Read full file for complete section.*
 
@@ -221,5 +218,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-03-14 8:36:22 AM*
+*DIGEST generated: 2026-03-17 10:23:33 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-03-14 8:36:22 AM
+**Generated**: 2026-03-17 10:23:33 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation
 
@@ -456,81 +456,6 @@ node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
 - **Process Scripts**: `scripts/add-sd-to-database.js`, `scripts/handoff.js`, `scripts/leo-create-sd.js`
 - **Plan-Aware Creation**: `docs/reference/sd-key-generator-guide.md` (--from-plan section)
 
-## Child SD Context Loading (MANDATORY)
-
-**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
-
-### Why This Applies to Children
-
-Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
-- Has its own PRD
-- Has its own handoffs
-- Has its own retrospective
-- Must meet its own gate thresholds
-
-**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
-
-### Required Context Loading Sequence
-
-Before starting ANY work on a child SD:
-
-1. **Run child preflight validation**:
-   ```bash
-   node scripts/child-sd-preflight.js SD-XXX-001
-   ```
-
-2. **Read CLAUDE_CORE.md** (provides SD type requirements):
-   ```
-   Read tool: CLAUDE_CORE.md
-   ```
-
-3. **Read phase-specific file** based on current_phase:
-   | Phase | File |
-   |-------|------|
-   | LEAD_APPROVAL | CLAUDE_LEAD.md |
-   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
-   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
-
-### What CLAUDE_CORE.md Provides
-
-- SD type definitions (feature, bugfix, infrastructure, etc.)
-- Gate pass thresholds per SD type
-- Required handoff counts
-- Required sub-agents per SD type
-- Global negative constraints
-
-### Consequences of Skipping Context Loading
-
-Without loading CLAUDE_CORE.md before child SD work:
-- **Unknown requirements**: May not know PRD is required
-- **Wrong thresholds**: May target 70% when 85% is required
-- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
-- **Incomplete handoffs**: May not execute full chain
-
-### Enforcement
-
-The `child-sd-preflight.js` script now displays a reminder:
-```
-⚠️  CONTEXT LOADING REMINDER:
-   Before starting work, you MUST read:
-   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
-   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
-```
-
-**This reminder is advisory.** The actual context loading must be performed by reading the files.
-
-### Quick Reference
-
-| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
-|---------------|----------------|--------------|--------------|
-| feature | 85% | 5 | YES |
-| bugfix | 85% | 5 | YES |
-| infrastructure | 80% | 4 | YES |
-| documentation | 60% | 4 | NO |
-| refactor | 75-90% | 5 | Brief |
-
-*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
-
 ## Common SD Creation Errors and Solutions
 
 ### Database Constraint Errors
@@ -803,6 +728,81 @@ const sdKey = await generateSDKey({ source, type, title });
 4. `scripts/create-sd.js`
 5. `scripts/modules/learning/executor.js`
 
+
+## Child SD Context Loading (MANDATORY)
+
+**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
+
+### Why This Applies to Children
+
+Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
+- Has its own PRD
+- Has its own handoffs
+- Has its own retrospective
+- Must meet its own gate thresholds
+
+**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
+
+### Required Context Loading Sequence
+
+Before starting ANY work on a child SD:
+
+1. **Run child preflight validation**:
+   ```bash
+   node scripts/child-sd-preflight.js SD-XXX-001
+   ```
+
+2. **Read CLAUDE_CORE.md** (provides SD type requirements):
+   ```
+   Read tool: CLAUDE_CORE.md
+   ```
+
+3. **Read phase-specific file** based on current_phase:
+   | Phase | File |
+   |-------|------|
+   | LEAD_APPROVAL | CLAUDE_LEAD.md |
+   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
+   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
+
+### What CLAUDE_CORE.md Provides
+
+- SD type definitions (feature, bugfix, infrastructure, etc.)
+- Gate pass thresholds per SD type
+- Required handoff counts
+- Required sub-agents per SD type
+- Global negative constraints
+
+### Consequences of Skipping Context Loading
+
+Without loading CLAUDE_CORE.md before child SD work:
+- **Unknown requirements**: May not know PRD is required
+- **Wrong thresholds**: May target 70% when 85% is required
+- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
+- **Incomplete handoffs**: May not execute full chain
+
+### Enforcement
+
+The `child-sd-preflight.js` script now displays a reminder:
+```
+⚠️  CONTEXT LOADING REMINDER:
+   Before starting work, you MUST read:
+   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
+   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
+```
+
+**This reminder is advisory.** The actual context loading must be performed by reading the files.
+
+### Quick Reference
+
+| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
+|---------------|----------------|--------------|--------------|
+| feature | 85% | 5 | YES |
+| bugfix | 85% | 5 | YES |
+| infrastructure | 80% | 4 | YES |
+| documentation | 60% | 4 | NO |
+| refactor | 75-90% | 5 | Brief |
+
+*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
 
 ## Phase-Specific Sub-Agent Guidance: LEAD
 
@@ -1487,6 +1487,6 @@ Check `objectives` (active, current period) and `key_results` (status != 'achiev
 
 ---
 
-*Generated from database: 2026-03-14*
+*Generated from database: 2026-03-17*
 *Protocol Version: 4.3.3*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-14T12:36:22.370Z -->
-<!-- git_commit: 05ee2881 -->
-<!-- db_snapshot_hash: cf3e5ecf7c7ae5c7 -->
+<!-- generated_at: 2026-03-17T14:23:33.230Z -->
+<!-- git_commit: 0be59f24 -->
+<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
@@ -126,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-14 8:36:22 AM*
+*DIGEST generated: 2026-03-17 10:23:33 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-03-14 8:36:22 AM
+**Generated**: 2026-03-17 10:23:33 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 
@@ -182,30 +182,6 @@ LEAD Phase                    PLAN Phase                   EXEC Phase
 ```
 
 
-## Deferred Work Management
-
-### What Gets Deferred
-- Technical debt discovered during implementation
-- Edge cases not critical for MVP
-- Performance optimizations for later
-- Nice-to-have features
-
-### Creating Deferred Items
-```sql
-INSERT INTO deferred_work (sd_id, title, reason, priority)
-VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
-```
-
-### Tracking
-- Deferred items linked to parent SD
-- Reviewed during retrospective
-- May become new SDs if significant
-
-### Rules
-- Document WHY deferred, not just WHAT
-- Set realistic priority (critical items shouldn't be deferred)
-- Max 5 deferred items per SD
-
 ## PLAN Phase Negative Constraints
 
 ## 🚫 PLAN Phase Negative Constraints
@@ -243,6 +219,30 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 **Why Wrong**: PRD validator blocks placeholders, signals incomplete planning
 **Correct Approach**: If truly unknown, use AskUserQuestion to clarify before PRD creation
 </negative_constraints>
+
+## Deferred Work Management
+
+### What Gets Deferred
+- Technical debt discovered during implementation
+- Edge cases not critical for MVP
+- Performance optimizations for later
+- Nice-to-have features
+
+### Creating Deferred Items
+```sql
+INSERT INTO deferred_work (sd_id, title, reason, priority)
+VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
+```
+
+### Tracking
+- Deferred items linked to parent SD
+- Reviewed during retrospective
+- May become new SDs if significant
+
+### Rules
+- Document WHY deferred, not just WHAT
+- Set realistic priority (critical items shouldn't be deferred)
+- Max 5 deferred items per SD
 
 ## Phase-Specific Sub-Agent Guidance: PLAN
 
@@ -786,6 +786,21 @@ node scripts/add-prd-to-database.js {SD-ID}
 - ⚠️ Never create PRDs as markdown files
 - ⚠️ Never skip validation gates
 
+## CI/CD Pipeline Verification
+
+## CI/CD Pipeline Verification (MANDATORY)
+
+**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
+
+### Verification Process
+
+**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
+
+1. Wait 2-3 minutes for GitHub Actions to complete
+2. Trigger DevOps sub-agent to verify pipeline status
+3. Document CI/CD status in PLAN→LEAD handoff
+4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
+
 ## DESIGN→DATABASE Validation Gates
 
 **4 mandatory gates ensuring sub-agent execution and implementation fidelity.**
@@ -837,21 +852,6 @@ Retroactive audit at SD closure:
 
 **Reference**: `scripts/modules/design-database-gates-validation.js`
 
-
-## CI/CD Pipeline Verification
-
-## CI/CD Pipeline Verification (MANDATORY)
-
-**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
-
-### Verification Process
-
-**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
-
-1. Wait 2-3 minutes for GitHub Actions to complete
-2. Trigger DevOps sub-agent to verify pipeline status
-3. Document CI/CD status in PLAN→LEAD handoff
-4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
 
 ## 🚪 Gate 2.5: Human Inspectability Validation
 
@@ -2349,6 +2349,6 @@ When creating a PRD during PLAN phase, connect functional requirements to releva
 
 ---
 
-*Generated from database: 2026-03-14*
+*Generated from database: 2026-03-17*
 *Protocol Version: 4.3.3*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-14T12:36:22.370Z -->
-<!-- git_commit: 05ee2881 -->
-<!-- db_snapshot_hash: cf3e5ecf7c7ae5c7 -->
+<!-- generated_at: 2026-03-17T14:23:33.230Z -->
+<!-- git_commit: 0be59f24 -->
+<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
@@ -124,5 +124,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-14 8:36:22 AM*
+*DIGEST generated: 2026-03-17 10:23:33 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,77 +1,77 @@
 {
-  "generated_at": "2026-03-14T12:36:22.370Z",
-  "git_commit": "05ee2881",
-  "db_snapshot_hash": "cf3e5ecf7c7ae5c7",
+  "generated_at": "2026-03-17T14:23:33.230Z",
+  "git_commit": "0be59f24",
+  "db_snapshot_hash": "41d2dee99ad0b539",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 5767,
-      "estimated_tokens": 1442,
-      "content_hash": "b2e36b79b2a94f36",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
+      "chars": 5753,
+      "estimated_tokens": 1439,
+      "content_hash": "ef5847a537f37ddb",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 51077,
-      "estimated_tokens": 12770,
-      "content_hash": "d5e3a4eb0fd5592f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
+      "chars": 51423,
+      "estimated_tokens": 12856,
+      "content_hash": "763dad0ae00586ad",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 54092,
-      "estimated_tokens": 13523,
-      "content_hash": "90d7704d4bdd64da",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
+      "chars": 54093,
+      "estimated_tokens": 13524,
+      "content_hash": "91e9862013f43d6c",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 82128,
-      "estimated_tokens": 20532,
-      "content_hash": "2f11d7938f8b9e66",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
+      "chars": 82129,
+      "estimated_tokens": 20533,
+      "content_hash": "cc2571ab149fe270",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 69134,
-      "estimated_tokens": 17284,
-      "content_hash": "8162218ecd9d8f63",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
+      "chars": 69303,
+      "estimated_tokens": 17326,
+      "content_hash": "d3f42680bc17dbb4",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 6618,
+      "chars": 6619,
       "estimated_tokens": 1655,
-      "content_hash": "2b2d3ae0cfacab47",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
+      "content_hash": "9e36b4877d1ed042",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 10174,
+      "chars": 10175,
       "estimated_tokens": 2544,
-      "content_hash": "3082557d64a475f3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "f22354d7766dea1e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 4801,
+      "chars": 4802,
       "estimated_tokens": 1201,
-      "content_hash": "ad0e9983f82b80ee",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "def40b765cd0e308",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 5031,
+      "chars": 5032,
       "estimated_tokens": 1258,
-      "content_hash": "8273e1b9b91b714f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "bdbcc27030bd79d0",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 9485,
+      "chars": 9486,
       "estimated_tokens": 2372,
-      "content_hash": "3d5ffb3e65e0e28f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "c6f60cb0066a64d6",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_EXEC_DIGEST.md"
     }
   }
 }

--- a/docs/guides/leo-protocol-quick-reference.md
+++ b/docs/guides/leo-protocol-quick-reference.md
@@ -59,10 +59,10 @@ node scripts/leo.js new-sd "Add feature X"
 node scripts/context-monitor.js check
 
 # Perform handoff
-node scripts/handoff-controller.js handoff LEAD-to-PLAN
+node scripts/handoff.js handoff LEAD-to-PLAN
 
 # Archive work
-node scripts/handoff-controller.js archive EXEC completed-feature
+node scripts/handoff.js archive EXEC completed-feature
 ```
 
 ---
@@ -213,7 +213,7 @@ Project/
 ```bash
 1. Complete missing items
 2. OR request exception:
-   node scripts/handoff-controller.js handoff [type]
+   node scripts/handoff.js handoff [type]
    > Provide justification
 ```
 

--- a/scripts/handoff-validator.js
+++ b/scripts/handoff-validator.js
@@ -30,7 +30,7 @@ class HandoffValidator {
       'PLAN->EXEC': 100,  // PLAN must be 100% complete
       'EXEC->PLAN': 100,  // EXEC must be 100% complete before verification
       'PLAN->LEAD': 100,  // Verification must be 100% complete
-      'LEAD->DEPLOY': 100 // Final approval must be 100%
+      'LEAD-FINAL-APPROVAL': 100 // Final approval must be 100%
     };
     
     // Define which sub-agents are critical at each handoff
@@ -72,8 +72,8 @@ class HandoffValidator {
           'Analytics': 'If success metrics defined'
         }
       },
-      'LEAD->DEPLOY': {
-        // LEAD approves for deployment
+      'LEAD-FINAL-APPROVAL': {
+        // LEAD final approval before completion
         triggers: {
           'DevOps': 'ALWAYS - deployment readiness',
           'Documentation': 'ALWAYS - final documentation',
@@ -415,7 +415,7 @@ class HandoffValidator {
       'PLAN->EXEC': 'PLAN_DESIGN',
       'EXEC->PLAN': 'EXEC_IMPLEMENTATION',
       'PLAN->LEAD': 'PLAN_VERIFICATION',
-      'LEAD->DEPLOY': 'LEAD_APPROVAL'
+      'LEAD-FINAL-APPROVAL': 'LEAD_APPROVAL'
     };
     return phaseMap[handoffKey] || 'UNKNOWN';
   }

--- a/scripts/modules/claude-md-generator/file-generators.js
+++ b/scripts/modules/claude-md-generator/file-generators.js
@@ -120,7 +120,7 @@ Use \`*_DIGEST.md\` variants only when context is constrained (e.g. smaller mode
 
 ## Essential Commands
 - **Pick Work**: \`npm run sd:next\`
-- **Phase Handoff**: \`node scripts/unified-handoff-system.js execute <PHASE> <SD-ID>\`
+- **Phase Handoff**: \`node scripts/handoff.js execute <PHASE> <SD-ID>\`
 - **Create SD**: \`node scripts/leo-create-sd.js\`
 - **Create PRD**: \`node scripts/add-prd-to-database.js\`
 - **LEO Stack**: \`node scripts/cross-platform-run.js leo-stack restart|status|stop\`


### PR DESCRIPTION
## Summary
- Replace all WSL paths (`/mnt/c/_EHG/`) with Windows paths across `leo_protocol_sections`, `leo_agents`, and `leo_process_scripts` DB tables
- Replace deprecated `unified-handoff-system.js` references with `handoff.js` in DB tables, generator script, and process scripts
- Remove duplicate Migration Execution Protocol header in CLAUDE_CORE.md
- Fix `.env.example` protocol version from 3.1.5.9 to 4.3.3
- Fix `LEAD->DEPLOY` to `LEAD-FINAL-APPROVAL` in handoff-validator.js
- Fix `handoff-controller.js` to `handoff.js` in quick-reference guide
- Regenerate all CLAUDE_*.md files from corrected database

SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001

## Test plan
- [x] `grep /mnt/c/ CLAUDE_*.md` returns 0 matches
- [x] `grep unified-handoff-system.js CLAUDE_*.md` returns 0 matches
- [x] CLAUDE_CORE.md has single Migration Execution Protocol header
- [x] `.env.example` shows `LEO_PROTOCOL_VERSION=4.3.3`
- [x] No references to non-existent scripts in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)