### PR TITLE
feat: move visual convergence to S15, hard gate to S19

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -543,7 +543,7 @@ export const CROSS_STAGE_DEPS = {
   // Phase 5: THE BUILD (Stages 17-21)
   17: [13, 14, 15, 16],      // Build readiness: roadmap + arch + risks + financials
   18: [13, 14, 17],          // Sprint planning: roadmap + arch + readiness
-  19: [15, 17, 18],          // Sprint planning + visual convergence: wireframes + readiness + sprint plan
+  19: [17, 18],              // Sprint planning: readiness + sprint plan
   20: [18, 19],              // QA & testing: sprint plan + dev output
   21: [19, 20],              // Build review: dev output + QA results
 

--- a/lib/eva/stage-templates/stage-15.js
+++ b/lib/eva/stage-templates/stage-15.js
@@ -14,6 +14,7 @@ import { validateString, validateArray, validateEnum, collectErrors } from './va
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage15 } from './analysis-steps/stage-15-risk-register.js';
 import { analyzeStage15WireframeGenerator } from './analysis-steps/stage-15-wireframe-generator.js';
+import { analyzeStage19VisualConvergence } from './analysis-steps/stage-19-visual-convergence.js';
 import { writeArtifact } from '../artifact-persistence-service.js';
 
 const MIN_RISKS = 1;
@@ -157,7 +158,25 @@ TEMPLATE.analysisStep = async function stage15Multiplexer(ctx) {
     logger.log('[Stage15] Skipping wireframes — Stage 10 brand data not available');
   }
 
-  return { ...riskResult, wireframes: wireframeResult };
+  // Sub-step 3: Wireframe preview convergence (lightweight — runs on wireframes just generated)
+  let convergenceResult = null;
+  if (wireframeResult?.screens?.length > 0) {
+    try {
+      convergenceResult = await analyzeStage19VisualConvergence(
+        ctx.ventureId,
+        { stage15_data: wireframeResult },
+        { logger },
+      );
+      logger.log('[Stage15] Wireframe preview convergence complete', {
+        score: convergenceResult?.overall_score,
+        verdict: convergenceResult?.verdict,
+      });
+    } catch (err) {
+      logger.warn('[Stage15] Wireframe convergence failed (non-fatal)', { error: err.message });
+    }
+  }
+
+  return { ...riskResult, wireframes: wireframeResult, wireframe_convergence: convergenceResult };
 };
 
 ensureOutputSchema(TEMPLATE);

--- a/lib/eva/stage-templates/stage-19.js
+++ b/lib/eva/stage-templates/stage-19.js
@@ -1,11 +1,13 @@
 /**
- * Stage 19 Template - Sprint Planning & Visual Convergence
+ * Stage 19 Template - Sprint Planning
  * Phase: THE BUILD LOOP (Stages 17-22)
- * Part of SD-LEO-FEAT-TMPL-BUILD-001, SD-MAN-INFRA-ITERATOR-STAGE-VISUAL-001
+ * Part of SD-LEO-FEAT-TMPL-BUILD-001
  *
  * Sprint planning with backlog items and Lifecycle-to-SD Bridge
  * that generates SD draft payloads for each sprint item.
- * Visual convergence 5-pass loop refines Stage 15 wireframes.
+ *
+ * Note: Visual convergence moved to Stage 15 (wireframe preview) and
+ * Stage 21 (build validation). Not run at Sprint Planning.
  *
  * @module lib/eva/stage-templates/stage-19
  */
@@ -13,7 +15,6 @@
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage18 } from './analysis-steps/stage-19-sprint-planning.js';
-import { analyzeStage19VisualConvergence } from './analysis-steps/stage-19-visual-convergence.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];
@@ -122,36 +123,7 @@ const TEMPLATE = {
 
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
 
-TEMPLATE.analysisStep = async function stage19Multiplexer(ctx) {
-  const logger = ctx.logger || console;
-
-  // Sub-step 1: Sprint planning (always runs)
-  const sprintResult = await analyzeStage18(ctx);
-
-  // Sub-step 2: Visual convergence (only if Stage 15 wireframes exist)
-  let convergenceResult = null;
-  // Check both paths: wrapped { wireframes: { screens: [...] } } and flat { screens: [...] }
-  const wireframes = ctx.stage15Data?.wireframes || (ctx.stage15Data?.screens ? ctx.stage15Data : null);
-  if (wireframes?.screens?.length > 0) {
-    try {
-      convergenceResult = await analyzeStage19VisualConvergence(
-        ctx.ventureId,
-        { stage15_data: wireframes },
-        { logger },
-      );
-      logger.log('[Stage19] Visual convergence complete', {
-        score: convergenceResult?.overall_score,
-        verdict: convergenceResult?.verdict,
-      });
-    } catch (err) {
-      logger.warn('[Stage19] Visual convergence failed (non-fatal)', { error: err.message });
-    }
-  } else {
-    logger.log('[Stage19] Skipping visual convergence — no Stage 15 wireframes');
-  }
-
-  return { ...sprintResult, visual_convergence: convergenceResult };
-};
+TEMPLATE.analysisStep = analyzeStage18;
 
 ensureOutputSchema(TEMPLATE);
 


### PR DESCRIPTION
## Summary

- **Move visual convergence** from Stage 19 (Sprint Planning) to Stage 15 (runs on freshly generated wireframes as a preview convergence)
- **Revert Stage 19** to simple sprint planning — no multiplexer needed
- **Remove S15 from S19 CROSS_STAGE_DEPS** (convergence no longer cross-stage)
- **hard_gate_stages** updated from [17] to [19] (DB config already applied)
- **Export RPC v3** applied to DB: adds Build Readiness, Sprint Plan, Visual Convergence groups

Stage 21 (QA) build validation convergence is a future SD.

## Test plan

- [x] S15 and S19 imports resolve
- [x] Export RPC v3 applied to Supabase
- [ ] Stage 15 produces wireframe convergence scores on next run
- [ ] Stage 19 blocks at hard gate for chairman approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)