### PR TITLE
feat: add lock heartbeat refresh for long-running stages

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -522,9 +522,9 @@ export class StageExecutionWorker {
           break;
         }
 
-        // Execute the stage with retries (includes execution record lifecycle)
+        // Execute the stage with retries (includes execution record lifecycle + lock refresh)
         const stageStartMs = Date.now();
-        const result = await this._executeWithRetry(ventureId, currentStage);
+        const result = await this._executeWithRetry(ventureId, currentStage, lockId);
         const stageDurationMs = Date.now() - stageStartMs;
         lastResult = result;
 
@@ -693,9 +693,10 @@ export class StageExecutionWorker {
    *
    * @param {string} ventureId
    * @param {number} stageNumber
+   * @param {string} [lockId] - Lock ID for periodic refresh (SD-VW-BACKEND-LOCK-HEARTBEAT-001)
    * @returns {Promise<Object>} Stage result
    */
-  async _executeWithRetry(ventureId, stageNumber) {
+  async _executeWithRetry(ventureId, stageNumber, lockId) {
     let lastError = null;
 
     for (let attempt = 0; attempt <= this._maxRetries; attempt++) {
@@ -708,13 +709,20 @@ export class StageExecutionWorker {
       // Create execution record for this attempt
       const execId = await this._createStageExecution(ventureId, stageNumber);
 
-      // Start heartbeat interval for the execution record
+      // Start heartbeat interval for execution record + lock refresh
       let heartbeatTimer = null;
-      if (execId) {
+      if (execId || lockId) {
         heartbeatTimer = setInterval(() => {
-          this._updateExecutionHeartbeat(execId).catch(err =>
-            this._logger.warn(`[Worker] Execution heartbeat failed: ${err.message}`)
-          );
+          if (execId) {
+            this._updateExecutionHeartbeat(execId).catch(err =>
+              this._logger.warn(`[Worker] Execution heartbeat failed: ${err.message}`)
+            );
+          }
+          if (lockId) {
+            this._refreshLock(ventureId, lockId).catch(err =>
+              this._logger.warn(`[Worker] Lock refresh failed: ${err.message}`)
+            );
+          }
         }, this._execHeartbeatMs);
       }
 
@@ -901,6 +909,38 @@ export class StageExecutionWorker {
     } catch (err) {
       this._logger.error(`[Worker] Stale execution sweep error: ${err.message}`);
     }
+  }
+
+  // ── Lock Heartbeat Refresh (SD-VW-BACKEND-LOCK-HEARTBEAT-001) ──
+
+  /**
+   * Refresh orchestrator_lock_acquired_at to prevent false stale-lock release.
+   * Uses atomic conditional UPDATE with lock_id verification to prevent
+   * refreshing a lock that was legitimately released/stolen.
+   *
+   * @param {string} ventureId
+   * @param {string} lockId - Must match current orchestrator_lock_id
+   * @returns {Promise<boolean>} True if refresh succeeded
+   */
+  async _refreshLock(ventureId, lockId) {
+    const { data, error } = await this._supabase
+      .from('ventures')
+      .update({ orchestrator_lock_acquired_at: new Date().toISOString() })
+      .eq('id', ventureId)
+      .eq('orchestrator_lock_id', lockId)
+      .eq('orchestrator_state', 'processing')
+      .select('id');
+
+    if (error) {
+      throw new Error(`Lock refresh DB error: ${error.message}`);
+    }
+
+    if (!data || data.length === 0) {
+      this._logger.warn(`[Worker] Lock refresh: no matching row (venture=${ventureId}, lockId=${lockId}) — lock may have been released`);
+      return false;
+    }
+
+    return true;
   }
 
   // ── Chairman Gate & Lock Methods ──────────────────────────

--- a/tests/unit/eva/stage-execution-records.test.js
+++ b/tests/unit/eva/stage-execution-records.test.js
@@ -259,4 +259,56 @@ describe('Stage Execution Records (SD-VW-BACKEND-EXEC-RECORDS-001)', () => {
       expect(failCall).toBeTruthy();
     });
   });
+
+  describe('_refreshLock (SD-VW-BACKEND-LOCK-HEARTBEAT-001)', () => {
+    it('updates orchestrator_lock_acquired_at with matching lockId', async () => {
+      // Override to return 1 matching row
+      const chain = {
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        select: vi.fn().mockResolvedValue({ data: [{ id: 'venture-123' }], error: null }),
+      };
+      supabase.from = vi.fn((table) => {
+        if (table === 'ventures') return chain;
+        return createMockSupabase().from(table);
+      });
+
+      worker = new StageExecutionWorker({ supabase, logger });
+      const refreshed = await worker._refreshLock('venture-123', 'lock-uuid-abc');
+
+      expect(refreshed).toBe(true);
+      expect(chain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ orchestrator_lock_acquired_at: expect.any(String) })
+      );
+      // Verify lock_id condition was applied
+      expect(chain.eq).toHaveBeenCalledWith('orchestrator_lock_id', 'lock-uuid-abc');
+    });
+
+    it('returns false when lock_id does not match (lock was released)', async () => {
+      const chain = {
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        select: vi.fn().mockResolvedValue({ data: [], error: null }),
+      };
+      supabase.from = vi.fn(() => chain);
+
+      worker = new StageExecutionWorker({ supabase, logger });
+      const refreshed = await worker._refreshLock('venture-123', 'stale-lock-id');
+
+      expect(refreshed).toBe(false);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('lock may have been released'));
+    });
+
+    it('throws on database error', async () => {
+      const chain = {
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        select: vi.fn().mockResolvedValue({ data: null, error: { message: 'connection failed' } }),
+      };
+      supabase.from = vi.fn(() => chain);
+
+      worker = new StageExecutionWorker({ supabase, logger });
+      await expect(worker._refreshLock('venture-123', 'lock-id')).rejects.toThrow('Lock refresh DB error');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add `_refreshLock()` method for atomic lock timestamp refresh with lock_id verification
- Integrate lock refresh alongside execution heartbeat in `_executeWithRetry()`
- Prevents false stale-lock releases when stages run longer than 5 minutes

## SD Reference
SD-VW-BACKEND-LOCK-HEARTBEAT-001 (child of SD-VW-BACKEND-RESILIENCE-001)

## Test plan
- [x] 3 unit tests for `_refreshLock()` (success, lock mismatch, DB error)
- [x] Smoke tests pass
- [x] All existing worker tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)