### PR TITLE
feat(SD-LEO-INFRA-GOOGLE-STITCH-DESIGN-001-B): Stitch provisioner post-Stage-15 hook

### DIFF
--- a/lib/eva/bridge/stitch-provisioner.js
+++ b/lib/eva/bridge/stitch-provisioner.js
@@ -1,0 +1,326 @@
+/**
+ * Stitch Provisioner - Post-Stage-15 Design Project Provisioning
+ * SD-LEO-INFRA-GOOGLE-STITCH-DESIGN-001-B
+ *
+ * Provisions a Google Stitch design project from EVA pipeline artifacts.
+ * Reads Stage 11 (visual identity) and Stage 15 (wireframe) data,
+ * constructs text prompts, and calls stitch-client to create project
+ * and generate design screens.
+ *
+ * Guarded by governance flags in chairman_dashboard_config.taste_gate_config.
+ *
+ * @module eva/bridge/stitch-provisioner
+ * @version 1.0.0
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const supabase = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
+);
+
+// ---------------------------------------------------------------------------
+// Stitch Client Loader (lazy, supports test injection)
+// ---------------------------------------------------------------------------
+
+let _stitchClient = null;
+let _stitchClientLoader = null;
+
+export function setStitchClientLoader(loader) {
+  _stitchClientLoader = loader;
+  _stitchClient = null;
+}
+
+async function getStitchClient() {
+  if (_stitchClient) return _stitchClient;
+  if (_stitchClientLoader) {
+    _stitchClient = await _stitchClientLoader();
+    return _stitchClient;
+  }
+  // Default: try to load from EHG repo's bridge directory
+  try {
+    const mod = await import(/* @vite-ignore */ '../../ehg/lib/eva/bridge/stitch-client.js');
+    _stitchClient = mod;
+    return _stitchClient;
+  } catch {
+    // Fallback: try relative path in same repo
+    try {
+      const mod = await import(/* @vite-ignore */ './stitch-client.js');
+      _stitchClient = mod;
+      return _stitchClient;
+    } catch (err) {
+      throw new Error(`Cannot load stitch-client: ${err.message}. Ensure @google/stitch-sdk is available.`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Governance Flag Check
+// ---------------------------------------------------------------------------
+
+async function checkGovernanceFlags() {
+  const { data, error } = await supabase
+    .from('chairman_dashboard_config')
+    .select('taste_gate_config')
+    .limit(1)
+    .single();
+
+  if (error || !data?.taste_gate_config) {
+    return { enabled: false, reason: 'governance_config_unavailable' };
+  }
+
+  const config = data.taste_gate_config;
+
+  if (!config.stitch_enabled) {
+    return { enabled: false, reason: 'stitch_disabled' };
+  }
+  if (!config.stitch_auto_provision) {
+    return { enabled: false, reason: 'auto_provision_disabled' };
+  }
+
+  return { enabled: true, config };
+}
+
+// ---------------------------------------------------------------------------
+// Artifact Readers
+// ---------------------------------------------------------------------------
+
+function extractStage11Tokens(stage11Artifacts) {
+  const tokens = {};
+
+  // Color palette
+  if (stage11Artifacts?.colorPalette) {
+    tokens.colors = Array.isArray(stage11Artifacts.colorPalette)
+      ? stage11Artifacts.colorPalette
+      : [stage11Artifacts.colorPalette];
+  } else if (stage11Artifacts?.visual_identity?.color_palette) {
+    tokens.colors = stage11Artifacts.visual_identity.color_palette;
+  }
+
+  // Typography
+  if (stage11Artifacts?.typography) {
+    tokens.fonts = Array.isArray(stage11Artifacts.typography)
+      ? stage11Artifacts.typography.map(t => typeof t === 'string' ? t : t.name || t.family)
+      : [stage11Artifacts.typography];
+  } else if (stage11Artifacts?.visual_identity?.typography) {
+    tokens.fonts = [stage11Artifacts.visual_identity.typography];
+  }
+
+  // Brand expression / personality
+  if (stage11Artifacts?.brandExpression) {
+    tokens.personality = stage11Artifacts.brandExpression;
+  } else if (stage11Artifacts?.brand_expression) {
+    tokens.personality = stage11Artifacts.brand_expression;
+  } else if (stage11Artifacts?.visual_identity?.brand_personality) {
+    tokens.personality = stage11Artifacts.visual_identity.brand_personality;
+  }
+
+  return tokens;
+}
+
+function extractStage15Screens(stage15Artifacts) {
+  // Try screens array directly
+  if (Array.isArray(stage15Artifacts?.screens)) {
+    return stage15Artifacts.screens;
+  }
+  // Try wireframes.screens
+  if (Array.isArray(stage15Artifacts?.wireframes?.screens)) {
+    return stage15Artifacts.wireframes.screens;
+  }
+  // Try navigation_flows as screen source
+  if (Array.isArray(stage15Artifacts?.navigation_flows)) {
+    return stage15Artifacts.navigation_flows.map(flow => ({
+      name: flow.name || flow.screen_name,
+      purpose: flow.purpose || flow.description,
+      key_components: flow.components || [],
+    }));
+  }
+
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Prompt Construction
+// ---------------------------------------------------------------------------
+
+function buildScreenPrompt(screen, brandTokens, ventureName) {
+  const parts = [];
+
+  parts.push(`Design a ${screen.name || 'screen'} for ${ventureName || 'the application'}.`);
+
+  if (screen.purpose) {
+    parts.push(`Purpose: ${screen.purpose}`);
+  }
+
+  // Brand tokens
+  if (brandTokens.colors?.length > 0) {
+    parts.push(`Color palette: ${brandTokens.colors.slice(0, 5).join(', ')}`);
+  }
+  if (brandTokens.fonts?.length > 0) {
+    parts.push(`Typography: ${brandTokens.fonts.join(', ')}`);
+  }
+  if (brandTokens.personality) {
+    const personality = typeof brandTokens.personality === 'string'
+      ? brandTokens.personality
+      : JSON.stringify(brandTokens.personality);
+    parts.push(`Brand personality: ${personality}`);
+  }
+
+  // Screen components
+  if (screen.key_components?.length > 0) {
+    parts.push(`Key components: ${screen.key_components.join(', ')}`);
+  }
+
+  return parts.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Artifact Storage
+// ---------------------------------------------------------------------------
+
+async function storeStitchArtifact(ventureId, projectId, projectUrl, screenCount) {
+  const { error } = await supabase
+    .from('venture_artifacts')
+    .upsert({
+      venture_id: ventureId,
+      artifact_type: 'stitch_project',
+      data: {
+        project_id: projectId,
+        url: projectUrl,
+        screen_count: screenCount,
+        provisioned_at: new Date().toISOString(),
+      },
+    }, { onConflict: 'venture_id,artifact_type' });
+
+  if (error) {
+    console.error(`[stitch-provisioner] Failed to store artifact: ${error.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main Entry Point
+// ---------------------------------------------------------------------------
+
+/**
+ * Provision a Stitch design project from Stage 11+15 artifacts.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} stage11Artifacts - Stage 11 visual identity data
+ * @param {Object} stage15Artifacts - Stage 15 wireframe/screen data
+ * @param {Object} [options] - Additional options
+ * @param {string} [options.ventureName] - Venture name for prompts
+ * @returns {Promise<{status: string, project_id?: string, url?: string, screens?: number}>}
+ */
+export async function provisionStitchProject(ventureId, stage11Artifacts, stage15Artifacts, options = {}) {
+  // Step 1: Check governance flags
+  const governance = await checkGovernanceFlags();
+  if (!governance.enabled) {
+    console.info(`[stitch-provisioner] Skipping: ${governance.reason}`);
+    return { status: 'no_op', reason: governance.reason };
+  }
+
+  // Step 2: Extract brand tokens from Stage 11
+  const brandTokens = extractStage11Tokens(stage11Artifacts);
+
+  // Step 3: Extract screens from Stage 15
+  const screens = extractStage15Screens(stage15Artifacts);
+  if (screens.length === 0) {
+    console.warn('[stitch-provisioner] No screens found in Stage 15 artifacts');
+    return { status: 'no_op', reason: 'no_screens' };
+  }
+
+  // Step 4: Build prompts
+  const prompts = screens.map(screen =>
+    buildScreenPrompt(screen, brandTokens, options.ventureName)
+  );
+
+  // Step 5: Create project via stitch-client
+  const client = await getStitchClient();
+
+  const project = await client.createProject({
+    name: `${options.ventureName || ventureId} - Design Screens`,
+    brandTokens,
+    screenDescriptions: prompts,
+    ventureId,
+  });
+
+  // Step 6: Generate screens
+  const generatedScreens = await client.generateScreens(
+    project.project_id,
+    prompts,
+    ventureId
+  );
+
+  // Step 7: Store artifact
+  await storeStitchArtifact(
+    ventureId,
+    project.project_id,
+    project.url,
+    generatedScreens.length
+  );
+
+  console.info(`[stitch-provisioner] Project provisioned: ${project.project_id} (${generatedScreens.length} screens)`);
+
+  return {
+    status: 'provisioned',
+    project_id: project.project_id,
+    url: project.url,
+    screens: generatedScreens.length,
+  };
+}
+
+/**
+ * Non-blocking hook for Stage 15 post-completion.
+ * Catches all errors to prevent blocking stage progression.
+ *
+ * @param {string} ventureId - Venture UUID
+ * @param {Object} stageData - Stage 15 completion data
+ */
+export async function postStage15Hook(ventureId, stageData) {
+  try {
+    // Fetch Stage 11 artifacts
+    const { data: s11 } = await supabase
+      .from('venture_stage_work')
+      .select('advisory_data')
+      .eq('venture_id', ventureId)
+      .eq('stage_number', 11)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    const result = await provisionStitchProject(
+      ventureId,
+      s11?.advisory_data || {},
+      stageData?.advisory_data || stageData || {},
+      { ventureName: stageData?.venture_name }
+    );
+
+    // Log result to advisory_data for visibility
+    if (result.status !== 'no_op') {
+      await supabase
+        .from('venture_stage_work')
+        .update({
+          advisory_data: supabase.rpc ? undefined : {
+            ...stageData?.advisory_data,
+            stitch_provisioning: result,
+          },
+        })
+        .eq('venture_id', ventureId)
+        .eq('stage_number', 15)
+        .order('created_at', { ascending: false })
+        .limit(1);
+    }
+
+    return result;
+  } catch (err) {
+    console.error(`[stitch-provisioner] Post-Stage-15 hook failed (non-blocking): ${err.message}`);
+    return { status: 'error', error: err.message };
+  }
+}
+
+// Export for testing
+export { extractStage11Tokens, extractStage15Screens, buildScreenPrompt, checkGovernanceFlags };

--- a/tests/unit/eva/bridge/stitch-provisioner.test.js
+++ b/tests/unit/eva/bridge/stitch-provisioner.test.js
@@ -1,0 +1,238 @@
+/**
+ * Unit tests for Stitch Provisioner
+ * SD-LEO-INFRA-GOOGLE-STITCH-DESIGN-001-B
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock Supabase
+const mockSingle = vi.fn();
+const mockLimit = vi.fn(() => ({ single: mockSingle }));
+const mockOrder = vi.fn(() => ({ limit: mockLimit }));
+const mockEq2 = vi.fn(() => ({ order: mockOrder, single: mockSingle }));
+const mockEq1 = vi.fn(() => ({ eq: mockEq2, order: mockOrder }));
+const mockSelect = vi.fn(() => ({ eq: mockEq1, limit: mockLimit }));
+const mockUpsert = vi.fn().mockResolvedValue({ error: null });
+const mockUpdate = vi.fn(() => ({ eq: mockEq1 }));
+const mockFrom = vi.fn(() => ({
+  select: mockSelect,
+  upsert: mockUpsert,
+  update: mockUpdate,
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ from: mockFrom })),
+}));
+vi.mock('dotenv', () => ({ default: { config: vi.fn() }, config: vi.fn() }));
+
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+
+// Mock stitch client
+const mockStitchClient = {
+  createProject: vi.fn(),
+  generateScreens: vi.fn(),
+};
+
+const {
+  provisionStitchProject,
+  postStage15Hook,
+  extractStage11Tokens,
+  extractStage15Screens,
+  buildScreenPrompt,
+  checkGovernanceFlags,
+  setStitchClientLoader,
+} = await import('../../../../lib/eva/bridge/stitch-provisioner.js');
+
+describe('stitch-provisioner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setStitchClientLoader(async () => mockStitchClient);
+
+    // Default: governance enabled
+    mockSingle.mockResolvedValue({
+      data: {
+        taste_gate_config: {
+          stitch_enabled: true,
+          stitch_auto_provision: true,
+        },
+      },
+      error: null,
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // extractStage11Tokens
+  // -----------------------------------------------------------------------
+  describe('extractStage11Tokens', () => {
+    it('extracts colorPalette, typography, brandExpression', () => {
+      const tokens = extractStage11Tokens({
+        colorPalette: ['#FF0000', '#00FF00'],
+        typography: ['Inter', 'Roboto'],
+        brandExpression: 'Modern, clean, professional',
+      });
+
+      expect(tokens.colors).toEqual(['#FF0000', '#00FF00']);
+      expect(tokens.fonts).toEqual(['Inter', 'Roboto']);
+      expect(tokens.personality).toBe('Modern, clean, professional');
+    });
+
+    it('handles visual_identity nested format', () => {
+      const tokens = extractStage11Tokens({
+        visual_identity: {
+          color_palette: ['#123456'],
+          typography: 'Poppins',
+          brand_personality: 'Bold',
+        },
+      });
+
+      expect(tokens.colors).toEqual(['#123456']);
+      expect(tokens.fonts).toEqual(['Poppins']);
+      expect(tokens.personality).toBe('Bold');
+    });
+
+    it('handles missing fields gracefully', () => {
+      const tokens = extractStage11Tokens({});
+      expect(tokens.colors).toBeUndefined();
+      expect(tokens.fonts).toBeUndefined();
+      expect(tokens.personality).toBeUndefined();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // extractStage15Screens
+  // -----------------------------------------------------------------------
+  describe('extractStage15Screens', () => {
+    it('extracts screens array directly', () => {
+      const screens = extractStage15Screens({
+        screens: [
+          { name: 'Home', purpose: 'Landing page', key_components: ['hero', 'nav'] },
+        ],
+      });
+      expect(screens).toHaveLength(1);
+      expect(screens[0].name).toBe('Home');
+    });
+
+    it('extracts from wireframes.screens', () => {
+      const screens = extractStage15Screens({
+        wireframes: { screens: [{ name: 'Dashboard' }] },
+      });
+      expect(screens).toHaveLength(1);
+    });
+
+    it('falls back to navigation_flows', () => {
+      const screens = extractStage15Screens({
+        navigation_flows: [{ name: 'Login', purpose: 'Auth', components: ['form'] }],
+      });
+      expect(screens).toHaveLength(1);
+      expect(screens[0].key_components).toEqual(['form']);
+    });
+
+    it('returns empty array when no screens found', () => {
+      expect(extractStage15Screens({})).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // buildScreenPrompt
+  // -----------------------------------------------------------------------
+  describe('buildScreenPrompt', () => {
+    it('includes brand tokens and screen context', () => {
+      const prompt = buildScreenPrompt(
+        { name: 'Dashboard', purpose: 'Analytics overview', key_components: ['charts', 'KPIs'] },
+        { colors: ['#FF0000'], fonts: ['Inter'], personality: 'Professional' },
+        'TestApp'
+      );
+
+      expect(prompt).toContain('Dashboard');
+      expect(prompt).toContain('TestApp');
+      expect(prompt).toContain('#FF0000');
+      expect(prompt).toContain('Inter');
+      expect(prompt).toContain('Professional');
+      expect(prompt).toContain('charts, KPIs');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Governance checks
+  // -----------------------------------------------------------------------
+  describe('governance', () => {
+    it('returns no_op when stitch_enabled=false', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: { taste_gate_config: { stitch_enabled: false, stitch_auto_provision: true } },
+        error: null,
+      });
+
+      const result = await provisionStitchProject('v1', {}, { screens: [{ name: 'Home' }] });
+
+      expect(result.status).toBe('no_op');
+      expect(result.reason).toBe('stitch_disabled');
+      expect(mockStitchClient.createProject).not.toHaveBeenCalled();
+    });
+
+    it('returns no_op when stitch_auto_provision=false', async () => {
+      mockSingle.mockResolvedValueOnce({
+        data: { taste_gate_config: { stitch_enabled: true, stitch_auto_provision: false } },
+        error: null,
+      });
+
+      const result = await provisionStitchProject('v1', {}, { screens: [{ name: 'Home' }] });
+
+      expect(result.status).toBe('no_op');
+      expect(result.reason).toBe('auto_provision_disabled');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // provisionStitchProject
+  // -----------------------------------------------------------------------
+  describe('provisionStitchProject', () => {
+    it('creates project and generates screens on success', async () => {
+      mockStitchClient.createProject.mockResolvedValue({
+        project_id: 'proj-789',
+        url: 'https://stitch.withgoogle.com/project/proj-789',
+      });
+      mockStitchClient.generateScreens.mockResolvedValue([
+        { screen_id: 's1', name: 'Home' },
+        { screen_id: 's2', name: 'About' },
+      ]);
+
+      const result = await provisionStitchProject(
+        'venture-123',
+        { colorPalette: ['#FF0000'], typography: ['Inter'], brandExpression: 'Modern' },
+        { screens: [{ name: 'Home', purpose: 'Landing' }, { name: 'About', purpose: 'Info' }] },
+        { ventureName: 'TestApp' }
+      );
+
+      expect(result.status).toBe('provisioned');
+      expect(result.project_id).toBe('proj-789');
+      expect(result.screens).toBe(2);
+      expect(mockStitchClient.createProject).toHaveBeenCalledOnce();
+      expect(mockStitchClient.generateScreens).toHaveBeenCalledOnce();
+      expect(mockUpsert).toHaveBeenCalled(); // artifact stored
+    });
+
+    it('returns no_op when no screens in artifacts', async () => {
+      const result = await provisionStitchProject('v1', {}, {});
+
+      expect(result.status).toBe('no_op');
+      expect(result.reason).toBe('no_screens');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // postStage15Hook
+  // -----------------------------------------------------------------------
+  describe('postStage15Hook', () => {
+    it('catches errors without blocking', async () => {
+      mockStitchClient.createProject.mockRejectedValue(new Error('API down'));
+
+      const result = await postStage15Hook('v1', {
+        screens: [{ name: 'Home' }],
+      });
+
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('API down');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `lib/eva/bridge/stitch-provisioner.js` — auto-provisions Stitch design projects from Stage 11+15 artifacts
- Constructs text prompts combining brand tokens (colors, fonts, personality) with screen context
- Governance-gated via `stitch_enabled` and `stitch_auto_provision` flags
- Stores project_id and URL in `venture_artifacts` table
- Non-blocking `postStage15Hook` catches all errors to prevent blocking stage progression
- 13 unit tests covering artifact extraction, prompt construction, governance, and error handling

## Test plan
- [x] 13 vitest unit tests pass (mocked stitch-client and Supabase)
- [x] Governance flag enforcement verified (no_op when disabled)
- [x] Error handling verified (non-blocking hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)