### PR TITLE
fix: JWT verification and CORS hardening for edge functions

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEO-DOC-ERROR-CODE-CATALOG-001",
-  "expectedBranch": "feat/SD-LEO-DOC-ERROR-CODE-CATALOG-001",
-  "createdAt": "2026-03-17T15:20:54.260Z",
+  "sdKey": "SD-LEO-FIX-EDGE-FUNCTION-JWT-001",
+  "expectedBranch": "feat/SD-LEO-FIX-EDGE-FUNCTION-JWT-001",
+  "createdAt": "2026-03-17T16:04:46.210Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,0 +1,76 @@
+// Shared authentication and CORS utilities for Supabase Edge Functions
+// SD: SD-LEO-FIX-EDGE-FUNCTION-JWT-001
+// Centralizes JWT verification and CORS origin checking to avoid duplication.
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+/**
+ * Allowed origins for CORS, loaded from ALLOWED_ORIGINS env var.
+ * Falls back to 'http://localhost:8080' if not set.
+ */
+const ALLOWED_ORIGINS = (Deno.env.get('ALLOWED_ORIGINS') ?? 'http://localhost:8080').split(',').filter(Boolean)
+
+/**
+ * Returns CORS headers with origin checking.
+ * If the request Origin is in the allowed list, it is reflected back.
+ * Otherwise, the first allowed origin is used (restrictive default).
+ */
+export function getCorsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get('Origin') ?? ''
+  const corsOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0]
+  return {
+    'Access-Control-Allow-Origin': corsOrigin,
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  }
+}
+
+/**
+ * Verifies the JWT token from the Authorization header.
+ * Uses the anon key client to call auth.getUser() which validates the token
+ * server-side against Supabase Auth.
+ *
+ * Returns the authenticated user on success, or an error with HTTP status on failure.
+ */
+export async function verifyJWT(
+  req: Request
+): Promise<{ user: any; error?: string; status?: number }> {
+  const authHeader = req.headers.get('Authorization')
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return {
+      user: null,
+      error: 'Missing or invalid Authorization header',
+      status: 401,
+    }
+  }
+
+  const token = authHeader.replace('Bearer ', '')
+
+  const supabaseAuth = createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+  )
+
+  const { data: { user }, error: authError } = await supabaseAuth.auth.getUser(token)
+
+  if (authError || !user) {
+    return {
+      user: null,
+      error: 'Invalid or expired token',
+      status: 401,
+    }
+  }
+
+  return { user }
+}
+
+/**
+ * Creates a Supabase admin client using the service role key.
+ * This client bypasses RLS and should only be used after JWT verification.
+ */
+export function createAdminClient() {
+  return createClient(
+    Deno.env.get('SUPABASE_URL') ?? '',
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  )
+}

--- a/supabase/functions/calibrate-confidence/index.ts
+++ b/supabase/functions/calibrate-confidence/index.ts
@@ -5,12 +5,7 @@
 // updates per-service per-venture confidence thresholds.
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { verifyJWT, getCorsHeaders, createAdminClient } from '../_shared/auth.ts';
 
 const EMA_ALPHA = 0.1;
 const DRIFT_THRESHOLD_PCT = 15;
@@ -69,30 +64,31 @@ function clampDelta(delta: number, maxPct: number): number {
 }
 
 serve(async (req: Request) => {
+  const corsHeaders = getCorsHeaders(req);
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: CORS_HEADERS });
+    return new Response('ok', { headers: corsHeaders });
   }
 
   if (req.method !== 'POST') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
   try {
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
+    // Verify JWT before any database operations
+    const { user, error: authError, status: authStatus } = await verifyJWT(req);
+    if (authError) {
       return new Response(
-        JSON.stringify({ error: 'Missing authorization header' }),
-        { status: 401, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: authError }),
+        { status: authStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-    );
+    // Use service_role client for DB operations (after JWT verification)
+    const supabase = createAdminClient();
 
     const body = await req.json().catch(() => ({}));
     const ventureId = body.venture_id;
@@ -122,14 +118,14 @@ serve(async (req: Request) => {
     if (telErr) {
       return new Response(
         JSON.stringify({ error: telErr.message }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
     if (!telemetry || telemetry.length === 0) {
       return new Response(
         JSON.stringify({ message: 'No telemetry data to calibrate', calibrations: [] }),
-        { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -217,12 +213,12 @@ serve(async (req: Request) => {
         calibrations: results,
         total_telemetry_processed: telemetry.length,
       }),
-      { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (err) {
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });

--- a/supabase/functions/compute-health-score/index.ts
+++ b/supabase/functions/compute-health-score/index.ts
@@ -7,12 +7,7 @@
 //   4. exit_readiness_pct (from venture_separability_scores)
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { verifyJWT, getCorsHeaders, createAdminClient } from '../_shared/auth.ts';
 
 const DEFAULT_WEIGHTS = {
   task_completion: 0.30,
@@ -39,30 +34,31 @@ function freshnessToScore(hoursSinceReport: number): number {
 }
 
 serve(async (req: Request) => {
+  const corsHeaders = getCorsHeaders(req);
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: CORS_HEADERS });
+    return new Response('ok', { headers: corsHeaders });
   }
 
   if (req.method !== 'POST') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
   try {
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
+    // Verify JWT before any database operations
+    const { user, error: authError, status: authStatus } = await verifyJWT(req);
+    if (authError) {
       return new Response(
-        JSON.stringify({ error: 'Missing authorization header' }),
-        { status: 401, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: authError }),
+        { status: authStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-    );
+    // Use service_role client for DB operations (after JWT verification)
+    const supabase = createAdminClient();
 
     const body = await req.json().catch(() => ({}));
     const ventureId = body.venture_id;
@@ -71,7 +67,7 @@ serve(async (req: Request) => {
     if (!ventureId) {
       return new Response(
         JSON.stringify({ error: 'venture_id is required' }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -188,12 +184,12 @@ serve(async (req: Request) => {
         },
         weights,
       }),
-      { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (err) {
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });

--- a/supabase/functions/execute-exit/index.ts
+++ b/supabase/functions/execute-exit/index.ts
@@ -9,11 +9,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { verifyJWT, getCorsHeaders, createAdminClient } from '../_shared/auth.ts';
 
 const MIN_SEPARABILITY_SCORE = 60;
 const ROUNDS = ['dependency_freeze', 'data_export', 'cutover_validation', 'certification'] as const;
@@ -29,30 +25,45 @@ interface ExitState {
 }
 
 serve(async (req: Request) => {
+  const corsHeaders = getCorsHeaders(req);
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: CORS_HEADERS });
+    return new Response('ok', { headers: corsHeaders });
   }
 
   if (req.method !== 'POST') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
   try {
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
+    // Verify JWT before any database operations
+    const { user, error: authError, status: authStatus } = await verifyJWT(req);
+    if (authError) {
       return new Response(
-        JSON.stringify({ error: 'Missing authorization header' }),
-        { status: 401, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: authError }),
+        { status: authStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-    );
+    // Use service_role client for DB operations (after JWT verification)
+    const supabase = createAdminClient();
+
+    // Check chairman role (only chairman can manage exits)
+    const { data: profile } = await supabase
+      .from('user_profiles')
+      .select('role')
+      .eq('user_id', user.id)
+      .single();
+
+    if (!profile || profile.role !== 'chairman') {
+      return new Response(
+        JSON.stringify({ error: 'Forbidden: chairman role required' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
 
     const body = await req.json().catch(() => ({}));
     const { venture_id, action, confirm } = body;
@@ -60,40 +71,44 @@ serve(async (req: Request) => {
     if (!venture_id) {
       return new Response(
         JSON.stringify({ error: 'venture_id is required' }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
     // Action: start, advance, abort, status
     if (action === 'status' || !action) {
-      return await getExitStatus(supabase, venture_id);
+      return await getExitStatus(supabase, venture_id, corsHeaders);
     }
 
     if (action === 'start') {
-      return await startExit(supabase, venture_id, confirm);
+      return await startExit(supabase, venture_id, confirm, corsHeaders);
     }
 
     if (action === 'advance') {
-      return await advanceRound(supabase, venture_id, body.chairman_approval);
+      return await advanceRound(supabase, venture_id, body.chairman_approval, corsHeaders);
     }
 
     if (action === 'abort') {
-      return await abortExit(supabase, venture_id);
+      return await abortExit(supabase, venture_id, corsHeaders);
     }
 
     return new Response(
       JSON.stringify({ error: 'Invalid action. Use: start, advance, abort, status' }),
-      { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (err) {
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });
 
-async function getExitStatus(supabase: ReturnType<typeof createClient>, ventureId: string) {
+async function getExitStatus(
+  supabase: ReturnType<typeof createClient>,
+  ventureId: string,
+  corsHeaders: Record<string, string>
+) {
   const { data } = await supabase
     .from('venture_exit_readiness')
     .select('*')
@@ -104,15 +119,20 @@ async function getExitStatus(supabase: ReturnType<typeof createClient>, ventureI
 
   return new Response(
     JSON.stringify({ exit_state: data ?? null }),
-    { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+    { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
   );
 }
 
-async function startExit(supabase: ReturnType<typeof createClient>, ventureId: string, confirm: boolean) {
+async function startExit(
+  supabase: ReturnType<typeof createClient>,
+  ventureId: string,
+  confirm: boolean,
+  corsHeaders: Record<string, string>
+) {
   if (!confirm) {
     return new Response(
       JSON.stringify({ error: 'Exit requires explicit confirmation. Set confirm: true' }),
-      { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -133,7 +153,7 @@ async function startExit(supabase: ReturnType<typeof createClient>, ventureId: s
         current_score: score,
         required_score: MIN_SEPARABILITY_SCORE,
       }),
-      { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -155,7 +175,7 @@ async function startExit(supabase: ReturnType<typeof createClient>, ventureId: s
   if (error) {
     return new Response(
       JSON.stringify({ error: error.message }),
-      { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -175,11 +195,16 @@ async function startExit(supabase: ReturnType<typeof createClient>, ventureId: s
       round_name: 'dependency_freeze',
       separability_score: score,
     }),
-    { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+    { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
   );
 }
 
-async function advanceRound(supabase: ReturnType<typeof createClient>, ventureId: string, chairmanApproval: boolean) {
+async function advanceRound(
+  supabase: ReturnType<typeof createClient>,
+  ventureId: string,
+  chairmanApproval: boolean,
+  corsHeaders: Record<string, string>
+) {
   const { data: state } = await supabase
     .from('venture_exit_readiness')
     .select('*')
@@ -189,7 +214,7 @@ async function advanceRound(supabase: ReturnType<typeof createClient>, ventureId
   if (!state || state.status !== 'in_progress') {
     return new Response(
       JSON.stringify({ error: 'No active exit process for this venture' }),
-      { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -200,7 +225,7 @@ async function advanceRound(supabase: ReturnType<typeof createClient>, ventureId
         current_round: state.current_round,
         round_name: ROUNDS[state.current_round - 1],
       }),
-      { status: 403, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -250,7 +275,7 @@ async function advanceRound(supabase: ReturnType<typeof createClient>, ventureId
         certification_id: certId,
         rounds_completed: completedRounds,
       }),
-      { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -279,11 +304,15 @@ async function advanceRound(supabase: ReturnType<typeof createClient>, ventureId
       round_name: ROUNDS[nextRound - 1],
       rounds_completed: completedRounds,
     }),
-    { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+    { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
   );
 }
 
-async function abortExit(supabase: ReturnType<typeof createClient>, ventureId: string) {
+async function abortExit(
+  supabase: ReturnType<typeof createClient>,
+  ventureId: string,
+  corsHeaders: Record<string, string>
+) {
   const { data: state } = await supabase
     .from('venture_exit_readiness')
     .select('current_round, status')
@@ -293,7 +322,7 @@ async function abortExit(supabase: ReturnType<typeof createClient>, ventureId: s
   if (!state || state.status !== 'in_progress') {
     return new Response(
       JSON.stringify({ error: 'No active exit process to abort' }),
-      { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -303,7 +332,7 @@ async function abortExit(supabase: ReturnType<typeof createClient>, ventureId: s
         error: 'Cannot abort after round 2. Rounds 3-4 are irreversible.',
         current_round: state.current_round,
       }),
-      { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -325,6 +354,6 @@ async function abortExit(supabase: ReturnType<typeof createClient>, ventureId: s
       venture_id: ventureId,
       aborted_at_round: state.current_round,
     }),
-    { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+    { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
   );
 }

--- a/supabase/functions/observer-code-health/index.ts
+++ b/supabase/functions/observer-code-health/index.ts
@@ -4,17 +4,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const ALLOWED_ORIGINS = (Deno.env.get('ALLOWED_ORIGINS') || '').split(',').filter(Boolean)
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get('Origin') || ''
-  const allowedOrigin = ALLOWED_ORIGINS.length > 0 && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0] || ''
-  return {
-    'Access-Control-Allow-Origin': allowedOrigin,
-    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  }
-}
+import { verifyJWT, getCorsHeaders, createAdminClient } from '../_shared/auth.ts';
 
 interface CoverageReport {
   total: {
@@ -98,33 +88,17 @@ serve(async (req: Request) => {
   }
 
   try {
-    // Verify authentication
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
+    // Verify JWT before any database operations
+    const { user, error: jwtError, status: jwtStatus } = await verifyJWT(req);
+    if (jwtError) {
       return new Response(
-        JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: jwtError }),
+        { status: jwtStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
-    const authClient = createClient(supabaseUrl, supabaseAnonKey);
-
-    const { data: { user }, error: authError } = await authClient.auth.getUser(
-      authHeader.replace('Bearer ', '')
-    );
-
-    if (authError || !user) {
-      return new Response(
-        JSON.stringify({ error: 'Invalid token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    // Initialize service client for DB operations
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    // Initialize service client for DB operations (after JWT verification)
+    const supabase = createAdminClient();
 
     // Parse request
     const body: CodeHealthPayload = await req.json();

--- a/supabase/functions/observer-dependencies/index.ts
+++ b/supabase/functions/observer-dependencies/index.ts
@@ -4,17 +4,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const ALLOWED_ORIGINS = (Deno.env.get('ALLOWED_ORIGINS') || '').split(',').filter(Boolean)
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get('Origin') || ''
-  const allowedOrigin = ALLOWED_ORIGINS.length > 0 && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0] || ''
-  return {
-    'Access-Control-Allow-Origin': allowedOrigin,
-    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  }
-}
+import { verifyJWT, getCorsHeaders, createAdminClient } from '../_shared/auth.ts';
 
 interface NpmAuditVulnerability {
   name: string;
@@ -55,33 +45,17 @@ serve(async (req: Request) => {
   }
 
   try {
-    // Verify authentication
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
+    // Verify JWT before any database operations
+    const { user, error: jwtError, status: jwtStatus } = await verifyJWT(req);
+    if (jwtError) {
       return new Response(
-        JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: jwtError }),
+        { status: jwtStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
-    const authClient = createClient(supabaseUrl, supabaseAnonKey);
-
-    const { data: { user }, error: authError } = await authClient.auth.getUser(
-      authHeader.replace('Bearer ', '')
-    );
-
-    if (authError || !user) {
-      return new Response(
-        JSON.stringify({ error: 'Invalid token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    // Initialize service client for DB operations
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    // Initialize service client for DB operations (after JWT verification)
+    const supabase = createAdminClient();
 
     // Parse request
     const body: ObserverRequest = await req.json();

--- a/supabase/functions/observer-retrospectives/index.ts
+++ b/supabase/functions/observer-retrospectives/index.ts
@@ -4,17 +4,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const ALLOWED_ORIGINS = (Deno.env.get('ALLOWED_ORIGINS') || '').split(',').filter(Boolean)
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get('Origin') || ''
-  const allowedOrigin = ALLOWED_ORIGINS.length > 0 && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0] || ''
-  return {
-    'Access-Control-Allow-Origin': allowedOrigin,
-    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  }
-}
+import { verifyJWT, getCorsHeaders, createAdminClient } from '../_shared/auth.ts';
 
 interface Retrospective {
   id: string;
@@ -72,34 +62,18 @@ serve(async (req: Request) => {
   }
 
   try {
-    // Verify authentication
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
+    // Verify JWT before any database operations
+    const { user, error: jwtError, status: jwtStatus } = await verifyJWT(req);
+    if (jwtError) {
       return new Response(
-        JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: jwtError }),
+        { status: jwtStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
-    const authClient = createClient(supabaseUrl, supabaseAnonKey);
-
-    const { data: { user }, error: authError } = await authClient.auth.getUser(
-      authHeader.replace('Bearer ', '')
-    );
-
-    if (authError || !user) {
-      return new Response(
-        JSON.stringify({ error: 'Invalid token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    // Initialize service client for DB operations
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    // Initialize service client for DB operations (after JWT verification)
     const openaiApiKey = Deno.env.get('OPENAI_API_KEY');
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const supabase = createAdminClient();
 
     // Parse request
     const body: ObserverRequest = await req.json();

--- a/supabase/functions/openai-realtime-token/index.ts
+++ b/supabase/functions/openai-realtime-token/index.ts
@@ -4,17 +4,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.56.1'
-
-const ALLOWED_ORIGINS = (Deno.env.get('ALLOWED_ORIGINS') || '').split(',').filter(Boolean)
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get('Origin') || ''
-  const allowedOrigin = ALLOWED_ORIGINS.length > 0 && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0] || ''
-  return {
-    'Access-Control-Allow-Origin': allowedOrigin,
-    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  }
-}
+import { verifyJWT, getCorsHeaders } from '../_shared/auth.ts'
 
 interface TokenRequest {
   userId?: string
@@ -37,32 +27,21 @@ serve(async (req) => {
   }
 
   try {
-    // Initialize Supabase client
+    // Verify JWT before any operations
+    const { user, error: jwtError, status: jwtStatus } = await verifyJWT(req)
+    if (jwtError) {
+      return new Response(
+        JSON.stringify({ error: jwtError }),
+        { status: jwtStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Initialize Supabase client for DB operations
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!
     const supabaseKey = Deno.env.get('SUPABASE_ANON_KEY')!
     const openaiApiKey = Deno.env.get('OPENAI_API_KEY')!
-    
+
     const supabase = createClient(supabaseUrl, supabaseKey)
-
-    // Verify authentication
-    const authHeader = req.headers.get('Authorization')
-    if (!authHeader) {
-      return new Response(
-        JSON.stringify({ error: 'No authorization header' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
-
-    const { data: { user }, error: authError } = await supabase.auth.getUser(
-      authHeader.replace('Bearer ', '')
-    )
-
-    if (authError || !user) {
-      return new Response(
-        JSON.stringify({ error: 'Invalid token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
 
     // Parse request body
     const { sessionConfig = {} } = await req.json() as TokenRequest

--- a/supabase/functions/realtime-relay/index.ts
+++ b/supabase/functions/realtime-relay/index.ts
@@ -4,17 +4,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.56.1'
-
-const ALLOWED_ORIGINS = (Deno.env.get('ALLOWED_ORIGINS') || '').split(',').filter(Boolean)
-
-function getCorsHeaders(req: Request) {
-  const origin = req.headers.get('Origin') || ''
-  const allowedOrigin = ALLOWED_ORIGINS.length > 0 && ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0] || ''
-  return {
-    'Access-Control-Allow-Origin': allowedOrigin,
-    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  }
-}
+import { verifyJWT, getCorsHeaders, createAdminClient } from '../_shared/auth.ts'
 
 interface RelayEvent {
   conversation_id: string
@@ -46,33 +36,17 @@ serve(async (req) => {
   }
 
   try {
-    // Verify authentication
-    const authHeader = req.headers.get('Authorization')
-    if (!authHeader) {
+    // Verify JWT before any database operations
+    const { user, error: jwtError, status: jwtStatus } = await verifyJWT(req)
+    if (jwtError) {
       return new Response(
-        JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: jwtError }),
+        { status: jwtStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       )
     }
 
-    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
-    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!
-    const authClient = createClient(supabaseUrl, supabaseAnonKey)
-
-    const { data: { user }, error: authError } = await authClient.auth.getUser(
-      authHeader.replace('Bearer ', '')
-    )
-
-    if (authError || !user) {
-      return new Response(
-        JSON.stringify({ error: 'Invalid token' }),
-        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      )
-    }
-
-    // Initialize service client for DB operations
-    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+    // Initialize service client for DB operations (after JWT verification)
+    const supabase = createAdminClient()
 
     // Parse request body
     const body = await req.json()

--- a/supabase/functions/service-tasks-claim/index.ts
+++ b/supabase/functions/service-tasks-claim/index.ts
@@ -5,6 +5,7 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { getCorsHeaders } from '../_shared/auth.ts';
 
 /**
  * Validates input_params against a JSON Schema definition from ehg_services.artifact_schema.
@@ -98,20 +99,17 @@ function validateAgainstSchema(
   return { valid: errors.length === 0, errors };
 }
 
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
-
 serve(async (req: Request) => {
+  const corsHeaders = getCorsHeaders(req);
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: CORS_HEADERS });
+    return new Response('ok', { headers: corsHeaders });
   }
 
   if (req.method !== 'POST') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -120,7 +118,7 @@ serve(async (req: Request) => {
     if (!authHeader) {
       return new Response(
         JSON.stringify({ error: 'Missing authorization header' }),
-        { status: 401, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -130,7 +128,7 @@ serve(async (req: Request) => {
     if (!task_id) {
       return new Response(
         JSON.stringify({ error: 'task_id is required' }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -173,7 +171,7 @@ serve(async (req: Request) => {
                 error: 'Input validation failed against service artifact_schema',
                 validation_errors: validation.errors,
               }),
-              { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+              { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
             );
           }
         }
@@ -209,30 +207,30 @@ serve(async (req: Request) => {
         if (existing && existing.status !== 'pending') {
           return new Response(
             JSON.stringify({ error: 'Task already claimed or completed', current_status: existing.status }),
-            { status: 409, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+            { status: 409, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
           );
         }
 
         return new Response(
           JSON.stringify({ error: 'Task not found or not accessible' }),
-          { status: 404, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
 
       return new Response(
         JSON.stringify({ error: error.message }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
     return new Response(
       JSON.stringify({ task: data }),
-      { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (err) {
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });

--- a/supabase/functions/service-tasks-complete/index.ts
+++ b/supabase/functions/service-tasks-complete/index.ts
@@ -5,21 +5,19 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { getCorsHeaders } from '../_shared/auth.ts';
 
 serve(async (req: Request) => {
+  const corsHeaders = getCorsHeaders(req);
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: CORS_HEADERS });
+    return new Response('ok', { headers: corsHeaders });
   }
 
   if (req.method !== 'POST') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -28,7 +26,7 @@ serve(async (req: Request) => {
     if (!authHeader) {
       return new Response(
         JSON.stringify({ error: 'Missing authorization header' }),
-        { status: 401, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -38,14 +36,14 @@ serve(async (req: Request) => {
     if (!task_id) {
       return new Response(
         JSON.stringify({ error: 'task_id is required' }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
     if (!action || (action !== 'complete' && action !== 'fail')) {
       return new Response(
         JSON.stringify({ error: 'action must be "complete" or "fail"' }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -67,7 +65,7 @@ serve(async (req: Request) => {
         if (isNaN(score) || score < 0 || score > 1) {
           return new Response(
             JSON.stringify({ error: 'confidence_score must be between 0 and 1' }),
-            { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
           );
         }
       }
@@ -91,12 +89,12 @@ serve(async (req: Request) => {
         if (error.code === 'PGRST116') {
           return new Response(
             JSON.stringify({ error: 'Task not found, not claimed, or not accessible' }),
-            { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
           );
         }
         return new Response(
           JSON.stringify({ error: error.message }),
-          { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
 
@@ -140,7 +138,7 @@ serve(async (req: Request) => {
 
       return new Response(
         JSON.stringify({ task: data, aggregated_confidence }),
-        { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -150,7 +148,7 @@ serve(async (req: Request) => {
       if (!error_message) {
         return new Response(
           JSON.stringify({ error: 'error_message is required for fail action' }),
-          { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
 
@@ -171,24 +169,24 @@ serve(async (req: Request) => {
         if (error.code === 'PGRST116') {
           return new Response(
             JSON.stringify({ error: 'Task not found, not claimed, or not accessible' }),
-            { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+            { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
           );
         }
         return new Response(
           JSON.stringify({ error: error.message }),
-          { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
 
       return new Response(
         JSON.stringify({ task: data }),
-        { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
   } catch (err) {
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });

--- a/supabase/functions/service-tasks-poll/index.ts
+++ b/supabase/functions/service-tasks-poll/index.ts
@@ -5,21 +5,19 @@
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { getCorsHeaders } from '../_shared/auth.ts';
 
 serve(async (req: Request) => {
+  const corsHeaders = getCorsHeaders(req);
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: CORS_HEADERS });
+    return new Response('ok', { headers: corsHeaders });
   }
 
   if (req.method !== 'GET') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
@@ -28,7 +26,7 @@ serve(async (req: Request) => {
     if (!authHeader) {
       return new Response(
         JSON.stringify({ error: 'Missing authorization header' }),
-        { status: 401, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -68,18 +66,18 @@ serve(async (req: Request) => {
     if (error) {
       return new Response(
         JSON.stringify({ error: error.message }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
     return new Response(
       JSON.stringify({ tasks: data ?? [], count: data?.length ?? 0 }),
-      { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (err) {
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });

--- a/supabase/functions/tier-evaluation/index.ts
+++ b/supabase/functions/tier-evaluation/index.ts
@@ -4,12 +4,7 @@
 // promotion criteria thresholds, and writes new venture_tiers evaluation record.
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-
-const CORS_HEADERS = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-};
+import { verifyJWT, getCorsHeaders, createAdminClient } from '../_shared/auth.ts';
 
 // Default promotion criteria thresholds per tier
 const DEFAULT_CRITERIA: Record<string, {
@@ -55,23 +50,26 @@ interface TelemetrySnapshot {
 }
 
 serve(async (req: Request) => {
+  const corsHeaders = getCorsHeaders(req);
+
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { headers: CORS_HEADERS });
+    return new Response('ok', { headers: corsHeaders });
   }
 
   if (req.method !== 'POST') {
     return new Response(
       JSON.stringify({ error: 'Method not allowed' }),
-      { status: 405, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 
   try {
-    const authHeader = req.headers.get('Authorization');
-    if (!authHeader) {
+    // Verify JWT before any database operations
+    const { user, error: authError, status: authStatus } = await verifyJWT(req);
+    if (authError) {
       return new Response(
-        JSON.stringify({ error: 'Missing authorization header' }),
-        { status: 401, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: authError }),
+        { status: authStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -81,15 +79,12 @@ serve(async (req: Request) => {
     if (!venture_id) {
       return new Response(
         JSON.stringify({ error: 'venture_id is required' }),
-        { status: 400, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    // Use service_role client to read across tables
-    const supabase = createClient(
-      Deno.env.get('SUPABASE_URL') ?? '',
-      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
-    );
+    // Use service_role client for DB operations (after JWT verification)
+    const supabase = createAdminClient();
 
     // Verify venture exists
     const { data: venture, error: ventureError } = await supabase
@@ -101,7 +96,7 @@ serve(async (req: Request) => {
     if (ventureError || !venture) {
       return new Response(
         JSON.stringify({ error: 'Venture not found' }),
-        { status: 404, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -204,7 +199,7 @@ serve(async (req: Request) => {
     if (insertError) {
       return new Response(
         JSON.stringify({ error: 'Failed to write tier evaluation', details: insertError.message }),
-        { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -221,12 +216,12 @@ serve(async (req: Request) => {
           tier_record: tierRecord,
         },
       }),
-      { status: 200, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (err) {
     return new Response(
       JSON.stringify({ error: 'Internal server error' }),
-      { status: 500, headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' } }
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   }
 });


### PR DESCRIPTION
## Summary
- CRITICAL: Fixed privilege escalation in execute-exit (accepted any Authorization header value)
- Added JWT verification to 4 service_role edge functions
- Added chairman role check to execute-exit
- Replaced wildcard CORS on 7 functions with ALLOWED_ORIGINS checking
- Created shared auth module to deduplicate auth/CORS logic (-115 LOC net)

## Security Impact
- Before: Anyone with the edge function URL could manage venture exits
- After: Requires valid JWT + chairman role

## Test plan
- [x] Smoke tests pass
- [x] Zero wildcard CORS remaining
- [x] All service_role functions require JWT
- [x] execute-exit requires chairman role

SD-LEO-FIX-EDGE-FUNCTION-JWT-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)