### PR TITLE
fix: Stage Zero portfolio detection and mental models query

### DIFF
--- a/lib/eva/mental-models/model-selector.js
+++ b/lib/eva/mental-models/model-selector.js
@@ -80,12 +80,14 @@ export async function selectModels({ stage, path, strategy, archetype, excludeId
 
     // Fetch effectiveness scores for ranking
     const modelIds = filtered.map(m => m.id);
-    const { data: effectiveness } = await supabase
+    const { data: effectiveness, error: effectivenessError } = await supabase
       .from('mental_model_effectiveness')
       .select('model_id, composite_effectiveness_score')
       .in('model_id', modelIds)
-      .eq('stage_number', stage)
-      .catch(() => ({ data: null }));
+      .eq('stage_number', stage);
+    if (effectivenessError) {
+      logger.warn(`   Mental models: Effectiveness query failed: ${effectivenessError.message}`);
+    }
 
     // Build effectiveness lookup
     const effectivenessMap = {};
@@ -100,12 +102,14 @@ export async function selectModels({ stage, path, strategy, archetype, excludeId
     // Fetch archetype affinity if archetype specified
     let affinityMap = {};
     if (archetype) {
-      const { data: affinities } = await supabase
+      const { data: affinities, error: affinityError } = await supabase
         .from('mental_model_archetype_affinity')
         .select('model_id, affinity_score')
         .in('model_id', modelIds)
-        .eq('archetype', archetype)
-        .catch(() => ({ data: null }));
+        .eq('archetype', archetype);
+      if (affinityError) {
+        logger.warn(`   Mental models: Affinity query failed: ${affinityError.message}`);
+      }
 
       if (affinities) {
         for (const a of affinities) {

--- a/lib/eva/stage-zero/synthesis/portfolio-evaluation.js
+++ b/lib/eva/stage-zero/synthesis/portfolio-evaluation.js
@@ -82,7 +82,7 @@ async function loadPortfolio(supabase) {
   const { data, error } = await supabase
     .from('ventures')
     .select('id, name, problem_statement, solution, target_market, status, metadata')
-    .in('status', ['active', 'launched'])
+    .in('status', ['active'])
     .order('created_at', { ascending: false })
     .limit(20);
 


### PR DESCRIPTION
## Summary
- Fix invalid `launched` enum value in portfolio query causing PostgreSQL error and silent empty result (portfolio-evaluation.js)
- Replace `.catch()` chains on Supabase query builders with standard `{ data, error }` destructuring (model-selector.js)
- Unblocks real portfolio-aware venture evaluation in Stage Zero synthesis

## Changes
- `lib/eva/stage-zero/synthesis/portfolio-evaluation.js`: Remove `launched` from `.in('status', [...])` filter (only `active` is valid)
- `lib/eva/mental-models/model-selector.js`: Replace 2x `.catch()` chains with `{ data, error }` destructuring + explicit error logging

## Test plan
- [x] Portfolio query returns 5 active ventures (was 0)
- [x] Mental model queries complete without TypeError
- [x] TESTING sub-agent validation: PASS (95% confidence)
- [x] 32 existing tests pass, 0 regressions

SD: SD-VW-FIX-STAGE-ZERO-PORTFOLIO-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)