### PR TITLE
fix: use structured automation_context for governance bypass in SD bridge

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -176,7 +176,7 @@ export async function convertSprintToSDs(params, deps = {}) {
         smoke_test_steps: [],
         risks: [],
         governance_metadata: {
-          automation_context: 'lifecycle-sd-bridge: automated SD creation from venture pipeline Stage 19 sprint planning',
+          automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated SD creation from venture pipeline Stage 19 sprint planning' },
         },
         metadata: {
           ...provenance,
@@ -236,7 +236,7 @@ export async function convertSprintToSDs(params, deps = {}) {
             typeof r === 'string' ? { risk: r, mitigation: 'TBD' } : r,
           ),
           governance_metadata: {
-            automation_context: 'lifecycle-sd-bridge: automated child SD from venture pipeline sprint decomposition',
+            automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated child SD from venture pipeline sprint decomposition' },
           },
           metadata: {
             ...provenance,
@@ -357,7 +357,7 @@ async function createGrandchildren({
         smoke_test_steps: [],
         risks: [],
         governance_metadata: {
-          automation_context: 'lifecycle-sd-bridge: automated grandchild SD from architecture-layer decomposition',
+          automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated grandchild SD from architecture-layer decomposition' },
         },
         metadata: {
           ...provenance,
@@ -561,7 +561,7 @@ export async function convertExpansionToSD(params, deps = {}) {
       smoke_test_steps: [],
       risks: [],
       governance_metadata: {
-        automation_context: 'lifecycle-sd-bridge: automated expansion SD from venture post-lifecycle EXPAND decision',
+        automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated expansion SD from venture post-lifecycle EXPAND decision' },
       },
       metadata: {
         ...provenance,


### PR DESCRIPTION
## Summary
- Changed `automation_context` from plain string to structured object with `bypass_governance`, `actor_role`, and `bypass_reason`
- All 4 INSERT locations updated

## Context
`is_valid_automation_bypass()` requires `{bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR'}` but the bridge passed a plain string. Grandchild SD creation failed with `SD_TYPE_CHANGE_EXPLANATION_REQUIRED`.

## Test plan
- [ ] Reset CodeGuardian CI to Stage 19, verify full hierarchy created (orchestrator + children + grandchildren)

🤖 Generated with [Claude Code](https://claude.com/claude-code)