### PR TITLE
feat(SD-LEO-INFRA-CUSTOM-SKILLS-PHASE-001-A): extract /leo settings into skill

### DIFF
--- a/.claude/commands/leo-settings.md
+++ b/.claude/commands/leo-settings.md
@@ -1,0 +1,80 @@
+---
+description: "View and modify LEO session settings (AUTO-PROCEED, Orchestrator Chaining). Use when user says /leo settings or needs to change session configuration."
+---
+
+<!-- GENERATED: hash=9ddd4dbe5907 timestamp=2026-04-03T19:00:30.243Z sections=1 -->
+
+# LEO Settings — View and Modify Session Configuration
+
+**Purpose**: Display and modify AUTO-PROCEED and Orchestrator Chaining settings.
+This skill handles global defaults, session overrides, and settings display.
+All database queries use canonical scripts.
+
+## Quick Reference
+```
+/leo settings     — View and modify settings
+```
+
+## Settings Protocol
+
+### LEO Settings Skill
+
+### Step 1: Query Current Settings
+
+Run the canonical settings script to get current values:
+```bash
+node scripts/leo-settings.js view
+```
+
+Parse the output for GLOBAL_AUTO_PROCEED, GLOBAL_CHAIN, SESSION_AUTO_PROCEED, SESSION_CHAIN values.
+
+### Step 2: Display Current Settings
+
+Present to the user:
+```
+LEO Settings
+
+Global Defaults (apply to new sessions):
+   Auto-Proceed: [GLOBAL_AUTO_PROCEED value]
+   Orchestrator Chaining: [GLOBAL_CHAIN value]
+
+Current Session:
+   Auto-Proceed: [SESSION_AUTO_PROCEED value] (or "inherited from global")
+   Orchestrator Chaining: [SESSION_CHAIN value] (or "inherited from global")
+
+Precedence: CLI flags > Session > Global > Default
+```
+
+### Step 3: Ask What to Configure
+
+Use AskUserQuestion with options:
+- "Change session settings" — Modify for THIS session only
+- "Change global defaults" — Modify for ALL future sessions
+- "View only" — Just display, no changes
+
+### Step 4a: Change Session Settings
+
+Ask about both Auto-Proceed and Chaining preferences using AskUserQuestion, then run:
+```bash
+node scripts/leo-settings.js session <true|false> <true|false>
+```
+
+### Step 4b: Change Global Defaults
+
+Ask using AskUserQuestion for preferences, then run:
+```bash
+node scripts/leo-settings.js global <true|false> <true|false>
+```
+
+### Step 5: Display Confirmation
+
+Show updated settings. Note: "Session settings override global defaults. New sessions inherit from global defaults."
+
+## Settings Precedence
+CLI flags > Session overrides > Global defaults > Hard-coded defaults
+
+## Anti-Drift Rules
+1. ALWAYS query current settings before displaying (never assume values)
+2. ALWAYS use AskUserQuestion for configuration changes
+3. NEVER modify settings without user confirmation
+4. Session settings override global defaults — display which layer is active

--- a/.claude/commands/leo.md
+++ b/.claude/commands/leo.md
@@ -201,141 +201,15 @@ Show an AI-generated narrative summary of project evolution based on merged GitH
    Display the script's stdout output directly to the user.
 
 ### If argument is "settings" or "s":
-Display and modify AUTO-PROCEED and Orchestrator Chaining settings.
 
-1. **First, query both global defaults and session settings:**
-   ```bash
-   node -e "
-   require('dotenv').config();
-   const { createClient } = require('@supabase/supabase-js');
-   const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+**DELEGATES TO**: `/leo-settings` skill (`.claude/commands/leo-settings.md`)
 
-   async function getSettings() {
-     // Get global defaults
-     const { data: globalData } = await supabase.rpc('get_leo_global_defaults');
-     const globals = globalData?.[0] || { auto_proceed: true, chain_orchestrators: false };
+Invoke the `leo-settings` skill using the Skill tool:
+```
+Skill tool: skill="leo-settings"
+```
 
-     // Get session settings
-     const { data: sessionData } = await supabase
-       .from('claude_sessions')
-       .select('session_id, metadata')
-       .eq('status', 'active')
-       .order('heartbeat_at', { ascending: false })
-       .limit(1)
-       .single();
-
-     const sessionAP = sessionData?.metadata?.auto_proceed;
-     const sessionChain = sessionData?.metadata?.chain_orchestrators;
-
-     console.log('GLOBAL_AUTO_PROCEED=' + globals.auto_proceed);
-     console.log('GLOBAL_CHAIN=' + globals.chain_orchestrators);
-     console.log('SESSION_ID=' + (sessionData?.session_id || 'none'));
-     console.log('SESSION_AUTO_PROCEED=' + (sessionAP === undefined ? 'inherited' : sessionAP));
-     console.log('SESSION_CHAIN=' + (sessionChain === undefined ? 'inherited' : sessionChain));
-   }
-
-   getSettings();
-   "
-   ```
-
-2. **Display current settings:**
-   ```
-   ⚙️  LEO Settings
-
-   Global Defaults (apply to new sessions):
-      Auto-Proceed: ON/OFF
-      Orchestrator Chaining: ON/OFF
-
-   Current Session:
-      Auto-Proceed: ON/OFF (or "inherited from global")
-      Orchestrator Chaining: ON/OFF (or "inherited from global")
-
-   Precedence: CLI flags > Session > Global > Default
-   ```
-
-3. **Ask what to configure:**
-   ```javascript
-   {
-     "questions": [
-       {
-         "question": "What would you like to configure?",
-         "header": "Settings",
-         "multiSelect": false,
-         "options": [
-           {"label": "Change session settings", "description": "Modify AUTO-PROCEED and Chaining for THIS session only"},
-           {"label": "Change global defaults", "description": "Modify defaults for ALL future sessions"},
-           {"label": "View only", "description": "Just display current settings without changing"}
-         ]
-       }
-     ]
-   }
-   ```
-
-4. **If "Change session settings" selected:**
-   Same flow as `/leo init` - ask about both preferences and update session metadata.
-
-5. **If "Change global defaults" selected:**
-   ```javascript
-   {
-     "questions": [
-       {
-         "question": "Set global AUTO-PROCEED default for new sessions:",
-         "header": "Auto-Proceed",
-         "multiSelect": false,
-         "options": [
-           {"label": "ON (Recommended)", "description": "New sessions auto-proceed through SD workflow"},
-           {"label": "OFF", "description": "New sessions pause at each phase transition"}
-         ]
-       },
-       {
-         "question": "Set global Orchestrator Chaining default for new sessions:",
-         "header": "Chaining",
-         "multiSelect": false,
-         "options": [
-           {"label": "OFF (Recommended)", "description": "Pause at orchestrator completion for review"},
-           {"label": "ON", "description": "Auto-continue to next orchestrator (power user mode)"}
-         ]
-       }
-     ]
-   }
-   ```
-
-   Then update global defaults:
-   ```bash
-   node -e "
-   require('dotenv').config();
-   const { createClient } = require('@supabase/supabase-js');
-   const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-   const autoProceed = process.argv[2] === 'true';
-   const chainOrchestrators = process.argv[3] === 'true';
-   supabase.rpc('set_leo_global_defaults', {
-     p_auto_proceed: autoProceed,
-     p_chain_orchestrators: chainOrchestrators,
-     p_updated_by: 'claude-session'
-   }).then(({data, error}) => {
-     if (error) console.error('Error:', error.message);
-     else console.log('Global defaults updated: auto_proceed=' + autoProceed + ', chain_orchestrators=' + chainOrchestrators);
-   });
-   " <true|false> <true|false>
-   ```
-
-6. **Display confirmation:**
-   ```
-   ✅ Settings Updated
-
-   [If session was changed]
-   Session Settings:
-      Auto-Proceed: ON/OFF
-      Orchestrator Chaining: ON/OFF
-
-   [If global was changed]
-   Global Defaults:
-      Auto-Proceed: ON/OFF
-      Orchestrator Chaining: ON/OFF
-
-   Note: Session settings override global defaults.
-   New sessions will inherit from global defaults.
-   ```
+The leo-settings skill handles querying current settings, displaying them, and modifying global defaults or session overrides.
 
 ### If argument is "restart" or "r":
 Run the LEO stack restart command:

--- a/scripts/generate-skills-from-db.js
+++ b/scripts/generate-skills-from-db.js
@@ -143,6 +143,34 @@ node scripts/handoff.js execute <PHASE> <SD-ID>
 4. NEVER retry blindly — read the error message and fix the specific issue
 `,
   },
+  'leo-settings': {
+    frontmatter: {
+      description: 'View and modify LEO session settings (AUTO-PROCEED, Orchestrator Chaining). Use when user says /leo settings or needs to change session configuration.',
+    },
+    header: `# LEO Settings — View and Modify Session Configuration
+
+**Purpose**: Display and modify AUTO-PROCEED and Orchestrator Chaining settings.
+This skill handles global defaults, session overrides, and settings display.
+All database queries use canonical scripts.
+
+## Quick Reference
+\`\`\`
+/leo settings     — View and modify settings
+\`\`\`
+
+## Settings Protocol
+`,
+    footer: `
+## Settings Precedence
+CLI flags > Session overrides > Global defaults > Hard-coded defaults
+
+## Anti-Drift Rules
+1. ALWAYS query current settings before displaying (never assume values)
+2. ALWAYS use AskUserQuestion for configuration changes
+3. NEVER modify settings without user confirmation
+4. Session settings override global defaults — display which layer is active
+`,
+  },
 };
 
 /**

--- a/scripts/leo-settings.js
+++ b/scripts/leo-settings.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * LEO Settings — Canonical script for viewing and modifying session settings.
+ *
+ * Usage:
+ *   node scripts/leo-settings.js view              — Display current settings
+ *   node scripts/leo-settings.js session <ap> <ch>  — Update session settings
+ *   node scripts/leo-settings.js global <ap> <ch>   — Update global defaults
+ *
+ * SD: SD-LEO-INFRA-CUSTOM-SKILLS-PHASE-001-A
+ */
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+
+dotenv.config();
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const [,, command, arg1, arg2] = process.argv;
+
+async function viewSettings() {
+  const { data: globalData } = await supabase.rpc('get_leo_global_defaults');
+  const globals = globalData?.[0] || { auto_proceed: true, chain_orchestrators: false };
+
+  const { data: sessionData } = await supabase
+    .from('claude_sessions')
+    .select('session_id, metadata')
+    .eq('status', 'active')
+    .order('heartbeat_at', { ascending: false })
+    .limit(1)
+    .single();
+
+  const sessionAP = sessionData?.metadata?.auto_proceed;
+  const sessionChain = sessionData?.metadata?.chain_orchestrators;
+
+  console.log('GLOBAL_AUTO_PROCEED=' + globals.auto_proceed);
+  console.log('GLOBAL_CHAIN=' + globals.chain_orchestrators);
+  console.log('SESSION_ID=' + (sessionData?.session_id || 'none'));
+  console.log('SESSION_AUTO_PROCEED=' + (sessionAP === undefined ? 'inherited' : sessionAP));
+  console.log('SESSION_CHAIN=' + (sessionChain === undefined ? 'inherited' : sessionChain));
+}
+
+async function updateSession(autoProceed, chainOrchestrators) {
+  const ap = autoProceed === 'true';
+  const ch = chainOrchestrators === 'true';
+  const { error } = await supabase.from('claude_sessions')
+    .upsert({
+      session_id: 'session_' + Date.now(),
+      status: 'active',
+      heartbeat_at: new Date().toISOString(),
+      metadata: { auto_proceed: ap, chain_orchestrators: ch }
+    }, { onConflict: 'session_id' });
+  if (error) console.error('Error:', error.message);
+  else console.log('Session preferences saved: auto_proceed=' + ap + ', chain_orchestrators=' + ch);
+}
+
+async function updateGlobal(autoProceed, chainOrchestrators) {
+  const ap = autoProceed === 'true';
+  const ch = chainOrchestrators === 'true';
+  const { error } = await supabase.rpc('set_leo_global_defaults', {
+    p_auto_proceed: ap,
+    p_chain_orchestrators: ch,
+    p_updated_by: 'claude-session'
+  });
+  if (error) console.error('Error:', error.message);
+  else console.log('Global defaults updated: auto_proceed=' + ap + ', chain_orchestrators=' + ch);
+}
+
+switch (command) {
+  case 'view':
+    await viewSettings();
+    break;
+  case 'session':
+    await updateSession(arg1, arg2);
+    break;
+  case 'global':
+    await updateGlobal(arg1, arg2);
+    break;
+  default:
+    await viewSettings();
+}


### PR DESCRIPTION
## Summary
- Extract /leo settings handler (136 lines) into DB-generated leo-settings.md skill
- Create scripts/leo-settings.js canonical script for settings queries
- Add leo-settings template to skill generation pipeline
- Leo.md: 39K -> 35K bytes (cumulative 34% reduction from original 52K)

## Test plan
- [ ] `/leo settings` delegates to leo-settings skill
- [ ] `npm run lint:skills` passes (3/3 clean)
- [ ] `node scripts/leo-settings.js view` returns correct settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)