### PR TITLE
feat(SD-LEO-INFRA-CENTRALIZE-HARDCODED-MODEL-001): centralize last hardcoded model strings

### DIFF
--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -523,7 +523,7 @@ export class OllamaAdapter {
     this.family = 'local';
     this.fallbackEnabled = options.fallbackEnabled ??
       (process.env.OLLAMA_FALLBACK_ENABLED !== 'false');
-    this.fallbackModel = options.fallbackModel || 'claude-haiku-4-5-20251001';
+    this.fallbackModel = options.fallbackModel || getClaudeModel('fast');
     this.timeoutMs = options.timeoutMs ||
       parseInt(process.env.OLLAMA_TIMEOUT_MS, 10) || 30000;
     addOpenAICompatLayer(this);
@@ -696,13 +696,13 @@ export function getAllAdapters(options = {}) {
  *
  * @param {Object} options - Adapter options
  * @param {string} options.localModel - Local model to use (default: qwen3-coder:30b)
- * @param {string} options.cloudModel - Cloud fallback model (default: claude-haiku-4-5-20251001)
+ * @param {string} options.cloudModel - Cloud fallback model (default: claude haiku fast tier)
  * @returns {OllamaAdapter}
  */
 export function getLocalFirstAdapter(options = {}) {
   return new OllamaAdapter({
     model: options.localModel || 'qwen3-coder:30b',
-    fallbackModel: options.cloudModel || 'claude-haiku-4-5-20251001',
+    fallbackModel: options.cloudModel || getClaudeModel('fast'),
     fallbackEnabled: true,
     ...options
   });


### PR DESCRIPTION
## Summary
- Replace last 2 hardcoded `claude-haiku-4-5-20251001` strings in `provider-adapters.js` with `getClaudeModel('fast')` getter calls
- OllamaAdapter constructor fallbackModel default and `getLocalFirstAdapter()` cloudModel default
- All other hardcoded model strings were already centralized by parallel session work
- Verification grep confirms zero remaining stale model strings in production code

## Context
Discovered during extent-of-condition analysis after SD-LEO-INFRA-LLM-MODEL-CONFIG-001 (model config upgrade). Initial scan found ~15 files with hardcoded strings — most were centralized by parallel sessions, leaving only these 2 instances.

## Test plan
- [x] 15/15 smoke tests pass
- [x] `grep -rn "claude-haiku-4-5-20251001" lib/ src/ --include="*.js" | grep -v node_modules | grep -v archive | grep -v test` returns only the model-config.js default (correct)
- [x] getClaudeModel('fast') returns 'claude-haiku-4-5-20251001' (current default, centralized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)