### PR TITLE
fix(handoff): remove status overwrite from displayExecutionResult

### DIFF
--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -245,25 +245,15 @@ export async function displayExecutionResult(result, handoffType, sdId) {
 
     const nextStep = nextStepMap[handoffType.toUpperCase()];
     if (nextStep) {
-      // Update SD status in database
+      // RCA-FIX: Removed status write — the executor's state-transitions.js is the
+      // authoritative state setter. This display function was overwriting the executor's
+      // status (e.g., 'in_progress' → 'planning'), which then blocked subsequent handoffs
+      // because verify-l2p rejects 'planning'. See PAT-HANDOFF-STATUS-OVERWRITE-001.
       const supabase = createSupabaseServiceClient();
       const canonicalId = await normalizeSDId(supabase, sdId);
 
-      if (canonicalId) {
-        const { data: updateData, error: updateError } = await supabase
-          .from('strategic_directives_v2')
-          .update({ status: nextStep.status, updated_at: new Date().toISOString() })
-          .eq('id', canonicalId)
-          .select('id')
-          .single();
-
-        if (updateError) {
-          console.warn(`   ⚠️  Failed to update SD status: ${updateError.message}`);
-        } else if (!updateData) {
-          console.warn('   ⚠️  SD status update returned no data - possible silent failure');
-        } else if (sdId !== canonicalId) {
-          console.log(`   ℹ️  ID normalized: "${sdId}" -> "${canonicalId}"`);
-        }
+      if (canonicalId && sdId !== canonicalId) {
+        console.log(`   ℹ️  ID normalized: "${sdId}" -> "${canonicalId}"`);
       }
 
       console.log('');

--- a/scripts/verify-l2p/constants.js
+++ b/scripts/verify-l2p/constants.js
@@ -92,7 +92,7 @@ export const TYPE_PATTERNS = {
 /**
  * Valid SD statuses for LEAD-TO-PLAN handoff
  */
-export const VALID_SD_STATUSES = ['draft', 'active', 'in_progress', 'pending_approval'];
+export const VALID_SD_STATUSES = ['draft', 'active', 'in_progress', 'pending_approval', 'planning'];
 
 /**
  * Risk keywords that suggest SD should have risk documentation


### PR DESCRIPTION
## Summary
- **Root Cause Fix**: `displayExecutionResult()` was silently overwriting the executor's authoritative state transition (`in_progress` → `planning`), blocking all subsequent LEAD-TO-PLAN retries
- Remove the status UPDATE from the display helper — `state-transitions.js` is the single source of truth
- Add `planning` to `VALID_SD_STATUSES` in `verify-l2p/constants.js` for defensive alignment

### Systemic Impact
Affected **any SD** where LEAD-TO-PLAN succeeded then needed retry — status stuck at `planning` which `verify-l2p` rejected. RCA: PAT-HANDOFF-STATUS-OVERWRITE-001.

## Test plan
- [x] Smoke tests pass (15/15)
- [x] RCA traced dual-write path through 5-whys analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)