### PR TITLE
fix(contracts): add stage 22 to CROSS_STAGE_DEPS[24]

### DIFF
--- a/lib/eva/contracts/stage-contracts.js
+++ b/lib/eva/contracts/stage-contracts.js
@@ -577,7 +577,7 @@ export const CROSS_STAGE_DEPS = {
   23: [1, 18, 19, 20, 21, 22], // Release readiness: idea + full build loop stages
 
   // Phase 6: LAUNCH & LEARN (Stages 24-26)
-  24: [1, 23],               // Marketing preparation: idea + release readiness
+  24: [1, 22, 23],            // Marketing preparation: idea + build review + release readiness
   25: [23, 24],              // Launch readiness (chairman gate): release + marketing
   26: [23, 24, 25],          // Launch execution (pipeline terminus): release + marketing + chairman approval
 };


### PR DESCRIPTION
Stage 24 contract consumes stage-22.promotion_gate but the dependency fetch array was [1, 23], missing stage 22. Found via RCA on CronRead venture stuck at S24.