### PR TITLE
fix(SD-LEO-INFRA-PARALLEL-AGENT-QUEUE-001): implement board guardrails for sd:drain

### DIFF
--- a/database/migrations/20260403_add_virtual_session_columns.sql
+++ b/database/migrations/20260403_add_virtual_session_columns.sql
@@ -1,0 +1,44 @@
+-- Migration: Add virtual session support for SD Queue Drainer
+-- SD: SD-LEO-INFRA-PARALLEL-AGENT-QUEUE-001
+-- Date: 2026-04-03
+--
+-- Adds columns to claude_sessions for drain agent virtual sessions:
+-- - is_virtual: distinguishes drain agents from real terminal sessions
+-- - parent_session_id: links agent to its parent drainer session
+-- - agent_slot: slot index (0, 1, 2) within the drainer
+-- - last_progress_at: meaningful work completion timestamp (not just liveness)
+
+-- Add columns (idempotent with IF NOT EXISTS via DO block)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'claude_sessions' AND column_name = 'is_virtual') THEN
+    ALTER TABLE claude_sessions ADD COLUMN is_virtual BOOLEAN DEFAULT FALSE;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'claude_sessions' AND column_name = 'parent_session_id') THEN
+    ALTER TABLE claude_sessions ADD COLUMN parent_session_id TEXT REFERENCES claude_sessions(session_id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'claude_sessions' AND column_name = 'agent_slot') THEN
+    ALTER TABLE claude_sessions ADD COLUMN agent_slot INTEGER;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'claude_sessions' AND column_name = 'last_progress_at') THEN
+    ALTER TABLE claude_sessions ADD COLUMN last_progress_at TIMESTAMPTZ;
+  END IF;
+END $$;
+
+-- Add index for efficient virtual session queries
+CREATE INDEX IF NOT EXISTS idx_claude_sessions_virtual
+  ON claude_sessions (parent_session_id)
+  WHERE is_virtual = TRUE;
+
+-- Add index for stale virtual session sweep (3-min threshold)
+CREATE INDEX IF NOT EXISTS idx_claude_sessions_virtual_heartbeat
+  ON claude_sessions (heartbeat_at)
+  WHERE is_virtual = TRUE AND status IN ('active', 'idle');
+
+COMMENT ON COLUMN claude_sessions.is_virtual IS 'True for drain agent virtual sessions (3-min stale threshold vs 15-min default)';
+COMMENT ON COLUMN claude_sessions.parent_session_id IS 'References the real session running the sd:drain command';
+COMMENT ON COLUMN claude_sessions.agent_slot IS 'Slot index (0-2) within the parent drainer';
+COMMENT ON COLUMN claude_sessions.last_progress_at IS 'Updated on meaningful work completion (handoff, commit, test pass) — distinct from heartbeat liveness';

--- a/lib/drain-orchestrator.mjs
+++ b/lib/drain-orchestrator.mjs
@@ -80,7 +80,7 @@ export class DrainOrchestrator {
   async loadQueue() {
     const { data, error } = await this.supabase
       .from('strategic_directives_v2')
-      .select('sd_key, title, sd_type, priority, current_phase, category')
+      .select('sd_key, title, sd_type, priority, current_phase, category, parent_sd_id, dependencies, metadata')
       .eq('is_active', true)
       .in('status', ['draft', 'in_progress', 'active'])
       .is('claiming_session_id', null)
@@ -101,6 +101,55 @@ export class DrainOrchestrator {
       if (targetCategory) {
         queue = queue.filter(sd => sd.category === targetCategory);
       }
+    }
+
+    // GUARDRAIL 6: Dependency-ordering filter — exclude child SDs whose parent
+    // has not completed PLAN phase. Prevents executing against partially-formed specs.
+    const childSDs = queue.filter(sd => sd.parent_sd_id);
+    if (childSDs.length > 0) {
+      const parentIds = [...new Set(childSDs.map(sd => sd.parent_sd_id))];
+      const { data: parents } = await this.supabase
+        .from('strategic_directives_v2')
+        .select('id, sd_key, current_phase, status')
+        .in('id', parentIds);
+
+      const completedParents = new Set(
+        (parents || [])
+          .filter(p => ['EXEC', 'EXEC_COMPLETE', 'COMPLETED'].includes(p.current_phase) || p.status === 'completed')
+          .map(p => p.id)
+      );
+
+      queue = queue.filter(sd => {
+        if (!sd.parent_sd_id) return true; // non-child SDs pass through
+        if (completedParents.has(sd.parent_sd_id)) return true; // parent finished PLAN
+        return false; // parent still in LEAD or PLAN — skip
+      });
+    }
+
+    // GUARDRAIL 7: Migration/schema serialization — SDs with risk keywords
+    // "migration" or "schema" must never run concurrently. If any slot is already
+    // running a migration/schema SD, exclude all others. If none running, allow at most one.
+    const SERIALIZED_KEYWORDS = /\b(migration|schema|migrate)\b/i;
+    const isSerializedSD = (sd) => {
+      const titleMatch = SERIALIZED_KEYWORDS.test(sd.title || '');
+      const typeMatch = sd.sd_type === 'migration';
+      const metaMatch = SERIALIZED_KEYWORDS.test(JSON.stringify(sd.metadata?.risk_keywords || ''));
+      return titleMatch || typeMatch || metaMatch;
+    };
+
+    const runningSerializedSD = this.slots.some(s =>
+      s.state === 'RUNNING' && s.sdKey && isSerializedSD({ title: s.sdKey }) // conservative: check active slots
+    );
+    if (runningSerializedSD) {
+      queue = queue.filter(sd => !isSerializedSD(sd));
+    } else {
+      // Allow at most one serialized SD — it will be the first one picked
+      let foundSerialized = false;
+      queue = queue.filter(sd => {
+        if (!isSerializedSD(sd)) return true;
+        if (!foundSerialized) { foundSerialized = true; return true; }
+        return false; // exclude additional serialized SDs
+      });
     }
 
     // Exclude already-processed and known-failed SDs
@@ -227,7 +276,7 @@ export class DrainOrchestrator {
     ], {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, DRAIN_AGENT_SLOT: String(slotIndex), DRAIN_PARENT_SESSION: this.parentSessionId }
+      env: this._buildAgentEnv(slotIndex)
     });
 
     slot.process = child;
@@ -265,6 +314,35 @@ export class DrainOrchestrator {
         slot.process.kill('SIGTERM');
       }
     }, AGENT_TIMEOUT_MS);
+  }
+
+  /**
+   * GUARDRAIL 8: Build a sanitized environment for sub-agents.
+   * Removes SUPABASE_SERVICE_ROLE_KEY — agents use SUPABASE_ANON_KEY instead.
+   */
+  _buildAgentEnv(slotIndex) {
+    const env = { ...process.env };
+    // Remove service role key — agents must not have superuser DB access
+    delete env.SUPABASE_SERVICE_ROLE_KEY;
+    // Add drain-specific identifiers
+    env.DRAIN_AGENT_SLOT = String(slotIndex);
+    env.DRAIN_PARENT_SESSION = this.parentSessionId;
+    env.DRAIN_AGENT = 'true';
+    return env;
+  }
+
+  /**
+   * GUARDRAIL 9: Kill all running sibling agents when circuit breaker trips.
+   */
+  _killAllRunningAgents(reason) {
+    for (const slot of this.slots) {
+      if (slot.process && slot.state === 'RUNNING') {
+        console.log(`  [Slot ${slot.slot}] Killing agent (circuit breaker): ${reason}`);
+        slot.process.kill('SIGTERM');
+        this._transition(slot.slot, 'FAILED');
+        this.progress.record(slot.slot, slot.sdKey, 'error', `Killed by circuit breaker: ${reason}`);
+      }
+    }
   }
 
   /**
@@ -307,6 +385,8 @@ export class DrainOrchestrator {
 
     if (result.tripped) {
       console.log(`\n🔴 CIRCUIT BREAKER TRIPPED: ${result.reason}`);
+      // GUARDRAIL 9: Immediately kill all running sibling agents
+      this._killAllRunningAgents(result.reason);
     }
 
     // Cleanup will happen asynchronously

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -23,7 +23,7 @@ function pad(str, len) {
 // ── Data Loading ──
 
 async function loadData() {
-  const [sessRes, allSessRes, childRes, workRes, coordRes, rawSessRes] = await Promise.all([
+  const [sessRes, allSessRes, childRes, workRes, coordRes, rawSessRes, drainRes] = await Promise.all([
     supabase
       .from('v_active_sessions')
       .select('session_id, sd_id, sd_title, heartbeat_age_seconds, heartbeat_age_human, computed_status, hostname, tty, pid, track')
@@ -55,11 +55,19 @@ async function loadData() {
       .select('session_id, sd_id, tty, status, heartbeat_at, pid')
       .not('sd_id', 'is', null)
       .order('heartbeat_at', { ascending: false })
-      .limit(30)
+      .limit(30),
+    // Drain agent sessions (virtual sessions with parent)
+    supabase
+      .from('claude_sessions')
+      .select('session_id, sd_id, status, heartbeat_at, is_virtual, parent_session_id, agent_slot, last_progress_at')
+      .eq('is_virtual', true)
+      .in('status', ['active', 'idle'])
+      .order('agent_slot', { ascending: true })
   ]);
 
   const sessions = sessRes.data || [];
   const allSessions = allSessRes.data || [];
+  const drainAgents = drainRes.data || [];
   const children = childRes.data || [];
   const workable = workRes.data || [];
   const coordMessages = coordRes.data || [];
@@ -109,7 +117,8 @@ async function loadData() {
     sessions, allSessions, children, workable, coordMessages, rawSessions, sdStatusMap,
     claimedSdIds, activeSessions, staleSessions, idleSessions,
     completedChildren, totalChildren, orchPct,
-    unclaimedChildren, unclaimedStandalone, bareShellSDs: bareShells
+    unclaimedChildren, unclaimedStandalone, bareShellSDs: bareShells,
+    drainAgents
   };
 }
 
@@ -156,6 +165,43 @@ function printWorkers(d) {
     }
   }
 
+  console.log('');
+}
+
+// ── Section: Drain Agents ──
+function printDrainAgents(d) {
+  if (!d.drainAgents || d.drainAgents.length === 0) return;
+
+  console.log('');
+  console.log('DRAIN AGENTS [virtual sessions]');
+  console.log('─'.repeat(72));
+  console.log('  ' + pad('Slot', 6) + pad('SD', 35) + pad('Status', 10) + pad('Progress', 12) + 'Heartbeat');
+  console.log('  ' + '─'.repeat(72));
+
+  // Group by parent_session_id
+  const byParent = {};
+  for (const a of d.drainAgents) {
+    const parent = a.parent_session_id || 'unknown';
+    if (!byParent[parent]) byParent[parent] = [];
+    byParent[parent].push(a);
+  }
+
+  for (const [parentId, agents] of Object.entries(byParent)) {
+    const shortParent = parentId.substring(0, 12);
+    console.log('  Parent: ' + shortParent + '...');
+    for (const a of agents) {
+      const slotLabel = a.agent_slot != null ? String(a.agent_slot) : '?';
+      const sd = a.sd_id || '(idle)';
+      const shortSd = sd.length > 33 ? sd.replace(/^SD-.*?-/, '').substring(0, 33) : sd;
+      const progressAge = a.last_progress_at
+        ? Math.round((Date.now() - new Date(a.last_progress_at).getTime()) / 1000) + 's ago'
+        : 'none';
+      const hbAge = a.heartbeat_at
+        ? Math.round((Date.now() - new Date(a.heartbeat_at).getTime()) / 1000) + 's ago'
+        : '?';
+      console.log('  ' + pad(slotLabel, 6) + pad(shortSd, 35) + pad(a.status, 10) + pad(progressAge, 12) + hbAge);
+    }
+  }
   console.log('');
 }
 
@@ -666,8 +712,10 @@ async function main() {
     qa:            () => printQA(d),
     forecast:      async () => await printForecast(d),
     predictions:   async () => await printPredictions(d),
+    drain:         () => printDrainAgents(d),
     all:           async () => {
       printWorkers(d);
+      printDrainAgents(d);
       printOrchestrator(d);
       printAvailable(d);
       printCoordination(d);


### PR DESCRIPTION
## Summary
- **Guardrail 6**: Dependency-ordering queue filter — child SDs excluded if parent hasn't completed PLAN phase
- **Guardrail 7**: Migration/schema serialization — SDs with migration/schema keywords never run concurrently
- **Guardrail 8**: Credential scoping — `_buildAgentEnv()` removes `SUPABASE_SERVICE_ROLE_KEY` from sub-agent environment
- **Guardrail 9**: Active sibling kill — `_killAllRunningAgents()` sends SIGTERM to all running agents on circuit breaker trip
- **Fleet dashboard**: New `printDrainAgents()` section shows virtual drain agents grouped by parent session
- **DB migration**: Adds `is_virtual`, `parent_session_id`, `agent_slot`, `last_progress_at` columns to `claude_sessions`

These guardrails were mandated by the Board of Directors deliberation (6/6 consensus) during the brainstorm that created this SD.

## Test plan
- [x] All drain modules import cleanly (`node -e "import('./lib/drain-orchestrator.mjs')"`)
- [x] Smoke tests pass (15/15)
- [x] DB migration applied and columns verified
- [x] `SUPABASE_SERVICE_ROLE_KEY` confirmed deleted from agent env in `_buildAgentEnv()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)