### PR TITLE
feat(SD-B1): GitHub App OAuth data layer

### DIFF
--- a/services/codeguardian-mock/src/data/oauth-repository.js
+++ b/services/codeguardian-mock/src/data/oauth-repository.js
@@ -1,0 +1,134 @@
+import { VALID_PLANS, VALID_INSTALL_STATUSES, VALID_ROLES, OAUTH_REQUIRED_FIELDS } from './oauth-schema.js';
+
+function validateEntity(type, entity) {
+  const errors = [];
+  const required = OAUTH_REQUIRED_FIELDS[type];
+  if (!required) return { valid: false, errors: [`Unknown type: ${type}`] };
+
+  for (const field of required) {
+    if (entity[field] === undefined || entity[field] === null) {
+      errors.push(`Missing: ${field}`);
+    }
+  }
+
+  if (type === 'tenant' && entity.plan && !VALID_PLANS.includes(entity.plan)) {
+    errors.push(`Invalid plan: ${entity.plan}`);
+  }
+  if (type === 'installation' && entity.status && !VALID_INSTALL_STATUSES.includes(entity.status)) {
+    errors.push(`Invalid status: ${entity.status}`);
+  }
+  if (type === 'user_account' && entity.role && !VALID_ROLES.includes(entity.role)) {
+    errors.push(`Invalid role: ${entity.role}`);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export class OAuthRepository {
+  constructor() {
+    this._tenants = new Map();
+    this._installations = new Map();
+    this._users = new Map();
+  }
+
+  // Tenants
+  createTenant(tenant) {
+    const { valid, errors } = validateEntity('tenant', tenant);
+    if (!valid) throw new Error(`Invalid tenant: ${errors.join(', ')}`);
+    const record = { ...tenant, created_at: tenant.created_at || new Date().toISOString() };
+    this._tenants.set(tenant.id, record);
+    return record;
+  }
+
+  getTenant(id) { return this._tenants.get(id) || null; }
+  listTenants() { return [...this._tenants.values()]; }
+
+  updateTenant(id, updates) {
+    const existing = this._tenants.get(id);
+    if (!existing) throw new Error(`Tenant not found: ${id}`);
+    const updated = { ...existing, ...updates, id };
+    this._tenants.set(id, updated);
+    return updated;
+  }
+
+  deleteTenant(id) {
+    if (!this._tenants.has(id)) throw new Error(`Tenant not found: ${id}`);
+    this._tenants.delete(id);
+    // Cascade: remove installations and users
+    for (const [k, v] of this._installations) { if (v.tenant_id === id) this._installations.delete(k); }
+    for (const [k, v] of this._users) { if (v.tenant_id === id) this._users.delete(k); }
+  }
+
+  // Installations
+  createInstallation(installation) {
+    const { valid, errors } = validateEntity('installation', installation);
+    if (!valid) throw new Error(`Invalid installation: ${errors.join(', ')}`);
+    if (!this._tenants.has(installation.tenant_id)) {
+      throw new Error(`Tenant not found: ${installation.tenant_id}`);
+    }
+    const record = {
+      ...installation,
+      permissions: installation.permissions || [],
+      repos: installation.repos || [],
+      created_at: installation.created_at || new Date().toISOString()
+    };
+    this._installations.set(installation.id, record);
+    return record;
+  }
+
+  getInstallation(id) { return this._installations.get(id) || null; }
+
+  listInstallations({ tenant_id, status } = {}) {
+    let results = [...this._installations.values()];
+    if (tenant_id) results = results.filter(i => i.tenant_id === tenant_id);
+    if (status) results = results.filter(i => i.status === status);
+    return results;
+  }
+
+  updateInstallation(id, updates) {
+    const existing = this._installations.get(id);
+    if (!existing) throw new Error(`Installation not found: ${id}`);
+    const updated = { ...existing, ...updates, id };
+    this._installations.set(id, updated);
+    return updated;
+  }
+
+  deleteInstallation(id) {
+    if (!this._installations.has(id)) throw new Error(`Installation not found: ${id}`);
+    this._installations.delete(id);
+  }
+
+  // User Accounts
+  createUser(user) {
+    const { valid, errors } = validateEntity('user_account', user);
+    if (!valid) throw new Error(`Invalid user: ${errors.join(', ')}`);
+    if (!this._tenants.has(user.tenant_id)) {
+      throw new Error(`Tenant not found: ${user.tenant_id}`);
+    }
+    const record = { ...user, created_at: user.created_at || new Date().toISOString() };
+    this._users.set(user.id, record);
+    return record;
+  }
+
+  getUser(id) { return this._users.get(id) || null; }
+
+  listUsers({ tenant_id, role } = {}) {
+    let results = [...this._users.values()];
+    if (tenant_id) results = results.filter(u => u.tenant_id === tenant_id);
+    if (role) results = results.filter(u => u.role === role);
+    return results;
+  }
+
+  updateUser(id, updates) {
+    const existing = this._users.get(id);
+    if (!existing) throw new Error(`User not found: ${id}`);
+    const updated = { ...existing, ...updates, id };
+    this._users.set(id, updated);
+    return updated;
+  }
+
+  deleteUser(id) {
+    if (!this._users.has(id)) throw new Error(`User not found: ${id}`);
+    this._users.delete(id);
+  }
+}

--- a/services/codeguardian-mock/src/data/oauth-schema.js
+++ b/services/codeguardian-mock/src/data/oauth-schema.js
@@ -1,0 +1,39 @@
+/**
+ * @typedef {Object} Tenant
+ * @property {string} id
+ * @property {string} name
+ * @property {string} github_org_id
+ * @property {'free'|'pro'|'enterprise'} plan
+ * @property {string} created_at - ISO 8601
+ */
+
+/**
+ * @typedef {Object} GitHubInstallation
+ * @property {string} id
+ * @property {string} tenant_id
+ * @property {number} installation_id - GitHub's installation ID
+ * @property {string[]} permissions
+ * @property {string[]} repos - repository full names
+ * @property {'active'|'suspended'|'removed'} status
+ * @property {string} created_at
+ */
+
+/**
+ * @typedef {Object} UserAccount
+ * @property {string} id
+ * @property {string} tenant_id
+ * @property {string} github_user_id
+ * @property {string} email
+ * @property {'admin'|'member'|'viewer'} role
+ * @property {string} created_at
+ */
+
+export const VALID_PLANS = ['free', 'pro', 'enterprise'];
+export const VALID_INSTALL_STATUSES = ['active', 'suspended', 'removed'];
+export const VALID_ROLES = ['admin', 'member', 'viewer'];
+
+export const OAUTH_REQUIRED_FIELDS = {
+  tenant: ['id', 'name', 'github_org_id', 'plan'],
+  installation: ['id', 'tenant_id', 'installation_id', 'status'],
+  user_account: ['id', 'tenant_id', 'github_user_id', 'email', 'role']
+};

--- a/services/codeguardian-mock/tests/oauth-data.test.js
+++ b/services/codeguardian-mock/tests/oauth-data.test.js
@@ -1,0 +1,156 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { OAuthRepository } from '../src/data/oauth-repository.js';
+import { VALID_PLANS, VALID_ROLES, VALID_INSTALL_STATUSES } from '../src/data/oauth-schema.js';
+
+const TENANT = { id: 't1', name: 'Acme', github_org_id: 'acme-org', plan: 'pro' };
+const INSTALL = { id: 'i1', tenant_id: 't1', installation_id: 12345, status: 'active', permissions: ['read'], repos: ['acme/api'] };
+const USER = { id: 'u1', tenant_id: 't1', github_user_id: 'gh-user-1', email: 'dev@acme.com', role: 'admin' };
+
+describe('Schema Constants', () => {
+  it('exports valid enums', () => {
+    assert.deepEqual(VALID_PLANS, ['free', 'pro', 'enterprise']);
+    assert.deepEqual(VALID_ROLES, ['admin', 'member', 'viewer']);
+    assert.deepEqual(VALID_INSTALL_STATUSES, ['active', 'suspended', 'removed']);
+  });
+});
+
+describe('Tenant CRUD', () => {
+  let repo;
+  beforeEach(() => { repo = new OAuthRepository(); });
+
+  it('creates and retrieves tenant', () => {
+    const t = repo.createTenant(TENANT);
+    assert.equal(t.name, 'Acme');
+    assert.ok(t.created_at);
+    assert.equal(repo.getTenant('t1').github_org_id, 'acme-org');
+  });
+
+  it('lists all tenants', () => {
+    repo.createTenant(TENANT);
+    repo.createTenant({ id: 't2', name: 'Beta', github_org_id: 'beta', plan: 'free' });
+    assert.equal(repo.listTenants().length, 2);
+  });
+
+  it('updates tenant', () => {
+    repo.createTenant(TENANT);
+    const updated = repo.updateTenant('t1', { plan: 'enterprise' });
+    assert.equal(updated.plan, 'enterprise');
+    assert.equal(updated.name, 'Acme');
+  });
+
+  it('deletes tenant and cascades', () => {
+    repo.createTenant(TENANT);
+    repo.createInstallation(INSTALL);
+    repo.createUser(USER);
+    repo.deleteTenant('t1');
+    assert.equal(repo.getTenant('t1'), null);
+    assert.equal(repo.listInstallations().length, 0);
+    assert.equal(repo.listUsers().length, 0);
+  });
+
+  it('rejects invalid plan', () => {
+    assert.throws(() => repo.createTenant({ ...TENANT, plan: 'invalid' }), /Invalid plan/);
+  });
+
+  it('rejects missing required fields', () => {
+    assert.throws(() => repo.createTenant({ id: 't1' }), /Missing/);
+  });
+});
+
+describe('Installation CRUD', () => {
+  let repo;
+  beforeEach(() => { repo = new OAuthRepository(); repo.createTenant(TENANT); });
+
+  it('creates installation linked to tenant', () => {
+    const inst = repo.createInstallation(INSTALL);
+    assert.equal(inst.tenant_id, 't1');
+    assert.equal(inst.installation_id, 12345);
+  });
+
+  it('rejects installation with invalid tenant_id', () => {
+    assert.throws(() => repo.createInstallation({ ...INSTALL, tenant_id: 'bad' }), /Tenant not found/);
+  });
+
+  it('filters by tenant_id and status', () => {
+    repo.createInstallation(INSTALL);
+    repo.createTenant({ id: 't2', name: 'B', github_org_id: 'b', plan: 'free' });
+    repo.createInstallation({ id: 'i2', tenant_id: 't2', installation_id: 999, status: 'suspended' });
+    assert.equal(repo.listInstallations({ tenant_id: 't1' }).length, 1);
+    assert.equal(repo.listInstallations({ status: 'suspended' }).length, 1);
+  });
+
+  it('updates installation', () => {
+    repo.createInstallation(INSTALL);
+    const updated = repo.updateInstallation('i1', { status: 'suspended' });
+    assert.equal(updated.status, 'suspended');
+  });
+
+  it('deletes installation', () => {
+    repo.createInstallation(INSTALL);
+    repo.deleteInstallation('i1');
+    assert.equal(repo.getInstallation('i1'), null);
+  });
+
+  it('rejects invalid status', () => {
+    assert.throws(() => repo.createInstallation({ ...INSTALL, status: 'invalid' }), /Invalid status/);
+  });
+});
+
+describe('User Account CRUD', () => {
+  let repo;
+  beforeEach(() => { repo = new OAuthRepository(); repo.createTenant(TENANT); });
+
+  it('creates user linked to tenant', () => {
+    const u = repo.createUser(USER);
+    assert.equal(u.tenant_id, 't1');
+    assert.equal(u.role, 'admin');
+  });
+
+  it('rejects user with invalid tenant_id', () => {
+    assert.throws(() => repo.createUser({ ...USER, tenant_id: 'bad' }), /Tenant not found/);
+  });
+
+  it('filters by tenant_id and role', () => {
+    repo.createUser(USER);
+    repo.createUser({ id: 'u2', tenant_id: 't1', github_user_id: 'gh-2', email: 'dev2@acme.com', role: 'member' });
+    assert.equal(repo.listUsers({ tenant_id: 't1' }).length, 2);
+    assert.equal(repo.listUsers({ role: 'admin' }).length, 1);
+  });
+
+  it('updates user', () => {
+    repo.createUser(USER);
+    const updated = repo.updateUser('u1', { role: 'viewer' });
+    assert.equal(updated.role, 'viewer');
+  });
+
+  it('deletes user', () => {
+    repo.createUser(USER);
+    repo.deleteUser('u1');
+    assert.equal(repo.getUser('u1'), null);
+  });
+
+  it('rejects invalid role', () => {
+    assert.throws(() => repo.createUser({ ...USER, role: 'superadmin' }), /Invalid role/);
+  });
+});
+
+describe('Multi-Tenant Isolation', () => {
+  it('queries return only data for specified tenant', () => {
+    const repo = new OAuthRepository();
+    repo.createTenant({ id: 't1', name: 'A', github_org_id: 'a', plan: 'pro' });
+    repo.createTenant({ id: 't2', name: 'B', github_org_id: 'b', plan: 'free' });
+    repo.createInstallation({ id: 'i1', tenant_id: 't1', installation_id: 1, status: 'active' });
+    repo.createInstallation({ id: 'i2', tenant_id: 't2', installation_id: 2, status: 'active' });
+    repo.createUser({ id: 'u1', tenant_id: 't1', github_user_id: 'g1', email: 'a@a.com', role: 'admin' });
+    repo.createUser({ id: 'u2', tenant_id: 't2', github_user_id: 'g2', email: 'b@b.com', role: 'member' });
+
+    const t1Installs = repo.listInstallations({ tenant_id: 't1' });
+    const t2Users = repo.listUsers({ tenant_id: 't2' });
+
+    assert.equal(t1Installs.length, 1);
+    assert.equal(t1Installs[0].id, 'i1');
+    assert.equal(t2Users.length, 1);
+    assert.equal(t2Users[0].id, 'u2');
+  });
+});


### PR DESCRIPTION
## Summary
- Add multi-tenant OAuth data model for CodeGuardian CI
- Tenant, GitHubInstallation, UserAccount entities with full CRUD
- FK validation (installation/user must reference valid tenant)
- Cascade delete (tenant deletion removes installations and users)
- Enum validation for plans (free/pro/enterprise), roles, statuses
- Multi-tenant isolation via tenant_id filtering
- All 20 tests pass

## Test plan
- [x] `node --test tests/oauth-data.test.js` passes all 20 tests
- [x] Tenant CRUD with cascade delete
- [x] Installation CRUD with FK to tenant
- [x] User CRUD with FK to tenant and role validation
- [x] Multi-tenant isolation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)