### PR TITLE
fix(QF-20260404-445): fix ship worktree cleanup ordering — cd before delete

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -459,23 +459,29 @@ This step runs automatically via PostToolUse hook - no manual action required.
 
 This prevents zombie worktree directories that point at deleted branches.
 
+**CRITICAL (QF-20260404-445 / PAT-WORKTREE-LIFECYCLE-001):** You MUST `cd` to the main repo BEFORE running cleanup. Deleting a worktree while CWD is inside it corrupts the Windows shell — all subsequent commands (including handoff scripts) fail with ERR_MODULE_NOT_FOUND.
+
 ```bash
-node scripts/modules/shipping/post-merge-worktree-cleanup.js
+# STEP 1: cd to main repo FIRST (before cleanup deletes the directory)
+cd C:\Users\rickf\Projects\_EHG\EHG_Engineer
+
+# STEP 2: Clean up using --sdKey mode (resolves worktree path externally, not from CWD)
+node scripts/modules/shipping/post-merge-worktree-cleanup.js --sdKey <SD-KEY-OR-QF-KEY>
 ```
 
 **If output contains `"cleaned": true`:**
 1. The worktree directory has been removed
-2. `cd` to the `mainRepoPath` from the output to return to the main repo
-3. Run `git checkout main && git pull` from the main repo
+2. You are already in the main repo (from Step 1 above)
+3. Run `git checkout main && git pull` to sync
 
 **If output contains `"cleaned": false`:**
-- No action needed (not inside a worktree)
+- No action needed (worktree not found or already cleaned)
 - Continue to Step 7
 
 **Example outputs:**
 ```json
-{"cleaned":true,"mainRepoPath":"C:/Users/rickf/Projects/_EHG/EHG_Engineer","workKey":"QF-20260211-001"}
-{"cleaned":false,"reason":"not_in_worktree"}
+{"cleaned":true,"mainRepoPath":"C:/Users/rickf/Projects/_EHG/EHG_Engineer","workKey":"QF-20260211-001","sdKey":"QF-20260211-001","resolvedFrom":"scan"}
+{"cleaned":false,"reason":"no_worktree_found","sdKey":"SD-XXX-001"}
 ```
 
 **Note:** The existing LEAD-FINAL-APPROVAL cleanup is kept as a safety net. It is idempotent — if this step already cleaned up, it reports "worktree_not_found" and moves on.

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -8,6 +8,7 @@
 import ResultBuilder from '../ResultBuilder.js';
 import { safeTruncate as _safeTruncate } from '../../../../lib/utils/safe-truncate.js';
 import path from 'path';
+import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { shouldSkipAndContinue, executeSkipAndContinue } from '../skip-and-continue.js';
@@ -55,6 +56,14 @@ function getRepoPath(repoName) {
         encoding: 'utf8',
         stdio: ['pipe', 'pipe', 'pipe']
       }).trim();
+      // QF-20260404-445: If resolved path is inside a deleted worktree (node_modules
+      // missing), fall back to __dirname-based resolution. This prevents
+      // ERR_MODULE_NOT_FOUND when handoffs run after worktree cleanup.
+      const nmPath = path.join(_cachedGitRoot, 'node_modules');
+      if (_cachedGitRoot.includes('.worktrees') && !fs.existsSync(nmPath)) {
+        console.debug('[BaseExecutor] Dead worktree detected, falling back to __dirname');
+        _cachedGitRoot = path.resolve(__dirname, '../../../../');
+      }
     } catch (e) {
       // Intentionally suppressed: Fallback when git rev-parse unavailable
       console.debug('[BaseExecutor] getRepoPath git rev-parse fallback:', e?.message || e);

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -31,6 +31,15 @@ function getMainRepoPath(meta, wtPath) {
 function cleanupCurrentWorktree() {
   if (!isInsideWorktree()) return { cleaned: false, reason: 'not_in_worktree' };
   const wtPath = gitExec('git rev-parse --show-toplevel');
+  // QF-20260404-445: Warn if CWD is inside the worktree about to be deleted.
+  // On Windows, deleting the CWD directory corrupts the shell — subsequent
+  // commands (handoffs, node module resolution) fail with ERR_MODULE_NOT_FOUND.
+  const cwd = process.cwd().replace(/\\/g, '/');
+  const normalized = wtPath.replace(/\\/g, '/');
+  if (cwd.startsWith(normalized)) {
+    const result = cleanupWorktreeByPath(wtPath);
+    return { ...result, warning: 'CWD_INSIDE_TARGET', hint: 'cd to main repo BEFORE running cleanup to avoid shell corruption' };
+  }
   return cleanupWorktreeByPath(wtPath);
 }
 


### PR DESCRIPTION
## Summary
- Fix ship.md Step 6.7 to cd to main repo BEFORE worktree cleanup (was deleting CWD)
- Add CWD_INSIDE_TARGET warning to post-merge-worktree-cleanup.js
- Add dead-worktree fallback in BaseExecutor.getRepoPath() (checks node_modules exists)
- Root cause: PAT-WORKTREE-LIFECYCLE-001 violation caused ERR_MODULE_NOT_FOUND on post-merge handoffs

## Test plan
- [ ] Ship from worktree: merge PR, cleanup, then run handoff — no ERR_MODULE_NOT_FOUND
- [ ] BaseExecutor resolves to main repo when CWD is dead worktree
- [ ] Cleanup script emits CWD_INSIDE_TARGET warning when called from inside worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)