### PR TITLE
feat: Stage 20 rescan RPC for venture build tracking

### DIFF
--- a/database/migrations/20260329_rescan_stage20_rpc.sql
+++ b/database/migrations/20260329_rescan_stage20_rpc.sql
@@ -1,0 +1,97 @@
+-- Rescan Stage 20: Refresh SD completion status for a venture
+-- Called from Chairman Dashboard to trigger build execution progress check.
+--
+-- Returns JSON: { success, total, terminal, pending_count, stage_status, build_pending }
+
+CREATE OR REPLACE FUNCTION rescan_stage_20(p_venture_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_total INTEGER;
+  v_terminal INTEGER;
+  v_pending INTEGER;
+  v_all_terminal BOOLEAN;
+  v_stage_status TEXT;
+  v_advisory JSONB;
+  v_current_stage INTEGER;
+BEGIN
+  -- Count SDs by terminal status
+  SELECT
+    COUNT(*),
+    COUNT(*) FILTER (WHERE status IN ('completed', 'cancelled')),
+    COUNT(*) FILTER (WHERE status NOT IN ('completed', 'cancelled'))
+  INTO v_total, v_terminal, v_pending
+  FROM strategic_directives_v2
+  WHERE venture_id = p_venture_id;
+
+  IF v_total = 0 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'reason', 'No SDs found for venture',
+      'total', 0, 'terminal', 0, 'pending_count', 0
+    );
+  END IF;
+
+  v_all_terminal := v_pending = 0;
+  v_stage_status := CASE WHEN v_all_terminal THEN 'completed' ELSE 'in_progress' END;
+
+  -- Build advisory_data with current SD statuses
+  SELECT jsonb_build_object(
+    'total_sds', v_total,
+    'terminal_sds', v_terminal,
+    'non_terminal_sds', v_pending,
+    'build_pending', NOT v_all_terminal,
+    'checked_at', NOW()::TEXT,
+    'rescan_source', 'rpc:rescan_stage_20',
+    'sd_statuses', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'sd_key', sd_key,
+        'title', title,
+        'status', status,
+        'current_phase', current_phase,
+        'sd_type', sd_type
+      ) ORDER BY sd_key)
+      FROM strategic_directives_v2
+      WHERE venture_id = p_venture_id
+    ), '[]'::jsonb)
+  ) INTO v_advisory;
+
+  -- Update venture_stage_work stage 20
+  UPDATE venture_stage_work
+  SET advisory_data = v_advisory,
+      stage_status = v_stage_status,
+      completed_at = CASE WHEN v_all_terminal THEN NOW() ELSE completed_at END,
+      updated_at = NOW()
+  WHERE venture_id = p_venture_id
+    AND lifecycle_stage = 20;
+
+  -- If all terminal, advance venture to stage 21
+  IF v_all_terminal THEN
+    SELECT current_lifecycle_stage INTO v_current_stage
+    FROM ventures WHERE id = p_venture_id;
+
+    IF v_current_stage IS NOT NULL AND v_current_stage <= 20 THEN
+      UPDATE ventures
+      SET current_lifecycle_stage = 21
+      WHERE id = p_venture_id;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'total', v_total,
+    'terminal', v_terminal,
+    'pending_count', v_pending,
+    'stage_status', v_stage_status,
+    'build_pending', NOT v_all_terminal,
+    'advanced_to', CASE WHEN v_all_terminal AND v_current_stage <= 20 THEN 21 ELSE NULL END
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION rescan_stage_20(UUID) IS
+  'Rescans SD completion status for a venture and updates Stage 20 advisory_data. '
+  'Called from Chairman Dashboard Stage 20 rescan button. '
+  'Auto-advances venture to Stage 21 if all SDs are terminal.';

--- a/scripts/rescan-stage20.js
+++ b/scripts/rescan-stage20.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Rescan Stage 20 — Refresh SD completion status for a venture
+ *
+ * Thin CLI wrapper around the rescan_stage_20 RPC function.
+ * The RPC queries current SD statuses, updates venture_stage_work
+ * stage 20 advisory_data, and advances to Stage 21 if all SDs are terminal.
+ *
+ * Usage:
+ *   node scripts/rescan-stage20.js --venture <venture-id>
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { fileURLToPath } from 'url';
+
+/**
+ * Rescan SD completion for a venture via RPC.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} [options]
+ * @param {Object} [options.supabase] - Supabase client (created if not provided)
+ * @returns {Promise<Object>} Rescan result from RPC
+ */
+export async function rescanStage20(ventureId, options = {}) {
+  const supabase = options.supabase || createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  const { data, error } = await supabase.rpc('rescan_stage_20', {
+    p_venture_id: ventureId,
+  });
+
+  if (error) throw new Error(`RPC failed: ${error.message}`);
+  return data;
+}
+
+// CLI entry point
+const isMain = import.meta.url === `file://${process.argv[1]}`
+  || import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`;
+
+if (isMain) {
+  const ventureIdx = process.argv.indexOf('--venture');
+  const ventureId = ventureIdx >= 0 ? process.argv[ventureIdx + 1] : null;
+
+  if (!ventureId) {
+    console.error('Usage: node scripts/rescan-stage20.js --venture <venture-id>');
+    process.exit(1);
+  }
+
+  rescanStage20(ventureId)
+    .then(result => {
+      console.log('\nStage 20 Rescan Result:');
+      console.log(`  SDs: ${result.terminal}/${result.total} terminal`);
+      console.log(`  Build pending: ${result.build_pending}`);
+      console.log(`  Stage status: ${result.stage_status}`);
+      if (result.pending_count > 0) {
+        console.log(`  Pending SDs: ${result.pending_count}`);
+      }
+      if (result.advanced_to) {
+        console.log(`  Venture advanced to stage ${result.advanced_to}`);
+      }
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error('Rescan failed:', err.message);
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- `rescan_stage_20(p_venture_id)` PostgreSQL RPC function — rescans SD completion, updates Stage 20 advisory_data, auto-advances to Stage 21
- `scripts/rescan-stage20.js` CLI wrapper for manual invocation
- Frontend button shipped in ehg PR #396

## Verified
- RPC tested: CommitCraft AI (21/21 terminal) -> Stage 20 completed, venture advanced to Stage 21

🤖 Generated with [Claude Code](https://claude.com/claude-code)