### PR TITLE
chore: add PostEdit type-check hook and Friday meeting learning insights

### DIFF
--- a/.claude/commands/friday.md
+++ b/.claude/commands/friday.md
@@ -79,3 +79,4 @@ Friday Meeting Complete
 - Only high-confidence findings (confidence_tier='high') appear in the meeting
 - Management review data comes from management-review-round.mjs
 - Decisions feed back into the confidence engine to improve future analysis
+- **Section 5d (Learning Insights)** runs every other week (even ISO weeks) — shows approval rates, recurrence monitoring, and top rejection reasons from `/learn insights`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -105,6 +105,17 @@
         ]
       },
       {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsc --noEmit --pretty 2>&1 | head -20 || true",
+            "timeout": 30,
+            "statusMessage": "Type-checking..."
+          }
+        ]
+      },
+      {
         "matcher": "Read",
         "hooks": [
           {

--- a/scripts/eva/friday-meeting.mjs
+++ b/scripts/eva/friday-meeting.mjs
@@ -7,6 +7,7 @@
  * 3. Consultant Findings — high-confidence recommendations by domain
  * 4. Intake Review — pending intake items
  * 5. R&D Proposals — skunkworks batch proposals for chairman review
+ * 5d. Learning Insights — approval rates, recurrence, rejections (biweekly)
  * 6. Decisions — interactive accept/dismiss via AskUserQuestion
  *
  * SD-MAN-ORCH-FRIDAY-EVA-AUTONOMOUS-001-B
@@ -16,6 +17,7 @@
 import { createSupabaseServiceClient } from '../../lib/supabase-client.js';
 import { getLLMClient } from '../../lib/llm/client-factory.js';
 import { gatherRdProposals as _gatherRdProposals, renderRdProposals as _renderRdProposals, buildCombinedDecisionPayload as _buildCombinedDecisionPayload, processRdProposalDecision as _processRdProposalDecision } from '../../lib/skunkworks/friday-rd-section.js';
+import { buildInsightsReport, formatInsightsForDisplay } from '../modules/learning/insights.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -339,6 +341,34 @@ function renderPluginDiscoveries(data) {
   return lines.join('\n');
 }
 
+// ─── Section 5d: Learning Insights (biweekly) ──────────────
+
+function isInsightsWeek() {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), 0, 1);
+  const dayOfYear = Math.floor((now - start) / 86400000);
+  const weekNumber = Math.ceil((dayOfYear + start.getDay() + 1) / 7);
+  return weekNumber % 2 === 0;
+}
+
+async function gatherLearningInsights() {
+  if (!isInsightsWeek()) return null;
+  try {
+    return await buildInsightsReport();
+  } catch (err) {
+    logger.warn(`  Learning insights failed (non-blocking): ${err.message}`);
+    return null;
+  }
+}
+
+function renderLearningInsights(data) {
+  if (!data) return '';
+
+  const lines = ['', '  SECTION 5d: LEARNING INSIGHTS (biweekly)', '  ' + '─'.repeat(40)];
+  lines.push(formatInsightsForDisplay(data));
+  return lines.join('\n');
+}
+
 // ─── Section 6: Decisions ────────────────────────────────────
 
 function buildDecisionPayload(findings) {
@@ -536,7 +566,7 @@ export async function fridayMeetingHandler(options = {}) {
   logger.log('═'.repeat(55));
 
   // Gather all data in parallel
-  const [perfData, capData, consultData, intakeData, rdData, fleetData, pluginData] = await Promise.all([
+  const [perfData, capData, consultData, intakeData, rdData, fleetData, pluginData, insightsData] = await Promise.all([
     gatherPerformanceReview(),
     gatherCapabilityReport(),
     gatherConsultantFindings(),
@@ -544,6 +574,7 @@ export async function fridayMeetingHandler(options = {}) {
     gatherRdProposals(),
     gatherFleetTelemetry(),
     gatherPluginDiscoveries(),
+    gatherLearningInsights(),
   ]);
 
   // Render sections 1-5b
@@ -554,6 +585,7 @@ export async function fridayMeetingHandler(options = {}) {
   logger.log(renderRdProposals(rdData));
   logger.log(renderFleetTelemetry(fleetData));
   logger.log(renderPluginDiscoveries(pluginData));
+  logger.log(renderLearningInsights(insightsData));
 
   // Section 6: Decisions
   logger.log('');
@@ -570,6 +602,7 @@ export async function fridayMeetingHandler(options = {}) {
       intake: { pendingItems: intakeData.pending.length },
       rd_proposals: { pendingProposals: rdData.proposals.length, sources: Object.keys(rdData.grouped).length },
       plugin_pipeline: { scannedThisWeek: pluginData?.total || 0 },
+      learning_insights: { included: !!insightsData, isInsightsWeek: isInsightsWeek() },
     },
     decisions: { accepted: 0, dismissed: 0, deferred: 0, total: totalDecisionItems },
   };

--- a/scripts/modules/learning/insights.js
+++ b/scripts/modules/learning/insights.js
@@ -229,7 +229,7 @@ export function formatInsightsForDisplay(insights) {
 }
 
 // CLI interface
-if (process.argv[1].includes('insights')) {
+if (process.argv[1]?.includes('insights')) {
   buildInsightsReport()
     .then(insights => {
       console.log(formatInsightsForDisplay(insights));


### PR DESCRIPTION
## Summary
- Add `PostToolUse` hook on `Edit` that runs `tsc --noEmit` after edits to catch UUID/JSONB type mismatches early
- Integrate biweekly learning insights into Friday meeting Section 5d (approval rates, recurrence monitoring, top rejection reasons)
- Fix null-safety issue in `insights.js` CLI entry point (`process.argv[1]?.includes`)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] ESLint auto-fix clean
- [x] `tsc --noEmit` pipe-tested successfully
- [ ] Verify hook fires after next Edit tool call
- [ ] Verify Friday meeting renders Section 5d on even ISO weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)