### PR TITLE
fix: SyntaxError in HandoffRecorder.js (blocks all handoffs)

### DIFF
--- a/scripts/modules/handoff/recording/HandoffRecorder.js
+++ b/scripts/modules/handoff/recording/HandoffRecorder.js
@@ -320,10 +320,8 @@ export class HandoffRecorder {
             .eq('sd_id', sdId)
             .eq('status', 'active');
         } catch (fallbackErr) {
-          // Non-blocking: ignore if both methods fail
+          console.warn(`   [handoff-fail-count] Non-blocking: ${fallbackErr.message}`);
         }
-      } catch (failCountErr) {
-        console.warn(`   [handoff-fail-count] Non-blocking: ${failCountErr.message}`);
       }
 
       // SD-MAN-FEAT-CORRECTIVE-VISION-GAP-072 US-001: Governance audit trail


### PR DESCRIPTION
## Summary
- Fix SyntaxError at HandoffRecorder.js:325 from PR #2294
- Extra `catch(failCountErr)` had no matching `try` block
- **CRITICAL**: This blocks ALL handoff operations system-wide

## Test plan
- [x] `node -c` syntax check passes
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)