### PR TITLE
fix: resolve broken ESM imports causing stage worker crash loop

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-23-release-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-release-readiness.js
@@ -14,7 +14,7 @@ import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
 // evaluatePromotionGate is a function declaration (hoisted), safe from TDZ in circular import
-import { evaluatePromotionGate } from '../stage-22.js';
+import { evaluatePromotionGate } from '../stage-23.js';
 
 // NOTE: These constants intentionally duplicated from stage-22.js
 // to avoid circular dependency — stage-22.js imports analyzeStage22 from this file,

--- a/lib/eva/stage-templates/analysis-steps/stage-24-marketing-prep.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-marketing-prep.js
@@ -13,7 +13,7 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
-import { checkReleaseReadiness } from '../stage-23.js';
+import { checkReleaseReadiness } from '../stage-24.js';
 
 // Duplicated from stage-23.js to avoid circular dependency at module-level eval
 const MARKETING_ITEM_TYPES = [

--- a/lib/eva/stage-templates/analysis-steps/stage-25-launch-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-25-launch-readiness.js
@@ -14,7 +14,7 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
-import { computeReadinessScore } from '../stage-24.js';
+import { computeReadinessScore } from '../stage-25.js';
 
 // Duplicated from stage-24.js to avoid circular dependency
 const GO_NO_GO_DECISIONS = ['go', 'no_go', 'conditional_go'];
@@ -180,7 +180,7 @@ Output ONLY valid JSON.`;
   const { readiness_score, all_checks_pass, blocking_items } = computeReadinessScore({ readiness_checklist });
 
   const latencyMs = Date.now() - startTime;
-  logger.log(`[Stage24] Launch readiness analysis complete`, {
+  logger.log('[Stage24] Launch readiness analysis complete', {
     readiness_score,
     go_no_go_decision,
     blocking_items: blocking_items.length,

--- a/lib/eva/stage-templates/analysis-steps/stage-26-launch-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-26-launch-execution.js
@@ -13,7 +13,7 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
-import { verifyLaunchAuthorization } from '../stage-25.js';
+import { verifyLaunchAuthorization } from '../stage-26.js';
 
 // Duplicated from stage-25.js to avoid circular dependency
 const CHANNEL_STATUSES = ['inactive', 'activating', 'active', 'failed', 'paused'];

--- a/lib/eva/stage-templates/stage-23.js
+++ b/lib/eva/stage-templates/stage-23.js
@@ -23,7 +23,7 @@ import { validateString, validateArray, validateEnum, collectErrors } from './va
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage22 } from './analysis-steps/stage-23-release-readiness.js';
 import { CHECKLIST_CATEGORIES } from './stage-18.js';
-import { MIN_COVERAGE_PCT } from './stage-20.js';
+import { MIN_COVERAGE_PCT } from './stage-21.js';
 import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 
 const APPROVAL_STATUSES = ['pending', 'approved', 'rejected'];
@@ -294,6 +294,32 @@ TEMPLATE.onBeforeAnalysis = async function onBeforeAnalysis(supabase, ventureId)
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage22;
 ensureOutputSchema(TEMPLATE);
+
+/**
+ * Evaluate kill gate for launch execution (Stage 24).
+ * Checks go_decision, incident response, monitoring, and rollback readiness.
+ */
+export function evaluateKillGate({ go_decision, incident_response_plan, monitoring_setup, rollback_plan, stage22Data }) {
+  const reasons = [];
+  let blockProgression = false;
+
+  if (go_decision === 'no-go') {
+    reasons.push('Go decision is no-go');
+    blockProgression = true;
+  }
+  if (!incident_response_plan || incident_response_plan === 'Incident response plan pending.') {
+    reasons.push('Incident response plan not defined');
+  }
+  if (!monitoring_setup || monitoring_setup === 'Monitoring setup pending.') {
+    reasons.push('Monitoring setup not defined');
+  }
+  if (!rollback_plan || rollback_plan === 'Rollback plan pending.') {
+    reasons.push('Rollback plan not defined');
+  }
+
+  const decision = blockProgression ? 'block' : reasons.length > 0 ? 'warn' : 'pass';
+  return { decision, blockProgression, reasons };
+}
 
 export { APPROVAL_STATUSES, RELEASE_CATEGORIES, RELEASE_DECISIONS, MIN_RELEASE_ITEMS, MIN_READINESS_PCT, MIN_BUILD_COMPLETION_PCT };
 export default TEMPLATE;

--- a/lib/eva/stage-templates/stage-25.js
+++ b/lib/eva/stage-templates/stage-25.js
@@ -197,6 +197,22 @@ TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 TEMPLATE.analysisStep = analyzeStage24;
 ensureOutputSchema(TEMPLATE);
 
+/**
+ * Detect drift between original venture vision and current state.
+ * Compares original vision text against current metrics/decisions.
+ */
+export function detectDrift({ original_vision, current_metrics, venture_decision }) {
+  if (!original_vision) {
+    return { drift_detected: false, drift_severity: 'none', details: 'No original vision available for comparison' };
+  }
+  // Simple heuristic: if venture is being sunset or pivoted, flag drift
+  const highDriftDecisions = ['pivot', 'sunset', 'exit'];
+  if (venture_decision && highDriftDecisions.includes(venture_decision)) {
+    return { drift_detected: true, drift_severity: 'high', details: `Venture decision "${venture_decision}" indicates significant drift from original vision` };
+  }
+  return { drift_detected: false, drift_severity: 'none', details: 'No significant drift detected' };
+}
+
 export {
   GO_NO_GO_DECISIONS,
   CHECKLIST_ITEM_STATUSES,


### PR DESCRIPTION
## Summary
- **Root cause**: 4 analysis-step files imported functions from wrong parent stage files (off-by-one pattern), plus 2 functions were never defined
- Fixed import paths in `stage-23-release-readiness.js`, `stage-24-marketing-prep.js`, `stage-25-launch-readiness.js`, `stage-26-launch-execution.js`
- Added missing `evaluateKillGate` stub to `stage-23.js` and `detectDrift` stub to `stage-25.js`
- ESM eagerly resolves all imports at startup, so even late-stage templates (23-26) crashed the worker for Stage 1 ventures like ClipGenius AI

## Impact
- Stage Execution Worker was in a permanent crash loop — **no ventures could progress past Stage 0**
- After fix: worker starts cleanly, all 41 exports load, ClipGenius AI can proceed through Stage 1

## Test plan
- [x] `node -e "import('./lib/eva/stage-templates/index.js')"` — loads all 41 exports
- [x] Stage Execution Worker starts and polls without crashing
- [ ] ClipGenius AI progresses through Stage 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)