### PR TITLE
fix(db): backfill venture typed columns from metadata.stage_zero

### DIFF
--- a/database/migrations/20260403_backfill_venture_typed_columns.sql
+++ b/database/migrations/20260403_backfill_venture_typed_columns.sql
@@ -1,19 +1,20 @@
 -- SD-MAN-FIX-FIX-FRONTEND-VENTURE-001: Backfill typed columns from metadata.stage_zero
 -- For ventures created before the CLI fix (SD-LEO-FIX-FIX-STAGE-VENTURE-001) that have
 -- data in metadata->stage_zero but NULL typed columns.
+-- NOTE: moat_strategy and build_estimate are JSONB columns, so use -> (not ->>) to preserve type.
 
 UPDATE ventures
 SET
   solution = COALESCE(solution, metadata->'stage_zero'->>'solution'),
   raw_chairman_intent = COALESCE(raw_chairman_intent, metadata->'stage_zero'->>'raw_chairman_intent'),
   archetype = COALESCE(archetype, metadata->'stage_zero'->>'archetype'),
-  moat_strategy = COALESCE(moat_strategy, metadata->'stage_zero'->>'moat_strategy'),
+  moat_strategy = COALESCE(moat_strategy, metadata->'stage_zero'->'moat_strategy'),
   portfolio_synergy_score = COALESCE(
     portfolio_synergy_score,
     (metadata->'stage_zero'->>'portfolio_synergy_score')::numeric
   ),
   time_horizon_classification = COALESCE(time_horizon_classification, metadata->'stage_zero'->>'time_horizon_classification'),
-  build_estimate = COALESCE(build_estimate, metadata->'stage_zero'->>'build_estimate'),
+  build_estimate = COALESCE(build_estimate, metadata->'stage_zero'->'build_estimate'),
   discovery_strategy = COALESCE(
     discovery_strategy,
     metadata->'stage_zero'->'origin_metadata'->>'discovery_strategy'


### PR DESCRIPTION
## Summary
- Backfill migration that promotes data from metadata.stage_zero to 9 typed columns for existing ventures where typed columns are NULL
- Uses COALESCE to only update NULL columns (safe to re-run)
- Handles JSONB columns (moat_strategy, build_estimate) with -> operator

## Context
SD-MAN-FIX-FIX-FRONTEND-VENTURE-001: Companion to rickfelix/ehg#407 (frontend fix). 1 venture backfilled.

## Test plan
- [ ] Migration applied — 1 row affected
- [ ] Verify previously NULL typed columns now populated
- [ ] Verify COALESCE doesn't overwrite existing non-NULL values

🤖 Generated with [Claude Code](https://claude.com/claude-code)