### PR TITLE
feat: parallel gate execution in ValidationOrchestrator

### DIFF
--- a/scripts/modules/handoff/validation/ValidationOrchestrator.js
+++ b/scripts/modules/handoff/validation/ValidationOrchestrator.js
@@ -223,63 +223,94 @@ export class ValidationOrchestrator {
     let weightedScoreSum = 0;
     let totalWeight = 0;
 
+    // SD-LEO-INFRA-PARALLEL-GATE-EXECUTION-001: Group gates by dependency tier
+    // Tier 0: instant/protocol checks, Tier 1 (default): independent DB gates,
+    // Tier 2: dependent on earlier results, Tier 3: LLM-powered gates
+    const tierMap = new Map();
     for (const gate of gates) {
-      // Check condition if provided
-      if (gate.condition && !(await gate.condition(context))) {
-        console.log(`⏭️  Skipping ${gate.name} (condition not met)`);
-        continue;
-      }
+      const tier = gate.tier ?? 1;
+      if (!tierMap.has(tier)) tierMap.set(tier, []);
+      tierMap.get(tier).push(gate);
+    }
+    const sortedTiers = [...tierMap.keys()].sort((a, b) => a - b);
 
-      const gateResult = await this.validateGate(gate.name, gate.validator, context);
-      results.gateResults[gate.name] = gateResult;
+    let earlyExit = false;
+    for (const tier of sortedTiers) {
+      if (earlyExit) break;
 
-      // SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001: Track SKIPPED status
-      const isSkipped = isSkippedResult(gateResult);
-      if (isSkipped) {
-        results.skippedCount++;
-        results.skippedGates.push(gate.name);
-        results.gateStatuses[gate.name] = {
-          status: ValidatorStatus.SKIPPED,
-          required: gate.required !== false,
-          skipReason: gateResult.skipReason || SkipReasonCode.NON_APPLICABLE_SD_TYPE,
-          skipDetails: gateResult.skipDetails
-        };
-      } else {
-        results.gateStatuses[gate.name] = {
-          status: gateResult.passed ? ValidatorStatus.PASS : ValidatorStatus.FAIL,
-          required: gate.required !== false
-        };
-      }
+      const tierGates = tierMap.get(tier);
 
-      // Backward compat: sum raw scores
-      results.totalScore += gateResult.score;
-      results.totalMaxScore += gateResult.maxScore;
-      results.gateCount++;
-
-      // Calculate weighted contribution
-      // Gate weight defaults to 1.0, can be customized per gate
-      const gateWeight = gate.weight || 1.0;
-      const gatePercentage = gateResult.maxScore > 0
-        ? (gateResult.score / gateResult.maxScore) * 100
-        : 0;
-      weightedScoreSum += gatePercentage * gateWeight;
-      totalWeight += gateWeight;
-
-      // Defensive check for optional warnings array (PAT-SCHEMA-VALIDATION-001)
-      if (gateResult.warnings && Array.isArray(gateResult.warnings)) {
-        results.warnings.push(...gateResult.warnings);
-      }
-
-      // SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001: SKIPPED counts as satisfied (not a failure)
-      // Only FAIL (not SKIPPED) should block handoff for required gates
-      if (!gateResult.passed && gate.required !== false && !isSkipped) {
-        results.passed = false;
-        results.failedGate = gate.name;
-        // Defensive check for optional issues array (PAT-SCHEMA-VALIDATION-001)
-        if (gateResult.issues && Array.isArray(gateResult.issues)) {
-          results.issues.push(...gateResult.issues);
+      // Filter gates with unmet conditions before parallel execution
+      const eligibleGates = [];
+      for (const gate of tierGates) {
+        if (gate.condition && !(await gate.condition(context))) {
+          console.log(`⏭️  Skipping ${gate.name} (condition not met)`);
+          continue;
         }
-        break; // Stop on first required failure
+        eligibleGates.push(gate);
+      }
+
+      if (eligibleGates.length === 0) continue;
+
+      // Execute all gates within this tier concurrently
+      const tierResults = await Promise.all(
+        eligibleGates.map(gate =>
+          this.validateGate(gate.name, gate.validator, context)
+            .then(gateResult => ({ gate, gateResult }))
+        )
+      );
+
+      // Process results from this tier
+      for (const { gate, gateResult } of tierResults) {
+        results.gateResults[gate.name] = gateResult;
+
+        // SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001: Track SKIPPED status
+        const isSkipped = isSkippedResult(gateResult);
+        if (isSkipped) {
+          results.skippedCount++;
+          results.skippedGates.push(gate.name);
+          results.gateStatuses[gate.name] = {
+            status: ValidatorStatus.SKIPPED,
+            required: gate.required !== false,
+            skipReason: gateResult.skipReason || SkipReasonCode.NON_APPLICABLE_SD_TYPE,
+            skipDetails: gateResult.skipDetails
+          };
+        } else {
+          results.gateStatuses[gate.name] = {
+            status: gateResult.passed ? ValidatorStatus.PASS : ValidatorStatus.FAIL,
+            required: gate.required !== false
+          };
+        }
+
+        // Backward compat: sum raw scores
+        results.totalScore += gateResult.score;
+        results.totalMaxScore += gateResult.maxScore;
+        results.gateCount++;
+
+        // Calculate weighted contribution
+        const gateWeight = gate.weight || 1.0;
+        const gatePercentage = gateResult.maxScore > 0
+          ? (gateResult.score / gateResult.maxScore) * 100
+          : 0;
+        weightedScoreSum += gatePercentage * gateWeight;
+        totalWeight += gateWeight;
+
+        // Defensive check for optional warnings array (PAT-SCHEMA-VALIDATION-001)
+        if (gateResult.warnings && Array.isArray(gateResult.warnings)) {
+          results.warnings.push(...gateResult.warnings);
+        }
+
+        // SD-LEO-FIX-REMEDIATE-TYPE-AWARE-001: SKIPPED counts as satisfied (not a failure)
+        // Only FAIL (not SKIPPED) should block handoff for required gates
+        if (!gateResult.passed && gate.required !== false && !isSkipped) {
+          results.passed = false;
+          if (!results.failedGate) results.failedGate = gate.name;
+          // Defensive check for optional issues array (PAT-SCHEMA-VALIDATION-001)
+          if (gateResult.issues && Array.isArray(gateResult.issues)) {
+            results.issues.push(...gateResult.issues);
+          }
+          earlyExit = true; // Stop after processing this tier's results
+        }
       }
     }
 
@@ -941,62 +972,87 @@ export class ValidationOrchestrator {
     let weightedScoreSum = 0;
     let totalWeight = 0;
 
-    // Run ALL gates, don't stop on failure
+    // SD-LEO-INFRA-PARALLEL-GATE-EXECUTION-001: Group gates by tier for parallel execution
+    const tierMap = new Map();
     for (const gate of gates) {
-      // Check condition if provided
-      if (gate.condition && !(await gate.condition(context))) {
-        console.log(`⏭️  Skipping ${gate.name} (condition not met)`);
-        continue;
-      }
+      const tier = gate.tier ?? 1;
+      if (!tierMap.has(tier)) tierMap.set(tier, []);
+      tierMap.get(tier).push(gate);
+    }
+    const sortedTiers = [...tierMap.keys()].sort((a, b) => a - b);
 
-      // Skip LLM-powered gates in precheck mode for fast advisory checks
-      if (context.precheckMode && gate.llmPowered) {
-        console.log(`⏭️  Skipping ${gate.name} (LLM gate — evaluated during execute)`);
-        const skipResult = { passed: true, score: 0, maxScore: 0, issues: [], warnings: [`Skipped in precheck mode (LLM gate)`] };
-        results.gateResults[gate.name] = skipResult;
-        results.warnings.push(`${gate.name}: Skipped in precheck mode (LLM gate — run execute for full evaluation)`);
-        if (!results.skippedGates) results.skippedGates = [];
-        results.skippedGates.push(gate.name);
-        continue;
-      }
+    // Run ALL tiers, don't stop on failure (batch mode)
+    for (const tier of sortedTiers) {
+      const tierGates = tierMap.get(tier);
 
-      const gateResult = await this.validateGate(gate.name, gate.validator, context);
-      results.gateResults[gate.name] = gateResult;
-
-      results.totalScore += gateResult.score;
-      results.totalMaxScore += gateResult.maxScore;
-      results.gateCount++;
-
-      const gateWeight = gate.weight || 1.0;
-      const gatePercentage = gateResult.maxScore > 0
-        ? (gateResult.score / gateResult.maxScore) * 100
-        : 0;
-      weightedScoreSum += gatePercentage * gateWeight;
-      totalWeight += gateWeight;
-
-      // Defensive check for optional warnings array (PAT-SCHEMA-VALIDATION-001)
-      if (gateResult.warnings && Array.isArray(gateResult.warnings)) {
-        results.warnings.push(...gateResult.warnings);
-      }
-
-      // Collect issues but DON'T stop - this is the key difference
-      if (!gateResult.passed && gate.required !== false) {
-        results.passed = false;
-        results.failedGates.push({
-          name: gate.name,
-          issues: gateResult.issues || [],
-          score: gateResult.score,
-          maxScore: gateResult.maxScore
-        });
-        // Defensive check for optional issues array (PAT-SCHEMA-VALIDATION-001)
-        if (gateResult.issues && Array.isArray(gateResult.issues)) {
-          results.issues.push(...gateResult.issues.map(issue => ({
-            gate: gate.name,
-            issue
-          })));
+      // Filter gates with unmet conditions or LLM gates in precheck mode
+      const eligibleGates = [];
+      for (const gate of tierGates) {
+        if (gate.condition && !(await gate.condition(context))) {
+          console.log(`⏭️  Skipping ${gate.name} (condition not met)`);
+          continue;
         }
-      } else {
-        results.passedGates.push(gate.name);
+        if (context.precheckMode && gate.llmPowered) {
+          console.log(`⏭️  Skipping ${gate.name} (LLM gate — evaluated during execute)`);
+          const skipResult = { passed: true, score: 0, maxScore: 0, issues: [], warnings: ['Skipped in precheck mode (LLM gate)'] };
+          results.gateResults[gate.name] = skipResult;
+          results.warnings.push(`${gate.name}: Skipped in precheck mode (LLM gate — run execute for full evaluation)`);
+          if (!results.skippedGates) results.skippedGates = [];
+          results.skippedGates.push(gate.name);
+          continue;
+        }
+        eligibleGates.push(gate);
+      }
+
+      if (eligibleGates.length === 0) continue;
+
+      // Execute all gates within this tier concurrently
+      const tierResults = await Promise.all(
+        eligibleGates.map(gate =>
+          this.validateGate(gate.name, gate.validator, context)
+            .then(gateResult => ({ gate, gateResult }))
+        )
+      );
+
+      // Process results from this tier
+      for (const { gate, gateResult } of tierResults) {
+        results.gateResults[gate.name] = gateResult;
+
+        results.totalScore += gateResult.score;
+        results.totalMaxScore += gateResult.maxScore;
+        results.gateCount++;
+
+        const gateWeight = gate.weight || 1.0;
+        const gatePercentage = gateResult.maxScore > 0
+          ? (gateResult.score / gateResult.maxScore) * 100
+          : 0;
+        weightedScoreSum += gatePercentage * gateWeight;
+        totalWeight += gateWeight;
+
+        // Defensive check for optional warnings array (PAT-SCHEMA-VALIDATION-001)
+        if (gateResult.warnings && Array.isArray(gateResult.warnings)) {
+          results.warnings.push(...gateResult.warnings);
+        }
+
+        // Collect issues but DON'T stop - this is the key difference
+        if (!gateResult.passed && gate.required !== false) {
+          results.passed = false;
+          results.failedGates.push({
+            name: gate.name,
+            issues: gateResult.issues || [],
+            score: gateResult.score,
+            maxScore: gateResult.maxScore
+          });
+          // Defensive check for optional issues array (PAT-SCHEMA-VALIDATION-001)
+          if (gateResult.issues && Array.isArray(gateResult.issues)) {
+            results.issues.push(...gateResult.issues.map(issue => ({
+              gate: gate.name,
+              issue
+            })));
+          }
+        } else {
+          results.passedGates.push(gate.name);
+        }
       }
     }
 

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -158,7 +158,7 @@ function createWorktree(sdKey, repoRoot) {
       cwd: repoRoot, encoding: 'utf8', stdio: 'pipe'
     }).trim();
     if (branches) {
-      branch = branches.split('\n')[0].replace(/^\*?\s*/, '').trim();
+      branch = branches.split('\n')[0].replace(/^[*+]?\s*/, '').trim();
     }
   } catch { /* no match */ }
 

--- a/tests/unit/handoff/validation-orchestrator-parallel.test.js
+++ b/tests/unit/handoff/validation-orchestrator-parallel.test.js
@@ -1,0 +1,320 @@
+/**
+ * Unit tests for ValidationOrchestrator parallel gate execution
+ * SD-LEO-INFRA-PARALLEL-GATE-EXECUTION-001
+ *
+ * Covers:
+ * - Parallel execution within tiers via Promise.all()
+ * - Early-exit between tiers for required gate failures
+ * - Backward compatibility (gates without tier default to tier 1)
+ * - Error isolation in parallel execution
+ * - validateGatesAll parallel execution without early-exit
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock telemetry
+vi.mock('../../../lib/telemetry/workflow-timer.js', () => ({
+  startSpan: vi.fn(),
+  endSpan: vi.fn()
+}));
+
+// Mock sd-type-validation
+vi.mock('../../../lib/utils/sd-type-validation.js', () => ({
+  shouldSkipCodeValidation: vi.fn(() => false)
+}));
+
+// Mock sd-type-applicability-policy
+vi.mock('../../../scripts/modules/handoff/validation/sd-type-applicability-policy.js', () => ({
+  createSkippedResult: vi.fn(),
+  isSkippedResult: vi.fn(() => false),
+  ValidatorStatus: { PASS: 'PASS', FAIL: 'FAIL', SKIPPED: 'SKIPPED' },
+  SkipReasonCode: { NON_APPLICABLE_SD_TYPE: 'NON_APPLICABLE_SD_TYPE' }
+}));
+
+// Mock sd-type-checker
+vi.mock('../../../scripts/modules/sd-type-checker.js', () => ({
+  THRESHOLD_PROFILES: {
+    default: { gateThreshold: 70 },
+    infrastructure: { gateThreshold: 80 }
+  }
+}));
+
+// Mock gate-result-schema
+vi.mock('../../../scripts/modules/handoff/validation/gate-result-schema.js', () => ({
+  validateGateResult: vi.fn((result, _name, _opts) => ({
+    passed: result.passed ?? true,
+    score: result.score ?? 100,
+    maxScore: result.maxScore ?? 100,
+    issues: result.issues || [],
+    warnings: result.warnings || []
+  }))
+}));
+
+// Mock ValidatorRegistry
+vi.mock('../../../scripts/modules/handoff/validation/ValidatorRegistry.js', () => ({
+  validatorRegistry: {
+    getOrCreateFallback: vi.fn(),
+    normalizeResult: vi.fn(r => r)
+  }
+}));
+
+// Mock OIV
+vi.mock('../../../scripts/modules/handoff/validation/oiv/index.js', () => {
+  class MockOIVGate {
+    constructor() {
+      this.validateHandoff = vi.fn(() => ({ passed: true, score: 100, issues: [] }));
+    }
+  }
+  return { OIVGate: MockOIVGate, OIV_GATE_WEIGHT: 0.15 };
+});
+
+// Mock gate-context-preloader
+vi.mock('../../../scripts/modules/handoff/validation/validator-registry/gate-context-preloader.js', () => ({
+  preloadGateContext: vi.fn(() => ({})),
+  getGateNumberForRule: vi.fn(() => null)
+}));
+
+// Mock ResultBuilder
+vi.mock('../../../scripts/modules/handoff/ResultBuilder.js', () => ({
+  default: {
+    logGateResult: vi.fn()
+  }
+}));
+
+import { ValidationOrchestrator } from '../../../scripts/modules/handoff/validation/ValidationOrchestrator.js';
+
+// Helper to create a gate that records execution order and timing
+function createTimedGate(name, { tier, delayMs = 10, passed = true, score = 100, required = true, weight } = {}) {
+  const execLog = [];
+  const gate = {
+    name,
+    tier,
+    required,
+    weight,
+    validator: async () => {
+      const start = Date.now();
+      execLog.push({ name, start });
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+      return { passed, score, maxScore: 100, issues: passed ? [] : [`${name} failed`], warnings: [] };
+    },
+    _execLog: execLog
+  };
+  return gate;
+}
+
+describe('ValidationOrchestrator - Parallel Gate Execution', () => {
+  let orchestrator;
+  let mockSupabase;
+
+  beforeEach(() => {
+    mockSupabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              limit: vi.fn(() => Promise.resolve({ data: [], error: null }))
+            })),
+            limit: vi.fn(() => Promise.resolve({ data: [], error: null }))
+          })),
+          order: vi.fn(() => ({
+            order: vi.fn(() => Promise.resolve({ data: [], error: null }))
+          }))
+        }))
+      }))
+    };
+    orchestrator = new ValidationOrchestrator(mockSupabase);
+    // Suppress console output in tests
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  describe('validateGates - parallel within tiers', () => {
+    it('runs gates without tier property in tier 1 (backward compat)', async () => {
+      const gates = [
+        createTimedGate('gate-a'),
+        createTimedGate('gate-b'),
+        createTimedGate('gate-c')
+      ];
+
+      const results = await orchestrator.validateGates(gates, {});
+
+      expect(results.passed).toBe(true);
+      expect(results.gateCount).toBe(3);
+      expect(results.gateResults['gate-a']).toBeDefined();
+      expect(results.gateResults['gate-b']).toBeDefined();
+      expect(results.gateResults['gate-c']).toBeDefined();
+    });
+
+    it('executes gates within the same tier concurrently', async () => {
+      // Three gates in tier 1, each taking 50ms
+      // Sequential would take ~150ms, parallel should take ~50ms
+      const gates = [
+        createTimedGate('gate-a', { tier: 1, delayMs: 50 }),
+        createTimedGate('gate-b', { tier: 1, delayMs: 50 }),
+        createTimedGate('gate-c', { tier: 1, delayMs: 50 })
+      ];
+
+      const start = Date.now();
+      const results = await orchestrator.validateGates(gates, {});
+      const elapsed = Date.now() - start;
+
+      expect(results.passed).toBe(true);
+      expect(results.gateCount).toBe(3);
+      // Parallel execution: should be ~50ms, not ~150ms
+      // Allow generous margin for CI, but should be well under sequential time
+      expect(elapsed).toBeLessThan(130);
+    });
+
+    it('preserves early-exit between tiers', async () => {
+      const gateT0 = createTimedGate('tier0-gate', { tier: 0, passed: false, score: 0, required: true });
+      const gateT1 = createTimedGate('tier1-gate', { tier: 1, delayMs: 10 });
+
+      const results = await orchestrator.validateGates([gateT0, gateT1], {});
+
+      expect(results.passed).toBe(false);
+      expect(results.failedGate).toBe('tier0-gate');
+      expect(results.gateCount).toBe(1); // tier 1 gate should not have run
+      expect(results.gateResults['tier1-gate']).toBeUndefined();
+    });
+
+    it('does not early-exit for non-required gate failures', async () => {
+      const gateT0 = createTimedGate('tier0-optional', { tier: 0, passed: false, score: 0, required: false });
+      const gateT1 = createTimedGate('tier1-gate', { tier: 1 });
+
+      const results = await orchestrator.validateGates([gateT0, gateT1], {});
+
+      expect(results.passed).toBe(true); // non-required failure doesn't block
+      expect(results.gateCount).toBe(2); // both gates ran
+    });
+
+    it('handles multiple tiers in order', async () => {
+      const executionOrder = [];
+      const makeGate = (name, tier, delayMs = 5) => ({
+        name,
+        tier,
+        required: true,
+        validator: async () => {
+          await new Promise(r => setTimeout(r, delayMs));
+          executionOrder.push(name);
+          return { passed: true, score: 100, maxScore: 100, issues: [], warnings: [] };
+        }
+      });
+
+      const gates = [
+        makeGate('t2-gate', 2),
+        makeGate('t0-gate', 0),
+        makeGate('t1-a', 1),
+        makeGate('t1-b', 1)
+      ];
+
+      const results = await orchestrator.validateGates(gates, {});
+
+      expect(results.passed).toBe(true);
+      expect(results.gateCount).toBe(4);
+      // t0 should complete before t1, t1 before t2
+      expect(executionOrder.indexOf('t0-gate')).toBeLessThan(executionOrder.indexOf('t1-a'));
+      expect(executionOrder.indexOf('t0-gate')).toBeLessThan(executionOrder.indexOf('t1-b'));
+      expect(executionOrder.indexOf('t1-a')).toBeLessThan(executionOrder.indexOf('t2-gate'));
+    });
+
+    it('produces identical scores to sequential (weighted average)', async () => {
+      const gates = [
+        createTimedGate('gate-a', { tier: 0, score: 80, weight: 2.0 }),
+        createTimedGate('gate-b', { tier: 1, score: 100, weight: 1.0 }),
+        createTimedGate('gate-c', { tier: 1, score: 60, weight: 1.0 })
+      ];
+
+      const results = await orchestrator.validateGates(gates, {});
+
+      // Weighted average: (80*2 + 100*1 + 60*1) / (2+1+1) = 320/4 = 80
+      expect(results.normalizedScore).toBe(80);
+      expect(results.gateCount).toBe(3);
+      expect(results.totalScore).toBe(240); // 80+100+60
+    });
+
+    it('isolates errors between gates in same tier', async () => {
+      const errorGate = {
+        name: 'error-gate',
+        tier: 1,
+        required: false,
+        validator: async () => {
+          throw new Error('Gate exploded');
+        }
+      };
+      const goodGate = createTimedGate('good-gate', { tier: 1, score: 100 });
+
+      const results = await orchestrator.validateGates([errorGate, goodGate], {});
+
+      // Error gate should return score 0, good gate unaffected
+      expect(results.gateResults['error-gate']).toBeDefined();
+      expect(results.gateResults['error-gate'].score).toBe(0);
+      expect(results.gateResults['good-gate']).toBeDefined();
+      expect(results.gateResults['good-gate'].score).toBe(100);
+      expect(results.gateCount).toBe(2);
+    });
+
+    it('skips gates with unmet conditions', async () => {
+      const gates = [
+        {
+          name: 'conditional-gate',
+          tier: 1,
+          required: true,
+          condition: async () => false,
+          validator: async () => ({ passed: true, score: 100, maxScore: 100, issues: [], warnings: [] })
+        },
+        createTimedGate('normal-gate', { tier: 1 })
+      ];
+
+      const results = await orchestrator.validateGates(gates, {});
+
+      expect(results.gateCount).toBe(1);
+      expect(results.gateResults['conditional-gate']).toBeUndefined();
+      expect(results.gateResults['normal-gate']).toBeDefined();
+    });
+  });
+
+  describe('validateGatesAll - parallel without early-exit', () => {
+    it('runs all gates even when required gates fail', async () => {
+      const gates = [
+        createTimedGate('fail-gate', { tier: 0, passed: false, score: 0, required: true }),
+        createTimedGate('pass-gate', { tier: 1, score: 100 })
+      ];
+
+      const results = await orchestrator.validateGatesAll(gates, {});
+
+      expect(results.passed).toBe(false);
+      expect(results.gateCount).toBe(2); // both ran despite tier 0 failure
+      expect(results.failedGates.length).toBe(1);
+      expect(results.passedGates).toContain('pass-gate');
+    });
+
+    it('runs gates within tiers concurrently', async () => {
+      const gates = [
+        createTimedGate('gate-a', { tier: 1, delayMs: 50 }),
+        createTimedGate('gate-b', { tier: 1, delayMs: 50 }),
+        createTimedGate('gate-c', { tier: 1, delayMs: 50 })
+      ];
+
+      const start = Date.now();
+      const results = await orchestrator.validateGatesAll(gates, {});
+      const elapsed = Date.now() - start;
+
+      expect(results.gateCount).toBe(3);
+      expect(elapsed).toBeLessThan(130);
+    });
+
+    it('collects all issues from all tiers', async () => {
+      const gates = [
+        createTimedGate('fail-1', { tier: 0, passed: false, score: 0, required: true }),
+        createTimedGate('fail-2', { tier: 1, passed: false, score: 0, required: true })
+      ];
+
+      const results = await orchestrator.validateGatesAll(gates, {});
+
+      expect(results.passed).toBe(false);
+      expect(results.failedGates.length).toBe(2);
+      expect(results.issues.length).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Modify `validateGates()` and `validateGatesAll()` to execute independent gates concurrently via `Promise.all()` grouped by dependency tier
- Gates classified into tiers (0=instant, 1=independent DB queries, 2=dependent, 3=LLM-powered) with default tier 1 for backward compatibility
- Early-exit behavior preserved between tiers for required gate failures
- Fix worktree branch name resolution bug (git `+` prefix not stripped)

## Test plan
- [x] 11 unit tests covering parallel execution, early-exit, backward compat, error isolation
- [x] All 15 smoke tests pass
- [x] Existing handoff orchestrator tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)