### PR TITLE
fix: add required fields to auto-SD creator

### DIFF
--- a/lib/eva/jobs/okr-stale-kr-sd-creator.js
+++ b/lib/eva/jobs/okr-stale-kr-sd-creator.js
@@ -102,7 +102,24 @@ async function createSDFromStaleKR(supabase, kr, dryRun = false) {
   const sdTitle = `Address stale KR: ${kr.code} — ${kr.title}`;
   const objective = kr.objectives;
 
+  // Generate unique SD key from KR code
+  const semantic = kr.code.replace(/[^A-Z0-9-]/gi, '-').toUpperCase();
+  const sdKey = `SD-OKR-AUTO-${semantic}-001`;
+
+  // Check for collision
+  const { data: existing } = await supabase
+    .from('strategic_directives_v2')
+    .select('id')
+    .eq('sd_key', sdKey)
+    .limit(1);
+  if (existing && existing.length > 0) {
+    console.log(`[stale-kr] Rate limited: ${kr.code} (SD ${sdKey} already exists)`);
+    return null;
+  }
+
   const sdData = {
+    id: sdKey,
+    sd_key: sdKey,
     title: sdTitle,
     description: `Auto-generated from stale KR ${kr.code} (${kr.title}). Part of objective ${objective.code}: ${objective.title}. Current: ${kr.current_value}${kr.unit}, Target: ${kr.target_value}${kr.unit}. KR has been at 0% progress for over ${DEFAULT_STALENESS_DAYS} days with no active aligned SDs.`,
     status: 'draft',
@@ -114,6 +131,11 @@ async function createSDFromStaleKR(supabase, kr, dryRun = false) {
     rationale: `OKR automation: KR ${kr.code} is at 0% progress with no active work. Objective: ${objective.title}.`,
     is_active: true,
     success_criteria: [{ criterion: `KR ${kr.code} progress > 0%`, measure: `current_value changes from ${kr.current_value}` }],
+    success_metrics: [{ metric: `${kr.code} progress`, target: `>${kr.baseline_value} ${kr.unit}`, actual: `${kr.current_value} ${kr.unit}` }],
+    key_principles: [`Address OKR gap for ${objective.code}`, 'Auto-generated — chairman review required before LEAD approval'],
+    key_changes: [{ change: `Move ${kr.code} off 0% progress`, type: 'feature' }],
+    strategic_objectives: [`Advance ${objective.code}: ${objective.title}`],
+    risks: [{ risk: 'Auto-generated scope may not match actual work needed', mitigation: 'Chairman reviews in DRAFT status before approval' }],
     metadata: {
       auto_generated: true,
       source: 'okr-stale-kr-sd-creator',


### PR DESCRIPTION
## Summary
- Fix `okr-stale-kr-sd-creator.js` missing required fields for `strategic_directives_v2` INSERT
- Adds: `id`/`sd_key` (generated from KR code), `key_principles`, `success_metrics`, `key_changes`, `strategic_objectives`, `risks`
- Adds collision detection before insert
- 22 LOC follow-up to PR #2726

## Test plan
- [x] Live run created 5 DRAFT SDs from stale KRs (KR-GOV-1.2, 1.3, 2.1, 2.2, 2.3)
- [x] 15/15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)