### PR TITLE
fix(deliberation): align DB inserts with debate_sessions/judge_verdicts constraints

### DIFF
--- a/lib/brainstorm/board-judiciary-bridge.js
+++ b/lib/brainstorm/board-judiciary-bridge.js
@@ -21,7 +21,9 @@ export async function createBoardDebateSession(brainstormSessionId, topic) {
   const { data, error } = await supabase
     .from('debate_sessions')
     .insert({
-      conflict_type: 'board_deliberation',
+      conflict_type: 'approach',
+      current_phase: 'EXEC',
+      conflict_statement: `Board deliberation: ${topic}`,
       source_agents: ['CSO', 'CRO', 'CTO', 'CISO', 'COO', 'CFO'],
       status: 'active',
       round_number: 1,
@@ -133,7 +135,7 @@ export async function recordJudiciaryVerdict({
   summary,
   detailedRationale,
   constitutionCitations = [],
-  constitutionalScore = 80,
+  constitutionalScore = 0.80,
   confidenceScore = 0.8,
   escalationRequired = false
 }) {

--- a/lib/brainstorm/deliberation-engine.js
+++ b/lib/brainstorm/deliberation-engine.js
@@ -317,7 +317,7 @@ Produce your judiciary verdict. Include:
   const citationsWithScores = citations.map(c => ({
     source: c.startsWith('CONST-') ? 'PROTOCOL' : c,
     rule_number: c,
-    relevance_score: 80 // Default; LLM should provide specific scores
+    relevance_score: 0.80 // Default; LLM should provide specific scores
   }));
 
   const verdictId = await recordJudiciaryVerdict({
@@ -325,7 +325,7 @@ Produce your judiciary verdict. Include:
     summary: verdictText.slice(0, 500),
     detailedRationale: verdictText,
     constitutionCitations: citationsWithScores,
-    constitutionalScore: 80,
+    constitutionalScore: 0.80,
     confidenceScore: escalationRequired ? 0.5 : 0.8,
     escalationRequired
   });


### PR DESCRIPTION
## Summary
- Fix 4 database constraint violations found by end-to-end testing of the deliberation engine
- `debate_sessions`: missing `current_phase`, `conflict_statement`, invalid `conflict_type` enum
- `judge_verdicts`: `constitutional_score` numeric(3,2) overflow (80 vs 0.80)

## Root cause
SD-MAN-INFRA-DELIBERATION-ENGINE-BRIDGE-001 shipped without a real execution test. Infrastructure SDs skip all testing gates (`requires_e2e_tests: false`, `requires_sub_agents: false`). Corrective SD created: SD-LEO-INFRA-ENFORCE-EXECUTION-SMOKE-001.

## Test plan
- [x] `node scripts/brainstorm-deliberate.js --topic "test" --keywords "mobile"` completes end-to-end
- [x] All 6 seats produce positions, rebuttals, and verdict recorded in DB
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)