### PR TITLE
feat: handoff --dry-run flag for gate audit and debugging

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEO-FIX-LLM-FACTORY-BYPASS-001",
-  "expectedBranch": "feat/SD-LEO-FIX-LLM-FACTORY-BYPASS-001",
-  "createdAt": "2026-03-17T18:33:06.318Z",
+  "sdKey": "SD-LEO-INFRA-HANDOFF-DRY-RUN-001",
+  "expectedBranch": "feat/SD-LEO-INFRA-HANDOFF-DRY-RUN-001",
+  "createdAt": "2026-03-17T18:44:21.456Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -267,6 +267,159 @@ export class HandoffOrchestrator {
   }
 
   /**
+   * Dry-run a handoff: resolve gate policies and display a manifest
+   * without executing gates, writing to database, or updating SD status.
+   *
+   * @param {string} handoffType - Handoff type (case-insensitive)
+   * @param {string} sdId - Strategic Directive ID
+   * @param {object} options - Options
+   * @returns {Promise<object>} Dry-run manifest
+   */
+  async dryRunHandoff(handoffType, sdId, options = {}) {
+    const normalizedType = handoffType.toUpperCase();
+
+    try {
+      // Validate handoff type
+      if (!this.supportedHandoffs.includes(normalizedType)) {
+        return {
+          success: false,
+          error: `Unsupported handoff type: ${normalizedType}. Valid: ${this.supportedHandoffs.join(', ')}`
+        };
+      }
+
+      // Step 1: Load SD info (read-only)
+      const sd = await this.sdRepo.getById(sdId);
+      if (!sd) {
+        return {
+          success: false,
+          error: `SD not found: ${sdId}`
+        };
+      }
+
+      // Step 2: Get executor
+      const executor = await this._getExecutor(normalizedType);
+      if (!executor) {
+        return {
+          success: false,
+          error: `No executor registered for handoff type: ${normalizedType}`
+        };
+      }
+
+      // Step 3: Get hardcoded gates from executor
+      const hardcodedGates = await executor.getRequiredGates(sd, options);
+
+      // Step 4: Inject DFE escalation gate (same as BaseExecutor.execute)
+      const hasDFE = hardcodedGates.some(g => g.name === 'DFE_ESCALATION_GATE');
+      if (!hasDFE) {
+        const { createDFEEscalationGate } = await import('./gates/dfe-escalation-gate.js');
+        hardcodedGates.push(createDFEEscalationGate(this.supabase, `${normalizedType}-gate`));
+      }
+
+      // Step 5: Apply gate policies (reads validation_gate_registry)
+      const { applyGatePolicies } = await import('./gate-policy-resolver.js');
+      const { filteredGates, resolutions, fallbackUsed } = await applyGatePolicies(
+        this.supabase,
+        hardcodedGates,
+        {
+          sdType: sd.sd_type,
+          validationProfile: sd.validation_profile || options.validationProfile,
+          sdId: sd.sd_key || sdId
+        }
+      );
+
+      // Step 6: Load database-driven rules (for display only)
+      const dbRules = await this.validationOrchestrator.loadValidationRules(normalizedType);
+
+      // Step 7: Resolve threshold
+      const { THRESHOLD_PROFILES } = await import('../../sd-type-checker.js');
+      const sdType = (sd.sd_type || 'feature').toLowerCase();
+      const thresholdProfile = THRESHOLD_PROFILES[sdType] || THRESHOLD_PROFILES.default;
+      const gateThreshold = thresholdProfile?.gateThreshold || 85;
+
+      // Step 8: Build manifest
+      const allGateNames = hardcodedGates.map(g => g.name || g.key || 'unknown');
+      const filteredGateNames = new Set(filteredGates.map(g => g.name || g.key || 'unknown'));
+      const dbRuleNames = new Set(dbRules.map(r => `${r.gate}:${r.rule_name}`));
+
+      const manifest = [];
+      for (const gate of hardcodedGates) {
+        const gateName = gate.name || gate.key || 'unknown';
+        const isEnabled = filteredGateNames.has(gateName);
+        const resolution = resolutions.find(r => r.gate_key === gateName);
+        const isRequired = gate.required !== false;
+
+        let source = 'executor';
+        if (gate.meta?.fromDatabase) {
+          source = 'validation_rules';
+        } else if (resolution) {
+          source = 'registry';
+        }
+
+        let policyReason = null;
+        if (!isEnabled && resolution) {
+          policyReason = `${resolution.matched_scope}: ${resolution.applicability}`;
+        } else if (!isEnabled) {
+          // Find the reason from the gate policy resolver resolutions
+          const matchingResolution = resolutions.find(r => r.gate_key === gateName && r.applicability === 'DISABLED');
+          if (matchingResolution) {
+            policyReason = `sd_type=${sdType}`;
+          }
+        }
+
+        manifest.push({
+          name: gateName,
+          enabled: isEnabled,
+          source,
+          required: isRequired,
+          policyReason,
+          weight: gate.weight || 0
+        });
+      }
+
+      // Add database rules not already represented
+      for (const rule of dbRules) {
+        const ruleName = `${rule.gate}:${rule.rule_name}`;
+        if (!allGateNames.includes(ruleName)) {
+          manifest.push({
+            name: ruleName,
+            enabled: true,
+            source: 'validation_rules',
+            required: rule.required !== false,
+            policyReason: null,
+            weight: rule.weight || 0
+          });
+        }
+      }
+
+      const enabledCount = manifest.filter(g => g.enabled).length;
+      const disabledCount = manifest.filter(g => !g.enabled).length;
+
+      return {
+        success: true,
+        handoffType: normalizedType,
+        sdId,
+        sdKey: sd.sd_key,
+        sdTitle: sd.title,
+        sdType,
+        gateThreshold,
+        fallbackUsed,
+        manifest,
+        summary: {
+          enabled: enabledCount,
+          disabled: disabledCount,
+          total: manifest.length
+        }
+      };
+
+    } catch (error) {
+      return {
+        success: false,
+        error: error.message
+      };
+    }
+  }
+
+  /**
    * List handoff executions
    * @param {object} filters - Query filters
    * @returns {Promise<array>} Execution records

--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -154,6 +154,7 @@ export function displayHelp() {
   console.log('  verify SD-ID           - Verify SD is truly complete (PAT-WF-NEXT-001)');
   console.log('  pending                - Show SDs stuck in pending_approval');
   console.log('  precheck TYPE SD-ID    - Find ALL issues before execute (batch validation)');
+  console.log('  dry-run TYPE SD-ID     - Show gate manifest without executing (read-only)');
   console.log('  execute TYPE SD-ID     - Execute handoff');
   console.log('  list [SD-ID]           - List handoff executions');
   console.log('  stats                  - Show system statistics');
@@ -178,10 +179,16 @@ export function displayHelp() {
   console.log('  --no-auto-proceed   Disable AUTO-PROCEED mode for this handoff');
   console.log('  (Precedence: CLI > ENV > Session > Database > Default)');
   console.log('');
+  console.log('DRY RUN FLAGS:');
+  console.log('  --dry-run               Show gate manifest instead of executing');
+  console.log('                          (can be used with execute or as standalone command)');
+  console.log('');
   console.log('EXAMPLES:');
   console.log('  node scripts/handoff.js workflow SD-LEO-GEMINI-001');
   console.log('  node scripts/handoff.js execute PLAN-TO-EXEC SD-FEATURE-001');
   console.log('  node scripts/handoff.js execute PLAN-TO-EXEC SD-FEATURE-001 --auto-proceed');
+  console.log('  node scripts/handoff.js execute PLAN-TO-EXEC SD-FEATURE-001 --dry-run');
+  console.log('  node scripts/handoff.js dry-run LEAD-TO-PLAN SD-INFRA-001');
   console.log('  node scripts/handoff.js list SD-FEATURE-001');
   console.log('  node scripts/handoff.js stats');
 
@@ -278,6 +285,71 @@ export async function introspectGateStatus(sdId, { json = true } = {}) {
     console.log(JSON.stringify({ sd_id: sdId, gates: results }, null, 2));
   }
   return results;
+}
+
+/**
+ * Handle dry-run command
+ *
+ * Shows a gate manifest for a handoff without executing anything.
+ * Displays which gates would run, which are disabled by policy,
+ * the threshold that would apply, and the source of each gate.
+ *
+ * @param {string} handoffType - Handoff type
+ * @param {string} sdId - SD identifier
+ * @returns {Promise<Object>} Result
+ */
+export async function handleDryRunCommand(handoffType, sdId) {
+  if (!handoffType || !sdId) {
+    console.log('Usage: node scripts/handoff.js dry-run HANDOFF_TYPE SD-ID');
+    console.log('');
+    console.log('Shows which gates WOULD run without executing anything.');
+    console.log('No database writes, no SD status changes.');
+    console.log('');
+    console.log('Examples:');
+    console.log('  node scripts/handoff.js dry-run LEAD-TO-PLAN SD-EXAMPLE-001');
+    console.log('  node scripts/handoff.js execute PLAN-TO-EXEC SD-EXAMPLE-001 --dry-run');
+    return { success: false };
+  }
+
+  const system = createHandoffSystem();
+  const result = await system.dryRunHandoff(handoffType, sdId);
+
+  if (!result.success) {
+    console.error(`\nDRY RUN ERROR: ${result.error}`);
+    return { success: false };
+  }
+
+  // Display manifest
+  console.log('');
+  console.log(`DRY RUN: ${result.handoffType} for ${result.sdKey || result.sdId}`);
+  console.log('='.repeat(70));
+  console.log('');
+  console.log(`  SD Title: ${result.sdTitle}`);
+  console.log(`  SD Type: ${result.sdType}`);
+  console.log(`  Gate Threshold: ${result.gateThreshold}%`);
+  if (result.fallbackUsed) {
+    console.log('  Policy Source: FALLBACK (validation_gate_registry unavailable)');
+  }
+  console.log('');
+  console.log('  Gates that would execute:');
+  console.log('  ' + '-'.repeat(66));
+
+  for (const gate of result.manifest) {
+    const status = gate.enabled ? 'ENABLED ' : 'DISABLED';
+    const req = gate.required ? 'Required' : 'Advisory';
+    let line = `    ${status} | ${gate.name.padEnd(38)} | Source: ${gate.source.padEnd(16)} | ${req}`;
+    if (!gate.enabled && gate.policyReason) {
+      line += `\n             Policy: ${gate.policyReason}`;
+    }
+    console.log(line);
+  }
+
+  console.log('');
+  console.log('  ' + '-'.repeat(66));
+  console.log(`  Summary: ${result.summary.enabled} gates enabled, ${result.summary.disabled} disabled by policy, ${result.summary.total} total`);
+  console.log('');
+
+  return { success: true };
 }
 
 export async function handlePrecheckCommand(precheckType, precheckSdId) {
@@ -957,9 +1029,18 @@ export async function main() {
       result = await handlePrecheckCommand(args[1], args[2]);
       break;
 
+    case 'dry-run':
+      result = await handleDryRunCommand(args[1], args[2]);
+      break;
+
     case 'execute':
-      // Use continuation wrapper for AUTO-PROCEED child SD continuation
-      result = await handleExecuteWithContinuation(args[1], args[2], args);
+      // Check for --dry-run flag on execute command
+      if (args.includes('--dry-run')) {
+        result = await handleDryRunCommand(args[1], args[2]);
+      } else {
+        // Use continuation wrapper for AUTO-PROCEED child SD continuation
+        result = await handleExecuteWithContinuation(args[1], args[2], args);
+      }
       break;
 
     case 'list':

--- a/scripts/modules/handoff/cli/index.js
+++ b/scripts/modules/handoff/cli/index.js
@@ -14,6 +14,7 @@ export {
   handleVerifyCommand,
   handlePendingCommand,
   handlePrecheckCommand,
+  handleDryRunCommand,
   handleExecuteCommand,
   handleListCommand,
   handleStatsCommand


### PR DESCRIPTION
## Summary
- New `dryRunHandoff()` in HandoffOrchestrator (153 lines)
- Shows gate manifest: enabled/disabled status, source, policy reasons
- Two invocation styles: `dry-run` command or `--dry-run` flag
- No DB writes, no gate execution, no status changes

## Usage
```bash
node scripts/handoff.js dry-run LEAD-TO-PLAN SD-XXX-001
node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001 --dry-run
```

## Test plan
- [x] Smoke tests pass
- [x] No existing behavior changed
- [x] Help text updated

SD-LEO-INFRA-HANDOFF-DRY-RUN-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)