### PR TITLE
feat(ventures): Replit repo seeder — seed GitHub with curated reference docs

### DIFF
--- a/lib/eva/bridge/replit-repo-seeder.js
+++ b/lib/eva/bridge/replit-repo-seeder.js
@@ -21,9 +21,7 @@ dotenv.config();
 
 import {
   formatArtifactContent,
-  extractArchitectureSection,
   normalizeGroupKey,
-  summarizeContent,
 } from './replit-format-strategies.js';
 
 /**


### PR DESCRIPTION
## Summary
Seeds a venture's GitHub repo with a `docs/` folder containing curated reference documents extracted from the 31 pipeline artifacts. Replit reads these files directly — build prompts reference them instead of inlining content.

**Seeded documents (7 must-have + 4 optional artifacts):**
- `docs/branding.md` — S10 personas, S11 product name, colors, typography, tagline
- `docs/architecture.md` — S14 tech stack, data model, API contract, schema
- `docs/wireframes.md` — S15 all screen layouts with ASCII mockups
- `docs/context.md` — S1 problem/value prop, S4 competitive landscape, S13 roadmap
- `docs/pricing.md` — S7 pricing model (optional)
- `replit.md` — Lightweight summary referencing docs/

**CLI:**
- `seed <venture-id> <repo-url>` — Clone repo, commit docs/, push
- `prompts <venture-id>` — Generate build prompts referencing docs/
- `initial <venture-name>` — Generate blank-slate scaffold prompt

Tested with CronRead venture — all 5 docs + replit.md committed and pushed to GitHub.

## Test plan
- [x] `initial "CronRead"` generates blank-slate prompt
- [x] `seed` commits 5 docs + replit.md to CronRead GitHub repo
- [x] `prompts` generates 7 screen-based build prompts referencing docs/

🤖 Generated with [Claude Code](https://claude.com/claude-code)