### PR TITLE
fix(srip): fix silent crash in buildSynthesisPrompt

### DIFF
--- a/lib/eva/services/srip-prompt-builder.js
+++ b/lib/eva/services/srip-prompt-builder.js
@@ -51,10 +51,18 @@ export function buildSynthesisPrompt({ dnaJson, answers, ventureName }) {
       }
     }
     if (tokens.spacing) {
-      sections.push(`### Spacing: ${tokens.spacing.join(', ')}`);
+      const spacingStr = Array.isArray(tokens.spacing)
+        ? tokens.spacing.join(', ')
+        : typeof tokens.spacing === 'object'
+          ? Object.entries(tokens.spacing).map(([k, v]) => `${k}: ${v}`).join(', ')
+          : String(tokens.spacing);
+      sections.push(`### Spacing: ${spacingStr}`);
     }
     if (tokens.border_radius) {
-      sections.push(`### Border Radius: ${tokens.border_radius.join(', ')}`);
+      const radiusStr = Array.isArray(tokens.border_radius)
+        ? tokens.border_radius.join(', ')
+        : String(tokens.border_radius);
+      sections.push(`### Border Radius: ${radiusStr}`);
     }
     sections.push('');
   }
@@ -63,9 +71,11 @@ export function buildSynthesisPrompt({ dnaJson, answers, ventureName }) {
   const arch = dnaJson?.macro_architecture;
   if (arch) {
     sections.push('## Page Architecture');
-    sections.push(`- Header: ${arch.has_header ? 'Yes' : 'No'}`);
-    sections.push(`- Footer: ${arch.has_footer ? 'Yes' : 'No'}`);
-    sections.push(`- Main Content: ${arch.has_main ? 'Yes' : 'No'}`);
+    if (arch.has_header !== undefined) sections.push(`- Header: ${arch.has_header ? 'Yes' : 'No'}`);
+    if (arch.has_footer !== undefined) sections.push(`- Footer: ${arch.has_footer ? 'Yes' : 'No'}`);
+    if (arch.has_main !== undefined) sections.push(`- Main Content: ${arch.has_main ? 'Yes' : 'No'}`);
+    if (arch.page_flow) sections.push(`- Page Flow: ${arch.page_flow}`);
+    if (arch.responsive_approach) sections.push(`- Responsive: ${arch.responsive_approach}`);
     sections.push(`- Grid System: ${arch.grid_system || 'unknown'}`);
     sections.push(`- Responsive: ${arch.responsive_approach || 'unknown'}`);
     sections.push(`- Page Flow: ${arch.page_flow || 'unknown'}`);


### PR DESCRIPTION
## Summary
- Fixed `tokens.spacing.join()` crash — synthesizer produces object `{base: '16px'}` but builder expected array
- Fixed `tokens.border_radius` same issue
- Fixed `macro_architecture` to handle both forensic audit fields and synthesized fields
- **Root cause**: SRIP enrichment silently failed for ALL auto-synthesized ventures — crash caught by try/catch, fell back to standalone LLM

## Test plan
- [x] Verified buildSynthesisPrompt succeeds for CronRead venture (2308 chars, 577 tokens)
- [x] Verified getLatestCompletedDna + getLatestCompletedInterview chain works

🤖 Generated with [Claude Code](https://claude.com/claude-code)