### PR TITLE
fix: align scanner-context query with v_capability_ledger schema

### DIFF
--- a/lib/capabilities/scanner-context.js
+++ b/lib/capabilities/scanner-context.js
@@ -25,7 +25,7 @@ export async function getCapabilityContextBlock(supabase, scannerType) {
   try {
     const { data: capabilities, error } = await supabase
       .from('v_capability_ledger')
-      .select('capability_name, capability_type, plane1_score, maturity_score, reuse_count, sd_key, scored_at')
+      .select('capability_key, name, capability_type, plane1_score, maturity_score, reuse_count, registered_by_sd, first_registered_at')
       .order('plane1_score', { ascending: false })
       .limit(MAX_CAPABILITIES);
 
@@ -76,7 +76,7 @@ function formatForTrendScanner(capabilities) {
   block += 'When suggesting ventures, consider how these existing capabilities provide a head start:\n\n';
 
   for (const [type, caps] of Object.entries(byType)) {
-    block += `**${type}**: ${caps.map(c => c.capability_name).join(', ')}\n`;
+    block += `**${type}**: ${caps.map(c => c.name || c.capability_key).join(', ')}\n`;
   }
 
   return block;
@@ -95,7 +95,7 @@ function formatForDemocratization(capabilities) {
 
   for (const cap of sorted.slice(0, 15)) {
     const reuse = cap.reuse_count ? ` (reused ${cap.reuse_count}x)` : '';
-    block += `- **${cap.capability_name}** [${cap.capability_type}]${reuse}\n`;
+    block += `- **${cap.name || cap.capability_key}** [${cap.capability_type}]${reuse}\n`;
   }
 
   return block;
@@ -115,7 +115,7 @@ function formatForOverhang(capabilities) {
     const score = cap.plane1_score != null ? cap.plane1_score.toFixed(1) : 'N/A';
     const maturity = cap.maturity_score != null ? cap.maturity_score : 'N/A';
     const reuse = cap.reuse_count || 0;
-    block += `| ${cap.capability_name} | ${cap.capability_type} | ${score} | ${maturity} | ${reuse}x |\n`;
+    block += `| ${cap.name || cap.capability_key} | ${cap.capability_type} | ${score} | ${maturity} | ${reuse}x |\n`;
   }
 
   block += '\nLook for gaps between these capabilities and market opportunities not yet productized.\n';
@@ -130,8 +130,8 @@ function formatForOverhang(capabilities) {
 function formatForNurseryReeval(capabilities) {
   // Sort by scored_at (most recent first) to highlight new capabilities
   const sorted = [...capabilities].sort((a, b) => {
-    const dateA = a.scored_at ? new Date(a.scored_at).getTime() : 0;
-    const dateB = b.scored_at ? new Date(b.scored_at).getTime() : 0;
+    const dateA = a.first_registered_at ? new Date(a.first_registered_at).getTime() : 0;
+    const dateB = b.first_registered_at ? new Date(b.first_registered_at).getTime() : 0;
     return dateB - dateA;
   });
 
@@ -139,8 +139,8 @@ function formatForNurseryReeval(capabilities) {
   block += 'Consider whether these new/updated capabilities unblock any parked ventures:\n\n';
 
   for (const cap of sorted.slice(0, 15)) {
-    const date = cap.scored_at ? new Date(cap.scored_at).toISOString().split('T')[0] : 'unknown';
-    block += `- **${cap.capability_name}** [${cap.capability_type}] — added ${date}\n`;
+    const date = cap.first_registered_at ? new Date(cap.first_registered_at).toISOString().split('T')[0] : 'unknown';
+    block += `- **${cap.name || cap.capability_key}** [${cap.capability_type}] — added ${date}\n`;
   }
 
   return block;

--- a/tests/unit/scanner-context.test.js
+++ b/tests/unit/scanner-context.test.js
@@ -18,11 +18,11 @@ function mockSupabase(data = [], error = null) {
 }
 
 const SAMPLE_CAPABILITIES = [
-  { capability_name: 'AI Image Classification', capability_type: 'ai_automation', plane1_score: 18.5, maturity_score: 4, reuse_count: 3, sd_key: 'SD-IMG-001', scored_at: '2026-03-01T00:00:00Z' },
-  { capability_name: 'Natural Language Processing', capability_type: 'ai_automation', plane1_score: 16.2, maturity_score: 3, reuse_count: 5, sd_key: 'SD-NLP-001', scored_at: '2026-03-02T00:00:00Z' },
-  { capability_name: 'Supabase Integration', capability_type: 'infrastructure', plane1_score: 14.0, maturity_score: 5, reuse_count: 10, sd_key: 'SD-INFRA-001', scored_at: '2026-02-15T00:00:00Z' },
-  { capability_name: 'Payment Processing', capability_type: 'integration', plane1_score: 12.0, maturity_score: 3, reuse_count: 2, sd_key: 'SD-PAY-001', scored_at: '2026-02-20T00:00:00Z' },
-  { capability_name: 'Automated Reporting', capability_type: 'application', plane1_score: 10.5, maturity_score: 2, reuse_count: 1, sd_key: 'SD-RPT-001', scored_at: '2026-03-03T00:00:00Z' },
+  { capability_key: 'ai_image_classification', name: 'AI Image Classification', capability_type: 'ai_automation', plane1_score: 18.5, maturity_score: 4, reuse_count: 3, registered_by_sd: 'SD-IMG-001', first_registered_at: '2026-03-01T00:00:00Z' },
+  { capability_key: 'natural_language_processing', name: 'Natural Language Processing', capability_type: 'ai_automation', plane1_score: 16.2, maturity_score: 3, reuse_count: 5, registered_by_sd: 'SD-NLP-001', first_registered_at: '2026-03-02T00:00:00Z' },
+  { capability_key: 'supabase_integration', name: 'Supabase Integration', capability_type: 'infrastructure', plane1_score: 14.0, maturity_score: 5, reuse_count: 10, registered_by_sd: 'SD-INFRA-001', first_registered_at: '2026-02-15T00:00:00Z' },
+  { capability_key: 'payment_processing', name: 'Payment Processing', capability_type: 'integration', plane1_score: 12.0, maturity_score: 3, reuse_count: 2, registered_by_sd: 'SD-PAY-001', first_registered_at: '2026-02-20T00:00:00Z' },
+  { capability_key: 'automated_reporting', name: 'Automated Reporting', capability_type: 'application', plane1_score: 10.5, maturity_score: 2, reuse_count: 1, registered_by_sd: 'SD-RPT-001', first_registered_at: '2026-03-03T00:00:00Z' },
 ];
 
 describe('getCapabilityContextBlock', () => {
@@ -87,13 +87,14 @@ describe('getCapabilityContextBlock', () => {
   it('enforces 2000 character cap', async () => {
     // Create a large capability set
     const largeSet = Array.from({ length: 20 }, (_, i) => ({
-      capability_name: `Very Long Capability Name That Takes Up Space Number ${i + 1} With Extra Description`,
+      capability_key: `very_long_capability_${i + 1}`,
+      name: `Very Long Capability Name That Takes Up Space Number ${i + 1} With Extra Description`,
       capability_type: 'ai_automation',
       plane1_score: 20 - i,
       maturity_score: 5,
       reuse_count: i,
-      sd_key: `SD-LONG-${i}`,
-      scored_at: '2026-03-01T00:00:00Z',
+      registered_by_sd: `SD-LONG-${i}`,
+      first_registered_at: '2026-03-01T00:00:00Z',
     }));
 
     const supabase = mockSupabase(largeSet);


### PR DESCRIPTION
## Summary
- Fixed `lib/capabilities/scanner-context.js` to query correct column names from `v_capability_ledger` view
- The module was querying `capability_name`, `sd_key`, `scored_at` — none of which exist on the view
- Corrected to `capability_key`, `name`, `registered_by_sd`, `first_registered_at`
- Formatters now use `name || capability_key` fallback for display
- Updated test fixtures to match real schema — all 10 tests pass

## Root Cause
Column names in the scanner-context module never matched the actual `v_capability_ledger` view created in `20260108_capability_ledger_v2.sql`. The error was caught silently, causing all discovery scanners to run without capability context.

## Test plan
- [x] All 10 unit tests pass (`vitest run tests/unit/scanner-context.test.js`)
- [ ] Next trend scanner run should inject capability context instead of returning empty string

🤖 Generated with [Claude Code](https://claude.com/claude-code)