### PR TITLE
fix(multi-model): wire per-seat provider routing + Anthropic passthrough

### DIFF
--- a/lib/brainstorm/deliberation-engine.js
+++ b/lib/brainstorm/deliberation-engine.js
@@ -23,9 +23,45 @@ import {
   updateDebateRound
 } from './board-judiciary-bridge.js';
 import { recordSeatAssignments, advanceRotation, isMultiModelEnabled } from './provider-rotation.js';
+import { getLLMClient } from '../llm/client-factory.js';
 
 const QUORUM_PERCENTAGE = 0.67; // 67% of panel size
 const DELIBERATION_TIMEOUT_MS = 180_000; // 3 minutes
+
+/**
+ * Create a per-seat invokeAgent wrapper that routes through the assigned provider.
+ * Anthropic seats use the default invokeAgent (Claude Code itself) — no external API needed.
+ * Google and OpenAI seats route through getLLMClient with provider override.
+ * Falls back to default invokeAgent on any error.
+ *
+ * @param {object} providerAssignment - {provider, modelId} from rotation scheduler
+ * @param {Function} defaultInvokeAgent - The session's default invokeAgent callback (Claude Code)
+ * @returns {Function} (systemPrompt, userPrompt) => string
+ */
+function createProviderInvokeAgent(providerAssignment, defaultInvokeAgent) {
+  if (!providerAssignment) return defaultInvokeAgent;
+
+  // Anthropic seats: use Claude Code directly (we're already inside it)
+  if (providerAssignment.provider === 'anthropic') {
+    return defaultInvokeAgent;
+  }
+
+  // Google/OpenAI seats: route through external API
+  return async (systemPrompt, userPrompt) => {
+    try {
+      const client = getLLMClient({
+        provider: providerAssignment.provider,
+        model: providerAssignment.modelId,
+        purpose: 'board-deliberation'
+      });
+      const result = await client.complete(systemPrompt, userPrompt);
+      return result?.content || result?.text || (typeof result === 'string' ? result : '');
+    } catch (err) {
+      console.warn(`[deliberation-engine] Provider ${providerAssignment.provider} failed, falling back to Claude Code:`, err.message);
+      return defaultInvokeAgent(systemPrompt, userPrompt);
+    }
+  };
+}
 
 /**
  * Execute a full board deliberation on a brainstorm topic.
@@ -100,7 +136,7 @@ export async function executeDeliberation({
   }
   result.preSeededSpecialists = preSeeded;
 
-  // 4. Round 1: All panel members in parallel
+  // 4. Round 1: All panel members in parallel (with per-seat provider routing)
   const round1Promises = panel.map(async seat => {
     const seatStart = Date.now();
     const prompt = seat.systemPrompt({
@@ -108,7 +144,12 @@ export async function executeDeliberation({
       specialistTestimony: preSeededRoster
     });
 
-    const position = await invokeAgent(
+    // Route through assigned provider if multi-model is active
+    const seatInvokeAgent = multiModel
+      ? createProviderInvokeAgent(seat.providerAssignment, invokeAgent)
+      : invokeAgent;
+
+    const position = await seatInvokeAgent(
       prompt,
       `Deliberation Topic: ${topic}\n\nDomain: ${topicContext.domain || 'general'}\n\nProduce your ${seat.title} position on this topic. Address your standing question: "${seat.standingQuestion}"\n\nBe specific to this topic. Reference concrete details.`
     );
@@ -227,7 +268,12 @@ export async function executeDeliberation({
       specialistTestimony: specialistContext
     });
 
-    const rebuttal = await invokeAgent(
+    // Route Round 2 through same provider as Round 1 for continuity
+    const seatInvokeAgent = multiModel
+      ? createProviderInvokeAgent(seat.providerAssignment, invokeAgent)
+      : invokeAgent;
+
+    const rebuttal = await seatInvokeAgent(
       prompt,
       `ROUND 2 REBUTTAL — Deliberation Topic: "${topic}"
 


### PR DESCRIPTION
## Summary
Restores per-seat provider routing that was lost in squash merge of PR #2691.

- Anthropic seats pass through to Claude Code (no external API needed)
- Google/OpenAI seats route through `getLLMClient({provider})` to external APIs
- Graceful fallback to Claude Code on any provider error
- Both Round 1 and Round 2 use per-seat routing

## Verified
- Google (gemini-2.5-pro): responds via external API
- OpenAI (gpt-5.4): responds via external API  
- Anthropic: uses Claude Code directly (no ANTHROPIC_API_KEY needed)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Both external providers respond to test prompts
- [x] Backward compatible when MULTI_MODEL_DELIBERATION=false

🤖 Generated with [Claude Code](https://claude.com/claude-code)