### PR TITLE
feat: heartbeat TTL claim auto-release in sd-start.js

### DIFF
--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -458,9 +458,40 @@ async function main() {
   const skippedSDs = [];
 
   if (!claimResult.success) {
-    // PID-based liveness check for enhanced diagnostics (same machine only)
+    // SD-LEO-INFRA-CLAIM-LIFECYCLE-HARDENING-001: Heartbeat TTL check (cross-machine compatible)
+    // Releases claims from sessions whose heartbeat is >30 minutes stale, regardless of PID visibility.
     let autoReleased = false;
-    if (claimResult.owner) {
+    const CLAIM_TTL_MS = 30 * 60 * 1000; // 30 minutes
+    if (claimResult.owner?.session_id) {
+      const { data: ownerSession } = await supabase
+        .from('claude_sessions')
+        .select('heartbeat_at, status')
+        .eq('session_id', claimResult.owner.session_id)
+        .maybeSingle();
+
+      const heartbeatAge = ownerSession?.heartbeat_at
+        ? Date.now() - new Date(ownerSession.heartbeat_at).getTime()
+        : Infinity;
+      const isStale = heartbeatAge > CLAIM_TTL_MS;
+      const isInactive = !ownerSession || ownerSession.status !== 'active';
+
+      if (isStale || isInactive) {
+        const ageMin = Math.round(heartbeatAge / 60000);
+        const reason = isInactive ? 'session inactive' : `heartbeat stale (${ageMin}m)`;
+        console.log(`[claimGuard] ${reason} for ${claimResult.owner.session_id} — auto-releasing claim on ${effectiveId}`);
+        const { error: releaseError } = await supabase.rpc('release_sd', {
+          p_session_id: claimResult.owner.session_id,
+          p_reason: 'ttl_expired'
+        });
+        if (!releaseError) {
+          console.log(`${colors.green}   ✅ TTL-expired claim released. Retrying...${colors.reset}`);
+          autoReleased = true;
+        }
+      }
+    }
+
+    // PID-based liveness check for enhanced diagnostics (same machine only)
+    if (!autoReleased && claimResult.owner) {
       const sameHost = claimResult.owner.hostname === os.hostname();
       const pidMatch = claimResult.owner.session_id?.match(/-(\d+)$/);
       const ownerPid = pidMatch ? parseInt(pidMatch[1]) : null;


### PR DESCRIPTION
## Summary
- Adds heartbeat TTL check before PID-based liveness check in sd-start.js
- Claims from sessions with heartbeat >30m stale are auto-released (cross-machine compatible)
- Falls through to existing PID check only if TTL check doesn't trigger
- Prevents orphan claim accumulation from dead sessions in multi-session fleet

Part of SD-LEO-INFRA-CLAIM-LIFECYCLE-HARDENING-001

## Test plan
- [x] Manual verification: 17 orphan claims found and cleaned in this session
- [x] TTL logic covers both inactive sessions and stale heartbeats
- [x] Existing PID check preserved as secondary mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)