### PR TITLE
fix: wireframes agent missed in artifact naming migration

### DIFF
--- a/lib/eva/blueprint-agents/wireframes.js
+++ b/lib/eva/blueprint-agents/wireframes.js
@@ -7,11 +7,13 @@
  * @module lib/eva/blueprint-agents/wireframes
  */
 
-export const artifactType = 'wireframes';
+import { ARTIFACT_TYPES } from '../artifact-types.js';
+
+export const artifactType = ARTIFACT_TYPES.BLUEPRINT_WIREFRAMES;
 
 export const description = 'Screen layouts with ASCII wireframes, navigation flows, and persona coverage';
 
-export const dependencies = ['technical_architecture', 'user_story_pack'];
+export const dependencies = [ARTIFACT_TYPES.BLUEPRINT_TECHNICAL_ARCHITECTURE, ARTIFACT_TYPES.BLUEPRINT_USER_STORY_PACK];
 
 export const systemPrompt = `You are a UX Wireframe Specialist for early-stage venture blueprints. Given the venture brief, technical architecture, and user stories, design low-fidelity wireframes for every key screen the product needs.
 


### PR DESCRIPTION
## Summary
- `lib/eva/blueprint-agents/wireframes.js` was missed during the artifact naming convention migration
- Updated `artifactType` and `dependencies` to import from `artifact-types.js` registry instead of hardcoded strings
- Verification script now passes: zero old-name remnants

## Test plan
- [x] `node scripts/verify-artifact-naming.js` — passes (0 old names)
- [x] 83 blueprint tests pass
- [x] Module compiles with correct artifact type constants

🤖 Generated with [Claude Code](https://claude.com/claude-code)