### PR TITLE
fix: document all empty catch blocks with intent comments

### DIFF
--- a/.claude/statusline.cjs
+++ b/.claude/statusline.cjs
@@ -39,15 +39,15 @@ const RED = `${ESC}[0;31m`;
 const BOLD_RED = `${ESC}[1;31m`;
 const WHITE_ON_RED = `${ESC}[97;41m`;
 
-// Ensure log dir exists
-try { fs.mkdirSync(LOG_DIR, { recursive: true }); } catch (_) {}
+// Ensure log dir exists (silent: statusline must never crash)
+try { fs.mkdirSync(LOG_DIR, { recursive: true }); } catch (_) { /* intentionally silent: non-critical setup */ }
 
 // Read stdin synchronously via fd 0 — works reliably on Windows when Claude Code
 // spawns this process and writes JSON to its stdin (not a PowerShell pipeline).
 let inputJson = '';
 try {
   inputJson = fs.readFileSync(0, 'utf8');
-} catch (_) {}
+} catch (_) { /* intentionally silent: stdin may not be available */ }
 
 let data = null;
 if (inputJson && inputJson.trim().length > 0) {
@@ -130,14 +130,14 @@ try {
     }
     try {
       execSync('git diff --quiet 2>NUL', { cwd, timeout: 2000, windowsHide: true });
-    } catch (_) { gitDirty = '*'; }
+    } catch (_) { gitDirty = '*'; } // expected: non-zero exit = dirty
     if (!gitDirty) {
       try {
         execSync('git diff --cached --quiet 2>NUL', { cwd, timeout: 2000, windowsHide: true });
-      } catch (_) { gitDirty = '*'; }
+      } catch (_) { gitDirty = '*'; } // expected: non-zero exit = staged changes
     }
   }
-} catch (_) {}
+} catch (_) { /* intentionally silent: git may not be available */ }
 
 // Worktree SD detection
 let activeWorktreeSd = '';
@@ -150,7 +150,7 @@ try {
     if (dirs.length === 1) activeWorktreeSd = dirs[0];
     else if (dirs.length > 1) activeWorktreeSd = `${dirs.length}wt`;
   }
-} catch (_) {}
+} catch (_) { /* intentionally silent: worktree detection is optional */ }
 
 // Activity state
 let activityState = 'idle';
@@ -171,7 +171,7 @@ try {
       if (timeSinceActive <= 4) activityState = 'running';
     }
   }
-} catch (_) {}
+} catch (_) { /* intentionally silent: activity state is best-effort */ }
 
 // Activity signal
 const activitySignal = activityState === 'running'
@@ -196,7 +196,7 @@ try {
       autoProceedInfo = ` | AP:ON/${apPhase}/${apProgress}%${childInfo}`;
     }
   }
-} catch (_) {}
+} catch (_) { /* intentionally silent: auto-proceed display is optional */ }
 
 // Project info
 const projectName = path.basename(cwd);
@@ -230,7 +230,7 @@ try {
     hook_triggered: false
   };
   fs.writeFileSync(STATE_FILE, JSON.stringify(newState), 'utf8');
-} catch (_) {}
+} catch (_) { /* intentionally silent: state persistence is best-effort */ }
 
 process.stdout.write(output + '\n');
 process.exit(0);

--- a/scripts/archive/one-time/analyze-prompt.js
+++ b/scripts/archive/one-time/analyze-prompt.js
@@ -43,7 +43,7 @@ async function analyzePrompt(prompt) {
       const { execSync } = await import('child_process');
       const branch = execSync('git branch --show-current', { encoding: 'utf8' }).trim();
       context.git_branch = branch;
-    } catch (_e) {}
+    } catch (_e) { /* intentionally silent: git branch is optional context */ }
 
     // Analyze with context monitor
     const _contextAnalysis = await contextMonitor.analyzeContext(prompt, context);

--- a/server/routes/testing-campaign.js
+++ b/server/routes/testing-campaign.js
@@ -231,7 +231,7 @@ router.post('/stop', (req, res) => {
       const heartbeatPath = '/tmp/campaign-heartbeat.txt';
       if (fs.existsSync(heartbeatPath)) fs.unlinkSync(heartbeatPath);
       if (fs.existsSync('/tmp/campaign-checkpoint.json')) fs.unlinkSync('/tmp/campaign-checkpoint.json');
-    } catch (_e) {}
+    } catch (_e) { /* intentionally silent: cleanup failure is non-critical */ }
 
     res.status(500).json({ error: error.message });
   }


### PR DESCRIPTION
## Summary
- Document all 9 empty catch blocks in the codebase with inline comments explaining intent
- `statusline.cjs` (7 catches): must never crash — all operations are optional/best-effort
- `testing-campaign.js` (1 catch): cleanup failure is non-critical
- `analyze-prompt.js` (1 catch): git branch detection is optional context
- Zero behavior change — comments only

SD-LEO-FIX-EMPTY-CATCH-BLOCK-001

## Test plan
- [x] Changes are comment-only (zero code behavior change)
- [x] `grep` confirms all empty catches now have explanatory comments
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)