### PR TITLE
feat: unify archetype taxonomy to Stage 1 constants

### DIFF
--- a/database/migrations/20260324_unify_archetype_taxonomy.sql
+++ b/database/migrations/20260324_unify_archetype_taxonomy.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- Migration: Unify Archetype Taxonomy
+-- SD: SD-MAN-INFRA-UNIFY-ARCHETYPE-TAXONOMY-001
+-- Purpose: Expand archetype_benchmarks to include all Stage 1 canonical
+--          archetypes, enabling direct ventures.archetype writes from Stage 1.
+-- ============================================================================
+
+-- ============================================================================
+-- Phase 1: Add Stage 1 canonical archetypes to archetype_benchmarks
+-- Uses INSERT ... ON CONFLICT DO NOTHING for idempotency.
+-- Financial benchmarks derived from closest existing archetype.
+-- ============================================================================
+
+INSERT INTO archetype_benchmarks (archetype, display_name, margin_target, margin_acceptable, breakeven_months, cac_ltv_ratio, description)
+VALUES
+  -- Canonical alias for saas_b2b/saas_b2c (blended benchmarks)
+  ('saas', 'SaaS', 0.65, 0.45, 21, 2.75, 'Software-as-a-service (B2B and B2C blended)'),
+  -- Canonical alias for ai_agents
+  ('ai_product', 'AI Product', 0.65, 0.45, 18, 3.50, 'AI-native tools, agents, copilots, automation'),
+  -- Canonical alias for content
+  ('media', 'Media', 0.50, 0.30, 24, 2.00, 'Content, publishing, entertainment'),
+  -- Canonical alias for hardware
+  ('deeptech', 'Deep Tech', 0.40, 0.25, 30, 2.00, 'Hardware, R&D, scientific computing'),
+  -- New archetypes (no direct equivalent in original benchmarks)
+  ('e_commerce', 'E-Commerce', 0.35, 0.20, 18, 3.00, 'Direct-to-consumer product sales'),
+  ('fintech', 'Fintech', 0.60, 0.40, 24, 3.50, 'Financial services and products'),
+  ('healthtech', 'Healthtech', 0.55, 0.35, 30, 3.00, 'Healthcare technology'),
+  ('edtech', 'Edtech', 0.50, 0.30, 24, 2.50, 'Education technology'),
+  ('creator_tools', 'Creator Tools', 0.60, 0.40, 18, 3.00, 'Tools for creators, freelancers, designers'),
+  ('real_estate', 'Real Estate Tech', 0.25, 0.15, 36, 4.00, 'Property technology')
+ON CONFLICT (archetype) DO NOTHING;
+
+-- ============================================================================
+-- Phase 2: Migrate existing ventures to canonical archetype values
+-- Old benchmark values -> Stage 1 canonical values.
+-- marketplace and services already match, no change needed.
+-- ============================================================================
+
+UPDATE ventures SET archetype = 'saas'       WHERE archetype = 'saas_b2b';
+UPDATE ventures SET archetype = 'saas'       WHERE archetype = 'saas_b2c';
+UPDATE ventures SET archetype = 'deeptech'   WHERE archetype = 'hardware';
+UPDATE ventures SET archetype = 'ai_product' WHERE archetype = 'ai_agents';
+UPDATE ventures SET archetype = 'media'      WHERE archetype = 'content';
+
+-- ============================================================================
+-- Verification: Count Stage 1 archetypes in benchmarks table
+-- Expected: >= 12 (original 7 + 10 new = 17, with marketplace and services shared)
+-- ============================================================================
+
+DO $$
+DECLARE
+  stage1_count INTEGER;
+BEGIN
+  SELECT count(*) INTO stage1_count
+  FROM archetype_benchmarks
+  WHERE archetype IN (
+    'saas', 'marketplace', 'ai_product', 'e_commerce', 'fintech',
+    'healthtech', 'edtech', 'media', 'creator_tools', 'services',
+    'deeptech', 'real_estate'
+  );
+
+  IF stage1_count < 12 THEN
+    RAISE WARNING 'Expected 12 Stage 1 archetypes in archetype_benchmarks, found %', stage1_count;
+  ELSE
+    RAISE NOTICE 'Verification passed: % Stage 1 archetypes found in archetype_benchmarks', stage1_count;
+  END IF;
+END $$;

--- a/lib/eva/stage-templates/analysis-steps/stage-01-hydration.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-01-hydration.js
@@ -22,7 +22,7 @@ You MUST output valid JSON with exactly these fields:
 - valueProp (string, min 20 chars): The core value proposition
 - targetMarket (string, min 10 chars): Who this is for
 - problemStatement (string, min 30 chars): The specific problem being solved
-- archetype (string): One of: saas, marketplace, deeptech, hardware, services, media, fintech
+- archetype (string): One of: ${ARCHETYPES.join(', ')}
 - ventureType (string): One of: ui, backend, mixed, data — classifies the venture's primary technology focus. "ui" = frontend/design-heavy (web app, mobile app, visual product). "backend" = API/services/infrastructure. "mixed" = full-stack with both UI and backend components. "data" = analytics, ML, data pipelines.
 - keyAssumptions (array of strings): 2-5 key assumptions the venture relies on
 - moatStrategy (string): Competitive advantage or defensibility strategy
@@ -121,18 +121,21 @@ Output ONLY valid JSON.`;
     ? parsed.ventureType
     : 'mixed'; // Default to mixed if LLM classification unclear
 
-  // Persist venture_type to ventures table (non-fatal)
-  // Note: archetype is NOT written here because ventures.archetype has a FK to
-  // archetype_benchmarks which uses a different taxonomy (saas_b2b/saas_b2c vs saas).
-  // The export RPC uses _get_venture_archetype() to fall back to artifact data.
+  // Persist venture_type and archetype to ventures table (non-fatal)
+  // archetype_benchmarks now contains all Stage 1 canonical archetypes,
+  // so ventures.archetype FK constraint is satisfied directly.
   if (supabase && ventureId && ventureType) {
     try {
+      const updateFields = { venture_type: ventureType };
+      if (archetype) {
+        updateFields.archetype = archetype;
+      }
       await supabase.from('ventures')
-        .update({ venture_type: ventureType })
+        .update(updateFields)
         .eq('id', ventureId);
-      logger.log('[Stage01] venture_type persisted', { ventureType });
+      logger.log('[Stage01] venture fields persisted', { ventureType, archetype });
     } catch (err) {
-      logger.warn('[Stage01] venture_type persist failed (non-fatal)', { error: err.message });
+      logger.warn('[Stage01] venture fields persist failed (non-fatal)', { error: err.message });
     }
   }
 


### PR DESCRIPTION
## Summary
- Expand `archetype_benchmarks` table with all 12 Stage 1 canonical archetypes (saas, marketplace, ai_product, e_commerce, fintech, healthtech, edtech, media, creator_tools, services, deeptech, real_estate)
- Update Stage 1 hydration LLM prompt to use `ARCHETYPES` constant instead of hardcoded list
- Enable direct `ventures.archetype` writes from Stage 1 hydration, eliminating the `_get_venture_archetype()` fallback need for new ventures

## Test plan
- [ ] Verify all 12 Stage 1 archetypes exist in `archetype_benchmarks` table
- [ ] Verify Stage 1 hydration LLM prompt lists all 12 archetypes
- [ ] Verify new ventures get archetype written directly to `ventures.archetype`
- [ ] Verify legacy ventures still work via artifact fallback
- [ ] Verify old archetype values (saas_b2b, saas_b2c, etc.) preserved for backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)