### PR TITLE
fix: master reset uses service-role client for RPC

### DIFF
--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -371,7 +371,12 @@ router.post('/competitor-analysis', asyncHandler(async (req, res) => {
 // ── Master Reset with Repo + Registry Cleanup ──────────────────────
 // SD-LEO-INFRA-BRIDGE-ARTIFACT-ENRICHMENT-001 (extended cleanup)
 router.post('/master-reset', asyncHandler(async (req, res) => {
-  const supabase = dbLoader.supabase;
+  // Use service-role client for admin operations (RPC requires service_role or chairman)
+  const { createClient } = await import('@supabase/supabase-js');
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
 
   // Phase 1: Collect venture repo info BEFORE deletion
   const { data: provisioningRows } = await supabase


### PR DESCRIPTION
## Summary
- Root cause: `dbLoader.supabase` uses anon key, but `master_reset_portfolio` RPC requires `service_role`
- Fix: create inline service-role client for the master-reset endpoint only

## Test plan
- [ ] POST /api/ventures/master-reset returns 200 with count

🤖 Generated with [Claude Code](https://claude.com/claude-code)