### PR TITLE
chore: ship accumulated fixes and artifacts

### DIFF
--- a/docs/guides/workflow/venture-stage-governance.md
+++ b/docs/guides/workflow/venture-stage-governance.md
@@ -1,0 +1,313 @@
+---
+category: Guide
+status: Approved
+version: 1.0.0
+author: Claude Code
+last_updated: 2026-03-23
+tags: [governance, auto-proceed, chairman-config, workers, gates, venture-workflow]
+---
+
+# Venture Stage Governance
+
+How ventures advance through the 26-stage lifecycle, how gates are evaluated, and how the chairman controls auto-approval behavior.
+
+## Architecture Overview
+
+```
+Chairman Dashboard (frontend)
+    │
+    ├── StageSettingsSheet.tsx ──► chairman_dashboard_config (DB)
+    │                                  │
+    │                                  ├── global_auto_proceed (boolean)
+    │                                  ├── hard_gate_stages (integer[])
+    │                                  └── stage_overrides (JSONB)
+    │
+    ▼
+Stage Execution Worker (backend)
+    │
+    ├── _loadChairmanConfig() ──► reads all 3 fields (cached 30s)
+    ├── _shouldAutoApproveStage(N) ──► evaluates 3-layer model
+    │
+    ├── processStage() ──► orchestrator (eva-orchestrator.js)
+    │       │
+    │       ├── chairmanConfig bypass ──► skips gates when auto-approved
+    │       ├── gate evaluation ──► kill gates, promotion gates, reality gates
+    │       └── filter engine ──► AUTO_PROCEED / REQUIRE_REVIEW / STOP
+    │
+    └── _handleChairmanGate() ──► worker-level gate approval
+```
+
+## Three-Layer Governance Model
+
+The chairman controls venture progression through three configurable layers in `chairman_dashboard_config`:
+
+### Layer 1: Global Auto-Proceed (`global_auto_proceed`)
+
+Master toggle. When `true`, ventures auto-advance through stages without pausing for chairman approval. When `false`, every gate stage blocks.
+
+### Layer 2: Per-Stage Overrides (`stage_overrides`)
+
+JSONB field set via the Settings panel (gear icon, top-right of venture detail page). Each stage can be individually paused:
+
+```json
+{
+  "stage_3": {
+    "auto_proceed": false,
+    "reason": "Requires manual kill gate review",
+    "set_by": "chairman",
+    "set_at": "2026-03-23T06:00:00.000Z"
+  }
+}
+```
+
+When `auto_proceed: false`, that stage always blocks regardless of the global toggle.
+
+### Layer 3: Hard Gate Stages (`hard_gate_stages`)
+
+Integer array of stages that can **never** be auto-approved, regardless of both global toggle and per-stage overrides. Managed via the Chairman Settings page Gates tab.
+
+```sql
+-- Example: only stage 17 is a hard gate
+UPDATE chairman_dashboard_config
+SET hard_gate_stages = ARRAY[17]
+WHERE config_key = 'default';
+```
+
+### Evaluation Priority
+
+The worker evaluates `_shouldAutoApproveStage(stageNumber)`:
+
+```
+  1. global_auto_proceed = false?     → BLOCK (nothing auto-approves)
+  2. stageNumber in hard_gate_stages? → BLOCK (never auto-approved)
+  3. stage_overrides[stage_N].auto_proceed = false? → BLOCK (chairman paused)
+  4. All checks pass                  → AUTO-APPROVE
+```
+
+**Important**: Autonomy levels (L2+) are evaluated separately in `_handleChairmanGate()` BEFORE the three-layer check. A venture at L2+ will auto-approve via autonomy even if `global_auto_proceed=false`. The chairman config is the fallback for L0/L1 ventures.
+
+### Orchestrator Chairman Bypass
+
+The orchestrator's chairman bypass checks BOTH the current stage and the next stage against `hard_gate_stages`. This means marking stage N as a hard gate prevents BOTH entering stage N and leaving stage N.
+
+### Failure Recovery
+
+Ventures in FAILED state are automatically recovered to IDLE by the worker on each poll cycle. This prevents transient errors (network timeouts, DB hiccups) from permanently stalling ventures.
+
+## Gate Types
+
+| Gate Type | Stages | Behavior |
+|-----------|--------|----------|
+| **Kill Gates** | 3, 5, 13, 24 | Go/no-go venture termination checkpoints |
+| **Promotion Gates** | 10, 17, 18, 23, 25 | Phase boundary advancement approval |
+| **Review-Mode** | 7, 8, 9, 11 | Pause for review before auto-advancing |
+| **Existing Gates** | 5→6, 22→23, 23→24 | Artifact-based validation (financial viability, UAT, deployment health) |
+
+Gate constants are defined in `lib/eva/gate-constants.js`.
+
+## Orchestrator Chairman Bypass
+
+When `global_auto_proceed=true` and the next stage is not a hard gate or paused stage, the orchestrator **skips gate evaluation entirely**:
+
+- No kill/promotion gate evaluation (avoids BLOCKED return)
+- No reality gate evaluation
+- No devil's advocate LLM call (saves cost and time)
+- processStage returns COMPLETED directly
+
+This prevents the BLOCKED → fix-up cycle where the orchestrator returns BLOCKED and the worker has to override it.
+
+## Stage Execution Worker
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `lib/eva/stage-execution-worker.js` | Worker class — polling, gate handling, stage advancement |
+| `scripts/start-stage-worker.js` | Supervisor entry point — process management, dedup, circuit breaker |
+| `lib/eva/eva-orchestrator.js` | Core stage processing — template execution, gate evaluation, filter engine |
+| `lib/eva/gate-constants.js` | Gate stage definitions (kill, promotion, review, operating modes) |
+| `lib/eva/autonomy-model.js` | L0-L4 autonomy levels and gate behavior matrix |
+| `config/workers.json` | Worker registry for LEO stack |
+
+### Worker Lifecycle
+
+```
+start-stage-worker.js (supervisor mode)
+    │
+    ├── killExistingWorkers() ──► finds & kills zombie workers (WMIC/pgrep)
+    ├── writePid(process.pid) ──► tracks supervisor PID (not child)
+    ├── fork('--direct') ──► spawns child worker
+    │
+    └── On child exit:
+        ├── Circuit breaker (5 restarts in 10min → 60s cooldown)
+        └── Exponential backoff (1s, 2s, 4s, 8s, 16s, capped 30s)
+```
+
+### Worker Version & Heartbeats
+
+Every heartbeat includes version and start time for diagnosability:
+
+```json
+{
+  "worker_id": "sew-Legion-Laptop-36152",
+  "status": "online",
+  "metadata": {
+    "codeVersion": "1.3.0",
+    "startedAt": "2026-03-23T06:22:29.429Z",
+    "uptime": 3600,
+    "activeVentures": 1,
+    "pollIntervalMs": 30000
+  }
+}
+```
+
+Query live workers:
+```sql
+SELECT pid, status, metadata->>'codeVersion' as version,
+       metadata->>'startedAt' as started,
+       last_heartbeat_at
+FROM worker_heartbeats
+WHERE worker_type = 'stage-execution-worker'
+  AND status = 'online'
+ORDER BY last_heartbeat_at DESC;
+```
+
+### Zombie Worker Prevention
+
+Three layers of defense:
+
+1. **Startup dedup** (`killExistingWorkers` in `start-stage-worker.js`): On startup, finds all node processes running `start-stage-worker` via WMIC (Windows) or pgrep (Unix) and kills them with process tree kill.
+
+2. **Stale heartbeat cleanup** (`_markStaleWorkersOnHost`): On startup, marks any "online" workers on the same host whose heartbeat is older than 2 poll intervals as "stopped".
+
+3. **Process tree kill** (`leo-stack.ps1` / `leo-stack.sh`): Uses `taskkill /T /F` (Windows) or `kill -TERM -- -$pid` (Unix) to kill entire process trees, preventing orphaned children.
+
+### PID File Tracking
+
+The supervisor writes its **own** PID to the PID file (not the child's). When `leo-stack stop` kills the supervisor, the `process.on('exit')` handler propagates SIGKILL to the child.
+
+## Venture Progression Flow
+
+### Normal Stage (no gate)
+
+```
+Worker polls → acquires lock → processStage()
+  → template execution → artifacts persisted
+  → gates bypassed (chairman auto-approve)
+  → filter engine → AUTO_PROCEED
+  → advanceStage() → next stage
+```
+
+### Gate Stage (with auto-approve)
+
+```
+Worker polls → acquires lock → processStage()
+  → template execution → artifacts persisted
+  → chairman bypass active → gates skipped
+  → filter engine → AUTO_PROCEED
+  → advanceStage() → next stage
+  → _handleChairmanGate auto-approves
+  → stage_work updated to 'completed'
+  → pending decisions approved
+```
+
+### Gate Stage (manual approval required)
+
+```
+Worker polls → acquires lock → processStage()
+  → template execution → artifacts persisted
+  → gate evaluation → BLOCKED
+  → worker creates chairman_decisions row
+  → venture released as BLOCKED
+  → Chairman approves via UI
+  → trg_chairman_decision_unblock trigger → sets orchestrator_state='idle'
+  → Next poll picks up venture → advances
+```
+
+### Operating Mode Boundaries
+
+Ventures pause at mode transitions:
+
+| Mode | Stages | Entry Gate |
+|------|--------|------------|
+| EVALUATION | 1-5 | — |
+| STRATEGY | 6-12 | Stage 5→6 boundary |
+| PLANNING | 13-17 | Stage 12→13 boundary |
+| BUILD | 18-22 | Stage 17→18 boundary |
+| LAUNCH | 23-26 | Stage 22→23 boundary |
+
+The worker detects mode changes and releases the venture as IDLE, picking it up again on the next poll cycle.
+
+## Database Tables
+
+### `chairman_dashboard_config`
+
+| Column | Type | Purpose |
+|--------|------|---------|
+| `config_key` | text | Always `'default'` |
+| `global_auto_proceed` | boolean | Master auto-approve toggle |
+| `hard_gate_stages` | integer[] | Stages that never auto-approve |
+| `stage_overrides` | JSONB | Per-stage pause/resume config |
+
+### `chairman_decisions`
+
+Created at gate stages when manual approval is required. The `trg_chairman_approval_unblock_orchestrator` trigger automatically sets `orchestrator_state='idle'` when a decision is approved.
+
+### `worker_heartbeats`
+
+Workers upsert heartbeats every poll cycle. Stale heartbeats (>2 poll intervals) indicate dead workers.
+
+### `venture_stage_work`
+
+Stage-level status tracking for the frontend. Updated by `_syncStageWork` after processStage returns.
+
+### `stage_executions`
+
+Per-attempt execution records with heartbeat tracking. Used for stale lock detection.
+
+## Common Operations
+
+### Check Fleet Status
+```bash
+# All active ventures with current state
+SELECT name, current_lifecycle_stage, orchestrator_state, status
+FROM ventures WHERE status = 'active'
+ORDER BY current_lifecycle_stage DESC;
+```
+
+### Unblock a Stuck Venture
+```bash
+# 1. Approve any pending decisions
+UPDATE chairman_decisions
+SET status = 'approved', decision = 'proceed', blocking = false
+WHERE venture_id = '<ID>' AND status = 'pending';
+
+# 2. Reset orchestrator state
+UPDATE ventures SET orchestrator_state = 'idle' WHERE id = '<ID>';
+```
+
+### Change Auto-Approve Configuration
+```bash
+# Auto-approve everything except stage 17
+UPDATE chairman_dashboard_config
+SET global_auto_proceed = true,
+    hard_gate_stages = ARRAY[17],
+    stage_overrides = '{}'
+WHERE config_key = 'default';
+```
+
+### Check Worker Health
+```bash
+SELECT pid, metadata->>'codeVersion' as version,
+       ROUND(EXTRACT(EPOCH FROM (NOW() - last_heartbeat_at))) as secs_since_heartbeat
+FROM worker_heartbeats
+WHERE worker_type = 'stage-execution-worker' AND status = 'online'
+ORDER BY last_heartbeat_at DESC;
+```
+
+## Related Documentation
+
+- [Worker Registry Guide](../../reference/worker-registry-guide.md) — adding/configuring workers
+- [EVA Orchestrator](./cli-venture-lifecycle/02-eva-orchestrator.md) — processStage internals
+- [Chairman Decisions](./cli-venture-lifecycle/reference/chairman-decisions.md) — decision model
+- [Gate Thresholds](./cli-venture-lifecycle/reference/gate-thresholds.md) — filter engine thresholds

--- a/lib/eva/gate-constants.js
+++ b/lib/eva/gate-constants.js
@@ -1,0 +1,55 @@
+/**
+ * Gate Constants — Single Source of Truth
+ *
+ * Shared gate stage definitions used by both stage-execution-worker.js
+ * and stage-gates.js. Any change to gate stage membership MUST be made
+ * here, not in consuming modules.
+ *
+ * @module lib/eva/gate-constants
+ */
+
+/**
+ * Kill gate stages — checkpoints where ventures may be terminated.
+ * Must always require manual chairman review regardless of autonomy level.
+ * Synced with frontend: KILL_GATE_STAGES in venture-workflow.ts
+ */
+export const KILL_GATE_STAGES = new Set([3, 5, 13, 24]);
+
+/**
+ * Promotion gate stages — checkpoints where ventures need chairman
+ * approval to advance to the next operating mode.
+ * Manual at L0-L1, auto at L2+.
+ */
+export const PROMOTION_GATE_STAGES = new Set([10, 17, 18, 23, 25]);
+
+/**
+ * Chairman gate stages where pipeline pauses for human decision.
+ * BLOCKING = union of KILL_GATE_STAGES and PROMOTION_GATE_STAGES.
+ */
+export const CHAIRMAN_GATES = Object.freeze({
+  BLOCKING: new Set([3, 5, 10, 13, 17, 18, 23, 24, 25]),
+});
+
+/**
+ * Review-mode stages: worker pauses for chairman review before auto-advancing.
+ * Stage 10 is already a BLOCKING gate, so it doesn't need review mode.
+ * Synced with frontend: venture-workflow.ts reviewMode === 'review'
+ */
+export const REVIEW_MODE_STAGES = new Set([7, 8, 9, 11]);
+
+/**
+ * Maximum pipeline stage number.
+ */
+export const MAX_STAGE = 26;
+
+/**
+ * Operating mode boundaries — entering a new mode requires all prior
+ * stages in the previous mode to be complete.
+ */
+export const OPERATING_MODES = Object.freeze({
+  EVALUATION: { start: 1, end: 5 },
+  STRATEGY:   { start: 6, end: 12 },
+  PLANNING:   { start: 13, end: 17 },
+  BUILD:      { start: 18, end: 22 },
+  LAUNCH:     { start: 23, end: 26 },
+});

--- a/lib/eva/services/product-hunt-client.js
+++ b/lib/eva/services/product-hunt-client.js
@@ -120,7 +120,7 @@ function getSupabase() {
 export async function searchProductHuntByCategory(category, limit = 10) {
   if (!category) return [];
 
-  const token = process.env.PRODUCT_HUNT_TOKEN;
+  const token = process.env.PRODUCT_HUNT_API_TOKEN;
 
   if (token) {
     return _fetchFromApi(category, limit, token);

--- a/scripts/archive/one-time/create-user-stories-srip-wireframe-frontend-001.cjs
+++ b/scripts/archive/one-time/create-user-stories-srip-wireframe-frontend-001.cjs
@@ -1,0 +1,439 @@
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+(async () => {
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  // Step 1: Probe schema
+  const { data: probe, error: probeErr } = await supabase
+    .from('user_stories')
+    .select('*')
+    .limit(1);
+
+  if (probeErr) {
+    console.error('Schema probe failed:', probeErr);
+    process.exit(1);
+  }
+
+  if (probe && probe.length > 0) {
+    console.log('User stories columns:', Object.keys(probe[0]).join(', '));
+  } else {
+    console.log('Table exists but empty; proceeding with known schema.');
+  }
+
+  const SD_ID = 'a9790c5e-0fd1-410c-9302-374856bf88ec';
+  const PRD_ID = '76e48d09-a6d2-493f-94e2-1afff8c2d082';
+  const SD_KEY = 'SD-LEO-FEAT-SRIP-WIREFRAME-FRONTEND-001';
+
+  const stories = [
+    {
+      story_key: `${SD_KEY}:US-001`,
+      sd_id: SD_ID,
+      prd_id: PRD_ID,
+      title: 'WireframeViewer renders ASCII wireframe layouts',
+      user_role: 'Chairman',
+      user_want: 'to view SRIP wireframe layouts as rendered ASCII art in the dashboard so I can review proposed UI structures',
+      user_benefit: 'I can visually assess and approve wireframe designs without requiring external tools or design software',
+      given_when_then: [
+        {
+          id: 'AC-001-1',
+          scenario: 'Happy path - Wireframe data renders correctly',
+          given: 'WireframeViewer component receives valid ASCII wireframe data from the SRIP pipeline',
+          when: 'The component mounts and renders',
+          then: 'ASCII wireframe is displayed in a monospace font container with correct alignment and spacing preserved'
+        },
+        {
+          id: 'AC-001-2',
+          scenario: 'Multiple wireframe sections render in sequence',
+          given: 'Wireframe data contains multiple page/section layouts',
+          when: 'WireframeViewer renders the data',
+          then: 'Each section is rendered with clear visual separation and section labels'
+        },
+        {
+          id: 'AC-001-3',
+          scenario: 'Error path - Invalid wireframe data',
+          given: 'WireframeViewer receives malformed or null wireframe data',
+          when: 'The component attempts to render',
+          then: 'A descriptive error message is shown instead of a blank screen or crash'
+        }
+      ],
+      acceptance_criteria: [
+        'WireframeViewer.tsx renders ASCII layouts in monospace font container',
+        'Alignment and spacing of ASCII art is preserved',
+        'Multiple sections render with visual separation',
+        'Malformed data shows error message, not blank/crash'
+      ],
+      story_points: 3,
+      priority: 'critical',
+      status: 'ready',
+      implementation_context: {
+        description: 'Create WireframeViewer.tsx component that renders ASCII wireframe layouts from SRIP pipeline data',
+        key_files: [
+          'src/components/chairman-v2/WireframeViewer.tsx'
+        ],
+        approach: 'Pre-formatted block with monospace font, split multi-section data, handle null/malformed gracefully'
+      },
+      testing_scenarios: {
+        test_cases: [
+          { id: 'TC-001', scenario: 'Valid wireframe renders correctly', priority: 'P0' },
+          { id: 'TC-002', scenario: 'Multi-section wireframe renders with separators', priority: 'P1' },
+          { id: 'TC-003', scenario: 'Null/malformed data shows error state', priority: 'P0' }
+        ]
+      },
+      technical_notes: ['Use <pre> or CSS white-space:pre for ASCII fidelity', 'Monospace font stack: Fira Code, Consolas, monospace'],
+      depends_on: [],
+      blocks: []
+    },
+    {
+      story_key: `${SD_KEY}:US-002`,
+      sd_id: SD_ID,
+      prd_id: PRD_ID,
+      title: 'SripDashboard displays SRIP brand interview data',
+      user_role: 'Chairman',
+      user_want: 'to see SRIP brand interview results organized in a dashboard view so I can understand the brand positioning research at a glance',
+      user_benefit: 'I can make informed strategic decisions based on consolidated brand interview insights without manually parsing raw data',
+      given_when_then: [
+        {
+          id: 'AC-002-1',
+          scenario: 'Happy path - Dashboard loads interview data',
+          given: 'SripDashboard component receives SRIP brand interview data from the API',
+          when: 'The dashboard mounts',
+          then: 'Interview data is displayed in organized sections showing key brand attributes, themes, and interview summaries'
+        },
+        {
+          id: 'AC-002-2',
+          scenario: 'Dashboard shows structured brand metrics',
+          given: 'Interview data includes quantitative brand metrics and qualitative themes',
+          when: 'SripDashboard renders the data',
+          then: 'Metrics are displayed with appropriate visual indicators and themes are grouped by category'
+        },
+        {
+          id: 'AC-002-3',
+          scenario: 'Edge case - Partial interview data',
+          given: 'Some interview fields are missing or incomplete',
+          when: 'SripDashboard renders',
+          then: 'Available data is displayed and missing sections show appropriate placeholder text rather than broken layout'
+        }
+      ],
+      acceptance_criteria: [
+        'SripDashboard.tsx displays brand interview data in organized sections',
+        'Key brand attributes and themes are grouped and labeled',
+        'Quantitative metrics shown with visual indicators',
+        'Partial/missing data renders gracefully with placeholders'
+      ],
+      story_points: 3,
+      priority: 'critical',
+      status: 'ready',
+      implementation_context: {
+        description: 'Create SripDashboard.tsx that displays SRIP brand interview data with structured sections for attributes, themes, and summaries',
+        key_files: [
+          'src/components/chairman-v2/SripDashboard.tsx'
+        ],
+        approach: 'Card-based layout with sections for metrics, themes, and summaries; handle partial data with conditional rendering'
+      },
+      testing_scenarios: {
+        test_cases: [
+          { id: 'TC-001', scenario: 'Full interview data renders all sections', priority: 'P0' },
+          { id: 'TC-002', scenario: 'Partial data shows placeholders', priority: 'P1' },
+          { id: 'TC-003', scenario: 'Empty data shows empty state', priority: 'P0' }
+        ]
+      },
+      technical_notes: ['Use Shadcn Card components for section layout', 'Consider collapsible sections for lengthy interview content'],
+      depends_on: [],
+      blocks: []
+    },
+    {
+      story_key: `${SD_KEY}:US-003`,
+      sd_id: SD_ID,
+      prd_id: PRD_ID,
+      title: 'Navigation flow visualization in WireframeViewer',
+      user_role: 'Chairman',
+      user_want: 'to see how screens connect and flow between each other in the wireframe viewer so I can evaluate the proposed user journey',
+      user_benefit: 'I can validate navigation logic and user flow before development begins, catching UX issues early',
+      given_when_then: [
+        {
+          id: 'AC-003-1',
+          scenario: 'Happy path - Navigation flow arrows render',
+          given: 'Wireframe data includes navigation flow metadata linking screens together',
+          when: 'WireframeViewer renders with flow visualization enabled',
+          then: 'Directional indicators (arrows or connectors) show navigation paths between wireframe sections'
+        },
+        {
+          id: 'AC-003-2',
+          scenario: 'Interactive flow navigation',
+          given: 'Multiple screens with navigation connections are displayed',
+          when: 'User clicks on a navigation indicator or target screen label',
+          then: 'The view scrolls to or highlights the connected wireframe section'
+        },
+        {
+          id: 'AC-003-3',
+          scenario: 'Edge case - No flow data available',
+          given: 'Wireframe data does not include navigation flow metadata',
+          when: 'WireframeViewer renders',
+          then: 'Wireframes render normally without flow indicators and no error is thrown'
+        }
+      ],
+      acceptance_criteria: [
+        'Navigation flow arrows/connectors render between linked wireframe sections',
+        'Clicking a flow indicator scrolls to or highlights the target section',
+        'Flow visualization degrades gracefully when no flow metadata exists',
+        'Flow direction is visually clear (source -> target)'
+      ],
+      story_points: 2,
+      priority: 'critical',
+      status: 'ready',
+      implementation_context: {
+        description: 'Add navigation flow visualization to WireframeViewer showing connections between screens',
+        key_files: [
+          'src/components/chairman-v2/WireframeViewer.tsx'
+        ],
+        approach: 'Parse flow metadata from wireframe data, render directional connectors between sections, add click-to-navigate behavior'
+      },
+      testing_scenarios: {
+        test_cases: [
+          { id: 'TC-001', scenario: 'Flow arrows render between connected screens', priority: 'P0' },
+          { id: 'TC-002', scenario: 'Click navigates to target section', priority: 'P1' },
+          { id: 'TC-003', scenario: 'No flow metadata renders wireframes without errors', priority: 'P0' }
+        ]
+      },
+      technical_notes: ['Use CSS-based arrows or SVG connectors for flow indicators', 'scrollIntoView for click-to-navigate'],
+      depends_on: [],
+      blocks: []
+    },
+    {
+      story_key: `${SD_KEY}:US-004`,
+      sd_id: SD_ID,
+      prd_id: PRD_ID,
+      title: 'ARTIFACT_ICONS extended for SRIP types',
+      user_role: 'EVA System',
+      user_want: 'SRIP-specific artifact types to have dedicated icons in the artifact icon registry so they are visually distinct from other artifact types',
+      user_benefit: 'Users can quickly identify SRIP artifacts (wireframes, brand interviews, navigation flows) by their unique icons in any artifact listing',
+      given_when_then: [
+        {
+          id: 'AC-004-1',
+          scenario: 'Happy path - SRIP artifact icons registered',
+          given: 'ARTIFACT_ICONS constant/map is defined in the codebase',
+          when: 'A new SRIP artifact type (wireframe, brand_interview, navigation_flow) is referenced',
+          then: 'The corresponding SRIP-specific icon is returned from the registry'
+        },
+        {
+          id: 'AC-004-2',
+          scenario: 'Icons render in artifact listings',
+          given: 'An artifact list includes SRIP-type artifacts',
+          when: 'The list renders each artifact row',
+          then: 'SRIP artifacts display their dedicated icons and non-SRIP artifacts continue using their existing icons'
+        },
+        {
+          id: 'AC-004-3',
+          scenario: 'Edge case - Unknown SRIP sub-type',
+          given: 'An SRIP artifact has a sub-type not yet in the registry',
+          when: 'The icon lookup occurs',
+          then: 'A generic SRIP fallback icon is returned rather than undefined or a broken image'
+        }
+      ],
+      acceptance_criteria: [
+        'ARTIFACT_ICONS includes entries for wireframe, brand_interview, and navigation_flow types',
+        'Each SRIP type has a visually distinct icon',
+        'Unknown SRIP sub-types fall back to a generic SRIP icon',
+        'Existing non-SRIP artifact icons are unaffected'
+      ],
+      story_points: 1,
+      priority: 'high',
+      status: 'ready',
+      implementation_context: {
+        description: 'Extend ARTIFACT_ICONS constant with SRIP-specific icon mappings for wireframe, brand_interview, and navigation_flow',
+        key_files: [
+          'src/components/chairman-v2/constants.ts'
+        ],
+        approach: 'Add new entries to ARTIFACT_ICONS map with Lucide or Shadcn icons; add SRIP fallback entry'
+      },
+      testing_scenarios: {
+        test_cases: [
+          { id: 'TC-001', scenario: 'Each SRIP type returns correct icon', priority: 'P0' },
+          { id: 'TC-002', scenario: 'Unknown sub-type returns fallback', priority: 'P1' },
+          { id: 'TC-003', scenario: 'Existing icons unchanged', priority: 'P0' }
+        ]
+      },
+      technical_notes: ['Lucide icons: Layout, MessageSquare, GitBranch as candidates', 'Ensure icon size consistency with existing entries'],
+      depends_on: [],
+      blocks: []
+    },
+    {
+      story_key: `${SD_KEY}:US-005`,
+      sd_id: SD_ID,
+      prd_id: PRD_ID,
+      title: 'Export new SRIP components from index.ts',
+      user_role: 'EVA System',
+      user_want: 'WireframeViewer and SripDashboard to be exported from the chairman-v2 index.ts barrel file so they can be imported by other modules',
+      user_benefit: 'Other parts of the application can import SRIP components through the standard barrel export pattern, maintaining codebase consistency',
+      given_when_then: [
+        {
+          id: 'AC-005-1',
+          scenario: 'Happy path - Components importable from barrel',
+          given: 'WireframeViewer.tsx and SripDashboard.tsx exist in the chairman-v2 directory',
+          when: 'Another module imports from the chairman-v2 index.ts barrel file',
+          then: 'Both WireframeViewer and SripDashboard are available as named exports'
+        },
+        {
+          id: 'AC-005-2',
+          scenario: 'TypeScript compilation succeeds',
+          given: 'index.ts includes export statements for the new SRIP components',
+          when: 'TypeScript compiler runs (tsc --noEmit)',
+          then: 'No type errors are produced and all exports resolve correctly'
+        },
+        {
+          id: 'AC-005-3',
+          scenario: 'Edge case - Tree-shaking compatibility',
+          given: 'SRIP components are exported via named exports (not default)',
+          when: 'A consuming module imports only WireframeViewer',
+          then: 'SripDashboard is not included in the bundle (tree-shakeable)'
+        }
+      ],
+      acceptance_criteria: [
+        'index.ts exports WireframeViewer and SripDashboard as named exports',
+        'TypeScript compilation passes with no errors',
+        'Named exports are tree-shakeable',
+        'Existing exports in index.ts are unchanged'
+      ],
+      story_points: 1,
+      priority: 'high',
+      status: 'ready',
+      implementation_context: {
+        description: 'Add export statements for WireframeViewer and SripDashboard to the chairman-v2 index.ts barrel file',
+        key_files: [
+          'src/components/chairman-v2/index.ts'
+        ],
+        approach: 'Add named re-exports: export { WireframeViewer } from ./WireframeViewer and export { SripDashboard } from ./SripDashboard'
+      },
+      testing_scenarios: {
+        test_cases: [
+          { id: 'TC-001', scenario: 'Named exports available from barrel', priority: 'P0' },
+          { id: 'TC-002', scenario: 'tsc --noEmit passes', priority: 'P0' }
+        ]
+      },
+      technical_notes: ['Use named exports for tree-shaking support', 'Keep alphabetical order in barrel file'],
+      depends_on: [],
+      blocks: []
+    },
+    {
+      story_key: `${SD_KEY}:US-006`,
+      sd_id: SD_ID,
+      prd_id: PRD_ID,
+      title: 'Graceful empty states for SRIP components',
+      user_role: 'Chairman',
+      user_want: 'SRIP components to show meaningful empty states when no data is available so I understand the system status rather than seeing blank screens',
+      user_benefit: 'I am never confused by blank areas in the dashboard and always know whether data is loading, unavailable, or not yet generated',
+      given_when_then: [
+        {
+          id: 'AC-006-1',
+          scenario: 'Happy path - WireframeViewer empty state',
+          given: 'WireframeViewer receives no wireframe data (null or empty array)',
+          when: 'The component renders',
+          then: 'A styled empty state is shown with an icon, a message like "No wireframes available", and a brief explanation'
+        },
+        {
+          id: 'AC-006-2',
+          scenario: 'Happy path - SripDashboard empty state',
+          given: 'SripDashboard receives no interview data',
+          when: 'The component renders',
+          then: 'A styled empty state is shown indicating no brand interview data is available with a suggestion to run the SRIP pipeline'
+        },
+        {
+          id: 'AC-006-3',
+          scenario: 'Loading state while data fetches',
+          given: 'SRIP data is being fetched from the API',
+          when: 'The component is in loading state',
+          then: 'A skeleton loader or spinner is displayed, distinct from the empty state'
+        },
+        {
+          id: 'AC-006-4',
+          scenario: 'Error state on fetch failure',
+          given: 'API call to fetch SRIP data fails with a network or server error',
+          when: 'The component handles the error',
+          then: 'An error state is shown with the error message and a retry option'
+        }
+      ],
+      acceptance_criteria: [
+        'WireframeViewer shows styled empty state with icon and message when no data',
+        'SripDashboard shows styled empty state with action suggestion when no data',
+        'Loading state shows skeleton/spinner distinct from empty state',
+        'Error state shows message and retry button on fetch failure',
+        'Empty states are visually consistent with existing chairman-v2 component patterns'
+      ],
+      story_points: 2,
+      priority: 'critical',
+      status: 'ready',
+      implementation_context: {
+        description: 'Add empty, loading, and error states to WireframeViewer and SripDashboard components',
+        key_files: [
+          'src/components/chairman-v2/WireframeViewer.tsx',
+          'src/components/chairman-v2/SripDashboard.tsx'
+        ],
+        approach: 'Use existing empty state patterns from chairman-v2 components; add loading skeleton and error boundary with retry'
+      },
+      testing_scenarios: {
+        test_cases: [
+          { id: 'TC-001', scenario: 'Null data shows empty state in WireframeViewer', priority: 'P0' },
+          { id: 'TC-002', scenario: 'Null data shows empty state in SripDashboard', priority: 'P0' },
+          { id: 'TC-003', scenario: 'Loading state shows skeleton', priority: 'P1' },
+          { id: 'TC-004', scenario: 'Error state shows message and retry', priority: 'P1' }
+        ]
+      },
+      technical_notes: ['Reuse existing empty state component if available in chairman-v2', 'Shadcn Skeleton component for loading state'],
+      depends_on: [],
+      blocks: []
+    }
+  ];
+
+  console.log(`Inserting ${stories.length} user stories for ${SD_KEY}...\n`);
+
+  let successCount = 0;
+  let failCount = 0;
+
+  for (const story of stories) {
+    const { data, error } = await supabase
+      .from('user_stories')
+      .upsert({
+        story_key: story.story_key,
+        sd_id: story.sd_id,
+        prd_id: story.prd_id,
+        title: story.title,
+        user_role: story.user_role,
+        user_want: story.user_want,
+        user_benefit: story.user_benefit,
+        given_when_then: story.given_when_then,
+        acceptance_criteria: story.acceptance_criteria,
+        story_points: story.story_points,
+        priority: story.priority,
+        status: story.status,
+        implementation_context: story.implementation_context,
+        testing_scenarios: story.testing_scenarios,
+        technical_notes: story.technical_notes,
+        depends_on: story.depends_on,
+        blocks: story.blocks,
+        validation_status: 'pending',
+        e2e_test_status: 'not_created',
+        created_by: 'STORIES-AGENT-v2.0.0'
+      }, { onConflict: 'story_key' })
+      .select('story_key, title');
+
+    if (error) {
+      console.error(`FAILED ${story.story_key}:`, error.message);
+      console.error('  Details:', JSON.stringify(error, null, 2));
+      failCount++;
+    } else {
+      console.log(`OK ${story.story_key}: ${story.title}`);
+      successCount++;
+    }
+  }
+
+  console.log(`\nResults: ${successCount} inserted, ${failCount} failed`);
+  console.log(`Total story points: ${stories.reduce((sum, s) => sum + s.story_points, 0)}`);
+
+  if (failCount > 0) {
+    process.exit(1);
+  }
+})();

--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -51,15 +51,15 @@ async function main() {
   const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
   let query = supabase
     .from('claude_sessions')
-    .select('session_id, sd_id, metadata, last_heartbeat_at')
-    .gte('last_heartbeat_at', fiveMinAgo)
+    .select('session_id, sd_id, metadata, heartbeat_at')
+    .gte('heartbeat_at', fiveMinAgo)
     .neq('status', 'terminated');
 
   if (excludeSession) {
     query = query.neq('session_id', excludeSession);
   }
 
-  const { data: workers, error } = await query.order('last_heartbeat_at', { ascending: false });
+  const { data: workers, error } = await query.order('heartbeat_at', { ascending: false });
 
   if (error) {
     console.error('Error querying workers:', error.message);
@@ -122,7 +122,7 @@ async function main() {
           payload: { color: id.color, callsign: id.callsign, display_name: expectedDisplayName },
           sender_type: 'coordinator',
           expires_at: new Date(Date.now() + 24 * 60 * 60_000).toISOString()
-        }).catch(() => { /* ignore */ });
+        });
       refreshed++;
     }
   }
@@ -148,7 +148,7 @@ async function main() {
     .delete()
     .eq('message_type', 'SET_IDENTITY')
     .lt('expires_at', new Date().toISOString())
-    .catch(() => { /* ignore */ });
+;
 
   console.log('');
   console.log(`${ANSI.bold}Fleet Identity Assignment${ANSI.reset}`);

--- a/scripts/reports/blueprint-factory-wiring-plan-2026-03-20.md
+++ b/scripts/reports/blueprint-factory-wiring-plan-2026-03-20.md
@@ -1,0 +1,131 @@
+# Blueprint Factory Wiring — Stages 14-16 Redesign + Wireframe Agent
+
+> **Date**: 2026-03-20
+> **Source**: Venture pipeline triangulation session — brainstorm + plan mode
+> **Prior Vision**: VISION-BLUEPRINT-FACTORY-L2-001 (Multi-Agent Blueprint Factory)
+> **Prior Architecture**: ARCH-BLUEPRINT-FACTORY-001
+> **Prior SDs (completed)**: SD-LEO-FIX-FIX-BLUEPRINT-STAGE-001, SD-LEO-INFRA-BLUEPRINT-TEMPLATE-SYSTEM-001, SD-LEO-INFRA-BLUEPRINT-AGENT-FACTORY-001, SD-LEO-INFRA-BLUEPRINT-QUALITY-SCORING-001, SD-LEO-INFRA-BLUEPRINT-PROMOTION-GATE-001
+> **SRIP Integration (completed)**: SD-LEO-INFRA-SRIP-CORE-PIPELINE-001, SD-LEO-FEAT-WIRE-SRIP-INTO-001
+
+## Context
+
+The Blueprint Factory infrastructure was fully built (5 completed SDs) but never wired into the stage pipeline. Stages 14-16 still use old single-agent `analyzeStageNN()` functions. The DB `lifecycle_stage_config` has wrong artifact names. A wireframe agent was specified in the vision (`VISION-BLUEPRINT-FACTORY-L2-001`) but never created.
+
+SRIP (brand genome, design DNA) is fully integrated into Stages 10-11 and feeds downstream — wireframes depend on this plus the technical architecture from S14.
+
+**Existing infrastructure (reuse, don't rebuild):**
+- 11 blueprint agents: `lib/eva/blueprint-agents/` with registry + coordinator
+- Blueprint Coordinator: `lib/eva/blueprint-coordinator.js` — topological sort + `orchestrate()`
+- Blueprint templates DB table: 11 rows with quality rubrics
+- Blueprint scoring: `lib/eva/blueprint-scoring/`
+
+**Target BLUEPRINT phase:**
+| Stage | Name | Artifacts | Gate |
+|-------|------|-----------|------|
+| S13 | Product Roadmap | `product_roadmap` | Kill |
+| S14 | Technical Architecture | `data_model`, `erd_diagram`, `technical_architecture`, `api_contract`, `schema_spec` | None |
+| S15 | Risk Register & UX Design | `risk_register`, `user_story_pack`, `wireframes` | None |
+| S16 | Financial Projections | `financial_projection` | Promotion (always manual) |
+
+---
+
+## Changes
+
+### 1. Create Wireframe Agent (~50 LOC)
+
+**Create** `lib/eva/blueprint-agents/wireframes.js`
+- `artifactType = 'wireframes'`
+- `dependencies = ['technical_architecture', 'user_story_pack']`
+- System prompt generates: `screens` array (name, purpose, ASCII layout, key_components, persona_mapping), `navigation_flows` array (from, to, trigger), `screen_count`, `persona_coverage`
+- Each screen represents a page/view of the venture's product with ASCII wireframe showing component layout
+
+**Modify** `lib/eva/blueprint-agents/index.js` — import + register
+
+**DB** — Insert `wireframes` row into `blueprint_templates` with quality rubric (screen_coverage 0.3, layout_clarity 0.25, navigation_completeness 0.25, persona_alignment 0.2)
+
+**Modify** `lib/eva/blueprint-scoring/rubric-definitions.js` — add `wireframes` entry
+
+### 2. Fix lifecycle_stage_config (DB migration)
+
+**Create** migration in `supabase/migrations/`:
+```sql
+UPDATE lifecycle_stage_config SET required_artifacts = ARRAY['data_model','erd_diagram','technical_architecture','api_contract','schema_spec'] WHERE stage_number = 14;
+UPDATE lifecycle_stage_config SET required_artifacts = ARRAY['risk_register','user_story_pack','wireframes'], stage_name = 'Risk Register & UX Design' WHERE stage_number = 15;
+UPDATE lifecycle_stage_config SET required_artifacts = ARRAY['financial_projection'] WHERE stage_number = 16;
+```
+
+### 3. Wire Coordinator into Stage Pipeline (~100-150 LOC)
+
+**Modify** `lib/eva/eva-orchestrator-helpers.js` — `loadStageTemplate()` (lines 93-164)
+
+When a stage template has a `blueprintAgents` array, build multi-step `analysisSteps` instead of wrapping a single `analysisStep`:
+
+- Use `resolveExecutionOrder()` to get dependency-sorted order, filter to the stage's subset
+- Create shared `blueprintResults` Map in closure for intra-stage dependency passing
+- Each step: call LLM with agent's `systemPrompt` + venture context + upstream results, store result in Map
+- Falls back to existing `analysisStep` path if `blueprintAgents` not present
+
+Key: the orchestrator already iterates steps sequentially (line 306), and topological sort guarantees dependencies satisfied. Cross-stage dependencies (e.g., S15's `risk_register` depends on `technical_architecture` from S14) are provided via `fetchUpstreamArtifacts()`.
+
+### 4. Update Stage Templates (~50 LOC)
+
+**Modify** `lib/eva/stage-templates/stage-14.js`
+- Add `blueprintAgents: ['data_model', 'erd_diagram', 'technical_architecture', 'api_contract', 'schema_spec']`
+- Keep existing `analysisStep` as fallback
+
+**Modify** `lib/eva/stage-templates/stage-15.js`
+- Fix title: `'Resource Planning'` → `'Risk Register & UX Design'`
+- Add `blueprintAgents: ['risk_register', 'user_story_pack', 'wireframes']`
+
+**S16 stays on old path** — single agent with integrated promotion gate. No benefit routing through coordinator.
+
+**Modify** `lib/eva/contracts/stage-contracts.js`
+- Update S14/S15 `produces` specs for new artifact types (required: false for backward compat)
+
+### 5. Promotion Gate Update (~50 LOC)
+
+**Modify** `lib/eva/stage-templates/stage-16.js` — `evaluatePromotionGateLegacy()`
+- Add checks for new S14 artifacts (api_contract, schema_spec) and S15 artifacts (user_story_pack, wireframes) — warn-only for new artifacts
+
+**Modify** `lib/eva/stage-templates/analysis-steps/stage-16-financial-projections.js`
+- Before calling `evaluatePromotionGate()`, attempt to load Blueprint Readiness Score from DB
+- Pass `readinessScore` — the score-based path already exists and takes priority
+
+### 6. Frontend (~100 LOC, ehg repo)
+
+**Modify** `ehg/src/components/artifacts/ArtifactPanel.tsx`
+- Add icon mappings: `wireframes: Layout`, `risk_register: AlertTriangle`, `financial_projection: DollarSign`
+
+**Optional** — `WireframeViewer.tsx` for visual rendering of ASCII screen layouts (can defer)
+
+---
+
+## Execution Order
+
+```
+1. Wireframe Agent (no deps)        ──┐
+2. DB Migration (no deps)           ──┼──> 4. Stage Templates ──> 3. Wire Coordinator
+5. Promotion Gate (parallel)        ──┘
+6. Frontend (parallel, different repo)
+```
+
+## Verification
+
+1. Reset BrandVoice AI to Stage 14, restart worker
+2. S14 produces 5 artifacts (data_model, erd_diagram, technical_architecture, api_contract, schema_spec)
+3. S15 produces 3 artifacts (risk_register, user_story_pack, wireframes)
+4. Wireframes artifact contains screens with ASCII layouts and navigation flows
+5. S16 produces financial_projection and blocks at promotion gate (always manual)
+6. Frontend shows correct icons for new artifact types
+
+## Critical Files
+
+- `lib/eva/blueprint-agents/wireframes.js` — NEW: wireframe agent
+- `lib/eva/blueprint-agents/index.js` — register wireframe agent
+- `lib/eva/eva-orchestrator-helpers.js` — wire coordinator into loadStageTemplate()
+- `lib/eva/stage-templates/stage-14.js` — add blueprintAgents array
+- `lib/eva/stage-templates/stage-15.js` — fix title + add blueprintAgents
+- `lib/eva/stage-templates/stage-16.js` — promotion gate checks for new artifacts
+- `lib/eva/blueprint-scoring/rubric-definitions.js` — wireframes rubric
+- `lib/eva/contracts/stage-contracts.js` — update produces specs
+- `ehg/src/components/artifacts/ArtifactPanel.tsx` — icon mappings

--- a/scripts/reports/venture-pipeline-triangulation-prompt-2026-03-19.md
+++ b/scripts/reports/venture-pipeline-triangulation-prompt-2026-03-19.md
@@ -1,0 +1,277 @@
+# EHG Venture Lifecycle Pipeline — Ground-Truth Triangulation Prompt
+
+> **Use this prompt in both AntiGravity (Gemini) and OpenAI for independent assessment.**
+> **Date**: 2026-03-19
+> **Prepared by**: Claude Code (with full codebase access)
+
+---
+
+## System Prompt (paste as system/instruction)
+
+You are a senior systems architect and venture pipeline analyst. You are reviewing a 25-stage AI-driven venture evaluation pipeline. Perform an independent critical assessment. Be specific about issues and actionable in recommendations. Do not trust documentation claims — the evidence below comes from actual code and production database queries.
+
+---
+
+## User Prompt (paste as user message)
+
+# EHG Venture Lifecycle Pipeline — Architecture Assessment
+
+## What This System Does
+
+The EHG system runs AI-simulated ventures through a 25-stage lifecycle pipeline. An autonomous Stage Execution Worker polls for ventures needing advancement, executes each stage via an LLM-powered `processStage()` function, and handles chairman approval gates, autonomy levels, reality gates, and decision filters. There is no real product being built — the pipeline evaluates and stress-tests venture IDEAS through simulation.
+
+A single human (the "Chairman") oversees the pipeline and approves/rejects/kills ventures at gate stages.
+
+---
+
+## The 25 Stages (from actual code: lib/eva/stage-templates/stage-NN.js)
+
+### PHASE 1: THE TRUTH (Stages 1-5) — EVALUATION Mode
+| Stage | Slug | What It Does | Artifacts Produced | Gate |
+|-------|------|-------------|-------------------|------|
+| 1 | draft-idea | Idea Capture | idea_brief (description, problem, value prop, target market) | None |
+| 2 | idea-validation | Idea Analysis | critique_report (7 sub-scores via Mixture of Agents) | None |
+| 3 | validation | Viability Kill Gate | validation_report + devils_advocate_review | **KILL GATE + CHAIRMAN BLOCK** — score ≥70 PASS, 50-70 REVISE→S2, <50 KILL |
+| 4 | competitive-intel | Competitive Landscape | competitive_analysis (SWOT per competitor) | None |
+| 5 | profitability | Financial Kill Gate | financial_model + devils_advocate_review | **KILL GATE + CHAIRMAN BLOCK + Reality Gate 5→6** |
+
+### PHASE 2: THE ENGINE (Stages 6-9) — STRATEGY Mode
+| Stage | Slug | What It Does | Artifacts Produced | Gate |
+|-------|------|-------------|-------------------|------|
+| 6 | risk-matrix | Risk Assessment | risk_matrix (≥10 risks, aggregate score) | None |
+| 7 | pricing | Revenue Architecture | pricing_model (model, tiers, landscape) | **REVIEW MODE** (pauses for chairman review before advancing) |
+| 8 | bmc | Business Model Canvas | business_model_canvas (all 9 BMC blocks) | **REVIEW MODE** |
+| 9 | exit-strategy | Exit Strategy | exit_strategy (thesis, ≥3 acquirers, valuation) | **REVIEW MODE + Reality Gate 9→10** |
+
+### PHASE 3: THE IDENTITY (Stages 10-12) — STRATEGY Mode (cont.)
+| Stage | Slug | What It Does | Artifacts Produced | Gate |
+|-------|------|-------------|-------------------|------|
+| 10 | customer-brand-foundation | Customer & Brand | cultural_design_config, strategic_narrative, marketing_manifest, brand_guidelines | **CHAIRMAN BLOCK** (≥3 personas, brand genome required) |
+| 11 | naming-visual-identity | Naming & Visual Identity | brand_name, gtm_plan, marketing_manifest | **REVIEW MODE** |
+| 12 | gtm-sales-strategy | GTM & Sales | sales_playbook (3 market tiers, 8 channels, funnel, journey) | Dual gate: local completeness + Reality Gate 12→13 |
+
+### PHASE 4: THE BLUEPRINT (Stages 13-16) — PLANNING Mode
+| Stage | Slug | What It Does | Artifacts Produced | Gate |
+|-------|------|-------------|-------------------|------|
+| 13 | product-roadmap | Product Roadmap | tech_stack_decision + devils_advocate_review | **KILL GATE + CHAIRMAN BLOCK** (≥3 milestones, timeline ≥3mo) |
+| 14 | technical-architecture | Technical Architecture | erd_diagram, data_model (5 architecture layers) | None |
+| 15 | risk-register | Resource Planning | user_story_pack (risks with severity/priority/mitigation) | None |
+| 16 | financial-projections | Financial Projections | schema_spec, api_contract + devils_advocate_review | **PROMOTION GATE + CHAIRMAN BLOCK + Reality Gate 16→17** |
+
+### PHASE 5: THE BUILD LOOP (Stages 17-21) — BUILD Mode
+| Stage | Slug | What It Does | Artifacts Produced | Gate |
+|-------|------|-------------|-------------------|------|
+| 17 | pre-build-checklist | Pre-Build Checklist | system_prompt, cicd_config + devils_advocate_review | **CHAIRMAN BLOCK** (go/conditional_go decision) |
+| 18 | sprint-planning | Sprint Planning | stage_output, lifecycle_sd_bridge (SD bridge payloads) | None |
+| 19 | build-execution | Build Execution | stage_output (sprint completion) | None |
+| 20 | quality-assurance | Quality Assurance | security_audit (coverage metrics) | None |
+| 21 | integration-testing | Build Review | uat_report, test_plan (approve/conditional) | None |
+
+### PHASE 6: LAUNCH & LEARN (Stages 22-25) — LAUNCH Mode
+| Stage | Slug | What It Does | Artifacts Produced | Gate |
+|-------|------|-------------|-------------------|------|
+| 22 | release-readiness | Release Readiness | deployment_runbook + devils_advocate_review | **PROMOTION GATE + CHAIRMAN BLOCK + Reality Gate 22→23** |
+| 23 | marketing-preparation | Marketing Preparation | launch_checklist + devils_advocate_review | **KILL GATE + CHAIRMAN BLOCK** |
+| 24 | launch-readiness | Launch Readiness | retention_playbook, churn_triggers, health_scoring_system, analytics_dashboard | **CHAIRMAN BLOCK** (go/no-go) |
+| 25 | launch-execution | Launch Execution | assumptions_vs_reality_report, optimization_roadmap | Terminal stage. Sets pipeline_mode='operations'. |
+
+---
+
+## Gate Architecture (from actual code constants)
+
+### Chairman Blocking Gates (9 of 25 stages): `[3, 5, 10, 13, 16, 17, 22, 23, 24]`
+Pipeline halts and waits for chairman to approve, reject, or kill.
+
+### Review Mode Stages (4 of 25): `[7, 8, 9, 11]`
+Pipeline executes the stage, then pauses for chairman review before advancing. Not a kill gate — chairman confirms quality.
+
+### Kill Gates (4 stages): `[3, 5, 13, 23]`
+Chairman can terminate the venture entirely.
+
+### Promotion Gates (5 stages): `[10, 16, 17, 22, 24]`
+Cross-stage validation — checks that prerequisites from prior stages are met.
+
+### Reality Gates (5 phase boundaries):
+| Boundary | Required Artifacts (with min quality score) |
+|----------|---------------------------------------------|
+| 5→6 (EVALUATION→STRATEGY) | problem_statement (≥0.6), target_market_analysis (≥0.5), value_proposition (≥0.6) |
+| 9→10 (STRATEGY→IDENTITY) | risk_assessment (≥0.5), revenue_model (≥0.5), business_model_canvas (≥0.6) |
+| 12→13 (IDENTITY→BLUEPRINT) | business_model_canvas (≥0.7), technical_architecture (≥0.6), project_plan (≥0.5) |
+| 16→17 (BLUEPRINT→BUILD) | mvp_build (≥0.7, **URL reachable**), test_coverage_report (≥0.6), deployment_runbook (≥0.5) |
+| 22→23 (BUILD→LAUNCH) | launch_metrics (≥0.6), user_feedback_summary (≥0.5), production_app (≥0.7, **URL reachable**) |
+
+### Operating Mode Boundaries (worker pauses at transitions):
+```
+EVALUATION: Stages 1-5
+STRATEGY:   Stages 6-12
+PLANNING:   Stages 13-16
+BUILD:      Stages 17-21
+LAUNCH:     Stages 22-25
+```
+
+---
+
+## Autonomy Model (from lib/eva/autonomy-model.js)
+
+| Level | stage_gate | reality_gate | devils_advocate | Description |
+|-------|-----------|-------------|-----------------|-------------|
+| L0 (Manual) | manual | manual | manual | All gates require chairman |
+| L1 (Guided) | auto_approve | manual | manual | Stage gates auto, reality manual |
+| L2 (Supervised) | auto_approve | auto_approve | auto_approve | All auto, chairman notified |
+| L3 (Autonomous) | auto_approve | auto_approve | skip | All auto, exceptions only |
+| L4 (Full) | auto_approve | auto_approve | skip | All auto, no notifications |
+
+---
+
+## Decision Filter Engine (from lib/eva/decision-filter-engine.js)
+
+Evaluated after each stage execution. Checks (in order):
+1. cost_threshold — spend exceeds limit
+2. budget_exceeded — token budget at/over limit
+3. new_tech_vendor — unapproved technology/vendor detected
+4. strategic_pivot — pivot keywords detected
+5. low_score — quality below threshold (stage-specific overrides for S3, S5)
+6. novel_pattern — new patterns vs. prior stages
+7. constraint_drift — parameter changes
+8. vision_score_signal — vision alignment low
+
+**Output**: `AUTO_PROCEED`, `PRESENT_TO_CHAIRMAN`, or `STOP`
+
+Chairman can override per-stage via `chairman_dashboard_config.stage_overrides`.
+
+---
+
+## Worker Pipeline Flow (from lib/eva/stage-execution-worker.js)
+
+```
+1. _tick() polls ventures table every 30s
+2. _pollForWork() → SELECT ventures WHERE status='active' AND orchestrator_state='idle' AND current_lifecycle_stage < 25
+3. _processVenture(ventureId):
+   a. acquireProcessingLock() — atomic CAS: idle → processing
+   b. Fetch current_lifecycle_stage from DB
+   c. WHILE currentStage <= 25 AND running:
+      - Check abort signal
+      - Check operating mode boundary → break if crossed
+      - Check governance override (chairman per-stage override) → break if manual
+      - _executeWithRetry(ventureId, stage, lockId):
+        * Create stage_executions record
+        * Call processStage() (the LLM-powered orchestrator)
+        * If COMPLETED or BLOCKED → return (no retry)
+        * If failed/threw → retry up to maxRetries (default 2) with backoff
+      - _syncStageWork() → write results to venture_stage_work for UI
+      - Check if already-approved decision exists (re-entry protection)
+      - If REVIEW_MODE stage → create decision, block for review
+      - If CHAIRMAN_GATE stage → _handleChairmanGate():
+        * Check autonomy level (L2+ auto-approves)
+        * Create or reuse pending decision
+        * If already approved → continue
+        * If killed → kill venture
+        * Otherwise → block
+      - Check result status (FAILED → break, BLOCKED → break)
+      - Check filter decision (STOP → break, REQUIRE_REVIEW → break)
+      - If stage >= 25 → markCompleted(), return
+      - Advance to next stage (from result.nextStageId or DB re-read)
+   d. Release lock with target state (idle/blocked/failed)
+```
+
+---
+
+## Production Data (from actual database queries, NOT documentation)
+
+### Venture: MarketInsight AI (created 2026-03-19)
+
+**Execution Results**: All 25 stages executed, ALL succeeded (zero errors).
+
+**Execution Attempt Counts** (CRITICAL — shows re-run problem):
+```
+Stage  1:  3 attempts
+Stage  2:  5 attempts  ⚠️
+Stage  3:  3 attempts
+Stage  4:  2 attempts
+Stage  5: 11 attempts  ⚠️⚠️
+Stage  6:  3 attempts
+Stage  7: 19 attempts  ⚠️⚠️⚠️
+Stage  8:  2 attempts
+Stage  9:  3 attempts
+Stage 10:  1 attempt
+Stage 11:  3 attempts
+Stage 12:  1 attempt
+Stages 13-19: 1 attempt each ✅
+Stage 20:  2 attempts
+Stages 21-23: 1 attempt each ✅
+Stage 24:  2 attempts
+Stage 25:  2 attempts
+```
+
+**Stage 5 Timing** (11 executions): Each takes 20-53 seconds, spaced ~30s apart. This is the **poll interval** — the worker re-processes Stage 5 every tick because the venture stays at Stage 5 (chairman gate blocks advancement, but worker doesn't see it as blocked on the NEXT tick).
+
+**Stage 7 Timing** (19 executions): First takes 25s, then **18 executions at 1-2 second intervals**. This is a **tight loop** — the worker is executing processStage 18 times in 36 seconds. Stage 7 is a REVIEW_MODE stage. The LLM returns instantly (cached/idempotent?) and the review-mode blocking logic may not be preventing re-entry.
+
+**Artifact Integrity**:
+```
+Stages 1-9:  Full dual-write ✅ (both content and artifact_data populated)
+Stage 10:    brand_guidelines — BOTH content AND artifact_data are NULL ⚠️
+Stage 11:    brand_name — BOTH content AND artifact_data are NULL ⚠️
+Stages 12-19: Full dual-write ✅
+Stage 20:    security_audit — content=NULL (data present)
+Stage 21:    uat_report, test_plan — content=NULL (data present)
+Stage 22:    deployment_runbook — content=NULL; devils_advocate_review — data=NULL
+Stage 23:    launch_checklist — content=NULL; devils_advocate_review — data=NULL
+Stage 24:    All 4 artifacts — content=NULL (data present)
+Stage 25:    Both artifacts — content=NULL (data present)
+```
+
+**Chairman Decisions**:
+```
+Stage  3: pending/advisory (never resolved?)
+Stage  5: pending/advisory (never resolved?)
+Stage  7: approved
+Stage  8: approved
+Stage  9: approved
+Stage 10: approved (proceed)
+Stage 11: approved
+Stage 16: pending/advisory (never resolved?)
+Stage 22: approved (proceed)
+Stage 24: approved (proceed)
+```
+
+---
+
+## Your Assessment Should Cover:
+
+### 1. Stage Progression Logic
+Is the 25-stage progression well-designed for AI-simulated venture evaluation? Are there stages that should be combined, split, or reordered? Note: these are SIMULATED ventures — there is no real product being built.
+
+### 2. Gate Density and Placement
+13 of 25 stages have some form of blocking (9 chairman + 4 review). For a single-chairman system, is this appropriate? Are gates placed at the right stages?
+
+### 3. Re-run Root Cause Analysis
+Stage 5 re-ran 11 times (every 30s poll cycle while blocked at chairman gate). Stage 7 re-ran 19 times (18 times in 36 seconds in a tight loop). Given the worker code flow above:
+- What specific code path allows re-execution of a blocked stage?
+- Why does Stage 7 (REVIEW_MODE) execute in a tight loop while Stage 5 (CHAIRMAN_GATE) executes at poll intervals?
+- What fix would prevent both patterns?
+
+### 4. Artifact Persistence Gaps
+Stages 10-11 have artifacts with BOTH fields NULL (empty placeholder rows). Stages 20-25 have content=NULL. What does this indicate about the persistence architecture?
+
+### 5. Chairman Decision Anomalies
+Stages 3, 5, and 16 show "pending/advisory" decisions that were never resolved, yet the venture advanced past them. How is this possible? Is this a feature or a bug?
+
+### 6. Autonomy Model Assessment
+Is L0-L4 well-calibrated? Should kill gates ALWAYS require manual review regardless of autonomy level? Should autonomy be per-gate-type rather than per-venture?
+
+### 7. Reality Gate Impossibility
+Reality gates at 16→17 and 22→23 require URL-reachable artifacts (mvp_build, production_app). These are AI-simulated ventures — no real URL exists. How should this be handled?
+
+### 8. Operating Mode Boundaries
+The worker pauses at mode transitions (EVALUATION→STRATEGY at 5→6, etc.). Is this necessary friction or valuable checkpoint?
+
+### 9. Post-Lifecycle
+After Stage 25, options are: continue, pivot (reset to S15), expand (create SD), sunset (30-day wind-down), exit (immediate archive). Is this sufficient?
+
+### 10. Top 3 Issues + Overall Grade (1-10)
+What are the three most critical issues, and what's your overall assessment?
+
+---
+
+*Evidence gathered from actual codebase and production database by Claude Code with full repository access.*

--- a/supabase/migrations/20260322_add_autonomy_level_column.sql
+++ b/supabase/migrations/20260322_add_autonomy_level_column.sql
@@ -1,0 +1,12 @@
+-- Add autonomy_level column to ventures table
+-- This enables the autonomy model to control gate behavior per venture.
+-- Default L0 (Manual) means all gates require chairman approval.
+-- Values: L0 (Manual), L1 (Guided), L2 (Supervised), L3 (Autonomous), L4 (Full Auto)
+ALTER TABLE ventures ADD COLUMN IF NOT EXISTS autonomy_level TEXT DEFAULT 'L0';
+
+-- Add check constraint for valid values
+ALTER TABLE ventures ADD CONSTRAINT ventures_autonomy_level_check
+  CHECK (autonomy_level IN ('L0', 'L1', 'L2', 'L3', 'L4'));
+
+-- Update autonomy model to query ventures table instead of eva_ventures
+COMMENT ON COLUMN ventures.autonomy_level IS 'Venture autonomy level: L0=Manual, L1=Guided, L2=Supervised, L3=Autonomous, L4=Full Auto';

--- a/supabase/migrations/20260322_fix_advance_stage_column_mismatch.sql
+++ b/supabase/migrations/20260322_fix_advance_stage_column_mismatch.sql
@@ -1,0 +1,192 @@
+-- ============================================================================
+-- Fix advance_venture_stage: column mismatch + overload ambiguity
+-- ============================================================================
+-- Problem: 20260322_update_advance_stage_gates_26.sql introduced two bugs:
+--   1. INSERT uses transitioned_at/metadata columns that don't exist on
+--      venture_stage_transitions (actual columns: approved_by, handoff_data,
+--      idempotency_key)
+--   2. Dropped stage_events emits and venture_stage_work updates
+--
+-- Additionally, an old overload with p_idempotency_key UUID causes PostgREST
+-- ambiguity (PGRST203) when the frontend omits the 4th parameter.
+--
+-- Fix: Merge 26-stage gate arrays into the working function body from
+-- 20260318_remove_gate_autocreate_from_advance.sql, using correct columns.
+-- Drop the orphaned p_idempotency_key overload.
+--
+-- Created: 2026-03-22
+-- ============================================================================
+
+-- Step 1: Drop the conflicting overload that causes PGRST203 ambiguity
+DROP FUNCTION IF EXISTS advance_venture_stage(UUID, INTEGER, INTEGER, UUID);
+
+-- Step 2: Replace with corrected function (26-stage gates + correct columns)
+CREATE OR REPLACE FUNCTION advance_venture_stage(
+  p_venture_id UUID,
+  p_from_stage INTEGER,
+  p_to_stage INTEGER,
+  p_transition_type TEXT DEFAULT 'normal'
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $fn$
+DECLARE
+  v_current_stage INTEGER;
+  v_venture_name TEXT;
+  -- 26-stage gate arrays (SD-LEO-INFRA-STAGE-BLUEPRINT-REVIEW-001)
+  v_kill_gates INTEGER[] := ARRAY[3, 5, 13, 24];
+  v_promotion_gates INTEGER[] := ARRAY[17, 18, 23];
+  v_all_gates INTEGER[] := ARRAY[3, 5, 13, 17, 18, 23, 24];
+  v_gate_decision RECORD;
+  v_idempotency UUID;
+BEGIN
+  -- Validate venture exists and lock row
+  SELECT current_lifecycle_stage, name
+    INTO v_current_stage, v_venture_name
+    FROM ventures
+    WHERE id = p_venture_id
+    FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'venture_not_found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  -- Validate from_stage matches current
+  IF v_current_stage != p_from_stage THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'stage_mismatch',
+      'current_stage', v_current_stage,
+      'from_stage', p_from_stage
+    );
+  END IF;
+
+  -- Validate to_stage range (26-stage lifecycle)
+  IF p_to_stage < 1 OR p_to_stage > 26 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'invalid_to_stage',
+      'to_stage', p_to_stage
+    );
+  END IF;
+
+  -- Gate enforcement: if from_stage is a gate, require approved decision
+  IF p_from_stage = ANY(v_all_gates) THEN
+    SELECT id, decision, status INTO v_gate_decision
+      FROM chairman_decisions
+      WHERE venture_id = p_venture_id
+        AND lifecycle_stage = p_from_stage
+        AND status = 'approved'
+        AND decision IN ('pass', 'go', 'proceed', 'approve', 'conditional_pass', 'conditional_go', 'continue', 'release')
+      ORDER BY created_at DESC
+      LIMIT 1;
+
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object(
+        'success', false,
+        'error', 'gate_not_approved',
+        'gate_stage', p_from_stage,
+        'gate_type', CASE
+          WHEN p_from_stage = ANY(v_kill_gates) THEN 'kill'
+          WHEN p_from_stage = ANY(v_promotion_gates) THEN 'promotion'
+          ELSE 'unknown'
+        END,
+        'message', format('Chairman approval required at stage %s before advancing', p_from_stage)
+      );
+    END IF;
+  END IF;
+
+  -- Mark current stage as completed
+  UPDATE venture_stage_work
+    SET stage_status = 'completed',
+        completed_at = NOW()
+    WHERE venture_id = p_venture_id
+      AND lifecycle_stage = p_from_stage;
+
+  -- Advance ventures.current_lifecycle_stage
+  UPDATE ventures
+    SET current_lifecycle_stage = p_to_stage,
+        updated_at = NOW()
+    WHERE id = p_venture_id;
+
+  -- Mark next stage as in_progress
+  UPDATE venture_stage_work
+    SET stage_status = 'in_progress',
+        started_at = NOW()
+    WHERE venture_id = p_venture_id
+      AND lifecycle_stage = p_to_stage;
+
+  -- Emit STAGE_COMPLETE event for from_stage
+  INSERT INTO stage_events (id, venture_id, stage_number, event_type, event_data, created_at)
+  VALUES (
+    gen_random_uuid(), p_venture_id, p_from_stage, 'STAGE_COMPLETE',
+    jsonb_build_object('advanced_to', p_to_stage, 'transition_type', p_transition_type),
+    NOW()
+  );
+
+  -- Emit STAGE_ENTRY event for to_stage
+  INSERT INTO stage_events (id, venture_id, stage_number, event_type, event_data, created_at)
+  VALUES (
+    gen_random_uuid(), p_venture_id, p_to_stage, 'STAGE_ENTRY',
+    jsonb_build_object('advanced_from', p_from_stage, 'transition_type', p_transition_type),
+    NOW()
+  );
+
+  -- Record transition (correct column names: approved_by, handoff_data, idempotency_key)
+  v_idempotency := uuid_generate_v5(
+    '00000000-0000-0000-0000-000000000000'::uuid,
+    p_venture_id::text || ':' || p_from_stage::text || ':' || p_to_stage::text
+      || ':' || COALESCE(
+        (SELECT COUNT(*)::text FROM venture_stage_transitions
+         WHERE venture_id = p_venture_id
+           AND from_stage = p_from_stage
+           AND to_stage = p_to_stage),
+        '0')
+  );
+
+  INSERT INTO venture_stage_transitions (
+    venture_id, from_stage, to_stage, transition_type,
+    approved_by, handoff_data, idempotency_key
+  ) VALUES (
+    p_venture_id, p_from_stage, p_to_stage, p_transition_type,
+    'system:advance', jsonb_build_object(
+      'gate_decision_id', v_gate_decision.id,
+      'venture_name', v_venture_name
+    ), v_idempotency
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'venture_id', p_venture_id,
+    'venture_name', v_venture_name,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage,
+    'transition_type', p_transition_type,
+    'gate_created', false,
+    'idempotency_key', v_idempotency
+  );
+
+EXCEPTION WHEN OTHERS THEN
+  RETURN jsonb_build_object(
+    'success', false,
+    'error', SQLERRM,
+    'venture_id', p_venture_id,
+    'from_stage', p_from_stage,
+    'to_stage', p_to_stage
+  );
+END;
+$fn$;
+
+GRANT EXECUTE ON FUNCTION advance_venture_stage(UUID, INTEGER, INTEGER, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION advance_venture_stage(UUID, INTEGER, INTEGER, TEXT) IS
+'Gate-enforced venture stage advancement. Kill gates: [3,5,13,24], Promotion gates: [17,18,23]. Max stage: 26.
+Marks stages complete/in_progress, emits events, records transitions.
+Fixed: uses correct venture_stage_transitions columns (approved_by, handoff_data, idempotency_key).';

--- a/supabase/migrations/20260323_fix_export_blueprint_review.sql
+++ b/supabase/migrations/20260323_fix_export_blueprint_review.sql
@@ -1,0 +1,126 @@
+-- Fix export_blueprint_review RPC:
+-- 1. Add venture_name and current_stage to output
+-- 2. Use COALESCE(content, artifact_data::text) to capture all artifact content
+-- 3. Read quality_score from direct column, not metadata JSONB
+-- 4. Read validation_status from direct column, not metadata JSONB
+-- Applied: 2026-03-23
+
+CREATE OR REPLACE FUNCTION export_blueprint_review(p_venture_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  result JSONB;
+  v_name TEXT;
+  v_stage INTEGER;
+  phase_data JSONB := '[]'::JSONB;
+  phase_record RECORD;
+  stage_artifacts JSONB;
+  phase_summary JSONB;
+  total_artifacts INTEGER := 0;
+  total_quality_sum NUMERIC := 0;
+  total_quality_count INTEGER := 0;
+  overall_quality NUMERIC := 0;
+BEGIN
+  -- Validate venture exists and get metadata
+  SELECT name, current_lifecycle_stage INTO v_name, v_stage
+  FROM ventures WHERE id = p_venture_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'error', 'Venture not found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  -- Build per-phase summaries
+  FOR phase_record IN
+    SELECT
+      phase_name,
+      phase_label,
+      stage_start,
+      stage_end
+    FROM (VALUES
+      ('THE_TRUTH',     'The Truth',     1,  5),
+      ('THE_ENGINE',    'The Engine',    6,  9),
+      ('THE_IDENTITY',  'The Identity',  10, 12),
+      ('THE_BLUEPRINT', 'The Blueprint', 13, 16)
+    ) AS phases(phase_name, phase_label, stage_start, stage_end)
+  LOOP
+    -- Get artifacts for this phase
+    -- Use COALESCE to pick up content from either 'content' or 'artifact_data' column
+    SELECT COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', va.id,
+        'lifecycle_stage', va.lifecycle_stage,
+        'artifact_type', va.artifact_type,
+        'content', COALESCE(va.content, va.artifact_data::text),
+        'quality_score', va.quality_score,
+        'validation_status', va.validation_status,
+        'created_at', va.created_at
+      ) ORDER BY va.lifecycle_stage
+    ), '[]'::jsonb)
+    INTO stage_artifacts
+    FROM venture_artifacts va
+    WHERE va.venture_id = p_venture_id
+      AND va.is_current = true
+      AND va.lifecycle_stage >= phase_record.stage_start
+      AND va.lifecycle_stage <= phase_record.stage_end;
+
+    -- Compute phase statistics
+    SELECT
+      jsonb_build_object(
+        'phase', phase_record.phase_label,
+        'phase_key', phase_record.phase_name,
+        'stage_range', jsonb_build_array(phase_record.stage_start, phase_record.stage_end),
+        'artifact_count', COALESCE(jsonb_array_length(stage_artifacts), 0),
+        'avg_quality_score', COALESCE(
+          (SELECT AVG((a->>'quality_score')::numeric)
+           FROM jsonb_array_elements(stage_artifacts) a
+           WHERE a->>'quality_score' IS NOT NULL), 0
+        ),
+        'artifacts', stage_artifacts
+      )
+    INTO phase_summary;
+
+    phase_data := phase_data || jsonb_build_array(phase_summary);
+    total_artifacts := total_artifacts + COALESCE(jsonb_array_length(stage_artifacts), 0);
+
+    -- Accumulate quality scores
+    SELECT
+      COALESCE(SUM((a->>'quality_score')::numeric), 0),
+      COALESCE(COUNT(*) FILTER (WHERE a->>'quality_score' IS NOT NULL), 0)
+    INTO total_quality_sum, total_quality_count
+    FROM jsonb_array_elements(stage_artifacts) a
+    WHERE a->>'quality_score' IS NOT NULL;
+  END LOOP;
+
+  -- Compute overall metrics
+  IF total_quality_count > 0 THEN
+    overall_quality := ROUND(total_quality_sum / total_quality_count, 1);
+  END IF;
+
+  -- Build result with venture context
+  result := jsonb_build_object(
+    'venture_id', p_venture_id,
+    'venture_name', v_name,
+    'current_stage', v_stage,
+    'exported_at', NOW()::text,
+    'phases', phase_data,
+    'summary', jsonb_build_object(
+      'total_artifacts', total_artifacts,
+      'overall_quality_score', overall_quality,
+      'phase_count', 4
+    )
+  );
+
+  RETURN result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION export_blueprint_review(UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION export_blueprint_review(UUID) TO authenticated;
+
+COMMENT ON FUNCTION export_blueprint_review(UUID) IS
+  'Export all pre-build artifacts (stages 1-16) for a venture with quality summaries. Includes venture_name and current_stage. Fixed: reads content from both content and artifact_data columns.';

--- a/supabase/migrations/20260323_regroup_export_blueprint_review.sql
+++ b/supabase/migrations/20260323_regroup_export_blueprint_review.sql
@@ -1,0 +1,143 @@
+-- Regroup export_blueprint_review into builder-oriented categories:
+--   1. WHAT to build (product definition)
+--   2. WHO it's for (market & audience)
+--   3. HOW to build it (technical specs)
+--   4. WHAT it costs (financial constraints)
+--   5. WHY these decisions (decision context / reference)
+-- Also includes stage 0 (intake) and stage 17 (DA review) artifacts.
+-- Applied: 2026-03-23
+
+CREATE OR REPLACE FUNCTION export_blueprint_review(p_venture_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  result JSONB;
+  v_name TEXT;
+  v_stage INTEGER;
+  group_data JSONB := '[]'::JSONB;
+  group_record RECORD;
+  group_artifacts JSONB;
+  group_summary JSONB;
+  total_artifacts INTEGER := 0;
+  total_quality_sum NUMERIC := 0;
+  total_quality_count INTEGER := 0;
+  overall_quality NUMERIC := 0;
+BEGIN
+  -- Validate venture exists and get metadata
+  SELECT name, current_lifecycle_stage INTO v_name, v_stage
+  FROM ventures WHERE id = p_venture_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'error', 'Venture not found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  -- Build groups by builder question
+  FOR group_record IN
+    SELECT
+      group_key,
+      group_label,
+      group_description,
+      artifact_types
+    FROM (VALUES
+      ('WHAT_TO_BUILD', 'What to Build', 'Product definition — idea, roadmap, user stories, personas',
+        ARRAY['intake_venture_analysis', 'truth_idea_brief', 'identity_persona_brand',
+              'blueprint_product_roadmap', 'blueprint_user_story_pack']),
+
+      ('WHO_ITS_FOR', 'Who It''s For', 'Market & audience — competitors, customers, GTM, brand',
+        ARRAY['truth_competitive_analysis', 'identity_naming_visual', 'identity_brand_guidelines',
+              'identity_gtm_sales_strategy']),
+
+      ('HOW_TO_BUILD', 'How to Build It', 'Technical specs — architecture, schema, ERD, API contracts',
+        ARRAY['blueprint_technical_architecture', 'blueprint_schema_spec', 'blueprint_data_model',
+              'blueprint_api_contract', 'blueprint_erd_diagram']),
+
+      ('WHAT_IT_COSTS', 'What It Costs', 'Financial constraints — pricing, projections, runway',
+        ARRAY['engine_pricing_model', 'blueprint_financial_projection']),
+
+      ('WHY_THESE_DECISIONS', 'Why These Decisions', 'Decision context — analysis, scores, risks, reviews (reference only)',
+        ARRAY['truth_ai_critique', 'truth_validation_decision', 'truth_financial_model',
+              'engine_risk_matrix', 'engine_business_model_canvas', 'engine_exit_strategy',
+              'blueprint_risk_register', 'blueprint_launch_readiness',
+              'system_devils_advocate_review'])
+    ) AS groups(group_key, group_label, group_description, artifact_types)
+  LOOP
+    -- Get artifacts matching this group's types
+    SELECT COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'id', va.id,
+        'lifecycle_stage', va.lifecycle_stage,
+        'artifact_type', va.artifact_type,
+        'content', COALESCE(va.content, va.artifact_data::text),
+        'quality_score', va.quality_score,
+        'validation_status', va.validation_status,
+        'created_at', va.created_at
+      ) ORDER BY va.lifecycle_stage, va.artifact_type
+    ), '[]'::jsonb)
+    INTO group_artifacts
+    FROM venture_artifacts va
+    WHERE va.venture_id = p_venture_id
+      AND va.is_current = true
+      AND va.lifecycle_stage <= 17
+      AND va.artifact_type = ANY(group_record.artifact_types);
+
+    -- Build group summary
+    group_summary := jsonb_build_object(
+      'group', group_record.group_label,
+      'group_key', group_record.group_key,
+      'description', group_record.group_description,
+      'artifact_count', COALESCE(jsonb_array_length(group_artifacts), 0),
+      'artifacts', group_artifacts
+    );
+
+    group_data := group_data || jsonb_build_array(group_summary);
+    total_artifacts := total_artifacts + COALESCE(jsonb_array_length(group_artifacts), 0);
+
+    -- Accumulate quality scores
+    DECLARE
+      q_sum NUMERIC;
+      q_count INTEGER;
+    BEGIN
+      SELECT
+        COALESCE(SUM((a->>'quality_score')::numeric), 0),
+        COALESCE(COUNT(*) FILTER (WHERE a->>'quality_score' IS NOT NULL), 0)
+      INTO q_sum, q_count
+      FROM jsonb_array_elements(group_artifacts) a
+      WHERE a->>'quality_score' IS NOT NULL;
+      total_quality_sum := total_quality_sum + q_sum;
+      total_quality_count := total_quality_count + q_count;
+    END;
+  END LOOP;
+
+  -- Compute overall metrics
+  IF total_quality_count > 0 THEN
+    overall_quality := ROUND(total_quality_sum / total_quality_count, 1);
+  END IF;
+
+  -- Build result
+  result := jsonb_build_object(
+    'venture_id', p_venture_id,
+    'venture_name', v_name,
+    'current_stage', v_stage,
+    'exported_at', NOW()::text,
+    'groups', group_data,
+    'summary', jsonb_build_object(
+      'total_artifacts', total_artifacts,
+      'overall_quality_score', overall_quality,
+      'group_count', 5
+    )
+  );
+
+  RETURN result;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION export_blueprint_review(UUID) TO service_role;
+GRANT EXECUTE ON FUNCTION export_blueprint_review(UUID) TO authenticated;
+
+COMMENT ON FUNCTION export_blueprint_review(UUID) IS
+  'Export venture artifacts grouped by builder need: What to Build, Who Its For, How to Build It, What It Costs, Why These Decisions. Includes stages 0-17.';

--- a/supabase/migrations/20260323_unique_active_venture_names.sql
+++ b/supabase/migrations/20260323_unique_active_venture_names.sql
@@ -1,0 +1,10 @@
+-- Enforce unique venture names among active/paused ventures.
+-- Completed, cancelled, and archived ventures can reuse names.
+-- Applied: 2026-03-23
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ventures_unique_active_name
+  ON ventures (name)
+  WHERE status IN ('active', 'paused');
+
+COMMENT ON INDEX idx_ventures_unique_active_name IS
+  'Prevents duplicate venture names among active/paused ventures. Archived/completed/cancelled can reuse names.';


### PR DESCRIPTION
## Summary
- Fix product-hunt-client env var name (`PRODUCT_HUNT_TOKEN` → `PRODUCT_HUNT_API_TOKEN`)
- Fix assign-fleet-identities column name (`last_heartbeat_at` → `heartbeat_at`), remove swallowed `.catch()` calls
- Add `gate-constants.js` for EVA gate threshold definitions
- Add 5 pending migration files (autonomy_level, advance_stage fix, export_blueprint_review, unique active venture names)
- Add venture-stage-governance guide
- Archive one-time user story creation script
- Add research reports (blueprint factory plan, triangulation prompt)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] No secrets detected
- [x] DOCMON clean (1 passive voice warning, non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)