### PR TITLE
feat(C5): auto-decompose quality rubric, grandchild PRD generator, hierarchy iterator

### DIFF
--- a/scripts/modules/decomposition-rubric.js
+++ b/scripts/modules/decomposition-rubric.js
@@ -1,0 +1,160 @@
+/**
+ * Decomposition Quality Rubric — Scores SD hierarchy decompositions
+ *
+ * SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001-E (C5)
+ *
+ * Evaluates auto-decomposed SD hierarchies on 4 dimensions (1-5 each):
+ * - Boundary cleanliness: No overlapping scope between siblings
+ * - Scope balance: LOC distribution within 2x of mean
+ * - Dependency clarity: Explicit depends_on links between children
+ * - Completeness: All architecture plan phases are covered
+ *
+ * @module scripts/modules/decomposition-rubric
+ */
+
+import { getLLMClient } from '../../lib/llm/index.js';
+import { parseJSON, extractUsage } from '../../lib/eva/utils/parse-json.js';
+
+const DIMENSIONS = ['boundary', 'balance', 'dependency', 'completeness'];
+const THRESHOLD = 3.5;
+
+const RUBRIC_SYSTEM_PROMPT = `You are a decomposition quality evaluator for software engineering work breakdown structures.
+
+Score the following SD hierarchy decomposition on 4 dimensions (1-5 each):
+
+1. **boundary** (1-5): Scope overlap between sibling SDs.
+   5 = No overlap, clear boundaries. 1 = Significant scope duplication.
+
+2. **balance** (1-5): LOC/effort distribution across children.
+   5 = Even distribution (within 2x of mean). 1 = One child has >60% of total scope.
+
+3. **dependency** (1-5): Clarity of inter-child dependencies.
+   5 = All dependencies explicit with clear ordering. 1 = Circular or missing dependencies.
+
+4. **completeness** (1-5): Coverage of architecture plan phases.
+   5 = Every phase mapped to a child. 1 = Multiple phases unaccounted for.
+
+Output ONLY valid JSON:
+{
+  "boundary": { "score": N, "reasoning": "..." },
+  "balance": { "score": N, "reasoning": "..." },
+  "dependency": { "score": N, "reasoning": "..." },
+  "completeness": { "score": N, "reasoning": "..." },
+  "aggregate": N,
+  "recommendations": ["..."]
+}`;
+
+/**
+ * Score a decomposed hierarchy using LLM-based rubric evaluation.
+ *
+ * @param {Object[]} children - Child SD records with title, description, scope, dependencies
+ * @param {Object} archPlan - Architecture plan with phases
+ * @param {Object} [options]
+ * @param {Object} [options.logger]
+ * @returns {Promise<Object>} Rubric scores with aggregate and recommendations
+ */
+export async function scoreDecomposition(children, archPlan, options = {}) {
+  const { logger = console } = options;
+
+  if (!children || children.length === 0) {
+    return { aggregate: 0, scores: {}, recommendations: ['No children to score'], passed: false };
+  }
+
+  // Build context for LLM
+  const childSummaries = children.map((c, i) => ({
+    index: i + 1,
+    title: c.title,
+    scope: c.scope || c.description?.substring(0, 200),
+    dependencies: c.dependencies || [],
+  }));
+
+  const phases = archPlan?.sections?.implementation_phases
+    || extractPhasesFromContent(archPlan?.content || '');
+
+  const userPrompt = `## Architecture Plan Phases
+${phases.map((p, i) => `${i + 1}. ${p.title || p}: ${p.description || ''}`).join('\n')}
+
+## Decomposed Children (${children.length})
+${childSummaries.map(c => `${c.index}. ${c.title}\n   Scope: ${c.scope}\n   Dependencies: ${JSON.stringify(c.dependencies)}`).join('\n\n')}
+
+Score this decomposition.`;
+
+  try {
+    const client = getLLMClient({ purpose: 'content-generation' });
+    const response = await client.complete(RUBRIC_SYSTEM_PROMPT, userPrompt, { timeout: 60000 });
+    const result = parseJSON(response);
+
+    const scores = {};
+    let total = 0;
+    for (const dim of DIMENSIONS) {
+      const score = result[dim]?.score ?? 3;
+      scores[dim] = { score, reasoning: result[dim]?.reasoning || '' };
+      total += score;
+    }
+
+    const aggregate = total / DIMENSIONS.length;
+    const passed = aggregate >= THRESHOLD;
+
+    logger.log(`[DecompositionRubric] Scored: ${aggregate.toFixed(1)}/5 (${passed ? 'PASS' : 'NEEDS_ITERATION'})`);
+
+    return {
+      aggregate,
+      scores,
+      recommendations: result.recommendations || [],
+      passed,
+      threshold: THRESHOLD,
+    };
+  } catch (err) {
+    logger.warn(`[DecompositionRubric] LLM scoring failed, using heuristic: ${err.message}`);
+    return scoreHeuristic(children, phases);
+  }
+}
+
+/**
+ * Heuristic fallback when LLM is unavailable.
+ */
+function scoreHeuristic(children, phases) {
+  const scores = {};
+
+  // Boundary: check title/scope overlap via word intersection
+  const scopes = children.map(c => new Set((c.scope || c.title || '').toLowerCase().split(/\s+/)));
+  let maxOverlap = 0;
+  for (let i = 0; i < scopes.length; i++) {
+    for (let j = i + 1; j < scopes.length; j++) {
+      const intersection = [...scopes[i]].filter(w => scopes[j].has(w) && w.length > 3);
+      const overlap = intersection.length / Math.min(scopes[i].size, scopes[j].size);
+      maxOverlap = Math.max(maxOverlap, overlap);
+    }
+  }
+  scores.boundary = { score: maxOverlap > 0.5 ? 2 : maxOverlap > 0.3 ? 3 : 4, reasoning: `Max word overlap: ${(maxOverlap * 100).toFixed(0)}%` };
+
+  // Balance: check child count distribution
+  scores.balance = { score: children.length >= 2 && children.length <= 6 ? 4 : 3, reasoning: `${children.length} children` };
+
+  // Dependency: check if any dependencies defined
+  const hasDeps = children.some(c => c.dependencies?.length > 0);
+  scores.dependency = { score: hasDeps ? 4 : 2, reasoning: hasDeps ? 'Dependencies defined' : 'No dependencies' };
+
+  // Completeness: phases covered
+  const phaseCoverage = phases.length > 0 ? Math.min(children.length / phases.length, 1) : 0.5;
+  scores.completeness = { score: phaseCoverage >= 1 ? 5 : phaseCoverage >= 0.8 ? 4 : 3, reasoning: `${children.length} children / ${phases.length} phases` };
+
+  const aggregate = DIMENSIONS.reduce((s, d) => s + scores[d].score, 0) / DIMENSIONS.length;
+
+  return { aggregate, scores, recommendations: [], passed: aggregate >= THRESHOLD, threshold: THRESHOLD };
+}
+
+/**
+ * Extract phase titles from markdown content.
+ */
+function extractPhasesFromContent(content) {
+  const phases = [];
+  const regex = /^#{1,3}\s*(?:Phase|Implementation Phase|Step)\s+(\d+)[:\s]*(.*)$/gim;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    phases.push({ number: parseInt(match[1]), title: match[2].trim() });
+  }
+  return phases;
+}
+
+export { DIMENSIONS, THRESHOLD };

--- a/scripts/modules/grandchild-prd-generator.js
+++ b/scripts/modules/grandchild-prd-generator.js
@@ -1,0 +1,128 @@
+/**
+ * Grandchild PRD Generator — Creates individually-scoped PRDs for child SDs
+ *
+ * SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001-E (C5)
+ *
+ * Given an architecture plan and a decomposed child SD, generates a PRD
+ * containing only the functional requirements relevant to that child's scope.
+ * Avoids copy-pasting the parent PRD.
+ *
+ * @module scripts/modules/grandchild-prd-generator
+ */
+
+import { getLLMClient } from '../../lib/llm/index.js';
+import { parseJSON } from '../../lib/eva/utils/parse-json.js';
+
+const PRD_SYSTEM_PROMPT = `You are a PRD generator for a specific child SD within a decomposed hierarchy.
+
+Given:
+- The parent architecture plan phase this child covers
+- The child SD title and scope
+- The full architecture plan for context
+
+Generate a focused PRD with ONLY the functional requirements relevant to this child.
+Do NOT include requirements from other phases or sibling SDs.
+
+Output valid JSON:
+{
+  "executive_summary": "1-2 sentence summary of this child's scope",
+  "functional_requirements": [
+    { "id": "FR-001", "title": "...", "description": "...", "priority": "must_have" }
+  ],
+  "acceptance_criteria": ["AC-001: ..."],
+  "implementation_approach": "Brief approach for this child only",
+  "risks": [{ "risk": "...", "mitigation": "..." }]
+}`;
+
+/**
+ * Generate a PRD for a single child SD based on its architecture plan phase.
+ *
+ * @param {Object} childSD - Child SD record with title, description, scope
+ * @param {Object} phase - Architecture plan phase this child covers
+ * @param {Object} archPlan - Full architecture plan for context
+ * @param {Object} [options]
+ * @param {Object} [options.logger]
+ * @returns {Promise<Object>} PRD content fields ready for product_requirements_v2
+ */
+export async function generateChildPRD(childSD, phase, archPlan, options = {}) {
+  const { logger = console } = options;
+
+  const userPrompt = `## Child SD
+Title: ${childSD.title}
+Scope: ${childSD.scope || childSD.description}
+
+## Architecture Plan Phase
+Title: ${phase.title || 'Phase'}
+Description: ${phase.description || 'No description'}
+${phase.sub_items ? `Sub-items:\n${phase.sub_items.map(s => `- ${s}`).join('\n')}` : ''}
+
+## Full Architecture Context (for reference only — do NOT include other phases' requirements)
+${(archPlan?.content || '').substring(0, 2000)}
+
+Generate a focused PRD for this child SD only.`;
+
+  try {
+    const client = getLLMClient({ purpose: 'content-generation' });
+    const response = await client.complete(PRD_SYSTEM_PROMPT, userPrompt, { timeout: 90000 });
+    const result = parseJSON(response);
+
+    logger.log(`[GrandchildPRD] Generated PRD for "${childSD.title}": ${result.functional_requirements?.length || 0} FRs`);
+
+    return {
+      executive_summary: result.executive_summary || `PRD for ${childSD.title}`,
+      functional_requirements: result.functional_requirements || [],
+      acceptance_criteria: result.acceptance_criteria || [],
+      implementation_approach: result.implementation_approach || '',
+      risks: result.risks || [],
+    };
+  } catch (err) {
+    logger.warn(`[GrandchildPRD] LLM generation failed for "${childSD.title}": ${err.message}`);
+    // Fallback: extract from phase content
+    return generateFallbackPRD(childSD, phase);
+  }
+}
+
+/**
+ * Generate PRDs for all children in a hierarchy.
+ *
+ * @param {Object[]} children - Array of child SD records
+ * @param {Object[]} phases - Architecture plan phases (aligned by index)
+ * @param {Object} archPlan - Full architecture plan
+ * @param {Object} [options]
+ * @returns {Promise<Map<string, Object>>} Map of sd_key → PRD content
+ */
+export async function generateAllChildPRDs(children, phases, archPlan, options = {}) {
+  const { logger = console } = options;
+  const results = new Map();
+
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    const phase = phases[i] || phases[phases.length - 1] || { title: child.title };
+
+    const prd = await generateChildPRD(child, phase, archPlan, { logger });
+    results.set(child.sd_key || child.title, prd);
+  }
+
+  logger.log(`[GrandchildPRD] Generated ${results.size} child PRDs`);
+  return results;
+}
+
+/**
+ * Fallback PRD generation without LLM.
+ */
+function generateFallbackPRD(childSD, phase) {
+  return {
+    executive_summary: `Implement ${childSD.title} as specified in the architecture plan.`,
+    functional_requirements: [
+      {
+        id: 'FR-001',
+        title: phase.title || childSD.title,
+        description: phase.description || childSD.description || childSD.scope || 'Implement as specified',
+        priority: 'must_have',
+      }
+    ],
+    acceptance_criteria: [`AC-001: ${childSD.title} is implemented and tested`],
+    implementation_approach: `Follow architecture plan phase: ${phase.title || 'as specified'}`,
+    risks: [],
+  };
+}

--- a/scripts/modules/hierarchy-iterator.js
+++ b/scripts/modules/hierarchy-iterator.js
@@ -1,0 +1,207 @@
+/**
+ * Hierarchy Iterator — Restructures poor SD decompositions
+ *
+ * SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001-E (C5)
+ *
+ * After rubric scoring, if aggregate score < threshold, this module
+ * restructures the hierarchy: merges over-scoped children, splits
+ * under-scoped ones, re-assigns FRs. Re-scores. Max 3 iterations.
+ *
+ * @module scripts/modules/hierarchy-iterator
+ */
+
+import { scoreDecomposition, THRESHOLD } from './decomposition-rubric.js';
+
+const MAX_ITERATIONS = 3;
+
+/**
+ * Run the iteration loop on a decomposed hierarchy.
+ *
+ * @param {Object[]} children - Child SD records
+ * @param {Object} archPlan - Architecture plan
+ * @param {Object} [options]
+ * @param {Object} [options.logger]
+ * @param {Function} [options.onRestructure] - Callback when restructuring occurs
+ * @returns {Promise<Object>} Final result with scores, iteration count, and restructured children
+ */
+export async function iterateHierarchy(children, archPlan, options = {}) {
+  const { logger = console, onRestructure } = options;
+  let currentChildren = [...children];
+  let iteration = 0;
+  let lastScore = null;
+
+  while (iteration < MAX_ITERATIONS) {
+    iteration++;
+    const rubric = await scoreDecomposition(currentChildren, archPlan, { logger });
+    lastScore = rubric;
+
+    logger.log(`[HierarchyIterator] Iteration ${iteration}/${MAX_ITERATIONS}: score ${rubric.aggregate.toFixed(1)}/5`);
+
+    if (rubric.passed) {
+      logger.log(`[HierarchyIterator] PASSED at iteration ${iteration}`);
+      return {
+        children: currentChildren,
+        score: rubric,
+        iterations: iteration,
+        converged: true,
+      };
+    }
+
+    if (iteration === MAX_ITERATIONS) {
+      logger.warn(`[HierarchyIterator] Max iterations reached, passing best attempt to chairman`);
+      break;
+    }
+
+    // Restructure based on rubric feedback
+    const restructured = restructureFromFeedback(currentChildren, rubric, archPlan, { logger });
+    if (restructured.length === currentChildren.length &&
+        JSON.stringify(restructured.map(c => c.title)) === JSON.stringify(currentChildren.map(c => c.title))) {
+      logger.warn('[HierarchyIterator] No restructuring changes — breaking iteration');
+      break;
+    }
+
+    currentChildren = restructured;
+    if (onRestructure) onRestructure(currentChildren, iteration);
+  }
+
+  return {
+    children: currentChildren,
+    score: lastScore,
+    iterations: iteration,
+    converged: false,
+  };
+}
+
+/**
+ * Restructure children based on rubric feedback.
+ *
+ * @param {Object[]} children - Current child SDs
+ * @param {Object} rubric - Rubric scores with recommendations
+ * @param {Object} archPlan - Architecture plan
+ * @param {Object} [options]
+ * @returns {Object[]} Restructured children
+ */
+function restructureFromFeedback(children, rubric, archPlan, options = {}) {
+  const { logger = console } = options;
+  let result = [...children];
+
+  // Address boundary issues: merge children with high scope overlap
+  if (rubric.scores.boundary?.score <= 2) {
+    logger.log('[HierarchyIterator] Addressing boundary issues — checking for merge candidates');
+    result = mergeSimilarChildren(result);
+  }
+
+  // Address balance issues: split overly large children
+  if (rubric.scores.balance?.score <= 2) {
+    logger.log('[HierarchyIterator] Addressing balance issues — checking for split candidates');
+    result = splitOversizedChildren(result);
+  }
+
+  // Address completeness: add missing phase children
+  if (rubric.scores.completeness?.score <= 2 && archPlan) {
+    logger.log('[HierarchyIterator] Addressing completeness — checking for uncovered phases');
+    result = addMissingPhaseChildren(result, archPlan);
+  }
+
+  return result;
+}
+
+/**
+ * Merge children with similar scope (boundary fix).
+ */
+function mergeSimilarChildren(children) {
+  if (children.length <= 2) return children;
+
+  const merged = [];
+  const used = new Set();
+
+  for (let i = 0; i < children.length; i++) {
+    if (used.has(i)) continue;
+
+    const current = children[i];
+    const words = new Set((current.scope || current.title || '').toLowerCase().split(/\s+/).filter(w => w.length > 3));
+
+    // Find a similar sibling to merge with
+    let mergeTarget = -1;
+    let maxOverlap = 0;
+    for (let j = i + 1; j < children.length; j++) {
+      if (used.has(j)) continue;
+      const otherWords = new Set((children[j].scope || children[j].title || '').toLowerCase().split(/\s+/).filter(w => w.length > 3));
+      const overlap = [...words].filter(w => otherWords.has(w)).length / Math.max(words.size, 1);
+      if (overlap > 0.5 && overlap > maxOverlap) {
+        maxOverlap = overlap;
+        mergeTarget = j;
+      }
+    }
+
+    if (mergeTarget >= 0) {
+      // Merge
+      merged.push({
+        ...current,
+        title: `${current.title} + ${children[mergeTarget].title}`,
+        scope: `${current.scope || current.description || ''}\n${children[mergeTarget].scope || children[mergeTarget].description || ''}`,
+      });
+      used.add(i);
+      used.add(mergeTarget);
+    } else {
+      merged.push(current);
+      used.add(i);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Split children that are significantly larger than siblings (balance fix).
+ */
+function splitOversizedChildren(children) {
+  if (children.length === 0) return children;
+
+  const avgLen = children.reduce((s, c) => s + (c.scope || c.description || '').length, 0) / children.length;
+  const result = [];
+
+  for (const child of children) {
+    const len = (child.scope || child.description || '').length;
+    if (len > avgLen * 3 && len > 200) {
+      // Split into two
+      const midpoint = Math.floor(len / 2);
+      const text = child.scope || child.description || '';
+      result.push({ ...child, title: `${child.title} (Part 1)`, scope: text.substring(0, midpoint) });
+      result.push({ ...child, title: `${child.title} (Part 2)`, scope: text.substring(midpoint) });
+    } else {
+      result.push(child);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Add children for uncovered architecture plan phases (completeness fix).
+ */
+function addMissingPhaseChildren(children, archPlan) {
+  const phases = archPlan?.sections?.implementation_phases || [];
+  if (phases.length === 0) return children;
+
+  const coveredTitles = new Set(children.map(c => (c.title || '').toLowerCase()));
+  const result = [...children];
+
+  for (const phase of phases) {
+    const phaseTitle = (phase.title || '').toLowerCase();
+    const isCovered = [...coveredTitles].some(t => t.includes(phaseTitle) || phaseTitle.includes(t));
+
+    if (!isCovered) {
+      result.push({
+        title: phase.title,
+        scope: phase.description || phase.title,
+        description: phase.description || `Implementation of architecture phase: ${phase.title}`,
+        dependencies: [],
+      });
+    }
+  }
+
+  return result;
+}
+
+export { MAX_ITERATIONS, restructureFromFeedback };

--- a/tests/unit/modules/decomposition-rubric.test.js
+++ b/tests/unit/modules/decomposition-rubric.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock LLM before import
+vi.mock('../../../lib/llm/index.js', () => ({
+  getLLMClient: () => ({
+    complete: vi.fn().mockResolvedValue(JSON.stringify({
+      boundary: { score: 4, reasoning: 'Clear boundaries' },
+      balance: { score: 4, reasoning: 'Even distribution' },
+      dependency: { score: 5, reasoning: 'Dependencies explicit' },
+      completeness: { score: 4, reasoning: 'All phases covered' },
+      aggregate: 4.25,
+      recommendations: []
+    }))
+  })
+}));
+
+vi.mock('../../../lib/eva/utils/parse-json.js', () => ({
+  parseJSON: (str) => typeof str === 'string' ? JSON.parse(str) : str,
+  extractUsage: () => ({})
+}));
+
+const { scoreDecomposition, DIMENSIONS, THRESHOLD } = await import('../../../scripts/modules/decomposition-rubric.js');
+
+const MOCK_CHILDREN = [
+  { title: 'Database Migration', scope: 'Add columns to EVA tables', dependencies: [] },
+  { title: 'API Enhancement', scope: 'Update writeArtifact endpoint', dependencies: [{ sd_key: 'child-1' }] },
+  { title: 'Stage Template Updates', scope: 'Pass vision keys through stages', dependencies: [{ sd_key: 'child-2' }] },
+];
+
+const MOCK_ARCH_PLAN = {
+  sections: {
+    implementation_phases: [
+      { number: 1, title: 'Database Migration', description: 'Schema changes' },
+      { number: 2, title: 'API Enhancement', description: 'Endpoint updates' },
+      { number: 3, title: 'Stage Templates', description: 'Key passing' },
+    ]
+  }
+};
+
+describe('decomposition-rubric', () => {
+  it('scores a decomposition with 4 dimensions', async () => {
+    const result = await scoreDecomposition(MOCK_CHILDREN, MOCK_ARCH_PLAN);
+    expect(Object.keys(result.scores)).toHaveLength(4);
+    for (const dim of DIMENSIONS) {
+      expect(result.scores[dim]).toBeDefined();
+      expect(result.scores[dim].score).toBeGreaterThanOrEqual(1);
+      expect(result.scores[dim].score).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it('calculates aggregate score', async () => {
+    const result = await scoreDecomposition(MOCK_CHILDREN, MOCK_ARCH_PLAN);
+    expect(result.aggregate).toBeGreaterThan(0);
+    expect(result.aggregate).toBeLessThanOrEqual(5);
+  });
+
+  it('returns passed=true when aggregate >= threshold', async () => {
+    const result = await scoreDecomposition(MOCK_CHILDREN, MOCK_ARCH_PLAN);
+    expect(result.passed).toBe(result.aggregate >= THRESHOLD);
+  });
+
+  it('handles empty children gracefully', async () => {
+    const result = await scoreDecomposition([], MOCK_ARCH_PLAN);
+    expect(result.aggregate).toBe(0);
+    expect(result.passed).toBe(false);
+  });
+
+  it('exports threshold constant', () => {
+    expect(THRESHOLD).toBe(3.5);
+  });
+
+  it('exports dimensions array', () => {
+    expect(DIMENSIONS).toEqual(['boundary', 'balance', 'dependency', 'completeness']);
+  });
+});

--- a/tests/unit/modules/hierarchy-iterator.test.js
+++ b/tests/unit/modules/hierarchy-iterator.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock the rubric module
+vi.mock('../../../scripts/modules/decomposition-rubric.js', () => {
+  let callCount = 0;
+  return {
+    THRESHOLD: 3.5,
+    DIMENSIONS: ['boundary', 'balance', 'dependency', 'completeness'],
+    scoreDecomposition: vi.fn().mockImplementation(async () => {
+      callCount++;
+      // First call fails, subsequent calls pass
+      const score = callCount === 1 ? 2.5 : 4.0;
+      return {
+        aggregate: score,
+        scores: {
+          boundary: { score: callCount === 1 ? 2 : 4, reasoning: '' },
+          balance: { score: callCount === 1 ? 2 : 4, reasoning: '' },
+          dependency: { score: 3, reasoning: '' },
+          completeness: { score: callCount === 1 ? 3 : 5, reasoning: '' },
+        },
+        recommendations: [],
+        passed: score >= 3.5,
+        threshold: 3.5,
+      };
+    })
+  };
+});
+
+const { iterateHierarchy, MAX_ITERATIONS, restructureFromFeedback } = await import('../../../scripts/modules/hierarchy-iterator.js');
+
+const MOCK_CHILDREN = [
+  { title: 'Database Migration', scope: 'Add columns to EVA tables', dependencies: [] },
+  { title: 'API Enhancement', scope: 'Update writeArtifact endpoint', dependencies: [] },
+];
+
+const MOCK_ARCH_PLAN = {
+  sections: {
+    implementation_phases: [
+      { number: 1, title: 'Database Migration', description: 'Schema changes' },
+      { number: 2, title: 'API Enhancement', description: 'Endpoint updates' },
+    ]
+  }
+};
+
+describe('hierarchy-iterator', () => {
+  it('converges when score passes after restructure', async () => {
+    // Use overlapping children so restructure actually changes something
+    const overlapping = [
+      { title: 'Database setup and migration work', scope: 'database migration setup and schema column changes for EVA', dependencies: [] },
+      { title: 'Database schema migration columns', scope: 'database migration schema column additions for EVA tables', dependencies: [] },
+      { title: 'API Enhancement', scope: 'Update writeArtifact endpoint for new columns', dependencies: [] },
+    ];
+    const result = await iterateHierarchy(overlapping, MOCK_ARCH_PLAN);
+    // Should either converge or hit max iterations
+    expect(result.iterations).toBeLessThanOrEqual(MAX_ITERATIONS);
+    expect(result.score).toBeDefined();
+    expect(result.score.aggregate).toBeGreaterThan(0);
+  });
+
+  it('returns score and iteration count', async () => {
+    const result = await iterateHierarchy(MOCK_CHILDREN, MOCK_ARCH_PLAN);
+    expect(result.score).toBeDefined();
+    expect(result.score.aggregate).toBeGreaterThan(0);
+    expect(typeof result.iterations).toBe('number');
+  });
+
+  it('exports MAX_ITERATIONS constant', () => {
+    expect(MAX_ITERATIONS).toBe(3);
+  });
+
+  it('restructureFromFeedback handles low boundary score', () => {
+    const children = [
+      { title: 'Database setup and migration work', scope: 'database migration setup and schema changes' },
+      { title: 'Database schema migration', scope: 'database migration schema and column additions' },
+    ];
+    const rubric = {
+      scores: {
+        boundary: { score: 1 },
+        balance: { score: 4 },
+        dependency: { score: 4 },
+        completeness: { score: 4 },
+      }
+    };
+    const result = restructureFromFeedback(children, rubric, MOCK_ARCH_PLAN);
+    // Should merge similar children
+    expect(result.length).toBeLessThanOrEqual(children.length);
+  });
+});


### PR DESCRIPTION
## Summary
- **decomposition-rubric.js**: Scores SD hierarchy decompositions on 4 dimensions (boundary cleanliness, scope balance, dependency clarity, completeness) using LLM with heuristic fallback
- **grandchild-prd-generator.js**: Generates individually-scoped PRDs for each child SD from architecture plan phases — no parent copy-paste
- **hierarchy-iterator.js**: Score→restructure→re-score loop (max 3 iterations) to improve poor decompositions before chairman review

Part of SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001-E

## Test plan
- [x] 6 unit tests for decomposition rubric (mock LLM, dimension scoring, threshold)
- [x] 4 unit tests for hierarchy iterator (convergence, restructure, max iterations)
- [x] All 10 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)