### PR TITLE
fix(SD-LEO-FIX-EVA-GATE-GOVERNANCE-001): respect _gateApproved flag at line 895

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -892,11 +892,15 @@ export class StageExecutionWorker {
           break;
         }
 
-        if (resultStatus === 'BLOCKED') {
+        if (resultStatus === 'BLOCKED' && !result._gateApproved) {
           this._logger.log(`[Worker] Stage ${currentStage} blocked for ${ventureId}`);
           this._logStageTransition(ventureId, currentStage, 'blocked', stageDurationMs, result).catch(() => {});
           releaseState = ORCHESTRATOR_STATES.BLOCKED;
           break;
+        }
+        if (resultStatus === 'BLOCKED' && result._gateApproved) {
+          this._logger.log(`[Worker] Stage ${currentStage} BLOCKED by EVA but governance auto-approved — advancing as advisory`);
+          this._recordAdvisoryWarning(ventureId, currentStage, result).catch(() => {});
         }
 
         // Log successful stage transition
@@ -1624,6 +1628,45 @@ export class StageExecutionWorker {
     } catch (err) {
       this._logger.warn(`[Worker] _shouldAutoApproveStage threw: ${err.message}`);
       return false;
+    }
+  }
+
+  /**
+   * Record an advisory warning when a gate was auto-overridden by governance config.
+   * Writes to venture_stage_work.advisory_data.gate_overrides array.
+   */
+  async _recordAdvisoryWarning(ventureId, stageNumber, result) {
+    try {
+      const { data: existing } = await this._supabase
+        .from('venture_stage_work')
+        .select('advisory_data')
+        .eq('venture_id', ventureId)
+        .eq('stage_number', stageNumber)
+        .maybeSingle();
+
+      const advisory = existing?.advisory_data || {};
+      const overrides = advisory.gate_overrides || [];
+      overrides.push({
+        stage: stageNumber,
+        original_status: result?.status || 'BLOCKED',
+        override_reason: 'governance_auto_proceed',
+        gate_type: result?.gate || 'unknown',
+        timestamp: new Date().toISOString(),
+      });
+      advisory.gate_overrides = overrides;
+
+      await this._supabase
+        .from('venture_stage_work')
+        .upsert({
+          venture_id: ventureId,
+          stage_number: stageNumber,
+          advisory_data: advisory,
+          updated_at: new Date().toISOString(),
+        }, { onConflict: 'venture_id,stage_number' });
+
+      this._logger.log(`[Worker] Advisory warning recorded for stage ${stageNumber} gate override`);
+    } catch (err) {
+      this._logger.warn(`[Worker] Failed to record advisory warning: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Line 895 in stage-execution-worker.js re-blocked ventures AFTER line 882 already set `result._gateApproved=true` from governance auto-approval
- Fix: Add `&& !result._gateApproved` to the BLOCKED check condition
- Add `_recordAdvisoryWarning()` helper to persist gate override events in `venture_stage_work.advisory_data`

## Test plan
- [x] 14/14 existing unit tests pass (2 pre-existing failures unrelated)
- [x] Fix is backward-compatible: `_gateApproved` defaults to undefined, preserving existing blocking behavior
- [ ] BrandKit Generator advances past Stage 16 with `global_auto_proceed=true`
- [ ] Stage 19 (in `hard_gate_stages`) still blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)