### PR TITLE
fix: wire orphaned analysis steps into stage execution pipeline

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -541,13 +541,13 @@ export const CROSS_STAGE_DEPS = {
   // Phase 4: THE BLUEPRINT (Stages 13-16)
   13: [1, 5, 8, 9],          // Product roadmap: idea + economics + BMC + exit
   14: [1, 13],               // Technical architecture: idea + roadmap
-  15: [1, 6, 13, 14],        // Risk register: idea + risk matrix + roadmap + architecture
+  15: [1, 6, 10, 13, 14],    // Risk register + wireframes: idea + risk matrix + brand + roadmap + architecture
   16: [1, 13, 14, 15],       // Financial projections (promotion gate): idea + roadmap + arch + risks
 
   // Phase 5: THE BUILD (Stages 17-21)
   17: [13, 14, 15, 16],      // Build readiness: roadmap + arch + risks + financials
   18: [13, 14, 17],          // Sprint planning: roadmap + arch + readiness
-  19: [17, 18],              // Dev execution: readiness + sprint plan
+  19: [15, 17, 18],          // Sprint planning + visual convergence: wireframes + readiness + sprint plan
   20: [18, 19],              // QA & testing: sprint plan + dev output
   21: [19, 20],              // Build review: dev output + QA results
 

--- a/lib/eva/services/srip-artifact-synthesizer.js
+++ b/lib/eva/services/srip-artifact-synthesizer.js
@@ -8,7 +8,7 @@
  * ventures that lack a manual reference URL.
  *
  * Data flow:
- *   venture_stage_work (stages 1,3,4,5,8)
+ *   venture_artifacts (stages 1,3,4,5,8, is_current=true)
  *     → synthetic dna_json
  *     → generateInterviewDefaults()
  *     → srip_site_dna + srip_brand_interviews
@@ -20,26 +20,36 @@ import { generateInterviewDefaults } from './srip-interview-engine.js';
 const SOURCE_TAG = 'artifact_synthesis';
 
 /**
- * Collect stage artifacts from venture_stage_work.
+ * Collect stage artifacts from venture_artifacts.
+ *
+ * Uses venture_artifacts (committed before stage progression) instead of
+ * venture_stage_work (updated after in _syncStageWork) to avoid a race
+ * condition where Stage 10 starts before previous stages' work is synced.
  *
  * @param {string} ventureId
  * @param {Object} supabase - Supabase client
- * @returns {Promise<Object|null>} Map of stage number to advisory_data, or null if stage 1 missing
+ * @returns {Promise<Object|null>} Map of stage number to artifact_data, or null if stage 1 missing
  */
 async function collectArtifacts(ventureId, supabase) {
   const { data, error } = await supabase
-    .from('venture_stage_work')
-    .select('lifecycle_stage, advisory_data')
+    .from('venture_artifacts')
+    .select('lifecycle_stage, artifact_data, content')
     .eq('venture_id', ventureId)
+    .eq('is_current', true)
     .in('lifecycle_stage', [1, 3, 4, 5, 8])
-    .eq('stage_status', 'completed')
     .order('lifecycle_stage', { ascending: true });
 
   if (error) throw new Error(`collectArtifacts failed: ${error.message}`);
 
   const artifacts = {};
   for (const row of data || []) {
-    artifacts[row.lifecycle_stage] = row.advisory_data || {};
+    let ad = row.artifact_data;
+    if (!ad && row.content && typeof row.content === 'string') {
+      try { ad = JSON.parse(row.content); } catch { /* skip unparseable content */ }
+    }
+    if (ad && typeof ad === 'object' && Object.keys(ad).length > 0) {
+      artifacts[row.lifecycle_stage] = ad;
+    }
   }
 
   // Stage 1 is the minimum required input
@@ -208,7 +218,7 @@ async function hasExistingSripData(ventureId, supabase) {
  *
  * This is the main entry point. It:
  * 1. Checks if SRIP data already exists (skip if so)
- * 2. Collects stage artifacts from venture_stage_work
+ * 2. Collects stage artifacts from venture_artifacts
  * 3. Maps artifacts to synthetic dna_json
  * 4. Generates 12 interview defaults
  * 5. Persists to srip_site_dna and srip_brand_interviews

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -790,6 +790,22 @@ export class StageExecutionWorker {
           // Auto-approved — mark the stage work as approved so _syncStageWork
           // does NOT override stageStatus to 'blocked'. (Fix: QF-20260320-509 Bug 1)
           if (result) result._gateApproved = true;
+
+          // Post-gate: Stage 17 doc generation (creates EVA vision + architecture plan)
+          if (currentStage === 17) {
+            try {
+              const { generateDocs } = await import('./stage-templates/analysis-steps/stage-17-doc-generation.js');
+              await generateDocs({
+                ventureId,
+                ventureName: ventureContext?.name,
+                supabase: this._supabase,
+                logger: this._logger,
+              });
+              this._logger.log('[Worker] Stage 17 post-gate: vision + architecture docs generated');
+            } catch (docErr) {
+              this._logger.warn(`[Worker] Stage 17 doc generation failed (non-fatal): ${docErr.message}`);
+            }
+          }
         }
 
         const resultStatus = (result?.status || '').toUpperCase();

--- a/lib/eva/stage-templates/analysis-steps/index.js
+++ b/lib/eva/stage-templates/analysis-steps/index.js
@@ -24,9 +24,9 @@ export { analyzeStage08 } from './stage-08-bmc-generation.js';
 export { analyzeStage09 } from './stage-09-exit-strategy.js';
 
 // THE IDENTITY (Stages 10-12)
-export { analyzeStage10 } from './stage-10-naming-brand.js';
-export { analyzeStage11 } from './stage-11-gtm.js';
-export { analyzeStage12 } from './stage-12-sales-logic.js';
+export { analyzeStage10 } from './stage-10-customer-brand.js';
+export { analyzeStage11 } from './stage-11-visual-identity.js';
+export { analyzeStage12 } from './stage-12-gtm-sales.js';
 
 // THE BLUEPRINT (Stages 13-17)
 export { analyzeStage13 } from './stage-13-product-roadmap.js';
@@ -58,6 +58,11 @@ export { analyzeStage20Acquirability as analyzeStage21Acquirability } from './st
 export { analyzeStage21Acquirability as analyzeStage22Acquirability } from './stage-22-acquirability.js';
 export { analyzeStage22Acquirability as analyzeStage23Acquirability } from './stage-23-acquirability.js';
 export { analyzeStage24AcquirabilityReview as analyzeStage25AcquirabilityReview } from './stage-25-acquirability-review.js';
+
+// SUPPLEMENTARY ANALYSIS STEPS (run inside stage multiplexers)
+export { analyzeStage15WireframeGenerator } from './stage-15-wireframe-generator.js';
+export { analyzeStage19VisualConvergence } from './stage-19-visual-convergence.js';
+export { generateDocs as generateStage17Docs } from './stage-17-doc-generation.js';
 
 /**
  * Get the acquirability analysis step for a given stage number.
@@ -95,9 +100,9 @@ export async function getAnalysisStep(stageNumber) {
     7: () => import('./stage-07-pricing-strategy.js').then(m => m.analyzeStage07),
     8: () => import('./stage-08-bmc-generation.js').then(m => m.analyzeStage08),
     9: () => import('./stage-09-exit-strategy.js').then(m => m.analyzeStage09),
-    10: () => import('./stage-10-naming-brand.js').then(m => m.analyzeStage10),
-    11: () => import('./stage-11-gtm.js').then(m => m.analyzeStage11),
-    12: () => import('./stage-12-sales-logic.js').then(m => m.analyzeStage12),
+    10: () => import('./stage-10-customer-brand.js').then(m => m.analyzeStage10),
+    11: () => import('./stage-11-visual-identity.js').then(m => m.analyzeStage11),
+    12: () => import('./stage-12-gtm-sales.js').then(m => m.analyzeStage12),
     13: () => import('./stage-13-product-roadmap.js').then(m => m.analyzeStage13),
     14: () => import('./stage-14-technical-architecture.js').then(m => m.analyzeStage14),
     15: () => import('./stage-15-risk-register.js').then(m => m.analyzeStage15),

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -1,10 +1,11 @@
 /**
- * Stage 15 Template - Risk Register
+ * Stage 15 Template - Risk Register & Wireframe Generation
  * Phase: THE BLUEPRINT (Stages 13-16)
- * Part of SD-EVA-FIX-STAGE15-RISK-001
+ * Part of SD-EVA-FIX-STAGE15-RISK-001, SD-MAN-INFRA-WIREFRAME-GENERATOR-STAGE-001
  *
  * Risk identification, severity/priority classification,
  * mitigation planning, and budget coherence validation.
+ * Wireframe generation from brand genome + technical architecture.
  *
  * @module lib/eva/stage-templates/stage-15
  */
@@ -12,6 +13,7 @@
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage15 } from './analysis-steps/stage-15-risk-register.js';
+import { analyzeStage15WireframeGenerator } from './analysis-steps/stage-15-wireframe-generator.js';
 
 const MIN_RISKS = 1;
 const SEVERITY_ENUM = ['critical', 'high', 'medium', 'low'];
@@ -112,7 +114,31 @@ const TEMPLATE = {
 };
 
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
-TEMPLATE.analysisStep = analyzeStage15;
+
+TEMPLATE.analysisStep = async function stage15Multiplexer(ctx) {
+  const logger = ctx.logger || console;
+
+  // Sub-step 1: Risk register (always runs)
+  const riskResult = await analyzeStage15(ctx);
+
+  // Sub-step 2: Wireframe generation (conditional on Stage 10 brand data)
+  let wireframeResult = null;
+  if (ctx.stage10Data?.customerPersonas?.length > 0 && ctx.stage10Data?.brandGenome) {
+    try {
+      wireframeResult = await analyzeStage15WireframeGenerator(ctx);
+      logger.log('[Stage15] Wireframe generation complete', {
+        screenCount: wireframeResult?.screens?.length || 0,
+      });
+    } catch (err) {
+      logger.warn('[Stage15] Wireframe generation failed (non-fatal)', { error: err.message });
+    }
+  } else {
+    logger.log('[Stage15] Skipping wireframes — Stage 10 brand data not available');
+  }
+
+  return { ...riskResult, wireframes: wireframeResult };
+};
+
 ensureOutputSchema(TEMPLATE);
 
 export { MIN_RISKS, SEVERITY_ENUM, PRIORITY_ENUM };

--- a/lib/eva/stage-templates/stage-19.js
+++ b/lib/eva/stage-templates/stage-19.js
@@ -1,17 +1,19 @@
 /**
- * Stage 18 Template - Sprint Planning
+ * Stage 19 Template - Sprint Planning & Visual Convergence
  * Phase: THE BUILD LOOP (Stages 17-22)
- * Part of SD-LEO-FEAT-TMPL-BUILD-001
+ * Part of SD-LEO-FEAT-TMPL-BUILD-001, SD-MAN-INFRA-ITERATOR-STAGE-VISUAL-001
  *
  * Sprint planning with backlog items and Lifecycle-to-SD Bridge
  * that generates SD draft payloads for each sprint item.
+ * Visual convergence 5-pass loop refines Stage 15 wireframes.
  *
- * @module lib/eva/stage-templates/stage-18
+ * @module lib/eva/stage-templates/stage-19
  */
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage18 } from './analysis-steps/stage-19-sprint-planning.js';
+import { analyzeStage19VisualConvergence } from './analysis-steps/stage-19-visual-convergence.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];
@@ -119,7 +121,37 @@ const TEMPLATE = {
 };
 
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
-TEMPLATE.analysisStep = analyzeStage18;
+
+TEMPLATE.analysisStep = async function stage19Multiplexer(ctx) {
+  const logger = ctx.logger || console;
+
+  // Sub-step 1: Sprint planning (always runs)
+  const sprintResult = await analyzeStage18(ctx);
+
+  // Sub-step 2: Visual convergence (only if Stage 15 wireframes exist)
+  let convergenceResult = null;
+  const wireframes = ctx.stage15Data?.wireframes;
+  if (wireframes?.screens?.length > 0) {
+    try {
+      convergenceResult = await analyzeStage19VisualConvergence(
+        ctx.ventureId,
+        { stage15_data: wireframes },
+        { logger },
+      );
+      logger.log('[Stage19] Visual convergence complete', {
+        score: convergenceResult?.overall_score,
+        verdict: convergenceResult?.verdict,
+      });
+    } catch (err) {
+      logger.warn('[Stage19] Visual convergence failed (non-fatal)', { error: err.message });
+    }
+  } else {
+    logger.log('[Stage19] Skipping visual convergence — no Stage 15 wireframes');
+  }
+
+  return { ...sprintResult, visual_convergence: convergenceResult };
+};
+
 ensureOutputSchema(TEMPLATE);
 
 export { PRIORITY_VALUES, SD_TYPES, MIN_SPRINT_ITEMS, SD_BRIDGE_REQUIRED_FIELDS, MIN_SPRINT_DURATION_DAYS, MAX_SPRINT_DURATION_DAYS };


### PR DESCRIPTION
## Summary

- **Wire wireframe generator into Stage 15** via multiplexer pattern (runs alongside risk register, conditional on S10 brand data)
- **Wire visual convergence into Stage 19** via multiplexer pattern (runs alongside sprint planning, conditional on S15 wireframes)
- **Add Stage 17 post-gate doc generation** in worker (creates EVA vision + architecture plan after chairman approves blueprint review)
- **Fix SRIP race condition**: read `venture_artifacts` (committed before stage progression) instead of `venture_stage_work` (committed after in `_syncStageWork`)
- **Fix `analysis-steps/index.js`** exports for stages 10-12 to match the files actually imported by stage templates
- **Add `CROSS_STAGE_DEPS`**: S10→S15 (brand data for wireframes), S15→S19 (wireframes for convergence)

All sub-steps wrapped in try/catch — failures are non-fatal. 68/68 tests passing.

## Test plan

- [x] Import validation: S15, S19, index.js all resolve correctly
- [x] SRIP data shape: verified `venture_artifacts.artifact_data` has `description`, `valueProp`, `customerSegments` etc.
- [x] Unit tests: 59 wireframe + convergence tests passing
- [x] Unit tests: 9 SRIP synthesizer tests passing
- [x] Smoke tests: 15/15 passing
- [ ] E2E: restart stage execution worker and verify ventures produce wireframe artifacts at Stage 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)