### PR TITLE
feat: implement standalone SD auto-chaining in handoff CLI

### DIFF
--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -13,7 +13,8 @@ import dotenv from 'dotenv';
 
 // AUTO-PROCEED continuation imports
 import { getNextReadyChild, getOrchestratorContext } from '../child-sd-selector.js';
-import { resolveAutoProceed } from '../auto-proceed-resolver.js';
+import { resolveAutoProceed, getChainOrchestrators } from '../auto-proceed-resolver.js';
+import { findNextAvailableOrchestrator } from '../orchestrator-completion-hook.js';
 
 // SD-MAN-FEAT-CORRECTIVE-VISION-GAP-007: Handoff sequence enforcement
 import { getWorkflowForType } from './workflow-definitions.js';
@@ -810,6 +811,7 @@ export async function handleExecuteWithContinuation(handoffType, sdId, args) {
     }
 
     // SD-LEO-ENH-AUTO-PROCEED-001-05: Handle orchestrator chaining for top-level SDs
+    // SD-LEO-INFRA-IMPLEMENT-STANDALONE-AUTO-001: Extended to support standalone SD chaining
     if (!completedSD.parent_sd_id) {
       // Check if this was an orchestrator that completed with chaining enabled
       const chainingInfo = currentResult.result?.orchestratorChaining;
@@ -826,7 +828,33 @@ export async function handleExecuteWithContinuation(handoffType, sdId, args) {
         continue; // Continue the loop for the new orchestrator's children
       }
 
-      console.log('   ℹ️  Top-level SD completed - no continuation needed');
+      // SD-LEO-INFRA-IMPLEMENT-STANDALONE-AUTO-001: Standalone SD chaining
+      // When a standalone (non-orchestrator) top-level SD completes, check if
+      // chain_orchestrators is enabled and find the next available SD to chain to.
+      const chainingConfig = await getChainOrchestrators(system.supabase);
+      if (chainingConfig.chainOrchestrators) {
+        const { orchestrator: nextSD, reason } = await findNextAvailableOrchestrator(
+          system.supabase,
+          currentSdId
+        );
+
+        if (nextSD) {
+          console.log('\n🔗 STANDALONE SD CHAINING: Auto-continuing to next SD');
+          console.log(`   Next: ${nextSD.sd_key || nextSD.id}`);
+          console.log(`   Title: ${nextSD.title}`);
+          console.log('   ➡️  Starting LEAD-TO-PLAN...');
+          console.log('');
+
+          currentSdId = nextSD.id;
+          currentHandoffType = 'LEAD-TO-PLAN';
+          currentResult = await handleExecuteCommand('LEAD-TO-PLAN', nextSD.id, args);
+          continue;
+        }
+
+        console.log(`\n⏸️  STANDALONE CHAINING: No next SD available (${reason})`);
+      } else {
+        console.log('   ℹ️  Top-level SD completed - chaining disabled');
+      }
       break;
     }
 

--- a/tests/unit/handoff/standalone-sd-chaining.test.js
+++ b/tests/unit/handoff/standalone-sd-chaining.test.js
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for Standalone SD Auto-Chaining
+ *
+ * Part of SD-LEO-INFRA-IMPLEMENT-STANDALONE-AUTO-001
+ *
+ * Tests the standalone SD chaining logic in cli-main.js that allows
+ * top-level non-orchestrator SDs to auto-chain to the next available SD
+ * when chain_orchestrators is enabled.
+ */
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Mock modules before importing the module under test
+vi.mock('../../../lib/terminal-identity.js', () => ({
+  getTerminalId: vi.fn().mockReturnValue('win-cc-test-12345')
+}));
+
+vi.mock('../../../lib/claim-guard.mjs', () => ({
+  claimGuard: vi.fn().mockResolvedValue({ success: true, claim: { status: 'newly_acquired' } }),
+  isSameConversation: vi.fn().mockReturnValue(true)
+}));
+
+vi.mock('../../../lib/resolve-own-session.js', () => ({
+  resolveOwnSession: vi.fn().mockResolvedValue({
+    data: { session_id: 'test-session', metadata: { auto_proceed: true, chain_orchestrators: true } }
+  })
+}));
+
+import { findNextAvailableOrchestrator } from '../../../scripts/modules/handoff/orchestrator-completion-hook.js';
+import { getChainOrchestrators } from '../../../scripts/modules/handoff/auto-proceed-resolver.js';
+
+describe('Standalone SD Auto-Chaining', () => {
+  describe('getChainOrchestrators', () => {
+    it('should return chainOrchestrators=true when session metadata has chain_orchestrators=true', async () => {
+      const result = await getChainOrchestrators({});
+      expect(result.chainOrchestrators).toBe(true);
+    });
+  });
+
+  describe('findNextAvailableOrchestrator (reused for standalone chaining)', () => {
+    it('should return the next unclaimed top-level SD', async () => {
+      const mockSupabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            not: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue([])
+            }),
+            in: vi.fn().mockReturnValue({
+              is: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockReturnValue({
+                      neq: vi.fn().mockResolvedValue({
+                        data: [
+                          { id: 'next-sd-uuid', sd_key: 'SD-NEXT-001', title: 'Next SD', status: 'draft', priority: 'medium', parent_sd_id: null }
+                        ],
+                        error: null
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      };
+
+      const result = await findNextAvailableOrchestrator(mockSupabase, 'current-sd-uuid');
+      expect(result.orchestrator).not.toBeNull();
+      expect(result.orchestrator.sd_key).toBe('SD-NEXT-001');
+    });
+
+    it('should return null when no SDs are available', async () => {
+      const mockSupabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            not: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue([])
+            }),
+            in: vi.fn().mockReturnValue({
+              is: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockReturnValue({
+                      neq: vi.fn().mockResolvedValue({
+                        data: [],
+                        error: null
+                      })
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      };
+
+      const result = await findNextAvailableOrchestrator(mockSupabase, 'current-sd-uuid');
+      expect(result.orchestrator).toBeNull();
+      expect(result.reason).toContain('No orchestrators in queue');
+    });
+
+    it('should exclude the just-completed SD from results', async () => {
+      const neqSpy = vi.fn().mockResolvedValue({
+        data: [{ id: 'other-uuid', sd_key: 'SD-OTHER-001', title: 'Other SD', status: 'draft', priority: 'medium', parent_sd_id: null }],
+        error: null
+      });
+
+      const mockSupabase = {
+        from: vi.fn().mockReturnValue({
+          select: vi.fn().mockReturnValue({
+            not: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue([])
+            }),
+            in: vi.fn().mockReturnValue({
+              is: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockReturnValue({
+                      neq: neqSpy
+                    })
+                  })
+                })
+              })
+            })
+          })
+        })
+      };
+
+      await findNextAvailableOrchestrator(mockSupabase, 'completed-sd-uuid');
+      expect(neqSpy).toHaveBeenCalledWith('id', 'completed-sd-uuid');
+    });
+  });
+
+  describe('Chaining behavior integration', () => {
+    it('should not chain when chain_orchestrators is false', async () => {
+      // Override resolveOwnSession for this test
+      const { resolveOwnSession } = await import('../../../lib/resolve-own-session.js');
+      resolveOwnSession.mockResolvedValueOnce({
+        data: { session_id: 'test-session', metadata: { auto_proceed: true, chain_orchestrators: false } }
+      });
+
+      const result = await getChainOrchestrators({});
+      expect(result.chainOrchestrators).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extends auto-chaining to standalone (non-orchestrator) top-level SDs in `handleExecuteWithContinuation`
- Reuses existing `findNextAvailableOrchestrator` and `getChainOrchestrators` — no new dependencies
- Replaces hard `break` at line 829 of `cli-main.js` with conditional chaining check
- 5 new unit tests covering: chaining enabled, chaining disabled, empty queue, SD exclusion

## Test plan
- [x] 5 new unit tests pass (`standalone-sd-chaining.test.js`)
- [x] 19 existing orchestrator-completion-hook tests still pass
- [ ] Manual verification: complete a standalone SD with `chain_orchestrators=true` and confirm next SD auto-starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)