### PR TITLE
feat(SD-A1): CodeGuardian CI data layer

### DIFF
--- a/services/codeguardian-mock/src/data/repository.js
+++ b/services/codeguardian-mock/src/data/repository.js
@@ -1,0 +1,86 @@
+import { validate } from './validator.js';
+
+export class DataRepository {
+  constructor() {
+    this._orgs = new Map();
+    this._repos = new Map();
+    this._findings = new Map();
+  }
+
+  clear() {
+    this._orgs.clear();
+    this._repos.clear();
+    this._findings.clear();
+  }
+
+  // Organizations
+  addOrg(org) {
+    const { valid, errors } = validate('organization', org);
+    if (!valid) throw new Error(`Invalid organization: ${errors.join(', ')}`);
+    this._orgs.set(org.id, { ...org });
+    return org;
+  }
+
+  getOrg(id) { return this._orgs.get(id) || null; }
+  listOrgs() { return [...this._orgs.values()]; }
+
+  // Repositories
+  addRepo(repo) {
+    const { valid, errors } = validate('repository', repo);
+    if (!valid) throw new Error(`Invalid repository: ${errors.join(', ')}`);
+    if (repo.org_id && !this._orgs.has(repo.org_id)) {
+      throw new Error(`Organization not found: ${repo.org_id}`);
+    }
+    this._repos.set(repo.id, { ...repo });
+    return repo;
+  }
+
+  getRepo(id) { return this._repos.get(id) || null; }
+
+  listRepos({ org_id, status, limit, offset } = {}) {
+    let results = [...this._repos.values()];
+    if (org_id) results = results.filter(r => r.org_id === org_id);
+    if (status) results = results.filter(r => r.status === status);
+    if (offset) results = results.slice(offset);
+    if (limit) results = results.slice(0, limit);
+    return results;
+  }
+
+  // Findings
+  addFinding(finding) {
+    const { valid, errors } = validate('finding', finding);
+    if (!valid) throw new Error(`Invalid finding: ${errors.join(', ')}`);
+    if (!this._repos.has(finding.repo_id)) {
+      throw new Error(`Repository not found: ${finding.repo_id}`);
+    }
+    this._findings.set(finding.id, { ...finding });
+    return finding;
+  }
+
+  getFinding(id) { return this._findings.get(id) || null; }
+
+  listFindings({ repo_id, severity, limit, offset } = {}) {
+    let results = [...this._findings.values()];
+    if (repo_id) results = results.filter(f => f.repo_id === repo_id);
+    if (severity) results = results.filter(f => f.severity === severity);
+    if (offset) results = results.slice(offset);
+    if (limit) results = results.slice(0, limit);
+    return results;
+  }
+
+  // Export/Import
+  export() {
+    return {
+      organizations: this.listOrgs(),
+      repositories: this.listRepos(),
+      findings: this.listFindings()
+    };
+  }
+
+  import(data) {
+    this.clear();
+    (data.organizations || []).forEach(o => this.addOrg(o));
+    (data.repositories || []).forEach(r => this.addRepo(r));
+    (data.findings || []).forEach(f => this.addFinding(f));
+  }
+}

--- a/services/codeguardian-mock/src/data/schema.js
+++ b/services/codeguardian-mock/src/data/schema.js
@@ -1,0 +1,44 @@
+/**
+ * @typedef {Object} Organization
+ * @property {string} id
+ * @property {string} name
+ * @property {number} repos_count
+ */
+
+/**
+ * @typedef {'passing'|'failing'|'pending'} ScanStatus
+ */
+
+/**
+ * @typedef {Object} Repository
+ * @property {string} id
+ * @property {string} name
+ * @property {string} org_id
+ * @property {ScanStatus} status
+ * @property {string|null} last_scan - ISO 8601 timestamp
+ * @property {{critical:number, high:number, medium:number, low:number}} findings
+ */
+
+/**
+ * @typedef {'critical'|'high'|'medium'|'low'} Severity
+ */
+
+/**
+ * @typedef {Object} Finding
+ * @property {string} id
+ * @property {string} repo_id
+ * @property {Severity} severity
+ * @property {string} title
+ * @property {string} file
+ * @property {number} line
+ * @property {string} description
+ */
+
+export const VALID_STATUSES = ['passing', 'failing', 'pending'];
+export const VALID_SEVERITIES = ['critical', 'high', 'medium', 'low'];
+
+export const REQUIRED_FIELDS = {
+  organization: ['id', 'name', 'repos_count'],
+  repository: ['id', 'name', 'org_id', 'status', 'findings'],
+  finding: ['id', 'repo_id', 'severity', 'title', 'file', 'line', 'description']
+};

--- a/services/codeguardian-mock/src/data/seed.js
+++ b/services/codeguardian-mock/src/data/seed.js
@@ -1,0 +1,18 @@
+import { orgs, repos, findings } from '../../ui/js/mock-data.js';
+
+export function getSeedData() {
+  return {
+    organizations: [...orgs],
+    repositories: [...repos],
+    findings: [...findings]
+  };
+}
+
+export function seed(repository) {
+  const data = getSeedData();
+  repository.clear();
+  data.organizations.forEach(o => repository.addOrg(o));
+  data.repositories.forEach(r => repository.addRepo(r));
+  data.findings.forEach(f => repository.addFinding(f));
+  return data;
+}

--- a/services/codeguardian-mock/src/data/validator.js
+++ b/services/codeguardian-mock/src/data/validator.js
@@ -1,0 +1,29 @@
+import { VALID_STATUSES, VALID_SEVERITIES, REQUIRED_FIELDS } from './schema.js';
+
+export function validate(type, entity) {
+  const errors = [];
+  const required = REQUIRED_FIELDS[type];
+  if (!required) {
+    return { valid: false, errors: [`Unknown entity type: ${type}`] };
+  }
+
+  for (const field of required) {
+    if (entity[field] === undefined || entity[field] === null) {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+
+  if (type === 'repository' && entity.status && !VALID_STATUSES.includes(entity.status)) {
+    errors.push(`Invalid status: ${entity.status}. Must be one of: ${VALID_STATUSES.join(', ')}`);
+  }
+
+  if (type === 'finding' && entity.severity && !VALID_SEVERITIES.includes(entity.severity)) {
+    errors.push(`Invalid severity: ${entity.severity}. Must be one of: ${VALID_SEVERITIES.join(', ')}`);
+  }
+
+  if (type === 'finding' && entity.line !== undefined && typeof entity.line !== 'number') {
+    errors.push(`line must be a number, got: ${typeof entity.line}`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/services/codeguardian-mock/tests/data.test.js
+++ b/services/codeguardian-mock/tests/data.test.js
@@ -1,0 +1,153 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { DataRepository } from '../src/data/repository.js';
+import { validate } from '../src/data/validator.js';
+import { VALID_STATUSES, VALID_SEVERITIES, REQUIRED_FIELDS } from '../src/data/schema.js';
+import { seed, getSeedData } from '../src/data/seed.js';
+
+describe('Schema', () => {
+  it('exports valid statuses and severities', () => {
+    assert.deepEqual(VALID_STATUSES, ['passing', 'failing', 'pending']);
+    assert.deepEqual(VALID_SEVERITIES, ['critical', 'high', 'medium', 'low']);
+  });
+
+  it('defines required fields for all entity types', () => {
+    assert.ok(REQUIRED_FIELDS.organization.length > 0);
+    assert.ok(REQUIRED_FIELDS.repository.length > 0);
+    assert.ok(REQUIRED_FIELDS.finding.length > 0);
+  });
+});
+
+describe('Validator', () => {
+  it('passes valid organization', () => {
+    const result = validate('organization', { id: '1', name: 'Test', repos_count: 5 });
+    assert.equal(result.valid, true);
+  });
+
+  it('rejects organization missing fields', () => {
+    const result = validate('organization', { id: '1' });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.length > 0);
+  });
+
+  it('rejects invalid repository status', () => {
+    const result = validate('repository', { id: '1', name: 'r', org_id: 'o', status: 'invalid', findings: {} });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some(e => e.includes('Invalid status')));
+  });
+
+  it('rejects invalid finding severity', () => {
+    const result = validate('finding', { id: '1', repo_id: 'r', severity: 'urgent', title: 't', file: 'f', line: 1, description: 'd' });
+    assert.equal(result.valid, false);
+    assert.ok(result.errors.some(e => e.includes('Invalid severity')));
+  });
+
+  it('rejects non-numeric line in finding', () => {
+    const result = validate('finding', { id: '1', repo_id: 'r', severity: 'high', title: 't', file: 'f', line: 'abc', description: 'd' });
+    assert.equal(result.valid, false);
+  });
+
+  it('rejects unknown entity type', () => {
+    const result = validate('unknown', {});
+    assert.equal(result.valid, false);
+  });
+});
+
+describe('DataRepository', () => {
+  let repo;
+  beforeEach(() => { repo = new DataRepository(); });
+
+  it('adds and retrieves organizations', () => {
+    repo.addOrg({ id: 'o1', name: 'Org', repos_count: 3 });
+    assert.equal(repo.getOrg('o1').name, 'Org');
+    assert.equal(repo.listOrgs().length, 1);
+  });
+
+  it('adds and retrieves repositories', () => {
+    repo.addOrg({ id: 'o1', name: 'Org', repos_count: 1 });
+    repo.addRepo({ id: 'r1', name: 'Repo', org_id: 'o1', status: 'passing', findings: { critical: 0, high: 0, medium: 0, low: 0 } });
+    assert.equal(repo.getRepo('r1').name, 'Repo');
+  });
+
+  it('filters repos by org_id and status', () => {
+    repo.addOrg({ id: 'o1', name: 'Org', repos_count: 2 });
+    repo.addRepo({ id: 'r1', name: 'A', org_id: 'o1', status: 'passing', findings: {} });
+    repo.addRepo({ id: 'r2', name: 'B', org_id: 'o1', status: 'failing', findings: {} });
+    assert.equal(repo.listRepos({ org_id: 'o1' }).length, 2);
+    assert.equal(repo.listRepos({ status: 'failing' }).length, 1);
+  });
+
+  it('supports pagination', () => {
+    repo.addOrg({ id: 'o1', name: 'Org', repos_count: 3 });
+    for (let i = 0; i < 5; i++) repo.addRepo({ id: `r${i}`, name: `R${i}`, org_id: 'o1', status: 'passing', findings: {} });
+    assert.equal(repo.listRepos({ limit: 2 }).length, 2);
+    assert.equal(repo.listRepos({ offset: 3 }).length, 2);
+  });
+
+  it('rejects repo with invalid org_id', () => {
+    assert.throws(() => repo.addRepo({ id: 'r1', name: 'R', org_id: 'bad', status: 'passing', findings: {} }), /Organization not found/);
+  });
+
+  it('rejects finding with invalid repo_id', () => {
+    assert.throws(() => repo.addFinding({ id: 'f1', repo_id: 'bad', severity: 'high', title: 't', file: 'f', line: 1, description: 'd' }), /Repository not found/);
+  });
+
+  it('filters findings by repo_id and severity', () => {
+    repo.addOrg({ id: 'o1', name: 'Org', repos_count: 1 });
+    repo.addRepo({ id: 'r1', name: 'R', org_id: 'o1', status: 'failing', findings: {} });
+    repo.addFinding({ id: 'f1', repo_id: 'r1', severity: 'critical', title: 't1', file: 'a.js', line: 1, description: 'd' });
+    repo.addFinding({ id: 'f2', repo_id: 'r1', severity: 'low', title: 't2', file: 'b.js', line: 2, description: 'd' });
+    assert.equal(repo.listFindings({ severity: 'critical' }).length, 1);
+    assert.equal(repo.listFindings({ repo_id: 'r1' }).length, 2);
+  });
+
+  it('clears all data', () => {
+    repo.addOrg({ id: 'o1', name: 'Org', repos_count: 0 });
+    repo.clear();
+    assert.equal(repo.listOrgs().length, 0);
+  });
+});
+
+describe('Export/Import', () => {
+  it('round-trips data correctly', () => {
+    const repo = new DataRepository();
+    repo.addOrg({ id: 'o1', name: 'Org', repos_count: 1 });
+    repo.addRepo({ id: 'r1', name: 'R', org_id: 'o1', status: 'passing', findings: {} });
+    repo.addFinding({ id: 'f1', repo_id: 'r1', severity: 'high', title: 't', file: 'x.js', line: 10, description: 'd' });
+
+    const exported = repo.export();
+    const repo2 = new DataRepository();
+    repo2.import(exported);
+
+    assert.equal(repo2.listOrgs().length, 1);
+    assert.equal(repo2.listRepos().length, 1);
+    assert.equal(repo2.listFindings().length, 1);
+    assert.deepEqual(repo2.getOrg('o1').name, 'Org');
+  });
+});
+
+describe('Seed', () => {
+  it('provides complete seed data', () => {
+    const data = getSeedData();
+    assert.ok(data.organizations.length >= 3, '3+ orgs');
+    assert.ok(data.repositories.length >= 5, '5+ repos');
+    assert.ok(data.findings.length >= 20, '20+ findings');
+  });
+
+  it('seeds repository with consistent data', () => {
+    const repo = new DataRepository();
+    seed(repo);
+    assert.ok(repo.listOrgs().length >= 3);
+    assert.ok(repo.listRepos().length >= 5);
+    assert.ok(repo.listFindings().length >= 20);
+  });
+
+  it('is idempotent', () => {
+    const repo = new DataRepository();
+    seed(repo);
+    const count1 = repo.listRepos().length;
+    seed(repo);
+    const count2 = repo.listRepos().length;
+    assert.equal(count1, count2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add data layer for CodeGuardian CI mock service
- Schema definitions with JSDoc types for Organization, Repository, Finding entities
- Validator module with field/type enforcement and severity/status validation
- DataRepository class with CRUD, filtering (org_id, status, severity), and pagination
- Seed module reusing UI mock-data for consistency across layers
- JSON export/import with full round-trip support
- All 20 tests pass (schema, validation, CRUD, pagination, export/import, seeding)

## Test plan
- [x] `node --test tests/data.test.js` passes all 20 tests
- [x] Schema exports valid constants and required field definitions
- [x] Validator catches invalid statuses, severities, missing fields, wrong types
- [x] Repository enforces foreign key relationships (org -> repo -> finding)
- [x] Filtering and pagination return correct subsets
- [x] Export/import round-trips preserve all data
- [x] Seed is idempotent and consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)