### PR TITLE
feat(SD-LEO-INFRA-OKR-AUTO-COMPLEXITY-001): complexity triage for OKR auto-SDs

### DIFF
--- a/lib/eva/jobs/okr-stale-kr-sd-creator.js
+++ b/lib/eva/jobs/okr-stale-kr-sd-creator.js
@@ -14,6 +14,74 @@ import { createSupabaseServiceClient } from '../../supabase-client.js';
 const DEFAULT_STALENESS_DAYS = 30;
 const MAX_SDS_PER_CYCLE = 5;
 
+// SD-LEO-INFRA-OKR-AUTO-COMPLEXITY-001: Complexity triage for auto-generated SDs
+// High-complexity KRs need brainstorm/vision/arch before LEAD approval
+const HIGH_COMPLEXITY_KEYWORDS = [
+  'consolidate', 'redesign', 'integrate', 'architect', 'migrate', 'refactor',
+  'resolve', 'deploy', 'operational', 'cascade', 'governance', 'multi-',
+  'cross-', 'unify', 'replace', 'overhaul'
+];
+const LOW_COMPLEXITY_KEYWORDS = [
+  'update', 'set', 'enable', 'disable', 'configure', 'toggle', 'bump', 'rename'
+];
+
+/**
+ * Classify a stale KR's complexity to determine if its auto-SD needs
+ * brainstorm/vision/arch or can proceed directly to LEAD.
+ *
+ * @param {Object} kr - KR object with title, metric_type, unit, objectives
+ * @returns {{ level: 'low'|'high', score: number, reasons: string[] }}
+ */
+export function classifyComplexity(kr) {
+  let score = 0;
+  const reasons = [];
+  const title = (kr.title || '').toLowerCase();
+  const objTitle = (kr.objectives?.title || '').toLowerCase();
+  const combined = `${title} ${objTitle}`;
+
+  // Signal 1: KR title keywords (strongest signal)
+  const highHits = HIGH_COMPLEXITY_KEYWORDS.filter(kw => combined.includes(kw));
+  const lowHits = LOW_COMPLEXITY_KEYWORDS.filter(kw => combined.includes(kw));
+  if (highHits.length > 0) {
+    score += highHits.length * 3;
+    reasons.push(`high-complexity keywords: ${highHits.join(', ')}`);
+  }
+  if (lowHits.length > 0) {
+    score -= lowHits.length * 2;
+    reasons.push(`low-complexity keywords: ${lowHits.join(', ')}`);
+  }
+
+  // Signal 2: Numeric range magnitude (large deltas = more work)
+  const baseline = parseFloat(kr.baseline_value) || 0;
+  const target = parseFloat(kr.target_value) || 0;
+  const delta = Math.abs(target - baseline);
+  if (delta > 3 || (kr.unit === 'references' && delta > 50)) {
+    score += 2;
+    reasons.push(`large delta: ${baseline}→${target} ${kr.unit}`);
+  }
+
+  // Signal 3: Objective source type (top-down = strategic = complex)
+  if (kr.source_type === 'manual' || kr.source_type === 'top_down') {
+    score += 2;
+    reasons.push('top-down/manual objective (strategic intent)');
+  }
+
+  // Signal 4: Multi-system scope signals
+  if (/\d+\s*(systems?|providers?|layers?|handlers?|guardrails?)/.test(title)) {
+    score += 2;
+    reasons.push('multi-system scope detected in KR title');
+  }
+
+  // Signal 5: Boolean/simple metrics are low complexity
+  if (kr.metric_type === 'boolean' || kr.unit === 'complete') {
+    score -= 3;
+    reasons.push('boolean/completion metric (simple)');
+  }
+
+  const level = score >= 3 ? 'high' : 'low';
+  return { level, score, reasons };
+}
+
 /**
  * Detect stale KRs that have no active aligned SDs.
  * @param {Object} supabase - Supabase client
@@ -102,6 +170,9 @@ async function createSDFromStaleKR(supabase, kr, dryRun = false) {
   const sdTitle = `Address stale KR: ${kr.code} — ${kr.title}`;
   const objective = kr.objectives;
 
+  // SD-LEO-INFRA-OKR-AUTO-COMPLEXITY-001: Classify complexity
+  const complexity = classifyComplexity(kr);
+
   // Generate unique SD key from KR code
   const semantic = kr.code.replace(/[^A-Z0-9-]/gi, '-').toUpperCase();
   const sdKey = `SD-OKR-AUTO-${semantic}-001`;
@@ -142,13 +213,21 @@ async function createSDFromStaleKR(supabase, kr, dryRun = false) {
       kr_id: kr.id,
       kr_code: kr.code,
       objective_code: objective.code,
-      created_at_cycle: new Date().toISOString()
+      created_at_cycle: new Date().toISOString(),
+      complexity: complexity.level,
+      complexity_score: complexity.score,
+      complexity_reasons: complexity.reasons,
+      needs_brainstorm: complexity.level === 'high'
     }
   };
 
   if (dryRun) {
-    console.log(`[DRY RUN] Would create DRAFT SD: ${sdTitle}`);
-    return { dry_run: true, title: sdTitle, kr_code: kr.code };
+    const flag = complexity.level === 'high' ? ' [NEEDS BRAINSTORM]' : '';
+    console.log(`[DRY RUN] Would create DRAFT SD: ${sdTitle} (complexity: ${complexity.level}, score: ${complexity.score})${flag}`);
+    if (complexity.reasons.length > 0) {
+      console.log(`          Reasons: ${complexity.reasons.join('; ')}`);
+    }
+    return { dry_run: true, title: sdTitle, kr_code: kr.code, complexity };
   }
 
   // Use leo-create-sd.js pattern: insert directly with required fields
@@ -169,6 +248,8 @@ async function createSDFromStaleKR(supabase, kr, dryRun = false) {
     sd_id: created.sd_key || created.id,
     kr_code: kr.code,
     objective_code: objective.code,
+    complexity: complexity.level,
+    needs_brainstorm: complexity.level === 'high',
     actor: 'okr-stale-kr-sd-creator',
     timestamp: new Date().toISOString()
   }));


### PR DESCRIPTION
## Summary
- Add `classifyComplexity()` to `okr-stale-kr-sd-creator.js`
- High-complexity SDs (consolidate, redesign, governance) get `metadata.needs_brainstorm=true`
- Low-complexity SDs (enable, update, boolean metrics) proceed directly to LEAD
- 5-signal classifier: title keywords, numeric delta, objective source, multi-system scope, metric type
- 84 LOC addition, dry-run output shows classification and reasoning

## Test plan
- [x] Classifier correctly flags "Consolidate schedulers" as HIGH (score 3)
- [x] Classifier correctly flags "Governance cascade" as HIGH (score 14)
- [x] Classifier correctly passes "Enable feature flag" as LOW (score -5)
- [x] 15/15 smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)