### PR TITLE
feat(cleanup): add missing tables to master_reset and create protected_resources

### DIFF
--- a/database/migrations/20260329_create_protected_resources.sql
+++ b/database/migrations/20260329_create_protected_resources.sql
@@ -1,0 +1,48 @@
+-- Migration: Create protected_resources table
+-- SD: SD-LEO-INFRA-VENTURE-CLEANUP-ORCHESTRATOR-001-A
+--
+-- Provides a database-driven protection list for the master_reset_portfolio RPC.
+-- Resources listed here are excluded from deletion during a portfolio reset.
+--
+-- Replaces the hard-coded PROTECTED_REPOS set in server/routes/ventures.js
+-- with a queryable, auditable table.
+
+CREATE TABLE IF NOT EXISTS public.protected_resources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  resource_type TEXT NOT NULL,          -- 'venture', 'repo', 'application'
+  resource_id TEXT NOT NULL,            -- UUID string for ventures, slug for repos
+  venture_id UUID,                      -- optional link to ventures table
+  protection_reason TEXT NOT NULL,      -- why this resource is protected
+  protected_by TEXT NOT NULL DEFAULT 'system',  -- who added the protection
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT unique_protected_resource UNIQUE (resource_type, resource_id)
+);
+
+COMMENT ON TABLE public.protected_resources IS 'Resources that must never be deleted during master reset or cleanup operations.';
+COMMENT ON COLUMN public.protected_resources.resource_type IS 'Type of protected resource: venture, repo, application';
+COMMENT ON COLUMN public.protected_resources.resource_id IS 'Identifier of the resource. UUID for ventures, slug for repos (e.g. rickfelix/ehg)';
+
+-- RLS: Only service_role and chairman can read/modify protected resources
+ALTER TABLE public.protected_resources ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY protected_resources_service_role ON public.protected_resources
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY protected_resources_authenticated_read ON public.protected_resources
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Seed with core protected repos (matches existing PROTECTED_REPOS in ventures.js)
+INSERT INTO public.protected_resources (resource_type, resource_id, protection_reason, protected_by)
+VALUES
+  ('repo', 'rickfelix/ehg', 'Core frontend application — must never be deleted', 'system'),
+  ('repo', 'rickfelix/EHG_Engineer', 'Core backend application — must never be deleted', 'system'),
+  ('repo', 'rickfelix/ehg_engineer', 'Core backend application (lowercase) — must never be deleted', 'system')
+ON CONFLICT (resource_type, resource_id) DO NOTHING;
+
+-- Grant permissions
+GRANT SELECT ON public.protected_resources TO authenticated;
+GRANT ALL ON public.protected_resources TO service_role;

--- a/database/migrations/20260329_patch_master_reset_missing_tables.sql
+++ b/database/migrations/20260329_patch_master_reset_missing_tables.sql
@@ -1,0 +1,259 @@
+-- Migration: Add missing infrastructure tables to master_reset_portfolio()
+-- SD: SD-LEO-INFRA-VENTURE-CLEANUP-ORCHESTRATOR-001-A
+--
+-- Adds conditional DELETEs for tables that may not yet exist in the schema:
+--   - genesis_deployments (simulation deployments)
+--   - managed_applications + children (application registry)
+--   - github_webhook_events + CI/CD tables (webhook audit trail)
+--
+-- Uses IF EXISTS checks so the RPC remains safe when tables are not yet created.
+-- Also adds protected_resources check: ventures marked as protected are excluded
+-- from deletion.
+--
+-- Rollback: Re-deploy previous version from
+--   20260328_patch_master_reset_add_enrichment_tables.sql
+
+CREATE OR REPLACE FUNCTION public.master_reset_portfolio()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  venture_ids UUID[];
+  deleted_count INTEGER;
+  caller_role TEXT;
+  caller_uid UUID;
+  protected_venture_ids UUID[];
+BEGIN
+  caller_role := current_setting('request.jwt.claims', true)::jsonb ->> 'role';
+  caller_uid  := (current_setting('request.jwt.claims', true)::jsonb ->> 'sub')::UUID;
+  IF caller_role IS DISTINCT FROM 'service_role'
+     AND NOT fn_is_chairman() THEN
+    RAISE EXCEPTION 'master_reset_portfolio: unauthorized (role=%, uid=%)', caller_role, caller_uid;
+  END IF;
+
+  -- Check for protected ventures (skip if table does not exist yet)
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'protected_resources') THEN
+    SELECT ARRAY_AGG(DISTINCT (resource_id)::UUID)
+      INTO protected_venture_ids
+      FROM protected_resources
+     WHERE resource_type = 'venture';
+  END IF;
+  protected_venture_ids := COALESCE(protected_venture_ids, ARRAY[]::UUID[]);
+
+  SELECT ARRAY_AGG(id) INTO venture_ids
+    FROM ventures
+   WHERE id != ALL(protected_venture_ids);
+
+  deleted_count := COALESCE(array_length(venture_ids, 1), 0);
+  IF deleted_count = 0 THEN
+    RETURN jsonb_build_object('success', true, 'count', 0, 'message', 'No ventures to delete');
+  END IF;
+
+  INSERT INTO operations_audit_log (entity_type, action, performed_by, severity, metadata)
+  VALUES (
+    'portfolio',
+    'master_reset_portfolio',
+    caller_uid,
+    'critical',
+    jsonb_build_object(
+      'venture_count', deleted_count,
+      'venture_ids', to_jsonb(venture_ids),
+      'protected_count', COALESCE(array_length(protected_venture_ids, 1), 0),
+      'caller_role', COALESCE(caller_role, 'unknown'),
+      'result', 'executing',
+      'timestamp', NOW()
+    )
+  );
+
+  -- Phase 1: SET bypass
+  SET LOCAL leo.bypass_working_on_check = 'true';
+
+  -- Phase 2: Governance tables
+  DELETE FROM chairman_decisions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM chairman_directives WHERE venture_id = ANY(venture_ids);
+  DELETE FROM governance_decisions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM compliance_gate_events WHERE venture_id = ANY(venture_ids);
+  DELETE FROM risk_escalation_log WHERE venture_id = ANY(venture_ids);
+  DELETE FROM risk_gate_passage_log WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 3: NULL out FK references
+  UPDATE strategic_directives_v2 SET venture_id = NULL WHERE venture_id = ANY(venture_ids);
+  UPDATE sd_phase_handoffs SET venture_id = NULL WHERE venture_id = ANY(venture_ids);
+  UPDATE sd_proposals SET venture_id = NULL WHERE venture_id = ANY(venture_ids);
+  UPDATE product_requirements_v2 SET venture_id = NULL WHERE venture_id = ANY(venture_ids);
+  UPDATE venture_dependencies SET dependent_venture_id = NULL WHERE dependent_venture_id = ANY(venture_ids);
+  UPDATE venture_dependencies SET provider_venture_id = NULL WHERE provider_venture_id = ANY(venture_ids);
+  UPDATE venture_capabilities SET origin_venture_id = NULL WHERE origin_venture_id = ANY(venture_ids);
+  UPDATE venture_templates SET source_venture_id = NULL WHERE source_venture_id = ANY(venture_ids);
+  UPDATE venture_nursery SET promoted_to_venture_id = NULL WHERE promoted_to_venture_id = ANY(venture_ids);
+  UPDATE agent_registry SET venture_id = NULL WHERE venture_id = ANY(venture_ids);
+  UPDATE ventures SET
+    brief_id = NULL,
+    vision_id = NULL,
+    architecture_plan_id = NULL,
+    ceo_agent_id = NULL,
+    portfolio_id = NULL,
+    company_id = NULL,
+    source_blueprint_id = NULL
+  WHERE id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (EVA subsystem)
+  DELETE FROM eva_vision_scores WHERE vision_id IN (
+    SELECT id FROM eva_vision_documents WHERE venture_id = ANY(venture_ids)
+  );
+  DELETE FROM eva_scheduler_metrics WHERE venture_id IN (
+    SELECT venture_id FROM eva_ventures WHERE venture_id = ANY(venture_ids)
+  );
+  DELETE FROM eva_scheduler_queue WHERE venture_id IN (
+    SELECT venture_id FROM eva_ventures WHERE venture_id = ANY(venture_ids)
+  );
+  DELETE FROM eva_audit_log WHERE eva_venture_id IN (
+    SELECT id FROM eva_ventures WHERE venture_id = ANY(venture_ids)
+  );
+  DELETE FROM venture_separability_scores WHERE venture_id IN (
+    SELECT venture_id FROM eva_ventures WHERE venture_id = ANY(venture_ids)
+  );
+  DELETE FROM eva_actions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM eva_architecture_plans WHERE venture_id = ANY(venture_ids);
+  DELETE FROM eva_interactions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM eva_orchestration_events WHERE venture_id = ANY(venture_ids);
+  DELETE FROM eva_saga_log WHERE venture_id = ANY(venture_ids);
+  DELETE FROM eva_stage_gate_results WHERE venture_id = ANY(venture_ids);
+  DELETE FROM eva_trace_log WHERE venture_id = ANY(venture_ids);
+  DELETE FROM eva_vision_documents WHERE venture_id = ANY(venture_ids);
+  DELETE FROM eva_ventures WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Chairman/Financial)
+  DELETE FROM chairman_approval_requests WHERE venture_id = ANY(venture_ids);
+  DELETE FROM chairman_settings WHERE venture_id = ANY(venture_ids);
+  DELETE FROM capital_transactions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM financial_models WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_financial_contract WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_phase_budgets WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_token_budgets WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_token_ledger WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Marketing)
+  DELETE FROM marketing_attribution WHERE venture_id = ANY(venture_ids);
+  DELETE FROM marketing_campaigns WHERE venture_id = ANY(venture_ids);
+  DELETE FROM marketing_channels WHERE venture_id = ANY(venture_ids);
+  DELETE FROM marketing_content WHERE venture_id = ANY(venture_ids);
+  DELETE FROM marketing_content_queue WHERE venture_id = ANY(venture_ids);
+  DELETE FROM channel_budgets WHERE venture_id = ANY(venture_ids);
+  DELETE FROM distribution_history WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Stage/Execution)
+  DELETE FROM stage_executions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM risk_recalibration_forms WHERE venture_id = ANY(venture_ids);
+  DELETE FROM stage13_valuations WHERE venture_id = ANY(venture_ids);
+  DELETE FROM stage13_substage_states WHERE venture_id = ANY(venture_ids);
+  DELETE FROM stage13_assessments WHERE venture_id = ANY(venture_ids);
+  DELETE FROM substage_transition_log WHERE venture_id = ANY(venture_ids);
+  DELETE FROM stage_zero_requests WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_stage_transitions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_stage_work WHERE venture_id = ANY(venture_ids);
+  DELETE FROM stage_events WHERE venture_id = ANY(venture_ids);
+  DELETE FROM stage_proving_journal WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Documents/Compliance)
+  DELETE FROM venture_documents WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_decisions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_compliance_artifacts WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_compliance_progress WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_exit_profiles WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Artifacts/Enrichment)
+  DELETE FROM venture_artifact_summaries WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_sd_artifact_mapping WHERE venture_type IN (
+    SELECT DISTINCT archetype FROM ventures WHERE id = ANY(venture_ids) AND archetype IS NOT NULL
+  );
+  DELETE FROM venture_artifacts WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Core venture data)
+  DELETE FROM venture_asset_registry WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_briefs WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_exit_readiness WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_tiers WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_fundamentals WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_compliance WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_provisioning_state WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (SRIP/Brand)
+  DELETE FROM srip_brand_interviews WHERE venture_id = ANY(venture_ids);
+  DELETE FROM srip_site_dna WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Agent/Intelligence)
+  DELETE FROM agent_memory_stores WHERE venture_id = ANY(venture_ids);
+  DELETE FROM intelligence_analysis WHERE venture_id = ANY(venture_ids);
+  DELETE FROM competitors WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Operational)
+  DELETE FROM daily_rollups WHERE venture_id = ANY(venture_ids);
+  DELETE FROM missions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM modeling_requests WHERE venture_id = ANY(venture_ids);
+  DELETE FROM monthly_ceo_reports WHERE venture_id = ANY(venture_ids);
+  DELETE FROM naming_suggestions WHERE venture_id = ANY(venture_ids);
+  DELETE FROM naming_favorites WHERE venture_id = ANY(venture_ids);
+  DELETE FROM orchestration_metrics WHERE venture_id = ANY(venture_ids);
+  DELETE FROM pending_ceo_handoffs WHERE venture_id = ANY(venture_ids);
+  DELETE FROM public_portfolio WHERE venture_id = ANY(venture_ids);
+  DELETE FROM tool_usage_ledger WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_tool_quotas WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4: CASCADE tables (Services/Workflows)
+  DELETE FROM service_tasks WHERE venture_id = ANY(venture_ids);
+  DELETE FROM venture_service_bindings WHERE venture_id = ANY(venture_ids);
+  DELETE FROM service_telemetry WHERE venture_id = ANY(venture_ids);
+  DELETE FROM workflow_executions WHERE venture_id = ANY(venture_ids);
+
+  -- Phase 4.5: Infrastructure tables (conditional — may not exist yet)
+  -- These tables have no venture_id FK but accumulate stale data after reset.
+  -- Delete all rows when present; skip silently when table is absent.
+
+  -- Genesis deployments (Vercel preview deployments)
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'genesis_deployments') THEN
+    DELETE FROM genesis_deployments;
+  END IF;
+
+  -- CI/CD pipeline tables (FK order: children first)
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'ci_cd_failure_resolutions') THEN
+    DELETE FROM ci_cd_failure_resolutions;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'github_webhook_events') THEN
+    DELETE FROM github_webhook_events;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'ci_cd_pipeline_status') THEN
+    DELETE FROM ci_cd_pipeline_status;
+  END IF;
+
+  -- Managed applications registry (FK order: children first)
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'application_credentials') THEN
+    DELETE FROM application_credentials;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'application_directives') THEN
+    DELETE FROM application_directives;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'application_sync_history') THEN
+    DELETE FROM application_sync_history;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'application_context') THEN
+    DELETE FROM application_context;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_tables WHERE schemaname = 'public' AND tablename = 'managed_applications') THEN
+    DELETE FROM managed_applications;
+  END IF;
+
+  -- Phase 5: Delete ventures themselves
+  DELETE FROM ventures WHERE id = ANY(venture_ids);
+  DELETE FROM stage_zero_requests WHERE venture_id IS NULL;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'count', deleted_count,
+    'message', deleted_count || ' venture(s) and all related data deleted',
+    'protected_count', COALESCE(array_length(protected_venture_ids, 1), 0)
+  );
+END;
+$function$;

--- a/tests/unit/cleanup/master-reset-validation.test.js
+++ b/tests/unit/cleanup/master-reset-validation.test.js
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import dotenv from 'dotenv';
+import pg from 'pg';
+
+dotenv.config();
+
+const { Client } = pg;
+
+/**
+ * Master Reset Validation Test
+ * SD: SD-LEO-INFRA-VENTURE-CLEANUP-ORCHESTRATOR-001-A
+ *
+ * Verifies that all tables referenced by master_reset_portfolio() exist in the
+ * database. Catches schema drift before reset attempts fail at runtime.
+ */
+
+// Tables that master_reset_portfolio() unconditionally deletes from.
+// These MUST exist for the RPC to succeed.
+const REQUIRED_TABLES = [
+  // Phase 2: Governance
+  'chairman_decisions', 'chairman_directives', 'governance_decisions',
+  'compliance_gate_events', 'risk_escalation_log', 'risk_gate_passage_log',
+  // Phase 3: FK nulling
+  'strategic_directives_v2', 'sd_phase_handoffs', 'sd_proposals',
+  'product_requirements_v2', 'venture_dependencies', 'venture_capabilities',
+  'venture_templates', 'venture_nursery', 'agent_registry', 'ventures',
+  // Phase 4: EVA
+  'eva_vision_scores', 'eva_scheduler_metrics', 'eva_scheduler_queue',
+  'eva_audit_log', 'venture_separability_scores', 'eva_actions',
+  'eva_architecture_plans', 'eva_interactions', 'eva_orchestration_events',
+  'eva_saga_log', 'eva_stage_gate_results', 'eva_trace_log',
+  'eva_vision_documents', 'eva_ventures',
+  // Phase 4: Financial
+  'chairman_approval_requests', 'chairman_settings', 'capital_transactions',
+  'financial_models', 'venture_financial_contract', 'venture_phase_budgets',
+  'venture_token_budgets', 'venture_token_ledger',
+  // Phase 4: Marketing
+  'marketing_attribution', 'marketing_campaigns', 'marketing_channels',
+  'marketing_content', 'marketing_content_queue', 'channel_budgets',
+  'distribution_history',
+  // Phase 4: Stage/Execution
+  'stage_executions', 'risk_recalibration_forms', 'stage13_valuations',
+  'stage13_substage_states', 'stage13_assessments', 'substage_transition_log',
+  'stage_zero_requests', 'venture_stage_transitions', 'venture_stage_work',
+  'stage_events', 'stage_proving_journal',
+  // Phase 4: Documents
+  'venture_documents', 'venture_decisions', 'venture_compliance_artifacts',
+  'venture_compliance_progress', 'venture_exit_profiles',
+  // Phase 4: Artifacts
+  'venture_artifact_summaries', 'venture_sd_artifact_mapping', 'venture_artifacts',
+  // Phase 4: Core
+  'venture_asset_registry', 'venture_briefs', 'venture_exit_readiness',
+  'venture_tiers', 'venture_fundamentals', 'venture_compliance',
+  'venture_provisioning_state',
+  // Phase 4: SRIP
+  'srip_brand_interviews', 'srip_site_dna',
+  // Phase 4: Agent
+  'agent_memory_stores', 'intelligence_analysis', 'competitors',
+  // Phase 4: Operational
+  'daily_rollups', 'missions', 'modeling_requests', 'monthly_ceo_reports',
+  'naming_suggestions', 'naming_favorites', 'orchestration_metrics',
+  'pending_ceo_handoffs', 'public_portfolio', 'tool_usage_ledger',
+  'venture_tool_quotas',
+  // Phase 4: Services
+  'service_tasks', 'venture_service_bindings', 'service_telemetry',
+  'workflow_executions',
+  // Supporting
+  'operations_audit_log',
+];
+
+// Tables in Phase 4.5 that use IF EXISTS — optional, won't break RPC if missing.
+const OPTIONAL_TABLES = [
+  'genesis_deployments',
+  'ci_cd_failure_resolutions', 'github_webhook_events', 'ci_cd_pipeline_status',
+  'application_credentials', 'application_directives', 'application_sync_history',
+  'application_context', 'managed_applications',
+  'protected_resources',
+];
+
+let client;
+
+beforeAll(async () => {
+  client = new Client({ connectionString: process.env.SUPABASE_POOLER_URL });
+  await client.connect();
+});
+
+afterAll(async () => {
+  if (client) await client.end();
+});
+
+describe('master_reset_portfolio table coverage', () => {
+  it('all required tables exist in the public schema', async () => {
+    const result = await client.query(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE'
+    `);
+    const existing = new Set(result.rows.map(r => r.table_name));
+    const missing = REQUIRED_TABLES.filter(t => !existing.has(t));
+
+    expect(missing, `Missing required tables: ${missing.join(', ')}`).toEqual([]);
+  });
+
+  it('reports optional table presence (informational)', async () => {
+    const result = await client.query(`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE'
+    `);
+    const existing = new Set(result.rows.map(r => r.table_name));
+    const present = OPTIONAL_TABLES.filter(t => existing.has(t));
+    const absent = OPTIONAL_TABLES.filter(t => !existing.has(t));
+
+    // Log for visibility — these are optional so we don't fail on them
+    if (absent.length > 0) {
+      console.log(`Optional tables NOT YET created (${absent.length}): ${absent.join(', ')}`);
+    }
+    if (present.length > 0) {
+      console.log(`Optional tables present (${present.length}): ${present.join(', ')}`);
+    }
+
+    // This test always passes — it's informational
+    expect(true).toBe(true);
+  });
+
+  it('master_reset_portfolio RPC exists', async () => {
+    const result = await client.query(`
+      SELECT routine_name
+      FROM information_schema.routines
+      WHERE routine_schema = 'public'
+        AND routine_name = 'master_reset_portfolio'
+    `);
+    expect(result.rows.length, 'master_reset_portfolio() RPC should exist').toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `master_reset_portfolio()` RPC with conditional DELETEs for 9 infrastructure tables (genesis_deployments, managed_applications + 4 children, github_webhook_events + 2 CI/CD tables)
- Creates `protected_resources` table with RLS and seed data for core repos
- Adds validation test verifying all cleanup target tables exist in the schema

## Test plan
- [x] Validation test passes (3/3): required tables exist, optional tables reported, RPC exists
- [x] Migrations executed successfully on Supabase
- [x] protected_resources seeded with 3 core repos
- [x] IF EXISTS guards prevent runtime errors for missing optional tables

SD: SD-LEO-INFRA-VENTURE-CLEANUP-ORCHESTRATOR-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)