### PR TITLE
fix(EVA): align stage 23-26 analysis params with lifecycle numbers

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -569,9 +569,13 @@ export const CROSS_STAGE_DEPS = {
   20: [18, 19],              // Build execution: readiness + sprint plan
   21: [19, 20],              // QA & testing: sprint plan + build execution
   22: [17, 18, 19, 20, 21],  // Build review: full build phase
-  23: [1, 22],               // Marketing preparation: idea + release readiness
-  24: [22, 23],              // Launch readiness (chairman gate): release + marketing
-  25: [24],                  // Launch execution (pipeline terminus): chairman approval
+  // Phase 5→6: Release Readiness (Stage 23)
+  23: [1, 18, 19, 20, 21, 22], // Release readiness: idea + full build loop stages
+
+  // Phase 6: LAUNCH & LEARN (Stages 24-26)
+  24: [1, 23],               // Marketing preparation: idea + release readiness
+  25: [23, 24],              // Launch readiness (chairman gate): release + marketing
+  26: [23, 24, 25],          // Launch execution (pipeline terminus): release + marketing + chairman approval
 };
 
 /**

--- a/lib/eva/stage-templates/analysis-steps/stage-23-release-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-23-release-readiness.js
@@ -22,35 +22,37 @@ const RELEASE_CATEGORIES = ['feature', 'bugfix', 'infrastructure', 'documentatio
  * Generate release readiness assessment from BUILD LOOP data.
  *
  * @param {Object} params
- * @param {Object} params.stage17Data - Build readiness
- * @param {Object} params.stage18Data - Sprint plan
- * @param {Object} params.stage19Data - Build execution
- * @param {Object} params.stage20Data - QA assessment
- * @param {Object} params.stage21Data - Build review
+ * @param {Object} params.stage18Data - Build readiness (lifecycle 18)
+ * @param {Object} params.stage19Data - Sprint plan (lifecycle 19)
+ * @param {Object} params.stage20Data - Build execution (lifecycle 20)
+ * @param {Object} params.stage21Data - QA assessment (lifecycle 21)
+ * @param {Object} params.stage22Data - Build review (lifecycle 22)
  * @param {string} [params.ventureName]
  * @returns {Promise<Object>} Release readiness with decision, retro, and summary
  */
-export async function analyzeStage22({ stage17Data, stage18Data, stage19Data, stage20Data, stage21Data, ventureName, supabase, ventureId, logger = console }) {
+export async function analyzeStage22({ stage18Data, stage19Data, stage20Data, stage21Data, stage22Data, ventureName, supabase, ventureId, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage22] Starting analysis', { ventureName });
-  if (!stage20Data || !stage21Data) {
-    throw new Error('Stage 22 release readiness requires Stage 20 (QA) and Stage 21 (review) data');
+  if (!stage21Data || !stage22Data) {
+    throw new Error('Stage 23 release readiness requires Stage 21 (QA) and Stage 22 (review) data');
   }
 
   // Use real data path if all upstream stages used real data
-  if (stage19Data?.dataSource === 'venture_stage_work' &&
-      stage20Data?.dataSource === 'venture_stage_work' &&
-      stage21Data?.dataSource === 'venture_stage_work') {
+  if (stage20Data?.dataSource === 'venture_stage_work' &&
+      stage21Data?.dataSource === 'venture_stage_work' &&
+      stage22Data?.dataSource === 'venture_stage_work') {
     try {
-      const realData = buildRealReleaseData(stage17Data, stage18Data, stage19Data, stage20Data, stage21Data, logger);
+      const realData = buildRealReleaseData(stage18Data, stage19Data, stage20Data, stage21Data, stage22Data, logger);
       if (realData) {
         // Still evaluate promotion gate (non-LLM, algorithmic)
+        // evaluatePromotionGate uses legacy param names (stage17=build readiness, etc.)
+        // Map lifecycle stage numbers to those legacy names
         const promotion_gate = evaluatePromotionGate({
-          stage17: stage17Data,
-          stage18: stage18Data,
-          stage19: stage19Data,
-          stage20: stage20Data,
-          stage21: stage21Data,
+          stage17: stage18Data,
+          stage18: stage19Data,
+          stage19: stage20Data,
+          stage20: stage21Data,
+          stage21: stage22Data,
           stage22: realData,
         });
         realData.promotion_gate = promotion_gate;
@@ -74,16 +76,16 @@ export async function analyzeStage22({ stage17Data, stage18Data, stage19Data, st
  * Build release readiness data from real upstream stage data (no LLM).
  * Derives release items from completed tasks, computes algorithmic release decision.
  *
- * @param {Object} stage17Data - Build readiness
- * @param {Object} stage18Data - Sprint plan
- * @param {Object} stage19Data - Build execution (real data)
- * @param {Object} stage20Data - QA (real data)
- * @param {Object} stage21Data - Build review (real data)
+ * @param {Object} stage18Data - Build readiness (lifecycle 18)
+ * @param {Object} stage19Data - Sprint plan (lifecycle 19)
+ * @param {Object} stage20Data - Build execution (lifecycle 20, real data)
+ * @param {Object} stage21Data - QA (lifecycle 21, real data)
+ * @param {Object} stage22Data - Build review (lifecycle 22, real data)
  * @param {Object} logger
- * @returns {Object|null} Stage 22 output or null if data insufficient
+ * @returns {Object|null} Stage 23 output or null if data insufficient
  */
-function buildRealReleaseData(stage17Data, stage18Data, stage19Data, stage20Data, stage21Data, logger) {
-  const tasks = stage19Data.tasks || [];
+function buildRealReleaseData(stage18Data, stage19Data, stage20Data, stage21Data, stage22Data, logger) {
+  const tasks = stage20Data.tasks || [];
   if (tasks.length === 0) return null;
 
   // Build release items from completed tasks
@@ -116,8 +118,8 @@ function buildRealReleaseData(stage17Data, stage18Data, stage19Data, stage20Data
   const all_approved = total_items > 0 && allItems.every(ri => ri.status === 'approved');
 
   // Algorithmic release decision from QA + review
-  const qaPass = stage20Data.qualityDecision?.decision === 'pass' || stage20Data.qualityDecision?.decision === 'conditional_pass';
-  const reviewPass = stage21Data.reviewDecision?.decision === 'approve' || stage21Data.reviewDecision?.decision === 'conditional';
+  const qaPass = stage21Data.qualityDecision?.decision === 'pass' || stage21Data.qualityDecision?.decision === 'conditional_pass';
+  const reviewPass = stage22Data.reviewDecision?.decision === 'approve' || stage22Data.reviewDecision?.decision === 'conditional';
 
   let decision;
   if (qaPass && reviewPass && all_approved) {
@@ -128,11 +130,11 @@ function buildRealReleaseData(stage17Data, stage18Data, stage19Data, stage20Data
     decision = 'cancel';
   }
 
-  const completedTasks = stage19Data.completed_tasks || 0;
-  const totalTasks = stage19Data.total_tasks || 0;
-  const passRate = stage20Data.overall_pass_rate || 0;
+  const completedTasks = stage20Data.completed_tasks || 0;
+  const totalTasks = stage20Data.total_tasks || 0;
+  const passRate = stage21Data.overall_pass_rate || 0;
 
-  const release_notes = `Real data release: ${completedTasks}/${totalTasks} tasks completed, ${passRate}% QA pass rate, review: ${stage21Data.reviewDecision?.decision}`;
+  const release_notes = `Real data release: ${completedTasks}/${totalTasks} tasks completed, ${passRate}% QA pass rate, review: ${stage22Data.reviewDecision?.decision}`;
   const target_date = new Date(Date.now() + 7 * 86400000).toISOString().split('T')[0];
 
   // Sprint retrospective from real metrics
@@ -140,8 +142,8 @@ function buildRealReleaseData(stage17Data, stage18Data, stage19Data, stage20Data
     wentWell: completedTasks > 0
       ? [`${completedTasks} of ${totalTasks} tasks completed successfully`]
       : ['Sprint initiated'],
-    wentPoorly: stage19Data.blocked_tasks > 0
-      ? [`${stage19Data.blocked_tasks} task(s) blocked during sprint`]
+    wentPoorly: stage20Data.blocked_tasks > 0
+      ? [`${stage20Data.blocked_tasks} task(s) blocked during sprint`]
       : ['No major issues identified'],
     actionItems: decision !== 'release'
       ? ['Resolve remaining blockers before next sprint']
@@ -150,14 +152,14 @@ function buildRealReleaseData(stage17Data, stage18Data, stage19Data, stage20Data
 
   // Sprint summary from real data
   const sprintSummary = {
-    sprintGoal: stage18Data?.sprint_goal || 'Build sprint',
+    sprintGoal: stage19Data?.sprint_goal || 'Build sprint',
     itemsPlanned: totalTasks,
     itemsCompleted: completedTasks,
-    qualityAssessment: `${passRate}% pass rate, ${stage20Data.coverage_pct || 0}% coverage`,
-    integrationStatus: `${stage21Data.passing_integrations || 0}/${stage21Data.total_integrations || 0} integrations passing`,
+    qualityAssessment: `${passRate}% pass rate, ${stage21Data.coverage_pct || 0}% coverage`,
+    integrationStatus: `${stage22Data.passing_integrations || 0}/${stage22Data.total_integrations || 0} integrations passing`,
   };
 
-  logger.log('[Stage22] Built real release data', { decision, total_items, approved_items });
+  logger.log('[Stage23] Built real release data', { decision, total_items, approved_items });
 
   return {
     release_items: allItems,
@@ -165,7 +167,7 @@ function buildRealReleaseData(stage17Data, stage18Data, stage19Data, stage20Data
     target_date,
     releaseDecision: {
       decision,
-      rationale: `Real data: QA ${stage20Data.qualityDecision?.decision}, Review ${stage21Data.reviewDecision?.decision}, ${approved_items}/${total_items} items approved`,
+      rationale: `Real data: QA ${stage21Data.qualityDecision?.decision}, Review ${stage22Data.reviewDecision?.decision}, ${approved_items}/${total_items} items approved`,
       approver: 'leo-protocol',
     },
     sprintRetrospective,

--- a/lib/eva/stage-templates/analysis-steps/stage-24-marketing-prep.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-24-marketing-prep.js
@@ -23,7 +23,7 @@ const MARKETING_PRIORITIES = ['critical', 'high', 'medium', 'low'];
  * Generate marketing preparation items from Stage 22 release readiness data.
  *
  * @param {Object} params
- * @param {Object} params.stage22Data - Release readiness (releaseDecision, releaseItems, etc.)
+ * @param {Object} params.stage23Data - Release readiness (lifecycle 23: releaseDecision, releaseItems, etc.)
  * @param {Object} [params.stage01Data] - Venture hydration (for product context)
  * @param {Object} [params.stage10Data] - Naming/branding data
  * @param {Object} [params.stage11Data] - GTM strategy data
@@ -31,12 +31,12 @@ const MARKETING_PRIORITIES = ['critical', 'high', 'medium', 'low'];
  * @param {Object} [params.logger]
  * @returns {Promise<Object>} Marketing items with SD bridge payloads
  */
-export async function analyzeStage23({ stage22Data, stage01Data, stage10Data, stage11Data, ventureName, ventureId, supabase, logger = console }) {
+export async function analyzeStage23({ stage23Data, stage01Data, stage10Data, stage11Data, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage23] Starting marketing preparation analysis', { ventureName });
 
-  // Check Stage 22 prerequisite
-  const readiness = checkReleaseReadiness({ stage22Data });
+  // Check Stage 23 prerequisite (release readiness)
+  const readiness = checkReleaseReadiness({ stage23Data });
   if (!readiness.ready) {
     // L2+ autonomy: auto-proceed despite release readiness not met
     let autonomyOverride = false;

--- a/lib/eva/stage-templates/analysis-steps/stage-25-launch-readiness.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-25-launch-readiness.js
@@ -15,19 +15,19 @@
  * Generate launch readiness assessment from Stage 22 and Stage 23 data.
  *
  * @param {Object} params
- * @param {Object} params.stage22Data - Release readiness data
- * @param {Object} params.stage23Data - Marketing preparation data
+ * @param {Object} params.stage23Data - Release readiness data (lifecycle 23)
+ * @param {Object} params.stage24Data - Marketing preparation data (lifecycle 24)
  * @param {Object} [params.stage01Data] - Venture hydration data
  * @param {string} [params.ventureName]
  * @param {Object} [params.logger]
  * @returns {Promise<Object>} Launch readiness with checklist, score, and recommendation
  */
-export async function analyzeStage24({ stage22Data, stage23Data, ventureName, logger = console }) {
+export async function analyzeStage24({ stage23Data, stage24Data, ventureName, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage24] Starting launch readiness analysis', { ventureName });
 
-  if (!stage22Data) {
-    throw new Error('Stage 24 launch readiness requires Stage 22 (release readiness) data');
+  if (!stage23Data) {
+    throw new Error('Stage 25 launch readiness requires Stage 23 (release readiness) data');
   }
 
   throw new Error(

--- a/lib/eva/stage-templates/analysis-steps/stage-26-launch-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-26-launch-execution.js
@@ -15,20 +15,20 @@ import { verifyLaunchAuthorization } from '../stage-26.js';
  * Generate launch execution plan from Stage 24 approval data.
  *
  * @param {Object} params
- * @param {Object} params.stage24Data - Launch readiness (chairman gate, readiness checklist)
- * @param {Object} [params.stage22Data] - Release readiness data
- * @param {Object} [params.stage23Data] - Marketing preparation data
+ * @param {Object} params.stage25Data - Launch readiness (lifecycle 25: chairman gate, readiness checklist)
+ * @param {Object} [params.stage23Data] - Release readiness data (lifecycle 23)
+ * @param {Object} [params.stage24Data] - Marketing preparation data (lifecycle 24)
  * @param {Object} [params.stage01Data] - Venture hydration data
  * @param {string} [params.ventureName]
  * @param {Object} [params.logger]
  * @returns {Promise<Object>} Launch execution with distribution channels and operations handoff
  */
-export async function analyzeStage25({ stage24Data, stage22Data, stage23Data, ventureName, ventureId, supabase, logger = console }) {
+export async function analyzeStage25({ stage25Data, stage23Data, stage24Data, ventureName, ventureId, supabase, logger = console }) {
   const startTime = Date.now();
   logger.log('[Stage25] Starting launch execution analysis', { ventureName });
 
-  // Verify Stage 24 chairman approval
-  const auth = verifyLaunchAuthorization({ stage24Data });
+  // Verify Stage 25 chairman approval
+  const auth = verifyLaunchAuthorization({ stage25Data });
   if (!auth.authorized) {
     // L2+ autonomy: auto-proceed despite launch not authorized
     let autonomyOverride = false;

--- a/lib/eva/stage-templates/stage-24.js
+++ b/lib/eva/stage-templates/stage-24.js
@@ -116,32 +116,32 @@ const TEMPLATE = {
 };
 
 /**
- * Pure function: check Stage 22 release readiness prerequisite.
+ * Pure function: check Stage 23 release readiness prerequisite.
  *
- * @param {{ stage22Data?: Object }} params
+ * @param {{ stage23Data?: Object }} params
  * @returns {{ ready: boolean, reasons: string[] }}
  */
-export function checkReleaseReadiness({ stage22Data }) {
+export function checkReleaseReadiness({ stage23Data }) {
   const reasons = [];
 
-  if (!stage22Data) {
-    reasons.push('Stage 22 release readiness data not available');
+  if (!stage23Data) {
+    reasons.push('Stage 23 release readiness data not available');
     return { ready: false, reasons };
   }
 
   // Check promotion gate
-  if (!stage22Data.promotion_gate?.pass) {
-    reasons.push('Stage 22 promotion gate has not passed');
+  if (!stage23Data.promotion_gate?.pass) {
+    reasons.push('Stage 23 promotion gate has not passed');
   }
 
   // Check release decision
-  if (stage22Data.releaseDecision) {
-    const rd = stage22Data.releaseDecision;
+  if (stage23Data.releaseDecision) {
+    const rd = stage23Data.releaseDecision;
     if (rd.decision !== 'release' && rd.decision !== 'approved') {
-      reasons.push(`Stage 22 release decision is '${rd.decision}', not 'release'`);
+      reasons.push(`Stage 23 release decision is '${rd.decision}', not 'release'`);
     }
   } else {
-    reasons.push('Stage 22 release decision not found');
+    reasons.push('Stage 23 release decision not found');
   }
 
   return { ready: reasons.length === 0, reasons };

--- a/lib/eva/stage-templates/stage-26.js
+++ b/lib/eva/stage-templates/stage-26.js
@@ -143,29 +143,29 @@ const TEMPLATE = {
 };
 
 /**
- * Pure function: verify Stage 24 chairman gate approval before launch.
+ * Pure function: verify Stage 25 chairman gate approval before launch.
  *
- * @param {{ stage24Data?: Object }} params
+ * @param {{ stage25Data?: Object }} params
  * @returns {{ authorized: boolean, reasons: string[] }}
  */
-export function verifyLaunchAuthorization({ stage24Data }) {
+export function verifyLaunchAuthorization({ stage25Data }) {
   const reasons = [];
 
-  if (!stage24Data) {
-    reasons.push('Stage 24 launch readiness data not available');
+  if (!stage25Data) {
+    reasons.push('Stage 25 launch readiness data not available');
     return { authorized: false, reasons };
   }
 
   // Check chairman gate
-  const gateStatus = stage24Data.chairmanGate?.status;
+  const gateStatus = stage25Data.chairmanGate?.status;
   if (gateStatus !== 'approved') {
-    reasons.push(`Stage 24 chairman gate status is '${gateStatus || 'unknown'}', not 'approved'`);
+    reasons.push(`Stage 25 chairman gate status is '${gateStatus || 'unknown'}', not 'approved'`);
   }
 
   // Check go/no-go decision
-  const decision = stage24Data.go_no_go_decision;
+  const decision = stage25Data.go_no_go_decision;
   if (decision !== 'go' && decision !== 'conditional_go') {
-    reasons.push(`Stage 24 go/no-go decision is '${decision || 'not set'}', expected 'go' or 'conditional_go'`);
+    reasons.push(`Stage 25 go/no-go decision is '${decision || 'not set'}', expected 'go' or 'conditional_go'`);
   }
 
   return { authorized: reasons.length === 0, reasons };

--- a/tests/unit/eva/stage-templates/analysis-steps/stage-23-release-readiness.test.js
+++ b/tests/unit/eva/stage-templates/analysis-steps/stage-23-release-readiness.test.js
@@ -1,8 +1,10 @@
 /**
- * Unit tests for Stage 22 Analysis Step - Release Readiness
+ * Unit tests for Stage 23 Analysis Step - Release Readiness
  * Part of SD-LEO-ORCH-EVA-STAGE-PIPELINE-001-C
  *
  * Tests both LLM-synthesis and real-data (buildRealReleaseData) paths.
+ * Lifecycle stage numbers: 18=build readiness, 19=sprint plan, 20=build exec,
+ * 21=QA, 22=build review, 23=release readiness.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -13,7 +15,7 @@ vi.mock('../../../../../lib/llm/index.js', () => ({
   })),
 }));
 
-vi.mock('../../../../../lib/eva/stage-templates/stage-22.js', () => ({
+vi.mock('../../../../../lib/eva/stage-templates/stage-23.js', () => ({
   evaluatePromotionGate: vi.fn(() => ({
     passed: true,
     score: 85,
@@ -21,7 +23,7 @@ vi.mock('../../../../../lib/eva/stage-templates/stage-22.js', () => ({
   })),
 }));
 
-import { analyzeStage22, RELEASE_DECISIONS, RELEASE_CATEGORIES } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-22-release-readiness.js';
+import { analyzeStage22, RELEASE_DECISIONS, RELEASE_CATEGORIES } from '../../../../../lib/eva/stage-templates/analysis-steps/stage-23-release-readiness.js';
 import { getLLMClient } from '../../../../../lib/llm/index.js';
 
 function createLLMResponse(overrides = {}) {
@@ -59,19 +61,20 @@ function setupMock(responseOverrides = {}) {
   return mockComplete;
 }
 
-const STAGE20_DATA = {
+// Fixture constants named by semantic role (lifecycle stage in comments)
+const QA_DATA = {                        // lifecycle stage 21
   qualityDecision: { decision: 'pass' },
   overall_pass_rate: 98,
   coverage_pct: 85,
 };
 
-const STAGE21_DATA = {
+const REVIEW_DATA = {                    // lifecycle stage 22
   reviewDecision: { decision: 'approve' },
   passing_integrations: 3,
   total_integrations: 3,
 };
 
-const STAGE19_DATA = {
+const BUILD_EXEC_DATA = {               // lifecycle stage 20
   tasks: [
     { name: 'T1', status: 'done' },
     { name: 'T2', status: 'done' },
@@ -82,14 +85,14 @@ const STAGE19_DATA = {
   blocked_tasks: 1,
 };
 
-const STAGE18_DATA = {
+const SPRINT_DATA = {                    // lifecycle stage 19
   sprint_goal: 'Ship MVP',
   total_items: 3,
 };
 
 const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
-describe('stage-22-release-readiness.js', () => {
+describe('stage-23-release-readiness.js', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -98,8 +101,8 @@ describe('stage-22-release-readiness.js', () => {
     it('should generate release readiness assessment', async () => {
       setupMock();
       const result = await analyzeStage22({
-        stage20Data: STAGE20_DATA,
-        stage21Data: STAGE21_DATA,
+        stage21Data: QA_DATA,
+        stage22Data: REVIEW_DATA,
         logger,
       });
 
@@ -109,29 +112,29 @@ describe('stage-22-release-readiness.js', () => {
       expect(result.promotion_gate).toBeDefined();
     });
 
-    it('should throw without stage20Data or stage21Data', async () => {
-      await expect(analyzeStage22({ stage21Data: STAGE21_DATA, logger }))
-        .rejects.toThrow('Stage 22 release readiness requires Stage 20');
-      await expect(analyzeStage22({ stage20Data: STAGE20_DATA, logger }))
-        .rejects.toThrow('Stage 22 release readiness requires Stage 20');
+    it('should throw without stage21Data or stage22Data', async () => {
+      await expect(analyzeStage22({ stage22Data: REVIEW_DATA, logger }))
+        .rejects.toThrow('Stage 23 release readiness requires Stage 21');
+      await expect(analyzeStage22({ stage21Data: QA_DATA, logger }))
+        .rejects.toThrow('Stage 23 release readiness requires Stage 21');
     });
 
     it('should normalize invalid release categories', async () => {
       setupMock({
         releaseItems: [{ name: 'X', category: 'INVALID', status: 'approved', approver: 'A' }],
       });
-      const result = await analyzeStage22({ stage20Data: STAGE20_DATA, stage21Data: STAGE21_DATA, logger });
+      const result = await analyzeStage22({ stage21Data: QA_DATA, stage22Data: REVIEW_DATA, logger });
 
       expect(result.release_items[0].category).toBe('feature');
     });
 
     it('should derive hold decision when only QA passes', async () => {
       setupMock({ releaseDecision: { decision: 'invalid' } });
-      const stage21Fail = { ...STAGE21_DATA, reviewDecision: { decision: 'reject' } };
+      const reviewFail = { ...REVIEW_DATA, reviewDecision: { decision: 'reject' } };
 
       const result = await analyzeStage22({
-        stage20Data: STAGE20_DATA,
-        stage21Data: stage21Fail,
+        stage21Data: QA_DATA,
+        stage22Data: reviewFail,
         logger,
       });
 
@@ -141,15 +144,15 @@ describe('stage-22-release-readiness.js', () => {
 
   describe('Real Data Path (buildRealReleaseData)', () => {
     it('should use real data when all upstream stages have venture_stage_work source', async () => {
-      const stage19Real = { ...STAGE19_DATA, dataSource: 'venture_stage_work' };
-      const stage20Real = { ...STAGE20_DATA, dataSource: 'venture_stage_work' };
-      const stage21Real = { ...STAGE21_DATA, dataSource: 'venture_stage_work' };
+      const buildExecReal = { ...BUILD_EXEC_DATA, dataSource: 'venture_stage_work' };
+      const qaReal = { ...QA_DATA, dataSource: 'venture_stage_work' };
+      const reviewReal = { ...REVIEW_DATA, dataSource: 'venture_stage_work' };
 
       const result = await analyzeStage22({
-        stage18Data: STAGE18_DATA,
-        stage19Data: stage19Real,
-        stage20Data: stage20Real,
-        stage21Data: stage21Real,
+        stage19Data: SPRINT_DATA,
+        stage20Data: buildExecReal,
+        stage21Data: qaReal,
+        stage22Data: reviewReal,
         logger,
       });
 
@@ -161,15 +164,15 @@ describe('stage-22-release-readiness.js', () => {
     });
 
     it('should compute hold decision when not all items approved', async () => {
-      const stage19Real = { ...STAGE19_DATA, dataSource: 'venture_stage_work' };
-      const stage20Real = { ...STAGE20_DATA, dataSource: 'venture_stage_work' };
-      const stage21Real = { ...STAGE21_DATA, dataSource: 'venture_stage_work' };
+      const buildExecReal = { ...BUILD_EXEC_DATA, dataSource: 'venture_stage_work' };
+      const qaReal = { ...QA_DATA, dataSource: 'venture_stage_work' };
+      const reviewReal = { ...REVIEW_DATA, dataSource: 'venture_stage_work' };
 
       const result = await analyzeStage22({
-        stage18Data: STAGE18_DATA,
-        stage19Data: stage19Real,
-        stage20Data: stage20Real,
-        stage21Data: stage21Real,
+        stage19Data: SPRINT_DATA,
+        stage20Data: buildExecReal,
+        stage21Data: qaReal,
+        stage22Data: reviewReal,
         logger,
       });
 
@@ -188,14 +191,14 @@ describe('stage-22-release-readiness.js', () => {
         blocked_tasks: 0,
         dataSource: 'venture_stage_work',
       };
-      const stage20Real = { ...STAGE20_DATA, dataSource: 'venture_stage_work' };
-      const stage21Real = { ...STAGE21_DATA, dataSource: 'venture_stage_work' };
+      const qaReal = { ...QA_DATA, dataSource: 'venture_stage_work' };
+      const reviewReal = { ...REVIEW_DATA, dataSource: 'venture_stage_work' };
 
       const result = await analyzeStage22({
-        stage18Data: STAGE18_DATA,
-        stage19Data: allDone,
-        stage20Data: stage20Real,
-        stage21Data: stage21Real,
+        stage19Data: SPRINT_DATA,
+        stage20Data: allDone,
+        stage21Data: qaReal,
+        stage22Data: reviewReal,
         logger,
       });
 
@@ -205,13 +208,13 @@ describe('stage-22-release-readiness.js', () => {
 
     it('should fall back to LLM when only some upstream stages use real data', async () => {
       setupMock();
-      const stage19Real = { ...STAGE19_DATA, dataSource: 'venture_stage_work' };
-      // stage20 and stage21 do NOT have dataSource
+      const buildExecReal = { ...BUILD_EXEC_DATA, dataSource: 'venture_stage_work' };
+      // stage21 and stage22 do NOT have dataSource
 
       const result = await analyzeStage22({
-        stage19Data: stage19Real,
-        stage20Data: STAGE20_DATA,
-        stage21Data: STAGE21_DATA,
+        stage20Data: buildExecReal,
+        stage21Data: QA_DATA,
+        stage22Data: REVIEW_DATA,
         logger,
       });
 
@@ -219,21 +222,21 @@ describe('stage-22-release-readiness.js', () => {
     });
 
     it('should include sprint retrospective from real data', async () => {
-      const stage19Real = {
+      const buildExecReal = {
         tasks: [{ name: 'T1', status: 'done' }],
         total_tasks: 1,
         completed_tasks: 1,
         blocked_tasks: 0,
         dataSource: 'venture_stage_work',
       };
-      const stage20Real = { ...STAGE20_DATA, dataSource: 'venture_stage_work' };
-      const stage21Real = { ...STAGE21_DATA, dataSource: 'venture_stage_work' };
+      const qaReal = { ...QA_DATA, dataSource: 'venture_stage_work' };
+      const reviewReal = { ...REVIEW_DATA, dataSource: 'venture_stage_work' };
 
       const result = await analyzeStage22({
-        stage18Data: STAGE18_DATA,
-        stage19Data: stage19Real,
-        stage20Data: stage20Real,
-        stage21Data: stage21Real,
+        stage19Data: SPRINT_DATA,
+        stage20Data: buildExecReal,
+        stage21Data: qaReal,
+        stage22Data: reviewReal,
         logger,
       });
 

--- a/tests/unit/eva/stage-templates/index.test.js
+++ b/tests/unit/eva/stage-templates/index.test.js
@@ -457,7 +457,7 @@ describe('index.js - Stage templates registry', () => {
 
     it('checkReleaseReadiness should work correctly', () => {
       const result = checkReleaseReadiness({
-        stage22Data: {
+        stage23Data: {
           promotion_gate: { pass: true, blockers: [] },
           releaseDecision: { decision: 'release' },
         },
@@ -466,15 +466,15 @@ describe('index.js - Stage templates registry', () => {
       expect(result.reasons).toEqual([]);
     });
 
-    it('checkReleaseReadiness should detect missing stage22Data', () => {
-      const result = checkReleaseReadiness({ stage22Data: undefined });
+    it('checkReleaseReadiness should detect missing stage23Data', () => {
+      const result = checkReleaseReadiness({ stage23Data: undefined });
       expect(result.ready).toBe(false);
       expect(result.reasons.length).toBeGreaterThan(0);
     });
 
     it('verifyLaunchAuthorization should work correctly', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'approved' },
           go_no_go_decision: 'go',
         },
@@ -483,8 +483,8 @@ describe('index.js - Stage templates registry', () => {
       expect(result.reasons).toEqual([]);
     });
 
-    it('verifyLaunchAuthorization should detect missing stage24Data', () => {
-      const result = verifyLaunchAuthorization({ stage24Data: undefined });
+    it('verifyLaunchAuthorization should detect missing stage25Data', () => {
+      const result = verifyLaunchAuthorization({ stage25Data: undefined });
       expect(result.authorized).toBe(false);
       expect(result.reasons.length).toBeGreaterThan(0);
     });

--- a/tests/unit/eva/stage-templates/stage-24.test.js
+++ b/tests/unit/eva/stage-templates/stage-24.test.js
@@ -266,7 +266,7 @@ describe('stage-23.js - Marketing Preparation template', () => {
   describe('checkReleaseReadiness() - Pure function', () => {
     it('should return ready when stage22 promotion gate passes and release decision is release', () => {
       const result = checkReleaseReadiness({
-        stage22Data: {
+        stage23Data: {
           promotion_gate: { pass: true, blockers: [] },
           releaseDecision: { decision: 'release' },
         },
@@ -277,7 +277,7 @@ describe('stage-23.js - Marketing Preparation template', () => {
 
     it('should return ready when release decision is approved', () => {
       const result = checkReleaseReadiness({
-        stage22Data: {
+        stage23Data: {
           promotion_gate: { pass: true, blockers: [] },
           releaseDecision: { decision: 'approved' },
         },
@@ -286,8 +286,8 @@ describe('stage-23.js - Marketing Preparation template', () => {
       expect(result.reasons).toEqual([]);
     });
 
-    it('should return not ready when stage22Data is not provided', () => {
-      const result = checkReleaseReadiness({ stage22Data: undefined });
+    it('should return not ready when stage23Data is not provided', () => {
+      const result = checkReleaseReadiness({ stage23Data: undefined });
       expect(result.ready).toBe(false);
       expect(result.reasons).toHaveLength(1);
       expect(result.reasons[0]).toContain('not available');
@@ -295,7 +295,7 @@ describe('stage-23.js - Marketing Preparation template', () => {
 
     it('should return not ready when promotion gate has not passed', () => {
       const result = checkReleaseReadiness({
-        stage22Data: {
+        stage23Data: {
           promotion_gate: { pass: false, blockers: ['Test coverage below 80%'] },
           releaseDecision: { decision: 'release' },
         },
@@ -306,7 +306,7 @@ describe('stage-23.js - Marketing Preparation template', () => {
 
     it('should return not ready when release decision is not release or approved', () => {
       const result = checkReleaseReadiness({
-        stage22Data: {
+        stage23Data: {
           promotion_gate: { pass: true, blockers: [] },
           releaseDecision: { decision: 'hold' },
         },
@@ -317,7 +317,7 @@ describe('stage-23.js - Marketing Preparation template', () => {
 
     it('should return not ready when releaseDecision is missing', () => {
       const result = checkReleaseReadiness({
-        stage22Data: {
+        stage23Data: {
           promotion_gate: { pass: true, blockers: [] },
         },
       });
@@ -327,7 +327,7 @@ describe('stage-23.js - Marketing Preparation template', () => {
 
     it('should collect multiple reasons when both gate and decision fail', () => {
       const result = checkReleaseReadiness({
-        stage22Data: {
+        stage23Data: {
           promotion_gate: { pass: false, blockers: ['Not ready'] },
           releaseDecision: { decision: 'hold' },
         },
@@ -338,8 +338,8 @@ describe('stage-23.js - Marketing Preparation template', () => {
       expect(result.reasons.some(r => r.includes('release decision'))).toBe(true);
     });
 
-    it('should handle null stage22Data', () => {
-      const result = checkReleaseReadiness({ stage22Data: null });
+    it('should handle null stage23Data', () => {
+      const result = checkReleaseReadiness({ stage23Data: null });
       expect(result.ready).toBe(false);
       expect(result.reasons.length).toBeGreaterThan(0);
     });

--- a/tests/unit/eva/stage-templates/stage-26.test.js
+++ b/tests/unit/eva/stage-templates/stage-26.test.js
@@ -334,7 +334,7 @@ describe('stage-25.js - Launch Execution template', () => {
   describe('verifyLaunchAuthorization() - Pure function', () => {
     it('should return authorized when chairman gate is approved and decision is go', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'approved' },
           go_no_go_decision: 'go',
         },
@@ -345,7 +345,7 @@ describe('stage-25.js - Launch Execution template', () => {
 
     it('should return authorized when decision is conditional_go', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'approved' },
           go_no_go_decision: 'conditional_go',
         },
@@ -354,22 +354,22 @@ describe('stage-25.js - Launch Execution template', () => {
       expect(result.reasons).toEqual([]);
     });
 
-    it('should return not authorized when stage24Data is not provided', () => {
-      const result = verifyLaunchAuthorization({ stage24Data: undefined });
+    it('should return not authorized when stage25Data is not provided', () => {
+      const result = verifyLaunchAuthorization({ stage25Data: undefined });
       expect(result.authorized).toBe(false);
       expect(result.reasons).toHaveLength(1);
       expect(result.reasons[0]).toContain('not available');
     });
 
-    it('should return not authorized when stage24Data is null', () => {
-      const result = verifyLaunchAuthorization({ stage24Data: null });
+    it('should return not authorized when stage25Data is null', () => {
+      const result = verifyLaunchAuthorization({ stage25Data: null });
       expect(result.authorized).toBe(false);
       expect(result.reasons.length).toBeGreaterThan(0);
     });
 
     it('should return not authorized when chairman gate is not approved', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'pending' },
           go_no_go_decision: 'go',
         },
@@ -380,7 +380,7 @@ describe('stage-25.js - Launch Execution template', () => {
 
     it('should return not authorized when chairman gate is rejected', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'rejected' },
           go_no_go_decision: 'go',
         },
@@ -391,7 +391,7 @@ describe('stage-25.js - Launch Execution template', () => {
 
     it('should return not authorized when decision is no_go', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'approved' },
           go_no_go_decision: 'no_go',
         },
@@ -402,7 +402,7 @@ describe('stage-25.js - Launch Execution template', () => {
 
     it('should return not authorized when decision is not set', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'approved' },
           go_no_go_decision: null,
         },
@@ -413,7 +413,7 @@ describe('stage-25.js - Launch Execution template', () => {
 
     it('should collect multiple reasons when both gate and decision fail', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'pending' },
           go_no_go_decision: 'no_go',
         },
@@ -424,9 +424,9 @@ describe('stage-25.js - Launch Execution template', () => {
       expect(result.reasons.some(r => r.includes('go/no-go decision'))).toBe(true);
     });
 
-    it('should handle missing chairmanGate in stage24Data', () => {
+    it('should handle missing chairmanGate in stage25Data', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           go_no_go_decision: 'go',
         },
       });
@@ -434,9 +434,9 @@ describe('stage-25.js - Launch Execution template', () => {
       expect(result.reasons.some(r => r.includes('chairman gate'))).toBe(true);
     });
 
-    it('should handle missing go_no_go_decision in stage24Data', () => {
+    it('should handle missing go_no_go_decision in stage25Data', () => {
       const result = verifyLaunchAuthorization({
-        stage24Data: {
+        stage25Data: {
           chairmanGate: { status: 'approved' },
         },
       });


### PR DESCRIPTION
## Summary
- Fixed parameter naming mismatch in stages 23-26 that caused CommitCraft AI to fail at Stage 23 (release readiness)
- `fetchUpstreamArtifacts` produces `stage${lifecycle}Data` keys but analysis functions used old numbering (off by one)
- Updated CROSS_STAGE_DEPS, 4 analysis functions, 2 helper functions, and worker enrichment sites

## Test plan
- [x] Real data path tests pass (5/5 in stage-23-release-readiness.test.js)
- [x] checkReleaseReadiness works with `stage23Data` param
- [x] verifyLaunchAuthorization works with `stage25Data` param
- [ ] Reset CommitCraft AI venture to S23 and verify auto-advance

🤖 Generated with [Claude Code](https://claude.com/claude-code)