### PR TITLE
feat(ventures): branding extraction + wireframe-scoped Replit prompts

### DIFF
--- a/lib/eva/bridge/replit-format-strategies.js
+++ b/lib/eva/bridge/replit-format-strategies.js
@@ -363,6 +363,58 @@ export function formatReplitMd(groups, venture, summary) {
     }
   }
 
+  // Branding — extract from identity_naming_visual (Stage 11)
+  const brandGroup = findGroup(groups, 'who_its_for');
+  if (brandGroup) {
+    const namingArtifact = brandGroup.artifacts.find(a =>
+      a.artifact_type === 'identity_naming_visual' || a.title?.toLowerCase().includes('naming')
+    );
+    if (namingArtifact?.content) {
+      const brandData = parseContent(namingArtifact.content) || {};
+      lines.push('## Branding');
+
+      // Product name
+      const selectedName = brandData.decision?.selectedName || brandData.decision?.name;
+      if (selectedName) {
+        lines.push(`- **Product Name**: ${selectedName}`);
+      } else if (brandData.candidates?.length) {
+        const top = brandData.candidates[0];
+        lines.push(`- **Product Name**: ${top.name || top}`);
+      }
+
+      // Color palette
+      const colors = brandData.visualIdentity?.colorPalette;
+      if (colors?.length) {
+        lines.push('- **Color Palette**:');
+        for (const color of colors.slice(0, 5)) {
+          lines.push(`  - \`${color.hex}\` ${color.name}: ${color.usage || ''}`);
+        }
+      }
+
+      // Typography
+      const typo = brandData.visualIdentity?.typography;
+      if (typo) {
+        lines.push('- **Typography**:');
+        if (Array.isArray(typo)) {
+          for (const t of typo.slice(0, 3)) {
+            lines.push(`  - ${t.name || t.role}: \`${t.font || t.fontFamily || t.family}\` — ${t.usage || ''}`);
+          }
+        } else if (typo.primary) {
+          lines.push(`  - Primary: \`${typo.primary}\``);
+        }
+      }
+
+      // Tagline / tone
+      if (brandData.brandExpression?.tagline) {
+        lines.push(`- **Tagline**: "${brandData.brandExpression.tagline}"`);
+      }
+      if (brandData.brandExpression?.toneKeywords?.length) {
+        lines.push(`- **Tone**: ${brandData.brandExpression.toneKeywords.join(', ')}`);
+      }
+      lines.push('');
+    }
+  }
+
   // Tech Stack
   lines.push('## Tech Stack');
   lines.push(`- **Framework**: ${framework}`);
@@ -398,6 +450,33 @@ export function formatReplitMd(groups, venture, summary) {
       lines.push('## Architecture');
       lines.push(summarizeContent(architecture, 2000));
       lines.push('');
+    }
+  }
+
+  // Wireframes — extract screen list from Stage 15
+  if (archGroup) {
+    const wireframeArtifact = archGroup.artifacts.find(a =>
+      a.artifact_type === 'blueprint_wireframes' || a.title?.toLowerCase().includes('wireframe')
+    );
+    if (wireframeArtifact?.content) {
+      const wfData = parseContent(wireframeArtifact.content) || {};
+      const screens = wfData.wireframes?.screens || wfData.screens || [];
+      if (screens.length > 0) {
+        lines.push('## Application Screens');
+        lines.push(`This app has ${screens.length} screens. Build ALL of them:`);
+        lines.push('');
+        for (const screen of screens) {
+          lines.push(`### ${screen.name || 'Screen'}`);
+          if (screen.purpose) lines.push(`Purpose: ${screen.purpose}`);
+          if (screen.persona) lines.push(`Primary user: ${screen.persona}`);
+          if (screen.ascii_layout) {
+            lines.push('```');
+            lines.push(screen.ascii_layout.slice(0, 500));
+            lines.push('```');
+          }
+          lines.push('');
+        }
+      }
     }
   }
 
@@ -564,6 +643,84 @@ export function formatFeaturePrompts(groups, venture, summary) {
     lines.push('- Refer to replit.md for project context, tech stack, and coding standards');
     lines.push('- Implement this feature completely before moving to the next');
     lines.push('- Test the feature works end-to-end before proceeding');
+    lines.push('- Checkpoint after completion');
+
+    const content = lines.join('\n');
+    return { filename, content, charCount: content.length };
+  });
+}
+
+// ── Format 3b: Wireframe-Based Feature Prompts ────────
+
+/**
+ * Extract wireframe screens from the how_to_build_it group.
+ */
+function extractWireframeScreens(groups) {
+  const archGroup = findGroup(groups, 'how_to_build_it');
+  if (!archGroup?.artifacts?.length) return [];
+
+  const wfArtifact = archGroup.artifacts.find(a =>
+    a.artifact_type === 'blueprint_wireframes' || a.title?.toLowerCase().includes('wireframe')
+  );
+  if (!wfArtifact?.content) return [];
+
+  const content = parseContent(wfArtifact.content) || {};
+  return content.wireframes?.screens || content.screens || [];
+}
+
+/**
+ * Generate one prompt per wireframe screen (full scope, not just sprint MVP).
+ *
+ * @param {Array} groups - RPC groups array
+ * @param {object} venture - { name, description }
+ * @param {object} summary - RPC summary
+ * @returns {Array<{filename: string, content: string, charCount: number}>}
+ */
+export function formatWireframePrompts(groups, venture, summary) {
+  const screens = extractWireframeScreens(groups);
+  if (screens.length === 0) return [];
+
+  return screens.map((screen, index) => {
+    const num = String(index + 1).padStart(2, '0');
+    const name = screen.name || `Screen ${index + 1}`;
+    const filename = `${num}-${slugify(name)}.md`;
+    const lines = [];
+
+    lines.push(`# Screen: ${name}`);
+    lines.push('');
+    if (screen.purpose) {
+      lines.push(`**Purpose**: ${screen.purpose}`);
+      lines.push('');
+    }
+    if (screen.persona) {
+      lines.push(`**Primary User**: ${screen.persona}`);
+      lines.push('');
+    }
+
+    // ASCII wireframe layout
+    if (screen.ascii_layout) {
+      lines.push('**Layout Reference:**');
+      lines.push('```');
+      lines.push(screen.ascii_layout);
+      lines.push('```');
+      lines.push('');
+    }
+
+    // Build order
+    if (screens.length > 1) {
+      lines.push(`> Screen ${index + 1} of ${screens.length}.`);
+      if (index > 0) {
+        lines.push(`> Build after: ${screens[index - 1].name || `Screen ${index}`}`);
+      }
+      lines.push('');
+    }
+
+    lines.push('**Instructions:**');
+    lines.push('- Refer to replit.md for branding (colors, typography, product name)');
+    lines.push('- Match the wireframe layout as closely as possible');
+    lines.push('- Implement all interactive elements shown in the wireframe');
+    lines.push('- Ensure responsive design (mobile-first)');
+    lines.push('- Test the screen works end-to-end before proceeding');
     lines.push('- Checkpoint after completion');
 
     const content = lines.join('\n');

--- a/lib/eva/bridge/replit-prompt-formatter.js
+++ b/lib/eva/bridge/replit-prompt-formatter.js
@@ -217,7 +217,8 @@ export async function formatReplitPrompt(ventureId, options = {}) {
  * @returns {Promise<{replitMd, planModePrompt, featurePrompts, warnings, manifest}>}
  */
 export async function formatReplitOptimized(ventureId, options = {}) {
-  const { formatReplitMd, formatPlanModePrompt, formatFeaturePrompts } =
+  const { scope = 'sprint' } = options; // 'sprint' (MVP) or 'wireframes' (full scope)
+  const { formatReplitMd, formatPlanModePrompt, formatFeaturePrompts, formatWireframePrompts } =
     await import('./replit-format-strategies.js');
 
   const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -234,7 +235,18 @@ export async function formatReplitOptimized(ventureId, options = {}) {
 
   const replitMdContent = formatReplitMd(data.groups, ventureMeta, summary);
   const planContent = formatPlanModePrompt(data.groups, ventureMeta, summary);
-  const features = formatFeaturePrompts(data.groups, ventureMeta, summary);
+
+  // Feature prompts: sprint-scoped (MVP) or wireframe-scoped (full app)
+  let features;
+  if (scope === 'wireframes') {
+    features = formatWireframePrompts(data.groups, ventureMeta, summary);
+    if (features.length === 0) {
+      warnings.push('No wireframe screens found — falling back to sprint items');
+      features = formatFeaturePrompts(data.groups, ventureMeta, summary);
+    }
+  } else {
+    features = formatFeaturePrompts(data.groups, ventureMeta, summary);
+  }
 
   if (replitMdContent.length > 15000) {
     warnings.push(`replit.md is ${replitMdContent.length} chars (>15000 target)`);

--- a/scripts/replit/export-prompt.mjs
+++ b/scripts/replit/export-prompt.mjs
@@ -71,6 +71,7 @@ Flags:
   const formatFlag = args.find(a => a.startsWith('--format='))?.split('=')[1] || 'monolithic';
   const outputDirFlag = args.find(a => a.startsWith('--output-dir='))?.split('=')[1]
     || args[args.indexOf('--output-dir') + 1];
+  const scope = args.find(a => a.startsWith('--scope='))?.split('=')[1] || 'sprint';
   const ventureNameIdx = args.indexOf('--venture-name');
   let input;
 
@@ -104,7 +105,7 @@ Flags:
   }
 
   // All other formats use the optimized formatter
-  const result = await formatReplitOptimized(ventureId);
+  const result = await formatReplitOptimized(ventureId, { scope });
 
   if (formatFlag === 'replit-md-only') {
     console.log(result.replitMd.content);


### PR DESCRIPTION
## Summary
- **Branding in replit.md**: Extracts product name, color palette (hex codes + usage), typography, tagline, tone from Stage 11 naming/visual identity
- **Wireframe-scoped prompts**: `--scope=wireframes` generates 1 prompt per wireframe screen (full app scope) vs sprint items (MVP only)
- **Application Screens section**: replit.md lists all wireframe screens with ASCII layouts

CronRead test: 7 screens (full) vs 4 items (sprint), branding includes Terminal Slate #0F172A + Syntax Emerald #10B981

## Test plan
- [x] CronRead export produces branding section with colors + tagline
- [x] `--scope=wireframes` generates 7 prompts (all wireframe screens)
- [x] Falls back to sprint items when no wireframes exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)