### PR TITLE
fix(QF-20260403-759): add CI gate for scripts/hooks/ directory changes

### DIFF
--- a/.github/workflows/hooks-harness-tests.yml
+++ b/.github/workflows/hooks-harness-tests.yml
@@ -1,0 +1,32 @@
+name: Hooks Harness Tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/hooks/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  harness-tests:
+    name: Run Hooks Harness Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run hooks harness tests
+        env:
+          NODE_OPTIONS: --experimental-vm-modules
+        run: npm test -- tests/unit/hooks/


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/hooks-harness-tests.yml` — a path-filtered CI workflow that triggers only when PRs touch `scripts/hooks/**`
- Runs `npm ci` then `npm test -- tests/unit/hooks/` to execute the hooks harness test suite
- Uses Node.js 22 on `ubuntu-latest`, matching project CI conventions
- 32 LOC total, well within the 50 LOC quick-fix limit

## Test plan
- [ ] Verify workflow triggers on a PR that modifies a file under `scripts/hooks/`
- [ ] Verify workflow does NOT trigger on PRs that only modify unrelated files
- [ ] Confirm `tests/unit/hooks/db-only-enforcement.test.js` passes in CI

Fixes: QF-20260403-759

Generated with [Claude Code](https://claude.com/claude-code)