### PR TITLE
docs: add cascade invalidation protocol documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,4 +119,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-03-17 10:23:33 AM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-03-25 8:09:51 AM | Protocol: LEO 4.3.3 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-03-17 10:23:33 AM
+**Generated**: 2026-03-25 8:09:51 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions
 
@@ -26,6 +26,39 @@ The DATABASE sub-agent handles common blockers automatically:
 Task tool with subagent_type="database-agent":
 "Execute the migration file: database/migrations/YYYYMMDD_name.sql"
 ```
+
+## Cascade Invalidation System
+
+**Purpose**: When a vision document evolves (version bump), all downstream architecture plans and objectives are automatically flagged for review.
+
+### How It Works
+1. **Trigger**: `trg_cascade_invalidation_on_vision_update` fires on `eva_vision_documents` when `version` column changes
+2. **Effect**: Sets `needs_review_since = now()` on all linked `eva_architecture_plans` and `objectives`
+3. **Audit**: Creates entries in `cascade_invalidation_log` (append-only) and `cascade_invalidation_flags` (work queue)
+
+### Flag Lifecycle
+| Status | Meaning |
+|--------|---------|
+| pending | Document needs review after upstream change |
+| acknowledged | Reviewer has seen the flag |
+| resolved | Document updated to reflect upstream changes |
+| dismissed | Flag reviewed and no action needed |
+
+### Commands
+```bash
+# View cascade health summary
+node scripts/modules/governance/cascade-invalidation-engine.js summary
+
+# List stale documents needing review
+node scripts/modules/governance/cascade-invalidation-engine.js stale
+
+# Resolve a flag after review
+node scripts/modules/governance/cascade-invalidation-engine.js resolve <flagId> "Updated to reflect vision v3"
+```
+
+### Key Columns
+- `eva_architecture_plans.needs_review_since` — auto-set by trigger, NULL when resolved
+- `eva_architecture_plans.vision_version_aligned_to` — tracks which vision version the plan was last aligned with
 
 ## 🏗️ Application Architecture - UNIFIED FRONTEND
 
@@ -179,6 +212,48 @@ npm run handoff:compliance SD-ID
 
 **FAILURE TO RUN THESE COMMANDS = LEO PROTOCOL VIOLATION**
 
+## 🤖 Built-in Agent Integration
+
+## Built-in Agent Integration
+
+### Three-Layer Agent Architecture
+
+LEO Protocol uses three complementary agent layers:
+
+| Layer | Source | Agents | Purpose |
+|-------|--------|--------|---------|
+| **Built-in** | Claude Code | `Explore`, `Plan` | Fast discovery & multi-perspective planning |
+| **Sub-Agents** | `.claude/agents/` | DATABASE, TESTING, VALIDATION, etc. | Formal validation & gate enforcement |
+| **Skills** | `~/.claude/skills/` | 54 skills | Creative guidance & patterns |
+
+### Integration Principle
+
+> **Explore** for discovery → **Sub-agents** for validation → **Skills** for implementation patterns
+
+Built-in agents run FIRST (fast, parallel exploration), then sub-agents run for formal validation (database-driven, deterministic).
+
+### When to Use Each Layer
+
+| Task | Use | Example |
+|------|-----|---------|
+| "Does this already exist?" | Explore agent | `Task(subagent_type="Explore", prompt="Search for existing auth implementations")` |
+| "What patterns do we use?" | Explore agent | `Task(subagent_type="Explore", prompt="Find component patterns in src/")` |
+| "Is this schema valid?" | Sub-agent | `node lib/sub-agent-executor.js DATABASE <SD-ID>` |
+| "How should I build this?" | Skills | `skill: "schema-design"` or `skill: "e2e-patterns"` |
+| "What are the trade-offs?" | Plan agent | Launch 2-3 Plan agents with different perspectives |
+
+### Parallel Execution
+
+Built-in agents support parallel execution. Launch multiple Explore agents in a single message:
+
+```
+Task(subagent_type="Explore", prompt="Search for existing implementations")
+Task(subagent_type="Explore", prompt="Find related patterns")
+Task(subagent_type="Explore", prompt="Identify affected areas")
+```
+
+This is faster than sequential exploration and provides comprehensive coverage.
+
 ## Claude Code Plan Mode Integration
 
 **Status**: ACTIVE | **Version**: 1.0.0
@@ -222,47 +297,37 @@ Claude Code's Plan Mode integrates with LEO Protocol to provide:
 ### Module Location
 `scripts/modules/plan-mode/` - LEOPlanModeOrchestrator.js, phase-permissions.js
 
-## 🤖 Built-in Agent Integration
+## Work Tracking Policy
 
-## Built-in Agent Integration
+**ALL changes to main must be tracked** as either:
 
-### Three-Layer Agent Architecture
+### Strategic Directive (SD) - For Substantial Work
+- Features, refactors, infrastructure (>50 LOC)
+- Branch: `feat/SD-XXX-*`, `fix/SD-XXX-*`, etc.
+- Command: `npm run sd:create`
 
-LEO Protocol uses three complementary agent layers:
+### Quick-Fix (QF) - For Small Fixes
+- Bugs, polish, docs (<=50 LOC)
+- Branch: `quick-fix/QF-YYYYMMDD-NNN`
+- Command: `node scripts/create-quick-fix.js --interactive`
 
-| Layer | Source | Agents | Purpose |
-|-------|--------|--------|---------|
-| **Built-in** | Claude Code | `Explore`, `Plan` | Fast discovery & multi-perspective planning |
-| **Sub-Agents** | `.claude/agents/` | DATABASE, TESTING, VALIDATION, etc. | Formal validation & gate enforcement |
-| **Skills** | `~/.claude/skills/` | 54 skills | Creative guidance & patterns |
+### Why This Matters
+- All work tracked in database
+- Lessons learned captured
+- Quality gates enforced
+- Progress metrics accurate
 
-### Integration Principle
-
-> **Explore** for discovery → **Sub-agents** for validation → **Skills** for implementation patterns
-
-Built-in agents run FIRST (fast, parallel exploration), then sub-agents run for formal validation (database-driven, deterministic).
-
-### When to Use Each Layer
-
-| Task | Use | Example |
-|------|-----|---------|
-| "Does this already exist?" | Explore agent | `Task(subagent_type="Explore", prompt="Search for existing auth implementations")` |
-| "What patterns do we use?" | Explore agent | `Task(subagent_type="Explore", prompt="Find component patterns in src/")` |
-| "Is this schema valid?" | Sub-agent | `node lib/sub-agent-executor.js DATABASE <SD-ID>` |
-| "How should I build this?" | Skills | `skill: "schema-design"` or `skill: "e2e-patterns"` |
-| "What are the trade-offs?" | Plan agent | Launch 2-3 Plan agents with different perspectives |
-
-### Parallel Execution
-
-Built-in agents support parallel execution. Launch multiple Explore agents in a single message:
-
+### Emergency Bypass (Logged)
+```bash
+EMERGENCY_PUSH="critical: reason here" git push
 ```
-Task(subagent_type="Explore", prompt="Search for existing implementations")
-Task(subagent_type="Explore", prompt="Find related patterns")
-Task(subagent_type="Explore", prompt="Identify affected areas")
-```
+This logs to audit_log and should be followed by retroactive SD/QF creation.
 
-This is faster than sequential exploration and provides comprehensive coverage.
+### Pre-Push Enforcement
+The pre-push hook automatically:
+1. Detects SD/QF from branch name
+2. Verifies completion status in database
+3. Blocks if not ready for merge
 
 ## Sub-Agent Model Routing
 
@@ -305,70 +370,43 @@ Task({ subagent_type: 'database-agent', prompt: '...', model: 'haiku' })  // NO!
 
 > **Team Capabilities**: All sub-agents are universal leaders — any agent can spawn specialist teams when a task requires cross-domain expertise. See **Teams Protocol** in CLAUDE.md for templates, dynamic agent creation, and knowledge enrichment.
 
-## Work Tracking Policy
+## Sub-Agent Routing Reference
 
-**ALL changes to main must be tracked** as either:
+All 16 specialized sub-agents are available in EVERY phase (LEAD, PLAN, EXEC). Use the Task tool with the appropriate `subagent_type` to invoke them. See phase-specific guidance in each phase's CLAUDE file for recommended priorities.
 
-### Strategic Directive (SD) - For Substantial Work
-- Features, refactors, infrastructure (>50 LOC)
-- Branch: `feat/SD-XXX-*`, `fix/SD-XXX-*`, etc.
-- Command: `npm run sd:create`
+> **Routing Config**: Full keyword-to-agent mappings are defined in `config/agent-keywords-routing.json`. The table below is a quick reference.
 
-### Quick-Fix (QF) - For Small Fixes
-- Bugs, polish, docs (<=50 LOC)
-- Branch: `quick-fix/QF-YYYYMMDD-NNN`
-- Command: `node scripts/create-quick-fix.js --interactive`
+| Agent | Trigger Keywords | Best For |
+|-------|-----------------|----------|
+| database-agent | migration, schema, sql, postgres, rls | Database operations, migrations, RLS policies |
+| design-agent | component design, tailwind, responsive, a11y | UI/UX design, accessibility, frontend components |
+| security-agent | auth bypass, csrf, xss, vulnerability | Security audits, vulnerability fixes |
+| testing-agent | test coverage, e2e test, unit test, vitest | Test creation, test infrastructure |
+| performance-agent | bottleneck, load time, memory leak | Performance optimization, profiling |
+| rca-agent | root cause, 5 whys, failure analysis | Root cause analysis, debugging |
+| docmon-agent | documentation update, api docs, readme | Documentation maintenance |
+| regression-agent | backward compatible, breaking change, refactor | Refactoring safety, API compatibility |
+| retro-agent | retrospective, lessons learned, post-mortem | Sprint retrospectives, learning capture |
+| risk-agent | risk assessment, security risk, tradeoff | Risk analysis, architecture decisions |
+| validation-agent | duplicate check, existing implementation | Codebase validation, overlap detection |
+| stories-agent | user stories, acceptance criteria, epic | User story generation |
+| github-agent | pull request, ci pipeline, code review | Git operations, CI/CD |
+| api-agent | api endpoint, rest api, graphql | API design and implementation |
+| dependency-agent | npm audit, outdated packages, vulnerability | Dependency management |
+| uat-agent | user acceptance test, user journey, manual test | User acceptance testing |
 
-### Why This Matters
-- All work tracked in database
-- Lessons learned captured
-- Quality gates enforced
-- Progress metrics accurate
-
-### Emergency Bypass (Logged)
-```bash
-EMERGENCY_PUSH="critical: reason here" git push
+### Invocation Pattern
 ```
-This logs to audit_log and should be followed by retroactive SD/QF creation.
+Task(subagent_type="<agent-name>", prompt="Execute <AGENT> analysis for SD-XXX...")
+```
 
-### Pre-Push Enforcement
-The pre-push hook automatically:
-1. Detects SD/QF from branch name
-2. Verifies completion status in database
-3. Blocks if not ready for merge
+### Key Rules
+- **ALL phases**: Sub-agents are available in LEAD, PLAN, and EXEC phases
+- **Model**: Always use Sonnet (never Haiku) - see Sub-Agent Model Routing section
+- **Immediate invocation**: When a task matches an agent's domain, invoke IMMEDIATELY - do not attempt manual workarounds
+- **Error routing**: ANY database error triggers database-agent; ANY test failure triggers testing-agent
 
-## 🖥️ UI Parity Requirement (MANDATORY)
-
-**Every backend data contract field MUST have a corresponding UI representation.**
-
-### Principle
-If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
-
-### Requirements
-
-1. **Data Contract Coverage**
-   - Every field in `stageX_data` wrappers must map to a UI component
-   - Score displays must show actual numeric values, not just pass/fail
-   - Confidence levels must be visible with appropriate visual indicators
-
-2. **Human Inspectability**
-   - Stage outputs must be viewable in human-readable format
-   - Key findings, red flags, and recommendations must be displayed
-   - Source citations must be accessible
-
-3. **No Hidden Logic**
-   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
-   - Threshold comparisons must be visible
-   - Stage weights must be displayed in aggregation views
-
-### Verification Checklist
-Before marking any stage/feature as complete:
-- [ ] All output fields have UI representation
-- [ ] Scores are displayed numerically
-- [ ] Key findings are visible to users
-- [ ] Recommendations are actionable in the UI
-
-**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
+*Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
 
 ## Execution Philosophy
 
@@ -407,43 +445,38 @@ Before marking any stage/feature as complete:
 - Skip PRD creation for child SDs
 - Mark parent complete before all children complete in database
 
-## Sub-Agent Routing Reference
+## 🖥️ UI Parity Requirement (MANDATORY)
 
-All 16 specialized sub-agents are available in EVERY phase (LEAD, PLAN, EXEC). Use the Task tool with the appropriate `subagent_type` to invoke them. See phase-specific guidance in each phase's CLAUDE file for recommended priorities.
+**Every backend data contract field MUST have a corresponding UI representation.**
 
-> **Routing Config**: Full keyword-to-agent mappings are defined in `config/agent-keywords-routing.json`. The table below is a quick reference.
+### Principle
+If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
 
-| Agent | Trigger Keywords | Best For |
-|-------|-----------------|----------|
-| database-agent | migration, schema, sql, postgres, rls | Database operations, migrations, RLS policies |
-| design-agent | component design, tailwind, responsive, a11y | UI/UX design, accessibility, frontend components |
-| security-agent | auth bypass, csrf, xss, vulnerability | Security audits, vulnerability fixes |
-| testing-agent | test coverage, e2e test, unit test, vitest | Test creation, test infrastructure |
-| performance-agent | bottleneck, load time, memory leak | Performance optimization, profiling |
-| rca-agent | root cause, 5 whys, failure analysis | Root cause analysis, debugging |
-| docmon-agent | documentation update, api docs, readme | Documentation maintenance |
-| regression-agent | backward compatible, breaking change, refactor | Refactoring safety, API compatibility |
-| retro-agent | retrospective, lessons learned, post-mortem | Sprint retrospectives, learning capture |
-| risk-agent | risk assessment, security risk, tradeoff | Risk analysis, architecture decisions |
-| validation-agent | duplicate check, existing implementation | Codebase validation, overlap detection |
-| stories-agent | user stories, acceptance criteria, epic | User story generation |
-| github-agent | pull request, ci pipeline, code review | Git operations, CI/CD |
-| api-agent | api endpoint, rest api, graphql | API design and implementation |
-| dependency-agent | npm audit, outdated packages, vulnerability | Dependency management |
-| uat-agent | user acceptance test, user journey, manual test | User acceptance testing |
+### Requirements
 
-### Invocation Pattern
-```
-Task(subagent_type="<agent-name>", prompt="Execute <AGENT> analysis for SD-XXX...")
-```
+1. **Data Contract Coverage**
+   - Every field in `stageX_data` wrappers must map to a UI component
+   - Score displays must show actual numeric values, not just pass/fail
+   - Confidence levels must be visible with appropriate visual indicators
 
-### Key Rules
-- **ALL phases**: Sub-agents are available in LEAD, PLAN, and EXEC phases
-- **Model**: Always use Sonnet (never Haiku) - see Sub-Agent Model Routing section
-- **Immediate invocation**: When a task matches an agent's domain, invoke IMMEDIATELY - do not attempt manual workarounds
-- **Error routing**: ANY database error triggers database-agent; ANY test failure triggers testing-agent
+2. **Human Inspectability**
+   - Stage outputs must be viewable in human-readable format
+   - Key findings, red flags, and recommendations must be displayed
+   - Source citations must be accessible
 
-*Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
+3. **No Hidden Logic**
+   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
+   - Threshold comparisons must be visible
+   - Stage weights must be displayed in aggregation views
+
+### Verification Checklist
+Before marking any stage/feature as complete:
+- [ ] All output fields have UI representation
+- [ ] Scores are displayed numerically
+- [ ] Key findings are visible to users
+- [ ] Recommendations are actionable in the UI
+
+**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## 🚫 Stage 7 Hard Block: UI Coverage Prerequisite
 
@@ -1135,60 +1168,63 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 **From Published Retrospectives** - Apply these learnings proactively.
 
-### 1. LEAD_TO_PLAN Handoff Retrospective: Crew Tournament Pattern for Stage 11 GTM [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
+### 1. LEAD_TO_PLAN Handoff Retrospective: Notification Service [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/27/2026 | **Score**: 100
 
 **Key Improvements**:
-- {"area":"PRD quality validation failed 4 times during planning (scores: 46, 0, 51, 49/100) - the LEA...
-- {"area":"Goal summary validation scored 0/100 on first attempt - the summary lacked measurable objec...
+- [PAT-AUTO-fee6f486] Gate RETROSPECTIVE_QUALITY_GATE failed: score 59/100
+- [PAT-AUTO-132791ed] Gate MANDATORY_TESTING_VALIDATION failed: score 0/100
 
 **Action Items**:
-- [ ] During LEAD approval for AI-related SDs, require explicit cost impact analysis (...
-- [ ] Add measurable success criteria to LEAD approval template: target quality improv...
+- [ ] Verify: 18 notification files verified and export expected functions for SD-MAN-...
+- [ ] Validate: Multi-channel delivery: email, telegram, discord, database for SD-MAN-...
 
-### 2. SD Completion Retrospective: Autonomy Model L0-L4 Full Implementation [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
+### 2. LEAD_TO_PLAN Handoff Retrospective: Unified Sensemaking Service - KB Binding, Multi-Type Routing, Dynamic Personas [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/23/2026 | **Score**: 100
 
 **Key Improvements**:
-- First EXEC-TO-PLAN handoff rejected (score 0) because sd_type="feature" requires 85% gate score but ...
-- PLAN-TO-LEAD retrospective rejected for learning_specificity (3/10) -- initial retrospective contain...
+- [PAT-AUTO-2db93761] Gate 1:userStoryQualityValidation failed: score 51/100
+- [PAT-AUTO-129d8943] Gate 1:prdQualityValidation failed: score 47/100
 
 **Action Items**:
-- [ ] Add sd_type "backend" or "infrastructure" that does not include UI gates in scor...
-- [ ] Document integration_operationalization required keys (consumers, dependencies, ...
+- [ ] Verify: Sensemaking service processes TYPE A (YouTube), TYPE B (text URL), TYPE ...
+- [ ] Validate: KB context from sensemaking_knowledge_base injected into every analysi...
 
-### 3. SD Completion Retrospective: Assumptions vs Reality End-to-End Loop (assumption-reality-tracker.js) [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
+### 3. LEAD_TO_PLAN Handoff Retrospective: Legacy Cleanup — Route Migration and Dead Component Removal [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/26/2026 | **Score**: 100
 
 **Key Improvements**:
-- PLAN-TO-EXEC handoff rejected 10 times before passing due to missing user stories and insufficient t...
-- deriveStatus() initially returned active instead of partially_validated, violating PRD FR-3 -- root ...
+- [PAT-AUTO-34afdf6c] Gate 1:prdQualityValidation failed: score 38/100
+- [PAT-AUTO-974f6c09] google API error: 503 - Google API error 503: {
+  "error": {
+    "code": 503,
+  ...
 
 **Action Items**:
-- [ ] Add observability/metrics for fire-and-forget Supabase writes in assumption-real...
-- [ ] Create integration test for full pipeline: collectRealityMeasurements -> buildCa...
+- [ ] Verify: Chairman routes point to v3 components for SD-LEO-ORCH-CHAIRMAN-WEB-PHAS...
+- [ ] Validate: Superseded chairman-v2 components deleted for SD-LEO-ORCH-CHAIRMAN-WEB...
 
-### 4. SD Completion Retrospective: Four Buckets Epistemic Classification Across 25 EVA Analysis Steps [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
+### 4. LEAD_TO_PLAN Handoff Retrospective: Notification Service [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/27/2026 | **Score**: 100
 
 **Key Improvements**:
-- PLAN-TO-EXEC handoff required 5 attempts because PRD separate columns (system_architecture, implemen...
-- Stage-02 (multi-persona) had fourBuckets variable scoped inside a for loop - required hoisting varia...
+- [PAT-AUTO-fee6f486] Gate RETROSPECTIVE_QUALITY_GATE failed: score 59/100
+- [PAT-AUTO-132791ed] Gate MANDATORY_TESTING_VALIDATION failed: score 0/100
 
 **Action Items**:
-- [ ] Create smoke test that runs one stage analysis end-to-end and verifies epistemic...
-- [ ] Monitor LLM token usage increase from appended Four Buckets prompt (~150 tokens ...
+- [ ] Verify: 18 notification files verified and export expected functions for SD-MAN-...
+- [ ] Validate: Multi-channel delivery: email, telegram, discord, database for SD-MAN-...
 
-### 5. PLAN_TO_EXEC Handoff Retrospective: Crew Tournament Pattern for Stage 11 GTM [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/15/2026 | **Score**: 100
+### 5. LEAD_TO_PLAN Handoff Retrospective: V1-Growth [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/27/2026 | **Score**: 100
 
 **Key Improvements**:
-- {"area":"PRD quality gate failed first attempt at 44/100 due to missing system_architecture section,...
-- {"area":"Exploration audit gate scored 0/100 because the format used files_examined instead of the r...
+- [PAT-AUTO-3439e3eb] Gate 1:userStoryQualityValidation failed: score 55/100
+- [PAT-AUTO-b8a37fa7] Gate 1:prdQualityValidation failed: score 18/100
 
 **Action Items**:
-- [ ] Create a pre-submission checklist for PRD quality gates that includes: system_ar...
-- [ ] Add timeout configuration testing to tournament orchestrator acceptance criteria...
+- [ ] Verify: Implementation complete with ~130 LOC for SD-MAN-INFRA-VISION-HEAL-PLATF...
+- [ ] Validate: All tests passing including stage-chain integration tests for SD-MAN-I...
 
 
 *Lessons auto-generated from `retrospectives` table. Query for full details.*
@@ -1254,7 +1290,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-03-17*
+*Generated from database: 2026-03-25*
 *Protocol Version: 4.3.3*
 *Includes: Proposals (0) + Hot Patterns (0) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-17T14:23:33.230Z -->
-<!-- git_commit: 0be59f24 -->
-<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
+<!-- generated_at: 2026-03-25T07:09:51.724Z -->
+<!-- git_commit: 859e85a2 -->
+<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
@@ -261,5 +261,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-03-17 10:23:33 AM*
+*DIGEST generated: 2026-03-25 8:09:51 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-17T14:23:33.230Z -->
-<!-- git_commit: 0be59f24 -->
-<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
+<!-- generated_at: 2026-03-25T07:09:51.724Z -->
+<!-- git_commit: 859e85a2 -->
+<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
@@ -152,5 +152,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-03-17 10:23:33 AM*
+*DIGEST generated: 2026-03-25 8:09:51 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-03-17 10:23:33 AM
+**Generated**: 2026-03-25 8:09:51 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing
 
@@ -291,7 +291,7 @@ npm run sd:branch:auto SD-XXX-001
 npm run sd:branch:check SD-XXX-001
 
 # Full command with options
-node scripts/create-sd-branch.js SD-XXX-001 --app EHG --auto-stash
+# scripts/create-sd-branch.js removed SD-XXX-001 --app EHG --auto-stash
 ```
 
 ### Branch Naming Convention
@@ -385,6 +385,41 @@ Sub-agents are FIRST RESPONDERS in EXEC phase. When you encounter a problem that
 
 *Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
 
+## Migration Script Pattern (MANDATORY)
+
+**Issue Pattern**: PAT-DB-MIGRATION-001
+
+When writing migration scripts, you MUST use the established pattern:
+
+### Correct Pattern
+```javascript
+import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
+import { readFileSync } from 'fs';
+
+const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
+const client = await createDatabaseClient('engineer', { verify: true });
+const statements = splitPostgreSQLStatements(migrationSQL);
+
+for (const statement of statements) {
+  await client.query(statement);
+}
+
+await client.end();
+```
+
+### NEVER Use This Pattern
+```javascript
+// WRONG - exec_sql RPC does not exist
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(url, key);
+await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
+```
+
+### Before Writing Migration Scripts
+1. Search for existing patterns: `Glob *migration*.js`
+2. Read `scripts/run-sql-migration.js` as canonical template
+3. Use `lib/supabase-connection.js` utilities
+
 ## 📚 Skill Integration (EXEC Phase)
 
 ## Skill Integration During EXEC
@@ -461,41 +496,6 @@ Skills provide patterns, templates, and examples. Apply them to your specific im
 Skills are for **creative guidance** (how to build).
 Sub-agents are for **validation** (did you build it right).
 Use skills during EXEC, save sub-agents for PLAN_VERIFY.
-
-## Migration Script Pattern (MANDATORY)
-
-**Issue Pattern**: PAT-DB-MIGRATION-001
-
-When writing migration scripts, you MUST use the established pattern:
-
-### Correct Pattern
-```javascript
-import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
-import { readFileSync } from 'fs';
-
-const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
-const client = await createDatabaseClient('engineer', { verify: true });
-const statements = splitPostgreSQLStatements(migrationSQL);
-
-for (const statement of statements) {
-  await client.query(statement);
-}
-
-await client.end();
-```
-
-### NEVER Use This Pattern
-```javascript
-// WRONG - exec_sql RPC does not exist
-import { createClient } from '@supabase/supabase-js';
-const supabase = createClient(url, key);
-await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
-```
-
-### Before Writing Migration Scripts
-1. Search for existing patterns: `Glob *migration*.js`
-2. Read `scripts/run-sql-migration.js` as canonical template
-3. Use `lib/supabase-connection.js` utilities
 
 ## Validation Rules (SD-LEARN-008)
 
@@ -694,6 +694,24 @@ EXEC→PLAN handoffs now have **intelligent verification**:
 | **300-600** | ✅ **OPTIMAL** | Sweet spot |
 | **>800** | **MUST split** | Too complex |
 
+## TODO Comment Standard
+
+## TODO Comment Standard (When Deferring Work)
+
+**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
+
+### Standard TODO Format
+
+```typescript
+// TODO (SD-ID): Action required
+// Requires: Dependencies, prerequisites
+// Estimated effort: X-Y hours
+// Current state: Mock/temporary/placeholder
+```
+
+**Success Pattern** (SD-UAT-003):
+> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
+
 ## Human-Like E2E Testing Fixtures
 
 ### Human-Like E2E Testing Enhancements (LEO v4.4)
@@ -777,24 +795,6 @@ All human-like test results are automatically included in the LEO evidence pack:
 - `test_results.attachments.accessibility` - axe-core violations
 - `test_results.attachments.chaos` - resilience test results
 - `test_results.attachments.llm_ux` - LLM evaluation scores
-
-## TODO Comment Standard
-
-## TODO Comment Standard (When Deferring Work)
-
-**Evidence from Retrospectives**: Proven pattern in SD-UAT-003 saved 4-6 hours.
-
-### Standard TODO Format
-
-```typescript
-// TODO (SD-ID): Action required
-// Requires: Dependencies, prerequisites
-// Estimated effort: X-Y hours
-// Current state: Mock/temporary/placeholder
-```
-
-**Success Pattern** (SD-UAT-003):
-> "Comprehensive TODO comments provided clear future work path. Saved 4-6 hours."
 
 ## EXEC Dual Test Requirement
 
@@ -912,86 +912,6 @@ UI Parity Status:
 - Gate 2.5 Status: PASS/FAIL
 ```
 
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
-
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
-
-**Every completed Strategic Directive and Quick-Fix MUST end with:**
-
-1. **Commit** - All changes committed with proper message format
-2. **Push** - Branch pushed to remote
-3. **Merge to Main** - Feature branch merged into main
-
-### For Quick-Fixes
-
-The `complete-quick-fix.js` script handles this automatically:
-
-```bash
-node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
-```
-
-The script will:
-1. Verify tests pass and UAT completed
-2. Commit and push changes
-3. **Prompt to merge PR to main** (or local merge if no PR)
-4. Delete the feature branch
-
-### For Strategic Directives
-
-After LEAD approval, execute the following:
-
-```bash
-# 1. Ensure all changes committed
-git add .
-git commit -m "feat(SD-YYYY-XXX): [description]
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
-
-# 2. Push to remote
-git push origin feature/SD-YYYY-XXX
-
-# 3. Create PR if not exists
-gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
-
-# 4. Merge PR (preferred method)
-gh pr merge --merge --delete-branch
-
-# OR local merge fallback
-git checkout main
-git pull origin main
-git merge --no-ff feature/SD-YYYY-XXX
-git push origin main
-git branch -d feature/SD-YYYY-XXX
-git push origin --delete feature/SD-YYYY-XXX
-```
-
-### Merge Checklist
-
-Before merging, verify:
-- [ ] All tests passing (unit + E2E)
-- [ ] CI/CD pipeline green
-- [ ] Code review completed (if required)
-- [ ] No merge conflicts
-- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
-
-### Anti-Patterns
-
-❌ **NEVER** leave feature branches unmerged after completion
-❌ **NEVER** skip the push step
-❌ **NEVER** merge without verifying tests pass
-❌ **NEVER** force push to main
-
-### Verification
-
-After merge, confirm:
-```bash
-git checkout main
-git pull origin main
-git log --oneline -5  # Should show your merge commit
-```
-
 ## 🌿 Branch Hygiene Gate (MANDATORY)
 
 ## Branch Hygiene Gate (MANDATORY)
@@ -1081,6 +1001,86 @@ When starting implementation:
 3. If multiple SDs detected → split branches
 4. If >100 files changed → assess scope creep
 5. Document branch health in handoff notes
+
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
+
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
+
+**Every completed Strategic Directive and Quick-Fix MUST end with:**
+
+1. **Commit** - All changes committed with proper message format
+2. **Push** - Branch pushed to remote
+3. **Merge to Main** - Feature branch merged into main
+
+### For Quick-Fixes
+
+The `complete-quick-fix.js` script handles this automatically:
+
+```bash
+node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
+```
+
+The script will:
+1. Verify tests pass and UAT completed
+2. Commit and push changes
+3. **Prompt to merge PR to main** (or local merge if no PR)
+4. Delete the feature branch
+
+### For Strategic Directives
+
+After LEAD approval, execute the following:
+
+```bash
+# 1. Ensure all changes committed
+git add .
+git commit -m "feat(SD-YYYY-XXX): [description]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# 2. Push to remote
+git push origin feature/SD-YYYY-XXX
+
+# 3. Create PR if not exists
+gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
+
+# 4. Merge PR (preferred method)
+gh pr merge --merge --delete-branch
+
+# OR local merge fallback
+git checkout main
+git pull origin main
+git merge --no-ff feature/SD-YYYY-XXX
+git push origin main
+git branch -d feature/SD-YYYY-XXX
+git push origin --delete feature/SD-YYYY-XXX
+```
+
+### Merge Checklist
+
+Before merging, verify:
+- [ ] All tests passing (unit + E2E)
+- [ ] CI/CD pipeline green
+- [ ] Code review completed (if required)
+- [ ] No merge conflicts
+- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
+
+### Anti-Patterns
+
+❌ **NEVER** leave feature branches unmerged after completion
+❌ **NEVER** skip the push step
+❌ **NEVER** merge without verifying tests pass
+❌ **NEVER** force push to main
+
+### Verification
+
+After merge, confirm:
+```bash
+git checkout main
+git pull origin main
+git log --oneline -5  # Should show your merge commit
+```
 
 ## Auto-Merge Workflow for SD Completion
 
@@ -1724,7 +1724,7 @@ Before writing any code, you MUST:
 | Requirement | Description |
 |-------------|-------------|
 | **Spec Compliance** | Code MUST match spec definitions exactly (table names, column types, API shapes) |
-| **26-Stage Insulation** | CEO Runtime MUST be OBSERVER-COMMITTER only - no direct venture_stage_work writes |
+| **25-Stage Insulation** | CEO Runtime MUST be OBSERVER-COMMITTER only - no direct venture_stage_work writes |
 | **Glass Cockpit Design** | UI MUST follow progressive disclosure, minimal chrome philosophy |
 | **Token Budget Enforcement** | All agent operations MUST respect venture token budgets |
 
@@ -1735,7 +1735,7 @@ All Vision V2 SDs have this implementation guidance:
 - **CREATE FROM NEW** - similar files may exist to learn from, but implement fresh
 - **DO NOT MODIFY** existing files - create new implementations per vision specs
 
-### 26-Stage Insulation Checklist (SD-VISION-V2-005 CRITICAL)
+### 25-Stage Insulation Checklist (SD-VISION-V2-005 CRITICAL)
 
 **Before marking SD-VISION-V2-005 complete:**
 
@@ -1774,8 +1774,8 @@ If SD implements a feature that reduces legacy references from 243 to 200:
 
 | Column | Valid Values | Hint |
 |--------|--------------|------|
-| `status` | pending, accepted, rejected, failed | Use one of: pending, accepted, rejected, failed |
 | `validation_score` | N/A | Validation score must be an integer between 0 and 100. Use Math.round() and clamp to 0-100. |
+| `status` | pending, accepted, rejected, failed | Use one of: pending, accepted, rejected, failed |
 
 ### leo_protocols
 
@@ -1800,9 +1800,9 @@ If SD implements a feature that reduces legacy references from 243 to 200:
 
 | Column | Valid Values | Hint |
 |--------|--------------|------|
+| `status` | pending_acceptance, accepted, rejected | Use one of: pending_acceptance, accepted, rejected |
 | `from_phase` | LEAD, PLAN, EXEC | Use one of: LEAD, PLAN, EXEC (uppercase) |
 | `to_phase` | LEAD, PLAN, EXEC | Use one of: LEAD, PLAN, EXEC (uppercase) |
-| `status` | pending_acceptance, accepted, rejected | Use one of: pending_acceptance, accepted, rejected |
 
 ### sd_scope_deliverables
 
@@ -1827,9 +1827,9 @@ If SD implements a feature that reduces legacy references from 243 to 200:
 
 | Column | Valid Values | Hint |
 |--------|--------------|------|
-| `status` | draft, completed, in_progress, ready | Use one of: draft, completed, in_progress, ready. NOT "approved" - that is not a valid value. |
-| `validation_status` | pending, in_progress, validated, failed, skipped | Use one of: pending, in_progress, validated, failed, skipped |
 | `e2e_test_status` | not_created, created, passing, failing, skipped | Use one of: not_created, created, passing, failing, skipped |
+| `validation_status` | pending, in_progress, validated, failed, skipped | Use one of: pending, in_progress, validated, failed, skipped |
+| `status` | draft, completed, in_progress, ready | Use one of: draft, completed, in_progress, ready. NOT "approved" - that is not a valid value. |
 
 
 
@@ -1937,6 +1937,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-03-17*
+*Generated from database: 2026-03-25*
 *Protocol Version: 4.3.3*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-17T14:23:33.230Z -->
-<!-- git_commit: 0be59f24 -->
-<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
+<!-- generated_at: 2026-03-25T07:09:51.724Z -->
+<!-- git_commit: 859e85a2 -->
+<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
@@ -218,5 +218,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-03-17 10:23:33 AM*
+*DIGEST generated: 2026-03-25 8:09:51 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-03-17 10:23:33 AM
+**Generated**: 2026-03-25 8:09:51 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation
 
@@ -456,6 +456,81 @@ node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
 - **Process Scripts**: `scripts/add-sd-to-database.js`, `scripts/handoff.js`, `scripts/leo-create-sd.js`
 - **Plan-Aware Creation**: `docs/reference/sd-key-generator-guide.md` (--from-plan section)
 
+## Child SD Context Loading (MANDATORY)
+
+**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
+
+### Why This Applies to Children
+
+Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
+- Has its own PRD
+- Has its own handoffs
+- Has its own retrospective
+- Must meet its own gate thresholds
+
+**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
+
+### Required Context Loading Sequence
+
+Before starting ANY work on a child SD:
+
+1. **Run child preflight validation**:
+   ```bash
+   node scripts/child-sd-preflight.js SD-XXX-001
+   ```
+
+2. **Read CLAUDE_CORE.md** (provides SD type requirements):
+   ```
+   Read tool: CLAUDE_CORE.md
+   ```
+
+3. **Read phase-specific file** based on current_phase:
+   | Phase | File |
+   |-------|------|
+   | LEAD_APPROVAL | CLAUDE_LEAD.md |
+   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
+   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
+
+### What CLAUDE_CORE.md Provides
+
+- SD type definitions (feature, bugfix, infrastructure, etc.)
+- Gate pass thresholds per SD type
+- Required handoff counts
+- Required sub-agents per SD type
+- Global negative constraints
+
+### Consequences of Skipping Context Loading
+
+Without loading CLAUDE_CORE.md before child SD work:
+- **Unknown requirements**: May not know PRD is required
+- **Wrong thresholds**: May target 70% when 85% is required
+- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
+- **Incomplete handoffs**: May not execute full chain
+
+### Enforcement
+
+The `child-sd-preflight.js` script now displays a reminder:
+```
+⚠️  CONTEXT LOADING REMINDER:
+   Before starting work, you MUST read:
+   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
+   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
+```
+
+**This reminder is advisory.** The actual context loading must be performed by reading the files.
+
+### Quick Reference
+
+| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
+|---------------|----------------|--------------|--------------|
+| feature | 85% | 5 | YES |
+| bugfix | 85% | 5 | YES |
+| infrastructure | 80% | 4 | YES |
+| documentation | 60% | 4 | NO |
+| refactor | 75-90% | 5 | Brief |
+
+*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
+
 ## Common SD Creation Errors and Solutions
 
 ### Database Constraint Errors
@@ -728,81 +803,6 @@ const sdKey = await generateSDKey({ source, type, title });
 4. `scripts/create-sd.js`
 5. `scripts/modules/learning/executor.js`
 
-
-## Child SD Context Loading (MANDATORY)
-
-**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
-
-### Why This Applies to Children
-
-Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
-- Has its own PRD
-- Has its own handoffs
-- Has its own retrospective
-- Must meet its own gate thresholds
-
-**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
-
-### Required Context Loading Sequence
-
-Before starting ANY work on a child SD:
-
-1. **Run child preflight validation**:
-   ```bash
-   node scripts/child-sd-preflight.js SD-XXX-001
-   ```
-
-2. **Read CLAUDE_CORE.md** (provides SD type requirements):
-   ```
-   Read tool: CLAUDE_CORE.md
-   ```
-
-3. **Read phase-specific file** based on current_phase:
-   | Phase | File |
-   |-------|------|
-   | LEAD_APPROVAL | CLAUDE_LEAD.md |
-   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
-   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
-
-### What CLAUDE_CORE.md Provides
-
-- SD type definitions (feature, bugfix, infrastructure, etc.)
-- Gate pass thresholds per SD type
-- Required handoff counts
-- Required sub-agents per SD type
-- Global negative constraints
-
-### Consequences of Skipping Context Loading
-
-Without loading CLAUDE_CORE.md before child SD work:
-- **Unknown requirements**: May not know PRD is required
-- **Wrong thresholds**: May target 70% when 85% is required
-- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
-- **Incomplete handoffs**: May not execute full chain
-
-### Enforcement
-
-The `child-sd-preflight.js` script now displays a reminder:
-```
-⚠️  CONTEXT LOADING REMINDER:
-   Before starting work, you MUST read:
-   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
-   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
-```
-
-**This reminder is advisory.** The actual context loading must be performed by reading the files.
-
-### Quick Reference
-
-| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
-|---------------|----------------|--------------|--------------|
-| feature | 85% | 5 | YES |
-| bugfix | 85% | 5 | YES |
-| infrastructure | 80% | 4 | YES |
-| documentation | 60% | 4 | NO |
-| refactor | 75-90% | 5 | Brief |
-
-*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
 
 ## Phase-Specific Sub-Agent Guidance: LEAD
 
@@ -1273,6 +1273,33 @@ Sequential LEAD approval allows learning from earlier children to inform later d
 
 > **Team Capabilities**: For orchestrator SDs with parallel children, agents can spawn specialist teams to accelerate cross-domain work. See **Teams Protocol** in CLAUDE.md.
 
+## SD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off SD creation scripts like:**
+- `create-*-sd.js`
+- `create-sd*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/leo-create-sd.js
+```
+
+### Why This Matters
+- One-off scripts bypass validation and governance
+- They create maintenance burden (100+ orphaned scripts)
+- They fragment the codebase and confuse future developers
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-sd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/leo-create-sd.js`
+2. Follow interactive prompts
+3. SD is properly validated and tracked in database
+
 ## Vision V2 SD Handling (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Reference Check
@@ -1301,7 +1328,7 @@ Before LEAD approval, you MUST:
 **Additional questions for Vision V2 SDs:**
 
 1. **Spec Alignment**: Does the SD scope match the referenced spec sections?
-2. **26-Stage Insulation**: If SD touches agents/CEOs, does it maintain READ-ONLY access to venture_stage_work?
+2. **25-Stage Insulation**: If SD touches agents/CEOs, does it maintain READ-ONLY access to venture_stage_work?
 3. **Vision Document Traceability**: Are specific spec sections cited in the SD description?
 
 ### Implementation Guidance
@@ -1314,33 +1341,6 @@ All Vision V2 SDs contain this metadata:
   "note": "Similar files may exist in the codebase that you can learn from, but we are creating from new."
 }
 ```
-
-## SD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off SD creation scripts like:**
-- `create-*-sd.js`
-- `create-sd*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/leo-create-sd.js
-```
-
-### Why This Matters
-- One-off scripts bypass validation and governance
-- They create maintenance burden (100+ orphaned scripts)
-- They fragment the codebase and confuse future developers
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-sd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/leo-create-sd.js`
-2. Follow interactive prompts
-3. SD is properly validated and tracked in database
 
 ## Parent-Child SD Phase Governance
 
@@ -1487,6 +1487,6 @@ Check `objectives` (active, current period) and `key_results` (status != 'achiev
 
 ---
 
-*Generated from database: 2026-03-17*
+*Generated from database: 2026-03-25*
 *Protocol Version: 4.3.3*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-17T14:23:33.230Z -->
-<!-- git_commit: 0be59f24 -->
-<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
+<!-- generated_at: 2026-03-25T07:09:51.724Z -->
+<!-- git_commit: 859e85a2 -->
+<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
@@ -126,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-17 10:23:33 AM*
+*DIGEST generated: 2026-03-25 8:09:51 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-03-17 10:23:33 AM
+**Generated**: 2026-03-25 8:09:51 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 
@@ -41,6 +41,19 @@ Resolve root causes so they do not happen again in the future. Update processes,
 
 *Directives from `leo_autonomous_directives` table (SD-LEO-CONTINUITY-001)*
 
+
+## Cascade Invalidation — PLAN Phase Guidance
+
+### Before Creating Architecture Plans
+Check if there are pending cascade invalidation flags:
+```bash
+node scripts/modules/governance/cascade-invalidation-engine.js stale architecture_plan
+```
+
+If flags exist, resolve them BEFORE creating new plans — stale plans should not be the basis for new work.
+
+### After Vision Updates
+When a vision document is updated during PLAN phase (e.g., via brainstorm refinement), the cascade trigger automatically flags downstream plans. Review flagged plans and update if the vision changes affect architecture decisions.
 
 ## 🎯 Multi-Perspective Planning
 
@@ -146,7 +159,7 @@ npm run sd:branch:auto SD-XXX-001
 npm run sd:branch:check SD-XXX-001
 
 # Full command with options
-node scripts/create-sd-branch.js SD-XXX-001 --app EHG --auto-stash
+# scripts/create-sd-branch.js removed SD-XXX-001 --app EHG --auto-stash
 ```
 
 ### Branch Naming Convention
@@ -431,23 +444,6 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 | "DESIGN sub-agent not executed" | Didn't run design-agent | Use Task tool with design-agent |
 | "DATABASE sub-agent not executed" | Didn't run database-agent | Use Task tool with database-agent |
 
-## Enhanced QA Engineering Director v2.0 - Testing-First Edition
-
-**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
-
-**Core Capabilities:**
-1. Professional test case generation from user stories
-2. Pre-test build validation (saves 2-3 hours)
-3. Database migration verification (prevents 1-2 hours debugging)
-4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
-5. Test infrastructure discovery and reuse
-
-**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
-
-**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
-
-**Full Guide**: See `docs/reference/qa-director-guide.md`
-
 ## ✅ Scope Verification with Explore (PLAN_VERIFY)
 
 ## Scope Verification with Explore
@@ -518,6 +514,23 @@ This change [describe]. Options:
 
 Which do you prefer?"
 ```
+
+## Enhanced QA Engineering Director v2.0 - Testing-First Edition
+
+**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
+
+**Core Capabilities:**
+1. Professional test case generation from user stories
+2. Pre-test build validation (saves 2-3 hours)
+3. Database migration verification (prevents 1-2 hours debugging)
+4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
+5. Test infrastructure discovery and reuse
+
+**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
+
+**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
+
+**Full Guide**: See `docs/reference/qa-director-guide.md`
 
 ## PLAN Pre-EXEC Checklist
 
@@ -1629,34 +1642,6 @@ for (const childId of childIds) {
 
 > **Team Capabilities**: When planning complex SDs, consider whether team spawning (any agent leading specialists) could parallelize cross-domain work. See **Teams Protocol** in CLAUDE.md.
 
-## PRD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off PRD creation scripts like:**
-- `create-prd-sd-*.js`
-- `insert-prd-*.js`
-- `enhance-prd-*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/add-prd-to-database.js
-```
-
-### Why This Matters
-- One-off scripts bypass PRD quality validation
-- They create massive maintenance burden (100+ orphaned scripts)
-- They fragment PRD creation patterns
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-prd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/add-prd-to-database.js`
-2. Follow the modular PRD creation system in `scripts/prd/`
-3. PRD is properly validated against quality rubrics
-
 ## Vision V2 PRD Requirements (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Integration in PRDs
@@ -1697,6 +1682,34 @@ Key spec requirements addressed:
 ### Implementation Guidance (from SD metadata)
 
 All Vision V2 SDs have `creation_mode: CREATE_FROM_NEW` - implement fresh per specs, learn from existing code but do not modify it.
+
+## PRD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off PRD creation scripts like:**
+- `create-prd-sd-*.js`
+- `insert-prd-*.js`
+- `enhance-prd-*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/add-prd-to-database.js
+```
+
+### Why This Matters
+- One-off scripts bypass PRD quality validation
+- They create massive maintenance burden (100+ orphaned scripts)
+- They fragment PRD creation patterns
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-prd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/add-prd-to-database.js`
+2. Follow the modular PRD creation system in `scripts/prd/`
+3. PRD is properly validated against quality rubrics
 
 ## Quality Assessment Integration in Handoffs
 
@@ -2077,18 +2090,6 @@ When creating a PRD during PLAN phase, connect functional requirements to releva
   - Criteria: max_length: 300; description: "Goal summary present and <= 300 chars"
 
 
-- **fileScopeValidation** (Gate 1)
-  - Weight: 0.08
-  - Required: Yes
-  - Criteria: description: "File scope has create/modify/delete arrays"; required_arrays: ["create","modify","delete"]
-
-
-- **executionPlanValidation** (Gate 1)
-  - Weight: 0.1
-  - Required: Yes
-  - Criteria: min_steps: 1; description: "Execution plan has >= 1 step"
-
-
 - **testingStrategyValidation** (Gate 1)
   - Weight: 0.1
   - Required: Yes
@@ -2269,24 +2270,6 @@ When creating a PRD during PLAN phase, connect functional requirements to releva
   - Criteria: description: "Target application is valid and accessible"; valid_targets: ["EHG","EHG_Engineer"]
 
 
-- **architectureVerification** (Gate 1)
-  - Weight: 0
-  - Required: No
-  - Criteria: checks: ["adr_exists","interfaces_defined"]; description: "Architecture verification gate"
-
-
-- **explorationAudit** (Gate 1)
-  - Weight: 0
-  - Required: No
-  - Criteria: checks: ["files_explored","patterns_identified"]; description: "Exploration audit - codebase understanding verified"
-
-
-- **branchEnforcement** (Gate 1)
-  - Weight: 0
-  - Required: Yes
-  - Criteria: checks: ["branch_exists","branch_naming_valid"]; description: "Git branch enforcement - feature branch created"
-
-
 - **subAgentOrchestration** (Gate 3)
   - Weight: 0
   - Required: Yes
@@ -2297,12 +2280,6 @@ When creating a PRD during PLAN phase, connect functional requirements to releva
   - Weight: 0
   - Required: No
   - Criteria: description: "Retrospective quality gate - lessons captured"; min_quality_score: 70
-
-
-- **gitCommitEnforcement** (Gate 3)
-  - Weight: 0
-  - Required: Yes
-  - Criteria: checks: ["commits_exist","commits_reference_sd"]; description: "Git commits reference SD ID"
 
 
 - **planToLeadHandoffExists** (Gate 4)
@@ -2349,6 +2326,6 @@ When creating a PRD during PLAN phase, connect functional requirements to releva
 
 ---
 
-*Generated from database: 2026-03-17*
+*Generated from database: 2026-03-25*
 *Protocol Version: 4.3.3*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-17T14:23:33.230Z -->
-<!-- git_commit: 0be59f24 -->
-<!-- db_snapshot_hash: 41d2dee99ad0b539 -->
+<!-- generated_at: 2026-03-25T07:09:51.724Z -->
+<!-- git_commit: 859e85a2 -->
+<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
@@ -124,5 +124,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-17 10:23:33 AM*
+*DIGEST generated: 2026-03-25 8:09:51 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,77 +1,77 @@
 {
-  "generated_at": "2026-03-17T14:23:33.230Z",
-  "git_commit": "0be59f24",
-  "db_snapshot_hash": "41d2dee99ad0b539",
+  "generated_at": "2026-03-25T07:09:51.724Z",
+  "git_commit": "859e85a2",
+  "db_snapshot_hash": "1ba41d24a4b01a2a",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 5753,
-      "estimated_tokens": 1439,
-      "content_hash": "ef5847a537f37ddb",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE.md"
+      "chars": 5752,
+      "estimated_tokens": 1438,
+      "content_hash": "a1fe2807cd6969f1",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 51423,
-      "estimated_tokens": 12856,
-      "content_hash": "763dad0ae00586ad",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_CORE.md"
+      "chars": 52506,
+      "estimated_tokens": 13127,
+      "content_hash": "b6238b72a6e60f80",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 54093,
-      "estimated_tokens": 13524,
-      "content_hash": "91e9862013f43d6c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_LEAD.md"
+      "chars": 54092,
+      "estimated_tokens": 13523,
+      "content_hash": "6892730c756d1a21",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 82129,
-      "estimated_tokens": 20533,
-      "content_hash": "cc2571ab149fe270",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_PLAN.md"
+      "chars": 81656,
+      "estimated_tokens": 20414,
+      "content_hash": "d37d9e4935c9226a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 69303,
-      "estimated_tokens": 17326,
-      "content_hash": "d3f42680bc17dbb4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_EXEC.md"
+      "chars": 69307,
+      "estimated_tokens": 17327,
+      "content_hash": "9e71ce13c66ef7c3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 6619,
+      "chars": 6618,
       "estimated_tokens": 1655,
-      "content_hash": "9e36b4877d1ed042",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_DIGEST.md"
+      "content_hash": "df6b2498f0cf8b8b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 10175,
+      "chars": 10174,
       "estimated_tokens": 2544,
-      "content_hash": "f22354d7766dea1e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "d688d9aed8b0b661",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 4802,
+      "chars": 4801,
       "estimated_tokens": 1201,
-      "content_hash": "def40b765cd0e308",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "eeaaf56bb2f9328a",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 5032,
+      "chars": 5031,
       "estimated_tokens": 1258,
-      "content_hash": "bdbcc27030bd79d0",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "51186629eac3b941",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 9486,
+      "chars": 9485,
       "estimated_tokens": 2372,
-      "content_hash": "c6f60cb0066a64d6",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-DOC-PROTOCOL-DOCUMENTATION-ACCURACY-001\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "7dc865e446aa9799",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     }
   }
 }

--- a/scripts/section-file-mapping.json
+++ b/scripts/section-file-mapping.json
@@ -43,7 +43,8 @@
       "work_tracking_policy",
       "genesis_codebase",
       "governance_strategic_hierarchy",
-      "governance_chairman_ceo_roles"
+      "governance_chairman_ceo_roles",
+      "cascade_invalidation_system"
     ],
     "_removed_sections_note": "weighted_keyword_scoring (implementation detail of keyword-intent-scorer.js, hook handles routing), mandatory_agent_invocation (covered by PreToolUse hook routing advisory), sub_agent_prompt_quality (duplicate of Five-Point Brief in CLAUDE.md router), sustainable_issue_resolution (overlaps RCA mandate and execution philosophy), skill_integration (skills are self-documenting, reference pointer sufficient), communication_context (common sense for Opus 4.6), parallel_execution (common sense - read-safe, write-sequential), development_workflow (duplicate of application_architecture), strunkian_writing_standards (moved to docs/reference/), rca_multi_expert_protocol (RCA agent knows its own collaboration protocol)"
   },
@@ -106,7 +107,8 @@
       "governance_kr_linkage_plan",
       "plan_smoke_test_requirement",
       "plan_failure_chain_ordering",
-      "sub_agent_phase_guidance_plan"
+      "sub_agent_phase_guidance_plan",
+      "cascade_invalidation_plan"
     ],
     "_removed_sections_note": "migration_execution_protocol_plan (duplicate of CORE), mandatory_phase_transitions_plan (duplicate of CORE), testing_tier_strategy (superseded by testing_tier_strategy_updated), schema_documentation_access + schema_documentation_reference + database_schema_overview (reference data, on-demand lookup via docs/), plan_visual_documentation_examples (Mermaid examples, reference doc). RCA mandate removed from generator — already in router."
   },


### PR DESCRIPTION
## Summary
- Verify `trg_cascade_invalidation_on_vision_update` trigger is active (14 log entries, 6 flags)
- Verify `needs_review_since` and `vision_version_aligned_to` columns exist on `eva_architecture_plans`
- Insert cascade invalidation documentation into `leo_protocol_sections` (core + plan sections)
- Update `section-file-mapping.json` with `cascade_invalidation_system` and `cascade_invalidation_plan` types
- Regenerate all CLAUDE and CLAUDE_DIGEST files from database

**SD**: SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001-C (B3: Cascade Invalidation End-to-End Verification)
**Parent**: SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001

## Test plan
- [x] Trigger exists and is enabled (verified via pg_trigger query)
- [x] Supporting tables have data (14 log, 6 flags)
- [x] Columns exist on eva_architecture_plans
- [x] Protocol sections appear in regenerated CLAUDE_CORE.md and CLAUDE_PLAN.md
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)