### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LEO-BUILD-001-A): fix target_application SD routing

### DIFF
--- a/lib/eva/bridge/sd-router.js
+++ b/lib/eva/bridge/sd-router.js
@@ -1,0 +1,58 @@
+/**
+ * SD Router — Resolves target_application for venture SDs
+ *
+ * Validates venture names against applications/registry.json via venture-resolver.js.
+ * Falls back to 'ehg' when venture name is null, undefined, or not registered.
+ *
+ * Created by: SD-LEO-INFRA-VENTURE-LEO-BUILD-001-A
+ *
+ * @module lib/eva/bridge/sd-router
+ */
+
+import { getVentureConfig } from '../../venture-resolver.js';
+
+const DEFAULT_TARGET = 'ehg';
+
+/**
+ * Resolve the target application for a venture SD.
+ *
+ * @param {string|null|undefined} ventureName - The venture name from stage execution context
+ * @param {Object} [options]
+ * @param {Object} [options.logger=console] - Logger instance
+ * @returns {{ targetApp: string, githubRepo: string|null, localPath: string|null, supabaseSchema: string|null, fallback: boolean }}
+ */
+export function resolveTargetApplication(ventureName, { logger = console } = {}) {
+  if (!ventureName) {
+    logger.log('[sd-router] No venture name provided, using default:', DEFAULT_TARGET);
+    return {
+      targetApp: DEFAULT_TARGET,
+      githubRepo: null,
+      localPath: null,
+      supabaseSchema: null,
+      fallback: true,
+    };
+  }
+
+  const config = getVentureConfig(ventureName);
+
+  if (!config) {
+    logger.warn(`[sd-router] Venture "${ventureName}" not found in registry, falling back to: ${DEFAULT_TARGET}`);
+    return {
+      targetApp: DEFAULT_TARGET,
+      githubRepo: null,
+      localPath: null,
+      supabaseSchema: null,
+      fallback: true,
+    };
+  }
+
+  logger.log(`[sd-router] Resolved venture "${ventureName}" → target_application: ${config.name}`);
+
+  return {
+    targetApp: config.name,
+    githubRepo: config.github_repo || null,
+    localPath: config.local_path || null,
+    supabaseSchema: config.supabase_schema || null,
+    fallback: false,
+  };
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
@@ -13,6 +13,7 @@ import { getLLMClient } from '../../../llm/index.js';
 import { parseJSON, extractUsage } from '../../utils/parse-json.js';
 import { getFourBucketsPrompt } from '../../utils/four-buckets-prompt.js';
 import { parseFourBuckets } from '../../utils/four-buckets-parser.js';
+import { resolveTargetApplication } from '../../bridge/sd-router.js';
 
 // NOTE: These constants intentionally duplicated from stage-19.js
 // to avoid circular dependency — stage-19.js imports analyzeStage19 from this file,
@@ -153,6 +154,9 @@ Output ONLY valid JSON.`;
     logger.warn('[Stage19] LLM fallback fields detected', { llmFallbackCount });
   }
 
+  // Resolve venture routing from registry (replaces hardcoded 'ehg')
+  const routing = resolveTargetApplication(ventureName, { logger });
+
   // Transform sprint items to match template schema
   const items = sprintItems.map(item => ({
     title: item.title,
@@ -163,7 +167,7 @@ Output ONLY valid JSON.`;
     success_criteria: String(item.acceptanceCriteria || 'Item completed').substring(0, 500),
     dependencies: [],
     risks: [],
-    target_application: 'ehg',
+    target_application: routing.targetApp,
     story_points: typeof item.estimatedLoc === 'number' ? Math.ceil(item.estimatedLoc / 50) : 3,
     architectureLayer: item.architectureLayer,
     milestoneRef: item.milestoneRef,

--- a/tests/unit/bridge/sd-router.test.js
+++ b/tests/unit/bridge/sd-router.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveTargetApplication } from '../../../lib/eva/bridge/sd-router.js';
+
+// Mock venture-resolver to avoid filesystem dependency
+vi.mock('../../../lib/venture-resolver.js', () => ({
+  getVentureConfig: vi.fn((name) => {
+    const registry = {
+      ehg: { name: 'ehg', github_repo: 'rickfelix/ehg.git', local_path: 'C:/Projects/ehg', supabase_schema: null },
+      'test-leo-project': { name: 'test-leo-project', github_repo: 'rickf-test/leo-test-repo', local_path: 'C:/Projects/test-leo-project', supabase_schema: 'venture_test_leo' },
+    };
+    return name ? registry[name.toLowerCase()] || null : null;
+  }),
+}));
+
+const silentLogger = { log: vi.fn(), warn: vi.fn() };
+
+describe('sd-router', () => {
+  describe('resolveTargetApplication', () => {
+    it('resolves known venture from registry', () => {
+      const result = resolveTargetApplication('ehg', { logger: silentLogger });
+      expect(result.targetApp).toBe('ehg');
+      expect(result.githubRepo).toBe('rickfelix/ehg.git');
+      expect(result.fallback).toBe(false);
+    });
+
+    it('resolves second registered venture', () => {
+      const result = resolveTargetApplication('test-leo-project', { logger: silentLogger });
+      expect(result.targetApp).toBe('test-leo-project');
+      expect(result.githubRepo).toBe('rickf-test/leo-test-repo');
+      expect(result.supabaseSchema).toBe('venture_test_leo');
+      expect(result.fallback).toBe(false);
+    });
+
+    it('falls back to ehg for unknown venture', () => {
+      const result = resolveTargetApplication('unknown-venture', { logger: silentLogger });
+      expect(result.targetApp).toBe('ehg');
+      expect(result.fallback).toBe(true);
+      expect(silentLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('unknown-venture')
+      );
+    });
+
+    it('falls back to ehg for null input', () => {
+      const result = resolveTargetApplication(null, { logger: silentLogger });
+      expect(result.targetApp).toBe('ehg');
+      expect(result.fallback).toBe(true);
+    });
+
+    it('falls back to ehg for undefined input', () => {
+      const result = resolveTargetApplication(undefined, { logger: silentLogger });
+      expect(result.targetApp).toBe('ehg');
+      expect(result.fallback).toBe(true);
+    });
+
+    it('falls back to ehg for empty string', () => {
+      const result = resolveTargetApplication('', { logger: silentLogger });
+      expect(result.targetApp).toBe('ehg');
+      expect(result.fallback).toBe(true);
+    });
+
+    it('uses console as default logger', () => {
+      // Should not throw when no logger provided
+      const result = resolveTargetApplication('ehg');
+      expect(result.targetApp).toBe('ehg');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace hardcoded `target_application: 'ehg'` in `stage-19-sprint-planning.js` with dynamic venture context lookup
- Create `lib/eva/bridge/sd-router.js` module that validates venture names against `applications/registry.json` via existing `venture-resolver.js`
- Falls back to `ehg` for null/unknown venture names (backward compatible)
- 7 unit tests covering known, unknown, null, and empty inputs

## Context
Child SD of orchestrator SD-LEO-INFRA-VENTURE-LEO-BUILD-001 (Venture-to-LEO Build Execution Bridge). This is the CRO's top-priority fix — no venture can produce real code through the Build Loop until SDs route to the correct venture codebase.

## Test plan
- [x] `npx vitest run tests/unit/bridge/sd-router.test.js` — 7/7 pass
- [ ] Verify stage-19 import resolves correctly
- [ ] Verify existing lifecycle-sd-bridge tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)