### PR TITLE
fix: gate query deduplication for gates 2, 3, and 4

### DIFF
--- a/scripts/modules/handoff/executors/exec-to-plan/gates/gate2-implementation-fidelity.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/gate2-implementation-fidelity.js
@@ -29,7 +29,9 @@ export function createGate2ImplementationFidelityGate(supabase) {
 
       // Use UUID (ctx.sd.id) not legacy_id (ctx.sdId) - queries use UUID FK
       const sdUuid = ctx.sd?.id || ctx.sdId;
-      return validateGate2ExecToPlan(sdUuid, supabase);
+      // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Pass pre-fetched context
+      const prefetched = { sd: ctx.sd, prd: ctx.prd, handoffHistory: ctx._prefetched?.handoffHistory };
+      return validateGate2ExecToPlan(sdUuid, supabase, { prefetched });
     },
     required: true
   };

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/traceability-gates.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/traceability-gates.js
@@ -25,18 +25,25 @@ export function createTraceabilityGate(supabase) {
       // Use UUID (ctx.sd.id) not legacy_id (ctx.sdId) - handoffs are stored by UUID
       const sdUuid = ctx.sd?.id || ctx.sdId;
 
-      // Fetch Gate 2 results from EXEC→PLAN handoff
-      const { data: execToPlanHandoff } = await supabase
-        .from('sd_phase_handoffs')
-        .select('metadata')
-        .eq('sd_id', sdUuid)
-        .eq('handoff_type', 'EXEC-TO-PLAN')
-        .order('created_at', { ascending: false })
-        .limit(1);
+      // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched handoff data when available
+      let gate2Results = null;
+      const handoffHistory = ctx._prefetched?.handoffHistory;
+      if (handoffHistory) {
+        const execToPlan = handoffHistory.find(h => h.handoff_type === 'EXEC-TO-PLAN');
+        gate2Results = execToPlan?.metadata?.gate2_validation || null;
+      } else {
+        const { data: execToPlanHandoff } = await supabase
+          .from('sd_phase_handoffs')
+          .select('metadata')
+          .eq('sd_id', sdUuid)
+          .eq('handoff_type', 'EXEC-TO-PLAN')
+          .order('created_at', { ascending: false })
+          .limit(1);
+        gate2Results = execToPlanHandoff?.[0]?.metadata?.gate2_validation || null;
+      }
 
-      const gate2Results = execToPlanHandoff?.[0]?.metadata?.gate2_validation || null;
-
-      const result = await validateGate3PlanToLead(sdUuid, supabase, gate2Results);
+      const prefetched = { sd: ctx.sd, prd: ctx.prd, handoffHistory };
+      const result = await validateGate3PlanToLead(sdUuid, supabase, gate2Results, { prefetched });
       ctx._gate3Results = result;
 
       return result;
@@ -64,31 +71,41 @@ export function createWorkflowROIGate(supabase) {
       // Use UUID (ctx.sd.id) not legacy_id (ctx.sdId) - handoffs are stored by UUID
       const sdUuid = ctx.sd?.id || ctx.sdId;
 
-      // Fetch Gate 1 results from PLAN→EXEC handoff
-      const { data: planToExecHandoff } = await supabase
-        .from('sd_phase_handoffs')
-        .select('metadata')
-        .eq('sd_id', sdUuid)
-        .eq('handoff_type', 'PLAN-TO-EXEC')
-        .order('created_at', { ascending: false })
-        .limit(1);
+      // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched handoff data when available
+      const handoffHistory = ctx._prefetched?.handoffHistory;
+      let allGateResults;
+      if (handoffHistory) {
+        const planToExec = handoffHistory.find(h => h.handoff_type === 'PLAN-TO-EXEC');
+        const execToPlan = handoffHistory.find(h => h.handoff_type === 'EXEC-TO-PLAN');
+        allGateResults = {
+          gate1: planToExec?.metadata?.gate1_validation || null,
+          gate2: execToPlan?.metadata?.gate2_validation || null,
+          gate3: ctx._gate3Results || null
+        };
+      } else {
+        const { data: planToExecHandoff } = await supabase
+          .from('sd_phase_handoffs')
+          .select('metadata')
+          .eq('sd_id', sdUuid)
+          .eq('handoff_type', 'PLAN-TO-EXEC')
+          .order('created_at', { ascending: false })
+          .limit(1);
+        const { data: execToPlanHandoff } = await supabase
+          .from('sd_phase_handoffs')
+          .select('metadata')
+          .eq('sd_id', sdUuid)
+          .eq('handoff_type', 'EXEC-TO-PLAN')
+          .order('created_at', { ascending: false })
+          .limit(1);
+        allGateResults = {
+          gate1: planToExecHandoff?.[0]?.metadata?.gate1_validation || null,
+          gate2: execToPlanHandoff?.[0]?.metadata?.gate2_validation || null,
+          gate3: ctx._gate3Results || null
+        };
+      }
 
-      // Fetch Gate 2 results from EXEC→PLAN handoff
-      const { data: execToPlanHandoff } = await supabase
-        .from('sd_phase_handoffs')
-        .select('metadata')
-        .eq('sd_id', sdUuid)
-        .eq('handoff_type', 'EXEC-TO-PLAN')
-        .order('created_at', { ascending: false })
-        .limit(1);
-
-      const allGateResults = {
-        gate1: planToExecHandoff?.[0]?.metadata?.gate1_validation || null,
-        gate2: execToPlanHandoff?.[0]?.metadata?.gate2_validation || null,
-        gate3: ctx._gate3Results || null
-      };
-
-      const result = await validateGate4LeadFinal(sdUuid, supabase, allGateResults);
+      const prefetched = { sd: ctx.sd, prd: ctx.prd, handoffHistory };
+      const result = await validateGate4LeadFinal(sdUuid, supabase, allGateResults, { prefetched });
       ctx._gate4Results = result;
 
       return result;

--- a/scripts/modules/handoff/validation/ValidationOrchestrator.js
+++ b/scripts/modules/handoff/validation/ValidationOrchestrator.js
@@ -33,6 +33,9 @@ import { validateGateResult } from './gate-result-schema.js';
 // SD-LEO-INFRA-OIV-001: Operational Integration Verification
 import { OIVGate, OIV_GATE_WEIGHT } from './oiv/index.js';
 
+// SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Gate context preloader
+import { preloadGateContext, getGateNumberForRule } from './validator-registry/gate-context-preloader.js';
+
 export class ValidationOrchestrator {
   constructor(supabase, options = {}) {
     if (!supabase) {
@@ -211,6 +214,10 @@ export class ValidationOrchestrator {
       issues: [],
       warnings: []
     };
+
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Pre-fetch shared gate data
+    // before running validators to eliminate redundant DB queries within a gate group
+    await this.preloadGateContexts(gates, context);
 
     // Track weighted scores for normalization
     let weightedScoreSum = 0;
@@ -561,6 +568,55 @@ export class ValidationOrchestrator {
     console.error('='.repeat(60));
   }
 
+  /**
+   * SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Pre-fetch shared gate data
+   * before running validators. Analyzes the gate list to determine which
+   * numbered gates (2, 3, 4) are present, fetches the shared validation
+   * data once per gate number, and injects it into context.gateContext.
+   *
+   * @param {Array} gates - Array of gate definitions about to be validated
+   * @param {Object} context - Validation context (will be mutated to add gateContext)
+   * @returns {Promise<void>}
+   */
+  async preloadGateContexts(gates, context) {
+    // Determine which gate numbers are present in the gate list
+    const gateNumbers = new Set();
+    for (const gate of gates) {
+      // Extract rule name from gate name (format: "GATE_CODE:rule_name" or just "rule_name")
+      const ruleName = gate.meta?.ruleName || (gate.name.includes(':') ? gate.name.split(':')[1] : gate.name);
+      const gateNum = getGateNumberForRule(ruleName);
+      if (gateNum !== null) {
+        gateNumbers.add(gateNum);
+      }
+    }
+
+    if (gateNumbers.size === 0) return;
+
+    const sdId = context.sd_id || context.sdId;
+    if (!sdId || !context.supabase) return;
+
+    const gateContext = {};
+
+    for (const gateNum of gateNumbers) {
+      try {
+        const extras = {};
+        if (gateNum === 3) extras.gate2Results = context.gate2Results || null;
+        if (gateNum === 4) extras.allGateResults = context.allGateResults || {};
+        // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Pass pre-fetched data from BaseExecutor
+        if (context._prefetched) extras.prefetched = { sd: context.sd, prd: context.prd, handoffHistory: context._prefetched?.handoffHistory };
+
+        const preloaded = await preloadGateContext(gateNum, sdId, context.supabase, extras);
+        Object.assign(gateContext, preloaded);
+      } catch (err) {
+        // Preload failure is non-fatal — validators will fetch independently
+        console.log(`   [GatePreloader] Warning: Gate ${gateNum} preload failed (${err.message}), validators will query independently`);
+      }
+    }
+
+    // Inject preloaded data into context
+    context.gateContext = gateContext;
+  }
+
   clearCache() {
     this.constraintsCache = null;
     this.constraintsCacheExpiry = 0;
@@ -878,6 +934,9 @@ export class ValidationOrchestrator {
       issues: [],       // ALL issues from ALL gates
       warnings: []
     };
+
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Pre-fetch shared gate data
+    await this.preloadGateContexts(gates, context);
 
     let weightedScoreSum = 0;
     let totalWeight = 0;

--- a/scripts/modules/handoff/validation/validator-registry/gate-context-preloader.js
+++ b/scripts/modules/handoff/validation/validator-registry/gate-context-preloader.js
@@ -1,0 +1,101 @@
+/**
+ * Gate Context Preloader
+ * SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001
+ *
+ * Pre-fetches shared validation data for numbered gates (2, 3, 4) so that
+ * individual validators within a gate can reuse the same query result instead
+ * of each making redundant DB calls.
+ *
+ * Usage:
+ *   const gateContext = await preloadGateContext(gateNumber, sdId, supabase, extras);
+ *   // Pass gateContext on the validator context object:
+ *   context.gateContext = gateContext;
+ *   // Each validator checks ctx.gateContext?.gate2Result first.
+ */
+
+import { validateGate2ExecToPlan } from '../../../implementation-fidelity-validation.js';
+import { validateGate3PlanToLead } from '../../../traceability-validation.js';
+import { validateGate4LeadFinal } from '../../../workflow-roi-validation.js';
+
+/**
+ * Pre-fetch shared gate data so validators can reuse it.
+ *
+ * @param {number} gateNumber - The gate number (2, 3, or 4)
+ * @param {string} sdId - Strategic Directive ID
+ * @param {object} supabase - Supabase client
+ * @param {object} [extras={}] - Additional args per gate:
+ *   gate 3: { gate2Results }
+ *   gate 4: { allGateResults }
+ * @returns {Promise<object>} Pre-fetched gate context keyed by gate result name
+ */
+export async function preloadGateContext(gateNumber, sdId, supabase, extras = {}) {
+  const context = {};
+  // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Pass pre-fetched data to avoid duplicate queries
+  const prefetchOpts = extras.prefetched ? { prefetched: extras.prefetched } : {};
+
+  switch (gateNumber) {
+    case 2: {
+      console.log('   [GatePreloader] Pre-fetching Gate 2 data (single query for all validators)');
+      context.gate2Result = await validateGate2ExecToPlan(sdId, supabase, prefetchOpts);
+      break;
+    }
+    case 3: {
+      console.log('   [GatePreloader] Pre-fetching Gate 3 data (single query for all validators)');
+      context.gate3Result = await validateGate3PlanToLead(sdId, supabase, extras.gate2Results || null, prefetchOpts);
+      break;
+    }
+    case 4: {
+      console.log('   [GatePreloader] Pre-fetching Gate 4 data (single query for all validators)');
+      context.gate4Result = await validateGate4LeadFinal(sdId, supabase, extras.allGateResults || {}, prefetchOpts);
+      break;
+    }
+    default:
+      // No preloading needed for other gates
+      break;
+  }
+
+  return context;
+}
+
+/**
+ * Determine which gate number a rule_name belongs to.
+ * Returns null if the rule is not part of a preloadable gate.
+ *
+ * @param {string} ruleName - The validator rule_name
+ * @returns {number|null} Gate number (2, 3, or 4) or null
+ */
+export function getGateNumberForRule(ruleName) {
+  if (GATE_2_RULES.has(ruleName)) return 2;
+  if (GATE_3_RULES.has(ruleName)) return 3;
+  if (GATE_4_RULES.has(ruleName)) return 4;
+  return null;
+}
+
+// Rule names that belong to each gate (for gate grouping detection)
+const GATE_2_RULES = new Set([
+  'uiComponentsImplemented',
+  'userWorkflowsImplemented',
+  'userActionsSupported',
+  'migrationsCreatedAndExecuted',
+  'rlsPoliciesImplemented',
+  'migrationComplexityAligned',
+  'databaseQueriesIntegrated',
+  'formUiIntegration',
+  'dataValidationImplemented',
+  'e2eTestCoverage'
+]);
+
+const GATE_3_RULES = new Set([
+  'recommendationAdherence',
+  'implementationQuality',
+  'traceabilityMapping',
+  'subAgentEffectiveness',
+  'lessonsCaptured'
+]);
+
+const GATE_4_RULES = new Set([
+  'valueDelivered',
+  'patternEffectiveness',
+  'executiveValidation',
+  'processAdherence'
+]);

--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-2-implementation-fidelity.js
@@ -1,11 +1,29 @@
 /**
  * Gates 2A-2D - Implementation Fidelity Validators
  * Part of SD-LEO-REFACTOR-VALIDATOR-REG-001
+ *
+ * SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Validators now check
+ * ctx.gateContext.gate2Result before making independent DB queries.
+ * The preloader fetches shared data once; validators reuse it.
  */
 
 import { validateGate2ExecToPlan } from '../../../../implementation-fidelity-validation.js';
 import { shouldSkipCodeValidation } from '../../../../../../lib/utils/sd-type-validation.js';
 import { validateWireframeQA } from '../../../validators/wireframe-qa-validator.js';
+
+/**
+ * Get Gate 2 result from preloaded context or fetch it fresh.
+ * @param {object} context - Validator context
+ * @returns {Promise<object>} Gate 2 validation result
+ */
+async function getGate2Result(context) {
+  // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use preloaded result if available
+  if (context.gateContext?.gate2Result) {
+    return context.gateContext.gate2Result;
+  }
+  const { sd_id, supabase } = context;
+  return validateGate2ExecToPlan(sd_id, supabase);
+}
 
 /**
  * Register Gate 2 validators
@@ -14,8 +32,7 @@ import { validateWireframeQA } from '../../../validators/wireframe-qa-validator.
 export function registerGate2Validators(registry) {
   // Section A: UI Components Implementation
   registry.register('uiComponentsImplemented', async (context) => {
-    const { sd_id, supabase } = context;
-    const result = await validateGate2ExecToPlan(sd_id, supabase);
+    const result = await getGate2Result(context);
 
     // Extract Section A score - check multiple paths for compatibility
     const sectionA = result?.sections?.A || result?.sectionScores?.A ||
@@ -48,8 +65,7 @@ export function registerGate2Validators(registry) {
 
   // Section B: Database Migrations
   registry.register('migrationsCreatedAndExecuted', async (context) => {
-    const { sd_id, supabase } = context;
-    const result = await validateGate2ExecToPlan(sd_id, supabase);
+    const result = await getGate2Result(context);
 
     const sectionB = result?.sections?.B || result?.sectionScores?.B ||
       result?.details?.database_fidelity || {};
@@ -80,8 +96,7 @@ export function registerGate2Validators(registry) {
 
   // Section C: Data Flow
   registry.register('databaseQueriesIntegrated', async (context) => {
-    const { sd_id, supabase } = context;
-    const result = await validateGate2ExecToPlan(sd_id, supabase);
+    const result = await getGate2Result(context);
 
     const sectionC = result?.sections?.C || result?.sectionScores?.C ||
       result?.details?.data_flow_alignment || {};
@@ -112,8 +127,7 @@ export function registerGate2Validators(registry) {
 
   // Section D: E2E Testing
   registry.register('e2eTestCoverage', async (context) => {
-    const { sd_id, supabase } = context;
-    const result = await validateGate2ExecToPlan(sd_id, supabase);
+    const result = await getGate2Result(context);
 
     const sectionD = result?.sections?.D || result?.sectionScores?.D ||
       result?.details?.enhanced_testing || {};

--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-3-traceability.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-3-traceability.js
@@ -1,9 +1,27 @@
 /**
  * Gate 3 - Traceability Validators
  * Part of SD-LEO-REFACTOR-VALIDATOR-REG-001
+ *
+ * SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Validators now check
+ * ctx.gateContext.gate3Result before making independent DB queries.
+ * The preloader fetches shared data once; validators reuse it.
  */
 
 import { validateGate3PlanToLead } from '../../../../traceability-validation.js';
+
+/**
+ * Get Gate 3 result from preloaded context or fetch it fresh.
+ * @param {object} context - Validator context
+ * @returns {Promise<object>} Gate 3 validation result
+ */
+async function getGate3Result(context) {
+  // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use preloaded result if available
+  if (context.gateContext?.gate3Result) {
+    return context.gateContext.gate3Result;
+  }
+  const { sd_id, supabase, gate2Results } = context;
+  return validateGate3PlanToLead(sd_id, supabase, gate2Results);
+}
 
 /**
  * Register Gate 3 validators
@@ -12,8 +30,7 @@ import { validateGate3PlanToLead } from '../../../../traceability-validation.js'
 export function registerGate3Validators(registry) {
   // Section A: Recommendation Adherence (30 points)
   registry.register('recommendationAdherence', async (context) => {
-    const { sd_id, supabase, gate2Results } = context;
-    const result = await validateGate3PlanToLead(sd_id, supabase, gate2Results);
+    const result = await getGate3Result(context);
 
     // SD-QUALITY-UI-001 FIX: Check multiple paths for section A score
     const sectionAFromSections = result?.sections?.A || {};
@@ -37,8 +54,7 @@ export function registerGate3Validators(registry) {
 
   // Section B: Implementation Quality (30 points)
   registry.register('implementationQuality', async (context) => {
-    const { sd_id, supabase, gate2Results } = context;
-    const result = await validateGate3PlanToLead(sd_id, supabase, gate2Results);
+    const result = await getGate3Result(context);
 
     const sectionBFromSections = result?.sections?.B || {};
     const sectionBScore = sectionBFromSections.score ??
@@ -61,8 +77,7 @@ export function registerGate3Validators(registry) {
 
   // Section C: Traceability Mapping (25 points)
   registry.register('traceabilityMapping', async (context) => {
-    const { sd_id, supabase, gate2Results } = context;
-    const result = await validateGate3PlanToLead(sd_id, supabase, gate2Results);
+    const result = await getGate3Result(context);
 
     const sectionCFromSections = result?.sections?.C || {};
     const sectionCScore = sectionCFromSections.score ??
@@ -85,8 +100,7 @@ export function registerGate3Validators(registry) {
 
   // Section D: Sub-Agent Effectiveness (10 points)
   registry.register('subAgentEffectiveness', async (context) => {
-    const { sd_id, supabase, gate2Results } = context;
-    const result = await validateGate3PlanToLead(sd_id, supabase, gate2Results);
+    const result = await getGate3Result(context);
 
     const sectionDFromSections = result?.sections?.D || {};
     const sectionDScore = sectionDFromSections.score ??
@@ -108,8 +122,7 @@ export function registerGate3Validators(registry) {
 
   // Section E: Lessons Captured (5 points)
   registry.register('lessonsCaptured', async (context) => {
-    const { sd_id, supabase, gate2Results } = context;
-    const result = await validateGate3PlanToLead(sd_id, supabase, gate2Results);
+    const result = await getGate3Result(context);
 
     const sectionEFromSections = result?.sections?.E || {};
     const sectionEScore = sectionEFromSections.score ??

--- a/scripts/modules/handoff/validation/validator-registry/gates/gate-4-strategic-value.js
+++ b/scripts/modules/handoff/validation/validator-registry/gates/gate-4-strategic-value.js
@@ -1,9 +1,27 @@
 /**
  * Gate 4 - Strategic Value Validators (LEAD Final)
  * Part of SD-LEO-REFACTOR-VALIDATOR-REG-001
+ *
+ * SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Validators now check
+ * ctx.gateContext.gate4Result before making independent DB queries.
+ * The preloader fetches shared data once; validators reuse it.
  */
 
 import { validateGate4LeadFinal } from '../../../../workflow-roi-validation.js';
+
+/**
+ * Get Gate 4 result from preloaded context or fetch it fresh.
+ * @param {object} context - Validator context
+ * @returns {Promise<object>} Gate 4 validation result
+ */
+async function getGate4Result(context) {
+  // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use preloaded result if available
+  if (context.gateContext?.gate4Result) {
+    return context.gateContext.gate4Result;
+  }
+  const { sd_id, supabase, allGateResults } = context;
+  return validateGate4LeadFinal(sd_id, supabase, allGateResults);
+}
 
 /**
  * Register Gate 4 validators
@@ -11,23 +29,22 @@ import { validateGate4LeadFinal } from '../../../../workflow-roi-validation.js';
  */
 export function registerGate4Validators(registry) {
   registry.register('valueDelivered', async (context) => {
-    const { sd_id, supabase, allGateResults } = context;
-    const result = await validateGate4LeadFinal(sd_id, supabase, allGateResults);
+    const result = await getGate4Result(context);
     return registry.normalizeResult(result);
   }, 'Strategic value delivered');
 
   registry.register('patternEffectiveness', async (context) => {
-    // Part of Gate 4 composite validation
+    // Part of Gate 4 composite validation — reuses same preloaded result
     return registry.validators.get('valueDelivered').validate(context);
   }, 'Pattern effectiveness');
 
   registry.register('executiveValidation', async (context) => {
-    // Part of Gate 4 composite validation
+    // Part of Gate 4 composite validation — reuses same preloaded result
     return registry.validators.get('valueDelivered').validate(context);
   }, 'Executive validation');
 
   registry.register('processAdherence', async (context) => {
-    // Part of Gate 4 composite validation
+    // Part of Gate 4 composite validation — reuses same preloaded result
     return registry.validators.get('valueDelivered').validate(context);
   }, 'Process adherence');
 }

--- a/scripts/modules/handoff/validation/validator-registry/index.js
+++ b/scripts/modules/handoff/validation/validator-registry/index.js
@@ -64,4 +64,7 @@ export {
   registerAdditionalValidators
 } from './gates/index.js';
 
+// SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Gate context preloader
+export { preloadGateContext, getGateNumberForRule } from './gate-context-preloader.js';
+
 export default ValidatorRegistry;

--- a/scripts/modules/implementation-fidelity/index.js
+++ b/scripts/modules/implementation-fidelity/index.js
@@ -42,7 +42,7 @@ import {
  * @param {Object} supabase - Supabase client
  * @returns {Promise<Object>} Validation result
  */
-export async function validateGate2ExecToPlan(sd_id, supabase) {
+export async function validateGate2ExecToPlan(sd_id, supabase, options = {}) {
   console.log('\n🚪 GATE 2: Implementation Fidelity Validation (EXEC→PLAN)');
   console.log('='.repeat(60));
 
@@ -58,12 +58,13 @@ export async function validateGate2ExecToPlan(sd_id, supabase) {
   };
 
   // Check if this is a documentation-only SD
+  // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched SD when available
   try {
-    const { data: sd } = await supabase
+    const sd = options.prefetched?.sd || (await supabase
       .from('strategic_directives_v2')
       .select('id, title, sd_type, scope, category')
       .eq('id', sd_id)
-      .single();
+      .single()).data;
 
     if (sd && shouldSkipCodeValidation(sd)) {
       const validationReqs = getValidationRequirements(sd);
@@ -109,16 +110,18 @@ export async function validateGate2ExecToPlan(sd_id, supabase) {
   // SD-LEO-FIX-COMPLETION-WORKFLOW-001: Fixed SD lookup to not use deprecated legacy_id
   let resolvedSdUuid = sd_id;
   try {
-    let sd;
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched SD when available
+    let sd = options.prefetched?.sd || null;
 
-    // Try direct ID lookup first (works for both UUID and SD-KEY format IDs)
-    const result = await supabase
-      .from('strategic_directives_v2')
-      .select('id, title, sd_type, scope, category, intensity_level, target_application')
-      .eq('id', sd_id)
-      .single();
-
-    sd = result.data;
+    if (!sd) {
+      // Try direct ID lookup first (works for both UUID and SD-KEY format IDs)
+      const result = await supabase
+        .from('strategic_directives_v2')
+        .select('id, title, sd_type, scope, category, intensity_level, target_application')
+        .eq('id', sd_id)
+        .single();
+      sd = result.data;
+    }
     if (sd?.id) {
       resolvedSdUuid = sd.id;
     }
@@ -179,12 +182,17 @@ export async function validateGate2ExecToPlan(sd_id, supabase) {
 
   try {
     // Fetch PRD metadata
-    // SD-LEO-FIX-PRD-FETCH-001: Use sd_id column (UUID) instead of directive_id (SD key string)
-    const { data: prdData, error: prdError } = await supabase
-      .from('product_requirements_v2')
-      .select('metadata, directive_id, sd_id, title')
-      .eq('sd_id', resolvedSdUuid)
-      .single();
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched PRD when available
+    let prdData = options.prefetched?.prd || null;
+    let prdError = null;
+    if (!prdData) {
+      // SD-LEO-FIX-PRD-FETCH-001: Use sd_id column (UUID) instead of directive_id (SD key string)
+      ({ data: prdData, error: prdError } = await supabase
+        .from('product_requirements_v2')
+        .select('metadata, directive_id, sd_id, title')
+        .eq('sd_id', resolvedSdUuid)
+        .single());
+    }
 
     if (prdError) {
       console.log(`   ⚠️  PRD fetch error: ${prdError.message}`);
@@ -228,24 +236,32 @@ export async function validateGate2ExecToPlan(sd_id, supabase) {
     console.log('\n' + '='.repeat(60));
     console.log(`GATE 2 SCORE: ${validation.score}/${validation.max_score} points`);
 
-    const { data: gate1Handoff } = await supabase
-      .from('sd_phase_handoffs')
-      .select('metadata')
-      .eq('sd_id', sd_id)
-      .eq('handoff_type', 'PLAN-TO-EXEC')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .single();
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched handoff/SD data when available
+    let gate1Handoff;
+    const handoffHistory = options.prefetched?.handoffHistory;
+    if (handoffHistory) {
+      gate1Handoff = handoffHistory.find(h => h.handoff_type === 'PLAN-TO-EXEC') || null;
+    } else {
+      const { data } = await supabase
+        .from('sd_phase_handoffs')
+        .select('metadata')
+        .eq('sd_id', sd_id)
+        .eq('handoff_type', 'PLAN-TO-EXEC')
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .single();
+      gate1Handoff = data;
+    }
 
     const priorGateScores = gate1Handoff?.metadata?.gate1_validation?.score
       ? [gate1Handoff.metadata.gate1_validation.score]
       : [];
 
-    const { data: sdData } = await supabase
+    const sdData = options.prefetched?.sd || (await supabase
       .from('strategic_directives_v2')
       .select('*')
       .eq('id', sd_id)
-      .single();
+      .single()).data;
 
     const patternStats = await getPatternStats(sdData, supabase);
 

--- a/scripts/modules/traceability-validation/index.js
+++ b/scripts/modules/traceability-validation/index.js
@@ -42,12 +42,13 @@ import {
  * @param {Object} gate2Results - Results from Gate 2 validation (optional)
  * @returns {Promise<Object>} Validation result
  */
-export async function validateGate3PlanToLead(sd_id, supabase, gate2Results = null) {
+export async function validateGate3PlanToLead(sd_id, supabase, gate2Results = null, options = {}) {
   console.log('\n GATE 3: End-to-End Traceability Validation (PLAN->LEAD)');
   console.log('='.repeat(60));
 
   // Resolve SD context (UUID, key, category, type, repo path)
-  const { sdUuid, sdKey, sdCategory, sdType, gitRepoPath } = await resolveSDContext(sd_id, supabase);
+  // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Pass pre-fetched SD to avoid duplicate query
+  const { sdUuid, sdKey, sdCategory, sdType, gitRepoPath } = await resolveSDContext(sd_id, supabase, options.prefetched?.sd);
 
   const validation = {
     passed: true,
@@ -71,24 +72,28 @@ export async function validateGate3PlanToLead(sd_id, supabase, gate2Results = nu
   console.log('-'.repeat(60));
 
   try {
-    // Fetch PRD metadata (try sd_key first, fallback to UUID for legacy PRDs)
-    let prdData, prdError;
-    ({ data: prdData, error: prdError } = await supabase
-      .from('product_requirements_v2')
-      .select('metadata, directive_id, title')
-      .eq('directive_id', sdKey)
-      .single());
-
-    // Root Cause 1 fix: Fallback to UUID if sd_key lookup failed
-    // Some PRDs (created via auto-generation before fix) store UUID in directive_id
-    if (prdError && sdUuid && sdUuid !== sdKey) {
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched PRD when available
+    let prdData = options.prefetched?.prd || null;
+    let prdError = null;
+    if (!prdData) {
+      // Fetch PRD metadata (try sd_key first, fallback to UUID for legacy PRDs)
       ({ data: prdData, error: prdError } = await supabase
         .from('product_requirements_v2')
         .select('metadata, directive_id, title')
-        .eq('directive_id', sdUuid)
+        .eq('directive_id', sdKey)
         .single());
-      if (prdData) {
-        console.log('   ℹ️  PRD found via UUID fallback (directive_id format mismatch)');
+
+      // Root Cause 1 fix: Fallback to UUID if sd_key lookup failed
+      // Some PRDs (created via auto-generation before fix) store UUID in directive_id
+      if (prdError && sdUuid && sdUuid !== sdKey) {
+        ({ data: prdData, error: prdError } = await supabase
+          .from('product_requirements_v2')
+          .select('metadata, directive_id, title')
+          .eq('directive_id', sdUuid)
+          .single());
+        if (prdData) {
+          console.log('   ℹ️  PRD found via UUID fallback (directive_id format mismatch)');
+        }
       }
     }
 
@@ -156,12 +161,19 @@ export async function validateGate3PlanToLead(sd_id, supabase, gate2Results = nu
     console.log('\n' + '='.repeat(60));
     console.log(`GATE 3 SCORE: ${validation.score}/${validation.max_score} points`);
 
-    const { data: handoffs } = await supabase
-      .from('sd_phase_handoffs')
-      .select('handoff_type, metadata')
-      .eq('sd_id', sdUuid)
-      .in('handoff_type', ['PLAN-TO-EXEC', 'EXEC-TO-PLAN'])
-      .order('created_at', { ascending: false });
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched handoff/SD data when available
+    const handoffHistory = options.prefetched?.handoffHistory;
+    let handoffs;
+    if (handoffHistory) {
+      handoffs = handoffHistory.filter(h => ['PLAN-TO-EXEC', 'EXEC-TO-PLAN'].includes(h.handoff_type));
+    } else {
+      ({ data: handoffs } = await supabase
+        .from('sd_phase_handoffs')
+        .select('handoff_type, metadata')
+        .eq('sd_id', sdUuid)
+        .in('handoff_type', ['PLAN-TO-EXEC', 'EXEC-TO-PLAN'])
+        .order('created_at', { ascending: false }));
+    }
 
     const priorGateScores = [];
     if (handoffs) {
@@ -171,11 +183,11 @@ export async function validateGate3PlanToLead(sd_id, supabase, gate2Results = nu
       if (gate2) priorGateScores.push(gate2);
     }
 
-    const { data: sdData } = await supabase
+    const sdData = options.prefetched?.sd || (await supabase
       .from('strategic_directives_v2')
       .select('*')
       .eq('id', sd_id)
-      .single();
+      .single()).data;
 
     const patternStats = await getPatternStats(sdData, supabase);
 

--- a/scripts/modules/traceability-validation/utils.js
+++ b/scripts/modules/traceability-validation/utils.js
@@ -19,22 +19,24 @@ export const EHG_ROOT = path.resolve(__dirname, '../../../../ehg');
 /**
  * Resolve SD UUID and get SD metadata
  * SD-LEO-GEN-RENAME-COLUMNS-SELF-001-D1: Removed legacy_id (column dropped 2026-01-24)
+ * SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Accept optional pre-fetched SD data
  * @param {string} sd_id - SD ID (may be sd_key or UUID)
  * @param {Object} supabase - Supabase client
+ * @param {Object} [prefetchedSd] - Pre-fetched SD data to avoid duplicate query
  * @returns {Promise<{sdUuid: string, sdKey: string, sdCategory: string|null, sdType: string|null, gitRepoPath: string}>}
  */
-export async function resolveSDContext(sd_id, supabase) {
+export async function resolveSDContext(sd_id, supabase, prefetchedSd = null) {
   let sdUuid = sd_id;
   let sdKey = sd_id;
   let sdCategory = null;
   let sdType = null;
   let gitRepoPath = process.cwd();
 
-  const { data: sdData } = await supabase
+  const sdData = prefetchedSd || (await supabase
     .from('strategic_directives_v2')
     .select('id, sd_key, category, metadata, target_application, sd_type')
     .or(`sd_key.eq.${sd_id},id.eq.${sd_id}`)
-    .single();
+    .single()).data;
 
   if (sdData) {
     sdUuid = sdData.id;

--- a/scripts/modules/workflow-roi-validation.js
+++ b/scripts/modules/workflow-roi-validation.js
@@ -38,7 +38,7 @@ const execAsync = promisify(exec);
  * @param {Object} allGateResults - Results from Gates 1-3 (optional)
  * @returns {Promise<Object>} Validation result
  */
-export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {}) {
+export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {}, options = {}) {
   console.log('\n🚪 GATE 4: Workflow ROI & Pattern Effectiveness (LEAD Final)');
   console.log('='.repeat(60));
 
@@ -58,11 +58,12 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
     // PRD.directive_id stores sd_key; sd_phase_handoffs.sd_id stores UUID (strategic_directives_v2.id)
     let prdLookupId = sd_id;
     let handoffLookupId = sd_id;
-    const { data: sdLookup } = await supabase
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched SD when available
+    const sdLookup = options.prefetched?.sd || (await supabase
       .from('strategic_directives_v2')
       .select('id, sd_key, sd_type')
       .or(`sd_key.eq.${sd_id},id.eq.${sd_id}`)
-      .single();
+      .single()).data;
     if (sdLookup) {
       prdLookupId = sdLookup.sd_key || sd_id;
       handoffLookupId = sdLookup.id || sd_id;
@@ -76,23 +77,27 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
       console.log(`   ℹ️  SD type '${sdType}' uses modified workflow - gate2 (EXEC-TO-PLAN) not required`);
     }
 
-    // Fetch PRD metadata with DESIGN and DATABASE analyses
-    let prdData, prdError;
-    ({ data: prdData, error: prdError } = await supabase
-      .from('product_requirements_v2')
-      .select('metadata, directive_id, title, created_at')
-      .eq('directive_id', prdLookupId)
-      .single());
-
-    // Root Cause 1 fix: Fallback to UUID if sd_key lookup failed
-    if (prdError && handoffLookupId && handoffLookupId !== prdLookupId) {
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched PRD when available
+    let prdData = options.prefetched?.prd || null;
+    let prdError = null;
+    if (!prdData) {
+      // Fetch PRD metadata with DESIGN and DATABASE analyses
       ({ data: prdData, error: prdError } = await supabase
         .from('product_requirements_v2')
         .select('metadata, directive_id, title, created_at')
-        .eq('directive_id', handoffLookupId)
+        .eq('directive_id', prdLookupId)
         .single());
-      if (prdData) {
-        console.log('   ℹ️  PRD found via UUID fallback (directive_id format mismatch)');
+
+      // Root Cause 1 fix: Fallback to UUID if sd_key lookup failed
+      if (prdError && handoffLookupId && handoffLookupId !== prdLookupId) {
+        ({ data: prdData, error: prdError } = await supabase
+          .from('product_requirements_v2')
+          .select('metadata, directive_id, title, created_at')
+          .eq('directive_id', handoffLookupId)
+          .single());
+        if (prdData) {
+          console.log('   ℹ️  PRD found via UUID fallback (directive_id format mismatch)');
+        }
       }
     }
 
@@ -120,12 +125,12 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
     // SD-LEARN-FIX-ADDRESS-PAT-AUTO-002: Track data sources for audit trail
     const gateDataSources = { gate1: 'none', gate2: 'none', gate3: 'none' };
     if (!gateResults.gate1 && !gateResults.gate2 && !gateResults.gate3) {
-      // Try to fetch from handoff metadata (use UUID for handoff lookup)
-      const { data: handoffs } = await supabase
+      // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched handoff data when available
+      const handoffs = options.prefetched?.handoffHistory || (await supabase
         .from('sd_phase_handoffs')
         .select('handoff_type, metadata, status, created_at')
         .eq('sd_id', handoffLookupId)
-        .order('created_at', { ascending: false });
+        .order('created_at', { ascending: false })).data;
 
       if (handoffs) {
         for (const handoff of handoffs) {
@@ -313,12 +318,12 @@ export async function validateGate4LeadFinal(sd_id, supabase, allGateResults = {
     if (gateResults.gate2?.score) priorGateScores.push(gateResults.gate2.score);
     if (gateResults.gate3?.score) priorGateScores.push(gateResults.gate3.score);
 
-    // Fetch SD data for pattern tracking
-    const { data: sdData } = await supabase
+    // SD-LEO-FIX-GATE-QUERY-DEDUPLICATION-001: Use pre-fetched SD for pattern tracking
+    const sdData = options.prefetched?.sd || (await supabase
       .from('strategic_directives_v2')
       .select('*')
       .eq('id', sd_id)
-      .single();
+      .single()).data;
 
     // Fetch pattern statistics for maturity bonus
     const patternStats = await getPatternStats(sdData, supabase);


### PR DESCRIPTION
## Summary
- Pre-fetches handoff history once in BaseExecutor before gates run, eliminating ~6 duplicate `sd_phase_handoffs` queries
- Passes pre-fetched SD, PRD, and handoff data through validation context to gates 2, 3, and 4
- Adds gate-context-preloader for database-driven validator registry sub-validators
- Fully backward compatible — gates fall back to individual queries when prefetched data is absent

**Impact**: Reduces gate-related Supabase queries from ~16 to ~4 per handoff execution (75% reduction).

## Test plan
- [x] All 13 modified files parse without errors
- [x] Handoff precheck runs successfully (19 gates evaluated, 17 passed — 2 pre-existing failures unrelated to this change)
- [ ] Run full PLAN-TO-LEAD handoff on a completed SD to verify end-to-end gate scoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)