### PR TITLE
feat(SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-D): 3-tier SD hierarchy generation with safety controls

### DIFF
--- a/database/migrations/20260322_fn_rollback_sd_hierarchy.sql
+++ b/database/migrations/20260322_fn_rollback_sd_hierarchy.sql
@@ -1,0 +1,65 @@
+-- fn_rollback_sd_hierarchy: Cascade-cancel an entire SD hierarchy
+-- SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-D (US-006)
+--
+-- Recursively finds all descendants of an orchestrator SD and sets
+-- their status to 'cancelled'. Also cancels associated PRDs.
+-- Returns a JSON summary of what was cancelled.
+
+CREATE OR REPLACE FUNCTION fn_rollback_sd_hierarchy(p_orchestrator_id TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_cancelled_sds INTEGER := 0;
+  v_cancelled_prds INTEGER := 0;
+  v_descendant_ids TEXT[];
+  v_descendant_uuids UUID[];
+BEGIN
+  -- Find all descendants using recursive CTE
+  WITH RECURSIVE descendants AS (
+    SELECT id, uuid_id
+    FROM strategic_directives_v2
+    WHERE id = p_orchestrator_id
+    UNION ALL
+    SELECT sd.id, sd.uuid_id
+    FROM strategic_directives_v2 sd
+    JOIN descendants d ON sd.parent_sd_id = d.id
+  )
+  SELECT
+    array_agg(id),
+    array_agg(uuid_id)
+  INTO v_descendant_ids, v_descendant_uuids
+  FROM descendants;
+
+  -- Cancel all descendant SDs
+  IF v_descendant_ids IS NOT NULL THEN
+    UPDATE strategic_directives_v2
+    SET status = 'cancelled',
+        updated_at = NOW()
+    WHERE id = ANY(v_descendant_ids)
+      AND status != 'cancelled';
+    GET DIAGNOSTICS v_cancelled_sds = ROW_COUNT;
+  END IF;
+
+  -- Cancel associated PRDs (directive_id references uuid_id)
+  IF v_descendant_uuids IS NOT NULL THEN
+    UPDATE product_requirements_v2
+    SET status = 'cancelled',
+        updated_at = NOW()
+    WHERE directive_id = ANY(v_descendant_uuids)
+      AND status != 'cancelled';
+    GET DIAGNOSTICS v_cancelled_prds = ROW_COUNT;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'cancelled_sds', v_cancelled_sds,
+    'cancelled_prds', v_cancelled_prds,
+    'orchestrator_id', p_orchestrator_id,
+    'total_descendants', COALESCE(array_length(v_descendant_ids, 1), 0)
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION fn_rollback_sd_hierarchy(TEXT) IS
+  'Cascade-cancel an SD hierarchy (orchestrator + children + grandchildren + PRDs). SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-D';

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -2,11 +2,20 @@
  * Lifecycle-to-SD Bridge
  *
  * SD-LEO-FEAT-LIFECYCLE-SD-BRIDGE-001
+ * SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-D (3-tier hierarchy, safety controls)
+ *
  * Converts Stage 18 sprint plan payloads into real LEO Strategic Directives.
+ * Supports 3-tier hierarchy: orchestrator -> children -> grandchildren.
  *
  * Stage 18 generates `sd_bridge_payloads` with structured data for each
  * sprint item. This module consumes those payloads, creates an orchestrator
- * SD for the sprint, and creates child SDs for each sprint item.
+ * SD for the sprint, child SDs for each sprint item, and optional grandchild
+ * SDs decomposed by architecture layer.
+ *
+ * Safety controls:
+ * - Amplification caps (MAX_CHILDREN=10, MAX_DEPTH=2, MAX_GRANDCHILDREN_PER_CHILD=5)
+ * - Transaction wrapping with rollback on failure
+ * - Provenance tagging on every auto-generated record
  *
  * Uses sd-key-generator.js for key generation with venture namespace.
  *
@@ -19,10 +28,20 @@ import { randomUUID } from 'crypto';
 import {
   generateSDKey,
   generateChildKey,
+  generateGrandchildKey,
   normalizeVenturePrefix,
 } from '../../scripts/modules/sd-key-generator.js';
 // SD-LEO-REFAC-ELIMINATE-HARD-CODED-001: Registry-driven target_application
 import { getCurrentVenture } from '../venture-resolver.js';
+
+// ── Amplification Caps (US-004) ─────────────────────────────────
+const MAX_CHILDREN_PER_ORCHESTRATOR = 10;
+const MAX_HIERARCHY_DEPTH = 2; // orchestrator(0) -> children(1) -> grandchildren(2)
+const MAX_GRANDCHILDREN_PER_CHILD = 5;
+
+// ── Provenance Constants (US-005) ───────────────────────────────
+const GENERATION_SOURCE = 'auto-pipeline-stage-17-doc-gen';
+const GENERATION_VERSION = '1.0';
 
 // Type mapping from Stage 18 types to database sd_type
 const TYPE_MAP = {
@@ -33,34 +52,65 @@ const TYPE_MAP = {
   infra: 'infrastructure',
 };
 
+// Architecture layers for grandchild decomposition
+const ARCHITECTURE_LAYERS = [
+  { key: 'data', label: 'Data Layer', description: 'Database schema, migrations, data access' },
+  { key: 'api', label: 'API Layer', description: 'REST endpoints, request handling, validation' },
+  { key: 'ui', label: 'UI Layer', description: 'Components, pages, user interactions' },
+  { key: 'tests', label: 'Test Layer', description: 'Unit tests, integration tests, E2E tests' },
+];
+
+/**
+ * Build provenance metadata for auto-generated records.
+ * @param {string} ventureId - Source venture UUID
+ * @returns {Object} Provenance metadata fields
+ */
+function buildProvenance(ventureId) {
+  return {
+    generation_source: GENERATION_SOURCE,
+    source_venture_id: ventureId || null,
+    generated_at: new Date().toISOString(),
+    generation_version: GENERATION_VERSION,
+  };
+}
+
 /**
  * Convert Stage 18 sprint plan output into LEO Strategic Directives.
  *
- * Creates one orchestrator SD for the sprint, plus one child SD per sprint item.
- * Idempotent: if the orchestrator already exists for this venture+sprint, returns
- * existing keys without creating duplicates.
+ * Creates a 3-tier hierarchy: orchestrator -> children -> grandchildren.
+ * Wrapped in try/catch with rollback on failure.
+ * Enforces amplification caps and provenance tagging.
  *
  * @param {Object} params
  * @param {Object} params.stageOutput - Output from Stage 18 (includes sd_bridge_payloads)
  * @param {Object} params.ventureContext - Venture metadata { id, name }
+ * @param {Object} [params.options] - Generation options
+ * @param {boolean} [params.options.generateGrandchildren=true] - Whether to decompose children into grandchildren
  * @param {Object} [deps]
  * @param {Object} [deps.supabase] - Supabase client override (for testing)
  * @param {Object} [deps.logger] - Logger (defaults to console)
- * @returns {Promise<Object>} { created, orchestratorKey, childKeys, errors }
+ * @returns {Promise<Object>} { created, orchestratorKey, childKeys, grandchildKeys, errors }
  */
 export async function convertSprintToSDs(params, deps = {}) {
-  const { stageOutput, ventureContext } = params;
+  const { stageOutput, ventureContext, options = {} } = params;
+  const { generateGrandchildren = true } = options;
   const { logger = console } = deps;
   const supabase = deps.supabase || getSupabaseClient();
 
   const sprintName = stageOutput.sprint_name;
   const sprintGoal = stageOutput.sprint_goal;
   const sprintDuration = stageOutput.sprint_duration_days;
-  const payloads = stageOutput.sd_bridge_payloads || [];
+  let payloads = stageOutput.sd_bridge_payloads || [];
 
   if (!payloads.length) {
     logger.warn('[LifecycleSDBridge] No sd_bridge_payloads in stage output');
-    return { created: false, orchestratorKey: null, childKeys: [], errors: ['No sprint items to convert'] };
+    return { created: false, orchestratorKey: null, childKeys: [], grandchildKeys: [], errors: ['No sprint items to convert'] };
+  }
+
+  // Amplification cap: limit children (US-004)
+  if (payloads.length > MAX_CHILDREN_PER_ORCHESTRATOR) {
+    logger.warn(`[LifecycleSDBridge] Amplification cap hit: requested ${payloads.length} children, capped at ${MAX_CHILDREN_PER_ORCHESTRATOR}`);
+    payloads = payloads.slice(0, MAX_CHILDREN_PER_ORCHESTRATOR);
   }
 
   const venturePrefix = ventureContext?.name
@@ -75,128 +125,293 @@ export async function convertSprintToSDs(params, deps = {}) {
       created: false,
       orchestratorKey: existing.orchestratorKey,
       childKeys: existing.childKeys,
+      grandchildKeys: [],
       errors: [],
     };
   }
 
-  // Generate orchestrator SD key
-  const orchestratorKey = await generateSDKey({
-    source: 'LEO',
-    type: 'orchestrator',
-    title: `Sprint ${sprintName}`,
-    venturePrefix,
-    skipLeadValidation: true,
-  });
-
-  // Create orchestrator SD
-  const orchestratorId = randomUUID();
-  const { error: orchError } = await supabase
-    .from('strategic_directives_v2')
-    .insert({
-      id: orchestratorId,
-      sd_key: orchestratorKey,
-      title: `Sprint: ${sprintName}`,
-      description: `Orchestrator for sprint "${sprintName}". Goal: ${sprintGoal}. Duration: ${sprintDuration} days. Items: ${payloads.length}.`,
-      scope: `Sprint orchestrator coordinating ${payloads.length} child SDs for venture ${ventureContext?.name || 'unknown'}.`,
-      rationale: `Stage 18 sprint planning generated ${payloads.length} items requiring LEO workflow execution.`,
-      sd_type: 'orchestrator',
-      status: 'draft',
-      priority: 'medium',
-      category: 'Feature',
-      current_phase: 'LEAD',
-      target_application: ventureContext?.name || getCurrentVenture(),
-      created_by: 'lifecycle-sd-bridge',
-      success_criteria: payloads.map(p => p.title),
-      success_metrics: [
-        { metric: 'Child SD completion', target: `${payloads.length}/${payloads.length} children completed`, actual: 'TBD' },
-      ],
-      strategic_objectives: [`Complete sprint "${sprintName}" via LEO workflow`],
-      key_principles: ['Follow LEO Protocol for all changes', 'Each sprint item is an independent SD'],
-      key_changes: payloads.map(p => ({ change: p.title, type: p.type })),
-      smoke_test_steps: [],
-      risks: [],
-      metadata: {
-        created_via: 'lifecycle-sd-bridge',
-        venture_id: ventureContext?.id,
-        venture_name: ventureContext?.name,
-        sprint_name: sprintName,
-        sprint_goal: sprintGoal,
-        sprint_duration_days: sprintDuration,
-        created_at: new Date().toISOString(),
-      },
-    });
-
-  if (orchError) {
-    logger.error(`[LifecycleSDBridge] Failed to create orchestrator: ${orchError.message}`);
-    return { created: false, orchestratorKey: null, childKeys: [], errors: [orchError.message] };
-  }
-
-  logger.log(`[LifecycleSDBridge] Created orchestrator: ${orchestratorKey} (${orchestratorId})`);
-
-  // Create child SDs for each sprint item
+  // Track all created IDs for rollback on failure
+  const createdIds = [];
   const childKeys = [];
+  const grandchildKeys = [];
   const errors = [];
 
-  for (let i = 0; i < payloads.length; i++) {
-    const payload = payloads[i];
-    const childKey = generateChildKey(orchestratorKey, i);
-    const dbType = TYPE_MAP[payload.type] || 'feature';
+  try {
+    // Generate orchestrator SD key
+    const orchestratorKey = await generateSDKey({
+      source: 'LEO',
+      type: 'orchestrator',
+      title: `Sprint ${sprintName}`,
+      venturePrefix,
+      skipLeadValidation: true,
+    });
 
-    const childId = randomUUID();
-    const { error: childError } = await supabase
+    // Create orchestrator SD
+    const orchestratorId = randomUUID();
+    const provenance = buildProvenance(ventureContext?.id);
+    const { error: orchError } = await supabase
       .from('strategic_directives_v2')
       .insert({
-        id: childId,
-        sd_key: childKey,
-        title: payload.title,
-        description: payload.description,
-        scope: payload.scope,
-        rationale: `Sprint item from "${sprintName}": ${payload.description}`,
-        sd_type: dbType,
+        id: orchestratorId,
+        sd_key: orchestratorKey,
+        title: `Sprint: ${sprintName}`,
+        description: `Orchestrator for sprint "${sprintName}". Goal: ${sprintGoal}. Duration: ${sprintDuration} days. Items: ${payloads.length}.`,
+        scope: `Sprint orchestrator coordinating ${payloads.length} child SDs for venture ${ventureContext?.name || 'unknown'}.`,
+        rationale: `Stage 18 sprint planning generated ${payloads.length} items requiring LEO workflow execution.`,
+        sd_type: 'orchestrator',
         status: 'draft',
-        priority: payload.priority || 'medium',
-        category: dbType.charAt(0).toUpperCase() + dbType.slice(1),
+        priority: 'medium',
+        category: 'Feature',
         current_phase: 'LEAD',
-        target_application: payload.target_application || getCurrentVenture(),
+        target_application: ventureContext?.name || getCurrentVenture(),
         created_by: 'lifecycle-sd-bridge',
-        parent_sd_id: orchestratorId,
-        success_criteria: [payload.success_criteria],
+        success_criteria: payloads.map(p => p.title),
         success_metrics: [
-          { metric: 'Implementation completeness', target: '100%', actual: 'TBD' },
+          { metric: 'Child SD completion', target: `${payloads.length}/${payloads.length} children completed`, actual: 'TBD' },
         ],
-        strategic_objectives: [`Deliver: ${payload.title}`],
-        key_principles: ['Follow LEO Protocol for all changes'],
-        key_changes: [{ change: payload.title, type: dbType }],
+        strategic_objectives: [`Complete sprint "${sprintName}" via LEO workflow`],
+        key_principles: ['Follow LEO Protocol for all changes', 'Each sprint item is an independent SD'],
+        key_changes: payloads.map(p => ({ change: p.title, type: p.type })),
         smoke_test_steps: [],
-        risks: (payload.risks || []).map(r =>
-          typeof r === 'string' ? { risk: r, mitigation: 'TBD' } : r,
-        ),
+        risks: [],
         metadata: {
+          ...provenance,
           created_via: 'lifecycle-sd-bridge',
           venture_id: ventureContext?.id,
           venture_name: ventureContext?.name,
           sprint_name: sprintName,
-          sprint_item_index: i,
-          dependencies: payload.dependencies || [],
+          sprint_goal: sprintGoal,
+          sprint_duration_days: sprintDuration,
           created_at: new Date().toISOString(),
         },
       });
 
-    if (childError) {
-      logger.error(`[LifecycleSDBridge] Failed to create child ${childKey}: ${childError.message}`);
-      errors.push(`${childKey}: ${childError.message}`);
-    } else {
-      logger.log(`[LifecycleSDBridge] Created child: ${childKey} (${dbType})`);
-      childKeys.push(childKey);
+    if (orchError) {
+      throw new Error(`Failed to create orchestrator: ${orchError.message}`);
     }
+
+    createdIds.push(orchestratorId);
+    logger.log(`[LifecycleSDBridge] Created orchestrator: ${orchestratorKey} (${orchestratorId})`);
+
+    // Create child SDs for each sprint item
+    for (let i = 0; i < payloads.length; i++) {
+      const payload = payloads[i];
+      const childKey = generateChildKey(orchestratorKey, i);
+      const dbType = TYPE_MAP[payload.type] || 'feature';
+
+      const childId = randomUUID();
+      const { error: childError } = await supabase
+        .from('strategic_directives_v2')
+        .insert({
+          id: childId,
+          sd_key: childKey,
+          title: payload.title,
+          description: payload.description,
+          scope: payload.scope,
+          rationale: `Sprint item from "${sprintName}": ${payload.description}`,
+          sd_type: dbType,
+          status: 'draft',
+          priority: payload.priority || 'medium',
+          category: dbType.charAt(0).toUpperCase() + dbType.slice(1),
+          current_phase: 'LEAD',
+          target_application: payload.target_application || getCurrentVenture(),
+          created_by: 'lifecycle-sd-bridge',
+          parent_sd_id: orchestratorId,
+          success_criteria: [payload.success_criteria],
+          success_metrics: [
+            { metric: 'Implementation completeness', target: '100%', actual: 'TBD' },
+          ],
+          strategic_objectives: [`Deliver: ${payload.title}`],
+          key_principles: ['Follow LEO Protocol for all changes'],
+          key_changes: [{ change: payload.title, type: dbType }],
+          smoke_test_steps: [],
+          risks: (payload.risks || []).map(r =>
+            typeof r === 'string' ? { risk: r, mitigation: 'TBD' } : r,
+          ),
+          metadata: {
+            ...provenance,
+            created_via: 'lifecycle-sd-bridge',
+            venture_id: ventureContext?.id,
+            venture_name: ventureContext?.name,
+            sprint_name: sprintName,
+            sprint_item_index: i,
+            dependencies: payload.dependencies || [],
+            created_at: new Date().toISOString(),
+          },
+        });
+
+      if (childError) {
+        throw new Error(`Failed to create child ${childKey}: ${childError.message}`);
+      }
+
+      createdIds.push(childId);
+      childKeys.push(childKey);
+      logger.log(`[LifecycleSDBridge] Created child: ${childKey} (${dbType})`);
+
+      // Generate grandchildren for this child (US-001)
+      if (generateGrandchildren) {
+        const gcKeys = await createGrandchildren({
+          supabase,
+          logger,
+          parentChildId: childId,
+          parentChildKey: childKey,
+          childPayload: payload,
+          ventureContext,
+          provenance,
+          createdIds,
+        });
+        grandchildKeys.push(...gcKeys);
+      }
+    }
+
+    return {
+      created: true,
+      orchestratorKey,
+      childKeys,
+      grandchildKeys,
+      errors,
+    };
+  } catch (err) {
+    logger.error(`[LifecycleSDBridge] Hierarchy creation failed: ${err.message}`);
+    errors.push(err.message);
+
+    // Rollback: try RPC first, then manual cleanup
+    if (createdIds.length > 0) {
+      await rollbackCreatedRecords(supabase, createdIds, logger);
+    }
+
+    return {
+      created: false,
+      orchestratorKey: null,
+      childKeys: [],
+      grandchildKeys: [],
+      errors,
+    };
+  }
+}
+
+/**
+ * Create grandchild SDs for a child by decomposing into architecture layers.
+ *
+ * @param {Object} params
+ * @returns {Promise<string[]>} Array of grandchild keys created
+ */
+async function createGrandchildren({
+  supabase, logger, parentChildId, parentChildKey,
+  childPayload, ventureContext, provenance, createdIds,
+}) {
+  const gcKeys = [];
+  // Determine which architecture layers apply based on payload hints
+  const layers = selectApplicableLayers(childPayload);
+
+  // Cap grandchildren per child (US-004)
+  const cappedLayers = layers.slice(0, MAX_GRANDCHILDREN_PER_CHILD);
+  if (layers.length > MAX_GRANDCHILDREN_PER_CHILD) {
+    logger.warn(
+      `[LifecycleSDBridge] Grandchild cap hit for ${parentChildKey}: requested ${layers.length}, capped at ${MAX_GRANDCHILDREN_PER_CHILD}`,
+    );
   }
 
-  return {
-    created: true,
-    orchestratorKey,
-    childKeys,
-    errors,
-  };
+  for (let j = 0; j < cappedLayers.length; j++) {
+    const layer = cappedLayers[j];
+    const gcKey = generateGrandchildKey(parentChildKey, j);
+    const gcId = randomUUID();
+
+    const { error: gcError } = await supabase
+      .from('strategic_directives_v2')
+      .insert({
+        id: gcId,
+        sd_key: gcKey,
+        title: `${childPayload.title} — ${layer.label}`,
+        description: `${layer.description} for "${childPayload.title}".`,
+        scope: `${layer.label} implementation for parent task.`,
+        rationale: `Architecture-layer decomposition of "${childPayload.title}" — ${layer.key} concern.`,
+        sd_type: TYPE_MAP[childPayload.type] || 'feature',
+        status: 'draft',
+        priority: childPayload.priority || 'medium',
+        category: 'Feature',
+        current_phase: 'LEAD',
+        target_application: childPayload.target_application || getCurrentVenture(),
+        created_by: 'lifecycle-sd-bridge',
+        parent_sd_id: parentChildId,
+        success_criteria: [`${layer.label} implementation complete and tested`],
+        success_metrics: [
+          { metric: `${layer.label} completeness`, target: '100%', actual: 'TBD' },
+        ],
+        strategic_objectives: [`Deliver ${layer.key} layer for: ${childPayload.title}`],
+        key_principles: ['Follow LEO Protocol for all changes'],
+        key_changes: [{ change: `${layer.label} for ${childPayload.title}`, type: childPayload.type || 'feature' }],
+        smoke_test_steps: [],
+        risks: [],
+        metadata: {
+          ...provenance,
+          created_via: 'lifecycle-sd-bridge',
+          venture_id: ventureContext?.id,
+          architecture_layer: layer.key,
+          parent_child_key: parentChildKey,
+          grandchild_index: j,
+          created_at: new Date().toISOString(),
+        },
+      });
+
+    if (gcError) {
+      throw new Error(`Failed to create grandchild ${gcKey}: ${gcError.message}`);
+    }
+
+    createdIds.push(gcId);
+    gcKeys.push(gcKey);
+    logger.log(`[LifecycleSDBridge] Created grandchild: ${gcKey} (${layer.key})`);
+  }
+
+  return gcKeys;
+}
+
+/**
+ * Determine which architecture layers apply for a given sprint item.
+ * Uses payload hints if available, otherwise returns all layers.
+ *
+ * @param {Object} payload - Sprint item payload
+ * @returns {Array} Applicable architecture layers
+ */
+function selectApplicableLayers(payload) {
+  if (payload.architecture_layers && Array.isArray(payload.architecture_layers)) {
+    return payload.architecture_layers
+      .map(key => ARCHITECTURE_LAYERS.find(l => l.key === key))
+      .filter(Boolean);
+  }
+  // Default: all layers apply
+  return ARCHITECTURE_LAYERS;
+}
+
+/**
+ * Rollback created records on failure (US-003).
+ * Tries fn_rollback_sd_hierarchy RPC first, falls back to manual cancel.
+ */
+async function rollbackCreatedRecords(supabase, createdIds, logger) {
+  // Try RPC rollback first (uses the first ID, which is the orchestrator)
+  const orchestratorId = createdIds[0];
+  const { data: rpcResult, error: rpcError } = await supabase.rpc(
+    'fn_rollback_sd_hierarchy',
+    { p_orchestrator_id: orchestratorId },
+  );
+
+  if (!rpcError && rpcResult) {
+    logger.log(`[LifecycleSDBridge] RPC rollback successful: ${JSON.stringify(rpcResult)}`);
+    return;
+  }
+
+  // Fallback: manually cancel each created record
+  logger.warn(`[LifecycleSDBridge] RPC rollback failed (${rpcError?.message}), using manual cleanup`);
+  for (const id of createdIds) {
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      .update({ status: 'cancelled', updated_at: new Date().toISOString() })
+      .eq('id', id);
+    if (error) {
+      logger.error(`[LifecycleSDBridge] Failed to cancel ${id}: ${error.message}`);
+    }
+  }
+  logger.log(`[LifecycleSDBridge] Manual rollback: cancelled ${createdIds.length} records`);
 }
 
 /**
@@ -217,13 +432,16 @@ export function buildBridgeArtifactRecord(ventureId, stageId, result) {
       created: result.created,
       orchestratorKey: result.orchestratorKey,
       childKeys: result.childKeys,
+      grandchildKeys: result.grandchildKeys || [],
       childCount: result.childKeys.length,
+      grandchildCount: (result.grandchildKeys || []).length,
       errors: result.errors,
       bridgedAt: new Date().toISOString(),
     }),
     metadata: {
       orchestratorKey: result.orchestratorKey,
       childCount: result.childKeys.length,
+      grandchildCount: (result.grandchildKeys || []).length,
       hasErrors: result.errors.length > 0,
     },
     quality_score: result.errors.length === 0 ? 100 : Math.max(0, 100 - result.errors.length * 25),
@@ -299,6 +517,7 @@ export async function convertExpansionToSD(params, deps = {}) {
   });
 
   const sdId = randomUUID();
+  const provenance = buildProvenance(parentVentureId);
   const { error } = await supabase
     .from('strategic_directives_v2')
     .insert({
@@ -325,6 +544,7 @@ export async function convertExpansionToSD(params, deps = {}) {
       smoke_test_steps: [],
       risks: [],
       metadata: {
+        ...provenance,
         created_via: 'lifecycle-sd-bridge-expand',
         parent_venture_id: parentVentureId,
         parent_venture_name: parentVentureName,
@@ -389,6 +609,16 @@ function getSupabaseClient() {
 
 export const _internal = {
   TYPE_MAP,
+  ARCHITECTURE_LAYERS,
+  MAX_CHILDREN_PER_ORCHESTRATOR,
+  MAX_HIERARCHY_DEPTH,
+  MAX_GRANDCHILDREN_PER_CHILD,
+  GENERATION_SOURCE,
+  GENERATION_VERSION,
+  buildProvenance,
+  selectApplicableLayers,
+  rollbackCreatedRecords,
+  createGrandchildren,
   findExistingOrchestrator,
   getSupabaseClient,
 };

--- a/tests/unit/eva/lifecycle-sd-bridge.test.js
+++ b/tests/unit/eva/lifecycle-sd-bridge.test.js
@@ -1,6 +1,7 @@
 /**
  * Tests for Lifecycle-SD Bridge
  * SD-LEO-ORCH-CLI-VENTURE-LIFECYCLE-002-B
+ * SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-D (3-tier hierarchy, safety controls)
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -8,7 +9,11 @@ import { describe, it, expect, vi } from 'vitest';
 // Mock sd-key-generator (has shebang that vitest can't transform)
 vi.mock('../../../scripts/modules/sd-key-generator.js', () => ({
   generateSDKey: vi.fn().mockReturnValue('SD-ORCH-SPRINT-TEST-001'),
-  generateChildKey: vi.fn().mockReturnValue('SD-ORCH-SPRINT-TEST-001-A'),
+  generateChildKey: vi.fn().mockImplementation((parent, idx) => {
+    const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    return `${parent}-${letters[idx]}`;
+  }),
+  generateGrandchildKey: vi.fn().mockImplementation((parent, idx) => `${parent}${idx + 1}`),
   normalizeVenturePrefix: vi.fn().mockReturnValue('TEST'),
 }));
 
@@ -18,12 +23,20 @@ import {
   _internal,
 } from '../../../lib/eva/lifecycle-sd-bridge.js';
 
-const { TYPE_MAP } = _internal;
+const {
+  TYPE_MAP,
+  ARCHITECTURE_LAYERS,
+  MAX_CHILDREN_PER_ORCHESTRATOR,
+  MAX_GRANDCHILDREN_PER_CHILD,
+  buildProvenance,
+  selectApplicableLayers,
+} = _internal;
 
 const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
-function createMockSupabase({ insertError = null, existingOrchestrator = null } = {}) {
+function createMockSupabase({ insertError = null, existingOrchestrator = null, failOnNthInsert = -1 } = {}) {
   let selectCallCount = 0;
+  let insertCallCount = 0;
 
   return {
     from: vi.fn((table) => {
@@ -39,7 +52,14 @@ function createMockSupabase({ insertError = null, existingOrchestrator = null } 
             return Promise.resolve({ data: [], error: null });
           }),
           order: vi.fn().mockResolvedValue({ data: [], error: null }),
-          insert: vi.fn().mockReturnThis(),
+          insert: vi.fn().mockImplementation(() => {
+            insertCallCount++;
+            if (failOnNthInsert > 0 && insertCallCount === failOnNthInsert) {
+              return Promise.resolve({ data: null, error: { message: `Insert #${insertCallCount} failed` } });
+            }
+            return Promise.resolve({ data: null, error: insertError });
+          }),
+          update: vi.fn().mockReturnThis(),
           single: vi.fn().mockResolvedValue({
             data: null,
             error: insertError,
@@ -51,6 +71,7 @@ function createMockSupabase({ insertError = null, existingOrchestrator = null } 
         insert: vi.fn().mockResolvedValue({ data: null, error: insertError }),
       };
     }),
+    rpc: vi.fn().mockResolvedValue({ data: { cancelled_sds: 0, cancelled_prds: 0 }, error: null }),
   };
 }
 
@@ -118,12 +139,146 @@ describe('LifecycleSDBridge', () => {
     });
   });
 
+  describe('convertSprintToSDs - grandchild generation (US-001)', () => {
+    it('should include grandchildKeys in result', async () => {
+      const result = await convertSprintToSDs(
+        {
+          stageOutput: {
+            sprint_name: 'Sprint 1',
+            sprint_goal: 'Build',
+            sd_bridge_payloads: [{ title: 'Feature A', type: 'feature', description: 'Desc', scope: 'Scope' }],
+          },
+          ventureContext: { id: 'v1', name: 'Test' },
+        },
+        { supabase: createMockSupabase(), logger: silentLogger },
+      );
+
+      expect(result.created).toBe(true);
+      expect(result.grandchildKeys).toBeDefined();
+      expect(result.grandchildKeys.length).toBeGreaterThan(0);
+    });
+
+    it('should skip grandchildren when option disabled', async () => {
+      const result = await convertSprintToSDs(
+        {
+          stageOutput: {
+            sprint_name: 'Sprint 1',
+            sprint_goal: 'Build',
+            sd_bridge_payloads: [{ title: 'Feature A', type: 'feature', description: 'D', scope: 'S' }],
+          },
+          ventureContext: { id: 'v1', name: 'Test' },
+          options: { generateGrandchildren: false },
+        },
+        { supabase: createMockSupabase(), logger: silentLogger },
+      );
+
+      expect(result.created).toBe(true);
+      expect(result.grandchildKeys).toEqual([]);
+    });
+  });
+
+  describe('Amplification cap (US-004)', () => {
+    it('should enforce MAX_CHILDREN_PER_ORCHESTRATOR', () => {
+      expect(MAX_CHILDREN_PER_ORCHESTRATOR).toBe(10);
+    });
+
+    it('should enforce MAX_GRANDCHILDREN_PER_CHILD', () => {
+      expect(MAX_GRANDCHILDREN_PER_CHILD).toBe(5);
+    });
+
+    it('should cap children to MAX when payloads exceed limit', async () => {
+      const payloads = Array.from({ length: 15 }, (_, i) => ({
+        title: `Item ${i}`, type: 'feature', description: 'D', scope: 'S',
+      }));
+      const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      const result = await convertSprintToSDs(
+        {
+          stageOutput: { sprint_name: 'Big Sprint', sprint_goal: 'Big', sd_bridge_payloads: payloads },
+          ventureContext: { id: 'v1', name: 'Test' },
+          options: { generateGrandchildren: false },
+        },
+        { supabase: createMockSupabase(), logger },
+      );
+
+      expect(result.childKeys.length).toBeLessThanOrEqual(MAX_CHILDREN_PER_ORCHESTRATOR);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Amplification cap hit'),
+      );
+    });
+  });
+
+  describe('Provenance tagging (US-005)', () => {
+    it('should build provenance with all required fields', () => {
+      const prov = buildProvenance('venture-123');
+      expect(prov.generation_source).toBe('auto-pipeline-stage-17-doc-gen');
+      expect(prov.source_venture_id).toBe('venture-123');
+      expect(prov.generated_at).toBeDefined();
+      expect(prov.generation_version).toBe('1.0');
+    });
+
+    it('should handle null ventureId', () => {
+      const prov = buildProvenance(null);
+      expect(prov.source_venture_id).toBeNull();
+    });
+  });
+
+  describe('selectApplicableLayers', () => {
+    it('should return all layers by default', () => {
+      const layers = selectApplicableLayers({});
+      expect(layers).toEqual(ARCHITECTURE_LAYERS);
+      expect(layers.length).toBe(4);
+    });
+
+    it('should filter by payload hints', () => {
+      const layers = selectApplicableLayers({ architecture_layers: ['data', 'api'] });
+      expect(layers.length).toBe(2);
+      expect(layers[0].key).toBe('data');
+      expect(layers[1].key).toBe('api');
+    });
+
+    it('should ignore unknown layer keys', () => {
+      const layers = selectApplicableLayers({ architecture_layers: ['data', 'unknown'] });
+      expect(layers.length).toBe(1);
+    });
+  });
+
+  describe('Transaction rollback (US-003)', () => {
+    it('should rollback on failure and return errors', async () => {
+      // Fail on 3rd insert (2nd child)
+      const mockSb = createMockSupabase({ failOnNthInsert: 3 });
+      const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      const result = await convertSprintToSDs(
+        {
+          stageOutput: {
+            sprint_name: 'Sprint 1',
+            sprint_goal: 'Build',
+            sd_bridge_payloads: [
+              { title: 'A', type: 'feature', description: 'D', scope: 'S' },
+              { title: 'B', type: 'feature', description: 'D', scope: 'S' },
+            ],
+          },
+          ventureContext: { id: 'v1', name: 'Test' },
+          options: { generateGrandchildren: false },
+        },
+        { supabase: mockSb, logger },
+      );
+
+      expect(result.created).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      // RPC rollback should have been attempted
+      expect(mockSb.rpc).toHaveBeenCalledWith('fn_rollback_sd_hierarchy', expect.any(Object));
+    });
+  });
+
   describe('buildBridgeArtifactRecord', () => {
     it('should build correct artifact for successful bridge', () => {
       const record = buildBridgeArtifactRecord('venture-1', 18, {
         created: true,
         orchestratorKey: 'SD-ORCH-SPRINT-001',
         childKeys: ['SD-ORCH-SPRINT-001-A', 'SD-ORCH-SPRINT-001-B'],
+        grandchildKeys: ['SD-ORCH-SPRINT-001-A1'],
         errors: [],
       });
 
@@ -134,6 +289,7 @@ describe('LifecycleSDBridge', () => {
       expect(record.validation_status).toBe('validated');
       expect(record.is_current).toBe(true);
       expect(record.metadata.childCount).toBe(2);
+      expect(record.metadata.grandchildCount).toBe(1);
       expect(record.metadata.hasErrors).toBe(false);
     });
 
@@ -142,6 +298,7 @@ describe('LifecycleSDBridge', () => {
         created: true,
         orchestratorKey: 'SD-ORCH-001',
         childKeys: ['SD-ORCH-001-A'],
+        grandchildKeys: [],
         errors: ['Child B failed', 'Child C failed'],
       });
 


### PR DESCRIPTION
## Summary
- Extend `lifecycle-sd-bridge.js` to generate 3-tier SD hierarchy (orchestrator -> children -> grandchildren) from venture sprint items
- Add amplification caps: MAX_CHILDREN=10, MAX_DEPTH=2, MAX_GRANDCHILDREN_PER_CHILD=5
- Add transaction wrapping with rollback on failure via `fn_rollback_sd_hierarchy` RPC
- Add provenance tagging (generation_source, source_venture_id, generated_at, generation_version) on all auto-generated records

## Test plan
- [x] All 22 unit tests pass (11 existing + 11 new)
- [x] Migration `fn_rollback_sd_hierarchy` deployed and verified
- [x] Amplification cap test: 15 payloads capped to 10
- [x] Rollback test: RPC called on failure with correct orchestrator ID
- [x] Provenance test: all fields populated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)