### PR TITLE
fix: remaining stage numbering in functional code & tests

### DIFF
--- a/lib/eva/stage-zero/stage-of-death-predictor.js
+++ b/lib/eva/stage-zero/stage-of-death-predictor.js
@@ -13,15 +13,15 @@
 
 import { VALID_COMPONENTS } from './profile-service.js';
 
-/** Default stage boundaries matching EHG 25-stage venture lifecycle */
-const TOTAL_STAGES = 25;
+/** Default stage boundaries matching EHG 26-stage venture lifecycle */
+const TOTAL_STAGES = 26;
 
 /** Stage groupings for mortality curve generation */
 const STAGE_PHASES = {
   filtering: { start: 1, end: 5, label: 'Filtering & Validation' },
   building: { start: 6, end: 12, label: 'Planning & Building' },
-  testing: { start: 13, end: 18, label: 'Testing & Launch' },
-  scaling: { start: 19, end: 25, label: 'Scaling & Optimization' },
+  testing: { start: 13, end: 19, label: 'Testing & Launch' },
+  scaling: { start: 20, end: 26, label: 'Scaling & Optimization' },
 };
 
 /**

--- a/tests/integration/eva/eva-orchestrator.integration.test.js
+++ b/tests/integration/eva/eva-orchestrator.integration.test.js
@@ -471,8 +471,8 @@ describe('Eva Orchestrator Integration', () => {
     });
 
     it('should verify kill gates and promotion gates are disjoint', () => {
-      const killGates = [3, 5, 13, 23];
-      const promotionGates = [16, 17, 22];
+      const killGates = [3, 5, 13, 24];
+      const promotionGates = [17, 18, 23];
 
       for (const stage of killGates) {
         expect(promotionGates).not.toContain(stage);

--- a/tests/integration/eva/phase-a-e2e.integration.test.js
+++ b/tests/integration/eva/phase-a-e2e.integration.test.js
@@ -784,15 +784,15 @@ describe('Phase A E2E Integration Test (15-Step Scenario)', () => {
       expect(boundaries).toContain('22->23');
     });
 
-    it('verifies kill gates at stages 3, 5, 13, 23 and promotion gates at 16, 17, 22', () => {
+    it('verifies kill gates at stages 3, 5, 13, 24 and promotion gates at 17, 18, 23', () => {
       // Kill gates
-      for (const stage of [3, 5, 13, 23]) {
+      for (const stage of [3, 5, 13, 24]) {
         const { isGate, gateType } = isDevilsAdvocateGate(stage);
         expect(isGate).toBe(true);
         expect(gateType).toBe('kill');
       }
       // Promotion gates
-      for (const stage of [16, 17, 22]) {
+      for (const stage of [17, 18, 23]) {
         const { isGate, gateType } = isDevilsAdvocateGate(stage);
         expect(isGate).toBe(true);
         expect(gateType).toBe('promotion');

--- a/tests/unit/devils-advocate.test.js
+++ b/tests/unit/devils-advocate.test.js
@@ -24,7 +24,7 @@ const {
 
 describe('isDevilsAdvocateGate', () => {
   it('identifies kill gates correctly', () => {
-    for (const stage of [3, 5, 13, 23]) {
+    for (const stage of [3, 5, 13, 24]) {
       const result = isDevilsAdvocateGate(stage);
       expect(result.isGate).toBe(true);
       expect(result.gateType).toBe('kill');
@@ -32,7 +32,7 @@ describe('isDevilsAdvocateGate', () => {
   });
 
   it('identifies promotion gates correctly', () => {
-    for (const stage of [16, 17, 22]) {
+    for (const stage of [17, 18, 23]) {
       const result = isDevilsAdvocateGate(stage);
       expect(result.isGate).toBe(true);
       expect(result.gateType).toBe('promotion');
@@ -40,7 +40,7 @@ describe('isDevilsAdvocateGate', () => {
   });
 
   it('returns false for non-gate stages', () => {
-    for (const stage of [1, 2, 4, 6, 7, 8, 9, 10, 11, 12, 14, 15, 18, 19, 20, 21, 24, 25]) {
+    for (const stage of [1, 2, 4, 6, 7, 8, 9, 10, 11, 12, 14, 15, 16, 19, 20, 21, 22, 25, 26]) {
       const result = isDevilsAdvocateGate(stage);
       expect(result.isGate).toBe(false);
       expect(result.gateType).toBeNull();

--- a/tests/unit/eva/devils-advocate.test.js
+++ b/tests/unit/eva/devils-advocate.test.js
@@ -16,7 +16,7 @@ const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 describe('DevilsAdvocate', () => {
   describe('isDevilsAdvocateGate', () => {
     it('should identify kill gates', () => {
-      for (const stage of [3, 5, 13, 23]) {
+      for (const stage of [3, 5, 13, 24]) {
         const result = isDevilsAdvocateGate(stage);
         expect(result.isGate).toBe(true);
         expect(result.gateType).toBe('kill');


### PR DESCRIPTION
## Summary
Catches missed during earlier sweeps:
- `stage-of-death-predictor.js`: TOTAL_STAGES 25→26, STAGE_PHASES shifted
- 4 test files: kill/promotion gate array expectations updated

## Test plan
- [x] Constant and test expectation updates only

🤖 Generated with [Claude Code](https://claude.com/claude-code)