### PR TITLE
feat: add EVA reference columns to venture_artifacts

### DIFF
--- a/database/migrations/20260324_venture_artifact_eva_references.sql
+++ b/database/migrations/20260324_venture_artifact_eva_references.sql
@@ -1,0 +1,38 @@
+-- Migration: Add EVA reference columns to venture_artifacts
+-- SD: SD-LEO-INFRA-STREAM-VENTURE-EVA-002-A
+-- Purpose: Enable evidence chain linkage from venture_artifacts to EVA governance records
+-- Behavior: Adds nullable soft-reference columns with partial indexes for efficient HEAL queries
+
+-- Add supports_vision_key column (soft reference to eva_vision_documents.vision_key)
+ALTER TABLE venture_artifacts
+  ADD COLUMN IF NOT EXISTS supports_vision_key VARCHAR(100);
+
+-- Add supports_plan_key column (soft reference to eva_architecture_plans.plan_key)
+ALTER TABLE venture_artifacts
+  ADD COLUMN IF NOT EXISTS supports_plan_key VARCHAR(100);
+
+-- Partial indexes for efficient HEAL evidence queries (only index non-null values)
+CREATE INDEX IF NOT EXISTS idx_va_supports_vision_key
+  ON venture_artifacts(supports_vision_key)
+  WHERE supports_vision_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_va_supports_plan_key
+  ON venture_artifacts(supports_plan_key)
+  WHERE supports_plan_key IS NOT NULL;
+
+-- Composite index for HEAL evidence chain queries that filter by vision_key + is_current
+CREATE INDEX IF NOT EXISTS idx_va_vision_key_current
+  ON venture_artifacts(supports_vision_key, is_current)
+  WHERE supports_vision_key IS NOT NULL AND is_current = true;
+
+CREATE INDEX IF NOT EXISTS idx_va_plan_key_current
+  ON venture_artifacts(supports_plan_key, is_current)
+  WHERE supports_plan_key IS NOT NULL AND is_current = true;
+
+-- Rollback SQL:
+-- DROP INDEX IF EXISTS idx_va_plan_key_current;
+-- DROP INDEX IF EXISTS idx_va_vision_key_current;
+-- DROP INDEX IF EXISTS idx_va_supports_plan_key;
+-- DROP INDEX IF EXISTS idx_va_supports_vision_key;
+-- ALTER TABLE venture_artifacts DROP COLUMN IF EXISTS supports_plan_key;
+-- ALTER TABLE venture_artifacts DROP COLUMN IF EXISTS supports_vision_key;


### PR DESCRIPTION
## Summary
- Add `supports_vision_key` and `supports_plan_key` nullable columns to `venture_artifacts`
- Create 4 partial indexes for efficient HEAL evidence chain queries
- Soft references (no FK constraint) for flexible EVA record management
- Migration is idempotent (IF NOT EXISTS) with rollback SQL included

**SD**: SD-LEO-INFRA-STREAM-VENTURE-EVA-002-A (A1: Database Migration)
**Orchestrator**: SD-LEO-INFRA-VENTURE-PIPELINE-TRACEABILITY-001

## Test plan
- [x] Migration executed successfully on production database
- [x] Both columns exist and are queryable
- [x] All 4 indexes created (verified via pg_indexes)
- [x] 511 existing rows unaffected (all NULL for new columns)
- [x] RLS policies intact (4 policies verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)