### PR TITLE
chore: stage worker gate fix, protocol regen, migrations, hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,4 +119,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-03-25 8:09:51 AM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-03-25 8:16:32 AM | Protocol: LEO 4.3.3 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-03-25 8:09:51 AM
+**Generated**: 2026-03-25 8:16:32 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:09:51.724Z -->
-<!-- git_commit: 859e85a2 -->
+<!-- generated_at: 2026-03-25T07:16:32.303Z -->
+<!-- git_commit: 7de0b7c0 -->
 <!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
@@ -261,5 +261,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-03-25 8:09:51 AM*
+*DIGEST generated: 2026-03-25 8:16:32 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:09:51.724Z -->
-<!-- git_commit: 859e85a2 -->
+<!-- generated_at: 2026-03-25T07:16:32.303Z -->
+<!-- git_commit: 7de0b7c0 -->
 <!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
@@ -152,5 +152,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-03-25 8:09:51 AM*
+*DIGEST generated: 2026-03-25 8:16:32 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-03-25 8:09:51 AM
+**Generated**: 2026-03-25 8:16:32 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing
 
@@ -1774,8 +1774,8 @@ If SD implements a feature that reduces legacy references from 243 to 200:
 
 | Column | Valid Values | Hint |
 |--------|--------------|------|
-| `validation_score` | N/A | Validation score must be an integer between 0 and 100. Use Math.round() and clamp to 0-100. |
 | `status` | pending, accepted, rejected, failed | Use one of: pending, accepted, rejected, failed |
+| `validation_score` | N/A | Validation score must be an integer between 0 and 100. Use Math.round() and clamp to 0-100. |
 
 ### leo_protocols
 
@@ -1800,9 +1800,9 @@ If SD implements a feature that reduces legacy references from 243 to 200:
 
 | Column | Valid Values | Hint |
 |--------|--------------|------|
-| `status` | pending_acceptance, accepted, rejected | Use one of: pending_acceptance, accepted, rejected |
 | `from_phase` | LEAD, PLAN, EXEC | Use one of: LEAD, PLAN, EXEC (uppercase) |
 | `to_phase` | LEAD, PLAN, EXEC | Use one of: LEAD, PLAN, EXEC (uppercase) |
+| `status` | pending_acceptance, accepted, rejected | Use one of: pending_acceptance, accepted, rejected |
 
 ### sd_scope_deliverables
 
@@ -1827,9 +1827,9 @@ If SD implements a feature that reduces legacy references from 243 to 200:
 
 | Column | Valid Values | Hint |
 |--------|--------------|------|
-| `e2e_test_status` | not_created, created, passing, failing, skipped | Use one of: not_created, created, passing, failing, skipped |
-| `validation_status` | pending, in_progress, validated, failed, skipped | Use one of: pending, in_progress, validated, failed, skipped |
 | `status` | draft, completed, in_progress, ready | Use one of: draft, completed, in_progress, ready. NOT "approved" - that is not a valid value. |
+| `validation_status` | pending, in_progress, validated, failed, skipped | Use one of: pending, in_progress, validated, failed, skipped |
+| `e2e_test_status` | not_created, created, passing, failing, skipped | Use one of: not_created, created, passing, failing, skipped |
 
 
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:09:51.724Z -->
-<!-- git_commit: 859e85a2 -->
+<!-- generated_at: 2026-03-25T07:16:32.303Z -->
+<!-- git_commit: 7de0b7c0 -->
 <!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
@@ -218,5 +218,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-03-25 8:09:51 AM*
+*DIGEST generated: 2026-03-25 8:16:32 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-03-25 8:09:51 AM
+**Generated**: 2026-03-25 8:16:32 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:09:51.724Z -->
-<!-- git_commit: 859e85a2 -->
+<!-- generated_at: 2026-03-25T07:16:32.303Z -->
+<!-- git_commit: 7de0b7c0 -->
 <!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
@@ -126,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-25 8:09:51 AM*
+*DIGEST generated: 2026-03-25 8:16:32 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-03-25 8:09:51 AM
+**Generated**: 2026-03-25 8:16:32 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:09:51.724Z -->
-<!-- git_commit: 859e85a2 -->
+<!-- generated_at: 2026-03-25T07:16:32.303Z -->
+<!-- git_commit: 7de0b7c0 -->
 <!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
 <!-- file_content_hash: pending -->
 
@@ -124,5 +124,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-25 8:09:51 AM*
+*DIGEST generated: 2026-03-25 8:16:32 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,76 +1,76 @@
 {
-  "generated_at": "2026-03-25T07:09:51.724Z",
-  "git_commit": "859e85a2",
+  "generated_at": "2026-03-25T07:16:32.303Z",
+  "git_commit": "7de0b7c0",
   "db_snapshot_hash": "1ba41d24a4b01a2a",
   "files": {
     "CLAUDE.md": {
       "type": "full",
       "chars": 5752,
       "estimated_tokens": 1438,
-      "content_hash": "a1fe2807cd6969f1",
+      "content_hash": "4b24881f422d6871",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
       "chars": 52506,
       "estimated_tokens": 13127,
-      "content_hash": "b6238b72a6e60f80",
+      "content_hash": "3306a501cb454f9c",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
       "chars": 54092,
       "estimated_tokens": 13523,
-      "content_hash": "6892730c756d1a21",
+      "content_hash": "7a17909ff2863a92",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
       "chars": 81656,
       "estimated_tokens": 20414,
-      "content_hash": "d37d9e4935c9226a",
+      "content_hash": "fc0a6f5f2a800f73",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
       "chars": 69307,
       "estimated_tokens": 17327,
-      "content_hash": "9e71ce13c66ef7c3",
+      "content_hash": "ad0962bdd72cf1bf",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
       "chars": 6618,
       "estimated_tokens": 1655,
-      "content_hash": "df6b2498f0cf8b8b",
+      "content_hash": "c4e697e511fa204f",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
       "chars": 10174,
       "estimated_tokens": 2544,
-      "content_hash": "d688d9aed8b0b661",
+      "content_hash": "6b335d547fc236ba",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
       "chars": 4801,
       "estimated_tokens": 1201,
-      "content_hash": "eeaaf56bb2f9328a",
+      "content_hash": "84bb15a8367300fe",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
       "chars": 5031,
       "estimated_tokens": 1258,
-      "content_hash": "51186629eac3b941",
+      "content_hash": "23e7f19eec1536ed",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
       "chars": 9485,
       "estimated_tokens": 2372,
-      "content_hash": "7dc865e446aa9799",
+      "content_hash": "02eea284bbbfeb9d",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     }
   }

--- a/database/migrations/20260324_enrich_stream_sds.sql
+++ b/database/migrations/20260324_enrich_stream_sds.sql
@@ -1,0 +1,80 @@
+-- Migration: Enrich three child stream SDs with proper descriptions, success criteria,
+-- key_changes, delivers_capabilities, and inter-stream dependencies.
+-- Date: 2026-03-24
+-- SDs: SD-LEO-INFRA-STREAM-VENTURE-EVA-002, SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001, SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001
+
+-- ============================================================
+-- STEP 1: Enrich descriptions, success_criteria, key_changes
+-- ============================================================
+
+-- Stream A: Venture EVA Foundation
+UPDATE strategic_directives_v2 SET
+  description = 'Foundation stream. Create venture-level EVA vision records seeded at Stage 1 and architecture records seeded at Stage 13. Add supports_vision_key and supports_plan_key columns to venture_artifacts. Enhance writeArtifact() in artifact-persistence-service.js with conditional EVA upsert (eager synthesis). Modify stage templates 1-15 to pass keys. Restart ventures through new pipeline. Update leo_protocol_sections and regenerate CLAUDE.md files.',
+  success_criteria = '[{"criterion":"venture_artifacts has supports_vision_key and supports_plan_key columns with partial indexes","measure":"Migration applied, columns queryable"},{"criterion":"writeArtifact() with visionKey upserts eva_vision_documents","measure":"Unit test passes: EVA record created/updated on write"},{"criterion":"writeArtifact() backward compatible without keys","measure":"Existing test suite passes unchanged"},{"criterion":"EVA upsert failure does not block artifact persistence","measure":"Unit test: try/catch isolation verified"},{"criterion":"Venture pipeline stages 1-5 produce vision record at v5+","measure":"Integration test with version check"},{"criterion":"Venture pipeline stages 13-15 produce arch record at v3+","measure":"Integration test with version check"},{"criterion":"All restarted ventures have EVA records with venture_id","measure":"DB query verification"},{"criterion":"CLAUDE_CORE.md and CLAUDE_LEAD.md regenerated with new sections","measure":"Protocol sections exist in leo_protocol_sections"}]'::jsonb,
+  key_changes = '[{"change":"Add supports_vision_key/supports_plan_key to venture_artifacts","impact":"Enables evidence chain linkage from artifacts to EVA records"},{"change":"Enhance writeArtifact() with conditional EVA upsert","impact":"Single write path for both artifact persistence and governance record synthesis"},{"change":"Stage templates 1-15 pass vision/plan keys","impact":"Every stage enriches the venture EVA records automatically"},{"change":"Seed vision at Stage 1, architecture at Stage 13","impact":"Ventures have formal EVA governance identity from birth"}]'::jsonb
+WHERE sd_key = 'SD-LEO-INFRA-STREAM-VENTURE-EVA-002';
+
+-- Stream B: Activate Dormant Infrastructure
+UPDATE strategic_directives_v2 SET
+  description = 'Activation stream. Populate leo_adrs table during Stage 14 technical architecture analysis. Activate version incrementing and addendum logging via artifact-versioning.js. Wire vision_version_aligned_to on architecture plans. Verify cascade invalidation trigger end-to-end. Update leo_protocol_sections and regenerate CLAUDE.md files. Depends on Stream A.',
+  success_criteria = '[{"criterion":"Stage 14 produces 3+ ADR entries in leo_adrs","measure":"DB query after Stage 14 execution"},{"criterion":"Architecture plan adr_ids array contains ADR UUIDs","measure":"DB query verification"},{"criterion":"EVA records show version progression with addendum trail","measure":"Version > 1 and addendums array non-empty"},{"criterion":"vision_version_aligned_to set on architecture plans","measure":"DB query: value equals current vision version"},{"criterion":"Cascade invalidation fires on vision update","measure":"Integration test: needs_review_since set on arch plan after vision update"},{"criterion":"ADR superseded_by chain works","measure":"Test: supersede an ADR, verify chain"},{"criterion":"CLAUDE_PLAN.md and CLAUDE_CORE.md regenerated","measure":"Protocol sections exist in leo_protocol_sections"}]'::jsonb,
+  key_changes = '[{"change":"Populate leo_adrs during Stage 14","impact":"Architectural decisions formally tracked with context, options, consequences"},{"change":"Activate version incrementing and addendum logging","impact":"Full change history visible for vision and architecture records"},{"change":"Wire cascade invalidation end-to-end","impact":"Vision changes automatically flag downstream architecture plans for review"}]'::jsonb
+WHERE sd_key = 'SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001';
+
+-- Stream C: Sprint Bridge
+UPDATE strategic_directives_v2 SET
+  description = 'Bridge stream. Move convertSprintToSDs() to post-Stage-19 approval. Pass vision/arch keys to created SDs. Add HEAL traceability dimensions with evidence-aware scoring. Implement auto-iterate quality loop. Build chairman batch review UX. Update leo_protocol_sections and regenerate all CLAUDE.md files. Depends on Streams A and B.',
+  success_criteria = '[{"criterion":"convertSprintToSDs() fires only after Stage 19 approval","measure":"Integration test: Stage 18 completion does NOT trigger conversion"},{"criterion":"Created SDs have vision_key and plan_key in metadata","measure":"DB query after SD creation"},{"criterion":"HEAL produces traceability scores for SDs/PRDs","measure":"Evidence-aware scoring returns non-null traceability dimensions"},{"criterion":"Auto-iterate re-enriches PRDs below threshold","measure":"Test: thin PRD score improves after iteration"},{"criterion":"Chairman can review full SD/PRD set","measure":"Batch review UI renders with quality scores"},{"criterion":"Complete Stage 1-19-SD-HEAL chain verified end-to-end","measure":"E2E test passes"},{"criterion":"All CLAUDE.md files regenerated with complete pipeline docs","measure":"Protocol sections cover full traceability system"}]'::jsonb,
+  key_changes = '[{"change":"Move convertSprintToSDs() to post-Stage-19","impact":"SDs created only after chairman approves the sprint plan"},{"change":"Pass vision/arch keys to sprint-spawned SDs","impact":"Every SD traces back to venture vision and architecture"},{"change":"HEAL evidence-aware traceability dimensions","impact":"PRD quality scored against full artifact evidence chain"},{"change":"Auto-iterate quality loop","impact":"Thin PRDs automatically enriched until traceability threshold met"},{"change":"Chairman batch review UX","impact":"Full SD/PRD set visible in single review surface with quality scores"}]'::jsonb
+WHERE sd_key = 'SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001';
+
+-- ============================================================
+-- STEP 2: Populate delivers_capabilities (JSONB objects, not strings)
+-- ============================================================
+
+UPDATE strategic_directives_v2 SET delivers_capabilities = '[
+  {"capability_type":"service","capability_key":"eager-synthesis-pipeline","name":"Eager Synthesis Pipeline","category":"infrastructure"},
+  {"capability_type":"database_function","capability_key":"venture-eva-seeding","name":"Venture EVA Record Seeding","category":"infrastructure"},
+  {"capability_type":"utility","capability_key":"evidence-chain-linkage","name":"Evidence Chain Linkage Columns","category":"infrastructure"}
+]'::jsonb WHERE sd_key = 'SD-LEO-INFRA-STREAM-VENTURE-EVA-002';
+
+UPDATE strategic_directives_v2 SET delivers_capabilities = '[
+  {"capability_type":"database_function","capability_key":"leo-adrs-population","name":"ADR Population Pipeline","category":"governance"},
+  {"capability_type":"quality_gate","capability_key":"cascade-invalidation","name":"Cascade Invalidation Wiring","category":"governance"},
+  {"capability_type":"utility","capability_key":"version-addendum-management","name":"Version and Addendum Management","category":"infrastructure"}
+]'::jsonb WHERE sd_key = 'SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001';
+
+UPDATE strategic_directives_v2 SET delivers_capabilities = '[
+  {"capability_type":"service","capability_key":"sprint-to-sd-bridge","name":"Sprint-to-SD Bridge","category":"infrastructure"},
+  {"capability_type":"quality_gate","capability_key":"heal-traceability-scoring","name":"HEAL Traceability Scoring","category":"governance"},
+  {"capability_type":"service","capability_key":"prd-auto-iterate","name":"PRD Auto-Iterate Quality Loop","category":"governance"},
+  {"capability_type":"service","capability_key":"chairman-batch-review","name":"Chairman Batch Review","category":"governance"}
+]'::jsonb WHERE sd_key = 'SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001';
+
+-- ============================================================
+-- STEP 3: Add formal inter-stream dependencies
+-- ============================================================
+
+UPDATE strategic_directives_v2 SET dependencies = '[{"sd_key":"SD-LEO-INFRA-STREAM-VENTURE-EVA-002","type":"blocks","reason":"Stream B requires venture EVA records and writeArtifact enhancement from Stream A"}]'::jsonb
+WHERE sd_key = 'SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001';
+
+UPDATE strategic_directives_v2 SET dependencies = '[{"sd_key":"SD-LEO-INFRA-STREAM-VENTURE-EVA-002","type":"blocks","reason":"Stream C requires EVA records and evidence linkage from Stream A"},{"sd_key":"SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001","type":"blocks","reason":"Stream C requires ADRs and versioning from Stream B for traceability scoring"}]'::jsonb
+WHERE sd_key = 'SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001';
+
+-- ============================================================
+-- STEP 4: Verification query
+-- ============================================================
+
+SELECT sd_key,
+  jsonb_array_length(COALESCE(success_criteria, '[]'::jsonb)) as sc_count,
+  jsonb_array_length(COALESCE(key_changes, '[]'::jsonb)) as kc_count,
+  jsonb_array_length(COALESCE(delivers_capabilities, '[]'::jsonb)) as cap_count,
+  jsonb_array_length(COALESCE(dependencies, '[]'::jsonb)) as dep_count,
+  length(description) as desc_len
+FROM strategic_directives_v2
+WHERE sd_key IN ('SD-LEO-INFRA-STREAM-VENTURE-EVA-002', 'SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001', 'SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001')
+ORDER BY sequence_rank;
+
+-- ROLLBACK (manual, if needed):
+-- UPDATE strategic_directives_v2 SET description = NULL, success_criteria = NULL, key_changes = NULL, delivers_capabilities = NULL WHERE sd_key IN ('SD-LEO-INFRA-STREAM-VENTURE-EVA-002', 'SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001', 'SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001');
+-- UPDATE strategic_directives_v2 SET dependencies = NULL WHERE sd_key IN ('SD-LEO-INFRA-STREAM-ACTIVATE-DORMANT-001', 'SD-LEO-INFRA-STREAM-SPRINT-BRIDGE-001');

--- a/database/migrations/20260324_export_blueprint_review_v3.sql
+++ b/database/migrations/20260324_export_blueprint_review_v3.sql
@@ -1,0 +1,512 @@
+-- Migration: export_blueprint_review v3
+-- Date: 2026-03-24
+-- Purpose: Extend the export_blueprint_review RPC with Stage 18 and Stage 19 data
+--          for the chairman's Build Commitment Review at Stage 19.
+--
+-- Changes from v2:
+--   1. Group 7 "Build Readiness" — Stage 18 artifacts (build_mvp_build, system_devils_advocate_review at S18)
+--   2. Group 8 "Sprint Plan" — Stage 19 artifact (blueprint_sprint_plan)
+--   3. Group 9 "Visual Convergence" — Conditional, extracted from blueprint_sprint_plan artifact_data
+--   4. Updated group_count and summary totals to include new groups
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS export_blueprint_review(UUID);
+--   -- Then re-deploy v2 from 20260324_export_blueprint_review_v2.sql
+
+CREATE OR REPLACE FUNCTION export_blueprint_review(p_venture_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  result JSONB;
+  v_venture_name TEXT;
+  v_current_stage INTEGER;
+  v_archetype TEXT;
+
+  -- Builder-oriented groups (existing)
+  group_what_to_build JSONB;
+  group_who_its_for JSONB;
+  group_how_to_build JSONB;
+  group_what_it_costs JSONB;
+  group_why_decisions JSONB;
+  group_design_intel JSONB;
+
+  -- New groups for Stages 18-19
+  group_build_readiness JSONB;
+  group_sprint_plan JSONB;
+  group_visual_convergence JSONB;
+  v_visual_convergence_data JSONB;
+
+  -- SRIP data
+  srip_site_dna_data JSONB;
+  srip_brand_data JSONB;
+  srip_design_refs JSONB;
+
+  -- Summary counters
+  total_artifacts INTEGER := 0;
+  total_quality_sum NUMERIC := 0;
+  total_quality_count INTEGER := 0;
+  overall_quality NUMERIC := 0;
+  group_count INTEGER := 7; -- base groups (5 original + 2 new), incremented if conditionals exist
+
+  groups_array JSONB := '[]'::JSONB;
+BEGIN
+  -- ----------------------------------------------------------------
+  -- 1. Validate venture exists and fetch metadata
+  -- ----------------------------------------------------------------
+  SELECT v.name, v.current_lifecycle_stage,
+         COALESCE(v.archetype, _get_venture_archetype(p_venture_id)) AS archetype
+    INTO v_venture_name, v_current_stage, v_archetype
+    FROM ventures v
+   WHERE v.id = p_venture_id;
+
+  IF v_venture_name IS NULL THEN
+    RETURN jsonb_build_object(
+      'error', 'Venture not found',
+      'venture_id', p_venture_id
+    );
+  END IF;
+
+  -- ----------------------------------------------------------------
+  -- 2. "What to Build" group
+  --    intake_venture_analysis (S0), truth_idea_brief (S1),
+  --    identity_persona_brand (S10), blueprint_product_roadmap (S13)
+  -- ----------------------------------------------------------------
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', va.id,
+      'lifecycle_stage', va.lifecycle_stage,
+      'artifact_type', va.artifact_type,
+      'title', va.title,
+      'content', COALESCE(va.content, va.artifact_data::text),
+      'quality_score', va.quality_score,
+      'validation_status', va.validation_status,
+      'created_at', va.created_at
+    ) ORDER BY va.lifecycle_stage, va.created_at
+  ), '[]'::jsonb)
+  INTO group_what_to_build
+  FROM venture_artifacts va
+  WHERE va.venture_id = p_venture_id
+    AND va.is_current = true
+    AND va.artifact_type IN (
+      'intake_venture_analysis',
+      'truth_idea_brief',
+      'identity_persona_brand',
+      'blueprint_product_roadmap'
+    );
+
+  -- ----------------------------------------------------------------
+  -- 3. "Who It's For" group
+  --    truth_competitive_analysis (S4), identity_naming_visual (S11),
+  --    identity_brand_guidelines (S12), identity_gtm_sales_strategy (S12)
+  -- ----------------------------------------------------------------
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', va.id,
+      'lifecycle_stage', va.lifecycle_stage,
+      'artifact_type', va.artifact_type,
+      'title', va.title,
+      'content', COALESCE(va.content, va.artifact_data::text),
+      'quality_score', va.quality_score,
+      'validation_status', va.validation_status,
+      'created_at', va.created_at
+    ) ORDER BY va.lifecycle_stage, va.created_at
+  ), '[]'::jsonb)
+  INTO group_who_its_for
+  FROM venture_artifacts va
+  WHERE va.venture_id = p_venture_id
+    AND va.is_current = true
+    AND va.artifact_type IN (
+      'truth_competitive_analysis',
+      'identity_naming_visual',
+      'identity_brand_guidelines',
+      'identity_gtm_sales_strategy'
+    );
+
+  -- ----------------------------------------------------------------
+  -- 4. "How to Build It" group
+  --    blueprint_technical_architecture (S14), blueprint_data_model (S14),
+  --    blueprint_schema_spec (S14), blueprint_api_contract (S14),
+  --    blueprint_erd_diagram (S14), blueprint_wireframes (S15)
+  -- ----------------------------------------------------------------
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', va.id,
+      'lifecycle_stage', va.lifecycle_stage,
+      'artifact_type', va.artifact_type,
+      'title', va.title,
+      'content', COALESCE(va.content, va.artifact_data::text),
+      'quality_score', va.quality_score,
+      'validation_status', va.validation_status,
+      'created_at', va.created_at
+    ) ORDER BY va.lifecycle_stage, va.created_at
+  ), '[]'::jsonb)
+  INTO group_how_to_build
+  FROM venture_artifacts va
+  WHERE va.venture_id = p_venture_id
+    AND va.is_current = true
+    AND va.artifact_type IN (
+      'blueprint_technical_architecture',
+      'blueprint_data_model',
+      'blueprint_schema_spec',
+      'blueprint_api_contract',
+      'blueprint_erd_diagram',
+      'blueprint_wireframes'
+    );
+
+  -- ----------------------------------------------------------------
+  -- 5. "What It Costs" group
+  --    engine_pricing_model (S7), blueprint_financial_projection (S16)
+  -- ----------------------------------------------------------------
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', va.id,
+      'lifecycle_stage', va.lifecycle_stage,
+      'artifact_type', va.artifact_type,
+      'title', va.title,
+      'content', COALESCE(va.content, va.artifact_data::text),
+      'quality_score', va.quality_score,
+      'validation_status', va.validation_status,
+      'created_at', va.created_at
+    ) ORDER BY va.lifecycle_stage, va.created_at
+  ), '[]'::jsonb)
+  INTO group_what_it_costs
+  FROM venture_artifacts va
+  WHERE va.venture_id = p_venture_id
+    AND va.is_current = true
+    AND va.artifact_type IN (
+      'engine_pricing_model',
+      'blueprint_financial_projection'
+    );
+
+  -- ----------------------------------------------------------------
+  -- 6. "Why These Decisions" group
+  --    truth_ai_critique (S2), truth_validation_decision (S3),
+  --    system_devils_advocate_review (S3/S5/S13/S17),
+  --    truth_financial_model (S5), engine_risk_matrix (S6),
+  --    engine_business_model_canvas (S8), engine_exit_strategy (S9),
+  --    blueprint_risk_register (S15)
+  -- ----------------------------------------------------------------
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', va.id,
+      'lifecycle_stage', va.lifecycle_stage,
+      'artifact_type', va.artifact_type,
+      'title', va.title,
+      'content', COALESCE(va.content, va.artifact_data::text),
+      'quality_score', va.quality_score,
+      'validation_status', va.validation_status,
+      'created_at', va.created_at
+    ) ORDER BY va.lifecycle_stage, va.created_at
+  ), '[]'::jsonb)
+  INTO group_why_decisions
+  FROM venture_artifacts va
+  WHERE va.venture_id = p_venture_id
+    AND va.is_current = true
+    AND va.artifact_type IN (
+      'truth_ai_critique',
+      'truth_validation_decision',
+      'system_devils_advocate_review',
+      'truth_financial_model',
+      'engine_risk_matrix',
+      'engine_business_model_canvas',
+      'engine_exit_strategy',
+      'blueprint_risk_register'
+    );
+
+  -- ----------------------------------------------------------------
+  -- 7. "Build Readiness" group (Stage 18)
+  --    build_mvp_build (S18) — checklist, readiness_pct, blocker_count, buildReadiness decision
+  --    system_devils_advocate_review (S18) — build phase DA review
+  -- ----------------------------------------------------------------
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', va.id,
+      'lifecycle_stage', va.lifecycle_stage,
+      'artifact_type', va.artifact_type,
+      'title', va.title,
+      'content', COALESCE(va.content, va.artifact_data::text),
+      'quality_score', va.quality_score,
+      'validation_status', va.validation_status,
+      'created_at', va.created_at
+    ) ORDER BY va.artifact_type, va.created_at
+  ), '[]'::jsonb)
+  INTO group_build_readiness
+  FROM venture_artifacts va
+  WHERE va.venture_id = p_venture_id
+    AND va.is_current = true
+    AND va.lifecycle_stage = '18'
+    AND va.artifact_type IN (
+      'build_mvp_build',
+      'system_devils_advocate_review'
+    );
+
+  -- ----------------------------------------------------------------
+  -- 8. "Sprint Plan" group (Stage 19)
+  --    blueprint_sprint_plan (S19) — sprint_name, sprint_goal, items, story points
+  -- ----------------------------------------------------------------
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', va.id,
+      'lifecycle_stage', va.lifecycle_stage,
+      'artifact_type', va.artifact_type,
+      'title', va.title,
+      'content', COALESCE(va.content, va.artifact_data::text),
+      'quality_score', va.quality_score,
+      'validation_status', va.validation_status,
+      'created_at', va.created_at
+    ) ORDER BY va.created_at
+  ), '[]'::jsonb)
+  INTO group_sprint_plan
+  FROM venture_artifacts va
+  WHERE va.venture_id = p_venture_id
+    AND va.is_current = true
+    AND va.lifecycle_stage = '19'
+    AND va.artifact_type = 'blueprint_sprint_plan';
+
+  -- ----------------------------------------------------------------
+  -- 9. "Visual Convergence" group (Stage 19, conditional)
+  --    Extracted from blueprint_sprint_plan artifact_data->'visual_convergence'
+  --    Only included if the key exists in the artifact data.
+  -- ----------------------------------------------------------------
+  SELECT va.artifact_data->'visual_convergence'
+    INTO v_visual_convergence_data
+    FROM venture_artifacts va
+   WHERE va.venture_id = p_venture_id
+     AND va.is_current = true
+     AND va.lifecycle_stage = '19'
+     AND va.artifact_type = 'blueprint_sprint_plan'
+     AND va.artifact_data ? 'visual_convergence'
+   ORDER BY va.created_at DESC
+   LIMIT 1;
+
+  IF v_visual_convergence_data IS NOT NULL THEN
+    group_visual_convergence := jsonb_build_object(
+      'group', 'Visual Convergence',
+      'group_key', 'visual_convergence',
+      'overall_score', v_visual_convergence_data->'overall_score',
+      'verdict', v_visual_convergence_data->'verdict',
+      'passes', v_visual_convergence_data->'passes'
+    );
+    group_count := group_count + 1;
+  END IF;
+
+  -- ----------------------------------------------------------------
+  -- 10. "Design Intelligence" group (SRIP data -- only if exists)
+  --     Sources: srip_site_dna, srip_brand_interviews, design_reference_library
+  -- ----------------------------------------------------------------
+
+  -- 10a. Site DNA records for this venture
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', sd.id,
+      'reference_url', sd.reference_url,
+      'dna_json', sd.dna_json,
+      'quality_score', sd.quality_score,
+      'status', sd.status,
+      'created_at', sd.created_at
+    ) ORDER BY sd.created_at
+  ), NULL)  -- NULL (not empty array) so we can detect absence
+  INTO srip_site_dna_data
+  FROM srip_site_dna sd
+  WHERE sd.venture_id = p_venture_id;
+
+  -- 10b. Brand interview records for this venture
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', bi.id,
+      'site_dna_id', bi.site_dna_id,
+      'answers', bi.answers,
+      'pre_populated_count', bi.pre_populated_count,
+      'manual_input_count', bi.manual_input_count,
+      'status', bi.status,
+      'created_at', bi.created_at
+    ) ORDER BY bi.created_at
+  ), NULL)
+  INTO srip_brand_data
+  FROM srip_brand_interviews bi
+  WHERE bi.venture_id = p_venture_id;
+
+  -- 10c. Design references matched by venture archetype
+  --      ventures.archetype maps to design_reference_library.archetype_category
+  SELECT COALESCE(jsonb_agg(
+    jsonb_build_object(
+      'id', drl.id,
+      'site_name', drl.site_name,
+      'url', drl.url,
+      'description', drl.description,
+      'score_design', drl.score_design,
+      'score_usability', drl.score_usability,
+      'score_creativity', drl.score_creativity,
+      'score_content', drl.score_content,
+      'score_combined', drl.score_combined,
+      'tech_stack', to_jsonb(drl.tech_stack),
+      'agency_name', drl.agency_name,
+      'country', drl.country
+    ) ORDER BY drl.score_combined DESC NULLS LAST
+  ), NULL)
+  INTO srip_design_refs
+  FROM design_reference_library drl
+  WHERE drl.archetype_category = v_archetype;
+
+  -- Build the Design Intelligence group only if any SRIP data exists
+  IF srip_site_dna_data IS NOT NULL
+     OR srip_brand_data IS NOT NULL
+     OR srip_design_refs IS NOT NULL
+  THEN
+    group_design_intel := jsonb_build_object(
+      'group', 'Design Intelligence',
+      'group_key', 'design_intelligence',
+      'description', 'SRIP-derived design tokens, brand interview insights, and curated design references',
+      'site_dna', COALESCE(srip_site_dna_data, '[]'::jsonb),
+      'brand_interviews', COALESCE(srip_brand_data, '[]'::jsonb),
+      'design_references', COALESCE(srip_design_refs, '[]'::jsonb)
+    );
+    group_count := group_count + 1;
+  END IF;
+
+  -- ----------------------------------------------------------------
+  -- 11. Assemble groups array with per-group quality stats
+  -- ----------------------------------------------------------------
+
+  groups_array := jsonb_build_array(
+    jsonb_build_object(
+      'group', 'What to Build',
+      'group_key', 'what_to_build',
+      'artifact_count', COALESCE(jsonb_array_length(group_what_to_build), 0),
+      'avg_quality_score', COALESCE(
+        (SELECT AVG((a->>'quality_score')::numeric)
+         FROM jsonb_array_elements(group_what_to_build) a
+         WHERE a->>'quality_score' IS NOT NULL), 0
+      ),
+      'artifacts', group_what_to_build
+    ),
+    jsonb_build_object(
+      'group', 'Who It''s For',
+      'group_key', 'who_its_for',
+      'artifact_count', COALESCE(jsonb_array_length(group_who_its_for), 0),
+      'avg_quality_score', COALESCE(
+        (SELECT AVG((a->>'quality_score')::numeric)
+         FROM jsonb_array_elements(group_who_its_for) a
+         WHERE a->>'quality_score' IS NOT NULL), 0
+      ),
+      'artifacts', group_who_its_for
+    ),
+    jsonb_build_object(
+      'group', 'How to Build It',
+      'group_key', 'how_to_build_it',
+      'artifact_count', COALESCE(jsonb_array_length(group_how_to_build), 0),
+      'avg_quality_score', COALESCE(
+        (SELECT AVG((a->>'quality_score')::numeric)
+         FROM jsonb_array_elements(group_how_to_build) a
+         WHERE a->>'quality_score' IS NOT NULL), 0
+      ),
+      'artifacts', group_how_to_build
+    ),
+    jsonb_build_object(
+      'group', 'What It Costs',
+      'group_key', 'what_it_costs',
+      'artifact_count', COALESCE(jsonb_array_length(group_what_it_costs), 0),
+      'avg_quality_score', COALESCE(
+        (SELECT AVG((a->>'quality_score')::numeric)
+         FROM jsonb_array_elements(group_what_it_costs) a
+         WHERE a->>'quality_score' IS NOT NULL), 0
+      ),
+      'artifacts', group_what_it_costs
+    ),
+    jsonb_build_object(
+      'group', 'Why These Decisions',
+      'group_key', 'why_these_decisions',
+      'artifact_count', COALESCE(jsonb_array_length(group_why_decisions), 0),
+      'avg_quality_score', COALESCE(
+        (SELECT AVG((a->>'quality_score')::numeric)
+         FROM jsonb_array_elements(group_why_decisions) a
+         WHERE a->>'quality_score' IS NOT NULL), 0
+      ),
+      'artifacts', group_why_decisions
+    ),
+    jsonb_build_object(
+      'group', 'Build Readiness',
+      'group_key', 'build_readiness',
+      'artifact_count', COALESCE(jsonb_array_length(group_build_readiness), 0),
+      'avg_quality_score', COALESCE(
+        (SELECT AVG((a->>'quality_score')::numeric)
+         FROM jsonb_array_elements(group_build_readiness) a
+         WHERE a->>'quality_score' IS NOT NULL), 0
+      ),
+      'artifacts', group_build_readiness
+    ),
+    jsonb_build_object(
+      'group', 'Sprint Plan',
+      'group_key', 'sprint_plan',
+      'artifact_count', COALESCE(jsonb_array_length(group_sprint_plan), 0),
+      'avg_quality_score', COALESCE(
+        (SELECT AVG((a->>'quality_score')::numeric)
+         FROM jsonb_array_elements(group_sprint_plan) a
+         WHERE a->>'quality_score' IS NOT NULL), 0
+      ),
+      'artifacts', group_sprint_plan
+    )
+  );
+
+  -- Append Visual Convergence group if it exists (conditional, non-artifact structure)
+  IF group_visual_convergence IS NOT NULL THEN
+    groups_array := groups_array || jsonb_build_array(group_visual_convergence);
+  END IF;
+
+  -- Append Design Intelligence group if it exists (conditional, non-artifact structure)
+  IF group_design_intel IS NOT NULL THEN
+    groups_array := groups_array || jsonb_build_array(group_design_intel);
+  END IF;
+
+  -- ----------------------------------------------------------------
+  -- 12. Compute overall summary from artifact groups
+  -- ----------------------------------------------------------------
+  SELECT
+    COALESCE(SUM((g->>'artifact_count')::integer), 0),
+    COALESCE(SUM(
+      CASE WHEN (g->>'avg_quality_score')::numeric > 0
+           THEN (g->>'avg_quality_score')::numeric
+           ELSE 0 END
+    ), 0),
+    COALESCE(COUNT(*) FILTER (
+      WHERE (g->>'avg_quality_score')::numeric > 0
+    ), 0)
+  INTO total_artifacts, total_quality_sum, total_quality_count
+  FROM jsonb_array_elements(groups_array) g
+  WHERE g ? 'artifact_count';  -- only artifact-bearing groups (excludes design_intel, visual_convergence)
+
+  IF total_quality_count > 0 THEN
+    overall_quality := ROUND(total_quality_sum / total_quality_count, 1);
+  END IF;
+
+  -- ----------------------------------------------------------------
+  -- 13. Build final result envelope
+  -- ----------------------------------------------------------------
+  result := jsonb_build_object(
+    'venture_id', p_venture_id,
+    'venture_name', v_venture_name,
+    'current_stage', v_current_stage,
+    'exported_at', NOW()::text,
+    'groups', groups_array,
+    'summary', jsonb_build_object(
+      'total_artifacts', total_artifacts,
+      'overall_quality_score', overall_quality,
+      'group_count', group_count,
+      'has_design_intelligence', (group_design_intel IS NOT NULL),
+      'has_visual_convergence', (group_visual_convergence IS NOT NULL),
+      'has_build_readiness', (COALESCE(jsonb_array_length(group_build_readiness), 0) > 0),
+      'has_sprint_plan', (COALESCE(jsonb_array_length(group_sprint_plan), 0) > 0)
+    )
+  );
+
+  RETURN result;
+END;
+$$;
+
+-- Grant access to service role
+GRANT EXECUTE ON FUNCTION export_blueprint_review(UUID) TO service_role;
+
+COMMENT ON FUNCTION export_blueprint_review(UUID) IS
+  'Export all pre-build artifacts for a venture grouped by builder concern (What/Who/How/Cost/Why/BuildReadiness/Sprint/VisualConvergence/Design), with Stage 18-19 data for Build Commitment Review. v3 2026-03-24.';

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -55,8 +55,8 @@ const WORKER_VERSION = '1.2.0';
  */
 const CHAIRMAN_GATES = Object.freeze({
   // All frontend gate stages that block the worker pipeline for chairman approval.
-  // Frontend KILL_GATE_STAGES [3, 5, 13, 24] + PROMOTION_GATE_STAGES [10, 17, 18, 23, 25]
-  BLOCKING: new Set([3, 5, 10, 13, 17, 18, 23, 24, 25]),
+  // Frontend KILL_GATE_STAGES [3, 5, 13, 24] + PROMOTION_GATE_STAGES [10, 17, 18, 19, 23, 25]
+  BLOCKING: new Set([3, 5, 10, 13, 17, 18, 19, 23, 24, 25]),
   ADVISORY: new Set([]),
 });
 

--- a/lib/eva/stage-templates/stage-18.js
+++ b/lib/eva/stage-templates/stage-18.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage17 } from './analysis-steps/stage-18-build-readiness.js';
+import { analyzeStage18 as analyzeStage17 } from './analysis-steps/stage-18-build-readiness.js';
 
 const CHECKLIST_CATEGORIES = [
   'architecture',

--- a/lib/eva/stage-templates/stage-19.js
+++ b/lib/eva/stage-templates/stage-19.js
@@ -14,7 +14,7 @@
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage18 } from './analysis-steps/stage-19-sprint-planning.js';
+import { analyzeStage19 as analyzeStage18 } from './analysis-steps/stage-19-sprint-planning.js';
 
 const PRIORITY_VALUES = ['critical', 'high', 'medium', 'low'];
 const SD_TYPES = ['feature', 'bugfix', 'enhancement', 'refactor', 'infra'];

--- a/lib/eva/stage-templates/stage-20.js
+++ b/lib/eva/stage-templates/stage-20.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage19 } from './analysis-steps/stage-20-build-execution.js';
+import { analyzeStage20 as analyzeStage19 } from './analysis-steps/stage-20-build-execution.js';
 
 const TASK_STATUSES = ['pending', 'in_progress', 'done', 'blocked'];
 const ISSUE_SEVERITIES = ['critical', 'high', 'medium', 'low'];

--- a/lib/eva/stage-templates/stage-21.js
+++ b/lib/eva/stage-templates/stage-21.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateNumber, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage20 } from './analysis-steps/stage-21-quality-assurance.js';
+import { analyzeStage21 as analyzeStage20 } from './analysis-steps/stage-21-quality-assurance.js';
 
 const DEFECT_SEVERITIES = ['critical', 'high', 'medium', 'low'];
 const DEFECT_STATUSES = ['open', 'investigating', 'resolved', 'deferred', 'wont_fix'];

--- a/lib/eva/stage-templates/stage-22.js
+++ b/lib/eva/stage-templates/stage-22.js
@@ -11,7 +11,7 @@
 
 import { validateString, validateArray, validateEnum, collectErrors } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
-import { analyzeStage21 } from './analysis-steps/stage-22-build-review.js';
+import { analyzeStage22 as analyzeStage21 } from './analysis-steps/stage-22-build-review.js';
 
 const INTEGRATION_STATUSES = ['pass', 'fail', 'skip', 'pending'];
 const REVIEW_DECISIONS = ['approve', 'conditional', 'reject'];

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -18,8 +18,10 @@ const path = require('path');
 const os = require('os');
 
 const THROTTLE_FILE = path.join(os.tmpdir(), 'claude-coordination-inbox-last-check.json');
+const HEARTBEAT_FILE = path.join(os.tmpdir(), 'claude-heartbeat-last-update.json');
 const IDENTITY_FILE = path.resolve(__dirname, '../../.claude/fleet-identity.json');
 const CHECK_INTERVAL_MS = 300_000; // Only check DB every 5 minutes
+const HEARTBEAT_INTERVAL_MS = 30_000; // Update heartbeat every 30 seconds
 const ACTIONABLE_TYPES = ['WORK_ASSIGNMENT', 'CLAIM_RELEASED', 'CLAIM_REMINDER'];
 
 function shouldCheck() {
@@ -36,6 +38,36 @@ function markChecked() {
   try {
     fs.writeFileSync(THROTTLE_FILE, JSON.stringify({ lastCheck: Date.now() }));
   } catch { /* ignore */ }
+}
+
+function shouldHeartbeat() {
+  try {
+    if (!fs.existsSync(HEARTBEAT_FILE)) return true;
+    const data = JSON.parse(fs.readFileSync(HEARTBEAT_FILE, 'utf8'));
+    return (Date.now() - data.lastHeartbeat) > HEARTBEAT_INTERVAL_MS;
+  } catch {
+    return true;
+  }
+}
+
+function markHeartbeat() {
+  try {
+    fs.writeFileSync(HEARTBEAT_FILE, JSON.stringify({ lastHeartbeat: Date.now() }));
+  } catch { /* ignore */ }
+}
+
+/**
+ * Update heartbeat_at on claude_sessions — runs every 30s regardless of inbox check
+ */
+async function updateHeartbeat(supabase, sessionId) {
+  if (!shouldHeartbeat()) return;
+  markHeartbeat();
+  try {
+    await supabase
+      .from('claude_sessions')
+      .update({ heartbeat_at: new Date().toISOString() })
+      .eq('session_id', sessionId);
+  } catch { /* fail silently */ }
 }
 
 function getCurrentSessionId() {
@@ -99,9 +131,6 @@ function emitAutoClaimDirective(suggestedSd, availableSds) {
 }
 
 async function main() {
-  if (!shouldCheck()) return;
-  markChecked();
-
   let supabase;
   try {
     const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
@@ -112,6 +141,12 @@ async function main() {
 
   const sessionId = getCurrentSessionId();
   if (!sessionId) return;
+
+  // Always update heartbeat (30s throttle) — even when inbox check is skipped
+  await updateHeartbeat(supabase, sessionId);
+
+  if (!shouldCheck()) return;
+  markChecked();
 
   // Check if this session is idle (no SD claimed)
   let isIdle = false;

--- a/scripts/hooks/session-register.cjs
+++ b/scripts/hooks/session-register.cjs
@@ -1,0 +1,91 @@
+/**
+ * Session Register Hook — Ensures session appears in claude_sessions on boot
+ *
+ * Hook: SessionStart
+ * Purpose: Upsert this session into claude_sessions with a fresh heartbeat_at
+ *          so the coordinator dashboard sees workers immediately, even before
+ *          they claim an SD.
+ *
+ * Without this, idle workers are invisible to the fleet dashboard until they
+ * run sd:next and claim work.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+function getCurrentSessionId() {
+  try {
+    const sessionFile = path.resolve(__dirname, '../../.claude/session-id.json');
+    if (fs.existsSync(sessionFile)) {
+      const data = JSON.parse(fs.readFileSync(sessionFile, 'utf8'));
+      if (data.session_id) return data.session_id;
+    }
+
+    const sessionDir = path.join(os.homedir(), '.claude-sessions');
+    if (!fs.existsSync(sessionDir)) return null;
+    const files = fs.readdirSync(sessionDir).filter(f => f.endsWith('.json'));
+    const pid = process.ppid || process.pid;
+
+    for (const file of files) {
+      try {
+        const data = JSON.parse(fs.readFileSync(path.join(sessionDir, file), 'utf8'));
+        if (data.pid === pid || data.session_id?.includes('win' + pid)) {
+          return data.session_id;
+        }
+      } catch { /* skip */ }
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+function getHostname() {
+  try {
+    return os.hostname();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getTTY() {
+  // Derive terminal identifier from PID (matches fleet-dashboard pattern)
+  const pid = process.ppid || process.pid;
+  return `win-${pid}`;
+}
+
+async function main() {
+  let supabase;
+  try {
+    const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+    supabase = createSupabaseServiceClient();
+  } catch {
+    return; // Supabase not available
+  }
+
+  const sessionId = getCurrentSessionId();
+  if (!sessionId) return;
+
+  const now = new Date().toISOString();
+
+  // Upsert session — create if new, update heartbeat if existing
+  const { error } = await supabase
+    .from('claude_sessions')
+    .upsert({
+      session_id: sessionId,
+      hostname: getHostname(),
+      tty: getTTY(),
+      codebase: 'EHG_Engineer',
+      status: 'active',
+      heartbeat_at: now,
+      started_at: now
+    }, {
+      onConflict: 'session_id',
+      ignoreDuplicates: false
+    });
+
+  if (!error) {
+    console.log(`session-register: registered ${sessionId.slice(0, 12)}...`);
+  }
+}
+
+main().catch(() => { /* fail silently */ });


### PR DESCRIPTION
## Summary
- Add Stage 19 to BLOCKING gate set in stage-execution-worker.js (prevents ventures bypassing S19 gate)
- Fix stage template analysis step imports for stages 18-22
- Regenerate CLAUDE*.md protocol files from database (timestamp update)
- Add enrich_stream_sds and export_blueprint_review_v3 database migrations
- Add session-register hook and update coordination-inbox hook

## Test plan
- [x] Stage worker BLOCKING set verified to include 19
- [x] Stage template imports resolve correctly
- [x] Protocol files match database content

🤖 Generated with [Claude Code](https://claude.com/claude-code)