### PR TITLE
fix: add bypass_reason at top level of governance_metadata

### DIFF
--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -176,6 +176,7 @@ export async function convertSprintToSDs(params, deps = {}) {
         smoke_test_steps: [],
         risks: [],
         governance_metadata: {
+          bypass_reason: 'lifecycle-sd-bridge: automated SD creation from venture pipeline Stage 19 sprint planning',
           automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated SD creation from venture pipeline Stage 19 sprint planning' },
         },
         metadata: {
@@ -236,7 +237,8 @@ export async function convertSprintToSDs(params, deps = {}) {
             typeof r === 'string' ? { risk: r, mitigation: 'TBD' } : r,
           ),
           governance_metadata: {
-            automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated child SD from venture pipeline sprint decomposition' },
+            bypass_reason: 'lifecycle-sd-bridge: automated child SD from venture pipeline sprint decomposition',
+          automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated child SD from venture pipeline sprint decomposition' },
           },
           metadata: {
             ...provenance,
@@ -357,6 +359,7 @@ async function createGrandchildren({
         smoke_test_steps: [],
         risks: [],
         governance_metadata: {
+          bypass_reason: 'lifecycle-sd-bridge: automated grandchild SD from architecture-layer decomposition',
           automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated grandchild SD from architecture-layer decomposition' },
         },
         metadata: {
@@ -561,6 +564,7 @@ export async function convertExpansionToSD(params, deps = {}) {
       smoke_test_steps: [],
       risks: [],
       governance_metadata: {
+        bypass_reason: 'lifecycle-sd-bridge: automated expansion SD from venture post-lifecycle EXPAND decision',
         automation_context: { bypass_governance: true, actor_role: 'LEO_ORCHESTRATOR', bypass_reason: 'lifecycle-sd-bridge: automated expansion SD from venture post-lifecycle EXPAND decision' },
       },
       metadata: {


### PR DESCRIPTION
## Summary
- Added `bypass_reason` at top level of `governance_metadata` (alongside `automation_context`)
- Two governance triggers check different paths: one reads `automation_context.bypass_governance`, the other reads `governance_metadata.bypass_reason`

## Test plan
- [ ] Reset CodeGuardian CI to Stage 19, verify full SD hierarchy created without type change errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)