### PR TITLE
fix(CA-3): repair broken import in design/workflow-analyzer.js

### DIFF
--- a/lib/sub-agents/design/workflow-analyzer.js
+++ b/lib/sub-agents/design/workflow-analyzer.js
@@ -22,8 +22,8 @@ import {
   generateWorkflowRecommendations,
   calculateOverallQualityScore
 } from './workflow-scoring.js';
-import {
 import { resolveRepoPath } from '../../repo-paths.js';
+import {
   extractWorkflowFromStories,
   buildInteractionGraph,
   detectWorkflowIssues


### PR DESCRIPTION
## Summary
- Fixes syntax error where `resolveRepoPath` import was inserted inside another import block
- Part of CA-3 corrective action from PCVP audit
- All sub-agent and QA module hardcoded paths confirmed clean (grep audit: zero matches)

## Test plan
- [x] `node --check lib/sub-agents/design/workflow-analyzer.js` passes
- [x] Smoke tests pass (15/15)
- [x] `grep -r "path.resolve.*ehg" lib/sub-agents/` returns zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)