### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LEO-BUILD-001-M): add venture health monitor

### DIFF
--- a/lib/eva/__tests__/venture-health-monitor.test.js
+++ b/lib/eva/__tests__/venture-health-monitor.test.js
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkVentureHealth, monitorVenture, buildHistoryEntry, resetAllStates } from '../bridge/venture-health-monitor.js';
+import { processHealthResult, getVentureState, CONSECUTIVE_FAILURE_THRESHOLD } from '../bridge/health-alert-manager.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  resetAllStates();
+});
+
+describe('checkVentureHealth', () => {
+  it('returns healthy for 200 response', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200, statusText: 'OK' });
+    const result = await checkVentureHealth('https://app.example.com');
+    expect(result.healthy).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.responseTime).toBeGreaterThanOrEqual(0);
+    expect(result.error).toBeNull();
+  });
+
+  it('returns unhealthy for 500 response', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 500, statusText: 'Internal Server Error' });
+    const result = await checkVentureHealth('https://app.example.com');
+    expect(result.healthy).toBe(false);
+    expect(result.statusCode).toBe(500);
+    expect(result.error).toContain('500');
+  });
+
+  it('returns unhealthy on timeout', async () => {
+    mockFetch.mockImplementationOnce(() => new Promise((_, reject) => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      setTimeout(() => reject(err), 10);
+    }));
+    const result = await checkVentureHealth('https://app.example.com', 5);
+    expect(result.healthy).toBe(false);
+    expect(result.statusCode).toBeNull();
+    expect(result.error).toContain('Timeout');
+  });
+
+  it('returns unhealthy on network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+    const result = await checkVentureHealth('https://app.example.com');
+    expect(result.healthy).toBe(false);
+    expect(result.error).toContain('ECONNREFUSED');
+  });
+
+  it('treats 301 redirect as healthy', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 301, statusText: 'Moved' });
+    const result = await checkVentureHealth('https://app.example.com');
+    expect(result.healthy).toBe(true);
+  });
+});
+
+describe('processHealthResult (alert state machine)', () => {
+  it('no alert on first healthy check', () => {
+    const result = processHealthResult('v1', true);
+    expect(result.alert).toBeNull();
+    expect(result.createSD).toBe(false);
+  });
+
+  it('alerts on first failure (state transition)', () => {
+    processHealthResult('v2', true); // establish healthy
+    const result = processHealthResult('v2', false);
+    expect(result.alert).toBe('failure');
+    expect(result.stateTransition).toContain('unhealthy');
+  });
+
+  it('does NOT alert on repeated failures (deduplication)', () => {
+    processHealthResult('v3', true);
+    processHealthResult('v3', false); // first failure -> alert
+    const result = processHealthResult('v3', false); // second failure -> no alert
+    expect(result.alert).toBeNull();
+    expect(result.consecutiveFailures).toBe(2);
+  });
+
+  it('alerts on recovery', () => {
+    processHealthResult('v4', true);
+    processHealthResult('v4', false); // go unhealthy
+    const result = processHealthResult('v4', true); // recover
+    expect(result.alert).toBe('recovery');
+    expect(result.stateTransition).toBe('unhealthy -> healthy');
+  });
+
+  it('creates SD after 3 consecutive failures', () => {
+    processHealthResult('v5', true);
+    processHealthResult('v5', false); // 1
+    processHealthResult('v5', false); // 2
+    const result = processHealthResult('v5', false); // 3
+    expect(result.createSD).toBe(true);
+    expect(result.consecutiveFailures).toBe(3);
+  });
+
+  it('does NOT create duplicate SDs', () => {
+    processHealthResult('v6', true);
+    processHealthResult('v6', false); // 1
+    processHealthResult('v6', false); // 2
+    processHealthResult('v6', false); // 3 -> createSD=true
+    const result = processHealthResult('v6', false); // 4 -> createSD=false
+    expect(result.createSD).toBe(false);
+  });
+
+  it('resets consecutive failures on recovery', () => {
+    processHealthResult('v7', false);
+    processHealthResult('v7', false);
+    processHealthResult('v7', true); // recover
+    const state = getVentureState('v7');
+    expect(state.consecutiveFailures).toBe(0);
+  });
+
+  it('exports CONSECUTIVE_FAILURE_THRESHOLD', () => {
+    expect(CONSECUTIVE_FAILURE_THRESHOLD).toBe(3);
+  });
+});
+
+describe('monitorVenture', () => {
+  it('calls onAlert callback on failure', async () => {
+    mockFetch.mockResolvedValueOnce({ status: 200, statusText: 'OK' });
+    await monitorVenture('v-cb1', 'https://ok.example.com'); // establish healthy
+
+    mockFetch.mockResolvedValueOnce({ status: 500, statusText: 'Error' });
+    const onAlert = vi.fn();
+    await monitorVenture('v-cb1', 'https://ok.example.com', { onAlert });
+    expect(onAlert).toHaveBeenCalledOnce();
+    expect(onAlert.mock.calls[0][1]).toBe('failure');
+  });
+
+  it('calls onCreateSD after threshold', async () => {
+    mockFetch.mockResolvedValue({ status: 500, statusText: 'Error' });
+    const onCreateSD = vi.fn();
+    // Need initial healthy state
+    mockFetch.mockResolvedValueOnce({ status: 200, statusText: 'OK' });
+    await monitorVenture('v-cb2', 'https://down.example.com');
+    mockFetch.mockResolvedValue({ status: 500, statusText: 'Error' });
+    await monitorVenture('v-cb2', 'https://down.example.com', { onCreateSD });
+    await monitorVenture('v-cb2', 'https://down.example.com', { onCreateSD });
+    await monitorVenture('v-cb2', 'https://down.example.com', { onCreateSD });
+    expect(onCreateSD).toHaveBeenCalledOnce();
+  });
+});
+
+describe('buildHistoryEntry', () => {
+  it('creates structured history entry', () => {
+    const entry = buildHistoryEntry(
+      { healthy: true, statusCode: 200, responseTime: 150, error: null },
+      { alert: null, consecutiveFailures: 0 }
+    );
+    expect(entry.timestamp).toBeTruthy();
+    expect(entry.healthy).toBe(true);
+    expect(entry.statusCode).toBe(200);
+    expect(entry.responseTime).toBe(150);
+    expect(entry.alert).toBeNull();
+  });
+});

--- a/lib/eva/bridge/health-alert-manager.js
+++ b/lib/eva/bridge/health-alert-manager.js
@@ -1,0 +1,95 @@
+/**
+ * Health Alert Manager
+ * SD-LEO-INFRA-VENTURE-LEO-BUILD-001-M
+ *
+ * Tracks health state per venture and implements exception-only alerting.
+ * Alerts on state transitions (healthy->unhealthy, unhealthy->healthy).
+ * Auto-creates maintenance SDs after consecutive failure threshold.
+ */
+
+const CONSECUTIVE_FAILURE_THRESHOLD = 3;
+
+/**
+ * In-memory state tracking per venture.
+ * @type {Map<string, { lastState: string, consecutiveFailures: number, alertedForCurrentIssue: boolean, sdCreated: boolean }>}
+ */
+const ventureStates = new Map();
+
+/**
+ * Get or initialize state for a venture.
+ * @param {string} ventureId
+ * @returns {object}
+ */
+export function getVentureState(ventureId) {
+  if (!ventureStates.has(ventureId)) {
+    ventureStates.set(ventureId, {
+      lastState: 'unknown',
+      consecutiveFailures: 0,
+      alertedForCurrentIssue: false,
+      sdCreated: false,
+    });
+  }
+  return ventureStates.get(ventureId);
+}
+
+/**
+ * Process a health check result and determine if alerts should fire.
+ * Returns alert actions to take (if any).
+ *
+ * @param {string} ventureId
+ * @param {boolean} healthy - Current health check result
+ * @param {object} [checkResult] - Full check result for context
+ * @returns {{ alert: 'failure'|'recovery'|null, createSD: boolean, consecutiveFailures: number, stateTransition: string|null }}
+ */
+export function processHealthResult(ventureId, healthy, checkResult = {}) {
+  const state = getVentureState(ventureId);
+  const previousState = state.lastState;
+  const currentState = healthy ? 'healthy' : 'unhealthy';
+
+  const result = {
+    alert: null,
+    createSD: false,
+    consecutiveFailures: 0,
+    stateTransition: null,
+  };
+
+  if (healthy) {
+    // Recovery
+    if (previousState === 'unhealthy') {
+      result.alert = 'recovery';
+      result.stateTransition = 'unhealthy -> healthy';
+    }
+    state.consecutiveFailures = 0;
+    state.alertedForCurrentIssue = false;
+    state.sdCreated = false;
+  } else {
+    // Failure
+    state.consecutiveFailures++;
+    result.consecutiveFailures = state.consecutiveFailures;
+
+    // Alert only on first failure (state transition)
+    if (previousState !== 'unhealthy' && !state.alertedForCurrentIssue) {
+      result.alert = 'failure';
+      result.stateTransition = `${previousState} -> unhealthy`;
+      state.alertedForCurrentIssue = true;
+    }
+
+    // Auto-create SD after threshold
+    if (state.consecutiveFailures >= CONSECUTIVE_FAILURE_THRESHOLD && !state.sdCreated) {
+      result.createSD = true;
+      state.sdCreated = true;
+    }
+  }
+
+  state.lastState = currentState;
+  return result;
+}
+
+/**
+ * Reset all venture states (for testing).
+ */
+export function resetAllStates() {
+  ventureStates.clear();
+}
+
+export { CONSECUTIVE_FAILURE_THRESHOLD };

--- a/lib/eva/bridge/venture-health-monitor.js
+++ b/lib/eva/bridge/venture-health-monitor.js
@@ -1,0 +1,154 @@
+/**
+ * Venture Health Monitor
+ * SD-LEO-INFRA-VENTURE-LEO-BUILD-001-M
+ *
+ * Automated HTTP health checks for deployed ventures.
+ * Exception-only alerts. Maintenance SDs auto-created for critical issues.
+ */
+
+import { processHealthResult, resetAllStates } from './health-alert-manager.js';
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const MAX_HISTORY_ENTRIES = 50;
+
+/**
+ * Execute an HTTP health check against a URL.
+ *
+ * @param {string} url - The URL to check
+ * @param {number} [timeoutMs=10000] - Request timeout in milliseconds
+ * @returns {Promise<{ healthy: boolean, statusCode: number|null, responseTime: number, error: string|null }>}
+ */
+export async function checkVentureHealth(url, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  const startTime = Date.now();
+
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    const response = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+      redirect: 'follow',
+    });
+
+    clearTimeout(timer);
+    const responseTime = Date.now() - startTime;
+    const healthy = response.status >= 200 && response.status < 400;
+
+    return {
+      healthy,
+      statusCode: response.status,
+      responseTime,
+      error: healthy ? null : `HTTP ${response.status} ${response.statusText}`,
+    };
+  } catch (err) {
+    const responseTime = Date.now() - startTime;
+    const isTimeout = err.name === 'AbortError';
+
+    return {
+      healthy: false,
+      statusCode: null,
+      responseTime,
+      error: isTimeout ? `Timeout after ${timeoutMs}ms` : err.message,
+    };
+  }
+}
+
+/**
+ * Run a health check for a single venture and process the result.
+ * Returns the check result with alert actions.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {string} url - Venture application URL
+ * @param {object} [options]
+ * @param {number} [options.timeoutMs] - Request timeout
+ * @param {function} [options.onAlert] - Callback for alerts: (ventureId, alertType, context) => void
+ * @param {function} [options.onCreateSD] - Callback for SD creation: (ventureId, context) => void
+ * @returns {Promise<{ checkResult: object, alertAction: object }>}
+ */
+export async function monitorVenture(ventureId, url, options = {}) {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, onAlert, onCreateSD } = options;
+
+  const checkResult = await checkVentureHealth(url, timeoutMs);
+  const alertAction = processHealthResult(ventureId, checkResult.healthy, checkResult);
+
+  // Fire callbacks if actions needed
+  if (alertAction.alert && onAlert) {
+    onAlert(ventureId, alertAction.alert, { checkResult, alertAction });
+  }
+  if (alertAction.createSD && onCreateSD) {
+    onCreateSD(ventureId, { checkResult, alertAction });
+  }
+
+  return { checkResult, alertAction };
+}
+
+/**
+ * Build a health history entry from a check result.
+ *
+ * @param {object} checkResult - From checkVentureHealth
+ * @param {object} alertAction - From processHealthResult
+ * @returns {object} History entry for advisory_data.health_history
+ */
+export function buildHistoryEntry(checkResult, alertAction) {
+  return {
+    timestamp: new Date().toISOString(),
+    healthy: checkResult.healthy,
+    statusCode: checkResult.statusCode,
+    responseTime: checkResult.responseTime,
+    error: checkResult.error,
+    alert: alertAction.alert,
+    consecutiveFailures: alertAction.consecutiveFailures,
+  };
+}
+
+/**
+ * Append a health history entry to venture_stage_work advisory_data.
+ * Maintains a rolling window of MAX_HISTORY_ENTRIES.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {string} ventureId - Venture UUID
+ * @param {number} lifecycleStage - Stage number (typically 22+)
+ * @param {object} entry - History entry from buildHistoryEntry
+ * @returns {Promise<{ success: boolean, error: string|null }>}
+ */
+export async function appendHealthHistory(supabase, ventureId, lifecycleStage, entry) {
+  try {
+    const { data: existing } = await supabase
+      .from('venture_stage_work')
+      .select('advisory_data')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', lifecycleStage)
+      .maybeSingle();
+
+    const currentAdvisory = existing?.advisory_data || {};
+    const history = Array.isArray(currentAdvisory.health_history)
+      ? currentAdvisory.health_history
+      : [];
+
+    history.push(entry);
+
+    // Rolling window
+    while (history.length > MAX_HISTORY_ENTRIES) {
+      history.shift();
+    }
+
+    const updatedAdvisory = { ...currentAdvisory, health_history: history };
+
+    if (existing) {
+      const { error } = await supabase
+        .from('venture_stage_work')
+        .update({ advisory_data: updatedAdvisory })
+        .eq('venture_id', ventureId)
+        .eq('lifecycle_stage', lifecycleStage);
+      if (error) return { success: false, error: error.message };
+    }
+    // If no row exists, skip (row must be created by stage execution)
+
+    return { success: true, error: null };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}
+
+export { resetAllStates, DEFAULT_TIMEOUT_MS, MAX_HISTORY_ENTRIES };


### PR DESCRIPTION
## Summary
- Create `lib/eva/bridge/venture-health-monitor.js` (~120 LOC) for HTTP health checks with configurable timeout
- Create `lib/eva/bridge/health-alert-manager.js` (~80 LOC) with exception-only alerting state machine
- Alerts only on state transitions (healthy->unhealthy, recovery) — no noise on repeated failures
- Auto-creates maintenance SD after 3 consecutive failures
- Health history tracking for advisory_data consumption

## Test plan
- [x] 16/16 unit tests passing (Vitest)
- [x] Health check: 200 OK, 500 error, timeout, network error, redirect
- [x] Alert dedup: repeated failures produce only one alert
- [x] Recovery alert fires on unhealthy->healthy transition
- [x] SD auto-creation after 3 consecutive failures
- [x] No duplicate SD creation on continued failures
- [x] Consecutive failure count resets on recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)