### PR TITLE
fix(CRITICAL): broken analysis-step imports in stage templates 18-26

### DIFF
--- a/lib/agents/modules/venture-state-machine/stage-gates.js
+++ b/lib/agents/modules/venture-state-machine/stage-gates.js
@@ -8,7 +8,7 @@
  * Integrates with Decision Filter Engine for threshold evaluation.
  *
  * Gate Types:
- *   EXISTING  - Original artifact-based gates (5->6, 21->22, 22->23)
+ *   EXISTING  - Original artifact-based gates (5->6, 22->23, 23->24)
  *   KILL      - Venture termination checkpoints (stages 3, 5, 13, 23)
  *   PROMOTION - Advancement approval gates (stages 16, 17, 22)
  *
@@ -623,7 +623,7 @@ async function validateFinancialViabilityGate(supabase, ventureId) {
 }
 
 /**
- * UAT Programmatic Signoff Gate (Stage 21->22)
+ * UAT Programmatic Signoff Gate (Stage 22->23)
  * Validates all UAT scenarios passed before deployment
  * Checks: test_coverage_report artifact with 100% UAT pass rate
  *
@@ -632,7 +632,7 @@ async function validateFinancialViabilityGate(supabase, ventureId) {
  * @returns {Promise<Object>} Gate result
  */
 async function validateUATSignoffGate(supabase, ventureId) {
-  console.log('   Validating UAT Signoff Gate (21->22)');
+  console.log('   Validating UAT Signoff Gate (22->23)');
 
   const gateResult = {
     passed: false,

--- a/lib/eva/stage-templates/stage-18.js
+++ b/lib/eva/stage-templates/stage-18.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage17 } from './analysis-steps/stage-17-build-readiness.js';
+import { analyzeStage17 } from './analysis-steps/stage-18-build-readiness.js';
 
 const CHECKLIST_CATEGORIES = [
   'architecture',

--- a/lib/eva/stage-templates/stage-19.js
+++ b/lib/eva/stage-templates/stage-19.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage18 } from './analysis-steps/stage-18-sprint-planning.js';
+import { analyzeStage18 } from './analysis-steps/stage-19-sprint-planning.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];

--- a/lib/eva/stage-templates/stage-20.js
+++ b/lib/eva/stage-templates/stage-20.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage19 } from './analysis-steps/stage-19-build-execution.js';
+import { analyzeStage19 } from './analysis-steps/stage-20-build-execution.js';
 
 const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
 const ISSUE_SEVERITIES = ['critical', 'high', 'medium', 'low'];

--- a/lib/eva/stage-templates/stage-21.js
+++ b/lib/eva/stage-templates/stage-21.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage20 } from './analysis-steps/stage-20-quality-assurance.js';
+import { analyzeStage20 } from './analysis-steps/stage-21-quality-assurance.js';
 
 const DEFECT_SEVERITIES = ['critical', 'high', 'medium', 'low'];
 const DEFECT_STATUSES = ['open', 'investigating', 'resolved', 'deferred', 'wont_fix'];

--- a/lib/eva/stage-templates/stage-22.js
+++ b/lib/eva/stage-templates/stage-22.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage21 } from './analysis-steps/stage-21-build-review.js';
+import { analyzeStage21 } from './analysis-steps/stage-22-build-review.js';
 
 const INTEGRATION_STATUSES = ['pass', 'fail', 'skip', 'pending'];
 const REVIEW_DECISIONS = ['approve', 'conditional', 'reject'];

--- a/lib/eva/stage-templates/stage-23.js
+++ b/lib/eva/stage-templates/stage-23.js
@@ -21,8 +21,8 @@
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage22 } from './analysis-steps/stage-22-release-readiness.js';
-import { CHECKLIST_CATEGORIES } from './stage-17.js';
+import { analyzeStage22 } from './analysis-steps/stage-23-release-readiness.js';
+import { CHECKLIST_CATEGORIES } from './stage-18.js';
 import { MIN_COVERAGE_PCT } from './stage-20.js';
 import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 

--- a/lib/eva/stage-templates/stage-24.js
+++ b/lib/eva/stage-templates/stage-24.js
@@ -13,7 +13,7 @@
 
 import { validateString, validateArray, validateNumber, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage23 } from './analysis-steps/stage-23-marketing-prep.js';
+import { analyzeStage23 } from './analysis-steps/stage-24-marketing-prep.js';
 
 const MARKETING_ITEM_TYPES = [
   'landing_page', 'social_media_campaign', 'press_release',

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -15,7 +15,7 @@
 
 import { validateString, validateNumber, validateEnum, validateArray, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage24 } from './analysis-steps/stage-24-launch-readiness.js';
+import { analyzeStage24 } from './analysis-steps/stage-25-launch-readiness.js';
 import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
 const GO_NO_GO_DECISIONS = ['go', 'no_go', 'conditional_go'];

--- a/lib/eva/stage-templates/stage-26.js
+++ b/lib/eva/stage-templates/stage-26.js
@@ -14,7 +14,7 @@
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage25 } from './analysis-steps/stage-25-launch-execution.js';
+import { analyzeStage25 } from './analysis-steps/stage-26-launch-execution.js';
 
 const CHANNEL_STATUSES = ['inactive', 'activating', 'active', 'failed', 'paused'];
 const PIPELINE_MODES = ['discovery', 'build', 'launch', 'operations'];

--- a/tests/integration/eva/eva-orchestrator.integration.test.js
+++ b/tests/integration/eva/eva-orchestrator.integration.test.js
@@ -454,7 +454,7 @@ describe('Eva Orchestrator Integration', () => {
       expect(boundaries).toContain('5->6');
       expect(boundaries).toContain('9->10');
       expect(boundaries).toContain('12->13');
-      expect(boundaries).toContain('16->17');
+      expect(boundaries).toContain('17->18');
       expect(boundaries).toContain('22->23');
 
       // Each boundary has 3 required artifacts

--- a/tests/integration/eva/phase-a-e2e.integration.test.js
+++ b/tests/integration/eva/phase-a-e2e.integration.test.js
@@ -507,7 +507,7 @@ describe('Phase A E2E Integration Test (15-Step Scenario)', () => {
 
       // Add artifacts for reality gate at 16->17
       if (stage === 16) {
-        state.artifacts.push(...buildBoundaryArtifacts('16->17'));
+        state.artifacts.push(...buildBoundaryArtifacts('17->18'));
       }
 
       const result = await processStage(
@@ -780,7 +780,7 @@ describe('Phase A E2E Integration Test (15-Step Scenario)', () => {
       expect(boundaries).toContain('5->6');
       expect(boundaries).toContain('9->10');
       expect(boundaries).toContain('12->13');
-      expect(boundaries).toContain('16->17');
+      expect(boundaries).toContain('17->18');
       expect(boundaries).toContain('22->23');
     });
 
@@ -817,7 +817,7 @@ describe('Phase A E2E Integration Test (15-Step Scenario)', () => {
         state.venture.current_lifecycle_stage = stage;
 
         // Seed boundary artifacts
-        const boundaries = ['5->6', '9->10', '12->13', '16->17', '22->23'];
+        const boundaries = ['5->6', '9->10', '12->13', '17->18', '23->24'];
         for (const b of boundaries) {
           const [from] = b.split('->').map(Number);
           if (stage === from) {

--- a/tests/unit/eva/stage-zero/gate-thresholds.test.js
+++ b/tests/unit/eva/stage-zero/gate-thresholds.test.js
@@ -23,7 +23,7 @@ import {
 describe('LEGACY_GATE_THRESHOLDS', () => {
   test('contains all 5 enforced boundaries', () => {
     expect(Object.keys(LEGACY_GATE_THRESHOLDS)).toEqual([
-      '5->6', '9->10', '12->13', '16->17', '20->21',
+      '5->6', '9->10', '12->13', '17->18', '23->24',
     ]);
   });
 
@@ -37,11 +37,11 @@ describe('LEGACY_GATE_THRESHOLDS', () => {
   });
 
   test('matches BOUNDARY_CONFIG values for shared boundaries', () => {
-    // LEGACY_GATE_THRESHOLDS covers boundaries 5->6, 9->10, 12->13, 16->17, 20->21
-    // BOUNDARY_CONFIG covers boundaries 5->6, 9->10, 12->13, 16->17, 22->23
-    // They share 5->6, 12->13, 16->17 with identical artifact types.
+    // LEGACY_GATE_THRESHOLDS covers boundaries 5->6, 9->10, 12->13, 17->18, 23->24
+    // BOUNDARY_CONFIG covers boundaries 5->6, 9->10, 12->13, 17->18, 23->24
+    // They share 5->6, 12->13, 17->18 with identical artifact types.
     // 9->10 and last boundary differ (legacy has old artifact types, config was updated).
-    const sharedBoundaries = ['5->6', '12->13', '16->17'];
+    const sharedBoundaries = ['5->6', '12->13', '17->18'];
     for (const boundary of sharedBoundaries) {
       const config = BOUNDARY_CONFIG[boundary];
       for (const artifact of config.required_artifacts) {


### PR DESCRIPTION
## Summary
**CRITICAL**: All 9 stage template files (18-26) had broken import paths pointing to pre-rename analysis step files. The `git mv` renames shifted filenames but didn't update the `import` statements inside the template files.

Example: `stage-18.js` imported from `./analysis-steps/stage-17-build-readiness.js` — file no longer exists (renamed to `stage-18-build-readiness.js`).

Also fixes:
- stage-23.js CHECKLIST_CATEGORIES import (stage-17→stage-18)
- stage-gates.js comments (old transition references)
- Integration/unit test boundary expectations (16->17→17->18)

## Test plan
- [x] All imports now point to existing files (verified via ls + grep)
- [ ] Run stage template tests to verify imports resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)