### PR TITLE
feat(SD-D2): add analysis results API layer

### DIFF
--- a/services/codeguardian-mock/src/index.js
+++ b/services/codeguardian-mock/src/index.js
@@ -5,6 +5,7 @@ import { config } from './config.js';
 import analysesRouter from './routes/analyses.js';
 import webhooksRouter from './routes/webhooks.js';
 import webhookCiRouter from './routes/webhook-routes.js';
+import analysisResultsRouter from './routes/analysis-routes.js';
 import { oauthRouter } from './routes/oauth.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -18,6 +19,7 @@ app.get('/health', (_req, res) => {
 app.use('/api/analyses', analysesRouter);
 app.use('/webhooks', webhooksRouter);
 app.use('/webhooks/ci', webhookCiRouter);
+app.use('/api/analysis-results', analysisResultsRouter);
 app.use('/oauth', oauthRouter);
 app.use('/ui', express.static(join(__dirname, '..', 'ui')));
 

--- a/services/codeguardian-mock/src/routes/analysis-routes.js
+++ b/services/codeguardian-mock/src/routes/analysis-routes.js
@@ -1,0 +1,110 @@
+import { Router } from 'express';
+import { AnalysisRepository } from '../data/analysis-repository.js';
+import { seed } from '../data/analysis-seed.js';
+
+const router = Router();
+const repo = new AnalysisRepository();
+seed(repo);
+
+/** Expose repository for testing */
+export { repo as analysisRepo };
+
+router.get('/', (req, res) => {
+  const { repository_name, status, limit, offset } = req.query;
+  const filters = {};
+  if (repository_name) filters.repository_name = repository_name;
+  if (status) filters.status = status;
+  if (limit) filters.limit = parseInt(limit, 10);
+  if (offset) filters.offset = parseInt(offset, 10);
+
+  const all = repo.listAnalyses({});
+  const filtered = repo.listAnalyses(filters);
+  res.json({
+    data: filtered,
+    meta: { total: all.length, count: filtered.length, limit: filters.limit || null, offset: filters.offset || 0 }
+  });
+});
+
+router.get('/stats', (_req, res) => {
+  const analyses = repo.listAnalyses({});
+  const findings = repo.listFindings({});
+  const metrics = repo.listMetrics({});
+
+  const statusCounts = {};
+  let totalScore = 0;
+  let scoredCount = 0;
+  for (const a of analyses) {
+    statusCounts[a.status] = (statusCounts[a.status] || 0) + 1;
+    if (a.quality_score !== null && a.quality_score !== undefined) {
+      totalScore += a.quality_score;
+      scoredCount++;
+    }
+  }
+
+  const severityCounts = {};
+  for (const f of findings) {
+    severityCounts[f.severity] = (severityCounts[f.severity] || 0) + 1;
+  }
+
+  const metricPassRate = metrics.length > 0
+    ? (metrics.filter(m => m.passed).length / metrics.length * 100).toFixed(1) + '%'
+    : '0%';
+
+  res.json({
+    total_analyses: analyses.length,
+    total_findings: findings.length,
+    total_metrics: metrics.length,
+    status_counts: statusCounts,
+    severity_counts: severityCounts,
+    avg_quality_score: scoredCount > 0 ? Math.round(totalScore / scoredCount) : null,
+    metric_pass_rate: metricPassRate
+  });
+});
+
+router.get('/:id', (req, res) => {
+  const analysis = repo.getAnalysis(req.params.id);
+  if (!analysis) {
+    return res.status(404).json({ error: 'Analysis not found', id: req.params.id });
+  }
+  const findings = repo.listFindings({ analysis_id: req.params.id });
+  const metrics = repo.listMetrics({ analysis_id: req.params.id });
+  res.json({ ...analysis, findings, metrics });
+});
+
+router.get('/:id/findings', (req, res) => {
+  const analysis = repo.getAnalysis(req.params.id);
+  if (!analysis) {
+    return res.status(404).json({ error: 'Analysis not found', id: req.params.id });
+  }
+  const { severity, finding_type, limit, offset } = req.query;
+  const filters = { analysis_id: req.params.id };
+  if (severity) filters.severity = severity;
+  if (finding_type) filters.finding_type = finding_type;
+  if (limit) filters.limit = parseInt(limit, 10);
+  if (offset) filters.offset = parseInt(offset, 10);
+
+  const all = repo.listFindings({ analysis_id: req.params.id });
+  const filtered = repo.listFindings(filters);
+  res.json({
+    data: filtered,
+    meta: { total: all.length, count: filtered.length, analysis_id: req.params.id }
+  });
+});
+
+router.get('/:id/metrics', (req, res) => {
+  const analysis = repo.getAnalysis(req.params.id);
+  if (!analysis) {
+    return res.status(404).json({ error: 'Analysis not found', id: req.params.id });
+  }
+  const { metric_type } = req.query;
+  const filters = { analysis_id: req.params.id };
+  if (metric_type) filters.metric_type = metric_type;
+
+  const results = repo.listMetrics(filters);
+  res.json({
+    data: results,
+    meta: { total: results.length, analysis_id: req.params.id }
+  });
+});
+
+export default router;

--- a/services/codeguardian-mock/tests/analysis-api.test.js
+++ b/services/codeguardian-mock/tests/analysis-api.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { analysisRepo } from '../src/routes/analysis-routes.js';
+import { seed } from '../src/data/analysis-seed.js';
+
+describe('Analysis API - GET /api/analysis-results (list)', () => {
+  beforeEach(() => { seed(analysisRepo); });
+
+  it('lists all analyses', () => {
+    const all = analysisRepo.listAnalyses({});
+    expect(all.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('filters by status', () => {
+    const completed = analysisRepo.listAnalyses({ status: 'completed' });
+    expect(completed.length).toBeGreaterThan(0);
+    completed.forEach(a => expect(a.status).toBe('completed'));
+  });
+
+  it('filters by repository_name', () => {
+    const ehg = analysisRepo.listAnalyses({ repository_name: 'rickfelix/ehg' });
+    expect(ehg.length).toBeGreaterThan(0);
+    ehg.forEach(a => expect(a.repository_name).toBe('rickfelix/ehg'));
+  });
+
+  it('supports pagination', () => {
+    const page = analysisRepo.listAnalyses({ limit: 2, offset: 1 });
+    expect(page).toHaveLength(2);
+  });
+});
+
+describe('Analysis API - GET /api/analysis-results/:id', () => {
+  beforeEach(() => { seed(analysisRepo); });
+
+  it('returns analysis with findings and metrics', () => {
+    const analysis = analysisRepo.getAnalysis('an-001');
+    expect(analysis).toBeDefined();
+    expect(analysis.repository_name).toBe('rickfelix/ehg');
+    const findings = analysisRepo.listFindings({ analysis_id: 'an-001' });
+    const metrics = analysisRepo.listMetrics({ analysis_id: 'an-001' });
+    expect(findings.length).toBeGreaterThan(0);
+    expect(metrics.length).toBeGreaterThan(0);
+  });
+
+  it('returns null for nonexistent analysis', () => {
+    expect(analysisRepo.getAnalysis('nonexistent')).toBeNull();
+  });
+});
+
+describe('Analysis API - GET /api/analysis-results/:id/findings', () => {
+  beforeEach(() => { seed(analysisRepo); });
+
+  it('lists findings for an analysis', () => {
+    const findings = analysisRepo.listFindings({ analysis_id: 'an-001' });
+    expect(findings.length).toBeGreaterThanOrEqual(3);
+    findings.forEach(f => expect(f.analysis_id).toBe('an-001'));
+  });
+
+  it('filters findings by severity', () => {
+    const critical = analysisRepo.listFindings({ analysis_id: 'an-003', severity: 'critical' });
+    expect(critical.length).toBeGreaterThan(0);
+    critical.forEach(f => expect(f.severity).toBe('critical'));
+  });
+
+  it('filters findings by finding_type', () => {
+    const vulns = analysisRepo.listFindings({ finding_type: 'vulnerability' });
+    expect(vulns.length).toBeGreaterThan(0);
+    vulns.forEach(f => expect(f.finding_type).toBe('vulnerability'));
+  });
+});
+
+describe('Analysis API - GET /api/analysis-results/:id/metrics', () => {
+  beforeEach(() => { seed(analysisRepo); });
+
+  it('lists metrics for an analysis', () => {
+    const metrics = analysisRepo.listMetrics({ analysis_id: 'an-001' });
+    expect(metrics.length).toBeGreaterThanOrEqual(2);
+    metrics.forEach(m => expect(m.analysis_id).toBe('an-001'));
+  });
+
+  it('filters metrics by type', () => {
+    const coverage = analysisRepo.listMetrics({ metric_type: 'test_coverage' });
+    expect(coverage.length).toBeGreaterThan(0);
+    coverage.forEach(m => expect(m.metric_type).toBe('test_coverage'));
+  });
+});
+
+describe('Analysis API - GET /api/analysis-results/stats', () => {
+  beforeEach(() => { seed(analysisRepo); });
+
+  it('returns correct total counts', () => {
+    const analyses = analysisRepo.listAnalyses({});
+    const findings = analysisRepo.listFindings({});
+    const metrics = analysisRepo.listMetrics({});
+    expect(analyses.length).toBeGreaterThanOrEqual(5);
+    expect(findings.length).toBeGreaterThanOrEqual(8);
+    expect(metrics.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('counts analyses by status', () => {
+    const analyses = analysisRepo.listAnalyses({});
+    const counts = {};
+    for (const a of analyses) counts[a.status] = (counts[a.status] || 0) + 1;
+    expect(counts.completed).toBeGreaterThanOrEqual(3);
+  });
+
+  it('computes average quality score', () => {
+    const analyses = analysisRepo.listAnalyses({});
+    const scored = analyses.filter(a => a.quality_score !== null);
+    expect(scored.length).toBeGreaterThan(0);
+    const avg = Math.round(scored.reduce((s, a) => s + a.quality_score, 0) / scored.length);
+    expect(avg).toBeGreaterThan(0);
+    expect(avg).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('Analysis API - Route registration', () => {
+  it('exports analysisRepo', () => {
+    expect(analysisRepo).toBeDefined();
+    expect(typeof analysisRepo.addAnalysis).toBe('function');
+    expect(typeof analysisRepo.listAnalyses).toBe('function');
+    expect(typeof analysisRepo.listFindings).toBe('function');
+    expect(typeof analysisRepo.listMetrics).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- 5 REST endpoints for querying analysis results, findings, metrics, and stats
- Filtering by repository_name, status, severity, finding_type, metric_type
- Pagination support with limit/offset
- 15 tests all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)