### PR TITLE
fix: add governance_metadata.automation_context to SD bridge inserts

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -174,6 +174,9 @@ export async function convertSprintToSDs(params, deps = {}) {
         key_changes: payloads.map(p => ({ change: p.title, type: p.type })),
         smoke_test_steps: [],
         risks: [],
+        governance_metadata: {
+          automation_context: 'lifecycle-sd-bridge: automated SD creation from venture pipeline Stage 19 sprint planning',
+        },
         metadata: {
           ...provenance,
           created_via: 'lifecycle-sd-bridge',
@@ -230,6 +233,9 @@ export async function convertSprintToSDs(params, deps = {}) {
           risks: (payload.risks || []).map(r =>
             typeof r === 'string' ? { risk: r, mitigation: 'TBD' } : r,
           ),
+          governance_metadata: {
+            automation_context: 'lifecycle-sd-bridge: automated child SD from venture pipeline sprint decomposition',
+          },
           metadata: {
             ...provenance,
             created_via: 'lifecycle-sd-bridge',
@@ -347,6 +353,9 @@ async function createGrandchildren({
         key_changes: [{ change: `${layer.label} for ${childPayload.title}`, type: childPayload.type || 'feature' }],
         smoke_test_steps: [],
         risks: [],
+        governance_metadata: {
+          automation_context: 'lifecycle-sd-bridge: automated grandchild SD from architecture-layer decomposition',
+        },
         metadata: {
           ...provenance,
           created_via: 'lifecycle-sd-bridge',
@@ -409,7 +418,7 @@ async function rollbackCreatedRecords(supabase, createdIds, logger) {
   for (const id of createdIds) {
     const { error } = await supabase
       .from('strategic_directives_v2')
-      .update({ status: 'cancelled', updated_at: new Date().toISOString() })
+      .update({ status: 'cancelled', cancellation_reason: 'lifecycle-sd-bridge rollback: hierarchy creation failed', updated_at: new Date().toISOString() })
       .eq('id', id);
     if (error) {
       logger.error(`[LifecycleSDBridge] Failed to cancel ${id}: ${error.message}`);
@@ -547,6 +556,9 @@ export async function convertExpansionToSD(params, deps = {}) {
       key_changes: [{ change: expansionTitle, type: dbType }],
       smoke_test_steps: [],
       risks: [],
+      governance_metadata: {
+        automation_context: 'lifecycle-sd-bridge: automated expansion SD from venture post-lifecycle EXPAND decision',
+      },
       metadata: {
         ...provenance,
         created_via: 'lifecycle-sd-bridge-expand',


### PR DESCRIPTION
## Summary
- Added `governance_metadata.automation_context` to all 4 SD INSERT locations in `lifecycle-sd-bridge.js`
- Added `cancellation_reason` to rollback UPDATE (required field that was missing)

## Context
The bridge successfully created orchestrator + first child SD after the constraint fix (PR #2511), but failed on grandchild creation with `SD_TYPE_CHANGE_EXPLANATION_REQUIRED`. The governance trigger requires `type_change_reason` or `automation_context` when `sd_type` differs from parent. The rollback then also failed because `cancellation_reason` is required.

## Test plan
- [ ] Reset CodeGuardian CI to Stage 19 and verify full SD hierarchy is created
- [ ] Verify Stage 20 BUILD_PENDING detects the linked SDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)