### PR TITLE
fix: S17 doc-gen column name + archplan venture_id

### DIFF
--- a/lib/eva/archplan-upsert.js
+++ b/lib/eva/archplan-upsert.js
@@ -7,7 +7,7 @@
  * @module lib/eva/archplan-upsert
  */
 
-export async function upsertArchPlan({ supabase, planKey, visionKey, content, sections: providedSections, dimensions, brainstormId, createdBy = 'eva-archplan-upsert' }) {
+export async function upsertArchPlan({ supabase, planKey, visionKey, content, sections: providedSections, dimensions, ventureId, brainstormId, createdBy = 'eva-archplan-upsert' }) {
   if (!supabase) throw new Error('supabase client is required');
   if (!planKey) throw new Error('planKey is required');
   if (!visionKey) throw new Error('visionKey is required');
@@ -101,6 +101,7 @@ export async function upsertArchPlan({ supabase, planKey, visionKey, content, se
     chairman_approved: true,
     created_by: createdBy,
     source_file_path: null,
+    ...(ventureId ? { venture_id: ventureId } : {}),
     ...(brainstormId ? { source_brainstorm_id: brainstormId } : {}),
     ...(sections ? { sections } : {}),
   };

--- a/lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-17-doc-generation.js
@@ -69,7 +69,7 @@ export async function generateDocs({
   // 1. Fetch all current artifacts for this venture
   const { data: artifacts, error: fetchErr } = await supabase
     .from('venture_artifacts')
-    .select('artifact_type, artifact_data, content, stage_number')
+    .select('artifact_type, artifact_data, content, lifecycle_stage')
     .eq('venture_id', ventureId)
     .eq('is_current', true);
 
@@ -216,6 +216,7 @@ export async function generateDocs({
       visionKey,
       content: archContent,
       sections: archSections,
+      ventureId,
       brainstormId,
       createdBy: 'stage-17-doc-generation',
     });
@@ -233,7 +234,7 @@ export async function generateDocs({
         for (let retry = 0; retry < 2; retry++) {
           const { data: retryData, error: retryErr } = await upsertArchPlan({
             supabase, planKey: archKey, visionKey, content: archContent,
-            sections: archSections, brainstormId,
+            sections: archSections, ventureId, brainstormId,
             createdBy: 'stage-17-doc-generation',
           });
           if (!retryErr && retryData?.quality_checked) {


### PR DESCRIPTION
## Summary
- Fix `stage_number` → `lifecycle_stage` column name in S17 doc-gen artifact query (day-one bug, never worked)
- Add `ventureId` parameter to `archplan-upsert.js` so arch plans get `venture_id` set (was always null)
- Pass `ventureId` from doc-gen to `upsertArchPlan` in both primary and retry paths

## Context
SynthTest venture exposed that S17 doc-gen failed silently on artifact fetch (wrong column name) and arch plans were created without venture_id. This prevented downstream stages from finding governance docs.

## Test plan
- [x] Syntax check passes
- [x] Manual S17 doc-gen run against SynthTest produced vision + arch docs
- [ ] End-to-end: venture S17→S19→S20 with real data (SynthTest live test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)