### PR TITLE
fix: governance override for ALL BLOCKED stages (v2)

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -892,15 +892,36 @@ export class StageExecutionWorker {
           break;
         }
 
-        if (resultStatus === 'BLOCKED' && !result._gateApproved) {
-          this._logger.log(`[Worker] Stage ${currentStage} blocked for ${ventureId}`);
-          this._logStageTransition(ventureId, currentStage, 'blocked', stageDurationMs, result).catch(() => {});
-          releaseState = ORCHESTRATOR_STATES.BLOCKED;
-          break;
-        }
-        if (resultStatus === 'BLOCKED' && result._gateApproved) {
-          this._logger.log(`[Worker] Stage ${currentStage} BLOCKED by EVA but governance auto-approved — advancing as advisory`);
-          this._recordAdvisoryWarning(ventureId, currentStage, result).catch(() => {});
+        if (resultStatus === 'BLOCKED') {
+          // Check governance config: if auto-proceed is enabled and this stage
+          // is NOT a hard gate, override the BLOCKED status and advance.
+          // This handles both: (1) stages in CHAIRMAN_GATES.BLOCKING that were
+          // auto-approved via _handleChairmanGate (result._gateApproved=true),
+          // and (2) stages NOT in BLOCKING that get BLOCKED by EVA's internal
+          // gate evaluations (e.g., Stage 16 promotion gate).
+          const governanceOverride = result._gateApproved || await this._shouldAutoApproveStage(currentStage);
+          if (governanceOverride) {
+            this._logger.log(`[Worker] Stage ${currentStage} BLOCKED by EVA but governance auto-approves — advancing as advisory`);
+            this._recordAdvisoryWarning(ventureId, currentStage, result).catch(() => {});
+            // Force advance since EVA didn't set nextStageId (it returned BLOCKED)
+            const nextOverrideStage = currentStage + 1;
+            await this._supabase.from('ventures')
+              .update({ current_lifecycle_stage: nextOverrideStage })
+              .eq('id', ventureId);
+            await this._supabase.from('venture_stage_work')
+              .update({ stage_status: 'completed', completed_at: new Date().toISOString() })
+              .eq('venture_id', ventureId)
+              .eq('stage_number', currentStage);
+            this._logger.log(`[Worker] Governance override: advanced S${currentStage} → S${nextOverrideStage}`);
+            this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
+            currentStage = nextOverrideStage;
+            continue;
+          } else {
+            this._logger.log(`[Worker] Stage ${currentStage} blocked for ${ventureId}`);
+            this._logStageTransition(ventureId, currentStage, 'blocked', stageDurationMs, result).catch(() => {});
+            releaseState = ORCHESTRATOR_STATES.BLOCKED;
+            break;
+          }
         }
 
         // Log successful stage transition
@@ -1015,7 +1036,8 @@ export class StageExecutionWorker {
         const provisionerPath = new URL('./venture-provisioner.js', import.meta.url);
         const { provisionVenture } = await import(provisionerPath.href);
         if (typeof provisionVenture === 'function') {
-          await provisionVenture(ventureName, { supabase: this._supabase, logger: this._logger });
+          const repoPath = provState?.github_repo_url || null;
+          await provisionVenture(ventureName, { supabase: this._supabase, logger: this._logger, ventureRepoPath: repoPath });
           this._logger.log(`[Worker] Stage 18: Auto-provisioned venture "${ventureName}"`);
         } else {
           this._logger.warn('[Worker] Stage 18: provisionVenture not exported — skipping auto-provision');


### PR DESCRIPTION
## Summary
- First fix (PR #2491) only handled stages in CHAIRMAN_GATES.BLOCKING via _gateApproved flag
- Stage 16 is NOT in BLOCKING — its promotion gate is evaluated inside EVA's processStage()
- Now line 895 calls _shouldAutoApproveStage() for ANY BLOCKED result regardless of gate set
- Adds explicit stage advancement after governance override (EVA doesn't set nextStageId for BLOCKED)

## Test plan
- [x] _shouldAutoApproveStage(16) returns true with config global_auto_proceed=true, hard_gate_stages=[19]
- [x] API Linter advances S16 → S17 with governance override logged
- [x] 14/14 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)