### PR TITLE
feat(ventures): add venture_resources registry for unified resource tracking

### DIFF
--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -14,6 +14,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { resolve, join } from 'path';
 import { fileURLToPath } from 'url';
 import { createSupabaseServiceClient } from '../../supabase-client.js';
+import { registerVentureResource } from '../../venture-resources.js';
 
 const __dirname = resolve(fileURLToPath(import.meta.url), '..');
 const REGISTRY_PATH = resolve(__dirname, '../../../applications/registry.json');
@@ -97,6 +98,13 @@ const DEFAULT_STEPS = [
       }
       ctx.ventureRepoPath = ctx.venture.localPath;
       ctx.log(`[repo_created] GitHub repo created: rickfelix/${repoName}`);
+
+      // Register resource in venture_resources registry
+      try {
+        await registerVentureResource(ctx.ventureId, 'github_repo', `rickfelix/${repoName}`, 'github', { url: `https://github.com/rickfelix/${repoName}` });
+        await registerVentureResource(ctx.ventureId, 'local_directory', ctx.venture.localPath, 'local');
+        ctx.log('[repo_created] Resources registered in venture_resources');
+      } catch (regErr) { ctx.log(`[repo_created] Resource registration non-fatal: ${regErr.message}`); }
     },
   },
   {

--- a/lib/venture-resources.js
+++ b/lib/venture-resources.js
@@ -1,0 +1,107 @@
+/**
+ * Venture Resources Registry — Helper Module
+ * SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-B
+ *
+ * Provides idempotent registration and cleanup of external resources per venture.
+ */
+
+import { createSupabaseServiceClient } from './supabase-client.js';
+
+/**
+ * Register an external resource for a venture (idempotent upsert).
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {string} resourceType - One of: github_repo, vercel_deployment, local_directory, supabase_project, domain, npm_package
+ * @param {string} resourceIdentifier - Unique identifier (e.g. repo URL, directory path)
+ * @param {string} provider - Provider name (e.g. 'github', 'vercel', 'local')
+ * @param {object} [metadata={}] - Additional metadata
+ * @returns {Promise<object|null>} The upserted row, or null on error
+ */
+export async function registerVentureResource(ventureId, resourceType, resourceIdentifier, provider, metadata = {}) {
+  try {
+    const supabase = createSupabaseServiceClient();
+    const { data, error } = await supabase
+      .from('venture_resources')
+      .upsert(
+        {
+          venture_id: ventureId,
+          resource_type: resourceType,
+          resource_identifier: resourceIdentifier,
+          provider,
+          status: 'active',
+          metadata,
+        },
+        { onConflict: 'venture_id,resource_type,resource_identifier' }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      console.error(`[venture-resources] register failed: ${error.message}`);
+      return null;
+    }
+    return data;
+  } catch (err) {
+    console.error(`[venture-resources] register error: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Mark all resources for a venture as cleaned (for master reset).
+ *
+ * @param {string} ventureId - Venture UUID
+ * @returns {Promise<number>} Count of updated rows
+ */
+export async function markResourcesCleaned(ventureId) {
+  try {
+    const supabase = createSupabaseServiceClient();
+    const { data, error } = await supabase
+      .from('venture_resources')
+      .update({ status: 'cleaned' })
+      .eq('venture_id', ventureId)
+      .eq('status', 'active')
+      .select('id');
+
+    if (error) {
+      console.error(`[venture-resources] cleanup failed: ${error.message}`);
+      return 0;
+    }
+    return data?.length ?? 0;
+  } catch (err) {
+    console.error(`[venture-resources] cleanup error: ${err.message}`);
+    return 0;
+  }
+}
+
+/**
+ * Get all resources for a venture.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {string} [status] - Optional status filter
+ * @returns {Promise<object[]>} Array of resource rows
+ */
+export async function getVentureResources(ventureId, status) {
+  try {
+    const supabase = createSupabaseServiceClient();
+    let query = supabase
+      .from('venture_resources')
+      .select('*')
+      .eq('venture_id', ventureId)
+      .order('created_at', { ascending: true });
+
+    if (status) {
+      query = query.eq('status', status);
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      console.error(`[venture-resources] get failed: ${error.message}`);
+      return [];
+    }
+    return data ?? [];
+  } catch (err) {
+    console.error(`[venture-resources] get error: ${err.message}`);
+    return [];
+  }
+}

--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -403,6 +403,18 @@ router.post('/master-reset', asyncHandler(async (req, res) => {
     teardownResults[ventureId] = await runTeardown(ventureId);
   }
 
+  // Phase 1.5a2: Mark venture_resources as cleaned (SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-B)
+  let resourcesCleanedCount = 0;
+  try {
+    const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
+    for (const ventureId of ventureIds) {
+      resourcesCleanedCount += await markResourcesCleaned(ventureId);
+    }
+    console.log(`[master-reset] ${resourcesCleanedCount} venture resource(s) marked as cleaned`);
+  } catch (resErr) {
+    console.error('[master-reset] Resource cleanup non-fatal:', resErr.message);
+  }
+
   // Phase 1.5b: REVOKE — Credential revocation at external providers BEFORE DB deletion
   // SD-LEO-INFRA-VENTURE-CLEANUP-ORCHESTRATOR-001-C
   // This MUST run while the relational mapping (managed_applications -> application_credentials) is intact

--- a/supabase/migrations/20260330_create_venture_resources.sql
+++ b/supabase/migrations/20260330_create_venture_resources.sql
@@ -1,0 +1,62 @@
+-- Venture Resources Registry
+-- SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-B
+--
+-- Unified registry of all external resources created during venture provisioning.
+-- Replaces fragmented tracking across venture_provisioning_state,
+-- venture_asset_registry, and protected_resources.
+
+CREATE TABLE IF NOT EXISTS venture_resources (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  venture_id UUID NOT NULL REFERENCES ventures(id) ON DELETE CASCADE,
+  resource_type TEXT NOT NULL CHECK (resource_type IN (
+    'github_repo', 'vercel_deployment', 'local_directory',
+    'supabase_project', 'domain', 'npm_package'
+  )),
+  resource_identifier TEXT NOT NULL,
+  provider TEXT NOT NULL DEFAULT 'unknown',
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'cleaned', 'failed', 'orphaned')),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  UNIQUE (venture_id, resource_type, resource_identifier)
+);
+
+-- Index for fast lookup by venture
+CREATE INDEX IF NOT EXISTS idx_venture_resources_venture_id ON venture_resources(venture_id);
+CREATE INDEX IF NOT EXISTS idx_venture_resources_status ON venture_resources(status);
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION update_venture_resources_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_venture_resources_updated_at ON venture_resources;
+CREATE TRIGGER trg_venture_resources_updated_at
+  BEFORE UPDATE ON venture_resources
+  FOR EACH ROW
+  EXECUTE FUNCTION update_venture_resources_updated_at();
+
+-- RLS
+ALTER TABLE venture_resources ENABLE ROW LEVEL SECURITY;
+
+-- Service role bypasses RLS automatically.
+-- Allow authenticated users to read resources for ventures they have access to.
+CREATE POLICY venture_resources_select_own ON venture_resources
+  FOR SELECT TO authenticated
+  USING (
+    (current_setting('role'::text, true) = 'service_role'::text)
+    OR portfolio.has_venture_access(venture_id)
+  );
+
+-- Service role insert/update (backend operations)
+CREATE POLICY venture_resources_service_all ON venture_resources
+  FOR ALL TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+COMMENT ON TABLE venture_resources IS 'Unified registry of external resources per venture (SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-B)';

--- a/tests/unit/venture-resources.test.js
+++ b/tests/unit/venture-resources.test.js
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for lib/venture-resources.js
+ * SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-B
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock supabase client
+const mockSelect = vi.fn();
+const mockSingle = vi.fn();
+const mockEq = vi.fn();
+const mockUpdate = vi.fn();
+const mockUpsert = vi.fn();
+const mockOrder = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock('../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: () => ({
+    from: mockFrom,
+  }),
+}));
+
+// Wire up fluent chain
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default chain: from().upsert().select().single()
+  mockSingle.mockResolvedValue({ data: { id: 'test-id', status: 'active' }, error: null });
+  mockSelect.mockReturnValue({ single: mockSingle });
+  mockUpsert.mockReturnValue({ select: mockSelect });
+
+  // For update chain: from().update().eq().eq().select()
+  mockEq.mockReturnValue({ eq: mockEq, select: mockSelect });
+  mockUpdate.mockReturnValue({ eq: mockEq });
+
+  // For query chain: from().select().eq().order()
+  mockOrder.mockResolvedValue({ data: [], error: null });
+  mockEq.mockReturnValue({ eq: mockEq, select: mockSelect, order: mockOrder });
+
+  mockFrom.mockReturnValue({
+    upsert: mockUpsert,
+    update: mockUpdate,
+    select: (...args) => {
+      mockSelect(...args);
+      return { eq: mockEq, order: mockOrder, single: mockSingle };
+    },
+  });
+});
+
+describe('registerVentureResource', () => {
+  it('should upsert a resource with correct parameters', async () => {
+    const { registerVentureResource } = await import('../../lib/venture-resources.js');
+
+    const result = await registerVentureResource(
+      'venture-123', 'github_repo', 'rickfelix/test', 'github', { url: 'https://github.com/rickfelix/test' }
+    );
+
+    expect(mockFrom).toHaveBeenCalledWith('venture_resources');
+    expect(mockUpsert).toHaveBeenCalledWith(
+      {
+        venture_id: 'venture-123',
+        resource_type: 'github_repo',
+        resource_identifier: 'rickfelix/test',
+        provider: 'github',
+        status: 'active',
+        metadata: { url: 'https://github.com/rickfelix/test' },
+      },
+      { onConflict: 'venture_id,resource_type,resource_identifier' }
+    );
+    expect(result).toEqual({ id: 'test-id', status: 'active' });
+  });
+
+  it('should return null on error', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'FK violation' } });
+    const { registerVentureResource } = await import('../../lib/venture-resources.js');
+
+    const result = await registerVentureResource('bad-id', 'github_repo', 'test', 'github');
+    expect(result).toBeNull();
+  });
+
+  it('should default metadata to empty object', async () => {
+    const { registerVentureResource } = await import('../../lib/venture-resources.js');
+
+    await registerVentureResource('v-1', 'local_directory', '/tmp/test', 'local');
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: {} }),
+      expect.any(Object)
+    );
+  });
+});
+
+describe('markResourcesCleaned', () => {
+  it('should update active resources to cleaned', async () => {
+    mockSelect.mockResolvedValue({ data: [{ id: '1' }, { id: '2' }], error: null });
+    const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
+
+    const count = await markResourcesCleaned('venture-123');
+
+    expect(mockFrom).toHaveBeenCalledWith('venture_resources');
+    expect(mockUpdate).toHaveBeenCalledWith({ status: 'cleaned' });
+    expect(count).toBe(2);
+  });
+
+  it('should return 0 when no resources exist', async () => {
+    mockSelect.mockResolvedValue({ data: [], error: null });
+    const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
+
+    const count = await markResourcesCleaned('empty-venture');
+    expect(count).toBe(0);
+  });
+
+  it('should return 0 on error', async () => {
+    mockSelect.mockResolvedValue({ data: null, error: { message: 'connection error' } });
+    const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
+
+    const count = await markResourcesCleaned('venture-123');
+    expect(count).toBe(0);
+  });
+});
+
+describe('getVentureResources', () => {
+  it('should query resources by venture_id', async () => {
+    mockOrder.mockResolvedValue({ data: [{ id: '1', resource_type: 'github_repo' }], error: null });
+    const { getVentureResources } = await import('../../lib/venture-resources.js');
+
+    const resources = await getVentureResources('venture-123');
+    expect(mockFrom).toHaveBeenCalledWith('venture_resources');
+    expect(resources).toHaveLength(1);
+  });
+
+  it('should return empty array on error', async () => {
+    mockOrder.mockResolvedValue({ data: null, error: { message: 'oops' } });
+    const { getVentureResources } = await import('../../lib/venture-resources.js');
+
+    const resources = await getVentureResources('venture-123');
+    expect(resources).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Create `venture_resources` table with RLS, FK to ventures, CHECK constraints for resource types and status
- Implement `lib/venture-resources.js` with idempotent `registerVentureResource()`, `markResourcesCleaned()`, and `getVentureResources()` helpers
- Integrate resource registration into `venture-provisioner.js` (GitHub repo + local directory)
- Integrate cleanup into master reset route (`server/routes/ventures.js`)

## Test plan
- [x] 8 unit tests passing (register, idempotency, cleanup, error handling)
- [x] Migration executed successfully against Supabase
- [ ] Manual: verify provisioning creates resource entries
- [ ] Manual: verify master reset marks resources as cleaned

SD: SD-LEO-INFRA-UNIFIED-VENTURE-CREATION-001-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)