### PR TITLE
chore: unify all model routing to Opus

### DIFF
--- a/.claude/commands/doc-audit.md
+++ b/.claude/commands/doc-audit.md
@@ -7,7 +7,7 @@ tools:
   - Write
   - Glob
   - Grep
-model: sonnet
+model: opus
 ---
 
 # /doc-audit - Documentation Health Audit

--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -9,7 +9,7 @@ tools:
   - Glob
   - Edit
   - Task
-model: sonnet
+model: opus
 ---
 
 # Intelligent Documentation Command (/document)

--- a/.claude/skills/testing-agent.md
+++ b/.claude/skills/testing-agent.md
@@ -5,7 +5,7 @@ tools:
   - Bash
   - Read
   - Write
-model: sonnet
+model: opus
 agent: TESTING
 hooks:
   PreToolUse:


### PR DESCRIPTION
## Summary
- Switch `/doc-audit`, `/document`, and `testing-agent` skill from Sonnet to Opus
- All agents, commands, and skills now consistently use Opus model routing

## Test plan
- [x] Smoke tests pass (15/15)
- [ ] Verify `/doc-audit`, `/document` commands invoke with Opus
- [ ] Verify testing-agent skill runs on Opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)