### PR TITLE
feat(SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-B): Stage 17 quality-dependent gate hardening

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-17-blueprint-review.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-blueprint-review.js
@@ -15,6 +15,8 @@
 
 import { ARTIFACT_TYPES } from '../../artifact-types.js';
 import { fetchSripSummary } from '../../eva-orchestrator-helpers.js';
+import { recordGateResult } from '../../artifact-persistence-service.js';
+import { createOrReusePendingDecision } from '../../chairman-decision-watcher.js';
 
 /**
  * Phase groupings for the Blueprint Review.
@@ -188,15 +190,16 @@ export async function analyzeStage17({
       ) / 10
     : 0;
 
-  // Gate recommendation
+  // Gate recommendation (thresholds configurable via stageConfig)
+  const thresholds = stageConfig?.promotion_thresholds || { pass: 70, review: 50, completeness_pass: 80, completeness_review: 60 };
   const criticalGaps = allGaps.filter(g => g.severity === 'critical');
   let gateRecommendation = 'FAIL';
   let gateRationale = '';
 
-  if (overallQuality >= 70 && criticalGaps.length === 0 && overallCompleteness >= 80) {
+  if (overallQuality >= thresholds.pass && criticalGaps.length === 0 && overallCompleteness >= (thresholds.completeness_pass || 80)) {
     gateRecommendation = 'PASS';
     gateRationale = `Quality ${overallQuality}/100, completeness ${overallCompleteness}%. All critical artifacts present.`;
-  } else if (overallQuality >= 50 && criticalGaps.length <= 2) {
+  } else if (overallQuality >= thresholds.review && criticalGaps.length <= 2) {
     gateRecommendation = 'REVIEW_NEEDED';
     gateRationale = `Quality ${overallQuality}/100, completeness ${overallCompleteness}%. ${allGaps.length} gap(s) found, ${criticalGaps.length} critical.`;
   } else {
@@ -319,6 +322,67 @@ export async function analyzeStage17({
   };
 
   logger.info(`[Stage17] Blueprint review complete: ${gateRecommendation} (quality: ${overallQuality}, completeness: ${overallCompleteness}%)`);
+
+  // ── Gate Result Persistence (SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-B) ──
+  // Persist gate evaluation to eva_stage_gate_results for audit trail
+  const perPhaseScores = {};
+  for (const ps of phaseSummaries) {
+    perPhaseScores[ps.phase_key.toLowerCase()] = ps.avg_quality_score;
+  }
+  try {
+    await recordGateResult(supabase, {
+      ventureId,
+      stageNumber: 17,
+      gateType: 'exit',
+      passed: gateRecommendation === 'PASS',
+      score: overallQuality,
+      metadata: JSON.stringify({
+        per_phase_scores: perPhaseScores,
+        gap_details: allGaps,
+        completeness_pct: overallCompleteness,
+        gate_recommendation: gateRecommendation,
+      }),
+    });
+    logger.info(`[Stage17] Gate result persisted: ${gateRecommendation} (score: ${overallQuality})`);
+  } catch (err) {
+    logger.warn(`[Stage17] Gate result persistence failed (non-fatal): ${err.message}`);
+  }
+
+  // ── Quality-Dependent Chairman Decision Pre-Creation ──
+  // PASS: pre-create approved decision so worker auto-advances
+  // REVIEW_NEEDED/FAIL: create pending decision with quality context
+  try {
+    const briefData = {
+      stage: 17,
+      gate_recommendation: gateRecommendation,
+      overall_quality: overallQuality,
+      completeness_pct: overallCompleteness,
+      critical_gaps: criticalGaps.length,
+      per_phase_scores: perPhaseScores,
+    };
+
+    const { id: decisionId } = await createOrReusePendingDecision({
+      ventureId,
+      stageNumber: 17,
+      briefData,
+      summary: `Blueprint Review: ${gateRecommendation} (quality: ${overallQuality}, completeness: ${overallCompleteness}%)`,
+      supabase,
+      logger,
+    });
+
+    if (gateRecommendation === 'PASS') {
+      // Auto-approve: worker _handleChairmanGate finds approved decision → auto-advances
+      await supabase
+        .from('chairman_decisions')
+        .update({ status: 'approved', decision: 'approve', resolved_at: new Date().toISOString() })
+        .eq('id', decisionId);
+      logger.info(`[Stage17] PASS — chairman decision auto-approved: ${decisionId}`);
+    } else {
+      logger.info(`[Stage17] ${gateRecommendation} — chairman decision pending: ${decisionId}`);
+    }
+  } catch (err) {
+    logger.warn(`[Stage17] Chairman decision pre-creation failed (non-fatal): ${err.message}`);
+  }
 
   return result;
 }

--- a/lib/eva/stage-templates/stage-17.js
+++ b/lib/eva/stage-templates/stage-17.js
@@ -20,7 +20,7 @@ const PHASE_GROUPINGS = {
   THE_BLUEPRINT: { start: 13, end: 16, label: 'The Blueprint' },
 };
 
-const PROMOTION_THRESHOLDS = { pass: 70, review: 50 };
+const PROMOTION_THRESHOLDS = { pass: 70, review: 50, completeness_pass: 80, completeness_review: 60 };
 const GATE_DECISIONS = ['PASS', 'FAIL', 'REVIEW_NEEDED'];
 
 const TEMPLATE = {
@@ -86,6 +86,8 @@ const TEMPLATE = {
  * @returns {{ pass: boolean, rationale: string, blockers: string[], decision: string }}
  */
 export function evaluatePromotionGate(reviewData, options = {}) {
+  const thresholds = options.thresholds || PROMOTION_THRESHOLDS;
+
   if (options.chairmanOverride?.approved) {
     return {
       pass: true,
@@ -96,30 +98,31 @@ export function evaluatePromotionGate(reviewData, options = {}) {
   }
 
   const score = reviewData?.overall_quality_score ?? 0;
-  const gaps = reviewData?.critical_gaps ?? [];
+  const completeness = reviewData?.overall_completeness_pct ?? 0;
+  const criticalGaps = (reviewData?.critical_gaps ?? []).filter(g => g.severity === 'critical');
 
-  if (score >= PROMOTION_THRESHOLDS.pass && gaps.length === 0) {
+  if (score >= thresholds.pass && completeness >= (thresholds.completeness_pass || 80) && criticalGaps.length === 0) {
     return {
       pass: true,
-      rationale: `Blueprint review score ${score}/100 meets threshold. All phases complete.`,
+      rationale: `Blueprint review score ${score}/100, completeness ${completeness}%. All phases complete.`,
       blockers: [],
       decision: 'PASS',
     };
   }
 
-  if (score >= PROMOTION_THRESHOLDS.review) {
+  if (score >= thresholds.review && criticalGaps.length <= 2) {
     return {
       pass: false,
-      rationale: `Blueprint review score ${score}/100. ${gaps.length} gap(s) require attention.`,
-      blockers: gaps.map(g => `${g.phase} stage ${g.stage}: missing ${g.artifact_type}`),
+      rationale: `Blueprint review score ${score}/100, completeness ${completeness}%. ${criticalGaps.length} critical gap(s) require attention.`,
+      blockers: criticalGaps.map(g => `${g.phase} stage ${g.stage}: missing ${g.artifact_type}`),
       decision: 'REVIEW_NEEDED',
     };
   }
 
   return {
     pass: false,
-    rationale: `Blueprint review score ${score}/100 is below threshold (${PROMOTION_THRESHOLDS.pass}).`,
-    blockers: gaps.map(g => `${g.phase} stage ${g.stage}: missing ${g.artifact_type}`),
+    rationale: `Blueprint review score ${score}/100, completeness ${completeness}% below threshold (${thresholds.pass}/${thresholds.completeness_pass || 80}).`,
+    blockers: (reviewData?.critical_gaps ?? []).map(g => `${g.phase} stage ${g.stage}: missing ${g.artifact_type}`),
     decision: 'FAIL',
   };
 }

--- a/tests/eva/stage-17-gate-hardening.test.js
+++ b/tests/eva/stage-17-gate-hardening.test.js
@@ -1,0 +1,118 @@
+/**
+ * Tests for Stage 17 Gate Hardening
+ * SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-B
+ *
+ * Validates:
+ * - evaluatePromotionGate with configurable thresholds
+ * - PASS/REVIEW_NEEDED/FAIL paths with completeness
+ * - Chairman override
+ */
+import { describe, it, expect } from 'vitest';
+import { evaluatePromotionGate, PROMOTION_THRESHOLDS } from '../../lib/eva/stage-templates/stage-17.js';
+
+describe('Stage 17 Gate Hardening', () => {
+  describe('evaluatePromotionGate', () => {
+    it('returns PASS when quality >= 70, completeness >= 80%, no critical gaps', () => {
+      const result = evaluatePromotionGate({
+        overall_quality_score: 80,
+        overall_completeness_pct: 90,
+        critical_gaps: [],
+      });
+      expect(result.pass).toBe(true);
+      expect(result.decision).toBe('PASS');
+      expect(result.blockers).toHaveLength(0);
+      expect(result.rationale).toContain('80');
+      expect(result.rationale).toContain('90');
+    });
+
+    it('returns REVIEW_NEEDED when quality >= 50, critical gaps <= 2', () => {
+      const result = evaluatePromotionGate({
+        overall_quality_score: 55,
+        overall_completeness_pct: 70,
+        critical_gaps: [
+          { severity: 'critical', phase: 'The Truth', stage: 1, artifact_type: 'truth_idea_brief' },
+        ],
+      });
+      expect(result.pass).toBe(false);
+      expect(result.decision).toBe('REVIEW_NEEDED');
+      expect(result.blockers.length).toBeGreaterThan(0);
+    });
+
+    it('returns FAIL when quality < 50 or critical gaps > 2', () => {
+      const result = evaluatePromotionGate({
+        overall_quality_score: 30,
+        overall_completeness_pct: 40,
+        critical_gaps: [
+          { severity: 'critical', phase: 'A', stage: 1, artifact_type: 'a' },
+          { severity: 'critical', phase: 'B', stage: 2, artifact_type: 'b' },
+          { severity: 'critical', phase: 'C', stage: 3, artifact_type: 'c' },
+        ],
+      });
+      expect(result.pass).toBe(false);
+      expect(result.decision).toBe('FAIL');
+    });
+
+    it('returns FAIL when quality is good but completeness too low', () => {
+      const result = evaluatePromotionGate({
+        overall_quality_score: 85,
+        overall_completeness_pct: 50,
+        critical_gaps: [],
+      });
+      // quality >= 70 but completeness < 80, so PASS threshold not met
+      // quality >= 50 and critical gaps <= 2, so REVIEW_NEEDED
+      expect(result.decision).toBe('REVIEW_NEEDED');
+    });
+
+    it('supports configurable thresholds via options.thresholds', () => {
+      // With default thresholds, quality=75 and completeness=85 would PASS
+      const passResult = evaluatePromotionGate(
+        { overall_quality_score: 75, overall_completeness_pct: 85, critical_gaps: [] },
+      );
+      expect(passResult.decision).toBe('PASS');
+
+      // With stricter thresholds, same data should NOT pass
+      const reviewResult = evaluatePromotionGate(
+        { overall_quality_score: 75, overall_completeness_pct: 85, critical_gaps: [] },
+        { thresholds: { pass: 80, review: 60, completeness_pass: 90 } },
+      );
+      expect(reviewResult.decision).toBe('REVIEW_NEEDED');
+    });
+
+    it('returns OVERRIDE on chairman override', () => {
+      const result = evaluatePromotionGate(
+        { overall_quality_score: 20, overall_completeness_pct: 10, critical_gaps: [] },
+        { chairmanOverride: { approved: true, justification: 'Strategic decision' } },
+      );
+      expect(result.pass).toBe(true);
+      expect(result.decision).toBe('OVERRIDE');
+      expect(result.rationale).toContain('Strategic decision');
+    });
+
+    it('handles null/undefined reviewData gracefully', () => {
+      const result = evaluatePromotionGate(null);
+      expect(result.pass).toBe(false);
+      expect(result.decision).toBe('FAIL');
+    });
+
+    it('filters only critical gaps for PASS evaluation', () => {
+      const result = evaluatePromotionGate({
+        overall_quality_score: 80,
+        overall_completeness_pct: 90,
+        critical_gaps: [
+          { severity: 'high', phase: 'A', stage: 6, artifact_type: 'test' },
+        ],
+      });
+      // 'high' severity gap is not 'critical', so PASS should still work
+      expect(result.decision).toBe('PASS');
+    });
+  });
+
+  describe('PROMOTION_THRESHOLDS', () => {
+    it('includes completeness thresholds', () => {
+      expect(PROMOTION_THRESHOLDS.pass).toBe(70);
+      expect(PROMOTION_THRESHOLDS.review).toBe(50);
+      expect(PROMOTION_THRESHOLDS.completeness_pass).toBe(80);
+      expect(PROMOTION_THRESHOLDS.completeness_review).toBe(60);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Transform Stage 17 from quality-agnostic to quality-dependent promotion gate
- PASS auto-advances, REVIEW_NEEDED/FAIL blocks for chairman review
- Gate results persisted to `eva_stage_gate_results` for audit trail
- Thresholds configurable via `stageConfig.promotion_thresholds`

## Changes
- **stage-17-blueprint-review.js**: Add gate result persistence via `recordGateResult()` and chairman decision pre-creation via `createOrReusePendingDecision()`
- **stage-17.js**: Make `evaluatePromotionGate()` support configurable thresholds and completeness checks
- **tests/eva/stage-17-gate-hardening.test.js**: 9 unit tests covering all gate paths

## Test plan
- [x] Unit tests: 9/9 passing (PASS, REVIEW_NEEDED, FAIL paths + configurable thresholds + chairman override + edge cases)
- [ ] Integration: Verify gate result persistence to `eva_stage_gate_results` with real venture
- [ ] Verify chairman decision auto-approval on PASS path

🤖 Generated with [Claude Code](https://claude.com/claude-code)