### PR TITLE
feat(SD-DORMANT-001-B): activate EVA version incrementing + addendum logging

### DIFF
--- a/lib/eva/archplan-upsert.js
+++ b/lib/eva/archplan-upsert.js
@@ -13,10 +13,10 @@ export async function upsertArchPlan({ supabase, planKey, visionKey, content, se
   if (!visionKey) throw new Error('visionKey is required');
   if (!content) throw new Error('content is required');
 
-  // Resolve vision_id from vision_key
+  // Resolve vision_id and version from vision_key
   const { data: visionDoc, error: visionErr } = await supabase
     .from('eva_vision_documents')
-    .select('id, vision_key, level, status')
+    .select('id, vision_key, level, status, version')
     .eq('vision_key', visionKey)
     .single();
 
@@ -93,6 +93,7 @@ export async function upsertArchPlan({ supabase, planKey, visionKey, content, se
   const record = {
     plan_key: planKey,
     vision_id: visionDoc.id,
+    vision_version_aligned_to: visionDoc.version || 1,
     content,
     extracted_dimensions: dimensions || null,
     version,

--- a/lib/eva/vision-upsert.js
+++ b/lib/eva/vision-upsert.js
@@ -21,6 +21,17 @@ export async function upsertVision({ supabase, visionKey, level = 'L2', content,
 
   const version = existing ? existing.version + 1 : 1;
 
+  // Build addendums array — append entry on each enrichment (append-only)
+  const prevAddendums = existing?.addendums || [];
+  const addendums = version > 1
+    ? [...prevAddendums, {
+        version,
+        timestamp: new Date().toISOString(),
+        created_by: createdBy,
+        changed_sections: sections ? Object.keys(sections).filter(k => k !== 'extracted_at' && k !== 'extraction_source') : [],
+      }]
+    : prevAddendums;
+
   const record = {
     vision_key: visionKey,
     level,
@@ -31,7 +42,7 @@ export async function upsertVision({ supabase, visionKey, level = 'L2', content,
     chairman_approved: true,
     source_file_path: null,
     created_by: createdBy,
-    addendums: existing?.addendums || [],
+    addendums,
     ...(sections && Object.keys(sections).length > 0 ? { sections } : {}),
     ...(ventureId ? { venture_id: ventureId } : {}),
     ...(brainstormId ? { source_brainstorm_id: brainstormId } : {}),


### PR DESCRIPTION
## Summary
- Append addendum entry on each vision document enrichment (stage, timestamp, changed_sections)
- Set vision_version_aligned_to on architecture plans from current vision version

## Test plan
- [x] vision-upsert.js appends addendum on version > 1
- [x] archplan-upsert.js sets vision_version_aligned_to from visionDoc.version
- [x] Column vision_version_aligned_to exists on eva_architecture_plans table
- [ ] Verify addendums array populated after pipeline processes ventures

🤖 Generated with [Claude Code](https://claude.com/claude-code)