### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LEO-BUILD-001-D): add build-feedback-collector

### DIFF
--- a/lib/eva/__tests__/build-feedback-collector.test.js
+++ b/lib/eva/__tests__/build-feedback-collector.test.js
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import { parseVitestJson, parsePlaywrightReport, parseLcovCoverage, collectBuildFeedback } from '../bridge/build-feedback-collector.js';
+
+// --- Sample Fixtures ---
+
+const VITEST_JSON = {
+  numTotalTests: 10,
+  numPassedTests: 8,
+  numFailedTests: 1,
+  numPendingTests: 1,
+  duration: 5200,
+  testResults: [
+    {
+      name: 'tests/unit/parser.test.js',
+      assertionResults: [
+        { fullName: 'parser > parses input', status: 'passed', duration: 12 },
+        { fullName: 'parser > handles edge case', status: 'failed', duration: 5, failureMessages: ['Expected 1 to be 2'] },
+      ],
+    },
+  ],
+};
+
+const PLAYWRIGHT_JSON = {
+  stats: { duration: 15000 },
+  suites: [
+    {
+      title: 'Dashboard',
+      specs: [
+        {
+          title: 'loads dashboard',
+          tests: [{ status: 'expected', results: [{ status: 'passed', duration: 3200, attachments: [] }] }],
+        },
+        {
+          title: 'shows error on failure',
+          tests: [{ status: 'unexpected', results: [{ status: 'failed', duration: 1500, attachments: [{ name: 'screenshot' }] }] }],
+        },
+      ],
+      suites: [],
+    },
+  ],
+};
+
+const LCOV_CONTENT = `SF:lib/module.js
+FNF:5
+FNH:4
+LF:100
+LH:85
+BRF:20
+BRH:16
+end_of_record
+SF:lib/other.js
+FNF:3
+FNH:3
+LF:50
+LH:50
+BRF:10
+BRH:10
+end_of_record`;
+
+// --- Tests ---
+
+describe('parseVitestJson', () => {
+  const tmpPath = '/tmp/test-vitest.json';
+
+  afterEach(() => {
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+  });
+
+  it('parses valid Vitest JSON output', () => {
+    fs.writeFileSync(tmpPath, JSON.stringify(VITEST_JSON));
+    const { data, warning } = parseVitestJson(tmpPath);
+    expect(warning).toBeNull();
+    expect(data.framework).toBe('vitest');
+    expect(data.numPassed).toBe(8);
+    expect(data.numFailed).toBe(1);
+    expect(data.numSkipped).toBe(1);
+    expect(data.numTotal).toBe(10);
+    expect(data.totalDuration).toBe(5200);
+    expect(data.success).toBe(false);
+    expect(data.failures).toHaveLength(1);
+    expect(data.failures[0].testName).toBe('parser > handles edge case');
+  });
+
+  it('returns warning when path is null', () => {
+    const { data, warning } = parseVitestJson(null);
+    expect(data).toBeNull();
+    expect(warning).toContain('not provided');
+  });
+
+  it('returns warning when file does not exist', () => {
+    const { data, warning } = parseVitestJson('/tmp/nonexistent.json');
+    expect(data).toBeNull();
+    expect(warning).toContain('not found');
+  });
+
+  it('returns warning on malformed JSON', () => {
+    fs.writeFileSync(tmpPath, '{{invalid json');
+    const { data, warning } = parseVitestJson(tmpPath);
+    expect(data).toBeNull();
+    expect(warning).toContain('parse error');
+  });
+
+  it('derives counts from testResults when top-level counts are zero', () => {
+    const minimalJson = {
+      numTotalTests: 0,
+      numPassedTests: 0,
+      numFailedTests: 0,
+      numPendingTests: 0,
+      testResults: [
+        {
+          name: 'test.js',
+          assertionResults: [
+            { status: 'passed', fullName: 'a' },
+            { status: 'failed', fullName: 'b', failureMessages: ['err'] },
+          ],
+        },
+      ],
+    };
+    fs.writeFileSync(tmpPath, JSON.stringify(minimalJson));
+    const { data } = parseVitestJson(tmpPath);
+    expect(data.numTotal).toBe(2);
+    expect(data.numPassed).toBe(1);
+    expect(data.numFailed).toBe(1);
+  });
+});
+
+describe('parsePlaywrightReport', () => {
+  const tmpPath = '/tmp/test-playwright.json';
+
+  afterEach(() => {
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+  });
+
+  it('parses valid Playwright JSON report', () => {
+    fs.writeFileSync(tmpPath, JSON.stringify(PLAYWRIGHT_JSON));
+    const { data, warning } = parsePlaywrightReport(tmpPath);
+    expect(warning).toBeNull();
+    expect(data.framework).toBe('playwright');
+    expect(data.numTotal).toBe(2);
+    expect(data.numPassed).toBe(1);
+    expect(data.numFailed).toBe(1);
+    expect(data.success).toBe(false);
+    expect(data.tests[1].attachments).toContain('screenshot');
+  });
+
+  it('returns warning when path is null', () => {
+    const { data, warning } = parsePlaywrightReport(null);
+    expect(data).toBeNull();
+    expect(warning).toContain('not provided');
+  });
+
+  it('returns warning when file does not exist', () => {
+    const { data, warning } = parsePlaywrightReport('/tmp/nonexistent.json');
+    expect(data).toBeNull();
+    expect(warning).toContain('not found');
+  });
+});
+
+describe('parseLcovCoverage', () => {
+  const tmpPath = '/tmp/test-lcov.info';
+
+  afterEach(() => {
+    try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
+  });
+
+  it('parses valid lcov.info file', () => {
+    fs.writeFileSync(tmpPath, LCOV_CONTENT);
+    const { data, warning } = parseLcovCoverage(tmpPath);
+    expect(warning).toBeNull();
+    // Lines: 135/150 = 90%
+    expect(data.lines).toBe(90);
+    // Branches: 26/30 = 86.67%
+    expect(data.branches).toBe(86.67);
+    // Functions: 7/8 = 87.5%
+    expect(data.functions).toBe(87.5);
+    expect(data.linesFound).toBe(150);
+    expect(data.linesHit).toBe(135);
+  });
+
+  it('returns warning when path is null', () => {
+    const { data, warning } = parseLcovCoverage(null);
+    expect(data).toBeNull();
+    expect(warning).toContain('not provided');
+  });
+
+  it('handles 0% coverage', () => {
+    fs.writeFileSync(tmpPath, 'SF:empty.js\nLF:10\nLH:0\nBRF:5\nBRH:0\nFNF:2\nFNH:0\nend_of_record');
+    const { data } = parseLcovCoverage(tmpPath);
+    expect(data.lines).toBe(0);
+    expect(data.branches).toBe(0);
+    expect(data.functions).toBe(0);
+  });
+});
+
+describe('collectBuildFeedback', () => {
+  it('returns partial results with warnings when no paths provided', async () => {
+    const result = await collectBuildFeedback('fake-venture-id', {}, { skipWrite: true });
+    expect(result.success).toBe(true);
+    expect(result.data.unit_tests).toBeNull();
+    expect(result.data.e2e_tests).toBeNull();
+    expect(result.data.coverage).toBeNull();
+    expect(result.warnings).toHaveLength(3);
+  });
+
+  it('parses all three artifacts when provided', async () => {
+    const vitestPath = '/tmp/test-collect-vitest.json';
+    const playwrightPath = '/tmp/test-collect-pw.json';
+    const lcovPath = '/tmp/test-collect-lcov.info';
+
+    fs.writeFileSync(vitestPath, JSON.stringify(VITEST_JSON));
+    fs.writeFileSync(playwrightPath, JSON.stringify(PLAYWRIGHT_JSON));
+    fs.writeFileSync(lcovPath, LCOV_CONTENT);
+
+    try {
+      const result = await collectBuildFeedback('fake-venture-id', {
+        vitestJson: vitestPath,
+        playwrightReport: playwrightPath,
+        lcovInfo: lcovPath,
+      }, { skipWrite: true });
+
+      expect(result.success).toBe(true);
+      expect(result.data.unit_tests).toBeTruthy();
+      expect(result.data.unit_tests.framework).toBe('vitest');
+      expect(result.data.e2e_tests).toBeTruthy();
+      expect(result.data.e2e_tests.framework).toBe('playwright');
+      expect(result.data.coverage).toBeTruthy();
+      expect(result.data.coverage.lines).toBe(90);
+      expect(result.warnings).toHaveLength(0);
+    } finally {
+      try { fs.unlinkSync(vitestPath); } catch { /* */ }
+      try { fs.unlinkSync(playwrightPath); } catch { /* */ }
+      try { fs.unlinkSync(lcovPath); } catch { /* */ }
+    }
+  });
+
+  it('requires ventureId for database write', async () => {
+    const result = await collectBuildFeedback(null, {});
+    expect(result.success).toBe(false);
+    expect(result.warnings.some(w => w.includes('ventureId'))).toBe(true);
+  });
+
+  it('collectBuildFeedback is exported as a function', async () => {
+    expect(typeof collectBuildFeedback).toBe('function');
+  });
+});

--- a/lib/eva/bridge/build-feedback-collector.js
+++ b/lib/eva/bridge/build-feedback-collector.js
@@ -1,0 +1,279 @@
+/**
+ * Build Feedback Collector
+ * SD-LEO-INFRA-VENTURE-LEO-BUILD-001-D
+ *
+ * Aggregates CI/CD results (Vitest, Playwright, lcov) from venture
+ * GitHub Actions into venture_stage_work advisory_data for Stage 20.
+ */
+
+import fs from 'fs';
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// --- Parsers ---
+
+/**
+ * Parse Vitest JSON reporter output.
+ * Expects the standard Vitest --reporter=json format.
+ * @param {string} filePath - Path to vitest JSON output
+ * @returns {{ data: object|null, warning: string|null }}
+ */
+export function parseVitestJson(filePath) {
+  if (!filePath) return { data: null, warning: 'Vitest JSON path not provided' };
+  try {
+    if (!fs.existsSync(filePath)) return { data: null, warning: `Vitest JSON not found: ${filePath}` };
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+    const testResults = raw.testResults || raw.files || [];
+    let numPassed = raw.numPassedTests || 0;
+    let numFailed = raw.numFailedTests || 0;
+    let numSkipped = raw.numPendingTests || 0;
+    let numTotal = raw.numTotalTests || 0;
+
+    // Derive from testResults if top-level counts are missing
+    if (!numTotal && testResults.length > 0) {
+      for (const file of testResults) {
+        const tests = file.assertionResults || file.tests || [];
+        numTotal += tests.length;
+        numPassed += tests.filter(t => t.status === 'passed').length;
+        numFailed += tests.filter(t => t.status === 'failed').length;
+        numSkipped += tests.filter(t => ['pending', 'skipped'].includes(t.status)).length;
+      }
+    }
+
+    const failures = [];
+    for (const file of testResults) {
+      for (const test of (file.assertionResults || file.tests || [])) {
+        if (test.status === 'failed') {
+          failures.push({
+            testName: test.fullName || test.name || test.title || 'unknown',
+            filePath: file.name || file.filePath || 'unknown',
+            errorMessage: (test.failureMessages?.join('\n') || test.error?.message || '').substring(0, 500),
+            duration: test.duration || 0,
+          });
+        }
+      }
+    }
+
+    return {
+      data: {
+        framework: 'vitest',
+        numPassed,
+        numFailed,
+        numSkipped,
+        numTotal,
+        totalDuration: raw.duration || 0,
+        success: numFailed === 0,
+        failures,
+      },
+      warning: null,
+    };
+  } catch (err) {
+    return { data: null, warning: `Vitest JSON parse error: ${err.message}` };
+  }
+}
+
+/**
+ * Parse Playwright JSON reporter output.
+ * Expects the standard Playwright --reporter=json format.
+ * @param {string} filePath - Path to playwright JSON output
+ * @returns {{ data: object|null, warning: string|null }}
+ */
+export function parsePlaywrightReport(filePath) {
+  if (!filePath) return { data: null, warning: 'Playwright report path not provided' };
+  try {
+    if (!fs.existsSync(filePath)) return { data: null, warning: `Playwright report not found: ${filePath}` };
+    const raw = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+
+    const suites = raw.suites || [];
+    const tests = [];
+
+    // Recursively extract tests from nested suites
+    function extractTests(suiteList) {
+      for (const suite of suiteList) {
+        for (const spec of (suite.specs || [])) {
+          for (const test of (spec.tests || [])) {
+            const result = test.results?.[0] || {};
+            tests.push({
+              title: spec.title || 'unknown',
+              status: result.status || test.status || 'unknown',
+              duration: result.duration || 0,
+              attachments: (result.attachments || []).map(a => a.name || a.path).filter(Boolean),
+            });
+          }
+        }
+        if (suite.suites) extractTests(suite.suites);
+      }
+    }
+    extractTests(suites);
+
+    const numPassed = tests.filter(t => t.status === 'passed' || t.status === 'expected').length;
+    const numFailed = tests.filter(t => t.status === 'failed' || t.status === 'unexpected').length;
+    const numSkipped = tests.filter(t => t.status === 'skipped').length;
+
+    return {
+      data: {
+        framework: 'playwright',
+        numPassed,
+        numFailed,
+        numSkipped,
+        numTotal: tests.length,
+        totalDuration: raw.stats?.duration || tests.reduce((sum, t) => sum + t.duration, 0),
+        success: numFailed === 0,
+        tests,
+      },
+      warning: null,
+    };
+  } catch (err) {
+    return { data: null, warning: `Playwright report parse error: ${err.message}` };
+  }
+}
+
+/**
+ * Parse Istanbul lcov.info coverage report.
+ * @param {string} filePath - Path to lcov.info file
+ * @returns {{ data: object|null, warning: string|null }}
+ */
+export function parseLcovCoverage(filePath) {
+  if (!filePath) return { data: null, warning: 'lcov file path not provided' };
+  try {
+    if (!fs.existsSync(filePath)) return { data: null, warning: `lcov file not found: ${filePath}` };
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    let linesFound = 0, linesHit = 0;
+    let branchesFound = 0, branchesHit = 0;
+    let functionsFound = 0, functionsHit = 0;
+
+    for (const line of content.split('\n')) {
+      const [tag, value] = line.split(':');
+      const num = parseInt(value, 10);
+      if (isNaN(num)) continue;
+      switch (tag) {
+        case 'LF': linesFound += num; break;
+        case 'LH': linesHit += num; break;
+        case 'BRF': branchesFound += num; break;
+        case 'BRH': branchesHit += num; break;
+        case 'FNF': functionsFound += num; break;
+        case 'FNH': functionsHit += num; break;
+      }
+    }
+
+    const pct = (hit, found) => found > 0 ? Math.round((hit / found) * 10000) / 100 : 0;
+
+    return {
+      data: {
+        lines: pct(linesHit, linesFound),
+        branches: pct(branchesHit, branchesFound),
+        functions: pct(functionsHit, functionsFound),
+        statements: pct(linesHit, linesFound), // lcov doesn't distinguish statements from lines
+        linesFound,
+        linesHit,
+      },
+      warning: null,
+    };
+  } catch (err) {
+    return { data: null, warning: `lcov parse error: ${err.message}` };
+  }
+}
+
+// --- Database Writer ---
+
+/**
+ * Write build feedback to venture_stage_work advisory_data.
+ * Merges into existing advisory_data under the 'build_feedback' key.
+ * @param {string} ventureId - Venture UUID
+ * @param {number} lifecycleStage - Stage number (default 20)
+ * @param {object} buildFeedback - Aggregated feedback data
+ * @returns {{ success: boolean, error: string|null }}
+ */
+async function writeAdvisoryData(ventureId, lifecycleStage, buildFeedback) {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !supabaseKey) {
+    return { success: false, error: 'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required' };
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  // Check row exists
+  const { data: existing, error: fetchError } = await supabase
+    .from('venture_stage_work')
+    .select('id, advisory_data')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', lifecycleStage)
+    .single();
+
+  if (fetchError || !existing) {
+    return { success: false, error: `venture_stage_work row not found for venture ${ventureId} stage ${lifecycleStage}` };
+  }
+
+  const currentAdvisory = existing.advisory_data || {};
+  const updatedAdvisory = {
+    ...currentAdvisory,
+    build_feedback: {
+      ...buildFeedback,
+      collected_at: new Date().toISOString(),
+    },
+  };
+
+  const { error: updateError } = await supabase
+    .from('venture_stage_work')
+    .update({ advisory_data: updatedAdvisory })
+    .eq('id', existing.id);
+
+  if (updateError) {
+    return { success: false, error: `Failed to update advisory_data: ${updateError.message}` };
+  }
+
+  return { success: true, error: null };
+}
+
+// --- Orchestrator ---
+
+/**
+ * Collect build feedback from CI/CD artifacts and write to venture_stage_work.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {object} artifactPaths - Optional paths to CI artifacts
+ * @param {string} [artifactPaths.vitestJson] - Path to Vitest JSON reporter output
+ * @param {string} [artifactPaths.playwrightReport] - Path to Playwright JSON report
+ * @param {string} [artifactPaths.lcovInfo] - Path to lcov.info coverage file
+ * @param {object} [options]
+ * @param {number} [options.lifecycleStage=20] - Target lifecycle stage
+ * @param {boolean} [options.skipWrite=false] - Parse only, skip database write
+ * @returns {Promise<{ success: boolean, data: object, warnings: string[] }>}
+ */
+export async function collectBuildFeedback(ventureId, artifactPaths = {}, options = {}) {
+  const { lifecycleStage = 20, skipWrite = false } = options;
+  const warnings = [];
+
+  // Parse all three artifact types
+  const vitest = parseVitestJson(artifactPaths.vitestJson);
+  const playwright = parsePlaywrightReport(artifactPaths.playwrightReport);
+  const lcov = parseLcovCoverage(artifactPaths.lcovInfo);
+
+  if (vitest.warning) warnings.push(vitest.warning);
+  if (playwright.warning) warnings.push(playwright.warning);
+  if (lcov.warning) warnings.push(lcov.warning);
+
+  const buildFeedback = {
+    unit_tests: vitest.data,
+    e2e_tests: playwright.data,
+    coverage: lcov.data,
+  };
+
+  if (!skipWrite) {
+    if (!ventureId) {
+      return { success: false, data: buildFeedback, warnings: [...warnings, 'ventureId is required for database write'] };
+    }
+
+    const writeResult = await writeAdvisoryData(ventureId, lifecycleStage, buildFeedback);
+    if (!writeResult.success) {
+      return { success: false, data: buildFeedback, warnings: [...warnings, writeResult.error] };
+    }
+  }
+
+  return { success: true, data: buildFeedback, warnings };
+}


### PR DESCRIPTION
## Summary
- Create `lib/eva/bridge/build-feedback-collector.js` (~235 LOC) that aggregates CI/CD results from venture GitHub Actions into `venture_stage_work.advisory_data`
- Implements three parsers: Vitest JSON, Playwright JSON, Istanbul lcov with graceful degradation on missing/malformed artifacts
- Includes 15 unit tests covering all parser functions, edge cases, and orchestrator

## Test plan
- [x] 15/15 unit tests passing (Vitest)
- [x] Vitest JSON parser handles valid input, missing files, malformed JSON
- [x] Playwright JSON parser handles nested suites, missing files
- [x] lcov parser handles multi-file reports, 0% coverage
- [x] collectBuildFeedback() graceful degradation with no artifacts
- [x] collectBuildFeedback() aggregates all 3 artifact types

🤖 Generated with [Claude Code](https://claude.com/claude-code)