### PR TITLE
fix(RCA): governance override for FAILED build-loop stages

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -857,13 +857,24 @@ export class StageExecutionWorker {
 
         const resultStatus = (result?.status || '').toUpperCase();
         if (!result || resultStatus === 'FAILED') {
-          this._logger.error(`[Worker] Stage ${currentStage} failed for ${ventureId} after retries`);
-          this._logStageTransition(ventureId, currentStage, 'failed', stageDurationMs, result).catch(() => {});
-          releaseState = ORCHESTRATOR_STATES.FAILED;
-          break;
+          // For build-loop stages with auto-approve, treat FAILED as BLOCKED so
+          // governance can override. Analysis steps throw REFUSED for LLM-disabled
+          // stages, which becomes FAILED — but governance should still advance.
+          // RCA: PAT-ORCH-STATE-001 (FAILED vs BLOCKED in build-loop)
+          const canGovernanceOverrideFailed = resultStatus === 'FAILED'
+            && currentStage >= 17 && currentStage <= 22
+            && await this._shouldAutoApproveStage(currentStage);
+          if (!canGovernanceOverrideFailed) {
+            this._logger.error(`[Worker] Stage ${currentStage} failed for ${ventureId} after retries`);
+            this._logStageTransition(ventureId, currentStage, 'failed', stageDurationMs, result).catch(() => {});
+            releaseState = ORCHESTRATOR_STATES.FAILED;
+            break;
+          }
+          this._logger.log(`[Worker] Stage ${currentStage} FAILED but governance can override (build-loop auto-approve)`);
+          // Fall through to BLOCKED handler which has governance override logic
         }
 
-        if (resultStatus === 'BLOCKED') {
+        if (resultStatus === 'BLOCKED' || resultStatus === 'FAILED') {
           // Check governance config: if auto-proceed is enabled and this stage
           // is NOT a hard gate, override the BLOCKED status and advance.
           // This handles both: (1) stages in CHAIRMAN_GATES.BLOCKING that were


### PR DESCRIPTION
## Summary
Build-loop stages throw REFUSED (→FAILED) when LLM synthesis is disabled. The worker treated FAILED as terminal, never reaching the governance override path. Fix: for stages 17-22 with auto-approve, let FAILED fall through to the BLOCKED governance handler.

This is the final piece of the PAT-ORCH-STATE-001 fix chain: #2564 (orchestrator_state), #2566 (stage advancement), #2567 (column typo + artifact persistence), #2568 (promotion_gate in override), #2569 (promotion_gate in pending-decision).

## Test plan
- [x] Smoke tests 15/15

🤖 Generated with [Claude Code](https://claude.com/claude-code)