### PR TITLE
fix(DB): restore SECURITY DEFINER on get_gate_decision_status

### DIFF
--- a/supabase/migrations/20260329_restore_gate_decision_status_secdef.sql
+++ b/supabase/migrations/20260329_restore_gate_decision_status_secdef.sql
@@ -1,0 +1,17 @@
+-- ============================================================================
+-- Restore SECURITY DEFINER on get_gate_decision_status
+-- ============================================================================
+-- Problem: The security_definer_audit migration (20260317) changed this
+-- function to SECURITY INVOKER. But chairman_decisions has RLS that blocks
+-- anon/authenticated reads. The function was intentionally SECURITY DEFINER
+-- to bypass RLS and return gate status to the frontend.
+--
+-- With SECURITY INVOKER, the SELECT returns nothing, the function falls
+-- through to its INSERT path, and creates duplicate PENDING decisions
+-- that collide on idx_chairman_decisions_unique_pending.
+--
+-- Fix: Restore SECURITY DEFINER with restricted search_path.
+-- ============================================================================
+
+ALTER FUNCTION public.get_gate_decision_status(UUID, INTEGER) SECURITY DEFINER;
+ALTER FUNCTION public.get_gate_decision_status(UUID, INTEGER) SET search_path TO 'public';


### PR DESCRIPTION
## Summary
- Restore `SECURITY DEFINER` on `get_gate_decision_status` RPC — the security audit migration (20260317) changed it to `SECURITY INVOKER`, but the function needs to bypass RLS on `chairman_decisions` to return gate status to the frontend
- Without it, the SELECT returns empty (RLS blocks anon), the function falls through to its INSERT path, and creates duplicate PENDING decisions that collide on `idx_chairman_decisions_unique_pending` (409 Conflict)

## Test plan
- [x] Applied directly to live DB and verified `prosecdef = true`
- [x] Fixed stale `venture_stage_work` status (stage 24 blocked → completed)
- [x] Deleted 0 stale pending decisions (none existed at query time)
- [ ] Verify frontend no longer shows 409 errors on venture detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)