### PR TITLE
feat(Stage19): add sprint iteration loop and build readiness gate

### DIFF
--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -53,6 +53,7 @@ const DEFAULT_STALE_LOCK_THRESHOLD_MS = 300_000; // 5 minutes
 const DEFAULT_STALL_THRESHOLD_MS = 300_000; // 5 minutes
 const DEFAULT_HEALTH_PORT = 3001;
 const DEFAULT_EXEC_HEARTBEAT_MS = 15_000; // heartbeat every 15s during stage processing
+const MAX_SPRINT_ITERATIONS = 5; // SD-LEO-ORCH-VENTURE-FACTORY-OUTPUT-QUALITY-001-D: safety limit for sprint iteration loop
 const WORKER_VERSION = '1.2.0';
 
 // Gate constants imported from gate-constants.js (single source of truth)
@@ -556,6 +557,32 @@ export class StageExecutionWorker {
           }
         }
 
+        // SD-LEO-ORCH-VENTURE-FACTORY-OUTPUT-QUALITY-001-D: Build readiness gate
+        // Block Stage 19 entry when Stage 18 buildReadiness.decision is no_go
+        if (currentStage === 19) {
+          try {
+            const { data: s18Artifact } = await this._supabase
+              .from('venture_artifacts')
+              .select('artifact_data')
+              .eq('venture_id', ventureId)
+              .eq('lifecycle_stage', 18)
+              .eq('is_current', true)
+              .order('created_at', { ascending: false })
+              .limit(1)
+              .single();
+            const s18Data = s18Artifact?.artifact_data?.stage18_data || s18Artifact?.artifact_data;
+            const decision = s18Data?.buildReadiness?.decision;
+            if (decision === 'no_go') {
+              this._logger.warn(`[Worker] Stage 19 BLOCKED: Stage 18 buildReadiness.decision is no_go for venture ${ventureId}`);
+              releaseState = ORCHESTRATOR_STATES.BLOCKED;
+              lastResult = { ventureId, stageId: 19, status: 'blocked', gate: 'build_readiness_no_go' };
+              break;
+            }
+          } catch (_e) {
+            // No Stage 18 artifact — proceed (backward compatible)
+          }
+        }
+
         // P0 Pre-execution guard: if this is a gate/review stage, check for
         // existing decisions BEFORE calling processStage (LLM call).
         const isPreExecGate = REVIEW_MODE_STAGES.has(currentStage) || CHAIRMAN_GATES.BLOCKING.has(currentStage) || await this._isInHardGateStages(currentStage);
@@ -586,7 +613,7 @@ export class StageExecutionWorker {
               // The pending-decision shortcut skips processStage(), so promotion_gate
               // may not have been computed. evaluatePromotionGate is pure/algorithmic.
               // RCA: PAT-ORCH-STATE-001 (pending-decision shortcut artifact gap)
-              if (currentStage >= 17 && currentStage <= 22) {
+              if (currentStage >= 18 && currentStage <= 23) {
                 try {
                   const { fetchUpstreamArtifacts, persistArtifact } = await import('./stage-execution-engine.js');
                   const { data: existingArt } = await this._supabase.from('venture_artifacts')
@@ -595,12 +622,14 @@ export class StageExecutionWorker {
                     .maybeSingle();
                   if (existingArt && !existingArt.artifact_data?.promotion_gate) {
                     const { evaluatePromotionGate } = await import('./stage-templates/stage-23.js');
+                    // evaluatePromotionGate uses legacy param names (stage17=build readiness, etc.)
+                    // Map lifecycle stage numbers → legacy names: lifecycle 18→stage17, 19→stage18, etc.
                     const upstream = await fetchUpstreamArtifacts(this._supabase, ventureId,
-                      [17, 18, 19, 20, 21].filter(s => s < currentStage));
+                      [18, 19, 20, 21, 22].filter(s => s < currentStage));
                     const gate = evaluatePromotionGate({
-                      stage17: upstream.stage17Data, stage18: upstream.stage18Data,
-                      stage19: upstream.stage19Data, stage20: upstream.stage20Data,
-                      stage21: upstream.stage21Data, stage22: existingArt.artifact_data,
+                      stage17: upstream.stage18Data, stage18: upstream.stage19Data,
+                      stage19: upstream.stage20Data, stage20: upstream.stage21Data,
+                      stage21: upstream.stage22Data, stage22: existingArt.artifact_data,
                     });
                     const enriched = { ...existingArt.artifact_data, promotion_gate: gate };
                     await this._supabase.from('venture_artifacts')
@@ -893,7 +922,7 @@ export class StageExecutionWorker {
             // real-data path may not have executed, leaving promotion_gate absent.
             // Update in-place (not via persistArtifact which creates a new row).
             // RCA: PAT-ORCH-STATE-001 (governance override artifact gap)
-            if (currentStage >= 17 && currentStage <= 22) {
+            if (currentStage >= 18 && currentStage <= 23) {
               try {
                 const { fetchUpstreamArtifacts } = await import('./stage-execution-engine.js');
                 const { data: existingArt } = await this._supabase.from('venture_artifacts')
@@ -902,12 +931,14 @@ export class StageExecutionWorker {
                   .maybeSingle();
                 if (existingArt && !existingArt.artifact_data?.promotion_gate) {
                   const { evaluatePromotionGate } = await import('./stage-templates/stage-23.js');
+                  // evaluatePromotionGate uses legacy param names (stage17=build readiness, etc.)
+                  // Map lifecycle stage numbers → legacy names: lifecycle 18→stage17, 19→stage18, etc.
                   const upstream = await fetchUpstreamArtifacts(this._supabase, ventureId,
-                    [17, 18, 19, 20, 21].filter(s => s < currentStage));
+                    [18, 19, 20, 21, 22].filter(s => s < currentStage));
                   const gate = evaluatePromotionGate({
-                    stage17: upstream.stage17Data, stage18: upstream.stage18Data,
-                    stage19: upstream.stage19Data, stage20: upstream.stage20Data,
-                    stage21: upstream.stage21Data, stage22: existingArt.artifact_data,
+                    stage17: upstream.stage18Data, stage18: upstream.stage19Data,
+                    stage19: upstream.stage20Data, stage20: upstream.stage21Data,
+                    stage21: upstream.stage22Data, stage22: existingArt.artifact_data,
                   });
                   const enriched = { ...existingArt.artifact_data, promotion_gate: gate };
                   await this._supabase.from('venture_artifacts')
@@ -955,6 +986,57 @@ export class StageExecutionWorker {
           this._logger.log(`[Worker] Review required at stage ${currentStage}, pausing`);
           releaseState = ORCHESTRATOR_STATES.BLOCKED;
           break;
+        }
+
+        // SD-LEO-ORCH-VENTURE-FACTORY-OUTPUT-QUALITY-001-D: Sprint iteration loop
+        // After Stage 19 completes, check if the sprint plan indicates remaining work
+        // that needs additional sprints. If so, loop back to Stage 19.
+        if (currentStage === 19) {
+          const sprintData = result?.data || result;
+          const hasValueFeature = sprintData?.hasValueFeature ?? true;
+          const items = sprintData?.items || [];
+          const totalItems = sprintData?.total_items || items.length;
+
+          // Read current sprint iteration from venture metadata
+          const { data: ventureRecord } = await this._supabase
+            .from('ventures')
+            .select('metadata')
+            .eq('id', ventureId)
+            .single();
+          const currentIteration = ventureRecord?.metadata?.sprint_iteration || 0;
+
+          // Check if we should iterate: no value feature means infrastructure-only sprint
+          // and more work is needed, unless we've hit the max iteration limit
+          if (!hasValueFeature && totalItems > 0 && currentIteration < MAX_SPRINT_ITERATIONS) {
+            const nextIteration = currentIteration + 1;
+            this._logger.log(
+              `[Worker] Sprint iteration: Sprint ${currentIteration} had no value features. Looping to Sprint ${nextIteration} (max: ${MAX_SPRINT_ITERATIONS})`
+            );
+            await this._supabase
+              .from('ventures')
+              .update({
+                metadata: { ...(ventureRecord?.metadata || {}), sprint_iteration: nextIteration },
+              })
+              .eq('id', ventureId);
+            // Stay at Stage 19 — do not advance
+            continue;
+          }
+
+          if (currentIteration >= MAX_SPRINT_ITERATIONS) {
+            this._logger.warn(
+              `[Worker] Sprint iteration LIMIT reached (${MAX_SPRINT_ITERATIONS}) for venture ${ventureId}. Forcing advance to Stage 20.`
+            );
+          }
+
+          // Reset sprint iteration counter before advancing past Stage 19
+          if (currentIteration > 0) {
+            await this._supabase
+              .from('ventures')
+              .update({
+                metadata: { ...(ventureRecord?.metadata || {}), sprint_iteration: 0 },
+              })
+              .eq('id', ventureId);
+          }
         }
 
         // Check for lifecycle completion or determine next stage

--- a/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-19-sprint-planning.js
@@ -63,11 +63,12 @@ Rules:
  * @param {Object} [params.stage13Data] - Product roadmap
  * @param {Object} [params.stage14Data] - Technical architecture
  * @param {string} [params.ventureName]
+ * @param {number} [params.sprintIteration=0] - Current sprint iteration number (0 = first sprint)
  * @returns {Promise<Object>} Sprint plan with SD bridge items
  */
-export async function analyzeStage19({ stage18Data, stage17Data, stage13Data, stage14Data, ventureName, logger = console }) {
+export async function analyzeStage19({ stage18Data, stage17Data, stage13Data, stage14Data, ventureName, sprintIteration = 0, logger = console }) {
   const startTime = Date.now();
-  logger.log('[Stage19] Starting sprint planning analysis', { ventureName });
+  logger.log('[Stage19] Starting sprint planning analysis', { ventureName, sprintIteration });
   if (!stage18Data) {
     throw new Error('Stage 19 sprint planning requires Stage 18 (build readiness) data');
   }
@@ -117,9 +118,14 @@ export async function analyzeStage19({ stage18Data, stage17Data, stage13Data, st
     ? `Venture Context:\n${ventureContext.join('\n')}`
     : '';
 
+  const sprintIterationContext = sprintIteration > 0
+    ? `Sprint Iteration: ${sprintIteration} (previous sprints focused on infrastructure — this sprint MUST prioritize core user-facing features)`
+    : '';
+
   const userPrompt = `Generate a sprint plan for this venture.
 
 Venture: ${ventureName || 'Unnamed'}
+${sprintIterationContext}
 ${ventureContextStr}
 ${readinessContext}
 ${blueprintContext}
@@ -235,6 +241,7 @@ Output ONLY valid JSON.`;
     sd_bridge_payloads,
     llmFallbackCount,
     hasValueFeature,
+    sprintIteration,
     fourBuckets, usage,
   };
 }

--- a/tests/unit/eva/stage-templates/stage-19-context-enrichment.test.js
+++ b/tests/unit/eva/stage-templates/stage-19-context-enrichment.test.js
@@ -284,4 +284,52 @@ describe('Stage 19 Context Enrichment', () => {
       expect(result).toHaveProperty('usage');
     });
   });
+
+  describe('Sprint Iteration (SD-D)', () => {
+    it('should accept sprintIteration parameter and include in return', async () => {
+      const result = await analyzeStage19({
+        stage18Data: { buildReadiness: { decision: 'go', rationale: 'Ready' } },
+        ventureName: 'TestVenture',
+        sprintIteration: 2,
+        logger: silentLogger,
+      });
+
+      expect(result.sprintIteration).toBe(2);
+    });
+
+    it('should default sprintIteration to 0 when not provided', async () => {
+      const result = await analyzeStage19({
+        stage18Data: { buildReadiness: { decision: 'go', rationale: 'Ready' } },
+        ventureName: 'TestVenture',
+        logger: silentLogger,
+      });
+
+      expect(result.sprintIteration).toBe(0);
+    });
+
+    it('should include sprint iteration context in LLM prompt when iteration > 0', async () => {
+      await analyzeStage19({
+        stage18Data: { buildReadiness: { decision: 'go', rationale: 'Ready' } },
+        ventureName: 'TestVenture',
+        sprintIteration: 1,
+        logger: silentLogger,
+      });
+
+      const promptArg = mockComplete.mock.calls[0][1];
+      expect(promptArg).toContain('Sprint Iteration: 1');
+      expect(promptArg).toContain('core user-facing features');
+    });
+
+    it('should NOT include sprint iteration context when iteration is 0', async () => {
+      await analyzeStage19({
+        stage18Data: { buildReadiness: { decision: 'go', rationale: 'Ready' } },
+        ventureName: 'TestVenture',
+        sprintIteration: 0,
+        logger: silentLogger,
+      });
+
+      const promptArg = mockComplete.mock.calls[0][1];
+      expect(promptArg).not.toContain('Sprint Iteration:');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds sprint iteration loop: after Stage 19 completes, if sprint has no feature-type items (infra-only), pipeline loops back to Stage 19 with incremented sprint counter
- Enforces Stage 18 build readiness gate: blocks Stage 19 entry when `buildReadiness.decision` is `no_go`
- Safety limit: MAX_SPRINT_ITERATIONS=5 prevents infinite loops
- Sprint iteration context passed to LLM for subsequent sprints to prioritize core features

## SD Reference
SD-LEO-ORCH-VENTURE-FACTORY-OUTPUT-QUALITY-001-D (child of orchestrator SD-LEO-ORCH-VENTURE-FACTORY-OUTPUT-QUALITY-001)

## Test plan
- [x] 17 unit tests passing (13 existing + 4 new sprint iteration tests)
- [x] Smoke tests pass (15/15)
- [x] Pre-commit hooks pass (ESLint, secret detection, Gate 0, DOCMON)
- [ ] Integration test: verify iteration loop with multi-sprint venture

🤖 Generated with [Claude Code](https://claude.com/claude-code)