### PR TITLE
feat(SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-B): add harness tests for 5 pre-tool-enforce.cjs permission tiers

### DIFF
--- a/tests/unit/hooks/pre-tool-enforce-background-ban.test.js
+++ b/tests/unit/hooks/pre-tool-enforce-background-ban.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+
+const HOOK_PATH = resolve(process.cwd(), 'scripts/hooks/pre-tool-enforce.cjs');
+
+function runHook(toolName, toolInput) {
+  try {
+    const result = execSync(`node "${HOOK_PATH}"`, {
+      env: { ...process.env, CLAUDE_TOOL_NAME: toolName, CLAUDE_TOOL_INPUT: JSON.stringify(toolInput) },
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000,
+    });
+    return { exitCode: 0, stdout: result, stderr: '' };
+  } catch (err) {
+    return { exitCode: err.status || 1, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+describe('Background Execution Ban (Enforcement 1 — NC-006)', () => {
+  it('blocks Task tool with run_in_background=true', () => {
+    const r = runHook('Task', { prompt: 'do something', run_in_background: true });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('PROTOCOL VIOLATION');
+  });
+
+  it('blocks Bash tool with run_in_background=true', () => {
+    const r = runHook('Bash', { command: 'echo hi', run_in_background: true });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('NC-006');
+  });
+
+  it('allows Task tool with run_in_background=false', () => {
+    const r = runHook('Task', { prompt: 'do something', run_in_background: false });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('allows Bash tool with no run_in_background field', () => {
+    const r = runHook('Bash', { command: 'echo hi' });
+    expect(r.exitCode).toBe(0);
+  });
+});

--- a/tests/unit/hooks/pre-tool-enforce-mcp-block.test.js
+++ b/tests/unit/hooks/pre-tool-enforce-mcp-block.test.js
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+
+const HOOK_PATH = resolve(process.cwd(), 'scripts/hooks/pre-tool-enforce.cjs');
+
+function runHook(toolName, toolInput) {
+  try {
+    const result = execSync(`node "${HOOK_PATH}"`, {
+      env: { ...process.env, CLAUDE_TOOL_NAME: toolName, CLAUDE_TOOL_INPUT: JSON.stringify(toolInput) },
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000,
+    });
+    return { exitCode: 0, stdout: result, stderr: '' };
+  } catch (err) {
+    return { exitCode: err.status || 1, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+describe('MCP Write Operation Block (Enforcement 6)', () => {
+  it('blocks mcp__supabase__apply_migration', () => {
+    const r = runHook('mcp__supabase__apply_migration', { name: 'test_migration', query: 'CREATE TABLE foo (id int);' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('MCP WRITE BLOCK');
+  });
+
+  it('allows mcp__supabase__execute_sql (read-only)', () => {
+    const r = runHook('mcp__supabase__execute_sql', { query: 'SELECT 1' });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('allows mcp__supabase__list_tables (read-only)', () => {
+    const r = runHook('mcp__supabase__list_tables', {});
+    expect(r.exitCode).toBe(0);
+  });
+});

--- a/tests/unit/hooks/pre-tool-enforce-routing.test.js
+++ b/tests/unit/hooks/pre-tool-enforce-routing.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+
+const HOOK_PATH = resolve(process.cwd(), 'scripts/hooks/pre-tool-enforce.cjs');
+
+function runHook(toolName, toolInput) {
+  try {
+    const result = execSync(`node "${HOOK_PATH}"`, {
+      env: { ...process.env, CLAUDE_TOOL_NAME: toolName, CLAUDE_TOOL_INPUT: JSON.stringify(toolInput) },
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000,
+    });
+    return { exitCode: 0, stdout: result, stderr: '' };
+  } catch (err) {
+    return { exitCode: err.status || 1, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+describe('Sub-Agent Routing Advisory (Enforcement 3)', () => {
+  it('exits 0 (advisory only, non-blocking) for routing mismatch', () => {
+    // "execute migration" is a DATABASE primary keyword — using wrong agent triggers hint
+    const r = runHook('Task', { subagent_type: 'api-agent', prompt: 'execute migration on the database' });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('emits ROUTING HINT to stdout when keyword matches wrong agent', () => {
+    const r = runHook('Task', { subagent_type: 'api-agent', prompt: 'execute migration on the users table' });
+    expect(r.stdout).toContain('ROUTING HINT');
+  });
+
+  it('emits no hint when correct agent type is used', () => {
+    const r = runHook('Task', { subagent_type: 'database-agent', prompt: 'execute migration on the users table' });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).not.toContain('ROUTING HINT');
+  });
+});

--- a/tests/unit/hooks/pre-tool-enforce-tool-policy.test.js
+++ b/tests/unit/hooks/pre-tool-enforce-tool-policy.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+import { writeFileSync, unlinkSync, mkdirSync, existsSync } from 'fs';
+
+const HOOK_PATH = resolve(process.cwd(), 'scripts/hooks/pre-tool-enforce.cjs');
+const AGENT_DIR = resolve(process.cwd(), '.claude/agents');
+const MOCK_AGENT = resolve(AGENT_DIR, '_test-restricted-agent.md');
+
+function runHook(toolName, toolInput) {
+  try {
+    const result = execSync(`node "${HOOK_PATH}"`, {
+      env: { ...process.env, CLAUDE_TOOL_NAME: toolName, CLAUDE_TOOL_INPUT: JSON.stringify(toolInput) },
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000,
+    });
+    return { exitCode: 0, stdout: result, stderr: '' };
+  } catch (err) {
+    return { exitCode: err.status || 1, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+describe('Tool Policy Profile Enforcement (Enforcement 2)', () => {
+  beforeEach(() => {
+    if (!existsSync(AGENT_DIR)) mkdirSync(AGENT_DIR, { recursive: true });
+    writeFileSync(MOCK_AGENT,
+      '---\nname: _test-restricted-agent\ndescription: "Test agent"\ntools: Read, Grep, Glob\n---\n# tool_policy_profile: readonly\n'
+    );
+  });
+
+  afterEach(() => {
+    if (existsSync(MOCK_AGENT)) unlinkSync(MOCK_AGENT);
+  });
+
+  it('exits 0 (advisory-only, non-blocking) when agent has restricted profile', () => {
+    const r = runHook('Task', { subagent_type: '_test-restricted-agent', prompt: 'read some files' });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('logs policy info to stdout for restricted agents', () => {
+    const r = runHook('Task', { subagent_type: '_test-restricted-agent', prompt: 'check something' });
+    expect(r.stdout).toMatch(/POLICY|profile/i);
+  });
+});

--- a/tests/unit/hooks/pre-tool-enforce-worktree.test.js
+++ b/tests/unit/hooks/pre-tool-enforce-worktree.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execSync } from 'child_process';
+import { resolve } from 'path';
+import { writeFileSync, unlinkSync, existsSync, readFileSync } from 'fs';
+
+const HOOK_PATH = resolve(process.cwd(), 'scripts/hooks/pre-tool-enforce.cjs');
+const STATE_FILE = resolve(process.cwd(), '.claude/unified-session-state.json');
+const STATE_BACKUP = STATE_FILE + '.test-backup';
+// SD key for "a different SD" — never matches this worktree
+const CLAIMED_SD = 'SD-UNIT-TEST-CLAIMED-999';
+
+function runHook(toolName, toolInput) {
+  try {
+    const result = execSync(`node "${HOOK_PATH}"`, {
+      env: { ...process.env, CLAUDE_TOOL_NAME: toolName, CLAUDE_TOOL_INPUT: JSON.stringify(toolInput) },
+      encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000,
+    });
+    return { exitCode: 0, stdout: result, stderr: '' };
+  } catch (err) {
+    return { exitCode: err.status || 1, stdout: err.stdout || '', stderr: err.stderr || '' };
+  }
+}
+
+describe('Worktree Claim Guard (Enforcement 4 — PAT-CLMMULTI-001)', () => {
+  beforeEach(() => {
+    if (existsSync(STATE_FILE)) writeFileSync(STATE_BACKUP, readFileSync(STATE_FILE));
+    writeFileSync(STATE_FILE, JSON.stringify({ sd: { id: CLAIMED_SD } }));
+  });
+
+  afterEach(() => {
+    if (existsSync(STATE_BACKUP)) { writeFileSync(STATE_FILE, readFileSync(STATE_BACKUP)); unlinkSync(STATE_BACKUP); }
+    else if (existsSync(STATE_FILE)) unlinkSync(STATE_FILE);
+  });
+
+  it('blocks Edit to a different SD worktree path', () => {
+    // .worktrees/<OTHER-SD>/file — different from what session claims
+    const r = runHook('Edit', { file_path: `/repo/.worktrees/SD-OTHER-PROJECT-001/src/foo.js`, old_string: 'a', new_string: 'b' });
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain('CLAIM GUARD');
+  });
+
+  it('allows Edit to the claimed SD worktree path', () => {
+    // .worktrees/<CLAIMED-SD>/file — matches session claim
+    const r = runHook('Edit', { file_path: `/repo/.worktrees/${CLAIMED_SD}/src/foo.js`, old_string: 'a', new_string: 'b' });
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('allows Edit outside any worktree (no .worktrees in path)', () => {
+    const r = runHook('Edit', { file_path: `/repo/src/app.js`, old_string: 'a', new_string: 'b' });
+    expect(r.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Creates 5 new test files in `tests/unit/hooks/` covering the 5 remaining untested permission tiers in `scripts/hooks/pre-tool-enforce.cjs`
- Each file uses `execSync` subprocess invocation with crafted `CLAUDE_TOOL_NAME`/`CLAUDE_TOOL_INPUT` env vars — no global state mutation
- Follows the pattern from the existing `db-only-enforcement.test.js`

## Test files added

| File | Rule | Coverage |
|------|------|----------|
| `pre-tool-enforce-background-ban.test.js` | Rule 1: NC-006 background execution ban | 4 tests — blocks run_in_background=true for Task/Bash, allows false/absent |
| `pre-tool-enforce-tool-policy.test.js` | Rule 2: Tool policy profile advisory | 2 tests — exit 0 with stdout log for restricted agents |
| `pre-tool-enforce-routing.test.js` | Rule 3: Sub-agent routing hint | 3 tests — ROUTING HINT emitted for keyword mismatch, silent for correct agent |
| `pre-tool-enforce-worktree.test.js` | Rule 4: Worktree claim guard | 3 tests — blocks cross-SD edits, allows same-SD and non-worktree paths |
| `pre-tool-enforce-mcp-block.test.js` | Rule 6: MCP write operation block | 3 tests — blocks apply_migration, allows execute_sql and list_tables |

**Total**: 15 tests, all passing.

## Test plan

- [x] Run `npm test tests/unit/hooks/pre-tool-enforce-background-ban.test.js` — 4/4 pass
- [x] Run `npm test tests/unit/hooks/pre-tool-enforce-tool-policy.test.js` — 2/2 pass
- [x] Run `npm test tests/unit/hooks/pre-tool-enforce-routing.test.js` — 3/3 pass
- [x] Run `npm test tests/unit/hooks/pre-tool-enforce-worktree.test.js` — 3/3 pass
- [x] Run `npm test tests/unit/hooks/pre-tool-enforce-mcp-block.test.js` — 3/3 pass

**SD**: SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-B
**Parent**: SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)