### PR TITLE
feat: add --deep mode to /research with extended thinking

### DIFF
--- a/.claude/skills/research.md
+++ b/.claude/skills/research.md
@@ -4,7 +4,7 @@ description: Multi-model deep research using AI providers for exploration and an
 
 # /research - Deep Research Command
 
-**Command:** /research <question> [--context <context>]
+**Command:** /research <question> [--context <context>] [--deep]
 
 ## Overview
 
@@ -29,14 +29,20 @@ Use `/research` when you need to:
 
 Extract the question from `$ARGUMENTS`. If no arguments provided, use AskUserQuestion to get the research topic.
 
+Check for `--deep` flag in arguments. If present, enable deep research mode which uses extended thinking/reasoning models for more thorough analysis (higher token budget, longer timeouts).
+
 ### Step 2: Run the Research Engine
 
 ```javascript
 import { runResearch } from '../../lib/research/research-engine.js';
 
+const deep = "$ARGUMENTS".includes('--deep');
+const question = "$ARGUMENTS".replace('--deep', '').trim();
+
 const result = await runResearch({
-  question: "$ARGUMENTS",
-  context: additionalContext || undefined
+  question,
+  context: additionalContext || undefined,
+  deep
 });
 ```
 

--- a/lib/research/research-engine.js
+++ b/lib/research/research-engine.js
@@ -10,6 +10,15 @@
 
 import { getAllAdapters } from '../sub-agents/vetting/provider-adapters.js';
 
+// Deep mode provider options — extended thinking/reasoning for each provider
+// SD-LEO-FEAT-DEEP-RESEARCH-API-001
+const DEEP_PROVIDER_OPTIONS = {
+  anthropic: { thinkingBudget: 10000, maxTokens: 16000, timeout: 180000 },
+  openai: { model: 'o3-mini', maxTokens: 16000, timeout: 180000 },
+  google: { maxTokens: 16000, timeout: 180000 },
+  ollama: { maxTokens: 8000, timeout: 300000 },
+};
+
 const RESEARCH_SYSTEM_PROMPT = `You are a research analyst providing thorough analysis on technical topics.
 
 Given a research question and optional context, provide a structured analysis covering:
@@ -40,9 +49,10 @@ Be specific, practical, and evidence-based. Avoid generic advice.`;
  * @param {string} params.question - The research question
  * @param {string} [params.context] - Additional context
  * @param {Object} [params.constraints] - Research constraints
+ * @param {boolean} [params.deep] - Enable deep/extended thinking mode (SD-LEO-FEAT-DEEP-RESEARCH-API-001)
  * @returns {Object} Structured research result
  */
-export async function runResearch({ question, context, constraints } = {}) {
+export async function runResearch({ question, context, constraints, deep = false } = {}) {
   if (!question) {
     throw new Error('Research question is required');
   }
@@ -60,18 +70,21 @@ export async function runResearch({ question, context, constraints } = {}) {
     userPrompt += `\n\n## Constraints\n\n${JSON.stringify(constraints, null, 2)}`;
   }
 
-  // Query all providers in parallel
+  // Query all providers in parallel (with deep options if enabled)
   const providerResults = await Promise.allSettled(
     providerNames.map(async (name) => {
       const adapter = adapters[name];
       const callStart = Date.now();
+      const providerOpts = deep ? (DEEP_PROVIDER_OPTIONS[name] || {}) : {};
       const response = await adapter.complete(RESEARCH_SYSTEM_PROMPT, userPrompt, {
-        maxTokens: 3000
+        maxTokens: deep ? 8000 : 3000,
+        ...providerOpts,
       });
       return {
         provider: name,
         model: response.model,
         content: response.content,
+        thinking: response.thinking || null,
         durationMs: Date.now() - callStart,
         usage: response.usage
       };
@@ -120,12 +133,17 @@ export async function runResearch({ question, context, constraints } = {}) {
   return {
     success: true,
     question,
+    deep,
     synthesis,
     provider_perspectives: parsedResults.map(r => ({
       provider: r.provider,
       is_structured: !r.raw,
       data: r.data
     })),
+    thinking: deep ? successes.filter(s => s.thinking).map(s => ({
+      provider: s.provider,
+      thinking: s.thinking
+    })) : undefined,
     providers_status: providersStatus,
     providers_used: successes.length,
     providers_failed: failures.length,


### PR DESCRIPTION
## Summary
- Add `DEEP_PROVIDER_OPTIONS` config for per-provider extended thinking (Anthropic thinkingBudget, OpenAI o3-mini, higher token/timeout budgets)
- Fix broken imports from non-existent `deep-research-adapters.js` and `deep-research-job-manager.js` by inlining deep mode logic
- Update `/research` skill to parse `--deep` flag

## SD Reference
SD-LEO-FEAT-DEEP-RESEARCH-API-001

## Test plan
- [x] Module imports cleanly (`runResearch` exported)
- [x] Smoke tests pass
- [x] Standard (non-deep) mode unchanged
- [ ] Manual: `/research --deep "what is the best approach for X"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)