### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PAT-AUTO-077): prevent Claude model names reaching Google API

### DIFF
--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -88,7 +88,16 @@ function addOpenAICompatLayer(adapter) {
         const userPrompt = userMsg?.content || '';
 
         const options = {};
-        if (model) options.model = model;
+        // Only pass model override if compatible with the adapter's provider.
+        // Prevents Claude/OpenAI model names from being sent to Google Gemini API
+        // which causes 404 errors (PAT-AUTO-c9b12816).
+        if (model) {
+          const isGoogleAdapter = adapter.provider === 'google';
+          const isCrossProviderModel = /^claude-|^gpt-|^o1-|^o3-/.test(model);
+          if (!(isGoogleAdapter && isCrossProviderModel)) {
+            options.model = model;
+          }
+        }
         if (max_completion_tokens) options.maxTokens = max_completion_tokens;
         if (max_tokens) options.maxTokens = max_tokens;
         if (temperature !== undefined) options.temperature = temperature;


### PR DESCRIPTION
## Summary
- Add cross-provider model name guard in `addOpenAICompatLayer()` 
- Filters `claude-*`, `gpt-*`, `o1-*`, `o3-*` model names when adapter is Google
- Prevents Google Gemini API 404 errors (PAT-AUTO-c9b12816, 3 occurrences)
- ~10 LOC change in `lib/sub-agents/vetting/provider-adapters.js`

## Test plan
- [x] Claude model names filtered for Google adapter
- [x] Gemini model overrides still pass through
- [x] Other adapters unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)