### PR TITLE
feat: add HANDOFF_RESULT machine-readable summary line

### DIFF
--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -286,6 +286,11 @@ export async function displayExecutionResult(result, handoffType, sdId) {
       // LEO 5.0: Hydrate tasks for next phase
       await hydrateAndOutputTasks(sdId, handoffType, supabase);
     }
+
+    // SD-LEO-INFRA-HANDOFF-RESULT-SUMMARY-001: Machine-readable result summary
+    // Emitted LAST so grep/tail can always find it regardless of output size
+    const displayScore = result.normalizedScore ?? result.qualityScore ?? Math.round((result.totalScore / result.maxScore) * 100) ?? 0;
+    console.log(`\nHANDOFF_RESULT=PASS SD=${sdId} SCORE=${displayScore} PHASE=${handoffType.toUpperCase()}`);
   } else {
     console.log('');
     console.log('❌ HANDOFF FAILED');
@@ -308,5 +313,10 @@ export async function displayExecutionResult(result, handoffType, sdId) {
       console.log('   💡 TIP: Run precheck to see ALL gate failures at once:');
       console.log(`      node scripts/handoff.js precheck ${handoffType} ${sdId}`);
     }
+
+    // SD-LEO-INFRA-HANDOFF-RESULT-SUMMARY-001: Machine-readable result summary
+    const failScore = result.normalizedScore ?? result.qualityScore ?? Math.round(((result.totalScore || 0) / (result.maxScore || 100)) * 100) ?? 0;
+    const reasonCode = result.reasonCode || 'VALIDATION_FAILED';
+    console.log(`\nHANDOFF_RESULT=FAIL SD=${sdId} SCORE=${failScore} PHASE=${handoffType.toUpperCase()} REASON=${reasonCode}`);
   }
 }


### PR DESCRIPTION
## Summary
- Adds HANDOFF_RESULT= machine-readable summary line to handoff output for automation consumption

## Test plan
- [x] Handoff output includes parseable result line
- [x] No breaking changes to existing handoff flow

SD: SD-LEO-FEAT-CHAIRMAN-GOVERNANCE-CONTROLS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)