### PR TITLE
fix(SD-LEO-INFRA-PHANTOM-TABLE-REFERENCE-001-D): remove 22 phantom table refs in Quality/Governance

### DIFF
--- a/lib/eva/operations/domain-handler.js
+++ b/lib/eva/operations/domain-handler.js
@@ -43,40 +43,11 @@ export function registerOperationsHandlers(domainRegistry) {
   });
 
   domainRegistry.register('ops_feedback_classify', async (params) => {
-    const { classifyFeedback } = await import('../feedback-dimension-classifier.js');
-    const { supabase, logger = console } = params;
+    const { logger = console } = params;
 
-    // Verify feedback_items table exists before querying (migration safety)
-    const { error: probeError } = await supabase
-      .from('feedback_items')
-      .select('id', { count: 'exact', head: true })
-      .limit(0);
-
-    if (probeError) {
-      logger.warn(`[ops_feedback_classify] feedback_items table not available: ${probeError.message}`);
-      return { classified: 0, total: 0, skipped: true, reason: probeError.message, timestamp: new Date().toISOString() };
-    }
-
-    const { data: unclassified } = await supabase
-      .from('feedback_items')
-      .select('id, title, description')
-      .is('dimension_code', null)
-      .limit(20);
-
-    let classified = 0;
-    for (const item of unclassified || []) {
-      const result = await classifyFeedback(item.title, item.description || '', supabase);
-      if (result?.dimensionCode) {
-        await supabase
-          .from('feedback_items')
-          .update({ dimension_code: result.dimensionCode })
-          .eq('id', item.id);
-        classified++;
-      }
-    }
-
-    logger.info(`[ops_feedback_classify] Classified ${classified}/${(unclassified || []).length} item(s)`);
-    return { classified, total: (unclassified || []).length, timestamp: new Date().toISOString() };
+    // feedback_items table does not exist — operation is a no-op
+    logger.info('[ops_feedback_classify] Skipped: feedback_items table not available');
+    return { classified: 0, total: 0, skipped: true, reason: 'table_not_available', timestamp: new Date().toISOString() };
   });
 
   domainRegistry.register('ops_metrics_collect', async (params) => {

--- a/lib/eva/operations/index.js
+++ b/lib/eva/operations/index.js
@@ -81,15 +81,11 @@ async function getMetricsStatus(supabase, logger) {
 async function getFeedbackStatus(supabase, logger) {
   if (!supabase) return { subsystem: 'feedback-classifier', status: 'no-client' };
 
-  const { data, error } = await supabase
-    .from('feedback_items')
-    .select('id', { count: 'exact', head: true })
-    .gte('created_at', new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
-
+  // feedback_items table does not exist — return unavailable status
   return {
     subsystem: 'feedback-classifier',
-    status: error ? 'error' : 'active',
-    last24hItems: data?.length ?? 0,
+    status: 'unavailable',
+    last24hItems: 0,
   };
 }
 

--- a/lib/governance/aegis/validators/CustomValidator.js
+++ b/lib/governance/aegis/validators/CustomValidator.js
@@ -194,15 +194,12 @@ export class CustomValidator extends BaseValidator {
     }
 
     try {
-      const { data, error } = await this.supabase
-        .from('chairman_activity')
-        .select('activity_at')
-        .order('activity_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
+      // chairman_activity table does not exist — skip dead man switch check
+      const data = null;
+      const error = null;
 
-      if (error || !data) {
-        return this.formatResult(true, 'No chairman activity record - check skipped');
+      if (!data) {
+        return this.formatResult(true, 'No chairman activity record - check skipped (table not available)');
       }
 
       const hoursSinceActivity = (Date.now() - new Date(data.activity_at).getTime()) / (1000 * 60 * 60);

--- a/lib/governance/hard-halt-protocol.js
+++ b/lib/governance/hard-halt-protocol.js
@@ -410,20 +410,8 @@ export class HardHaltProtocol {
       console.warn(`[HardHaltProtocol] Unknown activity type: ${activityType}`);
     }
 
-    try {
-      await this.supabase
-        .from('chairman_activity')
-        .insert({
-          activity_type: activityType,
-          activity_at: new Date().toISOString(),
-          session_id: sessionId
-        });
-
-      console.log(`[HardHaltProtocol] Recorded Chairman activity: ${activityType}`);
-    } catch (err) {
-      // Table may not exist yet - log but don't fail
-      console.warn('[HardHaltProtocol] Could not record activity:', err.message);
-    }
+    // chairman_activity table does not exist — skip recording
+    console.log(`[HardHaltProtocol] Chairman activity (${activityType}) — table not available, skipped`);
   }
 
   // ===========================================================================
@@ -578,26 +566,8 @@ export class HardHaltProtocol {
   async _getLastChairmanActivity() {
     if (!this.supabase) return null;
 
-    try {
-      // Try chairman_activity table first
-      const { data, error } = await this.supabase
-        .from('chairman_activity')
-        .select('activity_at, activity_type')
-        .order('activity_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (!error && data) {
-        return data;
-      }
-
-      // Fallback: check session data or return mock for now
-      console.log('[HardHaltProtocol] No chairman_activity table, using fallback');
-      return null;
-    } catch (err) {
-      console.warn('[HardHaltProtocol] Error fetching Chairman activity:', err.message);
-      return null;
-    }
+    // chairman_activity table does not exist — return null (no activity data)
+    return null;
   }
 
   /**

--- a/lib/governance/manifesto-mode.js
+++ b/lib/governance/manifesto-mode.js
@@ -154,7 +154,7 @@ export class ManifestoMode {
     }
 
     const { data, error } = await this.supabase
-      .from('system_configuration')
+      .from('app_config')
       .select('value')
       .eq('key', this.config.configKey)
       .single();
@@ -180,7 +180,7 @@ export class ManifestoMode {
    */
   async getVersion() {
     const { data, error } = await this.supabase
-      .from('system_configuration')
+      .from('app_config')
       .select('value')
       .eq('key', this.config.versionKey)
       .single();
@@ -300,7 +300,7 @@ export class ManifestoMode {
 
     // Upsert manifesto_active flag
     const { error: configError } = await this.supabase
-      .from('system_configuration')
+      .from('app_config')
       .upsert({
         key: this.config.configKey,
         value: true,
@@ -314,7 +314,7 @@ export class ManifestoMode {
 
     // Upsert version
     const { error: versionError } = await this.supabase
-      .from('system_configuration')
+      .from('app_config')
       .upsert({
         key: this.config.versionKey,
         value: this.config.currentVersion,
@@ -426,7 +426,7 @@ export class ManifestoMode {
 
     // Update config
     const { error: configError } = await this.supabase
-      .from('system_configuration')
+      .from('app_config')
       .update({
         value: false,
         updated_at: deactivationTimestamp
@@ -607,7 +607,7 @@ export class ManifestoMode {
 
     // Update version in config
     const { error: configError } = await this.supabase
-      .from('system_configuration')
+      .from('app_config')
       .upsert({
         key: this.config.versionKey,
         value: newVersion,

--- a/lib/quality/ignore-patterns.js
+++ b/lib/quality/ignore-patterns.js
@@ -74,48 +74,20 @@ export async function createIgnorePattern(pattern) {
     }
   }
 
-  const { data, error } = await supabase
-    .from('feedback_ignore_patterns')
-    .insert({
-      field: pattern.field,
-      pattern_type: pattern.type,
-      pattern_value: pattern.value,
-      reason: pattern.reason || null,
-      created_by: pattern.createdBy || null,
-      expires_at: pattern.expiresAt || null,
-      is_active: true,
-      created_at: new Date().toISOString()
-    })
-    .select()
-    .single();
-
-  if (error) {
-    // If table doesn't exist, create it inline
-    if (error.code === '42P01') {
-      await createIgnorePatternsTable();
-      return createIgnorePattern(pattern);
-    }
-    throw new Error(`Failed to create ignore pattern: ${error.message}`);
-  }
-
-  // Invalidate cache
-  patternsCache = null;
-
-  return data;
+  // feedback_ignore_patterns table does not exist — return stub
+  console.warn('[ignore-patterns] createIgnorePattern: table not available, returning stub');
+  return {
+    id: null,
+    field: pattern.field,
+    pattern_type: pattern.type,
+    pattern_value: pattern.value,
+    is_active: false,
+    _stub: true
+  };
 }
 
-/**
- * Create the ignore patterns table if it doesn't exist.
- * NOTE: exec_sql RPC does not exist in Supabase. Table must be created
- * via a database migration. This function logs a warning and returns.
- */
-async function createIgnorePatternsTable() {
-  console.warn(
-    'feedback_ignore_patterns table does not exist. ' +
-    'Create it via a database migration (database/migrations/) — ' +
-    'Supabase does not support exec_sql RPC for DDL from the client.'
-  );
-}
+// feedback_ignore_patterns table does not exist in the database schema.
+// All CRUD operations in this module return no-op stubs.
 
 /**
  * Get all active ignore patterns
@@ -131,23 +103,9 @@ export async function getActivePatterns(forceRefresh = false) {
     return patternsCache;
   }
 
-  const { data, error } = await supabase
-    .from('feedback_ignore_patterns')
-    .select('*')
-    .eq('is_active', true)
-    .or('expires_at.is.null,expires_at.gt.' + new Date().toISOString());
-
-  if (error) {
-    if (error.code === '42P01') {
-      // Table doesn't exist yet, return empty
-      return [];
-    }
-    throw new Error(`Failed to fetch ignore patterns: ${error.message}`);
-  }
-
-  patternsCache = data || [];
+  // feedback_ignore_patterns table does not exist — return empty
+  patternsCache = [];
   patternsCacheExpiry = now + CACHE_TTL_MS;
-
   return patternsCache;
 }
 
@@ -241,18 +199,7 @@ export function globMatch(str, pattern) {
  * @param {string} patternId - Pattern ID
  */
 async function updateMatchStats(patternId) {
-  try {
-    await supabase.rpc('increment_pattern_match', { pattern_id: patternId });
-  } catch {
-    // Fallback to manual update
-    await supabase
-      .from('feedback_ignore_patterns')
-      .update({
-        match_count: supabase.sql`match_count + 1`,
-        last_match_at: new Date().toISOString()
-      })
-      .eq('id', patternId);
-  }
+  // feedback_ignore_patterns table does not exist — no-op
 }
 
 /**
@@ -262,24 +209,10 @@ async function updateMatchStats(patternId) {
  * @returns {Object} Updated pattern
  */
 export async function deactivatePattern(patternId) {
-  const { data, error } = await supabase
-    .from('feedback_ignore_patterns')
-    .update({
-      is_active: false,
-      updated_at: new Date().toISOString()
-    })
-    .eq('id', patternId)
-    .select()
-    .single();
-
-  if (error) {
-    throw new Error(`Failed to deactivate pattern: ${error.message}`);
-  }
-
-  // Invalidate cache
+  // feedback_ignore_patterns table does not exist — no-op
+  console.warn('[ignore-patterns] deactivatePattern: table not available');
   patternsCache = null;
-
-  return data;
+  return null;
 }
 
 /**
@@ -288,16 +221,8 @@ export async function deactivatePattern(patternId) {
  * @param {string} patternId - Pattern ID to delete
  */
 export async function deletePattern(patternId) {
-  const { error } = await supabase
-    .from('feedback_ignore_patterns')
-    .delete()
-    .eq('id', patternId);
-
-  if (error) {
-    throw new Error(`Failed to delete pattern: ${error.message}`);
-  }
-
-  // Invalidate cache
+  // feedback_ignore_patterns table does not exist — no-op
+  console.warn('[ignore-patterns] deletePattern: table not available');
   patternsCache = null;
 }
 

--- a/scripts/modules/audit/audit-runner.js
+++ b/scripts/modules/audit/audit-runner.js
@@ -567,39 +567,9 @@ async function reportToFeedback(findings, runId, auditResult) {
   let successCount = 0;
   let failureCount = 0;
 
-  for (const finding of findings) {
-    try {
-      const { error } = await supabase
-        .from('feedback_items')
-        .insert({
-          source: 'self_audit',
-          source_id: runId,
-          sd_id: finding.sd_id,
-          severity: finding.severity,
-          category: 'audit_finding',
-          title: finding.rule_name,
-          description: finding.message,
-          metadata: {
-            rule_id: finding.rule_id,
-            evidence: finding.evidence,
-            checklist_artifact_key: finding.checklist_artifact_key,
-            finding_id: finding.finding_id,
-            source_run_id: runId
-          },
-          status: 'new'
-        });
-
-      if (error) {
-        console.warn(`  Failed to post finding ${finding.finding_id}:`, error.message);
-        failureCount++;
-      } else {
-        successCount++;
-      }
-    } catch (err) {
-      console.warn('  Exception posting finding:', err.message);
-      failureCount++;
-    }
-  }
+  // feedback_items table does not exist — skip posting findings
+  console.log(`  feedback_items table not available — ${findings.length} finding(s) not posted`);
+  failureCount = findings.length;
 
   auditResult.devops_summary.feedback_post_success_count = successCount;
   auditResult.devops_summary.feedback_post_failure_count = failureCount;

--- a/scripts/modules/risk-classifier/anti-bloat-system.js
+++ b/scripts/modules/risk-classifier/anti-bloat-system.js
@@ -128,39 +128,8 @@ export class AntiBloatSystem {
       return { persisted: false, reason: 'no_database' };
     }
 
-    try {
-      const { data, error } = await this.supabase
-        .from('improvement_rejection_reasons')
-        .insert({
-          improvement_id: rejection.improvement_id,
-          category: rejection.category,
-          decision: rejection.decision,
-          score: rejection.score,
-          safety_score: rejection.safety_score,
-          tier: rejection.tier,
-          rule: rejection.rule,
-          human_reason: rejection.human_reason,
-          metadata: rejection.metadata,
-          created_at: rejection.timestamp
-        })
-        .select()
-        .single();
-
-      if (error) {
-        // Table may not exist yet - graceful fallback
-        if (error.code === '42P01') {
-          this.logger.warn('[AntiBloatSystem] Table improvement_rejection_reasons does not exist');
-          return { persisted: false, reason: 'table_not_exists' };
-        }
-        this.logger.error('[AntiBloatSystem] Persist failed:', error.message);
-        return { persisted: false, reason: error.message };
-      }
-
-      return { persisted: true, id: data.id, record: data };
-    } catch (err) {
-      this.logger.error('[AntiBloatSystem] Persist error:', err.message);
-      return { persisted: false, reason: err.message };
-    }
+    // improvement_rejection_reasons table does not exist — skip persistence
+    return { persisted: false, reason: 'table_not_available' };
   }
 
   /**
@@ -220,57 +189,15 @@ export class AntiBloatSystem {
       };
     }
 
-    try {
-      const { data, error } = await this.supabase
-        .from('v_protocol_size')
-        .select('*')
-        .single();
-
-      if (error) {
-        // View may not exist yet
-        if (error.code === '42P01' || error.code === 'PGRST116') {
-          return {
-            available: false,
-            reason: 'view_not_exists',
-            current_tokens: 0,
-            max_tokens: HEALTH_THRESHOLDS.MAX_PROTOCOL_TOKENS,
-            usage_percent: 0,
-            status: 'UNKNOWN'
-          };
-        }
-        throw error;
-      }
-
-      const currentTokens = data?.approx_tokens || 0;
-      const usagePercent = Math.round((currentTokens / HEALTH_THRESHOLDS.MAX_PROTOCOL_TOKENS) * 100);
-
-      let status = 'HEALTHY';
-      if (usagePercent >= HEALTH_THRESHOLDS.TOKEN_BUDGET_CRITICAL) {
-        status = 'CRITICAL';
-      } else if (usagePercent >= HEALTH_THRESHOLDS.TOKEN_BUDGET_WARNING) {
-        status = 'WARNING';
-      }
-
-      return {
-        available: true,
-        current_tokens: currentTokens,
-        max_tokens: HEALTH_THRESHOLDS.MAX_PROTOCOL_TOKENS,
-        usage_percent: usagePercent,
-        status,
-        budget_remaining: HEALTH_THRESHOLDS.MAX_PROTOCOL_TOKENS - currentTokens,
-        sections_count: data?.total_sections || 0
-      };
-    } catch (err) {
-      this.logger.error('[AntiBloatSystem] Token budget query error:', err.message);
-      return {
-        available: false,
-        reason: err.message,
-        current_tokens: 0,
-        max_tokens: HEALTH_THRESHOLDS.MAX_PROTOCOL_TOKENS,
-        usage_percent: 0,
-        status: 'ERROR'
-      };
-    }
+    // v_protocol_size view does not exist — return unavailable status
+    return {
+      available: false,
+      reason: 'view_not_available',
+      current_tokens: 0,
+      max_tokens: HEALTH_THRESHOLDS.MAX_PROTOCOL_TOKENS,
+      usage_percent: 0,
+      status: 'UNKNOWN'
+    };
   }
 
   /**
@@ -439,38 +366,12 @@ export class AntiBloatSystem {
       };
     }
 
-    try {
-      const { data, error } = await this.supabase
-        .from('v_improvement_pipeline')
-        .select('*')
-        .limit(100);
-
-      if (error) {
-        // View may not exist yet
-        if (error.code === '42P01' || error.code === 'PGRST116') {
-          return {
-            available: false,
-            reason: 'view_not_exists',
-            analytics: this.getLocalAnalytics()
-          };
-        }
-        throw error;
-      }
-
-      return {
-        available: true,
-        total_records: data?.length || 0,
-        pipeline_data: data,
-        analytics: this.getLocalAnalytics()
-      };
-    } catch (err) {
-      this.logger.error('[AntiBloatSystem] Pipeline analytics error:', err.message);
-      return {
-        available: false,
-        reason: err.message,
-        analytics: this.getLocalAnalytics()
-      };
-    }
+    // v_improvement_pipeline view does not exist — return local analytics only
+    return {
+      available: false,
+      reason: 'view_not_available',
+      analytics: this.getLocalAnalytics()
+    };
   }
 
   /**

--- a/tests/integration/eva/operations-workers.integration.test.js
+++ b/tests/integration/eva/operations-workers.integration.test.js
@@ -235,7 +235,7 @@ describe('ops_feedback_classify handler', () => {
     expect(typeof result.total).toBe('number');
   }, 120000);
 
-  it('queries feedback_items for unclassified entries', async () => {
+  it('returns skipped status since feedback_items table is unavailable', async () => {
     const { registerOperationsHandlers } = await import(
       '../../../lib/eva/operations/domain-handler.js'
     );
@@ -244,9 +244,10 @@ describe('ops_feedback_classify handler', () => {
     const handlers = {};
     registerOperationsHandlers({ register: (n, h) => (handlers[n] = h) });
 
-    await handlers.ops_feedback_classify({ supabase, logger: silentLogger });
+    const result = await handlers.ops_feedback_classify({ supabase, logger: silentLogger });
 
-    expect(supabase.from).toHaveBeenCalledWith('feedback_items');
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('table_not_available');
   }, 120000);
 });
 

--- a/tests/unit/governance/manifesto-mode.test.js
+++ b/tests/unit/governance/manifesto-mode.test.js
@@ -65,7 +65,7 @@ describe('ManifestoMode', () => {
       const result = await manifestoMode.isActive();
 
       expect(result).toBe(true);
-      expect(mockSupabaseClient.from).toHaveBeenCalledWith('system_configuration');
+      expect(mockSupabaseClient.from).toHaveBeenCalledWith('app_config');
     });
 
     it('should return false when manifesto_active is false', async () => {


### PR DESCRIPTION
## Summary
- Remove `.from()` calls to 7 non-existent tables across 8 source files in the Quality/Governance subsystem
- Migrate `system_configuration` references to `app_config` (correct table with same schema)
- Replace phantom calls with graceful no-ops, preserving existing null-safe patterns
- Net reduction of 269 lines (67 added, 336 removed)

## Tables cleaned
| Table | Refs removed | Files affected |
|-------|-------------|----------------|
| feedback_items | 5 | domain-handler.js, index.js, audit-runner.js |
| feedback_ignore_patterns | 5 | ignore-patterns.js |
| system_configuration | 6 | manifesto-mode.js (→ app_config) |
| chairman_activity | 3 | hard-halt-protocol.js, CustomValidator.js |
| improvement_rejection_reasons | 1 | anti-bloat-system.js |
| v_protocol_size | 1 | anti-bloat-system.js |
| v_improvement_pipeline | 1 | anti-bloat-system.js |

## Test plan
- [x] Zero `.from()` calls to any of the 7 phantom tables remain (grep verified)
- [x] 6 pre-existing test failures unchanged (baseline matched)
- [x] No new test regressions introduced
- [x] `getFeedbackStatus` preserves `no-client` status when supabase is null

🤖 Generated with [Claude Code](https://claude.com/claude-code)