### PR TITLE
feat(SD-001-B/C/D/E): panel selector, outcome tracker, engine refactor, lineage migration

### DIFF
--- a/lib/brainstorm/deliberation-engine.js
+++ b/lib/brainstorm/deliberation-engine.js
@@ -2,14 +2,17 @@
  * Board Deliberation Engine
  *
  * Orchestrates the two-round board deliberation model:
- * - Round 1: All 6 seats in parallel produce initial positions
+ * - Round 1: Dynamic panel selected by topic relevance
  * - Specialist summoning: Auto-detect and fill expertise gaps
  * - Round 2: Rebuttals informed by Round 1 and specialist testimony
  * - Judiciary synthesis with constitutional citations
  *
- * Quorum enforcement: Minimum seats must participate (default: 4/6).
+ * Panel composition: Dynamic via selectPanel() — replaces hardcoded BOARD_SEATS.
+ * Quorum enforcement: Percentage-based (67% of panel size).
+ *
+ * SD: SD-LEO-INFRA-INTELLIGENT-DYNAMIC-BOARD-001-D (refactor)
  */
-import { BOARD_SEATS } from './board-seats/index.js';
+import { selectPanel } from './panel-selector.js';
 import { loadSeatMemory } from './institutional-memory.js';
 import { parseExpertiseGaps, findSpecialist, findRelevantSpecialists, generateSpecialistIdentity, registerSpecialist } from './specialist-registry.js';
 import {
@@ -20,7 +23,7 @@ import {
   updateDebateRound
 } from './board-judiciary-bridge.js';
 
-const DEFAULT_QUORUM = 4;
+const QUORUM_PERCENTAGE = 0.67; // 67% of panel size
 const DELIBERATION_TIMEOUT_MS = 180_000; // 3 minutes
 
 /**
@@ -40,8 +43,9 @@ export async function executeDeliberation({
   brainstormSessionId,
   keywords = [],
   invokeAgent,
-  quorum = DEFAULT_QUORUM,
-  topicContext = {}
+  quorum,
+  topicContext = {},
+  panelOverride
 }) {
   const startTime = Date.now();
   const result = {
@@ -52,21 +56,27 @@ export async function executeDeliberation({
     verdict: null,
     quorumMet: false,
     totalTimeMs: 0,
-    seatTimings: {}
+    seatTimings: {},
+    panelSize: 0
   };
 
   // 1. Create debate session
   result.debateSessionId = await createBoardDebateSession(brainstormSessionId, topic);
 
-  // 2. Load institutional memory for each seat (parallel)
-  const memoryPromises = BOARD_SEATS.map(async seat => {
+  // 2. Select panel — dynamic composition replaces hardcoded BOARD_SEATS
+  const panel = panelOverride || await selectPanel(topic, keywords);
+  result.panelSize = panel.length;
+  const effectiveQuorum = quorum || Math.ceil(panel.length * QUORUM_PERCENTAGE);
+
+  // 3. Load institutional memory for each panel member (parallel)
+  const memoryPromises = panel.map(async seat => {
     const memory = await loadSeatMemory(seat.code, topic, keywords);
     return { code: seat.code, memory };
   });
   const memories = await Promise.all(memoryPromises);
   const memoryMap = Object.fromEntries(memories.map(m => [m.code, m.memory]));
 
-  // 2.5. Pre-seed: query DB for specialists relevant to this topic
+  // 3.5. Pre-seed: query DB for specialists relevant to this topic
   const preSeeded = await findRelevantSpecialists(topic, keywords);
   let preSeededRoster = '';
   if (preSeeded.length > 0) {
@@ -77,8 +87,8 @@ export async function executeDeliberation({
   }
   result.preSeededSpecialists = preSeeded;
 
-  // 3. Round 1: All seats in parallel
-  const round1Promises = BOARD_SEATS.map(async seat => {
+  // 4. Round 1: All panel members in parallel
+  const round1Promises = panel.map(async seat => {
     const seatStart = Date.now();
     const prompt = seat.systemPrompt({
       memoryContext: memoryMap[seat.code] || '',
@@ -102,9 +112,9 @@ export async function executeDeliberation({
 
   result.round1Positions = await Promise.all(round1Promises);
 
-  // 4. Quorum check
+  // 5. Quorum check (percentage-based for variable panel size)
   const activeSeatCount = result.round1Positions.filter(p => p.position && p.position.length > 50).length;
-  result.quorumMet = activeSeatCount >= quorum;
+  result.quorumMet = activeSeatCount >= effectiveQuorum;
 
   if (!result.quorumMet) {
     const unavailable = result.round1Positions
@@ -113,7 +123,7 @@ export async function executeDeliberation({
 
     result.error = {
       type: 'QUORUM_NOT_MET',
-      message: `Quorum not met: ${activeSeatCount}/${BOARD_SEATS.length} seats responded (minimum: ${quorum})`,
+      message: `Quorum not met: ${activeSeatCount}/${panel.length} seats responded (minimum: ${effectiveQuorum})`,
       unavailableSeats: unavailable
     };
     result.totalTimeMs = Date.now() - startTime;
@@ -137,22 +147,23 @@ export async function executeDeliberation({
     round1Ids[pos.seatCode] = argId;
   }
 
-  // 6. Specialist summoning
+  // 7. Specialist summoning
   const allOutputs = result.round1Positions.map(p => p.position);
   const expertiseGaps = parseExpertiseGaps(allOutputs);
 
   if (expertiseGaps.length > 0) {
     for (const gap of expertiseGaps.slice(0, 3)) { // Max 3 specialists
-      let specialist = await findSpecialist(gap);
+      const searchKey = gap.description || gap.raw || gap;
+      let specialist = await findSpecialist(searchKey);
 
       if (!specialist) {
-        specialist = generateSpecialistIdentity(gap, topic);
+        specialist = generateSpecialistIdentity(searchKey, topic);
         await registerSpecialist(specialist);
       }
 
       const testimony = await invokeAgent(
         specialist.identity,
-        `The Board of Directors is deliberating on: "${topic}"\n\nThey identified an expertise gap in: ${gap}\n\nProvide your expert testimony. Be specific, actionable, and grounded in domain knowledge.`
+        `The Board of Directors is deliberating on: "${topic}"\n\nThey identified an expertise gap in: ${searchKey}\n\nProvide your expert testimony. Be specific, actionable, and grounded in domain knowledge.`
       );
 
       const testimonyId = await recordBoardArgument({
@@ -165,8 +176,10 @@ export async function executeDeliberation({
         confidenceScore: 0.85
       });
 
+      const categoryLabel = gap.category ? ` [${gap.category}]` : '';
       result.specialistTestimony.push({
-        gap,
+        gap: searchKey,
+        category: gap.category || null,
         agentCode: specialist.agentCode,
         testimony,
         argumentId: testimonyId
@@ -174,12 +187,12 @@ export async function executeDeliberation({
     }
   }
 
-  // 7. Round 2: Rebuttals with cross-seat awareness
+  // 8. Round 2: Rebuttals with cross-seat awareness
   const specialistContext = result.specialistTestimony
     .map(s => `[Specialist: ${s.agentCode}] ${s.testimony}`)
     .join('\n\n');
 
-  const round2Promises = BOARD_SEATS.map(async seat => {
+  const round2Promises = panel.map(async seat => {
     const seatStart = Date.now();
     const othersExceptSelf = result.round1Positions
       .filter(p => p.seatCode !== seat.code)
@@ -268,7 +281,7 @@ export async function synthesizeVerdict(deliberationResult, invokeAgent) {
 Your role: Synthesize the board's deliberation into a clear verdict that respects constitutional principles.
 
 You MUST:
-1. Identify consensus points across all 6 seats
+1. Identify consensus points across all seats
 2. Identify tension points where seats disagree
 3. Cite specific constitutional rules (PROTOCOL CONST-001 through CONST-010, FOUR_OATHS, DOCTRINE) where relevant, with a relevance score (0-100) for each citation
 4. Determine if the positions are reconcilable or require chairman escalation
@@ -326,4 +339,4 @@ Produce your judiciary verdict. Include:
 }
 
 // Re-export for convenience
-export { DEFAULT_QUORUM, DELIBERATION_TIMEOUT_MS };
+export { QUORUM_PERCENTAGE, DELIBERATION_TIMEOUT_MS };

--- a/lib/brainstorm/institutional-memory.js
+++ b/lib/brainstorm/institutional-memory.js
@@ -42,6 +42,8 @@ export async function loadSeatMemory(seatCode, topic, keywords = []) {
   }
 
   // 1. Fetch past positions from debate_arguments for this seat
+  //    SD-LEO-INFRA-INTELLIGENT-DYNAMIC-BOARD-001-E: Query by agent_code OR legacy_agent_code
+  //    for backward compatibility with the unified identity pool migration.
   const { data: pastPositions, error: posErr } = await supabase
     .from('debate_arguments')
     .select('id, debate_session_id, round_number, summary, detailed_reasoning, confidence_score, created_at')
@@ -49,7 +51,32 @@ export async function loadSeatMemory(seatCode, topic, keywords = []) {
     .order('created_at', { ascending: false })
     .limit(20);
 
+  // If no positions found by agent_code, try legacy_agent_code fallback
+  let positions = pastPositions;
   if (posErr || !pastPositions?.length) {
+    // Check if this code has a legacy mapping in specialist_registry
+    const { data: legacyMatch } = await supabase
+      .from('specialist_registry')
+      .select('legacy_agent_code, name')
+      .or(`legacy_agent_code.eq.${seatCode},name.eq.${seatCode}`)
+      .limit(1);
+
+    if (legacyMatch?.length) {
+      // Try querying with both the name and legacy code
+      const altCode = legacyMatch[0].legacy_agent_code || legacyMatch[0].name;
+      if (altCode && altCode !== seatCode) {
+        const { data: altPositions } = await supabase
+          .from('debate_arguments')
+          .select('id, debate_session_id, round_number, summary, detailed_reasoning, confidence_score, created_at')
+          .eq('agent_code', altCode)
+          .order('created_at', { ascending: false })
+          .limit(20);
+        if (altPositions?.length) positions = altPositions;
+      }
+    }
+  }
+
+  if (!positions?.length) {
     return '';
   }
 
@@ -69,7 +96,7 @@ export async function loadSeatMemory(seatCode, topic, keywords = []) {
     .limit(20);
 
   // 4. Annotate each position with lifecycle status
-  const annotated = pastPositions.map(pos => {
+  const annotated = positions.map(pos => {
     const posText = (pos.summary || '') + ' ' + (pos.detailed_reasoning || '');
     const relevance = computeRelevance(posText, keywords);
 

--- a/lib/brainstorm/outcome-tracker.js
+++ b/lib/brainstorm/outcome-tracker.js
@@ -1,0 +1,200 @@
+/**
+ * Outcome Tracker — Authority Score Feedback Loop
+ * SD: SD-LEO-INFRA-INTELLIGENT-DYNAMIC-BOARD-001-C
+ *
+ * Traces SD completion back to brainstorm deliberations and updates
+ * identity authority scores based on position-to-outcome correlation.
+ *
+ * Authority deltas:
+ *   +2  Position aligned with successful SD outcome
+ *   -1  Position aligned with failed SD outcome
+ *   +3  Dissent bonus: contrarian position correlated with success
+ *
+ * Scores clamped to [10, 100] to prevent runaway accumulation or death spiral.
+ */
+
+import { createSupabaseServiceClient } from '../supabase-client.js';
+
+const AUTHORITY_FLOOR = 10;
+const AUTHORITY_CEILING = 100;
+const DELTA_SUCCESS = 2;
+const DELTA_FAILURE = -1;
+const DELTA_DISSENT_BONUS = 3;
+
+/**
+ * Track the outcome of a completed SD and update participating identity authority scores.
+ *
+ * @param {string} sdKey - The completed SD's key (e.g., SD-XXX-001)
+ * @param {'success' | 'failure'} outcome - Whether the SD succeeded or failed
+ * @returns {Promise<object[]>} Array of authority updates applied
+ */
+export async function trackOutcome(sdKey, outcome) {
+  const supabase = createSupabaseServiceClient();
+  const updates = [];
+
+  // 1. Find the brainstorm session that created this SD
+  const { data: sessions } = await supabase
+    .from('brainstorm_sessions')
+    .select('id')
+    .eq('created_sd_id', sdKey)
+    .limit(1);
+
+  if (!sessions?.length) {
+    // Try metadata match
+    const { data: metaSessions } = await supabase
+      .from('brainstorm_sessions')
+      .select('id, metadata')
+      .not('metadata', 'is', null)
+      .limit(50);
+
+    const match = metaSessions?.find(s =>
+      s.metadata?.created_sd_key === sdKey || s.metadata?.sd_key === sdKey
+    );
+    if (!match) return updates;
+    sessions.push(match);
+  }
+
+  const sessionId = sessions[0].id;
+
+  // 2. Find the debate session linked to this brainstorm
+  const { data: debates } = await supabase
+    .from('board_debate_sessions')
+    .select('id')
+    .eq('brainstorm_session_id', sessionId)
+    .limit(1);
+
+  if (!debates?.length) return updates;
+
+  const debateId = debates[0].id;
+
+  // 3. Get all Round 1 positions from the debate
+  const { data: arguments_ } = await supabase
+    .from('debate_arguments')
+    .select('id, agent_code, round_number, argument_type, summary, detailed_reasoning')
+    .eq('debate_session_id', debateId)
+    .eq('round_number', 1)
+    .eq('argument_type', 'initial_position');
+
+  if (!arguments_?.length) return updates;
+
+  // 4. Get the judiciary verdict to determine consensus vs dissent
+  const { data: verdicts } = await supabase
+    .from('judge_verdicts')
+    .select('detailed_rationale')
+    .eq('debate_session_id', debateId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const verdictText = verdicts?.[0]?.detailed_rationale || '';
+
+  // 5. For each participating identity, compute authority delta
+  for (const arg of arguments_) {
+    const agentCode = arg.agent_code;
+    const isDissent = detectDissent(arg, verdictText);
+
+    let delta;
+    if (outcome === 'success') {
+      delta = isDissent ? DELTA_DISSENT_BONUS : DELTA_SUCCESS;
+    } else {
+      delta = isDissent ? DELTA_SUCCESS : DELTA_FAILURE; // Dissent on failure = they were right
+    }
+
+    const reason = outcome === 'success'
+      ? (isDissent ? 'Dissent position validated by successful SD outcome' : 'Position aligned with successful SD outcome')
+      : (isDissent ? 'Dissent position validated — SD failed as they warned' : 'Position aligned with failed SD outcome');
+
+    const update = await updateAuthority(agentCode, delta, reason);
+    if (update) updates.push(update);
+  }
+
+  return updates;
+}
+
+/**
+ * Update an identity's authority score by a delta amount.
+ *
+ * @param {string} agentCode - The identity's agent code or name
+ * @param {number} delta - Score adjustment (+/-)
+ * @param {string} reason - Audit trail reason
+ * @returns {Promise<object|null>} Update result or null if identity not found
+ */
+export async function updateAuthority(agentCode, delta, reason) {
+  const supabase = createSupabaseServiceClient();
+
+  // Find the identity by name or legacy_agent_code
+  const { data: identities } = await supabase
+    .from('specialist_registry')
+    .select('name, role, authority_score, total_deliberations, outcome_wins, outcome_losses')
+    .or(`name.eq.${agentCode},legacy_agent_code.eq.${agentCode}`)
+    .limit(1);
+
+  if (!identities?.length) return null;
+
+  const identity = identities[0];
+  const oldScore = identity.authority_score || 50;
+  const newScore = Math.max(AUTHORITY_FLOOR, Math.min(AUTHORITY_CEILING, oldScore + delta));
+
+  const updateFields = {
+    authority_score: newScore,
+    total_deliberations: (identity.total_deliberations || 0) + 1,
+    last_selected_at: new Date().toISOString()
+  };
+
+  if (delta > 0) {
+    updateFields.outcome_wins = (identity.outcome_wins || 0) + 1;
+  } else if (delta < 0) {
+    updateFields.outcome_losses = (identity.outcome_losses || 0) + 1;
+  }
+
+  const { error } = await supabase
+    .from('specialist_registry')
+    .update(updateFields)
+    .eq('role', identity.role);
+
+  if (error) {
+    console.error(`[OutcomeTracker] Failed to update ${agentCode}:`, error.message);
+    return null;
+  }
+
+  return {
+    agentCode,
+    oldScore,
+    newScore,
+    delta,
+    reason,
+    role: identity.role
+  };
+}
+
+/**
+ * Detect whether a position was dissenting (contrarian to the majority).
+ * Simple heuristic: if the verdict mentions the agent's concerns as tension points,
+ * they were likely dissenting.
+ */
+function detectDissent(argument, verdictText) {
+  if (!verdictText || !argument.agent_code) return false;
+
+  const lower = verdictText.toLowerCase();
+  const agentLower = argument.agent_code.toLowerCase();
+
+  // Check if this agent is mentioned in tension/disagreement context
+  const tensionPatterns = [
+    `${agentLower} disagree`,
+    `${agentLower} raised concern`,
+    `${agentLower} dissent`,
+    `tension.*${agentLower}`,
+    `${agentLower}.*contrary`,
+    `${agentLower}.*caution`,
+    `${agentLower}.*warn`
+  ];
+
+  return tensionPatterns.some(pattern => {
+    try {
+      return new RegExp(pattern, 'i').test(lower);
+    } catch {
+      return lower.includes(pattern.replace('.*', ''));
+    }
+  });
+}
+
+export { AUTHORITY_FLOOR, AUTHORITY_CEILING, DELTA_SUCCESS, DELTA_FAILURE, DELTA_DISSENT_BONUS };

--- a/lib/brainstorm/panel-selector.js
+++ b/lib/brainstorm/panel-selector.js
@@ -1,0 +1,158 @@
+/**
+ * Panel Selection Engine
+ * SD: SD-LEO-INFRA-INTELLIGENT-DYNAMIC-BOARD-001-B
+ *
+ * Selects an optimal panel of identities from the specialist_registry
+ * for a given brainstorm topic. Replaces the hardcoded BOARD_SEATS array.
+ *
+ * Selection algorithm:
+ * 1. Query all identities from specialist_registry
+ * 2. Score each by topic relevance (keyword matching) * authority_score
+ * 3. Apply cold start bonus for new identities (<5 deliberations)
+ * 4. Guarantee governance floor identities are always included
+ * 5. Fill remaining seats by composite score descending
+ */
+
+import { createSupabaseServiceClient } from '../supabase-client.js';
+import { buildRubricPrompt } from './expertise-gap-rubric.js';
+
+const COLD_START_THRESHOLD = 5;
+const COLD_START_BONUS = 10;
+const STOP_WORDS = new Set([
+  'a', 'an', 'the', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'can', 'to', 'of', 'in', 'for', 'on', 'with',
+  'at', 'by', 'from', 'as', 'into', 'about', 'and', 'but', 'or', 'not',
+  'if', 'then', 'when', 'where', 'how', 'what', 'which', 'who', 'that',
+  'this', 'it', 'its', 'we', 'our', 'they', 'them', 'their', 'up', 'out',
+  'no', 'all', 'any', 'each', 'every', 'some', 'only', 'also', 'just',
+  'more', 'most', 'very'
+]);
+
+const RUBRIC = buildRubricPrompt();
+
+/**
+ * Select an optimal panel of identities for a brainstorm topic.
+ *
+ * @param {string} topic - The brainstorm topic
+ * @param {string[]} keywords - Additional topic keywords
+ * @param {object} opts
+ * @param {number} opts.maxSeats - Maximum panel size (default: 6)
+ * @param {number} opts.minGovernance - Minimum governance floor seats (default: 2)
+ * @returns {Promise<object[]>} Selected panel identities with system prompts
+ */
+export async function selectPanel(topic, keywords = [], { maxSeats = 6, minGovernance = 2 } = {}) {
+  const supabase = createSupabaseServiceClient();
+
+  // 1. Fetch all identities from the pool
+  const { data: identities, error } = await supabase
+    .from('specialist_registry')
+    .select('name, role, expertise, context, metadata, authority_score, is_governance_floor, legacy_agent_code, expertise_domains, total_deliberations');
+
+  if (error || !identities?.length) {
+    console.warn('[PanelSelector] No identities found:', error?.message);
+    return [];
+  }
+
+  // 2. Build search words from topic + keywords
+  const topicWords = extractWords(topic);
+  const kwWords = keywords.flatMap(k => extractWords(k));
+  const searchWords = [...new Set([...topicWords, ...kwWords])];
+
+  if (!searchWords.length) return identities.slice(0, maxSeats);
+
+  // 3. Score each identity
+  const scored = identities.map(identity => {
+    const domainWords = new Set([
+      ...extractWords(identity.expertise || ''),
+      ...(identity.expertise_domains || []).flatMap(d => extractWords(d))
+    ]);
+
+    // Topic relevance: fraction of search words found in identity domains
+    const matched = searchWords.filter(w => domainWords.has(w)).length;
+    const relevance = searchWords.length > 0 ? matched / searchWords.length : 0;
+
+    // Authority weight (normalized 0-1)
+    const authority = (identity.authority_score || 50) / 100;
+
+    // Cold start bonus for new identities
+    const coldStart = (identity.total_deliberations || 0) < COLD_START_THRESHOLD
+      ? COLD_START_BONUS / 100
+      : 0;
+
+    const compositeScore = (relevance * 0.6) + (authority * 0.3) + (coldStart * 0.1);
+
+    return {
+      ...identity,
+      relevance,
+      compositeScore,
+      isGovernanceFloor: identity.is_governance_floor || false
+    };
+  });
+
+  // 4. Separate governance floor identities
+  const floorIdentities = scored.filter(s => s.isGovernanceFloor);
+  const nonFloor = scored.filter(s => !s.isGovernanceFloor);
+
+  // 5. Sort non-floor by composite score
+  nonFloor.sort((a, b) => b.compositeScore - a.compositeScore);
+
+  // 6. Build panel: governance floor first, then top-scoring non-floor
+  const panel = [];
+
+  // Always include governance floor (up to minGovernance)
+  for (const identity of floorIdentities.slice(0, minGovernance)) {
+    panel.push(identity);
+  }
+
+  // Fill remaining seats with top-scoring non-floor identities
+  const remaining = maxSeats - panel.length;
+  for (const identity of nonFloor.slice(0, remaining)) {
+    panel.push(identity);
+  }
+
+  // 7. Build system prompts for each panel member
+  return panel.map(identity => ({
+    code: identity.legacy_agent_code || identity.name,
+    title: identity.name,
+    perspective: identity.expertise,
+    standingQuestion: extractStandingQuestion(identity),
+    relevanceScore: identity.relevance,
+    compositeScore: identity.compositeScore,
+    authorityScore: identity.authority_score,
+    isGovernanceFloor: identity.isGovernanceFloor,
+    systemPrompt: (seat) => `You are ${identity.name} on EHG's Board of Directors.
+
+Your domain: ${identity.expertise}
+
+${identity.context || ''}
+
+${seat.memoryContext || ''}
+${seat.specialistTestimony || ''}
+
+Produce a position that is specific to THIS topic. Reference concrete details from the topic, not generic advice.
+
+${RUBRIC}`
+  }));
+}
+
+function extractWords(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .split(/[\s-]+/)
+    .filter(w => w.length > 2 && !STOP_WORDS.has(w));
+}
+
+function extractStandingQuestion(identity) {
+  const role = (identity.role || '').toLowerCase();
+  const questions = {
+    cso: 'Does this move EHG forward or sideways?',
+    cro: "What's the blast radius if this fails?",
+    cto: "What do we already have? What's the real build cost?",
+    ciso: 'What attack surface does this create?',
+    coo: 'Can we actually deliver this given current load?',
+    cfo: "What does this cost and what's the return?"
+  };
+  return questions[role] || `What is your expert assessment of this from a ${identity.expertise} perspective?`;
+}


### PR DESCRIPTION
## Summary
- **Child B**: New `panel-selector.js` — `selectPanel()` queries specialist_registry by topic relevance weighted by authority_score, enforces governance floor (CRO/CISO always included), handles cold start bonus for new identities
- **Child C**: New `outcome-tracker.js` — `trackOutcome()` traces SD completion to debate_arguments, computes authority deltas (+2 success, -1 failure, +3 dissent bonus), clamps scores to 10-100 range
- **Child D**: Refactored `deliberation-engine.js` — replaced `BOARD_SEATS` import with `selectPanel()` call, quorum now percentage-based (67% of panel size), supports variable panel composition
- **Child E**: Updated `institutional-memory.js` — `loadSeatMemory()` now queries by agent_code with legacy_agent_code fallback via specialist_registry lineage mapping

Part of orchestrator SD-LEO-INFRA-INTELLIGENT-DYNAMIC-BOARD-001 (Intelligent Dynamic Board Seats).

## Test plan
- [x] Migration executed and verified (PR #2615)
- [x] panel-selector.js exports selectPanel() with governance floor enforcement
- [x] outcome-tracker.js exports trackOutcome() and updateAuthority() with delta clamping
- [x] deliberation-engine.js no longer imports BOARD_SEATS
- [x] institutional-memory.js has legacy_agent_code fallback queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)