### PR TITLE
docs(protocol): add cross-stage data contract verification rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,4 +119,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-03-25 8:16:32 AM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-03-27 12:26:45 PM | Protocol: LEO 4.3.3 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-03-25 8:16:32 AM
+**Generated**: 2026-03-27 12:26:45 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions
 
@@ -9,23 +9,6 @@
 > For Strunkian writing standards, see `docs/reference/strunkian-writing-standards.md`.
 
 ---
-
-## Migration Execution Protocol
-
-**CRITICAL**: When you need to execute a migration, INVOKE the DATABASE sub-agent rather than writing execution scripts yourself.
-
-The DATABASE sub-agent handles common blockers automatically:
-- **Missing SUPABASE_DB_PASSWORD**: Uses `SUPABASE_POOLER_URL` instead (no password required)
-- **Connection issues**: Uses proven connection patterns
-- **Execution failures**: Tries alternative scripts before giving up
-
-**Never give up on migration execution** - the sub-agent has multiple fallback methods.
-
-**Invocation**:
-```
-Task tool with subagent_type="database-agent":
-"Execute the migration file: database/migrations/YYYYMMDD_name.sql"
-```
 
 ## Cascade Invalidation System
 
@@ -60,6 +43,23 @@ node scripts/modules/governance/cascade-invalidation-engine.js resolve <flagId> 
 - `eva_architecture_plans.needs_review_since` — auto-set by trigger, NULL when resolved
 - `eva_architecture_plans.vision_version_aligned_to` — tracks which vision version the plan was last aligned with
 
+## Migration Execution Protocol
+
+**CRITICAL**: When you need to execute a migration, INVOKE the DATABASE sub-agent rather than writing execution scripts yourself.
+
+The DATABASE sub-agent handles common blockers automatically:
+- **Missing SUPABASE_DB_PASSWORD**: Uses `SUPABASE_POOLER_URL` instead (no password required)
+- **Connection issues**: Uses proven connection patterns
+- **Execution failures**: Tries alternative scripts before giving up
+
+**Never give up on migration execution** - the sub-agent has multiple fallback methods.
+
+**Invocation**:
+```
+Task tool with subagent_type="database-agent":
+"Execute the migration file: database/migrations/YYYYMMDD_name.sql"
+```
+
 ## 🏗️ Application Architecture - UNIFIED FRONTEND
 
 ## Application Architecture - UNIFIED FRONTEND
@@ -84,6 +84,41 @@ node scripts/modules/governance/cascade-invalidation-engine.js resolve <flagId> 
 ```bash
 bash scripts/leo-stack.sh restart   # All 3 servers
 ```
+
+## 🔍 Session Start Verification (MANDATORY)
+
+**Anti-Hallucination Protocol**: Never trust session summaries for database state. ALWAYS verify.
+
+### Before Starting ANY SD Work:
+```
+[ ] Query database to confirm SD exists
+[ ] Verify SD status and current_phase  
+[ ] Check for existing PRD if phase > LEAD
+[ ] Check for existing handoffs
+[ ] Document: "Verified SD [title] exists, status=[X], phase=[Y]"
+```
+
+### Verification Queries:
+```sql
+-- Find SD by title
+SELECT legacy_id, title, status, current_phase, progress 
+FROM strategic_directives_v2 
+WHERE title ILIKE '%[keyword]%' AND is_active = true;
+
+-- Check PRD exists
+SELECT prd_id, status FROM product_requirements_v2 WHERE sd_id = '[SD-ID]';
+
+-- Check handoffs exist
+SELECT from_phase, to_phase, status FROM sd_phase_handoffs WHERE sd_id = '[SD-ID]';
+```
+
+### Why This Matters:
+- Session summaries describe *context*, not *state*
+- AI can hallucinate successful database operations
+- Database is the ONLY source of truth
+- If records don't exist, CREATE them before proceeding
+
+**Pattern Reference**: PAT-SESS-VER-001
 
 ## 🚀 Session Verification & Quick Start (MANDATORY)
 
@@ -124,41 +159,6 @@ bash scripts/leo-stack.sh restart   # All 3 servers
 | `npm run prio:top3` | Top priority SDs |
 | `git status` | Working tree status |
 | `npm run handoff:latest` | Latest handoff |
-
-## 🔍 Session Start Verification (MANDATORY)
-
-**Anti-Hallucination Protocol**: Never trust session summaries for database state. ALWAYS verify.
-
-### Before Starting ANY SD Work:
-```
-[ ] Query database to confirm SD exists
-[ ] Verify SD status and current_phase  
-[ ] Check for existing PRD if phase > LEAD
-[ ] Check for existing handoffs
-[ ] Document: "Verified SD [title] exists, status=[X], phase=[Y]"
-```
-
-### Verification Queries:
-```sql
--- Find SD by title
-SELECT legacy_id, title, status, current_phase, progress 
-FROM strategic_directives_v2 
-WHERE title ILIKE '%[keyword]%' AND is_active = true;
-
--- Check PRD exists
-SELECT prd_id, status FROM product_requirements_v2 WHERE sd_id = '[SD-ID]';
-
--- Check handoffs exist
-SELECT from_phase, to_phase, status FROM sd_phase_handoffs WHERE sd_id = '[SD-ID]';
-```
-
-### Why This Matters:
-- Session summaries describe *context*, not *state*
-- AI can hallucinate successful database operations
-- Database is the ONLY source of truth
-- If records don't exist, CREATE them before proceeding
-
-**Pattern Reference**: PAT-SESS-VER-001
 
 ## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
 
@@ -370,43 +370,38 @@ Task({ subagent_type: 'database-agent', prompt: '...', model: 'haiku' })  // NO!
 
 > **Team Capabilities**: All sub-agents are universal leaders — any agent can spawn specialist teams when a task requires cross-domain expertise. See **Teams Protocol** in CLAUDE.md for templates, dynamic agent creation, and knowledge enrichment.
 
-## Sub-Agent Routing Reference
+## 🖥️ UI Parity Requirement (MANDATORY)
 
-All 16 specialized sub-agents are available in EVERY phase (LEAD, PLAN, EXEC). Use the Task tool with the appropriate `subagent_type` to invoke them. See phase-specific guidance in each phase's CLAUDE file for recommended priorities.
+**Every backend data contract field MUST have a corresponding UI representation.**
 
-> **Routing Config**: Full keyword-to-agent mappings are defined in `config/agent-keywords-routing.json`. The table below is a quick reference.
+### Principle
+If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
 
-| Agent | Trigger Keywords | Best For |
-|-------|-----------------|----------|
-| database-agent | migration, schema, sql, postgres, rls | Database operations, migrations, RLS policies |
-| design-agent | component design, tailwind, responsive, a11y | UI/UX design, accessibility, frontend components |
-| security-agent | auth bypass, csrf, xss, vulnerability | Security audits, vulnerability fixes |
-| testing-agent | test coverage, e2e test, unit test, vitest | Test creation, test infrastructure |
-| performance-agent | bottleneck, load time, memory leak | Performance optimization, profiling |
-| rca-agent | root cause, 5 whys, failure analysis | Root cause analysis, debugging |
-| docmon-agent | documentation update, api docs, readme | Documentation maintenance |
-| regression-agent | backward compatible, breaking change, refactor | Refactoring safety, API compatibility |
-| retro-agent | retrospective, lessons learned, post-mortem | Sprint retrospectives, learning capture |
-| risk-agent | risk assessment, security risk, tradeoff | Risk analysis, architecture decisions |
-| validation-agent | duplicate check, existing implementation | Codebase validation, overlap detection |
-| stories-agent | user stories, acceptance criteria, epic | User story generation |
-| github-agent | pull request, ci pipeline, code review | Git operations, CI/CD |
-| api-agent | api endpoint, rest api, graphql | API design and implementation |
-| dependency-agent | npm audit, outdated packages, vulnerability | Dependency management |
-| uat-agent | user acceptance test, user journey, manual test | User acceptance testing |
+### Requirements
 
-### Invocation Pattern
-```
-Task(subagent_type="<agent-name>", prompt="Execute <AGENT> analysis for SD-XXX...")
-```
+1. **Data Contract Coverage**
+   - Every field in `stageX_data` wrappers must map to a UI component
+   - Score displays must show actual numeric values, not just pass/fail
+   - Confidence levels must be visible with appropriate visual indicators
 
-### Key Rules
-- **ALL phases**: Sub-agents are available in LEAD, PLAN, and EXEC phases
-- **Model**: Always use Sonnet (never Haiku) - see Sub-Agent Model Routing section
-- **Immediate invocation**: When a task matches an agent's domain, invoke IMMEDIATELY - do not attempt manual workarounds
-- **Error routing**: ANY database error triggers database-agent; ANY test failure triggers testing-agent
+2. **Human Inspectability**
+   - Stage outputs must be viewable in human-readable format
+   - Key findings, red flags, and recommendations must be displayed
+   - Source citations must be accessible
 
-*Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
+3. **No Hidden Logic**
+   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
+   - Threshold comparisons must be visible
+   - Stage weights must be displayed in aggregation views
+
+### Verification Checklist
+Before marking any stage/feature as complete:
+- [ ] All output fields have UI representation
+- [ ] Scores are displayed numerically
+- [ ] Key findings are visible to users
+- [ ] Recommendations are actionable in the UI
+
+**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## Execution Philosophy
 
@@ -445,38 +440,43 @@ Task(subagent_type="<agent-name>", prompt="Execute <AGENT> analysis for SD-XXX..
 - Skip PRD creation for child SDs
 - Mark parent complete before all children complete in database
 
-## 🖥️ UI Parity Requirement (MANDATORY)
+## Sub-Agent Routing Reference
 
-**Every backend data contract field MUST have a corresponding UI representation.**
+All 16 specialized sub-agents are available in EVERY phase (LEAD, PLAN, EXEC). Use the Task tool with the appropriate `subagent_type` to invoke them. See phase-specific guidance in each phase's CLAUDE file for recommended priorities.
 
-### Principle
-If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
+> **Routing Config**: Full keyword-to-agent mappings are defined in `config/agent-keywords-routing.json`. The table below is a quick reference.
 
-### Requirements
+| Agent | Trigger Keywords | Best For |
+|-------|-----------------|----------|
+| database-agent | migration, schema, sql, postgres, rls | Database operations, migrations, RLS policies |
+| design-agent | component design, tailwind, responsive, a11y | UI/UX design, accessibility, frontend components |
+| security-agent | auth bypass, csrf, xss, vulnerability | Security audits, vulnerability fixes |
+| testing-agent | test coverage, e2e test, unit test, vitest | Test creation, test infrastructure |
+| performance-agent | bottleneck, load time, memory leak | Performance optimization, profiling |
+| rca-agent | root cause, 5 whys, failure analysis | Root cause analysis, debugging |
+| docmon-agent | documentation update, api docs, readme | Documentation maintenance |
+| regression-agent | backward compatible, breaking change, refactor | Refactoring safety, API compatibility |
+| retro-agent | retrospective, lessons learned, post-mortem | Sprint retrospectives, learning capture |
+| risk-agent | risk assessment, security risk, tradeoff | Risk analysis, architecture decisions |
+| validation-agent | duplicate check, existing implementation | Codebase validation, overlap detection |
+| stories-agent | user stories, acceptance criteria, epic | User story generation |
+| github-agent | pull request, ci pipeline, code review | Git operations, CI/CD |
+| api-agent | api endpoint, rest api, graphql | API design and implementation |
+| dependency-agent | npm audit, outdated packages, vulnerability | Dependency management |
+| uat-agent | user acceptance test, user journey, manual test | User acceptance testing |
 
-1. **Data Contract Coverage**
-   - Every field in `stageX_data` wrappers must map to a UI component
-   - Score displays must show actual numeric values, not just pass/fail
-   - Confidence levels must be visible with appropriate visual indicators
+### Invocation Pattern
+```
+Task(subagent_type="<agent-name>", prompt="Execute <AGENT> analysis for SD-XXX...")
+```
 
-2. **Human Inspectability**
-   - Stage outputs must be viewable in human-readable format
-   - Key findings, red flags, and recommendations must be displayed
-   - Source citations must be accessible
+### Key Rules
+- **ALL phases**: Sub-agents are available in LEAD, PLAN, and EXEC phases
+- **Model**: Always use Sonnet (never Haiku) - see Sub-Agent Model Routing section
+- **Immediate invocation**: When a task matches an agent's domain, invoke IMMEDIATELY - do not attempt manual workarounds
+- **Error routing**: ANY database error triggers database-agent; ANY test failure triggers testing-agent
 
-3. **No Hidden Logic**
-   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
-   - Threshold comparisons must be visible
-   - Stage weights must be displayed in aggregation views
-
-### Verification Checklist
-Before marking any stage/feature as complete:
-- [ ] All output fields have UI representation
-- [ ] Scores are displayed numerically
-- [ ] Key findings are visible to users
-- [ ] Recommendations are actionable in the UI
-
-**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
+*Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
 
 ## 🚫 Stage 7 Hard Block: UI Coverage Prerequisite
 
@@ -523,38 +523,6 @@ To request an exception to this block:
 
 **No exceptions without explicit LEAD approval.**
 
-## Child SD Pre-Work Validation (MANDATORY)
-
-**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
-
-### Validation Command
-```bash
-node scripts/child-sd-preflight.js SD-XXX-001
-```
-
-### What It Checks
-1. **Is Child SD**: Verifies the SD has a parent_sd_id
-2. **Dependency Chain**: For each dependency SD:
-   - Status must be `completed`
-   - Progress must be `100%`
-   - Required handoffs must be present
-3. **Parent Context**: Loads parent orchestrator for reference
-
-### Results
-**PASS** - Ready to work if:
-- SD is standalone (not a child), OR
-- No dependencies, OR
-- All dependencies complete with required handoffs
-
-**BLOCKED** - Cannot proceed if:
-- One or more dependency SDs incomplete
-- Missing required handoffs on dependencies
-- Action: Complete blocking dependency first
-
-### Integration
-- `npm run sd:next` shows dependency status in queue
-- Child SDs with incomplete dependencies show as BLOCKED
-
 ## Global Negative Constraints
 
 These anti-patterns apply across ALL phases. Violating them leads to failed handoffs and rework.
@@ -587,6 +555,46 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 - `node scripts/handoff.js execute ...`
 - `node scripts/add-prd-to-database.js ...`
 - `node scripts/phase-preflight.js ...`
+
+### NC-7: No Silent Hook Failures
+❌ Catching post-stage hook errors and logging as "non-fatal" when the hook produced zero expected output rows
+✅ Hooks that write to database tables must verify their output exists after execution. Zero rows written = escalation to chairman dashboard, not a warning log.
+
+**Why**: SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001 revealed that the S17 doc-gen hook failed silently on every run since it was shipped (wrong column name in query). Because the error was caught as non-fatal, the pipeline continued without vision/architecture docs, and S19 generated an unvalidated sprint plan.
+
+**Rule**: "Non-fatal" means the hook threw an unexpected exception. "Hook ran but wrote zero rows to its target table" is a **data integrity failure** that must surface.
+
+## Child SD Pre-Work Validation (MANDATORY)
+
+**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
+
+### Validation Command
+```bash
+node scripts/child-sd-preflight.js SD-XXX-001
+```
+
+### What It Checks
+1. **Is Child SD**: Verifies the SD has a parent_sd_id
+2. **Dependency Chain**: For each dependency SD:
+   - Status must be `completed`
+   - Progress must be `100%`
+   - Required handoffs must be present
+3. **Parent Context**: Loads parent orchestrator for reference
+
+### Results
+**PASS** - Ready to work if:
+- SD is standalone (not a child), OR
+- No dependencies, OR
+- All dependencies complete with required handoffs
+
+**BLOCKED** - Cannot proceed if:
+- One or more dependency SDs incomplete
+- Missing required handoffs on dependencies
+- Action: Complete blocking dependency first
+
+### Integration
+- `npm run sd:next` shows dependency status in queue
+- Child SDs with incomplete dependencies show as BLOCKED
 
 ## 🔄 Git Commit Guidelines
 
@@ -1179,16 +1187,16 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 - [ ] Verify: 18 notification files verified and export expected functions for SD-MAN-...
 - [ ] Validate: Multi-channel delivery: email, telegram, discord, database for SD-MAN-...
 
-### 2. LEAD_TO_PLAN Handoff Retrospective: Unified Sensemaking Service - KB Binding, Multi-Type Routing, Dynamic Personas [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/23/2026 | **Score**: 100
+### 2. LEAD_TO_PLAN Handoff Retrospective: V1-Growth [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/27/2026 | **Score**: 100
 
 **Key Improvements**:
-- [PAT-AUTO-2db93761] Gate 1:userStoryQualityValidation failed: score 51/100
-- [PAT-AUTO-129d8943] Gate 1:prdQualityValidation failed: score 47/100
+- [PAT-AUTO-3439e3eb] Gate 1:userStoryQualityValidation failed: score 55/100
+- [PAT-AUTO-b8a37fa7] Gate 1:prdQualityValidation failed: score 18/100
 
 **Action Items**:
-- [ ] Verify: Sensemaking service processes TYPE A (YouTube), TYPE B (text URL), TYPE ...
-- [ ] Validate: KB context from sensemaking_knowledge_base injected into every analysi...
+- [ ] Verify: Implementation complete with ~130 LOC for SD-MAN-INFRA-VISION-HEAL-PLATF...
+- [ ] Validate: All tests passing including stage-chain integration tests for SD-MAN-I...
 
 ### 3. LEAD_TO_PLAN Handoff Retrospective: Legacy Cleanup — Route Migration and Dead Component Removal [QUALITY]
 **Category**: PROCESS_IMPROVEMENT | **Date**: 2/26/2026 | **Score**: 100
@@ -1215,16 +1223,16 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 - [ ] Verify: 18 notification files verified and export expected functions for SD-MAN-...
 - [ ] Validate: Multi-channel delivery: email, telegram, discord, database for SD-MAN-...
 
-### 5. LEAD_TO_PLAN Handoff Retrospective: V1-Growth [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 2/27/2026 | **Score**: 100
+### 5. LEAD_TO_PLAN Handoff Retrospective: Chairman V2 to V3 Complete Migration and Legacy Cleanup [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 2/28/2026 | **Score**: 100
 
 **Key Improvements**:
+- [PAT-AUTO-3b18dc45] Gate 1:prdQualityValidation failed: score 29/100
 - [PAT-AUTO-3439e3eb] Gate 1:userStoryQualityValidation failed: score 55/100
-- [PAT-AUTO-b8a37fa7] Gate 1:prdQualityValidation failed: score 18/100
 
 **Action Items**:
-- [ ] Verify: Implementation complete with ~130 LOC for SD-MAN-INFRA-VISION-HEAL-PLATF...
-- [ ] Validate: All tests passing including stage-chain integration tests for SD-MAN-I...
+- [ ] Verify: All chairman routes point to v3 components (zero v2 imports in routes) f...
+- [ ] Validate: chairman-v2/ directory completely deleted for SD-LEO-ORCH-CHAIRMAN-COM...
 
 
 *Lessons auto-generated from `retrospectives` table. Query for full details.*
@@ -1290,7 +1298,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-03-25*
+*Generated from database: 2026-03-27*
 *Protocol Version: 4.3.3*
 *Includes: Proposals (0) + Hot Patterns (0) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:16:32.303Z -->
-<!-- git_commit: 7de0b7c0 -->
-<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
+<!-- generated_at: 2026-03-27T16:26:45.916Z -->
+<!-- git_commit: 6e8c7731 -->
+<!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
@@ -125,6 +125,12 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 - `node scripts/handoff.js execute ...`
 - `node scripts/add-prd-to-database.js ...`
 - `node scripts/phase-preflight.js ...`
+
+### NC-7: No Silent Hook Failures
+❌ Catching post-stage hook errors and logging as "non-fatal" when the hook produced zero expected output rows
+✅ Hooks that write to database tables must ve
+
+*...truncated. Read full file for complete section.*
 
 ## Critical Term Definitions
 
@@ -261,5 +267,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-03-25 8:16:32 AM*
+*DIGEST generated: 2026-03-27 12:26:45 PM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:16:32.303Z -->
-<!-- git_commit: 7de0b7c0 -->
-<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
+<!-- generated_at: 2026-03-27T16:26:45.916Z -->
+<!-- git_commit: 6e8c7731 -->
+<!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
@@ -152,5 +152,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-03-25 8:16:32 AM*
+*DIGEST generated: 2026-03-27 12:26:45 PM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-03-25 8:16:32 AM
+**Generated**: 2026-03-27 12:26:45 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing
 
@@ -146,7 +146,7 @@ Before writing ANY code, EXEC MUST:
 
 ```bash
 # Check SD phase status
-node scripts/verify-sd-phase.js SD-XXX-001
+node scripts/phase-preflight.js SD-XXX-001
 
 # Or check via sd:status
 npm run sd:status SD-XXX-001
@@ -166,13 +166,77 @@ npm run sd:status SD-XXX-001
 1. Pre-commit hook (blocks commits for draft SDs)
 2. CLAUDE_EXEC.md (mandatory Phase 1 check)
 3. LOC threshold (>500 LOC requires SD)
-4. verify-sd-phase.js script
+4. phase-preflight.js script
 5. GitHub Action (PR validation)
 6. Orchestrator progress calculation
 
 See: `docs/03_protocols_and_standards/gate0-workflow-entry-enforcement.md` for complete documentation.
 
 **If SD is in draft**: STOP. Do not implement. Run LEAD-TO-PLAN handoff first.
+
+
+## Branch Creation (Automated at LEAD-TO-PLAN)
+
+## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
+
+### Automatic Branch Creation
+
+As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
+
+1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
+2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
+3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
+4. Database is updated with branch name for tracking
+
+### Manual Branch Creation (If Needed)
+
+If branch creation fails or you need to create one manually:
+
+```bash
+# Create branch for an SD (looks up title from database)
+npm run sd:branch SD-XXX-001
+
+# Create with auto-stash (non-interactive)
+npm run sd:branch:auto SD-XXX-001
+
+# Check if branch exists
+npm run sd:branch:check SD-XXX-001
+
+# Full command with options
+# scripts/create-sd-branch.js removed SD-XXX-001 --app EHG --auto-stash
+```
+
+### Branch Naming Convention
+
+| SD Type | Branch Prefix | Example |
+|---------|---------------|---------|
+| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
+| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
+| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
+| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
+| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
+
+### Branch Hygiene Rules
+
+From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
+- **≤7 days stale** at PLAN-TO-EXEC handoff
+- **One SD per branch** (no mixing work)
+- **Merge main at phase transitions**
+
+### When Branch is Created
+
+```
+LEAD Phase                    PLAN Phase                   EXEC Phase
+    |                              |                            |
+    |   LEAD-TO-PLAN handoff       |                            |
+    |---[Branch Created Here]----->|                            |
+    |                              |   PRD Creation             |
+    |                              |   Sub-agent validation     |
+    |                              |                            |
+    |                              |   PLAN-TO-EXEC handoff     |
+    |                              |---[Branch Validated]------>|
+    |                              |                            |
+```
 
 
 ## ❌ Anti-Patterns from Retrospectives (EXEC Phase)
@@ -263,70 +327,6 @@ If `research_confidence_score = 0.00`, you skipped this step.
 
 **Pattern References**: PAT-RECURSION-001 through PAT-RECURSION-005
 
-## Branch Creation (Automated at LEAD-TO-PLAN)
-
-## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
-
-### Automatic Branch Creation
-
-As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
-
-1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
-2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
-3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
-4. Database is updated with branch name for tracking
-
-### Manual Branch Creation (If Needed)
-
-If branch creation fails or you need to create one manually:
-
-```bash
-# Create branch for an SD (looks up title from database)
-npm run sd:branch SD-XXX-001
-
-# Create with auto-stash (non-interactive)
-npm run sd:branch:auto SD-XXX-001
-
-# Check if branch exists
-npm run sd:branch:check SD-XXX-001
-
-# Full command with options
-# scripts/create-sd-branch.js removed SD-XXX-001 --app EHG --auto-stash
-```
-
-### Branch Naming Convention
-
-| SD Type | Branch Prefix | Example |
-|---------|---------------|---------|
-| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
-| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
-| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
-| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
-| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
-
-### Branch Hygiene Rules
-
-From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
-- **≤7 days stale** at PLAN-TO-EXEC handoff
-- **One SD per branch** (no mixing work)
-- **Merge main at phase transitions**
-
-### When Branch is Created
-
-```
-LEAD Phase                    PLAN Phase                   EXEC Phase
-    |                              |                            |
-    |   LEAD-TO-PLAN handoff       |                            |
-    |---[Branch Created Here]----->|                            |
-    |                              |   PRD Creation             |
-    |                              |   Sub-agent validation     |
-    |                              |                            |
-    |                              |   PLAN-TO-EXEC handoff     |
-    |                              |---[Branch Validated]------>|
-    |                              |                            |
-```
-
-
 ## EXEC Phase Negative Constraints
 
 ## 🚫 EXEC Phase Negative Constraints
@@ -384,41 +384,6 @@ During the EXEC phase, use sub-agents proactively for implementation quality and
 Sub-agents are FIRST RESPONDERS in EXEC phase. When you encounter a problem that matches an agent's domain, invoke the agent IMMEDIATELY rather than attempting manual solutions.
 
 *Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
-
-## Migration Script Pattern (MANDATORY)
-
-**Issue Pattern**: PAT-DB-MIGRATION-001
-
-When writing migration scripts, you MUST use the established pattern:
-
-### Correct Pattern
-```javascript
-import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
-import { readFileSync } from 'fs';
-
-const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
-const client = await createDatabaseClient('engineer', { verify: true });
-const statements = splitPostgreSQLStatements(migrationSQL);
-
-for (const statement of statements) {
-  await client.query(statement);
-}
-
-await client.end();
-```
-
-### NEVER Use This Pattern
-```javascript
-// WRONG - exec_sql RPC does not exist
-import { createClient } from '@supabase/supabase-js';
-const supabase = createClient(url, key);
-await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
-```
-
-### Before Writing Migration Scripts
-1. Search for existing patterns: `Glob *migration*.js`
-2. Read `scripts/run-sql-migration.js` as canonical template
-3. Use `lib/supabase-connection.js` utilities
 
 ## 📚 Skill Integration (EXEC Phase)
 
@@ -497,6 +462,41 @@ Skills are for **creative guidance** (how to build).
 Sub-agents are for **validation** (did you build it right).
 Use skills during EXEC, save sub-agents for PLAN_VERIFY.
 
+## Migration Script Pattern (MANDATORY)
+
+**Issue Pattern**: PAT-DB-MIGRATION-001
+
+When writing migration scripts, you MUST use the established pattern:
+
+### Correct Pattern
+```javascript
+import { createDatabaseClient, splitPostgreSQLStatements } from './lib/supabase-connection.js';
+import { readFileSync } from 'fs';
+
+const migrationSQL = readFileSync('path/to/migration.sql', 'utf-8');
+const client = await createDatabaseClient('engineer', { verify: true });
+const statements = splitPostgreSQLStatements(migrationSQL);
+
+for (const statement of statements) {
+  await client.query(statement);
+}
+
+await client.end();
+```
+
+### NEVER Use This Pattern
+```javascript
+// WRONG - exec_sql RPC does not exist
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(url, key);
+await supabase.rpc('exec_sql', { sql_query: sql }); // FAILS
+```
+
+### Before Writing Migration Scripts
+1. Search for existing patterns: `Glob *migration*.js`
+2. Read `scripts/run-sql-migration.js` as canonical template
+3. Use `lib/supabase-connection.js` utilities
+
 ## Validation Rules (SD-LEARN-008)
 
 ## PLAN-TO-EXEC Validation Gates
@@ -512,7 +512,7 @@ Use skills during EXEC, save sub-agents for PLAN_VERIFY.
 
 **Remediation**:
 ```bash
-node scripts/create-prd-template.js <SD-ID>
+node scripts/add-prd-to-database.js <SD-ID>
 # Then approve the PRD and retry handoff
 ```
 
@@ -1346,6 +1346,22 @@ When this gate fails:
 - **Export**: `createIntegrationTestRequirementGate(supabase)`
 - **Gate Key**: `GATE_INTEGRATION_TEST_REQUIREMENT`
 
+### Cross-SD Pipeline Integration Tests
+
+**Trigger**: SD modifies code in a multi-stage pipeline where stages have producer-consumer relationships.
+
+**Detection**: Any SD touching files in `lib/eva/stage-templates/`, `lib/eva/stage-execution-worker.js`, or `lib/eva/lifecycle-sd-bridge.js`.
+
+**Requirement**: Integration tests must verify the **data contract** between the modified stage and its consumers:
+
+| Producer Stage | Target Table | Consumer Stage | What to Test |
+|---------------|--------------|----------------|--------------|
+| S17 doc-gen | eva_vision_documents, eva_architecture_plans | S19 bridge | Vision/arch docs exist and have expected fields |
+| S19 bridge | strategic_directives_v2 | Build pipeline | Orchestrator + children created with correct parent_sd_id |
+| Stage templates | venture_artifacts | Next stage | Artifact type, content schema, is_current flag |
+
+**Why this is separate from unit tests**: Unit tests verify a function works in isolation. Cross-SD integration tests verify that the output schema of Stage N matches the input expectations of Stage N+M. The S17 doc-gen passed its unit-level validation (file existed, function exported correctly) but failed at runtime because it queried a non-existent column — a bug only visible when running against the real database schema.
+
 ## User Story Acceptance Criteria Verification (MANDATORY)
 
 Before marking any user story as `status = 'completed'`, you **MUST** verify each acceptance criterion against implementation evidence. Bulk-updating story status to pass the ACCEPTANCE_CRITERIA_VALIDATION gate without per-criterion verification is a **protocol violation**.
@@ -1385,6 +1401,77 @@ The ACCEPTANCE_CRITERIA_VALIDATION gate scores stories as follows:
 - **0**: No acceptance criteria defined
 
 Threshold: overall score >= 60 AND no story scores 0.
+
+## Playwright MCP Integration
+
+## 🎭 Playwright MCP Integration
+
+**Status**: ✅ READY (Installed 2025-10-12)
+
+### Overview
+Playwright MCP (Model Context Protocol) provides browser automation capabilities for testing, scraping, and UI verification.
+
+### Installed Components
+- **Chrome**: Google Chrome browser for MCP operations
+- **Chromium**: Chromium 141.0.7390.37 (build 1194) for standard Playwright tests
+- **Chromium Headless Shell**: Headless browser for CI/CD pipelines
+- **System Dependencies**: All required Linux libraries installed
+
+### Available MCP Tools
+
+#### Navigation
+- `mcp__playwright__browser_navigate` - Navigate to URL
+- `mcp__playwright__browser_navigate_back` - Go back to previous page
+
+#### Interaction
+- `mcp__playwright__browser_click` - Click elements
+- `mcp__playwright__browser_fill` - Fill form fields
+- `mcp__playwright__browser_select` - Select dropdown options
+- `mcp__playwright__browser_hover` - Hover over elements
+- `mcp__playwright__browser_type` - Type text into elements
+
+#### Verification
+- `mcp__playwright__browser_snapshot` - Capture accessibility snapshot
+- `mcp__playwright__browser_take_screenshot` - Take screenshots
+- `mcp__playwright__browser_evaluate` - Execute JavaScript
+
+#### Management
+- `mcp__playwright__browser_close` - Close browser
+- `mcp__playwright__browser_tabs` - Manage tabs
+
+### Testing Integration
+
+**When to Use Playwright MCP**:
+1. ✅ Visual regression testing
+2. ✅ UI component verification
+3. ✅ Screenshot capture for evidence
+4. ✅ Accessibility tree validation
+5. ✅ Cross-browser testing
+
+**When to Use Standard Playwright**:
+1. ✅ E2E test suites (`npm run test:e2e`)
+2. ✅ CI/CD pipeline tests
+3. ✅ Automated test runs
+4. ✅ User story validation
+
+### Usage Example
+
+```javascript
+// Using Playwright MCP for visual verification
+await mcp__playwright__browser_navigate({ url: 'http://localhost:3000/dashboard' });
+await mcp__playwright__browser_snapshot(); // Get accessibility tree
+await mcp__playwright__browser_take_screenshot({ name: 'dashboard-state' });
+await mcp__playwright__browser_click({ element: 'Submit button', ref: 'e5' });
+```
+
+### QA Director Integration
+
+The QA Engineering Director sub-agent now has access to:
+- Playwright MCP for visual testing
+- Standard Playwright for E2E automation
+- Both Chrome (MCP) and Chromium (tests) browsers
+
+**Complete Guide**: See `docs/reference/playwright-mcp-guide.md`
 
 ## Triangulated Runtime Audit Protocol
 
@@ -1603,77 +1690,6 @@ See: `/runtime-audit` skill for full template
 - `codebase-search` - Finding code references
 - `schema-design` - Database schema issues
 
-
-## Playwright MCP Integration
-
-## 🎭 Playwright MCP Integration
-
-**Status**: ✅ READY (Installed 2025-10-12)
-
-### Overview
-Playwright MCP (Model Context Protocol) provides browser automation capabilities for testing, scraping, and UI verification.
-
-### Installed Components
-- **Chrome**: Google Chrome browser for MCP operations
-- **Chromium**: Chromium 141.0.7390.37 (build 1194) for standard Playwright tests
-- **Chromium Headless Shell**: Headless browser for CI/CD pipelines
-- **System Dependencies**: All required Linux libraries installed
-
-### Available MCP Tools
-
-#### Navigation
-- `mcp__playwright__browser_navigate` - Navigate to URL
-- `mcp__playwright__browser_navigate_back` - Go back to previous page
-
-#### Interaction
-- `mcp__playwright__browser_click` - Click elements
-- `mcp__playwright__browser_fill` - Fill form fields
-- `mcp__playwright__browser_select` - Select dropdown options
-- `mcp__playwright__browser_hover` - Hover over elements
-- `mcp__playwright__browser_type` - Type text into elements
-
-#### Verification
-- `mcp__playwright__browser_snapshot` - Capture accessibility snapshot
-- `mcp__playwright__browser_take_screenshot` - Take screenshots
-- `mcp__playwright__browser_evaluate` - Execute JavaScript
-
-#### Management
-- `mcp__playwright__browser_close` - Close browser
-- `mcp__playwright__browser_tabs` - Manage tabs
-
-### Testing Integration
-
-**When to Use Playwright MCP**:
-1. ✅ Visual regression testing
-2. ✅ UI component verification
-3. ✅ Screenshot capture for evidence
-4. ✅ Accessibility tree validation
-5. ✅ Cross-browser testing
-
-**When to Use Standard Playwright**:
-1. ✅ E2E test suites (`npm run test:e2e`)
-2. ✅ CI/CD pipeline tests
-3. ✅ Automated test runs
-4. ✅ User story validation
-
-### Usage Example
-
-```javascript
-// Using Playwright MCP for visual verification
-await mcp__playwright__browser_navigate({ url: 'http://localhost:3000/dashboard' });
-await mcp__playwright__browser_snapshot(); // Get accessibility tree
-await mcp__playwright__browser_take_screenshot({ name: 'dashboard-state' });
-await mcp__playwright__browser_click({ element: 'Submit button', ref: 'e5' });
-```
-
-### QA Director Integration
-
-The QA Engineering Director sub-agent now has access to:
-- Playwright MCP for visual testing
-- Standard Playwright for E2E automation
-- Both Chrome (MCP) and Chromium (tests) browsers
-
-**Complete Guide**: See `docs/reference/playwright-mcp-guide.md`
 
 ## Edge Case Testing Checklist
 
@@ -1937,6 +1953,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-03-25*
+*Generated from database: 2026-03-27*
 *Protocol Version: 4.3.3*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:16:32.303Z -->
-<!-- git_commit: 7de0b7c0 -->
-<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
+<!-- generated_at: 2026-03-27T16:26:45.916Z -->
+<!-- git_commit: 6e8c7731 -->
+<!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
@@ -218,5 +218,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-03-25 8:16:32 AM*
+*DIGEST generated: 2026-03-27 12:26:45 PM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-03-25 8:16:32 AM
+**Generated**: 2026-03-27 12:26:45 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation
 
@@ -1273,33 +1273,6 @@ Sequential LEAD approval allows learning from earlier children to inform later d
 
 > **Team Capabilities**: For orchestrator SDs with parallel children, agents can spawn specialist teams to accelerate cross-domain work. See **Teams Protocol** in CLAUDE.md.
 
-## SD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off SD creation scripts like:**
-- `create-*-sd.js`
-- `create-sd*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/leo-create-sd.js
-```
-
-### Why This Matters
-- One-off scripts bypass validation and governance
-- They create maintenance burden (100+ orphaned scripts)
-- They fragment the codebase and confuse future developers
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-sd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/leo-create-sd.js`
-2. Follow interactive prompts
-3. SD is properly validated and tracked in database
-
 ## Vision V2 SD Handling (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Reference Check
@@ -1341,6 +1314,33 @@ All Vision V2 SDs contain this metadata:
   "note": "Similar files may exist in the codebase that you can learn from, but we are creating from new."
 }
 ```
+
+## SD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off SD creation scripts like:**
+- `create-*-sd.js`
+- `create-sd*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/leo-create-sd.js
+```
+
+### Why This Matters
+- One-off scripts bypass validation and governance
+- They create maintenance burden (100+ orphaned scripts)
+- They fragment the codebase and confuse future developers
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-sd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/leo-create-sd.js`
+2. Follow interactive prompts
+3. SD is properly validated and tracked in database
 
 ## Parent-Child SD Phase Governance
 
@@ -1390,10 +1390,10 @@ SET phase = 'EXEC', status = 'in_progress'
 WHERE id = '<PARENT_SD_UUID>';
 ```
 
-**Option 2: Use Helper Script (Recommended)**
+**Option 2: Use sd:start (Recommended)**
 
 ```bash
-node scripts/reactivate-parent-sd.js <PARENT_SD_ID>
+npm run sd:start <PARENT_SD_KEY>
 ```
 
 ### Best Practices
@@ -1406,7 +1406,7 @@ node scripts/reactivate-parent-sd.js <PARENT_SD_ID>
 ### Recommended Improvements
 
 1. Update trigger error messages to include resolution steps
-2. Create `scripts/reactivate-parent-sd.js` helper script
+2. Use `npm run sd:start` to reactivate parent SDs
 3. Add database function for safe parent re-activation
 4. Update handoff.js for parent-child handling
 
@@ -1487,6 +1487,6 @@ Check `objectives` (active, current period) and `key_results` (status != 'achiev
 
 ---
 
-*Generated from database: 2026-03-25*
+*Generated from database: 2026-03-27*
 *Protocol Version: 4.3.3*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:16:32.303Z -->
-<!-- git_commit: 7de0b7c0 -->
-<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
+<!-- generated_at: 2026-03-27T16:26:45.916Z -->
+<!-- git_commit: 6e8c7731 -->
+<!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
@@ -126,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-25 8:16:32 AM*
+*DIGEST generated: 2026-03-27 12:26:45 PM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-03-25 8:16:32 AM
+**Generated**: 2026-03-27 12:26:45 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 
@@ -322,8 +322,8 @@ node scripts/add-prd-to-database.js \
   --title "Feature Name" \
   --status planning
 
-# Or use the generated script template:
-node scripts/create-prd-sd-xxx-001.js
+# Or specify SD directly:
+node scripts/add-prd-to-database.js --sd-id=SD-XXX-001
 ```
 
 ### Self-Critique Before Handoff
@@ -444,6 +444,23 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 | "DESIGN sub-agent not executed" | Didn't run design-agent | Use Task tool with design-agent |
 | "DATABASE sub-agent not executed" | Didn't run database-agent | Use Task tool with database-agent |
 
+## Enhanced QA Engineering Director v2.0 - Testing-First Edition
+
+**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
+
+**Core Capabilities:**
+1. Professional test case generation from user stories
+2. Pre-test build validation (saves 2-3 hours)
+3. Database migration verification (prevents 1-2 hours debugging)
+4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
+5. Test infrastructure discovery and reuse
+
+**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
+
+**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
+
+**Full Guide**: See `docs/reference/qa-director-guide.md`
+
 ## ✅ Scope Verification with Explore (PLAN_VERIFY)
 
 ## Scope Verification with Explore
@@ -514,23 +531,6 @@ This change [describe]. Options:
 
 Which do you prefer?"
 ```
-
-## Enhanced QA Engineering Director v2.0 - Testing-First Edition
-
-**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
-
-**Core Capabilities:**
-1. Professional test case generation from user stories
-2. Pre-test build validation (saves 2-3 hours)
-3. Database migration verification (prevents 1-2 hours debugging)
-4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
-5. Test infrastructure discovery and reuse
-
-**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
-
-**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
-
-**Full Guide**: See `docs/reference/qa-director-guide.md`
 
 ## PLAN Pre-EXEC Checklist
 
@@ -650,6 +650,24 @@ Before writing an architecture plan for any pipeline or integration fix, the arc
 
 **Detection**: The gate scans architecture plan content for evidence patterns (section headers, log output blocks, runtime observation language). Plans without evidence are rejected.
 
+### Cross-Stage Data Flow Verification (Pipeline SDs)
+
+When an SD creates code that **produces data consumed by a downstream stage**, the smoke test evidence must include verification that the downstream consumer receives valid data.
+
+**Applies to**: SDs where Stage N writes artifacts/records that Stage N+M reads.
+
+**Examples**:
+- S17 doc-gen writes to `eva_vision_documents` → S19 bridge reads vision_key for SD creation
+- S19 bridge writes to `strategic_directives_v2` → Build pipeline reads SDs for execution
+- Stage templates write to `venture_artifacts` → Downstream stages query artifacts by type
+
+**Required Evidence**:
+1. Run the producer stage and verify rows exist in the target table
+2. Run the consumer stage and verify it reads those rows successfully
+3. Include both queries in the "## Baseline Observation" section
+
+**Why**: SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001 and SD-LEO-INFRA-VENTURE-BUILD-READINESS-001-C each passed their individual gates, but the data contract between S17 (produces vision/arch docs) and S19 (consumes them for sprint validation) was never tested end-to-end. A column name mismatch in S17 caused zero docs to be written, and S19 proceeded with an unvalidated sprint plan.
+
 ## First-Failure-First Ordering (Pipeline Orchestrator SDs)
 
 ## First-Failure-First (FFF) Child Ordering
@@ -673,6 +691,33 @@ When a pipeline has cascading failures, the architecture plan MUST:
 **Why**: If Child A fixes Layer 4 (symptoms) while Layer 1 (root cause) remains broken, all downstream fixes are untestable. The root cause must be fixed first so subsequent children can verify their fixes against real output.
 
 **Detection**: The gate checks architecture plan content for failure chain diagrams and upstream-first child ordering language.
+
+## 🔬 BMAD Method Enhancements
+
+## BMAD Enhancements
+
+### 6 Key Improvements
+1. **Unified Handoff System** - All handoffs via `handoff.js`
+2. **Database-First PRDs** - PRDs stored in database, not markdown
+3. **Validation Gates** - 4-gate validation before EXEC
+4. **Progress Tracking** - Automatic progress % calculation
+5. **Context Management** - Proactive monitoring, compression strategies
+6. **Sub-Agent Compression** - 3-tier output reduction
+
+### Using Handoff System
+```bash
+node scripts/handoff.js create "{message}"
+```
+
+### PRD Creation
+```bash
+node scripts/add-prd-to-database.js {SD-ID}
+```
+
+### Never Bypass
+- ⚠️ Always use process scripts
+- ⚠️ Never create PRDs as markdown files
+- ⚠️ Never skip validation gates
 
 ## Research Lookup Before PRD Creation
 
@@ -772,48 +817,6 @@ node scripts/add-prd-to-database.js SD-RESEARCH-106
 ```
 
 
-## 🔬 BMAD Method Enhancements
-
-## BMAD Enhancements
-
-### 6 Key Improvements
-1. **Unified Handoff System** - All handoffs via `handoff.js`
-2. **Database-First PRDs** - PRDs stored in database, not markdown
-3. **Validation Gates** - 4-gate validation before EXEC
-4. **Progress Tracking** - Automatic progress % calculation
-5. **Context Management** - Proactive monitoring, compression strategies
-6. **Sub-Agent Compression** - 3-tier output reduction
-
-### Using Handoff System
-```bash
-node scripts/handoff.js create "{message}"
-```
-
-### PRD Creation
-```bash
-node scripts/add-prd-to-database.js {SD-ID}
-```
-
-### Never Bypass
-- ⚠️ Always use process scripts
-- ⚠️ Never create PRDs as markdown files
-- ⚠️ Never skip validation gates
-
-## CI/CD Pipeline Verification
-
-## CI/CD Pipeline Verification (MANDATORY)
-
-**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
-
-### Verification Process
-
-**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
-
-1. Wait 2-3 minutes for GitHub Actions to complete
-2. Trigger DevOps sub-agent to verify pipeline status
-3. Document CI/CD status in PLAN→LEAD handoff
-4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
-
 ## DESIGN→DATABASE Validation Gates
 
 **4 mandatory gates ensuring sub-agent execution and implementation fidelity.**
@@ -865,6 +868,21 @@ Retroactive audit at SD closure:
 
 **Reference**: `scripts/modules/design-database-gates-validation.js`
 
+
+## CI/CD Pipeline Verification
+
+## CI/CD Pipeline Verification (MANDATORY)
+
+**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
+
+### Verification Process
+
+**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
+
+1. Wait 2-3 minutes for GitHub Actions to complete
+2. Trigger DevOps sub-agent to verify pipeline status
+3. Document CI/CD status in PLAN→LEAD handoff
+4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
 
 ## 🚪 Gate 2.5: Human Inspectability Validation
 
@@ -1642,6 +1660,34 @@ for (const childId of childIds) {
 
 > **Team Capabilities**: When planning complex SDs, consider whether team spawning (any agent leading specialists) could parallelize cross-domain work. See **Teams Protocol** in CLAUDE.md.
 
+## PRD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off PRD creation scripts like:**
+- `create-prd-sd-*.js`
+- `insert-prd-*.js`
+- `enhance-prd-*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/add-prd-to-database.js
+```
+
+### Why This Matters
+- One-off scripts bypass PRD quality validation
+- They create massive maintenance burden (100+ orphaned scripts)
+- They fragment PRD creation patterns
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-prd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/add-prd-to-database.js`
+2. Follow the modular PRD creation system in `scripts/prd/`
+3. PRD is properly validated against quality rubrics
+
 ## Vision V2 PRD Requirements (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Integration in PRDs
@@ -1682,34 +1728,6 @@ Key spec requirements addressed:
 ### Implementation Guidance (from SD metadata)
 
 All Vision V2 SDs have `creation_mode: CREATE_FROM_NEW` - implement fresh per specs, learn from existing code but do not modify it.
-
-## PRD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off PRD creation scripts like:**
-- `create-prd-sd-*.js`
-- `insert-prd-*.js`
-- `enhance-prd-*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/add-prd-to-database.js
-```
-
-### Why This Matters
-- One-off scripts bypass PRD quality validation
-- They create massive maintenance burden (100+ orphaned scripts)
-- They fragment PRD creation patterns
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-prd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/add-prd-to-database.js`
-2. Follow the modular PRD creation system in `scripts/prd/`
-3. PRD is properly validated against quality rubrics
 
 ## Quality Assessment Integration in Handoffs
 
@@ -2326,6 +2344,6 @@ When creating a PRD during PLAN phase, connect functional requirements to releva
 
 ---
 
-*Generated from database: 2026-03-25*
+*Generated from database: 2026-03-27*
 *Protocol Version: 4.3.3*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,7 +1,7 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-25T07:16:32.303Z -->
-<!-- git_commit: 7de0b7c0 -->
-<!-- db_snapshot_hash: 1ba41d24a4b01a2a -->
+<!-- generated_at: 2026-03-27T16:26:45.916Z -->
+<!-- git_commit: 6e8c7731 -->
+<!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
@@ -124,5 +124,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-25 8:16:32 AM*
+*DIGEST generated: 2026-03-27 12:26:45 PM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,76 +1,76 @@
 {
-  "generated_at": "2026-03-25T07:16:32.303Z",
-  "git_commit": "7de0b7c0",
-  "db_snapshot_hash": "1ba41d24a4b01a2a",
+  "generated_at": "2026-03-27T16:26:45.916Z",
+  "git_commit": "6e8c7731",
+  "db_snapshot_hash": "82336bc777136c79",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 5752,
-      "estimated_tokens": 1438,
-      "content_hash": "4b24881f422d6871",
+      "chars": 5753,
+      "estimated_tokens": 1439,
+      "content_hash": "238ba65ce5032072",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 52506,
-      "estimated_tokens": 13127,
-      "content_hash": "3306a501cb454f9c",
+      "chars": 53271,
+      "estimated_tokens": 13318,
+      "content_hash": "b319280d6fb7686c",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 54092,
-      "estimated_tokens": 13523,
-      "content_hash": "7a17909ff2863a92",
+      "chars": 54062,
+      "estimated_tokens": 13516,
+      "content_hash": "f81ef17b52fa456c",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 81656,
-      "estimated_tokens": 20414,
-      "content_hash": "fc0a6f5f2a800f73",
+      "chars": 82876,
+      "estimated_tokens": 20719,
+      "content_hash": "e674314063735064",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 69307,
-      "estimated_tokens": 17327,
-      "content_hash": "ad0962bdd72cf1bf",
+      "chars": 70623,
+      "estimated_tokens": 17656,
+      "content_hash": "b4b6c1e73c88ca0d",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 6618,
+      "chars": 6619,
       "estimated_tokens": 1655,
-      "content_hash": "c4e697e511fa204f",
+      "content_hash": "bdc9ffecca616719",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 10174,
-      "estimated_tokens": 2544,
-      "content_hash": "6b335d547fc236ba",
+      "chars": 10420,
+      "estimated_tokens": 2605,
+      "content_hash": "b6a7b4f438db165d",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 4801,
+      "chars": 4802,
       "estimated_tokens": 1201,
-      "content_hash": "84bb15a8367300fe",
+      "content_hash": "bf69afde1c64d697",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 5031,
+      "chars": 5032,
       "estimated_tokens": 1258,
-      "content_hash": "23e7f19eec1536ed",
+      "content_hash": "bb32b23e4f32e0a9",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 9485,
+      "chars": 9486,
       "estimated_tokens": 2372,
-      "content_hash": "02eea284bbbfeb9d",
+      "content_hash": "e718dc2be08d9500",
       "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
     }
   }


### PR DESCRIPTION
## Summary
- **NC-7** (CLAUDE_CORE.md): No Silent Hook Failures — hooks writing to DB tables must verify output exists; zero rows = escalation, not a warning
- **Cross-Stage Data Flow Verification** (CLAUDE_PLAN.md): Pipeline SDs must include end-to-end producer-consumer evidence in smoke test section
- **Cross-SD Pipeline Integration Tests** (CLAUDE_EXEC.md): SDs modifying multi-stage pipeline code must include integration tests verifying data contracts between stages

## Context
SynthTest venture ran S1-S19 and exposed that S17 doc-gen silently failed (wrong column name `stage_number` vs `lifecycle_stage`) on every run since it shipped. S19 generated a sprint plan without vision/architecture validation. Each SD passed individually but the connected chain was never tested.

## Test plan
- [x] Protocol sections updated in `leo_protocol_sections` table (IDs 334, 525, 509)
- [x] CLAUDE files regenerated via `node scripts/generate-claude-md-from-db.js`
- [x] NC-7 appears in CLAUDE_CORE.md Global Negative Constraints
- [x] Cross-Stage section appears in CLAUDE_PLAN.md Smoke Test Evidence
- [x] Cross-SD section appears in CLAUDE_EXEC.md Integration Test Gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)