### PR TITLE
feat(ventures): enforce Stage 0 gate for venture creation

### DIFF
--- a/database/migrations/20260330_stage_zero_enforcement.sql
+++ b/database/migrations/20260330_stage_zero_enforcement.sql
@@ -1,0 +1,50 @@
+-- Migration: Stage 0 Gate Enforcement Trigger
+-- SD: SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-A
+--
+-- Blocks direct INSERT into ventures unless:
+--   1. leo.stage0_bypass session variable is set to 'true' (used by provisioner)
+--   2. leo.bypass_working_on_check is set to 'true' (used by master_reset)
+--
+-- All venture creation must go through the Stage 0 queue (stage_zero_requests)
+-- for chairman review before a venture record is created.
+
+CREATE OR REPLACE FUNCTION trg_enforce_stage0_origin()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Allow bypass for provisioner and master reset
+  IF current_setting('leo.stage0_bypass', true) = 'true'
+     OR current_setting('leo.bypass_working_on_check', true) = 'true' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Allow service_role (Supabase admin operations, queue processor)
+  IF current_setting('request.jwt.claims', true)::jsonb ->> 'role' = 'service_role' THEN
+    RETURN NEW;
+  END IF;
+
+  -- Log the blocked attempt
+  INSERT INTO operations_audit_log (entity_type, action, severity, metadata)
+  VALUES (
+    'venture_creation_blocked',
+    'direct_insert_prevented',
+    'warning',
+    jsonb_build_object(
+      'venture_name', NEW.name,
+      'origin_type', NEW.origin_type,
+      'reason', 'Direct INSERT blocked — must use Stage 0 queue',
+      'timestamp', NOW()
+    )
+  );
+
+  RAISE EXCEPTION 'Venture creation must go through Stage 0 queue (POST /api/ventures). Direct INSERT is blocked. Set leo.stage0_bypass=true for provisioner operations.';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_enforce_stage0_origin ON ventures;
+CREATE TRIGGER trg_enforce_stage0_origin
+  BEFORE INSERT ON ventures
+  FOR EACH ROW
+  EXECUTE FUNCTION trg_enforce_stage0_origin();
+
+COMMENT ON FUNCTION trg_enforce_stage0_origin() IS
+  'Blocks direct INSERT into ventures. All creation must go through stage_zero_requests queue for chairman review.';

--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -225,7 +225,8 @@ router.post('/:id/artifacts', validateUuidParam('id'), asyncHandler(async (req, 
   });
 }));
 
-// Create new venture - IDEATION-GENESIS-AUDIT: Capture raw Chairman intent
+// Create new venture — Routes through Stage 0 queue for chairman review
+// SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-A: Stage 0 Gate Enforcement
 router.post('/', asyncHandler(async (req, res) => {
   const ventureData = req.body;
 
@@ -240,36 +241,47 @@ router.post('/', asyncHandler(async (req, res) => {
     return res.status(400).json({ error: 'origin_type must be one of: manual, competitor_clone, blueprint' });
   }
 
+  // Route to Stage 0 queue instead of direct INSERT into ventures
+  const prompt = [
+    ventureData.name,
+    ventureData.problem_statement,
+    ventureData.solution,
+    ventureData.target_market
+  ].filter(Boolean).join('. ');
+
   const { data, error } = await dbLoader.supabase
-    .from('ventures')
+    .from('stage_zero_requests')
     .insert({
-      name: ventureData.name,
-      description: ventureData.description,
-      problem_statement: ventureData.problem_statement,
-      raw_chairman_intent: ventureData.problem_statement,
-      problem_statement_locked_at: new Date().toISOString(),
-      solution: ventureData.solution,
-      target_market: ventureData.target_market,
-      origin_type: ventureData.origin_type || 'manual',
-      competitor_ref: ventureData.competitor_ref || null,
-      current_lifecycle_stage: 1,
-      workflow_status: 'pending',
-      status: 'active'
+      prompt: prompt || ventureData.name,
+      status: 'pending',
+      priority: 0,
+      result: {
+        origin: 'api',
+        origin_type: ventureData.origin_type || 'manual',
+        venture_metadata: {
+          name: ventureData.name,
+          description: ventureData.description,
+          problem_statement: ventureData.problem_statement,
+          solution: ventureData.solution,
+          target_market: ventureData.target_market,
+          competitor_ref: ventureData.competitor_ref || null
+        }
+      }
     })
-    .select()
+    .select('id, status, created_at')
     .single();
 
   if (error) {
-    console.error('Error creating venture:', error);
+    console.error('Error creating stage zero request:', error);
     return res.status(500).json({ error: error.message });
   }
 
-  const venture = {
-    ...data,
-    stage: data.current_lifecycle_stage || 1
-  };
-
-  res.status(201).json(venture);
+  res.status(202).json({
+    stage_zero_request_id: data.id,
+    status: data.status,
+    message: 'Venture creation queued for Stage 0 chairman review',
+    created_at: data.created_at
+  });
 }));
 
 // Competitor Analysis - IDEATION-GENESIS-AUDIT: Real market intelligence


### PR DESCRIPTION
## Summary
- Rewires `POST /ventures` to create `stage_zero_requests` entries instead of direct INSERT — returns 202 Accepted
- Adds `trg_enforce_stage0_origin` database trigger blocking direct INSERT into ventures
- Service role, `leo.stage0_bypass`, and `leo.bypass_working_on_check` flags provide authorized bypass
- Blocked attempts logged to `operations_audit_log`

## Test plan
- [x] Migration executed: trigger verified on ventures table
- [x] Smoke tests pass (15/15)
- [x] Pre-commit hooks pass (ESLint, secrets scan, DOCMON)
- [x] Service role bypass allows queue processor to create ventures
- [x] Bypass flags allow provisioner and master reset operations

SD: SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)