### PR TITLE
feat(SD-LEO-INFRA-MULTI-REPO-ROUTING-001): claim-time routing and sd:next venture display

### DIFF
--- a/scripts/modules/sd-next/data-loaders.js
+++ b/scripts/modules/sd-next/data-loaders.js
@@ -184,7 +184,7 @@ export async function loadSDHierarchy(supabase) {
   try {
     const { data: sds } = await supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, title, parent_sd_id, status, current_phase, progress_percentage, dependencies, is_working_on, metadata, priority')
+      .select('id, sd_key, title, parent_sd_id, status, current_phase, progress_percentage, dependencies, is_working_on, metadata, priority, target_application')
       .eq('is_active', true)
       .order('created_at')
       .limit(1000);

--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -145,8 +145,12 @@ async function displaySDItem(item, indent, childItems, allItems, sessionContext)
   const urgencyBadge = item.urgency_band
     ? ` ${urgencyBadgeColors[item.urgency_band] || colors.dim}[${item.urgency_band}]${colors.reset}`
     : '';
+  // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Show venture affinity badge
+  const ventureBadge = item.target_application && item.target_application !== 'EHG_Engineer'
+    ? ` ${colors.cyan}[${item.target_application}]${colors.reset}`
+    : '';
 
-  console.log(`${indent}${claimedIcon}${workingIcon}${localActivityIcon}${rankStr} ${sdId} - ${title}${urgencyBadge}${visionBadge}${gapBadge}... ${statusIcon}`);
+  console.log(`${indent}${claimedIcon}${workingIcon}${localActivityIcon}${rankStr} ${sdId} - ${title}${ventureBadge}${urgencyBadge}${visionBadge}${gapBadge}... ${statusIcon}`);
 
   // Show claim details with PID-aware output
   if (isClaimedByOther) {

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -20,6 +20,7 @@
  */
 
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { getVenturePath } from '../lib/venture-resolver.js';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
@@ -268,7 +269,7 @@ function emitLog(fields) {
   console.error(JSON.stringify(entry));
 }
 
-async function resolve(sdKey, mode, repoRoot) {
+async function resolve(sdKey, mode, repoRoot, targetApp) {
   if (!validateSdKey(sdKey)) {
     return {
       sdKey, cwd: repoRoot, source: 'legacy', success: false,
@@ -276,6 +277,35 @@ async function resolve(sdKey, mode, repoRoot) {
       errorCode: 'INVALID_SD_KEY',
       error: `Invalid SD key: ${sdKey}`
     };
+  }
+
+  // SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Resolve repo root from SD's target_application
+  // When an SD targets a venture repo, create worktrees in that repo instead of EHG_Engineer
+  if (!targetApp) {
+    try {
+      const sb = createSupabaseServiceClient();
+      const { data: sdRow } = await sb
+        .from('strategic_directives_v2')
+        .select('target_application')
+        .or(`sd_key.eq.${sdKey},id.eq.${sdKey}`)
+        .single();
+      if (sdRow?.target_application) {
+        targetApp = sdRow.target_application;
+      }
+    } catch {
+      // Non-fatal — fall through to default repoRoot
+    }
+  }
+
+  if (targetApp && targetApp !== 'EHG_Engineer') {
+    const venturePath = getVenturePath(targetApp);
+    if (venturePath && fs.existsSync(path.join(venturePath, '.git'))) {
+      repoRoot = venturePath;
+      emitLog({ event: 'worktree.venture_repo_resolved', sdKey, targetApp, repoRoot: venturePath });
+    } else {
+      emitLog({ event: 'worktree.venture_repo_not_found', sdKey, targetApp, resolvedPath: venturePath });
+      // Fall through to default repoRoot (EHG_Engineer)
+    }
   }
 
   // 1. Try DB lookup first
@@ -358,11 +388,13 @@ async function main() {
   let sdKey = null;
   let mode = 'claim';
   let repoRoot = null;
+  let targetApp = null;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--sdKey' && args[i + 1]) { sdKey = args[++i]; }
     else if (args[i] === '--mode' && args[i + 1]) { mode = args[++i]; }
     else if (args[i] === '--repoRoot' && args[i + 1]) { repoRoot = args[++i]; }
+    else if (args[i] === '--target-app' && args[i + 1]) { targetApp = args[++i]; }
     else if (!args[i].startsWith('--')) { sdKey = sdKey || args[i]; }
   }
 
@@ -383,7 +415,7 @@ async function main() {
   }
 
   const resolvedRoot = getRepoRoot(repoRoot);
-  const result = await resolve(sdKey, mode, resolvedRoot);
+  const result = await resolve(sdKey, mode, resolvedRoot, targetApp);
 
   // Output to stdout (machine-readable)
   process.stdout.write(JSON.stringify(result));

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -186,7 +186,7 @@ async function getSDDetails(sdId) {
   // Note: legacy_id column was deprecated and removed - using sd_key instead
   const { data, error } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, title, status, current_phase, priority, progress_percentage, is_working_on, sd_type, created_at')
+    .select('id, sd_key, title, status, current_phase, priority, progress_percentage, is_working_on, sd_type, created_at, target_application, venture_id')
     .or(`sd_key.eq.${sdId},id.eq.${sdId}`)
     .single();
 
@@ -745,7 +745,7 @@ async function main() {
       if (!hasRequired) {
         console.log(`\n${colors.bgYellow}${colors.bold} STUCK SD WARNING ${colors.reset}`);
         console.log(`   ${colors.yellow}SD is in phase ${phase} but has no accepted ${req.from}→${req.to} handoff${colors.reset}`);
-        console.log(`   This SD may have a broken handoff chain.`);
+        console.log('   This SD may have a broken handoff chain.');
         console.log(`   ${colors.cyan}Run: npm run sd:recover -- ${effectiveId} --fix${colors.reset}`);
         console.log('');
       }
@@ -764,6 +764,27 @@ async function main() {
   console.log(`Progress: ${sd.progress_percentage || 0}%`);
   console.log(`Type: ${sd.sd_type || 'feature'}`);
   console.log(`claiming_session_id: ${colors.green}${session.session_id}${colors.reset}`);
+
+  // 5.05. SD-LEO-INFRA-MULTI-REPO-ROUTING-001: Set venture context on claim
+  // When an SD has target_application or venture_id, propagate to session metadata
+  if (sd.target_application && sd.target_application !== 'EHG_Engineer') {
+    try {
+      const { VentureContextManager } = await import('../lib/eva/venture-context-manager.js');
+      const vcm = new VentureContextManager({ supabaseClient: supabase });
+      if (sd.venture_id) {
+        await vcm.setActiveVenture(sd.venture_id);
+        console.log(`\n${colors.cyan}   🏢 Venture context set: ${sd.target_application} (from SD venture_id)${colors.reset}`);
+      } else {
+        // Store target_application in session metadata even without venture_id
+        await supabase.from('claude_sessions')
+          .update({ metadata: supabase.rpc ? undefined : { active_target_application: sd.target_application } })
+          .eq('session_id', session.session_id);
+        console.log(`\n${colors.cyan}   🏢 Target application: ${sd.target_application}${colors.reset}`);
+      }
+    } catch {
+      // Non-fatal — venture context is advisory
+    }
+  }
 
   // 5.1. Show worktree info + machine-readable activation directive
   if (worktreeInfo?.success && worktreeInfo.worktree?.exists) {


### PR DESCRIPTION
## Summary
- **sd-start.js**: Set venture context in session metadata when claiming an SD that targets a non-EHG_Engineer repo
- **resolve-sd-workdir.js**: Query SD's target_application to resolve correct venture repo root for worktree creation; add `--target-app` CLI flag
- **data-loaders.js**: Include target_application in SD queue query
- **tracks.js**: Show `[venture]` badge on SDs targeting non-EHG_Engineer repos in sd:next display

**Phase 2 of 4** for SD-LEO-INFRA-MULTI-REPO-ROUTING-001 (Multi-Repo Routing).

## Test plan
- [x] Syntax check passes on all 4 files
- [x] Smoke tests pass (15/15)
- [ ] Claim venture SD, verify session metadata updated with active_target_application
- [ ] Run sd:next with venture SDs, verify badge displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)