### PR TITLE
feat: add HANDOFF_RESULT machine-readable summary line

### DIFF
--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -286,6 +286,11 @@ export async function displayExecutionResult(result, handoffType, sdId) {
       // LEO 5.0: Hydrate tasks for next phase
       await hydrateAndOutputTasks(sdId, handoffType, supabase);
     }
+
+    // SD-LEO-INFRA-HANDOFF-RESULT-SUMMARY-001: Machine-readable result summary
+    // Emitted LAST so grep/tail can always find it regardless of output size
+    const displayScore = result.normalizedScore ?? result.qualityScore ?? Math.round((result.totalScore / result.maxScore) * 100) ?? 0;
+    console.log(`\nHANDOFF_RESULT=PASS SD=${sdId} SCORE=${displayScore} PHASE=${handoffType.toUpperCase()}`);
   } else {
     console.log('');
     console.log('❌ HANDOFF FAILED');
@@ -308,5 +313,10 @@ export async function displayExecutionResult(result, handoffType, sdId) {
       console.log('   💡 TIP: Run precheck to see ALL gate failures at once:');
       console.log(`      node scripts/handoff.js precheck ${handoffType} ${sdId}`);
     }
+
+    // SD-LEO-INFRA-HANDOFF-RESULT-SUMMARY-001: Machine-readable result summary
+    const failScore = result.normalizedScore ?? result.qualityScore ?? Math.round(((result.totalScore || 0) / (result.maxScore || 100)) * 100) ?? 0;
+    const reasonCode = result.reasonCode || 'VALIDATION_FAILED';
+    console.log(`\nHANDOFF_RESULT=FAIL SD=${sdId} SCORE=${failScore} PHASE=${handoffType.toUpperCase()} REASON=${reasonCode}`);
   }
 }


### PR DESCRIPTION
## Summary
- Emits `HANDOFF_RESULT=PASS|FAIL SD=<id> SCORE=<n> PHASE=<type>` as the final line of every handoff execution
- Enables reliable grep-based result extraction regardless of output size
- RCA preventative action: prevents information loss when handoff output is truncated (root cause from SD-LEO-FIX-STAGE1-DATA-RACE-001)

## Test plan
- [ ] Run a passing handoff and verify `grep HANDOFF_RESULT` returns exactly 1 line with PASS
- [ ] Run a failing handoff and verify `grep HANDOFF_RESULT` returns exactly 1 line with FAIL and REASON
- [ ] Verify existing `HANDOFF_NEXT_CMD` output is preserved

SD-LEO-INFRA-HANDOFF-RESULT-SUMMARY-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)