### PR TITLE
fix: prevent worker gate re-entry duplicate decision block

### DIFF
--- a/lib/eva/chairman-decision-watcher.js
+++ b/lib/eva/chairman-decision-watcher.js
@@ -210,8 +210,9 @@ export async function createOrReusePendingDecision({
     .single();
 
   if (error) {
-    // Handle unique constraint violation (race condition)
+    // Handle unique constraint violation (race condition or re-entry after approval)
     if (error.code === '23505') {
+      // First check for pending decisions (race condition)
       const { data: raced } = await supabase
         .from('chairman_decisions')
         .select('id')
@@ -223,6 +224,24 @@ export async function createOrReusePendingDecision({
       if (raced) {
         logger.log(`   Race condition handled, reusing: ${raced.id}`);
         return { id: raced.id, isNew: false };
+      }
+
+      // SD-VW-FIX-WORKER-GATE-REENTRY-001: Check for already-resolved decisions
+      // (re-entry after approval). Return the existing decision so the caller
+      // can detect it's already been handled.
+      const { data: resolved } = await supabase
+        .from('chairman_decisions')
+        .select('id')
+        .eq('venture_id', ventureId)
+        .eq('lifecycle_stage', stageNumber)
+        .in('status', ['approved', 'rejected'])
+        .order('updated_at', { ascending: false })
+        .limit(1)
+        .single();
+
+      if (resolved) {
+        logger.log(`   Re-entry detected: decision ${resolved.id} already resolved`);
+        return { id: resolved.id, isNew: false };
       }
     }
     throw new ServiceError('DECISION_CREATE_FAILED', `Failed to create decision: ${error.message}`, 'ChairmanDecisionWatcher');

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -539,6 +539,27 @@ export class StageExecutionWorker {
           this._logger.warn(`[Worker] venture_stage_work sync failed (non-fatal): ${err.message}`);
         }
 
+        // SD-VW-FIX-WORKER-GATE-REENTRY-001: Check for already-approved decisions
+        // before re-processing gate/review stages. On re-entry after approval,
+        // the worker would otherwise try to INSERT a duplicate decision row.
+        if (REVIEW_MODE_STAGES.has(currentStage) || CHAIRMAN_GATES.BLOCKING.has(currentStage)) {
+          const { data: approvedDecision } = await this._supabase
+            .from('chairman_decisions')
+            .select('id, status')
+            .eq('venture_id', ventureId)
+            .eq('lifecycle_stage', currentStage)
+            .eq('status', 'approved')
+            .limit(1)
+            .maybeSingle();
+
+          if (approvedDecision) {
+            this._logger.log(`[Worker] Stage ${currentStage} already approved (decision ${approvedDecision.id}) — advancing`);
+            this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
+            currentStage++;
+            continue;
+          }
+        }
+
         // Review-mode stages: pause for chairman review before auto-advancing
         if (REVIEW_MODE_STAGES.has(currentStage) && !CHAIRMAN_GATES.BLOCKING.has(currentStage)) {
           this._logger.log(`[Worker] Review-mode stage ${currentStage} — blocking for chairman review`);
@@ -550,7 +571,7 @@ export class StageExecutionWorker {
             .update({ current_lifecycle_stage: currentStage })
             .eq('id', ventureId);
 
-          // Create a chairman_decisions row with decision_type = 'review'
+          // Create or reuse a chairman_decisions row with decision_type = 'review'
           let reviewInsertOk = false;
           try {
             const { data: ventureForReview } = await this._supabase
@@ -559,19 +580,17 @@ export class StageExecutionWorker {
               .eq('id', ventureId)
               .single();
 
-            const { error: insertError } = await this._supabase.from('chairman_decisions').insert({
-              venture_id: ventureId,
-              lifecycle_stage: currentStage,
-              decision_type: 'review',
-              decision: 'review',
-              status: 'pending',
+            const { id: decisionId, isNew } = await createOrReusePendingDecision({
+              ventureId,
+              stageNumber: currentStage,
+              briefData: { stage: currentStage, ventureName: ventureForReview?.name },
               summary: `Review: Stage ${currentStage} complete for ${ventureForReview?.name || ventureId}`,
-              brief_data: { stage: currentStage, ventureName: ventureForReview?.name },
+              supabase: this._supabase,
+              logger: this._logger,
             });
-            if (insertError) {
-              this._logger.error(`[Worker] Review decision INSERT failed: ${insertError.message}`);
-            } else {
-              reviewInsertOk = true;
+            reviewInsertOk = true;
+            if (!isNew) {
+              this._logger.log(`[Worker] Reused existing review decision ${decisionId} for stage ${currentStage}`);
             }
           } catch (err) {
             this._logger.error(`[Worker] Review decision creation failed: ${err.message}`);

--- a/tests/unit/eva/chairman-decision-watcher.test.js
+++ b/tests/unit/eva/chairman-decision-watcher.test.js
@@ -210,4 +210,48 @@ describe('createOrReusePendingDecision', () => {
       summary: 'updated',
     });
   });
+
+  // SD-VW-FIX-WORKER-GATE-REENTRY-001: Test re-entry after approval
+  it('handles 23505 when existing decision is already approved', async () => {
+    let fromCallCount = 0;
+    const supabase = {
+      from: vi.fn().mockImplementation(() => {
+        fromCallCount++;
+        const chain = {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          single: vi.fn().mockImplementation(() => {
+            if (fromCallCount === 1) {
+              // First: check for pending — none found
+              return Promise.resolve({ data: null });
+            }
+            if (fromCallCount === 2) {
+              // Second: check for pending after 23505 — none found
+              return Promise.resolve({ data: null });
+            }
+            // Third: check for approved/rejected — found
+            return Promise.resolve({ data: { id: 'approved-id' } });
+          }),
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: null,
+                error: { code: '23505', message: 'unique_violation' },
+              }),
+            }),
+          }),
+        };
+        return chain;
+      }),
+    };
+
+    const result = await createOrReusePendingDecision({
+      ventureId: 'v1', stageNumber: 5, supabase, logger,
+    });
+    expect(result.id).toBe('approved-id');
+    expect(result.isNew).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Add approved-decision pre-check in worker stage loop to detect already-approved gates on re-entry
- Replace raw INSERT in review-mode stages with `createOrReusePendingDecision` for idempotent decision handling
- Enhance `createOrReusePendingDecision` 23505 handler to check for approved/rejected decisions (not just pending)
- Add unit test for 23505 with approved decision scenario

## Context
SD-VW-FIX-WORKER-GATE-REENTRY-001: Stage Execution Worker permanently blocked at gate stages (3, 5, 10) after chairman approval. Worker re-entered gate stage, tried to INSERT new decision row, hit `uq_chairman_decision_attempt` unique constraint.

## Test plan
- [x] 11/11 chairman-decision-watcher tests pass (including new re-entry test)
- [x] Pre-existing worker test failures confirmed unrelated (same on main)
- [x] TESTING sub-agent validation: PASS (95% confidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)