### PR TITLE
refactor: merge redundant SUCCESS_METRICS and VISION handoff gates

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/index.js
@@ -14,10 +14,11 @@ export { createUserStoryExistenceGate } from './user-story-existence.js';
 export { createDocumentationLinkValidationGate } from './documentation-link-validation.js';
 export { createHealBeforeCompleteGate } from './heal-before-complete.js';
 export { createAcceptanceCriteriaValidationGate } from './acceptance-criteria-validation.js';
-export { createSuccessMetricsAchievementGate } from './success-metrics-achievement.js';
-export { createVisionCompletionScoreGate } from './vision-completion-score.js';
+// SD-LEO-INFRA-MERGE-REDUNDANT-HANDOFF-001: Merged SUCCESS_METRICS gates
+export { createSuccessMetricsGate, createSuccessMetricsAchievementGate, createSuccessMetricsVerificationGate } from './success-metrics-gate.js';
+// SD-LEO-INFRA-MERGE-REDUNDANT-HANDOFF-001: vision-completion-score merged into heal-before-complete (advisory section)
+// createVisionCompletionScoreGate removed — heal-before-complete already checks vision advisory
 export { createArchitecturePlanValidationGate } from './architecture-plan-validation.js';
-export { createSuccessMetricsVerificationGate } from './success-metrics-verification.js';
 export { createSmokeTestEvidenceGate } from './smoke-test-evidence.js';
 export { createFailureChainOrderingGate } from './failure-chain-ordering.js';
 

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/success-metrics-gate.js
@@ -1,0 +1,299 @@
+/**
+ * Success Metrics Gate for PLAN-TO-LEAD (Consolidated)
+ * SD-LEO-INFRA-MERGE-REDUNDANT-HANDOFF-001
+ *
+ * Merges SUCCESS_METRICS_ACHIEVEMENT and SUCCESS_METRICS_VERIFICATION
+ * into a single gate with two sub-checks:
+ *   1. Achievement: Are actual values populated and do they meet targets?
+ *   2. Verification: Can metrics be independently verified? Do they match?
+ *
+ * Single success_metrics query shared by both sub-checks.
+ *
+ * BLOCKING gate — requires:
+ *   - Achievement score >= 70 AND no metric has empty actual value
+ *   - Verification score >= 60 (for non-advisory SD types)
+ */
+
+import { verifyAllMetrics } from '../../../../../lib/metric-auto-verifier.js';
+
+// ── Achievement helpers (from success-metrics-achievement.js) ──
+
+const NA_PATTERN = /^(n\/?a|not\s*applicable|not\s*measured|deferred|skipped)$/i;
+
+function isNotApplicable(value) {
+  if (value == null) return false;
+  return NA_PATTERN.test(String(value).trim());
+}
+
+function parseMetricValue(value) {
+  if (value == null) return null;
+  const str = String(value).trim();
+  if (!str) return null;
+  const pctMatch = str.match(/([<>=]*)\s*([\d.]+)\s*%/);
+  if (pctMatch) return parseFloat(pctMatch[2]);
+  const fracMatch = str.match(/^(\d+)\s*\/\s*(\d+)$/);
+  if (fracMatch) return (parseFloat(fracMatch[1]) / parseFloat(fracMatch[2])) * 100;
+  const num = parseFloat(str);
+  if (!isNaN(num)) return num;
+  return null;
+}
+
+function meetsTarget(actual, target) {
+  if (actual == null || target == null) return null;
+  const actualNum = parseMetricValue(String(actual));
+  const targetStr = String(target).trim();
+  const opMatch = targetStr.match(/^([<>=]+)/);
+  const operator = opMatch ? opMatch[1] : '>=';
+  const targetNum = parseMetricValue(targetStr);
+  if (actualNum == null || targetNum == null) return null;
+  switch (operator) {
+    case '>=': return actualNum >= targetNum;
+    case '>':  return actualNum > targetNum;
+    case '<=': return actualNum <= targetNum;
+    case '<':  return actualNum < targetNum;
+    case '=':
+    case '==': return actualNum === targetNum;
+    default:   return actualNum >= targetNum;
+  }
+}
+
+// ── Verification constants (from success-metrics-verification.js) ──
+
+const DISABLED_SD_TYPES = new Set(['documentation', 'orchestrator']);
+const ADVISORY_SD_TYPES = new Set(['infrastructure']);
+const VERIFICATION_THRESHOLD = 60;
+const ACHIEVEMENT_THRESHOLD = 70;
+
+/**
+ * Create the consolidated SUCCESS_METRICS gate.
+ */
+export function createSuccessMetricsGate(supabase) {
+  return {
+    name: 'SUCCESS_METRICS',
+    validator: async (ctx) => {
+      console.log('\n📊 SUCCESS METRICS GATE (Achievement + Verification)');
+      console.log('-'.repeat(50));
+
+      const sdUuid = ctx.sd?.id || ctx.sdId;
+      const sdType = (ctx.sd?.sd_type || 'feature').toLowerCase();
+
+      // ── Orchestrator bypass ──
+      const { data: childSDs } = await supabase
+        .from('strategic_directives_v2')
+        .select('id')
+        .eq('parent_sd_id', sdUuid);
+
+      if (childSDs && childSDs.length > 0) {
+        console.log(`   ℹ️  Parent orchestrator SD (${childSDs.length} children) — bypassing`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: ['Orchestrator SD — metrics deferred to children'],
+          details: { is_orchestrator: true, child_count: childSDs.length }
+        };
+      }
+
+      // ── SD type check (shared by both sub-checks) ──
+      if (DISABLED_SD_TYPES.has(sdType)) {
+        console.log(`   ℹ️  SD type '${sdType}' — metrics disabled`);
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [], warnings: [`SD type '${sdType}' does not require metrics`],
+          details: { sd_type: sdType, metrics_required: false }
+        };
+      }
+
+      // Child SD detection for verification advisory mode
+      let isChildSD = false;
+      try {
+        const { data: parentCheck } = await supabase
+          .from('strategic_directives_v2')
+          .select('parent_sd_id')
+          .eq('id', sdUuid)
+          .single();
+        isChildSD = !!parentCheck?.parent_sd_id;
+      } catch { /* fail-open */ }
+
+      const isVerificationAdvisory = ADVISORY_SD_TYPES.has(sdType) || isChildSD;
+
+      // ── SINGLE metrics query (shared by both sub-checks) ──
+      const { data: sdRecord, error: sdError } = await supabase
+        .from('strategic_directives_v2')
+        .select('success_metrics')
+        .eq('id', sdUuid)
+        .single();
+
+      if (sdError) {
+        console.log(`   ⚠️  SD query error: ${sdError.message}`);
+        return {
+          passed: false, score: 0, max_score: 100,
+          issues: [`Database error: ${sdError.message}`],
+          warnings: [], remediation: 'Check database connectivity and retry'
+        };
+      }
+
+      const rawMetrics = sdRecord?.success_metrics;
+      if (!rawMetrics || !Array.isArray(rawMetrics) || rawMetrics.length === 0) {
+        console.log('   ℹ️  No success metrics defined — skipping');
+        return {
+          passed: true, score: 100, max_score: 100,
+          issues: [],
+          warnings: ['No success metrics defined — consider adding measurable outcomes'],
+          details: { metrics_count: 0 }
+        };
+      }
+
+      // Normalize metrics
+      const metrics = rawMetrics.map(m =>
+        typeof m === 'string' ? { name: m, target: 'N/A', actual: null } : m
+      );
+
+      console.log(`   Found ${metrics.length} success metric(s)\n`);
+
+      // ═══════════════════════════════════════════
+      // Sub-check 1: ACHIEVEMENT
+      // ═══════════════════════════════════════════
+      console.log('   ── Achievement Check ──');
+      const metricScores = [];
+      for (const metric of metrics) {
+        const name = metric.metric || metric.name || 'Unnamed metric';
+        const actual = metric.actual;
+        const target = metric.target;
+        const hasActual = actual != null && String(actual).trim() !== '';
+
+        if (!hasActual) {
+          metricScores.push({ name, score: 0, reason: 'No actual value recorded', target, actual });
+          console.log(`   ❌ ${name}: No actual value (target: ${target || 'N/A'})`);
+          continue;
+        }
+
+        if (isNotApplicable(actual)) {
+          metricScores.push({ name, score: 75, reason: 'Metric marked N/A', target, actual });
+          console.log(`   ℹ️  ${name}: marked "${actual}" (N/A — accepted)`);
+          continue;
+        }
+
+        const met = meetsTarget(actual, target);
+        if (met === true) {
+          metricScores.push({ name, score: 100, reason: 'Target met', target, actual });
+          console.log(`   ✅ ${name}: ${actual} meets target ${target}`);
+        } else if (met === false) {
+          metricScores.push({ name, score: 50, reason: 'Target not met', target, actual });
+          console.log(`   ⚠️  ${name}: ${actual} does NOT meet target ${target}`);
+        } else {
+          metricScores.push({ name, score: 75, reason: 'Actual recorded (non-numeric)', target, actual });
+          console.log(`   ℹ️  ${name}: actual="${actual}" (non-numeric, target="${target || 'N/A'}")`);
+        }
+      }
+
+      const achievementScore = Math.round(
+        metricScores.reduce((sum, m) => sum + m.score, 0) / metricScores.length
+      );
+      const hasEmptyActual = metricScores.some(m => m.score === 0);
+      const achievementPassed = achievementScore >= ACHIEVEMENT_THRESHOLD && !hasEmptyActual;
+
+      console.log(`\n   Achievement Score: ${achievementScore}/100 (threshold: ${ACHIEVEMENT_THRESHOLD})`);
+      console.log(`   ${achievementPassed ? '✅' : '❌'} Achievement: ${achievementPassed ? 'PASSED' : 'FAILED'}`);
+
+      // ═══════════════════════════════════════════
+      // Sub-check 2: VERIFICATION
+      // ═══════════════════════════════════════════
+      console.log('\n   ── Verification Check ──');
+      if (isChildSD) {
+        console.log('   👶 Child SD — verification advisory (scoped metrics)');
+      }
+      console.log(`   Mode: ${isVerificationAdvisory ? 'ADVISORY' : 'REQUIRED'}`);
+
+      const repoRoot = process.cwd();
+      const { results: verifyResults, overallScore: verificationScore } = verifyAllMetrics(metrics, repoRoot);
+
+      for (const r of verifyResults) {
+        const icon = r.status === 'verified' ? '✅' : r.status === 'mismatch' ? '❌' : 'ℹ️ ';
+        console.log(`   ${icon} ${r.metric}: ${r.status}`);
+        if (r.measuredValue !== null) {
+          console.log(`      Reported: ${r.reportedValue} | Measured: ${r.measuredValue}`);
+        }
+      }
+
+      const verificationPassed = isVerificationAdvisory ? true : verificationScore >= VERIFICATION_THRESHOLD;
+      console.log(`\n   Verification Score: ${verificationScore}/100 (threshold: ${VERIFICATION_THRESHOLD})`);
+      console.log(`   ${verificationPassed ? '✅' : '❌'} Verification: ${verificationPassed ? 'PASSED' : 'FAILED'}${isVerificationAdvisory ? ' (advisory)' : ''}`);
+
+      // ═══════════════════════════════════════════
+      // Combined result
+      // ═══════════════════════════════════════════
+      const combinedScore = Math.round((achievementScore + verificationScore) / 2);
+      const passed = achievementPassed && verificationPassed;
+
+      const issues = [
+        ...metricScores.filter(m => m.score === 0).map(m => `${m.name}: No actual value recorded (target: ${m.target || 'N/A'})`),
+        ...(isVerificationAdvisory ? [] : verifyResults.filter(r => r.status === 'mismatch').map(r => r.issue))
+      ];
+
+      const warnings = [
+        ...metricScores.filter(m => m.score > 0 && m.score <= 50).map(m => `${m.name}: ${m.actual} does not meet target ${m.target}`),
+        ...(isVerificationAdvisory
+          ? verifyResults.filter(r => r.status === 'mismatch').map(r => r.issue)
+          : []),
+        ...verifyResults.filter(r => r.status === 'self_reported').map(r => `${r.metric}: self-reported (no independent verification available)`)
+      ];
+
+      console.log(`\n   Combined Score: ${combinedScore}/100`);
+      console.log(`   ${passed ? '✅ PASSED' : '❌ FAILED'}`);
+
+      if (!passed) {
+        console.log('\n   REMEDIATION:');
+        if (hasEmptyActual) {
+          console.log('   - Record actual values for all success metrics');
+        }
+        if (achievementScore < ACHIEVEMENT_THRESHOLD) {
+          console.log('   - Work toward meeting defined target values');
+        }
+        if (!verificationPassed) {
+          console.log('   - Ensure reported metric values match actual measurements');
+        }
+      }
+
+      return {
+        passed,
+        score: combinedScore,
+        max_score: 100,
+        issues,
+        warnings,
+        ...(!passed && {
+          remediation: 'Record actual values for all success metrics, ensure targets are met, and verify measurements match reports'
+        }),
+        details: {
+          metrics_count: metrics.length,
+          achievement: {
+            score: achievementScore,
+            threshold: ACHIEVEMENT_THRESHOLD,
+            passed: achievementPassed,
+            has_empty_actual: hasEmptyActual,
+            metric_scores: metricScores
+          },
+          verification: {
+            score: verificationScore,
+            threshold: VERIFICATION_THRESHOLD,
+            passed: verificationPassed,
+            enforcement: isVerificationAdvisory ? 'advisory' : 'required',
+            results: verifyResults,
+            is_child_sd: isChildSD
+          }
+        }
+      };
+    },
+    required: true
+  };
+}
+
+// Backward-compatible aliases for existing imports
+export const createSuccessMetricsAchievementGate = createSuccessMetricsGate;
+export const createSuccessMetricsVerificationGate = (supabase) => ({
+  name: 'SUCCESS_METRICS_VERIFICATION',
+  validator: async () => ({
+    passed: true, score: 100, max_score: 100,
+    issues: [], warnings: ['Merged into SUCCESS_METRICS gate — this is a no-op alias'],
+    details: { merged_into: 'SUCCESS_METRICS' }
+  }),
+  required: false
+});

--- a/scripts/modules/handoff/executors/plan-to-lead/index.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/index.js
@@ -32,10 +32,8 @@ import {
   createDocumentationLinkValidationGate,
   createHealBeforeCompleteGate,
   createAcceptanceCriteriaValidationGate,
-  createSuccessMetricsAchievementGate,
-  createVisionCompletionScoreGate,
+  createSuccessMetricsGate,
   createArchitecturePlanValidationGate,
-  createSuccessMetricsVerificationGate,
   createSmokeTestEvidenceGate,
   createFailureChainOrderingGate,
   // Semantic Validation Gates (SD-LEO-FEAT-SEMANTIC-VALIDATION-GATES-002)
@@ -240,8 +238,8 @@ export class PlanToLeadExecutor extends BaseExecutor {
     // SD heal score must meet threshold (93) before final approval
     gates.push(createHealBeforeCompleteGate(this.supabase));
 
-    // Vision completion re-score (advisory — detects vision regression)
-    gates.push(createVisionCompletionScoreGate(this.supabase));
+    // SD-LEO-INFRA-MERGE-REDUNDANT-HANDOFF-001: vision-completion-score merged into
+    // heal-before-complete (advisory vision section already handles vision scoring)
 
     // Sub-agent orchestration
     gates.push(createSubAgentOrchestrationGate(this.supabase));
@@ -268,11 +266,9 @@ export class PlanToLeadExecutor extends BaseExecutor {
     // Acceptance criteria validation (blocking — every story must have criteria)
     gates.push(createAcceptanceCriteriaValidationGate(this.supabase));
 
-    // Success metrics achievement (blocking — actuals must be recorded)
-    gates.push(createSuccessMetricsAchievementGate(this.supabase));
-
-    // Success metrics verification (Gap 2 — independently measures verifiable metrics)
-    gates.push(createSuccessMetricsVerificationGate(this.supabase));
+    // SD-LEO-INFRA-MERGE-REDUNDANT-HANDOFF-001: Consolidated success metrics gate
+    // (achievement + verification in single gate with shared DB query)
+    gates.push(createSuccessMetricsGate(this.supabase));
 
     // Documentation link validation gate (SD-LEO-ORCH-QUALITY-GATE-ENHANCEMENTS-001-D)
     gates.push(createDocumentationLinkValidationGate(this.supabase));


### PR DESCRIPTION
## Summary
- Merge SUCCESS_METRICS_ACHIEVEMENT + SUCCESS_METRICS_VERIFICATION into single SUCCESS_METRICS gate with two sub-checks (eliminates duplicate DB query)
- Remove VISION_COMPLETION_SCORE from gate pipeline (heal-before-complete already has vision advisory section, eliminating 60s redundant execution)
- Backward-compatible aliases preserved for existing imports

Research found scope and user story gates are NOT redundant — they operate at different handoff phases with distinct logic and thresholds, serving a temporal progression (before/during/after execution). Kept as-is.

SD: SD-LEO-INFRA-MERGE-REDUNDANT-HANDOFF-001

## Test plan
- [x] SUCCESS_METRICS gate combines achievement (actuals populated) + verification (independent measurement)
- [x] Both sub-check thresholds preserved (achievement >= 70, verification >= 60)
- [x] Orchestrator/child/SD-type bypasses preserved from both original gates
- [x] VISION_COMPLETION_SCORE advisory absorbed into heal-before-complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)