### PR TITLE
fix(ventures): use valid artifact_type values in re-entry adapter

### DIFF
--- a/lib/eva/bridge/replit-reentry-adapter.js
+++ b/lib/eva/bridge/replit-reentry-adapter.js
@@ -79,7 +79,7 @@ export async function importReplitBuild(ventureId, syncData, options = {}) {
     await writeArtifact(supabase, {
       ventureId,
       lifecycleStage: 20,
-      artifactType: 'build_execution_report',
+      artifactType: 'build_mvp_build',
       title: 'Build Execution (Replit Agent)',
       artifactData: stage20Data.advisory_data,
       content: stage20Data.advisory_data,
@@ -177,7 +177,7 @@ export async function populateVerificationArtifacts(ventureId, verificationResul
     await writeArtifact(supabase, {
       ventureId,
       lifecycleStage: 21,
-      artifactType: 'build_qa_assessment',
+      artifactType: 'build_test_coverage_report',
       title: 'QA Assessment (Replit Verification)',
       artifactData: qaData,
       content: qaData,
@@ -199,7 +199,7 @@ export async function populateVerificationArtifacts(ventureId, verificationResul
     await writeArtifact(supabase, {
       ventureId,
       lifecycleStage: 22,
-      artifactType: 'build_review_assessment',
+      artifactType: 'build_security_audit',
       title: 'Build Review (Replit Verification)',
       artifactData: secData,
       content: secData,


### PR DESCRIPTION
Uses build_mvp_build (S20), build_test_coverage_report (S21), build_security_audit (S22) instead of non-existent types that violated the CHECK constraint.