### PR TITLE
feat(SD-A3): CodeGuardian CI mock UI layer

### DIFF
--- a/services/codeguardian-mock/src/index.js
+++ b/services/codeguardian-mock/src/index.js
@@ -1,8 +1,11 @@
 import express from 'express';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { config } from './config.js';
 import analysesRouter from './routes/analyses.js';
 import webhooksRouter from './routes/webhooks.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const app = express();
 app.use(express.json());
 
@@ -12,6 +15,7 @@ app.get('/health', (_req, res) => {
 
 app.use('/api/analyses', analysesRouter);
 app.use('/webhooks', webhooksRouter);
+app.use('/ui', express.static(join(__dirname, '..', 'ui')));
 
 app.use((_req, res) => {
   res.status(404).json({ error: 'Not found' });

--- a/services/codeguardian-mock/tests/ui.test.js
+++ b/services/codeguardian-mock/tests/ui.test.js
@@ -1,0 +1,113 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+let app, server;
+
+async function req(path) {
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}${path}`);
+  return { status: res.status, text: await res.text(), headers: res.headers };
+}
+
+before(async () => {
+  process.env.MOCK_PORT = '0';
+  const mod = await import('../src/index.js');
+  app = mod.app;
+  server = mod.server;
+});
+
+after(() => { server?.close(); });
+
+describe('Mock Data Module', () => {
+  it('exports repos, orgs, findings, and utility functions', async () => {
+    const data = await import('../ui/js/mock-data.js');
+    assert.ok(Array.isArray(data.orgs), 'orgs is array');
+    assert.ok(data.orgs.length >= 3, '3+ orgs');
+    assert.ok(Array.isArray(data.repos), 'repos is array');
+    assert.ok(data.repos.length >= 5, '5+ repos');
+    assert.ok(Array.isArray(data.findings), 'findings is array');
+    assert.ok(data.findings.length >= 20, '20+ findings');
+    assert.equal(typeof data.getMetrics, 'function');
+    assert.equal(typeof data.getFindingsForRepo, 'function');
+    assert.equal(typeof data.getReposForOrg, 'function');
+  });
+
+  it('getMetrics returns correct counts', async () => {
+    const { getMetrics } = await import('../ui/js/mock-data.js');
+    const m = getMetrics();
+    assert.ok(m.total > 0);
+    assert.equal(m.passing + m.failing + m.pending, m.total);
+    assert.ok(m.totalFindings > 0);
+  });
+
+  it('getFindingsForRepo returns findings for a known repo', async () => {
+    const { getFindingsForRepo } = await import('../ui/js/mock-data.js');
+    const f = getFindingsForRepo('r2');
+    assert.ok(f.length > 0, 'r2 has findings');
+    assert.ok(f.every(item => item.repo_id === 'r2'));
+  });
+
+  it('getReposForOrg returns repos for a known org', async () => {
+    const { getReposForOrg } = await import('../ui/js/mock-data.js');
+    const r = getReposForOrg('org-1');
+    assert.ok(r.length > 0, 'org-1 has repos');
+    assert.ok(r.every(item => item.org_id === 'org-1'));
+  });
+});
+
+describe('UI Static Files', () => {
+  it('serves dashboard.html', async () => {
+    const res = await req('/ui/dashboard.html');
+    assert.equal(res.status, 200);
+    assert.ok(res.text.includes('Dashboard'));
+    assert.ok(res.text.includes('CodeGuardian CI'));
+  });
+
+  it('serves onboarding.html', async () => {
+    const res = await req('/ui/onboarding.html');
+    assert.equal(res.status, 200);
+    assert.ok(res.text.includes('Get Started'));
+  });
+
+  it('serves results.html', async () => {
+    const res = await req('/ui/results.html');
+    assert.equal(res.status, 200);
+    assert.ok(res.text.includes('Scan Results'));
+  });
+
+  it('serves CSS file', async () => {
+    const res = await req('/ui/css/styles.css');
+    assert.equal(res.status, 200);
+    assert.ok(res.text.includes('--bg:'));
+  });
+
+  it('serves mock-data.js', async () => {
+    const res = await req('/ui/js/mock-data.js');
+    assert.equal(res.status, 200);
+    assert.ok(res.text.includes('export const repos'));
+  });
+});
+
+describe('Findings Data Quality', () => {
+  it('all findings have required fields', async () => {
+    const { findings } = await import('../ui/js/mock-data.js');
+    for (const f of findings) {
+      assert.ok(f.id, 'finding has id');
+      assert.ok(f.repo_id, 'finding has repo_id');
+      assert.ok(['critical', 'high', 'medium', 'low'].includes(f.severity), `valid severity: ${f.severity}`);
+      assert.ok(f.title, 'finding has title');
+      assert.ok(f.file, 'finding has file');
+      assert.ok(typeof f.line === 'number', 'finding has line number');
+      assert.ok(f.description, 'finding has description');
+    }
+  });
+
+  it('findings cover all severity levels', async () => {
+    const { findings } = await import('../ui/js/mock-data.js');
+    const severities = new Set(findings.map(f => f.severity));
+    assert.ok(severities.has('critical'));
+    assert.ok(severities.has('high'));
+    assert.ok(severities.has('medium'));
+    assert.ok(severities.has('low'));
+  });
+});

--- a/services/codeguardian-mock/ui/css/styles.css
+++ b/services/codeguardian-mock/ui/css/styles.css
@@ -1,0 +1,64 @@
+:root { --bg: #0d1117; --surface: #161b22; --border: #30363d; --text: #e6edf3; --muted: #8b949e; --green: #3fb950; --red: #f85149; --yellow: #d29922; --blue: #58a6ff; }
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--bg); color: var(--text); line-height: 1.5; }
+.container { max-width: 1200px; margin: 0 auto; padding: 24px; }
+h1 { font-size: 24px; margin-bottom: 24px; }
+h2 { font-size: 18px; margin-bottom: 16px; color: var(--muted); }
+
+/* Metrics */
+.metrics { display: flex; gap: 16px; margin-bottom: 32px; flex-wrap: wrap; }
+.metric-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px 24px; min-width: 140px; }
+.metric-card .value { font-size: 32px; font-weight: 700; }
+.metric-card .label { font-size: 13px; color: var(--muted); }
+.metric-card.critical .value { color: var(--red); }
+.metric-card.passing .value { color: var(--green); }
+
+/* Repo Grid */
+.repo-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 16px; }
+.repo-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 20px; }
+.repo-card h3 { font-size: 16px; margin-bottom: 8px; }
+.repo-card .meta { display: flex; gap: 12px; color: var(--muted); font-size: 13px; }
+.badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 12px; font-weight: 600; }
+.badge.passing { background: rgba(63,185,80,0.15); color: var(--green); }
+.badge.failing { background: rgba(248,81,73,0.15); color: var(--red); }
+.badge.pending { background: rgba(210,153,34,0.15); color: var(--yellow); }
+.findings-summary { margin-top: 12px; display: flex; gap: 8px; font-size: 12px; }
+.findings-summary span { padding: 2px 6px; border-radius: 4px; }
+.sev-critical { background: rgba(248,81,73,0.15); color: var(--red); }
+.sev-high { background: rgba(210,153,34,0.15); color: var(--yellow); }
+.sev-medium { background: rgba(88,166,255,0.15); color: var(--blue); }
+.sev-low { background: rgba(139,148,158,0.15); color: var(--muted); }
+
+/* Wizard */
+.wizard { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 32px; max-width: 600px; margin: 0 auto; }
+.wizard .steps { display: flex; gap: 8px; margin-bottom: 24px; }
+.wizard .step { flex: 1; height: 4px; border-radius: 2px; background: var(--border); }
+.wizard .step.active { background: var(--blue); }
+.wizard .step.done { background: var(--green); }
+.option-list { list-style: none; }
+.option-list li { padding: 12px 16px; border: 1px solid var(--border); border-radius: 6px; margin-bottom: 8px; cursor: pointer; }
+.option-list li:hover, .option-list li.selected { border-color: var(--blue); background: rgba(88,166,255,0.08); }
+.btn { display: inline-block; padding: 8px 20px; border-radius: 6px; border: none; font-size: 14px; cursor: pointer; background: var(--blue); color: #fff; }
+.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-row { display: flex; justify-content: flex-end; gap: 8px; margin-top: 24px; }
+
+/* Results */
+.severity-group { margin-bottom: 24px; }
+.severity-group h3 { font-size: 14px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 8px; }
+.finding { background: var(--surface); border: 1px solid var(--border); border-radius: 6px; padding: 12px 16px; margin-bottom: 6px; cursor: pointer; }
+.finding .title { font-weight: 600; font-size: 14px; }
+.finding .location { color: var(--muted); font-size: 12px; }
+.finding .details { display: none; margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--border); font-size: 13px; color: var(--muted); }
+.finding.expanded .details { display: block; }
+
+/* Nav */
+nav { background: var(--surface); border-bottom: 1px solid var(--border); padding: 12px 24px; display: flex; gap: 24px; align-items: center; }
+nav a { color: var(--muted); text-decoration: none; font-size: 14px; }
+nav a:hover, nav a.active { color: var(--text); }
+nav .brand { font-weight: 700; color: var(--text); font-size: 16px; }
+
+@media (max-width: 768px) {
+  .repo-grid { grid-template-columns: 1fr; }
+  .metrics { flex-direction: column; }
+  .metric-card { min-width: auto; }
+}

--- a/services/codeguardian-mock/ui/dashboard.html
+++ b/services/codeguardian-mock/ui/dashboard.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CodeGuardian CI - Dashboard</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <nav>
+    <span class="brand">CodeGuardian CI</span>
+    <a href="dashboard.html" class="active">Dashboard</a>
+    <a href="onboarding.html">Setup</a>
+    <a href="results.html">Results</a>
+  </nav>
+  <div class="container">
+    <h1>Dashboard</h1>
+    <div class="metrics" id="metrics"></div>
+    <h2>Repositories</h2>
+    <div class="repo-grid" id="repo-grid"></div>
+  </div>
+  <script type="module">
+    import { repos, getMetrics } from './js/mock-data.js';
+    const m = getMetrics();
+    document.getElementById('metrics').innerHTML = `
+      <div class="metric-card"><div class="value">${m.total}</div><div class="label">Total Repos</div></div>
+      <div class="metric-card passing"><div class="value">${m.passing}</div><div class="label">Passing</div></div>
+      <div class="metric-card critical"><div class="value">${m.failing}</div><div class="label">Failing</div></div>
+      <div class="metric-card"><div class="value">${m.pending}</div><div class="label">Pending</div></div>
+      <div class="metric-card critical"><div class="value">${m.critical}</div><div class="label">Critical Findings</div></div>
+    `;
+    const grid = document.getElementById('repo-grid');
+    grid.innerHTML = repos.map(r => {
+      const f = r.findings;
+      const total = f.critical + f.high + f.medium + f.low;
+      const time = r.last_scan ? new Date(r.last_scan).toLocaleString() : 'Never';
+      return `<div class="repo-card">
+        <h3>${r.name} <span class="badge ${r.status}">${r.status}</span></h3>
+        <div class="meta"><span>Last scan: ${time}</span><span>${total} findings</span></div>
+        <div class="findings-summary">
+          ${f.critical ? `<span class="sev-critical">${f.critical} critical</span>` : ''}
+          ${f.high ? `<span class="sev-high">${f.high} high</span>` : ''}
+          ${f.medium ? `<span class="sev-medium">${f.medium} medium</span>` : ''}
+          ${f.low ? `<span class="sev-low">${f.low} low</span>` : ''}
+        </div>
+      </div>`;
+    }).join('');
+  </script>
+</body>
+</html>

--- a/services/codeguardian-mock/ui/js/mock-data.js
+++ b/services/codeguardian-mock/ui/js/mock-data.js
@@ -1,0 +1,58 @@
+export const orgs = [
+  { id: 'org-1', name: 'Acme Corp', repos_count: 12 },
+  { id: 'org-2', name: 'TechStart Inc', repos_count: 5 },
+  { id: 'org-3', name: 'DevOps Labs', repos_count: 8 }
+];
+
+export const repos = [
+  { id: 'r1', name: 'api-gateway', org_id: 'org-1', status: 'passing', last_scan: '2026-03-28T10:00:00Z', findings: { critical: 0, high: 0, medium: 2, low: 5 } },
+  { id: 'r2', name: 'auth-service', org_id: 'org-1', status: 'failing', last_scan: '2026-03-28T09:30:00Z', findings: { critical: 2, high: 3, medium: 1, low: 0 } },
+  { id: 'r3', name: 'web-frontend', org_id: 'org-1', status: 'passing', last_scan: '2026-03-28T08:00:00Z', findings: { critical: 0, high: 0, medium: 0, low: 3 } },
+  { id: 'r4', name: 'data-pipeline', org_id: 'org-2', status: 'pending', last_scan: null, findings: { critical: 0, high: 0, medium: 0, low: 0 } },
+  { id: 'r5', name: 'mobile-app', org_id: 'org-2', status: 'failing', last_scan: '2026-03-27T22:00:00Z', findings: { critical: 1, high: 2, medium: 4, low: 8 } },
+  { id: 'r6', name: 'infra-terraform', org_id: 'org-3', status: 'passing', last_scan: '2026-03-28T11:00:00Z', findings: { critical: 0, high: 1, medium: 0, low: 2 } }
+];
+
+export const findings = [
+  { id: 'f1', repo_id: 'r2', severity: 'critical', title: 'SQL Injection in login handler', file: 'src/auth/login.js', line: 42, description: 'User input passed directly to SQL query without parameterization.' },
+  { id: 'f2', repo_id: 'r2', severity: 'critical', title: 'Hardcoded API key in config', file: 'src/config/keys.js', line: 8, description: 'Production API key committed to source code.' },
+  { id: 'f3', repo_id: 'r2', severity: 'high', title: 'Missing rate limiting on auth endpoints', file: 'src/routes/auth.js', line: 15, description: 'Authentication endpoints lack rate limiting, vulnerable to brute force.' },
+  { id: 'f4', repo_id: 'r2', severity: 'high', title: 'Weak password hashing algorithm', file: 'src/auth/hash.js', line: 23, description: 'Using MD5 instead of bcrypt for password hashing.' },
+  { id: 'f5', repo_id: 'r2', severity: 'high', title: 'CORS wildcard in production', file: 'src/middleware/cors.js', line: 5, description: 'Access-Control-Allow-Origin set to * in production config.' },
+  { id: 'f6', repo_id: 'r2', severity: 'medium', title: 'Deprecated dependency detected', file: 'package.json', line: 12, description: 'express-validator@4 is deprecated, upgrade to v7.' },
+  { id: 'f7', repo_id: 'r5', severity: 'critical', title: 'Insecure data storage on device', file: 'src/storage/local.kt', line: 67, description: 'Sensitive user tokens stored in SharedPreferences without encryption.' },
+  { id: 'f8', repo_id: 'r5', severity: 'high', title: 'Certificate pinning not implemented', file: 'src/network/client.kt', line: 12, description: 'HTTPS connections do not verify server certificate pins.' },
+  { id: 'f9', repo_id: 'r5', severity: 'high', title: 'Debug logging in production build', file: 'src/utils/logger.kt', line: 3, description: 'Verbose logging enabled in release builds, leaking sensitive data.' },
+  { id: 'f10', repo_id: 'r5', severity: 'medium', title: 'Missing input validation on forms', file: 'src/ui/forms/LoginForm.kt', line: 45, description: 'Email and password fields accept any input without validation.' },
+  { id: 'f11', repo_id: 'r5', severity: 'medium', title: 'Unused permissions in manifest', file: 'AndroidManifest.xml', line: 8, description: 'Camera and location permissions declared but not used.' },
+  { id: 'f12', repo_id: 'r5', severity: 'medium', title: 'Memory leak in activity lifecycle', file: 'src/ui/MainActivity.kt', line: 89, description: 'Static reference to activity context prevents garbage collection.' },
+  { id: 'f13', repo_id: 'r5', severity: 'medium', title: 'Hardcoded strings', file: 'src/ui/screens/HomeScreen.kt', line: 20, description: 'UI strings hardcoded instead of using resources/i18n.' },
+  { id: 'f14', repo_id: 'r5', severity: 'low', title: 'Inconsistent naming conventions', file: 'src/models/User.kt', line: 1, description: 'Class uses camelCase for properties instead of project convention.' },
+  { id: 'f15', repo_id: 'r5', severity: 'low', title: 'Missing KDoc comments', file: 'src/api/ApiService.kt', line: 1, description: 'Public API methods lack documentation comments.' },
+  { id: 'f16', repo_id: 'r5', severity: 'low', title: 'Redundant null checks', file: 'src/utils/Extensions.kt', line: 34, description: 'Non-nullable type checked for null unnecessarily.' },
+  { id: 'f17', repo_id: 'r1', severity: 'medium', title: 'Request timeout not configured', file: 'src/proxy/handler.js', line: 55, description: 'Upstream service requests have no timeout, may hang indefinitely.' },
+  { id: 'f18', repo_id: 'r1', severity: 'medium', title: 'Missing health check endpoint docs', file: 'src/routes/health.js', line: 1, description: 'Health check endpoint not documented in OpenAPI spec.' },
+  { id: 'f19', repo_id: 'r1', severity: 'low', title: 'Console.log in production code', file: 'src/middleware/logger.js', line: 12, description: 'Debug console.log statements left in production code.' },
+  { id: 'f20', repo_id: 'r6', severity: 'high', title: 'Overly permissive IAM policy', file: 'modules/iam/main.tf', line: 23, description: 'IAM role grants * permissions on S3 bucket.' },
+  { id: 'f21', repo_id: 'r3', severity: 'low', title: 'Unused CSS classes', file: 'src/styles/main.css', line: 145, description: '15 CSS classes defined but never referenced in components.' },
+  { id: 'f22', repo_id: 'r3', severity: 'low', title: 'Missing alt text on images', file: 'src/components/Hero.tsx', line: 28, description: 'Decorative images missing aria-hidden or alt text.' },
+  { id: 'f23', repo_id: 'r3', severity: 'low', title: 'Bundle size warning', file: 'webpack.config.js', line: 1, description: 'Main bundle exceeds 250KB recommended limit (312KB).' }
+];
+
+export function getMetrics() {
+  const total = repos.length;
+  const passing = repos.filter(r => r.status === 'passing').length;
+  const failing = repos.filter(r => r.status === 'failing').length;
+  const pending = repos.filter(r => r.status === 'pending').length;
+  const totalFindings = findings.length;
+  const critical = findings.filter(f => f.severity === 'critical').length;
+  return { total, passing, failing, pending, totalFindings, critical };
+}
+
+export function getFindingsForRepo(repoId) {
+  return findings.filter(f => f.repo_id === repoId);
+}
+
+export function getReposForOrg(orgId) {
+  return repos.filter(r => r.org_id === orgId);
+}

--- a/services/codeguardian-mock/ui/onboarding.html
+++ b/services/codeguardian-mock/ui/onboarding.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CodeGuardian CI - Setup</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <nav>
+    <span class="brand">CodeGuardian CI</span>
+    <a href="dashboard.html">Dashboard</a>
+    <a href="onboarding.html" class="active">Setup</a>
+    <a href="results.html">Results</a>
+  </nav>
+  <div class="container">
+    <h1>Get Started</h1>
+    <div class="wizard" id="wizard"></div>
+  </div>
+  <script type="module">
+    import { orgs, getReposForOrg } from './js/mock-data.js';
+    let step = 1, selectedOrg = null, selectedRepos = new Set();
+
+    function render() {
+      const steps = `<div class="steps">
+        <div class="step ${step >= 1 ? (step > 1 ? 'done' : 'active') : ''}"></div>
+        <div class="step ${step >= 2 ? (step > 2 ? 'done' : 'active') : ''}"></div>
+        <div class="step ${step >= 3 ? 'active' : ''}"></div>
+      </div>`;
+
+      let content = '';
+      if (step === 1) {
+        content = `<h2>Select Organization</h2>
+          <ul class="option-list">${orgs.map(o =>
+            `<li data-id="${o.id}" class="${selectedOrg === o.id ? 'selected' : ''}">${o.name} <span style="color:var(--muted)">(${o.repos_count} repos)</span></li>`
+          ).join('')}</ul>
+          <div class="btn-row"><button class="btn" ${!selectedOrg ? 'disabled' : ''} id="next">Next</button></div>`;
+      } else if (step === 2) {
+        const repos = getReposForOrg(selectedOrg);
+        content = `<h2>Select Repositories</h2>
+          <ul class="option-list">${repos.map(r =>
+            `<li data-id="${r.id}" class="${selectedRepos.has(r.id) ? 'selected' : ''}">${r.name}</li>`
+          ).join('')}</ul>
+          <div class="btn-row"><button class="btn" style="background:var(--border)" id="back">Back</button><button class="btn" ${selectedRepos.size === 0 ? 'disabled' : ''} id="next">Next</button></div>`;
+      } else {
+        const orgName = orgs.find(o => o.id === selectedOrg).name;
+        content = `<h2>Confirm Setup</h2>
+          <p style="margin-bottom:16px">Organization: <strong>${orgName}</strong></p>
+          <p style="margin-bottom:16px">Repositories: <strong>${selectedRepos.size}</strong> selected</p>
+          <ul style="list-style:disc;padding-left:20px;margin-bottom:16px;color:var(--muted)">${[...selectedRepos].map(id => {
+            const allRepos = getReposForOrg(selectedOrg);
+            const r = allRepos.find(r => r.id === id);
+            return `<li>${r?.name || id}</li>`;
+          }).join('')}</ul>
+          <div class="btn-row"><button class="btn" style="background:var(--border)" id="back">Back</button><button class="btn" id="confirm">Start Scanning</button></div>`;
+      }
+      document.getElementById('wizard').innerHTML = steps + content;
+      attachHandlers();
+    }
+
+    function attachHandlers() {
+      document.querySelectorAll('.option-list li').forEach(li => {
+        li.addEventListener('click', () => {
+          const id = li.dataset.id;
+          if (step === 1) { selectedOrg = id; selectedRepos.clear(); }
+          else if (step === 2) { selectedRepos.has(id) ? selectedRepos.delete(id) : selectedRepos.add(id); }
+          render();
+        });
+      });
+      document.getElementById('next')?.addEventListener('click', () => { step++; render(); });
+      document.getElementById('back')?.addEventListener('click', () => { step--; render(); });
+      document.getElementById('confirm')?.addEventListener('click', () => { window.location.href = 'dashboard.html'; });
+    }
+    render();
+  </script>
+</body>
+</html>

--- a/services/codeguardian-mock/ui/results.html
+++ b/services/codeguardian-mock/ui/results.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CodeGuardian CI - Results</title>
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <nav>
+    <span class="brand">CodeGuardian CI</span>
+    <a href="dashboard.html">Dashboard</a>
+    <a href="onboarding.html">Setup</a>
+    <a href="results.html" class="active">Results</a>
+  </nav>
+  <div class="container">
+    <h1>Scan Results</h1>
+    <div style="margin-bottom:24px">
+      <select id="repo-select" style="background:var(--surface);color:var(--text);border:1px solid var(--border);padding:8px 12px;border-radius:6px;font-size:14px"></select>
+    </div>
+    <div id="results"></div>
+  </div>
+  <script type="module">
+    import { repos, getFindingsForRepo } from './js/mock-data.js';
+    const select = document.getElementById('repo-select');
+    select.innerHTML = repos.map(r => `<option value="${r.id}">${r.name} (${r.status})</option>`).join('');
+
+    function renderResults(repoId) {
+      const f = getFindingsForRepo(repoId);
+      const groups = { critical: [], high: [], medium: [], low: [] };
+      f.forEach(item => groups[item.severity]?.push(item));
+
+      const html = Object.entries(groups)
+        .filter(([, items]) => items.length > 0)
+        .map(([sev, items]) => `
+          <div class="severity-group">
+            <h3><span class="sev-${sev}" style="padding:4px 10px;border-radius:4px">${sev} (${items.length})</span></h3>
+            ${items.map(i => `
+              <div class="finding" onclick="this.classList.toggle('expanded')">
+                <div class="title">${i.title}</div>
+                <div class="location">${i.file}:${i.line}</div>
+                <div class="details">${i.description}</div>
+              </div>
+            `).join('')}
+          </div>
+        `).join('');
+
+      document.getElementById('results').innerHTML = html || '<p style="color:var(--muted)">No findings for this repository.</p>';
+    }
+
+    select.addEventListener('change', () => renderResults(select.value));
+    renderResults(repos[0].id);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add UI layer for CodeGuardian CI mock service: dashboard, onboarding wizard, scan results
- Dark-themed dashboard with repo scan status cards, metrics summary, responsive grid layout
- 3-step onboarding wizard (org select -> repo picker -> confirm)
- Scan results display with severity grouping and expandable finding details
- Mock data module with 6 repos, 3 orgs, 23 findings across all severity levels
- All 11 tests pass (data module, static serving, data quality)

## Test plan
- [x] `node --test tests/ui.test.js` passes all 11 tests
- [x] Mock data module exports correct structure (3+ orgs, 5+ repos, 20+ findings)
- [x] Dashboard, onboarding, results pages served via /ui/
- [x] CSS and JS static files served correctly
- [x] All findings have required fields and cover all severity levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)