### PR TITLE
feat(compliance): add retroactive compliance gate for Stage 20

### DIFF
--- a/lib/compliance/retroactive-check.js
+++ b/lib/compliance/retroactive-check.js
@@ -1,0 +1,101 @@
+/**
+ * Retroactive Compliance Check for Stage 20
+ * SD: SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-C
+ *
+ * Validates that sprint-built ventures (those that bypassed stages 0-17)
+ * have minimum required governance artifacts before advancing past Stage 20.
+ *
+ * Required artifacts:
+ *   - venture_briefs: At least one brief record
+ *   - eva_vision_documents: At least one vision document
+ *   - venture_fundamentals: A fundamentals record
+ *
+ * @example
+ * // Integration with Stage 20 execution worker:
+ * import { checkRetroactiveCompliance } from '../../lib/compliance/retroactive-check.js';
+ *
+ * const result = await checkRetroactiveCompliance(ventureId, supabase);
+ * if (!result.compliant) {
+ *   await supabase.from('stage_executions')
+ *     .update({ stage_status: 'blocked', compliance_gaps: result.gaps })
+ *     .eq('venture_id', ventureId).eq('stage_number', 20);
+ * }
+ *
+ * @module compliance/retroactive-check
+ */
+
+const REQUIRED_ARTIFACTS = [
+  {
+    table: 'venture_briefs',
+    column: 'venture_id',
+    label: 'Venture Brief',
+    description: 'At least one venture brief must exist',
+  },
+  {
+    table: 'eva_vision_documents',
+    column: 'venture_id',
+    label: 'Vision Document',
+    description: 'At least one EVA vision document must exist',
+  },
+  {
+    table: 'venture_fundamentals',
+    column: 'venture_id',
+    label: 'Venture Fundamentals',
+    description: 'A venture fundamentals record must exist',
+  },
+];
+
+/**
+ * Check if a venture has the minimum required governance artifacts.
+ *
+ * @param {string} ventureId - UUID of the venture to check
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase - Supabase client
+ * @param {Object} [options]
+ * @param {boolean} [options.skipStage0Ventures=true] - Skip check for ventures created through Stage 0
+ * @returns {Promise<{compliant: boolean, gaps: string[], checked: number, found: number}>}
+ */
+export async function checkRetroactiveCompliance(ventureId, supabase, options = {}) {
+  const { skipStage0Ventures = true } = options;
+
+  if (skipStage0Ventures) {
+    const { data: venture } = await supabase
+      .from('ventures')
+      .select('origin_type, current_lifecycle_stage')
+      .eq('id', ventureId)
+      .single();
+
+    // Ventures that entered through Stage 0 (origin_type not set or went through queue)
+    // already have governance artifacts from the synthesis pipeline
+    if (venture && venture.origin_type === 'stage0') {
+      return { compliant: true, gaps: [], checked: 0, found: 0 };
+    }
+  }
+
+  const gaps = [];
+  let found = 0;
+
+  for (const artifact of REQUIRED_ARTIFACTS) {
+    const { count, error } = await supabase
+      .from(artifact.table)
+      .select('*', { count: 'exact', head: true })
+      .eq(artifact.column, ventureId);
+
+    if (error) {
+      gaps.push(`${artifact.label}: query error (${error.message})`);
+      continue;
+    }
+
+    if (count === 0) {
+      gaps.push(`${artifact.label}: ${artifact.description}`);
+    } else {
+      found++;
+    }
+  }
+
+  return {
+    compliant: gaps.length === 0,
+    gaps,
+    checked: REQUIRED_ARTIFACTS.length,
+    found,
+  };
+}

--- a/tests/unit/compliance/retroactive-check.test.js
+++ b/tests/unit/compliance/retroactive-check.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { checkRetroactiveCompliance } from '../../../lib/compliance/retroactive-check.js';
+
+function mockSupabase(responses = {}) {
+  const fromChain = (table) => {
+    const resp = responses[table] || { count: 0, error: null };
+    return {
+      select: () => ({
+        eq: (col, val) => {
+          // If the response has .data, this is a .single() chain (ventures lookup)
+          if (resp.data !== undefined) {
+            return {
+              single: () => Promise.resolve({ data: resp.data, error: resp.error || null }),
+            };
+          }
+          // Otherwise it's a count query (artifact check)
+          return Promise.resolve({ count: resp.count ?? 0, error: resp.error || null });
+        },
+      }),
+    };
+  };
+  return { from: vi.fn(fromChain) };
+}
+
+describe('checkRetroactiveCompliance', () => {
+  it('returns compliant=false with 3 gaps when venture has no artifacts', async () => {
+    const supabase = mockSupabase({
+      ventures: { data: { origin_type: 'manual', current_lifecycle_stage: 20 } },
+      venture_briefs: { count: 0 },
+      eva_vision_documents: { count: 0 },
+      venture_fundamentals: { count: 0 },
+    });
+
+    const result = await checkRetroactiveCompliance('test-venture-id', supabase);
+
+    expect(result.compliant).toBe(false);
+    expect(result.gaps).toHaveLength(3);
+    expect(result.gaps[0]).toContain('Venture Brief');
+    expect(result.gaps[1]).toContain('Vision Document');
+    expect(result.gaps[2]).toContain('Venture Fundamentals');
+    expect(result.checked).toBe(3);
+    expect(result.found).toBe(0);
+  });
+
+  it('returns compliant=true when venture has all 3 artifacts', async () => {
+    const supabase = mockSupabase({
+      ventures: { data: { origin_type: 'manual', current_lifecycle_stage: 20 } },
+      venture_briefs: { count: 1 },
+      eva_vision_documents: { count: 2 },
+      venture_fundamentals: { count: 1 },
+    });
+
+    const result = await checkRetroactiveCompliance('test-venture-id', supabase);
+
+    expect(result.compliant).toBe(true);
+    expect(result.gaps).toHaveLength(0);
+    expect(result.found).toBe(3);
+  });
+
+  it('returns compliant=false with 2 gaps for partial artifacts', async () => {
+    const supabase = mockSupabase({
+      ventures: { data: { origin_type: 'manual', current_lifecycle_stage: 20 } },
+      venture_briefs: { count: 1 },
+      eva_vision_documents: { count: 0 },
+      venture_fundamentals: { count: 0 },
+    });
+
+    const result = await checkRetroactiveCompliance('test-venture-id', supabase);
+
+    expect(result.compliant).toBe(false);
+    expect(result.gaps).toHaveLength(2);
+    expect(result.found).toBe(1);
+  });
+
+  it('skips check for Stage 0 ventures when skipStage0Ventures=true', async () => {
+    const supabase = mockSupabase({
+      ventures: { data: { origin_type: 'stage0', current_lifecycle_stage: 20 } },
+    });
+
+    const result = await checkRetroactiveCompliance('test-venture-id', supabase);
+
+    expect(result.compliant).toBe(true);
+    expect(result.gaps).toHaveLength(0);
+    expect(result.checked).toBe(0);
+  });
+
+  it('checks Stage 0 ventures when skipStage0Ventures=false', async () => {
+    const supabase = mockSupabase({
+      ventures: { data: { origin_type: 'stage0', current_lifecycle_stage: 20 } },
+      venture_briefs: { count: 0 },
+      eva_vision_documents: { count: 0 },
+      venture_fundamentals: { count: 0 },
+    });
+
+    const result = await checkRetroactiveCompliance('test-venture-id', supabase, { skipStage0Ventures: false });
+
+    expect(result.compliant).toBe(false);
+    expect(result.gaps).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Creates `check_retroactive_compliance()` in `lib/compliance/retroactive-check.js`
- Validates sprint-built ventures have minimum governance artifacts (brief, vision doc, fundamentals)
- Stage 0 ventures skipped (already governed through synthesis pipeline)
- Returns `{ compliant, gaps, checked, found }` for integration with Stage 20 worker

## Test plan
- [x] 5/5 unit tests pass (no artifacts, all artifacts, partial, stage0 skip, stage0 force-check)
- [x] Smoke tests pass (15/15)
- [x] ESLint clean, no secrets detected

SD: SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)