### PR TITLE
feat(SD-C1): add webhook data layer for CodeGuardian CI

### DIFF
--- a/services/codeguardian-mock/src/data/webhook-repository.js
+++ b/services/codeguardian-mock/src/data/webhook-repository.js
@@ -1,0 +1,118 @@
+import { validateWebhook } from './webhook-validator.js';
+
+export class WebhookRepository {
+  constructor() {
+    this._deliveries = new Map();
+    this._pipelineRuns = new Map();
+    this._scanEvents = new Map();
+  }
+
+  clear() {
+    this._deliveries.clear();
+    this._pipelineRuns.clear();
+    this._scanEvents.clear();
+  }
+
+  // Deliveries
+  addDelivery(delivery) {
+    const { valid, errors } = validateWebhook('delivery', delivery);
+    if (!valid) throw new Error(`Invalid delivery: ${errors.join(', ')}`);
+    const record = { ...delivery, received_at: delivery.received_at || new Date().toISOString() };
+    this._deliveries.set(delivery.id, record);
+    return record;
+  }
+
+  getDelivery(id) { return this._deliveries.get(id) || null; }
+
+  listDeliveries({ event_type, sd_id, limit, offset } = {}) {
+    let results = [...this._deliveries.values()];
+    if (event_type) results = results.filter(d => d.event_type === event_type);
+    if (sd_id) results = results.filter(d => d.sd_id === sd_id);
+    if (offset) results = results.slice(offset);
+    if (limit) results = results.slice(0, limit);
+    return results;
+  }
+
+  updateDelivery(id, updates) {
+    const existing = this._deliveries.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...updates, id };
+    this._deliveries.set(id, updated);
+    return updated;
+  }
+
+  deleteDelivery(id) {
+    return this._deliveries.delete(id);
+  }
+
+  // Pipeline Runs
+  addPipelineRun(run) {
+    const { valid, errors } = validateWebhook('pipeline_run', run);
+    if (!valid) throw new Error(`Invalid pipeline run: ${errors.join(', ')}`);
+    this._pipelineRuns.set(run.id, { ...run });
+    return run;
+  }
+
+  getPipelineRun(id) { return this._pipelineRuns.get(id) || null; }
+
+  listPipelineRuns({ sd_id, status, repository_name, limit, offset } = {}) {
+    let results = [...this._pipelineRuns.values()];
+    if (sd_id) results = results.filter(r => r.sd_id === sd_id);
+    if (status) results = results.filter(r => r.status === status);
+    if (repository_name) results = results.filter(r => r.repository_name === repository_name);
+    if (offset) results = results.slice(offset);
+    if (limit) results = results.slice(0, limit);
+    return results;
+  }
+
+  updatePipelineRun(id, updates) {
+    const existing = this._pipelineRuns.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...updates, id };
+    this._pipelineRuns.set(id, updated);
+    return updated;
+  }
+
+  deletePipelineRun(id) {
+    return this._pipelineRuns.delete(id);
+  }
+
+  // Scan Events
+  addScanEvent(event) {
+    const { valid, errors } = validateWebhook('scan_event', event);
+    if (!valid) throw new Error(`Invalid scan event: ${errors.join(', ')}`);
+    if (!this._pipelineRuns.has(event.pipeline_run_id)) {
+      throw new Error(`Pipeline run not found: ${event.pipeline_run_id}`);
+    }
+    this._scanEvents.set(event.id, { ...event });
+    return event;
+  }
+
+  getScanEvent(id) { return this._scanEvents.get(id) || null; }
+
+  listScanEvents({ pipeline_run_id, scan_type, status, limit, offset } = {}) {
+    let results = [...this._scanEvents.values()];
+    if (pipeline_run_id) results = results.filter(e => e.pipeline_run_id === pipeline_run_id);
+    if (scan_type) results = results.filter(e => e.scan_type === scan_type);
+    if (status) results = results.filter(e => e.status === status);
+    if (offset) results = results.slice(offset);
+    if (limit) results = results.slice(0, limit);
+    return results;
+  }
+
+  // Export/Import
+  export() {
+    return {
+      deliveries: this.listDeliveries(),
+      pipelineRuns: this.listPipelineRuns(),
+      scanEvents: this.listScanEvents()
+    };
+  }
+
+  import(data) {
+    this.clear();
+    (data.deliveries || []).forEach(d => this.addDelivery(d));
+    (data.pipelineRuns || []).forEach(r => this.addPipelineRun(r));
+    (data.scanEvents || []).forEach(e => this.addScanEvent(e));
+  }
+}

--- a/services/codeguardian-mock/src/data/webhook-schema.js
+++ b/services/codeguardian-mock/src/data/webhook-schema.js
@@ -1,0 +1,71 @@
+/**
+ * @typedef {'push'|'pull_request'|'workflow_run'|'check_suite'|'deployment_status'} EventType
+ */
+
+/**
+ * @typedef {Object} WebhookDelivery
+ * @property {string} id
+ * @property {string} delivery_id
+ * @property {EventType} event_type
+ * @property {Object} payload
+ * @property {boolean} signature_valid
+ * @property {boolean} processed_successfully
+ * @property {string|null} sd_id
+ * @property {string} received_at - ISO 8601 timestamp
+ * @property {string|null} processed_at - ISO 8601 timestamp
+ */
+
+/**
+ * @typedef {'queued'|'in_progress'|'completed'|'failure'|'success'} PipelineStatus
+ */
+
+/**
+ * @typedef {'success'|'failure'|'neutral'|'cancelled'|'skipped'|'timed_out'|'action_required'|null} PipelineConclusion
+ */
+
+/**
+ * @typedef {Object} PipelineRun
+ * @property {string} id
+ * @property {string|null} sd_id
+ * @property {string} repository_name
+ * @property {string} workflow_name
+ * @property {string} run_id
+ * @property {string|null} commit_sha
+ * @property {PipelineStatus} status
+ * @property {PipelineConclusion} conclusion
+ * @property {string|null} started_at - ISO 8601 timestamp
+ * @property {string|null} completed_at - ISO 8601 timestamp
+ * @property {Object|null} job_details
+ */
+
+/**
+ * @typedef {'sast'|'dast'|'dependency'|'secret'|'license'|'container'} ScanType
+ */
+
+/**
+ * @typedef {'pending'|'running'|'completed'|'failed'} ScanStatus
+ */
+
+/**
+ * @typedef {Object} ScanEvent
+ * @property {string} id
+ * @property {string} pipeline_run_id
+ * @property {ScanType} scan_type
+ * @property {number} findings_count
+ * @property {{critical:number, high:number, medium:number, low:number}} severity_summary
+ * @property {string|null} started_at - ISO 8601 timestamp
+ * @property {string|null} completed_at - ISO 8601 timestamp
+ * @property {ScanStatus} status
+ */
+
+export const VALID_EVENT_TYPES = ['push', 'pull_request', 'workflow_run', 'check_suite', 'deployment_status'];
+export const VALID_PIPELINE_STATUSES = ['queued', 'in_progress', 'completed', 'failure', 'success'];
+export const VALID_CONCLUSIONS = ['success', 'failure', 'neutral', 'cancelled', 'skipped', 'timed_out', 'action_required'];
+export const VALID_SCAN_TYPES = ['sast', 'dast', 'dependency', 'secret', 'license', 'container'];
+export const VALID_SCAN_STATUSES = ['pending', 'running', 'completed', 'failed'];
+
+export const REQUIRED_FIELDS = {
+  delivery: ['id', 'delivery_id', 'event_type', 'payload', 'signature_valid'],
+  pipeline_run: ['id', 'repository_name', 'workflow_name', 'run_id', 'status'],
+  scan_event: ['id', 'pipeline_run_id', 'scan_type', 'findings_count', 'status']
+};

--- a/services/codeguardian-mock/src/data/webhook-seed.js
+++ b/services/codeguardian-mock/src/data/webhook-seed.js
@@ -1,0 +1,44 @@
+export function getSeedData() {
+  const deliveries = [
+    { id: 'del-001', delivery_id: 'gh-del-1001', event_type: 'push', payload: { ref: 'refs/heads/main', commits: [{ id: 'abc123' }] }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-001', received_at: '2026-03-28T10:00:00Z', processed_at: '2026-03-28T10:00:01Z' },
+    { id: 'del-002', delivery_id: 'gh-del-1002', event_type: 'pull_request', payload: { action: 'opened', number: 42 }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-001', received_at: '2026-03-28T10:05:00Z', processed_at: '2026-03-28T10:05:01Z' },
+    { id: 'del-003', delivery_id: 'gh-del-1003', event_type: 'workflow_run', payload: { action: 'completed', workflow_run: { id: 9001 } }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-002', received_at: '2026-03-28T10:10:00Z', processed_at: '2026-03-28T10:10:02Z' },
+    { id: 'del-004', delivery_id: 'gh-del-1004', event_type: 'check_suite', payload: { action: 'completed', check_suite: { id: 5001 } }, signature_valid: true, processed_successfully: false, sd_id: null, received_at: '2026-03-28T10:15:00Z', processed_at: null },
+    { id: 'del-005', delivery_id: 'gh-del-1005', event_type: 'push', payload: { ref: 'refs/heads/feature/auth', commits: [{ id: 'def456' }] }, signature_valid: false, processed_successfully: false, sd_id: null, received_at: '2026-03-28T10:20:00Z', processed_at: null },
+    { id: 'del-006', delivery_id: 'gh-del-1006', event_type: 'deployment_status', payload: { deployment: { id: 7001 }, state: 'success' }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-001', received_at: '2026-03-28T10:25:00Z', processed_at: '2026-03-28T10:25:01Z' },
+    { id: 'del-007', delivery_id: 'gh-del-1007', event_type: 'push', payload: { ref: 'refs/heads/main', commits: [{ id: 'ghi789' }] }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-003', received_at: '2026-03-28T10:30:00Z', processed_at: '2026-03-28T10:30:01Z' },
+    { id: 'del-008', delivery_id: 'gh-del-1008', event_type: 'pull_request', payload: { action: 'synchronize', number: 43 }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-002', received_at: '2026-03-28T10:35:00Z', processed_at: '2026-03-28T10:35:02Z' },
+    { id: 'del-009', delivery_id: 'gh-del-1009', event_type: 'workflow_run', payload: { action: 'requested', workflow_run: { id: 9002 } }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-003', received_at: '2026-03-28T10:40:00Z', processed_at: '2026-03-28T10:40:01Z' },
+    { id: 'del-010', delivery_id: 'gh-del-1010', event_type: 'push', payload: { ref: 'refs/heads/fix/hotfix', commits: [{ id: 'jkl012' }] }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-001', received_at: '2026-03-28T10:45:00Z', processed_at: '2026-03-28T10:45:01Z' },
+    { id: 'del-011', delivery_id: 'gh-del-1011', event_type: 'check_suite', payload: { action: 'requested', check_suite: { id: 5002 } }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-002', received_at: '2026-03-28T10:50:00Z', processed_at: '2026-03-28T10:50:01Z' },
+    { id: 'del-012', delivery_id: 'gh-del-1012', event_type: 'pull_request', payload: { action: 'closed', number: 44 }, signature_valid: true, processed_successfully: true, sd_id: 'SD-TEST-003', received_at: '2026-03-28T10:55:00Z', processed_at: '2026-03-28T10:55:01Z' }
+  ];
+
+  const pipelineRuns = [
+    { id: 'run-001', sd_id: 'SD-TEST-001', repository_name: 'rickfelix/ehg', workflow_name: 'CI', run_id: 'gh-run-2001', commit_sha: 'abc123def456', status: 'completed', conclusion: 'success', started_at: '2026-03-28T10:00:05Z', completed_at: '2026-03-28T10:03:00Z', job_details: { event: 'push', actor: 'rickfelix' } },
+    { id: 'run-002', sd_id: 'SD-TEST-001', repository_name: 'rickfelix/ehg', workflow_name: 'Deploy', run_id: 'gh-run-2002', commit_sha: 'abc123def456', status: 'completed', conclusion: 'failure', started_at: '2026-03-28T10:05:05Z', completed_at: '2026-03-28T10:08:00Z', job_details: { event: 'push', actor: 'rickfelix' } },
+    { id: 'run-003', sd_id: 'SD-TEST-002', repository_name: 'rickfelix/EHG_Engineer', workflow_name: 'CI', run_id: 'gh-run-2003', commit_sha: 'def456ghi789', status: 'in_progress', conclusion: null, started_at: '2026-03-28T10:10:05Z', completed_at: null, job_details: { event: 'workflow_run' } },
+    { id: 'run-004', sd_id: 'SD-TEST-002', repository_name: 'rickfelix/EHG_Engineer', workflow_name: 'Security Scan', run_id: 'gh-run-2004', commit_sha: 'def456ghi789', status: 'completed', conclusion: 'success', started_at: '2026-03-28T10:15:00Z', completed_at: '2026-03-28T10:17:00Z', job_details: { event: 'check_suite' } },
+    { id: 'run-005', sd_id: 'SD-TEST-003', repository_name: 'rickfelix/ehg', workflow_name: 'CI', run_id: 'gh-run-2005', commit_sha: 'ghi789jkl012', status: 'queued', conclusion: null, started_at: null, completed_at: null, job_details: null },
+    { id: 'run-006', sd_id: null, repository_name: 'rickfelix/ehg', workflow_name: 'Lint', run_id: 'gh-run-2006', commit_sha: 'jkl012mno345', status: 'completed', conclusion: 'success', started_at: '2026-03-28T10:45:05Z', completed_at: '2026-03-28T10:46:00Z', job_details: { event: 'push' } }
+  ];
+
+  const scanEvents = [
+    { id: 'scan-001', pipeline_run_id: 'run-001', scan_type: 'sast', findings_count: 3, severity_summary: { critical: 0, high: 1, medium: 1, low: 1 }, started_at: '2026-03-28T10:00:10Z', completed_at: '2026-03-28T10:01:30Z', status: 'completed' },
+    { id: 'scan-002', pipeline_run_id: 'run-001', scan_type: 'dependency', findings_count: 1, severity_summary: { critical: 0, high: 0, medium: 1, low: 0 }, started_at: '2026-03-28T10:00:10Z', completed_at: '2026-03-28T10:01:00Z', status: 'completed' },
+    { id: 'scan-003', pipeline_run_id: 'run-002', scan_type: 'secret', findings_count: 0, severity_summary: { critical: 0, high: 0, medium: 0, low: 0 }, started_at: '2026-03-28T10:05:10Z', completed_at: '2026-03-28T10:06:00Z', status: 'completed' },
+    { id: 'scan-004', pipeline_run_id: 'run-004', scan_type: 'sast', findings_count: 7, severity_summary: { critical: 1, high: 2, medium: 3, low: 1 }, started_at: '2026-03-28T10:15:05Z', completed_at: '2026-03-28T10:16:30Z', status: 'completed' },
+    { id: 'scan-005', pipeline_run_id: 'run-003', scan_type: 'container', findings_count: 0, severity_summary: { critical: 0, high: 0, medium: 0, low: 0 }, started_at: '2026-03-28T10:10:10Z', completed_at: null, status: 'running' }
+  ];
+
+  return { deliveries, pipelineRuns, scanEvents };
+}
+
+export function seed(repository) {
+  const data = getSeedData();
+  repository.clear();
+  data.deliveries.forEach(d => repository.addDelivery(d));
+  data.pipelineRuns.forEach(r => repository.addPipelineRun(r));
+  data.scanEvents.forEach(e => repository.addScanEvent(e));
+  return data;
+}

--- a/services/codeguardian-mock/src/data/webhook-validator.js
+++ b/services/codeguardian-mock/src/data/webhook-validator.js
@@ -1,0 +1,45 @@
+import {
+  VALID_EVENT_TYPES, VALID_PIPELINE_STATUSES, VALID_CONCLUSIONS,
+  VALID_SCAN_TYPES, VALID_SCAN_STATUSES, REQUIRED_FIELDS
+} from './webhook-schema.js';
+
+export function validateWebhook(type, entity) {
+  const errors = [];
+  const required = REQUIRED_FIELDS[type];
+  if (!required) {
+    return { valid: false, errors: [`Unknown entity type: ${type}`] };
+  }
+
+  for (const field of required) {
+    if (entity[field] === undefined || entity[field] === null) {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+
+  if (type === 'delivery' && entity.event_type && !VALID_EVENT_TYPES.includes(entity.event_type)) {
+    errors.push(`Invalid event_type: ${entity.event_type}. Must be one of: ${VALID_EVENT_TYPES.join(', ')}`);
+  }
+
+  if (type === 'pipeline_run') {
+    if (entity.status && !VALID_PIPELINE_STATUSES.includes(entity.status)) {
+      errors.push(`Invalid status: ${entity.status}. Must be one of: ${VALID_PIPELINE_STATUSES.join(', ')}`);
+    }
+    if (entity.conclusion && !VALID_CONCLUSIONS.includes(entity.conclusion)) {
+      errors.push(`Invalid conclusion: ${entity.conclusion}. Must be one of: ${VALID_CONCLUSIONS.join(', ')}`);
+    }
+  }
+
+  if (type === 'scan_event') {
+    if (entity.scan_type && !VALID_SCAN_TYPES.includes(entity.scan_type)) {
+      errors.push(`Invalid scan_type: ${entity.scan_type}. Must be one of: ${VALID_SCAN_TYPES.join(', ')}`);
+    }
+    if (entity.status && !VALID_SCAN_STATUSES.includes(entity.status)) {
+      errors.push(`Invalid status: ${entity.status}. Must be one of: ${VALID_SCAN_STATUSES.join(', ')}`);
+    }
+    if (entity.findings_count !== undefined && typeof entity.findings_count !== 'number') {
+      errors.push(`findings_count must be a number, got: ${typeof entity.findings_count}`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/services/codeguardian-mock/tests/webhook-data.test.js
+++ b/services/codeguardian-mock/tests/webhook-data.test.js
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  VALID_EVENT_TYPES, VALID_PIPELINE_STATUSES, VALID_CONCLUSIONS,
+  VALID_SCAN_TYPES, VALID_SCAN_STATUSES, REQUIRED_FIELDS
+} from '../src/data/webhook-schema.js';
+import { validateWebhook } from '../src/data/webhook-validator.js';
+import { WebhookRepository } from '../src/data/webhook-repository.js';
+import { getSeedData, seed } from '../src/data/webhook-seed.js';
+
+describe('Webhook Schema', () => {
+  it('exports valid event types', () => {
+    expect(VALID_EVENT_TYPES).toContain('push');
+    expect(VALID_EVENT_TYPES).toContain('pull_request');
+    expect(VALID_EVENT_TYPES).toContain('workflow_run');
+    expect(VALID_EVENT_TYPES.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('exports valid pipeline statuses', () => {
+    expect(VALID_PIPELINE_STATUSES).toContain('queued');
+    expect(VALID_PIPELINE_STATUSES).toContain('completed');
+    expect(VALID_PIPELINE_STATUSES.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('exports valid conclusions', () => {
+    expect(VALID_CONCLUSIONS).toContain('success');
+    expect(VALID_CONCLUSIONS).toContain('failure');
+    expect(VALID_CONCLUSIONS.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('exports valid scan types', () => {
+    expect(VALID_SCAN_TYPES).toContain('sast');
+    expect(VALID_SCAN_TYPES).toContain('dependency');
+    expect(VALID_SCAN_TYPES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('exports required fields for all entity types', () => {
+    expect(REQUIRED_FIELDS.delivery).toBeDefined();
+    expect(REQUIRED_FIELDS.pipeline_run).toBeDefined();
+    expect(REQUIRED_FIELDS.scan_event).toBeDefined();
+  });
+});
+
+describe('Webhook Validator', () => {
+  it('validates a correct delivery', () => {
+    const result = validateWebhook('delivery', {
+      id: 'd1', delivery_id: 'gh-1', event_type: 'push',
+      payload: {}, signature_valid: true
+    });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects delivery missing delivery_id', () => {
+    const result = validateWebhook('delivery', {
+      id: 'd1', event_type: 'push', payload: {}, signature_valid: true
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('delivery_id'))).toBe(true);
+  });
+
+  it('rejects delivery with invalid event_type', () => {
+    const result = validateWebhook('delivery', {
+      id: 'd1', delivery_id: 'gh-1', event_type: 'invalid_event',
+      payload: {}, signature_valid: true
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('event_type'))).toBe(true);
+  });
+
+  it('validates a correct pipeline run', () => {
+    const result = validateWebhook('pipeline_run', {
+      id: 'r1', repository_name: 'test/repo', workflow_name: 'CI',
+      run_id: 'gh-run-1', status: 'completed'
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects pipeline run with invalid status', () => {
+    const result = validateWebhook('pipeline_run', {
+      id: 'r1', repository_name: 'test/repo', workflow_name: 'CI',
+      run_id: 'gh-run-1', status: 'bogus'
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('status'))).toBe(true);
+  });
+
+  it('rejects pipeline run with invalid conclusion', () => {
+    const result = validateWebhook('pipeline_run', {
+      id: 'r1', repository_name: 'test/repo', workflow_name: 'CI',
+      run_id: 'gh-run-1', status: 'completed', conclusion: 'bogus'
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('conclusion'))).toBe(true);
+  });
+
+  it('validates a correct scan event', () => {
+    const result = validateWebhook('scan_event', {
+      id: 's1', pipeline_run_id: 'r1', scan_type: 'sast',
+      findings_count: 3, status: 'completed'
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects scan event with non-numeric findings_count', () => {
+    const result = validateWebhook('scan_event', {
+      id: 's1', pipeline_run_id: 'r1', scan_type: 'sast',
+      findings_count: 'three', status: 'completed'
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('findings_count'))).toBe(true);
+  });
+
+  it('rejects unknown entity type', () => {
+    const result = validateWebhook('unknown_type', { id: 'x' });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Unknown entity type'))).toBe(true);
+  });
+});
+
+describe('WebhookRepository - Deliveries', () => {
+  let repo;
+
+  beforeEach(() => { repo = new WebhookRepository(); });
+
+  it('adds and retrieves a delivery', () => {
+    const delivery = {
+      id: 'd1', delivery_id: 'gh-1', event_type: 'push',
+      payload: { ref: 'main' }, signature_valid: true
+    };
+    repo.addDelivery(delivery);
+    const found = repo.getDelivery('d1');
+    expect(found).toBeDefined();
+    expect(found.delivery_id).toBe('gh-1');
+    expect(found.received_at).toBeDefined();
+  });
+
+  it('returns null for missing delivery', () => {
+    expect(repo.getDelivery('nonexistent')).toBeNull();
+  });
+
+  it('lists all deliveries', () => {
+    repo.addDelivery({ id: 'd1', delivery_id: 'gh-1', event_type: 'push', payload: {}, signature_valid: true });
+    repo.addDelivery({ id: 'd2', delivery_id: 'gh-2', event_type: 'pull_request', payload: {}, signature_valid: true });
+    expect(repo.listDeliveries()).toHaveLength(2);
+  });
+
+  it('filters deliveries by event_type', () => {
+    repo.addDelivery({ id: 'd1', delivery_id: 'gh-1', event_type: 'push', payload: {}, signature_valid: true });
+    repo.addDelivery({ id: 'd2', delivery_id: 'gh-2', event_type: 'pull_request', payload: {}, signature_valid: true });
+    repo.addDelivery({ id: 'd3', delivery_id: 'gh-3', event_type: 'push', payload: {}, signature_valid: true });
+    const pushOnly = repo.listDeliveries({ event_type: 'push' });
+    expect(pushOnly).toHaveLength(2);
+    pushOnly.forEach(d => expect(d.event_type).toBe('push'));
+  });
+
+  it('filters deliveries by sd_id', () => {
+    repo.addDelivery({ id: 'd1', delivery_id: 'gh-1', event_type: 'push', payload: {}, signature_valid: true, sd_id: 'SD-1' });
+    repo.addDelivery({ id: 'd2', delivery_id: 'gh-2', event_type: 'push', payload: {}, signature_valid: true, sd_id: 'SD-2' });
+    expect(repo.listDeliveries({ sd_id: 'SD-1' })).toHaveLength(1);
+  });
+
+  it('paginates deliveries', () => {
+    for (let i = 0; i < 10; i++) {
+      repo.addDelivery({ id: `d${i}`, delivery_id: `gh-${i}`, event_type: 'push', payload: {}, signature_valid: true });
+    }
+    const page = repo.listDeliveries({ limit: 3, offset: 2 });
+    expect(page).toHaveLength(3);
+  });
+
+  it('updates a delivery', () => {
+    repo.addDelivery({ id: 'd1', delivery_id: 'gh-1', event_type: 'push', payload: {}, signature_valid: true, processed_successfully: false });
+    const updated = repo.updateDelivery('d1', { processed_successfully: true, processed_at: '2026-03-28T12:00:00Z' });
+    expect(updated.processed_successfully).toBe(true);
+    expect(updated.processed_at).toBe('2026-03-28T12:00:00Z');
+    expect(updated.id).toBe('d1');
+  });
+
+  it('returns null when updating nonexistent delivery', () => {
+    expect(repo.updateDelivery('nonexistent', {})).toBeNull();
+  });
+
+  it('deletes a delivery', () => {
+    repo.addDelivery({ id: 'd1', delivery_id: 'gh-1', event_type: 'push', payload: {}, signature_valid: true });
+    expect(repo.deleteDelivery('d1')).toBe(true);
+    expect(repo.getDelivery('d1')).toBeNull();
+    expect(repo.deleteDelivery('d1')).toBe(false);
+  });
+
+  it('throws on invalid delivery', () => {
+    expect(() => repo.addDelivery({ id: 'd1' })).toThrow('Invalid delivery');
+  });
+});
+
+describe('WebhookRepository - Pipeline Runs', () => {
+  let repo;
+
+  beforeEach(() => { repo = new WebhookRepository(); });
+
+  it('adds and retrieves a pipeline run', () => {
+    const run = {
+      id: 'r1', repository_name: 'test/repo', workflow_name: 'CI',
+      run_id: 'gh-run-1', status: 'completed', conclusion: 'success'
+    };
+    repo.addPipelineRun(run);
+    expect(repo.getPipelineRun('r1')).toBeDefined();
+    expect(repo.getPipelineRun('r1').conclusion).toBe('success');
+  });
+
+  it('filters pipeline runs by status', () => {
+    repo.addPipelineRun({ id: 'r1', repository_name: 'a', workflow_name: 'CI', run_id: 'g1', status: 'completed' });
+    repo.addPipelineRun({ id: 'r2', repository_name: 'a', workflow_name: 'CI', run_id: 'g2', status: 'in_progress' });
+    expect(repo.listPipelineRuns({ status: 'completed' })).toHaveLength(1);
+  });
+
+  it('filters pipeline runs by repository_name', () => {
+    repo.addPipelineRun({ id: 'r1', repository_name: 'repo-a', workflow_name: 'CI', run_id: 'g1', status: 'completed' });
+    repo.addPipelineRun({ id: 'r2', repository_name: 'repo-b', workflow_name: 'CI', run_id: 'g2', status: 'completed' });
+    expect(repo.listPipelineRuns({ repository_name: 'repo-a' })).toHaveLength(1);
+  });
+
+  it('updates a pipeline run', () => {
+    repo.addPipelineRun({ id: 'r1', repository_name: 'a', workflow_name: 'CI', run_id: 'g1', status: 'in_progress' });
+    const updated = repo.updatePipelineRun('r1', { status: 'completed', conclusion: 'success' });
+    expect(updated.status).toBe('completed');
+    expect(updated.conclusion).toBe('success');
+  });
+
+  it('deletes a pipeline run', () => {
+    repo.addPipelineRun({ id: 'r1', repository_name: 'a', workflow_name: 'CI', run_id: 'g1', status: 'completed' });
+    expect(repo.deletePipelineRun('r1')).toBe(true);
+    expect(repo.getPipelineRun('r1')).toBeNull();
+  });
+});
+
+describe('WebhookRepository - Scan Events', () => {
+  let repo;
+
+  beforeEach(() => {
+    repo = new WebhookRepository();
+    repo.addPipelineRun({ id: 'r1', repository_name: 'a', workflow_name: 'CI', run_id: 'g1', status: 'completed' });
+  });
+
+  it('adds and retrieves a scan event', () => {
+    repo.addScanEvent({ id: 's1', pipeline_run_id: 'r1', scan_type: 'sast', findings_count: 5, status: 'completed' });
+    expect(repo.getScanEvent('s1')).toBeDefined();
+    expect(repo.getScanEvent('s1').findings_count).toBe(5);
+  });
+
+  it('throws when pipeline run does not exist', () => {
+    expect(() => repo.addScanEvent({
+      id: 's1', pipeline_run_id: 'nonexistent', scan_type: 'sast', findings_count: 0, status: 'completed'
+    })).toThrow('Pipeline run not found');
+  });
+
+  it('filters scan events by scan_type', () => {
+    repo.addScanEvent({ id: 's1', pipeline_run_id: 'r1', scan_type: 'sast', findings_count: 3, status: 'completed' });
+    repo.addScanEvent({ id: 's2', pipeline_run_id: 'r1', scan_type: 'dependency', findings_count: 1, status: 'completed' });
+    expect(repo.listScanEvents({ scan_type: 'sast' })).toHaveLength(1);
+  });
+});
+
+describe('WebhookRepository - Export/Import', () => {
+  it('round-trips data via export/import', () => {
+    const repo1 = new WebhookRepository();
+    repo1.addDelivery({ id: 'd1', delivery_id: 'gh-1', event_type: 'push', payload: {}, signature_valid: true });
+    repo1.addPipelineRun({ id: 'r1', repository_name: 'a', workflow_name: 'CI', run_id: 'g1', status: 'completed' });
+    repo1.addScanEvent({ id: 's1', pipeline_run_id: 'r1', scan_type: 'sast', findings_count: 2, status: 'completed' });
+
+    const exported = repo1.export();
+    const repo2 = new WebhookRepository();
+    repo2.import(exported);
+
+    expect(repo2.listDeliveries()).toHaveLength(1);
+    expect(repo2.listPipelineRuns()).toHaveLength(1);
+    expect(repo2.listScanEvents()).toHaveLength(1);
+    expect(repo2.getDelivery('d1').delivery_id).toBe('gh-1');
+  });
+});
+
+describe('Webhook Seed', () => {
+  it('returns seed data with sufficient counts', () => {
+    const data = getSeedData();
+    expect(data.deliveries.length).toBeGreaterThanOrEqual(10);
+    expect(data.pipelineRuns.length).toBeGreaterThanOrEqual(5);
+    expect(data.scanEvents.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('populates a repository via seed()', () => {
+    const repo = new WebhookRepository();
+    seed(repo);
+    expect(repo.listDeliveries().length).toBeGreaterThanOrEqual(10);
+    expect(repo.listPipelineRuns().length).toBeGreaterThanOrEqual(5);
+    expect(repo.listScanEvents().length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('clears existing data before seeding', () => {
+    const repo = new WebhookRepository();
+    repo.addDelivery({ id: 'old', delivery_id: 'old', event_type: 'push', payload: {}, signature_valid: true });
+    seed(repo);
+    expect(repo.getDelivery('old')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add webhook-schema.js with WebhookDelivery, PipelineRun, ScanEvent type definitions
- Add webhook-repository.js with Map-based CRUD, filtering, and pagination
- Add webhook-validator.js for payload validation with enum enforcement
- Add webhook-seed.js with 12 deliveries, 6 pipeline runs, 5 scan events
- Add webhook-data.test.js with 36 comprehensive tests (all pass)

## Test plan
- [x] All 36 unit tests pass via `npx vitest run services/codeguardian-mock/tests/webhook-data.test.js`
- [x] Schema exports all constants (VALID_EVENT_TYPES, VALID_PIPELINE_STATUSES, etc.)
- [x] Validator rejects missing required fields and invalid enum values
- [x] Repository CRUD with filtering by event_type/sd_id/status and pagination
- [x] Seed data populates 12+ deliveries, 6+ pipeline runs, 3+ scan events

🤖 Generated with [Claude Code](https://claude.com/claude-code)