### PR TITLE
feat: brainstorm gate for high-complexity OKR auto-SDs

### DIFF
--- a/scripts/modules/sd-next/display/tracks.js
+++ b/scripts/modules/sd-next/display/tracks.js
@@ -149,8 +149,13 @@ async function displaySDItem(item, indent, childItems, allItems, sessionContext)
   const ventureBadge = item.target_application && item.target_application !== 'EHG_Engineer'
     ? ` ${colors.cyan}[${item.target_application}]${colors.reset}`
     : '';
+  // SD-LEO-INFRA-OKR-AUTO-COMPLEXITY-001: Brainstorm-needed badge for high-complexity auto-SDs
+  const needsBrainstorm = item.metadata?.needs_brainstorm === true;
+  const brainstormBadge = needsBrainstorm
+    ? ` ${colors.yellow}[BRAINSTORM FIRST]${colors.reset}`
+    : '';
 
-  console.log(`${indent}${claimedIcon}${workingIcon}${localActivityIcon}${rankStr} ${sdId} - ${title}${ventureBadge}${urgencyBadge}${visionBadge}${gapBadge}... ${statusIcon}`);
+  console.log(`${indent}${claimedIcon}${workingIcon}${localActivityIcon}${rankStr} ${sdId} - ${title}${ventureBadge}${urgencyBadge}${brainstormBadge}${visionBadge}${gapBadge}... ${statusIcon}`);
 
   // Show claim details with PID-aware output
   if (isClaimedByOther) {

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -903,11 +903,28 @@ async function main() {
     });
   }
 
+  // 7.5. SD-LEO-INFRA-OKR-AUTO-COMPLEXITY-001: Brainstorm gate for high-complexity auto-SDs
+  const needsBrainstorm = sd.metadata?.needs_brainstorm === true;
+  if (needsBrainstorm && sd.status === 'draft' && sd.current_phase === 'LEAD') {
+    console.log(`\n${colors.bgYellow}${colors.bold} BRAINSTORM REQUIRED ${colors.reset}`);
+    console.log(`${colors.yellow}   This SD was auto-generated from a stale OKR and classified as high-complexity.${colors.reset}`);
+    console.log(`${colors.yellow}   Run /brainstorm before proceeding to LEAD approval.${colors.reset}`);
+    console.log(`${colors.dim}   Complexity: score ${sd.metadata.complexity_score || '?'}, reasons: ${(sd.metadata.complexity_reasons || []).join(', ') || 'n/a'}${colors.reset}`);
+    console.log('\n>>> NEEDS_BRAINSTORM=true');
+  }
+
   // 8. Show next action
   const nextHandoff = await getNextHandoff(sd);
 
-  console.log(`\n${colors.bold}Next Action:${colors.reset}`);
-  console.log(`   ${colors.cyan}node scripts/handoff.js execute ${nextHandoff} ${effectiveId}${colors.reset}`);
+  if (needsBrainstorm && sd.status === 'draft') {
+    console.log(`\n${colors.bold}Next Action:${colors.reset}`);
+    console.log(`   ${colors.cyan}/brainstorm ${sd.title}${colors.reset}`);
+    console.log(`${colors.dim}   After brainstorm completes with vision+arch, then:${colors.reset}`);
+    console.log(`   ${colors.dim}node scripts/handoff.js execute ${nextHandoff} ${effectiveId}${colors.reset}`);
+  } else {
+    console.log(`\n${colors.bold}Next Action:${colors.reset}`);
+    console.log(`   ${colors.cyan}node scripts/handoff.js execute ${nextHandoff} ${effectiveId}${colors.reset}`);
+  }
 
   console.log(`\n${colors.dim}Session: ${session.session_id}${colors.reset}`);
   console.log('═'.repeat(50));


### PR DESCRIPTION
## Summary
- `sd:next` displays `[BRAINSTORM FIRST]` badge on SDs with `metadata.needs_brainstorm=true`
- `sd-start` shows `BRAINSTORM REQUIRED` banner and redirects Next Action to `/brainstorm` for flagged SDs
- Machine-readable output: `NEEDS_BRAINSTORM=true` for agent consumption
- 25 LOC across 2 files

## How it works
When an OKR auto-SD is created with high complexity (score >= 3), the stale KR creator sets `metadata.needs_brainstorm = true`. Now:
1. **sd:next** shows `[BRAINSTORM FIRST]` badge next to the SD title
2. **sd-start** detects the flag on DRAFT/LEAD SDs and shows the brainstorm requirement with complexity reasons
3. Next Action changes from `handoff.js execute LEAD-TO-PLAN` to `/brainstorm <title>`

## Test plan
- [x] 15/15 smoke tests pass
- [ ] sd:next shows badge on flagged SDs
- [ ] sd-start redirects to brainstorm for flagged DRAFT SDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)