### PR TITLE
fix: persist wireframe artifacts via writeArtifact in Stage 15

### DIFF
--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -14,6 +14,7 @@ import { validateString, validateArray, validateEnum, collectErrors } from './va
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage15 } from './analysis-steps/stage-15-risk-register.js';
 import { analyzeStage15WireframeGenerator } from './analysis-steps/stage-15-wireframe-generator.js';
+import { writeArtifact } from '../artifact-persistence-service.js';
 
 const MIN_RISKS = 1;
 const SEVERITY_ENUM = ['critical', 'high', 'medium', 'low'];
@@ -129,6 +130,26 @@ TEMPLATE.analysisStep = async function stage15Multiplexer(ctx) {
       logger.log('[Stage15] Wireframe generation complete', {
         screenCount: wireframeResult?.screens?.length || 0,
       });
+
+      // Persist wireframes as a separate artifact
+      if (wireframeResult && ctx.supabase && ctx.ventureId) {
+        try {
+          await writeArtifact(ctx.supabase, {
+            ventureId: ctx.ventureId,
+            lifecycleStage: 15,
+            artifactType: 'blueprint_wireframes',
+            title: 'Wireframe Screens (Stage 15)',
+            artifactData: wireframeResult,
+            content: JSON.stringify(wireframeResult),
+            qualityScore: 70,
+            validationStatus: 'validated',
+            source: 'stage-15-wireframe-generator',
+          });
+          logger.log('[Stage15] Wireframe artifact persisted');
+        } catch (persistErr) {
+          logger.warn('[Stage15] Wireframe artifact persist failed (non-fatal)', { error: persistErr.message });
+        }
+      }
     } catch (err) {
       logger.warn('[Stage15] Wireframe generation failed (non-fatal)', { error: err.message });
     }


### PR DESCRIPTION
## Summary

- Added `writeArtifact()` call in Stage 15 multiplexer to persist wireframe data as `blueprint_wireframes` artifact
- The wireframe generator returns data but doesn't self-persist — the multiplexer must do it
- Discovered during testing: PR #2435 wired the generator correctly but artifacts weren't saved

## Test plan

- [x] Verified: 4/4 ventures have `blueprint_wireframes` artifacts (6-7 screens each)
- [x] Smoke tests: 15/15 passing
- [x] Import validation: S15 resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)