### PR TITLE
feat: Chairman per-stage pipeline governance controls

### DIFF
--- a/database/migrations/20260318_add_stage_overrides_column.sql
+++ b/database/migrations/20260318_add_stage_overrides_column.sql
@@ -1,0 +1,113 @@
+-- Migration: Create chairman_dashboard_config table with stage_overrides column
+-- SD: SD-LEO-FEAT-PER-STAGE-AUTO-PROCEED-001
+-- US: US-001 - Per-stage auto-proceed overrides
+-- Date: 2026-03-18
+-- Idempotent: Yes (uses IF NOT EXISTS)
+--
+-- Purpose: Stores chairman dashboard configuration including per-stage
+-- auto-proceed overrides. The stage_overrides JSONB column allows the
+-- chairman to configure auto-proceed behavior per evaluation stage.
+--
+-- stage_overrides structure:
+-- {
+--   "stage_7": {
+--     "auto_proceed": false,
+--     "reason": "Manual review required",
+--     "set_by": "chairman",
+--     "set_at": "2026-03-17T..."
+--   }
+-- }
+
+-- Step 1: Create the table if it does not exist
+CREATE TABLE IF NOT EXISTS chairman_dashboard_config (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  company_id UUID NOT NULL,
+  config_key TEXT NOT NULL DEFAULT 'default',
+  stage_overrides JSONB NOT NULL DEFAULT '{}'::jsonb,
+  global_auto_proceed BOOLEAN NOT NULL DEFAULT true,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID,
+  CONSTRAINT uq_chairman_dashboard_config_company_key UNIQUE (company_id, config_key)
+);
+
+-- Step 2: Add stage_overrides column if table already existed without it
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'chairman_dashboard_config'
+      AND column_name = 'stage_overrides'
+  ) THEN
+    ALTER TABLE chairman_dashboard_config
+      ADD COLUMN stage_overrides JSONB NOT NULL DEFAULT '{}'::jsonb;
+  END IF;
+END
+$$;
+
+-- Step 3: Add comments for documentation
+COMMENT ON TABLE chairman_dashboard_config IS 'Chairman dashboard configuration including per-stage auto-proceed overrides (SD-LEO-FEAT-PER-STAGE-AUTO-PROCEED-001)';
+COMMENT ON COLUMN chairman_dashboard_config.stage_overrides IS 'Per-stage auto-proceed override settings. Keys are stage identifiers (e.g. "stage_7"), values are objects with auto_proceed, reason, set_by, set_at fields.';
+COMMENT ON COLUMN chairman_dashboard_config.global_auto_proceed IS 'Global auto-proceed toggle. Individual stage_overrides take precedence over this setting.';
+COMMENT ON COLUMN chairman_dashboard_config.config_key IS 'Configuration profile key. "default" is the primary configuration.';
+COMMENT ON COLUMN chairman_dashboard_config.company_id IS 'Company this configuration belongs to.';
+
+-- Step 4: Create GIN index on stage_overrides for efficient JSONB querying
+CREATE INDEX IF NOT EXISTS idx_chairman_dashboard_config_stage_overrides
+  ON chairman_dashboard_config USING GIN (stage_overrides);
+
+-- Step 5: Create updated_at trigger
+CREATE OR REPLACE FUNCTION update_chairman_dashboard_config_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_chairman_dashboard_config_updated_at ON chairman_dashboard_config;
+CREATE TRIGGER trg_chairman_dashboard_config_updated_at
+  BEFORE UPDATE ON chairman_dashboard_config
+  FOR EACH ROW
+  EXECUTE FUNCTION update_chairman_dashboard_config_updated_at();
+
+-- Step 6: Enable RLS (following chairman table patterns)
+ALTER TABLE chairman_dashboard_config ENABLE ROW LEVEL SECURITY;
+
+-- Step 7: Drop existing RLS policies for idempotency
+DROP POLICY IF EXISTS select_chairman_dashboard_config_policy ON chairman_dashboard_config;
+DROP POLICY IF EXISTS insert_chairman_dashboard_config_policy ON chairman_dashboard_config;
+DROP POLICY IF EXISTS update_chairman_dashboard_config_policy ON chairman_dashboard_config;
+DROP POLICY IF EXISTS delete_chairman_dashboard_config_policy ON chairman_dashboard_config;
+
+-- Step 8: Create RLS policies - authenticated users can read
+CREATE POLICY select_chairman_dashboard_config_policy
+  ON chairman_dashboard_config FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Step 9: Create RLS policies - service_role can insert
+CREATE POLICY insert_chairman_dashboard_config_policy
+  ON chairman_dashboard_config FOR INSERT
+  TO service_role
+  WITH CHECK (true);
+
+-- Step 10: Create RLS policies - service_role can update
+CREATE POLICY update_chairman_dashboard_config_policy
+  ON chairman_dashboard_config FOR UPDATE
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- Step 11: Create RLS policies - service_role can delete
+CREATE POLICY delete_chairman_dashboard_config_policy
+  ON chairman_dashboard_config FOR DELETE
+  TO service_role
+  USING (true);
+
+-- Rollback SQL (for reference only, not executed):
+-- DROP TRIGGER IF EXISTS trg_chairman_dashboard_config_updated_at ON chairman_dashboard_config;
+-- DROP FUNCTION IF EXISTS update_chairman_dashboard_config_updated_at();
+-- DROP TABLE IF EXISTS chairman_dashboard_config;

--- a/lib/eva/decision-filter-engine.js
+++ b/lib/eva/decision-filter-engine.js
@@ -100,6 +100,24 @@ export function evaluateDecision(input = {}, options = {}) {
   const logger = options.logger || { info() {}, debug() {} };
   const triggers = [];
 
+  // SD-LEO-FEAT-PER-STAGE-AUTO-PROCEED-001: Chairman governance override takes precedence
+  // If the Chairman has set this stage to manual review, DFE defers regardless of scoring.
+  if (options.governanceOverride && !options.governanceOverride.auto_proceed) {
+    logger.info('[DFE] Chairman governance override active for stage — forcing PRESENT_TO_CHAIRMAN');
+    return {
+      auto_proceed: false,
+      triggers: [{
+        type: 'chairman_governance_override',
+        severity: 'HIGH',
+        message: `Chairman set this stage to manual review: ${options.governanceOverride.reason || 'governance policy'}`,
+        details: { override: options.governanceOverride },
+      }],
+      recommendation: 'PRESENT_TO_CHAIRMAN',
+      escalation_level: 3,
+      escalation_label: 'Chairman Governance Override',
+    };
+  }
+
   // Helper to resolve preference with default and track missing keys
   function getPref(key) {
     if (key in preferences) return { value: preferences[key], source: 'preference' };

--- a/scripts/governance-stages.js
+++ b/scripts/governance-stages.js
@@ -11,38 +11,42 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import crypto from 'node:crypto';
 dotenv.config();
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
 
+// Hard gate stages — must match CHAIRMAN_GATES.BLOCKING in stage-execution-worker.js
+const HARD_GATE_STAGES = new Set([3, 5, 10, 22, 23, 24]);
+
 // Pipeline stage definitions (25 stages)
 const PIPELINE_STAGES = [
-  { num: 1, name: 'Ideation', hardGate: false },
-  { num: 2, name: 'Research', hardGate: false },
-  { num: 3, name: 'Validation', hardGate: true },
-  { num: 4, name: 'Market Analysis', hardGate: false },
-  { num: 5, name: 'Business Model', hardGate: true },
-  { num: 6, name: 'Competitor Analysis', hardGate: false },
-  { num: 7, name: 'MVP Definition', hardGate: false },
-  { num: 8, name: 'Technical Assessment', hardGate: false },
-  { num: 9, name: 'Financial Modeling', hardGate: true },
-  { num: 10, name: 'Team Formation', hardGate: false },
-  { num: 11, name: 'Prototype', hardGate: false },
-  { num: 12, name: 'User Testing', hardGate: false },
-  { num: 13, name: 'Pivot/Persevere', hardGate: true },
-  { num: 14, name: 'Go-to-Market', hardGate: false },
-  { num: 15, name: 'Launch Prep', hardGate: false },
-  { num: 16, name: 'Soft Launch', hardGate: false },
-  { num: 17, name: 'Metrics Review', hardGate: true },
-  { num: 18, name: 'Scale Planning', hardGate: false },
-  { num: 19, name: 'Funding Strategy', hardGate: false },
-  { num: 20, name: 'Partnership', hardGate: false },
-  { num: 21, name: 'Growth Phase', hardGate: false },
-  { num: 22, name: 'Optimization', hardGate: false },
-  { num: 23, name: 'Expansion', hardGate: false },
-  { num: 24, name: 'Maturity', hardGate: false },
-  { num: 25, name: 'Exit Strategy', hardGate: true },
-];
+  { num: 1, name: 'Ideation' },
+  { num: 2, name: 'Research' },
+  { num: 3, name: 'Validation' },
+  { num: 4, name: 'Market Analysis' },
+  { num: 5, name: 'Business Model' },
+  { num: 6, name: 'Competitor Analysis' },
+  { num: 7, name: 'MVP Definition' },
+  { num: 8, name: 'Technical Assessment' },
+  { num: 9, name: 'Financial Modeling' },
+  { num: 10, name: 'Team Formation' },
+  { num: 11, name: 'Prototype' },
+  { num: 12, name: 'User Testing' },
+  { num: 13, name: 'Pivot/Persevere' },
+  { num: 14, name: 'Go-to-Market' },
+  { num: 15, name: 'Launch Prep' },
+  { num: 16, name: 'Soft Launch' },
+  { num: 17, name: 'Metrics Review' },
+  { num: 18, name: 'Scale Planning' },
+  { num: 19, name: 'Funding Strategy' },
+  { num: 20, name: 'Partnership' },
+  { num: 21, name: 'Growth Phase' },
+  { num: 22, name: 'Optimization' },
+  { num: 23, name: 'Expansion' },
+  { num: 24, name: 'Maturity' },
+  { num: 25, name: 'Exit Strategy' },
+].map(s => ({ ...s, hardGate: HARD_GATE_STAGES.has(s.num) }));
 
 async function getConfig() {
   const { data, error } = await supabase
@@ -58,14 +62,27 @@ async function getConfig() {
 async function saveOverrides(overrides) {
   const { error } = await supabase
     .from('chairman_dashboard_config')
-    .upsert({
-      config_key: 'default',
-      company_id: '00000000-0000-0000-0000-000000000000',
+    .update({
       stage_overrides: overrides,
       updated_at: new Date().toISOString()
-    }, { onConflict: 'company_id,config_key' });
+    })
+    .eq('config_key', 'default');
 
   if (error) throw new Error(`Save error: ${error.message}`);
+}
+
+async function emitGovernanceEvent(stageNum, oldValue, newValue, actor) {
+  try {
+    await supabase.from('eva_event_log').insert({
+      event_type: 'governance_override_changed',
+      trigger_source: 'manual',
+      correlation_id: crypto.randomUUID(),
+      status: 'succeeded',
+      metadata: { stage_number: stageNum, old_value: oldValue, new_value: newValue, actor, source: 'governance-stages-cli' },
+    });
+  } catch (err) {
+    console.warn(`Event emission warning: ${err.message}`);
+  }
 }
 
 async function listStages() {
@@ -147,11 +164,20 @@ async function setStage(stageNum, mode, reason) {
   }
 
   await saveOverrides(overrides);
+  const oldValue = autoProceed ? 'manual' : 'auto';
+  const newValue = autoProceed ? 'auto' : 'manual';
+  await emitGovernanceEvent(stageNum, oldValue, newValue, 'chairman');
   console.log(`Stage ${stageNum} (${stage.name}) set to ${mode.toUpperCase()}`);
 }
 
 async function resetAll() {
+  const config = await getConfig();
+  const previousOverrides = config.stage_overrides || {};
   await saveOverrides({});
+  for (const key of Object.keys(previousOverrides)) {
+    const num = parseInt(key.replace('stage_', ''), 10);
+    if (!isNaN(num)) await emitGovernanceEvent(num, 'manual', 'auto', 'chairman');
+  }
   console.log('All stage overrides reset to default (AUTO)');
 }
 

--- a/tests/unit/governance/governance-stages.test.js
+++ b/tests/unit/governance/governance-stages.test.js
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for Chairman Pipeline Governance Controls
+ * SD-LEO-FEAT-PER-STAGE-AUTO-PROCEED-001
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateDecision } from '../../../lib/eva/decision-filter-engine.js';
+
+describe('DFE Chairman Governance Override', () => {
+  it('returns PRESENT_TO_CHAIRMAN when governance override is active', () => {
+    const result = evaluateDecision(
+      { score: 9, cost: 10, stage: 'stage_7' },
+      {
+        governanceOverride: { auto_proceed: false, reason: 'Manual review required' },
+      }
+    );
+
+    expect(result.auto_proceed).toBe(false);
+    expect(result.recommendation).toBe('PRESENT_TO_CHAIRMAN');
+    expect(result.triggers).toHaveLength(1);
+    expect(result.triggers[0].type).toBe('chairman_governance_override');
+  });
+
+  it('proceeds normally when no governance override', () => {
+    const result = evaluateDecision(
+      { score: 9, cost: 10 },
+      { preferences: { 'filter.cost_threshold': 100 } }
+    );
+
+    // Without governance override, DFE evaluates normally
+    expect(result.recommendation).not.toBe('PRESENT_TO_CHAIRMAN');
+  });
+
+  it('proceeds normally when governance override allows auto-proceed', () => {
+    const result = evaluateDecision(
+      { score: 9, cost: 10 },
+      {
+        governanceOverride: { auto_proceed: true },
+        preferences: { 'filter.cost_threshold': 100 },
+      }
+    );
+
+    // auto_proceed=true means no override, DFE evaluates normally
+    expect(result.triggers.every(t => t.type !== 'chairman_governance_override')).toBe(true);
+  });
+
+  it('governance override takes precedence over high DFE score', () => {
+    const result = evaluateDecision(
+      { score: 10, cost: 0 }, // Perfect score, no cost
+      {
+        governanceOverride: { auto_proceed: false, reason: 'Chairman review' },
+        preferences: { 'filter.cost_threshold': 1000 },
+      }
+    );
+
+    // Even with perfect inputs, governance override blocks
+    expect(result.auto_proceed).toBe(false);
+    expect(result.recommendation).toBe('PRESENT_TO_CHAIRMAN');
+  });
+});


### PR DESCRIPTION
## Summary
- Chairman can toggle per-stage auto-proceed vs manual review via CLI (`npm run governance:stages`)
- Stage-execution-worker checks governance overrides before auto-advancing ventures
- DFE defers to Chairman overrides, returning PRESENT_TO_CHAIRMAN regardless of scoring
- Governance changes emit `governance_override_changed` events to `eva_event_log` for audit trail
- Hard gate stages [3, 5, 10, 22, 23, 24] are locked and cannot be overridden
- Settings persist in `chairman_dashboard_config.stage_overrides` JSONB column

## Test plan
- [x] CLI `governance:stages list` displays all 25 stages with correct hard gates
- [x] CLI `governance:stages set <n> manual` saves override and emits event
- [x] CLI `governance:stages set <hard-gate> auto` rejects with error
- [x] DFE unit tests pass (4 tests) — governance override takes precedence
- [x] Event log contains `governance_override_changed` events with correct metadata
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)