### PR TITLE
fix(provisioner): remove manual Sentry setup fallback messages

### DIFF
--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -354,7 +354,7 @@ services:
 
       // Attempt auto-creation of Sentry project via API
       let sentryDsn = null;
-      if (sentryToken && sentryToken !== 'pending-manual-setup') {
+      if (sentryToken) {
         try {
           // List teams to find the default team
           const teamsRes = await fetch(`${sentryBaseUrl}/api/0/organizations/${sentryOrg}/teams/`, {
@@ -406,17 +406,17 @@ services:
           } else {
             const errBody = await createRes.text();
             ctx.log(`[monitoring_baseline] Sentry project creation failed (${createRes.status}): ${errBody.slice(0, 200)}`);
-            ctx.log('[monitoring_baseline] Falling back to manual setup — add project:write scope to auth token to enable auto-creation');
+            ctx.log('[monitoring_baseline] Sentry project creation failed — check SENTRY_AUTH_TOKEN has project:write scope');
           }
         } catch (err) {
-          ctx.log(`[monitoring_baseline] Sentry API unavailable: ${err.message} — falling back to manual setup`);
+          ctx.log(`[monitoring_baseline] Sentry API error: ${err.message}`);
         }
       }
 
       const sentryConfig = existingMetadata.sentry || {
         org: sentryOrg,
         project: projectSlug,
-        token: sentryToken || 'pending-manual-setup',
+        token: sentryToken,
         baseUrl: sentryBaseUrl,
         dsn: sentryDsn,
         lastPollAt: null
@@ -444,7 +444,7 @@ services:
 
       ctx.log(`[monitoring_baseline] Sentry config registered for ${ctx.venture.repoName}`);
       ctx.log('[monitoring_baseline] Guardrail state initialized');
-      if (!sentryDsn) ctx.log('[monitoring_baseline] Note: DSN not obtained — create Sentry project manually or add project:write scope to token');
+      if (!sentryDsn) ctx.log('[monitoring_baseline] Warning: DSN not obtained — Sentry project may need investigation');
     },
   },
 ];


### PR DESCRIPTION
## Summary
- Remove `pending-manual-setup` default and manual setup log messages from provisioner Step 18
- Internal Integration token now has full API access — Step 18 is fully automated

## Test plan
- [x] Sentry API scope verification: team:read PASS, project:write PASS, issue:read PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)