### PR TITLE
fix: S20 circuit breaker — verify vision, arch plan, and SDs exist

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js
@@ -126,24 +126,57 @@ export async function analyzeStage20({ stage19Data, stage18Data, ventureName, su
     }
   }
 
-  // Circuit breaker: If S19 produced sd_bridge_payloads but zero SDs exist,
-  // the bridge failed silently. Block advancement instead of synthesizing fake data.
-  // Without this check, the pipeline continues on fabricated progress reports
-  // while the actual SD creation (the whole point of S19) never happened.
-  if (supabase && ventureId && stage19Data.sd_bridge_payloads?.length > 0) {
+  // Circuit breaker: verify upstream pipeline produced the expected records.
+  // Without these checks, S20 falls through to LLM synthesis and fabricates
+  // progress reports on a foundation that doesn't exist.
+  if (supabase && ventureId) {
+    const missing = [];
+
+    // Check 1: Vision document must exist for this venture (produced by S17 doc-gen)
     try {
-      const { data: sds } = await supabase.from('strategic_directives_v2')
-        .select('sd_key')
+      const { data: vision } = await supabase.from('eva_vision_documents')
+        .select('vision_key')
         .eq('venture_id', ventureId)
         .limit(1);
-      if (!sds || sds.length === 0) {
-        const msg = `[Stage20] CIRCUIT BREAKER: S19 produced ${stage19Data.sd_bridge_payloads.length} sd_bridge_payloads but zero SDs exist for this venture. The lifecycle-sd-bridge failed to convert sprint items to Strategic Directives. Stage 20 cannot produce meaningful build progress without real SDs. Blocking advancement.`;
-        logger.error(msg);
-        throw new Error(msg);
+      if (!vision || vision.length === 0) {
+        missing.push('eva_vision_documents (S17 doc-gen did not produce a vision document)');
       }
     } catch (err) {
-      if (err.message.includes('CIRCUIT BREAKER')) throw err;
-      logger.warn('[Stage20] Circuit breaker SD check failed', { error: err.message });
+      logger.warn('[Stage20] Circuit breaker vision check failed', { error: err.message });
+    }
+
+    // Check 2: Architecture plan must exist for this venture (produced by S17 doc-gen)
+    try {
+      const { data: arch } = await supabase.from('eva_architecture_plans')
+        .select('plan_key')
+        .eq('venture_id', ventureId)
+        .limit(1);
+      if (!arch || arch.length === 0) {
+        missing.push('eva_architecture_plans (S17 doc-gen did not produce an architecture plan)');
+      }
+    } catch (err) {
+      logger.warn('[Stage20] Circuit breaker arch plan check failed', { error: err.message });
+    }
+
+    // Check 3: If S19 produced sd_bridge_payloads, SDs must exist (produced by S19 bridge hook)
+    if (stage19Data.sd_bridge_payloads?.length > 0) {
+      try {
+        const { data: sds } = await supabase.from('strategic_directives_v2')
+          .select('sd_key')
+          .eq('venture_id', ventureId)
+          .limit(1);
+        if (!sds || sds.length === 0) {
+          missing.push(`strategic_directives_v2 (S19 produced ${stage19Data.sd_bridge_payloads.length} sd_bridge_payloads but lifecycle-sd-bridge created zero SDs)`);
+        }
+      } catch (err) {
+        logger.warn('[Stage20] Circuit breaker SD check failed', { error: err.message });
+      }
+    }
+
+    if (missing.length > 0) {
+      const msg = `[Stage20] CIRCUIT BREAKER: ${missing.length} upstream record(s) missing for venture ${ventureId}. Stage 20 cannot produce meaningful build progress without these foundations. Missing: ${missing.join('; ')}`;
+      logger.error(msg);
+      throw new Error(msg);
     }
   }
 


### PR DESCRIPTION
## Summary
- Expand S20 circuit breaker from SD-only check to three upstream verifications
- Check 1: `eva_vision_documents` exists for venture_id (S17 doc-gen)
- Check 2: `eva_architecture_plans` exists for venture_id (S17 doc-gen)
- Check 3: `strategic_directives_v2` exists for venture_id (S19 bridge, only when payloads present)
- If any missing, S20 throws with diagnostic listing which records are absent and which stage produced them

## Test plan
- [x] Syntax check passes
- [ ] End-to-end with SynthTest after resetting to S19

🤖 Generated with [Claude Code](https://claude.com/claude-code)