### PR TITLE
fix(SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001): centralize post-stage hooks in registry

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -146,6 +146,16 @@ export class StageExecutionWorker {
 
     /** @type {import('http').Server|null} Health check HTTP server */
     this._healthServer = null;
+
+    /**
+     * SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001: Centralized post-stage hook registry.
+     * Hooks fire after ANY advancement path completes a stage, not just one path.
+     * @type {Map<number, (ventureId: string) => Promise<void>>}
+     */
+    this._postStageHookRegistry = new Map([
+      [17, (ventureId) => this._postStageHook_S17_DocGen(ventureId)],
+      [19, (ventureId) => this._postStageHook_S19_Bridge(ventureId)],
+    ]);
   }
 
   // ── Public API ──────────────────────────────────────────
@@ -538,6 +548,7 @@ export class StageExecutionWorker {
                 .eq('id', ventureId);
               this._logger.log(`[Worker] Advanced DB stage ${currentStage} → ${nextStage} (pending auto-approved)`);
               this._logStageTransition(ventureId, currentStage, 'completed', 0, null).catch(() => {});
+              await this._runPostStageHooks(ventureId, currentStage);
               currentStage = nextStage;
               continue;
             }
@@ -596,126 +607,7 @@ export class StageExecutionWorker {
                 .eq('id', ventureId);
               this._logger.log(`[Worker] Advanced DB stage ${currentStage} → ${nextStage} (pre-execution approved skip)`);
               this._logStageTransition(ventureId, currentStage, 'completed', 0, null).catch(() => {});
-
-              // Post-approval hook: Stage 17 doc generation (EVA vision + architecture plan)
-              if (currentStage === 17) {
-                try {
-                  const { data: ventureRow } = await this._supabase
-                    .from('ventures').select('name').eq('id', ventureId).single();
-                  const { generateDocs } = await import('./stage-templates/analysis-steps/stage-17-doc-generation.js');
-                  await generateDocs({
-                    ventureId,
-                    ventureName: ventureRow?.name,
-                    supabase: this._supabase,
-                    logger: this._logger,
-                  });
-                  this._logger.log('[Worker] Stage 17 post-approval: vision + architecture docs generated');
-                } catch (docErr) {
-                  this._logger.warn(`[Worker] Stage 17 doc generation failed (non-fatal): ${docErr.message}`);
-                }
-              }
-
-              // Post-approval hook: Stage 18 SD bridge conversion (sprint → LEO SDs)
-              // Fires AFTER chairman approves stage 18, ensuring only approved sprints become SDs.
-              // SD: SD-LEO-INFRA-VENTURE-LEO-BUILD-001-G — added provisioning verification
-              if (currentStage === 18) {
-                try {
-                  const { data: ventureRow } = await this._supabase
-                    .from('ventures').select('name').eq('id', ventureId).single();
-
-                  // Step 1: Verify venture provisioning before SD bridge conversion
-                  await this._verifyAndProvisionVenture(ventureId, ventureRow?.name);
-
-                  // Step 2: Fetch sd_bridge_payloads from persisted stage 18 artifacts
-                  const { data: artifacts } = await this._supabase
-                    .from('venture_artifacts')
-                    .select('content, metadata')
-                    .eq('venture_id', ventureId)
-                    .eq('lifecycle_stage', 18)
-                    .eq('is_current', true)
-                    .order('created_at', { ascending: false })
-                    .limit(5);
-
-                  // Extract sd_bridge_payloads from artifact content or metadata
-                  let sdBridgePayloads = [];
-                  for (const art of (artifacts || [])) {
-                    const payloads = art.content?.sd_bridge_payloads
-                      || art.metadata?.sd_bridge_payloads
-                      || art.content?.stage18_data?.sd_bridge_payloads;
-                    if (payloads?.length > 0) {
-                      sdBridgePayloads = payloads;
-                      break;
-                    }
-                  }
-
-                  if (sdBridgePayloads.length > 0) {
-                    // Query EVA records for vision_key and plan_key
-                    const { data: visionDoc } = await this._supabase
-                      .from('eva_vision_documents')
-                      .select('vision_key')
-                      .eq('venture_id', ventureId)
-                      .order('version', { ascending: false })
-                      .limit(1)
-                      .maybeSingle();
-
-                    const { data: archPlan } = await this._supabase
-                      .from('eva_architecture_plans')
-                      .select('plan_key')
-                      .eq('venture_id', ventureId)
-                      .order('version', { ascending: false })
-                      .limit(1)
-                      .maybeSingle();
-
-                    const { convertSprintToSDs, buildBridgeArtifactRecord } = await import('./lifecycle-sd-bridge.js');
-                    const { writeArtifact } = await import('./artifact-persistence-service.js');
-
-                    const stageOutput = {
-                      sd_bridge_payloads: sdBridgePayloads,
-                      sprint_name: artifacts[0]?.content?.sprint_name || artifacts[0]?.metadata?.sprint_name || 'unknown',
-                      sprint_goal: artifacts[0]?.content?.sprint_goal || artifacts[0]?.metadata?.sprint_goal || '',
-                      sprint_duration_days: artifacts[0]?.content?.sprint_duration_days || artifacts[0]?.metadata?.sprint_duration_days || 14,
-                    };
-
-                    const ventureContext = { id: ventureId, name: ventureRow?.name };
-                    const evaKeys = {
-                      vision_key: visionDoc?.vision_key || null,
-                      plan_key: archPlan?.plan_key || null,
-                    };
-
-                    const bridgeResult = await convertSprintToSDs(
-                      { stageOutput, ventureContext, evaKeys },
-                      { supabase: this._supabase, logger: this._logger },
-                    );
-
-                    if (bridgeResult.created) {
-                      this._logger.log(`[Worker] Stage 18 post-approval: Created orchestrator ${bridgeResult.orchestratorKey} with ${bridgeResult.childKeys.length} children`);
-
-                      // Persist bridge result as artifact
-                      try {
-                        const bridgeArtifact = buildBridgeArtifactRecord(ventureId, 18, bridgeResult);
-                        await writeArtifact(this._supabase, {
-                          ventureId,
-                          lifecycleStage: bridgeArtifact.lifecycle_stage,
-                          artifactType: bridgeArtifact.artifact_type,
-                          title: bridgeArtifact.title,
-                          content: bridgeArtifact.content,
-                          metadata: bridgeArtifact.metadata,
-                          source: bridgeArtifact.source || 'lifecycle-sd-bridge',
-                          qualityScore: bridgeArtifact.quality_score ?? 100,
-                          validationStatus: bridgeArtifact.validation_status || 'validated',
-                          validatedBy: bridgeArtifact.validated_by,
-                        });
-                      } catch (bridgeArtErr) {
-                        this._logger.warn(`[Worker] Bridge artifact persist failed: ${bridgeArtErr.message}`);
-                      }
-                    }
-                  } else {
-                    this._logger.log('[Worker] Stage 18 post-approval: No sd_bridge_payloads found in artifacts');
-                  }
-                } catch (bridgeErr) {
-                  this._logger.warn(`[Worker] Stage 18 SD bridge conversion failed (non-fatal): ${bridgeErr.message}`);
-                }
-              }
+              await this._runPostStageHooks(ventureId, currentStage);
 
               currentStage = nextStage;
               continue;
@@ -775,6 +667,7 @@ export class StageExecutionWorker {
               .eq('id', ventureId);
             this._logger.log(`[Worker] Advanced DB stage ${currentStage} → ${nextReentryStage} (re-entry after approval)`);
             this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
+            await this._runPostStageHooks(ventureId, currentStage);
             currentStage = nextReentryStage;
             continue;
           }
@@ -798,6 +691,7 @@ export class StageExecutionWorker {
               .eq('id', ventureId);
             this._logger.log(`[Worker] Advanced DB stage ${currentStage} → ${nextReviewStage} (review auto-approved)`);
             this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
+            await this._runPostStageHooks(ventureId, currentStage);
             currentStage = nextReviewStage;
             continue;
           }
@@ -1501,6 +1395,164 @@ export class StageExecutionWorker {
       );
 
     if (error) throw new Error(error.message);
+  }
+
+  // ── Post-Stage Hook Registry (SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001) ──
+
+  /**
+   * Run any registered post-stage hooks for the completed stage.
+   * Non-fatal: failures log warnings but never block advancement.
+   * @param {string} ventureId
+   * @param {number} completedStage - The stage that just finished
+   */
+  async _runPostStageHooks(ventureId, completedStage) {
+    const hook = this._postStageHookRegistry.get(completedStage);
+    if (!hook) return;
+    try {
+      await hook(ventureId);
+      this._logger.log(`[Worker] Post-stage hook fired for S${completedStage} (venture ${ventureId})`);
+    } catch (err) {
+      this._logger.warn(`[Worker] Post-stage hook S${completedStage} failed (non-fatal): ${err.message}`);
+    }
+  }
+
+  /**
+   * S17 post-stage hook: Generate EVA vision + architecture plan documents.
+   * @param {string} ventureId
+   */
+  async _postStageHook_S17_DocGen(ventureId) {
+    const { data: ventureRow } = await this._supabase
+      .from('ventures').select('name').eq('id', ventureId).single();
+    const { generateDocs } = await import('./stage-templates/analysis-steps/stage-17-doc-generation.js');
+    await generateDocs({
+      ventureId,
+      ventureName: ventureRow?.name,
+      supabase: this._supabase,
+      logger: this._logger,
+    });
+    this._logger.log('[Worker] S17 post-stage hook: vision + architecture docs generated');
+  }
+
+  /**
+   * S19 post-stage hook: Convert sprint plan → LEO Strategic Directives via lifecycle-sd-bridge.
+   * Queries S19 artifacts for sd_bridge_payloads, creates orchestrator + child SDs.
+   * @param {string} ventureId
+   */
+  async _postStageHook_S19_Bridge(ventureId) {
+    const { data: ventureRow } = await this._supabase
+      .from('ventures').select('name').eq('id', ventureId).single();
+
+    // Verify venture provisioning before SD bridge conversion
+    await this._verifyAndProvisionVenture(ventureId, ventureRow?.name);
+
+    // Fetch sd_bridge_payloads from S19 artifacts (fallback to S18 for legacy data)
+    const { data: artifacts } = await this._supabase
+      .from('venture_artifacts')
+      .select('content, metadata')
+      .eq('venture_id', ventureId)
+      .in('lifecycle_stage', [19, 18])
+      .eq('is_current', true)
+      .order('lifecycle_stage', { ascending: false })
+      .order('created_at', { ascending: false })
+      .limit(10);
+
+    let sdBridgePayloads = [];
+    for (const art of (artifacts || [])) {
+      // SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001: content column is TEXT — parse if needed
+      let content = art.content;
+      if (typeof content === 'string') {
+        try { content = JSON.parse(content); } catch { content = {}; }
+      }
+      let meta = art.metadata;
+      if (typeof meta === 'string') {
+        try { meta = JSON.parse(meta); } catch { meta = {}; }
+      }
+
+      const payloads = content?.sd_bridge_payloads
+        || meta?.sd_bridge_payloads
+        || content?.stage18_data?.sd_bridge_payloads
+        || content?.stage19_data?.sd_bridge_payloads;
+      if (payloads?.length > 0) {
+        sdBridgePayloads = payloads;
+        break;
+      }
+    }
+
+    if (sdBridgePayloads.length === 0) {
+      this._logger.log('[Worker] S19 post-stage hook: No sd_bridge_payloads found in artifacts');
+      return;
+    }
+
+    // Query EVA records for vision_key and plan_key
+    const { data: visionDoc } = await this._supabase
+      .from('eva_vision_documents')
+      .select('vision_key')
+      .eq('venture_id', ventureId)
+      .order('version', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const { data: archPlan } = await this._supabase
+      .from('eva_architecture_plans')
+      .select('plan_key')
+      .eq('venture_id', ventureId)
+      .order('version', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const { convertSprintToSDs, buildBridgeArtifactRecord } = await import('./lifecycle-sd-bridge.js');
+    const { writeArtifact } = await import('./artifact-persistence-service.js');
+
+    const firstArt = artifacts[0] || {};
+    let firstContent = firstArt.content;
+    if (typeof firstContent === 'string') {
+      try { firstContent = JSON.parse(firstContent); } catch { firstContent = {}; }
+    }
+    let firstMeta = firstArt.metadata;
+    if (typeof firstMeta === 'string') {
+      try { firstMeta = JSON.parse(firstMeta); } catch { firstMeta = {}; }
+    }
+
+    const stageOutput = {
+      sd_bridge_payloads: sdBridgePayloads,
+      sprint_name: firstContent?.sprint_name || firstMeta?.sprint_name || 'unknown',
+      sprint_goal: firstContent?.sprint_goal || firstMeta?.sprint_goal || '',
+      sprint_duration_days: firstContent?.sprint_duration_days || firstMeta?.sprint_duration_days || 14,
+    };
+
+    const ventureContext = { id: ventureId, name: ventureRow?.name };
+    const evaKeys = {
+      vision_key: visionDoc?.vision_key || null,
+      plan_key: archPlan?.plan_key || null,
+    };
+
+    const bridgeResult = await convertSprintToSDs(
+      { stageOutput, ventureContext, evaKeys },
+      { supabase: this._supabase, logger: this._logger },
+    );
+
+    if (bridgeResult.created) {
+      this._logger.log(`[Worker] S19 post-stage hook: Created orchestrator ${bridgeResult.orchestratorKey} with ${bridgeResult.childKeys.length} children`);
+
+      // Persist bridge result as artifact
+      try {
+        const bridgeArtifact = buildBridgeArtifactRecord(ventureId, 19, bridgeResult);
+        await writeArtifact(this._supabase, {
+          ventureId,
+          lifecycleStage: bridgeArtifact.lifecycle_stage,
+          artifactType: bridgeArtifact.artifact_type,
+          title: bridgeArtifact.title,
+          content: bridgeArtifact.content,
+          metadata: bridgeArtifact.metadata,
+          source: bridgeArtifact.source || 'lifecycle-sd-bridge',
+          qualityScore: bridgeArtifact.quality_score ?? 100,
+          validationStatus: bridgeArtifact.validation_status || 'validated',
+          validatedBy: bridgeArtifact.validated_by,
+        });
+      } catch (bridgeArtErr) {
+        this._logger.warn(`[Worker] Bridge artifact persist failed: ${bridgeArtErr.message}`);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Fix 3 bugs** preventing lifecycle-sd-bridge from firing when ventures advance through stages
- **Create `_postStageHookRegistry` Map** in StageExecutionWorker constructor with S17 (doc-gen) and S19 (bridge) entries
- **Add `_runPostStageHooks()`** method called from all 4 advancement paths (was only in 1)
- **Fix bridge stage** from S18 to S19 where `sd_bridge_payloads` actually live
- **Add JSON.parse guard** for TEXT content column before accessing `sd_bridge_payloads`
- Extract inline hooks (~120 lines) into dedicated methods, net +52 lines

## RCA Findings
1. Bridge hook embedded in only 1 of 4 advancement paths (pre-exec shortcut at L618)
2. Bridge wired to S18 but `sd_bridge_payloads` come from S19
3. Content column is TEXT, needs `JSON.parse` before accessing payloads

## Test plan
- [x] Syntax check passes
- [x] Existing unit tests pass (17/18, 1 pre-existing failure unrelated)
- [x] `_runPostStageHooks()` called from all 4 paths (grep verified)
- [x] No references to old inline S17/S18 hooks remain
- [ ] Run venture through S17-S21 to verify bridge fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)