### PR TITLE
fix: 9 more functional constants still using stage 25

### DIFF
--- a/lib/eva/constraint-drift-detector.js
+++ b/lib/eva/constraint-drift-detector.js
@@ -284,7 +284,7 @@ function compareCategories(baseline, currentCategories, currentStage) {
     if (baselineVal === undefined && currentVal === undefined) continue;
 
     // Stage 25 must always check vision if present in baseline
-    if (currentStage === 25 && category === 'vision') {
+    if (currentStage === 26 && category === 'vision') {
       if (!baselineVal) {
         findings.push({
           category: 'vision',

--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -631,7 +631,7 @@ export async function reportContractStatus(supabase, ventureId) {
     : CONTRACT_ENFORCEMENT.BLOCKING;
 
   const report = [];
-  for (let stage = 1; stage <= 25; stage++) {
+  for (let stage = 1; stage <= 26; stage++) {
     const result = validatePreStage(stage, stageDataMap, {
       logger: { log: () => {}, warn: () => {}, error: () => {} },
       enforcement: enforcementMode,

--- a/lib/eva/data-contract-scorer.js
+++ b/lib/eva/data-contract-scorer.js
@@ -8,7 +8,7 @@
  * @module lib/eva/data-contract-scorer
  */
 
-const EXPECTED_STAGES = 25;
+const EXPECTED_STAGES = 26;
 const REQUIRED_CONTRACT_FIELDS = ['type'];
 const OPTIONAL_CONTRACT_FIELDS = ['required', 'minLength', 'min', 'max', 'minItems'];
 

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -830,7 +830,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
  * @param {Object} params
  * @param {string} params.ventureId - Venture UUID
  * @param {Object} [params.options]
- * @param {number} [params.options.maxStages=25] - Max stages to process
+ * @param {number} [params.options.maxStages=26] - Max stages to process
  * @param {boolean} [params.options.autoProceed=true]
  * @param {string} [params.options.chairmanId]
  * @param {Object} deps - Injected dependencies
@@ -838,7 +838,7 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
  */
 export async function run({ ventureId, options = {} }, deps = {}) {
   const { logger = console } = deps;
-  const maxStages = options.maxStages || 25;
+  const maxStages = options.maxStages || 26;
   const results = [];
 
   logger.log(`[Eva] Starting orchestration loop for venture ${ventureId} (max ${maxStages} stages)`);

--- a/lib/eva/expand-spinoff-evaluator.js
+++ b/lib/eva/expand-spinoff-evaluator.js
@@ -20,7 +20,7 @@ const DEFAULT_WEIGHTS = {
   operational: 0.25,
 };
 
-const REQUIRED_STAGE = 25;
+const REQUIRED_STAGE = 26;
 
 // ── Weight Validation ───────────────────────────────────
 

--- a/lib/eva/post-lifecycle-decisions.js
+++ b/lib/eva/post-lifecycle-decisions.js
@@ -18,7 +18,7 @@ import { writeArtifact } from './artifact-persistence-service.js';
 
 export const MODULE_VERSION = '1.0.0';
 
-export const MAX_LIFECYCLE_STAGE = 25;
+export const MAX_LIFECYCLE_STAGE = 26;
 
 export const DECISION_TYPES = Object.freeze({
   CONTINUE: 'continue',

--- a/lib/eva/stage-registry.js
+++ b/lib/eva/stage-registry.js
@@ -126,7 +126,7 @@ export class StageRegistry {
    */
   async registerBuiltinStages() {
     let count = 0;
-    for (let i = 1; i <= 25; i++) {
+    for (let i = 1; i <= 26; i++) {
       const paddedNum = String(i).padStart(2, '0');
       const templatePath = join(STAGE_TEMPLATES_DIR, `stage-${paddedNum}.js`);
       try {

--- a/lib/eva/venture-monitor.js
+++ b/lib/eva/venture-monitor.js
@@ -470,8 +470,8 @@ export class VentureMonitor {
   }
 
   /**
-   * Execute pending venture decisions from Stage 25 venture reviews.
-   * Queries ventures at stage >= 25 with unprocessed advisory decisions,
+   * Execute pending venture decisions from Stage 26 venture reviews.
+   * Queries ventures at stage >= 26 with unprocessed advisory decisions,
    * then routes to appropriate handler based on ventureDecision.recommendation.
    */
   async _ventureDecisionExecution(correlationId) {

--- a/scripts/modules/sd-type-classifier.js
+++ b/scripts/modules/sd-type-classifier.js
@@ -456,11 +456,11 @@ async function main() {
   if (args[0] === '--test') {
     // Test with SD-VISION-TRANSITION-001D6
     const testSd = {
-      title: 'Phase 6 Stages: LAUNCH & LEARN (Stages 21-25)',
-      scope: `DELIVERABLE: Complete working UI/UX, forms, APIs, and AI agents for Stages 21-25 (LAUNCH & LEARN phase).
+      title: 'Phase 6 Stages: LAUNCH & LEARN (Stages 24-26)',
+      scope: `DELIVERABLE: Complete working UI/UX, forms, APIs, and AI agents for Stages 24-26 (LAUNCH & LEARN phase).
 BUILD REQUIREMENTS:
-1. UI/Forms: QA test runner, deployment dashboard, launch checklist, analytics viewer
-2. Stage Components: Stage21QA, Stage22Deployment, Stage23Launch, Stage24Analytics, Stage25Optimization`,
+1. UI/Forms: Marketing prep dashboard, launch checklist, analytics viewer
+2. Stage Components: Stage24MarketingPreparation, Stage25LaunchReadiness, Stage26LaunchExecution`,
       description: 'Implement the final phase of the venture lifecycle with React components for QA, deployment, launch, analytics, and optimization stages.',
       sd_type: 'infrastructure'
     };


### PR DESCRIPTION
## Summary
More extent-of-condition catches: 7 CRITICAL runtime constants and 2 comments still referenced 25 stages. These would cause:
- Stage 26 contracts never generated
- Stage 26 not registered in stage registry
- EVA orchestrator stopping at stage 25
- Post-lifecycle decisions triggered at wrong stage
- Spinoff evaluator requiring wrong stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)