### PR TITLE
fix: update remaining DB functions for 26-stage lifecycle

### DIFF
--- a/database/migrations/20260322_update_bootstrap_and_approve_26.sql
+++ b/database/migrations/20260322_update_bootstrap_and_approve_26.sql
@@ -1,0 +1,161 @@
+-- ============================================================================
+-- Update bootstrap_venture_workflow and approve_chairman_decision for 26 stages
+-- ============================================================================
+-- SD: SD-LEO-INFRA-STAGE-BLUEPRINT-REVIEW-001
+--
+-- bootstrap_venture_workflow:
+--   - Gate stages: [3,5,10,13,16,17,22,23,24] → [3,5,10,13,17,18,23,24,25]
+--   - Max tier stage: 25 → 26
+--
+-- approve_chairman_decision:
+--   - Stage 22 'release' → Stage 23 'release'
+--   - Stage 25 'continue' → Stage 26 'continue'
+-- ============================================================================
+
+-- 1. Update bootstrap_venture_workflow
+CREATE OR REPLACE FUNCTION bootstrap_venture_workflow(p_venture_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $fn$
+DECLARE
+  v_venture RECORD;
+  v_tier_max INTEGER;
+  v_stage INTEGER;
+  v_work_type TEXT;
+  v_rows_created INTEGER := 0;
+  v_current INTEGER;
+  v_gate_stages INTEGER[] := ARRAY[3, 5, 10, 13, 17, 18, 23, 24, 25];
+BEGIN
+  SELECT id, name, tier, current_lifecycle_stage
+    INTO v_venture
+    FROM ventures
+    WHERE id = p_venture_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Venture not found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  v_current := COALESCE(v_venture.current_lifecycle_stage, 1);
+
+  v_tier_max := CASE v_venture.tier
+    WHEN 0 THEN 3
+    WHEN 1 THEN 10
+    WHEN 2 THEN 15
+    ELSE 26
+  END;
+
+  FOR v_stage IN 1..v_tier_max LOOP
+    IF v_stage = ANY(v_gate_stages) THEN
+      v_work_type := 'decision_gate';
+    ELSIF v_stage = 2 THEN
+      v_work_type := 'automated_check';
+    ELSE
+      v_work_type := 'artifact_only';
+    END IF;
+
+    INSERT INTO venture_stage_work (
+      venture_id,
+      lifecycle_stage,
+      stage_status,
+      work_type
+    ) VALUES (
+      p_venture_id,
+      v_stage,
+      CASE WHEN v_stage < v_current THEN 'completed'
+           WHEN v_stage = v_current THEN 'in_progress'
+           ELSE 'not_started'
+      END,
+      v_work_type
+    )
+    ON CONFLICT (venture_id, lifecycle_stage) DO NOTHING;
+
+    v_rows_created := v_rows_created + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_venture.name,
+    'stages_created', v_rows_created,
+    'tier', v_venture.tier,
+    'tier_max', v_tier_max
+  );
+END;
+$fn$;
+
+COMMENT ON FUNCTION bootstrap_venture_workflow(UUID) IS
+  'Bootstrap venture_stage_work rows for a venture. Gate stages: [3,5,10,13,17,18,23,24,25]. Max: 26. Updated for SD-LEO-INFRA-STAGE-BLUEPRINT-REVIEW-001.';
+
+-- 2. Update approve_chairman_decision
+CREATE OR REPLACE FUNCTION approve_chairman_decision(
+  p_decision_id UUID,
+  p_rationale TEXT DEFAULT NULL,
+  p_decided_by TEXT DEFAULT NULL
+) RETURNS JSONB
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_decision RECORD;
+BEGIN
+  -- Lock the row
+  SELECT * INTO v_decision
+  FROM chairman_decisions
+  WHERE id = p_decision_id AND status = 'pending'
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Decision not found or already resolved'
+    );
+  END IF;
+
+  -- Update decision with stage-aware decision value
+  UPDATE chairman_decisions SET
+    decision = CASE
+      WHEN lifecycle_stage = 0 THEN 'proceed'
+      WHEN lifecycle_stage = 10 THEN 'approve'
+      WHEN lifecycle_stage = 23 THEN 'release'
+      WHEN lifecycle_stage = 26 THEN 'continue'
+      ELSE 'go'
+    END,
+    status = 'approved',
+    rationale = COALESCE(p_rationale, 'Approved by Chairman'),
+    decided_by = COALESCE(p_decided_by, auth.uid()::text),
+    blocking = false,
+    updated_at = now()
+  WHERE id = p_decision_id;
+
+  -- Unblock the orchestrator so the worker picks the venture back up
+  UPDATE ventures
+  SET orchestrator_state = 'idle',
+      updated_at = now()
+  WHERE id = v_decision.venture_id
+    AND orchestrator_state = 'blocked';
+
+  -- Mark stage_work as completed after approval
+  UPDATE venture_stage_work
+  SET stage_status = 'completed',
+      completed_at = NOW()
+  WHERE venture_id = v_decision.venture_id
+    AND lifecycle_stage = v_decision.lifecycle_stage
+    AND stage_status != 'completed';
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'decision_id', p_decision_id,
+    'venture_id', v_decision.venture_id,
+    'lifecycle_stage', v_decision.lifecycle_stage,
+    'new_status', 'approved'
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION approve_chairman_decision(UUID, TEXT, TEXT) IS
+  'Approve a pending chairman decision. Stage-aware decisions: stage 10=approve, 23=release, 26=continue. Updated for SD-LEO-INFRA-STAGE-BLUEPRINT-REVIEW-001.';

--- a/database/migrations/20260322_update_fn_advance_stage_26.sql
+++ b/database/migrations/20260322_update_fn_advance_stage_26.sql
@@ -1,0 +1,98 @@
+-- ============================================================================
+-- Update fn_advance_venture_stage for 26-stage lifecycle
+-- ============================================================================
+-- SD: SD-LEO-INFRA-STAGE-BLUEPRINT-REVIEW-001
+--
+-- Changes:
+--   - Max stage: 25 → 26
+--   - Compliance gate: stage 20→21 → stage 21→22 (shifted +1)
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION fn_advance_venture_stage(
+  p_venture_id UUID,
+  p_from_stage INTEGER,
+  p_to_stage INTEGER,
+  p_handoff_data JSONB DEFAULT '{}'::jsonb,
+  p_idempotency_key UUID DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_current_stage INTEGER;
+  v_venture_name TEXT;
+  v_gate_result JSONB;
+  v_user_id UUID;
+  v_idem_key UUID;
+BEGIN
+  -- Lock the venture row to prevent concurrent advances
+  SELECT current_lifecycle_stage, name INTO v_current_stage, v_venture_name
+  FROM ventures WHERE id = p_venture_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Venture not found', 'venture_id', p_venture_id);
+  END IF;
+
+  IF v_current_stage != p_from_stage THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Stage mismatch', 'current_stage', v_current_stage, 'from_stage', p_from_stage);
+  END IF;
+
+  IF p_to_stage < 1 OR p_to_stage > 26 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid to_stage', 'to_stage', p_to_stage);
+  END IF;
+
+  -- Idempotency check
+  IF p_idempotency_key IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM venture_stage_transitions WHERE idempotency_key = p_idempotency_key) THEN
+      RETURN jsonb_build_object('success', true, 'was_duplicate', true, 'venture_id', p_venture_id);
+    END IF;
+  END IF;
+
+  -- Compliance gate at Stage 21 (was Stage 20 before 26-stage migration)
+  IF p_from_stage = 21 AND p_to_stage = 22 THEN
+    v_user_id := (p_handoff_data->>'user_id')::UUID;
+    v_gate_result := evaluate_stage20_compliance_gate(p_venture_id, v_user_id);
+    IF NOT (v_gate_result->>'success')::BOOLEAN THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Compliance gate failed', 'gate_result', v_gate_result);
+    END IF;
+    IF (v_gate_result->>'outcome') = 'FAIL' THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Compliance gate blocked', 'gate_status', 'BLOCKED', 'gate_result', v_gate_result);
+    END IF;
+    PERFORM record_compliance_gate_passed(p_venture_id, v_user_id);
+  END IF;
+
+  -- Advance current_lifecycle_stage
+  UPDATE ventures SET current_lifecycle_stage = p_to_stage, updated_at = NOW() WHERE id = p_venture_id;
+
+  -- Mark current stage work as completed
+  UPDATE venture_stage_work SET stage_status = 'completed', completed_at = NOW()
+  WHERE venture_id = p_venture_id AND lifecycle_stage = p_from_stage;
+
+  v_idem_key := COALESCE(p_idempotency_key, gen_random_uuid());
+
+  -- Record transition
+  INSERT INTO venture_stage_transitions (
+    venture_id, from_stage, to_stage, transition_type,
+    approved_by, handoff_data, idempotency_key
+  ) VALUES (
+    p_venture_id, p_from_stage, p_to_stage, 'normal',
+    COALESCE(p_handoff_data->>'ceo_agent_id', 'system'), p_handoff_data, v_idem_key
+  ) ON CONFLICT DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'success', true, 'venture_id', p_venture_id, 'venture_name', v_venture_name,
+    'from_stage', p_from_stage, 'to_stage', p_to_stage, 'transitioned_at', NOW(), 'idempotency_key', v_idem_key
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object('success', false, 'error', SQLERRM, 'venture_id', p_venture_id);
+END;
+$fn$;
+
+GRANT EXECUTE ON FUNCTION fn_advance_venture_stage(UUID, INTEGER, INTEGER, JSONB, UUID) TO authenticated;
+
+COMMENT ON FUNCTION fn_advance_venture_stage(UUID, INTEGER, INTEGER, JSONB, UUID) IS
+  'Venture stage advancement (overloaded version with handoff data). Max stage: 26. Compliance gate at stage 21→22. Updated for SD-LEO-INFRA-STAGE-BLUEPRINT-REVIEW-001.';


### PR DESCRIPTION
## Summary
Extent-of-condition catch: 3 more live DB functions had old stage numbers:
- `fn_advance_venture_stage`: max 25→26, compliance gate shift
- `bootstrap_venture_workflow`: gate array + tier max
- `approve_chairman_decision`: stage-specific decision values

All executed against Supabase and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)