### PR TITLE
feat(B1): add architecture_plan_id FK, idempotency, and ADR tests

### DIFF
--- a/lib/eva/adr-extractor.js
+++ b/lib/eva/adr-extractor.js
@@ -121,14 +121,41 @@ export function extractADRs(archData) {
  * @param {Function} [options.logger] - Logger (default: console)
  * @returns {Promise<{inserted: number, adrIds: string[]}>}
  */
-export async function persistADRs(supabase, adrs, architecturePlanId, { logger = console } = {}) {
+export async function persistADRs(supabase, adrs, architecturePlanId, options = {}) {
+  const { logger = console } = options;
   if (!adrs || adrs.length === 0) {
     return { inserted: 0, adrIds: [] };
   }
 
+  // Check for existing ADRs to enable idempotency
+  if (architecturePlanId) {
+    const { data: existingAdrs } = await supabase
+      .from('leo_adrs')
+      .select('id, adr_number, decision')
+      .eq('architecture_plan_id', architecturePlanId)
+      .neq('status', 'superseded');
+
+    if (existingAdrs && existingAdrs.length > 0) {
+      const existingMap = new Map(existingAdrs.map(a => [a.adr_number, a]));
+      const newAdrs = adrs.filter(adr => {
+        const existing = existingMap.get(adr.adr_number);
+        if (existing && existing.decision === adr.decision) return false; // identical, skip
+        return true;
+      });
+      if (newAdrs.length === 0) {
+        logger.log('[ADR-Extractor] All ADRs already exist (idempotent skip)');
+        return { inserted: 0, adrIds: existingAdrs.map(a => a.id) };
+      }
+      // Filter to only new/changed ADRs
+      adrs = newAdrs;
+    }
+  }
+
   // Build rows for insertion
+  const prdId = options.prdId || `venture:${options.ventureId || 'unknown'}`;
   const rows = adrs.map(adr => ({
     id: adr.id,
+    prd_id: prdId,
     adr_number: adr.adr_number,
     title: adr.title,
     status: adr.status,
@@ -137,6 +164,7 @@ export async function persistADRs(supabase, adrs, architecturePlanId, { logger =
     options: typeof adr.options === 'string' ? JSON.parse(adr.options) : adr.options,
     consequences: typeof adr.consequences === 'string' ? JSON.parse(adr.consequences) : adr.consequences,
     rollback_plan: adr.rollback_plan,
+    ...(architecturePlanId ? { architecture_plan_id: architecturePlanId } : {}),
   }));
 
   const { error: insertError } = await supabase
@@ -193,4 +221,49 @@ export async function supersedeADR(supabase, oldAdrId, newAdrId) {
     .eq('id', oldAdrId);
 
   return !error;
+}
+
+/**
+ * Orchestrator entry point: extract ADRs from Stage 14 output and persist.
+ * Finds the architecture plan for the venture, extracts ADRs, and persists them.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} stageOutput - Stage 14 analysis output
+ * @param {Object} [options]
+ * @param {Function} [options.logger]
+ * @returns {Promise<{adrCount: number, adrIds: string[]}>}
+ */
+export async function extractAndPersistADRs(supabase, ventureId, stageOutput, options = {}) {
+  const { logger = console } = options;
+
+  // Find architecture plan for this venture
+  const { data: plan } = await supabase
+    .from('eva_architecture_plans')
+    .select('id, plan_key, adr_ids')
+    .eq('venture_id', ventureId)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!plan) {
+    logger.warn(`[ADR-Extractor] No architecture plan found for venture ${ventureId} — skipping`);
+    return { adrCount: 0, adrIds: [] };
+  }
+
+  const adrs = extractADRs(stageOutput);
+  if (adrs.length === 0) {
+    logger.warn('[ADR-Extractor] No ADRs extracted from Stage 14 output');
+    return { adrCount: 0, adrIds: [] };
+  }
+
+  logger.log(`[ADR-Extractor] Extracted ${adrs.length} ADRs from Stage 14 for venture ${ventureId}`);
+
+  const result = await persistADRs(supabase, adrs, plan.id, {
+    logger,
+    prdId: `venture:${ventureId}`,
+    ventureId,
+  });
+
+  return { adrCount: result.inserted, adrIds: result.adrIds };
 }

--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -25,6 +25,7 @@ import { attemptGateRecovery } from './gate-failure-recovery.js';
 import { isDevilsAdvocateGate, getDevilsAdvocateReview, buildArtifactRecord } from './devils-advocate.js';
 import { convertSprintToSDs, buildBridgeArtifactRecord } from './lifecycle-sd-bridge.js';
 import { writeArtifact, recordGateResult, advanceStage } from './artifact-persistence-service.js';
+import { extractAndPersistADRs } from './adr-extractor.js';
 import { handlePostLifecycleDecision, isFinalStage } from './post-lifecycle-decisions.js';
 import { createOrReusePendingDecision, waitForDecision, createAdvisoryNotification } from './chairman-decision-watcher.js';
 import { OrchestratorTracer } from './observability.js';
@@ -484,6 +485,19 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     }
   } else {
     tracer.endSpan(earlyPersistSpan.spanId, { status: 'skipped', metadata: { reason: 'dry_run' } });
+  }
+
+  // ── 4e. Stage 14 ADR extraction (post-artifact persistence) ──
+  if (resolvedStage === 14 && !options.dryRun && supabase) {
+    try {
+      const adrResult = await extractAndPersistADRs(supabase, ventureId, stageOutput, { logger });
+      if (adrResult.adrCount > 0) {
+        logger.log(`[Eva] Stage 14 ADR extraction: ${adrResult.adrCount} ADRs persisted`);
+      }
+    } catch (adrErr) {
+      // Non-blocking — ADR extraction failure should not stop the pipeline
+      logger.warn(`[Eva] Stage 14 ADR extraction failed (non-blocking): ${adrErr.message}`);
+    }
   }
 
   // ── 5. Evaluate gates (autonomy-aware) ──

--- a/tests/unit/eva/adr-extractor.test.js
+++ b/tests/unit/eva/adr-extractor.test.js
@@ -1,0 +1,295 @@
+/**
+ * Unit tests for ADR Extractor — Stage 14 ADR extraction and persistence
+ * SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001-A
+ *
+ * @module tests/unit/eva/adr-extractor.test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { extractADRs, persistADRs, supersedeADR } from '../../../lib/eva/adr-extractor.js';
+
+// Full architecture data matching Stage 14 output shape
+const FULL_ARCH_DATA = {
+  architecture_summary: 'Full-stack web application with React frontend and Node.js backend',
+  layers: {
+    presentation: { technology: 'React', components: ['Dashboard', 'Forms'], rationale: 'Component-based UI' },
+    api: { technology: 'REST/Express', components: ['Auth API', 'Data API'], rationale: 'Simple HTTP endpoints' },
+    business_logic: { technology: 'Node.js', components: ['Validator', 'Transformer'], rationale: 'JavaScript ecosystem' },
+    data: { technology: 'PostgreSQL', components: ['Users', 'Orders'], rationale: 'Relational data model' },
+    infrastructure: { technology: 'Vercel', components: ['CDN', 'Serverless'], rationale: 'Zero-config deployment' },
+  },
+  security: {
+    authStrategy: 'JWT',
+    dataClassification: 'confidential',
+    complianceRequirements: ['GDPR', 'SOC2'],
+  },
+  dataEntities: [
+    { name: 'User', description: 'Application user', relationships: ['Order'], estimatedVolume: '~10k' },
+    { name: 'Order', description: 'Purchase order', relationships: ['User', 'Product'], estimatedVolume: '~50k' },
+  ],
+  integration_points: [
+    { name: 'API Gateway', source_layer: 'presentation', target_layer: 'api', protocol: 'REST' },
+  ],
+  constraints: [
+    { name: 'Latency', description: '<200ms p99', category: 'performance' },
+  ],
+};
+
+describe('adr-extractor.js', () => {
+  describe('extractADRs()', () => {
+    it('should produce 3+ ADRs from full architecture data', () => {
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      expect(adrs.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it('should extract one ADR per non-TBD layer', () => {
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      const layerADRs = adrs.filter(a => a.title.includes('layer:'));
+      expect(layerADRs.length).toBe(5); // 5 layers, none TBD
+    });
+
+    it('should extract security ADR when authStrategy is defined', () => {
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      const securityADR = adrs.find(a => a.title.includes('Security:'));
+      expect(securityADR).toBeDefined();
+      expect(securityADR.decision).toContain('JWT');
+      expect(securityADR.decision).toContain('confidential');
+    });
+
+    it('should extract data model ADR when entities exist', () => {
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      const dataADR = adrs.find(a => a.title.includes('Data model:'));
+      expect(dataADR).toBeDefined();
+      expect(dataADR.decision).toContain('2 core data entities');
+    });
+
+    it('should assign correct decision_type per layer', () => {
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      const dataLayer = adrs.find(a => a.title.startsWith('data layer:'));
+      const apiLayer = adrs.find(a => a.title.startsWith('api layer:'));
+      const presLayer = adrs.find(a => a.title.startsWith('presentation layer:'));
+      expect(dataLayer.decision_type).toBe('data_model');
+      expect(apiLayer.decision_type).toBe('api_design');
+      expect(presLayer.decision_type).toBe('technical_choice');
+    });
+
+    it('should assign sequential adr_number values', () => {
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      const numbers = adrs.map(a => a.adr_number);
+      expect(numbers[0]).toBe('ADR-001');
+      expect(numbers[1]).toBe('ADR-002');
+      expect(numbers[numbers.length - 1]).toBe(`ADR-${String(adrs.length).padStart(3, '0')}`);
+    });
+
+    it('should generate unique UUIDs for each ADR', () => {
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      const ids = new Set(adrs.map(a => a.id));
+      expect(ids.size).toBe(adrs.length);
+    });
+
+    it('should skip layers with TBD technology', () => {
+      const partialData = {
+        ...FULL_ARCH_DATA,
+        layers: {
+          presentation: { technology: 'React', components: ['App'], rationale: 'Test' },
+          api: { technology: 'TBD', components: [], rationale: '' },
+          business_logic: { technology: 'TBD', components: [], rationale: '' },
+          data: { technology: 'TBD', components: [], rationale: '' },
+          infrastructure: { technology: 'TBD', components: [], rationale: '' },
+        },
+      };
+      const adrs = extractADRs(partialData);
+      const layerADRs = adrs.filter(a => a.title.includes('layer:'));
+      expect(layerADRs.length).toBe(1); // only presentation
+    });
+
+    it('should return empty array for null/undefined input', () => {
+      expect(extractADRs(null)).toEqual([]);
+      expect(extractADRs(undefined)).toEqual([]);
+    });
+
+    it('should return empty array when layers missing', () => {
+      expect(extractADRs({ security: {} })).toEqual([]);
+    });
+
+    it('should skip security ADR when authStrategy is TBD', () => {
+      const data = {
+        layers: { presentation: { technology: 'React', components: ['App'], rationale: 'Test' } },
+        security: { authStrategy: 'TBD', dataClassification: 'public' },
+      };
+      const adrs = extractADRs(data);
+      const secADR = adrs.find(a => a.title.includes('Security:'));
+      expect(secADR).toBeUndefined();
+    });
+
+    it('should skip data model ADR when no entities', () => {
+      const data = {
+        layers: { presentation: { technology: 'React', components: ['App'], rationale: 'Test' } },
+        dataEntities: [],
+      };
+      const adrs = extractADRs(data);
+      const dataADR = adrs.find(a => a.title.includes('Data model:'));
+      expect(dataADR).toBeUndefined();
+    });
+
+    it('should include rollback_plan on every ADR', () => {
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      adrs.forEach(adr => {
+        expect(adr.rollback_plan).toBeDefined();
+        expect(adr.rollback_plan.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('persistADRs()', () => {
+    /**
+     * Build a chainable Supabase mock that supports .from().select().eq().neq().single() etc.
+     */
+    function chainable(resolveValue) {
+      const chain = {};
+      const methods = ['select', 'eq', 'neq', 'order', 'limit', 'single', 'maybeSingle'];
+      methods.forEach(m => { chain[m] = vi.fn().mockReturnValue(chain); });
+      // Terminal methods resolve
+      chain.then = (fn) => Promise.resolve(resolveValue).then(fn);
+      // Make it thenable so await works
+      chain[Symbol.toStringTag] = 'Promise';
+      return chain;
+    }
+
+    function mockSupabase({ insertError = null, selectData = null, updateError = null } = {}) {
+      const leoAdrsChain = chainable({ data: selectData, error: null });
+      leoAdrsChain.insert = vi.fn().mockResolvedValue({ error: insertError });
+
+      const archPlansSelectChain = chainable({ data: { adr_ids: [] }, error: null });
+      const archPlansUpdateChain = chainable({ error: updateError });
+      archPlansSelectChain.select = vi.fn().mockReturnValue(archPlansSelectChain);
+      archPlansUpdateChain.update = vi.fn().mockReturnValue(archPlansUpdateChain);
+
+      return {
+        from: vi.fn((table) => {
+          if (table === 'leo_adrs') {
+            return {
+              insert: leoAdrsChain.insert,
+              select: vi.fn().mockReturnValue(leoAdrsChain),
+              update: vi.fn().mockReturnValue(leoAdrsChain),
+            };
+          }
+          if (table === 'eva_architecture_plans') {
+            return {
+              select: vi.fn().mockReturnValue(archPlansSelectChain),
+              update: vi.fn().mockReturnValue(archPlansUpdateChain),
+            };
+          }
+          return { insert: vi.fn().mockResolvedValue({ error: null }) };
+        }),
+      };
+    }
+
+    it('should return {inserted: 0} for empty ADR array', async () => {
+      const supabase = mockSupabase();
+      const result = await persistADRs(supabase, [], null);
+      expect(result).toEqual({ inserted: 0, adrIds: [] });
+    });
+
+    it('should insert ADR rows and return count + ids', async () => {
+      const supabase = mockSupabase();
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      const logger = { log: vi.fn(), warn: vi.fn() };
+      const result = await persistADRs(supabase, adrs, null, { logger });
+      expect(result.inserted).toBe(adrs.length);
+      expect(result.adrIds.length).toBe(adrs.length);
+    });
+
+    it('should set architecture_plan_id on rows when provided', async () => {
+      const insertFn = vi.fn().mockResolvedValue({ error: null });
+      // Build a supabase mock where we can inspect inserted rows
+      const leoChain = chainable({ data: [], error: null }); // no existing ADRs
+      const archChain = chainable({ data: { adr_ids: [] }, error: null });
+      const archUpdateChain = chainable({ error: null });
+
+      const supabase = {
+        from: vi.fn((table) => {
+          if (table === 'leo_adrs') {
+            return {
+              insert: insertFn,
+              select: vi.fn().mockReturnValue(leoChain),
+            };
+          }
+          if (table === 'eva_architecture_plans') {
+            return {
+              select: vi.fn().mockReturnValue(archChain),
+              update: vi.fn().mockReturnValue(archUpdateChain),
+            };
+          }
+          return {};
+        }),
+      };
+
+      const adrs = [extractADRs(FULL_ARCH_DATA)[0]];
+      const planId = 'plan-uuid-123';
+      const logger = { log: vi.fn(), warn: vi.fn() };
+      await persistADRs(supabase, adrs, planId, { logger });
+
+      expect(insertFn).toHaveBeenCalled();
+      const insertedRows = insertFn.mock.calls[0][0];
+      expect(insertedRows[0].architecture_plan_id).toBe(planId);
+    });
+
+    it('should return 0 on insert error', async () => {
+      const supabase = mockSupabase({ insertError: { message: 'DB error' } });
+      const adrs = extractADRs(FULL_ARCH_DATA);
+      const logger = { log: vi.fn(), warn: vi.fn() };
+      const result = await persistADRs(supabase, adrs, null, { logger });
+      expect(result.inserted).toBe(0);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('should include prd_id on rows', async () => {
+      const insertFn = vi.fn().mockResolvedValue({ error: null });
+      const supabase = {
+        from: vi.fn(() => ({
+          insert: insertFn,
+          select: vi.fn().mockReturnValue(chainable({ data: [], error: null })),
+        })),
+      };
+
+      const adrs = [extractADRs(FULL_ARCH_DATA)[0]];
+      const logger = { log: vi.fn(), warn: vi.fn() };
+      await persistADRs(supabase, adrs, null, { logger, prdId: 'test-prd-123' });
+
+      const insertedRows = insertFn.mock.calls[0][0];
+      expect(insertedRows[0].prd_id).toBe('test-prd-123');
+    });
+  });
+
+  describe('supersedeADR()', () => {
+    it('should update old ADR status to superseded with reference to new ADR', async () => {
+      const updateFn = vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      });
+      const supabase = {
+        from: vi.fn().mockReturnValue({ update: updateFn }),
+      };
+
+      const result = await supersedeADR(supabase, 'old-uuid', 'new-uuid');
+      expect(result).toBe(true);
+      expect(updateFn).toHaveBeenCalledWith({
+        status: 'superseded',
+        superseded_by: 'new-uuid',
+      });
+    });
+
+    it('should return false on error', async () => {
+      const supabase = {
+        from: vi.fn().mockReturnValue({
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: { message: 'Not found' } }),
+          }),
+        }),
+      };
+
+      const result = await supersedeADR(supabase, 'old-uuid', 'new-uuid');
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/tests/unit/eva/adr-persistence.test.js
+++ b/tests/unit/eva/adr-persistence.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { extractADRs } from '../../../lib/eva/adr-extractor.js';
+
+const MOCK_STAGE14_OUTPUT = {
+  architecture_summary: 'Modern web app with React frontend, Node.js API, PostgreSQL database',
+  layers: {
+    presentation: { technology: 'React 18', components: ['Dashboard', 'Settings'], rationale: 'Widely adopted, rich ecosystem' },
+    api: { technology: 'Express.js REST', components: ['Auth API', 'Data API'], rationale: 'Simple, well-documented' },
+    business_logic: { technology: 'Node.js', components: ['AuthService', 'DataService'], rationale: 'JavaScript full-stack consistency' },
+    data: { technology: 'PostgreSQL 15', components: ['users', 'ventures'], rationale: 'Strong JSONB support, relational integrity' },
+    infrastructure: { technology: 'Vercel + Supabase', components: ['CDN', 'Edge Functions'], rationale: 'Low-ops, managed services' },
+  },
+  security: {
+    authStrategy: 'JWT with refresh tokens',
+    dataClassification: 'internal',
+    complianceRequirements: ['GDPR'],
+  },
+  dataEntities: [
+    { name: 'User', description: 'Platform user', relationships: ['Venture'], estimatedVolume: '~1000/month' },
+    { name: 'Venture', description: 'Business venture', relationships: ['User', 'Stage'], estimatedVolume: '~500/month' },
+    { name: 'Stage', description: 'Evaluation stage', relationships: ['Venture'], estimatedVolume: '~5000/month' },
+  ],
+  integration_points: [
+    { name: 'Frontend-API', source_layer: 'presentation', target_layer: 'api', protocol: 'REST' },
+  ],
+  constraints: [
+    { name: 'Response time', description: 'API < 200ms p95', category: 'performance' },
+  ],
+};
+
+describe('extractADRs', () => {
+  it('extracts ADR for each non-TBD layer', () => {
+    const adrs = extractADRs(MOCK_STAGE14_OUTPUT);
+    // 5 layers → 5 ADRs (data→data_model, api→api_design, rest→technical_choice)
+    const layerAdrs = adrs.filter(a =>
+      ['technical_choice', 'data_model', 'api_design'].includes(a.decision_type) &&
+      a.title.includes('layer:')
+    );
+    expect(layerAdrs.length).toBe(5);
+  });
+
+  it('classifies data layer as data_model and api as api_design', () => {
+    const adrs = extractADRs(MOCK_STAGE14_OUTPUT);
+    const dataLayer = adrs.find(a => a.title.includes('data layer'));
+    const apiLayer = adrs.find(a => a.title.includes('api layer'));
+    expect(dataLayer.decision_type).toBe('data_model');
+    expect(apiLayer.decision_type).toBe('api_design');
+  });
+
+  it('extracts security ADR', () => {
+    const adrs = extractADRs(MOCK_STAGE14_OUTPUT);
+    const secAdrs = adrs.filter(a => a.decision_type === 'security_architecture');
+    expect(secAdrs.length).toBe(1);
+    expect(secAdrs[0].decision).toContain('JWT with refresh tokens');
+  });
+
+  it('extracts data model entity ADR', () => {
+    const adrs = extractADRs(MOCK_STAGE14_OUTPUT);
+    const entityAdrs = adrs.filter(a => a.title.includes('entities'));
+    expect(entityAdrs.length).toBe(1);
+    expect(entityAdrs[0].decision).toContain('3 core data entities');
+  });
+
+  it('produces >=3 ADRs total (success criteria)', () => {
+    const adrs = extractADRs(MOCK_STAGE14_OUTPUT);
+    expect(adrs.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('generates sequential adr_numbers', () => {
+    const adrs = extractADRs(MOCK_STAGE14_OUTPUT);
+    const numbers = adrs.map(a => a.adr_number);
+    expect(numbers[0]).toBe('ADR-001');
+    expect(numbers[1]).toBe('ADR-002');
+  });
+
+  it('sets status to accepted for all ADRs', () => {
+    const adrs = extractADRs(MOCK_STAGE14_OUTPUT);
+    expect(adrs.every(a => a.status === 'accepted')).toBe(true);
+  });
+
+  it('skips TBD layers', () => {
+    const output = {
+      ...MOCK_STAGE14_OUTPUT,
+      layers: {
+        ...MOCK_STAGE14_OUTPUT.layers,
+        presentation: { technology: 'TBD', components: ['TBD'], rationale: 'TBD' },
+      },
+    };
+    const adrs = extractADRs(output);
+    const layerAdrs = adrs.filter(a => a.title.includes('layer:'));
+    expect(layerAdrs.length).toBe(4); // 5 - 1 TBD
+  });
+
+  it('handles empty/null input gracefully', () => {
+    expect(extractADRs({})).toEqual([]);
+    expect(extractADRs({ layers: null })).toEqual([]);
+  });
+
+  it('includes context from layer rationale', () => {
+    const adrs = extractADRs(MOCK_STAGE14_OUTPUT);
+    const reactAdr = adrs.find(a => a.title.includes('React'));
+    expect(reactAdr.context).toBe('Widely adopted, rich ecosystem');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `architecture_plan_id` FK to ADR inserts for traceability
- Adds idempotency logic to prevent duplicate ADRs on re-execution
- Adds `extractAndPersistADRs()` orchestrator entry point
- Adds unit tests for ADR extractor (30 tests)

Part of SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001-A

## Test plan
- [x] Unit tests: 30/30 passing
- [x] No regressions in existing Stage 14 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)