### PR TITLE
feat(SD-LEO-INFRA-MULTI-REPO-ROUTING-001): wire venture context through routing pipeline

### DIFF
--- a/lib/multi-repo/index.js
+++ b/lib/multi-repo/index.js
@@ -16,7 +16,7 @@
  */
 
 import { execSync } from 'child_process';
-import { existsSync, readdirSync, statSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join, resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -33,25 +33,66 @@ export const EHG_BASE_DIR = resolve(__dirname, '../../..');
 // Repos to permanently ignore
 export const IGNORED_REPOS = ['ehg-replit-archive', 'solara2', 'node_modules', '.git'];
 
-// Known repositories with metadata
-export const KNOWN_REPOS = {
-  ehg: {
-    name: 'ehg',
-    displayName: 'EHG (Frontend)',
-    purpose: 'React/Vite frontend application',
-    github: 'rickfelix/ehg',
-    priority: 2,
-    contains: ['UI components', 'pages', 'routes', 'React hooks']
-  },
-  EHG_Engineer: {
-    name: 'EHG_Engineer',
-    displayName: 'EHG_Engineer (Backend)',
-    purpose: 'Backend tooling, CLI, and infrastructure',
-    github: 'rickfelix/EHG_Engineer',
-    priority: 1,
-    contains: ['CLI tools', 'scripts', 'lib modules', 'database migrations']
+// SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Registry-driven known repos
+// Builds KNOWN_REPOS from applications/registry.json instead of hardcoding.
+// Falls back to legacy hardcoded repos if registry is unavailable.
+function loadKnownReposFromRegistry() {
+  const registryPath = resolve(__dirname, '../../applications/registry.json');
+  try {
+    const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+    const apps = registry.applications || {};
+    const repos = {};
+    for (const app of Object.values(apps)) {
+      if (app.status !== 'active' || !app.name) continue;
+      repos[app.name] = {
+        name: app.name,
+        displayName: app.name,
+        purpose: app.description || '',
+        github: app.github_repo || `rickfelix/${app.name}`,
+        priority: app.name === 'EHG_Engineer' ? 1 : (app.name === 'ehg' ? 2 : 3),
+        contains: [],
+        local_path: app.local_path || null
+      };
+    }
+    // Ensure EHG_Engineer and ehg always present (core repos)
+    if (!repos.EHG_Engineer) {
+      repos.EHG_Engineer = {
+        name: 'EHG_Engineer', displayName: 'EHG_Engineer (Backend)',
+        purpose: 'Backend tooling, CLI, and infrastructure',
+        github: 'rickfelix/EHG_Engineer', priority: 1,
+        contains: ['CLI tools', 'scripts', 'lib modules', 'database migrations']
+      };
+    }
+    if (!repos.ehg) {
+      repos.ehg = {
+        name: 'ehg', displayName: 'EHG (Frontend)',
+        purpose: 'React/Vite frontend application',
+        github: 'rickfelix/ehg', priority: 2,
+        contains: ['UI components', 'pages', 'routes', 'React hooks']
+      };
+    }
+    return repos;
+  } catch {
+    // Fallback to legacy hardcoded repos if registry unavailable
+    return {
+      ehg: {
+        name: 'ehg', displayName: 'EHG (Frontend)',
+        purpose: 'React/Vite frontend application',
+        github: 'rickfelix/ehg', priority: 2,
+        contains: ['UI components', 'pages', 'routes', 'React hooks']
+      },
+      EHG_Engineer: {
+        name: 'EHG_Engineer', displayName: 'EHG_Engineer (Backend)',
+        purpose: 'Backend tooling, CLI, and infrastructure',
+        github: 'rickfelix/EHG_Engineer', priority: 1,
+        contains: ['CLI tools', 'scripts', 'lib modules', 'database migrations']
+      }
+    };
   }
-};
+}
+
+// Known repositories with metadata (registry-driven with fallback)
+export const KNOWN_REPOS = loadKnownReposFromRegistry();
 
 // Component type to repository mapping
 export const COMPONENT_REPO_MAP = {

--- a/lib/venture-resolver.js
+++ b/lib/venture-resolver.js
@@ -57,7 +57,7 @@ function loadRegistry() {
  * Handles case-insensitive matching (e.g., 'EHG', 'ehg', 'EHG_Engineer').
  *
  * @param {string} targetApp - Application name (e.g., 'EHG', 'EHG_Engineer', 'ehg')
- * @returns {string} Absolute local path to the venture repository
+ * @returns {string|null} Absolute local path to the venture repository, or null if not found
  */
 export function getVenturePath(targetApp) {
   if (!targetApp) return ENGINEER_ROOT;
@@ -78,9 +78,10 @@ export function getVenturePath(targetApp) {
     return ENGINEER_ROOT;
   }
 
-  // Auto-discover: assume sibling directory of EHG_Engineer parent
-  const baseDir = path.resolve(ENGINEER_ROOT, '..');
-  return path.resolve(baseDir, targetApp);
+  // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Registry-only resolution.
+  // Auto-discovery fallback removed per CRO risk assessment — unvalidated
+  // filesystem guesses are unacceptable for multi-repo routing.
+  return null;
 }
 
 /**

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -24,6 +24,7 @@ import {
   normalizeVenturePrefix
 } from './modules/sd-key-generator.js';
 import { VentureContextManager } from '../lib/eva/venture-context-manager.js';
+import { getCurrentVenture, getVentureConfig } from '../lib/venture-resolver.js';
 import {
   checkGate,
   getArtifacts,
@@ -956,6 +957,8 @@ async function createSD(options) {
     // PAT-SDCREATE-001: Allow passing key_changes and smoke_test_steps
     key_changes = null,
     smoke_test_steps = null,
+    // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Allow explicit target_application
+    target_application: explicitTargetApp = null,
   } = options;
 
   // QF-CLAIM-CONFLICT-UX-001 + SD-LEO-ENH-IMPLEMENT-TIERED-QUICK-001:
@@ -1260,6 +1263,12 @@ async function createSD(options) {
     }
   }
 
+  // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Resolve target_application from venture context
+  // Precedence: explicit param > VENTURE env var > getCurrentVenture() > 'EHG_Engineer'
+  const resolvedTargetApplication = explicitTargetApp
+    || (process.env.VENTURE && (getVentureConfig(process.env.VENTURE)?.name || process.env.VENTURE))
+    || null;
+
   const sdData = {
     id: randomUUID(),
     sd_key: sdKey,
@@ -1272,7 +1281,7 @@ async function createSD(options) {
     priority,
     category: categoryValue,  // Use calculated value (may be inherited from parent)
     current_phase: 'LEAD',
-    target_application: 'EHG_Engineer',
+    target_application: resolvedTargetApplication || getCurrentVenture() || 'EHG_Engineer',
     created_by: 'Claude',
     parent_sd_id: parentId,
     success_criteria: finalSuccessCriteria,  // Array, NOT JSON.stringify()
@@ -1828,6 +1837,10 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         console.log('✓ SD fields enriched from vision/architecture documents');
       }
 
+      // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Resolve target_application from --venture flag
+      const ventureConfig = cliVenture ? getVentureConfig(cliVenture) : null;
+      const targetApp = ventureConfig?.name || cliVenture || null;
+
       await createSD({
         sdKey,
         title,
@@ -1836,6 +1849,7 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         rationale: enriched?.rationale || 'Created via /leo create',
         success_criteria: enriched?.success_criteria || null,
         key_changes: enriched?.key_changes || null,
+        target_application: targetApp,
         metadata: {
           source: source.toLowerCase(),
           ...phase0Metadata,


### PR DESCRIPTION
## Summary
- **leo-create-sd.js**: Replace hardcoded `target_application: 'EHG_Engineer'` with venture context chain (explicit param > VENTURE env > getCurrentVenture() > fallback). Root cause of all SDs defaulting to EHG_Engineer.
- **multi-repo/index.js**: Load `KNOWN_REPOS` from `applications/registry.json` instead of hardcoded 2-repo map. Now discovers all 5 registered ventures automatically.
- **venture-resolver.js**: Remove unsafe auto-discovery fallback that guessed sibling directories. Returns `null` when venture not found in registry (fail-closed per CRO risk assessment).

**Phase 1 of 4** for SD-LEO-INFRA-MULTI-REPO-ROUTING-001 (Multi-Repo Routing).

## Test plan
- [x] `getVenturePath('ehg')` returns correct path
- [x] `getVenturePath('unknown')` returns `null` (no unsafe fallback)
- [x] `KNOWN_REPOS` loads 5 entries from registry (was hardcoded to 2)
- [x] leo-create-sd.js imports resolve without errors
- [ ] Create test SD with `VENTURE=ehg` env var, verify target_application='ehg'

🤖 Generated with [Claude Code](https://claude.com/claude-code)