### PR TITLE
feat: worker auto-approve gates + infinite loop fix

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -535,11 +535,10 @@ export class StageExecutionWorker {
           break;
         }
 
-        // P0 Pre-execution guard: if this is a gate/review stage and a pending
-        // decision already exists, skip LLM execution entirely. Prevents the
-        // re-run problem: redundant processStage calls while awaiting chairman
-        // or review approval (e.g., 19 wasted LLM calls at Stage 7).
+        // P0 Pre-execution guard: if this is a gate/review stage, check for
+        // existing decisions BEFORE calling processStage (LLM call).
         if (REVIEW_MODE_STAGES.has(currentStage) || CHAIRMAN_GATES.BLOCKING.has(currentStage)) {
+          // Check for pending decision → block without running LLM
           const { data: pendingDecision } = await this._supabase
             .from('chairman_decisions')
             .select('id, status')
@@ -550,6 +549,33 @@ export class StageExecutionWorker {
             .maybeSingle();
 
           if (pendingDecision && pendingDecision.status === 'pending') {
+            // If global auto-approve is on and this isn't stage 16, auto-approve
+            // the pending decision and advance instead of blocking.
+            const shouldAutoApprove = currentStage !== 16 && await this._checkGlobalAutoApprove();
+            if (shouldAutoApprove) {
+              this._logger.log(
+                `[Worker] Stage ${currentStage} pending decision ${pendingDecision.id} — auto-approving (global_auto_proceed=true)`
+              );
+              await this._supabase
+                .from('chairman_decisions')
+                .update({ status: 'approved', decision: 'proceed', blocking: false, updated_at: new Date().toISOString() })
+                .eq('id', pendingDecision.id);
+              await this._supabase
+                .from('venture_stage_work')
+                .update({ stage_status: 'completed', completed_at: new Date().toISOString() })
+                .eq('venture_id', ventureId)
+                .eq('lifecycle_stage', currentStage);
+              const nextStage = currentStage + 1;
+              await this._supabase
+                .from('ventures')
+                .update({ current_lifecycle_stage: nextStage })
+                .eq('id', ventureId);
+              this._logger.log(`[Worker] Advanced DB stage ${currentStage} → ${nextStage} (pending auto-approved)`);
+              this._logStageTransition(ventureId, currentStage, 'completed', 0, null).catch(() => {});
+              currentStage = nextStage;
+              continue;
+            }
+
             this._logger.log(
               `[Worker] Stage ${currentStage} has pending decision ${pendingDecision.id} — skipping execution, remaining blocked`
             );
@@ -562,6 +588,39 @@ export class StageExecutionWorker {
               pendingDecisionId: pendingDecision.id,
             };
             break;
+          }
+
+          // Check for already-approved decision → skip LLM, advance directly.
+          // This prevents the infinite re-execution loop: without this check,
+          // processStage runs an LLM call on every poll cycle even though the
+          // chairman already approved.
+          const { data: approvedDecision } = await this._supabase
+            .from('chairman_decisions')
+            .select('id, status')
+            .eq('venture_id', ventureId)
+            .eq('lifecycle_stage', currentStage)
+            .eq('status', 'approved')
+            .limit(1)
+            .maybeSingle();
+
+          if (approvedDecision && approvedDecision.status === 'approved') {
+            this._logger.log(
+              `[Worker] Stage ${currentStage} already approved (decision ${approvedDecision.id}) — skipping processStage, advancing`
+            );
+            await this._supabase
+              .from('venture_stage_work')
+              .update({ stage_status: 'completed', completed_at: new Date().toISOString() })
+              .eq('venture_id', ventureId)
+              .eq('lifecycle_stage', currentStage);
+            const nextStage = currentStage + 1;
+            await this._supabase
+              .from('ventures')
+              .update({ current_lifecycle_stage: nextStage })
+              .eq('id', ventureId);
+            this._logger.log(`[Worker] Advanced DB stage ${currentStage} → ${nextStage} (pre-execution approved skip)`);
+            this._logStageTransition(ventureId, currentStage, 'completed', 0, null).catch(() => {});
+            currentStage = nextStage;
+            continue;
           }
         }
 
@@ -598,20 +657,48 @@ export class StageExecutionWorker {
           if (approvedDecision) {
             this._logger.log(`[Worker] Stage ${currentStage} already approved (decision ${approvedDecision.id}) — advancing`);
             // Update venture_stage_work so the UI reflects the approved gate as completed
-            // (without this, the UI stays stuck on the gate stage showing "blocked")
             await this._supabase
               .from('venture_stage_work')
               .update({ stage_status: 'completed', completed_at: new Date().toISOString() })
               .eq('venture_id', ventureId)
               .eq('lifecycle_stage', currentStage);
+            // CRITICAL: Update current_lifecycle_stage in DB so the next poll cycle
+            // picks up from the correct stage. Without this, the venture stays at
+            // the approved gate stage forever (infinite re-execution loop).
+            const nextReentryStage = currentStage + 1;
+            await this._supabase
+              .from('ventures')
+              .update({ current_lifecycle_stage: nextReentryStage })
+              .eq('id', ventureId);
+            this._logger.log(`[Worker] Advanced DB stage ${currentStage} → ${nextReentryStage} (re-entry after approval)`);
             this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
-            currentStage++;
+            currentStage = nextReentryStage;
             continue;
           }
         }
 
         // Review-mode stages: pause for chairman review before auto-advancing
         if (REVIEW_MODE_STAGES.has(currentStage) && !CHAIRMAN_GATES.BLOCKING.has(currentStage)) {
+          // Check global auto-approve — if enabled, skip the review pause entirely
+          const reviewAutoApprove = await this._checkGlobalAutoApprove();
+          if (reviewAutoApprove) {
+            this._logger.log(`[Worker] Review-mode stage ${currentStage} auto-approved (global_auto_proceed=true)`);
+            await this._supabase
+              .from('venture_stage_work')
+              .update({ stage_status: 'completed', completed_at: new Date().toISOString() })
+              .eq('venture_id', ventureId)
+              .eq('lifecycle_stage', currentStage);
+            const nextReviewStage = currentStage + 1;
+            await this._supabase
+              .from('ventures')
+              .update({ current_lifecycle_stage: nextReviewStage })
+              .eq('id', ventureId);
+            this._logger.log(`[Worker] Advanced DB stage ${currentStage} → ${nextReviewStage} (review auto-approved)`);
+            this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
+            currentStage = nextReviewStage;
+            continue;
+          }
+
           this._logger.log(`[Worker] Review-mode stage ${currentStage} — blocking for chairman review`);
 
           // Revert current_lifecycle_stage back to the review stage so the UI
@@ -1061,6 +1148,19 @@ export class StageExecutionWorker {
         return { blocked: false, killed: false, approved: true };
       }
 
+      // Check global auto-approve setting from chairman dashboard config.
+      // When enabled, all gates are auto-approved EXCEPT Stage 16 (Blueprint→Build
+      // boundary) which always requires manual chairman approval before building.
+      if (stageNumber !== 16) {
+        const globalAutoApprove = await this._checkGlobalAutoApprove();
+        if (globalAutoApprove) {
+          this._logger.log(`[Worker] Chairman gate ${stageNumber} auto-approved (global_auto_proceed=true, type=${gateType})`);
+          return { blocked: false, killed: false, approved: true };
+        }
+      } else {
+        this._logger.log(`[Worker] Stage 16 (Blueprint→Build) always requires manual approval`);
+      }
+
       // Fetch brief data for the decision
       const { data: venture } = await this._supabase
         .from('ventures')
@@ -1296,6 +1396,25 @@ export class StageExecutionWorker {
     } catch {
       // If governance table doesn't exist or query fails, default to allowing auto-proceed
       return null;
+    }
+  }
+
+  /**
+   * Check if global auto-approve is enabled in chairman dashboard config.
+   * When enabled, all chairman gates are auto-approved without blocking.
+   * @returns {Promise<boolean>}
+   */
+  async _checkGlobalAutoApprove() {
+    try {
+      const { data } = await this._supabase
+        .from('chairman_dashboard_config')
+        .select('global_auto_proceed')
+        .eq('config_key', 'default')
+        .maybeSingle();
+
+      return data?.global_auto_proceed === true;
+    } catch {
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- **Auto-approve gates**: Worker checks `global_auto_proceed` from `chairman_dashboard_config` and auto-approves all chairman gates and review-mode stages (except Stage 16)
- **Auto-approve pending decisions**: Pre-execution guard auto-approves existing pending decisions when global auto-proceed is on
- **Infinite loop fix**: Re-entry check and pre-execution guard now update `current_lifecycle_stage` in DB (was only updating local variable, causing infinite re-execution at gate stages)
- **`_checkGlobalAutoApprove()`**: New method reads `chairman_dashboard_config.global_auto_proceed`

## Context
Part of the venture pipeline triangulation fixes. Paired with ehg PR #361 (frontend toggle).

## Test plan
- [ ] Enable auto-approve toggle → venture advances through all gates without manual buttons
- [ ] Stage 16 still blocks for manual approval even with auto-approve on
- [ ] Venture doesn't loop infinitely at any gate stage
- [ ] Disabling auto-approve restores normal blocking behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)