### PR TITLE
fix: add orchestrator/governance guards to sd-type-validation gate

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/sd-type-validation.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/sd-type-validation.js
@@ -244,6 +244,20 @@ export async function validateSdType(sd, supabase) {
     };
   }
 
+  // Guard: Orchestrator type is structural and immutable
+  // SD-LEO-FIX-PRD-SCRIPT-TYPE-001: defense-in-depth (same guards as prd/index.js)
+  if (currentType.toLowerCase() === 'orchestrator') {
+    console.log('   ℹ️  Guard: orchestrator type is immutable — skipping mismatch detection');
+    return { pass: true, score: 100, issues: [], warnings: ['Orchestrator type is immutable — mismatch detection skipped'] };
+  }
+
+  // Guard: Governance metadata with type_change_reason means type was deliberately set
+  // SD-LEO-FIX-PRD-SCRIPT-TYPE-001
+  if (sd.governance_metadata?.type_change_reason) {
+    console.log('   ℹ️  Guard: governance_metadata.type_change_reason present — skipping mismatch detection');
+    return { pass: true, score: 100, issues: [], warnings: [`Type protected by governance: ${sd.governance_metadata.type_change_reason}`] };
+  }
+
   // Check for potential mismatch using GPT 5.2 classifier
   let classification;
   try {


### PR DESCRIPTION
## Summary
- Adds orchestrator immutability and governance_metadata guards to the LEAD-TO-PLAN handoff gate's sd_type auto-correction logic
- Defense-in-depth complement to PR #2503 which added the same guards to `prd/index.js`
- Guard #3 (LEAD-TO-PLAN handoff check) is not applicable here since this gate runs during the handoff itself

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint auto-fix clean
- [x] Guards match prd/index.js pattern

SD: SD-LEO-FIX-PRD-SCRIPT-TYPE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)