### PR TITLE
fix: remove stray merge artifact in concurrent-session-worktree.cjs

### DIFF
--- a/scripts/hooks/concurrent-session-worktree.cjs
+++ b/scripts/hooks/concurrent-session-worktree.cjs
@@ -441,8 +441,7 @@ async function main() {
   let supabase;
   try {
     const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
- });
-        supabase = createSupabaseServiceClient();
+    supabase = createSupabaseServiceClient();
   } catch {
     return; // Supabase not available - skip silently
   }


### PR DESCRIPTION
## Summary
- Fixes syntax error at line 444 of `scripts/hooks/concurrent-session-worktree.cjs`
- Stray `});` merge artifact broke try/catch structure, preventing hook from running
- Discovered during PCVP audit of SD-LEO-INFRA-VENTURE-DEVWORKFLOW-AWARENESS-001

## Test plan
- [x] `node --check` confirms clean parse
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)