### PR TITLE
fix: S20 circuit breaker — block when bridge produces zero SDs

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js
@@ -126,6 +126,27 @@ export async function analyzeStage20({ stage19Data, stage18Data, ventureName, su
     }
   }
 
+  // Circuit breaker: If S19 produced sd_bridge_payloads but zero SDs exist,
+  // the bridge failed silently. Block advancement instead of synthesizing fake data.
+  // Without this check, the pipeline continues on fabricated progress reports
+  // while the actual SD creation (the whole point of S19) never happened.
+  if (supabase && ventureId && stage19Data.sd_bridge_payloads?.length > 0) {
+    try {
+      const { data: sds } = await supabase.from('strategic_directives_v2')
+        .select('sd_key')
+        .eq('venture_id', ventureId)
+        .limit(1);
+      if (!sds || sds.length === 0) {
+        const msg = `[Stage20] CIRCUIT BREAKER: S19 produced ${stage19Data.sd_bridge_payloads.length} sd_bridge_payloads but zero SDs exist for this venture. The lifecycle-sd-bridge failed to convert sprint items to Strategic Directives. Stage 20 cannot produce meaningful build progress without real SDs. Blocking advancement.`;
+        logger.error(msg);
+        throw new Error(msg);
+      }
+    } catch (err) {
+      if (err.message.includes('CIRCUIT BREAKER')) throw err;
+      logger.warn('[Stage20] Circuit breaker SD check failed', { error: err.message });
+    }
+  }
+
   logger.log('[Stage20] No real data found, using LLM synthesis');
   const client = getLLMClient({ purpose: 'content-generation' });
 


### PR DESCRIPTION
## Summary
- Add circuit breaker in `stage-20-build-execution.js` between real data check and LLM fallback
- If S19 artifact contains `sd_bridge_payloads` but zero SDs exist for the venture, S20 throws instead of synthesizing fake progress
- Prevents the pipeline from auto-advancing on fabricated data when the bridge silently failed

## Context
SynthTest venture ran S19→S20→S21 in under 25 seconds. S20 produced a synthetic build report (all tasks "in_progress" with fabricated descriptions) because the bridge never created SDs. Without this circuit breaker, downstream stages operate on a fabricated foundation.

## Test plan
- [x] Syntax check passes
- [ ] End-to-end: reset SynthTest to S19, approve, verify S20 blocks when no SDs exist
- [ ] End-to-end: run bridge first, then verify S20 passes with real SD data

🤖 Generated with [Claude Code](https://claude.com/claude-code)