### PR TITLE
fix: governance override must not skip contract validation failures

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -899,7 +899,9 @@ export class StageExecutionWorker {
           // auto-approved via _handleChairmanGate (result._gateApproved=true),
           // and (2) stages NOT in BLOCKING that get BLOCKED by EVA's internal
           // gate evaluations (e.g., Stage 16 promotion gate).
-          const governanceOverride = result._gateApproved || await this._shouldAutoApproveStage(currentStage);
+          // Only override gate/decision blocks, NOT contract validation failures (missing upstream data)
+          const isContractBlock = result?.errors?.some(e => e.code === 'MISSING_DEPENDENCY' || e.message?.includes('upstream') || e.message?.includes('missing'));
+          const governanceOverride = !isContractBlock && (result._gateApproved || await this._shouldAutoApproveStage(currentStage));
           if (governanceOverride) {
             this._logger.log(`[Worker] Stage ${currentStage} BLOCKED by EVA but governance auto-approves — advancing as advisory`);
             this._recordAdvisoryWarning(ventureId, currentStage, result).catch(() => {});


### PR DESCRIPTION
## Summary
- Governance override at line 895 was blindly advancing past ALL BLOCKED stages
- This skipped stages with missing upstream data (contract validation failures)
- Caused S19→S23 jump when S17/S18/S19 had no artifacts
- Fix: Check `result.errors` for MISSING_DEPENDENCY/upstream before overriding

## Test plan
- [x] Stages blocked by missing upstream data stay blocked
- [x] Stages blocked by gate failures still auto-advance when governance allows

🤖 Generated with [Claude Code](https://claude.com/claude-code)