### PR TITLE
fix(software-factory): provisioner import path, EU region, scheduled polling

### DIFF
--- a/.github/workflows/software-factory-poll.yml
+++ b/.github/workflows/software-factory-poll.yml
@@ -1,0 +1,70 @@
+name: "Clockwork: Software Factory Error Poll"
+
+on:
+  schedule:
+    # Run every 30 minutes during business hours (8 AM - 10 PM UTC)
+    - cron: '0,30 8-22 * * *'
+  workflow_dispatch:
+    inputs:
+      venture:
+        description: 'Poll a specific venture only (name filter)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Run in dry-run mode (no writes to feedback table)'
+        required: false
+        default: 'false'
+        type: boolean
+      digest:
+        description: 'Generate daily digest instead of polling'
+        required: false
+        default: 'false'
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  poll-errors:
+    name: Poll Venture Errors
+    runs-on: ubuntu-latest
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_BASE_URL: ${{ secrets.SENTRY_BASE_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Poll errors
+        if: inputs.digest != 'true'
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.venture }}" ]; then
+            ARGS="$ARGS --venture ${{ inputs.venture }}"
+          fi
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ARGS="$ARGS --dry-run"
+          fi
+          node scripts/factory/poll-errors.js $ARGS
+
+      - name: Generate digest
+        if: inputs.digest == 'true'
+        run: node scripts/factory/poll-errors.js --digest

--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -351,9 +351,10 @@ services:
 
       const existingMetadata = current?.metadata || {};
       const sentryConfig = existingMetadata.sentry || {
-        org: process.env.SENTRY_ORG || 'ehg',
+        org: process.env.SENTRY_ORG || 'ehg-3v',
         project: ctx.venture.repoName,
         token: process.env.SENTRY_AUTH_TOKEN || 'pending-manual-setup',
+        baseUrl: process.env.SENTRY_BASE_URL || 'https://de.sentry.io',
         lastPollAt: null
       };
 

--- a/lib/eva/stage-execution-worker.js
+++ b/lib/eva/stage-execution-worker.js
@@ -1143,7 +1143,7 @@ export class StageExecutionWorker {
       this._logger.log(`[Worker] Stage 18: Venture "${ventureName}" not provisioned — attempting auto-provision`);
 
       try {
-        const provisionerPath = new URL('./venture-provisioner.js', import.meta.url);
+        const provisionerPath = new URL('./bridge/venture-provisioner.js', import.meta.url);
         const { provisionVenture } = await import(provisionerPath.href);
         if (typeof provisionVenture === 'function') {
           const repoPath = provState?.github_repo_url || null;
@@ -1721,7 +1721,7 @@ export class StageExecutionWorker {
     const buildMethod = s19Work?.advisory_data?.build_method;
     if (buildMethod === 'replit_agent') {
       this._logger.log(
-        `[Worker] S19 Bridge: build_method=replit_agent — skipping SD creation. Venture will be built in Replit.`
+        '[Worker] S19 Bridge: build_method=replit_agent — skipping SD creation. Venture will be built in Replit.'
       );
       // Write the build_method to Stage 20 so BUILD_PENDING knows to check Replit sync
       await this._supabase
@@ -2059,7 +2059,7 @@ export class StageExecutionWorker {
     // Check 1: Has code been synced from Replit to GitHub?
     if (!replitSync || !replitSync.last_commit_sha) {
       this._logger.log(
-        `[Worker] Stage 20 REPLIT_BUILD_PENDING: No GitHub sync detected — waiting for Replit push`
+        '[Worker] Stage 20 REPLIT_BUILD_PENDING: No GitHub sync detected — waiting for Replit push'
       );
       result.blocked = true;
       result.totalCount = 1;
@@ -2081,7 +2081,7 @@ export class StageExecutionWorker {
     if (!verificationSDs || verificationSDs.length === 0) {
       // No verification SDs yet — they may need to be created
       this._logger.log(
-        `[Worker] Stage 20 REPLIT_BUILD_PENDING: GitHub synced but no verification SDs found — waiting for verification SD generation`
+        '[Worker] Stage 20 REPLIT_BUILD_PENDING: GitHub synced but no verification SDs found — waiting for verification SD generation'
       );
       result.blocked = true;
       result.totalCount = 1;

--- a/lib/factory/sentry-poller.js
+++ b/lib/factory/sentry-poller.js
@@ -19,18 +19,20 @@ const MAX_RETRIES = 3;
  * @param {string} config.sentryOrg - Sentry organization slug
  * @param {string} config.sentryProject - Sentry project slug
  * @param {string} config.sentryToken - Sentry auth token (bearer)
+ * @param {string} [config.baseUrl] - Sentry API base URL (default: https://sentry.io, use https://de.sentry.io for EU)
  * @param {string} [config.since] - ISO timestamp — only fetch issues seen after this time
  * @param {number} [config.limit] - Max issues to fetch (default: 25)
  * @returns {Promise<object[]>} Array of normalized error objects
  */
 export async function pollVentureErrors(config) {
-  const { sentryOrg, sentryProject, sentryToken, since, limit = DEFAULT_POLL_LIMIT } = config;
+  const { sentryOrg, sentryProject, sentryToken, baseUrl: sentryBaseUrl, since, limit = DEFAULT_POLL_LIMIT } = config;
 
   if (!sentryOrg || !sentryProject || !sentryToken) {
     throw new Error('Missing required Sentry config: sentryOrg, sentryProject, sentryToken');
   }
 
-  const baseUrl = `https://sentry.io/api/0/projects/${sentryOrg}/${sentryProject}/issues/`;
+  const apiHost = sentryBaseUrl || 'https://sentry.io';
+  const issuesUrl = `${apiHost}/api/0/projects/${sentryOrg}/${sentryProject}/issues/`;
   const params = new URLSearchParams({
     limit: String(limit),
     sort: 'date',
@@ -41,7 +43,7 @@ export async function pollVentureErrors(config) {
   let lastError = null;
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await fetch(`${baseUrl}?${params}`, {
+      const response = await fetch(`${issuesUrl}?${params}`, {
         headers: {
           'Authorization': `Bearer ${sentryToken}`,
           'Content-Type': 'application/json'

--- a/scripts/factory/poll-errors.js
+++ b/scripts/factory/poll-errors.js
@@ -105,6 +105,7 @@ async function main() {
         sentryOrg: sentryConfig.org,
         sentryProject: sentryConfig.project,
         sentryToken: sentryConfig.token,
+        baseUrl: sentryConfig.baseUrl || undefined,
         since: sentryConfig.lastPollAt || undefined
       });
 


### PR DESCRIPTION
## Summary
- Fix provisioner import path: `./venture-provisioner.js` -> `./bridge/venture-provisioner.js` (Step 18 was unreachable)
- Add EU region base URL to monitoring_baseline step and sentry-poller (defaults to `de.sentry.io`)
- Add Clockwork scheduled workflow: polls every 30min during 8AM-10PM UTC
- GitHub secrets configured: SENTRY_ORG, SENTRY_AUTH_TOKEN, SENTRY_BASE_URL

## Test plan
- [x] Smoke tests pass (15/15)
- [x] `poll-errors.js --venture CronRead` authenticates against EU Sentry API
- [x] Workflow syntax validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)