### PR TITLE
fix(SD-LEO-FIX-FIX-CLAIM-CONFLICT-001): release stale same-conversation claims before conflict check

### DIFF
--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -55,6 +55,40 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
   console.log(`   SD: ${sdId}`);
 
   try {
+    // SD-LEO-FIX-FIX-CLAIM-CONFLICT-001: Release stale sessions from the same
+    // hostname + terminal_id before checking for conflicts. Each handoff.js run
+    // creates a new session, leaving the previous run's session "active" until
+    // staleness timeout. This caused self-referential claim conflicts.
+    try {
+      await supabase.rpc('release_same_conversation_claims', {
+        p_sd_id: sdId,
+        p_hostname: currentHostname,
+        p_terminal_id: currentTerminalId,
+        p_current_session_id: currentSessionId
+      });
+    } catch (_) {
+      // RPC may not exist yet — fall back to direct cleanup
+      const { data: staleClaims } = await supabase
+        .from('claude_sessions')
+        .select('session_id, hostname, terminal_id')
+        .eq('sd_id', sdId)
+        .eq('status', 'active')
+        .eq('hostname', currentHostname);
+
+      const toRelease = (staleClaims || []).filter(s => {
+        if (s.session_id === currentSessionId) return false;
+        return isSameConversation(currentTerminalId, s.terminal_id) !== false;
+      });
+
+      for (const s of toRelease) {
+        await supabase
+          .from('claude_sessions')
+          .update({ sd_id: null, status: 'idle', released_at: new Date().toISOString() })
+          .eq('session_id', s.session_id);
+        console.log(`   🧹 Released stale same-conversation claim: ${s.session_id.substring(0, 24)}...`);
+      }
+    }
+
     // Query v_active_sessions for any active claim on this SD
     const { data, error } = await supabase
       .from('v_active_sessions')


### PR DESCRIPTION
## Summary
- Fix self-referential claim conflicts in `GATE_MULTI_SESSION_CLAIM_CONFLICT`
- Each `handoff.js` run creates a new session, leaving the previous run's session "active" until staleness timeout
- The claim conflict gate then blocks sequential handoffs on the same SD (burned 10/10 bypass attempts on previous SD)
- **Fix**: Before checking for conflicts, release any sessions from the same hostname + terminal_id that hold this SD

## Files Changed
- `scripts/modules/handoff/gates/multi-session-claim-gate.js` — Add self-cleanup before conflict check (+34 LOC)

## Test plan
- [x] 15/15 smoke tests passing
- [ ] Run 2 sequential handoffs on same SD without claim conflict failure
- [ ] Verify true multi-session conflicts (different hostname) still block

🤖 Generated with [Claude Code](https://claude.com/claude-code)