### PR TITLE
fix(deliberation): remove LLM dependency, fix argument_type constraint

### DIFF
--- a/lib/brainstorm/deliberation-engine.js
+++ b/lib/brainstorm/deliberation-engine.js
@@ -171,7 +171,7 @@ export async function executeDeliberation({
         debateSessionId: result.debateSessionId,
         agentCode: specialist.agentCode,
         roundNumber: 1,
-        argumentType: 'specialist_testimony',
+        argumentType: 'evidence',
         summary: testimony.slice(0, 500),
         detailedReasoning: testimony,
         confidenceScore: 0.85

--- a/scripts/brainstorm-deliberate.js
+++ b/scripts/brainstorm-deliberate.js
@@ -3,13 +3,28 @@
  * Brainstorm Deliberation CLI Runner
  *
  * Bridge between the /brainstorm skill command and the programmatic
- * deliberation engine. Invokes executeDeliberation() with an Agent-tool
- * wrapper, then synthesizes the judiciary verdict.
+ * deliberation engine. This script is invoked FROM Claude Code — the
+ * invokeAgent callback must be provided by the caller (the brainstorm
+ * command spec passes Claude's Agent tool as the callback).
  *
- * Usage:
- *   node scripts/brainstorm-deliberate.js --topic "Should we add OAuth2?"
- *   node scripts/brainstorm-deliberate.js --topic "..." --keywords "auth,security"
- *   node scripts/brainstorm-deliberate.js --topic "..." --session-id <brainstorm-session-id>
+ * This script handles:
+ * - CLI argument parsing (--topic, --keywords, --session-id, --dry-run)
+ * - Panel selection preview (--dry-run)
+ * - Orchestration: executeDeliberation() + synthesizeVerdict()
+ * - Timeout enforcement (3-minute budget)
+ * - Quorum failure detection
+ * - Result formatting and printing
+ *
+ * The invokeAgent function is NOT built into this script. It is injected
+ * by the brainstorm command which wraps Claude's Agent tool. For standalone
+ * testing, pass --dry-run to verify panel selection without LLM calls.
+ *
+ * Usage (from brainstorm command):
+ *   Called programmatically with invokeAgent injected
+ *
+ * Usage (standalone):
+ *   node scripts/brainstorm-deliberate.js --topic "..." --dry-run
+ *   node scripts/brainstorm-deliberate.js --topic "..." --keywords "auth,security" --dry-run
  *
  * SD: SD-MAN-INFRA-DELIBERATION-ENGINE-BRIDGE-001
  */
@@ -36,7 +51,7 @@ if (args.help || !args.topic) {
 Brainstorm Deliberation Runner
 
 Usage:
-  node scripts/brainstorm-deliberate.js --topic "Your topic here"
+  node scripts/brainstorm-deliberate.js --topic "Your topic here" --dry-run
 
 Options:
   --topic          The deliberation topic (required)
@@ -44,6 +59,10 @@ Options:
   --session-id     Brainstorm session ID (auto-generated if omitted)
   --dry-run        Show panel selection without running deliberation
   --help           Show this help
+
+Note: Full deliberation requires an invokeAgent callback (provided by
+the /brainstorm command via Claude's Agent tool). Use --dry-run for
+standalone panel selection testing.
 `);
   process.exit(args.help ? 0 : 1);
 }
@@ -51,38 +70,6 @@ Options:
 const topic = args.topic;
 const keywords = args.keywords ? args.keywords.split(',').map(k => k.trim()).filter(Boolean) : [];
 const sessionId = args['session-id'] || `deliberation-${Date.now()}`;
-
-// ---------------------------------------------------------------------------
-// invokeAgent wrapper
-// ---------------------------------------------------------------------------
-// In CLI mode, we use a simple LLM call via the client factory.
-// In Claude Code mode, the brainstorm skill invokes Agent tool directly.
-// This wrapper provides a consistent interface for both paths.
-let invokeAgentFn;
-
-try {
-  const { createLLMClient } = await import('../lib/llm/client-factory.js');
-  const llm = createLLMClient();
-
-  invokeAgentFn = async (systemPrompt, userPrompt) => {
-    const response = await llm.chat({
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userPrompt }
-      ],
-      temperature: 0.7,
-      max_tokens: 2000
-    });
-    return response?.choices?.[0]?.message?.content || response?.content || '';
-  };
-} catch {
-  // Fallback: if no LLM client available, provide a stub that explains the gap
-  console.warn('[deliberate] LLM client not available — using echo stub');
-  console.warn('[deliberate] Set ANTHROPIC_API_KEY or USE_LOCAL_LLM=true for real LLM calls');
-  invokeAgentFn = async (systemPrompt, userPrompt) => {
-    return `[Stub response — LLM not configured]\nSystem: ${systemPrompt.slice(0, 200)}...\nUser: ${userPrompt.slice(0, 200)}...`;
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Main execution
@@ -97,127 +84,135 @@ async function main() {
   console.log(`Budget:   ${DELIBERATION_TIMEOUT_MS / 1000}s`);
   console.log('');
 
+  // --dry-run: panel selection only (no LLM needed)
+  const { selectPanel } = await import('../lib/brainstorm/panel-selector.js');
+  const panel = await selectPanel(topic, keywords);
+  console.log(`Panel (${panel.length} seats):`);
+  for (const seat of panel) {
+    const floor = seat.isGovernanceFloor ? ' [GOV]' : '';
+    console.log(`  ${seat.code.padEnd(8)} ${seat.title}${floor}  (relevance: ${(seat.relevanceScore * 100).toFixed(0)}%, authority: ${seat.authorityScore || 50})`);
+  }
+
   if (args['dry-run']) {
-    const { selectPanel } = await import('../lib/brainstorm/panel-selector.js');
-    const panel = await selectPanel(topic, keywords);
-    console.log(`Panel (${panel.length} seats):`);
-    for (const seat of panel) {
-      const floor = seat.isGovernanceFloor ? ' [GOV]' : '';
-      console.log(`  ${seat.code.padEnd(8)} ${seat.title}${floor}  (relevance: ${(seat.relevanceScore * 100).toFixed(0)}%, authority: ${seat.authorityScore || 50})`);
-    }
+    console.log('');
+    console.log('Dry run complete. Panel selected but deliberation not executed.');
+    console.log('Full deliberation runs via /brainstorm command (Claude Agent tool provides invokeAgent).');
     process.exit(0);
   }
+
+  // Full deliberation requires invokeAgent — not available in standalone CLI
+  console.error('');
+  console.error('ERROR: Full deliberation requires an invokeAgent callback.');
+  console.error('');
+  console.error('The invokeAgent function is provided by the /brainstorm command,');
+  console.error('which wraps Claude\'s Agent tool to invoke board seats and specialists.');
+  console.error('');
+  console.error('To run a full deliberation:');
+  console.error('  1. Use /brainstorm in Claude Code (invokes this engine at Step 6D.1a)');
+  console.error('');
+  console.error('To test panel selection standalone:');
+  console.error('  node scripts/brainstorm-deliberate.js --topic "..." --dry-run');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Exported API for programmatic invocation from brainstorm command
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a full deliberation with an injected invokeAgent callback.
+ * Called by the /brainstorm command which provides Claude's Agent tool.
+ *
+ * @param {object} params
+ * @param {string} params.topic - Deliberation topic
+ * @param {string[]} params.keywords - Topic keywords
+ * @param {string} params.sessionId - Brainstorm session ID
+ * @param {Function} params.invokeAgent - (systemPrompt, userPrompt) => string
+ * @returns {Promise<object>} { result, verdict }
+ */
+export async function runDeliberation({ topic, keywords = [], sessionId, invokeAgent }) {
+  if (!invokeAgent) throw new Error('invokeAgent callback is required');
 
   // Timeout wrapper
   const timeoutPromise = new Promise((_, reject) => {
     setTimeout(() => reject(new Error('DELIBERATION_TIMEOUT')), DELIBERATION_TIMEOUT_MS);
   });
 
-  let result;
-  try {
-    result = await Promise.race([
-      executeDeliberation({
-        topic,
-        brainstormSessionId: sessionId,
-        keywords,
-        invokeAgent: invokeAgentFn,
-        topicContext: { domain: keywords[0] || 'general' }
-      }),
-      timeoutPromise
-    ]);
-  } catch (err) {
-    if (err.message === 'DELIBERATION_TIMEOUT') {
-      console.error('');
-      console.error(`TIMEOUT: Deliberation exceeded ${DELIBERATION_TIMEOUT_MS / 1000}s budget`);
-      console.error('Partial results may be available in the database.');
-      console.error(`Session: ${sessionId}`);
-      process.exit(2);
-    }
-    throw err;
+  const result = await Promise.race([
+    executeDeliberation({
+      topic,
+      brainstormSessionId: sessionId || `deliberation-${Date.now()}`,
+      keywords,
+      invokeAgent,
+      topicContext: { domain: keywords[0] || 'general' }
+    }),
+    timeoutPromise
+  ]);
+
+  let verdict = null;
+  if (result.quorumMet) {
+    verdict = await synthesizeVerdict(result, invokeAgent);
+    result.verdict = verdict;
   }
 
-  // Check quorum
-  if (!result.quorumMet) {
-    console.error('');
-    console.error('QUORUM NOT MET');
-    console.error(result.error?.message || 'Insufficient seats responded');
-    console.error('');
-    console.error('Available Round 1 positions:');
-    for (const pos of result.round1Positions) {
-      const hasContent = pos.position && pos.position.length > 50;
-      console.error(`  ${pos.seatCode}: ${hasContent ? 'responded' : 'NO RESPONSE'}`);
-    }
-    console.error('');
-    console.error('Falling back to partial results. Consider using --override-quorum or legacy 3-persona flow.');
-    // Still print whatever we have
-    printResults(result, null);
-    process.exit(3);
-  }
-
-  // Synthesize verdict
-  console.log('Synthesizing judiciary verdict...');
-  const verdict = await synthesizeVerdict(result, invokeAgentFn);
-  result.verdict = verdict;
-
-  printResults(result, verdict);
-
-  // Summary
-  console.log('');
-  console.log('Summary');
-  console.log('-------');
-  console.log(`Debate Session:  ${result.debateSessionId}`);
-  console.log(`Panel Size:      ${result.panelSize}`);
-  console.log(`Quorum Met:      ${result.quorumMet}`);
-  console.log(`Round 1:         ${result.round1Positions.length} positions`);
-  console.log(`Specialists:     ${result.specialistTestimony.length} summoned`);
-  console.log(`Round 2:         ${result.round2Rebuttals.length} rebuttals`);
-  console.log(`Escalation:      ${verdict.escalationRequired ? 'YES — chairman review needed' : 'No'}`);
-  console.log(`Total Time:      ${(result.totalTimeMs / 1000).toFixed(1)}s`);
-  console.log(`Verdict ID:      ${verdict.verdictId}`);
+  return { result, verdict };
 }
 
-function printResults(result, verdict) {
-  // Round 1
-  console.log('');
-  console.log('ROUND 1 — Initial Positions');
-  console.log('---------------------------');
+/**
+ * Format deliberation results as structured text for output.
+ */
+export function formatResults(result, verdict) {
+  const lines = [];
+
+  lines.push('ROUND 1 — Initial Positions');
+  lines.push('---------------------------');
   for (const pos of result.round1Positions) {
-    console.log(`\n[${pos.seatCode}] ${pos.seatTitle}`);
-    console.log(pos.position?.slice(0, 600) || '(no response)');
-    if (pos.position?.length > 600) console.log('...(truncated)');
+    lines.push(`\n[${pos.seatCode}] ${pos.seatTitle}`);
+    lines.push(pos.position?.slice(0, 600) || '(no response)');
+    if (pos.position?.length > 600) lines.push('...(truncated)');
   }
 
-  // Specialist testimony
-  if (result.specialistTestimony.length > 0) {
-    console.log('');
-    console.log('SPECIALIST TESTIMONY');
-    console.log('--------------------');
+  if (result.specialistTestimony?.length > 0) {
+    lines.push('\nSPECIALIST TESTIMONY');
+    lines.push('--------------------');
     for (const spec of result.specialistTestimony) {
-      console.log(`\n[${spec.agentCode}] Gap: ${spec.gap}`);
-      console.log(spec.testimony?.slice(0, 400) || '(no testimony)');
-      if (spec.testimony?.length > 400) console.log('...(truncated)');
+      lines.push(`\n[${spec.agentCode}] Gap: ${spec.gap}`);
+      lines.push(spec.testimony?.slice(0, 400) || '(no testimony)');
+      if (spec.testimony?.length > 400) lines.push('...(truncated)');
     }
   }
 
-  // Round 2
-  if (result.round2Rebuttals.length > 0) {
-    console.log('');
-    console.log('ROUND 2 — Rebuttals');
-    console.log('--------------------');
+  if (result.round2Rebuttals?.length > 0) {
+    lines.push('\nROUND 2 — Rebuttals');
+    lines.push('--------------------');
     for (const reb of result.round2Rebuttals) {
-      console.log(`\n[${reb.seatCode}] ${reb.seatTitle}`);
-      console.log(reb.rebuttal?.slice(0, 600) || '(no rebuttal)');
-      if (reb.rebuttal?.length > 600) console.log('...(truncated)');
+      lines.push(`\n[${reb.seatCode}] ${reb.seatTitle}`);
+      lines.push(reb.rebuttal?.slice(0, 600) || '(no rebuttal)');
+      if (reb.rebuttal?.length > 600) lines.push('...(truncated)');
     }
   }
 
-  // Verdict
   if (verdict) {
-    console.log('');
-    console.log('JUDICIARY VERDICT');
-    console.log('=================');
-    console.log(verdict.verdictText || '(no verdict)');
+    lines.push('\nJUDICIARY VERDICT');
+    lines.push('=================');
+    lines.push(verdict.verdictText || '(no verdict)');
   }
+
+  lines.push('\nSummary');
+  lines.push('-------');
+  lines.push(`Debate Session:  ${result.debateSessionId}`);
+  lines.push(`Panel Size:      ${result.panelSize}`);
+  lines.push(`Quorum Met:      ${result.quorumMet}`);
+  lines.push(`Round 1:         ${result.round1Positions.length} positions`);
+  lines.push(`Specialists:     ${result.specialistTestimony?.length || 0} summoned`);
+  lines.push(`Round 2:         ${result.round2Rebuttals?.length || 0} rebuttals`);
+  if (verdict) {
+    lines.push(`Escalation:      ${verdict.escalationRequired ? 'YES — chairman review needed' : 'No'}`);
+    lines.push(`Verdict ID:      ${verdict.verdictId}`);
+  }
+  lines.push(`Total Time:      ${(result.totalTimeMs / 1000).toFixed(1)}s`);
+
+  return lines.join('\n');
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- Remove LLM client factory (Ollama/Anthropic API) from `brainstorm-deliberate.js` — the `invokeAgent` callback is provided by the `/brainstorm` command via Claude's Agent tool
- CLI now supports `--dry-run` for standalone panel testing, exports `runDeliberation()` and `formatResults()` for programmatic use
- Fix `debate_arguments.argument_type` check constraint — `specialist_testimony` changed to `evidence`

## Test plan
- [x] `--dry-run` shows panel selection with relevance scores
- [x] Without `--dry-run`, shows clear error explaining invokeAgent is needed
- [x] `--help` shows usage
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)