### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LEO-BUILD-001-I): add real data QA gate to Stage 20

### DIFF
--- a/lib/eva/__tests__/stage-20-build-quality.test.js
+++ b/lib/eva/__tests__/stage-20-build-quality.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateRealBuildData, PASS_RATE_THRESHOLD, COVERAGE_THRESHOLD } from '../stage-templates/analysis-steps/stage-20-build-execution.js';
+
+describe('evaluateRealBuildData', () => {
+  it('PASS: all thresholds met', () => {
+    const result = evaluateRealBuildData({
+      unit_tests: { numPassed: 100, numFailed: 0, numTotal: 100 },
+      e2e_tests: { numPassed: 20, numFailed: 0, numTotal: 20 },
+      coverage: { lines: 85 },
+    });
+    expect(result.gateResult).toBe('PASS');
+    expect(result.passRate).toBe(100);
+    expect(result.coveragePct).toBe(85);
+    expect(result.totalTests).toBe(120);
+    expect(result.gateReasons).toHaveLength(0);
+    expect(result.dataSource).toBe('build_feedback');
+  });
+
+  it('PASS: exactly at thresholds', () => {
+    // 95% pass rate = threshold, 60% coverage = threshold
+    const result = evaluateRealBuildData({
+      unit_tests: { numPassed: 95, numFailed: 5, numTotal: 100 },
+      coverage: { lines: 60 },
+    });
+    expect(result.gateResult).toBe('PASS');
+    expect(result.passRate).toBe(95);
+    expect(result.coveragePct).toBe(60);
+  });
+
+  it('FAIL: low pass rate', () => {
+    const result = evaluateRealBuildData({
+      unit_tests: { numPassed: 90, numFailed: 10, numTotal: 100 },
+      coverage: { lines: 80 },
+    });
+    expect(result.gateResult).toBe('FAIL');
+    expect(result.passRate).toBe(90);
+    expect(result.gateReasons).toHaveLength(1);
+    expect(result.gateReasons[0]).toContain('Pass rate');
+    expect(result.gateReasons[0]).toContain('90.0%');
+  });
+
+  it('FAIL: low coverage', () => {
+    const result = evaluateRealBuildData({
+      unit_tests: { numPassed: 100, numFailed: 0, numTotal: 100 },
+      coverage: { lines: 50 },
+    });
+    expect(result.gateResult).toBe('FAIL');
+    expect(result.coveragePct).toBe(50);
+    expect(result.gateReasons).toHaveLength(1);
+    expect(result.gateReasons[0]).toContain('Coverage');
+  });
+
+  it('FAIL: both thresholds missed', () => {
+    const result = evaluateRealBuildData({
+      unit_tests: { numPassed: 80, numFailed: 20, numTotal: 100 },
+      coverage: { lines: 30 },
+    });
+    expect(result.gateResult).toBe('FAIL');
+    expect(result.gateReasons).toHaveLength(2);
+  });
+
+  it('PASS: only unit tests (no e2e, no coverage)', () => {
+    const result = evaluateRealBuildData({
+      unit_tests: { numPassed: 50, numFailed: 0, numTotal: 50 },
+      e2e_tests: null,
+      coverage: null,
+    });
+    expect(result.gateResult).toBe('PASS');
+    expect(result.passRate).toBe(100);
+    expect(result.coveragePct).toBeNull();
+    expect(result.gateReasons).toHaveLength(0);
+  });
+
+  it('SKIP: no test or coverage data at all', () => {
+    const result = evaluateRealBuildData({
+      unit_tests: null,
+      e2e_tests: null,
+      coverage: null,
+    });
+    expect(result.gateResult).toBe('SKIP');
+    expect(result.passRate).toBeNull();
+    expect(result.coveragePct).toBeNull();
+    expect(result.gateReasons).toHaveLength(1);
+    expect(result.gateReasons[0]).toContain('No test or coverage data');
+  });
+
+  it('combines unit + e2e test counts', () => {
+    const result = evaluateRealBuildData({
+      unit_tests: { numPassed: 80, numFailed: 0, numTotal: 80 },
+      e2e_tests: { numPassed: 18, numFailed: 2, numTotal: 20 },
+      coverage: { lines: 70 },
+    });
+    expect(result.totalTests).toBe(100);
+    expect(result.totalPassed).toBe(98);
+    expect(result.passRate).toBe(98);
+  });
+
+  it('exports threshold constants', () => {
+    expect(PASS_RATE_THRESHOLD).toBe(0.95);
+    expect(COVERAGE_THRESHOLD).toBe(60);
+  });
+});

--- a/lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js
@@ -23,6 +23,10 @@ const ISSUE_SEVERITIES = ['critical', 'high', 'medium', 'low'];
 const ISSUE_STATUSES = ['open', 'investigating', 'resolved', 'deferred'];
 const COMPLETION_DECISIONS = ['complete', 'continue', 'blocked'];
 
+// QA Gate Thresholds (SD-LEO-INFRA-VENTURE-LEO-BUILD-001-I)
+export const PASS_RATE_THRESHOLD = 0.95;
+export const COVERAGE_THRESHOLD = 60;
+
 const SYSTEM_PROMPT = `You are EVA's Build Execution Analyst. Synthesize build progress from sprint items and generate a sprint completion assessment.
 
 You MUST output valid JSON with exactly this structure:
@@ -76,7 +80,37 @@ export async function analyzeStage20({ stage19Data, stage18Data, ventureName, su
     throw new Error('Stage 20 build execution requires Stage 19 (sprint planning) data');
   }
 
-  // Try real data from venture_stage_work (written by sd-completed.js handler)
+  // Step 1: Check for real CI/CD build feedback (from build-feedback-collector, SD-D/SD-H)
+  if (supabase && ventureId) {
+    try {
+      const buildQuality = await fetchBuildFeedback(supabase, ventureId, logger);
+      if (buildQuality) {
+        logger.log('[Stage20] Real build feedback found', {
+          passRate: buildQuality.passRate,
+          coveragePct: buildQuality.coveragePct,
+          gateResult: buildQuality.gateResult,
+        });
+        // Build feedback enriches real task data or LLM output (attached below)
+        // but first check if we also have real task data
+        const realData = await fetchRealBuildData(supabase, ventureId, logger);
+        if (realData) {
+          realData.buildQuality = buildQuality;
+          logger.log('[Stage20] Using real task data + build feedback', {
+            tasks: realData.tasks.length,
+            completion_pct: realData.completion_pct,
+          });
+          return realData;
+        }
+        // No task data but have build feedback — still valuable, attach to LLM result later
+        // Store for attachment after LLM synthesis below
+        stage19Data._buildQuality = buildQuality;
+      }
+    } catch (err) {
+      logger.warn('[Stage20] Build feedback query failed', { error: err.message });
+    }
+  }
+
+  // Step 2: Try real task data from venture_stage_work (written by sd-completed.js handler)
   if (supabase && ventureId) {
     try {
       const realData = await fetchRealBuildData(supabase, ventureId, logger);
@@ -211,7 +245,7 @@ Output ONLY valid JSON.`;
   }
 
   logger.log('[Stage20] Analysis complete', { duration: Date.now() - startTime });
-  return {
+  const result = {
     tasks,
     issues,
     sprintCompletion,
@@ -224,8 +258,97 @@ Output ONLY valid JSON.`;
     llmFallbackCount,
     fourBuckets, usage,
   };
+
+  // Attach build quality if fetched earlier (build feedback exists but no task data)
+  if (stage19Data._buildQuality) {
+    result.buildQuality = stage19Data._buildQuality;
+    delete stage19Data._buildQuality;
+  }
+
+  return result;
 }
 
+
+/**
+ * Evaluate real build feedback from advisory_data.build_feedback.
+ * Applies QA gate thresholds and returns structured quality assessment.
+ * SD-LEO-INFRA-VENTURE-LEO-BUILD-001-I
+ *
+ * @param {Object} buildFeedback - The build_feedback object from advisory_data
+ * @returns {{ passRate: number, coveragePct: number|null, gateResult: string, gateReasons: string[], thresholds: Object, dataSource: string }}
+ */
+export function evaluateRealBuildData(buildFeedback) {
+  const unitTests = buildFeedback.unit_tests;
+  const e2eTests = buildFeedback.e2e_tests;
+  const coverage = buildFeedback.coverage;
+
+  // Compute combined pass rate from unit + e2e tests
+  let totalPassed = 0, totalTests = 0;
+  if (unitTests) {
+    totalPassed += unitTests.numPassed || 0;
+    totalTests += unitTests.numTotal || 0;
+  }
+  if (e2eTests) {
+    totalPassed += e2eTests.numPassed || 0;
+    totalTests += e2eTests.numTotal || 0;
+  }
+
+  const passRate = totalTests > 0 ? totalPassed / totalTests : null;
+  const coveragePct = coverage?.lines ?? null;
+
+  // Apply thresholds
+  const gateReasons = [];
+  let gateResult = 'PASS';
+
+  if (passRate !== null && passRate < PASS_RATE_THRESHOLD) {
+    gateResult = 'FAIL';
+    gateReasons.push(`Pass rate ${(passRate * 100).toFixed(1)}% below ${PASS_RATE_THRESHOLD * 100}% threshold`);
+  }
+  if (coveragePct !== null && coveragePct < COVERAGE_THRESHOLD) {
+    gateResult = 'FAIL';
+    gateReasons.push(`Coverage ${coveragePct}% below ${COVERAGE_THRESHOLD}% threshold`);
+  }
+  if (passRate === null && coveragePct === null) {
+    gateResult = 'SKIP';
+    gateReasons.push('No test or coverage data available in build feedback');
+  }
+
+  return {
+    passRate: passRate !== null ? Math.round(passRate * 10000) / 100 : null,
+    coveragePct,
+    totalTests,
+    totalPassed,
+    gateResult,
+    gateReasons,
+    thresholds: { passRate: PASS_RATE_THRESHOLD, coverage: COVERAGE_THRESHOLD },
+    dataSource: 'build_feedback',
+  };
+}
+
+/**
+ * Fetch build feedback from venture_stage_work stage 20 advisory_data.
+ * Written by build-feedback-collector.js (SD-D) or github-artifact-fetcher.js (SD-H).
+ * Returns null if no build feedback exists.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} logger
+ * @returns {Promise<Object|null>} Build quality evaluation or null
+ */
+async function fetchBuildFeedback(supabase, ventureId, logger) {
+  const { data, error } = await supabase
+    .from('venture_stage_work')
+    .select('advisory_data')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', 20)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data?.advisory_data?.build_feedback) return null;
+
+  logger.log('[Stage20] Found build_feedback in advisory_data');
+  return evaluateRealBuildData(data.advisory_data.build_feedback);
+}
 
 /**
  * Fetch real build data from venture_stage_work (written by sd-completed.js).


### PR DESCRIPTION
## Summary
- Modify `stage-20-build-execution.js` to prefer real CI/CD results from `advisory_data.build_feedback` over LLM synthesis
- Add `evaluateRealBuildData()` with configurable thresholds: 95% pass rate, 60% coverage
- Enriches Stage 20 output with `buildQuality` object containing metrics, gate result, and reasons
- Full backward compatibility: falls back to LLM synthesis when no real data available

## Test plan
- [x] 9/9 unit tests passing (Vitest)
- [x] PASS: all thresholds met (100% pass rate, 85% coverage)
- [x] PASS: exactly at threshold boundaries
- [x] FAIL: low pass rate (90% < 95% threshold)
- [x] FAIL: low coverage (50% < 60% threshold)
- [x] FAIL: both thresholds missed
- [x] PASS: only unit tests (no e2e/coverage)
- [x] SKIP: no test data at all
- [x] Combined unit + e2e test counts
- [x] Threshold constants exported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)