### PR TITLE
feat: add deep research API integration with multi-provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ applications/*/.env.encrypted
 applications/*/.env.decrypted
 applications/*/.leo-sync/supabase/.temp/
 
+# Deep research output files (SD-LEO-FEAT-DEEP-RESEARCH-API-001)
+.research/
+
 # Vision/Architecture documents are DB-only — never commit markdown versions
 docs/plans/*-vision.md
 docs/plans/*-architecture.md
@@ -231,3 +234,4 @@ nul
 tests/e2e/ehg-app/.auth/
 tests/e2e/.auth/
 tests/uat/.auth/
+.research/

--- a/lib/research/deep-research-adapters.js
+++ b/lib/research/deep-research-adapters.js
@@ -1,0 +1,128 @@
+/**
+ * Deep Research Provider Adapters
+ * SD-LEO-FEAT-DEEP-RESEARCH-API-001 (FR-001)
+ *
+ * Provider-specific adapters for extended thinking / deep research modes:
+ * - Anthropic: Extended Thinking with budget_tokens
+ * - Google: Gemini with grounding/search
+ * - OpenAI: o3-deep-research / o4-mini-deep-research
+ *
+ * All adapters normalize responses into a unified DeepResearchResult schema.
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+
+const DEEP_RESEARCH_SYSTEM = `You are a deep research analyst performing thorough, multi-angle analysis.
+Take your time to reason carefully. Consider multiple perspectives, edge cases, and implications.
+Provide comprehensive, actionable findings with specific evidence and recommendations.`;
+
+/** Anthropic Extended Thinking adapter. */
+export async function anthropicDeepResearch(query, options = {}) {
+  const client = new Anthropic();
+  const model = options.model || 'claude-opus-4-5-20251101';
+  const budgetTokens = options.thinkingBudget || 10000;
+  const startTime = Date.now();
+
+  const response = await client.messages.create({
+    model,
+    max_tokens: 16000,
+    thinking: { type: 'enabled', budget_tokens: budgetTokens },
+    messages: [{ role: 'user', content: `${DEEP_RESEARCH_SYSTEM}\n\n## Research Query\n\n${query}` }],
+  });
+
+  let thinking = '';
+  let result = '';
+  let tokensUsed = (response.usage?.input_tokens || 0) + (response.usage?.output_tokens || 0);
+
+  for (const block of response.content) {
+    if (block.type === 'thinking') thinking += block.thinking;
+    if (block.type === 'text') result += block.text;
+  }
+
+  return { provider: 'anthropic', model, query, thinking, result, tokens_used: tokensUsed, duration_ms: Date.now() - startTime, cost_estimate: estimateCost('anthropic', tokensUsed) };
+}
+
+/** Google Gemini deep research adapter. */
+export async function googleDeepResearch(query, options = {}) {
+  const apiKey = process.env.GOOGLE_AI_API_KEY || process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error('GOOGLE_AI_API_KEY or GEMINI_API_KEY required');
+
+  const model = options.model || 'gemini-2.5-pro';
+  const startTime = Date.now();
+
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: `${DEEP_RESEARCH_SYSTEM}\n\n## Research Query\n\n${query}` }] }],
+        generationConfig: { maxOutputTokens: 8192, temperature: 0.7 },
+        tools: [{ googleSearch: {} }],
+      }),
+    }
+  );
+
+  if (!response.ok) throw new Error(`Google API error: ${response.status} - ${await response.text()}`);
+
+  const data = await response.json();
+  const result = data.candidates?.[0]?.content?.parts?.map(p => p.text).join('\n') || '';
+  const tokensUsed = data.usageMetadata?.totalTokenCount || 0;
+
+  return { provider: 'google', model, query, thinking: '', result, tokens_used: tokensUsed, duration_ms: Date.now() - startTime, cost_estimate: estimateCost('google', tokensUsed) };
+}
+
+/** OpenAI deep research adapter. */
+export async function openaiDeepResearch(query, options = {}) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY required');
+
+  const model = options.model || 'o3-deep-research-2025-06-26';
+  const startTime = Date.now();
+
+  const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: 'system', content: DEEP_RESEARCH_SYSTEM }, { role: 'user', content: query }],
+      max_completion_tokens: 8192,
+    }),
+  });
+
+  if (!response.ok) throw new Error(`OpenAI API error: ${response.status} - ${await response.text()}`);
+
+  const data = await response.json();
+  const choice = data.choices?.[0];
+  const tokensUsed = data.usage?.total_tokens || 0;
+
+  return { provider: 'openai', model, query, thinking: choice?.message?.reasoning || '', result: choice?.message?.content || '', tokens_used: tokensUsed, duration_ms: Date.now() - startTime, cost_estimate: estimateCost('openai', tokensUsed) };
+}
+
+/** Estimate cost in USD based on provider and token count. */
+function estimateCost(provider, tokens) {
+  const rates = { anthropic: 0.000015, google: 0.000005, openai: 0.000015 };
+  return Math.round((tokens * (rates[provider] || 0.00001)) * 10000) / 10000;
+}
+
+/** Get the best available deep research provider based on API key availability. */
+export function getBestAvailableProvider() {
+  if (process.env.ANTHROPIC_API_KEY) return 'anthropic';
+  if (process.env.GOOGLE_AI_API_KEY || process.env.GEMINI_API_KEY) return 'google';
+  if (process.env.OPENAI_API_KEY) return 'openai';
+  return null;
+}
+
+/** Route to the appropriate deep research adapter. */
+export async function runDeepResearch(query, options = {}) {
+  const provider = options.provider || getBestAvailableProvider();
+  if (!provider) throw new Error('No AI provider API key configured for deep research');
+
+  const adapters = { anthropic: anthropicDeepResearch, google: googleDeepResearch, openai: openaiDeepResearch };
+  const adapter = adapters[provider];
+  if (!adapter) throw new Error(`Unknown deep research provider: ${provider}`);
+
+  return adapter(query, options);
+}
+
+export { estimateCost };

--- a/lib/research/deep-research-budget.js
+++ b/lib/research/deep-research-budget.js
@@ -1,0 +1,86 @@
+/**
+ * Deep Research Budget Controls
+ * SD-LEO-FEAT-DEEP-RESEARCH-API-001 (FR-003)
+ *
+ * Daily spending caps, pre-submission cost estimation, alert thresholds,
+ * and emergency kill-switch for deep research API calls.
+ */
+
+import { createSupabaseServiceClient } from '../supabase-client.js';
+
+const DEFAULT_DAILY_CAP = 10.00;
+const ALERT_THRESHOLD_PCT = 0.80;
+
+/** Check if a deep research request is within budget. */
+export async function checkBudget(provider, estimatedCost) {
+  const supabase = createSupabaseServiceClient();
+  const today = new Date().toISOString().split('T')[0];
+
+  const { data: killRow } = await supabase
+    .from('deep_research_budget')
+    .select('kill_switch')
+    .eq('date', today)
+    .eq('provider', 'aggregate')
+    .maybeSingle();
+
+  if (killRow?.kill_switch) {
+    return { allowed: false, reason: 'Kill-switch active — all deep research blocked', remaining: 0, spent: 0, cap: 0 };
+  }
+
+  const { data: budget } = await supabase
+    .from('deep_research_budget')
+    .select('total_cost, daily_cap')
+    .eq('date', today)
+    .eq('provider', 'aggregate')
+    .maybeSingle();
+
+  const spent = budget?.total_cost || 0;
+  const cap = budget?.daily_cap || DEFAULT_DAILY_CAP;
+  const remaining = cap - spent;
+
+  if (spent + estimatedCost > cap) {
+    return { allowed: false, reason: `Daily cap exceeded: $${spent.toFixed(2)} spent of $${cap.toFixed(2)} cap`, remaining, spent, cap };
+  }
+
+  if ((spent + estimatedCost) / cap >= ALERT_THRESHOLD_PCT) {
+    console.warn(`[Budget] Warning: ${Math.round(((spent + estimatedCost) / cap) * 100)}% of daily cap ($${cap.toFixed(2)})`);
+  }
+
+  return { allowed: true, reason: null, remaining: remaining - estimatedCost, spent, cap };
+}
+
+/** Record spending after a successful deep research call. */
+export async function recordSpending(provider, tokensUsed, cost) {
+  const supabase = createSupabaseServiceClient();
+  const today = new Date().toISOString().split('T')[0];
+
+  await supabase.from('deep_research_budget').upsert({
+    date: today, provider, tokens_used: tokensUsed, total_cost: cost, request_count: 1, daily_cap: DEFAULT_DAILY_CAP,
+  }, { onConflict: 'date,provider' });
+
+  // Update aggregate
+  const { data: allProviders } = await supabase
+    .from('deep_research_budget')
+    .select('total_cost, tokens_used, request_count')
+    .eq('date', today)
+    .neq('provider', 'aggregate');
+
+  const totals = (allProviders || []).reduce((acc, row) => ({
+    total_cost: acc.total_cost + (row.total_cost || 0),
+    tokens_used: acc.tokens_used + (row.tokens_used || 0),
+    request_count: acc.request_count + (row.request_count || 0),
+  }), { total_cost: 0, tokens_used: 0, request_count: 0 });
+
+  await supabase.from('deep_research_budget').upsert({
+    date: today, provider: 'aggregate', ...totals, daily_cap: DEFAULT_DAILY_CAP,
+  }, { onConflict: 'date,provider' });
+}
+
+/** Activate the emergency kill-switch. */
+export async function activateKillSwitch() {
+  const supabase = createSupabaseServiceClient();
+  const today = new Date().toISOString().split('T')[0];
+  await supabase.from('deep_research_budget').upsert({
+    date: today, provider: 'aggregate', kill_switch: true, daily_cap: DEFAULT_DAILY_CAP,
+  }, { onConflict: 'date,provider' });
+}

--- a/lib/research/deep-research-job-manager.js
+++ b/lib/research/deep-research-job-manager.js
@@ -1,0 +1,64 @@
+/**
+ * Deep Research Async Job Manager
+ * SD-LEO-FEAT-DEEP-RESEARCH-API-001 (FR-002)
+ *
+ * Manages long-running deep research jobs with budget checking,
+ * timeout, and state tracking.
+ */
+
+import { runDeepResearch, estimateCost } from './deep-research-adapters.js';
+import { checkBudget, recordSpending } from './deep-research-budget.js';
+import { storeResult, updateResultStatus } from './deep-research-storage.js';
+import { createSupabaseServiceClient } from '../supabase-client.js';
+
+const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes
+
+/** Submit a deep research job with budget checking and timeout. */
+export async function submitDeepResearch(query, options = {}) {
+  const supabase = createSupabaseServiceClient();
+  const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS;
+  const onStatus = options.onStatus || (() => {});
+
+  // Pre-flight budget check
+  const estimatedCost = estimateCost(options.provider || 'anthropic', 10000);
+  const budget = await checkBudget(options.provider || 'anthropic', estimatedCost);
+  if (!budget.allowed) {
+    onStatus('blocked', budget.reason);
+    throw new Error(`Budget blocked: ${budget.reason}`);
+  }
+
+  // Create initial DB record
+  const { data: job } = await supabase
+    .from('deep_research_results')
+    .insert({ query, provider: options.provider || 'anthropic', status: 'queued' })
+    .select('id')
+    .single();
+
+  const jobId = job?.id;
+  onStatus('queued', `Job ${jobId} queued`);
+
+  try {
+    await updateResultStatus(jobId, 'running');
+    onStatus('running', 'Deep research in progress...');
+
+    const result = await Promise.race([
+      runDeepResearch(query, options),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Deep research timed out')), timeoutMs)),
+    ]);
+
+    await storeResult(result);
+    await recordSpending(result.provider, result.tokens_used, result.cost_estimate);
+    await updateResultStatus(jobId, 'completed', {
+      completed_at: new Date().toISOString(), tokens_used: result.tokens_used,
+      cost_estimate: result.cost_estimate, duration_ms: result.duration_ms,
+    });
+
+    onStatus('completed', `Research complete (${result.duration_ms}ms, $${result.cost_estimate})`);
+    return result;
+  } catch (err) {
+    const status = err.message.includes('timed out') ? 'timed_out' : 'failed';
+    await updateResultStatus(jobId, status, { error_message: err.message });
+    onStatus(status, err.message);
+    throw err;
+  }
+}

--- a/lib/research/deep-research-storage.js
+++ b/lib/research/deep-research-storage.js
@@ -1,0 +1,51 @@
+/**
+ * Deep Research Dual Storage
+ * SD-LEO-FEAT-DEEP-RESEARCH-API-001 (FR-004)
+ *
+ * Dual-write: DB table for metadata/querying + .research/ files for full traces.
+ */
+
+import { createSupabaseServiceClient } from '../supabase-client.js';
+import { writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+
+const RESEARCH_DIR = join(process.cwd(), '.research');
+
+/** Store a deep research result in both DB and filesystem. */
+export async function storeResult(result) {
+  const supabase = createSupabaseServiceClient();
+
+  const { data, error } = await supabase
+    .from('deep_research_results')
+    .insert({
+      query: result.query, provider: result.provider, model: result.model,
+      status: 'completed', thinking: result.thinking || null, result: result.result,
+      summary: result.result?.substring(0, 500), tokens_used: result.tokens_used,
+      cost_estimate: result.cost_estimate, duration_ms: result.duration_ms,
+      completed_at: new Date().toISOString(),
+    })
+    .select('id')
+    .single();
+
+  if (error) throw error;
+
+  // Filesystem write (non-blocking, supplementary)
+  try {
+    await mkdir(RESEARCH_DIR, { recursive: true });
+    const slug = result.query.replace(/[^a-zA-Z0-9]+/g, '-').substring(0, 50).toLowerCase();
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    await writeFile(join(RESEARCH_DIR, `${timestamp}-${result.provider}-${slug}.json`), JSON.stringify(result, null, 2), 'utf8');
+  } catch (fsErr) {
+    console.warn(`[DeepResearch] Filesystem write failed (non-fatal): ${fsErr.message}`);
+  }
+
+  return data.id;
+}
+
+/** Update a deep research record status. */
+export async function updateResultStatus(id, status, updates = {}) {
+  const supabase = createSupabaseServiceClient();
+  await supabase.from('deep_research_results')
+    .update({ status, ...updates, updated_at: new Date().toISOString() })
+    .eq('id', id);
+}

--- a/lib/research/research-engine.js
+++ b/lib/research/research-engine.js
@@ -9,6 +9,7 @@
  */
 
 import { getAllAdapters } from '../sub-agents/vetting/provider-adapters.js';
+import { submitDeepResearch } from './deep-research-job-manager.js';
 
 const RESEARCH_SYSTEM_PROMPT = `You are a research analyst providing thorough analysis on technical topics.
 
@@ -222,4 +223,40 @@ function evaluateConsensus(structured) {
   return 'weak';
 }
 
-export default { runResearch };
+/**
+ * Run deep research mode (--deep flag).
+ * Routes to extended thinking / deep research adapters with budget controls.
+ * SD-LEO-FEAT-DEEP-RESEARCH-API-001 (FR-005)
+ */
+export async function runDeepResearchMode({ question, provider, verbose, timeoutMs } = {}) {
+  if (!question) throw new Error('Research question is required');
+
+  const startTime = Date.now();
+  console.log(`[DeepResearch] Starting deep research${provider ? ` (provider: ${provider})` : ''}...`);
+
+  const result = await submitDeepResearch(question, {
+    provider,
+    timeoutMs,
+    onStatus: (status, msg) => console.log(`[DeepResearch] ${status}: ${msg}`),
+  });
+
+  const output = {
+    success: true,
+    mode: 'deep',
+    question,
+    provider: result.provider,
+    model: result.model,
+    result: result.result,
+    tokens_used: result.tokens_used,
+    cost_estimate: result.cost_estimate,
+    durationMs: Date.now() - startTime,
+  };
+
+  if (verbose && result.thinking) {
+    output.thinking = result.thinking;
+  }
+
+  return output;
+}
+
+export default { runResearch, runDeepResearchMode };

--- a/supabase/migrations/20260319_deep_research_tables.sql
+++ b/supabase/migrations/20260319_deep_research_tables.sql
@@ -1,0 +1,55 @@
+-- Deep Research API Integration: Results and Budget tracking tables
+-- SD-LEO-FEAT-DEEP-RESEARCH-API-001
+-- NOTE: Tables may already exist from prior session. Using IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS deep_research_results (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  query TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('anthropic', 'google', 'openai')),
+  model TEXT,
+  status TEXT NOT NULL DEFAULT 'queued'
+    CHECK (status IN ('queued', 'running', 'completed', 'failed', 'timed_out', 'cancelled')),
+  thinking TEXT,
+  result TEXT,
+  summary TEXT,
+  tokens_used INTEGER DEFAULT 0,
+  cost_estimate NUMERIC(10, 4) DEFAULT 0,
+  duration_ms INTEGER,
+  error_message TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_deep_research_status ON deep_research_results (status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_deep_research_provider ON deep_research_results (provider, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS deep_research_budget (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  date DATE NOT NULL DEFAULT CURRENT_DATE,
+  provider TEXT NOT NULL CHECK (provider IN ('anthropic', 'google', 'openai', 'aggregate')),
+  tokens_used INTEGER DEFAULT 0,
+  total_cost NUMERIC(10, 4) DEFAULT 0,
+  request_count INTEGER DEFAULT 0,
+  daily_cap NUMERIC(10, 4) DEFAULT 10.00,
+  kill_switch BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (date, provider)
+);
+
+ALTER TABLE deep_research_results ENABLE ROW LEVEL SECURITY;
+ALTER TABLE deep_research_budget ENABLE ROW LEVEL SECURITY;
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'deep_research_results' AND policyname = 'Service role access on deep_research_results') THEN
+    CREATE POLICY "Service role access on deep_research_results" ON deep_research_results FOR ALL USING (auth.role() = 'service_role') WITH CHECK (auth.role() = 'service_role');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'deep_research_budget' AND policyname = 'Service role access on deep_research_budget') THEN
+    CREATE POLICY "Service role access on deep_research_budget" ON deep_research_budget FOR ALL USING (auth.role() = 'service_role') WITH CHECK (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+COMMENT ON TABLE deep_research_results IS 'Deep research job results with provider, tokens, cost, and thinking traces.';
+COMMENT ON TABLE deep_research_budget IS 'Daily spending tracking per provider with caps and kill-switch.';


### PR DESCRIPTION
## Summary
- Multi-provider deep research adapters (Anthropic Extended Thinking, Google Gemini, OpenAI o3-deep-research)
- Async job manager with 5-minute timeout and state tracking (queued -> running -> completed/failed/timed_out)
- Budget controls with $10/day daily cap, per-provider tracking, and emergency kill-switch
- Dual storage to DB (deep_research_results) + local .research/ files for offline review
- research-engine.js extended with runDeepResearchMode() for --deep flag routing

## Test plan
- [ ] Smoke tests pass
- [ ] Anthropic adapter sends extended thinking requests correctly
- [ ] Budget check blocks requests when daily cap exceeded
- [ ] Kill-switch blocks all deep research
- [ ] Results stored in both DB and .research/ directory
- [ ] Timeout triggers graceful cancellation after 5 minutes

SD-LEO-FEAT-DEEP-RESEARCH-API-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)