### PR TITLE
feat(SD-LEO-INFRA-VENTURE-LEO-BUILD-001-N): add per-venture cost tracker

### DIFF
--- a/lib/eva/__tests__/cost-tracker.test.js
+++ b/lib/eva/__tests__/cost-tracker.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  registerCollector, removeCollector, clearCollectors, getCollectorNames,
+  trackVentureCosts, DEFAULT_BUDGET,
+} from '../bridge/cost-tracker.js';
+
+beforeEach(() => {
+  clearCollectors();
+});
+
+describe('collector registry', () => {
+  it('registers and lists collectors', () => {
+    registerCollector('test', async () => ({ cost: 0, currency: 'USD', source: 'test' }));
+    expect(getCollectorNames()).toEqual(['test']);
+  });
+
+  it('removes a collector', () => {
+    registerCollector('a', async () => ({ cost: 0, currency: 'USD', source: 'a' }));
+    registerCollector('b', async () => ({ cost: 0, currency: 'USD', source: 'b' }));
+    removeCollector('a');
+    expect(getCollectorNames()).toEqual(['b']);
+  });
+
+  it('clearCollectors empties registry', () => {
+    registerCollector('x', async () => ({ cost: 0, currency: 'USD', source: 'x' }));
+    clearCollectors();
+    expect(getCollectorNames()).toHaveLength(0);
+  });
+});
+
+describe('trackVentureCosts', () => {
+  it('returns zero cost with no collectors', async () => {
+    const result = await trackVentureCosts('venture-1');
+    expect(result.totalCost).toBe(0);
+    expect(result.overBudget).toBe(false);
+    expect(result.breakdown).toEqual({});
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('aggregates costs from multiple collectors', async () => {
+    registerCollector('infra', async () => ({ cost: 100, currency: 'USD', source: 'infra' }));
+    registerCollector('compute', async () => ({ cost: 50.50, currency: 'USD', source: 'compute' }));
+    registerCollector('tokens', async () => ({ cost: 25.25, currency: 'USD', source: 'tokens' }));
+
+    const result = await trackVentureCosts('venture-2');
+    expect(result.totalCost).toBe(175.75);
+    expect(result.breakdown.infra.cost).toBe(100);
+    expect(result.breakdown.compute.cost).toBe(50.50);
+    expect(result.breakdown.tokens.cost).toBe(25.25);
+  });
+
+  it('detects over-budget condition', async () => {
+    registerCollector('expensive', async () => ({ cost: 600, currency: 'USD', source: 'expensive' }));
+
+    const result = await trackVentureCosts('venture-3', { budget: 500 });
+    expect(result.overBudget).toBe(true);
+    expect(result.amountOver).toBe(100);
+    expect(result.alerts).toHaveLength(1);
+    expect(result.alerts[0]).toContain('600');
+    expect(result.alerts[0]).toContain('500');
+  });
+
+  it('uses DEFAULT_BUDGET when not specified', async () => {
+    registerCollector('cheap', async () => ({ cost: 10, currency: 'USD', source: 'cheap' }));
+    const result = await trackVentureCosts('venture-4');
+    expect(result.overBudget).toBe(false);
+    expect(DEFAULT_BUDGET).toBe(500);
+  });
+
+  it('handles collector errors gracefully', async () => {
+    registerCollector('good', async () => ({ cost: 50, currency: 'USD', source: 'good' }));
+    registerCollector('broken', async () => { throw new Error('API down'); });
+
+    const result = await trackVentureCosts('venture-5');
+    expect(result.totalCost).toBe(50);
+    expect(result.breakdown.good.cost).toBe(50);
+    expect(result.breakdown.broken.error).toBe('API down');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('broken');
+  });
+
+  it('includes period in output', async () => {
+    const result = await trackVentureCosts('venture-6', { period: '2026-03' });
+    expect(result.period).toBe('2026-03');
+  });
+
+  it('auto-generates period when not specified', async () => {
+    const result = await trackVentureCosts('venture-7');
+    expect(result.period).toMatch(/^\d{4}-\d{2}$/);
+  });
+
+  it('rounds totalCost to 2 decimal places', async () => {
+    registerCollector('a', async () => ({ cost: 10.111, currency: 'USD', source: 'a' }));
+    registerCollector('b', async () => ({ cost: 20.222, currency: 'USD', source: 'b' }));
+    const result = await trackVentureCosts('venture-8');
+    expect(result.totalCost).toBe(30.33);
+  });
+
+  it('not over budget when exactly at budget', async () => {
+    registerCollector('exact', async () => ({ cost: 500, currency: 'USD', source: 'exact' }));
+    const result = await trackVentureCosts('venture-9', { budget: 500 });
+    expect(result.overBudget).toBe(false);
+    expect(result.amountOver).toBe(0);
+  });
+});
+
+describe('stub collectors', () => {
+  it('default stubs return valid structure', async () => {
+    // Re-register default stubs (cleared in beforeEach)
+    const { default: mod } = await import('../bridge/cost-tracker.js');
+    // Module-level registrations already happened, but clearCollectors removed them
+    // Register manually for test
+    registerCollector('supabase_compute', async () => ({ cost: 0, currency: 'USD', source: 'supabase_compute' }));
+    registerCollector('vercel_bandwidth', async () => ({ cost: 0, currency: 'USD', source: 'vercel_bandwidth' }));
+    registerCollector('llm_tokens', async () => ({ cost: 0, currency: 'USD', source: 'llm_tokens' }));
+
+    const result = await trackVentureCosts('venture-stub');
+    expect(result.totalCost).toBe(0);
+    expect(Object.keys(result.breakdown)).toHaveLength(3);
+    for (const [name, entry] of Object.entries(result.breakdown)) {
+      expect(entry.cost).toBe(0);
+      expect(entry.currency).toBe('USD');
+    }
+  });
+});

--- a/lib/eva/bridge/cost-tracker.js
+++ b/lib/eva/bridge/cost-tracker.js
@@ -1,0 +1,161 @@
+/**
+ * Per-Venture Cost Tracker
+ * SD-LEO-INFRA-VENTURE-LEO-BUILD-001-N
+ *
+ * Pluggable cost collector pattern for per-venture infrastructure cost
+ * aggregation. Stub collectors for Supabase/Vercel/LLM costs.
+ * Budget threshold alerting.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const DEFAULT_BUDGET = 500; // $500/month per venture
+
+/**
+ * Registry of cost collectors.
+ * Each collector: async (ventureId, period) => { cost: number, currency: string, source: string, details?: object }
+ * @type {Map<string, function>}
+ */
+const collectors = new Map();
+
+/**
+ * Register a cost collector.
+ * @param {string} name - Unique collector name
+ * @param {function} fn - Async collector function (ventureId, period) => { cost, currency, source }
+ */
+export function registerCollector(name, fn) {
+  collectors.set(name, fn);
+}
+
+/**
+ * Remove a collector.
+ * @param {string} name
+ */
+export function removeCollector(name) {
+  collectors.delete(name);
+}
+
+/**
+ * Clear all collectors (for testing).
+ */
+export function clearCollectors() {
+  collectors.clear();
+}
+
+/**
+ * Get registered collector names.
+ * @returns {string[]}
+ */
+export function getCollectorNames() {
+  return Array.from(collectors.keys());
+}
+
+// --- Stub Collectors ---
+
+/** Stub: Supabase compute costs (returns $0 until real API wired) */
+async function supabaseComputeCollector(ventureId, _period) {
+  return { cost: 0, currency: 'USD', source: 'supabase_compute', details: { note: 'Stub — shared Supabase, no per-venture billing yet' } };
+}
+
+/** Stub: Vercel bandwidth costs (returns $0 until real API wired) */
+async function vercelBandwidthCollector(ventureId, _period) {
+  return { cost: 0, currency: 'USD', source: 'vercel_bandwidth', details: { note: 'Stub — Vercel billing API not yet integrated' } };
+}
+
+/** Stub: LLM token costs (returns $0 until real tracking wired) */
+async function llmTokenCollector(ventureId, _period) {
+  return { cost: 0, currency: 'USD', source: 'llm_tokens', details: { note: 'Stub — LLM token tracking not yet per-venture' } };
+}
+
+// Register default stubs
+registerCollector('supabase_compute', supabaseComputeCollector);
+registerCollector('vercel_bandwidth', vercelBandwidthCollector);
+registerCollector('llm_tokens', llmTokenCollector);
+
+// --- Aggregation ---
+
+/**
+ * Track costs for a venture by invoking all registered collectors.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {object} [options]
+ * @param {string} [options.period] - Billing period (default: current month YYYY-MM)
+ * @param {number} [options.budget] - Budget threshold (default: DEFAULT_BUDGET)
+ * @returns {Promise<{ totalCost: number, breakdown: object, period: string, overBudget: boolean, amountOver: number, alerts: string[], warnings: string[] }>}
+ */
+export async function trackVentureCosts(ventureId, options = {}) {
+  const now = new Date();
+  const period = options.period || `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const budget = options.budget ?? DEFAULT_BUDGET;
+  const breakdown = {};
+  const warnings = [];
+  let totalCost = 0;
+
+  for (const [name, collector] of collectors) {
+    try {
+      const result = await collector(ventureId, period);
+      const cost = typeof result.cost === 'number' ? result.cost : 0;
+      breakdown[name] = { cost, currency: result.currency || 'USD', details: result.details || null };
+      totalCost += cost;
+    } catch (err) {
+      warnings.push(`Collector "${name}" failed: ${err.message}`);
+      breakdown[name] = { cost: 0, currency: 'USD', error: err.message };
+    }
+  }
+
+  totalCost = Math.round(totalCost * 100) / 100;
+  const overBudget = totalCost > budget;
+  const amountOver = overBudget ? Math.round((totalCost - budget) * 100) / 100 : 0;
+  const alerts = [];
+
+  if (overBudget) {
+    alerts.push(`Venture ${ventureId} cost $${totalCost} exceeds $${budget} budget by $${amountOver}`);
+  }
+
+  return { totalCost, breakdown, period, overBudget, amountOver, alerts, warnings };
+}
+
+/**
+ * Write cost tracking data to venture_stage_work advisory_data.
+ *
+ * @param {object} supabase - Supabase client
+ * @param {string} ventureId
+ * @param {number} lifecycleStage - Stage number
+ * @param {object} costData - From trackVentureCosts
+ * @returns {Promise<{ success: boolean, error: string|null }>}
+ */
+export async function writeCostToAdvisoryData(supabase, ventureId, lifecycleStage, costData) {
+  try {
+    const { data: existing } = await supabase
+      .from('venture_stage_work')
+      .select('advisory_data')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', lifecycleStage)
+      .maybeSingle();
+
+    const currentAdvisory = existing?.advisory_data || {};
+    const updatedAdvisory = {
+      ...currentAdvisory,
+      cost_tracking: {
+        ...costData,
+        tracked_at: new Date().toISOString(),
+      },
+    };
+
+    if (existing) {
+      const { error } = await supabase
+        .from('venture_stage_work')
+        .update({ advisory_data: updatedAdvisory })
+        .eq('venture_id', ventureId)
+        .eq('lifecycle_stage', lifecycleStage);
+      if (error) return { success: false, error: error.message };
+    }
+
+    return { success: true, error: null };
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
+}


### PR DESCRIPTION
## Summary
- Create `lib/eva/bridge/cost-tracker.js` (~120 LOC) with pluggable cost collector registry
- Stub collectors for Supabase compute, Vercel bandwidth, LLM tokens (real APIs wired later)
- Budget threshold alerting at $500/month default
- Advisory data storage for Chairman dashboard consumption

## Test plan
- [x] 13/13 unit tests passing
- [x] Registry: register, remove, clear collectors
- [x] Aggregation: sums costs across multiple collectors correctly
- [x] Over budget: detects and reports amount over threshold
- [x] Error handling: collector failures produce warnings, partial results
- [x] Rounding: totalCost rounded to 2 decimal places
- [x] Period: auto-generated or user-specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)