### PR TITLE
fix(QF-20260404-512): stabilize terminal_id fallback and claim gate liveness check

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -23,7 +23,7 @@
  */
 
 import { execSync } from 'child_process';
-import { readFileSync, readdirSync, statSync } from 'fs';
+import { readFileSync, readdirSync, statSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import crypto from 'crypto';
@@ -331,12 +331,33 @@ export function getTerminalId() {
         if (markerSessionId) {
           return markerSessionId;
         }
-        // Final fallback: SSE port + process.pid for uniqueness.
-        // process.pid changes per Bash tool call, but this is better than
-        // the shared win-cc-{port} that caused multi-session collisions.
-        // Sessions using this path will get inconsistent terminal_ids across
-        // tool calls, but at least they won't overwrite each other.
-        return `win-pid-${process.pid}`;
+        // Quick-fix QF-20260404-512: Write persistent fallback marker when all
+        // stable resolution methods fail. Subsequent calls find this marker via
+        // SSE port match, producing a stable terminal_id across Bash tool calls.
+        const fallbackId = `win-fallback-${ssePort}-${crypto.randomUUID().substring(0, 8)}`;
+        try {
+          const markerDir = resolve(__dirname, '../.claude/session-identity');
+          if (!existsSync(markerDir)) mkdirSync(markerDir, { recursive: true });
+          const fallbackMarker = resolve(markerDir, `fallback-${ssePort}.json`);
+          // Check if a fallback marker already exists for this SSE port
+          if (existsSync(fallbackMarker)) {
+            const existing = JSON.parse(readFileSync(fallbackMarker, 'utf8'));
+            if (existing.sse_port === ssePort && existing.session_id) {
+              return existing.session_id;
+            }
+          }
+          writeFileSync(fallbackMarker, JSON.stringify({
+            session_id: fallbackId,
+            sse_port: ssePort,
+            created_at: new Date().toISOString(),
+            source: 'pid-fallback-stabilizer'
+          }));
+          console.error(`[terminal-identity] WARNING: All stable methods failed. Wrote fallback marker: ${fallbackId}`);
+          return fallbackId;
+        } catch {
+          // Marker write failed — fall through to unstable PID
+          return `win-pid-${process.pid}`;
+        }
       }
       // Fallback: Windows console session ID (shared across all instances
       // in the same desktop session - less ideal for multi-instance)

--- a/scripts/modules/handoff/gates/multi-session-claim-gate.js
+++ b/scripts/modules/handoff/gates/multi-session-claim-gate.js
@@ -129,6 +129,22 @@ export async function validateMultiSessionClaim(supabase, sdId, options = {}) {
         const sameConvo = isSameConversation(currentTerminalId, claim.terminal_id);
         if (sameConvo === true) return false; // Definitely same conversation
         if (sameConvo === 'ambiguous') {
+          // Quick-fix QF-20260404-512: Before blocking on ambiguity, check if
+          // the claiming session's PID is still alive. When terminal_id uses the
+          // unstable win-pid-* fallback, every Bash call gets a new PID, making
+          // the claiming PID dead by definition. A dead PID means the claim is
+          // from the same conversation's prior Bash invocation, not a competitor.
+          const claimPidMatch = claim.terminal_id?.match(/^win-pid-(\d+)$/);
+          if (claimPidMatch) {
+            const claimPid = parseInt(claimPidMatch[1], 10);
+            try {
+              process.kill(claimPid, 0); // Signal 0 = existence check, no actual kill
+            } catch {
+              // PID is dead — this is a stale claim from a prior Bash invocation
+              console.log(`   ✅ Ambiguous terminal_id but claiming PID ${claimPid} is dead — allowing (same conversation)`);
+              return false;
+            }
+          }
           // SD-LEO-INFRA-CLAIM-DEFAULT-LEO-001: DENY-on-ambiguity
           // Ambiguous identity (e.g., UUID vs win-cc format mismatch) now blocks
           // rather than allowing passthrough. Blocking a handoff is recoverable;


### PR DESCRIPTION
## Summary
- **CAPA-1**: When `getTerminalId()` falls through all stable resolution methods to the PID-based fallback, write a persistent marker file (`fallback-{ssePort}.json`) so subsequent Bash calls find the same terminal_id via SSE port match
- **CAPA-3**: In the claim gate, when ambiguous `win-pid-*` terminal_id is detected, check if the claiming PID is alive before blocking — dead PID means stale claim from prior Bash invocation, not a competing session

## Root Cause
`getTerminalId()` has a 6-priority cascade. When all stable methods fail (marker files missing/cleaned up), it falls to `win-pid-${process.pid}` which changes on every Bash tool call. The claim gate then blocks every handoff as "different conversation."

## Test plan
- [x] Both modified files import cleanly (`terminal-identity.js`, `multi-session-claim-gate.js`)
- [x] Changes within 50 LOC cap (44 insertions, 7 deletions)
- [x] Unit tests pass (pre-existing failures unrelated to these files)
- [ ] Verify handoff succeeds after fix by running LEAD-TO-PLAN on an SD that previously failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)