### PR TITLE
fix: resolve 18 pre-existing handoff unit test failures

### DIFF
--- a/tests/unit/handoff/auto-proceed-resolver.test.js
+++ b/tests/unit/handoff/auto-proceed-resolver.test.js
@@ -3,10 +3,25 @@
  *
  * Part of SD-LEO-ENH-AUTO-PROCEED-001-02
  *
- * Tests the precedence order: CLI > env > session > database > default
+ * Tests the precedence order: CLI > env > session > global > default
  */
 
-// Jest provides describe, it, expect, beforeEach, afterEach globally
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+// Mock resolveOwnSession before importing the module under test.
+// The production code now uses resolveOwnSession() instead of direct Supabase
+// chain queries (from().select().eq().order().limit().single()).
+const mockResolveOwnSession = vi.fn();
+vi.mock('../../../lib/resolve-own-session.js', () => ({
+  resolveOwnSession: (...args) => mockResolveOwnSession(...args),
+  getOwnSessionId: vi.fn().mockReturnValue('test-session-mock')
+}));
+
+// Also mock terminal-identity to prevent filesystem access
+vi.mock('../../../lib/terminal-identity.js', () => ({
+  getTerminalId: vi.fn().mockReturnValue('win-cc-test-99999')
+}));
+
 import {
   parseCliFlags,
   parseEnvVar,
@@ -21,6 +36,10 @@ import {
 } from '../../../scripts/modules/handoff/auto-proceed-resolver.js';
 
 describe('AUTO-PROCEED Resolver', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe('parseCliFlags', () => {
     it('should return enabled when --auto-proceed flag is present', () => {
       const result = parseCliFlags(['node', 'script.js', '--auto-proceed']);
@@ -97,26 +116,15 @@ describe('AUTO-PROCEED Resolver', () => {
 
   describe('readFromSession', () => {
     it('should return session value when present', async () => {
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: {
-                      session_id: 'test-session-123',
-                      metadata: { auto_proceed: true }
-                    },
-                    error: null
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: {
+          session_id: 'test-session-123',
+          metadata: { auto_proceed: true }
+        },
+        source: 'env_var'
+      });
 
+      const mockSupabase = {};
       const result = await readFromSession(mockSupabase);
       expect(result.value).toBe(true);
       expect(result.source).toBe(RESOLUTION_SOURCES.SESSION);
@@ -124,49 +132,27 @@ describe('AUTO-PROCEED Resolver', () => {
     });
 
     it('should return null when no active session exists', async () => {
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: null,
-                    error: { code: 'PGRST116', message: 'no rows' }
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: null,
+        source: 'error'
+      });
 
+      const mockSupabase = {};
       const result = await readFromSession(mockSupabase);
       expect(result.value).toBe(null);
       expect(result.source).toBe(null);
     });
 
     it('should return null when session has no auto_proceed metadata', async () => {
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: {
-                      session_id: 'test-session-456',
-                      metadata: {}
-                    },
-                    error: null
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: {
+          session_id: 'test-session-456',
+          metadata: {}
+        },
+        source: 'env_var'
+      });
 
+      const mockSupabase = {};
       const result = await readFromSession(mockSupabase);
       expect(result.value).toBe(null);
       expect(result.sessionId).toBe('test-session-456');
@@ -224,26 +210,10 @@ describe('AUTO-PROCEED Resolver', () => {
 
     it('should prefer CLI over all other sources', async () => {
       process.env.AUTO_PROCEED = 'false';
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: { session_id: 's1', metadata: { auto_proceed: false } },
-                    error: null
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
 
       const result = await resolveAutoProceed({
         args: ['node', 'test', '--auto-proceed'],
-        supabase: mockSupabase,
+        supabase: {},
         persist: false,
         verbose: false
       });
@@ -254,26 +224,10 @@ describe('AUTO-PROCEED Resolver', () => {
 
     it('should prefer env over session/database', async () => {
       process.env.AUTO_PROCEED = 'true';
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: { session_id: 's1', metadata: { auto_proceed: false } },
-                    error: null
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
 
       const result = await resolveAutoProceed({
         args: ['node', 'test'],
-        supabase: mockSupabase,
+        supabase: {},
         persist: false,
         verbose: false
       });
@@ -284,26 +238,19 @@ describe('AUTO-PROCEED Resolver', () => {
 
     it('should fall back to session when CLI and env not set', async () => {
       delete process.env.AUTO_PROCEED;
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: { session_id: 's1', metadata: { auto_proceed: true } },
-                    error: null
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
+
+      // Mock readFromSession (called via resolveOwnSession)
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: {
+          session_id: 's1',
+          metadata: { auto_proceed: true }
+        },
+        source: 'env_var'
+      });
 
       const result = await resolveAutoProceed({
         args: ['node', 'test'],
-        supabase: mockSupabase,
+        supabase: {},
         persist: false,
         verbose: false
       });
@@ -314,20 +261,19 @@ describe('AUTO-PROCEED Resolver', () => {
 
     it('should use default when no source provides value', async () => {
       delete process.env.AUTO_PROCEED;
+
+      // Mock readFromSession returning no auto_proceed
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: {
+          session_id: 's1',
+          metadata: {}
+        },
+        source: 'env_var'
+      });
+
       const mockSupabase = {
+        rpc: () => Promise.resolve({ data: [], error: null }),
         from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: { session_id: 's1', metadata: {} },
-                    error: null
-                  })
-                })
-              })
-            })
-          }),
           upsert: () => Promise.resolve({ error: null })
         })
       };
@@ -360,110 +306,64 @@ describe('AUTO-PROCEED Resolver', () => {
       expect(RESOLUTION_SOURCES.CLI).toBe('cli');
       expect(RESOLUTION_SOURCES.ENV).toBe('env');
       expect(RESOLUTION_SOURCES.SESSION).toBe('session');
-      expect(RESOLUTION_SOURCES.DATABASE).toBe('database');
+      expect(RESOLUTION_SOURCES.GLOBAL).toBe('global');
       expect(RESOLUTION_SOURCES.DEFAULT).toBe('default');
     });
 
-    it('should have default as false (conservative)', () => {
-      expect(DEFAULT_AUTO_PROCEED).toBe(false);
+    it('should have default as true (ON by default per documentation)', () => {
+      expect(DEFAULT_AUTO_PROCEED).toBe(true);
     });
   });
 
   // SD-LEO-ENH-AUTO-PROCEED-001-05: Orchestrator Chaining Tests
   describe('getChainOrchestrators', () => {
     it('should return chain_orchestrators value when present in session', async () => {
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: {
-                      session_id: 'test-session-123',
-                      metadata: { auto_proceed: true, chain_orchestrators: true }
-                    },
-                    error: null
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: {
+          session_id: 'test-session-123',
+          metadata: { auto_proceed: true, chain_orchestrators: true }
+        },
+        source: 'env_var'
+      });
 
+      const mockSupabase = {};
       const result = await getChainOrchestrators(mockSupabase);
       expect(result.chainOrchestrators).toBe(true);
       expect(result.sessionId).toBe('test-session-123');
     });
 
-    it('should default to false when chain_orchestrators not set', async () => {
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: {
-                      session_id: 'test-session-456',
-                      metadata: { auto_proceed: true }
-                    },
-                    error: null
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
+    it('should default to true when chain_orchestrators not set (automation by default)', async () => {
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: {
+          session_id: 'test-session-456',
+          metadata: { auto_proceed: true }
+        },
+        source: 'env_var'
+      });
 
+      const mockSupabase = {};
       const result = await getChainOrchestrators(mockSupabase);
-      expect(result.chainOrchestrators).toBe(false);
+      // DEFAULT_CHAIN_ORCHESTRATORS is true (SD-MAN-GEN-CORRECTIVE-VISION-GAP-013)
+      expect(result.chainOrchestrators).toBe(true);
       expect(result.sessionId).toBe('test-session-456');
     });
 
     it('should default to false when no active session exists', async () => {
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: null,
-                    error: { code: 'PGRST116', message: 'no rows' }
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: null,
+        source: 'error'
+      });
 
+      const mockSupabase = {};
       const result = await getChainOrchestrators(mockSupabase);
       expect(result.chainOrchestrators).toBe(false);
       expect(result.sessionId).toBe(null);
     });
 
     it('should default to false on database error', async () => {
-      const mockSupabase = {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: () => ({
-                  single: () => Promise.resolve({
-                    data: null,
-                    error: { code: 'SOME_ERROR', message: 'Database error' }
-                  })
-                })
-              })
-            })
-          })
-        })
-      };
+      mockResolveOwnSession.mockRejectedValueOnce(new Error('Database error'));
 
+      const mockSupabase = {};
       const result = await getChainOrchestrators(mockSupabase);
       expect(result.chainOrchestrators).toBe(false);
       expect(result.sessionId).toBe(null);
@@ -472,29 +372,18 @@ describe('AUTO-PROCEED Resolver', () => {
 
   describe('setChainOrchestrators', () => {
     it('should successfully set chain_orchestrators in session', async () => {
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: {
+          session_id: 'existing-session',
+          metadata: { auto_proceed: true }
+        },
+        source: 'env_var'
+      });
+
       const mockSupabase = {
-        from: (table) => {
-          if (table === 'claude_sessions') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  order: () => ({
-                    limit: () => ({
-                      single: () => Promise.resolve({
-                        data: {
-                          session_id: 'existing-session',
-                          metadata: { auto_proceed: true }
-                        },
-                        error: null
-                      })
-                    })
-                  })
-                })
-              }),
-              upsert: () => Promise.resolve({ error: null })
-            };
-          }
-        }
+        from: () => ({
+          upsert: () => Promise.resolve({ error: null })
+        })
       };
 
       const result = await setChainOrchestrators(mockSupabase, true);
@@ -503,33 +392,22 @@ describe('AUTO-PROCEED Resolver', () => {
     });
 
     it('should preserve existing metadata when setting chain_orchestrators', async () => {
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: {
+          session_id: 'test-session',
+          metadata: { auto_proceed: true, other_setting: 'value' }
+        },
+        source: 'env_var'
+      });
+
       let upsertedData = null;
       const mockSupabase = {
-        from: (table) => {
-          if (table === 'claude_sessions') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  order: () => ({
-                    limit: () => ({
-                      single: () => Promise.resolve({
-                        data: {
-                          session_id: 'test-session',
-                          metadata: { auto_proceed: true, other_setting: 'value' }
-                        },
-                        error: null
-                      })
-                    })
-                  })
-                })
-              }),
-              upsert: (data) => {
-                upsertedData = data;
-                return Promise.resolve({ error: null });
-              }
-            };
+        from: () => ({
+          upsert: (data) => {
+            upsertedData = data;
+            return Promise.resolve({ error: null });
           }
-        }
+        })
       };
 
       await setChainOrchestrators(mockSupabase, true);
@@ -539,26 +417,15 @@ describe('AUTO-PROCEED Resolver', () => {
     });
 
     it('should handle write errors gracefully', async () => {
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: { session_id: 's1', metadata: {} },
+        source: 'env_var'
+      });
+
       const mockSupabase = {
-        from: (table) => {
-          if (table === 'claude_sessions') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  order: () => ({
-                    limit: () => ({
-                      single: () => Promise.resolve({
-                        data: { session_id: 's1', metadata: {} },
-                        error: null
-                      })
-                    })
-                  })
-                })
-              }),
-              upsert: () => Promise.resolve({ error: { message: 'Database error' } })
-            };
-          }
-        }
+        from: () => ({
+          upsert: () => Promise.resolve({ error: { message: 'Database error' } })
+        })
       };
 
       const result = await setChainOrchestrators(mockSupabase, true);
@@ -567,26 +434,15 @@ describe('AUTO-PROCEED Resolver', () => {
     });
 
     it('should create new session if none exists', async () => {
+      mockResolveOwnSession.mockResolvedValueOnce({
+        data: null,
+        source: 'error'
+      });
+
       const mockSupabase = {
-        from: (table) => {
-          if (table === 'claude_sessions') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  order: () => ({
-                    limit: () => ({
-                      single: () => Promise.resolve({
-                        data: null,
-                        error: { code: 'PGRST116', message: 'no rows' }
-                      })
-                    })
-                  })
-                })
-              }),
-              upsert: () => Promise.resolve({ error: null })
-            };
-          }
-        }
+        from: () => ({
+          upsert: () => Promise.resolve({ error: null })
+        })
       };
 
       const result = await setChainOrchestrators(mockSupabase, true);

--- a/tests/unit/handoff/child-sd-selector.test.js
+++ b/tests/unit/handoff/child-sd-selector.test.js
@@ -6,7 +6,20 @@
  * Tests selecting next ready child SD from orchestrator parent
  */
 
-// Jest provides describe, it, expect, beforeEach globally
+import { vi, describe, it, expect } from 'vitest';
+
+// Mock urgency-scorer to avoid importing real module
+vi.mock('../../../scripts/modules/handoff/auto-proceed/urgency-scorer.js', () => ({
+  sortByUrgency: vi.fn((items) => items), // pass through unchanged
+  scoreToBand: vi.fn(() => 'normal')
+}));
+
+// Mock dependency-dag to avoid importing real module
+vi.mock('../../../lib/orchestrator/dependency-dag.js', () => ({
+  buildDependencyDAG: vi.fn(),
+  detectCycles: vi.fn(),
+  computeRunnableSet: vi.fn()
+}));
 
 import {
   isChildSD,
@@ -60,108 +73,36 @@ describe('Child SD Selector', () => {
         sequence_rank: 2
       };
 
+      // Production code now uses:
+      //   .from('strategic_directives_v2')
+      //   .select(long column list)
+      //   .eq('parent_sd_id', parentSdId)
+      //   .in('status', ['draft', 'active'])
+      // then optionally .neq('id', excludeCompletedId)
+      // and awaits the result directly (no .order().limit() chain)
       const mockSupabase = {
-        from: (table) => {
-          if (table === 'strategic_directives_v2') {
-            return {
-              select: () => ({
-                eq: () => ({
-                  in: () => ({
-                    neq: () => ({
-                      order: () => ({
-                        order: () => ({
-                          order: () => ({
-                            limit: () => Promise.resolve({ data: [mockChild], error: null })
-                          })
-                        })
-                      })
-                    })
-                  })
-                })
-              })
-            };
-          }
-          return {};
-        }
-      };
-
-      const result = await getNextReadyChild(mockSupabase, 'parent-1', 'child-1');
-
-      expect(result.sd).toEqual(mockChild);
-      expect(result.allComplete).toBe(false);
-      expect(result.reason).toBe('Next child found');
-    });
-
-    it('should return allComplete=true when all children are completed', async () => {
-      const mockSupabase = {
-        from: (table) => {
-          if (table === 'strategic_directives_v2') {
-            return {
-              select: () => ({
-                eq: (field, value) => {
-                  // First query: looking for ready children
-                  if (field === 'parent_sd_id') {
-                    return {
-                      in: () => ({
-                        order: () => ({
-                          order: () => ({
-                            order: () => ({
-                              limit: () => Promise.resolve({ data: [], error: null })
-                            })
-                          })
-                        })
-                      }),
-                      // Second query: getting all children
-                    };
-                  }
-                  return {
-                    in: () => ({
-                      order: () => ({
-                        order: () => ({
-                          order: () => ({
-                            limit: () => Promise.resolve({ data: [], error: null })
-                          })
-                        })
-                      })
-                    })
-                  };
-                }
-              })
-            };
-          }
-          return {};
-        }
-      };
-
-      // Simplified mock that returns empty for ready children, then all completed
-      const simpleMock = {
         from: () => ({
           select: () => ({
             eq: () => ({
               in: () => ({
-                neq: () => ({
-                  order: () => ({
-                    order: () => ({
-                      order: () => ({
-                        limit: () => Promise.resolve({ data: [], error: null })
-                      })
-                    })
-                  })
-                }),
-                order: () => ({
-                  order: () => ({
-                    order: () => ({
-                      limit: () => Promise.resolve({ data: [], error: null })
-                    })
-                  })
-                })
+                neq: () => Promise.resolve({ data: [mockChild], error: null })
               })
             })
           })
         })
       };
 
-      // For this test, we need a mock that handles both query paths
+      const result = await getNextReadyChild(mockSupabase, 'parent-1', 'child-1');
+
+      // The result.sd will include urgency fields added by the production code
+      expect(result.sd).toBeTruthy();
+      expect(result.sd.id).toBe('child-2');
+      expect(result.sd.sd_key).toBe('SD-CHILD-002');
+      expect(result.allComplete).toBe(false);
+      expect(result.reason).toContain('Next child found');
+    });
+
+    it('should return allComplete=true when all children are completed', async () => {
       let queryCount = 0;
       const dualMock = {
         from: () => ({
@@ -169,20 +110,12 @@ describe('Child SD Selector', () => {
             eq: () => {
               queryCount++;
               if (queryCount === 1) {
-                // First query: looking for ready children (returns empty)
+                // First query: looking for ready children with .in('status', ...)
                 return {
-                  in: () => ({
-                    order: () => ({
-                      order: () => ({
-                        order: () => ({
-                          limit: () => Promise.resolve({ data: [], error: null })
-                        })
-                      })
-                    })
-                  })
+                  in: () => Promise.resolve({ data: [], error: null })
                 };
               } else {
-                // Second query: getting all children (all completed)
+                // Second query: getting all children (no .in, just .eq)
                 return Promise.resolve({
                   data: [
                     { id: 'c1', status: 'completed' },
@@ -212,15 +145,7 @@ describe('Child SD Selector', () => {
               if (queryCount === 1) {
                 // First query: looking for ready children (returns empty)
                 return {
-                  in: () => ({
-                    order: () => ({
-                      order: () => ({
-                        order: () => ({
-                          limit: () => Promise.resolve({ data: [], error: null })
-                        })
-                      })
-                    })
-                  })
+                  in: () => Promise.resolve({ data: [], error: null })
                 };
               } else {
                 // Second query: getting all children (some blocked)
@@ -246,19 +171,12 @@ describe('Child SD Selector', () => {
     });
 
     it('should handle query errors gracefully', async () => {
+      // Production code: the first query uses .eq().in() and awaits directly
       const mockSupabase = {
         from: () => ({
           select: () => ({
             eq: () => ({
-              in: () => ({
-                order: () => ({
-                  order: () => ({
-                    order: () => ({
-                      limit: () => Promise.resolve({ data: null, error: { message: 'DB error' } })
-                    })
-                  })
-                })
-              })
+              in: () => Promise.resolve({ data: null, error: { message: 'DB error' } })
             })
           })
         })
@@ -288,17 +206,14 @@ describe('Child SD Selector', () => {
       ];
 
       const mockSupabase = {
-        from: (table) => ({
+        from: () => ({
           select: () => ({
-            eq: () => {
-              // Check if this is the parent or children query
-              return {
-                single: () => Promise.resolve({ data: mockParent, error: null }),
-                order: () => ({
-                  order: () => Promise.resolve({ data: mockChildren, error: null })
-                })
-              };
-            }
+            eq: () => ({
+              single: () => Promise.resolve({ data: mockParent, error: null }),
+              order: () => ({
+                order: () => Promise.resolve({ data: mockChildren, error: null })
+              })
+            })
           })
         })
       };

--- a/tests/unit/handoff/executors/plan-to-exec/retrospective.test.js
+++ b/tests/unit/handoff/executors/plan-to-exec/retrospective.test.js
@@ -25,7 +25,7 @@ const SD = {
   key_changes: [{ change: 'Fix retrospective.js action item merge condition', file: 'retrospective.js' }],
   success_criteria: [
     'Action items have verification field on all items',
-    'RETROSPECTIVE_QUALITY_GATE passes ≥55/100 on first attempt',
+    'RETROSPECTIVE_QUALITY_GATE passes >=55/100 on first attempt',
   ],
   strategic_objectives: ['Eliminate manual retrospective patching'],
   risks: [{ risk: 'Edge case in merge condition', mitigation: 'Added OR clause for verification check' }],
@@ -33,31 +33,96 @@ const SD = {
 
 /**
  * Build a mock Supabase client that captures inserted retrospective data.
+ *
+ * The production code makes multiple calls to supabase.from():
+ *   1. from('issue_patterns').select().or().eq()  -- getIssuesForSD
+ *   2. from('retrospectives').select('id').eq().eq().order().limit().maybeSingle() -- existing check
+ *   3. from('retrospectives').insert(data).select()  -- or .update(data).eq().select()
+ *
  * Returns { supabase, getInserted } where getInserted() returns the last insert arg.
  */
 function buildMockSupabase() {
   let inserted = null;
 
   const supabase = {
-    from: vi.fn().mockReturnValue({
-      // issue_patterns query chain
-      select: vi.fn().mockReturnValue({
-        or: vi.fn().mockReturnValue({
-          eq: vi.fn().mockResolvedValue({ data: [], error: null }),
-        }),
-        eq: vi.fn().mockReturnValue({
-          order: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+    from: vi.fn().mockImplementation((table) => {
+      if (table === 'issue_patterns') {
+        return {
+          select: vi.fn().mockReturnValue({
+            or: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockReturnValue({
+                limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'retrospectives') {
+        return {
+          // For the existing-check query chain:
+          //   .select('id').eq().eq().order().limit().maybeSingle()
+          select: vi.fn().mockImplementation((cols) => {
+            if (cols === 'id') {
+              // This is the "check for existing" query
+              return {
+                eq: vi.fn().mockReturnValue({
+                  eq: vi.fn().mockReturnValue({
+                    order: vi.fn().mockReturnValue({
+                      limit: vi.fn().mockReturnValue({
+                        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                      }),
+                    }),
+                  }),
+                }),
+              };
+            }
+            // Fallback for .insert().select() chain - returns the inserted data
+            return {
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  order: vi.fn().mockReturnValue({
+                    limit: vi.fn().mockReturnValue({
+                      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+                    }),
+                  }),
+                }),
+              }),
+            };
+          }),
+          // For the insert chain: .insert(data).select()
+          insert: vi.fn().mockImplementation((data) => {
+            inserted = data;
+            return {
+              select: vi.fn().mockResolvedValue({ data: [{ id: 'retro-001', ...data }], error: null }),
+            };
+          }),
+          // For the update chain (if existing found): .update(data).eq().select()
+          update: vi.fn().mockImplementation((data) => {
+            inserted = data;
+            return {
+              eq: vi.fn().mockReturnValue({
+                select: vi.fn().mockResolvedValue({ data: [{ id: 'retro-001', ...data }], error: null }),
+              }),
+            };
+          }),
+        };
+      }
+      // Default fallback for any other table
+      return {
+        select: vi.fn().mockReturnValue({
+          or: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
           }),
         }),
-      }),
-      // retrospectives insert chain
-      insert: vi.fn().mockImplementation((data) => {
-        inserted = data;
-        return {
-          select: vi.fn().mockResolvedValue({ data: [{ id: 'retro-001', ...data }], error: null }),
-        };
-      }),
+      };
     }),
   };
 

--- a/tests/unit/handoff/handoff-system.test.js
+++ b/tests/unit/handoff/handoff-system.test.js
@@ -278,7 +278,8 @@ describe('ValidatorRegistry', () => {
       expect(typeof fallback).toBe('function');
       const result = await fallback();
       expect(result.passed).toBe(true);
-      expect(result.score).toBe(100);
+      // Fallback validators return a penalized score of 50, not 100
+      expect(result.score).toBe(50);
       expect(result.details.isFallback).toBe(true);
     });
 


### PR DESCRIPTION
## Summary
- Fixed 18 pre-existing test failures across 4 handoff unit test files
- **auto-proceed-resolver.test.js** (10 fixes): Aligned resolveOwnSession mock, updated RESOLUTION_SOURCES/defaults
- **child-sd-selector.test.js** (2 fixes): Updated Supabase mock chain to current `.eq().in().neq()` pattern
- **handoff-system.test.js** (1 fix): Updated fallback validator expected score (100→50)
- **retrospective.test.js** (5 fixes): Rewrote mock for multi-table dispatch and upsert pattern
- No production code changes — test-only fixes

## Test plan
- [x] 118 tests pass across the 4 fixed files (0 failures)
- [x] 365 total handoff tests pass (up from 347)
- [x] Smoke tests pass
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)