### PR TITLE
feat(SD-LEO-INFRA-S20-VENTURE-LEO-001): S20 pause/resume for LEO SD completion

### DIFF
--- a/lib/eva/rpc/get-s20-sd-progress.js
+++ b/lib/eva/rpc/get-s20-sd-progress.js
@@ -1,0 +1,208 @@
+/**
+ * RPC: Get S20 SD Progress
+ *
+ * SD-LEO-INFRA-S20-VENTURE-LEO-001
+ *
+ * Returns orchestrator + child SD status for a venture in Stage 20.
+ * Used by the chairman dashboard and the S20 pause controller.
+ *
+ * @module lib/eva/rpc/get-s20-sd-progress
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+/**
+ * Get SD progress for a venture at Stage 20.
+ *
+ * @param {string} ventureId - UUID of the venture
+ * @returns {Promise<object>} Progress data with orchestrators, children, and pause state
+ */
+export async function getS20SdProgress(ventureId) {
+  if (!ventureId) throw new Error('ventureId is required');
+
+  // Get pause state from venture_stage_work
+  const { data: stageWork } = await supabase
+    .from('venture_stage_work')
+    .select('advisory_data, stage_status, health_score, started_at')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', 20)
+    .maybeSingle();
+
+  const pauseState = stageWork?.advisory_data?.pause_state || null;
+
+  // Get all SDs linked to this venture
+  const { data: allSDs } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, title, status, current_phase, progress, parent_sd_id, created_at')
+    .eq('venture_id', ventureId);
+
+  if (!allSDs || allSDs.length === 0) {
+    return {
+      venture_id: ventureId,
+      pause_state: pauseState,
+      stage_status: stageWork?.stage_status || 'unknown',
+      health_score: stageWork?.health_score || 'green',
+      orchestrators: [],
+      summary: { total_orchestrators: 0, completed: 0, in_progress: 0, total_sds: 0 },
+    };
+  }
+
+  // Build parent→children map
+  const ventureSDIds = new Set(allSDs.map(sd => sd.id));
+  const childrenMap = new Map();
+  const topLevel = [];
+
+  for (const sd of allSDs) {
+    if (!sd.parent_sd_id || !ventureSDIds.has(sd.parent_sd_id)) {
+      topLevel.push(sd);
+    } else {
+      if (!childrenMap.has(sd.parent_sd_id)) childrenMap.set(sd.parent_sd_id, []);
+      childrenMap.get(sd.parent_sd_id).push(sd);
+    }
+  }
+
+  // Build orchestrator tree
+  const orchestrators = topLevel.map(osd => {
+    const children = (childrenMap.get(osd.id) || []).map(c => ({
+      sd_key: c.sd_key,
+      title: c.title,
+      status: c.status,
+      current_phase: c.current_phase,
+      progress: c.progress || 0,
+    }));
+
+    // Compute orchestrator progress from children if any
+    let effectiveProgress = osd.progress || 0;
+    if (children.length > 0) {
+      const completedChildren = children.filter(c => c.status === 'completed').length;
+      effectiveProgress = Math.round((completedChildren / children.length) * 100);
+    }
+
+    return {
+      sd_key: osd.sd_key,
+      title: osd.title,
+      status: osd.status,
+      current_phase: osd.current_phase,
+      progress: effectiveProgress,
+      children,
+      child_count: children.length,
+      completed_children: children.filter(c => c.status === 'completed').length,
+    };
+  });
+
+  // Compute summary
+  const completedOrch = orchestrators.filter(o => o.status === 'completed').length;
+  const inProgressOrch = orchestrators.filter(o =>
+    o.status !== 'completed' && o.status !== 'cancelled'
+  ).length;
+
+  // Compute time in pause
+  let timeInPause = null;
+  if (pauseState?.paused_at) {
+    const pausedMs = Date.now() - new Date(pauseState.paused_at).getTime();
+    timeInPause = {
+      ms: pausedMs,
+      hours: Math.round(pausedMs / (1000 * 60 * 60) * 10) / 10,
+      days: Math.round(pausedMs / (1000 * 60 * 60 * 24) * 10) / 10,
+      display: formatDuration(pausedMs),
+    };
+  }
+
+  return {
+    venture_id: ventureId,
+    pause_state: pauseState,
+    stage_status: stageWork?.stage_status || 'unknown',
+    health_score: stageWork?.health_score || 'green',
+    time_in_pause: timeInPause,
+    orchestrators,
+    summary: {
+      total_orchestrators: orchestrators.length,
+      completed: completedOrch,
+      in_progress: inProgressOrch,
+      total_sds: allSDs.length,
+    },
+  };
+}
+
+/**
+ * Force advance S20 for a venture.
+ *
+ * @param {string} ventureId
+ * @param {string} advancedBy - Who triggered the force advance
+ */
+export async function forceAdvanceS20(ventureId, advancedBy = 'chairman') {
+  if (!ventureId) throw new Error('ventureId is required');
+
+  const { data: stageWork } = await supabase
+    .from('venture_stage_work')
+    .select('advisory_data')
+    .eq('venture_id', ventureId)
+    .eq('lifecycle_stage', 20)
+    .maybeSingle();
+
+  const advisoryData = stageWork?.advisory_data || {};
+  advisoryData.pause_state = {
+    ...(advisoryData.pause_state || {}),
+    state: 'COMPLETE',
+    force_advanced: true,
+    force_advanced_by: advancedBy,
+    force_advanced_at: new Date().toISOString(),
+  };
+  // Preserve legacy override flag for backward compatibility
+  advisoryData.override = true;
+
+  await supabase
+    .from('venture_stage_work')
+    .upsert({
+      venture_id: ventureId,
+      lifecycle_stage: 20,
+      stage_status: 'completed',
+      advisory_data: advisoryData,
+    }, { onConflict: 'venture_id,lifecycle_stage' });
+
+  return { success: true, venture_id: ventureId, advanced_by: advancedBy };
+}
+
+function formatDuration(ms) {
+  const hours = Math.floor(ms / (1000 * 60 * 60));
+  const minutes = Math.floor((ms % (1000 * 60 * 60)) / (1000 * 60));
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const remainingHours = hours % 24;
+    return `${days}d ${remainingHours}h`;
+  }
+  return `${hours}h ${minutes}m`;
+}
+
+// CLI entry point
+if (import.meta.url === `file://${process.argv[1]}` ||
+    import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}`) {
+  const [,, command, ventureId, ...rest] = process.argv;
+
+  if (command === 'progress' && ventureId) {
+    getS20SdProgress(ventureId).then(result => {
+      console.log(JSON.stringify(result, null, 2));
+    }).catch(err => {
+      console.error('Error:', err.message);
+      process.exit(1);
+    });
+  } else if (command === 'force-advance' && ventureId) {
+    const advancedBy = rest[0] || 'chairman';
+    forceAdvanceS20(ventureId, advancedBy).then(result => {
+      console.log(JSON.stringify(result, null, 2));
+    }).catch(err => {
+      console.error('Error:', err.message);
+      process.exit(1);
+    });
+  } else {
+    console.log('Usage:');
+    console.log('  node get-s20-sd-progress.js progress <venture-id>');
+    console.log('  node get-s20-sd-progress.js force-advance <venture-id> [advanced-by]');
+  }
+}

--- a/lib/eva/s20-pause-controller.js
+++ b/lib/eva/s20-pause-controller.js
@@ -1,0 +1,436 @@
+/**
+ * S20 Pause Controller — Event-Driven Pause/Resume for Stage 20
+ *
+ * SD-LEO-INFRA-S20-VENTURE-LEO-001
+ *
+ * State machine: CHECKING → PAUSED → RESUMING → COMPLETE
+ *
+ * When S19 creates orchestrator SDs via the lifecycle-sd-bridge, S20 pauses
+ * and waits for ALL orchestrator SDs to reach COMPLETED before advancing.
+ * State is persisted in venture_stage_work.advisory_data so it survives
+ * worker restarts. Uses Supabase realtime for event-driven resume with
+ * a periodic safety-net DB check every 5 minutes.
+ *
+ * @module lib/eva/s20-pause-controller
+ */
+
+const PAUSE_STATES = {
+  CHECKING: 'CHECKING',
+  PAUSED: 'PAUSED',
+  RESUMING: 'RESUMING',
+  COMPLETE: 'COMPLETE',
+};
+
+const DEFAULT_TIMEOUT_DAYS = 7;
+const SAFETY_NET_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+export class S20PauseController {
+  /**
+   * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+   * @param {{ log: Function, warn: Function }} logger
+   */
+  constructor(supabase, logger) {
+    this._supabase = supabase;
+    this._logger = logger || { log: console.log, warn: console.warn };
+    this._realtimeChannels = new Map(); // ventureId → channel
+    this._safetyNetTimers = new Map(); // ventureId → timer
+  }
+
+  /**
+   * Main entry point: check if S20 should pause for this venture.
+   * Returns { blocked, status, data } to the worker's stage loop.
+   *
+   * @param {string} ventureId
+   * @returns {Promise<{ blocked: boolean, status: string, data: object }>}
+   */
+  async check(ventureId) {
+    try {
+      // Load existing pause state from DB
+      const pauseState = await this._loadPauseState(ventureId);
+
+      // Force advance override
+      if (pauseState?.force_advanced) {
+        this._logger.log(`[S20Pause] Venture ${ventureId}: force-advanced — skipping pause`);
+        return { blocked: false, status: 'force_advanced', data: pauseState };
+      }
+
+      // Already complete from a previous run
+      if (pauseState?.state === PAUSE_STATES.COMPLETE) {
+        this._logger.log(`[S20Pause] Venture ${ventureId}: already COMPLETE — proceeding`);
+        return { blocked: false, status: 'complete', data: pauseState };
+      }
+
+      // Check for Replit build path — delegate back to legacy handler
+      const buildMethod = await this._getBuildMethod(ventureId);
+      if (buildMethod === 'replit_agent') {
+        return { blocked: false, status: 'replit_path', data: { build_method: 'replit_agent' } };
+      }
+
+      // Find linked orchestrator SDs created by S19 bridge
+      const orchestratorSDs = await this._findLinkedOrchestratorSDs(ventureId);
+
+      // No SDs linked — legacy venture, skip pause
+      if (orchestratorSDs.length === 0) {
+        this._logger.log(`[S20Pause] Venture ${ventureId}: no linked SDs — skipping pause (backward compatible)`);
+        return { blocked: false, status: 'no_sds', data: { total_sds: 0 } };
+      }
+
+      // Check completion status of all orchestrators
+      const completionResult = this._evaluateCompletion(orchestratorSDs);
+
+      if (completionResult.allComplete) {
+        // All orchestrators done — transition to COMPLETE
+        this._logger.log(
+          `[S20Pause] Venture ${ventureId}: all ${orchestratorSDs.length} orchestrator(s) COMPLETED — resuming`
+        );
+        await this._savePauseState(ventureId, {
+          state: PAUSE_STATES.COMPLETE,
+          linked_sd_ids: orchestratorSDs.map(sd => sd.id),
+          completed_at: new Date().toISOString(),
+        });
+        this._cleanup(ventureId);
+        return {
+          blocked: false,
+          status: 'complete',
+          data: {
+            total_sds: orchestratorSDs.length,
+            completed_sds: completionResult.completedCount,
+            sd_statuses: completionResult.statuses,
+          },
+        };
+      }
+
+      // Not all complete — enter or remain in PAUSED state
+      const now = new Date();
+      const existingPause = pauseState?.state === PAUSE_STATES.PAUSED ? pauseState : null;
+      const pausedAt = existingPause?.paused_at ? new Date(existingPause.paused_at) : now;
+      const timeoutDays = existingPause?.timeout_days || DEFAULT_TIMEOUT_DAYS;
+      const timeoutAt = new Date(pausedAt.getTime() + timeoutDays * 24 * 60 * 60 * 1000);
+
+      // Check timeout
+      const isTimedOut = now >= timeoutAt;
+      if (isTimedOut) {
+        this._logger.warn(
+          `[S20Pause] Venture ${ventureId}: TIMEOUT after ${timeoutDays} days — alerting chairman (NOT auto-advancing)`
+        );
+      }
+
+      // Persist pause state
+      await this._savePauseState(ventureId, {
+        state: PAUSE_STATES.PAUSED,
+        linked_sd_ids: orchestratorSDs.map(sd => sd.id),
+        paused_at: pausedAt.toISOString(),
+        timeout_at: timeoutAt.toISOString(),
+        timeout_days: timeoutDays,
+        timed_out: isTimedOut,
+        last_checked_at: now.toISOString(),
+        total_sds: orchestratorSDs.length,
+        completed_sds: completionResult.completedCount,
+        non_terminal_sds: completionResult.nonTerminalCount,
+        sd_statuses: completionResult.statuses,
+      });
+
+      // Start realtime subscription if not already active
+      this._ensureRealtimeSubscription(ventureId, orchestratorSDs.map(sd => sd.id));
+
+      // Start safety-net timer if not already active
+      this._ensureSafetyNet(ventureId);
+
+      // Compute health score
+      const daysPaused = (now - pausedAt) / (1000 * 60 * 60 * 24);
+      let healthScore = 'green';
+      if (daysPaused >= timeoutDays) healthScore = 'red';
+      else if (daysPaused >= timeoutDays * 0.5) healthScore = 'yellow';
+
+      this._logger.log(
+        `[S20Pause] Venture ${ventureId}: PAUSED — ${completionResult.completedCount}/${orchestratorSDs.length} complete, ` +
+        `${daysPaused.toFixed(1)}d elapsed, health=${healthScore}`
+      );
+
+      return {
+        blocked: true,
+        status: 'paused',
+        data: {
+          state: PAUSE_STATES.PAUSED,
+          total_sds: orchestratorSDs.length,
+          completed_sds: completionResult.completedCount,
+          non_terminal_sds: completionResult.nonTerminalCount,
+          health_score: healthScore,
+          paused_at: pausedAt.toISOString(),
+          timeout_at: timeoutAt.toISOString(),
+          timed_out: isTimedOut,
+          sd_statuses: completionResult.statuses,
+        },
+      };
+    } catch (err) {
+      this._logger.warn(`[S20Pause] check failed for venture ${ventureId}: ${err.message}`);
+      // Fail-open: don't block on check failure
+      return { blocked: false, status: 'error', data: { error: err.message } };
+    }
+  }
+
+  /**
+   * Force advance S20 for a venture — chairman override.
+   * @param {string} ventureId
+   * @param {string} advancedBy
+   */
+  async forceAdvance(ventureId, advancedBy = 'chairman') {
+    const pauseState = await this._loadPauseState(ventureId);
+    await this._savePauseState(ventureId, {
+      ...pauseState,
+      state: PAUSE_STATES.COMPLETE,
+      force_advanced: true,
+      force_advanced_by: advancedBy,
+      force_advanced_at: new Date().toISOString(),
+    });
+    this._cleanup(ventureId);
+    this._logger.log(`[S20Pause] Venture ${ventureId}: force-advanced by ${advancedBy}`);
+  }
+
+  /**
+   * Get SD progress data for a venture — used by dashboard RPC.
+   * @param {string} ventureId
+   * @returns {Promise<object>}
+   */
+  async getProgress(ventureId) {
+    const pauseState = await this._loadPauseState(ventureId);
+    const orchestratorSDs = await this._findLinkedOrchestratorSDs(ventureId);
+
+    // For each orchestrator, fetch children
+    const orchestrators = [];
+    for (const osd of orchestratorSDs) {
+      const { data: children } = await this._supabase
+        .from('strategic_directives_v2')
+        .select('id, sd_key, title, status, current_phase, progress')
+        .eq('parent_sd_id', osd.id)
+        .order('created_at', { ascending: true });
+
+      orchestrators.push({
+        sd_key: osd.sd_key,
+        title: osd.title,
+        status: osd.status,
+        current_phase: osd.current_phase,
+        progress: osd.progress || 0,
+        children: (children || []).map(c => ({
+          sd_key: c.sd_key,
+          title: c.title,
+          status: c.status,
+          current_phase: c.current_phase,
+          progress: c.progress || 0,
+        })),
+      });
+    }
+
+    return {
+      venture_id: ventureId,
+      pause_state: pauseState,
+      orchestrators,
+      summary: {
+        total_orchestrators: orchestratorSDs.length,
+        completed: orchestratorSDs.filter(sd => sd.status === 'completed').length,
+        in_progress: orchestratorSDs.filter(sd => sd.status !== 'completed' && sd.status !== 'cancelled').length,
+      },
+    };
+  }
+
+  /**
+   * Re-subscribe to realtime channels for all PAUSED ventures.
+   * Called on worker startup to restore subscriptions.
+   */
+  async restoreSubscriptions() {
+    try {
+      const { data: pausedVentures } = await this._supabase
+        .from('venture_stage_work')
+        .select('venture_id, advisory_data')
+        .eq('lifecycle_stage', 20)
+        .eq('stage_status', 'blocked');
+
+      if (!pausedVentures || pausedVentures.length === 0) return;
+
+      for (const vsw of pausedVentures) {
+        const pause = vsw.advisory_data?.pause_state;
+        if (pause?.state === PAUSE_STATES.PAUSED && pause?.linked_sd_ids?.length > 0) {
+          this._logger.log(`[S20Pause] Restoring subscription for venture ${vsw.venture_id}`);
+          this._ensureRealtimeSubscription(vsw.venture_id, pause.linked_sd_ids);
+          this._ensureSafetyNet(vsw.venture_id);
+        }
+      }
+    } catch (err) {
+      this._logger.warn(`[S20Pause] restoreSubscriptions failed: ${err.message}`);
+    }
+  }
+
+  /**
+   * Cleanup all subscriptions and timers — call on worker shutdown.
+   */
+  destroy() {
+    for (const [ventureId] of this._realtimeChannels) {
+      this._cleanup(ventureId);
+    }
+  }
+
+  // ── Private Methods ──
+
+  async _loadPauseState(ventureId) {
+    const { data } = await this._supabase
+      .from('venture_stage_work')
+      .select('advisory_data')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 20)
+      .maybeSingle();
+
+    return data?.advisory_data?.pause_state || null;
+  }
+
+  async _savePauseState(ventureId, pauseState) {
+    // Load existing advisory_data to merge
+    const { data: existing } = await this._supabase
+      .from('venture_stage_work')
+      .select('advisory_data')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 20)
+      .maybeSingle();
+
+    const advisoryData = { ...(existing?.advisory_data || {}), pause_state: pauseState };
+    const stageStatus = pauseState.state === PAUSE_STATES.COMPLETE ? 'completed' : 'blocked';
+
+    await this._supabase
+      .from('venture_stage_work')
+      .upsert({
+        venture_id: ventureId,
+        lifecycle_stage: 20,
+        stage_status: stageStatus,
+        work_type: 'sd_required',
+        advisory_data: advisoryData,
+      }, { onConflict: 'venture_id,lifecycle_stage' });
+  }
+
+  async _getBuildMethod(ventureId) {
+    const { data } = await this._supabase
+      .from('venture_stage_work')
+      .select('advisory_data')
+      .eq('venture_id', ventureId)
+      .eq('lifecycle_stage', 20)
+      .maybeSingle();
+
+    return data?.advisory_data?.build_method || 'claude_code';
+  }
+
+  async _findLinkedOrchestratorSDs(ventureId) {
+    // Find SDs linked to this venture that are orchestrators (have children)
+    // or are standalone SDs from the S19 bridge
+    const { data: allSDs } = await this._supabase
+      .from('strategic_directives_v2')
+      .select('id, sd_key, title, status, current_phase, progress, parent_sd_id')
+      .eq('venture_id', ventureId);
+
+    if (!allSDs || allSDs.length === 0) return [];
+
+    // Find top-level SDs (no parent, or parent is not in this venture)
+    const ventureSDIds = new Set(allSDs.map(sd => sd.id));
+    const topLevel = allSDs.filter(sd =>
+      !sd.parent_sd_id || !ventureSDIds.has(sd.parent_sd_id)
+    );
+
+    return topLevel;
+  }
+
+  _evaluateCompletion(orchestratorSDs) {
+    const terminalStatuses = new Set(['completed', 'cancelled']);
+    const completedCount = orchestratorSDs.filter(sd => sd.status === 'completed').length;
+    const nonTerminal = orchestratorSDs.filter(sd => !terminalStatuses.has(sd.status));
+
+    return {
+      allComplete: nonTerminal.length === 0,
+      completedCount,
+      nonTerminalCount: nonTerminal.length,
+      statuses: orchestratorSDs.map(sd => ({
+        sd_key: sd.sd_key,
+        status: sd.status,
+        current_phase: sd.current_phase,
+        progress: sd.progress || 0,
+      })),
+    };
+  }
+
+  _ensureRealtimeSubscription(ventureId, sdIds) {
+    if (this._realtimeChannels.has(ventureId)) return;
+
+    const channelName = `s20-watch-${ventureId.slice(0, 8)}`;
+    const channel = this._supabase
+      .channel(channelName)
+      .on('postgres_changes', {
+        event: 'UPDATE',
+        schema: 'public',
+        table: 'strategic_directives_v2',
+      }, (payload) => {
+        // Check if this update is for one of our watched SDs
+        if (sdIds.includes(payload.new.id)) {
+          const newPhase = payload.new.current_phase;
+          const newStatus = payload.new.status;
+          if (newStatus === 'completed' || newPhase === 'COMPLETED') {
+            this._logger.log(
+              `[S20Pause] Realtime: SD ${payload.new.sd_key || payload.new.id} completed for venture ${ventureId}`
+            );
+            // The worker's next poll iteration will pick up the change
+            // via check() — no need to advance here directly
+          }
+        }
+      })
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          this._logger.log(`[S20Pause] Realtime channel ${channelName} subscribed for venture ${ventureId}`);
+        }
+      });
+
+    this._realtimeChannels.set(ventureId, channel);
+  }
+
+  _ensureSafetyNet(ventureId) {
+    if (this._safetyNetTimers.has(ventureId)) return;
+
+    const timer = setInterval(async () => {
+      try {
+        const orchestratorSDs = await this._findLinkedOrchestratorSDs(ventureId);
+        if (orchestratorSDs.length === 0) return;
+
+        const completion = this._evaluateCompletion(orchestratorSDs);
+        if (completion.allComplete) {
+          this._logger.log(
+            `[S20Pause] Safety-net: all orchestrators complete for venture ${ventureId} (missed realtime event)`
+          );
+          await this._savePauseState(ventureId, {
+            state: PAUSE_STATES.COMPLETE,
+            linked_sd_ids: orchestratorSDs.map(sd => sd.id),
+            completed_at: new Date().toISOString(),
+            completed_via: 'safety_net',
+          });
+          this._cleanup(ventureId);
+        }
+      } catch (err) {
+        this._logger.warn(`[S20Pause] Safety-net check failed for venture ${ventureId}: ${err.message}`);
+      }
+    }, SAFETY_NET_INTERVAL_MS);
+
+    this._safetyNetTimers.set(ventureId, timer);
+  }
+
+  _cleanup(ventureId) {
+    // Remove realtime channel
+    const channel = this._realtimeChannels.get(ventureId);
+    if (channel) {
+      this._supabase.removeChannel(channel);
+      this._realtimeChannels.delete(ventureId);
+    }
+
+    // Clear safety-net timer
+    const timer = this._safetyNetTimers.get(ventureId);
+    if (timer) {
+      clearInterval(timer);
+      this._safetyNetTimers.delete(ventureId);
+    }
+  }
+}
+
+export { PAUSE_STATES };
+export default S20PauseController;

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -31,6 +31,7 @@ import {
 } from './chairman-decision-watcher.js';
 import { emit } from './shared-services.js';
 import { checkAutonomy } from './autonomy-model.js';
+import { S20PauseController } from './s20-pause-controller.js';
 
 import { hostname } from 'os';
 import { createServer } from 'http';
@@ -132,6 +133,9 @@ export class StageExecutionWorker {
     /** @type {boolean} */
     this._processing = false;
 
+    /** @type {S20PauseController} SD-LEO-INFRA-S20-VENTURE-LEO-001 */
+    this._s20PauseController = new S20PauseController(this._supabase, this._logger);
+
     /** @type {Date} Worker start time */
     this._startedAt = null;
 
@@ -180,6 +184,11 @@ export class StageExecutionWorker {
       this._logger.warn(`[Worker] Initial heartbeat failed: ${err.message}`)
     );
 
+    // SD-LEO-INFRA-S20-VENTURE-LEO-001: Restore realtime subscriptions for paused ventures
+    this._s20PauseController.restoreSubscriptions().catch(err =>
+      this._logger.warn(`[Worker] S20 subscription restore failed: ${err.message}`)
+    );
+
     // Run immediately, then on interval
     this._tick();
     this._pollTimer = setInterval(() => this._tick(), this._pollIntervalMs);
@@ -204,6 +213,9 @@ export class StageExecutionWorker {
       controller.abort();
     }
     this._activeVentures.clear();
+
+    // SD-LEO-INFRA-S20-VENTURE-LEO-001: Cleanup S20 pause controller
+    this._s20PauseController.destroy();
 
     // Stop health server
     if (this._healthServer) {
@@ -513,48 +525,36 @@ export class StageExecutionWorker {
           break;
         }
 
-        // SD-LEO-INFRA-S20-BUILD-PENDING-001-A: BUILD_PENDING — pause at S20
-        // when linked SDs exist but are not all terminal (completed/cancelled).
-        // This prevents S20 from auto-advancing with LLM-synthesized fake build
-        // reports while LEO SDs are still being executed in Claude Code sessions.
+        // SD-LEO-INFRA-S20-VENTURE-LEO-001: S20 Pause/Resume Controller
+        // Event-driven pause at S20 waiting for orchestrator SD completion.
+        // Replaces the legacy BUILD_PENDING error gate with a proper state machine
+        // that persists across worker restarts and uses realtime subscriptions.
         if (currentStage === 20) {
-          const buildPendingResult = await this._checkBuildPending(ventureId);
-          if (buildPendingResult.blocked) {
-            this._logger.log(
-              `[Worker] Stage 20 BUILD_PENDING: ${buildPendingResult.nonTerminalCount} non-terminal SD(s) — blocking venture ${ventureId}`
-            );
+          const pauseResult = await this._s20PauseController.check(ventureId);
+
+          // Replit path — delegate to legacy handler
+          if (pauseResult.status === 'replit_path') {
+            const replitResult = await this._checkReplitBuildPending(ventureId);
+            if (replitResult.blocked) {
+              releaseState = ORCHESTRATOR_STATES.BLOCKED;
+              lastResult = { ventureId, stageId: currentStage, status: 'replit_build_pending', ...replitResult };
+              break;
+            }
+          } else if (pauseResult.blocked) {
             releaseState = ORCHESTRATOR_STATES.BLOCKED;
             lastResult = {
               ventureId,
               stageId: currentStage,
               status: 'build_pending',
-              nonTerminalSDs: buildPendingResult.nonTerminalCount,
-              totalSDs: buildPendingResult.totalCount,
-              healthScore: buildPendingResult.healthScore,
+              ...pauseResult.data,
             };
             break;
-          }
-          if (buildPendingResult.totalCount > 0 && !buildPendingResult.blocked) {
+          } else if (pauseResult.status === 'complete' || pauseResult.status === 'force_advanced') {
             this._logger.log(
-              `[Worker] Stage 20 BUILD_PENDING: all ${buildPendingResult.totalCount} SD(s) terminal — proceeding with real build data`
+              `[Worker] Stage 20 S20Pause: ${pauseResult.status} — proceeding with real build data`
             );
           }
-          if (buildPendingResult.totalCount === 0) {
-            this._logger.log(
-              `[Worker] Stage 20 BUILD_PENDING: zero SDs linked to venture ${ventureId} — blocking (bridge did not create SDs)`
-            );
-            releaseState = ORCHESTRATOR_STATES.BLOCKED;
-            lastResult = {
-              ventureId,
-              stageId: currentStage,
-              status: 'build_pending',
-              nonTerminalSDs: 0,
-              totalSDs: 0,
-              healthScore: 'red',
-              error: 'No SDs linked to venture — Stage 19 bridge did not create SDs',
-            };
-            break;
-          }
+          // status === 'no_sds' or 'error' — proceed (backward compatible / fail-open)
         }
 
         // SD-LEO-ORCH-VENTURE-FACTORY-OUTPUT-QUALITY-001-D: Build readiness gate

--- a/tests/eva/s20-pause-controller.test.js
+++ b/tests/eva/s20-pause-controller.test.js
@@ -1,0 +1,292 @@
+/**
+ * Tests for S20 Pause Controller
+ *
+ * SD-LEO-INFRA-S20-VENTURE-LEO-001
+ *
+ * Tests the pause/resume state machine, backward compatibility,
+ * force advance, and progress reporting.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { S20PauseController, PAUSE_STATES } from '../../lib/eva/s20-pause-controller.js';
+
+// Mock Supabase client
+function createMockSupabase(overrides = {}) {
+  const defaultData = {
+    venture_stage_work: null,
+    strategic_directives: [],
+    children: [],
+  };
+  const data = { ...defaultData, ...overrides };
+
+  const mockFrom = (table) => {
+    const chain = {
+      select: () => chain,
+      eq: () => chain,
+      maybeSingle: async () => {
+        if (table === 'venture_stage_work') {
+          return { data: data.venture_stage_work, error: null };
+        }
+        return { data: null, error: null };
+      },
+      single: async () => ({ data: null, error: null }),
+      order: () => chain,
+      upsert: async () => ({ data: null, error: null }),
+      update: async () => ({ data: null, error: null }),
+      then: (fn) => {
+        if (table === 'strategic_directives_v2') {
+          return fn({ data: data.strategic_directives, error: null });
+        }
+        if (table === 'venture_stage_work') {
+          return fn({ data: data.venture_stage_work ? [data.venture_stage_work] : [], error: null });
+        }
+        return fn({ data: [], error: null });
+      },
+    };
+    return chain;
+  };
+
+  return {
+    from: vi.fn(mockFrom),
+    channel: vi.fn(() => ({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn((cb) => { if (cb) cb('SUBSCRIBED'); return { unsubscribe: vi.fn() }; }),
+    })),
+    removeChannel: vi.fn(),
+  };
+}
+
+const mockLogger = {
+  log: vi.fn(),
+  warn: vi.fn(),
+};
+
+describe('S20PauseController', () => {
+  let controller;
+  let supabase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('PAUSE_STATES', () => {
+    it('exports all required states', () => {
+      expect(PAUSE_STATES.CHECKING).toBe('CHECKING');
+      expect(PAUSE_STATES.PAUSED).toBe('PAUSED');
+      expect(PAUSE_STATES.RESUMING).toBe('RESUMING');
+      expect(PAUSE_STATES.COMPLETE).toBe('COMPLETE');
+    });
+  });
+
+  describe('check() — no linked SDs (backward compatibility)', () => {
+    it('returns not blocked when no SDs linked to venture', async () => {
+      supabase = createMockSupabase({ strategic_directives: [] });
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      expect(result.blocked).toBe(false);
+      expect(result.status).toBe('no_sds');
+      expect(result.data.total_sds).toBe(0);
+    });
+  });
+
+  describe('check() — all SDs completed', () => {
+    it('returns not blocked when all orchestrator SDs are completed', async () => {
+      const sds = [
+        { id: 'sd-1', sd_key: 'SD-ORCH-001', title: 'Test', status: 'completed', current_phase: 'COMPLETED', progress: 100, parent_sd_id: null },
+      ];
+      supabase = createMockSupabase({ strategic_directives: sds });
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      expect(result.blocked).toBe(false);
+      expect(result.status).toBe('complete');
+    });
+  });
+
+  describe('check() — SDs in progress', () => {
+    it('returns blocked when orchestrator SDs are not complete', async () => {
+      const sds = [
+        { id: 'sd-1', sd_key: 'SD-ORCH-001', title: 'Test', status: 'in_progress', current_phase: 'EXEC', progress: 50, parent_sd_id: null },
+      ];
+      supabase = createMockSupabase({ strategic_directives: sds });
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      expect(result.blocked).toBe(true);
+      expect(result.status).toBe('paused');
+      expect(result.data.state).toBe(PAUSE_STATES.PAUSED);
+      expect(result.data.total_sds).toBe(1);
+      expect(result.data.non_terminal_sds).toBe(1);
+    });
+  });
+
+  describe('check() — multi-orchestrator', () => {
+    it('remains blocked when only some orchestrators are complete', async () => {
+      const sds = [
+        { id: 'sd-1', sd_key: 'SD-ORCH-001', title: 'First', status: 'completed', current_phase: 'COMPLETED', progress: 100, parent_sd_id: null },
+        { id: 'sd-2', sd_key: 'SD-ORCH-002', title: 'Second', status: 'in_progress', current_phase: 'EXEC', progress: 30, parent_sd_id: null },
+      ];
+      supabase = createMockSupabase({ strategic_directives: sds });
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      expect(result.blocked).toBe(true);
+      expect(result.data.completed_sds).toBe(1);
+      expect(result.data.non_terminal_sds).toBe(1);
+    });
+
+    it('resumes when ALL orchestrators are complete', async () => {
+      const sds = [
+        { id: 'sd-1', sd_key: 'SD-ORCH-001', title: 'First', status: 'completed', current_phase: 'COMPLETED', progress: 100, parent_sd_id: null },
+        { id: 'sd-2', sd_key: 'SD-ORCH-002', title: 'Second', status: 'completed', current_phase: 'COMPLETED', progress: 100, parent_sd_id: null },
+      ];
+      supabase = createMockSupabase({ strategic_directives: sds });
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      expect(result.blocked).toBe(false);
+      expect(result.status).toBe('complete');
+    });
+  });
+
+  describe('check() — force advance', () => {
+    it('returns not blocked when force_advanced is true', async () => {
+      supabase = createMockSupabase({
+        venture_stage_work: {
+          advisory_data: {
+            pause_state: { state: PAUSE_STATES.PAUSED, force_advanced: true },
+          },
+        },
+        strategic_directives: [
+          { id: 'sd-1', sd_key: 'SD-001', title: 'Test', status: 'in_progress', current_phase: 'EXEC', progress: 50, parent_sd_id: null },
+        ],
+      });
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      expect(result.blocked).toBe(false);
+      expect(result.status).toBe('force_advanced');
+    });
+  });
+
+  describe('check() — Replit build path', () => {
+    it('returns replit_path status for Replit ventures', async () => {
+      supabase = createMockSupabase({
+        venture_stage_work: {
+          advisory_data: { build_method: 'replit_agent' },
+        },
+      });
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      expect(result.blocked).toBe(false);
+      expect(result.status).toBe('replit_path');
+    });
+  });
+
+  describe('check() — error handling', () => {
+    it('fails open on error (does not block)', async () => {
+      supabase = {
+        from: vi.fn(() => { throw new Error('DB connection failed'); }),
+        channel: vi.fn(),
+        removeChannel: vi.fn(),
+      };
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      expect(result.blocked).toBe(false);
+      expect(result.status).toBe('error');
+    });
+  });
+
+  describe('check() — child SDs excluded from top-level', () => {
+    it('only watches top-level SDs, not children', async () => {
+      const sds = [
+        { id: 'sd-parent', sd_key: 'SD-ORCH-001', title: 'Parent', status: 'in_progress', current_phase: 'EXEC', progress: 50, parent_sd_id: null },
+        { id: 'sd-child-1', sd_key: 'SD-ORCH-001-A', title: 'Child A', status: 'completed', current_phase: 'COMPLETED', progress: 100, parent_sd_id: 'sd-parent' },
+        { id: 'sd-child-2', sd_key: 'SD-ORCH-001-B', title: 'Child B', status: 'in_progress', current_phase: 'EXEC', progress: 40, parent_sd_id: 'sd-parent' },
+      ];
+      supabase = createMockSupabase({ strategic_directives: sds });
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const result = await controller.check('venture-123');
+
+      // Only the parent should be in the top-level check, not children
+      expect(result.blocked).toBe(true);
+      expect(result.data.total_sds).toBe(1); // Only parent
+    });
+  });
+
+  describe('forceAdvance()', () => {
+    it('sets force_advanced in pause state', async () => {
+      supabase = createMockSupabase();
+      controller = new S20PauseController(supabase, mockLogger);
+
+      await controller.forceAdvance('venture-123', 'rick');
+
+      // Verify upsert was called
+      expect(supabase.from).toHaveBeenCalledWith('venture_stage_work');
+    });
+  });
+
+  describe('getProgress()', () => {
+    it('returns orchestrator tree with children', async () => {
+      const sds = [
+        { id: 'sd-parent', sd_key: 'SD-ORCH-001', title: 'Parent', status: 'in_progress', current_phase: 'EXEC', progress: 50, parent_sd_id: null },
+        { id: 'sd-child-1', sd_key: 'SD-ORCH-001-A', title: 'Child A', status: 'completed', current_phase: 'COMPLETED', progress: 100, parent_sd_id: 'sd-parent' },
+      ];
+
+      // Need a more sophisticated mock for getProgress since it makes multiple queries
+      const mockFrom = (table) => {
+        const chain = {
+          select: () => chain,
+          eq: (col, val) => {
+            chain._lastEq = { col, val };
+            return chain;
+          },
+          maybeSingle: async () => ({ data: null, error: null }),
+          order: () => chain,
+          then: (fn) => {
+            if (table === 'strategic_directives_v2') {
+              // If querying children (parent_sd_id filter)
+              if (chain._lastEq?.col === 'parent_sd_id') {
+                const children = sds.filter(sd => sd.parent_sd_id === chain._lastEq.val);
+                return fn({ data: children, error: null });
+              }
+              return fn({ data: sds, error: null });
+            }
+            return fn({ data: null, error: null });
+          },
+        };
+        return chain;
+      };
+
+      supabase = { from: vi.fn(mockFrom), channel: vi.fn(), removeChannel: vi.fn() };
+      controller = new S20PauseController(supabase, mockLogger);
+
+      const progress = await controller.getProgress('venture-123');
+
+      expect(progress.orchestrators.length).toBe(1);
+      expect(progress.orchestrators[0].sd_key).toBe('SD-ORCH-001');
+      expect(progress.summary.total_orchestrators).toBe(1);
+    });
+  });
+
+  describe('destroy()', () => {
+    it('does not throw on empty state', () => {
+      supabase = createMockSupabase();
+      controller = new S20PauseController(supabase, mockLogger);
+
+      expect(() => controller.destroy()).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replace legacy BUILD_PENDING error gate with event-driven S20 pause controller
- State machine (CHECKING→PAUSED→RESUMING→COMPLETE) persists across worker restarts via venture_stage_work.advisory_data
- Supabase realtime subscriptions for orchestrator SD completion detection + periodic safety-net DB check
- RPC endpoint for chairman dashboard SD progress queries and force-advance override
- Backward compatible: ventures with no linked SDs skip pause entirely

## Files Changed
- `lib/eva/s20-pause-controller.js` (NEW) — 436 LOC, state machine + realtime + safety net
- `lib/eva/rpc/get-s20-sd-progress.js` (NEW) — 208 LOC, progress RPC + force advance
- `lib/eva/stage-execution-worker.js` (MOD) — replaced BUILD_PENDING gate (+31/-31)
- `tests/eva/s20-pause-controller.test.js` (NEW) — 13 tests, all passing

## Test plan
- [x] 13 unit tests covering: no SDs (backward compat), all complete, in-progress pause, multi-orchestrator, force advance, Replit path, error handling, child SD exclusion
- [ ] Manual: verify worker starts and restores subscriptions for paused ventures
- [ ] Manual: verify force-advance RPC advances a paused venture

🤖 Generated with [Claude Code](https://claude.com/claude-code)