### PR TITLE
fix(sd-next): check SD work evidence before treating claims as orphaned

### DIFF
--- a/scripts/modules/sd-next/claim-analysis.js
+++ b/scripts/modules/sd-next/claim-analysis.js
@@ -99,6 +99,52 @@ export function analyzeClaimRelationship({ claimingSessionId: _claimingSessionId
 }
 
 /**
+ * Check whether the SD itself shows evidence of recent active work,
+ * independent of session heartbeat status. Prevents treating an SD as
+ * orphaned when a session compacted, restarted, or is mid-long-execution.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdId - The SD UUID (id column)
+ * @param {Object} sd - SD row with current_phase, progress_percentage, updated_at
+ * @param {number} [recencyMinutes=30] - How recent updated_at must be to count as active
+ * @returns {Promise<{ hasEvidence: boolean, reasons: string[] }>}
+ */
+export async function hasActiveWorkEvidence(supabase, sdId, sd, recencyMinutes = 30) {
+  const reasons = [];
+
+  // 1. SD in EXEC with non-zero progress — real implementation work happened
+  if (sd.current_phase === 'EXEC' && (sd.progress_percentage || 0) > 0) {
+    reasons.push(`EXEC phase at ${sd.progress_percentage}% progress`);
+  }
+
+  // 2. SD updated_at is recent — someone touched this SD recently
+  if (sd.updated_at) {
+    const updatedAt = new Date(sd.updated_at);
+    const ageMinutes = (Date.now() - updatedAt.getTime()) / 60000;
+    if (ageMinutes < recencyMinutes) {
+      reasons.push(`updated ${Math.round(ageMinutes)}m ago`);
+    }
+  }
+
+  // 3. Recent phase handoff records — confirms pipeline activity
+  const { data: handoffs } = await supabase
+    .from('sd_phase_handoffs')
+    .select('from_phase, to_phase, created_at')
+    .eq('sd_id', sdId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  if (handoffs && handoffs.length > 0) {
+    const handoffAge = (Date.now() - new Date(handoffs[0].created_at).getTime()) / 60000;
+    if (handoffAge < recencyMinutes) {
+      reasons.push(`handoff ${handoffs[0].from_phase}→${handoffs[0].to_phase} ${Math.round(handoffAge)}m ago`);
+    }
+  }
+
+  return { hasEvidence: reasons.length > 0, reasons };
+}
+
+/**
  * Auto-release a stale dead claim. Only call when relationship is 'stale_dead'
  * (triple-confirmed: heartbeat stale + same host + PID dead).
  *

--- a/scripts/modules/sd-next/display/recommendations.js
+++ b/scripts/modules/sd-next/display/recommendations.js
@@ -7,7 +7,7 @@ import { colors } from '../colors.js';
 import { isActionableForLead } from '../status-helpers.js';
 import { checkDependenciesResolved, checkMetadataDependency, resolveMetadataBlocker } from '../dependency-resolver.js';
 import { getEstimatedDuration, formatEstimateShort } from '../../../lib/duration-estimator.js';
-import { analyzeClaimRelationship } from '../claim-analysis.js';
+import { analyzeClaimRelationship, hasActiveWorkEvidence } from '../claim-analysis.js';
 
 /**
  * Display recommendations section and return structured action data.
@@ -254,7 +254,7 @@ async function categorizeBaselineSDs(supabase, baselineItems, sessionContext = {
   for (const item of baselineItems) {
     const { data: sd } = await supabase
       .from('strategic_directives_v2')
-      .select('id, sd_key, title, status, current_phase, progress_percentage, dependencies, is_active, metadata, claiming_session_id')
+      .select('id, sd_key, title, status, current_phase, progress_percentage, dependencies, is_active, metadata, claiming_session_id, updated_at')
       .or(`sd_key.eq.${item.sd_id},id.eq.${item.sd_id}`)
       .single();
 
@@ -270,8 +270,28 @@ async function categorizeBaselineSDs(supabase, baselineItems, sessionContext = {
             claimingSession,
             currentSession
           });
-          if (analysis.relationship === 'same_conversation' || analysis.relationship === 'stale_dead') {
+          if (analysis.relationship === 'same_conversation') {
             actionable = true;
+          } else if (analysis.relationship === 'stale_dead') {
+            // Don't assume orphaned — check if SD itself shows recent work
+            // (session may have compacted, restarted, or be mid-execution)
+            const evidence = await hasActiveWorkEvidence(supabase, sd.id, sd);
+            if (evidence.hasEvidence) {
+              console.log(`  ${colors.dim}⚠ ${sd.sd_key} claim looks stale but SD has active work: ${evidence.reasons.join(', ')}${colors.reset}`);
+              actionable = false; // Protect the claim
+            } else {
+              actionable = true; // Truly orphaned — no session AND no SD activity
+            }
+          }
+        } else if (!claimingSession) {
+          // Claiming session not in active list at all — could be compacted/restarted
+          // Cross-check SD-level evidence before assuming orphaned
+          const evidence = await hasActiveWorkEvidence(supabase, sd.id, sd);
+          if (evidence.hasEvidence) {
+            console.log(`  ${colors.dim}⚠ ${sd.sd_key} session missing but SD has active work: ${evidence.reasons.join(', ')}${colors.reset}`);
+            actionable = false; // Protect — session likely compacted
+          } else {
+            actionable = true; // No session + no SD activity = truly orphaned
           }
         }
         if (!actionable) continue;


### PR DESCRIPTION
## Summary
- Adds `hasActiveWorkEvidence()` to `claim-analysis.js` that checks SD phase/progress, `updated_at` recency, and phase handoff records
- Updates `categorizeBaselineSDs()` in `recommendations.js` to cross-check SD-level evidence when a session is stale-dead or missing from active list
- Prevents stomping on claims where the session compacted, restarted, or is mid-long-execution but the SD has real EXEC progress

## Test plan
- [x] Both modules import cleanly (`node -e "import(...)"`)
- [x] `npm run sd:next` runs without errors
- [x] Smoke tests pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)