### PR TITLE
feat(SD-OKR-AUTO-KR-GOV-2-3-001): add vision.gap_accepted event handler

### DIFF
--- a/lib/eva/event-bus/handlers/vision-gap-accepted.js
+++ b/lib/eva/event-bus/handlers/vision-gap-accepted.js
@@ -1,0 +1,64 @@
+/**
+ * Handler: vision.gap_accepted
+ * SD: SD-OKR-AUTO-KR-GOV-2-3-001
+ *
+ * Handles events when a vision gap is accepted (dismissed or wont_fix).
+ * Logs for observability and updates the gap status in eva_vision_gaps.
+ *
+ * Payload: { sdKey, gapId, dimensionId, reason, supabase }
+ */
+
+import { subscribeVisionEvent, VISION_EVENTS } from '../vision-events.js';
+
+let _registered = false;
+
+/**
+ * Register vision.gap_accepted subscribers.
+ * Idempotent — safe to call multiple times.
+ */
+export function registerVisionGapAcceptedHandlers() {
+  if (_registered) return;
+
+  // Subscriber 1: Log for observability
+  subscribeVisionEvent(VISION_EVENTS.GAP_ACCEPTED, async ({ sdKey, gapId, dimensionId, reason }) => {
+    console.log(`[VisionBus] Gap accepted: sd=${sdKey || '(unknown)'} gap=${gapId || dimensionId} reason=${reason || 'none'}`);
+  });
+
+  // Subscriber 2: Update gap status in eva_vision_gaps
+  subscribeVisionEvent(VISION_EVENTS.GAP_ACCEPTED, async ({ sdKey, gapId, dimensionId, reason, supabase }) => {
+    if (!supabase) return;
+
+    try {
+      const filter = supabase
+        .from('eva_vision_gaps')
+        .update({
+          status: 'accepted',
+          resolution_notes: reason || 'Accepted via gap_accepted event',
+          updated_at: new Date().toISOString(),
+        });
+
+      // Match by gapId if available, otherwise by sd_id + dimension_id
+      if (gapId) {
+        filter.eq('id', gapId);
+      } else if (sdKey && dimensionId) {
+        filter.eq('sd_id', sdKey).eq('dimension_id', dimensionId);
+      } else {
+        return; // Cannot identify the gap without identifiers
+      }
+
+      const { error } = await filter;
+      if (error) {
+        console.warn(`[VisionBus] Failed to update gap status: ${error.message}`);
+      }
+    } catch (err) {
+      console.warn(`[VisionBus] eva_vision_gaps accept error: ${err.message}`);
+    }
+  });
+
+  _registered = true;
+}
+
+/** Reset registration flag (for testing only). */
+export function _resetVisionGapAcceptedHandlers() {
+  _registered = false;
+}

--- a/lib/eva/event-bus/index.js
+++ b/lib/eva/event-bus/index.js
@@ -27,6 +27,7 @@ import { registerVisionCorrectiveSdCreatedHandlers } from './handlers/vision-cor
 import { registerVisionRescoreCompletedHandlers } from './handlers/vision-rescore-completed.js';
 import { registerLeoPatternResolvedHandlers } from './handlers/leo-pattern-resolved.js';
 import { registerFeedbackQualityUpdatedHandlers } from './handlers/feedback-quality-updated.js';
+import { registerVisionGapAcceptedHandlers } from './handlers/vision-gap-accepted.js';
 
 let _initialized = false;
 
@@ -157,6 +158,7 @@ export async function initializeEventBus(supabase) {
   registerVisionRescoreCompletedHandlers();
   registerLeoPatternResolvedHandlers();
   registerFeedbackQualityUpdatedHandlers();
+  registerVisionGapAcceptedHandlers();
 
   // --- Default governance hook observer (GAP-026: FR-002) ---
   // Bridge vision events into governance system for audit/observability.
@@ -228,3 +230,4 @@ export { registerVisionCorrectiveSdCreatedHandlers } from './handlers/vision-cor
 export { registerVisionRescoreCompletedHandlers } from './handlers/vision-rescore-completed.js';
 export { registerLeoPatternResolvedHandlers } from './handlers/leo-pattern-resolved.js';
 export { registerFeedbackQualityUpdatedHandlers } from './handlers/feedback-quality-updated.js';
+export { registerVisionGapAcceptedHandlers } from './handlers/vision-gap-accepted.js';

--- a/lib/eva/event-bus/vision-events.js
+++ b/lib/eva/event-bus/vision-events.js
@@ -50,6 +50,8 @@ export const VISION_EVENTS = {
   RESCORE_COMPLETED: 'vision.rescore_completed',
   /** Emitted when feedback is classified against vision dimensions — payload: {feedbackId, title, dimensionMatches, rubricScore, supabase} */
   FEEDBACK_QUALITY_UPDATED: 'feedback.quality_updated',
+  /** Emitted when a vision gap is accepted (dismissed/wont_fix) — payload: {sdKey, gapId, dimensionId, reason, supabase} */
+  GAP_ACCEPTED: 'vision.gap_accepted',
 };
 
 /**

--- a/scripts/eva-events-status.js
+++ b/scripts/eva-events-status.js
@@ -122,6 +122,9 @@ async function main() {
   const handlerTypes = [
     'stage.completed', 'decision.submitted', 'gate.evaluated', 'sd.completed',
     'venture.created', 'venture.killed', 'budget.exceeded', 'chairman.override', 'stage.failed',
+    'vision.scored', 'vision.gap_detected', 'vision.corrective_sd_created',
+    'vision.process_gap_detected', 'leo.pattern_resolved', 'vision.rescore_completed',
+    'feedback.quality_updated', 'vision.gap_accepted',
   ];
 
   const report = {


### PR DESCRIPTION
## Summary
- Add `vision.gap_accepted` event type and handler to the unified event bus, completing KR-GOV-2.3 (4/4 vision event handlers active)
- Handler logs gap acceptance and updates `eva_vision_gaps` status when a gap is dismissed/wont_fix
- Updates `eva-events-status.js` dashboard to include all vision event types (previously only showed EVA handlers)
- KR-GOV-2.3 `current_value` updated from 0 → 4 in `key_results` table

## Changes (72 LOC)
- `lib/eva/event-bus/vision-events.js` — add `GAP_ACCEPTED` to `VISION_EVENTS` enum
- `lib/eva/event-bus/handlers/vision-gap-accepted.js` — **new file** — handler with observability log + DB update
- `lib/eva/event-bus/index.js` — register handler in `initializeEventBus()` + export
- `scripts/eva-events-status.js` — add all 8 vision event types to dashboard handler list

## Test plan
- [x] `VISION_EVENTS.GAP_ACCEPTED` resolves to `vision.gap_accepted`
- [x] Handler registers 2 subscribers (log + DB update)
- [x] Existing event bus handlers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)