### PR TITLE
fix: correct fn_advance_venture_stage column names and add RPC result checking

### DIFF
--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -190,9 +190,8 @@ export async function recordGateResult(supabase, opts) {
     passed,
   };
 
-  if (score !== null) row.score = score;
-  if (reasoning) row.reasoning = reasoning;
-  if (metadata) row.metadata = metadata;
+  if (score !== null) row.overall_score = score;
+  if (reasoning || metadata) row.notes = reasoning || (typeof metadata === 'string' ? metadata : JSON.stringify(metadata));
 
   const { data, error } = await supabase
     .from('eva_stage_gate_results')
@@ -247,6 +246,14 @@ export async function advanceStage(supabase, opts) {
       `[artifact-persistence-service] advanceStage failed: ${error.message}. ` +
       `Venture: ${ventureId}, From: ${fromStage}, To: ${toStage}. ` +
       'Gateway fn_advance_venture_stage() is required for audit trail compliance.'
+    );
+  }
+
+  // Check RPC-level success (EXCEPTION WHEN OTHERS returns {success:false} as HTTP 200)
+  if (result && result.success === false) {
+    throw new Error(
+      `[artifact-persistence-service] advanceStage RPC returned failure: ${result.error}. ` +
+      `Venture: ${ventureId}, From: ${fromStage}, To: ${toStage}.`
     );
   }
 

--- a/supabase/migrations/20260319_fix_fn_advance_overload_ambiguity.sql
+++ b/supabase/migrations/20260319_fix_fn_advance_overload_ambiguity.sql
@@ -1,0 +1,93 @@
+-- Fix fn_advance_venture_stage overload ambiguity + column name corrections
+-- v1 had 4 column name errors: stage_id, health_score, approved_at, created_at
+-- v2 corrects to: lifecycle_stage, no health_score, no approved_at/created_at
+-- Also adds FOR UPDATE row lock (from working advance_venture_stage in 20260318)
+
+DROP FUNCTION IF EXISTS fn_advance_venture_stage(UUID, INTEGER, INTEGER, JSONB);
+DROP FUNCTION IF EXISTS fn_advance_venture_stage(UUID, INTEGER, INTEGER, JSONB, UUID);
+
+CREATE OR REPLACE FUNCTION fn_advance_venture_stage(
+  p_venture_id UUID,
+  p_from_stage INTEGER,
+  p_to_stage INTEGER,
+  p_handoff_data JSONB DEFAULT '{}'::jsonb,
+  p_idempotency_key UUID DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_current_stage INTEGER;
+  v_venture_name TEXT;
+  v_gate_result JSONB;
+  v_user_id UUID;
+  v_idem_key UUID;
+BEGIN
+  -- Lock the venture row to prevent concurrent advances
+  SELECT current_lifecycle_stage, name INTO v_current_stage, v_venture_name
+  FROM ventures WHERE id = p_venture_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture not found', 'venture_id', p_venture_id);
+  END IF;
+
+  IF v_current_stage != p_from_stage THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Stage mismatch', 'current_stage', v_current_stage, 'from_stage', p_from_stage);
+  END IF;
+
+  IF p_to_stage < 1 OR p_to_stage > 25 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid to_stage', 'to_stage', p_to_stage);
+  END IF;
+
+  -- Idempotency check
+  IF p_idempotency_key IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM venture_stage_transitions WHERE idempotency_key = p_idempotency_key) THEN
+      RETURN jsonb_build_object('success', true, 'was_duplicate', true, 'venture_id', p_venture_id);
+    END IF;
+  END IF;
+
+  -- Compliance gate at Stage 20
+  IF p_from_stage = 20 AND p_to_stage = 21 THEN
+    v_user_id := (p_handoff_data->>'user_id')::UUID;
+    v_gate_result := evaluate_stage20_compliance_gate(p_venture_id, v_user_id);
+    IF NOT (v_gate_result->>'success')::BOOLEAN THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Compliance gate failed', 'gate_result', v_gate_result);
+    END IF;
+    IF (v_gate_result->>'outcome') = 'FAIL' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Compliance gate blocked', 'gate_status', 'BLOCKED', 'gate_result', v_gate_result);
+    END IF;
+    PERFORM record_compliance_gate_passed(p_venture_id, v_user_id);
+  END IF;
+
+  -- Advance current_lifecycle_stage
+  UPDATE ventures SET current_lifecycle_stage = p_to_stage, updated_at = NOW() WHERE id = p_venture_id;
+
+  -- Mark current stage work as completed (FIXED: lifecycle_stage, no health_score)
+  UPDATE venture_stage_work SET stage_status = 'completed', completed_at = NOW()
+  WHERE venture_id = p_venture_id AND lifecycle_stage = p_from_stage;
+
+  v_idem_key := COALESCE(p_idempotency_key, gen_random_uuid());
+
+  -- Record transition (FIXED: removed approved_at and created_at)
+  INSERT INTO venture_stage_transitions (
+    venture_id, from_stage, to_stage, transition_type,
+    approved_by, handoff_data, idempotency_key
+  ) VALUES (
+    p_venture_id, p_from_stage, p_to_stage, 'normal',
+    COALESCE(p_handoff_data->>'ceo_agent_id', 'system'), p_handoff_data, v_idem_key
+  ) ON CONFLICT DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'success', true, 'venture_id', p_venture_id, 'venture_name', v_venture_name,
+    'from_stage', p_from_stage, 'to_stage', p_to_stage, 'transitioned_at', NOW(), 'idempotency_key', v_idem_key
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM, 'venture_id', p_venture_id);
+END;
+$fn$;
+
+GRANT EXECUTE ON FUNCTION fn_advance_venture_stage(UUID, INTEGER, INTEGER, JSONB, UUID) TO authenticated;


### PR DESCRIPTION
## Summary
- Fixed 4 hallucinated column names in fn_advance_venture_stage migration (stage_id→lifecycle_stage, removed health_score/approved_at/created_at)
- Added FOR UPDATE row lock for concurrent safety
- Fixed advanceStage() caller to check result.success (prevents silent RPC failures)
- Fixed recordGateResult() column mapping (score→overall_score, metadata→notes)
- Verified end-to-end: dual-write OK, transitions recording, stage advancement working

## Test plan
- [x] Direct RPC test returns success and updates DB
- [x] processStage() advances venture 1→2 with transition recorded
- [x] Dual-write verified (content + artifact_data populated)
- [x] Smoke tests pass (30/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)