### PR TITLE
fix: reconcile venture gate stage mismatch

### DIFF
--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -23,10 +23,17 @@ import { calculateStageWeightedScore } from '../../../eva/stage-zero/modeling.js
 import { randomUUID } from 'crypto';
 
 // ── Gate Configuration ──────────────────────────────────────────────
+// SD-LEO-FIX-VENTURE-GATE-STAGE-001: Canonical gate definitions.
+// Both the stage-execution-worker and DB function reference these.
 
 /**
  * Kill gate stages: checkpoints where ventures may be terminated
  * if Filter Engine thresholds fail.
+ *
+ * - Stage 3:  Initial Screening — filter out non-viable ideas early
+ * - Stage 5:  Post-Discovery — validate market fit before investing in strategy
+ * - Stage 13: Pre-Scale — final viability check before committing build resources
+ * - Stage 23: Pre-Launch — last chance to abort before public release
  */
 const KILL_GATE_STAGES = new Set([3, 5, 13, 23]);
 
@@ -39,8 +46,24 @@ const ADVISORY_GATE_STAGES = new Set([5, 13]);
 /**
  * Promotion gate stages: checkpoints where ventures need
  * Chairman approval to advance when thresholds pass.
+ *
+ * - Stage 16: Planning Complete — approval to begin BUILD phase
+ * - Stage 17: Architecture Signoff — approval of technical architecture
+ * - Stage 22: Launch Readiness — approval to proceed to deployment
  */
 const PROMOTION_GATE_STAGES = new Set([16, 17, 22]);
+
+/**
+ * Worker-blocking stages: the set of stages where the stage execution worker
+ * pauses for a chairman decision before advancing.
+ *
+ * Derived from kill + promotion gates, minus stages handled by mode boundaries:
+ *   Kill gates blocking worker:      3, 5, 23 (stage 13 handled by PLANNING mode boundary)
+ *   Promotion gates blocking worker: 22       (stages 16, 17 handled by mode boundaries)
+ *   Additional blocking:             10 (EVALUATION→STRATEGY mode boundary checkpoint)
+ *                                    24 (post-launch review)
+ */
+const WORKER_BLOCKING_STAGES = new Set([3, 5, 10, 22, 23, 24]);
 
 /**
  * Gate type enum for structured results.
@@ -807,6 +830,7 @@ export {
   KILL_GATE_STAGES,
   PROMOTION_GATE_STAGES,
   ADVISORY_GATE_STAGES,
+  WORKER_BLOCKING_STAGES,
   GATE_TYPE,
   GATE_STATUS,
   FILTER_PREFERENCE_KEYS,

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -30,6 +30,7 @@ import {
 } from './chairman-decision-watcher.js';
 import { emit } from './shared-services.js';
 import { checkAutonomy } from './autonomy-model.js';
+import { WORKER_BLOCKING_STAGES } from '../agents/modules/venture-state-machine/stage-gates.js';
 
 import { hostname } from 'os';
 import { createServer } from 'http';
@@ -50,12 +51,12 @@ const WORKER_VERSION = '1.1.0';
  * Chairman gate stages where pipeline pauses for human decision.
  * Blocking: pipeline waits for approved/rejected.
  * Advisory: notification sent, pipeline continues.
+ *
+ * SD-LEO-FIX-VENTURE-GATE-STAGE-001: BLOCKING now imported from
+ * canonical stage-gates.js (WORKER_BLOCKING_STAGES) instead of hardcoded.
  */
 const CHAIRMAN_GATES = Object.freeze({
-  // Subset of frontend gates that block the worker pipeline.
-  // Frontend KILL_GATE_STAGES [3, 5, 13, 23] + PROMOTION_GATE_STAGES [10, 16, 17, 22, 24]
-  // Stages 13, 16, 17 are handled by operating mode boundaries, not worker blocking.
-  BLOCKING: new Set([3, 5, 10, 22, 23, 24]),
+  BLOCKING: WORKER_BLOCKING_STAGES,
   ADVISORY: new Set([]),
 });
 

--- a/supabase/migrations/20260317_venture_backward_transition_guard.sql
+++ b/supabase/migrations/20260317_venture_backward_transition_guard.sql
@@ -1,0 +1,136 @@
+-- SD-LEO-FIX-VENTURE-GATE-STAGE-001: Add backward transition guard
+-- Prevents advance_venture_stage() from allowing stage regressions.
+-- Also syncs gate arrays with canonical stage-gates.js definitions.
+
+CREATE OR REPLACE FUNCTION advance_venture_stage(
+  p_venture_id UUID,
+  p_from_stage INTEGER,
+  p_to_stage INTEGER,
+  p_idempotency_key UUID DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $fn$
+DECLARE
+  v_current_stage INTEGER;
+  v_venture_name TEXT;
+  -- Canonical gate definitions (synced with stage-gates.js)
+  v_kill_gates INTEGER[] := ARRAY[3, 5, 13, 23];
+  v_promotion_gates INTEGER[] := ARRAY[16, 17, 22];
+  v_all_gates INTEGER[] := ARRAY[3, 5, 13, 16, 17, 22, 23];
+  v_gate_decision RECORD;
+  v_idempotency UUID;
+  v_gate_type TEXT;
+BEGIN
+  -- Validate venture exists and lock row
+  SELECT current_lifecycle_stage, name
+    INTO v_current_stage, v_venture_name
+    FROM ventures
+    WHERE id = p_venture_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'venture_not_found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  -- Validate from_stage matches current
+  IF v_current_stage != p_from_stage THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'stage_mismatch',
+      'current_stage', v_current_stage,
+      'from_stage', p_from_stage
+    );
+  END IF;
+
+  -- Validate to_stage range
+  IF p_to_stage < 1 OR p_to_stage > 25 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'invalid_to_stage',
+      'to_stage', p_to_stage
+    );
+  END IF;
+
+  -- SD-LEO-FIX-VENTURE-GATE-STAGE-001: Backward transition guard
+  -- Prevent stage regression (new stage must be > current stage)
+  IF p_to_stage <= v_current_stage THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'backward_transition_blocked',
+      'current_stage', v_current_stage,
+      'to_stage', p_to_stage,
+      'message', format('Cannot transition backward from stage %s to stage %s', v_current_stage, p_to_stage)
+    );
+  END IF;
+
+  -- Gate enforcement: if from_stage is a gate, require approved decision
+  IF p_from_stage = ANY(v_all_gates) THEN
+    -- Determine gate type
+    IF p_from_stage = ANY(v_kill_gates) THEN
+      v_gate_type := 'kill';
+    ELSE
+      v_gate_type := 'promotion';
+    END IF;
+
+    -- Check for approved chairman decision
+    SELECT id, decision, decided_at
+      INTO v_gate_decision
+      FROM chairman_decisions
+      WHERE venture_id = p_venture_id
+        AND gate_stage = p_from_stage
+        AND decision = 'approved'
+      ORDER BY decided_at DESC
+      LIMIT 1;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'gate_not_approved',
+        'gate_stage', p_from_stage,
+        'gate_type', v_gate_type,
+        'message', format('Stage %s is a %s gate requiring chairman approval', p_from_stage, v_gate_type)
+      );
+    END IF;
+  END IF;
+
+  -- Idempotency check
+  v_idempotency := COALESCE(p_idempotency_key, gen_random_uuid());
+
+  -- Update venture stage
+  UPDATE ventures
+    SET current_lifecycle_stage = p_to_stage,
+        updated_at = NOW()
+    WHERE id = p_venture_id;
+
+  -- Log transition
+  INSERT INTO venture_stage_transitions (
+    venture_id, from_stage, to_stage, idempotency_key, created_at
+  ) VALUES (
+    p_venture_id, p_from_stage, p_to_stage, v_idempotency, NOW()
+  )
+  ON CONFLICT (idempotency_key) DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_venture_name,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage,
+    'idempotency_key', v_idempotency
+  );
+END;
+$fn$;
+
+-- Add comment documenting the gate stages
+COMMENT ON FUNCTION advance_venture_stage IS
+  'Stage transition with gate enforcement and backward transition guard. '
+  'Gate stages synced with lib/agents/modules/venture-state-machine/stage-gates.js. '
+  'Kill gates: 3,5,13,23. Promotion gates: 16,17,22. '
+  'SD-LEO-FIX-VENTURE-GATE-STAGE-001';


### PR DESCRIPTION
## Summary
- Add `WORKER_BLOCKING_STAGES` export to `stage-gates.js` as single source of truth for worker blocking
- Update `stage-execution-worker.js` to import from `stage-gates.js` instead of hardcoding
- Add backward transition guard to `advance_venture_stage()` RPC (prevents stage regression)
- Document each gate stage with purpose/justification

## Test plan
- [ ] Verify worker still blocks at stages 3, 5, 10, 22, 23, 24
- [ ] Verify backward transition returns `backward_transition_blocked` error
- [ ] Verify forward transitions still succeed

SD-LEO-FIX-VENTURE-GATE-STAGE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)