### PR TITLE
feat(SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-C): add permission audit trail

### DIFF
--- a/database/migrations/20260403_create_permission_audit_log.sql
+++ b/database/migrations/20260403_create_permission_audit_log.sql
@@ -1,0 +1,51 @@
+-- Migration: Create permission_audit_log table
+-- SD: SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-C
+-- Purpose: Centralized audit trail for all tool permission enforcement decisions
+-- made by pre-tool-enforce.cjs (PreToolUse hook). Async fire-and-forget writes
+-- ensure enforcement latency is not impacted.
+
+CREATE TABLE IF NOT EXISTS permission_audit_log (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  session_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  rule_code TEXT NOT NULL,
+  rule_description TEXT,
+  outcome TEXT NOT NULL CHECK (outcome IN ('allow', 'block', 'override', 'warn')),
+  context_hash TEXT,
+  metadata JSONB DEFAULT '{}'
+);
+
+-- Index for querying by session (most common access pattern)
+CREATE INDEX IF NOT EXISTS idx_permission_audit_session
+  ON permission_audit_log(session_id);
+
+-- Index for time-range queries and TTL cleanup
+CREATE INDEX IF NOT EXISTS idx_permission_audit_created
+  ON permission_audit_log(created_at);
+
+-- Index for filtering by outcome (e.g. all blocks in a session)
+CREATE INDEX IF NOT EXISTS idx_permission_audit_outcome
+  ON permission_audit_log(outcome);
+
+-- Add table comment for documentation
+COMMENT ON TABLE permission_audit_log IS
+  'Audit trail for tool permission enforcement decisions. Written async (fire-and-forget) by pre-tool-enforce.cjs hook. Never blocks enforcement.';
+
+COMMENT ON COLUMN permission_audit_log.session_id IS
+  'Claude Code session identifier (from SESSION_ID env var or generated)';
+
+COMMENT ON COLUMN permission_audit_log.tool_name IS
+  'Name of the tool that was evaluated (e.g. Bash, mcp__supabase__apply_migration)';
+
+COMMENT ON COLUMN permission_audit_log.rule_code IS
+  'Enforcement rule code that triggered the decision (e.g. BLOCK_APPLY_MIGRATION)';
+
+COMMENT ON COLUMN permission_audit_log.outcome IS
+  'Enforcement decision: allow, block, override, or warn';
+
+COMMENT ON COLUMN permission_audit_log.context_hash IS
+  'SHA-256 (truncated to 16 chars) of the tool input JSON for correlation';
+
+COMMENT ON COLUMN permission_audit_log.metadata IS
+  'Additional context: tool input snippet, rule details, override reason, etc.';

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -11,6 +11,7 @@
  * 5. DB-only strategic artifacts (SD-LEO-INFRA-ONLY-ENFORCEMENT-STRATEGIC-002) - HARD BLOCK (exit 2)
  * 6. MCP write operation block (SD-LEO-INFRA-MCP-READ-WRITE-001) - HARD BLOCK (exit 2)
  * 7. Schema pre-flight validation (SD-LEO-ORCH-SELF-HEALING-DATABASE-001-C) - TIERED (blocking/advisory/skip)
+ * 8. Permission audit trail (SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-C) - ASYNC WRITE (fire-and-forget)
  *
  * Hook API:
  *   Input:  CLAUDE_TOOL_INPUT (JSON), CLAUDE_TOOL_NAME (string)
@@ -20,6 +21,81 @@
 
 const TOOL_NAME = process.env.CLAUDE_TOOL_NAME || '';
 const TOOL_INPUT_RAW = process.env.CLAUDE_TOOL_INPUT || '';
+
+// --- ENFORCEMENT 8: Permission Audit Trail (SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-C) ---
+// Fire-and-forget async write to permission_audit_log table.
+// NEVER blocks enforcement decisions. All errors swallowed.
+// Uses native fetch (Node 18+) — no new dependencies.
+
+/**
+ * Generate a short hash of the tool input for audit correlation.
+ * Uses crypto module (built-in Node.js) for SHA-256, truncated to 16 chars.
+ * @param {string} inputRaw - Raw JSON string of tool input
+ * @returns {string} 16-char hex hash
+ */
+function _auditContextHash(inputRaw) {
+  try {
+    const crypto = require('crypto');
+    return crypto.createHash('sha256').update(inputRaw || '').digest('hex').slice(0, 16);
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Fire-and-forget async write to permission_audit_log.
+ * Called after every enforcement decision (allow/block/override/warn).
+ * Failures are logged to stderr but NEVER block enforcement.
+ *
+ * @param {string} sessionId   - Claude Code session ID
+ * @param {string} toolName    - Tool being evaluated (CLAUDE_TOOL_NAME)
+ * @param {string} ruleCode    - Enforcement rule code (e.g. 'NC-006', 'PAT-CLMMULTI-001')
+ * @param {string} ruleDesc    - Human-readable rule description
+ * @param {string} outcome     - 'allow' | 'block' | 'override' | 'warn'
+ * @param {Object} [metadata]  - Additional context (never contains secrets)
+ */
+function auditPermissionDecision(sessionId, toolName, ruleCode, ruleDesc, outcome, metadata) {
+  try {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceKey) return; // Missing credentials — skip silently
+
+    const url = supabaseUrl + '/rest/v1/permission_audit_log';
+    const body = JSON.stringify({
+      session_id: sessionId || 'unknown',
+      tool_name: toolName || 'unknown',
+      rule_code: ruleCode || 'UNKNOWN',
+      rule_description: ruleDesc || null,
+      outcome: outcome,
+      context_hash: _auditContextHash(TOOL_INPUT_RAW),
+      metadata: metadata || {}
+    });
+
+    // Fire and forget — no await, intentionally. Enforcement must not wait for audit.
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        'apikey': serviceKey,
+        'Authorization': 'Bearer ' + serviceKey,
+        'Content-Type': 'application/json',
+        'Prefer': 'return=minimal'
+      },
+      body
+    }).catch(err => {
+      // Swallow network errors — audit must never block enforcement
+      process.stderr.write('[pre-tool-enforce] AUDIT WRITE FAILED (non-blocking): ' + err.message + '\n');
+    });
+  } catch (e) {
+    // Swallow all errors — audit must never throw
+    process.stderr.write('[pre-tool-enforce] AUDIT ERROR (non-blocking): ' + e.message + '\n');
+  }
+}
+
+// Derive session ID once at module load time
+const _SESSION_ID = process.env.SESSION_ID ||
+  process.env.CLAUDE_SESSION_ID ||
+  process.env.LEO_SESSION_ID ||
+  'unknown';
 
 // --- WORKTREE CLAIM GUARD (PAT-CLMMULTI-001) ---
 // Regex to detect paths inside .worktrees/<SD-KEY>/
@@ -183,6 +259,7 @@ async function validateBeforeExecution(command) {
 
     if (!result.valid) {
       if (tier === 'blocking') {
+        auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'SCHEMA_PREFLIGHT', 'Schema pre-flight validation failed', 'block', { tableName, errors: result.errors });
         process.stderr.write(
           `SCHEMA VALIDATION FAILED (blocking):\n` +
           `  Table: ${tableName}\n` +
@@ -192,6 +269,7 @@ async function validateBeforeExecution(command) {
         process.exit(2);
       } else {
         // Advisory: warn but allow
+        auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'SCHEMA_PREFLIGHT_ADVISORY', 'Schema pre-flight validation warning', 'warn', { tableName, errors: result.errors });
         console.log(
           `[schema-preflight] WARNING: ${result.errors.join('; ')} (table: ${tableName})`
         );
@@ -219,6 +297,7 @@ async function main() {
   // Applies to Task and Bash tools
   if (TOOL_NAME === 'Task' || TOOL_NAME === 'Bash') {
     if (input.run_in_background === true) {
+      auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'NC-006', 'Background execution ban (AUTO-PROCEED)', 'block', {});
       process.stderr.write(
         'PROTOCOL VIOLATION (NC-006): Background execution is forbidden when AUTO-PROCEED is ON.\n' +
         'Run this command in the foreground. Background tasks break the autonomous chain of thought.\n'
@@ -244,6 +323,7 @@ async function main() {
           const state = JSON.parse(fs.readFileSync(stateFile, 'utf8'));
           const claimedSd = state.sd?.id;
           if (claimedSd && claimedSd !== worktreeSdKey) {
+            auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'PAT-CLMMULTI-001', 'Worktree claim guard', 'block', { worktreeSdKey, claimedSd });
             process.stderr.write(
               `CLAIM GUARD (PAT-CLMMULTI-001): Edit/Write blocked.\n` +
               `  Target worktree: ${worktreeSdKey}\n` +
@@ -272,6 +352,7 @@ async function main() {
     // Block new file creation in docs/plans/ (excluding archived/)
     if (/docs\/plans\/(?!archived\/)/.test(filePath) && filePath.endsWith('.md')) {
       if (!fs.existsSync(input.file_path)) {
+        auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'SD-LEO-INFRA-ONLY-ENFORCEMENT-STRATEGIC-002', 'DB-only strategic artifacts: docs/plans/', 'block', { filePath });
         process.stderr.write(
           'DB-ONLY ENFORCEMENT: Blocked new markdown file in docs/plans/.\n' +
           'Vision/architecture documents must be stored in the database.\n' +
@@ -285,6 +366,7 @@ async function main() {
     // Block ALL markdown writes to brainstorm/ (new or existing)
     // Brainstorm content belongs in brainstorm_sessions.content column, not on disk.
     if (/brainstorm\/[^/]+\.md$/.test(filePath)) {
+      auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'SD-LEO-INFRA-ONLY-ENFORCEMENT-STRATEGIC-002', 'DB-only strategic artifacts: brainstorm/', 'block', { filePath });
       process.stderr.write(
         'DB-ONLY ENFORCEMENT: Blocked markdown write to brainstorm/.\n' +
         'Brainstorm content must be stored in brainstorm_sessions.content column.\n' +
@@ -299,6 +381,7 @@ async function main() {
   // Block mcp__supabase__apply_migration — it's a write op but MCP role is read-only.
   // Read tools (execute_sql, list_tables, list_extensions, list_migrations) remain allowed.
   if (TOOL_NAME === 'mcp__supabase__apply_migration') {
+    auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'SD-LEO-INFRA-MCP-READ-WRITE-001', 'MCP write operation block', 'block', {});
     process.stderr.write(
       'MCP WRITE BLOCK: mcp__supabase__apply_migration is a write operation.\n' +
       'The MCP Supabase role (supabase_read_only_user) cannot execute migrations.\n' +
@@ -329,6 +412,7 @@ async function main() {
           // This is informational — the YAML frontmatter already restricts what Claude sees
           const profile = content.match(/^# tool_policy_profile:\s*(\w+)/m);
           if (profile && profile[1] !== 'full') {
+            auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'TOOL_POLICY_PROFILE', 'Tool policy profile advisory', 'warn', { agentType, profile: profile[1], toolCount: declaredTools.length });
             console.log(
               `[pre-tool-enforce] POLICY: Agent "${agentType}" uses profile "${profile[1]}" ` +
               `(${declaredTools.length} tools allowed)`
@@ -351,6 +435,7 @@ async function main() {
       const matchedKeyword = route.keywords.find(k => promptLower.includes(k));
       if (matchedKeyword && currentType !== route.agent) {
         // Don't block - advise. The model may have a good reason for its choice.
+        auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'ROUTING_ADVISORY', 'Sub-agent routing advisory', 'warn', { matchedKeyword, suggestedAgent: route.agent, actualAgent: currentType });
         console.log(
           `[pre-tool-enforce] ROUTING HINT: Detected "${matchedKeyword}" in prompt. ` +
           `Consider using subagent_type="${route.agent}" for best results.`
@@ -370,6 +455,8 @@ async function main() {
     }
   }
 
+  // Final allow decision — audit the pass-through
+  auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'ALLOW', 'Tool call permitted by all enforcement rules', 'allow', {});
   process.exitCode = 0; // Allow
 }
 

--- a/scripts/permission-audit-log.cjs
+++ b/scripts/permission-audit-log.cjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * permission-audit-log.cjs
+ * CLI script for querying the permission_audit_log table.
+ * SD: SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-C
+ *
+ * Usage:
+ *   node scripts/permission-audit-log.cjs [options]
+ *
+ * Options:
+ *   --session <id>      Filter by session_id
+ *   --since <datetime>  Filter created_at >= <datetime> (ISO 8601)
+ *   --outcome <value>   Filter by outcome: allow | block | override | warn
+ *   --rule <code>       Filter by rule_code
+ *   --limit <n>         Max results (default: 20)
+ *   --help              Show this help message
+ *
+ * Examples:
+ *   node scripts/permission-audit-log.cjs --session abc123
+ *   node scripts/permission-audit-log.cjs --since 2026-04-03T00:00:00Z --outcome block
+ *   node scripts/permission-audit-log.cjs --rule NC-006 --limit 50
+ */
+
+'use strict';
+
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+// --- Argument parsing ---
+const args = process.argv.slice(2);
+
+function getArg(flag) {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return null;
+  return args[idx + 1] || null;
+}
+
+function hasFlag(flag) {
+  return args.includes(flag);
+}
+
+if (hasFlag('--help') || hasFlag('-h')) {
+  console.log(`
+permission-audit-log.cjs — Query the LEO permission audit log
+
+Usage:
+  node scripts/permission-audit-log.cjs [options]
+
+Options:
+  --session <id>      Filter by session_id
+  --since <datetime>  Filter created_at >= <datetime> (ISO 8601)
+  --outcome <value>   Filter by outcome: allow | block | override | warn
+  --rule <code>       Filter by rule_code
+  --limit <n>         Max results (default: 20)
+  --help              Show this help
+
+Examples:
+  node scripts/permission-audit-log.cjs --session abc123
+  node scripts/permission-audit-log.cjs --since 2026-04-03T00:00:00Z --outcome block
+  node scripts/permission-audit-log.cjs --rule NC-006 --limit 50
+`);
+  process.exit(0);
+}
+
+const sessionFilter = getArg('--session');
+const sinceFilter = getArg('--since');
+const outcomeFilter = getArg('--outcome');
+const ruleFilter = getArg('--rule');
+const limitStr = getArg('--limit');
+const limit = limitStr ? parseInt(limitStr, 10) : 20;
+
+// Validate outcome if provided
+const VALID_OUTCOMES = ['allow', 'block', 'override', 'warn'];
+if (outcomeFilter && !VALID_OUTCOMES.includes(outcomeFilter)) {
+  console.error('Error: --outcome must be one of: ' + VALID_OUTCOMES.join(', '));
+  process.exit(1);
+}
+
+// Validate limit
+if (isNaN(limit) || limit < 1) {
+  console.error('Error: --limit must be a positive integer');
+  process.exit(1);
+}
+
+// --- Supabase client ---
+const supabaseUrl = process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceKey) {
+  console.error('Error: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceKey);
+
+// --- Query execution ---
+async function main() {
+  let query = supabase
+    .from('permission_audit_log')
+    .select('created_at, session_id, tool_name, rule_code, rule_description, outcome, context_hash, metadata')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (sessionFilter) {
+    query = query.eq('session_id', sessionFilter);
+  }
+  if (sinceFilter) {
+    query = query.gte('created_at', sinceFilter);
+  }
+  if (outcomeFilter) {
+    query = query.eq('outcome', outcomeFilter);
+  }
+  if (ruleFilter) {
+    query = query.eq('rule_code', ruleFilter);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error('Query error:', error.message);
+    process.exit(1);
+  }
+
+  if (!data || data.length === 0) {
+    console.log('No results found.');
+    process.exit(0);
+  }
+
+  // --- Formatted output ---
+  console.log('\nPermission Audit Log');
+  console.log('='.repeat(100));
+
+  // Print applied filters
+  const filters = [];
+  if (sessionFilter) filters.push('session=' + sessionFilter);
+  if (sinceFilter) filters.push('since=' + sinceFilter);
+  if (outcomeFilter) filters.push('outcome=' + outcomeFilter);
+  if (ruleFilter) filters.push('rule=' + ruleFilter);
+  if (filters.length > 0) {
+    console.log('Filters: ' + filters.join(', '));
+  }
+  console.log('Results: ' + data.length + ' row(s) (limit: ' + limit + ')');
+  console.log('='.repeat(100));
+
+  // Column widths
+  const COL_TS = 24;
+  const COL_SESSION = 28;
+  const COL_TOOL = 28;
+  const COL_RULE = 30;
+  const COL_OUTCOME = 10;
+
+  function pad(str, len) {
+    const s = String(str || '').slice(0, len);
+    return s + ' '.repeat(Math.max(0, len - s.length));
+  }
+
+  // Header
+  console.log(
+    pad('created_at', COL_TS) + ' | ' +
+    pad('session_id', COL_SESSION) + ' | ' +
+    pad('tool_name', COL_TOOL) + ' | ' +
+    pad('rule_code', COL_RULE) + ' | ' +
+    pad('outcome', COL_OUTCOME)
+  );
+  console.log('-'.repeat(COL_TS + COL_SESSION + COL_TOOL + COL_RULE + COL_OUTCOME + 12));
+
+  // Rows
+  for (const row of data) {
+    const ts = row.created_at ? new Date(row.created_at).toISOString().replace('T', ' ').slice(0, 23) : '';
+    console.log(
+      pad(ts, COL_TS) + ' | ' +
+      pad(row.session_id, COL_SESSION) + ' | ' +
+      pad(row.tool_name, COL_TOOL) + ' | ' +
+      pad(row.rule_code, COL_RULE) + ' | ' +
+      pad(row.outcome, COL_OUTCOME)
+    );
+
+    // Show rule_description if present
+    if (row.rule_description) {
+      console.log('  desc: ' + row.rule_description);
+    }
+  }
+
+  console.log('='.repeat(100));
+  console.log('');
+}
+
+main().catch(err => {
+  console.error('Unexpected error:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Creates `permission_audit_log` Supabase table (migration `20260403_create_permission_audit_log.sql`) with session_id, tool_name, rule_code, outcome CHECK constraint, context_hash, metadata JSONB, and three indexes
- Adds `auditPermissionDecision()` fire-and-forget function to `scripts/hooks/pre-tool-enforce.cjs` that posts to `permission_audit_log` after every allow/block/override/warn enforcement decision using native Node 18+ fetch with no blocking
- Adds `scripts/permission-audit-log.cjs` CLI with `--session`, `--since`, `--outcome`, `--rule`, `--limit` flags for querying the audit table

## Test plan

- [ ] Run `node scripts/query-permission-audit.cjs --limit 5` (renamed to `permission-audit-log.cjs` due to gitignore rules)
- [ ] Trigger a tool call that gets blocked and verify a row appears in `permission_audit_log` with `outcome=block`
- [ ] Run `node scripts/permission-audit-log.cjs --outcome allow --limit 10` and verify formatted table output
- [ ] Confirm hook enforcement behavior is unchanged when DB is unreachable (audit swallows errors)

## SD Details

- **SD**: SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001-C
- **Parent**: SD-LEO-INFRA-LEO-PRIMITIVE-PARITY-001 (LEO 12/12 Primitive Parity)
- **Type**: infrastructure
- **Handoffs**: LEAD-TO-PLAN (95%), PLAN-TO-EXEC (90%), PLAN-TO-LEAD (88%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)