### PR TITLE
fix: cap Gemini 2.5 thinking budget and handle null systemPrompt

### DIFF
--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -397,10 +397,14 @@ export class GoogleAdapter {
           generationConfig.thinkingConfig = {
             thinkingLevel: levelMap[effortLevel] || 'low'
           };
-        } else if (isGemini2_5 && !effortLevel) {
-          // Gemini 2.5 requires thinking mode (thinkingBudget: 0 is invalid).
-          // Use minimal budget for simple tasks to limit thinking token consumption.
-          generationConfig.thinkingConfig = { thinkingBudget: 1024 };
+        } else if (isGemini2_5) {
+          // Gemini 2.5: thinking tokens share maxOutputTokens budget.
+          // Without a cap, thinking consumes the entire budget leaving 0 for output.
+          // Pro minimum is 128. Flash can be 0 (disabled).
+          const isFlash = model.includes('flash');
+          const budgetMap = { low: isFlash ? 512 : 512, medium: 2048, high: 8192 };
+          const budget = effortLevel ? (budgetMap[effortLevel] || 1024) : 1024;
+          generationConfig.thinkingConfig = { thinkingBudget: budget };
         }
 
         const response = await fetch(
@@ -411,8 +415,8 @@ export class GoogleAdapter {
               'Content-Type': 'application/json'
             },
             body: JSON.stringify({
-              systemInstruction: { parts: [{ text: sanitizeUnicode(systemPrompt) }] },
-              contents: [{ role: 'user', parts: [{ text: sanitizeUnicode(userPrompt) }] }],
+              ...(systemPrompt ? { systemInstruction: { parts: [{ text: sanitizeUnicode(systemPrompt) }] } } : {}),
+              contents: [{ role: 'user', parts: [{ text: sanitizeUnicode(userPrompt || 'Hello') }] }],
               generationConfig
             }),
             signal: controller.signal


### PR DESCRIPTION
## Summary
- Gemini 2.5 Pro/Flash thinking tokens were consuming entire `maxOutputTokens` budget, leaving 0 for actual output
- Fixed by applying `thinkingBudget` for ALL Gemini 2.5 calls (was only applied when `effortLevel` was unset)
- Added effort-level-aware budget mapping: low=512, medium=2048, high=8192
- Fixed 400 error when `systemPrompt` is null by conditionally including `systemInstruction`

## Test plan
- [x] Direct API test: Gemini returns actual text (not empty)
- [x] LLM factory test: `getLLMClient()`, `getValidationClient()`, null systemPrompt all work
- [x] Smoke tests pass (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)