### PR TITLE
fix: stage gate bypass and idempotency key collision

### DIFF
--- a/.worktree.json
+++ b/.worktree.json
@@ -1,6 +1,6 @@
 {
-  "sdKey": "SD-LEO-INFRA-HANDOFF-DRY-RUN-001",
-  "expectedBranch": "feat/SD-LEO-INFRA-HANDOFF-DRY-RUN-001",
-  "createdAt": "2026-03-17T18:44:21.456Z",
+  "sdKey": "SD-LEO-FIX-VENTURE-STAGE-GATE-001",
+  "expectedBranch": "feat/SD-LEO-FIX-VENTURE-STAGE-GATE-001",
+  "createdAt": "2026-03-17T18:54:15.059Z",
   "repoRoot": "C:/Users/rickf/Projects/_EHG/EHG_Engineer"
 }

--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -110,6 +110,9 @@ router.get('/:id/artifacts', validateUuidParam('id'), asyncHandler(async (req, r
   res.json(formattedWork);
 }));
 
+// Kill gate stages that require chairman approval before entry
+const GATE_STAGES = [3, 5, 10, 22, 23, 24];
+
 // Update venture stage
 router.patch('/:id/stage', validateUuidParam('id'), asyncHandler(async (req, res) => {
   const { id } = req.params;
@@ -117,6 +120,25 @@ router.patch('/:id/stage', validateUuidParam('id'), asyncHandler(async (req, res
 
   if (!stage || stage < 1 || stage > 25) {
     return res.status(400).json({ error: 'Invalid stage. Must be 1-25.' });
+  }
+
+  // Gate enforcement: if target stage is a gate, require chairman approval
+  if (GATE_STAGES.includes(stage)) {
+    const { data: approval } = await dbLoader.supabase
+      .from('chairman_decisions')
+      .select('id')
+      .eq('venture_id', id)
+      .eq('lifecycle_stage', stage)
+      .eq('status', 'approved')
+      .in('decision', ['pass', 'go', 'proceed', 'approve', 'conditional_pass', 'conditional_go', 'continue', 'release'])
+      .limit(1);
+
+    if (!approval || approval.length === 0) {
+      return res.status(403).json({
+        error: 'Gate stage requires chairman approval',
+        gate_stage: stage
+      });
+    }
   }
 
   const { data, error } = await dbLoader.supabase
@@ -132,6 +154,9 @@ router.patch('/:id/stage', validateUuidParam('id'), asyncHandler(async (req, res
     console.error('Error updating venture stage:', error);
     return res.status(500).json({ error: error.message });
   }
+
+  // Emit event for observability
+  console.log(`[VentureStage] Venture ${id} advanced to stage ${stage} via API`);
 
   res.json(data);
 }));

--- a/supabase/migrations/20260307_bootstrap_venture_workflow.sql
+++ b/supabase/migrations/20260307_bootstrap_venture_workflow.sql
@@ -288,10 +288,16 @@ BEGIN
     NOW()
   );
 
-  -- Record transition (idempotent)
+  -- Record transition (idempotent, with sequence counter to avoid collisions on REVISE loops)
   v_idempotency := uuid_generate_v5(
     '00000000-0000-0000-0000-000000000000'::uuid,
     p_venture_id::text || ':' || p_from_stage::text || ':' || p_to_stage::text
+      || ':' || COALESCE(
+        (SELECT COUNT(*)::text FROM venture_stage_transitions
+         WHERE venture_id = p_venture_id
+           AND from_stage = p_from_stage
+           AND to_stage = p_to_stage),
+        '0')
   );
 
   INSERT INTO venture_stage_transitions (


### PR DESCRIPTION
## Summary
- CRITICAL: PATCH /:id/stage now enforces chairman approval for gate stages
- Fixed idempotency key collision on REVISE loops (added attempt counter)
- Added observability logging for API-driven stage transitions

## Security Impact
- Before: Any authenticated user could skip kill gates via direct API call
- After: Gate stages require chairman decision approval

## Test plan
- [x] Smoke tests pass
- [x] Gate check uses same chairman_decisions table as advance_venture_stage RPC

SD-LEO-FIX-VENTURE-STAGE-GATE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)