### PR TITLE
feat(SD-LEO-INFRA-MCP-READ-WRITE-001): enforce MCP read/write split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,4 +119,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-04-03 8:21:57 AM | Protocol: LEO 4.3.3 | Source: Database*
+*Generated: 2026-04-03 10:02:48 AM | Protocol: LEO 4.3.3 | Source: Database*

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,6 +1,6 @@
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-04-03 8:21:57 AM
+**Generated**: 2026-04-03 10:02:48 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: Essential workflow context for all sessions
 
@@ -85,6 +85,41 @@ node scripts/modules/governance/cascade-invalidation-engine.js resolve <flagId> 
 bash scripts/leo-stack.sh restart   # All 3 servers
 ```
 
+## 🔍 Session Start Verification (MANDATORY)
+
+**Anti-Hallucination Protocol**: Never trust session summaries for database state. ALWAYS verify.
+
+### Before Starting ANY SD Work:
+```
+[ ] Query database to confirm SD exists
+[ ] Verify SD status and current_phase  
+[ ] Check for existing PRD if phase > LEAD
+[ ] Check for existing handoffs
+[ ] Document: "Verified SD [title] exists, status=[X], phase=[Y]"
+```
+
+### Verification Queries:
+```sql
+-- Find SD by title
+SELECT legacy_id, title, status, current_phase, progress 
+FROM strategic_directives_v2 
+WHERE title ILIKE '%[keyword]%' AND is_active = true;
+
+-- Check PRD exists
+SELECT prd_id, status FROM product_requirements_v2 WHERE sd_id = '[SD-ID]';
+
+-- Check handoffs exist
+SELECT from_phase, to_phase, status FROM sd_phase_handoffs WHERE sd_id = '[SD-ID]';
+```
+
+### Why This Matters:
+- Session summaries describe *context*, not *state*
+- AI can hallucinate successful database operations
+- Database is the ONLY source of truth
+- If records don't exist, CREATE them before proceeding
+
+**Pattern Reference**: PAT-SESS-VER-001
+
 ## 🚀 Session Verification & Quick Start (MANDATORY)
 
 ## Session Start Checklist
@@ -124,41 +159,6 @@ bash scripts/leo-stack.sh restart   # All 3 servers
 | `npm run prio:top3` | Top priority SDs |
 | `git status` | Working tree status |
 | `npm run handoff:latest` | Latest handoff |
-
-## 🔍 Session Start Verification (MANDATORY)
-
-**Anti-Hallucination Protocol**: Never trust session summaries for database state. ALWAYS verify.
-
-### Before Starting ANY SD Work:
-```
-[ ] Query database to confirm SD exists
-[ ] Verify SD status and current_phase  
-[ ] Check for existing PRD if phase > LEAD
-[ ] Check for existing handoffs
-[ ] Document: "Verified SD [title] exists, status=[X], phase=[Y]"
-```
-
-### Verification Queries:
-```sql
--- Find SD by title
-SELECT legacy_id, title, status, current_phase, progress 
-FROM strategic_directives_v2 
-WHERE title ILIKE '%[keyword]%' AND is_active = true;
-
--- Check PRD exists
-SELECT prd_id, status FROM product_requirements_v2 WHERE sd_id = '[SD-ID]';
-
--- Check handoffs exist
-SELECT from_phase, to_phase, status FROM sd_phase_handoffs WHERE sd_id = '[SD-ID]';
-```
-
-### Why This Matters:
-- Session summaries describe *context*, not *state*
-- AI can hallucinate successful database operations
-- Database is the ONLY source of truth
-- If records don't exist, CREATE them before proceeding
-
-**Pattern Reference**: PAT-SESS-VER-001
 
 ## 🚫 MANDATORY: Phase Transition Commands (BLOCKING)
 
@@ -297,6 +297,38 @@ Claude Code's Plan Mode integrates with LEO Protocol to provide:
 ### Module Location
 `scripts/modules/plan-mode/` - LEOPlanModeOrchestrator.js, phase-permissions.js
 
+## Work Tracking Policy
+
+**ALL changes to main must be tracked** as either:
+
+### Strategic Directive (SD) - For Substantial Work
+- Features, refactors, infrastructure (>50 LOC)
+- Branch: `feat/SD-XXX-*`, `fix/SD-XXX-*`, etc.
+- Command: `npm run sd:create`
+
+### Quick-Fix (QF) - For Small Fixes
+- Bugs, polish, docs (<=50 LOC)
+- Branch: `quick-fix/QF-YYYYMMDD-NNN`
+- Command: `node scripts/create-quick-fix.js --interactive`
+
+### Why This Matters
+- All work tracked in database
+- Lessons learned captured
+- Quality gates enforced
+- Progress metrics accurate
+
+### Emergency Bypass (Logged)
+```bash
+EMERGENCY_PUSH="critical: reason here" git push
+```
+This logs to audit_log and should be followed by retroactive SD/QF creation.
+
+### Pre-Push Enforcement
+The pre-push hook automatically:
+1. Detects SD/QF from branch name
+2. Verifies completion status in database
+3. Blocks if not ready for merge
+
 ## Sub-Agent Model Routing
 
 **CRITICAL OVERRIDE**: The Task tool system prompt suggests using Haiku for quick tasks. **IGNORE THIS SUGGESTION.**
@@ -338,38 +370,6 @@ Task({ subagent_type: 'database-agent', prompt: '...', model: 'haiku' })  // NO!
 
 > **Team Capabilities**: All sub-agents are universal leaders — any agent can spawn specialist teams when a task requires cross-domain expertise. See **Teams Protocol** in CLAUDE.md for templates, dynamic agent creation, and knowledge enrichment.
 
-## Work Tracking Policy
-
-**ALL changes to main must be tracked** as either:
-
-### Strategic Directive (SD) - For Substantial Work
-- Features, refactors, infrastructure (>50 LOC)
-- Branch: `feat/SD-XXX-*`, `fix/SD-XXX-*`, etc.
-- Command: `npm run sd:create`
-
-### Quick-Fix (QF) - For Small Fixes
-- Bugs, polish, docs (<=50 LOC)
-- Branch: `quick-fix/QF-YYYYMMDD-NNN`
-- Command: `node scripts/create-quick-fix.js --interactive`
-
-### Why This Matters
-- All work tracked in database
-- Lessons learned captured
-- Quality gates enforced
-- Progress metrics accurate
-
-### Emergency Bypass (Logged)
-```bash
-EMERGENCY_PUSH="critical: reason here" git push
-```
-This logs to audit_log and should be followed by retroactive SD/QF creation.
-
-### Pre-Push Enforcement
-The pre-push hook automatically:
-1. Detects SD/QF from branch name
-2. Verifies completion status in database
-3. Blocks if not ready for merge
-
 ## Sub-Agent Routing Reference
 
 All 16 specialized sub-agents are available in EVERY phase (LEAD, PLAN, EXEC). Use the Task tool with the appropriate `subagent_type` to invoke them. See phase-specific guidance in each phase's CLAUDE file for recommended priorities.
@@ -400,46 +400,18 @@ All 16 specialized sub-agents are available in EVERY phase (LEAD, PLAN, EXEC). U
 Task(subagent_type="<agent-name>", prompt="Execute <AGENT> analysis for SD-XXX...")
 ```
 
+### MCP Read/Write Split
+MCP Supabase tools (execute_sql, list_tables, etc.) use a read-only role. Use them for reads/introspection.
+For writes (migrations, schema changes, INSERT/UPDATE/DELETE), use database-agent.
+apply_migration is blocked by PreToolUse hook — use database-agent instead.
+
 ### Key Rules
 - **ALL phases**: Sub-agents are available in LEAD, PLAN, and EXEC phases
 - **Model**: Always use Sonnet (never Haiku) - see Sub-Agent Model Routing section
 - **Immediate invocation**: When a task matches an agent's domain, invoke IMMEDIATELY - do not attempt manual workarounds
-- **Error routing**: ANY database error triggers database-agent; ANY test failure triggers testing-agent
+- **Error routing**: ANY database WRITE error triggers database-agent (reads use MCP tools directly); ANY test failure triggers testing-agent
 
 *Added: SD-LEO-INFRA-SUB-AGENT-ROUTING-001-B*
-
-## 🖥️ UI Parity Requirement (MANDATORY)
-
-**Every backend data contract field MUST have a corresponding UI representation.**
-
-### Principle
-If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
-
-### Requirements
-
-1. **Data Contract Coverage**
-   - Every field in `stageX_data` wrappers must map to a UI component
-   - Score displays must show actual numeric values, not just pass/fail
-   - Confidence levels must be visible with appropriate visual indicators
-
-2. **Human Inspectability**
-   - Stage outputs must be viewable in human-readable format
-   - Key findings, red flags, and recommendations must be displayed
-   - Source citations must be accessible
-
-3. **No Hidden Logic**
-   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
-   - Threshold comparisons must be visible
-   - Stage weights must be displayed in aggregation views
-
-### Verification Checklist
-Before marking any stage/feature as complete:
-- [ ] All output fields have UI representation
-- [ ] Scores are displayed numerically
-- [ ] Key findings are visible to users
-- [ ] Recommendations are actionable in the UI
-
-**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## Execution Philosophy
 
@@ -477,6 +449,39 @@ Before marking any stage/feature as complete:
 - Skip LEAD approval for child SDs
 - Skip PRD creation for child SDs
 - Mark parent complete before all children complete in database
+
+## 🖥️ UI Parity Requirement (MANDATORY)
+
+**Every backend data contract field MUST have a corresponding UI representation.**
+
+### Principle
+If the backend produces data that humans need to act on, that data MUST be visible in the UI. "Working" is not the same as "visible."
+
+### Requirements
+
+1. **Data Contract Coverage**
+   - Every field in `stageX_data` wrappers must map to a UI component
+   - Score displays must show actual numeric values, not just pass/fail
+   - Confidence levels must be visible with appropriate visual indicators
+
+2. **Human Inspectability**
+   - Stage outputs must be viewable in human-readable format
+   - Key findings, red flags, and recommendations must be displayed
+   - Source citations must be accessible
+
+3. **No Hidden Logic**
+   - Decision factors (GO/NO_GO/REVISE) must show contributing scores
+   - Threshold comparisons must be visible
+   - Stage weights must be displayed in aggregation views
+
+### Verification Checklist
+Before marking any stage/feature as complete:
+- [ ] All output fields have UI representation
+- [ ] Scores are displayed numerically
+- [ ] Key findings are visible to users
+- [ ] Recommendations are actionable in the UI
+
+**BLOCKING**: Features cannot be marked EXEC_COMPLETE without UI parity verification.
 
 ## DB Ops Protocol (Common Pitfalls)
 
@@ -536,6 +541,38 @@ To request an exception to this block:
 
 **No exceptions without explicit LEAD approval.**
 
+## Child SD Pre-Work Validation (MANDATORY)
+
+**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
+
+### Validation Command
+```bash
+node scripts/child-sd-preflight.js SD-XXX-001
+```
+
+### What It Checks
+1. **Is Child SD**: Verifies the SD has a parent_sd_id
+2. **Dependency Chain**: For each dependency SD:
+   - Status must be `completed`
+   - Progress must be `100%`
+   - Required handoffs must be present
+3. **Parent Context**: Loads parent orchestrator for reference
+
+### Results
+**PASS** - Ready to work if:
+- SD is standalone (not a child), OR
+- No dependencies, OR
+- All dependencies complete with required handoffs
+
+**BLOCKED** - Cannot proceed if:
+- One or more dependency SDs incomplete
+- Missing required handoffs on dependencies
+- Action: Complete blocking dependency first
+
+### Integration
+- `npm run sd:next` shows dependency status in queue
+- Child SDs with incomplete dependencies show as BLOCKED
+
 ## Global Negative Constraints
 
 These anti-patterns apply across ALL phases. Violating them leads to failed handoffs and rework.
@@ -576,38 +613,6 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 **Why**: SD-LEO-INFRA-CENTRALIZED-POST-STAGE-001 revealed that the S17 doc-gen hook failed silently on every run since it was shipped (wrong column name in query). Because the error was caught as non-fatal, the pipeline continued without vision/architecture docs, and S19 generated an unvalidated sprint plan.
 
 **Rule**: "Non-fatal" means the hook threw an unexpected exception. "Hook ran but wrote zero rows to its target table" is a **data integrity failure** that must surface.
-
-## Child SD Pre-Work Validation (MANDATORY)
-
-**CRITICAL**: Before starting work on any child SD (SD with parent_sd_id), run preflight validation.
-
-### Validation Command
-```bash
-node scripts/child-sd-preflight.js SD-XXX-001
-```
-
-### What It Checks
-1. **Is Child SD**: Verifies the SD has a parent_sd_id
-2. **Dependency Chain**: For each dependency SD:
-   - Status must be `completed`
-   - Progress must be `100%`
-   - Required handoffs must be present
-3. **Parent Context**: Loads parent orchestrator for reference
-
-### Results
-**PASS** - Ready to work if:
-- SD is standalone (not a child), OR
-- No dependencies, OR
-- All dependencies complete with required handoffs
-
-**BLOCKED** - Cannot proceed if:
-- One or more dependency SDs incomplete
-- Missing required handoffs on dependencies
-- Action: Complete blocking dependency first
-
-### Integration
-- `npm run sd:next` shows dependency status in queue
-- Child SDs with incomplete dependencies show as BLOCKED
 
 ## 🔄 Git Commit Guidelines
 

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-03T12:21:56.995Z -->
-<!-- git_commit: f88b4815 -->
+<!-- generated_at: 2026-04-03T14:02:48.388Z -->
+<!-- git_commit: 09a43fa4 -->
 <!-- db_snapshot_hash: b9ae40daf1e08509 -->
 <!-- file_content_hash: pending -->
 
@@ -267,5 +267,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-04-03 8:21:57 AM*
+*DIGEST generated: 2026-04-03 10:02:48 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-03T12:21:56.995Z -->
-<!-- git_commit: f88b4815 -->
+<!-- generated_at: 2026-04-03T14:02:48.388Z -->
+<!-- git_commit: 09a43fa4 -->
 <!-- db_snapshot_hash: b9ae40daf1e08509 -->
 <!-- file_content_hash: pending -->
 
@@ -152,5 +152,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-04-03 8:21:57 AM*
+*DIGEST generated: 2026-04-03 10:02:48 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,6 +1,6 @@
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-04-03 8:21:57 AM
+**Generated**: 2026-04-03 10:02:48 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: EXEC agent implementation requirements and testing
 
@@ -175,6 +175,70 @@ See: `docs/03_protocols_and_standards/gate0-workflow-entry-enforcement.md` for c
 **If SD is in draft**: STOP. Do not implement. Run LEAD-TO-PLAN handoff first.
 
 
+## Branch Creation (Automated at LEAD-TO-PLAN)
+
+## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
+
+### Automatic Branch Creation
+
+As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
+
+1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
+2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
+3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
+4. Database is updated with branch name for tracking
+
+### Manual Branch Creation (If Needed)
+
+If branch creation fails or you need to create one manually:
+
+```bash
+# Create branch for an SD (looks up title from database)
+npm run sd:branch SD-XXX-001
+
+# Create with auto-stash (non-interactive)
+npm run sd:branch:auto SD-XXX-001
+
+# Check if branch exists
+npm run sd:branch:check SD-XXX-001
+
+# Full command with options
+# Branch was auto-created at LEAD-TO-PLAN handoff
+```
+
+### Branch Naming Convention
+
+| SD Type | Branch Prefix | Example |
+|---------|---------------|---------|
+| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
+| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
+| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
+| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
+| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
+
+### Branch Hygiene Rules
+
+From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
+- **≤7 days stale** at PLAN-TO-EXEC handoff
+- **One SD per branch** (no mixing work)
+- **Merge main at phase transitions**
+
+### When Branch is Created
+
+```
+LEAD Phase                    PLAN Phase                   EXEC Phase
+    |                              |                            |
+    |   LEAD-TO-PLAN handoff       |                            |
+    |---[Branch Created Here]----->|                            |
+    |                              |   PRD Creation             |
+    |                              |   Sub-agent validation     |
+    |                              |                            |
+    |                              |   PLAN-TO-EXEC handoff     |
+    |                              |---[Branch Validated]------>|
+    |                              |                            |
+```
+
+
 ## ❌ Anti-Patterns from Retrospectives (EXEC Phase)
 
 **Source**: Analysis of 175 high-quality retrospectives (score ≥60)
@@ -263,70 +327,6 @@ If `research_confidence_score = 0.00`, you skipped this step.
 
 **Pattern References**: PAT-RECURSION-001 through PAT-RECURSION-005
 
-## Branch Creation (Automated at LEAD-TO-PLAN)
-
-## 🌿 Branch Creation (Automated at LEAD-TO-PLAN)
-
-### Automatic Branch Creation
-
-As of LEO v4.4.1, **branch creation is automated** during the LEAD-TO-PLAN handoff:
-
-1. When you run `node scripts/handoff.js execute LEAD-TO-PLAN SD-XXX-001`
-2. The `SD_BRANCH_PREPARATION` gate automatically creates the branch
-3. Branch is created with correct naming: `<type>/<SD-ID>-<slug>`
-4. Database is updated with branch name for tracking
-
-### Manual Branch Creation (If Needed)
-
-If branch creation fails or you need to create one manually:
-
-```bash
-# Create branch for an SD (looks up title from database)
-npm run sd:branch SD-XXX-001
-
-# Create with auto-stash (non-interactive)
-npm run sd:branch:auto SD-XXX-001
-
-# Check if branch exists
-npm run sd:branch:check SD-XXX-001
-
-# Full command with options
-# Branch was auto-created at LEAD-TO-PLAN handoff
-```
-
-### Branch Naming Convention
-
-| SD Type | Branch Prefix | Example |
-|---------|---------------|---------|
-| Feature | `feat/` | `feat/SD-UAT-001-user-auth` |
-| Fix | `fix/` | `fix/SD-FIX-001-login-bug` |
-| Docs | `docs/` | `docs/SD-DOCS-001-api-guide` |
-| Refactor | `refactor/` | `refactor/SD-REFACTOR-001-cleanup` |
-| Test | `test/` | `test/SD-TEST-001-e2e-coverage` |
-
-### Branch Hygiene Rules
-
-From CLAUDE_EXEC.md (enforced at PLAN-TO-EXEC):
-- **≤7 days stale** at PLAN-TO-EXEC handoff
-- **One SD per branch** (no mixing work)
-- **Merge main at phase transitions**
-
-### When Branch is Created
-
-```
-LEAD Phase                    PLAN Phase                   EXEC Phase
-    |                              |                            |
-    |   LEAD-TO-PLAN handoff       |                            |
-    |---[Branch Created Here]----->|                            |
-    |                              |   PRD Creation             |
-    |                              |   Sub-agent validation     |
-    |                              |                            |
-    |                              |   PLAN-TO-EXEC handoff     |
-    |                              |---[Branch Validated]------>|
-    |                              |                            |
-```
-
-
 ## Vision/Architecture Doc Pre-Check
 
 ## Vision/Architecture Doc Pre-Check (Step 0.25)
@@ -395,7 +395,7 @@ During the EXEC phase, use sub-agents proactively for implementation quality and
 - **uat-agent**: For user acceptance test execution before handoff
 
 ### When to Invoke
-- **On ANY database error**: Immediately invoke database-agent (do not attempt workarounds)
+- **On ANY database WRITE error**: Immediately invoke database-agent (do not attempt workarounds). For read errors, check MCP tool configuration first.
 - **Before PR creation**: Run testing-agent for coverage, security-agent for review
 - **During refactoring**: Run regression-agent to validate backward compatibility
 - **On test failures**: Run rca-agent for root cause analysis, then testing-agent
@@ -933,6 +933,86 @@ UI Parity Status:
 - Gate 2.5 Status: PASS/FAIL
 ```
 
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
+
+## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
+
+**Every completed Strategic Directive and Quick-Fix MUST end with:**
+
+1. **Commit** - All changes committed with proper message format
+2. **Push** - Branch pushed to remote
+3. **Merge to Main** - Feature branch merged into main
+
+### For Quick-Fixes
+
+The `complete-quick-fix.js` script handles this automatically:
+
+```bash
+node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
+```
+
+The script will:
+1. Verify tests pass and UAT completed
+2. Commit and push changes
+3. **Prompt to merge PR to main** (or local merge if no PR)
+4. Delete the feature branch
+
+### For Strategic Directives
+
+After LEAD approval, execute the following:
+
+```bash
+# 1. Ensure all changes committed
+git add .
+git commit -m "feat(SD-YYYY-XXX): [description]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+
+# 2. Push to remote
+git push origin feature/SD-YYYY-XXX
+
+# 3. Create PR if not exists
+gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
+
+# 4. Merge PR (preferred method)
+gh pr merge --merge --delete-branch
+
+# OR local merge fallback
+git checkout main
+git pull origin main
+git merge --no-ff feature/SD-YYYY-XXX
+git push origin main
+git branch -d feature/SD-YYYY-XXX
+git push origin --delete feature/SD-YYYY-XXX
+```
+
+### Merge Checklist
+
+Before merging, verify:
+- [ ] All tests passing (unit + E2E)
+- [ ] CI/CD pipeline green
+- [ ] Code review completed (if required)
+- [ ] No merge conflicts
+- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
+
+### Anti-Patterns
+
+❌ **NEVER** leave feature branches unmerged after completion
+❌ **NEVER** skip the push step
+❌ **NEVER** merge without verifying tests pass
+❌ **NEVER** force push to main
+
+### Verification
+
+After merge, confirm:
+```bash
+git checkout main
+git pull origin main
+git log --oneline -5  # Should show your merge commit
+```
+
 ## 🌿 Branch Hygiene Gate (MANDATORY)
 
 ## Branch Hygiene Gate (MANDATORY)
@@ -1022,86 +1102,6 @@ When starting implementation:
 3. If multiple SDs detected → split branches
 4. If >100 files changed → assess scope creep
 5. Document branch health in handoff notes
-
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge
-
-## 🔀 SD/Quick-Fix Completion: Commit, Push, Merge (MANDATORY)
-
-**Every completed Strategic Directive and Quick-Fix MUST end with:**
-
-1. **Commit** - All changes committed with proper message format
-2. **Push** - Branch pushed to remote
-3. **Merge to Main** - Feature branch merged into main
-
-### For Quick-Fixes
-
-The `complete-quick-fix.js` script handles this automatically:
-
-```bash
-node scripts/complete-quick-fix.js QF-YYYYMMDD-NNN --pr-url https://...
-```
-
-The script will:
-1. Verify tests pass and UAT completed
-2. Commit and push changes
-3. **Prompt to merge PR to main** (or local merge if no PR)
-4. Delete the feature branch
-
-### For Strategic Directives
-
-After LEAD approval, execute the following:
-
-```bash
-# 1. Ensure all changes committed
-git add .
-git commit -m "feat(SD-YYYY-XXX): [description]
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
-
-# 2. Push to remote
-git push origin feature/SD-YYYY-XXX
-
-# 3. Create PR if not exists
-gh pr create --title "feat(SD-YYYY-XXX): [title]" --body "..."
-
-# 4. Merge PR (preferred method)
-gh pr merge --merge --delete-branch
-
-# OR local merge fallback
-git checkout main
-git pull origin main
-git merge --no-ff feature/SD-YYYY-XXX
-git push origin main
-git branch -d feature/SD-YYYY-XXX
-git push origin --delete feature/SD-YYYY-XXX
-```
-
-### Merge Checklist
-
-Before merging, verify:
-- [ ] All tests passing (unit + E2E)
-- [ ] CI/CD pipeline green
-- [ ] Code review completed (if required)
-- [ ] No merge conflicts
-- [ ] SD status = 'archived' OR Quick-Fix status = 'completed'
-
-### Anti-Patterns
-
-❌ **NEVER** leave feature branches unmerged after completion
-❌ **NEVER** skip the push step
-❌ **NEVER** merge without verifying tests pass
-❌ **NEVER** force push to main
-
-### Verification
-
-After merge, confirm:
-```bash
-git checkout main
-git pull origin main
-git log --oneline -5  # Should show your merge commit
-```
 
 ## Auto-Merge Workflow for SD Completion
 

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-03T12:21:56.995Z -->
-<!-- git_commit: f88b4815 -->
+<!-- generated_at: 2026-04-03T14:02:48.388Z -->
+<!-- git_commit: 09a43fa4 -->
 <!-- db_snapshot_hash: b9ae40daf1e08509 -->
 <!-- file_content_hash: pending -->
 
@@ -218,5 +218,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-04-03 8:21:57 AM*
+*DIGEST generated: 2026-04-03 10:02:48 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,6 +1,6 @@
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-04-03 8:21:57 AM
+**Generated**: 2026-04-03 10:02:48 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: LEAD agent operations and strategic validation
 
@@ -456,81 +456,6 @@ node scripts/handoff.js execute PLAN-TO-LEAD SD-XXX-001
 - **Process Scripts**: `scripts/add-sd-to-database.js`, `scripts/handoff.js`, `scripts/leo-create-sd.js`
 - **Plan-Aware Creation**: `docs/reference/sd-key-generator-guide.md` (--from-plan section)
 
-## Child SD Context Loading (MANDATORY)
-
-**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
-
-### Why This Applies to Children
-
-Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
-- Has its own PRD
-- Has its own handoffs
-- Has its own retrospective
-- Must meet its own gate thresholds
-
-**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
-
-### Required Context Loading Sequence
-
-Before starting ANY work on a child SD:
-
-1. **Run child preflight validation**:
-   ```bash
-   node scripts/child-sd-preflight.js SD-XXX-001
-   ```
-
-2. **Read CLAUDE_CORE.md** (provides SD type requirements):
-   ```
-   Read tool: CLAUDE_CORE.md
-   ```
-
-3. **Read phase-specific file** based on current_phase:
-   | Phase | File |
-   |-------|------|
-   | LEAD_APPROVAL | CLAUDE_LEAD.md |
-   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
-   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
-
-### What CLAUDE_CORE.md Provides
-
-- SD type definitions (feature, bugfix, infrastructure, etc.)
-- Gate pass thresholds per SD type
-- Required handoff counts
-- Required sub-agents per SD type
-- Global negative constraints
-
-### Consequences of Skipping Context Loading
-
-Without loading CLAUDE_CORE.md before child SD work:
-- **Unknown requirements**: May not know PRD is required
-- **Wrong thresholds**: May target 70% when 85% is required
-- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
-- **Incomplete handoffs**: May not execute full chain
-
-### Enforcement
-
-The `child-sd-preflight.js` script now displays a reminder:
-```
-⚠️  CONTEXT LOADING REMINDER:
-   Before starting work, you MUST read:
-   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
-   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
-```
-
-**This reminder is advisory.** The actual context loading must be performed by reading the files.
-
-### Quick Reference
-
-| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
-|---------------|----------------|--------------|--------------|
-| feature | 85% | 5 | YES |
-| bugfix | 85% | 5 | YES |
-| infrastructure | 80% | 4 | YES |
-| documentation | 60% | 4 | NO |
-| refactor | 75-90% | 5 | Brief |
-
-*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
-
 ## Common SD Creation Errors and Solutions
 
 ### Database Constraint Errors
@@ -803,6 +728,81 @@ const sdKey = await generateSDKey({ source, type, title });
 4. `scripts/create-sd.js`
 5. `scripts/modules/learning/executor.js`
 
+
+## Child SD Context Loading (MANDATORY)
+
+**CRITICAL**: When starting work on a child SD (any SD with a parent_sd_id), you MUST load context files before beginning work.
+
+### Why This Applies to Children
+
+Child SDs are **independent Strategic Directives** that require their own full LEAD→PLAN→EXEC workflow. Each child:
+- Has its own PRD
+- Has its own handoffs
+- Has its own retrospective
+- Must meet its own gate thresholds
+
+**Children are NOT sub-tasks.** They are first-class SDs that happen to be coordinated by a parent orchestrator.
+
+### Required Context Loading Sequence
+
+Before starting ANY work on a child SD:
+
+1. **Run child preflight validation**:
+   ```bash
+   node scripts/child-sd-preflight.js SD-XXX-001
+   ```
+
+2. **Read CLAUDE_CORE.md** (provides SD type requirements):
+   ```
+   Read tool: CLAUDE_CORE.md
+   ```
+
+3. **Read phase-specific file** based on current_phase:
+   | Phase | File |
+   |-------|------|
+   | LEAD_APPROVAL | CLAUDE_LEAD.md |
+   | PLAN_*, PRD_* | CLAUDE_PLAN.md |
+   | EXEC_*, IMPLEMENTATION_* | CLAUDE_EXEC.md |
+
+### What CLAUDE_CORE.md Provides
+
+- SD type definitions (feature, bugfix, infrastructure, etc.)
+- Gate pass thresholds per SD type
+- Required handoff counts
+- Required sub-agents per SD type
+- Global negative constraints
+
+### Consequences of Skipping Context Loading
+
+Without loading CLAUDE_CORE.md before child SD work:
+- **Unknown requirements**: May not know PRD is required
+- **Wrong thresholds**: May target 70% when 85% is required
+- **Missing sub-agents**: May skip TESTING, DESIGN, etc.
+- **Incomplete handoffs**: May not execute full chain
+
+### Enforcement
+
+The `child-sd-preflight.js` script now displays a reminder:
+```
+⚠️  CONTEXT LOADING REMINDER:
+   Before starting work, you MUST read:
+   1. CLAUDE_CORE.md (SD type requirements, gates, thresholds)
+   2. Phase-specific file (CLAUDE_LEAD.md, CLAUDE_PLAN.md, or CLAUDE_EXEC.md)
+```
+
+**This reminder is advisory.** The actual context loading must be performed by reading the files.
+
+### Quick Reference
+
+| Child SD Type | Gate Threshold | Min Handoffs | PRD Required |
+|---------------|----------------|--------------|--------------|
+| feature | 85% | 5 | YES |
+| bugfix | 85% | 5 | YES |
+| infrastructure | 80% | 4 | YES |
+| documentation | 60% | 4 | NO |
+| refactor | 75-90% | 5 | Brief |
+
+*Always verify current requirements from CLAUDE_CORE.md as they may be updated.*
 
 ## Phase-Specific Sub-Agent Guidance: LEAD
 

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-03T12:21:56.995Z -->
-<!-- git_commit: f88b4815 -->
+<!-- generated_at: 2026-04-03T14:02:48.388Z -->
+<!-- git_commit: 09a43fa4 -->
 <!-- db_snapshot_hash: b9ae40daf1e08509 -->
 <!-- file_content_hash: pending -->
 
@@ -126,5 +126,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-04-03 8:21:57 AM*
+*DIGEST generated: 2026-04-03 10:02:48 AM*
 *Protocol: 4.3.3*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,6 +1,6 @@
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-04-03 8:21:57 AM
+**Generated**: 2026-04-03 10:02:48 AM
 **Protocol**: LEO 4.3.3
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 
@@ -195,30 +195,6 @@ LEAD Phase                    PLAN Phase                   EXEC Phase
 ```
 
 
-## Deferred Work Management
-
-### What Gets Deferred
-- Technical debt discovered during implementation
-- Edge cases not critical for MVP
-- Performance optimizations for later
-- Nice-to-have features
-
-### Creating Deferred Items
-```sql
-INSERT INTO deferred_work (sd_id, title, reason, priority)
-VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
-```
-
-### Tracking
-- Deferred items linked to parent SD
-- Reviewed during retrospective
-- May become new SDs if significant
-
-### Rules
-- Document WHY deferred, not just WHAT
-- Set realistic priority (critical items shouldn't be deferred)
-- Max 5 deferred items per SD
-
 ## PLAN Phase Negative Constraints
 
 ## 🚫 PLAN Phase Negative Constraints
@@ -256,6 +232,30 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 **Why Wrong**: PRD validator blocks placeholders, signals incomplete planning
 **Correct Approach**: If truly unknown, use AskUserQuestion to clarify before PRD creation
 </negative_constraints>
+
+## Deferred Work Management
+
+### What Gets Deferred
+- Technical debt discovered during implementation
+- Edge cases not critical for MVP
+- Performance optimizations for later
+- Nice-to-have features
+
+### Creating Deferred Items
+```sql
+INSERT INTO deferred_work (sd_id, title, reason, priority)
+VALUES ('SD-XXX', 'Title', 'Reason for deferral', 'low');
+```
+
+### Tracking
+- Deferred items linked to parent SD
+- Reviewed during retrospective
+- May become new SDs if significant
+
+### Rules
+- Document WHY deferred, not just WHAT
+- Set realistic priority (critical items shouldn't be deferred)
+- Max 5 deferred items per SD
 
 ## Phase-Specific Sub-Agent Guidance: PLAN
 
@@ -444,6 +444,23 @@ Task(subagent_type="database-agent", prompt="Execute DATABASE analysis for SD-XX
 | "DESIGN sub-agent not executed" | Didn't run design-agent | Use Task tool with design-agent |
 | "DATABASE sub-agent not executed" | Didn't run database-agent | Use Task tool with database-agent |
 
+## Enhanced QA Engineering Director v2.0 - Testing-First Edition
+
+**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
+
+**Core Capabilities:**
+1. Professional test case generation from user stories
+2. Pre-test build validation (saves 2-3 hours)
+3. Database migration verification (prevents 1-2 hours debugging)
+4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
+5. Test infrastructure discovery and reuse
+
+**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
+
+**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
+
+**Full Guide**: See `docs/reference/qa-director-guide.md`
+
 ## ✅ Scope Verification with Explore (PLAN_VERIFY)
 
 ## Scope Verification with Explore
@@ -514,23 +531,6 @@ This change [describe]. Options:
 
 Which do you prefer?"
 ```
-
-## Enhanced QA Engineering Director v2.0 - Testing-First Edition
-
-**Enhanced QA Engineering Director v2.0**: Mission-critical testing automation with comprehensive E2E validation.
-
-**Core Capabilities:**
-1. Professional test case generation from user stories
-2. Pre-test build validation (saves 2-3 hours)
-3. Database migration verification (prevents 1-2 hours debugging)
-4. **Mandatory E2E testing via Playwright** (REQUIRED for approval)
-5. Test infrastructure discovery and reuse
-
-**5-Phase Workflow**: Pre-flight checks → Test generation → E2E execution → Evidence collection → Verdict & learnings
-
-**Activation**: Auto-triggers on `EXEC-TO-PLAN`, coverage keywords, testing evidence requests
-
-**Full Guide**: See `docs/reference/qa-director-guide.md`
 
 ## PLAN Pre-EXEC Checklist
 
@@ -692,6 +692,33 @@ When a pipeline has cascading failures, the architecture plan MUST:
 
 **Detection**: The gate checks architecture plan content for failure chain diagrams and upstream-first child ordering language.
 
+## 🔬 BMAD Method Enhancements
+
+## BMAD Enhancements
+
+### 6 Key Improvements
+1. **Unified Handoff System** - All handoffs via `handoff.js`
+2. **Database-First PRDs** - PRDs stored in database, not markdown
+3. **Validation Gates** - 4-gate validation before EXEC
+4. **Progress Tracking** - Automatic progress % calculation
+5. **Context Management** - Proactive monitoring, compression strategies
+6. **Sub-Agent Compression** - 3-tier output reduction
+
+### Using Handoff System
+```bash
+node scripts/handoff.js create "{message}"
+```
+
+### PRD Creation
+```bash
+node scripts/add-prd-to-database.js {SD-ID}
+```
+
+### Never Bypass
+- ⚠️ Always use process scripts
+- ⚠️ Never create PRDs as markdown files
+- ⚠️ Never skip validation gates
+
 ## Research Lookup Before PRD Creation
 
 ## Research Lookup Before PRD Creation (MANDATORY)
@@ -790,48 +817,6 @@ node scripts/add-prd-to-database.js SD-RESEARCH-106
 ```
 
 
-## 🔬 BMAD Method Enhancements
-
-## BMAD Enhancements
-
-### 6 Key Improvements
-1. **Unified Handoff System** - All handoffs via `handoff.js`
-2. **Database-First PRDs** - PRDs stored in database, not markdown
-3. **Validation Gates** - 4-gate validation before EXEC
-4. **Progress Tracking** - Automatic progress % calculation
-5. **Context Management** - Proactive monitoring, compression strategies
-6. **Sub-Agent Compression** - 3-tier output reduction
-
-### Using Handoff System
-```bash
-node scripts/handoff.js create "{message}"
-```
-
-### PRD Creation
-```bash
-node scripts/add-prd-to-database.js {SD-ID}
-```
-
-### Never Bypass
-- ⚠️ Always use process scripts
-- ⚠️ Never create PRDs as markdown files
-- ⚠️ Never skip validation gates
-
-## CI/CD Pipeline Verification
-
-## CI/CD Pipeline Verification (MANDATORY)
-
-**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
-
-### Verification Process
-
-**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
-
-1. Wait 2-3 minutes for GitHub Actions to complete
-2. Trigger DevOps sub-agent to verify pipeline status
-3. Document CI/CD status in PLAN→LEAD handoff
-4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
-
 ## DESIGN→DATABASE Validation Gates
 
 **4 mandatory gates ensuring sub-agent execution and implementation fidelity.**
@@ -883,6 +868,21 @@ Retroactive audit at SD closure:
 
 **Reference**: `scripts/modules/design-database-gates-validation.js`
 
+
+## CI/CD Pipeline Verification
+
+## CI/CD Pipeline Verification (MANDATORY)
+
+**Evidence from Retrospectives**: Gap identified in SD-UAT-002 and SD-LEO-002.
+
+### Verification Process
+
+**After EXEC implementation complete, BEFORE PLAN→LEAD handoff**:
+
+1. Wait 2-3 minutes for GitHub Actions to complete
+2. Trigger DevOps sub-agent to verify pipeline status
+3. Document CI/CD status in PLAN→LEAD handoff
+4. PLAN→LEAD handoff is **BLOCKED** if pipelines failing
 
 ## 🚪 Gate 2.5: Human Inspectability Validation
 
@@ -1660,34 +1660,6 @@ for (const childId of childIds) {
 
 > **Team Capabilities**: When planning complex SDs, consider whether team spawning (any agent leading specialists) could parallelize cross-domain work. See **Teams Protocol** in CLAUDE.md.
 
-## PRD Creation Anti-Pattern (PROHIBITED)
-
-**NEVER create one-off PRD creation scripts like:**
-- `create-prd-sd-*.js`
-- `insert-prd-*.js`
-- `enhance-prd-*.js`
-
-**ALWAYS use the standard CLI:**
-```bash
-node scripts/add-prd-to-database.js
-```
-
-### Why This Matters
-- One-off scripts bypass PRD quality validation
-- They create massive maintenance burden (100+ orphaned scripts)
-- They fragment PRD creation patterns
-
-### Archived Scripts Location
-~100 legacy one-off scripts have been moved to:
-- `scripts/archived-prd-scripts/`
-
-These are kept for reference but should NEVER be used as templates.
-
-### Correct Workflow
-1. Run `node scripts/add-prd-to-database.js`
-2. Follow the modular PRD creation system in `scripts/prd/`
-3. PRD is properly validated against quality rubrics
-
 ## Vision V2 PRD Requirements (SD-VISION-V2-*)
 
 ### MANDATORY: Vision Spec Integration in PRDs
@@ -1728,6 +1700,34 @@ Key spec requirements addressed:
 ### Implementation Guidance (from SD metadata)
 
 All Vision V2 SDs have `creation_mode: CREATE_FROM_NEW` - implement fresh per specs, learn from existing code but do not modify it.
+
+## PRD Creation Anti-Pattern (PROHIBITED)
+
+**NEVER create one-off PRD creation scripts like:**
+- `create-prd-sd-*.js`
+- `insert-prd-*.js`
+- `enhance-prd-*.js`
+
+**ALWAYS use the standard CLI:**
+```bash
+node scripts/add-prd-to-database.js
+```
+
+### Why This Matters
+- One-off scripts bypass PRD quality validation
+- They create massive maintenance burden (100+ orphaned scripts)
+- They fragment PRD creation patterns
+
+### Archived Scripts Location
+~100 legacy one-off scripts have been moved to:
+- `scripts/archived-prd-scripts/`
+
+These are kept for reference but should NEVER be used as templates.
+
+### Correct Workflow
+1. Run `node scripts/add-prd-to-database.js`
+2. Follow the modular PRD creation system in `scripts/prd/`
+3. PRD is properly validated against quality rubrics
 
 ## Quality Assessment Integration in Handoffs
 

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,6 +1,6 @@
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-04-03T12:21:56.995Z -->
-<!-- git_commit: f88b4815 -->
+<!-- generated_at: 2026-04-03T14:02:48.388Z -->
+<!-- git_commit: 09a43fa4 -->
 <!-- db_snapshot_hash: b9ae40daf1e08509 -->
 <!-- file_content_hash: pending -->
 
@@ -124,5 +124,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-04-03 8:21:57 AM*
+*DIGEST generated: 2026-04-03 10:02:48 AM*
 *Protocol: 4.3.3*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,77 +1,77 @@
 {
-  "generated_at": "2026-04-03T12:21:56.995Z",
-  "git_commit": "f88b4815",
+  "generated_at": "2026-04-03T14:02:48.388Z",
+  "git_commit": "09a43fa4",
   "db_snapshot_hash": "b9ae40daf1e08509",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 5752,
-      "estimated_tokens": 1438,
-      "content_hash": "18211f291aa3fea4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE.md"
+      "chars": 5753,
+      "estimated_tokens": 1439,
+      "content_hash": "e1af740bcd68c913",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 56573,
-      "estimated_tokens": 14144,
-      "content_hash": "8722510bf7447224",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_CORE.md"
+      "chars": 56904,
+      "estimated_tokens": 14226,
+      "content_hash": "cf1024309c46bde3",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 54061,
+      "chars": 54062,
       "estimated_tokens": 13516,
-      "content_hash": "f9bb5d2aa7a84eae",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_LEAD.md"
+      "content_hash": "494b5804b6e18a29",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 82863,
+      "chars": 82864,
       "estimated_tokens": 20716,
-      "content_hash": "a6557c05d2b826f4",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_PLAN.md"
+      "content_hash": "3c3a4c7be90c167b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 70683,
-      "estimated_tokens": 17671,
-      "content_hash": "3d0bc348910b6f20",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_EXEC.md"
+      "chars": 70744,
+      "estimated_tokens": 17686,
+      "content_hash": "67bf56dd20ee590f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 6618,
+      "chars": 6619,
       "estimated_tokens": 1655,
-      "content_hash": "b6e6fead427baeac",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_DIGEST.md"
+      "content_hash": "02c1a5937c6bf528",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 10419,
+      "chars": 10420,
       "estimated_tokens": 2605,
-      "content_hash": "583222aff58ee03b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "2e927d481fc89b57",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 4801,
+      "chars": 4802,
       "estimated_tokens": 1201,
-      "content_hash": "935cfa911286321e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "49d40bdbd7d81bb5",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 5031,
+      "chars": 5032,
       "estimated_tokens": 1258,
-      "content_hash": "e45b9b002fee9727",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "8f190bef292a614f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 9485,
+      "chars": 9486,
       "estimated_tokens": 2372,
-      "content_hash": "c018c1f2104847dd",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CLAUDE-PROTOCOL-HARDENING-001\\CLAUDE_EXEC_DIGEST.md"
+      "content_hash": "5385997cccb81e5e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-MCP-READ-WRITE-001\\CLAUDE_EXEC_DIGEST.md"
     }
   }
 }

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -9,6 +9,7 @@
  *
  * 4. Worktree claim guard (PAT-CLMMULTI-001) - HARD BLOCK (exit 2)
  * 5. DB-only strategic artifacts (SD-LEO-INFRA-ONLY-ENFORCEMENT-STRATEGIC-002) - HARD BLOCK (exit 2)
+ * 6. MCP write operation block (SD-LEO-INFRA-MCP-READ-WRITE-001) - HARD BLOCK (exit 2)
  *
  * Hook API:
  *   Input:  CLAUDE_TOOL_INPUT (JSON), CLAUDE_TOOL_NAME (string)
@@ -137,6 +138,19 @@ function main() {
       );
       process.exit(2);
     }
+  }
+
+  // --- ENFORCEMENT 6: MCP Write Operation Block (SD-LEO-INFRA-MCP-READ-WRITE-001) ---
+  // Block mcp__supabase__apply_migration — it's a write op but MCP role is read-only.
+  // Read tools (execute_sql, list_tables, list_extensions, list_migrations) remain allowed.
+  if (TOOL_NAME === 'mcp__supabase__apply_migration') {
+    process.stderr.write(
+      'MCP WRITE BLOCK: mcp__supabase__apply_migration is a write operation.\n' +
+      'The MCP Supabase role (supabase_read_only_user) cannot execute migrations.\n' +
+      'Use the database-agent instead:\n' +
+      '  Agent({ subagent_type: "database-agent", prompt: "Execute migration: <path>" })\n'
+    );
+    process.exit(2);
   }
 
   // --- ENFORCEMENT 2: Tool Policy Profile (Log-Only) ---


### PR DESCRIPTION
## Summary
- Block `mcp__supabase__apply_migration` via PreToolUse hook (write op on read-only MCP role, exit code 2 with structured error)
- Update sub-agent routing in `leo_protocol_sections` DB from "ANY database operation" to "ANY database WRITE"
- Add MCP Read/Write Split section to CLAUDE_CORE.md via regeneration
- Update MEMORY.md with MCP read/write routing guidance

## Test plan
- [x] `apply_migration` blocked (exit 2) with structured error directing to database-agent
- [x] `execute_sql` remains unblocked (exit 0)
- [x] `list_tables` remains unblocked (exit 0)
- [x] CLAUDE_CORE.md contains "MCP Read/Write Split" section
- [x] MEMORY.md reflects updated routing rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)