### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LEO-BUILD-001-E): venture conformance check integration

### DIFF
--- a/lib/eva/bridge/conformance-integration.js
+++ b/lib/eva/bridge/conformance-integration.js
@@ -1,0 +1,77 @@
+/**
+ * Conformance Integration — Post-provisioning conformance check for ventures
+ *
+ * Wraps venture-conformance-check.js for programmatic use by venture-provisioner.js.
+ * Runs the 28-check conformance suite against a venture repo path, evaluates against
+ * a configurable threshold, and returns structured results for provisioning state updates.
+ *
+ * Created by: SD-LEO-INFRA-VENTURE-LEO-BUILD-001-E
+ *
+ * @module lib/eva/bridge/conformance-integration
+ */
+
+import { runConformanceCheck } from '../../../scripts/venture-conformance-check.js';
+
+const DEFAULT_THRESHOLD = 80;
+
+/**
+ * Run venture conformance check and evaluate against threshold.
+ *
+ * @param {string} ventureRepoPath - Absolute path to the venture repository
+ * @param {Object} [options]
+ * @param {number} [options.threshold] - Minimum conformance score (default: VENTURE_CONFORMANCE_THRESHOLD env or 80)
+ * @param {Object} [options.logger=console] - Logger instance
+ * @returns {{ passed: boolean, score: number, threshold: number, total: number, passing: number, failing: number, failedChecks: Array<{name: string, details: string}> }}
+ */
+export function evaluateConformance(ventureRepoPath, { threshold, logger = console } = {}) {
+  const effectiveThreshold = threshold
+    ?? (parseInt(process.env.VENTURE_CONFORMANCE_THRESHOLD, 10) || DEFAULT_THRESHOLD);
+
+  logger.log(`[conformance] Running conformance check on: ${ventureRepoPath} (threshold: ${effectiveThreshold})`);
+
+  const results = runConformanceCheck(ventureRepoPath);
+  const passing = results.filter(r => r.pass).length;
+  const failing = results.filter(r => !r.pass).length;
+  const total = results.length;
+  const score = total > 0 ? Math.round((passing / total) * 100) : 0;
+  const passed = score >= effectiveThreshold;
+
+  const failedChecks = results
+    .filter(r => !r.pass)
+    .map(r => ({ name: r.name, details: r.details }));
+
+  if (passed) {
+    logger.log(`[conformance] PASS: score ${score}/${effectiveThreshold} threshold (${passing}/${total} checks)`);
+  } else {
+    logger.warn(`[conformance] FAIL: score ${score} below threshold ${effectiveThreshold} (${failing} failed checks)`);
+    failedChecks.forEach(c => logger.warn(`  - ${c.name}: ${c.details}`));
+  }
+
+  return {
+    passed,
+    score,
+    threshold: effectiveThreshold,
+    total,
+    passing,
+    failing,
+    failedChecks,
+  };
+}
+
+/**
+ * Build metadata object for venture_provisioning_state update.
+ *
+ * @param {{ passed: boolean, score: number, threshold: number, failedChecks: Array }} conformanceResult
+ * @returns {Object} Metadata to merge into provisioning state
+ */
+export function buildConformanceMetadata(conformanceResult) {
+  return {
+    conformance_score: conformanceResult.score,
+    conformance_threshold: conformanceResult.threshold,
+    conformance_passed: conformanceResult.passed,
+    conformance_checks_total: conformanceResult.total,
+    conformance_checks_passing: conformanceResult.passing,
+    conformance_failed_checks: conformanceResult.failedChecks,
+    conformance_checked_at: new Date().toISOString(),
+  };
+}

--- a/scripts/venture-conformance-check.js
+++ b/scripts/venture-conformance-check.js
@@ -175,4 +175,10 @@ function main() {
   process.exit(failing > 0 ? 1 : 0);
 }
 
-main();
+// Export for programmatic use by venture-provisioner.js
+export { run as runConformanceCheck };
+
+// CLI entry point
+if (import.meta.url === `file://${process.argv[1]}` || import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`) {
+  main();
+}

--- a/tests/unit/bridge/conformance-integration.test.js
+++ b/tests/unit/bridge/conformance-integration.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { evaluateConformance, buildConformanceMetadata } from '../../../lib/eva/bridge/conformance-integration.js';
+
+// Mock the conformance check to avoid filesystem dependency
+vi.mock('../../../scripts/venture-conformance-check.js', () => ({
+  runConformanceCheck: vi.fn((path) => {
+    // Simulate 28 checks, configurable pass rate based on path
+    if (path.includes('perfect')) {
+      return Array.from({ length: 28 }, (_, i) => ({ name: `check-${i}`, pass: true, details: 'OK' }));
+    }
+    if (path.includes('failing')) {
+      // 15 pass, 13 fail = score ~54
+      return Array.from({ length: 28 }, (_, i) => ({
+        name: `check-${i}`,
+        pass: i < 15,
+        details: i < 15 ? 'OK' : 'FAIL'
+      }));
+    }
+    // Default: 24 pass, 4 fail = score ~86
+    return Array.from({ length: 28 }, (_, i) => ({
+      name: `check-${i}`,
+      pass: i < 24,
+      details: i < 24 ? 'OK' : 'FAIL'
+    }));
+  }),
+}));
+
+const silentLogger = { log: vi.fn(), warn: vi.fn() };
+
+describe('conformance-integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.VENTURE_CONFORMANCE_THRESHOLD;
+  });
+
+  describe('evaluateConformance', () => {
+    it('passes when score >= default threshold (80)', () => {
+      const result = evaluateConformance('/test/venture', { logger: silentLogger });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(86); // 24/28
+      expect(result.threshold).toBe(80);
+      expect(result.failing).toBe(4);
+    });
+
+    it('fails when score < default threshold', () => {
+      const result = evaluateConformance('/test/failing-venture', { logger: silentLogger });
+      expect(result.passed).toBe(false);
+      expect(result.score).toBe(54); // 15/28
+      expect(result.failedChecks).toHaveLength(13);
+    });
+
+    it('respects custom threshold via option', () => {
+      const result = evaluateConformance('/test/failing-venture', { threshold: 50, logger: silentLogger });
+      expect(result.passed).toBe(true); // 54 >= 50
+      expect(result.threshold).toBe(50);
+    });
+
+    it('respects VENTURE_CONFORMANCE_THRESHOLD env var', () => {
+      process.env.VENTURE_CONFORMANCE_THRESHOLD = '50';
+      const result = evaluateConformance('/test/failing-venture', { logger: silentLogger });
+      expect(result.passed).toBe(true); // 54 >= 50
+      expect(result.threshold).toBe(50);
+    });
+
+    it('option threshold takes precedence over env var', () => {
+      process.env.VENTURE_CONFORMANCE_THRESHOLD = '50';
+      const result = evaluateConformance('/test/failing-venture', { threshold: 60, logger: silentLogger });
+      expect(result.threshold).toBe(60);
+    });
+
+    it('handles perfect score', () => {
+      const result = evaluateConformance('/test/perfect-venture', { logger: silentLogger });
+      expect(result.passed).toBe(true);
+      expect(result.score).toBe(100);
+      expect(result.failing).toBe(0);
+      expect(result.failedChecks).toHaveLength(0);
+    });
+
+    it('returns failed check names and details', () => {
+      const result = evaluateConformance('/test/venture', { logger: silentLogger });
+      expect(result.failedChecks[0]).toEqual({ name: 'check-24', details: 'FAIL' });
+    });
+
+    it('logs warning on failure', () => {
+      evaluateConformance('/test/failing-venture', { logger: silentLogger });
+      expect(silentLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('FAIL')
+      );
+    });
+  });
+
+  describe('buildConformanceMetadata', () => {
+    it('builds metadata object from conformance result', () => {
+      const result = evaluateConformance('/test/venture', { logger: silentLogger });
+      const metadata = buildConformanceMetadata(result);
+
+      expect(metadata.conformance_score).toBe(86);
+      expect(metadata.conformance_threshold).toBe(80);
+      expect(metadata.conformance_passed).toBe(true);
+      expect(metadata.conformance_checks_total).toBe(28);
+      expect(metadata.conformance_checks_passing).toBe(24);
+      expect(metadata.conformance_failed_checks).toHaveLength(4);
+      expect(metadata.conformance_checked_at).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Export `runConformanceCheck` from `venture-conformance-check.js` for programmatic use
- Create `lib/eva/bridge/conformance-integration.js` with `evaluateConformance()` and `buildConformanceMetadata()`
- Configurable threshold via `VENTURE_CONFORMANCE_THRESHOLD` env var (default 80)
- 9 unit tests covering pass/fail scenarios, custom thresholds, env var override, and metadata building

## Context
Child SD-E of orchestrator SD-LEO-INFRA-VENTURE-LEO-BUILD-001 (Phase 2). Integrates the existing 28-check conformance suite into the venture provisioning pipeline so scaffolder issues are caught before ventures enter the Build Loop.

## Test plan
- [x] `npx vitest run tests/unit/bridge/conformance-integration.test.js` — 9/9 pass
- [x] Smoke tests pass (15/15)
- [ ] Verify existing venture-conformance-check CLI still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)