### PR TITLE
fix(RCA): governance override computes promotion_gate for build-loop stages

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -849,20 +849,44 @@ export class StageExecutionWorker {
             // Without this, downstream stages hit contract violations because
             // fetchUpstreamArtifacts() finds no artifact for this stage.
             // RCA: PAT-ORCH-STATE-001 (governance override artifact gap)
-            if (result?.artifacts?.length > 0) {
-              try {
-                const { persistArtifact } = await import('./stage-execution-engine.js');
-                const payload = {};
+            try {
+              const { persistArtifact, fetchUpstreamArtifacts } = await import('./stage-execution-engine.js');
+              const payload = {};
+              if (result?.artifacts?.length > 0) {
                 for (const a of result.artifacts) {
                   if (a.payload && typeof a.payload === 'object') Object.assign(payload, a.payload);
                 }
-                if (Object.keys(payload).length > 0) {
-                  await persistArtifact(this._supabase, ventureId, currentStage, payload);
-                  this._logger.log(`[Worker] Governance override: persisted artifact for S${currentStage}`);
-                }
-              } catch (artErr) {
-                this._logger.warn(`[Worker] Governance override artifact persist failed (non-fatal): ${artErr.message}`);
               }
+
+              // For build-loop stages (17-22), compute promotion_gate if missing.
+              // evaluatePromotionGate is pure/algorithmic (no LLM) but is normally
+              // only called inside the analysis step's real-data path. When governance
+              // overrides a BLOCKED stage, the real-data path didn't execute, so
+              // promotion_gate is missing — causing downstream contract violations.
+              if (currentStage >= 17 && currentStage <= 22 && !payload.promotion_gate) {
+                try {
+                  const { evaluatePromotionGate } = await import('./stage-templates/stage-23.js');
+                  const upstream = await fetchUpstreamArtifacts(this._supabase, ventureId,
+                    [17, 18, 19, 20, 21].filter(s => s < currentStage));
+                  upstream[`stage${currentStage}Data`] = payload;
+                  const gate = evaluatePromotionGate({
+                    stage17: upstream.stage17Data, stage18: upstream.stage18Data,
+                    stage19: upstream.stage19Data, stage20: upstream.stage20Data,
+                    stage21: upstream.stage21Data, stage22: payload,
+                  });
+                  payload.promotion_gate = gate;
+                  this._logger.log(`[Worker] Governance override: computed promotion_gate for S${currentStage} (pass=${gate.pass})`);
+                } catch (pgErr) {
+                  this._logger.warn(`[Worker] promotion_gate computation failed (non-fatal): ${pgErr.message}`);
+                }
+              }
+
+              if (Object.keys(payload).length > 0) {
+                await persistArtifact(this._supabase, ventureId, currentStage, payload);
+                this._logger.log(`[Worker] Governance override: persisted artifact for S${currentStage}`);
+              }
+            } catch (artErr) {
+              this._logger.warn(`[Worker] Governance override artifact persist failed (non-fatal): ${artErr.message}`);
             }
 
             // Force advance since EVA didn't set nextStageId (it returned BLOCKED)


### PR DESCRIPTION
## Summary
Build-loop stages (17-22) governance-overridden by auto-approve lacked `promotion_gate` in their artifacts. Stage 23 requires this via cross-stage contract. Fix: compute it algorithmically during override using `evaluatePromotionGate()` (pure function, no LLM).

## Root cause
Stage 22 BLOCKED → governance override → artifact persisted without promotion_gate → Stage 23 contract violation → FAILED

## Test plan
- [x] Smoke tests 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)