### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LEO-BUILD-001-B): add --register flag to create-ehg-venture

### DIFF
--- a/packages/create-ehg-venture/index.js
+++ b/packages/create-ehg-venture/index.js
@@ -470,7 +470,7 @@ async function registerVenture(name, root) {
   } catch {
     // Repo doesn't exist — create it
     try {
-      const result = execSync(`gh repo create ${repoName} --public --description "EHG Venture: ${name}" --confirm`, { stdio: 'pipe', encoding: 'utf8' });
+      execSync(`gh repo create ${repoName} --public --description "EHG Venture: ${name}" --confirm`, { stdio: 'pipe', encoding: 'utf8' });
       githubRepoUrl = `https://github.com/${repoName}`;
       console.log(`  ✓ GitHub repo created: ${githubRepoUrl}`);
     } catch (err) {

--- a/tests/unit/create-ehg-venture-register.test.js
+++ b/tests/unit/create-ehg-venture-register.test.js
@@ -3,9 +3,8 @@
  * SD: SD-LEO-INFRA-VENTURE-LEO-BUILD-001-B
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { execSync } from 'child_process';
 
 const REGISTRY_PATH = join(process.cwd(), 'applications', 'registry.json');
 


### PR DESCRIPTION
## Summary
- Adds `--register` flag to `create-ehg-venture` CLI that automates post-scaffold registration: GitHub repo creation via `gh` CLI, `applications/registry.json` update, and `venture_provisioning_state` DB record
- Each registration step is independent with graceful error handling — failures don't block scaffold
- Includes venture name validation (lowercase alphanumeric with hyphens) and idempotent registry updates
- 7 unit tests covering flag parsing, registry logic, and backward compatibility

## Test plan
- [x] Unit tests pass (7/7)
- [x] Smoke tests pass (15/15)
- [x] ESLint clean
- [x] Existing scaffold behavior unchanged without `--register`
- [ ] Manual verification: run with `--register` on a test venture

🤖 Generated with [Claude Code](https://claude.com/claude-code)