### PR TITLE
fix: prevent [object Object] in SRIP synthesizer output

### DIFF
--- a/lib/eva/services/srip-artifact-synthesizer.js
+++ b/lib/eva/services/srip-artifact-synthesizer.js
@@ -20,6 +20,22 @@ import { generateInterviewDefaults } from './srip-interview-engine.js';
 const SOURCE_TAG = 'artifact_synthesis';
 
 /**
+ * Safely extract text from a value that may be a string, an object with a .text
+ * or .name field, or any other type. Prevents [object Object] in output.
+ */
+function toText(val, maxLen = 200) {
+  if (val == null) return '';
+  if (typeof val === 'string') return val.substring(0, maxLen);
+  if (typeof val === 'object') {
+    // BMC items use {text, evidence}, other objects may use {name} or {value}
+    const text = val.text || val.name || val.value || val.label || val.title;
+    if (typeof text === 'string') return text.substring(0, maxLen);
+    return JSON.stringify(val).substring(0, maxLen);
+  }
+  return String(val).substring(0, maxLen);
+}
+
+/**
  * Collect stage artifacts from venture_artifacts.
  *
  * Uses venture_artifacts (committed before stage progression) instead of
@@ -77,13 +93,13 @@ function mapArtifactsToDna(artifacts) {
 
   // Derive copy_patterns from stage 1 (idea brief) and stage 8 (BMC)
   const headings = [];
-  if (stage1.valueProp) headings.push(String(stage1.valueProp).substring(0, 200));
-  if (stage8.valuePropositions?.items?.[0]) headings.push(String(stage8.valuePropositions.items[0]).substring(0, 200));
+  if (stage1.valueProp) headings.push(toText(stage1.valueProp));
+  if (stage8.valuePropositions?.items?.[0]) headings.push(toText(stage8.valuePropositions.items[0]));
 
   const ctas = [];
   if (stage8.channels?.items) {
     for (const ch of stage8.channels.items.slice(0, 3)) {
-      ctas.push(String(ch).substring(0, 100));
+      ctas.push(toText(ch, 100));
     }
   }
   // Infer B2B vs B2C from customer segments


### PR DESCRIPTION
## Summary

- Added `toText()` helper that extracts `.text`, `.name`, or `.value` from objects before stringifying
- Fixes `[object Object]` in copy_patterns headings, CTAs, and brand interview answers
- Root cause: Stage 8 BMC produces items as `{text, evidence}` objects, but synthesizer used `String(item)`
- Re-synthesized SRIP data for all 4 active ventures

## Test plan

- [x] AdmitArchitect headings: proper text instead of `[object Object]`
- [x] CTAs: "Freemium Product-Led Growth..." instead of `[object Object]`
- [x] Brand interview answers: readable values
- [x] SRIP synthesizer tests: 9/9 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)