### PR TITLE
feat: conditional wireframe gating at Stage 17 (Phase 2)

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-01-hydration.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-01-hydration.js
@@ -23,6 +23,7 @@ You MUST output valid JSON with exactly these fields:
 - targetMarket (string, min 10 chars): Who this is for
 - problemStatement (string, min 30 chars): The specific problem being solved
 - archetype (string): One of: saas, marketplace, deeptech, hardware, services, media, fintech
+- ventureType (string): One of: ui, backend, mixed, data — classifies the venture's primary technology focus. "ui" = frontend/design-heavy (web app, mobile app, visual product). "backend" = API/services/infrastructure. "mixed" = full-stack with both UI and backend components. "data" = analytics, ML, data pipelines.
 - keyAssumptions (array of strings): 2-5 key assumptions the venture relies on
 - moatStrategy (string): Competitive advantage or defensibility strategy
 - successCriteria (array of strings): 2-4 measurable success criteria
@@ -44,7 +45,7 @@ Rules:
  * @param {Object} [params.templateContext] - Optional template context from onBeforeAnalysis
  * @returns {Promise<Object>} Draft idea matching stage-01 template schema
  */
-export async function analyzeStage01({ synthesis, ventureName, templateContext, logger = console }) {
+export async function analyzeStage01({ synthesis, ventureName, templateContext, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage01] Starting analysis', { ventureName });
   if (!synthesis) {
@@ -114,10 +115,28 @@ Output ONLY valid JSON.`;
     ? parsed.successCriteria.map(c => String(c).substring(0, 500))
     : [];
 
+  // Normalize ventureType (ui, backend, mixed, data)
+  const VENTURE_TYPES = ['ui', 'backend', 'mixed', 'data'];
+  const ventureType = VENTURE_TYPES.includes(parsed.ventureType)
+    ? parsed.ventureType
+    : 'mixed'; // Default to mixed if LLM classification unclear
+
+  // Persist venture_type to ventures table (non-fatal)
+  if (supabase && ventureId && ventureType) {
+    try {
+      await supabase.from('ventures')
+        .update({ venture_type: ventureType })
+        .eq('id', ventureId);
+      logger.log('[Stage01] venture_type persisted', { ventureType });
+    } catch (err) {
+      logger.warn('[Stage01] venture_type persist failed (non-fatal)', { error: err.message });
+    }
+  }
+
   // Build source provenance: track which fields came from Stage 0 vs LLM
   const sourceProvenance = {};
-  for (const field of ['description', 'problemStatement', 'valueProp', 'targetMarket', 'archetype', 'moatStrategy']) {
-    const val = { description, problemStatement, valueProp, targetMarket, archetype, moatStrategy }[field];
+  for (const field of ['description', 'problemStatement', 'valueProp', 'targetMarket', 'archetype', 'ventureType', 'moatStrategy']) {
+    const val = { description, problemStatement, valueProp, targetMarket, archetype, ventureType, moatStrategy }[field];
     if (!val) continue;
     sourceProvenance[field] = synthesis[field] ? 'stage0' : 'llm';
   }
@@ -129,6 +148,7 @@ Output ONLY valid JSON.`;
     valueProp,
     targetMarket,
     archetype,
+    ventureType,
     keyAssumptions,
     moatStrategy,
     successCriteria,

--- a/lib/eva/stage-templates/analysis-steps/stage-17-blueprint-review.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-blueprint-review.js
@@ -203,6 +203,67 @@ export async function analyzeStage17({
     gateRationale = `Quality ${overallQuality}/100, completeness ${overallCompleteness}%. ${criticalGaps.length} critical gap(s). Not ready for BUILD.`;
   }
 
+  // ── Conditional Wireframe Gating (Phase 2) ──────────────────
+  // When EVA_WIREFRAME_GATING_ENABLED and venture is ui/mixed,
+  // wireframes move from supplementary to required at Stage 15.
+  const wireframeGatingEnabled = process.env.EVA_WIREFRAME_GATING_ENABLED === 'true';
+  let ventureType = null;
+  if (wireframeGatingEnabled) {
+    try {
+      const { data: venture } = await supabase
+        .from('ventures')
+        .select('venture_type')
+        .eq('id', ventureId)
+        .single();
+      ventureType = venture?.venture_type;
+    } catch {
+      // Non-fatal: venture_type lookup failure falls back to non-gated
+    }
+  }
+  const wireframesRequired = wireframeGatingEnabled
+    && (ventureType === 'ui' || ventureType === 'mixed');
+
+  // If wireframes are required, add to completeness calculation
+  if (wireframesRequired) {
+    const stageArtifacts15 = artifactsByStage[15] || [];
+    const hasWireframes = stageArtifacts15.some(
+      a => a.artifact_type === ARTIFACT_TYPES.BLUEPRINT_WIREFRAMES
+    );
+    totalExpected++;
+    const blueprintPhase = phaseSummaries.find(p => p.phase_key === 'THE_BLUEPRINT');
+    if (blueprintPhase) blueprintPhase.expected_count++;
+    if (hasWireframes) {
+      totalPresent++;
+      if (blueprintPhase) {
+        blueprintPhase.artifact_count++;
+        blueprintPhase.completeness_pct = blueprintPhase.expected_count > 0
+          ? Math.round((blueprintPhase.artifact_count / blueprintPhase.expected_count) * 1000) / 10
+          : 100;
+      }
+    } else {
+      const gap = {
+        phase: 'The Blueprint',
+        stage: 15,
+        artifact_type: ARTIFACT_TYPES.BLUEPRINT_WIREFRAMES,
+        severity: 'high',
+      };
+      allGaps.push(gap);
+      if (blueprintPhase) blueprintPhase.gaps.push(gap);
+    }
+    // Recalculate overall completeness
+    const newCompleteness = totalExpected > 0
+      ? Math.round((totalPresent / totalExpected) * 1000) / 10
+      : 0;
+    // Recalculate gate recommendation with wireframe gating
+    if (newCompleteness < 80 || allGaps.filter(g => g.severity === 'critical').length > 0) {
+      if (gateRecommendation === 'PASS') {
+        gateRecommendation = hasWireframes ? 'PASS' : 'REVIEW_NEEDED';
+        gateRationale = `Quality ${overallQuality}/100, completeness ${newCompleteness}%. Wireframe gating active (venture_type: ${ventureType}).`;
+      }
+    }
+    logger.info(`[Stage17] Wireframe gating active: venture_type=${ventureType}, wireframes=${hasWireframes ? 'present' : 'missing'}`);
+  }
+
   // ── Supplementary Artifacts (informational, non-gating) ──────
   const supplementaryArtifacts = {};
 
@@ -213,28 +274,30 @@ export async function analyzeStage17({
     logger.info('[Stage17] SRIP summary included as supplementary artifact');
   }
 
-  // Wireframe artifacts for BLUEPRINT phase
-  try {
-    const { data: wireframeArt } = await supabase
-      .from('venture_artifacts')
-      .select('id, metadata, created_at')
-      .eq('venture_id', ventureId)
-      .eq('artifact_type', ARTIFACT_TYPES.BLUEPRINT_WIREFRAMES)
-      .eq('is_current', true)
-      .limit(1)
-      .maybeSingle();
+  // Wireframe artifacts for BLUEPRINT phase (supplementary when not required)
+  if (!wireframesRequired) {
+    try {
+      const { data: wireframeArt } = await supabase
+        .from('venture_artifacts')
+        .select('id, metadata, created_at')
+        .eq('venture_id', ventureId)
+        .eq('artifact_type', ARTIFACT_TYPES.BLUEPRINT_WIREFRAMES)
+        .eq('is_current', true)
+        .limit(1)
+        .maybeSingle();
 
-    if (wireframeArt) {
-      supplementaryArtifacts.wireframes = {
-        artifact_id: wireframeArt.id,
-        screen_count: wireframeArt.metadata?.screen_count ?? null,
-        created_at: wireframeArt.created_at,
-        has_data: true,
-      };
-      logger.info('[Stage17] Wireframe artifact included as supplementary artifact');
+      if (wireframeArt) {
+        supplementaryArtifacts.wireframes = {
+          artifact_id: wireframeArt.id,
+          screen_count: wireframeArt.metadata?.screen_count ?? null,
+          created_at: wireframeArt.created_at,
+          has_data: true,
+        };
+        logger.info('[Stage17] Wireframe artifact included as supplementary artifact');
+      }
+    } catch {
+      // Non-fatal: wireframe lookup failure does not affect review
     }
-  } catch {
-    // Non-fatal: wireframe lookup failure does not affect review
   }
 
   const result = {
@@ -249,6 +312,9 @@ export async function analyzeStage17({
     reviewed_at: new Date().toISOString(),
     ...(Object.keys(supplementaryArtifacts).length > 0
       ? { supplementary_artifacts: supplementaryArtifacts }
+      : {}),
+    ...(wireframeGatingEnabled
+      ? { wireframe_gating: { enabled: true, venture_type: ventureType, wireframes_required: wireframesRequired } }
       : {}),
   };
 


### PR DESCRIPTION
## Summary
- Add `venture_type` column to ventures table (ui/backend/mixed/data) via database migration
- Stage 1 classifies venture type from idea brief via LLM
- Stage 17 conditionally requires wireframes for ui/mixed ventures when `EVA_WIREFRAME_GATING_ENABLED=true`
- Backend/data ventures pass Stage 17 without wireframes (backward compatible)

## Test plan
- [ ] Verify venture_type column exists in database
- [ ] Verify Stage 1 produces ventureType classification
- [ ] Verify UI venture without wireframes fails Stage 17 (flag on)
- [ ] Verify backend venture passes without wireframes (flag on)
- [ ] Verify flag off keeps wireframes supplementary for all
- [ ] Blueprint scoring tests pass (27/27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)