### PR TITLE
feat: EVA analysis-first — contract pre-validation advisory instead of blocking

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -316,7 +316,8 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     logger.warn(`[Eva] Preference loading failed (non-fatal): ${err.message}`);
   }
 
-  // ── 3b. Cross-stage contract pre-validation ──
+  // ── 3b. Cross-stage contract pre-validation (advisory, not blocking) ──
+  let contractPreErrors = [];
   const contract = getContract(resolvedStage);
   if (contract && contract.consumes.length > 0) {
     const preSpan = tracer.startSpan('contract_pre_validation');
@@ -327,8 +328,13 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
       tracer.endSpan(preSpan.spanId, { status: preStatus, metadata: { errors: preResult.errors.length, warnings: preResult.warnings.length } });
 
       if (!preResult.valid && preResult.blocked) {
-        logger.error(`[Eva][Contract] Pre-stage ${resolvedStage} BLOCKED: ${preResult.errors.join('; ')}`);
-        return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.BLOCKED, errors: preResult.errors.map(e => ({ code: 'CONTRACT_PRE_VALIDATION', message: e })), traceId: tracer.traceId });
+        // SD-LEO-INFRA-EVA-ANALYSIS-FIRST-001: Contract pre-validation failures are now
+        // advisory, not blocking. Analysis always runs so artifacts are produced even when
+        // upstream data is incomplete. The worker's contract-block guard (line 902 in
+        // stage-execution-worker.js) provides defense-in-depth if needed.
+        logger.warn(`[Eva][Contract] Pre-stage ${resolvedStage} validation: ${preResult.errors.length} error(s) [advisory] { errors: ${JSON.stringify(preResult.errors)} }`);
+        // Store errors for downstream visibility but don't block
+        contractPreErrors = preResult.errors.map(e => ({ code: 'CONTRACT_PRE_VALIDATION', message: e }));
       }
     } catch (err) {
       tracer.endSpan(preSpan.spanId, { status: 'failed', metadata: { error: err.message } });


### PR DESCRIPTION
## Summary
- Contract pre-validation in processStage() changed from blocking to advisory
- Analysis always runs, artifacts always produced even with incomplete upstream data
- Prevents cascading empty stages when governance auto-proceed advances past blocked stages
- Worker contract-block guard (PR #2495) provides defense-in-depth

## Test plan
- [x] 5/5 existing tests pass
- [ ] API Linter S17-S19 produce artifacts even with partial upstream data
- [ ] Governance override advances with artifacts present

🤖 Generated with [Claude Code](https://claude.com/claude-code)