### PR TITLE
fix(SD-LEO-FIX-TERMINAL-IDENTITY-CWD-001): resolve terminal identity CWD dependence in worktrees

### DIFF
--- a/lib/terminal-identity.js
+++ b/lib/terminal-identity.js
@@ -32,6 +32,33 @@ import os from 'os';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+/**
+ * Resolve the main repo root, even when running from a git worktree.
+ * Worktrees have a different __dirname but share the .git directory.
+ * SD-LEO-FIX-TERMINAL-IDENTITY-CWD-001: Fixes false claim conflicts
+ * caused by marker file lookups resolving to worktree paths.
+ * @returns {string} Absolute path to the main repo root
+ */
+function resolveRepoRoot() {
+  try {
+    const gitCommonDir = execSync('git rev-parse --git-common-dir', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+      cwd: __dirname,
+      timeout: 3000
+    }).trim();
+    // git-common-dir returns the .git dir (or relative path to it)
+    // Resolve it relative to __dirname, then go up one level from .git
+    const absGitDir = resolve(__dirname, gitCommonDir);
+    return resolve(absGitDir, '..');
+  } catch {
+    // Fallback: assume __dirname is inside lib/ of the repo
+    return resolve(__dirname, '..');
+  }
+}
+
+const _repoRoot = resolveRepoRoot();
+
 // Cache the Claude Code ancestor PID — stable for the lifetime of this process
 // Uses undefined as "not yet searched", null as "searched but not found" (negative cache)
 let _cachedCCPid = undefined;
@@ -178,7 +205,7 @@ function _getAncestorPids() {
  */
 function _scanMarkersByAncestry(ssePort) {
   try {
-    const markerDir = resolve(__dirname, '../.claude/session-identity');
+    const markerDir = resolve(_repoRoot, '.claude/session-identity');
     const ancestorPids = _getAncestorPids();
     if (ancestorPids.size === 0) return null;
 
@@ -282,7 +309,7 @@ export function getTerminalId() {
     const ssePortForMarker = process.env.CLAUDE_CODE_SSE_PORT;
     if (ssePortForMarker) {
       try {
-        const markerDir = resolve(__dirname, '../.claude/session-identity');
+        const markerDir = resolve(_repoRoot, '.claude/session-identity');
         const files = readdirSync(markerDir).filter(f => f.startsWith('pid-') && f.endsWith('.json'));
         // Sort by mtime descending — most recent first
         const sorted = files
@@ -336,7 +363,7 @@ export function getTerminalId() {
         // SSE port match, producing a stable terminal_id across Bash tool calls.
         const fallbackId = `win-fallback-${ssePort}-${crypto.randomUUID().substring(0, 8)}`;
         try {
-          const markerDir = resolve(__dirname, '../.claude/session-identity');
+          const markerDir = resolve(_repoRoot, '.claude/session-identity');
           if (!existsSync(markerDir)) mkdirSync(markerDir, { recursive: true });
           const fallbackMarker = resolve(markerDir, `fallback-${ssePort}.json`);
           // Check if a fallback marker already exists for this SSE port


### PR DESCRIPTION
## Summary
- Fix false claim conflicts caused by terminal-identity.js resolving marker files relative to `__dirname` (worktree path) instead of main repo root
- Use `git rev-parse --git-common-dir` to always find the main repo's `.claude/session-identity/` directory
- 30 LOC change in 1 file

## Root Cause
When handoff scripts run from a git worktree, `__dirname` resolves to `.worktrees/SD-XXX/lib/`. Marker file lookups then search `.worktrees/SD-XXX/.claude/session-identity/` which is empty — the markers were written to the main repo's `.claude/session-identity/`. The fallback `win-fallback-*` ID differs from the session-stored terminal_id, triggering `GATE_MULTI_SESSION_CLAIM_CONFLICT` on every worktree handoff.

## Test plan
- [x] `getTerminalId()` returns identical value from main repo and worktree
- [x] 15/15 smoke tests pass
- [ ] Handoff from worktree passes claim conflict gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)