### PR TITLE
fix: add guardrail ensuring venture repos are always private

### DIFF
--- a/lib/eva/__tests__/venture-provisioner.test.js
+++ b/lib/eva/__tests__/venture-provisioner.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { provisionVenture } from '../bridge/venture-provisioner.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROVISIONER_SRC = readFileSync(resolve(__dirname, '../bridge/venture-provisioner.js'), 'utf8');
 
 const noop = () => {};
 
@@ -122,5 +128,11 @@ describe('provisionVenture', () => {
 
   it('exports provisionVenture as a function', () => {
     expect(typeof provisionVenture).toBe('function');
+  });
+
+  it('SAFETY: venture repos must always be private, never public', () => {
+    expect(PROVISIONER_SRC).toContain("REPO_VISIBILITY = '--private'");
+    expect(PROVISIONER_SRC).not.toContain("'--public'");
+    expect(PROVISIONER_SRC).not.toContain('"--public"');
   });
 });

--- a/lib/eva/bridge/venture-provisioner.js
+++ b/lib/eva/bridge/venture-provisioner.js
@@ -23,6 +23,9 @@ const ENGINEER_ROOT = resolve(__dirname, '../../..');
 const MAX_RETRIES = 3;
 const BASE_DELAY_MS = 1000;
 
+// SAFETY: All venture repos MUST be private. NEVER change this visibility.
+const REPO_VISIBILITY = '--private';
+
 /** Minimal fallback hook when the full template is missing */
 const FALLBACK_HOOK = `#!/bin/bash
 # Minimal pre-commit secret detection (fallback)
@@ -85,7 +88,7 @@ const DEFAULT_STEPS = [
 
       // Create GitHub repo via gh CLI
       ctx.log(`[repo_created] Creating GitHub repo: rickfelix/${repoName}`);
-      execFileSync('gh', ['repo', 'create', `rickfelix/${repoName}`, '--private', '--description', `EHG Venture: ${ctx.venture.name}`], {
+      execFileSync('gh', ['repo', 'create', `rickfelix/${repoName}`, REPO_VISIBILITY, '--description', `EHG Venture: ${ctx.venture.name}`], {
         stdio: 'pipe', encoding: 'utf8', timeout: 30000
       });
 


### PR DESCRIPTION
## Summary
- Extracted `REPO_VISIBILITY = '--private'` constant in `venture-provisioner.js` with safety comment
- Added test assertion that fails if anyone changes visibility to public or removes the private flag
- Ensures all GitHub repos created by the venture provisioner remain private

## Test plan
- [x] `venture-provisioner.test.js` — all 10 tests pass including new safety assertion
- [x] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)