### PR TITLE
feat(SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001): fix win-pid-* identity matching + sweep cleanup

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -89,19 +89,42 @@ function getSupabase() {
 export function isSameConversation(tidA, tidB) {
   if (tidA === tidB) return true;
 
-  // SD-LEO-INFRA-CONSOLIDATE-CLAIMS-INTO-001: UUID vs port-based cross-format match.
-  // The concurrent-session worktree hook assigns UUID-format terminal_ids while the
-  // fallback path produces win-cc-{port}. Both formats can coexist for subprocesses
-  // of the same Claude Code instance on the same machine.
+  // Format detectors
   const isUUID = (tid) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(tid || '');
   const isWinCC = (tid) => /^win-cc-\d+/.test(tid || '');
+  // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-4): Parse win-pid-{pid} fallback format.
+  // When getTerminalId() falls to the lowest fallback, it produces win-pid-{process.pid}.
+  // Previously unparseable, causing line 117 to return false for all win-pid comparisons.
+  const isWinPid = (tid) => /^win-pid-\d+$/.test(tid || '');
+  const parseWinPid = (tid) => {
+    const match = tid?.match(/^win-pid-(\d+)$/);
+    return match ? match[1] : null;
+  };
+
+  // SD-LEO-INFRA-CONSOLIDATE-CLAIMS-INTO-001: UUID vs port-based cross-format match.
   if ((isUUID(tidA) && isWinCC(tidB)) || (isUUID(tidB) && isWinCC(tidA))) return 'ambiguous';
+
+  // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-4): UUID vs win-pid cross-format match.
+  // win-pid-* is a per-process fallback — it cannot be matched to a UUID deterministically.
+  // Return 'ambiguous' to allow evidence-gated adoption upstream (heartbeat + SD phase check).
+  if ((isUUID(tidA) && isWinPid(tidB)) || (isUUID(tidB) && isWinPid(tidA))) return 'ambiguous';
+
+  // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-4): win-pid vs win-pid comparison.
+  // Same PID = same process = same conversation. Different PIDs = ambiguous (could be
+  // different Bash tool invocations from the same Claude Code instance).
+  if (isWinPid(tidA) && isWinPid(tidB)) {
+    const pidA = parseWinPid(tidA);
+    const pidB = parseWinPid(tidB);
+    return pidA === pidB ? true : 'ambiguous';
+  }
+
+  // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001: win-cc vs win-pid cross-format match.
+  // Both are Windows fallback formats from the same machine — ambiguous.
+  if ((isWinCC(tidA) && isWinPid(tidB)) || (isWinCC(tidB) && isWinPid(tidA))) return 'ambiguous';
 
   // Two UUID-format terminal_ids: compare literally.
   // Post PR #2231, getTerminalId() resolves via SSE port marker match,
   // producing stable UUIDs. Two different UUIDs = different conversations.
-  // (Previously returned 'ambiguous' due to marker cleanup instability,
-  // but SSE port matching eliminated that failure mode.)
   if (isUUID(tidA) && isUUID(tidB)) return false;
 
   // Parse win-cc-{port}[-{pid}] format
@@ -263,8 +286,9 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
       const sameConversation = isSameConversation(myTerminalId, claim.terminal_id);
 
       if (sameConversation === true) {
-        // Case A: Same SSE port + same PID suffix → definitely same conversation
-        console.log(`[claimGuard] Same-conversation match: adopting claim from ${claim.session_id} (terminal: ${claim.terminal_id})`);
+        // Case A: Definite same-conversation match → adopt claim
+        // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-6): Audit log on every identity transfer
+        console.log(`[claimGuard] IDENTITY_TRANSFER: prior_session=${claim.session_id}, new_session=${sessionId}, staleness_delta=${heartbeatAge}s, gate_result=ALLOW, my_terminal=${myTerminalId}, their_terminal=${claim.terminal_id}`);
         await supabase
           .from('claude_sessions')
           .update({ heartbeat_at: new Date().toISOString() })
@@ -285,7 +309,8 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
         }
 
         if (!processAlive) {
-          console.log(`[claimGuard] Ambiguous terminal match, claim holder PID ${claimPid} is dead — releasing ${claim.session_id}`);
+          // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-6): Audit log on ambiguous release
+          console.log(`[claimGuard] IDENTITY_TRANSFER: prior_session=${claim.session_id}, new_session=${sessionId}, staleness_delta=${heartbeatAge}s, gate_result=ALLOW_AMBIGUOUS_DEAD_PID, claim_pid=${claimPid}, my_terminal=${myTerminalId}, their_terminal=${claim.terminal_id}`);
           const { error: releaseError } = await supabase.rpc('release_sd', {
             p_session_id: claim.session_id,
             p_reason: 'manual'

--- a/lib/claim-guard.test.js
+++ b/lib/claim-guard.test.js
@@ -739,3 +739,97 @@ describe('formatClaimFailure', () => {
     expect(formatted).toContain('process alive');
   });
 });
+
+/**
+ * SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-4): Tests for win-pid-* format support
+ * in isSameConversation(). Previously, win-pid-* terminal_ids fell through parseWinCC()
+ * and returned false at line 117, blocking legitimate session transitions.
+ */
+describe('isSameConversation - win-pid-* format', () => {
+  let isSameConversation;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: vi.fn(() => mockSupabase)
+    }));
+    vi.doMock('dotenv', () => ({
+      default: { config: vi.fn() },
+      config: vi.fn()
+    }));
+    const mod = await import('./claim-guard.mjs');
+    isSameConversation = mod.isSameConversation;
+  });
+
+  // Exact match (all formats)
+  it('returns true for identical terminal_ids', () => {
+    expect(isSameConversation('win-pid-1234', 'win-pid-1234')).toBe(true);
+  });
+
+  // win-pid vs win-pid: same PID
+  it('returns true for win-pid with same PID', () => {
+    expect(isSameConversation('win-pid-5678', 'win-pid-5678')).toBe(true);
+  });
+
+  // win-pid vs win-pid: different PIDs → ambiguous (could be different Bash tool calls)
+  it('returns ambiguous for win-pid with different PIDs', () => {
+    expect(isSameConversation('win-pid-1234', 'win-pid-5678')).toBe('ambiguous');
+  });
+
+  // UUID vs win-pid → ambiguous (cross-format, needs evidence gate)
+  it('returns ambiguous for UUID vs win-pid', () => {
+    expect(isSameConversation(
+      '21e2970f-18c4-49bc-a93e-bc78b3a414c5',
+      'win-pid-3884'
+    )).toBe('ambiguous');
+  });
+
+  it('returns ambiguous for win-pid vs UUID (reversed order)', () => {
+    expect(isSameConversation(
+      'win-pid-3884',
+      '21e2970f-18c4-49bc-a93e-bc78b3a414c5'
+    )).toBe('ambiguous');
+  });
+
+  // win-cc vs win-pid → ambiguous (both Windows fallback formats)
+  it('returns ambiguous for win-cc vs win-pid', () => {
+    expect(isSameConversation('win-cc-55188', 'win-pid-3884')).toBe('ambiguous');
+  });
+
+  it('returns ambiguous for win-pid vs win-cc (reversed order)', () => {
+    expect(isSameConversation('win-pid-3884', 'win-cc-55188-4468')).toBe('ambiguous');
+  });
+
+  // Existing behavior preserved: UUID vs UUID
+  it('returns false for different UUIDs', () => {
+    expect(isSameConversation(
+      '21e2970f-18c4-49bc-a93e-bc78b3a414c5',
+      'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    )).toBe(false);
+  });
+
+  // Existing behavior preserved: UUID vs win-cc
+  it('returns ambiguous for UUID vs win-cc', () => {
+    expect(isSameConversation(
+      '21e2970f-18c4-49bc-a93e-bc78b3a414c5',
+      'win-cc-55188'
+    )).toBe('ambiguous');
+  });
+
+  // Existing behavior preserved: win-cc same port same PID
+  it('returns true for win-cc same port same PID', () => {
+    expect(isSameConversation('win-cc-55188-4468', 'win-cc-55188-4468')).toBe(true);
+  });
+
+  // Existing behavior preserved: win-cc same port different PID
+  it('returns false for win-cc same port different PID', () => {
+    expect(isSameConversation('win-cc-55188-4468', 'win-cc-55188-9999')).toBe(false);
+  });
+
+  // Existing behavior preserved: win-cc different port
+  it('returns false for win-cc different port', () => {
+    expect(isSameConversation('win-cc-55188-4468', 'win-cc-12345-4468')).toBe(false);
+  });
+});

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -335,13 +335,17 @@ async function main() {
     // idx_claude_sessions_unique_terminal_active (one active/idle per terminal).
     // Using 'idle' silently fails when another session on the same terminal exists.
     const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
+    // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-2): Clear dirty fields on claim release
     const { error } = await supabase
       .from('claude_sessions')
       .update({
         sd_id: null,
         status: targetStatus,
         released_at: now.toISOString(),
-        released_reason: 'SWEEP_SD_ALREADY_COMPLETED'
+        released_reason: 'SWEEP_SD_ALREADY_COMPLETED',
+        worktree_path: null,
+        has_uncommitted_changes: false,
+        current_branch: null
       })
       .eq('session_id', s.session_id);
 
@@ -360,13 +364,17 @@ async function main() {
   const orphanedClaims = classified.filter(s => !sdStatusMap[s.sd_id]);
   for (const s of orphanedClaims) {
     const targetStatus = s.status === 'ACTIVE' ? 'idle' : 'released';
+    // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-2): Clear dirty fields on claim release
     const { error } = await supabase
       .from('claude_sessions')
       .update({
         sd_id: null,
         status: targetStatus,
         released_at: now.toISOString(),
-        released_reason: 'SWEEP_ORPHANED_CLAIM'
+        released_reason: 'SWEEP_ORPHANED_CLAIM',
+        worktree_path: null,
+        has_uncommitted_changes: false,
+        current_branch: null
       })
       .eq('session_id', s.session_id);
 
@@ -513,13 +521,20 @@ async function main() {
       continue;
     }
 
+    // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-1, FR-2): Atomically set is_alive=false
+    // and clear dirty fields when releasing dead session claims. Prevents successor sessions
+    // from inheriting stale worktree_path, has_uncommitted_changes, and current_branch.
     const { error } = await supabase
       .from('claude_sessions')
       .update({
         sd_id: null,
         status: 'released',
         released_at: now.toISOString(),
-        released_reason: 'SWEEP_PID_DEAD'
+        released_reason: 'SWEEP_PID_DEAD',
+        is_alive: false,
+        worktree_path: null,
+        has_uncommitted_changes: false,
+        current_branch: null
       })
       .eq('session_id', s.session_id);
 
@@ -563,13 +578,17 @@ async function main() {
       if (dead.find(d => d.session_id === evict.session_id)) continue;
 
       const targetStatus = evict.status === 'ACTIVE' ? 'idle' : 'released';
+      // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-2): Clear dirty fields on claim release
       const { error } = await supabase
         .from('claude_sessions')
         .update({
           sd_id: null,
           status: targetStatus,
           released_at: now.toISOString(),
-          released_reason: 'SWEEP_CONFLICT_RESOLUTION'
+          released_reason: 'SWEEP_CONFLICT_RESOLUTION',
+          worktree_path: null,
+          has_uncommitted_changes: false,
+          current_branch: null
         })
         .eq('session_id', evict.session_id);
 


### PR DESCRIPTION
## Summary
- Extend `isSameConversation()` in `lib/claim-guard.mjs` to parse `win-pid-*` terminal_id format — previously returned `false` for all win-pid comparisons, blocking legitimate session transitions
- Add structured `IDENTITY_TRANSFER` audit log on every claim adoption
- Fix stale-session-sweep dirty field cleanup: atomically set `is_alive=false` + clear `worktree_path`, `has_uncommitted_changes`, `current_branch` on all 4 claim release paths
- 12 new unit tests for win-pid format handling (32/32 total pass)

## Context
Board of Directors deliberation (6/6 unanimous). Root cause confirmed by parallel session: `parseWinCC` regex at line 108 doesn't match `win-pid-*`, so line 117 returns false.

**Files changed**: `lib/claim-guard.mjs`, `lib/claim-guard.test.js`, `scripts/stale-session-sweep.cjs`
**Passive beneficiaries**: 24 files that call `isSameConversation()` inherit the fix automatically

## Test plan
- [x] claim-guard.test.js: 32/32 pass (20 existing + 12 new)
- [x] Smoke tests: 15/15 pass
- [x] Pre-commit hooks: all pass
- [ ] Manual: verify handoff gate passes with UUID vs win-pid terminal_ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)