### PR TITLE
feat(SD-D1): add analysis results data layer for CodeGuardian CI

### DIFF
--- a/services/codeguardian-mock/src/data/analysis-repository.js
+++ b/services/codeguardian-mock/src/data/analysis-repository.js
@@ -1,0 +1,108 @@
+import { validateAnalysis } from './analysis-validator.js';
+
+export class AnalysisRepository {
+  constructor() {
+    this._analyses = new Map();
+    this._findings = new Map();
+    this._metrics = new Map();
+  }
+
+  clear() {
+    this._analyses.clear();
+    this._findings.clear();
+    this._metrics.clear();
+  }
+
+  // Analyses
+  addAnalysis(analysis) {
+    const { valid, errors } = validateAnalysis('analysis', analysis);
+    if (!valid) throw new Error(`Invalid analysis: ${errors.join(', ')}`);
+    const record = { ...analysis, created_at: analysis.created_at || new Date().toISOString() };
+    this._analyses.set(analysis.id, record);
+    return record;
+  }
+
+  getAnalysis(id) { return this._analyses.get(id) || null; }
+
+  listAnalyses({ repository_name, status, limit, offset } = {}) {
+    let results = [...this._analyses.values()];
+    if (repository_name) results = results.filter(a => a.repository_name === repository_name);
+    if (status) results = results.filter(a => a.status === status);
+    if (offset) results = results.slice(offset);
+    if (limit) results = results.slice(0, limit);
+    return results;
+  }
+
+  updateAnalysis(id, updates) {
+    const existing = this._analyses.get(id);
+    if (!existing) return null;
+    const updated = { ...existing, ...updates, id };
+    this._analyses.set(id, updated);
+    return updated;
+  }
+
+  deleteAnalysis(id) {
+    return this._analyses.delete(id);
+  }
+
+  // Findings
+  addFinding(finding) {
+    const { valid, errors } = validateAnalysis('finding', finding);
+    if (!valid) throw new Error(`Invalid finding: ${errors.join(', ')}`);
+    if (!this._analyses.has(finding.analysis_id)) {
+      throw new Error(`Analysis not found: ${finding.analysis_id}`);
+    }
+    this._findings.set(finding.id, { ...finding });
+    return finding;
+  }
+
+  getFinding(id) { return this._findings.get(id) || null; }
+
+  listFindings({ analysis_id, severity, finding_type, limit, offset } = {}) {
+    let results = [...this._findings.values()];
+    if (analysis_id) results = results.filter(f => f.analysis_id === analysis_id);
+    if (severity) results = results.filter(f => f.severity === severity);
+    if (finding_type) results = results.filter(f => f.finding_type === finding_type);
+    if (offset) results = results.slice(offset);
+    if (limit) results = results.slice(0, limit);
+    return results;
+  }
+
+  // Metrics
+  addMetric(metric) {
+    const { valid, errors } = validateAnalysis('metric', metric);
+    if (!valid) throw new Error(`Invalid metric: ${errors.join(', ')}`);
+    if (!this._analyses.has(metric.analysis_id)) {
+      throw new Error(`Analysis not found: ${metric.analysis_id}`);
+    }
+    this._metrics.set(metric.id, { ...metric });
+    return metric;
+  }
+
+  getMetric(id) { return this._metrics.get(id) || null; }
+
+  listMetrics({ analysis_id, metric_type, limit, offset } = {}) {
+    let results = [...this._metrics.values()];
+    if (analysis_id) results = results.filter(m => m.analysis_id === analysis_id);
+    if (metric_type) results = results.filter(m => m.metric_type === metric_type);
+    if (offset) results = results.slice(offset);
+    if (limit) results = results.slice(0, limit);
+    return results;
+  }
+
+  // Export/Import
+  export() {
+    return {
+      analyses: this.listAnalyses(),
+      findings: this.listFindings(),
+      metrics: this.listMetrics()
+    };
+  }
+
+  import(data) {
+    this.clear();
+    (data.analyses || []).forEach(a => this.addAnalysis(a));
+    (data.findings || []).forEach(f => this.addFinding(f));
+    (data.metrics || []).forEach(m => this.addMetric(m));
+  }
+}

--- a/services/codeguardian-mock/src/data/analysis-schema.js
+++ b/services/codeguardian-mock/src/data/analysis-schema.js
@@ -1,0 +1,70 @@
+/**
+ * @typedef {'pending'|'running'|'completed'|'failed'|'cancelled'} AnalysisStatus
+ */
+
+/**
+ * @typedef {Object} AnalysisResult
+ * @property {string} id
+ * @property {string} repository_name
+ * @property {string} commit_sha
+ * @property {string|null} pr_number
+ * @property {string|null} branch
+ * @property {AnalysisStatus} status
+ * @property {number} total_findings
+ * @property {{critical:number, high:number, medium:number, low:number}} severity_summary
+ * @property {number|null} quality_score - 0-100 composite score
+ * @property {string|null} started_at - ISO 8601
+ * @property {string|null} completed_at - ISO 8601
+ * @property {string} created_at - ISO 8601
+ * @property {Object|null} metadata
+ */
+
+/**
+ * @typedef {'critical'|'high'|'medium'|'low'|'info'} FindingSeverity
+ */
+
+/**
+ * @typedef {'vulnerability'|'code_smell'|'bug'|'security_hotspot'|'duplication'} FindingType
+ */
+
+/**
+ * @typedef {Object} VulnerabilityFinding
+ * @property {string} id
+ * @property {string} analysis_id
+ * @property {FindingSeverity} severity
+ * @property {FindingType} finding_type
+ * @property {string} title
+ * @property {string} file_path
+ * @property {number} line_number
+ * @property {string} description
+ * @property {string|null} rule_id
+ * @property {string|null} suggestion
+ */
+
+/**
+ * @typedef {'latency'|'throughput'|'memory'|'cpu'|'bundle_size'|'test_coverage'} MetricType
+ */
+
+/**
+ * @typedef {Object} PerformanceMetric
+ * @property {string} id
+ * @property {string} analysis_id
+ * @property {MetricType} metric_type
+ * @property {string} name
+ * @property {number} value
+ * @property {string} unit
+ * @property {number|null} threshold
+ * @property {boolean} passed
+ * @property {string|null} measured_at - ISO 8601
+ */
+
+export const VALID_ANALYSIS_STATUSES = ['pending', 'running', 'completed', 'failed', 'cancelled'];
+export const VALID_SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'];
+export const VALID_FINDING_TYPES = ['vulnerability', 'code_smell', 'bug', 'security_hotspot', 'duplication'];
+export const VALID_METRIC_TYPES = ['latency', 'throughput', 'memory', 'cpu', 'bundle_size', 'test_coverage'];
+
+export const REQUIRED_FIELDS = {
+  analysis: ['id', 'repository_name', 'commit_sha', 'status'],
+  finding: ['id', 'analysis_id', 'severity', 'finding_type', 'title', 'file_path', 'line_number', 'description'],
+  metric: ['id', 'analysis_id', 'metric_type', 'name', 'value', 'unit']
+};

--- a/services/codeguardian-mock/src/data/analysis-seed.js
+++ b/services/codeguardian-mock/src/data/analysis-seed.js
@@ -1,0 +1,45 @@
+export function getSeedData() {
+  const analyses = [
+    { id: 'an-001', repository_name: 'rickfelix/ehg', commit_sha: 'abc123def', branch: 'main', pr_number: null, status: 'completed', total_findings: 8, severity_summary: { critical: 1, high: 2, medium: 3, low: 2 }, quality_score: 72, started_at: '2026-03-28T10:00:00Z', completed_at: '2026-03-28T10:03:00Z', metadata: { trigger: 'push' } },
+    { id: 'an-002', repository_name: 'rickfelix/ehg', commit_sha: 'def456ghi', branch: 'feat/auth', pr_number: '42', status: 'completed', total_findings: 3, severity_summary: { critical: 0, high: 1, medium: 1, low: 1 }, quality_score: 85, started_at: '2026-03-28T10:05:00Z', completed_at: '2026-03-28T10:07:00Z', metadata: { trigger: 'pull_request' } },
+    { id: 'an-003', repository_name: 'rickfelix/EHG_Engineer', commit_sha: 'ghi789jkl', branch: 'main', pr_number: null, status: 'completed', total_findings: 12, severity_summary: { critical: 2, high: 3, medium: 4, low: 3 }, quality_score: 61, started_at: '2026-03-28T10:10:00Z', completed_at: '2026-03-28T10:14:00Z', metadata: { trigger: 'push' } },
+    { id: 'an-004', repository_name: 'rickfelix/ehg', commit_sha: 'jkl012mno', branch: 'fix/hotfix', pr_number: '43', status: 'running', total_findings: 0, severity_summary: { critical: 0, high: 0, medium: 0, low: 0 }, quality_score: null, started_at: '2026-03-28T10:15:00Z', completed_at: null, metadata: null },
+    { id: 'an-005', repository_name: 'rickfelix/EHG_Engineer', commit_sha: 'mno345pqr', branch: 'main', pr_number: null, status: 'failed', total_findings: 0, severity_summary: { critical: 0, high: 0, medium: 0, low: 0 }, quality_score: null, started_at: '2026-03-28T10:20:00Z', completed_at: '2026-03-28T10:20:30Z', metadata: { error: 'timeout' } },
+    { id: 'an-006', repository_name: 'rickfelix/ehg', commit_sha: 'pqr678stu', branch: 'feat/dashboard', pr_number: '44', status: 'completed', total_findings: 5, severity_summary: { critical: 0, high: 0, medium: 3, low: 2 }, quality_score: 90, started_at: '2026-03-28T10:25:00Z', completed_at: '2026-03-28T10:27:00Z', metadata: { trigger: 'pull_request' } }
+  ];
+
+  const findings = [
+    { id: 'vf-001', analysis_id: 'an-001', severity: 'critical', finding_type: 'vulnerability', title: 'SQL Injection in query builder', file_path: 'src/db/query.js', line_number: 45, description: 'User input concatenated directly into SQL query', rule_id: 'CWE-89', suggestion: 'Use parameterized queries' },
+    { id: 'vf-002', analysis_id: 'an-001', severity: 'high', finding_type: 'security_hotspot', title: 'Hardcoded secret in config', file_path: 'src/config.js', line_number: 12, description: 'API key stored as string literal', rule_id: 'CWE-798', suggestion: 'Use environment variables' },
+    { id: 'vf-003', analysis_id: 'an-001', severity: 'high', finding_type: 'vulnerability', title: 'Missing CSRF protection', file_path: 'src/routes/api.js', line_number: 8, description: 'POST endpoints lack CSRF token validation', rule_id: 'CWE-352', suggestion: 'Add csurf middleware' },
+    { id: 'vf-004', analysis_id: 'an-001', severity: 'medium', finding_type: 'code_smell', title: 'Function too complex', file_path: 'src/services/auth.js', line_number: 100, description: 'Cyclomatic complexity of 15 exceeds threshold of 10', rule_id: 'S3776', suggestion: 'Extract helper functions' },
+    { id: 'vf-005', analysis_id: 'an-002', severity: 'high', finding_type: 'bug', title: 'Null dereference in error handler', file_path: 'src/middleware/error.js', line_number: 22, description: 'err.response accessed without null check', rule_id: 'S2259', suggestion: 'Add optional chaining' },
+    { id: 'vf-006', analysis_id: 'an-002', severity: 'medium', finding_type: 'duplication', title: 'Duplicated validation logic', file_path: 'src/validators/user.js', line_number: 15, description: '23 lines duplicated with src/validators/admin.js', rule_id: 'S1192', suggestion: 'Extract shared validation function' },
+    { id: 'vf-007', analysis_id: 'an-003', severity: 'critical', finding_type: 'vulnerability', title: 'Path traversal in file upload', file_path: 'src/upload/handler.js', line_number: 34, description: 'User-supplied filename used without sanitization', rule_id: 'CWE-22', suggestion: 'Use path.basename and whitelist extensions' },
+    { id: 'vf-008', analysis_id: 'an-003', severity: 'critical', finding_type: 'security_hotspot', title: 'Weak encryption algorithm', file_path: 'src/crypto/encrypt.js', line_number: 5, description: 'Using DES instead of AES-256-GCM', rule_id: 'CWE-327', suggestion: 'Upgrade to AES-256-GCM' },
+    { id: 'vf-009', analysis_id: 'an-006', severity: 'medium', finding_type: 'code_smell', title: 'Unused import', file_path: 'src/components/Chart.tsx', line_number: 3, description: 'Import useState is declared but never used', rule_id: 'S1128', suggestion: 'Remove unused import' },
+    { id: 'vf-010', analysis_id: 'an-006', severity: 'low', finding_type: 'code_smell', title: 'Magic number', file_path: 'src/utils/pagination.js', line_number: 18, description: 'Literal 25 should be a named constant', rule_id: 'S109', suggestion: 'Extract to PAGE_SIZE constant' }
+  ];
+
+  const metrics = [
+    { id: 'pm-001', analysis_id: 'an-001', metric_type: 'test_coverage', name: 'Line Coverage', value: 78.5, unit: '%', threshold: 80, passed: false, measured_at: '2026-03-28T10:02:00Z' },
+    { id: 'pm-002', analysis_id: 'an-001', metric_type: 'bundle_size', name: 'Main Bundle', value: 312, unit: 'KB', threshold: 250, passed: false, measured_at: '2026-03-28T10:02:30Z' },
+    { id: 'pm-003', analysis_id: 'an-002', metric_type: 'test_coverage', name: 'Line Coverage', value: 92.1, unit: '%', threshold: 80, passed: true, measured_at: '2026-03-28T10:06:00Z' },
+    { id: 'pm-004', analysis_id: 'an-002', metric_type: 'latency', name: 'API Response P95', value: 45, unit: 'ms', threshold: 100, passed: true, measured_at: '2026-03-28T10:06:30Z' },
+    { id: 'pm-005', analysis_id: 'an-003', metric_type: 'memory', name: 'Heap Usage', value: 256, unit: 'MB', threshold: 512, passed: true, measured_at: '2026-03-28T10:13:00Z' },
+    { id: 'pm-006', analysis_id: 'an-003', metric_type: 'cpu', name: 'Build CPU Time', value: 12.5, unit: 'seconds', threshold: 30, passed: true, measured_at: '2026-03-28T10:13:30Z' },
+    { id: 'pm-007', analysis_id: 'an-006', metric_type: 'test_coverage', name: 'Line Coverage', value: 95.3, unit: '%', threshold: 80, passed: true, measured_at: '2026-03-28T10:26:00Z' },
+    { id: 'pm-008', analysis_id: 'an-006', metric_type: 'throughput', name: 'Requests/sec', value: 1250, unit: 'rps', threshold: 500, passed: true, measured_at: '2026-03-28T10:26:30Z' }
+  ];
+
+  return { analyses, findings, metrics };
+}
+
+export function seed(repository) {
+  const data = getSeedData();
+  repository.clear();
+  data.analyses.forEach(a => repository.addAnalysis(a));
+  data.findings.forEach(f => repository.addFinding(f));
+  data.metrics.forEach(m => repository.addMetric(m));
+  return data;
+}

--- a/services/codeguardian-mock/src/data/analysis-validator.js
+++ b/services/codeguardian-mock/src/data/analysis-validator.js
@@ -1,0 +1,45 @@
+import {
+  VALID_ANALYSIS_STATUSES, VALID_SEVERITIES, VALID_FINDING_TYPES,
+  VALID_METRIC_TYPES, REQUIRED_FIELDS
+} from './analysis-schema.js';
+
+export function validateAnalysis(type, entity) {
+  const errors = [];
+  const required = REQUIRED_FIELDS[type];
+  if (!required) {
+    return { valid: false, errors: [`Unknown entity type: ${type}`] };
+  }
+
+  for (const field of required) {
+    if (entity[field] === undefined || entity[field] === null) {
+      errors.push(`Missing required field: ${field}`);
+    }
+  }
+
+  if (type === 'analysis' && entity.status && !VALID_ANALYSIS_STATUSES.includes(entity.status)) {
+    errors.push(`Invalid status: ${entity.status}. Must be one of: ${VALID_ANALYSIS_STATUSES.join(', ')}`);
+  }
+
+  if (type === 'finding') {
+    if (entity.severity && !VALID_SEVERITIES.includes(entity.severity)) {
+      errors.push(`Invalid severity: ${entity.severity}. Must be one of: ${VALID_SEVERITIES.join(', ')}`);
+    }
+    if (entity.finding_type && !VALID_FINDING_TYPES.includes(entity.finding_type)) {
+      errors.push(`Invalid finding_type: ${entity.finding_type}. Must be one of: ${VALID_FINDING_TYPES.join(', ')}`);
+    }
+    if (entity.line_number !== undefined && typeof entity.line_number !== 'number') {
+      errors.push(`line_number must be a number, got: ${typeof entity.line_number}`);
+    }
+  }
+
+  if (type === 'metric') {
+    if (entity.metric_type && !VALID_METRIC_TYPES.includes(entity.metric_type)) {
+      errors.push(`Invalid metric_type: ${entity.metric_type}. Must be one of: ${VALID_METRIC_TYPES.join(', ')}`);
+    }
+    if (entity.value !== undefined && typeof entity.value !== 'number') {
+      errors.push(`value must be a number, got: ${typeof entity.value}`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/services/codeguardian-mock/tests/analysis-data.test.js
+++ b/services/codeguardian-mock/tests/analysis-data.test.js
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  VALID_ANALYSIS_STATUSES, VALID_SEVERITIES, VALID_FINDING_TYPES,
+  VALID_METRIC_TYPES, REQUIRED_FIELDS
+} from '../src/data/analysis-schema.js';
+import { validateAnalysis } from '../src/data/analysis-validator.js';
+import { AnalysisRepository } from '../src/data/analysis-repository.js';
+import { getSeedData, seed } from '../src/data/analysis-seed.js';
+
+describe('Analysis Schema', () => {
+  it('exports valid analysis statuses', () => {
+    expect(VALID_ANALYSIS_STATUSES).toContain('completed');
+    expect(VALID_ANALYSIS_STATUSES).toContain('running');
+    expect(VALID_ANALYSIS_STATUSES.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('exports valid finding types', () => {
+    expect(VALID_FINDING_TYPES).toContain('vulnerability');
+    expect(VALID_FINDING_TYPES).toContain('code_smell');
+    expect(VALID_FINDING_TYPES.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('exports valid metric types', () => {
+    expect(VALID_METRIC_TYPES).toContain('test_coverage');
+    expect(VALID_METRIC_TYPES).toContain('latency');
+    expect(VALID_METRIC_TYPES.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('exports required fields for all entity types', () => {
+    expect(REQUIRED_FIELDS.analysis).toBeDefined();
+    expect(REQUIRED_FIELDS.finding).toBeDefined();
+    expect(REQUIRED_FIELDS.metric).toBeDefined();
+  });
+});
+
+describe('Analysis Validator', () => {
+  it('validates correct analysis', () => {
+    const { valid } = validateAnalysis('analysis', { id: 'a1', repository_name: 'r', commit_sha: 'abc', status: 'completed' });
+    expect(valid).toBe(true);
+  });
+
+  it('rejects analysis with invalid status', () => {
+    const { valid, errors } = validateAnalysis('analysis', { id: 'a1', repository_name: 'r', commit_sha: 'abc', status: 'bogus' });
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('status'))).toBe(true);
+  });
+
+  it('rejects finding with invalid severity', () => {
+    const { valid } = validateAnalysis('finding', {
+      id: 'f1', analysis_id: 'a1', severity: 'extreme', finding_type: 'bug',
+      title: 'Test', file_path: 'x.js', line_number: 1, description: 'desc'
+    });
+    expect(valid).toBe(false);
+  });
+
+  it('rejects finding with non-numeric line_number', () => {
+    const { valid, errors } = validateAnalysis('finding', {
+      id: 'f1', analysis_id: 'a1', severity: 'high', finding_type: 'bug',
+      title: 'Test', file_path: 'x.js', line_number: 'ten', description: 'desc'
+    });
+    expect(valid).toBe(false);
+    expect(errors.some(e => e.includes('line_number'))).toBe(true);
+  });
+
+  it('rejects metric with non-numeric value', () => {
+    const { valid } = validateAnalysis('metric', {
+      id: 'm1', analysis_id: 'a1', metric_type: 'latency', name: 'P95', value: 'fast', unit: 'ms'
+    });
+    expect(valid).toBe(false);
+  });
+
+  it('rejects unknown entity type', () => {
+    const { valid } = validateAnalysis('unknown', { id: 'x' });
+    expect(valid).toBe(false);
+  });
+});
+
+describe('AnalysisRepository - Analyses', () => {
+  let repo;
+  beforeEach(() => { repo = new AnalysisRepository(); });
+
+  it('adds and retrieves an analysis', () => {
+    const analysis = repo.addAnalysis({ id: 'a1', repository_name: 'test/repo', commit_sha: 'abc', status: 'completed' });
+    expect(analysis.created_at).toBeDefined();
+    expect(repo.getAnalysis('a1')).toBeDefined();
+  });
+
+  it('returns null for missing analysis', () => {
+    expect(repo.getAnalysis('nonexistent')).toBeNull();
+  });
+
+  it('filters analyses by status', () => {
+    repo.addAnalysis({ id: 'a1', repository_name: 'r', commit_sha: 'c1', status: 'completed' });
+    repo.addAnalysis({ id: 'a2', repository_name: 'r', commit_sha: 'c2', status: 'running' });
+    expect(repo.listAnalyses({ status: 'completed' })).toHaveLength(1);
+  });
+
+  it('filters analyses by repository_name', () => {
+    repo.addAnalysis({ id: 'a1', repository_name: 'repo-a', commit_sha: 'c1', status: 'completed' });
+    repo.addAnalysis({ id: 'a2', repository_name: 'repo-b', commit_sha: 'c2', status: 'completed' });
+    expect(repo.listAnalyses({ repository_name: 'repo-a' })).toHaveLength(1);
+  });
+
+  it('paginates analyses', () => {
+    for (let i = 0; i < 10; i++) {
+      repo.addAnalysis({ id: `a${i}`, repository_name: 'r', commit_sha: `c${i}`, status: 'completed' });
+    }
+    expect(repo.listAnalyses({ limit: 3, offset: 2 })).toHaveLength(3);
+  });
+
+  it('updates and deletes an analysis', () => {
+    repo.addAnalysis({ id: 'a1', repository_name: 'r', commit_sha: 'c1', status: 'running' });
+    const updated = repo.updateAnalysis('a1', { status: 'completed', quality_score: 85 });
+    expect(updated.status).toBe('completed');
+    expect(repo.deleteAnalysis('a1')).toBe(true);
+    expect(repo.getAnalysis('a1')).toBeNull();
+  });
+});
+
+describe('AnalysisRepository - Findings', () => {
+  let repo;
+  beforeEach(() => {
+    repo = new AnalysisRepository();
+    repo.addAnalysis({ id: 'a1', repository_name: 'r', commit_sha: 'c', status: 'completed' });
+  });
+
+  it('adds finding linked to analysis', () => {
+    repo.addFinding({ id: 'f1', analysis_id: 'a1', severity: 'high', finding_type: 'bug', title: 'Bug', file_path: 'x.js', line_number: 1, description: 'desc' });
+    expect(repo.getFinding('f1')).toBeDefined();
+  });
+
+  it('throws when analysis does not exist', () => {
+    expect(() => repo.addFinding({
+      id: 'f1', analysis_id: 'missing', severity: 'high', finding_type: 'bug',
+      title: 'Bug', file_path: 'x.js', line_number: 1, description: 'desc'
+    })).toThrow('Analysis not found');
+  });
+
+  it('filters findings by severity', () => {
+    repo.addFinding({ id: 'f1', analysis_id: 'a1', severity: 'critical', finding_type: 'vulnerability', title: 'A', file_path: 'a.js', line_number: 1, description: 'd' });
+    repo.addFinding({ id: 'f2', analysis_id: 'a1', severity: 'low', finding_type: 'code_smell', title: 'B', file_path: 'b.js', line_number: 2, description: 'd' });
+    expect(repo.listFindings({ severity: 'critical' })).toHaveLength(1);
+  });
+});
+
+describe('AnalysisRepository - Metrics', () => {
+  let repo;
+  beforeEach(() => {
+    repo = new AnalysisRepository();
+    repo.addAnalysis({ id: 'a1', repository_name: 'r', commit_sha: 'c', status: 'completed' });
+  });
+
+  it('adds metric linked to analysis', () => {
+    repo.addMetric({ id: 'm1', analysis_id: 'a1', metric_type: 'test_coverage', name: 'Coverage', value: 85, unit: '%' });
+    expect(repo.getMetric('m1').value).toBe(85);
+  });
+
+  it('filters metrics by type', () => {
+    repo.addMetric({ id: 'm1', analysis_id: 'a1', metric_type: 'test_coverage', name: 'Coverage', value: 85, unit: '%' });
+    repo.addMetric({ id: 'm2', analysis_id: 'a1', metric_type: 'latency', name: 'P95', value: 45, unit: 'ms' });
+    expect(repo.listMetrics({ metric_type: 'latency' })).toHaveLength(1);
+  });
+});
+
+describe('Analysis Seed', () => {
+  it('returns seed data with sufficient counts', () => {
+    const data = getSeedData();
+    expect(data.analyses.length).toBeGreaterThanOrEqual(5);
+    expect(data.findings.length).toBeGreaterThanOrEqual(8);
+    expect(data.metrics.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('populates repository via seed()', () => {
+    const repo = new AnalysisRepository();
+    seed(repo);
+    expect(repo.listAnalyses().length).toBeGreaterThanOrEqual(5);
+    expect(repo.listFindings().length).toBeGreaterThanOrEqual(8);
+    expect(repo.listMetrics().length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('round-trips via export/import', () => {
+    const repo1 = new AnalysisRepository();
+    seed(repo1);
+    const exported = repo1.export();
+    const repo2 = new AnalysisRepository();
+    repo2.import(exported);
+    expect(repo2.listAnalyses().length).toBe(repo1.listAnalyses().length);
+    expect(repo2.listFindings().length).toBe(repo1.listFindings().length);
+    expect(repo2.listMetrics().length).toBe(repo1.listMetrics().length);
+  });
+});


### PR DESCRIPTION
## Summary
- AnalysisResult, VulnerabilityFinding, PerformanceMetric entity types with JSDoc
- AnalysisRepository with Map-based CRUD, filtering, pagination
- Seed data: 6 analyses, 10 findings, 8 metrics
- 24 tests all passing

## Test plan
- [x] All 24 tests pass
- [x] Schema exports all constants
- [x] Validator enforces required fields and enum values
- [x] Repository CRUD with filtering and pagination
- [x] Seed data populates and round-trips via export/import

🤖 Generated with [Claude Code](https://claude.com/claude-code)