### PR TITLE
fix(QF-S20-VERDICT-FILTER): filter judge_verdicts by venture SD IDs

### DIFF
--- a/lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js
@@ -340,10 +340,20 @@ async function fetchJudgeVerdicts(supabase, ventureId, logger) {
 
     const sdIds = sds.map(sd => sd.id);
 
-    // Query judge_verdicts for these SDs via debate_sessions
+    // Join through debate_sessions to filter verdicts by venture SDs
+    const { data: sessions } = await supabase
+      .from('debate_sessions')
+      .select('id')
+      .in('sd_id', sdIds);
+
+    if (!sessions || sessions.length === 0) return null;
+
+    const sessionIds = sessions.map(s => s.id);
+
     const { data: verdicts, error } = await supabase
       .from('judge_verdicts')
-      .select('verdict, confidence, recommendation, constitutional_citations, created_at, debate_session_id')
+      .select('verdict_type, confidence_score, summary, constitution_citations, escalation_required, created_at, debate_session_id')
+      .in('debate_session_id', sessionIds)
       .order('created_at', { ascending: false })
       .limit(20);
 
@@ -351,23 +361,23 @@ async function fetchJudgeVerdicts(supabase, ventureId, logger) {
 
     // Compute aggregate verdict score from confidence values
     const confidences = verdicts
-      .map(v => v.confidence)
+      .map(v => v.confidence_score)
       .filter(c => typeof c === 'number' && !isNaN(c));
 
     const avgConfidence = confidences.length > 0
       ? Math.round((confidences.reduce((a, b) => a + b, 0) / confidences.length) * 100) / 100
       : null;
 
-    // Extract recommendations
+    // Extract summaries as recommendations
     const recommendations = verdicts
-      .map(v => v.recommendation)
+      .map(v => v.summary)
       .filter(Boolean)
       .slice(0, 5);
 
     // Count verdict types
     const verdictCounts = {};
     for (const v of verdicts) {
-      const type = v.verdict || 'unknown';
+      const type = v.verdict_type || 'unknown';
       verdictCounts[type] = (verdictCounts[type] || 0) + 1;
     }
 
@@ -382,7 +392,8 @@ async function fetchJudgeVerdicts(supabase, ventureId, logger) {
       verdictCount: verdicts.length,
       verdictTypes: verdictCounts,
       topRecommendations: recommendations,
-      hasConstitutionalCitations: verdicts.some(v => v.constitutional_citations?.length > 0),
+      hasConstitutionalCitations: verdicts.some(v => v.constitution_citations?.length > 0),
+      hasEscalations: verdicts.some(v => v.escalation_required),
       dataSource: 'judge_verdicts',
     };
   } catch (err) {

--- a/tests/eva/s20-judge-verdicts.test.js
+++ b/tests/eva/s20-judge-verdicts.test.js
@@ -1,0 +1,80 @@
+/**
+ * Tests for fetchJudgeVerdicts enrichment
+ * SD-LEO-INFRA-S20-BUILD-REPORT-001 (Gap 4)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { fetchJudgeVerdicts } from '../../lib/eva/stage-templates/analysis-steps/stage-20-build-execution.js';
+
+const logger = { log: vi.fn(), warn: vi.fn() };
+
+function buildMockSupabase({ sds = [], sessions = [], verdicts = [], sdError = null, sessError = null, vError = null } = {}) {
+  return {
+    from: vi.fn((table) => {
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        in: () => chain,
+        order: () => chain,
+        limit: () => chain,
+        then: (fn) => {
+          if (table === 'strategic_directives_v2') return fn({ data: sds, error: sdError });
+          if (table === 'debate_sessions') return fn({ data: sessions, error: sessError });
+          if (table === 'judge_verdicts') return fn({ data: verdicts, error: vError });
+          return fn({ data: [], error: null });
+        },
+      };
+      return chain;
+    }),
+  };
+}
+
+describe('fetchJudgeVerdicts()', () => {
+  it('returns enrichment when venture has verdicts via debate sessions', async () => {
+    const supabase = buildMockSupabase({
+      sds: [{ id: 'sd-1', sd_key: 'SD-001' }],
+      sessions: [{ id: 'sess-1' }],
+      verdicts: [
+        { verdict_type: 'synthesis', confidence_score: 0.85, summary: 'Board consensus reached', constitution_citations: [], escalation_required: false, created_at: '2026-01-01T00:00:00Z', debate_session_id: 'sess-1' },
+        { verdict_type: 'synthesis', confidence_score: 0.92, summary: 'Strong alignment', constitution_citations: ['ART-1'], escalation_required: false, created_at: '2026-01-02T00:00:00Z', debate_session_id: 'sess-1' },
+      ],
+    });
+
+    const result = await fetchJudgeVerdicts(supabase, 'venture-123', logger);
+
+    expect(result).not.toBeNull();
+    expect(result.verdictScore).toBeCloseTo(0.89, 1);
+    expect(result.verdictCount).toBe(2);
+    expect(result.verdictTypes.synthesis).toBe(2);
+    expect(result.topRecommendations).toEqual(['Board consensus reached', 'Strong alignment']);
+    expect(result.hasConstitutionalCitations).toBe(true);
+    expect(result.dataSource).toBe('judge_verdicts');
+  });
+
+  it('returns null when venture has no SDs', async () => {
+    const supabase = buildMockSupabase({ sds: [] });
+    const result = await fetchJudgeVerdicts(supabase, 'venture-123', logger);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when SDs have no debate sessions', async () => {
+    const supabase = buildMockSupabase({
+      sds: [{ id: 'sd-1', sd_key: 'SD-001' }],
+      sessions: [],
+    });
+    const result = await fetchJudgeVerdicts(supabase, 'venture-123', logger);
+    expect(result).toBeNull();
+  });
+
+  it('returns null and logs warning on DB error', async () => {
+    const supabase = {
+      from: vi.fn(() => { throw new Error('Connection refused'); }),
+    };
+    const result = await fetchJudgeVerdicts(supabase, 'venture-123', logger);
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Judge verdict fetch failed'),
+      expect.objectContaining({ error: 'Connection refused' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fix fetchJudgeVerdicts() to filter by venture SD IDs via debate_sessions join
- Fix column name mismatches (verdict_type, confidence_score, constitution_citations)
- 4 unit tests added

## Test plan
- [x] 4 unit tests passing (filtered results, no SDs, no sessions, DB error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)