### PR TITLE
fix(config): align statusline and remove duplicate hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:/Users/rickf/Projects/_EHG/EHG_Engineer/.claude/statusline-context-tracker.ps1"
+    "command": "node C:/Users/rickf/Projects/_EHG/EHG_Engineer/.claude/statusline.cjs"
   },
   "hooks": {
     "PreCompact": [


### PR DESCRIPTION
## Summary
- Aligned project statusline from PowerShell (`statusline-context-tracker.ps1`) to canonical Node.js implementation (`statusline.cjs`), matching global config
- Removed duplicate `coordination-inbox.cjs` hook from global settings — was running twice per tool call (once from global, once from project)
- Cleaned up ~47MB of stale files (old log backups + ~10,700 orphaned status-line PID files)

## Test plan
- [x] Smoke tests pass (15/15)
- [x] Both settings.json files validate as valid JSON
- [x] Statusline renders correctly with `.cjs` implementation
- [ ] Verify coordination-inbox fires only once per tool call

🤖 Generated with [Claude Code](https://claude.com/claude-code)