### PR TITLE
fix(SD-LEO-INFRA-LLM-MODEL-CONFIG-001): remove gpt-5.4-mini/nano from temperature blocklist

### DIFF
--- a/lib/config/model-config.js
+++ b/lib/config/model-config.js
@@ -91,10 +91,9 @@ const VALID_PURPOSES = ['validation', 'classification', 'generation', 'fast', 'v
  * BL-INF-2337D: gpt-5-mini returns 400 error if temperature != 1
  */
 const MODELS_WITHOUT_TEMPERATURE_SUPPORT = [
-  'gpt-5.4-mini',
-  'gpt-5.4-nano',
-  'gpt-5-mini',
-  'gpt-4o-mini',
+  'gpt-5-mini',    // Legacy: gpt-5-mini returns 400 if temperature != 1
+  'gpt-4o-mini',   // Legacy: older mini model, same limitation
+  // Note: gpt-5.4-mini and gpt-5.4-nano DO support custom temperature (verified 2026-04-04)
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Remove gpt-5.4-mini and gpt-5.4-nano from `MODELS_WITHOUT_TEMPERATURE_SUPPORT`
- Live API testing confirmed both models accept `temperature` values of 0, 0.5, and 1 without error
- The temperature limitation was specific to the older gpt-5-mini and does not carry forward to the 5.4 generation

## Test plan
- [x] `gpt-5.4-mini` with `temperature=0` → 200 OK (704ms)
- [x] `gpt-5.4-mini` with `temperature=0.5` → 200 OK (811ms)
- [x] `gpt-5.4-mini` with `temperature=1` → 200 OK (1183ms)
- [x] `gpt-5.4-nano` with `temperature=0` → 200 OK (937ms)
- [x] `gpt-5.4-nano` with `temperature=0.5` → 200 OK (1381ms)
- [x] 15/15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)