### PR TITLE
fix(RCA): pending-decision shortcut must enrich promotion_gate

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -581,6 +581,38 @@ export class StageExecutionWorker {
                 .from('chairman_decisions')
                 .update({ status: 'approved', decision: 'proceed', blocking: false, updated_at: new Date().toISOString() })
                 .eq('id', pendingDecision.id);
+
+              // Enrich existing artifact with promotion_gate if missing (build-loop stages).
+              // The pending-decision shortcut skips processStage(), so promotion_gate
+              // may not have been computed. evaluatePromotionGate is pure/algorithmic.
+              // RCA: PAT-ORCH-STATE-001 (pending-decision shortcut artifact gap)
+              if (currentStage >= 17 && currentStage <= 22) {
+                try {
+                  const { fetchUpstreamArtifacts, persistArtifact } = await import('./stage-execution-engine.js');
+                  const { data: existingArt } = await this._supabase.from('venture_artifacts')
+                    .select('id, artifact_data')
+                    .eq('venture_id', ventureId).eq('lifecycle_stage', currentStage).eq('is_current', true)
+                    .maybeSingle();
+                  if (existingArt && !existingArt.artifact_data?.promotion_gate) {
+                    const { evaluatePromotionGate } = await import('./stage-templates/stage-23.js');
+                    const upstream = await fetchUpstreamArtifacts(this._supabase, ventureId,
+                      [17, 18, 19, 20, 21].filter(s => s < currentStage));
+                    const gate = evaluatePromotionGate({
+                      stage17: upstream.stage17Data, stage18: upstream.stage18Data,
+                      stage19: upstream.stage19Data, stage20: upstream.stage20Data,
+                      stage21: upstream.stage21Data, stage22: existingArt.artifact_data,
+                    });
+                    const enriched = { ...existingArt.artifact_data, promotion_gate: gate };
+                    await this._supabase.from('venture_artifacts')
+                      .update({ artifact_data: enriched, content: enriched })
+                      .eq('id', existingArt.id);
+                    this._logger.log(`[Worker] Pending auto-approve: enriched S${currentStage} artifact with promotion_gate (pass=${gate.pass})`);
+                  }
+                } catch (pgErr) {
+                  this._logger.warn(`[Worker] promotion_gate enrichment failed (non-fatal): ${pgErr.message}`);
+                }
+              }
+
               await this._supabase
                 .from('venture_stage_work')
                 .update({ stage_status: 'completed', completed_at: new Date().toISOString() })


### PR DESCRIPTION
## Summary
Second code path fix for promotion_gate gap. The pending-decision auto-approve shortcut at line 576 advances stages without re-running processStage(), leaving the artifact from the first pass without promotion_gate. Stage 23 then fails with contract violation.

Fix: after auto-approving for build-loop stages (17-22), check existing artifact and compute promotion_gate if missing.

## Test plan
- [x] Smoke tests 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)