### PR TITLE
fix: drop check_target_application constraint and log bridge failures

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1596,6 +1596,9 @@ export class StageExecutionWorker {
       } catch (bridgeArtErr) {
         this._logger.warn(`[Worker] Bridge artifact persist failed: ${bridgeArtErr.message}`);
       }
+    } else {
+      const errors = bridgeResult.errors || bridgeResult.error || 'unknown';
+      this._logger.error(`[Worker] S19 post-stage hook: Bridge FAILED to create SDs for venture ${ventureId}. Errors: ${JSON.stringify(errors)}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- Dropped `check_target_application` constraint on `strategic_directives_v2` (hardcoded to only allow 'EHG'/'EHG_Engineer', blocking all venture-generated SDs)
- Added error logging when `bridgeResult.created === false` in the S19 post-stage hook — previously failures were silently discarded

## Context
RCA found that `lifecycle-sd-bridge.js` sets `target_application` to the venture name (e.g., 'CodeGuardian CI'), which violated the constraint. The INSERT failed silently, leaving zero SDs linked to the venture.

## Test plan
- [x] Constraint dropped via direct DDL execution
- [ ] Reset CodeGuardian CI to Stage 19 and verify SDs are created
- [ ] Verify bridge failure logging appears in worker log on errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)