### PR TITLE
fix(RCA): orchestrator_state not reset by external stage advancement

### DIFF
--- a/database/migrations/20260329_rescan_stage20_rpc.sql
+++ b/database/migrations/20260329_rescan_stage20_rpc.sql
@@ -74,8 +74,16 @@ BEGIN
 
     IF v_current_stage IS NOT NULL AND v_current_stage <= 20 THEN
       UPDATE ventures
-      SET current_lifecycle_stage = 21
+      SET current_lifecycle_stage = 21,
+          orchestrator_state = 'idle'
       WHERE id = p_venture_id;
+
+      -- Clean up stale chairman_decisions for Stage 20
+      UPDATE chairman_decisions
+      SET status = 'approved', decision = 'proceed', updated_at = NOW()
+      WHERE venture_id = p_venture_id
+        AND lifecycle_stage = 20
+        AND status = 'pending';
     END IF;
   END IF;
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -386,6 +386,7 @@ export class StageExecutionWorker {
         this._logger.warn(`[Worker] Heartbeat failed: ${err.message}`)
       );
       await this._releaseStaleLocks();
+      await this._checkResolvedBlocks();
       await this._markStaleExecutions();
 
       const ventures = await this._pollForWork();
@@ -1407,6 +1408,58 @@ export class StageExecutionWorker {
       }
     } catch (err) {
       this._logger.error(`[Worker] Stale lock sweep error: ${err.message}`);
+    }
+  }
+
+  /**
+   * Safety net: find ventures stuck in 'blocked' state whose blocking condition
+   * has been resolved by an external process (e.g., rescan_stage_20 RPC).
+   *
+   * Detects ventures where orchestrator_state='blocked' but venture_stage_work
+   * for the PREVIOUS stage shows stage_status='completed'. This means an external
+   * process advanced the stage but didn't reset orchestrator_state.
+   *
+   * RCA: PAT-ORCH-STATE-001 — External advancement bypassing orchestrator state machine
+   */
+  async _checkResolvedBlocks() {
+    try {
+      const { data: blocked } = await this._supabase
+        .from('ventures')
+        .select('id, name, current_lifecycle_stage')
+        .eq('status', 'active')
+        .eq('orchestrator_state', ORCHESTRATOR_STATES.BLOCKED);
+
+      if (!blocked || blocked.length === 0) return;
+
+      for (const venture of blocked) {
+        const prevStage = venture.current_lifecycle_stage - 1;
+        if (prevStage < 1) continue;
+
+        const { data: prevWork } = await this._supabase
+          .from('venture_stage_work')
+          .select('stage_status')
+          .eq('venture_id', venture.id)
+          .eq('lifecycle_stage', prevStage)
+          .maybeSingle();
+
+        if (prevWork?.stage_status === 'completed') {
+          this._logger.log(
+            `[Worker] Unblocking ${venture.name || venture.id}: Stage ${prevStage} completed externally, ` +
+            `resetting orchestrator_state to idle for Stage ${venture.current_lifecycle_stage}`
+          );
+          await this._supabase
+            .from('ventures')
+            .update({
+              orchestrator_state: ORCHESTRATOR_STATES.IDLE,
+              orchestrator_lock_id: null,
+              orchestrator_lock_acquired_at: null,
+            })
+            .eq('id', venture.id)
+            .eq('orchestrator_state', ORCHESTRATOR_STATES.BLOCKED);
+        }
+      }
+    } catch (err) {
+      this._logger.warn(`[Worker] Resolved-blocks sweep error: ${err.message}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `rescan_stage_20` RPC advanced `current_lifecycle_stage` to 21 but left `orchestrator_state = 'blocked'`, making the venture invisible to the worker's `_pollForWork()` query
- **Corrective**: RPC now sets `orchestrator_state = 'idle'` + cleans up stale `chairman_decisions`
- **Preventive**: New `_checkResolvedBlocks()` worker sweep detects blocked ventures whose previous stage was completed externally and auto-resets them to idle

## Pattern
PAT-ORCH-STATE-001 — External advancement bypassing orchestrator state machine

## Test plan
- [x] Smoke tests 15/15 pass
- [x] CommitCraft AI manually unblocked and verified (orchestrator_state set to idle)
- [x] RPC redeployed with orchestrator_state fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)