### PR TITLE
feat(SD-EVA-INFRA-UNIFIED-PERSIST-SVC-001): unified artifact persistence service

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -237,6 +237,55 @@ fi
 echo "✅ No secrets detected in staged files"
 
 # ============================================================================
+# STAGE 1.5: Unified Persistence Service Enforcement (BLOCKING)
+# ============================================================================
+# SD-EVA-INFRA-UNIFIED-PERSIST-SVC-001: All writes to venture_artifacts and
+# eva_stage_gate_results must go through artifact-persistence-service.js.
+# Direct writes outside the service are blocked.
+# ============================================================================
+echo ""
+echo "🔍 Running artifact persistence service enforcement..."
+
+STAGED_JS_FOR_PERSIST=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(js|ts|mjs|cjs)$' | grep -v 'artifact-persistence-service' | grep -v '__tests__' | grep -v 'test/' | grep -v 'tests/' | grep -v 'backfill-artifact-data' || true)
+
+if [ ! -z "$STAGED_JS_FOR_PERSIST" ]; then
+  PERSIST_VIOLATIONS=""
+
+  for file in $STAGED_JS_FOR_PERSIST; do
+    # Check for direct inserts/upserts to venture_artifacts
+    DIRECT_ARTIFACT=$(git diff --cached -U0 "$file" 2>/dev/null | grep "^+" | grep -v "^+++" | grep -E "from\(['\"]venture_artifacts['\"]" | grep -iE "\.(insert|upsert)" || true)
+
+    # Check for direct inserts/upserts to eva_stage_gate_results
+    DIRECT_GATE=$(git diff --cached -U0 "$file" 2>/dev/null | grep "^+" | grep -v "^+++" | grep -E "from\(['\"]eva_stage_gate_results['\"]" | grep -iE "\.(insert|upsert)" || true)
+
+    if [ ! -z "$DIRECT_ARTIFACT" ] || [ ! -z "$DIRECT_GATE" ]; then
+      PERSIST_VIOLATIONS="${PERSIST_VIOLATIONS}   - ${file}\n"
+    fi
+  done
+
+  if [ ! -z "$PERSIST_VIOLATIONS" ]; then
+    echo ""
+    echo "❌ BLOCKED: Direct writes to protected tables detected!"
+    echo "═══════════════════════════════════════════════════════════"
+    echo ""
+    echo "Files with direct writes (must use artifact-persistence-service.js):"
+    echo ""
+    echo -e "$PERSIST_VIOLATIONS"
+    echo ""
+    echo "💡 REMEDIATION:"
+    echo "   Use the unified persistence service instead:"
+    echo "   import { writeArtifact, recordGateResult, advanceStage }"
+    echo "     from 'lib/eva/artifact-persistence-service.js';"
+    echo ""
+    echo "   Emergency bypass (logged): git commit --no-verify"
+    echo ""
+    exit 1
+  fi
+fi
+
+echo "✅ Artifact persistence service enforcement passed"
+
+# ============================================================================
 # Auto-fix Linting Issues
 # ============================================================================
 echo "🔍 Running ESLint auto-fix on staged files..."

--- a/lib/agents/modules/venture-state-machine/handoff-operations.js
+++ b/lib/agents/modules/venture-state-machine/handoff-operations.js
@@ -17,6 +17,7 @@ import {
 } from './errors.js';
 import { validateStageGate } from './stage-gates.js';
 import { logPrediction, logOutcome } from './truth-layer.js';
+import { advanceStage } from '../../../eva/artifact-persistence-service.js';
 
 /**
  * Required fields for handoff package
@@ -185,13 +186,14 @@ export async function approveHandoff(context, handoff, ceo_notes) {
   const idempotencyKey = uuidv4();
   const startTime = Date.now();
 
-  // SD-HARDENING-V2-002B: fn_advance_venture_stage is the ONLY gateway
-  const { data: result, error } = await supabase
-    .rpc('fn_advance_venture_stage', {
-      p_venture_id: ventureId,
-      p_from_stage: handoff.from_stage,
-      p_to_stage: handoff.to_stage,
-      p_handoff_data: {
+  // SD-HARDENING-V2-002B / SD-EVA-INFRA-UNIFIED-PERSIST-SVC-001: unified advanceStage wrapper
+  let advanceResult;
+  try {
+    advanceResult = await advanceStage(supabase, {
+      ventureId,
+      fromStage: handoff.from_stage,
+      toStage: handoff.to_stage,
+      handoffData: {
         ...handoff.package,
         stage_gate_validation: stageGateResult,
         golden_nugget_validation: validationResults,
@@ -201,16 +203,14 @@ export async function approveHandoff(context, handoff, ceo_notes) {
           notes: ceo_notes
         }
       },
-      p_idempotency_key: idempotencyKey
+      idempotencyKey,
     });
-
-  const executionTime = Date.now() - startTime;
-
-  if (error) {
+  } catch (err) {
+    const executionTime = Date.now() - startTime;
     const outcome = {
       action: 'stage_transition',
       success: false,
-      error: error.message,
+      error: err.message,
       execution_time_ms: executionTime
     };
     await logOutcome(supabase, ceoAgentId, ventureId, predictionEventId, outcome, prediction);
@@ -220,17 +220,16 @@ export async function approveHandoff(context, handoff, ceo_notes) {
       from_stage: handoff.from_stage,
       to_stage: handoff.to_stage,
       idempotency_key: idempotencyKey,
-      error_message: error.message,
+      error_message: err.message,
       timestamp: new Date().toISOString()
     }, null, 2));
 
-    throw new Error(`Stage transition failed: ${error.message}. ` +
-      `Venture: ${ventureId}, From: ${handoff.from_stage}, To: ${handoff.to_stage}. ` +
-      'Gateway fn_advance_venture_stage() is required for audit trail compliance.');
+    throw err;
   }
 
-  const wasDuplicate = result?.was_duplicate === true;
-  if (wasDuplicate) {
+  const executionTime = Date.now() - startTime;
+
+  if (advanceResult.wasDuplicate) {
     console.log('   Duplicate transition detected (idempotent) - no action taken');
   }
 
@@ -239,7 +238,7 @@ export async function approveHandoff(context, handoff, ceo_notes) {
     action: 'stage_transition',
     success: true,
     new_stage: handoff.to_stage,
-    was_duplicate: wasDuplicate,
+    was_duplicate: advanceResult.wasDuplicate,
     execution_time_ms: executionTime,
     golden_nugget_validation_passed: true
   };

--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -13,6 +13,8 @@
  *   PROMOTION - Advancement approval gates (stages 16, 17, 22)
  *
  * @module lib/agents/modules/venture-state-machine/stage-gates
+ *
+ * @see lib/eva/artifact-persistence-service.js for unified write paths
  */
 
 import { evaluateDecision } from '../../../eva/decision-filter-engine.js';
@@ -20,6 +22,7 @@ import { ChairmanPreferenceStore } from '../../../eva/chairman-preference-store.
 import { CompetitiveBaselineService } from '../../../discovery/competitive-baseline-service.js';
 import { recordGateSignal } from '../../../eva/stage-zero/gate-signal-service.js';
 import { calculateStageWeightedScore } from '../../../eva/stage-zero/modeling.js';
+import { writeArtifact } from '../../../eva/artifact-persistence-service.js';
 import { randomUUID } from 'crypto';
 
 // ── Gate Configuration ──────────────────────────────────────────────
@@ -522,16 +525,18 @@ async function evaluateAdvisoryValueMultiplierGate(supabase, ventureId, toStage,
         : `Evidence quality ${assessment.epistemic} below required ${requiredEpistemic}. Consider gathering more data.`,
     };
 
-    // Log to venture_artifacts for tracking
-    await supabase.from('venture_artifacts').insert({
-      venture_id: ventureId,
-      lifecycle_stage: toStage,
-      artifact_type: 'value_multiplier_assessment',
-      artifact_data: advisoryResult,
-      is_current: true,
-    }).then(({ error }) => {
-      if (error) logger.warn(`   Failed to log advisory artifact: ${error.message}`);
-    });
+    // Log to venture_artifacts for tracking via unified service
+    try {
+      await writeArtifact(supabase, {
+        ventureId,
+        lifecycleStage: toStage,
+        artifactType: 'value_multiplier_assessment',
+        artifactData: advisoryResult,
+        source: 'stage-gates',
+      });
+    } catch (artErr) {
+      logger.warn(`   Failed to log advisory artifact: ${artErr.message}`);
+    }
 
     return advisoryResult;
   } catch (err) {

--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -1,0 +1,282 @@
+/**
+ * Unified Persistence Service for Venture Artifact Pipeline
+ *
+ * SD-EVA-INFRA-UNIFIED-PERSIST-SVC-001
+ *
+ * Three canonical write paths:
+ *   writeArtifact()    → venture_artifacts (dual-write: content + artifact_data)
+ *   recordGateResult() → eva_stage_gate_results
+ *   advanceStage()     → fn_advance_venture_stage RPC
+ *
+ * ALL writes to these tables MUST go through this service.
+ */
+
+/**
+ * Write a venture artifact with dual-write (content TEXT + artifact_data JSONB).
+ * Handles is_current deduplication: marks prior rows is_current=false before insert.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} opts
+ * @param {string} opts.ventureId - Venture UUID
+ * @param {number} opts.lifecycleStage - Stage number (1-25)
+ * @param {string} opts.artifactType - e.g. 'stage_analysis', 'devils_advocate_review'
+ * @param {string} opts.title - Human-readable title
+ * @param {Object|null} [opts.artifactData] - JSONB payload
+ * @param {string|null} [opts.content] - TEXT content (auto-derived from artifactData if omitted)
+ * @param {Object|null} [opts.metadata] - Additional metadata JSONB
+ * @param {string} [opts.source='artifact-persistence-service'] - Source identifier
+ * @param {number} [opts.qualityScore=70] - Quality score (0-100)
+ * @param {string} [opts.validationStatus='validated'] - Validation status
+ * @param {string|null} [opts.validatedBy] - Who validated
+ * @param {boolean} [opts.isCurrent=true] - Mark as current version
+ * @param {boolean} [opts.skipDedup=false] - Skip is_current dedup (used by batch)
+ * @param {string|null} [opts.idempotencyKey] - Idempotency key for dedup
+ * @param {string|null} [opts.epistemicClassification] - Four Buckets classification
+ * @param {Array|null} [opts.epistemicEvidence] - Four Buckets evidence
+ * @returns {Promise<string>} Inserted artifact ID
+ */
+export async function writeArtifact(supabase, opts) {
+  const {
+    ventureId,
+    lifecycleStage,
+    artifactType,
+    title,
+    artifactData = null,
+    content = null,
+    metadata = null,
+    source = 'artifact-persistence-service',
+    qualityScore = 70,
+    validationStatus = 'validated',
+    validatedBy = null,
+    isCurrent = true,
+    skipDedup = false,
+    idempotencyKey = null,
+    epistemicClassification = null,
+    epistemicEvidence = null,
+  } = opts;
+
+  // Dedup: mark prior is_current=true rows as false (skipped in batch mode)
+  if (isCurrent && !skipDedup) {
+    await supabase
+      .from('venture_artifacts')
+      .update({ is_current: false })
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', lifecycleStage)
+      .eq('is_current', true);
+  }
+
+  // Dual-write: ensure both content and artifact_data are populated
+  const resolvedArtifactData = artifactData ?? (content ? tryParse(content) : null);
+  const resolvedContent = content ?? (artifactData ? JSON.stringify(artifactData) : null);
+
+  const row = {
+    venture_id: ventureId,
+    lifecycle_stage: lifecycleStage,
+    artifact_type: artifactType,
+    title: title || `Stage ${lifecycleStage} ${artifactType}`,
+    artifact_data: resolvedArtifactData,
+    content: resolvedContent,
+    is_current: isCurrent,
+    source,
+    quality_score: qualityScore,
+    validation_status: validationStatus,
+  };
+
+  if (metadata) row.metadata = metadata;
+  if (validatedBy) row.validated_by = validatedBy;
+  if (idempotencyKey) row.idempotency_key = idempotencyKey;
+  if (epistemicClassification) row.epistemic_classification = epistemicClassification;
+  if (epistemicEvidence) row.epistemic_evidence = epistemicEvidence;
+
+  let { data, error } = await supabase
+    .from('venture_artifacts')
+    .insert(row)
+    .select('id')
+    .single();
+
+  // Graceful degradation: retry without epistemic columns if they cause constraint violation
+  if (error && row.epistemic_classification) {
+    delete row.epistemic_classification;
+    delete row.epistemic_evidence;
+    const retry = await supabase
+      .from('venture_artifacts')
+      .insert(row)
+      .select('id')
+      .single();
+    data = retry.data;
+    error = retry.error;
+  }
+
+  if (error) {
+    throw new Error(`[artifact-persistence-service] writeArtifact failed: ${error.message}`);
+  }
+
+  return data.id;
+}
+
+/**
+ * Write multiple artifacts in a batch (used by persistArtifacts migration).
+ * Marks all prior is_current rows for the stage as false, then inserts all artifacts.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} ventureId
+ * @param {number} lifecycleStage
+ * @param {Array<Object>} artifacts - Array of { artifactType, title, payload, source, qualityScore, ... }
+ * @param {string|null} [idempotencyKey]
+ * @returns {Promise<string[]>} Array of inserted artifact IDs
+ */
+export async function writeArtifactBatch(supabase, ventureId, lifecycleStage, artifacts, idempotencyKey = null) {
+  // Dedup: mark all prior is_current rows for this stage as false (once for entire batch)
+  await supabase
+    .from('venture_artifacts')
+    .update({ is_current: false })
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', lifecycleStage)
+    .eq('is_current', true);
+
+  const ids = [];
+  for (const art of artifacts) {
+    const id = await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage,
+      artifactType: art.artifactType,
+      title: art.title || art.artifactType || `Stage ${lifecycleStage} Analysis`,
+      artifactData: art.payload,
+      source: art.source || 'eva-orchestrator',
+      qualityScore: art.qualityScore ?? 70,
+      validationStatus: 'validated',
+      idempotencyKey,
+      epistemicClassification: deriveEpistemicClassification(art.payload),
+      epistemicEvidence: art.payload?.fourBuckets?.classifications || null,
+      isCurrent: true,
+      skipDedup: true, // already deduped once for entire batch above
+    });
+    ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Record a stage gate evaluation result.
+ * Uses upsert with venture_id + stage_number + gate_type as conflict key.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} opts
+ * @param {string} opts.ventureId - Venture UUID
+ * @param {number} opts.stageNumber - Stage number
+ * @param {string} opts.gateType - e.g. 'stage_gate', 'reality_gate', 'advisory'
+ * @param {boolean} opts.passed - Whether the gate passed
+ * @param {number|null} [opts.score] - Gate score (0-100)
+ * @param {string|null} [opts.reasoning] - Gate reasoning
+ * @param {Object|null} [opts.metadata] - Additional metadata
+ * @returns {Promise<string>} Inserted/updated row ID
+ */
+export async function recordGateResult(supabase, opts) {
+  const {
+    ventureId,
+    stageNumber,
+    gateType,
+    passed,
+    score = null,
+    reasoning = null,
+    metadata = null,
+  } = opts;
+
+  const row = {
+    venture_id: ventureId,
+    stage_number: stageNumber,
+    gate_type: gateType,
+    passed,
+  };
+
+  if (score !== null) row.score = score;
+  if (reasoning) row.reasoning = reasoning;
+  if (metadata) row.metadata = metadata;
+
+  const { data, error } = await supabase
+    .from('eva_stage_gate_results')
+    .upsert(row, { onConflict: 'venture_id,stage_number,gate_type' })
+    .select('id')
+    .single();
+
+  if (error) {
+    throw new Error(`[artifact-persistence-service] recordGateResult failed: ${error.message}`);
+  }
+
+  return data.id;
+}
+
+/**
+ * Advance a venture to the next stage via fn_advance_venture_stage RPC.
+ * Wraps the RPC call with structured error handling.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {Object} opts
+ * @param {string} opts.ventureId - Venture UUID
+ * @param {number} opts.fromStage - Current stage
+ * @param {number} opts.toStage - Target stage
+ * @param {Object} opts.handoffData - JSONB handoff payload
+ * @param {string|null} [opts.idempotencyKey] - Idempotency key
+ * @returns {Promise<{success: boolean, wasDuplicate: boolean, result: Object}>}
+ */
+export async function advanceStage(supabase, opts) {
+  const {
+    ventureId,
+    fromStage,
+    toStage,
+    handoffData,
+    idempotencyKey = null,
+  } = opts;
+
+  const rpcParams = {
+    p_venture_id: ventureId,
+    p_from_stage: fromStage,
+    p_to_stage: toStage,
+    p_handoff_data: handoffData,
+  };
+
+  if (idempotencyKey) {
+    rpcParams.p_idempotency_key = idempotencyKey;
+  }
+
+  const { data: result, error } = await supabase.rpc('fn_advance_venture_stage', rpcParams);
+
+  if (error) {
+    throw new Error(
+      `[artifact-persistence-service] advanceStage failed: ${error.message}. ` +
+      `Venture: ${ventureId}, From: ${fromStage}, To: ${toStage}. ` +
+      'Gateway fn_advance_venture_stage() is required for audit trail compliance.'
+    );
+  }
+
+  return {
+    success: true,
+    wasDuplicate: result?.was_duplicate === true,
+    result,
+  };
+}
+
+// ── Internal Helpers ──
+
+function tryParse(str) {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return { raw: str };
+  }
+}
+
+function deriveEpistemicClassification(payload) {
+  const fb = payload?.fourBuckets;
+  if (!fb?.classifications?.length) return null;
+
+  const s = fb.summary || {};
+  const bucketCounts = [
+    ['fact', s.facts || 0],
+    ['assumption', s.assumptions || 0],
+    ['simulation', s.simulations || 0],
+    ['unknown', s.unknowns || 0],
+  ];
+  bucketCounts.sort((a, b) => b[1] - a[1]);
+  return bucketCounts[0][0];
+}

--- a/lib/eva/eva-orchestrator-helpers.js
+++ b/lib/eva/eva-orchestrator-helpers.js
@@ -10,6 +10,8 @@
  * @module lib/eva/eva-orchestrator-helpers
  */
 
+import { writeArtifactBatch } from './artifact-persistence-service.js';
+
 // ── Status Constants ────────────────────────────────────────────
 
 const STATUS = Object.freeze({
@@ -162,74 +164,8 @@ async function loadStageTemplate(supabase, stageId) {
 }
 
 async function persistArtifacts(supabase, ventureId, stageId, artifacts, idempotencyKey) {
-  // Mark previous versions as not current before inserting new ones
-  await supabase
-    .from('venture_artifacts')
-    .update({ is_current: false })
-    .eq('venture_id', ventureId)
-    .eq('lifecycle_stage', stageId)
-    .eq('is_current', true);
-
-  const ids = [];
-  for (const art of artifacts) {
-    const row = {
-      venture_id: ventureId,
-      lifecycle_stage: stageId,
-      artifact_type: art.artifactType,
-      title: art.title || art.artifactType || `Stage ${stageId} Analysis`,
-      artifact_data: art.payload,
-      is_current: true,
-      source: art.source || 'eva-orchestrator',
-      quality_score: art.qualityScore ?? 70, // Default passing score for LLM-generated artifacts
-      validation_status: 'validated',
-    };
-    if (idempotencyKey) {
-      row.idempotency_key = idempotencyKey;
-    }
-
-    // Four Buckets: populate epistemic columns when classification data is present
-    const fb = art.payload?.fourBuckets;
-    if (fb?.classifications?.length > 0) {
-      // Dominant bucket = highest count in summary
-      const s = fb.summary || {};
-      const bucketCounts = [
-        ['fact', s.facts || 0],
-        ['assumption', s.assumptions || 0],
-        ['simulation', s.simulations || 0],
-        ['unknown', s.unknowns || 0],
-      ];
-      bucketCounts.sort((a, b) => b[1] - a[1]);
-      row.epistemic_classification = bucketCounts[0][0];
-      row.epistemic_evidence = fb.classifications;
-    }
-
-    let insertError;
-    let data;
-    const insertResult = await supabase
-      .from('venture_artifacts')
-      .insert(row)
-      .select('id')
-      .single();
-    data = insertResult.data;
-    insertError = insertResult.error;
-
-    // Graceful degradation: if epistemic columns cause constraint violation, retry without them
-    if (insertError && row.epistemic_classification) {
-      delete row.epistemic_classification;
-      delete row.epistemic_evidence;
-      const retryResult = await supabase
-        .from('venture_artifacts')
-        .insert(row)
-        .select('id')
-        .single();
-      data = retryResult.data;
-      insertError = retryResult.error;
-    }
-
-    if (insertError) throw new Error(`Failed to persist artifact: ${insertError.message}`);
-    ids.push(data.id);
-  }
-  return ids;
+  // Delegated to unified artifact-persistence-service (SD-EVA-INFRA-UNIFIED-PERSIST-SVC-001)
+  return writeArtifactBatch(supabase, ventureId, stageId, artifacts, idempotencyKey);
 }
 
 async function checkIdempotency(supabase, ventureId, stageId, idempotencyKey) {

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -24,6 +24,7 @@ import { evaluateRealityGate, isGatedBoundary } from './reality-gates.js';
 import { attemptGateRecovery } from './gate-failure-recovery.js';
 import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord } from './devils-advocate.js';
 import { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-bridge.js';
+import { writeArtifact } from './artifact-persistence-service.js';
 import { handlePostLifecycleDecision, isFinalStage } from './post-lifecycle-decisions.js';
 import { createOrReusePendingDecision, waitForDecision, createAdvisoryNotification } from './chairman-decision-watcher.js';
 import { OrchestratorTracer } from './observability.js';
@@ -578,11 +579,24 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
         stageOutput,
       }, { logger });
 
-      // Persist DA review as venture artifact
+      // Persist DA review as venture artifact via unified service
       if (!options.dryRun && supabase) {
-        const artifactRow = buildArtifactRecord(ventureId, devilsAdvocateReview);
-        const { error: daErr } = await supabase.from('venture_artifacts').insert(artifactRow);
-        if (daErr) logger.warn(`[Eva] DA artifact persist failed: ${daErr.message}`);
+        try {
+          const artifactRow = buildArtifactRecord(ventureId, devilsAdvocateReview);
+          await writeArtifact(supabase, {
+            ventureId,
+            lifecycleStage: artifactRow.lifecycle_stage,
+            artifactType: artifactRow.artifact_type,
+            title: artifactRow.title,
+            content: artifactRow.content,
+            metadata: artifactRow.metadata,
+            source: artifactRow.source || 'devils-advocate',
+            qualityScore: artifactRow.quality_score ?? 70,
+            validationStatus: artifactRow.validation_status || 'validated',
+          });
+        } catch (daErr) {
+          logger.warn(`[Eva] DA artifact persist failed: ${daErr.message}`);
+        }
       }
 
       gateResults.push({
@@ -689,10 +703,24 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       if (bridgeResult.created) {
         logger.log(`[Eva] Lifecycle-to-SD Bridge: Created orchestrator ${bridgeResult.orchestratorKey} with ${bridgeResult.childKeys.length} children`);
       }
-      // Persist bridge result as artifact
-      const bridgeArtifact = buildBridgeArtifactRecord(ventureId, resolvedStage, bridgeResult);
-      const { error: bridgeErr } = await supabase.from('venture_artifacts').insert(bridgeArtifact);
-      if (bridgeErr) logger.warn(`[Eva] Bridge artifact persist failed: ${bridgeErr.message}`);
+      // Persist bridge result as artifact via unified service
+      try {
+        const bridgeArtifact = buildBridgeArtifactRecord(ventureId, resolvedStage, bridgeResult);
+        await writeArtifact(supabase, {
+          ventureId,
+          lifecycleStage: bridgeArtifact.lifecycle_stage,
+          artifactType: bridgeArtifact.artifact_type,
+          title: bridgeArtifact.title,
+          content: bridgeArtifact.content,
+          metadata: bridgeArtifact.metadata,
+          source: bridgeArtifact.source || 'lifecycle-sd-bridge',
+          qualityScore: bridgeArtifact.quality_score ?? 100,
+          validationStatus: bridgeArtifact.validation_status || 'validated',
+          validatedBy: bridgeArtifact.validated_by,
+        });
+      } catch (bridgeErr) {
+        logger.warn(`[Eva] Bridge artifact persist failed: ${bridgeErr.message}`);
+      }
     } catch (err) {
       logger.warn(`[Eva] Lifecycle-to-SD Bridge failed (non-fatal): ${err.message}`);
     }

--- a/lib/eva/post-lifecycle-decisions.js
+++ b/lib/eva/post-lifecycle-decisions.js
@@ -12,6 +12,7 @@
 
 import { markCompleted, ORCHESTRATOR_STATES } from './orchestrator-state-machine.js';
 import { convertExpansionToSD } from './lifecycle-sd-bridge.js';
+import { writeArtifact } from './artifact-persistence-service.js';
 
 // ── Constants ───────────────────────────────────────────────
 
@@ -305,10 +306,10 @@ function getDecisionDescription(type, ventureContext) {
  */
 async function recordDecision(supabase, ventureId, decision, result, logger) {
   try {
-    await supabase.from('venture_artifacts').insert({
-      venture_id: ventureId,
-      lifecycle_stage: MAX_LIFECYCLE_STAGE,
-      artifact_type: 'post_lifecycle_decision',
+    await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: MAX_LIFECYCLE_STAGE,
+      artifactType: 'post_lifecycle_decision',
       title: `Post-Lifecycle Decision: ${decision.type.toUpperCase()}`,
       content: JSON.stringify({
         decision,
@@ -319,10 +320,9 @@ async function recordDecision(supabase, ventureId, decision, result, logger) {
         decision_type: decision.type,
         success: result.success,
       },
-      quality_score: result.success ? 100 : 0,
-      validation_status: result.success ? 'validated' : 'failed',
-      validated_by: 'post-lifecycle-decisions',
-      is_current: true,
+      qualityScore: result.success ? 100 : 0,
+      validationStatus: result.success ? 'validated' : 'failed',
+      validatedBy: 'post-lifecycle-decisions',
       source: 'post-lifecycle-decisions',
     });
   } catch (err) {

--- a/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
@@ -13,6 +13,7 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
+import { writeArtifact } from '../../artifact-persistence-service.js';
 
 // ── SRIP Enrichment (optional — all imports try/catch guarded) ──────
 let sripSiteDna = null;
@@ -498,14 +499,15 @@ async function writeStage10Artifacts({ supabase, ventureId, customerPersonas, br
     });
     logger.log('[Stage10] Brand genome created', { id: genomeResult?.id });
 
-    // Write venture_artifacts ref for brand genome
+    // Write venture_artifacts ref for brand genome via unified service
     try {
-      await supabase.from('venture_artifacts').insert({
-        venture_id: ventureId,
-        lifecycle_stage: 10,
-        artifact_type: 'brand_guidelines',
+      await writeArtifact(supabase, {
+        ventureId,
+        lifecycleStage: 10,
+        artifactType: 'brand_guidelines',
         title: 'Brand Genome (Stage 10)',
         metadata: { brand_genome_id: genomeResult?.id, source: 'stage-10-analysis' },
+        source: 'stage-10-analysis',
       });
     } catch (artifactErr) {
       logger.warn('[Stage10] Brand genome artifact ref failed', { error: artifactErr.message });
@@ -514,14 +516,15 @@ async function writeStage10Artifacts({ supabase, ventureId, customerPersonas, br
     logger.warn('[Stage10] Brand genome creation failed', { error: err.message });
   }
 
-  // 3. Write venture_artifacts ref for persona catalog
+  // 3. Write venture_artifacts ref for persona catalog via unified service
   try {
-    await supabase.from('venture_artifacts').insert({
-      venture_id: ventureId,
-      lifecycle_stage: 10,
-      artifact_type: 'brand_guidelines',
+    await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: 10,
+      artifactType: 'brand_guidelines',
       title: 'Customer Personas (Stage 10)',
       metadata: { persona_count: customerPersonas.length, source: 'stage-10-analysis' },
+      source: 'stage-10-analysis',
     });
   } catch (err) {
     logger.warn('[Stage10] Persona artifact ref failed', { error: err.message });

--- a/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-11-visual-identity.js
@@ -13,6 +13,7 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 import { runTournament } from '../../crews/tournament-orchestrator.js';
+import { writeArtifact } from '../../artifact-persistence-service.js';
 import { sanitizeForPrompt } from '../../utils/sanitize-for-prompt.js';
 
 // Duplicated from stage-11.js to avoid circular dependency
@@ -420,18 +421,19 @@ async function writeStage11Artifacts({ supabase, ventureId, candidates, logger }
     }
   }
 
-  // Write venture_artifacts ref for naming session
+  // Write venture_artifacts ref for naming session via unified service
   try {
-    await supabase.from('venture_artifacts').insert({
-      venture_id: ventureId,
-      lifecycle_stage: 11,
-      artifact_type: 'brand_name',
+    await writeArtifact(supabase, {
+      ventureId,
+      lifecycleStage: 11,
+      artifactType: 'brand_name',
       title: 'Naming Candidates (Stage 11)',
       metadata: {
         generation_session_id: generationSessionId,
         candidate_count: candidates.length,
         source: 'stage-11-analysis',
       },
+      source: 'stage-11-analysis',
     });
   } catch (err) {
     logger.warn('[Stage11] Naming artifact ref failed', { error: err.message });

--- a/scripts/backfill-artifact-data.mjs
+++ b/scripts/backfill-artifact-data.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * Backfill script for venture_artifacts table.
+ *
+ * SD-EVA-INFRA-UNIFIED-PERSIST-SVC-001 (US-005)
+ *
+ * Repairs two data integrity issues:
+ *   1. CONTENT_NULL: Artifacts with artifact_data but NULL content
+ *   2. DUPLICATE_IS_CURRENT: Multiple is_current=true rows per venture/stage/type
+ *
+ * Usage:
+ *   node scripts/backfill-artifact-data.mjs              # Dry run (report only)
+ *   node scripts/backfill-artifact-data.mjs --apply       # Execute repairs
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const DRY_RUN = !process.argv.includes('--apply');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+async function backfillContentNull() {
+  console.log('\n=== Phase 1: CONTENT_NULL Repair ===');
+
+  const { data: nullContent, error } = await supabase
+    .from('venture_artifacts')
+    .select('id, artifact_type, lifecycle_stage, artifact_data')
+    .is('content', null)
+    .not('artifact_data', 'is', null);
+
+  if (error) {
+    console.error('Query failed:', error.message);
+    return { found: 0, repaired: 0 };
+  }
+
+  console.log(`Found ${nullContent.length} artifacts with NULL content but non-NULL artifact_data`);
+
+  if (DRY_RUN) {
+    nullContent.slice(0, 5).forEach(a => {
+      console.log(`  [DRY] ${a.id} | stage ${a.lifecycle_stage} | ${a.artifact_type}`);
+    });
+    if (nullContent.length > 5) console.log(`  ... and ${nullContent.length - 5} more`);
+    return { found: nullContent.length, repaired: 0 };
+  }
+
+  let repaired = 0;
+  for (const artifact of nullContent) {
+    const contentStr = JSON.stringify(artifact.artifact_data);
+    const { error: updateErr } = await supabase
+      .from('venture_artifacts')
+      .update({ content: contentStr })
+      .eq('id', artifact.id);
+
+    if (updateErr) {
+      console.error(`  FAIL ${artifact.id}: ${updateErr.message}`);
+    } else {
+      repaired++;
+    }
+  }
+
+  console.log(`Repaired ${repaired}/${nullContent.length} CONTENT_NULL artifacts`);
+  return { found: nullContent.length, repaired };
+}
+
+async function fixDuplicateIsCurrent() {
+  console.log('\n=== Phase 2: DUPLICATE_IS_CURRENT Repair ===');
+
+  // Find duplicates: multiple is_current=true per venture/stage/type
+  const { data: allCurrent, error } = await supabase
+    .from('venture_artifacts')
+    .select('id, venture_id, lifecycle_stage, artifact_type, created_at')
+    .eq('is_current', true)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('Query failed:', error.message);
+    return { found: 0, repaired: 0 };
+  }
+
+  // Group by venture_id + lifecycle_stage + artifact_type
+  const groups = new Map();
+  for (const row of allCurrent) {
+    const key = `${row.venture_id}|${row.lifecycle_stage}|${row.artifact_type}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(row);
+  }
+
+  const duplicates = [...groups.entries()].filter(([, rows]) => rows.length > 1);
+  const totalDuplicateRows = duplicates.reduce((sum, [, rows]) => sum + rows.length - 1, 0);
+
+  console.log(`Found ${duplicates.length} duplicate groups (${totalDuplicateRows} rows to fix)`);
+
+  if (DRY_RUN) {
+    duplicates.slice(0, 5).forEach(([key, rows]) => {
+      console.log(`  [DRY] ${key}: ${rows.length} is_current=true (keeping newest)`);
+    });
+    if (duplicates.length > 5) console.log(`  ... and ${duplicates.length - 5} more`);
+    return { found: totalDuplicateRows, repaired: 0 };
+  }
+
+  let repaired = 0;
+  for (const [, rows] of duplicates) {
+    // Keep newest (first in list since sorted desc), set rest to false
+    const toFix = rows.slice(1);
+    for (const row of toFix) {
+      const { error: updateErr } = await supabase
+        .from('venture_artifacts')
+        .update({ is_current: false })
+        .eq('id', row.id);
+
+      if (updateErr) {
+        console.error(`  FAIL ${row.id}: ${updateErr.message}`);
+      } else {
+        repaired++;
+      }
+    }
+  }
+
+  console.log(`Repaired ${repaired}/${totalDuplicateRows} duplicate is_current rows`);
+  return { found: totalDuplicateRows, repaired };
+}
+
+async function main() {
+  console.log('╔══════════════════════════════════════════════════════╗');
+  console.log('║  Venture Artifact Backfill Script                   ║');
+  console.log('║  SD-EVA-INFRA-UNIFIED-PERSIST-SVC-001               ║');
+  console.log(`║  Mode: ${DRY_RUN ? 'DRY RUN (no changes)' : 'APPLY (writing changes)'}             ║`);
+  console.log('╚══════════════════════════════════════════════════════╝');
+
+  const contentResult = await backfillContentNull();
+  const duplicateResult = await fixDuplicateIsCurrent();
+
+  console.log('\n=== REPORT ===');
+  console.log(`Mode: ${DRY_RUN ? 'DRY RUN' : 'APPLIED'}`);
+  console.log(`CONTENT_NULL: ${contentResult.found} found, ${contentResult.repaired} repaired`);
+  console.log(`DUPLICATE_IS_CURRENT: ${duplicateResult.found} found, ${duplicateResult.repaired} repaired`);
+
+  if (DRY_RUN && (contentResult.found > 0 || duplicateResult.found > 0)) {
+    console.log('\nTo apply repairs, run: node scripts/backfill-artifact-data.mjs --apply');
+  }
+}
+
+main().catch(err => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Create `lib/eva/artifact-persistence-service.js` with `writeArtifact()`, `writeArtifactBatch()`, `recordGateResult()`, and `advanceStage()` as the single canonical write path
- Migrate 8 files (11 call sites) to use the unified service instead of direct Supabase inserts
- Add pre-commit hook (Stage 1.5) to block future direct writes to protected tables
- Add backfill script for CONTENT_NULL and DUPLICATE_IS_CURRENT repair

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Module imports verified for all 4 exports
- [x] All migrated files import correctly
- [x] Backfill dry-run clean (0 issues found)
- [x] EXEC-TO-PLAN handoff approved
- [x] PLAN-TO-LEAD handoff approved (92%)
- [x] LEAD-FINAL-APPROVAL passed (96%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)