### PR TITLE
feat(SD-LEO-ORCH-GSTACK-TASTE-GATE-001-C): taste gate observability metrics API

### DIFF
--- a/lib/eva/taste-confidence-tracker.js
+++ b/lib/eva/taste-confidence-tracker.js
@@ -86,6 +86,53 @@ export async function computeConfidence(gateType, options = {}) {
 }
 
 /**
+ * Get comprehensive metrics for the observability dashboard.
+ * Returns all data needed by TasteConfidenceMetrics widget.
+ * SD: SD-LEO-ORCH-GSTACK-TASTE-GATE-001-C
+ *
+ * @param {string} gateType - 'design', 'scope', or 'architecture'
+ * @returns {Promise<object>} Dashboard metrics
+ */
+export async function getDashboardMetrics(gateType) {
+  const supabase = createSupabaseServiceClient();
+  const confidence = await computeConfidence(gateType);
+
+  const { data: allDecisions } = await supabase
+    .from('taste_interaction_logs')
+    .select('decision, source, created_at')
+    .eq('gate_type', gateType)
+    .order('created_at', { ascending: false })
+    .limit(50);
+
+  const total = allDecisions?.length || 0;
+  const approvals = allDecisions?.filter(d => d.decision === 'approve').length || 0;
+  const passRate = total > 0 ? Math.round((approvals / total) * 100) : 0;
+
+  const overrides = allDecisions?.filter(d =>
+    (d.source === 'system' || d.source === 'timeout') && d.decision !== 'approve'
+  ).length || 0;
+  const overrideRate = total > 0 ? Math.round((overrides / total) * 100) : 0;
+
+  const { data: profile } = await supabase
+    .from('taste_profiles')
+    .select('trust_level')
+    .eq('gate_type', gateType)
+    .is('venture_id', null)
+    .maybeSingle();
+
+  return {
+    gateType,
+    confidence: confidence.confidence,
+    totalDecisions: confidence.totalDecisions,
+    driftAlert: confidence.driftAlert,
+    passRate,
+    overrideRate,
+    trustLevel: profile?.trust_level || 'manual',
+    decisionsForPromotion: Math.max(0, 15 - confidence.totalDecisions),
+  };
+}
+
+/**
  * Check if a gate type has sufficient decisions for trust promotion.
  *
  * @param {string} gateType


### PR DESCRIPTION
## Summary
- Add getDashboardMetrics() to taste-confidence-tracker.js
- Returns: confidence, pass rate, override rate, drift alert, trust level, decisions needed for promotion
- Backend API for EHG app dashboard components (TasteGateReviewPanel, TasteConfidenceMetrics, TrustPromotionControl)
- Dashboard UI components will be built in the EHG app repo separately

## Test plan
- [ ] getDashboardMetrics returns correct structure with empty tables (cold start)
- [ ] Pass rate computes correctly from taste_interaction_logs
- [ ] Drift alert triggers at 15-point divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)