### PR TITLE
fix: kill orphan worker processes during LEO stack restart

### DIFF
--- a/scripts/leo-stack.ps1
+++ b/scripts/leo-stack.ps1
@@ -274,6 +274,23 @@ function Stop-Workers {
         $pidFile = Join-Path $PidDir $worker.pid_file
         Stop-Server -PidFile $pidFile -Name $worker.display_name
     }
+
+    # Kill orphan workers not tracked by PID files (zombie processes from previous sessions)
+    $orphanPatterns = @('start-stage-worker', 'stage-zero-queue-processor', 'stage-execution-worker', 'eva-master-scheduler', 'subagent-worker')
+    $orphanCount = 0
+    foreach ($pattern in $orphanPatterns) {
+        $orphans = Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+            Where-Object { $_.CommandLine -match $pattern }
+        foreach ($orphan in $orphans) {
+            try {
+                Stop-Process -Id $orphan.ProcessId -Force -ErrorAction SilentlyContinue
+                $orphanCount++
+            } catch { }
+        }
+    }
+    if ($orphanCount -gt 0) {
+        Write-Log "WARN" "[WORKERS] Killed $orphanCount orphan worker process(es) from previous sessions" "Yellow"
+    }
 }
 
 # Function to stop a server by PID file


### PR DESCRIPTION
## Summary
- Adds orphan worker kill step to `Stop-Workers` in `leo-stack.ps1`
- After PID-file-based shutdown, scans for any `node.exe` processes matching worker command patterns (`start-stage-worker`, `stage-zero-queue-processor`, etc.) and kills them
- Logs count of orphans found

## Context
Found 17 zombie stage workers from previous sessions surviving `/restart` because they weren't tracked by PID files. These ran old code, processing ventures with stale logic (including the LLM fabrication bug at Stage 20).

## Test plan
- [x] Verified orphan kill logic finds processes by command line pattern
- [ ] Run `/restart` and confirm orphan count in log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)