### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LEO-BUILD-001-C): add venture provisioner state machine

### DIFF
--- a/lib/eva/__tests__/venture-provisioner.test.js
+++ b/lib/eva/__tests__/venture-provisioner.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+import { provisionVenture } from '../bridge/venture-provisioner.js';
+
+const noop = () => {};
+
+function makeStep(name, { alreadyDone = false, shouldFail = false, failCount = 0 } = {}) {
+  let callCount = 0;
+  return {
+    name,
+    check: vi.fn(async (ctx) => alreadyDone || ctx.stepsCompleted.includes(name)),
+    execute: vi.fn(async () => {
+      callCount++;
+      if (shouldFail) throw new Error(`${name} permanent failure`);
+      if (failCount > 0 && callCount <= failCount) throw new Error(`${name} transient failure`);
+    }),
+  };
+}
+
+describe('provisionVenture', () => {
+  it('executes all steps on fresh venture', async () => {
+    const steps = [makeStep('step_a'), makeStep('step_b'), makeStep('step_c')];
+    const result = await provisionVenture('venture-1', { steps, skipStateTracking: true, logger: noop });
+
+    expect(result.success).toBe(true);
+    expect(result.stepsCompleted).toEqual(['step_a', 'step_b', 'step_c']);
+    expect(result.stepsSkipped).toHaveLength(0);
+    expect(result.error).toBeNull();
+    expect(steps[0].execute).toHaveBeenCalledOnce();
+    expect(steps[1].execute).toHaveBeenCalledOnce();
+    expect(steps[2].execute).toHaveBeenCalledOnce();
+  });
+
+  it('skips already-completed steps (idempotency)', async () => {
+    const steps = [
+      makeStep('step_a', { alreadyDone: true }),
+      makeStep('step_b', { alreadyDone: true }),
+      makeStep('step_c'),
+    ];
+    const result = await provisionVenture('venture-2', { steps, skipStateTracking: true, logger: noop });
+
+    expect(result.success).toBe(true);
+    expect(result.stepsCompleted).toEqual(['step_c']);
+    expect(result.stepsSkipped).toEqual(['step_a', 'step_b']);
+    expect(steps[0].execute).not.toHaveBeenCalled();
+    expect(steps[1].execute).not.toHaveBeenCalled();
+    expect(steps[2].execute).toHaveBeenCalledOnce();
+  });
+
+  it('returns no-op when all steps already done', async () => {
+    const steps = [
+      makeStep('step_a', { alreadyDone: true }),
+      makeStep('step_b', { alreadyDone: true }),
+    ];
+    const result = await provisionVenture('venture-3', { steps, skipStateTracking: true, logger: noop });
+
+    expect(result.success).toBe(true);
+    expect(result.stepsCompleted).toHaveLength(0);
+    expect(result.stepsSkipped).toEqual(['step_a', 'step_b']);
+  });
+
+  it('retries transient failures and succeeds', async () => {
+    const steps = [makeStep('step_a'), makeStep('step_b', { failCount: 2 })];
+    const result = await provisionVenture('venture-4', { steps, skipStateTracking: true, logger: noop });
+
+    expect(result.success).toBe(true);
+    expect(result.stepsCompleted).toEqual(['step_a', 'step_b']);
+    // step_b should have been called 3 times (2 failures + 1 success)
+    expect(steps[1].execute).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails after exhausting retries', async () => {
+    const steps = [makeStep('step_a'), makeStep('step_b', { shouldFail: true })];
+    const result = await provisionVenture('venture-5', { steps, skipStateTracking: true, logger: noop });
+
+    expect(result.success).toBe(false);
+    expect(result.stepsCompleted).toEqual(['step_a']);
+    expect(result.error).toContain('step_b');
+    expect(result.error).toContain('3 attempts');
+  });
+
+  it('stops at first failure without executing later steps', async () => {
+    const steps = [
+      makeStep('step_a'),
+      makeStep('step_b', { shouldFail: true }),
+      makeStep('step_c'),
+    ];
+    const result = await provisionVenture('venture-6', { steps, skipStateTracking: true, logger: noop });
+
+    expect(result.success).toBe(false);
+    expect(result.stepsCompleted).toEqual(['step_a']);
+    expect(steps[2].execute).not.toHaveBeenCalled();
+  });
+
+  it('recovery after partial failure: second run picks up from failed step', async () => {
+    // First run: step_a succeeds, step_b fails
+    const stepA = makeStep('step_a');
+    const stepB_fail = makeStep('step_b', { shouldFail: true });
+    const stepC = makeStep('step_c');
+    await provisionVenture('venture-7', { steps: [stepA, stepB_fail, stepC], skipStateTracking: true, logger: noop });
+
+    // Second run: step_a already done (simulated), step_b now succeeds
+    const stepA2 = makeStep('step_a', { alreadyDone: true });
+    const stepB2 = makeStep('step_b'); // Now succeeds
+    const stepC2 = makeStep('step_c');
+    const result = await provisionVenture('venture-7', { steps: [stepA2, stepB2, stepC2], skipStateTracking: true, logger: noop });
+
+    expect(result.success).toBe(true);
+    expect(result.stepsCompleted).toEqual(['step_b', 'step_c']);
+    expect(result.stepsSkipped).toEqual(['step_a']);
+  });
+
+  it('passes ventureId in context', async () => {
+    let capturedCtx = null;
+    const steps = [{
+      name: 'capture',
+      check: async () => false,
+      execute: async (ctx) => { capturedCtx = ctx; },
+    }];
+    await provisionVenture('venture-ctx', { steps, skipStateTracking: true, logger: noop });
+    expect(capturedCtx.ventureId).toBe('venture-ctx');
+  });
+
+  it('exports provisionVenture as a function', () => {
+    expect(typeof provisionVenture).toBe('function');
+  });
+});

--- a/lib/eva/bridge/provisioning-state.js
+++ b/lib/eva/bridge/provisioning-state.js
@@ -1,0 +1,144 @@
+/**
+ * Provisioning State CRUD
+ * SD-LEO-INFRA-VENTURE-LEO-BUILD-001-C
+ *
+ * CRUD operations for the venture_provisioning_state table.
+ * Tracks the provisioning lifecycle per venture.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+function getSupabase() {
+  return createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+}
+
+/**
+ * Get provisioning state for a venture. Auto-creates if not found.
+ * @param {string} ventureId - Venture UUID
+ * @returns {Promise<{ data: object|null, error: string|null }>}
+ */
+export async function getState(ventureId) {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('venture_provisioning_state')
+    .select('*')
+    .eq('venture_id', ventureId)
+    .single();
+
+  if (error?.code === 'PGRST116') {
+    // No row found — auto-create with pending status
+    const newState = {
+      venture_id: ventureId,
+      status: 'pending',
+      current_step: null,
+      steps_completed: [],
+      error_details: null,
+      retry_count: 0,
+    };
+
+    const { data: created, error: createErr } = await supabase
+      .from('venture_provisioning_state')
+      .insert(newState)
+      .select('*')
+      .single();
+
+    if (createErr) return { data: null, error: `Failed to create state: ${createErr.message}` };
+    return { data: created, error: null };
+  }
+
+  if (error) return { data: null, error: `Failed to get state: ${error.message}` };
+  return { data, error: null };
+}
+
+/**
+ * Update the current step and optionally add to steps_completed.
+ * @param {string} ventureId
+ * @param {string} stepName - Current step being executed
+ * @param {string} status - 'in_progress' | 'completed' | 'failed'
+ * @param {object} [opts]
+ * @param {boolean} [opts.markStepDone=false] - Add step to steps_completed
+ * @param {string} [opts.errorMessage] - Error detail if failed
+ * @returns {Promise<{ success: boolean, error: string|null }>}
+ */
+export async function updateStep(ventureId, stepName, status, opts = {}) {
+  const supabase = getSupabase();
+  const { markStepDone = false, errorMessage = null } = opts;
+
+  // Get current state to merge steps_completed
+  const { data: current } = await supabase
+    .from('venture_provisioning_state')
+    .select('steps_completed')
+    .eq('venture_id', ventureId)
+    .single();
+
+  const stepsCompleted = current?.steps_completed || [];
+  if (markStepDone && !stepsCompleted.includes(stepName)) {
+    stepsCompleted.push(stepName);
+  }
+
+  const update = {
+    status,
+    current_step: stepName,
+    steps_completed: stepsCompleted,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (errorMessage) update.error_details = errorMessage;
+
+  const { error } = await supabase
+    .from('venture_provisioning_state')
+    .update(update)
+    .eq('venture_id', ventureId);
+
+  if (error) return { success: false, error: `Update failed: ${error.message}` };
+  return { success: true, error: null };
+}
+
+/**
+ * Mark provisioning as fully completed.
+ * @param {string} ventureId
+ * @returns {Promise<{ success: boolean, error: string|null }>}
+ */
+export async function markComplete(ventureId) {
+  const supabase = getSupabase();
+
+  const { error } = await supabase
+    .from('venture_provisioning_state')
+    .update({
+      status: 'completed',
+      current_step: null,
+      error_details: null,
+      completed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('venture_id', ventureId);
+
+  if (error) return { success: false, error: `Mark complete failed: ${error.message}` };
+  return { success: true, error: null };
+}
+
+/**
+ * Mark provisioning as permanently failed.
+ * @param {string} ventureId
+ * @param {string} errorMessage
+ * @returns {Promise<{ success: boolean, error: string|null }>}
+ */
+export async function markFailed(ventureId, errorMessage) {
+  const supabase = getSupabase();
+
+  const { error } = await supabase
+    .from('venture_provisioning_state')
+    .update({
+      status: 'failed',
+      error_details: errorMessage,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('venture_id', ventureId);
+
+  if (error) return { success: false, error: `Mark failed error: ${error.message}` };
+  return { success: true, error: null };
+}

--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -1,0 +1,166 @@
+/**
+ * Venture Provisioner — Idempotent State Machine
+ * SD-LEO-INFRA-VENTURE-LEO-BUILD-001-C
+ *
+ * Orchestrates the full venture provisioning lifecycle:
+ * repo creation, registry entry, schema setup, CI/CD config.
+ * Each step is idempotent — safe to re-run after failures.
+ */
+
+import { getState, updateStep, markComplete, markFailed } from './provisioning-state.js';
+
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+/**
+ * Default provisioning steps.
+ * Each step has: name, check (is it already done?), execute (do it).
+ * Steps are stubs — real implementations are wired by downstream SDs.
+ */
+const DEFAULT_STEPS = [
+  {
+    name: 'repo_created',
+    check: async (ctx) => ctx.stepsCompleted.includes('repo_created'),
+    execute: async (ctx) => {
+      // Stub: Real implementation in SD-F (CI/CD Template Generation)
+      // Would call: gh repo create <owner>/<venture-name> --template <template>
+      ctx.log(`[repo_created] Stub: Would create GitHub repo for venture ${ctx.ventureId}`);
+    },
+  },
+  {
+    name: 'registry_updated',
+    check: async (ctx) => ctx.stepsCompleted.includes('registry_updated'),
+    execute: async (ctx) => {
+      // Stub: Real implementation adds entry to applications/registry.json
+      ctx.log(`[registry_updated] Stub: Would update application registry for venture ${ctx.ventureId}`);
+    },
+  },
+  {
+    name: 'schema_created',
+    check: async (ctx) => ctx.stepsCompleted.includes('schema_created'),
+    execute: async (ctx) => {
+      // Stub: Real implementation creates Supabase schema for venture
+      ctx.log(`[schema_created] Stub: Would create Supabase schema for venture ${ctx.ventureId}`);
+    },
+  },
+  {
+    name: 'cicd_configured',
+    check: async (ctx) => ctx.stepsCompleted.includes('cicd_configured'),
+    execute: async (ctx) => {
+      // Stub: Real implementation in SD-F (CI/CD Template Generation)
+      ctx.log(`[cicd_configured] Stub: Would configure CI/CD for venture ${ctx.ventureId}`);
+    },
+  },
+];
+
+/**
+ * Sleep with exponential backoff.
+ * @param {number} attempt - Current attempt (0-indexed)
+ */
+function backoffDelay(attempt) {
+  const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+  return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+/**
+ * Execute a single step with retry logic.
+ * @param {object} step - Step definition { name, check, execute }
+ * @param {object} ctx - Execution context
+ * @returns {Promise<{ status: 'completed'|'skipped'|'failed', error: string|null }>}
+ */
+async function executeStepWithRetry(step, ctx) {
+  // Check if already done (idempotent)
+  const alreadyDone = await step.check(ctx);
+  if (alreadyDone) return { status: 'skipped', error: null };
+
+  // Execute with retries
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      await step.execute(ctx);
+      return { status: 'completed', error: null };
+    } catch (err) {
+      ctx.log(`[${step.name}] Attempt ${attempt + 1}/${MAX_RETRIES} failed: ${err.message}`);
+      if (attempt < MAX_RETRIES - 1) {
+        await backoffDelay(attempt);
+      } else {
+        return { status: 'failed', error: `${step.name} failed after ${MAX_RETRIES} attempts: ${err.message}` };
+      }
+    }
+  }
+
+  return { status: 'failed', error: `${step.name} exhausted retries` };
+}
+
+/**
+ * Provision a venture through the full lifecycle.
+ * Idempotent: safe to call multiple times on the same venture.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {object} [options]
+ * @param {object[]} [options.steps] - Custom steps (defaults to DEFAULT_STEPS)
+ * @param {boolean} [options.skipStateTracking=false] - Skip database state updates (for testing)
+ * @param {function} [options.logger] - Custom logger function
+ * @returns {Promise<{ success: boolean, stepsCompleted: string[], stepsSkipped: string[], error: string|null }>}
+ */
+export async function provisionVenture(ventureId, options = {}) {
+  const { steps = DEFAULT_STEPS, skipStateTracking = false, logger = console.log } = options;
+  const stepsCompleted = [];
+  const stepsSkipped = [];
+  const log = logger;
+
+  // Get or create provisioning state
+  let stateData = { stepsCompleted: [] };
+  if (!skipStateTracking) {
+    const { data, error } = await getState(ventureId);
+    if (error) return { success: false, stepsCompleted: [], stepsSkipped: [], error };
+
+    // Guard against concurrent runs
+    if (data.status === 'in_progress') {
+      return { success: false, stepsCompleted: [], stepsSkipped: [], error: 'Provisioning already in progress for this venture' };
+    }
+
+    // Already completed — no-op
+    if (data.status === 'completed') {
+      return { success: true, stepsCompleted: [], stepsSkipped: steps.map(s => s.name), error: null };
+    }
+
+    stateData = { stepsCompleted: data.steps_completed || [] };
+
+    // Mark as in_progress
+    await updateStep(ventureId, steps[0].name, 'in_progress');
+  }
+
+  const ctx = { ventureId, stepsCompleted: stateData.stepsCompleted, log };
+
+  // Execute each step
+  for (const step of steps) {
+    if (!skipStateTracking) {
+      await updateStep(ventureId, step.name, 'in_progress');
+    }
+
+    const result = await executeStepWithRetry(step, ctx);
+
+    if (result.status === 'completed') {
+      stepsCompleted.push(step.name);
+      ctx.stepsCompleted.push(step.name);
+      if (!skipStateTracking) {
+        await updateStep(ventureId, step.name, 'in_progress', { markStepDone: true });
+      }
+    } else if (result.status === 'skipped') {
+      stepsSkipped.push(step.name);
+    } else {
+      // Failed
+      if (!skipStateTracking) {
+        await markFailed(ventureId, result.error);
+      }
+      return { success: false, stepsCompleted, stepsSkipped, error: result.error };
+    }
+  }
+
+  // All steps done
+  if (!skipStateTracking) {
+    await markComplete(ventureId);
+  }
+
+  return { success: true, stepsCompleted, stepsSkipped, error: null };
+}


### PR DESCRIPTION
## Summary
- Create `lib/eva/bridge/venture-provisioner.js` (~140 LOC) — idempotent state machine for venture provisioning lifecycle
- Create `lib/eva/bridge/provisioning-state.js` (~110 LOC) — CRUD for venture_provisioning_state table
- Implements 4-step pipeline (repo, registry, schema, CI/CD) with retry logic (3 attempts, exponential backoff)
- Steps are stubs — downstream SDs (SD-F, SD-G) wire real implementations

## Test plan
- [x] 9/9 unit tests passing (Vitest)
- [x] Full pipeline: all 4 steps execute in order
- [x] Idempotency: re-run skips completed steps
- [x] No-op: all steps already done returns immediately
- [x] Retry: transient failure recovers after retries
- [x] Failure: permanent failure stops execution, records error
- [x] Recovery: second run picks up from failed step

🤖 Generated with [Claude Code](https://claude.com/claude-code)