### PR TITLE
fix(deliberation): map snake_case DB fields to camelCase in rotation state

### DIFF
--- a/lib/brainstorm/provider-rotation.js
+++ b/lib/brainstorm/provider-rotation.js
@@ -83,7 +83,9 @@ export async function getCurrentRotationState() {
     .limit(1)
     .single();
 
-  return data || { rotationIndex: 0, lastRotation: {} };
+  return data
+    ? { rotationIndex: data.rotation_index ?? 0, lastRotation: data.last_rotation ?? {} }
+    : { rotationIndex: 0, lastRotation: {} };
 }
 
 /**


### PR DESCRIPTION
## Summary
- `getCurrentRotationState()` returned raw DB column names (`rotation_index`, `last_rotation`) but callers destructured camelCase (`rotationIndex`)
- When `provider_rotation_state` had a row, `rotationIndex` was `undefined` → `ROTATION_MATRIX[NaN]` → `.length` crash in `panel-selector.js`
- Root cause: `brainstorm-deliberate.js --dry-run` fatal error discovered during brainstorm session

## Test plan
- [x] `node scripts/brainstorm-deliberate.js --topic "test" --dry-run` succeeds (previously crashed)
- [ ] Full board deliberation via `/brainstorm` completes panel selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)