### PR TITLE
feat: add EVA eager synthesis to writeArtifact()

### DIFF
--- a/lib/eva/artifact-persistence-service.js
+++ b/lib/eva/artifact-persistence-service.js
@@ -33,6 +33,8 @@
  * @param {string|null} [opts.idempotencyKey] - Idempotency key for dedup
  * @param {string|null} [opts.epistemicClassification] - Four Buckets classification
  * @param {Array|null} [opts.epistemicEvidence] - Four Buckets evidence
+ * @param {string|null} [opts.visionKey] - EVA vision key — triggers eager synthesis upsert
+ * @param {string|null} [opts.planKey] - EVA architecture plan key — triggers eager synthesis upsert
  * @returns {Promise<string>} Inserted artifact ID
  */
 export async function writeArtifact(supabase, opts) {
@@ -53,6 +55,8 @@ export async function writeArtifact(supabase, opts) {
     idempotencyKey = null,
     epistemicClassification = null,
     epistemicEvidence = null,
+    visionKey = null,
+    planKey = null,
   } = opts;
 
   // Dedup: mark prior is_current=true rows of the SAME artifact type as false.
@@ -91,6 +95,8 @@ export async function writeArtifact(supabase, opts) {
   if (idempotencyKey) row.idempotency_key = idempotencyKey;
   if (epistemicClassification) row.epistemic_classification = epistemicClassification;
   if (epistemicEvidence) row.epistemic_evidence = epistemicEvidence;
+  if (visionKey) row.supports_vision_key = visionKey;
+  if (planKey) row.supports_plan_key = planKey;
 
   let { data, error } = await supabase
     .from('venture_artifacts')
@@ -114,6 +120,23 @@ export async function writeArtifact(supabase, opts) {
 
   if (error) {
     throw new Error(`[artifact-persistence-service] writeArtifact failed: ${error.message}`);
+  }
+
+  // Eager synthesis: upsert EVA governance records when vision/plan keys provided.
+  // Wrapped in try/catch — failure is logged but NEVER blocks artifact persistence.
+  if (visionKey) {
+    try {
+      await upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, lifecycleStage);
+    } catch (evaErr) {
+      console.warn(`[artifact-persistence-service] EVA vision upsert failed (non-blocking): ${evaErr.message}`);
+    }
+  }
+  if (planKey) {
+    try {
+      await upsertEvaArchFromArtifacts(supabase, planKey, ventureId, lifecycleStage);
+    } catch (evaErr) {
+      console.warn(`[artifact-persistence-service] EVA arch upsert failed (non-blocking): ${evaErr.message}`);
+    }
   }
 
   return data.id;
@@ -308,6 +331,160 @@ function deriveContent(artifactData) {
     // Circular reference or non-serializable — return type description
     return `[non-serializable ${typeof artifactData}]`;
   }
+}
+
+// ── EVA Eager Synthesis ──
+
+/**
+ * Upsert eva_vision_documents by synthesizing content from all linked artifacts.
+ * Fetches all current artifacts with matching supports_vision_key, synthesizes
+ * structured content, and upserts the vision record (incrementing version).
+ */
+async function upsertEvaVisionFromArtifacts(supabase, visionKey, ventureId, triggerStage) {
+  const { data: artifacts } = await supabase
+    .from('venture_artifacts')
+    .select('lifecycle_stage, artifact_type, content, quality_score')
+    .eq('supports_vision_key', visionKey)
+    .eq('is_current', true)
+    .order('lifecycle_stage', { ascending: true });
+
+  if (!artifacts?.length) return;
+
+  const synthesized = synthesizeFromArtifacts(artifacts, 'vision');
+
+  const { data: existing } = await supabase
+    .from('eva_vision_documents')
+    .select('id, version, addendums')
+    .eq('vision_key', visionKey)
+    .single();
+
+  if (existing) {
+    const newVersion = (existing.version || 1) + 1;
+    const addendums = existing.addendums || [];
+    addendums.push({
+      stage_number: triggerStage,
+      artifact_count: artifacts.length,
+      timestamp: new Date().toISOString(),
+    });
+    await supabase.from('eva_vision_documents').update({
+      content: synthesized,
+      version: newVersion,
+      addendums,
+      updated_at: new Date().toISOString(),
+    }).eq('vision_key', visionKey);
+  } else {
+    await supabase.from('eva_vision_documents').insert({
+      vision_key: visionKey,
+      level: 'L2',
+      venture_id: ventureId,
+      content: synthesized,
+      version: 1,
+      status: 'draft',
+      created_by: 'eager-synthesis',
+      addendums: [{ stage_number: triggerStage, artifact_count: artifacts.length, timestamp: new Date().toISOString() }],
+    });
+  }
+}
+
+/**
+ * Upsert eva_architecture_plans by synthesizing content from all linked artifacts.
+ */
+async function upsertEvaArchFromArtifacts(supabase, planKey, ventureId, triggerStage) {
+  const { data: artifacts } = await supabase
+    .from('venture_artifacts')
+    .select('lifecycle_stage, artifact_type, content, quality_score')
+    .eq('supports_plan_key', planKey)
+    .eq('is_current', true)
+    .order('lifecycle_stage', { ascending: true });
+
+  if (!artifacts?.length) return;
+
+  const synthesized = synthesizeFromArtifacts(artifacts, 'architecture');
+
+  const { data: existing } = await supabase
+    .from('eva_architecture_plans')
+    .select('id, version, addendums')
+    .eq('plan_key', planKey)
+    .single();
+
+  if (existing) {
+    const newVersion = (existing.version || 1) + 1;
+    const addendums = existing.addendums || [];
+    addendums.push({
+      stage_number: triggerStage,
+      artifact_count: artifacts.length,
+      timestamp: new Date().toISOString(),
+    });
+    await supabase.from('eva_architecture_plans').update({
+      content: synthesized,
+      version: newVersion,
+      addendums,
+      updated_at: new Date().toISOString(),
+    }).eq('plan_key', planKey);
+  } else {
+    await supabase.from('eva_architecture_plans').insert({
+      plan_key: planKey,
+      venture_id: ventureId,
+      content: synthesized,
+      version: 1,
+      status: 'draft',
+      created_by: 'eager-synthesis',
+      addendums: [{ stage_number: triggerStage, artifact_count: artifacts.length, timestamp: new Date().toISOString() }],
+    });
+  }
+}
+
+/**
+ * Deterministic synthesis: compose structured content from venture artifacts.
+ * Routes content into sections based on artifact_type. No LLM call.
+ * @param {Array} artifacts - Sorted by lifecycle_stage
+ * @param {'vision'|'architecture'} docType
+ * @returns {string} Synthesized markdown content
+ */
+export function synthesizeFromArtifacts(artifacts, docType) {
+  const VISION_SECTIONS = {
+    truth_idea_brief: 'Problem Statement & Initial Vision',
+    truth_ai_critique: 'Multi-Agent Critique',
+    truth_validation_decision: 'Validation Assessment',
+    truth_competitive_analysis: 'Competitive Landscape',
+    truth_financial_model: 'Financial Model & Unit Economics',
+    engine_risk_matrix: 'Risk Assessment',
+    engine_pricing_model: 'Revenue Architecture',
+    engine_business_model_canvas: 'Business Model',
+    engine_exit_strategy: 'Exit Strategy',
+    identity_persona_brand: 'Customer Personas & Brand',
+    identity_naming_visual: 'Visual Identity',
+    identity_gtm_sales_strategy: 'Go-to-Market Strategy',
+    blueprint_product_roadmap: 'Product Roadmap',
+  };
+
+  const ARCH_SECTIONS = {
+    blueprint_technical_architecture: 'Technical Architecture',
+    blueprint_api_contract: 'API Contracts',
+    blueprint_schema_spec: 'Schema Specification',
+    blueprint_data_model: 'Data Model',
+    blueprint_erd_diagram: 'Entity-Relationship Diagram',
+    blueprint_wireframes: 'Wireframes & UI Structure',
+    blueprint_user_story_pack: 'User Stories',
+    blueprint_risk_register: 'Risk Register',
+    blueprint_product_roadmap: 'Product Roadmap Context',
+  };
+
+  const sectionMap = docType === 'vision' ? VISION_SECTIONS : ARCH_SECTIONS;
+  const title = docType === 'vision' ? 'Vision Document' : 'Architecture Plan';
+  const sections = [];
+
+  for (const artifact of artifacts) {
+    const heading = sectionMap[artifact.artifact_type] || `Stage ${artifact.lifecycle_stage}: ${artifact.artifact_type}`;
+    const body = typeof artifact.content === 'string'
+      ? artifact.content.substring(0, 5000)
+      : JSON.stringify(artifact.content)?.substring(0, 5000) || '';
+    if (body.trim()) {
+      sections.push(`## ${heading}\n\n${body}`);
+    }
+  }
+
+  return `# ${title} (Auto-Synthesized)\n\n*Synthesized from ${artifacts.length} artifacts across stages ${artifacts[0]?.lifecycle_stage}-${artifacts[artifacts.length - 1]?.lifecycle_stage}*\n\n${sections.join('\n\n---\n\n')}`;
 }
 
 function deriveEpistemicClassification(payload) {


### PR DESCRIPTION
## Summary
- Enhance `writeArtifact()` with optional `visionKey`/`planKey` params for EVA eager synthesis
- When keys provided: set `supports_vision_key`/`supports_plan_key` on artifact, then upsert EVA governance record with synthesized content from all linked artifacts
- EVA upsert failure is non-blocking (try/catch, logged as warning)
- New deterministic `synthesizeFromArtifacts()` function routes content by artifact_type into structured markdown sections
- Version incrementing and addendum logging on each EVA upsert
- Fully backward compatible — no behavior change when keys not provided

**SD**: SD-LEO-INFRA-STREAM-VENTURE-EVA-002-B (A2: writeArtifact Enhancement)
**Orchestrator**: SD-LEO-INFRA-VENTURE-PIPELINE-TRACEABILITY-001

## Test plan
- [x] Module imports successfully with all 5 exports
- [x] writeArtifact signature includes visionKey/planKey params
- [ ] Unit test: writeArtifact without keys = identical behavior (backward compat)
- [ ] Unit test: writeArtifact with visionKey = artifact stored + EVA upserted
- [ ] Unit test: EVA upsert failure does not block artifact persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)