### PR TITLE
feat(SD-LEO-ORCH-SELF-HEALING-DATABASE-001-C): PreToolUse hook schema validation integration

### DIFF
--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -10,6 +10,7 @@
  * 4. Worktree claim guard (PAT-CLMMULTI-001) - HARD BLOCK (exit 2)
  * 5. DB-only strategic artifacts (SD-LEO-INFRA-ONLY-ENFORCEMENT-STRATEGIC-002) - HARD BLOCK (exit 2)
  * 6. MCP write operation block (SD-LEO-INFRA-MCP-READ-WRITE-001) - HARD BLOCK (exit 2)
+ * 7. Schema pre-flight validation (SD-LEO-ORCH-SELF-HEALING-DATABASE-001-C) - TIERED (blocking/advisory/skip)
  *
  * Hook API:
  *   Input:  CLAUDE_TOOL_INPUT (JSON), CLAUDE_TOOL_NAME (string)
@@ -51,7 +52,131 @@ try {
   AGENT_ROUTING = [];
 }
 
-function main() {
+// --- SCHEMA PRE-FLIGHT VALIDATION CONFIG (SD-LEO-ORCH-SELF-HEALING-DATABASE-001-C) ---
+// Maps script path patterns to enforcement tiers.
+// 'blocking': exit(2) on validation failure. 'advisory': warn only. 'skip': no validation.
+const VALIDATION_CONFIG = {
+  blocking: [
+    /database\/migrations\//,
+    /scripts\/handoff\.js/,
+    /scripts\/unified-handoff-system\.js/,
+    /scripts\/add-prd-to-database\.js/,
+    /scripts\/add-sd-to-database\.js/,
+  ],
+  advisory: [
+    /scripts\//,
+    /lib\//,
+  ],
+  // Everything else is implicitly 'skip'
+};
+
+// Regex patterns to detect Supabase operations in Bash commands
+const SUPABASE_PATTERNS = [
+  /\.from\(\s*['"`](\w+)['"`]\s*\)/,        // .from('table_name')
+  /supabase\.from\(\s*['"`](\w+)['"`]\s*\)/, // supabase.from('table_name')
+  /\.rpc\(\s*['"`](\w+)['"`]/,               // .rpc('function_name')
+];
+
+/**
+ * Determine enforcement tier for the current Bash command context.
+ * Checks CWD and command content against VALIDATION_CONFIG path patterns.
+ * @param {string} command - The Bash command string
+ * @returns {'blocking'|'advisory'|'skip'}
+ */
+function getEnforcementTier(command) {
+  for (const pattern of VALIDATION_CONFIG.blocking) {
+    if (pattern.test(command)) return 'blocking';
+  }
+  for (const pattern of VALIDATION_CONFIG.advisory) {
+    if (pattern.test(command)) return 'advisory';
+  }
+  return 'skip';
+}
+
+/**
+ * Extract table name from a Bash command containing Supabase patterns.
+ * @param {string} command
+ * @returns {string|null}
+ */
+function extractTableName(command) {
+  for (const pattern of SUPABASE_PATTERNS) {
+    const match = command.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/**
+ * Extract column names from a Bash command (best-effort).
+ * Looks for .select(), .eq(), .update(), .insert() patterns.
+ * @param {string} command
+ * @returns {Object<string, *>}
+ */
+function extractParams(command) {
+  const params = {};
+  // Match .eq('col', value) / .eq("col", value)
+  const eqPattern = /\.eq\(\s*['"`](\w+)['"`]/g;
+  let match;
+  while ((match = eqPattern.exec(command)) !== null) {
+    params[match[1]] = 'unknown';
+  }
+  // Match .select('col1, col2') — extract column names
+  const selectMatch = command.match(/\.select\(\s*['"`]([^'"`]+)['"`]\s*\)/);
+  if (selectMatch && selectMatch[1] !== '*') {
+    selectMatch[1].split(',').forEach(col => {
+      const clean = col.trim().split(':')[0].trim(); // handle aliases
+      if (clean && clean !== '*') params[clean] = 'unknown';
+    });
+  }
+  return params;
+}
+
+/**
+ * Run schema pre-flight validation on a Bash command.
+ * Async — must be awaited. Fail-open on any error.
+ * @param {string} command
+ * @returns {Promise<void>}
+ */
+async function validateBeforeExecution(command) {
+  const tableName = extractTableName(command);
+  if (!tableName) return; // No Supabase pattern detected
+
+  const tier = getEnforcementTier(command);
+  if (tier === 'skip') return;
+
+  const params = extractParams(command);
+  if (Object.keys(params).length === 0) return; // No extractable params
+
+  try {
+    const { validateOperation } = require(path.resolve(__dirname, '..', '..', 'lib', 'schema-preflight.cjs'));
+    const result = await validateOperation(tableName, 'query', params);
+
+    if (!result.valid) {
+      if (tier === 'blocking') {
+        process.stderr.write(
+          `SCHEMA VALIDATION FAILED (blocking):\n` +
+          `  Table: ${tableName}\n` +
+          `  Errors: ${result.errors.join('; ')}\n` +
+          `  Fix the column names or types before running this command.\n`
+        );
+        process.exit(2);
+      } else {
+        // Advisory: warn but allow
+        console.log(
+          `[schema-preflight] WARNING: ${result.errors.join('; ')} (table: ${tableName})`
+        );
+      }
+    }
+
+    if (result.warnings.length > 0) {
+      console.log(`[schema-preflight] ${result.warnings.join('; ')}`);
+    }
+  } catch {
+    // Fail-open: validation errors never block execution
+  }
+}
+
+async function main() {
   let input;
   try {
     input = JSON.parse(TOOL_INPUT_RAW);
@@ -205,7 +330,17 @@ function main() {
     }
   }
 
-  process.exit(0); // Allow
+  // --- ENFORCEMENT 7: Schema Pre-Flight Validation (SD-LEO-ORCH-SELF-HEALING-DATABASE-001-C) ---
+  // Validates Supabase operations in Bash commands against live schema.
+  // Tiered: blocking for migrations/handoffs, advisory for general scripts, skip otherwise.
+  if (TOOL_NAME === 'Bash') {
+    const command = input.command || '';
+    if (SUPABASE_PATTERNS.some(p => p.test(command))) {
+      await validateBeforeExecution(command);
+    }
+  }
+
+  process.exitCode = 0; // Allow
 }
 
-main();
+main().catch(() => { process.exitCode = 0; }); // Fail-open: async errors never block

--- a/tests/unit/pre-tool-enforce-schema.test.js
+++ b/tests/unit/pre-tool-enforce-schema.test.js
@@ -1,0 +1,107 @@
+/**
+ * Integration Tests: PreToolUse Hook Schema Validation
+ * SD-LEO-ORCH-SELF-HEALING-DATABASE-001-C
+ *
+ * Tests the schema pre-flight validation integration in pre-tool-enforce.cjs.
+ * Uses child_process.execSync to run the hook as a subprocess (matching real usage).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import path from 'path';
+
+const hookPath = path.resolve('scripts/hooks/pre-tool-enforce.cjs');
+
+function runHook(toolName, toolInput, options = {}) {
+  const env = {
+    ...process.env,
+    CLAUDE_TOOL_NAME: toolName,
+    CLAUDE_TOOL_INPUT: JSON.stringify(toolInput),
+  };
+
+  try {
+    const stdout = execSync(`node "${hookPath}"`, {
+      env,
+      timeout: options.timeout || 15000,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { exitCode: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      exitCode: err.status,
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+    };
+  }
+}
+
+describe('pre-tool-enforce schema validation', () => {
+  it('allows non-Supabase Bash commands without validation', () => {
+    const result = runHook('Bash', { command: 'git status' });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).not.toContain('schema-preflight');
+  });
+
+  it('allows valid Supabase operations (advisory tier)', () => {
+    const result = runHook('Bash', {
+      command: 'node scripts/test.js && supabase.from(\'strategic_directives_v2\').select(\'sd_key\').eq(\'status\', \'active\')',
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('warns on unknown column in advisory tier', () => {
+    const result = runHook('Bash', {
+      command: 'node scripts/test.js && supabase.from(\'strategic_directives_v2\').eq(\'nonexistent_column\', \'x\')',
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('schema-preflight');
+    expect(result.stdout).toContain('Unknown column');
+  });
+
+  it('blocks unknown column in blocking tier (handoff script)', () => {
+    const result = runHook('Bash', {
+      command: 'node scripts/handoff.js execute LEAD-TO-PLAN SD-TEST && supabase.from(\'strategic_directives_v2\').eq(\'fake_col\', \'x\')',
+    });
+    // Should block (exit 2) or fail with assertion on Windows
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('SCHEMA VALIDATION FAILED');
+  });
+
+  it('blocks unknown column in blocking tier (migration path)', () => {
+    const result = runHook('Bash', {
+      command: 'node database/migrations/test.js && supabase.from(\'strategic_directives_v2\').eq(\'fake_col\', \'x\')',
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('SCHEMA VALIDATION FAILED');
+  });
+
+  it('skips validation when no columns are extractable', () => {
+    const result = runHook('Bash', {
+      command: 'supabase.from(\'strategic_directives_v2\').select(\'*\')',
+    });
+    expect(result.exitCode).toBe(0);
+    // No warning because select('*') has no extractable column params
+    expect(result.stdout).not.toContain('Unknown column');
+  });
+
+  it('preserves NC-006 background execution ban', () => {
+    const result = runHook('Bash', {
+      command: 'echo test',
+      run_in_background: true,
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('NC-006');
+  });
+
+  it('preserves MCP write operation block', () => {
+    const result = runHook('mcp__supabase__apply_migration', {});
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('MCP WRITE BLOCK');
+  });
+
+  it('allows non-Bash tools without schema validation', () => {
+    const result = runHook('Read', { file_path: '/tmp/test.txt' });
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Integrate schema-preflight.cjs into pre-tool-enforce.cjs PreToolUse hook
- Add tiered enforcement: blocking (migrations/handoffs), advisory (scripts), skip (other)
- Add VALIDATION_CONFIG, validateBeforeExecution(), Supabase pattern detection
- 9 integration tests covering all tiers + backward compatibility

## Test plan
- [x] 9/9 integration tests pass
- [x] Existing NC-006, MCP block, worktree guard still work
- [x] Advisory tier warns but allows on unknown columns
- [x] Blocking tier rejects with exit(2) on schema errors in handoff paths
- [x] Non-Supabase commands unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)