### PR TITLE
fix: stage renumbering consistency (backend)

### DIFF
--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -82,9 +82,9 @@ const FILTER_PREFERENCE_KEYS = [
  * Validate stage gate for a venture transition.
  *
  * Dispatches to the appropriate gate type:
- *   1. Existing artifact-based gates (5->6, 21->22, 22->23)
- *   2. Kill gates (entering stages 3, 5, 13, 23)
- *   3. Promotion gates (entering stages 16, 17, 22)
+ *   1. Existing artifact-based gates (5->6, 22->23, 23->24)
+ *   2. Kill gates (entering stages 3, 5, 13, 24)
+ *   3. Promotion gates (entering stages 17, 18, 23)
  *
  * @param {Object} supabase - Supabase client
  * @param {string} ventureId - Venture ID
@@ -105,9 +105,9 @@ export async function validateStageGate(supabase, ventureId, fromStage, toStage,
   switch (transition) {
     case '5->6':
       return validateFinancialViabilityGate(supabase, ventureId);
-    case '21->22':
-      return validateUATSignoffGate(supabase, ventureId);
     case '22->23':
+      return validateUATSignoffGate(supabase, ventureId);
+    case '23->24':
       return validateDeploymentHealthGate(supabase, ventureId);
   }
 

--- a/lib/eva/reality-gates.js
+++ b/lib/eva/reality-gates.js
@@ -60,7 +60,7 @@ const BOUNDARY_CONFIG = Object.freeze({
       { artifact_type: ARTIFACT_TYPES.BLUEPRINT_PROJECT_PLAN, min_quality_score: 0.5, url_verification_required: false },
     ],
   },
-  '16->17': {
+  '17->18': {
     description: 'BLUEPRINT → BUILD LOOP',
     required_artifacts: [
       { artifact_type: ARTIFACT_TYPES.BUILD_MVP_BUILD, min_quality_score: 0.7, url_verification_required: true },
@@ -68,7 +68,7 @@ const BOUNDARY_CONFIG = Object.freeze({
       { artifact_type: ARTIFACT_TYPES.LAUNCH_DEPLOYMENT_RUNBOOK, min_quality_score: 0.5, url_verification_required: false },
     ],
   },
-  '22->23': {
+  '23->24': {
     description: 'BUILD LOOP → LAUNCH & LEARN',
     required_artifacts: [
       { artifact_type: ARTIFACT_TYPES.LAUNCH_LAUNCH_METRICS, min_quality_score: 0.6, url_verification_required: false },

--- a/lib/eva/stage-zero/profile-service.js
+++ b/lib/eva/stage-zero/profile-service.js
@@ -296,12 +296,12 @@ const LEGACY_GATE_THRESHOLDS = {
     blueprint_technical_architecture: 0.6,
     blueprint_project_plan: 0.5,
   },
-  '16->17': {
+  '17->18': {
     build_mvp_build: 0.7,
     build_test_coverage_report: 0.6,
     launch_deployment_runbook: 0.5,
   },
-  '22->23': {
+  '23->24': {
     launch_launch_metrics: 0.6,
     launch_user_feedback_summary: 0.5,
     launch_production_app: 0.7,

--- a/scripts/modules/doc-audit/content-classifier.js
+++ b/scripts/modules/doc-audit/content-classifier.js
@@ -24,7 +24,7 @@ import { join, relative, extname } from 'path';
 
 const SOURCE_EXTENSIONS = new Set(['.js', '.ts', '.mjs', '.cjs', '.sql']);
 const SOURCE_DIRS = ['src', 'lib', 'scripts', 'database'];
-const MAX_STAGE = 25;
+const MAX_STAGE = 26;
 
 // ── Code Artifact Index ─────────────────────────────────────────────
 

--- a/tests/unit/eva/devils-advocate.test.js
+++ b/tests/unit/eva/devils-advocate.test.js
@@ -24,7 +24,7 @@ describe('DevilsAdvocate', () => {
     });
 
     it('should identify promotion gates', () => {
-      for (const stage of [16, 17, 22]) {
+      for (const stage of [17, 18, 23]) {
         const result = isDevilsAdvocateGate(stage);
         expect(result.isGate).toBe(true);
         expect(result.gateType).toBe('promotion');
@@ -32,7 +32,7 @@ describe('DevilsAdvocate', () => {
     });
 
     it('should return false for non-gate stages', () => {
-      for (const stage of [1, 2, 4, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21, 24, 25]) {
+      for (const stage of [1, 2, 4, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 19, 20, 21, 22, 25, 26]) {
         const result = isDevilsAdvocateGate(stage);
         expect(result.isGate).toBe(false);
         expect(result.gateType).toBeNull();
@@ -225,11 +225,11 @@ describe('DevilsAdvocate', () => {
 
     describe('constants', () => {
       it('should define correct kill gates', () => {
-        expect(_internal.KILL_GATES).toEqual([3, 5, 13, 23]);
+        expect(_internal.KILL_GATES).toEqual([3, 5, 13, 24]);
       });
 
       it('should define correct promotion gates', () => {
-        expect(_internal.PROMOTION_GATES).toEqual([16, 17, 22]);
+        expect(_internal.PROMOTION_GATES).toEqual([17, 18, 23]);
       });
 
       it('should have all gates combined', () => {

--- a/tests/unit/reality-gates.test.js
+++ b/tests/unit/reality-gates.test.js
@@ -100,7 +100,7 @@ describe('Reality Gates', () => {
 
     it('has config for exactly 5 boundaries', () => {
       const boundaries = Object.keys(BOUNDARY_CONFIG);
-      expect(boundaries).toEqual(['5->6', '9->10', '12->13', '16->17', '22->23']);
+      expect(boundaries).toEqual(['5->6', '9->10', '12->13', '17->18', '23->24']);
     });
   });
 

--- a/tests/unit/stage-gates-ext.test.js
+++ b/tests/unit/stage-gates-ext.test.js
@@ -144,20 +144,7 @@ describe('validateStageGate routing', () => {
     expect(result.passed).toBe(false);
   });
 
-  it('routes 21->22 to UAT Signoff Gate (existing)', async () => {
-    const supabase = createMockSupabase({
-      venture_artifacts: {
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
-      },
-    });
-
-    const result = await validateStageGate(supabase, 'v1', 21, 22, { logger: silentLogger });
-    expect(result.gate_name).toBe('UAT_SIGNOFF');
-  });
-
-  it('routes 22->23 to Deployment Health Gate (existing)', async () => {
+  it('routes 22->23 to UAT Signoff Gate (existing)', async () => {
     const supabase = createMockSupabase({
       venture_artifacts: {
         select: vi.fn().mockReturnThis(),
@@ -167,6 +154,19 @@ describe('validateStageGate routing', () => {
     });
 
     const result = await validateStageGate(supabase, 'v1', 22, 23, { logger: silentLogger });
+    expect(result.gate_name).toBe('UAT_SIGNOFF');
+  });
+
+  it('routes 23->24 to Deployment Health Gate (existing)', async () => {
+    const supabase = createMockSupabase({
+      venture_artifacts: {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        single: vi.fn().mockResolvedValue({ data: null, error: { message: 'not found' } }),
+      },
+    });
+
+    const result = await validateStageGate(supabase, 'v1', 23, 24, { logger: silentLogger });
     expect(result.gate_name).toBe('DEPLOYMENT_HEALTH');
   });
 


### PR DESCRIPTION
## Summary
- Fixes stage numbering inconsistencies missed in the initial 25→26 stage migration (PR #2383)
- 7 files with hardcoded old stage numbers in gate transitions, boundary configs, and test expectations

## Test plan
- [x] All changes are straightforward constant/array updates
- [ ] Run full test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)