### PR TITLE
feat(deliberation-bridge): wire brainstorm skill to programmatic engine

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -273,56 +273,49 @@ Present the score breakdown to the user.
 
 ### 6D.1a: Board of Directors Deliberation (Default — replaces 3-persona analysis)
 
-After discovery and crystallization, execute a full board deliberation using the Board of Directors governance model.
+After discovery and crystallization, execute a full board deliberation using the programmatic deliberation engine.
 
-The board deliberation system is implemented in `lib/brainstorm/deliberation-engine.js` and uses:
-- 6 permanent board seats (CSO, CRO, CTO, CISO, COO, CFO) defined in `lib/brainstorm/board-seats/index.js`
-- Institutional memory from past deliberations (`lib/brainstorm/institutional-memory.js`)
-- Specialist auto-summoning when expertise gaps detected (`lib/brainstorm/specialist-registry.js`)
-- Full judiciary integration with constitutional citations (`lib/brainstorm/board-judiciary-bridge.js`)
-
-**Execution Flow:**
-
-1. **Load institutional memory** for each seat (parallel) — past positions on related topics with lifecycle annotations
-2. **Round 1** — All 6 seats produce positions in parallel (via Agent tool, one per seat):
-   - Each seat uses its domain-specific system prompt with standing question
-   - Each seat has access to its institutional memory context
-   - Positions stored in `debate_arguments` with seat agent codes (CSO, CRO, etc.)
-   - Seats flag expertise gaps with `EXPERTISE_GAP: <description>` markers
-
-3. **Specialist Summoning** — If any seat flagged expertise gaps:
-   - Check specialist registry for reusable specialist identities
-   - Generate new specialist identities for unmatched gaps (max 3 specialists)
-   - Specialists produce testimony stored in `debate_arguments` with `specialist_testimony` type
-   - Register new specialists in the registry for future reuse
-
-4. **Quorum Check** — Verify minimum 4 of 6 seats responded with substantive positions
-   - If quorum not met, report which seats are unavailable and halt deliberation
-   - Chairman can override quorum with `--override-quorum` flag
-
-5. **Round 2** — All 6 seats produce rebuttals (parallel):
-   - Each seat receives all other Round 1 positions and specialist testimony
-   - Rebuttals must reference specific positions from other seats by code
-   - Stored in `debate_arguments` with `rebuttal` type and `in_response_to_argument_id`
-
-6. **Judiciary Synthesis** — Generate verdict with:
-   - Consensus points (where 2+ seats agree)
-   - Tension points (where seats disagree — most valuable insights)
-   - Constitutional citations with relevance scores (PROTOCOL, FOUR_OATHS, DOCTRINE)
-   - Escalation decision (if positions are irreconcilable → chairman override)
-   - Stored in `judge_verdicts` with full citation trail
-
-**Performance Budget**: Total deliberation (Round 1 + Specialists + Round 2 + Judiciary) must complete within 3 minutes.
-
-**Agent Invocation** — For each seat in Round 1 and Round 2, use the Agent tool:
-```
-Agent tool:
-  subagent_type: "general-purpose"
-  description: "[SEAT_CODE] board position"
-  prompt: [seat system prompt with memory context + user prompt with topic]
+**Invocation** — Run the deliberation engine CLI runner:
+```bash
+node scripts/brainstorm-deliberate.js --topic "<crystallized topic>" --keywords "<comma-separated keywords>"
 ```
 
-**Synthesis Output** (replaces the legacy Challenger/Visionary/Pragmatist synthesis):
+If a brainstorm session ID exists from earlier steps, pass it:
+```bash
+node scripts/brainstorm-deliberate.js --topic "<topic>" --keywords "<keywords>" --session-id "<brainstorm-session-id>"
+```
+
+To preview panel composition without running the full deliberation:
+```bash
+node scripts/brainstorm-deliberate.js --topic "<topic>" --keywords "<keywords>" --dry-run
+```
+
+The engine (`lib/brainstorm/deliberation-engine.js`) handles the complete flow automatically:
+- Dynamic panel selection from `specialist_registry` via `lib/brainstorm/panel-selector.js`
+- Expertise gap detection via rubric (`lib/brainstorm/expertise-gap-rubric.js`)
+- Institutional memory loading from past deliberations
+- Round 1 positions, specialist summoning, Round 2 rebuttals, judiciary verdict
+- All results persisted to `debate_arguments` and `judge_verdicts` tables
+- Specialists registered in `specialist_registry` for cross-session reuse
+
+**Execution Flow (handled by engine):**
+
+1. **Panel Selection** — Dynamic panel from `specialist_registry` (governance floor seats always included, domain specialists scored by topic relevance and authority)
+2. **Institutional Memory** — Past positions loaded for each seat (parallel)
+3. **Round 1** — All seats produce positions in parallel with expertise gap rubric
+4. **Specialist Summoning** — Gaps auto-detected, specialists reused or generated (max 3)
+5. **Quorum Check** — 67% of panel must respond with substantive positions
+6. **Round 2** — Rebuttals with cross-seat awareness and specialist testimony
+7. **Judiciary Synthesis** — Verdict with constitutional citations and escalation decision
+
+**Error Handling:**
+- **Timeout** (>3 minutes): Engine returns partial results, exit code 2
+- **Quorum failure** (<67% seats): Partial results printed, exit code 3 → fall back to Step 6D.1b
+- **LLM unavailable**: Engine uses echo stub, warns user to configure API keys
+
+**Performance Budget**: 3 minutes total (enforced by engine timeout).
+
+**Synthesis Output** (from engine stdout):
 - **Board Consensus**: Points where 3+ seats agree
 - **Key Tensions**: Where seats disagree (with constitutional citations if relevant)
 - **Specialist Insights**: Deep expertise from auto-summoned specialists

--- a/lib/brainstorm/expertise-gap-rubric.js
+++ b/lib/brainstorm/expertise-gap-rubric.js
@@ -1,0 +1,96 @@
+/**
+ * Expertise Gap Detection Rubric
+ *
+ * Structured criteria for board seats to consistently identify
+ * when specialist expertise is needed. Replaces ad-hoc LLM intuition
+ * with a concrete checklist scored against 5 gap categories.
+ */
+
+export const GAP_CATEGORIES = [
+  {
+    id: 'TOOLING',
+    name: 'Tooling Gap',
+    description: 'Topic references specific tools, APIs, libraries, or CLI commands that require implementation-level knowledge to evaluate',
+    examples: [
+      'Supabase migration rollback mechanics',
+      'AST parser selection for route detection',
+      'GitHub Actions matrix strategy configuration'
+    ]
+  },
+  {
+    id: 'DOMAIN',
+    name: 'Domain Knowledge Gap',
+    description: 'Topic touches an industry vertical, regulatory framework, or specialized discipline outside your C-suite role',
+    examples: [
+      'HIPAA compliance requirements for data handling',
+      'ML model selection and training pipeline design',
+      'Cryptographic protocol choices for token storage'
+    ]
+  },
+  {
+    id: 'PRECEDENT',
+    name: 'Precedent Gap',
+    description: 'Your position requires knowledge of how similar problems were solved in this codebase — specific patterns, tables, modules, or prior decisions you cannot reference with confidence',
+    examples: [
+      'How the existing gate system enforces EXEC checks',
+      'What pattern other skills use for DB verification',
+      'How the handoff system detects incomplete work'
+    ]
+  },
+  {
+    id: 'QUANTITATIVE',
+    name: 'Quantitative Gap',
+    description: 'Your position requires specific numbers — benchmarks, thresholds, costs, or performance targets — that you cannot provide with confidence',
+    examples: [
+      'Token cost per board deliberation session',
+      'Acceptable migration execution time threshold',
+      'Test coverage percentage that correlates with integration quality'
+    ]
+  },
+  {
+    id: 'CROSS_SYSTEM',
+    name: 'Cross-System Gap',
+    description: 'Topic involves interaction between two or more systems where the integration behavior is non-obvious and requires hands-on experience',
+    examples: [
+      'GitHub Actions triggering Supabase migrations on merge',
+      'Replit export format compatibility with LEO import pipeline',
+      'CI/CD webhook chains across multiple repositories'
+    ]
+  }
+];
+
+/**
+ * Build the rubric text to inject into each board seat's system prompt.
+ * The rubric is the same for all seats — each seat applies it from
+ * its own domain perspective.
+ */
+export function buildRubricPrompt() {
+  const categoryLines = GAP_CATEGORIES.map((cat, i) => {
+    const exampleList = cat.examples.map(e => `     - "${e}"`).join('\n');
+    return `${i + 1}. ${cat.name.toUpperCase()} — ${cat.description}
+   Examples:
+${exampleList}`;
+  }).join('\n\n');
+
+  return `
+EXPERTISE GAP DETECTION RUBRIC
+===============================
+Evaluate your position against each category below. Flag a gap when the
+missing knowledge would materially change your recommendation.
+
+${categoryLines}
+
+SCORING GUIDANCE:
+- If you CAN produce a substantive position without the missing knowledge
+  → note the gap but continue with your best assessment
+- If the gap would MATERIALLY change your recommendation
+  → FLAG as EXPERTISE_GAP (specialists will be summoned)
+- If MULTIPLE seats are likely to hit the same gap
+  → FLAG (one specialist serves all seats)
+
+FORMAT: EXPERTISE_GAP: [CATEGORY] — [specific knowledge needed]
+Example: EXPERTISE_GAP: TOOLING — Supabase CLI migration status API for detecting pending vs applied migrations
+Example: EXPERTISE_GAP: PRECEDENT — How the existing handoff.js validates integration completeness before phase transition
+Example: EXPERTISE_GAP: CROSS_SYSTEM — Interaction between PreToolUse hooks and skill invocation during EXEC gate checks
+`;
+}

--- a/scripts/brainstorm-deliberate.js
+++ b/scripts/brainstorm-deliberate.js
@@ -1,0 +1,226 @@
+#!/usr/bin/env node
+/**
+ * Brainstorm Deliberation CLI Runner
+ *
+ * Bridge between the /brainstorm skill command and the programmatic
+ * deliberation engine. Invokes executeDeliberation() with an Agent-tool
+ * wrapper, then synthesizes the judiciary verdict.
+ *
+ * Usage:
+ *   node scripts/brainstorm-deliberate.js --topic "Should we add OAuth2?"
+ *   node scripts/brainstorm-deliberate.js --topic "..." --keywords "auth,security"
+ *   node scripts/brainstorm-deliberate.js --topic "..." --session-id <brainstorm-session-id>
+ *
+ * SD: SD-MAN-INFRA-DELIBERATION-ENGINE-BRIDGE-001
+ */
+import 'dotenv/config';
+import { parseArgs } from 'node:util';
+import { executeDeliberation, synthesizeVerdict, DELIBERATION_TIMEOUT_MS } from '../lib/brainstorm/deliberation-engine.js';
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const { values: args } = parseArgs({
+  options: {
+    topic: { type: 'string' },
+    keywords: { type: 'string', default: '' },
+    'session-id': { type: 'string', default: '' },
+    'dry-run': { type: 'boolean', default: false },
+    help: { type: 'boolean', default: false }
+  },
+  strict: true
+});
+
+if (args.help || !args.topic) {
+  console.log(`
+Brainstorm Deliberation Runner
+
+Usage:
+  node scripts/brainstorm-deliberate.js --topic "Your topic here"
+
+Options:
+  --topic          The deliberation topic (required)
+  --keywords       Comma-separated keywords for panel selection
+  --session-id     Brainstorm session ID (auto-generated if omitted)
+  --dry-run        Show panel selection without running deliberation
+  --help           Show this help
+`);
+  process.exit(args.help ? 0 : 1);
+}
+
+const topic = args.topic;
+const keywords = args.keywords ? args.keywords.split(',').map(k => k.trim()).filter(Boolean) : [];
+const sessionId = args['session-id'] || `deliberation-${Date.now()}`;
+
+// ---------------------------------------------------------------------------
+// invokeAgent wrapper
+// ---------------------------------------------------------------------------
+// In CLI mode, we use a simple LLM call via the client factory.
+// In Claude Code mode, the brainstorm skill invokes Agent tool directly.
+// This wrapper provides a consistent interface for both paths.
+let invokeAgentFn;
+
+try {
+  const { createLLMClient } = await import('../lib/llm/client-factory.js');
+  const llm = createLLMClient();
+
+  invokeAgentFn = async (systemPrompt, userPrompt) => {
+    const response = await llm.chat({
+      messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: userPrompt }
+      ],
+      temperature: 0.7,
+      max_tokens: 2000
+    });
+    return response?.choices?.[0]?.message?.content || response?.content || '';
+  };
+} catch {
+  // Fallback: if no LLM client available, provide a stub that explains the gap
+  console.warn('[deliberate] LLM client not available — using echo stub');
+  console.warn('[deliberate] Set ANTHROPIC_API_KEY or USE_LOCAL_LLM=true for real LLM calls');
+  invokeAgentFn = async (systemPrompt, userPrompt) => {
+    return `[Stub response — LLM not configured]\nSystem: ${systemPrompt.slice(0, 200)}...\nUser: ${userPrompt.slice(0, 200)}...`;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main execution
+// ---------------------------------------------------------------------------
+async function main() {
+  console.log('');
+  console.log('Board Deliberation Engine');
+  console.log('========================');
+  console.log(`Topic:    ${topic}`);
+  console.log(`Keywords: ${keywords.length > 0 ? keywords.join(', ') : '(none)'}`);
+  console.log(`Session:  ${sessionId}`);
+  console.log(`Budget:   ${DELIBERATION_TIMEOUT_MS / 1000}s`);
+  console.log('');
+
+  if (args['dry-run']) {
+    const { selectPanel } = await import('../lib/brainstorm/panel-selector.js');
+    const panel = await selectPanel(topic, keywords);
+    console.log(`Panel (${panel.length} seats):`);
+    for (const seat of panel) {
+      const floor = seat.isGovernanceFloor ? ' [GOV]' : '';
+      console.log(`  ${seat.code.padEnd(8)} ${seat.title}${floor}  (relevance: ${(seat.relevanceScore * 100).toFixed(0)}%, authority: ${seat.authorityScore || 50})`);
+    }
+    process.exit(0);
+  }
+
+  // Timeout wrapper
+  const timeoutPromise = new Promise((_, reject) => {
+    setTimeout(() => reject(new Error('DELIBERATION_TIMEOUT')), DELIBERATION_TIMEOUT_MS);
+  });
+
+  let result;
+  try {
+    result = await Promise.race([
+      executeDeliberation({
+        topic,
+        brainstormSessionId: sessionId,
+        keywords,
+        invokeAgent: invokeAgentFn,
+        topicContext: { domain: keywords[0] || 'general' }
+      }),
+      timeoutPromise
+    ]);
+  } catch (err) {
+    if (err.message === 'DELIBERATION_TIMEOUT') {
+      console.error('');
+      console.error(`TIMEOUT: Deliberation exceeded ${DELIBERATION_TIMEOUT_MS / 1000}s budget`);
+      console.error('Partial results may be available in the database.');
+      console.error(`Session: ${sessionId}`);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  // Check quorum
+  if (!result.quorumMet) {
+    console.error('');
+    console.error('QUORUM NOT MET');
+    console.error(result.error?.message || 'Insufficient seats responded');
+    console.error('');
+    console.error('Available Round 1 positions:');
+    for (const pos of result.round1Positions) {
+      const hasContent = pos.position && pos.position.length > 50;
+      console.error(`  ${pos.seatCode}: ${hasContent ? 'responded' : 'NO RESPONSE'}`);
+    }
+    console.error('');
+    console.error('Falling back to partial results. Consider using --override-quorum or legacy 3-persona flow.');
+    // Still print whatever we have
+    printResults(result, null);
+    process.exit(3);
+  }
+
+  // Synthesize verdict
+  console.log('Synthesizing judiciary verdict...');
+  const verdict = await synthesizeVerdict(result, invokeAgentFn);
+  result.verdict = verdict;
+
+  printResults(result, verdict);
+
+  // Summary
+  console.log('');
+  console.log('Summary');
+  console.log('-------');
+  console.log(`Debate Session:  ${result.debateSessionId}`);
+  console.log(`Panel Size:      ${result.panelSize}`);
+  console.log(`Quorum Met:      ${result.quorumMet}`);
+  console.log(`Round 1:         ${result.round1Positions.length} positions`);
+  console.log(`Specialists:     ${result.specialistTestimony.length} summoned`);
+  console.log(`Round 2:         ${result.round2Rebuttals.length} rebuttals`);
+  console.log(`Escalation:      ${verdict.escalationRequired ? 'YES — chairman review needed' : 'No'}`);
+  console.log(`Total Time:      ${(result.totalTimeMs / 1000).toFixed(1)}s`);
+  console.log(`Verdict ID:      ${verdict.verdictId}`);
+}
+
+function printResults(result, verdict) {
+  // Round 1
+  console.log('');
+  console.log('ROUND 1 — Initial Positions');
+  console.log('---------------------------');
+  for (const pos of result.round1Positions) {
+    console.log(`\n[${pos.seatCode}] ${pos.seatTitle}`);
+    console.log(pos.position?.slice(0, 600) || '(no response)');
+    if (pos.position?.length > 600) console.log('...(truncated)');
+  }
+
+  // Specialist testimony
+  if (result.specialistTestimony.length > 0) {
+    console.log('');
+    console.log('SPECIALIST TESTIMONY');
+    console.log('--------------------');
+    for (const spec of result.specialistTestimony) {
+      console.log(`\n[${spec.agentCode}] Gap: ${spec.gap}`);
+      console.log(spec.testimony?.slice(0, 400) || '(no testimony)');
+      if (spec.testimony?.length > 400) console.log('...(truncated)');
+    }
+  }
+
+  // Round 2
+  if (result.round2Rebuttals.length > 0) {
+    console.log('');
+    console.log('ROUND 2 — Rebuttals');
+    console.log('--------------------');
+    for (const reb of result.round2Rebuttals) {
+      console.log(`\n[${reb.seatCode}] ${reb.seatTitle}`);
+      console.log(reb.rebuttal?.slice(0, 600) || '(no rebuttal)');
+      if (reb.rebuttal?.length > 600) console.log('...(truncated)');
+    }
+  }
+
+  // Verdict
+  if (verdict) {
+    console.log('');
+    console.log('JUDICIARY VERDICT');
+    console.log('=================');
+    console.log(verdict.verdictText || '(no verdict)');
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `lib/brainstorm/expertise-gap-rubric.js` — 5-category rubric (TOOLING, DOMAIN, PRECEDENT, QUANTITATIVE, CROSS_SYSTEM) for board seats to detect expertise gaps. Resolves missing import in `panel-selector.js`.
- Add `scripts/brainstorm-deliberate.js` — CLI entry point that invokes `executeDeliberation()` with LLM client wrapper. Supports `--topic`, `--keywords`, `--session-id`, `--dry-run`. Handles timeout (3min) and quorum failure with exit codes.
- Update `.claude/commands/brainstorm.md` Step 6D.1a to invoke CLI runner instead of manual Agent-tool orchestration, enabling specialist accumulation across sessions.

## Test plan
- [x] `node -e "import { buildRubricPrompt } from './lib/brainstorm/expertise-gap-rubric.js'; ..."` — exports resolve, 5 categories, 2707-char rubric
- [x] `node scripts/brainstorm-deliberate.js --help` — shows usage
- [x] `node scripts/brainstorm-deliberate.js --topic "test" --dry-run` — panel of 6 seats with governance floor markers
- [x] Brainstorm.md Step 6D.1a references CLI runner with `--topic` and `--keywords` args

SD: SD-MAN-INFRA-DELIBERATION-ENGINE-BRIDGE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)