### PR TITLE
fix: restore fleet scripts + add coordinator coaching

### DIFF
--- a/scripts/fleet-coaching.cjs
+++ b/scripts/fleet-coaching.cjs
@@ -1,0 +1,442 @@
+/**
+ * Fleet Coaching — Periodic Guidance for Active Workers
+ *
+ * Designed to run on a recurring loop: every 10 minutes via coordinator cron.
+ *
+ * Sends proactive coaching messages to active workers covering:
+ * 1. WORKTREE_REMINDER — working on main branch with parallel sessions
+ * 2. SMALL_PR_REMINDER — long-running EXEC sessions (possible scope creep)
+ * 3. LEARN_REMINDER — SD near completion, remind to run /learn
+ * 4. GATE_COMPLIANCE — repeated handoff failures
+ * 5. SUBAGENT_ROUTING — database/test work should use sub-agents
+ * 6. DEPENDENCY_UNLOCK — newly available SDs after blocker completed
+ * 7. PRIORITY_REBALANCE — working on MED when HIGH is available
+ *
+ * Anti-spam: 20-minute cooldown per coaching_type per worker.
+ * Messages expire after 30 minutes (ephemeral advice).
+ *
+ * Safe to run repeatedly — fully idempotent.
+ */
+
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const COOLDOWN_MINUTES = 20;
+const EXPIRE_MINUTES = 30;
+const LONG_SESSION_MINUTES = 45;
+
+// --- Helpers ---
+
+async function wasRecentlySent(sessionId, coachingType) {
+  const { data } = await supabase
+    .from('session_coordination')
+    .select('id')
+    .eq('target_session', sessionId)
+    .eq('message_type', 'COACHING')
+    .gte('created_at', new Date(Date.now() - COOLDOWN_MINUTES * 60 * 1000).toISOString())
+    .limit(10);
+
+  // Check payload coaching_type in JS since Supabase JS client doesn't support ->>'key' filters well
+  return (data || []).some(msg => {
+    // We need to re-query with payload — but to avoid N+1, do a broader check
+    return false; // Will refine below
+  });
+}
+
+// More precise: query with payload filter
+async function wasRecentlySentPrecise(sessionId, coachingType) {
+  const cutoff = new Date(Date.now() - COOLDOWN_MINUTES * 60 * 1000).toISOString();
+  const { data } = await supabase
+    .from('session_coordination')
+    .select('id, payload')
+    .eq('target_session', sessionId)
+    .eq('message_type', 'COACHING')
+    .gte('created_at', cutoff)
+    .limit(20);
+
+  return (data || []).some(m => m.payload?.coaching_type === coachingType);
+}
+
+async function sendCoaching(sessionId, coachingType, subject, body, extraPayload = {}) {
+  if (await wasRecentlySentPrecise(sessionId, coachingType)) {
+    return false; // Cooldown active
+  }
+
+  const expiresAt = new Date(Date.now() + EXPIRE_MINUTES * 60 * 1000).toISOString();
+
+  const { error } = await supabase
+    .from('session_coordination')
+    .insert({
+      target_session: sessionId,
+      message_type: 'COACHING',
+      subject,
+      body,
+      payload: { coaching_type: coachingType, ...extraPayload },
+      sender_type: 'coaching',
+      expires_at: expiresAt
+    });
+
+  return !error;
+}
+
+// --- Coaching Evaluators ---
+
+function evaluateWorktreeReminder(session, activeCount) {
+  // Only relevant when multiple workers are active
+  if (activeCount < 2) return null;
+
+  // If session is on main branch or has no branch info, it needs a worktree
+  const branch = session.current_branch;
+  if (!branch || branch === 'main' || branch === 'master') {
+    return {
+      subject: 'Working on main branch with ' + activeCount + ' parallel workers — use a worktree',
+      body: 'You are on the main branch while ' + activeCount + ' workers are active. ' +
+        'This risks git conflicts and corrupted node_modules.\n\n' +
+        'REQUIRED: Create an isolated worktree for your SD:\n' +
+        '  node scripts/resolve-sd-workdir.js ' + (session.sd_id || '<SD-ID>') + '\n\n' +
+        'This gives you a dedicated copy of the repo. Do this BEFORE starting any code changes.'
+    };
+  }
+  return null;
+}
+
+function evaluateSmallPRReminder(session, sdDetails) {
+  // Only for sessions in EXEC phase that have been working for >45 minutes
+  if (!sdDetails || sdDetails.current_phase !== 'EXEC') return null;
+
+  const claimedAt = session.claimed_at ? new Date(session.claimed_at) : null;
+  if (!claimedAt) return null;
+
+  const minutesClaimed = (Date.now() - claimedAt.getTime()) / (1000 * 60);
+  if (minutesClaimed < LONG_SESSION_MINUTES) return null;
+
+  const duration = minutesClaimed < 60
+    ? Math.round(minutesClaimed) + ' minutes'
+    : (minutesClaimed / 60).toFixed(1) + ' hours';
+
+  return {
+    subject: 'Working on ' + session.sd_id + ' for ' + duration + ' — check PR size',
+    body: 'LEO targets PRs at 100 LOC or less (max 400 with justification).\n\n' +
+      'Run: git diff --stat\n\n' +
+      'If your diff is growing beyond 100 LOC, consider:\n' +
+      '1. Splitting into multiple PRs\n' +
+      '2. Committing what you have and shipping the first PR\n' +
+      '3. Deferring non-essential changes to a follow-up SD'
+  };
+}
+
+function evaluateLearnReminder(session, sdDetails) {
+  if (!sdDetails) return null;
+
+  const nearComplete =
+    sdDetails.progress_percentage >= 90 ||
+    sdDetails.current_phase === 'EXEC_COMPLETE' ||
+    sdDetails.status === 'pending_approval';
+
+  if (!nearComplete) return null;
+
+  return {
+    subject: session.sd_id + ' is at ' + (sdDetails.progress_percentage || '?') + '% — remember /learn',
+    body: 'Your SD appears near completion. When done:\n\n' +
+      '1. Run /learn to generate the retrospective\n' +
+      '2. The retrospective is REQUIRED for the quality gate\n' +
+      '3. Skipping /learn causes RETROSPECTIVE_QUALITY_GATE failures\n\n' +
+      'Do NOT move to the next SD until /learn completes successfully.'
+  };
+}
+
+function evaluateGateCompliance(session) {
+  const fails = session.handoff_fail_count || 0;
+  if (fails < 2) return null;
+
+  if (fails >= 5) {
+    return {
+      subject: session.sd_id + ' has ' + fails + ' gate failures — invoke /rca',
+      body: 'Persistent handoff gate failures detected. Do NOT keep retrying the same approach.\n\n' +
+        'REQUIRED: Invoke the RCA sub-agent:\n' +
+        '  subagent_type="rca-agent"\n\n' +
+        'Provide: symptom, location, prior attempts, desired outcome.\n' +
+        'Common root causes: missing retrospective content, PRD boilerplate, test gaps.\n\n' +
+        'Do NOT use --no-verify to bypass gates.'
+    };
+  }
+
+  return {
+    subject: session.sd_id + ' has ' + fails + ' gate failures — check root cause',
+    body: 'You have ' + fails + ' handoff gate failures. Common causes:\n\n' +
+      '1. Missing retrospective with SD-specific content (not boilerplate)\n' +
+      '2. PRD missing required fields (executive_summary, functional_requirements, etc.)\n' +
+      '3. Test coverage below threshold\n\n' +
+      'Read the gate error output carefully before retrying.\n' +
+      'Do NOT use --no-verify to bypass gates.\n' +
+      'If stuck after 3+ failures, invoke /rca for root cause analysis.'
+  };
+}
+
+function evaluateSubagentRouting(session, sdDetails) {
+  if (!sdDetails || sdDetails.current_phase !== 'EXEC') return null;
+
+  const fails = session.handoff_fail_count || 0;
+  if (fails < 1) return null;
+
+  // Check SD title/description for database-related keywords
+  const text = ((sdDetails.title || '') + ' ' + (sdDetails.description || '')).toLowerCase();
+  const dbKeywords = ['migration', 'schema', 'ddl', 'rls', 'trigger', 'enum', 'database', 'supabase', 'postgres'];
+  const testKeywords = ['test', 'coverage', 'spec', 'e2e', 'unit test'];
+
+  const isDbWork = dbKeywords.some(kw => text.includes(kw));
+  const isTestWork = testKeywords.some(kw => text.includes(kw));
+
+  if (!isDbWork && !isTestWork) return null;
+
+  const agents = [];
+  if (isDbWork) agents.push('database-agent (for migrations, DDL, RLS, triggers)');
+  if (isTestWork) agents.push('testing-agent (for test creation and coverage)');
+
+  return {
+    subject: 'Use specialized sub-agents for ' + session.sd_id,
+    body: 'Your SD involves ' + (isDbWork ? 'database' : 'testing') + ' work and has gate failures.\n\n' +
+      'Use specialized sub-agents instead of manual implementation:\n' +
+      agents.map(a => '  - ' + a).join('\n') + '\n\n' +
+      'Sub-agents have domain expertise and follow LEO patterns correctly.\n' +
+      'Manual infrastructure implementation is an anti-pattern.'
+  };
+}
+
+function evaluateDependencyUnlock(session, recentCompletions, allSDs, activeClaims) {
+  // Find SDs that were blocked but are now unblocked due to recent completions
+  const completedKeys = new Set(recentCompletions.map(sd => sd.sd_key));
+  if (completedKeys.size === 0) return null;
+
+  const newlyUnblocked = allSDs.filter(sd => {
+    if (sd.status === 'completed') return false;
+    if (activeClaims.has(sd.sd_key)) return false;
+    if (!sd.dependencies || !Array.isArray(sd.dependencies)) return false;
+    // Has at least one dependency that just completed
+    const hasNewDep = sd.dependencies.some(dep => completedKeys.has(dep));
+    // All dependencies now met
+    const allMet = sd.dependencies.every(dep => {
+      const depSD = allSDs.find(s => s.sd_key === dep);
+      return depSD && depSD.status === 'completed';
+    });
+    return hasNewDep && allMet;
+  });
+
+  if (newlyUnblocked.length === 0) return null;
+
+  const sdList = newlyUnblocked.map(sd => sd.sd_key + ' (' + (sd.priority || 'med') + ')').join(', ');
+
+  return {
+    subject: newlyUnblocked.length + ' SD(s) just unblocked — available for work',
+    body: 'Recent completions have unblocked new SDs:\n\n' +
+      newlyUnblocked.map(sd => '  - ' + sd.sd_key + ': ' + (sd.title || '').substring(0, 60)).join('\n') + '\n\n' +
+      'When you finish your current SD, consider picking up one of these.\n' +
+      'Run: /claim to see all available work.',
+    extra: { unblocked_sds: newlyUnblocked.map(sd => sd.sd_key) }
+  };
+}
+
+function evaluatePriorityRebalance(session, sdDetails, availableSDs) {
+  if (!sdDetails) return null;
+
+  // Don't suggest switching if already in EXEC or near completion
+  if (sdDetails.current_phase === 'EXEC' && (sdDetails.progress_percentage || 0) > 20) return null;
+  if ((sdDetails.progress_percentage || 0) > 80) return null;
+
+  const currentPriority = (sdDetails.priority || 'medium').toLowerCase();
+  if (currentPriority === 'high' || currentPriority === 'critical') return null;
+
+  // Find unclaimed HIGH/CRITICAL SDs
+  const highAvailable = availableSDs.filter(sd =>
+    (sd.priority || '').toLowerCase() === 'high' || (sd.priority || '').toLowerCase() === 'critical'
+  );
+
+  if (highAvailable.length === 0) return null;
+
+  return {
+    subject: highAvailable.length + ' HIGH priority SD(s) available — you are on ' + currentPriority,
+    body: 'You are working on ' + session.sd_id + ' (priority: ' + currentPriority + ').\n\n' +
+      'Higher priority SDs are unclaimed:\n' +
+      highAvailable.slice(0, 5).map(sd => '  - ' + sd.sd_key + ' (' + sd.priority + '): ' + (sd.title || '').substring(0, 50)).join('\n') + '\n\n' +
+      'Consider finishing your current SD quickly, or if early in the process, switching to a HIGH priority item.',
+    extra: { high_available: highAvailable.map(sd => sd.sd_key) }
+  };
+}
+
+// --- Main ---
+
+async function main() {
+  const now = new Date();
+  const sent = [];
+  const skipped = [];
+
+  // 1. Load active sessions with SD claims
+  // v_active_sessions lacks handoff_fail_count/has_uncommitted_changes — query base table
+  const { data: sessions, error: sessErr } = await supabase
+    .from('claude_sessions')
+    .select('session_id, sd_id, tty, current_branch, claimed_at, handoff_fail_count, has_uncommitted_changes, current_phase, heartbeat_at')
+    .not('sd_id', 'is', null)
+    .in('status', ['active', 'idle'])
+    .order('heartbeat_at', { ascending: false });
+
+  if (sessErr) {
+    console.log('ERROR: Failed to query sessions — ' + sessErr.message);
+    process.exit(1);
+  }
+
+  // Filter to sessions with recent heartbeat (< 5 min)
+  const fiveMinAgo = Date.now() - 5 * 60 * 1000;
+  const activeSessions = (sessions || []).filter(s =>
+    s.heartbeat_at && new Date(s.heartbeat_at).getTime() > fiveMinAgo
+  );
+  if (activeSessions.length === 0) {
+    console.log('[' + now.toLocaleTimeString() + '] COACHING: No active workers. Nothing to coach.');
+    return;
+  }
+
+  // 2. Load SD details for all claimed SDs
+  const claimedSdKeys = [...new Set(activeSessions.map(s => s.sd_id).filter(Boolean))];
+  const { data: sdData } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, description, status, current_phase, progress_percentage, priority, dependencies, claiming_session_id')
+    .in('sd_key', claimedSdKeys);
+
+  const sdMap = {};
+  (sdData || []).forEach(sd => { sdMap[sd.sd_key] = sd; });
+
+  // 3. Load all pending SDs (for dependency unlock and priority rebalance)
+  const { data: allPendingSDs } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, status, current_phase, progress_percentage, priority, dependencies')
+    .in('status', ['draft', 'in_progress', 'ready', 'pending_approval', 'completed'])
+    .limit(100);
+
+  const allSDs = allPendingSDs || [];
+  const activeClaims = new Set(activeSessions.map(s => s.sd_id));
+
+  // 4. Find recently completed SDs (last 15 minutes) for dependency unlock
+  const recentCutoff = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+  const { data: recentCompletions } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, completion_date')
+    .eq('status', 'completed')
+    .gte('completion_date', recentCutoff);
+
+  // 5. Compute available SDs (unclaimed, deps met)
+  const completedKeys = new Set(allSDs.filter(sd => sd.status === 'completed').map(sd => sd.sd_key));
+  const availableSDs = allSDs.filter(sd => {
+    if (sd.status === 'completed') return false;
+    if (activeClaims.has(sd.sd_key)) return false;
+    if (sd.dependencies && Array.isArray(sd.dependencies) && sd.dependencies.length > 0) {
+      if (!sd.dependencies.every(dep => completedKeys.has(dep))) return false;
+    }
+    return true;
+  });
+
+  // 6. Evaluate coaching for each active worker
+  for (const session of activeSessions) {
+    const sdDetails = sdMap[session.sd_id];
+
+    // WORKTREE_REMINDER
+    const worktree = evaluateWorktreeReminder(session, activeSessions.length);
+    if (worktree) {
+      const ok = await sendCoaching(session.session_id, 'WORKTREE_REMINDER', worktree.subject, worktree.body, { sd_id: session.sd_id });
+      (ok ? sent : skipped).push({ session: session.tty, type: 'WORKTREE_REMINDER' });
+    }
+
+    // SMALL_PR_REMINDER
+    const smallPR = evaluateSmallPRReminder(session, sdDetails);
+    if (smallPR) {
+      const ok = await sendCoaching(session.session_id, 'SMALL_PR_REMINDER', smallPR.subject, smallPR.body, { sd_id: session.sd_id });
+      (ok ? sent : skipped).push({ session: session.tty, type: 'SMALL_PR_REMINDER' });
+    }
+
+    // LEARN_REMINDER
+    const learn = evaluateLearnReminder(session, sdDetails);
+    if (learn) {
+      const ok = await sendCoaching(session.session_id, 'LEARN_REMINDER', learn.subject, learn.body, { sd_id: session.sd_id });
+      (ok ? sent : skipped).push({ session: session.tty, type: 'LEARN_REMINDER' });
+    }
+
+    // GATE_COMPLIANCE
+    const gate = evaluateGateCompliance(session);
+    if (gate) {
+      const ok = await sendCoaching(session.session_id, 'GATE_COMPLIANCE', gate.subject, gate.body, { sd_id: session.sd_id, fails: session.handoff_fail_count });
+      (ok ? sent : skipped).push({ session: session.tty, type: 'GATE_COMPLIANCE' });
+    }
+
+    // SUBAGENT_ROUTING
+    const subagent = evaluateSubagentRouting(session, sdDetails);
+    if (subagent) {
+      const ok = await sendCoaching(session.session_id, 'SUBAGENT_ROUTING', subagent.subject, subagent.body, { sd_id: session.sd_id });
+      (ok ? sent : skipped).push({ session: session.tty, type: 'SUBAGENT_ROUTING' });
+    }
+
+    // DEPENDENCY_UNLOCK (broadcast to all active workers)
+    const unlock = evaluateDependencyUnlock(session, recentCompletions || [], allSDs, activeClaims);
+    if (unlock) {
+      const ok = await sendCoaching(session.session_id, 'DEPENDENCY_UNLOCK', unlock.subject, unlock.body, unlock.extra);
+      (ok ? sent : skipped).push({ session: session.tty, type: 'DEPENDENCY_UNLOCK' });
+    }
+
+    // PRIORITY_REBALANCE
+    const rebalance = evaluatePriorityRebalance(session, sdDetails, availableSDs);
+    if (rebalance) {
+      const ok = await sendCoaching(session.session_id, 'PRIORITY_REBALANCE', rebalance.subject, rebalance.body, rebalance.extra);
+      (ok ? sent : skipped).push({ session: session.tty, type: 'PRIORITY_REBALANCE' });
+    }
+  }
+
+  // 7. Output summary
+  console.log('');
+  console.log('=== FLEET COACHING [' + now.toLocaleTimeString() + '] ===');
+  console.log('');
+  console.log('ACTIVE WORKERS: ' + activeSessions.length);
+  activeSessions.forEach(s => {
+    const sd = sdMap[s.sd_id];
+    const phase = sd ? sd.current_phase : '?';
+    const pct = sd ? (sd.progress_percentage || 0) + '%' : '?';
+    console.log('  ' + (s.tty || '?').padEnd(12) + (s.sd_id || '?').padEnd(45) + phase.padEnd(10) + pct);
+  });
+  console.log('');
+
+  if (sent.length > 0) {
+    console.log('COACHING SENT (' + sent.length + '):');
+    sent.forEach(s => console.log('  > ' + (s.session || '?').padEnd(12) + s.type));
+    console.log('');
+  }
+
+  if (skipped.length > 0) {
+    console.log('SKIPPED (cooldown active) (' + skipped.length + '):');
+    skipped.forEach(s => console.log('  - ' + (s.session || '?').padEnd(12) + s.type));
+    console.log('');
+  }
+
+  if (sent.length === 0 && skipped.length === 0) {
+    console.log('No coaching needed this cycle — all workers on track.');
+    console.log('');
+  }
+
+  // Summary stats
+  const typeCount = {};
+  sent.forEach(s => { typeCount[s.type] = (typeCount[s.type] || 0) + 1; });
+  if (Object.keys(typeCount).length > 0) {
+    console.log('SUMMARY:');
+    Object.entries(typeCount).forEach(([type, count]) => {
+      console.log('  ' + type.padEnd(25) + count + ' worker(s)');
+    });
+    console.log('');
+  }
+
+  console.log('=== COACHING COMPLETE ===');
+}
+
+main().catch(err => {
+  console.error('COACHING FATAL:', err.message);
+  process.exit(1);
+});

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1,0 +1,648 @@
+// Fleet Dashboard — Modular status display for the coordinator session
+// Usage: node scripts/fleet-dashboard.cjs [workers|orchestrator|available|coordination|health|qa|forecast|all]
+
+const os = require('os');
+const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const STALE_THRESHOLD = parseInt(process.env.STALE_SESSION_THRESHOLD_SECONDS, 10) || 300;
+
+// ── Helpers ──
+
+function bar(pct, width = 20) {
+  const p = Math.max(0, Math.min(100, pct || 0));
+  const filled = Math.round((p / 100) * width);
+  return '\u2588'.repeat(filled) + '\u2591'.repeat(width - filled);
+}
+
+function pad(str, len) {
+  return (str || '').substring(0, len).padEnd(len);
+}
+
+// ── Data Loading ──
+
+async function loadData() {
+  const [sessRes, allSessRes, childRes, workRes, coordRes, rawSessRes] = await Promise.all([
+    supabase
+      .from('v_active_sessions')
+      .select('session_id, sd_id, sd_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, tty, pid, track')
+      .not('sd_id', 'is', null)
+      .order('heartbeat_age_seconds', { ascending: true }),
+    supabase
+      .from('v_active_sessions')
+      .select('session_id, sd_id, computed_status, tty, heartbeat_age_seconds, heartbeat_age_human')
+      .order('heartbeat_age_seconds', { ascending: true }),
+    supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, title, status, current_phase, progress_percentage, completion_date, created_at, dependencies')
+      .like('sd_key', 'SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-%')
+      .order('sd_key', { ascending: true }),
+    supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, title, status, current_phase, progress_percentage, priority')
+      .in('status', ['draft', 'in_progress', 'ready', 'pending_approval'])
+      .not('sd_key', 'like', 'SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001%')
+      .limit(15),
+    supabase
+      .from('session_coordination')
+      .select('id, target_session, target_sd, message_type, subject, read_at, acknowledged_at, created_at')
+      .is('acknowledged_at', null)
+      .order('created_at', { ascending: false })
+      .limit(20),
+    supabase
+      .from('claude_sessions')
+      .select('session_id, sd_id, tty, status, heartbeat_at, pid')
+      .not('sd_id', 'is', null)
+      .order('heartbeat_at', { ascending: false })
+      .limit(30)
+  ]);
+
+  const sessions = sessRes.data || [];
+  const allSessions = allSessRes.data || [];
+  const children = childRes.data || [];
+  const workable = workRes.data || [];
+  const coordMessages = coordRes.data || [];
+  const rawSessions = rawSessRes.data || [];
+
+  const claimedSdIds = new Set(sessions.map(s => s.sd_id));
+  const activeSessions = sessions.filter(s => s.heartbeat_age_seconds < STALE_THRESHOLD);
+  const staleSessions = sessions.filter(s => s.heartbeat_age_seconds >= STALE_THRESHOLD);
+  const DEAD_THRESHOLD = STALE_THRESHOLD * 3; // 15min
+  const idleSessions = allSessions.filter(s => !s.sd_id && s.heartbeat_age_seconds < DEAD_THRESHOLD);
+
+  const completedChildren = children.filter(c => c.status === 'completed').length;
+  const totalChildren = children.length;
+  const orchPct = totalChildren > 0 ? Math.round((completedChildren / totalChildren) * 100) : 0;
+
+  const unclaimedChildren = children.filter(c => c.status !== 'completed' && !claimedSdIds.has(c.sd_key));
+  const unclaimedStandalone = workable.filter(sd => !claimedSdIds.has(sd.sd_key));
+
+  // Build SD status map for QA checks (includes all SDs, not just orchestrator children)
+  const allSdKeys = [...new Set(rawSessions.map(s => s.sd_id).filter(Boolean))];
+  let sdStatusMap = {};
+  children.forEach(c => { sdStatusMap[c.sd_key] = c; });
+  // Fetch any non-child SDs that workers are claiming
+  const missingKeys = allSdKeys.filter(k => !sdStatusMap[k]);
+  if (missingKeys.length > 0) {
+    const { data: extraSds } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, title, status, progress_percentage, completion_date')
+      .in('sd_key', missingKeys);
+    (extraSds || []).forEach(sd => { sdStatusMap[sd.sd_key] = sd; });
+  }
+
+  // Detect bare-shell SDs: title == description, no real scope, not child stubs
+  const pendingKeys = workable.map(sd => sd.sd_key);
+  let bareShells = [];
+  if (pendingKeys.length > 0) {
+    const { data: descData } = await supabase.from('strategic_directives_v2')
+      .select('sd_key, title, description, scope').in('sd_key', pendingKeys);
+    bareShells = (descData || []).filter(sd => {
+      if (sd.description && sd.description.startsWith('Child SD of')) return false;
+      const thin = !sd.description || sd.description === sd.title || (sd.description.length < 100 && sd.scope === sd.title);
+      return thin;
+    });
+  }
+
+  return {
+    sessions, allSessions, children, workable, coordMessages, rawSessions, sdStatusMap,
+    claimedSdIds, activeSessions, staleSessions, idleSessions,
+    completedChildren, totalChildren, orchPct,
+    unclaimedChildren, unclaimedStandalone, bareShellSDs: bareShells
+  };
+}
+
+// ── Section: Workers ──
+function printWorkers(d) {
+  const now = new Date();
+  console.log('');
+  console.log('WORKERS [' + now.toLocaleTimeString() + ']');
+  console.log('─'.repeat(72));
+
+  if (d.activeSessions.length === 0) {
+    console.log('  (no active workers)');
+  } else {
+    console.log('  ' + pad('Terminal', 12) + pad('SD', 10) + pad('Progress', 26) + pad('Phase', 8) + pad('Fails', 6) + pad('WIP', 5) + 'Heartbeat');
+    console.log('  ' + '─'.repeat(72));
+    for (const s of d.activeSessions) {
+      const child = d.children.find(c => c.sd_key === s.sd_id);
+      const pct = child ? child.progress_percentage : 0;
+      const phase = s.current_phase || (child ? child.current_phase : '?');
+      const shortSd = s.sd_id.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+      const fails = s.handoff_fail_count != null ? String(s.handoff_fail_count) : '-';
+      const wip = s.has_uncommitted_changes === true ? 'Y' : s.has_uncommitted_changes === false ? 'N' : '-';
+      const struggleTag = (s.handoff_fail_count || 0) > 3 ? ' [STRUGGLING]' : '';
+      console.log('  ' + pad(s.tty, 12) + pad(shortSd, 10) + bar(pct) + ' ' + pad(pct + '%', 5) + pad(phase, 8) + pad(fails, 6) + pad(wip, 5) + s.heartbeat_age_human + struggleTag);
+    }
+  }
+
+  if (d.staleSessions.length > 0) {
+    console.log('');
+    console.log('  Stale (' + d.staleSessions.length + '):');
+    for (const s of d.staleSessions) {
+      const shortSd = s.sd_id.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+      console.log('  ' + pad(s.tty, 12) + pad(shortSd, 10) + s.heartbeat_age_human);
+    }
+  }
+
+  if (d.idleSessions.length > 0) {
+    console.log('');
+    console.log('  Idle — No Claim (' + d.idleSessions.length + '):');
+    for (const s of d.idleSessions) {
+      const age = s.heartbeat_age_human || (s.heartbeat_age_seconds < 60 ? s.heartbeat_age_seconds + 's ago' : Math.round(s.heartbeat_age_seconds / 60) + 'm ago');
+      const staleTag = s.heartbeat_age_seconds >= STALE_THRESHOLD ? ' [STALE]' : '';
+      console.log('  ' + pad(s.tty, 12) + pad('—', 10) + pad('', 26) + pad('idle', 14) + age + staleTag);
+    }
+  }
+
+  console.log('');
+}
+
+// ── Section: Orchestrator ──
+
+function printOrchestrator(d) {
+  console.log('ORCHESTRATOR ' + bar(d.orchPct, 25) + ' ' + d.completedChildren + '/' + d.totalChildren + ' (' + d.orchPct + '%)');
+  console.log('─'.repeat(72));
+
+  for (const c of d.children) {
+    const letter = c.sd_key.slice(-1);
+    const pct = c.progress_percentage || 0;
+    const isClaimed = d.claimedSdIds.has(c.sd_key);
+    const icon = c.status === 'completed' ? '\u2705' : isClaimed ? '\uD83D\uDD12' : '\uD83D\uDCCB';
+    const phase = c.status === 'completed' ? 'DONE' : c.current_phase;
+    console.log('  ' + letter + '  ' + bar(pct, 15) + ' ' + pad(pct + '%', 5) + ' ' + icon + ' ' + pad(phase, 12) + c.title.substring(0, 38));
+  }
+
+  console.log('');
+}
+
+// ── Section: Available ──
+function printAvailable(d) {
+  const total = d.unclaimedChildren.length + d.unclaimedStandalone.length;
+  console.log('AVAILABLE FOR CLAIM (' + total + ')');
+  console.log('─'.repeat(72));
+
+  if (total === 0) {
+    console.log('  (all SDs claimed or completed)');
+    console.log('');
+    return;
+  }
+
+  if (d.unclaimedChildren.length > 0) {
+    console.log('  Orchestrator Children:');
+    for (const c of d.unclaimedChildren) {
+      const letter = c.sd_key.slice(-1);
+      console.log('    Child ' + letter + '  ' + pad(c.title, 48) + c.status);
+    }
+  }
+
+  if (d.unclaimedStandalone.length > 0) {
+    console.log('  Standalone SDs:');
+    for (const sd of d.unclaimedStandalone) {
+      const shortKey = sd.sd_key.replace('SD-LEO-', '').replace('SD-', '').substring(0, 22);
+      const prio = sd.priority === 'high' ? 'HIGH' : 'MED';
+      console.log('    ' + pad(shortKey, 24) + pad(sd.title.substring(0, 38), 40) + prio);
+    }
+  }
+
+  console.log('');
+}
+
+// ── Section: Coordination ──
+function printCoordination(d) {
+  console.log('COORDINATION MESSAGES');
+  console.log('─'.repeat(72));
+
+  if (d.coordMessages.length === 0) {
+    console.log('  (no pending messages)');
+    console.log('');
+    return;
+  }
+
+  const unread = d.coordMessages.filter(m => !m.read_at).length;
+  const pending = d.coordMessages.filter(m => m.read_at && !m.acknowledged_at).length;
+  console.log('  ' + unread + ' unread, ' + pending + ' pending acknowledgment');
+  console.log('');
+
+  console.log('  ' + pad('Type', 20) + pad('Target', 16) + pad('Status', 10) + 'Subject');
+  console.log('  ' + '─'.repeat(68));
+  for (const m of d.coordMessages.slice(0, 10)) {
+    const status = m.acknowledged_at ? 'ACKED' : m.read_at ? 'READ' : 'UNREAD';
+    const target = (m.target_session || '').replace('session_', '').substring(0, 14);
+    console.log('  ' + pad(m.message_type, 20) + pad(target, 16) + pad(status, 10) + (m.subject || '').substring(0, 30));
+  }
+
+  console.log('');
+}
+
+// ── Section: Health ──
+function printHealth(d) {
+  const health = d.activeSessions.length >= 3 ? 'HEALTHY' : d.activeSessions.length >= 1 ? 'DEGRADED' : 'DOWN';
+  const icon = health === 'HEALTHY' ? '[OK]' : health === 'DEGRADED' ? '[!!]' : '[XX]';
+
+  console.log('FLEET HEALTH ' + icon);
+  console.log('─'.repeat(72));
+  console.log('  Active:  ' + d.activeSessions.length + ' workers');
+  console.log('  Unclaimed: ' + d.idleSessions.length + ' sessions (no SD claim)');
+  console.log('  Stale:   ' + d.staleSessions.length + ' sessions');
+  console.log('  Orch:    ' + d.completedChildren + '/' + d.totalChildren + ' children complete (' + d.orchPct + '%)');
+  console.log('  Status:  ' + health);
+  console.log('');
+}
+
+// ── Section: QA ──
+function printQA(d) {
+  const now = Date.now();
+  const issues = [];
+
+  // Filter raw sessions to recent (< 10 min heartbeat)
+  const recentRaw = d.rawSessions.filter(s => {
+    const age = (now - new Date(s.heartbeat_at).getTime()) / 1000;
+    return age < 600;
+  });
+
+  // QA 1: Working on completed SD
+  const onCompleted = recentRaw.filter(s => {
+    const sd = d.sdStatusMap[s.sd_id];
+    return sd && sd.status === 'completed';
+  });
+  onCompleted.forEach(s => {
+    const sd = d.sdStatusMap[s.sd_id];
+    const shortSd = s.sd_id.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+    issues.push({
+      severity: 'HIGH',
+      check: 'COMPLETED_SD',
+      msg: s.tty + ' working on ' + shortSd + ' — already completed' + (sd.completion_date ? ' at ' + new Date(sd.completion_date).toLocaleTimeString() : '')
+    });
+  });
+
+  // QA 2: Duplicate claims
+  const bySd = {};
+  recentRaw.forEach(s => {
+    if (!bySd[s.sd_id]) bySd[s.sd_id] = [];
+    bySd[s.sd_id].push(s);
+  });
+  Object.entries(bySd).filter(([, arr]) => arr.length > 1).forEach(([sdId, claimants]) => {
+    const shortSd = sdId.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+    issues.push({
+      severity: 'HIGH',
+      check: 'DUPLICATE',
+      msg: shortSd + ' claimed by ' + claimants.length + ' sessions: ' + claimants.map(s => s.tty).join(', ')
+    });
+  });
+
+  // QA 3: Orphaned claims (SD not in DB)
+  recentRaw.filter(s => !d.sdStatusMap[s.sd_id]).forEach(s => {
+    issues.push({
+      severity: 'MED',
+      check: 'ORPHAN',
+      msg: s.tty + ' claims ' + s.sd_id.substring(0, 30) + '… — SD not found in DB'
+    });
+  });
+
+  // QA 4: Claim with bad session status
+  recentRaw.filter(s => s.sd_id && !['active', 'idle'].includes(s.status)).forEach(s => {
+    const shortSd = s.sd_id.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+    issues.push({
+      severity: 'LOW',
+      check: 'BAD_STATUS',
+      msg: s.tty + ' status=' + s.status + ' but claims ' + shortSd
+    });
+  });
+
+  // QA 5: Progress 100% but not completed
+  Object.values(d.sdStatusMap).filter(sd => sd.progress_percentage >= 100 && sd.status !== 'completed').forEach(sd => {
+    const shortSd = sd.sd_key.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+    issues.push({
+      severity: 'MED',
+      check: 'STUCK_100',
+      msg: shortSd + ' at 100% but status=' + sd.status + ' — not marked completed'
+    });
+  });
+
+  // QA 6: SDs stuck in pending_approval with no active claiming session
+  const pendingApproval = Object.values(d.sdStatusMap).filter(sd => sd.status === 'pending_approval');
+  const activeClaimSdIds = new Set(recentRaw.map(s => s.sd_id).filter(Boolean));
+  pendingApproval.filter(sd => !activeClaimSdIds.has(sd.sd_key)).forEach(sd => {
+    const shortSd = sd.sd_key.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+    issues.push({
+      severity: 'HIGH',
+      check: 'STUCK_APPROVAL',
+      msg: shortSd + ' stuck in pending_approval — no session working on it (sweep will auto-reset to draft)'
+    });
+  });
+  // QA 7: Bare-shell SDs — title repeated as description, no real scope
+  (d.bareShellSDs || []).forEach(sd => {
+    const shortSd = sd.sd_key.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+    issues.push({ severity: 'MED', check: 'BARE_SHELL', msg: shortSd + ' has no real description — workers will waste cycles on LEAD setup' });
+  });
+  // Print
+  const icon = issues.length === 0 ? '[PASS]' : '[' + issues.length + ' ISSUES]';
+  console.log('QA CHECKS ' + icon);
+  console.log('─'.repeat(72));
+
+  if (issues.length === 0) {
+    console.log('  All checks passed. Fleet is clean.');
+  } else {
+    const severityIcon = { HIGH: '!!', MED: '! ', LOW: '- ' };
+    for (const issue of issues) {
+      console.log('  ' + severityIcon[issue.severity] + ' [' + pad(issue.check, 12) + '] ' + issue.msg);
+    }
+  }
+
+  console.log('');
+}
+
+// ── Section: Forecast ──
+async function printForecast(d) {
+  const now = new Date();
+  console.log('FORECAST');
+  console.log('─'.repeat(72));
+  const orchCompleted = d.children.filter(c => c.status === 'completed' && c.completion_date);
+  const orchRemaining = d.children.filter(c => c.status !== 'completed');
+
+  if (orchCompleted.length >= 2) {
+    const sorted = orchCompleted
+      .map(c => ({ ...c, completedAt: new Date(c.completion_date) }))
+      .sort((a, b) => a.completedAt - b.completedAt);
+
+    const firstCompletion = sorted[0].completedAt;
+    const lastCompletion = sorted[sorted.length - 1].completedAt;
+    const elapsedHours = (lastCompletion - firstCompletion) / (1000 * 60 * 60);
+    const velocity = elapsedHours > 0 ? (sorted.length - 1) / elapsedHours : 0;
+
+    let recentVelocity = velocity;
+    if (sorted.length >= 3) {
+      const recent = sorted.slice(-3);
+      const recentElapsed = (recent[recent.length - 1].completedAt - recent[0].completedAt) / (1000 * 60 * 60);
+      if (recentElapsed > 0) recentVelocity = (recent.length - 1) / recentElapsed;
+    }
+
+    const timeSinceLast = (now - lastCompletion) / (1000 * 60);
+    const timeSinceStr = timeSinceLast < 60
+      ? Math.round(timeSinceLast) + 'min ago'
+      : Math.round(timeSinceLast / 60 * 10) / 10 + 'h ago';
+
+    const effectiveVelocity = recentVelocity > 0 ? recentVelocity : velocity;
+    const orchEtaHours = effectiveVelocity > 0 ? orchRemaining.length / effectiveVelocity : null;
+
+    console.log('  ORCHESTRATOR (Stage Venture Workflow)');
+    console.log('  ' + bar(d.orchPct, 25) + ' ' + orchCompleted.length + '/' + d.totalChildren + ' (' + d.orchPct + '%)');
+    console.log('  Velocity:   ' + velocity.toFixed(1) + ' SDs/hr (overall)  ' + recentVelocity.toFixed(1) + ' SDs/hr (recent)');
+    console.log('  Last finish: ' + timeSinceStr);
+
+    if (orchRemaining.length === 0) {
+      console.log('  Status:     COMPLETE');
+    } else if (orchEtaHours !== null) {
+      const etaTime = new Date(now.getTime() + orchEtaHours * 60 * 60 * 1000);
+      const etaStr = orchEtaHours < 1
+        ? Math.round(orchEtaHours * 60) + ' minutes'
+        : Math.round(orchEtaHours * 10) / 10 + ' hours';
+      console.log('  Remaining:  ' + orchRemaining.length + ' child(ren)  ETA: ~' + etaStr + ' (around ' + etaTime.toLocaleTimeString() + ')');
+    }
+  } else if (orchRemaining.length === 0) {
+    console.log('  ORCHESTRATOR: COMPLETE (' + d.totalChildren + '/' + d.totalChildren + ')');
+  } else {
+    console.log('  ORCHESTRATOR: ' + orchCompleted.length + '/' + d.totalChildren + ' (need more data for velocity)');
+  }
+
+  console.log('');
+  // Full Queue Forecast — all pending SDs across the entire queue
+  const { data: allPending } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, status, priority, current_phase, progress_percentage, dependencies')
+    .in('status', ['draft', 'in_progress', 'ready', 'planning', 'pending_approval'])
+    .order('priority', { ascending: true });
+
+  const pending = allPending || [];
+  const activeWorkers = d.activeSessions.length;
+
+  // Categorize pending SDs
+  const inProgress = pending.filter(sd => sd.status === 'in_progress' || (sd.progress_percentage || 0) > 0);
+  const notStarted = pending.filter(sd => sd.status !== 'in_progress' && (sd.progress_percentage || 0) === 0);
+  const highPrio = pending.filter(sd => sd.priority === 'high' || sd.priority === 'critical');
+
+  console.log('  FULL QUEUE');
+  console.log('  Pending SDs:   ' + pending.length + ' total');
+  console.log('  In progress:   ' + inProgress.length);
+  console.log('  Not started:   ' + notStarted.length);
+  if (highPrio.length > 0) {
+    console.log('  High priority:  ' + highPrio.length);
+  }
+  console.log('  Active workers: ' + activeWorkers);
+
+  // Estimate full queue ETA reusing velocity from above
+  if (orchCompleted.length >= 2 && pending.length > 0) {
+    const s2 = orchCompleted.map(c => ({ ...c, completedAt: new Date(c.completion_date) })).sort((a, b) => a.completedAt - b.completedAt);
+    const vel = ((s2[s2.length - 1].completedAt - s2[0].completedAt) / 3600000);
+    const v = vel > 0 ? (s2.length - 1) / vel : 0;
+    if (v > 0) {
+      const h = pending.length / v;
+      const etaStr = h < 1 ? Math.round(h * 60) + ' minutes' : h < 24 ? Math.round(h * 10) / 10 + ' hours' : Math.round(h / 24 * 10) / 10 + ' days';
+      console.log('  Queue ETA:     ~' + etaStr + ' at current velocity (' + v.toFixed(1) + ' SDs/hr)');
+    }
+  }
+  console.log('');
+  console.log('  ' + '─'.repeat(66));
+
+  if (orchRemaining.length === 0 && pending.length === 0) {
+    console.log('  Queue is clear. All SDs complete. Nice work.');
+  } else if (orchRemaining.length === 0) {
+    console.log('  Orchestrator is done! ' + pending.length + ' standalone SDs remain in the queue.');
+    console.log('  ' + (activeWorkers > 0 ? activeWorkers + ' worker(s) can roll into the next priority items.' : 'Spin up workers to start burning through the backlog.'));
+  } else if (orchRemaining.length <= 2) {
+    console.log('  Orchestrator almost done — ' + orchRemaining.length + ' child(ren) left. Then ' + pending.length + ' more.');
+  } else {
+    console.log('  ' + activeWorkers + ' workers active across ' + pending.length + ' pending SDs.' + (highPrio.length > 0 ? ' ' + highPrio.length + ' high-priority.' : ''));
+  }
+
+  console.log('');
+}
+
+// ── Section: Predictions ──
+async function printPredictions(d) {
+  const signals = [];
+
+  // 1. Capacity — estimate real fleet size using heartbeat freshness
+  // Sessions with heartbeat < 3min are likely real; >= 3min are likely ghosts (exited without cleanup)
+  const ALIVE_THRESHOLD = 180; // 3 minutes
+  const aliveIdle = d.idleSessions.filter(s => s.heartbeat_age_seconds < ALIVE_THRESHOLD);
+  const ghostIdle = d.idleSessions.filter(s => s.heartbeat_age_seconds >= ALIVE_THRESHOLD);
+  const availableCount = d.unclaimedStandalone.length + d.unclaimedChildren.length;
+  // +1 for coordinator session (this session — not in fleet data since it has no SD claim)
+  const estimatedFleet = d.activeSessions.length + aliveIdle.length + 1;
+  const claimedCount = d.activeSessions.length;
+  const utilPct = estimatedFleet > 0 ? Math.round((claimedCount / estimatedFleet) * 100) : 0;
+
+  if (aliveIdle.length > 0 && availableCount > 0) {
+    signals.push({
+      icon: '!!',
+      label: 'CAPACITY',
+      msg: aliveIdle.length + ' idle / ' + availableCount + ' available — fleet ~' + estimatedFleet + ' sessions at ' + utilPct + '% utilization'
+        + (ghostIdle.length > 0 ? ' (' + ghostIdle.length + ' ghost sessions excluded)' : '')
+    });
+  } else if (aliveIdle.length > 0 && availableCount === 0) {
+    signals.push({
+      icon: 'OK',
+      label: 'CAPACITY',
+      msg: 'Fleet ~' + estimatedFleet + ' sessions — ' + aliveIdle.length + ' idle but 0 SDs available, waiting on completions/unblocks'
+    });
+  } else if (aliveIdle.length === 0 && availableCount > 0 && claimedCount > 0) {
+    signals.push({
+      icon: 'OK',
+      label: 'CAPACITY',
+      msg: 'Fleet ~' + estimatedFleet + ' sessions, all claimed — ' + availableCount + ' SDs queued for next free worker'
+        + (ghostIdle.length > 0 ? ' (' + ghostIdle.length + ' ghost sessions excluded)' : '')
+    });
+  } else if (aliveIdle.length === 0 && claimedCount > 0) {
+    signals.push({
+      icon: 'OK',
+      label: 'CAPACITY',
+      msg: 'Fleet ~' + estimatedFleet + ' sessions, fully utilized'
+    });
+  }
+
+  // 2. Dependency unlock forecast — what SDs will completing current work unblock?
+  const completedKeys = new Set(d.children.filter(c => c.status === 'completed').map(c => c.sd_key));
+  const claimedSdKeys = [...d.claimedSdIds];
+  // Get all blocked SDs with their dependencies
+  const { data: allBlockedRaw } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, dependencies, status')
+    .in('status', ['draft', 'in_progress', 'ready', 'planning'])
+    .not('dependencies', 'is', null);
+
+  const blocked = (allBlockedRaw || []).filter(sd => {
+    const deps = parseDeps(sd.dependencies);
+    return deps.length > 0 && deps.some(dep => !completedKeys.has(dep));
+  });
+
+  // For each currently claimed SD, count how many blocked SDs it would unblock
+  for (const claimedKey of claimedSdKeys) {
+    const wouldUnblock = blocked.filter(sd => {
+      const deps = parseDeps(sd.dependencies);
+      const unresolvedDeps = deps.filter(dep => !completedKeys.has(dep));
+      return unresolvedDeps.length === 1 && unresolvedDeps[0] === claimedKey;
+    });
+    if (wouldUnblock.length > 0) {
+      const shortKey = claimedKey.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*?-/, '');
+      const names = wouldUnblock.slice(0, 3).map(s => s.sd_key.replace('SD-LEO-ORCH-', '').replace(/^SD-.*?-/, '').substring(0, 20));
+      signals.push({
+        icon: '>>',
+        label: 'UNLOCK',
+        msg: 'When ' + shortKey + ' completes → unblocks ' + wouldUnblock.length + ' SD(s): ' + names.join(', ')
+      });
+    }
+  }
+
+  // 3. Heartbeat aging — workers approaching stale threshold (FIX #5: with coordination messages)
+  const STALE_WARNING = STALE_THRESHOLD * 0.6; // 60% of 5min = 3min
+  const agingWorkers = [];
+  for (const s of d.activeSessions) {
+    if (s.heartbeat_age_seconds >= STALE_WARNING) {
+      const remaining = Math.round(STALE_THRESHOLD - s.heartbeat_age_seconds);
+      const shortSd = s.sd_id.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+      signals.push({
+        icon: '~~',
+        label: 'AGING',
+        msg: s.tty + ' on ' + shortSd + ' — heartbeat aging (' + s.heartbeat_age_human + '), stale in ~' + remaining + 's'
+      });
+      agingWorkers.push(s);
+    }
+  }
+
+  // Send STALE_WARNING coordination messages for aging workers
+  for (const s of agingWorkers) {
+    // Check if we already sent a stale warning recently (avoid spam)
+    const { data: existingWarn } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('target_session', s.session_id)
+      .eq('message_type', 'STALE_WARNING')
+      .is('acknowledged_at', null)
+      .limit(1);
+
+    if (existingWarn && existingWarn.length > 0) continue;
+
+    await supabase
+      .from('session_coordination')
+      .insert({
+        target_session: s.session_id,
+        target_sd: s.sd_id,
+        message_type: 'STALE_WARNING',
+        subject: 'Heartbeat aging on ' + s.sd_id.split('-').pop() + ' — approaching stale threshold',
+        body: 'Your session on ' + s.sd_id + ' has not heartbeated in ' + s.heartbeat_age_human + '. If you are still working, send a heartbeat. If stuck, consider releasing the claim.',
+        payload: { session_id: s.session_id, heartbeat_age: s.heartbeat_age_seconds, stale_threshold: STALE_THRESHOLD },
+        sender_type: 'dashboard'
+      }).then(() => {}).catch(() => {}); // Non-blocking
+  }
+
+  // Print
+  console.log('PREDICTIONS');
+  console.log('─'.repeat(72));
+  if (signals.length === 0) {
+    console.log('  Fleet nominal — no predictive signals.');
+  } else {
+    for (const sig of signals) {
+      console.log('  ' + sig.icon + ' [' + pad(sig.label, 10) + '] ' + sig.msg);
+    }
+  }
+  console.log('');
+}
+
+// Helper: parse dependencies from various formats (string, array, JSONB)
+function parseDeps(deps) {
+  if (!deps) return [];
+  if (Array.isArray(deps)) return deps.map(d => typeof d === 'string' ? d : (d.sd_key || d.id || '')).filter(Boolean);
+  if (typeof deps === 'string') {
+    try { return parseDeps(JSON.parse(deps)); } catch (e) { return deps.split(',').map(s => s.trim()).filter(Boolean); }
+  }
+  return [];
+}
+
+// ── Main ──
+
+async function main() {
+  const section = (process.argv[2] || 'all').toLowerCase();
+  const d = await loadData();
+
+  const sections = {
+    workers:       () => printWorkers(d),
+    orchestrator:  () => printOrchestrator(d),
+    available:     () => printAvailable(d),
+    coordination:  () => printCoordination(d),
+    health:        () => printHealth(d),
+    qa:            () => printQA(d),
+    forecast:      async () => await printForecast(d),
+    predictions:   async () => await printPredictions(d),
+    all:           async () => {
+      printWorkers(d);
+      printOrchestrator(d);
+      printAvailable(d);
+      printCoordination(d);
+      printHealth(d);
+      printQA(d);
+      await printForecast(d);
+      await printPredictions(d);
+    }
+  };
+
+  const fn = sections[section];
+  if (!fn) {
+    console.log('Usage: node scripts/fleet-dashboard.cjs [section]');
+    console.log('Sections: workers, orchestrator, available, coordination, health, qa, forecast, predictions, all');
+    process.exit(1);
+  }
+
+  await fn();
+}
+
+main().catch(err => {
+  console.error('DASHBOARD ERROR:', err.message);
+  process.exit(1);
+});

--- a/scripts/fleet-eta-stats.cjs
+++ b/scripts/fleet-eta-stats.cjs
@@ -1,0 +1,192 @@
+/**
+ * fleet-eta-stats.cjs — Query historical SD completion data for ETA estimation.
+ *
+ * Run once per coordinator session to get data-driven baselines.
+ * Groups handoff durations by sd_type + child/standalone, returns medians.
+ * Reports both wall-clock and active-time (excluding idle gaps >30m).
+ *
+ * Usage: node scripts/fleet-eta-stats.cjs
+ */
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+// Idle gap threshold: gaps longer than this between handoffs are excluded from active-time
+const IDLE_GAP_THRESHOLD_MINUTES = 30;
+
+// SD key prefix patterns for sub-bucketing
+const KEY_PREFIXES = [
+  { pattern: /^SD-.*-OPS-/, label: 'OPS' },
+  { pattern: /^SD-.*-LEARN-FIX-/, label: 'LEARN-FIX' },
+  { pattern: /^SD-.*-WIRE-/, label: 'WIRE' },
+  { pattern: /^SD-.*-BLUEPRINT-/, label: 'BLUEPRINT' },
+  { pattern: /^SD-.*-MAN-/, label: 'MAN' },
+];
+
+function getKeyPrefix(sdKey) {
+  if (!sdKey) return null;
+  for (const { pattern, label } of KEY_PREFIXES) {
+    if (pattern.test(sdKey)) return label;
+  }
+  return null;
+}
+
+function stats(arr) {
+  if (!arr.length) return { n: 0, avg: 0, med: 0, p25: 0, p75: 0, min: 0, max: 0 };
+  arr.sort((a, b) => a - b);
+  return {
+    n: arr.length,
+    avg: Math.round(arr.reduce((a, b) => a + b, 0) / arr.length),
+    med: arr[Math.floor(arr.length / 2)],
+    p25: arr[Math.floor(arr.length * 0.25)],
+    p75: arr[Math.floor(arr.length * 0.75)],
+    min: arr[0],
+    max: arr[arr.length - 1],
+  };
+}
+
+/**
+ * Compute active-time from sorted handoff timestamps, excluding idle gaps
+ */
+function computeActiveMinutes(timestamps) {
+  if (timestamps.length < 2) return 0;
+  let active = 0;
+  for (let i = 0; i < timestamps.length - 1; i++) {
+    const interval = Math.round((new Date(timestamps[i + 1]) - new Date(timestamps[i])) / 60000);
+    if (interval <= IDLE_GAP_THRESHOLD_MINUTES) {
+      active += interval;
+    }
+  }
+  return active;
+}
+
+(async () => {
+  // 1. Get all handoffs
+  const { data: handoffs, error: e1 } = await sb.from('sd_phase_handoffs')
+    .select('sd_id, from_phase, to_phase, created_at, status')
+    .order('created_at', { ascending: true })
+    .limit(1000);
+
+  if (e1) { console.error('Handoff query error:', e1.message); process.exit(1); }
+
+  // 2. Get SD metadata
+  const sdIds = [...new Set(handoffs.map(h => h.sd_id))];
+  const { data: sdMeta, error: e2 } = await sb.from('strategic_directives_v2')
+    .select('id, sd_key, parent_sd_id, sd_type, status, current_phase')
+    .in('id', sdIds);
+
+  if (e2) { console.error('SD query error:', e2.message); process.exit(1); }
+
+  const sdMap = {};
+  for (const s of (sdMeta || [])) sdMap[s.id] = s;
+
+  // 3. Group handoffs by sd_id → compute total duration and phase breakdown
+  const bySD = {};
+  for (const h of handoffs) {
+    if (!bySD[h.sd_id]) bySD[h.sd_id] = [];
+    bySD[h.sd_id].push(h);
+  }
+
+  const rows = [];
+  for (const [sdId, hs] of Object.entries(bySD)) {
+    if (hs.length < 2) continue;
+    const meta = sdMap[sdId];
+    if (!meta) continue;
+
+    const timestamps = hs.map(h => h.created_at);
+    const first = new Date(timestamps[0]);
+    const last = new Date(timestamps[timestamps.length - 1]);
+    const totalMin = Math.round((last - first) / 60000);
+    if (totalMin <= 0 || totalMin > 1440) continue;
+
+    // Compute active-time (excluding idle gaps)
+    const activeMin = computeActiveMinutes(timestamps);
+
+    const phaseTotal = {};
+    for (let i = 0; i < hs.length - 1; i++) {
+      const dur = Math.round((new Date(hs[i + 1].created_at) - new Date(hs[i].created_at)) / 60000);
+      const phase = hs[i].to_phase;
+      phaseTotal[phase] = (phaseTotal[phase] || 0) + dur;
+    }
+
+    rows.push({
+      key: meta.sd_key,
+      isChild: !!meta.parent_sd_id,
+      sdType: meta.sd_type || 'unknown',
+      totalMin,
+      activeMin,
+      keyPrefix: getKeyPrefix(meta.sd_key),
+      lead: phaseTotal['LEAD'] || 0,
+      plan: phaseTotal['PLAN'] || 0,
+      exec: phaseTotal['EXEC'] || 0,
+    });
+  }
+
+  // 4. Group by type bucket and compute stats
+  const groups = {};
+  for (const r of rows) {
+    const key = `${r.isChild ? 'child' : 'standalone'}/${r.sdType}`;
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(r);
+  }
+
+  console.log('=== ETA REFERENCE DATA ===');
+  console.log(`Source: ${rows.length} completed SDs with handoff data`);
+  console.log(`Idle gap threshold: ${IDLE_GAP_THRESHOLD_MINUTES}m (gaps longer excluded from active-time)\n`);
+
+  console.log('TYPE BUCKET STATS (wall-clock / active-time):');
+  const sortedKeys = Object.keys(groups).sort();
+  for (const key of sortedKeys) {
+    const items = groups[key];
+    const sW = stats(items.map(i => i.totalMin));
+    const sA = stats(items.map(i => i.activeMin));
+    const sL = stats(items.map(i => i.lead));
+    const sP = stats(items.map(i => i.plan));
+    const sE = stats(items.map(i => i.exec));
+    const ratio = sA.med > 0 ? (sW.med / sA.med).toFixed(1) : '-';
+    console.log(`  ${key}: n=${sW.n}`);
+    console.log(`    wall-clock: med=${sW.med}m avg=${sW.avg}m p25=${sW.p25}m p75=${sW.p75}m range=${sW.min}-${sW.max}m`);
+    console.log(`    active-time: med=${sA.med}m avg=${sA.avg}m p25=${sA.p25}m p75=${sA.p75}m range=${sA.min}-${sA.max}m`);
+    console.log(`    ratio: ${ratio}x (wall/active) ${ratio > 1.5 ? '— significant idle time' : ''}`);
+    console.log(`    phases: LEAD med=${sL.med}m | PLAN med=${sP.med}m | EXEC med=${sE.med}m`);
+  }
+
+  // 5. Sub-bucket breakdown for standalone SDs by key prefix
+  console.log('\nSUB-BUCKET BREAKDOWN (by SD key prefix):');
+  const standaloneRows = rows.filter(r => !r.isChild && r.keyPrefix);
+  const subBuckets = {};
+  for (const r of standaloneRows) {
+    const bk = `${r.sdType}/${r.keyPrefix}`;
+    if (!subBuckets[bk]) subBuckets[bk] = [];
+    subBuckets[bk].push(r);
+  }
+
+  const subKeys = Object.keys(subBuckets).sort();
+  if (subKeys.length === 0) {
+    console.log('  (no matching key prefix patterns found)');
+  }
+  for (const key of subKeys) {
+    const items = subBuckets[key];
+    const sA = stats(items.map(i => i.activeMin));
+    const sW = stats(items.map(i => i.totalMin));
+    const reliable = sA.n >= 5 ? 'reliable' : `low-n (${sA.n})`;
+    console.log(`  ${key}: n=${sA.n} (${reliable}) | active med=${sA.med}m | wall med=${sW.med}m`);
+  }
+
+  // 6. Show pending SDs for matching
+  console.log('\nPENDING SDs:');
+  const { data: pending } = await sb.from('strategic_directives_v2')
+    .select('sd_key, title, sd_type, parent_sd_id, status, current_phase, progress_percentage')
+    .in('status', ['draft', 'in_progress', 'ready', 'planning']);
+
+  for (const sd of (pending || [])) {
+    const bucket = `${sd.parent_sd_id ? 'child' : 'standalone'}/${sd.sd_type || '?'}`;
+    const ref = groups[bucket];
+    const refStats = ref ? stats(ref.map(i => i.activeMin)) : null;
+    const match = refStats ? `matched: ${bucket} (n=${refStats.n}, active med=${refStats.med}m)` : `no match for ${bucket}`;
+    console.log(`  ${sd.sd_key} | ${bucket} | phase:${sd.current_phase} | ${sd.progress_percentage}% | ${match}`);
+  }
+
+  console.log('\n=== END ===');
+})().catch(e => { console.error(e.message); process.exit(1); });

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -97,6 +97,10 @@ async function main() {
         'SD_BLOCKED': 'SD BLOCKED',
         'SD_COMPLETED_NEARBY': 'NEARBY SD COMPLETED',
         'PRIORITY_CHANGE': 'PRIORITY CHANGE',
+        'COACHING': 'COACHING' + (msg.payload?.coaching_type ? ': ' + msg.payload.coaching_type : ''),
+        'IDENTITY_COLLISION': 'IDENTITY COLLISION',
+        'CLAIM_REMINDER': 'CLAIM REMINDER',
+        'STALE_WARNING': 'STALE WARNING',
         'INFO': 'INFO'
       }[msg.message_type] || msg.message_type;
 

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1,0 +1,887 @@
+/**
+ * Stale Session Sweep — Automated Conflict Resolution & Coordination
+ *
+ * Designed to run on a recurring loop: /loop 5m node scripts/stale-session-sweep.cjs
+ *
+ * What it does:
+ * 1. Scans all sessions with active SD claims
+ * 2. Detects stale sessions (heartbeat > threshold)
+ * 2b. IDENTITY COLLISION DETECTION — reads .claude/session-identity/ marker files
+ *     to detect multiple live Claude Code PIDs sharing one session_id. Splits
+ *     colliding sessions into separate DB records with unique terminal_ids.
+ * 2c. NPM INSTALL LOCK — checks/cleans stale npm install locks to prevent
+ *     concurrent installs from corrupting node_modules.
+ * 3. Checks PID liveness for same-host sessions
+ * 4. Auto-releases dead claims (stale + PID dead)
+ * 5. Detects and AUTO-RESOLVES duplicate claims on the same SD
+ * 6. Writes coordination messages for active sessions
+ * 7. Outputs a summary to stdout
+ *
+ * Safe to run repeatedly — fully idempotent.
+ */
+
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+const { createClient } = require('@supabase/supabase-js');
+const { randomUUID } = require('crypto');
+require('dotenv').config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+const STALE_THRESHOLD_SECONDS = parseInt(process.env.STALE_SESSION_THRESHOLD_SECONDS, 10) || 300;
+const LOCAL_HOSTNAME = os.hostname();
+
+function isProcessRunning(pid) {
+  if (!pid || typeof pid !== 'number') return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    if (err.code === 'ESRCH') return false;
+    if (err.code === 'EPERM') return true; // exists but no permission
+    return false;
+  }
+}
+
+function bar(pct, width = 20) {
+  const filled = Math.round((pct / 100) * width);
+  return '\u2588'.repeat(filled) + '\u2591'.repeat(width - filled);
+}
+
+// --- Layer 1: Terminal Identity Collision Detection ---
+// Reads .claude/session-identity/pid-*.json marker files to detect when multiple
+// live Claude Code processes share the same session_id (identity collision).
+// Returns: [{ pid, session_id, marker_path, cc_pid, sse_port }]
+function detectIdentityCollisions() {
+  const markerDir = path.resolve(__dirname, '../.claude/session-identity');
+  if (!fs.existsSync(markerDir)) return { collisions: [], aliveMarkers: [] };
+
+  const markers = fs.readdirSync(markerDir)
+    .filter(f => /^pid-\d+\.json$/.test(f))
+    .map(f => {
+      const filePath = path.resolve(markerDir, f);
+      const pid = Number(f.match(/^pid-(\d+)\.json$/)[1]);
+      try {
+        const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        return { pid, session_id: data.session_id, cc_pid: data.cc_pid || pid, sse_port: data.sse_port, marker_path: filePath, mtime: fs.statSync(filePath).mtimeMs };
+      } catch { return null; }
+    })
+    .filter(Boolean);
+
+  // Check which PIDs are alive
+  const aliveMarkers = markers.filter(m => isProcessRunning(m.pid));
+
+  // Group alive markers by session_id
+  const bySession = {};
+  for (const m of aliveMarkers) {
+    if (!m.session_id) continue;
+    if (!bySession[m.session_id]) bySession[m.session_id] = [];
+    bySession[m.session_id].push(m);
+  }
+
+  // Collisions: same session_id claimed by multiple live PIDs
+  const collisions = Object.entries(bySession)
+    .filter(([, arr]) => arr.length > 1)
+    .map(([sessionId, markers]) => ({
+      session_id: sessionId,
+      markers: markers.sort((a, b) => a.mtime - b.mtime) // oldest first
+    }));
+
+  return { collisions, aliveMarkers };
+}
+
+// --- Layer 2: Session Splitting ---
+// When identity collision is detected, create new DB sessions for duplicate PIDs
+// so each Claude Code process has its own identity.
+async function splitCollidingSessions(supabase, collisions, actions, warnings) {
+  for (const collision of collisions) {
+    const keeper = collision.markers[0]; // oldest marker keeps the session
+    const extras = collision.markers.slice(1); // newer markers get split
+
+    actions.push('IDENTITY_COLLISION: session ' + collision.session_id.substring(0, 12) + '... shared by PIDs ' +
+      collision.markers.map(m => m.pid).join(', ') + ' — keeper PID=' + keeper.pid);
+
+    for (const extra of extras) {
+      // Use marker-based UUID if available, fall back to PID-based format
+      const newTerminalId = extra.session_id || ('win-' + extra.pid);
+      const newSessionId = 'session_' + randomUUID().substring(0, 8) + '_' + extra.pid;
+
+      // Check if a session with this terminal_id already exists (idempotent)
+      const { data: existing } = await supabase
+        .from('claude_sessions')
+        .select('session_id')
+        .eq('terminal_id', newTerminalId)
+        .in('status', ['active', 'idle'])
+        .limit(1);
+
+      if (existing && existing.length > 0) {
+        actions.push('IDENTITY_SPLIT: PID ' + extra.pid + ' already has session ' + existing[0].session_id.substring(0, 20) + ' — skipped');
+        continue;
+      }
+
+      // Create a new session record for this PID
+      const { error: insertErr } = await supabase
+        .from('claude_sessions')
+        .insert({
+          session_id: newSessionId,
+          terminal_id: newTerminalId,
+          tty: newTerminalId,
+          pid: extra.pid,
+          hostname: LOCAL_HOSTNAME,
+          codebase: path.resolve(__dirname, '..'),
+          status: 'idle',
+          heartbeat_at: new Date().toISOString(),
+          metadata: { split_from: collision.session_id, split_reason: 'IDENTITY_COLLISION', original_pid: extra.pid }
+        });
+
+      if (insertErr) {
+        warnings.push('IDENTITY_SPLIT: failed to create session for PID ' + extra.pid + ' — ' + insertErr.message);
+        continue;
+      }
+
+      // Update the marker file to point to the new session
+      try {
+        const markerData = JSON.parse(fs.readFileSync(extra.marker_path, 'utf8'));
+        markerData.session_id = newSessionId;
+        markerData.split_from = collision.session_id;
+        markerData.split_at = new Date().toISOString();
+        fs.writeFileSync(extra.marker_path, JSON.stringify(markerData, null, 2));
+      } catch (e) {
+        warnings.push('IDENTITY_SPLIT: failed to update marker for PID ' + extra.pid + ' — ' + e.message);
+      }
+
+      // Send IDENTITY_COLLISION coordination message to the original session
+      // so the affected process knows to re-register on next heartbeat
+      await supabase.from('session_coordination').insert({
+        target_session: collision.session_id,
+        message_type: 'IDENTITY_COLLISION',
+        subject: 'Session identity collision detected — PID ' + extra.pid + ' split off',
+        body: 'Multiple Claude Code processes were sharing session ' + collision.session_id.substring(0, 12) + '...\n\n' +
+          'PID ' + extra.pid + ' has been assigned new session: ' + newSessionId + '\n' +
+          'PID ' + keeper.pid + ' keeps the original session.\n\n' +
+          'If you have an active SD claim, run /claim to verify your claim is intact.\n' +
+          'If your claim was lost, run /claim to re-claim your SD.',
+        payload: {
+          collision_pids: collision.markers.map(m => m.pid),
+          keeper_pid: keeper.pid,
+          split_pid: extra.pid,
+          new_session_id: newSessionId,
+          original_session_id: collision.session_id
+        },
+        sender_type: 'sweep'
+      }).catch(() => {});
+
+      actions.push('IDENTITY_SPLIT: PID ' + extra.pid + ' → new session ' + newSessionId.substring(0, 20) + ' (terminal_id=' + newTerminalId + ')');
+    }
+  }
+}
+
+// --- Layer 3: npm Install Mutex ---
+// File-based lock to prevent concurrent npm install from corrupting node_modules.
+const NPM_LOCK_PATH = path.resolve(__dirname, '../node_modules/.npm-install.lock');
+const NPM_LOCK_MAX_AGE_MS = 5 * 60 * 1000; // 5min max lock age (auto-expire stale locks)
+
+function checkNpmInstallLock() {
+  if (!fs.existsSync(NPM_LOCK_PATH)) return { locked: false };
+  try {
+    const data = JSON.parse(fs.readFileSync(NPM_LOCK_PATH, 'utf8'));
+    const age = Date.now() - data.timestamp;
+    if (age > NPM_LOCK_MAX_AGE_MS) {
+      // Stale lock — remove it
+      fs.unlinkSync(NPM_LOCK_PATH);
+      return { locked: false, stale_removed: true, stale_pid: data.pid };
+    }
+    // Check if lock holder is still alive
+    if (data.pid && !isProcessRunning(data.pid)) {
+      fs.unlinkSync(NPM_LOCK_PATH);
+      return { locked: false, dead_removed: true, dead_pid: data.pid };
+    }
+    return { locked: true, holder_pid: data.pid, age_seconds: Math.round(age / 1000) };
+  } catch {
+    // Corrupt lock file — remove
+    try { fs.unlinkSync(NPM_LOCK_PATH); } catch {}
+    return { locked: false };
+  }
+}
+
+async function main() {
+  const now = new Date();
+  const actions = [];
+  const warnings = [];
+  const conflictEvicted = [];
+
+  // 1. Get all sessions with SD claims
+  const { data: sessions, error: sessErr } = await supabase
+    .from('v_active_sessions')
+    .select('session_id, sd_id, sd_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, tty, pid, track')
+    .not('sd_id', 'is', null)
+    .order('heartbeat_age_seconds', { ascending: true });
+
+  if (sessErr) {
+    console.log('ERROR: Failed to query sessions — ' + sessErr.message);
+    process.exit(1);
+  }
+
+  if (!sessions || sessions.length === 0) {
+    console.log('[' + now.toLocaleTimeString() + '] SWEEP: No sessions with claims. All clear.');
+    return;
+  }
+
+  // 2. Classify each session
+  // NOTE: PID checks are unreliable on Windows — claude_sessions stores the PID
+  // of a bash child process, not the parent node.exe. These child PIDs are ephemeral
+  // and appear dead even when the session is actively running.
+  // Classification uses HEARTBEAT AGE ONLY as the liveness signal.
+  const VERY_STALE_SECONDS = STALE_THRESHOLD_SECONDS * 3; // 15min = definitely dead
+  const classified = sessions.map(s => {
+    const isStale = s.heartbeat_age_seconds > STALE_THRESHOLD_SECONDS;
+    const isVeryStale = s.heartbeat_age_seconds > VERY_STALE_SECONDS;
+
+    let status;
+    if (!isStale) {
+      status = 'ACTIVE';
+    } else if (isVeryStale) {
+      status = 'DEAD'; // No heartbeat for 15min+ = definitely gone
+    } else {
+      status = 'STALE_UNKNOWN'; // Between 5-15min = might be busy/compacting
+    }
+
+    return { ...s, isStale, status };
+  });
+
+  // 2b. Identity collision detection (Layer 1)
+  const { collisions, aliveMarkers } = detectIdentityCollisions();
+  if (collisions.length > 0) {
+    await splitCollidingSessions(supabase, collisions, actions, warnings);
+  }
+
+  // 2c. npm install lock cleanup (Layer 3)
+  const npmLock = checkNpmInstallLock();
+  if (npmLock.stale_removed) {
+    actions.push('NPM_LOCK: removed stale install lock (PID ' + npmLock.stale_pid + ' — expired)');
+  }
+  if (npmLock.dead_removed) {
+    actions.push('NPM_LOCK: removed dead install lock (PID ' + npmLock.dead_pid + ' — process gone)');
+  }
+  if (npmLock.locked) {
+    warnings.push('NPM_LOCK: active install lock held by PID ' + npmLock.holder_pid + ' (' + npmLock.age_seconds + 's)');
+  }
+
+  // 3. Detect conflicts (multiple sessions claiming same SD)
+  const bySD = {};
+  classified.forEach(s => {
+    if (!bySD[s.sd_id]) bySD[s.sd_id] = [];
+    bySD[s.sd_id].push(s);
+  });
+
+  const conflicts = Object.entries(bySD).filter(([, arr]) => arr.length > 1);
+
+  // 3b. QA — detect sessions working on completed SDs
+  const claimedSdKeys = [...new Set(classified.map(s => s.sd_id).filter(Boolean))];
+  const { data: claimedSdStatus } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, status, completion_date')
+    .in('sd_key', claimedSdKeys);
+
+  const sdStatusMap = {};
+  (claimedSdStatus || []).forEach(sd => { sdStatusMap[sd.sd_key] = sd; });
+
+  const workingOnCompleted = classified.filter(s => {
+    const sd = sdStatusMap[s.sd_id];
+    return sd && sd.status === 'completed';
+  });
+
+  for (const s of workingOnCompleted) {
+    // Use 'released' not 'idle' — stale sessions can't become 'idle' due to
+    // idx_claude_sessions_unique_terminal_active (one active/idle per terminal).
+    // Using 'idle' silently fails when another session on the same terminal exists.
+    const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
+    const { error } = await supabase
+      .from('claude_sessions')
+      .update({
+        sd_id: null,
+        status: targetStatus,
+        released_at: now.toISOString(),
+        released_reason: 'SWEEP_SD_ALREADY_COMPLETED'
+      })
+      .eq('session_id', s.session_id);
+
+    if (!error) {
+      // Also clear claiming_session_id on the SD to break the churn loop
+      await supabase
+        .from('strategic_directives_v2')
+        .update({ claiming_session_id: null, is_working_on: false })
+        .eq('sd_key', s.sd_id);
+      actions.push('QA: released ' + s.session_id + ' (' + s.tty + ') — ' + s.sd_id + ' already completed');
+    }
+  }
+
+  // 3c. QA — detect sessions claiming SDs that don't exist
+  const orphanedClaims = classified.filter(s => !sdStatusMap[s.sd_id]);
+  for (const s of orphanedClaims) {
+    const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
+    const { error } = await supabase
+      .from('claude_sessions')
+      .update({
+        sd_id: null,
+        status: targetStatus,
+        released_at: now.toISOString(),
+        released_reason: 'SWEEP_ORPHANED_CLAIM'
+      })
+      .eq('session_id', s.session_id);
+
+    if (!error) {
+      actions.push('QA: released ' + s.session_id + ' (' + s.tty + ') — SD ' + s.sd_id + ' not found in DB');
+    }
+  }
+
+  // 3d. QA — detect SDs stuck in pending_approval with no claiming session
+  const pendingApproval = (claimedSdStatus || []).filter(sd => sd.status === 'pending_approval');
+  // Also check standalone SDs not already in claimedSdStatus
+  const claimedKeys = new Set((claimedSdStatus || []).map(sd => sd.sd_key));
+  const { data: allPendingApproval } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, status, current_phase, progress_percentage, completion_date')
+    .eq('status', 'pending_approval');
+
+  const activeClaimSdIds = new Set(classified.filter(s => s.status === 'ACTIVE').map(s => s.sd_id));
+  const stuckApproval = (allPendingApproval || []).filter(sd => !activeClaimSdIds.has(sd.sd_key));
+
+  for (const sd of stuckApproval) {
+    // FIX #1: STUCK_100 — if at 100% with completion_date, mark completed instead of resetting
+    if (sd.progress_percentage >= 100 && sd.completion_date) {
+      const { error } = await supabase
+        .from('strategic_directives_v2')
+        .update({
+          status: 'completed',
+          claiming_session_id: null,
+          is_working_on: false
+        })
+        .eq('sd_key', sd.sd_key)
+        .select();
+
+      if (!error) {
+        actions.push('QA: completed ' + sd.sd_key + ' — was stuck at 100%/pending_approval with completion_date');
+      }
+    } else {
+      const { error } = await supabase
+        .from('strategic_directives_v2')
+        .update({
+          status: 'draft',
+          current_phase: 'LEAD',
+          progress_percentage: 0,
+          claiming_session_id: null,
+          is_working_on: false
+        })
+        .eq('sd_key', sd.sd_key);
+
+      if (!error) {
+        actions.push('QA: reset ' + sd.sd_key + ' from pending_approval → draft/LEAD/0% (no session working on it)');
+      }
+    }
+  }
+
+  // FIX #2: Proactively clear stale claiming_session_id on completed SDs to prevent churn
+  const { data: completedWithClaims } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, claiming_session_id, is_working_on')
+    .eq('status', 'completed')
+    .not('claiming_session_id', 'is', null);
+
+  for (const sd of (completedWithClaims || [])) {
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      .update({ claiming_session_id: null, is_working_on: false })
+      .eq('sd_key', sd.sd_key)
+      .select();
+
+    if (!error) {
+      actions.push('QA: cleared stale claiming_session_id on completed ' + sd.sd_key);
+    }
+  }
+
+  // 3e. QA — detect and auto-enrich bare-shell SDs (FIX #6)
+  const { data: pendingSDs } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, title, description, scope')
+    .in('status', ['draft', 'ready'])
+    .not('sd_key', 'like', '%ORCH-STAGE-VENTURE-WORKFLOW-001-%');
+  const bareShellSDs = (pendingSDs || []).filter(sd => {
+    if (sd.description && sd.description.startsWith('Child SD of')) return false;
+    return !sd.description || sd.description === sd.title || (sd.description.length < 100 && sd.scope === sd.title);
+  });
+  if (bareShellSDs.length > 0) {
+    const repoRoot = path.resolve(__dirname, '..');
+    const searchDirs = ['docs/audits', 'docs/plans', 'brainstorm'].map(d => path.join(repoRoot, d));
+
+    for (const sd of bareShellSDs) {
+      // Try to find matching content in docs/audits, docs/plans, brainstorm
+      const keywords = sd.title.toLowerCase().split(/[\s\-_]+/).filter(w => w.length > 3);
+      let bestMatch = null;
+      let bestScore = 0;
+
+      for (const dir of searchDirs) {
+        if (!fs.existsSync(dir)) continue;
+        const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
+        for (const file of files) {
+          const nameLower = file.toLowerCase();
+          const score = keywords.filter(kw => nameLower.includes(kw)).length;
+          if (score > bestScore) {
+            bestScore = score;
+            bestMatch = path.join(dir, file);
+          }
+        }
+      }
+
+      if (bestMatch && bestScore >= 2) {
+        // Read up to 2000 chars from the matching file for description enrichment
+        const content = fs.readFileSync(bestMatch, 'utf8').substring(0, 2000);
+        // Extract first paragraph or summary section
+        const lines = content.split('\n').filter(l => l.trim() && !l.startsWith('#'));
+        const summary = lines.slice(0, 10).join('\n').substring(0, 500);
+
+        if (summary.length > 50) {
+          const { error } = await supabase
+            .from('strategic_directives_v2')
+            .update({
+              description: sd.title + '\n\n' + summary + '\n\n[Auto-enriched by sweep from ' + path.basename(bestMatch) + ']'
+            })
+            .eq('sd_key', sd.sd_key)
+            .select();
+
+          if (!error) {
+            actions.push('ENRICH: ' + sd.sd_key + ' — description populated from ' + path.basename(bestMatch));
+          } else {
+            warnings.push('BARE_SHELL: ' + sd.sd_key + ' — enrichment failed: ' + error.message);
+          }
+        } else {
+          warnings.push('BARE_SHELL: ' + sd.sd_key + ' — found ' + path.basename(bestMatch) + ' but content too short');
+        }
+      } else {
+        warnings.push('BARE_SHELL: ' + sd.sd_key + ' has no real description — no matching docs found');
+      }
+    }
+  }
+
+  // 4. Auto-release dead sessions (with WIP guard)
+  const dead = classified.filter(s => s.status === 'DEAD');
+  for (const s of dead) {
+    // SD-MAN-INFRA-WORKER-WORKTREE-SELF-001: WIP release guard
+    // Sessions with uncommitted changes are protected from automatic release
+    if (s.has_uncommitted_changes === true) {
+      warnings.push('WIP_GUARD: ' + s.session_id + ' has uncommitted changes — NOT releasing (SD: ' + s.sd_id + ')');
+      continue;
+    }
+
+    const { error } = await supabase
+      .from('claude_sessions')
+      .update({
+        sd_id: null,
+        status: 'released',
+        released_at: now.toISOString(),
+        released_reason: 'SWEEP_PID_DEAD'
+      })
+      .eq('session_id', s.session_id);
+
+    if (error) {
+      actions.push('FAILED to release ' + s.session_id + ' (' + s.sd_id + '): ' + error.message);
+    } else {
+      actions.push('RELEASED ' + s.session_id + ' — PID ' + s.pid + ' dead — freed ' + s.sd_id);
+    }
+  }
+
+  // 4a. Worktree conflict detection (SD-MAN-INFRA-WORKER-WORKTREE-SELF-001)
+  // Detect multiple active sessions on the same feature branch (excludes main/QF)
+  const branchSessions = new Map();
+  for (const s of classified.filter(c => c.status === 'ACTIVE' && c.current_branch && c.current_branch !== 'main')) {
+    if (!branchSessions.has(s.current_branch)) branchSessions.set(s.current_branch, []);
+    branchSessions.get(s.current_branch).push(s);
+  }
+  for (const [branch, sessions] of branchSessions) {
+    if (sessions.length > 1) {
+      const ids = sessions.map(s => s.session_id).join(', ');
+      warnings.push('WORKTREE_CONFLICT: branch ' + branch + ' claimed by ' + sessions.length + ' sessions: ' + ids);
+    }
+  }
+
+  // 4b. Struggling worker detection (SD-MAN-INFRA-WORKER-WORKTREE-SELF-001)
+  // Flag workers with repeated handoff failures
+  for (const s of classified.filter(c => c.status === 'ACTIVE' && (c.handoff_fail_count || 0) > 3)) {
+    const tier = s.handoff_fail_count >= 7 ? 'REASSIGN' : s.handoff_fail_count >= 5 ? 'RCA' : 'WARN';
+    warnings.push('WORKER_STRUGGLING: ' + s.session_id + ' has ' + s.handoff_fail_count + ' handoff failures (tier: ' + tier + ', SD: ' + s.sd_id + ')');
+  }
+
+  // 5. Resolve conflicts — keep freshest, release ALL others (including active)
+  for (const [sdId, claimants] of conflicts) {
+    const sorted = claimants.sort((a, b) => a.heartbeat_age_seconds - b.heartbeat_age_seconds);
+    const keeper = sorted[0];
+    const evictees = sorted.slice(1);
+
+    for (const evict of evictees) {
+      // Skip if already released in step 4
+      if (dead.find(d => d.session_id === evict.session_id)) continue;
+
+      const targetStatus = evict.status === 'ACTIVE' ? 'idle' : 'released';
+      const { error } = await supabase
+        .from('claude_sessions')
+        .update({
+          sd_id: null,
+          status: targetStatus,
+          released_at: now.toISOString(),
+          released_reason: 'SWEEP_CONFLICT_RESOLUTION'
+        })
+        .eq('session_id', evict.session_id);
+
+      if (!error) {
+        const tag = evict.status === 'ACTIVE' ? ' (was active)' : '';
+        actions.push('CONFLICT on ' + sdId + ': released ' + evict.session_id + tag + ' (kept ' + keeper.session_id + ')');
+
+        // Send coordination message to the evicted session so it picks up other work
+        conflictEvicted.push(evict);
+      }
+    }
+  }
+
+  // 6. Send coordination messages to active sessions
+  // Load BOTH orchestrator children AND all pending standalone SDs
+  const [childRes, standaloneRes] = await Promise.all([
+    supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, title, status, current_phase, progress_percentage, dependencies')
+      .like('sd_key', 'SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-%')
+      .order('sd_key', { ascending: true }),
+    supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, title, status, current_phase, progress_percentage, dependencies, priority')
+      .in('status', ['draft', 'in_progress', 'ready', 'pending_approval'])
+      .not('sd_key', 'like', 'SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001%')
+      .limit(20)
+  ]);
+
+  const children = childRes.data || [];
+  const standaloneSDs = standaloneRes.data || [];
+  const allSDs = [...children, ...standaloneSDs];
+
+  // Dependency-aware availability: only suggest SDs whose deps are all completed
+  const completedKeys = new Set(allSDs.filter(c => c.status === 'completed').map(c => c.sd_key));
+  const claimedByActive = new Set(classified.filter(s => s.status === 'ACTIVE').map(s => s.sd_id));
+
+  const available = allSDs
+    .filter(c => {
+      if (c.status === 'completed') return false;
+      if (claimedByActive.has(c.sd_key)) return false;
+      // Check dependencies are satisfied
+      if (c.dependencies && Array.isArray(c.dependencies) && c.dependencies.length > 0) {
+        const allDepsMet = c.dependencies.every(dep => completedKeys.has(dep));
+        if (!allDepsMet) return false;
+      }
+      return true;
+    })
+    .map(c => c.sd_key);
+
+  const blocked = allSDs
+    .filter(c => {
+      if (c.status === 'completed') return false;
+      if (!c.dependencies || !Array.isArray(c.dependencies) || c.dependencies.length === 0) return false;
+      return !c.dependencies.every(dep => completedKeys.has(dep));
+    })
+    .map(c => c.sd_key);
+
+  const activeSessions = classified.filter(s => s.status === 'ACTIVE');
+
+  // 6b. QA — Claim Integrity: detect idle sessions with no SD claim and nudge them
+  const { data: idleSessions } = await supabase
+    .from('v_active_sessions')
+    .select('session_id, sd_id, heartbeat_age_seconds, heartbeat_age_human, computed_status, tty')
+    .is('sd_id', null)
+    .order('heartbeat_age_seconds', { ascending: true });
+
+  const aliveIdle = (idleSessions || []).filter(s => s.heartbeat_age_seconds < STALE_THRESHOLD_SECONDS);
+  const claimIntegrityIssues = [];
+
+  for (const s of aliveIdle) {
+    // Only nudge if idle for >5min (give time for post-completion transitions: /learn, protocol reads, context compaction)
+    if (s.heartbeat_age_seconds < 300) continue;
+
+    // Check if we already sent a CLAIM_REMINDER recently (avoid spam)
+    const { data: existingReminder } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('target_session', s.session_id)
+      .eq('message_type', 'CLAIM_REMINDER')
+      .is('acknowledged_at', null)
+      .limit(1);
+
+    if (existingReminder && existingReminder.length > 0) continue;
+
+    // Send CLAIM_REMINDER (includes worktree reminder)
+    const topSD = available.length > 0 ? available[0] : null;
+    const suggestion = topSD ? 'Suggested: ' + topSD + ' (highest priority unclaimed)' : 'Run /leo next for the SD queue.';
+    const worktreeReminder = '\n\nIMPORTANT: Before starting work, ensure you are in your own isolated worktree. ' +
+      'Run: node scripts/resolve-sd-workdir.js <SD-ID> — this creates a dedicated worktree so parallel workers ' +
+      'do not corrupt each other\'s node_modules or git state.';
+    await supabase.from('session_coordination').insert({
+      target_session: s.session_id,
+      message_type: 'CLAIM_REMINDER',
+      subject: 'No SD claimed — ' + available.length + ' SDs available for work',
+      body: 'You have been idle for ' + s.heartbeat_age_human + ' with no SD claim. ' + suggestion + worktreeReminder + '\n\nRun: /claim or /leo next',
+      payload: { available_sds: available, idle_seconds: s.heartbeat_age_seconds },
+      sender_type: 'sweep'
+    }).then(() => {}).catch(() => {});
+
+    claimIntegrityIssues.push(s.session_id.substring(0, 20) + ' (' + s.tty + ')');
+  }
+
+  // Also check: sessions with sd_id but SD's claiming_session_id doesn't match (broken claim)
+  for (const s of classified.filter(c => c.status === 'ACTIVE' && c.sd_id)) {
+    const { data: sd } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, claiming_session_id, is_working_on')
+      .eq('sd_key', s.sd_id)
+      .single();
+
+    if (!sd) continue;
+
+    // Fix broken claim: session thinks it owns SD but SD doesn't know
+    if (sd.claiming_session_id !== s.session_id) {
+      await supabase
+        .from('strategic_directives_v2')
+        .update({ claiming_session_id: s.session_id, is_working_on: true })
+        .eq('sd_key', s.sd_id)
+        .select();
+      actions.push('CLAIM_FIX: set claiming_session_id on ' + s.sd_id + ' → ' + s.session_id.substring(0, 20));
+    } else if (!sd.is_working_on) {
+      // Fix incomplete claim: claiming_session_id matches but is_working_on is false
+      await supabase
+        .from('strategic_directives_v2')
+        .update({ is_working_on: true })
+        .eq('sd_key', s.sd_id)
+        .select();
+      actions.push('CLAIM_FIX: set is_working_on=true on ' + s.sd_id);
+    }
+  }
+
+  if (claimIntegrityIssues.length > 0) {
+    actions.push('CLAIM_REMINDER: nudged ' + claimIntegrityIssues.length + ' idle session(s) — ' + claimIntegrityIssues.join(', '));
+  }
+
+  // Clean up expired messages first
+  try { await supabase.rpc('cleanup_expired_coordination'); } catch { /* ignore */ }
+
+  // FIX #3: Clean up coordination messages targeting dead/stale sessions
+  // These accumulate because target sessions exit without reading them
+  const allSessionIds = new Set(classified.map(s => s.session_id));
+  const { data: unreadMsgs } = await supabase
+    .from('session_coordination')
+    .select('id, target_session')
+    .is('acknowledged_at', null)
+    .is('read_at', null);
+
+  const deadMsgIds = (unreadMsgs || [])
+    .filter(m => !allSessionIds.has(m.target_session))
+    .map(m => m.id);
+
+  // Also include messages targeting sessions classified as DEAD or stale
+  const deadOrStaleIds = new Set(classified.filter(s => s.status !== 'ACTIVE').map(s => s.session_id));
+  const staleMsgIds = (unreadMsgs || [])
+    .filter(m => deadOrStaleIds.has(m.target_session))
+    .map(m => m.id);
+
+  const allDeadMsgIds = [...new Set([...deadMsgIds, ...staleMsgIds])];
+  if (allDeadMsgIds.length > 0) {
+    // Delete in batches of 50
+    for (let i = 0; i < allDeadMsgIds.length; i += 50) {
+      const batch = allDeadMsgIds.slice(i, i + 50);
+      await supabase.from('session_coordination').delete().in('id', batch);
+    }
+    actions.push('CLEANUP: deleted ' + allDeadMsgIds.length + ' unread coordination messages targeting dead/gone sessions');
+  }
+
+  for (const s of activeSessions) {
+    // Check if we already have an unacknowledged message for this session
+    const { data: existing } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('target_session', s.session_id)
+      .eq('message_type', 'WORK_ASSIGNMENT')
+      .is('acknowledged_at', null)
+      .limit(1);
+
+    if (existing && existing.length > 0) continue; // Don't spam
+
+    await supabase
+      .from('session_coordination')
+      .insert({
+        target_session: s.session_id,
+        target_sd: s.sd_id,
+        message_type: 'WORK_ASSIGNMENT',
+        subject: 'Next work available when ' + s.sd_id.split('-').pop() + ' completes',
+        body: 'When you complete ' + s.sd_id + ', pick up the next unclaimed child.\n\nREMINDER: Ensure you are in your own isolated worktree before starting new work. Run: node scripts/resolve-sd-workdir.js <SD-ID>',
+        payload: { available_sds: available, current_sd: s.sd_id },
+        sender_type: 'sweep'
+      });
+  }
+
+  // Also send CLAIM_RELEASED messages for any sessions we evicted (dead)
+  for (const d of dead) {
+    await supabase
+      .from('session_coordination')
+      .insert({
+        target_session: d.session_id,
+        target_sd: d.sd_id,
+        message_type: 'CLAIM_RELEASED',
+        subject: 'Claim on ' + d.sd_id + ' was released (PID dead)',
+        body: 'Your session was detected as dead (PID ' + d.pid + '). Claim released. Available: ' + available.join(', '),
+        payload: { released_sd: d.sd_id, reason: 'PID_DEAD', available_sds: available },
+        sender_type: 'sweep'
+      });
+  }
+
+  // Send CLAIM_RELEASED messages for conflict-evicted active sessions
+  for (const evict of conflictEvicted) {
+    const otherAvailable = available.filter(sd => sd !== evict.sd_id);
+    await supabase
+      .from('session_coordination')
+      .insert({
+        target_session: evict.session_id,
+        target_sd: evict.sd_id,
+        message_type: 'CLAIM_RELEASED',
+        subject: 'Duplicate claim on ' + evict.sd_id.split('-').pop() + ' resolved — pick next SD',
+        body: 'Another session is already working on ' + evict.sd_id + '. Your claim was released to avoid duplicate work. Please claim one of: ' + (otherAvailable.length > 0 ? otherAvailable.join(', ') : 'run /leo next for available SDs') + '\n\nREMINDER: Ensure you are in your own isolated worktree before starting new work. Run: node scripts/resolve-sd-workdir.js <SD-ID>',
+        payload: { released_sd: evict.sd_id, reason: 'CONFLICT_RESOLUTION', available_sds: otherAvailable },
+        sender_type: 'sweep'
+      });
+  }
+
+  // Send CLAIM_RELEASED messages for QA-released sessions (completed SD or orphan)
+  for (const s of [...workingOnCompleted, ...orphanedClaims]) {
+    await supabase
+      .from('session_coordination')
+      .insert({
+        target_session: s.session_id,
+        target_sd: s.sd_id,
+        message_type: 'CLAIM_RELEASED',
+        subject: 'SD ' + s.sd_id.split('-').pop() + ' already completed — pick next SD',
+        body: 'Your SD ' + s.sd_id + ' is already completed. Your claim was released. Please pick up one of: ' + (available.length > 0 ? available.join(', ') : 'run /leo next for available SDs'),
+        payload: { released_sd: s.sd_id, reason: 'SD_ALREADY_COMPLETED', available_sds: available },
+        sender_type: 'sweep'
+      });
+  }
+
+  // 7. Get orchestrator progress for summary
+  const completed = (children || []).filter(c => c.status === 'completed').length;
+  const total = (children || []).length;
+  const orchPct = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  // 8. Output summary
+  console.log('');
+  console.log('=== STALE SESSION SWEEP [' + now.toLocaleTimeString() + '] ===');
+  console.log('');
+
+  // Active workers
+  console.log('ACTIVE WORKERS (' + activeSessions.length + '):');
+  activeSessions.forEach(s => {
+    const child = (children || []).find(c => c.sd_key === s.sd_id);
+    const pct = child ? child.progress_percentage : '?';
+    console.log('  ' + (s.tty || '?').padEnd(12) + (s.sd_id || '?').padEnd(50) + bar(pct) + ' ' + pct + '%');
+  });
+  console.log('');
+
+  // Stale sessions
+  const stale = classified.filter(s => s.status !== 'ACTIVE');
+  if (stale.length > 0) {
+    console.log('STALE/DEAD (' + stale.length + '):');
+    stale.forEach(s => {
+      const tag = s.status === 'DEAD' ? 'RELEASED' : s.status;
+      console.log('  ' + (s.tty || '?').padEnd(12) + (s.sd_id || '?').padEnd(50) + tag + ' (' + s.heartbeat_age_human + ')');
+    });
+    console.log('');
+  }
+
+  // Actions taken
+  if (actions.length > 0) {
+    console.log('ACTIONS TAKEN (' + actions.length + '):');
+    actions.forEach(a => console.log('  > ' + a));
+    console.log('');
+  }
+
+  // Warnings
+  if (warnings.length > 0) {
+    console.log('WARNINGS (' + warnings.length + '):');
+    warnings.forEach(w => console.log('  ! ' + w));
+    console.log('');
+  }
+
+  // Conflicts
+  if (conflicts.length > 0) {
+    console.log('CONFLICTS DETECTED: ' + conflicts.length);
+    conflicts.forEach(([sdId, arr]) => {
+      console.log('  ' + sdId + ': ' + arr.map(s => s.session_id.substring(0, 20) + '(' + s.status + ')').join(' vs '));
+    });
+    console.log('');
+  } else {
+    console.log('CONFLICTS: None');
+    console.log('');
+  }
+
+  // QA summary
+  const stuckCompleted = stuckApproval.filter(sd => sd.progress_percentage >= 100 && sd.completion_date);
+  const stuckReset = stuckApproval.filter(sd => !(sd.progress_percentage >= 100 && sd.completion_date));
+  const qaIssues = workingOnCompleted.length + orphanedClaims.length + stuckApproval.length + (completedWithClaims || []).length;
+  if (qaIssues > 0) {
+    console.log('QA FIXES (' + qaIssues + '):');
+    if (workingOnCompleted.length > 0) console.log('  Released ' + workingOnCompleted.length + ' session(s) working on completed SDs');
+    if (orphanedClaims.length > 0) console.log('  Released ' + orphanedClaims.length + ' session(s) with orphaned claims');
+    if (stuckCompleted.length > 0) console.log('  Completed ' + stuckCompleted.length + ' SD(s) stuck at 100%/pending_approval');
+    if (stuckReset.length > 0) console.log('  Reset ' + stuckReset.length + ' SD(s) from pending_approval → draft (no session working on them)');
+    if ((completedWithClaims || []).length > 0) console.log('  Cleared ' + (completedWithClaims || []).length + ' stale claiming_session_id on completed SDs');
+    if (claimIntegrityIssues.length > 0) console.log('  Nudged ' + claimIntegrityIssues.length + ' idle session(s) with CLAIM_REMINDER');
+    console.log('');
+  }
+
+  // Identity collision summary
+  if (collisions.length > 0) {
+    console.log('IDENTITY COLLISIONS (' + collisions.length + '):');
+    for (const c of collisions) {
+      console.log('  Session ' + c.session_id.substring(0, 12) + '... shared by PIDs: ' + c.markers.map(m => m.pid).join(', '));
+    }
+    console.log('');
+  }
+
+  // Alive markers summary (useful for debugging)
+  if (aliveMarkers.length > 0) {
+    console.log('MARKER FILES (' + aliveMarkers.length + ' alive):');
+    for (const m of aliveMarkers) {
+      console.log('  PID=' + String(m.pid).padEnd(8) + 'session=' + (m.session_id || '?').substring(0, 12) + '...' + '  port=' + (m.sse_port || '?'));
+    }
+    console.log('');
+  }
+
+  // npm lock status
+  if (npmLock.locked || npmLock.stale_removed || npmLock.dead_removed) {
+    console.log('NPM INSTALL LOCK:');
+    if (npmLock.locked) console.log('  ACTIVE — held by PID ' + npmLock.holder_pid + ' for ' + npmLock.age_seconds + 's');
+    if (npmLock.stale_removed) console.log('  CLEARED — stale lock from PID ' + npmLock.stale_pid + ' (expired)');
+    if (npmLock.dead_removed) console.log('  CLEARED — dead lock from PID ' + npmLock.dead_pid + ' (process gone)');
+    console.log('');
+  }
+
+  // Orchestrator progress
+  console.log('ORCHESTRATOR: ' + bar(orchPct, 30) + ' ' + completed + '/' + total + ' children (' + orchPct + '%)');
+  console.log('AVAILABLE FOR CLAIM: ' + (available.length > 0 ? available.join(', ') : 'None — all assigned'));
+  if (blocked.length > 0) {
+    console.log('BLOCKED (deps unmet): ' + blocked.join(', '));
+  }
+  console.log('COORDINATION MSGS: Sent to ' + activeSessions.length + ' active sessions');
+  console.log('');
+  console.log('=== SWEEP COMPLETE ===');
+}
+
+main().catch(err => {
+  console.error('SWEEP FATAL:', err.message);
+  process.exit(1);
+});

--- a/supabase/ehg_engineer/migrations/20260317_coaching_message_type.sql
+++ b/supabase/ehg_engineer/migrations/20260317_coaching_message_type.sql
@@ -1,0 +1,6 @@
+-- Add COACHING and IDENTITY_COLLISION to coordination_message_type enum
+-- COACHING: periodic guidance messages from coordinator to active workers
+-- IDENTITY_COLLISION: already used by sweep but never formally added
+
+ALTER TYPE coordination_message_type ADD VALUE IF NOT EXISTS 'COACHING';
+ALTER TYPE coordination_message_type ADD VALUE IF NOT EXISTS 'IDENTITY_COLLISION';


### PR DESCRIPTION
## Summary
- Restores 3 fleet infrastructure scripts (`stale-session-sweep.cjs`, `fleet-dashboard.cjs`, `fleet-eta-stats.cjs`) incorrectly archived by Dead Script Archival SD (PR #2248)
- Adds `fleet-coaching.cjs` — coordinator sends periodic guidance to active workers every 10 minutes
- Coaching: worktree isolation, PR size, /learn reminders, gate compliance, sub-agent routing, dependency unlocks, priority rebalancing
- Updates coordinator command with `coaching` subcommand and third cron loop
- Adds COACHING enum to coordination_message_type

## Test plan
- [x] Sweep script runs successfully after restore
- [x] Dashboard script runs successfully after restore
- [x] Coaching script runs with clean output
- [x] Migration applied (COACHING + IDENTITY_COLLISION enum values)
- [x] Smoke tests pass (15/15)
- [ ] Verify coaching messages appear in worker inbox when conditions met

🤖 Generated with [Claude Code](https://claude.com/claude-code)