### PR TITLE
fix: post-stage contract validation advisory (matches pre-stage)

### DIFF
--- a/lib/eva/eva-orchestrator.js
+++ b/lib/eva/eva-orchestrator.js
@@ -545,8 +545,9 @@ export async function processStage({ ventureId, stageId, options = {} }, deps = 
     tracer.endSpan(postSpan.spanId, { status: postStatus, metadata: { errors: postResult.errors.length } });
 
     if (!postResult.valid && postResult.blocked) {
-      logger.error(`[Eva][Contract] Post-stage ${resolvedStage} FAILED: ${postResult.errors.join('; ')}`);
-      return buildResult({ ventureId, stageId: resolvedStage, startedAt, correlationId, status: STATUS.FAILED, artifacts, errors: postResult.errors.map(e => ({ code: 'CONTRACT_POST_VALIDATION', message: e })), traceId: tracer.traceId });
+      // SD-LEO-INFRA-EVA-ANALYSIS-FIRST-001: Post-validation advisory, not blocking.
+      // Artifacts are already produced — blocking here loses them. Log and continue.
+      logger.warn(`[Eva][Contract] Post-stage ${resolvedStage} validation: ${postResult.errors.length} error(s) [advisory] { errors: ${JSON.stringify(postResult.errors)} }`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Post-stage contract validation at line 547 blocked S17 with "decision required" error
- Artifacts were produced but lost because validation returned FAILED
- Changed to advisory (warn + continue) matching the pre-stage fix from PR #2496

## Test plan
- [ ] S17 processes to completion with advisory warning instead of FAILED
- [ ] Artifacts persisted even when post-validation has errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)