### PR TITLE
fix: Stage 17 empty gate contract, failed→blocked status, doc-gen ventureContext

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -274,11 +274,7 @@ const STAGE_CONTRACTS = new Map([
 
   [17, {
     consumes: [],
-    produces: {
-      checklist: { type: 'object' },
-      readiness_pct: { type: 'number' },
-      buildReadiness: { type: 'object' },
-    },
+    produces: {},  // Blueprint Review is a gate stage — no required output fields
   }],
 
   [18, {

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -633,10 +633,12 @@ export class StageExecutionWorker {
               // Post-approval hook: Stage 17 doc generation (EVA vision + architecture plan)
               if (currentStage === 17) {
                 try {
+                  const { data: ventureRow } = await this._supabase
+                    .from('ventures').select('name').eq('id', ventureId).single();
                   const { generateDocs } = await import('./stage-templates/analysis-steps/stage-17-doc-generation.js');
                   await generateDocs({
                     ventureId,
-                    ventureName: ventureContext?.name,
+                    ventureName: ventureRow?.name,
                     supabase: this._supabase,
                     logger: this._logger,
                   });
@@ -1524,7 +1526,7 @@ export class StageExecutionWorker {
     let stageStatus;
     if (resultStatus === 'COMPLETED') stageStatus = 'completed';
     else if (resultStatus === 'BLOCKED') stageStatus = 'blocked';
-    else if (resultStatus === 'FAILED') stageStatus = 'failed';
+    else if (resultStatus === 'FAILED') stageStatus = 'blocked'; // DB constraint only allows: not_started, in_progress, blocked, completed, skipped
     else stageStatus = 'in_progress';
 
     // For chairman gate stages, mark as blocked (awaiting chairman approval)


### PR DESCRIPTION
## Summary

- Stage 17 contract had wrong produces (copy-paste from Stage 18 Build Readiness). Set to empty — Blueprint Review is a gate stage with no required template output.
- Map FAILED result status to 'blocked' in _syncStageWork — DB check constraint only allows: not_started, in_progress, blocked, completed, skipped
- Fix `ventureContext is not defined` in doc-gen hook — fetch venture name directly since ventureContext is only available after processStage runs

## Test plan

- [x] Hard gate blocking verified: _shouldAutoApproveStage(17) returns false
- [x] 4/4 PENDING chairman decisions created at Stage 17
- [ ] Doc-gen fires after chairman approval (retesting after this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)