### PR TITLE
feat(SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002): fix 9 critical broken script references

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -29,12 +29,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Check dependency policy
-        run: |
-          echo "🔍 Checking dependency policy..."
-          node scripts/check-deps.js
-        continue-on-error: true
-
       - name: System deps (jq, bc)
         run: sudo apt-get update && sudo apt-get install -y jq bc
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,4 +119,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-03-27 12:26:45 PM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-03-27 4:44:07 PM | Protocol: LEO 4.3.3 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-03-27 12:26:45 PM
+**Generated**: 2026-03-27 4:44:07 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-27T16:26:45.916Z -->
-<!-- git_commit: 6e8c7731 -->
+<!-- generated_at: 2026-03-27T20:44:07.173Z -->
+<!-- git_commit: 7a225ca5 -->
 <!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
@@ -267,5 +267,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-03-27 12:26:45 PM*
+*DIGEST generated: 2026-03-27 4:44:07 PM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-27T16:26:45.916Z -->
-<!-- git_commit: 6e8c7731 -->
+<!-- generated_at: 2026-03-27T20:44:07.173Z -->
+<!-- git_commit: 7a225ca5 -->
 <!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
@@ -152,5 +152,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-03-27 12:26:45 PM*
+*DIGEST generated: 2026-03-27 4:44:07 PM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-03-27 12:26:45 PM
+**Generated**: 2026-03-27 4:44:07 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing
 
@@ -203,7 +203,7 @@ npm run sd:branch:auto SD-XXX-001
 npm run sd:branch:check SD-XXX-001
 
 # Full command with options
-# scripts/create-sd-branch.js removed SD-XXX-001 --app EHG --auto-stash
+# Branch was auto-created at LEAD-TO-PLAN handoff
 ```
 
 ### Branch Naming Convention
@@ -1906,36 +1906,7 @@ Adds a Product Requirements Document to the database with proper schema validati
 **Examples**:
 - `node scripts/add-prd-to-database.js --sd-id SD-IDEATION-STAGE1-001 --title "Stage 1 Implementation"`
 
-### Utility Scripts
-
-#### insert-leo-v431-protocol.js
-Inserts a new LEO protocol version and copies sections from previous version.
-
-**Usage**: `node scripts/insert-leo-v431-protocol.js`
-
-**Examples**:
-- `node scripts/insert-leo-v431-protocol.js`
-
-**Common Errors**:
-- Pattern: `violates check constraint.*status` -> Fix: Use valid status: active, superseded, draft, deprecated
-
 ### Validation Scripts
-
-#### verify-handoff-lead-to-plan.js
-Verifies LEAD to PLAN handoff requirements are met before allowing transition.
-
-**Usage**: `node scripts/verify-handoff-lead-to-plan.js <SD-ID>`
-
-**Examples**:
-- `node scripts/verify-handoff-lead-to-plan.js SD-IDEATION-STAGE1-001`
-
-#### verify-handoff-plan-to-exec.js
-Verifies PLAN to EXEC handoff requirements including PRD completeness and sub-agent validations.
-
-**Usage**: `node scripts/verify-handoff-plan-to-exec.js <SD-ID> [PRD-ID]`
-
-**Examples**:
-- `node scripts/verify-handoff-plan-to-exec.js SD-IDEATION-STAGE1-001`
 
 #### check-leo-version.js
 Verifies version consistency between CLAUDE*.md files and database. Use --fix to auto-regenerate.

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-27T16:26:45.916Z -->
-<!-- git_commit: 6e8c7731 -->
+<!-- generated_at: 2026-03-27T20:44:07.173Z -->
+<!-- git_commit: 7a225ca5 -->
 <!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
@@ -218,5 +218,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-03-27 12:26:45 PM*
+*DIGEST generated: 2026-03-27 4:44:07 PM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-03-27 12:26:45 PM
+**Generated**: 2026-03-27 4:44:07 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-27T16:26:45.916Z -->
-<!-- git_commit: 6e8c7731 -->
+<!-- generated_at: 2026-03-27T20:44:07.173Z -->
+<!-- git_commit: 7a225ca5 -->
 <!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
@@ -126,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-27 12:26:45 PM*
+*DIGEST generated: 2026-03-27 4:44:07 PM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-03-27 12:26:45 PM
+**Generated**: 2026-03-27 4:44:07 PM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 
@@ -159,7 +159,7 @@ npm run sd:branch:auto SD-XXX-001
 npm run sd:branch:check SD-XXX-001
 
 # Full command with options
-# scripts/create-sd-branch.js removed SD-XXX-001 --app EHG --auto-stash
+# Branch was auto-created at LEAD-TO-PLAN handoff
 ```
 
 ### Branch Naming Convention

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-03-27T16:26:45.916Z -->
-<!-- git_commit: 6e8c7731 -->
+<!-- generated_at: 2026-03-27T20:44:07.173Z -->
+<!-- git_commit: 7a225ca5 -->
 <!-- db_snapshot_hash: 82336bc777136c79 -->
 <!-- file_content_hash: pending -->
 
@@ -124,5 +124,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-03-27 12:26:45 PM*
+*DIGEST generated: 2026-03-27 4:44:07 PM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,77 +1,77 @@
 {
-  "generated_at": "2026-03-27T16:26:45.916Z",
-  "git_commit": "6e8c7731",
+  "generated_at": "2026-03-27T20:44:07.173Z",
+  "git_commit": "7a225ca5",
   "db_snapshot_hash": "82336bc777136c79",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 5753,
-      "estimated_tokens": 1439,
-      "content_hash": "238ba65ce5032072",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE.md"
+      "chars": 5752,
+      "estimated_tokens": 1438,
+      "content_hash": "177fcfa30ebc74ae",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 53271,
+      "chars": 53270,
       "estimated_tokens": 13318,
-      "content_hash": "b319280d6fb7686c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE.md"
+      "content_hash": "5c71e6d381d7c516",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 54062,
+      "chars": 54061,
       "estimated_tokens": 13516,
-      "content_hash": "f81ef17b52fa456c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD.md"
+      "content_hash": "23d253f52fdcf83e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 82876,
-      "estimated_tokens": 20719,
-      "content_hash": "e674314063735064",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN.md"
+      "chars": 82853,
+      "estimated_tokens": 20714,
+      "content_hash": "1f1d0d2fa9502f10",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 70623,
-      "estimated_tokens": 17656,
-      "content_hash": "b4b6c1e73c88ca0d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC.md"
+      "chars": 69658,
+      "estimated_tokens": 17415,
+      "content_hash": "7acc2692aaa31e91",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 6619,
+      "chars": 6618,
       "estimated_tokens": 1655,
-      "content_hash": "bdc9ffecca616719",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_DIGEST.md"
+      "content_hash": "e84ea937f73832b3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 10420,
+      "chars": 10419,
       "estimated_tokens": 2605,
-      "content_hash": "b6a7b4f438db165d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "a67b549b752d1458",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 4802,
+      "chars": 4801,
       "estimated_tokens": 1201,
-      "content_hash": "bf69afde1c64d697",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "821abc8db1591e9d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 5032,
+      "chars": 5031,
       "estimated_tokens": 1258,
-      "content_hash": "bb32b23e4f32e0a9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "b1db5e431474013e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 9486,
+      "chars": 9485,
       "estimated_tokens": 2372,
-      "content_hash": "e718dc2be08d9500",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "fd6dc455a35b36b7",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-DEAD-SCRIPT-ARCHIVAL-002\\CLAUDE_EXEC_DIGEST.md"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fix all 9 critical broken script references across CLAUDE_*.md files and CI workflows
- Deactivate 3 dead `leo_process_scripts` entries (verify-handoff-lead-to-plan, verify-handoff-plan-to-exec, insert-leo-v431-protocol)
- Update section 369 in `leo_protocol_sections` to remove stale `create-sd-branch.js` reference
- Remove dead `check-deps.js` CI step from `test-coverage.yml`
- Regenerate all CLAUDE_*.md from database, purging 4 stale hand-edits

## Evidence
- `validate-script-references.js --json` → 0 critical broken refs (was 9)
- `archive-dead-scripts.cjs --dry-run` → 213 protected by reference, zero false positives

## Test plan
- [x] Reference validator reports 0 critical broken refs
- [x] Archiver dry-run shows no false positives on referenced scripts
- [x] Pre-commit hook staged mode passes
- [x] All 5 PRD user stories validated with evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)