### PR TITLE
fix(RCA): governance override artifact persistence + column typo

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -844,6 +844,27 @@ export class StageExecutionWorker {
           if (governanceOverride) {
             this._logger.log(`[Worker] Stage ${currentStage} BLOCKED by EVA but governance auto-approves — advancing as advisory`);
             this._recordAdvisoryWarning(ventureId, currentStage, result).catch(() => {});
+
+            // Persist the stage's artifacts even though validation failed.
+            // Without this, downstream stages hit contract violations because
+            // fetchUpstreamArtifacts() finds no artifact for this stage.
+            // RCA: PAT-ORCH-STATE-001 (governance override artifact gap)
+            if (result?.artifacts?.length > 0) {
+              try {
+                const { persistArtifact } = await import('./stage-execution-engine.js');
+                const payload = {};
+                for (const a of result.artifacts) {
+                  if (a.payload && typeof a.payload === 'object') Object.assign(payload, a.payload);
+                }
+                if (Object.keys(payload).length > 0) {
+                  await persistArtifact(this._supabase, ventureId, currentStage, payload);
+                  this._logger.log(`[Worker] Governance override: persisted artifact for S${currentStage}`);
+                }
+              } catch (artErr) {
+                this._logger.warn(`[Worker] Governance override artifact persist failed (non-fatal): ${artErr.message}`);
+              }
+            }
+
             // Force advance since EVA didn't set nextStageId (it returned BLOCKED)
             const nextOverrideStage = currentStage + 1;
             await this._supabase.from('ventures')
@@ -852,7 +873,7 @@ export class StageExecutionWorker {
             await this._supabase.from('venture_stage_work')
               .update({ stage_status: 'completed', completed_at: new Date().toISOString() })
               .eq('venture_id', ventureId)
-              .eq('stage_number', currentStage);
+              .eq('lifecycle_stage', currentStage);
             this._logger.log(`[Worker] Governance override: advanced S${currentStage} → S${nextOverrideStage}`);
             this._logStageTransition(ventureId, currentStage, 'completed', stageDurationMs, result).catch(() => {});
             currentStage = nextOverrideStage;


### PR DESCRIPTION
## Summary
Two bugs in the worker's governance override path causing ventures to get stuck:

1. **Column typo**: `.eq('stage_number', ...)` should be `.eq('lifecycle_stage', ...)` — silently matched zero rows, leaving stage_status='blocked' after governance approval
2. **Missing artifacts**: governance override didn't persist stage artifacts, causing downstream contract violations (`stage-22.promotion_gate is required`)

## Root cause chain
Stage blocked → governance override advances → no artifact persisted → next stage's `fetchUpstreamArtifacts()` finds nothing → contract violation → FAILED

## Test plan
- [x] Smoke tests 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)