### PR TITLE
fix: venture pipeline gate resilience

### DIFF
--- a/database/migrations/20260317_fix_chairman_decision_check_and_unblock_trigger.sql
+++ b/database/migrations/20260317_fix_chairman_decision_check_and_unblock_trigger.sql
@@ -1,0 +1,83 @@
+-- Migration: Fix chairman_decisions_decision_check + auto-unblock orchestrator trigger
+-- SD: SD-LEO-FIX-VENTURE-PIPELINE-GATE-RESILIENCE-001
+-- Date: 2026-03-17
+-- Purpose:
+--   1. Expand chairman_decisions.decision CHECK constraint to include 'review' and 'advisory'
+--   2. Create trigger to auto-reset ventures.orchestrator_state to 'idle' when a decision is approved
+--
+-- Pre-migration validation (run manually to confirm):
+--   SELECT conname, pg_get_constraintdef(oid)
+--   FROM pg_constraint WHERE conname = 'chairman_decisions_decision_check';
+
+BEGIN;
+
+-- ============================================================
+-- Migration 1: Fix chairman_decisions_decision_check constraint
+-- ============================================================
+-- Current constraint has 28 values but is missing: 'review', 'advisory'
+-- Strategy: DROP existing, re-ADD with all original values PLUS the new ones
+
+ALTER TABLE chairman_decisions
+  DROP CONSTRAINT IF EXISTS chairman_decisions_decision_check;
+
+ALTER TABLE chairman_decisions
+  ADD CONSTRAINT chairman_decisions_decision_check
+  CHECK (decision::text = ANY (ARRAY[
+    -- Original values (28)
+    'pass', 'revise', 'kill', 'conditional_pass',
+    'go', 'conditional_go', 'no_go',
+    'complete', 'continue', 'blocked', 'fail',
+    'approve', 'conditional', 'reject',
+    'release', 'hold', 'cancel',
+    'no-go', 'pivot', 'expand', 'sunset', 'exit',
+    'proceed', 'fix', 'pause', 'override',
+    'pending', 'terminate',
+    -- New values (2)
+    'review', 'advisory'
+  ]::text[]));
+
+-- ============================================================
+-- Migration 2: Auto-reset orchestrator_state trigger
+-- ============================================================
+-- When a chairman_decisions row is updated to status='approved',
+-- reset the parent venture's orchestrator_state from 'blocked' to 'idle'
+-- so the pipeline can resume processing.
+
+CREATE OR REPLACE FUNCTION trg_chairman_approval_unblock_orchestrator()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Only fire when status changes to 'approved'
+  IF NEW.status = 'approved' AND (OLD.status IS DISTINCT FROM 'approved') THEN
+    UPDATE ventures
+    SET orchestrator_state = 'idle'
+    WHERE id = NEW.venture_id
+      AND orchestrator_state = 'blocked';
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop trigger if it already exists (idempotent)
+DROP TRIGGER IF EXISTS trg_chairman_decision_unblock ON chairman_decisions;
+
+CREATE TRIGGER trg_chairman_decision_unblock
+  AFTER UPDATE ON chairman_decisions
+  FOR EACH ROW
+  WHEN (NEW.status = 'approved' AND OLD.status IS DISTINCT FROM NEW.status)
+  EXECUTE FUNCTION trg_chairman_approval_unblock_orchestrator();
+
+COMMIT;
+
+-- Rollback SQL (for reference):
+--   BEGIN;
+--   DROP TRIGGER IF EXISTS trg_chairman_decision_unblock ON chairman_decisions;
+--   DROP FUNCTION IF EXISTS trg_chairman_approval_unblock_orchestrator();
+--   ALTER TABLE chairman_decisions DROP CONSTRAINT IF EXISTS chairman_decisions_decision_check;
+--   ALTER TABLE chairman_decisions ADD CONSTRAINT chairman_decisions_decision_check
+--     CHECK (decision::text = ANY (ARRAY[
+--       'pass','revise','kill','conditional_pass','go','conditional_go','no_go',
+--       'complete','continue','blocked','fail','approve','conditional','reject',
+--       'release','hold','cancel','no-go','pivot','expand','sunset','exit',
+--       'proceed','fix','pause','override','pending','terminate'
+--     ]::text[]));
+--   COMMIT;

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -531,7 +531,15 @@ export class StageExecutionWorker {
         if (REVIEW_MODE_STAGES.has(currentStage) && !CHAIRMAN_GATES.BLOCKING.has(currentStage)) {
           this._logger.log(`[Worker] Review-mode stage ${currentStage} — blocking for chairman review`);
 
+          // Revert current_lifecycle_stage back to the review stage so the UI
+          // shows the correct stage (not N+1) while awaiting review.
+          await this._supabase
+            .from('ventures')
+            .update({ current_lifecycle_stage: currentStage })
+            .eq('id', ventureId);
+
           // Create a chairman_decisions row with decision_type = 'review'
+          let reviewInsertOk = false;
           try {
             const { data: ventureForReview } = await this._supabase
               .from('ventures')
@@ -539,22 +547,35 @@ export class StageExecutionWorker {
               .eq('id', ventureId)
               .single();
 
-            await this._supabase.from('chairman_decisions').insert({
+            const { error: insertError } = await this._supabase.from('chairman_decisions').insert({
               venture_id: ventureId,
               lifecycle_stage: currentStage,
               decision_type: 'review',
+              decision: 'review',
               status: 'pending',
               summary: `Review: Stage ${currentStage} complete for ${ventureForReview?.name || ventureId}`,
               brief_data: { stage: currentStage, ventureName: ventureForReview?.name },
             });
+            if (insertError) {
+              this._logger.error(`[Worker] Review decision INSERT failed: ${insertError.message}`);
+            } else {
+              reviewInsertOk = true;
+            }
           } catch (err) {
-            this._logger.warn(`[Worker] Review decision creation failed (non-fatal): ${err.message}`);
+            this._logger.error(`[Worker] Review decision creation failed: ${err.message}`);
           }
 
-          this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
-          releaseState = ORCHESTRATOR_STATES.BLOCKED;
-          lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'review' };
-          break;
+          // Only block the orchestrator if the decision row was successfully created.
+          // If the insert failed, the venture would be permanently stuck with no
+          // UI path to unblock. Instead, log the error and continue processing.
+          if (reviewInsertOk) {
+            this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
+            releaseState = ORCHESTRATOR_STATES.BLOCKED;
+            lastResult = { ventureId, stageId: currentStage, status: 'blocked', gate: 'review' };
+            break;
+          } else {
+            this._logger.warn(`[Worker] Skipping review block for stage ${currentStage} — decision insert failed, continuing to prevent stuck venture`);
+          }
         }
 
         // Check chairman gate AFTER stage execution so validation data


### PR DESCRIPTION
## Summary
- Add `review` and `advisory` to `chairman_decisions_decision_check` constraint (was silently rejecting valid decision types)
- Add `trg_chairman_decision_unblock` trigger to auto-reset `orchestrator_state` when gate decisions are approved
- Fix review-mode stages to revert `current_lifecycle_stage` before blocking (prevents UI showing stage N+1 during review of stage N)
- Add insert failure recovery — orchestrator only enters `blocked` state if the decision row was created successfully

## Context
Found during live Structura venture walkthrough. Every gate and review stage was affected by silent failures that left ventures permanently stuck with no UI path to recover.

## Test plan
- [x] DB migration executed and verified (constraint + trigger)
- [x] INSERT with decision='review' succeeds
- [x] Approving chairman_decision auto-resets orchestrator_state from blocked to idle
- [ ] Full venture lifecycle test (stages 1-12) with no stuck ventures
- [ ] Review-mode stages show correct stage number in UI

SD: SD-LEO-FIX-VENTURE-PIPELINE-GATE-RESILIENCE-001

Generated with [Claude Code](https://claude.com/claude-code)