### PR TITLE
feat: handoff dry-run mode with gate evaluation

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,6 +294,7 @@
     "session:info": "node scripts/claude-session-coordinator.mjs info",
     "session:worktree": "node scripts/session-worktree.js",
     "handoff": "node scripts/handoff.js",
+    "handoff:dry-run": "node scripts/unified-handoff-system-v2.js execute --dry-run",
     "handoff:list": "node scripts/handoff.js list",
     "handoff:stats": "node scripts/handoff.js stats",
     "handoff:compliance": "node scripts/check-handoff-compliance.js",

--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -394,6 +394,77 @@ export class HandoffOrchestrator {
       const enabledCount = manifest.filter(g => g.enabled).length;
       const disabledCount = manifest.filter(g => !g.enabled).length;
 
+      // Step 9 (optional): Evaluate gates if requested
+      let evaluationResults = null;
+      let aggregateScore = null;
+      let wouldPass = null;
+
+      if (options.evaluate) {
+        console.log('\n  Evaluating gates (dry-run, no writes)...');
+
+        // Load PRD for context
+        let prd = null;
+        try { prd = await this.prdRepo.getBySdId(sd.id); } catch (_) { /* no PRD yet is ok */ }
+
+        const validationContext = {
+          sdId,
+          sd_id: sd.id || sdId,
+          sd,
+          prd,
+          prdId: prd?.id,
+          options: {},
+          supabase: this.supabase
+        };
+
+        // Build final gate set from rules + policy-filtered gates
+        const gates = await this.validationOrchestrator.buildGatesFromRules(
+          filteredGates,
+          normalizedType,
+          validationContext
+        );
+
+        // Run all gates without stopping (batch mode)
+        const gateResults = await this.validationOrchestrator.validateGatesAll(gates, validationContext);
+
+        // Build per-gate evaluation rows
+        evaluationResults = [];
+        for (const gate of manifest) {
+          const gateName = gate.name;
+          const result = gateResults.gateResults[gateName];
+          evaluationResults.push({
+            name: gateName,
+            source: gate.source,
+            enabled: gate.enabled,
+            required: gate.required,
+            score: result ? result.score : null,
+            maxScore: result ? result.maxScore : null,
+            passed: result ? result.passed : null,
+            issues: result?.issues || []
+          });
+        }
+
+        // Include any gates that were in gateResults but not in manifest
+        // (e.g. database-driven rules merged by buildGatesFromRules)
+        const manifestNames = new Set(manifest.map(m => m.name));
+        for (const [gateName, result] of Object.entries(gateResults.gateResults)) {
+          if (!manifestNames.has(gateName)) {
+            evaluationResults.push({
+              name: gateName,
+              source: 'validation_rules',
+              enabled: true,
+              required: true,
+              score: result.score,
+              maxScore: result.maxScore,
+              passed: result.passed,
+              issues: result.issues || []
+            });
+          }
+        }
+
+        aggregateScore = gateResults.normalizedScore;
+        wouldPass = gateResults.passed && aggregateScore >= gateThreshold;
+      }
+
       return {
         success: true,
         handoffType: normalizedType,
@@ -404,6 +475,9 @@ export class HandoffOrchestrator {
         gateThreshold,
         fallbackUsed,
         manifest,
+        evaluationResults,
+        aggregateScore,
+        wouldPass,
         summary: {
           enabled: enabledCount,
           disabled: disabledCount,

--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -298,31 +298,38 @@ export async function introspectGateStatus(sdId, { json = true } = {}) {
  * @param {string} sdId - SD identifier
  * @returns {Promise<Object>} Result
  */
-export async function handleDryRunCommand(handoffType, sdId) {
+export async function handleDryRunCommand(handoffType, sdId, options = {}) {
   if (!handoffType || !sdId) {
-    console.log('Usage: node scripts/handoff.js dry-run HANDOFF_TYPE SD-ID');
+    console.log('Usage: node scripts/handoff.js dry-run HANDOFF_TYPE SD-ID [--evaluate]');
     console.log('');
     console.log('Shows which gates WOULD run without executing anything.');
     console.log('No database writes, no SD status changes.');
     console.log('');
+    console.log('Flags:');
+    console.log('  --evaluate   Also run gate evaluation to show scores (default when invoked via --dry-run on execute)');
+    console.log('');
     console.log('Examples:');
     console.log('  node scripts/handoff.js dry-run LEAD-TO-PLAN SD-EXAMPLE-001');
+    console.log('  node scripts/handoff.js dry-run LEAD-TO-PLAN SD-EXAMPLE-001 --evaluate');
     console.log('  node scripts/handoff.js execute PLAN-TO-EXEC SD-EXAMPLE-001 --dry-run');
     return { success: false };
   }
 
   const system = createHandoffSystem();
-  const result = await system.dryRunHandoff(handoffType, sdId);
+
+  // --evaluate triggers gate scoring; --dry-run on execute always evaluates
+  const evaluate = options.evaluate !== undefined ? options.evaluate : false;
+  const result = await system.dryRunHandoff(handoffType, sdId, { evaluate });
 
   if (!result.success) {
     console.error(`\nDRY RUN ERROR: ${result.error}`);
     return { success: false };
   }
 
-  // Display manifest
+  // Display manifest header
   console.log('');
   console.log(`DRY RUN: ${result.handoffType} for ${result.sdKey || result.sdId}`);
-  console.log('='.repeat(70));
+  console.log('='.repeat(90));
   console.log('');
   console.log(`  SD Title: ${result.sdTitle}`);
   console.log(`  SD Type: ${result.sdType}`);
@@ -331,23 +338,68 @@ export async function handleDryRunCommand(handoffType, sdId) {
     console.log('  Policy Source: FALLBACK (validation_gate_registry unavailable)');
   }
   console.log('');
-  console.log('  Gates that would execute:');
-  console.log('  ' + '-'.repeat(66));
 
-  for (const gate of result.manifest) {
-    const status = gate.enabled ? 'ENABLED ' : 'DISABLED';
-    const req = gate.required ? 'Required' : 'Advisory';
-    let line = `    ${status} | ${gate.name.padEnd(38)} | Source: ${gate.source.padEnd(16)} | ${req}`;
-    if (!gate.enabled && gate.policyReason) {
-      line += `\n             Policy: ${gate.policyReason}`;
+  // If evaluation results available, show scored summary table
+  if (result.evaluationResults) {
+    console.log('  Gate                                    | Source           | Score     | Result');
+    console.log('  ' + '-'.repeat(86));
+
+    for (const row of result.evaluationResults) {
+      const name = row.name.substring(0, 40).padEnd(40);
+      const src = row.source.padEnd(16);
+      const score = row.score !== null ? `${row.score}/${row.maxScore}`.padEnd(9) : 'N/A      ';
+      let verdict;
+      if (!row.enabled) {
+        verdict = 'DISABLED';
+      } else if (row.passed === null) {
+        verdict = 'N/A';
+      } else {
+        verdict = row.passed ? 'PASS' : 'FAIL';
+      }
+      console.log(`  ${name} | ${src} | ${score} | ${verdict}`);
     }
-    console.log(line);
-  }
 
-  console.log('');
-  console.log('  ' + '-'.repeat(66));
-  console.log(`  Summary: ${result.summary.enabled} gates enabled, ${result.summary.disabled} disabled by policy, ${result.summary.total} total`);
-  console.log('');
+    console.log('  ' + '-'.repeat(86));
+    console.log(`  Aggregate: ${result.aggregateScore}% (threshold: ${result.gateThreshold}%) => ${result.wouldPass ? 'WOULD PASS' : 'WOULD FAIL'}`);
+    console.log('');
+
+    // Show failed gate details
+    const failedGates = result.evaluationResults.filter(r => r.enabled && r.passed === false);
+    if (failedGates.length > 0) {
+      console.log('  FAILED GATE DETAILS:');
+      for (const gate of failedGates) {
+        console.log(`    ${gate.name}:`);
+        for (const issue of gate.issues.slice(0, 5)) {
+          console.log(`      - ${issue}`);
+        }
+        if (gate.issues.length > 5) {
+          console.log(`      ... and ${gate.issues.length - 5} more`);
+        }
+      }
+      console.log('');
+    }
+  } else {
+    // Manifest-only display (no evaluation)
+    console.log('  Gates that would execute:');
+    console.log('  ' + '-'.repeat(66));
+
+    for (const gate of result.manifest) {
+      const status = gate.enabled ? 'ENABLED ' : 'DISABLED';
+      const req = gate.required ? 'Required' : 'Advisory';
+      let line = `    ${status} | ${gate.name.padEnd(38)} | Source: ${gate.source.padEnd(16)} | ${req}`;
+      if (!gate.enabled && gate.policyReason) {
+        line += `\n             Policy: ${gate.policyReason}`;
+      }
+      console.log(line);
+    }
+
+    console.log('');
+    console.log('  ' + '-'.repeat(66));
+    console.log(`  Summary: ${result.summary.enabled} gates enabled, ${result.summary.disabled} disabled by policy, ${result.summary.total} total`);
+    console.log('');
+    console.log('  TIP: Add --evaluate to also run gate scoring');
+    console.log('');
+  }
 
   return { success: true };
 }
@@ -1030,13 +1082,14 @@ export async function main() {
       break;
 
     case 'dry-run':
-      result = await handleDryRunCommand(args[1], args[2]);
+      result = await handleDryRunCommand(args[1], args[2], { evaluate: args.includes('--evaluate') });
       break;
 
     case 'execute':
       // Check for --dry-run flag on execute command
       if (args.includes('--dry-run')) {
-        result = await handleDryRunCommand(args[1], args[2]);
+        // --dry-run on execute always evaluates gates (shows scores)
+        result = await handleDryRunCommand(args[1], args[2], { evaluate: true });
       } else {
         // Use continuation wrapper for AUTO-PROCEED child SD continuation
         result = await handleExecuteWithContinuation(args[1], args[2], args);

--- a/scripts/unified-handoff-system-v2.js
+++ b/scripts/unified-handoff-system-v2.js
@@ -80,17 +80,51 @@ async function main() {
     case 'execute': {
       const handoffType = args[1];
       const sdId = args[2];
-      const prdId = args[3];
+      const dryRun = args.includes('--dry-run');
+      const prdId = args.find((a, i) => i >= 3 && !a.startsWith('--'));
 
       if (!handoffType || !sdId) {
-        console.log('Usage: node unified-handoff-system-v2.js execute HANDOFF_TYPE SD-YYYY-XXX [PRD-ID]');
+        console.log('Usage: node unified-handoff-system-v2.js execute HANDOFF_TYPE SD-YYYY-XXX [PRD-ID] [--dry-run]');
         console.log('');
         console.log('Handoff Types (case-insensitive, normalized to uppercase):');
         console.log('  LEAD-TO-PLAN   - Strategic to Planning handoff');
         console.log('  PLAN-TO-EXEC   - Planning to Execution handoff');
         console.log('  EXEC-TO-PLAN   - Execution to Verification handoff');
         console.log('  PLAN-TO-LEAD   - Verification to Final Approval handoff');
+        console.log('');
+        console.log('Flags:');
+        console.log('  --dry-run   Show gate manifest and scores without executing');
         process.exit(1);
+      }
+
+      if (dryRun) {
+        const result = await system._orchestrator.dryRunHandoff(handoffType, sdId, { prdId, evaluate: true });
+        if (!result.success) {
+          console.error(`DRY RUN ERROR: ${result.error}`);
+          process.exit(1);
+        }
+        // Display summary table
+        console.log('');
+        console.log(`DRY RUN: ${result.handoffType} for ${result.sdKey || result.sdId}`);
+        console.log('='.repeat(70));
+        console.log(`  SD: ${result.sdTitle} (${result.sdType})`);
+        console.log(`  Threshold: ${result.gateThreshold}%`);
+        console.log('');
+        if (result.evaluationResults) {
+          console.log('  Gate                                    | Source           | Score     | Result');
+          console.log('  ' + '-'.repeat(86));
+          for (const row of result.evaluationResults) {
+            const name = row.name.padEnd(40);
+            const src = row.source.padEnd(16);
+            const score = row.score !== null ? `${row.score}/${row.maxScore}`.padEnd(9) : 'N/A      ';
+            const pass = row.enabled ? (row.passed ? 'PASS' : 'FAIL') : 'DISABLED';
+            console.log(`  ${name} | ${src} | ${score} | ${pass}`);
+          }
+          console.log('  ' + '-'.repeat(86));
+          console.log(`  Aggregate: ${result.aggregateScore}% (threshold: ${result.gateThreshold}%) => ${result.wouldPass ? 'WOULD PASS' : 'WOULD FAIL'}`);
+        }
+        console.log('');
+        process.exit(0);
       }
 
       const result = await system.executeHandoff(handoffType, sdId, { prdId });


### PR DESCRIPTION
Add --dry-run flag showing gate scores without DB writes. npm run handoff:dry-run. 15/15 smoke tests pass.