### PR TITLE
feat(SD-LEO-INFRA-WIRE-VENTURE-PROVISIONER-001): wire provisioner stubs to real implementations

### DIFF
--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -9,6 +9,15 @@
 
 import { getState, updateStep, markComplete, markFailed } from './provisioning-state.js';
 import { evaluateConformance, buildConformanceMetadata } from './conformance-integration.js';
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { resolve, join } from 'path';
+import { fileURLToPath } from 'url';
+import { createSupabaseServiceClient } from '../../supabase-client.js';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+const REGISTRY_PATH = resolve(__dirname, '../../../applications/registry.json');
+const ENGINEER_ROOT = resolve(__dirname, '../../..');
 
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
@@ -18,38 +27,173 @@ const BASE_DELAY_MS = 1000;
  * Each step has: name, check (is it already done?), execute (do it).
  * Steps are stubs — real implementations are wired by downstream SDs.
  */
+/**
+ * Resolve venture metadata from DB for provisioning context.
+ * @param {string} ventureId - Venture UUID
+ * @returns {Promise<{name: string, repoName: string, localPath: string}|null>}
+ */
+async function resolveVentureMetadata(ventureId) {
+  const supabase = createSupabaseServiceClient();
+  const { data } = await supabase
+    .from('ventures')
+    .select('name, metadata')
+    .eq('id', ventureId)
+    .single();
+  if (!data) return null;
+  // Normalize name to kebab-case for repo/directory naming
+  const repoName = data.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  const localPath = resolve(ENGINEER_ROOT, '..', repoName);
+  return { name: data.name, repoName, localPath };
+}
+
 const DEFAULT_STEPS = [
   {
     name: 'repo_created',
-    check: async (ctx) => ctx.stepsCompleted.includes('repo_created'),
+    check: async (ctx) => {
+      if (ctx.stepsCompleted.includes('repo_created')) return true;
+      // Also check if GitHub repo already exists
+      if (!ctx.venture) return false;
+      try {
+        execSync(`gh repo view rickfelix/${ctx.venture.repoName} --json name`, { stdio: 'pipe', encoding: 'utf8' });
+        return true;
+      } catch { return false; }
+    },
     execute: async (ctx) => {
-      // Stub: Real implementation in SD-F (CI/CD Template Generation)
-      // Would call: gh repo create <owner>/<venture-name> --template <template>
-      ctx.log(`[repo_created] Stub: Would create GitHub repo for venture ${ctx.ventureId}`);
+      if (!ctx.venture) {
+        ctx.venture = await resolveVentureMetadata(ctx.ventureId);
+      }
+      if (!ctx.venture) throw new Error(`Venture ${ctx.ventureId} not found in ventures table`);
+      const { repoName } = ctx.venture;
+
+      // Create GitHub repo via gh CLI
+      ctx.log(`[repo_created] Creating GitHub repo: rickfelix/${repoName}`);
+      execSync(`gh repo create rickfelix/${repoName} --public --description "EHG Venture: ${ctx.venture.name}"`, {
+        stdio: 'pipe', encoding: 'utf8', timeout: 30000
+      });
+
+      // Clone locally and scaffold if needed
+      if (!existsSync(ctx.venture.localPath)) {
+        ctx.log(`[repo_created] Cloning to ${ctx.venture.localPath}`);
+        execSync(`git clone https://github.com/rickfelix/${repoName}.git "${ctx.venture.localPath}"`, {
+          stdio: 'pipe', encoding: 'utf8', timeout: 60000
+        });
+      }
+      ctx.ventureRepoPath = ctx.venture.localPath;
+      ctx.log(`[repo_created] GitHub repo created: rickfelix/${repoName}`);
     },
   },
   {
     name: 'registry_updated',
-    check: async (ctx) => ctx.stepsCompleted.includes('registry_updated'),
+    check: async (ctx) => {
+      if (ctx.stepsCompleted.includes('registry_updated')) return true;
+      if (!ctx.venture) return false;
+      try {
+        const registry = JSON.parse(readFileSync(REGISTRY_PATH, 'utf8'));
+        return Object.values(registry.applications || {}).some(
+          a => a.name?.toLowerCase() === ctx.venture.repoName.toLowerCase()
+        );
+      } catch { return false; }
+    },
     execute: async (ctx) => {
-      // Stub: Real implementation adds entry to applications/registry.json
-      ctx.log(`[registry_updated] Stub: Would update application registry for venture ${ctx.ventureId}`);
+      if (!ctx.venture) {
+        ctx.venture = await resolveVentureMetadata(ctx.ventureId);
+      }
+      if (!ctx.venture) throw new Error(`Venture ${ctx.ventureId} not found`);
+
+      const registry = JSON.parse(readFileSync(REGISTRY_PATH, 'utf8'));
+      const apps = registry.applications || {};
+
+      // Find next APP ID
+      const existingIds = Object.keys(apps).map(k => parseInt(k.replace('APP', ''), 10)).filter(n => !isNaN(n));
+      const nextId = `APP${String(Math.max(0, ...existingIds) + 1).padStart(3, '0')}`;
+
+      apps[nextId] = {
+        id: nextId,
+        name: ctx.venture.repoName,
+        github_repo: `rickfelix/${ctx.venture.repoName}`,
+        supabase_project_id: 'pending',
+        supabase_url: 'pending',
+        status: 'active',
+        environment: 'development',
+        registered_at: new Date().toISOString(),
+        registered_by: 'venture-provisioner',
+        local_path: ctx.venture.localPath.replace(/\\/g, '/')
+      };
+
+      registry.applications = apps;
+      registry.metadata.total_apps = Object.keys(apps).length;
+      registry.metadata.active_apps = Object.values(apps).filter(a => a.status === 'active').length;
+      registry.metadata.last_updated = new Date().toISOString();
+
+      writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2) + '\n');
+      ctx.log(`[registry_updated] Added ${nextId}: ${ctx.venture.repoName} to registry`);
     },
   },
   {
     name: 'schema_created',
     check: async (ctx) => ctx.stepsCompleted.includes('schema_created'),
     execute: async (ctx) => {
-      // Stub: Real implementation creates Supabase schema for venture
-      ctx.log(`[schema_created] Stub: Would create Supabase schema for venture ${ctx.ventureId}`);
+      // Default: use shared/consolidated DB (same as EHG_Engineer)
+      // Separate Supabase projects deferred until ventures reach production (per CFO/CISO board decision)
+      if (!ctx.venture) ctx.venture = await resolveVentureMetadata(ctx.ventureId);
+      ctx.log(`[schema_created] Using consolidated DB pattern (shared Supabase project)`);
+      ctx.log(`[schema_created] Venture ${ctx.venture?.repoName || ctx.ventureId} will use EHG_Engineer Supabase until production`);
+
+      // Update registry entry with consolidated DB URL if registry was already updated
+      try {
+        const registry = JSON.parse(readFileSync(REGISTRY_PATH, 'utf8'));
+        for (const app of Object.values(registry.applications || {})) {
+          if (app.name === ctx.venture?.repoName && app.supabase_url === 'pending') {
+            app.supabase_url = process.env.SUPABASE_URL || 'consolidated';
+            app.supabase_project_id = process.env.SUPABASE_PROJECT_ID || 'consolidated';
+            app.note = 'CONSOLIDATED: Uses same DB as EHG_Engineer until production';
+            writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2) + '\n');
+            ctx.log(`[schema_created] Registry updated with consolidated DB reference`);
+            break;
+          }
+        }
+      } catch { /* Non-fatal */ }
     },
   },
   {
     name: 'cicd_configured',
-    check: async (ctx) => ctx.stepsCompleted.includes('cicd_configured'),
+    check: async (ctx) => {
+      if (ctx.stepsCompleted.includes('cicd_configured')) return true;
+      // Check if CI workflow exists in local repo
+      const repoPath = ctx.ventureRepoPath || ctx.venture?.localPath;
+      if (!repoPath) return false;
+      return existsSync(join(repoPath, '.github', 'workflows', 'ci.yml'));
+    },
     execute: async (ctx) => {
-      // Stub: Real implementation in SD-F (CI/CD Template Generation)
-      ctx.log(`[cicd_configured] Stub: Would configure CI/CD for venture ${ctx.ventureId}`);
+      const repoPath = ctx.ventureRepoPath || ctx.venture?.localPath;
+      if (!repoPath || !existsSync(repoPath)) {
+        ctx.log('[cicd_configured] No local repo path — skipping CI/CD generation');
+        return;
+      }
+      const workflowDir = join(repoPath, '.github', 'workflows');
+      if (!existsSync(workflowDir)) {
+        execSync(`mkdir -p "${workflowDir.replace(/\\/g, '/')}"`, { stdio: 'pipe' });
+      }
+      // Generate minimal CI workflow
+      const ciYml = `name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm test
+`;
+      writeFileSync(join(workflowDir, 'ci.yml'), ciYml);
+      ctx.log(`[cicd_configured] Generated .github/workflows/ci.yml`);
     },
   },
   {
@@ -151,7 +295,9 @@ export async function provisionVenture(ventureId, options = {}) {
     await updateStep(ventureId, steps[0].name, 'in_progress');
   }
 
-  const ctx = { ventureId, ventureRepoPath: options.ventureRepoPath || null, stepsCompleted: stateData.stepsCompleted, log };
+  // SD-LEO-INFRA-WIRE-VENTURE-PROVISIONER-001: Pre-resolve venture metadata for steps
+  const venture = await resolveVentureMetadata(ventureId);
+  const ctx = { ventureId, venture, ventureRepoPath: options.ventureRepoPath || venture?.localPath || null, stepsCompleted: stateData.stepsCompleted, log };
 
   // Execute each step
   for (const step of steps) {


### PR DESCRIPTION
## Summary
- Replace all 4 stub steps in `venture-provisioner.js` with real implementations
- **repo_created**: GitHub repo via `gh repo create`, clone locally. Idempotent via `gh repo view`.
- **registry_updated**: Add APP entry to `registry.json` with auto-incrementing ID. Idempotent via name lookup.
- **schema_created**: Uses consolidated DB pattern (shared Supabase per board decision). Updates registry.
- **cicd_configured**: Generate `.github/workflows/ci.yml`. Idempotent via file existence.
- Add `resolveVentureMetadata()` helper (queries ventures table, derives kebab-case repo name)

Unblocks all venture sprints (CommitCraft AI, CodeGuardian CI) that need provisioned repos.

## Test plan
- [x] Syntax check passes
- [ ] Provision test venture, verify GitHub repo created
- [ ] Re-run provisioning, verify all steps skip (idempotent)
- [ ] Verify registry.json updated with new entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)