### PR TITLE
fix: set venture_id column on SD bridge inserts

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -154,6 +154,7 @@ export async function convertSprintToSDs(params, deps = {}) {
       .insert({
         id: orchestratorId,
         sd_key: orchestratorKey,
+        venture_id: ventureContext?.id || null,
         title: `Sprint: ${sprintName}`,
         description: `Orchestrator for sprint "${sprintName}". Goal: ${sprintGoal}. Duration: ${sprintDuration} days. Items: ${payloads.length}.`,
         scope: `Sprint orchestrator coordinating ${payloads.length} child SDs for venture ${ventureContext?.name || 'unknown'}.`,
@@ -210,6 +211,7 @@ export async function convertSprintToSDs(params, deps = {}) {
         .insert({
           id: childId,
           sd_key: childKey,
+          venture_id: ventureContext?.id || null,
           title: payload.title,
           description: payload.description,
           scope: payload.scope,
@@ -332,6 +334,7 @@ async function createGrandchildren({
       .insert({
         id: gcId,
         sd_key: gcKey,
+        venture_id: ventureContext?.id || null,
         title: `${childPayload.title} — ${layer.label}`,
         description: `${layer.description} for "${childPayload.title}".`,
         scope: `${layer.label} implementation for parent task.`,
@@ -536,6 +539,7 @@ export async function convertExpansionToSD(params, deps = {}) {
     .insert({
       id: sdId,
       sd_key: sdKey,
+      venture_id: parentVentureId || null,
       title: expansionTitle,
       description: expansionDescription,
       scope: `Venture expansion from completed lifecycle of "${parentVentureName}".`,


### PR DESCRIPTION
## Summary
- Added `venture_id` column to all 4 INSERT locations in `lifecycle-sd-bridge.js`
- Previously only stored in metadata JSONB, making BUILD_PENDING unable to find linked SDs

## Test plan
- [ ] Reset CodeGuardian CI to Stage 19, verify SDs created with venture_id populated
- [ ] Verify BUILD_PENDING detects linked SDs at Stage 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)