### PR TITLE
feat: SRIP auto-synthesizer for Stage 10 artifact enrichment

### DIFF
--- a/lib/eva/services/index.js
+++ b/lib/eva/services/index.js
@@ -83,6 +83,9 @@ export {
 
 export { buildSynthesisPrompt } from './srip-prompt-builder.js';
 
+// SRIP Artifact Synthesizer (SD-MAN-INFRA-SRIP-AUTO-SYNTHESIZER-001)
+export { synthesizeFromArtifacts } from './srip-artifact-synthesizer.js';
+
 // SRIP Quality Check services (SD-LEO-INFRA-SRIP-QUALITY-SCORING-001)
 export {
   createQualityCheck,

--- a/lib/eva/services/srip-artifact-synthesizer.js
+++ b/lib/eva/services/srip-artifact-synthesizer.js
@@ -1,0 +1,261 @@
+/**
+ * SRIP Artifact Synthesizer
+ * SD: SD-MAN-INFRA-SRIP-AUTO-SYNTHESIZER-001
+ *
+ * Maps stage 1-9 artifacts (idea brief, competitive analysis, financial model,
+ * BMC, exit strategy) into the SRIP dna_json format expected by
+ * srip-interview-engine.js. Enables SRIP enrichment for auto-discovered
+ * ventures that lack a manual reference URL.
+ *
+ * Data flow:
+ *   venture_stage_work (stages 1,3,4,5,8)
+ *     → synthetic dna_json
+ *     → generateInterviewDefaults()
+ *     → srip_site_dna + srip_brand_interviews
+ *     → checkSripEnrichment() finds data → Stage 10 LLM enriched
+ */
+
+import { generateInterviewDefaults } from './srip-interview-engine.js';
+
+const SOURCE_TAG = 'artifact_synthesis';
+
+/**
+ * Collect stage artifacts from venture_stage_work.
+ *
+ * @param {string} ventureId
+ * @param {Object} supabase - Supabase client
+ * @returns {Promise<Object|null>} Map of stage number to advisory_data, or null if stage 1 missing
+ */
+async function collectArtifacts(ventureId, supabase) {
+  const { data, error } = await supabase
+    .from('venture_stage_work')
+    .select('lifecycle_stage, advisory_data')
+    .eq('venture_id', ventureId)
+    .in('lifecycle_stage', [1, 3, 4, 5, 8])
+    .eq('stage_status', 'completed')
+    .order('lifecycle_stage', { ascending: true });
+
+  if (error) throw new Error(`collectArtifacts failed: ${error.message}`);
+
+  const artifacts = {};
+  for (const row of data || []) {
+    artifacts[row.lifecycle_stage] = row.advisory_data || {};
+  }
+
+  // Stage 1 is the minimum required input
+  if (!artifacts[1] || !artifacts[1].description) return null;
+
+  return artifacts;
+}
+
+/**
+ * Map stage artifacts into a synthetic dna_json matching the format
+ * expected by generateInterviewDefaults().
+ *
+ * The dna_json shape mirrors a real forensic audit output:
+ *   { design_tokens, copy_patterns, macro_architecture, component_behaviors, tech_stack }
+ *
+ * @param {Object} artifacts - Map of stage number to advisory_data
+ * @returns {Object} Synthetic dna_json
+ */
+function mapArtifactsToDna(artifacts) {
+  const stage1 = artifacts[1] || {};
+  const stage3 = artifacts[3] || {};
+  const stage4 = artifacts[4] || {};
+  const stage5 = artifacts[5] || {};
+  const stage8 = artifacts[8] || {};
+
+  // Derive copy_patterns from stage 1 (idea brief) and stage 8 (BMC)
+  const headings = [];
+  if (stage1.valueProp) headings.push(String(stage1.valueProp).substring(0, 200));
+  if (stage8.valuePropositions?.items?.[0]) headings.push(String(stage8.valuePropositions.items[0]).substring(0, 200));
+
+  const ctas = [];
+  if (stage8.channels?.items) {
+    for (const ch of stage8.channels.items.slice(0, 3)) {
+      ctas.push(String(ch).substring(0, 100));
+    }
+  }
+  // Infer B2B vs B2C from customer segments
+  const segments = stage8.customerSegments?.items || stage8.customerSegments || [];
+  const segmentText = JSON.stringify(segments).toLowerCase();
+  const isB2B = /enterprise|b2b|saas|business|corporate/i.test(segmentText);
+  if (isB2B) ctas.push('Contact Sales');
+  else ctas.push('Get Started');
+
+  // Derive tone from venture archetype / description
+  const tone = stage1.archetype
+    ? `${stage1.archetype}-inspired, professional`
+    : 'Professional, modern';
+
+  const copyPatterns = {
+    tone,
+    headings,
+    ctas,
+    sample_paragraphs: stage1.description ? [stage1.description.substring(0, 300)] : [],
+    word_count: (stage1.description || '').split(/\s+/).length,
+  };
+
+  // Derive design_tokens from venture category / archetype
+  const designTokens = {
+    colors: {
+      primary: inferPrimaryColor(stage1.archetype, stage1.ventureType),
+    },
+    typography: {
+      font_family: isB2B ? 'Inter, sans-serif' : 'Poppins, sans-serif',
+    },
+    spacing: { base: '16px' },
+  };
+
+  // Derive macro_architecture from BMC structure
+  const hasManySegments = (Array.isArray(segments) ? segments.length : 0) > 2;
+  const macroArchitecture = {
+    page_flow: hasManySegments ? 'multi-section' : 'single-page',
+    responsive_approach: 'mobile-first',
+  };
+
+  // Derive component_behaviors from BMC / stage 1
+  const components = [];
+  if (stage8.customerRelationships?.items?.length) {
+    components.push({ type: 'form', name: 'contact-form' });
+  }
+  if (stage4.competitors?.length > 0) {
+    components.push({ type: 'card_grid', name: 'feature-comparison' });
+  }
+  if (stage5.revenueStreams || stage5.year1) {
+    components.push({ type: 'pricing', name: 'pricing-table' });
+  }
+
+  const componentBehaviors = { components };
+
+  // Tech stack from venture type
+  const techStack = {
+    framework: 'react',
+    css_approach: 'tailwind',
+    rendering: 'client-side',
+  };
+
+  return {
+    design_tokens: designTokens,
+    copy_patterns: copyPatterns,
+    macro_architecture: macroArchitecture,
+    component_behaviors: componentBehaviors,
+    tech_stack: techStack,
+    _source: SOURCE_TAG,
+    _stage_sources: Object.keys(artifacts).map(Number),
+  };
+}
+
+/**
+ * Infer a primary brand color from venture archetype / type.
+ */
+function inferPrimaryColor(archetype, ventureType) {
+  const a = (archetype || '').toLowerCase();
+  const v = (ventureType || '').toLowerCase();
+
+  if (/hero|warrior|ruler/i.test(a)) return '#1a56db'; // Trust blue
+  if (/creator|magician|innovator/i.test(a)) return '#7c3aed'; // Creative purple
+  if (/caregiver|innocent|sage/i.test(a)) return '#059669'; // Growth green
+  if (/rebel|outlaw|jester/i.test(a)) return '#dc2626'; // Energy red
+  if (/explorer|adventurer/i.test(a)) return '#d97706'; // Exploration amber
+  if (/health|wellness|medical/i.test(v)) return '#059669';
+  if (/fintech|finance/i.test(v)) return '#1a56db';
+  if (/creative|design|art/i.test(v)) return '#7c3aed';
+  return '#1a56db'; // Default trust blue
+}
+
+/**
+ * Check if SRIP data already exists for this venture (manual or prior synthesis).
+ *
+ * @param {string} ventureId
+ * @param {Object} supabase
+ * @returns {Promise<boolean>}
+ */
+async function hasExistingSripData(ventureId, supabase) {
+  const { data, error } = await supabase
+    .from('srip_site_dna')
+    .select('id')
+    .eq('venture_id', ventureId)
+    .eq('status', 'completed')
+    .limit(1);
+
+  if (error) return false;
+  return (data?.length || 0) > 0;
+}
+
+/**
+ * Synthesize SRIP data from stage 1-9 artifacts for a venture.
+ *
+ * This is the main entry point. It:
+ * 1. Checks if SRIP data already exists (skip if so)
+ * 2. Collects stage artifacts from venture_stage_work
+ * 3. Maps artifacts to synthetic dna_json
+ * 4. Generates 12 interview defaults
+ * 5. Persists to srip_site_dna and srip_brand_interviews
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} supabase - Supabase client
+ * @param {Object} [logger=console] - Logger instance
+ * @returns {Promise<{synthesized: boolean, siteDnaId?: string, prePopulatedCount?: number}>}
+ */
+export async function synthesizeFromArtifacts(ventureId, supabase, logger = console) {
+  // 1. Skip if SRIP data already exists (manual or prior synthesis)
+  const exists = await hasExistingSripData(ventureId, supabase);
+  if (exists) {
+    logger.log('[SRIP-Synth] Existing SRIP data found — skipping synthesis');
+    return { synthesized: false };
+  }
+
+  // 2. Collect stage artifacts
+  const artifacts = await collectArtifacts(ventureId, supabase);
+  if (!artifacts) {
+    logger.log('[SRIP-Synth] Stage 1 data missing — cannot synthesize');
+    return { synthesized: false };
+  }
+
+  logger.log('[SRIP-Synth] Collected artifacts from stages:', Object.keys(artifacts).join(', '));
+
+  // 3. Map to synthetic DNA
+  const syntheticDna = mapArtifactsToDna(artifacts);
+
+  // 4. Generate interview defaults
+  const { answers, prePopulatedCount } = generateInterviewDefaults(syntheticDna);
+  logger.log(`[SRIP-Synth] Generated ${prePopulatedCount}/12 interview defaults`);
+
+  // 5. Persist srip_site_dna
+  const { data: dnaRow, error: dnaError } = await supabase
+    .from('srip_site_dna')
+    .insert({
+      venture_id: ventureId,
+      reference_url: `synthesized://artifacts/${ventureId}`,
+      dna_json: syntheticDna,
+      status: 'completed',
+      quality_score: 60, // Synthetic data scores lower than forensic audit
+      created_by: SOURCE_TAG,
+    })
+    .select('id')
+    .single();
+
+  if (dnaError) throw new Error(`SRIP DNA insert failed: ${dnaError.message}`);
+
+  // 6. Persist srip_brand_interviews
+  const { error: interviewError } = await supabase
+    .from('srip_brand_interviews')
+    .insert({
+      venture_id: ventureId,
+      site_dna_id: dnaRow.id,
+      answers,
+      pre_populated_count: prePopulatedCount,
+      manual_input_count: 0,
+      status: 'completed',
+      created_by: SOURCE_TAG,
+    });
+
+  if (interviewError) throw new Error(`SRIP interview insert failed: ${interviewError.message}`);
+
+  logger.log('[SRIP-Synth] Synthesis complete — DNA and interview persisted');
+  return { synthesized: true, siteDnaId: dnaRow.id, prePopulatedCount };
+}
+
+// For testing
+export { collectArtifacts, mapArtifactsToDna, hasExistingSripData, inferPrimaryColor };

--- a/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-10-customer-brand.js
@@ -20,11 +20,13 @@ let sripSiteDna = null;
 let sripBrandInterview = null;
 let sripPromptBuilder = null;
 let sripQualityCheck = null;
+let sripArtifactSynthesizer = null;
 try {
   sripSiteDna = await import('../../services/srip-site-dna.js');
   sripBrandInterview = await import('../../services/srip-brand-interview.js');
   sripPromptBuilder = await import('../../services/srip-prompt-builder.js');
   sripQualityCheck = await import('../../services/srip-quality-check.js');
+  sripArtifactSynthesizer = await import('../../services/srip-artifact-synthesizer.js');
 } catch {
   // SRIP modules not available — enrichment disabled, standalone LLM path used
 }
@@ -192,6 +194,18 @@ export async function analyzeStage10({ stage1Data, stage3Data, stage5Data, stage
   logger.log('[Stage10] Starting customer & brand foundation analysis', { ventureName });
   if (!stage1Data?.description) {
     throw new Error('Stage 10 customer & brand requires Stage 1 data with description');
+  }
+
+  // ── SRIP Auto-Synthesis (runs before enrichment check) ─────────
+  if (sripArtifactSynthesizer && supabase && ventureId) {
+    try {
+      const synthResult = await sripArtifactSynthesizer.synthesizeFromArtifacts(ventureId, supabase, logger);
+      if (synthResult.synthesized) {
+        logger.log('[Stage10-SRIP-Synth] Auto-synthesized SRIP data from stage artifacts');
+      }
+    } catch (err) {
+      logger.warn?.('[Stage10-SRIP-Synth] Synthesis failed — continuing with existing data', { error: err.message });
+    }
   }
 
   // ── SRIP Enrichment Check ──────────────────────────────────────

--- a/tests/unit/srip/srip-artifact-synthesizer.test.js
+++ b/tests/unit/srip/srip-artifact-synthesizer.test.js
@@ -1,0 +1,122 @@
+/**
+ * Tests for SRIP Artifact Synthesizer
+ * SD: SD-MAN-INFRA-SRIP-AUTO-SYNTHESIZER-001
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mapArtifactsToDna, inferPrimaryColor } from '../../../lib/eva/services/srip-artifact-synthesizer.js';
+
+describe('srip-artifact-synthesizer', () => {
+  describe('mapArtifactsToDna', () => {
+    it('maps full artifact set to dna_json', () => {
+      const artifacts = {
+        1: {
+          description: 'An AI-powered fitness coaching app that personalizes workout plans',
+          valueProp: 'Personalized AI coaching for everyone',
+          archetype: 'Hero',
+          ventureType: 'health',
+          targetMarket: 'Health-conscious adults 25-45',
+        },
+        3: { overallScore: 72, decision: 'GO' },
+        4: {
+          competitors: [
+            { name: 'FitBod', url: 'https://fitbod.me' },
+            { name: 'Noom', url: 'https://noom.com' },
+          ],
+        },
+        5: { year1: { revenue: 50000 }, revenueStreams: ['subscriptions'] },
+        8: {
+          customerSegments: { items: ['Busy professionals', 'Fitness beginners', 'Athletes'] },
+          valuePropositions: { items: ['AI-personalized workout plans'] },
+          channels: { items: ['App Store', 'Social Media', 'Influencer partnerships'] },
+          customerRelationships: { items: ['Automated coaching', 'Community forum'] },
+        },
+      };
+
+      const dna = mapArtifactsToDna(artifacts);
+
+      // design_tokens
+      expect(dna.design_tokens.colors.primary).toBe('#1a56db'); // Hero archetype = trust blue (archetype > ventureType)
+      expect(dna.design_tokens.typography.font_family).toContain('sans-serif');
+
+      // copy_patterns
+      expect(dna.copy_patterns.tone).toContain('Hero');
+      expect(dna.copy_patterns.headings).toContain('Personalized AI coaching for everyone');
+      expect(dna.copy_patterns.ctas.length).toBeGreaterThan(0);
+      expect(dna.copy_patterns.word_count).toBeGreaterThan(0);
+
+      // macro_architecture
+      expect(dna.macro_architecture.page_flow).toBe('multi-section'); // 3 segments
+      expect(dna.macro_architecture.responsive_approach).toBe('mobile-first');
+
+      // component_behaviors
+      expect(dna.component_behaviors.components.length).toBeGreaterThanOrEqual(2);
+      const types = dna.component_behaviors.components.map(c => c.type);
+      expect(types).toContain('form'); // customerRelationships present
+      expect(types).toContain('card_grid'); // competitors present
+
+      // tech_stack
+      expect(dna.tech_stack.framework).toBe('react');
+
+      // metadata
+      expect(dna._source).toBe('artifact_synthesis');
+      expect(dna._stage_sources).toEqual(expect.arrayContaining([1, 3, 4, 5, 8]));
+    });
+
+    it('maps partial artifacts (only stage 1)', () => {
+      const artifacts = {
+        1: {
+          description: 'A simple budgeting app',
+          valueProp: 'Budget smarter',
+        },
+      };
+
+      const dna = mapArtifactsToDna(artifacts);
+
+      expect(dna.copy_patterns.headings).toContain('Budget smarter');
+      expect(dna.copy_patterns.ctas).toContain('Get Started'); // Default B2C
+      expect(dna.component_behaviors.components.length).toBe(0); // No stage 4/8 data
+      expect(dna._stage_sources).toEqual([1]);
+    });
+
+    it('detects B2B ventures from customer segments', () => {
+      const artifacts = {
+        1: { description: 'Enterprise SaaS platform' },
+        8: {
+          customerSegments: { items: ['Enterprise IT teams', 'B2B SaaS companies'] },
+        },
+      };
+
+      const dna = mapArtifactsToDna(artifacts);
+
+      expect(dna.copy_patterns.ctas).toContain('Contact Sales');
+      expect(dna.design_tokens.typography.font_family).toBe('Inter, sans-serif');
+    });
+  });
+
+  describe('inferPrimaryColor', () => {
+    it('returns trust blue for Hero archetype', () => {
+      expect(inferPrimaryColor('Hero', '')).toBe('#1a56db');
+    });
+
+    it('returns creative purple for Creator archetype', () => {
+      expect(inferPrimaryColor('Creator', '')).toBe('#7c3aed');
+    });
+
+    it('returns growth green for health ventures', () => {
+      expect(inferPrimaryColor('', 'health')).toBe('#059669');
+    });
+
+    it('returns trust blue for fintech ventures', () => {
+      expect(inferPrimaryColor('', 'fintech')).toBe('#1a56db');
+    });
+
+    it('returns default blue when no match', () => {
+      expect(inferPrimaryColor('', '')).toBe('#1a56db');
+    });
+
+    it('prioritizes archetype over venture type', () => {
+      expect(inferPrimaryColor('Creator', 'fintech')).toBe('#7c3aed');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Create `srip-artifact-synthesizer.js` that maps stage 1-9 artifacts into synthetic SRIP dna_json format
- Wire auto-synthesizer into `stage-10-customer-brand.js` before `checkSripEnrichment()` with try/catch guard
- Enable SRIP enrichment for all auto-discovered ventures without requiring a manual reference URL
- Export from services barrel (`index.js`)

## Key Design Decisions
- **Idempotent**: Skips synthesis if SRIP data already exists (manual or prior synthesis)
- **Non-blocking**: Synthesis failure never crashes Stage 10 — falls back to standalone LLM
- **Source tagging**: `source=artifact_synthesis` distinguishes from real forensic audit DNA

## Test plan
- [x] 9 unit tests covering mapArtifactsToDna, inferPrimaryColor, full/partial/B2B artifact sets
- [x] All tests passing
- [x] LEAD-TO-PLAN: 94%, PLAN-TO-EXEC: 85%, PLAN-TO-LEAD: 89%, LEAD-FINAL: 97%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>